### PR TITLE
fix: sherpa-cpu build broken after sdr-core extraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,19 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow.workspace = true
 
 [features]
-# Default Linux build = GTK frontend + Whisper-CPU transcription backend.
-# On macOS / Windows the `gtk-frontend` feature is enabled but does nothing
-# (sdr-ui is a target-conditional optional dep that only resolves on Linux),
-# so `cargo build` produces just the stub `main()` from src/main.rs that
-# points users at the macOS app issue. The Whisper-CPU backend still
-# compiles via sdr-transcription, which is cross-platform.
-default = ["whisper-cpu", "gtk-frontend"]
+# Default Linux build = Whisper-CPU transcription backend with the GTK
+# frontend. The `gtk-frontend` feature is implied by every user-facing
+# transcription feature (whisper-* / sherpa-cpu) so users don't have to
+# remember to enable it explicitly when overriding defaults — i.e.
+# `cargo build --no-default-features --features sherpa-cpu` Just Works
+# instead of falling through to the no-frontend stub main.
+#
+# On macOS / Windows, `gtk-frontend` activates `dep:sdr-ui` which is a
+# target-conditional optional dep that only resolves on Linux, so the
+# activation is silently a no-op and `cargo build` produces just the
+# stub `main()` from src/main.rs that points users at the macOS app.
+# The transcription crate is cross-platform and still compiles.
+default = ["whisper-cpu"]
 
 # Pulls sdr-ui into the binary on Linux. On other targets the `dep:` is
 # a no-op because sdr-ui is gated to `[target.'cfg(target_os = "linux")']`
@@ -53,19 +59,21 @@ sherpa = ["sdr-transcription/sherpa", "sdr-ui?/sherpa"]
 
 # User-facing build targets. Pick exactly one. Whisper and Sherpa are
 # mutually exclusive at the source level (see compile_error in
-# crates/sdr-transcription/src/lib.rs).
+# crates/sdr-transcription/src/lib.rs). Each implies `gtk-frontend` so
+# the user gets a working GTK build with a single feature flag, with
+# no need for `--features sherpa-cpu,gtk-frontend` etc.
 #
 # Whisper backend with various accelerator backends:
-whisper-cpu = ["whisper", "sdr-transcription/whisper-cpu", "sdr-ui?/whisper-cpu"]
-whisper-cuda = ["whisper", "sdr-transcription/whisper-cuda", "sdr-ui?/whisper-cuda"]
-whisper-hipblas = ["whisper", "sdr-transcription/whisper-hipblas", "sdr-ui?/whisper-hipblas"]
-whisper-vulkan = ["whisper", "sdr-transcription/whisper-vulkan", "sdr-ui?/whisper-vulkan"]
-whisper-metal = ["whisper", "sdr-transcription/whisper-metal", "sdr-ui?/whisper-metal"]
-whisper-intel-sycl = ["whisper", "sdr-transcription/whisper-intel-sycl", "sdr-ui?/whisper-intel-sycl"]
-whisper-openblas = ["whisper", "sdr-transcription/whisper-openblas", "sdr-ui?/whisper-openblas"]
+whisper-cpu = ["whisper", "gtk-frontend", "sdr-transcription/whisper-cpu", "sdr-ui?/whisper-cpu"]
+whisper-cuda = ["whisper", "gtk-frontend", "sdr-transcription/whisper-cuda", "sdr-ui?/whisper-cuda"]
+whisper-hipblas = ["whisper", "gtk-frontend", "sdr-transcription/whisper-hipblas", "sdr-ui?/whisper-hipblas"]
+whisper-vulkan = ["whisper", "gtk-frontend", "sdr-transcription/whisper-vulkan", "sdr-ui?/whisper-vulkan"]
+whisper-metal = ["whisper", "gtk-frontend", "sdr-transcription/whisper-metal", "sdr-ui?/whisper-metal"]
+whisper-intel-sycl = ["whisper", "gtk-frontend", "sdr-transcription/whisper-intel-sycl", "sdr-ui?/whisper-intel-sycl"]
+whisper-openblas = ["whisper", "gtk-frontend", "sdr-transcription/whisper-openblas", "sdr-ui?/whisper-openblas"]
 
 # Sherpa backend (CPU only for now — GPU support tracked separately):
-sherpa-cpu = ["sherpa", "sdr-transcription/sherpa-cpu", "sdr-ui?/sherpa-cpu"]
+sherpa-cpu = ["sherpa", "gtk-frontend", "sdr-transcription/sherpa-cpu", "sdr-ui?/sherpa-cpu"]
 
 # GTK frontend stack — Linux only. The `sdr` binary on non-Linux targets
 # falls back to a stub `main()` (see src/main.rs) that prints a message

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,16 @@
 // The `sdr` binary is the GTK4 + libadwaita frontend, which is currently
-// Linux-only. On non-Linux platforms (macOS, Windows) we provide a stub
-// `main()` that prints a message and exits non-zero so the workspace still
-// builds end-to-end on every platform without surprising linker failures.
-// The macOS native frontend lives in `apps/macos/` (SwiftUI) and runs
-// against the `sdr-core` engine via the `sdr-ffi` C ABI.
+// Linux-only and gated behind the `gtk-frontend` cargo feature. On
+// non-Linux platforms (macOS, Windows) — or on Linux without the
+// `gtk-frontend` feature — we provide a stub `main()` that prints a
+// message and exits non-zero so the workspace still builds end-to-end
+// on every platform without surprising linker failures. The macOS
+// native frontend lives in `apps/macos/` (SwiftUI) and runs against
+// the `sdr-core` engine via the `sdr-ffi` C ABI.
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "gtk-frontend"))]
 use gtk4::glib;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "gtk-frontend"))]
 fn main() -> glib::ExitCode {
     // Limit glibc malloc arenas before any threads spawn.
     // Without this, glibc creates up to 8*cores arenas that each keep
@@ -40,13 +42,14 @@ fn main() -> glib::ExitCode {
     sdr_ui::run()
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(any(not(target_os = "linux"), not(feature = "gtk-frontend")))]
 fn main() -> std::process::ExitCode {
     eprintln!("sdr-rs: the GTK4 frontend is currently Linux-only.");
     eprintln!();
     eprintln!("macOS support via a native SwiftUI app is in progress");
     eprintln!("(see https://github.com/jasonherald/rtl-sdr/issues/228).");
     eprintln!();
-    eprintln!("On Linux, install GTK4 + libadwaita and run `cargo run --release`.");
+    eprintln!("On Linux, install GTK4 + libadwaita and run `cargo run --release`");
+    eprintln!("(the `gtk-frontend` feature is enabled by default).");
     std::process::ExitCode::from(1)
 }


### PR DESCRIPTION
## Summary

PR #251 (sdr-core extraction) made the GTK frontend optional via a new `gtk-frontend` cargo feature. The default features were updated to `[\"whisper-cpu\", \"gtk-frontend\"]` so the standard build still works, but `--no-default-features --features sherpa-cpu` no longer pulls in `gtk-frontend`, leaving \`src/main.rs\`'s \`sdr_ui::run()\` call referencing an unlinked crate. The sherpa build was broken on \`main\`.

This is a one-commit fix that does two things:

## Changes

**1. \`Cargo.toml\` — make \`gtk-frontend\` implicit in every transcription feature.**

Every user-facing transcription feature (\`whisper-cpu\`, \`whisper-cuda\`, \`whisper-hipblas\`, \`whisper-vulkan\`, \`whisper-metal\`, \`whisper-intel-sycl\`, \`whisper-openblas\`, \`sherpa-cpu\`) now pulls in \`gtk-frontend\` automatically. The \`default\` feature list collapses from \`[\"whisper-cpu\", \"gtk-frontend\"]\` to just \`[\"whisper-cpu\"]\` since the rest follows transitively.

User-facing benefit: a single \`--features sherpa-cpu\` produces a working GTK build instead of falling through to the no-frontend stub. No need for users to remember \`--features sherpa-cpu,gtk-frontend\`.

**2. \`src/main.rs\` — cfg-gate the Linux \`fn main()\` on \`gtk-frontend\`.**

The \`#[cfg(target_os = \"linux\")] fn main()\` is now \`#[cfg(all(target_os = \"linux\", feature = \"gtk-frontend\"))]\`. The non-Linux fallback stub also fires when Linux is built without \`gtk-frontend\`, so the binary compiles cleanly even if someone explicitly disables the frontend (e.g. for a future headless CLI variant).

## Why no source changes to \`sdr-ui\` / \`sdr-core\` / \`sdr-transcription\`

The extraction in #251 was clean — the only thing that broke was the build matrix, not the runtime logic. The transcription stack from PR #249 (mutex feature flags, SherpaHost, etc.) all works unchanged on top of the new \`sdr-core\` layer.

## macOS interaction

Verified the cross-platform story stays intact: on macOS, \`gtk-frontend\` activates \`dep:sdr-ui\` which is a target-conditional optional dep (\`[target.'cfg(target_os = \"linux\")']\`), so the activation is silently a no-op and \`cargo build\` produces the stub \`main()\` from \`src/main.rs\` that points users at the macOS app issue. The transcription crate remains cross-platform.

## Test plan

- [x] \`cargo build --workspace\` (default \`whisper-cpu\`) — clean
- [x] \`cargo build --workspace --no-default-features --features sherpa-cpu\` — clean (was broken on \`main\`)
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` (both configurations) — clean
- [x] \`cargo test --workspace\` — 34 test suites passing in both configurations
- [x] Manual: \`make install CARGO_FLAGS=\"--release --features whisper-cuda\"\` — Whisper transcription works end-to-end on real radio audio
- [x] Manual: \`make install CARGO_FLAGS=\"--release --no-default-features --features sherpa-cpu\"\` — Sherpa transcription works end-to-end on real radio audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured how the graphical interface is bundled with transcription features, making it possible to build without the GUI on Linux when needed.
  * Transcription backends now include the graphical interface by default on supported platforms for better out-of-the-box functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->