### PR TITLE
sdr-dsp channel + sdr-config: Phase 1 complete

### DIFF
--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -56,18 +56,21 @@ impl ConfigManager {
     /// Returns `ConfigError::Io` on filesystem errors.
     pub fn load(path: &Path, defaults: &Value) -> Result<Self, ConfigError> {
         let path = path.to_path_buf();
+        let mut should_save = false;
+
         let data = if path.exists() {
             match std::fs::read_to_string(&path) {
                 Ok(content) => match serde_json::from_str(&content) {
                     Ok(parsed) => merge_defaults(parsed, defaults),
                     Err(e) => {
                         tracing::warn!("config file corrupt, resetting: {e}");
+                        should_save = true;
                         defaults.clone()
                     }
                 },
                 Err(e) => {
-                    tracing::warn!("failed to read config, using defaults: {e}");
-                    defaults.clone()
+                    // IO error on existing file — don't overwrite, propagate error
+                    return Err(ConfigError::Io(e));
                 }
             }
         } else {
@@ -75,18 +78,21 @@ impl ConfigManager {
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
+            should_save = true;
             defaults.clone()
         };
 
         let mgr = Self {
             path,
             data: Arc::new(RwLock::new(data)),
-            modified: Arc::new(Mutex::new(true)), // Save on first auto-save cycle
+            modified: Arc::new(Mutex::new(false)),
             auto_save_handle: None,
         };
 
-        // Save initial config
-        mgr.save()?;
+        // Only save when creating new file or resetting corrupt config
+        if should_save {
+            mgr.save()?;
+        }
 
         Ok(mgr)
     }
@@ -201,6 +207,8 @@ fn auto_save_worker(
                 .wait_timeout_while(stop, Duration::from_millis(AUTO_SAVE_INTERVAL_MS), |s| !*s)
                 .unwrap_or_else(PoisonError::into_inner);
             if *guard {
+                // Flush any pending changes before exiting
+                flush_if_modified(&modified, &data, &path);
                 break;
             }
         }
@@ -217,17 +225,32 @@ fn auto_save_worker(
         };
 
         if should_save {
-            let d = data.read().unwrap_or_else(PoisonError::into_inner);
-            match serde_json::to_string_pretty(&*d) {
-                Ok(content) => {
-                    if let Err(e) = std::fs::write(&path, &content) {
-                        tracing::error!("auto-save write failed: {e}");
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("auto-save serialization failed: {e}");
-                }
+            flush_to_disk(&data, &path);
+        }
+    }
+}
+
+/// Check modified flag and flush to disk if set.
+fn flush_if_modified(modified: &Arc<Mutex<bool>>, data: &Arc<RwLock<Value>>, path: &Path) {
+    let mut m = modified.lock().unwrap_or_else(PoisonError::into_inner);
+    if *m {
+        *m = false;
+        drop(m);
+        flush_to_disk(data, path);
+    }
+}
+
+/// Write data to disk, logging any errors.
+fn flush_to_disk(data: &Arc<RwLock<Value>>, path: &Path) {
+    let d = data.read().unwrap_or_else(PoisonError::into_inner);
+    match serde_json::to_string_pretty(&*d) {
+        Ok(content) => {
+            if let Err(e) = std::fs::write(path, &content) {
+                tracing::error!("auto-save write failed: {e}");
             }
+        }
+        Err(e) => {
+            tracing::error!("auto-save serialization failed: {e}");
         }
     }
 }

--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -125,9 +125,8 @@ impl ConfigManager {
     {
         let mut data = self.data.write().unwrap_or_else(PoisonError::into_inner);
         let result = f(&mut data);
-        if let Ok(mut modified) = self.modified.lock() {
-            *modified = true;
-        }
+        let mut m = self.modified.lock().unwrap_or_else(PoisonError::into_inner);
+        *m = true;
         result
     }
 
@@ -219,10 +218,15 @@ fn auto_save_worker(
 
         if should_save {
             let d = data.read().unwrap_or_else(PoisonError::into_inner);
-            if let Ok(content) = serde_json::to_string_pretty(&*d)
-                && let Err(e) = std::fs::write(&path, &content)
-            {
-                tracing::error!("auto-save failed: {e}");
+            match serde_json::to_string_pretty(&*d) {
+                Ok(content) => {
+                    if let Err(e) = std::fs::write(&path, &content) {
+                        tracing::error!("auto-save write failed: {e}");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("auto-save serialization failed: {e}");
+                }
             }
         }
     }

--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -59,8 +59,8 @@ impl ConfigManager {
         let mut should_save = false;
 
         let data = if path.exists() {
-            match std::fs::read_to_string(&path) {
-                Ok(content) => match serde_json::from_str(&content) {
+            match std::fs::read(&path) {
+                Ok(bytes) => match serde_json::from_slice(&bytes) {
                     Ok(parsed) => merge_defaults(parsed, defaults),
                     Err(e) => {
                         tracing::warn!("config file corrupt, resetting: {e}");
@@ -224,33 +224,43 @@ fn auto_save_worker(
             }
         };
 
-        if should_save {
-            flush_to_disk(&data, &path);
+        if should_save && !flush_to_disk(&data, &path) {
+            // Re-mark dirty so next cycle retries
+            let mut m = modified.lock().unwrap_or_else(PoisonError::into_inner);
+            *m = true;
         }
     }
 }
 
-/// Check modified flag and flush to disk if set.
+/// Check modified flag and flush to disk if set. Re-marks dirty on failure.
 fn flush_if_modified(modified: &Arc<Mutex<bool>>, data: &Arc<RwLock<Value>>, path: &Path) {
     let mut m = modified.lock().unwrap_or_else(PoisonError::into_inner);
     if *m {
         *m = false;
         drop(m);
-        flush_to_disk(data, path);
+        if !flush_to_disk(data, path) {
+            // Re-mark dirty so next cycle retries
+            let mut m = modified.lock().unwrap_or_else(PoisonError::into_inner);
+            *m = true;
+        }
     }
 }
 
-/// Write data to disk, logging any errors.
-fn flush_to_disk(data: &Arc<RwLock<Value>>, path: &Path) {
+/// Write data to disk, logging any errors. Returns true on success.
+fn flush_to_disk(data: &Arc<RwLock<Value>>, path: &Path) -> bool {
     let d = data.read().unwrap_or_else(PoisonError::into_inner);
     match serde_json::to_string_pretty(&*d) {
         Ok(content) => {
             if let Err(e) = std::fs::write(path, &content) {
                 tracing::error!("auto-save write failed: {e}");
+                false
+            } else {
+                true
             }
         }
         Err(e) => {
             tracing::error!("auto-save serialization failed: {e}");
+            false
         }
     }
 }

--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -38,7 +38,7 @@ impl Drop for AutoSaveHandle {
             let mut stop = lock.lock().unwrap_or_else(PoisonError::into_inner);
             *stop = true;
         }
-        cvar.notify_one();
+        cvar.notify_all();
         if let Some(handle) = self.thread.take() {
             let _ = handle.join();
         }
@@ -166,11 +166,18 @@ impl ConfigManager {
     }
 }
 
-/// Merge loaded config with defaults — adds missing keys from defaults.
+/// Recursively merge loaded config with defaults — adds missing keys at all levels.
 fn merge_defaults(mut loaded: Value, defaults: &Value) -> Value {
     if let (Some(loaded_obj), Some(defaults_obj)) = (loaded.as_object_mut(), defaults.as_object()) {
         for (key, default_val) in defaults_obj {
-            if !loaded_obj.contains_key(key) {
+            if let Some(existing) = loaded_obj.get_mut(key) {
+                // Recursively merge nested objects
+                if existing.is_object() && default_val.is_object() {
+                    let merged = merge_defaults(existing.take(), default_val);
+                    *existing = merged;
+                }
+                // Existing non-object value takes precedence
+            } else {
                 loaded_obj.insert(key.clone(), default_val.clone());
             }
         }
@@ -188,13 +195,13 @@ fn auto_save_worker(
 ) {
     let (lock, cvar) = &*stop_flag;
     loop {
-        // Wait for interval or stop signal
+        // Wait for interval or stop signal (predicate avoids missed-notify stall)
         {
             let stop = lock.lock().unwrap_or_else(PoisonError::into_inner);
-            let result = cvar
-                .wait_timeout(stop, Duration::from_millis(AUTO_SAVE_INTERVAL_MS))
+            let (guard, _timeout) = cvar
+                .wait_timeout_while(stop, Duration::from_millis(AUTO_SAVE_INTERVAL_MS), |s| !*s)
                 .unwrap_or_else(PoisonError::into_inner);
-            if *result.0 {
+            if *guard {
                 break;
             }
         }
@@ -335,6 +342,16 @@ mod tests {
         assert_eq!(merged["a"], 1);
         assert_eq!(merged["b"], 2);
         assert_eq!(merged["c"], 3);
+    }
+
+    #[test]
+    fn test_merge_defaults_recursive() {
+        let loaded = json!({"audio": {"volume": 0.8}});
+        let defaults = json!({"audio": {"volume": 0.5, "device": "default"}, "freq": 100});
+        let merged = merge_defaults(loaded, &defaults);
+        assert_eq!(merged["audio"]["volume"], 0.8); // loaded wins
+        assert_eq!(merged["audio"]["device"], "default"); // merged from defaults
+        assert_eq!(merged["freq"], 100); // top-level default
     }
 
     #[test]

--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -1,1 +1,348 @@
-// sdr-config: JSON configuration persistence
+//! JSON configuration persistence.
+//!
+//! Ports SDR++ `ConfigManager`. Provides thread-safe JSON configuration
+//! with load, save, and auto-save functionality.
+
+use sdr_types::ConfigError;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex, PoisonError, RwLock};
+use std::thread;
+use std::time::Duration;
+
+/// Auto-save interval in milliseconds.
+const AUTO_SAVE_INTERVAL_MS: u64 = 1000;
+
+/// Thread-safe JSON configuration manager.
+///
+/// Ports SDR++ `ConfigManager`. Provides:
+/// - Load from file with defaults merging
+/// - Thread-safe read/write access via `RwLock`
+/// - Auto-save to disk on a background thread when modified
+pub struct ConfigManager {
+    path: PathBuf,
+    data: Arc<RwLock<Value>>,
+    modified: Arc<Mutex<bool>>,
+    auto_save_handle: Option<AutoSaveHandle>,
+}
+
+struct AutoSaveHandle {
+    stop_flag: Arc<(Mutex<bool>, Condvar)>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for AutoSaveHandle {
+    fn drop(&mut self) {
+        let (lock, cvar) = &*self.stop_flag;
+        {
+            let mut stop = lock.lock().unwrap_or_else(PoisonError::into_inner);
+            *stop = true;
+        }
+        cvar.notify_one();
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl ConfigManager {
+    /// Load configuration from a file, merging with defaults.
+    ///
+    /// If the file doesn't exist, it's created with the default values.
+    /// If the file exists but is corrupt, it's reset to defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::Io` on filesystem errors.
+    pub fn load(path: &Path, defaults: &Value) -> Result<Self, ConfigError> {
+        let path = path.to_path_buf();
+        let data = if path.exists() {
+            match std::fs::read_to_string(&path) {
+                Ok(content) => match serde_json::from_str(&content) {
+                    Ok(parsed) => merge_defaults(parsed, defaults),
+                    Err(e) => {
+                        tracing::warn!("config file corrupt, resetting: {e}");
+                        defaults.clone()
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!("failed to read config, using defaults: {e}");
+                    defaults.clone()
+                }
+            }
+        } else {
+            // Create parent directories if needed
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            defaults.clone()
+        };
+
+        let mgr = Self {
+            path,
+            data: Arc::new(RwLock::new(data)),
+            modified: Arc::new(Mutex::new(true)), // Save on first auto-save cycle
+            auto_save_handle: None,
+        };
+
+        // Save initial config
+        mgr.save()?;
+
+        Ok(mgr)
+    }
+
+    /// Save configuration to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::Io` on write failure.
+    pub fn save(&self) -> Result<(), ConfigError> {
+        let data = self.data.read().unwrap_or_else(PoisonError::into_inner);
+        let content =
+            serde_json::to_string_pretty(&*data).map_err(|e| ConfigError::Json(e.to_string()))?;
+        std::fs::write(&self.path, content)?;
+        Ok(())
+    }
+
+    /// Read the configuration via a closure.
+    ///
+    /// The closure receives an immutable reference to the JSON value.
+    pub fn read<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&Value) -> R,
+    {
+        let data = self.data.read().unwrap_or_else(PoisonError::into_inner);
+        f(&data)
+    }
+
+    /// Write to the configuration via a closure.
+    ///
+    /// The closure receives a mutable reference to the JSON value.
+    /// Automatically marks the config as modified for auto-save.
+    pub fn write<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut Value) -> R,
+    {
+        let mut data = self.data.write().unwrap_or_else(PoisonError::into_inner);
+        let result = f(&mut data);
+        if let Ok(mut modified) = self.modified.lock() {
+            *modified = true;
+        }
+        result
+    }
+
+    /// Enable periodic auto-save on a background thread.
+    ///
+    /// Checks for modifications every second and saves if needed.
+    pub fn enable_auto_save(&mut self) {
+        if self.auto_save_handle.is_some() {
+            return;
+        }
+
+        let stop_flag = Arc::new((Mutex::new(false), Condvar::new()));
+        let stop_clone = Arc::clone(&stop_flag);
+        let data = Arc::clone(&self.data);
+        let modified = Arc::clone(&self.modified);
+        let path = self.path.clone();
+
+        let thread = thread::spawn(move || {
+            auto_save_worker(stop_clone, data, modified, path);
+        });
+
+        self.auto_save_handle = Some(AutoSaveHandle {
+            stop_flag,
+            thread: Some(thread),
+        });
+    }
+
+    /// Disable auto-save and stop the background thread.
+    pub fn disable_auto_save(&mut self) {
+        self.auto_save_handle = None;
+    }
+
+    /// Returns the config file path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Merge loaded config with defaults — adds missing keys from defaults.
+fn merge_defaults(mut loaded: Value, defaults: &Value) -> Value {
+    if let (Some(loaded_obj), Some(defaults_obj)) = (loaded.as_object_mut(), defaults.as_object()) {
+        for (key, default_val) in defaults_obj {
+            if !loaded_obj.contains_key(key) {
+                loaded_obj.insert(key.clone(), default_val.clone());
+            }
+        }
+    }
+    loaded
+}
+
+/// Background auto-save worker thread.
+#[allow(clippy::needless_pass_by_value)]
+fn auto_save_worker(
+    stop_flag: Arc<(Mutex<bool>, Condvar)>,
+    data: Arc<RwLock<Value>>,
+    modified: Arc<Mutex<bool>>,
+    path: PathBuf,
+) {
+    let (lock, cvar) = &*stop_flag;
+    loop {
+        // Wait for interval or stop signal
+        {
+            let stop = lock.lock().unwrap_or_else(PoisonError::into_inner);
+            let result = cvar
+                .wait_timeout(stop, Duration::from_millis(AUTO_SAVE_INTERVAL_MS))
+                .unwrap_or_else(PoisonError::into_inner);
+            if *result.0 {
+                break;
+            }
+        }
+
+        // Check if modified
+        let should_save = {
+            let mut m = modified.lock().unwrap_or_else(PoisonError::into_inner);
+            if *m {
+                *m = false;
+                true
+            } else {
+                false
+            }
+        };
+
+        if should_save {
+            let d = data.read().unwrap_or_else(PoisonError::into_inner);
+            if let Ok(content) = serde_json::to_string_pretty(&*d)
+                && let Err(e) = std::fs::write(&path, &content)
+            {
+                tracing::error!("auto-save failed: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+
+    fn temp_path(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("sdr-config-test");
+        fs::create_dir_all(&dir).unwrap();
+        dir.join(name)
+    }
+
+    #[test]
+    fn test_load_creates_new_file() {
+        let path = temp_path("test_new.json");
+        let _ = fs::remove_file(&path);
+
+        let defaults = json!({"volume": 0.5, "frequency": 100_000_000});
+        let mgr = ConfigManager::load(&path, &defaults).unwrap();
+
+        assert!(path.exists());
+        mgr.read(|v| {
+            assert_eq!(v["volume"], 0.5);
+            assert_eq!(v["frequency"], 100_000_000);
+        });
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_load_existing_file() {
+        let path = temp_path("test_existing.json");
+        fs::write(&path, r#"{"volume": 0.8}"#).unwrap();
+
+        let defaults = json!({"volume": 0.5, "frequency": 100_000_000});
+        let mgr = ConfigManager::load(&path, &defaults).unwrap();
+
+        mgr.read(|v| {
+            assert_eq!(v["volume"], 0.8);
+            assert_eq!(v["frequency"], 100_000_000);
+        });
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_load_corrupt_file() {
+        let path = temp_path("test_corrupt.json");
+        fs::write(&path, "not valid json!!!").unwrap();
+
+        let defaults = json!({"volume": 0.5});
+        let mgr = ConfigManager::load(&path, &defaults).unwrap();
+
+        mgr.read(|v| {
+            assert_eq!(v["volume"], 0.5);
+        });
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_write_and_save() {
+        let path = temp_path("test_write.json");
+        let _ = fs::remove_file(&path);
+
+        let defaults = json!({"volume": 0.5});
+        let mgr = ConfigManager::load(&path, &defaults).unwrap();
+
+        mgr.write(|v| {
+            v["volume"] = json!(0.9);
+            v["new_key"] = json!("hello");
+        });
+        mgr.save().unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let on_disk: Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(on_disk["volume"], 0.9);
+        assert_eq!(on_disk["new_key"], "hello");
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_auto_save() {
+        let path = temp_path("test_autosave.json");
+        let _ = fs::remove_file(&path);
+
+        let defaults = json!({"volume": 0.5});
+        let mut mgr = ConfigManager::load(&path, &defaults).unwrap();
+        mgr.enable_auto_save();
+
+        mgr.write(|v| {
+            v["volume"] = json!(0.75);
+        });
+
+        thread::sleep(Duration::from_millis(1500));
+
+        let content = fs::read_to_string(&path).unwrap();
+        let on_disk: Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(on_disk["volume"], 0.75);
+
+        mgr.disable_auto_save();
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_merge_defaults() {
+        let loaded = json!({"a": 1, "b": 2});
+        let defaults = json!({"b": 99, "c": 3});
+        let merged = merge_defaults(loaded, &defaults);
+        assert_eq!(merged["a"], 1);
+        assert_eq!(merged["b"], 2);
+        assert_eq!(merged["c"], 3);
+    }
+
+    #[test]
+    fn test_path() {
+        let path = temp_path("test_path.json");
+        let _ = fs::remove_file(&path);
+        let mgr = ConfigManager::load(&path, &json!({})).unwrap();
+        assert_eq!(mgr.path(), path);
+        let _ = fs::remove_file(&path);
+    }
+}

--- a/crates/sdr-dsp/src/channel.rs
+++ b/crates/sdr-dsp/src/channel.rs
@@ -15,6 +15,9 @@ const VFO_FILTER_TRANSITION_RATIO: f64 = 0.1;
 /// Guard padding for resampler output buffer to handle worst-case rounding.
 const RESAMPLER_OUTPUT_PADDING: usize = 16;
 
+/// Tolerance in Hz for considering bandwidth equal to sample rate (no filter needed).
+const BANDWIDTH_BYPASS_TOLERANCE: f64 = 1.0;
+
 /// Frequency translator — shifts a signal in frequency using an NCO.
 ///
 /// Ports SDR++ `dsp::channel::FrequencyXlator`. Multiplies each input
@@ -125,7 +128,7 @@ impl RxVfo {
         let xlator = FrequencyXlator::from_hz(-offset, in_sample_rate);
         let resampler = RationalResampler::new(in_sample_rate, out_sample_rate)?;
 
-        let filter = if bandwidth < out_sample_rate - 1.0 {
+        let filter = if bandwidth < out_sample_rate - BANDWIDTH_BYPASS_TOLERANCE {
             let filter_width = bandwidth / 2.0;
             let filter_trans = filter_width * VFO_FILTER_TRANSITION_RATIO;
             let filter_taps = taps::low_pass(filter_width, filter_trans, out_sample_rate, true)?;
@@ -160,16 +163,19 @@ impl RxVfo {
     ///
     /// Returns `DspError::InvalidParameter` if bandwidth is invalid.
     pub fn set_bandwidth(&mut self, bandwidth: f64) -> Result<(), DspError> {
-        self.bandwidth = bandwidth;
-        if bandwidth < self.out_sample_rate - 1.0 {
+        // Build new filter before mutating state (transactional)
+        let new_filter = if bandwidth < self.out_sample_rate - BANDWIDTH_BYPASS_TOLERANCE {
             let filter_width = bandwidth / 2.0;
             let filter_trans = filter_width * VFO_FILTER_TRANSITION_RATIO;
             let filter_taps =
                 taps::low_pass(filter_width, filter_trans, self.out_sample_rate, true)?;
-            self.filter = Some(ComplexFirFilter::new(filter_taps)?);
+            Some(ComplexFirFilter::new(filter_taps)?)
         } else {
-            self.filter = None;
-        }
+            None
+        };
+        // Only update state after successful construction
+        self.bandwidth = bandwidth;
+        self.filter = new_filter;
         Ok(())
     }
 

--- a/crates/sdr-dsp/src/channel.rs
+++ b/crates/sdr-dsp/src/channel.rs
@@ -1,0 +1,356 @@
+//! Channel processing: frequency translation and VFO extraction.
+//!
+//! Ports SDR++ `dsp::channel` namespace.
+
+use sdr_types::{Complex, DspError};
+
+use crate::filter::ComplexFirFilter;
+use crate::math;
+use crate::multirate::RationalResampler;
+use crate::taps;
+
+/// Frequency translator — shifts a signal in frequency using an NCO.
+///
+/// Ports SDR++ `dsp::channel::FrequencyXlator`. Multiplies each input
+/// sample by a rotating complex phasor at the offset frequency, effectively
+/// shifting the spectrum.
+pub struct FrequencyXlator {
+    phase: f32,
+    phase_delta: f32,
+}
+
+impl FrequencyXlator {
+    /// Create a new frequency translator.
+    ///
+    /// - `offset`: frequency offset in radians/sample
+    pub fn new(offset: f32) -> Self {
+        Self {
+            phase: 0.0,
+            phase_delta: offset,
+        }
+    }
+
+    /// Create from offset in Hz and sample rate.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn from_hz(offset_hz: f64, sample_rate: f64) -> Self {
+        Self::new(math::hz_to_rads(offset_hz, sample_rate) as f32)
+    }
+
+    /// Update the frequency offset (radians/sample).
+    pub fn set_offset(&mut self, offset: f32) {
+        self.phase_delta = offset;
+    }
+
+    /// Update the frequency offset from Hz.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn set_offset_hz(&mut self, offset_hz: f64, sample_rate: f64) {
+        self.phase_delta = math::hz_to_rads(offset_hz, sample_rate) as f32;
+    }
+
+    /// Reset the NCO phase to zero.
+    pub fn reset(&mut self) {
+        self.phase = 0.0;
+    }
+
+    /// Process complex samples, shifting them in frequency.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::BufferTooSmall` if `output.len() < input.len()`.
+    pub fn process(
+        &mut self,
+        input: &[Complex],
+        output: &mut [Complex],
+    ) -> Result<usize, DspError> {
+        if output.len() < input.len() {
+            return Err(DspError::BufferTooSmall {
+                need: input.len(),
+                got: output.len(),
+            });
+        }
+        for (i, &s) in input.iter().enumerate() {
+            let (sin, cos) = self.phase.sin_cos();
+            let phasor = Complex::new(cos, sin);
+            output[i] = s * phasor;
+            self.phase += self.phase_delta;
+            // Wrap phase to prevent float precision loss over time
+            self.phase = math::normalize_phase(self.phase);
+        }
+        Ok(input.len())
+    }
+}
+
+/// Receive VFO — frequency translation + resampling + optional filtering.
+///
+/// Ports SDR++ `dsp::channel::RxVFO`. Extracts a channel from a wideband
+/// IQ stream by:
+/// 1. Frequency translating to center the desired signal at DC
+/// 2. Resampling to the output sample rate
+/// 3. Optionally bandpass filtering if bandwidth < output sample rate
+pub struct RxVfo {
+    xlator: FrequencyXlator,
+    resampler: RationalResampler,
+    filter: Option<ComplexFirFilter>,
+    in_sample_rate: f64,
+    out_sample_rate: f64,
+    bandwidth: f64,
+    offset: f64,
+    xlator_buf: Vec<Complex>,
+    resamp_buf: Vec<Complex>,
+}
+
+impl RxVfo {
+    /// Create a new `RxVfo`.
+    ///
+    /// - `in_sample_rate`: input sample rate in Hz
+    /// - `out_sample_rate`: desired output sample rate in Hz
+    /// - `bandwidth`: channel bandwidth in Hz
+    /// - `offset`: center frequency offset in Hz (negative = shift down)
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if parameters are invalid.
+    pub fn new(
+        in_sample_rate: f64,
+        out_sample_rate: f64,
+        bandwidth: f64,
+        offset: f64,
+    ) -> Result<Self, DspError> {
+        let xlator = FrequencyXlator::from_hz(-offset, in_sample_rate);
+        let resampler = RationalResampler::new(in_sample_rate, out_sample_rate)?;
+
+        let filter = if (bandwidth - out_sample_rate).abs() > 1.0 {
+            let filter_width = bandwidth / 2.0;
+            let filter_trans = filter_width * 0.1;
+            let filter_taps = taps::low_pass(filter_width, filter_trans, out_sample_rate, true)?;
+            Some(ComplexFirFilter::new(filter_taps)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            xlator,
+            resampler,
+            filter,
+            in_sample_rate,
+            out_sample_rate,
+            bandwidth,
+            offset,
+            xlator_buf: Vec::new(),
+            resamp_buf: Vec::new(),
+        })
+    }
+
+    /// Update the frequency offset.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn set_offset(&mut self, offset: f64) {
+        self.offset = offset;
+        self.xlator.set_offset_hz(-offset, self.in_sample_rate);
+    }
+
+    /// Update the bandwidth. Regenerates the filter if needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if bandwidth is invalid.
+    pub fn set_bandwidth(&mut self, bandwidth: f64) -> Result<(), DspError> {
+        self.bandwidth = bandwidth;
+        if (bandwidth - self.out_sample_rate).abs() > 1.0 {
+            let filter_width = bandwidth / 2.0;
+            let filter_trans = filter_width * 0.1;
+            let filter_taps =
+                taps::low_pass(filter_width, filter_trans, self.out_sample_rate, true)?;
+            self.filter = Some(ComplexFirFilter::new(filter_taps)?);
+        } else {
+            self.filter = None;
+        }
+        Ok(())
+    }
+
+    /// Reset all internal state.
+    pub fn reset(&mut self) {
+        self.xlator.reset();
+        self.resampler.reset();
+        if let Some(f) = &mut self.filter {
+            f.reset();
+        }
+    }
+
+    /// Process complex samples through the VFO chain.
+    ///
+    /// Returns the number of output samples written.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::BufferTooSmall` if `output` is too small.
+    pub fn process(
+        &mut self,
+        input: &[Complex],
+        output: &mut [Complex],
+    ) -> Result<usize, DspError> {
+        // Step 1: Frequency translate
+        self.xlator_buf.resize(input.len(), Complex::default());
+        self.xlator.process(input, &mut self.xlator_buf)?;
+
+        // Step 2: Resample
+        self.resamp_buf.resize(input.len() * 2, Complex::default());
+        let resamp_count = self
+            .resampler
+            .process(&self.xlator_buf, &mut self.resamp_buf)?;
+
+        // Step 3: Optional filter
+        if let Some(filter) = &mut self.filter {
+            if output.len() < resamp_count {
+                return Err(DspError::BufferTooSmall {
+                    need: resamp_count,
+                    got: output.len(),
+                });
+            }
+            filter.process(&self.resamp_buf[..resamp_count], output)?;
+            Ok(resamp_count)
+        } else {
+            if output.len() < resamp_count {
+                return Err(DspError::BufferTooSmall {
+                    need: resamp_count,
+                    got: output.len(),
+                });
+            }
+            output[..resamp_count].copy_from_slice(&self.resamp_buf[..resamp_count]);
+            Ok(resamp_count)
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::cast_precision_loss,
+    clippy::manual_range_contains
+)]
+mod tests {
+    use super::*;
+    use core::f32::consts::PI;
+
+    #[test]
+    fn test_xlator_dc_passthrough() {
+        // Zero offset should pass DC signal through unchanged
+        let mut xlator = FrequencyXlator::new(0.0);
+        let input = vec![Complex::new(1.0, 0.0); 100];
+        let mut output = vec![Complex::default(); 100];
+        xlator.process(&input, &mut output).unwrap();
+        for (i, &s) in output.iter().enumerate() {
+            assert!(
+                (s.re - 1.0).abs() < 1e-4,
+                "sample {i}: expected ~1.0, got {}",
+                s.re
+            );
+        }
+    }
+
+    #[test]
+    fn test_xlator_shifts_frequency() {
+        // Apply a frequency shift and verify the signal rotates
+        let offset = 0.1_f32;
+        let mut xlator = FrequencyXlator::new(offset);
+        let input = vec![Complex::new(1.0, 0.0); 100];
+        let mut output = vec![Complex::default(); 100];
+        xlator.process(&input, &mut output).unwrap();
+        // Output should be a rotating phasor at the offset frequency
+        // Check that amplitude is preserved (~1.0)
+        for s in &output {
+            assert!(
+                (s.amplitude() - 1.0).abs() < 1e-4,
+                "amplitude should be ~1.0"
+            );
+        }
+        // Phase should advance by offset each sample
+        let phase_diff = output[50].phase() - output[49].phase();
+        let normalized = math::normalize_phase(phase_diff);
+        assert!(
+            (normalized - offset).abs() < 0.02,
+            "phase advance should be ~{offset}, got {normalized}"
+        );
+    }
+
+    #[test]
+    fn test_xlator_reset() {
+        let mut xlator = FrequencyXlator::new(0.5);
+        let input = vec![Complex::new(1.0, 0.0); 100];
+        let mut output = vec![Complex::default(); 100];
+        xlator.process(&input, &mut output).unwrap();
+        xlator.reset();
+        // After reset, first output should have phase ~0
+        xlator.process(&input[..1], &mut output[..1]).unwrap();
+        assert!(
+            output[0].phase().abs() < 0.01,
+            "after reset, phase should be ~0"
+        );
+    }
+
+    #[test]
+    fn test_rxvfo_basic() {
+        // 48kHz input, 8kHz output, 6kHz bandwidth, no offset
+        let mut vfo = RxVfo::new(48_000.0, 8_000.0, 6_000.0, 0.0).unwrap();
+        let input = vec![Complex::new(1.0, 0.0); 4800];
+        let mut output = vec![Complex::default(); 4800];
+        let count = vfo.process(&input, &mut output).unwrap();
+        // Should produce ~800 samples (4800 * 8000/48000)
+        assert!(
+            count >= 600 && count <= 1000,
+            "expected ~800 samples, got {count}"
+        );
+    }
+
+    #[test]
+    fn test_rxvfo_passthrough_rate() {
+        // Same input/output rate, full bandwidth = no filter
+        let mut vfo = RxVfo::new(48_000.0, 48_000.0, 48_000.0, 0.0).unwrap();
+        let input = vec![Complex::new(1.0, 0.0); 1000];
+        let mut output = vec![Complex::default(); 1100];
+        let count = vfo.process(&input, &mut output).unwrap();
+        assert_eq!(count, 1000);
+    }
+
+    #[test]
+    fn test_rxvfo_with_offset() {
+        // Offset should shift the signal
+        let mut vfo = RxVfo::new(48_000.0, 48_000.0, 48_000.0, 1_000.0).unwrap();
+        let input = vec![Complex::new(1.0, 0.0); 1000];
+        let mut output = vec![Complex::default(); 1100];
+        let count = vfo.process(&input, &mut output).unwrap();
+        assert_eq!(count, 1000);
+        // Output should be oscillating (shifted from DC)
+        let crossings = output[100..count]
+            .windows(2)
+            .filter(|w| (w[0].re >= 0.0) != (w[1].re >= 0.0))
+            .count();
+        assert!(
+            crossings > 10,
+            "offset signal should oscillate, got {crossings} crossings"
+        );
+    }
+
+    #[test]
+    fn test_xlator_buffer_too_small() {
+        let mut xlator = FrequencyXlator::new(0.0);
+        let input = [Complex::default(); 10];
+        let mut output = [Complex::default(); 5];
+        assert!(xlator.process(&input, &mut output).is_err());
+    }
+
+    #[test]
+    fn test_xlator_output_is_unit_amplitude() {
+        // Regardless of offset, unit input should produce unit output
+        let mut xlator = FrequencyXlator::new(PI / 4.0);
+        let input = vec![Complex::new(1.0, 0.0); 500];
+        let mut output = vec![Complex::default(); 500];
+        xlator.process(&input, &mut output).unwrap();
+        for (i, s) in output.iter().enumerate() {
+            assert!(
+                (s.amplitude() - 1.0).abs() < 1e-3,
+                "sample {i}: amplitude {}, expected ~1.0",
+                s.amplitude()
+            );
+        }
+    }
+}

--- a/crates/sdr-dsp/src/channel.rs
+++ b/crates/sdr-dsp/src/channel.rs
@@ -5,12 +5,15 @@
 use sdr_types::{Complex, DspError};
 
 use crate::filter::ComplexFirFilter;
-
-/// Transition width as a fraction of filter bandwidth for VFO channel filter.
-const VFO_FILTER_TRANSITION_RATIO: f64 = 0.1;
 use crate::math;
 use crate::multirate::RationalResampler;
 use crate::taps;
+
+/// Transition width as a fraction of filter bandwidth for VFO channel filter.
+const VFO_FILTER_TRANSITION_RATIO: f64 = 0.1;
+
+/// Guard padding for resampler output buffer to handle worst-case rounding.
+const RESAMPLER_OUTPUT_PADDING: usize = 16;
 
 /// Frequency translator — shifts a signal in frequency using an NCO.
 ///
@@ -198,13 +201,12 @@ impl RxVfo {
         // Step 2: Resample — size buffer for worst-case expansion ratio
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let ratio = (self.out_sample_rate / self.in_sample_rate).ceil() as usize;
-        let resamp_size = input.len() * ratio.max(1) + 16;
+        let resamp_size = input.len() * ratio.max(1) + RESAMPLER_OUTPUT_PADDING;
         self.resamp_buf.resize(resamp_size, Complex::default());
         let resamp_count = self
             .resampler
             .process(&self.xlator_buf, &mut self.resamp_buf)?;
 
-        // Step 3: Optional filter
         // Step 3: Check output buffer and apply optional filter
         if output.len() < resamp_count {
             return Err(DspError::BufferTooSmall {

--- a/crates/sdr-dsp/src/channel.rs
+++ b/crates/sdr-dsp/src/channel.rs
@@ -119,7 +119,7 @@ impl RxVfo {
         let xlator = FrequencyXlator::from_hz(-offset, in_sample_rate);
         let resampler = RationalResampler::new(in_sample_rate, out_sample_rate)?;
 
-        let filter = if (bandwidth - out_sample_rate).abs() > 1.0 {
+        let filter = if bandwidth < out_sample_rate - 1.0 {
             let filter_width = bandwidth / 2.0;
             let filter_trans = filter_width * 0.1;
             let filter_taps = taps::low_pass(filter_width, filter_trans, out_sample_rate, true)?;
@@ -155,7 +155,7 @@ impl RxVfo {
     /// Returns `DspError::InvalidParameter` if bandwidth is invalid.
     pub fn set_bandwidth(&mut self, bandwidth: f64) -> Result<(), DspError> {
         self.bandwidth = bandwidth;
-        if (bandwidth - self.out_sample_rate).abs() > 1.0 {
+        if bandwidth < self.out_sample_rate - 1.0 {
             let filter_width = bandwidth / 2.0;
             let filter_trans = filter_width * 0.1;
             let filter_taps =
@@ -192,8 +192,11 @@ impl RxVfo {
         self.xlator_buf.resize(input.len(), Complex::default());
         self.xlator.process(input, &mut self.xlator_buf)?;
 
-        // Step 2: Resample
-        self.resamp_buf.resize(input.len() * 2, Complex::default());
+        // Step 2: Resample — size buffer for worst-case expansion ratio
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let ratio = (self.out_sample_rate / self.in_sample_rate).ceil() as usize;
+        let resamp_size = input.len() * ratio.max(1) + 16;
+        self.resamp_buf.resize(resamp_size, Complex::default());
         let resamp_count = self
             .resampler
             .process(&self.xlator_buf, &mut self.resamp_buf)?;

--- a/crates/sdr-dsp/src/channel.rs
+++ b/crates/sdr-dsp/src/channel.rs
@@ -151,7 +151,6 @@ impl RxVfo {
     }
 
     /// Update the frequency offset.
-    #[allow(clippy::cast_possible_truncation)]
     pub fn set_offset(&mut self, offset: f64) {
         self.offset = offset;
         self.xlator.set_offset_hz(-offset, self.in_sample_rate);

--- a/crates/sdr-dsp/src/channel.rs
+++ b/crates/sdr-dsp/src/channel.rs
@@ -5,6 +5,9 @@
 use sdr_types::{Complex, DspError};
 
 use crate::filter::ComplexFirFilter;
+
+/// Transition width as a fraction of filter bandwidth for VFO channel filter.
+const VFO_FILTER_TRANSITION_RATIO: f64 = 0.1;
 use crate::math;
 use crate::multirate::RationalResampler;
 use crate::taps;
@@ -121,7 +124,7 @@ impl RxVfo {
 
         let filter = if bandwidth < out_sample_rate - 1.0 {
             let filter_width = bandwidth / 2.0;
-            let filter_trans = filter_width * 0.1;
+            let filter_trans = filter_width * VFO_FILTER_TRANSITION_RATIO;
             let filter_taps = taps::low_pass(filter_width, filter_trans, out_sample_rate, true)?;
             Some(ComplexFirFilter::new(filter_taps)?)
         } else {
@@ -157,7 +160,7 @@ impl RxVfo {
         self.bandwidth = bandwidth;
         if bandwidth < self.out_sample_rate - 1.0 {
             let filter_width = bandwidth / 2.0;
-            let filter_trans = filter_width * 0.1;
+            let filter_trans = filter_width * VFO_FILTER_TRANSITION_RATIO;
             let filter_taps =
                 taps::low_pass(filter_width, filter_trans, self.out_sample_rate, true)?;
             self.filter = Some(ComplexFirFilter::new(filter_taps)?);
@@ -202,25 +205,19 @@ impl RxVfo {
             .process(&self.xlator_buf, &mut self.resamp_buf)?;
 
         // Step 3: Optional filter
-        if let Some(filter) = &mut self.filter {
-            if output.len() < resamp_count {
-                return Err(DspError::BufferTooSmall {
-                    need: resamp_count,
-                    got: output.len(),
-                });
-            }
-            filter.process(&self.resamp_buf[..resamp_count], output)?;
-            Ok(resamp_count)
-        } else {
-            if output.len() < resamp_count {
-                return Err(DspError::BufferTooSmall {
-                    need: resamp_count,
-                    got: output.len(),
-                });
-            }
-            output[..resamp_count].copy_from_slice(&self.resamp_buf[..resamp_count]);
-            Ok(resamp_count)
+        // Step 3: Check output buffer and apply optional filter
+        if output.len() < resamp_count {
+            return Err(DspError::BufferTooSmall {
+                need: resamp_count,
+                got: output.len(),
+            });
         }
+        if let Some(filter) = &mut self.filter {
+            filter.process(&self.resamp_buf[..resamp_count], output)?;
+        } else {
+            output[..resamp_count].copy_from_slice(&self.resamp_buf[..resamp_count]);
+        }
+        Ok(resamp_count)
     }
 }
 

--- a/crates/sdr-dsp/src/lib.rs
+++ b/crates/sdr-dsp/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! All functions are pure: no side effects, no thread spawning, no I/O.
 
+pub mod channel;
 pub mod convert;
 pub mod correction;
 pub mod demod;


### PR DESCRIPTION
## Summary

Final Phase 1 PR — completes the foundation layer.

**Channel processing** (ports SDR++ `dsp::channel`):
- `FrequencyXlator`: NCO-based frequency translation using `sin_cos`, phase wrapping
- `RxVfo`: composite processor (xlator + rational resampler + optional bandpass filter) with pre-allocated buffers

**Config manager** (ports SDR++ `ConfigManager`):
- `ConfigManager`: thread-safe JSON config via `Arc<RwLock<Value>>`
- Load with defaults merging, corrupt file recovery
- Auto-save on background thread with condvar shutdown
- `read()` / `write()` closures for safe concurrent access

## Test plan

- [x] 130 total tests passing (123 sdr-dsp + 7 sdr-config)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Channel: DC passthrough, frequency shift, unit amplitude, RxVfo rate conversion
- [x] Config: new file, existing merge, corrupt recovery, write+save, auto-save

Closes #12
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent JSON configuration with defaults, recovery for missing/corrupt files, manual load/save, read/write accessors, enable/disable auto-save background persistence, and path access.
  * DSP channel tools: frequency translator and Rx VFO pipeline with resampling, optional filtering, configurable bandwidth/offset, buffer-size validation, and reset behavior.

* **Tests**
  * Comprehensive tests for config persistence/auto-save, recursive default merging, and DSP components (translation, resampling, buffering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->