### PR TITLE
UI polish: bookmark names, about dialog, theme toggle

### DIFF
--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -414,6 +414,7 @@ impl IqFrontend {
             &mut self.fft_output,
             self.window_coherent_gain,
         )?;
+
         fft_out[..self.fft_size].copy_from_slice(&self.fft_output);
 
         Ok(())

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -42,6 +42,8 @@ pub struct DisplayPanel {
     pub fill_mode_row: adw::SwitchRow,
     /// Spectrum averaging mode selector.
     pub averaging_row: adw::ComboRow,
+    /// Theme selector (System / Dark / Light).
+    pub theme_row: adw::ComboRow,
 }
 
 /// Build the display settings panel.
@@ -114,6 +116,13 @@ pub fn build_display_panel() -> DisplayPanel {
         .model(&averaging_model)
         .build();
 
+    // --- Theme ---
+    let theme_model = gtk4::StringList::new(&["System", "Dark", "Light"]);
+    let theme_row = adw::ComboRow::builder()
+        .title("Theme")
+        .model(&theme_model)
+        .build();
+
     group.add(&fft_size_row);
     group.add(&window_fn_row);
     group.add(&frame_rate_row);
@@ -122,6 +131,7 @@ pub fn build_display_panel() -> DisplayPanel {
     group.add(&max_db_row);
     group.add(&fill_mode_row);
     group.add(&averaging_row);
+    group.add(&theme_row);
 
     // FFT size and window function connected via window.rs
 
@@ -135,6 +145,7 @@ pub fn build_display_panel() -> DisplayPanel {
         max_db_row,
         fill_mode_row,
         averaging_row,
+        theme_row,
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -14,6 +14,11 @@ const MAX_FPS: f64 = 60.0;
 /// Default FFT size selector index (2048 = index 2).
 const DEFAULT_FFT_SIZE_INDEX: u32 = 2;
 
+/// Theme selector indices (must match `StringList` order in `build_display_panel`).
+pub const THEME_SYSTEM: u32 = 0;
+pub const THEME_DARK: u32 = 1;
+pub const THEME_LIGHT: u32 = 2;
+
 /// Default window function selector index (Blackman = index 1).
 const DEFAULT_WINDOW_FN_INDEX: u32 = 1;
 

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -194,6 +194,13 @@ pub fn format_frequency(freq: u64) -> String {
 /// Callback type for navigation actions (tune to frequency + set mode + bandwidth).
 pub type NavigationCallback = Box<dyn Fn(u64, DemodMode, f64)>;
 
+/// Identity of the currently active bookmark (name + frequency).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ActiveBookmark {
+    pub name: String,
+    pub frequency: u64,
+}
+
 /// Navigation panel containing band presets and frequency bookmarks.
 pub struct NavigationPanel {
     /// Band presets group widget.
@@ -202,6 +209,8 @@ pub struct NavigationPanel {
     pub bookmarks_widget: gtk4::Box,
     /// Band preset combo row (for connection in window.rs).
     pub preset_row: adw::ComboRow,
+    /// Bookmark name entry (user-editable, defaults to formatted frequency).
+    pub name_entry: adw::EntryRow,
     /// Add bookmark button.
     pub add_button: gtk4::Button,
     /// Bookmark scroll container (height adjusted dynamically).
@@ -212,6 +221,8 @@ pub struct NavigationPanel {
     pub bookmarks: std::rc::Rc<std::cell::RefCell<Vec<Bookmark>>>,
     /// Callback fired when a preset or bookmark is recalled.
     pub on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>>,
+    /// Currently active bookmark identity (for visual highlighting).
+    pub active_bookmark: std::rc::Rc<std::cell::RefCell<ActiveBookmark>>,
 }
 
 impl NavigationPanel {
@@ -252,6 +263,9 @@ pub fn build_navigation_panel() -> NavigationPanel {
         .build();
     bookmarks_group.append(&bookmarks_label);
 
+    let name_entry = adw::EntryRow::builder().title("Name").build();
+    bookmarks_group.append(&name_entry);
+
     let bookmark_list = gtk4::ListBox::builder()
         .selection_mode(gtk4::SelectionMode::None)
         .css_classes(["boxed-list"])
@@ -274,8 +288,17 @@ pub fn build_navigation_panel() -> NavigationPanel {
     let on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>> =
         std::rc::Rc::new(std::cell::RefCell::new(None));
 
+    let active_bookmark = std::rc::Rc::new(std::cell::RefCell::new(ActiveBookmark::default()));
+
     // Build initial bookmark list
-    rebuild_bookmark_list(&bookmark_list, &bookmark_scroll, &bookmarks, &on_navigate);
+    rebuild_bookmark_list(
+        &bookmark_list,
+        &bookmark_scroll,
+        &bookmarks,
+        &on_navigate,
+        &active_bookmark,
+        &name_entry,
+    );
 
     // Connect preset row — auto-tune on selection
     let on_nav_preset = std::rc::Rc::clone(&on_navigate);
@@ -292,11 +315,13 @@ pub fn build_navigation_panel() -> NavigationPanel {
         presets_widget: presets_group,
         bookmarks_widget: bookmarks_group,
         preset_row,
+        name_entry,
         add_button,
         bookmark_scroll,
         bookmark_list,
         bookmarks,
         on_navigate,
+        active_bookmark,
     }
 }
 
@@ -306,11 +331,14 @@ const BOOKMARK_ROW_HEIGHT: i32 = 64;
 const MAX_VISIBLE_BOOKMARKS: i32 = 3;
 
 /// Rebuild the bookmark `ListBox` from the current bookmark list.
+#[allow(clippy::too_many_arguments)]
 pub fn rebuild_bookmark_list(
     list_box: &gtk4::ListBox,
     scroll: &gtk4::ScrolledWindow,
     bookmarks: &std::rc::Rc<std::cell::RefCell<Vec<Bookmark>>>,
     on_navigate: &std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>>,
+    active: &std::rc::Rc<std::cell::RefCell<ActiveBookmark>>,
+    name_entry: &adw::EntryRow,
 ) {
     // Remove all existing rows.
     while let Some(child) = list_box.first_child() {
@@ -318,7 +346,9 @@ pub fn rebuild_bookmark_list(
     }
 
     let bm_list = bookmarks.borrow();
+    let current_active = active.borrow().clone();
     for bm in bm_list.iter() {
+        let is_active = bm.name == current_active.name && bm.frequency == current_active.frequency;
         let row = adw::ActionRow::builder()
             .title(&bm.name)
             .subtitle(format!(
@@ -329,6 +359,13 @@ pub fn rebuild_bookmark_list(
             .activatable(true)
             .build();
 
+        // Highlight the active bookmark with an accent icon.
+        if is_active {
+            let icon = gtk4::Image::from_icon_name("media-playback-start-symbolic");
+            icon.set_valign(gtk4::Align::Center);
+            row.add_prefix(&icon);
+        }
+
         // Delete button — identify by name + frequency rather than index
         let delete_btn = gtk4::Button::builder()
             .icon_name("user-trash-symbolic")
@@ -338,8 +375,10 @@ pub fn rebuild_bookmark_list(
 
         let bm_rc = std::rc::Rc::clone(bookmarks);
         let nav_rc = std::rc::Rc::clone(on_navigate);
+        let active_rc = std::rc::Rc::clone(active);
         let list_ref = list_box.downgrade();
         let scroll_ref = scroll.downgrade();
+        let entry_del = name_entry.clone();
         let del_name = bm.name.clone();
         let del_freq = bm.frequency;
         delete_btn.connect_clicked(move |_| {
@@ -350,19 +389,48 @@ pub fn rebuild_bookmark_list(
             if let Some(lb) = list_ref.upgrade()
                 && let Some(sc) = scroll_ref.upgrade()
             {
-                rebuild_bookmark_list(&lb, &sc, &bm_rc, &nav_rc);
+                rebuild_bookmark_list(&lb, &sc, &bm_rc, &nav_rc, &active_rc, &entry_del);
             }
         });
         row.add_suffix(&delete_btn);
 
-        // Recall on row activation
+        // Recall on row activation — set active, update name entry, rebuild list
         let freq = bm.frequency;
         let mode = string_to_demod_mode(&bm.demod_mode);
         let bw = bm.bandwidth;
+        let recall_name = bm.name.clone();
         let on_nav_recall = std::rc::Rc::clone(on_navigate);
+        let active_recall = std::rc::Rc::clone(active);
+        let bm_recall = std::rc::Rc::clone(bookmarks);
+        let list_recall = list_box.downgrade();
+        let scroll_recall = scroll.downgrade();
+        let entry_recall = name_entry.clone();
         row.connect_activated(move |_| {
+            // Set this bookmark as active
+            *active_recall.borrow_mut() = ActiveBookmark {
+                name: recall_name.clone(),
+                frequency: freq,
+            };
+            // Show the active bookmark name in the entry (read-only indication)
+            entry_recall.set_text(&recall_name);
+
+            // Fire the navigate callback
             if let Some(cb) = on_nav_recall.borrow().as_ref() {
                 cb(freq, mode, bw);
+            }
+
+            // Rebuild list to update active highlighting
+            if let Some(lb) = list_recall.upgrade()
+                && let Some(sc) = scroll_recall.upgrade()
+            {
+                rebuild_bookmark_list(
+                    &lb,
+                    &sc,
+                    &bm_recall,
+                    &on_nav_recall,
+                    &active_recall,
+                    &entry_recall,
+                );
             }
         });
 

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -300,14 +300,35 @@ pub fn build_navigation_panel() -> NavigationPanel {
         &name_entry,
     );
 
-    // Connect preset row — auto-tune on selection
+    // Connect preset row — auto-tune on selection, clear active bookmark
     let on_nav_preset = std::rc::Rc::clone(&on_navigate);
+    let active_for_preset = std::rc::Rc::clone(&active_bookmark);
+    let entry_for_preset = name_entry.clone();
+    let list_for_preset = bookmark_list.downgrade();
+    let scroll_for_preset = bookmark_scroll.downgrade();
+    let bm_for_preset = std::rc::Rc::clone(&bookmarks);
     preset_row.connect_selected_notify(move |row| {
         let idx = row.selected() as usize;
         if let Some(preset) = BAND_PRESETS.get(idx)
             && let Some(cb) = on_nav_preset.borrow().as_ref()
         {
+            // Clear active bookmark — we're tuning via preset, not bookmark.
+            *active_for_preset.borrow_mut() = ActiveBookmark::default();
+            entry_for_preset.set_text("");
             cb(preset.frequency, preset.demod_mode, preset.bandwidth);
+            // Rebuild to remove stale highlight
+            if let Some(lb) = list_for_preset.upgrade()
+                && let Some(sc) = scroll_for_preset.upgrade()
+            {
+                rebuild_bookmark_list(
+                    &lb,
+                    &sc,
+                    &bm_for_preset,
+                    &on_nav_preset,
+                    &active_for_preset,
+                    &entry_for_preset,
+                );
+            }
         }
     });
 
@@ -382,6 +403,15 @@ pub fn rebuild_bookmark_list(
         let del_name = bm.name.clone();
         let del_freq = bm.frequency;
         delete_btn.connect_clicked(move |_| {
+            // Clear active state if deleting the active bookmark.
+            {
+                let active = active_rc.borrow();
+                if active.name == del_name && active.frequency == del_freq {
+                    drop(active);
+                    *active_rc.borrow_mut() = ActiveBookmark::default();
+                    entry_del.set_text("");
+                }
+            }
             bm_rc
                 .borrow_mut()
                 .retain(|b| !(b.name == del_name && b.frequency == del_freq));

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -801,8 +801,8 @@ fn connect_display_panel(
         .connect_selected_notify(move |row| {
             let style_manager = adw::StyleManager::default();
             let scheme = match row.selected() {
-                1 => adw::ColorScheme::ForceDark,
-                2 => adw::ColorScheme::ForceLight,
+                sidebar::display_panel::THEME_DARK => adw::ColorScheme::ForceDark,
+                sidebar::display_panel::THEME_LIGHT => adw::ColorScheme::ForceLight,
                 _ => adw::ColorScheme::Default,
             };
             style_manager.set_color_scheme(scheme);
@@ -954,4 +954,5 @@ fn setup_app_actions(app: &adw::Application, window: &adw::ApplicationWindow) {
         }
     ));
     app.add_action(&about_action);
+    app.set_accels_for_action("app.about", &["F1"]);
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -793,6 +793,20 @@ fn connect_display_panel(
                 .unwrap_or(spectrum::AveragingMode::None);
             spectrum_avg.set_averaging_mode(mode);
         });
+
+    // Theme selector (System / Dark / Light).
+    panels
+        .display
+        .theme_row
+        .connect_selected_notify(move |row| {
+            let style_manager = adw::StyleManager::default();
+            let scheme = match row.selected() {
+                1 => adw::ColorScheme::ForceDark,
+                2 => adw::ColorScheme::ForceLight,
+                _ => adw::ColorScheme::Default,
+            };
+            style_manager.set_color_scheme(scheme);
+        });
 }
 
 /// Connect navigation panel (band presets + bookmarks) to DSP commands.
@@ -851,6 +865,8 @@ fn connect_navigation_panel(
     let bm_list = nav.bookmark_list.clone();
     let bm_scroll = nav.bookmark_scroll.clone();
     let on_nav = nav.on_navigate.clone();
+    let active_bm = nav.active_bookmark.clone();
+    let name_entry = nav.name_entry.clone();
 
     nav.add_button.connect_clicked(move |_| {
         let freq = state_bm.center_frequency.get();
@@ -858,11 +874,24 @@ fn connect_navigation_panel(
         let bw = radio_bw.value();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let freq_u64 = freq as u64;
-        let name = sidebar::navigation_panel::format_frequency(freq_u64);
+        let entered = name_entry.text();
+        let name = if entered.is_empty() {
+            sidebar::navigation_panel::format_frequency(freq_u64)
+        } else {
+            entered.to_string()
+        };
         let bookmark = sidebar::navigation_panel::Bookmark::new(&name, freq_u64, mode, bw);
         bm_rc.borrow_mut().push(bookmark);
         sidebar::navigation_panel::save_bookmarks(&bm_rc.borrow());
-        sidebar::navigation_panel::rebuild_bookmark_list(&bm_list, &bm_scroll, &bm_rc, &on_nav);
+        sidebar::navigation_panel::rebuild_bookmark_list(
+            &bm_list,
+            &bm_scroll,
+            &bm_rc,
+            &on_nav,
+            &active_bm,
+            &name_entry,
+        );
+        name_entry.set_text("");
     });
 }
 
@@ -906,6 +935,20 @@ fn setup_app_actions(app: &adw::Application, window: &adw::ApplicationWindow) {
                 .application_icon("audio-radio-symbolic")
                 .license_type(gtk4::License::MitX11)
                 .website("https://github.com/jasonherald/rtl-sdr")
+                .comments("Software-defined radio for Linux")
+                .developers(["Jason Herald"])
+                .copyright("\u{00a9} 2026 Jason Herald")
+                .issue_url("https://github.com/jasonherald/rtl-sdr/issues")
+                .debug_info(format!(
+                    "GTK {}.{}.{}\nLibadwaita {}.{}.{}\nPlatform: {}",
+                    gtk4::major_version(),
+                    gtk4::minor_version(),
+                    gtk4::micro_version(),
+                    adw::major_version(),
+                    adw::minor_version(),
+                    adw::micro_version(),
+                    std::env::consts::OS,
+                ))
                 .build();
             about.present(Some(&window));
         }


### PR DESCRIPTION
## Summary
- **Editable bookmark names (#162):** Name entry field for custom bookmark names, active bookmark shown with play icon indicator and name in entry field
- **About dialog (#145):** Enhanced with description, developer credit, copyright, issue URL, and system info (GTK/libadwaita versions, platform)
- **Dark/light theme toggle (#147):** System / Dark / Light selector in display panel via `AdwStyleManager`

Note: #163 (waterfall alignment) investigated but deferred — requires syncing VFO display range with FFT bandwidth, not just fftshift. Issue updated with findings.

Closes #145, closes #147, closes #162

## Test plan
- [ ] Add bookmark with custom name, verify it appears with the name
- [ ] Click a bookmark, verify play icon appears and name shows in entry
- [ ] Click a different bookmark, verify indicator moves
- [ ] Open About dialog (menu → About SDR-RS), verify system info shows
- [ ] Switch theme to Dark/Light/System in display panel, verify it applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme selector: choose System, Dark, or Light and apply app-wide color scheme
  * Bookmark management: active bookmarks are visually highlighted; selecting presets clears active state
  * Custom bookmark naming: enter names for bookmarks; name field is cleared after saving
  * About dialog expanded: shows extra system/app metadata and adds F1 accelerator
<!-- end of auto-generated comment: release notes by coderabbit.ai -->