### PR TITLE
Audio/IQ recording, waterfall PNG export, desktop notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,7 @@ dependencies = [
 name = "sdr-ui"
 version = "0.1.0"
 dependencies = [
+ "cairo-rs",
  "gtk4",
  "libadwaita",
  "sdr-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ hound = "3"
 # GTK4 / UI
 gtk4 = { version = "0.11", features = ["v4_10"] }
 libadwaita = { version = "0.9", features = ["v1_5"] }
+cairo-rs = { version = "0.22", features = ["png"] }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -28,6 +28,7 @@ thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+cairo-rs.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -15,6 +15,9 @@ const APP_ID: &str = "com.sdr.rs";
 pub fn build_app() -> adw::Application {
     let app = adw::Application::builder().application_id(APP_ID).build();
 
+    // Register notification click action before any notifications are sent.
+    crate::notify::register_actions(&app);
+
     app.connect_startup(|_| {
         css::load_css();
 

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -22,6 +22,7 @@ use sdr_source_rtlsdr::RtlSdrSource;
 use sdr_types::{Complex, SinkError, Stereo};
 
 use crate::messages::{DspToUi, SourceType, UiToDsp};
+use crate::wav_writer::WavWriter;
 
 /// Number of IQ sample pairs per USB bulk read.
 const IQ_PAIRS_PER_READ: usize = 16_384;
@@ -53,6 +54,15 @@ const VFO_OUTPUT_PADDING: usize = 64;
 
 /// RTL-SDR device index to open.
 const DEVICE_INDEX: u32 = 0;
+
+/// Audio recording sample rate in Hz (matches `PipeWire` output).
+const AUDIO_SAMPLE_RATE: u32 = 48_000;
+
+/// Audio recording channel count (stereo).
+const AUDIO_CHANNELS: u16 = 2;
+
+/// IQ recording channel count (I + Q).
+const IQ_CHANNELS: u16 = 2;
 
 /// Spawn the DSP controller thread.
 ///
@@ -207,6 +217,10 @@ struct DspState {
     processed_buf: Vec<Complex>,
     fft_buf: Vec<f32>,
     audio_buf: Vec<Stereo>,
+
+    // Recording state
+    audio_writer: Option<WavWriter>,
+    iq_writer: Option<WavWriter>,
 }
 
 impl DspState {
@@ -254,6 +268,8 @@ impl DspState {
             processed_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             fft_buf: vec![0.0; DEFAULT_FFT_SIZE],
             audio_buf: Vec::new(),
+            audio_writer: None,
+            iq_writer: None,
         })
     }
 }
@@ -696,6 +712,49 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 let _ = dsp_tx.send(DspToUi::Error(format!("PPM correction failed: {e}")));
             }
         }
+
+        UiToDsp::StartAudioRecording(path) => {
+            tracing::info!(?path, "start audio recording");
+            match WavWriter::new(&path, AUDIO_SAMPLE_RATE, AUDIO_CHANNELS) {
+                Ok(writer) => {
+                    state.audio_writer = Some(writer);
+                    let _ = dsp_tx.send(DspToUi::AudioRecordingStarted(path));
+                }
+                Err(e) => {
+                    tracing::warn!("failed to start audio recording: {e}");
+                    let _ = dsp_tx.send(DspToUi::Error(format!("Audio record failed: {e}")));
+                }
+            }
+        }
+
+        UiToDsp::StopAudioRecording => {
+            tracing::info!("stop audio recording");
+            // Drop the writer — `Drop` finalizes the WAV header.
+            state.audio_writer = None;
+            let _ = dsp_tx.send(DspToUi::AudioRecordingStopped);
+        }
+
+        UiToDsp::StartIqRecording(path) => {
+            tracing::info!(?path, "start IQ recording");
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let iq_rate = state.sample_rate as u32;
+            match WavWriter::new(&path, iq_rate, IQ_CHANNELS) {
+                Ok(writer) => {
+                    state.iq_writer = Some(writer);
+                    let _ = dsp_tx.send(DspToUi::IqRecordingStarted(path));
+                }
+                Err(e) => {
+                    tracing::warn!("failed to start IQ recording: {e}");
+                    let _ = dsp_tx.send(DspToUi::Error(format!("IQ record failed: {e}")));
+                }
+            }
+        }
+
+        UiToDsp::StopIqRecording => {
+            tracing::info!("stop IQ recording");
+            state.iq_writer = None;
+            let _ = dsp_tx.send(DspToUi::IqRecordingStopped);
+        }
     }
 }
 
@@ -761,6 +820,14 @@ fn cleanup(state: &mut DspState) {
     // Stop the audio sink so it doesn't try to read stale data.
     if let Err(e) = state.audio_sink.stop() {
         tracing::debug!("audio sink stop: {e}");
+    }
+
+    // Finalize any active recordings (Drop patches the WAV header sizes).
+    if state.audio_writer.take().is_some() {
+        tracing::info!("audio recording finalized on cleanup");
+    }
+    if state.iq_writer.take().is_some() {
+        tracing::info!("IQ recording finalized on cleanup");
     }
 
     state.source = None;
@@ -879,6 +946,16 @@ fn process_iq_block(
         }
     };
 
+    // Write raw IQ samples to recording file (before any processing).
+    if let Some(writer) = &mut state.iq_writer
+        && let Err(e) = writer.write_iq(&state.iq_buf[..iq_count])
+    {
+        tracing::warn!("IQ recording write error: {e}");
+        state.iq_writer = None;
+        let _ = dsp_tx.send(DspToUi::Error("IQ recording write failed".to_string()));
+        let _ = dsp_tx.send(DspToUi::IqRecordingStopped);
+    }
+
     // Process through IQ frontend (decimation, DC blocking, FFT).
     match state.frontend.process(
         &state.iq_buf[..iq_count],
@@ -943,6 +1020,17 @@ fn process_iq_block(
                         for s in &mut state.audio_buf[..audio_count] {
                             s.l *= vol;
                             s.r *= vol;
+                        }
+
+                        // Write to audio recording file (post-volume).
+                        if let Some(writer) = &mut state.audio_writer
+                            && let Err(e) = writer.write_stereo(&state.audio_buf[..audio_count])
+                        {
+                            tracing::warn!("audio recording write error: {e}");
+                            state.audio_writer = None;
+                            let _ = dsp_tx
+                                .send(DspToUi::Error("Audio recording write failed".to_string()));
+                            let _ = dsp_tx.send(DspToUi::AudioRecordingStopped);
                         }
 
                         // Send to PipeWire for playback.

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -5,6 +5,7 @@ pub mod css;
 pub mod dsp_controller;
 pub mod header;
 pub mod messages;
+pub mod notify;
 pub mod shortcuts;
 pub mod sidebar;
 pub mod spectrum;

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -10,6 +10,7 @@ pub mod sidebar;
 pub mod spectrum;
 pub mod state;
 pub mod status_bar;
+pub mod wav_writer;
 pub mod window;
 
 use gtk4::glib;

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -22,6 +22,14 @@ pub enum DspToUi {
     GainList(Vec<f64>),
     /// Raw (pre-decimation) sample rate for spectrum display bandwidth.
     DisplayBandwidth(f64),
+    /// Audio recording started (contains the file path for display).
+    AudioRecordingStarted(std::path::PathBuf),
+    /// Audio recording stopped.
+    AudioRecordingStopped,
+    /// IQ recording started (contains the file path for display).
+    IqRecordingStarted(std::path::PathBuf),
+    /// IQ recording stopped.
+    IqRecordingStopped,
 }
 
 /// Available source types for IQ input.
@@ -106,6 +114,14 @@ pub enum UiToDsp {
     SetFilePath(std::path::PathBuf),
     /// Set PPM frequency correction for RTL-SDR crystal offset.
     SetPpmCorrection(i32),
+    /// Start recording demodulated audio to a WAV file.
+    StartAudioRecording(std::path::PathBuf),
+    /// Stop audio recording and finalize the WAV file.
+    StopAudioRecording,
+    /// Start recording raw IQ samples to a WAV file.
+    StartIqRecording(std::path::PathBuf),
+    /// Stop IQ recording and finalize the WAV file.
+    StopIqRecording,
 }
 
 #[cfg(test)]
@@ -133,9 +149,22 @@ mod tests {
 
         let info = DspToUi::DeviceInfo("RTL2838UHIDIR".to_string());
         assert!(matches!(info, DspToUi::DeviceInfo(ref s) if s == "RTL2838UHIDIR"));
+
+        let audio_rec = DspToUi::AudioRecordingStarted(std::path::PathBuf::from("/tmp/test.wav"));
+        assert!(matches!(audio_rec, DspToUi::AudioRecordingStarted(_)));
+
+        let audio_stop = DspToUi::AudioRecordingStopped;
+        assert!(matches!(audio_stop, DspToUi::AudioRecordingStopped));
+
+        let iq_rec = DspToUi::IqRecordingStarted(std::path::PathBuf::from("/tmp/iq.wav"));
+        assert!(matches!(iq_rec, DspToUi::IqRecordingStarted(_)));
+
+        let iq_stop = DspToUi::IqRecordingStopped;
+        assert!(matches!(iq_stop, DspToUi::IqRecordingStopped));
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_ui_to_dsp_variants() {
         let start = UiToDsp::Start;
         assert!(matches!(start, UiToDsp::Start));
@@ -262,6 +291,18 @@ mod tests {
 
         let ppm = UiToDsp::SetPpmCorrection(42);
         assert!(matches!(ppm, UiToDsp::SetPpmCorrection(42)));
+
+        let audio_rec = UiToDsp::StartAudioRecording(std::path::PathBuf::from("/tmp/audio.wav"));
+        assert!(matches!(audio_rec, UiToDsp::StartAudioRecording(_)));
+
+        let audio_stop = UiToDsp::StopAudioRecording;
+        assert!(matches!(audio_stop, UiToDsp::StopAudioRecording));
+
+        let iq_rec = UiToDsp::StartIqRecording(std::path::PathBuf::from("/tmp/iq.wav"));
+        assert!(matches!(iq_rec, UiToDsp::StartIqRecording(_)));
+
+        let iq_stop = UiToDsp::StopIqRecording;
+        assert!(matches!(iq_stop, UiToDsp::StopIqRecording));
     }
 
     #[test]

--- a/crates/sdr-ui/src/notify.rs
+++ b/crates/sdr-ui/src/notify.rs
@@ -19,7 +19,7 @@ pub fn send(summary: &str, body: &str, open_path: Option<&std::path::Path>) {
     notification.set_body(Some(body));
 
     if let Some(path) = open_path {
-        let uri = format!("file://{}", path.display());
+        let uri = gio::File::for_path(path).uri();
         notification.set_default_action_and_target_value("app.open-uri", Some(&uri.to_variant()));
     }
 

--- a/crates/sdr-ui/src/notify.rs
+++ b/crates/sdr-ui/src/notify.rs
@@ -1,0 +1,44 @@
+//! Desktop notification helper via `GNotification`.
+//!
+//! Uses GTK's `gio::Notification` API which integrates with the running
+//! `GtkApplication` and supports click-to-open actions.
+
+use gtk4::gio;
+use gtk4::glib;
+use gtk4::prelude::*;
+
+/// Send a desktop notification. If `open_path` is provided, clicking the
+/// notification opens the file with the default application.
+pub fn send(summary: &str, body: &str, open_path: Option<&std::path::Path>) {
+    let Some(app) = gio::Application::default() else {
+        tracing::debug!("no default GApplication — skipping notification");
+        return;
+    };
+
+    let notification = gio::Notification::new(summary);
+    notification.set_body(Some(body));
+
+    if let Some(path) = open_path {
+        let uri = format!("file://{}", path.display());
+        notification.set_default_action_and_target_value("app.open-uri", Some(&uri.to_variant()));
+    }
+
+    app.send_notification(Some("sdr-rs-notify"), &notification);
+}
+
+/// Register the `app.open-uri` action on the application.
+///
+/// Call once during startup so notification click actions work.
+pub fn register_actions(app: &impl IsA<gio::ActionMap>) {
+    let open_action = gio::SimpleAction::new("open-uri", Some(glib::VariantTy::STRING));
+    open_action.connect_activate(|_, param| {
+        let Some(uri) = param.and_then(glib::Variant::get::<String>) else {
+            return;
+        };
+        tracing::info!(uri, "opening from notification");
+        if let Err(e) = gio::AppInfo::launch_default_for_uri(&uri, gio::AppLaunchContext::NONE) {
+            tracing::warn!("failed to open URI: {e}");
+        }
+    });
+    app.add_action(&open_action);
+}

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -13,6 +13,8 @@ pub struct AudioPanel {
     pub sink_type_row: adw::ComboRow,
     /// Node names corresponding to device dropdown indices (for routing).
     pub device_node_names: Vec<String>,
+    /// Toggle to start/stop audio recording.
+    pub record_audio_row: adw::SwitchRow,
 }
 
 /// Build the audio output configuration panel.
@@ -41,13 +43,20 @@ pub fn build_audio_panel() -> AudioPanel {
         .model(&sink_model)
         .build();
 
+    let record_audio_row = adw::SwitchRow::builder()
+        .title("Record Audio")
+        .subtitle("48 kHz stereo WAV")
+        .build();
+
     group.add(&device_row);
     group.add(&sink_type_row);
+    group.add(&record_audio_row);
 
     AudioPanel {
         widget: group,
         device_row,
         sink_type_row,
         device_node_names: node_names,
+        record_audio_row,
     }
 }

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -52,8 +52,6 @@ pub struct DisplayPanel {
     pub averaging_row: adw::ComboRow,
     /// Theme selector (System / Dark / Light).
     pub theme_row: adw::ComboRow,
-    /// Export waterfall to PNG button.
-    pub export_waterfall_btn: gtk4::Button,
 }
 
 /// Build the display settings panel.
@@ -145,9 +143,6 @@ pub fn build_display_panel() -> DisplayPanel {
     group.add(&averaging_row);
     group.add(&theme_row);
 
-    // Export button is in the header bar, not here.
-    let export_waterfall_btn = gtk4::Button::new();
-
     // FFT size and window function connected via window.rs
 
     DisplayPanel {
@@ -161,7 +156,6 @@ pub fn build_display_panel() -> DisplayPanel {
         fill_mode_row,
         averaging_row,
         theme_row,
-        export_waterfall_btn,
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -52,6 +52,8 @@ pub struct DisplayPanel {
     pub averaging_row: adw::ComboRow,
     /// Theme selector (System / Dark / Light).
     pub theme_row: adw::ComboRow,
+    /// Export waterfall to PNG button.
+    pub export_waterfall_btn: gtk4::Button,
 }
 
 /// Build the display settings panel.
@@ -143,6 +145,9 @@ pub fn build_display_panel() -> DisplayPanel {
     group.add(&averaging_row);
     group.add(&theme_row);
 
+    // Export button is in the header bar, not here.
+    let export_waterfall_btn = gtk4::Button::new();
+
     // FFT size and window function connected via window.rs
 
     DisplayPanel {
@@ -156,6 +161,7 @@ pub fn build_display_panel() -> DisplayPanel {
         fill_mode_row,
         averaging_row,
         theme_row,
+        export_waterfall_btn,
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -75,6 +75,8 @@ pub struct SourcePanel {
     pub iq_inversion_row: adw::SwitchRow,
     /// Decimation factor selector (always visible).
     pub decimation_row: adw::ComboRow,
+    /// Toggle to start/stop IQ recording.
+    pub record_iq_row: adw::SwitchRow,
 }
 
 /// Default sample rate selector index (2.4 MHz = index 7).
@@ -261,6 +263,11 @@ pub fn build_source_panel() -> SourcePanel {
     let (dc_blocking_row, iq_correction_row, iq_inversion_row, decimation_row) =
         build_common_rows();
 
+    let record_iq_row = adw::SwitchRow::builder()
+        .title("Record IQ")
+        .subtitle("Raw IQ samples to WAV")
+        .build();
+
     // Add all rows to the group.
     group.add(&device_row);
     group.add(&sample_rate_row);
@@ -275,6 +282,7 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&iq_correction_row);
     group.add(&iq_inversion_row);
     group.add(&decimation_row);
+    group.add(&record_iq_row);
 
     // Derive initial visibility from the selected device.
     let selected = device_row.selected();
@@ -319,6 +327,7 @@ pub fn build_source_panel() -> SourcePanel {
         iq_correction_row,
         iq_inversion_row,
         decimation_row,
+        record_iq_row,
     }
 }
 

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -244,6 +244,15 @@ impl SpectrumHandle {
         self.waterfall_area.queue_draw();
     }
 
+    /// Export the current waterfall display as a PNG file.
+    pub fn export_waterfall_png(&self, path: &std::path::Path) -> Result<(), String> {
+        if let Some(s) = self.waterfall_state.borrow().as_ref() {
+            s.renderer.export_png(path)
+        } else {
+            Err("waterfall not initialized".to_string())
+        }
+    }
+
     /// Update the tuner center frequency for frequency axis labels.
     pub fn set_center_frequency(&self, freq_hz: f64) {
         self.center_freq.set(freq_hz);

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -290,6 +290,51 @@ impl WaterfallRenderer {
         }
     }
 
+    /// Export the waterfall display to a PNG file.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss
+    )]
+    pub fn export_png(&self, path: &std::path::Path) -> Result<(), String> {
+        if self.display_width == 0 {
+            return Err("no waterfall data".to_string());
+        }
+        let stride = cairo::Format::ARgb32
+            .stride_for_width(self.display_width as u32)
+            .map_err(|e| format!("stride: {e}"))?;
+        let expected = (self.display_width * 4) as i32;
+        let buf = if stride == expected {
+            self.pixel_buf.clone()
+        } else {
+            let mut padded = vec![0u8; stride as usize * HISTORY_LINES];
+            for row in 0..HISTORY_LINES {
+                let src = row * self.display_width * 4;
+                let dst = row * stride as usize;
+                padded[dst..dst + self.display_width * 4]
+                    .copy_from_slice(&self.pixel_buf[src..src + self.display_width * 4]);
+            }
+            padded
+        };
+        let surface = cairo::ImageSurface::create_for_data(
+            buf,
+            cairo::Format::ARgb32,
+            self.display_width as i32,
+            HISTORY_LINES as i32,
+            stride,
+        )
+        .map_err(|e| format!("surface: {e}"))?;
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let mut file = std::fs::File::create(path).map_err(|e| format!("file: {e}"))?;
+        surface
+            .write_to_png(&mut file)
+            .map_err(|e| format!("png: {e}"))?;
+        tracing::info!(?path, "waterfall exported to PNG");
+        Ok(())
+    }
+
     /// Current display width in bins.
     pub fn texture_width(&self) -> usize {
         self.display_width

--- a/crates/sdr-ui/src/wav_writer.rs
+++ b/crates/sdr-ui/src/wav_writer.rs
@@ -1,0 +1,276 @@
+//! WAV file writer for recording audio and IQ data.
+//!
+//! Writes IEEE float 32-bit WAV files. The header is written on creation
+//! with placeholder sizes, then patched on [`Drop`] to finalize the file.
+
+use std::fs::File;
+use std::io::{BufWriter, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use sdr_types::{Complex, Stereo};
+
+/// WAV format tag for IEEE 32-bit floating-point samples.
+const WAV_FORMAT_IEEE_FLOAT: u16 = 3;
+
+/// WAV header size in bytes (RIFF + fmt + data chunk headers).
+const WAV_HEADER_SIZE: u32 = 44;
+
+/// Bits per sample for f32 audio.
+const BITS_PER_SAMPLE: u16 = 32;
+
+/// Bytes per f32 sample.
+const BYTES_PER_SAMPLE: u32 = 4;
+
+/// Offset of the RIFF file-size field (byte 4).
+const RIFF_SIZE_OFFSET: u64 = 4;
+
+/// Offset of the data chunk size field (byte 40).
+const DATA_SIZE_OFFSET: u64 = 40;
+
+/// Size of the RIFF header prefix that is excluded from the file-size field.
+const RIFF_HEADER_PREFIX: u32 = 8;
+
+/// Writes demodulated stereo audio or raw IQ samples to a WAV file.
+///
+/// - Audio recording: 2-channel (L, R) at 48 kHz.
+/// - IQ recording: 2-channel (I, Q) at the source sample rate.
+///
+/// The file is finalized automatically when dropped.
+pub struct WavWriter {
+    writer: BufWriter<File>,
+    samples_written: u32,
+    channels: u16,
+    finalized: bool,
+}
+
+impl WavWriter {
+    /// Create a new WAV writer at `path`.
+    ///
+    /// Writes the 44-byte WAV header with placeholder sizes. The sizes are
+    /// patched in [`Drop`] once all samples have been written.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the file cannot be created or the header write fails.
+    pub fn new(path: &Path, sample_rate: u32, channels: u16) -> std::io::Result<Self> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+
+        // RIFF header
+        writer.write_all(b"RIFF")?;
+        writer.write_all(&0u32.to_le_bytes())?; // placeholder: file size - 8
+        writer.write_all(b"WAVE")?;
+
+        // fmt sub-chunk (16 bytes for PCM/float)
+        writer.write_all(b"fmt ")?;
+        writer.write_all(&16u32.to_le_bytes())?; // sub-chunk size
+        writer.write_all(&WAV_FORMAT_IEEE_FLOAT.to_le_bytes())?;
+        writer.write_all(&channels.to_le_bytes())?;
+        writer.write_all(&sample_rate.to_le_bytes())?;
+        let byte_rate = sample_rate * u32::from(channels) * BYTES_PER_SAMPLE;
+        writer.write_all(&byte_rate.to_le_bytes())?;
+        let block_align = channels * (BITS_PER_SAMPLE / 8);
+        writer.write_all(&block_align.to_le_bytes())?;
+        writer.write_all(&BITS_PER_SAMPLE.to_le_bytes())?;
+
+        // data sub-chunk header
+        writer.write_all(b"data")?;
+        writer.write_all(&0u32.to_le_bytes())?; // placeholder: data size
+
+        Ok(Self {
+            writer,
+            samples_written: 0,
+            channels,
+            finalized: false,
+        })
+    }
+
+    /// Write a slice of stereo audio samples (L, R interleaved as f32 pairs).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the write fails.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn write_stereo(&mut self, samples: &[Stereo]) -> std::io::Result<()> {
+        for s in samples {
+            self.writer.write_all(&s.l.to_le_bytes())?;
+            self.writer.write_all(&s.r.to_le_bytes())?;
+        }
+        self.samples_written = self.samples_written.saturating_add(samples.len() as u32);
+        Ok(())
+    }
+
+    /// Write a slice of IQ samples (I, Q interleaved as f32 pairs).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the write fails.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn write_iq(&mut self, samples: &[Complex]) -> std::io::Result<()> {
+        for s in samples {
+            self.writer.write_all(&s.re.to_le_bytes())?;
+            self.writer.write_all(&s.im.to_le_bytes())?;
+        }
+        self.samples_written = self.samples_written.saturating_add(samples.len() as u32);
+        Ok(())
+    }
+
+    /// Finalize the WAV file by patching the RIFF and data chunk sizes.
+    ///
+    /// Called automatically on [`Drop`], but can be called explicitly for
+    /// error handling. Subsequent calls are no-ops.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the seek or write fails.
+    pub fn finalize(&mut self) -> std::io::Result<()> {
+        if self.finalized {
+            return Ok(());
+        }
+        self.finalized = true;
+
+        self.writer.flush()?;
+
+        let data_size = self.samples_written * u32::from(self.channels) * BYTES_PER_SAMPLE;
+        let file_size = data_size + WAV_HEADER_SIZE - RIFF_HEADER_PREFIX;
+
+        // Patch RIFF file size (offset 4)
+        self.writer.seek(SeekFrom::Start(RIFF_SIZE_OFFSET))?;
+        self.writer.write_all(&file_size.to_le_bytes())?;
+
+        // Patch data chunk size (offset 40)
+        self.writer.seek(SeekFrom::Start(DATA_SIZE_OFFSET))?;
+        self.writer.write_all(&data_size.to_le_bytes())?;
+
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+impl Drop for WavWriter {
+    fn drop(&mut self) {
+        if let Err(e) = self.finalize() {
+            tracing::warn!("WAV finalize failed: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// Compile-time validation of WAV constants.
+    const _: () = {
+        assert!(WAV_HEADER_SIZE == 44);
+        assert!(BITS_PER_SAMPLE == 32);
+        assert!(BYTES_PER_SAMPLE == 4);
+        assert!(RIFF_HEADER_PREFIX == 8);
+    };
+
+    #[test]
+    fn write_and_finalize_stereo_wav() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_stereo.wav");
+
+        let sample_rate = 48_000;
+        let channels = 2;
+        let samples = vec![
+            Stereo { l: 0.5, r: -0.5 },
+            Stereo { l: 0.25, r: -0.25 },
+            Stereo { l: 0.0, r: 0.0 },
+        ];
+
+        {
+            let mut writer = WavWriter::new(&path, sample_rate, channels).unwrap();
+            writer.write_stereo(&samples).unwrap();
+            // Drop finalizes
+        }
+
+        // Read back and verify header
+        let data = std::fs::read(&path).unwrap();
+        assert!(data.len() >= 44, "WAV file too short");
+
+        // RIFF header
+        assert_eq!(&data[0..4], b"RIFF");
+        assert_eq!(&data[8..12], b"WAVE");
+
+        // fmt chunk
+        assert_eq!(&data[12..16], b"fmt ");
+        let format = u16::from_le_bytes([data[20], data[21]]);
+        assert_eq!(format, WAV_FORMAT_IEEE_FLOAT);
+        let ch = u16::from_le_bytes([data[22], data[23]]);
+        assert_eq!(ch, channels);
+        let sr = u32::from_le_bytes([data[24], data[25], data[26], data[27]]);
+        assert_eq!(sr, sample_rate);
+
+        // data chunk
+        assert_eq!(&data[36..40], b"data");
+        let data_size = u32::from_le_bytes([data[40], data[41], data[42], data[43]]);
+        // 3 samples * 2 channels * 4 bytes = 24
+        assert_eq!(data_size, 24);
+
+        // RIFF size = data_size + 36
+        let riff_size = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+        assert_eq!(riff_size, data_size + 36);
+
+        // Verify sample data
+        let first_l = f32::from_le_bytes([data[44], data[45], data[46], data[47]]);
+        assert!((first_l - 0.5).abs() < f32::EPSILON);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn write_and_finalize_iq_wav() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_iq.wav");
+
+        let sample_rate = 2_400_000;
+        let channels = 2;
+        let samples = vec![Complex::new(1.0, 0.0), Complex::new(0.0, 1.0)];
+
+        {
+            let mut writer = WavWriter::new(&path, sample_rate, channels).unwrap();
+            writer.write_iq(&samples).unwrap();
+        }
+
+        let data = std::fs::read(&path).unwrap();
+        let data_size = u32::from_le_bytes([data[40], data[41], data[42], data[43]]);
+        // 2 samples * 2 channels * 4 bytes = 16
+        assert_eq!(data_size, 16);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn explicit_finalize_is_idempotent() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_idempotent.wav");
+
+        let mut writer = WavWriter::new(&path, 48_000, 2).unwrap();
+        writer.finalize().unwrap();
+        writer.finalize().unwrap(); // second call is a no-op
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn empty_wav_is_valid() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_empty.wav");
+
+        {
+            let _writer = WavWriter::new(&path, 48_000, 2).unwrap();
+        }
+
+        let data = std::fs::read(&path).unwrap();
+        assert_eq!(data.len(), 44); // header only
+        let data_size = u32::from_le_bytes([data[40], data[41], data[42], data[43]]);
+        assert_eq!(data_size, 0);
+        let riff_size = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+        assert_eq!(riff_size, 36);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+}

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -57,7 +57,7 @@ pub fn build_window(app: &adw::Application) {
     let (split_view, panels, spectrum_handle_raw, status_bar) = build_split_view(&state);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
     let sidebar_toggle = build_sidebar_toggle(&split_view);
-    let (header, play_button, demod_dropdown, freq_selector) =
+    let (header, play_button, demod_dropdown, freq_selector, screenshot_button) =
         build_header_bar(&sidebar_toggle, &state);
     let toolbar_view = build_toolbar_view(&header, &split_view);
     let breakpoint = build_breakpoint(&split_view);
@@ -114,6 +114,32 @@ pub fn build_window(app: &adw::Application) {
         &demod_dropdown,
         &status_bar_demod,
     );
+
+    // Wire waterfall screenshot button.
+    let spectrum_screenshot = Rc::clone(&spectrum_handle);
+    screenshot_button.connect_clicked(move |_| {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let dir = glib::user_special_dir(glib::UserDirectory::Pictures)
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let path = dir.join(format!("sdr-rs-waterfall-{timestamp}.png"));
+        match spectrum_screenshot.export_waterfall_png(&path) {
+            Ok(()) => {
+                tracing::info!(?path, "waterfall exported");
+                crate::notify::send(
+                    "Waterfall Exported",
+                    &format!("Saved to {}", path.display()),
+                    Some(&path),
+                );
+            }
+            Err(e) => {
+                tracing::warn!("waterfall export failed: {e}");
+                crate::notify::send("Export Failed", &e, None);
+            }
+        }
+    });
 
     // Wire cursor readout from spectrum to status bar.
     let status_bar_for_cursor = Rc::clone(&status_bar_demod);
@@ -376,6 +402,7 @@ fn build_header_bar(
     gtk4::ToggleButton,
     gtk4::DropDown,
     header::frequency_selector::FrequencySelector,
+    gtk4::Button,
 ) {
     // Play/stop button
     let play_button = gtk4::ToggleButton::builder()
@@ -444,10 +471,23 @@ fn build_header_bar(
     header.pack_start(sidebar_toggle);
     header.pack_start(&play_button);
     header.pack_start(&demod_dropdown);
+    // Waterfall screenshot button
+    let screenshot_button = gtk4::Button::builder()
+        .icon_name("camera-photo-symbolic")
+        .tooltip_text("Export waterfall to PNG")
+        .build();
+
     header.pack_end(&menu_button);
     header.pack_end(&volume_button);
+    header.pack_end(&screenshot_button);
 
-    (header, play_button, demod_dropdown.clone(), freq_selector)
+    (
+        header,
+        play_button,
+        demod_dropdown.clone(),
+        freq_selector,
+        screenshot_button,
+    )
 }
 
 /// Build the app menu button with Keyboard Shortcuts / About / Quit actions.
@@ -800,6 +840,7 @@ const AVERAGING_MODES: [spectrum::AveragingMode; 4] = [
 ];
 
 /// Connect display panel controls to DSP commands.
+#[allow(clippy::too_many_lines)]
 fn connect_display_panel(
     panels: &SidebarPanels,
     state: &Rc<AppState>,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -24,6 +24,9 @@ use crate::spectrum;
 use crate::state::AppState;
 use crate::status_bar::{self, StatusBar};
 
+/// Default recording directory under the user's home.
+const RECORDING_DIR_NAME: &str = "sdr-recordings";
+
 /// Default window width in pixels.
 const DEFAULT_WIDTH: i32 = 1200;
 /// Default window height in pixels.
@@ -161,6 +164,8 @@ pub fn build_window(app: &adw::Application) {
     let toast_overlay_weak = toast_overlay.downgrade();
 
     let gain_row_for_dsp = panels.source.gain_row.clone();
+    let record_audio_for_dsp = panels.audio.record_audio_row.clone();
+    let record_iq_for_dsp = panels.source.record_iq_row.clone();
     glib::timeout_add_local(Duration::from_millis(DSP_POLL_INTERVAL_MS), move || {
         // Check for new FFT data from the shared buffer (zero-alloc path).
         fft_shared.take_if_ready(|data| {
@@ -179,6 +184,8 @@ pub fn build_window(app: &adw::Application) {
                         &toast_overlay_weak,
                         &status_bar_demod,
                         &gain_row_for_dsp,
+                        &record_audio_for_dsp,
+                        &record_iq_for_dsp,
                     );
                 }
                 Err(mpsc::TryRecvError::Empty) => break,
@@ -195,6 +202,7 @@ pub fn build_window(app: &adw::Application) {
 }
 
 /// Handle a single message from the DSP thread.
+#[allow(clippy::too_many_arguments)]
 fn handle_dsp_message(
     msg: DspToUi,
     spectrum_handle: &Rc<spectrum::SpectrumHandle>,
@@ -203,6 +211,8 @@ fn handle_dsp_message(
     toast_overlay_weak: &glib::WeakRef<adw::ToastOverlay>,
     status_bar: &Rc<StatusBar>,
     gain_row: &adw::SpinRow,
+    record_audio_row: &adw::SwitchRow,
+    record_iq_row: &adw::SwitchRow,
 ) {
     match msg {
         DspToUi::FftData(_) => {
@@ -228,6 +238,9 @@ fn handle_dsp_message(
                 btn.set_active(false);
                 btn.set_icon_name("media-playback-start-symbolic");
             }
+            // Reset recording toggles when the source stops.
+            record_audio_row.set_active(false);
+            record_iq_row.set_active(false);
         }
         DspToUi::SampleRateChanged(rate) => {
             tracing::info!(effective_sample_rate = rate, "sample rate changed");
@@ -251,6 +264,42 @@ fn handle_dsp_message(
                 // Update the gain slider range to match the device's actual capabilities
                 gain_row.adjustment().set_lower(min);
                 gain_row.adjustment().set_upper(max);
+            }
+        }
+        DspToUi::AudioRecordingStarted(path) => {
+            tracing::info!(?path, "audio recording started");
+            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                let name = path
+                    .file_name()
+                    .map_or("file".to_string(), |n| n.to_string_lossy().to_string());
+                let toast = adw::Toast::new(&format!("Recording audio: {name}"));
+                overlay.add_toast(toast);
+            }
+        }
+        DspToUi::AudioRecordingStopped => {
+            tracing::info!("audio recording stopped");
+            record_audio_row.set_active(false);
+            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                let toast = adw::Toast::new("Audio recording saved");
+                overlay.add_toast(toast);
+            }
+        }
+        DspToUi::IqRecordingStarted(path) => {
+            tracing::info!(?path, "IQ recording started");
+            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                let name = path
+                    .file_name()
+                    .map_or("file".to_string(), |n| n.to_string_lossy().to_string());
+                let toast = adw::Toast::new(&format!("Recording IQ: {name}"));
+                overlay.add_toast(toast);
+            }
+        }
+        DspToUi::IqRecordingStopped => {
+            tracing::info!("IQ recording stopped");
+            record_iq_row.set_active(false);
+            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                let toast = adw::Toast::new("IQ recording saved");
+                overlay.add_toast(toast);
             }
         }
     }
@@ -620,6 +669,22 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         let path = std::path::PathBuf::from(row.text().to_string());
         state_file.send_dsp(UiToDsp::SetFilePath(path));
     });
+
+    // IQ recording toggle
+    let state_iq_rec = Rc::clone(state);
+    panels
+        .source
+        .record_iq_row
+        .connect_active_notify(move |row| {
+            if row.is_active() {
+                let path = recording_path("iq");
+                tracing::info!(?path, "starting IQ recording");
+                state_iq_rec.send_dsp(UiToDsp::StartIqRecording(path));
+            } else {
+                tracing::info!("stopping IQ recording");
+                state_iq_rec.send_dsp(UiToDsp::StopIqRecording);
+            }
+        });
 }
 
 /// Connect radio panel controls to DSP commands.
@@ -1150,6 +1215,22 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             state_dev.send_dsp(UiToDsp::SetAudioDevice(node_name.clone()));
         }
     });
+
+    // Audio recording toggle
+    let state_rec = Rc::clone(state);
+    panels
+        .audio
+        .record_audio_row
+        .connect_active_notify(move |row| {
+            if row.is_active() {
+                let path = recording_path("audio");
+                tracing::info!(?path, "starting audio recording");
+                state_rec.send_dsp(UiToDsp::StartAudioRecording(path));
+            } else {
+                tracing::info!("stopping audio recording");
+                state_rec.send_dsp(UiToDsp::StopAudioRecording);
+            }
+        });
 }
 
 /// Register application-level actions (About, Quit).
@@ -1199,4 +1280,20 @@ fn setup_app_actions(app: &adw::Application, window: &adw::ApplicationWindow) {
     ));
     app.add_action(&about_action);
     app.set_accels_for_action("app.about", &["F1"]);
+}
+
+/// Generate a timestamped recording file path.
+///
+/// Creates the recording directory if it doesn't exist.
+/// Returns a path like `~/sdr-recordings/audio-2026-04-08-173001.wav`.
+fn recording_path(prefix: &str) -> std::path::PathBuf {
+    let base = glib::home_dir().join(RECORDING_DIR_NAME);
+    if let Err(e) = std::fs::create_dir_all(&base) {
+        tracing::warn!("failed to create recording directory: {e}");
+    }
+    let now = glib::DateTime::now_local();
+    let timestamp = now
+        .and_then(|dt| dt.format("%Y-%m-%d-%H%M%S"))
+        .map_or_else(|_| "unknown".to_string(), |s| s.to_string());
+    base.join(format!("{prefix}-{timestamp}.wav"))
 }


### PR DESCRIPTION
## Summary

- **Audio recording (#137):** Stereo f32 WAV at 48 kHz. Toggle in audio panel, saves to `~/sdr-recordings/audio-{timestamp}.wav`. Records post-volume audio.
- **IQ recording (#138):** Raw IQ samples to WAV at source sample rate. Toggle in source panel. Full pre-decimation bandwidth.
- **Waterfall PNG export (#149):** Camera icon in header bar, saves to `~/Pictures/sdr-rs-waterfall-{timestamp}.png`.
- **Desktop notifications:** GNotification with click-to-open action via `app.open-uri`. Works with mac-dock-hyprland, mako, dunst, etc.

Closes #137, closes #138, closes #149

## Test plan
- [x] Toggle "Record Audio" — verify WAV created in ~/sdr-recordings/
- [x] Toggle "Record IQ" — verify WAV created with IQ data
- [x] Click camera icon — verify PNG saved, notification appears
- [x] Click notification — verify image opens in default viewer
- [x] Stop pipeline while recording — verify recording stops cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audio recording capability (48 kHz stereo WAV format)
  * Added IQ recording capability (raw IQ samples to WAV)
  * Added waterfall visualization export to PNG
  * Added recording toggle controls in settings panel
  * Added desktop notifications for recording and export completion
  * Added file browser integration to open recorded and exported files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->