### PR TITLE
sdr-dsp: math utilities and window functions

### DIFF
--- a/crates/sdr-dsp/src/lib.rs
+++ b/crates/sdr-dsp/src/lib.rs
@@ -1,1 +1,6 @@
-// sdr-dsp: Pure DSP library (no threading, no I/O)
+//! Pure DSP library (no threading, no I/O).
+//!
+//! All functions are pure: no side effects, no thread spawning, no I/O.
+
+pub mod math;
+pub mod window;

--- a/crates/sdr-dsp/src/math.rs
+++ b/crates/sdr-dsp/src/math.rs
@@ -1,0 +1,133 @@
+//! DSP math utilities — ports SDR++ `dsp::math` namespace.
+
+use core::f64::consts::PI;
+
+/// Convert frequency in Hz to angular frequency in radians/sample.
+///
+/// Ports SDR++ `dsp::math::hzToRads`.
+#[inline]
+pub fn hz_to_rads(freq: f64, sample_rate: f64) -> f64 {
+    2.0 * PI * (freq / sample_rate)
+}
+
+/// Normalize a phase difference to the range `(-pi, pi]`.
+///
+/// Ports SDR++ `dsp::math::normalizePhase`.
+#[inline]
+pub fn normalize_phase(mut diff: f32) -> f32 {
+    if diff > core::f32::consts::PI {
+        diff -= 2.0 * core::f32::consts::PI;
+    } else if diff <= -core::f32::consts::PI {
+        diff += 2.0 * core::f32::consts::PI;
+    }
+    diff
+}
+
+/// Sinc function: `sin(x) / x`, with `sinc(0) = 1`.
+///
+/// Ports SDR++ `dsp::math::sinc`.
+#[inline]
+pub fn sinc(x: f64) -> f64 {
+    if x == 0.0 { 1.0 } else { x.sin() / x }
+}
+
+/// Fast atan2 approximation using rational polynomial.
+///
+/// Ports SDR++ `dsp::math::fastAtan2`. Note: SDR++ parameter order is
+/// `fastAtan2(x, y)` where x=real, y=imag — this matches that convention.
+/// Worst-case error ~0.07 radians.
+#[inline]
+pub fn fast_atan2(x: f32, y: f32) -> f32 {
+    let abs_y = y.abs();
+    if x == 0.0 && y == 0.0 {
+        return 0.0;
+    }
+    let angle = if x >= 0.0 {
+        let r = (x - abs_y) / (x + abs_y);
+        core::f32::consts::FRAC_PI_4 - core::f32::consts::FRAC_PI_4 * r
+    } else {
+        let r = (x + abs_y) / (abs_y - x);
+        3.0 * core::f32::consts::FRAC_PI_4 - core::f32::consts::FRAC_PI_4 * r
+    };
+    if y < 0.0 { -angle } else { angle }
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    const EPS_F32: f32 = 1e-6;
+    const EPS_F64: f64 = 1e-10;
+
+    fn approx_eq_f32(a: f32, b: f32) -> bool {
+        (a - b).abs() < EPS_F32
+    }
+
+    fn approx_eq_f64(a: f64, b: f64) -> bool {
+        (a - b).abs() < EPS_F64
+    }
+
+    #[test]
+    fn test_hz_to_rads() {
+        // Nyquist frequency should give pi radians/sample
+        assert!(approx_eq_f64(hz_to_rads(24000.0, 48000.0), PI));
+        // DC should give 0
+        assert!(approx_eq_f64(hz_to_rads(0.0, 48000.0), 0.0));
+        // Quarter sample rate should give pi/2
+        assert!(approx_eq_f64(
+            hz_to_rads(12000.0, 48000.0),
+            PI / 2.0
+        ));
+    }
+
+    #[test]
+    fn test_normalize_phase() {
+        // Already in range
+        assert!(approx_eq_f32(normalize_phase(1.0), 1.0));
+        assert!(approx_eq_f32(normalize_phase(-1.0), -1.0));
+        // Wraps from above pi
+        assert!(approx_eq_f32(
+            normalize_phase(core::f32::consts::PI + 0.5),
+            -core::f32::consts::PI + 0.5
+        ));
+        // Wraps from below -pi
+        assert!(approx_eq_f32(
+            normalize_phase(-core::f32::consts::PI - 0.5),
+            core::f32::consts::PI - 0.5
+        ));
+    }
+
+    #[test]
+    fn test_sinc() {
+        // sinc(0) = 1
+        assert_eq!(sinc(0.0), 1.0);
+        // sinc(pi) = 0
+        assert!(approx_eq_f64(sinc(PI), 0.0));
+        // sinc(x) = sin(x)/x for non-zero
+        let x = 1.5;
+        assert!(approx_eq_f64(sinc(x), x.sin() / x));
+    }
+
+    #[test]
+    fn test_fast_atan2() {
+        // Compare against standard atan2 — within ~0.08 radians
+        let cases: [(f32, f32); 7] = [
+            (1.0, 0.0),
+            (0.0, 1.0),
+            (-1.0, 0.0),
+            (0.0, -1.0),
+            (1.0, 1.0),
+            (-1.0, -1.0),
+            (3.0, 4.0),
+        ];
+        for (x, y) in &cases {
+            let fast = fast_atan2(*x, *y);
+            let exact = y.atan2(*x);
+            let diff = (fast - exact).abs();
+            assert!(diff < 0.08, "fast_atan2 error {diff} for ({x}, {y})");
+        }
+        // Zero returns zero
+        assert_eq!(fast_atan2(0.0, 0.0), 0.0);
+    }
+}

--- a/crates/sdr-dsp/src/math.rs
+++ b/crates/sdr-dsp/src/math.rs
@@ -100,11 +100,11 @@ mod tests {
             normalize_phase(5.0 * core::f32::consts::PI),
             core::f32::consts::PI
         ));
-        // Multi-wrap negative: -5*pi should normalize to pi (or -pi mapped to pi)
+        // Multi-wrap negative: -5*pi should normalize to pi (not -pi per contract)
         let result = normalize_phase(-5.0 * core::f32::consts::PI);
         assert!(
-            approx_eq_f32(result, core::f32::consts::PI)
-                || approx_eq_f32(result, -core::f32::consts::PI),
+            approx_eq_f32(result, core::f32::consts::PI),
+            "expected pi, got {result}"
         );
         // Zero stays zero
         assert!(approx_eq_f32(normalize_phase(0.0), 0.0));

--- a/crates/sdr-dsp/src/math.rs
+++ b/crates/sdr-dsp/src/math.rs
@@ -38,6 +38,10 @@ pub fn sinc(x: f64) -> f64 {
 /// Ports SDR++ `dsp::math::fastAtan2`. Note: SDR++ parameter order is
 /// `fastAtan2(x, y)` where x=real, y=imag — this matches that convention.
 /// Worst-case error ~0.07 radians.
+///
+/// Note: `Complex::fast_phase` in sdr-types uses the same algorithm inline.
+/// Duplication is intentional — sdr-types cannot depend on sdr-dsp, and
+/// `Complex::fast_phase` avoids the function call overhead in tight loops.
 #[inline]
 pub fn fast_atan2(x: f32, y: f32) -> f32 {
     let abs_y = y.abs();
@@ -61,6 +65,8 @@ mod tests {
 
     const EPS_F32: f32 = 1e-6;
     const EPS_F64: f64 = 1e-10;
+    const TEST_SAMPLE_RATE: f64 = 48_000.0;
+    const FAST_ATAN2_MAX_ERROR: f32 = 0.08;
 
     fn approx_eq_f32(a: f32, b: f32) -> bool {
         (a - b).abs() < EPS_F32
@@ -73,11 +79,14 @@ mod tests {
     #[test]
     fn test_hz_to_rads() {
         // Nyquist frequency should give pi radians/sample
-        assert!(approx_eq_f64(hz_to_rads(24000.0, 48000.0), PI));
+        assert!(approx_eq_f64(hz_to_rads(24_000.0, TEST_SAMPLE_RATE), PI));
         // DC should give 0
-        assert!(approx_eq_f64(hz_to_rads(0.0, 48000.0), 0.0));
+        assert!(approx_eq_f64(hz_to_rads(0.0, TEST_SAMPLE_RATE), 0.0));
         // Quarter sample rate should give pi/2
-        assert!(approx_eq_f64(hz_to_rads(12000.0, 48000.0), PI / 2.0));
+        assert!(approx_eq_f64(
+            hz_to_rads(12_000.0, TEST_SAMPLE_RATE),
+            PI / 2.0
+        ));
     }
 
     #[test]
@@ -137,7 +146,10 @@ mod tests {
             let fast = fast_atan2(*x, *y);
             let exact = y.atan2(*x);
             let diff = (fast - exact).abs();
-            assert!(diff < 0.08, "fast_atan2 error {diff} for ({x}, {y})");
+            assert!(
+                diff < FAST_ATAN2_MAX_ERROR,
+                "fast_atan2 error {diff} for ({x}, {y})"
+            );
         }
         // Zero returns zero
         assert_eq!(fast_atan2(0.0, 0.0), 0.0);

--- a/crates/sdr-dsp/src/math.rs
+++ b/crates/sdr-dsp/src/math.rs
@@ -10,17 +10,19 @@ pub fn hz_to_rads(freq: f64, sample_rate: f64) -> f64 {
     2.0 * PI * (freq / sample_rate)
 }
 
-/// Normalize a phase difference to the range `(-pi, pi]`.
+/// Normalize a phase value to the range `(-pi, pi]`.
 ///
-/// Ports SDR++ `dsp::math::normalizePhase`.
+/// Handles arbitrary input values (not just single-wrap).
+/// Based on SDR++ `dsp::math::normalizePhase` but extended for robustness.
 #[inline]
-pub fn normalize_phase(mut diff: f32) -> f32 {
-    if diff > core::f32::consts::PI {
-        diff -= 2.0 * core::f32::consts::PI;
-    } else if diff <= -core::f32::consts::PI {
-        diff += 2.0 * core::f32::consts::PI;
+pub fn normalize_phase(diff: f32) -> f32 {
+    let mut result =
+        (diff + core::f32::consts::PI).rem_euclid(core::f32::consts::TAU) - core::f32::consts::PI;
+    // rem_euclid can return exactly -PI due to floating point; map to PI
+    if result <= -core::f32::consts::PI {
+        result += core::f32::consts::TAU;
     }
-    diff
+    result
 }
 
 /// Sinc function: `sin(x) / x`, with `sinc(0) = 1`.
@@ -75,10 +77,7 @@ mod tests {
         // DC should give 0
         assert!(approx_eq_f64(hz_to_rads(0.0, 48000.0), 0.0));
         // Quarter sample rate should give pi/2
-        assert!(approx_eq_f64(
-            hz_to_rads(12000.0, 48000.0),
-            PI / 2.0
-        ));
+        assert!(approx_eq_f64(hz_to_rads(12000.0, 48000.0), PI / 2.0));
     }
 
     #[test]
@@ -96,6 +95,19 @@ mod tests {
             normalize_phase(-core::f32::consts::PI - 0.5),
             core::f32::consts::PI - 0.5
         ));
+        // Multi-wrap: 5*pi should normalize to pi
+        assert!(approx_eq_f32(
+            normalize_phase(5.0 * core::f32::consts::PI),
+            core::f32::consts::PI
+        ));
+        // Multi-wrap negative: -5*pi should normalize to pi (or -pi mapped to pi)
+        let result = normalize_phase(-5.0 * core::f32::consts::PI);
+        assert!(
+            approx_eq_f32(result, core::f32::consts::PI)
+                || approx_eq_f32(result, -core::f32::consts::PI),
+        );
+        // Zero stays zero
+        assert!(approx_eq_f32(normalize_phase(0.0), 0.0));
     }
 
     #[test]

--- a/crates/sdr-dsp/src/window.rs
+++ b/crates/sdr-dsp/src/window.rs
@@ -5,6 +5,20 @@
 
 use core::f64::consts::PI;
 
+// Window coefficient constants.
+const HANN_COEFS: [f64; 2] = [0.5, 0.5];
+const HAMMING_COEFS: [f64; 2] = [0.54, 0.46];
+const BLACKMAN_COEFS: [f64; 3] = [0.42, 0.5, 0.08];
+
+#[allow(clippy::unreadable_literal)]
+const BLACKMAN_HARRIS_COEFS: [f64; 4] = [0.35875, 0.48829, 0.14128, 0.01168];
+
+#[allow(clippy::unreadable_literal)]
+const BLACKMAN_NUTTALL_COEFS: [f64; 4] = [0.3635819, 0.4891775, 0.1365995, 0.0106411];
+
+#[allow(clippy::unreadable_literal)]
+const NUTTALL_COEFS: [f64; 4] = [0.355768, 0.487396, 0.144232, 0.012604];
+
 /// Generalized cosine window — base implementation for most window functions.
 ///
 /// Ports SDR++ `dsp::window::cosine`. Computes:
@@ -29,40 +43,37 @@ pub fn rectangular(_n: f64, _big_n: f64) -> f64 {
 /// Hann window.
 #[inline]
 pub fn hann(n: f64, big_n: f64) -> f64 {
-    cosine(n, big_n, &[0.5, 0.5])
+    cosine(n, big_n, &HANN_COEFS)
 }
 
 /// Hamming window.
 #[inline]
 pub fn hamming(n: f64, big_n: f64) -> f64 {
-    cosine(n, big_n, &[0.54, 0.46])
+    cosine(n, big_n, &HAMMING_COEFS)
 }
 
 /// Blackman window.
 #[inline]
 pub fn blackman(n: f64, big_n: f64) -> f64 {
-    cosine(n, big_n, &[0.42, 0.5, 0.08])
+    cosine(n, big_n, &BLACKMAN_COEFS)
 }
 
 /// Blackman-Harris window (4-term).
 #[inline]
-#[allow(clippy::unreadable_literal)]
 pub fn blackman_harris(n: f64, big_n: f64) -> f64 {
-    cosine(n, big_n, &[0.35875, 0.48829, 0.14128, 0.01168])
+    cosine(n, big_n, &BLACKMAN_HARRIS_COEFS)
 }
 
 /// Blackman-Nuttall window (4-term).
 #[inline]
-#[allow(clippy::unreadable_literal)]
 pub fn blackman_nuttall(n: f64, big_n: f64) -> f64 {
-    cosine(n, big_n, &[0.3635819, 0.4891775, 0.1365995, 0.0106411])
+    cosine(n, big_n, &BLACKMAN_NUTTALL_COEFS)
 }
 
 /// Nuttall window (4-term, continuous first derivative).
 #[inline]
-#[allow(clippy::unreadable_literal)]
 pub fn nuttall(n: f64, big_n: f64) -> f64 {
-    cosine(n, big_n, &[0.355768, 0.487396, 0.144232, 0.012604])
+    cosine(n, big_n, &NUTTALL_COEFS)
 }
 
 /// Apply a window function to a buffer in-place.
@@ -103,6 +114,12 @@ mod tests {
 
     fn approx_eq(a: f64, b: f64) -> bool {
         (a - b).abs() < EPS
+    }
+
+    /// Compute the coherent gain (sum of window values) for a window of size N.
+    #[allow(clippy::cast_precision_loss)]
+    fn window_sum(wf: fn(f64, f64) -> f64, big_n: usize) -> f64 {
+        (0..big_n).map(|i| wf(i as f64, big_n as f64)).sum()
     }
 
     #[test]
@@ -185,6 +202,31 @@ mod tests {
                     "symmetry failed at n={n}: {left} != {right}"
                 );
             }
+        }
+    }
+
+    #[test]
+    #[allow(clippy::cast_precision_loss, clippy::type_complexity)]
+    fn test_window_coherent_gain() {
+        // Coherent gain = sum(w[n]) / N. For each window, verify it matches
+        // the expected value (first coefficient of the cosine series).
+        let n = 128;
+        let cases: [(fn(f64, f64) -> f64, f64); 7] = [
+            (rectangular, 1.0),
+            (hann, HANN_COEFS[0]),
+            (hamming, HAMMING_COEFS[0]),
+            (blackman, BLACKMAN_COEFS[0]),
+            (blackman_harris, BLACKMAN_HARRIS_COEFS[0]),
+            (blackman_nuttall, BLACKMAN_NUTTALL_COEFS[0]),
+            (nuttall, NUTTALL_COEFS[0]),
+        ];
+        #[allow(clippy::cast_precision_loss)]
+        for (wf, expected_gain) in &cases {
+            let gain = window_sum(*wf, n) / n as f64;
+            assert!(
+                (gain - expected_gain).abs() < 1e-6,
+                "coherent gain mismatch: got {gain}, expected {expected_gain}"
+            );
         }
     }
 

--- a/crates/sdr-dsp/src/window.rs
+++ b/crates/sdr-dsp/src/window.rs
@@ -1,0 +1,209 @@
+//! Window functions for spectral analysis and FIR filter design.
+//!
+//! Ports SDR++ `dsp::window` namespace. All functions operate on a single
+//! sample index `n` within a window of length `N`.
+
+use core::f64::consts::PI;
+
+/// Generalized cosine window — base implementation for most window functions.
+///
+/// Ports SDR++ `dsp::window::cosine`. Computes:
+/// `w(n) = sum_k (-1)^k * coefs[k] * cos(2*pi*k*n/N)`
+#[allow(clippy::cast_precision_loss)]
+fn cosine(n: f64, big_n: f64, coefs: &[f64]) -> f64 {
+    let mut win = 0.0;
+    let mut sign = 1.0;
+    for (i, &c) in coefs.iter().enumerate() {
+        win += sign * c * (i as f64 * 2.0 * PI * n / big_n).cos();
+        sign = -sign;
+    }
+    win
+}
+
+/// Rectangular window (no windowing). Always returns 1.0.
+#[inline]
+pub fn rectangular(_n: f64, _big_n: f64) -> f64 {
+    1.0
+}
+
+/// Hann window.
+#[inline]
+pub fn hann(n: f64, big_n: f64) -> f64 {
+    cosine(n, big_n, &[0.5, 0.5])
+}
+
+/// Hamming window.
+#[inline]
+pub fn hamming(n: f64, big_n: f64) -> f64 {
+    cosine(n, big_n, &[0.54, 0.46])
+}
+
+/// Blackman window.
+#[inline]
+pub fn blackman(n: f64, big_n: f64) -> f64 {
+    cosine(n, big_n, &[0.42, 0.5, 0.08])
+}
+
+/// Blackman-Harris window (4-term).
+#[inline]
+#[allow(clippy::unreadable_literal)]
+pub fn blackman_harris(n: f64, big_n: f64) -> f64 {
+    cosine(n, big_n, &[0.35875, 0.48829, 0.14128, 0.01168])
+}
+
+/// Blackman-Nuttall window (4-term).
+#[inline]
+#[allow(clippy::unreadable_literal)]
+pub fn blackman_nuttall(n: f64, big_n: f64) -> f64 {
+    cosine(n, big_n, &[0.3635819, 0.4891775, 0.1365995, 0.0106411])
+}
+
+/// Nuttall window (4-term, continuous first derivative).
+#[inline]
+#[allow(clippy::unreadable_literal)]
+pub fn nuttall(n: f64, big_n: f64) -> f64 {
+    cosine(n, big_n, &[0.355768, 0.487396, 0.144232, 0.012604])
+}
+
+/// Apply a window function to a buffer in-place.
+///
+/// `window_fn` is called with `(n, N)` for each sample index.
+#[allow(clippy::cast_precision_loss)]
+pub fn apply<F>(buf: &mut [f64], window_fn: F)
+where
+    F: Fn(f64, f64) -> f64,
+{
+    let big_n = buf.len() as f64;
+    for (i, sample) in buf.iter_mut().enumerate() {
+        *sample *= window_fn(i as f64, big_n);
+    }
+}
+
+/// Apply a window function to f32 complex samples (multiply re and im).
+///
+/// `window_fn` is called with `(n, N)` for each sample index.
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+pub fn apply_complex<F>(buf: &mut [sdr_types::Complex], window_fn: F)
+where
+    F: Fn(f64, f64) -> f64,
+{
+    let big_n = buf.len() as f64;
+    for (i, sample) in buf.iter_mut().enumerate() {
+        let w = window_fn(i as f64, big_n) as f32;
+        sample.re *= w;
+        sample.im *= w;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPS: f64 = 1e-10;
+
+    fn approx_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() < EPS
+    }
+
+    #[test]
+    fn test_rectangular() {
+        for i in 0..10 {
+            assert!(approx_eq(rectangular(f64::from(i), 10.0), 1.0));
+        }
+    }
+
+    #[test]
+    fn test_hann_endpoints() {
+        assert!(approx_eq(hann(0.0, 64.0), 0.0));
+        assert!(approx_eq(hann(64.0, 64.0), 0.0));
+    }
+
+    #[test]
+    fn test_hann_peak() {
+        assert!(approx_eq(hann(32.0, 64.0), 1.0));
+    }
+
+    #[test]
+    fn test_hamming_endpoints() {
+        assert!(approx_eq(hamming(0.0, 64.0), 0.08));
+        assert!(approx_eq(hamming(64.0, 64.0), 0.08));
+    }
+
+    #[test]
+    fn test_hamming_peak() {
+        assert!(approx_eq(hamming(32.0, 64.0), 1.0));
+    }
+
+    #[test]
+    fn test_blackman_endpoints() {
+        assert!(blackman(0.0, 64.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_blackman_peak() {
+        assert!(approx_eq(blackman(32.0, 64.0), 1.0));
+    }
+
+    #[test]
+    fn test_blackman_harris_peak() {
+        assert!(approx_eq(blackman_harris(32.0, 64.0), 1.0));
+    }
+
+    #[test]
+    fn test_blackman_nuttall_peak() {
+        assert!(approx_eq(blackman_nuttall(32.0, 64.0), 1.0));
+    }
+
+    #[test]
+    fn test_nuttall_peak() {
+        assert!(approx_eq(nuttall(32.0, 64.0), 1.0));
+    }
+
+    #[test]
+    fn test_nuttall_endpoints() {
+        assert!(nuttall(0.0, 64.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_window_symmetry() {
+        let big_n = 128.0;
+        let fns: Vec<fn(f64, f64) -> f64> = vec![
+            hann,
+            hamming,
+            blackman,
+            blackman_harris,
+            blackman_nuttall,
+            nuttall,
+        ];
+        for wf in &fns {
+            for i in 0..64 {
+                let n = f64::from(i);
+                let left = wf(n, big_n);
+                let right = wf(big_n - n, big_n);
+                assert!(
+                    approx_eq(left, right),
+                    "symmetry failed at n={n}: {left} != {right}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_apply() {
+        let mut buf = vec![1.0; 64];
+        apply(&mut buf, hann);
+        assert!(buf[0].abs() < 1e-10);
+        assert!((buf[32] - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_apply_complex() {
+        use sdr_types::Complex;
+        let mut buf = vec![Complex::new(1.0, 1.0); 64];
+        apply_complex(&mut buf, hann);
+        assert!(buf[0].re.abs() < 1e-6);
+        assert!(buf[0].im.abs() < 1e-6);
+        assert!((buf[32].re - 1.0).abs() < 1e-6);
+        assert!((buf[32].im - 1.0).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement DSP math utilities: `hz_to_rads`, `normalize_phase`, `sinc`, `fast_atan2`
- Implement 7 window functions: rectangular, hann, hamming, blackman, blackman_harris, blackman_nuttall, nuttall
- Generalized cosine window base matching SDR++ implementation
- `apply()` and `apply_complex()` helpers for windowing buffers

## Test plan

- [x] 18 unit tests passing (`cargo test -p sdr-dsp`)
- [x] `cargo clippy -p sdr-dsp --all-targets -- -D warnings` clean
- [x] Full workspace builds clean
- [x] Math: hz_to_rads verified at Nyquist/DC/quarter, sinc at 0/pi, normalize_phase wrapping
- [x] Windows: endpoint values, peak values, symmetry across all 6 cosine windows
- [x] apply/apply_complex verified with Hann window

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DSP math utilities: frequency→radian conversion, phase normalization, sinc, and a fast atan2 approximation.
  * Added spectral windowing tools: rectangular, Hann, Hamming, Blackman variants, Nuttall, plus in-place application to real and complex buffers for spectral shaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->