### PR TITLE
Auto-squelch, cancellation token, transcription lifecycle fixes

### DIFF
--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -27,6 +27,12 @@ const NOISE_FLOOR_INITIAL_DB: f32 = -120.0;
 /// settled and the slow alpha is used.
 const NOISE_FLOOR_SETTLE_BLOCKS: u32 = 50;
 
+/// Maximum allowed rise in the noise floor estimate per block during settling (dB).
+/// Prevents strong signals at startup from biasing the floor estimate high.
+/// Must be large enough that the floor can converge from `NOISE_FLOOR_INITIAL_DB`
+/// to a typical noise floor (~-60 dB) within `NOISE_FLOOR_SETTLE_BLOCKS`.
+const NOISE_FLOOR_MAX_RISE_DB_PER_BLOCK: f32 = 3.0;
+
 /// Margin above the noise floor (dB) for squelch-open threshold.
 const AUTO_SQUELCH_OPEN_MARGIN_DB: f32 = 10.0;
 
@@ -144,10 +150,19 @@ impl PowerSquelch {
             let settling = self.settle_count < NOISE_FLOOR_SETTLE_BLOCKS;
             if settling {
                 self.settle_count = self.settle_count.saturating_add(1);
-                self.noise_floor_db = NOISE_FLOOR_FAST_ALPHA.mul_add(
-                    measured_db,
-                    (1.0 - NOISE_FLOOR_FAST_ALPHA) * self.noise_floor_db,
-                );
+                // During settling, use fast alpha but cap extreme upward jumps
+                // that are likely strong signals rather than noise. Only cap
+                // when the measurement is far above the current estimate
+                // (more than 2x the open margin).
+                let extreme_threshold =
+                    self.noise_floor_db + AUTO_SQUELCH_OPEN_MARGIN_DB * 2.0;
+                let capped_db = if measured_db > extreme_threshold {
+                    self.noise_floor_db + NOISE_FLOOR_MAX_RISE_DB_PER_BLOCK
+                } else {
+                    measured_db
+                };
+                self.noise_floor_db = NOISE_FLOOR_FAST_ALPHA
+                    .mul_add(capped_db, (1.0 - NOISE_FLOOR_FAST_ALPHA) * self.noise_floor_db);
             } else if !self.open || measured_db < self.noise_floor_db + AUTO_SQUELCH_CLOSE_MARGIN_DB
             {
                 self.noise_floor_db = NOISE_FLOOR_ALPHA
@@ -695,6 +710,13 @@ mod tests {
 
     // --- Auto-squelch tests ---
 
+    // Auto-squelch test constants.
+    const AUTO_SETTLE_ITERS: usize = 200;
+    const TEST_BLOCK_LEN: usize = 100;
+    const NOISE_AMP: f32 = 0.001;
+    const STRONG_AMP: f32 = 1.0;
+    const BORDERLINE_AMP: f32 = 0.003;
+
     #[test]
     fn test_auto_squelch_tracks_noise_floor() {
         let mut squelch = PowerSquelch::new(-100.0);
@@ -702,9 +724,9 @@ mod tests {
         assert!(squelch.auto_squelch_enabled());
 
         // Feed many blocks of low-level noise to settle the noise floor estimate.
-        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let noise = vec![Complex::new(NOISE_AMP, 0.0); TEST_BLOCK_LEN];
         let mut output = vec![Complex::default(); 100];
-        for _ in 0..200 {
+        for _ in 0..AUTO_SETTLE_ITERS {
             squelch.process(&noise, &mut output).unwrap();
         }
 
@@ -722,15 +744,15 @@ mod tests {
         squelch.set_auto_squelch(true);
 
         // Settle noise floor with weak signal.
-        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let noise = vec![Complex::new(NOISE_AMP, 0.0); TEST_BLOCK_LEN];
         let mut output = vec![Complex::default(); 100];
-        for _ in 0..200 {
+        for _ in 0..AUTO_SETTLE_ITERS {
             squelch.process(&noise, &mut output).unwrap();
         }
         assert!(!squelch.is_open(), "should be closed on noise-only");
 
         // Inject a strong signal — should open.
-        let signal = vec![Complex::new(1.0, 0.0); 100];
+        let signal = vec![Complex::new(STRONG_AMP, 0.0); TEST_BLOCK_LEN];
         squelch.process(&signal, &mut output).unwrap();
         assert!(squelch.is_open(), "should open on strong signal");
     }
@@ -741,14 +763,14 @@ mod tests {
         squelch.set_auto_squelch(true);
 
         // Settle noise floor.
-        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let noise = vec![Complex::new(NOISE_AMP, 0.0); TEST_BLOCK_LEN];
         let mut output = vec![Complex::default(); 100];
-        for _ in 0..200 {
+        for _ in 0..AUTO_SETTLE_ITERS {
             squelch.process(&noise, &mut output).unwrap();
         }
 
         // Open squelch with a strong signal.
-        let strong = vec![Complex::new(1.0, 0.0); 100];
+        let strong = vec![Complex::new(STRONG_AMP, 0.0); TEST_BLOCK_LEN];
         squelch.process(&strong, &mut output).unwrap();
         assert!(squelch.is_open());
 
@@ -756,7 +778,7 @@ mod tests {
         // (hysteresis: close margin is lower than open margin).
         // Noise floor is ~-60 dB, close margin is +6 dB = -54 dB.
         // Amplitude of 0.003 ≈ -50.5 dB, which is above -54 dB.
-        let borderline = vec![Complex::new(0.003, 0.0); 100];
+        let borderline = vec![Complex::new(BORDERLINE_AMP, 0.0); TEST_BLOCK_LEN];
         squelch.process(&borderline, &mut output).unwrap();
         assert!(
             squelch.is_open(),
@@ -770,14 +792,14 @@ mod tests {
         squelch.set_auto_squelch(true);
 
         // Settle noise floor.
-        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let noise = vec![Complex::new(NOISE_AMP, 0.0); TEST_BLOCK_LEN];
         let mut output = vec![Complex::default(); 100];
-        for _ in 0..200 {
+        for _ in 0..AUTO_SETTLE_ITERS {
             squelch.process(&noise, &mut output).unwrap();
         }
 
         // Strong signal should still open despite manual level of 100 dB.
-        let strong = vec![Complex::new(1.0, 0.0); 100];
+        let strong = vec![Complex::new(STRONG_AMP, 0.0); TEST_BLOCK_LEN];
         squelch.process(&strong, &mut output).unwrap();
         assert!(squelch.is_open(), "auto-squelch should ignore manual level");
     }
@@ -788,12 +810,12 @@ mod tests {
         squelch.set_auto_squelch(true);
 
         // Settle noise floor and open with signal.
-        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let noise = vec![Complex::new(NOISE_AMP, 0.0); TEST_BLOCK_LEN];
         let mut output = vec![Complex::default(); 100];
-        for _ in 0..200 {
+        for _ in 0..AUTO_SETTLE_ITERS {
             squelch.process(&noise, &mut output).unwrap();
         }
-        let strong = vec![Complex::new(1.0, 0.0); 100];
+        let strong = vec![Complex::new(STRONG_AMP, 0.0); TEST_BLOCK_LEN];
         squelch.process(&strong, &mut output).unwrap();
         assert!(squelch.is_open());
 

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -144,10 +144,11 @@ impl PowerSquelch {
             let settling = self.settle_count < NOISE_FLOOR_SETTLE_BLOCKS;
             if settling {
                 self.settle_count = self.settle_count.saturating_add(1);
-                self.noise_floor_db = NOISE_FLOOR_FAST_ALPHA
-                    .mul_add(measured_db, (1.0 - NOISE_FLOOR_FAST_ALPHA) * self.noise_floor_db);
-            } else if !self.open
-                || measured_db < self.noise_floor_db + AUTO_SQUELCH_CLOSE_MARGIN_DB
+                self.noise_floor_db = NOISE_FLOOR_FAST_ALPHA.mul_add(
+                    measured_db,
+                    (1.0 - NOISE_FLOOR_FAST_ALPHA) * self.noise_floor_db,
+                );
+            } else if !self.open || measured_db < self.noise_floor_db + AUTO_SQUELCH_CLOSE_MARGIN_DB
             {
                 self.noise_floor_db = NOISE_FLOOR_ALPHA
                     .mul_add(measured_db, (1.0 - NOISE_FLOOR_ALPHA) * self.noise_floor_db);
@@ -778,10 +779,7 @@ mod tests {
         // Strong signal should still open despite manual level of 100 dB.
         let strong = vec![Complex::new(1.0, 0.0); 100];
         squelch.process(&strong, &mut output).unwrap();
-        assert!(
-            squelch.is_open(),
-            "auto-squelch should ignore manual level"
-        );
+        assert!(squelch.is_open(), "auto-squelch should ignore manual level");
     }
 
     #[test]

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -8,14 +8,51 @@ use std::sync::Arc;
 
 use sdr_types::{Complex, DspError};
 
+/// Exponential moving average alpha for noise floor tracking.
+///
+/// Small values track slowly, avoiding false adaptation to transient signals.
+const NOISE_FLOOR_ALPHA: f32 = 0.02;
+
+/// Fast alpha used during the initial convergence period.
+///
+/// Allows the noise floor to quickly reach the actual noise level from the
+/// default initial estimate.
+const NOISE_FLOOR_FAST_ALPHA: f32 = 0.3;
+
+/// Initial noise floor estimate in dB (very low so squelch starts open
+/// until enough samples have been observed).
+const NOISE_FLOOR_INITIAL_DB: f32 = -120.0;
+
+/// Number of blocks required before the noise floor estimate is considered
+/// settled and the slow alpha is used.
+const NOISE_FLOOR_SETTLE_BLOCKS: u32 = 50;
+
+/// Margin above the noise floor (dB) for squelch-open threshold.
+const AUTO_SQUELCH_OPEN_MARGIN_DB: f32 = 10.0;
+
+/// Margin above the noise floor (dB) for squelch-close threshold (hysteresis).
+///
+/// Lower than the open margin so that once a signal opens the squelch,
+/// it stays open until it drops closer to the noise floor.
+const AUTO_SQUELCH_CLOSE_MARGIN_DB: f32 = 6.0;
+
 /// Power squelch — gates signal based on average power level.
 ///
 /// Ports SDR++ `dsp::noise_reduction::PowerSquelch`. Computes the mean
 /// power of the input block and compares against a threshold in dB.
 /// If below threshold, the entire block is zeroed.
+///
+/// Supports an auto-squelch mode that tracks the noise floor with an
+/// exponential moving average and applies hysteresis margins.
 pub struct PowerSquelch {
     level_db: f32,
     open: bool,
+    auto_squelch: bool,
+    /// Running noise floor estimate in dB (EMA-filtered).
+    noise_floor_db: f32,
+    /// Number of blocks processed since auto-squelch was enabled.
+    /// Used to detect the initial convergence period.
+    settle_count: u32,
 }
 
 impl PowerSquelch {
@@ -26,6 +63,9 @@ impl PowerSquelch {
         Self {
             level_db,
             open: false,
+            auto_squelch: false,
+            noise_floor_db: NOISE_FLOOR_INITIAL_DB,
+            settle_count: 0,
         }
     }
 
@@ -37,6 +77,29 @@ impl PowerSquelch {
     /// Update the squelch threshold.
     pub fn set_level(&mut self, level_db: f32) {
         self.level_db = level_db;
+    }
+
+    /// Enable or disable auto-squelch (noise floor tracking).
+    ///
+    /// When enabled, the manual `level_db` is ignored and the threshold
+    /// is derived from the tracked noise floor plus a margin.
+    pub fn set_auto_squelch(&mut self, enabled: bool) {
+        self.auto_squelch = enabled;
+        if enabled {
+            // Reset the noise floor estimate so it adapts to the current band.
+            self.noise_floor_db = NOISE_FLOOR_INITIAL_DB;
+            self.settle_count = 0;
+        }
+    }
+
+    /// Returns whether auto-squelch is enabled.
+    pub fn auto_squelch_enabled(&self) -> bool {
+        self.auto_squelch
+    }
+
+    /// Returns the current noise floor estimate in dB.
+    pub fn noise_floor_db(&self) -> f32 {
+        self.noise_floor_db
     }
 
     /// Process complex samples. Passes or zeros the entire block.
@@ -72,7 +135,39 @@ impl PowerSquelch {
         // This matches the standard dBFS convention used by most SDR tools.
         let measured_db = 20.0 * mean_amplitude.max(f32::MIN_POSITIVE).log10();
 
-        if measured_db >= self.level_db {
+        let threshold_db = if self.auto_squelch {
+            // During the initial settling period, use a fast alpha so the
+            // noise floor converges quickly from the default initial value.
+            // After settling, use the slow alpha and only update when the
+            // squelch is closed or the level is below the close margin,
+            // preventing active signals from corrupting the estimate.
+            let settling = self.settle_count < NOISE_FLOOR_SETTLE_BLOCKS;
+            if settling {
+                self.settle_count = self.settle_count.saturating_add(1);
+                self.noise_floor_db = NOISE_FLOOR_FAST_ALPHA
+                    .mul_add(measured_db, (1.0 - NOISE_FLOOR_FAST_ALPHA) * self.noise_floor_db);
+            } else if !self.open
+                || measured_db < self.noise_floor_db + AUTO_SQUELCH_CLOSE_MARGIN_DB
+            {
+                self.noise_floor_db = NOISE_FLOOR_ALPHA
+                    .mul_add(measured_db, (1.0 - NOISE_FLOOR_ALPHA) * self.noise_floor_db);
+            }
+
+            // During settling, keep squelch open (pass audio through) so
+            // users don't experience a silent startup period.
+            if settling {
+                f32::NEG_INFINITY
+            } else if self.open {
+                // Apply hysteresis: close threshold is lower than open threshold.
+                self.noise_floor_db + AUTO_SQUELCH_CLOSE_MARGIN_DB
+            } else {
+                self.noise_floor_db + AUTO_SQUELCH_OPEN_MARGIN_DB
+            }
+        } else {
+            self.level_db
+        };
+
+        if measured_db >= threshold_db {
             output[..input.len()].copy_from_slice(input);
             self.open = true;
         } else {
@@ -595,5 +690,121 @@ mod tests {
         let input = [Complex::default(); 10];
         let mut output = [Complex::default(); 5];
         assert!(squelch.process(&input, &mut output).is_err());
+    }
+
+    // --- Auto-squelch tests ---
+
+    #[test]
+    fn test_auto_squelch_tracks_noise_floor() {
+        let mut squelch = PowerSquelch::new(-100.0);
+        squelch.set_auto_squelch(true);
+        assert!(squelch.auto_squelch_enabled());
+
+        // Feed many blocks of low-level noise to settle the noise floor estimate.
+        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let mut output = vec![Complex::default(); 100];
+        for _ in 0..200 {
+            squelch.process(&noise, &mut output).unwrap();
+        }
+
+        // Noise floor should have settled near the noise level (-60 dBFS for 0.001).
+        let floor = squelch.noise_floor_db();
+        assert!(
+            floor > -70.0 && floor < -50.0,
+            "noise floor should be near -60 dB, got {floor}"
+        );
+    }
+
+    #[test]
+    fn test_auto_squelch_opens_on_signal() {
+        let mut squelch = PowerSquelch::new(-100.0);
+        squelch.set_auto_squelch(true);
+
+        // Settle noise floor with weak signal.
+        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let mut output = vec![Complex::default(); 100];
+        for _ in 0..200 {
+            squelch.process(&noise, &mut output).unwrap();
+        }
+        assert!(!squelch.is_open(), "should be closed on noise-only");
+
+        // Inject a strong signal — should open.
+        let signal = vec![Complex::new(1.0, 0.0); 100];
+        squelch.process(&signal, &mut output).unwrap();
+        assert!(squelch.is_open(), "should open on strong signal");
+    }
+
+    #[test]
+    fn test_auto_squelch_hysteresis() {
+        let mut squelch = PowerSquelch::new(-100.0);
+        squelch.set_auto_squelch(true);
+
+        // Settle noise floor.
+        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let mut output = vec![Complex::default(); 100];
+        for _ in 0..200 {
+            squelch.process(&noise, &mut output).unwrap();
+        }
+
+        // Open squelch with a strong signal.
+        let strong = vec![Complex::new(1.0, 0.0); 100];
+        squelch.process(&strong, &mut output).unwrap();
+        assert!(squelch.is_open());
+
+        // A borderline signal just above the close margin should stay open
+        // (hysteresis: close margin is lower than open margin).
+        // Noise floor is ~-60 dB, close margin is +6 dB = -54 dB.
+        // Amplitude of 0.003 ≈ -50.5 dB, which is above -54 dB.
+        let borderline = vec![Complex::new(0.003, 0.0); 100];
+        squelch.process(&borderline, &mut output).unwrap();
+        assert!(
+            squelch.is_open(),
+            "borderline signal should keep squelch open due to hysteresis"
+        );
+    }
+
+    #[test]
+    fn test_auto_squelch_ignores_manual_level() {
+        let mut squelch = PowerSquelch::new(100.0); // impossibly high manual threshold
+        squelch.set_auto_squelch(true);
+
+        // Settle noise floor.
+        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let mut output = vec![Complex::default(); 100];
+        for _ in 0..200 {
+            squelch.process(&noise, &mut output).unwrap();
+        }
+
+        // Strong signal should still open despite manual level of 100 dB.
+        let strong = vec![Complex::new(1.0, 0.0); 100];
+        squelch.process(&strong, &mut output).unwrap();
+        assert!(
+            squelch.is_open(),
+            "auto-squelch should ignore manual level"
+        );
+    }
+
+    #[test]
+    fn test_auto_squelch_disable_reverts_to_manual() {
+        let mut squelch = PowerSquelch::new(100.0); // impossibly high manual threshold
+        squelch.set_auto_squelch(true);
+
+        // Settle noise floor and open with signal.
+        let noise = vec![Complex::new(0.001, 0.0); 100];
+        let mut output = vec![Complex::default(); 100];
+        for _ in 0..200 {
+            squelch.process(&noise, &mut output).unwrap();
+        }
+        let strong = vec![Complex::new(1.0, 0.0); 100];
+        squelch.process(&strong, &mut output).unwrap();
+        assert!(squelch.is_open());
+
+        // Disable auto-squelch — should revert to manual 100 dB threshold.
+        squelch.set_auto_squelch(false);
+        squelch.process(&strong, &mut output).unwrap();
+        assert!(
+            !squelch.is_open(),
+            "with auto-squelch off, manual 100 dB threshold should close squelch"
+        );
     }
 }

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -154,15 +154,16 @@ impl PowerSquelch {
                 // that are likely strong signals rather than noise. Only cap
                 // when the measurement is far above the current estimate
                 // (more than 2x the open margin).
-                let extreme_threshold =
-                    self.noise_floor_db + AUTO_SQUELCH_OPEN_MARGIN_DB * 2.0;
+                let extreme_threshold = self.noise_floor_db + AUTO_SQUELCH_OPEN_MARGIN_DB * 2.0;
                 let capped_db = if measured_db > extreme_threshold {
                     self.noise_floor_db + NOISE_FLOOR_MAX_RISE_DB_PER_BLOCK
                 } else {
                     measured_db
                 };
-                self.noise_floor_db = NOISE_FLOOR_FAST_ALPHA
-                    .mul_add(capped_db, (1.0 - NOISE_FLOOR_FAST_ALPHA) * self.noise_floor_db);
+                self.noise_floor_db = NOISE_FLOOR_FAST_ALPHA.mul_add(
+                    capped_db,
+                    (1.0 - NOISE_FLOOR_FAST_ALPHA) * self.noise_floor_db,
+                );
             } else if !self.open || measured_db < self.noise_floor_db + AUTO_SQUELCH_CLOSE_MARGIN_DB
             {
                 self.noise_floor_db = NOISE_FLOOR_ALPHA

--- a/crates/sdr-radio/src/if_chain.rs
+++ b/crates/sdr-radio/src/if_chain.rs
@@ -103,7 +103,8 @@ impl IfChain {
 
     /// Returns whether the squelch is currently open (signal above threshold).
     pub fn squelch_open(&self) -> bool {
-        !self.squelch_enabled || self.squelch.is_open()
+        let active = self.squelch_enabled || self.squelch.auto_squelch_enabled();
+        !active || self.squelch.is_open()
     }
 
     /// Enable or disable FM IF noise reduction.
@@ -136,7 +137,8 @@ impl IfChain {
             });
         }
 
-        let any_enabled = self.nb_enabled || self.squelch_enabled || self.fm_if_nr_enabled;
+        let squelch_active = self.squelch_enabled || self.squelch.auto_squelch_enabled();
+        let any_enabled = self.nb_enabled || squelch_active || self.fm_if_nr_enabled;
         if !any_enabled {
             output[..input.len()].copy_from_slice(input);
             return Ok(input.len());
@@ -161,8 +163,8 @@ impl IfChain {
             current_is_a = !current_is_a;
         }
 
-        // Stage 2: Squelch
-        if self.squelch_enabled {
+        // Stage 2: Squelch (manual or auto)
+        if squelch_active {
             if current_is_a {
                 self.squelch
                     .process(&self.buf_a[..n], &mut self.buf_b[..n])?;

--- a/crates/sdr-radio/src/if_chain.rs
+++ b/crates/sdr-radio/src/if_chain.rs
@@ -88,6 +88,19 @@ impl IfChain {
         self.squelch.set_level(db);
     }
 
+    /// Enable or disable auto-squelch (noise floor tracking).
+    ///
+    /// When enabled, the squelch threshold is automatically derived from
+    /// the tracked noise floor. The manual squelch level is ignored.
+    pub fn set_auto_squelch_enabled(&mut self, enabled: bool) {
+        self.squelch.set_auto_squelch(enabled);
+    }
+
+    /// Returns whether auto-squelch is enabled.
+    pub fn auto_squelch_enabled(&self) -> bool {
+        self.squelch.auto_squelch_enabled()
+    }
+
     /// Returns whether the squelch is currently open (signal above threshold).
     pub fn squelch_open(&self) -> bool {
         !self.squelch_enabled || self.squelch.is_open()

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -323,6 +323,15 @@ impl RadioModule {
         self.if_chain.set_squelch_enabled(enabled);
     }
 
+    /// Enable or disable auto-squelch (noise floor tracking).
+    ///
+    /// When enabled, the squelch threshold is automatically derived from
+    /// the tracked noise floor with hysteresis. The manual squelch level
+    /// is ignored while auto-squelch is active.
+    pub fn set_auto_squelch_enabled(&mut self, enabled: bool) {
+        self.if_chain.set_auto_squelch_enabled(enabled);
+    }
+
     /// Set the deemphasis mode.
     ///
     /// # Errors
@@ -561,6 +570,20 @@ mod tests {
         let err = RadioError::ModeSwitchFailed("test".to_string());
         let msg = format!("{err}");
         assert!(msg.contains("mode switch failed"));
+    }
+
+    #[test]
+    fn test_radio_module_auto_squelch() {
+        let mut radio = RadioModule::with_default_rate().unwrap();
+        radio.set_squelch_enabled(true);
+        radio.set_auto_squelch_enabled(true);
+
+        // Verify auto-squelch is enabled on the IF chain
+        assert!(radio.if_chain().auto_squelch_enabled());
+
+        // Disable and verify
+        radio.set_auto_squelch_enabled(false);
+        assert!(!radio.if_chain().auto_squelch_enabled());
     }
 
     #[test]

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -13,7 +13,7 @@ pub use model::WhisperModel;
 pub use worker::TranscriptionEvent;
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::{Arc, mpsc};
 
 /// Bounded channel capacity for audio buffers from DSP → transcription.
 /// Each buffer is ~1024-4096 stereo samples (~20-80ms). At 48 kHz with

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -12,7 +12,8 @@ pub mod worker;
 pub use model::WhisperModel;
 pub use worker::TranscriptionEvent;
 
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
 
 /// Bounded channel capacity for audio buffers from DSP → transcription.
 /// Each buffer is ~1024-4096 stereo samples (~20-80ms). At 48 kHz with
@@ -35,6 +36,7 @@ pub enum TranscriptionError {
 pub struct TranscriptionEngine {
     audio_tx: Option<mpsc::SyncSender<Vec<f32>>>,
     worker_thread: Option<std::thread::JoinHandle<()>>,
+    cancel_token: Arc<AtomicBool>,
 }
 
 impl Default for TranscriptionEngine {
@@ -48,6 +50,7 @@ impl TranscriptionEngine {
         Self {
             audio_tx: None,
             worker_thread: None,
+            cancel_token: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -68,15 +71,19 @@ impl TranscriptionEngine {
             return Err(TranscriptionError::AlreadyRunning);
         }
 
+        self.cancel_token.store(false, Ordering::Relaxed);
+
         let (audio_tx, audio_rx) = mpsc::sync_channel(AUDIO_CHANNEL_CAPACITY);
         let (event_tx, event_rx) = mpsc::channel();
 
+        let cancel = Arc::clone(&self.cancel_token);
         let handle = std::thread::Builder::new()
             .name("transcription-worker".into())
             .spawn(move || {
                 worker::run_worker(
                     &audio_rx,
                     &event_tx,
+                    &cancel,
                     whisper_model,
                     silence_threshold,
                     noise_gate_ratio,
@@ -95,6 +102,7 @@ impl TranscriptionEngine {
     /// This may block if Whisper inference is in progress. Use
     /// [`shutdown_nonblocking`] during app exit to avoid freezing the UI.
     pub fn stop(&mut self) {
+        self.cancel_token.store(true, Ordering::Relaxed);
         self.audio_tx.take();
         if let Some(handle) = self.worker_thread.take() {
             let _ = handle.join();
@@ -108,6 +116,7 @@ impl TranscriptionEngine {
     /// inference completes. The thread is detached — the process can
     /// exit without joining it.
     pub fn shutdown_nonblocking(&mut self) {
+        self.cancel_token.store(true, Ordering::Relaxed);
         self.audio_tx.take();
         self.worker_thread.take(); // detach — don't join
         tracing::info!("transcription engine shutdown (non-blocking)");

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -17,6 +17,9 @@ const CHUNK_SECONDS: usize = 5;
 /// Number of 16 kHz mono samples per chunk (16000 * 5 = 80000).
 const CHUNK_SAMPLES: usize = 16_000 * CHUNK_SECONDS;
 
+/// Polling interval for the audio receive loop when checking for cancellation.
+const AUDIO_RECV_TIMEOUT: Duration = Duration::from_millis(100);
+
 /// Events emitted by the transcription worker.
 #[derive(Debug, Clone)]
 pub enum TranscriptionEvent {
@@ -71,6 +74,7 @@ pub fn run_worker(
 
 /// Inner implementation that returns errors as strings so the outer function
 /// can forward them as `TranscriptionEvent::Error`.
+#[allow(clippy::too_many_lines)]
 fn run_worker_inner(
     audio_rx: &mpsc::Receiver<Vec<f32>>,
     event_tx: &mpsc::Sender<TranscriptionEvent>,
@@ -131,10 +135,11 @@ fn run_worker_inner(
 
     loop {
         if cancel.load(Ordering::Relaxed) {
-            break;
+            tracing::info!("transcription cancelled, worker exiting");
+            return Ok(());
         }
 
-        let interleaved = match audio_rx.recv_timeout(Duration::from_millis(100)) {
+        let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
             Ok(data) => data,
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
@@ -144,12 +149,21 @@ fn run_worker_inner(
         resampler::downsample_stereo_to_mono_16k(&interleaved, &mut mono_buf);
 
         // Drain any additional queued buffers to minimize frame drops
-        // during long inference passes.
+        // during long inference passes. Check cancel between drains.
         while let Ok(extra) = audio_rx.try_recv() {
+            if cancel.load(Ordering::Relaxed) {
+                tracing::info!("transcription cancelled, worker exiting");
+                return Ok(());
+            }
             resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
         }
 
         while mono_buf.len() >= CHUNK_SAMPLES {
+            if cancel.load(Ordering::Relaxed) {
+                tracing::info!("transcription cancelled, worker exiting");
+                return Ok(());
+            }
+
             let mut chunk: Vec<f32> = mono_buf.drain(..CHUNK_SAMPLES).collect();
 
             // Spectral noise gate — remove broadband static and hiss

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -3,7 +3,9 @@
 //! Receives interleaved stereo f32 audio at 48 kHz, resamples to 16 kHz mono,
 //! accumulates 5-second chunks, and runs Whisper inference on non-silent chunks.
 
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
 
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
@@ -37,17 +39,20 @@ pub enum TranscriptionEvent {
 }
 
 /// Main worker loop. Blocks the calling thread and exits when `audio_rx` is
-/// closed (all senders dropped). Should be spawned on a dedicated thread.
+/// closed (all senders dropped) or the cancellation token is set.
+/// Should be spawned on a dedicated thread.
 ///
 /// # Arguments
 /// * `audio_rx` — receives interleaved stereo f32 audio at 48 kHz
 /// * `event_tx` — sends transcription events to the UI/consumer
+/// * `cancel` — cancellation token; when set to `true`, the worker exits promptly
 /// * `model` — which Whisper model to load
 /// * `silence_threshold` — RMS below which a chunk is skipped
 /// * `noise_gate_ratio` — spectral gate multiplier over noise floor
 pub fn run_worker(
     audio_rx: &mpsc::Receiver<Vec<f32>>,
     event_tx: &mpsc::Sender<TranscriptionEvent>,
+    cancel: &Arc<AtomicBool>,
     model: model::WhisperModel,
     silence_threshold: f32,
     noise_gate_ratio: f32,
@@ -55,6 +60,7 @@ pub fn run_worker(
     if let Err(e) = run_worker_inner(
         audio_rx,
         event_tx,
+        cancel,
         model,
         silence_threshold,
         noise_gate_ratio,
@@ -68,6 +74,7 @@ pub fn run_worker(
 fn run_worker_inner(
     audio_rx: &mpsc::Receiver<Vec<f32>>,
     event_tx: &mpsc::Sender<TranscriptionEvent>,
+    cancel: &Arc<AtomicBool>,
     model: model::WhisperModel,
     silence_threshold: f32,
     noise_gate_ratio: f32,
@@ -122,8 +129,18 @@ fn run_worker_inner(
     // --- Audio loop ---
     let mut mono_buf: Vec<f32> = Vec::with_capacity(CHUNK_SAMPLES * 2);
 
-    while let Ok(interleaved) = audio_rx.recv() {
-        // Process the first buffer we received via blocking recv().
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let interleaved = match audio_rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(data) => data,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+
+        // Process the first buffer we received.
         resampler::downsample_stereo_to_mono_16k(&interleaved, &mut mono_buf);
 
         // Drain any additional queued buffers to minimize frame drops

--- a/crates/sdr-transcription/src/worker.rs
+++ b/crates/sdr-transcription/src/worker.rs
@@ -4,7 +4,7 @@
 //! accumulates 5-second chunks, and runs Whisper inference on non-silent chunks.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::{Arc, mpsc};
 use std::time::Duration;
 
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -408,6 +408,11 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             state.radio.set_squelch_enabled(enabled);
         }
 
+        UiToDsp::SetAutoSquelch(enabled) => {
+            tracing::debug!(enabled, "set auto-squelch");
+            state.radio.set_auto_squelch_enabled(enabled);
+        }
+
         UiToDsp::SetVolume(vol) => {
             tracing::debug!(volume = vol, "set volume");
             state.volume = vol;

--- a/crates/sdr-ui/src/dsp_controller.rs
+++ b/crates/sdr-ui/src/dsp_controller.rs
@@ -331,6 +331,8 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 return;
             }
             tracing::info!("stopping DSP pipeline");
+            // Disconnect transcription tap so the worker stops receiving audio.
+            state.transcription_tx = None;
             cleanup(state);
             state.running = false;
             let _ = dsp_tx.send(DspToUi::SourceStopped);

--- a/crates/sdr-ui/src/messages.rs
+++ b/crates/sdr-ui/src/messages.rs
@@ -60,6 +60,8 @@ pub enum UiToDsp {
     SetSquelch(f32),
     /// Enable or disable the squelch gate.
     SetSquelchEnabled(bool),
+    /// Enable or disable auto-squelch (noise floor tracking).
+    SetAutoSquelch(bool),
     /// Set the audio output volume (0.0..=1.0).
     SetVolume(f32),
     /// Set the FM deemphasis mode.
@@ -190,6 +192,9 @@ mod tests {
 
         let sqe = UiToDsp::SetSquelchEnabled(true);
         assert!(matches!(sqe, UiToDsp::SetSquelchEnabled(true)));
+
+        let auto_sq = UiToDsp::SetAutoSquelch(true);
+        assert!(matches!(auto_sq, UiToDsp::SetAutoSquelch(true)));
 
         let vol = UiToDsp::SetVolume(0.75);
         assert!(matches!(vol, UiToDsp::SetVolume(v) if (v - 0.75).abs() < f32::EPSILON));

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -58,6 +58,8 @@ pub struct RadioPanel {
     pub squelch_enabled_row: adw::SwitchRow,
     /// Squelch level control.
     pub squelch_level_row: adw::SpinRow,
+    /// Auto-squelch toggle (noise floor tracking).
+    pub auto_squelch_row: adw::SwitchRow,
     /// De-emphasis filter selector.
     pub deemphasis_row: adw::ComboRow,
     /// Noise blanker toggle.
@@ -130,6 +132,12 @@ pub fn build_radio_panel() -> RadioPanel {
         .digits(0)
         .build();
 
+    // --- Auto-squelch ---
+    let auto_squelch_row = adw::SwitchRow::builder()
+        .title("Auto Squelch")
+        .subtitle("Track noise floor automatically")
+        .build();
+
     // --- De-emphasis ---
     let deemphasis_model =
         gtk4::StringList::new(&["None", "50 \u{00b5}s (EU)", "75 \u{00b5}s (US)"]);
@@ -194,6 +202,7 @@ pub fn build_radio_panel() -> RadioPanel {
     group.add(&bandwidth_row);
     group.add(&squelch_enabled_row);
     group.add(&squelch_level_row);
+    group.add(&auto_squelch_row);
     group.add(&deemphasis_row);
     group.add(&noise_blanker_row);
     group.add(&nb_level_row);
@@ -209,6 +218,7 @@ pub fn build_radio_panel() -> RadioPanel {
         bandwidth_row,
         squelch_enabled_row,
         squelch_level_row,
+        auto_squelch_row,
         deemphasis_row,
         noise_blanker_row,
         nb_level_row,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -271,6 +271,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let gain_row_for_dsp = panels.source.gain_row.clone();
     let record_audio_for_dsp = panels.audio.record_audio_row.clone();
     let record_iq_for_dsp = panels.source.record_iq_row.clone();
+    let transcription_enable_for_dsp = transcript_panel.enable_row.clone();
     glib::timeout_add_local(Duration::from_millis(DSP_POLL_INTERVAL_MS), move || {
         // Check for new FFT data from the shared buffer (zero-alloc path).
         fft_shared.take_if_ready(|data| {
@@ -291,6 +292,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                         &gain_row_for_dsp,
                         &record_audio_for_dsp,
                         &record_iq_for_dsp,
+                        &transcription_enable_for_dsp,
                     );
                 }
                 Err(mpsc::TryRecvError::Empty) => break,
@@ -318,6 +320,7 @@ fn handle_dsp_message(
     gain_row: &adw::SpinRow,
     record_audio_row: &adw::SwitchRow,
     record_iq_row: &adw::SwitchRow,
+    transcription_enable_row: &adw::SwitchRow,
 ) {
     match msg {
         DspToUi::FftData(_) => {
@@ -343,9 +346,10 @@ fn handle_dsp_message(
                 btn.set_active(false);
                 btn.set_icon_name("media-playback-start-symbolic");
             }
-            // Reset recording toggles when the source stops.
+            // Reset recording and transcription toggles when the source stops.
             record_audio_row.set_active(false);
             record_iq_row.set_active(false);
+            transcription_enable_row.set_active(false);
         }
         DspToUi::SampleRateChanged(rate) => {
             tracing::info!(effective_sample_rate = rate, "sample rate changed");

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -883,6 +883,15 @@ fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             state_squelch_lvl.send_dsp(UiToDsp::SetSquelch(row.value() as f32));
         });
 
+    // Auto-squelch
+    let state_auto_sq = Rc::clone(state);
+    panels
+        .radio
+        .auto_squelch_row
+        .connect_active_notify(move |row| {
+            state_auto_sq.send_dsp(UiToDsp::SetAutoSquelch(row.is_active()));
+        });
+
     // Deemphasis
     let state_de = Rc::clone(state);
     panels


### PR DESCRIPTION
## Summary

### Auto-squelch (#205)
- Automatic noise floor tracking via exponential moving average in `PowerSquelch`
- Hysteresis: opens at noise floor +10 dB, closes at +6 dB (prevents chatter)
- Fast settling period (50 blocks at alpha=0.3) for quick convergence on startup
- Toggle in Radio panel — works independently of manual squelch
- 5 new tests for noise floor tracking, signal detection, hysteresis, and manual revert

### Cancellation token (#209)
- `Arc<AtomicBool>` token for deterministic worker shutdown
- Worker uses `recv_timeout(100ms)` + cancel check instead of blocking `recv()`
- `stop()` sets token before joining — no more potential deadlock
- `shutdown_nonblocking()` sets token before detaching

### Transcription lifecycle fixes
- DSP Stop disconnects transcription audio tap
- Transcription toggle resets to off when DSP pipeline stops
- Matches existing behavior of recording toggles

Closes #205, closes #209

## Test plan
- [x] Auto-squelch: toggle on → squelch gates automatically based on noise floor
- [x] Auto-squelch works without manual squelch enabled
- [x] Manual squelch still works when auto-squelch is off
- [x] Transcription stops when DSP Stop is pressed
- [x] Transcription toggle flips off on Stop
- [x] App shuts down cleanly with transcription active
- [x] `cargo build --workspace` / `cargo clippy` / `cargo test` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-squelch: automatic noise-floor tracking with dynamic squelch threshold and exposed noise-floor readout.
  * UI toggle in the Radio panel and radio control to enable/disable and query Auto Squelch.

* **Improvements**
  * Transcription engine: cooperative cancellation so stopping transcription reliably stops the worker.

* **Tests**
  * Unit tests added for auto-squelch behavior and transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->