### PR TITLE
Wire UI controls to DSP: click-to-tune, stereo, NB level, FFT rate

### DIFF
--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -123,6 +123,9 @@ pub trait Demodulator {
 
     /// Human-readable name of this demod mode.
     fn name(&self) -> &'static str;
+
+    /// Enable or disable stereo decode (WFM only, no-op for other modes).
+    fn set_stereo(&mut self, _enabled: bool) {}
 }
 
 /// Create a boxed demodulator for the given mode.

--- a/crates/sdr-radio/src/demod/wfm.rs
+++ b/crates/sdr-radio/src/demod/wfm.rs
@@ -171,6 +171,10 @@ impl Demodulator for WfmDemodulator {
     fn name(&self) -> &'static str {
         "WFM"
     }
+
+    fn set_stereo(&mut self, enabled: bool) {
+        WfmDemodulator::set_stereo(self, enabled);
+    }
 }
 
 #[cfg(test)]

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -325,6 +325,14 @@ impl RadioModule {
         Ok(())
     }
 
+    /// Enable or disable WFM stereo decode.
+    ///
+    /// Only has an effect when the current mode is WFM. For other modes this
+    /// is a no-op via the default trait implementation.
+    pub fn set_wfm_stereo(&mut self, enabled: bool) {
+        self.demod.set_stereo(enabled);
+    }
+
     /// Get the current demodulation mode.
     pub fn current_mode(&self) -> DemodMode {
         self.mode

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -460,6 +460,24 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 vfo.set_offset(offset);
             }
         }
+
+        UiToDsp::SetNbLevel(level) => {
+            tracing::debug!(level, "set noise blanker level");
+            if let Err(e) = state.radio.if_chain_mut().set_nb_level(level) {
+                tracing::warn!("set NB level failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("NB level failed: {e}")));
+            }
+        }
+
+        UiToDsp::SetWfmStereo(enabled) => {
+            tracing::debug!(enabled, "set WFM stereo");
+            state.radio.set_wfm_stereo(enabled);
+        }
+
+        UiToDsp::SetFftRate(fps) => {
+            tracing::debug!(fps, "set FFT rate");
+            state.frontend.set_fft_rate(fps);
+        }
     }
 }
 

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -65,6 +65,12 @@ pub enum UiToDsp {
     SetWindowFunction(sdr_pipeline::iq_frontend::FftWindow),
     /// Set the VFO frequency offset from center in Hz (for click-to-tune).
     SetVfoOffset(f64),
+    /// Set the noise blanker level (threshold multiplier, >= 1.0).
+    SetNbLevel(f32),
+    /// Enable or disable WFM stereo decode.
+    SetWfmStereo(bool),
+    /// Set the FFT display frame rate (FPS).
+    SetFftRate(f64),
 }
 
 #[cfg(test)]
@@ -164,5 +170,14 @@ mod tests {
 
         let vfo = UiToDsp::SetVfoOffset(25_000.0);
         assert!(matches!(vfo, UiToDsp::SetVfoOffset(o) if (o - 25_000.0).abs() < f64::EPSILON));
+
+        let nb = UiToDsp::SetNbLevel(5.0);
+        assert!(matches!(nb, UiToDsp::SetNbLevel(l) if (l - 5.0).abs() < f32::EPSILON));
+
+        let stereo = UiToDsp::SetWfmStereo(true);
+        assert!(matches!(stereo, UiToDsp::SetWfmStereo(true)));
+
+        let fft_rate = UiToDsp::SetFftRate(30.0);
+        assert!(matches!(fft_rate, UiToDsp::SetFftRate(r) if (r - 30.0).abs() < f64::EPSILON));
     }
 }

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -14,6 +14,13 @@ const BANDWIDTH_STEP_HZ: f64 = 100.0;
 /// Bandwidth page increment in Hz (scroll/page-up/down).
 const BANDWIDTH_PAGE_HZ: f64 = 1_000.0;
 
+/// Default noise blanker level (threshold multiplier).
+const DEFAULT_NB_LEVEL: f64 = 5.0;
+/// Minimum noise blanker level.
+const MIN_NB_LEVEL: f64 = 1.0;
+/// Maximum noise blanker level.
+const MAX_NB_LEVEL: f64 = 20.0;
+
 /// Default squelch level in dB.
 const DEFAULT_SQUELCH_DB: f64 = -100.0;
 /// Minimum squelch level in dB.
@@ -39,8 +46,12 @@ pub struct RadioPanel {
     pub deemphasis_row: adw::ComboRow,
     /// Noise blanker toggle.
     pub noise_blanker_row: adw::SwitchRow,
+    /// Noise blanker level control (visible when NB is enabled).
+    pub nb_level_row: adw::SpinRow,
     /// FM IF noise reduction toggle (visible only for FM modes).
     pub fm_if_nr_row: adw::SwitchRow,
+    /// WFM stereo decode toggle (visible only for WFM mode).
+    pub stereo_row: adw::SwitchRow,
 }
 
 impl RadioPanel {
@@ -51,6 +62,11 @@ impl RadioPanel {
     pub fn set_fm_controls_visible(&self, visible: bool) {
         self.deemphasis_row.set_visible(visible);
         self.fm_if_nr_row.set_visible(visible);
+    }
+
+    /// Show or hide WFM-specific controls.
+    pub fn set_wfm_controls_visible(&self, visible: bool) {
+        self.stereo_row.set_visible(visible);
     }
 }
 
@@ -106,10 +122,27 @@ pub fn build_radio_panel() -> RadioPanel {
     // --- Noise Blanker ---
     let noise_blanker_row = adw::SwitchRow::builder().title("Noise Blanker").build();
 
+    // --- Noise Blanker Level ---
+    let nb_level_adj =
+        gtk4::Adjustment::new(DEFAULT_NB_LEVEL, MIN_NB_LEVEL, MAX_NB_LEVEL, 0.5, 1.0, 0.0);
+    let nb_level_row = adw::SpinRow::builder()
+        .title("NB Level")
+        .subtitle("Threshold multiplier")
+        .adjustment(&nb_level_adj)
+        .digits(1)
+        .build();
+
     // --- FM IF Noise Reduction ---
     let fm_if_nr_row = adw::SwitchRow::builder()
         .title("FM IF NR")
         .subtitle("IF noise reduction for FM modes")
+        .build();
+
+    // --- WFM Stereo ---
+    let stereo_row = adw::SwitchRow::builder()
+        .title("Stereo")
+        .subtitle("WFM stereo decode")
+        .visible(false) // Only shown in WFM mode
         .build();
 
     group.add(&bandwidth_row);
@@ -117,7 +150,9 @@ pub fn build_radio_panel() -> RadioPanel {
     group.add(&squelch_level_row);
     group.add(&deemphasis_row);
     group.add(&noise_blanker_row);
+    group.add(&nb_level_row);
     group.add(&fm_if_nr_row);
+    group.add(&stereo_row);
 
     // All rows connected to DSP pipeline via window.rs
 
@@ -128,7 +163,9 @@ pub fn build_radio_panel() -> RadioPanel {
         squelch_level_row,
         deemphasis_row,
         noise_blanker_row,
+        nb_level_row,
         fm_if_nr_row,
+        stereo_row,
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -203,5 +203,7 @@ mod tests {
         assert!(super::MIN_NB_LEVEL <= super::MAX_NB_LEVEL);
         assert!(super::DEFAULT_NB_LEVEL >= super::MIN_NB_LEVEL);
         assert!(super::DEFAULT_NB_LEVEL <= super::MAX_NB_LEVEL);
+        assert!(super::NB_LEVEL_STEP > 0.0);
+        assert!(super::NB_LEVEL_PAGE > 0.0);
     };
 }

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -186,4 +186,12 @@ mod tests {
         assert!(super::DEFAULT_SQUELCH_DB <= super::MAX_SQUELCH_DB);
         assert!(super::SQUELCH_STEP_DB > 0.0);
     };
+
+    /// Compile-time validation that NB level constants are consistent.
+    const _: () = {
+        assert!(super::MIN_NB_LEVEL >= 1.0); // NoiseBlanker requires >= 1.0
+        assert!(super::MIN_NB_LEVEL <= super::MAX_NB_LEVEL);
+        assert!(super::DEFAULT_NB_LEVEL >= super::MIN_NB_LEVEL);
+        assert!(super::DEFAULT_NB_LEVEL <= super::MAX_NB_LEVEL);
+    };
 }

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -37,6 +37,7 @@ const SQUELCH_STEP_DB: f64 = 1.0;
 const SQUELCH_PAGE_DB: f64 = 10.0;
 
 /// Radio / demodulator configuration panel with references to interactive rows.
+#[derive(Clone)]
 pub struct RadioPanel {
     /// The `AdwPreferencesGroup` widget to pack into the sidebar.
     pub widget: adw::PreferencesGroup,
@@ -59,18 +60,16 @@ pub struct RadioPanel {
 }
 
 impl RadioPanel {
-    /// Show or hide FM-specific controls based on the current demod mode.
+    /// Update mode-specific control visibility for the given demod mode.
     ///
-    /// Call this when the demod mode changes to show FM IF NR only for FM modes
-    /// (WFM and NFM).
-    pub fn set_fm_controls_visible(&self, visible: bool) {
-        self.deemphasis_row.set_visible(visible);
-        self.fm_if_nr_row.set_visible(visible);
-    }
-
-    /// Show or hide WFM-specific controls.
-    pub fn set_wfm_controls_visible(&self, visible: bool) {
-        self.stereo_row.set_visible(visible);
+    /// Centralizes FM/WFM visibility policy so startup and mode-switch
+    /// handlers stay in sync.
+    pub fn apply_demod_visibility(&self, mode: sdr_types::DemodMode) {
+        let is_fm = matches!(mode, sdr_types::DemodMode::Wfm | sdr_types::DemodMode::Nfm);
+        self.deemphasis_row.set_visible(is_fm);
+        self.fm_if_nr_row.set_visible(is_fm);
+        self.stereo_row
+            .set_visible(mode == sdr_types::DemodMode::Wfm);
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -20,6 +20,10 @@ const DEFAULT_NB_LEVEL: f64 = 5.0;
 const MIN_NB_LEVEL: f64 = 1.0;
 /// Maximum noise blanker level.
 const MAX_NB_LEVEL: f64 = 20.0;
+/// Noise blanker level step.
+const NB_LEVEL_STEP: f64 = 0.5;
+/// Noise blanker page increment.
+const NB_LEVEL_PAGE: f64 = 1.0;
 
 /// Default squelch level in dB.
 const DEFAULT_SQUELCH_DB: f64 = -100.0;
@@ -46,7 +50,7 @@ pub struct RadioPanel {
     pub deemphasis_row: adw::ComboRow,
     /// Noise blanker toggle.
     pub noise_blanker_row: adw::SwitchRow,
-    /// Noise blanker level control (visible when NB is enabled).
+    /// Noise blanker level control.
     pub nb_level_row: adw::SpinRow,
     /// FM IF noise reduction toggle (visible only for FM modes).
     pub fm_if_nr_row: adw::SwitchRow,
@@ -123,8 +127,14 @@ pub fn build_radio_panel() -> RadioPanel {
     let noise_blanker_row = adw::SwitchRow::builder().title("Noise Blanker").build();
 
     // --- Noise Blanker Level ---
-    let nb_level_adj =
-        gtk4::Adjustment::new(DEFAULT_NB_LEVEL, MIN_NB_LEVEL, MAX_NB_LEVEL, 0.5, 1.0, 0.0);
+    let nb_level_adj = gtk4::Adjustment::new(
+        DEFAULT_NB_LEVEL,
+        MIN_NB_LEVEL,
+        MAX_NB_LEVEL,
+        NB_LEVEL_STEP,
+        NB_LEVEL_PAGE,
+        0.0,
+    );
     let nb_level_row = adw::SpinRow::builder()
         .title("NB Level")
         .subtitle("Threshold multiplier")

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -21,6 +21,8 @@ use fft_plot::FftPlotRenderer;
 use vfo_overlay::{BwHandle, HitZone, VfoOverlayRenderer, VfoState};
 use waterfall::WaterfallRenderer;
 
+use crate::messages::UiToDsp;
+
 /// Number of FFT bins for the display (used for initial buffer sizing).
 const FFT_SIZE: usize = 1024;
 
@@ -83,7 +85,9 @@ impl SpectrumHandle {
 ///
 /// Returns a `(GtkPaned, SpectrumHandle)` — the paned widget for layout,
 /// and a handle for pushing real FFT data into the display.
-pub fn build_spectrum_view() -> (gtk4::Paned, SpectrumHandle) {
+pub fn build_spectrum_view(
+    dsp_tx: std::sync::mpsc::Sender<UiToDsp>,
+) -> (gtk4::Paned, SpectrumHandle) {
     let vfo_state: Rc<RefCell<VfoState>> = Rc::new(RefCell::new(VfoState::default()));
     let fft_state: Rc<RefCell<Option<FftPlotState>>> = Rc::new(RefCell::new(None));
     let waterfall_state: Rc<RefCell<Option<WaterfallState>>> = Rc::new(RefCell::new(None));
@@ -92,8 +96,8 @@ pub fn build_spectrum_view() -> (gtk4::Paned, SpectrumHandle) {
     let waterfall_area = build_waterfall_area(Rc::clone(&waterfall_state), Rc::clone(&vfo_state));
 
     // Attach interaction gestures to both the waterfall and FFT areas.
-    attach_click_gesture(&waterfall_area, &vfo_state);
-    attach_drag_gesture(&waterfall_area, &vfo_state);
+    attach_click_gesture(&waterfall_area, &vfo_state, dsp_tx.clone());
+    attach_drag_gesture(&waterfall_area, &vfo_state, dsp_tx);
     attach_scroll_gesture(&waterfall_area, &vfo_state);
 
     // Also attach scroll-to-zoom on the FFT area for convenience.
@@ -339,7 +343,11 @@ fn create_gl_context_and_waterfall_renderer()
 /// Attach a click-to-tune gesture to a `GtkGLArea`.
 ///
 /// Single-clicking sets the VFO center to the clicked frequency.
-fn attach_click_gesture(area: &gtk4::GLArea, vfo_state: &Rc<RefCell<VfoState>>) {
+fn attach_click_gesture(
+    area: &gtk4::GLArea,
+    vfo_state: &Rc<RefCell<VfoState>>,
+    dsp_tx: std::sync::mpsc::Sender<UiToDsp>,
+) {
     let click = gtk4::GestureClick::new();
 
     let vfo_state = Rc::clone(vfo_state);
@@ -352,11 +360,15 @@ fn attach_click_gesture(area: &gtk4::GLArea, vfo_state: &Rc<RefCell<VfoState>>) 
         let mut vfo = vfo_state.borrow_mut();
         let hz = vfo.pixel_to_hz(x, width);
         vfo.offset_hz = hz;
-        tracing::debug!(offset_hz = vfo.offset_hz, "click-to-tune");
+        let offset = vfo.offset_hz;
+        tracing::debug!(offset_hz = offset, "click-to-tune");
         drop(vfo);
 
-        // Request re-render. The periodic test-data timer also triggers
-        // re-renders of both areas, so the FFT plot overlay updates too.
+        // Send VFO offset to DSP thread for actual tuning
+        if let Err(e) = dsp_tx.send(UiToDsp::SetVfoOffset(offset)) {
+            tracing::warn!("click-to-tune DSP send failed: {e}");
+        }
+
         area.queue_render();
     });
 
@@ -364,7 +376,12 @@ fn attach_click_gesture(area: &gtk4::GLArea, vfo_state: &Rc<RefCell<VfoState>>) 
 }
 
 /// Attach a drag gesture for VFO center movement and bandwidth handle adjustment.
-fn attach_drag_gesture(area: &gtk4::GLArea, vfo_state: &Rc<RefCell<VfoState>>) {
+#[allow(clippy::needless_pass_by_value)]
+fn attach_drag_gesture(
+    area: &gtk4::GLArea,
+    vfo_state: &Rc<RefCell<VfoState>>,
+    dsp_tx: std::sync::mpsc::Sender<UiToDsp>,
+) {
     let drag = gtk4::GestureDrag::new();
 
     // Snapshot of VFO state at drag start, for computing deltas.
@@ -414,6 +431,7 @@ fn attach_drag_gesture(area: &gtk4::GLArea, vfo_state: &Rc<RefCell<VfoState>>) {
     let start_offset_update = Rc::clone(&drag_start_offset_hz);
     let start_bw_update = Rc::clone(&drag_start_bw_hz);
     let area_weak_update = area.downgrade();
+    let dsp_tx_update = dsp_tx.clone();
     drag.connect_drag_update(move |_gesture, offset_x, _offset_y| {
         let Some(area) = area_weak_update.upgrade() else {
             return;
@@ -424,6 +442,7 @@ fn attach_drag_gesture(area: &gtk4::GLArea, vfo_state: &Rc<RefCell<VfoState>>) {
         if vfo.dragging {
             let delta_hz = vfo.pixels_to_hz(offset_x, width);
             vfo.offset_hz = start_offset_update.get() + delta_hz;
+            let _ = dsp_tx_update.send(UiToDsp::SetVfoOffset(vfo.offset_hz));
             area.queue_render();
         } else if let Some(handle) = vfo.bw_dragging {
             let delta_hz = vfo.pixels_to_hz(offset_x, width);
@@ -457,6 +476,8 @@ fn attach_drag_gesture(area: &gtk4::GLArea, vfo_state: &Rc<RefCell<VfoState>>) {
                     }
                 }
             }
+            let _ = dsp_tx_update.send(UiToDsp::SetVfoOffset(vfo.offset_hz));
+            let _ = dsp_tx_update.send(UiToDsp::SetBandwidth(vfo.bandwidth_hz));
             area.queue_render();
         }
     });

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -12,6 +12,7 @@ use libadwaita::prelude::*;
 use sdr_pipeline::iq_frontend::FftWindow;
 use sdr_radio::DeemphasisMode;
 use sdr_source_rtlsdr::SAMPLE_RATES;
+use sdr_types::DemodMode;
 
 use crate::dsp_controller;
 use crate::header;
@@ -50,7 +51,7 @@ pub fn build_window(app: &adw::Application) {
     let state = AppState::new_shared(ui_tx);
 
     // --- Build UI ---
-    let (split_view, panels, spectrum_handle, status_bar) = build_split_view();
+    let (split_view, panels, spectrum_handle, status_bar) = build_split_view(&state);
     let sidebar_toggle = build_sidebar_toggle(&split_view);
     let (header, play_button, demod_dropdown, freq_selector) =
         build_header_bar(&sidebar_toggle, &state);
@@ -106,11 +107,20 @@ pub fn build_window(app: &adw::Application) {
     });
     let status_bar_for_demod = Rc::clone(&status_bar_demod);
     let bw_row_for_demod = panels.radio.bandwidth_row.clone();
+    let stereo_row_for_demod = panels.radio.stereo_row.clone();
+    let fm_controls_deemp = panels.radio.deemphasis_row.clone();
+    let fm_controls_nr = panels.radio.fm_if_nr_row.clone();
     demod_dropdown.connect_selected_notify(move |dd| {
         if let Some(mode) = demod_selector::index_to_demod_mode(dd.selected()) {
             let label = header::demod_mode_label(mode);
             let bw = bw_row_for_demod.value();
             status_bar_for_demod.update_demod(label, bw);
+
+            // Show/hide mode-specific controls
+            let is_fm = mode == DemodMode::Wfm || mode == DemodMode::Nfm;
+            fm_controls_deemp.set_visible(is_fm);
+            fm_controls_nr.set_visible(is_fm);
+            stereo_row_for_demod.set_visible(mode == DemodMode::Wfm);
         }
     });
 
@@ -204,7 +214,9 @@ fn handle_dsp_message(
 /// and status bar.
 ///
 /// Returns the split view, sidebar panels, spectrum display handle, and status bar.
-fn build_split_view() -> (
+fn build_split_view(
+    state: &Rc<AppState>,
+) -> (
     adw::OverlaySplitView,
     SidebarPanels,
     spectrum::SpectrumHandle,
@@ -214,7 +226,7 @@ fn build_split_view() -> (
     let (sidebar_scroll, panels) = sidebar::build_sidebar();
 
     // Main content area — spectrum display (FFT plot + waterfall) + status bar.
-    let (spectrum_view, spectrum_handle) = spectrum::build_spectrum_view();
+    let (spectrum_view, spectrum_handle) = spectrum::build_spectrum_view(state.ui_tx.clone());
     spectrum_view.add_css_class("spectrum-area");
 
     // Status bar at the bottom.
@@ -505,10 +517,23 @@ fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             state_noise_blanker.send_dsp(UiToDsp::SetNbEnabled(row.is_active()));
         });
 
+    // Noise blanker level
+    let state_nb_level = Rc::clone(state);
+    panels.radio.nb_level_row.connect_value_notify(move |row| {
+        #[allow(clippy::cast_possible_truncation)]
+        state_nb_level.send_dsp(UiToDsp::SetNbLevel(row.value() as f32));
+    });
+
     // FM IF NR
     let state_fm_nr = Rc::clone(state);
     panels.radio.fm_if_nr_row.connect_active_notify(move |row| {
         state_fm_nr.send_dsp(UiToDsp::SetFmIfNrEnabled(row.is_active()));
+    });
+
+    // WFM Stereo
+    let state_stereo = Rc::clone(state);
+    panels.radio.stereo_row.connect_active_notify(move |row| {
+        state_stereo.send_dsp(UiToDsp::SetWfmStereo(row.is_active()));
     });
 }
 
@@ -543,6 +568,15 @@ fn connect_display_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             if let Some(&window) = WINDOW_FUNCTIONS.get(idx) {
                 state_wf.send_dsp(UiToDsp::SetWindowFunction(window));
             }
+        });
+
+    // Frame rate (FFT rate control)
+    let state_fps = Rc::clone(state);
+    panels
+        .display
+        .frame_rate_row
+        .connect_value_notify(move |row| {
+            state_fps.send_dsp(UiToDsp::SetFftRate(row.value()));
         });
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -72,11 +72,18 @@ pub fn build_window(app: &adw::Application) {
 
     window.add_breakpoint(breakpoint);
 
-    // Set initial status bar values from the actual UI state.
+    // Set initial status bar values and mode-specific control visibility.
     if let Some(mode) = demod_selector::index_to_demod_mode(demod_dropdown.selected()) {
         let label = header::demod_mode_label(mode);
         let bw = panels.radio.bandwidth_row.value();
         status_bar.update_demod(label, bw);
+
+        // Sync initial visibility for mode-specific controls
+        let is_fm = mode == DemodMode::Wfm || mode == DemodMode::Nfm;
+        panels.radio.set_fm_controls_visible(is_fm);
+        panels
+            .radio
+            .set_wfm_controls_visible(mode == DemodMode::Wfm);
     }
     #[allow(clippy::cast_precision_loss)]
     status_bar.update_frequency(freq_selector.frequency() as f64);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -12,7 +12,6 @@ use libadwaita::prelude::*;
 use sdr_pipeline::iq_frontend::FftWindow;
 use sdr_radio::DeemphasisMode;
 use sdr_source_rtlsdr::SAMPLE_RATES;
-use sdr_types::DemodMode;
 
 use crate::dsp_controller;
 use crate::header;
@@ -78,12 +77,7 @@ pub fn build_window(app: &adw::Application) {
         let bw = panels.radio.bandwidth_row.value();
         status_bar.update_demod(label, bw);
 
-        // Sync initial visibility for mode-specific controls
-        let is_fm = mode == DemodMode::Wfm || mode == DemodMode::Nfm;
-        panels.radio.set_fm_controls_visible(is_fm);
-        panels
-            .radio
-            .set_wfm_controls_visible(mode == DemodMode::Wfm);
+        panels.radio.apply_demod_visibility(mode);
     }
     #[allow(clippy::cast_precision_loss)]
     status_bar.update_frequency(freq_selector.frequency() as f64);
@@ -114,20 +108,13 @@ pub fn build_window(app: &adw::Application) {
     });
     let status_bar_for_demod = Rc::clone(&status_bar_demod);
     let bw_row_for_demod = panels.radio.bandwidth_row.clone();
-    let stereo_row_for_demod = panels.radio.stereo_row.clone();
-    let fm_controls_deemp = panels.radio.deemphasis_row.clone();
-    let fm_controls_nr = panels.radio.fm_if_nr_row.clone();
+    let radio_for_demod = panels.radio.clone();
     demod_dropdown.connect_selected_notify(move |dd| {
         if let Some(mode) = demod_selector::index_to_demod_mode(dd.selected()) {
             let label = header::demod_mode_label(mode);
             let bw = bw_row_for_demod.value();
             status_bar_for_demod.update_demod(label, bw);
-
-            // Show/hide mode-specific controls
-            let is_fm = mode == DemodMode::Wfm || mode == DemodMode::Nfm;
-            fm_controls_deemp.set_visible(is_fm);
-            fm_controls_nr.set_visible(is_fm);
-            stereo_row_for_demod.set_visible(mode == DemodMode::Wfm);
+            radio_for_demod.apply_demod_visibility(mode);
         }
     });
 


### PR DESCRIPTION
## Summary

Wires 4 previously inert UI controls to the DSP pipeline:

- **#108 Click-to-tune** — spectrum click/drag gestures now send `SetVfoOffset` and `SetBandwidth` to DSP (was visual-only). Click sets VFO center, passband drag moves it, handle drag adjusts bandwidth.
- **#106 WFM stereo toggle** — new `AdwSwitchRow` in radio panel, `SetWfmStereo` message, `Demodulator` trait `set_stereo()` method. Only visible in WFM mode.
- **#107 NB level control** — new `AdwSpinRow` (1.0–20.0) in radio panel with `SetNbLevel` message.
- **#105 FFT rate control** — `frame_rate_row` wired to `SetFftRate` message in display panel.

Also adds mode-specific control visibility: stereo shown only for WFM, deemphasis/FM IF NR shown only for FM modes.

**Remaining open issues (separate PRs):**
- #109: Device/audio source switching (needs source manager infrastructure)
- #110: PipeWire device enumeration (needs pipewire-rs API work)

## Test plan

- [x] All 488 workspace tests pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual: click waterfall to tune, verify audio follows
- [ ] Manual: enable WFM stereo toggle, verify L/R separation
- [ ] Manual: adjust NB level slider, verify effect on noise
- [ ] Manual: adjust FFT frame rate, verify spectrum update speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WFM stereo toggle added to the radio panel and wired through the app to enable/disable stereo decoding; FM-specific controls now show/hide by demodulation mode
  * Noise‑blanker level control with step/page adjustments
  * FFT frame‑rate control for display refresh
  * Spectrum click/drag now updates VFO offset and bandwidth and sends updates to DSP

* **Tests**
  * UI→DSP message variants updated and covered to include the new controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->