### PR TITLE
Add SECURITY.md, audit/deny workflows, pin CI actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,36 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Dependency Audit
+    runs-on: rke-main
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config \
+            libgtk-4-dev libadwaita-1-dev libusb-1.0-0-dev \
+            libpipewire-0.3-dev libclang-dev
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: rke-main
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,27 @@
+name: Cargo Deny
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deny:
+    name: License & Supply Chain Check
+    runs-on: rke-main
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release on the `main` branch is supported with security updates. We do not backport fixes to older versions.
+
+| Branch | Supported |
+|--------|-----------|
+| `main` | Yes |
+| Other  | No  |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Use GitHub's private vulnerability reporting to submit a report:
+
+1. Go to the [Security tab](https://github.com/jasonherald/rtl-sdr/security)
+2. Click **"Report a vulnerability"**
+3. Provide a description, steps to reproduce, and any relevant details
+
+### What to expect
+
+- **Acknowledgment** within 48 hours
+- **Assessment** of severity and impact within 1 week
+- **Fix or mitigation** as soon as practical, depending on severity
+- **Disclosure** 90 days after the fix is released, or immediately if the vulnerability is already public
+- Credit in the fix commit (unless you prefer to remain anonymous)
+
+## Security Scanning
+
+This project uses automated security scanning across multiple layers:
+
+| Tool | Integration | Coverage |
+|------|-------------|----------|
+| [cargo-audit](https://rustsec.org/) | GitHub Actions (PR + weekly) | Known CVEs in Rust dependencies (RustSec advisory database) |
+| [cargo-deny](https://embarkstudios.github.io/cargo-deny/) | GitHub Actions (PR + weekly) | License compliance, duplicate crates, source restrictions |
+| [CodeRabbit](https://coderabbit.ai/) | GitHub App (PR review) | AI-assisted code review with OSV dependency scanning |
+
+## Scope
+
+This project is a software-defined radio application (Rust port of SDR++). It:
+
+- Communicates with RTL-SDR USB hardware via libusb
+- Receives and demodulates radio signals (FM, AM, SSB, CW)
+- Renders spectrum/waterfall displays via OpenGL
+- Outputs audio via PipeWire
+- Reads/writes configuration files and frequency bookmarks (JSON)
+- Accepts network IQ streams (TCP/UDP)
+
+Vulnerabilities in USB communication, network protocol handling, file parsing, or configuration handling are in scope.
+
+### Out of scope
+
+- Bugs in SDR++ C++ source (report upstream)
+- Bugs in RTL-SDR hardware firmware
+- Denial of service via trivially malformed input (e.g., empty files)
+- Vulnerabilities in PipeWire, Mesa, GTK, or system libraries — report upstream
+- Social engineering or phishing
+- Issues requiring physical access to the machine

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,10 @@ Use GitHub's private vulnerability reporting to submit a report:
 2. Click **"Report a vulnerability"**
 3. Provide a description, steps to reproduce, and any relevant details
 
+### Alternative reporting
+
+If you cannot use GitHub's private reporting, email **security@aaru.network** with a description, steps to reproduce, and any relevant details.
+
 ### What to expect
 
 - **Acknowledgment** within 48 hours

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ This project uses automated security scanning across multiple layers:
 | Tool | Integration | Coverage |
 |------|-------------|----------|
 | [cargo-audit](https://rustsec.org/) | GitHub Actions (PR + weekly) | Known CVEs in Rust dependencies (RustSec advisory database) |
-| [cargo-deny](https://embarkstudios.github.io/cargo-deny/) | GitHub Actions (PR + weekly) | License compliance, duplicate crates, source restrictions |
+| [cargo-deny](https://embarkstudios.github.io/cargo-deny/) | GitHub Actions (PR + weekly) | License compliance, duplicate crates (warn-only), source restrictions |
 | [CodeRabbit](https://coderabbit.ai/) | GitHub App (PR review) | AI-assisted code review with OSV dependency scanning |
 
 ## Scope


### PR DESCRIPTION
## Summary
- **SECURITY.md**: Vulnerability reporting policy via GitHub private reporting, security scanning tools table, scope definition for SDR-RS (USB, network IQ, file parsing, audio, config)
- **audit.yml**: Separate weekly + PR workflow for `cargo-audit` (RustSec advisory database)
- **deny.yml**: Separate weekly + PR workflow for `cargo-deny` (license compliance, supply chain)
- **ci.yml**: Pin all GitHub Actions to commit SHAs for supply chain integrity

All action references use pinned commit SHAs matching the patterns from mac-doc-hyprland and bambu-forge.

## Test plan
- [ ] Verify audit workflow runs on PR
- [ ] Verify deny workflow runs on PR
- [ ] Verify CI workflow still passes with pinned actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated security audit and cargo-deny supply‑chain/license workflows with regular scheduled and on-push checks.
  * Pinned CI action references for more reproducible runs.
* **Documentation**
  * Published a SECURITY.md outlining vulnerability reporting, response timelines, scanning coverage, and scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->