### PR TITLE
Enumerate PipeWire audio sinks via native API

### DIFF
--- a/crates/sdr-sink-audio/src/lib.rs
+++ b/crates/sdr-sink-audio/src/lib.rs
@@ -11,10 +11,16 @@
 mod pw_impl;
 
 #[cfg(feature = "pipewire")]
-pub use pw_impl::AudioSink;
+pub use pw_impl::{AudioSink, list_audio_sinks};
 
 #[cfg(not(feature = "pipewire"))]
 mod stub_impl;
 
 #[cfg(not(feature = "pipewire"))]
 pub use stub_impl::AudioSink;
+
+/// Stub for non-PipeWire builds — returns only "Default".
+#[cfg(not(feature = "pipewire"))]
+pub fn list_audio_sinks() -> Vec<String> {
+    vec!["Default".to_string()]
+}

--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -33,6 +33,89 @@ pub struct AudioSink {
     pw_thread: Option<std::thread::JoinHandle<()>>,
 }
 
+/// Query PipeWire for available audio output sinks.
+///
+/// Connects briefly to the PipeWire daemon, lists all Audio/Sink nodes,
+/// and returns their names. Always includes "Default" as the first entry.
+pub fn list_audio_sinks() -> Vec<String> {
+    let mut sinks = vec!["Default".to_string()];
+
+    // Run a short-lived PipeWire main loop to collect sink names.
+    // Must run on a separate thread because PipeWire main loops
+    // are not reentrant and we may already have one running.
+    let result = std::thread::Builder::new()
+        .name("pw-enumerate".to_string())
+        .spawn(move || {
+            let Ok(main_loop) = pipewire::main_loop::MainLoopRc::new(None) else {
+                return Vec::new();
+            };
+            let Ok(context) = pipewire::context::ContextRc::new(&main_loop, None) else {
+                return Vec::new();
+            };
+            let Ok(core) = context.connect(None) else {
+                return Vec::new();
+            };
+            let Ok(registry) = core.get_registry() else {
+                return Vec::new();
+            };
+
+            let found_sinks = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+            let found_clone = std::rc::Rc::clone(&found_sinks);
+
+            // Listen for global objects — Audio/Sink nodes are output devices
+            let listener = registry
+                .add_listener_local()
+                .global(move |global| {
+                    if let Some(props) = global.props {
+                        let media_class = props.get("media.class").unwrap_or("");
+                        if media_class == "Audio/Sink" {
+                            let name = props
+                                .get("node.description")
+                                .or_else(|| props.get("node.name"))
+                                .unwrap_or("Unknown Sink");
+                            found_clone.borrow_mut().push(name.to_string());
+                        }
+                    }
+                })
+                .register();
+
+            // Listen for the "done" signal — fires after all globals are enumerated
+            let ml_quit = main_loop.downgrade();
+            let core_listener = core
+                .add_listener_local()
+                .done(move |_id, _seq| {
+                    if let Some(ml) = ml_quit.upgrade() {
+                        ml.quit();
+                    }
+                })
+                .register();
+
+            // Trigger sync — done callback fires after all globals are sent
+            core.sync(0).ok();
+            main_loop.run();
+
+            // Listeners must stay alive until after run() completes
+            drop(listener);
+            drop(core_listener);
+            found_sinks.borrow().clone()
+        })
+        .and_then(|handle| {
+            handle
+                .join()
+                .map_err(|_| std::io::Error::other("join failed"))
+        });
+
+    if let Ok(found) = result {
+        for name in found {
+            if !sinks.contains(&name) {
+                sinks.push(name);
+            }
+        }
+    }
+
+    sinks
+}
+
 impl AudioSink {
     /// Create a new audio sink (not yet connected to PipeWire).
     pub fn new() -> Self {

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -14,14 +14,19 @@ pub struct AudioPanel {
 }
 
 /// Build the audio output configuration panel.
+///
+/// Queries `PipeWire` for available audio output sinks and populates
+/// the device selector dropdown.
 pub fn build_audio_panel() -> AudioPanel {
     let group = adw::PreferencesGroup::builder()
         .title("Audio")
         .description("Output configuration")
         .build();
 
-    // TODO(issue #92): populate with actual audio devices from PipeWire/PulseAudio
-    let device_model = gtk4::StringList::new(&["Default"]);
+    // Query PipeWire for available audio sinks
+    let sinks = sdr_sink_audio::list_audio_sinks();
+    let sink_names: Vec<&str> = sinks.iter().map(String::as_str).collect();
+    let device_model = gtk4::StringList::new(&sink_names);
     let device_row = adw::ComboRow::builder()
         .title("Device")
         .model(&device_model)


### PR DESCRIPTION
## Summary

Query PipeWire for available audio output devices at startup using the native `pipewire-rs` Registry API. No shell commands, no `pw-cli`, no attack vectors.

- Spawns a short-lived PipeWire main loop on a separate thread
- Listens for `GlobalObject` events with `media.class = "Audio/Sink"`
- Collects `node.description` (or `node.name`) for each sink
- Populates the audio panel device dropdown with real device names
- Falls back to "Default" only on non-PipeWire builds

Closes #110

## Test plan

- [x] All 499 workspace tests pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] Manual: Ryzen audio device appears in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)