### PR TITLE
Display polish: frequency labels, spectrum zoom, trace optimization

### DIFF
--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -19,6 +19,10 @@ const RING_CAPACITY: usize = 96_000;
 /// Initial capacity for the stereo interleave buffer in `write_samples`.
 const INTERLEAVE_BUF_INITIAL_CAP: usize = 1024;
 
+/// Initial sample capacity for the PipeWire callback read buffer.
+/// 4x typical quantum (1024 frames x 2 channels) to avoid RT reallocation.
+const READ_BUF_INITIAL_SAMPLES: usize = 8_192;
+
 /// Bytes per sample frame (2 channels x 4 bytes per f32).
 const FRAME_SIZE: usize = (AUDIO_CHANNELS as usize) * std::mem::size_of::<f32>();
 
@@ -482,7 +486,7 @@ impl AudioCallbackData {
             // 48 kHz stereo = 96,000 samples/sec. Typical PipeWire quantum is
             // 1024 frames = 2048 samples. Allocate for 4x that to handle any
             // reasonable quantum size without RT reallocation.
-            read_buf: vec![0.0; 8192],
+            read_buf: vec![0.0; READ_BUF_INITIAL_SAMPLES],
         }
     }
 }

--- a/crates/sdr-ui/src/spectrum/fft_plot.rs
+++ b/crates/sdr-ui/src/spectrum/fft_plot.rs
@@ -1,10 +1,13 @@
 //! FFT spectrum plot renderer using Cairo.
 //!
 //! Draws the power spectrum as a filled area with a line trace on top,
-//! plus horizontal dB grid lines and vertical frequency grid lines.
+//! plus horizontal dB grid lines with labels and vertical frequency grid
+//! lines with frequency labels. Supports zoom via display range parameters.
 //! Renders directly via Cairo draw calls — no OpenGL, no pixel buffers.
 
 use gtk4::cairo;
+
+use super::frequency_axis;
 
 /// Maximum bins for display rendering.
 /// FFT data wider than this is max-pooled down before drawing.
@@ -15,6 +18,15 @@ const DB_GRID_LINE_COUNT: usize = 8;
 
 /// Number of vertical frequency grid lines.
 const FREQ_GRID_LINE_COUNT: usize = 10;
+
+/// Font size for axis labels in Cairo units.
+const LABEL_FONT_SIZE: f64 = 10.0;
+
+/// Label color — light gray, semi-transparent.
+const LABEL_COLOR: [f64; 4] = [0.6, 0.6, 0.6, 0.8];
+
+/// Top margin in pixels reserved for frequency labels.
+const FREQ_LABEL_TOP_MARGIN: f64 = 14.0;
 
 // Colors (RGBA, 0.0..1.0)
 /// Spectrum trace line color — accent blue.
@@ -87,12 +99,16 @@ impl FftPlotRenderer {
     /// # Arguments
     ///
     /// * `cr` — The Cairo drawing context.
-    /// * `fft_data` — Power spectrum values in dB (one per frequency bin).
+    /// * `fft_data` — Power spectrum values in dB (one per frequency bin, full bandwidth).
     /// * `width` — Viewport width in pixels.
     /// * `height` — Viewport height in pixels.
     /// * `min_db` — Bottom of the display range in dB.
     /// * `max_db` — Top of the display range in dB.
     /// * `fill_enabled` — Whether to draw the filled area under the trace.
+    /// * `display_start_hz` — Left edge of the visible frequency range (relative to center).
+    /// * `display_end_hz` — Right edge of the visible frequency range (relative to center).
+    /// * `full_bandwidth` — Total FFT bandwidth in Hz (unzoomed span).
+    /// * `center_freq_hz` — Tuner center frequency in Hz (for absolute frequency labels).
     #[allow(clippy::cast_precision_loss, clippy::too_many_arguments)]
     pub fn render(
         &mut self,
@@ -103,6 +119,10 @@ impl FftPlotRenderer {
         min_db: f32,
         max_db: f32,
         fill_enabled: bool,
+        display_start_hz: f64,
+        display_end_hz: f64,
+        full_bandwidth: f64,
+        center_freq_hz: f64,
     ) {
         if fft_data.is_empty() || width <= 0 || height <= 0 {
             return;
@@ -129,113 +149,42 @@ impl FftPlotRenderer {
         );
         let _ = cr.paint();
 
-        // Grid lines.
-        Self::draw_grid(cr, w, h);
+        // Frequency-aware grid lines with labels.
+        Self::draw_grid(
+            cr,
+            w,
+            h,
+            min_db,
+            max_db,
+            display_start_hz,
+            display_end_hz,
+            center_freq_hz,
+        );
 
-        // Filled area under the spectrum curve.
+        // Build the trace path once, reuse for fill and stroke.
+        // Uses frequency-to-pixel mapping for zoom support.
+        Self::build_trace_path(
+            cr,
+            display_data,
+            w,
+            h,
+            db_range,
+            min_db,
+            display_start_hz,
+            display_end_hz,
+            full_bandwidth,
+        );
+
         if fill_enabled {
-            Self::draw_fill(cr, display_data, w, h, db_range, min_db);
+            // Close along bottom edge and fill.
+            cr.line_to(w, h);
+            cr.line_to(0.0, h);
+            cr.close_path();
+            cr.set_source_rgba(FILL_COLOR[0], FILL_COLOR[1], FILL_COLOR[2], FILL_COLOR[3]);
+            let _ = cr.fill_preserve();
         }
 
-        // Spectrum line trace on top.
-        Self::draw_trace(cr, display_data, w, h, db_range, min_db);
-
-        // Return the downsample buffer to self for reuse next frame.
-        let _ = display_data;
-        self.downsample_buf = ds_buf;
-    }
-
-    /// Draw horizontal dB grid lines and vertical frequency grid lines.
-    #[allow(clippy::cast_precision_loss)]
-    fn draw_grid(cr: &cairo::Context, w: f64, h: f64) {
-        cr.set_source_rgba(GRID_COLOR[0], GRID_COLOR[1], GRID_COLOR[2], GRID_COLOR[3]);
-        cr.set_line_width(1.0);
-
-        // Horizontal dB grid lines.
-        for i in 0..=DB_GRID_LINE_COUNT {
-            let frac = i as f64 / DB_GRID_LINE_COUNT as f64;
-            let y = (h * frac).floor() + 0.5; // snap to pixel center for crisp 1px lines
-            cr.move_to(0.0, y);
-            cr.line_to(w, y);
-        }
-
-        // Vertical frequency grid lines.
-        for i in 0..=FREQ_GRID_LINE_COUNT {
-            let frac = i as f64 / FREQ_GRID_LINE_COUNT as f64;
-            let x = (w * frac).floor() + 0.5;
-            cr.move_to(x, 0.0);
-            cr.line_to(x, h);
-        }
-
-        let _ = cr.stroke();
-    }
-
-    /// Draw the filled area under the spectrum curve.
-    #[allow(clippy::cast_precision_loss)]
-    fn draw_fill(
-        cr: &cairo::Context,
-        fft_data: &[f32],
-        w: f64,
-        h: f64,
-        db_range: f32,
-        min_db: f32,
-    ) {
-        let bin_count = fft_data.len();
-        if bin_count == 0 {
-            return;
-        }
-
-        let db_range_f64 = f64::from(db_range);
-        let min_db_f64 = f64::from(min_db);
-
-        // Build a path: trace line, then close along the bottom edge.
-        let first_db = f64::from(fft_data[0]);
-        let first_y = h * (1.0 - ((first_db - min_db_f64) / db_range_f64).clamp(0.0, 1.0));
-        cr.move_to(0.0, first_y);
-
-        for (i, &db) in fft_data.iter().enumerate().skip(1) {
-            let x = w * i as f64 / (bin_count - 1).max(1) as f64;
-            let y = h * (1.0 - ((f64::from(db) - min_db_f64) / db_range_f64).clamp(0.0, 1.0));
-            cr.line_to(x, y);
-        }
-
-        // Close along the bottom edge.
-        cr.line_to(w, h);
-        cr.line_to(0.0, h);
-        cr.close_path();
-
-        cr.set_source_rgba(FILL_COLOR[0], FILL_COLOR[1], FILL_COLOR[2], FILL_COLOR[3]);
-        let _ = cr.fill();
-    }
-
-    /// Draw the spectrum line trace.
-    #[allow(clippy::cast_precision_loss)]
-    fn draw_trace(
-        cr: &cairo::Context,
-        fft_data: &[f32],
-        w: f64,
-        h: f64,
-        db_range: f32,
-        min_db: f32,
-    ) {
-        let bin_count = fft_data.len();
-        if bin_count == 0 {
-            return;
-        }
-
-        let db_range_f64 = f64::from(db_range);
-        let min_db_f64 = f64::from(min_db);
-
-        for (i, &db) in fft_data.iter().enumerate() {
-            let x = w * i as f64 / (bin_count - 1).max(1) as f64;
-            let y = h * (1.0 - ((f64::from(db) - min_db_f64) / db_range_f64).clamp(0.0, 1.0));
-            if i == 0 {
-                cr.move_to(x, y);
-            } else {
-                cr.line_to(x, y);
-            }
-        }
-
+        // Stroke the trace line on top.
         cr.set_source_rgba(
             TRACE_COLOR[0],
             TRACE_COLOR[1],
@@ -244,5 +193,145 @@ impl FftPlotRenderer {
         );
         cr.set_line_width(1.0);
         let _ = cr.stroke();
+
+        // Return the downsample buffer to self for reuse next frame.
+        let _ = display_data;
+        self.downsample_buf = ds_buf;
+    }
+
+    /// Draw horizontal dB grid lines with labels and vertical frequency grid
+    /// lines with frequency labels.
+    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::too_many_arguments)]
+    fn draw_grid(
+        cr: &cairo::Context,
+        w: f64,
+        h: f64,
+        min_db: f32,
+        max_db: f32,
+        display_start_hz: f64,
+        display_end_hz: f64,
+        center_freq_hz: f64,
+    ) {
+        let display_span = display_end_hz - display_start_hz;
+
+        // --- Grid lines (drawn first, behind labels) ---
+        cr.set_source_rgba(GRID_COLOR[0], GRID_COLOR[1], GRID_COLOR[2], GRID_COLOR[3]);
+        cr.set_line_width(1.0);
+
+        let db_range = f64::from(max_db - min_db);
+
+        // Horizontal dB grid lines.
+        for i in 0..=DB_GRID_LINE_COUNT {
+            let frac = i as f64 / DB_GRID_LINE_COUNT as f64;
+            let y = (h * frac).floor() + 0.5;
+            cr.move_to(0.0, y);
+            cr.line_to(w, y);
+        }
+
+        // Vertical frequency grid lines at computed positions.
+        // Use absolute frequencies (center + offset) for labels.
+        let abs_start = center_freq_hz + display_start_hz;
+        let abs_end = center_freq_hz + display_end_hz;
+        let grid_lines = if display_span > 0.0 {
+            frequency_axis::compute_grid_lines(abs_start, abs_end, FREQ_GRID_LINE_COUNT)
+        } else {
+            Vec::new()
+        };
+
+        for &(freq_hz, _) in &grid_lines {
+            let frac = (freq_hz - abs_start) / display_span;
+            let x = (w * frac).floor() + 0.5;
+            cr.move_to(x, 0.0);
+            cr.line_to(x, h);
+        }
+
+        let _ = cr.stroke();
+
+        // --- Labels (drawn on top of grid lines) ---
+        cr.set_font_size(LABEL_FONT_SIZE);
+        cr.set_source_rgba(
+            LABEL_COLOR[0],
+            LABEL_COLOR[1],
+            LABEL_COLOR[2],
+            LABEL_COLOR[3],
+        );
+
+        // Frequency labels at the top of each vertical grid line.
+        for (freq_hz, label) in &grid_lines {
+            let frac = (freq_hz - abs_start) / display_span;
+            let x = w * frac;
+            cr.move_to(x + 2.0, FREQ_LABEL_TOP_MARGIN - 2.0);
+            cr.show_text(label).ok();
+        }
+
+        // dB labels at each horizontal grid line.
+        if db_range > 0.0 {
+            for i in 0..=DB_GRID_LINE_COUNT {
+                let frac = i as f64 / DB_GRID_LINE_COUNT as f64;
+                let y = h * frac;
+                // frac 0 = top = max_db, frac 1 = bottom = min_db.
+                let db_val = f64::from(max_db) - frac * db_range;
+                let label = format!("{db_val:.0} dB");
+                cr.move_to(2.0, y - 2.0);
+                cr.show_text(&label).ok();
+            }
+        }
+    }
+
+    /// Build the spectrum trace path on the Cairo context (no fill or stroke).
+    ///
+    /// Maps each FFT bin to a frequency in Hz, then to a pixel X coordinate
+    /// using the current display range. When zoomed in, bins outside the
+    /// visible range map to offscreen positions and Cairo clips them.
+    #[allow(clippy::cast_precision_loss, clippy::too_many_arguments)]
+    fn build_trace_path(
+        cr: &cairo::Context,
+        fft_data: &[f32],
+        w: f64,
+        h: f64,
+        db_range: f32,
+        min_db: f32,
+        display_start_hz: f64,
+        display_end_hz: f64,
+        full_bandwidth: f64,
+    ) {
+        let bin_count = fft_data.len();
+        if bin_count == 0 {
+            return;
+        }
+
+        let db_range_f64 = f64::from(db_range);
+        let min_db_f64 = f64::from(min_db);
+        let display_span = display_end_hz - display_start_hz;
+
+        // If full_bandwidth is not set (0), fall back to the display span
+        // (no zoom effect).
+        let effective_full_bw = if full_bandwidth > 0.0 {
+            full_bandwidth
+        } else {
+            display_span
+        };
+
+        for (i, &db) in fft_data.iter().enumerate() {
+            // Map bin index to frequency: after fftshift, bin 0 = -full_bw/2,
+            // bin N-1 = +full_bw/2.
+            let bin_freq = -effective_full_bw / 2.0
+                + (i as f64 / (bin_count - 1).max(1) as f64) * effective_full_bw;
+
+            // Map frequency to pixel X within the current display range.
+            let x = if display_span > 0.0 {
+                w * (bin_freq - display_start_hz) / display_span
+            } else {
+                w * i as f64 / (bin_count - 1).max(1) as f64
+            };
+
+            let y = h * (1.0 - ((f64::from(db) - min_db_f64) / db_range_f64).clamp(0.0, 1.0));
+            if i == 0 {
+                cr.move_to(x, y);
+            } else {
+                cr.line_to(x, y);
+            }
+        }
     }
 }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -110,6 +110,11 @@ pub struct SpectrumHandle {
     /// Pre-allocated buffer for fftshift of waterfall data (avoids per-frame alloc).
     shift_buffer: Rc<RefCell<Vec<f32>>>,
     cursor_callback: CursorCallback,
+    /// Full (unzoomed) FFT bandwidth in Hz, set by `set_display_bandwidth()`.
+    /// Used by the FFT plot and waterfall renderers for zoom mapping.
+    full_bandwidth: Rc<Cell<f64>>,
+    /// Tuner center frequency in Hz (for absolute frequency labels).
+    center_freq: Rc<Cell<f64>>,
 }
 
 impl SpectrumHandle {
@@ -226,14 +231,23 @@ impl SpectrumHandle {
     /// Update the VFO display range to match the effective FFT bandwidth.
     ///
     /// Called when the sample rate changes (mode switch, decimation change,
-    /// source switch). Sets the display to show +/-bandwidth/2 centered on DC.
+    /// source switch). Sets the display to show +/-bandwidth/2 centered on DC
+    /// and stores the full bandwidth for zoom calculations.
     pub fn set_display_bandwidth(&self, effective_sample_rate: f64) {
         let half = effective_sample_rate / 2.0;
         let mut vfo = self.vfo_state.borrow_mut();
         vfo.display_start_hz = -half;
         vfo.display_end_hz = half;
+        vfo.max_span_hz = effective_sample_rate;
+        self.full_bandwidth.set(effective_sample_rate);
         self.fft_area.queue_draw();
         self.waterfall_area.queue_draw();
+    }
+
+    /// Update the tuner center frequency for frequency axis labels.
+    pub fn set_center_frequency(&self, freq_hz: f64) {
+        self.center_freq.set(freq_hz);
+        self.fft_area.queue_draw();
     }
 
     /// Push a signal level sample (in dB) into the history graph.
@@ -275,6 +289,8 @@ pub fn build_spectrum_view(
     let max_db: Rc<Cell<f32>> = Rc::new(Cell::new(DEFAULT_MAX_DB));
     let fill_enabled: Rc<Cell<bool>> = Rc::new(Cell::new(true));
     let cursor_callback: CursorCallback = Rc::new(RefCell::new(None));
+    let full_bandwidth: Rc<Cell<f64>> = Rc::new(Cell::new(0.0));
+    let center_freq: Rc<Cell<f64>> = Rc::new(Cell::new(100_000_000.0)); // default 100 MHz
 
     // Initialize renderer state eagerly (no GL context needed).
     *fft_state.borrow_mut() = Some(FftPlotState {
@@ -302,8 +318,14 @@ pub fn build_spectrum_view(
         &max_db,
         &fill_enabled,
         &cursor_callback,
+        &full_bandwidth,
+        &center_freq,
     );
-    let waterfall_area = build_waterfall_area(Rc::clone(&waterfall_state), Rc::clone(&vfo_state));
+    let waterfall_area = build_waterfall_area(
+        Rc::clone(&waterfall_state),
+        Rc::clone(&vfo_state),
+        Rc::clone(&full_bandwidth),
+    );
     let signal_history_area =
         build_signal_history_area(Rc::clone(&signal_history_state), &min_db, &max_db);
 
@@ -366,12 +388,15 @@ pub fn build_spectrum_view(
         avg_buffer: Rc::new(RefCell::new(Vec::new())),
         shift_buffer: Rc::new(RefCell::new(Vec::new())),
         cursor_callback,
+        full_bandwidth,
+        center_freq,
     };
 
     (outer_box, handle)
 }
 
 /// Build the `DrawingArea` for the FFT power spectrum plot.
+#[allow(clippy::too_many_arguments)]
 fn build_fft_area(
     state: Rc<RefCell<Option<FftPlotState>>>,
     vfo_state: &Rc<RefCell<VfoState>>,
@@ -379,6 +404,8 @@ fn build_fft_area(
     max_db: &Rc<Cell<f32>>,
     fill_enabled: &Rc<Cell<bool>>,
     cursor_callback: &CursorCallback,
+    full_bandwidth: &Rc<Cell<f64>>,
+    center_freq: &Rc<Cell<f64>>,
 ) -> gtk4::DrawingArea {
     let area = gtk4::DrawingArea::builder()
         .hexpand(true)
@@ -390,8 +417,11 @@ fn build_fft_area(
     let max_db_render = Rc::clone(max_db);
     let fill_render = Rc::clone(fill_enabled);
     let vfo_render = Rc::clone(vfo_state);
+    let full_bw_render = Rc::clone(full_bandwidth);
+    let center_freq_render = Rc::clone(center_freq);
     area.set_draw_func(move |_area, cr, width, height| {
         if let Some(s) = state.borrow_mut().as_mut() {
+            let vfo = vfo_render.borrow();
             s.renderer.render(
                 cr,
                 &s.current_data,
@@ -400,9 +430,12 @@ fn build_fft_area(
                 min_db_render.get(),
                 max_db_render.get(),
                 fill_render.get(),
+                vfo.display_start_hz,
+                vfo.display_end_hz,
+                full_bw_render.get(),
+                center_freq_render.get(),
             );
 
-            let vfo = vfo_render.borrow();
             s.vfo_renderer.render(cr, &vfo, width, height);
         }
     });
@@ -456,6 +489,7 @@ fn build_fft_area(
 fn build_waterfall_area(
     state: Rc<RefCell<Option<WaterfallState>>>,
     vfo_state: Rc<RefCell<VfoState>>,
+    full_bandwidth: Rc<Cell<f64>>,
 ) -> gtk4::DrawingArea {
     let area = gtk4::DrawingArea::builder()
         .hexpand(true)
@@ -464,9 +498,16 @@ fn build_waterfall_area(
 
     area.set_draw_func(move |_area, cr, width, height| {
         if let Some(s) = state.borrow().as_ref() {
-            s.renderer.render(cr, width, height);
-
             let vfo = vfo_state.borrow();
+            s.renderer.render(
+                cr,
+                width,
+                height,
+                vfo.display_start_hz,
+                vfo.display_end_hz,
+                full_bandwidth.get(),
+            );
+
             s.vfo_renderer.render(cr, &vfo, width, height);
         }
     });

--- a/crates/sdr-ui/src/spectrum/vfo_overlay.rs
+++ b/crates/sdr-ui/src/spectrum/vfo_overlay.rs
@@ -42,9 +42,6 @@ const ZOOM_FACTOR: f64 = 1.2;
 /// Minimum display span in Hz to prevent zooming into nothing.
 const MIN_DISPLAY_SPAN_HZ: f64 = 1_000.0;
 
-/// Maximum display span in Hz.
-const MAX_DISPLAY_SPAN_HZ: f64 = 50_000_000.0;
-
 // ---------------------------------------------------------------------------
 // VFO state
 // ---------------------------------------------------------------------------
@@ -75,6 +72,8 @@ pub struct VfoState {
     pub dragging: bool,
     /// Whether a bandwidth handle is being dragged.
     pub bw_dragging: Option<BwHandle>,
+    /// Maximum zoom-out span in Hz (= full FFT bandwidth).
+    pub max_span_hz: f64,
 }
 
 impl Default for VfoState {
@@ -87,6 +86,7 @@ impl Default for VfoState {
             color: VFO_COLOR,
             dragging: false,
             bw_dragging: None,
+            max_span_hz: DEFAULT_DISPLAY_SPAN_HZ,
         }
     }
 }
@@ -199,7 +199,7 @@ impl VfoState {
         };
 
         let span = self.display_end_hz - self.display_start_hz;
-        let new_span = (span * factor).clamp(MIN_DISPLAY_SPAN_HZ, MAX_DISPLAY_SPAN_HZ);
+        let new_span = (span * factor).clamp(MIN_DISPLAY_SPAN_HZ, self.max_span_hz);
 
         // Keep the cursor frequency at the same relative position.
         let frac = if span > 0.0 {
@@ -359,6 +359,7 @@ mod tests {
             color: VFO_COLOR,
             dragging: false,
             bw_dragging: None,
+            max_span_hz: 1_000_000.0,
         }
     }
 
@@ -479,6 +480,8 @@ mod tests {
     #[test]
     fn zoom_out_widens_span() {
         let mut vfo = test_vfo();
+        // Zoom in first so there's room to zoom back out.
+        vfo.zoom(0.0, 1.0);
         let span_before = vfo.display_end_hz - vfo.display_start_hz;
         vfo.zoom(0.0, -1.0); // negative = zoom out
         let span_after = vfo.display_end_hz - vfo.display_start_hz;
@@ -511,8 +514,8 @@ mod tests {
         }
         let span = vfo.display_end_hz - vfo.display_start_hz;
         assert!(
-            span <= MAX_DISPLAY_SPAN_HZ,
-            "span should not exceed maximum: {span}"
+            span <= vfo.max_span_hz + 1.0, // +1 for float rounding
+            "span should not exceed max_span_hz: {span}"
         );
     }
 

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -158,14 +158,23 @@ impl WaterfallRenderer {
     /// Render the waterfall display to the given Cairo context.
     ///
     /// Blits the pixel buffer as a Cairo `ImageSurface` scaled to the
-    /// requested output size.
+    /// requested output size. When zoomed in, only the visible frequency
+    /// portion is shown by translating and scaling the source surface.
     #[allow(
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap,
         clippy::cast_precision_loss,
         clippy::cast_sign_loss
     )]
-    pub fn render(&self, cr: &cairo::Context, width: i32, height: i32) {
+    pub fn render(
+        &self,
+        cr: &cairo::Context,
+        width: i32,
+        height: i32,
+        display_start_hz: f64,
+        display_end_hz: f64,
+        full_bandwidth: f64,
+    ) {
         if width <= 0 || height <= 0 || self.display_width == 0 {
             return;
         }
@@ -216,16 +225,52 @@ impl WaterfallRenderer {
 
         let Ok(surface) = surface else { return };
 
-        // Scale the surface to fill the output area.
-        let _ = cr.save();
-        cr.scale(
-            f64::from(width) / self.display_width as f64,
-            f64::from(height) / HISTORY_LINES as f64,
-        );
-        let _ = cr.set_source_surface(&surface, 0.0, 0.0);
+        // Compute the visible portion of the full-bandwidth surface.
+        // The pixel buffer spans -full_bw/2 .. +full_bw/2.
+        // The display range is display_start_hz .. display_end_hz.
+        let effective_full_bw = if full_bandwidth > 0.0 {
+            full_bandwidth
+        } else {
+            display_end_hz - display_start_hz
+        };
 
-        // Use NEAREST filtering for crisp bin boundaries (matching the old GL
-        // NEAREST filter), or BILINEAR for smoother appearance.
+        let full_start_hz = -effective_full_bw / 2.0;
+
+        // Fractional position of the visible range within the full surface.
+        let visible_start_frac = if effective_full_bw > 0.0 {
+            (display_start_hz - full_start_hz) / effective_full_bw
+        } else {
+            0.0
+        };
+        let visible_end_frac = if effective_full_bw > 0.0 {
+            (display_end_hz - full_start_hz) / effective_full_bw
+        } else {
+            1.0
+        };
+
+        let visible_width_frac = visible_end_frac - visible_start_frac;
+
+        // Scale and translate the surface so only the visible portion fills
+        // the output area.
+        let _ = cr.save();
+
+        // Y scale: stretch history lines to fill output height.
+        let y_scale = f64::from(height) / HISTORY_LINES as f64;
+
+        // X scale: the visible fraction of the surface width maps to output width.
+        let x_scale = if visible_width_frac > 0.0 {
+            f64::from(width) / (self.display_width as f64 * visible_width_frac)
+        } else {
+            f64::from(width) / self.display_width as f64
+        };
+
+        cr.scale(x_scale, y_scale);
+
+        // Offset the surface so the visible start aligns with x=0.
+        let src_offset_x = -(visible_start_frac * self.display_width as f64);
+        let _ = cr.set_source_surface(&surface, src_offset_x, 0.0);
+
+        // Use NEAREST filtering for crisp bin boundaries.
         cr.source().set_filter(cairo::Filter::Nearest);
 
         let _ = cr.paint();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -120,6 +120,7 @@ pub fn build_window(app: &adw::Application) {
 
     let status_bar_for_freq = Rc::clone(&status_bar_demod);
     let state_freq = Rc::clone(&state);
+    let spectrum_for_freq = Rc::clone(&spectrum_handle);
     freq_selector.connect_frequency_changed(move |freq| {
         tracing::debug!(frequency_hz = freq, "frequency changed");
         #[allow(clippy::cast_precision_loss)]
@@ -127,6 +128,7 @@ pub fn build_window(app: &adw::Application) {
         state_freq.center_frequency.set(freq_f64);
         state_freq.send_dsp(UiToDsp::Tune(freq_f64));
         status_bar_for_freq.update_frequency(freq_f64);
+        spectrum_for_freq.set_center_frequency(freq_f64);
     });
     let status_bar_for_demod = Rc::clone(&status_bar_demod);
     let bw_row_for_demod = panels.radio.bandwidth_row.clone();
@@ -451,7 +453,14 @@ fn connect_sidebar_panels(
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
-    connect_navigation_panel(panels, state, freq_selector, demod_dropdown, status_bar);
+    connect_navigation_panel(
+        panels,
+        state,
+        freq_selector,
+        demod_dropdown,
+        status_bar,
+        spectrum_handle,
+    );
 }
 
 /// Connect source panel controls to DSP commands.
@@ -831,18 +840,21 @@ fn connect_display_panel(
 }
 
 /// Connect navigation panel (band presets + bookmarks) to DSP commands.
+#[allow(clippy::too_many_arguments)]
 fn connect_navigation_panel(
     panels: &SidebarPanels,
     state: &Rc<AppState>,
     freq_selector: &header::frequency_selector::FrequencySelector,
     demod_dropdown: &gtk4::DropDown,
     status_bar: &Rc<StatusBar>,
+    spectrum_handle: &Rc<spectrum::SpectrumHandle>,
 ) {
     // Navigation callback: tune + set mode + set bandwidth, update UI widgets.
     let state_nav = Rc::clone(state);
     let fs = freq_selector.clone();
     let dd_weak = demod_dropdown.downgrade();
     let sb = Rc::clone(status_bar);
+    let spectrum_nav = Rc::clone(spectrum_handle);
 
     panels.navigation.connect_navigate(move |freq, mode, bw| {
         #[allow(clippy::cast_precision_loss)]
@@ -857,6 +869,7 @@ fn connect_navigation_panel(
 
         // Update frequency selector display (does NOT fire callback — no duplicate Tune).
         fs.set_frequency(freq);
+        spectrum_nav.set_center_frequency(freq_f64);
 
         // Update demod dropdown — its callback sends SetDemodMode to DSP.
         if let Some(dd) = dd_weak.upgrade()


### PR DESCRIPTION
## Summary
- **Frequency axis labels (#166):** Absolute frequency labels on vertical grid lines (e.g., "89.100 MHz") and dB labels on horizontal lines. Grid lines positioned at round frequency intervals. Center frequency updates on tune and bookmark recall.
- **Spectrum zoom (#175):** Scroll-to-zoom now actually zooms the FFT plot and waterfall by mapping bins to the visible frequency range. Zoom-out clamped to full FFT bandwidth.
- **FFT plot optimization (#185):** Single `build_trace_path` reused for both fill (`fill_preserve`) and stroke, eliminating duplicate coordinate calculation.
- **PipeWire read buffer constant (#177):** Magic number promoted to `READ_BUF_INITIAL_SAMPLES`.

Closes #166, closes #175, closes #177, closes #185

## Test plan
- [ ] Verify frequency labels show absolute frequencies (e.g., "89.100 MHz")
- [ ] Tune to different frequencies — labels update correctly
- [ ] Recall bookmark — labels update
- [ ] Scroll to zoom in — FFT trace and waterfall zoom together
- [ ] Scroll to zoom out — stops at full FFT bandwidth (no empty space)
- [ ] Verify dB labels on horizontal grid lines
- [ ] Verify fill mode still works with shared trace path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frequency-aware zooming to the spectrum display with labeled grid lines
  * Integrated center frequency tracking with the spectrum view
  * Waterfall display now supports frequency-aware zooming
  * Spectrum visualization now renders frequency labels alongside the display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->