### PR TITLE
Live transcription via Whisper, SonarQube integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config \
+          sudo apt-get install -y build-essential pkg-config cmake \
             libgtk-4-dev libadwaita-1-dev libusb-1.0-0-dev \
             libpipewire-0.3-dev libclang-dev libdbus-1-dev
       - name: Install cargo tools

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 original
 /target
 .claude/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ original
 /target
 .claude/
 .env
+.scannerwork/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,6 +1783,7 @@ dependencies = [
  "sdr-source-file",
  "sdr-source-network",
  "sdr-source-rtlsdr",
+ "sdr-transcription",
  "sdr-types",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -184,6 +186,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +228,27 @@ checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "dbus",
  "zeroize",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -266,6 +298,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -966,6 +1004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libspa"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,7 +1234,7 @@ dependencies = [
  "nix",
  "once_cell",
  "pipewire-sys",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1223,6 +1270,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1275,7 +1332,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1296,7 +1353,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1358,6 +1415,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1560,7 +1628,7 @@ dependencies = [
  "sdr-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1570,7 +1638,7 @@ version = "0.1.0"
 dependencies = [
  "rustfft",
  "sdr-types",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1580,7 +1648,7 @@ dependencies = [
  "sdr-config",
  "sdr-dsp",
  "sdr-types",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1591,7 +1659,7 @@ dependencies = [
  "sdr-dsp",
  "sdr-pipeline",
  "sdr-types",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1603,7 +1671,7 @@ dependencies = [
  "reqwest",
  "sdr-types",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1612,7 +1680,7 @@ name = "sdr-rtlsdr"
 version = "0.1.0"
 dependencies = [
  "rusb",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1624,7 +1692,7 @@ dependencies = [
  "sdr-config",
  "sdr-pipeline",
  "sdr-types",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1635,7 +1703,7 @@ dependencies = [
  "sdr-config",
  "sdr-pipeline",
  "sdr-types",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1647,7 +1715,7 @@ dependencies = [
  "sdr-config",
  "sdr-pipeline",
  "sdr-types",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1658,7 +1726,7 @@ dependencies = [
  "sdr-config",
  "sdr-pipeline",
  "sdr-types",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1671,8 +1739,21 @@ dependencies = [
  "sdr-pipeline",
  "sdr-rtlsdr",
  "sdr-types",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "sdr-transcription"
+version = "0.1.0"
+dependencies = [
+ "dirs-next",
+ "libc",
+ "reqwest",
+ "sdr-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -1680,7 +1761,7 @@ name = "sdr-types"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1705,7 +1786,7 @@ dependencies = [
  "sdr-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1886,11 +1967,31 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2302,6 +2403,50 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "whisper-rs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
+ "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "dirs-next",
  "libc",
  "reqwest",
+ "rustfft",
  "sdr-types",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "crates/sdr-radio",
     "crates/sdr-config",
     "crates/sdr-radioreference",
+    "crates/sdr-transcription",
     "crates/sdr-ui",
 ]
 
@@ -69,6 +70,7 @@ sdr-sink-network = { path = "crates/sdr-sink-network" }
 sdr-radio = { path = "crates/sdr-radio" }
 sdr-config = { path = "crates/sdr-config" }
 sdr-radioreference = { path = "crates/sdr-radioreference" }
+sdr-transcription = { path = "crates/sdr-transcription" }
 sdr-ui = { path = "crates/sdr-ui" }
 
 # HTTP / XML (RadioReference)
@@ -77,6 +79,13 @@ quick-xml = "0.37"
 
 # Secure credential storage
 keyring = { version = "3", features = ["sync-secret-service"] }
+
+# Whisper speech-to-text
+whisper-rs = "0.16"
+
+# System directories / libc
+dirs-next = "2"
+libc = "0.2"
 
 # Error handling
 thiserror = "2"

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ lint: fmt-check clippy test deny audit
 
 scan:
 	@if [ -f .env ]; then \
-		eval $$(grep SONAR_APP_TOKEN .env) && \
+		SONAR_APP_TOKEN=$$(sed -n 's/^SONAR_APP_TOKEN=//p' .env | head -n 1) && \
 		SONAR_TOKEN=$$SONAR_APP_TOKEN /opt/sonar-scanner/bin/sonar-scanner \
 			-Dsonar.host.url=https://sonar.aaru.network \
 			-Dsonar.scanner.truststorePath=/tmp/sonar-truststore.jks \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CARGO       ?= cargo
 CARGO_FLAGS ?= --release
 
 .PHONY: all build install install-bin install-icon install-desktop \
-        uninstall test clippy fmt fmt-check lint deny audit clean help
+        uninstall test clippy fmt fmt-check lint deny audit scan clean help
 
 # ─────────────────────────────────────────────────────────────────────
 # Default
@@ -26,6 +26,7 @@ help:
 	@echo "  make build        Build release binary only"
 	@echo "  make test         Run all workspace tests"
 	@echo "  make lint         Run all checks (fmt, clippy, test, deny, audit)"
+	@echo "  make scan         Run SonarQube scan"
 	@echo "  make clean        Remove build artifacts"
 	@echo ""
 	@echo "Variables:"
@@ -106,6 +107,21 @@ audit:
 	$(CARGO) audit
 
 lint: fmt-check clippy test deny audit
+
+# ─────────────────────────────────────────────────────────────────────
+# SonarQube
+# ─────────────────────────────────────────────────────────────────────
+
+scan:
+	@if [ -f .env ]; then \
+		eval $$(grep SONAR_APP_TOKEN .env) && \
+		SONAR_TOKEN=$$SONAR_APP_TOKEN /opt/sonar-scanner/bin/sonar-scanner \
+			-Dsonar.host.url=https://sonar.aaru.network \
+			-Dsonar.scanner.truststorePath=/tmp/sonar-truststore.jks \
+			-Dsonar.scanner.truststorePassword=changeit; \
+	else \
+		echo "No .env file found. Create one with SONAR_APP_TOKEN=<token>"; \
+	fi
 
 clean:
 	$(CARGO) clean

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 
 ### Under the Hood
 
-- 14-crate workspace with clear dependency boundaries
+- 15-crate workspace with clear dependency boundaries
 - Pure DSP functions (no threading, no I/O, no side effects)
 - Zero per-frame heap allocations on hot paths
 - Lock-based SPSC audio ring buffer between DSP and audio threads

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 - IQ WAV recording (raw pre-decimation samples)
 - Waterfall PNG export with desktop notification and click-to-open
 
+### Transcription
+
+- Live speech-to-text via Whisper (tiny English model, ~75 MB)
+- Slide-out transcript panel with timestamped log
+- FFT-based spectral noise gate preprocessor for cleaner recognition
+- Auto-downloads model on first use
+- Volume-independent audio tap (transcription unaffected by volume knob)
+
 ### Integration
 
 - [RadioReference.com](https://www.radioreference.com) frequency database browser — search by ZIP code, browse by category/agency, import as bookmarks (requires RadioReference premium account)
@@ -55,25 +63,26 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 - **PipeWire** development libraries (Linux audio)
 - **libusb** (for RTL-SDR USB access)
 - **libdbus** (for secure credential storage)
+- **cmake** + **C++ compiler** (build-time, for whisper.cpp)
 - **libclang** (build-time, for bindgen if needed)
 
 #### Arch Linux
 
 ```bash
-sudo pacman -S gtk4 libadwaita pipewire libusb dbus clang
+sudo pacman -S gtk4 libadwaita pipewire libusb dbus clang cmake
 ```
 
 #### Ubuntu / Debian
 
 ```bash
 sudo apt install libgtk-4-dev libadwaita-1-dev libpipewire-0.3-dev \
-  libusb-1.0-0-dev libdbus-1-dev libclang-dev
+  libusb-1.0-0-dev libdbus-1-dev libclang-dev cmake g++
 ```
 
 #### macOS
 
 ```bash
-brew install gtk4 libadwaita libusb llvm
+brew install gtk4 libadwaita libusb llvm cmake
 ```
 
 ### Compile
@@ -127,7 +136,7 @@ sdr-rs
 
 ## Architecture
 
-14-crate workspace with clear dependency boundaries:
+15-crate workspace with clear dependency boundaries:
 
 ```text
 sdr (binary)              Entry point
@@ -139,6 +148,7 @@ sdr-types                 Foundation types, errors, constants
 sdr-config                JSON config persistence + OS keyring access
 sdr-rtlsdr                Pure Rust RTL-SDR USB driver (5 tuner chips)
 sdr-radioreference        RadioReference.com SOAP API client
+sdr-transcription         Live speech-to-text via Whisper + spectral denoiser
 sdr-source-rtlsdr         RTL-SDR source module
 sdr-source-network        TCP/UDP IQ source
 sdr-source-file           WAV file playback source

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 whisper-rs.workspace = true
 reqwest.workspace = true
+rustfft.workspace = true
 sdr-types.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sdr-transcription"
+version = "0.1.0"
+description = "Live audio transcription via Whisper"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+whisper-rs.workspace = true
+reqwest.workspace = true
+sdr-types.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+dirs-next.workspace = true
+libc.workspace = true
+
+[lints]
+workspace = true

--- a/crates/sdr-transcription/src/denoise.rs
+++ b/crates/sdr-transcription/src/denoise.rs
@@ -8,7 +8,7 @@
 //! Tariq & Khan (2023), "Mathematical Approach for Enhancing Audio Signal
 //! Quality: Theory, Insights, and Applications."
 
-use rustfft::{num_complex::Complex, FftPlanner};
+use rustfft::{FftPlanner, num_complex::Complex};
 
 /// Margin above the estimated noise floor in linear magnitude.
 /// Bins below `noise_floor * GATE_RATIO` are zeroed.
@@ -39,10 +39,7 @@ pub fn spectral_denoise(samples: &mut [f32]) {
     let fft_inv = planner.plan_fft_inverse(n);
 
     // Convert to complex for FFT.
-    let mut spectrum: Vec<Complex<f32>> = samples
-        .iter()
-        .map(|&s| Complex::new(s, 0.0))
-        .collect();
+    let mut spectrum: Vec<Complex<f32>> = samples.iter().map(|&s| Complex::new(s, 0.0)).collect();
 
     // Forward FFT.
     fft_fwd.process(&mut spectrum);

--- a/crates/sdr-transcription/src/denoise.rs
+++ b/crates/sdr-transcription/src/denoise.rs
@@ -1,0 +1,130 @@
+//! FFT-based spectral noise gate for cleaning radio audio before transcription.
+//!
+//! Estimates the noise floor from the quietest frequency bins, then zeros out
+//! bins that fall below `noise_floor + margin`. This removes broadband static,
+//! squelch tail hiss, and low-level interference while preserving speech.
+//!
+//! Based on the FFT → identify noise → zero bins → IFFT approach from
+//! Tariq & Khan (2023), "Mathematical Approach for Enhancing Audio Signal
+//! Quality: Theory, Insights, and Applications."
+
+use rustfft::{num_complex::Complex, FftPlanner};
+
+/// Margin above the estimated noise floor in linear magnitude.
+/// Bins below `noise_floor * GATE_RATIO` are zeroed.
+/// A ratio of 3.0 means bins must be 3x the noise floor to survive (~9.5 dB).
+const GATE_RATIO: f32 = 3.0;
+
+/// Percentile of magnitude-sorted bins used to estimate the noise floor.
+/// 0.2 means the bottom 20% of bins define the noise level.
+const NOISE_FLOOR_PERCENTILE: f32 = 0.20;
+
+/// Apply spectral noise gating to a mono f32 audio buffer in-place.
+///
+/// The buffer is FFT'd, noise floor is estimated from the quietest bins,
+/// bins below the threshold are zeroed, then IFFT'd back to time domain.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+pub fn spectral_denoise(samples: &mut [f32]) {
+    let n = samples.len();
+    if n < 64 {
+        return; // too short for meaningful FFT
+    }
+
+    let mut planner = FftPlanner::new();
+    let fft_fwd = planner.plan_fft_forward(n);
+    let fft_inv = planner.plan_fft_inverse(n);
+
+    // Convert to complex for FFT.
+    let mut spectrum: Vec<Complex<f32>> = samples
+        .iter()
+        .map(|&s| Complex::new(s, 0.0))
+        .collect();
+
+    // Forward FFT.
+    fft_fwd.process(&mut spectrum);
+
+    // Compute magnitudes for noise floor estimation.
+    let magnitudes: Vec<f32> = spectrum.iter().map(|c| c.norm()).collect();
+
+    // Estimate noise floor from the quietest percentile of bins.
+    let mut sorted_mags = magnitudes.clone();
+    sorted_mags.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let percentile_idx = ((n as f32) * NOISE_FLOOR_PERCENTILE) as usize;
+    let percentile_idx = percentile_idx.min(n.saturating_sub(1));
+    let noise_floor = sorted_mags[percentile_idx];
+
+    // Gate threshold: bins must exceed noise_floor * ratio to survive.
+    let threshold = noise_floor * GATE_RATIO;
+
+    // Zero out bins below threshold (spectral gate).
+    for (i, mag) in magnitudes.iter().enumerate() {
+        if *mag < threshold {
+            spectrum[i] = Complex::new(0.0, 0.0);
+        }
+    }
+
+    // Inverse FFT.
+    fft_inv.process(&mut spectrum);
+
+    // Normalize (rustfft doesn't normalize) and write back.
+    let scale = 1.0 / n as f32;
+    for (i, s) in samples.iter_mut().enumerate() {
+        *s = spectrum[i].re * scale;
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_precision_loss)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn silence_stays_silent() {
+        let mut buf = vec![0.0_f32; 256];
+        spectral_denoise(&mut buf);
+        for s in &buf {
+            assert!(s.abs() < 1e-6, "expected silence, got {s}");
+        }
+    }
+
+    #[test]
+    fn short_buffer_is_noop() {
+        let mut buf = vec![0.5_f32; 32];
+        let original = buf.clone();
+        spectral_denoise(&mut buf);
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn strong_tone_survives_gate() {
+        // Generate a strong 1 kHz tone at 16 kHz sample rate.
+        let n = 1600; // 100ms
+        let mut buf: Vec<f32> = (0..n)
+            .map(|i| {
+                let t = i as f32 / 16_000.0;
+                (2.0 * std::f32::consts::PI * 1000.0 * t).sin()
+            })
+            .collect();
+
+        // Add weak noise.
+        for (i, s) in buf.iter_mut().enumerate() {
+            *s += 0.01 * ((i * 7 % 13) as f32 / 13.0 - 0.5);
+        }
+
+        let pre_energy: f32 = buf.iter().map(|s| s * s).sum();
+
+        spectral_denoise(&mut buf);
+
+        let post_energy: f32 = buf.iter().map(|s| s * s).sum();
+
+        // The tone should retain most of its energy (at least 80%).
+        assert!(
+            post_energy > pre_energy * 0.8,
+            "tone lost too much energy: pre={pre_energy}, post={post_energy}"
+        );
+    }
+}

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod resampler;

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -4,6 +4,7 @@
 //! speech-to-text. Audio samples are fed from the DSP thread via a bounded
 //! channel; transcription results are returned via an event channel.
 
+pub mod denoise;
 pub mod model;
 pub mod resampler;
 pub mod worker;
@@ -68,13 +69,27 @@ impl TranscriptionEngine {
         Ok(event_rx)
     }
 
-    /// Stop the transcription worker.
+    /// Stop the transcription worker, waiting for it to finish.
+    ///
+    /// This may block if Whisper inference is in progress. Use
+    /// [`shutdown_nonblocking`] during app exit to avoid freezing the UI.
     pub fn stop(&mut self) {
         self.audio_tx.take();
         if let Some(handle) = self.worker_thread.take() {
             let _ = handle.join();
         }
         tracing::info!("transcription engine stopped");
+    }
+
+    /// Signal the worker to stop without waiting for it to finish.
+    ///
+    /// Drops the audio sender so the worker exits after its current
+    /// inference completes. The thread is detached — the process can
+    /// exit without joining it.
+    pub fn shutdown_nonblocking(&mut self) {
+        self.audio_tx.take();
+        self.worker_thread.take(); // detach — don't join
+        tracing::info!("transcription engine shutdown (non-blocking)");
     }
 
     /// Get a clone of the audio sender for feeding samples from the DSP thread.
@@ -90,6 +105,6 @@ impl TranscriptionEngine {
 
 impl Drop for TranscriptionEngine {
     fn drop(&mut self) {
-        self.stop();
+        self.shutdown_nonblocking();
     }
 }

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod model;
 pub mod resampler;

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -1,2 +1,97 @@
+//! Live audio transcription via Whisper.
+//!
+//! Provides `TranscriptionEngine` that runs a background worker thread for
+//! speech-to-text. Audio samples are fed from the DSP thread via a bounded
+//! channel; transcription results are returned via an event channel.
+
 pub mod model;
 pub mod resampler;
+pub mod worker;
+
+pub use worker::TranscriptionEvent;
+
+use std::sync::mpsc;
+
+/// Bounded channel capacity for audio buffers from DSP → transcription.
+const AUDIO_CHANNEL_CAPACITY: usize = 10;
+
+/// Error type for transcription operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TranscriptionError {
+    #[error("transcription is already running")]
+    AlreadyRunning,
+    #[error("transcription is not running")]
+    NotRunning,
+}
+
+/// Live audio transcription engine.
+pub struct TranscriptionEngine {
+    audio_tx: Option<mpsc::SyncSender<Vec<f32>>>,
+    worker_thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Default for TranscriptionEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TranscriptionEngine {
+    pub fn new() -> Self {
+        Self {
+            audio_tx: None,
+            worker_thread: None,
+        }
+    }
+
+    /// Start the transcription worker thread.
+    /// Returns a receiver for `TranscriptionEvent`.
+    pub fn start(
+        &mut self,
+    ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
+        if self.worker_thread.is_some() {
+            return Err(TranscriptionError::AlreadyRunning);
+        }
+
+        let (audio_tx, audio_rx) = mpsc::sync_channel(AUDIO_CHANNEL_CAPACITY);
+        let (event_tx, event_rx) = mpsc::channel();
+
+        let handle = std::thread::Builder::new()
+            .name("transcription-worker".into())
+            .spawn(move || {
+                worker::run_worker(&audio_rx, &event_tx);
+            })
+            .expect("failed to spawn transcription worker thread");
+
+        self.audio_tx = Some(audio_tx);
+        self.worker_thread = Some(handle);
+
+        tracing::info!("transcription engine started");
+        Ok(event_rx)
+    }
+
+    /// Stop the transcription worker.
+    pub fn stop(&mut self) {
+        self.audio_tx.take();
+        if let Some(handle) = self.worker_thread.take() {
+            let _ = handle.join();
+        }
+        tracing::info!("transcription engine stopped");
+    }
+
+    /// Get a clone of the audio sender for feeding samples from the DSP thread.
+    pub fn audio_sender(&self) -> Option<mpsc::SyncSender<Vec<f32>>> {
+        self.audio_tx.clone()
+    }
+
+    /// Check if the engine is currently running.
+    pub fn is_running(&self) -> bool {
+        self.worker_thread.is_some()
+    }
+}
+
+impl Drop for TranscriptionEngine {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -23,6 +23,8 @@ pub enum TranscriptionError {
     AlreadyRunning,
     #[error("transcription is not running")]
     NotRunning,
+    #[error("failed to spawn worker thread: {0}")]
+    Spawn(#[from] std::io::Error),
 }
 
 /// Live audio transcription engine.
@@ -59,8 +61,7 @@ impl TranscriptionEngine {
             .name("transcription-worker".into())
             .spawn(move || {
                 worker::run_worker(&audio_rx, &event_tx);
-            })
-            .expect("failed to spawn transcription worker thread");
+            })?;
 
         self.audio_tx = Some(audio_tx);
         self.worker_thread = Some(handle);

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -46,9 +46,7 @@ impl TranscriptionEngine {
 
     /// Start the transcription worker thread.
     /// Returns a receiver for `TranscriptionEvent`.
-    pub fn start(
-        &mut self,
-    ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
+    pub fn start(&mut self) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
         if self.worker_thread.is_some() {
             return Err(TranscriptionError::AlreadyRunning);
         }

--- a/crates/sdr-transcription/src/model.rs
+++ b/crates/sdr-transcription/src/model.rs
@@ -1,0 +1,105 @@
+//! Whisper model download and path management.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+/// Whisper tiny English GGML model URL.
+const MODEL_URL: &str =
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin";
+
+/// Model filename.
+const MODEL_FILENAME: &str = "ggml-tiny.en.bin";
+
+/// Errors from model download and path management.
+#[derive(Debug, thiserror::Error)]
+pub enum ModelError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+}
+
+/// Returns the directory for storing models (`~/.local/share/sdr-rs/models/`).
+pub fn models_dir() -> PathBuf {
+    dirs_next::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("sdr-rs")
+        .join("models")
+}
+
+/// Returns the full path to the Whisper tiny English model.
+pub fn model_path() -> PathBuf {
+    models_dir().join(MODEL_FILENAME)
+}
+
+/// Check if the model file exists.
+pub fn model_exists() -> bool {
+    model_path().is_file()
+}
+
+/// Download the Whisper tiny English model, sending progress events.
+/// Blocks until download completes.
+#[allow(clippy::cast_possible_truncation)]
+pub fn download_model(progress_tx: &mpsc::Sender<u8>) -> Result<PathBuf, ModelError> {
+    let dir = models_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    let dest = dir.join(MODEL_FILENAME);
+    tracing::info!(?dest, "downloading Whisper model");
+
+    let response = reqwest::blocking::get(MODEL_URL)?;
+    let total_size = response.content_length().unwrap_or(0);
+
+    let mut file = std::fs::File::create(&dest)?;
+    let mut downloaded: u64 = 0;
+    let mut last_pct: u8 = 0;
+
+    let mut reader = response;
+    let mut buf = vec![0u8; 64 * 1024];
+
+    loop {
+        let bytes_read = std::io::Read::read(&mut reader, &mut buf)?;
+        if bytes_read == 0 {
+            break;
+        }
+        file.write_all(&buf[..bytes_read])?;
+        downloaded += bytes_read as u64;
+
+        if let Some(pct) = (downloaded * 100).checked_div(total_size) {
+            let pct = pct.min(100) as u8;
+            if pct != last_pct {
+                last_pct = pct;
+                let _ = progress_tx.send(pct);
+            }
+        }
+    }
+
+    file.flush()?;
+    tracing::info!(?dest, bytes = downloaded, "model download complete");
+
+    Ok(dest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn models_dir_ends_with_expected_path() {
+        let dir = models_dir();
+        assert!(dir.ends_with("sdr-rs/models"));
+    }
+
+    #[test]
+    fn model_path_includes_filename() {
+        let path = model_path();
+        assert_eq!(path.file_name().and_then(|f| f.to_str()), Some(MODEL_FILENAME));
+    }
+
+    #[test]
+    fn model_exists_returns_false_when_no_file() {
+        // The model file should not exist in the test environment.
+        assert!(!model_exists());
+    }
+}

--- a/crates/sdr-transcription/src/model.rs
+++ b/crates/sdr-transcription/src/model.rs
@@ -46,12 +46,17 @@ pub fn download_model(progress_tx: &mpsc::Sender<u8>) -> Result<PathBuf, ModelEr
     std::fs::create_dir_all(&dir)?;
 
     let dest = dir.join(MODEL_FILENAME);
+    let part = dir.join(format!("{MODEL_FILENAME}.part"));
     tracing::info!(?dest, "downloading Whisper model");
 
-    let response = reqwest::blocking::get(MODEL_URL)?;
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_mins(2))
+        .build()?;
+
+    let response = client.get(MODEL_URL).send()?.error_for_status()?;
     let total_size = response.content_length().unwrap_or(0);
 
-    let mut file = std::fs::File::create(&dest)?;
+    let mut file = std::fs::File::create(&part)?;
     let mut downloaded: u64 = 0;
     let mut last_pct: u8 = 0;
 
@@ -76,6 +81,8 @@ pub fn download_model(progress_tx: &mpsc::Sender<u8>) -> Result<PathBuf, ModelEr
     }
 
     file.flush()?;
+    drop(file);
+    std::fs::rename(&part, &dest)?;
     tracing::info!(?dest, bytes = downloaded, "model download complete");
 
     Ok(dest)

--- a/crates/sdr-transcription/src/model.rs
+++ b/crates/sdr-transcription/src/model.rs
@@ -94,7 +94,10 @@ mod tests {
     #[test]
     fn model_path_includes_filename() {
         let path = model_path();
-        assert_eq!(path.file_name().and_then(|f| f.to_str()), Some(MODEL_FILENAME));
+        assert_eq!(
+            path.file_name().and_then(|f| f.to_str()),
+            Some(MODEL_FILENAME)
+        );
     }
 
     #[test]

--- a/crates/sdr-transcription/src/resampler.rs
+++ b/crates/sdr-transcription/src/resampler.rs
@@ -1,0 +1,79 @@
+/// Decimation factor: 48000 / 16000 = 3.
+const DECIMATION_FACTOR: usize = 3;
+
+/// Convert interleaved stereo f32 at 48 kHz to mono f32 at 16 kHz.
+///
+/// Each stereo pair (left, right) is averaged to mono, and every third
+/// pair is kept to decimate from 48 kHz to 16 kHz. Output samples are
+/// appended to `output`; existing contents are preserved.
+pub fn downsample_stereo_to_mono_16k(interleaved_48k: &[f32], output: &mut Vec<f32>) {
+    let pair_count = interleaved_48k.len() / 2;
+    let mut pair_idx = 0;
+    while pair_idx < pair_count {
+        let l = interleaved_48k[pair_idx * 2];
+        let r = interleaved_48k[pair_idx * 2 + 1];
+        output.push(f32::midpoint(l, r));
+        pair_idx += DECIMATION_FACTOR;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_produces_empty_output() {
+        let mut out = Vec::new();
+        downsample_stereo_to_mono_16k(&[], &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_stereo_pair_produces_one_sample() {
+        let mut out = Vec::new();
+        downsample_stereo_to_mono_16k(&[0.6, 0.4], &mut out);
+        assert_eq!(out.len(), 1);
+        assert!((out[0] - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn three_pairs_produce_one_sample() {
+        // 3 stereo pairs at 48 kHz → decimation 3:1 → 1 output sample
+        let input = [0.2, 0.8, 0.1, 0.3, 0.5, 0.5];
+        let mut out = Vec::new();
+        downsample_stereo_to_mono_16k(&input, &mut out);
+        assert_eq!(out.len(), 1);
+        // Only pair 0 is kept: (0.2 + 0.8) / 2 = 0.5
+        assert!((out[0] - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn six_pairs_produce_two_samples() {
+        // 6 stereo pairs → indices 0 and 3 are kept
+        let input = [
+            0.2, 0.4, // pair 0 → kept
+            0.0, 0.0, // pair 1 → skipped
+            0.0, 0.0, // pair 2 → skipped
+            0.6, 0.8, // pair 3 → kept
+            0.0, 0.0, // pair 4 → skipped
+            0.0, 0.0, // pair 5 → skipped
+        ];
+        let mut out = Vec::new();
+        downsample_stereo_to_mono_16k(&input, &mut out);
+        assert_eq!(out.len(), 2);
+        // Pair 0: (0.2 + 0.4) / 2 = 0.3
+        assert!((out[0] - 0.3).abs() < f32::EPSILON);
+        // Pair 3: (0.6 + 0.8) / 2 = 0.7
+        assert!((out[1] - 0.7).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn output_is_appended_not_replaced() {
+        let mut out = vec![1.0, 2.0];
+        downsample_stereo_to_mono_16k(&[0.6, 0.4], &mut out);
+        assert_eq!(out.len(), 3);
+        assert!((out[0] - 1.0).abs() < f32::EPSILON);
+        assert!((out[1] - 2.0).abs() < f32::EPSILON);
+        assert!((out[2] - 0.5).abs() < f32::EPSILON);
+    }
+}

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -231,9 +231,14 @@ fn chrono_timestamp() -> String {
 
     // SAFETY: `localtime_r` is the reentrant (thread-safe) variant.
     // We provide a valid `time_t` and a valid output buffer.
+    // Returns null on failure, in which case we fall back to UTC via `gmtime_r`.
     #[allow(unsafe_code)]
     let tm = unsafe {
-        libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
+        let result = libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
+        if result.is_null() {
+            // localtime_r failed — fall back to UTC.
+            libc::gmtime_r(&raw const epoch, tm.as_mut_ptr());
+        }
         tm.assume_init()
     };
 

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -235,9 +235,13 @@ fn chrono_timestamp() -> String {
     #[allow(unsafe_code)]
     let tm = unsafe {
         let result = libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
+        let result = if result.is_null() {
+            libc::gmtime_r(&raw const epoch, tm.as_mut_ptr())
+        } else {
+            result
+        };
         if result.is_null() {
-            // localtime_r failed — fall back to UTC.
-            libc::gmtime_r(&raw const epoch, tm.as_mut_ptr());
+            return "00:00:00".to_owned();
         }
         tm.assume_init()
     };

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -1,0 +1,234 @@
+//! Background worker thread for Whisper-based live transcription.
+//!
+//! Receives interleaved stereo f32 audio at 48 kHz, resamples to 16 kHz mono,
+//! accumulates 5-second chunks, and runs Whisper inference on non-silent chunks.
+
+use std::sync::mpsc;
+
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+use crate::{denoise, model, resampler};
+
+/// Seconds of audio per transcription chunk.
+const CHUNK_SECONDS: usize = 5;
+
+/// Number of 16 kHz mono samples per chunk (16000 * 5 = 80000).
+const CHUNK_SAMPLES: usize = 16_000 * CHUNK_SECONDS;
+
+/// RMS threshold below which a chunk is treated as silence and skipped.
+const SILENCE_THRESHOLD: f32 = 0.005;
+
+/// Events emitted by the transcription worker.
+#[derive(Debug, Clone)]
+pub enum TranscriptionEvent {
+    /// Model download in progress.
+    Downloading {
+        /// 0..=100
+        progress_pct: u8,
+    },
+    /// Model loaded and ready for inference.
+    Ready,
+    /// Transcribed text from one chunk.
+    Text {
+        /// Wall-clock timestamp in "HH:MM:SS" format.
+        timestamp: String,
+        /// Transcribed text (trimmed, non-empty).
+        text: String,
+    },
+    /// Fatal error — worker will exit after sending this.
+    Error(String),
+}
+
+/// Main worker loop. Blocks the calling thread and exits when `audio_rx` is
+/// closed (all senders dropped). Should be spawned on a dedicated thread.
+///
+/// # Arguments
+/// * `audio_rx` — receives interleaved stereo f32 audio at 48 kHz
+/// * `event_tx` — sends transcription events to the UI/consumer
+pub fn run_worker(
+    audio_rx: &mpsc::Receiver<Vec<f32>>,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+) {
+    if let Err(e) = run_worker_inner(audio_rx, event_tx) {
+        let _ = event_tx.send(TranscriptionEvent::Error(e));
+    }
+}
+
+/// Inner implementation that returns errors as strings so the outer function
+/// can forward them as `TranscriptionEvent::Error`.
+fn run_worker_inner(
+    audio_rx: &mpsc::Receiver<Vec<f32>>,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+) -> Result<(), String> {
+    // --- Model download / load ---
+    let model_path = if model::model_exists() {
+        tracing::info!("whisper model already present");
+        model::model_path()
+    } else {
+        tracing::info!("whisper model not found, downloading");
+        let (progress_tx, progress_rx) = mpsc::channel::<u8>();
+        let event_tx_dl = event_tx.clone();
+
+        // Forward download progress as TranscriptionEvent::Downloading.
+        let progress_thread = std::thread::Builder::new()
+            .name("whisper-dl-progress".into())
+            .spawn(move || {
+                while let Ok(pct) = progress_rx.recv() {
+                    let _ = event_tx_dl.send(TranscriptionEvent::Downloading { progress_pct: pct });
+                }
+            })
+            .map_err(|e| format!("failed to spawn progress thread: {e}"))?;
+
+        let path = model::download_model(&progress_tx)
+            .map_err(|e| format!("model download failed: {e}"))?;
+
+        // Drop the sender so the progress thread exits.
+        drop(progress_tx);
+        let _ = progress_thread.join();
+
+        path
+    };
+
+    let ctx = WhisperContext::new_with_params(&model_path, WhisperContextParameters::default())
+        .map_err(|e| format!("failed to load whisper model: {e}"))?;
+
+    let mut state = ctx
+        .create_state()
+        .map_err(|e| format!("failed to create whisper state: {e}"))?;
+
+    tracing::info!("whisper model loaded, ready for inference");
+    event_tx
+        .send(TranscriptionEvent::Ready)
+        .map_err(|_| "event channel closed before Ready".to_owned())?;
+
+    // --- Audio loop ---
+    let mut mono_buf: Vec<f32> = Vec::with_capacity(CHUNK_SAMPLES * 2);
+
+    while let Ok(interleaved) = audio_rx.recv() {
+        resampler::downsample_stereo_to_mono_16k(&interleaved, &mut mono_buf);
+
+        while mono_buf.len() >= CHUNK_SAMPLES {
+            let mut chunk: Vec<f32> = mono_buf.drain(..CHUNK_SAMPLES).collect();
+
+            // Spectral noise gate — remove broadband static and hiss
+            // before Whisper sees the audio.
+            denoise::spectral_denoise(&mut chunk);
+
+            let rms = compute_rms(&chunk);
+            if rms < SILENCE_THRESHOLD {
+                tracing::debug!(rms, "chunk below silence threshold, skipping");
+                continue;
+            }
+
+            // Run Whisper inference.
+            let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+            params.set_language(Some("en"));
+            params.set_print_progress(false);
+            params.set_print_realtime(false);
+            params.set_print_timestamps(false);
+            params.set_no_context(true);
+
+            if let Err(e) = state.full(params, &chunk) {
+                tracing::warn!("whisper inference failed: {e}");
+                continue;
+            }
+
+            let n_segments = state.full_n_segments();
+            let mut combined = String::new();
+
+            for i in 0..n_segments {
+                if let Some(segment) = state.get_segment(i)
+                    && let Ok(text) = segment.to_str()
+                {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        if !combined.is_empty() {
+                            combined.push(' ');
+                        }
+                        combined.push_str(trimmed);
+                    }
+                }
+            }
+
+            if !combined.is_empty() {
+                let timestamp = chrono_timestamp();
+                tracing::debug!(%timestamp, %combined, "transcribed chunk");
+                let _ = event_tx.send(TranscriptionEvent::Text {
+                    timestamp,
+                    text: combined,
+                });
+            }
+        }
+    }
+
+    tracing::info!("audio channel closed, worker exiting");
+    Ok(())
+}
+
+/// Compute the root-mean-square of a sample buffer.
+pub fn compute_rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|&s| s * s).sum();
+    #[allow(clippy::cast_precision_loss)]
+    let mean = sum_sq / samples.len() as f32;
+    mean.sqrt()
+}
+
+/// Return the current wall-clock time formatted as "HH:MM:SS" in local time.
+///
+/// Uses `libc::localtime_r` for timezone-aware formatting without pulling in
+/// the `chrono` crate.
+#[allow(unsafe_code)]
+fn chrono_timestamp() -> String {
+    let mut tv = libc::timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+
+    // SAFETY: `gettimeofday` writes into the provided buffer and is
+    // thread-safe. We pass null for the timezone (deprecated parameter).
+    #[allow(unsafe_code)]
+    let epoch = unsafe {
+        libc::gettimeofday(&raw mut tv, std::ptr::null_mut());
+        tv.tv_sec
+    };
+
+    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
+
+    // SAFETY: `localtime_r` is the reentrant (thread-safe) variant.
+    // We provide a valid `time_t` and a valid output buffer.
+    #[allow(unsafe_code)]
+    let tm = unsafe {
+        libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
+        tm.assume_init()
+    };
+
+    format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rms_of_silence_is_zero() {
+        let silence = vec![0.0_f32; 1024];
+        let rms = compute_rms(&silence);
+        assert!((rms - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn rms_of_ones_is_one() {
+        let ones = vec![1.0_f32; 1024];
+        let rms = compute_rms(&ones);
+        assert!((rms - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn rms_of_empty_is_zero() {
+        let rms = compute_rms(&[]);
+        assert!((rms - 0.0).abs() < f32::EPSILON);
+    }
+}

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -16,7 +16,8 @@ const CHUNK_SECONDS: usize = 5;
 const CHUNK_SAMPLES: usize = 16_000 * CHUNK_SECONDS;
 
 /// RMS threshold below which a chunk is treated as silence and skipped.
-const SILENCE_THRESHOLD: f32 = 0.005;
+/// Radio noise typically has RMS 0.01-0.03; speech is 0.05+.
+const SILENCE_THRESHOLD: f32 = 0.02;
 
 /// Events emitted by the transcription worker.
 #[derive(Debug, Clone)]
@@ -150,7 +151,7 @@ fn run_worker_inner(
                 }
             }
 
-            if !combined.is_empty() {
+            if !combined.is_empty() && !is_hallucination(&combined) {
                 let timestamp = chrono_timestamp();
                 tracing::debug!(%timestamp, %combined, "transcribed chunk");
                 let _ = event_tx.send(TranscriptionEvent::Text {
@@ -163,6 +164,37 @@ fn run_worker_inner(
 
     tracing::info!("audio channel closed, worker exiting");
     Ok(())
+}
+
+/// Common hallucination phrases Whisper produces on silence/noise.
+const HALLUCINATIONS: &[&str] = &[
+    "thank you",
+    "thanks for watching",
+    "subscribe",
+    "like and subscribe",
+    "see you next time",
+    "bye",
+    "you",
+    "the end",
+];
+
+/// Check if Whisper output is a known hallucination pattern.
+///
+/// Whisper tends to produce these when fed non-speech audio (radio static,
+/// tones, data bursts). We filter them out to keep the transcript clean.
+fn is_hallucination(text: &str) -> bool {
+    let lower = text.to_lowercase();
+
+    // Bracketed/parenthesized annotations Whisper generates for non-speech.
+    if (lower.starts_with('[') && lower.ends_with(']'))
+        || (lower.starts_with('(') && lower.ends_with(')'))
+    {
+        return true;
+    }
+
+    HALLUCINATIONS
+        .iter()
+        .any(|h| lower.trim().eq_ignore_ascii_case(h))
 }
 
 /// Compute the root-mean-square of a sample buffer.

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -16,8 +16,8 @@ const CHUNK_SECONDS: usize = 5;
 const CHUNK_SAMPLES: usize = 16_000 * CHUNK_SECONDS;
 
 /// RMS threshold below which a chunk is treated as silence and skipped.
-/// Radio noise typically has RMS 0.01-0.03; speech is 0.05+.
-const SILENCE_THRESHOLD: f32 = 0.02;
+/// Measured AFTER the spectral noise gate, so this catches residual noise.
+const SILENCE_THRESHOLD: f32 = 0.007;
 
 /// Events emitted by the transcription worker.
 #[derive(Debug, Clone)]

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -23,6 +23,7 @@ sdr-source-file.workspace = true
 sdr-sink-audio.workspace = true
 sdr-sink-network.workspace = true
 sdr-radioreference.workspace = true
+sdr-transcription.workspace = true
 gtk4.workspace = true
 libadwaita.workspace = true
 thiserror.workspace = true

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -221,6 +221,9 @@ struct DspState {
     // Recording state
     audio_writer: Option<WavWriter>,
     iq_writer: Option<WavWriter>,
+
+    /// Transcription audio tap — when Some, audio is copied to this channel.
+    transcription_tx: Option<std::sync::mpsc::SyncSender<Vec<f32>>>,
 }
 
 impl DspState {
@@ -270,6 +273,7 @@ impl DspState {
             audio_buf: Vec::new(),
             audio_writer: None,
             iq_writer: None,
+            transcription_tx: None,
         })
     }
 }
@@ -755,6 +759,15 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             state.iq_writer = None;
             let _ = dsp_tx.send(DspToUi::IqRecordingStopped);
         }
+
+        UiToDsp::EnableTranscription(tx) => {
+            state.transcription_tx = Some(tx);
+            tracing::info!("transcription audio tap enabled");
+        }
+        UiToDsp::DisableTranscription => {
+            state.transcription_tx = None;
+            tracing::info!("transcription audio tap disabled");
+        }
     }
 }
 
@@ -1031,6 +1044,16 @@ fn process_iq_block(
                             let _ = dsp_tx
                                 .send(DspToUi::Error("Audio recording write failed".to_string()));
                             let _ = dsp_tx.send(DspToUi::AudioRecordingStopped);
+                        }
+
+                        // Send audio copy to transcription worker (non-blocking).
+                        if let Some(ref tx) = state.transcription_tx {
+                            let mut interleaved = Vec::with_capacity(audio_count * 2);
+                            for s in &state.audio_buf[..audio_count] {
+                                interleaved.push(s.l);
+                                interleaved.push(s.r);
+                            }
+                            let _ = tx.try_send(interleaved);
                         }
 
                         // Send to PipeWire for playback.

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -1035,7 +1035,14 @@ fn process_iq_block(
                                 interleaved.push(s.l);
                                 interleaved.push(s.r);
                             }
-                            let _ = tx.try_send(interleaved);
+                            if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
+                                tx.try_send(interleaved)
+                            {
+                                state.transcription_tx = None;
+                                tracing::info!(
+                                    "transcription receiver disconnected, disabling tap"
+                                );
+                            }
                         }
 
                         // Apply volume with perceptual (power-law) scaling.

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -1027,6 +1027,17 @@ fn process_iq_block(
                             let _ = dsp_tx.send(DspToUi::SignalLevel(level_db));
                         }
 
+                        // Send audio copy to transcription worker BEFORE volume
+                        // scaling so recognition isn't affected by the volume knob.
+                        if let Some(ref tx) = state.transcription_tx {
+                            let mut interleaved = Vec::with_capacity(audio_count * 2);
+                            for s in &state.audio_buf[..audio_count] {
+                                interleaved.push(s.l);
+                                interleaved.push(s.r);
+                            }
+                            let _ = tx.try_send(interleaved);
+                        }
+
                         // Apply volume with perceptual (power-law) scaling.
                         // Quadratic curve maps the linear slider to perceived loudness.
                         let vol = state.volume * state.volume;
@@ -1044,16 +1055,6 @@ fn process_iq_block(
                             let _ = dsp_tx
                                 .send(DspToUi::Error("Audio recording write failed".to_string()));
                             let _ = dsp_tx.send(DspToUi::AudioRecordingStopped);
-                        }
-
-                        // Send audio copy to transcription worker (non-blocking).
-                        if let Some(ref tx) = state.transcription_tx {
-                            let mut interleaved = Vec::with_capacity(audio_count * 2);
-                            for s in &state.audio_buf[..audio_count] {
-                                interleaved.push(s.l);
-                                interleaved.push(s.r);
-                            }
-                            let _ = tx.try_send(interleaved);
                         }
 
                         // Send to PipeWire for playback.

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -122,6 +122,10 @@ pub enum UiToDsp {
     StartIqRecording(std::path::PathBuf),
     /// Stop IQ recording and finalize the WAV file.
     StopIqRecording,
+    /// Start sending audio to the transcription engine.
+    EnableTranscription(std::sync::mpsc::SyncSender<Vec<f32>>),
+    /// Stop sending audio to the transcription engine.
+    DisableTranscription,
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -307,6 +307,13 @@ mod tests {
 
         let iq_stop = UiToDsp::StopIqRecording;
         assert!(matches!(iq_stop, UiToDsp::StopIqRecording));
+
+        let (tx, _rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(1);
+        let enable = UiToDsp::EnableTranscription(tx);
+        assert!(matches!(enable, UiToDsp::EnableTranscription(_)));
+
+        let disable = UiToDsp::DisableTranscription;
+        assert!(matches!(disable, UiToDsp::DisableTranscription));
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -1,4 +1,4 @@
-//! Sidebar configuration panels — source, audio, radio, display, navigation.
+//! Sidebar configuration panels — source, audio, radio, display, navigation, transcript.
 
 use gtk4::prelude::*;
 
@@ -7,12 +7,14 @@ pub mod display_panel;
 pub mod navigation_panel;
 pub mod radio_panel;
 pub mod source_panel;
+pub mod transcript_panel;
 
 pub use audio_panel::{AudioPanel, build_audio_panel};
 pub use display_panel::{DisplayPanel, build_display_panel};
 pub use navigation_panel::{NavigationPanel, build_navigation_panel};
 pub use radio_panel::{RadioPanel, build_radio_panel};
 pub use source_panel::{SourcePanel, build_source_panel};
+pub use transcript_panel::{TranscriptPanel, build_transcript_panel};
 
 /// Spacing between sidebar preference groups in pixels.
 const SIDEBAR_SPACING: i32 = 12;
@@ -31,6 +33,8 @@ pub struct SidebarPanels {
     pub display: DisplayPanel,
     /// Navigation — band presets and bookmarks.
     pub navigation: NavigationPanel,
+    /// Live transcription display.
+    pub transcript: TranscriptPanel,
 }
 
 /// Build the complete sidebar `ScrolledWindow` containing all configuration panels.
@@ -43,6 +47,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     let radio = build_radio_panel();
     let display = build_display_panel();
     let navigation = build_navigation_panel();
+    let transcript = build_transcript_panel();
 
     let sidebar_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
@@ -59,6 +64,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     sidebar_box.append(&audio.widget);
     sidebar_box.append(&radio.widget);
     sidebar_box.append(&display.widget);
+    sidebar_box.append(&transcript.widget);
 
     let scroll = gtk4::ScrolledWindow::builder()
         .child(&sidebar_box)
@@ -71,6 +77,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
         radio,
         display,
         navigation,
+        transcript,
     };
 
     (scroll, panels)

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -1,4 +1,6 @@
-//! Sidebar configuration panels — source, audio, radio, display, navigation, transcript.
+//! Sidebar configuration panels — source, audio, radio, display, navigation.
+//!
+//! The transcript panel lives in a separate right-side revealer, not here.
 
 use gtk4::prelude::*;
 
@@ -33,8 +35,6 @@ pub struct SidebarPanels {
     pub display: DisplayPanel,
     /// Navigation — band presets and bookmarks.
     pub navigation: NavigationPanel,
-    /// Live transcription display.
-    pub transcript: TranscriptPanel,
 }
 
 /// Build the complete sidebar `ScrolledWindow` containing all configuration panels.
@@ -47,8 +47,6 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     let radio = build_radio_panel();
     let display = build_display_panel();
     let navigation = build_navigation_panel();
-    let transcript = build_transcript_panel();
-
     let sidebar_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
         .spacing(SIDEBAR_SPACING)
@@ -64,7 +62,6 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     sidebar_box.append(&audio.widget);
     sidebar_box.append(&radio.widget);
     sidebar_box.append(&display.widget);
-    sidebar_box.append(&transcript.widget);
 
     let scroll = gtk4::ScrolledWindow::builder()
         .child(&sidebar_box)
@@ -77,7 +74,6 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
         radio,
         display,
         navigation,
-        transcript,
     };
 
     (scroll, panels)

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -1,0 +1,103 @@
+//! Transcript sidebar panel — displays live transcription results.
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Transcript panel with toggle switch, status label, progress bar,
+/// scrolling transcript log, and clear button.
+pub struct TranscriptPanel {
+    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
+    pub widget: adw::PreferencesGroup,
+    /// Toggle to enable/disable live transcription.
+    pub enable_row: adw::SwitchRow,
+    /// Status label (downloading, listening, error).
+    pub status_label: gtk4::Label,
+    /// Model download progress bar.
+    pub progress_bar: gtk4::ProgressBar,
+    /// Scrolling transcript text display.
+    pub text_view: gtk4::TextView,
+    /// Scroll container for the text view.
+    pub scroll: gtk4::ScrolledWindow,
+    /// Button to clear the transcript log.
+    pub clear_button: gtk4::Button,
+}
+
+/// Build the transcript sidebar panel.
+pub fn build_transcript_panel() -> TranscriptPanel {
+    let group = adw::PreferencesGroup::builder()
+        .title("Transcript")
+        .description("Live speech-to-text")
+        .build();
+
+    let enable_row = adw::SwitchRow::builder()
+        .title("Enable Transcription")
+        .subtitle("Whisper tiny (English)")
+        .build();
+    group.add(&enable_row);
+
+    let status_label = gtk4::Label::builder()
+        .halign(gtk4::Align::Start)
+        .css_classes(["dim-label"])
+        .visible(false)
+        .margin_start(12)
+        .margin_top(4)
+        .build();
+
+    let progress_bar = gtk4::ProgressBar::builder()
+        .visible(false)
+        .margin_start(12)
+        .margin_end(12)
+        .margin_top(4)
+        .build();
+
+    let text_view = gtk4::TextView::builder()
+        .editable(false)
+        .cursor_visible(false)
+        .wrap_mode(gtk4::WrapMode::Word)
+        .monospace(true)
+        .top_margin(8)
+        .bottom_margin(8)
+        .left_margin(8)
+        .right_margin(8)
+        .build();
+
+    let scroll = gtk4::ScrolledWindow::builder()
+        .child(&text_view)
+        .min_content_height(150)
+        .max_content_height(300)
+        .css_classes(["card"])
+        .margin_top(8)
+        .build();
+
+    let clear_button = gtk4::Button::builder()
+        .label("Clear")
+        .halign(gtk4::Align::Start)
+        .margin_top(4)
+        .build();
+
+    let text_view_clear = text_view.clone();
+    clear_button.connect_clicked(move |_| {
+        text_view_clear.buffer().set_text("");
+    });
+
+    let content_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(4)
+        .build();
+    content_box.append(&status_label);
+    content_box.append(&progress_bar);
+    content_box.append(&scroll);
+    content_box.append(&clear_button);
+    group.add(&content_box);
+
+    TranscriptPanel {
+        widget: group,
+        enable_row,
+        status_label,
+        progress_bar,
+        text_view,
+        scroll,
+        clear_button,
+    }
+}

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -65,7 +65,7 @@ pub fn build_transcript_panel() -> TranscriptPanel {
     let scroll = gtk4::ScrolledWindow::builder()
         .child(&text_view)
         .min_content_height(150)
-        .max_content_height(300)
+        .vexpand(true)
         .css_classes(["card"])
         .margin_top(8)
         .build();
@@ -84,6 +84,7 @@ pub fn build_transcript_panel() -> TranscriptPanel {
     let content_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
         .spacing(4)
+        .vexpand(true)
         .build();
     content_box.append(&status_label);
     content_box.append(&progress_bar);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -55,11 +55,25 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let state = AppState::new_shared(ui_tx);
 
     // --- Build UI ---
-    let (split_view, panels, spectrum_handle_raw, status_bar) = build_split_view(&state);
+    let (split_view, panels, spectrum_handle_raw, status_bar, transcript_panel, transcript_revealer) =
+        build_split_view(&state);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
     let sidebar_toggle = build_sidebar_toggle(&split_view);
     let (header, play_button, demod_dropdown, freq_selector, screenshot_button, rr_button) =
         build_header_bar(&sidebar_toggle, &state);
+
+    // Transcript toggle button in header bar.
+    let transcript_button = gtk4::ToggleButton::builder()
+        .icon_name("document-page-setup-symbolic")
+        .tooltip_text("Toggle transcript panel")
+        .build();
+    header.pack_end(&transcript_button);
+
+    let revealer_clone = transcript_revealer.clone();
+    transcript_button.connect_toggled(move |btn| {
+        revealer_clone.set_reveal_child(btn.is_active());
+    });
+
     let toolbar_view = build_toolbar_view(&header, &split_view);
     let breakpoint = build_breakpoint(&split_view);
 
@@ -89,6 +103,9 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     status_bar.update_frequency(freq_selector.frequency() as f64);
 
     setup_app_actions(app, &window, config, &rr_button);
+
+    // Wire transcript panel (separate from sidebar panels).
+    connect_transcript_panel(&transcript_panel, &state);
 
     // --- Keyboard shortcuts ---
     shortcuts::setup_shortcuts(&window, &play_button, &sidebar_toggle, &demod_dropdown);
@@ -378,6 +395,8 @@ fn build_split_view(
     SidebarPanels,
     spectrum::SpectrumHandle,
     StatusBar,
+    sidebar::transcript_panel::TranscriptPanel,
+    gtk4::Revealer,
 ) {
     // Sidebar — configuration panels.
     let (sidebar_scroll, panels) = sidebar::build_sidebar();
@@ -397,13 +416,39 @@ fn build_split_view(
     content_box.append(&spectrum_view);
     content_box.append(&status_bar.widget);
 
+    // Transcript panel — slides out from the right.
+    let transcript_panel = sidebar::transcript_panel::build_transcript_panel();
+    let transcript_scroll = gtk4::ScrolledWindow::builder()
+        .child(&transcript_panel.widget)
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .width_request(320)
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .build();
+
+    let transcript_revealer = gtk4::Revealer::builder()
+        .transition_type(gtk4::RevealerTransitionType::SlideLeft)
+        .transition_duration(200)
+        .reveal_child(false)
+        .child(&transcript_scroll)
+        .build();
+
+    // Wrap content + transcript revealer in an HBox.
+    let content_with_transcript = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .build();
+    content_with_transcript.append(&content_box);
+    content_with_transcript.append(&transcript_revealer);
+
     let split_view = adw::OverlaySplitView::builder()
         .sidebar(&sidebar_scroll)
-        .content(&content_box)
+        .content(&content_with_transcript)
         .show_sidebar(true)
         .build();
 
-    (split_view, panels, spectrum_handle, status_bar)
+    (split_view, panels, spectrum_handle, status_bar, transcript_panel, transcript_revealer)
 }
 
 /// Build the sidebar toggle button bound to the split view.
@@ -589,7 +634,7 @@ fn connect_sidebar_panels(
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
-    connect_transcript_panel(panels, state);
+    // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
         panels,
         state,
@@ -1323,7 +1368,10 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
 }
 
 /// Connect transcript panel controls to DSP commands.
-fn connect_transcript_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
+fn connect_transcript_panel(
+    transcript: &sidebar::transcript_panel::TranscriptPanel,
+    state: &Rc<AppState>,
+) {
     use sdr_transcription::{TranscriptionEngine, TranscriptionEvent};
 
     let engine: Rc<RefCell<TranscriptionEngine>> =
@@ -1331,14 +1379,11 @@ fn connect_transcript_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
 
     let state_clone = Rc::clone(state);
     let engine_clone = Rc::clone(&engine);
-    let status_label = panels.transcript.status_label.clone();
-    let progress_bar = panels.transcript.progress_bar.clone();
-    let text_view = panels.transcript.text_view.clone();
+    let status_label = transcript.status_label.clone();
+    let progress_bar = transcript.progress_bar.clone();
+    let text_view = transcript.text_view.clone();
 
-    panels
-        .transcript
-        .enable_row
-        .connect_active_notify(move |row| {
+    transcript.enable_row.connect_active_notify(move |row| {
             let mut eng = engine_clone.borrow_mut();
 
             if row.is_active() {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1,5 +1,6 @@
 //! Main window construction — header bar, split view, breakpoints, DSP bridge.
 
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::mpsc;
 use std::time::Duration;
@@ -588,6 +589,7 @@ fn connect_sidebar_panels(
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
+    connect_transcript_panel(panels, state);
     connect_navigation_panel(
         panels,
         state,
@@ -1316,6 +1318,89 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             } else {
                 tracing::info!("stopping audio recording");
                 state_rec.send_dsp(UiToDsp::StopAudioRecording);
+            }
+        });
+}
+
+/// Connect transcript panel controls to DSP commands.
+fn connect_transcript_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
+    use sdr_transcription::{TranscriptionEngine, TranscriptionEvent};
+
+    let engine: Rc<RefCell<TranscriptionEngine>> =
+        Rc::new(RefCell::new(TranscriptionEngine::new()));
+
+    let state_clone = Rc::clone(state);
+    let engine_clone = Rc::clone(&engine);
+    let status_label = panels.transcript.status_label.clone();
+    let progress_bar = panels.transcript.progress_bar.clone();
+    let text_view = panels.transcript.text_view.clone();
+
+    panels
+        .transcript
+        .enable_row
+        .connect_active_notify(move |row| {
+            let mut eng = engine_clone.borrow_mut();
+
+            if row.is_active() {
+                match eng.start() {
+                    Ok(event_rx) => {
+                        if let Some(audio_tx) = eng.audio_sender() {
+                            state_clone
+                                .send_dsp(crate::messages::UiToDsp::EnableTranscription(audio_tx));
+                        }
+
+                        status_label.set_text("Starting...");
+                        status_label.set_visible(true);
+
+                        let status = status_label.clone();
+                        let progress = progress_bar.clone();
+                        let tv = text_view.clone();
+
+                        glib::timeout_add_local(Duration::from_millis(100), move || {
+                            while let Ok(event) = event_rx.try_recv() {
+                                match event {
+                                    TranscriptionEvent::Downloading { progress_pct } => {
+                                        status.set_text(&format!(
+                                            "Downloading model ({progress_pct}%)..."
+                                        ));
+                                        status.set_visible(true);
+                                        progress.set_fraction(f64::from(progress_pct) / 100.0);
+                                        progress.set_visible(true);
+                                    }
+                                    TranscriptionEvent::Ready => {
+                                        status.set_text("Listening...");
+                                        status.set_css_classes(&["success"]);
+                                        progress.set_visible(false);
+                                    }
+                                    TranscriptionEvent::Text { timestamp, text } => {
+                                        let buf = tv.buffer();
+                                        let mut end = buf.end_iter();
+                                        buf.insert(&mut end, &format!("[{timestamp}] {text}\n"));
+                                        // Auto-scroll to bottom
+                                        let mark = buf.create_mark(None, &buf.end_iter(), false);
+                                        tv.scroll_to_mark(&mark, 0.0, false, 0.0, 0.0);
+                                        buf.delete_mark(&mark);
+                                    }
+                                    TranscriptionEvent::Error(msg) => {
+                                        status.set_text(&msg);
+                                        status.set_css_classes(&["error"]);
+                                    }
+                                }
+                            }
+                            glib::ControlFlow::Continue
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!("failed to start transcription: {e}");
+                        row.set_active(false);
+                    }
+                }
+            } else {
+                state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
+                eng.stop();
+                status_label.set_text("");
+                status_label.set_visible(false);
+                progress_bar.set_visible(false);
             }
         });
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1407,12 +1407,13 @@ fn connect_transcript_panel(
     let text_view = transcript.text_view.clone();
 
     transcript.enable_row.connect_active_notify(move |row| {
-        let mut eng = engine_clone.borrow_mut();
-
         if row.is_active() {
-            match eng.start() {
+            // Scope the borrow so it's dropped before any potential re-entry
+            // from row.set_active(false) on error.
+            let start_result = engine_clone.borrow_mut().start();
+            match start_result {
                 Ok(event_rx) => {
-                    if let Some(audio_tx) = eng.audio_sender() {
+                    if let Some(audio_tx) = engine_clone.borrow().audio_sender() {
                         state_clone
                             .send_dsp(crate::messages::UiToDsp::EnableTranscription(audio_tx));
                     }
@@ -1445,7 +1446,6 @@ fn connect_transcript_panel(
                                         let buf = tv.buffer();
                                         let mut end = buf.end_iter();
                                         buf.insert(&mut end, &format!("[{timestamp}] {text}\n"));
-                                        // Auto-scroll to bottom
                                         let mark = buf.create_mark(None, &buf.end_iter(), false);
                                         tv.scroll_to_mark(&mark, 0.0, false, 0.0, 0.0);
                                         buf.delete_mark(&mark);
@@ -1471,7 +1471,7 @@ fn connect_transcript_panel(
             }
         } else {
             state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
-            eng.shutdown_nonblocking();
+            engine_clone.borrow_mut().shutdown_nonblocking();
             status_label.set_text("");
             status_label.set_visible(false);
             progress_bar.set_visible(false);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -55,8 +55,14 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let state = AppState::new_shared(ui_tx);
 
     // --- Build UI ---
-    let (split_view, panels, spectrum_handle_raw, status_bar, transcript_panel, transcript_revealer) =
-        build_split_view(&state);
+    let (
+        split_view,
+        panels,
+        spectrum_handle_raw,
+        status_bar,
+        transcript_panel,
+        transcript_revealer,
+    ) = build_split_view(&state);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
     let sidebar_toggle = build_sidebar_toggle(&split_view);
     let (header, play_button, demod_dropdown, freq_selector, screenshot_button, rr_button) =
@@ -456,7 +462,14 @@ fn build_split_view(
         .show_sidebar(true)
         .build();
 
-    (split_view, panels, spectrum_handle, status_bar, transcript_panel, transcript_revealer)
+    (
+        split_view,
+        panels,
+        spectrum_handle,
+        status_bar,
+        transcript_panel,
+        transcript_revealer,
+    )
 }
 
 /// Build the sidebar toggle button bound to the split view.
@@ -1394,26 +1407,27 @@ fn connect_transcript_panel(
     let text_view = transcript.text_view.clone();
 
     transcript.enable_row.connect_active_notify(move |row| {
-            let mut eng = engine_clone.borrow_mut();
+        let mut eng = engine_clone.borrow_mut();
 
-            if row.is_active() {
-                match eng.start() {
-                    Ok(event_rx) => {
-                        if let Some(audio_tx) = eng.audio_sender() {
-                            state_clone
-                                .send_dsp(crate::messages::UiToDsp::EnableTranscription(audio_tx));
-                        }
+        if row.is_active() {
+            match eng.start() {
+                Ok(event_rx) => {
+                    if let Some(audio_tx) = eng.audio_sender() {
+                        state_clone
+                            .send_dsp(crate::messages::UiToDsp::EnableTranscription(audio_tx));
+                    }
 
-                        status_label.set_text("Starting...");
-                        status_label.set_visible(true);
+                    status_label.set_text("Starting...");
+                    status_label.set_visible(true);
 
-                        let status = status_label.clone();
-                        let progress = progress_bar.clone();
-                        let tv = text_view.clone();
+                    let status = status_label.clone();
+                    let progress = progress_bar.clone();
+                    let tv = text_view.clone();
 
-                        glib::timeout_add_local(Duration::from_millis(100), move || {
-                            while let Ok(event) = event_rx.try_recv() {
-                                match event {
+                    glib::timeout_add_local(Duration::from_millis(100), move || {
+                        loop {
+                            match event_rx.try_recv() {
+                                Ok(event) => match event {
                                     TranscriptionEvent::Downloading { progress_pct } => {
                                         status.set_text(&format!(
                                             "Downloading model ({progress_pct}%)..."
@@ -1440,24 +1454,29 @@ fn connect_transcript_panel(
                                         status.set_text(&msg);
                                         status.set_css_classes(&["error"]);
                                     }
+                                },
+                                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                                    return glib::ControlFlow::Break;
                                 }
                             }
-                            glib::ControlFlow::Continue
-                        });
-                    }
-                    Err(e) => {
-                        tracing::warn!("failed to start transcription: {e}");
-                        row.set_active(false);
-                    }
+                        }
+                        glib::ControlFlow::Continue
+                    });
                 }
-            } else {
-                state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
-                eng.stop();
-                status_label.set_text("");
-                status_label.set_visible(false);
-                progress_bar.set_visible(false);
+                Err(e) => {
+                    tracing::warn!("failed to start transcription: {e}");
+                    row.set_active(false);
+                }
             }
-        });
+        } else {
+            state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
+            eng.shutdown_nonblocking();
+            status_label.set_text("");
+            status_label.set_visible(false);
+            progress_bar.set_visible(false);
+        }
+    });
 
     engine
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -105,7 +105,13 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     setup_app_actions(app, &window, config, &rr_button);
 
     // Wire transcript panel (separate from sidebar panels).
-    connect_transcript_panel(&transcript_panel, &state);
+    let transcription_engine = connect_transcript_panel(&transcript_panel, &state);
+
+    // On window close, signal the worker to stop without blocking.
+    window.connect_close_request(move |_| {
+        transcription_engine.borrow_mut().shutdown_nonblocking();
+        glib::Propagation::Proceed
+    });
 
     // --- Keyboard shortcuts ---
     shortcuts::setup_shortcuts(&window, &play_button, &sidebar_toggle, &demod_dropdown);
@@ -421,6 +427,7 @@ fn build_split_view(
     let transcript_scroll = gtk4::ScrolledWindow::builder()
         .child(&transcript_panel.widget)
         .hscrollbar_policy(gtk4::PolicyType::Never)
+        .vexpand(true)
         .width_request(320)
         .margin_top(12)
         .margin_bottom(12)
@@ -433,6 +440,7 @@ fn build_split_view(
         .transition_duration(200)
         .reveal_child(false)
         .child(&transcript_scroll)
+        .hexpand(false)
         .build();
 
     // Wrap content + transcript revealer in an HBox.
@@ -1368,10 +1376,12 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
 }
 
 /// Connect transcript panel controls to DSP commands.
+///
+/// Returns the engine handle so it can be stopped on window close.
 fn connect_transcript_panel(
     transcript: &sidebar::transcript_panel::TranscriptPanel,
     state: &Rc<AppState>,
-) {
+) -> Rc<RefCell<sdr_transcription::TranscriptionEngine>> {
     use sdr_transcription::{TranscriptionEngine, TranscriptionEvent};
 
     let engine: Rc<RefCell<TranscriptionEngine>> =
@@ -1448,6 +1458,8 @@ fn connect_transcript_panel(
                 progress_bar.set_visible(false);
             }
         });
+
+    engine
 }
 
 /// Register application-level actions (Preferences, About, Quit).

--- a/docs/superpowers/plans/2026-04-11-live-transcription.md
+++ b/docs/superpowers/plans/2026-04-11-live-transcription.md
@@ -1,0 +1,1178 @@
+# Live Transcription Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Real-time speech-to-text for demodulated radio audio, displayed in a scrolling transcript log in the sidebar.
+
+**Architecture:** New `sdr-transcription` crate wraps `whisper-rs` (whisper.cpp bindings) with a background worker thread. Audio is tapped from the DSP controller via a bounded channel, resampled 48 kHz stereo → 16 kHz mono, accumulated in chunks, and fed to Whisper for inference. Results flow back to a new Transcript sidebar panel via an event channel polled on a GTK timer.
+
+**Tech Stack:** `whisper-rs` (whisper.cpp bindings), `reqwest` (model download), GTK4/libadwaita sidebar panel
+
+**Design Spec:** `docs/superpowers/specs/2026-04-11-live-transcription-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+```text
+crates/sdr-transcription/
+  Cargo.toml
+  src/
+    lib.rs              — TranscriptionEngine public API + TranscriptionEvent enum
+    worker.rs           — background thread: audio accumulation, silence detection, Whisper inference
+    resampler.rs        — 48 kHz stereo → 16 kHz mono conversion
+    model.rs            — model download from HuggingFace, path management
+
+crates/sdr-ui/src/sidebar/
+  transcript_panel.rs   — Transcript sidebar panel UI
+```
+
+### Modified Files
+
+```text
+Cargo.toml                                  — workspace members + deps
+crates/sdr-ui/Cargo.toml                   — add sdr-transcription dep
+crates/sdr-ui/src/sidebar/mod.rs           — add transcript panel to SidebarPanels + build_sidebar
+crates/sdr-ui/src/window.rs                — connect transcript panel, wire enable/disable
+crates/sdr-ui/src/dsp_controller.rs        — audio tap + UiToDsp messages for transcription
+crates/sdr-ui/src/messages.rs              — add transcription-related UiToDsp/DspToUi variants
+```
+
+---
+
+## Task 1: sdr-transcription Crate — Resampler (TDD)
+
+**Files:**
+- Create: `crates/sdr-transcription/Cargo.toml`
+- Create: `crates/sdr-transcription/src/lib.rs`
+- Create: `crates/sdr-transcription/src/resampler.rs`
+- Modify: `Cargo.toml` (workspace members + deps)
+
+- [ ] **Step 1: Add workspace member and dependencies**
+
+In `Cargo.toml`, add to `[workspace]` members (after `"crates/sdr-radioreference"`):
+
+```toml
+"crates/sdr-transcription",
+```
+
+Add to `[workspace.dependencies]`:
+
+```toml
+sdr-transcription = { path = "crates/sdr-transcription" }
+whisper-rs = "0.14"
+```
+
+- [ ] **Step 2: Create crate Cargo.toml**
+
+Create `crates/sdr-transcription/Cargo.toml`:
+
+```toml
+[package]
+name = "sdr-transcription"
+version = "0.1.0"
+description = "Live audio transcription via Whisper"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+whisper-rs.workspace = true
+reqwest.workspace = true
+sdr-types.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 3: Create lib.rs stub**
+
+Create `crates/sdr-transcription/src/lib.rs`:
+
+```rust
+pub mod resampler;
+```
+
+- [ ] **Step 4: Write failing resampler tests**
+
+Create `crates/sdr-transcription/src/resampler.rs`:
+
+```rust
+//! Resample 48 kHz interleaved stereo to 16 kHz mono.
+//!
+//! Simple 3:1 decimation with stereo-to-mono mix. No anti-aliasing
+//! filter needed — radio audio bandwidth is well under 8 kHz.
+
+/// Decimation factor: 48000 / 16000 = 3.
+const DECIMATION_FACTOR: usize = 3;
+
+/// Convert interleaved stereo f32 at 48 kHz to mono f32 at 16 kHz.
+///
+/// Input: `[L0, R0, L1, R1, L2, R2, ...]` at 48 kHz
+/// Output: `[(L0+R0)/2, (L3+R3)/2, (L6+R6)/2, ...]` at 16 kHz
+///
+/// Each output sample is the mono mix of every 3rd stereo pair.
+pub fn downsample_stereo_to_mono_16k(interleaved_48k: &[f32], output: &mut Vec<f32>) {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_produces_empty_output() {
+        let mut out = Vec::new();
+        downsample_stereo_to_mono_16k(&[], &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_stereo_pair_produces_one_sample() {
+        // One stereo pair at index 0 → one output sample
+        let input = [0.6_f32, 0.4];
+        let mut out = Vec::new();
+        downsample_stereo_to_mono_16k(&input, &mut out);
+        assert_eq!(out.len(), 1);
+        assert!((out[0] - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn three_pairs_produce_one_sample() {
+        // 3 stereo pairs → take only index 0 (decimation factor 3)
+        let input = [0.6, 0.4, 0.1, 0.1, 0.2, 0.2];
+        let mut out = Vec::new();
+        downsample_stereo_to_mono_16k(&input, &mut out);
+        assert_eq!(out.len(), 1);
+        assert!((out[0] - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn six_pairs_produce_two_samples() {
+        // 6 stereo pairs → 2 output samples (indices 0 and 3)
+        let input = [
+            1.0, 0.0, // pair 0: mono = 0.5
+            0.0, 0.0, // pair 1: skipped
+            0.0, 0.0, // pair 2: skipped
+            0.0, 1.0, // pair 3: mono = 0.5
+            0.0, 0.0, // pair 4: skipped
+            0.0, 0.0, // pair 5: skipped
+        ];
+        let mut out = Vec::new();
+        downsample_stereo_to_mono_16k(&input, &mut out);
+        assert_eq!(out.len(), 2);
+        assert!((out[0] - 0.5).abs() < f32::EPSILON);
+        assert!((out[1] - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn output_is_appended_not_replaced() {
+        let input = [0.8, 0.2];
+        let mut out = vec![99.0];
+        downsample_stereo_to_mono_16k(&input, &mut out);
+        assert_eq!(out.len(), 2);
+        assert!((out[0] - 99.0).abs() < f32::EPSILON);
+        assert!((out[1] - 0.5).abs() < f32::EPSILON);
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they fail**
+
+Run: `cargo test -p sdr-transcription`
+Expected: FAIL — `todo!()` panics
+
+- [ ] **Step 6: Implement resampler**
+
+Replace `todo!()` in `downsample_stereo_to_mono_16k`:
+
+```rust
+pub fn downsample_stereo_to_mono_16k(interleaved_48k: &[f32], output: &mut Vec<f32>) {
+    // Each stereo pair is 2 floats. Step by DECIMATION_FACTOR pairs.
+    let pair_count = interleaved_48k.len() / 2;
+    let mut pair_idx = 0;
+    while pair_idx < pair_count {
+        let l = interleaved_48k[pair_idx * 2];
+        let r = interleaved_48k[pair_idx * 2 + 1];
+        output.push((l + r) / 2.0);
+        pair_idx += DECIMATION_FACTOR;
+    }
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cargo test -p sdr-transcription`
+Expected: All 5 tests PASS
+
+- [ ] **Step 8: Clippy**
+
+Run: `cargo clippy -p sdr-transcription -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/sdr-transcription/ Cargo.toml Cargo.lock
+git commit -m "add sdr-transcription crate with 48kHz→16kHz resampler"
+```
+
+---
+
+## Task 2: Model Download + Path Management
+
+**Files:**
+- Create: `crates/sdr-transcription/src/model.rs`
+- Modify: `crates/sdr-transcription/src/lib.rs`
+
+- [ ] **Step 1: Create model.rs**
+
+Create `crates/sdr-transcription/src/model.rs`:
+
+```rust
+//! Whisper model download and path management.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+
+/// Whisper tiny English GGML model URL (from ggerganov/whisper.cpp on HuggingFace).
+const MODEL_URL: &str =
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin";
+
+/// Model filename.
+const MODEL_FILENAME: &str = "ggml-tiny.en.bin";
+
+/// Returns the directory for storing models.
+///
+/// Uses `$XDG_DATA_HOME/sdr-rs/models/` (typically `~/.local/share/sdr-rs/models/`).
+pub fn models_dir() -> PathBuf {
+    let data_dir = dirs_next::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("sdr-rs")
+        .join("models");
+    data_dir
+}
+
+/// Returns the full path to the Whisper tiny English model.
+pub fn model_path() -> PathBuf {
+    models_dir().join(MODEL_FILENAME)
+}
+
+/// Check if the model file exists.
+pub fn model_exists() -> bool {
+    model_path().is_file()
+}
+
+/// Download the Whisper tiny English model, sending progress events.
+///
+/// Blocks until download completes. Sends `progress_pct` (0..100) to the
+/// provided sender.
+#[allow(clippy::cast_possible_truncation)]
+pub fn download_model(
+    progress_tx: &mpsc::Sender<u8>,
+) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
+    let dir = models_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    let dest = dir.join(MODEL_FILENAME);
+    tracing::info!(?dest, "downloading Whisper model");
+
+    let response = reqwest::blocking::get(MODEL_URL)?;
+    let total_size = response.content_length().unwrap_or(0);
+
+    let mut file = std::fs::File::create(&dest)?;
+    let mut downloaded: u64 = 0;
+    let mut last_pct: u8 = 0;
+
+    let mut reader = response;
+    let mut buf = vec![0u8; 64 * 1024];
+
+    loop {
+        let bytes_read = std::io::Read::read(&mut reader, &mut buf)?;
+        if bytes_read == 0 {
+            break;
+        }
+        file.write_all(&buf[..bytes_read])?;
+        downloaded += bytes_read as u64;
+
+        if total_size > 0 {
+            let pct = ((downloaded * 100) / total_size).min(100) as u8;
+            if pct != last_pct {
+                last_pct = pct;
+                let _ = progress_tx.send(pct);
+            }
+        }
+    }
+
+    file.flush()?;
+    tracing::info!(?dest, bytes = downloaded, "model download complete");
+
+    Ok(dest)
+}
+```
+
+- [ ] **Step 2: Add `dirs-next` dependency**
+
+Add to `Cargo.toml` workspace dependencies:
+
+```toml
+dirs-next = "2"
+```
+
+Add to `crates/sdr-transcription/Cargo.toml` dependencies:
+
+```toml
+dirs-next.workspace = true
+```
+
+- [ ] **Step 3: Update lib.rs**
+
+```rust
+pub mod model;
+pub mod resampler;
+```
+
+- [ ] **Step 4: Build and clippy**
+
+Run: `cargo build -p sdr-transcription && cargo clippy -p sdr-transcription -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-transcription/ Cargo.toml Cargo.lock
+git commit -m "add Whisper model download and path management"
+```
+
+---
+
+## Task 3: Whisper Worker Thread
+
+**Files:**
+- Create: `crates/sdr-transcription/src/worker.rs`
+- Modify: `crates/sdr-transcription/src/lib.rs`
+
+- [ ] **Step 1: Create worker.rs**
+
+Create `crates/sdr-transcription/src/worker.rs`:
+
+```rust
+//! Background worker thread for audio transcription.
+//!
+//! Receives interleaved stereo f32 at 48 kHz, resamples to 16 kHz mono,
+//! accumulates chunks, and runs Whisper inference when enough audio has
+//! accumulated.
+
+use std::sync::mpsc;
+
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+use crate::model;
+use crate::resampler;
+
+/// How many seconds of 16 kHz audio to accumulate before transcribing.
+const CHUNK_SECONDS: usize = 5;
+
+/// 16 kHz * 5 seconds = 80,000 samples per chunk.
+const CHUNK_SAMPLES: usize = 16_000 * CHUNK_SECONDS;
+
+/// Minimum RMS energy to consider a chunk as containing speech.
+/// Below this threshold the chunk is treated as silence and skipped.
+const SILENCE_THRESHOLD: f32 = 0.005;
+
+/// Events sent from the worker to the UI.
+#[derive(Debug, Clone)]
+pub enum TranscriptionEvent {
+    /// Model is being downloaded.
+    Downloading { progress_pct: u8 },
+    /// Model loaded, worker is listening for speech.
+    Ready,
+    /// A transcribed text segment.
+    Text { timestamp: String, text: String },
+    /// An error occurred.
+    Error(String),
+}
+
+/// Run the transcription worker loop.
+///
+/// This function blocks and should be called from a dedicated thread.
+/// It exits when the `audio_rx` channel is closed (sender dropped).
+#[allow(clippy::too_many_lines)]
+pub fn run_worker(
+    audio_rx: mpsc::Receiver<Vec<f32>>,
+    event_tx: mpsc::Sender<TranscriptionEvent>,
+) {
+    // ── Model download / load ───────────────────────────────────────
+    let model_path = if model::model_exists() {
+        model::model_path()
+    } else {
+        let (progress_tx, progress_rx) = mpsc::channel();
+
+        // Forward progress events
+        let event_tx_dl = event_tx.clone();
+        let progress_thread = std::thread::spawn(move || {
+            while let Ok(pct) = progress_rx.recv() {
+                let _ = event_tx_dl.send(TranscriptionEvent::Downloading {
+                    progress_pct: pct,
+                });
+            }
+        });
+
+        match model::download_model(&progress_tx) {
+            Ok(path) => {
+                drop(progress_tx);
+                let _ = progress_thread.join();
+                path
+            }
+            Err(e) => {
+                let _ = event_tx.send(TranscriptionEvent::Error(format!(
+                    "model download failed: {e}"
+                )));
+                return;
+            }
+        }
+    };
+
+    // Load whisper context
+    let ctx = match WhisperContext::new_with_params(
+        model_path.to_str().unwrap_or_default(),
+        WhisperContextParameters::default(),
+    ) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            let _ = event_tx.send(TranscriptionEvent::Error(format!(
+                "failed to load Whisper model: {e}"
+            )));
+            return;
+        }
+    };
+
+    let mut state = match ctx.create_state() {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = event_tx.send(TranscriptionEvent::Error(format!(
+                "failed to create Whisper state: {e}"
+            )));
+            return;
+        }
+    };
+
+    let _ = event_tx.send(TranscriptionEvent::Ready);
+    tracing::info!("transcription worker ready");
+
+    // ── Audio accumulation + inference loop ──────────────────────────
+    let mut mono_buf: Vec<f32> = Vec::with_capacity(CHUNK_SAMPLES);
+    let mut resample_buf: Vec<f32> = Vec::new();
+
+    while let Ok(interleaved) = audio_rx.recv() {
+        // Resample 48 kHz stereo → 16 kHz mono, appending to resample_buf
+        resample_buf.clear();
+        resampler::downsample_stereo_to_mono_16k(&interleaved, &mut resample_buf);
+        mono_buf.extend_from_slice(&resample_buf);
+
+        // When we have enough audio, transcribe
+        if mono_buf.len() >= CHUNK_SAMPLES {
+            // Check energy — skip silence
+            let rms = compute_rms(&mono_buf[..CHUNK_SAMPLES]);
+            if rms < SILENCE_THRESHOLD {
+                tracing::trace!(rms, "skipping silent chunk");
+                mono_buf.drain(..CHUNK_SAMPLES);
+                continue;
+            }
+
+            // Run Whisper inference
+            let chunk: Vec<f32> = mono_buf.drain(..CHUNK_SAMPLES).collect();
+            let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+            params.set_language(Some("en"));
+            params.set_print_progress(false);
+            params.set_print_realtime(false);
+            params.set_print_timestamps(false);
+            params.set_no_context(true);
+
+            match state.full(params, &chunk) {
+                Ok(()) => {
+                    let n_segments = state.full_n_segments().unwrap_or(0);
+                    let mut full_text = String::new();
+                    for i in 0..n_segments {
+                        if let Ok(text) = state.full_get_segment_text(i) {
+                            let trimmed = text.trim();
+                            if !trimmed.is_empty() {
+                                if !full_text.is_empty() {
+                                    full_text.push(' ');
+                                }
+                                full_text.push_str(trimmed);
+                            }
+                        }
+                    }
+                    if !full_text.is_empty() {
+                        let timestamp = chrono_timestamp();
+                        let _ = event_tx.send(TranscriptionEvent::Text {
+                            timestamp,
+                            text: full_text,
+                        });
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("whisper inference failed: {e}");
+                }
+            }
+        }
+    }
+
+    tracing::info!("transcription worker exiting");
+}
+
+/// Compute RMS energy of an audio buffer.
+fn compute_rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|&s| s * s).sum();
+    (sum_sq / samples.len() as f32).sqrt()
+}
+
+/// Format the current wall clock time as HH:MM:SS.
+fn chrono_timestamp() -> String {
+    let now = std::time::SystemTime::now();
+    let since_midnight = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let secs_today = since_midnight % 86400;
+    // Adjust for local timezone offset
+    let local_offset = {
+        // Use libc localtime to get the real offset
+        #[cfg(unix)]
+        {
+            let t = since_midnight as libc::time_t;
+            let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
+            // SAFETY: localtime_r is thread-safe and writes into our buffer.
+            #[allow(unsafe_code)]
+            unsafe {
+                libc::localtime_r(&t, tm.as_mut_ptr());
+                (*tm.as_ptr()).tm_gmtoff
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            0i64
+        }
+    };
+    #[allow(clippy::cast_sign_loss)]
+    let local_secs = (secs_today as i64 + local_offset).rem_euclid(86400) as u64;
+    let h = local_secs / 3600;
+    let m = (local_secs % 3600) / 60;
+    let s = local_secs % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rms_of_silence_is_zero() {
+        assert!((compute_rms(&[0.0; 100]) - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn rms_of_ones_is_one() {
+        assert!((compute_rms(&[1.0; 100]) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn rms_of_empty_is_zero() {
+        assert!((compute_rms(&[]) - 0.0).abs() < f32::EPSILON);
+    }
+}
+```
+
+- [ ] **Step 2: Add libc dependency**
+
+Add to `Cargo.toml` workspace dependencies:
+
+```toml
+libc = "0.2"
+```
+
+Add to `crates/sdr-transcription/Cargo.toml` dependencies:
+
+```toml
+libc.workspace = true
+```
+
+- [ ] **Step 3: Update lib.rs**
+
+```rust
+pub mod model;
+pub mod resampler;
+pub mod worker;
+
+pub use worker::TranscriptionEvent;
+```
+
+- [ ] **Step 4: Build and test**
+
+Run: `cargo build -p sdr-transcription && cargo test -p sdr-transcription && cargo clippy -p sdr-transcription -- -D warnings`
+Expected: All tests pass, clippy clean
+
+Note: The first build will compile `whisper.cpp` from source via `whisper-rs-sys`. This requires `cmake` and a C++ compiler. If the build fails, install: `sudo pacman -S cmake` (Arch) or `sudo apt install cmake` (Ubuntu).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-transcription/ Cargo.toml Cargo.lock
+git commit -m "add Whisper worker thread with audio accumulation and silence detection"
+```
+
+---
+
+## Task 4: TranscriptionEngine Public API
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/lib.rs`
+
+- [ ] **Step 1: Implement TranscriptionEngine**
+
+Replace `crates/sdr-transcription/src/lib.rs`:
+
+```rust
+//! Live audio transcription via Whisper.
+//!
+//! Provides `TranscriptionEngine` that runs a background worker thread for
+//! speech-to-text. Audio samples are fed from the DSP thread via a bounded
+//! channel; transcription results are returned via an event channel.
+
+pub mod model;
+pub mod resampler;
+pub mod worker;
+
+pub use worker::TranscriptionEvent;
+
+use std::sync::mpsc;
+
+/// Bounded channel capacity for audio buffers from DSP → transcription.
+/// Each buffer is ~1024-4096 stereo samples (~20-80ms). 10 buffers gives
+/// ~800ms of headroom before drops.
+const AUDIO_CHANNEL_CAPACITY: usize = 10;
+
+/// Error type for transcription operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TranscriptionError {
+    #[error("transcription is already running")]
+    AlreadyRunning,
+    #[error("transcription is not running")]
+    NotRunning,
+}
+
+/// Live audio transcription engine.
+///
+/// Create with `new()`, call `start()` to begin, `stop()` to end.
+/// Feed audio via `audio_sender()` and receive results from the
+/// `Receiver<TranscriptionEvent>` returned by `start()`.
+pub struct TranscriptionEngine {
+    audio_tx: Option<mpsc::SyncSender<Vec<f32>>>,
+    worker_thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl TranscriptionEngine {
+    /// Create a new engine. Does not start the worker thread.
+    pub fn new() -> Self {
+        Self {
+            audio_tx: None,
+            worker_thread: None,
+        }
+    }
+
+    /// Start the transcription worker thread.
+    ///
+    /// Returns a receiver for `TranscriptionEvent`s. The worker will
+    /// download the model on first run if needed.
+    pub fn start(
+        &mut self,
+    ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
+        if self.worker_thread.is_some() {
+            return Err(TranscriptionError::AlreadyRunning);
+        }
+
+        let (audio_tx, audio_rx) = mpsc::sync_channel(AUDIO_CHANNEL_CAPACITY);
+        let (event_tx, event_rx) = mpsc::channel();
+
+        let handle = std::thread::Builder::new()
+            .name("transcription-worker".into())
+            .spawn(move || {
+                worker::run_worker(audio_rx, event_tx);
+            })
+            .expect("failed to spawn transcription worker thread");
+
+        self.audio_tx = Some(audio_tx);
+        self.worker_thread = Some(handle);
+
+        tracing::info!("transcription engine started");
+        Ok(event_rx)
+    }
+
+    /// Stop the transcription worker.
+    pub fn stop(&mut self) {
+        // Drop the audio sender to signal the worker to exit.
+        self.audio_tx.take();
+
+        if let Some(handle) = self.worker_thread.take() {
+            let _ = handle.join();
+        }
+
+        tracing::info!("transcription engine stopped");
+    }
+
+    /// Get a clone of the audio sender for feeding samples from the DSP thread.
+    ///
+    /// Returns `None` if the engine is not running.
+    pub fn audio_sender(&self) -> Option<mpsc::SyncSender<Vec<f32>>> {
+        self.audio_tx.clone()
+    }
+
+    /// Check if the engine is currently running.
+    pub fn is_running(&self) -> bool {
+        self.worker_thread.is_some()
+    }
+}
+
+impl Drop for TranscriptionEngine {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+```
+
+- [ ] **Step 2: Build and clippy**
+
+Run: `cargo build -p sdr-transcription && cargo clippy -p sdr-transcription -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-transcription/src/lib.rs
+git commit -m "add TranscriptionEngine public API"
+```
+
+---
+
+## Task 5: Audio Tap in DSP Controller
+
+**Files:**
+- Modify: `crates/sdr-ui/src/messages.rs` (add UiToDsp variants)
+- Modify: `crates/sdr-ui/src/dsp_controller.rs` (add audio tap)
+- Modify: `crates/sdr-ui/Cargo.toml` (add sdr-transcription dep)
+
+- [ ] **Step 1: Add sdr-transcription dependency to sdr-ui**
+
+In `crates/sdr-ui/Cargo.toml`, add:
+
+```toml
+sdr-transcription.workspace = true
+```
+
+- [ ] **Step 2: Add UiToDsp messages**
+
+In `crates/sdr-ui/src/messages.rs`, add these variants to the `UiToDsp` enum:
+
+```rust
+/// Start sending audio to the transcription engine.
+EnableTranscription(std::sync::mpsc::SyncSender<Vec<f32>>),
+/// Stop sending audio to the transcription engine.
+DisableTranscription,
+```
+
+- [ ] **Step 3: Add transcription sender to DspState**
+
+In `crates/sdr-ui/src/dsp_controller.rs`, add a field to `DspState`:
+
+```rust
+/// Transcription audio tap — when Some, audio is copied to this channel.
+transcription_tx: Option<std::sync::mpsc::SyncSender<Vec<f32>>>,
+```
+
+Initialize it as `None` in `DspState::new()`.
+
+- [ ] **Step 4: Handle UiToDsp messages in the DSP loop**
+
+In the message handling section of the DSP loop (where `UiToDsp` variants are matched), add:
+
+```rust
+UiToDsp::EnableTranscription(tx) => {
+    state.transcription_tx = Some(tx);
+    tracing::info!("transcription audio tap enabled");
+}
+UiToDsp::DisableTranscription => {
+    state.transcription_tx = None;
+    tracing::info!("transcription audio tap disabled");
+}
+```
+
+- [ ] **Step 5: Add audio tap after write_samples**
+
+In `process_iq_block()`, right after the `state.audio_sink.write_samples()` call (around line 1039), add the transcription tap:
+
+```rust
+// Send audio copy to transcription worker (non-blocking).
+if let Some(ref tx) = state.transcription_tx {
+    let _ = tx.try_send(state.interleave_buf.clone());
+}
+```
+
+Wait — the interleave buffer is inside AudioSink. We need to tap the `audio_buf` (Stereo samples) and interleave ourselves. Let me adjust.
+
+Actually, the simpler approach: tap the audio buffer BEFORE it enters AudioSink and interleave for the transcription channel:
+
+```rust
+// Send audio copy to transcription worker (non-blocking).
+if let Some(ref tx) = state.transcription_tx {
+    let mut interleaved = Vec::with_capacity(audio_count * 2);
+    for s in &state.audio_buf[..audio_count] {
+        interleaved.push(s.l);
+        interleaved.push(s.r);
+    }
+    let _ = tx.try_send(interleaved);
+}
+```
+
+Add this BEFORE the `state.audio_sink.write_samples()` call.
+
+- [ ] **Step 6: Build and clippy**
+
+Run: `cargo build --workspace && cargo clippy --all-targets --workspace -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/sdr-ui/Cargo.toml crates/sdr-ui/src/messages.rs crates/sdr-ui/src/dsp_controller.rs
+git commit -m "add transcription audio tap to DSP controller"
+```
+
+---
+
+## Task 6: Transcript Sidebar Panel
+
+**Files:**
+- Create: `crates/sdr-ui/src/sidebar/transcript_panel.rs`
+- Modify: `crates/sdr-ui/src/sidebar/mod.rs`
+
+- [ ] **Step 1: Create transcript_panel.rs**
+
+Create `crates/sdr-ui/src/sidebar/transcript_panel.rs`:
+
+```rust
+//! Transcript sidebar panel — displays live transcription results.
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Transcript panel UI elements.
+pub struct TranscriptPanel {
+    /// The top-level widget for the sidebar.
+    pub widget: adw::PreferencesGroup,
+    /// Toggle to enable/disable transcription.
+    pub enable_row: adw::SwitchRow,
+    /// Status label ("Listening...", "Downloading...", error).
+    pub status_label: gtk4::Label,
+    /// Progress bar for model download.
+    pub progress_bar: gtk4::ProgressBar,
+    /// Scrolled text view for the transcript log.
+    pub text_view: gtk4::TextView,
+    /// Scroll container for the text view.
+    pub scroll: gtk4::ScrolledWindow,
+    /// Clear button.
+    pub clear_button: gtk4::Button,
+}
+
+/// Build the transcript sidebar panel.
+pub fn build_transcript_panel() -> TranscriptPanel {
+    let group = adw::PreferencesGroup::builder()
+        .title("Transcript")
+        .description("Live speech-to-text")
+        .build();
+
+    // Enable/disable toggle
+    let enable_row = adw::SwitchRow::builder()
+        .title("Enable Transcription")
+        .subtitle("Whisper tiny (English)")
+        .build();
+    group.add(&enable_row);
+
+    // Status label
+    let status_label = gtk4::Label::builder()
+        .halign(gtk4::Align::Start)
+        .css_classes(["dim-label"])
+        .visible(false)
+        .margin_start(12)
+        .margin_top(4)
+        .build();
+
+    // Progress bar (for model download)
+    let progress_bar = gtk4::ProgressBar::builder()
+        .visible(false)
+        .margin_start(12)
+        .margin_end(12)
+        .margin_top(4)
+        .build();
+
+    // Transcript text view
+    let text_view = gtk4::TextView::builder()
+        .editable(false)
+        .cursor_visible(false)
+        .wrap_mode(gtk4::WrapMode::Word)
+        .monospace(true)
+        .top_margin(8)
+        .bottom_margin(8)
+        .left_margin(8)
+        .right_margin(8)
+        .build();
+
+    let scroll = gtk4::ScrolledWindow::builder()
+        .child(&text_view)
+        .min_content_height(150)
+        .max_content_height(300)
+        .css_classes(["card"])
+        .margin_top(8)
+        .build();
+
+    // Clear button
+    let clear_button = gtk4::Button::builder()
+        .label("Clear")
+        .halign(gtk4::Align::Start)
+        .margin_top(4)
+        .build();
+
+    let text_view_clear = text_view.clone();
+    clear_button.connect_clicked(move |_| {
+        text_view_clear.buffer().set_text("");
+    });
+
+    // Build layout — status, progress, scroll, and clear go into a vertical box
+    let content_box = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(4)
+        .build();
+    content_box.append(&status_label);
+    content_box.append(&progress_bar);
+    content_box.append(&scroll);
+    content_box.append(&clear_button);
+    group.add(&content_box);
+
+    TranscriptPanel {
+        widget: group,
+        enable_row,
+        status_label,
+        progress_bar,
+        text_view,
+        scroll,
+        clear_button,
+    }
+}
+```
+
+- [ ] **Step 2: Add to sidebar mod.rs**
+
+In `crates/sdr-ui/src/sidebar/mod.rs`:
+
+1. Add module declaration:
+
+```rust
+pub mod transcript_panel;
+```
+
+2. Add to exports:
+
+```rust
+pub use transcript_panel::{TranscriptPanel, build_transcript_panel};
+```
+
+3. Add `transcript: TranscriptPanel` field to `SidebarPanels` struct.
+
+4. In `build_sidebar()`, add:
+
+```rust
+let transcript = build_transcript_panel();
+```
+
+Append to the sidebar box (after display):
+
+```rust
+sidebar_box.append(&transcript.widget);
+```
+
+Add to the `SidebarPanels` struct construction:
+
+```rust
+transcript,
+```
+
+- [ ] **Step 3: Build and clippy**
+
+Run: `cargo build --workspace && cargo clippy --all-targets --workspace -- -D warnings`
+Expected: Clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/sidebar/transcript_panel.rs crates/sdr-ui/src/sidebar/mod.rs
+git commit -m "add Transcript sidebar panel with toggle, log, and clear button"
+```
+
+---
+
+## Task 7: Final Wiring — Connect Transcription to UI
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs`
+
+- [ ] **Step 1: Add connect_transcript_panel function**
+
+In `crates/sdr-ui/src/window.rs`, add a new function after `connect_audio_panel`:
+
+```rust
+/// Wire the transcript panel: toggle enables/disables transcription,
+/// poll for events to update the transcript log.
+fn connect_transcript_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
+    use sdr_transcription::{TranscriptionEngine, TranscriptionEvent};
+
+    let engine: Rc<RefCell<TranscriptionEngine>> =
+        Rc::new(RefCell::new(TranscriptionEngine::new()));
+
+    let state_clone = Rc::clone(state);
+    let engine_clone = Rc::clone(&engine);
+    let status_label = panels.transcript.status_label.clone();
+    let progress_bar = panels.transcript.progress_bar.clone();
+    let text_view = panels.transcript.text_view.clone();
+    let scroll = panels.transcript.scroll.clone();
+
+    panels.transcript.enable_row.connect_active_notify(move |row| {
+        let mut eng = engine_clone.borrow_mut();
+
+        if row.is_active() {
+            // Start transcription
+            match eng.start() {
+                Ok(event_rx) => {
+                    // Send audio sender to DSP thread
+                    if let Some(audio_tx) = eng.audio_sender() {
+                        state_clone.send_dsp(
+                            crate::messages::UiToDsp::EnableTranscription(audio_tx),
+                        );
+                    }
+
+                    status_label.set_text("Starting...");
+                    status_label.set_visible(true);
+
+                    // Poll for transcription events on a 100ms timer
+                    let status = status_label.clone();
+                    let progress = progress_bar.clone();
+                    let tv = text_view.clone();
+                    let sc = scroll.clone();
+
+                    glib::timeout_add_local(
+                        std::time::Duration::from_millis(100),
+                        move || {
+                            while let Ok(event) = event_rx.try_recv() {
+                                match event {
+                                    TranscriptionEvent::Downloading { progress_pct } => {
+                                        status.set_text(&format!(
+                                            "Downloading model ({progress_pct}%)..."
+                                        ));
+                                        status.set_visible(true);
+                                        progress.set_fraction(f64::from(progress_pct) / 100.0);
+                                        progress.set_visible(true);
+                                    }
+                                    TranscriptionEvent::Ready => {
+                                        status.set_text("Listening...");
+                                        status.set_css_classes(&["success"]);
+                                        progress.set_visible(false);
+                                    }
+                                    TranscriptionEvent::Text { timestamp, text } => {
+                                        let buf = tv.buffer();
+                                        let mut end = buf.end_iter();
+                                        buf.insert(
+                                            &mut end,
+                                            &format!("[{timestamp}] {text}\n"),
+                                        );
+                                        // Auto-scroll to bottom
+                                        let mark = buf.create_mark(
+                                            None,
+                                            &buf.end_iter(),
+                                            false,
+                                        );
+                                        tv.scroll_to_mark(&mark, 0.0, false, 0.0, 0.0);
+                                        buf.delete_mark(&mark);
+                                    }
+                                    TranscriptionEvent::Error(msg) => {
+                                        status.set_text(&msg);
+                                        status.set_css_classes(&["error"]);
+                                    }
+                                }
+                            }
+                            glib::ControlFlow::Continue
+                        },
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!("failed to start transcription: {e}");
+                    row.set_active(false);
+                }
+            }
+        } else {
+            // Stop transcription
+            state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
+            eng.stop();
+            status_label.set_text("");
+            status_label.set_visible(false);
+            progress_bar.set_visible(false);
+        }
+    });
+}
+```
+
+- [ ] **Step 2: Call connect_transcript_panel from connect_sidebar_panels**
+
+In `connect_sidebar_panels()`, add after `connect_audio_panel(panels, state)`:
+
+```rust
+connect_transcript_panel(panels, state);
+```
+
+- [ ] **Step 3: Build, clippy, test**
+
+Run: `cargo build --workspace && cargo clippy --all-targets --workspace -- -D warnings && cargo test --workspace`
+Expected: All clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "wire transcript panel: toggle, event polling, auto-scroll log"
+```
+
+---
+
+## Verification Checklist
+
+After all tasks:
+
+1. `cargo build --workspace` compiles (including whisper.cpp from source)
+2. `cargo test --workspace` all tests pass
+3. `cargo clippy --all-targets --workspace -- -D warnings` clean
+4. Transcript panel appears in sidebar with toggle, text view, and clear button
+5. Toggle on → status shows "Downloading model..." with progress bar (first run)
+6. After download → status shows "Listening..."
+7. Audio plays → transcribed text appears as timestamped lines in log
+8. Silent periods are skipped (no empty transcriptions)
+9. Clear button wipes the log
+10. Toggle off → transcription stops, audio tap disconnected
+11. No audio dropouts or stuttering when transcription is active
+12. Model persists in `~/.local/share/sdr-rs/models/` between sessions

--- a/docs/superpowers/specs/2026-04-11-live-transcription-design.md
+++ b/docs/superpowers/specs/2026-04-11-live-transcription-design.md
@@ -1,0 +1,206 @@
+# Live Transcription — Design Spec
+
+## Overview
+
+Real-time speech-to-text for demodulated radio audio using Whisper (via `whisper-rs`). Audio is tapped from the audio sink, resampled, and fed to a background transcription worker. Results appear in a new Transcript sidebar panel as timestamped log entries.
+
+## Architecture
+
+```text
+sdr-transcription    — NEW crate: Whisper inference, audio buffering, VAD
+sdr-sink-audio       — Audio tap (copy of samples to transcription channel)
+sdr-ui               — Transcript sidebar panel
+```
+
+### Data Flow
+
+```text
+AudioSink::write_samples()
+  ├→ PipeWire ring buffer (audio playback, unchanged)
+  └→ try_send to transcription channel (non-blocking, drops if full)
+
+Transcription worker thread:
+  ← Receives interleaved f32 at 48 kHz stereo
+  → Resample to 16 kHz mono (average L+R, decimate 3:1)
+  → VAD accumulates until speech pause
+  → Whisper inference on accumulated segment
+  → Send TranscriptionEvent::Text to UI
+
+UI thread:
+  ← Receives TranscriptionEvent
+  → Appends timestamped line to transcript panel
+```
+
+### Threading Model
+
+| Thread | Role | Blocking allowed? |
+|--------|------|--------------------|
+| DSP | Copies audio to channel via `try_send` | No |
+| Transcription worker | Accumulates audio, runs Whisper | Yes (dedicated thread) |
+| UI | Displays transcript updates | No (GTK main loop) |
+
+Audio playback is never affected by transcription — the tap is fire-and-forget.
+
+## New Crate: `sdr-transcription`
+
+### File Structure
+
+```text
+crates/sdr-transcription/src/
+  lib.rs           — TranscriptionEngine public API
+  worker.rs        — background thread: audio accumulation, VAD, inference
+  resampler.rs     — 48 kHz stereo → 16 kHz mono conversion
+  model.rs         — model download, path management, loading
+```
+
+### Dependencies
+
+```toml
+whisper-rs = "0.14"
+reqwest = { workspace = true }         # model download (blocking)
+sdr-types.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+```
+
+### Public API
+
+```rust
+pub struct TranscriptionEngine { ... }
+
+impl TranscriptionEngine {
+    /// Create a new engine (does not start worker or load model).
+    pub fn new() -> Self;
+
+    /// Start the transcription worker. Downloads model if needed.
+    /// Returns a receiver for transcription events.
+    pub fn start(&mut self) -> Result<std::sync::mpsc::Receiver<TranscriptionEvent>, TranscriptionError>;
+
+    /// Stop the worker and release resources.
+    pub fn stop(&mut self);
+
+    /// Get the sender for feeding audio from the DSP thread.
+    /// Returns None if not started.
+    pub fn audio_sender(&self) -> Option<std::sync::mpsc::SyncSender<Vec<f32>>>;
+}
+```
+
+### TranscriptionEvent
+
+```rust
+pub enum TranscriptionEvent {
+    /// Model is being downloaded.
+    Downloading { progress_pct: u8 },
+    /// Model loaded, listening for speech.
+    Ready,
+    /// A transcribed utterance.
+    Text { timestamp: String, text: String },
+    /// An error occurred.
+    Error(String),
+}
+```
+
+### Worker Loop
+
+1. Receive interleaved stereo f32 samples at 48 kHz from `SyncSender` channel
+2. Resample to 16 kHz mono:
+   - Average L and R channels: `(left + right) / 2.0`
+   - Decimate 3:1 (48000 / 16000 = 3)
+3. Feed to `whisper-rs` with VAD enabled — accumulates until speech pause
+4. On speech end: run Whisper inference on the accumulated segment
+5. Format timestamp from wall clock
+6. Send `TranscriptionEvent::Text { timestamp, text }` to UI
+
+### Resampler
+
+Simple 3:1 decimation with averaging:
+- Input: interleaved `[L, R, L, R, ...]` at 48 kHz
+- Step 1: mono mix `(L + R) / 2.0` → mono at 48 kHz
+- Step 2: take every 3rd sample → mono at 16 kHz
+
+No anti-aliasing filter needed — Whisper's mel-spectrogram computation
+handles the frequency content, and radio audio bandwidth is typically
+well under 8 kHz (Nyquist at 16 kHz).
+
+### Model Management
+
+- **Storage:** `~/.local/share/sdr-rs/models/`
+- **Model file:** `ggml-tiny.en.bin` (~75 MB)
+- **Source:** `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin`
+- **Download:** `reqwest::blocking::get()` with progress tracking via `Content-Length` header
+- **First-run flow:** `start()` → check file exists → download if missing → load → `Ready`
+
+## Audio Tap (`sdr-sink-audio`)
+
+### Changes to AudioSink
+
+Add an `Option<SyncSender<Vec<f32>>>` field to `AudioSink`. When set:
+- After writing to the PipeWire ring buffer, clone the interleaved buffer
+- `try_send` the clone to the transcription channel
+- If channel is full, silently drop (no audio impact)
+
+When `None` (transcription disabled): zero overhead, no allocation.
+
+### Integration Point
+
+`AudioSink::write_samples()` in `crates/sdr-sink-audio/src/pw_impl.rs` —
+after the existing `ring.write(&self.interleave_buf)` call.
+
+## Transcript Panel (`sdr-ui`)
+
+### File
+
+```text
+crates/sdr-ui/src/sidebar/transcript_panel.rs
+```
+
+### Layout
+
+```text
+┌─ Transcript ─────────────────────┐
+│ [Toggle: Enable Transcription]   │
+│ Status: Listening...             │
+│ ┌──────────────────────────────┐ │
+│ │ [14:32:05] Officer respond...│ │
+│ │ [14:32:12] Copy that, en ... │ │
+│ │ [14:32:28] 10-4 received ... │ │
+│ │                              │ │
+│ └──────────────────────────────┘ │
+│ [Clear]                          │
+└──────────────────────────────────┘
+```
+
+### Components
+
+- **Toggle switch** (`adw::SwitchRow`): Enable/Disable transcription
+  - On enable: create `TranscriptionEngine`, call `start()`, hook audio tap
+  - On disable: call `stop()`, disconnect audio tap
+- **Status label**: Shows "Downloading model (42%)...", "Listening...", or error
+- **Progress bar** (`gtk4::ProgressBar`): visible only during model download
+- **Transcript log** (`gtk4::TextView`): read-only, monospace, auto-scroll to bottom
+- **Clear button**: wipes the text buffer
+
+### Event Handling
+
+Poll `TranscriptionEvent` receiver on a GTK timer (100ms interval):
+- `Downloading { pct }` → update progress bar + status
+- `Ready` → hide progress bar, show "Listening..."
+- `Text { timestamp, text }` → append `[{timestamp}] {text}\n` to text view, auto-scroll
+- `Error(msg)` → show in status label with error styling
+
+## V1 Scope
+
+- English only, Whisper tiny model
+- Auto-download on first enable
+- No model picker, no language selector
+- No 10-code interpretation
+- No transcript export
+
+## Dependencies (Workspace)
+
+| Crate | Version | Used By | Purpose |
+|-------|---------|---------|---------|
+| whisper-rs | 0.14 | sdr-transcription | Whisper inference + VAD |
+
+Note: `whisper-rs` statically links `whisper.cpp` (C++). Requires `cmake` and
+a C++ compiler at build time (already available for GTK).

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,20 @@
+# SonarQube project configuration
+sonar.projectKey=sdr-rs
+sonar.projectName=SDR-RS
+sonar.projectVersion=0.1.0
+
+# Source code location
+sonar.sources=crates,src
+sonar.tests=crates
+
+# Rust source files
+sonar.inclusions=**/*.rs
+
+# Exclude non-source files
+sonar.exclusions=**/target/**,original/**,docs/**
+
+# Test file pattern
+sonar.test.inclusions=**/*test*.rs,**/tests/**
+
+# Encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

Two features in this PR:

### Live Transcription (#204)
- **New `sdr-transcription` crate** (15th in workspace) — Whisper speech-to-text via `whisper-rs` (whisper.cpp bindings)
- **Spectral noise gate** — FFT-based denoiser removes broadband static/hiss before Whisper sees the audio (based on Tariq & Khan 2023)
- **Slide-out transcript panel** — right-side revealer toggled by header bar button, with timestamped scrolling log, enable/disable toggle, model download progress bar, clear button
- **Audio tap** — non-blocking copy of demodulated audio sent to transcription worker BEFORE volume scaling
- **Whisper hallucination filter** — catches common false positives like "[Music]", "(electronic music)", "thank you", etc.
- **Auto-download** — Whisper tiny English model (~75 MB) downloaded from HuggingFace on first enable
- **Clean shutdown** — non-blocking engine stop on window close (no UI freeze during inference)
- **Silence detection** — RMS-based gate skips non-speech chunks (threshold tuned for NFM radio)

### SonarQube
- `sonar-project.properties` for project config
- `make scan` target in Makefile
- `.env` added to `.gitignore`

## Test plan
- [x] `cargo build --workspace` compiles (including whisper.cpp from source)
- [x] `cargo test --workspace` all tests pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] Transcript panel slides out from right on button click, starts closed
- [x] Toggle on → downloads model on first run with progress bar
- [x] NFM radio speech transcribed with timestamps in log
- [x] Silence/noise chunks filtered (no "[Music]" hallucinations)
- [x] Volume knob doesn't affect transcription quality
- [x] App shuts down cleanly with transcription active
- [x] Clear button wipes transcript log

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live speech-to-text transcription with timestamped, slide-out transcript panel, enable/disable toggle, progress/status UI, and clear/autoscroll behavior
  * Spectral noise-gate audio denoising and stereo→mono downsampling for transcription
  * Automatic Whisper model download with progress reporting

* **Chores**
  * Updated build requirements to include cmake and a C++ compiler
  * Extended .gitignore for environment and scanner artifacts
  * Added SonarQube scan target and configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->