### PR TITLE
sdr-types: foundation types, errors, and constants

### DIFF
--- a/crates/sdr-types/src/complex.rs
+++ b/crates/sdr-types/src/complex.rs
@@ -1,0 +1,330 @@
+/// IQ complex sample type — matches SDR++ `dsp::complex_t` memory layout.
+///
+/// Two f32 fields (re, im) representing in-phase and quadrature components.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[repr(C)]
+#[must_use]
+pub struct Complex {
+    pub re: f32,
+    pub im: f32,
+}
+
+impl Complex {
+    /// Create a new complex value.
+    #[inline]
+    pub fn new(re: f32, im: f32) -> Self {
+        Self { re, im }
+    }
+
+    /// Complex conjugate (negate imaginary part).
+    #[inline]
+    pub fn conj(self) -> Self {
+        Self {
+            re: self.re,
+            im: -self.im,
+        }
+    }
+
+    /// Phase angle via `atan2(im, re)`.
+    #[inline]
+    pub fn phase(self) -> f32 {
+        self.im.atan2(self.re)
+    }
+
+    /// Fast phase approximation using rational polynomial.
+    ///
+    /// Ports SDR++ `complex_t::fastPhase()` — accurate to ~0.01 radians.
+    #[inline]
+    pub fn fast_phase(self) -> f32 {
+        let abs_im = self.im.abs();
+        if self.re == 0.0 && self.im == 0.0 {
+            return 0.0;
+        }
+        let angle = if self.re >= 0.0 {
+            let r = (self.re - abs_im) / (self.re + abs_im);
+            core::f32::consts::FRAC_PI_4 - core::f32::consts::FRAC_PI_4 * r
+        } else {
+            let r = (self.re + abs_im) / (abs_im - self.re);
+            3.0 * core::f32::consts::FRAC_PI_4 - core::f32::consts::FRAC_PI_4 * r
+        };
+        if self.im < 0.0 { -angle } else { angle }
+    }
+
+    /// Amplitude (magnitude): `sqrt(re^2 + im^2)`.
+    #[inline]
+    pub fn amplitude(self) -> f32 {
+        (self.re * self.re + self.im * self.im).sqrt()
+    }
+
+    /// Fast amplitude approximation: `max(|re|,|im|) + 0.4 * min(|re|,|im|)`.
+    ///
+    /// Ports SDR++ `complex_t::fastAmplitude()` — ~4% max error.
+    #[inline]
+    pub fn fast_amplitude(self) -> f32 {
+        let re_abs = self.re.abs();
+        let im_abs = self.im.abs();
+        if re_abs > im_abs {
+            re_abs + 0.4 * im_abs
+        } else {
+            im_abs + 0.4 * re_abs
+        }
+    }
+}
+
+// --- Arithmetic operators ---
+
+impl std::ops::Add for Complex {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self {
+            re: self.re + rhs.re,
+            im: self.im + rhs.im,
+        }
+    }
+}
+
+impl std::ops::Sub for Complex {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            re: self.re - rhs.re,
+            im: self.im - rhs.im,
+        }
+    }
+}
+
+impl std::ops::Mul for Complex {
+    type Output = Self;
+    /// Complex multiplication: `(a+bi)(c+di) = (ac-bd) + (bc+ad)i`
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Self {
+            re: self.re * rhs.re - self.im * rhs.im,
+            im: self.im * rhs.re + self.re * rhs.im,
+        }
+    }
+}
+
+impl std::ops::Mul<f32> for Complex {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: f32) -> Self {
+        Self {
+            re: self.re * rhs,
+            im: self.im * rhs,
+        }
+    }
+}
+
+impl std::ops::Div<f32> for Complex {
+    type Output = Self;
+    #[inline]
+    fn div(self, rhs: f32) -> Self {
+        Self {
+            re: self.re / rhs,
+            im: self.im / rhs,
+        }
+    }
+}
+
+impl std::ops::AddAssign for Complex {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.re += rhs.re;
+        self.im += rhs.im;
+    }
+}
+
+impl std::ops::SubAssign for Complex {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.re -= rhs.re;
+        self.im -= rhs.im;
+    }
+}
+
+impl std::ops::MulAssign<f32> for Complex {
+    #[inline]
+    fn mul_assign(&mut self, rhs: f32) {
+        self.re *= rhs;
+        self.im *= rhs;
+    }
+}
+
+impl std::ops::Neg for Complex {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        Self {
+            re: -self.re,
+            im: -self.im,
+        }
+    }
+}
+
+// Complex is two f32s — Send + Sync auto-derived.
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    const EPS: f32 = 1e-6;
+
+    fn approx_eq(a: f32, b: f32) -> bool {
+        (a - b).abs() < EPS
+    }
+
+    #[test]
+    fn test_new_and_default() {
+        let c = Complex::new(1.0, 2.0);
+        assert_eq!(c.re, 1.0);
+        assert_eq!(c.im, 2.0);
+
+        let d = Complex::default();
+        assert_eq!(d.re, 0.0);
+        assert_eq!(d.im, 0.0);
+    }
+
+    #[test]
+    fn test_conj() {
+        let c = Complex::new(3.0, 4.0).conj();
+        assert_eq!(c.re, 3.0);
+        assert_eq!(c.im, -4.0);
+    }
+
+    #[test]
+    fn test_phase() {
+        // Phase of (1, 0) = 0
+        assert!(approx_eq(Complex::new(1.0, 0.0).phase(), 0.0));
+        // Phase of (0, 1) = pi/2
+        assert!(approx_eq(
+            Complex::new(0.0, 1.0).phase(),
+            core::f32::consts::FRAC_PI_2
+        ));
+        // Phase of (-1, 0) = pi
+        assert!(approx_eq(
+            Complex::new(-1.0, 0.0).phase(),
+            core::f32::consts::PI
+        ));
+    }
+
+    #[test]
+    fn test_fast_phase() {
+        // Fast phase should be within ~0.01 radians of true phase
+        let cases = [
+            Complex::new(1.0, 0.0),
+            Complex::new(0.0, 1.0),
+            Complex::new(-1.0, 0.0),
+            Complex::new(0.0, -1.0),
+            Complex::new(1.0, 1.0),
+            Complex::new(-1.0, -1.0),
+            Complex::new(3.0, 4.0),
+        ];
+        for c in &cases {
+            let diff = (c.fast_phase() - c.phase()).abs();
+            assert!(diff < 0.08, "fast_phase error {diff} for {c:?}");
+        }
+        // Zero returns zero
+        assert_eq!(Complex::new(0.0, 0.0).fast_phase(), 0.0);
+    }
+
+    #[test]
+    fn test_amplitude() {
+        // 3-4-5 triangle
+        assert!(approx_eq(Complex::new(3.0, 4.0).amplitude(), 5.0));
+        assert!(approx_eq(Complex::new(0.0, 0.0).amplitude(), 0.0));
+        assert!(approx_eq(Complex::new(1.0, 0.0).amplitude(), 1.0));
+    }
+
+    #[test]
+    fn test_fast_amplitude() {
+        let c = Complex::new(3.0, 4.0);
+        let fast = c.fast_amplitude();
+        let exact = c.amplitude();
+        // Should be within ~5% of exact
+        let error = ((fast - exact) / exact).abs();
+        assert!(error < 0.05, "fast_amplitude error {error}");
+    }
+
+    #[test]
+    fn test_add() {
+        let a = Complex::new(1.0, 2.0);
+        let b = Complex::new(3.0, 4.0);
+        let c = a + b;
+        assert_eq!(c.re, 4.0);
+        assert_eq!(c.im, 6.0);
+    }
+
+    #[test]
+    fn test_sub() {
+        let a = Complex::new(5.0, 7.0);
+        let b = Complex::new(3.0, 4.0);
+        let c = a - b;
+        assert_eq!(c.re, 2.0);
+        assert_eq!(c.im, 3.0);
+    }
+
+    #[test]
+    fn test_complex_mul() {
+        // (1+2i)(3+4i) = (3-8) + (6+4)i = -5 + 10i
+        let a = Complex::new(1.0, 2.0);
+        let b = Complex::new(3.0, 4.0);
+        let c = a * b;
+        assert!(approx_eq(c.re, -5.0));
+        assert!(approx_eq(c.im, 10.0));
+    }
+
+    #[test]
+    fn test_scalar_mul() {
+        let c = Complex::new(2.0, 3.0) * 2.0;
+        assert_eq!(c.re, 4.0);
+        assert_eq!(c.im, 6.0);
+    }
+
+    #[test]
+    fn test_scalar_div() {
+        let c = Complex::new(4.0, 6.0) / 2.0;
+        assert_eq!(c.re, 2.0);
+        assert_eq!(c.im, 3.0);
+    }
+
+    #[test]
+    fn test_add_assign() {
+        let mut a = Complex::new(1.0, 2.0);
+        a += Complex::new(3.0, 4.0);
+        assert_eq!(a.re, 4.0);
+        assert_eq!(a.im, 6.0);
+    }
+
+    #[test]
+    fn test_sub_assign() {
+        let mut a = Complex::new(5.0, 7.0);
+        a -= Complex::new(3.0, 4.0);
+        assert_eq!(a.re, 2.0);
+        assert_eq!(a.im, 3.0);
+    }
+
+    #[test]
+    fn test_mul_assign() {
+        let mut a = Complex::new(2.0, 3.0);
+        a *= 2.0;
+        assert_eq!(a.re, 4.0);
+        assert_eq!(a.im, 6.0);
+    }
+
+    #[test]
+    fn test_neg() {
+        let c = -Complex::new(1.0, -2.0);
+        assert_eq!(c.re, -1.0);
+        assert_eq!(c.im, 2.0);
+    }
+
+    #[test]
+    fn test_repr_c_size() {
+        assert_eq!(std::mem::size_of::<Complex>(), 8);
+        assert_eq!(std::mem::align_of::<Complex>(), 4);
+    }
+}

--- a/crates/sdr-types/src/complex.rs
+++ b/crates/sdr-types/src/complex.rs
@@ -1,3 +1,6 @@
+/// Alpha-max-beta-min coefficient for fast amplitude approximation.
+const FAST_AMPLITUDE_BETA: f32 = 0.4;
+
 /// IQ complex sample type — matches SDR++ `dsp::complex_t` memory layout.
 ///
 /// Two f32 fields (re, im) representing in-phase and quadrature components.
@@ -64,9 +67,9 @@ impl Complex {
         let re_abs = self.re.abs();
         let im_abs = self.im.abs();
         if re_abs > im_abs {
-            re_abs + 0.4 * im_abs
+            re_abs + FAST_AMPLITUDE_BETA * im_abs
         } else {
-            im_abs + 0.4 * re_abs
+            im_abs + FAST_AMPLITUDE_BETA * re_abs
         }
     }
 }

--- a/crates/sdr-types/src/complex.rs
+++ b/crates/sdr-types/src/complex.rs
@@ -36,7 +36,7 @@ impl Complex {
 
     /// Fast phase approximation using rational polynomial.
     ///
-    /// Ports SDR++ `complex_t::fastPhase()` — accurate to ~0.01 radians.
+    /// Ports SDR++ `complex_t::fastPhase()` — worst-case error ~0.07 radians.
     #[inline]
     pub fn fast_phase(self) -> f32 {
         let abs_im = self.im.abs();
@@ -123,6 +123,7 @@ impl std::ops::Mul<f32> for Complex {
 
 impl std::ops::Div<f32> for Complex {
     type Output = Self;
+    /// Scalar division. Follows IEEE 754: division by zero yields infinity.
     #[inline]
     fn div(self, rhs: f32) -> Self {
         Self {
@@ -173,6 +174,12 @@ impl std::ops::Neg for Complex {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
+
+    // Compile-time verification of thread safety.
+    const _: fn() = || {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Complex>();
+    };
 
     const EPS: f32 = 1e-6;
 

--- a/crates/sdr-types/src/complex.rs
+++ b/crates/sdr-types/src/complex.rs
@@ -157,6 +157,14 @@ impl std::ops::MulAssign<f32> for Complex {
     }
 }
 
+impl std::ops::DivAssign<f32> for Complex {
+    #[inline]
+    fn div_assign(&mut self, rhs: f32) {
+        self.re /= rhs;
+        self.im /= rhs;
+    }
+}
+
 impl std::ops::Neg for Complex {
     type Output = Self;
     #[inline]
@@ -223,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_fast_phase() {
-        // Fast phase should be within ~0.01 radians of true phase
+        // Fast phase should be within ~0.08 radians of true phase
         let cases = [
             Complex::new(1.0, 0.0),
             Complex::new(0.0, 1.0),
@@ -323,6 +331,14 @@ mod tests {
         a *= 2.0;
         assert_eq!(a.re, 4.0);
         assert_eq!(a.im, 6.0);
+    }
+
+    #[test]
+    fn test_div_assign() {
+        let mut a = Complex::new(4.0, 6.0);
+        a /= 2.0;
+        assert_eq!(a.re, 2.0);
+        assert_eq!(a.im, 3.0);
     }
 
     #[test]

--- a/crates/sdr-types/src/constants.rs
+++ b/crates/sdr-types/src/constants.rs
@@ -1,0 +1,10 @@
+/// Stream buffer size in samples — matches SDR++ `STREAM_BUFFER_SIZE`.
+pub const STREAM_BUFFER_SIZE: usize = 1_000_000;
+
+/// Default audio sample rate in Hz.
+pub const DEFAULT_AUDIO_SAMPLE_RATE: f64 = 48_000.0;
+
+/// Alignment in bytes for sample buffer allocation.
+///
+/// 32 bytes covers AVX (256-bit) alignment. AVX-512 would need 64.
+pub const BUFFER_ALIGNMENT: usize = 32;

--- a/crates/sdr-types/src/enums.rs
+++ b/crates/sdr-types/src/enums.rs
@@ -1,0 +1,66 @@
+/// Demodulation mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DemodMode {
+    /// Wideband FM (broadcast, ~200kHz bandwidth).
+    Wfm,
+    /// Narrowband FM (12.5/25kHz, public safety, ham).
+    Nfm,
+    /// Amplitude modulation.
+    Am,
+    /// Upper sideband (SSB).
+    Usb,
+    /// Lower sideband (SSB).
+    Lsb,
+    /// Double sideband.
+    Dsb,
+    /// Continuous wave (morse code).
+    Cw,
+    /// Raw IQ passthrough.
+    Raw,
+}
+
+/// Network IQ sample format — matches SDR++ `SampleType` enum.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SampleFormat {
+    /// Signed 8-bit integer (2 bytes per complex sample).
+    Int8,
+    /// Signed 16-bit integer (4 bytes per complex sample).
+    Int16,
+    /// Signed 32-bit integer (8 bytes per complex sample).
+    Int32,
+    /// 32-bit float (8 bytes per complex sample).
+    Float32,
+}
+
+impl SampleFormat {
+    /// Byte size of one complex sample (I + Q) in this format.
+    pub fn complex_byte_size(self) -> usize {
+        match self {
+            Self::Int8 => 2,
+            Self::Int16 => 4,
+            Self::Int32 | Self::Float32 => 8,
+        }
+    }
+}
+
+/// Network protocol for IQ sources and audio sinks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Protocol {
+    /// TCP client connection.
+    TcpClient,
+    /// UDP unicast/multicast.
+    Udp,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sample_format_sizes() {
+        assert_eq!(SampleFormat::Int8.complex_byte_size(), 2);
+        assert_eq!(SampleFormat::Int16.complex_byte_size(), 4);
+        assert_eq!(SampleFormat::Int32.complex_byte_size(), 8);
+        assert_eq!(SampleFormat::Float32.complex_byte_size(), 8);
+    }
+}

--- a/crates/sdr-types/src/error.rs
+++ b/crates/sdr-types/src/error.rs
@@ -1,0 +1,81 @@
+/// Errors from DSP operations.
+#[derive(Debug, thiserror::Error)]
+pub enum DspError {
+    #[error("invalid parameter: {0}")]
+    InvalidParameter(String),
+    #[error("buffer too small: need {need}, got {got}")]
+    BufferTooSmall { need: usize, got: usize },
+}
+
+/// Errors from pipeline/streaming operations.
+#[derive(Debug, thiserror::Error)]
+pub enum PipelineError {
+    #[error("stream stopped")]
+    StreamStopped,
+    #[error("block not running")]
+    BlockNotRunning,
+    #[error("source error: {0}")]
+    Source(#[from] SourceError),
+    #[error("sink error: {0}")]
+    Sink(#[from] SinkError),
+}
+
+/// Errors from source modules.
+#[derive(Debug, thiserror::Error)]
+pub enum SourceError {
+    #[error("device not found: {0}")]
+    DeviceNotFound(String),
+    #[error("device open failed: {0}")]
+    OpenFailed(String),
+    #[error("tune failed: {0}")]
+    TuneFailed(String),
+    #[error("not running")]
+    NotRunning,
+    #[error("already running")]
+    AlreadyRunning,
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Errors from sink modules.
+#[derive(Debug, thiserror::Error)]
+pub enum SinkError {
+    #[error("device not found: {0}")]
+    DeviceNotFound(String),
+    #[error("device open failed: {0}")]
+    OpenFailed(String),
+    #[error("not running")]
+    NotRunning,
+    #[error("already running")]
+    AlreadyRunning,
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Errors from configuration.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON parse error: {0}")]
+    Json(String),
+    #[error("missing key: {0}")]
+    MissingKey(String),
+}
+
+/// Errors from RTL-SDR USB operations.
+#[derive(Debug, thiserror::Error)]
+pub enum RtlsdrError {
+    #[error("device not found")]
+    DeviceNotFound,
+    #[error("USB error: {0}")]
+    Usb(String),
+    #[error("tuner error: {0}")]
+    Tuner(String),
+    #[error("invalid sample rate: {0}")]
+    InvalidSampleRate(u32),
+    #[error("device busy")]
+    DeviceBusy,
+    #[error("timeout")]
+    Timeout,
+}

--- a/crates/sdr-types/src/lib.rs
+++ b/crates/sdr-types/src/lib.rs
@@ -1,1 +1,13 @@
-// sdr-types: Foundation types, errors, and constants
+//! Foundation types, errors, and constants for sdr-rs.
+
+mod complex;
+mod constants;
+mod enums;
+mod error;
+mod stereo;
+
+pub use complex::Complex;
+pub use constants::*;
+pub use enums::{DemodMode, Protocol, SampleFormat};
+pub use error::{ConfigError, DspError, PipelineError, RtlsdrError, SinkError, SourceError};
+pub use stereo::Stereo;

--- a/crates/sdr-types/src/stereo.rs
+++ b/crates/sdr-types/src/stereo.rs
@@ -1,0 +1,156 @@
+/// Stereo audio sample — matches SDR++ `dsp::stereo_t` memory layout.
+///
+/// Two f32 fields (l, r) representing left and right audio channels.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[repr(C)]
+#[must_use]
+pub struct Stereo {
+    pub l: f32,
+    pub r: f32,
+}
+
+impl Stereo {
+    /// Create a new stereo sample.
+    #[inline]
+    pub fn new(l: f32, r: f32) -> Self {
+        Self { l, r }
+    }
+
+    /// Create a mono sample (same value in both channels).
+    #[inline]
+    pub fn mono(v: f32) -> Self {
+        Self { l: v, r: v }
+    }
+}
+
+// --- Arithmetic operators ---
+
+impl std::ops::Add for Stereo {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self {
+            l: self.l + rhs.l,
+            r: self.r + rhs.r,
+        }
+    }
+}
+
+impl std::ops::Sub for Stereo {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            l: self.l - rhs.l,
+            r: self.r - rhs.r,
+        }
+    }
+}
+
+impl std::ops::Mul<f32> for Stereo {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: f32) -> Self {
+        Self {
+            l: self.l * rhs,
+            r: self.r * rhs,
+        }
+    }
+}
+
+impl std::ops::AddAssign for Stereo {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.l += rhs.l;
+        self.r += rhs.r;
+    }
+}
+
+impl std::ops::SubAssign for Stereo {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.l -= rhs.l;
+        self.r -= rhs.r;
+    }
+}
+
+impl std::ops::MulAssign<f32> for Stereo {
+    #[inline]
+    fn mul_assign(&mut self, rhs: f32) {
+        self.l *= rhs;
+        self.r *= rhs;
+    }
+}
+
+// Stereo is two f32s — Send + Sync auto-derived.
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_and_default() {
+        let s = Stereo::new(1.0, 2.0);
+        assert_eq!(s.l, 1.0);
+        assert_eq!(s.r, 2.0);
+
+        let d = Stereo::default();
+        assert_eq!(d.l, 0.0);
+        assert_eq!(d.r, 0.0);
+    }
+
+    #[test]
+    fn test_mono() {
+        let s = Stereo::mono(0.5);
+        assert_eq!(s.l, 0.5);
+        assert_eq!(s.r, 0.5);
+    }
+
+    #[test]
+    fn test_add() {
+        let a = Stereo::new(1.0, 2.0);
+        let b = Stereo::new(3.0, 4.0);
+        let c = a + b;
+        assert_eq!(c.l, 4.0);
+        assert_eq!(c.r, 6.0);
+    }
+
+    #[test]
+    fn test_sub() {
+        let a = Stereo::new(5.0, 7.0);
+        let b = Stereo::new(3.0, 4.0);
+        let c = a - b;
+        assert_eq!(c.l, 2.0);
+        assert_eq!(c.r, 3.0);
+    }
+
+    #[test]
+    fn test_scalar_mul() {
+        let s = Stereo::new(2.0, 3.0) * 2.0;
+        assert_eq!(s.l, 4.0);
+        assert_eq!(s.r, 6.0);
+    }
+
+    #[test]
+    fn test_add_assign() {
+        let mut a = Stereo::new(1.0, 2.0);
+        a += Stereo::new(3.0, 4.0);
+        assert_eq!(a.l, 4.0);
+        assert_eq!(a.r, 6.0);
+    }
+
+    #[test]
+    fn test_mul_assign() {
+        let mut a = Stereo::new(2.0, 3.0);
+        a *= 2.0;
+        assert_eq!(a.l, 4.0);
+        assert_eq!(a.r, 6.0);
+    }
+
+    #[test]
+    fn test_repr_c_size() {
+        assert_eq!(std::mem::size_of::<Stereo>(), 8);
+        assert_eq!(std::mem::align_of::<Stereo>(), 4);
+    }
+}

--- a/crates/sdr-types/src/stereo.rs
+++ b/crates/sdr-types/src/stereo.rs
@@ -58,6 +58,17 @@ impl std::ops::Mul<f32> for Stereo {
     }
 }
 
+impl std::ops::Div<f32> for Stereo {
+    type Output = Self;
+    #[inline]
+    fn div(self, rhs: f32) -> Self {
+        Self {
+            l: self.l / rhs,
+            r: self.r / rhs,
+        }
+    }
+}
+
 impl std::ops::AddAssign for Stereo {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
@@ -130,6 +141,13 @@ mod tests {
         let s = Stereo::new(2.0, 3.0) * 2.0;
         assert_eq!(s.l, 4.0);
         assert_eq!(s.r, 6.0);
+    }
+
+    #[test]
+    fn test_scalar_div() {
+        let s = Stereo::new(4.0, 6.0) / 2.0;
+        assert_eq!(s.l, 2.0);
+        assert_eq!(s.r, 3.0);
     }
 
     #[test]

--- a/crates/sdr-types/src/stereo.rs
+++ b/crates/sdr-types/src/stereo.rs
@@ -85,6 +85,14 @@ impl std::ops::SubAssign for Stereo {
     }
 }
 
+impl std::ops::DivAssign<f32> for Stereo {
+    #[inline]
+    fn div_assign(&mut self, rhs: f32) {
+        self.l /= rhs;
+        self.r /= rhs;
+    }
+}
+
 impl std::ops::MulAssign<f32> for Stereo {
     #[inline]
     fn mul_assign(&mut self, rhs: f32) {
@@ -99,6 +107,12 @@ impl std::ops::MulAssign<f32> for Stereo {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
+
+    // Compile-time verification of thread safety.
+    const _: fn() = || {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Stereo>();
+    };
 
     #[test]
     fn test_new_and_default() {
@@ -164,6 +178,14 @@ mod tests {
         a *= 2.0;
         assert_eq!(a.l, 4.0);
         assert_eq!(a.r, 6.0);
+    }
+
+    #[test]
+    fn test_div_assign() {
+        let mut a = Stereo::new(4.0, 6.0);
+        a /= 2.0;
+        assert_eq!(a.l, 2.0);
+        assert_eq!(a.r, 3.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Implement `Complex` (f32 re/im) with arithmetic ops, `conj()`, `phase()`, `fast_phase()`, `amplitude()`, `fast_amplitude()` — ports SDR++ `dsp::complex_t`
- Implement `Stereo` (f32 l/r) with arithmetic ops — ports SDR++ `dsp::stereo_t`
- Both types are `#[repr(C)]`, `Copy`, `Send`, `Sync` with matching memory layout
- `DemodMode`, `SampleFormat`, `Protocol` enums
- Error types via `thiserror`: `DspError`, `PipelineError`, `SourceError`, `SinkError`, `ConfigError`, `RtlsdrError`
- Constants: `STREAM_BUFFER_SIZE`, `DEFAULT_AUDIO_SAMPLE_RATE`, `BUFFER_ALIGNMENT`

## Test plan

- [x] 25 unit tests passing (`cargo test -p sdr-types`)
- [x] `cargo clippy -p sdr-types --all-targets -- -D warnings` clean
- [x] Full workspace builds clean
- [x] Complex arithmetic verified against known values (3-4-5 triangle, complex multiply)
- [x] fast_phase within 0.08 radians of exact phase
- [x] fast_amplitude within 5% of exact amplitude
- [x] `#[repr(C)]` size/alignment verified (8 bytes, 4-byte aligned)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Complex number type with exact and fast phase/amplitude, arithmetic ops, and tests.
  * Added Stereo audio sample type with constructors, per-channel ops, and tests.
  * Added DemodMode, SampleFormat (with complex-byte-size helper), and Protocol enums.
  * Added error types for DSP, pipeline, source/sink, config, and device errors.
  * Added constants for stream buffer size, default audio rate, and buffer alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->