### PR TITLE
Signal strength history graph

### DIFF
--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -568,7 +568,7 @@ fn build_signal_history_area(
     let min_db_render = Rc::clone(min_db);
     let max_db_render = Rc::clone(max_db);
     area.connect_render(move |area, _ctx| {
-        if let Some(s) = state.borrow().as_ref() {
+        if let Some(s) = state.borrow_mut().as_mut() {
             let width = area.width();
             let height = area.height();
             let scale = area.scale_factor();

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -8,6 +8,7 @@ pub mod colormap;
 pub mod fft_plot;
 pub mod frequency_axis;
 pub mod gl_renderer;
+pub mod signal_history;
 pub mod vfo_overlay;
 pub mod waterfall;
 
@@ -18,6 +19,7 @@ use gtk4::glib;
 use gtk4::prelude::*;
 
 use fft_plot::FftPlotRenderer;
+use signal_history::SignalHistoryRenderer;
 use vfo_overlay::{BwHandle, HitZone, VfoOverlayRenderer, VfoState};
 use waterfall::WaterfallRenderer;
 
@@ -69,6 +71,12 @@ struct WaterfallState {
     vfo_renderer: VfoOverlayRenderer,
 }
 
+/// Shared state for the signal history `GtkGLArea`.
+struct SignalHistoryState {
+    gl: glow::Context,
+    renderer: SignalHistoryRenderer,
+}
+
 /// Handle for pushing FFT data into the spectrum display from outside.
 ///
 /// Obtained from `build_spectrum_view` and used by the `DspToUi::FftData`
@@ -76,8 +84,10 @@ struct WaterfallState {
 pub struct SpectrumHandle {
     fft_state: Rc<RefCell<Option<FftPlotState>>>,
     waterfall_state: Rc<RefCell<Option<WaterfallState>>>,
+    signal_history_state: Rc<RefCell<Option<SignalHistoryState>>>,
     fft_area: gtk4::GLArea,
     waterfall_area: gtk4::GLArea,
+    signal_history_area: gtk4::GLArea,
     min_db: Rc<Cell<f32>>,
     max_db: Rc<Cell<f32>>,
     fill_enabled: Rc<Cell<bool>>,
@@ -152,7 +162,7 @@ impl SpectrumHandle {
         self.waterfall_area.queue_render();
     }
 
-    /// Update the display dB range for both the FFT plot and waterfall.
+    /// Update the display dB range for the FFT plot, waterfall, and signal history.
     pub fn set_db_range(&self, min_db: f32, max_db: f32) {
         if min_db >= max_db {
             tracing::trace!(min_db, max_db, "set_db_range: ignoring inverted range");
@@ -165,6 +175,7 @@ impl SpectrumHandle {
         }
         self.fft_area.queue_render();
         self.waterfall_area.queue_render();
+        self.signal_history_area.queue_render();
     }
 
     /// Enable or disable the spectrum fill area under the trace.
@@ -181,6 +192,16 @@ impl SpectrumHandle {
         tracing::debug!(?mode, "averaging mode changed");
     }
 
+    /// Push a signal level sample (in dB) into the history graph.
+    ///
+    /// Call this from the GTK main loop when `DspToUi::SignalLevel` arrives.
+    pub fn push_signal_level(&self, db: f32) {
+        if let Some(s) = self.signal_history_state.borrow_mut().as_mut() {
+            s.renderer.push(db);
+        }
+        self.signal_history_area.queue_render();
+    }
+
     /// Register a callback invoked when the cursor moves over the FFT area.
     ///
     /// The callback receives `(frequency_hz, power_db)`. When the cursor
@@ -190,16 +211,21 @@ impl SpectrumHandle {
     }
 }
 
-/// Build the spectrum view containing the FFT plot and waterfall display.
+/// Height in pixels for the collapsible signal history area.
+const SIGNAL_HISTORY_HEIGHT: i32 = 100;
+
+/// Build the spectrum view containing the FFT plot, waterfall display,
+/// and a collapsible signal history graph.
 ///
-/// Returns a `(GtkPaned, SpectrumHandle)` — the paned widget for layout,
-/// and a handle for pushing real FFT data into the display.
+/// Returns a `(gtk4::Box, SpectrumHandle)` — the box widget for layout,
+/// and a handle for pushing real FFT/signal data into the display.
 pub fn build_spectrum_view(
     dsp_tx: std::sync::mpsc::Sender<UiToDsp>,
-) -> (gtk4::Paned, SpectrumHandle) {
+) -> (gtk4::Box, SpectrumHandle) {
     let vfo_state: Rc<RefCell<VfoState>> = Rc::new(RefCell::new(VfoState::default()));
     let fft_state: Rc<RefCell<Option<FftPlotState>>> = Rc::new(RefCell::new(None));
     let waterfall_state: Rc<RefCell<Option<WaterfallState>>> = Rc::new(RefCell::new(None));
+    let signal_history_state: Rc<RefCell<Option<SignalHistoryState>>> = Rc::new(RefCell::new(None));
 
     let min_db: Rc<Cell<f32>> = Rc::new(Cell::new(DEFAULT_MIN_DB));
     let max_db: Rc<Cell<f32>> = Rc::new(Cell::new(DEFAULT_MAX_DB));
@@ -220,6 +246,8 @@ pub fn build_spectrum_view(
         &min_db,
         &max_db,
     );
+    let signal_history_area =
+        build_signal_history_area(Rc::clone(&signal_history_state), &min_db, &max_db);
 
     // Attach interaction gestures to both the waterfall and FFT areas.
     attach_click_gesture(&waterfall_area, &vfo_state, dsp_tx.clone());
@@ -248,11 +276,30 @@ pub fn build_spectrum_view(
         }
     });
 
+    // Wrap the signal history GLArea in a collapsible expander.
+    let expander = gtk4::Expander::builder()
+        .label("Signal History")
+        .expanded(true)
+        .build();
+    expander.set_child(Some(&signal_history_area));
+
+    // Combine the FFT+waterfall paned and the signal history expander
+    // into a vertical box.
+    let outer_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .hexpand(true)
+        .vexpand(true)
+        .build();
+    outer_box.append(&paned);
+    outer_box.append(&expander);
+
     let handle = SpectrumHandle {
         fft_state,
         waterfall_state,
+        signal_history_state,
         fft_area: fft_area.clone(),
         waterfall_area: waterfall_area.clone(),
+        signal_history_area: signal_history_area.clone(),
         min_db,
         max_db,
         fill_enabled,
@@ -261,7 +308,7 @@ pub fn build_spectrum_view(
         cursor_callback,
     };
 
-    (paned, handle)
+    (outer_box, handle)
 }
 
 /// Build the `GtkGLArea` for the FFT power spectrum plot.
@@ -470,6 +517,78 @@ fn build_waterfall_area(
     area
 }
 
+/// Build the `GtkGLArea` for the signal strength history graph.
+fn build_signal_history_area(
+    state: Rc<RefCell<Option<SignalHistoryState>>>,
+    min_db: &Rc<Cell<f32>>,
+    max_db: &Rc<Cell<f32>>,
+) -> gtk4::GLArea {
+    let area = gtk4::GLArea::builder()
+        .hexpand(true)
+        .vexpand(false)
+        .height_request(SIGNAL_HISTORY_HEIGHT)
+        .auto_render(false)
+        .build();
+    area.set_required_version(3, 0);
+
+    // On realize: create GL context and renderer.
+    let state_realize = Rc::clone(&state);
+    area.connect_realize(move |area| {
+        area.make_current();
+        if area.error().is_some() {
+            tracing::warn!("signal history GLArea has error after make_current");
+            return;
+        }
+
+        match create_gl_context_and_signal_history_renderer() {
+            Ok((gl, renderer)) => {
+                *state_realize.borrow_mut() = Some(SignalHistoryState { gl, renderer });
+                tracing::info!("signal history GL renderer initialized");
+            }
+            Err(e) => {
+                tracing::warn!("failed to initialize signal history renderer: {e}");
+            }
+        }
+    });
+
+    // On unrealize: clean up GL resources.
+    let state_unrealize = Rc::clone(&state);
+    area.connect_unrealize(move |area| {
+        area.make_current();
+        if area.error().is_some() {
+            tracing::warn!("signal history GLArea error on unrealize — skipping GL cleanup");
+        } else if let Some(s) = state_unrealize.borrow().as_ref() {
+            s.renderer.destroy(&s.gl);
+            tracing::info!("signal history GL renderer destroyed");
+        }
+        *state_unrealize.borrow_mut() = None;
+    });
+
+    // On render: draw the signal history plot.
+    let min_db_render = Rc::clone(min_db);
+    let max_db_render = Rc::clone(max_db);
+    area.connect_render(move |area, _ctx| {
+        if let Some(s) = state.borrow().as_ref() {
+            let width = area.width();
+            let height = area.height();
+            let scale = area.scale_factor();
+            let phys_w = width * scale;
+            let phys_h = height * scale;
+
+            s.renderer.render(
+                &s.gl,
+                phys_w,
+                phys_h,
+                min_db_render.get(),
+                max_db_render.get(),
+            );
+        }
+        glib::Propagation::Stop
+    });
+
+    area
+}
+
 /// Create a glow GL context from the current GDK GL context.
 ///
 /// Must be called after `GtkGLArea::make_current()`.
@@ -534,6 +653,14 @@ fn create_gl_context_and_waterfall_renderer()
     let renderer = WaterfallRenderer::new(&gl, FFT_SIZE)?;
     let vfo_renderer = VfoOverlayRenderer::new(&gl)?;
     Ok((gl, renderer, vfo_renderer))
+}
+
+/// Create a glow context and signal history renderer.
+fn create_gl_context_and_signal_history_renderer()
+-> Result<(glow::Context, SignalHistoryRenderer), gl_renderer::GlError> {
+    let gl = create_glow_context();
+    let renderer = SignalHistoryRenderer::new(&gl)?;
+    Ok((gl, renderer))
 }
 
 /// Attach a click-to-tune gesture to a `GtkGLArea`.

--- a/crates/sdr-ui/src/spectrum/signal_history.rs
+++ b/crates/sdr-ui/src/spectrum/signal_history.rs
@@ -192,13 +192,19 @@ impl SignalHistoryRenderer {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
-    fn draw_grid(&self, gl: &glow::Context, _db_range: f32, _min_db: f32) {
+    fn draw_grid(&self, gl: &glow::Context, db_range: f32, min_db: f32) {
+        // Draw grid lines at round 20 dB intervals aligned to actual dB values.
+        const DB_STEP: f32 = 20.0;
         let mut vertices = Vec::with_capacity((DB_GRID_LINE_COUNT + 1) * 4);
 
-        for i in 0..=DB_GRID_LINE_COUNT {
-            let frac = i as f32 / DB_GRID_LINE_COUNT as f32;
-            let y = -1.0 + 2.0 * frac;
-            vertices.extend_from_slice(&[-1.0, y, 1.0, y]);
+        if db_range > 0.0 {
+            let first = (min_db / DB_STEP).ceil() * DB_STEP;
+            let mut db = first;
+            while db < min_db + db_range {
+                let y = -1.0 + 2.0 * ((db - min_db) / db_range);
+                vertices.extend_from_slice(&[-1.0, y, 1.0, y]);
+                db += DB_STEP;
+            }
         }
 
         let bytes = f32_slice_as_bytes(&vertices);
@@ -291,6 +297,6 @@ mod tests {
     const _: () = {
         assert!(super::HISTORY_SIZE > 0);
         assert!(super::DB_GRID_LINE_COUNT > 0);
-        assert!(super::MAX_VERTICES >= super::HISTORY_SIZE);
+        assert!(super::MAX_VERTICES >= super::HISTORY_SIZE + (super::DB_GRID_LINE_COUNT + 1) * 2);
     };
 }

--- a/crates/sdr-ui/src/spectrum/signal_history.rs
+++ b/crates/sdr-ui/src/spectrum/signal_history.rs
@@ -1,0 +1,296 @@
+//! Signal strength history graph — a time-series line plot showing signal
+//! level (dB) over the last ~60 seconds, rendered via OpenGL.
+
+use glow::HasContext;
+
+use super::gl_renderer::{self, GlError, f32_slice_as_bytes};
+
+/// Number of samples in the history buffer (~60 seconds at ~10 updates/sec).
+const HISTORY_SIZE: usize = 600;
+
+/// Number of horizontal dB grid lines in the history plot.
+const DB_GRID_LINE_COUNT: usize = 4;
+
+// Colors (RGBA, 0.0..1.0)
+/// Trace line color — green.
+const TRACE_COLOR: [f32; 4] = [0.3, 0.85, 0.4, 1.0];
+/// Grid line color — dim gray.
+const GRID_COLOR: [f32; 4] = [0.4, 0.4, 0.4, 0.3];
+/// Background clear color — near-black.
+const BACKGROUND_COLOR: [f32; 4] = [0.08, 0.08, 0.10, 1.0];
+
+/// Maximum vertices needed: history samples for the trace, plus grid lines.
+const MAX_VERTICES: usize = HISTORY_SIZE + (DB_GRID_LINE_COUNT + 1) * 2;
+
+/// Vertex shader — maps 2D positions directly to clip space.
+const VERT_SHADER: &str = r"#version 300 es
+precision highp float;
+layout(location = 0) in vec2 a_pos;
+void main() {
+    gl_Position = vec4(a_pos, 0.0, 1.0);
+}
+";
+
+/// Fragment shader — outputs a uniform color.
+const FRAG_SHADER: &str = r"#version 300 es
+precision highp float;
+uniform vec4 u_color;
+out vec4 frag_color;
+void main() {
+    frag_color = u_color;
+}
+";
+
+/// OpenGL renderer for the signal strength history plot.
+///
+/// Maintains a circular buffer of dB samples and draws them as a line strip
+/// with horizontal grid lines for dB reference.
+pub struct SignalHistoryRenderer {
+    program: glow::Program,
+    vao: glow::VertexArray,
+    vbo: glow::Buffer,
+    color_location: glow::UniformLocation,
+    samples: Vec<f32>,
+    write_pos: usize,
+    count: usize,
+}
+
+impl SignalHistoryRenderer {
+    /// Create a new signal history renderer, compiling shaders and allocating GL buffers.
+    ///
+    /// # Errors
+    ///
+    /// Returns `GlError` if shader compilation, linking, or buffer creation fails.
+    #[allow(
+        unsafe_code,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    pub fn new(gl: &glow::Context) -> Result<Self, GlError> {
+        let vert = gl_renderer::compile_shader(gl, glow::VERTEX_SHADER, VERT_SHADER)?;
+        let frag = gl_renderer::compile_shader(gl, glow::FRAGMENT_SHADER, FRAG_SHADER)?;
+        let program = gl_renderer::link_program(gl, vert, frag)?;
+
+        let color_location = unsafe {
+            gl.get_uniform_location(program, "u_color")
+                .ok_or_else(|| GlError::ResourceCreation("u_color uniform not found".into()))?
+        };
+
+        let (vao, vbo) = unsafe {
+            let vao = gl
+                .create_vertex_array()
+                .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+            let vbo = gl
+                .create_buffer()
+                .map_err(|e| GlError::ResourceCreation(e.clone()))?;
+
+            gl.bind_vertex_array(Some(vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+
+            // Pre-allocate buffer for the largest usage (2 floats per vertex).
+            let max_bytes = MAX_VERTICES * 2 * std::mem::size_of::<f32>();
+            gl.buffer_data_size(glow::ARRAY_BUFFER, max_bytes as i32, glow::DYNAMIC_DRAW);
+
+            // Vertex attribute: vec2 at location 0.
+            gl.enable_vertex_attrib_array(0);
+            gl.vertex_attrib_pointer_f32(
+                0,
+                2,
+                glow::FLOAT,
+                false,
+                (2 * std::mem::size_of::<f32>()) as i32,
+                0,
+            );
+
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+
+            (vao, vbo)
+        };
+
+        Ok(Self {
+            program,
+            vao,
+            vbo,
+            color_location,
+            samples: vec![f32::NEG_INFINITY; HISTORY_SIZE],
+            write_pos: 0,
+            count: 0,
+        })
+    }
+
+    /// Add a signal level sample (in dB) to the circular buffer.
+    pub fn push(&mut self, db: f32) {
+        self.samples[self.write_pos] = db;
+        self.write_pos = (self.write_pos + 1) % HISTORY_SIZE;
+        if self.count < HISTORY_SIZE {
+            self.count += 1;
+        }
+    }
+
+    /// Render the signal history line plot.
+    ///
+    /// # Arguments
+    ///
+    /// * `gl` — The glow GL context.
+    /// * `width` — Viewport width in pixels.
+    /// * `height` — Viewport height in pixels.
+    /// * `min_db` — Bottom of the display range in dB.
+    /// * `max_db` — Top of the display range in dB.
+    #[allow(
+        unsafe_code,
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    pub fn render(&self, gl: &glow::Context, width: i32, height: i32, min_db: f32, max_db: f32) {
+        if width <= 0 || height <= 0 {
+            return;
+        }
+
+        let db_range = max_db - min_db;
+        if db_range <= 0.0 {
+            return;
+        }
+
+        unsafe {
+            gl.viewport(0, 0, width, height);
+            gl.clear_color(
+                BACKGROUND_COLOR[0],
+                BACKGROUND_COLOR[1],
+                BACKGROUND_COLOR[2],
+                BACKGROUND_COLOR[3],
+            );
+            gl.clear(glow::COLOR_BUFFER_BIT);
+
+            gl.use_program(Some(self.program));
+            gl.bind_vertex_array(Some(self.vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo));
+
+            gl.enable(glow::BLEND);
+            gl.blend_func(glow::SRC_ALPHA, glow::ONE_MINUS_SRC_ALPHA);
+        }
+
+        // Draw horizontal dB grid lines.
+        self.draw_grid(gl, db_range, min_db);
+
+        // Draw the signal trace as a line strip.
+        self.draw_trace(gl, db_range, min_db);
+
+        unsafe {
+            gl.disable(glow::BLEND);
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.use_program(None);
+        }
+    }
+
+    /// Draw horizontal dB grid lines.
+    #[allow(
+        unsafe_code,
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    fn draw_grid(&self, gl: &glow::Context, _db_range: f32, _min_db: f32) {
+        let mut vertices = Vec::with_capacity((DB_GRID_LINE_COUNT + 1) * 4);
+
+        for i in 0..=DB_GRID_LINE_COUNT {
+            let frac = i as f32 / DB_GRID_LINE_COUNT as f32;
+            let y = -1.0 + 2.0 * frac;
+            vertices.extend_from_slice(&[-1.0, y, 1.0, y]);
+        }
+
+        let bytes = f32_slice_as_bytes(&vertices);
+        let vertex_count = vertices.len() / 2;
+
+        unsafe {
+            gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+
+            gl.uniform_4_f32(
+                Some(&self.color_location),
+                GRID_COLOR[0],
+                GRID_COLOR[1],
+                GRID_COLOR[2],
+                GRID_COLOR[3],
+            );
+
+            gl.draw_arrays(glow::LINES, 0, vertex_count as i32);
+        }
+    }
+
+    /// Draw the signal level trace as a line strip.
+    ///
+    /// Reads from the circular buffer starting at `write_pos` (oldest sample)
+    /// and wrapping around to `write_pos - 1` (newest sample).
+    #[allow(
+        unsafe_code,
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    fn draw_trace(&self, gl: &glow::Context, db_range: f32, min_db: f32) {
+        if self.count == 0 {
+            return;
+        }
+
+        let n = self.count;
+        let mut vertices = Vec::with_capacity(n * 2);
+
+        // Start from the oldest sample in the circular buffer.
+        let start = if self.count < HISTORY_SIZE {
+            0
+        } else {
+            self.write_pos
+        };
+
+        for i in 0..n {
+            let idx = (start + i) % HISTORY_SIZE;
+            let db = self.samples[idx];
+
+            // X axis: time, oldest on left, newest on right.
+            let x = -1.0 + 2.0 * (i as f32 / (n - 1).max(1) as f32);
+            // Y axis: dB mapped to [-1, 1] clip space.
+            let y = -1.0 + 2.0 * ((db - min_db) / db_range).clamp(0.0, 1.0);
+
+            vertices.extend_from_slice(&[x, y]);
+        }
+
+        let bytes = f32_slice_as_bytes(&vertices);
+        let vertex_count = vertices.len() / 2;
+
+        unsafe {
+            gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+
+            gl.uniform_4_f32(
+                Some(&self.color_location),
+                TRACE_COLOR[0],
+                TRACE_COLOR[1],
+                TRACE_COLOR[2],
+                TRACE_COLOR[3],
+            );
+
+            gl.draw_arrays(glow::LINE_STRIP, 0, vertex_count as i32);
+        }
+    }
+
+    /// Release GL resources.
+    #[allow(unsafe_code)]
+    pub fn destroy(&self, gl: &glow::Context) {
+        unsafe {
+            gl.delete_buffer(self.vbo);
+            gl.delete_vertex_array(self.vao);
+            gl.delete_program(self.program);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Compile-time validation that signal history constants are consistent.
+    const _: () = {
+        assert!(super::HISTORY_SIZE > 0);
+        assert!(super::DB_GRID_LINE_COUNT > 0);
+        assert!(super::MAX_VERTICES >= super::HISTORY_SIZE);
+    };
+}

--- a/crates/sdr-ui/src/spectrum/signal_history.rs
+++ b/crates/sdr-ui/src/spectrum/signal_history.rs
@@ -53,6 +53,9 @@ pub struct SignalHistoryRenderer {
     samples: Vec<f32>,
     write_pos: usize,
     count: usize,
+    // Reusable staging buffers to avoid per-frame allocations.
+    grid_vertices: Vec<f32>,
+    trace_vertices: Vec<f32>,
 }
 
 impl SignalHistoryRenderer {
@@ -116,6 +119,8 @@ impl SignalHistoryRenderer {
             samples: vec![f32::NEG_INFINITY; HISTORY_SIZE],
             write_pos: 0,
             count: 0,
+            grid_vertices: Vec::with_capacity((DB_GRID_LINE_COUNT + 1) * 4),
+            trace_vertices: Vec::with_capacity(HISTORY_SIZE * 2),
         })
     }
 
@@ -143,7 +148,14 @@ impl SignalHistoryRenderer {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
-    pub fn render(&self, gl: &glow::Context, width: i32, height: i32, min_db: f32, max_db: f32) {
+    pub fn render(
+        &mut self,
+        gl: &glow::Context,
+        width: i32,
+        height: i32,
+        min_db: f32,
+        max_db: f32,
+    ) {
         if width <= 0 || height <= 0 {
             return;
         }
@@ -192,23 +204,23 @@ impl SignalHistoryRenderer {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
-    fn draw_grid(&self, gl: &glow::Context, db_range: f32, min_db: f32) {
+    fn draw_grid(&mut self, gl: &glow::Context, db_range: f32, min_db: f32) {
         // Draw grid lines at round 20 dB intervals aligned to actual dB values.
         const DB_STEP: f32 = 20.0;
-        let mut vertices = Vec::with_capacity((DB_GRID_LINE_COUNT + 1) * 4);
+        self.grid_vertices.clear();
 
         if db_range > 0.0 {
             let first = (min_db / DB_STEP).ceil() * DB_STEP;
             let mut db = first;
             while db < min_db + db_range {
                 let y = -1.0 + 2.0 * ((db - min_db) / db_range);
-                vertices.extend_from_slice(&[-1.0, y, 1.0, y]);
+                self.grid_vertices.extend_from_slice(&[-1.0, y, 1.0, y]);
                 db += DB_STEP;
             }
         }
 
-        let bytes = f32_slice_as_bytes(&vertices);
-        let vertex_count = vertices.len() / 2;
+        let bytes = f32_slice_as_bytes(&self.grid_vertices);
+        let vertex_count = self.grid_vertices.len() / 2;
 
         unsafe {
             gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
@@ -235,13 +247,13 @@ impl SignalHistoryRenderer {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
-    fn draw_trace(&self, gl: &glow::Context, db_range: f32, min_db: f32) {
+    fn draw_trace(&mut self, gl: &glow::Context, db_range: f32, min_db: f32) {
         if self.count == 0 {
             return;
         }
 
         let n = self.count;
-        let mut vertices = Vec::with_capacity(n * 2);
+        self.trace_vertices.clear();
 
         // Start from the oldest sample in the circular buffer.
         let start = if self.count < HISTORY_SIZE {
@@ -259,11 +271,11 @@ impl SignalHistoryRenderer {
             // Y axis: dB mapped to [-1, 1] clip space.
             let y = -1.0 + 2.0 * ((db - min_db) / db_range).clamp(0.0, 1.0);
 
-            vertices.extend_from_slice(&[x, y]);
+            self.trace_vertices.extend_from_slice(&[x, y]);
         }
 
-        let bytes = f32_slice_as_bytes(&vertices);
-        let vertex_count = vertices.len() / 2;
+        let bytes = f32_slice_as_bytes(&self.trace_vertices);
+        let vertex_count = self.trace_vertices.len() / 2;
 
         unsafe {
             gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -195,6 +195,7 @@ fn handle_dsp_message(
         }
         DspToUi::SignalLevel(level) => {
             status_bar.update_signal_level(level);
+            spectrum_handle.push_signal_level(level);
         }
         DspToUi::Error(err_msg) => {
             tracing::warn!(error = %err_msg, "DSP error");


### PR DESCRIPTION
## Summary
- Collapsible time-series plot below the waterfall showing ~60 seconds of signal level history
- Green line trace with horizontal dB grid lines, circular buffer of 600 samples
- Oldest data on left, newest on right — useful for monitoring fading, antenna adjustment, and propagation analysis
- Uses same dB range as FFT plot/waterfall
- Default expanded, click expander to collapse

Closes #150

## Test plan
- [ ] Verify history plot appears below waterfall in collapsible expander
- [ ] Start receiving, verify green trace updates in real time
- [ ] Collapse/expand the expander, verify it toggles correctly
- [ ] Adjust dB range in display panel, verify history plot updates
- [ ] Use squelch to create signal variation, verify trace shows changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a signal strength history visualization: a time-series line plot with reference grid lines showing recent dB levels.
  * History view is available below the spectrum in an expandable panel and updates in real time as new samples arrive.
* **Improvements**
  * Adjusting the displayed dB range now refreshes the history view to reflect the new scale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->