### PR TITLE
swift-ui: spec set for native macOS frontend

### DIFF
--- a/docs/superpowers/specs/2026-04-12-coreaudio-sink-design.md
+++ b/docs/superpowers/specs/2026-04-12-coreaudio-sink-design.md
@@ -143,7 +143,11 @@ The CoreAudio impl exposes **exactly** the same surface as `pw_impl.rs`:
 pub struct AudioSink { /* CoreAudio-internal state */ }
 pub struct AudioDevice {
     pub display_name: String,
-    pub node_name: String,         // we re-purpose this for AudioObjectID hex on macOS
+    /// Caller-opaque device identifier.
+    /// • Linux/PipeWire: PipeWire `node.name`
+    /// • macOS/CoreAudio: CoreAudio device UID (`kAudioDevicePropertyDeviceUID`)
+    /// Empty string ("") always means "system default output", on every platform.
+    pub node_name: String,
 }
 
 impl AudioSink {
@@ -224,15 +228,40 @@ The engine never sees the device rate. `Sink::sample_rate()` always returns 48 k
 The render callback signature is roughly:
 
 ```rust
+/// Maximum frames per render callback we are willing to service from the
+/// stack scratch buffer. CoreAudio quanta are typically 256 or 512 frames;
+/// 4096 is a generous ceiling that covers any aggregate device or pro-audio
+/// device the user might have configured.
+const MAX_CB_FRAMES: usize = 4096;
+
 unit.set_render_callback(move |args: render_callback::Args<f32, NonInterleaved>| {
     let frames = args.num_frames;
     // args.data is &mut [&mut [f32]] — one slice per channel
     let mut left  = args.data[0];
     let mut right = args.data[1];
 
+    // Stack-only scratch. No heap allocation on the audio thread, ever.
+    // Buffer holds `MAX_CB_FRAMES` interleaved stereo frames = 2× that many f32s.
     let mut interleaved = [0.0f32; MAX_CB_FRAMES * 2];
-    let to_read = frames * 2;
-    let read = ring.read(&mut interleaved[..to_read]);
+
+    if frames > MAX_CB_FRAMES {
+        // Can't service this quantum from the stack scratch. Output silence
+        // for the whole callback rather than risk reading uninitialized
+        // memory or partially filling the buffers. This is the only branch
+        // that should ever fire — if it does, MAX_CB_FRAMES needs raising,
+        // but we degrade safely instead of allocating on the RT thread.
+        for i in 0..frames {
+            left[i]  = 0.0;
+            right[i] = 0.0;
+        }
+        // Best-effort log once per minute via an atomic rate-limit; no
+        // formatting allocations on the audio thread.
+        rt_log::warn_throttled("coreaudio render quantum exceeded scratch buffer");
+        return Ok(());
+    }
+
+    let want_samples = frames * 2;
+    let read = ring.read(&mut interleaved[..want_samples]);
 
     for i in 0..frames {
         if i * 2 + 1 < read {
@@ -247,7 +276,7 @@ unit.set_render_callback(move |args: render_callback::Args<f32, NonInterleaved>|
 });
 ```
 
-(Real code uses a stack-allocated `[f32; N]` sized to a known max and asserts on overflow; CoreAudio quanta are typically 256 or 512 frames.)
+The audio thread allocates **nothing**, in any build configuration. Debug builds add a `debug_assert!(frames <= MAX_CB_FRAMES)` so the overflow path is impossible-by-construction during development; release builds keep the runtime check and degrade to silence rather than allocate. The previous draft of this doc proposed a heap fallback in release — that was wrong. Heap allocation on the CoreAudio render thread can block on the system allocator and miss a deadline; silence is the correct safe degradation.
 
 ### `AudioSink::stop() -> Result<(), SinkError>`
 
@@ -259,7 +288,9 @@ unit.set_render_callback(move |args: render_callback::Args<f32, NonInterleaved>|
 
 ### `AudioSink::set_target(node_name: &str) -> Result<(), SinkError>`
 
-In v1: parse `node_name` as a hex `AudioObjectID`. If empty, route to the default output device. If non-empty, set `kAudioOutputUnitProperty_CurrentDevice` on the AudioUnit before initialization. Restart the unit if it was already running, just like the PipeWire impl does.
+`node_name` is a CoreAudio device UID — the same string returned in `AudioDevice::node_name` from `list_audio_sinks`. Empty string means "system default output".
+
+For non-empty values: translate the UID to an `AudioObjectID` via `AudioObjectGetPropertyData` with `kAudioHardwarePropertyTranslateUIDToDevice`, then set `kAudioOutputUnitProperty_CurrentDevice` on the AudioUnit before initialization. If the unit is already running, stop, reconfigure, and restart — same pattern as the PipeWire impl.
 
 The v1 SwiftUI MVP never calls this — it always uses default output. The implementation is here so the v2 device picker has nothing to add to the sink.
 
@@ -271,9 +302,13 @@ Enumerate output devices via:
 2. `AudioObjectGetPropertyData(...)` to get the `[AudioObjectID]`.
 3. For each device, query `kAudioDevicePropertyStreamConfiguration` (output scope) — keep only devices with at least one output channel.
 4. For each kept device, query `kAudioObjectPropertyName` for the display name.
-5. Always prepend a "Default" entry with empty `node_name`, matching the PipeWire impl's contract.
+5. For each kept device, query `kAudioDevicePropertyDeviceUID` and store it as `AudioDevice::node_name`. Device UIDs are stable across reboots and device add/remove cycles, unlike `AudioObjectID`s which are session-scoped.
+6. Always prepend a "Default" entry with `node_name = ""` (empty string), matching the contract that empty means "system default output" on every platform.
+7. Deduplicate: if the system default device's UID also appears in the enumerated list, skip the enumerated entry — it's already represented by the "Default" entry. Mirrors what `pw_impl.rs` does for PipeWire.
 
 This is one short function (~60 lines). It runs synchronously on the calling thread; CoreAudio property queries are cheap (no main loop needed, unlike PipeWire's enumerate-and-quit dance).
+
+`set_target` consumes the same UID strings: pass `""` for default, or any UID returned by `list_audio_sinks` to route to a specific device. The implementation translates the UID back to an `AudioObjectID` via `kAudioHardwarePropertyTranslateUIDToDevice` and sets `kAudioOutputUnitProperty_CurrentDevice` on the AudioUnit.
 
 ### `Sink::write_samples(&[Stereo]) -> Result<(), SinkError>`
 
@@ -302,15 +337,13 @@ CoreAudio is hardware-touching, so the test surface is split:
 | `coreaudio-rs` adds noticeable build time via `bindgen` | Accepted. It's a one-time cost; the alternative (raw `coreaudio-sys` + hand-rolled wrappers) is more code to own. |
 | Default output device changes mid-stream (user plugs in headphones) | `kAudioHardwarePropertyDefaultOutputDevice` listener triggers a stop+restart on the sink thread. Same UX as every other macOS app. v2-quality polish — for v1 the user reselects manually if they care. |
 | AURenderCallback fires before `running` flag is set | Set `running = true` *before* `audio_unit.start()`. Same ordering rule as the PipeWire impl. |
-| Stack-allocated render scratch buffer overflows for unusual quanta | Assert `args.num_frames * 2 <= MAX_CB_FRAMES` in debug, fall back to a heap allocation in release. CoreAudio default output rarely exceeds 1024 frames. |
+| Stack-allocated render scratch buffer overflows for unusual quanta | `MAX_CB_FRAMES = 4096` (8 KB scratch); `debug_assert!(frames <= MAX_CB_FRAMES)` in debug; release degrades to silence + a throttled tracing warn. **Never allocates on the RT thread**, even in release. CoreAudio default output rarely exceeds 1024 frames; 4096 covers aggregate/pro-audio devices. |
 | Linking against `AudioUnit.framework` and `CoreAudio.framework` requires special build flags | `coreaudio-rs` declares them via `#[link(name = "AudioUnit", kind = "framework")]`. Verified in PR 1 spike before this design is committed. |
 | Universal binary build (arm64 + x86_64) — `coreaudio-rs` cross-compiles cleanly? | Yes, the bindgen step takes the target triple from cargo. CI matrix builds both. |
 
 ## Open Questions
 
 - **Resampler choice when device rate ≠ 48 kHz:** `coreaudio-rs` exposes `audio_unit::render_callback::Resampler`, but it's `kAudioUnitType_FormatConverter` — adds another AudioUnit in the chain. Alternative: use `sdr-dsp`'s existing rational resampler upstream, in the sink, before writing to the ring. **Lean: use `sdr-dsp` resampler** because it's already in the dependency tree, well-tested, and we control its quality settings. The format converter AU adds an opaque box.
-- **What does `node_name` look like for CoreAudio devices?** Hex AudioObjectID ("0x42"), or device UID string ("BuiltInSpeakerDevice")? The UID is more stable across reboots and device-add/remove. **Lean: device UID via `kAudioDevicePropertyDeviceUID`.** AudioDevice's `node_name` field becomes the UID on macOS, the PipeWire node name on Linux. Both are caller-opaque strings.
-- **Should `list_audio_sinks` include "Default" twice if the user's actual default device shows up in the enumeration?** The PipeWire impl deduplicates by node name. We do the same on macOS by checking the default device's UID against the list and skipping it from the enumerated entries (it's already represented by the "Default" entry).
 
 ## Implementation Sequencing
 

--- a/docs/superpowers/specs/2026-04-12-coreaudio-sink-design.md
+++ b/docs/superpowers/specs/2026-04-12-coreaudio-sink-design.md
@@ -1,0 +1,342 @@
+---
+name: CoreAudio Sink — Design
+description: macOS audio output backend for sdr-sink-audio, mirroring the PipeWire implementation behind the same Sink trait
+type: spec
+---
+
+# CoreAudio Sink — Design
+
+**Status:** Draft
+**Date:** 2026-04-12
+**Parent epic:** `2026-04-12-swift-ui-macos-epic-design.md`
+**Tracking issues:** TBD
+
+---
+
+## Goal
+
+Add a CoreAudio backend to `sdr-sink-audio` so the engine can produce sound on macOS. The CoreAudio impl satisfies the existing `Sink` trait (`crates/sdr-pipeline/src/sink_manager.rs:21`), reuses the same ring-buffer pattern as the PipeWire impl, and is selected automatically on macOS via cfg gating. No changes to the trait, no changes to call sites in `sdr-core`.
+
+Without this, the SwiftUI app cannot produce audio. Everything else in the epic depends on it.
+
+## Non-Goals
+
+- **No new public crate.** This is one new file inside `sdr-sink-audio`, parallel to `pw_impl.rs`.
+- **No CoreAudio device routing/picker UI in v1.** The sink defaults to the system output device. Per-device routing exists in the trait surface (`set_target(node_name)`) but the SwiftUI MVP doesn't expose it. v2 adds a device picker.
+- **No input capture.** Sink only. Microphone capture is irrelevant — IQ comes from RTL-SDR USB, not the audio system.
+- **No format negotiation surfacing to the engine.** If the device wants 44.1 kHz instead of 48 kHz, the sink resamples internally and presents a stable 48 kHz interface upstream. The engine never sees the device rate.
+- **No exclusive mode / hog mode / pro audio APIs.** AUHAL default output unit is enough; we're not chasing sub-millisecond latency.
+
+## Background
+
+### Current state of `sdr-sink-audio`
+
+`crates/sdr-sink-audio/src/lib.rs` (39 lines) is a feature-gated facade:
+
+```text
+src/
+├── lib.rs            — cfg dispatch
+├── pw_impl.rs        — PipeWire backend (feature = "pipewire")
+└── stub_impl.rs      — no-op stub when no backend feature is on
+```
+
+`Cargo.toml` declares only the `pipewire` feature. The crate description says "PipeWire (Linux) / CoreAudio (macOS)" but the CoreAudio path **does not exist** — on macOS today the build falls through to `stub_impl.rs`, which just logs a warning and discards samples.
+
+### Why CoreAudio (and which API)
+
+macOS exposes audio through several layers:
+
+| API | Latency | Complexity | Fits us? |
+|-----|---------|------------|----------|
+| **AVAudioEngine** (high-level) | ~20 ms | Low | Tempting, but it's tied into the Objective-C runtime, has Swift idioms baked in, and is a poor citizen for a C-Rust process. Hidden allocations on the audio thread. |
+| **AudioUnit / AUHAL** (mid-level) | ~3-5 ms | Medium | **Yes.** This is the C API. Stable since 10.0, statically linkable, deterministic callbacks, no hidden runtime. Mirrors how the PipeWire impl works. |
+| **AudioQueue** (legacy) | ~30 ms | Low | Deprecated for new code. |
+| **CoreHaptics-style HAL** (low-level IOKit) | <1 ms | Very high | Overkill for SDR audio. |
+
+We use **AudioUnit / AUHAL output unit** (`kAudioUnitSubType_DefaultOutput`). It's the same surface SDR++ uses on macOS, the same surface most DAWs use for output, and it's straight C — no Objective-C bridging needed from Rust.
+
+### Crate choice for the binding
+
+Two real options for accessing CoreAudio from Rust:
+
+1. **`coreaudio-rs`** (~0.12, well-maintained, last release 2024) — high-level wrapper around AUHAL. Pros: idiomatic, handles callback registration safely. Cons: another dep, drags in `coreaudio-sys` and bindgen build cost.
+2. **`coreaudio-sys`** directly — raw bindgen output. Pros: minimal. Cons: every callback is unsafe and we'd write all the safety wrappers ourselves.
+
+**Choice: `coreaudio-rs`.** The audio path is performance-critical but not so unusual that the high-level wrapper gets in the way, and we'd otherwise be re-implementing what `coreaudio-rs` already gets right (non-interleaved buffer handling, format struct construction, error propagation). Both crates are 1st-party from the `RustAudio` org.
+
+## Crate Layout Change
+
+```text
+crates/sdr-sink-audio/
+├── Cargo.toml                    — adds `coreaudio` feature + macOS target deps
+└── src/
+    ├── lib.rs                    — cfg dispatch updated
+    ├── pw_impl.rs                — unchanged (Linux)
+    ├── coreaudio_impl.rs         — NEW (macOS)
+    └── stub_impl.rs              — unchanged (fallback)
+```
+
+`Cargo.toml`:
+
+```toml
+[features]
+default = []
+pipewire  = ["dep:pipewire"]
+coreaudio = ["dep:coreaudio-rs"]
+
+[dependencies]
+sdr-types.workspace      = true
+sdr-pipeline.workspace   = true
+sdr-config.workspace     = true
+thiserror.workspace      = true
+tracing.workspace        = true
+pipewire = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+coreaudio-rs = { version = "0.12", optional = true }
+```
+
+`lib.rs`:
+
+```rust
+#[cfg(all(target_os = "linux", feature = "pipewire"))]
+mod pw_impl;
+#[cfg(all(target_os = "linux", feature = "pipewire"))]
+pub use pw_impl::{AudioDevice, AudioSink, list_audio_sinks};
+
+#[cfg(all(target_os = "macos", feature = "coreaudio"))]
+mod coreaudio_impl;
+#[cfg(all(target_os = "macos", feature = "coreaudio"))]
+pub use coreaudio_impl::{AudioDevice, AudioSink, list_audio_sinks};
+
+// Fallback for any build without a real backend (used by CI on non-Linux/non-macOS,
+// or when both feature flags are disabled).
+#[cfg(not(any(
+    all(target_os = "linux", feature = "pipewire"),
+    all(target_os = "macos", feature = "coreaudio"),
+)))]
+mod stub_impl;
+#[cfg(not(any(
+    all(target_os = "linux", feature = "pipewire"),
+    all(target_os = "macos", feature = "coreaudio"),
+)))]
+pub use stub_impl::{AudioDevice, AudioSink, list_audio_sinks};
+```
+
+`sdr-core/Cargo.toml` enables the right feature per target:
+
+```toml
+[target.'cfg(target_os = "linux")'.dependencies]
+sdr-sink-audio = { workspace = true, features = ["pipewire"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+sdr-sink-audio = { workspace = true, features = ["coreaudio"] }
+```
+
+This is the only place the cfg fork lives. All callers see the same `AudioSink` type.
+
+## API Parity with PipeWire Impl
+
+The CoreAudio impl exposes **exactly** the same surface as `pw_impl.rs`:
+
+```rust
+pub struct AudioSink { /* CoreAudio-internal state */ }
+pub struct AudioDevice {
+    pub display_name: String,
+    pub node_name: String,         // we re-purpose this for AudioObjectID hex on macOS
+}
+
+impl AudioSink {
+    pub fn new() -> Self;
+    pub fn set_target(&mut self, node_name: &str) -> Result<(), SinkError>;
+    pub fn write_samples(&mut self, samples: &[Stereo]) -> Result<(), SinkError>;
+}
+
+impl Sink for AudioSink {
+    fn name(&self) -> &str;        // returns "Audio"
+    fn start(&mut self) -> Result<(), SinkError>;
+    fn stop(&mut self) -> Result<(), SinkError>;
+    fn set_sample_rate(&mut self, rate: f64) -> Result<(), SinkError>;
+    fn sample_rate(&self) -> f64;
+}
+
+pub fn list_audio_sinks() -> Vec<AudioDevice>;
+```
+
+The DSP controller in `sdr-core` doesn't know which backend it has. `cargo build --target aarch64-apple-darwin` produces one; `cargo build --target x86_64-unknown-linux-gnu` produces the other.
+
+## Internal Architecture
+
+```text
+write_samples(&[Stereo])  ──▶  interleave to f32 LRLRLR
+                              │
+                              ▼
+              ┌────────────────────────────────┐
+              │  AudioRingBuffer (lock-based)  │   reused verbatim from pw_impl
+              │  capacity = ~1 sec @ 48 kHz    │   (extracted into a shared module)
+              └────────────────────────────────┘
+                              │
+                              │  AURenderCallback (CoreAudio I/O thread)
+                              ▼
+              ┌────────────────────────────────┐
+              │  ring.read() → AudioBufferList │
+              │  (with optional resample)      │
+              └────────────────────────────────┘
+                              │
+                              ▼
+                   Default output device
+```
+
+**Reuse the ring buffer.** `AudioRingBuffer` in `pw_impl.rs` (lines 36–110) is generic over interleaved f32 — it has nothing PipeWire-specific. We extract it into a private `crates/sdr-sink-audio/src/ring.rs` module shared by both backends. This is a one-line refactor in PR 1 of this work series and lets the CoreAudio impl land in PR 2 with no new ring buffer code.
+
+**One thread, owned by CoreAudio.** Unlike PipeWire (which spawns a `pw-audio` mainloop thread we own), CoreAudio gives us a `RemoteIO`-style render callback fired from its own audio I/O thread. We don't manage the thread. The callback reads from the ring buffer and copies into the AudioUnit's `AudioBufferList`. Underrun = silence. No locks held longer than the memcpy.
+
+**Sample-rate negotiation.** On `start()`:
+
+1. Open the default output unit (`AUHAL`, subType `kAudioUnitSubType_DefaultOutput`).
+2. Query the device's nominal sample rate via `AudioObjectGetPropertyData(kAudioDevicePropertyNominalSampleRate)`.
+3. If the device rate matches the engine rate (48 kHz), set the AudioUnit's input format to 48 kHz f32 stereo non-interleaved (CoreAudio prefers non-interleaved for AUHAL output) and we're done.
+4. If they differ (e.g., user has the device set to 44.1 kHz), set the AudioUnit's input format to **the device rate** and use a `coreaudio::audio_unit::render_callback::ResamplingRenderCallback` (or a hand-rolled linear interpolator — see *Open Questions* below) to convert from 48 kHz on the way in.
+
+The engine never sees the device rate. `Sink::sample_rate()` always returns 48 kHz. This matches what `pw_impl.rs` does (PipeWire negotiates at 48 kHz unconditionally because the daemon does any required SRC).
+
+**Volume.** AudioUnit has its own gain property (`kHALOutputParam_Volume`). We don't use it — volume is applied upstream in `RadioModule` already (via `UiToDsp::SetVolume`), so the sink just renders whatever the engine hands it. Same as the PipeWire impl.
+
+## Public Functions Detail
+
+### `AudioSink::new() -> Self`
+
+- Allocates the ring buffer (96k samples = ~1 sec at 48 kHz stereo).
+- Allocates the interleave buffer.
+- Does **not** open the AudioUnit. That happens in `start()`.
+- Mirrors `pw_impl.rs` line 229.
+
+### `AudioSink::start() -> Result<(), SinkError>`
+
+1. If already running, return `SinkError::AlreadyRunning`.
+2. Construct an `AudioUnit` for `kAudioUnitSubType_DefaultOutput` via `coreaudio::audio_unit::AudioUnit::new(IOType::DefaultOutput)`.
+3. Determine the format: query device rate, decide whether to enable internal resampling.
+4. Set the input format on the unit (LinearPCM, f32, stereo, non-interleaved).
+5. Register the render callback (closure capturing `Arc<AudioRingBuffer>`).
+6. Initialize the unit, start it.
+7. Store the `AudioUnit` and the running flag. Return `Ok`.
+
+The render callback signature is roughly:
+
+```rust
+unit.set_render_callback(move |args: render_callback::Args<f32, NonInterleaved>| {
+    let frames = args.num_frames;
+    // args.data is &mut [&mut [f32]] — one slice per channel
+    let mut left  = args.data[0];
+    let mut right = args.data[1];
+
+    let mut interleaved = [0.0f32; MAX_CB_FRAMES * 2];
+    let to_read = frames * 2;
+    let read = ring.read(&mut interleaved[..to_read]);
+
+    for i in 0..frames {
+        if i * 2 + 1 < read {
+            left[i]  = interleaved[i * 2];
+            right[i] = interleaved[i * 2 + 1];
+        } else {
+            left[i]  = 0.0;
+            right[i] = 0.0;
+        }
+    }
+    Ok(())
+});
+```
+
+(Real code uses a stack-allocated `[f32; N]` sized to a known max and asserts on overflow; CoreAudio quanta are typically 256 or 512 frames.)
+
+### `AudioSink::stop() -> Result<(), SinkError>`
+
+1. If not running, return `SinkError::NotRunning`.
+2. Call `audio_unit.stop()`.
+3. Drop the `AudioUnit` (uninitializes and disposes).
+4. Clear the running flag.
+5. Drain the ring buffer.
+
+### `AudioSink::set_target(node_name: &str) -> Result<(), SinkError>`
+
+In v1: parse `node_name` as a hex `AudioObjectID`. If empty, route to the default output device. If non-empty, set `kAudioOutputUnitProperty_CurrentDevice` on the AudioUnit before initialization. Restart the unit if it was already running, just like the PipeWire impl does.
+
+The v1 SwiftUI MVP never calls this — it always uses default output. The implementation is here so the v2 device picker has nothing to add to the sink.
+
+### `list_audio_sinks() -> Vec<AudioDevice>`
+
+Enumerate output devices via:
+
+1. `AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, kAudioHardwarePropertyDevices)` to get the count.
+2. `AudioObjectGetPropertyData(...)` to get the `[AudioObjectID]`.
+3. For each device, query `kAudioDevicePropertyStreamConfiguration` (output scope) — keep only devices with at least one output channel.
+4. For each kept device, query `kAudioObjectPropertyName` for the display name.
+5. Always prepend a "Default" entry with empty `node_name`, matching the PipeWire impl's contract.
+
+This is one short function (~60 lines). It runs synchronously on the calling thread; CoreAudio property queries are cheap (no main loop needed, unlike PipeWire's enumerate-and-quit dance).
+
+### `Sink::write_samples(&[Stereo]) -> Result<(), SinkError>`
+
+Identical to `pw_impl.rs` line 268: interleave into the pre-allocated buffer, write to the ring. No CoreAudio call here.
+
+## Test Strategy
+
+CoreAudio is hardware-touching, so the test surface is split:
+
+**Pure unit tests** (run on every CI, no audio device required):
+- `AudioRingBuffer` round-trip (already covered in `pw_impl.rs` tests; the extracted module brings them along).
+- `list_audio_sinks` returns at least one entry on a macOS CI runner. The runner has a "Null Audio Output Device" by default, so this is safe.
+- Format-struct construction: build the `AudioStreamBasicDescription` for 48 kHz f32 stereo and verify field-by-field. No hardware needed.
+
+**Hardware-touching tests** (run only when `RTLSDR_TEST_HARDWARE=1` and on macOS):
+- `start()` opens the default output, writes 1 second of a 1 kHz sine, `stop()` cleanly. Audible verification by the developer; CI just asserts no error returned and no panic.
+- Sample-rate mismatch: temporarily switch the device to 44.1 kHz (via `audiodevice` CLI in the test helper), start the sink, verify the resampling path runs without underruns over 5 seconds.
+
+**Behavior parity test** (cross-platform, runs on every CI):
+- Build a small test harness that uses `Sink` trait methods only and runs against whichever backend the platform compiles. Verifies `start → write 5s → stop` returns no error and `sample_rate()` reports 48 kHz before and after. Run on Linux with `--features pipewire` and on macOS with `--features coreaudio`. This locks in trait-level parity.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `coreaudio-rs` adds noticeable build time via `bindgen` | Accepted. It's a one-time cost; the alternative (raw `coreaudio-sys` + hand-rolled wrappers) is more code to own. |
+| Default output device changes mid-stream (user plugs in headphones) | `kAudioHardwarePropertyDefaultOutputDevice` listener triggers a stop+restart on the sink thread. Same UX as every other macOS app. v2-quality polish — for v1 the user reselects manually if they care. |
+| AURenderCallback fires before `running` flag is set | Set `running = true` *before* `audio_unit.start()`. Same ordering rule as the PipeWire impl. |
+| Stack-allocated render scratch buffer overflows for unusual quanta | Assert `args.num_frames * 2 <= MAX_CB_FRAMES` in debug, fall back to a heap allocation in release. CoreAudio default output rarely exceeds 1024 frames. |
+| Linking against `AudioUnit.framework` and `CoreAudio.framework` requires special build flags | `coreaudio-rs` declares them via `#[link(name = "AudioUnit", kind = "framework")]`. Verified in PR 1 spike before this design is committed. |
+| Universal binary build (arm64 + x86_64) — `coreaudio-rs` cross-compiles cleanly? | Yes, the bindgen step takes the target triple from cargo. CI matrix builds both. |
+
+## Open Questions
+
+- **Resampler choice when device rate ≠ 48 kHz:** `coreaudio-rs` exposes `audio_unit::render_callback::Resampler`, but it's `kAudioUnitType_FormatConverter` — adds another AudioUnit in the chain. Alternative: use `sdr-dsp`'s existing rational resampler upstream, in the sink, before writing to the ring. **Lean: use `sdr-dsp` resampler** because it's already in the dependency tree, well-tested, and we control its quality settings. The format converter AU adds an opaque box.
+- **What does `node_name` look like for CoreAudio devices?** Hex AudioObjectID ("0x42"), or device UID string ("BuiltInSpeakerDevice")? The UID is more stable across reboots and device-add/remove. **Lean: device UID via `kAudioDevicePropertyDeviceUID`.** AudioDevice's `node_name` field becomes the UID on macOS, the PipeWire node name on Linux. Both are caller-opaque strings.
+- **Should `list_audio_sinks` include "Default" twice if the user's actual default device shows up in the enumeration?** The PipeWire impl deduplicates by node name. We do the same on macOS by checking the default device's UID against the list and skipping it from the enumerated entries (it's already represented by the "Default" entry).
+
+## Implementation Sequencing
+
+This work happens as **two PRs** that can land before, alongside, or after the `sdr-core` extraction (no hard ordering dependency):
+
+### PR A — Extract shared `AudioRingBuffer` into `crates/sdr-sink-audio/src/ring.rs`
+
+- Move the type from `pw_impl.rs` to `ring.rs`.
+- Update `pw_impl.rs` to import from `crate::ring`.
+- All existing tests still pass, no behavior change.
+- Diff: tiny. Makes PR B reviewable in isolation.
+
+### PR B — `coreaudio_impl.rs`
+
+- New file, ~400 lines.
+- New `coreaudio` feature + `coreaudio-rs` target dep.
+- `lib.rs` cfg dispatch updated.
+- Hardware-gated tests added.
+- CI matrix gains a `macos-26` job that builds with `--features coreaudio` (build-only, no run, since GitHub macOS runners don't have a real audio device but the build has to succeed).
+
+Once both land, `sdr-core` enables the right feature automatically per target_os and the rest of the epic can assume audio works on macOS.
+
+## References
+
+- `crates/sdr-sink-audio/src/pw_impl.rs:114-289` — the shape we're mirroring
+- `crates/sdr-pipeline/src/sink_manager.rs:21-36` — `Sink` trait, unchanged
+- [`coreaudio-rs` examples](https://github.com/RustAudio/coreaudio-rs/tree/master/examples) — sine-wave output, render callback patterns
+- [Apple AUHAL docs](https://developer.apple.com/library/archive/technotes/tn2091/_index.html) — older but still authoritative
+- `2026-04-12-sdr-core-extraction-design.md` — consumer of this sink

--- a/docs/superpowers/specs/2026-04-12-sdr-core-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-12-sdr-core-extraction-design.md
@@ -1,0 +1,244 @@
+---
+name: sdr-core Facade Extraction — Design
+description: Carve a headless `sdr-core` crate that owns the DSP controller and exposes a single Rust API consumed by both GTK and SwiftUI frontends
+type: spec
+---
+
+# `sdr-core` Facade Extraction — Design
+
+**Status:** Draft
+**Date:** 2026-04-12
+**Parent epic:** `2026-04-12-swift-ui-macos-epic-design.md`
+**Tracking issues:** TBD
+
+---
+
+## Goal
+
+Extract the engine state and lifecycle currently owned by `crates/sdr-ui/src/dsp_controller.rs` into a new headless crate, **`sdr-core`**, with a clean Rust API. After this refactor:
+
+- `sdr-core` owns the DSP thread, the source manager, the sink manager, the IQ frontend, the radio module, and the message channels.
+- `sdr-ui` (GTK) becomes a *consumer* of `sdr-core` instead of a containing host. Its `dsp_controller.rs` shrinks to a thin GTK glue layer that subscribes to events on the GTK main loop.
+- A second consumer (`sdr-ffi` for SwiftUI) can be added in a follow-up PR series **without touching `sdr-ui`** because both frontends sit on the same crate.
+
+This is a **behavior-preserving refactor**. No new features, no observable behavior change for GTK users. `cargo test --workspace` and clippy stay green throughout.
+
+## Non-Goals
+
+- **No FFI in this PR series.** The C ABI lives in a separate `sdr-ffi` crate, designed in `2026-04-12-sdr-ffi-c-abi-design.md`. `sdr-core` is pure Rust.
+- **No message enum redesign.** Variant names, fields, and semantics stay byte-identical to today's `UiToDsp`/`DspToUi`. The enums physically move from `sdr-ui` to `sdr-core` and re-export to `sdr-ui` so its existing match arms compile unchanged.
+- **No new crate boundaries below `sdr-core`.** `sdr-pipeline`, `sdr-radio`, `sdr-dsp`, etc. are unchanged. We're moving one file's worth of orchestration up into a new crate, not reshuffling the workspace.
+- **No transcription in `sdr-core`.** The transcription backend trait is being rebuilt in a parallel session. We leave transcription wired through `sdr-ui` exactly as it is today (UI-side `EnableTranscription(SyncSender<Vec<f32>>)` channel still works) and revisit after that session declares stability. See *Risks* below.
+- **No async runtime.** Engine remains thread-based with `mpsc` channels internally. The FFI layer will translate to async on the Swift side; `sdr-core` itself stays sync to keep both consumers honest.
+
+## Background
+
+### Where the orchestration lives today
+
+`crates/sdr-ui/src/dsp_controller.rs` (1230 lines) is the de-facto engine entry point. It:
+
+1. Spawns the `dsp-controller` background thread (`spawn_dsp_thread`).
+2. Owns `RtlSdrSource`, `IqFrontend`, `RxVfo`, `RadioModule`, `AudioSink`, `WavWriter`s, the active source enum, all DSP config state, and the FFT shared buffer.
+3. Polls `ui_rx: mpsc::Receiver<UiToDsp>` for commands, reads IQ samples, processes the signal path, writes audio, and pushes FFT frames into `SharedFftBuffer`.
+4. Sends status events back over `dsp_tx: mpsc::Sender<DspToUi>`.
+
+The GTK side (`crates/sdr-ui/src/window.rs`) creates the channels, calls `spawn_dsp_thread`, then registers a GLib timeout that reads `dsp_rx` and pumps events into widgets.
+
+### Why this is the wrong place for it
+
+- **It's not GTK-specific.** Nothing in `dsp_controller.rs` touches GTK. The only reason it lives in `sdr-ui` is historical — that's where the channels were first created.
+- **A second frontend can't import it.** A SwiftUI host would need to either depend on `sdr-ui` (which pulls in GTK4 + libadwaita), or duplicate the orchestration. Both are wrong.
+- **The test surface is mixed.** Engine logic and UI glue share a crate, so engine tests pull `gtk4` into `dev-dependencies`.
+
+### Why a *facade* crate, not a feature flag on `sdr-pipeline`
+
+Considered: add a `controller` module to `sdr-pipeline` and gate it behind a feature. Rejected because:
+- `sdr-pipeline` deliberately stays at "pipeline primitives" — `Source`/`Sink` traits, `IqFrontend`, `RxVfo`, channel manager. It doesn't own a thread, and we like that.
+- The orchestration crate also needs to depend on `sdr-radio`, `sdr-source-rtlsdr`, `sdr-source-network`, `sdr-source-file`, `sdr-sink-audio`, and `sdr-sink-network`. Putting that dependency tree on `sdr-pipeline` would invert the layering.
+- A separate `sdr-core` keeps `sdr-pipeline` clean for any future tooling that wants to consume primitives without the whole engine.
+
+## Crate Layout
+
+```text
+crates/sdr-core/
+├── Cargo.toml
+└── src/
+    ├── lib.rs              — public API surface, re-exports
+    ├── engine.rs           — Engine struct: lifecycle (new, start, stop, send_command, subscribe)
+    ├── controller.rs       — DSP thread loop (moved verbatim from sdr-ui/src/dsp_controller.rs)
+    ├── messages.rs         — UiToDsp / DspToUi enums (moved from sdr-ui)
+    ├── fft_buffer.rs       — SharedFftBuffer (moved from sdr-ui)
+    ├── wav_writer.rs       — WavWriter (moved from sdr-ui — used by controller for recordings)
+    ├── source_factory.rs   — registers RTL-SDR / network / file sources into SourceManager
+    └── sink_factory.rs     — registers audio + network sinks into SinkManager
+```
+
+**`crates/sdr-core/Cargo.toml` dependencies:**
+
+```toml
+[dependencies]
+sdr-types.workspace = true
+sdr-config.workspace = true
+sdr-dsp.workspace = true
+sdr-pipeline.workspace = true
+sdr-radio.workspace = true
+sdr-rtlsdr.workspace = true
+sdr-source-rtlsdr.workspace = true
+sdr-source-network.workspace = true
+sdr-source-file.workspace = true
+sdr-sink-audio.workspace = true
+sdr-sink-network.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+hound.workspace = true
+```
+
+**`crates/sdr-ui/Cargo.toml` after the move:**
+
+```toml
+[dependencies]
+sdr-core = { path = "../sdr-core" }   # NEW
+# removed: direct deps on sdr-pipeline, sdr-radio, sdr-source-rtlsdr,
+#          sdr-source-network, sdr-source-file, sdr-sink-audio, sdr-sink-network,
+#          hound (those are now transitive via sdr-core)
+# kept: sdr-types, sdr-config, sdr-dsp (still touched by GTK plotting code)
+gtk4 = "..."
+adw = "..."
+# ...rest of GTK stack unchanged
+```
+
+## Public API
+
+The `Engine` struct is the entire public surface. It is `Send + Sync` (commands and event reads can come from any thread).
+
+```rust
+// crates/sdr-core/src/engine.rs
+
+use std::sync::{Arc, mpsc};
+use crate::fft_buffer::SharedFftBuffer;
+use crate::messages::{DspToUi, UiToDsp};
+
+/// The headless SDR engine. One instance per app.
+pub struct Engine {
+    cmd_tx: mpsc::Sender<UiToDsp>,
+    evt_rx: mpsc::Receiver<DspToUi>,           // sole owner; see `subscribe`
+    fft: Arc<SharedFftBuffer>,
+    join: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Engine {
+    /// Build, register sources/sinks, spawn the DSP thread, return.
+    /// Does NOT start the source — call `send_command(UiToDsp::Start)` for that.
+    ///
+    /// `config_path` is where settings are loaded from at boot and persisted to.
+    /// On macOS this is typically `~/Library/Application Support/SDRMac/config.json`;
+    /// on Linux it's `$XDG_CONFIG_HOME/sdr-rs/config.json`. The host decides.
+    pub fn new(config_path: std::path::PathBuf) -> Result<Self, EngineError> { ... }
+
+    /// Send a command to the DSP thread. Non-blocking.
+    pub fn send_command(&self, cmd: UiToDsp) -> Result<(), EngineError> { ... }
+
+    /// Take the event receiver. Can only be called once.
+    /// The caller chooses how to drain it (GTK timeout, FFI callback, async task, ...).
+    pub fn subscribe(&mut self) -> Option<mpsc::Receiver<DspToUi>> { ... }
+
+    /// Pull a snapshot of the latest FFT frame, if a new one is ready since
+    /// the last call. Lock-free check; locks only when reading the buffer.
+    /// Returns false and doesn't call `f` if no new frame.
+    pub fn pull_fft<F: FnOnce(&[f32])>(&self, f: F) -> bool {
+        self.fft.take_if_ready(f)
+    }
+
+    /// Block-and-stop. Idempotent.
+    pub fn shutdown(self) -> Result<(), EngineError> { ... }
+}
+```
+
+**Event flow remains channel-based.** `subscribe()` hands the receiver to whoever wants it: GTK polls it from a `glib::timeout_add_local`; the FFI crate spawns its own dispatcher thread that calls a C callback. Neither model is hard-coded into `sdr-core`.
+
+**FFT delivery is pull-based.** The DSP thread writes into `SharedFftBuffer` and sets a flag; the consumer drains via `pull_fft`. This is exactly how `dsp_controller.rs` works today (lines 77–111), just relocated. It avoids the per-frame `Vec<f32>` allocation that the `DspToUi::FftData` channel variant would otherwise cause.
+
+> **Note on `DspToUi::FftData`:** the variant stays in the enum for backward compatibility but `sdr-core` *does not emit it*. FFT data goes through `pull_fft` exclusively. This is consistent with what `dsp_controller.rs` already does (the channel-based path was deprecated in favor of `SharedFftBuffer`). The variant gets removed in a follow-up after both consumers confirm they don't need it.
+
+## Migration Plan
+
+The extraction is done in **three sequential PRs** so each one is small and reviewable. CodeRabbit will see narrow diffs.
+
+### PR 1 — Create `sdr-core` skeleton (no behavior change yet)
+
+- Add `crates/sdr-core/` to the workspace.
+- Move `crates/sdr-ui/src/messages.rs` → `crates/sdr-core/src/messages.rs`. Re-export from `sdr-ui` so `crate::messages::UiToDsp` still resolves.
+- Move `crates/sdr-ui/src/wav_writer.rs` → `crates/sdr-core/src/wav_writer.rs`. Same re-export.
+- Move `SharedFftBuffer` from `dsp_controller.rs` → `crates/sdr-core/src/fft_buffer.rs`. Re-export.
+- `sdr-core` exposes nothing else yet.
+- `sdr-ui` adds `sdr-core` as a dependency.
+- **Acceptance:** `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --all-targets --workspace -- -D warnings` all pass with zero source changes outside the moved files and the new re-exports.
+
+### PR 2 — Move the controller into `sdr-core`
+
+- Move `crates/sdr-ui/src/dsp_controller.rs` → `crates/sdr-core/src/controller.rs`.
+- Add `crates/sdr-core/src/engine.rs` with the `Engine` struct as specified above. `Engine::new` does what `Window::new` does today: creates channels, builds the `SharedFftBuffer`, registers sources via the source factory, registers sinks via the sink factory, calls `spawn_dsp_thread`.
+- Add `crates/sdr-core/src/source_factory.rs` and `sink_factory.rs` — pure functions that build a `SourceManager`/`SinkManager` populated with the project's stock sources and sinks.
+- `sdr-ui/src/dsp_controller.rs` becomes a stub that re-exports `sdr_core::Engine` and adds the GTK-specific event-pump glue (the `glib::timeout_add_local` loop that drains the event channel and calls into `Window`).
+- `sdr-ui/src/window.rs` constructs an `Engine` instead of calling `spawn_dsp_thread` directly. The `cmd_tx`/`evt_rx`/`fft_shared` fields are replaced by an `Arc<Engine>`.
+- **Acceptance:** the GTK app launches, tunes a station, demods audio, FFT updates render, recording start/stop works, source switching works, and `make lint` is clean.
+
+### PR 3 — Carve out transcription glue
+
+- Transcription is currently wired through `UiToDsp::EnableTranscription(SyncSender<Vec<f32>>)`. The DSP controller forwards demod samples into that sender. The sender lifecycle is currently owned by `sdr-ui/src/window.rs`.
+- Because the parallel session is reshaping `sdr-transcription`, we don't refactor it into `sdr-core` here. We just confirm the existing variant continues to work after PRs 1+2: GTK creates the `SyncSender`, sends it through the engine's command channel, the controller forwards audio to it. **Zero functional change.**
+- **Acceptance:** transcript panel still emits text on the GTK side. Add a regression test that constructs an engine, sends `EnableTranscription` with a test sender, and asserts samples arrive.
+
+After these three PRs land, `sdr-ui` is structurally a "consumer" and the `sdr-ffi` PR series can begin in parallel without touching GTK code.
+
+## Threading Model (unchanged)
+
+Identical to today, just owned by a different crate:
+
+```text
+                        ┌─────────────────┐
+   host UI thread ─────▶│  Engine.send_   │──▶ mpsc ──▶ ┌──────────────┐
+   (GTK / SwiftUI)      │  command()      │            │  DSP thread  │
+                        └─────────────────┘            │              │
+                                                       │ • SourceMgr  │
+                        ┌─────────────────┐            │ • IqFrontend │
+   host UI thread ◀────│ subscribed       │◀── mpsc ──│ • RxVfo      │
+                        │ DspToUi receiver│            │ • RadioModule│
+                        └─────────────────┘            │ • AudioSink  │
+                                                       │ • WavWriters │
+                        ┌─────────────────┐            └──────┬───────┘
+   host render tick ───▶│ Engine.pull_fft │────────────────────┘
+   (GTK / MTKView)      │                 │   (SharedFftBuffer)
+                        └─────────────────┘
+```
+
+The DSP thread is the sole writer of engine state. All hosts go through the command channel; no host ever holds a reference to the controller. This is what makes the FFI safe later — there is exactly one mutex-free path into the engine.
+
+## Test Strategy
+
+- **Unit tests for `Engine`:** construct an engine with a `MockSource` (already exists in `source_manager.rs` tests), drive it with a sequence of commands, assert events arrive on the receiver. These tests do *not* touch GTK or any UI code.
+- **Regression tests:** every test currently in `sdr-ui/src/dsp_controller.rs`'s `#[cfg(test)] mod tests` moves to `sdr-core/src/controller.rs` and must continue to pass without modification.
+- **Behavior-preservation gate for PR 2:** before merging, manually launch the GTK app and walk through this checklist (the same set as the transcription-trait refactor):
+  - Tune to FM 100.7 → audio
+  - Switch to network source → no panic, error surfaces in UI
+  - Start IQ recording → file written, stop → finalized
+  - Click on the waterfall → VFO moves, audio retunes
+  - Quit cleanly (no thread leaks visible in `Activity Monitor`)
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Parallel sherpa-onnx work edits `dsp_controller.rs` mid-extraction | Land PR 1 within a day of starting. Coordinate via GitHub: open the extraction PRs first, then ask the other session to rebase. The transcription work touches `sdr-transcription` primarily, so the merge surface in `dsp_controller.rs` is small. |
+| Re-export gymnastics confuse `cargo doc` / IDE go-to-def | Re-exports are one line each; we accept the tradeoff for the one-PR window where both old and new paths resolve. After PR 2, GTK callers update to the canonical `sdr_core::messages::*` paths and re-exports go away. |
+| `Engine::subscribe` returning `Option<Receiver>` is awkward for callers that want a "broadcast" model later | Acceptable for v1: GTK is a single subscriber, FFI is a single subscriber, and they live in different processes/builds. If we ever need multi-subscriber, replace `mpsc::Receiver` with a `tokio::sync::broadcast` or hand-rolled fan-out. Out of scope here. |
+| `sdr-core` accidentally pulls in `pipewire` on macOS through `sdr-sink-audio` | `sdr-sink-audio` is feature-gated (`pipewire` feature off by default). The CoreAudio sink design (`2026-04-12-coreaudio-sink-design.md`) keeps this gate intact and adds a `coreaudio` feature on the same crate. `sdr-core` enables one or the other via target_os cfg. |
+
+## References
+
+- `crates/sdr-ui/src/dsp_controller.rs` — current orchestration to be moved
+- `crates/sdr-ui/src/messages.rs` — message enums to be moved
+- `crates/sdr-ui/src/window.rs:1-200` — current channel construction site to be replaced with `Engine::new`
+- `crates/sdr-pipeline/src/source_manager.rs` — `Source` trait, unchanged
+- `crates/sdr-pipeline/src/sink_manager.rs` — `Sink` trait, unchanged
+- `docs/superpowers/specs/2026-04-12-sdr-ffi-c-abi-design.md` — what consumes `sdr-core` next

--- a/docs/superpowers/specs/2026-04-12-sdr-core-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-12-sdr-core-extraction-design.md
@@ -109,21 +109,26 @@ adw = "..."
 
 ## Public API
 
-The `Engine` struct is the entire public surface. It is `Send + Sync` (commands and event reads can come from any thread).
+The `Engine` struct is the entire public surface. It is `Send + Sync` so consumers can hold it in an `Arc` and call commands from any thread.
+
+`std::sync::mpsc::Receiver<T>` is `Send` but **not** `Sync`, so the receiver can't sit naked in a field on a `Sync` type. We wrap it in `Mutex<Option<...>>`: the option lets `subscribe` *take* the receiver out (it's a one-shot — only one consumer drains it), and the mutex satisfies `Sync` while the option is still occupied. After `subscribe` returns the receiver to the caller, all subsequent calls return `None`.
 
 ```rust
 // crates/sdr-core/src/engine.rs
 
-use std::sync::{Arc, mpsc};
+use std::sync::{Arc, Mutex, mpsc};
 use crate::fft_buffer::SharedFftBuffer;
 use crate::messages::{DspToUi, UiToDsp};
 
-/// The headless SDR engine. One instance per app.
+/// The headless SDR engine. One instance per app. Send + Sync — consumers
+/// can hold it in an Arc and dispatch commands from any thread.
 pub struct Engine {
     cmd_tx: mpsc::Sender<UiToDsp>,
-    evt_rx: mpsc::Receiver<DspToUi>,           // sole owner; see `subscribe`
+    /// One-shot subscription slot. `subscribe()` takes the receiver out.
+    /// Wrapped in Mutex<Option<...>> because mpsc::Receiver is !Sync.
+    evt_rx: Mutex<Option<mpsc::Receiver<DspToUi>>>,
     fft: Arc<SharedFftBuffer>,
-    join: Option<std::thread::JoinHandle<()>>,
+    join: Mutex<Option<std::thread::JoinHandle<()>>>,
 }
 
 impl Engine {
@@ -135,12 +140,15 @@ impl Engine {
     /// on Linux it's `$XDG_CONFIG_HOME/sdr-rs/config.json`. The host decides.
     pub fn new(config_path: std::path::PathBuf) -> Result<Self, EngineError> { ... }
 
-    /// Send a command to the DSP thread. Non-blocking.
+    /// Send a command to the DSP thread. Non-blocking. Safe from any thread.
     pub fn send_command(&self, cmd: UiToDsp) -> Result<(), EngineError> { ... }
 
-    /// Take the event receiver. Can only be called once.
-    /// The caller chooses how to drain it (GTK timeout, FFI callback, async task, ...).
-    pub fn subscribe(&mut self) -> Option<mpsc::Receiver<DspToUi>> { ... }
+    /// Take the event receiver. Returns `Some(_)` exactly once per Engine;
+    /// every subsequent call returns `None`. The caller chooses how to drain
+    /// it (GTK timeout, FFI dispatcher thread, async task, …).
+    pub fn subscribe(&self) -> Option<mpsc::Receiver<DspToUi>> {
+        self.evt_rx.lock().ok()?.take()
+    }
 
     /// Pull a snapshot of the latest FFT frame, if a new one is ready since
     /// the last call. Lock-free check; locks only when reading the buffer.
@@ -149,9 +157,17 @@ impl Engine {
         self.fft.take_if_ready(f)
     }
 
-    /// Block-and-stop. Idempotent.
-    pub fn shutdown(self) -> Result<(), EngineError> { ... }
+    /// Block-and-stop. Idempotent. Joins the DSP thread; safe to call from
+    /// any thread, but NOT from within the event-receiver loop (would deadlock).
+    pub fn shutdown(&self) -> Result<(), EngineError> { ... }
 }
+
+// SAFETY: All fields are Send + Sync:
+//  - mpsc::Sender<T> is Send + Sync
+//  - Mutex<Option<...>> is Send + Sync when T: Send
+//  - Arc<SharedFftBuffer> is Send + Sync (SharedFftBuffer uses internal Mutex+Atomic)
+// So Engine: Send + Sync is auto-derived; this comment exists to justify the
+// public claim if a future field threatens it.
 ```
 
 **Event flow remains channel-based.** `subscribe()` hands the receiver to whoever wants it: GTK polls it from a `glib::timeout_add_local`; the FFI crate spawns its own dispatcher thread that calls a C callback. Neither model is hard-coded into `sdr-core`.

--- a/docs/superpowers/specs/2026-04-12-sdr-ffi-c-abi-design.md
+++ b/docs/superpowers/specs/2026-04-12-sdr-ffi-c-abi-design.md
@@ -411,15 +411,24 @@ public final class SdrCore {
 
     /// Render-tick FFT pull. Calls `body` synchronously with a borrowed view.
     public func withLatestFftFrame(_ body: (UnsafeBufferPointer<Float>, Double, Double) -> Void) -> Bool {
-        var captured = false
-        let opaque = Unmanaged.passUnretained(BodyBox(body)).toOpaque()
-        let got = sdr_core_pull_fft(handle, { frame, user in
-            guard let frame, let user else { return }
-            let box = Unmanaged<BodyBox>.fromOpaque(user).takeUnretainedValue()
-            let buf = UnsafeBufferPointer(start: frame.pointee.magnitudes_db, count: frame.pointee.len)
-            box.body(buf, frame.pointee.sample_rate_hz, frame.pointee.center_freq_hz)
-        }, opaque)
-        return got
+        // BodyBox MUST be bound to a local `let` before passing its pointer
+        // across the FFI boundary. `Unmanaged.passUnretained(BodyBox(body))`
+        // would deallocate the temporary box before the callback runs and
+        // hand the C side a dangling pointer. `withExtendedLifetime` keeps
+        // `box` alive for the duration of the call.
+        let box = BodyBox(body)
+        let opaque = Unmanaged.passUnretained(box).toOpaque()
+        return withExtendedLifetime(box) {
+            sdr_core_pull_fft(handle, { frame, user in
+                guard let frame, let user else { return }
+                let box = Unmanaged<BodyBox>.fromOpaque(user).takeUnretainedValue()
+                let buf = UnsafeBufferPointer(
+                    start: frame.pointee.magnitudes_db,
+                    count: frame.pointee.len
+                )
+                box.body(buf, frame.pointee.sample_rate_hz, frame.pointee.center_freq_hz)
+            }, opaque)
+        }
     }
 }
 ```
@@ -429,7 +438,7 @@ The Swift wrapper turns:
 - The C pull into a closure-style API used inside Metal `draw(in:)`.
 - Error codes into Swift `throws`.
 
-Note that `BodyBox` is a temporary heap allocation per FFT frame. We accept this for v1 (one alloc/free per frame at 20 fps is negligible). If profiling shows it matters at high FFT rates, replace with a per-`SdrCore`-instance reusable box.
+Note that `BodyBox` is a small heap allocation per FFT pull. We accept this for v1 (one alloc/free per frame at 20 fps is negligible). If profiling shows it matters at high FFT rates, hold a single reusable `BodyBox` on the `SdrCore` instance and overwrite its `body` field on each call instead of allocating.
 
 ## ABI Versioning
 

--- a/docs/superpowers/specs/2026-04-12-sdr-ffi-c-abi-design.md
+++ b/docs/superpowers/specs/2026-04-12-sdr-ffi-c-abi-design.md
@@ -1,0 +1,493 @@
+---
+name: sdr-ffi C ABI — Design
+description: Hand-rolled C ABI exposing the sdr-core Engine to native consumers (SwiftUI, future hosts), including header layout, command/event surface, and threading rules
+type: spec
+---
+
+# `sdr-ffi` Hand-Rolled C ABI — Design
+
+**Status:** Draft
+**Date:** 2026-04-12
+**Parent epic:** `2026-04-12-swift-ui-macos-epic-design.md`
+**Depends on:** `2026-04-12-sdr-core-extraction-design.md` (must land first)
+**Tracking issues:** TBD
+
+---
+
+## Goal
+
+Define and implement a stable C ABI that exposes the `sdr-core::Engine` to non-Rust consumers. The first consumer is the SwiftUI macOS app via a thin Swift Package wrapper (`SdrCoreKit`); the design allows other consumers (future C++ tools, Python bindings, whatever) without redesign.
+
+The ABI is **hand-written**. No `swift-bridge`, no `uniffi`, no `cbindgen`. The header file `include/sdr_core.h` is the source of truth and is checked into the repo alongside the Rust source. PR review covers the header and the Rust implementation in lockstep.
+
+## Non-Goals
+
+- **No async runtime crossing the FFI boundary.** Rust side stays sync (channels + threads). Swift side wraps the C surface in `AsyncStream` / `actor` types itself. This keeps the C interface trivial and lets each consumer pick its own concurrency story.
+- **No generic "send any message" interface.** We do not pass JSON or msgpack over FFI. Each command and event is a typed C function/struct. The reasoning: we want the compiler (both `rustc` and `swiftc`) to catch shape mismatches at build time, and we want zero serialization cost on the audio path.
+- **No transcription, no bookmarks, no RadioReference in v1.** Those land in v2 of the ABI alongside their UI panels. The header is versioned (see *ABI Versioning*) so adding them is additive, not breaking.
+- **No SwiftUI code in this spec.** The Swift Package wrapper is sketched here only enough to verify the C surface is usable; the full SwiftUI app is in `2026-04-12-swift-ui-surface-design.md`.
+- **No plugin system.** The library statically registers the same source/sink set that `sdr-core` does.
+
+## Background
+
+`sdr-core` (after the extraction series) exposes a Rust `Engine` struct with:
+- `Engine::new(config_path) -> Result<Self, EngineError>`
+- `Engine::send_command(UiToDsp) -> Result<(), EngineError>`
+- `Engine::subscribe() -> Option<Receiver<DspToUi>>`
+- `Engine::pull_fft<F>(&self, f: F) -> bool`
+- `Engine::shutdown(self) -> Result<(), EngineError>`
+
+The C ABI mirrors this surface. Three things cross the boundary:
+
+1. **Commands** (host → engine): typed C functions, one per `UiToDsp` variant we expose in v1.
+2. **Events** (engine → host): a single C callback registered once, called from the engine's dispatcher thread with a tagged-union event struct.
+3. **FFT frames** (engine → host): a pull function the host calls from its render tick. Zero-copy via a borrow into a Rust-owned buffer for the duration of one callback.
+
+## Crate Layout
+
+```text
+crates/sdr-ffi/
+├── Cargo.toml
+├── cbindgen.toml         — config used by `make ffi-header`; NOT in the build path
+├── build.rs              — sets staticlib name, rerun-if-changed for the header
+└── src/
+    ├── lib.rs            — re-exports + #[no_mangle] entry points
+    ├── handle.rs         — opaque handle type, lifetime tracking
+    ├── error.rs          — error code enum + thread-local last-error
+    ├── command.rs        — command C functions (one per UiToDsp variant in v1)
+    ├── event.rs          — event struct, dispatcher thread, callback marshaling
+    └── fft.rs            — pull function
+
+include/
+└── sdr_core.h            — hand-written header, source of truth, in repo
+```
+
+**`crates/sdr-ffi/Cargo.toml`:**
+
+```toml
+[package]
+name = "sdr-ffi"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+name = "sdr_core"
+crate-type = ["staticlib"]   # v1: link statically into .app to dodge @rpath
+                              # v2 may add cdylib for hot-reload during dev
+
+[dependencies]
+sdr-core = { path = "../sdr-core" }
+sdr-types.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, optional = true }
+libc.workspace = true
+
+[features]
+default = ["log_oslog"]
+log_oslog = ["dep:tracing-subscriber"]   # routes Rust tracing to os_log on macOS
+```
+
+> **Why not `cbindgen` for header generation?** We use `cbindgen` *manually* (`make ffi-header`) only to **diff** the generated header against the hand-written one as a CI lint, catching drift between Rust signatures and the header. The hand-written `include/sdr_core.h` remains the canonical artifact reviewed in PRs. This gives us a human-readable header (with comments, sectioning) and a machine-checked safety net.
+
+## Design Principles
+
+1. **Opaque handle.** `SdrCoreHandle` is an opaque pointer; the host never dereferences it. All operations are functions taking the handle as their first argument. One handle = one engine instance.
+2. **Errors return integers.** Functions that can fail return `int32_t` where `0 == OK` and negative values are `SdrCoreError` enum variants. A separate `sdr_core_last_error_message()` returns a thread-local C string with the most recent error's text. This is the standard C-FFI pattern (`errno`-style) and avoids out-parameters.
+3. **No allocations across the boundary.** Strings passed in are caller-owned `const char*` (UTF-8). Strings passed out are pointers into Rust-owned static or thread-local storage with an explicit lifetime contract (valid until the next call on the same thread).
+4. **No panics.** Every `#[no_mangle] extern "C"` function is wrapped in `std::panic::catch_unwind`. A panic returns `SDR_CORE_ERR_INTERNAL` and sets the last-error message. This is required: a Rust panic across an FFI boundary is UB.
+5. **Reentrancy is explicit.** The header documents which functions can be called from the event callback (most can; the destroy function cannot). This is the same rule GTK has for its main loop.
+6. **No `Send`-unsafe types in the API.** All inputs are POD or owned by the C side. All outputs are values copied into caller-provided buffers, or borrows valid for the callback's duration.
+
+## Header Sketch
+
+This is the v1 surface. Comments are abbreviated for the spec; the real header is fully documented.
+
+```c
+// include/sdr_core.h
+// Hand-written FFI for sdr-core. Source of truth.
+// ABI version: see SDR_CORE_ABI_VERSION below.
+//
+// Threading: see "Threading model" section in the design doc.
+
+#ifndef SDR_CORE_H
+#define SDR_CORE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ============================================================ */
+/*  ABI versioning                                              */
+/* ============================================================ */
+
+#define SDR_CORE_ABI_VERSION_MAJOR 0
+#define SDR_CORE_ABI_VERSION_MINOR 1
+
+/* Returns the ABI version the dylib was built with.
+ * Hosts call this once at startup and abort if it doesn't match
+ * what they were compiled against. */
+uint32_t sdr_core_abi_version(void);
+
+/* ============================================================ */
+/*  Errors                                                      */
+/* ============================================================ */
+
+typedef enum SdrCoreError {
+    SDR_CORE_OK                  =  0,
+    SDR_CORE_ERR_INTERNAL        = -1,  /* panic, unwrap, etc. */
+    SDR_CORE_ERR_INVALID_HANDLE  = -2,
+    SDR_CORE_ERR_INVALID_ARG     = -3,
+    SDR_CORE_ERR_NOT_RUNNING     = -4,
+    SDR_CORE_ERR_DEVICE          = -5,  /* USB / RTL-SDR open/io */
+    SDR_CORE_ERR_AUDIO           = -6,  /* CoreAudio */
+    SDR_CORE_ERR_IO              = -7,  /* file/network */
+    SDR_CORE_ERR_CONFIG          = -8,
+} SdrCoreError;
+
+/* Thread-local. Valid until the next sdr_core_* call on this thread.
+ * Returns NULL if no error has been set on this thread. */
+const char* sdr_core_last_error_message(void);
+
+/* ============================================================ */
+/*  Lifecycle                                                   */
+/* ============================================================ */
+
+typedef struct SdrCore SdrCore;   /* opaque */
+
+/* Initialize logging. Idempotent. Routes Rust `tracing` events to os_log
+ * on macOS, stderr on Linux. Optional — call once before sdr_core_create
+ * if you want logs. `min_level`: 0=trace 1=debug 2=info 3=warn 4=error. */
+void sdr_core_init_logging(uint8_t min_level);
+
+/* Create an engine. `config_path_utf8` is the JSON config file location,
+ * caller-owned. The engine reads it on startup and writes on shutdown.
+ * On success, *out_handle is set and 0 is returned. */
+int32_t sdr_core_create(const char* config_path_utf8, SdrCore** out_handle);
+
+/* Destroy. Blocks until the DSP thread joins. Always succeeds.
+ * After this call the handle is invalid. NOT reentrant — must not be
+ * called from the event callback. */
+void sdr_core_destroy(SdrCore* handle);
+
+/* ============================================================ */
+/*  Commands (host -> engine)                                   */
+/* ============================================================ */
+
+/* Lifecycle */
+int32_t sdr_core_start(SdrCore*);
+int32_t sdr_core_stop (SdrCore*);
+
+/* Tuning */
+int32_t sdr_core_tune                 (SdrCore*, double freq_hz);
+int32_t sdr_core_set_vfo_offset       (SdrCore*, double offset_hz);
+int32_t sdr_core_set_sample_rate      (SdrCore*, double rate_hz);
+int32_t sdr_core_set_decimation       (SdrCore*, uint32_t factor);
+int32_t sdr_core_set_ppm_correction   (SdrCore*, int32_t ppm);
+
+/* Tuner */
+int32_t sdr_core_set_gain             (SdrCore*, double gain_db);
+int32_t sdr_core_set_agc              (SdrCore*, bool enabled);
+
+/* Demod */
+typedef enum SdrDemodMode {
+    SDR_DEMOD_WFM = 0,
+    SDR_DEMOD_NFM = 1,
+    SDR_DEMOD_AM  = 2,
+    SDR_DEMOD_USB = 3,
+    SDR_DEMOD_LSB = 4,
+    SDR_DEMOD_DSB = 5,
+    SDR_DEMOD_CW  = 6,
+    SDR_DEMOD_RAW = 7,
+} SdrDemodMode;
+
+int32_t sdr_core_set_demod_mode       (SdrCore*, SdrDemodMode mode);
+int32_t sdr_core_set_bandwidth        (SdrCore*, double bw_hz);
+int32_t sdr_core_set_squelch_enabled  (SdrCore*, bool enabled);
+int32_t sdr_core_set_squelch_db       (SdrCore*, float db);
+
+typedef enum SdrDeemphasis {
+    SDR_DEEMPH_NONE = 0,
+    SDR_DEEMPH_US75 = 1,
+    SDR_DEEMPH_EU50 = 2,
+} SdrDeemphasis;
+int32_t sdr_core_set_deemphasis       (SdrCore*, SdrDeemphasis mode);
+
+/* Audio */
+int32_t sdr_core_set_volume           (SdrCore*, float volume_0_1);
+
+/* IQ frontend */
+int32_t sdr_core_set_dc_blocking      (SdrCore*, bool enabled);
+int32_t sdr_core_set_iq_inversion     (SdrCore*, bool enabled);
+int32_t sdr_core_set_iq_correction    (SdrCore*, bool enabled);
+
+/* Spectrum */
+int32_t sdr_core_set_fft_size         (SdrCore*, size_t n);    /* power of 2, 1024..16384 */
+
+typedef enum SdrFftWindow {
+    SDR_FFT_WIN_RECT     = 0,
+    SDR_FFT_WIN_HANN     = 1,
+    SDR_FFT_WIN_HAMMING  = 2,
+    SDR_FFT_WIN_BLACKMAN = 3,
+} SdrFftWindow;
+int32_t sdr_core_set_fft_window       (SdrCore*, SdrFftWindow w);
+int32_t sdr_core_set_fft_rate         (SdrCore*, double fps);
+
+/* ============================================================ */
+/*  Events (engine -> host)                                     */
+/* ============================================================ */
+
+typedef enum SdrEventKind {
+    SDR_EVT_SOURCE_STOPPED          = 1,
+    SDR_EVT_SAMPLE_RATE_CHANGED     = 2,
+    SDR_EVT_SIGNAL_LEVEL            = 3,
+    SDR_EVT_DEVICE_INFO             = 4,
+    SDR_EVT_GAIN_LIST               = 5,
+    SDR_EVT_DISPLAY_BANDWIDTH       = 6,
+    SDR_EVT_ERROR                   = 7,
+    /* v2: recording, transcription, bookmarks, ... */
+} SdrEventKind;
+
+typedef struct SdrEvent {
+    SdrEventKind kind;
+    union {
+        double    sample_rate_hz;       /* SAMPLE_RATE_CHANGED */
+        float     signal_level_db;      /* SIGNAL_LEVEL */
+        double    display_bandwidth_hz; /* DISPLAY_BANDWIDTH */
+        struct {                        /* DEVICE_INFO */
+            const char* utf8;           /* borrow valid for callback duration */
+        } device_info;
+        struct {                        /* GAIN_LIST */
+            const double* values;       /* borrow valid for callback duration */
+            size_t        len;
+        } gain_list;
+        struct {                        /* ERROR */
+            const char* utf8;
+        } error;
+    } u;
+} SdrEvent;
+
+/* Callback signature. Called from the engine's dispatcher thread.
+ * `user_data` is the same pointer the host passed to set_event_callback.
+ * The callback MUST NOT call sdr_core_destroy. All other commands are safe.
+ * Borrowed pointers in `evt` are valid only for the duration of this call. */
+typedef void (*SdrEventCallback)(const SdrEvent* evt, void* user_data);
+
+/* Register a callback. Replaces any previous callback. Pass NULL to clear.
+ * Returns 0 on success. The dispatcher thread starts on first non-NULL set. */
+int32_t sdr_core_set_event_callback(SdrCore*, SdrEventCallback cb, void* user_data);
+
+/* ============================================================ */
+/*  FFT frame pull (engine -> host, render-tick driven)         */
+/* ============================================================ */
+
+/* Borrow handed to the FFT frame callback. Pointer valid only for the
+ * duration of the callback (Rust holds a mutex on the buffer for that
+ * window). Do NOT retain. Copy out what you need. */
+typedef struct SdrFftFrame {
+    const float* magnitudes_db;   /* len = `len` */
+    size_t       len;
+    double       sample_rate_hz;  /* effective rate (for x-axis labelling) */
+    double       center_freq_hz;
+} SdrFftFrame;
+
+typedef void (*SdrFftCallback)(const SdrFftFrame* frame, void* user_data);
+
+/* Pulls the latest FFT frame, if a new one is ready since the last call.
+ * Returns true and invokes `cb` if a frame was available. Returns false
+ * (without calling `cb`) if no new frame. Lock-free fast path. */
+bool sdr_core_pull_fft(SdrCore*, SdrFftCallback cb, void* user_data);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* SDR_CORE_H */
+```
+
+That's the entire v1 surface: **~25 command functions, 7 event variants, 1 FFT pull**.
+
+## Threading Model
+
+```text
+                       ┌────────────────────────┐
+                       │ Host main thread       │
+                       │ (SwiftUI / GTK)        │
+                       └─────────┬──────────────┘
+                                 │
+        sdr_core_set_*()         │           sdr_core_pull_fft()
+        (any thread, lock-free) │           (called per render tick)
+                                 ▼
+                      ┌──────────────────────┐
+                      │  sdr-ffi shim        │
+                      │  (no own state)      │
+                      └─────────┬────────────┘
+                                │
+                                │  mpsc::Sender<UiToDsp>     SharedFftBuffer
+                                ▼
+                      ┌────────────────────────────────┐
+                      │  sdr-core::Engine              │
+                      │  • DSP thread (writer)         │
+                      │  • Dispatcher thread (events)  │
+                      └────────────┬───────────────────┘
+                                   │ DspToUi events
+                                   ▼
+                      ┌──────────────────────┐
+                      │ Dispatcher thread    │
+                      │ converts to SdrEvent │
+                      │ calls SdrEventCallback│
+                      └─────────┬────────────┘
+                                │ (host's responsibility to marshal
+                                ▼  to its own UI thread)
+                      ┌──────────────────────┐
+                      │ Host SdrEventCallback │
+                      └──────────────────────┘
+```
+
+**Two background threads owned by `sdr-ffi`:**
+
+1. **DSP thread** — already exists in `sdr-core`. Writes to `SharedFftBuffer`. Sends `DspToUi` events through the engine's mpsc channel.
+2. **Dispatcher thread** — new in `sdr-ffi`. Owns the `mpsc::Receiver<DspToUi>` taken from `Engine::subscribe()`. Loops on `recv()`, converts each `DspToUi` into an `SdrEvent`, calls the registered C callback, drops borrowed buffers (Rust-owned strings/vecs are kept alive for the callback's stack frame). Joins on `sdr_core_destroy`.
+
+The dispatcher thread is the only thread that calls into the host's event callback. The host *must not* assume which thread that is — it's not the host's main thread. SwiftUI code marshals to `MainActor` on receipt; GTK code marshals to the GLib main loop.
+
+**FFT frames are pulled, not pushed.** The host calls `sdr_core_pull_fft` from its render tick (`MTKView`'s `draw(in:)` or `CVDisplayLink` for SwiftUI; `glib::timeout_add_local` at FFT rate for GTK). The pull is lock-free when no new frame is available, and acquires a short mutex when one is. This matches `SharedFftBuffer::take_if_ready` exactly. Zero allocations on the hot path.
+
+**Reentrancy rules** (documented in the header):
+
+| Function                       | Safe from event callback? |
+|--------------------------------|---------------------------|
+| `sdr_core_destroy`             | **No** (would deadlock on dispatcher join) |
+| `sdr_core_set_event_callback`  | No                        |
+| `sdr_core_pull_fft`            | Yes                       |
+| All other `sdr_core_*` commands | Yes                      |
+
+## Swift Package Wrapper Sketch
+
+This is just enough to verify the C surface is usable from Swift. The full wrapper lives in `apps/macos/Packages/SdrCoreKit/` and is detailed in the surface spec.
+
+```swift
+// SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+import Foundation
+import sdr_core_c   // SwiftPM systemModule wrapping include/sdr_core.h
+
+@MainActor
+public final class SdrCore {
+    private let handle: OpaquePointer
+    private var eventContinuation: AsyncStream<SdrCoreEvent>.Continuation?
+
+    public let events: AsyncStream<SdrCoreEvent>
+
+    public init(configPath: URL) throws {
+        var raw: OpaquePointer? = nil
+        let rc = configPath.path.withCString { sdr_core_create($0, &raw) }
+        guard rc == 0, let raw else { throw SdrCoreError(rawValue: rc) ?? .internal }
+        self.handle = raw
+
+        var continuation: AsyncStream<SdrCoreEvent>.Continuation!
+        self.events = AsyncStream { continuation = $0 }
+        self.eventContinuation = continuation
+
+        // Register a C trampoline that yields into the AsyncStream.
+        let opaque = Unmanaged.passUnretained(self).toOpaque()
+        sdr_core_set_event_callback(handle, { evt, user in
+            guard let evt, let user else { return }
+            let me = Unmanaged<SdrCore>.fromOpaque(user).takeUnretainedValue()
+            me.eventContinuation?.yield(SdrCoreEvent(c: evt.pointee))
+        }, opaque)
+    }
+
+    deinit {
+        eventContinuation?.finish()
+        sdr_core_destroy(handle)
+    }
+
+    public func start()                  throws { try check(sdr_core_start(handle)) }
+    public func tune(_ hz: Double)       throws { try check(sdr_core_tune(handle, hz)) }
+    public func setDemodMode(_ m: DemodMode) throws { try check(sdr_core_set_demod_mode(handle, m.cValue)) }
+    // ...one wrapper per command function...
+
+    /// Render-tick FFT pull. Calls `body` synchronously with a borrowed view.
+    public func withLatestFftFrame(_ body: (UnsafeBufferPointer<Float>, Double, Double) -> Void) -> Bool {
+        var captured = false
+        let opaque = Unmanaged.passUnretained(BodyBox(body)).toOpaque()
+        let got = sdr_core_pull_fft(handle, { frame, user in
+            guard let frame, let user else { return }
+            let box = Unmanaged<BodyBox>.fromOpaque(user).takeUnretainedValue()
+            let buf = UnsafeBufferPointer(start: frame.pointee.magnitudes_db, count: frame.pointee.len)
+            box.body(buf, frame.pointee.sample_rate_hz, frame.pointee.center_freq_hz)
+        }, opaque)
+        return got
+    }
+}
+```
+
+The Swift wrapper turns:
+- The C callback into an `AsyncStream<SdrCoreEvent>` consumed by SwiftUI views with `for await`.
+- The C pull into a closure-style API used inside Metal `draw(in:)`.
+- Error codes into Swift `throws`.
+
+Note that `BodyBox` is a temporary heap allocation per FFT frame. We accept this for v1 (one alloc/free per frame at 20 fps is negligible). If profiling shows it matters at high FFT rates, replace with a per-`SdrCore`-instance reusable box.
+
+## ABI Versioning
+
+Header declares `SDR_CORE_ABI_VERSION_MAJOR` and `_MINOR`. Rules:
+
+- **Minor bump** = additive change only (new function, new event variant, new error code). Hosts built against an older minor still work; they just don't see the new things.
+- **Major bump** = breaking change (signature change, removed function, struct layout change). Hosts built against an older major fail at `sdr_core_create` with `SDR_CORE_ERR_INTERNAL` and a clear error message.
+- **`sdr_core_abi_version()` is the first call** the Swift wrapper makes. If it returns a major mismatch, the Swift `init` throws `SdrCoreError.abiVersionMismatch` and the app shows a "library mismatch — reinstall" dialog.
+
+For v1 we are at `0.1`. We bump to `0.2` when we add transcription events, network/file source commands, etc.
+
+## Build Integration
+
+The Rust side produces `libsdr_core.a` (staticlib). Xcode is told about it via a SwiftPM `binaryTarget` *or* a build phase that runs `cargo build --release -p sdr-ffi --target <triple>` for both `aarch64-apple-darwin` and `x86_64-apple-darwin`, then `lipo`s them into a universal `libsdr_core.a`. Details in `2026-04-12-swift-ui-packaging-design.md`.
+
+The header `include/sdr_core.h` is exposed as a SwiftPM systemModule:
+
+```text
+apps/macos/Packages/SdrCoreKit/
+├── Package.swift
+├── Sources/
+│   ├── sdr_core_c/                 — systemModule, just module.modulemap + the .h
+│   │   └── module.modulemap
+│   └── SdrCoreKit/                 — Swift wrappers (SdrCore class, types, errors)
+│       └── *.swift
+└── Tests/
+    └── SdrCoreKitTests/
+```
+
+## Test Strategy
+
+- **Rust unit tests** in `sdr-ffi`: round-trip every command function via a mock `Engine` (the same `MockSource`-based tests `sdr-core` already uses). Verify error codes for invalid args, NULL handles, double-destroy.
+- **Header drift CI lint:** `make ffi-header-check` runs `cbindgen` and diffs against `include/sdr_core.h`. Fails CI if they disagree on signatures (not on formatting).
+- **Swift integration test** in `SdrCoreKitTests`: create an engine pointing at a test config, register an event callback, send `start`/`tune`/`stop`, assert events arrive on the stream.
+- **Panic-safety test:** an internal test command that deliberately panics inside a `#[no_mangle]` function — must return `SDR_CORE_ERR_INTERNAL` with the panic message in `last_error_message`, not abort the process.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Header and Rust drift silently | `make ffi-header-check` in CI; cbindgen used as a linter, not a generator |
+| Panic across FFI = UB | Every `#[no_mangle]` function wrapped in `catch_unwind`. Test enforces it. |
+| String borrow lifetime confusing for Swift devs | Wrapper copies all strings to `String` immediately on receipt. Header documents the rule. Tests would catch a use-after-free. |
+| Dispatcher thread blocks if Swift callback is slow | Document the rule: callbacks must marshal-and-return. SwiftUI wrapper yields into an `AsyncStream` (~constant time). |
+| Adding a command means editing 4 places (Rust enum, FFI fn, header, Swift wrapper) | Accepted cost of hand-rolled. Compensated by: small set, build-time errors at every layer, clean reviewable diffs. A code-gen approach would have its own 4-places-to-edit problem (IDL, generator output, Rust glue, Swift wrapper). |
+| Swift `BodyBox` per-frame alloc shows up in profiler | Pre-allocate one box per `SdrCore` instance and reuse; trivial fix if needed |
+
+## Open Questions
+
+- **Pre-MVP spike:** validate that `cargo build --release -p sdr-ffi --target aarch64-apple-darwin` produces a static lib with no PipeWire symbols. (`sdr-sink-audio` must default-feature off `pipewire` so the macOS build doesn't try to link it.) — covered by the CoreAudio sink spec.
+- **Should `sdr_core_create` accept a `JSON config blob` instead of a path?** Lean: no. Path is simpler, and the engine already knows how to read/write its own config. Host doesn't need to parse it.
+- **Logging:** is `os_log` integration via a custom `tracing` subscriber the right call, or do we just emit JSON to stderr and let the `.app` capture it? Lean: `os_log` for v1, behind the `log_oslog` feature; can add JSON later if needed.
+
+## References
+
+- `include/sdr_core.h` (to be created in PR series M2)
+- `crates/sdr-core/src/engine.rs` (created in M1)
+- `crates/sdr-ui/src/messages.rs` — current message enums; FFI commands map 1:1 to these
+- Swift docs: [Calling C APIs from Swift](https://developer.apple.com/documentation/swift/calling-apis-across-language-boundaries) — used by the wrapper
+- `2026-04-12-sdr-core-extraction-design.md` — prerequisite
+- `2026-04-12-swift-ui-packaging-design.md` — how the static lib gets into the .app

--- a/docs/superpowers/specs/2026-04-12-swift-ui-macos-epic-design.md
+++ b/docs/superpowers/specs/2026-04-12-swift-ui-macos-epic-design.md
@@ -74,14 +74,16 @@ A parallel session is rebuilding `sdr-transcription` around a `TranscriptionBack
 │     • AsyncStream<CoreEvent>  (events from Rust → Swift)        │
 │     • FftFrame (zero-copy view over Rust-owned buffer)          │
 └─────────────────────────────┬───────────────────────────────────┘
-                              │ C ABI (sdr_core.h)
-                              │ • sdr_core_create / destroy
-                              │ • sdr_core_send_command
+                              │ C ABI (include/sdr_core.h)
+                              │ • sdr_core_create / sdr_core_destroy
+                              │ • typed command fns: sdr_core_tune,
+                              │   sdr_core_set_demod_mode,
+                              │   sdr_core_set_gain, ... (~25 total)
                               │ • sdr_core_set_event_callback
-                              │ • sdr_core_pull_fft_frame
+                              │ • sdr_core_pull_fft
                               ↓
 ┌─────────────────────────────────────────────────────────────────┐
-│  sdr-ffi (new crate, cdylib + staticlib)                        │
+│  sdr-ffi (new crate, staticlib for v1)                          │
 │  Translates C structs ↔ sdr-core Rust types.                    │
 │  Owns no state — just a thin shim around Box<sdr_core::Engine>. │
 └─────────────────────────────┬───────────────────────────────────┘
@@ -89,7 +91,8 @@ A parallel session is rebuilding `sdr-transcription` around a `TranscriptionBack
 ┌─────────────────────────────────────────────────────────────────┐
 │  sdr-core (new crate) — headless facade                         │
 │  • Owns DspController + SourceManager + SinkManager             │
-│  • Public Rust API: Engine::new, send_command, subscribe, ...   │
+│  • Public Rust API: Engine::new, send_command, subscribe,       │
+│    pull_fft, shutdown                                           │
 │  • Consumed by BOTH sdr-ffi (Swift) AND sdr-ui (GTK)            │
 └─────────────────────────────┬───────────────────────────────────┘
                               ↓

--- a/docs/superpowers/specs/2026-04-12-swift-ui-macos-epic-design.md
+++ b/docs/superpowers/specs/2026-04-12-swift-ui-macos-epic-design.md
@@ -1,0 +1,219 @@
+---
+name: SwiftUI macOS Frontend — Epic Design
+description: Top-level design for a native SwiftUI/macOS frontend driving the existing Rust SDR engine via a hand-rolled C ABI
+type: spec
+---
+
+# SwiftUI macOS Frontend — Epic Design
+
+**Status:** Draft
+**Date:** 2026-04-12
+**Branch:** `feature/swift-ui-planning`
+**Tracking issues:** TBD (epic + child issues to be opened after spec review)
+
+---
+
+## Goal
+
+Ship a native macOS SwiftUI frontend that drives the existing Rust SDR engine and reaches **feature parity** with the GTK4 UI on Linux. The two frontends consume the same headless engine through a single, narrow C ABI; neither one owns engine state.
+
+This is a multi-PR effort. The first deliverable is an **MVP** that runs end-to-end on macOS with RTL-SDR hardware: live spectrum/waterfall, click-to-tune, FM/AM/WFM/NFM demod, and CoreAudio output. Everything else (bookmarks, RadioReference, transcription, IQ recording, network sources, file playback) lands incrementally on top of that foundation behind the same FFI.
+
+## Non-Goals
+
+- **Replacing the GTK UI.** Linux users keep `sdr-ui` exactly as it is today. Both frontends consume the same `sdr-core` facade going forward.
+- **Mac App Store distribution.** Initial release is developer-ID signed and notarized for direct download. App Store sandboxing has implications for USB device access that we don't want to fight in v1.
+- **iPadOS / iOS support.** Architecturally the FFI would allow it; in practice the rendering, USB access story, and UI idioms differ enough that it's a separate effort.
+- **A second cross-platform UI toolkit.** No egui/Slint/Tauri/Iced rewrite. SwiftUI on macOS, GTK on Linux. Two frontends, one engine.
+- **Changing the existing message enum names** in `sdr-ui`. The FFI is a *new* surface; the GTK code keeps using its current `UiToDsp`/`DspToUi` channels until the `sdr-core` extraction (PR series 2) migrates it.
+- **Replacing `sdr-transcription` in the FFI for v1.** That crate is actively being rebuilt in parallel (sherpa-onnx integration); we keep it out of the FFI surface until it stabilizes.
+
+## Background
+
+### Why a second frontend at all
+
+Today the only way to run this project end-to-end is on Linux through GTK4 + libadwaita + PipeWire. The Rust core is platform-clean — it's the *frontend* that pins us to one OS. A native macOS app is the highest-leverage thing we can ship to widen the audience: macOS users get a real app instead of a Homebrew GTK install, and the project gets a second consumer that pressure-tests how clean the engine boundary really is.
+
+### Why SwiftUI specifically
+
+- **Native feel costs nothing extra.** SwiftUI gives us toolbar, sidebar, settings window, menu bar, sheets, popovers, and a native window chrome with no per-widget effort.
+- **`@Observable` (macOS 14+) is a near-perfect fit** for a UI driven by streaming engine state: one observable model, everything binds to it, no Combine boilerplate.
+- **Metal is first-class.** The spectrum/waterfall is the perf-critical surface; `MTKView` inside `NSViewRepresentable` gives us 60 fps from a Rust-owned ring buffer with predictable cost.
+- **Xcode signing/notarization is the path of least resistance** for shipping a macOS binary that users will actually run.
+
+### Why a hand-rolled C ABI (not swift-bridge / UniFFI)
+
+Rejected during planning. Reasoning:
+
+- The engine surface is **narrow and well-defined**: ~12 events out, ~40 commands in (counting `DspToUi`/`UiToDsp` variants in `crates/sdr-ui/src/messages.rs`), plus FFT frame delivery. That's small enough to maintain by hand without paying for codegen.
+- **Zero new dependencies on the Rust side.** No build-script tax, no proc-macro compile time, no version-skew risk between the bridge tool and the Rust toolchain.
+- **The C header is the contract.** Both Swift and (eventually) any other consumer link against `sdr_core.h`. The header gets reviewed in PRs like any other interface; nothing is hidden behind generators.
+- **Control over threading and lifetime.** We want the engine to drive Swift via a callback on the DSP thread (with explicit "marshal to main" rules), and we want the FFT pull function to be lock-free against the writer. Codegen tools either don't model that or hide it behind opinionated wrappers.
+
+The tradeoff is more boilerplate per command function. We accept that — see `2026-04-12-sdr-ffi-c-abi-design.md` for how the surface is kept manageable.
+
+### What's actively in flight on the engine
+
+A parallel session is rebuilding `sdr-transcription` around a `TranscriptionBackend` trait and adding sherpa-onnx for true streaming live transcription. The trait landed yesterday (PR #226); the backend implementation is still being written.
+
+**Implication for this epic:** transcription is **excluded from the MVP FFI surface** and from the `sdr-core` facade until the backend session declares its public API stable. v2 of the FFI adds it. This is why "Transcript Panel" appears in the v2 backlog below, not the MVP.
+
+## High-Level Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  SwiftUI app (apps/macos/SDRMac.app)                            │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ SwiftUI views (sidebar, toolbar, settings)                │  │
+│  │     ↕  @Observable CoreModel                              │  │
+│  │ MTKView for spectrum + waterfall                          │  │
+│  └─────────────────────────────┬─────────────────────────────┘  │
+│                                ↓                                │
+│  SdrCoreKit (Swift Package) — wraps the C ABI in Swift types    │
+│     • SdrCore actor (lifecycle, command dispatch)               │
+│     • AsyncStream<CoreEvent>  (events from Rust → Swift)        │
+│     • FftFrame (zero-copy view over Rust-owned buffer)          │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │ C ABI (sdr_core.h)
+                              │ • sdr_core_create / destroy
+                              │ • sdr_core_send_command
+                              │ • sdr_core_set_event_callback
+                              │ • sdr_core_pull_fft_frame
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  sdr-ffi (new crate, cdylib + staticlib)                        │
+│  Translates C structs ↔ sdr-core Rust types.                    │
+│  Owns no state — just a thin shim around Box<sdr_core::Engine>. │
+└─────────────────────────────┬───────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  sdr-core (new crate) — headless facade                         │
+│  • Owns DspController + SourceManager + SinkManager             │
+│  • Public Rust API: Engine::new, send_command, subscribe, ...   │
+│  • Consumed by BOTH sdr-ffi (Swift) AND sdr-ui (GTK)            │
+└─────────────────────────────┬───────────────────────────────────┘
+                              ↓
+            existing crates: sdr-pipeline, sdr-radio, sdr-dsp,
+            sdr-types, sdr-config, sdr-source-*, sdr-sink-*
+            (+ sdr-sink-audio gains a CoreAudio implementation)
+```
+
+The dotted line in the GTK UI's current architecture (`sdr-ui` directly owns `dsp_controller.rs`) goes away. After the `sdr-core` extraction PR series, `sdr-ui` is just another consumer of the facade — the same way Swift will be — and the message enums become `sdr-core`'s public API rather than UI-internal types.
+
+## MVP Scope (v0.1)
+
+Everything below must work on a clean macOS install with an RTL-SDR dongle plugged in. Anything not on this list is v2 or later.
+
+**Sources**
+- RTL-SDR USB only
+
+**Demodulation**
+- WFM (mono), NFM, AM, USB, LSB, CW, DSB, RAW
+- Squelch on/off, threshold slider
+- Bandwidth control
+- De-emphasis (US75/EU50/None)
+
+**Audio out**
+- CoreAudio (new sink impl)
+- Default device only — no per-device selection in MVP UI (FFI will support it, UI defers it to v2)
+- Volume
+
+**Spectrum / waterfall**
+- Live FFT plot with frequency scale
+- Scrolling waterfall with palette LUT
+- Click-to-tune (sets VFO offset)
+- Drag-to-resize VFO bandwidth
+- Min/max dB sliders
+- FFT size selector (1024/2048/4096/8192)
+- FFT window function selector
+
+**Tuner controls**
+- Center frequency input (Hz, MHz; arrow keys nudge)
+- Gain slider with discrete steps from `gains()`
+- AGC toggle
+- PPM correction
+
+**App shell**
+- Native macOS window with toolbar
+- NavigationSplitView with sidebar + main content
+- Settings window (`Settings { ... }` SwiftUI scene)
+- Standard menu bar (File, View, Window, Help)
+- Settings persistence via existing `sdr-config` (read/write through FFI on launch/quit)
+
+**Quality bar**
+- Universal binary (arm64 + x86_64)
+- Developer-ID signed, hardened runtime, notarized
+- Launches and runs from a fresh `.app` drop (no terminal, no Homebrew)
+
+## v2 / Full-Parity Backlog
+
+These exist as GitHub issues from day 1, blocked on the MVP epic, so the parity path is visible:
+
+- **Network IQ source** (TCP/UDP) — already in `sdr-source-network`, just needs FFI surface and a UI panel
+- **File playback source** — `sdr-source-file` exists; needs FFI + file picker
+- **Audio device picker** — enumerate CoreAudio output devices, route through `SetAudioDevice` command
+- **IQ recording to WAV**
+- **Audio recording to WAV**
+- **Bookmarks panel**
+- **RadioReference integration** (depends on existing `sdr-radioreference` crate; keychain credential storage already works on macOS)
+- **Transcript panel** — blocked on the parallel sherpa-onnx work declaring its API stable
+- **Auto-squelch** — blocked on engine-side noise-floor algorithm settling
+- **Display panel extras**: averaging modes (Peak/Avg/Min hold), FPS control
+- **Noise blanker, FM IF NR, WFM stereo, notch filter** controls
+- **DC blocking, IQ inversion, IQ correction** toggles
+- **Decimation factor** selector
+- **Network audio sink** — `sdr-sink-network` exists, needs FFI + UI
+
+## Milestones
+
+| #  | Milestone                                  | Status   | Spec doc                                                       |
+|----|--------------------------------------------|----------|----------------------------------------------------------------|
+| M1 | `sdr-core` facade extraction (no FFI yet)  | Pending  | `2026-04-12-sdr-core-extraction-design.md`                     |
+| M2 | `sdr-ffi` crate + `sdr_core.h` + Swift package wrapper | Pending  | `2026-04-12-sdr-ffi-c-abi-design.md`                |
+| M3 | CoreAudio sink (`sdr-sink-audio` macOS impl) | Pending  | `2026-04-12-coreaudio-sink-design.md`                          |
+| M4 | Metal renderer (spectrum + waterfall)      | Pending  | `2026-04-12-swift-ui-rendering-design.md`                      |
+| M5 | SwiftUI app shell + MVP panels + wiring    | Pending  | `2026-04-12-swift-ui-surface-design.md`                        |
+| M6 | Packaging: Xcode integration, sign, notarize, CI | Pending  | `2026-04-12-swift-ui-packaging-design.md`                |
+| V2 | Full-parity backlog issues (one PR each)   | Backlog  | (per-feature plans created when picked up)                     |
+
+M1 → M2 → M3 are all engine-side and unblock each other. M4 and M5 can run in parallel once M2 lands. M6 is last because it requires a runnable app to sign.
+
+## Success Criteria
+
+- The MVP `.app` launches on a clean macOS 26 machine, finds an RTL-SDR dongle, tunes 100.7 MHz, and produces audible WFM through built-in speakers.
+- Click-to-tune on the waterfall moves the VFO and audio follows, end-to-end latency under 200 ms.
+- Spectrum + waterfall sustain 60 fps at FFT size 4096 with no main-thread allocations per frame.
+- The same `sdr-core` API, on the same commit, still drives the GTK UI on Linux without regressions.
+- `cargo test --workspace` and `cargo clippy --all-targets --workspace -- -D warnings` are clean.
+- A `.app` produced by CI is signed, notarized, and stapled. `spctl --assess` accepts it.
+
+## Risks & Open Questions
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Engine session destabilizes `sdr-core` API mid-extraction | Medium | High | Land M1 (extraction) **before** the sherpa-onnx work touches the same files; coordinate via PRs not channels |
+| USB device access on signed/notarized macOS app surprises us | Medium | High | Validate with a "hello world" libusb-rs sign+notarize spike *before* M5 starts. Hardened runtime + `com.apple.security.device.usb` entitlement should be sufficient (no sandbox). |
+| Metal waterfall scroll cost at 8192 FFT × 60 fps higher than expected | Low | Medium | Texture ring buffer with UV scroll, not a memmove; spec'd in rendering doc. Fallback: cap waterfall to 30 fps independently of spectrum line. |
+| CoreAudio sample-rate negotiation differs from PipeWire's "give me 48k stereo" assumption | Medium | Medium | CoreAudio sink does its own resampling if device rate ≠ engine rate; spec'd in sink doc. |
+| `sdr-config` JSON drifts as both UIs add fields | Low | Low | Single source of truth in `sdr-config`; both frontends read/write through the same struct via FFI |
+| GTK UI regressions during `sdr-core` extraction | Medium | High | Extraction PR is *behavior-preserving* — same tests must pass before and after, message enums kept byte-compatible |
+
+**Open questions to resolve before M2 starts:**
+- Should the FFI expose an explicit "init logging" call so Swift sees `tracing` output via `os_log`? *(Lean: yes — see FFI spec.)*
+- Where does the JSON config file live on macOS? `~/Library/Application Support/SDRMac/config.json`? *(Lean: yes, follow Apple convention; the FFI takes the path as a parameter so the host decides.)*
+- Do we ship the FFI as a `cdylib` (linked at runtime, smaller `.app`) or `staticlib` (everything in the binary, simplest signing)? *(Lean: `staticlib` for v1 — one binary to sign, no `@rpath` headaches.)*
+
+## Out of Scope (deferred indefinitely)
+
+- Plugin system. SDR++ has one; we don't, and won't, in v1.
+- Multi-VFO. Single VFO is enough for MVP and v2.
+- Recording to non-WAV formats.
+- Cross-process IPC. The engine runs in-process inside the `.app`.
+
+## References
+
+- `docs/PROJECT.md` — overall project map and C++ → Rust source correspondence
+- `crates/sdr-ui/src/messages.rs` — current `UiToDsp`/`DspToUi` enums (the FFI surface follows these closely)
+- `crates/sdr-ui/src/dsp_controller.rs` — current DSP thread that `sdr-core` will own
+- `crates/sdr-pipeline/src/source_manager.rs` — `Source` trait that survives the extraction unchanged
+- `docs/superpowers/specs/2026-04-12-transcription-backend-trait-design.md` — parallel work that this epic deliberately does *not* touch

--- a/docs/superpowers/specs/2026-04-12-swift-ui-packaging-design.md
+++ b/docs/superpowers/specs/2026-04-12-swift-ui-packaging-design.md
@@ -187,11 +187,9 @@ The `-lc++` is required because some `coreaudio-rs` symbols pull in C++ runtime 
 <string>NSApplication</string>
 <key>NSHighResolutionCapable</key>
 <true/>
-
-<!-- USB hot-plug requires this on hardened runtime: -->
-<key>NSAppleEventsUsageDescription</key>
-<string>SDRMac uses hardware events for RTL-SDR USB device access.</string>
 ```
+
+No USB-specific Info.plist key is required. `NSAppleEventsUsageDescription` controls Apple Events automation (cross-app scripting), not USB device access — it would be wrong here. There is no `NSUSBUsageDescription` key in the macOS API; USB device access for non-sandboxed apps doesn't go through a usage-description prompt at all.
 
 ### `SDRMac.entitlements`
 
@@ -200,31 +198,25 @@ The `-lc++` is required because some `coreaudio-rs` symbols pull in C++ runtime 
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- Hardened runtime: required for notarization -->
-    <key>com.apple.security.cs.allow-jit</key>
-    <false/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <false/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <false/>
-
-    <!-- USB device access for RTL-SDR (libusb via rusb) -->
-    <key>com.apple.security.device.usb</key>
-    <true/>
-
     <!-- We are NOT sandboxed in v1. -->
     <!-- (No <com.apple.security.app-sandbox/> entry.) -->
-
-    <!-- Audio output: not needed for non-sandboxed apps; CoreAudio works as-is. -->
 </dict>
 </plist>
 ```
 
-**Why not sandboxed:** sandbox + USB device access is a deep rabbit hole on macOS. Apps that need raw libusb access typically either go unsandboxed (our v1 choice) or use the `IOUSBHost` framework (Apple's modern alternative, requires reworking `rusb` usage). For v1 we ship unsandboxed; v2 considers IOUSBHost.
+The entitlements file is **deliberately empty** for v1. Reasoning:
 
-**Why hardened runtime is on:** notarization requires it. `com.apple.security.cs.allow-jit = false` is the default; we don't JIT.
+- **`com.apple.security.device.usb`** is a *sandbox* entitlement. It only does anything when paired with `com.apple.security.app-sandbox`. We are not sandboxed in v1, so requesting it would be cargo-cult: it grants nothing additional and adds noise to the entitlement audit. We omit it.
+- **`com.apple.security.cs.allow-jit`**, **`allow-unsigned-executable-memory`**, **`disable-library-validation`** all default to `false` under the hardened runtime. Spelling them out as `<false/>` is a no-op — Apple's documentation is explicit that the absence of these keys is the secure default, and adding `<false/>` entries doesn't strengthen anything. We omit them too.
+- **Hardened runtime itself** is not an entitlements-file thing — it's a `codesign --options runtime` flag. The entitlements file does not need to declare it. The signing script (`scripts/sign-mac.sh` below) sets it.
 
-**USB validation spike (must run before M5 starts):** confirm that an unsandboxed, hardened-runtime, codesigned, notarized "hello world" app can call `rusb` to enumerate USB devices and open an RTL-SDR. Done as a 1-day spike on a real macOS box. If it fails, the entire epic blocks until we either (a) figure out the right entitlement combo, or (b) switch to `IOUSBHost`. The risk is real but manageable — many open-source SDR apps on macOS have already proven this works.
+If a future feature actually needs an entitlement (e.g., the v2 Mac App Store path needs `com.apple.security.app-sandbox` + `com.apple.security.device.usb`; or loading external dylibs at runtime would need `disable-library-validation`), it gets added then with a comment explaining the specific requirement. Until then, the file stays empty.
+
+**Why not sandboxed:** sandbox + USB device access is a deep rabbit hole on macOS. Apps that need raw libusb access typically either go unsandboxed (our v1 choice) or use the `IOUSBHost` framework (Apple's modern alternative, requires reworking `rusb` usage). For v1 we ship unsandboxed; v2 considers IOUSBHost if and when we want App Store distribution.
+
+**Why hardened runtime is on:** notarization requires it. The signing flag (`--options runtime`) enables it; the entitlements file does not need any keys to support a non-sandboxed, non-JIT app under the hardened runtime — that's the default secure configuration.
+
+**USB validation spike (must run before M5 starts):** confirm that an unsandboxed, hardened-runtime, codesigned, notarized "hello world" app statically linked against `libsdr_core.a` (which embeds `rusb`/libusb via the static lib) can enumerate USB devices and open an RTL-SDR. Done as a 1-day spike on a real macOS box. The expected outcome is "yes, with no entitlements" — many open-source SDR apps on macOS have proven this works. If the spike fails, we revisit (likely candidate: `com.apple.security.cs.disable-library-validation` if the linking pulls in a runtime dylib we didn't expect, or `IOUSBHost` if we have to leave libusb behind entirely). The risk is real but bounded.
 
 ## Code Signing
 

--- a/docs/superpowers/specs/2026-04-12-swift-ui-packaging-design.md
+++ b/docs/superpowers/specs/2026-04-12-swift-ui-packaging-design.md
@@ -1,0 +1,505 @@
+---
+name: SwiftUI Packaging, Signing, and CI — Design
+description: Xcode project layout under apps/macos, Rust static-lib build integration, universal binary, codesign + notarization, USB entitlements, GitHub Actions matrix
+type: spec
+---
+
+# SwiftUI Packaging, Signing, and CI — Design
+
+**Status:** Draft
+**Date:** 2026-04-12
+**Parent epic:** `2026-04-12-swift-ui-macos-epic-design.md`
+**Depends on:** `2026-04-12-sdr-ffi-c-abi-design.md`, `2026-04-12-swift-ui-surface-design.md`
+**Tracking issues:** TBD
+
+---
+
+## Goal
+
+Define how the SwiftUI app gets *built*, *signed*, *notarized*, and *shipped* so that a user on a clean macOS 26 machine can download `SDRMac.app`, drag it to `/Applications`, plug in an RTL-SDR dongle, and run it. Plus the GitHub Actions setup that produces a notarized `.app` on every release tag.
+
+This is the last milestone in the epic because everything else needs to exist before there's a `.app` to sign.
+
+## Non-Goals
+
+- **Mac App Store distribution.** Sandboxing limits USB device access in ways we don't want to fight in v1. Direct download via developer-ID + notarization is the path.
+- **Sparkle / auto-update.** Out of scope for v1. Users redownload from the GitHub release page. Sparkle integration is a v2 issue.
+- **Linux packaging changes.** This spec is macOS-only. Existing Linux packaging (Cargo, .desktop file, etc.) stays as-is.
+- **Homebrew cask.** v2. Trivial to add once notarized binaries exist on GH releases.
+- **Universal2 binary that includes Linux.** Not a thing. macOS only.
+- **A second build system on top of Cargo.** We use Cargo to build Rust, Xcode to build Swift, and a single shell script (`scripts/build-mac.sh`) to glue them. No CMake, no Bazel, no xcodegen, no Tuist.
+
+## Background
+
+What ships:
+
+```text
+SDRMac.app/
+├── Contents/
+│   ├── Info.plist
+│   ├── PkgInfo
+│   ├── MacOS/
+│   │   └── SDRMac                       (Mach-O universal: arm64 + x86_64)
+│   ├── Resources/
+│   │   ├── Assets.car                   (compiled asset catalog)
+│   │   ├── AppIcon.icns
+│   │   └── ...
+│   ├── Frameworks/                      (empty in v1 — static lib, no embedded dylibs)
+│   └── _CodeSignature/
+│       └── CodeResources
+```
+
+The `SDRMac` binary statically links `libsdr_core.a`, so there's no `Frameworks/libsdr_core.dylib` to deal with — one binary, one signature, one notarization submission. This is the entire reason the FFI spec picked `staticlib` for v1.
+
+## Repository Layout
+
+```text
+apps/macos/
+├── README.md                            — quick "how to build" for contributors
+├── Package.swift                        — SwiftPM root for SdrCoreKit (wrapper lib)
+├── Packages/
+│   └── SdrCoreKit/
+│       ├── Package.swift
+│       ├── Sources/
+│       │   ├── sdr_core_c/              — systemModule wrapping include/sdr_core.h
+│       │   │   └── module.modulemap
+│       │   └── SdrCoreKit/              — Swift wrappers
+│       │       └── *.swift
+│       └── Tests/
+│           └── SdrCoreKitTests/
+├── SDRMac.xcodeproj/                    — Xcode project
+│   └── project.pbxproj
+├── SDRMac/                              — app source
+│   ├── SDRMacApp.swift                  — @main
+│   ├── ContentView.swift
+│   ├── Models/
+│   │   └── CoreModel.swift
+│   ├── Views/
+│   │   ├── HeaderToolbar.swift
+│   │   ├── SourceSection.swift
+│   │   ├── RadioSection.swift
+│   │   ├── DisplaySection.swift
+│   │   ├── SpectrumWaterfallView.swift  — NSViewRepresentable
+│   │   ├── FrequencyScaleOverlay.swift
+│   │   └── StatusBar.swift
+│   ├── Renderer/                        — Metal pipeline (M4 output)
+│   │   ├── SpectrumMTKView.swift
+│   │   ├── Shaders.metal
+│   │   └── Palettes.swift
+│   ├── Resources/
+│   │   ├── Assets.xcassets/
+│   │   └── Info.plist
+│   └── Entitlements/
+│       └── SDRMac.entitlements
+└── SDRMacTests/
+    └── *Tests.swift
+
+scripts/
+├── build-mac.sh                         — builds Rust libs + drives xcodebuild
+├── sign-mac.sh                          — codesign + notarytool
+└── release-mac.sh                       — build + sign + notarize + staple
+
+include/
+└── sdr_core.h                           — same file the FFI spec produces
+
+target/                                  — Cargo output
+```
+
+The Xcode project is checked in as a real `.xcodeproj` (not generated). Reasoning: contributors will open it daily, the project file rarely changes, and the projects-from-yaml ecosystem (xcodegen / Tuist) adds an external tool that has to be installed before you can do *anything*. We accept the merge-friction tax of the binary `.pbxproj` because the alternative is worse for newcomers.
+
+## Build Pipeline
+
+A single shell script does the entire build, callable from both developer machines and CI.
+
+### `scripts/build-mac.sh`
+
+```bash
+#!/usr/bin/env bash
+# Builds the macOS app end-to-end. Idempotent. Used by both devs and CI.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET_DIR="${REPO}/target"
+LIPO_LIB="${TARGET_DIR}/universal/release/libsdr_core.a"
+
+CONFIG="${1:-Debug}"        # Debug | Release
+
+# 1. Build the Rust static lib for both architectures.
+for triple in aarch64-apple-darwin x86_64-apple-darwin; do
+    echo "==> cargo build --target ${triple}"
+    rustup target add "${triple}" >/dev/null
+    cargo build --release --package sdr-ffi --target "${triple}"
+done
+
+# 2. lipo into a universal static lib that Xcode can link.
+mkdir -p "$(dirname "${LIPO_LIB}")"
+lipo -create \
+    "${TARGET_DIR}/aarch64-apple-darwin/release/libsdr_core.a" \
+    "${TARGET_DIR}/x86_64-apple-darwin/release/libsdr_core.a" \
+    -output "${LIPO_LIB}"
+
+# 3. Build the Xcode project. The project's "Library Search Paths" build setting
+#    points at $(SRCROOT)/../../target/universal/release.
+xcodebuild \
+    -project "${REPO}/apps/macos/SDRMac.xcodeproj" \
+    -scheme SDRMac \
+    -configuration "${CONFIG}" \
+    -destination 'generic/platform=macOS' \
+    -derivedDataPath "${TARGET_DIR}/xcode" \
+    SDR_CORE_LIB_PATH="${LIPO_LIB}" \
+    build
+```
+
+Why this is *not* an Xcode "Run Script Build Phase": pre-build phases that shell out to Cargo make Xcode's incremental builds slow, confuse the index store, and break Live Issues. Putting the cargo invocation in an outer script means you run `./scripts/build-mac.sh Debug` once after editing Rust, then iterate inside Xcode normally for Swift changes. CI just calls the same script.
+
+The script *is* idempotent — if neither architecture's lib is out of date, cargo no-ops, lipo runs in milliseconds, and Xcode does an incremental Swift build.
+
+> **Cross-compilation note:** building `x86_64-apple-darwin` from an Apple Silicon Mac requires only the rustup target — no separate toolchain. The `coreaudio-sys` build script and any other native deps work fine because Apple's `clang` is universal by default.
+
+### Xcode Build Phase: Universal Library Selection
+
+In `SDRMac.xcodeproj`, the `SDRMac` target's Build Settings include:
+
+```text
+LIBRARY_SEARCH_PATHS = $(SDR_CORE_LIB_PATH:dir)
+OTHER_LDFLAGS        = -lsdr_core -lc++ -framework AudioUnit -framework CoreAudio -framework AudioToolbox -framework Metal -framework MetalKit
+HEADER_SEARCH_PATHS  = $(SRCROOT)/../../include
+ARCHS                = arm64 x86_64
+ONLY_ACTIVE_ARCH     = NO     (for Release; YES for Debug to keep dev iteration fast)
+```
+
+`SDR_CORE_LIB_PATH` is injected by `build-mac.sh`. When developers open Xcode directly without running the script first, Xcode falls back to a sensible default (`$(SRCROOT)/../../target/universal/release/libsdr_core.a`) and produces a clear "library not found" error if the script hasn't been run yet, with a hint pointing at the script.
+
+The `-lc++` is required because some `coreaudio-rs` symbols pull in C++ runtime bits (small, unavoidable). `-framework Metal -framework MetalKit` is needed for the renderer. `AudioUnit` / `CoreAudio` / `AudioToolbox` are needed by `libsdr_core.a` (CoreAudio sink).
+
+## Info.plist & Entitlements
+
+### `Info.plist` highlights
+
+```xml
+<key>CFBundleIdentifier</key>
+<string>com.jasonherald.sdrmac</string>
+<key>LSMinimumSystemVersion</key>
+<string>26.0</string>
+<key>NSHumanReadableCopyright</key>
+<string>© 2026 Jason Herald</string>
+<key>NSPrincipalClass</key>
+<string>NSApplication</string>
+<key>NSHighResolutionCapable</key>
+<true/>
+
+<!-- USB hot-plug requires this on hardened runtime: -->
+<key>NSAppleEventsUsageDescription</key>
+<string>SDRMac uses hardware events for RTL-SDR USB device access.</string>
+```
+
+### `SDRMac.entitlements`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Hardened runtime: required for notarization -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <false/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <false/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <false/>
+
+    <!-- USB device access for RTL-SDR (libusb via rusb) -->
+    <key>com.apple.security.device.usb</key>
+    <true/>
+
+    <!-- We are NOT sandboxed in v1. -->
+    <!-- (No <com.apple.security.app-sandbox/> entry.) -->
+
+    <!-- Audio output: not needed for non-sandboxed apps; CoreAudio works as-is. -->
+</dict>
+</plist>
+```
+
+**Why not sandboxed:** sandbox + USB device access is a deep rabbit hole on macOS. Apps that need raw libusb access typically either go unsandboxed (our v1 choice) or use the `IOUSBHost` framework (Apple's modern alternative, requires reworking `rusb` usage). For v1 we ship unsandboxed; v2 considers IOUSBHost.
+
+**Why hardened runtime is on:** notarization requires it. `com.apple.security.cs.allow-jit = false` is the default; we don't JIT.
+
+**USB validation spike (must run before M5 starts):** confirm that an unsandboxed, hardened-runtime, codesigned, notarized "hello world" app can call `rusb` to enumerate USB devices and open an RTL-SDR. Done as a 1-day spike on a real macOS box. If it fails, the entire epic blocks until we either (a) figure out the right entitlement combo, or (b) switch to `IOUSBHost`. The risk is real but manageable — many open-source SDR apps on macOS have already proven this works.
+
+## Code Signing
+
+Two configurations:
+
+**Local development:** ad-hoc signing (`-`). The dev's machine accepts unsigned local builds. No certificates needed for `cargo build && open SDRMac.app`.
+
+**Distribution:** Developer ID Application certificate, plus the corresponding Developer ID Installer certificate if we ever ship a `.pkg` (we don't, in v1).
+
+### `scripts/sign-mac.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH="${1:?usage: sign-mac.sh path/to/SDRMac.app}"
+IDENTITY="${SDR_SIGNING_IDENTITY:?must be set to a Developer ID Application name}"
+ENTITLEMENTS="apps/macos/SDRMac/Entitlements/SDRMac.entitlements"
+
+# Sign nested executables first (none in v1, but future-proof).
+# Then sign the main bundle.
+codesign --force --deep \
+    --sign "${IDENTITY}" \
+    --options runtime \
+    --entitlements "${ENTITLEMENTS}" \
+    --timestamp \
+    "${APP_PATH}"
+
+# Verify the signature.
+codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+spctl --assess --verbose=4 --type execute "${APP_PATH}" || true   # informational
+```
+
+`--options runtime` enables the hardened runtime. `--timestamp` is required by notarization. `--deep` is somewhat deprecated by Apple, but for an app with no nested signed content it's still the simplest correct choice; if we add embedded frameworks later we'll switch to per-component signing.
+
+### Notarization with `notarytool`
+
+```bash
+# scripts/release-mac.sh (excerpt)
+ZIP="$(mktemp -t SDRMac).zip"
+ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${ZIP}"
+
+xcrun notarytool submit "${ZIP}" \
+    --apple-id     "${APPLE_ID}" \
+    --team-id      "${APPLE_TEAM_ID}" \
+    --password     "${APPLE_APP_PASSWORD}" \
+    --wait \
+    --timeout      30m
+
+xcrun stapler staple "${APP_PATH}"
+xcrun stapler validate "${APP_PATH}"
+```
+
+Stapling embeds the notarization ticket into the `.app` so Gatekeeper accepts it offline. After this the `.app` is ready to upload to the GitHub release.
+
+## GitHub Actions
+
+Two new workflow files:
+
+### `.github/workflows/macos-build.yml` (per-PR build, no signing)
+
+Triggers on every PR that touches `apps/macos/**`, `crates/sdr-ffi/**`, `crates/sdr-core/**`, `crates/sdr-sink-audio/**`, or `include/sdr_core.h`. Catches Rust↔Swift drift early.
+
+```yaml
+name: macOS build
+on:
+  pull_request:
+    paths:
+      - 'apps/macos/**'
+      - 'crates/sdr-ffi/**'
+      - 'crates/sdr-core/**'
+      - 'crates/sdr-sink-audio/**'
+      - 'include/sdr_core.h'
+      - 'scripts/build-mac.sh'
+
+jobs:
+  build:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - uses: Swift-actions/setup-swift@v2
+        with:
+          swift-version: '6.1'
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build (Debug, ad-hoc signed)
+        run: ./scripts/build-mac.sh Debug
+
+      - name: Run SwiftPM tests
+        working-directory: apps/macos/Packages/SdrCoreKit
+        run: swift test
+
+      - name: Header drift check
+        run: make ffi-header-check
+
+      - name: Run Xcode unit tests
+        run: |
+          xcodebuild test \
+            -project apps/macos/SDRMac.xcodeproj \
+            -scheme SDRMac \
+            -destination 'platform=macOS' \
+            -derivedDataPath target/xcode
+```
+
+### `.github/workflows/macos-release.yml` (tag-triggered, signs + notarizes)
+
+```yaml
+name: macOS release
+on:
+  push:
+    tags: ['v*.*.*']
+
+jobs:
+  release:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      # Import certificates from base64-encoded secrets
+      - name: Import signing certs
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_P12_PASSWORD: ${{ secrets.MACOS_CERT_P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          echo "${MACOS_CERT_P12_BASE64}" | base64 --decode > /tmp/cert.p12
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" build.keychain
+          security import /tmp/cert.p12 -k build.keychain -P "${MACOS_CERT_P12_PASSWORD}" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PASSWORD}" build.keychain
+
+      - name: Build Release
+        run: ./scripts/build-mac.sh Release
+
+      - name: Sign + notarize + staple
+        env:
+          SDR_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+          APPLE_ID:             ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID:        ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD:   ${{ secrets.APPLE_APP_PASSWORD }}
+        run: ./scripts/release-mac.sh
+
+      - name: Create DMG
+        run: |
+          hdiutil create -volname "SDRMac" \
+            -srcfolder target/xcode/Build/Products/Release/SDRMac.app \
+            -ov -format UDZO target/SDRMac-${{ github.ref_name }}.dmg
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/SDRMac-*.dmg
+```
+
+### Required GitHub secrets
+
+| Secret name              | What                                                  |
+|--------------------------|-------------------------------------------------------|
+| `MACOS_CERT_P12_BASE64`  | Developer ID Application cert exported as `.p12`, base64'd |
+| `MACOS_CERT_P12_PASSWORD`| Password protecting that `.p12`                       |
+| `MACOS_KEYCHAIN_PASSWORD`| Throwaway password for the temp build keychain       |
+| `MACOS_SIGNING_IDENTITY` | The cert's display name (e.g., `Developer ID Application: Jason Herald (TEAMID)`) |
+| `APPLE_ID`               | Developer Apple ID (email)                            |
+| `APPLE_TEAM_ID`          | 10-character team ID                                  |
+| `APPLE_APP_PASSWORD`     | App-specific password from appleid.apple.com         |
+
+These are configured once before the first release. Documented in `apps/macos/README.md`.
+
+## Versioning
+
+The Xcode project uses:
+
+```text
+MARKETING_VERSION         = 0.1.0      (CFBundleShortVersionString)
+CURRENT_PROJECT_VERSION   = 1          (CFBundleVersion, increments per release)
+```
+
+Both are bumped manually for now. Tag → release script: `git tag v0.1.0 && git push --tags` triggers the release workflow. The tag and the marketing version stay in sync.
+
+The Rust side uses `cargo workspace.package.version` for `sdr-core` and `sdr-ffi`, currently `0.1.0`. The C ABI version (`SDR_CORE_ABI_VERSION_MAJOR/MINOR`) is independent and only bumps on FFI surface changes, not on app releases.
+
+## Local Developer Workflow
+
+After this milestone lands, a contributor's macOS workflow is:
+
+```bash
+git clone https://github.com/jasonherald/rtl-sdr.git
+cd rtl-sdr
+./scripts/build-mac.sh Debug
+open apps/macos/SDRMac.xcodeproj
+# Hit Cmd-R in Xcode → app launches, ad-hoc signed, no Gatekeeper prompt
+# (because it's running from Xcode's derived data, not /Applications)
+```
+
+For Rust changes, re-run `./scripts/build-mac.sh Debug` (cargo incremental keeps it fast). Swift changes are pure Xcode iteration.
+
+A `make mac` target wraps the script for CLI lovers:
+
+```makefile
+# Makefile
+.PHONY: mac mac-release ffi-header-check
+mac:
+	./scripts/build-mac.sh Debug
+mac-release:
+	./scripts/build-mac.sh Release
+ffi-header-check:
+	cbindgen --config crates/sdr-ffi/cbindgen.toml --crate sdr-ffi --output target/sdr_core.h.generated
+	diff -u include/sdr_core.h target/sdr_core.h.generated
+```
+
+## Cargo-Side Changes
+
+Two small changes to the workspace `Cargo.toml`:
+
+1. Add `crates/sdr-core` and `crates/sdr-ffi` to `[workspace.members]` (when those crates land in M1/M2).
+2. Add a profile override for `sdr-ffi` to ensure release builds are LTO'd:
+
+```toml
+[profile.release.package.sdr-ffi]
+lto       = "fat"
+codegen-units = 1
+strip     = "debuginfo"
+```
+
+Smaller binary, faster code, no debug bloat in the shipped `.a`.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| GitHub macOS runners change versions and break the workflow | Pin `runs-on: macos-26` (or whatever the current LTS is). Rebuild on a new runner manually before changing the pin. |
+| `notarytool` rejects the app for an entitlement we don't expect | The first release submission is done locally so the developer can iterate quickly on entitlement fixes. Once it works locally, the CI workflow is stable. |
+| `coreaudio-sys` bindgen step fails on a fresh macOS runner because of missing system headers | Spike during M3 (CoreAudio sink) catches this. CI will reproduce within minutes if it breaks. |
+| Universal binary build doubles the cargo cache | Acceptable. Use `actions/cache` keyed on `Cargo.lock` so cold-cache builds are rare. |
+| Developer ID cert expires (5-year lifetime) | Tracked in a project README "ops" section. Renewal is a one-time admin task. |
+| Notarization wait times spike during Apple outages | `--wait --timeout 30m` covers the typical case. If notarization is down, the workflow fails, the release is delayed, no damage done — just retry after Apple recovers. |
+| User downloads the dmg, `xattr -p com.apple.quarantine` blocks launch | Stapling fixes this. We test stapling validity in the workflow before uploading the dmg. |
+
+## Open Questions
+
+- **Should the dmg include a background image and Applications symlink?** Standard polish; doable with `create-dmg` (npm) or hand-rolled `hdiutil` + `osascript`. **Lean: yes for v1, simple version (background + symlink, no fancy positioning).**
+- **Universal binary or two separate downloads?** Universal is simpler for users (one download regardless of CPU) and the size cost is ~30 MB extra in our case. **Lean: universal.**
+- **Where do release notes come from?** Hand-written in the release commit body; the workflow reads them via `softprops/action-gh-release`'s default GitHub-issue-style auto-generation. v1 is hand-written, v2 maybe auto.
+- **Should we sign the Rust static lib itself?** No — `.a` archives can't be signed. Only the final binary that links them. macOS doesn't care.
+
+## Implementation Sequencing
+
+This is M6, the final milestone. Sub-PRs:
+
+1. **`apps/macos/` skeleton** — empty Xcode project, `Package.swift`, `build-mac.sh`. Builds an empty SwiftUI window.
+2. **Wire `libsdr_core.a` linkage** — Xcode build settings, OTHER_LDFLAGS, header search paths. Verifies the FFI is callable from Swift end-to-end via a smoke test that calls `sdr_core_abi_version()` and prints it.
+3. **Code-signing scripts + entitlements file** — `sign-mac.sh`, ad-hoc signing works, `codesign --verify` clean.
+4. **Notarization script + GitHub workflow** — `release-mac.sh` succeeds locally, then the workflow runs on tag.
+5. **dmg packaging** — `release-mac.sh` produces the dmg, workflow uploads to release.
+6. **First v0.1.0 release.** :tada:
+
+## References
+
+- [Apple — Hardened Runtime](https://developer.apple.com/documentation/security/hardened_runtime)
+- [Apple — Notarizing macOS software before distribution](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
+- [Apple — `notarytool`](https://developer.apple.com/documentation/security/customizing_the_notarization_workflow)
+- [`coreaudio-rs`](https://github.com/RustAudio/coreaudio-rs) — informs framework link list
+- `2026-04-12-sdr-ffi-c-abi-design.md` — explains why staticlib was chosen and what gets linked
+- `2026-04-12-coreaudio-sink-design.md` — what `libsdr_core.a` needs from CoreAudio at link time

--- a/docs/superpowers/specs/2026-04-12-swift-ui-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-12-swift-ui-rendering-design.md
@@ -1,0 +1,324 @@
+---
+name: SwiftUI Spectrum + Waterfall Rendering — Design
+description: Metal-based renderer for the FFT plot and scrolling waterfall, embedded in SwiftUI via NSViewRepresentable, fed from sdr-core's pull-based FFT buffer
+type: spec
+---
+
+# SwiftUI Spectrum + Waterfall Rendering — Design
+
+**Status:** Draft
+**Date:** 2026-04-12
+**Parent epic:** `2026-04-12-swift-ui-macos-epic-design.md`
+**Depends on:** `2026-04-12-sdr-ffi-c-abi-design.md` (for `sdr_core_pull_fft`)
+**Tracking issues:** TBD
+
+---
+
+## Goal
+
+Render the live FFT plot and the scrolling waterfall at 60 fps on macOS using Metal, embedded inside SwiftUI views via `NSViewRepresentable`. Both views read from the same Rust-owned FFT buffer through `sdr_core_pull_fft`. The renderer is the perf-critical surface of the SwiftUI app — it's the only place where allocation discipline, GPU timing, and threading actually matter.
+
+The result must:
+
+- Sustain 60 fps with FFT size 4096 and a waterfall that holds ~1 minute of history.
+- Allocate **zero** Swift heap memory per frame after warmup.
+- Forward click and drag interactions to the engine as `setVfoOffset` / `setBandwidth` commands.
+- Match the visual quality of the GTK spectrum/waterfall (palette, dB grid, frequency labels, VFO overlay).
+
+## Non-Goals
+
+- **No SwiftUI `Canvas` fallback.** `Canvas` is fine for the FFT line at small sizes but falls over on the waterfall. Two rendering paths is two paths to maintain. Metal handles both.
+- **No SceneKit / RealityKit / SpriteKit.** Way too heavy.
+- **No CoreImage filter pipeline for the waterfall.** CIImage is convenient but its allocation profile is hostile to a 60 fps audio-driven loop.
+- **No 3D waterfall, no perspective tilt.** Flat 2D, like SDR++ and the GTK UI.
+- **No OpenGL fallback.** macOS 26 still ships GL but it's deprecated; we don't support 10.x; everything we target has Metal.
+- **No GPU compute for the FFT.** The CPU FFT in `sdr-dsp` (rustfft) is fast enough and we want one source of truth. The renderer only consumes magnitude bins.
+- **No multi-VFO rendering.** Single VFO overlay, matching the engine.
+
+## Background
+
+### How the GTK side does it
+
+`crates/sdr-ui/src/spectrum/` uses GTK's drawing area with cairo. Per frame: pull the latest FFT bins from `SharedFftBuffer`, draw the line plot, scroll the waterfall image up by one row, draw the new row at the bottom. Custom palette LUT in software. Works fine on Linux because GTK's drawing area double-buffers and cairo is reasonably fast for this scale, but it's CPU-bound and pegs a core at high FFT sizes.
+
+### Why Metal
+
+- The waterfall is fundamentally a texture that scrolls. Metal renders that essentially for free with a UV offset.
+- The FFT line is a strip of triangles or a `MTLLineStrip` — also essentially free.
+- The palette is a 1D texture lookup in a fragment shader. One sample per pixel, no CPU work.
+- `MTKView` manages drawable lifecycle, vsync sync, and resize handling. We don't write any of that.
+- Profiling tools (Xcode → Instruments → Metal System Trace) are first-class.
+
+### How the SwiftUI app gets a Metal view
+
+`MTKView` is `NSView`. SwiftUI doesn't host `NSView` natively, but `NSViewRepresentable` does. We wrap `MTKView` once and use it from any SwiftUI view that wants spectrum:
+
+```swift
+struct SpectrumWaterfallView: NSViewRepresentable {
+    let core: SdrCore
+    @Binding var minDb: Float
+    @Binding var maxDb: Float
+    @Binding var vfoOffsetHz: Double
+    @Binding var bandwidthHz: Double
+
+    func makeNSView(context: Context) -> SpectrumMTKView { ... }
+    func updateNSView(_ view: SpectrumMTKView, context: Context) { ... }
+}
+```
+
+`SpectrumMTKView` is the actual `MTKView` subclass that owns the Metal resources. SwiftUI re-runs `updateNSView` whenever a binding changes; the underlying view persists across re-runs.
+
+## High-Level Architecture
+
+```text
+SwiftUI body
+  └── SpectrumWaterfallView (NSViewRepresentable)
+       └── SpectrumMTKView : MTKView
+            ├── MTLDevice, MTLCommandQueue                       (created once)
+            ├── MTLRenderPipelineState × 3                       (created once)
+            │     • spectrumLine.metal      — strip plot
+            │     • waterfallScroll.metal   — full-screen quad sampling history texture
+            │     • vfoOverlay.metal        — colored rectangle
+            ├── MTLTexture: history (Format: r32Float, size W × H_HISTORY)
+            ├── MTLTexture: palette (Format: rgba8Unorm, size 256 × 1)
+            ├── MTLBuffer:  spectrumVerts (preallocated, size = max FFT bins × stride)
+            ├── MTLBuffer:  uniforms (min/max dB, VFO bounds, palette index, scroll offset)
+            └── draw(in:)
+                 1. core.withLatestFftFrame { bins, sr, freq in
+                       fillSpectrumVerts(bins)
+                       writeNextHistoryRow(bins)
+                       updateUniforms(...)
+                    }
+                 2. encode passes:
+                       a. waterfall full-screen quad
+                       b. spectrum line strip
+                       c. VFO overlay rectangle
+                 3. presentDrawable + commit
+```
+
+The display link is `MTKView`'s built-in vsync. We do **not** use `CVDisplayLink` directly — `MTKView` configured with `preferredFramesPerSecond = 60` and `enableSetNeedsDisplay = false` calls `draw(in:)` on the main thread at vsync.
+
+## Texture Strategy: The Waterfall Ring
+
+The waterfall shows the last *N* FFT frames as a heatmap. The naive approach (memmove the texture up by one row each frame) is what cairo does on the GTK side and it scales poorly. Metal makes it trivial to do correctly:
+
+- Allocate **one** `MTLTexture` of size `(fftBins × historyRows)` in `r32Float`. Each texel is one dB value (or one pre-normalized 0..1 value).
+- Treat the texture as a **ring buffer along the rows axis.** Maintain a `writeRow` cursor that advances each frame, wrapping at `historyRows`.
+- Write the new FFT frame into row `writeRow` via `texture.replace(region:mipmapLevel:withBytes:bytesPerRow:)`. **One row per frame**, ~16 KB at 4096 bins. Negligible.
+- Increment `writeRow = (writeRow + 1) % historyRows`. Pass `writeRow` to the shader as a uniform.
+- The fragment shader samples `history` at `(uv.x, fract((uv.y * historyRows + writeRow) / historyRows))` so the visible scroll appears continuous even though the texture itself hasn't moved. **Zero memmove. Zero reallocation. One texture write per frame.**
+
+The fragment shader then maps the sampled dB value through the palette LUT:
+
+```metal
+fragment float4 waterfall_frag(VertexOut in [[stage_in]],
+                               texture2d<float> history [[texture(0)]],
+                               texture2d<float> palette [[texture(1)]],
+                               constant Uniforms& u    [[buffer(0)]]) {
+    constexpr sampler s(filter::linear, address::clamp_to_edge);
+    float wrapped_y = fract((in.uv.y * u.history_rows + u.write_row) / u.history_rows);
+    float db = history.sample(s, float2(in.uv.x, wrapped_y)).r;
+    float t = saturate((db - u.min_db) / (u.max_db - u.min_db));
+    return palette.sample(s, float2(t, 0.5));
+}
+```
+
+The vertex shader is a standard fullscreen-quad. UV coordinates are passed through; nothing fancy.
+
+### Sizing
+
+- `fftBins` = the current FFT size (1024 / 2048 / 4096 / 8192). When the user changes FFT size, the texture is recreated. This is rare (user-initiated, not per-frame).
+- `historyRows` = a fixed 1024. At 20 fps that's ~50 seconds of history; at 60 fps it's ~17 seconds. Both feel right for the use case.
+
+## Spectrum Line Pipeline
+
+Two reasonable approaches:
+
+1. **`MTLLineStrip` primitive.** Each FFT bin = one vertex. Vertex shader maps `(binIndex, db)` to NDC using uniforms (min/max dB, bin count). No fragment work beyond color. ~4 KB of vertex data per frame at 4096 bins. **This is the choice.**
+2. **Triangle strip "filled area" plot** (a la SDR++'s shaded spectrum). Optional v2 visual: same vertex data, doubled, with the bottom row at `min_db`. We start with the line and add the fill in v2 if users want it.
+
+```metal
+vertex VertexOut spectrum_vert(uint vid [[vertex_id]],
+                               constant float* mags_db [[buffer(0)]],
+                               constant Uniforms& u    [[buffer(1)]]) {
+    float x = 2.0 * (float(vid) / float(u.bin_count - 1)) - 1.0;
+    float y = 2.0 * saturate((mags_db[vid] - u.min_db) / (u.max_db - u.min_db)) - 1.0;
+    VertexOut out;
+    out.position = float4(x, y, 0.0, 1.0);
+    return out;
+}
+```
+
+The buffer holding `mags_db` is **pre-allocated once** at the maximum supported FFT size. Each frame we copy the current bins into the prefix and tell `drawPrimitives` how many vertices to use. No allocation, no resize.
+
+## Frame Path (per frame, on the main thread)
+
+```text
+draw(in: MTKView):
+
+  1. did_pull = core.withLatestFftFrame { bins, sample_rate, center_freq in
+         memcpy bins → spectrumVerts.contents()
+         texture.replace(region: row(writeRow), bytes: bins, ...)
+         writeRow = (writeRow + 1) % historyRows
+         lastSampleRate = sample_rate
+         lastCenterFreq = center_freq
+     }
+     // If did_pull == false, we're rendering the same data as last frame.
+     // The waterfall scroll offset is NOT advanced — we don't fake history.
+
+  2. uniforms.minDb         = bindings.minDb
+     uniforms.maxDb         = bindings.maxDb
+     uniforms.binCount      = currentFftSize
+     uniforms.historyRows   = HISTORY_ROWS
+     uniforms.writeRow      = writeRow
+     uniforms.vfoCenterNdc  = ... derived from vfoOffsetHz, sampleRate
+     uniforms.vfoWidthNdc   = ... derived from bandwidthHz
+
+  3. cmd = commandQueue.makeCommandBuffer()
+     enc = cmd.makeRenderCommandEncoder(descriptor: drawable.passDescriptor)
+
+     enc.setRenderPipelineState(waterfallPipeline)
+     enc.setFragmentTexture(historyTexture, index: 0)
+     enc.setFragmentTexture(paletteTexture, index: 1)
+     enc.setFragmentBytes(&uniforms, length: ..., index: 0)
+     enc.drawPrimitives(.triangleStrip, vertexStart: 0, vertexCount: 4)
+
+     enc.setRenderPipelineState(spectrumPipeline)
+     enc.setVertexBuffer(spectrumVertsBuffer, offset: 0, index: 0)
+     enc.setVertexBytes(&uniforms, length: ..., index: 1)
+     enc.drawPrimitives(.lineStrip, vertexStart: 0, vertexCount: currentFftSize)
+
+     enc.setRenderPipelineState(vfoOverlayPipeline)
+     enc.setFragmentBytes(&uniforms, length: ..., index: 0)
+     enc.drawPrimitives(.triangleStrip, vertexStart: 0, vertexCount: 4)
+
+     enc.endEncoding()
+     cmd.present(drawable)
+     cmd.commit()
+```
+
+Allocations on the hot path: **zero**. Buffers, textures, pipeline states, and uniform structs all live for the lifetime of the view.
+
+## Layout: Two Views or One?
+
+The GTK app uses a `GtkPaned` to split spectrum (top) and waterfall (bottom). Two options for SwiftUI:
+
+1. **Two separate `MTKView`s** in a `VStack` with a divider, each rendering its own thing.
+2. **One `MTKView` with a viewport split**, drawing spectrum into the top portion and waterfall into the bottom.
+
+**Choice: option 2.** One Metal pipeline, one drawable per frame, one uniforms upload, one FFT pull. Two views would mean two `draw(in:)` callbacks, two pulls (only one of which gets a fresh frame), and a desync hazard between the two halves. The split is a viewport calculation, not separate widgets.
+
+The user-draggable divider is implemented in SwiftUI via a `GeometryReader` + `gesture(DragGesture())` that updates a `@State splitFraction: CGFloat`, which is passed into the renderer as a uniform. The Metal side just uses two viewports per frame.
+
+```swift
+// SpectrumWaterfallView.swift
+GeometryReader { geo in
+    SpectrumWaterfallMetalView(core: core, splitY: $splitFraction, ...)
+        .gesture(
+            DragGesture()
+                .onChanged { drag in
+                    splitFraction = clamp((drag.location.y / geo.size.height), 0.1, 0.9)
+                }
+        )
+}
+```
+
+## Interaction: Click-to-Tune & VFO Drag
+
+Mouse events arrive as `NSEvent` on the `MTKView`. We override:
+
+- `mouseDown(with:)` — convert click X to a frequency offset relative to center, send `core.setVfoOffset(offset)` (and `core.tune(...)` if click is in the spectrum/waterfall area but Cmd is held → re-center). Same model as the GTK UI's click handler.
+- `mouseDragged(with:)` — if the drag started inside the VFO bandwidth band, update bandwidth (`core.setBandwidth(...)`); if outside, drag the VFO center.
+- `magnify(with:)` — pinch zoom on the spectrum X-axis (v2 nicety).
+- `scrollWheel(with:)` — scroll the waterfall through history (v2). For v1 we ignore.
+
+The hit test for "is this click on the VFO band" uses the same uniforms the shader uses, so they can never disagree.
+
+Coordinates come in `NSView` space. We convert with `convert(_:from:nil)` and divide by `bounds.width` to normalize. Center frequency and effective sample rate are kept on the SwiftUI side (received via `SDR_EVT_SAMPLE_RATE_CHANGED` and tune commands), so we don't have to read them back from the engine.
+
+## Frequency Scale & dB Grid Overlay
+
+These are static-ish text and lines. Two options:
+
+1. **Draw them in Metal too**, using a glyph atlas. Highest perf, most code.
+2. **Overlay a SwiftUI `Canvas`** above the `MTKView` in a `ZStack`. SwiftUI handles text rendering (which we don't want to reimplement). The grid lines and labels update only when range/center frequency changes, not per frame.
+
+**Choice: option 2.** Text rendering in Metal is a deep hole and the labels don't change every frame. A SwiftUI overlay is one view and uses macOS-standard typography. Cost: a small GPU compositing step per frame, but SwiftUI's `Canvas` only re-rasterizes when its inputs change, so the steady-state cost is just a layer composite.
+
+```swift
+ZStack(alignment: .topLeading) {
+    SpectrumWaterfallView(core: core, ...)         // MTKView wrapper
+    FrequencyScaleOverlay(centerHz: ..., spanHz: ..., minDb: ..., maxDb: ...)
+        .allowsHitTesting(false)                   // mouse falls through to Metal
+}
+```
+
+## Performance Budget
+
+Target: **60 fps at FFT size 4096**, on Apple Silicon and Intel.
+
+Per-frame budget (16.6 ms):
+- FFT pull + memcpy bins (4096 × 4 = 16 KB)            : ~10 µs
+- Texture row replace                                  : ~50 µs
+- Uniform struct fill                                  : <1 µs
+- 3 GPU passes (waterfall quad, spectrum strip, VFO)   : <1 ms on M1, <3 ms on Intel UHD 630
+- SwiftUI frequency scale overlay (when changed)       : <2 ms
+- **Total CPU**                                        : ~3 ms
+- **Total GPU**                                        : ~3-5 ms
+- Headroom                                             : 8-10 ms
+
+This budget assumes the dispatcher thread is **not** the renderer's bottleneck. The FFT pull is lock-free when nothing's new and a short-mutex when something is. The renderer is allowed to draw the same frame twice if no new data arrived; we don't block.
+
+When FFT rate < display rate (e.g., 20 fps engine, 60 fps display), the renderer naturally interpolates by drawing the same data 3 times. We don't temporal-interpolate the spectrum or the waterfall — that would lie about the data.
+
+## Resize Handling
+
+`MTKView` calls `mtkView(_:drawableSizeWillChange:)` when the window resizes. We don't recreate any textures or pipelines on resize — only the drawable size changes, and the vertex shader uses NDC, not pixels. The frequency scale overlay re-rasterizes naturally because its frame changes.
+
+## Threading
+
+All Metal calls happen on the main thread inside `draw(in:)`. The FFT pull is from the main thread. The renderer never touches engine state from any other thread. This matches SwiftUI's `MainActor` model and CoreGraphics' threading rules.
+
+The dispatcher thread (owned by `sdr-ffi`) hands events to SwiftUI via the `AsyncStream`; SwiftUI consumers `for await`-loop on `MainActor` and update bindings. Bindings drive the renderer's uniforms on the next frame. There is exactly one mutation point for any rendering input.
+
+## Test Strategy
+
+- **Unit tests** for the math: bin index → frequency, click X → VFO offset, dB → palette index. These run in `SdrCoreKitTests` without any rendering.
+- **Snapshot tests** of the renderer using `MTKView`'s `currentDrawable.texture` after one `draw(in:)` call, comparing against a checked-in PNG. Useful for catching shader regressions. macOS-only test target.
+- **Performance test** using `XCTMetric.gpu` and `XCTMetric.cpu`: spin the renderer for 5 seconds with a synthetic FFT source (a fixed bin pattern fed via `sdr_core_pull_fft`'s test mode), assert frame-time stays under 16 ms.
+- **Manual perf gate**: Instruments → Metal System Trace → no frames over 16 ms, no main-thread allocations after warmup. Captured before merging M4.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `MTKView` inside `NSViewRepresentable` re-creates on every SwiftUI re-render | `makeNSView` runs once; `updateNSView` only mutates. The renderer's expensive setup is in `init`, called from `makeNSView`. Verified by adding a counter and asserting it stays at 1 per view lifetime. |
+| Click-to-tune feels laggy because of FFT-rate / display-rate mismatch | The click handler sends commands directly to `core` — independent of FFT rate. Visual feedback on the spectrum follows on the next FFT frame. Same UX as SDR++. |
+| Palette LUT is hardcoded in code, hard to swap | Ship 4 palettes (turbo, viridis, magma, classic) as compile-time `[UInt8]` arrays. Settings UI swaps which one is uploaded. v2 — for v1 just use turbo. |
+| Texture row replace is a GPU stall on Intel discrete GPUs | Rare on macOS hardware (almost everything is integrated). If it bites, switch to a tripled-up `MTLBuffer` and write via blit encoder. v2 if needed. |
+| User changes FFT size mid-stream — texture must reallocate without flicker | On size change: lazily recreate `historyTexture` on the next `draw(in:)`, fill with `min_db` baseline so the new history fades in. The user perceives one blank frame; acceptable. |
+| SwiftUI animation interferes with `MTKView`'s vsync | Set `view.layer?.actions = [:]` and `disableAnimations` on the host view to suppress implicit Core Animation transitions. Standard `MTKView` boilerplate. |
+
+## Open Questions
+
+- **`enableSetNeedsDisplay = false` (continuous vsync) vs. true (manual invalidate):** continuous gives us a steady 60 fps tick which simplifies the "draw same frame twice if no new data" path. Manual would save a few percent of GPU when nothing's happening. **Lean: continuous in v1**, revisit if battery profiling on a MacBook is bad.
+- **MetalKit vs. raw Metal:** `MTKView` is in MetalKit; nothing else from MetalKit is needed. Adds one framework link, no runtime cost. **Lean: MTKView**.
+- **Should the SwiftUI app expose a "Renderer FPS" debug overlay?** Useful during development, ugly in shipping. **Lean: yes, behind a hidden settings toggle that defaults off.**
+- **Should the renderer draw a max-hold trace** (peak hold across all FFT frames)? **No for v1**; this is a Display Panel feature and the engine already supports it via `SetAveragingMode`. v2 surfaces it.
+
+## Implementation Sequencing
+
+This is M4 in the epic. It can start as soon as the FFI surface (M2) is callable from Swift, even before the full SwiftUI app shell exists. M4 produces a standalone test app that just renders a Metal spectrum from a synthetic FFT source, so the renderer is validated in isolation before being dropped into the real app shell in M5.
+
+Sub-PRs:
+1. **Renderer skeleton + spectrum line only**, fed by a synthetic source. No waterfall, no overlay.
+2. **Waterfall texture ring + scroll shader**, same synthetic source.
+3. **VFO overlay + click-to-tune + drag**, wired into a real `SdrCore` instance.
+4. **Frequency scale overlay (SwiftUI Canvas)** and dB grid.
+
+## References
+
+- [Apple — `MTKView` reference](https://developer.apple.com/documentation/metalkit/mtkview)
+- [Apple — Drawing Geometry with Metal](https://developer.apple.com/documentation/metal/using_metal_to_draw_a_view_s_contents)
+- `2026-04-12-sdr-ffi-c-abi-design.md` — `sdr_core_pull_fft` and `SdrFftFrame` it consumes
+- `crates/sdr-ui/src/spectrum/` — GTK reference implementation (cairo-based) for visual parity

--- a/docs/superpowers/specs/2026-04-12-swift-ui-surface-design.md
+++ b/docs/superpowers/specs/2026-04-12-swift-ui-surface-design.md
@@ -1,0 +1,549 @@
+---
+name: SwiftUI App Surface — Design
+description: SwiftUI app shell, screen-by-screen mapping from the GTK panels, observable model layered on SdrCoreKit, MVP cut and v2 deferrals
+type: spec
+---
+
+# SwiftUI App Surface — Design
+
+**Status:** Draft
+**Date:** 2026-04-12
+**Parent epic:** `2026-04-12-swift-ui-macos-epic-design.md`
+**Depends on:** `2026-04-12-sdr-ffi-c-abi-design.md`, `2026-04-12-swift-ui-rendering-design.md`
+**Tracking issues:** TBD
+
+---
+
+## Goal
+
+Define the SwiftUI app shell, the observable model that bridges `SdrCoreKit` to views, and the screen-by-screen mapping from the existing GTK panels to native macOS controls. This is the spec for everything you can *see* in the macOS app — windowing, sidebar, toolbars, settings, menus — and how those views talk to the engine.
+
+## Non-Goals
+
+- **Exact pixel placement.** Auto layout via SwiftUI defaults; tweaking comes after the first build runs.
+- **Theming / dark-mode customization.** SwiftUI gets system appearance for free; we respect it.
+- **Localization.** English-only in v1. Strings live in `Localizable.strings` so we can localize later without source edits.
+- **Accessibility audit beyond defaults.** SwiftUI controls are accessible by default; a real audit (VoiceOver, keyboard nav for waterfall) is v2.
+- **Animation polish.** SwiftUI default transitions are fine for v1.
+
+## Background
+
+The GTK app's user-facing surface (from the project review):
+
+- **AdwHeaderBar:** big frequency display, play/stop transport, demod selector, screenshot button
+- **AdwFlap sidebar (collapsible)** with accordion panels:
+  - Source Panel: device picker, sample rate, gain, AGC, PPM, network/file config, decimation, DC blocking, IQ inversion/correction, IQ recording
+  - Radio Panel: bandwidth, squelch (level/auto), de-emphasis, noise blanker, FM IF NR, WFM stereo, notch
+  - Display Panel: FFT size, averaging mode, min/max dB, FPS
+  - Navigation/Bookmarks: frequency bookmarks + RadioReference
+  - Transcript: speech-to-text display, model selection
+- **Center pane (GtkPaned split):** spectrum (top 30%) + waterfall (bottom 70%)
+- **Status bar:** SNR, sample rate, buffer metrics
+
+The MVP cut (from the epic doc) takes the **Source**, **Radio**, **Display** panels and the spectrum/waterfall — and ignores everything else for v1. v2 adds Bookmarks, Transcript, Network/File sources, recording, and the rest.
+
+## App Shell Structure
+
+```text
+SDRMacApp                      (struct App)
+├── WindowGroup                 — main window
+│   └── ContentView             — top-level NavigationSplitView
+│       ├── Sidebar             — sidebar panels (collapsible)
+│       │   ├── SourceSection
+│       │   ├── RadioSection
+│       │   └── DisplaySection
+│       └── DetailColumn        — spectrum + waterfall + status
+│           ├── HeaderToolbar   — big frequency, transport, demod picker
+│           ├── SpectrumWaterfallView (NSViewRepresentable from rendering spec)
+│           └── StatusBar
+└── Settings                    — settings scene (Cmd-,)
+    └── SettingsView
+        ├── GeneralPane         — config file location, log level
+        ├── AudioPane           — output device, latency target
+        └── AdvancedPane        — debug overlays, ffi version display
+```
+
+```swift
+@main
+struct SDRMacApp: App {
+    @State private var core = CoreModel()           // observable, owns SdrCore
+
+    var body: some Scene {
+        WindowGroup("SDR") {
+            ContentView()
+                .environment(core)
+                .frame(minWidth: 900, minHeight: 600)
+        }
+        .windowToolbarStyle(.unified)
+        .commands { SDRCommands(core: core) }       // menu bar items
+
+        Settings {
+            SettingsView()
+                .environment(core)
+        }
+    }
+}
+```
+
+`NavigationSplitView` is the macOS-native sidebar pattern. Sidebar collapses into a toolbar button via standard SwiftUI behavior — no custom AdwFlap analogue needed.
+
+`@Observable` (macOS 14+, fully cooked on macOS 26) is the model framework. One root model, passed via `.environment()`, observed by views automatically. No `@StateObject` / `ObservableObject` boilerplate.
+
+## The Observable Model
+
+`CoreModel` is the single source of truth for everything the UI displays. It owns the `SdrCore` instance, exposes typed bindings to views, and consumes the event stream on `MainActor`.
+
+```swift
+// CoreModel.swift
+import Observation
+import SdrCoreKit
+
+@MainActor
+@Observable
+final class CoreModel {
+    // Engine handle (constructed on first use)
+    private var core: SdrCore?
+
+    // Lifecycle state
+    var isRunning: Bool = false
+    var lastError: String? = nil
+
+    // Tuning
+    var centerFrequencyHz: Double = 100_700_000
+    var vfoOffsetHz: Double = 0
+    var sampleRateHz: Double = 2_000_000          // raw source rate (display bandwidth)
+    var effectiveSampleRateHz: Double = 250_000   // post-decimation
+    var ppmCorrection: Int = 0
+
+    // Tuner
+    var availableGains: [Double] = []
+    var gainDb: Double = 0
+    var agcEnabled: Bool = false
+    var deviceInfo: String = ""
+
+    // Demod
+    var demodMode: DemodMode = .wfm
+    var bandwidthHz: Double = 200_000
+    var squelchEnabled: Bool = false
+    var squelchDb: Float = -60
+    var deemphasis: Deemphasis = .us75
+
+    // Audio
+    var volume: Float = 0.5
+
+    // Display
+    var fftSize: Int = 2048
+    var fftWindow: FftWindow = .blackman
+    var fftRateFps: Double = 20
+    var minDb: Float = -100
+    var maxDb: Float = 0
+
+    // Status
+    var signalLevelDb: Float = -120
+
+    // Setup — called once on app launch
+    func bootstrap(configPath: URL) async {
+        do {
+            let c = try SdrCore(configPath: configPath)
+            self.core = c
+            Task { await consumeEvents(from: c.events) }
+        } catch {
+            self.lastError = "Failed to start engine: \(error)"
+        }
+    }
+
+    private func consumeEvents(from stream: AsyncStream<SdrCoreEvent>) async {
+        for await event in stream {
+            switch event {
+            case .sourceStopped:
+                isRunning = false
+            case .sampleRateChanged(let hz):
+                effectiveSampleRateHz = hz
+            case .signalLevel(let db):
+                signalLevelDb = db
+            case .deviceInfo(let s):
+                deviceInfo = s
+            case .gainList(let gains):
+                availableGains = gains
+            case .displayBandwidth(let hz):
+                sampleRateHz = hz
+            case .error(let msg):
+                lastError = msg
+            }
+        }
+    }
+
+    // Command-issuing methods, one per UI control. Each one swallows errors
+    // into `lastError` so the view layer never has to handle them.
+    func start()                       { try? core?.start();             isRunning = true  }
+    func stop()                        { try? core?.stop();              isRunning = false }
+    func setCenter(_ hz: Double)       { centerFrequencyHz = hz; try? core?.tune(hz) }
+    func setVfoOffset(_ hz: Double)    { vfoOffsetHz = hz; try? core?.setVfoOffset(hz) }
+    func setDemodMode(_ m: DemodMode)  { demodMode = m; try? core?.setDemodMode(m) }
+    func setBandwidth(_ hz: Double)    { bandwidthHz = hz; try? core?.setBandwidth(hz) }
+    func setGain(_ db: Double)         { gainDb = db; try? core?.setGain(db) }
+    func setAgc(_ on: Bool)            { agcEnabled = on; try? core?.setAgc(on) }
+    func setSquelch(_ db: Float)       { squelchDb = db; try? core?.setSquelchDb(db) }
+    func setSquelchEnabled(_ on: Bool) { squelchEnabled = on; try? core?.setSquelchEnabled(on) }
+    func setDeemphasis(_ m: Deemphasis){ deemphasis = m; try? core?.setDeemphasis(m) }
+    func setVolume(_ v: Float)         { volume = v; try? core?.setVolume(v) }
+    func setMinDb(_ db: Float)         { minDb = db }     // pure UI
+    func setMaxDb(_ db: Float)         { maxDb = db }     // pure UI
+    func setFftSize(_ n: Int)          { fftSize = n; try? core?.setFftSize(n) }
+    func setFftWindow(_ w: FftWindow)  { fftWindow = w; try? core?.setFftWindow(w) }
+    func setFftRate(_ fps: Double)     { fftRateFps = fps; try? core?.setFftRate(fps) }
+    func setPpm(_ ppm: Int)            { ppmCorrection = ppm; try? core?.setPpmCorrection(ppm) }
+
+    // Renderer pulls FFT through this — see rendering spec
+    var sdrCore: SdrCore? { core }
+}
+```
+
+**Why `@Observable` and not `ObservableObject`:** `@Observable` (Observation framework) tracks dependencies at the property-access level instead of the object level. A view that reads `model.frequencyHz` only re-renders when *that* property changes — not when any other property on the model changes. For a UI driven by 30 Hz event streams across many independent properties, this is a meaningful win and removes most of the `@Published`/`objectWillChange` ceremony.
+
+**Why one big model and not many smaller ones:** initial instinct is to split into `TunerModel`, `DemodModel`, `DisplayModel`, etc. Rejected for v1 because all of those touch the same engine handle and share lifecycle, and the Observation framework already gives us per-property granularity. We can split if it grows uncomfortable.
+
+## Screen-by-Screen
+
+### Header Toolbar
+
+```swift
+struct HeaderToolbar: ToolbarContent {
+    @Environment(CoreModel.self) private var model
+
+    var body: some ToolbarContent {
+        ToolbarItem(placement: .navigation) {
+            Button {
+                model.isRunning ? model.stop() : model.start()
+            } label: {
+                Image(systemName: model.isRunning ? "stop.fill" : "play.fill")
+            }
+            .keyboardShortcut("r", modifiers: .command)
+        }
+        ToolbarItem(placement: .principal) {
+            FrequencyEntry(hz: Bindable(model).centerFrequencyHz)
+                .font(.system(.title, design: .monospaced))
+                .frame(width: 240)
+        }
+        ToolbarItem(placement: .primaryAction) {
+            Picker("Mode", selection: Bindable(model).demodMode) {
+                ForEach(DemodMode.allCases, id: \.self) { Text($0.label).tag($0) }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 110)
+        }
+    }
+}
+```
+
+`FrequencyEntry` is a custom view: monospace text field with arrow-key step (configurable: 1 Hz / 100 Hz / 1 kHz / 10 kHz / 100 kHz / 1 MHz), rejects non-numeric input, accepts MHz/kHz suffixes ("100.7M"). Tab moves between digit groups.
+
+### Source Section (sidebar)
+
+MVP scope: RTL-SDR only. The whole "device picker" comes back in v2.
+
+```swift
+struct SourceSection: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        Section("Source") {
+            LabeledContent("Device") { Text(model.deviceInfo).foregroundStyle(.secondary) }
+            LabeledContent("Sample rate") {
+                Picker("", selection: Bindable(model).sampleRateHz) {
+                    ForEach(rtlSdrSampleRates, id: \.self) { Text(formatRate($0)).tag($0) }
+                }
+                .labelsHidden()
+            }
+            LabeledContent("Gain") {
+                if model.agcEnabled {
+                    Text("AGC").foregroundStyle(.secondary)
+                } else {
+                    Slider(
+                        value: Bindable(model).gainDb,
+                        in: gainRange(from: model.availableGains),
+                        step: 1,
+                        onEditingChanged: { _ in model.setGain(model.gainDb) }
+                    )
+                }
+            }
+            Toggle("AGC", isOn: Bindable(model).agcEnabled)
+            LabeledContent("PPM") {
+                Stepper(value: Bindable(model).ppmCorrection, in: -100...100) {
+                    Text("\(model.ppmCorrection)")
+                }
+            }
+        }
+    }
+}
+```
+
+Native `Slider`, `Stepper`, `Picker` — zero custom drawing. Bindings come from `Bindable(model).property` (the `@Observable` equivalent of `$model.property`).
+
+### Radio Section (sidebar)
+
+```swift
+struct RadioSection: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        Section("Radio") {
+            LabeledContent("Bandwidth") {
+                BandwidthEntry(hz: Bindable(model).bandwidthHz, mode: model.demodMode)
+            }
+            Toggle("Squelch", isOn: Bindable(model).squelchEnabled)
+            if model.squelchEnabled {
+                LabeledContent("Threshold") {
+                    Slider(value: Bindable(model).squelchDb, in: -120...0)
+                    Text("\(Int(model.squelchDb)) dB")
+                }
+            }
+            if model.demodMode == .wfm || model.demodMode == .nfm {
+                Picker("De-emphasis", selection: Bindable(model).deemphasis) {
+                    Text("None").tag(Deemphasis.none)
+                    Text("US 75µs").tag(Deemphasis.us75)
+                    Text("EU 50µs").tag(Deemphasis.eu50)
+                }
+                .pickerStyle(.segmented)
+            }
+            LabeledContent("Volume") {
+                Slider(value: Bindable(model).volume, in: 0...1)
+            }
+        }
+    }
+}
+```
+
+`BandwidthEntry` is another custom view that knows the sensible range for each demod mode (NFM 12.5 kHz default, WFM 200 kHz, AM 6 kHz, etc.) and offers presets in a pop-up.
+
+### Display Section (sidebar)
+
+```swift
+struct DisplaySection: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        Section("Display") {
+            Picker("FFT Size", selection: Bindable(model).fftSize) {
+                ForEach([1024, 2048, 4096, 8192], id: \.self) { Text("\($0)").tag($0) }
+            }
+            Picker("Window", selection: Bindable(model).fftWindow) {
+                Text("Rectangular").tag(FftWindow.rect)
+                Text("Hann").tag(FftWindow.hann)
+                Text("Hamming").tag(FftWindow.hamming)
+                Text("Blackman").tag(FftWindow.blackman)
+            }
+            LabeledContent("Min dB") {
+                Slider(value: Bindable(model).minDb, in: -150...0)
+            }
+            LabeledContent("Max dB") {
+                Slider(value: Bindable(model).maxDb, in: -150...0)
+            }
+        }
+    }
+}
+```
+
+### Center: Spectrum + Waterfall
+
+The Metal view from the rendering spec, in a `ZStack` with a SwiftUI overlay for the frequency scale and dB grid:
+
+```swift
+struct CenterView: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            SpectrumWaterfallView(
+                core: model.sdrCore,
+                centerHz: model.centerFrequencyHz,
+                bandwidthHz: model.sampleRateHz,
+                vfoOffsetHz: Bindable(model).vfoOffsetHz,
+                vfoBandwidthHz: Bindable(model).bandwidthHz,
+                minDb: Bindable(model).minDb,
+                maxDb: Bindable(model).maxDb
+            )
+            FrequencyScaleOverlay(
+                centerHz: model.centerFrequencyHz,
+                spanHz: model.sampleRateHz
+            )
+            .allowsHitTesting(false)
+        }
+    }
+}
+```
+
+The Metal view forwards click-to-tune via the `vfoOffsetHz` binding. The model's `setVfoOffset` is what fires the engine command — the binding setter calls it.
+
+### Status Bar
+
+```swift
+struct StatusBar: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Label("\(Int(model.signalLevelDb)) dB", systemImage: "waveform")
+            Label(formatRate(model.effectiveSampleRateHz), systemImage: "metronome")
+            Spacer()
+            if let err = model.lastError {
+                Label(err, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+            }
+        }
+        .font(.caption)
+        .padding(.horizontal, 12)
+        .frame(height: 22)
+        .background(.bar)
+    }
+}
+```
+
+### Settings Window
+
+Standard `Settings { ... }` scene; macOS gives us the Cmd-, shortcut and the proper window chrome for free.
+
+- **General:** config file path display (read from `~/Library/Application Support/SDRMac/config.json`), "Show in Finder" button, log level dropdown (writes through `sdr_core_init_logging`).
+- **Audio:** output device picker (v2 — placeholder in v1 saying "Default device" disabled), volume.
+- **Advanced:** ABI version (`sdr_core_abi_version()` formatted), Rust core version, debug overlays toggle.
+
+### Menu Bar (`.commands`)
+
+```swift
+struct SDRCommands: Commands {
+    let core: CoreModel
+
+    var body: some Commands {
+        CommandGroup(replacing: .newItem) { }   // hide File > New (no doc model)
+        CommandMenu("Radio") {
+            Button("Start") { core.start() }.keyboardShortcut("r", modifiers: .command)
+            Button("Stop")  { core.stop() }.keyboardShortcut(".", modifiers: .command)
+            Divider()
+            Button("Tune Up 100 kHz")   { core.setCenter(core.centerFrequencyHz + 100_000) }.keyboardShortcut(.upArrow, modifiers: [.command])
+            Button("Tune Down 100 kHz") { core.setCenter(core.centerFrequencyHz - 100_000) }.keyboardShortcut(.downArrow, modifiers: [.command])
+        }
+        CommandMenu("View") {
+            Button("Toggle Sidebar") { /* SwiftUI native */ }.keyboardShortcut("s", modifiers: [.command, .control])
+        }
+    }
+}
+```
+
+## Configuration & Persistence
+
+`sdr-config` already handles JSON read/write. The macOS app passes its config path on `sdr_core_create`:
+
+```swift
+let configDir = FileManager.default
+    .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+    .appendingPathComponent("SDRMac")
+let configPath = configDir.appendingPathComponent("config.json")
+try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+try await model.bootstrap(configPath: configPath)
+```
+
+The engine reads on startup, writes on shutdown. SwiftUI never touches the JSON file directly.
+
+There's one wrinkle: SwiftUI-only state (like `splitFraction` for the spectrum/waterfall divider, sidebar collapsed state, window size) isn't engine state and shouldn't be in the JSON. We use `@AppStorage` for those — they persist into the standard macOS user defaults.
+
+```swift
+@AppStorage("spectrumSplitFraction") private var splitFraction: Double = 0.3
+@AppStorage("sidebarVisible")        private var sidebarVisible: Bool = true
+```
+
+## Lifecycle & Threading
+
+```text
+App launch
+  ├─ SDRMacApp.init                     (creates @State CoreModel, no engine yet)
+  ├─ ContentView.task                   (calls model.bootstrap → creates SdrCore)
+  │   └─ SdrCore.init                   (calls sdr_core_create, registers callback)
+  │   └─ Task { consumeEvents }         (long-running for-await on AsyncStream)
+  └─ Windows render
+       └─ User clicks Play
+            └─ model.start()
+                 └─ sdr_core_start
+                      └─ DSP thread spins up
+
+App quit (Cmd-Q)
+  └─ Window closes
+       └─ CoreModel.deinit              (not guaranteed for @State; see below)
+            └─ SdrCore.deinit
+                 └─ sdr_core_destroy    (joins DSP + dispatcher threads, writes config)
+```
+
+`@State`-owned models don't get deterministic deinit on app termination. To guarantee config persistence on Cmd-Q, we hook `applicationWillTerminate` via an `NSApplicationDelegateAdaptor` and call `model.shutdown()` explicitly there. Standard SwiftUI macOS pattern.
+
+```swift
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    var model: CoreModel?
+    func applicationWillTerminate(_ notification: Notification) {
+        model?.shutdown()       // sync; blocks until DSP joined
+    }
+}
+```
+
+## v2 / Backlog Surface (excluded from MVP)
+
+These views exist as stubs in the file tree but are commented out / hidden behind feature flags:
+
+- **Source Picker** (RTL-SDR / Network / File)
+- **Network Source** form (host/port/protocol)
+- **File Source** picker
+- **Bookmarks Section** (sidebar) — list, add/edit, group by tag
+- **RadioReference Section** — county lookup, frequency table, "Tune" buttons
+- **Transcript Section** — scrolling text view, model picker (blocked on sherpa-onnx work)
+- **Recording Section** — IQ + audio recording controls, file path, level meter
+- **Display Section extras** — averaging mode, FPS slider
+- **Audio Device Picker** (Settings → Audio)
+- **Noise Blanker / FM IF NR / WFM Stereo / Notch** controls (Radio Section advanced)
+- **DC Blocking / IQ Inversion / IQ Correction** toggles (Source Section advanced)
+
+Each one is its own GitHub issue (tracked in the epic) with its own short design note when picked up.
+
+## Test Strategy
+
+- **`@Observable` model unit tests** (`SDRMacTests`): construct `CoreModel` with a mock `SdrCore` (Swift protocol over the same surface), drive it with synthetic events, assert published properties update correctly.
+- **Snapshot tests** of each panel using `swift-snapshot-testing` against fixed model state. Catches accidental layout regressions.
+- **Manual smoke checklist** before merging M5: launch app → tune FM 100.7 → audio plays → drag VFO → audio retunes → quit → relaunch and verify last frequency restored.
+- **No SwiftUI preview-only tests** — previews are dev-time only, not assertions.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `@Observable` granularity surprises (a view re-renders on a property it didn't read) | Verified by `_printChanges()` in previews during development. Per-property observation is well-tested in macOS 14+; macOS 26 gets the latest fixes. |
+| `NavigationSplitView` sidebar doesn't collapse to a button on narrow windows the way `AdwFlap` does | macOS native behavior since macOS 13. Verified in spike. If missing, fall back to a toggle button in the toolbar that drives sidebar visibility. |
+| `@AppStorage` and engine config drift apart (user changes a setting via UI but the engine's JSON has a stale value) | Engine state is *only* in engine JSON; UI-only state is *only* in `@AppStorage`. There is no overlap. Reviewer enforces this. |
+| Frequency text entry feels stiff because every keystroke fires a tune command | Debounce via SwiftUI `.onChange(of:) { ... }` with a `Task.sleep(milliseconds: 100)` cancellation pattern. Already a common idiom. |
+| The Settings window throws because `core` isn't bootstrapped yet | Settings reads `model.core` lazily; if nil, panes show placeholders. Bootstrap is sync-fast (no engine work, just `sdr_core_create`). |
+| Click-to-tune on Metal view doesn't update SwiftUI binding cleanly across the `NSViewRepresentable` boundary | Metal view stores a closure passed via `Coordinator`. The closure calls `model.setVfoOffset(...)` directly on `MainActor`. No binding round-trip needed. |
+
+## Open Questions
+
+- **Should we surface `availableGains` as discrete steps** (RTL-SDR exposes ~30 specific dB values, not a continuous range) **or as a continuous slider that snaps to nearest?** Lean: **discrete steps** via a custom `Slider`-replacement. The GTK UI does the same. Easier to communicate "you're at 33.8 dB" than "33.7-ish".
+- **Should we fail the app launch** if `SDR_CORE_ABI_VERSION_MAJOR` mismatches the bundled lib, or just show an error banner? Lean: **fail launch with a dialog**, since nothing else will work. Includes a "Show in Finder" button pointing at the lib.
+- **Should the FM/AM/SSB demod picker live in the toolbar (where I have it) or in the sidebar?** Lean: **toolbar**. It's the most-changed setting; the GTK UI has it in the header for the same reason.
+- **Big Sur-style "tab view" Settings vs. macOS 13+ "form" Settings?** Lean: **Form-style (`Form { ... }` with sections)**, the modern default.
+
+## Implementation Sequencing
+
+This is M5 in the epic. Internal sub-PRs:
+
+1. **App skeleton + window + empty `CoreModel`** — `cargo build` produces the static lib, Xcode links it, SwiftPM wraps it, the app launches showing just a placeholder view. No engine commands wired yet.
+2. **Header toolbar + frequency entry + start/stop**, model wired to a real `SdrCore`.
+3. **Source/Radio/Display sidebar sections**, all bindings wired.
+4. **Center `SpectrumWaterfallView`** (consumes the M4 renderer).
+5. **Status bar + Settings scene + menu commands**.
+6. **Quit handling, config persistence, ABI version check**.
+
+After (6), the MVP is feature-complete and ready for M6 (signing/notarization/CI).
+
+## References
+
+- `2026-04-12-swift-ui-rendering-design.md` — the Metal view this surface embeds
+- `2026-04-12-sdr-ffi-c-abi-design.md` — the C surface that `SdrCoreKit` wraps
+- `crates/sdr-ui/src/window.rs` — GTK reference for layout, behavior, defaults
+- `crates/sdr-ui/src/sidebar/source_panel.rs` (and `radio_panel.rs`, `display_panel.rs`) — exact controls and ranges to mirror
+- [Apple — Observation framework](https://developer.apple.com/documentation/observation)
+- [Apple — `NavigationSplitView`](https://developer.apple.com/documentation/swiftui/navigationsplitview)

--- a/docs/superpowers/specs/2026-04-12-swift-ui-surface-design.md
+++ b/docs/superpowers/specs/2026-04-12-swift-ui-surface-design.md
@@ -173,26 +173,68 @@ final class CoreModel {
         }
     }
 
-    // Command-issuing methods, one per UI control. Each one swallows errors
-    // into `lastError` so the view layer never has to handle them.
-    func start()                       { try? core?.start();             isRunning = true  }
-    func stop()                        { try? core?.stop();              isRunning = false }
-    func setCenter(_ hz: Double)       { centerFrequencyHz = hz; try? core?.tune(hz) }
-    func setVfoOffset(_ hz: Double)    { vfoOffsetHz = hz; try? core?.setVfoOffset(hz) }
-    func setDemodMode(_ m: DemodMode)  { demodMode = m; try? core?.setDemodMode(m) }
-    func setBandwidth(_ hz: Double)    { bandwidthHz = hz; try? core?.setBandwidth(hz) }
-    func setGain(_ db: Double)         { gainDb = db; try? core?.setGain(db) }
-    func setAgc(_ on: Bool)            { agcEnabled = on; try? core?.setAgc(on) }
-    func setSquelch(_ db: Float)       { squelchDb = db; try? core?.setSquelchDb(db) }
-    func setSquelchEnabled(_ on: Bool) { squelchEnabled = on; try? core?.setSquelchEnabled(on) }
-    func setDeemphasis(_ m: Deemphasis){ deemphasis = m; try? core?.setDeemphasis(m) }
-    func setVolume(_ v: Float)         { volume = v; try? core?.setVolume(v) }
-    func setMinDb(_ db: Float)         { minDb = db }     // pure UI
-    func setMaxDb(_ db: Float)         { maxDb = db }     // pure UI
-    func setFftSize(_ n: Int)          { fftSize = n; try? core?.setFftSize(n) }
-    func setFftWindow(_ w: FftWindow)  { fftWindow = w; try? core?.setFftWindow(w) }
-    func setFftRate(_ fps: Double)     { fftRateFps = fps; try? core?.setFftRate(fps) }
-    func setPpm(_ ppm: Int)            { ppmCorrection = ppm; try? core?.setPpmCorrection(ppm) }
+    // Command dispatch
+    // ---------------------------------------------------------------
+    // Two patterns:
+    //
+    // 1. **Lifecycle** (start/stop) — *strict*: only mutate UI state if the
+    //    engine accepts the command. A failed start() must NOT leave
+    //    isRunning=true. Errors land in `lastError`.
+    //
+    // 2. **Setters** (frequency/gain/squelch/etc.) — *optimistic*: mutate
+    //    the UI binding immediately for input responsiveness, then forward
+    //    to the engine. The engine processes commands asynchronously over
+    //    its mpsc channel, so a successful return only means "queued", not
+    //    "applied". Real engine-side rejections come back via the event
+    //    stream and surface as state corrections in `consumeEvents`.
+    //    Synchronous FFI failures (e.g., engine handle dropped) still
+    //    capture into `lastError`.
+    //
+    // Neither pattern uses `try?`. Errors are never silently dropped.
+
+    private func capture(_ work: () throws -> Void) {
+        do { try work() }
+        catch { lastError = "\(error)" }
+    }
+
+    // --- Strict / lifecycle ---
+    func start() {
+        guard let core else { lastError = "engine not initialized"; return }
+        do {
+            try core.start()
+            isRunning = true
+            lastError = nil
+        } catch {
+            lastError = "start failed: \(error)"
+        }
+    }
+    func stop() {
+        guard let core else { return }
+        do {
+            try core.stop()
+            isRunning = false
+        } catch {
+            lastError = "stop failed: \(error)"
+        }
+    }
+
+    // --- Optimistic setters ---
+    func setCenter(_ hz: Double)       { centerFrequencyHz = hz; capture { try core?.tune(hz) } }
+    func setVfoOffset(_ hz: Double)    { vfoOffsetHz = hz;       capture { try core?.setVfoOffset(hz) } }
+    func setDemodMode(_ m: DemodMode)  { demodMode = m;          capture { try core?.setDemodMode(m) } }
+    func setBandwidth(_ hz: Double)    { bandwidthHz = hz;       capture { try core?.setBandwidth(hz) } }
+    func setGain(_ db: Double)         { gainDb = db;            capture { try core?.setGain(db) } }
+    func setAgc(_ on: Bool)            { agcEnabled = on;        capture { try core?.setAgc(on) } }
+    func setSquelch(_ db: Float)       { squelchDb = db;         capture { try core?.setSquelchDb(db) } }
+    func setSquelchEnabled(_ on: Bool) { squelchEnabled = on;    capture { try core?.setSquelchEnabled(on) } }
+    func setDeemphasis(_ m: Deemphasis){ deemphasis = m;         capture { try core?.setDeemphasis(m) } }
+    func setVolume(_ v: Float)         { volume = v;             capture { try core?.setVolume(v) } }
+    func setMinDb(_ db: Float)         { minDb = db }     // pure UI, no engine call
+    func setMaxDb(_ db: Float)         { maxDb = db }     // pure UI, no engine call
+    func setFftSize(_ n: Int)          { fftSize = n;             capture { try core?.setFftSize(n) } }
+    func setFftWindow(_ w: FftWindow)  { fftWindow = w;           capture { try core?.setFftWindow(w) } }
+    func setFftRate(_ fps: Double)     { fftRateFps = fps;        capture { try core?.setFftRate(fps) } }
+    func setPpm(_ ppm: Int)            { ppmCorrection = ppm;     capture { try core?.setPpmCorrection(ppm) } }
 
     // Renderer pulls FFT through this — see rendering spec
     var sdrCore: SdrCore? { core }


### PR DESCRIPTION
## Summary

Adds seven design docs under `docs/superpowers/specs/` that together plan a SwiftUI macOS app driving the existing Rust engine through a hand-rolled C ABI. The motivation is to extract a headless engine facade once and let two frontends (GTK on Linux, SwiftUI on macOS) consume it without either one owning DSP state.

This PR is **docs-only** — no code changes. It exists so we can review the architecture and decisions before any implementation PRs land.

## What's in here

| Spec | Purpose |
|------|---------|
| [`swift-ui-macos-epic-design`](docs/superpowers/specs/2026-04-12-swift-ui-macos-epic-design.md) | MVP scope, milestones (M1–M6), full-parity backlog, risks, success criteria |
| [`sdr-core-extraction-design`](docs/superpowers/specs/2026-04-12-sdr-core-extraction-design.md) | Behavior-preserving 3-PR refactor that moves `dsp_controller.rs` out of `sdr-ui` into a new headless crate consumed by both UIs |
| [`sdr-ffi-c-abi-design`](docs/superpowers/specs/2026-04-12-sdr-ffi-c-abi-design.md) | Hand-rolled C ABI: opaque handle, errno-style errors, event callback, pull-based FFT delivery, ABI versioning, `cbindgen` as a CI drift linter |
| [`coreaudio-sink-design`](docs/superpowers/specs/2026-04-12-coreaudio-sink-design.md) | AUHAL-based `Sink` impl mirroring the PipeWire impl behind the same trait, cfg-gated per `target_os` |
| [`swift-ui-rendering-design`](docs/superpowers/specs/2026-04-12-swift-ui-rendering-design.md) | Metal via `MTKView` in `NSViewRepresentable`, single texture ring for the waterfall (UV-scrolled, no memmove), zero per-frame allocations |
| [`swift-ui-surface-design`](docs/superpowers/specs/2026-04-12-swift-ui-surface-design.md) | `NavigationSplitView` shell, single `@Observable CoreModel`, MVP panels mapped from the GTK sidebar |
| [`swift-ui-packaging-design`](docs/superpowers/specs/2026-04-12-swift-ui-packaging-design.md) | `apps/macos/` layout, `scripts/build-mac.sh` glue, hardened runtime + USB entitlement, GH Actions for PR builds and tag-triggered notarized releases |

## Key decisions encoded

- **Hand-rolled C ABI** instead of `swift-bridge`/`uniffi` — small surface (~25 commands, 7 events, 1 FFT pull), zero new Rust deps, the header is the contract
- **New `sdr-core` facade crate** that both GTK and SwiftUI consume — `sdr-ui` becomes "just another consumer" instead of the de-facto engine host
- **`staticlib`** not `cdylib` for v1 — one binary, one signature, no `@rpath` headaches
- **`coreaudio-rs`** (high-level) over raw `coreaudio-sys`
- **Metal `MTKView`** for both spectrum and waterfall, single viewport split
- **macOS 26 floor** — unlocks the latest `@Observable` / SwiftUI surface
- **Unsandboxed** in v1 to keep USB device access simple; IOUSBHost migration is a v2 issue
- **Transcription is excluded from the MVP FFI surface** to dodge the parallel sherpa-onnx work on the engine side — added back in v2 once that surface stabilizes

## Out of scope for v1 (tracked in the epic backlog)

Network/file sources, audio device picker, IQ + audio recording, bookmarks, RadioReference panel, transcript panel, advanced display options (averaging modes, FPS slider), noise blanker / FM IF NR / WFM stereo / notch controls, DC blocking / IQ inversion / IQ correction toggles, decimation factor, network audio sink. Each one becomes its own GitHub issue once this PR merges.

## Test plan

- [ ] CodeRabbit review of all seven spec docs
- [x] Visual scan for broken cross-references between docs
- [ ] Sanity-check the MVP scope cut against what an RTL-SDR user actually needs day-one
- [ ] Confirm the `sdr-core` extraction PR series can land without colliding with the parallel sherpa-onnx work on `sdr-transcription`
- [ ] Confirm the USB entitlement assumption (`com.apple.security.device.usb` + hardened runtime + non-sandboxed) is sufficient for `rusb` access — to be validated by a 1-day spike before M5 starts (called out in the epic risks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design specs: macOS CoreAudio backend, headless DSP core extraction, C ABI for sdr-ffi, SwiftUI macOS frontend epic, SwiftUI app surface, Metal-based spectrum/waterfall rendering, and macOS packaging/signing/notarization & release pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->