### PR TITLE
Wire RxVFO, fix all DSP audit items, complete signal chain

### DIFF
--- a/crates/sdr-dsp/src/filter.rs
+++ b/crates/sdr-dsp/src/filter.rs
@@ -131,6 +131,22 @@ impl ComplexFirFilter {
         Ok(Self { taps, delay_line })
     }
 
+    /// Replace the filter taps. Resets the delay line.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if `taps` is empty.
+    pub fn set_taps(&mut self, taps: Vec<f32>) -> Result<(), DspError> {
+        if taps.is_empty() {
+            return Err(DspError::InvalidParameter(
+                "FIR taps must not be empty".to_string(),
+            ));
+        }
+        self.delay_line = vec![Complex::default(); taps.len() - 1];
+        self.taps = taps;
+        Ok(())
+    }
+
     /// Reset the delay line to zero.
     pub fn reset(&mut self) {
         self.delay_line.fill(Complex::default());
@@ -480,6 +496,26 @@ mod tests {
         assert!((output[0].im).abs() < 1e-6);
         assert!((output[1].re - 1.0).abs() < 1e-6);
         assert!((output[1].im - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_complex_fir_set_taps() {
+        let mut fir = ComplexFirFilter::new(vec![1.0]).unwrap();
+        // Identity -> 2-tap delay filter
+        fir.set_taps(vec![0.0, 1.0]).unwrap();
+        assert_eq!(fir.tap_count(), 2);
+        let input = [Complex::new(1.0, 2.0), Complex::new(3.0, 4.0)];
+        let mut output = [Complex::default(); 2];
+        fir.process(&input, &mut output).unwrap();
+        // First output should be zero (from delay line reset)
+        assert!((output[0].re).abs() < 1e-6);
+        assert!((output[1].re - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_complex_fir_set_taps_empty() {
+        let mut fir = ComplexFirFilter::new(vec![1.0]).unwrap();
+        assert!(fir.set_taps(vec![]).is_err());
     }
 
     #[test]

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -2,6 +2,10 @@
 //!
 //! Ports SDR++ `dsp::noise_reduction` namespace.
 
+use rustfft::num_complex::Complex as RustFftComplex;
+use rustfft::{Fft, FftPlanner};
+use std::sync::Arc;
+
 use sdr_types::{Complex, DspError};
 
 /// Power squelch — gates signal based on average power level.
@@ -140,8 +144,12 @@ impl NoiseBlanker {
         }
         for (i, &s) in input.iter().enumerate() {
             let in_amp = s.amplitude();
-            // Always update EMA so baseline decays during silence
-            self.amp = self.amp * self.inv_rate + in_amp * self.rate;
+            // Only update EMA for non-zero samples (matches C++ behavior).
+            // This prevents the baseline from decaying to zero during silence,
+            // which would cause false spike detections on the next real signal.
+            if in_amp != 0.0 {
+                self.amp = self.amp * self.inv_rate + in_amp * self.rate;
+            }
             let gain = if self.amp > f32::MIN_POSITIVE {
                 let excess = in_amp / self.amp;
                 if excess > self.level {
@@ -158,51 +166,186 @@ impl NoiseBlanker {
     }
 }
 
+/// Default FFT size for FM IF noise reduction.
+const FM_IF_NR_FFT_SIZE: usize = 256;
+
+/// Number of bins around the peak to preserve (radius on each side).
+const FM_IF_NR_PEAK_RADIUS: usize = 2;
+
 /// FM IF noise reduction — frequency-domain peak tracking.
 ///
 /// Ports SDR++ `dsp::noise_reduction::FMIF`. Uses FFT to find the dominant
 /// frequency bin and reconstructs the signal from that bin only, effectively
 /// removing noise from narrow FM signals.
 ///
-/// Note: Currently a passthrough stub. The full FFT-based implementation
-/// will be added during pipeline integration when the FFT engine is available.
+/// The algorithm:
+/// 1. Forward FFT the input block
+/// 2. Find the bin with maximum magnitude
+/// 3. Zero all bins outside a narrow window around the peak
+/// 4. Inverse FFT to reconstruct the cleaned signal
 pub struct FmIfNoiseReduction {
-    _private: (),
+    fft_forward: Arc<dyn Fft<f32>>,
+    fft_inverse: Arc<dyn Fft<f32>>,
+    fft_size: usize,
+    fft_buf: Vec<RustFftComplex<f32>>,
+    scratch: Vec<RustFftComplex<f32>>,
+    /// Overlap buffer for input blocks smaller than FFT size.
+    overlap_buf: Vec<Complex>,
+    overlap_count: usize,
 }
 
 impl FmIfNoiseReduction {
-    /// Create a new FM IF noise reduction processor (passthrough stub).
-    pub fn new() -> Self {
-        Self { _private: () }
+    /// Create a new FM IF noise reduction processor.
+    ///
+    /// Uses a default FFT size of 256 points.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if internal FFT setup fails.
+    pub fn new() -> Result<Self, DspError> {
+        Self::with_fft_size(FM_IF_NR_FFT_SIZE)
     }
 
-    /// Process complex samples. Currently acts as passthrough.
+    /// Create with a custom FFT size.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if `fft_size` is 0.
+    pub fn with_fft_size(fft_size: usize) -> Result<Self, DspError> {
+        if fft_size == 0 {
+            return Err(DspError::InvalidParameter(
+                "FFT size must be > 0".to_string(),
+            ));
+        }
+        let mut planner = FftPlanner::new();
+        let fft_forward = planner.plan_fft_forward(fft_size);
+        let fft_inverse = planner.plan_fft_inverse(fft_size);
+        let scratch_len = fft_forward
+            .get_inplace_scratch_len()
+            .max(fft_inverse.get_inplace_scratch_len());
+        let scratch = vec![RustFftComplex::new(0.0, 0.0); scratch_len];
+        let fft_buf = vec![RustFftComplex::new(0.0, 0.0); fft_size];
+
+        Ok(Self {
+            fft_forward,
+            fft_inverse,
+            fft_size,
+            fft_buf,
+            scratch,
+            overlap_buf: vec![Complex::default(); fft_size],
+            overlap_count: 0,
+        })
+    }
+
+    /// Process complex samples through FFT-based noise reduction.
+    ///
+    /// Processes complete FFT-size blocks. Remaining samples are buffered
+    /// internally for the next call.
     ///
     /// # Errors
     ///
     /// Returns `DspError::BufferTooSmall` if `output.len() < input.len()`.
-    pub fn process(&self, input: &[Complex], output: &mut [Complex]) -> Result<usize, DspError> {
+    #[allow(clippy::cast_precision_loss)]
+    pub fn process(
+        &mut self,
+        input: &[Complex],
+        output: &mut [Complex],
+    ) -> Result<usize, DspError> {
         if output.len() < input.len() {
             return Err(DspError::BufferTooSmall {
                 need: input.len(),
                 got: output.len(),
             });
         }
-        // Passthrough for now — full FFT-based implementation will be added
-        // when integrated with the pipeline's FFT engine
-        output[..input.len()].copy_from_slice(input);
-        Ok(input.len())
-    }
-}
 
-impl Default for FmIfNoiseReduction {
-    fn default() -> Self {
-        Self::new()
+        let mut in_pos = 0;
+        let mut out_pos = 0;
+
+        while in_pos < input.len() {
+            // Fill the overlap buffer from input.
+            let can_take = (self.fft_size - self.overlap_count).min(input.len() - in_pos);
+            self.overlap_buf[self.overlap_count..self.overlap_count + can_take]
+                .copy_from_slice(&input[in_pos..in_pos + can_take]);
+            self.overlap_count += can_take;
+            in_pos += can_take;
+
+            // Process a complete block when we have enough samples.
+            if self.overlap_count == self.fft_size {
+                self.process_block(&mut output[out_pos..out_pos + self.fft_size]);
+                out_pos += self.fft_size;
+                self.overlap_count = 0;
+            }
+        }
+
+        // Copy through any partial block samples that weren't processed yet.
+        // This ensures output count matches input count for downstream consumers.
+        if self.overlap_count > 0 && out_pos < input.len() {
+            let remaining = input.len() - out_pos;
+            output[out_pos..out_pos + remaining].copy_from_slice(&input[input.len() - remaining..]);
+            out_pos += remaining;
+        }
+
+        Ok(out_pos)
+    }
+
+    /// Process a single FFT-size block: forward FFT, peak-select, inverse FFT.
+    #[allow(clippy::cast_precision_loss)]
+    fn process_block(&mut self, output: &mut [Complex]) {
+        let n = self.fft_size;
+        let inv_n = 1.0 / n as f32;
+
+        // Copy overlap buffer into FFT working buffer.
+        for (i, s) in self.overlap_buf[..n].iter().enumerate() {
+            self.fft_buf[i] = RustFftComplex::new(s.re, s.im);
+        }
+
+        // Forward FFT.
+        self.fft_forward
+            .process_with_scratch(&mut self.fft_buf, &mut self.scratch);
+
+        // Find the bin with maximum magnitude.
+        let mut peak_bin = 0;
+        let mut peak_mag = 0.0_f32;
+        for (i, bin) in self.fft_buf.iter().enumerate() {
+            let mag = bin.re * bin.re + bin.im * bin.im;
+            if mag > peak_mag {
+                peak_mag = mag;
+                peak_bin = i;
+            }
+        }
+
+        // Zero all bins outside a narrow window around the peak.
+        for (i, bin) in self.fft_buf.iter_mut().enumerate() {
+            // Compute circular distance from peak bin.
+            let dist_fwd = if i >= peak_bin {
+                i - peak_bin
+            } else {
+                n - peak_bin + i
+            };
+            let dist_rev = if peak_bin >= i {
+                peak_bin - i
+            } else {
+                n - i + peak_bin
+            };
+            let dist = dist_fwd.min(dist_rev);
+            if dist > FM_IF_NR_PEAK_RADIUS {
+                *bin = RustFftComplex::new(0.0, 0.0);
+            }
+        }
+
+        // Inverse FFT.
+        self.fft_inverse
+            .process_with_scratch(&mut self.fft_buf, &mut self.scratch);
+
+        // Write normalized result to output.
+        for (i, bin) in self.fft_buf[..n].iter().enumerate() {
+            output[i] = Complex::new(bin.re * inv_n, bin.im * inv_n);
+        }
     }
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::float_cmp)]
+#[allow(clippy::unwrap_used, clippy::float_cmp, clippy::cast_precision_loss)]
 mod tests {
     use super::*;
 
@@ -284,6 +427,25 @@ mod tests {
     }
 
     #[test]
+    fn test_blanker_skips_ema_on_zero_samples() {
+        let mut nb = NoiseBlanker::new(0.5, 3.0).unwrap();
+        // Settle the EMA with a known amplitude.
+        let normal = vec![Complex::new(1.0, 0.0); 100];
+        let mut out = vec![Complex::default(); 100];
+        nb.process(&normal, &mut out).unwrap();
+        let amp_before = nb.amp;
+
+        // Feed zero samples — EMA should NOT decay.
+        let zeros = vec![Complex::default(); 100];
+        nb.process(&zeros, &mut out).unwrap();
+        assert!(
+            (nb.amp - amp_before).abs() < 1e-6,
+            "EMA should not change on zero samples, was {amp_before}, now {}",
+            nb.amp
+        );
+    }
+
+    #[test]
     fn test_blanker_reset() {
         let mut nb = NoiseBlanker::new(0.1, 5.0).unwrap();
         let input = vec![Complex::new(10.0, 0.0); 100];
@@ -299,14 +461,74 @@ mod tests {
     // --- FM IF NR tests ---
 
     #[test]
-    fn test_fm_if_nr_passthrough() {
-        let nr = FmIfNoiseReduction::new();
-        let input = vec![Complex::new(1.0, 2.0); 100];
-        let mut output = vec![Complex::default(); 100];
+    fn test_fm_if_nr_preserves_tone() {
+        use core::f32::consts::PI;
+
+        // Generate a pure tone at bin 8 of a 256-point FFT — it should survive NR.
+        let fft_size = 256;
+        let mut nr = FmIfNoiseReduction::with_fft_size(fft_size).unwrap();
+        let tone_bin = 8;
+        let input: Vec<Complex> = (0..fft_size)
+            .map(|i| {
+                let phase = 2.0 * PI * (tone_bin as f32) * (i as f32) / (fft_size as f32);
+                Complex::new(phase.cos(), phase.sin())
+            })
+            .collect();
+        let mut output = vec![Complex::default(); fft_size];
         let count = nr.process(&input, &mut output).unwrap();
-        assert_eq!(count, 100);
-        assert_eq!(output[0].re, 1.0);
-        assert_eq!(output[0].im, 2.0);
+        assert_eq!(count, fft_size);
+
+        // Output should have significant energy (tone preserved).
+        let energy: f32 = output.iter().map(|s| s.re * s.re + s.im * s.im).sum();
+        let input_energy: f32 = input.iter().map(|s| s.re * s.re + s.im * s.im).sum();
+        assert!(
+            energy > input_energy * 0.5,
+            "tone should be mostly preserved, energy ratio = {}",
+            energy / input_energy
+        );
+    }
+
+    #[test]
+    fn test_fm_if_nr_reduces_noise() {
+        // A tone + broadband noise: output energy should be less than input energy
+        // because NR zeroes the noise bins.
+        let fft_size = 256;
+        let mut nr = FmIfNoiseReduction::with_fft_size(fft_size).unwrap();
+
+        // Deterministic "noise": many tones across the spectrum.
+        let input: Vec<Complex> = (0..fft_size)
+            .map(|i| {
+                let tone = (2.0 * core::f32::consts::PI * 8.0 * (i as f32) / fft_size as f32).cos();
+                // Add energy at many other bins (pseudo-noise).
+                let noise = (0.3 * (i as f32 * 1.7).sin())
+                    + (0.2 * (i as f32 * 3.1).cos())
+                    + (0.15 * (i as f32 * 7.3).sin());
+                Complex::new(tone + noise, 0.0)
+            })
+            .collect();
+        let mut output = vec![Complex::default(); fft_size];
+        nr.process(&input, &mut output).unwrap();
+
+        let input_energy: f32 = input.iter().map(|s| s.re * s.re + s.im * s.im).sum();
+        let output_energy: f32 = output.iter().map(|s| s.re * s.re + s.im * s.im).sum();
+        assert!(
+            output_energy < input_energy * 0.9,
+            "NR should reduce broadband energy, ratio = {}",
+            output_energy / input_energy
+        );
+    }
+
+    #[test]
+    fn test_fm_if_nr_invalid_size() {
+        assert!(FmIfNoiseReduction::with_fft_size(0).is_err());
+    }
+
+    #[test]
+    fn test_fm_if_nr_buffer_too_small() {
+        let mut nr = FmIfNoiseReduction::new().unwrap();
+        let input = [Complex::default(); 300];
+        let mut output = [Complex::default(); 100];
+        assert!(nr.process(&input, &mut output).is_err());
     }
 
     #[test]

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -271,8 +271,11 @@ impl FmIfNoiseReduction {
 
             // Process a complete block when we have enough samples.
             if self.overlap_count == self.fft_size {
-                self.process_block(&mut output[out_pos..out_pos + self.fft_size]);
-                out_pos += self.fft_size;
+                // Guard: ensure output has room for a full FFT block.
+                if out_pos + self.fft_size <= output.len() {
+                    self.process_block(&mut output[out_pos..out_pos + self.fft_size]);
+                    out_pos += self.fft_size;
+                }
                 self.overlap_count = 0;
             }
         }

--- a/crates/sdr-radio/src/af_chain.rs
+++ b/crates/sdr-radio/src/af_chain.rs
@@ -97,8 +97,10 @@ impl AfChain {
     pub fn set_deemp_enabled(&mut self, enabled: bool, tau: f64) -> Result<(), DspError> {
         self.deemp_enabled = enabled;
         if enabled && tau > 0.0 {
-            self.deemp_l = Some(DeemphasisFilter::new(tau, self.af_sample_rate)?);
-            self.deemp_r = Some(DeemphasisFilter::new(tau, self.af_sample_rate)?);
+            // Deemphasis runs AFTER resampling, so use the audio output rate.
+            // C++ SDR++ applies deemphasis at 48 kHz, not the demod AF rate.
+            self.deemp_l = Some(DeemphasisFilter::new(tau, self.audio_sample_rate)?);
+            self.deemp_r = Some(DeemphasisFilter::new(tau, self.audio_sample_rate)?);
         } else {
             self.deemp_l = None;
             self.deemp_r = None;
@@ -137,93 +139,78 @@ impl AfChain {
 
         let n = input.len();
 
-        // Stage 1: Deemphasis (operates on L and R channels separately)
-        let deemph_applied = if self.deemp_enabled {
-            if let (Some(deemp_l), Some(deemp_r)) = (&mut self.deemp_l, &mut self.deemp_r) {
-                self.deemp_buf_l.resize(n, 0.0);
-                self.deemp_buf_r.resize(n, 0.0);
-
-                // Extract L and R channels
-                for (i, s) in input.iter().enumerate() {
-                    self.deemp_buf_l[i] = s.l;
-                    self.deemp_buf_r[i] = s.r;
-                }
-
-                // Apply deemphasis using pre-allocated output buffers
-                self.deemp_out_l.resize(n, 0.0);
-                self.deemp_out_r.resize(n, 0.0);
-                deemp_l.process(&self.deemp_buf_l[..n], &mut self.deemp_out_l[..n])?;
-                deemp_r.process(&self.deemp_buf_r[..n], &mut self.deemp_out_r[..n])?;
-
-                // Swap input and output buffers so downstream reads from out
-                std::mem::swap(&mut self.deemp_buf_l, &mut self.deemp_out_l);
-                std::mem::swap(&mut self.deemp_buf_r, &mut self.deemp_out_r);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-
-        // Stage 2: Resampling
-        if let Some(resampler) = &mut self.resampler {
-            // Convert stereo to complex for resampling
+        // Stage 1: Resample from AF rate to audio output rate.
+        // C++ SDR++ order: Resample FIRST, then deemphasis at audio rate.
+        let (resampled, resamp_count) = if let Some(resampler) = &mut self.resampler {
             self.resamp_in.resize(n, Complex::default());
-            if deemph_applied {
-                for i in 0..n {
-                    self.resamp_in[i] = Complex::new(self.deemp_buf_l[i], self.deemp_buf_r[i]);
-                }
-            } else {
-                for (i, s) in input.iter().enumerate() {
-                    self.resamp_in[i] = Complex::new(s.l, s.r);
-                }
+            for (i, s) in input.iter().enumerate() {
+                self.resamp_in[i] = Complex::new(s.l, s.r);
             }
 
-            // Allocate output buffer with headroom
             let ratio = (self.audio_sample_rate / self.af_sample_rate).ceil() as usize;
             let max_out = n * ratio.max(1) + RESAMPLER_OUTPUT_PADDING;
             self.resamp_out.resize(max_out, Complex::default());
 
             let out_count = resampler.process(&self.resamp_in[..n], &mut self.resamp_out)?;
+            (true, out_count)
+        } else {
+            (false, n)
+        };
 
-            if output.len() < out_count {
-                return Err(DspError::BufferTooSmall {
-                    need: out_count,
-                    got: output.len(),
-                });
-            }
+        if output.len() < resamp_count {
+            return Err(DspError::BufferTooSmall {
+                need: resamp_count,
+                got: output.len(),
+            });
+        }
 
-            // Convert complex back to stereo
+        // Write resampled (or passthrough) samples to output.
+        if resampled {
             for (out, c) in output
                 .iter_mut()
                 .zip(self.resamp_out.iter())
-                .take(out_count)
+                .take(resamp_count)
             {
                 *out = Stereo::new(c.re, c.im);
             }
-            Ok(out_count)
         } else {
-            // No resampling needed
-            if output.len() < n {
-                return Err(DspError::BufferTooSmall {
-                    need: n,
-                    got: output.len(),
-                });
-            }
-            if deemph_applied {
-                for (out, (&l, &r)) in output
-                    .iter_mut()
-                    .zip(self.deemp_buf_l.iter().zip(self.deemp_buf_r.iter()))
-                    .take(n)
-                {
-                    *out = Stereo::new(l, r);
-                }
-            } else {
-                output[..n].copy_from_slice(input);
-            }
-            Ok(n)
+            output[..n].copy_from_slice(input);
         }
+
+        // Stage 2: Deemphasis at the audio output rate (48 kHz).
+        // Applied AFTER resampling, matching SDR++ signal chain order.
+        if self.deemp_enabled
+            && let (Some(deemp_l), Some(deemp_r)) = (&mut self.deemp_l, &mut self.deemp_r)
+        {
+            self.deemp_buf_l.resize(resamp_count, 0.0);
+            self.deemp_buf_r.resize(resamp_count, 0.0);
+
+            for (i, s) in output[..resamp_count].iter().enumerate() {
+                self.deemp_buf_l[i] = s.l;
+                self.deemp_buf_r[i] = s.r;
+            }
+
+            self.deemp_out_l.resize(resamp_count, 0.0);
+            self.deemp_out_r.resize(resamp_count, 0.0);
+            deemp_l.process(
+                &self.deemp_buf_l[..resamp_count],
+                &mut self.deemp_out_l[..resamp_count],
+            )?;
+            deemp_r.process(
+                &self.deemp_buf_r[..resamp_count],
+                &mut self.deemp_out_r[..resamp_count],
+            )?;
+
+            for (out, (&l, &r)) in output[..resamp_count].iter_mut().zip(
+                self.deemp_out_l[..resamp_count]
+                    .iter()
+                    .zip(self.deemp_out_r[..resamp_count].iter()),
+            ) {
+                *out = Stereo::new(l, r);
+            }
+        }
+
+        Ok(resamp_count)
     }
 }
 

--- a/crates/sdr-radio/src/demod/am.rs
+++ b/crates/sdr-radio/src/demod/am.rs
@@ -1,6 +1,7 @@
 //! Amplitude modulation demodulator.
 
 use sdr_dsp::demod::AmDemod;
+use sdr_dsp::loops::Agc;
 use sdr_types::{Complex, DspError, Stereo};
 
 use super::{DemodConfig, Demodulator, VfoReference};
@@ -23,19 +24,46 @@ const AM_MAX_BANDWIDTH: f64 = 15_000.0;
 /// Default frequency snap interval for AM (Hz).
 const AM_SNAP_INTERVAL: f64 = 1_000.0;
 
+/// AGC set point (target output amplitude) for AM mode.
+const AM_AGC_SET_POINT: f32 = 1.0;
+/// AGC attack coefficient for AM mode.
+const AM_AGC_ATTACK: f32 = 0.001;
+/// AGC decay coefficient for AM mode.
+const AM_AGC_DECAY: f32 = 0.0001;
+/// AGC maximum gain for AM mode.
+const AM_AGC_MAX_GAIN: f32 = 1e6;
+/// AGC maximum output amplitude for AM mode.
+const AM_AGC_MAX_OUTPUT: f32 = 10.0;
+/// AGC initial gain for AM mode.
+const AM_AGC_INIT_GAIN: f32 = 1.0;
+
 /// AM demodulator using `AmDemod` from sdr-dsp.
 ///
-/// Extracts the amplitude envelope, applies DC blocking, and outputs stereo.
+/// Extracts the amplitude envelope, applies DC blocking and AGC, and outputs stereo.
 pub struct AmDemodulator {
     demod: AmDemod,
+    agc: Agc,
     config: DemodConfig,
     mono_buf: Vec<f32>,
+    agc_buf: Vec<f32>,
 }
 
 impl AmDemodulator {
     /// Create a new AM demodulator.
-    pub fn new() -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError` if the AGC cannot be created.
+    pub fn new() -> Result<Self, DspError> {
         let demod = AmDemod::new();
+        let agc = Agc::new(
+            AM_AGC_SET_POINT,
+            AM_AGC_ATTACK,
+            AM_AGC_DECAY,
+            AM_AGC_MAX_GAIN,
+            AM_AGC_MAX_OUTPUT,
+            AM_AGC_INIT_GAIN,
+        )?;
         let config = DemodConfig {
             if_sample_rate: AM_IF_SAMPLE_RATE,
             af_sample_rate: AM_AF_SAMPLE_RATE,
@@ -53,17 +81,13 @@ impl AmDemodulator {
             high_pass_allowed: true,
             squelch_allowed: true,
         };
-        Self {
+        Ok(Self {
             demod,
+            agc,
             config,
             mono_buf: Vec::new(),
-        }
-    }
-}
-
-impl Default for AmDemodulator {
-    fn default() -> Self {
-        Self::new()
+            agc_buf: Vec::new(),
+        })
     }
 }
 
@@ -77,7 +101,13 @@ impl Demodulator for AmDemodulator {
         }
         self.mono_buf.resize(input.len(), 0.0);
         let count = self.demod.process(input, &mut self.mono_buf)?;
-        sdr_dsp::convert::mono_to_stereo(&self.mono_buf[..count], &mut output[..count])?;
+
+        // Apply AGC to normalize AM audio levels before stereo conversion.
+        self.agc_buf.resize(count, 0.0);
+        self.agc
+            .process_f32(&self.mono_buf[..count], &mut self.agc_buf[..count])?;
+
+        sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
         Ok(count)
     }
 
@@ -102,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_am_config() {
-        let demod = AmDemodulator::new();
+        let demod = AmDemodulator::new().unwrap();
         let cfg = demod.config();
         assert!((cfg.if_sample_rate - 15_000.0).abs() < f64::EPSILON);
         assert!((cfg.default_bandwidth - 10_000.0).abs() < f64::EPSILON);
@@ -112,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_am_process_envelope() {
-        let mut demod = AmDemodulator::new();
+        let mut demod = AmDemodulator::new().unwrap();
         // AM signal: carrier with modulated amplitude
         let input: Vec<Complex> = (0..1000)
             .map(|i| {

--- a/crates/sdr-radio/src/demod/dsb.rs
+++ b/crates/sdr-radio/src/demod/dsb.rs
@@ -1,6 +1,7 @@
 //! Double sideband (DSB) demodulator.
 
 use sdr_dsp::demod::{SsbDemod, SsbMode};
+use sdr_dsp::loops::Agc;
 use sdr_types::{Complex, DspError, Stereo};
 
 use super::{DemodConfig, Demodulator, VfoReference};
@@ -23,11 +24,26 @@ const DSB_MAX_BANDWIDTH: f64 = 12_000.0;
 /// Default frequency snap interval for DSB (Hz).
 const DSB_SNAP_INTERVAL: f64 = 100.0;
 
+/// AGC set point (target output amplitude) for SSB modes.
+const SSB_AGC_SET_POINT: f32 = 1.0;
+/// AGC attack coefficient for SSB modes.
+const SSB_AGC_ATTACK: f32 = 0.001;
+/// AGC decay coefficient for SSB modes.
+const SSB_AGC_DECAY: f32 = 0.0001;
+/// AGC maximum gain for SSB modes.
+const SSB_AGC_MAX_GAIN: f32 = 1e6;
+/// AGC maximum output amplitude for SSB modes.
+const SSB_AGC_MAX_OUTPUT: f32 = 10.0;
+/// AGC initial gain for SSB modes.
+const SSB_AGC_INIT_GAIN: f32 = 1.0;
+
 /// Double sideband demodulator using `SsbDemod(Dsb)` from sdr-dsp.
 pub struct DsbDemodulator {
     demod: SsbDemod,
+    agc: Agc,
     config: DemodConfig,
     mono_buf: Vec<f32>,
+    agc_buf: Vec<f32>,
 }
 
 impl DsbDemodulator {
@@ -38,6 +54,14 @@ impl DsbDemodulator {
     /// Returns `DspError` if the underlying SSB demod cannot be created.
     pub fn new() -> Result<Self, DspError> {
         let demod = SsbDemod::new(SsbMode::Dsb, DSB_DEFAULT_BANDWIDTH, DSB_IF_SAMPLE_RATE)?;
+        let agc = Agc::new(
+            SSB_AGC_SET_POINT,
+            SSB_AGC_ATTACK,
+            SSB_AGC_DECAY,
+            SSB_AGC_MAX_GAIN,
+            SSB_AGC_MAX_OUTPUT,
+            SSB_AGC_INIT_GAIN,
+        )?;
         let config = DemodConfig {
             if_sample_rate: DSB_IF_SAMPLE_RATE,
             af_sample_rate: DSB_AF_SAMPLE_RATE,
@@ -57,8 +81,10 @@ impl DsbDemodulator {
         };
         Ok(Self {
             demod,
+            agc,
             config,
             mono_buf: Vec::new(),
+            agc_buf: Vec::new(),
         })
     }
 }
@@ -73,7 +99,13 @@ impl Demodulator for DsbDemodulator {
         }
         self.mono_buf.resize(input.len(), 0.0);
         let count = self.demod.process(input, &mut self.mono_buf)?;
-        sdr_dsp::convert::mono_to_stereo(&self.mono_buf[..count], &mut output[..count])?;
+
+        // Apply AGC to normalize SSB audio levels before stereo conversion.
+        self.agc_buf.resize(count, 0.0);
+        self.agc
+            .process_f32(&self.mono_buf[..count], &mut self.agc_buf[..count])?;
+
+        sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
         Ok(count)
     }
 
@@ -93,7 +125,7 @@ impl Demodulator for DsbDemodulator {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::cast_precision_loss)]
 mod tests {
     use super::*;
 
@@ -107,15 +139,23 @@ mod tests {
     }
 
     #[test]
-    fn test_dsb_extracts_real_part() {
+    fn test_dsb_produces_audio() {
         let mut demod = DsbDemodulator::new().unwrap();
-        // DSB with no translation should extract the real part
-        let input = [Complex::new(1.0, 2.0), Complex::new(3.0, 4.0)];
-        let mut output = [Stereo::default(); 2];
+        // Feed a longer signal so AGC can settle, then verify output is non-zero.
+        let input: Vec<Complex> = (0..500)
+            .map(|i| {
+                let phase = 2.0 * core::f32::consts::PI * 1000.0 * (i as f32) / 24_000.0;
+                Complex::new(phase.cos(), phase.sin())
+            })
+            .collect();
+        let mut output = vec![Stereo::default(); 500];
         let count = demod.process(&input, &mut output).unwrap();
-        assert_eq!(count, 2);
-        // DSB extracts real part (no frequency translation)
-        assert!((output[0].l - 1.0).abs() < 1e-5);
-        assert!((output[1].l - 3.0).abs() < 1e-5);
+        assert_eq!(count, 500);
+        // After AGC settles, output should have meaningful amplitude.
+        let peak = output[100..]
+            .iter()
+            .map(|s| s.l.abs())
+            .fold(0.0_f32, f32::max);
+        assert!(peak > 0.1, "DSB should produce audio, peak = {peak}");
     }
 }

--- a/crates/sdr-radio/src/demod/dsb.rs
+++ b/crates/sdr-radio/src/demod/dsb.rs
@@ -4,7 +4,10 @@ use sdr_dsp::demod::{SsbDemod, SsbMode};
 use sdr_dsp::loops::Agc;
 use sdr_types::{Complex, DspError, Stereo};
 
-use super::{DemodConfig, Demodulator, VfoReference};
+use super::{
+    DemodConfig, Demodulator, SSB_AGC_ATTACK, SSB_AGC_DECAY, SSB_AGC_INIT_GAIN, SSB_AGC_MAX_GAIN,
+    SSB_AGC_MAX_OUTPUT, SSB_AGC_SET_POINT, VfoReference,
+};
 
 /// IF sample rate for DSB mode (Hz).
 const DSB_IF_SAMPLE_RATE: f64 = 24_000.0;
@@ -23,19 +26,6 @@ const DSB_MAX_BANDWIDTH: f64 = 12_000.0;
 
 /// Default frequency snap interval for DSB (Hz).
 const DSB_SNAP_INTERVAL: f64 = 100.0;
-
-/// AGC set point (target output amplitude) for SSB modes.
-const SSB_AGC_SET_POINT: f32 = 1.0;
-/// AGC attack coefficient for SSB modes.
-const SSB_AGC_ATTACK: f32 = 0.001;
-/// AGC decay coefficient for SSB modes.
-const SSB_AGC_DECAY: f32 = 0.0001;
-/// AGC maximum gain for SSB modes.
-const SSB_AGC_MAX_GAIN: f32 = 1e6;
-/// AGC maximum output amplitude for SSB modes.
-const SSB_AGC_MAX_OUTPUT: f32 = 10.0;
-/// AGC initial gain for SSB modes.
-const SSB_AGC_INIT_GAIN: f32 = 1.0;
 
 /// Double sideband demodulator using `SsbDemod(Dsb)` from sdr-dsp.
 pub struct DsbDemodulator {

--- a/crates/sdr-radio/src/demod/dsb.rs
+++ b/crates/sdr-radio/src/demod/dsb.rs
@@ -89,14 +89,12 @@ impl Demodulator for DsbDemodulator {
         }
         self.mono_buf.resize(input.len(), 0.0);
         let count = self.demod.process(input, &mut self.mono_buf)?;
-
-        // Apply AGC to normalize SSB audio levels before stereo conversion.
-        self.agc_buf.resize(count, 0.0);
-        self.agc
-            .process_f32(&self.mono_buf[..count], &mut self.agc_buf[..count])?;
-
-        sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
-        Ok(count)
+        super::process_with_agc_to_stereo(
+            &mut self.agc,
+            &self.mono_buf[..count],
+            &mut self.agc_buf,
+            &mut output[..count],
+        )
     }
 
     fn set_bandwidth(&mut self, bw: f64) {

--- a/crates/sdr-radio/src/demod/lsb.rs
+++ b/crates/sdr-radio/src/demod/lsb.rs
@@ -89,14 +89,12 @@ impl Demodulator for LsbDemodulator {
         }
         self.mono_buf.resize(input.len(), 0.0);
         let count = self.demod.process(input, &mut self.mono_buf)?;
-
-        // Apply AGC to normalize SSB audio levels before stereo conversion.
-        self.agc_buf.resize(count, 0.0);
-        self.agc
-            .process_f32(&self.mono_buf[..count], &mut self.agc_buf[..count])?;
-
-        sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
-        Ok(count)
+        super::process_with_agc_to_stereo(
+            &mut self.agc,
+            &self.mono_buf[..count],
+            &mut self.agc_buf,
+            &mut output[..count],
+        )
     }
 
     fn set_bandwidth(&mut self, bw: f64) {

--- a/crates/sdr-radio/src/demod/lsb.rs
+++ b/crates/sdr-radio/src/demod/lsb.rs
@@ -4,7 +4,10 @@ use sdr_dsp::demod::{SsbDemod, SsbMode};
 use sdr_dsp::loops::Agc;
 use sdr_types::{Complex, DspError, Stereo};
 
-use super::{DemodConfig, Demodulator, VfoReference};
+use super::{
+    DemodConfig, Demodulator, SSB_AGC_ATTACK, SSB_AGC_DECAY, SSB_AGC_INIT_GAIN, SSB_AGC_MAX_GAIN,
+    SSB_AGC_MAX_OUTPUT, SSB_AGC_SET_POINT, VfoReference,
+};
 
 /// IF sample rate for LSB mode (Hz).
 const LSB_IF_SAMPLE_RATE: f64 = 24_000.0;
@@ -23,19 +26,6 @@ const LSB_MAX_BANDWIDTH: f64 = 12_000.0;
 
 /// Default frequency snap interval for LSB (Hz).
 const LSB_SNAP_INTERVAL: f64 = 100.0;
-
-/// AGC set point (target output amplitude) for SSB modes.
-const SSB_AGC_SET_POINT: f32 = 1.0;
-/// AGC attack coefficient for SSB modes.
-const SSB_AGC_ATTACK: f32 = 0.001;
-/// AGC decay coefficient for SSB modes.
-const SSB_AGC_DECAY: f32 = 0.0001;
-/// AGC maximum gain for SSB modes.
-const SSB_AGC_MAX_GAIN: f32 = 1e6;
-/// AGC maximum output amplitude for SSB modes.
-const SSB_AGC_MAX_OUTPUT: f32 = 10.0;
-/// AGC initial gain for SSB modes.
-const SSB_AGC_INIT_GAIN: f32 = 1.0;
 
 /// Lower sideband demodulator using `SsbDemod(Lsb)` from sdr-dsp.
 pub struct LsbDemodulator {

--- a/crates/sdr-radio/src/demod/lsb.rs
+++ b/crates/sdr-radio/src/demod/lsb.rs
@@ -1,6 +1,7 @@
 //! Lower sideband (LSB) demodulator.
 
 use sdr_dsp::demod::{SsbDemod, SsbMode};
+use sdr_dsp::loops::Agc;
 use sdr_types::{Complex, DspError, Stereo};
 
 use super::{DemodConfig, Demodulator, VfoReference};
@@ -23,11 +24,26 @@ const LSB_MAX_BANDWIDTH: f64 = 12_000.0;
 /// Default frequency snap interval for LSB (Hz).
 const LSB_SNAP_INTERVAL: f64 = 100.0;
 
+/// AGC set point (target output amplitude) for SSB modes.
+const SSB_AGC_SET_POINT: f32 = 1.0;
+/// AGC attack coefficient for SSB modes.
+const SSB_AGC_ATTACK: f32 = 0.001;
+/// AGC decay coefficient for SSB modes.
+const SSB_AGC_DECAY: f32 = 0.0001;
+/// AGC maximum gain for SSB modes.
+const SSB_AGC_MAX_GAIN: f32 = 1e6;
+/// AGC maximum output amplitude for SSB modes.
+const SSB_AGC_MAX_OUTPUT: f32 = 10.0;
+/// AGC initial gain for SSB modes.
+const SSB_AGC_INIT_GAIN: f32 = 1.0;
+
 /// Lower sideband demodulator using `SsbDemod(Lsb)` from sdr-dsp.
 pub struct LsbDemodulator {
     demod: SsbDemod,
+    agc: Agc,
     config: DemodConfig,
     mono_buf: Vec<f32>,
+    agc_buf: Vec<f32>,
 }
 
 impl LsbDemodulator {
@@ -38,6 +54,14 @@ impl LsbDemodulator {
     /// Returns `DspError` if the underlying SSB demod cannot be created.
     pub fn new() -> Result<Self, DspError> {
         let demod = SsbDemod::new(SsbMode::Lsb, LSB_DEFAULT_BANDWIDTH, LSB_IF_SAMPLE_RATE)?;
+        let agc = Agc::new(
+            SSB_AGC_SET_POINT,
+            SSB_AGC_ATTACK,
+            SSB_AGC_DECAY,
+            SSB_AGC_MAX_GAIN,
+            SSB_AGC_MAX_OUTPUT,
+            SSB_AGC_INIT_GAIN,
+        )?;
         let config = DemodConfig {
             if_sample_rate: LSB_IF_SAMPLE_RATE,
             af_sample_rate: LSB_AF_SAMPLE_RATE,
@@ -57,8 +81,10 @@ impl LsbDemodulator {
         };
         Ok(Self {
             demod,
+            agc,
             config,
             mono_buf: Vec::new(),
+            agc_buf: Vec::new(),
         })
     }
 }
@@ -73,7 +99,13 @@ impl Demodulator for LsbDemodulator {
         }
         self.mono_buf.resize(input.len(), 0.0);
         let count = self.demod.process(input, &mut self.mono_buf)?;
-        sdr_dsp::convert::mono_to_stereo(&self.mono_buf[..count], &mut output[..count])?;
+
+        // Apply AGC to normalize SSB audio levels before stereo conversion.
+        self.agc_buf.resize(count, 0.0);
+        self.agc
+            .process_f32(&self.mono_buf[..count], &mut self.agc_buf[..count])?;
+
+        sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
         Ok(count)
     }
 

--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -13,6 +13,22 @@ mod raw;
 mod usb;
 mod wfm;
 
+// Shared AGC profile for SSB modes (USB, LSB, DSB).
+// Centralized here so all three modes stay in sync when retuning.
+
+/// AGC set point (target output amplitude) for SSB modes.
+pub(crate) const SSB_AGC_SET_POINT: f32 = 1.0;
+/// AGC attack coefficient for SSB modes.
+pub(crate) const SSB_AGC_ATTACK: f32 = 0.001;
+/// AGC decay coefficient for SSB modes.
+pub(crate) const SSB_AGC_DECAY: f32 = 0.0001;
+/// AGC maximum gain for SSB modes.
+pub(crate) const SSB_AGC_MAX_GAIN: f32 = 1e6;
+/// AGC maximum output amplitude for SSB modes.
+pub(crate) const SSB_AGC_MAX_OUTPUT: f32 = 10.0;
+/// AGC initial gain for SSB modes.
+pub(crate) const SSB_AGC_INIT_GAIN: f32 = 1.0;
+
 pub use am::AmDemodulator;
 pub use cw::CwDemodulator;
 pub use dsb::DsbDemodulator;

--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -29,6 +29,22 @@ pub(crate) const SSB_AGC_MAX_OUTPUT: f32 = 10.0;
 /// AGC initial gain for SSB modes.
 pub(crate) const SSB_AGC_INIT_GAIN: f32 = 1.0;
 
+/// Process mono audio through AGC and convert to stereo.
+///
+/// Shared helper for SSB modes (USB, LSB, DSB) to avoid code duplication.
+pub(crate) fn process_with_agc_to_stereo(
+    agc: &mut sdr_dsp::loops::Agc,
+    mono_in: &[f32],
+    agc_buf: &mut Vec<f32>,
+    stereo_out: &mut [Stereo],
+) -> Result<usize, DspError> {
+    let count = mono_in.len();
+    agc_buf.resize(count, 0.0);
+    agc.process_f32(&mono_in[..count], &mut agc_buf[..count])?;
+    sdr_dsp::convert::mono_to_stereo(&agc_buf[..count], &mut stereo_out[..count])?;
+    Ok(count)
+}
+
 pub use am::AmDemodulator;
 pub use cw::CwDemodulator;
 pub use dsb::DsbDemodulator;

--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -105,7 +105,7 @@ pub fn create_demodulator(
     match mode {
         DemodMode::Wfm => Ok(Box::new(WfmDemodulator::new()?)),
         DemodMode::Nfm => Ok(Box::new(NfmDemodulator::new()?)),
-        DemodMode::Am => Ok(Box::new(AmDemodulator::new())),
+        DemodMode::Am => Ok(Box::new(AmDemodulator::new()?)),
         DemodMode::Usb => Ok(Box::new(UsbDemodulator::new()?)),
         DemodMode::Lsb => Ok(Box::new(LsbDemodulator::new()?)),
         DemodMode::Dsb => Ok(Box::new(DsbDemodulator::new()?)),

--- a/crates/sdr-radio/src/demod/nfm.rs
+++ b/crates/sdr-radio/src/demod/nfm.rs
@@ -85,8 +85,9 @@ impl Demodulator for NfmDemodulator {
     fn set_bandwidth(&mut self, bw: f64) {
         // Rebuild the FM discriminator with deviation = bw/2 so the
         // demodulator sensitivity tracks the channel bandwidth.
-        if let Ok(new_demod) = FmDemod::from_hz(bw / 2.0, NFM_IF_SAMPLE_RATE) {
-            self.demod = new_demod;
+        match FmDemod::from_hz(bw / 2.0, NFM_IF_SAMPLE_RATE) {
+            Ok(new_demod) => self.demod = new_demod,
+            Err(e) => tracing::warn!("NFM: set_bandwidth({bw}) failed: {e}"),
         }
     }
 

--- a/crates/sdr-radio/src/demod/nfm.rs
+++ b/crates/sdr-radio/src/demod/nfm.rs
@@ -82,8 +82,12 @@ impl Demodulator for NfmDemodulator {
         Ok(count)
     }
 
-    fn set_bandwidth(&mut self, _bw: f64) {
-        // Bandwidth is handled by the VFO channel filter, not the discriminator.
+    fn set_bandwidth(&mut self, bw: f64) {
+        // Rebuild the FM discriminator with deviation = bw/2 so the
+        // demodulator sensitivity tracks the channel bandwidth.
+        if let Ok(new_demod) = FmDemod::from_hz(bw / 2.0, NFM_IF_SAMPLE_RATE) {
+            self.demod = new_demod;
+        }
     }
 
     fn config(&self) -> &DemodConfig {

--- a/crates/sdr-radio/src/demod/usb.rs
+++ b/crates/sdr-radio/src/demod/usb.rs
@@ -89,14 +89,12 @@ impl Demodulator for UsbDemodulator {
         }
         self.mono_buf.resize(input.len(), 0.0);
         let count = self.demod.process(input, &mut self.mono_buf)?;
-
-        // Apply AGC to normalize SSB audio levels before stereo conversion.
-        self.agc_buf.resize(count, 0.0);
-        self.agc
-            .process_f32(&self.mono_buf[..count], &mut self.agc_buf[..count])?;
-
-        sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
-        Ok(count)
+        super::process_with_agc_to_stereo(
+            &mut self.agc,
+            &self.mono_buf[..count],
+            &mut self.agc_buf,
+            &mut output[..count],
+        )
     }
 
     fn set_bandwidth(&mut self, bw: f64) {

--- a/crates/sdr-radio/src/demod/usb.rs
+++ b/crates/sdr-radio/src/demod/usb.rs
@@ -1,6 +1,7 @@
 //! Upper sideband (USB) demodulator.
 
 use sdr_dsp::demod::{SsbDemod, SsbMode};
+use sdr_dsp::loops::Agc;
 use sdr_types::{Complex, DspError, Stereo};
 
 use super::{DemodConfig, Demodulator, VfoReference};
@@ -23,11 +24,26 @@ const USB_MAX_BANDWIDTH: f64 = 12_000.0;
 /// Default frequency snap interval for USB (Hz).
 const USB_SNAP_INTERVAL: f64 = 100.0;
 
+/// AGC set point (target output amplitude) for SSB modes.
+const SSB_AGC_SET_POINT: f32 = 1.0;
+/// AGC attack coefficient for SSB modes.
+const SSB_AGC_ATTACK: f32 = 0.001;
+/// AGC decay coefficient for SSB modes.
+const SSB_AGC_DECAY: f32 = 0.0001;
+/// AGC maximum gain for SSB modes.
+const SSB_AGC_MAX_GAIN: f32 = 1e6;
+/// AGC maximum output amplitude for SSB modes.
+const SSB_AGC_MAX_OUTPUT: f32 = 10.0;
+/// AGC initial gain for SSB modes.
+const SSB_AGC_INIT_GAIN: f32 = 1.0;
+
 /// Upper sideband demodulator using `SsbDemod(Usb)` from sdr-dsp.
 pub struct UsbDemodulator {
     demod: SsbDemod,
+    agc: Agc,
     config: DemodConfig,
     mono_buf: Vec<f32>,
+    agc_buf: Vec<f32>,
 }
 
 impl UsbDemodulator {
@@ -38,6 +54,14 @@ impl UsbDemodulator {
     /// Returns `DspError` if the underlying SSB demod cannot be created.
     pub fn new() -> Result<Self, DspError> {
         let demod = SsbDemod::new(SsbMode::Usb, USB_DEFAULT_BANDWIDTH, USB_IF_SAMPLE_RATE)?;
+        let agc = Agc::new(
+            SSB_AGC_SET_POINT,
+            SSB_AGC_ATTACK,
+            SSB_AGC_DECAY,
+            SSB_AGC_MAX_GAIN,
+            SSB_AGC_MAX_OUTPUT,
+            SSB_AGC_INIT_GAIN,
+        )?;
         let config = DemodConfig {
             if_sample_rate: USB_IF_SAMPLE_RATE,
             af_sample_rate: USB_AF_SAMPLE_RATE,
@@ -57,8 +81,10 @@ impl UsbDemodulator {
         };
         Ok(Self {
             demod,
+            agc,
             config,
             mono_buf: Vec::new(),
+            agc_buf: Vec::new(),
         })
     }
 }
@@ -73,7 +99,13 @@ impl Demodulator for UsbDemodulator {
         }
         self.mono_buf.resize(input.len(), 0.0);
         let count = self.demod.process(input, &mut self.mono_buf)?;
-        sdr_dsp::convert::mono_to_stereo(&self.mono_buf[..count], &mut output[..count])?;
+
+        // Apply AGC to normalize SSB audio levels before stereo conversion.
+        self.agc_buf.resize(count, 0.0);
+        self.agc
+            .process_f32(&self.mono_buf[..count], &mut self.agc_buf[..count])?;
+
+        sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
         Ok(count)
     }
 

--- a/crates/sdr-radio/src/demod/usb.rs
+++ b/crates/sdr-radio/src/demod/usb.rs
@@ -4,7 +4,10 @@ use sdr_dsp::demod::{SsbDemod, SsbMode};
 use sdr_dsp::loops::Agc;
 use sdr_types::{Complex, DspError, Stereo};
 
-use super::{DemodConfig, Demodulator, VfoReference};
+use super::{
+    DemodConfig, Demodulator, SSB_AGC_ATTACK, SSB_AGC_DECAY, SSB_AGC_INIT_GAIN, SSB_AGC_MAX_GAIN,
+    SSB_AGC_MAX_OUTPUT, SSB_AGC_SET_POINT, VfoReference,
+};
 
 /// IF sample rate for USB mode (Hz).
 const USB_IF_SAMPLE_RATE: f64 = 24_000.0;
@@ -23,19 +26,6 @@ const USB_MAX_BANDWIDTH: f64 = 12_000.0;
 
 /// Default frequency snap interval for USB (Hz).
 const USB_SNAP_INTERVAL: f64 = 100.0;
-
-/// AGC set point (target output amplitude) for SSB modes.
-const SSB_AGC_SET_POINT: f32 = 1.0;
-/// AGC attack coefficient for SSB modes.
-const SSB_AGC_ATTACK: f32 = 0.001;
-/// AGC decay coefficient for SSB modes.
-const SSB_AGC_DECAY: f32 = 0.0001;
-/// AGC maximum gain for SSB modes.
-const SSB_AGC_MAX_GAIN: f32 = 1e6;
-/// AGC maximum output amplitude for SSB modes.
-const SSB_AGC_MAX_OUTPUT: f32 = 10.0;
-/// AGC initial gain for SSB modes.
-const SSB_AGC_INIT_GAIN: f32 = 1.0;
 
 /// Upper sideband demodulator using `SsbDemod(Usb)` from sdr-dsp.
 pub struct UsbDemodulator {

--- a/crates/sdr-radio/src/demod/wfm.rs
+++ b/crates/sdr-radio/src/demod/wfm.rs
@@ -1,10 +1,17 @@
 //! Wideband FM (broadcast) demodulator.
 
 use sdr_dsp::demod::BroadcastFmDemod;
-use sdr_dsp::filter::DEEMPHASIS_TAU_EU;
+use sdr_dsp::filter::{DEEMPHASIS_TAU_EU, FirFilter};
+use sdr_dsp::taps;
 use sdr_types::{Complex, DspError, Stereo};
 
 use super::{DemodConfig, Demodulator, VfoReference};
+
+/// Audio lowpass cutoff frequency (Hz) — removes pilot, stereo subcarrier, RDS.
+const AUDIO_LOWPASS_CUTOFF_HZ: f64 = 15_000.0;
+
+/// Audio lowpass transition width (Hz).
+const AUDIO_LOWPASS_TRANSITION_HZ: f64 = 4_000.0;
 
 /// IF sample rate for WFM mode (Hz).
 const WFM_IF_SAMPLE_RATE: f64 = 250_000.0;
@@ -31,8 +38,11 @@ const WFM_SNAP_INTERVAL: f64 = 100_000.0;
 /// with deemphasis. Full stereo decode is deferred to a later phase.
 pub struct WfmDemodulator {
     demod: BroadcastFmDemod,
+    /// 15 kHz lowpass filter — removes pilot tone, stereo subcarrier, RDS, noise.
+    audio_lpf: FirFilter,
     config: DemodConfig,
     mono_buf: Vec<f32>,
+    lpf_buf: Vec<f32>,
 }
 
 impl WfmDemodulator {
@@ -43,6 +53,18 @@ impl WfmDemodulator {
     /// Returns `DspError` if the underlying FM demod cannot be created.
     pub fn new() -> Result<Self, DspError> {
         let demod = BroadcastFmDemod::new(WFM_IF_SAMPLE_RATE)?;
+
+        // 15 kHz lowpass removes pilot tone (19 kHz), stereo subcarrier
+        // (23-53 kHz), RDS (57 kHz), and wideband noise from the FM
+        // composite baseband. Matches C++ broadcast_fm.h audioFirTaps.
+        let lpf_taps = taps::low_pass(
+            AUDIO_LOWPASS_CUTOFF_HZ,
+            AUDIO_LOWPASS_TRANSITION_HZ,
+            WFM_IF_SAMPLE_RATE,
+            false,
+        )?;
+        let audio_lpf = FirFilter::new(lpf_taps)?;
+
         let config = DemodConfig {
             if_sample_rate: WFM_IF_SAMPLE_RATE,
             af_sample_rate: WFM_AF_SAMPLE_RATE,
@@ -55,15 +77,17 @@ impl WfmDemodulator {
             deemp_allowed: true,
             post_proc_enabled: true,
             default_deemp_tau: DEEMPHASIS_TAU_EU,
-            fm_if_nr_allowed: false,
-            nb_allowed: true,
-            high_pass_allowed: false,
+            fm_if_nr_allowed: true,
+            nb_allowed: false,
+            high_pass_allowed: true,
             squelch_allowed: true,
         };
         Ok(Self {
             demod,
+            audio_lpf,
             config,
             mono_buf: Vec::new(),
+            lpf_buf: Vec::new(),
         })
     }
 }
@@ -78,14 +102,21 @@ impl Demodulator for WfmDemodulator {
         }
         self.mono_buf.resize(input.len(), 0.0);
         let count = self.demod.process(input, &mut self.mono_buf)?;
-        // Convert mono discriminator output to stereo (same signal both channels)
-        sdr_dsp::convert::mono_to_stereo(&self.mono_buf[..count], &mut output[..count])?;
+
+        // Apply 15 kHz lowpass to remove pilot, subcarrier, RDS, and noise.
+        self.lpf_buf.resize(count, 0.0);
+        self.audio_lpf
+            .process_f32(&self.mono_buf[..count], &mut self.lpf_buf[..count])?;
+
+        // Convert filtered mono to stereo (same signal both channels)
+        sdr_dsp::convert::mono_to_stereo(&self.lpf_buf[..count], &mut output[..count])?;
         Ok(count)
     }
 
     fn set_bandwidth(&mut self, _bw: f64) {
         // WFM bandwidth affects the VFO channel filter, not the discriminator.
-        // The demod itself always operates at the fixed IF sample rate.
+        // Unlike NFM, broadcast FM deviation is fixed at 75 kHz by standard,
+        // so BroadcastFmDemod does not need rebuilding when bandwidth changes.
     }
 
     fn config(&self) -> &DemodConfig {

--- a/crates/sdr-radio/src/if_chain.rs
+++ b/crates/sdr-radio/src/if_chain.rs
@@ -46,7 +46,7 @@ impl IfChain {
             nb_enabled: false,
             squelch: PowerSquelch::new(SQUELCH_DEFAULT_LEVEL_DB),
             squelch_enabled: false,
-            fm_if_nr: FmIfNoiseReduction::new(),
+            fm_if_nr: FmIfNoiseReduction::new()?,
             fm_if_nr_enabled: false,
             buf_a: Vec::new(),
             buf_b: Vec::new(),
@@ -251,13 +251,14 @@ mod tests {
         chain.set_fm_if_nr_enabled(true);
         assert!(chain.fm_if_nr_enabled());
 
-        let input = vec![Complex::new(1.0, 2.0); 100];
-        let mut output = vec![Complex::default(); 100];
+        // Use a signal large enough for the FFT block size (256 default).
+        let input = vec![Complex::new(1.0, 0.0); 512];
+        let mut output = vec![Complex::default(); 512];
         let count = chain.process(&input, &mut output).unwrap();
-        assert_eq!(count, 100);
-        // FM IF NR is currently passthrough, so output should match input
-        assert_eq!(output[0].re, 1.0);
-        assert_eq!(output[0].im, 2.0);
+        assert_eq!(count, 512);
+        // DC signal should mostly survive (peak bin = 0).
+        let energy: f32 = output.iter().map(|s| s.re * s.re + s.im * s.im).sum();
+        assert!(energy > 0.0, "FM IF NR should produce output");
     }
 
     #[test]
@@ -268,10 +269,10 @@ mod tests {
         chain.set_squelch_level(-50.0);
         chain.set_fm_if_nr_enabled(true);
 
-        let input = vec![Complex::new(1.0, 0.0); 500];
-        let mut output = vec![Complex::default(); 500];
+        let input = vec![Complex::new(1.0, 0.0); 512];
+        let mut output = vec![Complex::default(); 512];
         let count = chain.process(&input, &mut output).unwrap();
-        assert_eq!(count, 500);
+        assert_eq!(count, 512);
     }
 
     #[test]

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -262,13 +262,17 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetBandwidth(bw) => {
             tracing::debug!(bandwidth_hz = bw, "set bandwidth");
-            state.bandwidth = bw;
-            // Update the VFO channel filter for the new bandwidth.
-            if let Some(vfo) = &mut state.vfo
-                && let Err(e) = vfo.set_bandwidth(bw)
-            {
-                tracing::warn!("VFO bandwidth update failed: {e}");
-                let _ = dsp_tx.send(DspToUi::Error(format!("Bandwidth failed: {e}")));
+            // Update the VFO channel filter first; only persist on success.
+            if let Some(vfo) = &mut state.vfo {
+                match vfo.set_bandwidth(bw) {
+                    Ok(()) => state.bandwidth = bw,
+                    Err(e) => {
+                        tracing::warn!("VFO bandwidth update failed: {e}");
+                        let _ = dsp_tx.send(DspToUi::Error(format!("Bandwidth failed: {e}")));
+                    }
+                }
+            } else {
+                state.bandwidth = bw;
             }
             // Also pass to the radio module (some demods use it internally).
             state.radio.set_bandwidth(bw);

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -133,6 +133,8 @@ struct DspState {
     dc_blocking: bool,
     invert_iq: bool,
     window_fn: FftWindow,
+    /// Current channel bandwidth (persisted so VFO rebuilds use it, not mode default).
+    bandwidth: f64,
 
     // RxVFO — frequency translation + resampling + channel filter
     vfo: Option<RxVfo>,
@@ -160,6 +162,7 @@ impl DspState {
 
         let radio =
             RadioModule::with_default_rate().map_err(|e| format!("RadioModule init: {e}"))?;
+        let initial_bandwidth = radio.demod_config().default_bandwidth;
 
         // The RxVfo and RadioModule input rate are configured in open_device()
         // once we know the actual effective sample rate from the hardware.
@@ -176,6 +179,7 @@ impl DspState {
             dc_blocking: true,
             invert_iq: false,
             window_fn: FftWindow::Nuttall,
+            bandwidth: initial_bandwidth,
             vfo: None,
             vfo_buf: Vec::new(),
             vfo_offset: 0.0,
@@ -246,6 +250,8 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 tracing::warn!("set demod mode failed: {e}");
                 let _ = dsp_tx.send(DspToUi::Error(format!("Mode switch failed: {e}")));
             } else {
+                // Reset bandwidth to the new mode's default.
+                state.bandwidth = state.radio.demod_config().default_bandwidth;
                 // Rebuild the RxVfo for the new demod's IF rate and bandwidth.
                 if let Err(e) = rebuild_vfo(state) {
                     tracing::warn!("VFO rebuild on mode switch failed: {e}");
@@ -256,6 +262,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetBandwidth(bw) => {
             tracing::debug!(bandwidth_hz = bw, "set bandwidth");
+            state.bandwidth = bw;
             // Update the VFO channel filter for the new bandwidth.
             if let Some(vfo) = &mut state.vfo
                 && let Err(e) = vfo.set_bandwidth(bw)
@@ -464,13 +471,12 @@ fn open_device(state: &mut DspState) -> Result<(), String> {
         .reset_buffer()
         .map_err(|e| format!("reset buffer: {e}"))?;
 
-    // Rebuild the frontend to match the configured sample rate.
-    state.device = Some(device);
-
+    // Rebuild frontend and VFO before committing the device to state.
+    // If either fails, the local `device` handle is dropped and startup
+    // leaves no partially-open device behind.
     rebuild_frontend(state)?;
-
-    // Build the RxVfo and configure RadioModule to receive at the demod IF rate.
     rebuild_vfo(state)?;
+    state.device = Some(device);
 
     tracing::info!(
         sample_rate = state.sample_rate,
@@ -516,9 +522,8 @@ fn rebuild_vfo(state: &mut DspState) -> Result<(), String> {
     let effective_rate = state.frontend.effective_sample_rate();
     let demod_cfg = state.radio.demod_config();
     let if_rate = demod_cfg.if_sample_rate;
-    let bandwidth = demod_cfg.default_bandwidth;
 
-    let vfo = RxVfo::new(effective_rate, if_rate, bandwidth, state.vfo_offset)
+    let vfo = RxVfo::new(effective_rate, if_rate, state.bandwidth, state.vfo_offset)
         .map_err(|e| format!("RxVfo build: {e}"))?;
 
     state.vfo = Some(vfo);
@@ -533,7 +538,7 @@ fn rebuild_vfo(state: &mut DspState) -> Result<(), String> {
     tracing::debug!(
         frontend_rate = effective_rate,
         if_rate,
-        bandwidth,
+        bandwidth = state.bandwidth,
         offset = state.vfo_offset,
         "RxVfo rebuilt"
     );

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -5,12 +5,14 @@
 //! 1. Checks for UI commands (non-blocking when running, blocking when stopped).
 //! 2. Reads IQ samples from the RTL-SDR device via `read_sync`.
 //! 3. Processes samples through `IqFrontend` (decimation, DC blocking, FFT).
-//! 4. Processes through `RadioModule` (IF chain, demod, AF chain).
-//! 5. Sends FFT data back to the UI for display.
+//! 4. Processes through `RxVfo` (frequency translation, resampling, channel filter).
+//! 5. Processes through `RadioModule` (IF chain, demod, AF chain).
+//! 6. Sends FFT data back to the UI for display.
 
 use std::sync::mpsc;
 use std::time::Duration;
 
+use sdr_dsp::channel::RxVfo;
 use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
 use sdr_pipeline::sink_manager::Sink;
 use sdr_radio::RadioModule;
@@ -30,10 +32,12 @@ const RAW_BUF_SIZE: usize = IQ_PAIRS_PER_READ * 2;
 /// Default FFT size for spectrum display.
 const DEFAULT_FFT_SIZE: usize = 2048;
 
-/// Default sample rate in Hz (2.4 MHz).
-const DEFAULT_SAMPLE_RATE: f64 = 2_400_000.0;
+/// Default sample rate in Hz (2.0 Msps).
+/// With decimation 8, effective rate = 250 kHz, matching WFM IF exactly.
+/// This avoids the input resampler entirely for WFM.
+const DEFAULT_SAMPLE_RATE: f64 = 2_000_000.0;
 
-/// Default decimation ratio (2.4M / 8 = 300 kHz effective rate).
+/// Default decimation ratio (2.0M / 8 = 250 kHz effective rate).
 const DEFAULT_DECIMATION: u32 = 8;
 
 /// Default center frequency in Hz (100 MHz — FM broadcast).
@@ -44,6 +48,9 @@ const IDLE_SLEEP_MS: u64 = 50;
 
 /// Timeout for blocking `recv` when the pipeline is stopped (ms).
 const RECV_TIMEOUT_MS: u64 = 50;
+
+/// Padding added to VFO output buffer to handle resampler edge effects.
+const VFO_OUTPUT_PADDING: usize = 64;
 
 /// RTL-SDR device index to open.
 const DEVICE_INDEX: u32 = 0;
@@ -127,6 +134,11 @@ struct DspState {
     invert_iq: bool,
     window_fn: FftWindow,
 
+    // RxVFO — frequency translation + resampling + channel filter
+    vfo: Option<RxVfo>,
+    vfo_buf: Vec<Complex>,
+    vfo_offset: f64,
+
     // Pre-allocated buffers
     raw_buf: Vec<u8>,
     iq_buf: Vec<Complex>,
@@ -149,6 +161,9 @@ impl DspState {
         let radio =
             RadioModule::with_default_rate().map_err(|e| format!("RadioModule init: {e}"))?;
 
+        // The RxVfo and RadioModule input rate are configured in open_device()
+        // once we know the actual effective sample rate from the hardware.
+
         Ok(Self {
             device: None,
             frontend,
@@ -161,6 +176,9 @@ impl DspState {
             dc_blocking: true,
             invert_iq: false,
             window_fn: FftWindow::Nuttall,
+            vfo: None,
+            vfo_buf: Vec::new(),
+            vfo_offset: 0.0,
             raw_buf: vec![0u8; RAW_BUF_SIZE],
             iq_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             processed_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
@@ -227,11 +245,25 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             if let Err(e) = state.radio.set_mode(mode) {
                 tracing::warn!("set demod mode failed: {e}");
                 let _ = dsp_tx.send(DspToUi::Error(format!("Mode switch failed: {e}")));
+            } else {
+                // Rebuild the RxVfo for the new demod's IF rate and bandwidth.
+                if let Err(e) = rebuild_vfo(state) {
+                    tracing::warn!("VFO rebuild on mode switch failed: {e}");
+                    let _ = dsp_tx.send(DspToUi::Error(format!("VFO rebuild failed: {e}")));
+                }
             }
         }
 
         UiToDsp::SetBandwidth(bw) => {
             tracing::debug!(bandwidth_hz = bw, "set bandwidth");
+            // Update the VFO channel filter for the new bandwidth.
+            if let Some(vfo) = &mut state.vfo
+                && let Err(e) = vfo.set_bandwidth(bw)
+            {
+                tracing::warn!("VFO bandwidth update failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("Bandwidth failed: {e}")));
+            }
+            // Also pass to the radio module (some demods use it internally).
             state.radio.set_bandwidth(bw);
         }
 
@@ -271,6 +303,11 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             }
             match rebuild_frontend(state) {
                 Ok(()) => {
+                    // Rebuild VFO for the new effective rate.
+                    if let Err(e) = rebuild_vfo(state) {
+                        tracing::warn!("VFO rebuild on sample rate change failed: {e}");
+                        let _ = dsp_tx.send(DspToUi::Error(format!("VFO rebuild failed: {e}")));
+                    }
                     let _ = dsp_tx.send(DspToUi::SampleRateChanged(
                         state.frontend.effective_sample_rate(),
                     ));
@@ -288,13 +325,14 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 tracing::warn!("set decimation failed: {e}");
                 let _ = dsp_tx.send(DspToUi::Error(format!("Decimation failed: {e}")));
             } else {
-                // Update RadioModule for the new effective sample rate.
-                let effective = state.frontend.effective_sample_rate();
-                if let Err(e) = state.radio.set_input_sample_rate(effective) {
-                    tracing::warn!("radio input resample update failed: {e}");
-                    let _ = dsp_tx.send(DspToUi::Error(format!("Input resampler failed: {e}")));
+                // Rebuild VFO for the new effective sample rate.
+                if let Err(e) = rebuild_vfo(state) {
+                    tracing::warn!("VFO rebuild on decimation change failed: {e}");
+                    let _ = dsp_tx.send(DspToUi::Error(format!("VFO rebuild failed: {e}")));
                 }
-                let _ = dsp_tx.send(DspToUi::SampleRateChanged(effective));
+                let _ = dsp_tx.send(DspToUi::SampleRateChanged(
+                    state.frontend.effective_sample_rate(),
+                ));
             }
         }
 
@@ -398,6 +436,14 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 }
             }
         }
+
+        UiToDsp::SetVfoOffset(offset) => {
+            tracing::debug!(offset_hz = offset, "set VFO offset");
+            state.vfo_offset = offset;
+            if let Some(vfo) = &mut state.vfo {
+                vfo.set_offset(offset);
+            }
+        }
     }
 }
 
@@ -423,11 +469,8 @@ fn open_device(state: &mut DspState) -> Result<(), String> {
 
     rebuild_frontend(state)?;
 
-    // Configure the radio module's input resampler for the effective sample rate.
-    let effective_rate = state.frontend.effective_sample_rate();
-    if let Err(e) = state.radio.set_input_sample_rate(effective_rate) {
-        tracing::warn!("failed to set radio input sample rate: {e}");
-    }
+    // Build the RxVfo and configure RadioModule to receive at the demod IF rate.
+    rebuild_vfo(state)?;
 
     tracing::info!(
         sample_rate = state.sample_rate,
@@ -462,14 +505,38 @@ fn rebuild_frontend(state: &mut DspState) -> Result<(), String> {
 
     new_frontend.set_invert_iq(state.invert_iq);
     state.frontend = new_frontend;
+    Ok(())
+}
 
-    // Update the radio module's input resampler for the new effective rate.
+/// Build or rebuild the `RxVfo` from the current frontend and demod configuration.
+///
+/// Also tells `RadioModule` that its input is now at the demod IF rate (since the
+/// VFO handles resampling from the frontend effective rate to the IF rate).
+fn rebuild_vfo(state: &mut DspState) -> Result<(), String> {
     let effective_rate = state.frontend.effective_sample_rate();
+    let demod_cfg = state.radio.demod_config();
+    let if_rate = demod_cfg.if_sample_rate;
+    let bandwidth = demod_cfg.default_bandwidth;
+
+    let vfo = RxVfo::new(effective_rate, if_rate, bandwidth, state.vfo_offset)
+        .map_err(|e| format!("RxVfo build: {e}"))?;
+
+    state.vfo = Some(vfo);
+
+    // Tell RadioModule it receives samples at the demod IF rate — no internal
+    // resampling needed since the VFO already handled it.
     state
         .radio
-        .set_input_sample_rate(effective_rate)
-        .map_err(|e| format!("radio input resample: {e}"))?;
+        .set_input_sample_rate(if_rate)
+        .map_err(|e| format!("radio input rate: {e}"))?;
 
+    tracing::debug!(
+        frontend_rate = effective_rate,
+        if_rate,
+        bandwidth,
+        offset = state.vfo_offset,
+        "RxVfo rebuilt"
+    );
     Ok(())
 }
 
@@ -517,19 +584,44 @@ fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
                 let _ = dsp_tx.send(DspToUi::FftData(state.fft_buf.clone()));
             }
 
-            // Process through radio module for audio output.
             if processed_count > 0 {
-                let max_out = state.radio.max_output_samples(processed_count);
+                // Pass through RxVfo: frequency translate, resample, channel filter.
+                let radio_input = if let Some(vfo) = &mut state.vfo {
+                    // Size VFO output buffer generously for resampling expansion.
+                    let demod_cfg = state.radio.demod_config();
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_sign_loss,
+                        clippy::cast_precision_loss
+                    )]
+                    let ratio = (demod_cfg.if_sample_rate / state.frontend.effective_sample_rate())
+                        .ceil() as usize;
+                    let vfo_out_size = processed_count * ratio.max(1) + VFO_OUTPUT_PADDING;
+                    state.vfo_buf.resize(vfo_out_size, Complex::default());
+
+                    match vfo.process(&state.processed_buf[..processed_count], &mut state.vfo_buf) {
+                        Ok(vfo_count) => &state.vfo_buf[..vfo_count],
+                        Err(e) => {
+                            tracing::warn!("VFO processing error: {e}");
+                            return;
+                        }
+                    }
+                } else {
+                    // No VFO configured — pass frontend output directly (fallback).
+                    &state.processed_buf[..processed_count]
+                };
+
+                // Process through radio module for audio output.
+                let max_out = state.radio.max_output_samples(radio_input.len());
                 state.audio_buf.resize(max_out, Stereo::default());
-                match state.radio.process(
-                    &state.processed_buf[..processed_count],
-                    &mut state.audio_buf,
-                ) {
+                match state.radio.process(radio_input, &mut state.audio_buf) {
                     Ok(audio_count) => {
-                        // Apply volume scaling.
+                        // Apply volume with perceptual (power-law) scaling.
+                        // Quadratic curve maps the linear slider to perceived loudness.
+                        let vol = state.volume * state.volume;
                         for s in &mut state.audio_buf[..audio_count] {
-                            s.l *= state.volume;
-                            s.r *= state.volume;
+                            s.l *= vol;
+                            s.r *= vol;
                         }
 
                         // Send to PipeWire for playback.
@@ -553,7 +645,7 @@ fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
                         tracing::warn!("radio processing error: {e}");
                     }
                 }
-            }
+            } // end if processed_count > 0
         }
         Err(e) => {
             tracing::warn!("frontend processing error: {e}");
@@ -562,7 +654,7 @@ fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::cast_precision_loss)]
 mod tests {
     use super::*;
 
@@ -574,6 +666,7 @@ mod tests {
         assert!(DEFAULT_CENTER_FREQ > 0.0);
         assert!(IDLE_SLEEP_MS > 0);
         assert!(RECV_TIMEOUT_MS > 0);
+        assert!(VFO_OUTPUT_PADDING > 0);
     };
 
     #[test]
@@ -584,5 +677,110 @@ mod tests {
         assert_eq!(state.raw_buf.len(), RAW_BUF_SIZE);
         assert_eq!(state.iq_buf.len(), IQ_PAIRS_PER_READ);
         assert_eq!(state.fft_buf.len(), DEFAULT_FFT_SIZE);
+        // VFO starts as None (created on device open).
+        assert!(state.vfo.is_none());
+        assert!((state.vfo_offset - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn rebuild_vfo_creates_vfo_and_sets_radio_rate() {
+        let mut state = DspState::new().unwrap();
+        // Simulate what open_device does: frontend is already built at default rate.
+        rebuild_vfo(&mut state).unwrap();
+        assert!(state.vfo.is_some());
+    }
+
+    #[test]
+    fn rebuild_vfo_after_mode_switch_changes_rates() {
+        let mut state = DspState::new().unwrap();
+        // Start with NFM (default) — IF rate 50 kHz
+        rebuild_vfo(&mut state).unwrap();
+
+        // Switch to WFM — IF rate 250 kHz
+        state.radio.set_mode(sdr_types::DemodMode::Wfm).unwrap();
+        rebuild_vfo(&mut state).unwrap();
+        assert!(state.vfo.is_some());
+
+        // Switch to NFM — IF rate 50 kHz (different from WFM)
+        state.radio.set_mode(sdr_types::DemodMode::Nfm).unwrap();
+        rebuild_vfo(&mut state).unwrap();
+        assert!(state.vfo.is_some());
+    }
+
+    #[test]
+    fn vfo_preserves_signal_at_zero_offset() {
+        // Create an RxVfo at same in/out rate, full bandwidth, offset 0.
+        // The signal at DC should pass through essentially unchanged.
+        let rate = 250_000.0;
+        let mut vfo = RxVfo::new(rate, rate, rate, 0.0).unwrap();
+        let input = vec![Complex::new(1.0, 0.0); 1000];
+        let mut output = vec![Complex::default(); 1100];
+        let count = vfo.process(&input, &mut output).unwrap();
+        assert_eq!(count, 1000);
+        // DC signal at zero offset should pass through with ~unity amplitude.
+        for (i, s) in output[..count].iter().enumerate() {
+            assert!(
+                s.amplitude() > 0.9,
+                "sample {i}: amplitude {} too low",
+                s.amplitude()
+            );
+        }
+    }
+
+    #[test]
+    fn vfo_translates_offset_signal_to_baseband() {
+        // Generate a tone at +10 kHz offset within a 250 kHz stream.
+        // Set VFO offset to +10 kHz so the tone lands at DC after translation.
+        let in_rate = 250_000.0;
+        let offset_hz = 10_000.0;
+        let n = 2500;
+
+        // Generate a pure tone at +offset_hz.
+        let input: Vec<Complex> = (0..n)
+            .map(|i| {
+                let phase = 2.0 * std::f64::consts::PI * offset_hz * (i as f64) / in_rate;
+                #[allow(clippy::cast_possible_truncation)]
+                Complex::new(phase.cos() as f32, phase.sin() as f32)
+            })
+            .collect();
+
+        let mut vfo = RxVfo::new(in_rate, in_rate, in_rate, offset_hz).unwrap();
+        let mut output = vec![Complex::default(); n + 100];
+        let count = vfo.process(&input, &mut output).unwrap();
+        assert!(count > 0);
+
+        // After translation by -offset_hz, the signal should be near DC.
+        // Skip the first few samples (filter settling) and check that the
+        // imaginary part is small (signal is near real-only at DC).
+        let settle = count / 4;
+        let avg_imag: f32 = output[settle..count]
+            .iter()
+            .map(|s| s.im.abs())
+            .sum::<f32>()
+            / (count - settle) as f32;
+        assert!(
+            avg_imag < 0.15,
+            "after translation, signal should be near DC — avg |imag| = {avg_imag}"
+        );
+    }
+
+    #[test]
+    fn vfo_resamples_250k_to_50k() {
+        // Simulates WFM frontend (250 kHz) feeding NFM demod (50 kHz).
+        let in_rate = 250_000.0;
+        let out_rate = 50_000.0;
+        let bandwidth = 12_500.0;
+        let n = 2500; // 10 ms at 250 kHz
+
+        let mut vfo = RxVfo::new(in_rate, out_rate, bandwidth, 0.0).unwrap();
+        let input = vec![Complex::new(1.0, 0.0); n];
+        let mut output = vec![Complex::default(); n]; // more than enough
+        let count = vfo.process(&input, &mut output).unwrap();
+
+        // Expected ~500 samples (2500 * 50k/250k)
+        assert!(
+            (400..=600).contains(&count),
+            "expected ~500 samples at 50 kHz, got {count}"
+        );
     }
 }

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -63,6 +63,8 @@ pub enum UiToDsp {
     SetIqCorrection(bool),
     /// Set the FFT window function.
     SetWindowFunction(sdr_pipeline::iq_frontend::FftWindow),
+    /// Set the VFO frequency offset from center in Hz (for click-to-tune).
+    SetVfoOffset(f64),
 }
 
 #[cfg(test)]
@@ -159,5 +161,8 @@ mod tests {
             wf,
             UiToDsp::SetWindowFunction(sdr_pipeline::iq_frontend::FftWindow::Blackman)
         ));
+
+        let vfo = UiToDsp::SetVfoOffset(25_000.0);
+        assert!(matches!(vfo, UiToDsp::SetVfoOffset(o) if (o - 25_000.0).abs() < f64::EPSILON));
     }
 }


### PR DESCRIPTION
## Summary

Major signal chain fix plus all DSP audit items from issue #90.

### Signal Chain (root cause of "static" audio)
- **Wire RxVFO** between IqFrontend and RadioModule — provides frequency translation, channel filtering, and resampling that was completely missing
- Rebuild VFO on mode switch, sample rate change, decimation change
- Add `SetVfoOffset` message for future click-to-tune support

### WFM Demod Fixes
- Add **15 kHz lowpass filter** after FM discriminator (removes pilot tone, stereo subcarrier, RDS, broadband noise — this was the primary cause of "station under static")
- Fix **deemphasis sample rate** — now runs at 48 kHz after resampling (was 250 kHz, ~4x too aggressive)
- Fix WFM config flags to match C++ (fm_if_nr_allowed, nb_allowed, high_pass)

### DSP Audit Fixes (issue #90)
- **NoiseBlanker**: guard EMA update with `in_amp != 0` matching C++ behavior
- **SSB AGC**: add AGC to USB/LSB/DSB demodulators (SSB unusable without it)
- **AM AGC**: add AGC to AM demodulator for consistent audio levels
- **NFM deviation**: `set_bandwidth()` now rebuilds FmDemod with `bw/2` as deviation
- **FM IF Noise Reduction**: replace passthrough stub with FFT-based peak tracking implementation
- **ComplexFirFilter**: add `set_taps()` for runtime filter reconfiguration
- **Volume**: quadratic (perceptual) scaling instead of linear

### Tuner Fixes
- R82XX PLL `saturating_add` to prevent overflow panics on out-of-range frequencies

791 lines changed across 13 files

Closes #88, closes #89, partially addresses #90

## Test plan

- [x] All workspace tests pass
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --all -- --check` passes
- [ ] Manual: FM broadcast audio quality improved
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AGC added to AM, DSB, LSB and USB demodulators
  * VFO support with a new UI control to set VFO offset
  * FFT-based FM IF noise reduction
  * Runtime FIR tap replacement for complex filters
  * WFM now applies a 15 kHz low-pass audio filter

* **Bug Fixes**
  * NFM bandwidth changes now take effect
  * Improved handling of silent/zero-input in noise blanking

* **Improvements**
  * Volume scaling now perceptual (power-law)
  * Resample-before-deemphasis audio pipeline; default sample rate adjusted to 2.0 Msps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->