### PR TITLE
sdr-pipeline: Managers, IqFrontend — Phase 2 complete

### DIFF
--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -37,6 +37,7 @@ pub struct IqFrontend {
     fft_input: Vec<Complex>,
     fft_output: Vec<f32>,
     dc_blocker: Option<DcBlocker>,
+    dc_scratch: Vec<Complex>,
     invert_iq: bool,
 }
 
@@ -92,6 +93,7 @@ impl IqFrontend {
             fft_input: vec![Complex::default(); fft_size],
             fft_output: vec![0.0; fft_size],
             dc_blocker,
+            dc_scratch: Vec::new(),
             invert_iq: false,
         })
     }
@@ -168,8 +170,9 @@ impl IqFrontend {
 
         // Step 3: DC blocking
         if let Some(dc) = &mut self.dc_blocker {
-            let temp: Vec<Complex> = output[..input.len()].to_vec();
-            dc.process(&temp, &mut output[..input.len()])?;
+            self.dc_scratch.resize(input.len(), Complex::default());
+            self.dc_scratch.copy_from_slice(&output[..input.len()]);
+            dc.process(&self.dc_scratch, &mut output[..input.len()])?;
         }
 
         // Step 4: Compute FFT from the last fft_size samples (or available)

--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -1,0 +1,329 @@
+//! IQ frontend — central signal processing hub.
+//!
+//! Ports SDR++ `IQFrontEnd`. Sits between the source and VFOs, providing:
+//! - Power decimation
+//! - DC blocking
+//! - IQ conjugation (inversion correction)
+//! - FFT computation for waterfall display
+//! - Fan-out to multiple VFO consumers
+
+use sdr_dsp::correction::DcBlocker;
+use sdr_dsp::fft::{self, FftEngine, RustFftEngine};
+use sdr_dsp::window;
+use sdr_types::{Complex, DspError};
+
+/// FFT window function selection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FftWindow {
+    /// Rectangular (no windowing).
+    Rectangular,
+    /// Blackman window.
+    Blackman,
+    /// Nuttall window (default).
+    Nuttall,
+}
+
+/// IQ frontend processing hub.
+///
+/// Processes raw IQ from a source through decimation, correction,
+/// and FFT computation, then distributes to VFO consumers.
+pub struct IqFrontend {
+    sample_rate: f64,
+    fft_size: usize,
+    #[allow(dead_code)]
+    fft_window: FftWindow,
+    fft_engine: RustFftEngine,
+    fft_window_buf: Vec<f32>,
+    fft_input: Vec<Complex>,
+    fft_output: Vec<f32>,
+    dc_blocker: Option<DcBlocker>,
+    invert_iq: bool,
+}
+
+/// DC blocker convergence rate for the IQ frontend.
+const DC_BLOCK_RATE: f64 = 0.001;
+
+impl IqFrontend {
+    /// Create a new IQ frontend.
+    ///
+    /// - `sample_rate`: input sample rate in Hz
+    /// - `fft_size`: FFT size for spectrum display
+    /// - `fft_window`: window function for FFT
+    /// - `dc_blocking`: whether to enable DC blocking
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if `fft_size` is 0.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+    pub fn new(
+        sample_rate: f64,
+        fft_size: usize,
+        fft_window: FftWindow,
+        dc_blocking: bool,
+    ) -> Result<Self, DspError> {
+        let fft_engine = RustFftEngine::new(fft_size)?;
+
+        // Pre-compute window coefficients
+        let fft_window_buf: Vec<f32> = (0..fft_size)
+            .map(|i| {
+                let n = i as f64;
+                let big_n = fft_size as f64;
+                let w = match fft_window {
+                    FftWindow::Rectangular => window::rectangular(n, big_n),
+                    FftWindow::Blackman => window::blackman(n, big_n),
+                    FftWindow::Nuttall => window::nuttall(n, big_n),
+                };
+                w as f32
+            })
+            .collect();
+
+        let dc_blocker = if dc_blocking {
+            Some(DcBlocker::new(DC_BLOCK_RATE)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            sample_rate,
+            fft_size,
+            fft_window,
+            fft_engine,
+            fft_window_buf,
+            fft_input: vec![Complex::default(); fft_size],
+            fft_output: vec![0.0; fft_size],
+            dc_blocker,
+            invert_iq: false,
+        })
+    }
+
+    /// Get the current sample rate.
+    pub fn sample_rate(&self) -> f64 {
+        self.sample_rate
+    }
+
+    /// Get the FFT size.
+    pub fn fft_size(&self) -> usize {
+        self.fft_size
+    }
+
+    /// Enable or disable IQ inversion correction.
+    pub fn set_invert_iq(&mut self, invert: bool) {
+        self.invert_iq = invert;
+    }
+
+    /// Enable or disable DC blocking.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError` if the DC blocker cannot be created.
+    pub fn set_dc_blocking(&mut self, enabled: bool) -> Result<(), DspError> {
+        self.dc_blocker = if enabled {
+            Some(DcBlocker::new(DC_BLOCK_RATE)?)
+        } else {
+            None
+        };
+        Ok(())
+    }
+
+    /// Process a block of IQ samples through the frontend.
+    ///
+    /// Applies DC blocking and IQ inversion, then computes FFT.
+    /// Returns the processed IQ samples and FFT power spectrum.
+    ///
+    /// - `input`: raw IQ samples from source
+    /// - `output`: processed IQ samples (same length as input)
+    /// - `fft_out`: FFT power spectrum in dB (length = `fft_size`)
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::BufferTooSmall` if buffers are too small.
+    pub fn process(
+        &mut self,
+        input: &[Complex],
+        output: &mut [Complex],
+        fft_out: &mut [f32],
+    ) -> Result<usize, DspError> {
+        if output.len() < input.len() {
+            return Err(DspError::BufferTooSmall {
+                need: input.len(),
+                got: output.len(),
+            });
+        }
+        if fft_out.len() < self.fft_size {
+            return Err(DspError::BufferTooSmall {
+                need: self.fft_size,
+                got: fft_out.len(),
+            });
+        }
+
+        // Step 1: Copy input to output
+        output[..input.len()].copy_from_slice(input);
+
+        // Step 2: IQ inversion (conjugate)
+        if self.invert_iq {
+            for s in &mut output[..input.len()] {
+                s.im = -s.im;
+            }
+        }
+
+        // Step 3: DC blocking
+        if let Some(dc) = &mut self.dc_blocker {
+            let temp: Vec<Complex> = output[..input.len()].to_vec();
+            dc.process(&temp, &mut output[..input.len()])?;
+        }
+
+        // Step 4: Compute FFT from the last fft_size samples (or available)
+        let fft_samples = input.len().min(self.fft_size);
+        let fft_start = input.len().saturating_sub(fft_samples);
+
+        // Clear FFT input and copy windowed samples
+        self.fft_input.fill(Complex::default());
+        for i in 0..fft_samples {
+            let w = self.fft_window_buf[i];
+            self.fft_input[i] = output[fft_start + i] * w;
+        }
+
+        // Execute FFT
+        self.fft_engine.forward(&mut self.fft_input)?;
+
+        // Convert to power spectrum dB
+        fft::power_spectrum_db(&self.fft_input, &mut self.fft_output)?;
+        fft_out[..self.fft_size].copy_from_slice(&self.fft_output);
+
+        Ok(input.len())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
+mod tests {
+    use super::*;
+    use core::f32::consts::PI;
+
+    const TEST_FFT_SIZE: usize = 1024;
+    const TEST_SAMPLE_RATE: f64 = 48_000.0;
+
+    #[test]
+    fn test_new() {
+        let fe = IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, true);
+        assert!(fe.is_ok());
+        let fe = fe.unwrap();
+        assert_eq!(fe.fft_size(), TEST_FFT_SIZE);
+        assert!((fe.sample_rate() - TEST_SAMPLE_RATE).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_new_zero_fft() {
+        assert!(IqFrontend::new(TEST_SAMPLE_RATE, 0, FftWindow::Nuttall, true).is_err());
+    }
+
+    #[test]
+    fn test_process_dc_signal() {
+        let mut fe =
+            IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+        let input = vec![Complex::new(1.0, 0.0); TEST_FFT_SIZE];
+        let mut output = vec![Complex::default(); TEST_FFT_SIZE];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+
+        let count = fe.process(&input, &mut output, &mut fft_out).unwrap();
+        assert_eq!(count, TEST_FFT_SIZE);
+
+        // DC signal should have peak at bin 0
+        let peak_bin = fft_out
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map_or(0, |(i, _)| i);
+        assert_eq!(peak_bin, 0, "DC signal should peak at bin 0");
+    }
+
+    #[test]
+    fn test_process_tone() {
+        let mut fe =
+            IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+
+        // Generate a tone at bin 64
+        let tone_bin = 64;
+        let input: Vec<Complex> = (0..TEST_FFT_SIZE)
+            .map(|i| {
+                let phase = 2.0 * PI * (tone_bin as f32) * (i as f32) / (TEST_FFT_SIZE as f32);
+                Complex::new(phase.cos(), phase.sin())
+            })
+            .collect();
+
+        let mut output = vec![Complex::default(); TEST_FFT_SIZE];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+
+        fe.process(&input, &mut output, &mut fft_out).unwrap();
+
+        // Find the peak — should be near the tone bin
+        let peak_bin = fft_out
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map_or(0, |(i, _)| i);
+
+        // Allow ±2 bins due to windowing
+        assert!(
+            peak_bin.abs_diff(tone_bin) <= 2,
+            "expected peak near bin {tone_bin}, got {peak_bin}"
+        );
+    }
+
+    #[test]
+    fn test_iq_inversion() {
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            TEST_FFT_SIZE,
+            FftWindow::Rectangular,
+            false,
+        )
+        .unwrap();
+        fe.set_invert_iq(true);
+
+        let input = [Complex::new(1.0, 2.0)];
+        let mut output = [Complex::default(); 1];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+
+        fe.process(&input, &mut output, &mut fft_out).unwrap();
+        assert!((output[0].im - (-2.0)).abs() < 1e-6, "im should be negated");
+    }
+
+    #[test]
+    fn test_dc_blocking() {
+        let mut fe =
+            IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, true).unwrap();
+
+        // Process DC signal many times — DC blocker should reduce it
+        let input = vec![Complex::new(5.0, 3.0); TEST_FFT_SIZE];
+        let mut output = vec![Complex::default(); TEST_FFT_SIZE];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+
+        for _ in 0..10 {
+            fe.process(&input, &mut output, &mut fft_out).unwrap();
+        }
+
+        // After many blocks, DC should be substantially reduced
+        let last = output[TEST_FFT_SIZE - 1];
+        assert!(
+            last.re.abs() < 2.0,
+            "DC should be reduced, got re={}",
+            last.re
+        );
+    }
+
+    #[test]
+    fn test_buffer_too_small() {
+        let mut fe =
+            IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+        let input = vec![Complex::default(); 100];
+        let mut output = vec![Complex::default(); 50]; // too small
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+        assert!(fe.process(&input, &mut output, &mut fft_out).is_err());
+    }
+}

--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -30,8 +30,6 @@ pub enum FftWindow {
 pub struct IqFrontend {
     sample_rate: f64,
     fft_size: usize,
-    #[allow(dead_code)]
-    fft_window: FftWindow,
     fft_engine: RustFftEngine,
     fft_window_buf: Vec<f32>,
     fft_input: Vec<Complex>,
@@ -87,7 +85,6 @@ impl IqFrontend {
         Ok(Self {
             sample_rate,
             fft_size,
-            fft_window,
             fft_engine,
             fft_window_buf,
             fft_input: vec![Complex::default(); fft_size],

--- a/crates/sdr-pipeline/src/lib.rs
+++ b/crates/sdr-pipeline/src/lib.rs
@@ -5,5 +5,9 @@
 
 pub mod block;
 pub mod chain;
+pub mod iq_frontend;
+pub mod sink_manager;
+pub mod source_manager;
 pub mod splitter;
 pub mod stream;
+pub mod vfo_manager;

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -71,8 +71,14 @@ impl SinkManager {
         Ok(())
     }
 
-    /// Unregister a sink by name.
+    /// Unregister a sink by name. Clears any stream references to it.
     pub fn unregister_sink(&mut self, name: &str) -> Option<Box<dyn Sink>> {
+        // Clear stale active_sink references in streams
+        for stream in self.streams.values_mut() {
+            if stream.active_sink.as_deref() == Some(name) {
+                stream.active_sink = None;
+            }
+        }
         self.sinks.remove(name)
     }
 
@@ -241,5 +247,25 @@ mod tests {
         let mut mgr = SinkManager::new();
         mgr.register_sink(Box::new(MockSink::new("Audio"))).unwrap();
         assert!(mgr.set_stream_sink("nonexistent", "Audio").is_err());
+    }
+
+    #[test]
+    fn test_unregister_sink_clears_stream_refs() {
+        let mut mgr = SinkManager::new();
+        mgr.register_sink(Box::new(MockSink::new("Audio"))).unwrap();
+        mgr.register_stream("main", 48_000.0);
+        mgr.set_stream_sink("main", "Audio").unwrap();
+        mgr.unregister_sink("Audio");
+        // Stream's active_sink should be cleared
+        let stream = mgr.streams.get("main").unwrap();
+        assert!(stream.active_sink.is_none());
+    }
+
+    #[test]
+    fn test_volume_clamp_negative() {
+        let mut mgr = SinkManager::new();
+        mgr.register_stream("main", 48_000.0);
+        mgr.set_volume("main", -0.5).unwrap();
+        assert!((mgr.volume("main").unwrap()).abs() < f32::EPSILON);
     }
 }

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -233,4 +233,11 @@ mod tests {
         mgr.register_stream("main", 48_000.0);
         assert!(mgr.set_stream_sink("main", "NonExistent").is_err());
     }
+
+    #[test]
+    fn test_set_stream_sink_stream_not_found() {
+        let mut mgr = SinkManager::new();
+        mgr.register_sink(Box::new(MockSink::new("Audio"))).unwrap();
+        assert!(mgr.set_stream_sink("nonexistent", "Audio").is_err());
+    }
 }

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -6,6 +6,15 @@
 use sdr_types::SinkError;
 use std::collections::HashMap;
 
+/// Minimum volume level.
+const MIN_VOLUME: f32 = 0.0;
+
+/// Maximum volume level.
+const MAX_VOLUME: f32 = 1.0;
+
+/// Default volume for new streams.
+const DEFAULT_VOLUME: f32 = 1.0;
+
 /// Trait for an audio/data output sink.
 ///
 /// Implemented by each sink module (audio, network).
@@ -93,7 +102,7 @@ impl SinkManager {
             name.to_string(),
             ManagedStream {
                 name: name.to_string(),
-                volume: 1.0,
+                volume: DEFAULT_VOLUME,
                 sample_rate,
                 active_sink: None,
             },
@@ -120,7 +129,7 @@ impl SinkManager {
             .streams
             .get_mut(stream_name)
             .ok_or_else(|| SinkError::DeviceNotFound(stream_name.to_string()))?;
-        stream.volume = volume.clamp(0.0, 1.0);
+        stream.volume = volume.clamp(MIN_VOLUME, MAX_VOLUME);
         Ok(())
     }
 
@@ -135,9 +144,21 @@ impl SinkManager {
     ///
     /// Returns `SinkError` if stream or sink is not found.
     pub fn set_stream_sink(&mut self, stream_name: &str, sink_name: &str) -> Result<(), SinkError> {
-        if !self.sinks.contains_key(sink_name) {
-            return Err(SinkError::DeviceNotFound(sink_name.to_string()));
-        }
+        // Get stream sample rate first
+        let sample_rate = self
+            .streams
+            .get(stream_name)
+            .ok_or_else(|| SinkError::DeviceNotFound(stream_name.to_string()))?
+            .sample_rate;
+
+        // Apply sample rate to the sink
+        let sink = self
+            .sinks
+            .get_mut(sink_name)
+            .ok_or_else(|| SinkError::DeviceNotFound(sink_name.to_string()))?;
+        sink.set_sample_rate(sample_rate)?;
+
+        // Update stream's active sink
         let stream = self
             .streams
             .get_mut(stream_name)

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -302,4 +302,13 @@ mod tests {
         mgr.set_volume("main", -0.5).unwrap();
         assert!((mgr.volume("main").unwrap()).abs() < f32::EPSILON);
     }
+
+    #[test]
+    fn test_volume_rejects_nan() {
+        let mut mgr = SinkManager::new();
+        mgr.register_stream("main", 48_000.0);
+        assert!(mgr.set_volume("main", f32::NAN).is_err());
+        assert!(mgr.set_volume("main", f32::INFINITY).is_err());
+        assert!(mgr.set_volume("main", f32::NEG_INFINITY).is_err());
+    }
 }

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -93,7 +93,9 @@ impl SinkManager {
 
     /// Get the names of all registered sinks.
     pub fn sink_names(&self) -> Vec<&str> {
-        self.sinks.keys().map(String::as_str).collect()
+        let mut names: Vec<&str> = self.sinks.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        names
     }
 
     /// Register a named audio stream. Replaces any existing stream with the same name.
@@ -116,15 +118,22 @@ impl SinkManager {
 
     /// Get stream names.
     pub fn stream_names(&self) -> Vec<&str> {
-        self.streams.keys().map(String::as_str).collect()
+        let mut names: Vec<&str> = self.streams.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        names
     }
 
     /// Set the volume for a stream (0.0 to 1.0).
     ///
     /// # Errors
     ///
-    /// Returns `SinkError` if the stream is not found.
+    /// Returns `SinkError` if the stream is not found or volume is non-finite.
     pub fn set_volume(&mut self, stream_name: &str, volume: f32) -> Result<(), SinkError> {
+        if !volume.is_finite() {
+            return Err(SinkError::OpenFailed(format!(
+                "volume must be finite, got {volume}"
+            )));
+        }
         let stream = self
             .streams
             .get_mut(stream_name)

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -13,7 +13,7 @@ const MIN_VOLUME: f32 = 0.0;
 const MAX_VOLUME: f32 = 1.0;
 
 /// Default volume for new streams.
-const DEFAULT_VOLUME: f32 = 1.0;
+const DEFAULT_VOLUME: f32 = MAX_VOLUME;
 
 /// Trait for an audio/data output sink.
 ///
@@ -254,6 +254,10 @@ mod tests {
         mgr.register_sink(Box::new(MockSink::new("Audio"))).unwrap();
         mgr.register_stream("main", 48_000.0);
         mgr.set_stream_sink("main", "Audio").unwrap();
+        assert_eq!(
+            mgr.streams.get("main").unwrap().active_sink.as_deref(),
+            Some("Audio")
+        );
     }
 
     #[test]

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -1,0 +1,236 @@
+//! Sink manager — registration and lifecycle for audio/network sinks.
+//!
+//! Ports SDR++ `SinkManager`. Manages output sinks (audio, network)
+//! with volume control and stream routing.
+
+use sdr_types::SinkError;
+use std::collections::HashMap;
+
+/// Trait for an audio/data output sink.
+///
+/// Implemented by each sink module (audio, network).
+pub trait Sink: Send {
+    /// Human-readable name (e.g., "Audio", "Network").
+    fn name(&self) -> &str;
+
+    /// Start the sink.
+    fn start(&mut self) -> Result<(), SinkError>;
+
+    /// Stop the sink.
+    fn stop(&mut self) -> Result<(), SinkError>;
+
+    /// Set the sample rate.
+    fn set_sample_rate(&mut self, rate: f64);
+
+    /// Current sample rate.
+    fn sample_rate(&self) -> f64;
+}
+
+/// An audio stream managed by the sink manager.
+pub struct ManagedStream {
+    /// Name of this stream.
+    pub name: String,
+    /// Volume (0.0 to 1.0).
+    pub volume: f32,
+    /// Sample rate.
+    pub sample_rate: f64,
+    /// Active sink name.
+    pub active_sink: Option<String>,
+}
+
+/// Manages output sinks and audio streams.
+///
+/// Ports SDR++ `SinkManager`.
+pub struct SinkManager {
+    sinks: HashMap<String, Box<dyn Sink>>,
+    streams: HashMap<String, ManagedStream>,
+}
+
+impl SinkManager {
+    /// Create a new empty sink manager.
+    pub fn new() -> Self {
+        Self {
+            sinks: HashMap::new(),
+            streams: HashMap::new(),
+        }
+    }
+
+    /// Register a sink.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SinkError` if a sink with this name already exists.
+    pub fn register_sink(&mut self, sink: Box<dyn Sink>) -> Result<(), SinkError> {
+        let name = sink.name().to_string();
+        if self.sinks.contains_key(&name) {
+            return Err(SinkError::OpenFailed(format!(
+                "sink already registered: {name}"
+            )));
+        }
+        self.sinks.insert(name, sink);
+        Ok(())
+    }
+
+    /// Unregister a sink by name.
+    pub fn unregister_sink(&mut self, name: &str) -> Option<Box<dyn Sink>> {
+        self.sinks.remove(name)
+    }
+
+    /// Get the names of all registered sinks.
+    pub fn sink_names(&self) -> Vec<&str> {
+        self.sinks.keys().map(String::as_str).collect()
+    }
+
+    /// Register a named audio stream.
+    pub fn register_stream(&mut self, name: &str, sample_rate: f64) {
+        self.streams.insert(
+            name.to_string(),
+            ManagedStream {
+                name: name.to_string(),
+                volume: 1.0,
+                sample_rate,
+                active_sink: None,
+            },
+        );
+    }
+
+    /// Unregister a stream.
+    pub fn unregister_stream(&mut self, name: &str) {
+        self.streams.remove(name);
+    }
+
+    /// Get stream names.
+    pub fn stream_names(&self) -> Vec<&str> {
+        self.streams.keys().map(String::as_str).collect()
+    }
+
+    /// Set the volume for a stream (0.0 to 1.0).
+    ///
+    /// # Errors
+    ///
+    /// Returns `SinkError` if the stream is not found.
+    pub fn set_volume(&mut self, stream_name: &str, volume: f32) -> Result<(), SinkError> {
+        let stream = self
+            .streams
+            .get_mut(stream_name)
+            .ok_or_else(|| SinkError::DeviceNotFound(stream_name.to_string()))?;
+        stream.volume = volume.clamp(0.0, 1.0);
+        Ok(())
+    }
+
+    /// Get the volume for a stream.
+    pub fn volume(&self, stream_name: &str) -> Option<f32> {
+        self.streams.get(stream_name).map(|s| s.volume)
+    }
+
+    /// Set the active sink for a stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SinkError` if stream or sink is not found.
+    pub fn set_stream_sink(&mut self, stream_name: &str, sink_name: &str) -> Result<(), SinkError> {
+        if !self.sinks.contains_key(sink_name) {
+            return Err(SinkError::DeviceNotFound(sink_name.to_string()));
+        }
+        let stream = self
+            .streams
+            .get_mut(stream_name)
+            .ok_or_else(|| SinkError::DeviceNotFound(stream_name.to_string()))?;
+        stream.active_sink = Some(sink_name.to_string());
+        Ok(())
+    }
+}
+
+impl Default for SinkManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    struct MockSink {
+        name: String,
+    }
+
+    impl MockSink {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+            }
+        }
+    }
+
+    impl Sink for MockSink {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn start(&mut self) -> Result<(), SinkError> {
+            Ok(())
+        }
+        fn stop(&mut self) -> Result<(), SinkError> {
+            Ok(())
+        }
+        fn set_sample_rate(&mut self, _rate: f64) {}
+        fn sample_rate(&self) -> f64 {
+            48_000.0
+        }
+    }
+
+    #[test]
+    fn test_register_sink() {
+        let mut mgr = SinkManager::new();
+        mgr.register_sink(Box::new(MockSink::new("Audio"))).unwrap();
+        assert_eq!(mgr.sink_names(), vec!["Audio"]);
+    }
+
+    #[test]
+    fn test_duplicate_sink() {
+        let mut mgr = SinkManager::new();
+        mgr.register_sink(Box::new(MockSink::new("Audio"))).unwrap();
+        assert!(mgr.register_sink(Box::new(MockSink::new("Audio"))).is_err());
+    }
+
+    #[test]
+    fn test_stream_lifecycle() {
+        let mut mgr = SinkManager::new();
+        mgr.register_stream("main", 48_000.0);
+        assert_eq!(mgr.stream_names(), vec!["main"]);
+        mgr.unregister_stream("main");
+        assert!(mgr.stream_names().is_empty());
+    }
+
+    #[test]
+    fn test_volume() {
+        let mut mgr = SinkManager::new();
+        mgr.register_stream("main", 48_000.0);
+        mgr.set_volume("main", 0.5).unwrap();
+        assert!((mgr.volume("main").unwrap() - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_volume_clamp() {
+        let mut mgr = SinkManager::new();
+        mgr.register_stream("main", 48_000.0);
+        mgr.set_volume("main", 2.0).unwrap();
+        assert!((mgr.volume("main").unwrap() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_set_stream_sink() {
+        let mut mgr = SinkManager::new();
+        mgr.register_sink(Box::new(MockSink::new("Audio"))).unwrap();
+        mgr.register_stream("main", 48_000.0);
+        mgr.set_stream_sink("main", "Audio").unwrap();
+    }
+
+    #[test]
+    fn test_set_stream_sink_not_found() {
+        let mut mgr = SinkManager::new();
+        mgr.register_stream("main", 48_000.0);
+        assert!(mgr.set_stream_sink("main", "NonExistent").is_err());
+    }
+}

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -20,7 +20,7 @@ pub trait Sink: Send {
     fn stop(&mut self) -> Result<(), SinkError>;
 
     /// Set the sample rate.
-    fn set_sample_rate(&mut self, rate: f64);
+    fn set_sample_rate(&mut self, rate: f64) -> Result<(), SinkError>;
 
     /// Current sample rate.
     fn sample_rate(&self) -> f64;
@@ -174,7 +174,9 @@ mod tests {
         fn stop(&mut self) -> Result<(), SinkError> {
             Ok(())
         }
-        fn set_sample_rate(&mut self, _rate: f64) {}
+        fn set_sample_rate(&mut self, _rate: f64) -> Result<(), SinkError> {
+            Ok(())
+        }
         fn sample_rate(&self) -> f64 {
             48_000.0
         }

--- a/crates/sdr-pipeline/src/sink_manager.rs
+++ b/crates/sdr-pipeline/src/sink_manager.rs
@@ -81,7 +81,7 @@ impl SinkManager {
         self.sinks.keys().map(String::as_str).collect()
     }
 
-    /// Register a named audio stream.
+    /// Register a named audio stream. Replaces any existing stream with the same name.
     pub fn register_stream(&mut self, name: &str, sample_rate: f64) {
         self.streams.insert(
             name.to_string(),

--- a/crates/sdr-pipeline/src/source_manager.rs
+++ b/crates/sdr-pipeline/src/source_manager.rs
@@ -71,8 +71,10 @@ impl SourceManager {
     pub fn unregister(&mut self, name: &str) -> Option<Box<dyn Source>> {
         // Stop the source if it's the selected running source
         if self.selected.as_deref() == Some(name) && self.running {
-            if let Some(source) = self.sources.get_mut(name) {
-                let _ = source.stop();
+            if let Some(source) = self.sources.get_mut(name)
+                && let Err(e) = source.stop()
+            {
+                tracing::warn!("failed to stop source during unregister: {e}");
             }
             self.running = false;
             self.selected = None;
@@ -268,5 +270,58 @@ mod tests {
         mgr.unregister("Test");
         assert!(mgr.selected().is_none());
         assert!(mgr.source_names().is_empty());
+    }
+
+    #[test]
+    fn test_unregister_stops_running_source() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct TrackingSource {
+            stopped: Arc<AtomicBool>,
+        }
+        impl Source for TrackingSource {
+            #[allow(clippy::unnecessary_literal_bound)]
+            fn name(&self) -> &str {
+                "Tracker"
+            }
+            fn start(&mut self) -> Result<(), SourceError> {
+                Ok(())
+            }
+            fn stop(&mut self) -> Result<(), SourceError> {
+                self.stopped.store(true, Ordering::Relaxed);
+                Ok(())
+            }
+            fn tune(&mut self, _: f64) -> Result<(), SourceError> {
+                Ok(())
+            }
+            fn sample_rates(&self) -> &[f64] {
+                &[]
+            }
+            fn sample_rate(&self) -> f64 {
+                48_000.0
+            }
+            fn set_sample_rate(&mut self, _: f64) -> Result<(), SourceError> {
+                Ok(())
+            }
+        }
+
+        let stopped = Arc::new(AtomicBool::new(false));
+        let source = TrackingSource {
+            stopped: Arc::clone(&stopped),
+        };
+
+        let mut mgr = SourceManager::new();
+        mgr.register(Box::new(source)).unwrap();
+        mgr.select("Tracker").unwrap();
+        mgr.start().unwrap();
+        assert!(mgr.is_running());
+
+        mgr.unregister("Tracker");
+        assert!(
+            stopped.load(Ordering::Relaxed),
+            "source should have been stopped"
+        );
+        assert!(!mgr.is_running());
     }
 }

--- a/crates/sdr-pipeline/src/source_manager.rs
+++ b/crates/sdr-pipeline/src/source_manager.rs
@@ -1,0 +1,275 @@
+//! Source manager — registration and lifecycle for IQ sources.
+//!
+//! Ports SDR++ `SourceManager`. Manages the set of available IQ sources
+//! (RTL-SDR, Network, File) and controls which one is active.
+
+use sdr_types::SourceError;
+use std::collections::HashMap;
+
+/// Trait for an IQ signal source.
+///
+/// Implemented by each source module (RTL-SDR, network, file).
+pub trait Source: Send {
+    /// Human-readable name (e.g., "RTL-SDR", "Network").
+    fn name(&self) -> &str;
+
+    /// Start producing IQ samples.
+    fn start(&mut self) -> Result<(), SourceError>;
+
+    /// Stop producing samples.
+    fn stop(&mut self) -> Result<(), SourceError>;
+
+    /// Tune to a frequency in Hz.
+    fn tune(&mut self, frequency_hz: f64) -> Result<(), SourceError>;
+
+    /// List of supported sample rates in Hz.
+    fn sample_rates(&self) -> &[f64];
+
+    /// Current sample rate in Hz.
+    fn sample_rate(&self) -> f64;
+
+    /// Set sample rate.
+    fn set_sample_rate(&mut self, rate: f64) -> Result<(), SourceError>;
+}
+
+/// Manages available IQ sources and the active source lifecycle.
+///
+/// Ports SDR++ `SourceManager`.
+pub struct SourceManager {
+    sources: HashMap<String, Box<dyn Source>>,
+    selected: Option<String>,
+    running: bool,
+}
+
+impl SourceManager {
+    /// Create a new empty source manager.
+    pub fn new() -> Self {
+        Self {
+            sources: HashMap::new(),
+            selected: None,
+            running: false,
+        }
+    }
+
+    /// Register a source.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SourceError` if a source with this name already exists.
+    pub fn register(&mut self, source: Box<dyn Source>) -> Result<(), SourceError> {
+        let name = source.name().to_string();
+        if self.sources.contains_key(&name) {
+            return Err(SourceError::OpenFailed(format!(
+                "source already registered: {name}"
+            )));
+        }
+        self.sources.insert(name, source);
+        Ok(())
+    }
+
+    /// Unregister a source by name.
+    pub fn unregister(&mut self, name: &str) -> Option<Box<dyn Source>> {
+        if self.selected.as_deref() == Some(name) {
+            self.selected = None;
+        }
+        self.sources.remove(name)
+    }
+
+    /// Get the names of all registered sources.
+    pub fn source_names(&self) -> Vec<&str> {
+        self.sources.keys().map(String::as_str).collect()
+    }
+
+    /// Select a source by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SourceError::DeviceNotFound` if the name is not registered.
+    pub fn select(&mut self, name: &str) -> Result<(), SourceError> {
+        if !self.sources.contains_key(name) {
+            return Err(SourceError::DeviceNotFound(name.to_string()));
+        }
+        self.selected = Some(name.to_string());
+        Ok(())
+    }
+
+    /// Get the currently selected source name.
+    pub fn selected(&self) -> Option<&str> {
+        self.selected.as_deref()
+    }
+
+    /// Start the selected source.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SourceError` if no source is selected or start fails.
+    pub fn start(&mut self) -> Result<(), SourceError> {
+        let name = self
+            .selected
+            .as_ref()
+            .ok_or(SourceError::NotRunning)?
+            .clone();
+        let source = self
+            .sources
+            .get_mut(&name)
+            .ok_or(SourceError::DeviceNotFound(name))?;
+        source.start()?;
+        self.running = true;
+        Ok(())
+    }
+
+    /// Stop the selected source.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SourceError` if no source is selected or stop fails.
+    pub fn stop(&mut self) -> Result<(), SourceError> {
+        let name = self
+            .selected
+            .as_ref()
+            .ok_or(SourceError::NotRunning)?
+            .clone();
+        let source = self
+            .sources
+            .get_mut(&name)
+            .ok_or(SourceError::DeviceNotFound(name))?;
+        source.stop()?;
+        self.running = false;
+        Ok(())
+    }
+
+    /// Tune the selected source.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SourceError` if no source is selected or tune fails.
+    pub fn tune(&mut self, frequency_hz: f64) -> Result<(), SourceError> {
+        let name = self
+            .selected
+            .as_ref()
+            .ok_or(SourceError::NotRunning)?
+            .clone();
+        let source = self
+            .sources
+            .get_mut(&name)
+            .ok_or(SourceError::DeviceNotFound(name))?;
+        source.tune(frequency_hz)
+    }
+
+    /// Whether a source is currently running.
+    pub fn is_running(&self) -> bool {
+        self.running
+    }
+}
+
+impl Default for SourceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    struct MockSource {
+        name: String,
+        started: bool,
+        freq: f64,
+    }
+
+    impl MockSource {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                started: false,
+                freq: 0.0,
+            }
+        }
+    }
+
+    impl Source for MockSource {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn start(&mut self) -> Result<(), SourceError> {
+            self.started = true;
+            Ok(())
+        }
+        fn stop(&mut self) -> Result<(), SourceError> {
+            self.started = false;
+            Ok(())
+        }
+        fn tune(&mut self, frequency_hz: f64) -> Result<(), SourceError> {
+            self.freq = frequency_hz;
+            Ok(())
+        }
+        fn sample_rates(&self) -> &[f64] {
+            &[48_000.0, 2_400_000.0]
+        }
+        fn sample_rate(&self) -> f64 {
+            2_400_000.0
+        }
+        fn set_sample_rate(&mut self, _rate: f64) -> Result<(), SourceError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_register_and_select() {
+        let mut mgr = SourceManager::new();
+        mgr.register(Box::new(MockSource::new("Test"))).unwrap();
+        assert_eq!(mgr.source_names(), vec!["Test"]);
+        mgr.select("Test").unwrap();
+        assert_eq!(mgr.selected(), Some("Test"));
+    }
+
+    #[test]
+    fn test_select_not_found() {
+        let mut mgr = SourceManager::new();
+        assert!(mgr.select("NonExistent").is_err());
+    }
+
+    #[test]
+    fn test_start_stop() {
+        let mut mgr = SourceManager::new();
+        mgr.register(Box::new(MockSource::new("Test"))).unwrap();
+        mgr.select("Test").unwrap();
+        mgr.start().unwrap();
+        assert!(mgr.is_running());
+        mgr.stop().unwrap();
+        assert!(!mgr.is_running());
+    }
+
+    #[test]
+    fn test_tune() {
+        let mut mgr = SourceManager::new();
+        mgr.register(Box::new(MockSource::new("Test"))).unwrap();
+        mgr.select("Test").unwrap();
+        mgr.tune(100_000_000.0).unwrap();
+    }
+
+    #[test]
+    fn test_start_no_selection() {
+        let mut mgr = SourceManager::new();
+        assert!(mgr.start().is_err());
+    }
+
+    #[test]
+    fn test_duplicate_register() {
+        let mut mgr = SourceManager::new();
+        mgr.register(Box::new(MockSource::new("Test"))).unwrap();
+        assert!(mgr.register(Box::new(MockSource::new("Test"))).is_err());
+    }
+
+    #[test]
+    fn test_unregister() {
+        let mut mgr = SourceManager::new();
+        mgr.register(Box::new(MockSource::new("Test"))).unwrap();
+        mgr.select("Test").unwrap();
+        mgr.unregister("Test");
+        assert!(mgr.selected().is_none());
+        assert!(mgr.source_names().is_empty());
+    }
+}

--- a/crates/sdr-pipeline/src/source_manager.rs
+++ b/crates/sdr-pipeline/src/source_manager.rs
@@ -67,9 +67,16 @@ impl SourceManager {
         Ok(())
     }
 
-    /// Unregister a source by name.
+    /// Unregister a source by name. Stops it first if running.
     pub fn unregister(&mut self, name: &str) -> Option<Box<dyn Source>> {
-        if self.selected.as_deref() == Some(name) {
+        // Stop the source if it's the selected running source
+        if self.selected.as_deref() == Some(name) && self.running {
+            if let Some(source) = self.sources.get_mut(name) {
+                let _ = source.stop();
+            }
+            self.running = false;
+            self.selected = None;
+        } else if self.selected.as_deref() == Some(name) {
             self.selected = None;
         }
         self.sources.remove(name)
@@ -104,16 +111,7 @@ impl SourceManager {
     ///
     /// Returns `SourceError` if no source is selected or start fails.
     pub fn start(&mut self) -> Result<(), SourceError> {
-        let name = self
-            .selected
-            .as_ref()
-            .ok_or(SourceError::NotRunning)?
-            .clone();
-        let source = self
-            .sources
-            .get_mut(&name)
-            .ok_or(SourceError::DeviceNotFound(name))?;
-        source.start()?;
+        self.with_selected_source(|source| source.start())?;
         self.running = true;
         Ok(())
     }
@@ -124,16 +122,7 @@ impl SourceManager {
     ///
     /// Returns `SourceError` if no source is selected or stop fails.
     pub fn stop(&mut self) -> Result<(), SourceError> {
-        let name = self
-            .selected
-            .as_ref()
-            .ok_or(SourceError::NotRunning)?
-            .clone();
-        let source = self
-            .sources
-            .get_mut(&name)
-            .ok_or(SourceError::DeviceNotFound(name))?;
-        source.stop()?;
+        self.with_selected_source(|source| source.stop())?;
         self.running = false;
         Ok(())
     }
@@ -144,6 +133,19 @@ impl SourceManager {
     ///
     /// Returns `SourceError` if no source is selected or tune fails.
     pub fn tune(&mut self, frequency_hz: f64) -> Result<(), SourceError> {
+        self.with_selected_source(|source| source.tune(frequency_hz))
+    }
+
+    /// Whether a source is currently running.
+    pub fn is_running(&self) -> bool {
+        self.running
+    }
+
+    /// Helper: look up the selected source and apply a closure.
+    fn with_selected_source<F, R>(&mut self, f: F) -> Result<R, SourceError>
+    where
+        F: FnOnce(&mut dyn Source) -> Result<R, SourceError>,
+    {
         let name = self
             .selected
             .as_ref()
@@ -153,12 +155,7 @@ impl SourceManager {
             .sources
             .get_mut(&name)
             .ok_or(SourceError::DeviceNotFound(name))?;
-        source.tune(frequency_hz)
-    }
-
-    /// Whether a source is currently running.
-    pub fn is_running(&self) -> bool {
-        self.running
+        f(source.as_mut())
     }
 }
 

--- a/crates/sdr-pipeline/src/vfo_manager.rs
+++ b/crates/sdr-pipeline/src/vfo_manager.rs
@@ -226,4 +226,15 @@ mod tests {
         names.sort_unstable();
         assert_eq!(names, vec!["a", "b"]);
     }
+
+    #[test]
+    fn test_set_bandwidth_limits_invalid() {
+        let mut mgr = VfoManager::new();
+        mgr.create_vfo(VfoParams::new("vfo1", 0.0, 200_000.0, 48_000.0))
+            .unwrap();
+        assert!(
+            mgr.set_bandwidth_limits("vfo1", 100_000.0, 50_000.0)
+                .is_err()
+        );
+    }
 }

--- a/crates/sdr-pipeline/src/vfo_manager.rs
+++ b/crates/sdr-pipeline/src/vfo_manager.rs
@@ -6,6 +6,9 @@
 use sdr_types::DspError;
 use std::collections::HashMap;
 
+/// Default minimum VFO bandwidth in Hz.
+const DEFAULT_MIN_BANDWIDTH: f64 = 1_000.0;
+
 /// Parameters for a Virtual Frequency Oscillator.
 #[derive(Clone, Debug)]
 pub struct VfoParams {
@@ -32,7 +35,7 @@ impl VfoParams {
             name: name.to_string(),
             offset,
             bandwidth,
-            min_bandwidth: 1_000.0,
+            min_bandwidth: DEFAULT_MIN_BANDWIDTH,
             max_bandwidth: sample_rate,
             sample_rate,
             snap_interval: 0.0,
@@ -118,8 +121,13 @@ impl VfoManager {
     ///
     /// # Errors
     ///
-    /// Returns `DspError::InvalidParameter` if the VFO is not found.
+    /// Returns `DspError::InvalidParameter` if the VFO is not found or `min > max`.
     pub fn set_bandwidth_limits(&mut self, name: &str, min: f64, max: f64) -> Result<(), DspError> {
+        if min > max {
+            return Err(DspError::InvalidParameter(format!(
+                "min bandwidth ({min}) must be <= max bandwidth ({max})"
+            )));
+        }
         let vfo = self.get_vfo_mut(name)?;
         vfo.min_bandwidth = min;
         vfo.max_bandwidth = max;

--- a/crates/sdr-pipeline/src/vfo_manager.rs
+++ b/crates/sdr-pipeline/src/vfo_manager.rs
@@ -1,0 +1,221 @@
+//! VFO manager — multi-VFO creation and parameter management.
+//!
+//! Ports SDR++ `VFOManager`. Each VFO extracts a channel from the
+//! wideband IQ stream at a given frequency offset and bandwidth.
+
+use sdr_types::DspError;
+use std::collections::HashMap;
+
+/// Parameters for a Virtual Frequency Oscillator.
+#[derive(Clone, Debug)]
+pub struct VfoParams {
+    /// Name identifier.
+    pub name: String,
+    /// Frequency offset from center in Hz.
+    pub offset: f64,
+    /// Channel bandwidth in Hz.
+    pub bandwidth: f64,
+    /// Minimum allowed bandwidth in Hz.
+    pub min_bandwidth: f64,
+    /// Maximum allowed bandwidth in Hz.
+    pub max_bandwidth: f64,
+    /// Output sample rate in Hz.
+    pub sample_rate: f64,
+    /// Frequency snap interval in Hz (0 = no snap).
+    pub snap_interval: f64,
+}
+
+impl VfoParams {
+    /// Create VFO params with defaults.
+    pub fn new(name: &str, offset: f64, bandwidth: f64, sample_rate: f64) -> Self {
+        Self {
+            name: name.to_string(),
+            offset,
+            bandwidth,
+            min_bandwidth: 1_000.0,
+            max_bandwidth: sample_rate,
+            sample_rate,
+            snap_interval: 0.0,
+        }
+    }
+}
+
+/// Manages multiple VFOs, each extracting a channel from the IQ stream.
+///
+/// Ports SDR++ `VFOManager`.
+pub struct VfoManager {
+    vfos: HashMap<String, VfoParams>,
+}
+
+impl VfoManager {
+    /// Create a new empty VFO manager.
+    pub fn new() -> Self {
+        Self {
+            vfos: HashMap::new(),
+        }
+    }
+
+    /// Create a new VFO with the given parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if a VFO with this name already exists.
+    pub fn create_vfo(&mut self, params: VfoParams) -> Result<(), DspError> {
+        if self.vfos.contains_key(&params.name) {
+            return Err(DspError::InvalidParameter(format!(
+                "VFO already exists: {}",
+                params.name
+            )));
+        }
+        self.vfos.insert(params.name.clone(), params);
+        Ok(())
+    }
+
+    /// Delete a VFO by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the VFO is not found.
+    pub fn delete_vfo(&mut self, name: &str) -> Result<(), DspError> {
+        self.vfos
+            .remove(name)
+            .map(|_| ())
+            .ok_or_else(|| DspError::InvalidParameter(format!("VFO not found: {name}")))
+    }
+
+    /// Check if a VFO exists.
+    pub fn vfo_exists(&self, name: &str) -> bool {
+        self.vfos.contains_key(name)
+    }
+
+    /// Get VFO parameters.
+    pub fn get_vfo(&self, name: &str) -> Option<&VfoParams> {
+        self.vfos.get(name)
+    }
+
+    /// Set VFO frequency offset.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the VFO is not found.
+    pub fn set_offset(&mut self, name: &str, offset: f64) -> Result<(), DspError> {
+        self.get_vfo_mut(name)?.offset = offset;
+        Ok(())
+    }
+
+    /// Set VFO bandwidth, clamped to min/max limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the VFO is not found.
+    pub fn set_bandwidth(&mut self, name: &str, bandwidth: f64) -> Result<(), DspError> {
+        let vfo = self.get_vfo_mut(name)?;
+        vfo.bandwidth = bandwidth.clamp(vfo.min_bandwidth, vfo.max_bandwidth);
+        Ok(())
+    }
+
+    /// Set VFO bandwidth limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the VFO is not found.
+    pub fn set_bandwidth_limits(&mut self, name: &str, min: f64, max: f64) -> Result<(), DspError> {
+        let vfo = self.get_vfo_mut(name)?;
+        vfo.min_bandwidth = min;
+        vfo.max_bandwidth = max;
+        vfo.bandwidth = vfo.bandwidth.clamp(min, max);
+        Ok(())
+    }
+
+    /// Get all VFO names.
+    pub fn vfo_names(&self) -> Vec<&str> {
+        self.vfos.keys().map(String::as_str).collect()
+    }
+
+    /// Number of VFOs.
+    pub fn count(&self) -> usize {
+        self.vfos.len()
+    }
+
+    fn get_vfo_mut(&mut self, name: &str) -> Result<&mut VfoParams, DspError> {
+        self.vfos
+            .get_mut(name)
+            .ok_or_else(|| DspError::InvalidParameter(format!("VFO not found: {name}")))
+    }
+}
+
+impl Default for VfoManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_and_delete() {
+        let mut mgr = VfoManager::new();
+        let params = VfoParams::new("vfo1", 10_000.0, 200_000.0, 48_000.0);
+        mgr.create_vfo(params).unwrap();
+        assert!(mgr.vfo_exists("vfo1"));
+        assert_eq!(mgr.count(), 1);
+        mgr.delete_vfo("vfo1").unwrap();
+        assert!(!mgr.vfo_exists("vfo1"));
+    }
+
+    #[test]
+    fn test_duplicate_create() {
+        let mut mgr = VfoManager::new();
+        mgr.create_vfo(VfoParams::new("vfo1", 0.0, 200_000.0, 48_000.0))
+            .unwrap();
+        assert!(
+            mgr.create_vfo(VfoParams::new("vfo1", 0.0, 200_000.0, 48_000.0))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_delete_not_found() {
+        let mut mgr = VfoManager::new();
+        assert!(mgr.delete_vfo("nonexistent").is_err());
+    }
+
+    #[test]
+    fn test_set_offset() {
+        let mut mgr = VfoManager::new();
+        mgr.create_vfo(VfoParams::new("vfo1", 0.0, 200_000.0, 48_000.0))
+            .unwrap();
+        mgr.set_offset("vfo1", 5_000.0).unwrap();
+        assert_eq!(mgr.get_vfo("vfo1").unwrap().offset, 5_000.0);
+    }
+
+    #[test]
+    fn test_set_bandwidth_clamped() {
+        let mut mgr = VfoManager::new();
+        mgr.create_vfo(VfoParams::new("vfo1", 0.0, 200_000.0, 48_000.0))
+            .unwrap();
+        mgr.set_bandwidth_limits("vfo1", 5_000.0, 100_000.0)
+            .unwrap();
+        // Set below min
+        mgr.set_bandwidth("vfo1", 1_000.0).unwrap();
+        assert_eq!(mgr.get_vfo("vfo1").unwrap().bandwidth, 5_000.0);
+        // Set above max
+        mgr.set_bandwidth("vfo1", 500_000.0).unwrap();
+        assert_eq!(mgr.get_vfo("vfo1").unwrap().bandwidth, 100_000.0);
+    }
+
+    #[test]
+    fn test_vfo_names() {
+        let mut mgr = VfoManager::new();
+        mgr.create_vfo(VfoParams::new("a", 0.0, 200_000.0, 48_000.0))
+            .unwrap();
+        mgr.create_vfo(VfoParams::new("b", 0.0, 200_000.0, 48_000.0))
+            .unwrap();
+        let mut names = mgr.vfo_names();
+        names.sort_unstable();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+}


### PR DESCRIPTION
## Summary

Final Phase 2 PR — completes the pipeline infrastructure.

- `SourceManager`: Source trait + register/select/start/stop/tune lifecycle
- `SinkManager`: Sink trait + stream management with volume control and sink routing
- `VfoManager`: VFO parameter management with bandwidth clamping
- `IqFrontend`: FFT windowing, DC blocking, IQ inversion, power spectrum output

## Test plan

- [x] 57 total pipeline tests (30 from PR1 + 27 new)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] SourceManager: register, select, start/stop, tune, duplicate rejection
- [x] SinkManager: register sink/stream, volume clamping, sink routing
- [x] VfoManager: create/delete, offset, bandwidth clamping, duplicate rejection
- [x] IqFrontend: DC signal FFT peak, tone detection, IQ inversion, DC blocking

Closes #17
Closes #18
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time IQ frontend: configurable FFT window, DC blocking toggle, IQ inversion, spectrum output, and sample/FFT size controls
  * Source management: register/select sources, start/stop, tune, and sample-rate configuration
  * Sink/stream management: register outputs, per-stream routing and volume clamping
  * Multi‑VFO management: create/delete VFOs, offsets, bandwidths/limits, and listing
  * Crate exports updated to expose the new modules

* **Tests**
  * Unit tests for signal processing, managers, and error conditions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->