### PR TITLE
Fix RadioReference SOAP client for real API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ sdr-sink-network          TCP/UDP audio output
 
 DSP functions are pure (no threading, no I/O). Threading and streaming live in `sdr-pipeline`.
 
+## RadioReference Integration
+
+SDR-RS can browse and import frequencies from [RadioReference.com](https://www.radioreference.com), the largest radio communications reference source in the US.
+
+**Setup:** Open Preferences (Ctrl+,) > Accounts > enter your RadioReference credentials > Test & Save. A [premium account](https://www.radioreference.com/premium/) is required for API access.
+
+**Usage:** Click the antenna icon in the header bar > enter a US ZIP code > browse frequencies by category and agency > check the ones you want > Import. Frequencies are saved as bookmarks with auto-mapped demod mode and bandwidth.
+
+Your credentials are stored in your system keyring (GNOME Keyring / macOS Keychain) and are only sent to RadioReference.com.
+
 ## Security
 
 See [SECURITY.md](SECURITY.md) for vulnerability reporting and security scanning details.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 
 ### Integration
 
-- RadioReference.com frequency database browser (SOAP API client)
+- [RadioReference.com](https://www.radioreference.com) frequency database browser — search by ZIP code, browse by category/agency, import as bookmarks (requires RadioReference premium account)
 - Secure credential storage via OS keyring (GNOME Keyring / macOS Keychain)
 - Preferences window with directory settings and account management
 - PipeWire audio output (Linux), CoreAudio planned (macOS)

--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -8,7 +8,7 @@ pub mod soap;
 pub mod types;
 
 pub use soap::SoapError;
-pub use types::{RrFrequency, RrTag, ZipInfo};
+pub use types::{CountyInfo, RrCategory, RrFrequency, RrSubcategory, RrTag, ZipInfo};
 
 /// Application API key — identifies the SDR-RS app to `RadioReference`.
 /// This is not a secret; it identifies the application, not the user.
@@ -63,11 +63,65 @@ impl RrClient {
         soap::get_zipcode_info(&self.http, &self.auth, zipcode)
     }
 
-    /// Get all frequencies for a county.
+    /// Get detailed county info including categories and subcategories.
+    pub fn get_county_info(&self, county_id: u32) -> Result<CountyInfo, SoapError> {
+        tracing::debug!(county_id, "querying RadioReference county info");
+        soap::get_county_info(&self.http, &self.auth, county_id)
+    }
+
+    /// Get all frequencies for a county by fetching each subcategory.
     ///
-    /// Calls `getCountyFreqsByTag` with `tag=0` to request all categories.
-    pub fn get_county_frequencies(&self, county_id: u32) -> Result<Vec<RrFrequency>, SoapError> {
-        tracing::debug!(county_id, "querying RadioReference county frequencies");
-        soap::get_county_freqs_by_tag(&self.http, &self.auth, county_id, 0)
+    /// Returns `(county_name, frequencies)`. Calls `getCountyInfo` to discover
+    /// subcategories, then `getSubcatFreqs` for each one. Attaches the
+    /// category/subcategory name as a tag on each frequency for UI filtering.
+    pub fn get_county_frequencies(
+        &self,
+        county_id: u32,
+    ) -> Result<(String, Vec<RrFrequency>), SoapError> {
+        let info = self.get_county_info(county_id)?;
+        let county_name = info.county_name.clone();
+
+        let mut all_freqs: Vec<RrFrequency> = Vec::new();
+        for cat in &info.categories {
+            for subcat in &cat.subcategories {
+                tracing::debug!(
+                    scid = subcat.scid,
+                    name = %subcat.name,
+                    category = %cat.name,
+                    "fetching subcategory frequencies"
+                );
+                match soap::get_subcat_freqs(&self.http, &self.auth, subcat.scid) {
+                    Ok(mut freqs) => {
+                        // Attach category/subcategory as a tag if none present
+                        for freq in &mut freqs {
+                            if freq.tags.is_empty() {
+                                freq.tags.push(RrTag {
+                                    id: subcat.scid,
+                                    description: format!("{} - {}", cat.name, subcat.name),
+                                });
+                            }
+                        }
+                        all_freqs.extend(freqs);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            scid = subcat.scid,
+                            name = %subcat.name,
+                            "failed to fetch subcategory: {e}"
+                        );
+                        // Continue with other subcategories
+                    }
+                }
+            }
+        }
+
+        tracing::info!(
+            county_id,
+            county = %info.county_name,
+            total = all_freqs.len(),
+            "fetched county frequencies"
+        );
+
+        Ok((county_name, all_freqs))
     }
 }

--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -105,13 +105,21 @@ impl RrClient {
                             count = freqs.len(),
                             "fetched subcategory frequencies"
                         );
-                        // Attach category/subcategory as a tag if none present
+                        // Always set the category tag from the county hierarchy
+                        // we fetched — the API's own tags are often empty strings.
+                        let cat_tag = RrTag {
+                            id: subcat.scid,
+                            description: subcat.name.clone(),
+                        };
                         for freq in &mut freqs {
-                            if freq.tags.is_empty() {
-                                freq.tags.push(RrTag {
-                                    id: subcat.scid,
-                                    description: format!("{} - {}", cat.name, subcat.name),
-                                });
+                            // Replace empty/useless API tags with our category tag
+                            let has_useful_tags = freq
+                                .tags
+                                .iter()
+                                .any(|t| !t.description.is_empty());
+                            if !has_useful_tags {
+                                freq.tags.clear();
+                                freq.tags.push(cat_tag.clone());
                             }
                         }
                         all_freqs.extend(freqs);

--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -113,10 +113,8 @@ impl RrClient {
                         };
                         for freq in &mut freqs {
                             // Replace empty/useless API tags with our category tag
-                            let has_useful_tags = freq
-                                .tags
-                                .iter()
-                                .any(|t| !t.description.is_empty());
+                            let has_useful_tags =
+                                freq.tags.iter().any(|t| !t.description.is_empty());
                             if !has_useful_tags {
                                 freq.tags.clear();
                                 freq.tags.push(cat_tag.clone());

--- a/crates/sdr-radioreference/src/lib.rs
+++ b/crates/sdr-radioreference/src/lib.rs
@@ -81,17 +81,30 @@ impl RrClient {
         let info = self.get_county_info(county_id)?;
         let county_name = info.county_name.clone();
 
+        tracing::info!(
+            county = %info.county_name,
+            categories = info.categories.len(),
+            subcategories = info.categories.iter().map(|c| c.subcategories.len()).sum::<usize>(),
+            "county structure loaded"
+        );
+
         let mut all_freqs: Vec<RrFrequency> = Vec::new();
         for cat in &info.categories {
+            tracing::debug!(
+                category = %cat.name,
+                subcategories = cat.subcategories.len(),
+                "processing category"
+            );
             for subcat in &cat.subcategories {
-                tracing::debug!(
-                    scid = subcat.scid,
-                    name = %subcat.name,
-                    category = %cat.name,
-                    "fetching subcategory frequencies"
-                );
                 match soap::get_subcat_freqs(&self.http, &self.auth, subcat.scid) {
                     Ok(mut freqs) => {
+                        tracing::debug!(
+                            scid = subcat.scid,
+                            name = %subcat.name,
+                            category = %cat.name,
+                            count = freqs.len(),
+                            "fetched subcategory frequencies"
+                        );
                         // Attach category/subcategory as a tag if none present
                         for freq in &mut freqs {
                             if freq.tags.is_empty() {

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -462,11 +462,15 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
                             current_field.clear();
                         }
                         "stid" if state == Top => {
-                            state_id = text.parse().unwrap_or(0);
+                            state_id = text
+                                .parse()
+                                .map_err(|e| SoapError::Unexpected(format!("bad stid: {e}")))?;
                             current_field.clear();
                         }
                         "cid" => {
-                            current_cat_id = text.parse().unwrap_or(0);
+                            current_cat_id = text
+                                .parse()
+                                .map_err(|e| SoapError::Unexpected(format!("bad cid: {e}")))?;
                             current_field.clear();
                         }
                         "cName" => {
@@ -474,7 +478,9 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
                             current_field.clear();
                         }
                         "scid" => {
-                            current_scid = text.parse().unwrap_or(0);
+                            current_scid = text
+                                .parse()
+                                .map_err(|e| SoapError::Unexpected(format!("bad scid: {e}")))?;
                             current_field.clear();
                         }
                         "scName" => {

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -413,8 +413,8 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
     let mut reader = Reader::from_str(xml);
     reader.config_mut().trim_text(true);
 
-    let mut county_name = String::new();
-    let mut state_id: u32 = 0;
+    let mut county_name: Option<String> = None;
+    let mut state_id: Option<u32> = None;
     let mut categories: Vec<RrCategory> = Vec::new();
 
     let mut state = Top;
@@ -458,13 +458,14 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
                 if let Ok(text) = e.unescape() {
                     match current_field.as_str() {
                         "countyName" => {
-                            county_name = text.into_owned();
+                            county_name = Some(text.into_owned());
                             current_field.clear();
                         }
                         "stid" if state == Top => {
-                            state_id = text
-                                .parse()
-                                .map_err(|e| SoapError::Unexpected(format!("bad stid: {e}")))?;
+                            state_id = Some(
+                                text.parse()
+                                    .map_err(|e| SoapError::Unexpected(format!("bad stid: {e}")))?,
+                            );
                             current_field.clear();
                         }
                         "cid" => {
@@ -526,7 +527,7 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
 
     tracing::debug!(
         county_id,
-        %county_name,
+        county_name = ?county_name,
         categories = categories.len(),
         subcategories = categories.iter().map(|c| c.subcategories.len()).sum::<usize>(),
         "parsed county info"
@@ -534,8 +535,9 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
 
     Ok(CountyInfo {
         county_id,
-        county_name,
-        state_id,
+        county_name: county_name
+            .ok_or_else(|| SoapError::Unexpected("missing countyName".into()))?,
+        state_id: state_id.ok_or_else(|| SoapError::Unexpected("missing stid".into()))?,
         categories,
     })
 }

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -9,7 +9,7 @@ use quick_xml::Writer;
 use quick_xml::events::{BytesDecl, BytesText, Event};
 use reqwest::blocking::Client;
 
-use crate::types::{RrFrequency, RrTag, ZipInfo};
+use crate::types::{CountyInfo, RrCategory, RrFrequency, RrSubcategory, RrTag, ZipInfo};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -266,6 +266,41 @@ pub fn get_county_freqs_by_tag(
     parse_frequencies(&body)
 }
 
+/// Fetches detailed county information including categories and subcategories
+/// via the `getCountyInfo` SOAP method.
+pub fn get_county_info(
+    client: &Client,
+    auth: &SoapAuth,
+    county_id: u32,
+) -> Result<CountyInfo, SoapError> {
+    let county_str = county_id.to_string();
+
+    let envelope = build_envelope("getCountyInfo", auth, |w| {
+        write_typed_element(w, "ctid", "xsd:int", &county_str)?;
+        Ok(())
+    })?;
+
+    let body = send_request(client, &envelope)?;
+    parse_county_info(&body, county_id)
+}
+
+/// Fetches frequencies for a subcategory via the `getSubcatFreqs` SOAP method.
+pub fn get_subcat_freqs(
+    client: &Client,
+    auth: &SoapAuth,
+    scid: u32,
+) -> Result<Vec<RrFrequency>, SoapError> {
+    let scid_str = scid.to_string();
+
+    let envelope = build_envelope("getSubcatFreqs", auth, |w| {
+        write_typed_element(w, "scid", "xsd:int", &scid_str)?;
+        Ok(())
+    })?;
+
+    let body = send_request(client, &envelope)?;
+    parse_frequencies(&body)
+}
+
 // ---------------------------------------------------------------------------
 // XML parsers
 // ---------------------------------------------------------------------------
@@ -356,6 +391,147 @@ pub fn parse_zip_info(xml: &str) -> Result<ZipInfo, SoapError> {
         city: city.ok_or_else(|| SoapError::Unexpected("missing city".into()))?,
         lat: lat.unwrap_or_default(),
         lon: lon.unwrap_or_default(),
+    })
+}
+
+/// Nesting state for `parse_county_info`.
+#[derive(PartialEq, Eq)]
+enum CountyParseState {
+    Top,
+    InCats,
+    InCat,
+    InSubcats,
+    InSubcat,
+}
+
+/// Parses a `getCountyInfo` response, extracting county name and
+/// category/subcategory hierarchy.
+#[allow(clippy::too_many_lines)]
+pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapError> {
+    use CountyParseState::{InCat, InCats, InSubcat, InSubcats, Top};
+
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut county_name = String::new();
+    let mut state_id: u32 = 0;
+    let mut categories: Vec<RrCategory> = Vec::new();
+
+    let mut state = Top;
+    let mut current_cat_id: u32 = 0;
+    let mut current_cat_name = String::new();
+    let mut current_subcats: Vec<RrSubcategory> = Vec::new();
+    let mut current_scid: u32 = 0;
+    let mut current_sc_name = String::new();
+    let mut current_field = String::new();
+
+    // Nesting: return > cats > item(cat) > subcats > item(subcat)
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => {
+                let name = e.name();
+                let name_ref = name.as_ref();
+                let local = local_name(name_ref);
+                match (&state, local) {
+                    (Top, b"countyName" | b"stid")
+                    | (InCat, b"cid" | b"cName")
+                    | (InSubcat, b"scid" | b"scName") => {
+                        current_field =
+                            String::from_utf8_lossy(local).into_owned();
+                    }
+                    (Top, b"cats") => state = InCats,
+                    (InCats, b"item") => {
+                        state = InCat;
+                        current_cat_id = 0;
+                        current_cat_name.clear();
+                        current_subcats.clear();
+                    }
+                    (InCat, b"subcats") => state = InSubcats,
+                    (InSubcats, b"item") => {
+                        state = InSubcat;
+                        current_scid = 0;
+                        current_sc_name.clear();
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Text(ref e)) => {
+                if let Ok(text) = e.unescape() {
+                    match current_field.as_str() {
+                        "countyName" => {
+                            county_name = text.into_owned();
+                            current_field.clear();
+                        }
+                        "stid" if state == Top => {
+                            state_id = text.parse().unwrap_or(0);
+                            current_field.clear();
+                        }
+                        "cid" => {
+                            current_cat_id = text.parse().unwrap_or(0);
+                            current_field.clear();
+                        }
+                        "cName" => {
+                            current_cat_name = text.into_owned();
+                            current_field.clear();
+                        }
+                        "scid" => {
+                            current_scid = text.parse().unwrap_or(0);
+                            current_field.clear();
+                        }
+                        "scName" => {
+                            current_sc_name = text.into_owned();
+                            current_field.clear();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let name = e.name();
+                let name_ref = name.as_ref();
+                let local = local_name(name_ref);
+                match (&state, local) {
+                    (InSubcat, b"item") => {
+                        if current_scid > 0 {
+                            current_subcats.push(RrSubcategory {
+                                scid: current_scid,
+                                name: std::mem::take(&mut current_sc_name),
+                            });
+                        }
+                        state = InSubcats;
+                    }
+                    (InSubcats, b"subcats") => state = InCat,
+                    (InCat, b"item") => {
+                        categories.push(RrCategory {
+                            id: current_cat_id,
+                            name: std::mem::take(&mut current_cat_name),
+                            subcategories: std::mem::take(&mut current_subcats),
+                        });
+                        state = InCats;
+                    }
+                    (InCats, b"cats") => state = Top,
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(SoapError::Xml(e)),
+            _ => {}
+        }
+    }
+
+    tracing::debug!(
+        county_id,
+        %county_name,
+        categories = categories.len(),
+        subcategories = categories.iter().map(|c| c.subcategories.len()).sum::<usize>(),
+        "parsed county info"
+    );
+
+    Ok(CountyInfo {
+        county_id,
+        county_name,
+        state_id,
+        categories,
     })
 }
 

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -622,10 +622,11 @@ impl FreqBuilder {
             b"mode" => self.mode = Some(read_text_content(reader)?.into_owned()),
             b"tone" => {
                 let t = read_text_content(reader)?;
-                self.tone_val = Some(
-                    t.parse::<f32>()
-                        .map_err(|e| SoapError::Unexpected(format!("bad tone: {e}")))?,
-                );
+                // Tone field is xsd:string — may be a float ("110.9"), empty,
+                // or text like "CSQ". Parse as float, ignore failures.
+                if let Ok(val) = t.parse::<f32>() {
+                    self.tone_val = Some(val);
+                }
             }
             b"descr" => self.description = Some(read_text_content(reader)?.into_owned()),
             b"alpha" => self.alpha_tag = Some(read_text_content(reader)?.into_owned()),
@@ -708,10 +709,19 @@ pub fn parse_frequencies(xml: &str) -> Result<Vec<RrFrequency>, SoapError> {
                         state = FreqParseState::InFreqItem;
                     }
                     FreqParseState::InFreqItem if local == b"item" => {
+                        // Log before finish() consumes fields
+                        let fid_dbg = builder.fid.clone();
+                        let has_freq = builder.freq_mhz.is_some();
+                        let has_mode = builder.mode.is_some();
                         if let Some(freq) = builder.finish() {
                             frequencies.push(freq);
                         } else {
-                            tracing::warn!("skipping frequency item with missing required fields");
+                            tracing::warn!(
+                                fid = ?fid_dbg,
+                                has_freq,
+                                has_mode,
+                                "skipping frequency item with missing required fields"
+                            );
                         }
                         state = FreqParseState::TopLevel;
                     }

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -462,10 +462,10 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
                             current_field.clear();
                         }
                         "stid" if state == Top => {
-                            state_id = Some(
-                                text.parse()
-                                    .map_err(|e| SoapError::Unexpected(format!("bad stid: {e}")))?,
-                            );
+                            state_id =
+                                Some(text.parse().map_err(|e| {
+                                    SoapError::Unexpected(format!("bad stid: {e}"))
+                                })?);
                             current_field.clear();
                         }
                         "cid" => {

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -309,8 +309,8 @@ pub fn parse_zip_info(xml: &str) -> Result<ZipInfo, SoapError> {
     let mut county_id: Option<u32> = None;
     let mut state_id: Option<u32> = None;
     let mut city: Option<String> = None;
-    let mut county_name: Option<String> = None;
-    let mut state_name: Option<String> = None;
+    let mut lat: Option<String> = None;
+    let mut lon: Option<String> = None;
 
     loop {
         match reader.read_event() {
@@ -335,11 +335,11 @@ pub fn parse_zip_info(xml: &str) -> Result<ZipInfo, SoapError> {
                     b"city" => {
                         city = Some(read_text_content(&mut reader)?.into_owned());
                     }
-                    b"countyName" => {
-                        county_name = Some(read_text_content(&mut reader)?.into_owned());
+                    b"lat" => {
+                        lat = Some(read_text_content(&mut reader)?.into_owned());
                     }
-                    b"stateName" => {
-                        state_name = Some(read_text_content(&mut reader)?.into_owned());
+                    b"lon" => {
+                        lon = Some(read_text_content(&mut reader)?.into_owned());
                     }
                     _ => {}
                 }
@@ -354,9 +354,8 @@ pub fn parse_zip_info(xml: &str) -> Result<ZipInfo, SoapError> {
         county_id: county_id.ok_or_else(|| SoapError::Unexpected("missing ctid".into()))?,
         state_id: state_id.ok_or_else(|| SoapError::Unexpected("missing stid".into()))?,
         city: city.ok_or_else(|| SoapError::Unexpected("missing city".into()))?,
-        county_name: county_name
-            .ok_or_else(|| SoapError::Unexpected("missing countyName".into()))?,
-        state_name: state_name.ok_or_else(|| SoapError::Unexpected("missing stateName".into()))?,
+        lat: lat.unwrap_or_default(),
+        lon: lon.unwrap_or_default(),
     })
 }
 
@@ -570,11 +569,12 @@ mod tests {
   <SOAP-ENV:Body>
     <ns1:getZipcodeInfoResponse>
       <return xsi:type="ns1:ZipcodeInfo">
-        <ctid xsi:type="xsd:int">277</ctid>
-        <stid xsi:type="xsd:int">6</stid>
+        <zipCode xsi:type="xsd:int">90210</zipCode>
+        <lat xsi:type="xsd:string">34.0901</lat>
+        <lon xsi:type="xsd:string">-118.4065</lon>
         <city xsi:type="xsd:string">Beverly Hills</city>
-        <countyName xsi:type="xsd:string">Los Angeles</countyName>
-        <stateName xsi:type="xsd:string">California</stateName>
+        <stid xsi:type="xsd:int">6</stid>
+        <ctid xsi:type="xsd:int">277</ctid>
       </return>
     </ns1:getZipcodeInfoResponse>
   </SOAP-ENV:Body>
@@ -643,8 +643,8 @@ mod tests {
         assert_eq!(info.county_id, 277);
         assert_eq!(info.state_id, 6);
         assert_eq!(info.city, "Beverly Hills");
-        assert_eq!(info.county_name, "Los Angeles");
-        assert_eq!(info.state_name, "California");
+        assert_eq!(info.lat, "34.0901");
+        assert_eq!(info.lon, "-118.4065");
     }
 
     #[test]

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -436,8 +436,7 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
                     (Top, b"countyName" | b"stid")
                     | (InCat, b"cid" | b"cName")
                     | (InSubcat, b"scid" | b"scName") => {
-                        current_field =
-                            String::from_utf8_lossy(local).into_owned();
+                        current_field = String::from_utf8_lossy(local).into_owned();
                     }
                     (Top, b"cats") => state = InCats,
                     (InCats, b"item") => {

--- a/crates/sdr-radioreference/src/soap.rs
+++ b/crates/sdr-radioreference/src/soap.rs
@@ -508,11 +508,15 @@ pub fn parse_county_info(xml: &str, county_id: u32) -> Result<CountyInfo, SoapEr
                     }
                     (InSubcats, b"subcats") => state = InCat,
                     (InCat, b"item") => {
-                        categories.push(RrCategory {
-                            id: current_cat_id,
-                            name: std::mem::take(&mut current_cat_name),
-                            subcategories: std::mem::take(&mut current_subcats),
-                        });
+                        if current_cat_id > 0 {
+                            categories.push(RrCategory {
+                                id: current_cat_id,
+                                name: std::mem::take(&mut current_cat_name),
+                                subcategories: std::mem::take(&mut current_subcats),
+                            });
+                        } else {
+                            tracing::warn!("skipping category with missing/zero cid");
+                        }
                         state = InCats;
                     }
                     (InCats, b"cats") => state = Top,

--- a/crates/sdr-radioreference/src/types.rs
+++ b/crates/sdr-radioreference/src/types.rs
@@ -18,6 +18,39 @@ pub struct ZipInfo {
     pub lon: String,
 }
 
+/// Detailed county information from `getCountyInfo`.
+#[derive(Debug, Clone)]
+pub struct CountyInfo {
+    /// County ID.
+    pub county_id: u32,
+    /// County name.
+    pub county_name: String,
+    /// State ID.
+    pub state_id: u32,
+    /// Categories containing subcategories with frequency data.
+    pub categories: Vec<RrCategory>,
+}
+
+/// A frequency category (e.g. "Public Safety", "Business").
+#[derive(Debug, Clone)]
+pub struct RrCategory {
+    /// Category ID.
+    pub id: u32,
+    /// Category name.
+    pub name: String,
+    /// Subcategories within this category.
+    pub subcategories: Vec<RrSubcategory>,
+}
+
+/// A subcategory within a category (e.g. "Police", "Fire").
+#[derive(Debug, Clone)]
+pub struct RrSubcategory {
+    /// Subcategory ID — used with `getSubcatFreqs`.
+    pub scid: u32,
+    /// Subcategory name.
+    pub name: String,
+}
+
 /// A tag (category) applied to a `RadioReference` frequency entry.
 #[derive(Debug, Clone)]
 pub struct RrTag {

--- a/crates/sdr-radioreference/src/types.rs
+++ b/crates/sdr-radioreference/src/types.rs
@@ -1,6 +1,9 @@
 //! Response types returned by the `RadioReference` SOAP API.
 
 /// Information about a US ZIP code, including its county and state.
+///
+/// The API returns county/state as numeric IDs only — names are not available
+/// from `getZipcodeInfo`.
 #[derive(Debug, Clone)]
 pub struct ZipInfo {
     /// County ID on `RadioReference`.
@@ -9,10 +12,10 @@ pub struct ZipInfo {
     pub state_id: u32,
     /// City name.
     pub city: String,
-    /// County name.
-    pub county_name: String,
-    /// State name.
-    pub state_name: String,
+    /// Latitude.
+    pub lat: String,
+    /// Longitude.
+    pub lon: String,
 }
 
 /// A tag (category) applied to a `RadioReference` frequency entry.

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -62,7 +62,12 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
 
     let group = adw::PreferencesGroup::builder()
         .title("RadioReference")
-        .description("Premium account required for frequency database access")
+        .description(
+            "Premium account required for frequency database access. \
+             Your credentials are stored securely in your system keyring \
+             (GNOME Keyring / macOS Keychain) and are never sent anywhere \
+             other than RadioReference.com.",
+        )
         .build();
 
     // --- Username row ---

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -70,6 +70,21 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
         )
         .build();
 
+    // --- Sign up link ---
+    let signup_row = adw::ActionRow::builder()
+        .title("Don't have an account?")
+        .subtitle("Sign up at radioreference.com")
+        .activatable(true)
+        .build();
+    signup_row.add_suffix(&gtk4::Image::from_icon_name("external-link-symbolic"));
+    signup_row.connect_activated(|_| {
+        let _ = gtk4::gio::AppInfo::launch_default_for_uri(
+            "https://www.radioreference.com/premium/",
+            gtk4::gio::AppLaunchContext::NONE,
+        );
+    });
+    group.add(&signup_row);
+
     // --- Username row ---
     let username_row = adw::EntryRow::builder().title("Username").build();
 

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -78,10 +78,12 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
         .build();
     signup_row.add_suffix(&gtk4::Image::from_icon_name("external-link-symbolic"));
     signup_row.connect_activated(|_| {
-        let _ = gtk4::gio::AppInfo::launch_default_for_uri(
+        if let Err(e) = gtk4::gio::AppInfo::launch_default_for_uri(
             "https://www.radioreference.com/premium/",
             gtk4::gio::AppLaunchContext::NONE,
-        );
+        ) {
+            tracing::warn!("failed to open RadioReference signup URL: {e}");
+        }
     });
     group.add(&signup_row);
 

--- a/crates/sdr-ui/src/radioreference/frequency_list.rs
+++ b/crates/sdr-ui/src/radioreference/frequency_list.rs
@@ -90,8 +90,24 @@ pub fn populate_frequencies(
     for row_model in &rows {
         let rm = row_model.borrow();
         let freq_label = format_frequency(rm.freq.freq_hz);
-        let title = format!("{freq_label}  {}", rm.freq.mode);
-        let subtitle = rm.freq.description.clone();
+        let mapped = sdr_radioreference::mode_map::map_rr_mode(&rm.freq.mode);
+
+        // Title: alpha tag if available, otherwise description
+        let title = if rm.freq.alpha_tag.is_empty() {
+            rm.freq.description.clone()
+        } else {
+            rm.freq.alpha_tag.clone()
+        };
+
+        // Subtitle: frequency, mapped mode, tone, description (if not in title)
+        let mut parts = vec![format!("{freq_label}  {}", mapped.demod_mode)];
+        if let Some(tone) = rm.freq.tone {
+            parts.push(format!("PL {tone:.1}"));
+        }
+        if !rm.freq.alpha_tag.is_empty() && !rm.freq.description.is_empty() {
+            parts.push(rm.freq.description.clone());
+        }
+        let subtitle = parts.join("  \u{00b7}  "); // middle dot separator
 
         let action_row = adw::ActionRow::builder()
             .title(&title)

--- a/crates/sdr-ui/src/radioreference/mod.rs
+++ b/crates/sdr-ui/src/radioreference/mod.rs
@@ -10,8 +10,6 @@ use gtk4::glib;
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
-use sdr_radioreference::RrFrequency;
-
 use crate::preferences::accounts_page::load_rr_credentials;
 use crate::sidebar::navigation_panel::{
     Bookmark, format_frequency, load_bookmarks, parse_demod_mode, save_bookmarks,
@@ -220,10 +218,9 @@ pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on
                 let result = gio::spawn_blocking(move || {
                     let client = sdr_radioreference::RrClient::new(&username, &password)?;
                     let zip_info = client.get_zip_info(&zip)?;
-                    let freqs = client.get_county_frequencies(zip_info.county_id)?;
-                    Ok::<(sdr_radioreference::ZipInfo, Vec<RrFrequency>), sdr_radioreference::SoapError>(
-                        (zip_info, freqs),
-                    )
+                    let (county_name, freqs) =
+                        client.get_county_frequencies(zip_info.county_id)?;
+                    Ok::<_, sdr_radioreference::SoapError>((zip_info, county_name, freqs))
                 })
                 .await
                 .unwrap_or_else(|_| Err(sdr_radioreference::SoapError::Fault(
@@ -236,10 +233,14 @@ pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on
                 search_button_ref.set_sensitive(true);
 
                 match result {
-                    Ok((zip_info, freqs)) => {
+                    Ok((zip_info, county_name, freqs)) => {
+                        let location = if county_name.is_empty() {
+                            zip_info.city.clone()
+                        } else {
+                            format!("{}, {}", zip_info.city, county_name)
+                        };
                         let msg = format!(
-                            "{} \u{2014} {} frequencies",
-                            zip_info.city,
+                            "{location} \u{2014} {} frequencies",
                             freqs.len()
                         );
                         show_status(&status_label, &msg, true);

--- a/crates/sdr-ui/src/radioreference/mod.rs
+++ b/crates/sdr-ui/src/radioreference/mod.rs
@@ -238,9 +238,8 @@ pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on
                 match result {
                     Ok((zip_info, freqs)) => {
                         let msg = format!(
-                            "{}, {} \u{2014} {} frequencies",
-                            zip_info.county_name,
-                            zip_info.state_name,
+                            "{} \u{2014} {} frequencies",
+                            zip_info.city,
                             freqs.len()
                         );
                         show_status(&status_label, &msg, true);

--- a/crates/sdr-ui/src/radioreference/mod.rs
+++ b/crates/sdr-ui/src/radioreference/mod.rs
@@ -70,11 +70,14 @@ pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on
     zip_entry.add_suffix(&search_button);
 
     search_group.add(&zip_entry);
+    content.append(&search_group);
 
-    // Spinner + status row
+    // Spinner + status row — outside the preferences group for better alignment
     let status_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Horizontal)
         .spacing(8)
+        .margin_start(4)
+        .margin_top(4)
         .build();
 
     let spinner = gtk4::Spinner::builder().visible(false).build();
@@ -88,9 +91,7 @@ pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on
 
     status_box.append(&spinner);
     status_box.append(&status_label);
-    search_group.add(&status_box);
-
-    content.append(&search_group);
+    content.append(&status_box);
 
     // -----------------------------------------------------------------------
     // Results section (hidden until search succeeds)

--- a/crates/sdr-ui/src/radioreference/mod.rs
+++ b/crates/sdr-ui/src/radioreference/mod.rs
@@ -57,7 +57,7 @@ pub fn show_browse_dialog<F: Fn() + 'static>(parent: &impl IsA<gtk4::Widget>, on
     // -----------------------------------------------------------------------
     let search_group = adw::PreferencesGroup::builder()
         .title("Search")
-        .description("Enter a US ZIP code to find local frequencies")
+        .description("Enter a US ZIP code to find local frequencies (US only)")
         .build();
 
     let zip_entry = adw::EntryRow::builder().title("ZIP Code").build();

--- a/crates/sdr-ui/src/radioreference/mod.rs
+++ b/crates/sdr-ui/src/radioreference/mod.rs
@@ -5,16 +5,16 @@ mod frequency_list;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use gtk4::gio;
-use gtk4::glib;
-use gtk4::prelude::*;
-use libadwaita as adw;
-use libadwaita::prelude::*;
 use crate::preferences::accounts_page::load_rr_credentials;
 use crate::sidebar::navigation_panel::{
     Bookmark, format_frequency, load_bookmarks, parse_demod_mode, save_bookmarks,
 };
 use frequency_list::FrequencyRow;
+use gtk4::gio;
+use gtk4::glib;
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
 
 /// Dialog content width in pixels.
 const DIALOG_WIDTH: i32 = 700;


### PR DESCRIPTION
## Summary

Fixes discovered during end-to-end testing with real RadioReference API:

- **ZipInfo parser**: API returns `zipCode`, `lat`, `lon`, `city`, `stid`, `ctid` — no `countyName`/`stateName` fields. Fixed parser and types to match.
- **Frequency fetching**: `getCountyFreqsByTag` with `tag=0` returns nothing. Switched to `getCountyInfo` (discovers subcategories) + `getSubcatFreqs` (per subcategory). County name now comes from `getCountyInfo`.
- **Tone parsing**: API returns tone as `xsd:string` — can be float, empty, or text like "CSQ". Was erroring on non-float values, killing entire subcategories. Now silently ignores unparseable tones.
- **Category filter**: API returns tags with empty descriptions (`[""]`). Now uses subcategory names from the county hierarchy instead.
- **Frequency list display**: Title shows alpha tag ("PD Disp"), subtitle shows formatted frequency, mapped mode, PL tone, and description separated by middle dots.
- **Status label layout**: Moved outside PreferencesGroup for better alignment with zip entry.

## Test plan
- [x] `cargo build --workspace` / `cargo clippy` / `cargo test` all clean
- [x] End-to-end: zip 24073 returns 48 frequencies across 6 subcategories
- [x] Category filter populated with subcategory names
- [x] Import creates bookmarks with correct frequency/mode/bandwidth
- [x] Imported bookmark tunes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded RadioReference docs: ZIP-code search, category/agency browsing, bookmark import, premium-account requirement, and setup steps in Preferences.

* **Improvements**
  * Bookmark import maps demod mode/bandwidth and preserves tones.
  * Frequency list titles/subtitles enhanced with demod mode, PL tone, and richer descriptions.
  * ZIP lookup now includes latitude/longitude; search results show county name with city.
  * Account prefs state credentials are stored in the system keyring and only sent to RadioReference.com.

* **Resilience**
  * County/category fetches tolerate partial failures and return collected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->