### PR TITLE
Transcription settings: model persistence, OOM handling, tuning sliders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
+ "libc",
  "whisper-rs-sys",
 ]
 

--- a/crates/sdr-transcription/src/denoise.rs
+++ b/crates/sdr-transcription/src/denoise.rs
@@ -10,9 +10,10 @@
 
 use rustfft::{FftPlanner, num_complex::Complex};
 
-/// Margin above the estimated noise floor in linear magnitude.
-/// Bins below `noise_floor * GATE_RATIO` are zeroed.
-/// A ratio of 3.0 means bins must be 3x the noise floor to survive (~9.5 dB).
+/// Default gate ratio — bins must exceed `noise_floor * GATE_RATIO` to survive.
+/// A ratio of 3.0 means bins must be 3x the noise floor (~9.5 dB above).
+/// Used as the default in tests; the runtime value is user-configurable.
+#[cfg(test)]
 const GATE_RATIO: f32 = 3.0;
 
 /// Percentile of magnitude-sorted bins used to estimate the noise floor.
@@ -23,12 +24,16 @@ const NOISE_FLOOR_PERCENTILE: f32 = 0.20;
 ///
 /// The buffer is FFT'd, noise floor is estimated from the quietest bins,
 /// bins below the threshold are zeroed, then IFFT'd back to time domain.
+///
+/// `gate_ratio` controls how aggressive the gate is — bins must exceed
+/// `noise_floor * gate_ratio` to survive. Higher values remove more noise
+/// but may clip speech transients.
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )]
-pub fn spectral_denoise(samples: &mut [f32]) {
+pub fn spectral_denoise(samples: &mut [f32], gate_ratio: f32) {
     let n = samples.len();
     if n < 64 {
         return; // too short for meaningful FFT
@@ -55,7 +60,7 @@ pub fn spectral_denoise(samples: &mut [f32]) {
     let noise_floor = sorted_mags[percentile_idx];
 
     // Gate threshold: bins must exceed noise_floor * ratio to survive.
-    let threshold = noise_floor * GATE_RATIO;
+    let threshold = noise_floor * gate_ratio;
 
     // Zero out bins below threshold (spectral gate).
     for (i, mag) in magnitudes.iter().enumerate() {
@@ -82,7 +87,7 @@ mod tests {
     #[test]
     fn silence_stays_silent() {
         let mut buf = vec![0.0_f32; 256];
-        spectral_denoise(&mut buf);
+        spectral_denoise(&mut buf, GATE_RATIO);
         for s in &buf {
             assert!(s.abs() < 1e-6, "expected silence, got {s}");
         }
@@ -92,7 +97,7 @@ mod tests {
     fn short_buffer_is_noop() {
         let mut buf = vec![0.5_f32; 32];
         let original = buf.clone();
-        spectral_denoise(&mut buf);
+        spectral_denoise(&mut buf, GATE_RATIO);
         assert_eq!(buf, original);
     }
 
@@ -114,7 +119,7 @@ mod tests {
 
         let pre_energy: f32 = buf.iter().map(|s| s * s).sum();
 
-        spectral_denoise(&mut buf);
+        spectral_denoise(&mut buf, GATE_RATIO);
 
         let post_energy: f32 = buf.iter().map(|s| s * s).sum();
 

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -53,9 +53,16 @@ impl TranscriptionEngine {
 
     /// Start the transcription worker thread with the given model.
     /// Returns a receiver for `TranscriptionEvent`.
+    ///
+    /// # Arguments
+    /// * `whisper_model` — which Whisper model to load
+    /// * `silence_threshold` — RMS below which a chunk is skipped
+    /// * `noise_gate_ratio` — spectral gate multiplier over noise floor
     pub fn start(
         &mut self,
         whisper_model: WhisperModel,
+        silence_threshold: f32,
+        noise_gate_ratio: f32,
     ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
         if self.worker_thread.is_some() {
             return Err(TranscriptionError::AlreadyRunning);
@@ -67,7 +74,13 @@ impl TranscriptionEngine {
         let handle = std::thread::Builder::new()
             .name("transcription-worker".into())
             .spawn(move || {
-                worker::run_worker(&audio_rx, &event_tx, whisper_model);
+                worker::run_worker(
+                    &audio_rx,
+                    &event_tx,
+                    whisper_model,
+                    silence_threshold,
+                    noise_gate_ratio,
+                );
             })?;
 
         self.audio_tx = Some(audio_tx);

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -15,10 +15,6 @@ const CHUNK_SECONDS: usize = 5;
 /// Number of 16 kHz mono samples per chunk (16000 * 5 = 80000).
 const CHUNK_SAMPLES: usize = 16_000 * CHUNK_SECONDS;
 
-/// RMS threshold below which a chunk is treated as silence and skipped.
-/// Measured AFTER the spectral noise gate, so this catches residual noise.
-const SILENCE_THRESHOLD: f32 = 0.007;
-
 /// Events emitted by the transcription worker.
 #[derive(Debug, Clone)]
 pub enum TranscriptionEvent {
@@ -46,12 +42,23 @@ pub enum TranscriptionEvent {
 /// # Arguments
 /// * `audio_rx` — receives interleaved stereo f32 audio at 48 kHz
 /// * `event_tx` — sends transcription events to the UI/consumer
+/// * `model` — which Whisper model to load
+/// * `silence_threshold` — RMS below which a chunk is skipped
+/// * `noise_gate_ratio` — spectral gate multiplier over noise floor
 pub fn run_worker(
     audio_rx: &mpsc::Receiver<Vec<f32>>,
     event_tx: &mpsc::Sender<TranscriptionEvent>,
     model: model::WhisperModel,
+    silence_threshold: f32,
+    noise_gate_ratio: f32,
 ) {
-    if let Err(e) = run_worker_inner(audio_rx, event_tx, model) {
+    if let Err(e) = run_worker_inner(
+        audio_rx,
+        event_tx,
+        model,
+        silence_threshold,
+        noise_gate_ratio,
+    ) {
         let _ = event_tx.send(TranscriptionEvent::Error(e));
     }
 }
@@ -62,6 +69,8 @@ fn run_worker_inner(
     audio_rx: &mpsc::Receiver<Vec<f32>>,
     event_tx: &mpsc::Sender<TranscriptionEvent>,
     model: model::WhisperModel,
+    silence_threshold: f32,
+    noise_gate_ratio: f32,
 ) -> Result<(), String> {
     // --- Model download / load ---
     let model_path = if model::model_exists(model) {
@@ -128,10 +137,10 @@ fn run_worker_inner(
 
             // Spectral noise gate — remove broadband static and hiss
             // before Whisper sees the audio.
-            denoise::spectral_denoise(&mut chunk);
+            denoise::spectral_denoise(&mut chunk, noise_gate_ratio);
 
             let rms = compute_rms(&chunk);
-            if rms < SILENCE_THRESHOLD {
+            if rms < silence_threshold {
                 tracing::debug!(rms, "chunk below silence threshold, skipping");
                 continue;
             }

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -92,8 +92,14 @@ fn run_worker_inner(
         path
     };
 
+    tracing::info!(?model_path, "loading Whisper model");
     let ctx = WhisperContext::new_with_params(&model_path, WhisperContextParameters::default())
-        .map_err(|e| format!("failed to load whisper model: {e}"))?;
+        .map_err(|e| {
+            format!(
+                "Failed to load model: {e}. If using a GPU, try a smaller model — \
+                 the selected model may exceed available VRAM."
+            )
+        })?;
 
     let mut state = ctx
         .create_state()

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -52,7 +52,10 @@ pub fn build_app() -> adw::Application {
             .join("config.json");
         let defaults = serde_json::json!({});
         let config = match sdr_config::ConfigManager::load(&config_path, &defaults) {
-            Ok(c) => std::sync::Arc::new(c),
+            Ok(mut c) => {
+                c.enable_auto_save();
+                std::sync::Arc::new(c)
+            }
             Err(e) => {
                 tracing::warn!("config load failed, using in-memory defaults: {e}");
                 // Fall back to in-memory config so the app still launches.

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -46,23 +46,24 @@ pub fn build_app() -> adw::Application {
         tracing::info!("sdr-rs UI starting");
     });
 
-    app.connect_activate(|app| {
-        let config_path = gtk4::glib::user_config_dir()
-            .join("sdr-rs")
-            .join("config.json");
-        let defaults = serde_json::json!({});
-        let config = match sdr_config::ConfigManager::load(&config_path, &defaults) {
-            Ok(mut c) => {
-                c.enable_auto_save();
-                std::sync::Arc::new(c)
-            }
-            Err(e) => {
-                tracing::warn!("config load failed, using in-memory defaults: {e}");
-                // Fall back to in-memory config so the app still launches.
-                // Settings won't persist but the app is functional.
-                std::sync::Arc::new(sdr_config::ConfigManager::in_memory(&defaults))
-            }
-        };
+    // Load config once and share across activations (connect_activate can
+    // fire more than once on re-activation).
+    let config_path = gtk4::glib::user_config_dir()
+        .join("sdr-rs")
+        .join("config.json");
+    let defaults = serde_json::json!({});
+    let config = match sdr_config::ConfigManager::load(&config_path, &defaults) {
+        Ok(mut c) => {
+            c.enable_auto_save();
+            std::sync::Arc::new(c)
+        }
+        Err(e) => {
+            tracing::warn!("config load failed, using in-memory defaults: {e}");
+            std::sync::Arc::new(sdr_config::ConfigManager::in_memory(&defaults))
+        }
+    };
+
+    app.connect_activate(move |app| {
         window::build_window(app, &config);
     });
 

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -60,10 +60,15 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let model_list = gtk4::StringList::new(&model_labels);
 
     #[allow(clippy::cast_possible_truncation)]
+    let max_model_idx = sdr_transcription::WhisperModel::ALL.len() as u32;
+
+    #[allow(clippy::cast_possible_truncation)]
     let saved_model_idx = config.read(|v| {
         v.get(KEY_MODEL)
             .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0) as u32
+            .and_then(|idx| u32::try_from(idx).ok())
+            .filter(|&idx| idx < max_model_idx)
+            .unwrap_or(0)
     });
 
     let model_row = adw::ComboRow::builder()
@@ -73,13 +78,15 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         .build();
     group.add(&model_row);
 
-    // Persist model selection on change.
+    // Persist model selection on change (ignore transient out-of-range indices).
     let config_model = Arc::clone(config);
     model_row.connect_selected_notify(move |row| {
         let idx = row.selected();
-        config_model.write(|v| {
-            v[KEY_MODEL] = serde_json::json!(idx);
-        });
+        if idx < max_model_idx {
+            config_model.write(|v| {
+                v[KEY_MODEL] = serde_json::json!(idx);
+            });
+        }
     });
 
     // --- Tuning sliders ---

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -14,6 +14,20 @@ const KEY_SILENCE_THRESHOLD: &str = "transcription_silence_threshold";
 /// Config key for the spectral noise gate ratio.
 const KEY_NOISE_GATE: &str = "transcription_noise_gate";
 
+// Silence threshold slider defaults and range.
+const DEFAULT_SILENCE_THRESHOLD: f64 = 0.007;
+const SILENCE_THRESHOLD_MIN: f64 = 0.001;
+const SILENCE_THRESHOLD_MAX: f64 = 0.100;
+const SILENCE_THRESHOLD_STEP: f64 = 0.001;
+const SILENCE_THRESHOLD_PAGE: f64 = 0.01;
+
+// Noise gate slider defaults and range.
+const DEFAULT_NOISE_GATE: f64 = 3.0;
+const NOISE_GATE_MIN: f64 = 1.0;
+const NOISE_GATE_MAX: f64 = 10.0;
+const NOISE_GATE_STEP: f64 = 0.5;
+const NOISE_GATE_PAGE: f64 = 1.0;
+
 /// Transcript panel with toggle switch, model picker, tuning sliders,
 /// status label, progress bar, scrolling transcript log, and clear button.
 pub struct TranscriptPanel {
@@ -94,17 +108,17 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let saved_silence = config.read(|v| {
         v.get(KEY_SILENCE_THRESHOLD)
             .and_then(serde_json::Value::as_f64)
-            .unwrap_or(0.007)
+            .unwrap_or(DEFAULT_SILENCE_THRESHOLD)
     });
 
     let silence_row = adw::SpinRow::builder()
         .title("Silence threshold")
         .adjustment(&gtk4::Adjustment::new(
             saved_silence,
-            0.001,
-            0.1,
-            0.001,
-            0.01,
+            SILENCE_THRESHOLD_MIN,
+            SILENCE_THRESHOLD_MAX,
+            SILENCE_THRESHOLD_STEP,
+            SILENCE_THRESHOLD_PAGE,
             0.0,
         ))
         .digits(3)
@@ -122,7 +136,7 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let saved_noise_gate = config.read(|v| {
         v.get(KEY_NOISE_GATE)
             .and_then(serde_json::Value::as_f64)
-            .unwrap_or(3.0)
+            .unwrap_or(DEFAULT_NOISE_GATE)
     });
 
     let noise_gate_row = adw::SpinRow::builder()
@@ -130,10 +144,10 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         .subtitle("Spectral gate ratio")
         .adjustment(&gtk4::Adjustment::new(
             saved_noise_gate,
-            1.0,
-            10.0,
-            0.5,
-            1.0,
+            NOISE_GATE_MIN,
+            NOISE_GATE_MAX,
+            NOISE_GATE_STEP,
+            NOISE_GATE_PAGE,
             0.0,
         ))
         .digits(1)

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -9,9 +9,13 @@ use sdr_config::ConfigManager;
 
 /// Config key for the persisted Whisper model index.
 const KEY_MODEL: &str = "transcription_model";
+/// Config key for the silence threshold after spectral denoising.
+const KEY_SILENCE_THRESHOLD: &str = "transcription_silence_threshold";
+/// Config key for the spectral noise gate ratio.
+const KEY_NOISE_GATE: &str = "transcription_noise_gate";
 
-/// Transcript panel with toggle switch, model picker, status label,
-/// progress bar, scrolling transcript log, and clear button.
+/// Transcript panel with toggle switch, model picker, tuning sliders,
+/// status label, progress bar, scrolling transcript log, and clear button.
 pub struct TranscriptPanel {
     /// The `AdwPreferencesGroup` widget to pack into the sidebar.
     pub widget: adw::PreferencesGroup,
@@ -19,6 +23,10 @@ pub struct TranscriptPanel {
     pub enable_row: adw::SwitchRow,
     /// Model size selector.
     pub model_row: adw::ComboRow,
+    /// Silence threshold spin row.
+    pub silence_row: adw::SpinRow,
+    /// Noise gate spin row.
+    pub noise_gate_row: adw::SpinRow,
     /// Status label (downloading, listening, error).
     pub status_label: gtk4::Label,
     /// Model download progress bar.
@@ -32,6 +40,7 @@ pub struct TranscriptPanel {
 }
 
 /// Build the transcript sidebar panel.
+#[allow(clippy::too_many_lines)]
 pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let group = adw::PreferencesGroup::builder()
         .title("Transcript")
@@ -70,6 +79,65 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         let idx = row.selected();
         config_model.write(|v| {
             v[KEY_MODEL] = serde_json::json!(idx);
+        });
+    });
+
+    // --- Tuning sliders ---
+
+    let saved_silence = config.read(|v| {
+        v.get(KEY_SILENCE_THRESHOLD)
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(0.007)
+    });
+
+    let silence_row = adw::SpinRow::builder()
+        .title("Silence threshold")
+        .adjustment(&gtk4::Adjustment::new(
+            saved_silence,
+            0.001,
+            0.1,
+            0.001,
+            0.01,
+            0.0,
+        ))
+        .digits(3)
+        .build();
+    group.add(&silence_row);
+
+    let config_silence = Arc::clone(config);
+    silence_row.connect_value_notify(move |row| {
+        let val = row.value();
+        config_silence.write(|v| {
+            v[KEY_SILENCE_THRESHOLD] = serde_json::json!(val);
+        });
+    });
+
+    let saved_noise_gate = config.read(|v| {
+        v.get(KEY_NOISE_GATE)
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(3.0)
+    });
+
+    let noise_gate_row = adw::SpinRow::builder()
+        .title("Noise gate")
+        .subtitle("Spectral gate ratio")
+        .adjustment(&gtk4::Adjustment::new(
+            saved_noise_gate,
+            1.0,
+            10.0,
+            0.5,
+            1.0,
+            0.0,
+        ))
+        .digits(1)
+        .build();
+    group.add(&noise_gate_row);
+
+    let config_noise = Arc::clone(config);
+    noise_gate_row.connect_value_notify(move |row| {
+        let val = row.value();
+        config_noise.write(|v| {
+            v[KEY_NOISE_GATE] = serde_json::json!(val);
         });
     });
 
@@ -133,6 +201,8 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         widget: group,
         enable_row,
         model_row,
+        silence_row,
+        noise_gate_row,
         status_label,
         progress_bar,
         text_view,

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -1,8 +1,14 @@
 //! Transcript sidebar panel — displays live transcription results.
 
+use std::sync::Arc;
+
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
+use sdr_config::ConfigManager;
+
+/// Config key for the persisted Whisper model index.
+const KEY_MODEL: &str = "transcription_model";
 
 /// Transcript panel with toggle switch, model picker, status label,
 /// progress bar, scrolling transcript log, and clear button.
@@ -26,7 +32,7 @@ pub struct TranscriptPanel {
 }
 
 /// Build the transcript sidebar panel.
-pub fn build_transcript_panel() -> TranscriptPanel {
+pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let group = adw::PreferencesGroup::builder()
         .title("Transcript")
         .description("Live speech-to-text")
@@ -43,12 +49,29 @@ pub fn build_transcript_panel() -> TranscriptPanel {
         .map(|m| m.label())
         .collect();
     let model_list = gtk4::StringList::new(&model_labels);
+
+    #[allow(clippy::cast_possible_truncation)]
+    let saved_model_idx = config.read(|v| {
+        v.get(KEY_MODEL)
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as u32
+    });
+
     let model_row = adw::ComboRow::builder()
         .title("Model")
         .model(&model_list)
-        .selected(0)
+        .selected(saved_model_idx)
         .build();
     group.add(&model_row);
+
+    // Persist model selection on change.
+    let config_model = Arc::clone(config);
+    model_row.connect_selected_notify(move |row| {
+        let idx = row.selected();
+        config_model.write(|v| {
+            v[KEY_MODEL] = serde_json::json!(idx);
+        });
+    });
 
     let status_label = gtk4::Label::builder()
         .halign(gtk4::Align::Start)

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -108,6 +108,7 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let saved_silence = config.read(|v| {
         v.get(KEY_SILENCE_THRESHOLD)
             .and_then(serde_json::Value::as_f64)
+            .map(|val| val.clamp(SILENCE_THRESHOLD_MIN, SILENCE_THRESHOLD_MAX))
             .unwrap_or(DEFAULT_SILENCE_THRESHOLD)
     });
 
@@ -136,6 +137,7 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let saved_noise_gate = config.read(|v| {
         v.get(KEY_NOISE_GATE)
             .and_then(serde_json::Value::as_f64)
+            .map(|val| val.clamp(NOISE_GATE_MIN, NOISE_GATE_MAX))
             .unwrap_or(DEFAULT_NOISE_GATE)
     });
 

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -108,8 +108,9 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let saved_silence = config.read(|v| {
         v.get(KEY_SILENCE_THRESHOLD)
             .and_then(serde_json::Value::as_f64)
-            .map(|val| val.clamp(SILENCE_THRESHOLD_MIN, SILENCE_THRESHOLD_MAX))
-            .unwrap_or(DEFAULT_SILENCE_THRESHOLD)
+            .map_or(DEFAULT_SILENCE_THRESHOLD, |val| {
+                val.clamp(SILENCE_THRESHOLD_MIN, SILENCE_THRESHOLD_MAX)
+            })
     });
 
     let silence_row = adw::SpinRow::builder()
@@ -137,8 +138,9 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     let saved_noise_gate = config.read(|v| {
         v.get(KEY_NOISE_GATE)
             .and_then(serde_json::Value::as_f64)
-            .map(|val| val.clamp(NOISE_GATE_MIN, NOISE_GATE_MAX))
-            .unwrap_or(DEFAULT_NOISE_GATE)
+            .map_or(DEFAULT_NOISE_GATE, |val| {
+                val.clamp(NOISE_GATE_MIN, NOISE_GATE_MAX)
+            })
     });
 
     let noise_gate_row = adw::SpinRow::builder()

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1407,6 +1407,8 @@ fn connect_transcript_panel(
     let progress_bar = transcript.progress_bar.clone();
     let text_view = transcript.text_view.clone();
     let model_row = transcript.model_row.clone();
+    let silence_row = transcript.silence_row.clone();
+    let noise_gate_row = transcript.noise_gate_row.clone();
 
     transcript.enable_row.connect_active_notify(move |row| {
         if row.is_active() {
@@ -1420,9 +1422,18 @@ fn connect_transcript_panel(
                 .copied()
                 .unwrap_or(sdr_transcription::WhisperModel::TinyEn);
 
+            // Read tuning slider values.
+            #[allow(clippy::cast_possible_truncation)]
+            let silence_threshold = silence_row.value() as f32;
+            #[allow(clippy::cast_possible_truncation)]
+            let noise_gate_ratio = noise_gate_row.value() as f32;
+
             // Scope the borrow so it's dropped before any potential re-entry
             // from row.set_active(false) on error.
-            let start_result = engine_clone.borrow_mut().start(whisper_model);
+            let start_result =
+                engine_clone
+                    .borrow_mut()
+                    .start(whisper_model, silence_threshold, noise_gate_ratio);
             match start_result {
                 Ok(event_rx) => {
                     if let Some(audio_tx) = engine_clone.borrow().audio_sender() {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -62,7 +62,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         status_bar,
         transcript_panel,
         transcript_revealer,
-    ) = build_split_view(&state);
+    ) = build_split_view(&state, config);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
     let sidebar_toggle = build_sidebar_toggle(&split_view);
     let (header, play_button, demod_dropdown, freq_selector, screenshot_button, rr_button) =
@@ -402,6 +402,7 @@ fn handle_dsp_message(
 /// Returns the split view, sidebar panels, spectrum display handle, and status bar.
 fn build_split_view(
     state: &Rc<AppState>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
 ) -> (
     adw::OverlaySplitView,
     SidebarPanels,
@@ -429,7 +430,7 @@ fn build_split_view(
     content_box.append(&status_bar.widget);
 
     // Transcript panel — slides out from the right.
-    let transcript_panel = sidebar::transcript_panel::build_transcript_panel();
+    let transcript_panel = sidebar::transcript_panel::build_transcript_panel(config);
     let transcript_scroll = gtk4::ScrolledWindow::builder()
         .child(&transcript_panel.widget)
         .hscrollbar_policy(gtk4::PolicyType::Never)

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1413,8 +1413,10 @@ fn connect_transcript_panel(
     transcript.enable_row.connect_active_notify(move |row| {
         if row.is_active() {
             // Read selected model from dropdown.
-            // Lock model selection while transcription is active.
+            // Lock model and tuning controls while transcription is active.
             model_row.set_sensitive(false);
+            silence_row.set_sensitive(false);
+            noise_gate_row.set_sensitive(false);
 
             let model_idx = model_row.selected() as usize;
             let whisper_model = sdr_transcription::WhisperModel::ALL
@@ -1490,11 +1492,15 @@ fn connect_transcript_panel(
                 Err(e) => {
                     tracing::warn!("failed to start transcription: {e}");
                     model_row.set_sensitive(true);
+                    silence_row.set_sensitive(true);
+                    noise_gate_row.set_sensitive(true);
                     row.set_active(false);
                 }
             }
         } else {
             model_row.set_sensitive(true);
+            silence_row.set_sensitive(true);
+            noise_gate_row.set_sensitive(true);
             state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
             engine_clone.borrow_mut().shutdown_nonblocking();
             status_label.set_text("");


### PR DESCRIPTION
## Summary

Four commits addressing three issues:

### Persist model selection (#215)
- Selected Whisper model saved to `config.json` via `transcription_model` key
- Restored on app start — dropdown shows last-used model
- **Also fixed:** `enable_auto_save()` was never called on the ConfigManager, so ALL config writes (including directory preferences) were only in-memory. Now enabled on startup.

### GPU OOM error message (#213)
- Improved error message when Whisper model fails to load — suggests trying a smaller model if GPU VRAM is insufficient
- Added `tracing::info` logging which model is being loaded

### Silence threshold and noise gate sliders (#207 partial)
- Two `AdwSpinRow` widgets in transcript panel for real-time tuning:
  - Silence threshold (0.001–0.100, default 0.007)
  - Noise gate ratio (1.0–10.0, default 3.0)
- Values persisted to config and passed through engine → worker → denoise
- `spectral_denoise()` and `run_worker()` now accept configurable parameters

Closes #215, closes #213
Partially addresses #207

## Test plan
- [x] `cargo build --workspace` / `cargo clippy` / `cargo test` / `cargo fmt --check` all clean
- [x] Model selection persists across app restarts
- [x] Silence threshold slider affects transcription sensitivity
- [x] Noise gate slider affects denoiser aggressiveness
- [x] GPU OOM shows helpful error instead of crashing (tested on AMD 4 GB iGPU)
- [x] Config auto-save now works for all settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Silence threshold" and "Noise gate" tuning controls in the transcription panel for customizable denoising and silence detection.
  * Transcription engine now accepts and applies configurable silence and noise-gate values at runtime.

* **Improvements**
  * Model selection and tuning values are persisted and auto-saved across sessions.
  * Configuration is loaded once at startup and shared across windows for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->