### PR TITLE
Add Responsible Use section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Your credentials are stored in your system keyring (GNOME Keyring / macOS Keycha
 
 ## Responsible Use
 
+> **Disclaimer:** This section provides general information and is **not legal advice**. Consult a qualified attorney for guidance specific to your situation and jurisdiction.
+
 SDR-RS is a personal listening tool for unencrypted radio transmissions. Listening to public safety, amateur, and commercial radio is legal in most jurisdictions, but please use it responsibly:
 
 **It's legal to:**
@@ -206,7 +208,7 @@ Public safety broadcasts may include personally identifiable information — nam
 - The Whisper model runs entirely on your machine
 - Audio recordings are saved locally only when you explicitly enable them
 
-If you're using SDR-RS in a shared space, be mindful that others may see the transcript on your screen. Future versions may add automatic redaction of PII patterns and a "lock transcript" mode (see issues #219, #220, #221).
+If you're using SDR-RS in a shared space, be mindful that others may see the transcript on your screen. Future versions may add automatic redaction of PII patterns and a "lock transcript" mode (see [#219](https://github.com/jasonherald/rtl-sdr/issues/219), [#220](https://github.com/jasonherald/rtl-sdr/issues/220), [#221](https://github.com/jasonherald/rtl-sdr/issues/221)).
 
 **Know your local laws:** Scanner laws vary by jurisdiction. Some US states restrict scanner use in vehicles. Some countries prohibit listening to certain frequencies entirely. It's your responsibility to know and follow the laws where you live.
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,35 @@ SDR-RS can browse and import frequencies from [RadioReference.com](https://www.r
 
 Your credentials are stored in your system keyring (GNOME Keyring / macOS Keychain) and are only sent to RadioReference.com.
 
+## Responsible Use
+
+SDR-RS is a personal listening tool for unencrypted radio transmissions. Listening to public safety, amateur, and commercial radio is legal in most jurisdictions, but please use it responsibly:
+
+**It's legal to:**
+- Listen to unencrypted radio for personal interest, education, or amateur radio activities
+- Take notes for your own reference
+- Use the transcription feature to convert audio to text on your local machine
+
+**It's not OK to:**
+- Publish or share transcripts of intercepted public safety communications (US Communications Act §605 prohibits divulging or publishing intercepted communications)
+- Aggregate or sell information overheard on the radio
+- Use information obtained from radio listening to identify, track, harass, or harm individuals
+- Decrypt encrypted transmissions
+- Listen to cellular phone communications (illegal under ECPA)
+
+**Privacy considerations:**
+
+Public safety broadcasts may include personally identifiable information — names, addresses, license plates, phone numbers. SDR-RS keeps everything local:
+
+- Transcripts live in memory only and are cleared when the app closes
+- No data is uploaded anywhere
+- The Whisper model runs entirely on your machine
+- Audio recordings are saved locally only when you explicitly enable them
+
+If you're using SDR-RS in a shared space, be mindful that others may see the transcript on your screen. Future versions may add automatic redaction of PII patterns and a "lock transcript" mode (see issues #219, #220, #221).
+
+**Know your local laws:** Scanner laws vary by jurisdiction. Some US states restrict scanner use in vehicles. Some countries prohibit listening to certain frequencies entirely. It's your responsibility to know and follow the laws where you live.
+
 ## Security
 
 See [SECURITY.md](SECURITY.md) for vulnerability reporting and security scanning details.


### PR DESCRIPTION
## Summary

Adds a Responsible Use section to the README documenting:

- What's legal vs. not when listening to and transcribing radio
- Privacy guarantees of SDR-RS (everything local, nothing uploaded)
- Reference to upcoming responsible-use features (#219, #220, #221)
- Reminder that local laws vary by jurisdiction

## Context

After running the app for a while and seeing license plates and names in the transcription, it was clear we should be explicit about responsible use. Personal listening to unencrypted public safety radio is legal, but the broadcasts contain sensitive information and the README should help users understand both their rights and their responsibilities.

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Responsible Use” section with a legal-use disclaimer and clear guidance on allowed vs. disallowed behaviors for radio listening, transcription, and handling sensitive information (e.g., no publishing/sharing intercepted public-safety transcripts, no aggregating/selling overheard info, and no using data to identify/track/harm individuals).
  * Clarified privacy: transcripts held in-memory and cleared on close, no data uploaded, local processing, audio saved locally only when explicitly enabled; notes on shared‑space visibility and potential future PII redaction/lock-transcript options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->