### PR TITLE
Large FFT support up to 65536 with max-pool downsampling

### DIFF
--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc;
 
 use sdr_pipeline::sink_manager::Sink;
 use sdr_types::{SinkError, Stereo};
@@ -13,10 +12,9 @@ const AUDIO_SAMPLE_RATE: u32 = 48_000;
 /// Number of audio channels (stereo).
 const AUDIO_CHANNELS: u32 = 2;
 
-/// Bounded channel capacity in chunks.
-/// Large enough to absorb USB timing jitter at high sample rates.
-/// At WFM rates (~393 samples/chunk, ~8ms per chunk), 128 chunks = ~1 second.
-const CHANNEL_BOUND: usize = 128;
+/// Audio ring buffer capacity in f32 samples (interleaved stereo).
+/// ~1 second at 48 kHz stereo = 96,000 samples.
+const RING_CAPACITY: usize = 96_000;
 
 /// Bytes per sample frame (2 channels x 4 bytes per f32).
 const FRAME_SIZE: usize = (AUDIO_CHANNELS as usize) * std::mem::size_of::<f32>();
@@ -24,15 +22,87 @@ const FRAME_SIZE: usize = (AUDIO_CHANNELS as usize) * std::mem::size_of::<f32>()
 /// Sentinel message sent via the PipeWire channel to request shutdown.
 struct Quit;
 
+/// Lock-based SPSC ring buffer for interleaved audio samples.
+///
+/// Pre-allocated at startup — zero allocation during streaming.
+/// The Mutex is held only for memcpy duration (microseconds).
+struct AudioRingBuffer {
+    buf: std::sync::Mutex<AudioRingInner>,
+}
+
+struct AudioRingInner {
+    data: Vec<f32>,
+    read_pos: usize,
+    write_pos: usize,
+    count: usize,
+    capacity: usize,
+}
+
+impl AudioRingBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            buf: std::sync::Mutex::new(AudioRingInner {
+                data: vec![0.0; capacity],
+                read_pos: 0,
+                write_pos: 0,
+                count: 0,
+                capacity,
+            }),
+        }
+    }
+
+    /// Write samples into the ring buffer. Drops oldest data if full.
+    fn write(&self, samples: &[f32]) {
+        let Ok(mut inner) = self.buf.lock() else {
+            return;
+        };
+        let cap = inner.capacity;
+        let mut wp = inner.write_pos;
+        let mut rp = inner.read_pos;
+        let mut cnt = inner.count;
+        for &s in samples {
+            inner.data[wp] = s;
+            wp = (wp + 1) % cap;
+            if cnt < cap {
+                cnt += 1;
+            } else {
+                rp = (rp + 1) % cap;
+            }
+        }
+        inner.write_pos = wp;
+        inner.read_pos = rp;
+        inner.count = cnt;
+    }
+
+    /// Read up to `output.len()` samples. Returns count read.
+    fn read(&self, output: &mut [f32]) -> usize {
+        let Ok(mut inner) = self.buf.lock() else {
+            return 0;
+        };
+        let to_read = output.len().min(inner.count);
+        let mut rp = inner.read_pos;
+        let cap = inner.capacity;
+        for out in output.iter_mut().take(to_read) {
+            *out = inner.data[rp];
+            rp = (rp + 1) % cap;
+        }
+        inner.read_pos = rp;
+        inner.count -= to_read;
+        to_read
+    }
+}
+
 /// Audio output sink backed by PipeWire.
 pub struct AudioSink {
     sample_rate: f64,
     running: Arc<AtomicBool>,
-    tx: Option<mpsc::SyncSender<Vec<f32>>>,
+    ring: Arc<AudioRingBuffer>,
     quit_tx: Option<pipewire::channel::Sender<Quit>>,
     pw_thread: Option<std::thread::JoinHandle<()>>,
     /// Target PipeWire node name for routing (empty = system default).
     target_node: String,
+    /// Pre-allocated interleave buffer for write_samples (avoids per-call alloc).
+    interleave_buf: Vec<f32>,
 }
 
 /// An audio sink device with display name and PipeWire node name.
@@ -144,10 +214,11 @@ impl AudioSink {
         Self {
             sample_rate: f64::from(AUDIO_SAMPLE_RATE),
             running: Arc::new(AtomicBool::new(false)),
-            tx: None,
+            ring: Arc::new(AudioRingBuffer::new(RING_CAPACITY)),
             quit_tx: None,
             pw_thread: None,
             target_node: String::new(),
+            interleave_buf: Vec::with_capacity(1024),
         }
     }
 
@@ -158,9 +229,7 @@ impl AudioSink {
     ///
     /// Pass an empty string for the system default sink.
     pub fn set_target(&mut self, node_name: &str) -> Result<(), SinkError> {
-        // Check owned state (tx/thread) rather than the atomic flag, which
-        // the worker thread may clear before cleanup finishes.
-        let had_state = self.tx.is_some() || self.pw_thread.is_some();
+        let had_state = self.pw_thread.is_some();
         if had_state {
             self.stop()?;
         }
@@ -178,22 +247,19 @@ impl AudioSink {
     ///
     /// Returns `SinkError::NotRunning` if the sink has not been started.
     /// Returns `SinkError::Disconnected` if the PipeWire thread has exited.
-    pub fn write_samples(&self, samples: &[Stereo]) -> Result<(), SinkError> {
-        let tx = self.tx.as_ref().ok_or(SinkError::NotRunning)?;
+    pub fn write_samples(&mut self, samples: &[Stereo]) -> Result<(), SinkError> {
+        if !self.running.load(Ordering::Acquire) {
+            return Err(SinkError::NotRunning);
+        }
 
-        let mut buf = Vec::with_capacity(samples.len() * 2);
+        // Interleave stereo into pre-allocated buffer (zero allocation).
+        self.interleave_buf.clear();
         for s in samples {
-            buf.push(s.l);
-            buf.push(s.r);
+            self.interleave_buf.push(s.l);
+            self.interleave_buf.push(s.r);
         }
 
-        match tx.send(buf) {
-            Ok(()) => {}
-            Err(mpsc::SendError(_)) => {
-                return Err(SinkError::Disconnected);
-            }
-        }
-
+        self.ring.write(&self.interleave_buf);
         Ok(())
     }
 }
@@ -214,16 +280,16 @@ impl Sink for AudioSink {
             return Err(SinkError::AlreadyRunning);
         }
 
-        let (tx, rx) = mpsc::sync_channel::<Vec<f32>>(CHANNEL_BOUND);
         let (quit_tx, quit_rx) = pipewire::channel::channel::<Quit>();
 
         let running = Arc::clone(&self.running);
+        let ring = Arc::clone(&self.ring);
         let target = self.target_node.clone();
 
         let handle = std::thread::Builder::new()
             .name("pw-audio".into())
             .spawn(move || {
-                if let Err(e) = pipewire_thread(rx, quit_rx, &target) {
+                if let Err(e) = pipewire_thread(ring, quit_rx, &target) {
                     tracing::error!("PipeWire thread failed: {e}");
                 }
                 running.store(false, Ordering::Release);
@@ -231,7 +297,6 @@ impl Sink for AudioSink {
             .map_err(|e| SinkError::OpenFailed(format!("spawn PipeWire thread: {e}")))?;
 
         // Commit state only after spawn succeeds.
-        self.tx = Some(tx);
         self.quit_tx = Some(quit_tx);
         self.running.store(true, Ordering::Release);
         self.pw_thread = Some(handle);
@@ -243,12 +308,11 @@ impl Sink for AudioSink {
         // Always clean up if handles exist, regardless of `running` flag.
         // The worker thread may have exited on its own (setting running=false),
         // but we still need to join and drop channels.
-        let had_state = self.tx.is_some() || self.pw_thread.is_some();
+        let had_state = self.pw_thread.is_some();
 
         if let Some(quit_tx) = self.quit_tx.take() {
             let _ = quit_tx.send(Quit);
         }
-        self.tx = None;
         if let Some(handle) = self.pw_thread.take() {
             let _ = handle.join();
         }
@@ -290,7 +354,6 @@ impl Drop for AudioSink {
             if let Some(quit_tx) = self.quit_tx.take() {
                 let _ = quit_tx.send(Quit);
             }
-            self.tx = None;
             if let Some(handle) = self.pw_thread.take() {
                 let _ = handle.join();
             }
@@ -303,7 +366,7 @@ impl Drop for AudioSink {
 // ---------------------------------------------------------------------------
 
 fn pipewire_thread(
-    rx: mpsc::Receiver<Vec<f32>>,
+    ring: Arc<AudioRingBuffer>,
     quit_rx: pipewire::channel::Receiver<Quit>,
     target_node: &str,
 ) -> Result<(), SinkError> {
@@ -341,7 +404,7 @@ fn pipewire_thread(
         .map_err(|e| SinkError::OpenFailed(format!("Stream::new: {e}")))?;
 
     let _listener = stream
-        .add_local_listener_with_user_data(AudioCallbackData::new(rx))
+        .add_local_listener_with_user_data(AudioCallbackData::new(ring))
         .process(process_callback)
         .register()
         .map_err(|e| SinkError::OpenFailed(format!("stream listener: {e}")))?;
@@ -384,15 +447,16 @@ fn pipewire_thread(
 }
 
 struct AudioCallbackData {
-    rx: mpsc::Receiver<Vec<f32>>,
-    remainder: Vec<f32>,
+    ring: Arc<AudioRingBuffer>,
+    /// Pre-allocated read buffer — sized for PipeWire's largest request.
+    read_buf: Vec<f32>,
 }
 
 impl AudioCallbackData {
-    fn new(rx: mpsc::Receiver<Vec<f32>>) -> Self {
+    fn new(ring: Arc<AudioRingBuffer>) -> Self {
         Self {
-            rx,
-            remainder: Vec::new(),
+            ring,
+            read_buf: vec![0.0; 4096],
         }
     }
 }
@@ -415,13 +479,11 @@ fn process_callback(stream: &pipewire::stream::Stream, data: &mut AudioCallbackD
     let n_frames = slice.len() / FRAME_SIZE;
     let n_samples = n_frames * (AUDIO_CHANNELS as usize);
 
-    while let Ok(chunk) = data.rx.try_recv() {
-        data.remainder.extend_from_slice(&chunk);
-    }
+    // Read from ring buffer into pre-allocated buffer (zero allocation).
+    data.read_buf.resize(n_samples, 0.0);
+    let available = data.ring.read(&mut data.read_buf[..n_samples]);
 
-    let available = data.remainder.len().min(n_samples);
-
-    for (i, &sample) in data.remainder[..available].iter().enumerate() {
+    for (i, &sample) in data.read_buf[..available].iter().enumerate() {
         let offset = i * std::mem::size_of::<f32>();
         let end = offset + std::mem::size_of::<f32>();
         if end <= slice.len() {
@@ -436,10 +498,6 @@ fn process_callback(stream: &pipewire::stream::Stream, data: &mut AudioCallbackD
             *byte = 0;
         }
     }
-
-    let leftover_len = data.remainder.len() - available;
-    data.remainder.copy_within(available.., 0);
-    data.remainder.truncate(leftover_len);
 
     let chunk = buf_data.chunk_mut();
     *chunk.offset_mut() = 0;
@@ -464,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_write_before_start_returns_not_running() {
-        let sink = AudioSink::new();
+        let mut sink = AudioSink::new();
         let samples = [Stereo::new(0.0, 0.0)];
         assert!(
             matches!(sink.write_samples(&samples), Err(SinkError::NotRunning)),

--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -16,6 +16,9 @@ const AUDIO_CHANNELS: u32 = 2;
 /// ~1 second at 48 kHz stereo = 96,000 samples.
 const RING_CAPACITY: usize = 96_000;
 
+/// Initial capacity for the stereo interleave buffer in `write_samples`.
+const INTERLEAVE_BUF_INITIAL_CAP: usize = 1024;
+
 /// Bytes per sample frame (2 channels x 4 bytes per f32).
 const FRAME_SIZE: usize = (AUDIO_CHANNELS as usize) * std::mem::size_of::<f32>();
 
@@ -74,10 +77,21 @@ impl AudioRingBuffer {
         inner.count = cnt;
     }
 
-    /// Read up to `output.len()` samples. Returns count read.
-    fn read(&self, output: &mut [f32]) -> usize {
+    /// Clear the ring buffer (used on start/stop to avoid replaying stale audio).
+    fn clear(&self) {
         let Ok(mut inner) = self.buf.lock() else {
-            return 0;
+            return;
+        };
+        inner.read_pos = 0;
+        inner.write_pos = 0;
+        inner.count = 0;
+    }
+
+    /// Read up to `output.len()` samples. Returns count read.
+    /// Uses `try_lock` to avoid blocking the PipeWire RT callback thread.
+    fn read(&self, output: &mut [f32]) -> usize {
+        let Ok(mut inner) = self.buf.try_lock() else {
+            return 0; // Contended — return silence this cycle.
         };
         let to_read = output.len().min(inner.count);
         let mut rp = inner.read_pos;
@@ -218,7 +232,7 @@ impl AudioSink {
             quit_tx: None,
             pw_thread: None,
             target_node: String::new(),
-            interleave_buf: Vec::with_capacity(1024),
+            interleave_buf: Vec::with_capacity(INTERLEAVE_BUF_INITIAL_CAP),
         }
     }
 
@@ -279,6 +293,7 @@ impl Sink for AudioSink {
         if self.running.load(Ordering::Acquire) {
             return Err(SinkError::AlreadyRunning);
         }
+        self.ring.clear();
 
         let (quit_tx, quit_rx) = pipewire::channel::channel::<Quit>();
 
@@ -318,6 +333,7 @@ impl Sink for AudioSink {
         }
 
         self.running.store(false, Ordering::Release);
+        self.ring.clear();
 
         if had_state {
             tracing::info!("audio sink stopped");

--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -301,19 +301,26 @@ impl Sink for AudioSink {
         let ring = Arc::clone(&self.ring);
         let target = self.target_node.clone();
 
-        let handle = std::thread::Builder::new()
+        // Set running BEFORE spawn so write_samples can start queueing.
+        // Roll back on spawn failure.
+        self.running.store(true, Ordering::Release);
+
+        let handle = match std::thread::Builder::new()
             .name("pw-audio".into())
             .spawn(move || {
                 if let Err(e) = pipewire_thread(ring, quit_rx, &target) {
                     tracing::error!("PipeWire thread failed: {e}");
                 }
                 running.store(false, Ordering::Release);
-            })
-            .map_err(|e| SinkError::OpenFailed(format!("spawn PipeWire thread: {e}")))?;
+            }) {
+            Ok(h) => h,
+            Err(e) => {
+                self.running.store(false, Ordering::Release);
+                return Err(SinkError::OpenFailed(format!("spawn PipeWire thread: {e}")));
+            }
+        };
 
-        // Commit state only after spawn succeeds.
         self.quit_tx = Some(quit_tx);
-        self.running.store(true, Ordering::Release);
         self.pw_thread = Some(handle);
         tracing::info!("audio sink started (PipeWire, {AUDIO_SAMPLE_RATE} Hz stereo f32)");
         Ok(())
@@ -472,7 +479,10 @@ impl AudioCallbackData {
     fn new(ring: Arc<AudioRingBuffer>) -> Self {
         Self {
             ring,
-            read_buf: vec![0.0; 4096],
+            // 48 kHz stereo = 96,000 samples/sec. Typical PipeWire quantum is
+            // 1024 frames = 2048 samples. Allocate for 4x that to handle any
+            // reasonable quantum size without RT reallocation.
+            read_buf: vec![0.0; 8192],
         }
     }
 }
@@ -495,8 +505,12 @@ fn process_callback(stream: &pipewire::stream::Stream, data: &mut AudioCallbackD
     let n_frames = slice.len() / FRAME_SIZE;
     let n_samples = n_frames * (AUDIO_CHANNELS as usize);
 
-    // Read from ring buffer into pre-allocated buffer (zero allocation).
-    data.read_buf.resize(n_samples, 0.0);
+    // Read from ring buffer into pre-allocated buffer.
+    // Grow the buffer if PipeWire requests more than expected (rare, only
+    // happens once per new quantum size — not a per-frame allocation).
+    if data.read_buf.len() < n_samples {
+        data.read_buf.resize(n_samples, 0.0);
+    }
     let available = data.ring.read(&mut data.read_buf[..n_samples]);
 
     for (i, &sample) in data.read_buf[..available].iter().enumerate() {

--- a/crates/sdr-sink-audio/src/stub_impl.rs
+++ b/crates/sdr-sink-audio/src/stub_impl.rs
@@ -39,7 +39,7 @@ impl AudioSink {
     /// Always returns `Ok` (samples are discarded).
     pub fn write_samples(&mut self, samples: &[Stereo]) -> Result<(), SinkError> {
         self.write_count += 1;
-        if self.write_count % STUB_LOG_INTERVAL == 0 {
+        if self.write_count.is_multiple_of(STUB_LOG_INTERVAL) {
             tracing::debug!(
                 calls = self.write_count,
                 samples = samples.len(),

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -1,5 +1,8 @@
 //! Application setup — creates the `AdwApplication` and connects signals.
 
+use std::time::Duration;
+
+use gtk4::glib;
 use gtk4::prelude::*;
 use libadwaita as adw;
 
@@ -27,6 +30,21 @@ pub fn build_app() -> adw::Application {
 
     app.connect_activate(|app| {
         window::build_window(app);
+
+        // Periodically trim the glibc heap to return freed pages to the OS.
+        // Without this, freed allocations (especially from per-frame FFT clones)
+        // accumulate in malloc arenas and RSS grows indefinitely.
+        #[cfg(target_os = "linux")]
+        glib::timeout_add_local(Duration::from_mins(1), || {
+            #[allow(unsafe_code)]
+            unsafe {
+                unsafe extern "C" {
+                    fn malloc_trim(pad: usize) -> i32;
+                }
+                malloc_trim(0);
+            }
+            glib::ControlFlow::Continue
+        });
     });
 
     app

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -25,17 +25,11 @@ pub fn build_app() -> adw::Application {
             icon_theme.add_search_path("data");
         }
 
-        tracing::info!("sdr-rs UI starting");
-    });
-
-    app.connect_activate(|app| {
-        window::build_window(app);
-
         // Periodically trim the glibc heap to return freed pages to the OS.
-        // Without this, freed allocations (especially from per-frame FFT clones)
-        // accumulate in malloc arenas and RSS grows indefinitely.
-        #[cfg(target_os = "linux")]
-        glib::timeout_add_local(Duration::from_mins(1), || {
+        // Registered in startup (not activate) since activate can fire
+        // multiple times on re-activation.
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        glib::timeout_add_local(Duration::from_secs(10), || {
             #[allow(unsafe_code)]
             unsafe {
                 unsafe extern "C" {
@@ -45,6 +39,12 @@ pub fn build_app() -> adw::Application {
             }
             glib::ControlFlow::Continue
         });
+
+        tracing::info!("sdr-rs UI starting");
+    });
+
+    app.connect_activate(|app| {
+        window::build_window(app);
     });
 
     app

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -59,11 +59,54 @@ const DEVICE_INDEX: u32 = 0;
 ///
 /// This function returns immediately; the DSP work happens on a background
 /// thread that runs until the UI channel is dropped.
-pub fn spawn_dsp_thread(dsp_tx: mpsc::Sender<DspToUi>, ui_rx: mpsc::Receiver<UiToDsp>) {
+/// Shared FFT display buffer — written by DSP thread, read by UI thread.
+/// Avoids per-frame Vec allocation that causes glibc arena fragmentation
+/// from cross-thread alloc/free patterns.
+pub struct SharedFftBuffer {
+    buf: std::sync::Mutex<Vec<f32>>,
+    ready: std::sync::atomic::AtomicBool,
+}
+
+impl SharedFftBuffer {
+    /// Create a new shared buffer with the given initial size.
+    pub fn new(size: usize) -> Self {
+        Self {
+            buf: std::sync::Mutex::new(vec![0.0; size]),
+            ready: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// DSP thread: write FFT data and mark as ready.
+    fn write(&self, data: &[f32]) {
+        if let Ok(mut buf) = self.buf.lock() {
+            buf.resize(data.len(), 0.0);
+            buf.copy_from_slice(data);
+            self.ready.store(true, std::sync::atomic::Ordering::Release);
+        }
+    }
+
+    /// UI thread: read FFT data if a new frame is ready.
+    /// Returns None if no new frame, or the data slice via callback.
+    pub fn take_if_ready<F: FnOnce(&[f32])>(&self, f: F) -> bool {
+        if !self.ready.swap(false, std::sync::atomic::Ordering::AcqRel) {
+            return false;
+        }
+        if let Ok(buf) = self.buf.lock() {
+            f(&buf);
+        }
+        true
+    }
+}
+
+pub fn spawn_dsp_thread(
+    dsp_tx: mpsc::Sender<DspToUi>,
+    ui_rx: mpsc::Receiver<UiToDsp>,
+    fft_shared: std::sync::Arc<SharedFftBuffer>,
+) {
     match std::thread::Builder::new()
         .name("dsp-controller".into())
         .spawn(move || {
-            dsp_thread_main(dsp_tx, ui_rx);
+            dsp_thread_main(dsp_tx, ui_rx, fft_shared);
         }) {
         Ok(_) => {}
         Err(e) => {
@@ -77,7 +120,11 @@ pub fn spawn_dsp_thread(dsp_tx: mpsc::Sender<DspToUi>, ui_rx: mpsc::Receiver<UiT
 ///
 /// Runs until the `ui_rx` channel is disconnected (UI closed).
 #[allow(clippy::needless_pass_by_value)]
-fn dsp_thread_main(dsp_tx: mpsc::Sender<DspToUi>, ui_rx: mpsc::Receiver<UiToDsp>) {
+fn dsp_thread_main(
+    dsp_tx: mpsc::Sender<DspToUi>,
+    ui_rx: mpsc::Receiver<UiToDsp>,
+    fft_shared: std::sync::Arc<SharedFftBuffer>,
+) {
     tracing::info!("DSP controller thread started");
 
     let mut state = match DspState::new() {
@@ -105,7 +152,7 @@ fn dsp_thread_main(dsp_tx: mpsc::Sender<DspToUi>, ui_rx: mpsc::Receiver<UiToDsp>
             }
 
             // Read and process one IQ block.
-            process_iq_block(&mut state, &dsp_tx);
+            process_iq_block(&mut state, &dsp_tx, &fft_shared);
         } else {
             // Pipeline stopped — block with timeout to avoid busy-waiting.
             match ui_rx.recv_timeout(Duration::from_millis(RECV_TIMEOUT_MS)) {
@@ -777,7 +824,11 @@ fn auto_decimation_ratio(sample_rate: f64, if_rate: f64) -> u32 {
 /// Read one block of IQ data from the source, process it, and send FFT data
 /// to the UI.
 #[allow(clippy::too_many_lines)]
-fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
+fn process_iq_block(
+    state: &mut DspState,
+    dsp_tx: &mpsc::Sender<DspToUi>,
+    fft_shared: &SharedFftBuffer,
+) {
     let Some(source) = &mut state.source else {
         tracing::warn!("process_iq_block called without source");
         state.running = false;
@@ -823,12 +874,10 @@ fn process_iq_block(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
         &mut state.fft_buf,
     ) {
         Ok((processed_count, fft_ready)) => {
-            // Send FFT data to UI if a new frame is ready.
-            // Clone the buffer and zero in-place to avoid per-frame Vec
-            // allocation (the clone reuses allocator memory; zeroing is
-            // a memset with no allocation).
+            // Write FFT data to shared buffer (zero allocation — no Vec
+            // cloned across threads, avoiding glibc arena fragmentation).
             if fft_ready {
-                let _ = dsp_tx.send(DspToUi::FftData(state.fft_buf.clone()));
+                fft_shared.write(&state.fft_buf);
                 state.fft_buf.fill(0.0);
             }
 

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -11,6 +11,9 @@ const MIN_FPS: f64 = 1.0;
 /// Maximum frame rate in FPS.
 const MAX_FPS: f64 = 60.0;
 
+/// Available FFT sizes — single source of truth for dropdown and DSP mapping.
+pub const FFT_SIZES: &[usize] = &[512, 1024, 2048, 4096, 8192, 16384, 32768, 65536];
+
 /// Default FFT size selector index (2048 = index 2).
 const DEFAULT_FFT_SIZE_INDEX: u32 = 2;
 
@@ -59,9 +62,9 @@ pub fn build_display_panel() -> DisplayPanel {
         .build();
 
     // --- FFT Size ---
-    let fft_size_model = gtk4::StringList::new(&[
-        "512", "1024", "2048", "4096", "8192", "16384", "32768", "65536",
-    ]);
+    let fft_labels: Vec<String> = FFT_SIZES.iter().map(usize::to_string).collect();
+    let fft_label_refs: Vec<&str> = fft_labels.iter().map(String::as_str).collect();
+    let fft_size_model = gtk4::StringList::new(&fft_label_refs);
     let fft_size_row = adw::ComboRow::builder()
         .title("FFT Size")
         .model(&fft_size_model)

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -59,7 +59,9 @@ pub fn build_display_panel() -> DisplayPanel {
         .build();
 
     // --- FFT Size ---
-    let fft_size_model = gtk4::StringList::new(&["512", "1024", "2048"]);
+    let fft_size_model = gtk4::StringList::new(&[
+        "512", "1024", "2048", "4096", "8192", "16384", "32768", "65536",
+    ]);
     let fft_size_row = adw::ComboRow::builder()
         .title("FFT Size")
         .model(&fft_size_model)

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -347,7 +347,7 @@ pub fn build_navigation_panel() -> NavigationPanel {
 }
 
 /// Approximate height of one `AdwActionRow` with subtitle in pixels.
-const BOOKMARK_ROW_HEIGHT: i32 = 64;
+const BOOKMARK_ROW_HEIGHT: i32 = 56;
 /// Maximum visible bookmark rows before scrolling.
 const MAX_VISIBLE_BOOKMARKS: i32 = 3;
 

--- a/crates/sdr-ui/src/spectrum/fft_plot.rs
+++ b/crates/sdr-ui/src/spectrum/fft_plot.rs
@@ -7,8 +7,9 @@ use glow::HasContext;
 
 use super::gl_renderer::{self, GlError, f32_slice_as_bytes};
 
-/// Maximum number of FFT bins the renderer can display.
-const MAX_FFT_BINS: usize = 8192;
+/// Maximum bins for display rendering (limits vertex count).
+/// FFT data wider than this is max-pooled down before drawing.
+const MAX_DISPLAY_BINS: usize = 4096;
 
 /// Number of horizontal dB grid lines.
 const DB_GRID_LINE_COUNT: usize = 8;
@@ -17,7 +18,7 @@ const DB_GRID_LINE_COUNT: usize = 8;
 const FREQ_GRID_LINE_COUNT: usize = 10;
 
 /// Maximum vertices for the filled spectrum area (2 per bin: top + bottom).
-const MAX_FILL_VERTICES: usize = MAX_FFT_BINS * 2;
+const MAX_FILL_VERTICES: usize = MAX_DISPLAY_BINS * 2;
 
 /// Maximum vertices for grid lines (2 per line, both axes).
 const MAX_GRID_VERTICES: usize = (DB_GRID_LINE_COUNT + FREQ_GRID_LINE_COUNT) * 2;
@@ -51,6 +52,39 @@ void main() {
 }
 ";
 
+/// Downsample FFT data by max-pooling bins to fit display width.
+///
+/// When the input has more bins than `MAX_DISPLAY_BINS`, groups of bins
+/// are reduced to a single bin by taking the maximum dB value in each group.
+/// This preserves signal peaks. Returns a slice of the downsampled buffer,
+/// or the original data if no downsampling is needed.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn downsample_fft<'a>(data: &'a [f32], buf: &'a mut Vec<f32>) -> &'a [f32] {
+    if data.len() <= MAX_DISPLAY_BINS {
+        return data;
+    }
+    let out_bins = MAX_DISPLAY_BINS;
+    buf.resize(out_bins, f32::NEG_INFINITY);
+    let ratio = data.len() as f32 / out_bins as f32;
+    for (i, out) in buf.iter_mut().enumerate().take(out_bins) {
+        let start = (i as f32 * ratio) as usize;
+        let end = (((i + 1) as f32) * ratio) as usize;
+        let end = end.min(data.len());
+        let mut max_val = f32::NEG_INFINITY;
+        for &v in &data[start..end] {
+            if v > max_val {
+                max_val = v;
+            }
+        }
+        *out = max_val;
+    }
+    buf
+}
+
 /// OpenGL renderer for the FFT power spectrum plot.
 ///
 /// Renders a filled area under the spectrum curve, a line trace on top,
@@ -60,6 +94,8 @@ pub struct FftPlotRenderer {
     vao: glow::VertexArray,
     vbo: glow::Buffer,
     color_location: glow::UniformLocation,
+    /// Pre-allocated buffer for downsampling large FFT data.
+    downsample_buf: Vec<f32>,
 }
 
 impl FftPlotRenderer {
@@ -120,6 +156,7 @@ impl FftPlotRenderer {
             vao,
             vbo,
             color_location,
+            downsample_buf: Vec::with_capacity(MAX_DISPLAY_BINS),
         })
     }
 
@@ -135,7 +172,7 @@ impl FftPlotRenderer {
     /// * `max_db` — Top of the display range in dB.
     #[allow(unsafe_code, clippy::too_many_arguments)]
     pub fn render(
-        &self,
+        &mut self,
         gl: &glow::Context,
         fft_data: &[f32],
         width: i32,
@@ -152,6 +189,12 @@ impl FftPlotRenderer {
         if db_range <= 0.0 {
             return;
         }
+
+        // Downsample large FFTs to limit vertex count.
+        // Take the buffer out of self to avoid holding a mutable borrow
+        // across the draw calls that also borrow self.
+        let mut ds_buf = std::mem::take(&mut self.downsample_buf);
+        let display_data = downsample_fft(fft_data, &mut ds_buf);
 
         unsafe {
             gl.viewport(0, 0, width, height);
@@ -176,11 +219,15 @@ impl FftPlotRenderer {
 
         // Draw filled area under the spectrum curve (when enabled).
         if fill_enabled {
-            self.draw_fill(gl, fft_data, db_range, min_db);
+            self.draw_fill(gl, display_data, db_range, min_db);
         }
 
         // Draw the spectrum line trace on top.
-        self.draw_trace(gl, fft_data, db_range, min_db);
+        self.draw_trace(gl, display_data, db_range, min_db);
+
+        // Return the downsample buffer to self for reuse next frame.
+        let _ = display_data;
+        self.downsample_buf = ds_buf;
 
         unsafe {
             gl.disable(glow::BLEND);
@@ -242,7 +289,7 @@ impl FftPlotRenderer {
         clippy::cast_possible_wrap
     )]
     fn draw_fill(&self, gl: &glow::Context, fft_data: &[f32], db_range: f32, min_db: f32) {
-        let bin_count = fft_data.len().min(MAX_FFT_BINS);
+        let bin_count = fft_data.len();
         let mut vertices = Vec::with_capacity(bin_count * 4);
 
         for (i, &db) in fft_data.iter().take(bin_count).enumerate() {
@@ -279,7 +326,7 @@ impl FftPlotRenderer {
         clippy::cast_possible_wrap
     )]
     fn draw_trace(&self, gl: &glow::Context, fft_data: &[f32], db_range: f32, min_db: f32) {
-        let bin_count = fft_data.len().min(MAX_FFT_BINS);
+        let bin_count = fft_data.len();
         let mut vertices = Vec::with_capacity(bin_count * 2);
 
         for (i, &db) in fft_data.iter().take(bin_count).enumerate() {

--- a/crates/sdr-ui/src/spectrum/fft_plot.rs
+++ b/crates/sdr-ui/src/spectrum/fft_plot.rs
@@ -96,6 +96,10 @@ pub struct FftPlotRenderer {
     color_location: glow::UniformLocation,
     /// Pre-allocated buffer for downsampling large FFT data.
     downsample_buf: Vec<f32>,
+    // Pre-allocated vertex staging buffers to avoid per-frame allocation.
+    grid_vertices: Vec<f32>,
+    fill_vertices: Vec<f32>,
+    trace_vertices: Vec<f32>,
 }
 
 impl FftPlotRenderer {
@@ -157,6 +161,9 @@ impl FftPlotRenderer {
             vbo,
             color_location,
             downsample_buf: Vec::with_capacity(MAX_DISPLAY_BINS),
+            grid_vertices: Vec::with_capacity(MAX_GRID_VERTICES * 2),
+            fill_vertices: Vec::with_capacity(MAX_DISPLAY_BINS * 4),
+            trace_vertices: Vec::with_capacity(MAX_DISPLAY_BINS * 2),
         })
     }
 
@@ -244,27 +251,23 @@ impl FftPlotRenderer {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
-    fn draw_grid(&self, gl: &glow::Context) {
-        let mut vertices = Vec::with_capacity(MAX_GRID_VERTICES * 2);
+    fn draw_grid(&mut self, gl: &glow::Context) {
+        self.grid_vertices.clear();
 
-        // Horizontal dB grid lines.
         for i in 0..=DB_GRID_LINE_COUNT {
             let frac = i as f32 / DB_GRID_LINE_COUNT as f32;
             let y = -1.0 + 2.0 * frac;
-            // Full-width horizontal line.
-            vertices.extend_from_slice(&[-1.0, y, 1.0, y]);
+            self.grid_vertices.extend_from_slice(&[-1.0, y, 1.0, y]);
         }
 
-        // Vertical frequency grid lines.
         for i in 0..=FREQ_GRID_LINE_COUNT {
             let frac = i as f32 / FREQ_GRID_LINE_COUNT as f32;
             let x = -1.0 + 2.0 * frac;
-            // Full-height vertical line.
-            vertices.extend_from_slice(&[x, -1.0, x, 1.0]);
+            self.grid_vertices.extend_from_slice(&[x, -1.0, x, 1.0]);
         }
 
-        let bytes = f32_slice_as_bytes(&vertices);
-        let vertex_count = vertices.len() / 2;
+        let bytes = f32_slice_as_bytes(&self.grid_vertices);
+        let vertex_count = self.grid_vertices.len() / 2;
 
         unsafe {
             gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
@@ -288,20 +291,18 @@ impl FftPlotRenderer {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
-    fn draw_fill(&self, gl: &glow::Context, fft_data: &[f32], db_range: f32, min_db: f32) {
+    fn draw_fill(&mut self, gl: &glow::Context, fft_data: &[f32], db_range: f32, min_db: f32) {
         let bin_count = fft_data.len();
-        let mut vertices = Vec::with_capacity(bin_count * 4);
+        self.fill_vertices.clear();
 
         for (i, &db) in fft_data.iter().take(bin_count).enumerate() {
             let x = -1.0 + 2.0 * (i as f32 / (bin_count - 1).max(1) as f32);
             let y = -1.0 + 2.0 * ((db - min_db) / db_range).clamp(0.0, 1.0);
-
-            // Bottom vertex (y = -1) then top vertex (y = spectrum value).
-            vertices.extend_from_slice(&[x, -1.0, x, y]);
+            self.fill_vertices.extend_from_slice(&[x, -1.0, x, y]);
         }
 
-        let bytes = f32_slice_as_bytes(&vertices);
-        let vertex_count = vertices.len() / 2;
+        let bytes = f32_slice_as_bytes(&self.fill_vertices);
+        let vertex_count = self.fill_vertices.len() / 2;
 
         unsafe {
             gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
@@ -325,18 +326,18 @@ impl FftPlotRenderer {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
-    fn draw_trace(&self, gl: &glow::Context, fft_data: &[f32], db_range: f32, min_db: f32) {
+    fn draw_trace(&mut self, gl: &glow::Context, fft_data: &[f32], db_range: f32, min_db: f32) {
         let bin_count = fft_data.len();
-        let mut vertices = Vec::with_capacity(bin_count * 2);
+        self.trace_vertices.clear();
 
         for (i, &db) in fft_data.iter().take(bin_count).enumerate() {
             let x = -1.0 + 2.0 * (i as f32 / (bin_count - 1).max(1) as f32);
             let y = -1.0 + 2.0 * ((db - min_db) / db_range).clamp(0.0, 1.0);
-            vertices.extend_from_slice(&[x, y]);
+            self.trace_vertices.extend_from_slice(&[x, y]);
         }
 
-        let bytes = f32_slice_as_bytes(&vertices);
-        let vertex_count = vertices.len() / 2;
+        let bytes = f32_slice_as_bytes(&self.trace_vertices);
+        let vertex_count = self.trace_vertices.len() / 2;
 
         unsafe {
             gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -178,7 +178,7 @@ impl SpectrumHandle {
         // from the UI, avoiding races with queued old-size frames.
         if let Some(s) = self.waterfall_state.borrow_mut().as_mut() {
             self.waterfall_area.make_current();
-            let target_width = data.len().min(waterfall::MAX_TEXTURE_WIDTH);
+            let target_width = waterfall::supported_texture_width_for(&s.gl, data.len());
             if target_width != s.renderer.texture_width() {
                 s.renderer.resize(&s.gl, data.len());
             }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -112,6 +112,8 @@ pub struct SpectrumHandle {
     fill_enabled: Rc<Cell<bool>>,
     averaging_mode: Rc<Cell<AveragingMode>>,
     avg_buffer: Rc<RefCell<Vec<f32>>>,
+    /// Pre-allocated buffer for fftshift of waterfall data (avoids per-frame alloc).
+    shift_buffer: Rc<RefCell<Vec<f32>>>,
     cursor_callback: CursorCallback,
 }
 
@@ -180,7 +182,9 @@ impl SpectrumHandle {
             if target_width != s.renderer.texture_width() {
                 s.renderer.resize(&s.gl, data.len());
             }
-            let mut shifted = data.to_vec();
+            let mut shifted = self.shift_buffer.borrow_mut();
+            shifted.resize(data.len(), 0.0);
+            shifted.copy_from_slice(data);
             fftshift_in_place(&mut shifted);
             s.renderer.push_line(&s.gl, &shifted);
         }
@@ -353,6 +357,7 @@ pub fn build_spectrum_view(
         fill_enabled,
         averaging_mode: Rc::new(Cell::new(AveragingMode::default())),
         avg_buffer: Rc::new(RefCell::new(Vec::new())),
+        shift_buffer: Rc::new(RefCell::new(Vec::new())),
         cursor_callback,
     };
 

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -45,7 +45,7 @@ use crate::messages::UiToDsp;
 type CursorCallback = Rc<RefCell<Option<Box<dyn Fn(f64, f32)>>>>;
 
 /// Number of FFT bins for the display (used for initial buffer sizing).
-const FFT_SIZE: usize = 1024;
+const FFT_SIZE: usize = 2048;
 
 /// Default FFT plot pane height fraction (30% of total).
 const FFT_PANE_FRACTION: f64 = 0.30;
@@ -218,6 +218,22 @@ impl SpectrumHandle {
         // Reset the averaging buffer so stale data doesn't persist.
         self.avg_buffer.borrow_mut().clear();
         tracing::debug!(?mode, "averaging mode changed");
+    }
+
+    /// Resize the waterfall texture for a new FFT size.
+    ///
+    /// Called when the user changes the FFT size in the display panel.
+    /// The texture width is capped at `waterfall::MAX_TEXTURE_WIDTH` to stay
+    /// within safe GPU limits; the waterfall renderer downsamples wider FFTs.
+    pub fn set_fft_size(&self, size: usize) {
+        if let Some(s) = self.waterfall_state.borrow_mut().as_mut() {
+            self.waterfall_area.make_current();
+            let texture_width = size.min(waterfall::MAX_TEXTURE_WIDTH);
+            s.renderer.resize(&s.gl, texture_width);
+        }
+        // Reset averaging buffer since bin count changed.
+        self.avg_buffer.borrow_mut().clear();
+        self.waterfall_area.queue_render();
     }
 
     /// Update the VFO display range to match the effective FFT bandwidth.
@@ -403,7 +419,7 @@ fn build_fft_area(
     let fill_render = Rc::clone(fill_enabled);
     let vfo_render = Rc::clone(vfo_state);
     area.connect_render(move |area, _ctx| {
-        if let Some(s) = state.borrow().as_ref() {
+        if let Some(s) = state.borrow_mut().as_mut() {
             let width = area.width();
             let height = area.height();
             let scale = area.scale_factor();

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -171,9 +171,15 @@ impl SpectrumHandle {
         self.fft_area.queue_render();
 
         // Push a new line to the waterfall (also needs fftshift).
+        // Auto-resize the waterfall texture when the FFT size changes —
+        // driven by the first matching-size frame rather than synchronously
+        // from the UI, avoiding races with queued old-size frames.
         if let Some(s) = self.waterfall_state.borrow_mut().as_mut() {
             self.waterfall_area.make_current();
-            // Apply fftshift to waterfall data too.
+            let target_width = data.len().min(waterfall::MAX_TEXTURE_WIDTH);
+            if target_width != s.renderer.texture_width() {
+                s.renderer.resize(&s.gl, data.len());
+            }
             let mut shifted = data.to_vec();
             fftshift_in_place(&mut shifted);
             s.renderer.push_line(&s.gl, &shifted);
@@ -218,22 +224,6 @@ impl SpectrumHandle {
         // Reset the averaging buffer so stale data doesn't persist.
         self.avg_buffer.borrow_mut().clear();
         tracing::debug!(?mode, "averaging mode changed");
-    }
-
-    /// Resize the waterfall texture for a new FFT size.
-    ///
-    /// Called when the user changes the FFT size in the display panel.
-    /// The texture width is capped at `waterfall::MAX_TEXTURE_WIDTH` to stay
-    /// within safe GPU limits; the waterfall renderer downsamples wider FFTs.
-    pub fn set_fft_size(&self, size: usize) {
-        if let Some(s) = self.waterfall_state.borrow_mut().as_mut() {
-            self.waterfall_area.make_current();
-            let texture_width = size.min(waterfall::MAX_TEXTURE_WIDTH);
-            s.renderer.resize(&s.gl, texture_width);
-        }
-        // Reset averaging buffer since bin count changed.
-        self.avg_buffer.borrow_mut().clear();
-        self.waterfall_area.queue_render();
     }
 
     /// Update the VFO display range to match the effective FFT bandwidth.

--- a/crates/sdr-ui/src/spectrum/vfo_overlay.rs
+++ b/crates/sdr-ui/src/spectrum/vfo_overlay.rs
@@ -13,10 +13,10 @@ use super::gl_renderer::{self, GlError, f32_slice_as_bytes};
 // ---------------------------------------------------------------------------
 
 /// Default VFO passband fill color (semi-transparent blue).
-const VFO_COLOR: [f32; 4] = [0.2, 0.6, 1.0, 0.3];
+const VFO_COLOR: [f32; 4] = [0.2, 0.6, 1.0, 0.15];
 
 /// VFO center frequency line color (brighter blue).
-const VFO_CENTER_COLOR: [f32; 4] = [0.3, 0.7, 1.0, 0.9];
+const VFO_CENTER_COLOR: [f32; 4] = [0.3, 0.7, 1.0, 0.5];
 
 /// VFO bandwidth handle edge color.
 const VFO_EDGE_COLOR: [f32; 4] = [0.5, 0.8, 1.0, 0.6];
@@ -406,9 +406,9 @@ impl VfoOverlayRenderer {
         #[allow(clippy::cast_precision_loss)]
         let cx = vfo.center_clip_x() as f32;
 
-        // 2px wide quad in clip space.
+        // 1px wide quad in clip space — thin enough to see the signal behind it.
         #[allow(clippy::cast_precision_loss)]
-        let half_w = if width > 0 { 2.0 / width as f32 } else { 0.002 };
+        let half_w = if width > 0 { 1.0 / width as f32 } else { 0.001 };
         let vertices: [f32; 8] = [
             cx - half_w,
             -1.0,

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -555,13 +555,14 @@ mod tests {
 
     #[test]
     fn downsample_non_divisible() {
+        // 7 bins → 3: ratio 2.333, buckets [0..3), [2..5), [5..7)
         let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
         let mut buf = Vec::new();
         downsample_to(&data, &mut buf, 3);
         assert_eq!(buf.len(), 3);
-        assert!(buf[0] >= 2.0);
-        assert!(buf[1] >= 4.0);
-        assert!(buf[2] >= 7.0);
+        assert!((buf[0] - 3.0).abs() < f32::EPSILON); // max(1, 2, 3)
+        assert!((buf[1] - 5.0).abs() < f32::EPSILON); // max(3, 4, 5)
+        assert!((buf[2] - 7.0).abs() < f32::EPSILON); // max(6, 7)
     }
 
     #[test]

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn downsample_non_divisible() {
-        // 7 bins → 3: ratio 2.333, buckets [0..3), [2..5), [5..7)
+        // 7 bins → 3: ratio 2.333, buckets [0..3), [2..5), [4..7)
         let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
         let mut buf = Vec::new();
         downsample_to(&data, &mut buf, 3);

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -108,6 +108,12 @@ fn supported_texture_width(gl: &glow::Context, requested: usize) -> usize {
     requested.min(MAX_TEXTURE_WIDTH).min(gpu_limit.max(1))
 }
 
+/// Public version of `supported_texture_width` for use by `mod.rs`.
+#[allow(unsafe_code, clippy::cast_sign_loss)]
+pub fn supported_texture_width_for(gl: &glow::Context, requested: usize) -> usize {
+    supported_texture_width(gl, requested)
+}
+
 /// OpenGL renderer for the scrolling waterfall spectrogram.
 pub struct WaterfallRenderer {
     program: glow::Program,

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -377,19 +377,23 @@ impl WaterfallRenderer {
     )]
     pub fn resize(&mut self, gl: &glow::Context, new_width: usize) {
         let capped_width = new_width.min(MAX_TEXTURE_WIDTH);
-        if capped_width == self.texture_width {
-            return;
-        }
-        unsafe {
-            gl.delete_texture(self.data_texture);
-        }
+        // Always reset history (even at same width) to clear mixed-resolution data.
+        // Create replacement texture BEFORE deleting the old one so a failed
+        // allocation doesn't leave a dangling handle.
         match create_data_texture(gl, capped_width) {
             Ok(tex) => {
-                self.data_texture = tex;
-                self.texture_width = capped_width;
-                self.row_buffer = vec![0u8; capped_width];
+                let old_tex = std::mem::replace(&mut self.data_texture, tex);
+                unsafe {
+                    gl.delete_texture(old_tex);
+                }
+                if capped_width == self.texture_width {
+                    self.row_buffer.fill(0);
+                } else {
+                    self.texture_width = capped_width;
+                    self.row_buffer = vec![0u8; capped_width];
+                }
                 self.write_row = 0;
-                tracing::debug!(width = capped_width, "waterfall texture resized");
+                tracing::debug!(width = capped_width, "waterfall texture reset");
             }
             Err(e) => {
                 tracing::warn!("failed to resize waterfall texture: {e}");

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -562,7 +562,7 @@ mod tests {
         assert_eq!(buf.len(), 3);
         assert!((buf[0] - 3.0).abs() < f32::EPSILON); // max(1, 2, 3)
         assert!((buf[1] - 5.0).abs() < f32::EPSILON); // max(3, 4, 5)
-        assert!((buf[2] - 7.0).abs() < f32::EPSILON); // max(6, 7)
+        assert!((buf[2] - 7.0).abs() < f32::EPSILON); // max(5, 6, 7)
     }
 
     #[test]

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -101,6 +101,13 @@ fn downsample_to(data: &[f32], buf: &mut Vec<f32>, target_width: usize) {
     }
 }
 
+/// Clamp texture width to both the app limit and the GPU's `GL_MAX_TEXTURE_SIZE`.
+#[allow(unsafe_code, clippy::cast_sign_loss)]
+fn supported_texture_width(gl: &glow::Context, requested: usize) -> usize {
+    let gpu_limit = unsafe { gl.get_parameter_i32(glow::MAX_TEXTURE_SIZE) as usize };
+    requested.min(MAX_TEXTURE_WIDTH).min(gpu_limit.max(1))
+}
+
 /// OpenGL renderer for the scrolling waterfall spectrogram.
 pub struct WaterfallRenderer {
     program: glow::Program,
@@ -143,7 +150,7 @@ impl WaterfallRenderer {
         clippy::cast_possible_wrap
     )]
     pub fn new(gl: &glow::Context, requested_width: usize) -> Result<Self, GlError> {
-        let width = requested_width.min(MAX_TEXTURE_WIDTH);
+        let width = supported_texture_width(gl, requested_width);
         let vert = gl_renderer::compile_shader(gl, glow::VERTEX_SHADER, VERT_SHADER)?;
         let frag = gl_renderer::compile_shader(gl, glow::FRAGMENT_SHADER, FRAG_SHADER)?;
         let program = gl_renderer::link_program(gl, vert, frag)?;
@@ -366,17 +373,23 @@ impl WaterfallRenderer {
         }
     }
 
+    /// Current texture width in bins.
+    pub fn texture_width(&self) -> usize {
+        self.texture_width
+    }
+
     /// Resize the waterfall texture for a new FFT size.
     ///
-    /// Deletes the old data texture and creates a new one at the given width
-    /// (capped at `MAX_TEXTURE_WIDTH`). Resets the ring buffer write position.
+    /// Creates replacement texture before deleting the old one so a failed
+    /// allocation doesn't leave a dangling handle. Resets history on every
+    /// call to clear mixed-resolution data.
     #[allow(
         unsafe_code,
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
     pub fn resize(&mut self, gl: &glow::Context, new_width: usize) {
-        let capped_width = new_width.min(MAX_TEXTURE_WIDTH);
+        let capped_width = supported_texture_width(gl, new_width);
         // Always reset history (even at same width) to clear mixed-resolution data.
         // Create replacement texture BEFORE deleting the old one so a failed
         // allocation doesn't leave a dangling handle.

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -11,6 +11,9 @@ use super::gl_renderer::{self, GlError, f32_slice_as_bytes};
 /// Number of history lines stored in the ring-buffer texture.
 const HISTORY_LINES: usize = 1024;
 
+/// Maximum waterfall texture width. FFT data wider than this is downsampled.
+pub const MAX_TEXTURE_WIDTH: usize = 4096;
+
 /// Default minimum display level in dB.
 const DEFAULT_MIN_DB: f32 = -70.0;
 /// Default maximum display level in dB.
@@ -72,6 +75,32 @@ const QUAD_VERTICES: [f32; 24] = [
     -1.0, 1.0, 0.0, 0.0, // top-left
 ];
 
+/// Downsample FFT data by max-pooling bins to a target width.
+///
+/// Groups of input bins are reduced to one output bin by taking the maximum
+/// dB value in each group, preserving signal peaks for display.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn downsample_to(data: &[f32], buf: &mut Vec<f32>, target_width: usize) {
+    buf.resize(target_width, f32::NEG_INFINITY);
+    let ratio = data.len() as f32 / target_width as f32;
+    for (i, out) in buf.iter_mut().enumerate().take(target_width) {
+        let start = (i as f32 * ratio) as usize;
+        let end = (((i + 1) as f32) * ratio).ceil() as usize;
+        let end = end.min(data.len());
+        let mut max_val = f32::NEG_INFINITY;
+        for &v in &data[start..end] {
+            if v > max_val {
+                max_val = v;
+            }
+        }
+        *out = max_val;
+    }
+}
+
 /// OpenGL renderer for the scrolling waterfall spectrogram.
 pub struct WaterfallRenderer {
     program: glow::Program,
@@ -90,6 +119,8 @@ pub struct WaterfallRenderer {
     history_lines_loc: glow::UniformLocation,
     data_tex_loc: glow::UniformLocation,
     colormap_tex_loc: glow::UniformLocation,
+    /// Pre-allocated buffer for downsampling large FFT data.
+    downsample_buf: Vec<f32>,
     /// Display range in dB.
     min_db: f32,
     max_db: f32,
@@ -111,7 +142,8 @@ impl WaterfallRenderer {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
-    pub fn new(gl: &glow::Context, width: usize) -> Result<Self, GlError> {
+    pub fn new(gl: &glow::Context, requested_width: usize) -> Result<Self, GlError> {
+        let width = requested_width.min(MAX_TEXTURE_WIDTH);
         let vert = gl_renderer::compile_shader(gl, glow::VERTEX_SHADER, VERT_SHADER)?;
         let frag = gl_renderer::compile_shader(gl, glow::FRAGMENT_SHADER, FRAG_SHADER)?;
         let program = gl_renderer::link_program(gl, vert, frag)?;
@@ -197,6 +229,7 @@ impl WaterfallRenderer {
             history_lines_loc,
             data_tex_loc,
             colormap_tex_loc,
+            downsample_buf: Vec::with_capacity(MAX_TEXTURE_WIDTH),
             min_db: DEFAULT_MIN_DB,
             max_db: DEFAULT_MAX_DB,
         })
@@ -213,15 +246,24 @@ impl WaterfallRenderer {
         clippy::cast_sign_loss
     )]
     pub fn push_line(&mut self, gl: &glow::Context, fft_data: &[f32]) {
-        let bin_count = fft_data.len().min(self.texture_width);
         let db_range = self.max_db - self.min_db;
         if !db_range.is_finite() || db_range <= 0.0 {
             return;
         }
 
+        // Downsample if FFT bins exceed texture width.
+        let display_data = if fft_data.len() > self.texture_width {
+            downsample_to(fft_data, &mut self.downsample_buf, self.texture_width);
+            &self.downsample_buf
+        } else {
+            fft_data
+        };
+
+        let bin_count = display_data.len().min(self.texture_width);
+
         // Normalize dB values to 0..255 using pre-allocated row buffer.
         self.row_buffer.fill(0);
-        for (i, &db) in fft_data.iter().take(bin_count).enumerate() {
+        for (i, &db) in display_data.iter().take(bin_count).enumerate() {
             let normalized = ((db - self.min_db) / db_range).clamp(0.0, 1.0);
             self.row_buffer[i] = (normalized * 255.0).round() as u8;
         }
@@ -321,6 +363,37 @@ impl WaterfallRenderer {
         if min_db.is_finite() && max_db.is_finite() && max_db > min_db {
             self.min_db = min_db;
             self.max_db = max_db;
+        }
+    }
+
+    /// Resize the waterfall texture for a new FFT size.
+    ///
+    /// Deletes the old data texture and creates a new one at the given width
+    /// (capped at `MAX_TEXTURE_WIDTH`). Resets the ring buffer write position.
+    #[allow(
+        unsafe_code,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    pub fn resize(&mut self, gl: &glow::Context, new_width: usize) {
+        let capped_width = new_width.min(MAX_TEXTURE_WIDTH);
+        if capped_width == self.texture_width {
+            return;
+        }
+        unsafe {
+            gl.delete_texture(self.data_texture);
+        }
+        match create_data_texture(gl, capped_width) {
+            Ok(tex) => {
+                self.data_texture = tex;
+                self.texture_width = capped_width;
+                self.row_buffer = vec![0u8; capped_width];
+                self.write_row = 0;
+                tracing::debug!(width = capped_width, "waterfall texture resized");
+            }
+            Err(e) => {
+                tracing::warn!("failed to resize waterfall texture: {e}");
+            }
         }
     }
 

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -536,3 +536,51 @@ fn create_colormap_texture(gl: &glow::Context) -> Result<glow::Texture, GlError>
         Ok(texture)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn downsample_preserves_peak() {
+        let data = [0.0, 5.0, 1.0, 3.0, 2.0, 8.0, 4.0, 1.0];
+        let mut buf = Vec::new();
+        downsample_to(&data, &mut buf, 4);
+        assert_eq!(buf.len(), 4);
+        assert!((buf[0] - 5.0).abs() < f32::EPSILON);
+        assert!((buf[1] - 3.0).abs() < f32::EPSILON);
+        assert!((buf[2] - 8.0).abs() < f32::EPSILON);
+        assert!((buf[3] - 4.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn downsample_non_divisible() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+        let mut buf = Vec::new();
+        downsample_to(&data, &mut buf, 3);
+        assert_eq!(buf.len(), 3);
+        assert!(buf[0] >= 2.0);
+        assert!(buf[1] >= 4.0);
+        assert!(buf[2] >= 7.0);
+    }
+
+    #[test]
+    fn downsample_single_output() {
+        let data = [1.0, 9.0, 3.0, 2.0];
+        let mut buf = Vec::new();
+        downsample_to(&data, &mut buf, 1);
+        assert_eq!(buf.len(), 1);
+        assert!((buf[0] - 9.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn downsample_same_size_passthrough() {
+        let data = [1.0, 2.0, 3.0];
+        let mut buf = Vec::new();
+        downsample_to(&data, &mut buf, 3);
+        assert_eq!(buf.len(), 3);
+        assert!((buf[0] - 1.0).abs() < f32::EPSILON);
+        assert!((buf[1] - 2.0).abs() < f32::EPSILON);
+        assert!((buf[2] - 3.0).abs() < f32::EPSILON);
+    }
+}

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -31,8 +31,8 @@ const DEFAULT_HEIGHT: i32 = 800;
 /// Sidebar collapse breakpoint width in pixels.
 const SIDEBAR_BREAKPOINT_PX: f64 = 800.0;
 
-/// FFT sizes available in the display panel dropdown (must match panel order).
-const FFT_SIZES: &[usize] = &[512, 1024, 2048, 4096, 8192, 16384, 32768, 65536];
+/// FFT sizes — re-exported from display panel (single source of truth).
+use crate::sidebar::display_panel::FFT_SIZES;
 
 /// Decimation factors available in the source panel dropdown (must match panel order).
 const DECIMATION_FACTORS: &[u32] = &[1, 2, 4, 8, 16];

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -150,15 +150,21 @@ pub fn build_window(app: &adw::Application) {
     });
 
     // --- Spawn DSP thread ---
-    dsp_controller::spawn_dsp_thread(dsp_tx, ui_rx);
+    let fft_shared = std::sync::Arc::new(dsp_controller::SharedFftBuffer::new(2048));
+    dsp_controller::spawn_dsp_thread(dsp_tx, ui_rx, std::sync::Arc::clone(&fft_shared));
 
-    // --- Poll DspToUi channel from the GTK main loop ---
+    // --- Poll DspToUi channel and shared FFT buffer from the GTK main loop ---
     let play_button_weak = play_button.downgrade();
     let state_rx = Rc::clone(&state);
     let toast_overlay_weak = toast_overlay.downgrade();
 
     let gain_row_for_dsp = panels.source.gain_row.clone();
     glib::timeout_add_local(Duration::from_millis(DSP_POLL_INTERVAL_MS), move || {
+        // Check for new FFT data from the shared buffer (zero-alloc path).
+        fft_shared.take_if_ready(|data| {
+            spectrum_handle.push_fft_data(data);
+        });
+
         // Drain all pending DSP messages.
         loop {
             match dsp_rx.try_recv() {
@@ -197,8 +203,10 @@ fn handle_dsp_message(
     gain_row: &adw::SpinRow,
 ) {
     match msg {
-        DspToUi::FftData(data) => {
-            spectrum_handle.push_fft_data(&data);
+        DspToUi::FftData(_) => {
+            // FFT data now comes via SharedFftBuffer, not the channel.
+            // This variant is kept for backward compatibility but shouldn't
+            // be sent in normal operation.
         }
         DspToUi::SignalLevel(level) => {
             status_bar.update_signal_level(level);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -706,7 +706,6 @@ fn connect_display_panel(
 ) {
     // FFT size
     let state_fft = Rc::clone(state);
-    let spectrum_fft = Rc::clone(spectrum_handle);
     panels
         .display
         .fft_size_row
@@ -714,7 +713,8 @@ fn connect_display_panel(
             let idx = row.selected() as usize;
             if let Some(&size) = FFT_SIZES.get(idx) {
                 state_fft.send_dsp(UiToDsp::SetFftSize(size));
-                spectrum_fft.set_fft_size(size);
+                // Waterfall resize happens in push_fft_data when the first
+                // new-size frame arrives — avoids race with queued old-size frames.
             }
         });
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -32,7 +32,7 @@ const DEFAULT_HEIGHT: i32 = 800;
 const SIDEBAR_BREAKPOINT_PX: f64 = 800.0;
 
 /// FFT sizes available in the display panel dropdown (must match panel order).
-const FFT_SIZES: &[usize] = &[512, 1024, 2048];
+const FFT_SIZES: &[usize] = &[512, 1024, 2048, 4096, 8192, 16384, 32768, 65536];
 
 /// Decimation factors available in the source panel dropdown (must match panel order).
 const DECIMATION_FACTORS: &[u32] = &[1, 2, 4, 8, 16];
@@ -706,6 +706,7 @@ fn connect_display_panel(
 ) {
     // FFT size
     let state_fft = Rc::clone(state);
+    let spectrum_fft = Rc::clone(spectrum_handle);
     panels
         .display
         .fft_size_row
@@ -713,6 +714,7 @@ fn connect_display_panel(
             let idx = row.selected() as usize;
             if let Some(&size) = FFT_SIZES.get(idx) {
                 state_fft.send_dsp(UiToDsp::SetFftSize(size));
+                spectrum_fft.set_fft_size(size);
             }
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,19 @@ fn main() -> glib::ExitCode {
     // at allocator init (before main), so set_var is too late.
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     #[allow(unsafe_code)]
-    unsafe {
+    let arena_ok = unsafe {
         unsafe extern "C" {
             fn mallopt(param: i32, value: i32) -> i32;
         }
         const M_ARENA_MAX: i32 = -8;
-        mallopt(M_ARENA_MAX, 4);
-    }
+        mallopt(M_ARENA_MAX, 4) != 0
+    };
 
     tracing_subscriber::fmt::init();
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    if !arena_ok {
+        tracing::warn!("mallopt(M_ARENA_MAX, 4) failed — arena cap not applied");
+    }
     tracing::info!("sdr-rs starting");
     sdr_ui::run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,19 @@
 use gtk4::glib;
 
 fn main() -> glib::ExitCode {
-    // Limit glibc malloc arenas BEFORE any threads spawn.
+    // Limit glibc malloc arenas before any threads spawn.
     // Without this, glibc creates up to 8*cores arenas that each keep
     // their high-water mark, causing RSS to grow indefinitely with 40+ threads.
-    // Limit glibc malloc arenas BEFORE any threads spawn.
-    // Without this, glibc creates up to 8*cores arenas that each keep
-    // their high-water mark, causing RSS to grow indefinitely with 40+ threads.
-    #[cfg(target_os = "linux")]
+    // Uses mallopt() instead of env var — glibc reads MALLOC_ARENA_MAX
+    // at allocator init (before main), so set_var is too late.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     #[allow(unsafe_code)]
-    // SAFETY: single-threaded at this point — no threads spawned yet.
     unsafe {
-        std::env::set_var("MALLOC_ARENA_MAX", "4");
+        unsafe extern "C" {
+            fn mallopt(param: i32, value: i32) -> i32;
+        }
+        const M_ARENA_MAX: i32 = -8;
+        mallopt(M_ARENA_MAX, 4);
     }
 
     tracing_subscriber::fmt::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,19 @@
 use gtk4::glib;
 
 fn main() -> glib::ExitCode {
+    // Limit glibc malloc arenas BEFORE any threads spawn.
+    // Without this, glibc creates up to 8*cores arenas that each keep
+    // their high-water mark, causing RSS to grow indefinitely with 40+ threads.
+    // Limit glibc malloc arenas BEFORE any threads spawn.
+    // Without this, glibc creates up to 8*cores arenas that each keep
+    // their high-water mark, causing RSS to grow indefinitely with 40+ threads.
+    #[cfg(target_os = "linux")]
+    #[allow(unsafe_code)]
+    // SAFETY: single-threaded at this point — no threads spawned yet.
+    unsafe {
+        std::env::set_var("MALLOC_ARENA_MAX", "4");
+    }
+
     tracing_subscriber::fmt::init();
     tracing::info!("sdr-rs starting");
     sdr_ui::run()


### PR DESCRIPTION
## Summary
- **Large FFT (#173):** FFT sizes 512 through 65536 now available. Max-pool downsampling preserves signal peaks when bins exceed display capacity (4096 cap for both FFT plot and waterfall texture).
- **Dynamic waterfall resize:** Texture recreated when FFT size changes at runtime
- **VFO overlay transparency:** Passband fill reduced to 15% opacity, centerline thinned to 1px at 50% alpha — signals visible through the overlay
- **Zoom rendering:** Filed #175 for proper frequency-range-aware zoom (current zoom changes VFO coordinates but doesn't crop spectrum data)

Closes #173

## Test plan
- [ ] Select each FFT size (512 through 65536) — verify display renders correctly
- [ ] At 65536, verify channel lines are sharp and detailed
- [ ] Verify VFO overlay is see-through (signal visible behind passband fill)
- [ ] Verify no performance degradation at large FFT sizes
- [ ] Switch between FFT sizes while running — verify waterfall clears and resizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded FFT size options in the UI (up to 65536).

* **UI Improvements**
  * Reduced VFO passband opacity and thinner center-frequency line.
  * Slightly smaller bookmark row height.

* **Display Enhancements**
  * Improved plotting performance via single-frame downsampling and buffer reuse.
  * Waterfall now enforces a max texture width, supports runtime resizing, and default FFT resolution increased.

* **Audio**
  * Audio backend switched to a shared ring buffer for fewer allocations and steadier streaming.

* **Tests**
  * Added unit tests for waterfall downsampling.

* **Chores**
  * Linux memory tuning: periodic heap trimming and reduced allocator arenas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->