### PR TITLE
Port remaining tuner drivers: E4000, FC0012, FC0013, FC2580

### DIFF
--- a/crates/sdr-rtlsdr/src/tuner/e4k.rs
+++ b/crates/sdr-rtlsdr/src/tuner/e4k.rs
@@ -1231,7 +1231,11 @@ impl Tuner for E4kTuner {
         handle: &rusb::DeviceHandle<rusb::GlobalContext>,
         gain: i32,
     ) -> Result<(), RtlSdrError> {
-        let mixgain: i8 = if gain > MIXER_GAIN_THRESH { 12 } else { 4 };
+        let mixgain: i8 = if gain > MIXER_GAIN_THRESH {
+            MIXER_GAIN_12DB
+        } else {
+            MIXER_GAIN_4DB
+        };
 
         // LNA gain: gain minus mixer contribution, capped at 300 (tenths of dB)
         let lna_gain = (gain - i32::from(mixgain) * 10).min(MAX_LNA_GAIN);

--- a/crates/sdr-rtlsdr/src/tuner/e4k.rs
+++ b/crates/sdr-rtlsdr/src/tuner/e4k.rs
@@ -1,0 +1,1577 @@
+//! Elonics E4000 tuner driver.
+//!
+//! Faithful port of `tuner_e4k.c` from librtlsdr.
+//!
+//! Original copyright:
+//! - Copyright (C) 2011-2012 by Harald Welte <laforge@gnumonks.org>
+//! - Copyright (C) 2012 by Sylvain Munaut <tnt@246tNt.com>
+//! - Copyright (C) 2012 by Hoernchen <la@tfc-server.de>
+
+use crate::error::RtlSdrError;
+use crate::tuner::Tuner;
+use crate::usb;
+
+// ---------------------------------------------------------------------------
+// I2C address and identification
+// ---------------------------------------------------------------------------
+
+/// E4000 I2C address.
+pub const I2C_ADDR: u8 = 0xc8;
+
+/// Register address used to identify the E4000 (MASTER3 register).
+pub const CHECK_ADDR: u8 = 0x02;
+
+/// Expected chip ID value read from `CHECK_ADDR`.
+pub const CHECK_VAL: u8 = 0x40;
+
+// ---------------------------------------------------------------------------
+// Register addresses
+// ---------------------------------------------------------------------------
+
+const REG_MASTER1: u8 = 0x00;
+const REG_SYNTH1: u8 = 0x07;
+const REG_SYNTH3: u8 = 0x09;
+const REG_SYNTH4: u8 = 0x0a;
+const REG_SYNTH5: u8 = 0x0b;
+const REG_SYNTH7: u8 = 0x0d;
+const REG_FILT1: u8 = 0x10;
+const REG_FILT2: u8 = 0x11;
+const REG_FILT3: u8 = 0x12;
+const REG_GAIN1: u8 = 0x14;
+const REG_GAIN2: u8 = 0x15;
+const REG_GAIN3: u8 = 0x16;
+const REG_GAIN4: u8 = 0x17;
+const REG_AGC1: u8 = 0x1a;
+const REG_AGC4: u8 = 0x1d;
+const REG_AGC5: u8 = 0x1e;
+const REG_AGC6: u8 = 0x1f;
+const REG_AGC7: u8 = 0x20;
+const REG_AGC11: u8 = 0x24;
+// DC offset registers — used by dc_offset_gen_table (ported from C `#if 0` block)
+#[allow(dead_code)]
+const REG_DC1: u8 = 0x29;
+#[allow(dead_code)]
+const REG_DC2: u8 = 0x2a;
+#[allow(dead_code)]
+const REG_DC3: u8 = 0x2b;
+#[allow(dead_code)]
+const REG_DC4: u8 = 0x2c;
+#[allow(dead_code)]
+const REG_DC5: u8 = 0x2d;
+#[allow(dead_code)]
+const REG_DC7: u8 = 0x2f;
+const REG_DCTIME1: u8 = 0x70;
+const REG_DCTIME2: u8 = 0x71;
+const REG_BIAS: u8 = 0x78;
+const REG_CLKOUT_PWDN: u8 = 0x7a;
+const REG_REF_CLK: u8 = 0x06;
+const REG_CLK_INP: u8 = 0x05;
+
+// ---------------------------------------------------------------------------
+// Register bit masks and values
+// ---------------------------------------------------------------------------
+
+/// MASTER1 register: reset bit.
+const MASTER1_RESET: u8 = 1 << 0;
+
+/// MASTER1 register: normal standby bit.
+const MASTER1_NORM_STBY: u8 = 1 << 1;
+
+/// MASTER1 register: power-on-reset detect bit.
+const MASTER1_POR_DET: u8 = 1 << 2;
+
+/// FILT3 register: channel filter disable bit.
+const FILT3_DISABLE: u8 = 1 << 5;
+
+/// AGC1 register: mode mask (lower 4 bits).
+const AGC1_MOD_MASK: u8 = 0x0f;
+
+/// AGC7 register: mixer gain auto bit.
+const AGC7_MIX_GAIN_AUTO: u8 = 1 << 0;
+
+/// AGC11 register: LNA gain enhancement enable bit.
+#[allow(dead_code)]
+const AGC11_LNA_GAIN_ENH: u8 = 1 << 0;
+
+/// DC5 register: range detect enable bit.
+#[allow(dead_code)]
+const DC5_RANGE_DET_EN: u8 = 1 << 2;
+
+/// Clock output disable value.
+const CLKOUT_DISABLE: u8 = 0x96;
+
+// ---------------------------------------------------------------------------
+// AGC mode values
+// ---------------------------------------------------------------------------
+
+/// AGC mode: serial (fully manual).
+const AGC_MOD_SERIAL: u8 = 0x00;
+
+/// AGC mode: IF serial, LNA autonomous.
+const AGC_MOD_IF_SERIAL_LNA_AUTON: u8 = 0x09;
+
+// ---------------------------------------------------------------------------
+// PLL constants
+// ---------------------------------------------------------------------------
+
+/// PLL Y constant (sigma-delta modulator denominator).
+const PLL_Y: u64 = 65536;
+
+/// Minimum valid oscillator frequency (16 MHz).
+const FOSC_MIN: u32 = 16_000_000;
+
+/// Maximum valid oscillator frequency (30 MHz).
+const FOSC_MAX: u32 = 30_000_000;
+
+/// 3-phase mixing threshold frequency (350 MHz).
+#[allow(dead_code)]
+const THREE_PHASE_MIXING_THRESH: u32 = 350_000_000;
+
+/// Band boundary: VHF2/VHF3 at 140 MHz.
+const BAND_VHF2_MAX: u32 = 140_000_000;
+
+/// Band boundary: VHF3/UHF at 350 MHz.
+const BAND_VHF3_MAX: u32 = 350_000_000;
+
+/// Band boundary: UHF/L at 1135 MHz.
+const BAND_UHF_MAX: u32 = 1_135_000_000;
+
+// ---------------------------------------------------------------------------
+// Frequency band enumeration
+// ---------------------------------------------------------------------------
+
+/// E4000 frequency band selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Band {
+    Vhf2 = 0,
+    Vhf3 = 1,
+    Uhf = 2,
+    L = 3,
+}
+
+// ---------------------------------------------------------------------------
+// IF filter type
+// ---------------------------------------------------------------------------
+
+/// E4000 IF filter selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(usize)]
+enum IfFilter {
+    Mix = 0,
+    Chan = 1,
+    Rc = 2,
+}
+
+// ---------------------------------------------------------------------------
+// Register field descriptor (for field read/write helpers)
+// ---------------------------------------------------------------------------
+
+/// Describes a bit field within a register.
+struct RegField {
+    reg: u8,
+    shift: u8,
+    width: u8,
+}
+
+// ---------------------------------------------------------------------------
+// Width-to-mask lookup table
+// ---------------------------------------------------------------------------
+
+/// Bit-width to mask lookup: `WIDTH_MASK[n]` = (1 << n) - 1.
+const WIDTH_MASK: [u8; 9] = [0, 1, 3, 7, 0x0f, 0x1f, 0x3f, 0x7f, 0xff];
+
+// ---------------------------------------------------------------------------
+// PLL settings table
+// ---------------------------------------------------------------------------
+
+/// PLL divider settings entry.
+struct PllSettings {
+    /// Maximum frequency in kHz (exclusive upper bound for this entry).
+    freq_khz: u32,
+    /// REG_SYNTH7 register value (3-phase enable + divider index).
+    reg_synth7: u8,
+    /// VCO frequency multiplier.
+    mult: u8,
+}
+
+/// PLL divider table, ordered by ascending maximum frequency.
+#[allow(clippy::identity_op)]
+const PLL_VARS: [PllSettings; 10] = [
+    PllSettings {
+        freq_khz: 72_400,
+        reg_synth7: (1 << 3) | 7,
+        mult: 48,
+    },
+    PllSettings {
+        freq_khz: 81_200,
+        reg_synth7: (1 << 3) | 6,
+        mult: 40,
+    },
+    PllSettings {
+        freq_khz: 108_300,
+        reg_synth7: (1 << 3) | 5,
+        mult: 32,
+    },
+    PllSettings {
+        freq_khz: 162_500,
+        reg_synth7: (1 << 3) | 4,
+        mult: 24,
+    },
+    PllSettings {
+        freq_khz: 216_600,
+        reg_synth7: (1 << 3) | 3,
+        mult: 16,
+    },
+    PllSettings {
+        freq_khz: 325_000,
+        reg_synth7: (1 << 3) | 2,
+        mult: 12,
+    },
+    PllSettings {
+        freq_khz: 350_000,
+        reg_synth7: (1 << 3) | 1,
+        mult: 8,
+    },
+    PllSettings {
+        freq_khz: 432_000,
+        reg_synth7: (0 << 3) | 3,
+        mult: 8,
+    },
+    PllSettings {
+        freq_khz: 667_000,
+        reg_synth7: (0 << 3) | 2,
+        mult: 6,
+    },
+    PllSettings {
+        freq_khz: 1_200_000,
+        reg_synth7: (0 << 3) | 1,
+        mult: 4,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// RF filter center frequency tables
+// ---------------------------------------------------------------------------
+
+/// UHF band RF filter center frequencies in Hz.
+const RF_FILT_CENTER_UHF: [u32; 16] = [
+    360_000_000,
+    380_000_000,
+    405_000_000,
+    425_000_000,
+    450_000_000,
+    475_000_000,
+    505_000_000,
+    540_000_000,
+    575_000_000,
+    615_000_000,
+    670_000_000,
+    720_000_000,
+    760_000_000,
+    840_000_000,
+    890_000_000,
+    970_000_000,
+];
+
+/// L band RF filter center frequencies in Hz.
+const RF_FILT_CENTER_L: [u32; 16] = [
+    1_300_000_000,
+    1_320_000_000,
+    1_360_000_000,
+    1_410_000_000,
+    1_445_000_000,
+    1_460_000_000,
+    1_490_000_000,
+    1_530_000_000,
+    1_560_000_000,
+    1_590_000_000,
+    1_640_000_000,
+    1_660_000_000,
+    1_680_000_000,
+    1_700_000_000,
+    1_720_000_000,
+    1_750_000_000,
+];
+
+// ---------------------------------------------------------------------------
+// IF filter bandwidth tables
+// ---------------------------------------------------------------------------
+
+/// Mixer filter bandwidth values in Hz.
+const MIX_FILTER_BW: [u32; 16] = [
+    27_000_000, 27_000_000, 27_000_000, 27_000_000, 27_000_000, 27_000_000, 27_000_000, 27_000_000,
+    4_600_000, 4_200_000, 3_800_000, 3_400_000, 3_300_000, 2_700_000, 2_300_000, 1_900_000,
+];
+
+/// IF RC filter bandwidth values in Hz.
+const IFRC_FILTER_BW: [u32; 16] = [
+    21_400_000, 21_000_000, 17_600_000, 14_700_000, 12_400_000, 10_600_000, 9_000_000, 7_700_000,
+    6_400_000, 5_300_000, 4_400_000, 3_400_000, 2_600_000, 1_800_000, 1_200_000, 1_000_000,
+];
+
+/// IF channel filter bandwidth values in Hz.
+const IFCH_FILTER_BW: [u32; 32] = [
+    5_500_000, 5_300_000, 5_000_000, 4_800_000, 4_600_000, 4_400_000, 4_300_000, 4_100_000,
+    3_900_000, 3_800_000, 3_700_000, 3_600_000, 3_400_000, 3_300_000, 3_200_000, 3_100_000,
+    3_000_000, 2_950_000, 2_900_000, 2_800_000, 2_750_000, 2_700_000, 2_600_000, 2_550_000,
+    2_500_000, 2_450_000, 2_400_000, 2_300_000, 2_280_000, 2_240_000, 2_200_000, 2_150_000,
+];
+
+/// IF filter register field descriptors, indexed by `IfFilter`.
+const IF_FILTER_FIELDS: [RegField; 3] = [
+    RegField {
+        reg: REG_FILT2,
+        shift: 4,
+        width: 4,
+    },
+    RegField {
+        reg: REG_FILT3,
+        shift: 0,
+        width: 5,
+    },
+    RegField {
+        reg: REG_FILT2,
+        shift: 0,
+        width: 4,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// IF stage gain tables
+// ---------------------------------------------------------------------------
+
+/// IF gain stage 1 values in dB (2 entries, 1-bit field).
+const IF_STAGE1_GAIN: [i8; 2] = [-3, 6];
+
+/// IF gain stages 2 and 3 values in dB (4 entries, 2-bit field).
+const IF_STAGE23_GAIN: [i8; 4] = [0, 3, 6, 9];
+
+/// IF gain stage 4 values in dB (4 entries, 2-bit field).
+const IF_STAGE4_GAIN: [i8; 4] = [0, 1, 2, 2];
+
+/// IF gain stages 5 and 6 values in dB (8 entries, 3-bit field).
+const IF_STAGE56_GAIN: [i8; 8] = [3, 6, 9, 12, 15, 15, 15, 15];
+
+/// Maximum IF gain per stage (indexed 0..6, stage 0 unused).
+/// Used by `dc_offset_gen_table` (ported from C `#if 0` block).
+#[allow(dead_code)]
+const IF_GAINS_MAX: [i8; 7] = [0, 6, 9, 9, 2, 15, 15];
+
+/// IF gain stage register field descriptors (indexed 0..6, stage 0 unused).
+const IF_STAGE_GAIN_REGS: [RegField; 7] = [
+    RegField {
+        reg: 0,
+        shift: 0,
+        width: 0,
+    },
+    RegField {
+        reg: REG_GAIN3,
+        shift: 0,
+        width: 1,
+    },
+    RegField {
+        reg: REG_GAIN3,
+        shift: 1,
+        width: 2,
+    },
+    RegField {
+        reg: REG_GAIN3,
+        shift: 3,
+        width: 2,
+    },
+    RegField {
+        reg: REG_GAIN3,
+        shift: 5,
+        width: 2,
+    },
+    RegField {
+        reg: REG_GAIN4,
+        shift: 0,
+        width: 3,
+    },
+    RegField {
+        reg: REG_GAIN4,
+        shift: 3,
+        width: 3,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// LNA gain table
+// ---------------------------------------------------------------------------
+
+/// LNA gain table: pairs of (gain in tenths of dB, register value).
+const LNA_GAIN: [(i32, u8); 13] = [
+    (-50, 0),
+    (-25, 1),
+    (0, 4),
+    (25, 5),
+    (50, 6),
+    (75, 7),
+    (100, 8),
+    (125, 9),
+    (150, 10),
+    (175, 11),
+    (200, 12),
+    (250, 13),
+    (300, 14),
+];
+
+/// LNA gain mask in GAIN1 register (lower 4 bits).
+const LNA_GAIN_MASK: u8 = 0x0f;
+
+// ---------------------------------------------------------------------------
+// Enhancement gain table
+// ---------------------------------------------------------------------------
+
+/// Enhancement gain values in tenths of dB.
+/// Used by `set_enh_gain` (ported from C `#if 0` block).
+#[allow(dead_code)]
+const ENH_GAIN: [i32; 4] = [10, 30, 50, 70];
+
+/// Enhancement gain mask in AGC11 register (lower 3 bits).
+#[allow(dead_code)]
+const ENH_GAIN_MASK: u8 = 0x07;
+
+// ---------------------------------------------------------------------------
+// Mixer gain constants
+// ---------------------------------------------------------------------------
+
+/// Mixer gain value for 4 dB.
+const MIXER_GAIN_4DB: i8 = 4;
+
+/// Mixer gain value for 12 dB.
+const MIXER_GAIN_12DB: i8 = 12;
+
+/// Mixer gain threshold for `set_gain` (tenths of dB): above 340, use 12 dB.
+const MIXER_GAIN_THRESH: i32 = 340;
+
+/// Maximum LNA gain value for `set_gain` (tenths of dB).
+const MAX_LNA_GAIN: i32 = 300;
+
+// ---------------------------------------------------------------------------
+// DC offset calibration gain combinations
+// ---------------------------------------------------------------------------
+
+/// DC offset calibration gain combination entry.
+/// Used by `dc_offset_gen_table` (ported from C `#if 0` block).
+#[allow(dead_code)]
+struct DcGainComb {
+    mixer_gain: i8,
+    if1_gain: i8,
+    reg: u8,
+}
+
+/// DC offset calibration gain combinations.
+#[allow(dead_code)]
+const DC_GAIN_COMB: [DcGainComb; 4] = [
+    DcGainComb {
+        mixer_gain: 4,
+        if1_gain: -3,
+        reg: 0x50,
+    },
+    DcGainComb {
+        mixer_gain: 4,
+        if1_gain: 6,
+        reg: 0x51,
+    },
+    DcGainComb {
+        mixer_gain: 12,
+        if1_gain: -3,
+        reg: 0x52,
+    },
+    DcGainComb {
+        mixer_gain: 12,
+        if1_gain: 6,
+        reg: 0x53,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Gains table (public, for device enumeration)
+// ---------------------------------------------------------------------------
+
+/// Supported gain values in tenths of dB, matching librtlsdr `e4k_gains[]`.
+pub const E4K_GAINS: [i32; 14] = [
+    -10, 15, 40, 65, 90, 115, 140, 165, 190, 215, 240, 290, 340, 420,
+];
+
+// ---------------------------------------------------------------------------
+// Magic init register writes
+// ---------------------------------------------------------------------------
+
+/// Magic initialization register writes (address, value) pairs.
+const MAGIC_INIT_REGS: [(u8, u8); 8] = [
+    (0x7e, 0x01),
+    (0x7f, 0xfe),
+    (0x82, 0x00),
+    (0x86, 0x50), // polarity A
+    (0x87, 0x20),
+    (0x88, 0x01),
+    (0x9f, 0x7f),
+    (0xa0, 0x07),
+];
+
+// ---------------------------------------------------------------------------
+// Init constants
+// ---------------------------------------------------------------------------
+
+/// AGC4 high threshold value during init.
+const INIT_AGC4_HIGH_THRESH: u8 = 0x10;
+
+/// AGC5 low threshold value during init.
+const INIT_AGC5_LOW_THRESH: u8 = 0x04;
+
+/// AGC6 LNA calib + loop rate value during init.
+const INIT_AGC6_LNA_CALIB: u8 = 0x1a;
+
+/// IF filter bandwidth for mixer filter during init (1900 kHz).
+const INIT_IF_FILTER_MIX_BW: u32 = 1_900_000;
+
+/// IF filter bandwidth for RC filter during init (1000 kHz).
+const INIT_IF_FILTER_RC_BW: u32 = 1_000_000;
+
+/// IF filter bandwidth for channel filter during init (2150 kHz).
+const INIT_IF_FILTER_CHAN_BW: u32 = 2_150_000;
+
+/// Initial IF gain stage 1 value (dB).
+const INIT_IF_GAIN_STAGE1: i8 = 6;
+
+/// Initial IF gain stages 2-4 value (dB).
+const INIT_IF_GAIN_STAGES_2_4: i8 = 0;
+
+/// Initial IF gain stages 5-6 value (dB).
+const INIT_IF_GAIN_STAGES_5_6: i8 = 9;
+
+// ---------------------------------------------------------------------------
+// PLL parameters
+// ---------------------------------------------------------------------------
+
+/// Computed PLL parameters for the E4000 tuner.
+#[derive(Debug, Clone, Copy)]
+struct PllParams {
+    /// Oscillator frequency in Hz.
+    fosc: u32,
+    /// Actual tuned LO frequency in Hz.
+    flo: u32,
+    /// Integer part of VCO multiplier.
+    z: u8,
+    /// Fractional part of VCO multiplier.
+    x: u16,
+    /// VCO divisor (used in PLL computation, stored for completeness).
+    #[allow(dead_code)]
+    r: u8,
+    /// REG_SYNTH7 register value.
+    r_idx: u8,
+}
+
+// ---------------------------------------------------------------------------
+// E4000 tuner state
+// ---------------------------------------------------------------------------
+
+/// Elonics E4000 tuner driver.
+///
+/// Ports `e4k_init`, `e4k_tune_freq`, gain control, and filter configuration
+/// from `tuner_e4k.c`.
+pub struct E4kTuner {
+    /// Crystal oscillator frequency in Hz.
+    xtal: u32,
+    /// Current PLL parameters.
+    pll: PllParams,
+    /// Current band selection.
+    band: Band,
+}
+
+impl E4kTuner {
+    /// Create a new E4000 tuner driver.
+    pub fn new(xtal: u32) -> Self {
+        Self {
+            xtal,
+            pll: PllParams {
+                fosc: xtal,
+                flo: 0,
+                z: 0,
+                x: 0,
+                r: 2,
+                r_idx: 0,
+            },
+            band: Band::Vhf2,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Low-level I2C register access
+    // -----------------------------------------------------------------------
+
+    /// Write a single register via I2C.
+    #[allow(clippy::unused_self)]
+    fn write_reg(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+        val: u8,
+    ) -> Result<(), RtlSdrError> {
+        usb::i2c_write_reg(handle, I2C_ADDR, reg, val)
+    }
+
+    /// Read a single register via I2C.
+    #[allow(clippy::unused_self)]
+    fn read_reg(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+    ) -> Result<u8, RtlSdrError> {
+        usb::i2c_read_reg(handle, I2C_ADDR, reg)
+    }
+
+    /// Set or clear masked bits inside a register (read-modify-write).
+    ///
+    /// Ports `e4k_reg_set_mask`.
+    fn reg_set_mask(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+        mask: u8,
+        val: u8,
+    ) -> Result<(), RtlSdrError> {
+        let tmp = self.read_reg(handle, reg)?;
+
+        if (tmp & mask) == (val & mask) {
+            return Ok(());
+        }
+
+        self.write_reg(handle, reg, (tmp & !mask) | (val & mask))
+    }
+
+    /// Write a value to a register bit field.
+    ///
+    /// Ports `e4k_field_write`.
+    fn field_write(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        field: &RegField,
+        val: u8,
+    ) -> Result<(), RtlSdrError> {
+        let mask = WIDTH_MASK[field.width as usize] << field.shift;
+        self.reg_set_mask(handle, field.reg, mask, val << field.shift)
+    }
+
+    // -----------------------------------------------------------------------
+    // Filter control
+    // -----------------------------------------------------------------------
+
+    /// Find the closest index in an array to a target frequency.
+    ///
+    /// Ports `closest_arr_idx`.
+    fn closest_arr_idx(arr: &[u32], freq: u32) -> usize {
+        let mut best_idx = 0;
+        let mut best_delta = u32::MAX;
+
+        for (i, &center) in arr.iter().enumerate() {
+            let delta = freq.abs_diff(center);
+            if delta < best_delta {
+                best_delta = delta;
+                best_idx = i;
+            }
+        }
+
+        best_idx
+    }
+
+    /// Choose the 4-bit RF filter index for a given band and frequency.
+    ///
+    /// Ports `choose_rf_filter`.
+    fn choose_rf_filter(band: Band, freq: u32) -> u8 {
+        match band {
+            Band::Vhf2 | Band::Vhf3 => 0,
+            Band::Uhf => Self::closest_arr_idx(&RF_FILT_CENTER_UHF, freq) as u8,
+            Band::L => Self::closest_arr_idx(&RF_FILT_CENTER_L, freq) as u8,
+        }
+    }
+
+    /// Set the RF filter based on current band and tuned frequency.
+    ///
+    /// Ports `e4k_rf_filter_set`.
+    fn rf_filter_set(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        let rc = Self::choose_rf_filter(self.band, self.pll.flo);
+        self.reg_set_mask(handle, REG_FILT1, 0x0f, rc)
+    }
+
+    /// Find the closest IF filter bandwidth index.
+    ///
+    /// Ports `find_if_bw`.
+    fn find_if_bw(filter: IfFilter, bw: u32) -> u8 {
+        let arr: &[u32] = match filter {
+            IfFilter::Mix => &MIX_FILTER_BW,
+            IfFilter::Chan => &IFCH_FILTER_BW,
+            IfFilter::Rc => &IFRC_FILTER_BW,
+        };
+        Self::closest_arr_idx(arr, bw) as u8
+    }
+
+    /// Set the IF filter bandwidth.
+    ///
+    /// Ports `e4k_if_filter_bw_set`.
+    fn if_filter_bw_set(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        filter: IfFilter,
+        bandwidth: u32,
+    ) -> Result<(), RtlSdrError> {
+        let bw_idx = Self::find_if_bw(filter, bandwidth);
+        let field = &IF_FILTER_FIELDS[filter as usize];
+        self.field_write(handle, field, bw_idx)
+    }
+
+    /// Enable or disable the channel filter.
+    ///
+    /// Ports `e4k_if_filter_chan_enable`.
+    fn if_filter_chan_enable(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        on: bool,
+    ) -> Result<(), RtlSdrError> {
+        self.reg_set_mask(
+            handle,
+            REG_FILT3,
+            FILT3_DISABLE,
+            if on { 0 } else { FILT3_DISABLE },
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // PLL / frequency control
+    // -----------------------------------------------------------------------
+
+    /// Compute PLL parameters for a target frequency.
+    ///
+    /// Ports `e4k_compute_pll_params`. Returns `None` if the oscillator
+    /// frequency is out of range.
+    #[allow(clippy::cast_possible_truncation)]
+    fn compute_pll_params(fosc: u32, intended_flo: u32) -> Option<PllParams> {
+        // Validate oscillator frequency
+        if fosc < FOSC_MIN || fosc > FOSC_MAX {
+            return None;
+        }
+
+        let mut r: u8 = 2;
+        let mut r_idx: u8 = 0;
+
+        // Find the appropriate PLL divider settings
+        let intended_flo_khz = intended_flo / 1000;
+        for entry in &PLL_VARS {
+            if intended_flo_khz < entry.freq_khz {
+                r_idx = entry.reg_synth7;
+                r = entry.mult;
+                break;
+            }
+        }
+
+        // Compute VCO frequency (need 64-bit: flo_max=1700MHz * r_max=48)
+        let intended_fvco = u64::from(intended_flo) * u64::from(r);
+
+        // Compute integer component of multiplier
+        let z = intended_fvco / u64::from(fosc);
+
+        // Compute fractional part
+        let remainder = intended_fvco - u64::from(fosc) * z;
+        let x = ((remainder * PLL_Y) / u64::from(fosc)) as u32;
+
+        // Compute actual LO frequency
+        let fvco = u64::from(fosc) * z + (u64::from(fosc) * u64::from(x as u16)) / PLL_Y;
+        let flo = (fvco / u64::from(r)) as u32;
+
+        Some(PllParams {
+            fosc,
+            flo,
+            z: z as u8,
+            x: x as u16,
+            r,
+            r_idx,
+        })
+    }
+
+    /// Set the frequency band and write the band register.
+    ///
+    /// Ports `e4k_band_set`.
+    fn band_set(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        band: Band,
+    ) -> Result<(), RtlSdrError> {
+        // Set bias register based on band
+        match band {
+            Band::Vhf2 | Band::Vhf3 | Band::Uhf => {
+                self.write_reg(handle, REG_BIAS, 3)?;
+            }
+            Band::L => {
+                self.write_reg(handle, REG_BIAS, 0)?;
+            }
+        }
+
+        // Workaround: reset SYNTH1 band bits before writing to avoid
+        // gap between 325-350 MHz
+        self.reg_set_mask(handle, REG_SYNTH1, 0x06, 0)?;
+        self.reg_set_mask(handle, REG_SYNTH1, 0x06, (band as u8) << 1)?;
+
+        self.band = band;
+        Ok(())
+    }
+
+    /// Program PLL parameters into the tuner and set band/filter.
+    ///
+    /// Ports `e4k_tune_params`.
+    fn tune_params(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        p: &PllParams,
+    ) -> Result<(), RtlSdrError> {
+        // Program R + 3phase/2phase
+        self.write_reg(handle, REG_SYNTH7, p.r_idx)?;
+        // Program Z
+        self.write_reg(handle, REG_SYNTH3, p.z)?;
+        // Program X
+        self.write_reg(handle, REG_SYNTH4, (p.x & 0xff) as u8)?;
+        self.write_reg(handle, REG_SYNTH5, (p.x >> 8) as u8)?;
+
+        // Store PLL params
+        self.pll = *p;
+
+        // Set the band based on frequency
+        let band = if self.pll.flo < BAND_VHF2_MAX {
+            Band::Vhf2
+        } else if self.pll.flo < BAND_VHF3_MAX {
+            Band::Vhf3
+        } else if self.pll.flo < BAND_UHF_MAX {
+            Band::Uhf
+        } else {
+            Band::L
+        };
+        self.band_set(handle, band)?;
+
+        // Select and set proper RF filter
+        self.rf_filter_set(handle)?;
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Gain control
+    // -----------------------------------------------------------------------
+
+    /// Find the index of a gain value in a stage gain table.
+    ///
+    /// Ports `find_stage_gain`.
+    fn find_stage_gain(stage: u8, val: i8) -> Result<u8, RtlSdrError> {
+        let arr: &[i8] = match stage {
+            1 => &IF_STAGE1_GAIN,
+            2 | 3 => &IF_STAGE23_GAIN,
+            4 => &IF_STAGE4_GAIN,
+            5 | 6 => &IF_STAGE56_GAIN,
+            _ => {
+                return Err(RtlSdrError::Tuner(format!(
+                    "E4K: invalid IF gain stage {stage}"
+                )));
+            }
+        };
+
+        for (i, &g) in arr.iter().enumerate() {
+            if g == val {
+                return Ok(i as u8);
+            }
+        }
+
+        Err(RtlSdrError::Tuner(format!(
+            "E4K: invalid gain value {val} dB for IF stage {stage}"
+        )))
+    }
+
+    /// Set the gain of one of the IF gain stages (1..6).
+    ///
+    /// Ports `e4k_if_gain_set`.
+    fn if_gain_set(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        stage: u8,
+        value: i8,
+    ) -> Result<(), RtlSdrError> {
+        let idx = Self::find_stage_gain(stage, value)?;
+
+        let field = &IF_STAGE_GAIN_REGS[stage as usize];
+        let mask = WIDTH_MASK[field.width as usize] << field.shift;
+
+        self.reg_set_mask(handle, field.reg, mask, idx << field.shift)
+    }
+
+    /// Set the LNA gain.
+    ///
+    /// Ports `e4k_set_lna_gain`. Gain is in tenths of dB.
+    fn set_lna_gain(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        gain: i32,
+    ) -> Result<(), RtlSdrError> {
+        for &(g, reg_val) in &LNA_GAIN {
+            if g == gain {
+                return self.reg_set_mask(handle, REG_GAIN1, LNA_GAIN_MASK, reg_val);
+            }
+        }
+
+        Err(RtlSdrError::Tuner(format!(
+            "E4K: invalid LNA gain value {gain} (tenths of dB)"
+        )))
+    }
+
+    /// Set the mixer gain (4 or 12 dB).
+    ///
+    /// Ports `e4k_mixer_gain_set`.
+    fn mixer_gain_set(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        value: i8,
+    ) -> Result<(), RtlSdrError> {
+        let bit = match value {
+            MIXER_GAIN_4DB => 0u8,
+            MIXER_GAIN_12DB => 1u8,
+            _ => {
+                return Err(RtlSdrError::Tuner(format!(
+                    "E4K: invalid mixer gain {value} dB"
+                )));
+            }
+        };
+
+        self.reg_set_mask(handle, REG_GAIN2, 1, bit)
+    }
+
+    /// Set the enhancement gain.
+    ///
+    /// Ports `e4k_set_enh_gain`. Gain is in tenths of dB; 0 = off.
+    /// Not called in the default configuration (C source has this in `#if 0`).
+    #[allow(dead_code)]
+    fn set_enh_gain(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        gain: i32,
+    ) -> Result<(), RtlSdrError> {
+        for (i, &g) in ENH_GAIN.iter().enumerate() {
+            if g == gain {
+                let val = AGC11_LNA_GAIN_ENH | ((i as u8) << 1);
+                return self.reg_set_mask(handle, REG_AGC11, ENH_GAIN_MASK, val);
+            }
+        }
+
+        // Disable enhancement gain
+        self.reg_set_mask(handle, REG_AGC11, ENH_GAIN_MASK, 0)?;
+
+        if gain == 0 {
+            Ok(())
+        } else {
+            Err(RtlSdrError::Tuner(format!(
+                "E4K: invalid enhancement gain {gain} (tenths of dB)"
+            )))
+        }
+    }
+
+    /// Enable or disable manual gain mode.
+    ///
+    /// Ports `e4k_enable_manual_gain`.
+    fn enable_manual_gain(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        manual: bool,
+    ) -> Result<(), RtlSdrError> {
+        if manual {
+            // Set LNA mode to manual (serial)
+            self.reg_set_mask(handle, REG_AGC1, AGC1_MOD_MASK, AGC_MOD_SERIAL)?;
+            // Set Mixer Gain Control to manual
+            self.reg_set_mask(handle, REG_AGC7, AGC7_MIX_GAIN_AUTO, 0)?;
+        } else {
+            // Set LNA mode to auto
+            self.reg_set_mask(handle, REG_AGC1, AGC1_MOD_MASK, AGC_MOD_IF_SERIAL_LNA_AUTON)?;
+            // Set Mixer Gain Control to auto
+            self.reg_set_mask(handle, REG_AGC7, AGC7_MIX_GAIN_AUTO, 1)?;
+            // Disable enhancement gain
+            self.reg_set_mask(handle, REG_AGC11, ENH_GAIN_MASK, 0)?;
+        }
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // DC offset calibration
+    // -----------------------------------------------------------------------
+
+    /// Trigger a DC offset calibration.
+    ///
+    /// Ports `e4k_dc_offset_calibrate`.
+    /// Not called in the default configuration (C source has this in `#if 0`).
+    #[allow(dead_code)]
+    fn dc_offset_calibrate(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        // Make sure the DC range detector is enabled
+        self.reg_set_mask(handle, REG_DC5, DC5_RANGE_DET_EN, DC5_RANGE_DET_EN)?;
+        self.write_reg(handle, REG_DC1, 0x01)
+    }
+
+    /// Generate the DC offset lookup table.
+    ///
+    /// Ports `e4k_dc_offset_gen_table`.
+    /// Not called in the default configuration (C source has this in `#if 0`).
+    #[allow(dead_code)]
+    fn dc_offset_gen_table(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        // Disable auto mixer gain
+        self.reg_set_mask(handle, REG_AGC7, AGC7_MIX_GAIN_AUTO, 0)?;
+
+        // Set LNA/IF gain to full manual
+        self.reg_set_mask(handle, REG_AGC1, AGC1_MOD_MASK, AGC_MOD_SERIAL)?;
+
+        // Set all 'other' gains to maximum
+        for stage in 2..=6u8 {
+            self.if_gain_set(handle, stage, IF_GAINS_MAX[stage as usize])?;
+        }
+
+        // Iterate over all mixer + if_stage_1 gain combinations
+        for comb in &DC_GAIN_COMB {
+            // Set the combination of mixer / if1 gain
+            self.mixer_gain_set(handle, comb.mixer_gain)?;
+            self.if_gain_set(handle, 1, comb.if1_gain)?;
+
+            // Perform actual calibration
+            self.dc_offset_calibrate(handle)?;
+
+            // Extract I/Q offset and range values
+            let offs_i = self.read_reg(handle, REG_DC2)? & 0x3f;
+            let offs_q = self.read_reg(handle, REG_DC3)? & 0x3f;
+            let range = self.read_reg(handle, REG_DC4)?;
+            let range_i = range & 0x03;
+            let range_q = (range >> 4) & 0x03;
+
+            // Write into the lookup table
+            // TO_LUT(offset, range) = offset | (range << 6)
+            self.write_reg(handle, comb.reg, offs_q | (range_q << 6))?;
+            self.write_reg(handle, comb.reg + 0x10, offs_i | (range_i << 6))?;
+        }
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Standby
+    // -----------------------------------------------------------------------
+
+    /// Enable or disable standby mode.
+    ///
+    /// Ports `e4k_standby`.
+    fn standby(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        enable: bool,
+    ) -> Result<(), RtlSdrError> {
+        self.reg_set_mask(
+            handle,
+            REG_MASTER1,
+            MASTER1_NORM_STBY,
+            if enable { 0 } else { MASTER1_NORM_STBY },
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // Magic init
+    // -----------------------------------------------------------------------
+
+    /// Write magic initialization values.
+    ///
+    /// Ports `magic_init`.
+    fn magic_init(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        for &(reg, val) in &MAGIC_INIT_REGS {
+            self.write_reg(handle, reg, val)?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tuner trait implementation
+// ---------------------------------------------------------------------------
+
+impl Tuner for E4kTuner {
+    /// Initialize the E4000 tuner.
+    ///
+    /// Exact port of `e4k_init`.
+    fn init(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        // Make a dummy I2C read (will not be ACKed)
+        let _ = self.read_reg(handle, 0);
+
+        // Reset everything and clear POR indicator
+        self.write_reg(
+            handle,
+            REG_MASTER1,
+            MASTER1_RESET | MASTER1_NORM_STBY | MASTER1_POR_DET,
+        )?;
+
+        // Configure clock input
+        self.write_reg(handle, REG_CLK_INP, 0x00)?;
+
+        // Disable clock output
+        self.write_reg(handle, REG_REF_CLK, 0x00)?;
+        self.write_reg(handle, REG_CLKOUT_PWDN, CLKOUT_DISABLE)?;
+
+        // Write magic initialization values
+        self.magic_init(handle)?;
+
+        // Set AGC thresholds
+        self.write_reg(handle, REG_AGC4, INIT_AGC4_HIGH_THRESH)?;
+        self.write_reg(handle, REG_AGC5, INIT_AGC5_LOW_THRESH)?;
+        self.write_reg(handle, REG_AGC6, INIT_AGC6_LNA_CALIB)?;
+
+        // Set LNA mode to manual (serial)
+        self.reg_set_mask(handle, REG_AGC1, AGC1_MOD_MASK, AGC_MOD_SERIAL)?;
+
+        // Set Mixer Gain Control to manual
+        self.reg_set_mask(handle, REG_AGC7, AGC7_MIX_GAIN_AUTO, 0)?;
+
+        // Use auto-gain as default
+        self.enable_manual_gain(handle, false)?;
+
+        // Select moderate gain levels
+        self.if_gain_set(handle, 1, INIT_IF_GAIN_STAGE1)?;
+        self.if_gain_set(handle, 2, INIT_IF_GAIN_STAGES_2_4)?;
+        self.if_gain_set(handle, 3, INIT_IF_GAIN_STAGES_2_4)?;
+        self.if_gain_set(handle, 4, INIT_IF_GAIN_STAGES_2_4)?;
+        self.if_gain_set(handle, 5, INIT_IF_GAIN_STAGES_5_6)?;
+        self.if_gain_set(handle, 6, INIT_IF_GAIN_STAGES_5_6)?;
+
+        // Set the most narrow filters we can use
+        self.if_filter_bw_set(handle, IfFilter::Mix, INIT_IF_FILTER_MIX_BW)?;
+        self.if_filter_bw_set(handle, IfFilter::Rc, INIT_IF_FILTER_RC_BW)?;
+        self.if_filter_bw_set(handle, IfFilter::Chan, INIT_IF_FILTER_CHAN_BW)?;
+        self.if_filter_chan_enable(handle, true)?;
+
+        // Disable time variant DC correction and LUT
+        self.reg_set_mask(handle, REG_DC5, 0x03, 0)?;
+        self.reg_set_mask(handle, REG_DCTIME1, 0x03, 0)?;
+        self.reg_set_mask(handle, REG_DCTIME2, 0x03, 0)?;
+
+        Ok(())
+    }
+
+    /// Put the tuner in standby (exit).
+    ///
+    /// Ports `e4000_exit` which calls `e4k_standby(e4k, 1)`.
+    fn exit(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        self.standby(handle, true)
+    }
+
+    /// Set the tuner frequency in Hz.
+    ///
+    /// Ports `e4k_tune_freq`.
+    fn set_freq(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq: u32,
+    ) -> Result<(), RtlSdrError> {
+        // Determine PLL parameters
+        let p = Self::compute_pll_params(self.pll.fosc, freq).ok_or_else(|| {
+            RtlSdrError::Tuner(format!("E4K: cannot compute PLL params for {freq} Hz"))
+        })?;
+
+        // Actually tune to those parameters
+        self.tune_params(handle, &p)?;
+
+        // Check PLL lock
+        let synth1 = self.read_reg(handle, REG_SYNTH1)?;
+        if synth1 & 0x01 == 0 {
+            return Err(RtlSdrError::Tuner(format!(
+                "E4K: PLL not locked for {freq} Hz"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Set the tuner bandwidth in Hz. Returns 0 as the IF frequency.
+    ///
+    /// Ports `e4000_set_bw` from `librtlsdr.c`.
+    fn set_bw(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        bw: u32,
+        _sample_rate: u32,
+    ) -> Result<u32, RtlSdrError> {
+        self.if_filter_bw_set(handle, IfFilter::Mix, bw)?;
+        self.if_filter_bw_set(handle, IfFilter::Rc, bw)?;
+        self.if_filter_bw_set(handle, IfFilter::Chan, bw)?;
+        Ok(0)
+    }
+
+    /// Set the tuner gain in tenths of dB.
+    ///
+    /// Ports `e4000_set_gain` from `librtlsdr.c`.
+    fn set_gain(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        gain: i32,
+    ) -> Result<(), RtlSdrError> {
+        let mixgain: i8 = if gain > MIXER_GAIN_THRESH { 12 } else { 4 };
+
+        // LNA gain: gain minus mixer contribution, capped at 300 (tenths of dB)
+        let lna_gain = (gain - i32::from(mixgain) * 10).min(MAX_LNA_GAIN);
+        self.set_lna_gain(handle, lna_gain)?;
+        self.mixer_gain_set(handle, mixgain)?;
+
+        Ok(())
+    }
+
+    /// Update the crystal frequency.
+    fn set_xtal(&mut self, xtal: u32) {
+        self.xtal = xtal;
+        self.pll.fosc = xtal;
+    }
+
+    /// Set manual or automatic gain mode.
+    ///
+    /// Ports `e4000_set_gain_mode` which calls `e4k_enable_manual_gain`.
+    fn set_gain_mode(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        manual: bool,
+    ) -> Result<(), RtlSdrError> {
+        self.enable_manual_gain(handle, manual)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_i2c_addr() {
+        assert_eq!(I2C_ADDR, 0xc8);
+    }
+
+    #[test]
+    fn test_check_val() {
+        assert_eq!(CHECK_VAL, 0x40);
+    }
+
+    #[test]
+    fn test_check_addr() {
+        assert_eq!(CHECK_ADDR, 0x02);
+    }
+
+    #[test]
+    fn test_gains_sorted() {
+        for w in E4K_GAINS.windows(2) {
+            assert!(w[0] < w[1], "gains must be in ascending order");
+        }
+    }
+
+    #[test]
+    fn test_gains_count() {
+        assert_eq!(E4K_GAINS.len(), 14);
+    }
+
+    #[test]
+    fn test_gains_values() {
+        // Verify exact gain values from C source (tenths of dB)
+        assert_eq!(E4K_GAINS[0], -10);
+        assert_eq!(E4K_GAINS[13], 420);
+    }
+
+    #[test]
+    fn test_new_defaults() {
+        let tuner = E4kTuner::new(28_800_000);
+        assert_eq!(tuner.xtal, 28_800_000);
+        assert_eq!(tuner.pll.fosc, 28_800_000);
+        assert_eq!(tuner.pll.flo, 0);
+    }
+
+    #[test]
+    fn test_pll_vars_ordered() {
+        for w in PLL_VARS.windows(2) {
+            assert!(
+                w[0].freq_khz < w[1].freq_khz,
+                "PLL vars must be in ascending frequency order"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_pll_params_valid() {
+        // 100 MHz with 28.8 MHz crystal
+        let params = E4kTuner::compute_pll_params(28_800_000, 100_000_000);
+        assert!(params.is_some());
+        let p = params.expect("should compute PLL params");
+        assert_eq!(p.fosc, 28_800_000);
+        // The actual frequency should be close to 100 MHz
+        assert!(
+            p.flo.abs_diff(100_000_000) < 100_000,
+            "flo should be near 100 MHz, got {}",
+            p.flo
+        );
+    }
+
+    #[test]
+    fn test_compute_pll_params_invalid_fosc() {
+        // Oscillator too low
+        assert!(E4kTuner::compute_pll_params(10_000_000, 100_000_000).is_none());
+        // Oscillator too high
+        assert!(E4kTuner::compute_pll_params(40_000_000, 100_000_000).is_none());
+    }
+
+    #[test]
+    fn test_compute_pll_params_various_frequencies() {
+        let fosc = 28_800_000;
+
+        // VHF2 range
+        let p = E4kTuner::compute_pll_params(fosc, 70_000_000);
+        assert!(p.is_some());
+        let p = p.expect("VHF2 params");
+        assert!(p.flo.abs_diff(70_000_000) < 100_000);
+
+        // UHF range
+        let p = E4kTuner::compute_pll_params(fosc, 500_000_000);
+        assert!(p.is_some());
+        let p = p.expect("UHF params");
+        assert!(p.flo.abs_diff(500_000_000) < 100_000);
+
+        // L band range
+        let p = E4kTuner::compute_pll_params(fosc, 1_200_000_000);
+        assert!(p.is_some());
+    }
+
+    #[test]
+    fn test_closest_arr_idx() {
+        // Test with UHF filter centers
+        let idx = E4kTuner::closest_arr_idx(&RF_FILT_CENTER_UHF, 360_000_000);
+        assert_eq!(idx, 0);
+
+        let idx = E4kTuner::closest_arr_idx(&RF_FILT_CENTER_UHF, 970_000_000);
+        assert_eq!(idx, 15);
+
+        // Test with a frequency between entries
+        let idx = E4kTuner::closest_arr_idx(&RF_FILT_CENTER_UHF, 400_000_000);
+        // Should be closer to 405 MHz (index 2) than 380 MHz (index 1)
+        assert_eq!(idx, 2);
+    }
+
+    #[test]
+    fn test_choose_rf_filter() {
+        // VHF bands always return 0
+        assert_eq!(E4kTuner::choose_rf_filter(Band::Vhf2, 100_000_000), 0);
+        assert_eq!(E4kTuner::choose_rf_filter(Band::Vhf3, 200_000_000), 0);
+
+        // UHF returns an index
+        let idx = E4kTuner::choose_rf_filter(Band::Uhf, 500_000_000);
+        assert!(idx < 16);
+
+        // L band returns an index
+        let idx = E4kTuner::choose_rf_filter(Band::L, 1_500_000_000);
+        assert!(idx < 16);
+    }
+
+    #[test]
+    fn test_find_if_bw() {
+        // Mixer filter: closest to 1900 kHz should be last entry (index 15)
+        let idx = E4kTuner::find_if_bw(IfFilter::Mix, 1_900_000);
+        assert_eq!(idx, 15);
+
+        // Channel filter: closest to 2150 kHz should be last entry (index 31)
+        let idx = E4kTuner::find_if_bw(IfFilter::Chan, 2_150_000);
+        assert_eq!(idx, 31);
+
+        // RC filter: closest to 1000 kHz should be last entry (index 15)
+        let idx = E4kTuner::find_if_bw(IfFilter::Rc, 1_000_000);
+        assert_eq!(idx, 15);
+    }
+
+    #[test]
+    fn test_find_stage_gain_valid() {
+        // Stage 1: -3 -> index 0, 6 -> index 1
+        assert_eq!(E4kTuner::find_stage_gain(1, -3).expect("ok"), 0);
+        assert_eq!(E4kTuner::find_stage_gain(1, 6).expect("ok"), 1);
+
+        // Stage 2: 0 -> index 0, 9 -> index 3
+        assert_eq!(E4kTuner::find_stage_gain(2, 0).expect("ok"), 0);
+        assert_eq!(E4kTuner::find_stage_gain(2, 9).expect("ok"), 3);
+
+        // Stage 5: 3 -> index 0, 15 -> index 4
+        assert_eq!(E4kTuner::find_stage_gain(5, 3).expect("ok"), 0);
+        assert_eq!(E4kTuner::find_stage_gain(5, 15).expect("ok"), 4);
+    }
+
+    #[test]
+    fn test_find_stage_gain_invalid_stage() {
+        assert!(E4kTuner::find_stage_gain(0, 0).is_err());
+        assert!(E4kTuner::find_stage_gain(7, 0).is_err());
+    }
+
+    #[test]
+    fn test_find_stage_gain_invalid_value() {
+        assert!(E4kTuner::find_stage_gain(1, 0).is_err());
+        assert!(E4kTuner::find_stage_gain(2, 5).is_err());
+    }
+
+    #[test]
+    fn test_lna_gain_table() {
+        // Verify all entries have valid register values (0..14)
+        for &(_, reg_val) in &LNA_GAIN {
+            assert!(reg_val <= 14, "LNA gain register value out of range");
+        }
+        // Verify sorted by gain
+        for w in LNA_GAIN.windows(2) {
+            assert!(w[0].0 < w[1].0, "LNA gain table must be sorted");
+        }
+    }
+
+    #[test]
+    fn test_enh_gain_table() {
+        assert_eq!(ENH_GAIN.len(), 4);
+        assert_eq!(ENH_GAIN[0], 10);
+        assert_eq!(ENH_GAIN[3], 70);
+    }
+
+    #[test]
+    fn test_if_filter_bw_tables_lengths() {
+        assert_eq!(MIX_FILTER_BW.len(), 16);
+        assert_eq!(IFRC_FILTER_BW.len(), 16);
+        assert_eq!(IFCH_FILTER_BW.len(), 32);
+    }
+
+    #[test]
+    fn test_rf_filter_center_tables_lengths() {
+        assert_eq!(RF_FILT_CENTER_UHF.len(), 16);
+        assert_eq!(RF_FILT_CENTER_L.len(), 16);
+    }
+
+    #[test]
+    fn test_width_mask() {
+        assert_eq!(WIDTH_MASK[0], 0);
+        assert_eq!(WIDTH_MASK[1], 1);
+        assert_eq!(WIDTH_MASK[4], 0x0f);
+        assert_eq!(WIDTH_MASK[8], 0xff);
+    }
+
+    #[test]
+    fn test_magic_init_regs_count() {
+        assert_eq!(MAGIC_INIT_REGS.len(), 8);
+    }
+
+    #[test]
+    fn test_dc_gain_comb() {
+        assert_eq!(DC_GAIN_COMB.len(), 4);
+        assert_eq!(DC_GAIN_COMB[0].reg, 0x50);
+        assert_eq!(DC_GAIN_COMB[3].reg, 0x53);
+    }
+
+    #[test]
+    fn test_if_gains_max() {
+        assert_eq!(IF_GAINS_MAX[1], 6);
+        assert_eq!(IF_GAINS_MAX[2], 9);
+        assert_eq!(IF_GAINS_MAX[5], 15);
+        assert_eq!(IF_GAINS_MAX[6], 15);
+    }
+
+    #[test]
+    fn test_set_xtal() {
+        let mut tuner = E4kTuner::new(28_800_000);
+        tuner.set_xtal(26_000_000);
+        assert_eq!(tuner.xtal, 26_000_000);
+        assert_eq!(tuner.pll.fosc, 26_000_000);
+    }
+
+    #[test]
+    fn test_band_boundaries() {
+        // Verify band boundary constants match C source
+        assert_eq!(BAND_VHF2_MAX, 140_000_000);
+        assert_eq!(BAND_VHF3_MAX, 350_000_000);
+        assert_eq!(BAND_UHF_MAX, 1_135_000_000);
+    }
+
+    #[test]
+    fn test_pll_params_r_values() {
+        // Check that PLL multiplier values match the C source
+        assert_eq!(PLL_VARS[0].mult, 48);
+        assert_eq!(PLL_VARS[1].mult, 40);
+        assert_eq!(PLL_VARS[2].mult, 32);
+        assert_eq!(PLL_VARS[3].mult, 24);
+        assert_eq!(PLL_VARS[4].mult, 16);
+        assert_eq!(PLL_VARS[5].mult, 12);
+        assert_eq!(PLL_VARS[6].mult, 8);
+        assert_eq!(PLL_VARS[7].mult, 8);
+        assert_eq!(PLL_VARS[8].mult, 6);
+        assert_eq!(PLL_VARS[9].mult, 4);
+    }
+
+    #[test]
+    fn test_pll_params_synth7_values() {
+        // First 7 entries have 3-phase bit set (bit 3)
+        for entry in &PLL_VARS[..7] {
+            assert_ne!(
+                entry.reg_synth7 & 0x08,
+                0,
+                "first 7 entries should have 3-phase bit"
+            );
+        }
+        // Last 3 entries do NOT have 3-phase bit set
+        for entry in &PLL_VARS[7..] {
+            assert_eq!(
+                entry.reg_synth7 & 0x08,
+                0,
+                "last 3 entries should not have 3-phase bit"
+            );
+        }
+    }
+
+    #[test]
+    fn test_if_stage_gain_regs() {
+        // Stage 0 is unused (dummy)
+        assert_eq!(IF_STAGE_GAIN_REGS[0].reg, 0);
+
+        // Stages 1-4 use GAIN3
+        for i in 1..=4 {
+            assert_eq!(IF_STAGE_GAIN_REGS[i].reg, REG_GAIN3);
+        }
+
+        // Stages 5-6 use GAIN4
+        for i in 5..=6 {
+            assert_eq!(IF_STAGE_GAIN_REGS[i].reg, REG_GAIN4);
+        }
+    }
+
+    #[test]
+    fn test_if_filter_fields() {
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Mix as usize].reg, REG_FILT2);
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Mix as usize].shift, 4);
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Mix as usize].width, 4);
+
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Chan as usize].reg, REG_FILT3);
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Chan as usize].shift, 0);
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Chan as usize].width, 5);
+
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Rc as usize].reg, REG_FILT2);
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Rc as usize].shift, 0);
+        assert_eq!(IF_FILTER_FIELDS[IfFilter::Rc as usize].width, 4);
+    }
+}

--- a/crates/sdr-rtlsdr/src/tuner/e4k.rs
+++ b/crates/sdr-rtlsdr/src/tuner/e4k.rs
@@ -777,9 +777,10 @@ impl E4kTuner {
         // Compute integer component of multiplier
         let z = intended_fvco / u64::from(fosc);
 
-        // Compute fractional part
+        // Compute fractional part (remainder < fosc, so x < PLL_Y, fits in u16)
         let remainder = intended_fvco - u64::from(fosc) * z;
         let x = ((remainder * PLL_Y) / u64::from(fosc)) as u32;
+        debug_assert!(x <= 0xFFFF, "PLL fractional part exceeds u16 range");
 
         // Compute actual LO frequency
         let fvco = u64::from(fosc) * z + (u64::from(fosc) * u64::from(x as u16)) / PLL_Y;

--- a/crates/sdr-rtlsdr/src/tuner/e4k.rs
+++ b/crates/sdr-rtlsdr/src/tuner/e4k.rs
@@ -786,6 +786,7 @@ impl E4kTuner {
         let fvco = u64::from(fosc) * z + (u64::from(fosc) * u64::from(x as u16)) / PLL_Y;
         let flo = (fvco / u64::from(r)) as u32;
 
+        debug_assert!(z <= 255, "PLL integer part exceeds u8 range");
         Some(PllParams {
             fosc,
             flo,

--- a/crates/sdr-rtlsdr/src/tuner/fc0012.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc0012.rs
@@ -1,0 +1,712 @@
+//! Fitipower FC0012 tuner driver.
+//!
+//! Faithful port of `tuner_fc0012.c` from librtlsdr.
+//!
+//! Original copyright:
+//! - Copyright (C) 2012 Hans-Frieder Vogt <hfvogt@gmx.net>
+//! - Copyright (C) 2012 Steve Markgraf <steve@steve-m.de> (librtlsdr modifications)
+
+use crate::error::RtlSdrError;
+use crate::tuner::Tuner;
+use crate::usb;
+
+// ---------------------------------------------------------------------------
+// I2C address and identification
+// ---------------------------------------------------------------------------
+
+/// FC0012 I2C address.
+pub const I2C_ADDR: u8 = 0xc6;
+
+/// Register address used to identify the FC0012 (chip ID register).
+pub const CHECK_ADDR: u8 = 0x00;
+
+/// Expected chip ID value read from `CHECK_ADDR`.
+pub const CHECK_VAL: u8 = 0xa1;
+
+// ---------------------------------------------------------------------------
+// Register addresses (only registers referenced outside the init loop)
+// ---------------------------------------------------------------------------
+
+/// RF divider count-to-9 cycles (reg 0x01, bits 0-3).
+const REG_RF_A: u8 = 0x01;
+
+/// RF divider total cycles (reg 0x02, bits 0-7).
+const REG_RF_M: u8 = 0x02;
+
+/// Fractional divider bits 8..14 (reg 0x03, bits 0-6).
+const REG_RF_K_HIGH: u8 = 0x03;
+
+/// Fractional divider bits 0..7 (reg 0x04, bits 0-7).
+const REG_RF_K_LOW: u8 = 0x04;
+
+/// RF output divider A (reg 0x05, bits 3-7).
+const REG_RF_OUTDIV_A: u8 = 0x05;
+
+/// LNA power down, RF output divider B, VCO speed, bandwidth (reg 0x06).
+const REG_VCO_BW: u8 = 0x06;
+
+/// AGC/LNA forcing register (reg 0x0d).
+const REG_AGC_LNA_FORCE: u8 = 0x0d;
+
+/// VCO calibration and voltage register (reg 0x0e).
+const REG_VCO_CALIB: u8 = 0x0e;
+
+/// LNA gain register (reg 0x13, bits 3-4 for gain, bit 7 for IX2).
+const REG_LNA_GAIN: u8 = 0x13;
+
+// ---------------------------------------------------------------------------
+// Init register default values
+// ---------------------------------------------------------------------------
+
+/// Number of registers written during init (regs 0x01 to 0x15 = 21).
+const NUM_INIT_REGS: usize = 21;
+
+/// Default register values for init, indexed 0..20 mapping to regs 0x01..0x15.
+///
+/// Each value is annotated with its register address and meaning from the
+/// original C source.
+const INIT_REGS: [u8; NUM_INIT_REGS] = [
+    0x05, // reg 0x01: RF_A
+    0x10, // reg 0x02: RF_M
+    0x00, // reg 0x03: RF_K_HIGH
+    0x00, // reg 0x04: RF_K_LOW
+    0x0f, // reg 0x05: RF_OUTDIV_A (may also be 0x0a)
+    0x00, // reg 0x06: divider 2, VCO slow
+    0x00, // reg 0x07: XTAL_SPEED (may also be 0x0f)
+    0xff, // reg 0x08: AGC clock divide by 256, AGC gain 1/256, loop BW 1/8
+    0x6e, // reg 0x09: disable loop-through (enable: 0x6f)
+    0xb8, // reg 0x0a: disable LO test buffer
+    0x82, // reg 0x0b: output clock = clock frequency (may also be 0x83)
+    0xfc, // reg 0x0c: AGC up-down mode (may need 0xf8)
+    0x02, // reg 0x0d: AGC not forcing & LNA forcing (DVB-T)
+    0x00, // reg 0x0e: VCO calibration
+    0x00, // reg 0x0f
+    0x00, // reg 0x10 (may also be 0x0d)
+    0x00, // reg 0x11
+    0x1f, // reg 0x12: set to maximum gain
+    0x00, // reg 0x13: low gain (low=0x00, high=0x10, enable IX2=0x80)
+    0x00, // reg 0x14
+    0x04, // reg 0x15: enable LNA COMPS
+];
+
+// ---------------------------------------------------------------------------
+// Frequency divider constants
+// ---------------------------------------------------------------------------
+
+/// VCO frequency threshold for high-range selection (3.06 GHz).
+const VCO_HIGH_THRESH: u64 = 3_060_000_000;
+
+/// VCO re-calibration: low voltage threshold.
+const VCO_VOLTAGE_LOW: u8 = 0x02;
+
+/// VCO re-calibration: high voltage threshold.
+const VCO_VOLTAGE_HIGH: u8 = 0x3c;
+
+/// Mask for VCO voltage readback (bits 0-5).
+const VCO_VOLTAGE_MASK: u8 = 0x3f;
+
+/// VCO speed bit in register 0x06 (high VCO range).
+const VCO_SPEED_BIT: u8 = 0x08;
+
+/// Clock-out fix bit in register 0x06.
+const CLOCK_OUT_BIT: u8 = 0x20;
+
+/// VCO calibration trigger value (set high to trigger).
+const VCO_CALIB_TRIGGER: u8 = 0x80;
+
+/// VCO calibration reset value.
+const VCO_CALIB_RESET: u8 = 0x00;
+
+/// 28.8 MHz crystal select bit in register 0x07.
+const XTAL_28_8_MHZ_BIT: u8 = 0x20;
+
+/// Dual master bit in register 0x0c.
+const DUAL_MASTER_BIT: u8 = 0x02;
+
+/// Fractional divider threshold (xin >= 16384 adds 32768).
+const XIN_THRESHOLD: u16 = 16384;
+
+/// Fractional divider overflow correction.
+const XIN_OVERFLOW_ADD: u16 = 32768;
+
+/// Bandwidth bits mask in register 0x06 (bits 6-7).
+const BW_MASK: u8 = 0x3f;
+
+/// 6 MHz bandwidth setting for register 0x06.
+const BW_6MHZ: u8 = 0x80;
+
+/// 7 MHz bandwidth setting for register 0x06.
+const BW_7MHZ: u8 = 0x40;
+
+/// Bandwidth: 6 MHz in Hz.
+const BW_6MHZ_HZ: u32 = 6_000_000;
+
+/// Bandwidth: 7 MHz in Hz.
+const BW_7MHZ_HZ: u32 = 7_000_000;
+
+/// Modified register 0x05 lower bits for Realtek demod.
+const REALTEK_DEMOD_BITS: u8 = 0x07;
+
+/// LNA gain register mask (bits 0-4).
+const LNA_GAIN_MASK: u8 = 0xe0;
+
+// ---------------------------------------------------------------------------
+// Frequency divider table
+// ---------------------------------------------------------------------------
+
+/// Frequency divider selection entry.
+///
+/// Maps a maximum frequency to the VCO multiplier and register values
+/// for registers 0x05 and 0x06 that control the RF output divider.
+struct FreqDivider {
+    /// Maximum frequency in Hz (exclusive upper bound).
+    max_freq: u32,
+    /// VCO frequency multiplier.
+    multi: u8,
+    /// Value for register 0x05 (RF_OUTDIV_A).
+    reg5: u8,
+    /// Value for register 0x06 (RF_OUTDIV_B and VCO speed).
+    reg6: u8,
+}
+
+/// Frequency divider table, ordered by ascending max frequency.
+///
+/// Each entry defines the multiplier used such that `freq * multi < 3.56 GHz`.
+/// The last entry has no upper bound (used as fallback for freq >= 593334000).
+const FREQ_DIVIDERS: [FreqDivider; 10] = [
+    FreqDivider {
+        max_freq: 37_084_000,
+        multi: 96,
+        reg5: 0x82,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 55_625_000,
+        multi: 64,
+        reg5: 0x82,
+        reg6: 0x02,
+    },
+    FreqDivider {
+        max_freq: 74_167_000,
+        multi: 48,
+        reg5: 0x42,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 111_250_000,
+        multi: 32,
+        reg5: 0x42,
+        reg6: 0x02,
+    },
+    FreqDivider {
+        max_freq: 148_334_000,
+        multi: 24,
+        reg5: 0x22,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 222_500_000,
+        multi: 16,
+        reg5: 0x22,
+        reg6: 0x02,
+    },
+    FreqDivider {
+        max_freq: 296_667_000,
+        multi: 12,
+        reg5: 0x12,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 445_000_000,
+        multi: 8,
+        reg5: 0x12,
+        reg6: 0x02,
+    },
+    FreqDivider {
+        max_freq: 593_334_000,
+        multi: 6,
+        reg5: 0x0a,
+        reg6: 0x00,
+    },
+    // Fallback: freq >= 593334000
+    FreqDivider {
+        max_freq: u32::MAX,
+        multi: 4,
+        reg5: 0x0a,
+        reg6: 0x02,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Gain table
+// ---------------------------------------------------------------------------
+
+/// Supported gain values in tenths of dB.
+///
+/// From librtlsdr `fc0012_gains[]`:
+/// -9.9 dB, -4.0 dB, 7.1 dB, 17.9 dB, 19.2 dB
+pub const FC0012_GAINS: [i32; 5] = [-99, -40, 71, 179, 192];
+
+/// Gain register value for -9.9 dB.
+const GAIN_NEG_9_9_DB: u8 = 0x02;
+
+/// Gain register value for -4.0 dB.
+const GAIN_NEG_4_0_DB: u8 = 0x00;
+
+/// Gain register value for 7.1 dB.
+const GAIN_7_1_DB: u8 = 0x08;
+
+/// Gain register value for 17.9 dB.
+const GAIN_17_9_DB: u8 = 0x17;
+
+/// Gain register value for 19.2 dB.
+const GAIN_19_2_DB: u8 = 0x10;
+
+/// Gain threshold: below this, select -9.9 dB (tenths of dB).
+const GAIN_THRESH_NEG_9_9: i32 = -40;
+
+/// Gain threshold: below this, select -4.0 dB (tenths of dB).
+const GAIN_THRESH_NEG_4_0: i32 = 71;
+
+/// Gain threshold: below this, select 7.1 dB (tenths of dB).
+const GAIN_THRESH_7_1: i32 = 179;
+
+/// Gain threshold: below this, select 17.9 dB (tenths of dB).
+const GAIN_THRESH_17_9: i32 = 192;
+
+// ---------------------------------------------------------------------------
+// PLL validation limits
+// ---------------------------------------------------------------------------
+
+/// Maximum valid value for register 1 (RF_A) during PLL calculation.
+const PLL_REG1_MAX: u8 = 15;
+
+/// Minimum valid value for register 2 (RF_M) during PLL calculation.
+const PLL_REG2_MIN: u8 = 0x0b;
+
+// ---------------------------------------------------------------------------
+// FC0012 tuner state
+// ---------------------------------------------------------------------------
+
+/// Fitipower FC0012 tuner driver.
+///
+/// Ports the `fc0012_init`, `fc0012_set_params`, and `fc0012_set_gain`
+/// functions from `tuner_fc0012.c`.
+pub struct Fc0012Tuner {
+    /// Crystal oscillator frequency in Hz.
+    xtal: u32,
+    /// Current bandwidth setting in Hz (stored for `set_freq`).
+    bandwidth: u32,
+    /// Current tuned frequency in Hz.
+    freq: u32,
+}
+
+impl Fc0012Tuner {
+    /// Create a new FC0012 tuner driver.
+    pub fn new(xtal: u32) -> Self {
+        Self {
+            xtal,
+            bandwidth: BW_6MHZ_HZ,
+            freq: 0,
+        }
+    }
+
+    /// Write a single register via I2C.
+    ///
+    /// Ports `fc0012_writereg`. Method (not associated fn) for consistency
+    /// with the Tuner trait pattern and future state-dependent tuner drivers.
+    #[allow(clippy::unused_self)]
+    fn write_reg(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+        val: u8,
+    ) -> Result<(), RtlSdrError> {
+        usb::i2c_write_reg(handle, I2C_ADDR, reg, val)
+    }
+
+    /// Read a single register via I2C.
+    ///
+    /// Ports `fc0012_readreg`. Method (not associated fn) for consistency
+    /// with the Tuner trait pattern and future state-dependent tuner drivers.
+    #[allow(clippy::unused_self)]
+    fn read_reg(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+    ) -> Result<u8, RtlSdrError> {
+        usb::i2c_read_reg(handle, I2C_ADDR, reg)
+    }
+
+    /// Set tuner frequency and bandwidth.
+    ///
+    /// Exact port of `fc0012_set_params`.
+    #[allow(clippy::cast_possible_truncation)]
+    fn set_params(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq: u32,
+        bandwidth: u32,
+    ) -> Result<(), RtlSdrError> {
+        let xtal_freq_div_2 = self.xtal / 2;
+
+        // Select frequency divider and VCO frequency
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| freq < d.max_freq)
+            .unwrap_or(&FREQ_DIVIDERS[FREQ_DIVIDERS.len() - 1]);
+
+        let multi = divider.multi;
+        let mut reg5 = divider.reg5;
+        let mut reg6 = divider.reg6;
+
+        let f_vco = u64::from(freq) * u64::from(multi);
+
+        let mut vco_select = false;
+        if f_vco >= VCO_HIGH_THRESH {
+            reg6 |= VCO_SPEED_BIT;
+            vco_select = true;
+        }
+
+        // From divided value (XDIV) determine the FA (am) and FP (pm) values
+        let mut xdiv = (f_vco / u64::from(xtal_freq_div_2)) as u16;
+        let remainder = f_vco - u64::from(xdiv) * u64::from(xtal_freq_div_2);
+        if remainder >= u64::from(xtal_freq_div_2 / 2) {
+            xdiv += 1;
+        }
+
+        let mut pm = xdiv / 8;
+        let mut am = xdiv - (8 * pm);
+
+        if am < 2 {
+            am += 8;
+            pm -= 1;
+        }
+
+        let (reg1, reg2) = if pm > 31 {
+            ((am + 8 * (pm - 31)) as u8, 31u8)
+        } else {
+            (am as u8, pm as u8)
+        };
+
+        if reg1 > PLL_REG1_MAX || reg2 < PLL_REG2_MIN {
+            return Err(RtlSdrError::Tuner(format!(
+                "FC0012: no valid PLL combination found for {freq} Hz"
+            )));
+        }
+
+        // Fix clock out
+        reg6 |= CLOCK_OUT_BIT;
+
+        // Calculate XIN (fractional part of Delta Sigma PLL)
+        let xin_remainder =
+            (f_vco - (f_vco / u64::from(xtal_freq_div_2)) * u64::from(xtal_freq_div_2)) / 1000;
+        let mut xin = ((xin_remainder as u16) << 15) / ((xtal_freq_div_2 / 1000) as u16);
+        if xin >= XIN_THRESHOLD {
+            xin += XIN_OVERFLOW_ADD;
+        }
+
+        let reg3 = (xin >> 8) as u8;
+        let reg4 = (xin & 0xff) as u8;
+
+        // Bandwidth selection (bits 6-7 of reg6)
+        reg6 &= BW_MASK;
+        match bandwidth {
+            BW_6MHZ_HZ => reg6 |= BW_6MHZ,
+            BW_7MHZ_HZ => reg6 |= BW_7MHZ,
+            _ => {} // 8 MHz: no extra bits
+        }
+
+        // Modified for Realtek demod
+        reg5 |= REALTEK_DEMOD_BITS;
+
+        // Write PLL registers 0x01 through 0x06
+        self.write_reg(handle, REG_RF_A, reg1)?;
+        self.write_reg(handle, REG_RF_M, reg2)?;
+        self.write_reg(handle, REG_RF_K_HIGH, reg3)?;
+        self.write_reg(handle, REG_RF_K_LOW, reg4)?;
+        self.write_reg(handle, REG_RF_OUTDIV_A, reg5)?;
+        self.write_reg(handle, REG_VCO_BW, reg6)?;
+
+        // VCO calibration: set high then low
+        self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_TRIGGER)?;
+        self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_RESET)?;
+
+        // VCO re-calibration if needed
+        self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_RESET)?;
+
+        let tmp = self.read_reg(handle, REG_VCO_CALIB)?;
+
+        // VCO selection based on control voltage
+        let voltage = tmp & VCO_VOLTAGE_MASK;
+
+        if vco_select {
+            if voltage > VCO_VOLTAGE_HIGH {
+                reg6 &= !VCO_SPEED_BIT;
+                self.write_reg(handle, REG_VCO_BW, reg6)?;
+                self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_TRIGGER)?;
+                self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_RESET)?;
+            }
+        } else if voltage < VCO_VOLTAGE_LOW {
+            reg6 |= VCO_SPEED_BIT;
+            self.write_reg(handle, REG_VCO_BW, reg6)?;
+            self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_TRIGGER)?;
+            self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_RESET)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Tuner for Fc0012Tuner {
+    /// Initialize the FC0012 tuner.
+    ///
+    /// Exact port of `fc0012_init`.
+    fn init(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        // Start with default register values
+        let mut regs = INIT_REGS;
+
+        // 28.8 MHz crystal: set bit 5 of register 0x07
+        // Index 6 in our array corresponds to register 0x07
+        regs[6] |= XTAL_28_8_MHZ_BIT;
+
+        // Dual master mode: set bit 1 of register 0x0c
+        // Index 11 in our array corresponds to register 0x0c
+        regs[11] |= DUAL_MASTER_BIT;
+
+        // Write registers 0x01 through 0x15
+        for (i, &val) in regs.iter().enumerate() {
+            let reg_addr = (i + 1) as u8;
+            self.write_reg(handle, reg_addr, val)?;
+        }
+
+        Ok(())
+    }
+
+    /// Put the tuner in standby.
+    ///
+    /// The FC0012 C driver does not define an explicit exit/standby function.
+    /// Power down the LNA by setting bit 0 of register 0x06.
+    fn exit(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        // Power down LNA (bit 0 of reg 0x06 = LNA_POWER_DOWN)
+        let val = self.read_reg(handle, REG_VCO_BW)?;
+        self.write_reg(handle, REG_VCO_BW, val | 0x01)?;
+        Ok(())
+    }
+
+    /// Set the tuner frequency.
+    ///
+    /// Delegates to `set_params` with the stored bandwidth.
+    fn set_freq(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq: u32,
+    ) -> Result<(), RtlSdrError> {
+        self.freq = freq;
+        self.set_params(handle, freq, self.bandwidth)
+    }
+
+    /// Set the tuner bandwidth. Returns 0 as the IF frequency (the FC0012
+    /// does not have a configurable IF output like the R82XX).
+    fn set_bw(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        bw: u32,
+        _sample_rate: u32,
+    ) -> Result<u32, RtlSdrError> {
+        self.bandwidth = bw;
+        // Re-apply frequency with new bandwidth if already tuned
+        if self.freq > 0 {
+            self.set_params(handle, self.freq, bw)?;
+        }
+        // FC0012 does not have a separate IF frequency to report
+        Ok(0)
+    }
+
+    /// Set the tuner gain.
+    ///
+    /// Exact port of `fc0012_set_gain`. Gain is in tenths of dB.
+    fn set_gain(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        gain: i32,
+    ) -> Result<(), RtlSdrError> {
+        let mut tmp = self.read_reg(handle, REG_LNA_GAIN)?;
+
+        // Mask off gain bits (keep bits 5-7)
+        tmp &= LNA_GAIN_MASK;
+
+        // Select gain based on thresholds (tenths of dB)
+        let gain_bits = if gain < GAIN_THRESH_NEG_9_9 {
+            GAIN_NEG_9_9_DB
+        } else if gain < GAIN_THRESH_NEG_4_0 {
+            GAIN_NEG_4_0_DB
+        } else if gain < GAIN_THRESH_7_1 {
+            GAIN_7_1_DB
+        } else if gain < GAIN_THRESH_17_9 {
+            GAIN_17_9_DB
+        } else {
+            GAIN_19_2_DB
+        };
+
+        tmp |= gain_bits;
+        self.write_reg(handle, REG_LNA_GAIN, tmp)?;
+
+        Ok(())
+    }
+
+    /// Update the crystal frequency.
+    fn set_xtal(&mut self, xtal: u32) {
+        self.xtal = xtal;
+    }
+
+    /// Set manual or automatic gain mode.
+    ///
+    /// The FC0012 uses register 0x0d to control AGC/LNA forcing.
+    fn set_gain_mode(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        manual: bool,
+    ) -> Result<(), RtlSdrError> {
+        if manual {
+            // LNA forcing on, AGC not forcing (DVB-T mode from init: 0x02)
+            self.write_reg(handle, REG_AGC_LNA_FORCE, 0x02)?;
+        } else {
+            // Disable LNA forcing for automatic gain
+            self.write_reg(handle, REG_AGC_LNA_FORCE, 0x00)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_regs_length() {
+        assert_eq!(INIT_REGS.len(), NUM_INIT_REGS);
+        // Covers registers 0x01 through 0x15 = 21 registers
+        assert_eq!(NUM_INIT_REGS, 21);
+    }
+
+    #[test]
+    fn test_freq_dividers_ordered() {
+        for w in FREQ_DIVIDERS.windows(2) {
+            assert!(
+                w[0].max_freq < w[1].max_freq,
+                "frequency dividers must be in ascending order"
+            );
+        }
+    }
+
+    #[test]
+    fn test_freq_dividers_cover_full_range() {
+        // Last entry should cover everything up to u32::MAX
+        assert_eq!(FREQ_DIVIDERS[FREQ_DIVIDERS.len() - 1].max_freq, u32::MAX);
+    }
+
+    #[test]
+    fn test_gains_sorted() {
+        for w in FC0012_GAINS.windows(2) {
+            assert!(w[0] < w[1], "gains must be in ascending order");
+        }
+    }
+
+    #[test]
+    fn test_gains_count() {
+        assert_eq!(FC0012_GAINS.len(), 5);
+    }
+
+    #[test]
+    fn test_gains_values() {
+        // Verify exact gain values from C source (tenths of dB)
+        assert_eq!(FC0012_GAINS[0], -99); // -9.9 dB
+        assert_eq!(FC0012_GAINS[1], -40); // -4.0 dB
+        assert_eq!(FC0012_GAINS[2], 71); //  7.1 dB
+        assert_eq!(FC0012_GAINS[3], 179); // 17.9 dB
+        assert_eq!(FC0012_GAINS[4], 192); // 19.2 dB
+    }
+
+    #[test]
+    fn test_i2c_addr() {
+        assert_eq!(I2C_ADDR, 0xc6);
+    }
+
+    #[test]
+    fn test_check_val() {
+        assert_eq!(CHECK_VAL, 0xa1);
+    }
+
+    #[test]
+    fn test_new_defaults() {
+        let tuner = Fc0012Tuner::new(28_800_000);
+        assert_eq!(tuner.xtal, 28_800_000);
+        assert_eq!(tuner.bandwidth, BW_6MHZ_HZ);
+        assert_eq!(tuner.freq, 0);
+    }
+
+    #[test]
+    fn test_init_regs_xtal_bit() {
+        // Register 0x07 is at index 6 in INIT_REGS.
+        // After applying XTAL_28_8_MHZ_BIT, bit 5 should be set.
+        let mut regs = INIT_REGS;
+        regs[6] |= XTAL_28_8_MHZ_BIT;
+        assert_eq!(regs[6] & XTAL_28_8_MHZ_BIT, XTAL_28_8_MHZ_BIT);
+    }
+
+    #[test]
+    fn test_init_regs_dual_master_bit() {
+        // Register 0x0c is at index 11 in INIT_REGS.
+        // After applying DUAL_MASTER_BIT, bit 1 should be set.
+        let mut regs = INIT_REGS;
+        regs[11] |= DUAL_MASTER_BIT;
+        assert_eq!(regs[11] & DUAL_MASTER_BIT, DUAL_MASTER_BIT);
+    }
+
+    #[test]
+    fn test_freq_divider_selection() {
+        // 100 MHz should select multi=32
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 100_000_000 < d.max_freq)
+            .expect("should find divider for 100 MHz");
+        assert_eq!(divider.multi, 32);
+
+        // 500 MHz should select multi=6
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 500_000_000 < d.max_freq)
+            .expect("should find divider for 500 MHz");
+        assert_eq!(divider.multi, 6);
+
+        // 30 MHz should select multi=96
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 30_000_000 < d.max_freq)
+            .expect("should find divider for 30 MHz");
+        assert_eq!(divider.multi, 96);
+
+        // 700 MHz should select multi=4 (fallback)
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 700_000_000 < d.max_freq)
+            .expect("should find divider for 700 MHz");
+        assert_eq!(divider.multi, 4);
+    }
+
+    #[test]
+    fn test_gain_threshold_values() {
+        // Verify gain thresholds match the C source boundary values (tenths of dB)
+        assert_eq!(GAIN_THRESH_NEG_9_9, -40);
+        assert_eq!(GAIN_THRESH_NEG_4_0, 71);
+        assert_eq!(GAIN_THRESH_7_1, 179);
+        assert_eq!(GAIN_THRESH_17_9, 192);
+    }
+}

--- a/crates/sdr-rtlsdr/src/tuner/fc0012.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc0012.rs
@@ -399,9 +399,12 @@ impl Fc0012Tuner {
         reg6 |= CLOCK_OUT_BIT;
 
         // Calculate XIN (fractional part of Delta Sigma PLL)
+        // In C, `xin << 15` promotes the uint16_t to int (32-bit) before shifting,
+        // so the shift and division must be done in u32 to avoid u16 overflow.
         let xin_remainder =
             (f_vco - (f_vco / u64::from(xtal_freq_div_2)) * u64::from(xtal_freq_div_2)) / 1000;
-        let mut xin = ((xin_remainder as u16) << 15) / ((xtal_freq_div_2 / 1000) as u16);
+        let xin_wide = (u32::from(xin_remainder as u16) << 15) / (xtal_freq_div_2 / 1000);
+        let mut xin = xin_wide as u16;
         if xin >= XIN_THRESHOLD {
             xin += XIN_OVERFLOW_ADD;
         }

--- a/crates/sdr-rtlsdr/src/tuner/fc0013.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc0013.rs
@@ -1,0 +1,968 @@
+//! Fitipower FC0013 tuner driver.
+//!
+//! Faithful port of `tuner_fc0013.c` from librtlsdr.
+//!
+//! Original copyright:
+//! - Copyright (C) 2012 Hans-Frieder Vogt <hfvogt@gmx.net>
+//! - Copyright (C) 2010 Fitipower Integrated Technology Inc (partial driver code)
+//! - Copyright (C) 2012 Steve Markgraf <steve@steve-m.de> (librtlsdr modifications)
+
+use crate::error::RtlSdrError;
+use crate::tuner::Tuner;
+use crate::usb;
+
+// ---------------------------------------------------------------------------
+// I2C address and identification
+// ---------------------------------------------------------------------------
+
+/// FC0013 I2C address.
+pub const I2C_ADDR: u8 = 0xc6;
+
+/// Register address used to identify the FC0013 (chip ID register).
+pub const CHECK_ADDR: u8 = 0x00;
+
+/// Expected chip ID value read from `CHECK_ADDR`.
+pub const CHECK_VAL: u8 = 0xa3;
+
+// ---------------------------------------------------------------------------
+// Register addresses
+// ---------------------------------------------------------------------------
+
+/// RF divider count-to-9 cycles (reg 0x01).
+const REG_RF_A: u8 = 0x01;
+
+/// RF divider total cycles (reg 0x02).
+const REG_RF_M: u8 = 0x02;
+
+/// Fractional divider bits 8..15 (reg 0x03).
+const REG_RF_K_HIGH: u8 = 0x03;
+
+/// Fractional divider bits 0..7 (reg 0x04).
+const REG_RF_K_LOW: u8 = 0x04;
+
+/// RF output divider A (reg 0x05).
+const REG_RF_OUTDIV_A: u8 = 0x05;
+
+/// LNA power down, RF output divider B, VCO speed, bandwidth (reg 0x06).
+const REG_VCO_BW: u8 = 0x06;
+
+/// Crystal speed / VHF filter control register (reg 0x07).
+const REG_XTAL_SPEED: u8 = 0x07;
+
+/// RC calibration push register (reg 0x10).
+const REG_RC_CAL: u8 = 0x10;
+
+/// Multi select / 64x divider register (reg 0x11).
+const REG_MULTI_SELECT: u8 = 0x11;
+
+/// IF gain register (reg 0x13).
+const REG_IF_GAIN: u8 = 0x13;
+
+/// AGC/LNA forcing register (reg 0x0d).
+const REG_AGC_LNA_FORCE: u8 = 0x0d;
+
+/// VCO calibration register (reg 0x0e).
+const REG_VCO_CALIB: u8 = 0x0e;
+
+/// LNA gain / UHF-VHF-GPS band register (reg 0x14).
+const REG_LNA_GAIN: u8 = 0x14;
+
+/// VHF tracking filter register (reg 0x1d).
+const REG_VHF_TRACK: u8 = 0x1d;
+
+// ---------------------------------------------------------------------------
+// Init register default values
+// ---------------------------------------------------------------------------
+
+/// Number of registers written during init (regs 0x01 to 0x15 = 21).
+const NUM_INIT_REGS: usize = 21;
+
+/// Default register values for init, indexed 0..20 mapping to regs 0x01..0x15.
+///
+/// The C source uses `reg[0]` as a dummy (unused); we skip it and index
+/// from 0 corresponding to register address 0x01.
+const INIT_REGS: [u8; NUM_INIT_REGS] = [
+    0x09, // reg 0x01
+    0x16, // reg 0x02
+    0x00, // reg 0x03
+    0x00, // reg 0x04
+    0x17, // reg 0x05
+    0x02, // reg 0x06: LPF bandwidth
+    0x0a, // reg 0x07: CHECK (xtal speed bits applied later)
+    0xff, // reg 0x08: AGC clock divide by 256, AGC gain 1/256, loop BW 1/8
+    0x6e, // reg 0x09: disable loop-through (enable: 0x6f)
+    0xb8, // reg 0x0a: disable LO test buffer
+    0x82, // reg 0x0b: CHECK
+    0xfc, // reg 0x0c: AGC up-down mode (may need 0xf8)
+    0x01, // reg 0x0d: AGC not forcing & LNA forcing (may need 0x02)
+    0x00, // reg 0x0e
+    0x00, // reg 0x0f
+    0x00, // reg 0x10
+    0x00, // reg 0x11
+    0x00, // reg 0x12
+    0x00, // reg 0x13
+    0x50, // reg 0x14: DVB-t high gain, UHF (mid: 0x48, low: 0x40)
+    0x01, // reg 0x15
+];
+
+// ---------------------------------------------------------------------------
+// Frequency-related constants
+// ---------------------------------------------------------------------------
+
+/// VCO frequency threshold for high-range selection (3.06 GHz).
+const VCO_HIGH_THRESH: u64 = 3_060_000_000;
+
+/// VCO re-calibration: low voltage threshold.
+const VCO_VOLTAGE_LOW: u8 = 0x02;
+
+/// VCO re-calibration: high voltage threshold.
+const VCO_VOLTAGE_HIGH: u8 = 0x3c;
+
+/// Mask for VCO voltage readback (bits 0-5).
+const VCO_VOLTAGE_MASK: u8 = 0x3f;
+
+/// VCO speed bit in register 0x06 (high VCO range).
+const VCO_SPEED_BIT: u8 = 0x08;
+
+/// Clock-out fix bit in register 0x06.
+const CLOCK_OUT_BIT: u8 = 0x20;
+
+/// VCO calibration trigger value.
+const VCO_CALIB_TRIGGER: u8 = 0x80;
+
+/// VCO calibration reset value.
+const VCO_CALIB_RESET: u8 = 0x00;
+
+/// 28.8 MHz crystal select bit in register 0x07.
+const XTAL_28_8_MHZ_BIT: u8 = 0x20;
+
+/// Dual master bit in register 0x0c.
+const DUAL_MASTER_BIT: u8 = 0x02;
+
+/// Fractional divider threshold (xin >= 16384 adds 32768).
+const XIN_THRESHOLD: u16 = 16384;
+
+/// Fractional divider overflow correction.
+const XIN_OVERFLOW_ADD: u16 = 32768;
+
+/// Bandwidth bits mask in register 0x06 (bits 6-7 cleared).
+const BW_MASK: u8 = 0x3f;
+
+/// 6 MHz bandwidth setting for register 0x06.
+const BW_6MHZ: u8 = 0x80;
+
+/// 7 MHz bandwidth setting for register 0x06.
+const BW_7MHZ: u8 = 0x40;
+
+/// Bandwidth: 6 MHz in Hz.
+const BW_6MHZ_HZ: u32 = 6_000_000;
+
+/// Bandwidth: 7 MHz in Hz.
+const BW_7MHZ_HZ: u32 = 7_000_000;
+
+/// Modified register 0x05 lower bits for Realtek demod.
+const REALTEK_DEMOD_BITS: u8 = 0x07;
+
+/// LNA gain register mask (bits 5-7 preserved, bits 0-4 cleared).
+const LNA_GAIN_MASK: u8 = 0xe0;
+
+/// VHF filter enable bit in register 0x07.
+const VHF_FILTER_ENABLE_BIT: u8 = 0x10;
+
+/// VHF filter disable mask for register 0x07.
+const VHF_FILTER_DISABLE_MASK: u8 = 0xef;
+
+/// UHF/GPS band mask for register 0x14 (bits 0-4 preserved).
+const BAND_SELECT_MASK: u8 = 0x1f;
+
+/// UHF enable bit in register 0x14.
+const UHF_ENABLE_BIT: u8 = 0x40;
+
+/// VHF tracking filter mask for register 0x1d (preserves bits 0-1 and 5-7).
+const VHF_TRACK_MASK: u8 = 0xe3;
+
+/// Multi=64 select bit in register 0x11.
+const MULTI_64_BIT: u8 = 0x04;
+
+/// Multi=64 disable mask for register 0x11.
+const MULTI_64_DISABLE_MASK: u8 = 0xfb;
+
+/// Manual gain mode bit in register 0x0d (bit 3).
+const MANUAL_GAIN_BIT: u8 = 1 << 3;
+
+/// Fixed IF gain value written to register 0x13.
+const FIXED_IF_GAIN: u8 = 0x0a;
+
+/// RC calibration forcing mode value for register 0x0d.
+const RC_CAL_FORCE: u8 = 0x11;
+
+/// RC calibration reset value for register 0x0d.
+const RC_CAL_RESET: u8 = 0x01;
+
+/// Maximum valid RC calibration value.
+const RC_CAL_MAX: u8 = 0x0f;
+
+// ---------------------------------------------------------------------------
+// VHF tracking filter values
+// ---------------------------------------------------------------------------
+
+/// VHF track value for freq <= 177.5 MHz (track 7).
+const VHF_TRACK_7: u8 = 0x1c;
+
+/// VHF track value for freq <= 184.5 MHz (track 6).
+const VHF_TRACK_6: u8 = 0x18;
+
+/// VHF track value for freq <= 191.5 MHz (track 5).
+const VHF_TRACK_5: u8 = 0x14;
+
+/// VHF track value for freq <= 198.5 MHz (track 4).
+const VHF_TRACK_4: u8 = 0x10;
+
+/// VHF track value for freq <= 205.5 MHz (track 3).
+const VHF_TRACK_3: u8 = 0x0c;
+
+/// VHF track value for freq <= 219.5 MHz (track 2).
+const VHF_TRACK_2: u8 = 0x08;
+
+/// VHF track value for freq < 300 MHz (track 1).
+const VHF_TRACK_1: u8 = 0x04;
+
+/// VHF track value for UHF/GPS (same as track 7).
+const VHF_TRACK_UHF_GPS: u8 = 0x1c;
+
+/// VHF track frequency thresholds in Hz.
+const VHF_TRACK_THRESH_7: u32 = 177_500_000;
+const VHF_TRACK_THRESH_6: u32 = 184_500_000;
+const VHF_TRACK_THRESH_5: u32 = 191_500_000;
+const VHF_TRACK_THRESH_4: u32 = 198_500_000;
+const VHF_TRACK_THRESH_3: u32 = 205_500_000;
+const VHF_TRACK_THRESH_2: u32 = 219_500_000;
+
+/// VHF/UHF boundary frequency.
+const VHF_UHF_BOUNDARY: u32 = 300_000_000;
+
+// ---------------------------------------------------------------------------
+// Frequency divider table
+// ---------------------------------------------------------------------------
+
+/// Frequency divider selection entry.
+///
+/// Maps a maximum frequency to the VCO multiplier and register values
+/// for registers 0x05 and 0x06 that control the RF output divider.
+struct FreqDivider {
+    /// Maximum frequency in Hz (exclusive upper bound).
+    max_freq: u32,
+    /// VCO frequency multiplier.
+    multi: u8,
+    /// Value for register 0x05 (RF_OUTDIV_A).
+    reg5: u8,
+    /// Value for register 0x06 (RF_OUTDIV_B and VCO speed).
+    reg6: u8,
+}
+
+/// Frequency divider table, ordered by ascending max frequency.
+///
+/// Each entry defines the multiplier used such that `freq * multi < 3.56 GHz`
+/// (or 3.8 GHz for the 950 MHz entry).
+/// The last entry has no upper bound (used as fallback for freq >= 950 MHz).
+const FREQ_DIVIDERS: [FreqDivider; 11] = [
+    FreqDivider {
+        max_freq: 37_084_000,
+        multi: 96,
+        reg5: 0x82,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 55_625_000,
+        multi: 64,
+        reg5: 0x02,
+        reg6: 0x02,
+    },
+    FreqDivider {
+        max_freq: 74_167_000,
+        multi: 48,
+        reg5: 0x42,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 111_250_000,
+        multi: 32,
+        reg5: 0x82,
+        reg6: 0x02,
+    },
+    FreqDivider {
+        max_freq: 148_334_000,
+        multi: 24,
+        reg5: 0x22,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 222_500_000,
+        multi: 16,
+        reg5: 0x42,
+        reg6: 0x02,
+    },
+    FreqDivider {
+        max_freq: 296_667_000,
+        multi: 12,
+        reg5: 0x12,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 445_000_000,
+        multi: 8,
+        reg5: 0x22,
+        reg6: 0x02,
+    },
+    FreqDivider {
+        max_freq: 593_334_000,
+        multi: 6,
+        reg5: 0x0a,
+        reg6: 0x00,
+    },
+    FreqDivider {
+        max_freq: 950_000_000,
+        multi: 4,
+        reg5: 0x12,
+        reg6: 0x02,
+    },
+    // Fallback: freq >= 950 MHz
+    FreqDivider {
+        max_freq: u32::MAX,
+        multi: 2,
+        reg5: 0x0a,
+        reg6: 0x02,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// LNA gain table
+// ---------------------------------------------------------------------------
+
+/// LNA gain entry: (gain in tenths of dB, register value).
+///
+/// From librtlsdr `fc0013_lna_gains[]`. The table is ordered by ascending
+/// gain so that `set_lna_gain` can find the first entry >= requested gain.
+const LNA_GAINS: [(i32, u8); 24] = [
+    (-99, 0x02),
+    (-73, 0x03),
+    (-65, 0x05),
+    (-63, 0x04),
+    (-63, 0x00),
+    (-60, 0x07),
+    (-58, 0x01),
+    (-54, 0x06),
+    (58, 0x0f),
+    (61, 0x0e),
+    (63, 0x0d),
+    (65, 0x0c),
+    (67, 0x0b),
+    (68, 0x0a),
+    (70, 0x09),
+    (71, 0x08),
+    (179, 0x17),
+    (181, 0x16),
+    (182, 0x15),
+    (184, 0x14),
+    (186, 0x13),
+    (188, 0x12),
+    (191, 0x11),
+    (197, 0x10),
+];
+
+/// Supported gain values in tenths of dB (extracted from `LNA_GAINS`).
+///
+/// Matches `FC0013_GAINS` in `constants.rs` for use in the tuner type
+/// gain table. Deduplicated (the C table has -63 twice).
+pub const FC0013_GAINS: [i32; 23] = [
+    -99, -73, -65, -63, -60, -58, -54, 58, 61, 63, 65, 67, 68, 70, 71, 179, 181, 182, 184, 186,
+    188, 191, 197,
+];
+
+// ---------------------------------------------------------------------------
+// PLL validation limits
+// ---------------------------------------------------------------------------
+
+/// Maximum valid value for register 1 (RF_A) during PLL calculation.
+const PLL_REG1_MAX: u8 = 15;
+
+/// Minimum valid value for register 2 (RF_M) during PLL calculation.
+const PLL_REG2_MIN: u8 = 0x0b;
+
+// ---------------------------------------------------------------------------
+// FC0013 tuner state
+// ---------------------------------------------------------------------------
+
+/// Fitipower FC0013 tuner driver.
+///
+/// Ports `fc0013_init`, `fc0013_set_params`, `fc0013_set_gain_mode`,
+/// and `fc0013_set_lna_gain` from `tuner_fc0013.c`.
+pub struct Fc0013Tuner {
+    /// Crystal oscillator frequency in Hz.
+    xtal: u32,
+    /// Current bandwidth setting in Hz (stored for `set_freq`).
+    bandwidth: u32,
+    /// Current tuned frequency in Hz.
+    freq: u32,
+}
+
+impl Fc0013Tuner {
+    /// Create a new FC0013 tuner driver.
+    pub fn new(xtal: u32) -> Self {
+        Self {
+            xtal,
+            bandwidth: BW_6MHZ_HZ,
+            freq: 0,
+        }
+    }
+
+    /// Write a single register via I2C.
+    ///
+    /// Ports `fc0013_writereg`.
+    #[allow(clippy::unused_self)]
+    fn write_reg(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+        val: u8,
+    ) -> Result<(), RtlSdrError> {
+        usb::i2c_write_reg(handle, I2C_ADDR, reg, val)
+    }
+
+    /// Read a single register via I2C.
+    ///
+    /// Ports `fc0013_readreg`.
+    #[allow(clippy::unused_self)]
+    fn read_reg(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+    ) -> Result<u8, RtlSdrError> {
+        usb::i2c_read_reg(handle, I2C_ADDR, reg)
+    }
+
+    /// Set VHF tracking filter based on frequency.
+    ///
+    /// Exact port of `fc0013_set_vhf_track`.
+    fn set_vhf_track(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq: u32,
+    ) -> Result<(), RtlSdrError> {
+        let tmp = self.read_reg(handle, REG_VHF_TRACK)?;
+        let tmp = tmp & VHF_TRACK_MASK;
+
+        let track_bits = if freq <= VHF_TRACK_THRESH_7 {
+            VHF_TRACK_7
+        } else if freq <= VHF_TRACK_THRESH_6 {
+            VHF_TRACK_6
+        } else if freq <= VHF_TRACK_THRESH_5 {
+            VHF_TRACK_5
+        } else if freq <= VHF_TRACK_THRESH_4 {
+            VHF_TRACK_4
+        } else if freq <= VHF_TRACK_THRESH_3 {
+            VHF_TRACK_3
+        } else if freq <= VHF_TRACK_THRESH_2 {
+            VHF_TRACK_2
+        } else if freq < VHF_UHF_BOUNDARY {
+            VHF_TRACK_1
+        } else {
+            // UHF and GPS
+            VHF_TRACK_UHF_GPS
+        };
+
+        self.write_reg(handle, REG_VHF_TRACK, tmp | track_bits)
+    }
+
+    /// Set tuner frequency and bandwidth.
+    ///
+    /// Exact port of `fc0013_set_params`.
+    #[allow(clippy::cast_possible_truncation)]
+    fn set_params(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq: u32,
+        bandwidth: u32,
+    ) -> Result<(), RtlSdrError> {
+        let xtal_freq_div_2 = self.xtal / 2;
+
+        // Set VHF track
+        self.set_vhf_track(handle, freq)?;
+
+        // VHF/UHF/GPS band selection
+        if freq < VHF_UHF_BOUNDARY {
+            // Enable VHF filter
+            let tmp = self.read_reg(handle, REG_XTAL_SPEED)?;
+            self.write_reg(handle, REG_XTAL_SPEED, tmp | VHF_FILTER_ENABLE_BIT)?;
+
+            // Disable UHF & disable GPS
+            let tmp = self.read_reg(handle, REG_LNA_GAIN)?;
+            self.write_reg(handle, REG_LNA_GAIN, tmp & BAND_SELECT_MASK)?;
+        } else {
+            // freq >= 300 MHz (UHF or GPS): same handling for both <=862MHz and >862MHz
+            // Disable VHF filter
+            let tmp = self.read_reg(handle, REG_XTAL_SPEED)?;
+            self.write_reg(handle, REG_XTAL_SPEED, tmp & VHF_FILTER_DISABLE_MASK)?;
+
+            // Enable UHF & disable GPS
+            let tmp = self.read_reg(handle, REG_LNA_GAIN)?;
+            self.write_reg(
+                handle,
+                REG_LNA_GAIN,
+                (tmp & BAND_SELECT_MASK) | UHF_ENABLE_BIT,
+            )?;
+        }
+
+        // Select frequency divider and VCO frequency
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| freq < d.max_freq)
+            .unwrap_or(&FREQ_DIVIDERS[FREQ_DIVIDERS.len() - 1]);
+
+        let multi = divider.multi;
+        let mut reg5 = divider.reg5;
+        let mut reg6 = divider.reg6;
+
+        let f_vco = u64::from(freq) * u64::from(multi);
+
+        let mut vco_select = false;
+        if f_vco >= VCO_HIGH_THRESH {
+            reg6 |= VCO_SPEED_BIT;
+            vco_select = true;
+        }
+
+        // From divided value (XDIV) determine the FA (am) and FP (pm) values
+        let mut xdiv = (f_vco / u64::from(xtal_freq_div_2)) as u16;
+        let remainder = f_vco - u64::from(xdiv) * u64::from(xtal_freq_div_2);
+        if remainder >= u64::from(xtal_freq_div_2 / 2) {
+            xdiv += 1;
+        }
+
+        let mut pm = xdiv / 8;
+        let mut am = xdiv - (8 * pm);
+
+        if am < 2 {
+            am += 8;
+            pm -= 1;
+        }
+
+        let (reg1, reg2) = if pm > 31 {
+            ((am + 8 * (pm - 31)) as u8, 31u8)
+        } else {
+            (am as u8, pm as u8)
+        };
+
+        if reg1 > PLL_REG1_MAX || reg2 < PLL_REG2_MIN {
+            return Err(RtlSdrError::Tuner(format!(
+                "FC0013: no valid PLL combination found for {freq} Hz"
+            )));
+        }
+
+        // Fix clock out
+        reg6 |= CLOCK_OUT_BIT;
+
+        // Calculate XIN (fractional part of Delta Sigma PLL)
+        let xin_remainder =
+            (f_vco - (f_vco / u64::from(xtal_freq_div_2)) * u64::from(xtal_freq_div_2)) / 1000;
+        let mut xin = ((xin_remainder as u16) << 15) / ((xtal_freq_div_2 / 1000) as u16);
+        if xin >= XIN_THRESHOLD {
+            xin += XIN_OVERFLOW_ADD;
+        }
+
+        let reg3 = (xin >> 8) as u8;
+        let reg4 = (xin & 0xff) as u8;
+
+        // Bandwidth selection (bits 6-7 of reg6)
+        reg6 &= BW_MASK;
+        match bandwidth {
+            BW_6MHZ_HZ => reg6 |= BW_6MHZ,
+            BW_7MHZ_HZ => reg6 |= BW_7MHZ,
+            _ => {} // 8 MHz: no extra bits
+        }
+
+        // Modified for Realtek demod
+        reg5 |= REALTEK_DEMOD_BITS;
+
+        // Write PLL registers 0x01 through 0x06
+        self.write_reg(handle, REG_RF_A, reg1)?;
+        self.write_reg(handle, REG_RF_M, reg2)?;
+        self.write_reg(handle, REG_RF_K_HIGH, reg3)?;
+        self.write_reg(handle, REG_RF_K_LOW, reg4)?;
+        self.write_reg(handle, REG_RF_OUTDIV_A, reg5)?;
+        self.write_reg(handle, REG_VCO_BW, reg6)?;
+
+        // Multi=64 special case: set bit 2 of register 0x11
+        let tmp = self.read_reg(handle, REG_MULTI_SELECT)?;
+        if multi == 64 {
+            self.write_reg(handle, REG_MULTI_SELECT, tmp | MULTI_64_BIT)?;
+        } else {
+            self.write_reg(handle, REG_MULTI_SELECT, tmp & MULTI_64_DISABLE_MASK)?;
+        }
+
+        // VCO calibration: set high then low
+        self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_TRIGGER)?;
+        self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_RESET)?;
+
+        // VCO re-calibration if needed
+        self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_RESET)?;
+
+        let tmp = self.read_reg(handle, REG_VCO_CALIB)?;
+
+        // VCO selection based on control voltage
+        let voltage = tmp & VCO_VOLTAGE_MASK;
+
+        if vco_select {
+            if voltage > VCO_VOLTAGE_HIGH {
+                reg6 &= !VCO_SPEED_BIT;
+                self.write_reg(handle, REG_VCO_BW, reg6)?;
+                self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_TRIGGER)?;
+                self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_RESET)?;
+            }
+        } else if voltage < VCO_VOLTAGE_LOW {
+            reg6 |= VCO_SPEED_BIT;
+            self.write_reg(handle, REG_VCO_BW, reg6)?;
+            self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_TRIGGER)?;
+            self.write_reg(handle, REG_VCO_CALIB, VCO_CALIB_RESET)?;
+        }
+
+        Ok(())
+    }
+
+    /// Add an offset to the RC calibration value.
+    ///
+    /// Exact port of `fc0013_rc_cal_add`.
+    #[allow(dead_code)]
+    pub fn rc_cal_add(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        rc_val: i32,
+    ) -> Result<(), RtlSdrError> {
+        // Push rc_cal value, then read it back
+        self.write_reg(handle, REG_RC_CAL, 0x00)?;
+
+        let rc_cal = self.read_reg(handle, REG_RC_CAL)?;
+        let rc_cal = i32::from(rc_cal & RC_CAL_MAX);
+
+        let val = rc_cal + rc_val;
+
+        // Force rc_cal
+        self.write_reg(handle, REG_AGC_LNA_FORCE, RC_CAL_FORCE)?;
+
+        // Modify rc_cal value (clamped to 0..15)
+        if val > i32::from(RC_CAL_MAX) {
+            self.write_reg(handle, REG_RC_CAL, RC_CAL_MAX)?;
+        } else if val < 0 {
+            self.write_reg(handle, REG_RC_CAL, 0x00)?;
+        } else {
+            self.write_reg(handle, REG_RC_CAL, val as u8)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reset the RC calibration.
+    ///
+    /// Exact port of `fc0013_rc_cal_reset`.
+    #[allow(dead_code)]
+    pub fn rc_cal_reset(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        self.write_reg(handle, REG_AGC_LNA_FORCE, RC_CAL_RESET)?;
+        self.write_reg(handle, REG_RC_CAL, 0x00)?;
+        Ok(())
+    }
+}
+
+impl Tuner for Fc0013Tuner {
+    /// Initialize the FC0013 tuner.
+    ///
+    /// Exact port of `fc0013_init`.
+    fn init(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        let mut regs = INIT_REGS;
+
+        // 28.8 MHz crystal: set bit 5 of register 0x07
+        // Index 6 in our array corresponds to register 0x07
+        regs[6] |= XTAL_28_8_MHZ_BIT;
+
+        // Dual master mode: set bit 1 of register 0x0c
+        // Index 11 in our array corresponds to register 0x0c
+        regs[11] |= DUAL_MASTER_BIT;
+
+        // Write registers 0x01 through 0x15
+        for (i, &val) in regs.iter().enumerate() {
+            let reg_addr = (i + 1) as u8;
+            self.write_reg(handle, reg_addr, val)?;
+        }
+
+        Ok(())
+    }
+
+    /// Put the tuner in standby.
+    ///
+    /// The FC0013 C driver does not define an explicit exit/standby function.
+    /// Power down the LNA by setting bit 0 of register 0x06.
+    fn exit(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        let val = self.read_reg(handle, REG_VCO_BW)?;
+        self.write_reg(handle, REG_VCO_BW, val | 0x01)?;
+        Ok(())
+    }
+
+    /// Set the tuner frequency.
+    ///
+    /// Delegates to `set_params` with the stored bandwidth.
+    fn set_freq(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq: u32,
+    ) -> Result<(), RtlSdrError> {
+        self.freq = freq;
+        self.set_params(handle, freq, self.bandwidth)
+    }
+
+    /// Set the tuner bandwidth. Returns 0 as the IF frequency (the FC0013
+    /// does not have a configurable IF output like the R82XX).
+    fn set_bw(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        bw: u32,
+        _sample_rate: u32,
+    ) -> Result<u32, RtlSdrError> {
+        self.bandwidth = bw;
+        // Re-apply frequency with new bandwidth if already tuned
+        if self.freq > 0 {
+            self.set_params(handle, self.freq, bw)?;
+        }
+        // FC0013 does not have a separate IF frequency to report
+        Ok(0)
+    }
+
+    /// Set the LNA gain.
+    ///
+    /// Exact port of `fc0013_set_lna_gain`. Gain is in tenths of dB.
+    fn set_gain(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        gain: i32,
+    ) -> Result<(), RtlSdrError> {
+        let mut tmp = self.read_reg(handle, REG_LNA_GAIN)?;
+
+        // Mask off LNA gain bits (keep bits 5-7)
+        tmp &= LNA_GAIN_MASK;
+
+        // Find the first entry whose gain >= requested, or use the last entry
+        for (i, &(entry_gain, reg_val)) in LNA_GAINS.iter().enumerate() {
+            if entry_gain >= gain || i + 1 == LNA_GAINS.len() {
+                tmp |= reg_val;
+                break;
+            }
+        }
+
+        self.write_reg(handle, REG_LNA_GAIN, tmp)?;
+
+        Ok(())
+    }
+
+    /// Update the crystal frequency.
+    fn set_xtal(&mut self, xtal: u32) {
+        self.xtal = xtal;
+    }
+
+    /// Set manual or automatic gain mode.
+    ///
+    /// Exact port of `fc0013_set_gain_mode`.
+    fn set_gain_mode(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        manual: bool,
+    ) -> Result<(), RtlSdrError> {
+        let mut tmp = self.read_reg(handle, REG_AGC_LNA_FORCE)?;
+
+        if manual {
+            tmp |= MANUAL_GAIN_BIT;
+        } else {
+            tmp &= !MANUAL_GAIN_BIT;
+        }
+
+        self.write_reg(handle, REG_AGC_LNA_FORCE, tmp)?;
+
+        // Set a fixed IF gain
+        self.write_reg(handle, REG_IF_GAIN, FIXED_IF_GAIN)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_regs_length() {
+        assert_eq!(INIT_REGS.len(), NUM_INIT_REGS);
+        // Covers registers 0x01 through 0x15 = 21 registers
+        assert_eq!(NUM_INIT_REGS, 21);
+    }
+
+    #[test]
+    fn test_freq_dividers_ordered() {
+        for w in FREQ_DIVIDERS.windows(2) {
+            assert!(
+                w[0].max_freq < w[1].max_freq,
+                "frequency dividers must be in ascending order"
+            );
+        }
+    }
+
+    #[test]
+    fn test_freq_dividers_cover_full_range() {
+        assert_eq!(FREQ_DIVIDERS[FREQ_DIVIDERS.len() - 1].max_freq, u32::MAX);
+    }
+
+    #[test]
+    fn test_gains_sorted() {
+        for w in FC0013_GAINS.windows(2) {
+            assert!(w[0] <= w[1], "gains must be in ascending order");
+        }
+    }
+
+    #[test]
+    fn test_gains_count() {
+        // 24 entries in C source, but -63 appears twice; deduplicated to 23
+        assert_eq!(FC0013_GAINS.len(), 23);
+    }
+
+    #[test]
+    fn test_lna_gains_count() {
+        // Full table from C source has 24 entries (including duplicate -63)
+        assert_eq!(LNA_GAINS.len(), 24);
+    }
+
+    #[test]
+    fn test_lna_gains_match_c_source() {
+        // Verify first, last, and a few middle entries
+        assert_eq!(LNA_GAINS[0], (-99, 0x02));
+        assert_eq!(LNA_GAINS[1], (-73, 0x03));
+        assert_eq!(LNA_GAINS[3], (-63, 0x04));
+        assert_eq!(LNA_GAINS[4], (-63, 0x00));
+        assert_eq!(LNA_GAINS[8], (58, 0x0f));
+        assert_eq!(LNA_GAINS[15], (71, 0x08));
+        assert_eq!(LNA_GAINS[16], (179, 0x17));
+        assert_eq!(LNA_GAINS[23], (197, 0x10));
+    }
+
+    #[test]
+    fn test_i2c_addr() {
+        assert_eq!(I2C_ADDR, 0xc6);
+    }
+
+    #[test]
+    fn test_check_val() {
+        assert_eq!(CHECK_VAL, 0xa3);
+    }
+
+    #[test]
+    fn test_new_defaults() {
+        let tuner = Fc0013Tuner::new(28_800_000);
+        assert_eq!(tuner.xtal, 28_800_000);
+        assert_eq!(tuner.bandwidth, BW_6MHZ_HZ);
+        assert_eq!(tuner.freq, 0);
+    }
+
+    #[test]
+    fn test_init_regs_xtal_bit() {
+        let mut regs = INIT_REGS;
+        regs[6] |= XTAL_28_8_MHZ_BIT;
+        assert_eq!(regs[6] & XTAL_28_8_MHZ_BIT, XTAL_28_8_MHZ_BIT);
+    }
+
+    #[test]
+    fn test_init_regs_dual_master_bit() {
+        let mut regs = INIT_REGS;
+        regs[11] |= DUAL_MASTER_BIT;
+        assert_eq!(regs[11] & DUAL_MASTER_BIT, DUAL_MASTER_BIT);
+    }
+
+    #[test]
+    fn test_freq_divider_selection() {
+        // 100 MHz should select multi=32
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 100_000_000 < d.max_freq)
+            .expect("should find divider for 100 MHz");
+        assert_eq!(divider.multi, 32);
+
+        // 500 MHz should select multi=6
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 500_000_000 < d.max_freq)
+            .expect("should find divider for 500 MHz");
+        assert_eq!(divider.multi, 6);
+
+        // 30 MHz should select multi=96
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 30_000_000 < d.max_freq)
+            .expect("should find divider for 30 MHz");
+        assert_eq!(divider.multi, 96);
+
+        // 700 MHz should select multi=4
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 700_000_000 < d.max_freq)
+            .expect("should find divider for 700 MHz");
+        assert_eq!(divider.multi, 4);
+
+        // 1 GHz should select multi=2 (fallback)
+        let divider = FREQ_DIVIDERS
+            .iter()
+            .find(|d| 1_000_000_000 < d.max_freq)
+            .expect("should find divider for 1 GHz");
+        assert_eq!(divider.multi, 2);
+    }
+
+    #[test]
+    fn test_fc0013_differs_from_fc0012_dividers() {
+        // FC0013 has 11 entries (FC0012 has 10), including multi=2 fallback
+        assert_eq!(FREQ_DIVIDERS.len(), 11);
+
+        // FC0013 has multi=2 in its last entry (FC0012 has multi=4)
+        assert_eq!(FREQ_DIVIDERS[FREQ_DIVIDERS.len() - 1].multi, 2);
+
+        // FC0013 has multi=4 with max_freq=950_000_000 (not u32::MAX)
+        assert_eq!(FREQ_DIVIDERS[9].multi, 4);
+        assert_eq!(FREQ_DIVIDERS[9].max_freq, 950_000_000);
+    }
+
+    #[test]
+    fn test_vhf_track_thresholds() {
+        // Verify all VHF track thresholds match C source
+        assert_eq!(VHF_TRACK_THRESH_7, 177_500_000);
+        assert_eq!(VHF_TRACK_THRESH_6, 184_500_000);
+        assert_eq!(VHF_TRACK_THRESH_5, 191_500_000);
+        assert_eq!(VHF_TRACK_THRESH_4, 198_500_000);
+        assert_eq!(VHF_TRACK_THRESH_3, 205_500_000);
+        assert_eq!(VHF_TRACK_THRESH_2, 219_500_000);
+    }
+
+    #[test]
+    fn test_init_reg_values_match_c_source() {
+        // Spot-check init register values against C source
+        assert_eq!(INIT_REGS[0], 0x09); // reg 0x01
+        assert_eq!(INIT_REGS[1], 0x16); // reg 0x02
+        assert_eq!(INIT_REGS[5], 0x02); // reg 0x06: LPF bandwidth
+        assert_eq!(INIT_REGS[6], 0x0a); // reg 0x07: CHECK
+        assert_eq!(INIT_REGS[7], 0xff); // reg 0x08
+        assert_eq!(INIT_REGS[8], 0x6e); // reg 0x09
+        assert_eq!(INIT_REGS[11], 0xfc); // reg 0x0c
+        assert_eq!(INIT_REGS[12], 0x01); // reg 0x0d
+        assert_eq!(INIT_REGS[19], 0x50); // reg 0x14
+        assert_eq!(INIT_REGS[20], 0x01); // reg 0x15
+    }
+}

--- a/crates/sdr-rtlsdr/src/tuner/fc0013.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc0013.rs
@@ -562,9 +562,12 @@ impl Fc0013Tuner {
         reg6 |= CLOCK_OUT_BIT;
 
         // Calculate XIN (fractional part of Delta Sigma PLL)
+        // In C, `xin << 15` promotes the uint16_t to int (32-bit) before shifting,
+        // so the shift and division must be done in u32 to avoid u16 overflow.
         let xin_remainder =
             (f_vco - (f_vco / u64::from(xtal_freq_div_2)) * u64::from(xtal_freq_div_2)) / 1000;
-        let mut xin = ((xin_remainder as u16) << 15) / ((xtal_freq_div_2 / 1000) as u16);
+        let xin_wide = (u32::from(xin_remainder as u16) << 15) / (xtal_freq_div_2 / 1000);
+        let mut xin = xin_wide as u16;
         if xin >= XIN_THRESHOLD {
             xin += XIN_OVERFLOW_ADD;
         }

--- a/crates/sdr-rtlsdr/src/tuner/fc0013.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc0013.rs
@@ -485,7 +485,7 @@ impl Fc0013Tuner {
     /// Set tuner frequency and bandwidth.
     ///
     /// Exact port of `fc0013_set_params`.
-    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
     fn set_params(
         &self,
         handle: &rusb::DeviceHandle<rusb::GlobalContext>,
@@ -574,6 +574,10 @@ impl Fc0013Tuner {
         // so the shift and division must be done in u32 to avoid u16 overflow.
         let xin_remainder =
             (f_vco - (f_vco / u64::from(xtal_freq_div_2)) * u64::from(xtal_freq_div_2)) / 1000;
+        debug_assert!(
+            xin_remainder <= 0xFFFF,
+            "XIN remainder exceeds u16 range: {xin_remainder}"
+        );
         let xin_wide = (u32::from(xin_remainder as u16) << 15) / (xtal_freq_div_2 / 1000);
         let mut xin = xin_wide as u16;
         if xin >= XIN_THRESHOLD {

--- a/crates/sdr-rtlsdr/src/tuner/fc0013.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc0013.rs
@@ -50,6 +50,8 @@ const REG_VCO_BW: u8 = 0x06;
 const REG_XTAL_SPEED: u8 = 0x07;
 
 /// RC calibration push register (reg 0x10).
+/// Used by `rc_cal_add`/`rc_cal_reset` (ported for completeness).
+#[allow(dead_code)]
 const REG_RC_CAL: u8 = 0x10;
 
 /// Multi select / 64x divider register (reg 0x11).
@@ -194,12 +196,18 @@ const MANUAL_GAIN_BIT: u8 = 1 << 3;
 const FIXED_IF_GAIN: u8 = 0x0a;
 
 /// RC calibration forcing mode value for register 0x0d.
+/// Used by `rc_cal_add` (ported for completeness).
+#[allow(dead_code)]
 const RC_CAL_FORCE: u8 = 0x11;
 
 /// RC calibration reset value for register 0x0d.
+/// Used by `rc_cal_reset` (ported for completeness).
+#[allow(dead_code)]
 const RC_CAL_RESET: u8 = 0x01;
 
 /// Maximum valid RC calibration value.
+/// Used by `rc_cal_add` (ported for completeness).
+#[allow(dead_code)]
 const RC_CAL_MAX: u8 = 0x0f;
 
 // ---------------------------------------------------------------------------
@@ -633,9 +641,10 @@ impl Fc0013Tuner {
 
     /// Add an offset to the RC calibration value.
     ///
-    /// Exact port of `fc0013_rc_cal_add`.
+    /// Exact port of `fc0013_rc_cal_add`. Currently unused but available
+    /// for future RC filter recalibration support.
     #[allow(dead_code)]
-    pub fn rc_cal_add(
+    pub(crate) fn rc_cal_add(
         &self,
         handle: &rusb::DeviceHandle<rusb::GlobalContext>,
         rc_val: i32,
@@ -665,9 +674,10 @@ impl Fc0013Tuner {
 
     /// Reset the RC calibration.
     ///
-    /// Exact port of `fc0013_rc_cal_reset`.
+    /// Exact port of `fc0013_rc_cal_reset`. Currently unused but available
+    /// for future RC filter recalibration support.
     #[allow(dead_code)]
-    pub fn rc_cal_reset(
+    pub(crate) fn rc_cal_reset(
         &self,
         handle: &rusb::DeviceHandle<rusb::GlobalContext>,
     ) -> Result<(), RtlSdrError> {

--- a/crates/sdr-rtlsdr/src/tuner/fc2580.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc2580.rs
@@ -27,8 +27,8 @@ pub const CHECK_VAL: u8 = 0x56;
 // Crystal and clock constants
 // ---------------------------------------------------------------------------
 
-/// Crystal oscillator frequency in Hz (16.384 MHz, at least on the Logilink VG0002A).
-const CRYSTAL_FREQ: u32 = 16_384_000;
+/// Default crystal oscillator frequency in Hz (16.384 MHz, at least on the Logilink VG0002A).
+pub const CRYSTAL_FREQ: u32 = 16_384_000;
 
 /// Use external clock input (0 = internal XTAL oscillator, 1 = external clock).
 const USE_EXT_CLK: u8 = 0;
@@ -778,8 +778,8 @@ impl Tuner for Fc2580Tuner {
         // AGC mode: external (matching the C source TODO comment)
         let agc_mode = AGC_EXTERNAL;
 
-        // Crystal frequency in kHz: round(CrystalFreqHz / 1000)
-        let crystal_freq_khz = (CRYSTAL_FREQ + 500) / 1000;
+        // Crystal frequency in kHz: round(xtal / 1000)
+        let crystal_freq_khz = (self.xtal + 500) / 1000;
 
         self.set_init(handle, agc_mode, crystal_freq_khz)
     }
@@ -806,7 +806,7 @@ impl Tuner for Fc2580Tuner {
 
         // Convert Hz to kHz: round(freq / 1000)
         let rf_freq_khz = (freq + 500) / 1000;
-        let crystal_freq_khz = (CRYSTAL_FREQ + 500) / 1000;
+        let crystal_freq_khz = (self.xtal + 500) / 1000;
 
         self.set_freq_internal(handle, rf_freq_khz, crystal_freq_khz)
     }
@@ -820,7 +820,7 @@ impl Tuner for Fc2580Tuner {
         bw: u32,
         _sample_rate: u32,
     ) -> Result<u32, RtlSdrError> {
-        let crystal_freq_khz = (CRYSTAL_FREQ + 500) / 1000;
+        let crystal_freq_khz = (self.xtal + 500) / 1000;
 
         // Map bandwidth in Hz to the filter mode byte
         let filter_mode = match bw {

--- a/crates/sdr-rtlsdr/src/tuner/fc2580.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc2580.rs
@@ -1,0 +1,1090 @@
+//! FCI FC2580 tuner driver.
+//!
+//! Faithful port of `tuner_fc2580.c` from librtlsdr.
+//!
+//! Original copyright:
+//! - FCI FC2580 tuner driver, taken from the kernel driver that can be found
+//!   on <http://linux.terratec.de/tv_en.html>
+
+use crate::error::RtlSdrError;
+use crate::tuner::Tuner;
+use crate::usb;
+
+// ---------------------------------------------------------------------------
+// I2C address and identification
+// ---------------------------------------------------------------------------
+
+/// FC2580 I2C address.
+pub const I2C_ADDR: u8 = 0xac;
+
+/// Register address used to identify the FC2580 (chip ID register).
+pub const CHECK_ADDR: u8 = 0x01;
+
+/// Expected chip ID value read from `CHECK_ADDR`.
+pub const CHECK_VAL: u8 = 0x56;
+
+// ---------------------------------------------------------------------------
+// Crystal and clock constants
+// ---------------------------------------------------------------------------
+
+/// Crystal oscillator frequency in Hz (16.384 MHz, at least on the Logilink VG0002A).
+const CRYSTAL_FREQ: u32 = 16_384_000;
+
+/// Use external clock input (0 = internal XTAL oscillator, 1 = external clock).
+const USE_EXT_CLK: u8 = 0;
+
+/// VCO border frequency in kHz: determines whether low or high VCO is used.
+/// 2.6 GHz = 2_600_000 kHz.
+const BORDER_FREQ: u32 = 2_600_000;
+
+// ---------------------------------------------------------------------------
+// AGC mode constants
+// ---------------------------------------------------------------------------
+
+/// Internal AGC mode.
+const AGC_INTERNAL: i32 = 1;
+
+/// External (voltage control) AGC mode.
+const AGC_EXTERNAL: i32 = 2;
+
+// ---------------------------------------------------------------------------
+// Bandwidth mode constants
+// ---------------------------------------------------------------------------
+
+/// 1.53 MHz bandwidth (TDMB).
+const FILTER_BW_1_53MHZ: u8 = 1;
+
+/// 6 MHz bandwidth.
+const FILTER_BW_6MHZ: u8 = 6;
+
+/// 6.8 MHz bandwidth (7 MHz mode).
+const FILTER_BW_7MHZ: u8 = 7;
+
+/// 7.8 MHz bandwidth (8 MHz mode).
+const FILTER_BW_8MHZ: u8 = 8;
+
+// ---------------------------------------------------------------------------
+// Bandwidth in Hz (for set_bw mapping)
+// ---------------------------------------------------------------------------
+
+/// Bandwidth: 1.53 MHz in Hz.
+const BW_1_53MHZ_HZ: u32 = 1_530_000;
+
+/// Bandwidth: 6 MHz in Hz.
+const BW_6MHZ_HZ: u32 = 6_000_000;
+
+/// Bandwidth: 7 MHz in Hz.
+const BW_7MHZ_HZ: u32 = 7_000_000;
+
+// Note: 8 MHz is the default/fallback in set_bw, so BW_8MHZ_HZ is not needed
+// as a named constant (any value not matching 1.53/6/7 MHz maps to filter mode 8).
+
+// ---------------------------------------------------------------------------
+// Band type
+// ---------------------------------------------------------------------------
+
+/// Frequency band classification for the FC2580 tuner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Band {
+    /// VHF band: f_lo <= 400 MHz.
+    Vhf,
+    /// UHF band: 400 MHz < f_lo <= 1000 MHz.
+    Uhf,
+    /// L-Band: f_lo > 1000 MHz.
+    #[allow(clippy::enum_variant_names)]
+    LBand,
+}
+
+// ---------------------------------------------------------------------------
+// UHF sub-band frequency thresholds (in kHz)
+// ---------------------------------------------------------------------------
+
+/// UHF sub-band threshold: below this, use low-frequency UHF register config.
+const UHF_LOW_THRESH_KHZ: u32 = 538_000;
+
+/// UHF sub-band threshold: below this, use mid-frequency UHF register config.
+const UHF_MID_THRESH_KHZ: u32 = 794_000;
+
+/// UHF LNA load cap threshold (kHz): at or below this, use 0x9F; above, use 0x8F.
+const UHF_LNA_CAP_THRESH_KHZ: u32 = 794_000;
+
+// ---------------------------------------------------------------------------
+// Init register addresses and values
+// ---------------------------------------------------------------------------
+
+const REG_00: u8 = 0x00;
+const REG_02: u8 = 0x02;
+const REG_09: u8 = 0x09;
+const REG_0B: u8 = 0x0B;
+const REG_0C: u8 = 0x0C;
+const REG_0E: u8 = 0x0E;
+const REG_12: u8 = 0x12;
+const REG_14: u8 = 0x14;
+const REG_16: u8 = 0x16;
+const REG_18: u8 = 0x18;
+const REG_1A: u8 = 0x1A;
+const REG_1B: u8 = 0x1B;
+const REG_1C: u8 = 0x1C;
+const REG_1F: u8 = 0x1F;
+const REG_21: u8 = 0x21;
+const REG_22: u8 = 0x22;
+const REG_25: u8 = 0x25;
+const REG_27: u8 = 0x27;
+const REG_28: u8 = 0x28;
+const REG_29: u8 = 0x29;
+const REG_2B: u8 = 0x2B;
+const REG_2C: u8 = 0x2C;
+const REG_2D: u8 = 0x2D;
+const REG_2E: u8 = 0x2E;
+const REG_2F: u8 = 0x2F;
+const REG_30: u8 = 0x30;
+const REG_36: u8 = 0x36;
+const REG_37: u8 = 0x37;
+const REG_39: u8 = 0x39;
+const REG_3F: u8 = 0x3F;
+const REG_44: u8 = 0x44;
+const REG_45: u8 = 0x45;
+const REG_4B: u8 = 0x4B;
+const REG_4C: u8 = 0x4C;
+const REG_50: u8 = 0x50;
+const REG_53: u8 = 0x53;
+const REG_58: u8 = 0x58;
+const REG_5F: u8 = 0x5F;
+const REG_61: u8 = 0x61;
+const REG_62: u8 = 0x62;
+const REG_63: u8 = 0x63;
+const REG_67: u8 = 0x67;
+const REG_68: u8 = 0x68;
+const REG_69: u8 = 0x69;
+const REG_6A: u8 = 0x6A;
+const REG_6B: u8 = 0x6B;
+const REG_6C: u8 = 0x6C;
+const REG_6D: u8 = 0x6D;
+const REG_6E: u8 = 0x6E;
+const REG_6F: u8 = 0x6F;
+
+// ---------------------------------------------------------------------------
+// Init register values
+// ---------------------------------------------------------------------------
+
+const INIT_REG_00_VAL: u8 = 0x00;
+const INIT_REG_12_VAL: u8 = 0x86;
+const INIT_REG_14_VAL: u8 = 0x5C;
+const INIT_REG_16_VAL: u8 = 0x3C;
+const INIT_REG_1F_VAL: u8 = 0xD2;
+const INIT_REG_09_VAL: u8 = 0xD7;
+const INIT_REG_0B_VAL: u8 = 0xD5;
+const INIT_REG_0C_VAL: u8 = 0x32;
+const INIT_REG_0E_VAL: u8 = 0x43;
+const INIT_REG_21_VAL: u8 = 0x0A;
+const INIT_REG_22_VAL: u8 = 0x82;
+const INIT_REG_3F_VAL: u8 = 0x88;
+const INIT_REG_02_VAL: u8 = 0x0E;
+const INIT_REG_58_VAL: u8 = 0x14;
+
+// AGC register values
+const AGC_INTERNAL_REG_45: u8 = 0x10;
+const AGC_INTERNAL_REG_4C: u8 = 0x00;
+const AGC_EXTERNAL_REG_45: u8 = 0x20;
+const AGC_EXTERNAL_REG_4C: u8 = 0x02;
+
+// ---------------------------------------------------------------------------
+// Filter calibration constants
+// ---------------------------------------------------------------------------
+
+/// Filter calibration monitor register.
+const FILTER_CAL_MON_MASK: u8 = 0xC0;
+
+/// Expected calibration complete value.
+const FILTER_CAL_COMPLETE: u8 = 0xC0;
+
+/// Filter calibration trigger value.
+const FILTER_CAL_TRIGGER: u8 = 0x09;
+
+/// Filter calibration reset value.
+const FILTER_CAL_RESET: u8 = 0x01;
+
+/// Maximum number of filter calibration retries.
+const FILTER_CAL_MAX_RETRIES: u8 = 5;
+
+// ---------------------------------------------------------------------------
+// Filter bandwidth register values
+// ---------------------------------------------------------------------------
+
+// BW 1.53 MHz
+const FILTER_1_53_REG_36: u8 = 0x1C;
+const FILTER_1_53_COEFF: u32 = 4151;
+const FILTER_1_53_REG_39: u8 = 0x00;
+
+// BW 6 MHz
+const FILTER_6_REG_36: u8 = 0x18;
+const FILTER_6_COEFF: u32 = 4400;
+const FILTER_6_REG_39: u8 = 0x00;
+
+// BW 7 MHz (6.8 MHz)
+const FILTER_7_REG_36: u8 = 0x18;
+const FILTER_7_COEFF: u32 = 3910;
+const FILTER_7_REG_39: u8 = 0x80;
+
+// BW 8 MHz (7.8 MHz)
+const FILTER_8_REG_36: u8 = 0x18;
+const FILTER_8_COEFF: u32 = 3300;
+const FILTER_8_REG_39: u8 = 0x80;
+
+// ---------------------------------------------------------------------------
+// PLL register constants
+// ---------------------------------------------------------------------------
+
+/// VCO band select bit in register 0x02.
+const VCO_BAND_SELECT_BIT: u8 = 0x08;
+
+/// Mask to clear band bits in register 0x02 (clear bits 6-7).
+const BAND_CLEAR_MASK: u8 = 0x3F;
+
+/// VHF band bit in register 0x02 (bit 7).
+const VHF_BAND_BIT: u8 = 0x80;
+
+/// L-Band bit in register 0x02 (bit 6).
+const L_BAND_BIT: u8 = 0x40;
+
+/// R divider value encoding for R=1 in register 0x18.
+const R_VAL_1_BITS: u8 = 0x00;
+
+/// R divider value encoding for R=2 in register 0x18.
+const R_VAL_2_BITS: u8 = 0x10;
+
+/// R divider value encoding for R=4 in register 0x18.
+const R_VAL_4_BITS: u8 = 0x20;
+
+/// Pre-shift bits to prevent overflow when computing k_val.
+const PLL_PRE_SHIFT_BITS: u8 = 4;
+
+/// K value shift amount (20 - pre_shift_bits = 16).
+const PLL_K_SHIFT: u8 = 20 - PLL_PRE_SHIFT_BITS;
+
+// ---------------------------------------------------------------------------
+// UHF band register values
+// ---------------------------------------------------------------------------
+
+const UHF_REG_25: u8 = 0xF0;
+const UHF_REG_27: u8 = 0x77;
+const UHF_REG_28: u8 = 0x53;
+const UHF_REG_29: u8 = 0x60;
+const UHF_REG_30: u8 = 0x09;
+const UHF_REG_50: u8 = 0x8C;
+const UHF_REG_53: u8 = 0x50;
+
+// UHF sub-band: low (< 538 MHz)
+const UHF_LOW_REG_5F: u8 = 0x13;
+const UHF_LOW_REG_61: u8 = 0x07;
+const UHF_LOW_REG_62: u8 = 0x06;
+const UHF_LOW_REG_67: u8 = 0x06;
+const UHF_LOW_REG_68: u8 = 0x08;
+const UHF_LOW_REG_69: u8 = 0x10;
+const UHF_LOW_REG_6A: u8 = 0x12;
+
+// UHF sub-band: mid (538-794 MHz)
+const UHF_MID_REG_61: u8 = 0x03;
+const UHF_MID_REG_62: u8 = 0x03;
+const UHF_MID_REG_67: u8 = 0x03;
+const UHF_MID_REG_68: u8 = 0x05;
+const UHF_MID_REG_69: u8 = 0x0C;
+const UHF_MID_REG_6A: u8 = 0x0E;
+
+// UHF sub-band: high (>= 794 MHz)
+const UHF_HIGH_REG_5F: u8 = 0x15;
+const UHF_HIGH_REG_61: u8 = 0x07;
+const UHF_HIGH_REG_62: u8 = 0x06;
+const UHF_HIGH_REG_67: u8 = 0x07;
+const UHF_HIGH_REG_68: u8 = 0x09;
+const UHF_HIGH_REG_69: u8 = 0x10;
+const UHF_HIGH_REG_6A: u8 = 0x12;
+
+const UHF_REG_63: u8 = 0x15;
+const UHF_REG_6B: u8 = 0x0B;
+const UHF_REG_6C: u8 = 0x0C;
+const UHF_REG_6D: u8 = 0x78;
+const UHF_REG_6E: u8 = 0x32;
+const UHF_REG_6F: u8 = 0x14;
+
+// ---------------------------------------------------------------------------
+// VHF band register values
+// ---------------------------------------------------------------------------
+
+const VHF_REG_27: u8 = 0x77;
+const VHF_REG_28: u8 = 0x33;
+const VHF_REG_29: u8 = 0x40;
+const VHF_REG_30: u8 = 0x09;
+const VHF_REG_50: u8 = 0x8C;
+const VHF_REG_53: u8 = 0x50;
+const VHF_REG_5F: u8 = 0x0F;
+const VHF_REG_61: u8 = 0x07;
+const VHF_REG_62: u8 = 0x00;
+const VHF_REG_63: u8 = 0x15;
+const VHF_REG_67: u8 = 0x03;
+const VHF_REG_68: u8 = 0x05;
+const VHF_REG_69: u8 = 0x10;
+const VHF_REG_6A: u8 = 0x12;
+const VHF_REG_6B: u8 = 0x08;
+const VHF_REG_6C: u8 = 0x0A;
+const VHF_REG_6D: u8 = 0x78;
+const VHF_REG_6E: u8 = 0x32;
+const VHF_REG_6F: u8 = 0x54;
+
+// ---------------------------------------------------------------------------
+// L-Band register values
+// ---------------------------------------------------------------------------
+
+const LBAND_REG_2B: u8 = 0x70;
+const LBAND_REG_2C: u8 = 0x37;
+const LBAND_REG_2D: u8 = 0xE7;
+const LBAND_REG_30: u8 = 0x09;
+const LBAND_REG_44: u8 = 0x20;
+const LBAND_REG_50: u8 = 0x8C;
+const LBAND_REG_53: u8 = 0x50;
+const LBAND_REG_5F: u8 = 0x0F;
+const LBAND_REG_61: u8 = 0x0F;
+const LBAND_REG_62: u8 = 0x00;
+const LBAND_REG_63: u8 = 0x13;
+const LBAND_REG_67: u8 = 0x00;
+const LBAND_REG_68: u8 = 0x02;
+const LBAND_REG_69: u8 = 0x0C;
+const LBAND_REG_6A: u8 = 0x0E;
+const LBAND_REG_6B: u8 = 0x08;
+const LBAND_REG_6C: u8 = 0x0A;
+const LBAND_REG_6D: u8 = 0xA0;
+const LBAND_REG_6E: u8 = 0x50;
+const LBAND_REG_6F: u8 = 0x14;
+
+// ---------------------------------------------------------------------------
+// AGC clock pre-divide ratio threshold (kHz)
+// ---------------------------------------------------------------------------
+
+/// Crystal frequency threshold for AGC clock pre-divide ratio.
+const AGC_CLK_PREDIV_THRESH_KHZ: u32 = 28_000;
+
+/// AGC clock pre-divide register value.
+const AGC_CLK_PREDIV_VAL: u8 = 0x22;
+
+// ---------------------------------------------------------------------------
+// UHF LNA load cap values
+// ---------------------------------------------------------------------------
+
+/// LNA load cap value for low UHF frequencies (<= 794 MHz).
+const LNA_CAP_LOW: u8 = 0x9F;
+
+/// LNA load cap value for high UHF frequencies (> 794 MHz).
+const LNA_CAP_HIGH: u8 = 0x8F;
+
+// ---------------------------------------------------------------------------
+// Gain table
+// ---------------------------------------------------------------------------
+
+/// Supported gain values in tenths of dB.
+///
+/// The FC2580 has no gain control in the original C driver (empty gain table).
+pub const FC2580_GAINS: [i32; 1] = [0];
+
+// ---------------------------------------------------------------------------
+// FC2580 tuner state
+// ---------------------------------------------------------------------------
+
+/// FCI FC2580 tuner driver.
+///
+/// Ports the `fc2580_set_init`, `fc2580_set_freq`, and `fc2580_set_filter`
+/// functions from `tuner_fc2580.c`.
+pub struct Fc2580Tuner {
+    /// Crystal oscillator frequency in Hz.
+    xtal: u32,
+    /// Current tuned frequency in Hz.
+    freq: u32,
+}
+
+impl Fc2580Tuner {
+    /// Create a new FC2580 tuner driver.
+    pub fn new(xtal: u32) -> Self {
+        Self { xtal, freq: 0 }
+    }
+
+    /// Write a single register via I2C.
+    #[allow(clippy::unused_self)]
+    fn write_reg(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+        val: u8,
+    ) -> Result<(), RtlSdrError> {
+        usb::i2c_write_reg(handle, I2C_ADDR, reg, val)
+    }
+
+    /// Read a single register via I2C.
+    #[allow(clippy::unused_self)]
+    fn read_reg(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        reg: u8,
+    ) -> Result<u8, RtlSdrError> {
+        usb::i2c_read_reg(handle, I2C_ADDR, reg)
+    }
+
+    /// Determine the band for a given frequency in kHz.
+    fn classify_band(f_lo_khz: u32) -> Band {
+        if f_lo_khz > 1_000_000 {
+            Band::LBand
+        } else if f_lo_khz > 400_000 {
+            Band::Uhf
+        } else {
+            Band::Vhf
+        }
+    }
+
+    /// Set the channel selection filter bandwidth.
+    ///
+    /// Exact port of `fc2580_set_filter`.
+    #[allow(clippy::cast_possible_truncation)]
+    fn set_filter(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        filter_bw: u8,
+        freq_xtal_khz: u32,
+    ) -> Result<(), RtlSdrError> {
+        match filter_bw {
+            FILTER_BW_1_53MHZ => {
+                self.write_reg(handle, REG_36, FILTER_1_53_REG_36)?;
+                self.write_reg(
+                    handle,
+                    REG_37,
+                    (FILTER_1_53_COEFF * freq_xtal_khz / 1_000_000) as u8,
+                )?;
+                self.write_reg(handle, REG_39, FILTER_1_53_REG_39)?;
+                self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
+            }
+            FILTER_BW_6MHZ => {
+                self.write_reg(handle, REG_36, FILTER_6_REG_36)?;
+                self.write_reg(
+                    handle,
+                    REG_37,
+                    (FILTER_6_COEFF * freq_xtal_khz / 1_000_000) as u8,
+                )?;
+                self.write_reg(handle, REG_39, FILTER_6_REG_39)?;
+                self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
+            }
+            FILTER_BW_7MHZ => {
+                self.write_reg(handle, REG_36, FILTER_7_REG_36)?;
+                self.write_reg(
+                    handle,
+                    REG_37,
+                    (FILTER_7_COEFF * freq_xtal_khz / 1_000_000) as u8,
+                )?;
+                self.write_reg(handle, REG_39, FILTER_7_REG_39)?;
+                self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
+            }
+            FILTER_BW_8MHZ => {
+                self.write_reg(handle, REG_36, FILTER_8_REG_36)?;
+                self.write_reg(
+                    handle,
+                    REG_37,
+                    (FILTER_8_COEFF * freq_xtal_khz / 1_000_000) as u8,
+                )?;
+                self.write_reg(handle, REG_39, FILTER_8_REG_39)?;
+                self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
+            }
+            _ => {
+                return Err(RtlSdrError::Tuner(format!(
+                    "FC2580: unsupported filter bandwidth mode {filter_bw}"
+                )));
+            }
+        }
+
+        // Filter calibration: poll up to 5 times, re-trigger if not complete
+        for _ in 0..FILTER_CAL_MAX_RETRIES {
+            // USB latency serves as the wait (original C: fc2580_wait_msec 5ms)
+            let cal_mon = self.read_reg(handle, REG_2F)?;
+            if (cal_mon & FILTER_CAL_MON_MASK) == FILTER_CAL_COMPLETE {
+                break;
+            }
+            self.write_reg(handle, REG_2E, FILTER_CAL_RESET)?;
+            self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
+        }
+
+        self.write_reg(handle, REG_2E, FILTER_CAL_RESET)?;
+
+        Ok(())
+    }
+
+    /// Write UHF band registers. Extracted from `set_freq_internal`.
+    fn write_uhf_band_regs(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        f_lo_khz: u32,
+        freq_xtal_khz: u32,
+    ) -> Result<(), RtlSdrError> {
+        self.write_reg(handle, REG_25, UHF_REG_25)?;
+        self.write_reg(handle, REG_27, UHF_REG_27)?;
+        self.write_reg(handle, REG_28, UHF_REG_28)?;
+        self.write_reg(handle, REG_29, UHF_REG_29)?;
+        self.write_reg(handle, REG_30, UHF_REG_30)?;
+        self.write_reg(handle, REG_50, UHF_REG_50)?;
+        self.write_reg(handle, REG_53, UHF_REG_53)?;
+
+        if f_lo_khz < UHF_LOW_THRESH_KHZ {
+            self.write_reg(handle, REG_5F, UHF_LOW_REG_5F)?;
+        } else {
+            self.write_reg(handle, REG_5F, UHF_HIGH_REG_5F)?;
+        }
+
+        if f_lo_khz < UHF_LOW_THRESH_KHZ {
+            self.write_reg(handle, REG_61, UHF_LOW_REG_61)?;
+            self.write_reg(handle, REG_62, UHF_LOW_REG_62)?;
+            self.write_reg(handle, REG_67, UHF_LOW_REG_67)?;
+            self.write_reg(handle, REG_68, UHF_LOW_REG_68)?;
+            self.write_reg(handle, REG_69, UHF_LOW_REG_69)?;
+            self.write_reg(handle, REG_6A, UHF_LOW_REG_6A)?;
+        } else if f_lo_khz < UHF_MID_THRESH_KHZ {
+            self.write_reg(handle, REG_61, UHF_MID_REG_61)?;
+            self.write_reg(handle, REG_62, UHF_MID_REG_62)?;
+            self.write_reg(handle, REG_67, UHF_MID_REG_67)?;
+            self.write_reg(handle, REG_68, UHF_MID_REG_68)?;
+            self.write_reg(handle, REG_69, UHF_MID_REG_69)?;
+            self.write_reg(handle, REG_6A, UHF_MID_REG_6A)?;
+        } else {
+            self.write_reg(handle, REG_61, UHF_HIGH_REG_61)?;
+            self.write_reg(handle, REG_62, UHF_HIGH_REG_62)?;
+            self.write_reg(handle, REG_67, UHF_HIGH_REG_67)?;
+            self.write_reg(handle, REG_68, UHF_HIGH_REG_68)?;
+            self.write_reg(handle, REG_69, UHF_HIGH_REG_69)?;
+            self.write_reg(handle, REG_6A, UHF_HIGH_REG_6A)?;
+        }
+
+        self.write_reg(handle, REG_63, UHF_REG_63)?;
+        self.write_reg(handle, REG_6B, UHF_REG_6B)?;
+        self.write_reg(handle, REG_6C, UHF_REG_6C)?;
+        self.write_reg(handle, REG_6D, UHF_REG_6D)?;
+        self.write_reg(handle, REG_6E, UHF_REG_6E)?;
+        self.write_reg(handle, REG_6F, UHF_REG_6F)?;
+        self.set_filter(handle, FILTER_BW_8MHZ, freq_xtal_khz)
+    }
+
+    /// Write VHF band registers. Extracted from `set_freq_internal`.
+    fn write_vhf_band_regs(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq_xtal_khz: u32,
+    ) -> Result<(), RtlSdrError> {
+        self.write_reg(handle, REG_27, VHF_REG_27)?;
+        self.write_reg(handle, REG_28, VHF_REG_28)?;
+        self.write_reg(handle, REG_29, VHF_REG_29)?;
+        self.write_reg(handle, REG_30, VHF_REG_30)?;
+        self.write_reg(handle, REG_50, VHF_REG_50)?;
+        self.write_reg(handle, REG_53, VHF_REG_53)?;
+        self.write_reg(handle, REG_5F, VHF_REG_5F)?;
+        self.write_reg(handle, REG_61, VHF_REG_61)?;
+        self.write_reg(handle, REG_62, VHF_REG_62)?;
+        self.write_reg(handle, REG_63, VHF_REG_63)?;
+        self.write_reg(handle, REG_67, VHF_REG_67)?;
+        self.write_reg(handle, REG_68, VHF_REG_68)?;
+        self.write_reg(handle, REG_69, VHF_REG_69)?;
+        self.write_reg(handle, REG_6A, VHF_REG_6A)?;
+        self.write_reg(handle, REG_6B, VHF_REG_6B)?;
+        self.write_reg(handle, REG_6C, VHF_REG_6C)?;
+        self.write_reg(handle, REG_6D, VHF_REG_6D)?;
+        self.write_reg(handle, REG_6E, VHF_REG_6E)?;
+        self.write_reg(handle, REG_6F, VHF_REG_6F)?;
+        self.set_filter(handle, FILTER_BW_7MHZ, freq_xtal_khz)
+    }
+
+    /// Write L-Band registers. Extracted from `set_freq_internal`.
+    fn write_lband_regs(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq_xtal_khz: u32,
+    ) -> Result<(), RtlSdrError> {
+        self.write_reg(handle, REG_2B, LBAND_REG_2B)?;
+        self.write_reg(handle, REG_2C, LBAND_REG_2C)?;
+        self.write_reg(handle, REG_2D, LBAND_REG_2D)?;
+        self.write_reg(handle, REG_30, LBAND_REG_30)?;
+        self.write_reg(handle, REG_44, LBAND_REG_44)?;
+        self.write_reg(handle, REG_50, LBAND_REG_50)?;
+        self.write_reg(handle, REG_53, LBAND_REG_53)?;
+        self.write_reg(handle, REG_5F, LBAND_REG_5F)?;
+        self.write_reg(handle, REG_61, LBAND_REG_61)?;
+        self.write_reg(handle, REG_62, LBAND_REG_62)?;
+        self.write_reg(handle, REG_63, LBAND_REG_63)?;
+        self.write_reg(handle, REG_67, LBAND_REG_67)?;
+        self.write_reg(handle, REG_68, LBAND_REG_68)?;
+        self.write_reg(handle, REG_69, LBAND_REG_69)?;
+        self.write_reg(handle, REG_6A, LBAND_REG_6A)?;
+        self.write_reg(handle, REG_6B, LBAND_REG_6B)?;
+        self.write_reg(handle, REG_6C, LBAND_REG_6C)?;
+        self.write_reg(handle, REG_6D, LBAND_REG_6D)?;
+        self.write_reg(handle, REG_6E, LBAND_REG_6E)?;
+        self.write_reg(handle, REG_6F, LBAND_REG_6F)?;
+        self.set_filter(handle, FILTER_BW_1_53MHZ, freq_xtal_khz)
+    }
+
+    /// Set the LO frequency.
+    ///
+    /// Exact port of `fc2580_set_freq`. `f_lo_khz` is in kHz, `freq_xtal_khz` is in kHz.
+    #[allow(clippy::cast_possible_truncation)]
+    fn set_freq_internal(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        f_lo_khz: u32,
+        freq_xtal_khz: u32,
+    ) -> Result<(), RtlSdrError> {
+        let band = Self::classify_band(f_lo_khz);
+
+        // Calculate VCO frequency
+        let f_vco: u32 = match band {
+            Band::Uhf => f_lo_khz * 4,
+            Band::LBand => f_lo_khz * 2,
+            Band::Vhf => f_lo_khz * 12,
+        };
+
+        // Calculate R divider
+        let r_val: u32 = if f_vco >= 2 * 76 * freq_xtal_khz {
+            1
+        } else if f_vco >= 76 * freq_xtal_khz {
+            2
+        } else {
+            4
+        };
+
+        let f_comp = freq_xtal_khz / r_val;
+        let n_val = (f_vco / 2) / f_comp;
+
+        let f_diff = f_vco - 2 * f_comp * n_val;
+        let f_diff_shifted = f_diff << PLL_K_SHIFT;
+        let f_comp_shifted = (2 * f_comp) >> PLL_PRE_SHIFT_BITS;
+        let mut k_val = f_diff_shifted / f_comp_shifted;
+
+        if f_diff_shifted - k_val * f_comp_shifted >= (f_comp >> PLL_PRE_SHIFT_BITS) {
+            k_val += 1;
+        }
+
+        // Base value for register 0x02
+        let mut data_0x02: u8 = (USE_EXT_CLK << 5) | INIT_REG_02_VAL;
+
+        // Select VCO Band
+        if f_vco >= BORDER_FREQ {
+            data_0x02 |= VCO_BAND_SELECT_BIT;
+        } else {
+            data_0x02 &= !VCO_BAND_SELECT_BIT;
+        }
+
+        // Band-specific register configuration
+        match band {
+            Band::Uhf => {
+                data_0x02 &= BAND_CLEAR_MASK;
+                self.write_uhf_band_regs(handle, f_lo_khz, freq_xtal_khz)?;
+            }
+            Band::Vhf => {
+                data_0x02 = (data_0x02 & BAND_CLEAR_MASK) | VHF_BAND_BIT;
+                self.write_vhf_band_regs(handle, freq_xtal_khz)?;
+            }
+            Band::LBand => {
+                data_0x02 = (data_0x02 & BAND_CLEAR_MASK) | L_BAND_BIT;
+                self.write_lband_regs(handle, freq_xtal_khz)?;
+            }
+        }
+
+        // AGC clock pre-divide ratio
+        if freq_xtal_khz >= AGC_CLK_PREDIV_THRESH_KHZ {
+            self.write_reg(handle, REG_4B, AGC_CLK_PREDIV_VAL)?;
+        }
+
+        // VCO Band and PLL setting
+        self.write_reg(handle, REG_02, data_0x02)?;
+
+        // Register 0x18: R divider encoding + high part of K value
+        let r_bits = match r_val {
+            1 => R_VAL_1_BITS,
+            2 => R_VAL_2_BITS,
+            _ => R_VAL_4_BITS,
+        };
+        let data_0x18 = r_bits + (k_val >> 16) as u8;
+        self.write_reg(handle, REG_18, data_0x18)?;
+
+        // Load middle part of K value
+        self.write_reg(handle, REG_1A, (k_val >> 8) as u8)?;
+
+        // Load lower part of K value
+        self.write_reg(handle, REG_1B, k_val as u8)?;
+
+        // Load N value
+        self.write_reg(handle, REG_1C, n_val as u8)?;
+
+        // UHF LNA Load Cap
+        if band == Band::Uhf {
+            let lna_cap = if f_lo_khz <= UHF_LNA_CAP_THRESH_KHZ {
+                LNA_CAP_LOW
+            } else {
+                LNA_CAP_HIGH
+            };
+            self.write_reg(handle, REG_2D, lna_cap)?;
+        }
+
+        Ok(())
+    }
+
+    /// Perform tuner initialization.
+    ///
+    /// Exact port of `fc2580_set_init`.
+    fn set_init(
+        &self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        ifagc_mode: i32,
+        freq_xtal_khz: u32,
+    ) -> Result<(), RtlSdrError> {
+        self.write_reg(handle, REG_00, INIT_REG_00_VAL)?;
+        self.write_reg(handle, REG_12, INIT_REG_12_VAL)?;
+        self.write_reg(handle, REG_14, INIT_REG_14_VAL)?;
+        self.write_reg(handle, REG_16, INIT_REG_16_VAL)?;
+        self.write_reg(handle, REG_1F, INIT_REG_1F_VAL)?;
+        self.write_reg(handle, REG_09, INIT_REG_09_VAL)?;
+        self.write_reg(handle, REG_0B, INIT_REG_0B_VAL)?;
+        self.write_reg(handle, REG_0C, INIT_REG_0C_VAL)?;
+        self.write_reg(handle, REG_0E, INIT_REG_0E_VAL)?;
+        self.write_reg(handle, REG_21, INIT_REG_21_VAL)?;
+        self.write_reg(handle, REG_22, INIT_REG_22_VAL)?;
+
+        if ifagc_mode == AGC_INTERNAL {
+            self.write_reg(handle, REG_45, AGC_INTERNAL_REG_45)?;
+            self.write_reg(handle, REG_4C, AGC_INTERNAL_REG_4C)?;
+        } else if ifagc_mode == AGC_EXTERNAL {
+            self.write_reg(handle, REG_45, AGC_EXTERNAL_REG_45)?;
+            self.write_reg(handle, REG_4C, AGC_EXTERNAL_REG_4C)?;
+        }
+
+        self.write_reg(handle, REG_3F, INIT_REG_3F_VAL)?;
+        self.write_reg(handle, REG_02, INIT_REG_02_VAL)?;
+        self.write_reg(handle, REG_58, INIT_REG_58_VAL)?;
+
+        // Default bandwidth: 7.8 MHz (filter_bw = 8)
+        self.set_filter(handle, FILTER_BW_8MHZ, freq_xtal_khz)?;
+
+        Ok(())
+    }
+}
+
+impl Tuner for Fc2580Tuner {
+    /// Initialize the FC2580 tuner.
+    ///
+    /// Exact port of `fc2580_Initialize`.
+    fn init(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        // AGC mode: external (matching the C source TODO comment)
+        let agc_mode = AGC_EXTERNAL;
+
+        // Crystal frequency in kHz: round(CrystalFreqHz / 1000)
+        let crystal_freq_khz = (CRYSTAL_FREQ + 500) / 1000;
+
+        self.set_init(handle, agc_mode, crystal_freq_khz)
+    }
+
+    /// Put the tuner in standby.
+    ///
+    /// The FC2580 C driver does not define an explicit exit/standby function.
+    fn exit(
+        &mut self,
+        _handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+    ) -> Result<(), RtlSdrError> {
+        Ok(())
+    }
+
+    /// Set the tuner frequency in Hz.
+    ///
+    /// Exact port of `fc2580_SetRfFreqHz`.
+    fn set_freq(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        freq: u32,
+    ) -> Result<(), RtlSdrError> {
+        self.freq = freq;
+
+        // Convert Hz to kHz: round(freq / 1000)
+        let rf_freq_khz = (freq + 500) / 1000;
+        let crystal_freq_khz = (CRYSTAL_FREQ + 500) / 1000;
+
+        self.set_freq_internal(handle, rf_freq_khz, crystal_freq_khz)
+    }
+
+    /// Set the tuner bandwidth. Returns 0 as the IF frequency.
+    ///
+    /// Exact port of `fc2580_SetBandwidthMode`.
+    fn set_bw(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        bw: u32,
+        _sample_rate: u32,
+    ) -> Result<u32, RtlSdrError> {
+        let crystal_freq_khz = (CRYSTAL_FREQ + 500) / 1000;
+
+        // Map bandwidth in Hz to the filter mode byte
+        let filter_mode = match bw {
+            BW_1_53MHZ_HZ => FILTER_BW_1_53MHZ,
+            BW_6MHZ_HZ => FILTER_BW_6MHZ,
+            BW_7MHZ_HZ => FILTER_BW_7MHZ,
+            _ => FILTER_BW_8MHZ,
+        };
+
+        self.set_filter(handle, filter_mode, crystal_freq_khz)?;
+
+        // FC2580 does not have a separate IF frequency to report
+        Ok(0)
+    }
+
+    /// Set the tuner gain in tenths of dB.
+    ///
+    /// The FC2580 has no gain control in the original C driver.
+    fn set_gain(
+        &mut self,
+        _handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        _gain: i32,
+    ) -> Result<(), RtlSdrError> {
+        Ok(())
+    }
+
+    /// Update the crystal frequency.
+    fn set_xtal(&mut self, xtal: u32) {
+        self.xtal = xtal;
+    }
+
+    /// Set manual or automatic gain mode.
+    ///
+    /// The FC2580 uses external AGC; gain mode switching is a no-op.
+    fn set_gain_mode(
+        &mut self,
+        _handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        _manual: bool,
+    ) -> Result<(), RtlSdrError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_i2c_addr() {
+        assert_eq!(I2C_ADDR, 0xac);
+    }
+
+    #[test]
+    fn test_check_addr() {
+        assert_eq!(CHECK_ADDR, 0x01);
+    }
+
+    #[test]
+    fn test_check_val() {
+        assert_eq!(CHECK_VAL, 0x56);
+    }
+
+    #[test]
+    fn test_crystal_freq() {
+        // 16.384 MHz
+        assert_eq!(CRYSTAL_FREQ, 16_384_000);
+    }
+
+    #[test]
+    fn test_crystal_freq_khz_rounding() {
+        // round(16384000 / 1000) = 16384
+        let khz = (CRYSTAL_FREQ + 500) / 1000;
+        assert_eq!(khz, 16384);
+    }
+
+    #[test]
+    fn test_band_classification_vhf() {
+        // <= 400 MHz = VHF
+        assert_eq!(Fc2580Tuner::classify_band(100_000), Band::Vhf);
+        assert_eq!(Fc2580Tuner::classify_band(400_000), Band::Vhf);
+    }
+
+    #[test]
+    fn test_band_classification_uhf() {
+        // 400 MHz < f <= 1000 MHz = UHF
+        assert_eq!(Fc2580Tuner::classify_band(400_001), Band::Uhf);
+        assert_eq!(Fc2580Tuner::classify_band(500_000), Band::Uhf);
+        assert_eq!(Fc2580Tuner::classify_band(1_000_000), Band::Uhf);
+    }
+
+    #[test]
+    fn test_band_classification_lband() {
+        // > 1000 MHz = L-Band
+        assert_eq!(Fc2580Tuner::classify_band(1_000_001), Band::LBand);
+        assert_eq!(Fc2580Tuner::classify_band(2_000_000), Band::LBand);
+    }
+
+    #[test]
+    fn test_new_defaults() {
+        let tuner = Fc2580Tuner::new(28_800_000);
+        assert_eq!(tuner.xtal, 28_800_000);
+        assert_eq!(tuner.freq, 0);
+    }
+
+    #[test]
+    fn test_gains_count() {
+        // FC2580 has no gain control (single zero entry)
+        assert_eq!(FC2580_GAINS.len(), 1);
+        assert_eq!(FC2580_GAINS[0], 0);
+    }
+
+    #[test]
+    fn test_border_freq() {
+        // 2.6 GHz in kHz
+        assert_eq!(BORDER_FREQ, 2_600_000);
+    }
+
+    #[test]
+    fn test_vco_calculation_uhf() {
+        // UHF: f_vco = f_lo * 4
+        let f_lo_khz: u32 = 500_000; // 500 MHz
+        let f_vco = f_lo_khz * 4;
+        assert_eq!(f_vco, 2_000_000); // 2 GHz in kHz
+    }
+
+    #[test]
+    fn test_vco_calculation_lband() {
+        // L-Band: f_vco = f_lo * 2
+        let f_lo_khz: u32 = 1_500_000; // 1.5 GHz
+        let f_vco = f_lo_khz * 2;
+        assert_eq!(f_vco, 3_000_000); // 3 GHz in kHz
+    }
+
+    #[test]
+    fn test_vco_calculation_vhf() {
+        // VHF: f_vco = f_lo * 12
+        let f_lo_khz: u32 = 200_000; // 200 MHz
+        let f_vco = f_lo_khz * 12;
+        assert_eq!(f_vco, 2_400_000); // 2.4 GHz in kHz
+    }
+
+    #[test]
+    fn test_r_val_selection() {
+        let freq_xtal_khz: u32 = 16384;
+
+        // Test case where f_vco >= 2*76*freq_xtal -> r_val = 1
+        let f_vco_high: u32 = 2 * 76 * freq_xtal_khz;
+        let r_val = if f_vco_high >= 2 * 76 * freq_xtal_khz {
+            1u32
+        } else if f_vco_high >= 76 * freq_xtal_khz {
+            2
+        } else {
+            4
+        };
+        assert_eq!(r_val, 1);
+
+        // Test case where 76*freq_xtal <= f_vco < 2*76*freq_xtal -> r_val = 2
+        let f_vco_mid: u32 = 76 * freq_xtal_khz;
+        let r_val = if f_vco_mid >= 2 * 76 * freq_xtal_khz {
+            1u32
+        } else if f_vco_mid >= 76 * freq_xtal_khz {
+            2
+        } else {
+            4
+        };
+        assert_eq!(r_val, 2);
+
+        // Test case where f_vco < 76*freq_xtal -> r_val = 4
+        let f_vco_low: u32 = 76 * freq_xtal_khz - 1;
+        let r_val = if f_vco_low >= 2 * 76 * freq_xtal_khz {
+            1u32
+        } else if f_vco_low >= 76 * freq_xtal_khz {
+            2
+        } else {
+            4
+        };
+        assert_eq!(r_val, 4);
+    }
+
+    #[test]
+    fn test_pll_k_shift() {
+        assert_eq!(PLL_K_SHIFT, 16);
+    }
+
+    #[test]
+    fn test_r_val_bits_encoding() {
+        assert_eq!(R_VAL_1_BITS, 0x00);
+        assert_eq!(R_VAL_2_BITS, 0x10);
+        assert_eq!(R_VAL_4_BITS, 0x20);
+    }
+
+    #[test]
+    fn test_filter_coefficients() {
+        // Verify filter coefficient calculations for 16384 kHz crystal
+        let freq_xtal_khz: u32 = 16384;
+
+        // BW 1.53 MHz: 4151 * 16384 / 1000000 = 68 (truncated)
+        let val = (FILTER_1_53_COEFF * freq_xtal_khz / 1_000_000) as u8;
+        assert_eq!(val, 68);
+
+        // BW 6 MHz: 4400 * 16384 / 1000000 = 72 (truncated)
+        let val = (FILTER_6_COEFF * freq_xtal_khz / 1_000_000) as u8;
+        assert_eq!(val, 72);
+
+        // BW 7 MHz: 3910 * 16384 / 1000000 = 64 (truncated)
+        let val = (FILTER_7_COEFF * freq_xtal_khz / 1_000_000) as u8;
+        assert_eq!(val, 64);
+
+        // BW 8 MHz: 3300 * 16384 / 1000000 = 54 (truncated)
+        let val = (FILTER_8_COEFF * freq_xtal_khz / 1_000_000) as u8;
+        assert_eq!(val, 54);
+    }
+
+    #[test]
+    fn test_agc_mode_constants() {
+        assert_eq!(AGC_INTERNAL, 1);
+        assert_eq!(AGC_EXTERNAL, 2);
+    }
+
+    #[test]
+    fn test_band_bits() {
+        // Verify band bit assignments
+        let base: u8 = 0x0E;
+
+        // UHF: clear bits 6-7
+        let uhf = base & BAND_CLEAR_MASK;
+        assert_eq!(uhf & 0xC0, 0x00);
+
+        // VHF: set bit 7
+        let vhf = (base & BAND_CLEAR_MASK) | VHF_BAND_BIT;
+        assert_eq!(vhf & 0xC0, 0x80);
+
+        // L-Band: set bit 6
+        let lband = (base & BAND_CLEAR_MASK) | L_BAND_BIT;
+        assert_eq!(lband & 0xC0, 0x40);
+    }
+
+    #[test]
+    fn test_uhf_lna_cap_values() {
+        assert_eq!(LNA_CAP_LOW, 0x9F);
+        assert_eq!(LNA_CAP_HIGH, 0x8F);
+    }
+
+    #[test]
+    fn test_filter_cal_mon_mask() {
+        // Calibration complete when bits 6-7 are both set
+        assert_eq!(FILTER_CAL_MON_MASK, 0xC0);
+        assert_eq!(FILTER_CAL_COMPLETE, 0xC0);
+
+        // Test: calibration complete
+        assert_eq!(0xC0_u8 & FILTER_CAL_MON_MASK, FILTER_CAL_COMPLETE);
+        assert_eq!(0xDF_u8 & FILTER_CAL_MON_MASK, FILTER_CAL_COMPLETE);
+
+        // Test: calibration not complete
+        assert_ne!(0x80_u8 & FILTER_CAL_MON_MASK, FILTER_CAL_COMPLETE);
+        assert_ne!(0x40_u8 & FILTER_CAL_MON_MASK, FILTER_CAL_COMPLETE);
+        assert_ne!(0x3F_u8 & FILTER_CAL_MON_MASK, FILTER_CAL_COMPLETE);
+    }
+
+    #[test]
+    fn test_set_xtal() {
+        let mut tuner = Fc2580Tuner::new(16_384_000);
+        assert_eq!(tuner.xtal, 16_384_000);
+        tuner.set_xtal(28_800_000);
+        assert_eq!(tuner.xtal, 28_800_000);
+    }
+}

--- a/crates/sdr-rtlsdr/src/tuner/fc2580.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc2580.rs
@@ -497,14 +497,23 @@ impl Fc2580Tuner {
         }
 
         // Filter calibration: poll up to 5 times, re-trigger if not complete
+        let mut cal_ok = false;
         for _ in 0..FILTER_CAL_MAX_RETRIES {
             // USB latency serves as the wait (original C: fc2580_wait_msec 5ms)
             let cal_mon = self.read_reg(handle, REG_2F)?;
             if (cal_mon & FILTER_CAL_MON_MASK) == FILTER_CAL_COMPLETE {
+                cal_ok = true;
                 break;
             }
             self.write_reg(handle, REG_2E, FILTER_CAL_RESET)?;
             self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
+        }
+
+        if !cal_ok {
+            tracing::warn!(
+                "FC2580: filter calibration did not complete after {} retries",
+                FILTER_CAL_MAX_RETRIES
+            );
         }
 
         self.write_reg(handle, REG_2E, FILTER_CAL_RESET)?;
@@ -712,6 +721,7 @@ impl Fc2580Tuner {
         self.write_reg(handle, REG_1B, k_val as u8)?;
 
         // Load N value
+        debug_assert!(n_val <= 255, "FC2580 PLL n_val exceeds u8 range: {n_val}");
         self.write_reg(handle, REG_1C, n_val as u8)?;
 
         // UHF LNA Load Cap

--- a/crates/sdr-rtlsdr/src/tuner/fc2580.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc2580.rs
@@ -406,6 +406,17 @@ impl Fc2580Tuner {
         Self { xtal, freq: 0 }
     }
 
+    /// Convert crystal frequency to kHz with rounding, guarding against zero.
+    fn xtal_khz(&self) -> Result<u32, RtlSdrError> {
+        let khz = self.xtal.saturating_add(500) / 1000;
+        if khz == 0 {
+            return Err(RtlSdrError::Tuner(
+                "FC2580: crystal frequency too low".to_string(),
+            ));
+        }
+        Ok(khz)
+    }
+
     /// Write a single register via I2C.
     #[allow(clippy::unused_self)]
     fn write_reg(
@@ -788,8 +799,7 @@ impl Tuner for Fc2580Tuner {
         // AGC mode: external (matching the C source TODO comment)
         let agc_mode = AGC_EXTERNAL;
 
-        // Crystal frequency in kHz: round(xtal / 1000)
-        let crystal_freq_khz = (self.xtal + 500) / 1000;
+        let crystal_freq_khz = self.xtal_khz()?;
 
         self.set_init(handle, agc_mode, crystal_freq_khz)
     }
@@ -812,13 +822,13 @@ impl Tuner for Fc2580Tuner {
         handle: &rusb::DeviceHandle<rusb::GlobalContext>,
         freq: u32,
     ) -> Result<(), RtlSdrError> {
-        self.freq = freq;
-
         // Convert Hz to kHz: round(freq / 1000)
-        let rf_freq_khz = (freq + 500) / 1000;
-        let crystal_freq_khz = (self.xtal + 500) / 1000;
+        let rf_freq_khz = freq.saturating_add(500) / 1000;
+        let crystal_freq_khz = self.xtal_khz()?;
 
-        self.set_freq_internal(handle, rf_freq_khz, crystal_freq_khz)
+        self.set_freq_internal(handle, rf_freq_khz, crystal_freq_khz)?;
+        self.freq = freq;
+        Ok(())
     }
 
     /// Set the tuner bandwidth. Returns 0 as the IF frequency.
@@ -830,7 +840,7 @@ impl Tuner for Fc2580Tuner {
         bw: u32,
         _sample_rate: u32,
     ) -> Result<u32, RtlSdrError> {
-        let crystal_freq_khz = (self.xtal + 500) / 1000;
+        let crystal_freq_khz = self.xtal_khz()?;
 
         // Map bandwidth in Hz to the filter mode byte
         let filter_mode = match bw {

--- a/crates/sdr-rtlsdr/src/tuner/mod.rs
+++ b/crates/sdr-rtlsdr/src/tuner/mod.rs
@@ -3,6 +3,10 @@
 //! Each tuner IC (R820T, E4000, FC0012, etc.) implements the `Tuner` trait,
 //! providing frequency, gain, and bandwidth control via I2C.
 
+pub mod e4k;
+pub mod fc0012;
+pub mod fc0013;
+pub mod fc2580;
 pub mod r82xx;
 
 use crate::error::RtlSdrError;


### PR DESCRIPTION
## Summary

- Port all 4 remaining tuner drivers from C librtlsdr to Rust, completing the pure Rust driver
- E4000 (1,000 LOC C): complex PLL with sigma-delta, multi-stage IF gain, RF filter selection, DC offset calibration
- FC0012 (333 LOC C): VCO calibration, 5 gain levels, GPIO band switching
- FC0013 (500 LOC C): enhanced FC0012 with VHF tracking filter, 24-entry LNA gain table, RC calibration
- FC2580 (494 LOC C): multi-band UHF/VHF/L-Band, VCO selection, bandwidth calibration
- All 4 drivers audited function-by-function against C source; one bug found and fixed (XIN `u16` overflow in FC0012/FC0013)
- 83 new tests across all 4 drivers (335 total workspace tests passing)

Closes #74

## Test plan

- [x] All 335 workspace tests pass
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --all -- --check` passes
- [x] Function-by-function audit against C source for all 4 drivers
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for four additional RTL‑SDR tuner devices (E4000, FC0012, FC0013, FC2580).
  * Exposes RF frequency tuning, selectable IF filter bandwidths, and device init/detection and standby behavior.
  * Provides gain/AGC controls where supported (driver-specific; some devices have no software gain).

* **Tests**
  * Comprehensive unit tests added for tuning, filter selection, and gain behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->