### PR TITLE
Spectrum display: dB range, averaging, cursor readout, fill toggle, window correction

### DIFF
--- a/crates/sdr-dsp/src/fft.rs
+++ b/crates/sdr-dsp/src/fft.rs
@@ -85,14 +85,19 @@ impl FftEngine for RustFftEngine {
 
 /// Compute power spectrum in dB from complex FFT output.
 ///
-/// Converts each complex bin to `10 * log10(re^2 + im^2)` and writes to `output`.
-/// This matches the SDR++ `volk_32fc_s32f_power_spectrum_32f` usage.
+/// Converts each complex bin to `10 * log10(|X[k]|² / (N * cg)²)` where `cg` is
+/// the window's coherent gain. This corrects for the energy loss from windowing
+/// so that signal amplitudes display at their true level.
 ///
 /// # Errors
 ///
 /// Returns `DspError::BufferTooSmall` if `output.len() < fft_output.len()`.
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-pub fn power_spectrum_db(fft_output: &[Complex], output: &mut [f32]) -> Result<(), DspError> {
+pub fn power_spectrum_db(
+    fft_output: &[Complex],
+    output: &mut [f32],
+    window_coherent_gain: f32,
+) -> Result<(), DspError> {
     if output.len() < fft_output.len() {
         return Err(DspError::BufferTooSmall {
             need: fft_output.len(),
@@ -100,8 +105,12 @@ pub fn power_spectrum_db(fft_output: &[Complex], output: &mut [f32]) -> Result<(
         });
     }
     let size = fft_output.len() as f32;
+    // Normalization: divide by (N * coherent_gain)² to correct for both
+    // FFT scaling and window energy loss.
+    let norm = size * window_coherent_gain;
+    let norm_sq = norm * norm;
     for (i, bin) in fft_output.iter().enumerate() {
-        let power = (bin.re * bin.re + bin.im * bin.im) / (size * size);
+        let power = (bin.re * bin.re + bin.im * bin.im) / norm_sq;
         output[i] = 10.0 * power.max(f32::MIN_POSITIVE).log10();
     }
     Ok(())
@@ -194,7 +203,8 @@ mod tests {
         engine.forward(&mut buf).unwrap();
 
         let mut output = vec![0.0_f32; FFT_SIZE];
-        power_spectrum_db(&buf, &mut output).unwrap();
+        // coherent_gain = 1.0 for rectangular window (no correction)
+        power_spectrum_db(&buf, &mut output, 1.0).unwrap();
 
         // DC bin should be 0 dB (power = 1.0 after normalization by N^2)
         assert!(
@@ -213,7 +223,7 @@ mod tests {
     fn test_power_spectrum_db_buffer_too_small() {
         let buf = vec![Complex::default(); 64];
         let mut output = vec![0.0_f32; 32];
-        assert!(power_spectrum_db(&buf, &mut output).is_err());
+        assert!(power_spectrum_db(&buf, &mut output, 1.0).is_err());
     }
 
     #[test]

--- a/crates/sdr-dsp/src/fft.rs
+++ b/crates/sdr-dsp/src/fft.rs
@@ -98,6 +98,11 @@ pub fn power_spectrum_db(
     output: &mut [f32],
     window_coherent_gain: f32,
 ) -> Result<(), DspError> {
+    if window_coherent_gain <= 0.0 || !window_coherent_gain.is_finite() {
+        return Err(DspError::InvalidParameter(
+            "window_coherent_gain must be finite and > 0".to_string(),
+        ));
+    }
     if output.len() < fft_output.len() {
         return Err(DspError::BufferTooSmall {
             need: fft_output.len(),

--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -24,6 +24,21 @@ pub enum FftWindow {
     Nuttall,
 }
 
+impl FftWindow {
+    /// Coherent gain (DC gain) of the window — first cosine coefficient.
+    ///
+    /// Used to correct power spectrum magnitudes so windowed signals
+    /// display at their true amplitude rather than appearing lower.
+    #[must_use]
+    pub fn coherent_gain(self) -> f32 {
+        match self {
+            Self::Rectangular => 1.0,
+            Self::Blackman => 0.42,
+            Self::Nuttall => 0.355_768,
+        }
+    }
+}
+
 /// DC blocker rate factor: `50.0 / sample_rate`.
 /// Matches C++ `genDCBlockRate`.
 const DC_BLOCK_RATE_FACTOR: f64 = 50.0;
@@ -60,6 +75,8 @@ pub struct IqFrontend {
     fft_size: usize,
     fft_engine: RustFftEngine,
     fft_window_buf: Vec<f32>,
+    /// Window coherent gain for energy correction in power spectrum.
+    window_coherent_gain: f32,
     fft_accum: Vec<Complex>,
     fft_accum_count: usize,
     fft_output: Vec<f32>,
@@ -148,6 +165,7 @@ impl IqFrontend {
             fft_size,
             fft_engine,
             fft_window_buf,
+            window_coherent_gain: fft_window.coherent_gain(),
             fft_accum: vec![Complex::default(); fft_size],
             fft_accum_count: 0,
             fft_output: vec![0.0; fft_size],
@@ -390,8 +408,12 @@ impl IqFrontend {
         // Execute FFT
         self.fft_engine.forward(&mut self.fft_work)?;
 
-        // Convert to power spectrum dB
-        fft::power_spectrum_db(&self.fft_work, &mut self.fft_output)?;
+        // Convert to power spectrum dB (with window energy correction)
+        fft::power_spectrum_db(
+            &self.fft_work,
+            &mut self.fft_output,
+            self.window_coherent_gain,
+        )?;
         fft_out[..self.fft_size].copy_from_slice(&self.fft_output);
 
         Ok(())

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -1,4 +1,5 @@
-//! Display settings panel — FFT size, window function, frame rate, color map.
+//! Display settings panel — FFT size, window function, frame rate, color map,
+//! dB range, fill mode, and averaging mode.
 
 use libadwaita as adw;
 use libadwaita::prelude::*;
@@ -16,6 +17,11 @@ const DEFAULT_FFT_SIZE_INDEX: u32 = 2;
 /// Default window function selector index (Blackman = index 1).
 const DEFAULT_WINDOW_FN_INDEX: u32 = 1;
 
+/// Default minimum dB level for the display range.
+const DEFAULT_MIN_DB: f64 = -120.0;
+/// Default maximum dB level for the display range.
+const DEFAULT_MAX_DB: f64 = 0.0;
+
 /// Display settings panel with references to interactive rows.
 pub struct DisplayPanel {
     /// The `AdwPreferencesGroup` widget to pack into the sidebar.
@@ -28,6 +34,14 @@ pub struct DisplayPanel {
     pub frame_rate_row: adw::SpinRow,
     /// Color map selector.
     pub color_map_row: adw::ComboRow,
+    /// Minimum dB level for the display range.
+    pub min_db_row: adw::SpinRow,
+    /// Maximum dB level for the display range.
+    pub max_db_row: adw::SpinRow,
+    /// Toggle for spectrum fill area under the trace.
+    pub fill_mode_row: adw::SwitchRow,
+    /// Spectrum averaging mode selector.
+    pub averaging_row: adw::ComboRow,
 }
 
 /// Build the display settings panel.
@@ -69,10 +83,45 @@ pub fn build_display_panel() -> DisplayPanel {
         .model(&colormap_model)
         .build();
 
+    // --- Min dB ---
+    let min_db_adj = gtk4::Adjustment::new(DEFAULT_MIN_DB, -200.0, 0.0, 1.0, 10.0, 0.0);
+    let min_db_row = adw::SpinRow::builder()
+        .title("Min Level")
+        .subtitle("dB")
+        .adjustment(&min_db_adj)
+        .digits(0)
+        .build();
+
+    // --- Max dB ---
+    let max_db_adj = gtk4::Adjustment::new(DEFAULT_MAX_DB, -120.0, 20.0, 1.0, 10.0, 0.0);
+    let max_db_row = adw::SpinRow::builder()
+        .title("Max Level")
+        .subtitle("dB")
+        .adjustment(&max_db_adj)
+        .digits(0)
+        .build();
+
+    // --- Fill Mode ---
+    let fill_mode_row = adw::SwitchRow::builder()
+        .title("Spectrum Fill")
+        .active(true)
+        .build();
+
+    // --- Averaging Mode ---
+    let averaging_model = gtk4::StringList::new(&["None", "Peak Hold", "Average", "Min Hold"]);
+    let averaging_row = adw::ComboRow::builder()
+        .title("Averaging")
+        .model(&averaging_model)
+        .build();
+
     group.add(&fft_size_row);
     group.add(&window_fn_row);
     group.add(&frame_rate_row);
     group.add(&color_map_row);
+    group.add(&min_db_row);
+    group.add(&max_db_row);
+    group.add(&fill_mode_row);
+    group.add(&averaging_row);
 
     // FFT size and window function connected via window.rs
 
@@ -82,6 +131,10 @@ pub fn build_display_panel() -> DisplayPanel {
         window_fn_row,
         frame_rate_row,
         color_map_row,
+        min_db_row,
+        max_db_row,
+        fill_mode_row,
+        averaging_row,
     }
 }
 

--- a/crates/sdr-ui/src/spectrum/fft_plot.rs
+++ b/crates/sdr-ui/src/spectrum/fft_plot.rs
@@ -133,7 +133,7 @@ impl FftPlotRenderer {
     /// * `height` — Viewport height in pixels.
     /// * `min_db` — Bottom of the display range in dB.
     /// * `max_db` — Top of the display range in dB.
-    #[allow(unsafe_code)]
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     pub fn render(
         &self,
         gl: &glow::Context,
@@ -142,6 +142,7 @@ impl FftPlotRenderer {
         height: i32,
         min_db: f32,
         max_db: f32,
+        fill_enabled: bool,
     ) {
         if fft_data.is_empty() || width <= 0 || height <= 0 {
             return;
@@ -173,8 +174,10 @@ impl FftPlotRenderer {
         // Draw grid lines.
         self.draw_grid(gl);
 
-        // Draw filled area under the spectrum curve.
-        self.draw_fill(gl, fft_data, db_range, min_db);
+        // Draw filled area under the spectrum curve (when enabled).
+        if fill_enabled {
+            self.draw_fill(gl, fft_data, db_range, min_db);
+        }
 
         // Draw the spectrum line trace on top.
         self.draw_trace(gl, fft_data, db_range, min_db);

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -214,7 +214,8 @@ pub fn build_spectrum_view(
         &fill_enabled,
         &cursor_callback,
     );
-    let waterfall_area = build_waterfall_area(Rc::clone(&waterfall_state), Rc::clone(&vfo_state));
+    let waterfall_area =
+        build_waterfall_area(Rc::clone(&waterfall_state), Rc::clone(&vfo_state), &min_db, &max_db);
 
     // Attach interaction gestures to both the waterfall and FFT areas.
     attach_click_gesture(&waterfall_area, &vfo_state, dsp_tx.clone());
@@ -392,6 +393,8 @@ fn build_fft_area(
 fn build_waterfall_area(
     state: Rc<RefCell<Option<WaterfallState>>>,
     vfo_state: Rc<RefCell<VfoState>>,
+    min_db: &Rc<Cell<f32>>,
+    max_db: &Rc<Cell<f32>>,
 ) -> gtk4::GLArea {
     let area = gtk4::GLArea::builder()
         .hexpand(true)
@@ -400,8 +403,10 @@ fn build_waterfall_area(
         .build();
     area.set_required_version(3, 0);
 
-    // On realize: create GL context and renderer.
+    // On realize: create GL context and renderer with current dB range.
     let state_realize = Rc::clone(&state);
+    let min_db_realize = Rc::clone(min_db);
+    let max_db_realize = Rc::clone(max_db);
     area.connect_realize(move |area| {
         area.make_current();
         if area.error().is_some() {
@@ -410,7 +415,10 @@ fn build_waterfall_area(
         }
 
         match create_gl_context_and_waterfall_renderer() {
-            Ok((gl, renderer, vfo_renderer)) => {
+            Ok((gl, mut renderer, vfo_renderer)) => {
+                // Apply stored dB range so the waterfall matches the FFT plot
+                // even if set_db_range was called before realization.
+                renderer.set_db_range(min_db_realize.get(), max_db_realize.get());
                 *state_realize.borrow_mut() = Some(WaterfallState {
                     gl,
                     renderer,

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -104,29 +104,29 @@ impl SpectrumHandle {
 
             match mode {
                 AveragingMode::None => {
-                    s.current_data.clear();
-                    s.current_data.extend_from_slice(data);
+                    s.current_data.resize(data.len(), 0.0);
+                    s.current_data.copy_from_slice(data);
                 }
                 AveragingMode::PeakHold => {
                     for (i, &d) in data.iter().enumerate() {
                         avg[i] = avg[i].max(d);
                     }
-                    s.current_data.clear();
-                    s.current_data.extend_from_slice(&avg);
+                    s.current_data.resize(avg.len(), 0.0);
+                    s.current_data.copy_from_slice(&avg);
                 }
                 AveragingMode::RunningAvg => {
                     for (i, &d) in data.iter().enumerate() {
                         avg[i] = AVERAGING_ALPHA.mul_add(d, (1.0 - AVERAGING_ALPHA) * avg[i]);
                     }
-                    s.current_data.clear();
-                    s.current_data.extend_from_slice(&avg);
+                    s.current_data.resize(avg.len(), 0.0);
+                    s.current_data.copy_from_slice(&avg);
                 }
                 AveragingMode::MinHold => {
                     for (i, &d) in data.iter().enumerate() {
                         avg[i] = avg[i].min(d);
                     }
-                    s.current_data.clear();
-                    s.current_data.extend_from_slice(&avg);
+                    s.current_data.resize(avg.len(), 0.0);
+                    s.current_data.copy_from_slice(&avg);
                 }
             }
         }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -154,6 +154,9 @@ impl SpectrumHandle {
 
     /// Update the display dB range for both the FFT plot and waterfall.
     pub fn set_db_range(&self, min_db: f32, max_db: f32) {
+        if min_db >= max_db {
+            return;
+        }
         self.min_db.set(min_db);
         self.max_db.set(max_db);
         if let Some(s) = self.waterfall_state.borrow_mut().as_mut() {

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -97,9 +97,12 @@ impl SpectrumHandle {
             let mode = self.averaging_mode.get();
             let mut avg = self.avg_buffer.borrow_mut();
 
-            // Resize averaging buffer if FFT size changed.
+            // Seed the averaging buffer from the first frame, or re-seed if
+            // the FFT size changed. This avoids mode-specific init values
+            // (e.g., MinHold needs high init, PeakHold needs low init) and
+            // prevents one-frame artifacts after mode switches.
             if avg.len() != data.len() {
-                *avg = vec![DEFAULT_MIN_DB; data.len()];
+                *avg = data.to_vec();
             }
 
             match mode {

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -214,8 +214,12 @@ pub fn build_spectrum_view(
         &fill_enabled,
         &cursor_callback,
     );
-    let waterfall_area =
-        build_waterfall_area(Rc::clone(&waterfall_state), Rc::clone(&vfo_state), &min_db, &max_db);
+    let waterfall_area = build_waterfall_area(
+        Rc::clone(&waterfall_state),
+        Rc::clone(&vfo_state),
+        &min_db,
+        &max_db,
+    );
 
     // Attach interaction gestures to both the waterfall and FFT areas.
     attach_click_gesture(&waterfall_area, &vfo_state, dsp_tx.clone());

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -11,7 +11,7 @@ pub mod gl_renderer;
 pub mod vfo_overlay;
 pub mod waterfall;
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use gtk4::glib;
@@ -23,16 +23,36 @@ use waterfall::WaterfallRenderer;
 
 use crate::messages::UiToDsp;
 
+/// Shared cursor callback type — invoked with `(frequency_hz, power_db)`.
+type CursorCallback = Rc<RefCell<Option<Box<dyn Fn(f64, f32)>>>>;
+
 /// Number of FFT bins for the display (used for initial buffer sizing).
 const FFT_SIZE: usize = 1024;
 
 /// Default FFT plot pane height fraction (30% of total).
 const FFT_PANE_FRACTION: f64 = 0.30;
 
-/// Minimum display level in dB.
-const MIN_DB: f32 = -120.0;
-/// Maximum display level in dB.
-const MAX_DB: f32 = 0.0;
+/// Default minimum display level in dB.
+const DEFAULT_MIN_DB: f32 = -120.0;
+/// Default maximum display level in dB.
+const DEFAULT_MAX_DB: f32 = 0.0;
+
+/// Exponential moving average smoothing factor for `RunningAvg` mode.
+const AVERAGING_ALPHA: f32 = 0.3;
+
+/// Spectrum averaging mode for the FFT display.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum AveragingMode {
+    /// No averaging — display raw FFT data.
+    #[default]
+    None,
+    /// Hold peak values across frames.
+    PeakHold,
+    /// Exponential moving average (smoothed).
+    RunningAvg,
+    /// Hold minimum values across frames.
+    MinHold,
+}
 
 /// Shared state for the FFT plot `GtkGLArea`.
 struct FftPlotState {
@@ -58,17 +78,57 @@ pub struct SpectrumHandle {
     waterfall_state: Rc<RefCell<Option<WaterfallState>>>,
     fft_area: gtk4::GLArea,
     waterfall_area: gtk4::GLArea,
+    min_db: Rc<Cell<f32>>,
+    max_db: Rc<Cell<f32>>,
+    fill_enabled: Rc<Cell<bool>>,
+    averaging_mode: Rc<Cell<AveragingMode>>,
+    avg_buffer: Rc<RefCell<Vec<f32>>>,
+    cursor_callback: CursorCallback,
 }
 
 impl SpectrumHandle {
     /// Push a new FFT frame into both the FFT plot and waterfall display.
     ///
+    /// Applies the current averaging mode before storing into the display buffer.
     /// Call this from the GTK main loop when `DspToUi::FftData` arrives.
     pub fn push_fft_data(&self, data: &[f32]) {
-        // Update FFT plot data.
+        // Apply averaging, then update FFT plot data.
         if let Some(s) = self.fft_state.borrow_mut().as_mut() {
-            s.current_data.clear();
-            s.current_data.extend_from_slice(data);
+            let mode = self.averaging_mode.get();
+            let mut avg = self.avg_buffer.borrow_mut();
+
+            // Resize averaging buffer if FFT size changed.
+            if avg.len() != data.len() {
+                *avg = vec![DEFAULT_MIN_DB; data.len()];
+            }
+
+            match mode {
+                AveragingMode::None => {
+                    s.current_data.clear();
+                    s.current_data.extend_from_slice(data);
+                }
+                AveragingMode::PeakHold => {
+                    for (i, &d) in data.iter().enumerate() {
+                        avg[i] = avg[i].max(d);
+                    }
+                    s.current_data.clear();
+                    s.current_data.extend_from_slice(&avg);
+                }
+                AveragingMode::RunningAvg => {
+                    for (i, &d) in data.iter().enumerate() {
+                        avg[i] = AVERAGING_ALPHA.mul_add(d, (1.0 - AVERAGING_ALPHA) * avg[i]);
+                    }
+                    s.current_data.clear();
+                    s.current_data.extend_from_slice(&avg);
+                }
+                AveragingMode::MinHold => {
+                    for (i, &d) in data.iter().enumerate() {
+                        avg[i] = avg[i].min(d);
+                    }
+                    s.current_data.clear();
+                    s.current_data.extend_from_slice(&avg);
+                }
+            }
         }
         self.fft_area.queue_render();
 
@@ -88,6 +148,39 @@ impl SpectrumHandle {
         }
         self.waterfall_area.queue_render();
     }
+
+    /// Update the display dB range for both the FFT plot and waterfall.
+    pub fn set_db_range(&self, min_db: f32, max_db: f32) {
+        self.min_db.set(min_db);
+        self.max_db.set(max_db);
+        if let Some(s) = self.waterfall_state.borrow_mut().as_mut() {
+            s.renderer.set_db_range(min_db, max_db);
+        }
+        self.fft_area.queue_render();
+        self.waterfall_area.queue_render();
+    }
+
+    /// Enable or disable the spectrum fill area under the trace.
+    pub fn set_fill_enabled(&self, enabled: bool) {
+        self.fill_enabled.set(enabled);
+        self.fft_area.queue_render();
+    }
+
+    /// Set the spectrum averaging mode, resetting the averaging buffer.
+    pub fn set_averaging_mode(&self, mode: AveragingMode) {
+        self.averaging_mode.set(mode);
+        // Reset the averaging buffer so stale data doesn't persist.
+        self.avg_buffer.borrow_mut().clear();
+        tracing::debug!(?mode, "averaging mode changed");
+    }
+
+    /// Register a callback invoked when the cursor moves over the FFT area.
+    ///
+    /// The callback receives `(frequency_hz, power_db)`. When the cursor
+    /// leaves the area, `power_db` is `f32::NEG_INFINITY`.
+    pub fn connect_cursor_moved<F: Fn(f64, f32) + 'static>(&self, f: F) {
+        *self.cursor_callback.borrow_mut() = Some(Box::new(f));
+    }
 }
 
 /// Build the spectrum view containing the FFT plot and waterfall display.
@@ -101,7 +194,19 @@ pub fn build_spectrum_view(
     let fft_state: Rc<RefCell<Option<FftPlotState>>> = Rc::new(RefCell::new(None));
     let waterfall_state: Rc<RefCell<Option<WaterfallState>>> = Rc::new(RefCell::new(None));
 
-    let fft_area = build_fft_area(Rc::clone(&fft_state), Rc::clone(&vfo_state));
+    let min_db: Rc<Cell<f32>> = Rc::new(Cell::new(DEFAULT_MIN_DB));
+    let max_db: Rc<Cell<f32>> = Rc::new(Cell::new(DEFAULT_MAX_DB));
+    let fill_enabled: Rc<Cell<bool>> = Rc::new(Cell::new(true));
+    let cursor_callback: CursorCallback = Rc::new(RefCell::new(None));
+
+    let fft_area = build_fft_area(
+        Rc::clone(&fft_state),
+        &vfo_state,
+        &min_db,
+        &max_db,
+        &fill_enabled,
+        &cursor_callback,
+    );
     let waterfall_area = build_waterfall_area(Rc::clone(&waterfall_state), Rc::clone(&vfo_state));
 
     // Attach interaction gestures to both the waterfall and FFT areas.
@@ -136,6 +241,12 @@ pub fn build_spectrum_view(
         waterfall_state,
         fft_area: fft_area.clone(),
         waterfall_area: waterfall_area.clone(),
+        min_db,
+        max_db,
+        fill_enabled,
+        averaging_mode: Rc::new(Cell::new(AveragingMode::default())),
+        avg_buffer: Rc::new(RefCell::new(Vec::new())),
+        cursor_callback,
     };
 
     (paned, handle)
@@ -144,7 +255,11 @@ pub fn build_spectrum_view(
 /// Build the `GtkGLArea` for the FFT power spectrum plot.
 fn build_fft_area(
     state: Rc<RefCell<Option<FftPlotState>>>,
-    vfo_state: Rc<RefCell<VfoState>>,
+    vfo_state: &Rc<RefCell<VfoState>>,
+    min_db: &Rc<Cell<f32>>,
+    max_db: &Rc<Cell<f32>>,
+    fill_enabled: &Rc<Cell<bool>>,
+    cursor_callback: &CursorCallback,
 ) -> gtk4::GLArea {
     let area = gtk4::GLArea::builder()
         .hexpand(true)
@@ -168,7 +283,7 @@ fn build_fft_area(
                     gl,
                     renderer,
                     vfo_renderer,
-                    current_data: vec![MIN_DB; FFT_SIZE],
+                    current_data: vec![DEFAULT_MIN_DB; FFT_SIZE],
                 });
                 tracing::info!("FFT plot GL renderer initialized");
             }
@@ -193,6 +308,10 @@ fn build_fft_area(
     });
 
     // On render: draw the FFT plot, then the VFO overlay on top.
+    let min_db_render = Rc::clone(min_db);
+    let max_db_render = Rc::clone(max_db);
+    let fill_render = Rc::clone(fill_enabled);
+    let vfo_render = Rc::clone(vfo_state);
     area.connect_render(move |area, _ctx| {
         if let Some(s) = state.borrow().as_ref() {
             let width = area.width();
@@ -201,14 +320,63 @@ fn build_fft_area(
             let phys_w = width * scale;
             let phys_h = height * scale;
 
-            s.renderer
-                .render(&s.gl, &s.current_data, phys_w, phys_h, MIN_DB, MAX_DB);
+            s.renderer.render(
+                &s.gl,
+                &s.current_data,
+                phys_w,
+                phys_h,
+                min_db_render.get(),
+                max_db_render.get(),
+                fill_render.get(),
+            );
 
-            let vfo = vfo_state.borrow();
+            let vfo = vfo_render.borrow();
             s.vfo_renderer.render(&s.gl, &vfo, phys_w, phys_h);
         }
         glib::Propagation::Stop
     });
+
+    // Cursor readout: track mouse motion to compute frequency and power.
+    let motion = gtk4::EventControllerMotion::new();
+    let cursor_vfo = Rc::clone(vfo_state);
+    let cursor_min = Rc::clone(min_db);
+    let cursor_max = Rc::clone(max_db);
+    let cursor_cb = Rc::clone(cursor_callback);
+    let area_weak_motion = area.downgrade();
+    motion.connect_motion(move |_ctrl, x, y| {
+        let Some(area) = area_weak_motion.upgrade() else {
+            return;
+        };
+        let width = f64::from(area.width());
+        let height = f64::from(area.height());
+        if width <= 0.0 || height <= 0.0 {
+            return;
+        }
+
+        let vfo = cursor_vfo.borrow();
+        let freq_hz = vfo.pixel_to_hz(x, width);
+        drop(vfo);
+
+        let lo = cursor_min.get();
+        let hi = cursor_max.get();
+        let db_range = hi - lo;
+        // y=0 is top (max_db), y=height is bottom (min_db).
+        #[allow(clippy::cast_possible_truncation)]
+        let power_db = hi - (y as f32 / height as f32) * db_range;
+
+        if let Some(cb) = cursor_cb.borrow().as_ref() {
+            cb(freq_hz, power_db);
+        }
+    });
+
+    let cursor_cb_leave = Rc::clone(cursor_callback);
+    motion.connect_leave(move |_ctrl| {
+        if let Some(cb) = cursor_cb_leave.borrow().as_ref() {
+            cb(0.0, f32::NEG_INFINITY);
+        }
+    });
+
+    area.add_controller(motion);
 
     area
 }
@@ -546,6 +714,8 @@ mod tests {
         assert!(super::FFT_SIZE > 0);
         assert!(super::FFT_PANE_FRACTION > 0.0);
         assert!(super::FFT_PANE_FRACTION < 1.0);
-        assert!(super::MIN_DB < super::MAX_DB);
+        assert!(super::DEFAULT_MIN_DB < super::DEFAULT_MAX_DB);
+        assert!(super::AVERAGING_ALPHA > 0.0);
+        assert!(super::AVERAGING_ALPHA < 1.0);
     };
 }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -155,6 +155,7 @@ impl SpectrumHandle {
     /// Update the display dB range for both the FFT plot and waterfall.
     pub fn set_db_range(&self, min_db: f32, max_db: f32) {
         if min_db >= max_db {
+            tracing::trace!(min_db, max_db, "set_db_range: ignoring inverted range");
             return;
         }
         self.min_db.set(min_db);

--- a/crates/sdr-ui/src/status_bar.rs
+++ b/crates/sdr-ui/src/status_bar.rs
@@ -22,6 +22,8 @@ const DEFAULT_SAMPLE_RATE_TEXT: &str = "SR: --";
 const DEFAULT_DEMOD_TEXT: &str = "-- --";
 /// Default frequency display text when no data has arrived.
 const DEFAULT_FREQUENCY_TEXT: &str = "-- Hz";
+/// Default cursor readout text when the cursor is not over the spectrum.
+const DEFAULT_CURSOR_TEXT: &str = "Cursor: --";
 
 /// Bottom status bar showing live metrics.
 pub struct StatusBar {
@@ -35,6 +37,8 @@ pub struct StatusBar {
     pub demod_label: gtk4::Label,
     /// Label showing center frequency.
     pub frequency_label: gtk4::Label,
+    /// Label showing cursor frequency and power readout.
+    pub cursor_label: gtk4::Label,
 }
 
 impl StatusBar {
@@ -60,6 +64,21 @@ impl StatusBar {
     pub fn update_frequency(&self, hz: f64) {
         self.frequency_label.set_label(&format_frequency(hz));
     }
+
+    /// Update the cursor readout with frequency and power at the mouse position.
+    ///
+    /// When `power_db` is `f32::NEG_INFINITY`, the cursor has left the area
+    /// and the readout is cleared.
+    pub fn update_cursor(&self, freq_hz: f64, power_db: f32) {
+        if power_db == f32::NEG_INFINITY {
+            self.cursor_label.set_label(DEFAULT_CURSOR_TEXT);
+        } else {
+            self.cursor_label.set_label(&format!(
+                "Cursor: {} / {power_db:.1} dB",
+                format_frequency(freq_hz)
+            ));
+        }
+    }
 }
 
 /// Build the status bar widget with initial placeholder labels.
@@ -68,6 +87,7 @@ pub fn build_status_bar() -> StatusBar {
     let sample_rate_label = gtk4::Label::new(Some(DEFAULT_SAMPLE_RATE_TEXT));
     let demod_label = gtk4::Label::new(Some(DEFAULT_DEMOD_TEXT));
     let frequency_label = gtk4::Label::new(Some(DEFAULT_FREQUENCY_TEXT));
+    let cursor_label = gtk4::Label::new(Some(DEFAULT_CURSOR_TEXT));
 
     let widget = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Horizontal)
@@ -82,6 +102,8 @@ pub fn build_status_bar() -> StatusBar {
     widget.append(&demod_label);
     widget.append(&gtk4::Separator::new(gtk4::Orientation::Vertical));
     widget.append(&frequency_label);
+    widget.append(&gtk4::Separator::new(gtk4::Orientation::Vertical));
+    widget.append(&cursor_label);
 
     StatusBar {
         widget,
@@ -89,6 +111,7 @@ pub fn build_status_bar() -> StatusBar {
         sample_rate_label,
         demod_label,
         frequency_label,
+        cursor_label,
     }
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -41,6 +41,7 @@ const DECIMATION_FACTORS: &[u32] = &[1, 2, 4, 8, 16];
 const DSP_POLL_INTERVAL_MS: u64 = 16;
 
 /// Build and present the main application window.
+#[allow(clippy::too_many_lines)]
 pub fn build_window(app: &adw::Application) {
     // --- Channel setup ---
     let (dsp_tx, dsp_rx) = mpsc::channel::<DspToUi>();
@@ -103,6 +104,13 @@ pub fn build_window(app: &adw::Application) {
         &demod_dropdown,
         &status_bar_demod,
     );
+
+    // Wire cursor readout from spectrum to status bar.
+    let status_bar_for_cursor = Rc::clone(&status_bar_demod);
+    spectrum_handle.connect_cursor_moved(move |freq_hz, power_db| {
+        status_bar_for_cursor.update_cursor(freq_hz, power_db);
+    });
+
     let status_bar_for_freq = Rc::clone(&status_bar_demod);
     let state_freq = Rc::clone(&state);
     freq_selector.connect_frequency_changed(move |freq| {
@@ -670,6 +678,14 @@ const COLORMAP_STYLES: [spectrum::colormap::ColormapStyle; 4] = [
     spectrum::colormap::ColormapStyle::Inferno,
 ];
 
+/// Averaging mode options matching the display panel combo.
+const AVERAGING_MODES: [spectrum::AveragingMode; 4] = [
+    spectrum::AveragingMode::None,
+    spectrum::AveragingMode::PeakHold,
+    spectrum::AveragingMode::RunningAvg,
+    spectrum::AveragingMode::MinHold,
+];
+
 /// Connect display panel controls to DSP commands.
 fn connect_display_panel(
     panels: &SidebarPanels,
@@ -721,6 +737,54 @@ fn connect_display_panel(
                 .copied()
                 .unwrap_or(spectrum::colormap::ColormapStyle::Turbo);
             spectrum_for_cmap.set_colormap(style);
+        });
+
+    // Min dB level — update the spectrum dB range.
+    let spectrum_min = Rc::clone(spectrum_handle);
+    let max_row_for_min = panels.display.max_db_row.clone();
+    panels.display.min_db_row.connect_value_notify(move |row| {
+        #[allow(clippy::cast_possible_truncation)]
+        let min_db = row.value() as f32;
+        #[allow(clippy::cast_possible_truncation)]
+        let max_db = max_row_for_min.value() as f32;
+        spectrum_min.set_db_range(min_db, max_db);
+        tracing::debug!(min_db, max_db, "dB range changed");
+    });
+
+    // Max dB level — update the spectrum dB range.
+    let spectrum_max = Rc::clone(spectrum_handle);
+    let min_row_for_max = panels.display.min_db_row.clone();
+    panels.display.max_db_row.connect_value_notify(move |row| {
+        #[allow(clippy::cast_possible_truncation)]
+        let max_db = row.value() as f32;
+        #[allow(clippy::cast_possible_truncation)]
+        let min_db = min_row_for_max.value() as f32;
+        spectrum_max.set_db_range(min_db, max_db);
+        tracing::debug!(min_db, max_db, "dB range changed");
+    });
+
+    // Spectrum fill mode toggle.
+    let spectrum_fill = Rc::clone(spectrum_handle);
+    panels
+        .display
+        .fill_mode_row
+        .connect_active_notify(move |row| {
+            spectrum_fill.set_fill_enabled(row.is_active());
+            tracing::debug!(fill = row.is_active(), "fill mode changed");
+        });
+
+    // Averaging mode selector.
+    let spectrum_avg = Rc::clone(spectrum_handle);
+    panels
+        .display
+        .averaging_row
+        .connect_selected_notify(move |row| {
+            let idx = row.selected() as usize;
+            let mode = AVERAGING_MODES
+                .get(idx)
+                .copied()
+                .unwrap_or(spectrum::AveragingMode::None);
+            spectrum_avg.set_averaging_mode(mode);
         });
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -739,7 +739,7 @@ fn connect_display_panel(
             spectrum_for_cmap.set_colormap(style);
         });
 
-    // Min dB level — update the spectrum dB range.
+    // Min dB level — update the spectrum dB range (skip if min >= max).
     let spectrum_min = Rc::clone(spectrum_handle);
     let max_row_for_min = panels.display.max_db_row.clone();
     panels.display.min_db_row.connect_value_notify(move |row| {
@@ -747,11 +747,14 @@ fn connect_display_panel(
         let min_db = row.value() as f32;
         #[allow(clippy::cast_possible_truncation)]
         let max_db = max_row_for_min.value() as f32;
+        if min_db >= max_db {
+            return;
+        }
         spectrum_min.set_db_range(min_db, max_db);
         tracing::debug!(min_db, max_db, "dB range changed");
     });
 
-    // Max dB level — update the spectrum dB range.
+    // Max dB level — update the spectrum dB range (skip if max <= min).
     let spectrum_max = Rc::clone(spectrum_handle);
     let min_row_for_max = panels.display.min_db_row.clone();
     panels.display.max_db_row.connect_value_notify(move |row| {
@@ -759,6 +762,9 @@ fn connect_display_panel(
         let max_db = row.value() as f32;
         #[allow(clippy::cast_possible_truncation)]
         let min_db = min_row_for_max.value() as f32;
+        if max_db <= min_db {
+            return;
+        }
         spectrum_max.set_db_range(min_db, max_db);
         tracing::debug!(min_db, max_db, "dB range changed");
     });

--- a/tests/hardware_integration.rs
+++ b/tests/hardware_integration.rs
@@ -258,7 +258,7 @@ fn pipeline_fft_standalone() {
     engine.forward(&mut fft_buf).expect("FFT forward");
 
     let mut power = vec![0.0_f32; TEST_FFT_SIZE];
-    sdr_dsp::fft::power_spectrum_db(&fft_buf, &mut power).expect("power_spectrum_db");
+    sdr_dsp::fft::power_spectrum_db(&fft_buf, &mut power, 1.0).expect("power_spectrum_db");
     assert!(
         power.iter().all(|v| v.is_finite()),
         "Non-finite power spectrum values"


### PR DESCRIPTION
## Summary
- **Window energy correction (#159):** Fixed ~4.5 dB systematic error — `power_spectrum_db` now normalizes by window coherent gain so windowed signals display at true amplitude
- **Adjustable dB range (#140):** Min/Max dB SpinRows in display panel, updates FFT plot and waterfall in real time
- **Spectrum averaging (#141):** None / Peak Hold / Running Average (EMA) / Min Hold modes via ComboRow
- **Cursor readout (#143):** Mouse over FFT plot shows frequency and power level in status bar
- **Spectrum fill mode (#146):** SwitchRow toggles filled area below trace vs line-only

Closes #140, closes #141, closes #143, closes #146, closes #159

## Test plan
- [ ] Verify FFT signal levels appear ~4.5 dB higher than before (window correction)
- [ ] Adjust min/max dB in display panel, verify FFT plot and waterfall update
- [ ] Switch averaging modes: peak hold retains peaks, average smooths, min hold shows floor
- [ ] Hover mouse over FFT plot, verify cursor readout in status bar shows freq + power
- [ ] Toggle fill mode off, verify line-only trace; toggle on, verify filled area returns
- [ ] Verify all existing controls still work (FFT size, window fn, frame rate, colormap, VFO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spectrum display settings: adjustable min/max dB, fill toggle, and averaging selector
  * Multiple averaging modes with per-frame averaging and persistent buffer
  * Interactive spectrum cursor reporting frequency and power; status bar shows cursor readout

* **Bug Fixes**
  * Power‑spectrum normalization now applies and validates window coherent gain for more accurate level reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->