### PR TITLE
Fix deferred issues: IqFrontend decimation, FFT accumulation, network I/O

### DIFF
--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -1,14 +1,15 @@
 //! IQ frontend — central signal processing hub.
 //!
 //! Ports SDR++ `IQFrontEnd`. Sits between the source and VFOs, providing:
-//! - Power decimation
+//! - Power decimation (configurable ratio)
 //! - DC blocking
 //! - IQ conjugation (inversion correction)
-//! - FFT computation for waterfall display
+//! - FFT computation for waterfall display (with sample accumulation)
 //! - Fan-out to multiple VFO consumers
 
 use sdr_dsp::correction::DcBlocker;
 use sdr_dsp::fft::{self, FftEngine, RustFftEngine};
+use sdr_dsp::multirate::PowerDecimator;
 use sdr_dsp::window;
 use sdr_types::{Complex, DspError};
 
@@ -23,39 +24,53 @@ pub enum FftWindow {
     Nuttall,
 }
 
+/// DC blocker rate factor: `50.0 / sample_rate`.
+/// Matches C++ `genDCBlockRate`.
+const DC_BLOCK_RATE_FACTOR: f64 = 50.0;
+
 /// IQ frontend processing hub.
 ///
 /// Processes raw IQ from a source through decimation, correction,
 /// and FFT computation, then distributes to VFO consumers.
 pub struct IqFrontend {
     sample_rate: f64,
+    decim_ratio: u32,
+    effective_sample_rate: f64,
+
+    // Pre-processing
+    decimator: Option<PowerDecimator>,
+    dc_blocker: Option<DcBlocker>,
+    invert_iq: bool,
+
+    // FFT
     fft_size: usize,
     fft_engine: RustFftEngine,
     fft_window_buf: Vec<f32>,
-    fft_input: Vec<Complex>,
+    fft_accum: Vec<Complex>,
+    fft_accum_count: usize,
     fft_output: Vec<f32>,
-    dc_blocker: Option<DcBlocker>,
-    dc_scratch: Vec<Complex>,
-    invert_iq: bool,
-}
 
-/// DC blocker convergence rate for the IQ frontend.
-const DC_BLOCK_RATE: f64 = 0.001;
+    // Scratch buffers
+    decim_buf: Vec<Complex>,
+    dc_scratch: Vec<Complex>,
+}
 
 impl IqFrontend {
     /// Create a new IQ frontend.
     ///
     /// - `sample_rate`: input sample rate in Hz
+    /// - `decim_ratio`: power-of-2 decimation ratio (1 = no decimation)
     /// - `fft_size`: FFT size for spectrum display
     /// - `fft_window`: window function for FFT
     /// - `dc_blocking`: whether to enable DC blocking
     ///
     /// # Errors
     ///
-    /// Returns `DspError::InvalidParameter` if `fft_size` is 0.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+    /// Returns `DspError::InvalidParameter` if `fft_size` is 0 or `decim_ratio` is invalid.
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
     pub fn new(
         sample_rate: f64,
+        decim_ratio: u32,
         fft_size: usize,
         fft_window: FftWindow,
         dc_blocking: bool,
@@ -76,28 +91,54 @@ impl IqFrontend {
             })
             .collect();
 
+        let effective_sample_rate = sample_rate / f64::from(decim_ratio);
+
+        let decimator = if decim_ratio > 1 {
+            Some(PowerDecimator::new(decim_ratio)?)
+        } else {
+            None
+        };
+
         let dc_blocker = if dc_blocking {
-            Some(DcBlocker::new(DC_BLOCK_RATE)?)
+            let rate = DC_BLOCK_RATE_FACTOR / effective_sample_rate;
+            Some(DcBlocker::new(rate)?)
         } else {
             None
         };
 
         Ok(Self {
             sample_rate,
+            decim_ratio,
+            effective_sample_rate,
+            decimator,
+            dc_blocker,
+            invert_iq: false,
             fft_size,
             fft_engine,
             fft_window_buf,
-            fft_input: vec![Complex::default(); fft_size],
+            fft_accum: vec![Complex::default(); fft_size],
+            fft_accum_count: 0,
             fft_output: vec![0.0; fft_size],
-            dc_blocker,
+            decim_buf: Vec::new(),
             dc_scratch: Vec::new(),
-            invert_iq: false,
         })
     }
 
-    /// Get the current sample rate.
+    /// Get the input sample rate.
     pub fn sample_rate(&self) -> f64 {
         self.sample_rate
+    }
+
+    /// Get the effective sample rate after decimation.
+    ///
+    /// Ports `IQFrontEnd::getEffectiveSamplerate`.
+    pub fn effective_sample_rate(&self) -> f64 {
+        self.effective_sample_rate
+    }
+
+    /// Get the decimation ratio.
+    pub fn decim_ratio(&self) -> u32 {
+        self.decim_ratio
     }
 
     /// Get the FFT size.
@@ -117,21 +158,46 @@ impl IqFrontend {
     /// Returns `DspError` if the DC blocker cannot be created.
     pub fn set_dc_blocking(&mut self, enabled: bool) -> Result<(), DspError> {
         self.dc_blocker = if enabled {
-            Some(DcBlocker::new(DC_BLOCK_RATE)?)
+            let rate = DC_BLOCK_RATE_FACTOR / self.effective_sample_rate;
+            Some(DcBlocker::new(rate)?)
         } else {
             None
         };
         Ok(())
     }
 
+    /// Set the decimation ratio.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError` if the ratio is invalid.
+    pub fn set_decimation(&mut self, ratio: u32) -> Result<(), DspError> {
+        self.decim_ratio = ratio;
+        self.effective_sample_rate = self.sample_rate / f64::from(ratio);
+        self.decimator = if ratio > 1 {
+            Some(PowerDecimator::new(ratio)?)
+        } else {
+            None
+        };
+        // Update DC blocker rate for new effective sample rate
+        if self.dc_blocker.is_some() {
+            self.set_dc_blocking(true)?;
+        }
+        Ok(())
+    }
+
     /// Process a block of IQ samples through the frontend.
     ///
-    /// Applies DC blocking and IQ inversion, then computes FFT.
-    /// Returns the processed IQ samples and FFT power spectrum.
+    /// Applies decimation, DC blocking, IQ inversion, and accumulates
+    /// FFT data. When enough samples are accumulated for a full FFT,
+    /// computes the power spectrum.
     ///
     /// - `input`: raw IQ samples from source
-    /// - `output`: processed IQ samples (same length as input)
-    /// - `fft_out`: FFT power spectrum in dB (length = `fft_size`)
+    /// - `output`: processed IQ samples (may be shorter than input due to decimation)
+    /// - `fft_out`: FFT power spectrum in dB (length = `fft_size`), updated when ready
+    ///
+    /// Returns `(processed_count, fft_ready)` — the number of output samples
+    /// and whether a new FFT result is available in `fft_out`.
     ///
     /// # Errors
     ///
@@ -141,13 +207,7 @@ impl IqFrontend {
         input: &[Complex],
         output: &mut [Complex],
         fft_out: &mut [f32],
-    ) -> Result<usize, DspError> {
-        if output.len() < input.len() {
-            return Err(DspError::BufferTooSmall {
-                need: input.len(),
-                got: output.len(),
-            });
-        }
+    ) -> Result<(usize, bool), DspError> {
         if fft_out.len() < self.fft_size {
             return Err(DspError::BufferTooSmall {
                 need: self.fft_size,
@@ -155,42 +215,85 @@ impl IqFrontend {
             });
         }
 
-        // Step 1: Copy input to output
-        output[..input.len()].copy_from_slice(input);
+        // Step 1: Decimation
+        let processed = if let Some(decim) = &mut self.decimator {
+            self.decim_buf.resize(input.len(), Complex::default());
+            let count = decim.process(input, &mut self.decim_buf)?;
+            if output.len() < count {
+                return Err(DspError::BufferTooSmall {
+                    need: count,
+                    got: output.len(),
+                });
+            }
+            output[..count].copy_from_slice(&self.decim_buf[..count]);
+            count
+        } else {
+            if output.len() < input.len() {
+                return Err(DspError::BufferTooSmall {
+                    need: input.len(),
+                    got: output.len(),
+                });
+            }
+            output[..input.len()].copy_from_slice(input);
+            input.len()
+        };
 
         // Step 2: IQ inversion (conjugate)
         if self.invert_iq {
-            for s in &mut output[..input.len()] {
+            for s in &mut output[..processed] {
                 s.im = -s.im;
             }
         }
 
         // Step 3: DC blocking
         if let Some(dc) = &mut self.dc_blocker {
-            self.dc_scratch.resize(input.len(), Complex::default());
-            self.dc_scratch.copy_from_slice(&output[..input.len()]);
-            dc.process(&self.dc_scratch, &mut output[..input.len()])?;
+            self.dc_scratch.resize(processed, Complex::default());
+            self.dc_scratch.copy_from_slice(&output[..processed]);
+            dc.process(&self.dc_scratch, &mut output[..processed])?;
         }
 
-        // Step 4: Compute FFT from the last fft_size samples (or available)
-        let fft_samples = input.len().min(self.fft_size);
-        let fft_start = input.len().saturating_sub(fft_samples);
+        // Step 4: Accumulate samples for FFT
+        let mut fft_ready = false;
+        let mut pos = 0;
+        while pos < processed {
+            let remaining_fft = self.fft_size - self.fft_accum_count;
+            let available = processed - pos;
+            let to_copy = remaining_fft.min(available);
 
-        // Clear FFT input and copy windowed samples
-        self.fft_input.fill(Complex::default());
-        for i in 0..fft_samples {
+            self.fft_accum[self.fft_accum_count..self.fft_accum_count + to_copy]
+                .copy_from_slice(&output[pos..pos + to_copy]);
+            self.fft_accum_count += to_copy;
+            pos += to_copy;
+
+            if self.fft_accum_count >= self.fft_size {
+                // Full FFT buffer — compute spectrum
+                self.compute_fft(fft_out)?;
+                fft_ready = true;
+                self.fft_accum_count = 0;
+            }
+        }
+
+        Ok((processed, fft_ready))
+    }
+
+    /// Compute FFT from the accumulated buffer.
+    fn compute_fft(&mut self, fft_out: &mut [f32]) -> Result<(), DspError> {
+        // Apply window to accumulated samples
+        let mut windowed = self.fft_accum.clone();
+        for (i, s) in windowed.iter_mut().enumerate() {
             let w = self.fft_window_buf[i];
-            self.fft_input[i] = output[fft_start + i] * w;
+            s.re *= w;
+            s.im *= w;
         }
 
         // Execute FFT
-        self.fft_engine.forward(&mut self.fft_input)?;
+        self.fft_engine.forward(&mut windowed)?;
 
         // Convert to power spectrum dB
-        fft::power_spectrum_db(&self.fft_input, &mut self.fft_output)?;
+        fft::power_spectrum_db(&windowed, &mut self.fft_output)?;
         fft_out[..self.fft_size].copy_from_slice(&self.fft_output);
 
-        Ok(input.len())
+        Ok(())
     }
 }
 
@@ -210,28 +313,50 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let fe = IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, true);
+        let fe = IqFrontend::new(TEST_SAMPLE_RATE, 1, TEST_FFT_SIZE, FftWindow::Nuttall, true);
         assert!(fe.is_ok());
         let fe = fe.unwrap();
         assert_eq!(fe.fft_size(), TEST_FFT_SIZE);
         assert!((fe.sample_rate() - TEST_SAMPLE_RATE).abs() < 1.0);
+        assert!((fe.effective_sample_rate() - TEST_SAMPLE_RATE).abs() < 1.0);
     }
 
     #[test]
     fn test_new_zero_fft() {
-        assert!(IqFrontend::new(TEST_SAMPLE_RATE, 0, FftWindow::Nuttall, true).is_err());
+        assert!(IqFrontend::new(TEST_SAMPLE_RATE, 1, 0, FftWindow::Nuttall, true).is_err());
+    }
+
+    #[test]
+    fn test_decimation_ratio() {
+        let fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            4,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
+        assert_eq!(fe.decim_ratio(), 4);
+        assert!((fe.effective_sample_rate() - 12_000.0).abs() < 1.0);
     }
 
     #[test]
     fn test_process_dc_signal() {
-        let mut fe =
-            IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
         let input = vec![Complex::new(1.0, 0.0); TEST_FFT_SIZE];
         let mut output = vec![Complex::default(); TEST_FFT_SIZE];
         let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
 
-        let count = fe.process(&input, &mut output, &mut fft_out).unwrap();
+        let (count, fft_ready) = fe.process(&input, &mut output, &mut fft_out).unwrap();
         assert_eq!(count, TEST_FFT_SIZE);
+        assert!(fft_ready, "FFT should be ready after fft_size samples");
 
         // DC signal should have peak at bin 0
         let peak_bin = fft_out
@@ -244,8 +369,14 @@ mod tests {
 
     #[test]
     fn test_process_tone() {
-        let mut fe =
-            IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
 
         // Generate a tone at bin 64
         let tone_bin = 64;
@@ -259,16 +390,15 @@ mod tests {
         let mut output = vec![Complex::default(); TEST_FFT_SIZE];
         let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
 
-        fe.process(&input, &mut output, &mut fft_out).unwrap();
+        let (_, fft_ready) = fe.process(&input, &mut output, &mut fft_out).unwrap();
+        assert!(fft_ready);
 
-        // Find the peak — should be near the tone bin
         let peak_bin = fft_out
             .iter()
             .enumerate()
             .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
             .map_or(0, |(i, _)| i);
 
-        // Allow ±2 bins due to windowing
         assert!(
             peak_bin.abs_diff(tone_bin) <= 2,
             "expected peak near bin {tone_bin}, got {peak_bin}"
@@ -276,9 +406,37 @@ mod tests {
     }
 
     #[test]
+    fn test_fft_accumulation() {
+        // Send samples in chunks smaller than fft_size — FFT should only fire
+        // when enough samples accumulate
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
+        let chunk = vec![Complex::new(1.0, 0.0); 256];
+        let mut output = vec![Complex::default(); 256];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+
+        // First 3 chunks: 768 samples, not enough for 1024 FFT
+        for _ in 0..3 {
+            let (_, fft_ready) = fe.process(&chunk, &mut output, &mut fft_out).unwrap();
+            assert!(!fft_ready, "FFT should not be ready yet");
+        }
+
+        // 4th chunk: 1024 total — FFT should fire
+        let (_, fft_ready) = fe.process(&chunk, &mut output, &mut fft_out).unwrap();
+        assert!(fft_ready, "FFT should be ready after 1024 samples");
+    }
+
+    #[test]
     fn test_iq_inversion() {
         let mut fe = IqFrontend::new(
             TEST_SAMPLE_RATE,
+            1,
             TEST_FFT_SIZE,
             FftWindow::Rectangular,
             false,
@@ -297,9 +455,8 @@ mod tests {
     #[test]
     fn test_dc_blocking() {
         let mut fe =
-            IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, true).unwrap();
+            IqFrontend::new(TEST_SAMPLE_RATE, 1, TEST_FFT_SIZE, FftWindow::Nuttall, true).unwrap();
 
-        // Process DC signal many times — DC blocker should reduce it
         let input = vec![Complex::new(5.0, 3.0); TEST_FFT_SIZE];
         let mut output = vec![Complex::default(); TEST_FFT_SIZE];
         let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
@@ -308,7 +465,6 @@ mod tests {
             fe.process(&input, &mut output, &mut fft_out).unwrap();
         }
 
-        // After many blocks, DC should be substantially reduced
         let last = output[TEST_FFT_SIZE - 1];
         assert!(
             last.re.abs() < 2.0,
@@ -319,11 +475,33 @@ mod tests {
 
     #[test]
     fn test_buffer_too_small() {
-        let mut fe =
-            IqFrontend::new(TEST_SAMPLE_RATE, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
         let input = vec![Complex::default(); 100];
         let mut output = vec![Complex::default(); 50]; // too small
         let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
         assert!(fe.process(&input, &mut output, &mut fft_out).is_err());
+    }
+
+    #[test]
+    fn test_decimation_reduces_output() {
+        let mut fe =
+            IqFrontend::new(96_000.0, 2, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+        let input = vec![Complex::new(1.0, 0.0); 2048];
+        let mut output = vec![Complex::default(); 2048];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+
+        let (count, _) = fe.process(&input, &mut output, &mut fft_out).unwrap();
+        // 2x decimation: ~1024 output from 2048 input
+        assert!(
+            (900..=1100).contains(&count),
+            "expected ~1024 after 2x decim, got {count}"
+        );
     }
 }

--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -206,6 +206,8 @@ impl IqFrontend {
         self.effective_sample_rate = new_effective_rate;
         self.decimator = new_decimator;
         self.dc_blocker = new_dc_blocker;
+        // Discard any partially accumulated FFT data from the old rate
+        self.fft_accum_count = 0;
         Ok(())
     }
 

--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -53,6 +53,7 @@ pub struct IqFrontend {
     // Scratch buffers
     decim_buf: Vec<Complex>,
     dc_scratch: Vec<Complex>,
+    fft_work: Vec<Complex>,
 }
 
 impl IqFrontend {
@@ -75,6 +76,11 @@ impl IqFrontend {
         fft_window: FftWindow,
         dc_blocking: bool,
     ) -> Result<Self, DspError> {
+        if decim_ratio == 0 {
+            return Err(DspError::InvalidParameter(
+                "decimation ratio must be >= 1".to_string(),
+            ));
+        }
         let fft_engine = RustFftEngine::new(fft_size)?;
 
         // Pre-compute window coefficients
@@ -121,6 +127,7 @@ impl IqFrontend {
             fft_output: vec![0.0; fft_size],
             decim_buf: Vec::new(),
             dc_scratch: Vec::new(),
+            fft_work: vec![Complex::default(); fft_size],
         })
     }
 
@@ -172,17 +179,33 @@ impl IqFrontend {
     ///
     /// Returns `DspError` if the ratio is invalid.
     pub fn set_decimation(&mut self, ratio: u32) -> Result<(), DspError> {
-        self.decim_ratio = ratio;
-        self.effective_sample_rate = self.sample_rate / f64::from(ratio);
-        self.decimator = if ratio > 1 {
+        if ratio == 0 {
+            return Err(DspError::InvalidParameter(
+                "decimation ratio must be >= 1".to_string(),
+            ));
+        }
+
+        // Validate before mutating — construct decimator first
+        let new_decimator = if ratio > 1 {
             Some(PowerDecimator::new(ratio)?)
         } else {
             None
         };
-        // Update DC blocker rate for new effective sample rate
-        if self.dc_blocker.is_some() {
-            self.set_dc_blocking(true)?;
-        }
+        let new_effective_rate = self.sample_rate / f64::from(ratio);
+
+        // Rebuild DC blocker at new rate before committing
+        let new_dc_blocker = if self.dc_blocker.is_some() {
+            let rate = DC_BLOCK_RATE_FACTOR / new_effective_rate;
+            Some(DcBlocker::new(rate)?)
+        } else {
+            None
+        };
+
+        // All validated — commit state atomically
+        self.decim_ratio = ratio;
+        self.effective_sample_rate = new_effective_rate;
+        self.decimator = new_decimator;
+        self.dc_blocker = new_dc_blocker;
         Ok(())
     }
 
@@ -278,19 +301,19 @@ impl IqFrontend {
 
     /// Compute FFT from the accumulated buffer.
     fn compute_fft(&mut self, fft_out: &mut [f32]) -> Result<(), DspError> {
-        // Apply window to accumulated samples
-        let mut windowed = self.fft_accum.clone();
-        for (i, s) in windowed.iter_mut().enumerate() {
+        // Copy accumulated samples into pre-allocated work buffer and apply window
+        self.fft_work.copy_from_slice(&self.fft_accum);
+        for (i, s) in self.fft_work.iter_mut().enumerate() {
             let w = self.fft_window_buf[i];
             s.re *= w;
             s.im *= w;
         }
 
         // Execute FFT
-        self.fft_engine.forward(&mut windowed)?;
+        self.fft_engine.forward(&mut self.fft_work)?;
 
         // Convert to power spectrum dB
-        fft::power_spectrum_db(&windowed, &mut self.fft_output)?;
+        fft::power_spectrum_db(&self.fft_work, &mut self.fft_output)?;
         fft_out[..self.fft_size].copy_from_slice(&self.fft_output);
 
         Ok(())
@@ -324,6 +347,20 @@ mod tests {
     #[test]
     fn test_new_zero_fft() {
         assert!(IqFrontend::new(TEST_SAMPLE_RATE, 1, 0, FftWindow::Nuttall, true).is_err());
+    }
+
+    #[test]
+    fn test_new_zero_decimation_rejected() {
+        assert!(IqFrontend::new(TEST_SAMPLE_RATE, 0, TEST_FFT_SIZE, FftWindow::Nuttall, false).is_err());
+    }
+
+    #[test]
+    fn test_set_decimation_zero_rejected() {
+        let mut fe = IqFrontend::new(TEST_SAMPLE_RATE, 1, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+        assert!(fe.set_decimation(0).is_err());
+        // State should be unchanged after rejection
+        assert_eq!(fe.decim_ratio(), 1);
+        assert!((fe.effective_sample_rate() - TEST_SAMPLE_RATE).abs() < 1.0);
     }
 
     #[test]

--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -351,12 +351,28 @@ mod tests {
 
     #[test]
     fn test_new_zero_decimation_rejected() {
-        assert!(IqFrontend::new(TEST_SAMPLE_RATE, 0, TEST_FFT_SIZE, FftWindow::Nuttall, false).is_err());
+        assert!(
+            IqFrontend::new(
+                TEST_SAMPLE_RATE,
+                0,
+                TEST_FFT_SIZE,
+                FftWindow::Nuttall,
+                false
+            )
+            .is_err()
+        );
     }
 
     #[test]
     fn test_set_decimation_zero_rejected() {
-        let mut fe = IqFrontend::new(TEST_SAMPLE_RATE, 1, TEST_FFT_SIZE, FftWindow::Nuttall, false).unwrap();
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
         assert!(fe.set_decimation(0).is_err());
         // State should be unchanged after rejection
         assert_eq!(fe.decim_ratio(), 1);

--- a/crates/sdr-sink-network/src/lib.rs
+++ b/crates/sdr-sink-network/src/lib.rs
@@ -21,6 +21,9 @@ use sdr_types::{Protocol, SinkError, Stereo};
 use std::io::Write;
 use std::net::{TcpListener, TcpStream, UdpSocket};
 
+/// Default network sink sample rate.
+const DEFAULT_SAMPLE_RATE: f64 = 48_000.0;
+
 /// Network audio output sink.
 ///
 /// Sends audio samples over TCP (server) or UDP in int16 format.
@@ -31,9 +34,12 @@ pub struct NetworkSink {
     sample_rate: f64,
     stereo: bool,
     connection: Option<NetworkSinkConnection>,
+    // Pre-allocated buffers to avoid hot-path allocation
+    send_buf: Vec<u8>,
+    // Cached UDP target address
+    cached_addr: String,
 }
 
-#[allow(dead_code)]
 enum NetworkSinkConnection {
     TcpServer {
         listener: TcpListener,
@@ -49,9 +55,11 @@ impl NetworkSink {
             hostname: hostname.to_string(),
             port,
             protocol,
-            sample_rate: 48_000.0,
+            sample_rate: DEFAULT_SAMPLE_RATE,
             stereo: false,
             connection: None,
+            send_buf: Vec::new(),
+            cached_addr: format!("{hostname}:{port}"),
         }
     }
 
@@ -63,41 +71,64 @@ impl NetworkSink {
     /// Write audio samples to the network.
     ///
     /// Converts f32 stereo samples to int16 before sending.
+    /// For TCP server mode, polls for new client connections before writing.
     pub fn write_stereo_samples(&mut self, samples: &[Stereo]) -> Result<(), SinkError> {
         let conn = self.connection.as_mut().ok_or(SinkError::NotRunning)?;
 
-        // Convert to int16
-        let sample_count = if self.stereo {
-            samples.len() * 2
+        // TCP: poll for incoming client connections (non-blocking accept)
+        if let NetworkSinkConnection::TcpServer { listener, client } = conn
+            && client.is_none()
+        {
+            match listener.accept() {
+                Ok((stream, addr)) => {
+                    tracing::info!("network sink: TCP client connected from {addr}");
+                    *client = Some(stream);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // No client waiting — that's fine
+                }
+                Err(e) => {
+                    tracing::warn!("network sink: TCP accept error: {e}");
+                }
+            }
+        }
+
+        // Convert to int16 using pre-allocated buffer
+        let byte_count = if self.stereo {
+            samples.len() * 4
         } else {
-            samples.len()
+            samples.len() * 2
         };
-        let mut buf = vec![0u8; sample_count * 2];
+        self.send_buf.resize(byte_count, 0);
 
         if self.stereo {
             for (i, s) in samples.iter().enumerate() {
                 let l = (s.l.clamp(-1.0, 1.0) * 32767.0) as i16;
                 let r = (s.r.clamp(-1.0, 1.0) * 32767.0) as i16;
-                buf[i * 4..i * 4 + 2].copy_from_slice(&l.to_le_bytes());
-                buf[i * 4 + 2..i * 4 + 4].copy_from_slice(&r.to_le_bytes());
+                self.send_buf[i * 4..i * 4 + 2].copy_from_slice(&l.to_le_bytes());
+                self.send_buf[i * 4 + 2..i * 4 + 4].copy_from_slice(&r.to_le_bytes());
             }
         } else {
-            // Mono: average L and R
             for (i, s) in samples.iter().enumerate() {
                 let mono = (((s.l + s.r) / 2.0).clamp(-1.0, 1.0) * 32767.0) as i16;
-                buf[i * 2..i * 2 + 2].copy_from_slice(&mono.to_le_bytes());
+                self.send_buf[i * 2..i * 2 + 2].copy_from_slice(&mono.to_le_bytes());
             }
         }
 
         match conn {
             NetworkSinkConnection::TcpServer { client, .. } => {
-                if let Some(stream) = client {
-                    stream.write_all(&buf).map_err(SinkError::Io)?;
+                if let Some(stream) = client
+                    && let Err(e) = stream.write_all(&self.send_buf)
+                {
+                    tracing::warn!("TCP client disconnected: {e}");
+                    *client = None;
                 }
+                // No client connected — silently drop (matching C++ behavior)
             }
             NetworkSinkConnection::Udp(socket) => {
-                let addr = format!("{}:{}", self.hostname, self.port);
-                socket.send_to(&buf, &addr).map_err(SinkError::Io)?;
+                socket
+                    .send_to(&self.send_buf, &self.cached_addr)
+                    .map_err(SinkError::Io)?;
             }
         }
 
@@ -155,15 +186,16 @@ mod tests {
     fn test_new() {
         let sink = NetworkSink::new("localhost", 7355, Protocol::Udp);
         assert_eq!(sink.name(), "Network");
-        assert!((sink.sample_rate() - 48_000.0).abs() < f64::EPSILON);
+        assert!((sink.sample_rate() - DEFAULT_SAMPLE_RATE).abs() < f64::EPSILON);
+        assert_eq!(sink.cached_addr, "localhost:7355");
     }
 
     #[test]
-    fn test_stereo_conversion() {
-        let _samples = [Stereo::new(0.5, -0.5)];
-        // Verify construction works (can't test write without connection)
+    fn test_send_buf_reuse() {
         let mut sink = NetworkSink::new("localhost", 7355, Protocol::Udp);
-        sink.set_stereo(true);
-        // Can't write without a connection, but the conversion logic is tested implicitly
+        sink.set_stereo(false);
+        // Verify send_buf grows but is reused
+        let _samples = [Stereo::new(0.5, -0.5)];
+        assert!(sink.send_buf.is_empty());
     }
 }

--- a/crates/sdr-sink-network/src/lib.rs
+++ b/crates/sdr-sink-network/src/lib.rs
@@ -19,7 +19,7 @@
 use sdr_pipeline::sink_manager::Sink;
 use sdr_types::{Protocol, SinkError, Stereo};
 use std::io::Write;
-use std::net::{TcpListener, TcpStream, UdpSocket};
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 
 /// Default network sink sample rate.
 const DEFAULT_SAMPLE_RATE: f64 = 48_000.0;
@@ -36,8 +36,8 @@ pub struct NetworkSink {
     connection: Option<NetworkSinkConnection>,
     // Pre-allocated buffers to avoid hot-path allocation
     send_buf: Vec<u8>,
-    // Cached UDP target address
-    cached_addr: String,
+    // Resolved UDP target address (avoids ToSocketAddrs parsing on every send)
+    cached_addr: Option<SocketAddr>,
 }
 
 enum NetworkSinkConnection {
@@ -59,7 +59,7 @@ impl NetworkSink {
             stereo: false,
             connection: None,
             send_buf: Vec::new(),
-            cached_addr: format!("{hostname}:{port}"),
+            cached_addr: None,
         }
     }
 
@@ -131,9 +131,11 @@ impl NetworkSink {
                 // No client connected — silently drop (matching C++ behavior)
             }
             NetworkSinkConnection::Udp(socket) => {
-                socket
-                    .send_to(&self.send_buf, &self.cached_addr)
-                    .map_err(SinkError::Io)?;
+                if let Some(addr) = self.cached_addr {
+                    socket
+                        .send_to(&self.send_buf, addr)
+                        .map_err(SinkError::Io)?;
+                }
             }
         }
 
@@ -159,6 +161,18 @@ impl Sink for NetworkSink {
                 }
             }
             Protocol::Udp => {
+                // Resolve target address once at startup (avoids per-packet parsing)
+                let target = (self.hostname.as_str(), self.port)
+                    .to_socket_addrs()
+                    .map_err(SinkError::Io)?
+                    .next()
+                    .ok_or_else(|| {
+                        SinkError::Io(std::io::Error::new(
+                            std::io::ErrorKind::AddrNotAvailable,
+                            format!("could not resolve {}:{}", self.hostname, self.port),
+                        ))
+                    })?;
+                self.cached_addr = Some(target);
                 let socket =
                     UdpSocket::bind(format!("0.0.0.0:{}", self.port)).map_err(SinkError::Io)?;
                 NetworkSinkConnection::Udp(socket)
@@ -192,15 +206,12 @@ mod tests {
         let sink = NetworkSink::new("localhost", 7355, Protocol::Udp);
         assert_eq!(sink.name(), "Network");
         assert!((sink.sample_rate() - DEFAULT_SAMPLE_RATE).abs() < f64::EPSILON);
-        assert_eq!(sink.cached_addr, "localhost:7355");
+        assert!(sink.cached_addr.is_none());
     }
 
     #[test]
-    fn test_send_buf_reuse() {
-        let mut sink = NetworkSink::new("localhost", 7355, Protocol::Udp);
-        sink.set_stereo(false);
-        // Verify send_buf grows but is reused
-        let _samples = [Stereo::new(0.5, -0.5)];
+    fn test_send_buf_initially_empty() {
+        let sink = NetworkSink::new("localhost", 7355, Protocol::Udp);
         assert!(sink.send_buf.is_empty());
     }
 }

--- a/crates/sdr-sink-network/src/lib.rs
+++ b/crates/sdr-sink-network/src/lib.rs
@@ -82,6 +82,11 @@ impl NetworkSink {
             match listener.accept() {
                 Ok((stream, addr)) => {
                     tracing::info!("network sink: TCP client connected from {addr}");
+                    // Accepted stream inherits nonblocking from listener —
+                    // switch to blocking so write_all works correctly.
+                    if let Err(e) = stream.set_nonblocking(false) {
+                        tracing::warn!("network sink: failed to set TCP stream blocking: {e}");
+                    }
                     *client = Some(stream);
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {

--- a/crates/sdr-source-network/src/lib.rs
+++ b/crates/sdr-source-network/src/lib.rs
@@ -73,17 +73,15 @@ impl NetworkSource {
         let sample_size = self.sample_format.complex_byte_size();
         let max_bytes = output.len() * sample_size;
 
-        // Ensure recv_buf is large enough
-        self.recv_buf.resize(max_bytes + self.carry_buf.len(), 0);
-
-        // Prepend any carry-over bytes from previous call
-        let carry_len = self.carry_buf.len();
-        if carry_len > 0 {
-            self.recv_buf[..carry_len].copy_from_slice(&self.carry_buf);
-        }
-
         let bytes_read = match &mut self.connection {
             Some(NetworkConnection::Tcp(stream)) => {
+                // TCP is a byte stream — prepend carry-over from previous partial read
+                let carry_len = self.carry_buf.len();
+                self.recv_buf.resize(max_bytes + carry_len, 0);
+                if carry_len > 0 {
+                    self.recv_buf[..carry_len].copy_from_slice(&self.carry_buf);
+                }
+
                 let n = stream
                     .read(&mut self.recv_buf[carry_len..])
                     .map_err(SourceError::Io)?;
@@ -96,10 +94,12 @@ impl NetworkSource {
                 carry_len + n
             }
             Some(NetworkConnection::Udp(socket)) => {
+                // UDP delivers complete datagrams — no carry-over needed
+                self.recv_buf.resize(max_bytes, 0);
                 let (n, _addr) = socket
-                    .recv_from(&mut self.recv_buf[carry_len..])
+                    .recv_from(&mut self.recv_buf)
                     .map_err(SourceError::Io)?;
-                carry_len + n
+                n
             }
             None => return Err(SourceError::NotRunning),
         };
@@ -115,10 +115,10 @@ impl NetworkSource {
             count,
         );
 
-        // Carry over incomplete bytes for next call
+        // Carry over incomplete bytes for TCP only (UDP datagrams are atomic)
         let leftover = bytes_read - complete_bytes;
         self.carry_buf.clear();
-        if leftover > 0 {
+        if leftover > 0 && matches!(self.connection, Some(NetworkConnection::Tcp(_))) {
             self.carry_buf
                 .extend_from_slice(&self.recv_buf[complete_bytes..bytes_read]);
         }

--- a/crates/sdr-source-network/src/lib.rs
+++ b/crates/sdr-source-network/src/lib.rs
@@ -24,6 +24,7 @@ use std::net::{TcpStream, UdpSocket};
 /// Network IQ source for the pipeline.
 ///
 /// Receives complex IQ samples over TCP or UDP with format conversion.
+/// Carries incomplete sample bytes across calls to prevent stream misalignment.
 pub struct NetworkSource {
     hostname: String,
     port: u16,
@@ -32,6 +33,10 @@ pub struct NetworkSource {
     sample_rate: f64,
     frequency: f64,
     connection: Option<NetworkConnection>,
+    // Pre-allocated receive buffer (reused across calls)
+    recv_buf: Vec<u8>,
+    // Carry-over buffer for incomplete samples from TCP partial reads
+    carry_buf: Vec<u8>,
 }
 
 enum NetworkConnection {
@@ -50,6 +55,8 @@ impl NetworkSource {
             sample_rate: 1_000_000.0,
             frequency: 0.0,
             connection: None,
+            recv_buf: Vec::new(),
+            carry_buf: Vec::new(),
         }
     }
 
@@ -61,39 +68,67 @@ impl NetworkSource {
     /// Read samples from the network connection and convert to Complex.
     ///
     /// Returns the number of Complex samples written.
+    /// Carries incomplete sample bytes across calls for TCP streams.
     pub fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
         let sample_size = self.sample_format.complex_byte_size();
         let max_bytes = output.len() * sample_size;
-        let mut buf = vec![0u8; max_bytes];
+
+        // Ensure recv_buf is large enough
+        self.recv_buf.resize(max_bytes + self.carry_buf.len(), 0);
+
+        // Prepend any carry-over bytes from previous call
+        let carry_len = self.carry_buf.len();
+        if carry_len > 0 {
+            self.recv_buf[..carry_len].copy_from_slice(&self.carry_buf);
+        }
 
         let bytes_read = match &mut self.connection {
             Some(NetworkConnection::Tcp(stream)) => {
-                stream.read(&mut buf).map_err(SourceError::Io)?
+                let n = stream
+                    .read(&mut self.recv_buf[carry_len..])
+                    .map_err(SourceError::Io)?;
+                if n == 0 {
+                    // TCP EOF — connection closed
+                    return Err(SourceError::Io(std::io::Error::from(
+                        std::io::ErrorKind::UnexpectedEof,
+                    )));
+                }
+                carry_len + n
             }
             Some(NetworkConnection::Udp(socket)) => {
-                let (n, _addr) = socket.recv_from(&mut buf).map_err(SourceError::Io)?;
-                n
+                let (n, _addr) = socket
+                    .recv_from(&mut self.recv_buf[carry_len..])
+                    .map_err(SourceError::Io)?;
+                carry_len + n
             }
             None => return Err(SourceError::NotRunning),
         };
 
-        let count = bytes_read / sample_size;
-        Ok(convert_samples(
-            &buf[..bytes_read],
+        // Convert only complete samples
+        let complete_bytes = (bytes_read / sample_size) * sample_size;
+        let count = complete_bytes / sample_size;
+
+        convert_samples(
+            &self.recv_buf[..complete_bytes],
             output,
             self.sample_format,
             count,
-        ))
+        );
+
+        // Carry over incomplete bytes for next call
+        let leftover = bytes_read - complete_bytes;
+        self.carry_buf.clear();
+        if leftover > 0 {
+            self.carry_buf
+                .extend_from_slice(&self.recv_buf[complete_bytes..bytes_read]);
+        }
+
+        Ok(count)
     }
 }
 
 /// Convert raw network bytes to Complex f32 samples.
-fn convert_samples(
-    raw: &[u8],
-    output: &mut [Complex],
-    format: SampleFormat,
-    count: usize,
-) -> usize {
+fn convert_samples(raw: &[u8], output: &mut [Complex], format: SampleFormat, count: usize) {
     let count = count.min(output.len());
     match format {
         SampleFormat::Int8 => {
@@ -147,7 +182,6 @@ fn convert_samples(
             }
         }
     }
-    count
 }
 
 impl Source for NetworkSource {
@@ -168,22 +202,22 @@ impl Source for NetworkSource {
             }
         };
         self.connection = Some(conn);
+        self.carry_buf.clear();
         Ok(())
     }
 
     fn stop(&mut self) -> Result<(), SourceError> {
         self.connection = None;
+        self.carry_buf.clear();
         Ok(())
     }
 
     fn tune(&mut self, frequency_hz: f64) -> Result<(), SourceError> {
         self.frequency = frequency_hz;
-        // Network source doesn't tune — frequency is informational
         Ok(())
     }
 
     fn sample_rates(&self) -> &[f64] {
-        // Network source accepts any sample rate
         &[]
     }
 
@@ -198,12 +232,12 @@ impl Source for NetworkSource {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_convert_int16() {
-        // Int16: 32767 = max positive, -32768 = max negative
         let raw: [u8; 8] = [
             0xff, 0x7f, // re = 32767
             0x00, 0x80, // im = -32768
@@ -211,8 +245,7 @@ mod tests {
             0x00, 0x00, // im = 0
         ];
         let mut output = [Complex::default(); 2];
-        let count = convert_samples(&raw, &mut output, SampleFormat::Int16, 2);
-        assert_eq!(count, 2);
+        convert_samples(&raw, &mut output, SampleFormat::Int16, 2);
         assert!((output[0].re - 1.0).abs() < 0.001);
         assert!((output[0].im - (-1.0)).abs() < 0.001);
         assert!((output[1].re).abs() < 0.001);
@@ -227,8 +260,7 @@ mod tests {
         raw[4..8].copy_from_slice(&im_bytes);
 
         let mut output = [Complex::default(); 1];
-        let count = convert_samples(&raw, &mut output, SampleFormat::Float32, 1);
-        assert_eq!(count, 1);
+        convert_samples(&raw, &mut output, SampleFormat::Float32, 1);
         assert!((output[0].re - 0.5).abs() < 1e-6);
         assert!((output[0].im - (-0.25)).abs() < 1e-6);
     }
@@ -237,5 +269,15 @@ mod tests {
     fn test_new() {
         let source = NetworkSource::new("localhost", 1234, Protocol::Udp);
         assert_eq!(source.name(), "Network");
+        assert!(source.carry_buf.is_empty());
+    }
+
+    #[test]
+    fn test_carry_buf_cleared_on_start_stop() {
+        let mut source = NetworkSource::new("localhost", 1234, Protocol::Udp);
+        source.carry_buf.push(0x42);
+        // Stop clears carry buffer
+        source.stop().unwrap();
+        assert!(source.carry_buf.is_empty());
     }
 }

--- a/crates/sdr-source-network/src/lib.rs
+++ b/crates/sdr-source-network/src/lib.rs
@@ -70,6 +70,9 @@ impl NetworkSource {
     /// Returns the number of Complex samples written.
     /// Carries incomplete sample bytes across calls for TCP streams.
     pub fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+        if output.is_empty() {
+            return Ok(0);
+        }
         let sample_size = self.sample_format.complex_byte_size();
         let max_bytes = output.len() * sample_size;
 


### PR DESCRIPTION
## Summary

Fixes 4 deferred audit issues.

### #64: IqFrontend decimation stage
- Added `PowerDecimator` with configurable ratio (power-of-2)
- `effective_sample_rate = sample_rate / decim_ratio`
- DC blocker rate computed from effective rate (50.0/sr matching C++)
- `set_decimation()` for dynamic ratio changes

### #68: IqFrontend FFT sample accumulation
- Samples accumulate in `fft_accum` buffer across `process()` calls
- FFT only computed when `fft_size` samples available
- Returns `(count, fft_ready)` tuple — no more zero-padded partial FFTs

### #71: Network sink TCP accept + hot-path allocations
- TCP server polls `accept()` on each write (non-blocking)
- Pre-allocated `send_buf` eliminates per-call Vec allocation
- Cached UDP address string eliminates per-send `format!()`
- Client auto-clears on disconnect for re-accept

### #72: Network source TCP buffering
- `carry_buf` holds incomplete sample bytes across calls
- TCP partial reads no longer cause stream misalignment
- TCP EOF surfaced as `UnexpectedEof` error
- Pre-allocated `recv_buf` reused across calls

## Test plan

- [x] 240 tests passing
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] FFT accumulation: 4 chunks of 256 → fires at 1024
- [x] Decimation: 2x reduces ~2048 input to ~1024 output
- [x] Network carry buffer cleared on start/stop

Closes #64 #68 #71 #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable power-decimation with runtime decimation control and updated FFT readiness signaling
* **Improvements**
  * FFT accumulation now computes only when enough samples collected
  * Reduced memory allocations via send/receive buffer reuse and cached network address
  * Better handling of partial TCP reads and EOF; more stable TCP client acceptance and UDP sends
* **Bug Fixes**
  * Invalid decimation ratios are rejected and handled safely
<!-- end of auto-generated comment: release notes by coderabbit.ai -->