### PR TITLE
Switch to GitHub-hosted runners, add CodeQL

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   audit:
     name: Dependency Audit
-    runs-on: rke-main
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check:
     name: Check & Lint
-    runs-on: rke-main
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 07:00 UTC
+    - cron: '0 7 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@662472033e021d55d94146f65f9b3b7010b4ba78 # v3
+        with:
+          languages: actions
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@662472033e021d55d94146f65f9b3b7010b4ba78 # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@662472033e021d55d94146f65f9b3b7010b4ba78 # v3
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         with:
           languages: actions
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@662472033e021d55d94146f65f9b3b7010b4ba78 # v3
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: read
   security-events: write
+  actions: read
 
 jobs:
   analyze:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   deny:
     name: License & Supply Chain Check
-    runs-on: rke-main
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- **All workflows**: Switch `runs-on` from `rke-main` (self-hosted) to `ubuntu-latest` (GitHub-hosted). Required before making the repo public — self-hosted runners are a security risk for public repos (forks can run arbitrary code on them).
- **CodeQL**: New workflow scanning GitHub Actions for injection vulnerabilities. Runs on push, PR, and weekly schedule. Pinned to commit SHA.

## Test plan
- [x] No code changes — CI configuration only
- [ ] CI passes on GitHub-hosted runner after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI runners to ubuntu-latest for audit, check, and deny workflows.
  * Added a CodeQL security analysis workflow with scheduled scans, PR scanning, and configured concurrency/permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->