### PR TITLE
Source switching: RTL-SDR / Network / File with live UI switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,6 @@ dependencies = [
  "glow",
  "gtk4",
  "libadwaita",
- "rusb",
  "sdr-config",
  "sdr-dsp",
  "sdr-pipeline",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
 name = "sdr-source-rtlsdr"
 version = "0.1.0"
 dependencies = [
+ "rusb",
  "sdr-config",
  "sdr-pipeline",
  "sdr-rtlsdr",

--- a/crates/sdr-pipeline/src/source_manager.rs
+++ b/crates/sdr-pipeline/src/source_manager.rs
@@ -3,7 +3,7 @@
 //! Ports SDR++ `SourceManager`. Manages the set of available IQ sources
 //! (RTL-SDR, Network, File) and controls which one is active.
 
-use sdr_types::SourceError;
+use sdr_types::{Complex, SourceError};
 use std::collections::HashMap;
 
 /// Trait for an IQ signal source.
@@ -30,6 +30,24 @@ pub trait Source: Send {
 
     /// Set sample rate.
     fn set_sample_rate(&mut self, rate: f64) -> Result<(), SourceError>;
+
+    /// Read IQ samples into the output buffer. Returns number of Complex samples written.
+    fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError>;
+
+    /// Set tuner gain in tenths of dB (no-op default for non-tuner sources).
+    fn set_gain(&mut self, _gain_tenths: i32) -> Result<(), SourceError> {
+        Ok(())
+    }
+
+    /// Set AGC mode (no-op default for non-tuner sources).
+    fn set_gain_mode(&mut self, _manual: bool) -> Result<(), SourceError> {
+        Ok(())
+    }
+
+    /// Get available gain values in tenths of dB (empty for non-tuner sources).
+    fn gains(&self) -> &[i32] {
+        &[]
+    }
 }
 
 /// Manages available IQ sources and the active source lifecycle.
@@ -222,6 +240,12 @@ mod tests {
         fn set_sample_rate(&mut self, _rate: f64) -> Result<(), SourceError> {
             Ok(())
         }
+        fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+            for s in output.iter_mut() {
+                *s = Complex::default();
+            }
+            Ok(output.len())
+        }
     }
 
     #[test]
@@ -312,6 +336,12 @@ mod tests {
             }
             fn set_sample_rate(&mut self, _: f64) -> Result<(), SourceError> {
                 Ok(())
+            }
+            fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+                for s in output.iter_mut() {
+                    *s = Complex::default();
+                }
+                Ok(output.len())
             }
         }
 

--- a/crates/sdr-source-file/src/lib.rs
+++ b/crates/sdr-source-file/src/lib.rs
@@ -76,7 +76,7 @@ impl FileSource {
     ///
     /// Returns the number of Complex samples written.
     /// Each complex sample uses 2 WAV channels (I = ch0, Q = ch1).
-    pub fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+    pub fn read_samples_impl(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
         let state = self.reader.as_mut().ok_or(SourceError::NotRunning)?;
         let mut count = 0;
 
@@ -220,6 +220,10 @@ impl Source for FileSource {
             )));
         }
         Ok(())
+    }
+
+    fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+        self.read_samples_impl(output)
     }
 }
 

--- a/crates/sdr-source-network/src/lib.rs
+++ b/crates/sdr-source-network/src/lib.rs
@@ -69,7 +69,7 @@ impl NetworkSource {
     ///
     /// Returns the number of Complex samples written.
     /// Carries incomplete sample bytes across calls for TCP streams.
-    pub fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+    pub fn read_samples_impl(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
         if output.is_empty() {
             return Ok(0);
         }
@@ -231,6 +231,10 @@ impl Source for NetworkSource {
     fn set_sample_rate(&mut self, rate: f64) -> Result<(), SourceError> {
         self.sample_rate = rate;
         Ok(())
+    }
+
+    fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+        self.read_samples_impl(output)
     }
 }
 

--- a/crates/sdr-source-rtlsdr/Cargo.toml
+++ b/crates/sdr-source-rtlsdr/Cargo.toml
@@ -11,6 +11,7 @@ sdr-types.workspace = true
 sdr-pipeline.workspace = true
 sdr-rtlsdr.workspace = true
 sdr-config.workspace = true
+rusb.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -13,20 +13,29 @@
 )]
 //! RTL-SDR source module — wraps sdr-rtlsdr for the pipeline.
 //!
-//! Converts raw uint8 IQ samples from the USB device to f32 Complex
-//! samples for the signal processing pipeline.
+//! Owns a USB reader thread and lock-free ring buffer. Converts raw
+//! uint8 IQ samples from the USB device to f32 Complex samples for
+//! the signal processing pipeline.
 
 use sdr_pipeline::source_manager::Source;
 use sdr_rtlsdr::RtlSdrDevice;
 use sdr_types::{Complex, SourceError};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 /// IQ sample conversion factor: `(sample - 127.4) / 128.0`
 ///
 /// Matches SDR++ `RTLSDRSourceModule::asyncHandler`.
 const IQ_OFFSET: f32 = 127.4;
 const IQ_SCALE: f32 = 128.0;
+
+/// Raw USB buffer size in bytes (16K IQ pairs x 2 bytes each).
+const RAW_BUF_SIZE: usize = 16_384 * 2;
+
+/// Number of slots in the USB ring buffer.
+/// At 2 Msps, each slot is 16384 samples = ~8.2 ms. 32 slots = ~260 ms buffer.
+const RING_SLOTS: usize = 32;
 
 /// RTL-SDR USB sample rates (Hz).
 pub const SAMPLE_RATES: &[f64] = &[
@@ -43,16 +52,68 @@ pub const SAMPLE_RATES: &[f64] = &[
     3_200_000.0,
 ];
 
+// ---------------------------------------------------------------------------
+// Ring buffer — lock-free SPSC for USB bulk read data
+// ---------------------------------------------------------------------------
+
+/// A single slot in the ring buffer.
+///
+/// The `Mutex` is never contended: the atomic `state` flag ensures the
+/// writer and reader never access the same slot simultaneously.
+struct RingSlot {
+    data: Mutex<Vec<u8>>,
+    len: AtomicUsize,
+    /// 0 = empty (writer can fill), 1 = full (reader can consume).
+    state: AtomicU8,
+}
+
+/// Lock-free SPSC ring buffer for USB data blocks.
+///
+/// The writer (USB reader thread) fills empty slots, the reader (DSP
+/// thread via `read_samples`) consumes full slots. No copies, no
+/// allocations in steady state.
+struct UsbRingBuffer {
+    slots: Vec<RingSlot>,
+    slot_count: usize,
+    write_idx: AtomicUsize,
+    read_idx: AtomicUsize,
+}
+
+impl UsbRingBuffer {
+    fn new(slot_count: usize, slot_size: usize) -> Self {
+        let slots = (0..slot_count)
+            .map(|_| RingSlot {
+                data: Mutex::new(vec![0u8; slot_size]),
+                len: AtomicUsize::new(0),
+                state: AtomicU8::new(0), // empty
+            })
+            .collect();
+        Self {
+            slots,
+            slot_count,
+            write_idx: AtomicUsize::new(0),
+            read_idx: AtomicUsize::new(0),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RtlSdrSource
+// ---------------------------------------------------------------------------
+
 /// RTL-SDR IQ source for the pipeline.
 ///
 /// Ports SDR++ `RTLSDRSourceModule`. Opens the RTL-SDR device,
-/// configures it, and converts uint8 IQ pairs to f32 Complex samples.
+/// configures it, spawns a USB reader thread, and converts uint8 IQ
+/// pairs to f32 Complex samples via `read_samples`.
 pub struct RtlSdrSource {
     device: Option<RtlSdrDevice>,
     device_index: u32,
     sample_rate: f64,
     frequency: f64,
     running: Arc<AtomicBool>,
+    ring: Option<Arc<UsbRingBuffer>>,
+    reader_thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl RtlSdrSource {
@@ -64,6 +125,8 @@ impl RtlSdrSource {
             sample_rate: SAMPLE_RATES[7], // 2.4 MHz default
             frequency: 100_000_000.0,     // 100 MHz default
             running: Arc::new(AtomicBool::new(false)),
+            ring: None,
+            reader_thread: None,
         }
     }
 
@@ -104,6 +167,54 @@ impl Source for RtlSdrSource {
             .reset_buffer()
             .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
 
+        // Create the ring buffer and spawn the USB reader thread.
+        let ring = Arc::new(UsbRingBuffer::new(RING_SLOTS, RAW_BUF_SIZE));
+        let ring_writer = Arc::clone(&ring);
+        let cancel = Arc::clone(&self.running);
+        let handle = device.usb_handle();
+
+        let thread = std::thread::Builder::new()
+            .name("usb-reader".into())
+            .spawn(move || {
+                tracing::info!("USB reader thread started (ring slots={RING_SLOTS})");
+                let timeout = Duration::from_secs(1);
+
+                while cancel.load(Ordering::Relaxed) {
+                    let idx =
+                        ring_writer.write_idx.load(Ordering::Relaxed) % ring_writer.slot_count;
+                    let slot = &ring_writer.slots[idx];
+
+                    // Wait for slot to be empty.
+                    if slot.state.load(Ordering::Acquire) != 0 {
+                        // Ring full — DSP can't keep up. Yield briefly.
+                        std::thread::yield_now();
+                        continue;
+                    }
+
+                    // Lock the slot's buffer for writing. Never contended because
+                    // the state flag ensures reader and writer don't overlap.
+                    let mut data = slot.data.lock().expect("ring slot poisoned");
+
+                    match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut data, timeout)
+                    {
+                        Ok(n) if n > 0 => {
+                            slot.len.store(n, Ordering::Relaxed);
+                            slot.state.store(1, Ordering::Release); // mark full
+                            ring_writer.write_idx.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Ok(_) | Err(rusb::Error::Timeout) => {}
+                        Err(e) => {
+                            tracing::warn!("USB reader error: {e}");
+                            break;
+                        }
+                    }
+                }
+                tracing::debug!("USB reader thread stopped");
+            })
+            .map_err(|e| SourceError::OpenFailed(format!("failed to spawn USB reader: {e}")))?;
+
+        self.ring = Some(ring);
+        self.reader_thread = Some(thread);
         self.device = Some(device);
         self.running.store(true, Ordering::Relaxed);
         Ok(())
@@ -111,6 +222,10 @@ impl Source for RtlSdrSource {
 
     fn stop(&mut self) -> Result<(), SourceError> {
         self.running.store(false, Ordering::Relaxed);
+        if let Some(thread) = self.reader_thread.take() {
+            let _ = thread.join();
+        }
+        self.ring = None;
         self.device = None; // Drop closes the device
         Ok(())
     }
@@ -141,6 +256,57 @@ impl Source for RtlSdrSource {
                 .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
         }
         Ok(())
+    }
+
+    fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+        let ring = self.ring.as_ref().ok_or(SourceError::NotRunning)?;
+        let idx = ring.read_idx.load(Ordering::Relaxed) % ring.slot_count;
+        let slot = &ring.slots[idx];
+
+        if slot.state.load(Ordering::Acquire) != 1 {
+            return Ok(0); // No data available yet
+        }
+
+        let len = slot.len.load(Ordering::Relaxed);
+        let count = {
+            let data = slot
+                .data
+                .lock()
+                .map_err(|e| SourceError::ReadFailed(e.to_string()))?;
+            Self::convert_samples(&data[..len], output)
+        };
+
+        // Release the slot back to the writer.
+        slot.state.store(0, Ordering::Release);
+        ring.read_idx.fetch_add(1, Ordering::Relaxed);
+
+        Ok(count)
+    }
+
+    fn set_gain(&mut self, gain_tenths: i32) -> Result<(), SourceError> {
+        if let Some(device) = &mut self.device {
+            device
+                .set_tuner_gain(gain_tenths)
+                .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn set_gain_mode(&mut self, manual: bool) -> Result<(), SourceError> {
+        if let Some(device) = &mut self.device {
+            device
+                .set_tuner_gain_mode(manual)
+                .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn gains(&self) -> &[i32] {
+        if let Some(device) = &self.device {
+            device.tuner_gains()
+        } else {
+            &[]
+        }
     }
 }
 

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -77,6 +77,8 @@ struct UsbRingBuffer {
     slot_count: usize,
     write_idx: AtomicUsize,
     read_idx: AtomicUsize,
+    /// Set to true by the reader thread on fatal USB error or panic.
+    error: AtomicBool,
 }
 
 impl UsbRingBuffer {
@@ -85,7 +87,7 @@ impl UsbRingBuffer {
             .map(|_| RingSlot {
                 data: Mutex::new(vec![0u8; slot_size]),
                 len: AtomicUsize::new(0),
-                state: AtomicU8::new(0), // empty
+                state: AtomicU8::new(0),
             })
             .collect();
         Self {
@@ -93,6 +95,7 @@ impl UsbRingBuffer {
             slot_count,
             write_idx: AtomicUsize::new(0),
             read_idx: AtomicUsize::new(0),
+            error: AtomicBool::new(false),
         }
     }
 }
@@ -167,6 +170,9 @@ impl Source for RtlSdrSource {
             .reset_buffer()
             .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
 
+        // Set running BEFORE spawning so the reader thread sees it immediately.
+        self.running.store(true, Ordering::Release);
+
         // Create the ring buffer and spawn the USB reader thread.
         let ring = Arc::new(UsbRingBuffer::new(RING_SLOTS, RAW_BUF_SIZE));
         let ring_writer = Arc::clone(&ring);
@@ -179,7 +185,7 @@ impl Source for RtlSdrSource {
                 tracing::info!("USB reader thread started (ring slots={RING_SLOTS})");
                 let timeout = Duration::from_secs(1);
 
-                while cancel.load(Ordering::Relaxed) {
+                while cancel.load(Ordering::Acquire) {
                     let idx =
                         ring_writer.write_idx.load(Ordering::Relaxed) % ring_writer.slot_count;
                     let slot = &ring_writer.slots[idx];
@@ -193,7 +199,11 @@ impl Source for RtlSdrSource {
 
                     // Lock the slot's buffer for writing. Never contended because
                     // the state flag ensures reader and writer don't overlap.
-                    let mut data = slot.data.lock().expect("ring slot poisoned");
+                    let Ok(mut data) = slot.data.lock() else {
+                        tracing::error!("ring slot mutex poisoned");
+                        ring_writer.error.store(true, Ordering::Release);
+                        break;
+                    };
 
                     match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut data, timeout)
                     {
@@ -205,6 +215,7 @@ impl Source for RtlSdrSource {
                         Ok(_) | Err(rusb::Error::Timeout) => {}
                         Err(e) => {
                             tracing::warn!("USB reader error: {e}");
+                            ring_writer.error.store(true, Ordering::Release);
                             break;
                         }
                     }
@@ -216,7 +227,6 @@ impl Source for RtlSdrSource {
         self.ring = Some(ring);
         self.reader_thread = Some(thread);
         self.device = Some(device);
-        self.running.store(true, Ordering::Relaxed);
         Ok(())
     }
 
@@ -260,6 +270,12 @@ impl Source for RtlSdrSource {
 
     fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
         let ring = self.ring.as_ref().ok_or(SourceError::NotRunning)?;
+        // Check if the reader thread died (USB error or mutex poisoned)
+        if ring.error.load(Ordering::Acquire) {
+            return Err(SourceError::ReadFailed(
+                "USB reader thread died".to_string(),
+            ));
+        }
         let idx = ring.read_idx.load(Ordering::Relaxed) % ring.slot_count;
         let slot = &ring.slots[idx];
 

--- a/crates/sdr-types/src/error.rs
+++ b/crates/sdr-types/src/error.rs
@@ -35,6 +35,8 @@ pub enum SourceError {
     NotRunning,
     #[error("already running")]
     AlreadyRunning,
+    #[error("read failed: {0}")]
+    ReadFailed(String),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -22,7 +22,6 @@ sdr-source-network.workspace = true
 sdr-source-file.workspace = true
 sdr-sink-audio.workspace = true
 sdr-sink-network.workspace = true
-rusb.workspace = true
 gtk4.workspace = true
 libadwaita.workspace = true
 glow.workspace = true

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -342,13 +342,16 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetSampleRate(rate) => {
             tracing::debug!(sample_rate = rate, "set sample rate");
-            state.sample_rate = rate;
-            if let Some(source) = &mut state.source
-                && let Err(e) = source.set_sample_rate(rate)
-            {
-                tracing::warn!("set sample rate failed: {e}");
-                let _ = dsp_tx.send(DspToUi::Error(format!("Sample rate failed: {e}")));
-                return;
+            if let Some(source) = &mut state.source {
+                if let Err(e) = source.set_sample_rate(rate) {
+                    tracing::warn!("set sample rate failed: {e}");
+                    let _ = dsp_tx.send(DspToUi::Error(format!("Sample rate failed: {e}")));
+                    return;
+                }
+                // Use the source's actual rate (may differ due to hardware rounding)
+                state.sample_rate = source.sample_rate();
+            } else {
+                state.sample_rate = rate;
             }
 
             // Auto-select decimation ratio so the effective rate is close to
@@ -559,8 +562,24 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                     Ok(()) => {
                         if let Err(e) = state.audio_sink.start() {
                             tracing::warn!("audio sink restart failed: {e}");
+                            let _ =
+                                dsp_tx.send(DspToUi::Error(format!("Audio output failed: {e}")));
                         }
                         state.running = true;
+                        // Refresh UI with new source capabilities
+                        if let Some(source) = &state.source {
+                            let gains: Vec<f64> = source
+                                .gains()
+                                .iter()
+                                .map(|&g| f64::from(g) / 10.0)
+                                .collect();
+                            if !gains.is_empty() {
+                                let _ = dsp_tx.send(DspToUi::GainList(gains));
+                            }
+                        }
+                        let _ = dsp_tx.send(DspToUi::SampleRateChanged(
+                            state.frontend.effective_sample_rate(),
+                        ));
                     }
                     Err(e) => {
                         tracing::warn!("source switch failed: {e}");
@@ -617,6 +636,14 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
 
     // Sync sample rate from the source (file sources have fixed rates).
     state.sample_rate = source.sample_rate();
+
+    // Auto-adjust decimation for the source's actual sample rate.
+    let if_rate = state.radio.demod_config().if_sample_rate;
+    let auto_decim = auto_decimation_ratio(state.sample_rate, if_rate);
+    if auto_decim != state.frontend.decim_ratio() {
+        tracing::info!(auto_decim, "auto-adjusting decimation for source rate");
+        let _ = state.frontend.set_decimation(auto_decim);
+    }
 
     // Rebuild frontend and VFO before committing the source to state.
     rebuild_frontend(state)?;

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -145,6 +145,8 @@ struct DspState {
     vfo_offset: f64,
 
     // Source type and configuration
+    /// User-configured sample rate (persisted across source switches).
+    configured_sample_rate: f64,
     source_type: SourceType,
     network_host: String,
     network_port: u16,
@@ -184,6 +186,7 @@ impl DspState {
             running: false,
             center_freq: DEFAULT_CENTER_FREQ,
             sample_rate: DEFAULT_SAMPLE_RATE,
+            configured_sample_rate: DEFAULT_SAMPLE_RATE,
             volume: 1.0,
             dc_blocking: true,
             invert_iq: false,
@@ -342,6 +345,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetSampleRate(rate) => {
             tracing::debug!(sample_rate = rate, "set sample rate");
+            state.configured_sample_rate = rate;
             if let Some(source) = &mut state.source {
                 if let Err(e) = source.set_sample_rate(rate) {
                     tracing::warn!("set sample rate failed: {e}");
@@ -620,7 +624,7 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
         SourceType::File => Box::new(sdr_source_file::FileSource::new(&state.file_path)),
     };
 
-    if let Err(e) = source.set_sample_rate(state.sample_rate) {
+    if let Err(e) = source.set_sample_rate(state.configured_sample_rate) {
         if state.source_type == SourceType::File {
             tracing::warn!("file source sample rate mismatch: {e}");
         } else {
@@ -646,8 +650,11 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
     }
 
     // Rebuild frontend and VFO before committing the source to state.
-    rebuild_frontend(state)?;
-    rebuild_vfo(state)?;
+    // If either fails, stop the source to avoid a leaked running source.
+    if let Err(e) = rebuild_frontend(state).and_then(|()| rebuild_vfo(state)) {
+        let _ = source.stop();
+        return Err(e);
+    }
     state.source = Some(source);
 
     tracing::info!(

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -714,6 +714,7 @@ fn auto_decimation_ratio(sample_rate: f64, if_rate: f64) -> u32 {
 
 /// Read one block of IQ data from the source, process it, and send FFT data
 /// to the UI.
+#[allow(clippy::too_many_lines)]
 fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
     let Some(source) = &mut state.source else {
         tracing::warn!("process_iq_block called without source");
@@ -729,7 +730,19 @@ fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
         }
         Ok(n) => n,
         Err(e) => {
-            tracing::warn!("source read error: {e}");
+            // Fatal errors (USB reader death, device lost) — stop the pipeline
+            if matches!(
+                e,
+                sdr_types::SourceError::ReadFailed(_) | sdr_types::SourceError::NotRunning
+            ) {
+                tracing::error!("fatal source error: {e}");
+                cleanup(state);
+                state.running = false;
+                let _ = dsp_tx.send(DspToUi::Error(format!("Source error: {e}")));
+                let _ = dsp_tx.send(DspToUi::SourceStopped);
+            } else {
+                tracing::warn!("source read error: {e}");
+            }
             return;
         }
     };

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -21,7 +21,7 @@ use sdr_sink_audio::AudioSink;
 use sdr_source_rtlsdr::RtlSdrSource;
 use sdr_types::{Complex, SinkError, Stereo};
 
-use crate::messages::{DspToUi, UiToDsp};
+use crate::messages::{DspToUi, SourceType, UiToDsp};
 
 /// Number of IQ sample pairs per USB bulk read.
 const IQ_PAIRS_PER_READ: usize = 16_384;
@@ -144,6 +144,12 @@ struct DspState {
     vfo_buf: Vec<Complex>,
     vfo_offset: f64,
 
+    // Source type and configuration
+    source_type: SourceType,
+    network_host: String,
+    network_port: u16,
+    file_path: std::path::PathBuf,
+
     // Pre-allocated buffers
     iq_buf: Vec<Complex>,
     processed_buf: Vec<Complex>,
@@ -186,6 +192,10 @@ impl DspState {
             vfo: None,
             vfo_buf: Vec::new(),
             vfo_offset: 0.0,
+            source_type: SourceType::RtlSdr,
+            network_host: "127.0.0.1".to_string(),
+            network_port: 1234,
+            file_path: std::path::PathBuf::new(),
             iq_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             processed_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             fft_buf: vec![0.0; DEFAULT_FFT_SIZE],
@@ -532,17 +542,54 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 let _ = dsp_tx.send(DspToUi::Error(format!("Audio device switch failed: {e}")));
             }
         }
+
+        UiToDsp::SetSourceType(source_type) => {
+            tracing::info!(?source_type, "switching source type");
+            if state.running {
+                cleanup(state);
+                state.running = false;
+                let _ = dsp_tx.send(DspToUi::SourceStopped);
+            }
+            state.source_type = source_type;
+        }
+
+        UiToDsp::SetNetworkConfig { hostname, port } => {
+            tracing::debug!(%hostname, port, "set network config");
+            state.network_host = hostname;
+            state.network_port = port;
+        }
+
+        UiToDsp::SetFilePath(path) => {
+            tracing::debug!(?path, "set file path");
+            state.file_path = path;
+        }
     }
 }
 
 /// Open the active IQ source and configure it for streaming.
 fn open_source(state: &mut DspState) -> Result<(), String> {
-    let mut source: Box<dyn Source> = Box::new(RtlSdrSource::new(DEVICE_INDEX));
+    let mut source: Box<dyn Source> = match state.source_type {
+        SourceType::RtlSdr => Box::new(RtlSdrSource::new(DEVICE_INDEX)),
+        SourceType::Network => Box::new(sdr_source_network::NetworkSource::new(
+            &state.network_host,
+            state.network_port,
+            sdr_types::Protocol::TcpClient,
+        )),
+        SourceType::File => Box::new(sdr_source_file::FileSource::new(&state.file_path)),
+    };
 
-    source
-        .set_sample_rate(state.sample_rate)
-        .map_err(|e| e.to_string())?;
-    source.tune(state.center_freq).map_err(|e| e.to_string())?;
+    if let Err(e) = source.set_sample_rate(state.sample_rate) {
+        if state.source_type == SourceType::File {
+            tracing::warn!("file source sample rate mismatch: {e}");
+        } else {
+            return Err(e.to_string());
+        }
+    }
+
+    if state.source_type == SourceType::RtlSdr {
+        source.tune(state.center_freq).map_err(|e| e.to_string())?;
+    }
+
     source.start().map_err(|e| e.to_string())?;
 
     // Rebuild frontend and VFO before committing the source to state.

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -752,6 +752,13 @@ fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
 
     let iq_count = match source.read_samples(&mut state.iq_buf) {
         Ok(0) => {
+            // File sources return Ok(0) at EOF — stop playback cleanly
+            if state.source_type == SourceType::File {
+                tracing::info!("file source reached EOF");
+                cleanup(state);
+                state.running = false;
+                let _ = dsp_tx.send(DspToUi::SourceStopped);
+            }
             std::thread::yield_now();
             return;
         }

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -148,6 +148,7 @@ struct DspState {
     source_type: SourceType,
     network_host: String,
     network_port: u16,
+    network_protocol: sdr_types::Protocol,
     file_path: std::path::PathBuf,
 
     // Pre-allocated buffers
@@ -195,6 +196,7 @@ impl DspState {
             source_type: SourceType::RtlSdr,
             network_host: "127.0.0.1".to_string(),
             network_port: 1234,
+            network_protocol: sdr_types::Protocol::TcpClient,
             file_path: std::path::PathBuf::new(),
             iq_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             processed_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
@@ -545,18 +547,39 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetSourceType(source_type) => {
             tracing::info!(?source_type, "switching source type");
-            if state.running {
+            let was_running = state.running;
+            if was_running {
                 cleanup(state);
                 state.running = false;
-                let _ = dsp_tx.send(DspToUi::SourceStopped);
             }
             state.source_type = source_type;
+            // Restart with the new source type if was playing
+            if was_running {
+                match open_source(state) {
+                    Ok(()) => {
+                        if let Err(e) = state.audio_sink.start() {
+                            tracing::warn!("audio sink restart failed: {e}");
+                        }
+                        state.running = true;
+                    }
+                    Err(e) => {
+                        tracing::warn!("source switch failed: {e}");
+                        let _ = dsp_tx.send(DspToUi::Error(format!("Source switch failed: {e}")));
+                        let _ = dsp_tx.send(DspToUi::SourceStopped);
+                    }
+                }
+            }
         }
 
-        UiToDsp::SetNetworkConfig { hostname, port } => {
-            tracing::debug!(%hostname, port, "set network config");
+        UiToDsp::SetNetworkConfig {
+            hostname,
+            port,
+            protocol,
+        } => {
+            tracing::debug!(%hostname, port, ?protocol, "set network config");
             state.network_host = hostname;
             state.network_port = port;
+            state.network_protocol = protocol;
         }
 
         UiToDsp::SetFilePath(path) => {
@@ -573,7 +596,7 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
         SourceType::Network => Box::new(sdr_source_network::NetworkSource::new(
             &state.network_host,
             state.network_port,
-            sdr_types::Protocol::TcpClient,
+            state.network_protocol,
         )),
         SourceType::File => Box::new(sdr_source_file::FileSource::new(&state.file_path)),
     };
@@ -591,6 +614,9 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
     }
 
     source.start().map_err(|e| e.to_string())?;
+
+    // Sync sample rate from the source (file sources have fixed rates).
+    state.sample_rate = source.sample_rate();
 
     // Rebuild frontend and VFO before committing the source to state.
     rebuild_frontend(state)?;

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -3,21 +3,20 @@
 //!
 //! The DSP thread runs a loop that:
 //! 1. Checks for UI commands (non-blocking when running, blocking when stopped).
-//! 2. Reads IQ samples from the RTL-SDR device via `read_sync`.
+//! 2. Reads IQ samples from the active source via `Source::read_samples`.
 //! 3. Processes samples through `IqFrontend` (decimation, DC blocking, FFT).
 //! 4. Processes through `RxVfo` (frequency translation, resampling, channel filter).
 //! 5. Processes through `RadioModule` (IF chain, demod, AF chain).
 //! 6. Sends FFT data back to the UI for display.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, mpsc};
+use std::sync::mpsc;
 use std::time::Duration;
 
 use sdr_dsp::channel::RxVfo;
 use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
 use sdr_pipeline::sink_manager::Sink;
+use sdr_pipeline::source_manager::Source;
 use sdr_radio::RadioModule;
-use sdr_rtlsdr::RtlSdrDevice;
 use sdr_sink_audio::AudioSink;
 use sdr_source_rtlsdr::RtlSdrSource;
 use sdr_types::{Complex, SinkError, Stereo};
@@ -26,13 +25,6 @@ use crate::messages::{DspToUi, UiToDsp};
 
 /// Number of IQ sample pairs per USB bulk read.
 const IQ_PAIRS_PER_READ: usize = 16_384;
-
-/// Raw USB buffer size in bytes (2 bytes per IQ pair: I + Q).
-const RAW_BUF_SIZE: usize = IQ_PAIRS_PER_READ * 2;
-
-/// Number of queued blocks in the USB reader channel.
-/// At 2 Msps, each block is 16384 samples = 8.2 ms. 32 blocks = ~260 ms buffer.
-const USB_READER_QUEUE_DEPTH: usize = 32;
 
 /// Default FFT size for spectrum display.
 const DEFAULT_FFT_SIZE: usize = 2048;
@@ -128,148 +120,9 @@ fn dsp_thread_main(dsp_tx: mpsc::Sender<DspToUi>, ui_rx: mpsc::Receiver<UiToDsp>
     }
 }
 
-/// Slot in the lock-free ring buffer.
-struct RingSlot {
-    data: std::sync::Mutex<Vec<u8>>,
-    len: std::sync::atomic::AtomicUsize,
-    /// 0 = empty (writer can fill), 1 = full (reader can consume)
-    state: std::sync::atomic::AtomicU8,
-}
-
-/// Lock-free SPSC ring buffer for USB data blocks.
-///
-/// The writer (USB thread) fills empty slots, the reader (DSP thread)
-/// consumes full slots. No copies, no allocations in steady state.
-struct UsbRingBuffer {
-    slots: Vec<RingSlot>,
-    slot_count: usize,
-    write_idx: std::sync::atomic::AtomicUsize,
-    read_idx: std::sync::atomic::AtomicUsize,
-}
-
-impl UsbRingBuffer {
-    fn new(slot_count: usize, slot_size: usize) -> Self {
-        let slots = (0..slot_count)
-            .map(|_| RingSlot {
-                data: std::sync::Mutex::new(vec![0u8; slot_size]),
-                len: std::sync::atomic::AtomicUsize::new(0),
-                state: std::sync::atomic::AtomicU8::new(0), // empty
-            })
-            .collect();
-        Self {
-            slots,
-            slot_count,
-            write_idx: std::sync::atomic::AtomicUsize::new(0),
-            read_idx: std::sync::atomic::AtomicUsize::new(0),
-        }
-    }
-}
-
-/// Async USB reader — runs bulk reads on a dedicated thread using a
-/// lock-free ring buffer. Zero copies, zero allocations on the hot path.
-struct UsbReader {
-    cancel: Arc<AtomicBool>,
-    thread: Option<std::thread::JoinHandle<()>>,
-    ring: Arc<UsbRingBuffer>,
-}
-
-impl UsbReader {
-    fn start(device: &RtlSdrDevice) -> Self {
-        let ring = Arc::new(UsbRingBuffer::new(USB_READER_QUEUE_DEPTH, RAW_BUF_SIZE));
-        let ring_writer = Arc::clone(&ring);
-        let cancel = Arc::new(AtomicBool::new(false));
-        let cancel_clone = Arc::clone(&cancel);
-        let handle = device.usb_handle();
-
-        let thread = std::thread::Builder::new()
-            .name("usb-reader".to_string())
-            .spawn(move || {
-                tracing::info!("USB reader thread started (ring slots={USB_READER_QUEUE_DEPTH})");
-                let timeout = Duration::from_secs(1);
-
-                while !cancel_clone.load(Ordering::Relaxed) {
-                    let idx =
-                        ring_writer.write_idx.load(Ordering::Relaxed) % ring_writer.slot_count;
-                    let slot = &ring_writer.slots[idx];
-
-                    // Wait for slot to be empty
-                    if slot.state.load(Ordering::Acquire) != 0 {
-                        // Ring full — DSP can't keep up. Spin briefly.
-                        std::thread::yield_now();
-                        continue;
-                    }
-
-                    // Lock the slot's buffer for writing. Never contended because
-                    // the state flag ensures reader and writer don't overlap.
-                    let mut data = slot.data.lock().expect("ring slot poisoned");
-
-                    match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut data, timeout)
-                    {
-                        Ok(n) if n > 0 => {
-                            slot.len.store(n, Ordering::Relaxed);
-                            slot.state.store(1, Ordering::Release); // mark full
-                            ring_writer.write_idx.fetch_add(1, Ordering::Relaxed);
-                        }
-                        Ok(_) | Err(rusb::Error::Timeout) => {}
-                        Err(e) => {
-                            tracing::warn!("USB reader error: {e}");
-                            break;
-                        }
-                    }
-                }
-                tracing::debug!("USB reader thread stopped");
-            })
-            .expect("failed to spawn USB reader thread");
-
-        Self {
-            cancel,
-            thread: Some(thread),
-            ring,
-        }
-    }
-
-    /// Try to read the next block, converting samples directly into the
-    /// output buffer. Returns the number of IQ samples converted, or None
-    /// if no block is available.
-    fn try_read_into(&self, iq_buf: &mut [Complex]) -> Option<usize> {
-        let idx = self.ring.read_idx.load(Ordering::Relaxed) % self.ring.slot_count;
-        let slot = &self.ring.slots[idx];
-
-        if slot.state.load(Ordering::Acquire) != 1 {
-            return None; // slot empty
-        }
-
-        let len = slot.len.load(Ordering::Relaxed);
-        let count = {
-            let data = slot.data.lock().expect("ring slot poisoned");
-            RtlSdrSource::convert_samples(&data[..len], iq_buf)
-        };
-
-        // Release the slot back to the writer
-        slot.state.store(0, Ordering::Release);
-        self.ring.read_idx.fetch_add(1, Ordering::Relaxed);
-
-        Some(count)
-    }
-
-    fn stop(&mut self) {
-        self.cancel.store(true, Ordering::Relaxed);
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
-        }
-    }
-}
-
-impl Drop for UsbReader {
-    fn drop(&mut self) {
-        self.stop();
-    }
-}
-
 /// Mutable state owned by the DSP thread.
 struct DspState {
-    device: Option<RtlSdrDevice>,
-    usb_reader: Option<UsbReader>,
+    source: Option<Box<dyn Source>>,
     frontend: IqFrontend,
     radio: RadioModule,
     audio_sink: AudioSink,
@@ -313,12 +166,11 @@ impl DspState {
             RadioModule::with_default_rate().map_err(|e| format!("RadioModule init: {e}"))?;
         let initial_bandwidth = radio.demod_config().default_bandwidth;
 
-        // The RxVfo and RadioModule input rate are configured in open_device()
+        // The RxVfo and RadioModule input rate are configured in open_source()
         // once we know the actual effective sample rate from the hardware.
 
         Ok(Self {
-            device: None,
-            usb_reader: None,
+            source: None,
             frontend,
             radio,
             audio_sink: AudioSink::new(),
@@ -352,7 +204,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 return;
             }
             tracing::info!("starting DSP pipeline");
-            match open_device(state) {
+            match open_source(state) {
                 Ok(()) => {
                     // Start the audio sink -- if it fails, log but continue
                     // so the spectrum display still works.
@@ -363,14 +215,16 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                     state.running = true;
                     tracing::info!("DSP pipeline started");
 
-                    // Send the device's supported gain values to the UI.
-                    if let Some(dev) = &state.device {
-                        let gains: Vec<f64> = dev
-                            .tuner_gains()
+                    // Send the source's supported gain values to the UI.
+                    if let Some(source) = &state.source {
+                        let gains: Vec<f64> = source
+                            .gains()
                             .iter()
                             .map(|&g| f64::from(g) / 10.0) // tenths of dB → dB
                             .collect();
-                        let _ = dsp_tx.send(DspToUi::GainList(gains));
+                        if !gains.is_empty() {
+                            let _ = dsp_tx.send(DspToUi::GainList(gains));
+                        }
                     }
                 }
                 Err(e) => {
@@ -395,9 +249,8 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         UiToDsp::Tune(freq) => {
             tracing::debug!(frequency_hz = freq, "tune command");
             state.center_freq = freq;
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            if let Some(dev) = &mut state.device
-                && let Err(e) = dev.set_center_freq(freq as u32)
+            if let Some(source) = &mut state.source
+                && let Err(e) = source.tune(freq)
             {
                 tracing::warn!("tune failed: {e}");
                 let _ = dsp_tx.send(DspToUi::Error(format!("Tune failed: {e}")));
@@ -478,9 +331,8 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         UiToDsp::SetSampleRate(rate) => {
             tracing::debug!(sample_rate = rate, "set sample rate");
             state.sample_rate = rate;
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            if let Some(dev) = &mut state.device
-                && let Err(e) = dev.set_sample_rate(rate as u32)
+            if let Some(source) = &mut state.source
+                && let Err(e) = source.set_sample_rate(rate)
             {
                 tracing::warn!("set sample rate failed: {e}");
                 let _ = dsp_tx.send(DspToUi::Error(format!("Sample rate failed: {e}")));
@@ -587,10 +439,10 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         UiToDsp::SetGain(gain_db) => {
             tracing::debug!(gain_db, "set gain");
             #[allow(clippy::cast_possible_truncation)]
-            if let Some(dev) = &mut state.device {
-                // RTL-SDR gain is in tenths of dB (e.g., 49.6 dB = 496)
+            if let Some(source) = &mut state.source {
+                // Source gain is in tenths of dB (e.g., 49.6 dB = 496)
                 let gain_tenths = (gain_db * 10.0) as i32;
-                if let Err(e) = dev.set_tuner_gain(gain_tenths) {
+                if let Err(e) = source.set_gain(gain_tenths) {
                     tracing::warn!("set gain failed: {e}");
                     let _ = dsp_tx.send(DspToUi::Error(format!("Set gain failed: {e}")));
                 }
@@ -599,9 +451,9 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetAgc(enabled) => {
             tracing::debug!(enabled, "set AGC");
-            if let Some(dev) = &mut state.device {
+            if let Some(source) = &mut state.source {
                 // AGC enabled = automatic gain (manual=false), AGC disabled = manual gain
-                if let Err(e) = dev.set_tuner_gain_mode(!enabled) {
+                if let Err(e) = source.set_gain_mode(!enabled) {
                     tracing::warn!("set AGC failed: {e}");
                     let _ = dsp_tx.send(DspToUi::Error(format!("AGC failed: {e}")));
                 }
@@ -683,47 +535,33 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
     }
 }
 
-/// Open the RTL-SDR device and configure it for streaming.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn open_device(state: &mut DspState) -> Result<(), String> {
-    let mut device = RtlSdrDevice::open(DEVICE_INDEX).map_err(|e| e.to_string())?;
+/// Open the active IQ source and configure it for streaming.
+fn open_source(state: &mut DspState) -> Result<(), String> {
+    let mut source: Box<dyn Source> = Box::new(RtlSdrSource::new(DEVICE_INDEX));
 
-    device
-        .set_sample_rate(state.sample_rate as u32)
-        .map_err(|e| format!("set sample rate: {e}"))?;
+    source
+        .set_sample_rate(state.sample_rate)
+        .map_err(|e| e.to_string())?;
+    source.tune(state.center_freq).map_err(|e| e.to_string())?;
+    source.start().map_err(|e| e.to_string())?;
 
-    device
-        .set_center_freq(state.center_freq as u32)
-        .map_err(|e| format!("set center freq: {e}"))?;
-
-    device
-        .reset_buffer()
-        .map_err(|e| format!("reset buffer: {e}"))?;
-
-    // Rebuild frontend and VFO before committing the device to state.
-    // If either fails, the local `device` handle is dropped and startup
-    // leaves no partially-open device behind.
+    // Rebuild frontend and VFO before committing the source to state.
     rebuild_frontend(state)?;
     rebuild_vfo(state)?;
-    // Start the async USB reader thread before storing the device.
-    // This decouples USB I/O from DSP processing, preventing data loss
-    // at high sample rates (>2 Msps).
-    state.usb_reader = Some(UsbReader::start(&device));
-    state.device = Some(device);
+    state.source = Some(source);
 
     tracing::info!(
         sample_rate = state.sample_rate,
         center_freq = state.center_freq,
-        "RTL-SDR device opened"
+        "source opened"
     );
     Ok(())
 }
 
-/// Stop the device and release resources.
+/// Stop the source and release resources.
 fn cleanup(state: &mut DspState) {
-    // Stop the USB reader thread first.
-    if let Some(mut reader) = state.usb_reader.take() {
-        reader.stop();
+    if let Some(source) = &mut state.source {
+        let _ = source.stop();
     }
 
     // Stop the audio sink so it doesn't try to read stale data.
@@ -731,9 +569,8 @@ fn cleanup(state: &mut DspState) {
         tracing::debug!("audio sink stop: {e}");
     }
 
-    // Dropping the device closes the USB handle.
-    state.device = None;
-    tracing::info!("RTL-SDR device closed");
+    state.source = None;
+    tracing::info!("source closed");
 }
 
 /// Rebuild the IQ frontend with the current sample rate, preserving user settings.
@@ -802,33 +639,27 @@ fn auto_decimation_ratio(sample_rate: f64, if_rate: f64) -> u32 {
     pow2.clamp(1, 8192) // MAX_POWER_DECIM_RATIO
 }
 
-/// Read one block of IQ data from the device, process it, and send FFT data
+/// Read one block of IQ data from the source, process it, and send FFT data
 /// to the UI.
 fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
-    if state.device.is_none() {
-        tracing::warn!("process_iq_block called without device");
+    let Some(source) = &mut state.source else {
+        tracing::warn!("process_iq_block called without source");
         state.running = false;
         let _ = dsp_tx.send(DspToUi::SourceStopped);
         return;
-    }
-
-    // Receive raw USB data from the async reader thread.
-    // This decouples USB I/O from DSP — the reader thread fills the channel
-    // continuously, and we consume blocks as fast as we can process them.
-    let Some(reader) = &state.usb_reader else {
-        return;
     };
 
-    // Read from the lock-free ring buffer and convert to IQ in one step.
-    let Some(iq_count) = reader.try_read_into(&mut state.iq_buf) else {
-        // No data yet — yield to avoid busy-waiting.
-        std::thread::yield_now();
-        return;
+    let iq_count = match source.read_samples(&mut state.iq_buf) {
+        Ok(0) => {
+            std::thread::yield_now();
+            return;
+        }
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!("source read error: {e}");
+            return;
+        }
     };
-
-    if iq_count == 0 {
-        return;
-    }
 
     // Process through IQ frontend (decimation, DC blocking, FFT).
     match state.frontend.process(
@@ -933,11 +764,9 @@ mod tests {
 
     /// Compile-time validation that DSP buffer constants are consistent.
     const _: () = {
-        assert!(RAW_BUF_SIZE == IQ_PAIRS_PER_READ * 2);
         assert!(DEFAULT_FFT_SIZE > 0);
         assert!(DEFAULT_SAMPLE_RATE > 0.0);
         assert!(DEFAULT_CENTER_FREQ > 0.0);
-        assert!(USB_READER_QUEUE_DEPTH > 0);
         assert!(RECV_TIMEOUT_MS > 0);
         assert!(VFO_OUTPUT_PADDING > 0);
     };
@@ -946,8 +775,7 @@ mod tests {
     fn dsp_state_creates_successfully() {
         let state = DspState::new().unwrap();
         assert!(!state.running);
-        assert!(state.device.is_none());
-        assert!(state.usb_reader.is_none());
+        assert!(state.source.is_none());
         assert_eq!(state.iq_buf.len(), IQ_PAIRS_PER_READ);
         assert_eq!(state.fft_buf.len(), DEFAULT_FFT_SIZE);
         // VFO starts as None (created on device open).
@@ -958,7 +786,7 @@ mod tests {
     #[test]
     fn rebuild_vfo_creates_vfo_and_sets_radio_rate() {
         let mut state = DspState::new().unwrap();
-        // Simulate what open_device does: frontend is already built at default rate.
+        // Simulate what open_source does: frontend is already built at default rate.
         rebuild_vfo(&mut state).unwrap();
         assert!(state.vfo.is_some());
     }

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -22,6 +22,17 @@ pub enum DspToUi {
     GainList(Vec<f64>),
 }
 
+/// Available source types for IQ input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceType {
+    /// RTL-SDR USB dongle.
+    RtlSdr,
+    /// TCP/UDP network IQ stream.
+    Network,
+    /// WAV file playback.
+    File,
+}
+
 /// Messages sent from the UI thread to the DSP pipeline thread.
 #[derive(Debug)]
 pub enum UiToDsp {
@@ -77,6 +88,12 @@ pub enum UiToDsp {
     SetHighPass(bool),
     /// Set the audio output device by `PipeWire` node name.
     SetAudioDevice(String),
+    /// Switch the source type (stops current source if running).
+    SetSourceType(SourceType),
+    /// Configure network source hostname and port.
+    SetNetworkConfig { hostname: String, port: u16 },
+    /// Set the file path for file source playback.
+    SetFilePath(std::path::PathBuf),
 }
 
 #[cfg(test)]
@@ -191,5 +208,39 @@ mod tests {
 
         let device = UiToDsp::SetAudioDevice("default".to_string());
         assert!(matches!(device, UiToDsp::SetAudioDevice(ref s) if s == "default"));
+
+        let src_type = UiToDsp::SetSourceType(SourceType::RtlSdr);
+        assert!(matches!(src_type, UiToDsp::SetSourceType(SourceType::RtlSdr)));
+
+        let src_net = UiToDsp::SetSourceType(SourceType::Network);
+        assert!(matches!(src_net, UiToDsp::SetSourceType(SourceType::Network)));
+
+        let src_file = UiToDsp::SetSourceType(SourceType::File);
+        assert!(matches!(src_file, UiToDsp::SetSourceType(SourceType::File)));
+
+        let net_cfg = UiToDsp::SetNetworkConfig {
+            hostname: "192.168.1.1".to_string(),
+            port: 4321,
+        };
+        assert!(matches!(
+            net_cfg,
+            UiToDsp::SetNetworkConfig { ref hostname, port: 4321 } if hostname == "192.168.1.1"
+        ));
+
+        let file_path = UiToDsp::SetFilePath(std::path::PathBuf::from("/tmp/test.wav"));
+        assert!(matches!(
+            file_path,
+            UiToDsp::SetFilePath(ref p) if p == std::path::Path::new("/tmp/test.wav")
+        ));
+    }
+
+    #[test]
+    fn test_source_type_variants() {
+        assert_eq!(SourceType::RtlSdr, SourceType::RtlSdr);
+        assert_ne!(SourceType::RtlSdr, SourceType::Network);
+        assert_ne!(SourceType::Network, SourceType::File);
+
+        let types = [SourceType::RtlSdr, SourceType::Network, SourceType::File];
+        assert_eq!(types.len(), 3);
     }
 }

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -90,8 +90,12 @@ pub enum UiToDsp {
     SetAudioDevice(String),
     /// Switch the source type (stops current source if running).
     SetSourceType(SourceType),
-    /// Configure network source hostname and port.
-    SetNetworkConfig { hostname: String, port: u16 },
+    /// Configure network source hostname, port, and protocol.
+    SetNetworkConfig {
+        hostname: String,
+        port: u16,
+        protocol: sdr_types::Protocol,
+    },
     /// Set the file path for file source playback.
     SetFilePath(std::path::PathBuf),
 }
@@ -227,10 +231,11 @@ mod tests {
         let net_cfg = UiToDsp::SetNetworkConfig {
             hostname: "192.168.1.1".to_string(),
             port: 4321,
+            protocol: sdr_types::Protocol::TcpClient,
         };
         assert!(matches!(
             net_cfg,
-            UiToDsp::SetNetworkConfig { ref hostname, port: 4321 } if hostname == "192.168.1.1"
+            UiToDsp::SetNetworkConfig { ref hostname, port: 4321, .. } if hostname == "192.168.1.1"
         ));
 
         let file_path = UiToDsp::SetFilePath(std::path::PathBuf::from("/tmp/test.wav"));

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -210,10 +210,16 @@ mod tests {
         assert!(matches!(device, UiToDsp::SetAudioDevice(ref s) if s == "default"));
 
         let src_type = UiToDsp::SetSourceType(SourceType::RtlSdr);
-        assert!(matches!(src_type, UiToDsp::SetSourceType(SourceType::RtlSdr)));
+        assert!(matches!(
+            src_type,
+            UiToDsp::SetSourceType(SourceType::RtlSdr)
+        ));
 
         let src_net = UiToDsp::SetSourceType(SourceType::Network);
-        assert!(matches!(src_net, UiToDsp::SetSourceType(SourceType::Network)));
+        assert!(matches!(
+            src_net,
+            UiToDsp::SetSourceType(SourceType::Network)
+        ));
 
         let src_file = UiToDsp::SetSourceType(SourceType::File);
         assert!(matches!(src_file, UiToDsp::SetSourceType(SourceType::File)));

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -197,7 +197,6 @@ fn connect_device_visibility(
             port_row.set_visible(is_network);
             protocol_row.set_visible(is_network);
 
-            // TODO(issue #92): send device change to DSP pipeline
             tracing::debug!(device = selected, "source device changed");
         }
     ));

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -9,6 +9,8 @@ use libadwaita::prelude::*;
 const DEVICE_RTLSDR: u32 = 0;
 /// Device selector index for Network.
 const DEVICE_NETWORK: u32 = 1;
+/// Device selector index for File.
+const DEVICE_FILE: u32 = 2;
 
 /// Default gain in dB.
 const DEFAULT_GAIN_DB: f64 = 0.0;
@@ -50,6 +52,8 @@ pub struct SourcePanel {
     pub port_row: adw::SpinRow,
     /// Network protocol selector (TCP, UDP).
     pub protocol_row: adw::ComboRow,
+    /// File path entry (File source).
+    pub file_path_row: adw::EntryRow,
     /// DC blocking filter toggle (always visible).
     pub dc_blocking_row: adw::SwitchRow,
     /// IQ correction toggle (always visible).
@@ -162,6 +166,7 @@ fn build_common_rows() -> (
 }
 
 /// Wire the device selector to show/hide source-specific rows.
+#[allow(clippy::too_many_arguments)]
 fn connect_device_visibility(
     device_row: &adw::ComboRow,
     sample_rate_row: &adw::ComboRow,
@@ -170,6 +175,7 @@ fn connect_device_visibility(
     hostname_row: &adw::EntryRow,
     port_row: &adw::SpinRow,
     protocol_row: &adw::ComboRow,
+    file_path_row: &adw::EntryRow,
 ) {
     device_row.connect_selected_notify(glib::clone!(
         #[weak]
@@ -184,10 +190,13 @@ fn connect_device_visibility(
         port_row,
         #[weak]
         protocol_row,
+        #[weak]
+        file_path_row,
         move |row| {
             let selected = row.selected();
             let is_rtlsdr = selected == DEVICE_RTLSDR;
             let is_network = selected == DEVICE_NETWORK;
+            let is_file = selected == DEVICE_FILE;
 
             sample_rate_row.set_visible(is_rtlsdr);
             gain_row.set_visible(is_rtlsdr);
@@ -196,6 +205,8 @@ fn connect_device_visibility(
             hostname_row.set_visible(is_network);
             port_row.set_visible(is_network);
             protocol_row.set_visible(is_network);
+
+            file_path_row.set_visible(is_file);
 
             tracing::debug!(device = selected, "source device changed");
         }
@@ -217,6 +228,11 @@ pub fn build_source_panel() -> SourcePanel {
 
     let (sample_rate_row, gain_row, agc_row) = build_rtlsdr_rows();
     let (hostname_row, port_row, protocol_row) = build_network_rows();
+    let file_path_row = adw::EntryRow::builder()
+        .title("File Path")
+        .text("")
+        .visible(false)
+        .build();
     let (dc_blocking_row, iq_correction_row, iq_inversion_row, decimation_row) =
         build_common_rows();
 
@@ -228,6 +244,7 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&hostname_row);
     group.add(&port_row);
     group.add(&protocol_row);
+    group.add(&file_path_row);
     group.add(&dc_blocking_row);
     group.add(&iq_correction_row);
     group.add(&iq_inversion_row);
@@ -237,12 +254,14 @@ pub fn build_source_panel() -> SourcePanel {
     let selected = device_row.selected();
     let is_rtlsdr = selected == DEVICE_RTLSDR;
     let is_network = selected == DEVICE_NETWORK;
+    let is_file = selected == DEVICE_FILE;
     sample_rate_row.set_visible(is_rtlsdr);
     gain_row.set_visible(is_rtlsdr);
     agc_row.set_visible(is_rtlsdr);
     hostname_row.set_visible(is_network);
     port_row.set_visible(is_network);
     protocol_row.set_visible(is_network);
+    file_path_row.set_visible(is_file);
 
     connect_device_visibility(
         &device_row,
@@ -252,6 +271,7 @@ pub fn build_source_panel() -> SourcePanel {
         &hostname_row,
         &port_row,
         &protocol_row,
+        &file_path_row,
     );
 
     // Controls connected to DSP pipeline via window.rs
@@ -265,6 +285,7 @@ pub fn build_source_panel() -> SourcePanel {
         hostname_row,
         port_row,
         protocol_row,
+        file_path_row,
         dc_blocking_row,
         iq_correction_row,
         iq_inversion_row,

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -209,8 +209,7 @@ pub fn build_source_panel() -> SourcePanel {
         .description("Device and input configuration")
         .build();
 
-    // File source omitted until a file picker is implemented.
-    let device_model = gtk4::StringList::new(&["RTL-SDR", "Network"]);
+    let device_model = gtk4::StringList::new(&["RTL-SDR", "Network", "File"]);
     let device_row = adw::ComboRow::builder()
         .title("Device")
         .model(&device_model)

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -536,6 +536,29 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         });
     });
 
+    // Network protocol
+    let state_proto = Rc::clone(state);
+    let host_for_proto = panels.source.hostname_row.clone();
+    let port_for_proto = panels.source.port_row.clone();
+    panels
+        .source
+        .protocol_row
+        .connect_selected_notify(move |row| {
+            let hostname = host_for_proto.text().to_string();
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let port = port_for_proto.value() as u16;
+            let protocol = if row.selected() == 1 {
+                sdr_types::Protocol::Udp
+            } else {
+                sdr_types::Protocol::TcpClient
+            };
+            state_proto.send_dsp(UiToDsp::SetNetworkConfig {
+                hostname,
+                port,
+                protocol,
+            });
+        });
+
     // File path (apply on Enter key)
     let state_file = Rc::clone(state);
     panels.source.file_path_row.connect_apply(move |row| {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -417,6 +417,7 @@ fn connect_sidebar_panels(
 }
 
 /// Connect source panel controls to DSP commands.
+#[allow(clippy::too_many_lines)]
 fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
     // Sample rate selector
     let state_sr = Rc::clone(state);
@@ -498,21 +499,41 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
     // Network hostname (fires on Enter key)
     let state_host = Rc::clone(state);
     let port_for_host = panels.source.port_row.clone();
+    let proto_for_host = panels.source.protocol_row.clone();
     panels.source.hostname_row.connect_apply(move |row| {
         let hostname = row.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = port_for_host.value() as u16;
-        state_host.send_dsp(UiToDsp::SetNetworkConfig { hostname, port });
+        let protocol = if proto_for_host.selected() == 1 {
+            sdr_types::Protocol::Udp
+        } else {
+            sdr_types::Protocol::TcpClient
+        };
+        state_host.send_dsp(UiToDsp::SetNetworkConfig {
+            hostname,
+            port,
+            protocol,
+        });
     });
 
     // Network port
     let state_port = Rc::clone(state);
     let host_for_port = panels.source.hostname_row.clone();
+    let proto_for_port = panels.source.protocol_row.clone();
     panels.source.port_row.connect_value_notify(move |row| {
         let hostname = host_for_port.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = row.value() as u16;
-        state_port.send_dsp(UiToDsp::SetNetworkConfig { hostname, port });
+        let protocol = if proto_for_port.selected() == 1 {
+            sdr_types::Protocol::Udp
+        } else {
+            sdr_types::Protocol::TcpClient
+        };
+        state_port.send_dsp(UiToDsp::SetNetworkConfig {
+            hostname,
+            port,
+            protocol,
+        });
     });
 
     // File path (apply on Enter key)

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -16,7 +16,7 @@ use sdr_source_rtlsdr::SAMPLE_RATES;
 use crate::dsp_controller;
 use crate::header;
 use crate::header::demod_selector;
-use crate::messages::{DspToUi, UiToDsp};
+use crate::messages::{DspToUi, SourceType, UiToDsp};
 use crate::shortcuts;
 use crate::sidebar;
 use crate::sidebar::SidebarPanels;
@@ -480,6 +480,40 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         .connect_active_notify(move |row| {
             state_iq_corr.send_dsp(UiToDsp::SetIqCorrection(row.is_active()));
         });
+
+    // Source type selector
+    let state_source = Rc::clone(state);
+    panels
+        .source
+        .device_row
+        .connect_selected_notify(move |row| {
+            let source_type = match row.selected() {
+                1 => SourceType::Network,
+                2 => SourceType::File,
+                _ => SourceType::RtlSdr,
+            };
+            state_source.send_dsp(UiToDsp::SetSourceType(source_type));
+        });
+
+    // Network hostname (fires on Enter key)
+    let state_host = Rc::clone(state);
+    let port_for_host = panels.source.port_row.clone();
+    panels.source.hostname_row.connect_apply(move |row| {
+        let hostname = row.text().to_string();
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let port = port_for_host.value() as u16;
+        state_host.send_dsp(UiToDsp::SetNetworkConfig { hostname, port });
+    });
+
+    // Network port
+    let state_port = Rc::clone(state);
+    let host_for_port = panels.source.hostname_row.clone();
+    panels.source.port_row.connect_value_notify(move |row| {
+        let hostname = host_for_port.text().to_string();
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let port = row.value() as u16;
+        state_port.send_dsp(UiToDsp::SetNetworkConfig { hostname, port });
+    });
 }
 
 /// Connect radio panel controls to DSP commands.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -514,6 +514,13 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         let port = row.value() as u16;
         state_port.send_dsp(UiToDsp::SetNetworkConfig { hostname, port });
     });
+
+    // File path (apply on Enter key)
+    let state_file = Rc::clone(state);
+    panels.source.file_path_row.connect_apply(move |row| {
+        let path = std::path::PathBuf::from(row.text().to_string());
+        state_file.send_dsp(UiToDsp::SetFilePath(path));
+    });
 }
 
 /// Connect radio panel controls to DSP commands.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -482,25 +482,26 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             state_iq_corr.send_dsp(UiToDsp::SetIqCorrection(row.is_active()));
         });
 
-    // Source type selector
+    // Source type selector — guard against transient out-of-range indices
     let state_source = Rc::clone(state);
     panels
         .source
         .device_row
         .connect_selected_notify(move |row| {
             let source_type = match row.selected() {
+                0 => SourceType::RtlSdr,
                 1 => SourceType::Network,
                 2 => SourceType::File,
-                _ => SourceType::RtlSdr,
+                _ => return, // ignore transient indices
             };
             state_source.send_dsp(UiToDsp::SetSourceType(source_type));
         });
 
-    // Network hostname (fires on Enter key)
+    // Network hostname — send on every edit so Play always has current value
     let state_host = Rc::clone(state);
     let port_for_host = panels.source.port_row.clone();
     let proto_for_host = panels.source.protocol_row.clone();
-    panels.source.hostname_row.connect_apply(move |row| {
+    panels.source.hostname_row.connect_changed(move |row| {
         let hostname = row.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = port_for_host.value() as u16;
@@ -547,10 +548,10 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             let hostname = host_for_proto.text().to_string();
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let port = port_for_proto.value() as u16;
-            let protocol = if row.selected() == 1 {
-                sdr_types::Protocol::Udp
-            } else {
-                sdr_types::Protocol::TcpClient
+            let protocol = match row.selected() {
+                0 => sdr_types::Protocol::TcpClient,
+                1 => sdr_types::Protocol::Udp,
+                _ => return, // ignore transient indices
             };
             state_proto.send_dsp(UiToDsp::SetNetworkConfig {
                 hostname,
@@ -559,9 +560,9 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             });
         });
 
-    // File path (apply on Enter key)
+    // File path — send on every edit so Play always has current value
     let state_file = Rc::clone(state);
-    panels.source.file_path_row.connect_apply(move |row| {
+    panels.source.file_path_row.connect_changed(move |row| {
         let path = std::path::PathBuf::from(row.text().to_string());
         state_file.send_dsp(UiToDsp::SetFilePath(path));
     });

--- a/docs/superpowers/plans/2026-04-07-source-switching.md
+++ b/docs/superpowers/plans/2026-04-07-source-switching.md
@@ -1,0 +1,483 @@
+# Source Switching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded RTL-SDR device in the DSP controller with a trait-based source abstraction supporting RTL-SDR, Network, and File sources, with live switching from the UI sidebar.
+
+**Architecture:** Extend the existing `Source` trait in `sdr-pipeline` with `read_samples()` and gain methods. Move the USB ring buffer into `RtlSdrSource` so each source handles its own I/O. Refactor `DspState` to hold `Box<dyn Source>` instead of `RtlSdrDevice`. Wire the source panel dropdown to a new `SetSourceType` message.
+
+**Tech Stack:** Rust, GTK4/libadwaita, PipeWire, rusb, sdr-pipeline Source trait
+
+---
+
+### Task 1: Extend Source Trait with read_samples and gain methods
+
+**Files:**
+- Modify: `crates/sdr-pipeline/src/source_manager.rs`
+- Modify: `crates/sdr-types/src/error.rs` (add ReadFailed variant)
+
+- [ ] **Step 1: Add ReadFailed to SourceError**
+
+In `crates/sdr-types/src/error.rs`, add after `AlreadyRunning`:
+```rust
+#[error("read failed: {0}")]
+ReadFailed(String),
+```
+
+- [ ] **Step 2: Add read_samples and gain methods to Source trait**
+
+In `crates/sdr-pipeline/src/source_manager.rs`, add to the `Source` trait after `set_sample_rate`:
+```rust
+/// Read IQ samples into the output buffer. Returns number of Complex samples written.
+/// May block briefly waiting for data. Each source handles its own I/O mechanism.
+fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError>;
+
+/// Set tuner gain in tenths of dB (RTL-SDR specific, no-op for others).
+fn set_gain(&mut self, _gain_tenths: i32) -> Result<(), SourceError> { Ok(()) }
+
+/// Set AGC mode (RTL-SDR specific, no-op for others).
+fn set_gain_mode(&mut self, _manual: bool) -> Result<(), SourceError> { Ok(()) }
+
+/// Get available gain values in tenths of dB (empty for non-tuner sources).
+fn gains(&self) -> &[i32] { &[] }
+```
+
+Add `use sdr_types::Complex;` to imports.
+
+- [ ] **Step 3: Update MockSource and TrackingSource in tests**
+
+Add `read_samples` implementations returning DC silence:
+```rust
+fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+    for s in output.iter_mut() { *s = Complex::default(); }
+    Ok(output.len())
+}
+```
+
+- [ ] **Step 4: Build and run tests**
+
+Run: `cargo test -p sdr-pipeline -p sdr-types`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-pipeline/src/source_manager.rs crates/sdr-types/src/error.rs
+git commit -m "extend Source trait with read_samples and gain methods"
+```
+
+---
+
+### Task 2: Implement read_samples for RtlSdrSource (with ring buffer)
+
+**Files:**
+- Modify: `crates/sdr-source-rtlsdr/src/lib.rs`
+
+The key architectural decision: move the ring buffer from `dsp_controller.rs` into `RtlSdrSource`. When `start()` is called, spawn the USB reader thread. `read_samples()` reads from the ring buffer and converts u8→Complex.
+
+- [ ] **Step 1: Add ring buffer and reader thread to RtlSdrSource**
+
+Add fields to `RtlSdrSource`:
+```rust
+pub struct RtlSdrSource {
+    device: Option<RtlSdrDevice>,
+    device_index: u32,
+    sample_rate: f64,
+    frequency: f64,
+    running: Arc<AtomicBool>,
+    // Ring buffer for async USB reads
+    ring: Option<Arc<UsbRingBuffer>>,
+    reader_thread: Option<std::thread::JoinHandle<()>>,
+}
+```
+
+Copy `RingSlot` and `UsbRingBuffer` structs from `dsp_controller.rs` into this file (they're self-contained). Add ring buffer constants:
+```rust
+const RAW_BUF_SIZE: usize = 16_384 * 2; // 16K IQ pairs × 2 bytes
+const RING_SLOTS: usize = 32;
+```
+
+- [ ] **Step 2: Update start() to spawn the reader thread**
+
+In `start()`, after opening the device and configuring it, spawn the USB reader thread:
+```rust
+fn start(&mut self) -> Result<(), SourceError> {
+    // ... existing open/configure code ...
+    
+    let ring = Arc::new(UsbRingBuffer::new(RING_SLOTS, RAW_BUF_SIZE));
+    let ring_writer = Arc::clone(&ring);
+    let cancel = Arc::clone(&self.running);
+    let handle = self.device.as_ref().unwrap().usb_handle();
+    
+    let thread = std::thread::Builder::new()
+        .name("rtlsdr-reader".to_string())
+        .spawn(move || { /* USB read loop */ })
+        .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
+    
+    self.ring = Some(ring);
+    self.reader_thread = Some(thread);
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Implement read_samples()**
+
+```rust
+fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+    let ring = self.ring.as_ref().ok_or(SourceError::NotRunning)?;
+    // Try to read from ring buffer, convert u8→Complex
+    let idx = ring.read_idx.load(Ordering::Relaxed) % ring.slot_count;
+    let slot = &ring.slots[idx];
+    if slot.state.load(Ordering::Acquire) != 1 {
+        return Ok(0); // No data available yet
+    }
+    let len = slot.len.load(Ordering::Relaxed);
+    let count = {
+        let data = slot.data.lock().expect("ring slot poisoned");
+        Self::convert_samples(&data[..len], output)
+    };
+    slot.state.store(0, Ordering::Release);
+    ring.read_idx.fetch_add(1, Ordering::Relaxed);
+    Ok(count)
+}
+```
+
+- [ ] **Step 4: Update stop() to join the reader thread**
+
+```rust
+fn stop(&mut self) -> Result<(), SourceError> {
+    self.running.store(false, Ordering::Relaxed);
+    if let Some(thread) = self.reader_thread.take() {
+        let _ = thread.join();
+    }
+    self.ring = None;
+    self.device = None;
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Implement gain methods**
+
+```rust
+fn set_gain(&mut self, gain_tenths: i32) -> Result<(), SourceError> { ... }
+fn set_gain_mode(&mut self, manual: bool) -> Result<(), SourceError> { ... }
+fn gains(&self) -> &[i32] { ... }
+```
+
+- [ ] **Step 6: Build and test**
+
+Run: `cargo test -p sdr-source-rtlsdr`
+Expected: All pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/sdr-source-rtlsdr/
+git commit -m "implement read_samples for RtlSdrSource with ring buffer"
+```
+
+---
+
+### Task 3: Implement read_samples for NetworkSource and FileSource
+
+**Files:**
+- Modify: `crates/sdr-source-network/src/lib.rs`
+- Modify: `crates/sdr-source-file/src/lib.rs`
+
+Both already have internal `read_samples()` methods — just need to expose them via the trait.
+
+- [ ] **Step 1: NetworkSource — delegate to existing read_samples**
+
+The existing `read_samples()` at line 72 is a standalone method, not a trait impl. Wire it:
+```rust
+fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+    // Call the existing method (self.read_samples is the internal one)
+    NetworkSource::read_samples_internal(self, output)
+}
+```
+Or rename the internal method to avoid conflict.
+
+- [ ] **Step 2: FileSource — delegate to existing read_samples**
+
+Same pattern — wire the existing `read_samples()` method as the trait impl.
+
+- [ ] **Step 3: Build and test**
+
+Run: `cargo test -p sdr-source-network -p sdr-source-file`
+Expected: All pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-source-network/ crates/sdr-source-file/
+git commit -m "implement Source::read_samples for network and file sources"
+```
+
+---
+
+### Task 4: Refactor DspState to use Box<dyn Source>
+
+**Files:**
+- Modify: `crates/sdr-ui/src/dsp_controller.rs`
+
+This is the largest task. Replace `device: Option<RtlSdrDevice>` and `usb_reader: Option<UsbReader>` with `source: Option<Box<dyn Source>>`.
+
+- [ ] **Step 1: Remove UsbReader, UsbRingBuffer, RingSlot from dsp_controller**
+
+Delete the entire ring buffer infrastructure (lines 130-266) — it's now inside RtlSdrSource.
+
+- [ ] **Step 2: Update DspState struct**
+
+Replace:
+```rust
+device: Option<RtlSdrDevice>,
+usb_reader: Option<UsbReader>,
+```
+With:
+```rust
+source: Option<Box<dyn Source>>,
+```
+
+Remove `use sdr_rtlsdr::RtlSdrDevice;` import. Add `use sdr_pipeline::source_manager::Source;`.
+
+- [ ] **Step 3: Update DspState::new()**
+
+Initialize with `source: None` instead of `device: None, usb_reader: None`.
+
+- [ ] **Step 4: Refactor open_device() → open_source()**
+
+Replace hardcoded RTL-SDR open with Source trait calls:
+```rust
+fn open_source(state: &mut DspState) -> Result<(), String> {
+    let mut source = Box::new(RtlSdrSource::new(DEVICE_INDEX));
+    source.set_sample_rate(state.sample_rate)
+        .map_err(|e| e.to_string())?;
+    source.tune(state.center_freq)
+        .map_err(|e| e.to_string())?;
+    source.start()
+        .map_err(|e| e.to_string())?;
+    
+    rebuild_frontend(state)?;
+    rebuild_vfo(state)?;
+    state.source = Some(source);
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Update cleanup()**
+
+```rust
+fn cleanup(state: &mut DspState) {
+    if let Some(source) = &mut state.source {
+        let _ = source.stop();
+    }
+    state.source = None;
+    // ... audio sink stop ...
+}
+```
+
+- [ ] **Step 6: Update process_iq_block()**
+
+Replace ring buffer reading with `source.read_samples()`:
+```rust
+let Some(source) = &mut state.source else { return; };
+let iq_count = match source.read_samples(&mut state.iq_buf) {
+    Ok(0) => { std::thread::yield_now(); return; }
+    Ok(n) => n,
+    Err(e) => { tracing::warn!("source read error: {e}"); return; }
+};
+```
+
+- [ ] **Step 7: Update Tune, SetSampleRate, SetGain, SetAgc handlers**
+
+Route through Source trait methods:
+```rust
+UiToDsp::Tune(freq) => {
+    state.center_freq = freq;
+    if let Some(source) = &mut state.source {
+        if let Err(e) = source.tune(freq) { ... }
+    }
+}
+UiToDsp::SetGain(gain_db) => {
+    if let Some(source) = &mut state.source {
+        let gain_tenths = (gain_db * 10.0) as i32;
+        if let Err(e) = source.set_gain(gain_tenths) { ... }
+    }
+}
+```
+
+- [ ] **Step 8: Update GainList sending on Start**
+
+```rust
+if let Some(source) = &state.source {
+    let gains: Vec<f64> = source.gains()
+        .iter()
+        .map(|&g| f64::from(g) / 10.0)
+        .collect();
+    if !gains.is_empty() {
+        let _ = dsp_tx.send(DspToUi::GainList(gains));
+    }
+}
+```
+
+- [ ] **Step 9: Build and test**
+
+Run: `cargo test --workspace`
+Expected: All pass (behavior unchanged, just refactored)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/sdr-ui/src/dsp_controller.rs
+git commit -m "refactor DspState to use Box<dyn Source> instead of RtlSdrDevice"
+```
+
+---
+
+### Task 5: Add source switching messages and handler
+
+**Files:**
+- Modify: `crates/sdr-ui/src/messages.rs`
+- Modify: `crates/sdr-ui/src/dsp_controller.rs`
+
+- [ ] **Step 1: Add SourceType enum and message**
+
+In `messages.rs`:
+```rust
+/// Available source types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceType {
+    RtlSdr,
+    Network,
+    File,
+}
+```
+
+Add to `UiToDsp`:
+```rust
+SetSourceType(SourceType),
+SetNetworkConfig { hostname: String, port: u16 },
+SetFilePath(std::path::PathBuf),
+```
+
+- [ ] **Step 2: Add SetSourceType handler in dsp_controller**
+
+```rust
+UiToDsp::SetSourceType(source_type) => {
+    let was_running = state.source.is_some();
+    if was_running { cleanup(state); }
+    state.source_type = source_type;
+    // Don't auto-start — user needs to press play
+}
+```
+
+Add `source_type: SourceType` to DspState, update `open_source()` to create the right source type based on it.
+
+- [ ] **Step 3: Update open_source to be source-type-aware**
+
+```rust
+fn open_source(state: &mut DspState) -> Result<(), String> {
+    let mut source: Box<dyn Source> = match state.source_type {
+        SourceType::RtlSdr => Box::new(RtlSdrSource::new(DEVICE_INDEX)),
+        SourceType::Network => {
+            let mut ns = NetworkSource::new(&state.network_host, state.network_port, ...);
+            ns
+        }
+        SourceType::File => {
+            let mut fs = FileSource::new(&state.file_path);
+            fs
+        }
+    };
+    source.set_sample_rate(state.sample_rate).map_err(|e| e.to_string())?;
+    source.start().map_err(|e| e.to_string())?;
+    // ... rest of setup ...
+}
+```
+
+- [ ] **Step 4: Add message test**
+
+- [ ] **Step 5: Build and test**
+
+Run: `cargo test --workspace`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-ui/
+git commit -m "add source switching messages and handler"
+```
+
+---
+
+### Task 6: Wire source panel UI controls
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/source_panel.rs`
+- Modify: `crates/sdr-ui/src/window.rs`
+
+- [ ] **Step 1: Remove TODO and wire device_row to send SetSourceType**
+
+In `source_panel.rs` `connect_device_visibility`, replace the TODO with actual DSP send. Need to pass AppState into this function.
+
+- [ ] **Step 2: Wire network hostname/port controls**
+
+Connect `hostname_row` and `port_row` to send `SetNetworkConfig` when changed.
+
+- [ ] **Step 3: Add connect_device_visibility AppState parameter**
+
+Update the function signature to accept `&Rc<AppState>` and send messages.
+
+- [ ] **Step 4: Update connect_source_panel in window.rs**
+
+Pass `state` through to `connect_device_visibility`.
+
+- [ ] **Step 5: Build, test, install**
+
+Run: `cargo test --workspace && make install`
+
+- [ ] **Step 6: Manual test**
+
+- Switch between RTL-SDR and Network in the dropdown
+- Verify RTL-SDR controls show/hide correctly
+- Verify source switching restarts properly
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/sdr-ui/
+git commit -m "wire source panel controls to DSP source switching"
+```
+
+---
+
+### Task 7: Final integration and cleanup
+
+**Files:**
+- Modify: `crates/sdr-ui/Cargo.toml` (remove direct rusb dependency if no longer needed)
+- Modify: Various files for clippy cleanup
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cargo test --workspace
+cargo clippy --all-targets --workspace -- -D warnings
+cargo fmt --all -- --check
+```
+
+- [ ] **Step 2: Remove unused imports and dead code**
+
+Clean up any remaining `use sdr_rtlsdr::RtlSdrDevice` references, unused `rusb` imports, etc.
+
+- [ ] **Step 3: Make install and manual test**
+
+Test all three source types:
+- RTL-SDR: tune to FM station, verify audio
+- Network: won't connect without a server, but verify no crash
+- File: won't play without a WAV, but verify source switch works
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "source switching: cleanup and integration"
+```


### PR DESCRIPTION
## Summary

Major architecture refactor: replace hardcoded RTL-SDR device with trait-based source abstraction supporting live switching between RTL-SDR, Network (TCP/UDP), and File (WAV) sources.

### Architecture
- **Source trait** extended with `read_samples()`, `set_gain()`, `set_gain_mode()`, `gains()`
- **RtlSdrSource** now owns its USB ring buffer and reader thread internally
- **DspState** uses `Box<dyn Source>` instead of `Option<RtlSdrDevice>`
- All device operations (tune, gain, AGC, sample rate, read) route through the trait
- Each source handles its own I/O mechanism (USB ring buffer, TCP/UDP socket, WAV file reader)

### Changes by commit
1. Extend Source trait with `read_samples` and gain methods
2. Move USB ring buffer into RtlSdrSource with `read_samples` impl
3. Wire NetworkSource and FileSource `read_samples` via trait
4. Refactor DspState: `Box<dyn Source>` replaces `RtlSdrDevice` + `UsbReader`
5. Add SourceType enum, SetSourceType/SetNetworkConfig/SetFilePath messages
6. Wire source panel dropdown to DSP source switching
7. Final cleanup (remove dead `rusb` dependency)
8. Add File source to dropdown with file path entry row

### What works
- **RTL-SDR**: Full functionality — tune, gain, AGC, all sample rates, clear audio
- **Network**: Source selection works, shows hostname/port/protocol controls
- **File**: Source selection works, shows file path entry row
- **Live switching**: Switch between any source type, controls show/hide correctly

Closes #132

## Test plan
- [x] All workspace tests pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] Manual: RTL-SDR audio works after refactor
- [x] Manual: Source dropdown switches between RTL-SDR/Network/File
- [x] Manual: Controls show/hide correctly per source type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose IQ source at runtime (RTL‑SDR, Network, File) with UI controls for host/port/protocol and file path; live switching and persisted source settings.
  * Unified read_samples API with per-source gain controls and reporting.

* **Refactor**
  * DSP pipeline now uses pluggable source implementations; RTL‑SDR handling moved to a dedicated reader/queue model.

* **Bug Fixes**
  * Improved detection and reporting of read failures.

* **Tests**
  * Updated tests for new source messaging and behaviors.

* **Documentation**
  * Added source‑switching plan and validation notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->