### PR TITLE
RadioReference integration: SOAP client, preferences, frequency browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config \
             libgtk-4-dev libadwaita-1-dev libusb-1.0-0-dev \
-            libpipewire-0.3-dev libclang-dev
+            libpipewire-0.3-dev libclang-dev libdbus-1-dev
       - name: Install cargo tools
         run: cargo install --locked cargo-deny cargo-audit
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,10 +34,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -65,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +101,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cairo-rs"
@@ -175,6 +199,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,12 +238,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -246,6 +291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,8 +309,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -322,6 +376,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gio"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,7 +429,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -536,6 +617,208 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +826,22 @@ checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -559,6 +858,18 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -654,10 +965,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -688,6 +1011,17 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nix"
@@ -726,7 +1060,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -787,6 +1121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +1167,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "primal-check"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,12 +1212,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -890,6 +1347,60 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rusb"
@@ -929,6 +1440,53 @@ dependencies = [
  "strength_reduce",
  "transpose",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sdr"
@@ -991,6 +1549,18 @@ dependencies = [
  "sdr-dsp",
  "sdr-pipeline",
  "sdr-types",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "sdr-radioreference"
+version = "0.1.0"
+dependencies = [
+ "quick-xml",
+ "reqwest",
+ "sdr-types",
+ "serde",
  "thiserror",
  "tracing",
 ]
@@ -1155,6 +1725,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,10 +1764,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1196,6 +1800,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1244,6 +1868,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1296,6 +1969,51 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1369,6 +2087,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +2109,30 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -1405,10 +2153,136 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1420,12 +2294,256 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +893,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "dbus-secret-service",
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +945,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -1515,6 +1556,7 @@ dependencies = [
 name = "sdr-config"
 version = "0.1.0"
 dependencies = [
+ "keyring",
  "sdr-types",
  "serde",
  "serde_json",
@@ -2277,6 +2319,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -2512,6 +2563,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,6 +1695,7 @@ dependencies = [
  "sdr-dsp",
  "sdr-pipeline",
  "sdr-radio",
+ "sdr-radioreference",
  "sdr-rtlsdr",
  "sdr-sink-audio",
  "sdr-sink-network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "crates/sdr-sink-network",
     "crates/sdr-radio",
     "crates/sdr-config",
+    "crates/sdr-radioreference",
     "crates/sdr-ui",
 ]
 
@@ -67,7 +68,12 @@ sdr-sink-audio = { path = "crates/sdr-sink-audio" }
 sdr-sink-network = { path = "crates/sdr-sink-network" }
 sdr-radio = { path = "crates/sdr-radio" }
 sdr-config = { path = "crates/sdr-config" }
+sdr-radioreference = { path = "crates/sdr-radioreference" }
 sdr-ui = { path = "crates/sdr-ui" }
+
+# HTTP / XML (RadioReference)
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+quick-xml = "0.37"
 
 # Error handling
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ sdr-ui = { path = "crates/sdr-ui" }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 quick-xml = "0.37"
 
+# Secure credential storage
+keyring = { version = "3", features = ["sync-secret-service"] }
+
 # Error handling
 thiserror = "2"
 anyhow = "1"

--- a/crates/sdr-config/Cargo.toml
+++ b/crates/sdr-config/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+keyring.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-config/src/keyring_store.rs
+++ b/crates/sdr-config/src/keyring_store.rs
@@ -52,7 +52,13 @@ impl KeyringStore {
     }
 
     pub fn has(&self, key: &str) -> bool {
-        self.get(key).ok().flatten().is_some()
+        match self.get(key) {
+            Ok(val) => val.is_some(),
+            Err(e) => {
+                tracing::warn!(key, "keyring check failed: {e}");
+                false
+            }
+        }
     }
 
     fn entry(&self, key: &str) -> Result<keyring::Entry, KeyringError> {

--- a/crates/sdr-config/src/keyring_store.rs
+++ b/crates/sdr-config/src/keyring_store.rs
@@ -61,13 +61,9 @@ impl KeyringStore {
     }
 
     fn entry(&self, key: &str) -> Result<keyring::Entry, KeyringError> {
-        keyring::Entry::new(&self.service, key).map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("no default") || msg.contains("platform") {
-                KeyringError::NoBackend
-            } else {
-                KeyringError::Platform(msg)
-            }
+        keyring::Entry::new(&self.service, key).map_err(|e| match e {
+            keyring::Error::NoStorageAccess(_) => KeyringError::NoBackend,
+            other => KeyringError::Platform(other.to_string()),
         })
     }
 }

--- a/crates/sdr-config/src/keyring_store.rs
+++ b/crates/sdr-config/src/keyring_store.rs
@@ -1,0 +1,68 @@
+//! Secure credential storage via the OS keyring.
+//!
+//! Uses `keyring` crate which delegates to:
+//! - **Linux**: Secret Service D-Bus API (GNOME Keyring, `KeePassXC`)
+//! - **macOS**: Keychain
+
+/// Error type for keyring operations.
+#[derive(Debug, thiserror::Error)]
+pub enum KeyringError {
+    #[error("no secure storage available — install GNOME Keyring or KeePassXC")]
+    NoBackend,
+    #[error("credential not found")]
+    NotFound,
+    #[error("keyring error: {0}")]
+    Platform(String),
+}
+
+/// Thin wrapper around the OS keyring for storing secrets.
+pub struct KeyringStore {
+    service: String,
+}
+
+impl KeyringStore {
+    pub fn new(service: &str) -> Self {
+        Self {
+            service: service.to_string(),
+        }
+    }
+
+    pub fn set(&self, key: &str, value: &str) -> Result<(), KeyringError> {
+        let entry = self.entry(key)?;
+        entry
+            .set_password(value)
+            .map_err(|e| KeyringError::Platform(e.to_string()))
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<String>, KeyringError> {
+        let entry = self.entry(key)?;
+        match entry.get_password() {
+            Ok(val) => Ok(Some(val)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(KeyringError::Platform(e.to_string())),
+        }
+    }
+
+    pub fn delete(&self, key: &str) -> Result<(), KeyringError> {
+        let entry = self.entry(key)?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(KeyringError::Platform(e.to_string())),
+        }
+    }
+
+    pub fn has(&self, key: &str) -> bool {
+        self.get(key).ok().flatten().is_some()
+    }
+
+    fn entry(&self, key: &str) -> Result<keyring::Entry, KeyringError> {
+        keyring::Entry::new(&self.service, key).map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("no default") || msg.contains("platform") {
+                KeyringError::NoBackend
+            } else {
+                KeyringError::Platform(msg)
+            }
+        })
+    }
+}

--- a/crates/sdr-config/src/keyring_store.rs
+++ b/crates/sdr-config/src/keyring_store.rs
@@ -51,14 +51,13 @@ impl KeyringStore {
         }
     }
 
-    pub fn has(&self, key: &str) -> bool {
-        match self.get(key) {
-            Ok(val) => val.is_some(),
-            Err(e) => {
-                tracing::warn!(key, "keyring check failed: {e}");
-                false
-            }
-        }
+    /// Check whether a credential exists for the given key.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`KeyringError`] if the keyring backend is unavailable.
+    pub fn has(&self, key: &str) -> Result<bool, KeyringError> {
+        self.get(key).map(|val| val.is_some())
     }
 
     fn entry(&self, key: &str) -> Result<keyring::Entry, KeyringError> {

--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -3,6 +3,9 @@
 //! Ports SDR++ `ConfigManager`. Provides thread-safe JSON configuration
 //! with load, save, and auto-save functionality.
 
+pub mod keyring_store;
+pub use keyring_store::KeyringStore;
+
 use sdr_types::ConfigError;
 use serde_json::Value;
 use std::path::{Path, PathBuf};

--- a/crates/sdr-radioreference/Cargo.toml
+++ b/crates/sdr-radioreference/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sdr-radioreference"
+version = "0.1.0"
+description = "RadioReference.com SOAP API client"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+sdr-types.workspace = true
+reqwest.workspace = true
+quick-xml.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+serde.workspace = true
+
+[lints]
+workspace = true

--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod mode_map;
+pub mod soap;
+pub mod types;

--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -1,3 +1,59 @@
+//! `RadioReference.com` SOAP API client.
+//!
+//! Provides `RrClient` for querying the `RadioReference` frequency database.
+//! All methods are blocking — call from a background thread when used with GTK.
+
 pub mod mode_map;
 pub mod soap;
 pub mod types;
+
+pub use soap::SoapError;
+pub use types::{RrFrequency, RrTag, ZipInfo};
+
+/// Application API key — identifies the SDR-RS app to `RadioReference`.
+/// This is not a secret; it's distributed with the application.
+const APP_KEY: &str = "PENDING_API_KEY";
+
+/// `RadioReference` SOAP API client.
+///
+/// Holds user credentials and an HTTP client. All methods are blocking.
+pub struct RrClient {
+    auth: soap::SoapAuth,
+    http: reqwest::blocking::Client,
+}
+
+impl RrClient {
+    /// Create a new client with the given `RadioReference` credentials.
+    pub fn new(username: &str, password: &str) -> Self {
+        Self {
+            auth: soap::SoapAuth {
+                username: username.to_string(),
+                password: password.to_string(),
+                app_key: APP_KEY.to_string(),
+            },
+            http: reqwest::blocking::Client::new(),
+        }
+    }
+
+    /// Test the connection by querying zip code 90210.
+    ///
+    /// Returns `Ok(())` if credentials are valid, `Err` otherwise.
+    pub fn test_connection(&self) -> Result<(), SoapError> {
+        soap::get_zipcode_info(&self.http, &self.auth, "90210")?;
+        Ok(())
+    }
+
+    /// Look up county/state info for a US zip code.
+    pub fn get_zip_info(&self, zipcode: &str) -> Result<ZipInfo, SoapError> {
+        tracing::debug!(zipcode, "querying RadioReference zip info");
+        soap::get_zipcode_info(&self.http, &self.auth, zipcode)
+    }
+
+    /// Get all frequencies for a county.
+    ///
+    /// Calls `getCountyFreqsByTag` with `tag=0` to request all categories.
+    pub fn get_county_frequencies(&self, county_id: u32) -> Result<Vec<RrFrequency>, SoapError> {
+        tracing::debug!(county_id, "querying RadioReference county frequencies");
+        soap::get_county_freqs_by_tag(&self.http, &self.auth, county_id, 0)
+    }
+}

--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -12,7 +12,13 @@ pub use types::{RrFrequency, RrTag, ZipInfo};
 
 /// Application API key — identifies the SDR-RS app to `RadioReference`.
 /// This is not a secret; it's distributed with the application.
-const APP_KEY: &str = "PENDING_API_KEY";
+///
+/// Set via `RADIOREFERENCE_APP_KEY` env var at build time, or defaults to a
+/// placeholder that will fail at runtime with an auth error.
+const APP_KEY: &str = match option_env!("RADIOREFERENCE_APP_KEY") {
+    Some(key) => key,
+    None => "PENDING_API_KEY",
+};
 
 /// `RadioReference` SOAP API client.
 ///
@@ -23,16 +29,25 @@ pub struct RrClient {
 }
 
 impl RrClient {
-    /// Create a new client with the given `RadioReference` credentials.
-    pub fn new(username: &str, password: &str) -> Self {
-        Self {
+    ///
+    /// Configures HTTP timeouts to prevent indefinite hangs.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SoapError`] if the HTTP client cannot be constructed.
+    pub fn new(username: &str, password: &str) -> Result<Self, SoapError> {
+        let http = reqwest::blocking::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
+        Ok(Self {
             auth: soap::SoapAuth {
                 username: username.to_string(),
                 password: password.to_string(),
                 app_key: APP_KEY.to_string(),
             },
-            http: reqwest::blocking::Client::new(),
-        }
+            http,
+        })
     }
 
     /// Test the connection by querying zip code 90210.

--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod mode_map;

--- a/crates/sdr-radioreference/src/mode_map.rs
+++ b/crates/sdr-radioreference/src/mode_map.rs
@@ -48,7 +48,10 @@ pub fn map_rr_mode(rr_mode: &str) -> MappedMode {
             bandwidth: CW_BW,
         },
         _ => {
-            tracing::warn!(mode = rr_mode, "unknown RadioReference mode, defaulting to NFM");
+            tracing::warn!(
+                mode = rr_mode,
+                "unknown RadioReference mode, defaulting to NFM"
+            );
             MappedMode {
                 demod_mode: "NFM",
                 bandwidth: NFM_BW,

--- a/crates/sdr-radioreference/src/mode_map.rs
+++ b/crates/sdr-radioreference/src/mode_map.rs
@@ -1,0 +1,143 @@
+//! Maps `RadioReference` mode strings to SDR demodulator modes and bandwidths.
+
+/// The result of mapping a `RadioReference` mode string to an SDR demodulator
+/// mode and bandwidth.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MappedMode {
+    /// SDR demodulator mode (e.g. "NFM", "WFM", "AM", "USB", "LSB", "CW").
+    pub demod_mode: &'static str,
+    /// Channel bandwidth in Hz.
+    pub bandwidth: f64,
+}
+
+/// Bandwidth constants (Hz).
+const NFM_BW: f64 = 12_500.0;
+const WFM_BW: f64 = 150_000.0;
+const AM_BW: f64 = 10_000.0;
+const SSB_BW: f64 = 2_800.0;
+const CW_BW: f64 = 500.0;
+
+/// Maps a `RadioReference` mode string to the corresponding SDR demodulator mode
+/// and bandwidth.
+///
+/// Matching is case-insensitive. Unknown modes default to NFM at 12 500 Hz.
+pub fn map_rr_mode(rr_mode: &str) -> MappedMode {
+    match rr_mode.to_uppercase().as_str() {
+        "FM" | "FMN" => MappedMode {
+            demod_mode: "NFM",
+            bandwidth: NFM_BW,
+        },
+        "FMW" => MappedMode {
+            demod_mode: "WFM",
+            bandwidth: WFM_BW,
+        },
+        "AM" => MappedMode {
+            demod_mode: "AM",
+            bandwidth: AM_BW,
+        },
+        "USB" => MappedMode {
+            demod_mode: "USB",
+            bandwidth: SSB_BW,
+        },
+        "LSB" => MappedMode {
+            demod_mode: "LSB",
+            bandwidth: SSB_BW,
+        },
+        "CW" => MappedMode {
+            demod_mode: "CW",
+            bandwidth: CW_BW,
+        },
+        _ => {
+            tracing::warn!(mode = rr_mode, "unknown RadioReference mode, defaulting to NFM");
+            MappedMode {
+                demod_mode: "NFM",
+                bandwidth: NFM_BW,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fm_maps_to_nfm() {
+        let m = map_rr_mode("FM");
+        assert_eq!(m.demod_mode, "NFM");
+        assert!((m.bandwidth - 12_500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn fmn_maps_to_nfm() {
+        let m = map_rr_mode("FMN");
+        assert_eq!(m.demod_mode, "NFM");
+        assert!((m.bandwidth - 12_500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn fmw_maps_to_wfm() {
+        let m = map_rr_mode("FMW");
+        assert_eq!(m.demod_mode, "WFM");
+        assert!((m.bandwidth - 150_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn am_maps_to_am() {
+        let m = map_rr_mode("AM");
+        assert_eq!(m.demod_mode, "AM");
+        assert!((m.bandwidth - 10_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn usb_maps_to_usb() {
+        let m = map_rr_mode("USB");
+        assert_eq!(m.demod_mode, "USB");
+        assert!((m.bandwidth - 2_800.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lsb_maps_to_lsb() {
+        let m = map_rr_mode("LSB");
+        assert_eq!(m.demod_mode, "LSB");
+        assert!((m.bandwidth - 2_800.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cw_maps_to_cw() {
+        let m = map_rr_mode("CW");
+        assert_eq!(m.demod_mode, "CW");
+        assert!((m.bandwidth - 500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn unknown_mode_defaults_to_nfm() {
+        let m = map_rr_mode("P25");
+        assert_eq!(m.demod_mode, "NFM");
+        assert!((m.bandwidth - 12_500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn case_insensitive_lowercase() {
+        let m = map_rr_mode("fm");
+        assert_eq!(m.demod_mode, "NFM");
+    }
+
+    #[test]
+    fn case_insensitive_mixed_case() {
+        let m = map_rr_mode("Fmw");
+        assert_eq!(m.demod_mode, "WFM");
+    }
+
+    #[test]
+    fn case_insensitive_am_lower() {
+        let m = map_rr_mode("am");
+        assert_eq!(m.demod_mode, "AM");
+    }
+
+    #[test]
+    fn case_insensitive_cw_lower() {
+        let m = map_rr_mode("cw");
+        assert_eq!(m.demod_mode, "CW");
+    }
+}

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -1,0 +1,690 @@
+//! SOAP envelope builder, HTTP transport, and XML response parsers for the
+//! `RadioReference` API.
+
+use std::borrow::Cow;
+use std::io::Cursor;
+
+use quick_xml::events::{BytesDecl, BytesText, Event};
+use quick_xml::Reader;
+use quick_xml::Writer;
+use reqwest::blocking::Client;
+
+use crate::types::{RrFrequency, RrTag, ZipInfo};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// `RadioReference` SOAP endpoint URL.
+const SOAP_ENDPOINT: &str = "https://api.radioreference.com/soap2/index.php";
+
+/// API version sent in every request.
+const API_VERSION: &str = "18";
+
+// XML namespace constants
+const NS_SOAP_ENV: &str = "http://schemas.xmlsoap.org/soap/envelope/";
+const NS_SOAP_ENC: &str = "http://schemas.xmlsoap.org/soap/encoding/";
+const NS_XSI: &str = "http://www.w3.org/2001/XMLSchema-instance";
+const NS_XSD: &str = "http://www.w3.org/2001/XMLSchema";
+const NS_TNS: &str = "http://api.radioreference.com/soap2";
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur during SOAP communication.
+#[derive(Debug, thiserror::Error)]
+pub enum SoapError {
+    /// HTTP transport error.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// XML parsing error.
+    #[error("XML error: {0}")]
+    Xml(#[from] quick_xml::Error),
+
+    /// I/O error during XML writing.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The server returned a SOAP fault.
+    #[error("SOAP fault: {0}")]
+    Fault(String),
+
+    /// Unexpected response structure.
+    #[error("unexpected response: {0}")]
+    Unexpected(String),
+
+    /// Authentication failed.
+    #[error("authentication failed")]
+    AuthFailed,
+}
+
+// quick-xml attribute errors can surface during parsing.
+impl From<quick_xml::events::attributes::AttrError> for SoapError {
+    fn from(e: quick_xml::events::attributes::AttrError) -> Self {
+        Self::Xml(quick_xml::Error::InvalidAttr(e))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+/// Credentials used for every `RadioReference` API call.
+#[derive(Debug, Clone)]
+pub struct SoapAuth {
+    /// `RadioReference` username.
+    pub username: String,
+    /// `RadioReference` password.
+    pub password: String,
+    /// Application key issued by `RadioReference`.
+    pub app_key: String,
+}
+
+// ---------------------------------------------------------------------------
+// Envelope builder helpers
+// ---------------------------------------------------------------------------
+
+/// Builds a complete SOAP XML envelope for the given `method`.
+///
+/// `body_fn` is a closure that writes method-specific parameter elements into
+/// the method body (the writer is positioned inside the `<tns:method>` element).
+/// Auth info is appended automatically after `body_fn` returns.
+pub fn build_envelope<F>(method: &str, auth: &SoapAuth, body_fn: F) -> Result<String, SoapError>
+where
+    F: FnOnce(&mut Writer<Cursor<Vec<u8>>>) -> Result<(), SoapError>,
+{
+    let mut writer = Writer::new(Cursor::new(Vec::new()));
+
+    // XML declaration
+    writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
+
+    // Build the body XML with the method call
+    let method_tag = format!("tns:{method}");
+    writer
+        .create_element("SOAP-ENV:Envelope")
+        .with_attribute(("xmlns:SOAP-ENV", NS_SOAP_ENV))
+        .with_attribute(("xmlns:SOAP-ENC", NS_SOAP_ENC))
+        .with_attribute(("xmlns:xsi", NS_XSI))
+        .with_attribute(("xmlns:xsd", NS_XSD))
+        .with_attribute(("xmlns:tns", NS_TNS))
+        .write_inner_content(|w| {
+            w.create_element("SOAP-ENV:Body")
+                .write_inner_content(|w| {
+                    w.create_element(&*method_tag)
+                        .write_inner_content(|w| {
+                            body_fn(w).map_err(|e| {
+                                std::io::Error::other(e.to_string())
+                            })?;
+                            write_auth_info(w, auth)?;
+                            Ok(())
+                        })?;
+                    Ok(())
+                })?;
+            Ok(())
+        })?;
+
+    let buf = writer.into_inner().into_inner();
+    String::from_utf8(buf).map_err(|e| SoapError::Unexpected(e.to_string()))
+}
+
+/// Writes the `<authInfo>` block with `appKey`, `username`, `password`,
+/// `version`, and `style` elements.
+fn write_auth_info(
+    writer: &mut Writer<Cursor<Vec<u8>>>,
+    auth: &SoapAuth,
+) -> std::io::Result<()> {
+    writer
+        .create_element("authInfo")
+        .with_attribute(("xsi:type", "tns:authInfo"))
+        .write_inner_content(|w| {
+            write_typed_element(w, "appKey", "xsd:string", &auth.app_key)?;
+            write_typed_element(w, "username", "xsd:string", &auth.username)?;
+            write_typed_element(w, "password", "xsd:string", &auth.password)?;
+            write_typed_element(w, "version", "xsd:string", API_VERSION)?;
+            write_typed_element(w, "style", "xsd:string", "rpc")?;
+            Ok(())
+        })?;
+    Ok(())
+}
+
+/// Writes `<name xsi:type="type">value</name>`.
+fn write_typed_element(
+    writer: &mut Writer<Cursor<Vec<u8>>>,
+    name: &str,
+    xsi_type: &str,
+    value: &str,
+) -> std::io::Result<()> {
+    writer
+        .create_element(name)
+        .with_attribute(("xsi:type", xsi_type))
+        .write_text_content(BytesText::new(value))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// HTTP transport
+// ---------------------------------------------------------------------------
+
+/// Posts the SOAP envelope to the `RadioReference` endpoint and returns the
+/// response body as a string.  Checks for SOAP faults before returning.
+pub fn send_request(client: &Client, envelope: &str) -> Result<String, SoapError> {
+    let resp = client
+        .post(SOAP_ENDPOINT)
+        .header("Content-Type", "text/xml; charset=utf-8")
+        .body(envelope.to_owned())
+        .send()?
+        .text()?;
+
+    if let Some(fault) = extract_soap_fault(&resp) {
+        if fault.contains("Authentication")
+            || fault.contains("auth")
+            || fault.contains("login")
+        {
+            return Err(SoapError::AuthFailed);
+        }
+        return Err(SoapError::Fault(fault));
+    }
+
+    Ok(resp)
+}
+
+/// Extracts the `<faultstring>` text from a SOAP fault response, if present.
+pub fn extract_soap_fault(xml: &str) -> Option<String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut inside_fault_string = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => {
+                let name = e.name();
+                let local = local_name(name.as_ref());
+                if local == b"faultstring" {
+                    inside_fault_string = true;
+                }
+            }
+            Ok(Event::Text(ref e)) if inside_fault_string => {
+                return e.unescape().ok().map(Cow::into_owned);
+            }
+            Ok(Event::Eof) | Err(_) => return None,
+            _ => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public operations
+// ---------------------------------------------------------------------------
+
+/// Looks up ZIP code information (county, state, city) via the
+/// `getZipcodeInfo` SOAP method.
+pub fn get_zipcode_info(
+    client: &Client,
+    auth: &SoapAuth,
+    zipcode: &str,
+) -> Result<ZipInfo, SoapError> {
+    let envelope = build_envelope("getZipcodeInfo", auth, |w| {
+        write_typed_element(w, "zipcode", "xsd:int", zipcode)?;
+        Ok(())
+    })?;
+
+    let body = send_request(client, &envelope)?;
+    parse_zip_info(&body)
+}
+
+/// Fetches frequencies for a county filtered by tag via the
+/// `getCountyFreqsByTag` SOAP method.
+pub fn get_county_freqs_by_tag(
+    client: &Client,
+    auth: &SoapAuth,
+    county_id: u32,
+    tag: u32,
+) -> Result<Vec<RrFrequency>, SoapError> {
+    let county_str = county_id.to_string();
+    let tag_str = tag.to_string();
+
+    let envelope = build_envelope("getCountyFreqsByTag", auth, |w| {
+        write_typed_element(w, "ctid", "xsd:int", &county_str)?;
+        write_typed_element(w, "tag", "xsd:int", &tag_str)?;
+        Ok(())
+    })?;
+
+    let body = send_request(client, &envelope)?;
+    parse_frequencies(&body)
+}
+
+// ---------------------------------------------------------------------------
+// XML parsers
+// ---------------------------------------------------------------------------
+
+/// Extracts the local name from a potentially namespace-prefixed element name.
+/// For example, `ns1:faultstring` becomes `faultstring`.
+fn local_name(full: &[u8]) -> &[u8] {
+    full.iter()
+        .position(|&b| b == b':')
+        .map_or(full, |pos| &full[pos + 1..])
+}
+
+/// Reads the text content of the current element (caller has just seen
+/// `Event::Start` for this element).
+fn read_text_content<'a>(reader: &mut Reader<&'a [u8]>) -> Result<Cow<'a, str>, SoapError> {
+    let mut text = String::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Text(e)) => {
+                let unescaped = e.unescape()?;
+                text.push_str(&unescaped);
+            }
+            Ok(Event::End(_)) => break,
+            Ok(Event::Eof) => {
+                return Err(SoapError::Unexpected(
+                    "unexpected EOF while reading element text".into(),
+                ));
+            }
+            Err(e) => return Err(SoapError::Xml(e)),
+            _ => {}
+        }
+    }
+    Ok(Cow::Owned(text))
+}
+
+/// Parses a `getZipcodeInfo` response and returns the extracted `ZipInfo`.
+pub fn parse_zip_info(xml: &str) -> Result<ZipInfo, SoapError> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut county_id: Option<u32> = None;
+    let mut state_id: Option<u32> = None;
+    let mut city: Option<String> = None;
+    let mut county_name: Option<String> = None;
+    let mut state_name: Option<String> = None;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => {
+                let name = e.name();
+                let local = local_name(name.as_ref());
+                match local {
+                    b"ctid" => {
+                        let t = read_text_content(&mut reader)?;
+                        county_id = Some(
+                            t.parse::<u32>()
+                                .map_err(|e| SoapError::Unexpected(format!("bad ctid: {e}")))?,
+                        );
+                    }
+                    b"stid" => {
+                        let t = read_text_content(&mut reader)?;
+                        state_id = Some(
+                            t.parse::<u32>()
+                                .map_err(|e| SoapError::Unexpected(format!("bad stid: {e}")))?,
+                        );
+                    }
+                    b"city" => {
+                        city = Some(read_text_content(&mut reader)?.into_owned());
+                    }
+                    b"countyName" => {
+                        county_name = Some(read_text_content(&mut reader)?.into_owned());
+                    }
+                    b"stateName" => {
+                        state_name = Some(read_text_content(&mut reader)?.into_owned());
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(SoapError::Xml(e)),
+            _ => {}
+        }
+    }
+
+    Ok(ZipInfo {
+        county_id: county_id
+            .ok_or_else(|| SoapError::Unexpected("missing ctid".into()))?,
+        state_id: state_id
+            .ok_or_else(|| SoapError::Unexpected("missing stid".into()))?,
+        city: city.ok_or_else(|| SoapError::Unexpected("missing city".into()))?,
+        county_name: county_name
+            .ok_or_else(|| SoapError::Unexpected("missing countyName".into()))?,
+        state_name: state_name
+            .ok_or_else(|| SoapError::Unexpected("missing stateName".into()))?,
+    })
+}
+
+/// Tracks nesting depth when parsing frequency responses, distinguishing
+/// top-level `<item>` (frequency) from nested `<item>` (tag inside `<tags>`).
+#[derive(Debug, PartialEq, Eq)]
+enum FreqParseState {
+    TopLevel,
+    InFreqItem,
+    InTags,
+    InTagItem,
+}
+
+/// Accumulator for building a single frequency from streamed XML events.
+#[derive(Default)]
+struct FreqBuilder {
+    fid: Option<String>,
+    freq_mhz: Option<f64>,
+    mode: Option<String>,
+    tone_val: Option<f32>,
+    description: Option<String>,
+    alpha_tag: Option<String>,
+    tags: Vec<RrTag>,
+    tag_id: Option<u32>,
+    tag_descr: Option<String>,
+}
+
+impl FreqBuilder {
+    /// Resets all fields for a new frequency `<item>`.
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Consumes accumulated fields and returns a finished `RrFrequency`.
+    fn finish(&mut self) -> RrFrequency {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let hz = self
+            .freq_mhz
+            .map_or(0, |mhz| (mhz * 1_000_000.0).round() as u64);
+
+        let tone = self.tone_val.and_then(|t| {
+            #[allow(clippy::float_cmp)]
+            if t == 0.0 { None } else { Some(t) }
+        });
+
+        RrFrequency {
+            id: self.fid.take().unwrap_or_default(),
+            freq_hz: hz,
+            mode: self.mode.take().unwrap_or_default(),
+            tone,
+            description: self.description.take().unwrap_or_default(),
+            alpha_tag: self.alpha_tag.take().unwrap_or_default(),
+            tags: std::mem::take(&mut self.tags),
+        }
+    }
+
+    /// Pushes the current tag accumulator into the tags list.
+    fn push_tag(&mut self) {
+        self.tags.push(RrTag {
+            id: self.tag_id.unwrap_or(0),
+            description: self.tag_descr.take().unwrap_or_default(),
+        });
+    }
+
+    /// Handles a `Start` event while inside a frequency `<item>`.
+    fn handle_freq_field(
+        &mut self,
+        local: &[u8],
+        reader: &mut Reader<&[u8]>,
+    ) -> Result<Option<FreqParseState>, SoapError> {
+        match local {
+            b"fid" => self.fid = Some(read_text_content(reader)?.into_owned()),
+            b"out" => {
+                let t = read_text_content(reader)?;
+                self.freq_mhz = Some(
+                    t.parse::<f64>()
+                        .map_err(|e| SoapError::Unexpected(format!("bad frequency: {e}")))?,
+                );
+            }
+            b"mode" => self.mode = Some(read_text_content(reader)?.into_owned()),
+            b"tone" => {
+                let t = read_text_content(reader)?;
+                self.tone_val = Some(
+                    t.parse::<f32>()
+                        .map_err(|e| SoapError::Unexpected(format!("bad tone: {e}")))?,
+                );
+            }
+            b"descr" => self.description = Some(read_text_content(reader)?.into_owned()),
+            b"alpha" => self.alpha_tag = Some(read_text_content(reader)?.into_owned()),
+            b"tags" => return Ok(Some(FreqParseState::InTags)),
+            _ => {}
+        }
+        Ok(None)
+    }
+
+    /// Handles a `Start` event while inside a tag `<item>`.
+    fn handle_tag_field(
+        &mut self,
+        local: &[u8],
+        reader: &mut Reader<&[u8]>,
+    ) -> Result<(), SoapError> {
+        match local {
+            b"tagId" => {
+                let t = read_text_content(reader)?;
+                self.tag_id = Some(
+                    t.parse::<u32>()
+                        .map_err(|e| SoapError::Unexpected(format!("bad tagId: {e}")))?,
+                );
+            }
+            b"tagDescr" => self.tag_descr = Some(read_text_content(reader)?.into_owned()),
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+/// Parses a `getCountyFreqsByTag` (or similar) response containing a list of
+/// frequency `<item>` elements.
+///
+/// The `out` field in the response is in MHz and is converted to Hz via
+/// `(mhz * 1_000_000.0).round() as u64`.  A `tone` value of `0` is mapped to
+/// `None`.
+pub fn parse_frequencies(xml: &str) -> Result<Vec<RrFrequency>, SoapError> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut frequencies: Vec<RrFrequency> = Vec::new();
+    let mut state = FreqParseState::TopLevel;
+    let mut builder = FreqBuilder::default();
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => {
+                let name = e.name();
+                let local = local_name(name.as_ref());
+                match state {
+                    FreqParseState::TopLevel if local == b"item" => {
+                        state = FreqParseState::InFreqItem;
+                        builder.reset();
+                    }
+                    FreqParseState::InFreqItem => {
+                        if let Some(new) = builder.handle_freq_field(local, &mut reader)? {
+                            state = new;
+                        }
+                    }
+                    FreqParseState::InTags if local == b"item" => {
+                        state = FreqParseState::InTagItem;
+                        builder.tag_id = None;
+                        builder.tag_descr = None;
+                    }
+                    FreqParseState::InTagItem => {
+                        builder.handle_tag_field(local, &mut reader)?;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let name = e.name();
+                let local = local_name(name.as_ref());
+                match state {
+                    FreqParseState::InTagItem if local == b"item" => {
+                        builder.push_tag();
+                        state = FreqParseState::InTags;
+                    }
+                    FreqParseState::InTags if local == b"tags" => {
+                        state = FreqParseState::InFreqItem;
+                    }
+                    FreqParseState::InFreqItem if local == b"item" => {
+                        frequencies.push(builder.finish());
+                        state = FreqParseState::TopLevel;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(SoapError::Xml(e)),
+            _ => {}
+        }
+    }
+
+    Ok(frequencies)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Canned SOAP response for `getZipcodeInfo` -- ZIP 90210 (Beverly Hills).
+    const ZIP_RESPONSE_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:ns1="http://api.radioreference.com/soap2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+  <SOAP-ENV:Body>
+    <ns1:getZipcodeInfoResponse>
+      <return xsi:type="ns1:ZipcodeInfo">
+        <ctid xsi:type="xsd:int">277</ctid>
+        <stid xsi:type="xsd:int">6</stid>
+        <city xsi:type="xsd:string">Beverly Hills</city>
+        <countyName xsi:type="xsd:string">Los Angeles</countyName>
+        <stateName xsi:type="xsd:string">California</stateName>
+      </return>
+    </ns1:getZipcodeInfoResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"#;
+
+    /// Canned SOAP response for `getCountyFreqsByTag` with two frequency items.
+    const FREQS_RESPONSE_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:ns1="http://api.radioreference.com/soap2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+  <SOAP-ENV:Body>
+    <ns1:getCountyFreqsByTagResponse>
+      <return SOAP-ENC:arrayType="ns1:CountyFreq[2]" xsi:type="SOAP-ENC:Array">
+        <item xsi:type="ns1:CountyFreq">
+          <fid xsi:type="xsd:string">12345</fid>
+          <out xsi:type="xsd:float">155.475</out>
+          <mode xsi:type="xsd:string">FM</mode>
+          <tone xsi:type="xsd:float">110.9</tone>
+          <descr xsi:type="xsd:string">City Police Dispatch</descr>
+          <alpha xsi:type="xsd:string">PD Disp</alpha>
+          <tags SOAP-ENC:arrayType="ns1:TagInfo[1]" xsi:type="SOAP-ENC:Array">
+            <item xsi:type="ns1:TagInfo">
+              <tagId xsi:type="xsd:int">1</tagId>
+              <tagDescr xsi:type="xsd:string">Law Dispatch</tagDescr>
+            </item>
+          </tags>
+        </item>
+        <item xsi:type="ns1:CountyFreq">
+          <fid xsi:type="xsd:string">67890</fid>
+          <out xsi:type="xsd:float">154.28</out>
+          <mode xsi:type="xsd:string">FMN</mode>
+          <tone xsi:type="xsd:float">0</tone>
+          <descr xsi:type="xsd:string">County Fire Tac</descr>
+          <alpha xsi:type="xsd:string">FD Tac</alpha>
+          <tags SOAP-ENC:arrayType="ns1:TagInfo[1]" xsi:type="SOAP-ENC:Array">
+            <item xsi:type="ns1:TagInfo">
+              <tagId xsi:type="xsd:int">2</tagId>
+              <tagDescr xsi:type="xsd:string">Fire Tac</tagDescr>
+            </item>
+          </tags>
+        </item>
+      </return>
+    </ns1:getCountyFreqsByTagResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"#;
+
+    /// Canned SOAP fault response.
+    const FAULT_RESPONSE_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <SOAP-ENV:Fault>
+      <faultcode>SOAP-ENV:Server</faultcode>
+      <faultstring>Invalid API key</faultstring>
+    </SOAP-ENV:Fault>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"#;
+
+    /// Canned success response (no fault) -- reuse the ZIP response.
+    const SUCCESS_RESPONSE_XML: &str = ZIP_RESPONSE_XML;
+
+    #[test]
+    fn parse_zip_info_response() {
+        let info = parse_zip_info(ZIP_RESPONSE_XML).expect("should parse zip info");
+        assert_eq!(info.county_id, 277);
+        assert_eq!(info.state_id, 6);
+        assert_eq!(info.city, "Beverly Hills");
+        assert_eq!(info.county_name, "Los Angeles");
+        assert_eq!(info.state_name, "California");
+    }
+
+    #[test]
+    fn parse_frequencies_response() {
+        let freqs = parse_frequencies(FREQS_RESPONSE_XML).expect("should parse frequencies");
+        assert_eq!(freqs.len(), 2);
+
+        // First frequency -- 155.475 MHz with tone 110.9
+        let f1 = &freqs[0];
+        assert_eq!(f1.id, "12345");
+        assert_eq!(f1.freq_hz, 155_475_000);
+        assert_eq!(f1.mode, "FM");
+        assert_eq!(f1.tone, Some(110.9));
+        assert_eq!(f1.description, "City Police Dispatch");
+        assert_eq!(f1.alpha_tag, "PD Disp");
+        assert_eq!(f1.tags.len(), 1);
+        assert_eq!(f1.tags[0].id, 1);
+        assert_eq!(f1.tags[0].description, "Law Dispatch");
+
+        // Second frequency -- 154.28 MHz with tone 0 (should be None)
+        let f2 = &freqs[1];
+        assert_eq!(f2.id, "67890");
+        assert_eq!(f2.freq_hz, 154_280_000);
+        assert_eq!(f2.mode, "FMN");
+        assert_eq!(f2.tone, None);
+        assert_eq!(f2.description, "County Fire Tac");
+        assert_eq!(f2.alpha_tag, "FD Tac");
+        assert_eq!(f2.tags.len(), 1);
+        assert_eq!(f2.tags[0].id, 2);
+        assert_eq!(f2.tags[0].description, "Fire Tac");
+    }
+
+    #[test]
+    fn extract_fault_from_response() {
+        let fault = extract_soap_fault(FAULT_RESPONSE_XML);
+        assert_eq!(fault.as_deref(), Some("Invalid API key"));
+    }
+
+    #[test]
+    fn no_fault_in_success_response() {
+        let fault = extract_soap_fault(SUCCESS_RESPONSE_XML);
+        assert!(fault.is_none());
+    }
+
+    #[test]
+    fn envelope_contains_auth_info() {
+        let auth = SoapAuth {
+            username: "testuser".into(),
+            password: "testpass".into(),
+            app_key: "testkey123".into(),
+        };
+        let envelope =
+            build_envelope("getZipcodeInfo", &auth, |_w| Ok(())).expect("should build envelope");
+
+        assert!(envelope.contains("testuser"), "missing username");
+        assert!(envelope.contains("testpass"), "missing password");
+        assert!(envelope.contains("testkey123"), "missing appKey");
+        assert!(envelope.contains("tns:getZipcodeInfo"), "missing method");
+        assert!(envelope.contains("authInfo"), "missing authInfo element");
+        assert!(envelope.contains(API_VERSION), "missing version");
+    }
+}

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -72,7 +72,7 @@ impl From<quick_xml::events::attributes::AttrError> for SoapError {
 // ---------------------------------------------------------------------------
 
 /// Credentials used for every `RadioReference` API call.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SoapAuth {
     /// `RadioReference` username.
     pub username: String,
@@ -80,6 +80,16 @@ pub struct SoapAuth {
     pub password: String,
     /// Application key issued by `RadioReference`.
     pub app_key: String,
+}
+
+impl std::fmt::Debug for SoapAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SoapAuth")
+            .field("username", &self.username)
+            .field("password", &"[REDACTED]")
+            .field("app_key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -177,17 +177,27 @@ pub fn send_request(client: &Client, envelope: &str) -> Result<String, SoapError
         .post(SOAP_ENDPOINT)
         .header("Content-Type", "text/xml; charset=utf-8")
         .body(envelope.to_owned())
-        .send()?
-        .text()?;
+        .send()?;
 
-    if let Some(fault) = extract_soap_fault(&resp) {
+    let status = resp.status();
+    let body = resp.text()?;
+
+    // Check for SOAP faults first — the server may return a fault inside
+    // either a 200 or a 500 response.
+    if let Some(fault) = extract_soap_fault(&body) {
         if fault.contains("Authentication") || fault.contains("auth") || fault.contains("login") {
             return Err(SoapError::AuthFailed);
         }
         return Err(SoapError::Fault(fault));
     }
 
-    Ok(resp)
+    // Reject non-success HTTP responses that weren't SOAP faults (e.g.,
+    // HTML error pages, 503s).
+    if !status.is_success() {
+        return Err(SoapError::Unexpected(format!("HTTP {status}")));
+    }
+
+    Ok(body)
 }
 
 /// Extracts the `<faultstring>` text from a SOAP fault response, if present.

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -436,10 +436,13 @@ impl FreqBuilder {
             b"fid" => self.fid = Some(read_text_content(reader)?.into_owned()),
             b"out" => {
                 let t = read_text_content(reader)?;
-                self.freq_mhz = Some(
-                    t.parse::<f64>()
-                        .map_err(|e| SoapError::Unexpected(format!("bad frequency: {e}")))?,
-                );
+                let mhz = t
+                    .parse::<f64>()
+                    .map_err(|e| SoapError::Unexpected(format!("bad frequency: {e}")))?;
+                if !mhz.is_finite() || mhz <= 0.0 {
+                    return Err(SoapError::Unexpected(format!("invalid frequency: {mhz}")));
+                }
+                self.freq_mhz = Some(mhz);
             }
             b"mode" => self.mode = Some(read_text_content(reader)?.into_owned()),
             b"tone" => {

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -391,26 +391,31 @@ impl FreqBuilder {
     }
 
     /// Consumes accumulated fields and returns a finished `RrFrequency`.
-    fn finish(&mut self) -> RrFrequency {
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let hz = self
-            .freq_mhz
-            .map_or(0, |mhz| (mhz * 1_000_000.0).round() as u64);
+    ///
+    /// Returns `None` if required fields (`fid`, `out`, `mode`) are missing,
+    /// logging a warning rather than producing a bogus entry.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn finish(&mut self) -> Option<RrFrequency> {
+        let fid = self.fid.take()?;
+        let freq_mhz = self.freq_mhz?;
+        let mode = self.mode.take()?;
+
+        let hz = (freq_mhz * 1_000_000.0).round() as u64;
 
         let tone = self.tone_val.and_then(|t| {
             #[allow(clippy::float_cmp)]
             if t == 0.0 { None } else { Some(t) }
         });
 
-        RrFrequency {
-            id: self.fid.take().unwrap_or_default(),
+        Some(RrFrequency {
+            id: fid,
             freq_hz: hz,
-            mode: self.mode.take().unwrap_or_default(),
+            mode,
             tone,
             description: self.description.take().unwrap_or_default(),
             alpha_tag: self.alpha_tag.take().unwrap_or_default(),
             tags: std::mem::take(&mut self.tags),
-        }
+        })
     }
 
     /// Pushes the current tag accumulator into the tags list.
@@ -525,7 +530,11 @@ pub fn parse_frequencies(xml: &str) -> Result<Vec<RrFrequency>, SoapError> {
                         state = FreqParseState::InFreqItem;
                     }
                     FreqParseState::InFreqItem if local == b"item" => {
-                        frequencies.push(builder.finish());
+                        if let Some(freq) = builder.finish() {
+                            frequencies.push(freq);
+                        } else {
+                            tracing::warn!("skipping frequency item with missing required fields");
+                        }
                         state = FreqParseState::TopLevel;
                     }
                     _ => {}

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -4,9 +4,9 @@
 use std::borrow::Cow;
 use std::io::Cursor;
 
-use quick_xml::events::{BytesDecl, BytesText, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use quick_xml::events::{BytesDecl, BytesText, Event};
 use reqwest::blocking::Client;
 
 use crate::types::{RrFrequency, RrTag, ZipInfo};
@@ -110,18 +110,14 @@ where
         .with_attribute(("xmlns:xsd", NS_XSD))
         .with_attribute(("xmlns:tns", NS_TNS))
         .write_inner_content(|w| {
-            w.create_element("SOAP-ENV:Body")
-                .write_inner_content(|w| {
-                    w.create_element(&*method_tag)
-                        .write_inner_content(|w| {
-                            body_fn(w).map_err(|e| {
-                                std::io::Error::other(e.to_string())
-                            })?;
-                            write_auth_info(w, auth)?;
-                            Ok(())
-                        })?;
+            w.create_element("SOAP-ENV:Body").write_inner_content(|w| {
+                w.create_element(&*method_tag).write_inner_content(|w| {
+                    body_fn(w).map_err(|e| std::io::Error::other(e.to_string()))?;
+                    write_auth_info(w, auth)?;
                     Ok(())
                 })?;
+                Ok(())
+            })?;
             Ok(())
         })?;
 
@@ -131,10 +127,7 @@ where
 
 /// Writes the `<authInfo>` block with `appKey`, `username`, `password`,
 /// `version`, and `style` elements.
-fn write_auth_info(
-    writer: &mut Writer<Cursor<Vec<u8>>>,
-    auth: &SoapAuth,
-) -> std::io::Result<()> {
+fn write_auth_info(writer: &mut Writer<Cursor<Vec<u8>>>, auth: &SoapAuth) -> std::io::Result<()> {
     writer
         .create_element("authInfo")
         .with_attribute(("xsi:type", "tns:authInfo"))
@@ -178,10 +171,7 @@ pub fn send_request(client: &Client, envelope: &str) -> Result<String, SoapError
         .text()?;
 
     if let Some(fault) = extract_soap_fault(&resp) {
-        if fault.contains("Authentication")
-            || fault.contains("auth")
-            || fault.contains("login")
-        {
+        if fault.contains("Authentication") || fault.contains("auth") || fault.contains("login") {
             return Err(SoapError::AuthFailed);
         }
         return Err(SoapError::Fault(fault));
@@ -341,15 +331,12 @@ pub fn parse_zip_info(xml: &str) -> Result<ZipInfo, SoapError> {
     }
 
     Ok(ZipInfo {
-        county_id: county_id
-            .ok_or_else(|| SoapError::Unexpected("missing ctid".into()))?,
-        state_id: state_id
-            .ok_or_else(|| SoapError::Unexpected("missing stid".into()))?,
+        county_id: county_id.ok_or_else(|| SoapError::Unexpected("missing ctid".into()))?,
+        state_id: state_id.ok_or_else(|| SoapError::Unexpected("missing stid".into()))?,
         city: city.ok_or_else(|| SoapError::Unexpected("missing city".into()))?,
         county_name: county_name
             .ok_or_else(|| SoapError::Unexpected("missing countyName".into()))?,
-        state_name: state_name
-            .ok_or_else(|| SoapError::Unexpected("missing stateName".into()))?,
+        state_name: state_name.ok_or_else(|| SoapError::Unexpected("missing stateName".into()))?,
     })
 }
 

--- a/crates/sdr-radioreference/src/types.rs
+++ b/crates/sdr-radioreference/src/types.rs
@@ -1,0 +1,44 @@
+//! Response types returned by the `RadioReference` SOAP API.
+
+/// Information about a US ZIP code, including its county and state.
+#[derive(Debug, Clone)]
+pub struct ZipInfo {
+    /// County ID on `RadioReference`.
+    pub county_id: u32,
+    /// State ID on `RadioReference`.
+    pub state_id: u32,
+    /// City name.
+    pub city: String,
+    /// County name.
+    pub county_name: String,
+    /// State name.
+    pub state_name: String,
+}
+
+/// A tag (category) applied to a `RadioReference` frequency entry.
+#[derive(Debug, Clone)]
+pub struct RrTag {
+    /// Tag identifier.
+    pub id: u32,
+    /// Human-readable tag description.
+    pub description: String,
+}
+
+/// A frequency entry from `RadioReference`.
+#[derive(Debug, Clone)]
+pub struct RrFrequency {
+    /// Frequency ID from `RadioReference` (fid).
+    pub id: String,
+    /// Output frequency in Hz (converted from the MHz value returned by the API).
+    pub freq_hz: u64,
+    /// Raw `RadioReference` mode string (e.g. "FM", "FMN", "AM").
+    pub mode: String,
+    /// CTCSS/PL tone in Hz, or `None` if absent or zero.
+    pub tone: Option<f32>,
+    /// Frequency description.
+    pub description: String,
+    /// Short alpha tag label.
+    pub alpha_tag: String,
+    /// Category tags applied to this frequency.
+    pub tags: Vec<RrTag>,
+}

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -22,6 +22,7 @@ sdr-source-network.workspace = true
 sdr-source-file.workspace = true
 sdr-sink-audio.workspace = true
 sdr-sink-network.workspace = true
+sdr-radioreference.workspace = true
 gtk4.workspace = true
 libadwaita.workspace = true
 thiserror.workspace = true

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -47,7 +47,16 @@ pub fn build_app() -> adw::Application {
     });
 
     app.connect_activate(|app| {
-        window::build_window(app);
+        let config_path = gtk4::glib::user_config_dir().join("sdr-rs").join("config.json");
+        let defaults = serde_json::json!({});
+        let config = match sdr_config::ConfigManager::load(&config_path, &defaults) {
+            Ok(c) => std::sync::Arc::new(c),
+            Err(e) => {
+                tracing::warn!("config load failed: {e}");
+                return;
+            }
+        };
+        window::build_window(app, &config);
     });
 
     app

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -47,7 +47,9 @@ pub fn build_app() -> adw::Application {
     });
 
     app.connect_activate(|app| {
-        let config_path = gtk4::glib::user_config_dir().join("sdr-rs").join("config.json");
+        let config_path = gtk4::glib::user_config_dir()
+            .join("sdr-rs")
+            .join("config.json");
         let defaults = serde_json::json!({});
         let config = match sdr_config::ConfigManager::load(&config_path, &defaults) {
             Ok(c) => std::sync::Arc::new(c),

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -7,6 +7,7 @@ pub mod header;
 pub mod messages;
 pub mod notify;
 pub mod preferences;
+pub mod radioreference;
 pub mod shortcuts;
 pub mod sidebar;
 pub mod spectrum;

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -13,6 +13,7 @@ pub mod sidebar;
 pub mod spectrum;
 pub mod state;
 pub mod status_bar;
+pub mod ui_helpers;
 pub mod wav_writer;
 pub mod window;
 

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -6,6 +6,7 @@ pub mod dsp_controller;
 pub mod header;
 pub mod messages;
 pub mod notify;
+pub mod preferences;
 pub mod shortcuts;
 pub mod sidebar;
 pub mod spectrum;

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -236,18 +236,4 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
     (page, has_credentials)
 }
 
-/// Show the status label with appropriate color.
-fn show_status(label: &gtk4::Label, text: &str, success: bool) {
-    label.set_visible(true);
-    if success {
-        label.set_markup(&format!(
-            "<span foreground=\"#2ec27e\">{}</span>",
-            glib::markup_escape_text(text)
-        ));
-    } else {
-        label.set_markup(&format!(
-            "<span foreground=\"#e01b24\">{}</span>",
-            glib::markup_escape_text(text)
-        ));
-    }
-}
+use crate::ui_helpers::show_status;

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -173,6 +173,7 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
                             return Err(format!("keyring error: {e}"));
                         }
                         if let Err(e) = store.set(KEY_RR_PASSWORD, &password) {
+                            let _ = store.delete(KEY_RR_USERNAME);
                             return Err(format!("keyring error: {e}"));
                         }
                     }

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -1,0 +1,248 @@
+//! Accounts preferences page — `RadioReference` credential management.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use sdr_config::KeyringStore;
+
+/// Keyring service name for the application.
+const KEYRING_SERVICE: &str = "sdr-rs";
+
+/// Keyring key for the `RadioReference` username.
+const KEY_RR_USERNAME: &str = "radioreference-username";
+
+/// Keyring key for the `RadioReference` password.
+const KEY_RR_PASSWORD: &str = "radioreference-password";
+
+/// Check whether `RadioReference` credentials exist in the keyring.
+pub fn has_rr_credentials() -> bool {
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    store.has(KEY_RR_USERNAME) && store.has(KEY_RR_PASSWORD)
+}
+
+/// Load `RadioReference` credentials from the keyring, if present.
+///
+/// Returns `Some((username, password))` when both are stored, `None` otherwise.
+pub fn load_rr_credentials() -> Option<(String, String)> {
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    let username = store.get(KEY_RR_USERNAME).ok().flatten()?;
+    let password = store.get(KEY_RR_PASSWORD).ok().flatten()?;
+    if username.is_empty() || password.is_empty() {
+        return None;
+    }
+    Some((username, password))
+}
+
+/// Build the Accounts preferences page.
+///
+/// Returns the page widget and a reactive flag indicating whether credentials
+/// are currently stored in the keyring.
+#[allow(clippy::too_many_lines)]
+pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
+    let has_credentials = Rc::new(Cell::new(has_rr_credentials()));
+
+    let page = adw::PreferencesPage::builder()
+        .title("Accounts")
+        .icon_name("system-users-symbolic")
+        .build();
+
+    let group = adw::PreferencesGroup::builder()
+        .title("RadioReference")
+        .description("Premium account required for frequency database access")
+        .build();
+
+    // --- Username row ---
+    let username_row = adw::EntryRow::builder()
+        .title("Username")
+        .build();
+
+    // --- Password row ---
+    let password_row = adw::PasswordEntryRow::builder()
+        .title("Password")
+        .build();
+
+    // Pre-fill username if credentials already exist
+    if let Some((stored_user, _)) = load_rr_credentials() {
+        username_row.set_text(&stored_user);
+    }
+
+    group.add(&username_row);
+    group.add(&password_row);
+
+    // --- Status label (hidden by default) ---
+    let status_label = gtk4::Label::builder()
+        .halign(gtk4::Align::Start)
+        .margin_top(8)
+        .visible(false)
+        .build();
+
+    // --- Button box ---
+    let button_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .spacing(12)
+        .margin_top(12)
+        .halign(gtk4::Align::Start)
+        .build();
+
+    let spinner = gtk4::Spinner::builder()
+        .visible(false)
+        .build();
+
+    let test_button = gtk4::Button::builder()
+        .label("Test & Save")
+        .css_classes(["suggested-action"])
+        .build();
+
+    let remove_button = gtk4::Button::builder()
+        .label("Remove Credentials")
+        .css_classes(["destructive-action"])
+        .visible(has_credentials.get())
+        .build();
+
+    button_box.append(&test_button);
+    button_box.append(&spinner);
+    button_box.append(&remove_button);
+
+    // Wrap status + buttons in a vertical box for the group
+    let controls_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .build();
+    controls_box.append(&button_box);
+    controls_box.append(&status_label);
+
+    group.add(&controls_box);
+    page.add(&group);
+
+    // --- "Test & Save" click handler ---
+    {
+        let cb_username_row = username_row.clone();
+        let cb_password_row = password_row.clone();
+        let cb_status_label = status_label.clone();
+        let cb_spinner = spinner.clone();
+        let cb_remove_button = remove_button.clone();
+        let cb_has_credentials = Rc::clone(&has_credentials);
+
+        test_button.connect_clicked(move |btn| {
+            let username = cb_username_row.text().to_string();
+            let password = cb_password_row.text().to_string();
+
+            // Validate fields are not empty
+            if username.trim().is_empty() || password.trim().is_empty() {
+                show_status(&cb_status_label, "Username and password are required", false);
+                return;
+            }
+
+            // Disable button, show spinner
+            btn.set_sensitive(false);
+            cb_spinner.set_visible(true);
+            cb_spinner.start();
+            cb_status_label.set_visible(false);
+
+            // Capture clones for the async block (runs on the main thread)
+            let status_label = cb_status_label.clone();
+            let btn_ref = btn.clone();
+            let spinner = cb_spinner.clone();
+            let remove_button = cb_remove_button.clone();
+            let has_credentials = Rc::clone(&cb_has_credentials);
+
+            // Spawn blocking SOAP test, then handle result on main thread
+            glib::spawn_future_local(async move {
+                let result = gtk4::gio::spawn_blocking(move || {
+                    let client =
+                        sdr_radioreference::RrClient::new(&username, &password);
+                    let test_result =
+                        client.test_connection().map_err(|e| e.to_string());
+
+                    // Save to keyring on success
+                    if test_result.is_ok() {
+                        let store = KeyringStore::new(KEYRING_SERVICE);
+                        if let Err(e) = store.set(KEY_RR_USERNAME, &username) {
+                            return Err(format!("keyring error: {e}"));
+                        }
+                        if let Err(e) = store.set(KEY_RR_PASSWORD, &password) {
+                            return Err(format!("keyring error: {e}"));
+                        }
+                    }
+
+                    test_result
+                })
+                .await
+                .unwrap_or_else(|_| Err("background task panicked".to_string()));
+
+                // Back on the main thread — update UI
+                spinner.stop();
+                spinner.set_visible(false);
+                btn_ref.set_sensitive(true);
+
+                match result {
+                    Ok(()) => {
+                        show_status(
+                            &status_label,
+                            "Connected \u{2014} credentials saved",
+                            true,
+                        );
+                        has_credentials.set(true);
+                        remove_button.set_visible(true);
+                    }
+                    Err(ref msg) => {
+                        tracing::warn!("RadioReference test failed: {msg}");
+                        show_status(&status_label, msg, false);
+                    }
+                }
+            });
+        });
+    }
+
+    // --- "Remove Credentials" click handler ---
+    {
+        let username_row = username_row.clone();
+        let status_label = status_label.clone();
+        let has_credentials = Rc::clone(&has_credentials);
+
+        remove_button.connect_clicked(move |btn| {
+            let store = KeyringStore::new(KEYRING_SERVICE);
+            let mut ok = true;
+
+            if let Err(e) = store.delete(KEY_RR_USERNAME) {
+                tracing::error!("failed to delete username from keyring: {e}");
+                ok = false;
+            }
+            if let Err(e) = store.delete(KEY_RR_PASSWORD) {
+                tracing::error!("failed to delete password from keyring: {e}");
+                ok = false;
+            }
+
+            if ok {
+                username_row.set_text("");
+                password_row.set_text("");
+                has_credentials.set(false);
+                btn.set_visible(false);
+                show_status(&status_label, "Credentials removed", true);
+            } else {
+                show_status(&status_label, "Failed to remove credentials", false);
+            }
+        });
+    }
+
+    (page, has_credentials)
+}
+
+/// Show the status label with appropriate color.
+fn show_status(label: &gtk4::Label, text: &str, success: bool) {
+    label.set_visible(true);
+    if success {
+        label.set_markup(&format!(
+            "<span foreground=\"#2ec27e\">{}</span>",
+            glib::markup_escape_text(text)
+        ));
+    } else {
+        label.set_markup(&format!(
+            "<span foreground=\"#e01b24\">{}</span>",
+            glib::markup_escape_text(text)
+        ));
+    }
+}

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -19,9 +19,19 @@ const KEY_RR_USERNAME: &str = "radioreference-username";
 const KEY_RR_PASSWORD: &str = "radioreference-password";
 
 /// Check whether `RadioReference` credentials exist in the keyring.
+///
+/// Returns `false` if the keyring backend is unavailable, logging the error.
 pub fn has_rr_credentials() -> bool {
     let store = KeyringStore::new(KEYRING_SERVICE);
-    store.has(KEY_RR_USERNAME) && store.has(KEY_RR_PASSWORD)
+    let has_user = store.has(KEY_RR_USERNAME).unwrap_or_else(|e| {
+        tracing::warn!("keyring check failed: {e}");
+        false
+    });
+    let has_pass = store.has(KEY_RR_PASSWORD).unwrap_or_else(|e| {
+        tracing::warn!("keyring check failed: {e}");
+        false
+    });
+    has_user && has_pass
 }
 
 /// Load `RadioReference` credentials from the keyring, if present.
@@ -150,7 +160,10 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
             // Spawn blocking SOAP test, then handle result on main thread
             glib::spawn_future_local(async move {
                 let result = gtk4::gio::spawn_blocking(move || {
-                    let client = sdr_radioreference::RrClient::new(&username, &password);
+                    let client = match sdr_radioreference::RrClient::new(&username, &password) {
+                        Ok(c) => c,
+                        Err(e) => return Err(format!("client init: {e}")),
+                    };
                     let test_result = client.test_connection().map_err(|e| e.to_string());
 
                     // Save to keyring on success

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -56,14 +56,10 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
         .build();
 
     // --- Username row ---
-    let username_row = adw::EntryRow::builder()
-        .title("Username")
-        .build();
+    let username_row = adw::EntryRow::builder().title("Username").build();
 
     // --- Password row ---
-    let password_row = adw::PasswordEntryRow::builder()
-        .title("Password")
-        .build();
+    let password_row = adw::PasswordEntryRow::builder().title("Password").build();
 
     // Pre-fill username if credentials already exist
     if let Some((stored_user, _)) = load_rr_credentials() {
@@ -88,9 +84,7 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
         .halign(gtk4::Align::Start)
         .build();
 
-    let spinner = gtk4::Spinner::builder()
-        .visible(false)
-        .build();
+    let spinner = gtk4::Spinner::builder().visible(false).build();
 
     let test_button = gtk4::Button::builder()
         .label("Test & Save")
@@ -132,7 +126,11 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
 
             // Validate fields are not empty
             if username.trim().is_empty() || password.trim().is_empty() {
-                show_status(&cb_status_label, "Username and password are required", false);
+                show_status(
+                    &cb_status_label,
+                    "Username and password are required",
+                    false,
+                );
                 return;
             }
 
@@ -152,10 +150,8 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
             // Spawn blocking SOAP test, then handle result on main thread
             glib::spawn_future_local(async move {
                 let result = gtk4::gio::spawn_blocking(move || {
-                    let client =
-                        sdr_radioreference::RrClient::new(&username, &password);
-                    let test_result =
-                        client.test_connection().map_err(|e| e.to_string());
+                    let client = sdr_radioreference::RrClient::new(&username, &password);
+                    let test_result = client.test_connection().map_err(|e| e.to_string());
 
                     // Save to keyring on success
                     if test_result.is_ok() {
@@ -180,11 +176,7 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
 
                 match result {
                     Ok(()) => {
-                        show_status(
-                            &status_label,
-                            "Connected \u{2014} credentials saved",
-                            true,
-                        );
+                        show_status(&status_label, "Connected \u{2014} credentials saved", true);
                         has_credentials.set(true);
                         remove_button.set_visible(true);
                     }

--- a/crates/sdr-ui/src/preferences/general_page.rs
+++ b/crates/sdr-ui/src/preferences/general_page.rs
@@ -152,19 +152,15 @@ fn open_folder_picker(
     let key = config_key.to_owned();
     let row = row.clone();
 
-    dialog.select_folder(
-        Some(window),
-        gtk4::gio::Cancellable::NONE,
-        move |result| {
-            if let Ok(folder) = result
-                && let Some(path) = folder.path()
-            {
-                let path_str = path.to_string_lossy().into_owned();
-                row.set_subtitle(&path_str);
-                config.write(|v| {
-                    v[&key] = serde_json::Value::String(path_str);
-                });
-            }
-        },
-    );
+    dialog.select_folder(Some(window), gtk4::gio::Cancellable::NONE, move |result| {
+        if let Ok(folder) = result
+            && let Some(path) = folder.path()
+        {
+            let path_str = path.to_string_lossy().into_owned();
+            row.set_subtitle(&path_str);
+            config.write(|v| {
+                v[&key] = serde_json::Value::String(path_str);
+            });
+        }
+    });
 }

--- a/crates/sdr-ui/src/preferences/general_page.rs
+++ b/crates/sdr-ui/src/preferences/general_page.rs
@@ -1,0 +1,170 @@
+//! General preferences page — directory settings for recordings and screenshots.
+
+use std::sync::Arc;
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use sdr_config::ConfigManager;
+
+/// Config key for the recording directory path.
+const KEY_RECORDING_DIR: &str = "recording_directory";
+
+/// Config key for the screenshot directory path.
+const KEY_SCREENSHOT_DIR: &str = "screenshot_directory";
+
+/// Default recording directory name under `$HOME`.
+const DEFAULT_RECORDING_DIR_NAME: &str = "sdr-recordings";
+
+/// Build the General preferences page.
+pub fn build_general_page(
+    window: &adw::PreferencesWindow,
+    config: &Arc<ConfigManager>,
+) -> adw::PreferencesPage {
+    let page = adw::PreferencesPage::builder()
+        .title("General")
+        .icon_name("preferences-system-symbolic")
+        .build();
+
+    let directories_group = adw::PreferencesGroup::builder()
+        .title("Directories")
+        .description("Default locations for saved files")
+        .build();
+
+    // --- Recording directory row ---
+    let recording_row = build_directory_row(
+        "Recording Directory",
+        "Location for IQ and audio recordings",
+        &current_recording_dir(config),
+    );
+    let recording_button = folder_button();
+    recording_row.add_suffix(&recording_button);
+
+    let config_rec = Arc::clone(config);
+    let row_rec = recording_row.clone();
+    let window_rec = window.clone();
+    recording_button.connect_clicked(move |_| {
+        open_folder_picker(
+            "Select Recording Directory",
+            &window_rec,
+            &config_rec,
+            KEY_RECORDING_DIR,
+            &row_rec,
+        );
+    });
+
+    directories_group.add(&recording_row);
+
+    // --- Screenshot directory row ---
+    let screenshot_row = build_directory_row(
+        "Screenshot Directory",
+        "Location for waterfall screenshots",
+        &current_screenshot_dir(config),
+    );
+    let screenshot_button = folder_button();
+    screenshot_row.add_suffix(&screenshot_button);
+
+    let config_ss = Arc::clone(config);
+    let row_ss = screenshot_row.clone();
+    let window_ss = window.clone();
+    screenshot_button.connect_clicked(move |_| {
+        open_folder_picker(
+            "Select Screenshot Directory",
+            &window_ss,
+            &config_ss,
+            KEY_SCREENSHOT_DIR,
+            &row_ss,
+        );
+    });
+
+    directories_group.add(&screenshot_row);
+
+    page.add(&directories_group);
+    page
+}
+
+/// Read the current recording directory from config, falling back to `~/sdr-recordings`.
+fn current_recording_dir(config: &ConfigManager) -> String {
+    config.read(|v| {
+        v.get(KEY_RECORDING_DIR)
+            .and_then(serde_json::Value::as_str)
+            .map_or_else(
+                || {
+                    glib::home_dir()
+                        .join(DEFAULT_RECORDING_DIR_NAME)
+                        .to_string_lossy()
+                        .into_owned()
+                },
+                String::from,
+            )
+    })
+}
+
+/// Read the current screenshot directory from config, falling back to `~/Pictures`.
+fn current_screenshot_dir(config: &ConfigManager) -> String {
+    config.read(|v| {
+        v.get(KEY_SCREENSHOT_DIR)
+            .and_then(serde_json::Value::as_str)
+            .map_or_else(
+                || {
+                    glib::user_special_dir(glib::UserDirectory::Pictures)
+                        .unwrap_or_else(|| glib::home_dir().join("Pictures"))
+                        .to_string_lossy()
+                        .into_owned()
+                },
+                String::from,
+            )
+    })
+}
+
+/// Build a directory `ActionRow` with a subtitle showing the current path.
+fn build_directory_row(title: &str, subtitle: &str, current_path: &str) -> adw::ActionRow {
+    adw::ActionRow::builder()
+        .title(title)
+        .subtitle(current_path)
+        .subtitle_lines(1)
+        .tooltip_text(subtitle)
+        .build()
+}
+
+/// Build a flat folder-open button for use as an `ActionRow` suffix.
+fn folder_button() -> gtk4::Button {
+    gtk4::Button::builder()
+        .icon_name("folder-open-symbolic")
+        .valign(gtk4::Align::Center)
+        .tooltip_text("Choose folder")
+        .css_classes(["flat"])
+        .build()
+}
+
+/// Open a `FileDialog` folder picker, saving the result to config and updating the row subtitle.
+fn open_folder_picker(
+    title: &str,
+    window: &adw::PreferencesWindow,
+    config: &Arc<ConfigManager>,
+    config_key: &str,
+    row: &adw::ActionRow,
+) {
+    let dialog = gtk4::FileDialog::builder().title(title).build();
+
+    let config = Arc::clone(config);
+    let key = config_key.to_owned();
+    let row = row.clone();
+
+    dialog.select_folder(
+        Some(window),
+        gtk4::gio::Cancellable::NONE,
+        move |result| {
+            if let Ok(folder) = result
+                && let Some(path) = folder.path()
+            {
+                let path_str = path.to_string_lossy().into_owned();
+                row.set_subtitle(&path_str);
+                config.write(|v| {
+                    v[&key] = serde_json::Value::String(path_str);
+                });
+            }
+        },
+    );
+}

--- a/crates/sdr-ui/src/preferences/mod.rs
+++ b/crates/sdr-ui/src/preferences/mod.rs
@@ -1,0 +1,36 @@
+//! Preferences window — application settings organized into pages.
+
+pub mod general_page;
+
+use std::sync::Arc;
+
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use sdr_config::ConfigManager;
+
+/// Default preferences window width in pixels.
+const PREFS_WIDTH: i32 = 600;
+
+/// Default preferences window height in pixels.
+const PREFS_HEIGHT: i32 = 500;
+
+/// Build and return the preferences window.
+///
+/// The window is modal and transient for `parent`.
+pub fn build_preferences_window(
+    parent: &adw::ApplicationWindow,
+    config: &Arc<ConfigManager>,
+) -> adw::PreferencesWindow {
+    let window = adw::PreferencesWindow::builder()
+        .title("Preferences")
+        .default_width(PREFS_WIDTH)
+        .default_height(PREFS_HEIGHT)
+        .modal(true)
+        .transient_for(parent)
+        .build();
+
+    let general_page = general_page::build_general_page(&window, config);
+    window.add(&general_page);
+
+    window
+}

--- a/crates/sdr-ui/src/preferences/mod.rs
+++ b/crates/sdr-ui/src/preferences/mod.rs
@@ -1,5 +1,6 @@
 //! Preferences window — application settings organized into pages.
 
+pub mod accounts_page;
 pub mod general_page;
 
 use std::sync::Arc;
@@ -31,6 +32,9 @@ pub fn build_preferences_window(
 
     let general_page = general_page::build_general_page(&window, config);
     window.add(&general_page);
+
+    let (accounts_page, _has_credentials) = accounts_page::build_accounts_page();
+    window.add(&accounts_page);
 
     window
 }

--- a/crates/sdr-ui/src/radioreference/frequency_list.rs
+++ b/crates/sdr-ui/src/radioreference/frequency_list.rs
@@ -1,0 +1,348 @@
+//! Frequency list widget for the `RadioReference` browse dialog.
+//!
+//! Builds and manages an `adw::ActionRow`-based list inside a `gtk4::ListBox`,
+//! where each row represents an `RrFrequency`.  Already-bookmarked frequencies
+//! are dimmed; the rest get a check-button for selection.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use sdr_radioreference::RrFrequency;
+
+use crate::sidebar::navigation_panel::{Bookmark, format_frequency, load_bookmarks};
+
+// ---------------------------------------------------------------------------
+// Row model
+// ---------------------------------------------------------------------------
+
+/// View-model for a single row in the frequency list.
+pub struct FrequencyRow {
+    /// The upstream `RadioReference` frequency record.
+    pub freq: RrFrequency,
+    /// Whether the user has selected this row for import.
+    pub selected: bool,
+    /// Whether an existing bookmark already matches this frequency.
+    pub already_bookmarked: bool,
+    /// First tag description (used as category filter key), or empty.
+    pub category: String,
+}
+
+// ---------------------------------------------------------------------------
+// Populate helper
+// ---------------------------------------------------------------------------
+
+/// Rebuild the `list_box` from a fresh set of frequencies.
+///
+/// Returns the row models (wrapped in `Rc<RefCell>` so check-button closures
+/// can mutate `selected`), plus the sorted-unique category and agency lists
+/// (each prefixed with "All").
+#[allow(clippy::too_many_lines)]
+pub fn populate_frequencies(
+    list_box: &gtk4::ListBox,
+    frequencies: &[RrFrequency],
+    import_button: &gtk4::Button,
+    category_model: &gtk4::StringList,
+    agency_model: &gtk4::StringList,
+) -> Vec<Rc<RefCell<FrequencyRow>>> {
+    // Clear existing children.
+    while let Some(child) = list_box.first_child() {
+        list_box.remove(&child);
+    }
+
+    // Load existing bookmarks for duplicate detection.
+    let existing = load_bookmarks();
+
+    // Build row models.
+    let mut rows: Vec<Rc<RefCell<FrequencyRow>>> = Vec::with_capacity(frequencies.len());
+    let mut categories = std::collections::BTreeSet::new();
+    let mut agencies = std::collections::BTreeSet::new();
+
+    for freq in frequencies {
+        let already = is_already_bookmarked(freq, &existing);
+        let category = freq
+            .tags
+            .first()
+            .map_or_else(String::new, |t| t.description.clone());
+
+        if !category.is_empty() {
+            categories.insert(category.clone());
+        }
+        if !freq.alpha_tag.is_empty() {
+            agencies.insert(freq.alpha_tag.clone());
+        }
+
+        let row_model = Rc::new(RefCell::new(FrequencyRow {
+            freq: freq.clone(),
+            selected: false,
+            already_bookmarked: already,
+            category,
+        }));
+        rows.push(row_model);
+    }
+
+    // Build GTK rows.
+    let import_button_weak = import_button.downgrade();
+    let rows_for_count = Rc::new(rows.clone());
+
+    for row_model in &rows {
+        let rm = row_model.borrow();
+        let freq_label = format_frequency(rm.freq.freq_hz);
+        let title = format!("{freq_label}  {}", rm.freq.mode);
+        let subtitle = rm.freq.description.clone();
+
+        let action_row = adw::ActionRow::builder()
+            .title(&title)
+            .subtitle(&subtitle)
+            .build();
+
+        if rm.already_bookmarked {
+            let icon = gtk4::Image::from_icon_name("emblem-ok-symbolic");
+            icon.set_valign(gtk4::Align::Center);
+            action_row.add_prefix(&icon);
+            action_row.set_sensitive(false);
+        } else {
+            let check = gtk4::CheckButton::new();
+            check.set_valign(gtk4::Align::Center);
+
+            let model_ref = Rc::clone(row_model);
+            let btn_weak = import_button_weak.clone();
+            let count_rows = Rc::clone(&rows_for_count);
+            check.connect_toggled(move |cb| {
+                model_ref.borrow_mut().selected = cb.is_active();
+                if let Some(btn) = btn_weak.upgrade() {
+                    update_import_count(&btn, &count_rows);
+                }
+            });
+            action_row.add_prefix(&check);
+        }
+
+        // Store category and alpha_tag as widget names so filters can match.
+        // We use two custom data keys via GObject data.
+        action_row.set_widget_name(&format!("{}|||{}", rm.category, rm.freq.alpha_tag));
+
+        list_box.append(&action_row);
+    }
+
+    // Update filter dropdown models.
+    rebuild_string_list(category_model, &categories);
+    rebuild_string_list(agency_model, &agencies);
+
+    // Reset import button.
+    update_import_count(import_button, &rows);
+
+    rows
+}
+
+// ---------------------------------------------------------------------------
+// Import-count helper
+// ---------------------------------------------------------------------------
+
+/// Update the import button label and sensitivity based on the number of
+/// selected (non-bookmarked) rows.
+pub fn update_import_count(button: &gtk4::Button, rows: &[Rc<RefCell<FrequencyRow>>]) {
+    let count = rows
+        .iter()
+        .filter(|r| {
+            let r = r.borrow();
+            r.selected && !r.already_bookmarked
+        })
+        .count();
+
+    if count == 0 {
+        button.set_label("Import Selected");
+        button.set_sensitive(false);
+    } else {
+        button.set_label(&format!("Import Selected ({count})"));
+        button.set_sensitive(true);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filter helper
+// ---------------------------------------------------------------------------
+
+/// Show/hide rows in the list box according to the current category and agency
+/// filter values.  `"All"` (or index 0) means no filtering on that axis.
+pub fn apply_filters(
+    list_box: &gtk4::ListBox,
+    rows: &[Rc<RefCell<FrequencyRow>>],
+    category_filter: &str,
+    agency_filter: &str,
+) {
+    let show_all_categories = category_filter == "All" || category_filter.is_empty();
+    let show_all_agencies = agency_filter == "All" || agency_filter.is_empty();
+
+    let mut child = list_box.first_child();
+    let mut idx = 0;
+    while let Some(widget) = child {
+        if let Some(row_model) = rows.get(idx) {
+            let rm = row_model.borrow();
+            let cat_ok = show_all_categories || rm.category == category_filter;
+            let agency_ok = show_all_agencies || rm.freq.alpha_tag == agency_filter;
+            widget.set_visible(cat_ok && agency_ok);
+        }
+        child = widget.next_sibling();
+        idx += 1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Check whether an `RrFrequency` already exists as a bookmark.
+///
+/// Matches on `rr_import_id` first (exact), then falls back to `freq_hz`.
+fn is_already_bookmarked(freq: &RrFrequency, bookmarks: &[Bookmark]) -> bool {
+    bookmarks.iter().any(|bm| {
+        // Exact match on RadioReference frequency ID.
+        if let Some(ref import_id) = bm.rr_import_id
+            && *import_id == freq.id
+        {
+            return true;
+        }
+        // Fallback: match on frequency in Hz.
+        bm.frequency == freq.freq_hz
+    })
+}
+
+/// Rebuild a `StringList` with "All" followed by sorted unique values.
+fn rebuild_string_list(model: &gtk4::StringList, values: &std::collections::BTreeSet<String>) {
+    // Remove all existing items.
+    let n = model.n_items();
+    if n > 0 {
+        model.splice(0, n, &[] as &[&str]);
+    }
+
+    model.append("All");
+    for v in values {
+        model.append(v);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sdr_radioreference::RrTag;
+
+    fn sample_freq(id: &str, freq_hz: u64, mode: &str, desc: &str) -> RrFrequency {
+        RrFrequency {
+            id: id.to_string(),
+            freq_hz,
+            mode: mode.to_string(),
+            tone: None,
+            description: desc.to_string(),
+            alpha_tag: String::new(),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn duplicate_detection_by_import_id() {
+        let bm = Bookmark {
+            name: "Test".to_string(),
+            frequency: 100_000_000,
+            demod_mode: "NFM".to_string(),
+            bandwidth: 12_500.0,
+            squelch_enabled: None,
+            squelch_level: None,
+            gain: None,
+            agc: None,
+            volume: None,
+            deemphasis: None,
+            nb_enabled: None,
+            nb_level: None,
+            fm_if_nr: None,
+            wfm_stereo: None,
+            high_pass: None,
+            rr_category: None,
+            rr_import_id: Some("42".to_string()),
+        };
+
+        let freq = sample_freq("42", 999_999_999, "FM", "test");
+        assert!(is_already_bookmarked(&freq, &[bm]));
+    }
+
+    #[test]
+    fn duplicate_detection_by_freq_hz() {
+        let bm = Bookmark {
+            name: "Test".to_string(),
+            frequency: 155_000_000,
+            demod_mode: "NFM".to_string(),
+            bandwidth: 12_500.0,
+            squelch_enabled: None,
+            squelch_level: None,
+            gain: None,
+            agc: None,
+            volume: None,
+            deemphasis: None,
+            nb_enabled: None,
+            nb_level: None,
+            fm_if_nr: None,
+            wfm_stereo: None,
+            high_pass: None,
+            rr_category: None,
+            rr_import_id: None,
+        };
+
+        let freq = sample_freq("99", 155_000_000, "FM", "test");
+        assert!(is_already_bookmarked(&freq, &[bm]));
+    }
+
+    #[test]
+    fn not_bookmarked_when_no_match() {
+        let bm = Bookmark {
+            name: "Other".to_string(),
+            frequency: 100_000_000,
+            demod_mode: "NFM".to_string(),
+            bandwidth: 12_500.0,
+            squelch_enabled: None,
+            squelch_level: None,
+            gain: None,
+            agc: None,
+            volume: None,
+            deemphasis: None,
+            nb_enabled: None,
+            nb_level: None,
+            fm_if_nr: None,
+            wfm_stereo: None,
+            high_pass: None,
+            rr_category: None,
+            rr_import_id: Some("10".to_string()),
+        };
+
+        let freq = sample_freq("99", 155_000_000, "FM", "test");
+        assert!(!is_already_bookmarked(&freq, &[bm]));
+    }
+
+    #[test]
+    fn category_from_first_tag() {
+        let freq = RrFrequency {
+            id: "1".to_string(),
+            freq_hz: 155_000_000,
+            mode: "FM".to_string(),
+            tone: None,
+            description: "Test".to_string(),
+            alpha_tag: "PD".to_string(),
+            tags: vec![
+                RrTag {
+                    id: 1,
+                    description: "Law Dispatch".to_string(),
+                },
+                RrTag {
+                    id: 2,
+                    description: "Fire".to_string(),
+                },
+            ],
+        };
+
+        let cat = freq
+            .tags
+            .first()
+            .map_or_else(String::new, |t| t.description.clone());
+        assert_eq!(cat, "Law Dispatch");
+    }
+}

--- a/crates/sdr-ui/src/radioreference/mod.rs
+++ b/crates/sdr-ui/src/radioreference/mod.rs
@@ -218,7 +218,7 @@ pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on
 
             glib::spawn_future_local(async move {
                 let result = gio::spawn_blocking(move || {
-                    let client = sdr_radioreference::RrClient::new(&username, &password);
+                    let client = sdr_radioreference::RrClient::new(&username, &password)?;
                     let zip_info = client.get_zip_info(&zip)?;
                     let freqs = client.get_county_frequencies(zip_info.county_id)?;
                     Ok::<(sdr_radioreference::ZipInfo, Vec<RrFrequency>), sdr_radioreference::SoapError>(

--- a/crates/sdr-ui/src/radioreference/mod.rs
+++ b/crates/sdr-ui/src/radioreference/mod.rs
@@ -374,15 +374,7 @@ pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Show the status label with success (green) or error (red) styling.
-fn show_status(label: &gtk4::Label, text: &str, success: bool) {
-    label.set_visible(true);
-    let color = if success { "#2ec27e" } else { "#e01b24" };
-    label.set_markup(&format!(
-        "<span foreground=\"{color}\">{}</span>",
-        glib::markup_escape_text(text)
-    ));
-}
+use crate::ui_helpers::show_status;
 
 /// Read the string at the given index from a `DropDown`'s `StringList` model.
 fn selected_string(model: &gtk4::StringList, index: u32) -> String {

--- a/crates/sdr-ui/src/radioreference/mod.rs
+++ b/crates/sdr-ui/src/radioreference/mod.rs
@@ -1,0 +1,400 @@
+//! `RadioReference` browse dialog — zip code search, frequency list, and import.
+
+mod frequency_list;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk4::gio;
+use gtk4::glib;
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use sdr_radioreference::RrFrequency;
+
+use crate::preferences::accounts_page::load_rr_credentials;
+use crate::sidebar::navigation_panel::{
+    Bookmark, format_frequency, load_bookmarks, parse_demod_mode, save_bookmarks,
+};
+use frequency_list::FrequencyRow;
+
+/// Dialog content width in pixels.
+const DIALOG_WIDTH: i32 = 700;
+/// Dialog content height in pixels.
+const DIALOG_HEIGHT: i32 = 600;
+
+/// Show the `RadioReference` browse dialog.
+///
+/// `on_import` is called (on the GTK main thread) after bookmarks are saved,
+/// so the caller can rebuild the bookmark list in the sidebar.
+#[allow(clippy::too_many_lines)]
+pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on_import: F) {
+    let on_import = Rc::new(on_import);
+
+    // -----------------------------------------------------------------------
+    // Top-level dialog shell
+    // -----------------------------------------------------------------------
+    let content = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(12)
+        .margin_start(16)
+        .margin_end(16)
+        .margin_top(12)
+        .margin_bottom(12)
+        .build();
+
+    let toolbar = adw::ToolbarView::new();
+    toolbar.add_top_bar(&adw::HeaderBar::new());
+    toolbar.set_content(Some(&content));
+
+    let dialog = adw::Dialog::builder()
+        .title("RadioReference")
+        .content_width(DIALOG_WIDTH)
+        .content_height(DIALOG_HEIGHT)
+        .build();
+    dialog.set_child(Some(&toolbar));
+
+    // -----------------------------------------------------------------------
+    // Search section
+    // -----------------------------------------------------------------------
+    let search_group = adw::PreferencesGroup::builder()
+        .title("Search")
+        .description("Enter a US ZIP code to find local frequencies")
+        .build();
+
+    let zip_entry = adw::EntryRow::builder().title("ZIP Code").build();
+
+    let search_button = gtk4::Button::builder()
+        .label("Search")
+        .valign(gtk4::Align::Center)
+        .css_classes(["suggested-action"])
+        .build();
+    zip_entry.add_suffix(&search_button);
+
+    search_group.add(&zip_entry);
+
+    // Spinner + status row
+    let status_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .spacing(8)
+        .build();
+
+    let spinner = gtk4::Spinner::builder().visible(false).build();
+
+    let status_label = gtk4::Label::builder()
+        .halign(gtk4::Align::Start)
+        .hexpand(true)
+        .wrap(true)
+        .visible(false)
+        .build();
+
+    status_box.append(&spinner);
+    status_box.append(&status_label);
+    search_group.add(&status_box);
+
+    content.append(&search_group);
+
+    // -----------------------------------------------------------------------
+    // Results section (hidden until search succeeds)
+    // -----------------------------------------------------------------------
+    let results_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(8)
+        .visible(false)
+        .vexpand(true)
+        .build();
+
+    // Category filter
+    let category_model = gtk4::StringList::new(&["All"]);
+    let category_dropdown = gtk4::DropDown::builder()
+        .model(&category_model)
+        .valign(gtk4::Align::Center)
+        .build();
+    let category_row = adw::ActionRow::builder()
+        .title("Category")
+        .activatable(false)
+        .build();
+    category_row.add_suffix(&category_dropdown);
+
+    // Agency filter
+    let agency_model = gtk4::StringList::new(&["All"]);
+    let agency_dropdown = gtk4::DropDown::builder()
+        .model(&agency_model)
+        .valign(gtk4::Align::Center)
+        .build();
+    let agency_row = adw::ActionRow::builder()
+        .title("Agency")
+        .activatable(false)
+        .build();
+    agency_row.add_suffix(&agency_dropdown);
+
+    let filter_list = gtk4::ListBox::builder()
+        .selection_mode(gtk4::SelectionMode::None)
+        .css_classes(["boxed-list"])
+        .build();
+    filter_list.append(&category_row);
+    filter_list.append(&agency_row);
+    results_box.append(&filter_list);
+
+    // Scrollable frequency list
+    let freq_list = gtk4::ListBox::builder()
+        .selection_mode(gtk4::SelectionMode::None)
+        .css_classes(["boxed-list"])
+        .build();
+
+    let freq_scroll = gtk4::ScrolledWindow::builder()
+        .child(&freq_list)
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .vscrollbar_policy(gtk4::PolicyType::Automatic)
+        .vexpand(true)
+        .build();
+    results_box.append(&freq_scroll);
+
+    // Import button
+    let import_button = gtk4::Button::builder()
+        .label("Import Selected")
+        .css_classes(["suggested-action"])
+        .sensitive(false)
+        .build();
+    results_box.append(&import_button);
+
+    content.append(&results_box);
+
+    // -----------------------------------------------------------------------
+    // Shared mutable state for closures
+    // -----------------------------------------------------------------------
+    let rows: Rc<RefCell<Vec<Rc<RefCell<FrequencyRow>>>>> = Rc::new(RefCell::new(Vec::new()));
+
+    // -----------------------------------------------------------------------
+    // Search handler
+    // -----------------------------------------------------------------------
+    {
+        let zip_entry = zip_entry.clone();
+        let spinner = spinner.clone();
+        let status_label = status_label.clone();
+        let results_box = results_box.clone();
+        let freq_list = freq_list.clone();
+        let import_button = import_button.clone();
+        let category_model = category_model.clone();
+        let agency_model = agency_model.clone();
+        let rows = Rc::clone(&rows);
+        let search_button_ref = search_button.clone();
+
+        search_button.connect_clicked(move |_| {
+            let zip = zip_entry.text().trim().to_string();
+
+            // Validate 5-digit US zip code.
+            if zip.len() != 5 || !zip.chars().all(|c| c.is_ascii_digit()) {
+                show_status(&status_label, "Please enter a valid 5-digit ZIP code", false);
+                return;
+            }
+
+            // Load credentials.
+            let Some((username, password)) = load_rr_credentials() else {
+                show_status(
+                    &status_label,
+                    "No RadioReference credentials — configure them in Preferences \u{2192} Accounts",
+                    false,
+                );
+                return;
+            };
+
+            // Show spinner, disable button.
+            spinner.set_visible(true);
+            spinner.start();
+            status_label.set_visible(false);
+            search_button_ref.set_sensitive(false);
+            results_box.set_visible(false);
+
+            let status_label = status_label.clone();
+            let spinner = spinner.clone();
+            let results_box = results_box.clone();
+            let freq_list = freq_list.clone();
+            let import_button = import_button.clone();
+            let category_model = category_model.clone();
+            let agency_model = agency_model.clone();
+            let rows = Rc::clone(&rows);
+            let search_button_ref = search_button_ref.clone();
+
+            glib::spawn_future_local(async move {
+                let result = gio::spawn_blocking(move || {
+                    let client = sdr_radioreference::RrClient::new(&username, &password);
+                    let zip_info = client.get_zip_info(&zip)?;
+                    let freqs = client.get_county_frequencies(zip_info.county_id)?;
+                    Ok::<(sdr_radioreference::ZipInfo, Vec<RrFrequency>), sdr_radioreference::SoapError>(
+                        (zip_info, freqs),
+                    )
+                })
+                .await
+                .unwrap_or_else(|_| Err(sdr_radioreference::SoapError::Fault(
+                    "background task panicked".to_string(),
+                )));
+
+                // Back on the main thread.
+                spinner.stop();
+                spinner.set_visible(false);
+                search_button_ref.set_sensitive(true);
+
+                match result {
+                    Ok((zip_info, freqs)) => {
+                        let msg = format!(
+                            "{}, {} \u{2014} {} frequencies",
+                            zip_info.county_name,
+                            zip_info.state_name,
+                            freqs.len()
+                        );
+                        show_status(&status_label, &msg, true);
+
+                        let new_rows = frequency_list::populate_frequencies(
+                            &freq_list,
+                            &freqs,
+                            &import_button,
+                            &category_model,
+                            &agency_model,
+                        );
+                        *rows.borrow_mut() = new_rows;
+                        results_box.set_visible(true);
+                    }
+                    Err(e) => {
+                        tracing::warn!("RadioReference search failed: {e}");
+                        show_status(&status_label, &e.to_string(), false);
+                    }
+                }
+            });
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Category filter handler
+    // -----------------------------------------------------------------------
+    {
+        let freq_list = freq_list.clone();
+        let rows = Rc::clone(&rows);
+        let agency_model = agency_model.clone();
+        let agency_dropdown = agency_dropdown.clone();
+
+        category_dropdown.connect_selected_notify(move |dd| {
+            let cat = selected_string(&category_model, dd.selected());
+            let agency = selected_string(&agency_model, agency_dropdown.selected());
+            frequency_list::apply_filters(&freq_list, &rows.borrow(), &cat, &agency);
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Agency filter handler
+    // -----------------------------------------------------------------------
+    {
+        let freq_list = freq_list.clone();
+        let rows = Rc::clone(&rows);
+        let category_dropdown_ref = category_dropdown.clone();
+
+        agency_dropdown.connect_selected_notify(move |dd| {
+            let cat = category_dropdown_ref.model().map_or_else(
+                || "All".to_string(),
+                |m| string_at(&m, category_dropdown_ref.selected()),
+            );
+            let agency_val = dd
+                .model()
+                .map_or_else(|| "All".to_string(), |m| string_at(&m, dd.selected()));
+
+            frequency_list::apply_filters(&freq_list, &rows.borrow(), &cat, &agency_val);
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Import handler
+    // -----------------------------------------------------------------------
+    {
+        let rows = Rc::clone(&rows);
+        let dialog_weak = dialog.downgrade();
+        let on_import = Rc::clone(&on_import);
+
+        import_button.connect_clicked(move |_| {
+            let rows = rows.borrow();
+            let selected: Vec<_> = rows
+                .iter()
+                .filter(|r| {
+                    let r = r.borrow();
+                    r.selected && !r.already_bookmarked
+                })
+                .collect();
+
+            if selected.is_empty() {
+                return;
+            }
+
+            let mut bookmarks = load_bookmarks();
+
+            for row_rc in &selected {
+                let row = row_rc.borrow();
+                let freq = &row.freq;
+                let mapped = sdr_radioreference::mode_map::map_rr_mode(&freq.mode);
+                let demod = parse_demod_mode(mapped.demod_mode);
+
+                let name = if freq.alpha_tag.is_empty() {
+                    freq.description.clone()
+                } else {
+                    format!("{} - {}", freq.alpha_tag, freq.description)
+                };
+                // Use formatted frequency as fallback name if both are empty.
+                let name = if name.trim().is_empty() {
+                    format_frequency(freq.freq_hz)
+                } else {
+                    name
+                };
+
+                let mut bookmark = Bookmark::new(&name, freq.freq_hz, demod, mapped.bandwidth);
+                bookmark.rr_category = if row.category.is_empty() {
+                    None
+                } else {
+                    Some(row.category.clone())
+                };
+                bookmark.rr_import_id = Some(freq.id.clone());
+
+                bookmarks.push(bookmark);
+            }
+
+            save_bookmarks(&bookmarks);
+
+            let count = selected.len();
+            tracing::info!(count, "imported RadioReference frequencies as bookmarks");
+
+            on_import();
+
+            if let Some(d) = dialog_weak.upgrade() {
+                d.close();
+            }
+        });
+    }
+
+    dialog.present(Some(parent));
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Show the status label with success (green) or error (red) styling.
+fn show_status(label: &gtk4::Label, text: &str, success: bool) {
+    label.set_visible(true);
+    let color = if success { "#2ec27e" } else { "#e01b24" };
+    label.set_markup(&format!(
+        "<span foreground=\"{color}\">{}</span>",
+        glib::markup_escape_text(text)
+    ));
+}
+
+/// Read the string at the given index from a `DropDown`'s `StringList` model.
+fn selected_string(model: &gtk4::StringList, index: u32) -> String {
+    model
+        .string(index)
+        .map_or_else(|| "All".to_string(), |s| s.to_string())
+}
+
+/// Read the string at the given index from a generic `ListModel`.
+fn string_at(model: &gio::ListModel, index: u32) -> String {
+    model
+        .item(index)
+        .and_then(|obj| obj.downcast::<gtk4::StringObject>().ok())
+        .map_or_else(|| "All".to_string(), |s| s.string().to_string())
+}

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -251,7 +251,7 @@ fn bookmarks_path() -> std::path::PathBuf {
     path
 }
 
-fn load_bookmarks() -> Vec<Bookmark> {
+pub fn load_bookmarks() -> Vec<Bookmark> {
     let path = bookmarks_path();
     let Ok(data) = std::fs::read_to_string(&path) else {
         return Vec::new();

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -140,6 +140,13 @@ pub struct Bookmark {
     pub wfm_stereo: Option<bool>,
     #[serde(default)]
     pub high_pass: Option<bool>,
+    /// RadioReference category (e.g., "Law Dispatch"). Metadata for future
+    /// bookmark tree organization.
+    #[serde(default)]
+    pub rr_category: Option<String>,
+    /// RadioReference frequency ID for duplicate detection and future sync.
+    #[serde(default)]
+    pub rr_import_id: Option<String>,
 }
 
 impl Bookmark {
@@ -161,6 +168,8 @@ impl Bookmark {
             fm_if_nr: None,
             wfm_stereo: None,
             high_pass: None,
+            rr_category: None,
+            rr_import_id: None,
         }
     }
 
@@ -188,6 +197,8 @@ impl Bookmark {
             fm_if_nr: Some(profile.fm_if_nr),
             wfm_stereo: Some(profile.wfm_stereo),
             high_pass: profile.high_pass,
+            rr_category: None,
+            rr_import_id: None,
         }
     }
 

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -140,11 +140,11 @@ pub struct Bookmark {
     pub wfm_stereo: Option<bool>,
     #[serde(default)]
     pub high_pass: Option<bool>,
-    /// RadioReference category (e.g., "Law Dispatch"). Metadata for future
+    /// `RadioReference` category (e.g., "Law Dispatch"). Metadata for future
     /// bookmark tree organization.
     #[serde(default)]
     pub rr_category: Option<String>,
-    /// RadioReference frequency ID for duplicate detection and future sync.
+    /// `RadioReference` frequency ID for duplicate detection and future sync.
     #[serde(default)]
     pub rr_import_id: Option<String>,
 }

--- a/crates/sdr-ui/src/ui_helpers.rs
+++ b/crates/sdr-ui/src/ui_helpers.rs
@@ -1,0 +1,12 @@
+//! Shared UI utility functions.
+
+use gtk4::prelude::*;
+
+/// Show a status label with success (green) or error (red) styling.
+///
+/// Uses Adwaita CSS classes for theme-aware colors.
+pub fn show_status(label: &gtk4::Label, text: &str, success: bool) {
+    label.set_visible(true);
+    label.set_text(text);
+    label.set_css_classes(if success { &["success"] } else { &["error"] });
+}

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -57,7 +57,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let (split_view, panels, spectrum_handle_raw, status_bar) = build_split_view(&state);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
     let sidebar_toggle = build_sidebar_toggle(&split_view);
-    let (header, play_button, demod_dropdown, freq_selector, screenshot_button) =
+    let (header, play_button, demod_dropdown, freq_selector, screenshot_button, rr_button) =
         build_header_bar(&sidebar_toggle, &state);
     let toolbar_view = build_toolbar_view(&header, &split_view);
     let breakpoint = build_breakpoint(&split_view);
@@ -140,6 +140,41 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
             }
         }
     });
+
+    // Wire RadioReference browse button.
+    {
+        let bm_list = panels.navigation.bookmark_list.clone();
+        let bm_scroll = panels.navigation.bookmark_scroll.clone();
+        let bm_rc = panels.navigation.bookmarks.clone();
+        let on_nav = panels.navigation.on_navigate.clone();
+        let active_bm = panels.navigation.active_bookmark.clone();
+        let name_entry = panels.navigation.name_entry.clone();
+        let on_save = panels.navigation.on_save.clone();
+
+        rr_button.connect_clicked(move |btn| {
+            let bm_list = bm_list.clone();
+            let bm_scroll = bm_scroll.clone();
+            let bm_rc = bm_rc.clone();
+            let on_nav = on_nav.clone();
+            let active_bm = active_bm.clone();
+            let name_entry = name_entry.clone();
+            let on_save = on_save.clone();
+
+            crate::radioreference::show_browse_dialog(btn, move || {
+                // Reload bookmarks from disk and rebuild the sidebar list.
+                *bm_rc.borrow_mut() = sidebar::navigation_panel::load_bookmarks();
+                sidebar::navigation_panel::rebuild_bookmark_list(
+                    &bm_list,
+                    &bm_scroll,
+                    &bm_rc,
+                    &on_nav,
+                    &active_bm,
+                    &name_entry,
+                    &on_save,
+                );
+            });
+        });
+    }
 
     // Wire cursor readout from spectrum to status bar.
     let status_bar_for_cursor = Rc::clone(&status_bar_demod);
@@ -403,6 +438,7 @@ fn build_header_bar(
     gtk4::DropDown,
     header::frequency_selector::FrequencySelector,
     gtk4::Button,
+    gtk4::Button,
 ) {
     // Play/stop button
     let play_button = gtk4::ToggleButton::builder()
@@ -477,8 +513,16 @@ fn build_header_bar(
         .tooltip_text("Export waterfall to PNG")
         .build();
 
+    // RadioReference frequency browser button
+    let rr_button = gtk4::Button::builder()
+        .icon_name("network-wireless-symbolic")
+        .tooltip_text("RadioReference Frequency Browser")
+        .visible(crate::preferences::accounts_page::has_rr_credentials())
+        .build();
+
     header.pack_end(&menu_button);
     header.pack_end(&volume_button);
+    header.pack_end(&rr_button);
     header.pack_end(&screenshot_button);
 
     (
@@ -487,6 +531,7 @@ fn build_header_bar(
         demod_dropdown.clone(),
         freq_selector,
         screenshot_button,
+        rr_button,
     )
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -45,7 +45,7 @@ const DSP_POLL_INTERVAL_MS: u64 = 16;
 
 /// Build and present the main application window.
 #[allow(clippy::too_many_lines)]
-pub fn build_window(app: &adw::Application) {
+pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::ConfigManager>) {
     // --- Channel setup ---
     let (dsp_tx, dsp_rx) = mpsc::channel::<DspToUi>();
     let (ui_tx, ui_rx) = mpsc::channel::<UiToDsp>();
@@ -87,7 +87,7 @@ pub fn build_window(app: &adw::Application) {
     #[allow(clippy::cast_precision_loss)]
     status_bar.update_frequency(freq_selector.frequency() as f64);
 
-    setup_app_actions(app, &window);
+    setup_app_actions(app, &window, config);
 
     // --- Keyboard shortcuts ---
     shortcuts::setup_shortcuts(&window, &play_button, &sidebar_toggle, &demod_dropdown);
@@ -490,9 +490,10 @@ fn build_header_bar(
     )
 }
 
-/// Build the app menu button with Keyboard Shortcuts / About / Quit actions.
+/// Build the app menu button with Preferences / Keyboard Shortcuts / About / Quit actions.
 fn build_menu_button() -> gtk4::MenuButton {
     let menu = gio::Menu::new();
+    menu.append(Some("_Preferences"), Some("app.preferences"));
     menu.append(Some("_Keyboard Shortcuts"), Some("win.show-help-overlay"));
     menu.append(Some("_About SDR-RS"), Some("app.about"));
     menu.append(Some("_Quit"), Some("app.quit"));
@@ -1274,8 +1275,12 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         });
 }
 
-/// Register application-level actions (About, Quit).
-fn setup_app_actions(app: &adw::Application, window: &adw::ApplicationWindow) {
+/// Register application-level actions (Preferences, About, Quit).
+fn setup_app_actions(
+    app: &adw::Application,
+    window: &adw::ApplicationWindow,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
     // Quit action
     let quit_action = gio::SimpleAction::new("quit", None);
     quit_action.connect_activate(glib::clone!(
@@ -1287,6 +1292,21 @@ fn setup_app_actions(app: &adw::Application, window: &adw::ApplicationWindow) {
     ));
     app.add_action(&quit_action);
     app.set_accels_for_action("app.quit", &["<Ctrl>q"]);
+
+    // Preferences action
+    let prefs_action = gio::SimpleAction::new("preferences", None);
+    let config_for_prefs = std::sync::Arc::clone(config);
+    prefs_action.connect_activate(glib::clone!(
+        #[weak]
+        window,
+        move |_, _| {
+            let prefs_window =
+                crate::preferences::build_preferences_window(&window, &config_for_prefs);
+            prefs_window.present();
+        }
+    ));
+    app.add_action(&prefs_action);
+    app.set_accels_for_action("app.preferences", &["<Ctrl>comma"]);
 
     // About action
     let about_action = gio::SimpleAction::new("about", None);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -87,7 +87,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     #[allow(clippy::cast_precision_loss)]
     status_bar.update_frequency(freq_selector.frequency() as f64);
 
-    setup_app_actions(app, &window, config);
+    setup_app_actions(app, &window, config, &rr_button);
 
     // --- Keyboard shortcuts ---
     shortcuts::setup_shortcuts(&window, &play_button, &sidebar_toggle, &demod_dropdown);
@@ -1325,6 +1325,7 @@ fn setup_app_actions(
     app: &adw::Application,
     window: &adw::ApplicationWindow,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
+    rr_button: &gtk4::Button,
 ) {
     // Quit action
     let quit_action = gio::SimpleAction::new("quit", None);
@@ -1341,12 +1342,19 @@ fn setup_app_actions(
     // Preferences action
     let prefs_action = gio::SimpleAction::new("preferences", None);
     let config_for_prefs = std::sync::Arc::clone(config);
+    let rr_button_prefs = rr_button.clone();
     prefs_action.connect_activate(glib::clone!(
         #[weak]
         window,
         move |_, _| {
             let prefs_window =
                 crate::preferences::build_preferences_window(&window, &config_for_prefs);
+            // Update RR button visibility when preferences window closes
+            let rr_btn = rr_button_prefs.clone();
+            prefs_window.connect_close_request(move |_| {
+                rr_btn.set_visible(crate::preferences::accounts_page::has_rr_credentials());
+                glib::Propagation::Proceed
+            });
             prefs_window.present();
         }
     ));

--- a/docs/superpowers/plans/2026-04-08-radioreference-integration.md
+++ b/docs/superpowers/plans/2026-04-08-radioreference-integration.md
@@ -16,7 +16,7 @@
 
 ### New Files
 
-```
+```text
 crates/sdr-radioreference/
   Cargo.toml
   src/
@@ -37,7 +37,7 @@ crates/sdr-ui/src/
 
 ### Modified Files
 
-```
+```text
 Cargo.toml                                      -- workspace members + deps
 crates/sdr-config/Cargo.toml                    -- add keyring dep
 crates/sdr-config/src/lib.rs                    -- add KeyringStore module

--- a/docs/superpowers/plans/2026-04-08-radioreference-integration.md
+++ b/docs/superpowers/plans/2026-04-08-radioreference-integration.md
@@ -1,0 +1,2346 @@
+# RadioReference Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to browse RadioReference.com frequencies by zip code and import them as bookmarks, with secure credential storage and a new Preferences window.
+
+**Architecture:** New `sdr-radioreference` crate for SOAP client + types + mode mapping. `KeyringStore` in `sdr-config` for OS keyring access. `AdwPreferencesWindow` and `AdwDialog`-based browse UI in `sdr-ui`. SOAP calls run on GLib thread pool via `gio::spawn_blocking()`.
+
+**Tech Stack:** `reqwest` (blocking), `quick-xml`, `keyring` (sync-secret-service), GTK4/libadwaita 1.5
+
+**Design Spec:** `docs/superpowers/specs/2026-04-08-radioreference-integration-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+```
+crates/sdr-radioreference/
+  Cargo.toml
+  src/
+    lib.rs              -- RrClient public API
+    soap.rs             -- SOAP envelope construction + HTTP transport + XML parsing
+    types.rs            -- ZipInfo, RrFrequency, RrTag response structs
+    mode_map.rs         -- RR mode string -> demod mode + bandwidth
+
+crates/sdr-ui/src/
+  preferences/
+    mod.rs              -- AdwPreferencesWindow construction
+    general_page.rs     -- Recording/screenshot directory settings
+    accounts_page.rs    -- RadioReference credential entry + test & save
+  radioreference/
+    mod.rs              -- AdwDialog browse UI, search flow, import
+    frequency_list.rs   -- GtkListBox with check rows, filtering, dedup
+```
+
+### Modified Files
+
+```
+Cargo.toml                                      -- workspace members + deps
+crates/sdr-config/Cargo.toml                    -- add keyring dep
+crates/sdr-config/src/lib.rs                    -- add KeyringStore module
+crates/sdr-ui/Cargo.toml                        -- add sdr-radioreference dep
+crates/sdr-ui/src/lib.rs                        -- add preferences + radioreference modules
+crates/sdr-ui/src/sidebar/navigation_panel.rs   -- add rr_category + rr_import_id to Bookmark
+crates/sdr-ui/src/window.rs                     -- Preferences menu item, RR header button, wiring
+```
+
+---
+
+## Task 1: sdr-radioreference Crate — Mode Mapping
+
+**Files:**
+- Create: `crates/sdr-radioreference/Cargo.toml`
+- Create: `crates/sdr-radioreference/src/lib.rs`
+- Create: `crates/sdr-radioreference/src/mode_map.rs`
+- Modify: `Cargo.toml:34-50` (workspace members + deps)
+
+- [ ] **Step 1: Add workspace dependencies and crate member**
+
+In `Cargo.toml`, add to `[workspace]` members:
+
+```toml
+"crates/sdr-radioreference",
+```
+
+Add to `[workspace.dependencies]`:
+
+```toml
+# RadioReference SOAP client
+sdr-radioreference = { path = "crates/sdr-radioreference" }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+quick-xml = "0.37"
+```
+
+- [ ] **Step 2: Create crate Cargo.toml**
+
+Create `crates/sdr-radioreference/Cargo.toml`:
+
+```toml
+[package]
+name = "sdr-radioreference"
+version = "0.1.0"
+description = "RadioReference.com SOAP API client"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+sdr-types.workspace = true
+reqwest.workspace = true
+quick-xml.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+serde.workspace = true
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 3: Create lib.rs stub**
+
+Create `crates/sdr-radioreference/src/lib.rs`:
+
+```rust
+pub mod mode_map;
+```
+
+- [ ] **Step 4: Write failing tests for mode mapping**
+
+Create `crates/sdr-radioreference/src/mode_map.rs`:
+
+```rust
+//! Map RadioReference mode strings to SDR-RS demod modes and default bandwidths.
+
+/// Result of mapping an RR mode string to our demod system.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MappedMode {
+    /// Our demod mode name: "NFM", "WFM", "AM", "USB", "LSB", "CW", "RAW".
+    pub demod_mode: &'static str,
+    /// Default bandwidth in Hz for this mode.
+    pub bandwidth: f64,
+}
+
+/// Map a RadioReference mode string to our demod mode and default bandwidth.
+///
+/// Unknown modes default to NFM 12,500 Hz since most public safety
+/// traffic is narrowband FM.
+pub fn map_rr_mode(rr_mode: &str) -> MappedMode {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fm_maps_to_nfm() {
+        let m = map_rr_mode("FM");
+        assert_eq!(m.demod_mode, "NFM");
+        assert!((m.bandwidth - 12_500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn fmn_maps_to_nfm() {
+        let m = map_rr_mode("FMN");
+        assert_eq!(m.demod_mode, "NFM");
+        assert!((m.bandwidth - 12_500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn fmw_maps_to_wfm() {
+        let m = map_rr_mode("FMW");
+        assert_eq!(m.demod_mode, "WFM");
+        assert!((m.bandwidth - 150_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn am_maps_to_am() {
+        let m = map_rr_mode("AM");
+        assert_eq!(m.demod_mode, "AM");
+        assert!((m.bandwidth - 10_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn usb_maps_to_usb() {
+        let m = map_rr_mode("USB");
+        assert_eq!(m.demod_mode, "USB");
+        assert!((m.bandwidth - 2_800.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lsb_maps_to_lsb() {
+        let m = map_rr_mode("LSB");
+        assert_eq!(m.demod_mode, "LSB");
+        assert!((m.bandwidth - 2_800.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cw_maps_to_cw() {
+        let m = map_rr_mode("CW");
+        assert_eq!(m.demod_mode, "CW");
+        assert!((m.bandwidth - 500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn unknown_defaults_to_nfm() {
+        let m = map_rr_mode("P25");
+        assert_eq!(m.demod_mode, "NFM");
+        assert!((m.bandwidth - 12_500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let m = map_rr_mode("fm");
+        assert_eq!(m.demod_mode, "NFM");
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they fail**
+
+Run: `cargo test -p sdr-radioreference`
+Expected: FAIL — `todo!()` panics
+
+- [ ] **Step 6: Implement mode mapping**
+
+Replace `todo!()` in `map_rr_mode`:
+
+```rust
+pub fn map_rr_mode(rr_mode: &str) -> MappedMode {
+    match rr_mode.to_uppercase().as_str() {
+        "FM" | "FMN" => MappedMode {
+            demod_mode: "NFM",
+            bandwidth: 12_500.0,
+        },
+        "FMW" => MappedMode {
+            demod_mode: "WFM",
+            bandwidth: 150_000.0,
+        },
+        "AM" => MappedMode {
+            demod_mode: "AM",
+            bandwidth: 10_000.0,
+        },
+        "USB" => MappedMode {
+            demod_mode: "USB",
+            bandwidth: 2_800.0,
+        },
+        "LSB" => MappedMode {
+            demod_mode: "LSB",
+            bandwidth: 2_800.0,
+        },
+        "CW" => MappedMode {
+            demod_mode: "CW",
+            bandwidth: 500.0,
+        },
+        _ => MappedMode {
+            demod_mode: "NFM",
+            bandwidth: 12_500.0,
+        },
+    }
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cargo test -p sdr-radioreference`
+Expected: All 9 tests PASS
+
+- [ ] **Step 8: Run clippy**
+
+Run: `cargo clippy -p sdr-radioreference -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/sdr-radioreference/ Cargo.toml Cargo.lock
+git commit -m "add sdr-radioreference crate with mode mapping"
+```
+
+---
+
+## Task 2: sdr-radioreference — SOAP Types and Transport
+
+**Files:**
+- Create: `crates/sdr-radioreference/src/types.rs`
+- Create: `crates/sdr-radioreference/src/soap.rs`
+- Modify: `crates/sdr-radioreference/src/lib.rs`
+
+- [ ] **Step 1: Create response types**
+
+Create `crates/sdr-radioreference/src/types.rs`:
+
+```rust
+//! RadioReference API response types.
+
+/// Zip code lookup result from `getZipcodeInfo`.
+#[derive(Debug, Clone)]
+pub struct ZipInfo {
+    /// County ID for use in subsequent queries.
+    pub county_id: u32,
+    /// State ID.
+    pub state_id: u32,
+    /// City name.
+    pub city: String,
+    /// County name.
+    pub county_name: String,
+    /// State name.
+    pub state_name: String,
+}
+
+/// A tag/category associated with a frequency.
+#[derive(Debug, Clone)]
+pub struct RrTag {
+    /// Tag ID.
+    pub id: u32,
+    /// Tag description (e.g., "Law Dispatch", "Fire Dispatch").
+    pub description: String,
+}
+
+/// A frequency entry from RadioReference.
+#[derive(Debug, Clone)]
+pub struct RrFrequency {
+    /// RadioReference unique frequency ID.
+    pub id: String,
+    /// Output/downlink frequency in Hz.
+    pub freq_hz: u64,
+    /// Raw RR mode string (e.g., "FM", "FMN", "AM").
+    pub mode: String,
+    /// CTCSS/PL tone in Hz, if any.
+    pub tone: Option<f32>,
+    /// Description text.
+    pub description: String,
+    /// Alpha tag / display label.
+    pub alpha_tag: String,
+    /// Category tags associated with this frequency.
+    pub tags: Vec<RrTag>,
+}
+```
+
+- [ ] **Step 2: Create SOAP envelope builder and XML parser**
+
+Create `crates/sdr-radioreference/src/soap.rs`:
+
+```rust
+//! SOAP envelope construction and XML response parsing for RadioReference API.
+
+use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::{Reader, Writer};
+
+use crate::types::{RrFrequency, RrTag, ZipInfo};
+
+/// RadioReference SOAP API endpoint.
+const SOAP_ENDPOINT: &str = "https://api.radioreference.com/soap2/index.php";
+
+/// API version.
+const API_VERSION: &str = "18";
+
+/// SOAP XML namespace constants.
+const NS_SOAP: &str = "http://schemas.xmlsoap.org/soap/envelope/";
+const NS_XSI: &str = "http://www.w3.org/2001/XMLSchema-instance";
+const NS_XSD: &str = "http://www.w3.org/2001/XMLSchema";
+const NS_TNS: &str = "http://api.radioreference.com/soap2";
+const NS_ENC: &str = "http://schemas.xmlsoap.org/soap/encoding/";
+
+/// Error type for SOAP operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SoapError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("XML parse error: {0}")]
+    Xml(#[from] quick_xml::Error),
+    #[error("SOAP fault: {0}")]
+    Fault(String),
+    #[error("unexpected response: {0}")]
+    Unexpected(String),
+    #[error("authentication failed")]
+    AuthFailed,
+}
+
+/// Credentials for SOAP requests.
+pub struct SoapAuth {
+    pub username: String,
+    pub password: String,
+    pub app_key: String,
+}
+
+/// Build a complete SOAP envelope for a method call.
+///
+/// The `body_fn` closure writes method-specific parameters into the
+/// method element using the provided `Writer`.
+fn build_envelope<F>(method: &str, auth: &SoapAuth, body_fn: F) -> Result<Vec<u8>, SoapError>
+where
+    F: FnOnce(&mut Writer<Vec<u8>>) -> Result<(), quick_xml::Error>,
+{
+    let mut writer = Writer::new(Vec::new());
+
+    // XML declaration
+    writer.write_event(Event::Decl(quick_xml::events::BytesDecl::new("1.0", Some("UTF-8"), None)))?;
+
+    // SOAP Envelope
+    let mut envelope = BytesStart::new("SOAP-ENV:Envelope");
+    envelope.push_attribute(("xmlns:SOAP-ENV", NS_SOAP));
+    envelope.push_attribute(("xmlns:SOAP-ENC", NS_ENC));
+    envelope.push_attribute(("xmlns:xsi", NS_XSI));
+    envelope.push_attribute(("xmlns:xsd", NS_XSD));
+    envelope.push_attribute(("xmlns:tns", NS_TNS));
+    writer.write_event(Event::Start(envelope))?;
+
+    // Empty header
+    writer.write_event(Event::Empty(BytesStart::new("SOAP-ENV:Header")))?;
+
+    // Body
+    writer.write_event(Event::Start(BytesStart::new("SOAP-ENV:Body")))?;
+
+    // Method element
+    let method_tag = format!("tns:{method}");
+    writer.write_event(Event::Start(BytesStart::new(&method_tag)))?;
+
+    // Method-specific parameters
+    body_fn(&mut writer)?;
+
+    // authInfo block
+    write_auth_info(&mut writer, auth)?;
+
+    // Close method, body, envelope
+    writer.write_event(Event::End(BytesEnd::new(&method_tag)))?;
+    writer.write_event(Event::End(BytesEnd::new("SOAP-ENV:Body")))?;
+    writer.write_event(Event::End(BytesEnd::new("SOAP-ENV:Envelope")))?;
+
+    Ok(writer.into_inner())
+}
+
+/// Write the authInfo element into the SOAP body.
+fn write_auth_info(writer: &mut Writer<Vec<u8>>, auth: &SoapAuth) -> Result<(), quick_xml::Error> {
+    let mut ai = BytesStart::new("authInfo");
+    ai.push_attribute(("xsi:type", "tns:authInfo"));
+    writer.write_event(Event::Start(ai))?;
+
+    write_typed_element(writer, "appKey", "xsd:string", &auth.app_key)?;
+    write_typed_element(writer, "username", "xsd:string", &auth.username)?;
+    write_typed_element(writer, "password", "xsd:string", &auth.password)?;
+    write_typed_element(writer, "version", "xsd:string", API_VERSION)?;
+    write_typed_element(writer, "style", "xsd:string", "rpc")?;
+
+    writer.write_event(Event::End(BytesEnd::new("authInfo")))?;
+    Ok(())
+}
+
+/// Write a single typed element: `<name xsi:type="type">value</name>`.
+fn write_typed_element(
+    writer: &mut Writer<Vec<u8>>,
+    name: &str,
+    xsi_type: &str,
+    value: &str,
+) -> Result<(), quick_xml::Error> {
+    let mut elem = BytesStart::new(name);
+    elem.push_attribute(("xsi:type", xsi_type));
+    writer.write_event(Event::Start(elem))?;
+    writer.write_event(Event::Text(BytesText::new(value)))?;
+    writer.write_event(Event::End(BytesEnd::new(name)))?;
+    Ok(())
+}
+
+/// Send a SOAP request and return the raw XML response body.
+fn send_request(client: &reqwest::blocking::Client, envelope: &[u8]) -> Result<String, SoapError> {
+    let response = client
+        .post(SOAP_ENDPOINT)
+        .header("Content-Type", "text/xml;charset=UTF-8")
+        .body(envelope.to_vec())
+        .send()?;
+
+    let status = response.status();
+    let body = response.text()?;
+
+    if !status.is_success() {
+        // Check for SOAP fault in error response
+        if let Some(fault) = extract_soap_fault(&body) {
+            if fault.contains("authentication") || fault.contains("login") {
+                return Err(SoapError::AuthFailed);
+            }
+            return Err(SoapError::Fault(fault));
+        }
+        return Err(SoapError::Unexpected(format!("HTTP {status}")));
+    }
+
+    // Check for SOAP fault in success response too
+    if let Some(fault) = extract_soap_fault(&body) {
+        return Err(SoapError::Fault(fault));
+    }
+
+    Ok(body)
+}
+
+/// Extract SOAP fault string from response XML, if present.
+fn extract_soap_fault(xml: &str) -> Option<String> {
+    let mut reader = Reader::from_str(xml);
+    let mut in_fault_string = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) if e.local_name().as_ref() == b"faultstring" => {
+                in_fault_string = true;
+            }
+            Ok(Event::Text(e)) if in_fault_string => {
+                return e.unescape().ok().map(|s| s.to_string());
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+    None
+}
+
+// ── Public SOAP operations ──────────────────────────────────────────
+
+/// Build and send a `getZipcodeInfo` SOAP request.
+pub fn get_zipcode_info(
+    client: &reqwest::blocking::Client,
+    auth: &SoapAuth,
+    zipcode: &str,
+) -> Result<ZipInfo, SoapError> {
+    let envelope = build_envelope("getZipcodeInfo", auth, |w| {
+        write_typed_element(w, "zipcode", "xsd:int", zipcode)
+    })?;
+
+    let response = send_request(client, &envelope)?;
+    parse_zip_info(&response)
+}
+
+/// Build and send a `getCountyFreqsByTag` SOAP request.
+///
+/// Pass `tag = 0` to attempt fetching all frequencies.
+pub fn get_county_freqs_by_tag(
+    client: &reqwest::blocking::Client,
+    auth: &SoapAuth,
+    county_id: u32,
+    tag: u32,
+) -> Result<Vec<RrFrequency>, SoapError> {
+    let envelope = build_envelope("getCountyFreqsByTag", auth, |w| {
+        write_typed_element(w, "ctid", "xsd:int", &county_id.to_string())?;
+        write_typed_element(w, "tag", "xsd:int", &tag.to_string())
+    })?;
+
+    let response = send_request(client, &envelope)?;
+    parse_frequencies(&response)
+}
+
+// ── XML response parsers ────────────────────────────────────────────
+
+/// Parse `getZipcodeInfo` response XML into a `ZipInfo`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn parse_zip_info(xml: &str) -> Result<ZipInfo, SoapError> {
+    let mut reader = Reader::from_str(xml);
+    let mut current_tag = String::new();
+    let mut zip = ZipInfo {
+        county_id: 0,
+        state_id: 0,
+        city: String::new(),
+        county_name: String::new(),
+        state_name: String::new(),
+    };
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) => {
+                current_tag = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
+            }
+            Ok(Event::Text(e)) => {
+                let text = e.unescape().unwrap_or_default().to_string();
+                match current_tag.as_str() {
+                    "ctid" => zip.county_id = text.parse().unwrap_or(0),
+                    "stid" => zip.state_id = text.parse().unwrap_or(0),
+                    "city" => zip.city = text,
+                    "countyName" => zip.county_name = text,
+                    "stateName" => zip.state_name = text,
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(SoapError::Xml(e)),
+            _ => {}
+        }
+    }
+
+    if zip.county_id == 0 {
+        return Err(SoapError::Unexpected("no county ID in response".to_string()));
+    }
+
+    Ok(zip)
+}
+
+/// Parse `getCountyFreqsByTag` response XML into a list of `RrFrequency`.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss
+)]
+fn parse_frequencies(xml: &str) -> Result<Vec<RrFrequency>, SoapError> {
+    let mut reader = Reader::from_str(xml);
+    let mut frequencies = Vec::new();
+    let mut current_freq: Option<RrFrequency> = None;
+    let mut current_tag_elem: Option<RrTag> = None;
+    let mut current_xml_tag = String::new();
+    let mut in_tag_item = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) => {
+                let name = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
+                match name.as_str() {
+                    "item" if current_freq.is_none() => {
+                        current_freq = Some(RrFrequency {
+                            id: String::new(),
+                            freq_hz: 0,
+                            mode: String::new(),
+                            tone: None,
+                            description: String::new(),
+                            alpha_tag: String::new(),
+                            tags: Vec::new(),
+                        });
+                    }
+                    "item" if current_freq.is_some() => {
+                        // Nested item = tag entry
+                        in_tag_item = true;
+                        current_tag_elem = Some(RrTag {
+                            id: 0,
+                            description: String::new(),
+                        });
+                    }
+                    _ => {
+                        current_xml_tag = name;
+                    }
+                }
+            }
+            Ok(Event::Text(e)) => {
+                let text = e.unescape().unwrap_or_default().to_string();
+                if in_tag_item {
+                    if let Some(ref mut tag) = current_tag_elem {
+                        match current_xml_tag.as_str() {
+                            "tagId" => tag.id = text.parse().unwrap_or(0),
+                            "tagDescr" => tag.description = text,
+                            _ => {}
+                        }
+                    }
+                } else if let Some(ref mut freq) = current_freq {
+                    match current_xml_tag.as_str() {
+                        "fid" => freq.id = text,
+                        "out" => {
+                            // RR returns frequency in MHz; convert to Hz
+                            if let Ok(mhz) = text.parse::<f64>() {
+                                freq.freq_hz = (mhz * 1_000_000.0).round() as u64;
+                            }
+                        }
+                        "mode" => freq.mode = text,
+                        "tone" => {
+                            if let Ok(t) = text.parse::<f32>() {
+                                if t > 0.0 {
+                                    freq.tone = Some(t);
+                                }
+                            }
+                        }
+                        "descr" => freq.description = text,
+                        "alpha" => freq.alpha_tag = text,
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::End(e)) => {
+                let name = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
+                if name == "item" {
+                    if in_tag_item {
+                        // Close a tag item
+                        if let (Some(ref mut freq), Some(tag)) =
+                            (&mut current_freq, current_tag_elem.take())
+                        {
+                            freq.tags.push(tag);
+                        }
+                        in_tag_item = false;
+                    } else if let Some(freq) = current_freq.take() {
+                        // Close a frequency item
+                        if freq.freq_hz > 0 {
+                            frequencies.push(freq);
+                        }
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(SoapError::Xml(e)),
+            _ => {}
+        }
+    }
+
+    Ok(frequencies)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ZIP_RESPONSE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+<SOAP-ENV:Body>
+<ns1:getZipcodeInfoResponse xmlns:ns1="http://api.radioreference.com/soap2">
+<return>
+<zipCode>90210</zipCode>
+<city>Beverly Hills</city>
+<stid>6</stid>
+<ctid>277</ctid>
+<lat>34.0901</lat>
+<lon>-118.4065</lon>
+<countyName>Los Angeles</countyName>
+<stateName>California</stateName>
+</return>
+</ns1:getZipcodeInfoResponse>
+</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"#;
+
+    const FREQ_RESPONSE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+<SOAP-ENV:Body>
+<ns1:getCountyFreqsByTagResponse xmlns:ns1="http://api.radioreference.com/soap2">
+<return>
+<item>
+<fid>12345</fid>
+<out>155.37000</out>
+<mode>FMN</mode>
+<tone>110.9</tone>
+<descr>Police Dispatch</descr>
+<alpha>PD Disp</alpha>
+<tags>
+<item><tagId>32</tagId><tagDescr>Law Dispatch</tagDescr></item>
+</tags>
+</item>
+<item>
+<fid>12346</fid>
+<out>154.43000</out>
+<mode>FM</mode>
+<tone>0</tone>
+<descr>Fire Dispatch</descr>
+<alpha>FD Disp</alpha>
+<tags>
+<item><tagId>33</tagId><tagDescr>Fire Dispatch</tagDescr></item>
+</tags>
+</item>
+</return>
+</ns1:getCountyFreqsByTagResponse>
+</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"#;
+
+    const FAULT_RESPONSE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+<SOAP-ENV:Body>
+<SOAP-ENV:Fault>
+<faultcode>SOAP-ENV:Server</faultcode>
+<faultstring>authentication failed</faultstring>
+</SOAP-ENV:Fault>
+</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"#;
+
+    #[test]
+    fn parse_zip_info_response() {
+        let zip = parse_zip_info(ZIP_RESPONSE).expect("should parse");
+        assert_eq!(zip.county_id, 277);
+        assert_eq!(zip.state_id, 6);
+        assert_eq!(zip.city, "Beverly Hills");
+        assert_eq!(zip.county_name, "Los Angeles");
+        assert_eq!(zip.state_name, "California");
+    }
+
+    #[test]
+    fn parse_frequencies_response() {
+        let freqs = parse_frequencies(FREQ_RESPONSE).expect("should parse");
+        assert_eq!(freqs.len(), 2);
+
+        assert_eq!(freqs[0].id, "12345");
+        assert_eq!(freqs[0].freq_hz, 155_370_000);
+        assert_eq!(freqs[0].mode, "FMN");
+        assert!((freqs[0].tone.expect("should have tone") - 110.9).abs() < f32::EPSILON);
+        assert_eq!(freqs[0].description, "Police Dispatch");
+        assert_eq!(freqs[0].alpha_tag, "PD Disp");
+        assert_eq!(freqs[0].tags.len(), 1);
+        assert_eq!(freqs[0].tags[0].id, 32);
+        assert_eq!(freqs[0].tags[0].description, "Law Dispatch");
+
+        assert_eq!(freqs[1].id, "12346");
+        assert_eq!(freqs[1].freq_hz, 154_430_000);
+        assert!(freqs[1].tone.is_none()); // tone=0 means no tone
+    }
+
+    #[test]
+    fn extract_fault_from_response() {
+        let fault = extract_soap_fault(FAULT_RESPONSE);
+        assert_eq!(fault, Some("authentication failed".to_string()));
+    }
+
+    #[test]
+    fn no_fault_in_success_response() {
+        let fault = extract_soap_fault(ZIP_RESPONSE);
+        assert!(fault.is_none());
+    }
+
+    #[test]
+    fn envelope_contains_auth_info() {
+        let auth = SoapAuth {
+            username: "testuser".to_string(),
+            password: "testpass".to_string(),
+            app_key: "testkey".to_string(),
+        };
+        let envelope = build_envelope("getZipcodeInfo", &auth, |w| {
+            write_typed_element(w, "zipcode", "xsd:int", "90210")
+        })
+        .expect("should build");
+        let xml = String::from_utf8(envelope).expect("valid utf8");
+
+        assert!(xml.contains("getZipcodeInfo"));
+        assert!(xml.contains("<username"));
+        assert!(xml.contains("testuser"));
+        assert!(xml.contains("<password"));
+        assert!(xml.contains("testpass"));
+        assert!(xml.contains("<appKey"));
+        assert!(xml.contains("testkey"));
+        assert!(xml.contains("<zipcode"));
+        assert!(xml.contains("90210"));
+    }
+}
+```
+
+- [ ] **Step 3: Update lib.rs**
+
+```rust
+pub mod mode_map;
+pub mod soap;
+pub mod types;
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p sdr-radioreference`
+Expected: All tests PASS (mode_map + soap)
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy -p sdr-radioreference -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-radioreference/
+git commit -m "add SOAP types, envelope builder, XML parsers with tests"
+```
+
+---
+
+## Task 3: sdr-radioreference — RrClient Public API
+
+**Files:**
+- Modify: `crates/sdr-radioreference/src/lib.rs`
+
+- [ ] **Step 1: Implement RrClient**
+
+Replace `crates/sdr-radioreference/src/lib.rs`:
+
+```rust
+//! RadioReference.com SOAP API client.
+//!
+//! Provides `RrClient` for querying the RadioReference frequency database.
+//! All methods are blocking — call from a background thread when used with GTK.
+
+pub mod mode_map;
+pub mod soap;
+pub mod types;
+
+pub use soap::SoapError;
+pub use types::{RrFrequency, RrTag, ZipInfo};
+
+/// Application API key — identifies the SDR-RS app to RadioReference.
+/// This is not a secret; it's distributed with the application.
+const APP_KEY: &str = "PENDING_API_KEY";
+
+/// RadioReference SOAP API client.
+///
+/// Holds user credentials and an HTTP client. All methods are blocking.
+pub struct RrClient {
+    auth: soap::SoapAuth,
+    http: reqwest::blocking::Client,
+}
+
+impl RrClient {
+    /// Create a new client with the given RadioReference credentials.
+    pub fn new(username: &str, password: &str) -> Self {
+        Self {
+            auth: soap::SoapAuth {
+                username: username.to_string(),
+                password: password.to_string(),
+                app_key: APP_KEY.to_string(),
+            },
+            http: reqwest::blocking::Client::new(),
+        }
+    }
+
+    /// Test the connection by querying zip code 90210.
+    ///
+    /// Returns `Ok(())` if credentials are valid, `Err` otherwise.
+    pub fn test_connection(&self) -> Result<(), SoapError> {
+        soap::get_zipcode_info(&self.http, &self.auth, "90210")?;
+        Ok(())
+    }
+
+    /// Look up county/state info for a US zip code.
+    pub fn get_zip_info(&self, zipcode: &str) -> Result<ZipInfo, SoapError> {
+        tracing::debug!(zipcode, "querying RadioReference zip info");
+        soap::get_zipcode_info(&self.http, &self.auth, zipcode)
+    }
+
+    /// Get all frequencies for a county.
+    ///
+    /// Calls `getCountyFreqsByTag` with `tag=0` to request all categories.
+    pub fn get_county_frequencies(&self, county_id: u32) -> Result<Vec<RrFrequency>, SoapError> {
+        tracing::debug!(county_id, "querying RadioReference county frequencies");
+        soap::get_county_freqs_by_tag(&self.http, &self.auth, county_id, 0)
+    }
+}
+```
+
+- [ ] **Step 2: Build and clippy**
+
+Run: `cargo build -p sdr-radioreference && cargo clippy -p sdr-radioreference -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-radioreference/src/lib.rs
+git commit -m "add RrClient public API"
+```
+
+---
+
+## Task 4: sdr-config — KeyringStore
+
+**Files:**
+- Modify: `Cargo.toml` (workspace deps)
+- Modify: `crates/sdr-config/Cargo.toml`
+- Create: `crates/sdr-config/src/keyring_store.rs`
+- Modify: `crates/sdr-config/src/lib.rs`
+
+- [ ] **Step 1: Add keyring dependency**
+
+Add to `Cargo.toml` workspace dependencies:
+
+```toml
+keyring = { version = "3", features = ["sync-secret-service"] }
+```
+
+Add to `crates/sdr-config/Cargo.toml` dependencies:
+
+```toml
+keyring.workspace = true
+```
+
+- [ ] **Step 2: Create KeyringStore**
+
+Create `crates/sdr-config/src/keyring_store.rs`:
+
+```rust
+//! Secure credential storage via the OS keyring.
+//!
+//! Uses `keyring` crate which delegates to:
+//! - **Linux**: Secret Service D-Bus API (GNOME Keyring, KeePassXC)
+//! - **macOS**: Keychain
+
+/// Error type for keyring operations.
+#[derive(Debug, thiserror::Error)]
+pub enum KeyringError {
+    /// No keyring backend available on this system.
+    #[error("no secure storage available — install GNOME Keyring or KeePassXC")]
+    NoBackend,
+    /// The requested credential was not found.
+    #[error("credential not found")]
+    NotFound,
+    /// Platform-specific keyring error.
+    #[error("keyring error: {0}")]
+    Platform(String),
+}
+
+/// Thin wrapper around the OS keyring for storing secrets.
+///
+/// Each instance is scoped to a service name (e.g., `"sdr-rs"`).
+pub struct KeyringStore {
+    service: String,
+}
+
+impl KeyringStore {
+    /// Create a new store scoped to the given service name.
+    pub fn new(service: &str) -> Self {
+        Self {
+            service: service.to_string(),
+        }
+    }
+
+    /// Store a secret value for the given key.
+    pub fn set(&self, key: &str, value: &str) -> Result<(), KeyringError> {
+        let entry = self.entry(key)?;
+        entry
+            .set_password(value)
+            .map_err(|e| KeyringError::Platform(e.to_string()))
+    }
+
+    /// Retrieve a secret value for the given key.
+    ///
+    /// Returns `Ok(None)` if the key does not exist.
+    pub fn get(&self, key: &str) -> Result<Option<String>, KeyringError> {
+        let entry = self.entry(key)?;
+        match entry.get_password() {
+            Ok(val) => Ok(Some(val)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(KeyringError::Platform(e.to_string())),
+        }
+    }
+
+    /// Delete a stored secret.
+    ///
+    /// Returns `Ok(())` even if the key did not exist.
+    pub fn delete(&self, key: &str) -> Result<(), KeyringError> {
+        let entry = self.entry(key)?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(KeyringError::Platform(e.to_string())),
+        }
+    }
+
+    /// Check whether a credential exists for the given key.
+    pub fn has(&self, key: &str) -> bool {
+        self.get(key).ok().flatten().is_some()
+    }
+
+    /// Create a keyring entry for the given key.
+    fn entry(&self, key: &str) -> Result<keyring::Entry, KeyringError> {
+        keyring::Entry::new(&self.service, key).map_err(|e| {
+            if e.to_string().contains("no default") || e.to_string().contains("platform") {
+                KeyringError::NoBackend
+            } else {
+                KeyringError::Platform(e.to_string())
+            }
+        })
+    }
+}
+```
+
+- [ ] **Step 3: Add module to sdr-config lib.rs**
+
+Add to `crates/sdr-config/src/lib.rs` (at the top, with other module declarations):
+
+```rust
+pub mod keyring_store;
+pub use keyring_store::KeyringStore;
+```
+
+- [ ] **Step 4: Build and clippy**
+
+Run: `cargo build -p sdr-config && cargo clippy -p sdr-config -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/sdr-config/
+git commit -m "add KeyringStore for secure credential storage via OS keyring"
+```
+
+---
+
+## Task 5: Bookmark Struct — Add RR Metadata Fields
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/navigation_panel.rs:114-143`
+
+- [ ] **Step 1: Add fields to Bookmark struct**
+
+In `crates/sdr-ui/src/sidebar/navigation_panel.rs`, add two new fields to the `Bookmark` struct after the `high_pass` field (around line 141):
+
+```rust
+    #[serde(default)]
+    pub high_pass: Option<bool>,
+    /// RadioReference category (e.g., "Law Dispatch"). Metadata for future
+    /// bookmark tree organization.
+    #[serde(default)]
+    pub rr_category: Option<String>,
+    /// RadioReference frequency ID for duplicate detection and future sync.
+    #[serde(default)]
+    pub rr_import_id: Option<String>,
+```
+
+- [ ] **Step 2: Update Bookmark::new to include new fields**
+
+In the `Bookmark::new()` method (around line 147), add the new fields with `None` values:
+
+```rust
+            high_pass: None,
+            rr_category: None,
+            rr_import_id: None,
+```
+
+- [ ] **Step 3: Update Bookmark::with_profile to include new fields**
+
+In the `Bookmark::with_profile()` method (around line 168), add the new fields with `None` values:
+
+```rust
+            high_pass: profile.high_pass,
+            rr_category: None,
+            rr_import_id: None,
+```
+
+- [ ] **Step 4: Build and test**
+
+Run: `cargo build --workspace && cargo test --workspace`
+Expected: Clean build, all tests pass (serde(default) ensures backward compat)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-ui/src/sidebar/navigation_panel.rs
+git commit -m "add rr_category and rr_import_id fields to Bookmark"
+```
+
+---
+
+## Task 6: Preferences Window — Scaffold + General Page
+
+**Files:**
+- Create: `crates/sdr-ui/src/preferences/mod.rs`
+- Create: `crates/sdr-ui/src/preferences/general_page.rs`
+- Modify: `crates/sdr-ui/src/lib.rs` (add module)
+- Modify: `crates/sdr-ui/src/window.rs` (add Preferences menu item + action)
+
+- [ ] **Step 1: Create general_page.rs**
+
+Create `crates/sdr-ui/src/preferences/general_page.rs`:
+
+```rust
+//! General preferences page — default directories for recordings and screenshots.
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use sdr_config::ConfigManager;
+use std::sync::Arc;
+
+/// Default recording directory.
+const DEFAULT_RECORDING_DIR: &str = "sdr-recordings";
+/// Default screenshot directory.
+const DEFAULT_SCREENSHOT_DIR: &str = "Pictures";
+
+/// Build the General preferences page.
+pub fn build_general_page(config: &Arc<ConfigManager>) -> adw::PreferencesPage {
+    let page = adw::PreferencesPage::builder()
+        .title("General")
+        .icon_name("preferences-system-symbolic")
+        .build();
+
+    let group = adw::PreferencesGroup::builder()
+        .title("Directories")
+        .description("Default save locations for recordings and screenshots")
+        .build();
+
+    // Recording directory
+    let recording_dir = get_config_dir(config, "recording_dir", DEFAULT_RECORDING_DIR);
+    let recording_row = adw::ActionRow::builder()
+        .title("Recording Directory")
+        .subtitle(&recording_dir)
+        .build();
+
+    let recording_btn = gtk4::Button::builder()
+        .icon_name("folder-open-symbolic")
+        .valign(gtk4::Align::Center)
+        .tooltip_text("Choose directory")
+        .build();
+    recording_row.add_suffix(&recording_btn);
+
+    let config_clone = Arc::clone(config);
+    let row_clone = recording_row.clone();
+    recording_btn.connect_clicked(move |btn| {
+        let dialog = gtk4::FileDialog::builder()
+            .title("Select Recording Directory")
+            .build();
+        let config_inner = Arc::clone(&config_clone);
+        let row_inner = row_clone.clone();
+        let window = btn.root().and_downcast::<gtk4::Window>();
+        dialog.select_folder(window.as_ref(), gtk4::gio::Cancellable::NONE, move |result| {
+            if let Ok(folder) = result {
+                if let Some(path) = folder.path() {
+                    let path_str = path.to_string_lossy().to_string();
+                    row_inner.set_subtitle(&path_str);
+                    config_inner.write(|v| {
+                        v["recording_dir"] = serde_json::Value::String(path_str);
+                    });
+                }
+            }
+        });
+    });
+
+    // Screenshot directory
+    let screenshot_dir = get_config_dir(config, "screenshot_dir", DEFAULT_SCREENSHOT_DIR);
+    let screenshot_row = adw::ActionRow::builder()
+        .title("Screenshot Directory")
+        .subtitle(&screenshot_dir)
+        .build();
+
+    let screenshot_btn = gtk4::Button::builder()
+        .icon_name("folder-open-symbolic")
+        .valign(gtk4::Align::Center)
+        .tooltip_text("Choose directory")
+        .build();
+    screenshot_row.add_suffix(&screenshot_btn);
+
+    let config_clone = Arc::clone(config);
+    let row_clone = screenshot_row.clone();
+    screenshot_btn.connect_clicked(move |btn| {
+        let dialog = gtk4::FileDialog::builder()
+            .title("Select Screenshot Directory")
+            .build();
+        let config_inner = Arc::clone(&config_clone);
+        let row_inner = row_clone.clone();
+        let window = btn.root().and_downcast::<gtk4::Window>();
+        dialog.select_folder(window.as_ref(), gtk4::gio::Cancellable::NONE, move |result| {
+            if let Ok(folder) = result {
+                if let Some(path) = folder.path() {
+                    let path_str = path.to_string_lossy().to_string();
+                    row_inner.set_subtitle(&path_str);
+                    config_inner.write(|v| {
+                        v["screenshot_dir"] = serde_json::Value::String(path_str);
+                    });
+                }
+            }
+        });
+    });
+
+    group.add(&recording_row);
+    group.add(&screenshot_row);
+    page.add(&group);
+    page
+}
+
+/// Read a directory config value, falling back to `$HOME/default`.
+fn get_config_dir(config: &Arc<ConfigManager>, key: &str, default_subdir: &str) -> String {
+    config.read(|v| {
+        v.get(key)
+            .and_then(serde_json::Value::as_str)
+            .map(String::from)
+            .unwrap_or_else(|| {
+                let home = gtk4::glib::home_dir();
+                home.join(default_subdir).to_string_lossy().to_string()
+            })
+    })
+}
+```
+
+- [ ] **Step 2: Create preferences/mod.rs**
+
+Create `crates/sdr-ui/src/preferences/mod.rs`:
+
+```rust
+//! Application preferences window.
+
+pub mod general_page;
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use sdr_config::ConfigManager;
+use std::sync::Arc;
+
+/// Build and return the preferences window.
+pub fn build_preferences_window(
+    parent: &impl IsA<gtk4::Window>,
+    config: &Arc<ConfigManager>,
+) -> adw::PreferencesWindow {
+    let window = adw::PreferencesWindow::builder()
+        .title("Preferences")
+        .transient_for(parent)
+        .modal(true)
+        .default_width(600)
+        .default_height(500)
+        .build();
+
+    // General page
+    let general = general_page::build_general_page(config);
+    window.add(&general);
+
+    window
+}
+```
+
+- [ ] **Step 3: Add module to lib.rs**
+
+In `crates/sdr-ui/src/lib.rs`, add after the `notify` module:
+
+```rust
+pub mod preferences;
+```
+
+- [ ] **Step 4: Add Preferences menu item and action to window.rs**
+
+In `crates/sdr-ui/src/window.rs`, in `build_menu_button()` (around line 495), add a "Preferences" menu item before the "Keyboard Shortcuts" item:
+
+```rust
+menu.append(Some("_Preferences"), Some("app.preferences"));
+```
+
+In `setup_app_actions()` (around line 1278), add the preferences action. This function receives the `app` and `window`. Add a new action that opens the preferences window:
+
+```rust
+let preferences_action = gio::SimpleAction::new("preferences", None);
+let window_clone = window.clone();
+preferences_action.connect_activate(move |_, _| {
+    // ConfigManager needs to be available here — read from the
+    // function parameter or state. We'll pass it through.
+    let prefs = crate::preferences::build_preferences_window(
+        &window_clone,
+        // config ref — see Step 5 for how this is threaded through
+    );
+    prefs.present();
+});
+app.add_action(&preferences_action);
+```
+
+Note: The `ConfigManager` needs to be threaded into `setup_app_actions`. This requires adding a `config: &Arc<ConfigManager>` parameter to `setup_app_actions` and to `build_window`. The config is already created in `dsp_controller.rs` — read the current `build_window` call site to understand how to pass it through.
+
+- [ ] **Step 5: Thread ConfigManager through to preferences**
+
+The `ConfigManager` is created in `dsp_controller.rs`. It needs to reach the preferences window. Add `config: Arc<ConfigManager>` as a parameter to `build_window()` and `setup_app_actions()`, then pass it from the call site.
+
+In `app.rs`, the `connect_activate` closure calls `window::build_window(app)`. Update this to also create/load the config and pass it:
+
+```rust
+app.connect_activate(|app| {
+    let config_path = gtk4::glib::user_config_dir().join("sdr-rs").join("config.json");
+    let defaults = serde_json::json!({});
+    let config = std::sync::Arc::new(
+        sdr_config::ConfigManager::load(&config_path, &defaults)
+            .unwrap_or_else(|e| {
+                tracing::warn!("config load failed, using defaults: {e}");
+                sdr_config::ConfigManager::load(&config_path, &defaults)
+                    .expect("default config creation should not fail")
+            })
+    );
+    window::build_window(app, &config);
+});
+```
+
+Update `build_window` signature to accept `config: &Arc<ConfigManager>` and thread it to `setup_app_actions`.
+
+- [ ] **Step 6: Build and test**
+
+Run: `cargo build --workspace && cargo clippy --all-targets --workspace -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/sdr-ui/src/preferences/ crates/sdr-ui/src/lib.rs crates/sdr-ui/src/window.rs crates/sdr-ui/src/app.rs
+git commit -m "add AdwPreferencesWindow with General page for directory settings"
+```
+
+---
+
+## Task 7: Accounts Page — Credential Entry + Test & Save
+
+**Files:**
+- Create: `crates/sdr-ui/src/preferences/accounts_page.rs`
+- Modify: `crates/sdr-ui/src/preferences/mod.rs`
+- Modify: `crates/sdr-ui/Cargo.toml` (add sdr-radioreference dep)
+
+- [ ] **Step 1: Add sdr-radioreference to sdr-ui dependencies**
+
+In `crates/sdr-ui/Cargo.toml`, add:
+
+```toml
+sdr-radioreference.workspace = true
+```
+
+- [ ] **Step 2: Create accounts_page.rs**
+
+Create `crates/sdr-ui/src/preferences/accounts_page.rs`:
+
+```rust
+//! Accounts preferences page — RadioReference credential management.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use sdr_config::KeyringStore;
+
+/// Keyring service name.
+const KEYRING_SERVICE: &str = "sdr-rs";
+/// Keyring key for RR username.
+const RR_USERNAME_KEY: &str = "radioreference-username";
+/// Keyring key for RR password.
+const RR_PASSWORD_KEY: &str = "radioreference-password";
+
+/// Build the Accounts preferences page.
+///
+/// Returns `(page, has_credentials_flag)`. The flag is `true` if valid
+/// credentials are currently stored and can be used by other UI components
+/// to show/hide the RadioReference browse button.
+pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
+    let page = adw::PreferencesPage::builder()
+        .title("Accounts")
+        .icon_name("system-users-symbolic")
+        .build();
+
+    let group = adw::PreferencesGroup::builder()
+        .title("RadioReference")
+        .description("Premium account credentials for frequency database access")
+        .build();
+
+    let username_row = adw::EntryRow::builder()
+        .title("Username")
+        .build();
+
+    let password_row = adw::PasswordEntryRow::builder()
+        .title("Password")
+        .build();
+
+    // Status label (hidden initially)
+    let status_label = gtk4::Label::builder()
+        .css_classes(["dim-label"])
+        .visible(false)
+        .build();
+
+    // Test & Save button
+    let test_button = gtk4::Button::builder()
+        .label("Test & Save")
+        .css_classes(["suggested-action"])
+        .build();
+
+    // Spinner (hidden initially)
+    let spinner = gtk4::Spinner::builder()
+        .visible(false)
+        .build();
+
+    // Remove credentials button (visible only when creds exist)
+    let remove_button = gtk4::Button::builder()
+        .label("Remove Credentials")
+        .css_classes(["destructive-action"])
+        .build();
+
+    // Track whether credentials are stored
+    let has_credentials = Rc::new(Cell::new(false));
+
+    // Pre-fill if credentials exist
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    if let Ok(Some(user)) = store.get(RR_USERNAME_KEY) {
+        username_row.set_text(&user);
+        has_credentials.set(true);
+        remove_button.set_visible(true);
+        status_label.set_text("Credentials stored");
+        status_label.set_css_classes(&["success"]);
+        status_label.set_visible(true);
+    } else {
+        remove_button.set_visible(false);
+    }
+
+    // Test & Save handler
+    let username_clone = username_row.clone();
+    let password_clone = password_row.clone();
+    let status_clone = status_label.clone();
+    let spinner_clone = spinner.clone();
+    let test_btn_clone = test_button.clone();
+    let remove_btn_clone = remove_button.clone();
+    let has_creds_clone = Rc::clone(&has_credentials);
+
+    test_button.connect_clicked(move |_| {
+        let username = username_clone.text().to_string();
+        let password = password_clone.text().to_string();
+
+        if username.is_empty() || password.is_empty() {
+            status_clone.set_text("Enter username and password");
+            status_clone.set_css_classes(&["error"]);
+            status_clone.set_visible(true);
+            return;
+        }
+
+        // Show spinner, disable button
+        spinner_clone.set_visible(true);
+        spinner_clone.start();
+        test_btn_clone.set_sensitive(false);
+        status_clone.set_visible(false);
+
+        let status = status_clone.clone();
+        let spinner = spinner_clone.clone();
+        let test_btn = test_btn_clone.clone();
+        let remove_btn = remove_btn_clone.clone();
+        let has_creds = Rc::clone(&has_creds_clone);
+
+        // Run SOAP test on background thread
+        let (sender, receiver) = glib::MainContext::channel::<Result<(), String>>(glib::Priority::DEFAULT);
+
+        gtk4::gio::spawn_blocking(move || {
+            let client = sdr_radioreference::RrClient::new(&username, &password);
+            let result = client
+                .test_connection()
+                .map_err(|e| e.to_string());
+
+            if result.is_ok() {
+                // Save credentials on success
+                let store = KeyringStore::new(KEYRING_SERVICE);
+                if let Err(e) = store.set(RR_USERNAME_KEY, &username) {
+                    let _ = sender.send(Err(format!("keyring: {e}")));
+                    return;
+                }
+                if let Err(e) = store.set(RR_PASSWORD_KEY, &password) {
+                    let _ = sender.send(Err(format!("keyring: {e}")));
+                    return;
+                }
+            }
+
+            let _ = sender.send(result);
+        });
+
+        receiver.attach(None, move |result| {
+            spinner.stop();
+            spinner.set_visible(false);
+            test_btn.set_sensitive(true);
+
+            match result {
+                Ok(()) => {
+                    status.set_text("Connected — credentials saved");
+                    status.set_css_classes(&["success"]);
+                    has_creds.set(true);
+                    remove_btn.set_visible(true);
+                }
+                Err(e) => {
+                    status.set_text(&format!("Failed: {e}"));
+                    status.set_css_classes(&["error"]);
+                }
+            }
+            status.set_visible(true);
+            glib::ControlFlow::Continue
+        });
+    });
+
+    // Remove credentials handler
+    let status_clone = status_label.clone();
+    let username_clone = username_row.clone();
+    let password_clone = password_row.clone();
+    let has_creds_clone = Rc::clone(&has_credentials);
+    let remove_btn_clone = remove_button.clone();
+
+    remove_button.connect_clicked(move |_| {
+        let store = KeyringStore::new(KEYRING_SERVICE);
+        let _ = store.delete(RR_USERNAME_KEY);
+        let _ = store.delete(RR_PASSWORD_KEY);
+
+        username_clone.set_text("");
+        password_clone.set_text("");
+        has_creds_clone.set(false);
+        remove_btn_clone.set_visible(false);
+        status_clone.set_text("Credentials removed");
+        status_clone.set_css_classes(&["dim-label"]);
+        status_clone.set_visible(true);
+    });
+
+    // Layout: rows in a vertical box within the group
+    let button_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .spacing(12)
+        .margin_top(8)
+        .build();
+    button_box.append(&test_button);
+    button_box.append(&spinner);
+    button_box.append(&remove_button);
+
+    group.add(&username_row);
+    group.add(&password_row);
+
+    let status_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(8)
+        .margin_top(8)
+        .build();
+    status_box.append(&button_box);
+    status_box.append(&status_label);
+    group.add(&status_box);
+
+    page.add(&group);
+
+    (page, has_credentials)
+}
+
+/// Check if RadioReference credentials are stored in the keyring.
+pub fn has_rr_credentials() -> bool {
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    store.has(RR_USERNAME_KEY) && store.has(RR_PASSWORD_KEY)
+}
+
+/// Load RadioReference credentials from the keyring.
+///
+/// Returns `(username, password)` or `None` if not stored.
+pub fn load_rr_credentials() -> Option<(String, String)> {
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    let username = store.get(RR_USERNAME_KEY).ok()??;
+    let password = store.get(RR_PASSWORD_KEY).ok()??;
+    Some((username, password))
+}
+```
+
+- [ ] **Step 3: Add accounts page to preferences mod.rs**
+
+In `crates/sdr-ui/src/preferences/mod.rs`, add:
+
+```rust
+pub mod accounts_page;
+```
+
+And in `build_preferences_window`, add the accounts page after the general page:
+
+```rust
+    // Accounts page
+    let (accounts, _has_credentials) = accounts_page::build_accounts_page();
+    window.add(&accounts);
+```
+
+- [ ] **Step 4: Build and clippy**
+
+Run: `cargo build --workspace && cargo clippy --all-targets --workspace -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-ui/Cargo.toml crates/sdr-ui/src/preferences/
+git commit -m "add Accounts preferences page with RR credential test & save"
+```
+
+---
+
+## Task 8: RadioReference Browse Dialog — Search + County Picker
+
+**Files:**
+- Create: `crates/sdr-ui/src/radioreference/mod.rs`
+- Create: `crates/sdr-ui/src/radioreference/frequency_list.rs`
+- Modify: `crates/sdr-ui/src/lib.rs`
+- Modify: `crates/sdr-ui/src/window.rs` (header button + wiring)
+
+- [ ] **Step 1: Create frequency_list.rs**
+
+Create `crates/sdr-ui/src/radioreference/frequency_list.rs`:
+
+```rust
+//! Frequency list widget with checkboxes, filtering, and duplicate detection.
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+
+use sdr_radioreference::RrFrequency;
+use crate::sidebar::navigation_panel::{format_frequency, Bookmark};
+
+/// A frequency row in the list — wraps an `RrFrequency` with selection state.
+#[derive(Debug, Clone)]
+pub struct FrequencyRow {
+    pub frequency: RrFrequency,
+    pub selected: bool,
+    pub already_bookmarked: bool,
+}
+
+/// Build the frequency list box and associated filter dropdowns.
+///
+/// Returns `(container, frequency_rows, import_button)` where:
+/// - `container` is the full widget with filters + list + import button
+/// - `frequency_rows` is the shared mutable list of rows for reading selection state
+/// - `import_button` is the import button for connecting the import action externally
+#[allow(clippy::too_many_lines)]
+pub fn build_frequency_list(
+    existing_bookmarks: &[Bookmark],
+) -> (gtk4::Box, Rc<RefCell<Vec<FrequencyRow>>>, gtk4::Button) {
+    let container = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(8)
+        .build();
+
+    // Category filter
+    let category_model = gtk4::StringList::new(&["All"]);
+    let category_dropdown = gtk4::DropDown::builder()
+        .model(&category_model)
+        .build();
+    let category_row = adw::ActionRow::builder()
+        .title("Category")
+        .build();
+    category_row.add_suffix(&category_dropdown);
+
+    // Agency filter
+    let agency_model = gtk4::StringList::new(&["All"]);
+    let agency_dropdown = gtk4::DropDown::builder()
+        .model(&agency_model)
+        .build();
+    let agency_row = adw::ActionRow::builder()
+        .title("Agency")
+        .build();
+    agency_row.add_suffix(&agency_dropdown);
+
+    // Frequency list
+    let scroll = gtk4::ScrolledWindow::builder()
+        .vexpand(true)
+        .min_content_height(300)
+        .build();
+    let list_box = gtk4::ListBox::builder()
+        .css_classes(["boxed-list"])
+        .selection_mode(gtk4::SelectionMode::None)
+        .build();
+    scroll.set_child(Some(&list_box));
+
+    // Import button
+    let import_button = gtk4::Button::builder()
+        .label("Import Selected (0)")
+        .css_classes(["suggested-action"])
+        .sensitive(false)
+        .build();
+
+    // Shared state
+    let rows: Rc<RefCell<Vec<FrequencyRow>>> = Rc::new(RefCell::new(Vec::new()));
+
+    // Build set of existing bookmark IDs and frequencies for dedup
+    let existing_rr_ids: HashSet<String> = existing_bookmarks
+        .iter()
+        .filter_map(|b| b.rr_import_id.clone())
+        .collect();
+    let existing_freqs: HashSet<u64> = existing_bookmarks
+        .iter()
+        .map(|b| b.frequency)
+        .collect();
+
+    // Store dedup sets for use in populate
+    let existing_rr_ids = Rc::new(existing_rr_ids);
+    let existing_freqs = Rc::new(existing_freqs);
+
+    container.append(&category_row);
+    container.append(&agency_row);
+    container.append(&scroll);
+    container.append(&import_button);
+
+    // Expose populate and filter functions via closures stored on widgets
+    // The parent dialog will call populate_frequencies() after a successful search
+
+    (container, rows, import_button)
+}
+
+/// Populate the frequency list with results from RadioReference.
+///
+/// Builds check rows, applies duplicate detection, and sets up filter dropdowns.
+pub fn populate_frequencies(
+    list_box: &gtk4::ListBox,
+    rows: &Rc<RefCell<Vec<FrequencyRow>>>,
+    frequencies: &[RrFrequency],
+    existing_bookmarks: &[Bookmark],
+    category_model: &gtk4::StringList,
+    agency_model: &gtk4::StringList,
+    import_button: &gtk4::Button,
+) {
+    // Clear existing
+    while let Some(child) = list_box.first_child() {
+        list_box.remove(&child);
+    }
+    rows.borrow_mut().clear();
+
+    // Build dedup sets
+    let existing_rr_ids: HashSet<String> = existing_bookmarks
+        .iter()
+        .filter_map(|b| b.rr_import_id.clone())
+        .collect();
+    let existing_freqs: HashSet<u64> = existing_bookmarks
+        .iter()
+        .map(|b| b.frequency)
+        .collect();
+
+    // Collect unique categories and agencies for filter dropdowns
+    let mut categories: Vec<String> = Vec::new();
+    let mut agencies: Vec<String> = Vec::new();
+
+    // Build rows
+    let mut freq_rows = Vec::new();
+    for freq in frequencies {
+        let already_bookmarked = existing_rr_ids.contains(&freq.id)
+            || existing_freqs.contains(&freq.freq_hz);
+
+        // Derive category from first tag
+        let category = freq
+            .tags
+            .first()
+            .map(|t| t.description.clone())
+            .unwrap_or_else(|| "Uncategorized".to_string());
+
+        if !categories.contains(&category) {
+            categories.push(category.clone());
+        }
+
+        let agency = freq.alpha_tag.clone();
+        if !agency.is_empty() && !agencies.contains(&agency) {
+            agencies.push(agency.clone());
+        }
+
+        freq_rows.push(FrequencyRow {
+            frequency: freq.clone(),
+            selected: false,
+            already_bookmarked,
+        });
+    }
+
+    // Update filter models
+    category_model.splice(0, category_model.n_items(), &{
+        let mut items = vec!["All".to_string()];
+        categories.sort();
+        items.extend(categories);
+        items.iter().map(String::as_str).collect::<Vec<_>>()
+    });
+
+    agency_model.splice(0, agency_model.n_items(), &{
+        let mut items = vec!["All".to_string()];
+        agencies.sort();
+        items.extend(agencies);
+        items.iter().map(String::as_str).collect::<Vec<_>>()
+    });
+
+    // Build list rows
+    let import_btn = import_button.clone();
+    let rows_ref = Rc::clone(rows);
+
+    for (i, row) in freq_rows.iter().enumerate() {
+        let freq = &row.frequency;
+        let freq_str = format_frequency(freq.freq_hz);
+        let mapped = sdr_radioreference::mode_map::map_rr_mode(&freq.mode);
+
+        let list_row = adw::ActionRow::builder()
+            .title(&format!("{freq_str}  {}", mapped.demod_mode))
+            .subtitle(&freq.description)
+            .build();
+
+        if row.already_bookmarked {
+            // Show saved indicator — not selectable
+            let icon = gtk4::Image::builder()
+                .icon_name("emblem-ok-symbolic")
+                .tooltip_text("Already bookmarked")
+                .css_classes(["dim-label"])
+                .build();
+            list_row.add_prefix(&icon);
+            list_row.set_sensitive(false);
+        } else {
+            // Checkbox for selection
+            let check = gtk4::CheckButton::builder()
+                .valign(gtk4::Align::Center)
+                .build();
+            list_row.add_prefix(&check);
+
+            let rows_inner = Rc::clone(&rows_ref);
+            let import_inner = import_btn.clone();
+            check.connect_toggled(move |cb| {
+                if let Some(r) = rows_inner.borrow_mut().get_mut(i) {
+                    r.selected = cb.is_active();
+                }
+                update_import_count(&rows_inner, &import_inner);
+            });
+        }
+
+        list_box.append(&list_row);
+    }
+
+    *rows.borrow_mut() = freq_rows;
+    update_import_count(rows, import_button);
+}
+
+/// Update the import button label with the count of selected frequencies.
+fn update_import_count(rows: &Rc<RefCell<Vec<FrequencyRow>>>, button: &gtk4::Button) {
+    let count = rows
+        .borrow()
+        .iter()
+        .filter(|r| r.selected && !r.already_bookmarked)
+        .count();
+    button.set_label(&format!("Import Selected ({count})"));
+    button.set_sensitive(count > 0);
+}
+```
+
+- [ ] **Step 2: Create radioreference/mod.rs — browse dialog**
+
+Create `crates/sdr-ui/src/radioreference/mod.rs`:
+
+```rust
+//! RadioReference browse dialog — search by zip code, filter, and import frequencies.
+
+pub mod frequency_list;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use sdr_radioreference::{RrFrequency, ZipInfo};
+
+use crate::sidebar::navigation_panel::{
+    Bookmark, load_bookmarks, save_bookmarks,
+};
+use frequency_list::{FrequencyRow, populate_frequencies};
+
+/// Open the RadioReference browse dialog.
+#[allow(clippy::too_many_lines)]
+pub fn show_browse_dialog(parent: &impl IsA<gtk4::Widget>) {
+    let dialog = adw::Dialog::builder()
+        .title("RadioReference")
+        .content_width(700)
+        .content_height(600)
+        .build();
+
+    let content = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(12)
+        .margin_start(16)
+        .margin_end(16)
+        .margin_top(16)
+        .margin_bottom(16)
+        .build();
+
+    // ── Search section ──────────────────────────────────────────────
+
+    let search_group = adw::PreferencesGroup::builder()
+        .title("Search")
+        .build();
+
+    let zip_row = adw::EntryRow::builder()
+        .title("Zip Code")
+        .build();
+
+    let search_button = gtk4::Button::builder()
+        .label("Search")
+        .css_classes(["suggested-action"])
+        .valign(gtk4::Align::Center)
+        .build();
+    zip_row.add_suffix(&search_button);
+
+    search_group.add(&zip_row);
+
+    // County dropdown (hidden until search returns multiple)
+    let county_model = gtk4::StringList::new(&[]);
+    let county_dropdown = gtk4::DropDown::builder()
+        .model(&county_model)
+        .visible(false)
+        .build();
+    let county_row = adw::ActionRow::builder()
+        .title("County")
+        .visible(false)
+        .build();
+    county_row.add_suffix(&county_dropdown);
+    search_group.add(&county_row);
+
+    // Status / spinner
+    let search_spinner = gtk4::Spinner::builder()
+        .visible(false)
+        .build();
+    let search_status = gtk4::Label::builder()
+        .css_classes(["dim-label"])
+        .visible(false)
+        .build();
+
+    content.append(&search_group);
+    content.append(&search_spinner);
+    content.append(&search_status);
+
+    // ── Results section ─────────────────────────────────────────────
+
+    let results_group = adw::PreferencesGroup::builder()
+        .title("Frequencies")
+        .visible(false)
+        .build();
+
+    // Category filter
+    let category_model = gtk4::StringList::new(&["All"]);
+    let category_dropdown = gtk4::DropDown::builder()
+        .model(&category_model)
+        .build();
+    let category_row = adw::ActionRow::builder()
+        .title("Category")
+        .build();
+    category_row.add_suffix(&category_dropdown);
+    results_group.add(&category_row);
+
+    // Agency filter
+    let agency_model = gtk4::StringList::new(&["All"]);
+    let agency_dropdown = gtk4::DropDown::builder()
+        .model(&agency_model)
+        .build();
+    let agency_row = adw::ActionRow::builder()
+        .title("Agency")
+        .build();
+    agency_row.add_suffix(&agency_dropdown);
+    results_group.add(&agency_row);
+
+    // Frequency list
+    let scroll = gtk4::ScrolledWindow::builder()
+        .vexpand(true)
+        .min_content_height(300)
+        .build();
+    let list_box = gtk4::ListBox::builder()
+        .css_classes(["boxed-list"])
+        .selection_mode(gtk4::SelectionMode::None)
+        .build();
+    scroll.set_child(Some(&list_box));
+    results_group.add(&scroll);
+
+    // Import button
+    let import_button = gtk4::Button::builder()
+        .label("Import Selected (0)")
+        .css_classes(["suggested-action"])
+        .sensitive(false)
+        .margin_top(8)
+        .build();
+
+    content.append(&results_group);
+    content.append(&import_button);
+
+    // ── Shared state ────────────────────────────────────────────────
+
+    let rows: Rc<RefCell<Vec<FrequencyRow>>> = Rc::new(RefCell::new(Vec::new()));
+    let fetched_frequencies: Rc<RefCell<Vec<RrFrequency>>> = Rc::new(RefCell::new(Vec::new()));
+    let zip_infos: Rc<RefCell<Vec<ZipInfo>>> = Rc::new(RefCell::new(Vec::new()));
+
+    // ── Search handler ──────────────────────────────────────────────
+
+    let zip_clone = zip_row.clone();
+    let spinner_clone = search_spinner.clone();
+    let status_clone = search_status.clone();
+    let county_row_clone = county_row.clone();
+    let county_dropdown_clone = county_dropdown.clone();
+    let county_model_clone = county_model.clone();
+    let results_group_clone = results_group.clone();
+    let list_box_clone = list_box.clone();
+    let rows_clone = Rc::clone(&rows);
+    let fetched_clone = Rc::clone(&fetched_frequencies);
+    let zip_infos_clone = Rc::clone(&zip_infos);
+    let category_model_clone = category_model.clone();
+    let agency_model_clone = agency_model.clone();
+    let import_btn_clone = import_button.clone();
+
+    search_button.connect_clicked(move |_| {
+        let zipcode = zip_clone.text().to_string().trim().to_string();
+        if zipcode.is_empty() || zipcode.len() != 5 {
+            status_clone.set_text("Enter a 5-digit zip code");
+            status_clone.set_css_classes(&["error"]);
+            status_clone.set_visible(true);
+            return;
+        }
+
+        // Show spinner
+        spinner_clone.set_visible(true);
+        spinner_clone.start();
+        status_clone.set_visible(false);
+
+        let (sender, receiver) =
+            glib::MainContext::channel::<Result<(ZipInfo, Vec<RrFrequency>), String>>(
+                glib::Priority::DEFAULT,
+            );
+
+        // Load credentials and query on background thread
+        let zip = zipcode.clone();
+        gtk4::gio::spawn_blocking(move || {
+            let Some((username, password)) =
+                crate::preferences::accounts_page::load_rr_credentials()
+            else {
+                let _ = sender.send(Err("no credentials stored".to_string()));
+                return;
+            };
+
+            let client = sdr_radioreference::RrClient::new(&username, &password);
+
+            // Step 1: get zip info
+            let zip_info = match client.get_zip_info(&zip) {
+                Ok(info) => info,
+                Err(e) => {
+                    let _ = sender.send(Err(format!("zip lookup: {e}")));
+                    return;
+                }
+            };
+
+            // Step 2: get county frequencies
+            let freqs = match client.get_county_frequencies(zip_info.county_id) {
+                Ok(f) => f,
+                Err(e) => {
+                    let _ = sender.send(Err(format!("frequency query: {e}")));
+                    return;
+                }
+            };
+
+            let _ = sender.send(Ok((zip_info, freqs)));
+        });
+
+        let spinner = spinner_clone.clone();
+        let status = status_clone.clone();
+        let county_row = county_row_clone.clone();
+        let county_dropdown = county_dropdown_clone.clone();
+        let results_group = results_group_clone.clone();
+        let list_box = list_box_clone.clone();
+        let rows = Rc::clone(&rows_clone);
+        let fetched = Rc::clone(&fetched_clone);
+        let cat_model = category_model_clone.clone();
+        let agency_model = agency_model_clone.clone();
+        let import_btn = import_btn_clone.clone();
+
+        receiver.attach(None, move |result| {
+            spinner.stop();
+            spinner.set_visible(false);
+
+            match result {
+                Ok((zip_info, frequencies)) => {
+                    status.set_text(&format!(
+                        "{}, {} — {} frequencies",
+                        zip_info.county_name,
+                        zip_info.state_name,
+                        frequencies.len()
+                    ));
+                    status.set_css_classes(&["dim-label"]);
+                    status.set_visible(true);
+
+                    // Store fetched data
+                    *fetched.borrow_mut() = frequencies.clone();
+
+                    // Populate the frequency list
+                    let bookmarks = load_bookmarks();
+                    populate_frequencies(
+                        &list_box,
+                        &rows,
+                        &frequencies,
+                        &bookmarks,
+                        &cat_model,
+                        &agency_model,
+                        &import_btn,
+                    );
+
+                    results_group.set_visible(true);
+                }
+                Err(e) => {
+                    status.set_text(&e);
+                    status.set_css_classes(&["error"]);
+                    status.set_visible(true);
+                    results_group.set_visible(false);
+                }
+            }
+
+            glib::ControlFlow::Continue
+        });
+    });
+
+    // ── Import handler ──────────────────────────────────────────────
+
+    let rows_import = Rc::clone(&rows);
+    let dialog_ref = dialog.clone();
+
+    import_button.connect_clicked(move |_| {
+        let selected: Vec<RrFrequency> = rows_import
+            .borrow()
+            .iter()
+            .filter(|r| r.selected && !r.already_bookmarked)
+            .map(|r| r.frequency.clone())
+            .collect();
+
+        if selected.is_empty() {
+            return;
+        }
+
+        let mut bookmarks = load_bookmarks();
+
+        for freq in &selected {
+            let mapped = sdr_radioreference::mode_map::map_rr_mode(&freq.mode);
+            let name = if freq.alpha_tag.is_empty() {
+                freq.description.clone()
+            } else {
+                format!("{} - {}", freq.alpha_tag, freq.description)
+            };
+
+            let mut bookmark = Bookmark::new(
+                &name,
+                freq.freq_hz,
+                mapped.demod_mode,
+                mapped.bandwidth,
+            );
+            bookmark.rr_category = freq
+                .tags
+                .first()
+                .map(|t| t.description.clone());
+            bookmark.rr_import_id = Some(freq.id.clone());
+
+            bookmarks.push(bookmark);
+        }
+
+        save_bookmarks(&bookmarks);
+        tracing::info!(count = selected.len(), "imported RadioReference frequencies");
+
+        dialog_ref.close();
+    });
+
+    // ── Present ─────────────────────────────────────────────────────
+
+    let scroll_outer = gtk4::ScrolledWindow::builder()
+        .child(&content)
+        .build();
+    dialog.set_child(Some(&scroll_outer));
+    dialog.present(Some(parent));
+}
+```
+
+- [ ] **Step 3: Add module to lib.rs**
+
+In `crates/sdr-ui/src/lib.rs`, add:
+
+```rust
+pub mod radioreference;
+```
+
+- [ ] **Step 4: Add RadioReference button to header bar and wire it**
+
+In `crates/sdr-ui/src/window.rs`:
+
+1. In `build_header_bar()`, add a RadioReference button (near the screenshot button, packed to the end):
+
+```rust
+let rr_button = gtk4::Button::builder()
+    .icon_name("network-wireless-symbolic")
+    .tooltip_text("RadioReference Frequency Browser")
+    .visible(crate::preferences::accounts_page::has_rr_credentials())
+    .build();
+```
+
+Pack it: `header.pack_end(&rr_button);` (before the screenshot button pack_end call so it appears to the left of the screenshot button).
+
+2. Return `rr_button` from `build_header_bar` (add it to the return tuple).
+
+3. In `build_window()`, wire the RR button click:
+
+```rust
+rr_button.connect_clicked(move |btn| {
+    crate::radioreference::show_browse_dialog(btn);
+});
+```
+
+- [ ] **Step 5: Build and clippy**
+
+Run: `cargo build --workspace && cargo clippy --all-targets --workspace -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-ui/src/radioreference/ crates/sdr-ui/src/lib.rs crates/sdr-ui/src/window.rs
+git commit -m "add RadioReference browse dialog with zip search and frequency import"
+```
+
+---
+
+## Task 9: Cascading Filters + Final Wiring
+
+**Files:**
+- Modify: `crates/sdr-ui/src/radioreference/mod.rs`
+- Modify: `crates/sdr-ui/src/radioreference/frequency_list.rs`
+
+- [ ] **Step 1: Add filter-by-category logic**
+
+In `crates/sdr-ui/src/radioreference/mod.rs`, after the frequency list is populated, wire the category and agency dropdowns to filter the list:
+
+Connect the `category_dropdown` `notify::selected` signal to rebuild the visible list rows. When a category is selected:
+- If "All" → show all rows
+- Otherwise → show only rows whose first tag matches the selected category
+
+Similarly for `agency_dropdown`:
+- If "All" → show all (subject to category filter)
+- Otherwise → show only rows whose `alpha_tag` matches
+
+The filtering is client-side: just toggle `set_visible` on list rows based on the active filter values.
+
+- [ ] **Step 2: Wire filter dropdowns in the dialog**
+
+After the frequency list is populated (in the search handler's receiver callback), connect the filter signals:
+
+```rust
+// Category filter
+let list_box_filter = list_box.clone();
+let rows_filter = Rc::clone(&rows);
+let cat_model_filter = cat_model.clone();
+category_dropdown.connect_notify(Some("selected"), move |dd, _| {
+    let idx = dd.selected();
+    let filter_val = if idx == 0 {
+        None // "All"
+    } else {
+        cat_model_filter
+            .string(idx)
+            .map(|s| s.to_string())
+    };
+    apply_filters(&list_box_filter, &rows_filter, &filter_val, &None);
+});
+```
+
+Add the `apply_filters` function that iterates list box children and sets visibility based on category/agency match.
+
+- [ ] **Step 3: Refresh bookmark list after import**
+
+After `dialog_ref.close()` in the import handler, the main window's bookmark list needs to reload. Pass a callback or use the existing `NavigationPanel::bookmarks` `RefCell` to trigger a rebuild.
+
+The simplest approach: since `save_bookmarks()` writes to disk, and the navigation panel's bookmark list is rebuilt from disk on demand, the next time the user interacts with bookmarks it will reload. For immediate feedback, call the existing `rebuild_bookmark_list` function after import.
+
+Thread the bookmark reload callback into `show_browse_dialog`:
+
+```rust
+pub fn show_browse_dialog(parent: &impl IsA<gtk4::Widget>, on_import: impl Fn() + 'static)
+```
+
+In the import handler, call `on_import()` after saving. In `window.rs`, pass a closure that rebuilds the bookmark list.
+
+- [ ] **Step 4: Build, clippy, test**
+
+Run: `cargo build --workspace && cargo clippy --all-targets --workspace -- -D warnings && cargo test --workspace`
+Expected: All clean
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add crates/sdr-ui/
+git commit -m "add cascading category/agency filters and bookmark refresh on import"
+```
+
+---
+
+## Verification Checklist
+
+After all tasks:
+
+1. `cargo build --workspace` compiles
+2. `cargo test --workspace` all tests pass
+3. `cargo clippy --all-targets --workspace -- -D warnings` clean
+4. Preferences window opens from app menu with General + Accounts pages
+5. General page folder pickers work and persist to config
+6. Accounts page: entering RR credentials + Test & Save validates via SOAP call
+7. Credentials stored in OS keyring (verify via `secret-tool lookup service sdr-rs`)
+8. RadioReference icon appears in header bar after credentials are saved
+9. Browse dialog opens, zip code search returns frequencies
+10. County picker appears when zip maps to multiple counties
+11. Category/Agency filters narrow the frequency list
+12. Already-bookmarked frequencies shown as saved (dimmed, checkmark icon)
+13. Import adds selected frequencies as bookmarks with correct mode/bandwidth
+14. Bookmark list refreshes after import
+15. Existing `bookmarks.json` files still load (backward compat with new optional fields)

--- a/docs/superpowers/specs/2026-04-08-radioreference-integration-design.md
+++ b/docs/superpowers/specs/2026-04-08-radioreference-integration-design.md
@@ -1,0 +1,286 @@
+# RadioReference Integration — Design Spec
+
+## Overview
+
+Integrate RadioReference.com's frequency database into SDR-RS, allowing users to browse frequencies by location and import them as bookmarks. Users authenticate with their own RadioReference premium credentials. Credentials are stored securely in the OS keyring.
+
+This also introduces the app's first `AdwPreferencesWindow` and a general-purpose credential storage layer in `sdr-config`.
+
+## Architecture
+
+```
+sdr-config          — KeyringStore: get/set/delete secrets via OS keyring
+sdr-radioreference  — NEW crate: SOAP client, RR data types, mode mapping
+sdr-ui              — AdwPreferencesWindow, RadioReference browse dialog
+```
+
+### Data Flow
+
+1. User opens Preferences > Accounts > enters RR username + password
+2. "Test & Save" fires a lightweight SOAP call to validate credentials
+3. Green checkmark on success > credentials saved to OS keyring
+4. RadioReference icon appears in header bar (only when credentials are stored)
+5. User clicks icon > browse dialog opens
+6. Zip code entered > SOAP calls: `getZipCodeInfo` > county picker (if multiple) > `getCountyFreqsByTag`
+7. Cascading filters: Category > Agency > Frequencies
+8. User checkboxes desired frequencies > Import > auto-mapped Bookmark entries added
+
+### Threading
+
+SOAP calls are blocking HTTP via `reqwest::blocking::Client`. They run on GLib's thread pool via `gio::spawn_blocking()` and the result is awaited on the main thread via `glib::spawn_future_local()`. No tokio runtime needed.
+
+## Credential Storage (`sdr-config`)
+
+### KeyringStore
+
+Thin wrapper around the `keyring` crate (v2):
+
+```rust
+KeyringStore::new("sdr-rs")
+  .set("radioreference-username", "jason") -> Result<()>
+  .get("radioreference-username") -> Result<Option<String>>
+  .delete("radioreference-username") -> Result<()>
+```
+
+Three keyring entries for RadioReference:
+- `radioreference-username`
+- `radioreference-password`
+
+The application API key is a compile-time constant embedded in the binary. It identifies the app, not the user, and is not secret.
+
+### Backend
+
+- **Linux**: Secret Service D-Bus API (GNOME Keyring, KeePassXC)
+- **macOS**: Keychain
+
+If no keyring backend is available, the `keyring` crate returns an error. The UI surfaces this as "No secure storage available — install GNOME Keyring or KeePassXC."
+
+### Dependencies
+
+Add `keyring = "3"` to `sdr-config/Cargo.toml`.
+
+## SOAP Client (`sdr-radioreference`)
+
+### Crate Structure
+
+```
+crates/sdr-radioreference/src/
+  lib.rs          — pub API: RrClient, query functions
+  soap.rs         — SOAP envelope construction, HTTP transport
+  types.rs        — Response structs (ZipInfo, County, Category, Agency, Frequency)
+  mode_map.rs     — RR mode string -> DemodMode + bandwidth mapping
+```
+
+### RrClient API
+
+```rust
+RrClient::new(username: &str, password: &str, app_key: &str) -> Self
+
+// Validates credentials by calling getZipCodeInfo("90210") — lightweight, deterministic
+fn test_connection(&self) -> Result<()>
+
+// Returns county/state info for a US zip code
+fn get_zip_info(&self, zip: &str) -> Result<ZipInfo>
+
+// Returns all frequencies for a county, grouped by category/agency
+fn get_county_frequencies(&self, county_id: u32) -> Result<Vec<RrFrequency>>
+```
+
+### SOAP Transport
+
+Each method:
+1. Builds a SOAP XML envelope with `quick-xml::Writer`
+2. POSTs to `https://api.radioreference.com/soap2/` via `reqwest::blocking::Client`
+3. Parses the XML response with `quick-xml::Reader`
+
+No SOAP framework needed — the API surface is small enough for hand-crafted envelopes.
+
+### Response Types
+
+```rust
+pub struct ZipInfo {
+    pub county_id: u32,
+    pub state_id: u32,
+    pub city: String,
+    pub county_name: String,
+    pub state_name: String,
+}
+
+pub struct RrFrequency {
+    pub id: String,            // RR's unique frequency ID
+    pub freq_hz: u64,
+    pub mode: String,          // raw RR mode string
+    pub tone: Option<f32>,     // PL/CTCSS tone Hz
+    pub tone_type: Option<String>,
+    pub description: String,
+    pub agency: String,
+    pub category: String,
+    pub subcategory: Option<String>,
+}
+```
+
+### Mode Mapping (`mode_map.rs`)
+
+| RR Mode | DemodMode | Default Bandwidth |
+|---------|-----------|-------------------|
+| FM, FMN | NFM | 12,500 Hz |
+| FMW | WFM | 150,000 Hz |
+| AM | AM | 10,000 Hz |
+| USB | USB | 2,800 Hz |
+| LSB | LSB | 2,800 Hz |
+| CW | CW | 500 Hz |
+| (unknown) | NFM | 12,500 Hz |
+
+Default to NFM for unknown modes — most public safety traffic is narrowband FM.
+
+```rust
+pub struct MappedMode {
+    pub demod_mode: String,    // "NFM", "WFM", "AM", etc.
+    pub bandwidth: f64,        // Hz
+}
+
+pub fn map_rr_mode(rr_mode: &str) -> MappedMode
+```
+
+### Dependencies
+
+```toml
+[dependencies]
+sdr-types.workspace = true
+reqwest = { version = "0.12", features = ["blocking"] }
+quick-xml = "0.37"
+thiserror.workspace = true
+tracing.workspace = true
+serde.workspace = true
+```
+
+## Preferences Window (`sdr-ui`)
+
+### File Structure
+
+```
+crates/sdr-ui/src/
+  preferences/
+    mod.rs              — AdwPreferencesWindow construction
+    general_page.rs     — Recording/screenshot directory settings
+    accounts_page.rs    — RadioReference credential entry + test
+```
+
+### Pages
+
+**General page (`AdwPreferencesPage`):**
+- `AdwActionRow` — Recording directory with folder picker button (default: `~/sdr-recordings`)
+- `AdwActionRow` — Screenshot directory with folder picker button (default: `~/Pictures`)
+
+**Accounts page (`AdwPreferencesPage`):**
+- RadioReference group (`AdwPreferencesGroup`):
+  - `AdwEntryRow` — Username
+  - `AdwPasswordEntryRow` — Password (masked input)
+  - Test & Save button:
+    - Spinner while testing
+    - Green checkmark + "Connected" on success
+    - Red error label on failure (bad creds, network error, no keyring)
+  - Remove credentials button (visible only when credentials exist)
+
+### Access
+
+Opened from the app menu (`GtkMenuButton` at top right) > "Preferences" menu item.
+
+## RadioReference Browse Dialog (`sdr-ui`)
+
+### File Structure
+
+```
+crates/sdr-ui/src/
+  radioreference/
+    mod.rs              — AdwDialog construction, search flow orchestration
+    frequency_list.rs   — GtkListBox with check rows, filtering, duplicate detection
+```
+
+### Trigger
+
+New icon button in the header bar (right side, near screenshot button). Uses a radio/antenna icon. Only visible when RR credentials are stored in the keyring.
+
+### Dialog Layout
+
+```
++---------------------------------------------+
+|  RadioReference                        [X]   |
++----------------------------------------------+
+|  Zip Code: [_____] [Search]                  |
+|                                              |
+|  County: [v dropdown]  (if multiple)         |
+|                                              |
+|  Category: [v All / Law Enforcement / ...]   |
+|  Agency:   [v All / Springfield PD / ...]    |
+|                                              |
+|  +------------------------------------------+|
+|  | [ ] 155.370 MHz  NFM  SpringfieldPD Disp ||
+|  | [ ] 155.730 MHz  NFM  SpringfieldPD Tac1 ||
+|  | [ ] 154.430 MHz  NFM  Springfield FD Disp||
+|  |  *  460.025 MHz  NFM  County EMS (saved) ||
+|  +------------------------------------------+|
+|                                              |
+|  [Import Selected (2)]                       |
++----------------------------------------------+
+```
+
+### Behavior
+
+- **Search** fires zip lookup > populates county dropdown (auto-selects if only one) > loads all frequencies for that county
+- **Category/Agency dropdowns** filter the frequency list client-side (all data fetched once per county)
+- **Frequency rows** show: checkbox, formatted frequency, mode, description
+- **Already-bookmarked** frequencies show a checkmark icon instead of a checkbox, dimmed row, not selectable
+- **Duplicate detection** uses `rr_import_id` first (exact match on RR frequency ID), falls back to frequency Hz match
+- **Import button** label shows count: "Import Selected (3)"
+- **Loading states**: spinner overlay during SOAP calls
+
+### On Import
+
+Each selected frequency becomes a `Bookmark`:
+- `name`: `"{agency} - {description}"`
+- `frequency`: from RR data (Hz)
+- `demod_mode`: auto-mapped via `mode_map::map_rr_mode()`
+- `bandwidth`: inferred from mapped mode
+- `rr_category`: RR category string (stored for future tree rework)
+- `rr_import_id`: RR frequency ID (for dedup)
+- All other profile fields: `None` (defaults)
+
+## Bookmark Struct Changes
+
+Two new optional fields on `Bookmark`:
+
+```rust
+#[serde(default)]
+pub rr_category: Option<String>,    // "Law Enforcement", "Fire", "EMS", etc.
+
+#[serde(default)]
+pub rr_import_id: Option<String>,   // RR frequency ID for dedup and future sync
+```
+
+Both `#[serde(default)]` for backward compatibility with existing `bookmarks.json` files.
+
+These fields are metadata for future use (bookmark category tree). They do not affect current bookmark display or behavior.
+
+## New Dependencies (Workspace)
+
+| Crate | Version | Used By | Purpose |
+|-------|---------|---------|---------|
+| reqwest | 0.12 (blocking feature) | sdr-radioreference | SOAP HTTP client |
+| quick-xml | 0.37 | sdr-radioreference | Parse SOAP XML |
+| keyring | 3 | sdr-config | OS keyring access |
+
+## Issue Mapping
+
+| Issue | Scope |
+|-------|-------|
+| #152 | KeyringStore in sdr-config |
+| #153 | sdr-radioreference crate (SOAP client, types, mode map) |
+| #154 | RadioReference browse dialog (zip search, county picker) |
+| #155 | Frequency list with cascading category/agency filters |
+| #156 | Import selected frequencies as bookmarks |
+| #151 | Epic — all of the above |
+
+Additional work not in original issues:
+- AdwPreferencesWindow (General + Accounts pages)
+- Header bar RadioReference button (conditional visibility)

--- a/docs/superpowers/specs/2026-04-08-radioreference-integration-design.md
+++ b/docs/superpowers/specs/2026-04-08-radioreference-integration-design.md
@@ -8,7 +8,7 @@ This also introduces the app's first `AdwPreferencesWindow` and a general-purpos
 
 ## Architecture
 
-```
+```text
 sdr-config          — KeyringStore: get/set/delete secrets via OS keyring
 sdr-radioreference  — NEW crate: SOAP client, RR data types, mode mapping
 sdr-ui              — AdwPreferencesWindow, RadioReference browse dialog
@@ -33,7 +33,7 @@ SOAP calls are blocking HTTP via `reqwest::blocking::Client`. They run on GLib's
 
 ### KeyringStore
 
-Thin wrapper around the `keyring` crate (v2):
+Thin wrapper around the `keyring` crate (v3):
 
 ```rust
 KeyringStore::new("sdr-rs")
@@ -42,7 +42,7 @@ KeyringStore::new("sdr-rs")
   .delete("radioreference-username") -> Result<()>
 ```
 
-Three keyring entries for RadioReference:
+Two keyring entries for RadioReference:
 - `radioreference-username`
 - `radioreference-password`
 
@@ -63,7 +63,7 @@ Add `keyring = "3"` to `sdr-config/Cargo.toml`.
 
 ### Crate Structure
 
-```
+```text
 crates/sdr-radioreference/src/
   lib.rs          — pub API: RrClient, query functions
   soap.rs         — SOAP envelope construction, HTTP transport
@@ -74,7 +74,7 @@ crates/sdr-radioreference/src/
 ### RrClient API
 
 ```rust
-RrClient::new(username: &str, password: &str, app_key: &str) -> Self
+RrClient::new(username: &str, password: &str) -> Result<Self, SoapError>
 
 // Validates credentials by calling getZipCodeInfo("90210") — lightweight, deterministic
 fn test_connection(&self) -> Result<()>
@@ -158,7 +158,7 @@ serde.workspace = true
 
 ### File Structure
 
-```
+```text
 crates/sdr-ui/src/
   preferences/
     mod.rs              — AdwPreferencesWindow construction
@@ -190,7 +190,7 @@ Opened from the app menu (`GtkMenuButton` at top right) > "Preferences" menu ite
 
 ### File Structure
 
-```
+```text
 crates/sdr-ui/src/
   radioreference/
     mod.rs              — AdwDialog construction, search flow orchestration
@@ -203,7 +203,7 @@ New icon button in the header bar (right side, near screenshot button). Uses a r
 
 ### Dialog Layout
 
-```
+```text
 +---------------------------------------------+
 |  RadioReference                        [X]   |
 +----------------------------------------------+


### PR DESCRIPTION
## Summary

Full RadioReference.com frequency database integration:

- **New `sdr-radioreference` crate** — SOAP API client with mode mapping, XML parser, `RrClient` public API
- **`KeyringStore` in `sdr-config`** — OS keyring wrapper (GNOME Keyring / macOS Keychain) for secure credential storage
- **`AdwPreferencesWindow`** — first settings dialog with General page (recording/screenshot directories) and Accounts page (RadioReference credential entry + test & save)
- **RadioReference browse dialog** — zip code search, county picker, cascading category/agency filters, frequency list with checkboxes, duplicate detection, import as bookmarks
- **Bookmark struct** extended with `rr_category` and `rr_import_id` fields (backward compatible)
- **Header bar** RadioReference button (conditional on stored credentials, updates on prefs close)

Closes #151, closes #152, closes #153, closes #154, closes #155, closes #156

## Test plan

- [x] `cargo build --workspace` compiles
- [x] `cargo test --workspace` — all tests pass (17 new tests in sdr-radioreference: mode mapping, SOAP XML parsing, envelope construction, fault extraction, duplicate detection)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `SoapAuth` Debug impl redacts password and app key
- [x] RR button visibility updates when credentials are saved/removed in Preferences
- [x] Existing `bookmarks.json` files remain backward compatible (serde default on new fields)
- [ ] End-to-end test with real RadioReference credentials (pending API key from RadioReference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RadioReference integration: ZIP search, county frequency browse, category/agency filters, select & import frequencies into bookmarks
  * Preferences window: General (directories) and Accounts pages with Test & Save / Remove credential flow
  * Secure OS keyring credential storage; bookmarks record RadioReference metadata for deduplication
* **Documentation**
  * Added design spec and implementation plan for the RadioReference integration
* **Chores**
  * CI: added a system dependency for build environments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->