### PR TITLE
Phase 5e: sidebar panels — source, audio, radio, display config

### DIFF
--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -4,6 +4,7 @@ pub mod app;
 pub mod css;
 pub mod header;
 pub mod messages;
+pub mod sidebar;
 pub mod spectrum;
 pub mod state;
 pub mod window;

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -1,0 +1,36 @@
+//! Audio output configuration panel — sink type selection.
+
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Audio output configuration panel with references to interactive rows.
+pub struct AudioPanel {
+    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
+    pub widget: adw::PreferencesGroup,
+    /// Sink type selector (Audio, Network).
+    pub sink_type_row: adw::ComboRow,
+}
+
+/// Build the audio output configuration panel.
+pub fn build_audio_panel() -> AudioPanel {
+    let group = adw::PreferencesGroup::builder()
+        .title("Audio")
+        .description("Output configuration")
+        .build();
+
+    let sink_model = gtk4::StringList::new(&["Audio", "Network"]);
+    let sink_type_row = adw::ComboRow::builder()
+        .title("Sink Type")
+        .model(&sink_model)
+        .build();
+
+    // TODO: Connect sink_type_row to DSP pipeline (PR #7)
+    // TODO: Add device enumeration when DSP bridge is wired
+
+    group.add(&sink_type_row);
+
+    AudioPanel {
+        widget: group,
+        sink_type_row,
+    }
+}

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -1,4 +1,4 @@
-//! Audio output configuration panel — sink type selection.
+//! Audio output configuration panel — device and sink type selection.
 
 use libadwaita as adw;
 use libadwaita::prelude::*;

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -7,6 +7,8 @@ use libadwaita::prelude::*;
 pub struct AudioPanel {
     /// The `AdwPreferencesGroup` widget to pack into the sidebar.
     pub widget: adw::PreferencesGroup,
+    /// Audio device selector.
+    pub device_row: adw::ComboRow,
     /// Sink type selector (Audio, Network).
     pub sink_type_row: adw::ComboRow,
 }
@@ -18,19 +20,27 @@ pub fn build_audio_panel() -> AudioPanel {
         .description("Output configuration")
         .build();
 
+    // TODO: Populate with actual audio devices from PipeWire/PulseAudio (PR #7)
+    let device_model = gtk4::StringList::new(&["Default"]);
+    let device_row = adw::ComboRow::builder()
+        .title("Device")
+        .model(&device_model)
+        .build();
+
     let sink_model = gtk4::StringList::new(&["Audio", "Network"]);
     let sink_type_row = adw::ComboRow::builder()
         .title("Sink Type")
         .model(&sink_model)
         .build();
 
-    // TODO: Connect sink_type_row to DSP pipeline (PR #7)
-    // TODO: Add device enumeration when DSP bridge is wired
+    // TODO: Connect rows to DSP pipeline (PR #7)
 
+    group.add(&device_row);
     group.add(&sink_type_row);
 
     AudioPanel {
         widget: group,
+        device_row,
         sink_type_row,
     }
 }

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -1,0 +1,93 @@
+//! Display settings panel — FFT size, window function, frame rate, color map.
+
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Default frame rate in FPS.
+const DEFAULT_FPS: f64 = 20.0;
+/// Minimum frame rate in FPS.
+const MIN_FPS: f64 = 1.0;
+/// Maximum frame rate in FPS.
+const MAX_FPS: f64 = 60.0;
+
+/// Default FFT size selector index (2048 = index 2).
+const DEFAULT_FFT_SIZE_INDEX: u32 = 2;
+
+/// Display settings panel with references to interactive rows.
+pub struct DisplayPanel {
+    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
+    pub widget: adw::PreferencesGroup,
+    /// FFT size selector.
+    pub fft_size_row: adw::ComboRow,
+    /// Window function selector.
+    pub window_fn_row: adw::ComboRow,
+    /// Frame rate control.
+    pub frame_rate_row: adw::SpinRow,
+    /// Color map selector.
+    pub color_map_row: adw::ComboRow,
+}
+
+/// Build the display settings panel.
+pub fn build_display_panel() -> DisplayPanel {
+    let group = adw::PreferencesGroup::builder()
+        .title("Display")
+        .description("Spectrum & waterfall settings")
+        .build();
+
+    // --- FFT Size ---
+    let fft_size_model = gtk4::StringList::new(&["512", "1024", "2048", "4096", "8192"]);
+    let fft_size_row = adw::ComboRow::builder()
+        .title("FFT Size")
+        .model(&fft_size_model)
+        .selected(DEFAULT_FFT_SIZE_INDEX)
+        .build();
+
+    // --- Window Function ---
+    let window_fn_model = gtk4::StringList::new(&["Rectangular", "Blackman", "Nuttall"]);
+    let window_fn_row = adw::ComboRow::builder()
+        .title("Window Function")
+        .model(&window_fn_model)
+        .selected(1) // default to Blackman
+        .build();
+
+    // --- Frame Rate ---
+    let fps_adj = gtk4::Adjustment::new(DEFAULT_FPS, MIN_FPS, MAX_FPS, 1.0, 5.0, 0.0);
+    let frame_rate_row = adw::SpinRow::builder()
+        .title("Frame Rate")
+        .subtitle("FPS")
+        .adjustment(&fps_adj)
+        .digits(0)
+        .build();
+
+    // --- Color Map ---
+    let colormap_model = gtk4::StringList::new(&["Turbo", "Viridis", "Plasma"]);
+    let color_map_row = adw::ComboRow::builder()
+        .title("Color Map")
+        .model(&colormap_model)
+        .build();
+
+    group.add(&fft_size_row);
+    group.add(&window_fn_row);
+    group.add(&frame_rate_row);
+    group.add(&color_map_row);
+
+    // TODO: Connect all rows to spectrum display (PR #7)
+
+    DisplayPanel {
+        widget: group,
+        fft_size_row,
+        window_fn_row,
+        frame_rate_row,
+        color_map_row,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Compile-time validation that frame rate constants are consistent.
+    const _: () = {
+        assert!(super::MIN_FPS <= super::MAX_FPS);
+        assert!(super::DEFAULT_FPS >= super::MIN_FPS);
+        assert!(super::DEFAULT_FPS <= super::MAX_FPS);
+    };
+}

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -13,6 +13,9 @@ const MAX_FPS: f64 = 60.0;
 /// Default FFT size selector index (2048 = index 2).
 const DEFAULT_FFT_SIZE_INDEX: u32 = 2;
 
+/// Default window function selector index (Blackman = index 1).
+const DEFAULT_WINDOW_FN_INDEX: u32 = 1;
+
 /// Display settings panel with references to interactive rows.
 pub struct DisplayPanel {
     /// The `AdwPreferencesGroup` widget to pack into the sidebar.
@@ -47,7 +50,7 @@ pub fn build_display_panel() -> DisplayPanel {
     let window_fn_row = adw::ComboRow::builder()
         .title("Window Function")
         .model(&window_fn_model)
-        .selected(1) // default to Blackman
+        .selected(DEFAULT_WINDOW_FN_INDEX)
         .build();
 
     // --- Frame Rate ---
@@ -60,7 +63,7 @@ pub fn build_display_panel() -> DisplayPanel {
         .build();
 
     // --- Color Map ---
-    let colormap_model = gtk4::StringList::new(&["Turbo", "Viridis", "Plasma"]);
+    let colormap_model = gtk4::StringList::new(&["Turbo"]);
     let color_map_row = adw::ComboRow::builder()
         .title("Color Map")
         .model(&colormap_model)

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -1,0 +1,69 @@
+//! Sidebar configuration panels — source, audio, radio, display.
+
+use gtk4::prelude::*;
+
+pub mod audio_panel;
+pub mod display_panel;
+pub mod radio_panel;
+pub mod source_panel;
+
+pub use audio_panel::{AudioPanel, build_audio_panel};
+pub use display_panel::{DisplayPanel, build_display_panel};
+pub use radio_panel::{RadioPanel, build_radio_panel};
+pub use source_panel::{SourcePanel, build_source_panel};
+
+/// Spacing between sidebar preference groups in pixels.
+const SIDEBAR_SPACING: i32 = 12;
+/// Margin around the sidebar content in pixels.
+const SIDEBAR_MARGIN: i32 = 12;
+
+/// All sidebar panels, for DSP bridge wiring.
+pub struct SidebarPanels {
+    /// Source device configuration.
+    pub source: SourcePanel,
+    /// Audio output configuration.
+    pub audio: AudioPanel,
+    /// Radio / demodulator configuration.
+    pub radio: RadioPanel,
+    /// Display / spectrum settings.
+    pub display: DisplayPanel,
+}
+
+/// Build the complete sidebar `ScrolledWindow` containing all configuration panels.
+///
+/// Returns both the scroll widget (for embedding in the split view) and the
+/// `SidebarPanels` struct (for DSP bridge signal wiring in PR #7).
+pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
+    let source = build_source_panel();
+    let audio = build_audio_panel();
+    let radio = build_radio_panel();
+    let display = build_display_panel();
+
+    let sidebar_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(SIDEBAR_SPACING)
+        .margin_top(SIDEBAR_MARGIN)
+        .margin_bottom(SIDEBAR_MARGIN)
+        .margin_start(SIDEBAR_MARGIN)
+        .margin_end(SIDEBAR_MARGIN)
+        .build();
+
+    sidebar_box.append(&source.widget);
+    sidebar_box.append(&audio.widget);
+    sidebar_box.append(&radio.widget);
+    sidebar_box.append(&display.widget);
+
+    let scroll = gtk4::ScrolledWindow::builder()
+        .child(&sidebar_box)
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .build();
+
+    let panels = SidebarPanels {
+        source,
+        audio,
+        radio,
+        display,
+    };
+
+    (scroll, panels)
+}

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -11,6 +11,8 @@ const MIN_BANDWIDTH_HZ: f64 = 100.0;
 const MAX_BANDWIDTH_HZ: f64 = 250_000.0;
 /// Bandwidth step in Hz.
 const BANDWIDTH_STEP_HZ: f64 = 100.0;
+/// Bandwidth page increment in Hz (scroll/page-up/down).
+const BANDWIDTH_PAGE_HZ: f64 = 1_000.0;
 
 /// Default squelch level in dB.
 const DEFAULT_SQUELCH_DB: f64 = -100.0;
@@ -20,6 +22,8 @@ const MIN_SQUELCH_DB: f64 = -160.0;
 const MAX_SQUELCH_DB: f64 = 0.0;
 /// Squelch step in dB.
 const SQUELCH_STEP_DB: f64 = 1.0;
+/// Squelch page increment in dB.
+const SQUELCH_PAGE_DB: f64 = 10.0;
 
 /// Radio / demodulator configuration panel with references to interactive rows.
 pub struct RadioPanel {
@@ -63,7 +67,7 @@ pub fn build_radio_panel() -> RadioPanel {
         MIN_BANDWIDTH_HZ,
         MAX_BANDWIDTH_HZ,
         BANDWIDTH_STEP_HZ,
-        1_000.0,
+        BANDWIDTH_PAGE_HZ,
         0.0,
     );
     let bandwidth_row = adw::SpinRow::builder()
@@ -81,7 +85,7 @@ pub fn build_radio_panel() -> RadioPanel {
         MIN_SQUELCH_DB,
         MAX_SQUELCH_DB,
         SQUELCH_STEP_DB,
-        10.0,
+        SQUELCH_PAGE_DB,
         0.0,
     );
     let squelch_level_row = adw::SpinRow::builder()

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -45,6 +45,7 @@ impl RadioPanel {
     /// Call this when the demod mode changes to show FM IF NR only for FM modes
     /// (WFM and NFM).
     pub fn set_fm_controls_visible(&self, visible: bool) {
+        self.deemphasis_row.set_visible(visible);
         self.fm_if_nr_row.set_visible(visible);
     }
 }

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -1,0 +1,147 @@
+//! Radio / demodulator configuration panel — bandwidth, squelch, de-emphasis.
+
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Default bandwidth in Hz.
+const DEFAULT_BANDWIDTH_HZ: f64 = 12_500.0;
+/// Minimum bandwidth in Hz.
+const MIN_BANDWIDTH_HZ: f64 = 100.0;
+/// Maximum bandwidth in Hz.
+const MAX_BANDWIDTH_HZ: f64 = 250_000.0;
+/// Bandwidth step in Hz.
+const BANDWIDTH_STEP_HZ: f64 = 100.0;
+
+/// Default squelch level in dB.
+const DEFAULT_SQUELCH_DB: f64 = -100.0;
+/// Minimum squelch level in dB.
+const MIN_SQUELCH_DB: f64 = -160.0;
+/// Maximum squelch level in dB.
+const MAX_SQUELCH_DB: f64 = 0.0;
+/// Squelch step in dB.
+const SQUELCH_STEP_DB: f64 = 1.0;
+
+/// Radio / demodulator configuration panel with references to interactive rows.
+pub struct RadioPanel {
+    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
+    pub widget: adw::PreferencesGroup,
+    /// Bandwidth control.
+    pub bandwidth_row: adw::SpinRow,
+    /// Squelch enable toggle.
+    pub squelch_enabled_row: adw::SwitchRow,
+    /// Squelch level control.
+    pub squelch_level_row: adw::SpinRow,
+    /// De-emphasis filter selector.
+    pub deemphasis_row: adw::ComboRow,
+    /// Noise blanker toggle.
+    pub noise_blanker_row: adw::SwitchRow,
+    /// FM IF noise reduction toggle (visible only for FM modes).
+    pub fm_if_nr_row: adw::SwitchRow,
+}
+
+impl RadioPanel {
+    /// Show or hide FM-specific controls based on the current demod mode.
+    ///
+    /// Call this when the demod mode changes to show FM IF NR only for FM modes
+    /// (WFM and NFM).
+    pub fn set_fm_controls_visible(&self, visible: bool) {
+        self.fm_if_nr_row.set_visible(visible);
+    }
+}
+
+/// Build the radio / demodulator configuration panel.
+pub fn build_radio_panel() -> RadioPanel {
+    let group = adw::PreferencesGroup::builder()
+        .title("Radio")
+        .description("Demodulator settings")
+        .build();
+
+    // --- Bandwidth ---
+    let bandwidth_adj = gtk4::Adjustment::new(
+        DEFAULT_BANDWIDTH_HZ,
+        MIN_BANDWIDTH_HZ,
+        MAX_BANDWIDTH_HZ,
+        BANDWIDTH_STEP_HZ,
+        1_000.0,
+        0.0,
+    );
+    let bandwidth_row = adw::SpinRow::builder()
+        .title("Bandwidth")
+        .subtitle("Hz")
+        .adjustment(&bandwidth_adj)
+        .digits(0)
+        .build();
+
+    // --- Squelch ---
+    let squelch_enabled_row = adw::SwitchRow::builder().title("Squelch").build();
+
+    let squelch_adj = gtk4::Adjustment::new(
+        DEFAULT_SQUELCH_DB,
+        MIN_SQUELCH_DB,
+        MAX_SQUELCH_DB,
+        SQUELCH_STEP_DB,
+        10.0,
+        0.0,
+    );
+    let squelch_level_row = adw::SpinRow::builder()
+        .title("Squelch Level")
+        .subtitle("dB")
+        .adjustment(&squelch_adj)
+        .digits(0)
+        .build();
+
+    // --- De-emphasis ---
+    let deemphasis_model =
+        gtk4::StringList::new(&["None", "50 \u{00b5}s (EU)", "75 \u{00b5}s (US)"]);
+    let deemphasis_row = adw::ComboRow::builder()
+        .title("De-emphasis")
+        .model(&deemphasis_model)
+        .build();
+
+    // --- Noise Blanker ---
+    let noise_blanker_row = adw::SwitchRow::builder().title("Noise Blanker").build();
+
+    // --- FM IF Noise Reduction ---
+    let fm_if_nr_row = adw::SwitchRow::builder()
+        .title("FM IF NR")
+        .subtitle("IF noise reduction for FM modes")
+        .build();
+
+    group.add(&bandwidth_row);
+    group.add(&squelch_enabled_row);
+    group.add(&squelch_level_row);
+    group.add(&deemphasis_row);
+    group.add(&noise_blanker_row);
+    group.add(&fm_if_nr_row);
+
+    // TODO: Connect all rows to DSP pipeline (PR #7)
+
+    RadioPanel {
+        widget: group,
+        bandwidth_row,
+        squelch_enabled_row,
+        squelch_level_row,
+        deemphasis_row,
+        noise_blanker_row,
+        fm_if_nr_row,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Compile-time validation that bandwidth constants are consistent.
+    const _: () = {
+        assert!(super::MIN_BANDWIDTH_HZ <= super::MAX_BANDWIDTH_HZ);
+        assert!(super::DEFAULT_BANDWIDTH_HZ >= super::MIN_BANDWIDTH_HZ);
+        assert!(super::DEFAULT_BANDWIDTH_HZ <= super::MAX_BANDWIDTH_HZ);
+        assert!(super::BANDWIDTH_STEP_HZ > 0.0);
+    };
+
+    /// Compile-time validation that squelch constants are consistent.
+    const _: () = {
+        assert!(super::MIN_SQUELCH_DB <= super::MAX_SQUELCH_DB);
+        assert!(super::DEFAULT_SQUELCH_DB >= super::MIN_SQUELCH_DB);
+        assert!(super::DEFAULT_SQUELCH_DB <= super::MAX_SQUELCH_DB);
+        assert!(super::SQUELCH_STEP_DB > 0.0);
+    };
+}

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -30,7 +30,7 @@ const MAX_PORT: f64 = 65535.0;
 pub struct SourcePanel {
     /// The `AdwPreferencesGroup` widget to pack into the sidebar.
     pub widget: adw::PreferencesGroup,
-    /// Device type selector (RTL-SDR, Network, File).
+    /// Device type selector (RTL-SDR, Network).
     pub device_row: adw::ComboRow,
     /// RTL-SDR sample rate selector.
     pub sample_rate_row: adw::ComboRow,
@@ -48,17 +48,34 @@ pub struct SourcePanel {
     pub dc_blocking_row: adw::SwitchRow,
     /// IQ correction toggle (always visible).
     pub iq_correction_row: adw::SwitchRow,
+    /// IQ inversion toggle (always visible).
+    pub iq_inversion_row: adw::SwitchRow,
     /// Decimation factor selector (always visible).
     pub decimation_row: adw::ComboRow,
 }
 
+/// Default sample rate selector index (2.4 MHz = index 7).
+const DEFAULT_SAMPLE_RATE_INDEX: u32 = 7;
+
 /// Build RTL-SDR-specific rows: sample rate, gain, AGC.
 fn build_rtlsdr_rows() -> (adw::ComboRow, adw::SpinRow, adw::SwitchRow) {
-    let sample_rate_model = gtk4::StringList::new(&["250 kHz", "1.024 MHz", "2.4 MHz", "3.2 MHz"]);
+    let sample_rate_model = gtk4::StringList::new(&[
+        "250 kHz",
+        "1.024 MHz",
+        "1.536 MHz",
+        "1.792 MHz",
+        "1.920 MHz",
+        "2.048 MHz",
+        "2.160 MHz",
+        "2.4 MHz",
+        "2.560 MHz",
+        "2.880 MHz",
+        "3.2 MHz",
+    ]);
     let sample_rate_row = adw::ComboRow::builder()
         .title("Sample Rate")
         .model(&sample_rate_model)
-        .selected(2) // default to 2.4 MHz
+        .selected(DEFAULT_SAMPLE_RATE_INDEX)
         .build();
 
     let gain_adj = gtk4::Adjustment::new(
@@ -107,8 +124,13 @@ fn build_network_rows() -> (adw::EntryRow, adw::SpinRow, adw::ComboRow) {
     (hostname_row, port_row, protocol_row)
 }
 
-/// Build common controls: DC blocking, IQ correction, decimation.
-fn build_common_rows() -> (adw::SwitchRow, adw::SwitchRow, adw::ComboRow) {
+/// Build common controls: DC blocking, IQ correction, IQ inversion, decimation.
+fn build_common_rows() -> (
+    adw::SwitchRow,
+    adw::SwitchRow,
+    adw::SwitchRow,
+    adw::ComboRow,
+) {
     let dc_blocking_row = adw::SwitchRow::builder()
         .title("DC Blocking")
         .active(true)
@@ -116,13 +138,20 @@ fn build_common_rows() -> (adw::SwitchRow, adw::SwitchRow, adw::ComboRow) {
 
     let iq_correction_row = adw::SwitchRow::builder().title("IQ Correction").build();
 
+    let iq_inversion_row = adw::SwitchRow::builder().title("Invert IQ").build();
+
     let decimation_model = gtk4::StringList::new(&["None", "2x", "4x", "8x", "16x"]);
     let decimation_row = adw::ComboRow::builder()
         .title("Decimation")
         .model(&decimation_model)
         .build();
 
-    (dc_blocking_row, iq_correction_row, decimation_row)
+    (
+        dc_blocking_row,
+        iq_correction_row,
+        iq_inversion_row,
+        decimation_row,
+    )
 }
 
 /// Wire the device selector to show/hide source-specific rows.
@@ -174,7 +203,8 @@ pub fn build_source_panel() -> SourcePanel {
         .description("Device & input configuration")
         .build();
 
-    let device_model = gtk4::StringList::new(&["RTL-SDR", "Network", "File"]);
+    // File source omitted until a file picker is implemented.
+    let device_model = gtk4::StringList::new(&["RTL-SDR", "Network"]);
     let device_row = adw::ComboRow::builder()
         .title("Device")
         .model(&device_model)
@@ -182,7 +212,8 @@ pub fn build_source_panel() -> SourcePanel {
 
     let (sample_rate_row, gain_row, agc_row) = build_rtlsdr_rows();
     let (hostname_row, port_row, protocol_row) = build_network_rows();
-    let (dc_blocking_row, iq_correction_row, decimation_row) = build_common_rows();
+    let (dc_blocking_row, iq_correction_row, iq_inversion_row, decimation_row) =
+        build_common_rows();
 
     // Add all rows to the group.
     group.add(&device_row);
@@ -194,6 +225,7 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&protocol_row);
     group.add(&dc_blocking_row);
     group.add(&iq_correction_row);
+    group.add(&iq_inversion_row);
     group.add(&decimation_row);
 
     // Set initial visibility: show RTL-SDR controls, hide Network controls.
@@ -224,6 +256,7 @@ pub fn build_source_panel() -> SourcePanel {
         protocol_row,
         dc_blocking_row,
         iq_correction_row,
+        iq_inversion_row,
         decimation_row,
     }
 }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -1,0 +1,252 @@
+//! Source device configuration panel — device selector, RTL-SDR / Network controls.
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Device selector index for RTL-SDR.
+const DEVICE_RTLSDR: u32 = 0;
+/// Device selector index for Network.
+const DEVICE_NETWORK: u32 = 1;
+
+/// Default gain in dB.
+const DEFAULT_GAIN_DB: f64 = 0.0;
+/// Minimum gain in dB.
+const MIN_GAIN_DB: f64 = 0.0;
+/// Maximum gain in dB.
+const MAX_GAIN_DB: f64 = 49.6;
+/// Gain step in dB.
+const GAIN_STEP_DB: f64 = 0.1;
+
+/// Default network port.
+const DEFAULT_PORT: f64 = 1234.0;
+/// Minimum port number.
+const MIN_PORT: f64 = 1.0;
+/// Maximum port number.
+const MAX_PORT: f64 = 65535.0;
+
+/// Source device configuration panel with references to all interactive rows.
+pub struct SourcePanel {
+    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
+    pub widget: adw::PreferencesGroup,
+    /// Device type selector (RTL-SDR, Network, File).
+    pub device_row: adw::ComboRow,
+    /// RTL-SDR sample rate selector.
+    pub sample_rate_row: adw::ComboRow,
+    /// RTL-SDR gain control.
+    pub gain_row: adw::SpinRow,
+    /// RTL-SDR AGC toggle.
+    pub agc_row: adw::SwitchRow,
+    /// Network hostname entry.
+    pub hostname_row: adw::EntryRow,
+    /// Network port number.
+    pub port_row: adw::SpinRow,
+    /// Network protocol selector (TCP, UDP).
+    pub protocol_row: adw::ComboRow,
+    /// DC blocking filter toggle (always visible).
+    pub dc_blocking_row: adw::SwitchRow,
+    /// IQ correction toggle (always visible).
+    pub iq_correction_row: adw::SwitchRow,
+    /// Decimation factor selector (always visible).
+    pub decimation_row: adw::ComboRow,
+}
+
+/// Build RTL-SDR-specific rows: sample rate, gain, AGC.
+fn build_rtlsdr_rows() -> (adw::ComboRow, adw::SpinRow, adw::SwitchRow) {
+    let sample_rate_model = gtk4::StringList::new(&["250 kHz", "1.024 MHz", "2.4 MHz", "3.2 MHz"]);
+    let sample_rate_row = adw::ComboRow::builder()
+        .title("Sample Rate")
+        .model(&sample_rate_model)
+        .selected(2) // default to 2.4 MHz
+        .build();
+
+    let gain_adj = gtk4::Adjustment::new(
+        DEFAULT_GAIN_DB,
+        MIN_GAIN_DB,
+        MAX_GAIN_DB,
+        GAIN_STEP_DB,
+        1.0,
+        0.0,
+    );
+    let gain_row = adw::SpinRow::builder()
+        .title("Gain")
+        .subtitle("dB")
+        .adjustment(&gain_adj)
+        .digits(1)
+        .build();
+
+    let agc_row = adw::SwitchRow::builder()
+        .title("AGC")
+        .subtitle("Automatic gain control")
+        .build();
+
+    (sample_rate_row, gain_row, agc_row)
+}
+
+/// Build network-specific rows: hostname, port, protocol.
+fn build_network_rows() -> (adw::EntryRow, adw::SpinRow, adw::ComboRow) {
+    let hostname_row = adw::EntryRow::builder()
+        .title("Hostname")
+        .text("localhost")
+        .build();
+
+    let port_adj = gtk4::Adjustment::new(DEFAULT_PORT, MIN_PORT, MAX_PORT, 1.0, 100.0, 0.0);
+    let port_row = adw::SpinRow::builder()
+        .title("Port")
+        .adjustment(&port_adj)
+        .digits(0)
+        .build();
+
+    let protocol_model = gtk4::StringList::new(&["TCP", "UDP"]);
+    let protocol_row = adw::ComboRow::builder()
+        .title("Protocol")
+        .model(&protocol_model)
+        .build();
+
+    (hostname_row, port_row, protocol_row)
+}
+
+/// Build common controls: DC blocking, IQ correction, decimation.
+fn build_common_rows() -> (adw::SwitchRow, adw::SwitchRow, adw::ComboRow) {
+    let dc_blocking_row = adw::SwitchRow::builder()
+        .title("DC Blocking")
+        .active(true)
+        .build();
+
+    let iq_correction_row = adw::SwitchRow::builder().title("IQ Correction").build();
+
+    let decimation_model = gtk4::StringList::new(&["None", "2x", "4x", "8x", "16x"]);
+    let decimation_row = adw::ComboRow::builder()
+        .title("Decimation")
+        .model(&decimation_model)
+        .build();
+
+    (dc_blocking_row, iq_correction_row, decimation_row)
+}
+
+/// Wire the device selector to show/hide source-specific rows.
+fn connect_device_visibility(
+    device_row: &adw::ComboRow,
+    sample_rate_row: &adw::ComboRow,
+    gain_row: &adw::SpinRow,
+    agc_row: &adw::SwitchRow,
+    hostname_row: &adw::EntryRow,
+    port_row: &adw::SpinRow,
+    protocol_row: &adw::ComboRow,
+) {
+    device_row.connect_selected_notify(glib::clone!(
+        #[weak]
+        sample_rate_row,
+        #[weak]
+        gain_row,
+        #[weak]
+        agc_row,
+        #[weak]
+        hostname_row,
+        #[weak]
+        port_row,
+        #[weak]
+        protocol_row,
+        move |row| {
+            let selected = row.selected();
+            let is_rtlsdr = selected == DEVICE_RTLSDR;
+            let is_network = selected == DEVICE_NETWORK;
+
+            sample_rate_row.set_visible(is_rtlsdr);
+            gain_row.set_visible(is_rtlsdr);
+            agc_row.set_visible(is_rtlsdr);
+
+            hostname_row.set_visible(is_network);
+            port_row.set_visible(is_network);
+            protocol_row.set_visible(is_network);
+
+            // TODO: Send device change to DSP pipeline (PR #7)
+            tracing::debug!(device = selected, "source device changed");
+        }
+    ));
+}
+
+/// Build the source device configuration panel.
+pub fn build_source_panel() -> SourcePanel {
+    let group = adw::PreferencesGroup::builder()
+        .title("Source")
+        .description("Device & input configuration")
+        .build();
+
+    let device_model = gtk4::StringList::new(&["RTL-SDR", "Network", "File"]);
+    let device_row = adw::ComboRow::builder()
+        .title("Device")
+        .model(&device_model)
+        .build();
+
+    let (sample_rate_row, gain_row, agc_row) = build_rtlsdr_rows();
+    let (hostname_row, port_row, protocol_row) = build_network_rows();
+    let (dc_blocking_row, iq_correction_row, decimation_row) = build_common_rows();
+
+    // Add all rows to the group.
+    group.add(&device_row);
+    group.add(&sample_rate_row);
+    group.add(&gain_row);
+    group.add(&agc_row);
+    group.add(&hostname_row);
+    group.add(&port_row);
+    group.add(&protocol_row);
+    group.add(&dc_blocking_row);
+    group.add(&iq_correction_row);
+    group.add(&decimation_row);
+
+    // Set initial visibility: show RTL-SDR controls, hide Network controls.
+    hostname_row.set_visible(false);
+    port_row.set_visible(false);
+    protocol_row.set_visible(false);
+
+    connect_device_visibility(
+        &device_row,
+        &sample_rate_row,
+        &gain_row,
+        &agc_row,
+        &hostname_row,
+        &port_row,
+        &protocol_row,
+    );
+
+    // TODO: Connect sample_rate_row, gain_row, agc_row, etc. to DSP pipeline (PR #7)
+
+    SourcePanel {
+        widget: group,
+        device_row,
+        sample_rate_row,
+        gain_row,
+        agc_row,
+        hostname_row,
+        port_row,
+        protocol_row,
+        dc_blocking_row,
+        iq_correction_row,
+        decimation_row,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time validation that gain constants are consistent.
+    const _: () = {
+        assert!(MIN_GAIN_DB <= MAX_GAIN_DB);
+        assert!(GAIN_STEP_DB > 0.0);
+    };
+
+    /// Compile-time validation that port constants are consistent.
+    const _: () = {
+        assert!(MIN_PORT <= MAX_PORT);
+        assert!(DEFAULT_PORT >= MIN_PORT);
+        assert!(DEFAULT_PORT <= MAX_PORT);
+    };
+
+    #[test]
+    fn device_indices_are_distinct() {
+        assert_ne!(DEVICE_RTLSDR, DEVICE_NETWORK);
+    }
+}

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -18,6 +18,8 @@ const MIN_GAIN_DB: f64 = 0.0;
 const MAX_GAIN_DB: f64 = 49.6;
 /// Gain step in dB.
 const GAIN_STEP_DB: f64 = 0.1;
+/// Gain page increment in dB.
+const GAIN_PAGE_DB: f64 = 1.0;
 
 /// Default network port.
 const DEFAULT_PORT: f64 = 1234.0;
@@ -25,6 +27,10 @@ const DEFAULT_PORT: f64 = 1234.0;
 const MIN_PORT: f64 = 1.0;
 /// Maximum port number.
 const MAX_PORT: f64 = 65535.0;
+/// Port spin step.
+const PORT_STEP: f64 = 1.0;
+/// Port page increment.
+const PORT_PAGE: f64 = 100.0;
 
 /// Source device configuration panel with references to all interactive rows.
 pub struct SourcePanel {
@@ -83,7 +89,7 @@ fn build_rtlsdr_rows() -> (adw::ComboRow, adw::SpinRow, adw::SwitchRow) {
         MIN_GAIN_DB,
         MAX_GAIN_DB,
         GAIN_STEP_DB,
-        1.0,
+        GAIN_PAGE_DB,
         0.0,
     );
     let gain_row = adw::SpinRow::builder()
@@ -108,7 +114,8 @@ fn build_network_rows() -> (adw::EntryRow, adw::SpinRow, adw::ComboRow) {
         .text("localhost")
         .build();
 
-    let port_adj = gtk4::Adjustment::new(DEFAULT_PORT, MIN_PORT, MAX_PORT, 1.0, 100.0, 0.0);
+    let port_adj =
+        gtk4::Adjustment::new(DEFAULT_PORT, MIN_PORT, MAX_PORT, PORT_STEP, PORT_PAGE, 0.0);
     let port_row = adw::SpinRow::builder()
         .title("Port")
         .adjustment(&port_adj)
@@ -228,10 +235,16 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&iq_inversion_row);
     group.add(&decimation_row);
 
-    // Set initial visibility: show RTL-SDR controls, hide Network controls.
-    hostname_row.set_visible(false);
-    port_row.set_visible(false);
-    protocol_row.set_visible(false);
+    // Derive initial visibility from the selected device.
+    let selected = device_row.selected();
+    let is_rtlsdr = selected == DEVICE_RTLSDR;
+    let is_network = selected == DEVICE_NETWORK;
+    sample_rate_row.set_visible(is_rtlsdr);
+    gain_row.set_visible(is_rtlsdr);
+    agc_row.set_visible(is_rtlsdr);
+    hostname_row.set_visible(is_network);
+    port_row.set_visible(is_network);
+    protocol_row.set_visible(is_network);
 
     connect_device_visibility(
         &device_row,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -7,6 +7,7 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::header;
+use crate::sidebar;
 use crate::spectrum;
 
 /// Default window width in pixels.
@@ -39,26 +40,11 @@ pub fn build_window(app: &adw::Application) {
     window.present();
 }
 
-/// Build the `AdwOverlaySplitView` with sidebar and content placeholders.
+/// Build the `AdwOverlaySplitView` with sidebar configuration panels and content.
 fn build_split_view() -> adw::OverlaySplitView {
-    // Sidebar content
-    let sidebar_label = gtk4::Label::builder()
-        .label("Configuration panels coming soon")
-        .margin_top(12)
-        .margin_bottom(12)
-        .margin_start(12)
-        .margin_end(12)
-        .build();
-
-    let sidebar_box = gtk4::Box::builder()
-        .orientation(gtk4::Orientation::Vertical)
-        .build();
-    sidebar_box.append(&sidebar_label);
-
-    let sidebar_scroll = gtk4::ScrolledWindow::builder()
-        .child(&sidebar_box)
-        .hscrollbar_policy(gtk4::PolicyType::Never)
-        .build();
+    // Sidebar — configuration panels.
+    let (sidebar_scroll, _panels) = sidebar::build_sidebar();
+    // TODO: Store `_panels` for DSP bridge signal wiring (PR #7)
 
     // Main content area — spectrum display (FFT plot + waterfall).
     let spectrum_view = spectrum::build_spectrum_view();


### PR DESCRIPTION
## Summary

- Four AdwPreferencesGroup configuration panels in the collapsible sidebar
- **Source**: Device selector (RTL-SDR/Network/File) with conditional visibility — RTL-SDR shows gain/sample rate/AGC, Network shows hostname/port/protocol
- **Audio**: Sink type selector (Audio/Network)
- **Radio**: Bandwidth, squelch enable/level, de-emphasis (None/50us/75us), noise blanker, FM IF NR with mode-dependent visibility
- **Display**: FFT size, window function, frame rate, color map
- Panel structs expose row references for DSP bridge signal wiring in PR #7
- All controls visual-only with TODO comments for future wiring
- 597 new lines

Closes #38

## Test plan

- [x] All workspace tests pass
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --all -- --check` passes
- [ ] Manual: sidebar shows all 4 panels, device selector toggles controls
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable sidebar with panels for Source, Audio, Radio, and Display. Users can select input device (including network/RTL‑SDR), adjust audio output, configure demodulator settings (bandwidth, squelch, de‑emphasis, noise options), and tune display options (FFT size, window, frame rate, color map).
* **Chores**
  * Sidebar is now integrated into the main split view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->