### PR TITLE
GPU feature flags, config fallback, keyring warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,15 @@ anyhow.workspace = true
 gtk4.workspace = true
 libadwaita.workspace = true
 
+[features]
+default = []
+cuda = ["sdr-ui/cuda"]
+hipblas = ["sdr-ui/hipblas"]
+vulkan = ["sdr-ui/vulkan"]
+metal = ["sdr-ui/metal"]
+intel-sycl = ["sdr-ui/intel-sycl"]
+openblas = ["sdr-ui/openblas"]
+
 [target.'cfg(target_os = "linux")'.dependencies]
 sdr-ui = { workspace = true, features = ["pipewire"] }
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 
 ### Transcription
 
-- Live speech-to-text via Whisper (tiny English model, ~75 MB)
-- Slide-out transcript panel with timestamped log
+- Live speech-to-text via Whisper — 5 model sizes from tiny (75 MB) to large-v3 (3.1 GB)
+- Optional GPU acceleration: CUDA (NVIDIA), ROCm/HIP (AMD), Vulkan, Metal (macOS)
+- Slide-out transcript panel with timestamped log and model selector
 - FFT-based spectral noise gate preprocessor for cleaner recognition
-- Auto-downloads model on first use
+- Auto-downloads selected model on first use
 - Volume-independent audio tap (transcription unaffected by volume knob)
 
 ### Integration
@@ -98,6 +99,16 @@ make install
 ```
 
 Installs the binary, desktop entry, and icon for app launcher integration.
+
+### GPU-accelerated transcription (optional)
+
+```bash
+make install CARGO_FLAGS="--release --features cuda"      # NVIDIA
+make install CARGO_FLAGS="--release --features hipblas"    # AMD ROCm
+make install CARGO_FLAGS="--release --features vulkan"     # Cross-vendor
+```
+
+Requires the corresponding GPU toolkit (CUDA toolkit, ROCm, Vulkan SDK).
 
 ### Run tests
 

--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -430,4 +430,28 @@ mod tests {
         assert_eq!(mgr.path(), path);
         let _ = fs::remove_file(&path);
     }
+
+    #[test]
+    fn in_memory_save_is_noop() {
+        let mgr = ConfigManager::in_memory(&json!({"key": "value"}));
+        // save() should succeed without creating any file.
+        mgr.save().unwrap();
+        assert!(mgr.path().as_os_str().is_empty());
+    }
+
+    #[test]
+    fn in_memory_enable_auto_save_is_noop() {
+        let mut mgr = ConfigManager::in_memory(&json!({}));
+        mgr.enable_auto_save();
+        // No auto-save handle should be created for in-memory configs.
+        assert!(mgr.auto_save_handle.is_none());
+    }
+
+    #[test]
+    fn in_memory_read_write_works() {
+        let mgr = ConfigManager::in_memory(&json!({"volume": 0.5}));
+        mgr.read(|v| assert_eq!(v["volume"], 0.5));
+        mgr.write(|v| v["volume"] = json!(0.8));
+        mgr.read(|v| assert_eq!(v["volume"], 0.8));
+    }
 }

--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -163,6 +163,10 @@ impl ConfigManager {
     ///
     /// Checks for modifications every second and saves if needed.
     pub fn enable_auto_save(&mut self) {
+        // In-memory configs have no path — nothing to auto-save.
+        if self.path.as_os_str().is_empty() {
+            return;
+        }
         if self.auto_save_handle.is_some() {
             return;
         }

--- a/crates/sdr-config/src/lib.rs
+++ b/crates/sdr-config/src/lib.rs
@@ -100,12 +100,29 @@ impl ConfigManager {
         Ok(mgr)
     }
 
+    /// Create an in-memory configuration that won't persist to disk.
+    ///
+    /// Used as a fallback when the config file can't be loaded (permissions,
+    /// disk full, etc.). The app remains functional with default settings.
+    pub fn in_memory(defaults: &Value) -> Self {
+        Self {
+            path: PathBuf::new(),
+            data: Arc::new(RwLock::new(defaults.clone())),
+            modified: Arc::new(Mutex::new(false)),
+            auto_save_handle: None,
+        }
+    }
+
     /// Save configuration to disk.
     ///
     /// # Errors
     ///
     /// Returns `ConfigError::Io` on write failure.
     pub fn save(&self) -> Result<(), ConfigError> {
+        // In-memory configs have no path — skip saving.
+        if self.path.as_os_str().is_empty() {
+            return Ok(());
+        }
         let data = self.data.read().unwrap_or_else(PoisonError::into_inner);
         let content =
             serde_json::to_string_pretty(&*data).map_err(|e| ConfigError::Json(e.to_string()))?;

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -6,6 +6,15 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+cuda = ["whisper-rs/cuda"]
+hipblas = ["whisper-rs/hipblas"]
+vulkan = ["whisper-rs/vulkan"]
+metal = ["whisper-rs/metal"]
+intel-sycl = ["whisper-rs/intel-sycl"]
+openblas = ["whisper-rs/openblas"]
+
 [dependencies]
 whisper-rs.workspace = true
 reqwest.workspace = true

--- a/crates/sdr-transcription/src/model.rs
+++ b/crates/sdr-transcription/src/model.rs
@@ -37,11 +37,11 @@ impl WhisperModel {
     /// Human-readable display label.
     pub fn label(self) -> &'static str {
         match self {
-            Self::TinyEn => "Tiny (English, ~75 MB)",
-            Self::BaseEn => "Base (English, ~142 MB)",
-            Self::SmallEn => "Small (English, ~466 MB)",
-            Self::MediumEn => "Medium (English, ~1.5 GB)",
-            Self::LargeV3 => "Large v3 (Multilingual, ~3.1 GB)",
+            Self::TinyEn => "Tiny — 75 MB",
+            Self::BaseEn => "Base — 142 MB",
+            Self::SmallEn => "Small — 466 MB",
+            Self::MediumEn => "Medium — 1.5 GB (GPU)",
+            Self::LargeV3 => "Large v3 — 3.1 GB (GPU)",
         }
     }
 

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -9,6 +9,12 @@ repository.workspace = true
 [features]
 default = []
 pipewire = ["sdr-sink-audio/pipewire"]
+cuda = ["sdr-transcription/cuda"]
+hipblas = ["sdr-transcription/hipblas"]
+vulkan = ["sdr-transcription/vulkan"]
+metal = ["sdr-transcription/metal"]
+intel-sycl = ["sdr-transcription/intel-sycl"]
+openblas = ["sdr-transcription/openblas"]
 
 [dependencies]
 sdr-types.workspace = true

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -54,8 +54,10 @@ pub fn build_app() -> adw::Application {
         let config = match sdr_config::ConfigManager::load(&config_path, &defaults) {
             Ok(c) => std::sync::Arc::new(c),
             Err(e) => {
-                tracing::warn!("config load failed: {e}");
-                return;
+                tracing::warn!("config load failed, using in-memory defaults: {e}");
+                // Fall back to in-memory config so the app still launches.
+                // Settings won't persist but the app is functional.
+                std::sync::Arc::new(sdr_config::ConfigManager::in_memory(&defaults))
             }
         };
         window::build_window(app, &config);

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -143,12 +143,14 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
     let test_button = gtk4::Button::builder()
         .label("Test & Save")
         .css_classes(["suggested-action"])
+        .sensitive(keyring_available)
         .build();
 
     let remove_button = gtk4::Button::builder()
         .label("Remove Credentials")
         .css_classes(["destructive-action"])
         .visible(has_credentials.get())
+        .sensitive(keyring_available)
         .build();
 
     button_box.append(&test_button);

--- a/crates/sdr-ui/src/preferences/accounts_page.rs
+++ b/crates/sdr-ui/src/preferences/accounts_page.rs
@@ -70,6 +70,22 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
         )
         .build();
 
+    // --- Keyring availability check ---
+    let keyring_available = {
+        let store = KeyringStore::new(KEYRING_SERVICE);
+        store.has(KEY_RR_USERNAME).is_ok()
+    };
+
+    if !keyring_available {
+        let banner = adw::ActionRow::builder()
+            .title("Secure storage unavailable")
+            .subtitle("Install GNOME Keyring or KeePassXC to store credentials")
+            .css_classes(["error"])
+            .build();
+        banner.add_prefix(&gtk4::Image::from_icon_name("dialog-warning-symbolic"));
+        group.add(&banner);
+    }
+
     // --- Sign up link ---
     let signup_row = adw::ActionRow::builder()
         .title("Don't have an account?")
@@ -94,8 +110,14 @@ pub fn build_accounts_page() -> (adw::PreferencesPage, Rc<Cell<bool>>) {
     let password_row = adw::PasswordEntryRow::builder().title("Password").build();
 
     // Pre-fill username if credentials already exist
-    if let Some((stored_user, _)) = load_rr_credentials() {
-        username_row.set_text(&stored_user);
+    if keyring_available {
+        if let Some((stored_user, _)) = load_rr_credentials() {
+            username_row.set_text(&stored_user);
+        }
+    } else {
+        // Disable credential entry when keyring is unavailable.
+        username_row.set_sensitive(false);
+        password_row.set_sensitive(false);
     }
 
     group.add(&username_row);


### PR DESCRIPTION
## Summary

Three items bundled:

### GPU-accelerated Whisper inference (#212)
- Optional cargo feature flags: `cuda`, `hipblas`, `vulkan`, `metal`, `intel-sycl`, `openblas`
- Pass-through from root → sdr-ui → sdr-transcription → whisper-rs
- Build with: `make install CARGO_FLAGS="--release --features cuda"`
- Tested: CUDA (RTX 4080 Super) and ROCm/HIP (AMD iGPU) — both work
- Large-v3 model runs real-time on CUDA with zero lag, flawless transcription
- Model labels shortened with GPU hints on medium/large
- README updated with GPU build instructions

### Graceful config fallback (#194)
- `ConfigManager::in_memory(defaults)` constructor for non-persistent fallback
- App now launches with default settings instead of silently exiting on config load failure
- `save()` is a no-op for in-memory configs

### Keyring backend warning (#193)
- Accounts page checks keyring availability on load
- Shows warning banner with install instructions if no backend found
- Disables credential entry fields when keyring unavailable

Closes #212, closes #194, closes #193

## Test plan
- [x] Default build (no GPU features) compiles clean
- [x] CUDA build compiles and runs — tested all 5 models on RTX 4080 Super
- [x] ROCm/HIP build compiles and runs — tested tiny/base/small on AMD iGPU (4 GB VRAM)
- [x] Config fallback: app launches when config.json is unreadable
- [x] Keyring warning: banner shown when no keyring backend available
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional GPU-accelerated transcription across multiple backends; model selector with auto-download of the chosen model.

* **Bug Fixes**
  * Config loading falls back to in-memory defaults without persisting; auto-save disabled for in-memory mode.
  * Preferences page now detects missing keyring and disables credential fields with messaging.

* **Documentation**
  * README adds model sizes, GPU install examples, and notes for GPU-accelerated transcription.

* **Style**
  * Whisper model labels refreshed for clearer display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->