### PR TITLE
Set RadioReference application API key

### DIFF
--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -11,13 +11,12 @@ pub use soap::SoapError;
 pub use types::{RrFrequency, RrTag, ZipInfo};
 
 /// Application API key — identifies the SDR-RS app to `RadioReference`.
-/// This is not a secret; it's distributed with the application.
+/// This is not a secret; it identifies the application, not the user.
 ///
-/// Set via `RADIOREFERENCE_APP_KEY` env var at build time, or defaults to a
-/// placeholder that will fail at runtime with an auth error.
+/// Override via `RADIOREFERENCE_APP_KEY` env var at build time if needed.
 const APP_KEY: &str = match option_env!("RADIOREFERENCE_APP_KEY") {
     Some(key) => key,
-    None => "PENDING_API_KEY",
+    None => "2e4b8c24-341a-11f1-bb32-0ef97433b5f9",
 };
 
 /// `RadioReference` SOAP API client.


### PR DESCRIPTION
## Summary
- Replace placeholder `PENDING_API_KEY` with the real RadioReference application API key
- The key identifies the app, not the user — it is not a secret and is meant to be distributed with client applications
- `option_env!` override still available for anyone building with their own key

## Test plan
- [x] Builds clean
- [x] Clippy clean
- [ ] End-to-end test: `make install`, open Preferences > Accounts, enter RR credentials, test connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the application key identifies the application rather than the user.

* **Chores**
  * Updated default application key configuration value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->