### PR TITLE
Audio device routing: live PipeWire sink switching

### DIFF
--- a/crates/sdr-sink-audio/src/lib.rs
+++ b/crates/sdr-sink-audio/src/lib.rs
@@ -11,7 +11,7 @@
 mod pw_impl;
 
 #[cfg(feature = "pipewire")]
-pub use pw_impl::{AudioSink, list_audio_sinks};
+pub use pw_impl::{AudioDevice, AudioSink, list_audio_sinks};
 
 #[cfg(not(feature = "pipewire"))]
 mod stub_impl;
@@ -19,8 +19,21 @@ mod stub_impl;
 #[cfg(not(feature = "pipewire"))]
 pub use stub_impl::AudioSink;
 
+/// Audio device info (stub for non-PipeWire builds).
+#[cfg(not(feature = "pipewire"))]
+#[derive(Clone, Debug)]
+pub struct AudioDevice {
+    /// Human-readable name.
+    pub display_name: String,
+    /// PipeWire node name.
+    pub node_name: String,
+}
+
 /// Stub for non-PipeWire builds — returns only "Default".
 #[cfg(not(feature = "pipewire"))]
-pub fn list_audio_sinks() -> Vec<String> {
-    vec!["Default".to_string()]
+pub fn list_audio_sinks() -> Vec<AudioDevice> {
+    vec![AudioDevice {
+        display_name: "Default".to_string(),
+        node_name: String::new(),
+    }]
 }

--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -157,15 +157,19 @@ impl AudioSink {
     /// already running, it will be restarted with the new target.
     ///
     /// Pass an empty string for the system default sink.
-    pub fn set_target(&mut self, node_name: &str) {
-        let was_running = self.running.load(Ordering::Relaxed);
-        if was_running {
-            let _ = self.stop();
+    pub fn set_target(&mut self, node_name: &str) -> Result<(), SinkError> {
+        // Check owned state (tx/thread) rather than the atomic flag, which
+        // the worker thread may clear before cleanup finishes.
+        let had_state = self.tx.is_some() || self.pw_thread.is_some();
+        if had_state {
+            self.stop()?;
         }
-        self.target_node = node_name.to_string();
-        if was_running {
-            let _ = self.start();
+        self.target_node.clear();
+        self.target_node.push_str(node_name);
+        if had_state {
+            self.start()?;
         }
+        Ok(())
     }
 
     /// Send stereo audio samples to PipeWire for playback.

--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -31,14 +31,29 @@ pub struct AudioSink {
     tx: Option<mpsc::SyncSender<Vec<f32>>>,
     quit_tx: Option<pipewire::channel::Sender<Quit>>,
     pw_thread: Option<std::thread::JoinHandle<()>>,
+    /// Target PipeWire node name for routing (empty = system default).
+    target_node: String,
+}
+
+/// An audio sink device with display name and PipeWire node name.
+#[derive(Clone, Debug)]
+pub struct AudioDevice {
+    /// Human-readable name (from `node.description`).
+    pub display_name: String,
+    /// PipeWire node name (used for `target.object` routing).
+    pub node_name: String,
 }
 
 /// Query PipeWire for available audio output sinks.
 ///
-/// Connects briefly to the PipeWire daemon, lists all Audio/Sink nodes,
-/// and returns their names. Always includes "Default" as the first entry.
-pub fn list_audio_sinks() -> Vec<String> {
-    let mut sinks = vec!["Default".to_string()];
+/// Connects briefly to the PipeWire daemon, lists all `Audio/Sink` nodes,
+/// and returns their display names and node names. Always includes "Default"
+/// as the first entry (routes to the system default sink).
+pub fn list_audio_sinks() -> Vec<AudioDevice> {
+    let mut sinks = vec![AudioDevice {
+        display_name: "Default".to_string(),
+        node_name: String::new(), // empty = system default
+    }];
 
     // Run a short-lived PipeWire main loop to collect sink names.
     // Must run on a separate thread because PipeWire main loops
@@ -59,7 +74,7 @@ pub fn list_audio_sinks() -> Vec<String> {
                 return Vec::new();
             };
 
-            let found_sinks = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+            let found_sinks = std::rc::Rc::new(std::cell::RefCell::new(Vec::<AudioDevice>::new()));
             let found_clone = std::rc::Rc::clone(&found_sinks);
 
             // Listen for global objects — Audio/Sink nodes are output devices
@@ -69,11 +84,16 @@ pub fn list_audio_sinks() -> Vec<String> {
                     if let Some(props) = global.props {
                         let media_class = props.get("media.class").unwrap_or("");
                         if media_class == "Audio/Sink" {
-                            let name = props
+                            let display_name = props
                                 .get("node.description")
                                 .or_else(|| props.get("node.name"))
-                                .unwrap_or("Unknown Sink");
-                            found_clone.borrow_mut().push(name.to_string());
+                                .unwrap_or("Unknown Sink")
+                                .to_string();
+                            let node_name = props.get("node.name").unwrap_or("unknown").to_string();
+                            found_clone.borrow_mut().push(AudioDevice {
+                                display_name,
+                                node_name,
+                            });
                         }
                     }
                 })
@@ -106,9 +126,9 @@ pub fn list_audio_sinks() -> Vec<String> {
         });
 
     if let Ok(found) = result {
-        for name in found {
-            if !sinks.contains(&name) {
-                sinks.push(name);
+        for dev in found {
+            if !sinks.iter().any(|s| s.node_name == dev.node_name) {
+                sinks.push(dev);
             }
         }
     }
@@ -127,6 +147,24 @@ impl AudioSink {
             tx: None,
             quit_tx: None,
             pw_thread: None,
+            target_node: String::new(),
+        }
+    }
+
+    /// Set the target audio device by node name.
+    ///
+    /// Call before `start()` to route to a specific sink. If the sink is
+    /// already running, it will be restarted with the new target.
+    ///
+    /// Pass an empty string for the system default sink.
+    pub fn set_target(&mut self, node_name: &str) {
+        let was_running = self.running.load(Ordering::Relaxed);
+        if was_running {
+            let _ = self.stop();
+        }
+        self.target_node = node_name.to_string();
+        if was_running {
+            let _ = self.start();
         }
     }
 
@@ -176,11 +214,12 @@ impl Sink for AudioSink {
         let (quit_tx, quit_rx) = pipewire::channel::channel::<Quit>();
 
         let running = Arc::clone(&self.running);
+        let target = self.target_node.clone();
 
         let handle = std::thread::Builder::new()
             .name("pw-audio".into())
             .spawn(move || {
-                if let Err(e) = pipewire_thread(rx, quit_rx) {
+                if let Err(e) = pipewire_thread(rx, quit_rx, &target) {
                     tracing::error!("PipeWire thread failed: {e}");
                 }
                 running.store(false, Ordering::Release);
@@ -262,6 +301,7 @@ impl Drop for AudioSink {
 fn pipewire_thread(
     rx: mpsc::Receiver<Vec<f32>>,
     quit_rx: pipewire::channel::Receiver<Quit>,
+    target_node: &str,
 ) -> Result<(), SinkError> {
     use pipewire as pw;
     use pw::spa;
@@ -280,18 +320,21 @@ fn pipewire_thread(
         quit_loop.quit();
     });
 
-    let stream = pw::stream::StreamBox::new(
-        &core,
-        "sdr-audio",
-        pw::properties::properties! {
-            *pw::keys::MEDIA_TYPE => "Audio",
-            *pw::keys::MEDIA_CATEGORY => "Playback",
-            *pw::keys::MEDIA_ROLE => "Music",
-            *pw::keys::NODE_NAME => "sdr-rs",
-            *pw::keys::APP_NAME => "SDR-RS",
-        },
-    )
-    .map_err(|e| SinkError::OpenFailed(format!("Stream::new: {e}")))?;
+    let mut props = pw::properties::properties! {
+        *pw::keys::MEDIA_TYPE => "Audio",
+        *pw::keys::MEDIA_CATEGORY => "Playback",
+        *pw::keys::MEDIA_ROLE => "Music",
+        *pw::keys::NODE_NAME => "sdr-rs",
+        *pw::keys::APP_NAME => "SDR-RS",
+    };
+    // Route to a specific sink if requested (empty = system default)
+    if !target_node.is_empty() {
+        props.insert("target.object", target_node);
+        tracing::info!(target = target_node, "routing audio to specific sink");
+    }
+
+    let stream = pw::stream::StreamBox::new(&core, "sdr-audio", props)
+        .map_err(|e| SinkError::OpenFailed(format!("Stream::new: {e}")))?;
 
     let _listener = stream
         .add_local_listener_with_user_data(AudioCallbackData::new(rx))

--- a/crates/sdr-sink-audio/src/stub_impl.rs
+++ b/crates/sdr-sink-audio/src/stub_impl.rs
@@ -24,6 +24,11 @@ impl AudioSink {
         }
     }
 
+    /// Stub — no-op for non-PipeWire builds.
+    pub fn set_target(&mut self, _node_name: &str) -> Result<(), SinkError> {
+        Ok(())
+    }
+
     /// Stub — drops samples with periodic debug logging.
     ///
     /// Logs once every 1000 calls so operators can confirm audio data

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -675,7 +675,10 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetAudioDevice(node_name) => {
             tracing::info!(target_node = %node_name, "set audio device");
-            state.audio_sink.set_target(&node_name);
+            if let Err(e) = state.audio_sink.set_target(&node_name) {
+                tracing::warn!("audio device switch failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("Audio device switch failed: {e}")));
+            }
         }
     }
 }

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -672,6 +672,11 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             tracing::debug!(enabled, "set high-pass filter");
             state.radio.set_high_pass_enabled(enabled);
         }
+
+        UiToDsp::SetAudioDevice(node_name) => {
+            tracing::info!(target_node = %node_name, "set audio device");
+            state.audio_sink.set_target(&node_name);
+        }
     }
 }
 

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -75,6 +75,8 @@ pub enum UiToDsp {
     SetFftRate(f64),
     /// Enable or disable the audio high-pass filter (voice modes).
     SetHighPass(bool),
+    /// Set the audio output device by `PipeWire` node name.
+    SetAudioDevice(String),
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -188,5 +188,8 @@ mod tests {
 
         let hp = UiToDsp::SetHighPass(true);
         assert!(matches!(hp, UiToDsp::SetHighPass(true)));
+
+        let device = UiToDsp::SetAudioDevice("default".to_string());
+        assert!(matches!(device, UiToDsp::SetAudioDevice(ref s) if s == "default"));
     }
 }

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -11,6 +11,8 @@ pub struct AudioPanel {
     pub device_row: adw::ComboRow,
     /// Sink type selector (Audio, Network).
     pub sink_type_row: adw::ComboRow,
+    /// Node names corresponding to device dropdown indices (for routing).
+    pub device_node_names: Vec<String>,
 }
 
 /// Build the audio output configuration panel.
@@ -25,8 +27,9 @@ pub fn build_audio_panel() -> AudioPanel {
 
     // Query PipeWire for available audio sinks
     let sinks = sdr_sink_audio::list_audio_sinks();
-    let sink_names: Vec<&str> = sinks.iter().map(String::as_str).collect();
-    let device_model = gtk4::StringList::new(&sink_names);
+    let display_names: Vec<&str> = sinks.iter().map(|s| s.display_name.as_str()).collect();
+    let node_names: Vec<String> = sinks.iter().map(|s| s.node_name.clone()).collect();
+    let device_model = gtk4::StringList::new(&display_names);
     let device_row = adw::ComboRow::builder()
         .title("Device")
         .model(&device_model)
@@ -38,8 +41,6 @@ pub fn build_audio_panel() -> AudioPanel {
         .model(&sink_model)
         .build();
 
-    // TODO(issue #92): connect rows to DSP pipeline for device/sink switching
-
     group.add(&device_row);
     group.add(&sink_type_row);
 
@@ -47,5 +48,6 @@ pub fn build_audio_panel() -> AudioPanel {
         widget: group,
         device_row,
         sink_type_row,
+        device_node_names: node_names,
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -413,6 +413,7 @@ fn connect_sidebar_panels(
     connect_source_panel(panels, state);
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
+    connect_audio_panel(panels, state);
 }
 
 /// Connect source panel controls to DSP commands.
@@ -618,6 +619,19 @@ fn connect_display_panel(
                 .unwrap_or(spectrum::colormap::ColormapStyle::Turbo);
             spectrum_for_cmap.set_colormap(style);
         });
+}
+
+/// Connect audio panel controls to DSP commands.
+fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
+    // Audio device selector — routes PipeWire output to the selected sink
+    let state_dev = Rc::clone(state);
+    let node_names = panels.audio.device_node_names.clone();
+    panels.audio.device_row.connect_selected_notify(move |row| {
+        let idx = row.selected() as usize;
+        if let Some(node_name) = node_names.get(idx) {
+            state_dev.send_dsp(UiToDsp::SetAudioDevice(node_name.clone()));
+        }
+    });
 }
 
 /// Register application-level actions (About, Quit).


### PR DESCRIPTION
## Summary

Wire the audio panel device dropdown to actually route audio output to the selected PipeWire sink.

- **AudioDevice struct** — carries both display name (for UI) and node name (for PipeWire routing)
- **set_target()** — restarts the PipeWire stream with `target.object` property set to the selected node
- **SetAudioDevice message** — full UI → DSP → PipeWire pipeline
- **Live switching** — audio pauses briefly during stream restart, then reconnects cleanly

Closes #131

## Test plan
- [x] All tests pass, clippy clean
- [x] Manual: switch between Default and Ryzen audio — audio pauses and reconnects cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select an audio output device from the audio panel to route playback to a chosen sink.
  * Device list now exposes display names with underlying node identifiers for accurate routing.
* **Behavioral**
  * Non-PipeWire builds provide a sensible default audio device fallback.
* **Stability**
  * Setting the target device is supported in stub and real builds; failures surface as UI errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->