### PR TITLE
Navigation and tuning: PPM correction, band presets, bookmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,8 @@ dependencies = [
  "sdr-source-network",
  "sdr-source-rtlsdr",
  "sdr-types",
+ "serde",
+ "serde_json",
  "thiserror",
  "tracing",
 ]

--- a/crates/sdr-pipeline/src/source_manager.rs
+++ b/crates/sdr-pipeline/src/source_manager.rs
@@ -48,6 +48,11 @@ pub trait Source: Send {
     fn gains(&self) -> &[i32] {
         &[]
     }
+
+    /// Set PPM frequency correction (no-op default for non-tuner sources).
+    fn set_ppm_correction(&mut self, _ppm: i32) -> Result<(), SourceError> {
+        Ok(())
+    }
 }
 
 /// Manages available IQ sources and the active source lifecycle.

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -324,6 +324,15 @@ impl Source for RtlSdrSource {
             &[]
         }
     }
+
+    fn set_ppm_correction(&mut self, ppm: i32) -> Result<(), SourceError> {
+        if let Some(device) = &mut self.device {
+            device
+                .set_freq_correction(ppm)
+                .map_err(|e| SourceError::TuneFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -27,6 +27,8 @@ libadwaita.workspace = true
 glow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -609,6 +609,16 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             tracing::debug!(?path, "set file path");
             state.file_path = path;
         }
+
+        UiToDsp::SetPpmCorrection(ppm) => {
+            tracing::debug!(ppm, "set PPM correction");
+            if let Some(source) = &mut state.source
+                && let Err(e) = source.set_ppm_correction(ppm)
+            {
+                tracing::warn!("set PPM correction failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("PPM correction failed: {e}")));
+            }
+        }
     }
 }
 

--- a/crates/sdr-ui/src/header/frequency_selector.rs
+++ b/crates/sdr-ui/src/header/frequency_selector.rs
@@ -25,6 +25,7 @@ const MAX_FREQUENCY_HZ: u64 = 999_999_999_999;
 const DIGITS_PER_GROUP: usize = 3;
 
 /// Frequency selector widget composed of 12 digit labels and 3 separator dots.
+#[derive(Clone)]
 pub struct FrequencySelector {
     /// The container widget to pack into the header bar.
     pub widget: gtk4::Box,
@@ -60,6 +61,17 @@ impl FrequencySelector {
     /// Register a callback invoked whenever the frequency changes from user interaction.
     pub fn connect_frequency_changed<F: Fn(u64) + 'static>(&self, f: F) {
         *self.on_changed.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Programmatically set the frequency and update the display.
+    ///
+    /// Does NOT fire the frequency-changed callback — callers are responsible
+    /// for sending DSP commands and updating the status bar.
+    pub fn set_frequency(&self, freq: u64) {
+        let clamped = freq.min(MAX_FREQUENCY_HZ);
+        self.frequency.set(clamped);
+        let digits = frequency_to_digits(clamped);
+        update_labels_and_styles(&self.digit_labels, &digits, self.selected_digit.get());
     }
 }
 

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -98,6 +98,8 @@ pub enum UiToDsp {
     },
     /// Set the file path for file source playback.
     SetFilePath(std::path::PathBuf),
+    /// Set PPM frequency correction for RTL-SDR crystal offset.
+    SetPpmCorrection(i32),
 }
 
 #[cfg(test)]
@@ -243,6 +245,9 @@ mod tests {
             file_path,
             UiToDsp::SetFilePath(ref p) if p == std::path::Path::new("/tmp/test.wav")
         ));
+
+        let ppm = UiToDsp::SetPpmCorrection(42);
+        assert!(matches!(ppm, UiToDsp::SetPpmCorrection(42)));
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -1,14 +1,16 @@
-//! Sidebar configuration panels — source, audio, radio, display.
+//! Sidebar configuration panels — source, audio, radio, display, navigation.
 
 use gtk4::prelude::*;
 
 pub mod audio_panel;
 pub mod display_panel;
+pub mod navigation_panel;
 pub mod radio_panel;
 pub mod source_panel;
 
 pub use audio_panel::{AudioPanel, build_audio_panel};
 pub use display_panel::{DisplayPanel, build_display_panel};
+pub use navigation_panel::{NavigationPanel, build_navigation_panel};
 pub use radio_panel::{RadioPanel, build_radio_panel};
 pub use source_panel::{SourcePanel, build_source_panel};
 
@@ -27,6 +29,8 @@ pub struct SidebarPanels {
     pub radio: RadioPanel,
     /// Display / spectrum settings.
     pub display: DisplayPanel,
+    /// Navigation — band presets and bookmarks.
+    pub navigation: NavigationPanel,
 }
 
 /// Build the complete sidebar `ScrolledWindow` containing all configuration panels.
@@ -38,6 +42,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     let audio = build_audio_panel();
     let radio = build_radio_panel();
     let display = build_display_panel();
+    let navigation = build_navigation_panel();
 
     let sidebar_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
@@ -48,6 +53,8 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
         .margin_end(SIDEBAR_MARGIN)
         .build();
 
+    sidebar_box.append(&navigation.presets_widget);
+    sidebar_box.append(&navigation.bookmarks_widget);
     sidebar_box.append(&source.widget);
     sidebar_box.append(&audio.widget);
     sidebar_box.append(&radio.widget);
@@ -63,6 +70,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
         audio,
         radio,
         display,
+        navigation,
     };
 
     (scroll, panels)

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -234,6 +234,7 @@ pub fn build_navigation_panel() -> NavigationPanel {
     let preset_row = adw::ComboRow::builder()
         .title("Band")
         .model(&preset_model)
+        .selected(gtk4::INVALID_LIST_POSITION)
         .build();
     presets_group.add(&preset_row);
 

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -96,19 +96,14 @@ pub struct Bookmark {
 }
 
 impl Bookmark {
-    /// Create a bookmark from the current tuning state (internal).
-    fn new(name: &str, frequency: u64, demod_mode: DemodMode, bandwidth: f64) -> Self {
+    /// Create a bookmark from the current tuning state.
+    pub fn new(name: &str, frequency: u64, demod_mode: DemodMode, bandwidth: f64) -> Self {
         Self {
             name: name.to_string(),
             frequency,
             demod_mode: demod_mode_to_string(demod_mode),
             bandwidth,
         }
-    }
-
-    /// Create a bookmark from UI state (public for window.rs wiring).
-    pub fn new_pub(name: &str, frequency: u64, demod_mode: DemodMode, bandwidth: f64) -> Self {
-        Self::new(name, frequency, demod_mode, bandwidth)
     }
 }
 
@@ -150,10 +145,16 @@ fn bookmarks_path() -> std::path::PathBuf {
 
 fn load_bookmarks() -> Vec<Bookmark> {
     let path = bookmarks_path();
-    let Ok(data) = std::fs::read_to_string(path) else {
+    let Ok(data) = std::fs::read_to_string(&path) else {
         return Vec::new();
     };
-    serde_json::from_str(&data).unwrap_or_default()
+    match serde_json::from_str(&data) {
+        Ok(bookmarks) => bookmarks,
+        Err(e) => {
+            tracing::warn!(?path, "failed to parse bookmarks, starting fresh: {e}");
+            Vec::new()
+        }
+    }
 }
 
 pub fn save_bookmarks(bookmarks: &[Bookmark]) {
@@ -316,7 +317,7 @@ pub fn rebuild_bookmark_list(
     }
 
     let bm_list = bookmarks.borrow();
-    for (i, bm) in bm_list.iter().enumerate() {
+    for bm in bm_list.iter() {
         let row = adw::ActionRow::builder()
             .title(&bm.name)
             .subtitle(format!(
@@ -327,7 +328,7 @@ pub fn rebuild_bookmark_list(
             .activatable(true)
             .build();
 
-        // Delete button
+        // Delete button — identify by name + frequency rather than index
         let delete_btn = gtk4::Button::builder()
             .icon_name("user-trash-symbolic")
             .valign(gtk4::Align::Center)
@@ -338,8 +339,12 @@ pub fn rebuild_bookmark_list(
         let nav_rc = std::rc::Rc::clone(on_navigate);
         let list_ref = list_box.downgrade();
         let scroll_ref = scroll.downgrade();
+        let del_name = bm.name.clone();
+        let del_freq = bm.frequency;
         delete_btn.connect_clicked(move |_| {
-            bm_rc.borrow_mut().remove(i);
+            bm_rc
+                .borrow_mut()
+                .retain(|b| !(b.name == del_name && b.frequency == del_freq));
             save_bookmarks(&bm_rc.borrow());
             if let Some(lb) = list_ref.upgrade()
                 && let Some(sc) = scroll_ref.upgrade()

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -1,0 +1,438 @@
+//! Navigation panel — band presets and frequency bookmarks.
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use sdr_types::DemodMode;
+
+// ---------------------------------------------------------------------------
+// Band presets — static, well-known frequency bands
+// ---------------------------------------------------------------------------
+
+/// A predefined frequency band preset.
+struct BandPreset {
+    name: &'static str,
+    frequency: u64,
+    demod_mode: DemodMode,
+    bandwidth: f64,
+}
+
+/// Common band presets for North America / ITU Region 2.
+const BAND_PRESETS: &[BandPreset] = &[
+    BandPreset {
+        name: "FM Broadcast",
+        frequency: 98_100_000,
+        demod_mode: DemodMode::Wfm,
+        bandwidth: 150_000.0,
+    },
+    BandPreset {
+        name: "NOAA Weather",
+        frequency: 162_550_000,
+        demod_mode: DemodMode::Nfm,
+        bandwidth: 12_500.0,
+    },
+    BandPreset {
+        name: "Aviation (Guard)",
+        frequency: 121_500_000,
+        demod_mode: DemodMode::Am,
+        bandwidth: 8_333.0,
+    },
+    BandPreset {
+        name: "2m Calling",
+        frequency: 146_520_000,
+        demod_mode: DemodMode::Nfm,
+        bandwidth: 12_500.0,
+    },
+    BandPreset {
+        name: "70cm Calling",
+        frequency: 446_000_000,
+        demod_mode: DemodMode::Nfm,
+        bandwidth: 12_500.0,
+    },
+    BandPreset {
+        name: "Marine Ch 16",
+        frequency: 156_800_000,
+        demod_mode: DemodMode::Nfm,
+        bandwidth: 25_000.0,
+    },
+    BandPreset {
+        name: "FRS Ch 1",
+        frequency: 462_562_500,
+        demod_mode: DemodMode::Nfm,
+        bandwidth: 12_500.0,
+    },
+    BandPreset {
+        name: "MURS Ch 1",
+        frequency: 151_820_000,
+        demod_mode: DemodMode::Nfm,
+        bandwidth: 11_250.0,
+    },
+    BandPreset {
+        name: "CB Ch 19",
+        frequency: 27_185_000,
+        demod_mode: DemodMode::Am,
+        bandwidth: 10_000.0,
+    },
+    BandPreset {
+        name: "10m Calling",
+        frequency: 28_400_000,
+        demod_mode: DemodMode::Usb,
+        bandwidth: 2_700.0,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Bookmarks — user-saved frequencies with JSON persistence
+// ---------------------------------------------------------------------------
+
+/// A user-saved frequency bookmark.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Bookmark {
+    pub name: String,
+    pub frequency: u64,
+    pub demod_mode: String,
+    pub bandwidth: f64,
+}
+
+impl Bookmark {
+    /// Create a bookmark from the current tuning state (internal).
+    fn new(name: &str, frequency: u64, demod_mode: DemodMode, bandwidth: f64) -> Self {
+        Self {
+            name: name.to_string(),
+            frequency,
+            demod_mode: demod_mode_to_string(demod_mode),
+            bandwidth,
+        }
+    }
+
+    /// Create a bookmark from UI state (public for window.rs wiring).
+    pub fn new_pub(name: &str, frequency: u64, demod_mode: DemodMode, bandwidth: f64) -> Self {
+        Self::new(name, frequency, demod_mode, bandwidth)
+    }
+}
+
+fn demod_mode_to_string(mode: DemodMode) -> String {
+    match mode {
+        DemodMode::Wfm => "WFM",
+        DemodMode::Nfm => "NFM",
+        DemodMode::Am => "AM",
+        DemodMode::Usb => "USB",
+        DemodMode::Lsb => "LSB",
+        DemodMode::Dsb => "DSB",
+        DemodMode::Cw => "CW",
+        DemodMode::Raw => "RAW",
+    }
+    .to_string()
+}
+
+fn string_to_demod_mode(s: &str) -> DemodMode {
+    match s {
+        "WFM" => DemodMode::Wfm,
+        "AM" => DemodMode::Am,
+        "USB" => DemodMode::Usb,
+        "LSB" => DemodMode::Lsb,
+        "DSB" => DemodMode::Dsb,
+        "CW" => DemodMode::Cw,
+        "RAW" => DemodMode::Raw,
+        // "NFM" and any unrecognized string default to NFM.
+        _ => DemodMode::Nfm,
+    }
+}
+
+/// Default bookmark file location.
+fn bookmarks_path() -> std::path::PathBuf {
+    let mut path = glib::user_config_dir();
+    path.push("sdr-rs");
+    path.push("bookmarks.json");
+    path
+}
+
+fn load_bookmarks() -> Vec<Bookmark> {
+    let path = bookmarks_path();
+    let Ok(data) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    serde_json::from_str(&data).unwrap_or_default()
+}
+
+pub fn save_bookmarks(bookmarks: &[Bookmark]) {
+    let path = bookmarks_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match serde_json::to_string_pretty(bookmarks) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(path, json) {
+                tracing::warn!("failed to save bookmarks: {e}");
+            }
+        }
+        Err(e) => tracing::warn!("failed to serialize bookmarks: {e}"),
+    }
+}
+
+/// Format a frequency as a human-readable string (e.g., "98.100 MHz").
+pub fn format_frequency(freq: u64) -> String {
+    #[allow(clippy::cast_precision_loss)]
+    let freq_f64 = freq as f64;
+    if freq >= 1_000_000_000 {
+        format!("{:.3} GHz", freq_f64 / 1_000_000_000.0)
+    } else if freq >= 1_000_000 {
+        format!("{:.3} MHz", freq_f64 / 1_000_000.0)
+    } else if freq >= 1_000 {
+        format!("{:.1} kHz", freq_f64 / 1_000.0)
+    } else {
+        format!("{freq} Hz")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Navigation panel widget
+// ---------------------------------------------------------------------------
+
+/// Callback type for navigation actions (tune to frequency + set mode + bandwidth).
+pub type NavigationCallback = Box<dyn Fn(u64, DemodMode, f64)>;
+
+/// Navigation panel containing band presets and frequency bookmarks.
+pub struct NavigationPanel {
+    /// Band presets group widget.
+    pub presets_widget: adw::PreferencesGroup,
+    /// Bookmarks container widget.
+    pub bookmarks_widget: gtk4::Box,
+    /// Band preset combo row (for connection in window.rs).
+    pub preset_row: adw::ComboRow,
+    /// Add bookmark button.
+    pub add_button: gtk4::Button,
+    /// Bookmark scroll container (height adjusted dynamically).
+    pub bookmark_scroll: gtk4::ScrolledWindow,
+    /// Bookmark list box (rebuilt on add/remove).
+    pub bookmark_list: gtk4::ListBox,
+    /// Current bookmarks (shared state for closures).
+    pub bookmarks: std::rc::Rc<std::cell::RefCell<Vec<Bookmark>>>,
+    /// Callback fired when a preset or bookmark is recalled.
+    pub on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>>,
+}
+
+impl NavigationPanel {
+    /// Register a callback invoked when the user selects a preset or bookmark.
+    pub fn connect_navigate<F: Fn(u64, DemodMode, f64) + 'static>(&self, f: F) {
+        *self.on_navigate.borrow_mut() = Some(Box::new(f));
+    }
+}
+
+/// Build the complete navigation panel (band presets + bookmarks).
+pub fn build_navigation_panel() -> NavigationPanel {
+    // --- Band Presets ---
+    let presets_group = adw::PreferencesGroup::builder()
+        .title("Band Presets")
+        .description("Quick-tune to common frequencies")
+        .build();
+
+    let preset_names: Vec<&str> = BAND_PRESETS.iter().map(|p| p.name).collect();
+    let preset_model = gtk4::StringList::new(&preset_names);
+    let preset_row = adw::ComboRow::builder()
+        .title("Band")
+        .model(&preset_model)
+        .build();
+    presets_group.add(&preset_row);
+
+    // --- Bookmarks ---
+    // Use a plain Box instead of PreferencesGroup so ScrolledWindow sizing works.
+    let bookmarks_group = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(8)
+        .build();
+
+    let bookmarks_label = gtk4::Label::builder()
+        .label("Bookmarks")
+        .css_classes(["heading"])
+        .halign(gtk4::Align::Start)
+        .build();
+    bookmarks_group.append(&bookmarks_label);
+
+    let bookmark_list = gtk4::ListBox::builder()
+        .selection_mode(gtk4::SelectionMode::None)
+        .css_classes(["boxed-list"])
+        .build();
+
+    let bookmark_scroll = gtk4::ScrolledWindow::builder()
+        .child(&bookmark_list)
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .vscrollbar_policy(gtk4::PolicyType::Automatic)
+        .build();
+    bookmarks_group.append(&bookmark_scroll);
+
+    let add_button = gtk4::Button::builder()
+        .label("Add Bookmark")
+        .css_classes(["suggested-action"])
+        .build();
+    bookmarks_group.append(&add_button);
+
+    let bookmarks = std::rc::Rc::new(std::cell::RefCell::new(load_bookmarks()));
+    let on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>> =
+        std::rc::Rc::new(std::cell::RefCell::new(None));
+
+    // Build initial bookmark list
+    rebuild_bookmark_list(&bookmark_list, &bookmark_scroll, &bookmarks, &on_navigate);
+
+    // Connect preset row — auto-tune on selection
+    let on_nav_preset = std::rc::Rc::clone(&on_navigate);
+    preset_row.connect_selected_notify(move |row| {
+        let idx = row.selected() as usize;
+        if let Some(preset) = BAND_PRESETS.get(idx)
+            && let Some(cb) = on_nav_preset.borrow().as_ref()
+        {
+            cb(preset.frequency, preset.demod_mode, preset.bandwidth);
+        }
+    });
+
+    NavigationPanel {
+        presets_widget: presets_group,
+        bookmarks_widget: bookmarks_group,
+        preset_row,
+        add_button,
+        bookmark_scroll,
+        bookmark_list,
+        bookmarks,
+        on_navigate,
+    }
+}
+
+/// Approximate height of one `AdwActionRow` with subtitle in pixels.
+const BOOKMARK_ROW_HEIGHT: i32 = 64;
+/// Maximum visible bookmark rows before scrolling.
+const MAX_VISIBLE_BOOKMARKS: i32 = 3;
+
+/// Rebuild the bookmark `ListBox` from the current bookmark list.
+pub fn rebuild_bookmark_list(
+    list_box: &gtk4::ListBox,
+    scroll: &gtk4::ScrolledWindow,
+    bookmarks: &std::rc::Rc<std::cell::RefCell<Vec<Bookmark>>>,
+    on_navigate: &std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>>,
+) {
+    // Remove all existing rows.
+    while let Some(child) = list_box.first_child() {
+        list_box.remove(&child);
+    }
+
+    let bm_list = bookmarks.borrow();
+    for (i, bm) in bm_list.iter().enumerate() {
+        let row = adw::ActionRow::builder()
+            .title(&bm.name)
+            .subtitle(format!(
+                "{} — {}",
+                format_frequency(bm.frequency),
+                bm.demod_mode
+            ))
+            .activatable(true)
+            .build();
+
+        // Delete button
+        let delete_btn = gtk4::Button::builder()
+            .icon_name("user-trash-symbolic")
+            .valign(gtk4::Align::Center)
+            .css_classes(["flat"])
+            .build();
+
+        let bm_rc = std::rc::Rc::clone(bookmarks);
+        let nav_rc = std::rc::Rc::clone(on_navigate);
+        let list_ref = list_box.downgrade();
+        let scroll_ref = scroll.downgrade();
+        delete_btn.connect_clicked(move |_| {
+            bm_rc.borrow_mut().remove(i);
+            save_bookmarks(&bm_rc.borrow());
+            if let Some(lb) = list_ref.upgrade()
+                && let Some(sc) = scroll_ref.upgrade()
+            {
+                rebuild_bookmark_list(&lb, &sc, &bm_rc, &nav_rc);
+            }
+        });
+        row.add_suffix(&delete_btn);
+
+        // Recall on row activation
+        let freq = bm.frequency;
+        let mode = string_to_demod_mode(&bm.demod_mode);
+        let bw = bm.bandwidth;
+        let on_nav_recall = std::rc::Rc::clone(on_navigate);
+        row.connect_activated(move |_| {
+            if let Some(cb) = on_nav_recall.borrow().as_ref() {
+                cb(freq, mode, bw);
+            }
+        });
+
+        list_box.append(&row);
+    }
+
+    // Dynamically size: show all items up to 3, then scroll.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let count = bm_list.len() as i32;
+    let visible = count.clamp(0, MAX_VISIBLE_BOOKMARKS);
+    let height = visible * BOOKMARK_ROW_HEIGHT;
+    scroll.set_height_request(height);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_frequency_mhz() {
+        assert_eq!(format_frequency(98_100_000), "98.100 MHz");
+        assert_eq!(format_frequency(162_550_000), "162.550 MHz");
+    }
+
+    #[test]
+    fn format_frequency_ghz() {
+        assert_eq!(format_frequency(1_090_000_000), "1.090 GHz");
+    }
+
+    #[test]
+    fn format_frequency_khz() {
+        assert_eq!(format_frequency(500_000), "500.0 kHz");
+    }
+
+    #[test]
+    fn format_frequency_hz() {
+        assert_eq!(format_frequency(440), "440 Hz");
+    }
+
+    #[test]
+    fn demod_mode_roundtrip() {
+        let modes = [
+            DemodMode::Wfm,
+            DemodMode::Nfm,
+            DemodMode::Am,
+            DemodMode::Usb,
+            DemodMode::Lsb,
+            DemodMode::Dsb,
+            DemodMode::Cw,
+            DemodMode::Raw,
+        ];
+        for mode in modes {
+            let s = demod_mode_to_string(mode);
+            let back = string_to_demod_mode(&s);
+            assert_eq!(mode, back);
+        }
+    }
+
+    #[test]
+    fn band_presets_have_valid_data() {
+        for preset in BAND_PRESETS {
+            assert!(!preset.name.is_empty());
+            assert!(preset.frequency > 0);
+            assert!(preset.bandwidth > 0.0);
+        }
+    }
+
+    #[test]
+    fn bookmark_serialization_roundtrip() {
+        let bm = Bookmark::new("Test", 100_000_000, DemodMode::Wfm, 150_000.0);
+        let json = serde_json::to_string(&bm).unwrap();
+        let back: Bookmark = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.name, "Test");
+        assert_eq!(back.frequency, 100_000_000);
+        assert_eq!(back.demod_mode, "WFM");
+        assert!((back.bandwidth - 150_000.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -34,6 +34,17 @@ const PORT_STEP: f64 = 1.0;
 /// Port page increment.
 const PORT_PAGE: f64 = 100.0;
 
+/// Default PPM correction.
+const DEFAULT_PPM: f64 = 0.0;
+/// Minimum PPM correction.
+const MIN_PPM: f64 = -200.0;
+/// Maximum PPM correction.
+const MAX_PPM: f64 = 200.0;
+/// PPM step increment.
+const PPM_STEP: f64 = 1.0;
+/// PPM page increment.
+const PPM_PAGE: f64 = 10.0;
+
 /// Source device configuration panel with references to all interactive rows.
 pub struct SourcePanel {
     /// The `AdwPreferencesGroup` widget to pack into the sidebar.
@@ -46,6 +57,8 @@ pub struct SourcePanel {
     pub gain_row: adw::SpinRow,
     /// RTL-SDR AGC toggle.
     pub agc_row: adw::SwitchRow,
+    /// RTL-SDR PPM frequency correction.
+    pub ppm_row: adw::SpinRow,
     /// Network hostname entry.
     pub hostname_row: adw::EntryRow,
     /// Network port number.
@@ -67,8 +80,8 @@ pub struct SourcePanel {
 /// Default sample rate selector index (2.4 MHz = index 7).
 const DEFAULT_SAMPLE_RATE_INDEX: u32 = 7;
 
-/// Build RTL-SDR-specific rows: sample rate, gain, AGC.
-fn build_rtlsdr_rows() -> (adw::ComboRow, adw::SpinRow, adw::SwitchRow) {
+/// Build RTL-SDR-specific rows: sample rate, gain, AGC, PPM correction.
+fn build_rtlsdr_rows() -> (adw::ComboRow, adw::SpinRow, adw::SwitchRow, adw::SpinRow) {
     let sample_rate_model = gtk4::StringList::new(&[
         "250 kHz",
         "1.024 MHz",
@@ -108,7 +121,15 @@ fn build_rtlsdr_rows() -> (adw::ComboRow, adw::SpinRow, adw::SwitchRow) {
         .subtitle("Automatic gain control")
         .build();
 
-    (sample_rate_row, gain_row, agc_row)
+    let ppm_adj = gtk4::Adjustment::new(DEFAULT_PPM, MIN_PPM, MAX_PPM, PPM_STEP, PPM_PAGE, 0.0);
+    let ppm_row = adw::SpinRow::builder()
+        .title("PPM Correction")
+        .subtitle("Crystal frequency offset")
+        .adjustment(&ppm_adj)
+        .digits(0)
+        .build();
+
+    (sample_rate_row, gain_row, agc_row, ppm_row)
 }
 
 /// Build network-specific rows: hostname, port, protocol.
@@ -172,6 +193,7 @@ fn connect_device_visibility(
     sample_rate_row: &adw::ComboRow,
     gain_row: &adw::SpinRow,
     agc_row: &adw::SwitchRow,
+    ppm_row: &adw::SpinRow,
     hostname_row: &adw::EntryRow,
     port_row: &adw::SpinRow,
     protocol_row: &adw::ComboRow,
@@ -184,6 +206,8 @@ fn connect_device_visibility(
         gain_row,
         #[weak]
         agc_row,
+        #[weak]
+        ppm_row,
         #[weak]
         hostname_row,
         #[weak]
@@ -201,6 +225,7 @@ fn connect_device_visibility(
             sample_rate_row.set_visible(is_rtlsdr);
             gain_row.set_visible(is_rtlsdr);
             agc_row.set_visible(is_rtlsdr);
+            ppm_row.set_visible(is_rtlsdr);
 
             hostname_row.set_visible(is_network);
             port_row.set_visible(is_network);
@@ -226,7 +251,7 @@ pub fn build_source_panel() -> SourcePanel {
         .model(&device_model)
         .build();
 
-    let (sample_rate_row, gain_row, agc_row) = build_rtlsdr_rows();
+    let (sample_rate_row, gain_row, agc_row, ppm_row) = build_rtlsdr_rows();
     let (hostname_row, port_row, protocol_row) = build_network_rows();
     let file_path_row = adw::EntryRow::builder()
         .title("File Path")
@@ -241,6 +266,7 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&sample_rate_row);
     group.add(&gain_row);
     group.add(&agc_row);
+    group.add(&ppm_row);
     group.add(&hostname_row);
     group.add(&port_row);
     group.add(&protocol_row);
@@ -258,6 +284,7 @@ pub fn build_source_panel() -> SourcePanel {
     sample_rate_row.set_visible(is_rtlsdr);
     gain_row.set_visible(is_rtlsdr);
     agc_row.set_visible(is_rtlsdr);
+    ppm_row.set_visible(is_rtlsdr);
     hostname_row.set_visible(is_network);
     port_row.set_visible(is_network);
     protocol_row.set_visible(is_network);
@@ -268,6 +295,7 @@ pub fn build_source_panel() -> SourcePanel {
         &sample_rate_row,
         &gain_row,
         &agc_row,
+        &ppm_row,
         &hostname_row,
         &port_row,
         &protocol_row,
@@ -282,6 +310,7 @@ pub fn build_source_panel() -> SourcePanel {
         sample_rate_row,
         gain_row,
         agc_row,
+        ppm_row,
         hostname_row,
         port_row,
         protocol_row,

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -339,6 +339,14 @@ mod tests {
         assert!(DEFAULT_PORT <= MAX_PORT);
     };
 
+    /// Compile-time validation that PPM constants are consistent.
+    const _: () = {
+        assert!(MIN_PPM <= MAX_PPM);
+        assert!(DEFAULT_PPM >= MIN_PPM);
+        assert!(DEFAULT_PPM <= MAX_PPM);
+        assert!(PPM_STEP > 0.0);
+    };
+
     #[test]
     fn device_indices_are_distinct() {
         assert_ne!(DEVICE_RTLSDR, DEVICE_NETWORK);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -787,7 +787,7 @@ fn connect_navigation_panel(
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let freq_u64 = freq as u64;
         let name = sidebar::navigation_panel::format_frequency(freq_u64);
-        let bookmark = sidebar::navigation_panel::Bookmark::new_pub(&name, freq_u64, mode, bw);
+        let bookmark = sidebar::navigation_panel::Bookmark::new(&name, freq_u64, mode, bw);
         bm_rc.borrow_mut().push(bookmark);
         sidebar::navigation_panel::save_bookmarks(&bm_rc.borrow());
         sidebar::navigation_panel::rebuild_bookmark_list(&bm_list, &bm_scroll, &bm_rc, &on_nav);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -739,19 +739,20 @@ fn connect_navigation_panel(
     let sb = Rc::clone(status_bar);
 
     panels.navigation.connect_navigate(move |freq, mode, bw| {
-        // Update DSP state
         #[allow(clippy::cast_precision_loss)]
         let freq_f64 = freq as f64;
         state_nav.center_frequency.set(freq_f64);
         state_nav.demod_mode.set(mode);
+
+        // Send Tune and Bandwidth directly. SetDemodMode is sent by the
+        // demod dropdown callback when we update its selection below.
         state_nav.send_dsp(UiToDsp::Tune(freq_f64));
-        state_nav.send_dsp(UiToDsp::SetDemodMode(mode));
         state_nav.send_dsp(UiToDsp::SetBandwidth(bw));
 
-        // Update frequency selector display (no callback — we handle DSP above).
+        // Update frequency selector display (does NOT fire callback — no duplicate Tune).
         fs.set_frequency(freq);
 
-        // Update demod dropdown
+        // Update demod dropdown — its callback sends SetDemodMode to DSP.
         if let Some(dd) = dd_weak.upgrade()
             && let Some(idx) = demod_selector::demod_mode_to_index(mode)
         {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -92,11 +92,17 @@ pub fn build_window(app: &adw::Application) {
     let shortcuts_window = shortcuts::build_shortcuts_window();
     window.set_help_overlay(Some(&shortcuts_window));
 
-    // --- Connect sidebar panels to DSP ---
-    connect_sidebar_panels(&panels, &state, &spectrum_handle);
-
-    // --- Wire frequency selector to DSP and status bar ---
+    // --- Wire sidebar panels and frequency/demod to DSP + status bar ---
     let status_bar_demod = Rc::new(status_bar);
+
+    connect_sidebar_panels(
+        &panels,
+        &state,
+        &spectrum_handle,
+        &freq_selector,
+        &demod_dropdown,
+        &status_bar_demod,
+    );
     let status_bar_for_freq = Rc::clone(&status_bar_demod);
     let state_freq = Rc::clone(&state);
     freq_selector.connect_frequency_changed(move |freq| {
@@ -409,11 +415,15 @@ fn connect_sidebar_panels(
     panels: &SidebarPanels,
     state: &Rc<AppState>,
     spectrum_handle: &Rc<spectrum::SpectrumHandle>,
+    freq_selector: &header::frequency_selector::FrequencySelector,
+    demod_dropdown: &gtk4::DropDown,
+    status_bar: &Rc<StatusBar>,
 ) {
     connect_source_panel(panels, state);
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
+    connect_navigation_panel(panels, state, freq_selector, demod_dropdown, status_bar);
 }
 
 /// Connect source panel controls to DSP commands.
@@ -481,6 +491,13 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         .connect_active_notify(move |row| {
             state_iq_corr.send_dsp(UiToDsp::SetIqCorrection(row.is_active()));
         });
+
+    // PPM correction
+    let state_ppm = Rc::clone(state);
+    panels.source.ppm_row.connect_value_notify(move |row| {
+        #[allow(clippy::cast_possible_truncation)]
+        state_ppm.send_dsp(UiToDsp::SetPpmCorrection(row.value() as i32));
+    });
 
     // Source type selector — guard against transient out-of-range indices
     let state_source = Rc::clone(state);
@@ -705,6 +722,76 @@ fn connect_display_panel(
                 .unwrap_or(spectrum::colormap::ColormapStyle::Turbo);
             spectrum_for_cmap.set_colormap(style);
         });
+}
+
+/// Connect navigation panel (band presets + bookmarks) to DSP commands.
+fn connect_navigation_panel(
+    panels: &SidebarPanels,
+    state: &Rc<AppState>,
+    freq_selector: &header::frequency_selector::FrequencySelector,
+    demod_dropdown: &gtk4::DropDown,
+    status_bar: &Rc<StatusBar>,
+) {
+    // Navigation callback: tune + set mode + set bandwidth, update UI widgets.
+    let state_nav = Rc::clone(state);
+    let fs = freq_selector.clone();
+    let dd_weak = demod_dropdown.downgrade();
+    let sb = Rc::clone(status_bar);
+
+    panels.navigation.connect_navigate(move |freq, mode, bw| {
+        // Update DSP state
+        #[allow(clippy::cast_precision_loss)]
+        let freq_f64 = freq as f64;
+        state_nav.center_frequency.set(freq_f64);
+        state_nav.demod_mode.set(mode);
+        state_nav.send_dsp(UiToDsp::Tune(freq_f64));
+        state_nav.send_dsp(UiToDsp::SetDemodMode(mode));
+        state_nav.send_dsp(UiToDsp::SetBandwidth(bw));
+
+        // Update frequency selector display (no callback — we handle DSP above).
+        fs.set_frequency(freq);
+
+        // Update demod dropdown
+        if let Some(dd) = dd_weak.upgrade()
+            && let Some(idx) = demod_selector::demod_mode_to_index(mode)
+        {
+            dd.set_selected(idx);
+        }
+
+        // Update status bar
+        sb.update_frequency(freq_f64);
+        let label = header::demod_mode_label(mode);
+        sb.update_demod(label, bw);
+
+        tracing::info!(
+            frequency = freq,
+            ?mode,
+            bandwidth = bw,
+            "navigated to frequency"
+        );
+    });
+
+    // "Add Bookmark" button
+    let state_bm = Rc::clone(state);
+    let radio_bw = panels.radio.bandwidth_row.clone();
+    let nav = &panels.navigation;
+    let bm_rc = nav.bookmarks.clone();
+    let bm_list = nav.bookmark_list.clone();
+    let bm_scroll = nav.bookmark_scroll.clone();
+    let on_nav = nav.on_navigate.clone();
+
+    nav.add_button.connect_clicked(move |_| {
+        let freq = state_bm.center_frequency.get();
+        let mode = state_bm.demod_mode.get();
+        let bw = radio_bw.value();
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let freq_u64 = freq as u64;
+        let name = sidebar::navigation_panel::format_frequency(freq_u64);
+        let bookmark = sidebar::navigation_panel::Bookmark::new_pub(&name, freq_u64, mode, bw);
+        bm_rc.borrow_mut().push(bookmark);
+        sidebar::navigation_panel::save_bookmarks(&bm_rc.borrow());
+        sidebar::navigation_panel::rebuild_bookmark_list(&bm_list, &bm_scroll, &bm_rc, &on_nav);
+    });
 }
 
 /// Connect audio panel controls to DSP commands.


### PR DESCRIPTION
## Summary
- **PPM correction (#144):** SpinRow in source panel (RTL-SDR only, ±200 PPM) wired through Source trait to `set_freq_correction`
- **Band presets (#142):** Navigation panel with 10 common frequency presets (FM, NOAA, aviation, amateur, marine, FRS, MURS, CB) — auto-sets frequency, demod mode, and bandwidth
- **Frequency bookmarks (#139):** JSON-persisted bookmark list with add/remove/recall, dynamically sized (shows up to 3, scrolls beyond), stored at `~/.config/sdr-rs/bookmarks.json`

Closes #139, closes #142, closes #144

## Test plan
- [ ] PPM correction: change PPM value with RTL-SDR selected, verify it only shows for RTL-SDR source type
- [ ] Band presets: select each preset, verify frequency/demod/bandwidth update correctly
- [ ] Bookmarks: add bookmark, verify it appears in list with correct freq/mode; recall bookmark, verify tuning changes; delete bookmark, verify removal; restart app, verify bookmarks persist
- [ ] Verify bookmark list flexes for 0-3 items and scrolls beyond 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PPM correction control for RTL‑SDR devices (UI + device handling).
  * Navigation panel with band presets and persistent frequency bookmarks.
  * One‑click tuning: apply preset/bookmark frequency, demod mode, and bandwidth; UI syncs accordingly.
  * Programmatic frequency updates now supported without emitting the user-change callback.

* **Bug Fixes / Reliability**
  * Safer handling when no device is present during PPM updates.

* **Tests**
  * Unit tests for navigation/bookmark serialization and frequency formatting.

* **Chores**
  * Added serialization dependency for bookmark persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->