### PR TITLE
Driver fixes: tuner PLL overflow, DC blocker, network sink, resampler

### DIFF
--- a/crates/sdr-dsp/src/correction.rs
+++ b/crates/sdr-dsp/src/correction.rs
@@ -6,20 +6,26 @@ use sdr_types::{Complex, DspError};
 
 /// DC blocking filter — removes DC offset from a signal.
 ///
-/// Ports SDR++ `dsp::correction::DCBlocker`. Implements a simple
-/// feedback loop: `out[i] = in[i] - offset; offset += out[i] * rate`.
+/// Uses the Julius O. Smith textbook topology:
+/// `y[n] = x[n] - x[n-1] + R * y[n-1]`
+/// where `R = 1 - (2π × cutoff / sample_rate)`.
 ///
-/// The `rate` parameter controls convergence speed. Typical values:
-/// - Direct rate: 0.0001 to 0.01
-/// - Or computed as `rate_hz / sample_rate` (e.g., 1.0 / 48000.0)
+/// This filter has an explicit zero at DC (z=1), guaranteeing perfect
+/// DC rejection at steady state. The pole near z=R provides the
+/// high-pass cutoff frequency.
 pub struct DcBlocker {
-    rate: f32,
-    offset_re: f32,
-    offset_im: f32,
+    r: f32,
+    last_in_re: f32,
+    last_in_im: f32,
+    last_out_re: f32,
+    last_out_im: f32,
 }
 
 impl DcBlocker {
     /// Create a new DC blocker with the given convergence rate.
+    ///
+    /// The `rate` parameter sets the cutoff: `R = 1 - rate`.
+    /// Typical values: 0.0001 to 0.01 (lower = narrower notch at DC).
     ///
     /// # Errors
     ///
@@ -32,9 +38,11 @@ impl DcBlocker {
             )));
         }
         Ok(Self {
-            rate: rate as f32,
-            offset_re: 0.0,
-            offset_im: 0.0,
+            r: (1.0 - rate) as f32,
+            last_in_re: 0.0,
+            last_in_im: 0.0,
+            last_out_re: 0.0,
+            last_out_im: 0.0,
         })
     }
 
@@ -47,10 +55,12 @@ impl DcBlocker {
         Self::new(rate_hz / sample_rate)
     }
 
-    /// Reset the DC offset estimate to zero.
+    /// Reset the DC blocker state.
     pub fn reset(&mut self) {
-        self.offset_re = 0.0;
-        self.offset_im = 0.0;
+        self.last_in_re = 0.0;
+        self.last_in_im = 0.0;
+        self.last_out_re = 0.0;
+        self.last_out_im = 0.0;
     }
 
     /// Process complex samples, removing DC offset.
@@ -70,10 +80,13 @@ impl DcBlocker {
             });
         }
         for (i, &s) in input.iter().enumerate() {
-            let out_re = s.re - self.offset_re;
-            let out_im = s.im - self.offset_im;
-            self.offset_re += out_re * self.rate;
-            self.offset_im += out_im * self.rate;
+            // y[n] = x[n] - x[n-1] + R * y[n-1]
+            let out_re = s.re - self.last_in_re + self.r * self.last_out_re;
+            let out_im = s.im - self.last_in_im + self.r * self.last_out_im;
+            self.last_in_re = s.re;
+            self.last_in_im = s.im;
+            self.last_out_re = out_re;
+            self.last_out_im = out_im;
             output[i] = Complex::new(out_re, out_im);
         }
         Ok(input.len())
@@ -110,6 +123,23 @@ mod tests {
     }
 
     #[test]
+    fn test_dc_blocker_perfect_dc_rejection() {
+        // The textbook topology has an explicit zero at DC — verify
+        // that steady-state DC is perfectly rejected (not just reduced).
+        let mut dc = DcBlocker::new(0.001).unwrap();
+        let input = vec![Complex::new(1.0, 0.5); 50_000];
+        let mut output = vec![Complex::default(); 50_000];
+        dc.process(&input, &mut output).unwrap();
+        // With the zero at DC, the output converges to exactly 0.0
+        let last = output[49_999];
+        assert!(
+            last.re.abs() < 0.01,
+            "DC should be perfectly rejected, re = {}",
+            last.re
+        );
+    }
+
+    #[test]
     fn test_dc_blocker_passes_ac() {
         let mut dc = DcBlocker::new(0.001).unwrap();
         // AC signal (alternating) with no DC
@@ -136,7 +166,7 @@ mod tests {
         let mut output = vec![Complex::default(); 100];
         dc.process(&input, &mut output).unwrap();
         dc.reset();
-        // After reset, offset should be zero again
+        // After reset, state should be zero
         let zeros = vec![Complex::new(0.0, 0.0); 10];
         let mut out2 = vec![Complex::default(); 10];
         dc.process(&zeros, &mut out2).unwrap();

--- a/crates/sdr-dsp/src/multirate.rs
+++ b/crates/sdr-dsp/src/multirate.rs
@@ -73,7 +73,6 @@ pub struct PolyphaseResampler {
     delay_line: Vec<Complex>,
     phase: usize,
     offset: usize,
-    work_buf: Vec<Complex>,
 }
 
 impl PolyphaseResampler {
@@ -109,7 +108,6 @@ impl PolyphaseResampler {
             delay_line,
             phase: 0,
             offset: 0,
-            work_buf: Vec::new(),
         })
     }
 
@@ -154,31 +152,28 @@ impl PolyphaseResampler {
         let tpp = self.bank.taps_per_phase;
         let delay_len = tpp - 1;
 
-        // Reuse pre-allocated work buffer: delay_line + input
-        self.work_buf.clear();
-        self.work_buf.reserve(delay_len + input.len());
-        self.work_buf
-            .extend_from_slice(&self.delay_line[..delay_len]);
-        self.work_buf.extend_from_slice(input);
-        let work = &self.work_buf;
-
+        // Convolve directly from delay_line + input without building a
+        // concatenated work buffer. Avoids per-call copy of the delay line.
         let mut out_count = 0;
 
         while self.offset < input.len() {
-            // Convolve with current phase
             let phase_taps = &self.bank.phases[self.phase];
             let buf_start = self.offset;
             let mut acc_re = 0.0_f32;
             let mut acc_im = 0.0_f32;
             for (j, &tap) in phase_taps.iter().enumerate() {
-                let s = work[buf_start + j];
+                let idx = buf_start + j;
+                let s = if idx < delay_len {
+                    self.delay_line[idx]
+                } else {
+                    input[idx - delay_len]
+                };
                 acc_re += s.re * tap;
                 acc_im += s.im * tap;
             }
             output[out_count] = Complex::new(acc_re, acc_im);
             out_count += 1;
 
-            // Advance phase and offset
             self.phase += self.decim;
             self.offset += self.phase / self.interp;
             self.phase %= self.interp;
@@ -186,10 +181,13 @@ impl PolyphaseResampler {
 
         self.offset -= input.len();
 
-        // Update delay line: keep last (tpp - 1) samples from work buffer
-        let work_len = work.len();
-        if work_len >= delay_len {
-            self.delay_line[..delay_len].copy_from_slice(&work[work_len - delay_len..]);
+        // Update delay line: keep last (tpp - 1) input samples
+        if input.len() >= delay_len {
+            self.delay_line[..delay_len].copy_from_slice(&input[input.len() - delay_len..]);
+        } else if delay_len > 0 {
+            let shift = delay_len - input.len();
+            self.delay_line.copy_within(input.len().., 0);
+            self.delay_line[shift..].copy_from_slice(input);
         }
 
         Ok(out_count)

--- a/crates/sdr-rtlsdr/src/tuner/e4k.rs
+++ b/crates/sdr-rtlsdr/src/tuner/e4k.rs
@@ -779,19 +779,20 @@ impl E4kTuner {
 
         // Compute fractional part (remainder < fosc, so x < PLL_Y, fits in u16)
         let remainder = intended_fvco - u64::from(fosc) * z;
-        let x = ((remainder * PLL_Y) / u64::from(fosc)) as u32;
-        debug_assert!(x <= 0xFFFF, "PLL fractional part exceeds u16 range");
+        let x_raw = (remainder * PLL_Y) / u64::from(fosc);
+        if x_raw > u64::from(u16::MAX) || z > 255 {
+            return None; // PLL parameters out of range for this frequency
+        }
+        let x = x_raw as u16;
 
-        // Compute actual LO frequency
-        let fvco = u64::from(fosc) * z + (u64::from(fosc) * u64::from(x as u16)) / PLL_Y;
+        // Compute actual LO frequency (u64 throughout to prevent overflow)
+        let fvco = u64::from(fosc) * z + (u64::from(fosc) * u64::from(x)) / PLL_Y;
         let flo = (fvco / u64::from(r)) as u32;
-
-        debug_assert!(z <= 255, "PLL integer part exceeds u8 range");
         Some(PllParams {
             fosc,
             flo,
             z: z as u8,
-            x: x as u16,
+            x,
             r,
             r_idx,
         })

--- a/crates/sdr-rtlsdr/src/tuner/fc2580.rs
+++ b/crates/sdr-rtlsdr/src/tuner/fc2580.rs
@@ -465,7 +465,7 @@ impl Fc2580Tuner {
                 self.write_reg(
                     handle,
                     REG_37,
-                    (FILTER_1_53_COEFF * freq_xtal_khz / 1_000_000) as u8,
+                    (FILTER_1_53_COEFF * freq_xtal_khz / 1_000_000).min(255) as u8,
                 )?;
                 self.write_reg(handle, REG_39, FILTER_1_53_REG_39)?;
                 self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
@@ -475,7 +475,7 @@ impl Fc2580Tuner {
                 self.write_reg(
                     handle,
                     REG_37,
-                    (FILTER_6_COEFF * freq_xtal_khz / 1_000_000) as u8,
+                    (FILTER_6_COEFF * freq_xtal_khz / 1_000_000).min(255) as u8,
                 )?;
                 self.write_reg(handle, REG_39, FILTER_6_REG_39)?;
                 self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
@@ -485,7 +485,7 @@ impl Fc2580Tuner {
                 self.write_reg(
                     handle,
                     REG_37,
-                    (FILTER_7_COEFF * freq_xtal_khz / 1_000_000) as u8,
+                    (FILTER_7_COEFF * freq_xtal_khz / 1_000_000).min(255) as u8,
                 )?;
                 self.write_reg(handle, REG_39, FILTER_7_REG_39)?;
                 self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
@@ -495,7 +495,7 @@ impl Fc2580Tuner {
                 self.write_reg(
                     handle,
                     REG_37,
-                    (FILTER_8_COEFF * freq_xtal_khz / 1_000_000) as u8,
+                    (FILTER_8_COEFF * freq_xtal_khz / 1_000_000).min(255) as u8,
                 )?;
                 self.write_reg(handle, REG_39, FILTER_8_REG_39)?;
                 self.write_reg(handle, REG_2E, FILTER_CAL_TRIGGER)?;
@@ -731,8 +731,12 @@ impl Fc2580Tuner {
         // Load lower part of K value
         self.write_reg(handle, REG_1B, k_val as u8)?;
 
-        // Load N value
-        debug_assert!(n_val <= 255, "FC2580 PLL n_val exceeds u8 range: {n_val}");
+        // Load N value (must fit in u8 register)
+        if n_val > 255 {
+            return Err(RtlSdrError::Tuner(format!(
+                "FC2580 PLL n_val {n_val} exceeds u8 range"
+            )));
+        }
         self.write_reg(handle, REG_1C, n_val as u8)?;
 
         // UHF LNA Load Cap
@@ -1038,19 +1042,19 @@ mod tests {
         let freq_xtal_khz: u32 = 16384;
 
         // BW 1.53 MHz: 4151 * 16384 / 1000000 = 68 (truncated)
-        let val = (FILTER_1_53_COEFF * freq_xtal_khz / 1_000_000) as u8;
+        let val = (FILTER_1_53_COEFF * freq_xtal_khz / 1_000_000).min(255) as u8;
         assert_eq!(val, 68);
 
         // BW 6 MHz: 4400 * 16384 / 1000000 = 72 (truncated)
-        let val = (FILTER_6_COEFF * freq_xtal_khz / 1_000_000) as u8;
+        let val = (FILTER_6_COEFF * freq_xtal_khz / 1_000_000).min(255) as u8;
         assert_eq!(val, 72);
 
         // BW 7 MHz: 3910 * 16384 / 1000000 = 64 (truncated)
-        let val = (FILTER_7_COEFF * freq_xtal_khz / 1_000_000) as u8;
+        let val = (FILTER_7_COEFF * freq_xtal_khz / 1_000_000).min(255) as u8;
         assert_eq!(val, 64);
 
         // BW 8 MHz: 3300 * 16384 / 1000000 = 54 (truncated)
-        let val = (FILTER_8_COEFF * freq_xtal_khz / 1_000_000) as u8;
+        let val = (FILTER_8_COEFF * freq_xtal_khz / 1_000_000).min(255) as u8;
         assert_eq!(val, 54);
     }
 

--- a/crates/sdr-sink-network/src/lib.rs
+++ b/crates/sdr-sink-network/src/lib.rs
@@ -108,14 +108,17 @@ impl NetworkSink {
 
         if self.stereo {
             for (i, s) in samples.iter().enumerate() {
-                let l = (s.l.clamp(-1.0, 1.0) * 32767.0) as i16;
-                let r = (s.r.clamp(-1.0, 1.0) * 32767.0) as i16;
+                let l = (s.l.clamp(-1.0, 1.0) * 32768.0) as i32;
+                let l = l.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
+                let r = (s.r.clamp(-1.0, 1.0) * 32768.0) as i32;
+                let r = r.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
                 self.send_buf[i * 4..i * 4 + 2].copy_from_slice(&l.to_le_bytes());
                 self.send_buf[i * 4 + 2..i * 4 + 4].copy_from_slice(&r.to_le_bytes());
             }
         } else {
             for (i, s) in samples.iter().enumerate() {
-                let mono = (((s.l + s.r) / 2.0).clamp(-1.0, 1.0) * 32767.0) as i16;
+                let mono_f = ((s.l + s.r) / 2.0).clamp(-1.0, 1.0) * 32768.0;
+                let mono = (mono_f as i32).clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
                 self.send_buf[i * 2..i * 2 + 2].copy_from_slice(&mono.to_le_bytes());
             }
         }


### PR DESCRIPTION
## Summary

5 fixes from the mathematical correctness audit, closing 5 issues:

- **#122 E4000 PLL overflow**: Runtime validation for PLL fractional/integer parts instead of debug_assert. Returns None for unachievable frequencies instead of silently truncating.
- **#123 FC2580 overflow**: Filter coefficients clamped to u8 range, N value returns error instead of debug_assert. Prevents wrong LO frequency on non-standard crystals.
- **#124 Network sink scale**: f32→i16 conversion uses 32768.0 (full range) with i32 clamping instead of 32767.0 (asymmetric).
- **#121 DC blocker**: Julius O. Smith textbook topology `y[n] = x[n] - x[n-1] + R*y[n-1]` with explicit DC zero. Perfect DC rejection at steady state.
- **#114 Polyphase resampler**: Eliminate work_buf Vec allocation per call. Direct inline access from delay_line + input array.

## Test plan

- [x] All 499 workspace tests pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)