### PR TITLE
Sherpa-onnx streaming backend (mutex feature flag with Whisper) — PR 2 of 5 for #204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "sdr-source-file",
  "sdr-source-network",
  "sdr-source-rtlsdr",
+ "sdr-transcription",
  "sdr-types",
  "sdr-ui",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +117,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +236,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,10 +330,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -748,7 +814,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1009,7 +1075,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1051,6 +1120,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1099,6 +1174,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1253,6 +1338,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1418,6 +1509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,7 +1594,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1551,11 +1651,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1752,6 +1866,7 @@ dependencies = [
  "reqwest",
  "rustfft",
  "sdr-types",
+ "sherpa-onnx",
  "thiserror 2.0.18",
  "tracing",
  "whisper-rs",
@@ -1872,10 +1987,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sherpa-onnx"
+version = "1.12.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f69ec9bc7c245dc7b976e7662c8529b32236efb04ab9d53427af2c4b8393b0da"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sherpa-onnx-sys",
+]
+
+[[package]]
+name = "sherpa-onnx-sys"
+version = "1.12.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b78e254a3030040d015edcdc4adfa1ea4714d3284dba0034f120feccbbde4aff"
+dependencies = [
+ "bzip2",
+ "tar",
+ "ureq",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1959,6 +2102,17 @@ dependencies = [
  "pkg-config",
  "toml",
  "version-compare",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2263,6 +2417,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2565,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2642,6 +2821,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,9 @@ keyring = { version = "3", features = ["sync-secret-service"] }
 # Whisper speech-to-text
 whisper-rs = "0.16"
 
+# Sherpa-onnx streaming ASR
+sherpa-onnx = "1.12"
+
 # System directories / libc
 dirs-next = "2"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ sdr-source-network.workspace = true
 sdr-source-file.workspace = true
 sdr-sink-audio.workspace = true
 sdr-sink-network.workspace = true
+sdr-transcription.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,20 +27,30 @@ gtk4.workspace = true
 libadwaita.workspace = true
 
 [features]
-default = ["whisper"]
+default = ["whisper-cpu"]
 
-# Mutually exclusive transcription backends. Pick exactly one.
+# Internal cfg flags. Source code uses #[cfg(feature = "whisper")] /
+# #[cfg(feature = "sherpa")] to gate per-backend code. These are pulled
+# in by the user-facing whisper-* / sherpa-* features below — users
+# should not enable them directly.
 whisper = ["sdr-transcription/whisper", "sdr-ui/whisper"]
 sherpa = ["sdr-transcription/sherpa", "sdr-ui/sherpa"]
 
-# GPU acceleration features for the Whisper backend.
-# These imply `whisper` automatically.
-cuda = ["whisper", "sdr-ui/cuda"]
-hipblas = ["whisper", "sdr-ui/hipblas"]
-vulkan = ["whisper", "sdr-ui/vulkan"]
-metal = ["whisper", "sdr-ui/metal"]
-intel-sycl = ["whisper", "sdr-ui/intel-sycl"]
-openblas = ["whisper", "sdr-ui/openblas"]
+# User-facing build targets. Pick exactly one. Whisper and Sherpa are
+# mutually exclusive at the source level (see compile_error in
+# crates/sdr-transcription/src/lib.rs).
+#
+# Whisper backend with various accelerator backends:
+whisper-cpu = ["whisper", "sdr-transcription/whisper-cpu", "sdr-ui/whisper-cpu"]
+whisper-cuda = ["whisper", "sdr-transcription/whisper-cuda", "sdr-ui/whisper-cuda"]
+whisper-hipblas = ["whisper", "sdr-transcription/whisper-hipblas", "sdr-ui/whisper-hipblas"]
+whisper-vulkan = ["whisper", "sdr-transcription/whisper-vulkan", "sdr-ui/whisper-vulkan"]
+whisper-metal = ["whisper", "sdr-transcription/whisper-metal", "sdr-ui/whisper-metal"]
+whisper-intel-sycl = ["whisper", "sdr-transcription/whisper-intel-sycl", "sdr-ui/whisper-intel-sycl"]
+whisper-openblas = ["whisper", "sdr-transcription/whisper-openblas", "sdr-ui/whisper-openblas"]
+
+# Sherpa backend (CPU only for now — GPU support tracked separately):
+sherpa-cpu = ["sherpa", "sdr-transcription/sherpa-cpu", "sdr-ui/sherpa-cpu"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sdr-ui = { workspace = true, features = ["pipewire"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,20 @@ gtk4.workspace = true
 libadwaita.workspace = true
 
 [features]
-default = []
-cuda = ["sdr-ui/cuda"]
-hipblas = ["sdr-ui/hipblas"]
-vulkan = ["sdr-ui/vulkan"]
-metal = ["sdr-ui/metal"]
-intel-sycl = ["sdr-ui/intel-sycl"]
-openblas = ["sdr-ui/openblas"]
+default = ["whisper"]
+
+# Mutually exclusive transcription backends. Pick exactly one.
+whisper = ["sdr-transcription/whisper", "sdr-ui/whisper"]
+sherpa = ["sdr-transcription/sherpa", "sdr-ui/sherpa"]
+
+# GPU acceleration features for the Whisper backend.
+# These imply `whisper` automatically.
+cuda = ["whisper", "sdr-ui/cuda"]
+hipblas = ["whisper", "sdr-ui/hipblas"]
+vulkan = ["whisper", "sdr-ui/vulkan"]
+metal = ["whisper", "sdr-ui/metal"]
+intel-sycl = ["whisper", "sdr-ui/intel-sycl"]
+openblas = ["whisper", "sdr-ui/openblas"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sdr-ui = { workspace = true, features = ["pipewire"] }

--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ make install
 
 Installs the binary, desktop entry, and icon for app launcher integration.
 
-### GPU-accelerated transcription (optional)
+### Transcription backend (optional)
 
 ```bash
-make install CARGO_FLAGS="--release --features cuda"      # NVIDIA
-make install CARGO_FLAGS="--release --features hipblas"    # AMD ROCm
-make install CARGO_FLAGS="--release --features vulkan"     # Cross-vendor
+make install CARGO_FLAGS="--release --features whisper-cuda"      # NVIDIA
+make install CARGO_FLAGS="--release --features whisper-hipblas"   # AMD ROCm
+make install CARGO_FLAGS="--release --features whisper-vulkan"    # Cross-vendor
+make install CARGO_FLAGS="--release"                               # Whisper CPU (default)
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"  # Sherpa CPU
 ```
 
 Requires the corresponding GPU toolkit (CUDA toolkit, ROCm, Vulkan SDK).

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -31,7 +31,7 @@ sherpa-cpu = ["sherpa"]
 
 [dependencies]
 whisper-rs = { workspace = true, optional = true }
-sherpa-onnx = { version = "1.12", optional = true }
+sherpa-onnx = { workspace = true, optional = true }
 reqwest.workspace = true
 rustfft.workspace = true
 sdr-types.workspace = true

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -8,19 +8,30 @@ repository.workspace = true
 
 [features]
 default = []
-cuda = ["whisper-rs/cuda"]
-hipblas = ["whisper-rs/hipblas"]
-vulkan = ["whisper-rs/vulkan"]
-metal = ["whisper-rs/metal"]
-intel-sycl = ["whisper-rs/intel-sycl"]
-openblas = ["whisper-rs/openblas"]
+
+# Mutually exclusive transcription backend selection. Exactly one of
+# `whisper` or `sherpa` must be enabled. Building with both, or neither,
+# triggers a compile_error in lib.rs.
+whisper = ["dep:whisper-rs"]
+sherpa = ["dep:sherpa-onnx"]
+
+# GPU acceleration features for the Whisper backend.
+# Each implies `whisper` so users who pass --features cuda still get a
+# whisper build. Users who want sherpa must pass
+# --no-default-features --features sherpa.
+cuda = ["whisper", "whisper-rs/cuda"]
+hipblas = ["whisper", "whisper-rs/hipblas"]
+vulkan = ["whisper", "whisper-rs/vulkan"]
+metal = ["whisper", "whisper-rs/metal"]
+intel-sycl = ["whisper", "whisper-rs/intel-sycl"]
+openblas = ["whisper", "whisper-rs/openblas"]
 
 [dependencies]
-whisper-rs.workspace = true
+whisper-rs = { workspace = true, optional = true }
+sherpa-onnx = { version = "1.12", optional = true }
 reqwest.workspace = true
 rustfft.workspace = true
 sdr-types.workspace = true
-sherpa-onnx = "1.12"
 thiserror.workspace = true
 tracing.workspace = true
 dirs-next.workspace = true

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -20,6 +20,7 @@ whisper-rs.workspace = true
 reqwest.workspace = true
 rustfft.workspace = true
 sdr-types.workspace = true
+sherpa-onnx = "1.12"
 thiserror.workspace = true
 tracing.workspace = true
 dirs-next.workspace = true

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -9,22 +9,25 @@ repository.workspace = true
 [features]
 default = []
 
-# Mutually exclusive transcription backend selection. Exactly one of
-# `whisper` or `sherpa` must be enabled. Building with both, or neither,
-# triggers a compile_error in lib.rs.
+# Internal cfg flags. Source code uses #[cfg(feature = "whisper")] /
+# #[cfg(feature = "sherpa")] to gate per-backend code. Pulled in by the
+# user-facing whisper-* / sherpa-* features below.
 whisper = ["dep:whisper-rs"]
 sherpa = ["dep:sherpa-onnx"]
 
-# GPU acceleration features for the Whisper backend.
-# Each implies `whisper` so users who pass --features cuda still get a
-# whisper build. Users who want sherpa must pass
-# --no-default-features --features sherpa.
-cuda = ["whisper", "whisper-rs/cuda"]
-hipblas = ["whisper", "whisper-rs/hipblas"]
-vulkan = ["whisper", "whisper-rs/vulkan"]
-metal = ["whisper", "whisper-rs/metal"]
-intel-sycl = ["whisper", "whisper-rs/intel-sycl"]
-openblas = ["whisper", "whisper-rs/openblas"]
+# User-facing build targets — pick exactly one.
+#
+# Whisper backend with accelerator variants:
+whisper-cpu = ["whisper"]
+whisper-cuda = ["whisper", "whisper-rs/cuda"]
+whisper-hipblas = ["whisper", "whisper-rs/hipblas"]
+whisper-vulkan = ["whisper", "whisper-rs/vulkan"]
+whisper-metal = ["whisper", "whisper-rs/metal"]
+whisper-intel-sycl = ["whisper", "whisper-rs/intel-sycl"]
+whisper-openblas = ["whisper", "whisper-rs/openblas"]
+
+# Sherpa backend (CPU only for now):
+sherpa-cpu = ["sherpa"]
 
 [dependencies]
 whisper-rs = { workspace = true, optional = true }

--- a/crates/sdr-transcription/src/backend.rs
+++ b/crates/sdr-transcription/src/backend.rs
@@ -72,7 +72,9 @@ pub struct BackendHandle {
 pub enum BackendError {
     #[error("failed to spawn worker thread: {0}")]
     Spawn(#[from] std::io::Error),
-    #[error("model files not found at {path}; download the bundle and place its contents in this directory")]
+    #[error(
+        "model files not found at {path}; download the bundle and place its contents in this directory"
+    )]
     ModelNotFound { path: PathBuf },
     #[error("backend received the wrong model kind in BackendConfig — engine bug")]
     WrongModelKind,

--- a/crates/sdr-transcription/src/backend.rs
+++ b/crates/sdr-transcription/src/backend.rs
@@ -8,6 +8,7 @@
 use std::path::PathBuf;
 use std::sync::mpsc;
 
+#[cfg(feature = "whisper")]
 use crate::model::WhisperModel;
 
 /// Configuration handed to a backend at `start` time.
@@ -24,9 +25,14 @@ pub struct BackendConfig {
 /// User-facing model selection.
 ///
 /// The variant determines which backend the engine instantiates internally.
+/// At any given build, exactly one variant exists — the `whisper` and
+/// `sherpa` features are mutually exclusive (see `lib.rs` `compile_error`
+/// guards).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelChoice {
+    #[cfg(feature = "whisper")]
     Whisper(WhisperModel),
+    #[cfg(feature = "sherpa")]
     Sherpa(crate::sherpa_model::SherpaModel),
 }
 
@@ -76,6 +82,10 @@ pub enum BackendError {
         "model files not found at {path}; download the bundle and place its contents in this directory"
     )]
     ModelNotFound { path: PathBuf },
+    // Retained for when whisper+sherpa are re-unified. In single-feature
+    // builds the cfg-gated match arms below are never both present, so
+    // this variant is never constructed — silence the lint.
+    #[allow(dead_code)]
     #[error("backend received the wrong model kind in BackendConfig — engine bug")]
     WrongModelKind,
     #[error("backend initialization failed: {0}")]

--- a/crates/sdr-transcription/src/backend.rs
+++ b/crates/sdr-transcription/src/backend.rs
@@ -5,6 +5,7 @@
 //! This file defines the trait, the handle returned by `start`, the config
 //! passed in, and the event type emitted to consumers.
 
+use std::path::PathBuf;
 use std::sync::mpsc;
 
 use crate::model::WhisperModel;
@@ -23,10 +24,10 @@ pub struct BackendConfig {
 /// User-facing model selection.
 ///
 /// The variant determines which backend the engine instantiates internally.
-/// Currently only `Whisper` is implemented; `Sherpa` lands in PR 2.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelChoice {
     Whisper(WhisperModel),
+    Sherpa(crate::sherpa_model::SherpaModel),
 }
 
 /// Events emitted by a backend during its lifecycle.
@@ -38,7 +39,12 @@ pub enum TranscriptionEvent {
     Downloading { progress_pct: u8 },
     /// Model loaded and ready for inference.
     Ready,
-    /// Transcribed text from one inference pass.
+    /// Incremental hypothesis from a streaming backend. May be replaced
+    /// by another `Partial` before being committed as a `Text`. Backends
+    /// that return `false` from `supports_partials()` never emit this.
+    Partial { text: String },
+    /// Transcribed text from one inference pass (or one committed
+    /// streaming utterance).
     Text {
         /// Wall-clock timestamp in "HH:MM:SS" format.
         timestamp: String,
@@ -66,6 +72,12 @@ pub struct BackendHandle {
 pub enum BackendError {
     #[error("failed to spawn worker thread: {0}")]
     Spawn(#[from] std::io::Error),
+    #[error("model files not found at {path}; download the bundle and place its contents in this directory")]
+    ModelNotFound { path: PathBuf },
+    #[error("backend received the wrong model kind in BackendConfig — engine bug")]
+    WrongModelKind,
+    #[error("backend initialization failed: {0}")]
+    Init(String),
 }
 
 /// Trait every transcription backend must implement.

--- a/crates/sdr-transcription/src/backends/mock.rs
+++ b/crates/sdr-transcription/src/backends/mock.rs
@@ -87,11 +87,16 @@ impl TranscriptionBackend for MockBackend {
 mod tests {
     use super::*;
     use crate::backend::ModelChoice;
+    #[cfg(feature = "whisper")]
     use crate::model::WhisperModel;
 
     fn dummy_config() -> BackendConfig {
+        #[cfg(feature = "whisper")]
+        let model = ModelChoice::Whisper(WhisperModel::TinyEn);
+        #[cfg(feature = "sherpa")]
+        let model = ModelChoice::Sherpa(crate::SherpaModel::StreamingZipformerEn);
         BackendConfig {
-            model: ModelChoice::Whisper(WhisperModel::TinyEn),
+            model,
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
         }

--- a/crates/sdr-transcription/src/backends/mod.rs
+++ b/crates/sdr-transcription/src/backends/mod.rs
@@ -1,10 +1,13 @@
 //! Concrete `TranscriptionBackend` implementations.
 //!
-//! Each backend is a self-contained module. The engine in `lib.rs`
-//! constructs one based on the [`crate::backend::ModelChoice`] variant
-//! and delegates lifecycle to it.
+//! Each backend is a self-contained module gated behind a cargo feature.
+//! Whisper and Sherpa are mutually exclusive (see `lib.rs` `compile_error`
+//! guards) — exactly one is compiled into any given binary.
 
+#[cfg(feature = "sherpa")]
 pub mod sherpa;
+
+#[cfg(feature = "whisper")]
 pub mod whisper;
 
 #[cfg(test)]

--- a/crates/sdr-transcription/src/backends/mod.rs
+++ b/crates/sdr-transcription/src/backends/mod.rs
@@ -4,6 +4,7 @@
 //! constructs one based on the [`crate::backend::ModelChoice`] variant
 //! and delegates lifecycle to it.
 
+pub mod sherpa;
 pub mod whisper;
 
 #[cfg(test)]

--- a/crates/sdr-transcription/src/backends/sherpa.rs
+++ b/crates/sdr-transcription/src/backends/sherpa.rs
@@ -48,6 +48,15 @@ const RULE3_MIN_UTTERANCE_LENGTH: f32 = 20.0;
 /// success or failure before giving up. Recognizer load is typically <1s.
 const HOST_INIT_TIMEOUT: Duration = Duration::from_mins(1);
 
+/// Sample rate sherpa-onnx expects from `accept_waveform`.
+const SHERPA_SAMPLE_RATE_HZ: i32 = 16_000;
+/// Initial capacity for the per-session resampled-mono scratch buffer.
+const SESSION_MONO_BUFFER_CAPACITY: usize = 16_000;
+/// ONNX Runtime threads per recognizer. Sherpa is fast enough on CPU
+/// that one thread is sufficient and avoids competing with the audio
+/// pipeline.
+const SHERPA_NUM_THREADS: i32 = 1;
+
 /// Process-wide singleton for the sherpa-onnx host. Stores either a ready
 /// host or the error message from a failed initialization. Set exactly once
 /// by [`init_sherpa_host`]; subsequent calls are no-ops.
@@ -206,7 +215,7 @@ fn build_recognizer_config(model: SherpaModel, provider: &str) -> OnlineRecogniz
     config.model_config.transducer.joiner = Some(joiner.to_string_lossy().into_owned());
     config.model_config.tokens = Some(tokens.to_string_lossy().into_owned());
     config.model_config.provider = Some(provider.to_owned());
-    config.model_config.num_threads = 1;
+    config.model_config.num_threads = SHERPA_NUM_THREADS;
     config.enable_endpoint = true;
     config.decoding_method = Some("greedy_search".to_owned());
     config.rule1_min_trailing_silence = RULE1_MIN_TRAILING_SILENCE;
@@ -232,7 +241,7 @@ fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
         return;
     }
 
-    let mut mono_buf: Vec<f32> = Vec::with_capacity(16_000);
+    let mut mono_buf: Vec<f32> = Vec::with_capacity(SESSION_MONO_BUFFER_CAPACITY);
     let mut last_partial = String::new();
 
     loop {
@@ -268,7 +277,7 @@ fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
 
         denoise::spectral_denoise(&mut mono_buf, noise_gate_ratio);
 
-        stream.accept_waveform(16_000_i32, &mono_buf);
+        stream.accept_waveform(SHERPA_SAMPLE_RATE_HZ, &mono_buf);
 
         while recognizer.is_ready(&stream) {
             if cancel.load(Ordering::Relaxed) {
@@ -300,12 +309,19 @@ fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
         // Endpoint check is independent of get_result and must always run
         // so reset() fires when the recognizer says the utterance is over.
         if recognizer.is_endpoint(&stream) {
-            if !current_text.is_empty() {
+            // If get_result returned empty, fall back to last_partial so
+            // we don't drop the utterance. Mirrors finalize_session.
+            let committed_text = if current_text.is_empty() {
+                last_partial.clone()
+            } else {
+                current_text
+            };
+            if !committed_text.is_empty() {
                 let timestamp = crate::util::wall_clock_timestamp();
-                tracing::debug!(%timestamp, text = %current_text, "sherpa committed utterance");
+                tracing::debug!(%timestamp, text = %committed_text, "sherpa committed utterance");
                 let _ = event_tx.send(TranscriptionEvent::Text {
                     timestamp,
-                    text: current_text,
+                    text: committed_text,
                 });
             }
             recognizer.reset(&stream);

--- a/crates/sdr-transcription/src/backends/sherpa.rs
+++ b/crates/sdr-transcription/src/backends/sherpa.rs
@@ -1,19 +1,27 @@
 //! Sherpa-onnx backend — streaming-native ASR via the official k2-fsa
 //! `sherpa-onnx` Rust crate.
 //!
-//! Implements [`TranscriptionBackend`] using `OnlineRecognizer` for true
-//! frame-by-frame streaming with endpoint detection. Partial hypotheses
-//! are emitted as `TranscriptionEvent::Partial`; committed utterances
-//! after silence detection are emitted as `TranscriptionEvent::Text`.
+//! ## Architecture
 //!
-//! `OnlineRecognizer` and `OnlineStream` are `!Send` (they wrap raw
-//! pointers into the C library), so all recognizer interaction happens
-//! on the worker thread. The `SherpaBackend` struct itself only holds
-//! the cancellation token and the worker join handle, mirroring
-//! `WhisperBackend`.
+//! The recognizer is created ONCE per process by [`SherpaHost`], a
+//! long-lived worker thread spawned from `main()` BEFORE GTK is loaded.
+//! This is a workaround for a C++ static-initializer collision between
+//! sherpa-onnx's bundled ONNX Runtime and GTK4's transitive C++ deps —
+//! creating the recognizer after GTK init causes `free(): invalid pointer`
+//! inside `std::regex` constructors called by ONNX Runtime's
+//! `ParseSemVerVersion`.
+//!
+//! [`SherpaBackend`] is a thin facade that asks the global host for a
+//! new session. The host creates a fresh [`OnlineStream`] from the
+//! existing recognizer and runs the audio feed loop until the session
+//! is cancelled or the audio channel disconnects.
+//!
+//! Both [`OnlineRecognizer`] and [`OnlineStream`] are `!Send`. They
+//! live entirely on the host worker thread; the host wraps its command
+//! sender in a Mutex so it can be stored in a process-wide `OnceLock`.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, mpsc};
+use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::time::Duration;
 
 use sherpa_onnx::{OnlineRecognizer, OnlineRecognizerConfig};
@@ -26,9 +34,6 @@ use crate::sherpa_model::{self, SherpaModel};
 use crate::{denoise, resampler};
 
 /// Bounded channel capacity for audio buffers from DSP → backend.
-/// Sherpa accepts much smaller chunks than Whisper (per-frame, not
-/// 5-second windows), so we don't need the same headroom `WhisperBackend`
-/// does. 256 still gives plenty of buffer.
 const AUDIO_CHANNEL_CAPACITY: usize = 256;
 
 /// Polling interval for the audio receive loop when checking for cancellation.
@@ -39,99 +44,149 @@ const RULE1_MIN_TRAILING_SILENCE: f32 = 2.4;
 const RULE2_MIN_TRAILING_SILENCE: f32 = 1.2;
 const RULE3_MIN_UTTERANCE_LENGTH: f32 = 20.0;
 
-/// `TranscriptionBackend` implementation backed by `sherpa-onnx`.
-pub struct SherpaBackend {
+/// Maximum time we wait for the host worker thread to report initialization
+/// success or failure before giving up. Recognizer load is typically <1s.
+const HOST_INIT_TIMEOUT: Duration = Duration::from_mins(1);
+
+/// Process-wide singleton for the sherpa-onnx host. Stores either a ready
+/// host or the error message from a failed initialization. Set exactly once
+/// by [`init_sherpa_host`]; subsequent calls are no-ops.
+static SHERPA_HOST: OnceLock<Result<SherpaHost, String>> = OnceLock::new();
+
+/// Spawn the global sherpa-onnx host thread.
+///
+/// **MUST be called from `main()` BEFORE GTK is initialized** (before
+/// `sdr_ui::run()`). The host's worker thread creates the
+/// [`OnlineRecognizer`] once at startup, which initializes ONNX Runtime's
+/// C++ runtime state. Doing this before GTK loads avoids a static-initializer
+/// collision that causes `free(): invalid pointer` corruption inside
+/// libstdc++ regex code on the first decode call.
+///
+/// Idempotent — safe to call multiple times; only the first call has effect.
+/// If initialization fails (model files missing, ONNX error), the error is
+/// stashed in the global slot and reported when the user actually tries to
+/// start a Sherpa transcription session.
+pub fn init_sherpa_host(model: SherpaModel) {
+    let _ = SHERPA_HOST.set(SherpaHost::spawn(model).map_err(|e| e.to_string()));
+}
+
+/// Look up the global sherpa host. Returns `None` if `init_sherpa_host` was
+/// never called.
+fn global_sherpa_host() -> Option<&'static Result<SherpaHost, String>> {
+    SHERPA_HOST.get()
+}
+
+/// Parameters handed to the host worker for one transcription session.
+struct SessionParams {
     cancel: Arc<AtomicBool>,
-    worker: Option<std::thread::JoinHandle<()>>,
+    audio_rx: mpsc::Receiver<Vec<f32>>,
+    event_tx: mpsc::Sender<TranscriptionEvent>,
+    noise_gate_ratio: f32,
 }
 
-impl Default for SherpaBackend {
-    fn default() -> Self {
-        Self::new()
-    }
+/// Commands sent to the host worker thread.
+enum HostCommand {
+    StartSession(SessionParams),
 }
 
-impl SherpaBackend {
-    pub fn new() -> Self {
-        Self {
-            cancel: Arc::new(AtomicBool::new(false)),
-            worker: None,
-        }
-    }
+/// Internal state of a sherpa host. Wrapped in a `Mutex` inside `SherpaHost`
+/// because `mpsc::Sender` is `!Sync` and we need `SherpaHost: Sync` for
+/// `OnceLock` storage.
+struct SherpaHostState {
+    cmd_tx: mpsc::Sender<HostCommand>,
 }
 
-impl TranscriptionBackend for SherpaBackend {
-    fn name(&self) -> &'static str {
-        "sherpa"
-    }
+/// Long-lived host for sherpa-onnx transcription. Owns one worker thread
+/// that holds the [`OnlineRecognizer`] for the entire process lifetime.
+pub struct SherpaHost {
+    state: Mutex<SherpaHostState>,
+}
 
-    fn supports_partials(&self) -> bool {
-        true
-    }
-
-    fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
-        let ModelChoice::Sherpa(sherpa_model) = config.model else {
-            return Err(BackendError::WrongModelKind);
-        };
-
-        // Verify the model files exist before spawning the worker, so the
-        // user gets a useful error immediately rather than after the
-        // recognizer fails inside the thread.
-        if !sherpa_model::model_exists(sherpa_model) {
+impl SherpaHost {
+    /// Spawn the host worker thread and block until the recognizer is
+    /// either ready or initialization has failed.
+    ///
+    /// Returns `BackendError::ModelNotFound` if the model files for `model`
+    /// are not present on disk, or `BackendError::Init(_)` if the
+    /// recognizer creation fails.
+    pub fn spawn(model: SherpaModel) -> Result<Self, BackendError> {
+        if !sherpa_model::model_exists(model) {
             return Err(BackendError::ModelNotFound {
-                path: sherpa_model::model_directory(sherpa_model),
+                path: sherpa_model::model_directory(model),
             });
         }
 
-        self.cancel.store(false, Ordering::Relaxed);
+        let (cmd_tx, cmd_rx) = mpsc::channel::<HostCommand>();
+        let (init_tx, init_rx) = mpsc::sync_channel::<Result<(), String>>(1);
 
-        let (audio_tx, audio_rx) = mpsc::sync_channel(AUDIO_CHANNEL_CAPACITY);
-        let (event_tx, event_rx) = mpsc::channel();
-
-        let cancel = Arc::clone(&self.cancel);
-        // silence_threshold is unused: sherpa's endpoint detection
-        // handles silence natively.
-        let noise_gate_ratio = config.noise_gate_ratio;
-
-        let handle = std::thread::Builder::new()
-            .name("sherpa-worker".into())
+        std::thread::Builder::new()
+            .name("sherpa-host".into())
             .spawn(move || {
-                run_worker(
-                    &audio_rx,
-                    &event_tx,
-                    &cancel,
-                    sherpa_model,
-                    noise_gate_ratio,
-                );
+                run_host_loop(model, &cmd_rx, init_tx);
             })?;
 
-        self.worker = Some(handle);
-        tracing::info!("sherpa backend started");
-
-        Ok(BackendHandle { audio_tx, event_rx })
-    }
-
-    fn stop(&mut self) {
-        self.cancel.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.worker.take() {
-            let _ = handle.join();
+        match init_rx.recv_timeout(HOST_INIT_TIMEOUT) {
+            Ok(Ok(())) => Ok(Self {
+                state: Mutex::new(SherpaHostState { cmd_tx }),
+            }),
+            Ok(Err(msg)) => Err(BackendError::Init(msg)),
+            Err(_) => Err(BackendError::Init(
+                "sherpa host worker timed out during initialization".to_owned(),
+            )),
         }
-        tracing::info!("sherpa backend stopped");
     }
 
-    fn shutdown_nonblocking(&mut self) {
-        self.cancel.store(true, Ordering::Relaxed);
-        self.worker.take(); // detach — don't join
-        tracing::info!("sherpa backend shutdown (non-blocking)");
+    /// Send a `StartSession` command to the host. Returns an error if the
+    /// host worker has died.
+    fn start_session(&self, params: SessionParams) -> Result<(), BackendError> {
+        let state = self.state.lock().expect("sherpa host mutex poisoned");
+        state
+            .cmd_tx
+            .send(HostCommand::StartSession(params))
+            .map_err(|_| BackendError::Init("sherpa host worker is no longer running".to_owned()))
     }
 }
 
+/// Worker thread entry point. Creates the [`OnlineRecognizer`] once and
+/// signals success/failure on `init_tx`, then loops processing
+/// `StartSession` commands until the command channel disconnects (which
+/// happens at process exit when the global host is dropped).
+fn run_host_loop(
+    model: SherpaModel,
+    cmd_rx: &mpsc::Receiver<HostCommand>,
+    init_tx: mpsc::SyncSender<Result<(), String>>,
+) {
+    let recognizer_config = build_recognizer_config(model, "cpu");
+    tracing::info!(?model, "creating sherpa-onnx recognizer (host init)");
+
+    let Some(recognizer) = OnlineRecognizer::create(&recognizer_config) else {
+        let msg = "OnlineRecognizer::create returned None — check model file paths".to_owned();
+        tracing::error!(%msg);
+        let _ = init_tx.send(Err(msg));
+        return;
+    };
+    tracing::info!("sherpa-onnx recognizer created successfully");
+
+    if init_tx.send(Ok(())).is_err() {
+        tracing::warn!("sherpa host init channel closed before send — controller dropped");
+        return;
+    }
+    drop(init_tx);
+
+    tracing::info!("sherpa-host ready, waiting for sessions");
+    while let Ok(cmd) = cmd_rx.recv() {
+        match cmd {
+            HostCommand::StartSession(params) => {
+                tracing::info!("sherpa-host: starting session");
+                run_session(&recognizer, params);
+                tracing::info!("sherpa-host: session ended");
+            }
+        }
+    }
+    tracing::info!("sherpa-host worker exiting");
+}
+
 /// Build the `OnlineRecognizerConfig` for a Streaming Zipformer model.
-///
-/// The `provider` parameter selects the ONNX execution provider — `"cpu"`
-/// is the default; `"cuda"` enables GPU acceleration if libsherpa was
-/// built with CUDA support. PR 2 hardcodes `"cpu"`; CUDA validation is
-/// the manual smoke test in Task 10.
 fn build_recognizer_config(model: SherpaModel, provider: &str) -> OnlineRecognizerConfig {
     let (encoder, decoder, joiner, tokens) = sherpa_model::model_file_paths(model);
 
@@ -151,66 +206,38 @@ fn build_recognizer_config(model: SherpaModel, provider: &str) -> OnlineRecogniz
     config
 }
 
-/// Worker thread entry point. Owns the recognizer and stream for the
-/// entire transcription session.
-fn run_worker(
-    audio_rx: &mpsc::Receiver<Vec<f32>>,
-    event_tx: &mpsc::Sender<TranscriptionEvent>,
-    cancel: &Arc<AtomicBool>,
-    model: SherpaModel,
-    noise_gate_ratio: f32,
-) {
-    if let Err(e) = run_worker_inner(audio_rx, event_tx, cancel, model, noise_gate_ratio) {
-        let _ = event_tx.send(TranscriptionEvent::Error(e));
-    }
-}
-
-#[allow(clippy::too_many_lines)]
-fn run_worker_inner(
-    audio_rx: &mpsc::Receiver<Vec<f32>>,
-    event_tx: &mpsc::Sender<TranscriptionEvent>,
-    cancel: &Arc<AtomicBool>,
-    model: SherpaModel,
-    noise_gate_ratio: f32,
-) -> Result<(), String> {
-    // For PR 2 we hardcode CPU provider. CUDA support is validated in
-    // the smoke test step; if CUDA works, a follow-up PR wires it
-    // through the UI as a separate setting.
-    let provider = "cpu";
-    let recognizer_config = build_recognizer_config(model, provider);
-
-    tracing::info!(?model, provider, "loading sherpa-onnx model");
-    let recognizer = OnlineRecognizer::create(&recognizer_config).ok_or_else(|| {
-        "OnlineRecognizer::create returned None — check model file paths".to_owned()
-    })?;
+/// One transcription session. Creates a fresh stream from `recognizer`,
+/// runs the feed loop until cancelled or the audio channel disconnects.
+fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
+    let SessionParams {
+        cancel,
+        audio_rx,
+        event_tx,
+        noise_gate_ratio,
+    } = params;
 
     let stream = recognizer.create_stream();
 
-    tracing::info!("sherpa-onnx model loaded, ready for inference");
-    event_tx
-        .send(TranscriptionEvent::Ready)
-        .map_err(|_| "event channel closed before Ready".to_owned())?;
+    if event_tx.send(TranscriptionEvent::Ready).is_err() {
+        return;
+    }
 
-    // Sherpa expects 16 kHz mono f32 samples. We accept the same
-    // 48 kHz interleaved stereo from the DSP thread that Whisper does,
-    // run it through the spectral denoiser, downsample to 16k mono, and
-    // feed sherpa one chunk at a time.
     let mut mono_buf: Vec<f32> = Vec::with_capacity(16_000);
     let mut last_partial = String::new();
 
     loop {
         if cancel.load(Ordering::Relaxed) {
-            tracing::info!("sherpa transcription cancelled, worker exiting");
-            return Ok(());
+            tracing::info!("sherpa session cancelled");
+            return;
         }
 
         let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
-            Ok(data) => data,
+            Ok(d) => d,
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         };
 
-        // Resample 48k stereo → 16k mono into the scratch buffer.
+        // Resample 48 kHz stereo → 16 kHz mono into the scratch buffer.
         mono_buf.clear();
         resampler::downsample_stereo_to_mono_16k(&interleaved, &mut mono_buf);
 
@@ -218,8 +245,7 @@ fn run_worker_inner(
         // (same pattern as WhisperBackend) so we don't fall behind.
         while let Ok(extra) = audio_rx.try_recv() {
             if cancel.load(Ordering::Relaxed) {
-                tracing::info!("sherpa transcription cancelled, worker exiting");
-                return Ok(());
+                return;
             }
             resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
         }
@@ -228,25 +254,20 @@ fn run_worker_inner(
             continue;
         }
 
-        // Spectral noise gate (same preprocessor as Whisper).
         denoise::spectral_denoise(&mut mono_buf, noise_gate_ratio);
 
-        // Feed the chunk to sherpa.
         stream.accept_waveform(16_000_i32, &mono_buf);
 
-        // Decode as much as the recognizer is ready for.
         while recognizer.is_ready(&stream) {
             if cancel.load(Ordering::Relaxed) {
-                tracing::info!("sherpa transcription cancelled mid-decode, exiting");
-                return Ok(());
+                return;
             }
             recognizer.decode(&stream);
         }
 
-        // Pull the current hypothesis. Emit a Partial event if it
-        // changed since the last one (avoid flooding the UI thread).
-        // We capture the trimmed text so it can be reused for the
-        // committed Text event below if the stream reaches an endpoint.
+        // Pull the current hypothesis. Emit a Partial event if it changed
+        // since the last one. Capture the trimmed text into a local that's
+        // reused below for the committed Text event when the endpoint fires.
         let current_text = if let Some(result) = recognizer.get_result(&stream) {
             let trimmed = result.text.trim().to_owned();
             if !trimmed.is_empty() && trimmed != last_partial {
@@ -259,14 +280,12 @@ fn run_worker_inner(
         } else {
             // get_result can return None on a serde failure inside the C
             // layer. We must NOT skip the endpoint check below in that
-            // case — otherwise the stream can get stuck in endpoint state
-            // and silently stop transcribing.
+            // case — otherwise the stream can get stuck in endpoint state.
             String::new()
         };
 
-        // Endpoint check is independent of get_result and must always
-        // run so reset() fires when the recognizer says the utterance
-        // is over.
+        // Endpoint check is independent of get_result and must always run
+        // so reset() fires when the recognizer says the utterance is over.
         if recognizer.is_endpoint(&stream) {
             if !current_text.is_empty() {
                 let timestamp = wall_clock_timestamp();
@@ -281,13 +300,96 @@ fn run_worker_inner(
         }
     }
 
-    tracing::info!("sherpa audio channel closed, worker exiting");
-    Ok(())
+    tracing::info!("sherpa session ended (audio channel disconnected)");
+}
+
+/// `TranscriptionBackend` implementation backed by the global sherpa host.
+///
+/// `SherpaBackend` is stateless apart from a per-session cancellation flag.
+/// All actual recognizer state lives on the long-lived host worker thread
+/// spawned by [`init_sherpa_host`].
+pub struct SherpaBackend {
+    cancel: Arc<AtomicBool>,
+}
+
+impl Default for SherpaBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SherpaBackend {
+    pub fn new() -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl TranscriptionBackend for SherpaBackend {
+    fn name(&self) -> &'static str {
+        "sherpa"
+    }
+
+    fn supports_partials(&self) -> bool {
+        true
+    }
+
+    fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
+        let ModelChoice::Sherpa(_) = config.model else {
+            return Err(BackendError::WrongModelKind);
+        };
+
+        let host = match global_sherpa_host() {
+            Some(Ok(h)) => h,
+            Some(Err(msg)) => {
+                return Err(BackendError::Init(format!(
+                    "sherpa host failed to initialize: {msg}"
+                )));
+            }
+            None => {
+                return Err(BackendError::Init(
+                    "sherpa host not initialized — main() must call \
+                     sdr_transcription::init_sherpa_host before sdr_ui::run"
+                        .to_owned(),
+                ));
+            }
+        };
+
+        self.cancel.store(false, Ordering::Relaxed);
+
+        let (audio_tx, audio_rx) = mpsc::sync_channel(AUDIO_CHANNEL_CAPACITY);
+        let (event_tx, event_rx) = mpsc::channel();
+
+        host.start_session(SessionParams {
+            cancel: Arc::clone(&self.cancel),
+            audio_rx,
+            event_tx,
+            noise_gate_ratio: config.noise_gate_ratio,
+        })?;
+
+        tracing::info!("sherpa backend session requested");
+
+        Ok(BackendHandle { audio_tx, event_rx })
+    }
+
+    fn stop(&mut self) {
+        // The host detects the cancel flag on its next recv_timeout
+        // (every 100 ms) and ends the session naturally. We don't need
+        // to join anything — the worker thread is shared and lives forever.
+        self.cancel.store(true, Ordering::Relaxed);
+        tracing::info!("sherpa backend stopped");
+    }
+
+    fn shutdown_nonblocking(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        tracing::info!("sherpa backend shutdown (non-blocking)");
+    }
 }
 
 /// Wall-clock "HH:MM:SS" string. Same implementation as
-/// [`crate::backends::whisper`] but kept local to avoid a public
-/// re-export of an internal helper.
+/// [`crate::backends::whisper`] but kept local to avoid a public re-export
+/// of an internal helper.
 fn wall_clock_timestamp() -> String {
     let mut tv = libc::timeval {
         tv_sec: 0,
@@ -339,33 +441,56 @@ mod tests {
 
     #[test]
     #[allow(clippy::panic)]
-    fn sherpa_backend_start_returns_model_not_found_when_files_missing() {
-        // The test environment has no sherpa model files in
-        // ~/.local/share/sdr-rs/models/sherpa/, so start() should
-        // synchronously return ModelNotFound before spawning the worker.
-        // This exercises the synchronous error path without needing a
-        // real model bundle.
+    fn sherpa_backend_start_returns_init_error_when_host_not_initialized() {
+        // The test process never calls init_sherpa_host, so the global
+        // OnceLock is empty and start() should return BackendError::Init
+        // with a clear message about the host not being initialized.
         //
-        // Note: this test would fail if the developer running it has
-        // actually downloaded the Streaming Zipformer model. That's
-        // acceptable — CI runs in a clean environment.
+        // Note: this test relies on no other test in this binary calling
+        // init_sherpa_host. Cargo runs each integration test binary
+        // separately but unit tests share a process. If this test ever
+        // becomes flaky, mark it #[ignore] and run manually.
         let mut backend = SherpaBackend::new();
         let config = BackendConfig {
             model: ModelChoice::Sherpa(SherpaModel::StreamingZipformerEn),
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
         };
-        let result = backend.start(config);
-        match result {
+        match backend.start(config) {
+            Err(BackendError::Init(msg)) => {
+                assert!(
+                    msg.contains("not initialized") || msg.contains("failed to initialize"),
+                    "expected init error mentioning initialization, got: {msg}"
+                );
+            }
+            Err(e) => panic!("expected Init error, got: {e:?}"),
+            Ok(_) => {
+                panic!("expected Init error because init_sherpa_host was never called, got Ok")
+            }
+        }
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn sherpa_host_spawn_returns_model_not_found_when_files_missing() {
+        // SherpaHost::spawn checks for model files synchronously before
+        // spawning the worker thread. In an environment without the
+        // model bundle, this should return ModelNotFound. If the dev
+        // happens to have the model installed, gracefully skip without
+        // calling spawn() — spawning and then dropping a live host
+        // would trigger ONNX Runtime cleanup that races with other tests.
+        if sherpa_model::model_exists(SherpaModel::StreamingZipformerEn) {
+            eprintln!("skipping test: streaming-zipformer-en model is present locally");
+            return;
+        }
+        match SherpaHost::spawn(SherpaModel::StreamingZipformerEn) {
             Err(BackendError::ModelNotFound { path }) => {
                 assert!(path.ends_with("sherpa/streaming-zipformer-en"));
             }
-            Ok(_) => {
-                // If the developer happens to have the model downloaded
-                // locally, skip this test rather than fail. Tearing down
-                // the running backend is fine because it's just a thread.
-                backend.shutdown_nonblocking();
-                eprintln!("skipping test: streaming-zipformer-en model is present locally");
+            Ok(_host) => {
+                // model_exists() returned false above, so spawn() returning
+                // Ok here would be a logic error in model_exists.
+                panic!("model_exists returned false but spawn succeeded — inconsistent state");
             }
             Err(e) => panic!("expected ModelNotFound, got {e:?}"),
         }

--- a/crates/sdr-transcription/src/backends/sherpa.rs
+++ b/crates/sdr-transcription/src/backends/sherpa.rs
@@ -12,12 +12,32 @@
 //! the cancellation token and the worker join handle, mirroring
 //! `WhisperBackend`.
 
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
+use std::time::Duration;
+
+use sherpa_onnx::{OnlineRecognizer, OnlineRecognizerConfig};
 
 use crate::backend::{
-    BackendConfig, BackendError, BackendHandle, TranscriptionBackend,
+    BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
+    TranscriptionEvent,
 };
+use crate::sherpa_model::{self, SherpaModel};
+use crate::{denoise, resampler};
+
+/// Bounded channel capacity for audio buffers from DSP → backend.
+/// Sherpa accepts much smaller chunks than Whisper (per-frame, not
+/// 5-second windows), so we don't need the same headroom WhisperBackend
+/// does. 256 still gives plenty of buffer.
+const AUDIO_CHANNEL_CAPACITY: usize = 256;
+
+/// Polling interval for the audio receive loop when checking for cancellation.
+const AUDIO_RECV_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Endpoint detection rule defaults — match upstream sherpa-onnx examples.
+const RULE1_MIN_TRAILING_SILENCE: f32 = 2.4;
+const RULE2_MIN_TRAILING_SILENCE: f32 = 1.2;
+const RULE3_MIN_UTTERANCE_LENGTH: f32 = 20.0;
 
 /// `TranscriptionBackend` implementation backed by `sherpa-onnx`.
 pub struct SherpaBackend {
@@ -49,23 +69,245 @@ impl TranscriptionBackend for SherpaBackend {
         true
     }
 
-    fn start(&mut self, _config: BackendConfig) -> Result<BackendHandle, BackendError> {
-        // Skeleton — real implementation lands in Task 7.
-        Err(BackendError::Init(
-            "SherpaBackend is not yet implemented (Task 7)".to_owned(),
-        ))
+    fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
+        let ModelChoice::Sherpa(sherpa_model) = config.model else {
+            return Err(BackendError::WrongModelKind);
+        };
+
+        // Verify the model files exist before spawning the worker, so the
+        // user gets a useful error immediately rather than after the
+        // recognizer fails inside the thread.
+        if !sherpa_model::model_exists(sherpa_model) {
+            return Err(BackendError::ModelNotFound {
+                path: sherpa_model::model_directory(sherpa_model),
+            });
+        }
+
+        self.cancel.store(false, Ordering::Relaxed);
+
+        let (audio_tx, audio_rx) = mpsc::sync_channel(AUDIO_CHANNEL_CAPACITY);
+        let (event_tx, event_rx) = mpsc::channel();
+
+        let cancel = Arc::clone(&self.cancel);
+        let noise_gate_ratio = config.noise_gate_ratio;
+
+        let handle = std::thread::Builder::new()
+            .name("sherpa-worker".into())
+            .spawn(move || {
+                run_worker(
+                    &audio_rx,
+                    &event_tx,
+                    &cancel,
+                    sherpa_model,
+                    noise_gate_ratio,
+                );
+            })?;
+
+        self.worker = Some(handle);
+        tracing::info!("sherpa backend started");
+
+        Ok(BackendHandle { audio_tx, event_rx })
     }
 
     fn stop(&mut self) {
-        self.shutdown_nonblocking();
+        self.cancel.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.worker.take() {
+            let _ = handle.join();
+        }
+        tracing::info!("sherpa backend stopped");
     }
 
     fn shutdown_nonblocking(&mut self) {
-        self.cancel
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        self.worker.take(); // detach
+        self.cancel.store(true, Ordering::Relaxed);
+        self.worker.take(); // detach — don't join
         tracing::info!("sherpa backend shutdown (non-blocking)");
     }
+}
+
+/// Build the `OnlineRecognizerConfig` for a Streaming Zipformer model.
+///
+/// The `provider` parameter selects the ONNX execution provider — `"cpu"`
+/// is the default; `"cuda"` enables GPU acceleration if libsherpa was
+/// built with CUDA support. PR 2 hardcodes `"cpu"`; CUDA validation is
+/// the manual smoke test in Task 10.
+fn build_recognizer_config(model: SherpaModel, provider: &str) -> OnlineRecognizerConfig {
+    let (encoder, decoder, joiner, tokens) = sherpa_model::model_file_paths(model);
+
+    let mut config = OnlineRecognizerConfig::default();
+    config.model_config.transducer.encoder = Some(encoder.to_string_lossy().into_owned());
+    config.model_config.transducer.decoder = Some(decoder.to_string_lossy().into_owned());
+    config.model_config.transducer.joiner = Some(joiner.to_string_lossy().into_owned());
+    config.model_config.tokens = Some(tokens.to_string_lossy().into_owned());
+    config.model_config.provider = Some(provider.to_owned());
+    config.model_config.num_threads = 1;
+    config.enable_endpoint = true;
+    config.decoding_method = Some("greedy_search".to_owned());
+    config.rule1_min_trailing_silence = RULE1_MIN_TRAILING_SILENCE;
+    config.rule2_min_trailing_silence = RULE2_MIN_TRAILING_SILENCE;
+    config.rule3_min_utterance_length = RULE3_MIN_UTTERANCE_LENGTH;
+
+    config
+}
+
+/// Worker thread entry point. Owns the recognizer and stream for the
+/// entire transcription session.
+fn run_worker(
+    audio_rx: &mpsc::Receiver<Vec<f32>>,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+    cancel: &Arc<AtomicBool>,
+    model: SherpaModel,
+    noise_gate_ratio: f32,
+) {
+    if let Err(e) = run_worker_inner(audio_rx, event_tx, cancel, model, noise_gate_ratio) {
+        let _ = event_tx.send(TranscriptionEvent::Error(e));
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_worker_inner(
+    audio_rx: &mpsc::Receiver<Vec<f32>>,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+    cancel: &Arc<AtomicBool>,
+    model: SherpaModel,
+    noise_gate_ratio: f32,
+) -> Result<(), String> {
+    // For PR 2 we hardcode CPU provider. CUDA support is validated in
+    // the smoke test step; if CUDA works, a follow-up PR wires it
+    // through the UI as a separate setting.
+    let provider = "cpu";
+    let recognizer_config = build_recognizer_config(model, provider);
+
+    tracing::info!(?model, provider, "loading sherpa-onnx model");
+    let recognizer = OnlineRecognizer::create(&recognizer_config).ok_or_else(|| {
+        "OnlineRecognizer::create returned None — check model file paths".to_owned()
+    })?;
+
+    let stream = recognizer.create_stream();
+
+    tracing::info!("sherpa-onnx model loaded, ready for inference");
+    event_tx
+        .send(TranscriptionEvent::Ready)
+        .map_err(|_| "event channel closed before Ready".to_owned())?;
+
+    // Sherpa expects 16 kHz mono f32 samples. We accept the same
+    // 48 kHz interleaved stereo from the DSP thread that Whisper does,
+    // run it through the spectral denoiser, downsample to 16k mono, and
+    // feed sherpa one chunk at a time.
+    let mut mono_buf: Vec<f32> = Vec::with_capacity(16_000);
+    let mut last_partial = String::new();
+
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            tracing::info!("sherpa transcription cancelled, worker exiting");
+            return Ok(());
+        }
+
+        let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
+            Ok(data) => data,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+
+        // Resample 48k stereo → 16k mono into the scratch buffer.
+        mono_buf.clear();
+        resampler::downsample_stereo_to_mono_16k(&interleaved, &mut mono_buf);
+
+        // Drain any additional queued buffers into the same scratch
+        // (same pattern as WhisperBackend) so we don't fall behind.
+        while let Ok(extra) = audio_rx.try_recv() {
+            if cancel.load(Ordering::Relaxed) {
+                tracing::info!("sherpa transcription cancelled, worker exiting");
+                return Ok(());
+            }
+            resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
+        }
+
+        if mono_buf.is_empty() {
+            continue;
+        }
+
+        // Spectral noise gate (same preprocessor as Whisper).
+        denoise::spectral_denoise(&mut mono_buf, noise_gate_ratio);
+
+        // Feed the chunk to sherpa.
+        stream.accept_waveform(16_000_i32, &mono_buf);
+
+        // Decode as much as the recognizer is ready for.
+        while recognizer.is_ready(&stream) {
+            if cancel.load(Ordering::Relaxed) {
+                tracing::info!("sherpa transcription cancelled mid-decode, exiting");
+                return Ok(());
+            }
+            recognizer.decode(&stream);
+        }
+
+        // Pull the current hypothesis. Emit a Partial event if it
+        // changed since the last one (avoid flooding the UI thread).
+        if let Some(result) = recognizer.get_result(&stream) {
+            let trimmed = result.text.trim();
+            if !trimmed.is_empty() && trimmed != last_partial {
+                last_partial = trimmed.to_owned();
+                let _ = event_tx.send(TranscriptionEvent::Partial {
+                    text: trimmed.to_owned(),
+                });
+            }
+
+            // On endpoint, commit the utterance as Text and reset the
+            // stream so the next utterance starts fresh.
+            if recognizer.is_endpoint(&stream) {
+                if !trimmed.is_empty() {
+                    let timestamp = wall_clock_timestamp();
+                    tracing::debug!(%timestamp, %trimmed, "sherpa committed utterance");
+                    let _ = event_tx.send(TranscriptionEvent::Text {
+                        timestamp,
+                        text: trimmed.to_owned(),
+                    });
+                }
+                recognizer.reset(&stream);
+                last_partial.clear();
+            }
+        }
+    }
+
+    tracing::info!("sherpa audio channel closed, worker exiting");
+    Ok(())
+}
+
+/// Wall-clock "HH:MM:SS" string. Same implementation as
+/// [`crate::backends::whisper`] but kept local to avoid a public
+/// re-export of an internal helper.
+#[allow(unsafe_code)]
+fn wall_clock_timestamp() -> String {
+    let mut tv = libc::timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+
+    // SAFETY: gettimeofday writes into the provided buffer and is thread-safe.
+    #[allow(unsafe_code)]
+    let epoch = unsafe {
+        libc::gettimeofday(&raw mut tv, std::ptr::null_mut());
+        tv.tv_sec
+    };
+
+    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
+
+    // SAFETY: localtime_r is the reentrant variant; gmtime_r is the UTC fallback.
+    #[allow(unsafe_code)]
+    let tm = unsafe {
+        let result = libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
+        let result = if result.is_null() {
+            libc::gmtime_r(&raw const epoch, tm.as_mut_ptr())
+        } else {
+            result
+        };
+        if result.is_null() {
+            return "00:00:00".to_owned();
+        }
+        tm.assume_init()
+    };
+
+    format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec)
 }
 
 #[cfg(test)]

--- a/crates/sdr-transcription/src/backends/sherpa.rs
+++ b/crates/sdr-transcription/src/backends/sherpa.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::time::Duration;
 
-use sherpa_onnx::{OnlineRecognizer, OnlineRecognizerConfig};
+use sherpa_onnx::{OnlineRecognizer, OnlineRecognizerConfig, OnlineStream};
 
 use crate::backend::{
     BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
@@ -51,7 +51,7 @@ const HOST_INIT_TIMEOUT: Duration = Duration::from_mins(1);
 /// Process-wide singleton for the sherpa-onnx host. Stores either a ready
 /// host or the error message from a failed initialization. Set exactly once
 /// by [`init_sherpa_host`]; subsequent calls are no-ops.
-static SHERPA_HOST: OnceLock<Result<SherpaHost, String>> = OnceLock::new();
+static SHERPA_HOST: OnceLock<Result<SherpaHost, Arc<BackendError>>> = OnceLock::new();
 
 /// Spawn the global sherpa-onnx host thread.
 ///
@@ -67,12 +67,12 @@ static SHERPA_HOST: OnceLock<Result<SherpaHost, String>> = OnceLock::new();
 /// stashed in the global slot and reported when the user actually tries to
 /// start a Sherpa transcription session.
 pub fn init_sherpa_host(model: SherpaModel) {
-    let _ = SHERPA_HOST.set(SherpaHost::spawn(model).map_err(|e| e.to_string()));
+    let _ = SHERPA_HOST.set(SherpaHost::spawn(model).map_err(Arc::new));
 }
 
 /// Look up the global sherpa host. Returns `None` if `init_sherpa_host` was
 /// never called.
-fn global_sherpa_host() -> Option<&'static Result<SherpaHost, String>> {
+fn global_sherpa_host() -> Option<&'static Result<SherpaHost, Arc<BackendError>>> {
     SHERPA_HOST.get()
 }
 
@@ -139,7 +139,10 @@ impl SherpaHost {
     /// Send a `StartSession` command to the host. Returns an error if the
     /// host worker has died.
     fn start_session(&self, params: SessionParams) -> Result<(), BackendError> {
-        let state = self.state.lock().expect("sherpa host mutex poisoned");
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| BackendError::Init("sherpa host mutex poisoned".to_owned()))?;
         state
             .cmd_tx
             .send(HostCommand::StartSession(params))
@@ -187,6 +190,13 @@ fn run_host_loop(
 }
 
 /// Build the `OnlineRecognizerConfig` for a Streaming Zipformer model.
+///
+/// Note: `BackendConfig::silence_threshold` is intentionally NOT honored here
+/// because sherpa-onnx's `OnlineRecognizer` has native endpoint detection
+/// (via `rule1`/`rule2`/`rule3_min_trailing_silence`) that handles silence
+/// at the model level. Adding an RMS-based pre-gate would mask short pauses
+/// inside utterances and confuse the streaming decoder. The Whisper backend
+/// uses `silence_threshold` because Whisper has no built-in VAD.
 fn build_recognizer_config(model: SherpaModel, provider: &str) -> OnlineRecognizerConfig {
     let (encoder, decoder, joiner, tokens) = sherpa_model::model_file_paths(model);
 
@@ -228,6 +238,7 @@ fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
     loop {
         if cancel.load(Ordering::Relaxed) {
             tracing::info!("sherpa session cancelled");
+            finalize_session(recognizer, &stream, &last_partial, &event_tx);
             return;
         }
 
@@ -245,6 +256,7 @@ fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
         // (same pattern as WhisperBackend) so we don't fall behind.
         while let Ok(extra) = audio_rx.try_recv() {
             if cancel.load(Ordering::Relaxed) {
+                finalize_session(recognizer, &stream, &last_partial, &event_tx);
                 return;
             }
             resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
@@ -260,6 +272,7 @@ fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
 
         while recognizer.is_ready(&stream) {
             if cancel.load(Ordering::Relaxed) {
+                finalize_session(recognizer, &stream, &last_partial, &event_tx);
                 return;
             }
             recognizer.decode(&stream);
@@ -288,7 +301,7 @@ fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
         // so reset() fires when the recognizer says the utterance is over.
         if recognizer.is_endpoint(&stream) {
             if !current_text.is_empty() {
-                let timestamp = wall_clock_timestamp();
+                let timestamp = crate::util::wall_clock_timestamp();
                 tracing::debug!(%timestamp, text = %current_text, "sherpa committed utterance");
                 let _ = event_tx.send(TranscriptionEvent::Text {
                     timestamp,
@@ -300,6 +313,9 @@ fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
         }
     }
 
+    // Audio channel disconnected — commit any in-flight hypothesis as Text
+    // before exiting so the last spoken phrase isn't lost.
+    finalize_session(recognizer, &stream, &last_partial, &event_tx);
     tracing::info!("sherpa session ended (audio channel disconnected)");
 }
 
@@ -344,10 +360,29 @@ impl TranscriptionBackend for SherpaBackend {
 
         let host = match global_sherpa_host() {
             Some(Ok(h)) => h,
-            Some(Err(msg)) => {
-                return Err(BackendError::Init(format!(
-                    "sherpa host failed to initialize: {msg}"
-                )));
+            Some(Err(stored)) => {
+                // Reconstruct a fresh BackendError so callers (and the UI)
+                // see the original variant. ModelNotFound is the most
+                // important case to preserve — it tells the user exactly
+                // where to download the model bundle.
+                return Err(match &**stored {
+                    BackendError::ModelNotFound { path } => {
+                        BackendError::ModelNotFound { path: path.clone() }
+                    }
+                    BackendError::Init(msg) => {
+                        BackendError::Init(format!("sherpa host failed to initialize: {msg}"))
+                    }
+                    BackendError::Spawn(io_err) => {
+                        // io::Error isn't Clone; flatten to a string and
+                        // wrap in Init. This is a rare path (worker thread
+                        // spawn failure during init) so the loss of fidelity
+                        // is acceptable.
+                        BackendError::Init(format!(
+                            "sherpa host worker thread spawn failed: {io_err}"
+                        ))
+                    }
+                    BackendError::WrongModelKind => BackendError::WrongModelKind,
+                });
             }
             None => {
                 return Err(BackendError::Init(
@@ -389,40 +424,33 @@ impl TranscriptionBackend for SherpaBackend {
     }
 }
 
-/// Wall-clock "HH:MM:SS" string. Same implementation as
-/// [`crate::backends::whisper`] but kept local to avoid a public re-export
-/// of an internal helper.
-fn wall_clock_timestamp() -> String {
-    let mut tv = libc::timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
+/// Commit any in-flight partial hypothesis as a final `Text` event before
+/// the session ends. Called from both the cancel and disconnect exit paths.
+///
+/// We pull `get_result` one more time so we capture any text the recognizer
+/// produced after the last partial event but before the loop exited. If
+/// that's empty we fall back to `last_partial` which holds whatever was
+/// most recently emitted.
+fn finalize_session(
+    recognizer: &OnlineRecognizer,
+    stream: &OnlineStream,
+    last_partial: &str,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+) {
+    let final_text = recognizer
+        .get_result(stream)
+        .map(|r| r.text.trim().to_owned())
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| last_partial.to_owned());
 
-    // SAFETY: gettimeofday writes into the provided buffer and is thread-safe.
-    #[allow(unsafe_code)]
-    let epoch = unsafe {
-        libc::gettimeofday(&raw mut tv, std::ptr::null_mut());
-        tv.tv_sec
-    };
-
-    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
-
-    // SAFETY: localtime_r is the reentrant variant; gmtime_r is the UTC fallback.
-    #[allow(unsafe_code)]
-    let tm = unsafe {
-        let result = libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
-        let result = if result.is_null() {
-            libc::gmtime_r(&raw const epoch, tm.as_mut_ptr())
-        } else {
-            result
-        };
-        if result.is_null() {
-            return "00:00:00".to_owned();
-        }
-        tm.assume_init()
-    };
-
-    format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec)
+    if !final_text.is_empty() {
+        let timestamp = crate::util::wall_clock_timestamp();
+        tracing::debug!(%timestamp, text = %final_text, "sherpa finalizing on session end");
+        let _ = event_tx.send(TranscriptionEvent::Text {
+            timestamp,
+            text: final_text,
+        });
+    }
 }
 
 #[cfg(test)]
@@ -439,37 +467,6 @@ mod tests {
     fn sherpa_backend_name_is_stable() {
         let backend = SherpaBackend::new();
         assert_eq!(backend.name(), "sherpa");
-    }
-
-    #[test]
-    #[allow(clippy::panic)]
-    fn sherpa_backend_start_returns_init_error_when_host_not_initialized() {
-        // The test process never calls init_sherpa_host, so the global
-        // OnceLock is empty and start() should return BackendError::Init
-        // with a clear message about the host not being initialized.
-        //
-        // Note: this test relies on no other test in this binary calling
-        // init_sherpa_host. Cargo runs each integration test binary
-        // separately but unit tests share a process. If this test ever
-        // becomes flaky, mark it #[ignore] and run manually.
-        let mut backend = SherpaBackend::new();
-        let config = BackendConfig {
-            model: ModelChoice::Sherpa(SherpaModel::StreamingZipformerEn),
-            silence_threshold: 0.007,
-            noise_gate_ratio: 3.0,
-        };
-        match backend.start(config) {
-            Err(BackendError::Init(msg)) => {
-                assert!(
-                    msg.contains("not initialized") || msg.contains("failed to initialize"),
-                    "expected init error mentioning initialization, got: {msg}"
-                );
-            }
-            Err(e) => panic!("expected Init error, got: {e:?}"),
-            Ok(_) => {
-                panic!("expected Init error because init_sherpa_host was never called, got Ok")
-            }
-        }
     }
 
     #[test]

--- a/crates/sdr-transcription/src/backends/sherpa.rs
+++ b/crates/sdr-transcription/src/backends/sherpa.rs
@@ -336,9 +336,11 @@ impl TranscriptionBackend for SherpaBackend {
     }
 
     fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
-        let ModelChoice::Sherpa(_) = config.model else {
-            return Err(BackendError::WrongModelKind);
-        };
+        match config.model {
+            ModelChoice::Sherpa(_) => {}
+            #[cfg(feature = "whisper")]
+            ModelChoice::Whisper(_) => return Err(BackendError::WrongModelKind),
+        }
 
         let host = match global_sherpa_host() {
             Some(Ok(h)) => h,

--- a/crates/sdr-transcription/src/backends/sherpa.rs
+++ b/crates/sdr-transcription/src/backends/sherpa.rs
@@ -365,9 +365,7 @@ mod tests {
                 // locally, skip this test rather than fail. Tearing down
                 // the running backend is fine because it's just a thread.
                 backend.shutdown_nonblocking();
-                eprintln!(
-                    "skipping test: streaming-zipformer-en model is present locally"
-                );
+                eprintln!("skipping test: streaming-zipformer-en model is present locally");
             }
             Err(e) => panic!("expected ModelNotFound, got {e:?}"),
         }

--- a/crates/sdr-transcription/src/backends/sherpa.rs
+++ b/crates/sdr-transcription/src/backends/sherpa.rs
@@ -27,7 +27,7 @@ use crate::{denoise, resampler};
 
 /// Bounded channel capacity for audio buffers from DSP → backend.
 /// Sherpa accepts much smaller chunks than Whisper (per-frame, not
-/// 5-second windows), so we don't need the same headroom WhisperBackend
+/// 5-second windows), so we don't need the same headroom `WhisperBackend`
 /// does. 256 still gives plenty of buffer.
 const AUDIO_CHANNEL_CAPACITY: usize = 256;
 
@@ -89,6 +89,8 @@ impl TranscriptionBackend for SherpaBackend {
         let (event_tx, event_rx) = mpsc::channel();
 
         let cancel = Arc::clone(&self.cancel);
+        // silence_threshold is unused: sherpa's endpoint detection
+        // handles silence natively.
         let noise_gate_ratio = config.noise_gate_ratio;
 
         let handle = std::thread::Builder::new()
@@ -243,29 +245,39 @@ fn run_worker_inner(
 
         // Pull the current hypothesis. Emit a Partial event if it
         // changed since the last one (avoid flooding the UI thread).
-        if let Some(result) = recognizer.get_result(&stream) {
-            let trimmed = result.text.trim();
+        // We capture the trimmed text so it can be reused for the
+        // committed Text event below if the stream reaches an endpoint.
+        let current_text = if let Some(result) = recognizer.get_result(&stream) {
+            let trimmed = result.text.trim().to_owned();
             if !trimmed.is_empty() && trimmed != last_partial {
-                last_partial = trimmed.to_owned();
+                last_partial.clone_from(&trimmed);
                 let _ = event_tx.send(TranscriptionEvent::Partial {
-                    text: trimmed.to_owned(),
+                    text: trimmed.clone(),
                 });
             }
+            trimmed
+        } else {
+            // get_result can return None on a serde failure inside the C
+            // layer. We must NOT skip the endpoint check below in that
+            // case — otherwise the stream can get stuck in endpoint state
+            // and silently stop transcribing.
+            String::new()
+        };
 
-            // On endpoint, commit the utterance as Text and reset the
-            // stream so the next utterance starts fresh.
-            if recognizer.is_endpoint(&stream) {
-                if !trimmed.is_empty() {
-                    let timestamp = wall_clock_timestamp();
-                    tracing::debug!(%timestamp, %trimmed, "sherpa committed utterance");
-                    let _ = event_tx.send(TranscriptionEvent::Text {
-                        timestamp,
-                        text: trimmed.to_owned(),
-                    });
-                }
-                recognizer.reset(&stream);
-                last_partial.clear();
+        // Endpoint check is independent of get_result and must always
+        // run so reset() fires when the recognizer says the utterance
+        // is over.
+        if recognizer.is_endpoint(&stream) {
+            if !current_text.is_empty() {
+                let timestamp = wall_clock_timestamp();
+                tracing::debug!(%timestamp, text = %current_text, "sherpa committed utterance");
+                let _ = event_tx.send(TranscriptionEvent::Text {
+                    timestamp,
+                    text: current_text,
+                });
             }
+            recognizer.reset(&stream);
+            last_partial.clear();
         }
     }
 
@@ -276,7 +288,6 @@ fn run_worker_inner(
 /// Wall-clock "HH:MM:SS" string. Same implementation as
 /// [`crate::backends::whisper`] but kept local to avoid a public
 /// re-export of an internal helper.
-#[allow(unsafe_code)]
 fn wall_clock_timestamp() -> String {
     let mut tv = libc::timeval {
         tv_sec: 0,
@@ -324,5 +335,41 @@ mod tests {
     fn sherpa_backend_name_is_stable() {
         let backend = SherpaBackend::new();
         assert_eq!(backend.name(), "sherpa");
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn sherpa_backend_start_returns_model_not_found_when_files_missing() {
+        // The test environment has no sherpa model files in
+        // ~/.local/share/sdr-rs/models/sherpa/, so start() should
+        // synchronously return ModelNotFound before spawning the worker.
+        // This exercises the synchronous error path without needing a
+        // real model bundle.
+        //
+        // Note: this test would fail if the developer running it has
+        // actually downloaded the Streaming Zipformer model. That's
+        // acceptable — CI runs in a clean environment.
+        let mut backend = SherpaBackend::new();
+        let config = BackendConfig {
+            model: ModelChoice::Sherpa(SherpaModel::StreamingZipformerEn),
+            silence_threshold: 0.007,
+            noise_gate_ratio: 3.0,
+        };
+        let result = backend.start(config);
+        match result {
+            Err(BackendError::ModelNotFound { path }) => {
+                assert!(path.ends_with("sherpa/streaming-zipformer-en"));
+            }
+            Ok(_) => {
+                // If the developer happens to have the model downloaded
+                // locally, skip this test rather than fail. Tearing down
+                // the running backend is fine because it's just a thread.
+                backend.shutdown_nonblocking();
+                eprintln!(
+                    "skipping test: streaming-zipformer-en model is present locally"
+                );
+            }
+            Err(e) => panic!("expected ModelNotFound, got {e:?}"),
+        }
     }
 }

--- a/crates/sdr-transcription/src/backends/sherpa.rs
+++ b/crates/sdr-transcription/src/backends/sherpa.rs
@@ -1,0 +1,86 @@
+//! Sherpa-onnx backend — streaming-native ASR via the official k2-fsa
+//! `sherpa-onnx` Rust crate.
+//!
+//! Implements [`TranscriptionBackend`] using `OnlineRecognizer` for true
+//! frame-by-frame streaming with endpoint detection. Partial hypotheses
+//! are emitted as `TranscriptionEvent::Partial`; committed utterances
+//! after silence detection are emitted as `TranscriptionEvent::Text`.
+//!
+//! `OnlineRecognizer` and `OnlineStream` are `!Send` (they wrap raw
+//! pointers into the C library), so all recognizer interaction happens
+//! on the worker thread. The `SherpaBackend` struct itself only holds
+//! the cancellation token and the worker join handle, mirroring
+//! `WhisperBackend`.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use crate::backend::{
+    BackendConfig, BackendError, BackendHandle, TranscriptionBackend,
+};
+
+/// `TranscriptionBackend` implementation backed by `sherpa-onnx`.
+pub struct SherpaBackend {
+    cancel: Arc<AtomicBool>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Default for SherpaBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SherpaBackend {
+    pub fn new() -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+            worker: None,
+        }
+    }
+}
+
+impl TranscriptionBackend for SherpaBackend {
+    fn name(&self) -> &'static str {
+        "sherpa"
+    }
+
+    fn supports_partials(&self) -> bool {
+        true
+    }
+
+    fn start(&mut self, _config: BackendConfig) -> Result<BackendHandle, BackendError> {
+        // Skeleton — real implementation lands in Task 7.
+        Err(BackendError::Init(
+            "SherpaBackend is not yet implemented (Task 7)".to_owned(),
+        ))
+    }
+
+    fn stop(&mut self) {
+        self.shutdown_nonblocking();
+    }
+
+    fn shutdown_nonblocking(&mut self) {
+        self.cancel
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.worker.take(); // detach
+        tracing::info!("sherpa backend shutdown (non-blocking)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sherpa_backend_supports_partials() {
+        let backend = SherpaBackend::new();
+        assert!(backend.supports_partials());
+    }
+
+    #[test]
+    fn sherpa_backend_name_is_stable() {
+        let backend = SherpaBackend::new();
+        assert_eq!(backend.name(), "sherpa");
+    }
+}

--- a/crates/sdr-transcription/src/backends/whisper.rs
+++ b/crates/sdr-transcription/src/backends/whisper.rs
@@ -63,8 +63,15 @@ impl TranscriptionBackend for WhisperBackend {
     }
 
     fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
-        let ModelChoice::Whisper(whisper_model) = config.model else {
-            return Err(BackendError::WrongModelKind);
+        // The cfg-gated Sherpa arm exists only when both features are
+        // enabled (which compile_error prevents). In whisper-only builds
+        // this match has one arm — allow clippy's infallible_destructuring_match
+        // warning rather than hiding the intent of the guard.
+        #[allow(clippy::infallible_destructuring_match)]
+        let whisper_model = match config.model {
+            ModelChoice::Whisper(m) => m,
+            #[cfg(feature = "sherpa")]
+            ModelChoice::Sherpa(_) => return Err(BackendError::WrongModelKind),
         };
 
         self.cancel.store(false, Ordering::Relaxed);

--- a/crates/sdr-transcription/src/backends/whisper.rs
+++ b/crates/sdr-transcription/src/backends/whisper.rs
@@ -63,7 +63,9 @@ impl TranscriptionBackend for WhisperBackend {
     }
 
     fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
-        let ModelChoice::Whisper(whisper_model) = config.model;
+        let ModelChoice::Whisper(whisper_model) = config.model else {
+            return Err(BackendError::WrongModelKind);
+        };
 
         self.cancel.store(false, Ordering::Relaxed);
 

--- a/crates/sdr-transcription/src/backends/whisper.rs
+++ b/crates/sdr-transcription/src/backends/whisper.rs
@@ -279,7 +279,7 @@ fn run_worker_inner(
             }
 
             if !combined.is_empty() && !is_hallucination(&combined) {
-                let timestamp = chrono_timestamp();
+                let timestamp = crate::util::wall_clock_timestamp();
                 tracing::debug!(%timestamp, %combined, "transcribed chunk");
                 let _ = event_tx.send(TranscriptionEvent::Text {
                     timestamp,
@@ -332,47 +332,6 @@ pub(crate) fn compute_rms(samples: &[f32]) -> f32 {
     #[allow(clippy::cast_precision_loss)]
     let mean = sum_sq / samples.len() as f32;
     mean.sqrt()
-}
-
-/// Return the current wall-clock time formatted as "HH:MM:SS" in local time.
-///
-/// Uses `libc::localtime_r` for timezone-aware formatting without pulling in
-/// the `chrono` crate.
-#[allow(unsafe_code)]
-fn chrono_timestamp() -> String {
-    let mut tv = libc::timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
-
-    // SAFETY: `gettimeofday` writes into the provided buffer and is
-    // thread-safe. We pass null for the timezone (deprecated parameter).
-    #[allow(unsafe_code)]
-    let epoch = unsafe {
-        libc::gettimeofday(&raw mut tv, std::ptr::null_mut());
-        tv.tv_sec
-    };
-
-    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
-
-    // SAFETY: `localtime_r` is the reentrant (thread-safe) variant.
-    // We provide a valid `time_t` and a valid output buffer.
-    // Returns null on failure, in which case we fall back to UTC via `gmtime_r`.
-    #[allow(unsafe_code)]
-    let tm = unsafe {
-        let result = libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
-        let result = if result.is_null() {
-            libc::gmtime_r(&raw const epoch, tm.as_mut_ptr())
-        } else {
-            result
-        };
-        if result.is_null() {
-            return "00:00:00".to_owned();
-        }
-        tm.assume_init()
-    };
-
-    format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec)
 }
 
 #[cfg(test)]

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -12,12 +12,14 @@ pub mod backends;
 pub mod denoise;
 pub mod model;
 pub mod resampler;
+pub mod sherpa_model;
 
 pub use backend::{
     BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
     TranscriptionEvent,
 };
 pub use model::WhisperModel;
+pub use sherpa_model::SherpaModel;
 
 use std::sync::mpsc;
 

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -30,6 +30,7 @@ pub mod backend;
 pub mod backends;
 pub mod denoise;
 pub mod resampler;
+pub mod util;
 
 #[cfg(feature = "whisper")]
 pub mod model;

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -4,8 +4,9 @@
 //! [`backend::TranscriptionBackend`] implementations. The engine owns
 //! one backend at a time and delegates lifecycle to it.
 //!
-//! Currently only the Whisper backend is implemented; sherpa-onnx
-//! lands in PR 2.
+//! Two backends are currently implemented: [`backends::whisper::WhisperBackend`]
+//! (file-based, chunked inference via whisper-rs) and
+//! [`backends::sherpa::SherpaBackend`] (true streaming via sherpa-onnx).
 
 pub mod backend;
 pub mod backends;

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -7,25 +7,55 @@
 //! Two backends are currently implemented: [`backends::whisper::WhisperBackend`]
 //! (file-based, chunked inference via whisper-rs) and
 //! [`backends::sherpa::SherpaBackend`] (true streaming via sherpa-onnx).
+//!
+//! The `whisper` and `sherpa` cargo features are mutually exclusive. Exactly
+//! one must be enabled at build time (see the `compile_error` guards below).
+
+#[cfg(all(feature = "whisper", feature = "sherpa"))]
+compile_error!(
+    "features `whisper` and `sherpa` are mutually exclusive. \
+     Pick exactly one. For Whisper: `--features cuda` (or hipblas/vulkan/metal/etc) \
+     or `--features whisper`. For Sherpa: `--no-default-features --features sherpa`."
+);
+
+#[cfg(not(any(feature = "whisper", feature = "sherpa")))]
+compile_error!(
+    "exactly one of the `whisper` or `sherpa` features must be enabled. \
+     The default is `whisper`. For Sherpa: `--no-default-features --features sherpa`."
+);
 
 pub mod backend;
 pub mod backends;
 pub mod denoise;
-pub mod model;
 pub mod resampler;
+
+#[cfg(feature = "whisper")]
+pub mod model;
+
+#[cfg(feature = "sherpa")]
 pub mod sherpa_model;
 
 pub use backend::{
     BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
     TranscriptionEvent,
 };
-pub use backends::sherpa::init_sherpa_host;
+
+#[cfg(feature = "whisper")]
 pub use model::WhisperModel;
+
+#[cfg(feature = "sherpa")]
+pub use backends::sherpa::init_sherpa_host;
+
+#[cfg(feature = "sherpa")]
 pub use sherpa_model::SherpaModel;
 
 use std::sync::mpsc;
 
+#[cfg(feature = "whisper")]
 use crate::backends::whisper::WhisperBackend;
+
+#[cfg(feature = "sherpa")]
+use crate::backends::sherpa::SherpaBackend;
 
 /// Error type for engine-level operations.
 #[derive(Debug, thiserror::Error)]
@@ -71,8 +101,10 @@ impl TranscriptionEngine {
         config: BackendConfig,
     ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
         let backend: Box<dyn TranscriptionBackend> = match config.model {
+            #[cfg(feature = "whisper")]
             ModelChoice::Whisper(_) => Box::new(WhisperBackend::new()),
-            ModelChoice::Sherpa(_) => Box::new(backends::sherpa::SherpaBackend::new()),
+            #[cfg(feature = "sherpa")]
+            ModelChoice::Sherpa(_) => Box::new(SherpaBackend::new()),
         };
         self.start_with_backend(backend, config)
     }
@@ -153,8 +185,12 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     fn dummy_config() -> BackendConfig {
+        #[cfg(feature = "whisper")]
+        let model = ModelChoice::Whisper(WhisperModel::TinyEn);
+        #[cfg(feature = "sherpa")]
+        let model = ModelChoice::Sherpa(crate::SherpaModel::StreamingZipformerEn);
         BackendConfig {
-            model: ModelChoice::Whisper(WhisperModel::TinyEn),
+            model,
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
         }

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -60,22 +60,17 @@ impl TranscriptionEngine {
         }
     }
 
-    /// Start the Whisper backend with the given model and parameters.
-    /// Returns a receiver for [`TranscriptionEvent`].
+    /// Start a transcription backend selected by `config.model`.
     ///
-    /// Kept for API compatibility with the pre-refactor engine.
-    /// Internally constructs a [`WhisperBackend`] and delegates.
+    /// Constructs the right backend (Whisper or Sherpa) for the chosen
+    /// model and returns a receiver for [`TranscriptionEvent`].
     pub fn start(
         &mut self,
-        whisper_model: WhisperModel,
-        silence_threshold: f32,
-        noise_gate_ratio: f32,
+        config: BackendConfig,
     ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
-        let backend: Box<dyn TranscriptionBackend> = Box::new(WhisperBackend::new());
-        let config = BackendConfig {
-            model: ModelChoice::Whisper(whisper_model),
-            silence_threshold,
-            noise_gate_ratio,
+        let backend: Box<dyn TranscriptionBackend> = match config.model {
+            ModelChoice::Whisper(_) => Box::new(WhisperBackend::new()),
+            ModelChoice::Sherpa(_) => Box::new(backends::sherpa::SherpaBackend::new()),
         };
         self.start_with_backend(backend, config)
     }

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -19,6 +19,7 @@ pub use backend::{
     BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
     TranscriptionEvent,
 };
+pub use backends::sherpa::init_sherpa_host;
 pub use model::WhisperModel;
 pub use sherpa_model::SherpaModel;
 

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -13,15 +13,17 @@
 
 #[cfg(all(feature = "whisper", feature = "sherpa"))]
 compile_error!(
-    "features `whisper` and `sherpa` are mutually exclusive. \
-     Pick exactly one. For Whisper: `--features cuda` (or hipblas/vulkan/metal/etc) \
-     or `--features whisper`. For Sherpa: `--no-default-features --features sherpa`."
+    "the whisper and sherpa transcription backends are mutually exclusive. \
+     Pick exactly one user-facing feature: \
+     `whisper-cpu` (default), `whisper-cuda`, `whisper-hipblas`, \
+     `whisper-vulkan`, `whisper-metal`, `whisper-intel-sycl`, `whisper-openblas`, \
+     or `sherpa-cpu`. For sherpa, pass `--no-default-features --features sherpa-cpu`."
 );
 
 #[cfg(not(any(feature = "whisper", feature = "sherpa")))]
 compile_error!(
-    "exactly one of the `whisper` or `sherpa` features must be enabled. \
-     The default is `whisper`. For Sherpa: `--no-default-features --features sherpa`."
+    "exactly one transcription backend must be enabled. The default is \
+     `whisper-cpu`. For sherpa, pass `--no-default-features --features sherpa-cpu`."
 );
 
 pub mod backend;

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -36,27 +36,21 @@ impl SherpaModel {
     /// Filename of the encoder ONNX file inside the model directory.
     pub fn encoder_filename(self) -> &'static str {
         match self {
-            Self::StreamingZipformerEn => {
-                "encoder-epoch-99-avg-1-chunk-16-left-128.onnx"
-            }
+            Self::StreamingZipformerEn => "encoder-epoch-99-avg-1-chunk-16-left-128.onnx",
         }
     }
 
     /// Filename of the decoder ONNX file inside the model directory.
     pub fn decoder_filename(self) -> &'static str {
         match self {
-            Self::StreamingZipformerEn => {
-                "decoder-epoch-99-avg-1-chunk-16-left-128.onnx"
-            }
+            Self::StreamingZipformerEn => "decoder-epoch-99-avg-1-chunk-16-left-128.onnx",
         }
     }
 
     /// Filename of the joiner ONNX file inside the model directory.
     pub fn joiner_filename(self) -> &'static str {
         match self {
-            Self::StreamingZipformerEn => {
-                "joiner-epoch-99-avg-1-chunk-16-left-128.onnx"
-            }
+            Self::StreamingZipformerEn => "joiner-epoch-99-avg-1-chunk-16-left-128.onnx",
         }
     }
 

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -1,0 +1,133 @@
+//! Sherpa-onnx model registry and path management.
+//!
+//! Mirrors `model.rs` (the Whisper registry) but for sherpa-onnx bundles.
+//! Each `SherpaModel` variant maps to a directory containing the encoder,
+//! decoder, joiner, and tokens files for one streaming ASR model.
+//!
+//! For PR 2 (the sherpa spike) the user manually downloads bundles into
+//! `models_dir() / sherpa / <model>/` before launching. PR 3 adds
+//! auto-download.
+
+use std::path::PathBuf;
+
+/// Available sherpa-onnx model variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SherpaModel {
+    /// Streaming Zipformer English (k2-fsa, 2023-06-26).
+    StreamingZipformerEn,
+}
+
+impl SherpaModel {
+    /// Human-readable display label for the model picker.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "Streaming Zipformer (English)",
+        }
+    }
+
+    /// Directory name (under `models_dir() / sherpa /`) where this model's
+    /// files live.
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "streaming-zipformer-en",
+        }
+    }
+
+    /// Filename of the encoder ONNX file inside the model directory.
+    pub fn encoder_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => {
+                "encoder-epoch-99-avg-1-chunk-16-left-128.onnx"
+            }
+        }
+    }
+
+    /// Filename of the decoder ONNX file inside the model directory.
+    pub fn decoder_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => {
+                "decoder-epoch-99-avg-1-chunk-16-left-128.onnx"
+            }
+        }
+    }
+
+    /// Filename of the joiner ONNX file inside the model directory.
+    pub fn joiner_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => {
+                "joiner-epoch-99-avg-1-chunk-16-left-128.onnx"
+            }
+        }
+    }
+
+    /// Filename of the tokens file inside the model directory.
+    pub fn tokens_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "tokens.txt",
+        }
+    }
+
+    /// All available variants in order — used to populate the UI dropdown.
+    pub const ALL: &[Self] = &[Self::StreamingZipformerEn];
+}
+
+/// Returns the sherpa subdirectory under the shared models dir
+/// (`~/.local/share/sdr-rs/models/sherpa/`).
+pub fn sherpa_models_dir() -> PathBuf {
+    crate::model::models_dir().join("sherpa")
+}
+
+/// Returns the directory containing all files for a given sherpa model
+/// (`~/.local/share/sdr-rs/models/sherpa/<dir_name>/`).
+pub fn model_directory(model: SherpaModel) -> PathBuf {
+    sherpa_models_dir().join(model.dir_name())
+}
+
+/// Returns the full paths for all files needed by a sherpa model.
+///
+/// Order: (encoder, decoder, joiner, tokens). The caller checks each path
+/// for existence and emits a helpful error if any are missing.
+pub fn model_file_paths(model: SherpaModel) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let dir = model_directory(model);
+    (
+        dir.join(model.encoder_filename()),
+        dir.join(model.decoder_filename()),
+        dir.join(model.joiner_filename()),
+        dir.join(model.tokens_filename()),
+    )
+}
+
+/// True if all four required files for `model` exist on disk.
+pub fn model_exists(model: SherpaModel) -> bool {
+    let (e, d, j, t) = model_file_paths(model);
+    e.is_file() && d.is_file() && j.is_file() && t.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_models_have_unique_directory_names() {
+        let names: Vec<_> = SherpaModel::ALL.iter().map(|m| m.dir_name()).collect();
+        let unique: std::collections::HashSet<_> = names.iter().collect();
+        assert_eq!(names.len(), unique.len());
+    }
+
+    #[test]
+    fn streaming_zipformer_en_dir_is_under_sherpa() {
+        let dir = model_directory(SherpaModel::StreamingZipformerEn);
+        assert!(dir.ends_with("sherpa/streaming-zipformer-en"));
+    }
+
+    #[test]
+    fn model_file_paths_returns_four_distinct_files() {
+        let (e, d, j, t) = model_file_paths(SherpaModel::StreamingZipformerEn);
+        assert_ne!(e, d);
+        assert_ne!(e, j);
+        assert_ne!(e, t);
+        assert_ne!(d, j);
+        assert_ne!(d, t);
+        assert_ne!(j, t);
+    }
+}

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -10,6 +10,17 @@
 
 use std::path::PathBuf;
 
+/// Returns the base directory for storing models (`~/.local/share/sdr-rs/models/`).
+///
+/// Duplicated from `model::models_dir` so that `sherpa_model` has no
+/// dependency on the `whisper`-gated `model` module.
+fn models_dir() -> PathBuf {
+    dirs_next::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("sdr-rs")
+        .join("models")
+}
+
 /// Available sherpa-onnx model variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SherpaModel {
@@ -68,7 +79,7 @@ impl SherpaModel {
 /// Returns the sherpa subdirectory under the shared models dir
 /// (`~/.local/share/sdr-rs/models/sherpa/`).
 pub fn sherpa_models_dir() -> PathBuf {
-    crate::model::models_dir().join("sherpa")
+    models_dir().join("sherpa")
 }
 
 /// Returns the directory containing all files for a given sherpa model

--- a/crates/sdr-transcription/src/util.rs
+++ b/crates/sdr-transcription/src/util.rs
@@ -1,0 +1,60 @@
+//! Shared utilities for transcription backends.
+//!
+//! Centralizes the unsafe libc calls for wall-clock time formatting so
+//! both backends share one reviewed implementation instead of each
+//! adding its own `#[allow(unsafe_code)]` block.
+
+/// Return the current wall-clock time formatted as "HH:MM:SS" in local time.
+///
+/// Uses `libc::localtime_r` for timezone-aware formatting without pulling in
+/// the `chrono` crate. Both `WhisperBackend` and `SherpaBackend` call this
+/// to timestamp committed transcription events.
+#[allow(unsafe_code)]
+pub fn wall_clock_timestamp() -> String {
+    let mut tv = libc::timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+
+    // SAFETY: gettimeofday writes into the provided buffer and is thread-safe.
+    // We pass null for the timezone (deprecated parameter).
+    #[allow(unsafe_code)]
+    let epoch = unsafe {
+        libc::gettimeofday(&raw mut tv, std::ptr::null_mut());
+        tv.tv_sec
+    };
+
+    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
+
+    // SAFETY: localtime_r is the reentrant (thread-safe) variant.
+    // We provide a valid `time_t` and a valid output buffer.
+    // Returns null on failure, in which case we fall back to UTC via gmtime_r.
+    #[allow(unsafe_code)]
+    let tm = unsafe {
+        let result = libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
+        let result = if result.is_null() {
+            libc::gmtime_r(&raw const epoch, tm.as_mut_ptr())
+        } else {
+            result
+        };
+        if result.is_null() {
+            return "00:00:00".to_owned();
+        }
+        tm.assume_init()
+    };
+
+    format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_format_is_hhmmss() {
+        let ts = wall_clock_timestamp();
+        // Expect "HH:MM:SS" — 8 chars, two colons.
+        assert_eq!(ts.len(), 8);
+        assert_eq!(ts.chars().filter(|&c| c == ':').count(), 2);
+    }
+}

--- a/crates/sdr-transcription/src/util.rs
+++ b/crates/sdr-transcription/src/util.rs
@@ -9,6 +9,16 @@
 /// Uses `libc::localtime_r` for timezone-aware formatting without pulling in
 /// the `chrono` crate. Both `WhisperBackend` and `SherpaBackend` call this
 /// to timestamp committed transcription events.
+///
+/// # Safety
+///
+/// This function contains the only `unsafe` blocks in `sdr-transcription`.
+/// The intentional exception to the workspace `unsafe_code = "deny"` lint
+/// is tracked in <https://github.com/jasonherald/rtl-sdr/issues/250> — the
+/// rationale is that pulling in `chrono` or `time` for one `strftime` call
+/// is overkill for a 200 KB-plus dep tree, and the libc shim has detailed
+/// SAFETY comments on each unsafe block. Re-evaluate if we ever add chrono
+/// transitively for another reason.
 #[allow(unsafe_code)]
 pub fn wall_clock_timestamp() -> String {
     let mut tv = libc::timeval {

--- a/crates/sdr-transcription/tests/sherpa_uninitialized.rs
+++ b/crates/sdr-transcription/tests/sherpa_uninitialized.rs
@@ -1,0 +1,38 @@
+//! Integration test verifying that `SherpaBackend::start` returns a clear
+//! `BackendError::Init` when `init_sherpa_host` was never called.
+//!
+//! This MUST be an integration test (separate test binary, separate process)
+//! because it depends on the process-wide `OnceLock<SHERPA_HOST>` being empty.
+//! Unit tests share a process and can't reliably guarantee that.
+
+#![cfg(feature = "sherpa")]
+
+use sdr_transcription::backends::sherpa::SherpaBackend;
+use sdr_transcription::{
+    BackendConfig, BackendError, ModelChoice, SherpaModel, TranscriptionBackend,
+};
+
+#[test]
+#[allow(clippy::panic)]
+fn sherpa_backend_start_returns_init_error_when_host_not_initialized() {
+    // The integration test process never calls init_sherpa_host, so the
+    // global SHERPA_HOST OnceLock is empty and start() must return
+    // BackendError::Init with a clear "not initialized" message.
+    let mut backend = SherpaBackend::new();
+    let config = BackendConfig {
+        model: ModelChoice::Sherpa(SherpaModel::StreamingZipformerEn),
+        silence_threshold: 0.007,
+        noise_gate_ratio: 3.0,
+    };
+    let result = backend.start(config);
+    match result {
+        Err(BackendError::Init(msg)) => {
+            assert!(
+                msg.contains("not initialized") || msg.contains("failed to initialize"),
+                "expected init error mentioning initialization, got: {msg}"
+            );
+        }
+        Err(e) => panic!("expected Init error, got: {e:?}"),
+        Ok(_) => panic!("expected Init error because init_sherpa_host was never called, got Ok"),
+    }
+}

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -13,12 +13,15 @@ pipewire = ["sdr-sink-audio/pipewire"]
 whisper = ["sdr-transcription/whisper"]
 sherpa = ["sdr-transcription/sherpa"]
 
-cuda = ["whisper", "sdr-transcription/cuda"]
-hipblas = ["whisper", "sdr-transcription/hipblas"]
-vulkan = ["whisper", "sdr-transcription/vulkan"]
-metal = ["whisper", "sdr-transcription/metal"]
-intel-sycl = ["whisper", "sdr-transcription/intel-sycl"]
-openblas = ["whisper", "sdr-transcription/openblas"]
+whisper-cpu = ["whisper", "sdr-transcription/whisper-cpu"]
+whisper-cuda = ["whisper", "sdr-transcription/whisper-cuda"]
+whisper-hipblas = ["whisper", "sdr-transcription/whisper-hipblas"]
+whisper-vulkan = ["whisper", "sdr-transcription/whisper-vulkan"]
+whisper-metal = ["whisper", "sdr-transcription/whisper-metal"]
+whisper-intel-sycl = ["whisper", "sdr-transcription/whisper-intel-sycl"]
+whisper-openblas = ["whisper", "sdr-transcription/whisper-openblas"]
+
+sherpa-cpu = ["sherpa", "sdr-transcription/sherpa-cpu"]
 
 [dependencies]
 sdr-types.workspace = true

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -9,12 +9,16 @@ repository.workspace = true
 [features]
 default = []
 pipewire = ["sdr-sink-audio/pipewire"]
-cuda = ["sdr-transcription/cuda"]
-hipblas = ["sdr-transcription/hipblas"]
-vulkan = ["sdr-transcription/vulkan"]
-metal = ["sdr-transcription/metal"]
-intel-sycl = ["sdr-transcription/intel-sycl"]
-openblas = ["sdr-transcription/openblas"]
+
+whisper = ["sdr-transcription/whisper"]
+sherpa = ["sdr-transcription/sherpa"]
+
+cuda = ["whisper", "sdr-transcription/cuda"]
+hipblas = ["whisper", "sdr-transcription/hipblas"]
+vulkan = ["whisper", "sdr-transcription/vulkan"]
+metal = ["whisper", "sdr-transcription/metal"]
+intel-sycl = ["whisper", "sdr-transcription/intel-sycl"]
+openblas = ["whisper", "sdr-transcription/openblas"]
 
 [dependencies]
 sdr-types.workspace = true

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -10,7 +10,9 @@ use sdr_config::ConfigManager;
 #[cfg(feature = "whisper")]
 /// Config key for the persisted Whisper model index.
 const KEY_MODEL: &str = "transcription_model";
+#[cfg(feature = "whisper")]
 /// Config key for the silence threshold after spectral denoising.
+/// Whisper-only — Sherpa uses native endpoint detection.
 const KEY_SILENCE_THRESHOLD: &str = "transcription_silence_threshold";
 /// Config key for the spectral noise gate ratio.
 const KEY_NOISE_GATE: &str = "transcription_noise_gate";
@@ -18,11 +20,17 @@ const KEY_NOISE_GATE: &str = "transcription_noise_gate";
 /// Config key for the persisted Sherpa model index.
 const KEY_SHERPA_MODEL: &str = "transcription_sherpa_model";
 
-// Silence threshold slider defaults and range.
+// Silence threshold slider defaults and range. Whisper-only — Sherpa
+// uses native endpoint detection so the slider isn't shown.
+#[cfg(feature = "whisper")]
 const DEFAULT_SILENCE_THRESHOLD: f64 = 0.007;
+#[cfg(feature = "whisper")]
 const SILENCE_THRESHOLD_MIN: f64 = 0.001;
+#[cfg(feature = "whisper")]
 const SILENCE_THRESHOLD_MAX: f64 = 0.100;
+#[cfg(feature = "whisper")]
 const SILENCE_THRESHOLD_STEP: f64 = 0.001;
+#[cfg(feature = "whisper")]
 const SILENCE_THRESHOLD_PAGE: f64 = 0.01;
 
 // Noise gate slider defaults and range.
@@ -42,7 +50,9 @@ pub struct TranscriptPanel {
     /// Model size selector — shows Whisper or Sherpa models based on
     /// which cargo feature was compiled in.
     pub model_row: adw::ComboRow,
-    /// Silence threshold spin row.
+    /// Silence threshold spin row. Whisper-only — Sherpa hides this
+    /// because it uses native endpoint detection.
+    #[cfg(feature = "whisper")]
     pub silence_row: adw::SpinRow,
     /// Noise gate spin row.
     pub noise_gate_row: adw::SpinRow,
@@ -136,35 +146,42 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
 
     // --- Tuning sliders ---
 
-    let saved_silence = config.read(|v| {
-        v.get(KEY_SILENCE_THRESHOLD)
-            .and_then(serde_json::Value::as_f64)
-            .map_or(DEFAULT_SILENCE_THRESHOLD, |val| {
-                val.clamp(SILENCE_THRESHOLD_MIN, SILENCE_THRESHOLD_MAX)
-            })
-    });
-
-    let silence_row = adw::SpinRow::builder()
-        .title("Silence threshold")
-        .adjustment(&gtk4::Adjustment::new(
-            saved_silence,
-            SILENCE_THRESHOLD_MIN,
-            SILENCE_THRESHOLD_MAX,
-            SILENCE_THRESHOLD_STEP,
-            SILENCE_THRESHOLD_PAGE,
-            0.0,
-        ))
-        .digits(3)
-        .build();
-    group.add(&silence_row);
-
-    let config_silence = Arc::clone(config);
-    silence_row.connect_value_notify(move |row| {
-        let val = row.value();
-        config_silence.write(|v| {
-            v[KEY_SILENCE_THRESHOLD] = serde_json::json!(val);
+    // Silence threshold slider — Whisper-only because Sherpa has
+    // native endpoint detection (see SherpaBackend::build_recognizer_config).
+    #[cfg(feature = "whisper")]
+    let silence_row = {
+        let saved_silence = config.read(|v| {
+            v.get(KEY_SILENCE_THRESHOLD)
+                .and_then(serde_json::Value::as_f64)
+                .map_or(DEFAULT_SILENCE_THRESHOLD, |val| {
+                    val.clamp(SILENCE_THRESHOLD_MIN, SILENCE_THRESHOLD_MAX)
+                })
         });
-    });
+
+        let row = adw::SpinRow::builder()
+            .title("Silence threshold")
+            .adjustment(&gtk4::Adjustment::new(
+                saved_silence,
+                SILENCE_THRESHOLD_MIN,
+                SILENCE_THRESHOLD_MAX,
+                SILENCE_THRESHOLD_STEP,
+                SILENCE_THRESHOLD_PAGE,
+                0.0,
+            ))
+            .digits(3)
+            .build();
+        group.add(&row);
+
+        let config_silence = Arc::clone(config);
+        row.connect_value_notify(move |r| {
+            let val = r.value();
+            config_silence.write(|v| {
+                v[KEY_SILENCE_THRESHOLD] = serde_json::json!(val);
+            });
+        });
+
+        row
+    };
 
     let saved_noise_gate = config.read(|v| {
         v.get(KEY_NOISE_GATE)
@@ -257,6 +274,7 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         widget: group,
         enable_row,
         model_row,
+        #[cfg(feature = "whisper")]
         silence_row,
         noise_gate_row,
         status_label,

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -7,21 +7,16 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 use sdr_config::ConfigManager;
 
+#[cfg(feature = "whisper")]
 /// Config key for the persisted Whisper model index.
 const KEY_MODEL: &str = "transcription_model";
 /// Config key for the silence threshold after spectral denoising.
 const KEY_SILENCE_THRESHOLD: &str = "transcription_silence_threshold";
 /// Config key for the spectral noise gate ratio.
 const KEY_NOISE_GATE: &str = "transcription_noise_gate";
-/// Config key for the persisted backend selection ("whisper" or "sherpa").
-const KEY_BACKEND: &str = "transcription_backend";
+#[cfg(feature = "sherpa")]
 /// Config key for the persisted Sherpa model index.
 const KEY_SHERPA_MODEL: &str = "transcription_sherpa_model";
-
-/// Backend index for Whisper in the backend selector `ComboRow`.
-const BACKEND_IDX_WHISPER: u32 = 0;
-/// Backend index for Sherpa in the backend selector `ComboRow`.
-const BACKEND_IDX_SHERPA: u32 = 1;
 
 // Silence threshold slider defaults and range.
 const DEFAULT_SILENCE_THRESHOLD: f64 = 0.007;
@@ -44,9 +39,8 @@ pub struct TranscriptPanel {
     pub widget: adw::PreferencesGroup,
     /// Toggle to enable/disable live transcription.
     pub enable_row: adw::SwitchRow,
-    /// Backend selector (Whisper / Sherpa).
-    pub backend_row: adw::ComboRow,
-    /// Model size selector — contents change based on backend selection.
+    /// Model size selector — shows Whisper or Sherpa models based on
+    /// which cargo feature was compiled in.
     pub model_row: adw::ComboRow,
     /// Silence threshold spin row.
     pub silence_row: adw::SpinRow,
@@ -77,138 +71,67 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         .build();
     group.add(&enable_row);
 
-    // --- Backend selector ---
-    let backend_labels = ["Whisper", "Sherpa (streaming)"];
-    let backend_list = gtk4::StringList::new(&backend_labels);
-
-    let saved_backend_idx = config.read(|v| {
-        v.get(KEY_BACKEND)
-            .and_then(serde_json::Value::as_str)
-            .map_or(BACKEND_IDX_WHISPER, |s| match s {
-                "sherpa" => BACKEND_IDX_SHERPA,
-                _ => BACKEND_IDX_WHISPER,
-            })
-    });
-
-    let backend_row = adw::ComboRow::builder()
-        .title("Backend")
-        .model(&backend_list)
-        .selected(saved_backend_idx)
-        .build();
-    group.add(&backend_row);
-
     // --- Model selector ---
     //
-    // Contents are populated based on the active backend. We rebuild the
-    // string list each time the backend changes; the selected index
-    // resets to whichever value was last persisted for that backend.
-    let whisper_model_labels: Vec<&'static str> = sdr_transcription::WhisperModel::ALL
-        .iter()
-        .map(|m| m.label())
-        .collect();
-    let sherpa_model_labels: Vec<&'static str> = sdr_transcription::SherpaModel::ALL
-        .iter()
-        .map(|m| m.label())
-        .collect();
+    // Whisper and Sherpa are mutually exclusive cargo features (see
+    // sdr-transcription/src/lib.rs compile_error guards). The model picker
+    // shows whichever backend was compiled in. The user picks the build
+    // they want at install time:
+    //
+    //   make install CARGO_FLAGS="--release --features cuda"     # Whisper + CUDA
+    //   make install CARGO_FLAGS="--release --no-default-features --features sherpa"  # Sherpa CPU
+    #[cfg(feature = "whisper")]
+    let (model_labels, max_model_idx, key_for_persistence): (Vec<&'static str>, u32, &str) = {
+        let labels: Vec<&'static str> = sdr_transcription::WhisperModel::ALL
+            .iter()
+            .map(|m| m.label())
+            .collect();
+        #[allow(clippy::cast_possible_truncation)]
+        let max = sdr_transcription::WhisperModel::ALL.len() as u32;
+        (labels, max, KEY_MODEL)
+    };
+    #[cfg(feature = "sherpa")]
+    let (model_labels, max_model_idx, key_for_persistence): (Vec<&'static str>, u32, &str) = {
+        let labels: Vec<&'static str> = sdr_transcription::SherpaModel::ALL
+            .iter()
+            .map(|m| m.label())
+            .collect();
+        #[allow(clippy::cast_possible_truncation)]
+        let max = sdr_transcription::SherpaModel::ALL.len() as u32;
+        (labels, max, KEY_SHERPA_MODEL)
+    };
 
-    #[allow(clippy::cast_possible_truncation)]
-    let max_whisper_idx = sdr_transcription::WhisperModel::ALL.len() as u32;
-    #[allow(clippy::cast_possible_truncation)]
-    let max_sherpa_idx = sdr_transcription::SherpaModel::ALL.len() as u32;
+    let model_list = gtk4::StringList::new(&model_labels);
 
-    let saved_whisper_model_idx = config.read(|v| {
-        v.get(KEY_MODEL)
+    let saved_model_idx = config.read(|v| {
+        v.get(key_for_persistence)
             .and_then(serde_json::Value::as_u64)
             .and_then(|idx| u32::try_from(idx).ok())
-            .filter(|&idx| idx < max_whisper_idx)
-            .unwrap_or(0)
-    });
-    let saved_sherpa_model_idx = config.read(|v| {
-        v.get(KEY_SHERPA_MODEL)
-            .and_then(serde_json::Value::as_u64)
-            .and_then(|idx| u32::try_from(idx).ok())
-            .filter(|&idx| idx < max_sherpa_idx)
+            .filter(|&idx| idx < max_model_idx)
             .unwrap_or(0)
     });
 
-    let initial_model_list = if saved_backend_idx == BACKEND_IDX_SHERPA {
-        gtk4::StringList::new(&sherpa_model_labels)
-    } else {
-        gtk4::StringList::new(&whisper_model_labels)
-    };
-    let initial_model_idx = if saved_backend_idx == BACKEND_IDX_SHERPA {
-        saved_sherpa_model_idx
-    } else {
-        saved_whisper_model_idx
-    };
+    #[cfg(feature = "whisper")]
+    let model_title = "Whisper Model";
+    #[cfg(feature = "sherpa")]
+    let model_title = "Sherpa Model";
 
     let model_row = adw::ComboRow::builder()
-        .title("Model")
-        .model(&initial_model_list)
-        .selected(initial_model_idx)
+        .title(model_title)
+        .model(&model_list)
+        .selected(saved_model_idx)
         .build();
     group.add(&model_row);
 
-    // --- Backend change handler ---
-    //
-    // Rebuilds the model picker contents and persists the new backend.
-    let config_backend = Arc::clone(config);
-    let model_row_for_backend_change = model_row.clone();
-    let whisper_labels_for_backend = whisper_model_labels.clone();
-    let sherpa_labels_for_backend = sherpa_model_labels.clone();
-    backend_row.connect_selected_notify(move |row| {
-        let idx = row.selected();
-        let (backend_str, new_list, new_idx) = if idx == BACKEND_IDX_SHERPA {
-            (
-                "sherpa",
-                gtk4::StringList::new(&sherpa_labels_for_backend),
-                config_backend.read(|v| {
-                    v.get(KEY_SHERPA_MODEL)
-                        .and_then(serde_json::Value::as_u64)
-                        .and_then(|i| u32::try_from(i).ok())
-                        .filter(|&i| i < max_sherpa_idx)
-                        .unwrap_or(0)
-                }),
-            )
-        } else {
-            (
-                "whisper",
-                gtk4::StringList::new(&whisper_labels_for_backend),
-                config_backend.read(|v| {
-                    v.get(KEY_MODEL)
-                        .and_then(serde_json::Value::as_u64)
-                        .and_then(|i| u32::try_from(i).ok())
-                        .filter(|&i| i < max_whisper_idx)
-                        .unwrap_or(0)
-                }),
-            )
-        };
-
-        model_row_for_backend_change.set_model(Some(&new_list));
-        model_row_for_backend_change.set_selected(new_idx);
-
-        config_backend.write(|v| {
-            v[KEY_BACKEND] = serde_json::json!(backend_str);
-        });
-    });
-
-    // --- Model change handler ---
-    //
-    // Persists to KEY_MODEL or KEY_SHERPA_MODEL depending on which
-    // backend is currently selected.
+    // Persist model selection on change.
     let config_model = Arc::clone(config);
-    let backend_row_for_model_change = backend_row.clone();
     model_row.connect_selected_notify(move |row| {
         let idx = row.selected();
-        let backend_idx = backend_row_for_model_change.selected();
-        let key = if backend_idx == BACKEND_IDX_SHERPA {
-            KEY_SHERPA_MODEL
-        } else {
-            KEY_MODEL
-        };
-        config_model.write(|v| {
-            v[key] = serde_json::json!(idx);
-        });
+        if idx < max_model_idx {
+            config_model.write(|v| {
+                v[key_for_persistence] = serde_json::json!(idx);
+            });
+        }
     });
 
     // --- Tuning sliders ---
@@ -333,7 +256,6 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     TranscriptPanel {
         widget: group,
         enable_row,
-        backend_row,
         model_row,
         silence_row,
         noise_gate_row,

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -78,8 +78,8 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     // shows whichever backend was compiled in. The user picks the build
     // they want at install time:
     //
-    //   make install CARGO_FLAGS="--release --features cuda"     # Whisper + CUDA
-    //   make install CARGO_FLAGS="--release --no-default-features --features sherpa"  # Sherpa CPU
+    //   make install CARGO_FLAGS="--release --features whisper-cuda"     # Whisper + CUDA
+    //   make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"  # Sherpa CPU
     #[cfg(feature = "whisper")]
     let (model_labels, max_model_idx, key_for_persistence): (Vec<&'static str>, u32, &str) = {
         let labels: Vec<&'static str> = sdr_transcription::WhisperModel::ALL

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -13,6 +13,15 @@ const KEY_MODEL: &str = "transcription_model";
 const KEY_SILENCE_THRESHOLD: &str = "transcription_silence_threshold";
 /// Config key for the spectral noise gate ratio.
 const KEY_NOISE_GATE: &str = "transcription_noise_gate";
+/// Config key for the persisted backend selection ("whisper" or "sherpa").
+const KEY_BACKEND: &str = "transcription_backend";
+/// Config key for the persisted Sherpa model index.
+const KEY_SHERPA_MODEL: &str = "transcription_sherpa_model";
+
+/// Backend index for Whisper in the backend selector `ComboRow`.
+const BACKEND_IDX_WHISPER: u32 = 0;
+/// Backend index for Sherpa in the backend selector `ComboRow`.
+const BACKEND_IDX_SHERPA: u32 = 1;
 
 // Silence threshold slider defaults and range.
 const DEFAULT_SILENCE_THRESHOLD: f64 = 0.007;
@@ -35,7 +44,9 @@ pub struct TranscriptPanel {
     pub widget: adw::PreferencesGroup,
     /// Toggle to enable/disable live transcription.
     pub enable_row: adw::SwitchRow,
-    /// Model size selector.
+    /// Backend selector (Whisper / Sherpa).
+    pub backend_row: adw::ComboRow,
+    /// Model size selector — contents change based on backend selection.
     pub model_row: adw::ComboRow,
     /// Silence threshold spin row.
     pub silence_row: adw::SpinRow,
@@ -66,41 +77,138 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         .build();
     group.add(&enable_row);
 
-    // Model selector
-    let model_labels: Vec<&str> = sdr_transcription::WhisperModel::ALL
+    // --- Backend selector ---
+    let backend_labels = ["Whisper", "Sherpa (streaming)"];
+    let backend_list = gtk4::StringList::new(&backend_labels);
+
+    let saved_backend_idx = config.read(|v| {
+        v.get(KEY_BACKEND)
+            .and_then(serde_json::Value::as_str)
+            .map_or(BACKEND_IDX_WHISPER, |s| match s {
+                "sherpa" => BACKEND_IDX_SHERPA,
+                _ => BACKEND_IDX_WHISPER,
+            })
+    });
+
+    let backend_row = adw::ComboRow::builder()
+        .title("Backend")
+        .model(&backend_list)
+        .selected(saved_backend_idx)
+        .build();
+    group.add(&backend_row);
+
+    // --- Model selector ---
+    //
+    // Contents are populated based on the active backend. We rebuild the
+    // string list each time the backend changes; the selected index
+    // resets to whichever value was last persisted for that backend.
+    let whisper_model_labels: Vec<&'static str> = sdr_transcription::WhisperModel::ALL
         .iter()
         .map(|m| m.label())
         .collect();
-    let model_list = gtk4::StringList::new(&model_labels);
+    let sherpa_model_labels: Vec<&'static str> = sdr_transcription::SherpaModel::ALL
+        .iter()
+        .map(|m| m.label())
+        .collect();
 
     #[allow(clippy::cast_possible_truncation)]
-    let max_model_idx = sdr_transcription::WhisperModel::ALL.len() as u32;
-
+    let max_whisper_idx = sdr_transcription::WhisperModel::ALL.len() as u32;
     #[allow(clippy::cast_possible_truncation)]
-    let saved_model_idx = config.read(|v| {
+    let max_sherpa_idx = sdr_transcription::SherpaModel::ALL.len() as u32;
+
+    let saved_whisper_model_idx = config.read(|v| {
         v.get(KEY_MODEL)
             .and_then(serde_json::Value::as_u64)
             .and_then(|idx| u32::try_from(idx).ok())
-            .filter(|&idx| idx < max_model_idx)
+            .filter(|&idx| idx < max_whisper_idx)
+            .unwrap_or(0)
+    });
+    let saved_sherpa_model_idx = config.read(|v| {
+        v.get(KEY_SHERPA_MODEL)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|idx| u32::try_from(idx).ok())
+            .filter(|&idx| idx < max_sherpa_idx)
             .unwrap_or(0)
     });
 
+    let initial_model_list = if saved_backend_idx == BACKEND_IDX_SHERPA {
+        gtk4::StringList::new(&sherpa_model_labels)
+    } else {
+        gtk4::StringList::new(&whisper_model_labels)
+    };
+    let initial_model_idx = if saved_backend_idx == BACKEND_IDX_SHERPA {
+        saved_sherpa_model_idx
+    } else {
+        saved_whisper_model_idx
+    };
+
     let model_row = adw::ComboRow::builder()
         .title("Model")
-        .model(&model_list)
-        .selected(saved_model_idx)
+        .model(&initial_model_list)
+        .selected(initial_model_idx)
         .build();
     group.add(&model_row);
 
-    // Persist model selection on change (ignore transient out-of-range indices).
+    // --- Backend change handler ---
+    //
+    // Rebuilds the model picker contents and persists the new backend.
+    let config_backend = Arc::clone(config);
+    let model_row_for_backend_change = model_row.clone();
+    let whisper_labels_for_backend = whisper_model_labels.clone();
+    let sherpa_labels_for_backend = sherpa_model_labels.clone();
+    backend_row.connect_selected_notify(move |row| {
+        let idx = row.selected();
+        let (backend_str, new_list, new_idx) = if idx == BACKEND_IDX_SHERPA {
+            (
+                "sherpa",
+                gtk4::StringList::new(&sherpa_labels_for_backend),
+                config_backend.read(|v| {
+                    v.get(KEY_SHERPA_MODEL)
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|i| u32::try_from(i).ok())
+                        .filter(|&i| i < max_sherpa_idx)
+                        .unwrap_or(0)
+                }),
+            )
+        } else {
+            (
+                "whisper",
+                gtk4::StringList::new(&whisper_labels_for_backend),
+                config_backend.read(|v| {
+                    v.get(KEY_MODEL)
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|i| u32::try_from(i).ok())
+                        .filter(|&i| i < max_whisper_idx)
+                        .unwrap_or(0)
+                }),
+            )
+        };
+
+        model_row_for_backend_change.set_model(Some(&new_list));
+        model_row_for_backend_change.set_selected(new_idx);
+
+        config_backend.write(|v| {
+            v[KEY_BACKEND] = serde_json::json!(backend_str);
+        });
+    });
+
+    // --- Model change handler ---
+    //
+    // Persists to KEY_MODEL or KEY_SHERPA_MODEL depending on which
+    // backend is currently selected.
     let config_model = Arc::clone(config);
+    let backend_row_for_model_change = backend_row.clone();
     model_row.connect_selected_notify(move |row| {
         let idx = row.selected();
-        if idx < max_model_idx {
-            config_model.write(|v| {
-                v[KEY_MODEL] = serde_json::json!(idx);
-            });
-        }
+        let backend_idx = backend_row_for_model_change.selected();
+        let key = if backend_idx == BACKEND_IDX_SHERPA {
+            KEY_SHERPA_MODEL
+        } else {
+            KEY_MODEL
+        };
+        config_model.write(|v| {
+            v[key] = serde_json::json!(idx);
+        });
     });
 
     // --- Tuning sliders ---
@@ -225,6 +333,7 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     TranscriptPanel {
         widget: group,
         enable_row,
+        backend_row,
         model_row,
         silence_row,
         noise_gate_row,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1494,6 +1494,11 @@ fn connect_transcript_panel(
                                         status.set_css_classes(&["success"]);
                                         progress.set_visible(false);
                                     }
+                                    TranscriptionEvent::Partial { text } => {
+                                        // PR 4 will render this as a live caption line.
+                                        // For the PR 2 spike, log only.
+                                        tracing::debug!(target: "transcription", partial = %text);
+                                    }
                                     TranscriptionEvent::Text { timestamp, text } => {
                                         let buf = tv.buffer();
                                         let mut end = buf.end_iter();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1419,6 +1419,7 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
 /// Connect transcript panel controls to DSP commands.
 ///
 /// Returns the engine handle so it can be stopped on window close.
+#[allow(clippy::too_many_lines)]
 fn connect_transcript_panel(
     transcript: &sidebar::transcript_panel::TranscriptPanel,
     state: &Rc<AppState>,
@@ -1433,6 +1434,7 @@ fn connect_transcript_panel(
     let status_label = transcript.status_label.clone();
     let progress_bar = transcript.progress_bar.clone();
     let text_view = transcript.text_view.clone();
+    let backend_row = transcript.backend_row.clone();
     let model_row = transcript.model_row.clone();
     let silence_row = transcript.silence_row.clone();
     let noise_gate_row = transcript.noise_gate_row.clone();
@@ -1440,16 +1442,14 @@ fn connect_transcript_panel(
     transcript.enable_row.connect_active_notify(move |row| {
         if row.is_active() {
             // Read selected model from dropdown.
-            // Lock model and tuning controls while transcription is active.
+            // Lock model, backend, and tuning controls while transcription is active.
+            backend_row.set_sensitive(false);
             model_row.set_sensitive(false);
             silence_row.set_sensitive(false);
             noise_gate_row.set_sensitive(false);
 
             let model_idx = model_row.selected() as usize;
-            let whisper_model = sdr_transcription::WhisperModel::ALL
-                .get(model_idx)
-                .copied()
-                .unwrap_or(sdr_transcription::WhisperModel::TinyEn);
+            let backend_idx = backend_row.selected();
 
             // Read tuning slider values.
             #[allow(clippy::cast_possible_truncation)]
@@ -1457,11 +1457,24 @@ fn connect_transcript_panel(
             #[allow(clippy::cast_possible_truncation)]
             let noise_gate_ratio = noise_gate_row.value() as f32;
 
-            // Build BackendConfig. For Task 6 we hardcode Whisper —
-            // Task 8 wires the backend selector ComboRow that provides
-            // ModelChoice::Sherpa(...) when the user picks it.
+            // Build BackendConfig from the panel state. Backend index
+            // 1 = Sherpa; everything else = Whisper.
+            let model = if backend_idx == 1 {
+                let sherpa_model = sdr_transcription::SherpaModel::ALL
+                    .get(model_idx)
+                    .copied()
+                    .unwrap_or(sdr_transcription::SherpaModel::StreamingZipformerEn);
+                sdr_transcription::ModelChoice::Sherpa(sherpa_model)
+            } else {
+                let whisper_model = sdr_transcription::WhisperModel::ALL
+                    .get(model_idx)
+                    .copied()
+                    .unwrap_or(sdr_transcription::WhisperModel::TinyEn);
+                sdr_transcription::ModelChoice::Whisper(whisper_model)
+            };
+
             let config = sdr_transcription::BackendConfig {
-                model: sdr_transcription::ModelChoice::Whisper(whisper_model),
+                model,
                 silence_threshold,
                 noise_gate_ratio,
             };
@@ -1529,6 +1542,7 @@ fn connect_transcript_panel(
                 }
                 Err(e) => {
                     tracing::warn!("failed to start transcription: {e}");
+                    backend_row.set_sensitive(true);
                     model_row.set_sensitive(true);
                     silence_row.set_sensitive(true);
                     noise_gate_row.set_sensitive(true);
@@ -1536,6 +1550,7 @@ fn connect_transcript_panel(
                 }
             }
         } else {
+            backend_row.set_sensitive(true);
             model_row.set_sensitive(true);
             silence_row.set_sensitive(true);
             noise_gate_row.set_sensitive(true);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1553,7 +1553,15 @@ fn connect_transcript_panel(
                     #[cfg(feature = "whisper")]
                     silence_row.set_sensitive(true);
                     noise_gate_row.set_sensitive(true);
+                    // Reset the toggle FIRST (the else branch clears
+                    // status_label as part of its normal teardown), then
+                    // set the error text so the user actually sees it.
+                    // Otherwise the failure is silent — only in stderr.
                     row.set_active(false);
+                    status_label.set_text(&e.to_string());
+                    status_label.set_css_classes(&["error"]);
+                    status_label.set_visible(true);
+                    progress_bar.set_visible(false);
                 }
             }
         } else {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1435,6 +1435,7 @@ fn connect_transcript_panel(
     let progress_bar = transcript.progress_bar.clone();
     let text_view = transcript.text_view.clone();
     let model_row = transcript.model_row.clone();
+    #[cfg(feature = "whisper")]
     let silence_row = transcript.silence_row.clone();
     let noise_gate_row = transcript.noise_gate_row.clone();
 
@@ -1443,14 +1444,20 @@ fn connect_transcript_panel(
             // Read selected model from dropdown.
             // Lock model and tuning controls while transcription is active.
             model_row.set_sensitive(false);
+            #[cfg(feature = "whisper")]
             silence_row.set_sensitive(false);
             noise_gate_row.set_sensitive(false);
 
             let model_idx = model_row.selected() as usize;
 
             // Read tuning slider values.
+            #[cfg(feature = "whisper")]
             #[allow(clippy::cast_possible_truncation)]
             let silence_threshold = silence_row.value() as f32;
+            // Sherpa builds: silence_threshold is unused by SherpaBackend
+            // (see build_recognizer_config doc comment). Pass a sentinel.
+            #[cfg(feature = "sherpa")]
+            let silence_threshold: f32 = 0.0;
             #[allow(clippy::cast_possible_truncation)]
             let noise_gate_ratio = noise_gate_row.value() as f32;
 
@@ -1543,6 +1550,7 @@ fn connect_transcript_panel(
                 Err(e) => {
                     tracing::warn!("failed to start transcription: {e}");
                     model_row.set_sensitive(true);
+                    #[cfg(feature = "whisper")]
                     silence_row.set_sensitive(true);
                     noise_gate_row.set_sensitive(true);
                     row.set_active(false);
@@ -1550,6 +1558,7 @@ fn connect_transcript_panel(
             }
         } else {
             model_row.set_sensitive(true);
+            #[cfg(feature = "whisper")]
             silence_row.set_sensitive(true);
             noise_gate_row.set_sensitive(true);
             state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1438,6 +1438,15 @@ fn connect_transcript_panel(
     #[cfg(feature = "whisper")]
     let silence_row = transcript.silence_row.clone();
     let noise_gate_row = transcript.noise_gate_row.clone();
+    // Weak refs used by the async event-loop closure to drive the same
+    // teardown the synchronous error path does (see below) when the
+    // backend fires TranscriptionEvent::Error mid-session. Weak so the
+    // timeout closure doesn't keep widgets alive past their UI lifetime.
+    let enable_row_weak = transcript.enable_row.downgrade();
+    let model_row_weak = model_row.downgrade();
+    #[cfg(feature = "whisper")]
+    let silence_row_weak = silence_row.downgrade();
+    let noise_gate_row_weak = noise_gate_row.downgrade();
 
     transcript.enable_row.connect_active_notify(move |row| {
         if row.is_active() {
@@ -1502,6 +1511,15 @@ fn connect_transcript_panel(
                     let status = status_label.clone();
                     let progress = progress_bar.clone();
                     let tv = text_view.clone();
+                    // Clone weak refs into the closure so we can drive
+                    // the full teardown on a fatal Error event without
+                    // creating a strong reference cycle through the
+                    // glib timeout source.
+                    let enable_row_weak = enable_row_weak.clone();
+                    let model_row_weak = model_row_weak.clone();
+                    #[cfg(feature = "whisper")]
+                    let silence_row_weak = silence_row_weak.clone();
+                    let noise_gate_row_weak = noise_gate_row_weak.clone();
 
                     glib::timeout_add_local(Duration::from_millis(100), move || {
                         loop {
@@ -1534,8 +1552,28 @@ fn connect_transcript_panel(
                                         buf.delete_mark(&mark);
                                     }
                                     TranscriptionEvent::Error(msg) => {
+                                        // Fatal — backend has exited.
+                                        // Mirror the synchronous start()
+                                        // failure teardown so the UI
+                                        // isn't left locked.
+                                        if let Some(model) = model_row_weak.upgrade() {
+                                            model.set_sensitive(true);
+                                        }
+                                        #[cfg(feature = "whisper")]
+                                        if let Some(silence) = silence_row_weak.upgrade() {
+                                            silence.set_sensitive(true);
+                                        }
+                                        if let Some(noise) = noise_gate_row_weak.upgrade() {
+                                            noise.set_sensitive(true);
+                                        }
+                                        if let Some(enable) = enable_row_weak.upgrade() {
+                                            enable.set_active(false);
+                                        }
                                         status.set_text(&msg);
                                         status.set_css_classes(&["error"]);
+                                        status.set_visible(true);
+                                        progress.set_visible(false);
+                                        return glib::ControlFlow::Break;
                                     }
                                 },
                                 Err(std::sync::mpsc::TryRecvError::Empty) => break,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1457,12 +1457,18 @@ fn connect_transcript_panel(
             #[allow(clippy::cast_possible_truncation)]
             let noise_gate_ratio = noise_gate_row.value() as f32;
 
+            // Build BackendConfig. For Task 6 we hardcode Whisper —
+            // Task 8 wires the backend selector ComboRow that provides
+            // ModelChoice::Sherpa(...) when the user picks it.
+            let config = sdr_transcription::BackendConfig {
+                model: sdr_transcription::ModelChoice::Whisper(whisper_model),
+                silence_threshold,
+                noise_gate_ratio,
+            };
+
             // Scope the borrow so it's dropped before any potential re-entry
             // from row.set_active(false) on error.
-            let start_result =
-                engine_clone
-                    .borrow_mut()
-                    .start(whisper_model, silence_threshold, noise_gate_ratio);
+            let start_result = engine_clone.borrow_mut().start(config);
             match start_result {
                 Ok(event_rx) => {
                     if let Some(audio_tx) = engine_clone.borrow().audio_sender() {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1508,13 +1508,13 @@ fn connect_transcript_panel(
                     status_label.set_text("Starting...");
                     status_label.set_visible(true);
 
-                    let status = status_label.clone();
-                    let progress = progress_bar.clone();
-                    let tv = text_view.clone();
-                    // Clone weak refs into the closure so we can drive
-                    // the full teardown on a fatal Error event without
-                    // creating a strong reference cycle through the
-                    // glib timeout source.
+                    // Weak refs for the entire timeout source — see the
+                    // weak-ref decl block at the top of connect_transcript_panel
+                    // for the rationale (don't keep widgets alive past their
+                    // UI lifetime through the glib timeout source).
+                    let status_weak = status_label.downgrade();
+                    let progress_weak = progress_bar.downgrade();
+                    let tv_weak = text_view.downgrade();
                     let enable_row_weak = enable_row_weak.clone();
                     let model_row_weak = model_row_weak.clone();
                     #[cfg(feature = "whisper")]
@@ -1522,6 +1522,19 @@ fn connect_transcript_panel(
                     let noise_gate_row_weak = noise_gate_row_weak.clone();
 
                     glib::timeout_add_local(Duration::from_millis(100), move || {
+                        // Upgrade once per tick. If any widget has been
+                        // dropped (e.g. window closed), stop the timeout
+                        // immediately so we don't resurrect dead UI.
+                        let Some(status) = status_weak.upgrade() else {
+                            return glib::ControlFlow::Break;
+                        };
+                        let Some(progress) = progress_weak.upgrade() else {
+                            return glib::ControlFlow::Break;
+                        };
+                        let Some(tv) = tv_weak.upgrade() else {
+                            return glib::ControlFlow::Break;
+                        };
+
                         loop {
                             match event_rx.try_recv() {
                                 Ok(event) => match event {
@@ -1539,9 +1552,16 @@ fn connect_transcript_panel(
                                         progress.set_visible(false);
                                     }
                                     TranscriptionEvent::Partial { text } => {
-                                        // PR 4 will render this as a live caption line.
-                                        // For the PR 2 spike, log only.
-                                        tracing::debug!(target: "transcription", partial = %text);
+                                        // PR 4 will render this as a live
+                                        // caption line. For the PR 2 spike,
+                                        // log only the length — never the
+                                        // raw text. Public safety scanner
+                                        // content does not belong in logs.
+                                        tracing::debug!(
+                                            target: "transcription",
+                                            partial_chars = text.chars().count(),
+                                            "sherpa partial received"
+                                        );
                                     }
                                     TranscriptionEvent::Text { timestamp, text } => {
                                         let buf = tv.buffer();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1434,7 +1434,6 @@ fn connect_transcript_panel(
     let status_label = transcript.status_label.clone();
     let progress_bar = transcript.progress_bar.clone();
     let text_view = transcript.text_view.clone();
-    let backend_row = transcript.backend_row.clone();
     let model_row = transcript.model_row.clone();
     let silence_row = transcript.silence_row.clone();
     let noise_gate_row = transcript.noise_gate_row.clone();
@@ -1442,14 +1441,12 @@ fn connect_transcript_panel(
     transcript.enable_row.connect_active_notify(move |row| {
         if row.is_active() {
             // Read selected model from dropdown.
-            // Lock model, backend, and tuning controls while transcription is active.
-            backend_row.set_sensitive(false);
+            // Lock model and tuning controls while transcription is active.
             model_row.set_sensitive(false);
             silence_row.set_sensitive(false);
             noise_gate_row.set_sensitive(false);
 
             let model_idx = model_row.selected() as usize;
-            let backend_idx = backend_row.selected();
 
             // Read tuning slider values.
             #[allow(clippy::cast_possible_truncation)]
@@ -1457,20 +1454,23 @@ fn connect_transcript_panel(
             #[allow(clippy::cast_possible_truncation)]
             let noise_gate_ratio = noise_gate_row.value() as f32;
 
-            // Build BackendConfig from the panel state. Backend index
-            // 1 = Sherpa; everything else = Whisper.
-            let model = if backend_idx == 1 {
-                let sherpa_model = sdr_transcription::SherpaModel::ALL
-                    .get(model_idx)
-                    .copied()
-                    .unwrap_or(sdr_transcription::SherpaModel::StreamingZipformerEn);
-                sdr_transcription::ModelChoice::Sherpa(sherpa_model)
-            } else {
+            // Build BackendConfig — Whisper and Sherpa are mutually exclusive
+            // cargo features, so exactly one variant is compiled in.
+            #[cfg(feature = "whisper")]
+            let model = {
                 let whisper_model = sdr_transcription::WhisperModel::ALL
                     .get(model_idx)
                     .copied()
                     .unwrap_or(sdr_transcription::WhisperModel::TinyEn);
                 sdr_transcription::ModelChoice::Whisper(whisper_model)
+            };
+            #[cfg(feature = "sherpa")]
+            let model = {
+                let sherpa_model = sdr_transcription::SherpaModel::ALL
+                    .get(model_idx)
+                    .copied()
+                    .unwrap_or(sdr_transcription::SherpaModel::StreamingZipformerEn);
+                sdr_transcription::ModelChoice::Sherpa(sherpa_model)
             };
 
             let config = sdr_transcription::BackendConfig {
@@ -1542,7 +1542,6 @@ fn connect_transcript_panel(
                 }
                 Err(e) => {
                     tracing::warn!("failed to start transcription: {e}");
-                    backend_row.set_sensitive(true);
                     model_row.set_sensitive(true);
                     silence_row.set_sensitive(true);
                     noise_gate_row.set_sensitive(true);
@@ -1550,7 +1549,6 @@ fn connect_transcript_panel(
                 }
             }
         } else {
-            backend_row.set_sensitive(true);
             model_row.set_sensitive(true);
             silence_row.set_sensitive(true);
             noise_gate_row.set_sensitive(true);

--- a/docs/superpowers/plans/2026-04-12-transcription-sherpa-spike.md
+++ b/docs/superpowers/plans/2026-04-12-transcription-sherpa-spike.md
@@ -1,0 +1,1945 @@
+# Sherpa-Onnx Spike + Backend Selector UI — PR 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a working `SherpaBackend` powered by the official `sherpa-onnx` Rust crate, prove streaming-native ASR works end-to-end on a real radio source (Streaming Zipformer English, CPU and CUDA), and add a UI backend selector so the user can switch between Whisper and Sherpa from the transcript panel.
+
+**Architecture:** New `backends/sherpa.rs` implements `TranscriptionBackend` using `sherpa_onnx::OnlineRecognizer`. The backend owns its worker thread (same pattern as `WhisperBackend`) and lives entirely on that thread to avoid the recognizer's `!Send` constraint. The `TranscriptionEngine::start` API is widened to take a `BackendConfig` directly so the UI can pick which backend to instantiate. `ModelChoice` gets a `Sherpa(SherpaModel)` variant; `TranscriptionEvent` gets a new `Partial { text }` variant. The transcript panel UI grows a backend selector `AdwComboRow` above the existing model picker, and the model picker becomes contextual to the selected backend. For this PR, partial events are routed to `tracing::debug!` only — full live-captions UI rendering lands in PR 4.
+
+**Tech Stack:** Rust 2024, `sherpa-onnx 1.12`, GTK4/libadwaita ComboRow + StringList, `mpsc` channels, `Arc<AtomicBool>` cancellation, `thiserror`.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-transcription-backend-trait-design.md`
+
+**Branch:** `feature/transcription-sherpa-spike` (already created, no commits yet)
+
+---
+
+## File Structure
+
+**Create:**
+- `crates/sdr-transcription/src/sherpa_model.rs` — `SherpaModel` enum, directory discovery, file path helpers
+- `crates/sdr-transcription/src/backends/sherpa.rs` — `SherpaBackend` struct + `TranscriptionBackend` impl + worker loop
+
+**Modify:**
+- `crates/sdr-transcription/Cargo.toml` — add `sherpa-onnx = "1.12"` dependency
+- `crates/sdr-transcription/src/lib.rs` — re-export `SherpaModel`, change `start(WhisperModel, ...)` to `start(BackendConfig)`, route `ModelChoice` to the right backend
+- `crates/sdr-transcription/src/backend.rs` — add `Sherpa(SherpaModel)` to `ModelChoice`, add `Partial { text }` to `TranscriptionEvent`, add `BackendError::ModelNotFound { path: PathBuf }` and `BackendError::WrongModelKind`
+- `crates/sdr-transcription/src/backends/whisper.rs` — `start()` returns `WrongModelKind` if a non-Whisper `ModelChoice` is passed
+- `crates/sdr-transcription/src/backends/mock.rs` — accept any `ModelChoice` (mock is testing the engine, not the backend dispatch)
+- `crates/sdr-ui/src/sidebar/transcript_panel.rs` — add `backend_row` field, build the backend selector ComboRow, swap model picker contents on backend change, persist backend + sherpa model selection
+- `crates/sdr-ui/src/window.rs` — construct `BackendConfig` from the panel state, call new `engine.start(config)`, add `Partial { text }` match arm that routes to `tracing::debug!`
+- `crates/sdr-ui/src/dsp_controller.rs` — no changes expected (just verify nothing in the audio tap path depends on the engine API shape)
+- `Cargo.lock` — auto-updated by cargo
+
+**Untouched (regression surface check):**
+- `crates/sdr-transcription/src/denoise.rs` — unchanged
+- `crates/sdr-transcription/src/resampler.rs` — unchanged
+- `crates/sdr-transcription/src/model.rs` — unchanged
+- `crates/sdr-transcription/src/backends/mod.rs` — already declares `pub mod whisper;` and `#[cfg(test)] pub mod mock;`; we add `pub mod sherpa;` to it
+- All other UI files unchanged
+
+---
+
+## Conventions for this PR
+
+- The Whisper transcription flow MUST keep working unchanged. After every task that touches lib.rs, backend.rs, or window.rs, verify Whisper still starts and transcribes via the existing path.
+- The sherpa backend is allowed to fail loudly if the model isn't downloaded — that's the spike contract. PR 3 adds auto-download. The error message must tell the user EXACTLY where to download to and what files are expected.
+- `OnlineRecognizer` and `OnlineStream` are `!Send`. Construct them inside the worker thread, never store them in `SherpaBackend` itself. Same pattern as `WhisperContext` in `WhisperBackend`.
+- For this PR, the sherpa partial events route to `tracing::debug!("partial: {text}")` in window.rs. Final events render to the text view exactly like Whisper's `Text` event. Full live-captions UI lands in PR 4.
+- The CUDA story for `sherpa-onnx-sys` is one of the spike's primary unknowns. The plan asks the user to test both CPU and CUDA in the smoke test step. If CUDA fails, document the failure in the PR description and ship CPU-only — PR 4 or a follow-up can fix it.
+
+---
+
+## Sherpa model bundle: Streaming Zipformer English
+
+Initial model: `sherpa-onnx-streaming-zipformer-en-2023-06-26`
+
+**Bundle URL:** `https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2`
+
+**Expected files** (after `tar -xjf` extraction):
+- `encoder-epoch-99-avg-1-chunk-16-left-128.onnx` (or `.int8.onnx` quantized variant)
+- `decoder-epoch-99-avg-1-chunk-16-left-128.onnx`
+- `joiner-epoch-99-avg-1-chunk-16-left-128.onnx`
+- `tokens.txt`
+
+**Target directory** (chosen by `SherpaModel::directory()`):
+- `~/.local/share/sdr-rs/models/sherpa/streaming-zipformer-en/`
+
+For the spike, the user runs (once):
+
+```bash
+mkdir -p ~/.local/share/sdr-rs/models/sherpa
+cd ~/.local/share/sdr-rs/models/sherpa
+wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2
+tar -xjf sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2
+mv sherpa-onnx-streaming-zipformer-en-2023-06-26 streaming-zipformer-en
+```
+
+PR 3 automates all of this.
+
+---
+
+## Task 1: Add `sherpa-onnx` dependency and verify the build works
+
+The riskiest single change in this PR — `sherpa-onnx-sys` build script downloads a precompiled libsherpa archive on first build. We need to know early whether this works on the user's network and toolchain.
+
+**Files:**
+- Modify: `crates/sdr-transcription/Cargo.toml`
+
+- [ ] **Step 1: Add the dependency**
+
+Find the `[dependencies]` section in `crates/sdr-transcription/Cargo.toml` and add:
+
+```toml
+sherpa-onnx = "1.12"
+```
+
+The line goes alongside the existing deps (alphabetical position is fine). The crate uses `default = ["static"]` which statically links libsherpa-onnx into our binary. No additional system deps required.
+
+The full section should look something like:
+
+```toml
+[dependencies]
+whisper-rs.workspace = true
+reqwest.workspace = true
+rustfft.workspace = true
+sdr-types.workspace = true
+sherpa-onnx = "1.12"
+thiserror.workspace = true
+tracing.workspace = true
+dirs-next.workspace = true
+libc.workspace = true
+```
+
+- [ ] **Step 2: Build the crate (this will take a while on first build — libsherpa download)**
+
+```bash
+cd /data/source/rtl-sdr
+cargo build -p sdr-transcription 2>&1 | tail -30
+```
+
+**Expected:** the first build downloads the precompiled libsherpa archive (~50-200 MB) via the `sherpa-onnx-sys` build script. This may take 30-180 seconds. On subsequent builds, the cached library is used.
+
+**If the build fails:**
+- "could not download libsherpa-onnx" → network issue or upstream URL change. Check the build script error message. If upstream changed, may need to pin to a specific older version like `sherpa-onnx = "1.12.38"`.
+- Linker errors → missing system deps. Should not happen with `default = ["static"]` but if it does, document the missing dep.
+- Slow build → expected for the first time. Don't kill it under 5 minutes.
+
+**STOP and report BLOCKED if the build fails.** Don't try to work around build failures — we need the user to know if their environment can't build sherpa-onnx before we sink any more effort into this PR.
+
+- [ ] **Step 3: Verify the workspace still builds**
+
+```bash
+cargo build --workspace 2>&1 | tail -10
+```
+
+**Expected:** clean. Adding the dependency to `sdr-transcription` should not break any other crate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-transcription/Cargo.toml Cargo.lock
+git commit -m "$(cat <<'EOF'
+sdr-transcription: add sherpa-onnx dependency
+
+First step of PR 2 (sherpa spike). Adds the official k2-fsa
+sherpa-onnx Rust crate with default static linking. The build script
+downloads a precompiled libsherpa archive on first build (~50-200 MB,
+cached after that). No system dependencies required.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Create `sherpa_model.rs` with `SherpaModel` enum
+
+The model registry — mirrors `model.rs` (the Whisper one) but for sherpa bundles. For PR 2 there's only one variant; PR 5+ adds Parakeet, Moonshine, etc.
+
+**Files:**
+- Create: `crates/sdr-transcription/src/sherpa_model.rs`
+
+- [ ] **Step 1: Write the file**
+
+Write this exact content to `crates/sdr-transcription/src/sherpa_model.rs`:
+
+```rust
+//! Sherpa-onnx model registry and path management.
+//!
+//! Mirrors `model.rs` (the Whisper registry) but for sherpa-onnx bundles.
+//! Each `SherpaModel` variant maps to a directory containing the encoder,
+//! decoder, joiner, and tokens files for one streaming ASR model.
+//!
+//! For PR 2 (the sherpa spike) the user manually downloads bundles into
+//! `models_dir() / sherpa / <model>/` before launching. PR 3 adds
+//! auto-download.
+
+use std::path::PathBuf;
+
+/// Available sherpa-onnx model variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SherpaModel {
+    /// Streaming Zipformer English (k2-fsa, 2023-06-26).
+    StreamingZipformerEn,
+}
+
+impl SherpaModel {
+    /// Human-readable display label for the model picker.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "Streaming Zipformer (English)",
+        }
+    }
+
+    /// Directory name (under `models_dir() / sherpa /`) where this model's
+    /// files live.
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "streaming-zipformer-en",
+        }
+    }
+
+    /// Filename of the encoder ONNX file inside the model directory.
+    pub fn encoder_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => {
+                "encoder-epoch-99-avg-1-chunk-16-left-128.onnx"
+            }
+        }
+    }
+
+    /// Filename of the decoder ONNX file inside the model directory.
+    pub fn decoder_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => {
+                "decoder-epoch-99-avg-1-chunk-16-left-128.onnx"
+            }
+        }
+    }
+
+    /// Filename of the joiner ONNX file inside the model directory.
+    pub fn joiner_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => {
+                "joiner-epoch-99-avg-1-chunk-16-left-128.onnx"
+            }
+        }
+    }
+
+    /// Filename of the tokens file inside the model directory.
+    pub fn tokens_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "tokens.txt",
+        }
+    }
+
+    /// All available variants in order — used to populate the UI dropdown.
+    pub const ALL: &[Self] = &[Self::StreamingZipformerEn];
+}
+
+/// Returns the sherpa subdirectory under the shared models dir
+/// (`~/.local/share/sdr-rs/models/sherpa/`).
+pub fn sherpa_models_dir() -> PathBuf {
+    crate::model::models_dir().join("sherpa")
+}
+
+/// Returns the directory containing all files for a given sherpa model
+/// (`~/.local/share/sdr-rs/models/sherpa/<dir_name>/`).
+pub fn model_directory(model: SherpaModel) -> PathBuf {
+    sherpa_models_dir().join(model.dir_name())
+}
+
+/// Returns the full paths for all files needed by a sherpa model.
+///
+/// Order: (encoder, decoder, joiner, tokens). The caller checks each path
+/// for existence and emits a helpful error if any are missing.
+pub fn model_file_paths(model: SherpaModel) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let dir = model_directory(model);
+    (
+        dir.join(model.encoder_filename()),
+        dir.join(model.decoder_filename()),
+        dir.join(model.joiner_filename()),
+        dir.join(model.tokens_filename()),
+    )
+}
+
+/// True if all four required files for `model` exist on disk.
+pub fn model_exists(model: SherpaModel) -> bool {
+    let (e, d, j, t) = model_file_paths(model);
+    e.is_file() && d.is_file() && j.is_file() && t.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_models_have_unique_directory_names() {
+        let names: Vec<_> = SherpaModel::ALL.iter().map(|m| m.dir_name()).collect();
+        let unique: std::collections::HashSet<_> = names.iter().collect();
+        assert_eq!(names.len(), unique.len());
+    }
+
+    #[test]
+    fn streaming_zipformer_en_dir_is_under_sherpa() {
+        let dir = model_directory(SherpaModel::StreamingZipformerEn);
+        assert!(dir.ends_with("sherpa/streaming-zipformer-en"));
+    }
+
+    #[test]
+    fn model_file_paths_returns_four_distinct_files() {
+        let (e, d, j, t) = model_file_paths(SherpaModel::StreamingZipformerEn);
+        assert_ne!(e, d);
+        assert_ne!(e, j);
+        assert_ne!(e, t);
+        assert_ne!(d, j);
+        assert_ne!(d, t);
+        assert_ne!(j, t);
+    }
+}
+```
+
+- [ ] **Step 2: Verify (not yet wired into lib.rs)**
+
+```bash
+cd /data/source/rtl-sdr
+cargo check -p sdr-transcription 2>&1 | tail -10
+```
+
+**Expected:** clean (the new file is not yet referenced from lib.rs, so the compiler won't see it; that's expected).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-transcription/src/sherpa_model.rs
+git commit -m "$(cat <<'EOF'
+sdr-transcription: add SherpaModel enum and path helpers
+
+New sherpa_model.rs registry mirrors model.rs (the Whisper one) for
+sherpa-onnx model bundles. PR 2 ships only one variant
+(StreamingZipformerEn); Parakeet (#223) and Moonshine (#224) follow.
+
+Files live under ~/.local/share/sdr-rs/models/sherpa/<dir_name>/ as
+encoder.onnx + decoder.onnx + joiner.onnx + tokens.txt. For the spike
+the user downloads manually; PR 3 adds auto-download.
+
+Not yet wired into lib.rs — that happens in the next task.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Extend `backend.rs` types and update lib.rs API
+
+Adds the `Sherpa` variant to `ModelChoice`, the `Partial` event variant, two new `BackendError` variants, and changes `TranscriptionEngine::start` to take a `BackendConfig` directly.
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backend.rs`
+- Modify: `crates/sdr-transcription/src/lib.rs`
+- Modify: `crates/sdr-transcription/src/backends/whisper.rs` (`WrongModelKind` guard)
+- Modify: `crates/sdr-transcription/src/backends/mock.rs` (still accepts any ModelChoice)
+
+This task is the API churn point — after it lands, the UI in Task 4 has to change to match.
+
+- [ ] **Step 1: Update `backend.rs` — extend `ModelChoice`, add `Partial`, extend `BackendError`**
+
+Read the current `crates/sdr-transcription/src/backend.rs` file. Make these specific edits:
+
+**Edit A — Add `use` for `PathBuf`:** at the top of the file, after `use std::sync::mpsc;`, insert:
+
+```rust
+use std::path::PathBuf;
+```
+
+**Edit B — Add `Sherpa` variant to `ModelChoice`:** find the `ModelChoice` enum and replace it with:
+
+```rust
+/// User-facing model selection.
+///
+/// The variant determines which backend the engine instantiates internally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelChoice {
+    Whisper(WhisperModel),
+    Sherpa(crate::sherpa_model::SherpaModel),
+}
+```
+
+**Edit C — Add `Partial` variant to `TranscriptionEvent`:** find the `TranscriptionEvent` enum and add the `Partial` variant. The full enum should look like:
+
+```rust
+/// Events emitted by a backend during its lifecycle.
+///
+/// Variant names are stable — UI consumers match on them by name.
+#[derive(Debug, Clone)]
+pub enum TranscriptionEvent {
+    /// Model download in progress (0..=100).
+    Downloading { progress_pct: u8 },
+    /// Model loaded and ready for inference.
+    Ready,
+    /// Incremental hypothesis from a streaming backend. May be replaced
+    /// by another `Partial` before being committed as a `Text`. Backends
+    /// that return `false` from `supports_partials()` never emit this.
+    Partial { text: String },
+    /// Transcribed text from one inference pass (or one committed
+    /// streaming utterance).
+    Text {
+        /// Wall-clock timestamp in "HH:MM:SS" format.
+        timestamp: String,
+        /// Transcribed text (trimmed, non-empty).
+        text: String,
+    },
+    /// Fatal error — backend will exit after sending this.
+    Error(String),
+}
+```
+
+**Edit D — Extend `BackendError`:** find the `BackendError` enum and replace it with:
+
+```rust
+/// Errors a backend can return from `start`.
+///
+/// Mirrors `crate::TranscriptionError` so the engine can convert
+/// transparently. Kept separate so backends don't depend on the engine.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    #[error("failed to spawn worker thread: {0}")]
+    Spawn(#[from] std::io::Error),
+    #[error("model files not found at {path}; download the bundle and place its contents in this directory")]
+    ModelNotFound { path: PathBuf },
+    #[error("backend received the wrong model kind in BackendConfig — engine bug")]
+    WrongModelKind,
+    #[error("backend initialization failed: {0}")]
+    Init(String),
+}
+```
+
+- [ ] **Step 2: Update `lib.rs` — change `start()` signature to take `BackendConfig`, route by `ModelChoice`**
+
+Read the current `crates/sdr-transcription/src/lib.rs`. Replace the `pub fn start(...)` method with this version that takes `BackendConfig` directly:
+
+**Find:**
+
+```rust
+    /// Start the Whisper backend with the given model and parameters.
+    /// Returns a receiver for [`TranscriptionEvent`].
+    ///
+    /// Kept for API compatibility with the pre-refactor engine.
+    /// Internally constructs a [`WhisperBackend`] and delegates.
+    pub fn start(
+        &mut self,
+        whisper_model: WhisperModel,
+        silence_threshold: f32,
+        noise_gate_ratio: f32,
+    ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
+        let backend: Box<dyn TranscriptionBackend> = Box::new(WhisperBackend::new());
+        let config = BackendConfig {
+            model: ModelChoice::Whisper(whisper_model),
+            silence_threshold,
+            noise_gate_ratio,
+        };
+        self.start_with_backend(backend, config)
+    }
+```
+
+**Replace with:**
+
+```rust
+    /// Start a transcription backend selected by `config.model`.
+    ///
+    /// Constructs the right backend (Whisper or Sherpa) for the chosen
+    /// model and returns a receiver for [`TranscriptionEvent`].
+    pub fn start(
+        &mut self,
+        config: BackendConfig,
+    ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
+        let backend: Box<dyn TranscriptionBackend> = match config.model {
+            ModelChoice::Whisper(_) => Box::new(WhisperBackend::new()),
+            ModelChoice::Sherpa(_) => Box::new(backends::sherpa::SherpaBackend::new()),
+        };
+        self.start_with_backend(backend, config)
+    }
+```
+
+Also add `pub use sherpa_model::SherpaModel;` and `pub mod sherpa_model;` near the top. The full module/re-export block should look like:
+
+```rust
+pub mod backend;
+pub mod backends;
+pub mod denoise;
+pub mod model;
+pub mod resampler;
+pub mod sherpa_model;
+
+pub use backend::{
+    BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
+    TranscriptionEvent,
+};
+pub use model::WhisperModel;
+pub use sherpa_model::SherpaModel;
+```
+
+Note: this commit will reference `backends::sherpa::SherpaBackend::new()` which doesn't exist yet. **The crate will not compile after this step alone.** We're committing in a logical chunk — the SherpaBackend skeleton lands in Task 5 and the code will compile then. Tasks 4 wires the UI to the new API in between, but that depends on this task's API change being committed first.
+
+**Strategy:** stash the new lib.rs `start` method content for now, leave the old `start(WhisperModel, ...)` in place, and make the API change in Task 5 alongside the SherpaBackend file. This way every commit compiles cleanly.
+
+**Revised plan for this step:** do NOT change `lib.rs` `start()` in this task. Only:
+- Add the new variants/types to backend.rs
+- Add `pub use sherpa_model::SherpaModel;` and `pub mod sherpa_model;` to lib.rs
+
+The `start()` signature change happens in Task 5 alongside the SherpaBackend skeleton.
+
+**Concrete instruction:** in lib.rs, only add these two lines:
+- `pub mod sherpa_model;` (in the module declarations block)
+- `pub use sherpa_model::SherpaModel;` (in the re-exports block)
+
+Do NOT change the `start()` method body in this task.
+
+- [ ] **Step 3: Update `backends/whisper.rs` — add `WrongModelKind` guard**
+
+The `WhisperBackend::start()` method currently does an irrefutable destructure: `let ModelChoice::Whisper(whisper_model) = config.model;`. Since `ModelChoice` now has two variants, this becomes a `match` that returns `WrongModelKind` for the Sherpa case.
+
+**Find:**
+
+```rust
+    fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
+        let ModelChoice::Whisper(whisper_model) = config.model;
+
+        self.cancel.store(false, Ordering::Relaxed);
+```
+
+**Replace with:**
+
+```rust
+    fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
+        let ModelChoice::Whisper(whisper_model) = config.model else {
+            return Err(BackendError::WrongModelKind);
+        };
+
+        self.cancel.store(false, Ordering::Relaxed);
+```
+
+- [ ] **Step 4: `backends/mock.rs` needs no changes**
+
+The mock's `start()` already takes a `BackendConfig` by value and doesn't destructure `model` — it ignores `_config` entirely. The test fixture continues to work for both `Whisper` and `Sherpa` model choices.
+
+- [ ] **Step 5: Verify build**
+
+```bash
+cd /data/source/rtl-sdr
+cargo build -p sdr-transcription 2>&1 | tail -20
+```
+
+**Expected:** clean build of `sdr-transcription`. The full workspace will fail because `sdr-ui/src/window.rs` matches on `TranscriptionEvent` exhaustively and now has a missing `Partial` arm — that's fixed in Task 4. For now, only verify the crate-level build.
+
+```bash
+cargo test -p sdr-transcription 2>&1 | tail -20
+```
+
+**Expected:** all 28 tests still pass (3 new tests in `sherpa_model.rs` bring it to 31 — confirm the count went up).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backend.rs crates/sdr-transcription/src/lib.rs crates/sdr-transcription/src/backends/whisper.rs
+git commit -m "$(cat <<'EOF'
+sdr-transcription: extend ModelChoice + TranscriptionEvent for sherpa
+
+Adds the Sherpa variant to ModelChoice, the Partial event variant
+that streaming backends emit, and BackendError::ModelNotFound +
+WrongModelKind variants. WhisperBackend::start now returns
+WrongModelKind if a non-Whisper choice is passed.
+
+The TranscriptionEngine::start signature change (BackendConfig
+parameter) and the SherpaBackend dispatch land in the next tasks,
+so this commit compiles sdr-transcription cleanly but sdr-ui will
+fail until window.rs grows a Partial match arm in Task 4.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update `sdr-ui` for the new event variant + temporary tracing arm
+
+Adds a `Partial { text }` match arm to `window.rs`'s transcript event handler. For the spike, the arm just calls `tracing::debug!`. This unblocks the workspace build.
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs`
+
+- [ ] **Step 1: Add the Partial match arm**
+
+In `crates/sdr-ui/src/window.rs`, find the `match event` block inside the `glib::timeout_add_local` closure (around line 1483-1509). The current arms are: `Downloading`, `Ready`, `Text`, `Error`. Add a `Partial` arm BEFORE the `Text` arm so streaming partial hypotheses are logged but not rendered (full rendering lands in PR 4).
+
+**Find:**
+
+```rust
+                                    TranscriptionEvent::Ready => {
+                                        status.set_text("Listening...");
+                                        status.set_css_classes(&["success"]);
+                                        progress.set_visible(false);
+                                    }
+                                    TranscriptionEvent::Text { timestamp, text } => {
+```
+
+**Replace with:**
+
+```rust
+                                    TranscriptionEvent::Ready => {
+                                        status.set_text("Listening...");
+                                        status.set_css_classes(&["success"]);
+                                        progress.set_visible(false);
+                                    }
+                                    TranscriptionEvent::Partial { text } => {
+                                        // PR 4 will render this as a live caption line.
+                                        // For the PR 2 spike, log only.
+                                        tracing::debug!(target: "transcription", partial = %text);
+                                    }
+                                    TranscriptionEvent::Text { timestamp, text } => {
+```
+
+- [ ] **Step 2: Verify the workspace builds**
+
+```bash
+cd /data/source/rtl-sdr
+cargo build --workspace 2>&1 | tail -15
+```
+
+**Expected:** clean. The exhaustive match in `sdr-ui` is now satisfied.
+
+```bash
+cargo test --workspace 2>&1 | grep "test result" | tail -20
+```
+
+**Expected:** all tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "$(cat <<'EOF'
+sdr-ui: handle TranscriptionEvent::Partial (spike: log only)
+
+Adds the missing match arm for the new Partial event variant
+introduced in the previous commit. For the PR 2 spike, partials
+just go to tracing::debug — full live captions rendering with
+the two-line model lands in PR 4.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Create `SherpaBackend` skeleton + change engine.start() signature
+
+Creates the SherpaBackend file with a struct that compiles but immediately returns `BackendError::Init` from `start()`. Also lands the `engine.start()` signature change to take `BackendConfig`. The UI will be updated in Task 6 to call the new signature; until then, the workspace build will be temporarily broken (UI window.rs still calls the old `start(WhisperModel, ...)` form). Task 6 is small and lands right after.
+
+**Files:**
+- Create: `crates/sdr-transcription/src/backends/sherpa.rs`
+- Modify: `crates/sdr-transcription/src/backends/mod.rs` (declare `pub mod sherpa;`)
+- Modify: `crates/sdr-transcription/src/lib.rs` (change `start` signature)
+
+- [ ] **Step 1: Add the module declaration**
+
+In `crates/sdr-transcription/src/backends/mod.rs`, add `pub mod sherpa;` so the file should look like:
+
+```rust
+//! Concrete `TranscriptionBackend` implementations.
+//!
+//! Each backend is a self-contained module. The engine in `lib.rs`
+//! constructs one based on the [`crate::backend::ModelChoice`] variant
+//! and delegates lifecycle to it.
+
+pub mod sherpa;
+pub mod whisper;
+
+#[cfg(test)]
+pub mod mock;
+```
+
+- [ ] **Step 2: Create the SherpaBackend skeleton**
+
+Write this content to `crates/sdr-transcription/src/backends/sherpa.rs`. This is a SKELETON — the real recognizer wiring lands in Task 7. For now, `start()` returns `BackendError::Init("not yet implemented")` so the file compiles and can be referenced from lib.rs.
+
+```rust
+//! Sherpa-onnx backend — streaming-native ASR via the official k2-fsa
+//! `sherpa-onnx` Rust crate.
+//!
+//! Implements [`TranscriptionBackend`] using `OnlineRecognizer` for true
+//! frame-by-frame streaming with endpoint detection. Partial hypotheses
+//! are emitted as `TranscriptionEvent::Partial`; committed utterances
+//! after silence detection are emitted as `TranscriptionEvent::Text`.
+//!
+//! `OnlineRecognizer` and `OnlineStream` are `!Send` (they wrap raw
+//! pointers into the C library), so all recognizer interaction happens
+//! on the worker thread. The `SherpaBackend` struct itself only holds
+//! the cancellation token and the worker join handle, mirroring
+//! `WhisperBackend`.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use crate::backend::{
+    BackendConfig, BackendError, BackendHandle, TranscriptionBackend,
+};
+
+/// `TranscriptionBackend` implementation backed by `sherpa-onnx`.
+pub struct SherpaBackend {
+    cancel: Arc<AtomicBool>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Default for SherpaBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SherpaBackend {
+    pub fn new() -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+            worker: None,
+        }
+    }
+}
+
+impl TranscriptionBackend for SherpaBackend {
+    fn name(&self) -> &'static str {
+        "sherpa"
+    }
+
+    fn supports_partials(&self) -> bool {
+        true
+    }
+
+    fn start(&mut self, _config: BackendConfig) -> Result<BackendHandle, BackendError> {
+        // Skeleton — real implementation lands in Task 7.
+        Err(BackendError::Init(
+            "SherpaBackend is not yet implemented (Task 7)".to_owned(),
+        ))
+    }
+
+    fn stop(&mut self) {
+        self.shutdown_nonblocking();
+    }
+
+    fn shutdown_nonblocking(&mut self) {
+        self.cancel
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.worker.take(); // detach
+        tracing::info!("sherpa backend shutdown (non-blocking)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sherpa_backend_supports_partials() {
+        let backend = SherpaBackend::new();
+        assert!(backend.supports_partials());
+    }
+
+    #[test]
+    fn sherpa_backend_name_is_stable() {
+        let backend = SherpaBackend::new();
+        assert_eq!(backend.name(), "sherpa");
+    }
+}
+```
+
+- [ ] **Step 3: Change `lib.rs` `start()` signature**
+
+In `crates/sdr-transcription/src/lib.rs`, find the existing `start()` method and replace it with the version that takes `BackendConfig`:
+
+**Find:**
+
+```rust
+    /// Start the Whisper backend with the given model and parameters.
+    /// Returns a receiver for [`TranscriptionEvent`].
+    ///
+    /// Kept for API compatibility with the pre-refactor engine.
+    /// Internally constructs a [`WhisperBackend`] and delegates.
+    pub fn start(
+        &mut self,
+        whisper_model: WhisperModel,
+        silence_threshold: f32,
+        noise_gate_ratio: f32,
+    ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
+        let backend: Box<dyn TranscriptionBackend> = Box::new(WhisperBackend::new());
+        let config = BackendConfig {
+            model: ModelChoice::Whisper(whisper_model),
+            silence_threshold,
+            noise_gate_ratio,
+        };
+        self.start_with_backend(backend, config)
+    }
+```
+
+**Replace with:**
+
+```rust
+    /// Start a transcription backend selected by `config.model`.
+    ///
+    /// Constructs the right backend (Whisper or Sherpa) for the chosen
+    /// model and returns a receiver for [`TranscriptionEvent`].
+    pub fn start(
+        &mut self,
+        config: BackendConfig,
+    ) -> Result<mpsc::Receiver<TranscriptionEvent>, TranscriptionError> {
+        let backend: Box<dyn TranscriptionBackend> = match config.model {
+            ModelChoice::Whisper(_) => Box::new(WhisperBackend::new()),
+            ModelChoice::Sherpa(_) => Box::new(backends::sherpa::SherpaBackend::new()),
+        };
+        self.start_with_backend(backend, config)
+    }
+```
+
+- [ ] **Step 4: Update the engine tests in lib.rs**
+
+The existing engine tests use `dummy_config()` which returns a `BackendConfig` — they already work with `start_with_backend(backend, config)`, so they don't need changes. But there are no tests calling the public `start(config)` directly. Add one:
+
+Find the `engine_drop_runs_shutdown` test in `crates/sdr-transcription/src/lib.rs` and add a new test after `engine_stop_clears_state` (or wherever the last test is):
+
+```rust
+    #[test]
+    fn engine_start_with_whisper_choice_picks_whisper_backend() {
+        // We can't run a real Whisper start without downloading a model,
+        // so this test only verifies the dispatch logic compiles and the
+        // ModelChoice → backend type mapping is wired through start().
+        // The behavioral coverage lives in start_with_backend tests above.
+        let mut engine = TranscriptionEngine::new();
+        // Use start_with_backend with a mock so we don't actually load
+        // a Whisper model. The point of this test is just type-level
+        // coverage of the new start(config) entry point — see
+        // engine_starts_with_mock_backend for the actual behavior.
+        let backend = Box::new(MockBackend::new());
+        let _ = engine
+            .start_with_backend(backend, dummy_config())
+            .expect("start_with_backend ok");
+        assert!(engine.is_running());
+    }
+```
+
+(This test is admittedly thin — the real coverage is in `engine_starts_with_mock_backend`. The new test is here just so PR review can see that the new `start(config)` entry point at least compiles.)
+
+- [ ] **Step 5: Verify the crate builds**
+
+```bash
+cd /data/source/rtl-sdr
+cargo build -p sdr-transcription 2>&1 | tail -20
+cargo test -p sdr-transcription 2>&1 | tail -20
+```
+
+**Expected:** crate builds and tests pass. New test count: 33 (was 31 after Task 2, +2 from sherpa.rs trait surface tests, +1 from the start dispatch test would be 34 — but the start dispatch test is using `start_with_backend`, so it's just one of the existing test patterns. Actual count: depends on what's added).
+
+The workspace build will be broken because `sdr-ui/src/window.rs` line 1465 still calls `engine.start(whisper_model, silence_threshold, noise_gate_ratio)` which no longer matches the new signature. Task 6 fixes that.
+
+```bash
+cargo build --workspace 2>&1 | tail -10
+```
+
+**Expected:** error in `sdr-ui/src/window.rs` about argument mismatch on `engine.start(...)`. This is intentional — the next task fixes it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa.rs crates/sdr-transcription/src/backends/mod.rs crates/sdr-transcription/src/lib.rs
+git commit -m "$(cat <<'EOF'
+sdr-transcription: SherpaBackend skeleton + engine.start(BackendConfig)
+
+Skeleton SherpaBackend that implements TranscriptionBackend with
+supports_partials() = true. start() returns BackendError::Init for
+now — real OnlineRecognizer wiring lands in Task 7.
+
+TranscriptionEngine::start now takes a BackendConfig directly and
+routes to WhisperBackend or SherpaBackend based on config.model.
+
+sdr-ui/window.rs is intentionally broken at this commit; fixed in
+the next task.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Update `sdr-ui` to call the new `engine.start(BackendConfig)` API
+
+Updates the call site in `window.rs` to construct a `BackendConfig` and pass it. Adds basic backend selection wiring (reads from the panel state which Task 8 sets up — for now, hardcode Whisper).
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs`
+
+- [ ] **Step 1: Update the start() call site**
+
+Find this section in `crates/sdr-ui/src/window.rs` (around line 1448-1466):
+
+```rust
+            let model_idx = model_row.selected() as usize;
+            let whisper_model = sdr_transcription::WhisperModel::ALL
+                .get(model_idx)
+                .copied()
+                .unwrap_or(sdr_transcription::WhisperModel::TinyEn);
+
+            // Read tuning slider values.
+            #[allow(clippy::cast_possible_truncation)]
+            let silence_threshold = silence_row.value() as f32;
+            #[allow(clippy::cast_possible_truncation)]
+            let noise_gate_ratio = noise_gate_row.value() as f32;
+
+            // Scope the borrow so it's dropped before any potential re-entry
+            // from row.set_active(false) on error.
+            let start_result =
+                engine_clone
+                    .borrow_mut()
+                    .start(whisper_model, silence_threshold, noise_gate_ratio);
+```
+
+**Replace with:**
+
+```rust
+            let model_idx = model_row.selected() as usize;
+            let whisper_model = sdr_transcription::WhisperModel::ALL
+                .get(model_idx)
+                .copied()
+                .unwrap_or(sdr_transcription::WhisperModel::TinyEn);
+
+            // Read tuning slider values.
+            #[allow(clippy::cast_possible_truncation)]
+            let silence_threshold = silence_row.value() as f32;
+            #[allow(clippy::cast_possible_truncation)]
+            let noise_gate_ratio = noise_gate_row.value() as f32;
+
+            // Build BackendConfig. For Task 6 we hardcode Whisper —
+            // Task 8 wires the backend selector ComboRow that provides
+            // ModelChoice::Sherpa(...) when the user picks it.
+            let config = sdr_transcription::BackendConfig {
+                model: sdr_transcription::ModelChoice::Whisper(whisper_model),
+                silence_threshold,
+                noise_gate_ratio,
+            };
+
+            // Scope the borrow so it's dropped before any potential re-entry
+            // from row.set_active(false) on error.
+            let start_result = engine_clone.borrow_mut().start(config);
+```
+
+- [ ] **Step 2: Verify the workspace builds**
+
+```bash
+cd /data/source/rtl-sdr
+cargo build --workspace 2>&1 | tail -10
+cargo test --workspace 2>&1 | grep "test result" | tail -20
+```
+
+**Expected:** clean. All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "$(cat <<'EOF'
+sdr-ui: call engine.start(BackendConfig) instead of (WhisperModel, ...)
+
+Constructs a BackendConfig from the panel state (currently
+hardcoded to ModelChoice::Whisper) and passes it to the new engine
+API. Backend selection via the upcoming ComboRow lands in Task 8;
+this commit unblocks the workspace build after the API change.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Implement the real `SherpaBackend` feed loop
+
+Replace the skeleton `start()` with a working implementation that loads the model files, creates an `OnlineRecognizer`, spawns a worker thread, and runs the streaming feed loop. This is the meat of the spike.
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa.rs`
+
+- [ ] **Step 1: Replace the skeleton with the real implementation**
+
+Replace the entire content of `crates/sdr-transcription/src/backends/sherpa.rs` with:
+
+```rust
+//! Sherpa-onnx backend — streaming-native ASR via the official k2-fsa
+//! `sherpa-onnx` Rust crate.
+//!
+//! Implements [`TranscriptionBackend`] using `OnlineRecognizer` for true
+//! frame-by-frame streaming with endpoint detection. Partial hypotheses
+//! are emitted as `TranscriptionEvent::Partial`; committed utterances
+//! after silence detection are emitted as `TranscriptionEvent::Text`.
+//!
+//! `OnlineRecognizer` and `OnlineStream` are `!Send` (they wrap raw
+//! pointers into the C library), so all recognizer interaction happens
+//! on the worker thread. The `SherpaBackend` struct itself only holds
+//! the cancellation token and the worker join handle, mirroring
+//! `WhisperBackend`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
+use std::time::Duration;
+
+use sherpa_onnx::{OnlineRecognizer, OnlineRecognizerConfig};
+
+use crate::backend::{
+    BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
+    TranscriptionEvent,
+};
+use crate::sherpa_model::{self, SherpaModel};
+use crate::{denoise, resampler};
+
+/// Bounded channel capacity for audio buffers from DSP → backend.
+/// Sherpa accepts much smaller chunks than Whisper (per-frame, not
+/// 5-second windows), so we don't need the same headroom WhisperBackend
+/// does. 256 still gives plenty of buffer.
+const AUDIO_CHANNEL_CAPACITY: usize = 256;
+
+/// Polling interval for the audio receive loop when checking for cancellation.
+const AUDIO_RECV_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// `TranscriptionBackend` implementation backed by `sherpa-onnx`.
+pub struct SherpaBackend {
+    cancel: Arc<AtomicBool>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Default for SherpaBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SherpaBackend {
+    pub fn new() -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+            worker: None,
+        }
+    }
+}
+
+impl TranscriptionBackend for SherpaBackend {
+    fn name(&self) -> &'static str {
+        "sherpa"
+    }
+
+    fn supports_partials(&self) -> bool {
+        true
+    }
+
+    fn start(&mut self, config: BackendConfig) -> Result<BackendHandle, BackendError> {
+        let ModelChoice::Sherpa(sherpa_model) = config.model else {
+            return Err(BackendError::WrongModelKind);
+        };
+
+        // Verify the model files exist before spawning the worker, so the
+        // user gets a useful error immediately rather than after the
+        // recognizer fails inside the thread.
+        if !sherpa_model::model_exists(sherpa_model) {
+            return Err(BackendError::ModelNotFound {
+                path: sherpa_model::model_directory(sherpa_model),
+            });
+        }
+
+        self.cancel.store(false, Ordering::Relaxed);
+
+        let (audio_tx, audio_rx) = mpsc::sync_channel(AUDIO_CHANNEL_CAPACITY);
+        let (event_tx, event_rx) = mpsc::channel();
+
+        let cancel = Arc::clone(&self.cancel);
+        let noise_gate_ratio = config.noise_gate_ratio;
+
+        let handle = std::thread::Builder::new()
+            .name("sherpa-worker".into())
+            .spawn(move || {
+                run_worker(
+                    &audio_rx,
+                    &event_tx,
+                    &cancel,
+                    sherpa_model,
+                    noise_gate_ratio,
+                );
+            })?;
+
+        self.worker = Some(handle);
+        tracing::info!("sherpa backend started");
+
+        Ok(BackendHandle { audio_tx, event_rx })
+    }
+
+    fn stop(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.worker.take() {
+            let _ = handle.join();
+        }
+        tracing::info!("sherpa backend stopped");
+    }
+
+    fn shutdown_nonblocking(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        self.worker.take(); // detach — don't join
+        tracing::info!("sherpa backend shutdown (non-blocking)");
+    }
+}
+
+/// Build the `OnlineRecognizerConfig` for a Streaming Zipformer model.
+///
+/// Returns `Init` errors with helpful messages on misconfiguration. The
+/// `provider` parameter selects the ONNX execution provider — `"cpu"` is
+/// the default; `"cuda"` enables GPU acceleration if libsherpa was built
+/// with CUDA support.
+fn build_recognizer_config(
+    model: SherpaModel,
+    provider: &str,
+) -> Result<OnlineRecognizerConfig, BackendError> {
+    let (encoder, decoder, joiner, tokens) = sherpa_model::model_file_paths(model);
+
+    let mut config = OnlineRecognizerConfig::default();
+    config.model_config.transducer.encoder = Some(encoder.to_string_lossy().into_owned());
+    config.model_config.transducer.decoder = Some(decoder.to_string_lossy().into_owned());
+    config.model_config.transducer.joiner = Some(joiner.to_string_lossy().into_owned());
+    config.model_config.tokens = Some(tokens.to_string_lossy().into_owned());
+    config.model_config.provider = Some(provider.to_owned());
+    config.model_config.num_threads = 1;
+    config.enable_endpoint = true;
+    config.decoding_method = Some("greedy_search".to_owned());
+    // Endpoint detection rules — defaults from sherpa-onnx examples.
+    config.rule1_min_trailing_silence = 2.4;
+    config.rule2_min_trailing_silence = 1.2;
+    config.rule3_min_utterance_length = 20.0;
+
+    Ok(config)
+}
+
+/// Worker thread entry point. Owns the recognizer and stream for the
+/// entire transcription session.
+fn run_worker(
+    audio_rx: &mpsc::Receiver<Vec<f32>>,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+    cancel: &Arc<AtomicBool>,
+    model: SherpaModel,
+    noise_gate_ratio: f32,
+) {
+    if let Err(e) = run_worker_inner(audio_rx, event_tx, cancel, model, noise_gate_ratio) {
+        let _ = event_tx.send(TranscriptionEvent::Error(e));
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_worker_inner(
+    audio_rx: &mpsc::Receiver<Vec<f32>>,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+    cancel: &Arc<AtomicBool>,
+    model: SherpaModel,
+    noise_gate_ratio: f32,
+) -> Result<(), String> {
+    // --- Build the recognizer ---
+    //
+    // For PR 2 we hardcode CPU provider. CUDA support is validated in
+    // the smoke test step; if CUDA works, a follow-up PR (or PR 4) wires
+    // it through the UI as a separate setting.
+    let provider = "cpu";
+    let recognizer_config = build_recognizer_config(model, provider)
+        .map_err(|e| format!("failed to build recognizer config: {e}"))?;
+
+    tracing::info!(?model, provider, "loading sherpa-onnx model");
+    let recognizer = OnlineRecognizer::create(&recognizer_config)
+        .ok_or_else(|| "OnlineRecognizer::create returned None — check model file paths".to_owned())?;
+
+    let stream = recognizer.create_stream();
+
+    tracing::info!("sherpa-onnx model loaded, ready for inference");
+    event_tx
+        .send(TranscriptionEvent::Ready)
+        .map_err(|_| "event channel closed before Ready".to_owned())?;
+
+    // --- Audio loop ---
+    //
+    // Sherpa expects 16 kHz mono f32 samples. We accept the same
+    // 48 kHz interleaved stereo from the DSP thread that Whisper does,
+    // run it through the spectral denoiser, downsample to 16k mono, and
+    // feed sherpa one chunk at a time.
+    let mut mono_buf: Vec<f32> = Vec::with_capacity(16_000);
+    let mut last_partial = String::new();
+
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            tracing::info!("sherpa transcription cancelled, worker exiting");
+            return Ok(());
+        }
+
+        let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
+            Ok(data) => data,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+
+        // Resample 48k stereo → 16k mono into the scratch buffer.
+        mono_buf.clear();
+        resampler::downsample_stereo_to_mono_16k(&interleaved, &mut mono_buf);
+
+        // Drain any additional queued buffers into the same scratch
+        // (same pattern as WhisperBackend) so we don't fall behind.
+        while let Ok(extra) = audio_rx.try_recv() {
+            if cancel.load(Ordering::Relaxed) {
+                tracing::info!("sherpa transcription cancelled, worker exiting");
+                return Ok(());
+            }
+            resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
+        }
+
+        if mono_buf.is_empty() {
+            continue;
+        }
+
+        // Spectral noise gate (same preprocessor as Whisper).
+        denoise::spectral_denoise(&mut mono_buf, noise_gate_ratio);
+
+        // Feed the chunk to sherpa.
+        stream.accept_waveform(16_000, &mono_buf);
+
+        // Decode as much as the recognizer is ready for.
+        while recognizer.is_ready(&stream) {
+            if cancel.load(Ordering::Relaxed) {
+                tracing::info!("sherpa transcription cancelled mid-decode, exiting");
+                return Ok(());
+            }
+            recognizer.decode(&stream);
+        }
+
+        // Pull the current hypothesis. Emit a Partial event if it
+        // changed since the last one (avoid flooding the UI thread).
+        if let Some(result) = recognizer.get_result(&stream) {
+            let trimmed = result.text.trim();
+            if !trimmed.is_empty() && trimmed != last_partial {
+                last_partial = trimmed.to_owned();
+                let _ = event_tx.send(TranscriptionEvent::Partial {
+                    text: trimmed.to_owned(),
+                });
+            }
+
+            // On endpoint, commit the utterance as Text and reset the
+            // stream so the next utterance starts fresh.
+            if recognizer.is_endpoint(&stream) {
+                if !trimmed.is_empty() {
+                    let timestamp = wall_clock_timestamp();
+                    tracing::debug!(%timestamp, %trimmed, "sherpa committed utterance");
+                    let _ = event_tx.send(TranscriptionEvent::Text {
+                        timestamp,
+                        text: trimmed.to_owned(),
+                    });
+                }
+                recognizer.reset(&stream);
+                last_partial.clear();
+            }
+        }
+    }
+
+    tracing::info!("sherpa audio channel closed, worker exiting");
+    Ok(())
+}
+
+/// Wall-clock "HH:MM:SS" string. Same implementation as
+/// [`crate::backends::whisper`] but kept local to avoid a public
+/// re-export of an internal helper.
+#[allow(unsafe_code)]
+fn wall_clock_timestamp() -> String {
+    let mut tv = libc::timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+
+    // SAFETY: gettimeofday writes into the provided buffer and is thread-safe.
+    #[allow(unsafe_code)]
+    let epoch = unsafe {
+        libc::gettimeofday(&raw mut tv, std::ptr::null_mut());
+        tv.tv_sec
+    };
+
+    let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
+
+    // SAFETY: localtime_r is the reentrant variant; gmtime_r is the UTC fallback.
+    #[allow(unsafe_code)]
+    let tm = unsafe {
+        let result = libc::localtime_r(&raw const epoch, tm.as_mut_ptr());
+        let result = if result.is_null() {
+            libc::gmtime_r(&raw const epoch, tm.as_mut_ptr())
+        } else {
+            result
+        };
+        if result.is_null() {
+            return "00:00:00".to_owned();
+        }
+        tm.assume_init()
+    };
+
+    format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sherpa_backend_supports_partials() {
+        let backend = SherpaBackend::new();
+        assert!(backend.supports_partials());
+    }
+
+    #[test]
+    fn sherpa_backend_name_is_stable() {
+        let backend = SherpaBackend::new();
+        assert_eq!(backend.name(), "sherpa");
+    }
+}
+```
+
+- [ ] **Step 2: Verify the crate builds**
+
+```bash
+cd /data/source/rtl-sdr
+cargo build -p sdr-transcription 2>&1 | tail -20
+```
+
+**Expected:** clean. If there are sherpa-onnx API mismatches (e.g., a struct field name we got wrong), the compiler will tell you. Common mismatches and fixes:
+- `OnlineRecognizerConfig.model_config.transducer.encoder: Option<String>` — confirmed in the upstream source we read
+- `OnlineRecognizerConfig.enable_endpoint: bool` — confirmed
+- `OnlineRecognizerConfig.decoding_method: Option<String>` — confirmed
+- `OnlineRecognizer::create(&config) -> Option<Self>` — confirmed
+- `recognizer.create_stream() -> OnlineStream` — confirmed
+- `stream.accept_waveform(sample_rate: i32, samples: &[f32])` — note `i32` not `u32`. We pass `16_000` which is a literal that should infer correctly; if not, force it with `16_000_i32`.
+- `recognizer.get_result(&stream) -> Option<RecognizerResult>` where `RecognizerResult.text: String` — confirmed
+- `recognizer.is_endpoint(&stream) -> bool` — confirmed
+- `recognizer.reset(&stream)` — confirmed
+
+If you hit any compile errors, fix them by reading the actual sherpa-onnx 1.12 source at `~/.cargo/registry/src/index.crates.io-*/sherpa-onnx-1.12.*/src/online_asr.rs` to confirm the correct API.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo test -p sdr-transcription 2>&1 | tail -20
+```
+
+**Expected:** all tests still pass. Sherpa backend tests just verify trait surface — no model loading, so they don't need the user's model files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa.rs
+git commit -m "$(cat <<'EOF'
+sdr-transcription: implement SherpaBackend feed loop
+
+Real implementation of SherpaBackend.start() — loads the model files
+into an OnlineRecognizer, creates a stream, spawns a worker thread,
+and runs the streaming feed loop:
+
+  recv audio → resample 48k stereo → 16k mono → spectral denoise
+  → accept_waveform → loop { is_ready → decode } → get_result
+  → emit Partial → on endpoint, emit Text + reset stream
+
+Uses CPU provider for now; CUDA validation happens in the smoke test.
+Endpoint detection rules (rule1/2/3) match the upstream sherpa-onnx
+example defaults.
+
+Returns BackendError::ModelNotFound with the expected directory path
+if the model files aren't on disk yet — auto-download lands in PR 3.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Add backend selector ComboRow to the transcript panel
+
+The user-facing UI work. Adds a "Backend" `AdwComboRow` above the existing "Model" picker, swaps the model picker contents based on the selected backend, and persists both selections.
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/transcript_panel.rs`
+- Modify: `crates/sdr-ui/src/window.rs` (read backend selection when starting)
+
+- [ ] **Step 1: Update `transcript_panel.rs`**
+
+The full file rewrite is long because we're adding new state. Read the current `crates/sdr-ui/src/sidebar/transcript_panel.rs` for reference, then apply these changes:
+
+**Edit A — Add new config keys at the top:**
+
+After the existing `KEY_NOISE_GATE` constant, add:
+
+```rust
+/// Config key for the persisted backend selection ("whisper" or "sherpa").
+const KEY_BACKEND: &str = "transcription_backend";
+/// Config key for the persisted Sherpa model index.
+const KEY_SHERPA_MODEL: &str = "transcription_sherpa_model";
+
+/// Backend index for Whisper in the backend selector ComboRow.
+const BACKEND_IDX_WHISPER: u32 = 0;
+/// Backend index for Sherpa in the backend selector ComboRow.
+const BACKEND_IDX_SHERPA: u32 = 1;
+```
+
+**Edit B — Add `backend_row` field to `TranscriptPanel` struct:**
+
+In the `TranscriptPanel` struct definition (around line 33), add a new field:
+
+```rust
+pub struct TranscriptPanel {
+    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
+    pub widget: adw::PreferencesGroup,
+    /// Toggle to enable/disable live transcription.
+    pub enable_row: adw::SwitchRow,
+    /// Backend selector (Whisper / Sherpa).
+    pub backend_row: adw::ComboRow,
+    /// Model size selector — contents change based on backend selection.
+    pub model_row: adw::ComboRow,
+    // ... rest unchanged ...
+}
+```
+
+And add `backend_row` to the returned struct literal at the bottom of `build_transcript_panel()`.
+
+**Edit C — Build the backend selector and contextual model picker:**
+
+Find the existing model picker section (lines ~69-104, the block starting with `// Model selector` and ending after `connect_selected_notify`). Replace it with:
+
+```rust
+    // --- Backend selector ---
+    let backend_labels = ["Whisper", "Sherpa (streaming)"];
+    let backend_list = gtk4::StringList::new(&backend_labels);
+
+    let saved_backend_idx = config.read(|v| {
+        v.get(KEY_BACKEND)
+            .and_then(serde_json::Value::as_str)
+            .map_or(BACKEND_IDX_WHISPER, |s| match s {
+                "sherpa" => BACKEND_IDX_SHERPA,
+                _ => BACKEND_IDX_WHISPER,
+            })
+    });
+
+    let backend_row = adw::ComboRow::builder()
+        .title("Backend")
+        .model(&backend_list)
+        .selected(saved_backend_idx)
+        .build();
+    group.add(&backend_row);
+
+    // --- Model selector ---
+    //
+    // Contents are populated based on the active backend. We rebuild the
+    // string list each time the backend changes; the selected index
+    // resets to 0.
+    let whisper_model_labels: Vec<&str> = sdr_transcription::WhisperModel::ALL
+        .iter()
+        .map(|m| m.label())
+        .collect();
+    let sherpa_model_labels: Vec<&str> = sdr_transcription::SherpaModel::ALL
+        .iter()
+        .map(|m| m.label())
+        .collect();
+
+    let initial_model_list = if saved_backend_idx == BACKEND_IDX_SHERPA {
+        gtk4::StringList::new(&sherpa_model_labels)
+    } else {
+        gtk4::StringList::new(&whisper_model_labels)
+    };
+
+    #[allow(clippy::cast_possible_truncation)]
+    let max_whisper_idx = sdr_transcription::WhisperModel::ALL.len() as u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let max_sherpa_idx = sdr_transcription::SherpaModel::ALL.len() as u32;
+
+    let saved_whisper_model_idx = config.read(|v| {
+        v.get(KEY_MODEL)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|idx| u32::try_from(idx).ok())
+            .filter(|&idx| idx < max_whisper_idx)
+            .unwrap_or(0)
+    });
+    let saved_sherpa_model_idx = config.read(|v| {
+        v.get(KEY_SHERPA_MODEL)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|idx| u32::try_from(idx).ok())
+            .filter(|&idx| idx < max_sherpa_idx)
+            .unwrap_or(0)
+    });
+
+    let initial_model_idx = if saved_backend_idx == BACKEND_IDX_SHERPA {
+        saved_sherpa_model_idx
+    } else {
+        saved_whisper_model_idx
+    };
+
+    let model_row = adw::ComboRow::builder()
+        .title("Model")
+        .model(&initial_model_list)
+        .selected(initial_model_idx)
+        .build();
+    group.add(&model_row);
+
+    // --- Backend change handler ---
+    //
+    // Rebuilds the model picker contents and persists the new backend.
+    let config_backend = Arc::clone(config);
+    let model_row_for_backend_change = model_row.clone();
+    backend_row.connect_selected_notify(move |row| {
+        let idx = row.selected();
+        let (backend_str, new_list, new_idx) = if idx == BACKEND_IDX_SHERPA {
+            (
+                "sherpa",
+                gtk4::StringList::new(&sherpa_model_labels),
+                config_backend.read(|v| {
+                    v.get(KEY_SHERPA_MODEL)
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|i| u32::try_from(i).ok())
+                        .filter(|&i| i < max_sherpa_idx)
+                        .unwrap_or(0)
+                }),
+            )
+        } else {
+            (
+                "whisper",
+                gtk4::StringList::new(&whisper_model_labels),
+                config_backend.read(|v| {
+                    v.get(KEY_MODEL)
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|i| u32::try_from(i).ok())
+                        .filter(|&i| i < max_whisper_idx)
+                        .unwrap_or(0)
+                }),
+            )
+        };
+
+        model_row_for_backend_change.set_model(Some(&new_list));
+        model_row_for_backend_change.set_selected(new_idx);
+
+        config_backend.write(|v| {
+            v[KEY_BACKEND] = serde_json::json!(backend_str);
+        });
+    });
+
+    // --- Model change handler ---
+    //
+    // Persists to KEY_MODEL or KEY_SHERPA_MODEL depending on which
+    // backend is currently selected.
+    let config_model = Arc::clone(config);
+    let backend_row_for_model_change = backend_row.clone();
+    model_row.connect_selected_notify(move |row| {
+        let idx = row.selected();
+        let backend_idx = backend_row_for_model_change.selected();
+        let key = if backend_idx == BACKEND_IDX_SHERPA {
+            KEY_SHERPA_MODEL
+        } else {
+            KEY_MODEL
+        };
+        config_model.write(|v| {
+            v[key] = serde_json::json!(idx);
+        });
+    });
+```
+
+**Edit D — Update the returned `TranscriptPanel` struct literal at the bottom of `build_transcript_panel`:**
+
+Add `backend_row` to the struct literal so it looks like:
+
+```rust
+    TranscriptPanel {
+        widget: group,
+        enable_row,
+        backend_row,
+        model_row,
+        silence_row,
+        noise_gate_row,
+        status_label,
+        progress_bar,
+        text_view,
+        scroll,
+        clear_button,
+    }
+```
+
+- [ ] **Step 2: Update `window.rs` to read the backend selection**
+
+In `crates/sdr-ui/src/window.rs`, find the section (in `connect_transcript_panel`) where you currently construct the `BackendConfig` (added in Task 6) — around lines 1448-1466.
+
+**Find:**
+
+```rust
+            let model_idx = model_row.selected() as usize;
+            let whisper_model = sdr_transcription::WhisperModel::ALL
+                .get(model_idx)
+                .copied()
+                .unwrap_or(sdr_transcription::WhisperModel::TinyEn);
+
+            // Read tuning slider values.
+            #[allow(clippy::cast_possible_truncation)]
+            let silence_threshold = silence_row.value() as f32;
+            #[allow(clippy::cast_possible_truncation)]
+            let noise_gate_ratio = noise_gate_row.value() as f32;
+
+            // Build BackendConfig. For Task 6 we hardcode Whisper —
+            // Task 8 wires the backend selector ComboRow that provides
+            // ModelChoice::Sherpa(...) when the user picks it.
+            let config = sdr_transcription::BackendConfig {
+                model: sdr_transcription::ModelChoice::Whisper(whisper_model),
+                silence_threshold,
+                noise_gate_ratio,
+            };
+```
+
+**Replace with:**
+
+```rust
+            let model_idx = model_row.selected() as usize;
+            let backend_idx = backend_row.selected();
+
+            // Read tuning slider values.
+            #[allow(clippy::cast_possible_truncation)]
+            let silence_threshold = silence_row.value() as f32;
+            #[allow(clippy::cast_possible_truncation)]
+            let noise_gate_ratio = noise_gate_row.value() as f32;
+
+            // Build BackendConfig from the panel state. Backend index
+            // 1 = Sherpa; everything else = Whisper.
+            let model = if backend_idx == 1 {
+                let sherpa_model = sdr_transcription::SherpaModel::ALL
+                    .get(model_idx)
+                    .copied()
+                    .unwrap_or(sdr_transcription::SherpaModel::StreamingZipformerEn);
+                sdr_transcription::ModelChoice::Sherpa(sherpa_model)
+            } else {
+                let whisper_model = sdr_transcription::WhisperModel::ALL
+                    .get(model_idx)
+                    .copied()
+                    .unwrap_or(sdr_transcription::WhisperModel::TinyEn);
+                sdr_transcription::ModelChoice::Whisper(whisper_model)
+            };
+
+            let config = sdr_transcription::BackendConfig {
+                model,
+                silence_threshold,
+                noise_gate_ratio,
+            };
+```
+
+You also need to bind `backend_row` from the panel earlier in `connect_transcript_panel`. Find where `model_row`, `silence_row`, `noise_gate_row` etc. are cloned out of the panel struct and add `backend_row` to the list:
+
+**Find:**
+
+```rust
+    let model_row = transcript.model_row.clone();
+    let silence_row = transcript.silence_row.clone();
+    let noise_gate_row = transcript.noise_gate_row.clone();
+```
+
+**Replace with:**
+
+```rust
+    let backend_row = transcript.backend_row.clone();
+    let model_row = transcript.model_row.clone();
+    let silence_row = transcript.silence_row.clone();
+    let noise_gate_row = transcript.noise_gate_row.clone();
+```
+
+Also, in the existing code that locks/unlocks rows during transcription start/stop, add `backend_row` to the disabled list. Find:
+
+```rust
+            model_row.set_sensitive(false);
+            silence_row.set_sensitive(false);
+            noise_gate_row.set_sensitive(false);
+```
+
+**Replace with:**
+
+```rust
+            backend_row.set_sensitive(false);
+            model_row.set_sensitive(false);
+            silence_row.set_sensitive(false);
+            noise_gate_row.set_sensitive(false);
+```
+
+And the corresponding re-enable in the else branch and error path:
+
+```rust
+            model_row.set_sensitive(true);
+            silence_row.set_sensitive(true);
+            noise_gate_row.set_sensitive(true);
+```
+
+**Replace with:**
+
+```rust
+            backend_row.set_sensitive(true);
+            model_row.set_sensitive(true);
+            silence_row.set_sensitive(true);
+            noise_gate_row.set_sensitive(true);
+```
+
+(There are TWO occurrences of the re-enable pattern — one in the error path on `Err(e)` and one in the `else` branch where the user toggles transcription off. Apply to both.)
+
+- [ ] **Step 3: Verify the workspace builds**
+
+```bash
+cd /data/source/rtl-sdr
+cargo build --workspace 2>&1 | tail -15
+cargo test --workspace 2>&1 | grep "test result" | tail -20
+```
+
+**Expected:** clean. All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/sidebar/transcript_panel.rs crates/sdr-ui/src/window.rs
+git commit -m "$(cat <<'EOF'
+sdr-ui: backend selector ComboRow + contextual model picker
+
+Adds an AdwComboRow above the model picker for selecting the
+transcription backend (Whisper or Sherpa). The model picker contents
+are rebuilt based on the active backend, with separate persisted
+selection indices (KEY_MODEL for Whisper, KEY_SHERPA_MODEL for
+Sherpa). The backend itself is persisted as a string under
+KEY_BACKEND.
+
+window.rs reads the backend index when starting transcription and
+constructs ModelChoice::Whisper(...) or ModelChoice::Sherpa(...)
+accordingly. Backend row is also disabled while transcription is
+active alongside the existing model/slider lockouts.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Lint, format, full workspace verify
+
+- [ ] **Step 1: Run clippy**
+
+```bash
+cd /data/source/rtl-sdr
+cargo clippy --all-targets --workspace -- -D warnings 2>&1 | tail -40
+```
+
+**Expected:** zero warnings. Common issues:
+- Unused imports — remove
+- Missing `#[must_use]` on builder methods — add
+- `cast_possible_truncation` complaints — already silenced with `#[allow]` in similar spots
+
+- [ ] **Step 2: Run fmt**
+
+```bash
+cargo fmt --all 2>&1 | tail -10
+```
+
+If anything changes, commit it.
+
+- [ ] **Step 3: Full test suite**
+
+```bash
+cargo test --workspace 2>&1 | grep "test result" | tail -25
+```
+
+**Expected:** all tests pass. `sdr-transcription` should now have ~33 tests (28 original + 3 sherpa_model + 2 sherpa backend trait = 33).
+
+- [ ] **Step 4: Make lint (deny + audit)**
+
+```bash
+make lint 2>&1 | tail -40
+```
+
+**Expected:** clean. We added `sherpa-onnx` and its transitive dependencies — `cargo deny` may flag a license or new dependency we need to allow. If so, address with the minimum config change.
+
+- [ ] **Step 5: Commit any fmt/lint fixups**
+
+```bash
+git status
+# If anything is modified:
+git add -u
+git commit -m "$(cat <<'EOF'
+sdr-transcription/sdr-ui: fmt + clippy fixups
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If `git status` is clean, skip this step.
+
+---
+
+## Task 10: Build with CUDA, hand off for manual smoke test
+
+**This task requires the user. Do not attempt to automate.**
+
+- [ ] **Step 1: Build and install with CUDA**
+
+```bash
+cd /data/source/rtl-sdr
+make install CARGO_FLAGS="--release --features cuda" 2>&1 | tail -20
+```
+
+**Expected:** clean build, binary installed.
+
+- [ ] **Step 2: Hand off to user with this script**
+
+Tell the user:
+
+> "PR 2 (sherpa spike + backend selector) is built and installed. **You need to download the Streaming Zipformer model first** since auto-download lands in PR 3.
+>
+> Run this once:
+>
+> ```bash
+> mkdir -p ~/.local/share/sdr-rs/models/sherpa
+> cd ~/.local/share/sdr-rs/models/sherpa
+> wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2
+> tar -xjf sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2
+> mv sherpa-onnx-streaming-zipformer-en-2023-06-26 streaming-zipformer-en
+> ```
+>
+> Then test:
+>
+> 1. **Verify Whisper still works** (regression check)
+>    - Launch app, enable transcription with a Whisper model on a real radio source
+>    - Confirm it transcribes as before
+>
+> 2. **Switch to Sherpa**
+>    - In the transcript panel, change the **Backend** dropdown to "Sherpa (streaming)"
+>    - The Model dropdown should now show "Streaming Zipformer (English)"
+>    - Toggle Enable Transcription on
+>    - Confirm:
+>      - Status shows "Listening..." after model load
+>      - Live transcription appears in the panel as committed (Final/Text) lines
+>      - Open the terminal/journal and look for `partial:` debug log lines — these prove the Partial events are flowing
+>    - Try a quick test phrase, then a longer one — confirm endpoint detection commits utterances at silence
+>
+> 3. **Stop / restart cycle**
+>    - Toggle transcription off — confirm clean shutdown
+>    - Switch backend back to Whisper — confirm model picker repopulates with Whisper models
+>    - Toggle transcription on with Whisper — confirm it still works
+>
+> 4. **Persistence**
+>    - Close the app while on Sherpa backend
+>    - Reopen — confirm Sherpa is still selected, model picker shows sherpa models
+>
+> 5. **CUDA validation (the unknown)**
+>    - The current SherpaBackend hardcodes `provider = "cpu"` in the worker (Task 7). For the spike, this is the path we're committing to and testing.
+>    - **Optional CUDA test:** if you want to spot-check CUDA, edit `crates/sdr-transcription/src/backends/sherpa.rs` line ~190 (`let provider = "cpu";`) to `let provider = "cuda";`, rebuild, and try the Sherpa flow again. If it crashes or errors, that tells us libsherpa wasn't built with CUDA support — document the failure and revert. **Don't commit the CUDA edit** — proper provider selection lands in a follow-up.
+>
+> Anything that crashes, hangs, or transcribes wrong is a bug we need to fix before merging."
+
+- [ ] **Step 3: Wait for user confirmation**
+
+Do NOT proceed to PR creation until the user confirms:
+- Whisper regression: still works
+- Sherpa flow: model loads, transcribes, partials in logs
+- CUDA: documented (works / doesn't work / didn't test)
+
+If anything regresses or fails, debug, fix on the same branch, and re-run the smoke test.
+
+---
+
+## Task 11: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /data/source/rtl-sdr
+git push -u origin feature/transcription-sherpa-spike
+```
+
+- [ ] **Step 2: Create the PR**
+
+Use this template, customizing the CUDA section based on what the smoke test found:
+
+```bash
+gh pr create --title "Sherpa-onnx streaming backend + UI selector (PR 2 of 5 for #204)" --body "$(cat <<'EOF'
+## Summary
+
+Adds a working `SherpaBackend` powered by the official `sherpa-onnx` Rust crate (k2-fsa, 1.12), proves streaming-native ASR works end-to-end on a real radio source with Streaming Zipformer English, and adds a UI backend selector so the user can switch between Whisper and Sherpa from the transcript panel.
+
+This is **PR 2 of 5** for #204. PR 1 (the trait refactor) made this possible.
+
+## What changed
+
+**New:**
+- `crates/sdr-transcription/src/sherpa_model.rs` — `SherpaModel` enum, directory discovery, file path helpers (mirrors `model.rs` for Whisper)
+- `crates/sdr-transcription/src/backends/sherpa.rs` — full `SherpaBackend` implementation with `OnlineRecognizer` feed loop, partial/final event emission, endpoint detection
+
+**Extended:**
+- `TranscriptionEvent::Partial { text }` — new variant emitted by streaming backends
+- `ModelChoice::Sherpa(SherpaModel)` — backend dispatch
+- `BackendError::ModelNotFound { path }` and `WrongModelKind` and `Init(String)`
+- `TranscriptionEngine::start(BackendConfig)` — signature changed to take a single config struct (was `start(WhisperModel, f32, f32)`)
+
+**UI:**
+- Backend selector `AdwComboRow` above the existing model picker
+- Model picker contents now contextual to the selected backend
+- Backend row locks during transcription alongside model + sliders
+- Persistence: `transcription_backend` (string) + `transcription_sherpa_model` (u32 index) config keys
+- `Partial` event variant routed to `tracing::debug!` for the spike (PR 4 will render proper live captions)
+
+**Dependency added:**
+- `sherpa-onnx = "1.12"` — official k2-fsa Rust bindings, statically linked, build script downloads precompiled libsherpa on first build
+
+## Spike scope notes
+
+- **Manual model download.** The user runs `wget` + `tar -xjf` once into `~/.local/share/sdr-rs/models/sherpa/streaming-zipformer-en/`. Auto-download lands in PR 3. If the directory is missing, `SherpaBackend::start` returns `BackendError::ModelNotFound { path }` with the exact expected path.
+- **Provider hardcoded to CPU.** The sherpa-onnx execution provider is `"cpu"` in the worker. CUDA validation is in the smoke test.
+- **Partials log only.** `TranscriptionEvent::Partial { text }` events go to `tracing::debug!(target: "transcription", partial = %text)` — they're not yet rendered in the UI text view. PR 4 adds the two-line live captions rendering.
+- **Single sherpa model.** Only Streaming Zipformer English ships in this PR. Parakeet (#223) and Moonshine (#224) follow.
+
+## CUDA finding
+
+(Customize this section based on smoke test results)
+
+- **CPU:** verified working on a real NFM voice channel
+- **CUDA:** [DOCUMENT WHAT THE SMOKE TEST FOUND HERE]
+
+## Test plan
+
+- [x] `cargo build --workspace` clean
+- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
+- [x] `cargo test --workspace` passes (33+ tests in sdr-transcription)
+- [x] `cargo fmt --all -- --check` clean
+- [x] `make lint` clean
+- [x] Manual: Whisper regression — still transcribes as before
+- [x] Manual: Sherpa flow — model loads, live transcription works, partials visible in tracing logs
+- [x] Manual: backend switch mid-session works, model picker repopulates correctly
+- [x] Manual: persistence across app restart for backend + sherpa model selection
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CodeRabbit review**
+
+Per project workflow: don't merge until CodeRabbit has reviewed and any inline comments are addressed.
+
+---
+
+## Done
+
+After PR 2 merges, the user has a working dual-backend transcription system. Next PRs:
+
+- **PR 3** — Auto-download for sherpa model bundles (`tar` + `bzip2-rs`, mirror Whisper UX)
+- **PR 4** — Display mode toggle + live captions two-line rendering (now smaller scope since the backend selector is already done)
+- **PR 5+** — Additional sherpa models (Parakeet, Moonshine — one PR each)

--- a/docs/superpowers/plans/2026-04-12-transcription-sherpa-spike.md
+++ b/docs/superpowers/plans/2026-04-12-transcription-sherpa-spike.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a working `SherpaBackend` powered by the official `sherpa-onnx` Rust crate, prove streaming-native ASR works end-to-end on a real radio source (Streaming Zipformer English, CPU and CUDA), and add a UI backend selector so the user can switch between Whisper and Sherpa from the transcript panel.
+**Goal:** Add a working `SherpaBackend` powered by the official `sherpa-onnx` Rust crate, prove streaming-native ASR works end-to-end on a real radio source (Streaming Zipformer English), and ship Whisper / Sherpa as **mutually exclusive cargo features** picked at build time. The original plan called for a runtime backend selector ComboRow in the UI, but we hit an unresolved heap corruption when sherpa-onnx's bundled ONNX Runtime initializes inside the sdr-rs binary. The build-time mutex sidesteps it definitively — see PR #249 for the full debugging trail.
 
-**Architecture:** New `backends/sherpa.rs` implements `TranscriptionBackend` using `sherpa_onnx::OnlineRecognizer`. The backend owns its worker thread (same pattern as `WhisperBackend`) and lives entirely on that thread to avoid the recognizer's `!Send` constraint. The `TranscriptionEngine::start` API is widened to take a `BackendConfig` directly so the UI can pick which backend to instantiate. `ModelChoice` gets a `Sherpa(SherpaModel)` variant; `TranscriptionEvent` gets a new `Partial { text }` variant. The transcript panel UI grows a backend selector `AdwComboRow` above the existing model picker, and the model picker becomes contextual to the selected backend. For this PR, partial events are routed to `tracing::debug!` only — full live-captions UI rendering lands in PR 4.
+**Architecture:** New `backends/sherpa.rs` implements `TranscriptionBackend` using `sherpa_onnx::OnlineRecognizer`. A long-lived `SherpaHost` worker thread (spawned from `main()` before `sdr_ui::run()`) owns the recognizer for the entire process lifetime; per-session `OnlineStream`s are created inside the host's event loop. The recognizer is `!Send`, so it lives entirely on the host thread; the host wraps its command sender in a `Mutex` to satisfy `OnceLock<Sync>`. The `TranscriptionEngine::start` API is widened to take a `BackendConfig` directly. `ModelChoice` and `TranscriptionEvent::Partial` variants are cfg-gated on the `whisper` / `sherpa` features. The transcript panel's model picker becomes contextual to whichever backend was compiled in, with no runtime selector. For this PR, partial events are routed to `tracing::debug!` only — full live-captions UI rendering lands in PR 4.
 
 **Tech Stack:** Rust 2024, `sherpa-onnx 1.12`, GTK4/libadwaita ComboRow + StringList, `mpsc` channels, `Arc<AtomicBool>` cancellation, `thiserror`.
 
@@ -26,7 +26,7 @@
 - `crates/sdr-transcription/src/backend.rs` — add `Sherpa(SherpaModel)` to `ModelChoice`, add `Partial { text }` to `TranscriptionEvent`, add `BackendError::ModelNotFound { path: PathBuf }` and `BackendError::WrongModelKind`
 - `crates/sdr-transcription/src/backends/whisper.rs` — `start()` returns `WrongModelKind` if a non-Whisper `ModelChoice` is passed
 - `crates/sdr-transcription/src/backends/mock.rs` — accept any `ModelChoice` (mock is testing the engine, not the backend dispatch)
-- `crates/sdr-ui/src/sidebar/transcript_panel.rs` — add `backend_row` field, build the backend selector ComboRow, swap model picker contents on backend change, persist backend + sherpa model selection
+- `crates/sdr-ui/src/sidebar/transcript_panel.rs` — model picker becomes contextual to whichever backend was compiled in; silence_threshold slider cfg-gated on `whisper` feature (Note: the original `backend_row` ComboRow design was superseded by the build-time mutex feature flag — see PR #249.)
 - `crates/sdr-ui/src/window.rs` — construct `BackendConfig` from the panel state, call new `engine.start(config)`, add `Partial { text }` match arm that routes to `tracing::debug!`
 - `crates/sdr-ui/src/dsp_controller.rs` — no changes expected (just verify nothing in the audio tap path depends on the engine API shape)
 - `Cargo.lock` — auto-updated by cargo
@@ -922,9 +922,10 @@ Find this section in `crates/sdr-ui/src/window.rs` (around line 1448-1466):
             #[allow(clippy::cast_possible_truncation)]
             let noise_gate_ratio = noise_gate_row.value() as f32;
 
-            // Build BackendConfig. For Task 6 we hardcode Whisper —
-            // Task 8 wires the backend selector ComboRow that provides
-            // ModelChoice::Sherpa(...) when the user picks it.
+            // Build BackendConfig. Backend is selected at compile time via
+            // cargo features (whisper / sherpa are mutually exclusive).
+            // Note: the original Task 8 runtime backend selector ComboRow
+            // design was superseded by the build-time mutex — see PR #249.
             let config = sdr_transcription::BackendConfig {
                 model: sdr_transcription::ModelChoice::Whisper(whisper_model),
                 silence_threshold,
@@ -1369,7 +1370,9 @@ EOF
 
 ## Task 8: Add backend selector ComboRow to the transcript panel
 
-The user-facing UI work. Adds a "Backend" `AdwComboRow` above the existing "Model" picker, swaps the model picker contents based on the selected backend, and persists both selections.
+> **Note:** The runtime backend selector ComboRow design described below was superseded by the build-time mutex feature flag (`whisper` / `sherpa` are mutually exclusive cargo features) — see PR #249. The actual shipped implementation cfg-gates the model picker and silence_threshold slider rather than adding a `backend_row` ComboRow.
+
+The original plan: Adds a "Backend" `AdwComboRow` above the existing "Model" picker, swaps the model picker contents based on the selected backend, and persists both selections.
 
 **Files:**
 - Modify: `crates/sdr-ui/src/sidebar/transcript_panel.rs`
@@ -1593,9 +1596,10 @@ In `crates/sdr-ui/src/window.rs`, find the section (in `connect_transcript_panel
             #[allow(clippy::cast_possible_truncation)]
             let noise_gate_ratio = noise_gate_row.value() as f32;
 
-            // Build BackendConfig. For Task 6 we hardcode Whisper —
-            // Task 8 wires the backend selector ComboRow that provides
-            // ModelChoice::Sherpa(...) when the user picks it.
+            // Build BackendConfig. Backend is selected at compile time via
+            // cargo features (whisper / sherpa are mutually exclusive).
+            // Note: the original Task 8 runtime backend selector ComboRow
+            // design was superseded by the build-time mutex — see PR #249.
             let config = sdr_transcription::BackendConfig {
                 model: sdr_transcription::ModelChoice::Whisper(whisper_model),
                 silence_threshold,
@@ -1873,7 +1877,7 @@ Use this template, customizing the CUDA section based on what the smoke test fou
 gh pr create --title "Sherpa-onnx streaming backend + UI selector (PR 2 of 5 for #204)" --body "$(cat <<'EOF'
 ## Summary
 
-Adds a working `SherpaBackend` powered by the official `sherpa-onnx` Rust crate (k2-fsa, 1.12), proves streaming-native ASR works end-to-end on a real radio source with Streaming Zipformer English, and adds a UI backend selector so the user can switch between Whisper and Sherpa from the transcript panel.
+Adds a working `SherpaBackend` powered by the official `sherpa-onnx` Rust crate (k2-fsa, 1.12), proves streaming-native ASR works end-to-end on a real radio source with Streaming Zipformer English. Ships Whisper and Sherpa as mutually exclusive build-time cargo features rather than a runtime backend selector (the original design was superseded — see PR #249 for details on the heap corruption that motivated the build-time mutex approach).
 
 This is **PR 2 of 5** for #204. PR 1 (the trait refactor) made this possible.
 
@@ -1890,10 +1894,9 @@ This is **PR 2 of 5** for #204. PR 1 (the trait refactor) made this possible.
 - `TranscriptionEngine::start(BackendConfig)` — signature changed to take a single config struct (was `start(WhisperModel, f32, f32)`)
 
 **UI:**
-- Backend selector `AdwComboRow` above the existing model picker
-- Model picker contents now contextual to the selected backend
-- Backend row locks during transcription alongside model + sliders
-- Persistence: `transcription_backend` (string) + `transcription_sherpa_model` (u32 index) config keys
+- Model picker contents contextual to whichever backend was compiled in (no runtime selector — superseded by build-time mutex, see PR #249)
+- Silence threshold slider cfg-gated on `whisper` feature (Sherpa uses native endpoint detection)
+- Persistence: `transcription_sherpa_model` (u32 index) config key for Sherpa builds
 - `Partial` event variant routed to `tracing::debug!` for the spike (PR 4 will render proper live captions)
 
 **Dependency added:**
@@ -1922,8 +1925,8 @@ This is **PR 2 of 5** for #204. PR 1 (the trait refactor) made this possible.
 - [x] `make lint` clean
 - [x] Manual: Whisper regression — still transcribes as before
 - [x] Manual: Sherpa flow — model loads, live transcription works, partials visible in tracing logs
-- [x] Manual: backend switch mid-session works, model picker repopulates correctly
-- [x] Manual: persistence across app restart for backend + sherpa model selection
+- [x] Manual: Sherpa flow — model loads, live transcription works, partials visible in tracing logs (Note: runtime backend switch test N/A — design superseded by build-time mutex)
+- [x] Manual: persistence across app restart for sherpa model selection
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
@@ -1941,5 +1944,5 @@ Per project workflow: don't merge until CodeRabbit has reviewed and any inline c
 After PR 2 merges, the user has a working dual-backend transcription system. Next PRs:
 
 - **PR 3** — Auto-download for sherpa model bundles (`tar` + `bzip2-rs`, mirror Whisper UX)
-- **PR 4** — Display mode toggle + live captions two-line rendering (now smaller scope since the backend selector is already done)
+- **PR 4** — Display mode toggle + live captions two-line rendering
 - **PR 5+** — Additional sherpa models (Parakeet, Moonshine — one PR each)

--- a/docs/superpowers/plans/2026-04-12-transcription-sherpa-spike.md
+++ b/docs/superpowers/plans/2026-04-12-transcription-sherpa-spike.md
@@ -1793,7 +1793,7 @@ If `git status` is clean, skip this step.
 
 ```bash
 cd /data/source/rtl-sdr
-make install CARGO_FLAGS="--release --features cuda" 2>&1 | tail -20
+make install CARGO_FLAGS="--release --features whisper-cuda" 2>&1 | tail -20
 ```
 
 **Expected:** clean build, binary installed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,13 +23,9 @@ fn main() -> glib::ExitCode {
     }
     tracing::info!("sdr-rs starting");
 
-    // Initialize the sherpa-onnx host BEFORE GTK is loaded. The host's
-    // worker thread creates the OnlineRecognizer which initializes ONNX
-    // Runtime's C++ runtime state. Doing this before sdr_ui::run() (which
-    // loads GTK4 and its transitive C++ deps) avoids a static-initializer
-    // collision that causes free() corruption inside libstdc++ regex code.
-    // If init fails (e.g. model files not downloaded), the failure is
-    // stashed and reported in-app when the user toggles Sherpa on.
+    // Initialize the sherpa-onnx host BEFORE GTK is loaded.
+    // Only present in builds with the `sherpa` feature.
+    #[cfg(feature = "sherpa")]
     sdr_transcription::init_sherpa_host(sdr_transcription::SherpaModel::StreamingZipformerEn);
 
     sdr_ui::run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,5 +22,15 @@ fn main() -> glib::ExitCode {
         tracing::warn!("mallopt(M_ARENA_MAX, 4) failed — arena cap not applied");
     }
     tracing::info!("sdr-rs starting");
+
+    // Initialize the sherpa-onnx host BEFORE GTK is loaded. The host's
+    // worker thread creates the OnlineRecognizer which initializes ONNX
+    // Runtime's C++ runtime state. Doing this before sdr_ui::run() (which
+    // loads GTK4 and its transitive C++ deps) avoids a static-initializer
+    // collision that causes free() corruption inside libstdc++ regex code.
+    // If init fails (e.g. model files not downloaded), the failure is
+    // stashed and reported in-app when the user toggles Sherpa on.
+    sdr_transcription::init_sherpa_host(sdr_transcription::SherpaModel::StreamingZipformerEn);
+
     sdr_ui::run()
 }


### PR DESCRIPTION
## Summary

Adds a working `SherpaBackend` for the official `sherpa-onnx` Rust crate (k2-fsa, 1.12.36), powered by Streaming Zipformer English. **Whisper and Sherpa are mutually exclusive cargo features** — pick one at install time. This is **PR 2 of 5** for #204.

The backend selector ComboRow and runtime switching from the original PR 2 design have been removed in favor of a build-time mutex (see Architecture Note below). The trait abstraction from PR 1 is unchanged — when upstream sherpa-onnx ships a fix for the heap corruption we hit, deleting the cfg gates will let both backends coexist again. ~10-line cleanup.

## Architecture note: why a build-time mutex

Days of debugging revealed an unresolved heap corruption: when sherpa-onnx's bundled ONNX Runtime initializes inside the sdr-rs binary, `OnlineRecognizer::create` crashes with `free(): invalid pointer` inside `std::regex` constructors called by ONNX Runtime's `ParseSemVerVersion`. The same code path works perfectly in isolation (verified with a minimal reproduction that links every C++ dep sdr-rs uses). We could not isolate which library is causing the conflict.

What we tried:
- Locale fixes (`LC_ALL=C`)
- Disabling LTO
- Disabling strip
- Eager warmup before GTK init
- Long-lived host worker thread spawned before `sdr_ui::run()`
- Building a minimal repro with **every** sdr-rs dep including pipewire, gtk4, libadwaita, whisper-rs/cuda, rustfft, tracing-subscriber, dbus, libusb, keyring, reqwest, chrono — all worked
- gdb backtrace showing the exact crash site (in `std::__detail::_Compiler<std::regex_traits<char>>::_Compiler` → `ParseSemVerVersion` → `CreateEpDevice` → `CpuEpFactory::GetSupportedDevices` → `Environment::Initialize` → `OrtApis::CreateEnv`)

Decision: ship the backends as **mutually exclusive cargo features**. The user picks one at install time. They never coexist in a binary, so the heap conflict cannot happen. When the upstream interaction is understood (or fixed in a newer sherpa-onnx release), reverting to runtime selection is a small follow-up.

## Build commands

```bash
# Whisper backend (default — current behavior)
make install CARGO_FLAGS=\"--release --features whisper-cuda\"      # NVIDIA
make install CARGO_FLAGS=\"--release --features whisper-hipblas\"   # AMD ROCm
make install CARGO_FLAGS=\"--release --features whisper-vulkan\"    # Cross-vendor
make install CARGO_FLAGS=\"--release --features whisper-metal\"     # Apple
make install CARGO_FLAGS=\"--release\"                                # Whisper CPU (default)

# Sherpa backend (CPU only — GPU support tracked separately)
make install CARGO_FLAGS=\"--release --no-default-features --features sherpa-cpu\"
```

Trying to enable both produces a clear `compile_error!` telling the user to pick one.

## What changed

**New code:**
- `crates/sdr-transcription/src/sherpa_model.rs` — `SherpaModel` enum, directory discovery, file path helpers (mirrors Whisper's `model.rs`)
- `crates/sdr-transcription/src/backends/sherpa.rs` — full `SherpaBackend` implementation with `OnlineRecognizer` feed loop, partial/final event emission, endpoint detection, and a long-lived `SherpaHost` worker thread that owns the recognizer for the process lifetime

**Type system extensions** (`backend.rs`):
- `TranscriptionEvent::Partial { text }` — new variant emitted by streaming backends; routed to `tracing::debug!` in this PR (full UI rendering lands in PR 4)
- `ModelChoice::Sherpa(SherpaModel)` variant
- `BackendError::ModelNotFound { path }`, `WrongModelKind`, `Init(String)`

**Engine API**:
- `TranscriptionEngine::start(BackendConfig)` now takes a single config struct instead of `(WhisperModel, f32, f32)`. Cleaner forward-looking shape.

**Mutex feature flags** — the key architectural decision:
- Two internal cfg flags: `whisper`, `sherpa` (mutually exclusive via `compile_error!` in lib.rs)
- Eight user-facing build targets:
  - `whisper-cpu` (default), `whisper-cuda`, `whisper-hipblas`, `whisper-vulkan`, `whisper-metal`, `whisper-intel-sycl`, `whisper-openblas`
  - `sherpa-cpu`
- All `WhisperBackend` / `SherpaBackend` / model types / engine match arms are cfg-gated

**UI changes**:
- The transcript panel's model picker is now backend-aware: title shows \"Whisper Model\" or \"Sherpa Model\" based on the active build, model dropdown shows the appropriate set
- Backend selector ComboRow removed (no runtime choice)
- Persistence keys stay separate (`transcription_model` for Whisper, `transcription_sherpa_model` for Sherpa) so a future re-unification keeps state

**`src/main.rs`**:
- Cfg-gated `init_sherpa_host(SherpaModel::StreamingZipformerEn)` call before `sdr_ui::run()` — the host worker thread is spawned at startup so the recognizer is ready immediately when the user toggles transcription on

## Sherpa model setup (manual for now)

Auto-download lands in PR 3. For this spike, the user runs once:

```bash
mkdir -p ~/.local/share/sdr-rs/models/sherpa
cd ~/.local/share/sdr-rs/models/sherpa
wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2
tar -xjf sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2
mv sherpa-onnx-streaming-zipformer-en-2023-06-26 streaming-zipformer-en
```

Sherpa builds report `BackendError::ModelNotFound` with the exact expected directory if files are missing.

## CUDA story for Sherpa

Out of scope for PR 2 — `sherpa-onnx-sys` 1.12.36 doesn't expose a CUDA feature flag like the deprecated `sherpa-rs` did. The provider is hardcoded to `\"cpu\"` in `SherpaHost`. Investigation notes: setting `model_config.provider = Some(\"cuda\".to_owned())` is the API hook, but the prebuilt libsherpa archive that `sherpa-onnx-sys` downloads needs to be built with CUDA support, which the upstream releases may or may not provide. Tracked for a follow-up.

## Test plan

- [x] `cargo build --workspace` clean (default whisper-cpu)
- [x] `cargo build --workspace --features whisper-cuda` clean
- [x] `cargo build --workspace --no-default-features --features sherpa-cpu` clean
- [x] `cargo build --workspace --features whisper-cuda,sherpa-cpu` produces the expected `compile_error!`
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (both build configurations)
- [x] `cargo test --workspace` passes (both build configurations — 585 tests in workspace, 35 in sdr-transcription)
- [x] `cargo fmt --all -- --check` clean
- [x] `make lint` clean
- [x] **Manual: Whisper smoke test** (whisper-cuda build) — verified Whisper transcribes a real radio source identically to before
- [x] **Manual: Sherpa smoke test** (sherpa-cpu build) — verified Sherpa transcribes a real radio source with Streaming Zipformer (the milestone after days of debugging)

## Spec/plan deviations

- **Backend selector ComboRow removed.** Original Task 8 added it to support runtime backend switching. The mutex feature flag refactor made it pointless (no choice to make at runtime), so it's gone. The contextual model picker logic stays.
- **`Partial` event UI rendering deferred to PR 4.** This PR routes `Partial` events to `tracing::debug!` only. Full live captions two-line rendering lands in PR 4 alongside the display mode toggle.
- **CUDA for Sherpa deferred.** Hardcoded CPU. See note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sherpa streaming ASR backend added; Whisper remains available with selectable backends (default: Whisper CPU)

* **Streaming**
  * Partial transcription events for live interim updates

* **Bug Fixes / Reliability**
  * Clearer initialization and model-missing errors; more robust host startup and improved wall-clock timestamps

* **UI**
  * Model selector and controls adapt to the compiled backend and persist selections per-backend; error conditions are surfaced and controls reset

* **Documentation**
  * Install/build docs updated to use new whisper-*/sherpa-* feature names

* **Tests**
  * New unit and integration tests covering Sherpa init, model utilities, and partial support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->