### PR TITLE
sdr-pipeline: Stream, Block, Chain, Splitter

### DIFF
--- a/crates/sdr-pipeline/src/block.rs
+++ b/crates/sdr-pipeline/src/block.rs
@@ -1,0 +1,154 @@
+//! DSP block trait and worker thread infrastructure.
+//!
+//! Ports SDR++ `dsp::block`. A block is a processing unit that runs on its
+//! own worker thread, reading from input streams and writing to output streams.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+
+/// Trait for a DSP processing block that runs on a worker thread.
+///
+/// Blocks are the fundamental processing units in the pipeline. Each block:
+/// - Has a `run()` method called repeatedly by the worker thread
+/// - Returns the number of samples processed, or -1 to stop
+/// - Can be started/stopped dynamically
+pub trait Block: Send + 'static {
+    /// Execute one processing cycle.
+    ///
+    /// Called repeatedly by the worker thread. Returns:
+    /// - Positive value: number of samples processed
+    /// - -1: stop the worker thread (graceful shutdown)
+    fn run(&mut self) -> i32;
+}
+
+/// Worker thread wrapper for a `Block`.
+///
+/// Manages the lifecycle of a worker thread that repeatedly calls `block.run()`.
+pub struct BlockRunner {
+    running: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl BlockRunner {
+    /// Start a block on a new worker thread.
+    ///
+    /// The worker thread calls `block.run()` in a loop until it returns -1
+    /// or `stop()` is called.
+    pub fn start<B: Block>(mut block: B) -> Self {
+        let running = Arc::new(AtomicBool::new(true));
+        let running_clone = Arc::clone(&running);
+
+        let thread = thread::spawn(move || {
+            while running_clone.load(Ordering::Relaxed) {
+                let result = block.run();
+                if result < 0 {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            running,
+            thread: Some(thread),
+        }
+    }
+
+    /// Check if the block is still running.
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::Relaxed)
+    }
+
+    /// Stop the block and join the worker thread.
+    ///
+    /// Sets the running flag to false and waits for the thread to finish.
+    /// The block must also return -1 from `run()` to fully exit (e.g., by
+    /// stopping its input stream).
+    pub fn stop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for BlockRunner {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicI32;
+    use std::time::Duration;
+
+    struct CountingBlock {
+        count: Arc<AtomicI32>,
+        max: i32,
+    }
+
+    impl Block for CountingBlock {
+        fn run(&mut self) -> i32 {
+            let c = self.count.fetch_add(1, Ordering::Relaxed);
+            if c >= self.max {
+                return -1;
+            }
+            // Small sleep to avoid spinning
+            thread::sleep(Duration::from_micros(100));
+            1
+        }
+    }
+
+    #[test]
+    fn test_block_runner_runs_and_stops() {
+        let count = Arc::new(AtomicI32::new(0));
+        let block = CountingBlock {
+            count: Arc::clone(&count),
+            max: 10,
+        };
+        let mut runner = BlockRunner::start(block);
+
+        // Wait for block to finish
+        thread::sleep(Duration::from_millis(50));
+
+        runner.stop();
+        assert!(count.load(Ordering::Relaxed) >= 10);
+    }
+
+    #[test]
+    fn test_block_runner_early_stop() {
+        let count = Arc::new(AtomicI32::new(0));
+        let block = CountingBlock {
+            count: Arc::clone(&count),
+            max: 1_000_000, // Would run forever
+        };
+        let mut runner = BlockRunner::start(block);
+
+        thread::sleep(Duration::from_millis(10));
+        runner.stop();
+
+        // Should have stopped well before max
+        let final_count = count.load(Ordering::Relaxed);
+        assert!(final_count > 0 && final_count < 1_000_000);
+    }
+
+    #[test]
+    fn test_block_runner_drop_stops() {
+        let count = Arc::new(AtomicI32::new(0));
+        let block = CountingBlock {
+            count: Arc::clone(&count),
+            max: 1_000_000,
+        };
+        {
+            let _runner = BlockRunner::start(block);
+            thread::sleep(Duration::from_millis(10));
+            // Runner dropped here — should stop the thread
+        }
+
+        let final_count = count.load(Ordering::Relaxed);
+        assert!(final_count > 0);
+    }
+}

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -394,6 +394,18 @@ mod tests {
     }
 
     #[test]
+    fn test_processor_overflow_detected() {
+        let mut chain: Chain<f32> = Chain::new();
+        // Processor that claims to have written more than buffer size
+        chain
+            .add("overflow", |_: &[f32], _: &mut [f32]| Ok(999_999))
+            .unwrap();
+        let input = [1.0];
+        let mut output = [0.0_f32; 1];
+        assert!(chain.process(&input, &mut output).is_err());
+    }
+
+    #[test]
     fn test_buffer_too_small() {
         let mut chain: Chain<f32> = Chain::new();
         let input = [1.0, 2.0, 3.0];

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -83,6 +83,21 @@ impl<T: Copy + Default> Chain<T> {
         Ok(self.find_step(name)?.enabled)
     }
 
+    /// Remove a processor by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the name is not found.
+    pub fn remove(&mut self, name: &str) -> Result<(), DspError> {
+        let idx = self
+            .steps
+            .iter()
+            .position(|s| s.name == name)
+            .ok_or_else(|| DspError::InvalidParameter(format!("step not found: {name}")))?;
+        self.steps.remove(idx);
+        Ok(())
+    }
+
     /// Number of steps in the chain.
     pub fn len(&self) -> usize {
         self.steps.len()

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -1,0 +1,303 @@
+//! Processor chain with enable/disable support.
+//!
+//! Ports SDR++ `dsp::chain`. A chain is an ordered list of processors
+//! that can be individually enabled or disabled. When a processor is
+//! disabled, data flows around it to the next enabled processor.
+
+use sdr_types::DspError;
+
+/// Boxed processor function type for chain steps.
+type ProcessorFn<T> = Box<dyn FnMut(&[T], &mut [T]) -> Result<usize, DspError> + Send>;
+
+/// A processing step in a chain.
+///
+/// Each step wraps a boxed processor function and tracks its enabled state.
+pub struct ChainStep<T> {
+    /// The processor function: takes input slice, writes to output, returns count.
+    processor: ProcessorFn<T>,
+    /// Whether this step is enabled.
+    enabled: bool,
+    /// Name for debugging.
+    name: String,
+}
+
+/// Ordered chain of processors with enable/disable support.
+///
+/// When a processor is disabled, input passes through to the next
+/// enabled processor unchanged. All enabled processors are applied
+/// in order.
+pub struct Chain<T: Copy + Default> {
+    steps: Vec<ChainStep<T>>,
+    buf_a: Vec<T>,
+    buf_b: Vec<T>,
+}
+
+impl<T: Copy + Default> Chain<T> {
+    /// Create a new empty chain.
+    pub fn new() -> Self {
+        Self {
+            steps: Vec::new(),
+            buf_a: Vec::new(),
+            buf_b: Vec::new(),
+        }
+    }
+
+    /// Add a named processor to the chain (initially enabled).
+    pub fn add<F>(&mut self, name: &str, processor: F)
+    where
+        F: FnMut(&[T], &mut [T]) -> Result<usize, DspError> + Send + 'static,
+    {
+        self.steps.push(ChainStep {
+            processor: Box::new(processor),
+            enabled: true,
+            name: name.to_string(),
+        });
+    }
+
+    /// Enable a processor by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the name is not found.
+    pub fn enable(&mut self, name: &str) -> Result<(), DspError> {
+        self.find_step_mut(name)?.enabled = true;
+        Ok(())
+    }
+
+    /// Disable a processor by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the name is not found.
+    pub fn disable(&mut self, name: &str) -> Result<(), DspError> {
+        self.find_step_mut(name)?.enabled = false;
+        Ok(())
+    }
+
+    /// Check if a processor is enabled.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the name is not found.
+    pub fn is_enabled(&self, name: &str) -> Result<bool, DspError> {
+        Ok(self.find_step(name)?.enabled)
+    }
+
+    /// Number of steps in the chain.
+    pub fn len(&self) -> usize {
+        self.steps.len()
+    }
+
+    /// Whether the chain has no steps.
+    pub fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+    }
+
+    /// Process samples through all enabled processors in order.
+    ///
+    /// Disabled processors are skipped (input passes through unchanged).
+    /// Returns the number of output samples.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::BufferTooSmall` if `output` is too small.
+    pub fn process(&mut self, input: &[T], output: &mut [T]) -> Result<usize, DspError> {
+        if output.len() < input.len() {
+            return Err(DspError::BufferTooSmall {
+                need: input.len(),
+                got: output.len(),
+            });
+        }
+
+        // Count enabled steps
+        let enabled_count = self.steps.iter().filter(|s| s.enabled).count();
+
+        if enabled_count == 0 {
+            // No processors enabled — passthrough
+            output[..input.len()].copy_from_slice(input);
+            return Ok(input.len());
+        }
+
+        // Process through enabled steps using ping-pong buffers (a ↔ b)
+        self.buf_a.resize(input.len(), T::default());
+        self.buf_b.resize(input.len(), T::default());
+        self.buf_a[..input.len()].copy_from_slice(input);
+
+        let mut current_count = input.len();
+        let mut src_is_a = true;
+
+        for step in &mut self.steps {
+            if !step.enabled {
+                continue;
+            }
+            if src_is_a {
+                current_count = (step.processor)(&self.buf_a[..current_count], &mut self.buf_b)?;
+            } else {
+                current_count = (step.processor)(&self.buf_b[..current_count], &mut self.buf_a)?;
+            }
+            src_is_a = !src_is_a;
+        }
+
+        // Copy result to output from whichever buffer has the final data
+        let result = if src_is_a {
+            &self.buf_a[..current_count]
+        } else {
+            &self.buf_b[..current_count]
+        };
+        output[..current_count].copy_from_slice(result);
+
+        Ok(current_count)
+    }
+
+    fn find_step(&self, name: &str) -> Result<&ChainStep<T>, DspError> {
+        self.steps
+            .iter()
+            .find(|s| s.name == name)
+            .ok_or_else(|| DspError::InvalidParameter(format!("step not found: {name}")))
+    }
+
+    fn find_step_mut(&mut self, name: &str) -> Result<&mut ChainStep<T>, DspError> {
+        self.steps
+            .iter_mut()
+            .find(|s| s.name == name)
+            .ok_or_else(|| DspError::InvalidParameter(format!("step not found: {name}")))
+    }
+}
+
+impl<T: Copy + Default> Default for Chain<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_chain_passthrough() {
+        let mut chain: Chain<f32> = Chain::new();
+        let input = [1.0, 2.0, 3.0, 4.0];
+        let mut output = [0.0_f32; 4];
+        let count = chain.process(&input, &mut output).unwrap();
+        assert_eq!(count, 4);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_single_processor() {
+        let mut chain: Chain<f32> = Chain::new();
+        chain.add("double", |input: &[f32], output: &mut [f32]| {
+            for (i, &v) in input.iter().enumerate() {
+                output[i] = v * 2.0;
+            }
+            Ok(input.len())
+        });
+
+        let input = [1.0, 2.0, 3.0];
+        let mut output = [0.0_f32; 3];
+        let count = chain.process(&input, &mut output).unwrap();
+        assert_eq!(count, 3);
+        assert_eq!(output, [2.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn test_chained_processors() {
+        let mut chain: Chain<f32> = Chain::new();
+        chain.add("add_one", |input: &[f32], output: &mut [f32]| {
+            for (i, &v) in input.iter().enumerate() {
+                output[i] = v + 1.0;
+            }
+            Ok(input.len())
+        });
+        chain.add("double", |input: &[f32], output: &mut [f32]| {
+            for (i, &v) in input.iter().enumerate() {
+                output[i] = v * 2.0;
+            }
+            Ok(input.len())
+        });
+
+        let input = [1.0, 2.0, 3.0];
+        let mut output = [0.0_f32; 3];
+        let count = chain.process(&input, &mut output).unwrap();
+        assert_eq!(count, 3);
+        // (1+1)*2=4, (2+1)*2=6, (3+1)*2=8
+        assert_eq!(output, [4.0, 6.0, 8.0]);
+    }
+
+    #[test]
+    fn test_disable_processor() {
+        let mut chain: Chain<f32> = Chain::new();
+        chain.add("add_one", |input: &[f32], output: &mut [f32]| {
+            for (i, &v) in input.iter().enumerate() {
+                output[i] = v + 1.0;
+            }
+            Ok(input.len())
+        });
+        chain.add("double", |input: &[f32], output: &mut [f32]| {
+            for (i, &v) in input.iter().enumerate() {
+                output[i] = v * 2.0;
+            }
+            Ok(input.len())
+        });
+
+        // Disable the first processor
+        chain.disable("add_one").unwrap();
+
+        let input = [1.0, 2.0, 3.0];
+        let mut output = [0.0_f32; 3];
+        let count = chain.process(&input, &mut output).unwrap();
+        assert_eq!(count, 3);
+        // Only double: 1*2=2, 2*2=4, 3*2=6
+        assert_eq!(output, [2.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn test_enable_disable_toggle() {
+        let mut chain: Chain<f32> = Chain::new();
+        chain.add("negate", |input: &[f32], output: &mut [f32]| {
+            for (i, &v) in input.iter().enumerate() {
+                output[i] = -v;
+            }
+            Ok(input.len())
+        });
+
+        assert!(chain.is_enabled("negate").unwrap());
+        chain.disable("negate").unwrap();
+        assert!(!chain.is_enabled("negate").unwrap());
+        chain.enable("negate").unwrap();
+        assert!(chain.is_enabled("negate").unwrap());
+    }
+
+    #[test]
+    fn test_all_disabled_passthrough() {
+        let mut chain: Chain<f32> = Chain::new();
+        chain.add("a", |_: &[f32], _: &mut [f32]| Ok(0));
+        chain.add("b", |_: &[f32], _: &mut [f32]| Ok(0));
+        chain.disable("a").unwrap();
+        chain.disable("b").unwrap();
+
+        let input = [1.0, 2.0, 3.0];
+        let mut output = [0.0_f32; 3];
+        let count = chain.process(&input, &mut output).unwrap();
+        assert_eq!(count, 3);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_not_found_error() {
+        let mut chain: Chain<f32> = Chain::new();
+        assert!(chain.enable("nonexistent").is_err());
+        assert!(chain.disable("nonexistent").is_err());
+        assert!(chain.is_enabled("nonexistent").is_err());
+    }
+
+    #[test]
+    fn test_buffer_too_small() {
+        let mut chain: Chain<f32> = Chain::new();
+        let input = [1.0, 2.0, 3.0];
+        let mut output = [0.0_f32; 2];
+        assert!(chain.process(&input, &mut output).is_err());
+    }
+}

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -137,6 +137,12 @@ impl<T: Copy + Default> Chain<T> {
             } else {
                 current_count = (step.processor)(&self.buf_b[..current_count], &mut self.buf_a)?;
             }
+            if current_count > buf_size {
+                return Err(DspError::BufferTooSmall {
+                    need: current_count,
+                    got: buf_size,
+                });
+            }
             src_is_a = !src_is_a;
         }
 

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -43,15 +43,24 @@ impl<T: Copy + Default> Chain<T> {
     }
 
     /// Add a named processor to the chain (initially enabled).
-    pub fn add<F>(&mut self, name: &str, processor: F)
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if a step with the same name already exists.
+    pub fn add<F>(&mut self, name: &str, processor: F) -> Result<(), DspError>
     where
         F: FnMut(&[T], &mut [T]) -> Result<usize, DspError> + Send + 'static,
     {
+        if self.steps.iter().any(|s| s.name == name) {
+            return Err(DspError::InvalidParameter(format!(
+                "step already exists: {name}"
+            )));
+        }
         self.steps.push(ChainStep {
             processor: Box::new(processor),
             enabled: true,
             name: name.to_string(),
         });
+        Ok(())
     }
 
     /// Enable a processor by name.
@@ -211,12 +220,14 @@ mod tests {
     #[test]
     fn test_single_processor() {
         let mut chain: Chain<f32> = Chain::new();
-        chain.add("double", |input: &[f32], output: &mut [f32]| {
-            for (i, &v) in input.iter().enumerate() {
-                output[i] = v * 2.0;
-            }
-            Ok(input.len())
-        });
+        chain
+            .add("double", |input: &[f32], output: &mut [f32]| {
+                for (i, &v) in input.iter().enumerate() {
+                    output[i] = v * 2.0;
+                }
+                Ok(input.len())
+            })
+            .unwrap();
 
         let input = [1.0, 2.0, 3.0];
         let mut output = [0.0_f32; 3];
@@ -228,18 +239,22 @@ mod tests {
     #[test]
     fn test_chained_processors() {
         let mut chain: Chain<f32> = Chain::new();
-        chain.add("add_one", |input: &[f32], output: &mut [f32]| {
-            for (i, &v) in input.iter().enumerate() {
-                output[i] = v + 1.0;
-            }
-            Ok(input.len())
-        });
-        chain.add("double", |input: &[f32], output: &mut [f32]| {
-            for (i, &v) in input.iter().enumerate() {
-                output[i] = v * 2.0;
-            }
-            Ok(input.len())
-        });
+        chain
+            .add("add_one", |input: &[f32], output: &mut [f32]| {
+                for (i, &v) in input.iter().enumerate() {
+                    output[i] = v + 1.0;
+                }
+                Ok(input.len())
+            })
+            .unwrap();
+        chain
+            .add("double", |input: &[f32], output: &mut [f32]| {
+                for (i, &v) in input.iter().enumerate() {
+                    output[i] = v * 2.0;
+                }
+                Ok(input.len())
+            })
+            .unwrap();
 
         let input = [1.0, 2.0, 3.0];
         let mut output = [0.0_f32; 3];
@@ -252,18 +267,22 @@ mod tests {
     #[test]
     fn test_disable_processor() {
         let mut chain: Chain<f32> = Chain::new();
-        chain.add("add_one", |input: &[f32], output: &mut [f32]| {
-            for (i, &v) in input.iter().enumerate() {
-                output[i] = v + 1.0;
-            }
-            Ok(input.len())
-        });
-        chain.add("double", |input: &[f32], output: &mut [f32]| {
-            for (i, &v) in input.iter().enumerate() {
-                output[i] = v * 2.0;
-            }
-            Ok(input.len())
-        });
+        chain
+            .add("add_one", |input: &[f32], output: &mut [f32]| {
+                for (i, &v) in input.iter().enumerate() {
+                    output[i] = v + 1.0;
+                }
+                Ok(input.len())
+            })
+            .unwrap();
+        chain
+            .add("double", |input: &[f32], output: &mut [f32]| {
+                for (i, &v) in input.iter().enumerate() {
+                    output[i] = v * 2.0;
+                }
+                Ok(input.len())
+            })
+            .unwrap();
 
         // Disable the first processor
         chain.disable("add_one").unwrap();
@@ -279,12 +298,14 @@ mod tests {
     #[test]
     fn test_enable_disable_toggle() {
         let mut chain: Chain<f32> = Chain::new();
-        chain.add("negate", |input: &[f32], output: &mut [f32]| {
-            for (i, &v) in input.iter().enumerate() {
-                output[i] = -v;
-            }
-            Ok(input.len())
-        });
+        chain
+            .add("negate", |input: &[f32], output: &mut [f32]| {
+                for (i, &v) in input.iter().enumerate() {
+                    output[i] = -v;
+                }
+                Ok(input.len())
+            })
+            .unwrap();
 
         assert!(chain.is_enabled("negate").unwrap());
         chain.disable("negate").unwrap();
@@ -296,8 +317,8 @@ mod tests {
     #[test]
     fn test_all_disabled_passthrough() {
         let mut chain: Chain<f32> = Chain::new();
-        chain.add("a", |_: &[f32], _: &mut [f32]| Ok(0));
-        chain.add("b", |_: &[f32], _: &mut [f32]| Ok(0));
+        chain.add("a", |_: &[f32], _: &mut [f32]| Ok(0)).unwrap();
+        chain.add("b", |_: &[f32], _: &mut [f32]| Ok(0)).unwrap();
         chain.disable("a").unwrap();
         chain.disable("b").unwrap();
 
@@ -319,18 +340,22 @@ mod tests {
     #[test]
     fn test_remove_processor() {
         let mut chain: Chain<f32> = Chain::new();
-        chain.add("a", |input: &[f32], output: &mut [f32]| {
-            for (i, &v) in input.iter().enumerate() {
-                output[i] = v + 1.0;
-            }
-            Ok(input.len())
-        });
-        chain.add("b", |input: &[f32], output: &mut [f32]| {
-            for (i, &v) in input.iter().enumerate() {
-                output[i] = v * 2.0;
-            }
-            Ok(input.len())
-        });
+        chain
+            .add("a", |input: &[f32], output: &mut [f32]| {
+                for (i, &v) in input.iter().enumerate() {
+                    output[i] = v + 1.0;
+                }
+                Ok(input.len())
+            })
+            .unwrap();
+        chain
+            .add("b", |input: &[f32], output: &mut [f32]| {
+                for (i, &v) in input.iter().enumerate() {
+                    output[i] = v * 2.0;
+                }
+                Ok(input.len())
+            })
+            .unwrap();
 
         // Remove "a", only "b" remains
         chain.remove("a").unwrap();

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -395,10 +395,11 @@ mod tests {
 
     #[test]
     fn test_processor_overflow_detected() {
+        const OVERSIZED_COUNT: usize = 999_999;
         let mut chain: Chain<f32> = Chain::new();
         // Processor that claims to have written more than buffer size
         chain
-            .add("overflow", |_: &[f32], _: &mut [f32]| Ok(999_999))
+            .add("overflow", |_: &[f32], _: &mut [f32]| Ok(OVERSIZED_COUNT))
             .unwrap();
         let input = [1.0];
         let mut output = [0.0_f32; 1];

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -119,8 +119,10 @@ impl<T: Copy + Default> Chain<T> {
         }
 
         // Process through enabled steps using ping-pong buffers (a ↔ b)
-        self.buf_a.resize(input.len(), T::default());
-        self.buf_b.resize(input.len(), T::default());
+        // Size to output.len() to support interpolating processors
+        let buf_size = output.len().max(input.len());
+        self.buf_a.resize(buf_size, T::default());
+        self.buf_b.resize(buf_size, T::default());
         self.buf_a[..input.len()].copy_from_slice(input);
 
         let mut current_count = input.len();

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -317,6 +317,39 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_processor() {
+        let mut chain: Chain<f32> = Chain::new();
+        chain.add("a", |input: &[f32], output: &mut [f32]| {
+            for (i, &v) in input.iter().enumerate() {
+                output[i] = v + 1.0;
+            }
+            Ok(input.len())
+        });
+        chain.add("b", |input: &[f32], output: &mut [f32]| {
+            for (i, &v) in input.iter().enumerate() {
+                output[i] = v * 2.0;
+            }
+            Ok(input.len())
+        });
+
+        // Remove "a", only "b" remains
+        chain.remove("a").unwrap();
+        assert_eq!(chain.len(), 1);
+
+        let input = [3.0];
+        let mut output = [0.0_f32; 1];
+        let count = chain.process(&input, &mut output).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(output[0], 6.0); // 3*2, not (3+1)*2
+    }
+
+    #[test]
+    fn test_remove_not_found() {
+        let mut chain: Chain<f32> = Chain::new();
+        assert!(chain.remove("nonexistent").is_err());
+    }
+
+    #[test]
     fn test_buffer_too_small() {
         let mut chain: Chain<f32> = Chain::new();
         let input = [1.0, 2.0, 3.0];

--- a/crates/sdr-pipeline/src/chain.rs
+++ b/crates/sdr-pipeline/src/chain.rs
@@ -375,6 +375,25 @@ mod tests {
     }
 
     #[test]
+    fn test_add_duplicate_name() {
+        let mut chain: Chain<f32> = Chain::new();
+        chain
+            .add("a", |i: &[f32], o: &mut [f32]| {
+                o[..i.len()].copy_from_slice(i);
+                Ok(i.len())
+            })
+            .unwrap();
+        assert!(
+            chain
+                .add("a", |i: &[f32], o: &mut [f32]| {
+                    o[..i.len()].copy_from_slice(i);
+                    Ok(i.len())
+                })
+                .is_err()
+        );
+    }
+
+    #[test]
     fn test_buffer_too_small() {
         let mut chain: Chain<f32> = Chain::new();
         let input = [1.0, 2.0, 3.0];

--- a/crates/sdr-pipeline/src/lib.rs
+++ b/crates/sdr-pipeline/src/lib.rs
@@ -1,1 +1,9 @@
-// sdr-pipeline: Threading, streaming, and signal path management
+//! Threading, streaming, and signal path management.
+//!
+//! Provides the infrastructure that connects DSP blocks into a real-time
+//! signal processing pipeline.
+
+pub mod block;
+pub mod chain;
+pub mod splitter;
+pub mod stream;

--- a/crates/sdr-pipeline/src/splitter.rs
+++ b/crates/sdr-pipeline/src/splitter.rs
@@ -30,6 +30,9 @@ impl<T: Copy + Default> Splitter<T> {
 
     /// Remove an output by index.
     ///
+    /// Note: this shifts all subsequent indices. Callers should not cache
+    /// indices across removals.
+    ///
     /// # Errors
     ///
     /// Returns `DspError::InvalidParameter` if the index is out of bounds.

--- a/crates/sdr-pipeline/src/splitter.rs
+++ b/crates/sdr-pipeline/src/splitter.rs
@@ -1,0 +1,155 @@
+//! Stream splitter — fan-out one input to multiple outputs.
+//!
+//! Ports SDR++ `dsp::routing::Splitter`. Copies input data to all
+//! bound output streams.
+
+use sdr_types::DspError;
+
+/// Fan-out splitter that copies input to multiple output buffers.
+///
+/// Ports SDR++ `dsp::routing::Splitter`. Each call to `process()`
+/// copies the input to all registered output buffers.
+pub struct Splitter<T: Copy + Default> {
+    outputs: Vec<Vec<T>>,
+}
+
+impl<T: Copy + Default> Splitter<T> {
+    /// Create a new splitter with no outputs.
+    pub fn new() -> Self {
+        Self {
+            outputs: Vec::new(),
+        }
+    }
+
+    /// Add an output buffer. Returns the index of the new output.
+    pub fn add_output(&mut self) -> usize {
+        let idx = self.outputs.len();
+        self.outputs.push(Vec::new());
+        idx
+    }
+
+    /// Remove an output by index.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the index is out of bounds.
+    pub fn remove_output(&mut self, index: usize) -> Result<(), DspError> {
+        if index >= self.outputs.len() {
+            return Err(DspError::InvalidParameter(format!(
+                "output index {index} out of bounds (have {})",
+                self.outputs.len()
+            )));
+        }
+        self.outputs.remove(index);
+        Ok(())
+    }
+
+    /// Number of outputs.
+    pub fn output_count(&self) -> usize {
+        self.outputs.len()
+    }
+
+    /// Process input by copying to all output buffers.
+    ///
+    /// Each output buffer is resized to hold the input data.
+    pub fn process(&mut self, input: &[T]) {
+        for output in &mut self.outputs {
+            output.resize(input.len(), T::default());
+            output.copy_from_slice(input);
+        }
+    }
+
+    /// Get a reference to an output buffer.
+    ///
+    /// Valid after `process()` has been called.
+    pub fn output(&self, index: usize) -> Option<&[T]> {
+        self.outputs.get(index).map(Vec::as_slice)
+    }
+}
+
+impl<T: Copy + Default> Default for Splitter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_outputs() {
+        let mut splitter: Splitter<f32> = Splitter::new();
+        splitter.process(&[1.0, 2.0, 3.0]);
+        assert_eq!(splitter.output_count(), 0);
+    }
+
+    #[test]
+    fn test_single_output() {
+        let mut splitter: Splitter<f32> = Splitter::new();
+        let idx = splitter.add_output();
+        assert_eq!(idx, 0);
+
+        splitter.process(&[1.0, 2.0, 3.0]);
+        let out = splitter.output(0).unwrap();
+        assert_eq!(out, &[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_multiple_outputs() {
+        let mut splitter: Splitter<f32> = Splitter::new();
+        splitter.add_output();
+        splitter.add_output();
+        splitter.add_output();
+        assert_eq!(splitter.output_count(), 3);
+
+        let input = [10.0, 20.0, 30.0];
+        splitter.process(&input);
+
+        for i in 0..3 {
+            let out = splitter.output(i).unwrap();
+            assert_eq!(out, &input);
+        }
+    }
+
+    #[test]
+    fn test_remove_output() {
+        let mut splitter: Splitter<f32> = Splitter::new();
+        splitter.add_output();
+        splitter.add_output();
+        assert_eq!(splitter.output_count(), 2);
+
+        splitter.remove_output(0).unwrap();
+        assert_eq!(splitter.output_count(), 1);
+    }
+
+    #[test]
+    fn test_remove_output_invalid() {
+        let mut splitter: Splitter<f32> = Splitter::new();
+        assert!(splitter.remove_output(0).is_err());
+    }
+
+    #[test]
+    fn test_output_out_of_bounds() {
+        let splitter: Splitter<f32> = Splitter::new();
+        assert!(splitter.output(0).is_none());
+    }
+
+    #[test]
+    fn test_independent_outputs() {
+        let mut splitter: Splitter<f32> = Splitter::new();
+        splitter.add_output();
+        splitter.add_output();
+
+        // First process
+        splitter.process(&[1.0, 2.0]);
+        assert_eq!(splitter.output(0).unwrap(), &[1.0, 2.0]);
+        assert_eq!(splitter.output(1).unwrap(), &[1.0, 2.0]);
+
+        // Second process with different data
+        splitter.process(&[3.0, 4.0, 5.0]);
+        assert_eq!(splitter.output(0).unwrap(), &[3.0, 4.0, 5.0]);
+        assert_eq!(splitter.output(1).unwrap(), &[3.0, 4.0, 5.0]);
+    }
+}

--- a/crates/sdr-pipeline/src/stream.rs
+++ b/crates/sdr-pipeline/src/stream.rs
@@ -1,0 +1,237 @@
+//! Double-buffer swap streaming channel.
+//!
+//! Ports SDR++ `dsp::stream<T>`. This is the fundamental inter-block data
+//! transport. A producer writes into `write_buf`, then calls `swap(count)`
+//! to publish the data. A consumer calls `read()` to wait for data,
+//! processes `read_buf[..count]`, then calls `flush()` to release the buffer.
+
+use sdr_types::STREAM_BUFFER_SIZE;
+use std::sync::{Condvar, Mutex, PoisonError};
+
+/// Double-buffer swap channel for streaming samples between DSP blocks.
+///
+/// Thread-safe single-producer, single-consumer channel with backpressure.
+/// The producer writes to `write_buf` and swaps; the consumer reads from
+/// `read_buf` after `read()` returns.
+pub struct Stream<T: Copy + Send + Default + 'static> {
+    write_buf: Box<[T]>,
+    read_buf: Box<[T]>,
+    state: Mutex<StreamState>,
+    swap_cv: Condvar,
+    ready_cv: Condvar,
+}
+
+#[allow(clippy::struct_excessive_bools)]
+struct StreamState {
+    can_swap: bool,
+    data_ready: bool,
+    data_size: usize,
+    reader_stop: bool,
+    writer_stop: bool,
+}
+
+impl<T: Copy + Send + Default + 'static> Stream<T> {
+    /// Create a new stream with the default buffer size.
+    pub fn new() -> Self {
+        Self::with_capacity(STREAM_BUFFER_SIZE)
+    }
+
+    /// Create a new stream with the given buffer capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            write_buf: vec![T::default(); capacity].into_boxed_slice(),
+            read_buf: vec![T::default(); capacity].into_boxed_slice(),
+            state: Mutex::new(StreamState {
+                can_swap: true,
+                data_ready: false,
+                data_size: 0,
+                reader_stop: false,
+                writer_stop: false,
+            }),
+            swap_cv: Condvar::new(),
+            ready_cv: Condvar::new(),
+        }
+    }
+
+    /// Get a mutable reference to the write buffer.
+    pub fn write_buf(&mut self) -> &mut [T] {
+        &mut self.write_buf
+    }
+
+    /// Get a reference to the read buffer.
+    pub fn read_buf(&self) -> &[T] {
+        &self.read_buf
+    }
+
+    /// Swap the write buffer with the read buffer, publishing `size` samples.
+    ///
+    /// Blocks until the consumer has flushed the previous data.
+    /// Returns `false` if the writer was stopped (graceful shutdown).
+    pub fn swap(&mut self, size: usize) -> bool {
+        {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state = self
+                .swap_cv
+                .wait_while(state, |s| !s.can_swap && !s.writer_stop)
+                .unwrap_or_else(PoisonError::into_inner);
+
+            if state.writer_stop {
+                return false;
+            }
+
+            state.data_size = size;
+            std::mem::swap(&mut self.write_buf, &mut self.read_buf);
+            state.can_swap = false;
+        }
+
+        {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.data_ready = true;
+        }
+        self.ready_cv.notify_all();
+
+        true
+    }
+
+    /// Wait for data to be available in the read buffer.
+    ///
+    /// Returns the number of samples available, or `-1` if the reader was stopped.
+    #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+    pub fn read(&self) -> i32 {
+        let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let state = self
+            .ready_cv
+            .wait_while(state, |s| !s.data_ready && !s.reader_stop)
+            .unwrap_or_else(PoisonError::into_inner);
+
+        if state.reader_stop {
+            return -1;
+        }
+
+        state.data_size as i32
+    }
+
+    /// Release the read buffer, allowing the producer to swap again.
+    pub fn flush(&self) {
+        {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.data_ready = false;
+        }
+        {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.can_swap = true;
+        }
+        self.swap_cv.notify_all();
+    }
+
+    /// Signal the writer to stop (unblocks a pending `swap()`).
+    pub fn stop_writer(&self) {
+        {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.writer_stop = true;
+        }
+        self.swap_cv.notify_all();
+    }
+
+    /// Clear the writer stop flag.
+    pub fn clear_write_stop(&self) {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        state.writer_stop = false;
+    }
+
+    /// Signal the reader to stop (unblocks a pending `read()`).
+    pub fn stop_reader(&self) {
+        {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.reader_stop = true;
+        }
+        self.ready_cv.notify_all();
+    }
+
+    /// Clear the reader stop flag.
+    pub fn clear_read_stop(&self) {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        state.reader_stop = false;
+    }
+
+    /// Buffer capacity (number of samples).
+    pub fn capacity(&self) -> usize {
+        self.write_buf.len()
+    }
+}
+
+impl<T: Copy + Send + Default + 'static> Default for Stream<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_default_capacity() {
+        let s: Stream<f32> = Stream::new();
+        assert_eq!(s.capacity(), STREAM_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let s: Stream<f32> = Stream::with_capacity(1024);
+        assert_eq!(s.capacity(), 1024);
+    }
+
+    #[test]
+    fn test_single_thread_swap_read_flush() {
+        let mut s: Stream<f32> = Stream::with_capacity(256);
+
+        s.write_buf()[0] = 42.0;
+        s.write_buf()[1] = 43.0;
+        assert!(s.swap(2));
+
+        let count = s.read();
+        assert_eq!(count, 2);
+        assert!((s.read_buf()[0] - 42.0).abs() < f32::EPSILON);
+        assert!((s.read_buf()[1] - 43.0).abs() < f32::EPSILON);
+
+        s.flush();
+    }
+
+    #[test]
+    fn test_multiple_swap_read_cycles() {
+        let mut s: Stream<f32> = Stream::with_capacity(256);
+
+        for cycle in 0..5 {
+            let val = (cycle + 1) as f32;
+            s.write_buf()[0] = val;
+            assert!(s.swap(1));
+
+            let count = s.read();
+            assert_eq!(count, 1);
+            assert!((s.read_buf()[0] - val).abs() < f32::EPSILON);
+            s.flush();
+        }
+    }
+
+    #[test]
+    fn test_stop_writer() {
+        let mut s: Stream<f32> = Stream::with_capacity(256);
+        s.stop_writer();
+        assert!(!s.swap(1), "swap should return false when writer stopped");
+        s.clear_write_stop();
+    }
+
+    #[test]
+    fn test_stop_reader() {
+        let s: Stream<f32> = Stream::with_capacity(256);
+        s.stop_reader();
+        assert_eq!(s.read(), -1, "read should return -1 when reader stopped");
+        s.clear_read_stop();
+    }
+}

--- a/crates/sdr-pipeline/src/stream.rs
+++ b/crates/sdr-pipeline/src/stream.rs
@@ -66,7 +66,8 @@ impl<T: Copy + Send + Default + 'static> Stream<T> {
     /// Swap the write buffer with the read buffer, publishing `size` samples.
     ///
     /// Blocks until the consumer has flushed the previous data.
-    /// Returns `false` if the writer was stopped (graceful shutdown).
+    /// Returns `false` if the writer was stopped or `size` is invalid
+    /// (zero or exceeds capacity).
     pub fn swap(&mut self, size: usize) -> bool {
         if size == 0 || size > self.write_buf.len() {
             return false;

--- a/crates/sdr-pipeline/src/stream.rs
+++ b/crates/sdr-pipeline/src/stream.rs
@@ -235,13 +235,20 @@ mod tests {
         s.stop_writer();
         assert!(!s.swap(1), "swap should return false when writer stopped");
         s.clear_write_stop();
+        // After clearing, swap should work again
+        s.write_buf()[0] = 1.0;
+        assert!(s.swap(1), "swap should succeed after clear_write_stop");
     }
 
     #[test]
     fn test_stop_reader() {
-        let s: Stream<f32> = Stream::with_capacity(256);
+        let mut s: Stream<f32> = Stream::with_capacity(256);
         s.stop_reader();
         assert_eq!(s.read(), -1, "read should return -1 when reader stopped");
         s.clear_read_stop();
+        // After clearing, read should work again (need data first)
+        s.write_buf()[0] = 1.0;
+        s.swap(1);
+        assert_eq!(s.read(), 1, "read should succeed after clear_read_stop");
     }
 }

--- a/crates/sdr-pipeline/src/stream.rs
+++ b/crates/sdr-pipeline/src/stream.rs
@@ -68,6 +68,12 @@ impl<T: Copy + Send + Default + 'static> Stream<T> {
     /// Blocks until the consumer has flushed the previous data.
     /// Returns `false` if the writer was stopped (graceful shutdown).
     pub fn swap(&mut self, size: usize) -> bool {
+        assert!(
+            size <= self.write_buf.len(),
+            "swap size ({size}) exceeds buffer capacity ({})",
+            self.write_buf.len()
+        );
+
         {
             let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
             state = self

--- a/crates/sdr-pipeline/src/stream.rs
+++ b/crates/sdr-pipeline/src/stream.rs
@@ -68,11 +68,9 @@ impl<T: Copy + Send + Default + 'static> Stream<T> {
     /// Blocks until the consumer has flushed the previous data.
     /// Returns `false` if the writer was stopped (graceful shutdown).
     pub fn swap(&mut self, size: usize) -> bool {
-        assert!(
-            size <= self.write_buf.len(),
-            "swap size ({size}) exceeds buffer capacity ({})",
-            self.write_buf.len()
-        );
+        if size == 0 || size > self.write_buf.len() {
+            return false;
+        }
 
         {
             let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);

--- a/crates/sdr-pipeline/src/stream.rs
+++ b/crates/sdr-pipeline/src/stream.rs
@@ -82,10 +82,6 @@ impl<T: Copy + Send + Default + 'static> Stream<T> {
             state.data_size = size;
             std::mem::swap(&mut self.write_buf, &mut self.read_buf);
             state.can_swap = false;
-        }
-
-        {
-            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
             state.data_ready = true;
         }
         self.ready_cv.notify_all();

--- a/crates/sdr-pipeline/src/stream.rs
+++ b/crates/sdr-pipeline/src/stream.rs
@@ -116,9 +116,6 @@ impl<T: Copy + Send + Default + 'static> Stream<T> {
         {
             let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
             state.data_ready = false;
-        }
-        {
-            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
             state.can_swap = true;
         }
         self.swap_cv.notify_all();

--- a/crates/sdr-pipeline/src/stream.rs
+++ b/crates/sdr-pipeline/src/stream.rs
@@ -218,6 +218,18 @@ mod tests {
     }
 
     #[test]
+    fn test_swap_zero_size_returns_false() {
+        let mut s: Stream<f32> = Stream::with_capacity(256);
+        assert!(!s.swap(0));
+    }
+
+    #[test]
+    fn test_swap_exceeds_capacity_returns_false() {
+        let mut s: Stream<f32> = Stream::with_capacity(256);
+        assert!(!s.swap(257));
+    }
+
+    #[test]
     fn test_stop_writer() {
         let mut s: Stream<f32> = Stream::with_capacity(256);
         s.stop_writer();


### PR DESCRIPTION
## Summary

Pipeline infrastructure foundations — the streaming and processing backbone.

- `Stream<T>`: double-buffer swap channel with Mutex+Condvar backpressure, stop semantics
- `BlockRunner`: worker thread wrapper with RAII stop-on-drop, cooperative shutdown via AtomicBool
- `Chain<T>`: ordered named processors with enable/disable, ping-pong internal buffers
- `Splitter<T>`: fan-out copies input to N output buffers with dynamic add/remove

## Test plan

- [x] 24 unit tests passing (`cargo test -p sdr-pipeline`)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Stream: swap/read/flush cycles, stop writer/reader
- [x] Block: runner starts, stops cooperatively, drop-stops, early stop
- [x] Chain: single/chained processors, disable bypass, enable toggle, all-disabled passthrough
- [x] Splitter: single/multiple outputs, independent copies, add/remove

Closes #14
Closes #15
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modular DSP pipeline: controllable processing units with start/stop, automatic runner shutdown on drop.
  * Ordered processing chain: named, enable/disable steps, passthrough when all disabled, runtime step management and safety checks.
  * Thread-safe double-buffered stream: blocking swap/read, flush, capacity, and stop/unblock controls.
  * Fan-out splitter: duplicate inputs across dynamic outputs.
  * Public crate modules exported.

* **Tests**
  * Unit tests covering core behaviors and edge cases for all components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->