### PR TITLE
Phase 5b: spectrum display — FFT plot + waterfall with OpenGL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+sdr-types.workspace = true
+sdr-dsp.workspace = true
 sdr-ui.workspace = true
 sdr-pipeline.workspace = true
 sdr-config.workspace = true
 sdr-radio.workspace = true
+sdr-rtlsdr.workspace = true
 sdr-source-rtlsdr.workspace = true
 sdr-source-network.workspace = true
 sdr-source-file.workspace = true

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod app;
 pub mod css;
 pub mod messages;
+pub mod spectrum;
 pub mod state;
 pub mod window;
 

--- a/crates/sdr-ui/src/spectrum/colormap.rs
+++ b/crates/sdr-ui/src/spectrum/colormap.rs
@@ -1,0 +1,139 @@
+//! Colormap generation for waterfall display.
+//!
+//! Provides a turbo/jet-style colormap mapping dB values (0..255) to RGBA,
+//! suitable for RF spectrum visualization.
+
+/// Number of entries in the colormap lookup table.
+pub const COLORMAP_SIZE: usize = 256;
+
+/// Generate a 256-entry RGBA colormap for waterfall display.
+///
+/// Maps indices 0..255 through a perceptually-motivated gradient:
+/// black -> dark blue -> blue -> cyan -> green -> yellow -> red -> white.
+/// This provides good contrast across the full dynamic range typical
+/// of SDR waterfall displays (-120 dB to 0 dB).
+#[allow(clippy::cast_precision_loss)]
+pub fn generate_colormap() -> Vec<[u8; 4]> {
+    let mut map = Vec::with_capacity(COLORMAP_SIZE);
+
+    for i in 0..COLORMAP_SIZE {
+        let t = i as f32 / (COLORMAP_SIZE - 1) as f32;
+        let (r, g, b) = turbo_color(t);
+        map.push([r, g, b, 255]);
+    }
+
+    map
+}
+
+/// Compute an RGB color from a turbo-style colormap at position `t` in [0, 1].
+///
+/// Uses a piecewise-linear interpolation through key color stops:
+/// - 0.00 black
+/// - 0.10 dark blue
+/// - 0.25 blue
+/// - 0.40 cyan
+/// - 0.55 green
+/// - 0.70 yellow
+/// - 0.85 red
+/// - 1.00 white
+fn turbo_color(t: f32) -> (u8, u8, u8) {
+    /// Color stop: (position, red, green, blue) all in 0..255.
+    const STOPS: &[(f32, u8, u8, u8)] = &[
+        (0.00, 0, 0, 0),       // black
+        (0.10, 10, 10, 80),    // dark blue
+        (0.25, 20, 40, 200),   // blue
+        (0.40, 0, 180, 220),   // cyan
+        (0.55, 20, 200, 40),   // green
+        (0.70, 240, 220, 10),  // yellow
+        (0.85, 240, 40, 10),   // red
+        (1.00, 255, 255, 255), // white
+    ];
+
+    // Find the two stops that bracket `t`.
+    let mut lower = 0;
+    for (i, &(pos, _, _, _)) in STOPS.iter().enumerate().skip(1) {
+        if pos >= t {
+            lower = i - 1;
+            break;
+        }
+        // If we've gone past all stops, clamp to last segment.
+        if i == STOPS.len() - 1 {
+            lower = i - 1;
+        }
+    }
+
+    let (t0, r0, g0, b0) = STOPS[lower];
+    let (t1, r1, g1, b1) = STOPS[lower + 1];
+
+    let span = t1 - t0;
+    let frac = if span > 0.0 { (t - t0) / span } else { 0.0 };
+    let frac = frac.clamp(0.0, 1.0);
+
+    let r = lerp_u8(r0, r1, frac);
+    let g = lerp_u8(g0, g1, frac);
+    let b = lerp_u8(b0, b1, frac);
+
+    (r, g, b)
+}
+
+/// Linearly interpolate between two `u8` values.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
+    let result = f32::from(a) + (f32::from(b) - f32::from(a)) * t;
+    result.round().clamp(0.0, 255.0) as u8
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colormap_has_correct_size() {
+        let map = generate_colormap();
+        assert_eq!(map.len(), COLORMAP_SIZE);
+    }
+
+    #[test]
+    fn colormap_starts_dark() {
+        let map = generate_colormap();
+        let [r, g, b, a] = map[0];
+        // First entry should be near-black.
+        assert!(r < 5, "red channel at 0 should be near 0, got {r}");
+        assert!(g < 5, "green channel at 0 should be near 0, got {g}");
+        assert!(b < 5, "blue channel at 0 should be near 0, got {b}");
+        assert_eq!(a, 255);
+    }
+
+    #[test]
+    fn colormap_ends_bright() {
+        let map = generate_colormap();
+        let [r, g, b, a] = map[COLORMAP_SIZE - 1];
+        // Last entry should be near-white.
+        assert!(r > 250, "red channel at 255 should be near 255, got {r}");
+        assert!(g > 250, "green channel at 255 should be near 255, got {g}");
+        assert!(b > 250, "blue channel at 255 should be near 255, got {b}");
+        assert_eq!(a, 255);
+    }
+
+    #[test]
+    fn colormap_all_entries_fully_opaque() {
+        let map = generate_colormap();
+        for (i, &[_, _, _, a]) in map.iter().enumerate() {
+            assert_eq!(a, 255, "entry {i} alpha should be 255");
+        }
+    }
+
+    #[test]
+    fn colormap_midpoint_is_colored() {
+        let map = generate_colormap();
+        let [r, g, b, _] = map[128];
+        // Midpoint should be somewhere in the green/cyan range — not black or white.
+        let total = u16::from(r) + u16::from(g) + u16::from(b);
+        assert!(
+            total > 50,
+            "midpoint should have visible color, total={total}"
+        );
+        assert!(total < 700, "midpoint should not be white, total={total}");
+    }
+}

--- a/crates/sdr-ui/src/spectrum/fft_plot.rs
+++ b/crates/sdr-ui/src/spectrum/fft_plot.rs
@@ -1,0 +1,324 @@
+//! FFT spectrum plot renderer using OpenGL via glow.
+//!
+//! Draws the power spectrum as a filled area with a line trace on top,
+//! plus horizontal dB grid lines and vertical frequency grid lines.
+
+use glow::HasContext;
+
+use super::gl_renderer::{self, GlError};
+
+/// Maximum number of FFT bins the renderer can display.
+const MAX_FFT_BINS: usize = 8192;
+
+/// Number of horizontal dB grid lines.
+const DB_GRID_LINE_COUNT: usize = 8;
+
+/// Number of vertical frequency grid lines.
+const FREQ_GRID_LINE_COUNT: usize = 10;
+
+/// Maximum vertices for the filled spectrum area (2 per bin: top + bottom).
+const MAX_FILL_VERTICES: usize = MAX_FFT_BINS * 2;
+
+/// Maximum vertices for grid lines (2 per line, both axes).
+const MAX_GRID_VERTICES: usize = (DB_GRID_LINE_COUNT + FREQ_GRID_LINE_COUNT) * 2;
+
+// Colors (RGBA, 0.0..1.0)
+/// Spectrum trace line color — accent blue.
+const TRACE_COLOR: [f32; 4] = [0.3, 0.7, 1.0, 1.0];
+/// Spectrum fill color — semi-transparent blue.
+const FILL_COLOR: [f32; 4] = [0.2, 0.4, 0.8, 0.35];
+/// Grid line color — dim gray.
+const GRID_COLOR: [f32; 4] = [0.4, 0.4, 0.4, 0.5];
+/// Background clear color — near-black.
+const BACKGROUND_COLOR: [f32; 4] = [0.08, 0.08, 0.10, 1.0];
+
+/// Vertex shader — maps 2D positions directly to clip space.
+const VERT_SHADER: &str = r"#version 300 es
+precision highp float;
+layout(location = 0) in vec2 a_pos;
+void main() {
+    gl_Position = vec4(a_pos, 0.0, 1.0);
+}
+";
+
+/// Fragment shader — outputs a uniform color.
+const FRAG_SHADER: &str = r"#version 300 es
+precision highp float;
+uniform vec4 u_color;
+out vec4 frag_color;
+void main() {
+    frag_color = u_color;
+}
+";
+
+/// OpenGL renderer for the FFT power spectrum plot.
+///
+/// Renders a filled area under the spectrum curve, a line trace on top,
+/// and grid lines for dB and frequency reference.
+pub struct FftPlotRenderer {
+    program: glow::Program,
+    vao: glow::VertexArray,
+    vbo: glow::Buffer,
+    color_location: glow::UniformLocation,
+}
+
+impl FftPlotRenderer {
+    /// Create a new FFT plot renderer, compiling shaders and allocating GL buffers.
+    ///
+    /// # Errors
+    ///
+    /// Returns `GlError` if shader compilation, linking, or buffer creation fails.
+    #[allow(
+        unsafe_code,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    pub fn new(gl: &glow::Context) -> Result<Self, GlError> {
+        let vert = gl_renderer::compile_shader(gl, glow::VERTEX_SHADER, VERT_SHADER)?;
+        let frag = gl_renderer::compile_shader(gl, glow::FRAGMENT_SHADER, FRAG_SHADER)?;
+        let program = gl_renderer::link_program(gl, vert, frag)?;
+
+        let color_location = unsafe {
+            gl.get_uniform_location(program, "u_color")
+                .ok_or_else(|| GlError::ResourceCreation("u_color uniform not found".into()))?
+        };
+
+        let (vao, vbo) = unsafe {
+            let vao = gl
+                .create_vertex_array()
+                .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+            let vbo = gl
+                .create_buffer()
+                .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+
+            gl.bind_vertex_array(Some(vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+
+            // Pre-allocate buffer for the largest usage (fill vertices: 2 floats each).
+            let max_bytes = MAX_FILL_VERTICES * 2 * std::mem::size_of::<f32>();
+            gl.buffer_data_size(glow::ARRAY_BUFFER, max_bytes as i32, glow::DYNAMIC_DRAW);
+
+            // Vertex attribute: vec2 at location 0.
+            gl.enable_vertex_attrib_array(0);
+            gl.vertex_attrib_pointer_f32(
+                0,
+                2,
+                glow::FLOAT,
+                false,
+                (2 * std::mem::size_of::<f32>()) as i32,
+                0,
+            );
+
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+
+            (vao, vbo)
+        };
+
+        Ok(Self {
+            program,
+            vao,
+            vbo,
+            color_location,
+        })
+    }
+
+    /// Render the FFT spectrum plot.
+    ///
+    /// # Arguments
+    ///
+    /// * `gl` — The glow GL context.
+    /// * `fft_data` — Power spectrum values in dB (one per frequency bin).
+    /// * `width` — Viewport width in pixels.
+    /// * `height` — Viewport height in pixels.
+    /// * `min_db` — Bottom of the display range in dB.
+    /// * `max_db` — Top of the display range in dB.
+    #[allow(unsafe_code)]
+    pub fn render(
+        &self,
+        gl: &glow::Context,
+        fft_data: &[f32],
+        width: i32,
+        height: i32,
+        min_db: f32,
+        max_db: f32,
+    ) {
+        if fft_data.is_empty() || width <= 0 || height <= 0 {
+            return;
+        }
+
+        let db_range = max_db - min_db;
+        if db_range <= 0.0 {
+            return;
+        }
+
+        unsafe {
+            gl.viewport(0, 0, width, height);
+            gl.clear_color(
+                BACKGROUND_COLOR[0],
+                BACKGROUND_COLOR[1],
+                BACKGROUND_COLOR[2],
+                BACKGROUND_COLOR[3],
+            );
+            gl.clear(glow::COLOR_BUFFER_BIT);
+
+            gl.use_program(Some(self.program));
+            gl.bind_vertex_array(Some(self.vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo));
+
+            gl.enable(glow::BLEND);
+            gl.blend_func(glow::SRC_ALPHA, glow::ONE_MINUS_SRC_ALPHA);
+        }
+
+        // Draw grid lines.
+        self.draw_grid(gl);
+
+        // Draw filled area under the spectrum curve.
+        self.draw_fill(gl, fft_data, db_range, min_db);
+
+        // Draw the spectrum line trace on top.
+        self.draw_trace(gl, fft_data, db_range, min_db);
+
+        unsafe {
+            gl.disable(glow::BLEND);
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.use_program(None);
+        }
+    }
+
+    /// Draw horizontal dB grid lines and vertical frequency grid lines.
+    #[allow(
+        unsafe_code,
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    fn draw_grid(&self, gl: &glow::Context) {
+        let mut vertices = Vec::with_capacity(MAX_GRID_VERTICES * 2);
+
+        // Horizontal dB grid lines.
+        for i in 0..=DB_GRID_LINE_COUNT {
+            let frac = i as f32 / DB_GRID_LINE_COUNT as f32;
+            let y = -1.0 + 2.0 * frac;
+            // Full-width horizontal line.
+            vertices.extend_from_slice(&[-1.0, y, 1.0, y]);
+        }
+
+        // Vertical frequency grid lines.
+        for i in 0..=FREQ_GRID_LINE_COUNT {
+            let frac = i as f32 / FREQ_GRID_LINE_COUNT as f32;
+            let x = -1.0 + 2.0 * frac;
+            // Full-height vertical line.
+            vertices.extend_from_slice(&[x, -1.0, x, 1.0]);
+        }
+
+        let bytes = bytemuck_cast_slice(&vertices);
+        let vertex_count = vertices.len() / 2;
+
+        unsafe {
+            gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+
+            gl.uniform_4_f32(
+                Some(&self.color_location),
+                GRID_COLOR[0],
+                GRID_COLOR[1],
+                GRID_COLOR[2],
+                GRID_COLOR[3],
+            );
+
+            gl.draw_arrays(glow::LINES, 0, vertex_count as i32);
+        }
+    }
+
+    /// Draw the filled area under the spectrum curve as a triangle strip.
+    #[allow(
+        unsafe_code,
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    fn draw_fill(&self, gl: &glow::Context, fft_data: &[f32], db_range: f32, min_db: f32) {
+        let bin_count = fft_data.len().min(MAX_FFT_BINS);
+        let mut vertices = Vec::with_capacity(bin_count * 4);
+
+        for (i, &db) in fft_data.iter().take(bin_count).enumerate() {
+            let x = -1.0 + 2.0 * (i as f32 / (bin_count - 1).max(1) as f32);
+            let y = -1.0 + 2.0 * ((db - min_db) / db_range).clamp(0.0, 1.0);
+
+            // Bottom vertex (y = -1) then top vertex (y = spectrum value).
+            vertices.extend_from_slice(&[x, -1.0, x, y]);
+        }
+
+        let bytes = bytemuck_cast_slice(&vertices);
+        let vertex_count = vertices.len() / 2;
+
+        unsafe {
+            gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+
+            gl.uniform_4_f32(
+                Some(&self.color_location),
+                FILL_COLOR[0],
+                FILL_COLOR[1],
+                FILL_COLOR[2],
+                FILL_COLOR[3],
+            );
+
+            gl.draw_arrays(glow::TRIANGLE_STRIP, 0, vertex_count as i32);
+        }
+    }
+
+    /// Draw the spectrum line trace.
+    #[allow(
+        unsafe_code,
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    fn draw_trace(&self, gl: &glow::Context, fft_data: &[f32], db_range: f32, min_db: f32) {
+        let bin_count = fft_data.len().min(MAX_FFT_BINS);
+        let mut vertices = Vec::with_capacity(bin_count * 2);
+
+        for (i, &db) in fft_data.iter().take(bin_count).enumerate() {
+            let x = -1.0 + 2.0 * (i as f32 / (bin_count - 1).max(1) as f32);
+            let y = -1.0 + 2.0 * ((db - min_db) / db_range).clamp(0.0, 1.0);
+            vertices.extend_from_slice(&[x, y]);
+        }
+
+        let bytes = bytemuck_cast_slice(&vertices);
+        let vertex_count = vertices.len() / 2;
+
+        unsafe {
+            gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+
+            gl.uniform_4_f32(
+                Some(&self.color_location),
+                TRACE_COLOR[0],
+                TRACE_COLOR[1],
+                TRACE_COLOR[2],
+                TRACE_COLOR[3],
+            );
+
+            gl.draw_arrays(glow::LINE_STRIP, 0, vertex_count as i32);
+        }
+    }
+
+    /// Release GL resources.
+    #[allow(unsafe_code)]
+    pub fn destroy(&self, gl: &glow::Context) {
+        unsafe {
+            gl.delete_buffer(self.vbo);
+            gl.delete_vertex_array(self.vao);
+            gl.delete_program(self.program);
+        }
+    }
+}
+
+/// Reinterpret a `&[f32]` as `&[u8]` for uploading to GL buffers.
+///
+/// This is safe because `f32` has no alignment or validity invariants
+/// beyond its representation, and we only read the bytes for upload.
+#[allow(unsafe_code)]
+fn bytemuck_cast_slice(data: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), std::mem::size_of_val(data)) }
+}

--- a/crates/sdr-ui/src/spectrum/frequency_axis.rs
+++ b/crates/sdr-ui/src/spectrum/frequency_axis.rs
@@ -101,7 +101,7 @@ pub fn compute_grid_lines(start_hz: f64, end_hz: f64, max_lines: usize) -> Vec<(
         .iter()
         .copied()
         .find(|&s| (span / s) < max_lines as f64)
-        .unwrap_or(span); // fallback: one line per span
+        .unwrap_or(span * 2.0); // fallback: step > span guarantees at most 1 line
 
     // First grid line at or after start_hz, snapped to `step`.
     let first = (start_hz / step).ceil() * step;

--- a/crates/sdr-ui/src/spectrum/frequency_axis.rs
+++ b/crates/sdr-ui/src/spectrum/frequency_axis.rs
@@ -1,0 +1,203 @@
+//! Frequency axis formatting and grid-line computation.
+//!
+//! Provides smart frequency formatting ("100.0 MHz", "433.5 MHz", "1.2 GHz")
+//! and grid-line placement logic for FFT plot and waterfall axes.
+
+/// Threshold above which to display in GHz.
+const GHZ_THRESHOLD: f64 = 1_000_000_000.0;
+/// Threshold above which to display in MHz.
+const MHZ_THRESHOLD: f64 = 1_000_000.0;
+/// Threshold above which to display in kHz.
+const KHZ_THRESHOLD: f64 = 1_000.0;
+
+/// Hz per GHz.
+const HZ_PER_GHZ: f64 = 1_000_000_000.0;
+/// Hz per MHz.
+const HZ_PER_MHZ: f64 = 1_000_000.0;
+/// Hz per kHz.
+const HZ_PER_KHZ: f64 = 1_000.0;
+
+/// Format a frequency in Hz to a human-readable string with appropriate unit.
+///
+/// # Examples
+///
+/// ```
+/// # use sdr_ui::spectrum::frequency_axis::format_frequency;
+/// assert_eq!(format_frequency(100_000_000.0), "100.000 MHz");
+/// assert_eq!(format_frequency(1_200_000_000.0), "1.200 GHz");
+/// assert_eq!(format_frequency(7_055_000.0), "7.055 MHz");
+/// assert_eq!(format_frequency(455.0), "455.0 Hz");
+/// ```
+pub fn format_frequency(hz: f64) -> String {
+    let abs = hz.abs();
+    let sign = if hz < 0.0 { "-" } else { "" };
+
+    if abs >= GHZ_THRESHOLD {
+        format!("{sign}{:.3} GHz", abs / HZ_PER_GHZ)
+    } else if abs >= MHZ_THRESHOLD {
+        format!("{sign}{:.3} MHz", abs / HZ_PER_MHZ)
+    } else if abs >= KHZ_THRESHOLD {
+        format!("{sign}{:.1} kHz", abs / HZ_PER_KHZ)
+    } else {
+        format!("{sign}{abs:.1} Hz")
+    }
+}
+
+/// Candidate step sizes in Hz, from small to large.
+/// Each step divides common bandwidth ranges into sensible intervals.
+const STEP_CANDIDATES: &[f64] = &[
+    1.0,
+    2.0,
+    5.0,
+    10.0,
+    20.0,
+    50.0,
+    100.0,
+    200.0,
+    500.0,
+    1_000.0, // 1 kHz
+    2_000.0,
+    5_000.0,
+    10_000.0, // 10 kHz
+    20_000.0,
+    50_000.0,
+    100_000.0, // 100 kHz
+    200_000.0,
+    500_000.0,
+    1_000_000.0, // 1 MHz
+    2_000_000.0,
+    5_000_000.0,
+    10_000_000.0, // 10 MHz
+    20_000_000.0,
+    50_000_000.0,
+    100_000_000.0, // 100 MHz
+    200_000_000.0,
+    500_000_000.0,
+    1_000_000_000.0, // 1 GHz
+];
+
+/// Compute grid line positions and labels for a frequency axis.
+///
+/// Returns a list of `(frequency_hz, label)` pairs spaced at round intervals
+/// that produce at most `max_lines` grid lines within the given range.
+///
+/// # Arguments
+///
+/// * `start_hz` — Left edge of the display in Hz.
+/// * `end_hz` — Right edge of the display in Hz.
+/// * `max_lines` — Maximum number of grid lines desired.
+#[allow(clippy::cast_precision_loss)]
+pub fn compute_grid_lines(start_hz: f64, end_hz: f64, max_lines: usize) -> Vec<(f64, String)> {
+    if max_lines == 0 || end_hz <= start_hz {
+        return Vec::new();
+    }
+
+    let span = end_hz - start_hz;
+
+    // Find the smallest step that gives at most `max_lines` lines.
+    // Use strict `<` because the line count is `floor(span/step) + 1` in the
+    // worst case (when both range endpoints align to a step boundary).
+    let step = STEP_CANDIDATES
+        .iter()
+        .copied()
+        .find(|&s| (span / s) < max_lines as f64)
+        .unwrap_or(span); // fallback: one line per span
+
+    // First grid line at or after start_hz, snapped to `step`.
+    let first = (start_hz / step).ceil() * step;
+
+    let mut lines = Vec::new();
+    let mut freq = first;
+    while freq <= end_hz {
+        lines.push((freq, format_frequency(freq)));
+        freq += step;
+    }
+
+    lines
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_hz() {
+        assert_eq!(format_frequency(455.0), "455.0 Hz");
+        assert_eq!(format_frequency(0.0), "0.0 Hz");
+    }
+
+    #[test]
+    fn format_khz() {
+        assert_eq!(format_frequency(7_055.0), "7.1 kHz");
+        assert_eq!(format_frequency(1_000.0), "1.0 kHz");
+    }
+
+    #[test]
+    fn format_mhz() {
+        assert_eq!(format_frequency(100_000_000.0), "100.000 MHz");
+        assert_eq!(format_frequency(433_500_000.0), "433.500 MHz");
+        assert_eq!(format_frequency(7_055_000.0), "7.055 MHz");
+    }
+
+    #[test]
+    fn format_ghz() {
+        assert_eq!(format_frequency(1_200_000_000.0), "1.200 GHz");
+        assert_eq!(format_frequency(2_400_000_000.0), "2.400 GHz");
+    }
+
+    #[test]
+    fn format_negative() {
+        assert_eq!(format_frequency(-100_000_000.0), "-100.000 MHz");
+    }
+
+    #[test]
+    fn grid_lines_empty_on_zero_max() {
+        let lines = compute_grid_lines(0.0, 1_000_000.0, 0);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn grid_lines_empty_on_inverted_range() {
+        let lines = compute_grid_lines(1_000_000.0, 0.0, 10);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn grid_lines_reasonable_count() {
+        // 2 MHz span, up to 10 lines
+        let lines = compute_grid_lines(99_000_000.0, 101_000_000.0, 10);
+        assert!(!lines.is_empty());
+        assert!(
+            lines.len() <= 10,
+            "expected at most 10 lines, got {}",
+            lines.len()
+        );
+    }
+
+    #[test]
+    fn grid_lines_within_range() {
+        let start = 100_000_000.0;
+        let end = 102_000_000.0;
+        let lines = compute_grid_lines(start, end, 10);
+        for (freq, _label) in &lines {
+            assert!(
+                *freq >= start && *freq <= end,
+                "grid line {freq} outside range [{start}, {end}]"
+            );
+        }
+    }
+
+    #[test]
+    fn grid_lines_are_sorted() {
+        let lines = compute_grid_lines(88_000_000.0, 108_000_000.0, 20);
+        for pair in lines.windows(2) {
+            assert!(
+                pair[0].0 < pair[1].0,
+                "grid lines should be ascending: {} >= {}",
+                pair[0].0,
+                pair[1].0
+            );
+        }
+    }
+}

--- a/crates/sdr-ui/src/spectrum/gl_renderer.rs
+++ b/crates/sdr-ui/src/spectrum/gl_renderer.rs
@@ -1,0 +1,101 @@
+//! Shared OpenGL utility functions for shader compilation and program linking.
+//!
+//! Used by both the FFT plot renderer and the waterfall renderer.
+
+use glow::HasContext;
+
+/// Error type for OpenGL operations in the spectrum display.
+#[derive(Debug, thiserror::Error)]
+pub enum GlError {
+    /// Shader compilation failed.
+    #[error("shader compilation failed: {0}")]
+    ShaderCompile(String),
+    /// Program linking failed.
+    #[error("program link failed: {0}")]
+    ProgramLink(String),
+    /// A GL resource could not be created.
+    #[error("GL resource creation failed: {0}")]
+    ResourceCreation(String),
+}
+
+/// Compile a single shader of the given type from GLSL source.
+///
+/// # Errors
+///
+/// Returns `GlError::ShaderCompile` if compilation fails, or
+/// `GlError::ResourceCreation` if the shader object cannot be allocated.
+#[allow(unsafe_code)]
+pub fn compile_shader(
+    gl: &glow::Context,
+    shader_type: u32,
+    source: &str,
+) -> Result<glow::Shader, GlError> {
+    unsafe {
+        let shader = gl
+            .create_shader(shader_type)
+            .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+
+        gl.shader_source(shader, source);
+        gl.compile_shader(shader);
+
+        if !gl.get_shader_compile_status(shader) {
+            let log = gl.get_shader_info_log(shader);
+            gl.delete_shader(shader);
+            return Err(GlError::ShaderCompile(log));
+        }
+
+        Ok(shader)
+    }
+}
+
+/// Link a vertex and fragment shader into a program.
+///
+/// Both shaders are detached and deleted after successful linking.
+///
+/// # Errors
+///
+/// Returns `GlError::ProgramLink` if linking fails, or
+/// `GlError::ResourceCreation` if the program object cannot be allocated.
+#[allow(unsafe_code)]
+pub fn link_program(
+    gl: &glow::Context,
+    vert: glow::Shader,
+    frag: glow::Shader,
+) -> Result<glow::Program, GlError> {
+    unsafe {
+        let program = gl
+            .create_program()
+            .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+
+        gl.attach_shader(program, vert);
+        gl.attach_shader(program, frag);
+        gl.link_program(program);
+
+        // Shaders can be detached + deleted after linking regardless of outcome.
+        gl.detach_shader(program, vert);
+        gl.detach_shader(program, frag);
+        gl.delete_shader(vert);
+        gl.delete_shader(frag);
+
+        if !gl.get_program_link_status(program) {
+            let log = gl.get_program_info_log(program);
+            gl.delete_program(program);
+            return Err(GlError::ProgramLink(log));
+        }
+
+        Ok(program)
+    }
+}
+
+/// Log any pending OpenGL errors via `tracing::warn!`.
+///
+/// Call after GL operations during debugging to catch driver issues.
+#[allow(unsafe_code)]
+pub fn check_gl_errors(gl: &glow::Context, label: &str) {
+    unsafe {
+        let err = gl.get_error();
+        if err != glow::NO_ERROR {
+            tracing::warn!("GL error at {label}: 0x{err:04X}");
+        }
+    }
+}

--- a/crates/sdr-ui/src/spectrum/gl_renderer.rs
+++ b/crates/sdr-ui/src/spectrum/gl_renderer.rs
@@ -63,9 +63,14 @@ pub fn link_program(
     frag: glow::Shader,
 ) -> Result<glow::Program, GlError> {
     unsafe {
-        let program = gl
-            .create_program()
-            .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+        let program = match gl.create_program() {
+            Ok(p) => p,
+            Err(e) => {
+                gl.delete_shader(vert);
+                gl.delete_shader(frag);
+                return Err(GlError::ResourceCreation(e));
+            }
+        };
 
         gl.attach_shader(program, vert);
         gl.attach_shader(program, frag);

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -103,8 +103,8 @@ pub fn build_spectrum_view() -> gtk4::Paned {
     start_test_data_timer(
         Rc::clone(&fft_state),
         Rc::clone(&waterfall_state),
-        fft_area.clone(),
-        waterfall_area.clone(),
+        &fft_area,
+        &waterfall_area,
     );
 
     paned
@@ -289,14 +289,25 @@ fn create_gl_context_and_waterfall_renderer()
 fn start_test_data_timer(
     fft_state: Rc<RefCell<Option<FftPlotState>>>,
     waterfall_state: Rc<RefCell<Option<WaterfallState>>>,
-    fft_area: gtk4::GLArea,
-    waterfall_area: gtk4::GLArea,
+    fft_area: &gtk4::GLArea,
+    waterfall_area: &gtk4::GLArea,
 ) {
     let frame_counter = Rc::new(std::cell::Cell::new(0_usize));
+
+    // Use weak references so the timer stops when the GLAreas are dropped.
+    let fft_area_weak = fft_area.downgrade();
+    let waterfall_area_weak = waterfall_area.downgrade();
 
     glib::timeout_add_local(
         std::time::Duration::from_millis(TEST_FRAME_INTERVAL_MS),
         move || {
+            // Stop the timer if either GLArea has been destroyed.
+            let (Some(fft_area), Some(waterfall_area)) =
+                (fft_area_weak.upgrade(), waterfall_area_weak.upgrade())
+            else {
+                return glib::ControlFlow::Break;
+            };
+
             let frame = frame_counter.get();
             frame_counter.set(frame.wrapping_add(1));
 

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -31,7 +31,7 @@ const MIN_DB: f32 = -120.0;
 const MAX_DB: f32 = 0.0;
 
 /// Interval between synthetic test frames, in milliseconds.
-const TEST_FRAME_INTERVAL_MS: u64 = 50;
+const TEST_FRAME_INTERVAL_MS: u64 = 16;
 
 /// Width of synthetic signal peaks in bins.
 const TEST_PEAK_WIDTH: usize = 20;
@@ -117,6 +117,7 @@ fn build_fft_area(state: Rc<RefCell<Option<FftPlotState>>>) -> gtk4::GLArea {
         .vexpand(true)
         .auto_render(false)
         .build();
+    area.set_required_version(3, 0);
 
     // On realize: create GL context and renderer.
     let state_realize = Rc::clone(&state);
@@ -144,8 +145,11 @@ fn build_fft_area(state: Rc<RefCell<Option<FftPlotState>>>) -> gtk4::GLArea {
 
     // On unrealize: clean up GL resources.
     let state_unrealize = Rc::clone(&state);
-    area.connect_unrealize(move |_area| {
-        if let Some(s) = state_unrealize.borrow().as_ref() {
+    area.connect_unrealize(move |area| {
+        area.make_current();
+        if area.error().is_some() {
+            tracing::warn!("FFT GLArea error on unrealize — skipping GL cleanup");
+        } else if let Some(s) = state_unrealize.borrow().as_ref() {
             s.renderer.destroy(&s.gl);
             tracing::info!("FFT plot GL renderer destroyed");
         }
@@ -181,6 +185,7 @@ fn build_waterfall_area(state: Rc<RefCell<Option<WaterfallState>>>) -> gtk4::GLA
         .vexpand(true)
         .auto_render(false)
         .build();
+    area.set_required_version(3, 0);
 
     // On realize: create GL context and renderer.
     let state_realize = Rc::clone(&state);
@@ -204,8 +209,11 @@ fn build_waterfall_area(state: Rc<RefCell<Option<WaterfallState>>>) -> gtk4::GLA
 
     // On unrealize: clean up GL resources.
     let state_unrealize = Rc::clone(&state);
-    area.connect_unrealize(move |_area| {
-        if let Some(s) = state_unrealize.borrow().as_ref() {
+    area.connect_unrealize(move |area| {
+        area.make_current();
+        if area.error().is_some() {
+            tracing::warn!("waterfall GLArea error on unrealize — skipping GL cleanup");
+        } else if let Some(s) = state_unrealize.borrow().as_ref() {
             s.renderer.destroy(&s.gl);
             tracing::info!("waterfall GL renderer destroyed");
         }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -1,0 +1,402 @@
+//! Spectrum display: FFT plot (top) + waterfall spectrogram (bottom).
+//!
+//! Both are rendered via `GtkGLArea` widgets using OpenGL through `glow`.
+//! A `GtkPaned` splits them vertically, with the FFT plot on top (~30%)
+//! and the waterfall below (~70%).
+
+pub mod colormap;
+pub mod fft_plot;
+pub mod frequency_axis;
+pub mod gl_renderer;
+pub mod waterfall;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk4::glib;
+use gtk4::prelude::*;
+
+use fft_plot::FftPlotRenderer;
+use waterfall::WaterfallRenderer;
+
+/// Number of FFT bins for the display.
+const FFT_SIZE: usize = 1024;
+
+/// Default FFT plot pane height fraction (30% of total).
+const FFT_PANE_FRACTION: f64 = 0.30;
+
+/// Minimum display level in dB.
+const MIN_DB: f32 = -120.0;
+/// Maximum display level in dB.
+const MAX_DB: f32 = 0.0;
+
+/// Interval between synthetic test frames, in milliseconds.
+const TEST_FRAME_INTERVAL_MS: u64 = 50;
+
+/// Width of synthetic signal peaks in bins.
+const TEST_PEAK_WIDTH: usize = 20;
+/// Center offset within the peak width.
+const TEST_PEAK_CENTER: i32 = 10;
+/// Noise floor level in dB for test data.
+const TEST_NOISE_FLOOR_DB: f32 = -90.0;
+/// Peak 1 signal level in dB.
+const TEST_PEAK1_DB: f32 = -30.0;
+/// Peak 2 signal level in dB.
+const TEST_PEAK2_DB: f32 = -40.0;
+/// dB falloff per bin distance from peak center.
+const TEST_PEAK_FALLOFF_DB: f32 = -3.0;
+/// Peak 1 drift rate in bins per frame.
+const TEST_PEAK1_DRIFT: usize = 100;
+/// Peak 2 drift rate in bins per frame.
+const TEST_PEAK2_DRIFT: usize = 80;
+/// Noise variation amplitude in dB.
+const TEST_NOISE_VARIATION_DB: f32 = 3.0;
+/// Noise variation frequency scaling factor.
+const TEST_NOISE_FREQ_SCALE: f32 = 0.1;
+
+/// Shared state for the FFT plot `GtkGLArea`.
+struct FftPlotState {
+    gl: glow::Context,
+    renderer: FftPlotRenderer,
+    current_data: Vec<f32>,
+}
+
+/// Shared state for the waterfall `GtkGLArea`.
+struct WaterfallState {
+    gl: glow::Context,
+    renderer: WaterfallRenderer,
+}
+
+/// Build the spectrum view containing the FFT plot and waterfall display.
+///
+/// Returns a `GtkPaned` with vertical orientation: FFT plot on top,
+/// waterfall on bottom. Both are `GtkGLArea` widgets rendered via OpenGL.
+///
+/// Currently drives both displays with synthetic test data for visual validation.
+pub fn build_spectrum_view() -> gtk4::Paned {
+    let fft_state: Rc<RefCell<Option<FftPlotState>>> = Rc::new(RefCell::new(None));
+    let waterfall_state: Rc<RefCell<Option<WaterfallState>>> = Rc::new(RefCell::new(None));
+
+    let fft_area = build_fft_area(Rc::clone(&fft_state));
+    let waterfall_area = build_waterfall_area(Rc::clone(&waterfall_state));
+
+    let paned = gtk4::Paned::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .hexpand(true)
+        .vexpand(true)
+        .build();
+
+    paned.set_start_child(Some(&fft_area));
+    paned.set_end_child(Some(&waterfall_area));
+
+    // Set the initial split position once the widget has a size.
+    paned.connect_realize(|paned| {
+        let height = paned.height();
+        if height > 0 {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let pos = (f64::from(height) * FFT_PANE_FRACTION) as i32;
+            paned.set_position(pos);
+        }
+    });
+
+    // Start synthetic test data generation.
+    start_test_data_timer(
+        Rc::clone(&fft_state),
+        Rc::clone(&waterfall_state),
+        fft_area.clone(),
+        waterfall_area.clone(),
+    );
+
+    paned
+}
+
+/// Build the `GtkGLArea` for the FFT power spectrum plot.
+fn build_fft_area(state: Rc<RefCell<Option<FftPlotState>>>) -> gtk4::GLArea {
+    let area = gtk4::GLArea::builder()
+        .hexpand(true)
+        .vexpand(true)
+        .auto_render(false)
+        .build();
+
+    // On realize: create GL context and renderer.
+    let state_realize = Rc::clone(&state);
+    area.connect_realize(move |area| {
+        area.make_current();
+        if area.error().is_some() {
+            tracing::warn!("FFT GLArea has error after make_current");
+            return;
+        }
+
+        match create_gl_context_and_fft_renderer() {
+            Ok((gl, renderer)) => {
+                *state_realize.borrow_mut() = Some(FftPlotState {
+                    gl,
+                    renderer,
+                    current_data: vec![MIN_DB; FFT_SIZE],
+                });
+                tracing::info!("FFT plot GL renderer initialized");
+            }
+            Err(e) => {
+                tracing::warn!("failed to initialize FFT plot renderer: {e}");
+            }
+        }
+    });
+
+    // On unrealize: clean up GL resources.
+    let state_unrealize = Rc::clone(&state);
+    area.connect_unrealize(move |_area| {
+        if let Some(s) = state_unrealize.borrow().as_ref() {
+            s.renderer.destroy(&s.gl);
+            tracing::info!("FFT plot GL renderer destroyed");
+        }
+        *state_unrealize.borrow_mut() = None;
+    });
+
+    // On render: draw the FFT plot.
+    area.connect_render(move |area, _ctx| {
+        if let Some(s) = state.borrow().as_ref() {
+            let width = area.width();
+            let height = area.height();
+            // Account for HiDPI scale factor.
+            let scale = area.scale_factor();
+            s.renderer.render(
+                &s.gl,
+                &s.current_data,
+                width * scale,
+                height * scale,
+                MIN_DB,
+                MAX_DB,
+            );
+        }
+        glib::Propagation::Stop
+    });
+
+    area
+}
+
+/// Build the `GtkGLArea` for the waterfall spectrogram.
+fn build_waterfall_area(state: Rc<RefCell<Option<WaterfallState>>>) -> gtk4::GLArea {
+    let area = gtk4::GLArea::builder()
+        .hexpand(true)
+        .vexpand(true)
+        .auto_render(false)
+        .build();
+
+    // On realize: create GL context and renderer.
+    let state_realize = Rc::clone(&state);
+    area.connect_realize(move |area| {
+        area.make_current();
+        if area.error().is_some() {
+            tracing::warn!("waterfall GLArea has error after make_current");
+            return;
+        }
+
+        match create_gl_context_and_waterfall_renderer() {
+            Ok((gl, renderer)) => {
+                *state_realize.borrow_mut() = Some(WaterfallState { gl, renderer });
+                tracing::info!("waterfall GL renderer initialized");
+            }
+            Err(e) => {
+                tracing::warn!("failed to initialize waterfall renderer: {e}");
+            }
+        }
+    });
+
+    // On unrealize: clean up GL resources.
+    let state_unrealize = Rc::clone(&state);
+    area.connect_unrealize(move |_area| {
+        if let Some(s) = state_unrealize.borrow().as_ref() {
+            s.renderer.destroy(&s.gl);
+            tracing::info!("waterfall GL renderer destroyed");
+        }
+        *state_unrealize.borrow_mut() = None;
+    });
+
+    // On render: draw the waterfall.
+    area.connect_render(move |area, _ctx| {
+        if let Some(s) = state.borrow().as_ref() {
+            let width = area.width();
+            let height = area.height();
+            let scale = area.scale_factor();
+            s.renderer.render(&s.gl, width * scale, height * scale);
+        }
+        glib::Propagation::Stop
+    });
+
+    area
+}
+
+/// Create a glow GL context from the current GDK GL context.
+///
+/// Must be called after `GtkGLArea::make_current()`.
+///
+/// Uses `dlsym(RTLD_DEFAULT, ...)` to resolve OpenGL function pointers from
+/// the GL library already loaded by GTK4's display backend. At runtime, GTK4
+/// has already loaded libEGL + libGLESv2 (Wayland) or libGL (X11), so all
+/// GL symbols are available via the dynamic linker's global scope.
+#[allow(unsafe_code)]
+fn create_glow_context() -> glow::Context {
+    unsafe {
+        glow::Context::from_loader_function_cstr(|name| {
+            // dlsym with RTLD_DEFAULT searches all loaded shared objects.
+            // GTK4 has already loaded the platform GL library (libGL, libGLESv2,
+            // or libEGL) so GL entry points are resolvable.
+            dlsym(RTLD_DEFAULT, name.as_ptr())
+        })
+    }
+}
+
+/// Handle for `dlsym(RTLD_DEFAULT, ...)` — search all loaded shared objects.
+#[allow(unsafe_code)]
+const RTLD_DEFAULT: *mut std::os::raw::c_void = std::ptr::null_mut();
+
+#[allow(unsafe_code)]
+unsafe extern "C" {
+    /// POSIX `dlsym` — resolve a symbol from a shared object handle.
+    fn dlsym(
+        handle: *mut std::os::raw::c_void,
+        symbol: *const std::os::raw::c_char,
+    ) -> *const std::os::raw::c_void;
+}
+
+/// Create a glow context and FFT plot renderer.
+fn create_gl_context_and_fft_renderer()
+-> Result<(glow::Context, FftPlotRenderer), gl_renderer::GlError> {
+    let gl = create_glow_context();
+    let renderer = FftPlotRenderer::new(&gl)?;
+    Ok((gl, renderer))
+}
+
+/// Create a glow context and waterfall renderer.
+fn create_gl_context_and_waterfall_renderer()
+-> Result<(glow::Context, WaterfallRenderer), gl_renderer::GlError> {
+    let gl = create_glow_context();
+    let renderer = WaterfallRenderer::new(&gl, FFT_SIZE)?;
+    Ok((gl, renderer))
+}
+
+/// Start a periodic timer that generates synthetic FFT test data and pushes
+/// it to both renderers. This provides visual validation until real DSP data
+/// is connected.
+fn start_test_data_timer(
+    fft_state: Rc<RefCell<Option<FftPlotState>>>,
+    waterfall_state: Rc<RefCell<Option<WaterfallState>>>,
+    fft_area: gtk4::GLArea,
+    waterfall_area: gtk4::GLArea,
+) {
+    let frame_counter = Rc::new(std::cell::Cell::new(0_usize));
+
+    glib::timeout_add_local(
+        std::time::Duration::from_millis(TEST_FRAME_INTERVAL_MS),
+        move || {
+            let frame = frame_counter.get();
+            frame_counter.set(frame.wrapping_add(1));
+
+            let data = generate_test_fft(FFT_SIZE, frame);
+
+            // Update FFT plot data.
+            if let Some(s) = fft_state.borrow_mut().as_mut() {
+                s.current_data.clear();
+                s.current_data.extend_from_slice(&data);
+            }
+            fft_area.queue_render();
+
+            // Push a new line to the waterfall.
+            if let Some(s) = waterfall_state.borrow_mut().as_mut() {
+                waterfall_area.make_current();
+                s.renderer.push_line(&s.gl, &data);
+            }
+            waterfall_area.queue_render();
+
+            glib::ControlFlow::Continue
+        },
+    );
+}
+
+/// Generate synthetic FFT test data for visual validation.
+///
+/// Produces a noise floor with two moving peaks, suitable for verifying
+/// that the spectrum display and waterfall are rendering correctly.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
+fn generate_test_fft(size: usize, frame: usize) -> Vec<f32> {
+    let mut data = vec![TEST_NOISE_FLOOR_DB; size];
+
+    // Two peaks that slowly drift across the spectrum.
+    let peak1_center = (size / 4 + frame % TEST_PEAK1_DRIFT) % size;
+    let peak2_center = (3 * size / 4 + size - frame % TEST_PEAK2_DRIFT) % size;
+
+    for i in 0..TEST_PEAK_WIDTH {
+        let dist = (TEST_PEAK_CENTER - i as i32).abs() as f32;
+
+        let idx1 = (peak1_center + i) % size;
+        data[idx1] = TEST_PEAK1_DB + dist * TEST_PEAK_FALLOFF_DB;
+
+        let idx2 = (peak2_center + i) % size;
+        data[idx2] = TEST_PEAK2_DB + dist * TEST_PEAK_FALLOFF_DB;
+    }
+
+    // Add subtle noise variation.
+    let variation = (frame as f32 * TEST_NOISE_FREQ_SCALE).sin() * TEST_NOISE_VARIATION_DB;
+    for d in &mut data {
+        *d += variation;
+    }
+
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_test_fft_size() {
+        let data = generate_test_fft(FFT_SIZE, 0);
+        assert_eq!(data.len(), FFT_SIZE);
+    }
+
+    #[test]
+    fn test_generate_test_fft_has_peaks() {
+        let data = generate_test_fft(FFT_SIZE, 0);
+        let max_val = data.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let min_val = data.iter().copied().fold(f32::INFINITY, f32::min);
+        // Peaks should be well above the noise floor.
+        assert!(
+            max_val > TEST_NOISE_FLOOR_DB + 20.0,
+            "max value {max_val} should be well above noise floor"
+        );
+        // There should be dynamic range.
+        assert!(
+            max_val - min_val > 30.0,
+            "dynamic range {} dB is too small",
+            max_val - min_val
+        );
+    }
+
+    #[test]
+    fn test_generate_test_fft_peaks_move() {
+        let data_frame_start = generate_test_fft(FFT_SIZE, 0);
+        let data_frame_later = generate_test_fft(FFT_SIZE, 50);
+
+        // Find peak positions.
+        let peak_at_start = data_frame_start
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i);
+        let peak_at_later = data_frame_later
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i);
+
+        // Peaks should have moved between frames.
+        assert_ne!(
+            peak_at_start, peak_at_later,
+            "peaks should drift between frames"
+        );
+    }
+}

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -271,8 +271,9 @@ impl WaterfallRenderer {
             gl.bind_texture(glow::TEXTURE_2D, Some(self.colormap_texture));
             gl.uniform_1_i32(Some(&self.colormap_tex_loc), 1);
 
-            // Set scroll offset and history size.
-            gl.uniform_1_f32(Some(&self.scroll_offset_loc), self.write_row as f32);
+            // Set scroll offset to the newest written row (not the next free slot).
+            let newest_row = (self.write_row + HISTORY_LINES - 1) % HISTORY_LINES;
+            gl.uniform_1_f32(Some(&self.scroll_offset_loc), newest_row as f32);
             gl.uniform_1_f32(Some(&self.history_lines_loc), HISTORY_LINES as f32);
 
             gl.bind_vertex_array(Some(self.vao));

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -324,6 +324,10 @@ fn create_data_texture(gl: &glow::Context, width: usize) -> Result<glow::Texture
 
         gl.bind_texture(glow::TEXTURE_2D, Some(texture));
 
+        // R8 is 1 byte/pixel — set alignment to 1 so non-power-of-4 widths
+        // don't cause row misalignment from the default GL_UNPACK_ALIGNMENT of 4.
+        gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 1);
+
         // Initialize with zeros.
         let data = vec![0u8; width * HISTORY_LINES];
         gl.tex_image_2d(

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -1,0 +1,419 @@
+//! Waterfall display renderer using OpenGL via glow.
+//!
+//! Renders a scrolling spectrogram: each FFT frame becomes one horizontal line
+//! in a ring-buffer texture, mapped through a colormap for visualization.
+
+use glow::HasContext;
+
+use super::colormap;
+use super::gl_renderer::{self, GlError};
+
+/// Number of history lines stored in the ring-buffer texture.
+const HISTORY_LINES: usize = 1024;
+
+/// Default minimum display level in dB.
+const DEFAULT_MIN_DB: f32 = -120.0;
+/// Default maximum display level in dB.
+const DEFAULT_MAX_DB: f32 = 0.0;
+
+/// Background clear color — near-black, matching FFT plot.
+const BACKGROUND_COLOR: [f32; 4] = [0.08, 0.08, 0.10, 1.0];
+
+/// Vertex shader for the waterfall full-screen quad.
+/// Passes texture coordinates to the fragment shader.
+const VERT_SHADER: &str = r"#version 300 es
+precision highp float;
+layout(location = 0) in vec2 a_pos;
+layout(location = 1) in vec2 a_uv;
+out vec2 v_uv;
+void main() {
+    gl_Position = vec4(a_pos, 0.0, 1.0);
+    v_uv = a_uv;
+}
+";
+
+/// Fragment shader for the waterfall display.
+/// Samples the data texture (R channel = normalized dB),
+/// applies the scroll offset, and maps through the colormap.
+const FRAG_SHADER: &str = r"#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_data_tex;
+uniform sampler2D u_colormap_tex;
+uniform float u_scroll_offset;
+uniform float u_history_lines;
+out vec4 frag_color;
+void main() {
+    // Apply ring-buffer scroll: shift V coordinate by the write position.
+    float v = v_uv.y + u_scroll_offset / u_history_lines;
+    v = fract(v); // wrap around
+    vec2 uv = vec2(v_uv.x, v);
+
+    // Sample data texture: R channel holds normalized power (0..1).
+    float power = texture(u_data_tex, uv).r;
+
+    // Map through colormap (1D lookup along U axis).
+    vec4 color = texture(u_colormap_tex, vec2(power, 0.5));
+    frag_color = color;
+}
+";
+
+/// Full-screen quad vertices: position (x, y) + texcoord (u, v).
+/// Two triangles covering the entire NDC [-1, 1] range.
+#[allow(clippy::excessive_precision)]
+const QUAD_VERTICES: [f32; 24] = [
+    // Triangle 1
+    -1.0, -1.0, 0.0, 1.0, // bottom-left  (v=1 = oldest)
+    1.0, -1.0, 1.0, 1.0, // bottom-right
+    -1.0, 1.0, 0.0, 0.0, // top-left     (v=0 = newest)
+    // Triangle 2
+    1.0, -1.0, 1.0, 1.0, // bottom-right
+    1.0, 1.0, 1.0, 0.0, // top-right
+    -1.0, 1.0, 0.0, 0.0, // top-left
+];
+
+/// OpenGL renderer for the scrolling waterfall spectrogram.
+pub struct WaterfallRenderer {
+    program: glow::Program,
+    vao: glow::VertexArray,
+    vbo: glow::Buffer,
+    data_texture: glow::Texture,
+    colormap_texture: glow::Texture,
+    /// Current write position in the ring buffer (`0..HISTORY_LINES`).
+    write_row: usize,
+    /// Width of the data texture in texels (= number of FFT bins).
+    texture_width: usize,
+    /// Uniform locations.
+    scroll_offset_loc: glow::UniformLocation,
+    history_lines_loc: glow::UniformLocation,
+    data_tex_loc: glow::UniformLocation,
+    colormap_tex_loc: glow::UniformLocation,
+    /// Display range in dB.
+    min_db: f32,
+    max_db: f32,
+}
+
+impl WaterfallRenderer {
+    /// Create a new waterfall renderer.
+    ///
+    /// # Arguments
+    ///
+    /// * `gl` — The glow GL context.
+    /// * `width` — Number of FFT bins (data texture width).
+    ///
+    /// # Errors
+    ///
+    /// Returns `GlError` if shader compilation, linking, or resource creation fails.
+    #[allow(
+        unsafe_code,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    pub fn new(gl: &glow::Context, width: usize) -> Result<Self, GlError> {
+        let vert = gl_renderer::compile_shader(gl, glow::VERTEX_SHADER, VERT_SHADER)?;
+        let frag = gl_renderer::compile_shader(gl, glow::FRAGMENT_SHADER, FRAG_SHADER)?;
+        let program = gl_renderer::link_program(gl, vert, frag)?;
+
+        // Look up uniforms.
+        let scroll_offset_loc = unsafe {
+            gl.get_uniform_location(program, "u_scroll_offset")
+                .ok_or_else(|| {
+                    GlError::ResourceCreation("u_scroll_offset uniform not found".into())
+                })?
+        };
+        let history_lines_loc = unsafe {
+            gl.get_uniform_location(program, "u_history_lines")
+                .ok_or_else(|| {
+                    GlError::ResourceCreation("u_history_lines uniform not found".into())
+                })?
+        };
+        let data_tex_loc = unsafe {
+            gl.get_uniform_location(program, "u_data_tex")
+                .ok_or_else(|| GlError::ResourceCreation("u_data_tex uniform not found".into()))?
+        };
+        let colormap_tex_loc = unsafe {
+            gl.get_uniform_location(program, "u_colormap_tex")
+                .ok_or_else(|| {
+                    GlError::ResourceCreation("u_colormap_tex uniform not found".into())
+                })?
+        };
+
+        // Create and upload quad VBO/VAO.
+        let (vao, vbo) = unsafe {
+            let vao = gl
+                .create_vertex_array()
+                .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+            let vbo = gl
+                .create_buffer()
+                .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+
+            gl.bind_vertex_array(Some(vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+
+            let bytes = bytemuck_cast_slice(&QUAD_VERTICES);
+            gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, bytes, glow::STATIC_DRAW);
+
+            let stride = (4 * std::mem::size_of::<f32>()) as i32;
+
+            // Attribute 0: vec2 position.
+            gl.enable_vertex_attrib_array(0);
+            gl.vertex_attrib_pointer_f32(0, 2, glow::FLOAT, false, stride, 0);
+
+            // Attribute 1: vec2 texcoord.
+            gl.enable_vertex_attrib_array(1);
+            gl.vertex_attrib_pointer_f32(
+                1,
+                2,
+                glow::FLOAT,
+                false,
+                stride,
+                (2 * std::mem::size_of::<f32>()) as i32,
+            );
+
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+
+            (vao, vbo)
+        };
+
+        // Create the data texture (R8, width x HISTORY_LINES).
+        let data_texture = create_data_texture(gl, width)?;
+
+        // Create the colormap texture (RGBA, 256 x 1).
+        let colormap_texture = create_colormap_texture(gl)?;
+
+        Ok(Self {
+            program,
+            vao,
+            vbo,
+            data_texture,
+            colormap_texture,
+            write_row: 0,
+            texture_width: width,
+            scroll_offset_loc,
+            history_lines_loc,
+            data_tex_loc,
+            colormap_tex_loc,
+            min_db: DEFAULT_MIN_DB,
+            max_db: DEFAULT_MAX_DB,
+        })
+    }
+
+    /// Push one FFT frame as a new row in the ring-buffer texture.
+    ///
+    /// The dB values are normalized to 0..255 using the current display range
+    /// and written to the current row via `texSubImage2D`.
+    #[allow(
+        unsafe_code,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss
+    )]
+    pub fn push_line(&mut self, gl: &glow::Context, fft_data: &[f32]) {
+        let bin_count = fft_data.len().min(self.texture_width);
+        let db_range = self.max_db - self.min_db;
+        if db_range <= 0.0 {
+            return;
+        }
+
+        // Normalize dB values to 0..255 bytes.
+        let mut row_data = vec![0u8; self.texture_width];
+        for (i, &db) in fft_data.iter().take(bin_count).enumerate() {
+            let normalized = ((db - self.min_db) / db_range).clamp(0.0, 1.0);
+            row_data[i] = (normalized * 255.0).round() as u8;
+        }
+
+        unsafe {
+            gl.bind_texture(glow::TEXTURE_2D, Some(self.data_texture));
+            gl.tex_sub_image_2d(
+                glow::TEXTURE_2D,
+                0,
+                0,
+                self.write_row as i32,
+                self.texture_width as i32,
+                1,
+                glow::RED,
+                glow::UNSIGNED_BYTE,
+                glow::PixelUnpackData::Slice(Some(&row_data)),
+            );
+            gl.bind_texture(glow::TEXTURE_2D, None);
+        }
+
+        self.write_row = (self.write_row + 1) % HISTORY_LINES;
+    }
+
+    /// Render the full waterfall display.
+    #[allow(unsafe_code, clippy::cast_precision_loss)]
+    pub fn render(&self, gl: &glow::Context, width: i32, height: i32) {
+        if width <= 0 || height <= 0 {
+            return;
+        }
+
+        unsafe {
+            gl.viewport(0, 0, width, height);
+            gl.clear_color(
+                BACKGROUND_COLOR[0],
+                BACKGROUND_COLOR[1],
+                BACKGROUND_COLOR[2],
+                BACKGROUND_COLOR[3],
+            );
+            gl.clear(glow::COLOR_BUFFER_BIT);
+
+            gl.use_program(Some(self.program));
+
+            // Bind data texture to unit 0.
+            gl.active_texture(glow::TEXTURE0);
+            gl.bind_texture(glow::TEXTURE_2D, Some(self.data_texture));
+            gl.uniform_1_i32(Some(&self.data_tex_loc), 0);
+
+            // Bind colormap texture to unit 1.
+            gl.active_texture(glow::TEXTURE1);
+            gl.bind_texture(glow::TEXTURE_2D, Some(self.colormap_texture));
+            gl.uniform_1_i32(Some(&self.colormap_tex_loc), 1);
+
+            // Set scroll offset and history size.
+            gl.uniform_1_f32(Some(&self.scroll_offset_loc), self.write_row as f32);
+            gl.uniform_1_f32(Some(&self.history_lines_loc), HISTORY_LINES as f32);
+
+            gl.bind_vertex_array(Some(self.vao));
+            gl.draw_arrays(glow::TRIANGLES, 0, 6);
+
+            gl.bind_vertex_array(None);
+            gl.active_texture(glow::TEXTURE0);
+            gl.bind_texture(glow::TEXTURE_2D, None);
+            gl.active_texture(glow::TEXTURE1);
+            gl.bind_texture(glow::TEXTURE_2D, None);
+            gl.use_program(None);
+        }
+    }
+
+    /// Update the display range in dB.
+    pub fn set_db_range(&mut self, min_db: f32, max_db: f32) {
+        self.min_db = min_db;
+        self.max_db = max_db;
+    }
+
+    /// Release GL resources.
+    #[allow(unsafe_code)]
+    pub fn destroy(&self, gl: &glow::Context) {
+        unsafe {
+            gl.delete_texture(self.data_texture);
+            gl.delete_texture(self.colormap_texture);
+            gl.delete_buffer(self.vbo);
+            gl.delete_vertex_array(self.vao);
+            gl.delete_program(self.program);
+        }
+    }
+}
+
+/// Create the ring-buffer data texture (R8, width x `HISTORY_LINES`).
+#[allow(
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
+fn create_data_texture(gl: &glow::Context, width: usize) -> Result<glow::Texture, GlError> {
+    unsafe {
+        let texture = gl
+            .create_texture()
+            .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+
+        gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+
+        // Initialize with zeros.
+        let data = vec![0u8; width * HISTORY_LINES];
+        gl.tex_image_2d(
+            glow::TEXTURE_2D,
+            0,
+            glow::R8 as i32,
+            width as i32,
+            HISTORY_LINES as i32,
+            0,
+            glow::RED,
+            glow::UNSIGNED_BYTE,
+            glow::PixelUnpackData::Slice(Some(&data)),
+        );
+
+        // Nearest filtering — we want crisp bin boundaries.
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_MIN_FILTER,
+            glow::NEAREST as i32,
+        );
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_MAG_FILTER,
+            glow::NEAREST as i32,
+        );
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_WRAP_S,
+            glow::CLAMP_TO_EDGE as i32,
+        );
+        gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_T, glow::REPEAT as i32);
+
+        gl.bind_texture(glow::TEXTURE_2D, None);
+        Ok(texture)
+    }
+}
+
+/// Create the colormap lookup texture (RGBA, 256 x 1).
+#[allow(
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
+fn create_colormap_texture(gl: &glow::Context) -> Result<glow::Texture, GlError> {
+    unsafe {
+        let texture = gl
+            .create_texture()
+            .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+
+        gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+
+        let colormap = colormap::generate_colormap();
+        let flat: Vec<u8> = colormap.iter().flat_map(|c| c.iter().copied()).collect();
+
+        gl.tex_image_2d(
+            glow::TEXTURE_2D,
+            0,
+            glow::RGBA8 as i32,
+            colormap::COLORMAP_SIZE as i32,
+            1,
+            0,
+            glow::RGBA,
+            glow::UNSIGNED_BYTE,
+            glow::PixelUnpackData::Slice(Some(&flat)),
+        );
+
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_MIN_FILTER,
+            glow::LINEAR as i32,
+        );
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_MAG_FILTER,
+            glow::LINEAR as i32,
+        );
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_WRAP_S,
+            glow::CLAMP_TO_EDGE as i32,
+        );
+        gl.tex_parameter_i32(
+            glow::TEXTURE_2D,
+            glow::TEXTURE_WRAP_T,
+            glow::CLAMP_TO_EDGE as i32,
+        );
+
+        gl.bind_texture(glow::TEXTURE_2D, None);
+        Ok(texture)
+    }
+}
+
+/// Reinterpret a `&[f32]` as `&[u8]` for uploading to GL buffers.
+#[allow(unsafe_code)]
+fn bytemuck_cast_slice(data: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), std::mem::size_of_val(data)) }
+}

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -79,6 +79,8 @@ pub struct WaterfallRenderer {
     vbo: glow::Buffer,
     data_texture: glow::Texture,
     colormap_texture: glow::Texture,
+    /// Pre-allocated buffer for uploading one row of normalized pixel data.
+    row_buffer: Vec<u8>,
     /// Current write position in the ring buffer (`0..HISTORY_LINES`).
     write_row: usize,
     /// Width of the data texture in texels (= number of FFT bins).
@@ -188,6 +190,7 @@ impl WaterfallRenderer {
             vbo,
             data_texture,
             colormap_texture,
+            row_buffer: vec![0u8; width],
             write_row: 0,
             texture_width: width,
             scroll_offset_loc,
@@ -216,11 +219,11 @@ impl WaterfallRenderer {
             return;
         }
 
-        // Normalize dB values to 0..255 bytes.
-        let mut row_data = vec![0u8; self.texture_width];
+        // Normalize dB values to 0..255 using pre-allocated row buffer.
+        self.row_buffer.fill(0);
         for (i, &db) in fft_data.iter().take(bin_count).enumerate() {
             let normalized = ((db - self.min_db) / db_range).clamp(0.0, 1.0);
-            row_data[i] = (normalized * 255.0).round() as u8;
+            self.row_buffer[i] = (normalized * 255.0).round() as u8;
         }
 
         unsafe {
@@ -234,7 +237,7 @@ impl WaterfallRenderer {
                 1,
                 glow::RED,
                 glow::UNSIGNED_BYTE,
-                glow::PixelUnpackData::Slice(Some(&row_data)),
+                glow::PixelUnpackData::Slice(Some(&self.row_buffer)),
             );
             gl.bind_texture(glow::TEXTURE_2D, None);
         }

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -215,7 +215,7 @@ impl WaterfallRenderer {
     pub fn push_line(&mut self, gl: &glow::Context, fft_data: &[f32]) {
         let bin_count = fft_data.len().min(self.texture_width);
         let db_range = self.max_db - self.min_db;
-        if db_range <= 0.0 {
+        if !db_range.is_finite() || db_range <= 0.0 {
             return;
         }
 
@@ -293,8 +293,10 @@ impl WaterfallRenderer {
 
     /// Update the display range in dB.
     pub fn set_db_range(&mut self, min_db: f32, max_db: f32) {
-        self.min_db = min_db;
-        self.max_db = max_db;
+        if min_db.is_finite() && max_db.is_finite() && max_db > min_db {
+            self.min_db = min_db;
+            self.max_db = max_db;
+        }
     }
 
     /// Release GL resources.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -6,6 +6,8 @@ use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
 
+use crate::spectrum;
+
 /// Default window width in pixels.
 const DEFAULT_WIDTH: i32 = 1200;
 /// Default window height in pixels.
@@ -57,20 +59,16 @@ fn build_split_view() -> adw::OverlaySplitView {
         .hscrollbar_policy(gtk4::PolicyType::Never)
         .build();
 
-    // Main content area
-    let content_label = gtk4::Label::builder()
-        .label("Spectrum display coming soon")
-        .css_classes(["spectrum-area"])
-        .hexpand(true)
-        .vexpand(true)
-        .build();
+    // Main content area — spectrum display (FFT plot + waterfall).
+    let spectrum_view = spectrum::build_spectrum_view();
+    spectrum_view.add_css_class("spectrum-area");
 
     let content_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
         .hexpand(true)
         .vexpand(true)
         .build();
-    content_box.append(&content_label);
+    content_box.append(&spectrum_view);
 
     adw::OverlaySplitView::builder()
         .sidebar(&sidebar_scroll)

--- a/tests/hardware_integration.rs
+++ b/tests/hardware_integration.rs
@@ -208,18 +208,25 @@ fn pipeline_iq_frontend_produces_fft() {
     tracing::info!("IqFrontend: processed {processed} samples, FFT ready: {fft_ready}");
     assert!(processed > 0, "No samples processed");
 
-    // If we read enough samples, FFT should be ready
-    if iq_count >= TEST_FFT_SIZE {
-        assert!(fft_ready, "FFT should be ready with {iq_count} samples");
+    assert!(
+        iq_count >= TEST_FFT_SIZE,
+        "Need at least {TEST_FFT_SIZE} IQ samples for FFT validation, got {iq_count}"
+    );
+    assert!(fft_ready, "FFT should be ready with {iq_count} samples");
 
-        // FFT output should be in dB range (roughly -120 to 0)
-        let fft_min = fft_out.iter().copied().reduce(f32::min).unwrap_or(0.0);
-        let fft_max = fft_out.iter().copied().reduce(f32::max).unwrap_or(0.0);
-        tracing::info!("FFT range: {fft_min:.1} to {fft_max:.1} dB");
+    // FFT output should be in dB range with finite values
+    let fft_min = fft_out.iter().copied().reduce(f32::min).unwrap_or(0.0);
+    let fft_max = fft_out.iter().copied().reduce(f32::max).unwrap_or(0.0);
+    tracing::info!("FFT range: {fft_min:.1} to {fft_max:.1} dB");
 
-        assert!(fft_max > -120.0, "FFT max too low: {fft_max}");
-        assert!(fft_min < 0.0, "FFT min should be negative dB: {fft_min}");
-    }
+    assert!(
+        fft_min.is_finite() && fft_max.is_finite(),
+        "Non-finite FFT dB values"
+    );
+    assert!(
+        fft_max > fft_min,
+        "Flat FFT output indicates invalid spectrum computation"
+    );
 }
 
 #[test]
@@ -241,27 +248,36 @@ fn pipeline_fft_standalone() {
     let mut iq = vec![Complex::default(); bytes_read / 2];
     let count = RtlSdrSource::convert_samples(&raw[..bytes_read], &mut iq);
 
-    if count >= TEST_FFT_SIZE {
-        let mut engine = RustFftEngine::new(TEST_FFT_SIZE).expect("create FFT engine");
-        let mut fft_buf = iq[..TEST_FFT_SIZE].to_vec();
-        engine.forward(&mut fft_buf).expect("FFT forward");
+    assert!(
+        count >= TEST_FFT_SIZE,
+        "Need at least {TEST_FFT_SIZE} IQ samples, got {count}"
+    );
 
-        let mut power = vec![0.0_f32; TEST_FFT_SIZE];
-        sdr_dsp::fft::power_spectrum_db(&fft_buf, &mut power).expect("power_spectrum_db");
+    let mut engine = RustFftEngine::new(TEST_FFT_SIZE).expect("create FFT engine");
+    let mut fft_buf = iq[..TEST_FFT_SIZE].to_vec();
+    engine.forward(&mut fft_buf).expect("FFT forward");
 
-        let peak_bin = power
-            .iter()
-            .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-            .map(|(i, _)| i)
-            .unwrap_or(0);
-        let peak_db = power[peak_bin];
-        tracing::info!(
-            "FFT peak at bin {peak_bin} ({:.1} dB), noise floor ~{:.1} dB",
-            peak_db,
-            power.iter().sum::<f32>() / power.len() as f32
-        );
-    }
+    let mut power = vec![0.0_f32; TEST_FFT_SIZE];
+    sdr_dsp::fft::power_spectrum_db(&fft_buf, &mut power).expect("power_spectrum_db");
+    assert!(
+        power.iter().all(|v| v.is_finite()),
+        "Non-finite power spectrum values"
+    );
+
+    let peak_bin = power
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    let peak_db = power[peak_bin];
+    let min_db = power.iter().copied().reduce(f32::min).unwrap_or(peak_db);
+    tracing::info!(
+        "FFT peak at bin {peak_bin} ({:.1} dB), noise floor ~{:.1} dB",
+        peak_db,
+        power.iter().sum::<f32>() / power.len() as f32
+    );
+    assert!(peak_db > min_db, "No spectral dynamic range detected");
 }
 
 // =========================================================================

--- a/tests/hardware_integration.rs
+++ b/tests/hardware_integration.rs
@@ -15,7 +15,8 @@
     clippy::float_cmp,
     clippy::map_unwrap_or,
     clippy::expect_fun_call,
-    clippy::doc_markdown
+    clippy::doc_markdown,
+    clippy::panic
 )]
 
 use sdr_dsp::fft::{FftEngine, RustFftEngine};
@@ -406,14 +407,16 @@ fn end_to_end_mode_switching() {
     ];
 
     for mode in &modes {
-        radio.set_mode(*mode).expect(&format!("set mode {mode:?}"));
+        radio
+            .set_mode(*mode)
+            .unwrap_or_else(|e| panic!("set mode {mode:?}: {e}"));
 
         let max_out = radio.max_output_samples(processed_count);
         let mut audio_out = vec![Stereo::default(); max_out];
 
         let audio_count = radio
             .process(&processed_iq[..processed_count], &mut audio_out)
-            .expect(&format!("{mode:?}::process"));
+            .unwrap_or_else(|e| panic!("{mode:?}::process: {e}"));
 
         tracing::info!("{mode:?}: {audio_count} audio samples from {processed_count} IQ");
         assert!(audio_count > 0, "{mode:?}: no audio output");

--- a/tests/hardware_integration.rs
+++ b/tests/hardware_integration.rs
@@ -1,0 +1,431 @@
+//! Hardware integration tests — require a real RTL-SDR device.
+//!
+//! Run with: `cargo test --test hardware_integration -- --ignored --test-threads=1`
+//!
+//! IMPORTANT: Use `--test-threads=1` — all tests share one USB device.
+//!
+//! These tests are `#[ignore]` by default so CI passes without hardware.
+//! They exercise the full signal chain from USB device to audio samples.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::cast_lossless,
+    clippy::float_cmp,
+    clippy::map_unwrap_or,
+    clippy::expect_fun_call,
+    clippy::doc_markdown
+)]
+
+use sdr_dsp::fft::{FftEngine, RustFftEngine};
+use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
+use sdr_pipeline::source_manager::Source;
+use sdr_radio::RadioModule;
+use sdr_rtlsdr::RtlSdrDevice;
+use sdr_source_rtlsdr::RtlSdrSource;
+use sdr_types::{Complex, DemodMode, Stereo};
+
+/// Default test frequency: 100 MHz (FM broadcast band).
+const TEST_FREQ_HZ: u32 = 100_000_000;
+
+/// Default test sample rate: 2.4 MHz.
+const TEST_SAMPLE_RATE: u32 = 2_400_000;
+
+/// Number of IQ sample pairs to read per bulk transfer.
+const READ_BUF_SIZE: usize = 16384;
+
+/// FFT size for pipeline tests.
+const TEST_FFT_SIZE: usize = 2048;
+
+// =========================================================================
+// Level 1: Raw device access
+// =========================================================================
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn device_enumerate() {
+    let count = sdr_rtlsdr::get_device_count();
+    assert!(count > 0, "No RTL-SDR devices found — is one plugged in?");
+    tracing::info!("Found {count} RTL-SDR device(s)");
+
+    let name = sdr_rtlsdr::get_device_name(0);
+    tracing::info!("Device 0: {name}");
+    assert!(!name.is_empty());
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn device_open_close() {
+    let device = RtlSdrDevice::open(0).expect("Failed to open RTL-SDR device");
+    let tuner = device.tuner_type();
+    tracing::info!("Tuner type: {tuner:?}");
+    drop(device);
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn device_set_sample_rate() {
+    let mut device = RtlSdrDevice::open(0).expect("Failed to open device");
+    device
+        .set_sample_rate(TEST_SAMPLE_RATE)
+        .expect("Failed to set sample rate");
+    let actual = device.sample_rate();
+    tracing::info!("Requested {TEST_SAMPLE_RATE} Hz, got {actual} Hz");
+    // RTL-SDR may round slightly
+    assert!(
+        (actual as i64 - TEST_SAMPLE_RATE as i64).unsigned_abs() < 1000,
+        "Sample rate mismatch: expected ~{TEST_SAMPLE_RATE}, got {actual}"
+    );
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn device_tune_and_read_iq() {
+    let mut device = RtlSdrDevice::open(0).expect("Failed to open device");
+    device
+        .set_sample_rate(TEST_SAMPLE_RATE)
+        .expect("set sample rate");
+    device
+        .set_center_freq(TEST_FREQ_HZ)
+        .expect("set center freq");
+    device.reset_buffer().expect("reset buffer");
+
+    // Read a chunk of raw IQ data
+    let mut buf = vec![0u8; READ_BUF_SIZE * 2]; // 2 bytes per IQ pair
+    let bytes_read = device.read_sync(&mut buf).expect("read_sync failed");
+    tracing::info!("Read {bytes_read} bytes ({} IQ pairs)", bytes_read / 2);
+
+    assert!(bytes_read > 0, "No data received from device");
+    assert_eq!(bytes_read % 2, 0, "Odd byte count — IQ misalignment");
+
+    // Verify data isn't all zeros (device is producing something)
+    let nonzero = buf[..bytes_read].iter().filter(|&&b| b != 0).count();
+    assert!(
+        nonzero > bytes_read / 4,
+        "Too many zero bytes — device may not be streaming"
+    );
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn device_convert_uint8_to_complex() {
+    let mut device = RtlSdrDevice::open(0).expect("Failed to open device");
+    device
+        .set_sample_rate(TEST_SAMPLE_RATE)
+        .expect("set sample rate");
+    device
+        .set_center_freq(TEST_FREQ_HZ)
+        .expect("set center freq");
+    device.reset_buffer().expect("reset buffer");
+
+    let mut raw = vec![0u8; READ_BUF_SIZE * 2];
+    let bytes_read = device.read_sync(&mut raw).expect("read_sync");
+    let iq_count = bytes_read / 2;
+
+    // Convert to Complex f32
+    let mut iq = vec![Complex::default(); iq_count];
+    let converted = RtlSdrSource::convert_samples(&raw[..bytes_read], &mut iq);
+    assert_eq!(converted, iq_count);
+
+    // All values should be in [-1.0, 1.0] range
+    for (i, s) in iq.iter().enumerate().take(converted) {
+        assert!(
+            s.re >= -1.1 && s.re <= 1.1,
+            "Sample {i}: re={} out of range",
+            s.re
+        );
+        assert!(
+            s.im >= -1.1 && s.im <= 1.1,
+            "Sample {i}: im={} out of range",
+            s.im
+        );
+    }
+
+    // Compute mean magnitude — should be nonzero (device is receiving noise at least)
+    let mean_mag: f32 = iq[..converted]
+        .iter()
+        .map(|s| (s.re * s.re + s.im * s.im).sqrt())
+        .sum::<f32>()
+        / converted as f32;
+    tracing::info!("Mean IQ magnitude: {mean_mag:.4}");
+    assert!(mean_mag > 0.001, "Mean magnitude too low: {mean_mag}");
+}
+
+// =========================================================================
+// Level 2: Pipeline — Source + IqFrontend + FFT
+// =========================================================================
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn pipeline_source_start_stop() {
+    let mut source = RtlSdrSource::new(0);
+    assert_eq!(source.name(), "RTL-SDR");
+
+    source.start().expect("Failed to start source");
+    source.stop().expect("Failed to stop source");
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn pipeline_iq_frontend_produces_fft() {
+    // Open device and read raw IQ
+    let mut device = RtlSdrDevice::open(0).expect("open device");
+    device
+        .set_sample_rate(TEST_SAMPLE_RATE)
+        .expect("set sample rate");
+    device
+        .set_center_freq(TEST_FREQ_HZ)
+        .expect("set center freq");
+    device.reset_buffer().expect("reset buffer");
+
+    let mut raw = vec![0u8; READ_BUF_SIZE * 2];
+    let bytes_read = device.read_sync(&mut raw).expect("read_sync");
+    let iq_count = bytes_read / 2;
+
+    // Convert to Complex
+    let mut iq = vec![Complex::default(); iq_count];
+    RtlSdrSource::convert_samples(&raw[..bytes_read], &mut iq);
+
+    // Process through IqFrontend
+    let mut frontend = IqFrontend::new(
+        TEST_SAMPLE_RATE as f64,
+        1, // no decimation
+        TEST_FFT_SIZE,
+        FftWindow::Nuttall,
+        true, // DC blocking
+    )
+    .expect("create IqFrontend");
+
+    let mut output = vec![Complex::default(); iq_count];
+    let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+
+    let (processed, fft_ready) = frontend
+        .process(&iq[..iq_count], &mut output, &mut fft_out)
+        .expect("IqFrontend::process");
+
+    tracing::info!("IqFrontend: processed {processed} samples, FFT ready: {fft_ready}");
+    assert!(processed > 0, "No samples processed");
+
+    // If we read enough samples, FFT should be ready
+    if iq_count >= TEST_FFT_SIZE {
+        assert!(fft_ready, "FFT should be ready with {iq_count} samples");
+
+        // FFT output should be in dB range (roughly -120 to 0)
+        let fft_min = fft_out.iter().copied().reduce(f32::min).unwrap_or(0.0);
+        let fft_max = fft_out.iter().copied().reduce(f32::max).unwrap_or(0.0);
+        tracing::info!("FFT range: {fft_min:.1} to {fft_max:.1} dB");
+
+        assert!(fft_max > -120.0, "FFT max too low: {fft_max}");
+        assert!(fft_min < 0.0, "FFT min should be negative dB: {fft_min}");
+    }
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn pipeline_fft_standalone() {
+    // Read raw IQ, convert, run FFT directly (bypassing IqFrontend)
+    let mut device = RtlSdrDevice::open(0).expect("open device");
+    device
+        .set_sample_rate(TEST_SAMPLE_RATE)
+        .expect("set sample rate");
+    device
+        .set_center_freq(TEST_FREQ_HZ)
+        .expect("set center freq");
+    device.reset_buffer().expect("reset buffer");
+
+    let mut raw = vec![0u8; TEST_FFT_SIZE * 2 * 2]; // enough for fft_size IQ pairs
+    let bytes_read = device.read_sync(&mut raw).expect("read_sync");
+
+    let mut iq = vec![Complex::default(); bytes_read / 2];
+    let count = RtlSdrSource::convert_samples(&raw[..bytes_read], &mut iq);
+
+    if count >= TEST_FFT_SIZE {
+        let mut engine = RustFftEngine::new(TEST_FFT_SIZE).expect("create FFT engine");
+        let mut fft_buf = iq[..TEST_FFT_SIZE].to_vec();
+        engine.forward(&mut fft_buf).expect("FFT forward");
+
+        let mut power = vec![0.0_f32; TEST_FFT_SIZE];
+        sdr_dsp::fft::power_spectrum_db(&fft_buf, &mut power).expect("power_spectrum_db");
+
+        let peak_bin = power
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        let peak_db = power[peak_bin];
+        tracing::info!(
+            "FFT peak at bin {peak_bin} ({:.1} dB), noise floor ~{:.1} dB",
+            peak_db,
+            power.iter().sum::<f32>() / power.len() as f32
+        );
+    }
+}
+
+// =========================================================================
+// Level 3: End-to-end — Device → IqFrontend → RadioModule → Audio
+// =========================================================================
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn end_to_end_nfm_demod() {
+    end_to_end_demod(DemodMode::Nfm, "NFM");
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn end_to_end_wfm_demod() {
+    end_to_end_demod(DemodMode::Wfm, "WFM");
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn end_to_end_am_demod() {
+    end_to_end_demod(DemodMode::Am, "AM");
+}
+
+/// Shared end-to-end test: Device → IqFrontend → RadioModule → Stereo audio
+fn end_to_end_demod(mode: DemodMode, mode_name: &str) {
+    // 1. Open device and read IQ
+    let mut device = RtlSdrDevice::open(0).expect("open device");
+    device
+        .set_sample_rate(TEST_SAMPLE_RATE)
+        .expect("set sample rate");
+    device
+        .set_center_freq(TEST_FREQ_HZ)
+        .expect("set center freq");
+    device.reset_buffer().expect("reset buffer");
+
+    let mut raw = vec![0u8; READ_BUF_SIZE * 4]; // read a good chunk
+    let bytes_read = device.read_sync(&mut raw).expect("read_sync");
+    let iq_count = bytes_read / 2;
+
+    let mut iq = vec![Complex::default(); iq_count];
+    RtlSdrSource::convert_samples(&raw[..bytes_read], &mut iq);
+
+    // 2. Process through IqFrontend (no decimation for simplicity)
+    let mut frontend = IqFrontend::new(
+        TEST_SAMPLE_RATE as f64,
+        1,
+        TEST_FFT_SIZE,
+        FftWindow::Nuttall,
+        true,
+    )
+    .expect("create IqFrontend");
+
+    let mut processed_iq = vec![Complex::default(); iq_count];
+    let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+    let (processed_count, _) = frontend
+        .process(&iq[..iq_count], &mut processed_iq, &mut fft_out)
+        .expect("IqFrontend::process");
+
+    tracing::info!("{mode_name}: IqFrontend produced {processed_count} samples");
+
+    // 3. Process through RadioModule
+    let mut radio = RadioModule::new(48_000.0).expect("create RadioModule");
+    radio.set_mode(mode).expect("set mode");
+
+    let max_out = radio.max_output_samples(processed_count);
+    let mut audio_out = vec![Stereo::default(); max_out];
+
+    let audio_count = radio
+        .process(&processed_iq[..processed_count], &mut audio_out)
+        .expect("RadioModule::process");
+
+    tracing::info!(
+        "{mode_name}: RadioModule produced {audio_count} stereo audio samples from {processed_count} IQ"
+    );
+
+    assert!(
+        audio_count > 0,
+        "{mode_name}: expected audio output, got 0 samples"
+    );
+
+    // 4. Verify audio is in reasonable range
+    let mut max_abs = 0.0_f32;
+    for s in &audio_out[..audio_count] {
+        max_abs = max_abs.max(s.l.abs()).max(s.r.abs());
+    }
+    tracing::info!("{mode_name}: max audio amplitude: {max_abs:.4}");
+
+    // Audio should be finite and not absurdly large
+    assert!(max_abs.is_finite(), "{mode_name}: audio contains NaN/Inf");
+    assert!(
+        max_abs < 100.0,
+        "{mode_name}: audio amplitude too high: {max_abs}"
+    );
+}
+
+#[test]
+#[ignore = "requires RTL-SDR hardware"]
+fn end_to_end_mode_switching() {
+    // Read IQ once, then process through all modes
+    let mut device = RtlSdrDevice::open(0).expect("open device");
+    device
+        .set_sample_rate(TEST_SAMPLE_RATE)
+        .expect("set sample rate");
+    device
+        .set_center_freq(TEST_FREQ_HZ)
+        .expect("set center freq");
+    device.reset_buffer().expect("reset buffer");
+
+    let mut raw = vec![0u8; READ_BUF_SIZE * 4];
+    let bytes_read = device.read_sync(&mut raw).expect("read_sync");
+    let iq_count = bytes_read / 2;
+
+    let mut iq = vec![Complex::default(); iq_count];
+    RtlSdrSource::convert_samples(&raw[..bytes_read], &mut iq);
+
+    let mut frontend = IqFrontend::new(
+        TEST_SAMPLE_RATE as f64,
+        1,
+        TEST_FFT_SIZE,
+        FftWindow::Nuttall,
+        true,
+    )
+    .expect("create IqFrontend");
+
+    let mut processed_iq = vec![Complex::default(); iq_count];
+    let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+    let (processed_count, _) = frontend
+        .process(&iq[..iq_count], &mut processed_iq, &mut fft_out)
+        .expect("IqFrontend::process");
+
+    let mut radio = RadioModule::new(48_000.0).expect("create RadioModule");
+
+    let modes = [
+        DemodMode::Nfm,
+        DemodMode::Wfm,
+        DemodMode::Am,
+        DemodMode::Usb,
+        DemodMode::Lsb,
+        DemodMode::Dsb,
+        DemodMode::Cw,
+        DemodMode::Raw,
+    ];
+
+    for mode in &modes {
+        radio.set_mode(*mode).expect(&format!("set mode {mode:?}"));
+
+        let max_out = radio.max_output_samples(processed_count);
+        let mut audio_out = vec![Stereo::default(); max_out];
+
+        let audio_count = radio
+            .process(&processed_iq[..processed_count], &mut audio_out)
+            .expect(&format!("{mode:?}::process"));
+
+        tracing::info!("{mode:?}: {audio_count} audio samples from {processed_count} IQ");
+        assert!(audio_count > 0, "{mode:?}: no audio output");
+
+        // Verify no NaN/Inf
+        for (i, s) in audio_out[..audio_count].iter().enumerate() {
+            assert!(
+                s.l.is_finite() && s.r.is_finite(),
+                "{mode:?}: NaN/Inf at sample {i}"
+            );
+        }
+    }
+
+    tracing::info!("All 8 demod modes produced valid audio from real hardware IQ");
+}


### PR DESCRIPTION
## Summary

- FFT spectrum plot with accent-colored line trace + semi-transparent filled area
- Scrolling waterfall display using ring-buffer OpenGL texture (glTexSubImage2D per line)
- Turbo-style colormap (black→blue→cyan→green→yellow→red→white) via 1D texture lookup
- GtkPaned for user-adjustable FFT/waterfall split ratio
- Shared GL utilities (shader compilation, program linking, error checking)
- Smart frequency axis formatting: auto-selects Hz/kHz/MHz/GHz units
- Grid lines: horizontal dB scale, vertical frequency markers
- Synthetic test data with drifting peaks drives both renderers for visual validation
- GL function loading via dlsym from GTK4's already-loaded GL libraries (no extra deps)
- GLSL 300 es shaders for desktop GL + GLES (Wayland) compatibility
- 1,588 new lines, 22 tests in sdr-ui

Closes #35

## Test plan

- [x] All workspace tests pass (22 in sdr-ui)
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --all -- --check` passes
- [ ] Manual: `cargo run` shows FFT plot + waterfall with synthetic data
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full spectrum visualization: interactive FFT power plot, scrolling waterfall spectrogram, frequency-axis labels/grid, and a 256-color colormap; integrated into the main window replacing the placeholder.

* **Tests**
  * Added hardware integration tests covering RTL‑SDR device access, the signal-processing pipeline, FFT outputs, and end-to-end demodulation modes (ignored by default; require hardware).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->