### PR TITLE
sdr-sink-audio: CoreAudio AUHAL backend for macOS (M3, #231)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16dd574a72a021b90c7656c474ea31d11a2f0366a8eff574186e761e0b9e3586"
+dependencies = [
+ "bitflags",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +298,16 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -1264,6 +1288,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1919,7 @@ dependencies = [
 name = "sdr-sink-audio"
 version = "0.1.0"
 dependencies = [
+ "coreaudio-rs",
  "pipewire",
  "sdr-config",
  "sdr-pipeline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,11 @@ rusb = "0.9"
 # Audio (PipeWire on Linux)
 pipewire = "0.9"
 
+# Audio (CoreAudio / AUHAL on macOS). Spec called for 0.12, but 0.14 is
+# the current maintained release; same surface, no breaking changes that
+# affect us.
+coreaudio-rs = "0.14"
+
 # WAV files
 hound = "3"
 

--- a/crates/sdr-core/Cargo.toml
+++ b/crates/sdr-core/Cargo.toml
@@ -35,13 +35,17 @@ thiserror.workspace = true
 tracing.workspace = true
 bytemuck.workspace = true
 
-# Audio sink: pulled in with the right backend feature per target_os.
-# On Linux we want PipeWire; on macOS we want CoreAudio. Without these
-# target-conditional overrides, the workspace baseline build would fall
-# through to the no-backend stub. The stub still exists for unusual
-# build configurations (e.g., Windows, or macOS+Linux cross-builds
-# with no default features) — see the cfg dispatch in
-# crates/sdr-sink-audio/src/lib.rs.
+# Audio sink. The base dep is unconditional so `controller.rs`'s
+# `use sdr_sink_audio::AudioSink;` resolves on every target — including
+# Windows / BSD / etc. that fall through to the no-backend stub. The
+# target-specific entries below ADD the right backend feature on Linux
+# (PipeWire) and macOS (CoreAudio); Cargo merges per-target dep entries
+# into the base dep, so on Linux the effective entry is
+# `sdr-sink-audio = { ..., features = ["pipewire"] }`, on macOS it's
+# `["coreaudio"]`, and on every other target the feature list is empty
+# and the crate's `lib.rs` cfg dispatch resolves to the stub backend.
+sdr-sink-audio.workspace = true
+
 [target.'cfg(target_os = "linux")'.dependencies]
 sdr-sink-audio = { workspace = true, features = ["pipewire"] }
 

--- a/crates/sdr-core/Cargo.toml
+++ b/crates/sdr-core/Cargo.toml
@@ -30,11 +30,23 @@ sdr-rtlsdr.workspace = true
 sdr-source-rtlsdr.workspace = true
 sdr-source-network.workspace = true
 sdr-source-file.workspace = true
-sdr-sink-audio.workspace = true
 sdr-sink-network.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 bytemuck.workspace = true
+
+# Audio sink: pulled in with the right backend feature per target_os.
+# On Linux we want PipeWire; on macOS we want CoreAudio. Without these
+# target-conditional overrides, the workspace baseline build would fall
+# through to the no-backend stub. The stub still exists for unusual
+# build configurations (e.g., Windows, or macOS+Linux cross-builds
+# with no default features) — see the cfg dispatch in
+# crates/sdr-sink-audio/src/lib.rs.
+[target.'cfg(target_os = "linux")'.dependencies]
+sdr-sink-audio = { workspace = true, features = ["pipewire"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+sdr-sink-audio = { workspace = true, features = ["coreaudio"] }
 
 [lints]
 workspace = true

--- a/crates/sdr-sink-audio/Cargo.toml
+++ b/crates/sdr-sink-audio/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [features]
 default = []
 pipewire = ["dep:pipewire"]
+coreaudio = ["dep:coreaudio-rs"]
 
 [dependencies]
 sdr-types.workspace = true
@@ -17,6 +18,13 @@ sdr-config.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 pipewire = { workspace = true, optional = true }
+
+# CoreAudio is a macOS-only system framework. Declared at the workspace
+# level (root Cargo.toml), pulled in here only on macOS so a Linux build
+# never tries to bind to a non-existent framework even if the `coreaudio`
+# feature is somehow flipped on by mistake.
+[target.'cfg(target_os = "macos")'.dependencies]
+coreaudio-rs = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/sdr-sink-audio/src/coreaudio_impl.rs
+++ b/crates/sdr-sink-audio/src/coreaudio_impl.rs
@@ -225,19 +225,35 @@ impl AudioSink {
         unit.set_stream_format(format, Scope::Input, Element::Output)
             .map_err(|e| SinkError::OpenFailed(format!("set_stream_format: {e}")))?;
 
-        // Register the render callback. The callback captures an Arc to
-        // the ring buffer plus a heap-allocated scratch buffer used to
-        // de-interleave samples for each quantum. The scratch buffer is
-        // allocated **here** (the cold start path) and reused for the
-        // lifetime of the AudioUnit — the audio I/O thread never
-        // allocates. Ring buffer reads are non-blocking via `try_lock`
-        // so contention with the writer never blocks the callback
-        // thread either.
+        // Register the render callback. The callback captures three
+        // pieces of state by move:
+        //
+        //   1. `ring_for_cb`: Arc clone of the audio ring buffer.
+        //      Reads are non-blocking via `try_lock` so contention with
+        //      the producer never blocks the audio I/O thread.
+        //
+        //   2. `scratch_buf`: a heap-allocated de-interleave scratch
+        //      buffer, allocated **here** (the cold start path) and
+        //      reused for the lifetime of the AudioUnit. The audio I/O
+        //      thread never allocates.
+        //
+        //   3. `overflow_warned`: a one-shot atomic flag used by
+        //      `render_callback_body` to throttle the "render quantum
+        //      exceeded scratch buffer" warning to exactly **one log
+        //      line per sink lifetime**. Without this, a device whose
+        //      quantum is consistently above MAX_CB_FRAMES would
+        //      generate hundreds of `tracing::warn!` calls per second
+        //      from the RT thread — turning the silence fallback into
+        //      its own dropout source. The flag resets on every
+        //      `start()` call (because a fresh closure is constructed)
+        //      so users who fix their device config and restart get a
+        //      fresh warning if the issue recurs.
         let ring_for_cb = Arc::clone(&self.ring);
         let mut scratch_buf: Vec<f32> = vec![0.0; MAX_CB_FRAMES * 2];
+        let overflow_warned = AtomicBool::new(false);
         unit.set_render_callback(
             move |args: render_callback::Args<data::NonInterleaved<f32>>| {
-                render_callback_body(&ring_for_cb, &mut scratch_buf, args);
+                render_callback_body(&ring_for_cb, &overflow_warned, &mut scratch_buf, args);
                 // The inner function is infallible by construction —
                 // every code path in it writes silence on degraded
                 // quanta rather than returning an error. The Result
@@ -350,13 +366,16 @@ impl Sink for AudioSink {
 /// closure (allocated once at sink construction) and passed in by
 /// `&mut`. The callback uses `scratch.len() / 2` as the per-quantum
 /// frame ceiling; if a single quantum exceeds it, the callback writes
-/// silence to both channels and emits a `tracing` warning rather than
-/// growing the scratch on the audio thread. Heap allocation on the
-/// CoreAudio render thread can block on the system allocator and miss
-/// a deadline; silence is the correct safe degradation. Debug builds
-/// also `debug_assert!` so the overflow path fires loudly during dev.
+/// silence to both channels and emits a `tracing` warning **at most
+/// once per sink lifetime** (gated by the `overflow_warned` atomic)
+/// rather than growing the scratch on the audio thread. Heap
+/// allocation on the CoreAudio render thread can block on the system
+/// allocator and miss a deadline; silence is the correct safe
+/// degradation. Debug builds also `debug_assert!` so the overflow
+/// path fires loudly during dev.
 fn render_callback_body(
     ring: &AudioRingBuffer,
+    overflow_warned: &AtomicBool,
     scratch: &mut [f32],
     mut args: render_callback::Args<data::NonInterleaved<f32>>,
 ) {
@@ -386,14 +405,26 @@ fn render_callback_body(
     );
 
     if frames > max_frames {
-        // Release-build degradation: write silence to both channels and
-        // log once. Cannot allocate on the RT thread; cannot panic on
-        // the RT thread either. Silence is the correct safe fallback.
-        tracing::warn!(
-            frames,
-            max_frames,
-            "CoreAudio render quantum exceeded scratch buffer; rendering silence"
-        );
+        // Release-build degradation: write silence to both channels.
+        // Emit the warning at most ONCE per sink lifetime via the
+        // `overflow_warned` flag — without this gate the warning would
+        // fire on every oversized quantum from the RT thread, which
+        // would itself become a dropout source (each tracing::warn! is
+        // a syscall + format work). Once-per-lifetime means the user
+        // sees the issue, observes the silence symptom, and has the
+        // info to act; the `start()` path constructs a fresh atomic
+        // so a stop-and-restart after fixing the device gets a fresh
+        // warning if the issue recurs.
+        //
+        // `swap(true)` is a single atomic write — Relaxed is fine
+        // because we don't need to synchronize anything else.
+        if !overflow_warned.swap(true, Ordering::Relaxed) {
+            tracing::warn!(
+                frames,
+                max_frames,
+                "CoreAudio render quantum exceeded scratch buffer; rendering silence (further occurrences will be silenced)"
+            );
+        }
         for v in left.iter_mut().take(frames) {
             *v = 0.0;
         }

--- a/crates/sdr-sink-audio/src/coreaudio_impl.rs
+++ b/crates/sdr-sink-audio/src/coreaudio_impl.rs
@@ -647,10 +647,21 @@ pub fn list_audio_sinks() -> Vec<AudioDevice> {
 
     let default_id = get_default_device_id(false);
 
-    let Ok(all_ids) = get_audio_device_ids_for_scope(Scope::Global) else {
-        // Could not enumerate — return just the default entry. The
-        // caller can still route audio.
-        return sinks;
+    let all_ids = match get_audio_device_ids_for_scope(Scope::Global) {
+        Ok(ids) => ids,
+        Err(err) => {
+            // Could not enumerate. Return just the default entry —
+            // the caller can still route audio to system default —
+            // but log the failure so CI / user reports can tell the
+            // difference between "no other devices attached" and
+            // "CoreAudio enumeration broke."
+            tracing::warn!(
+                error = ?err,
+                "list_audio_sinks: get_audio_device_ids_for_scope(Global) failed; \
+                 returning only the system default entry"
+            );
+            return sinks;
+        }
     };
 
     for device_id in all_ids {

--- a/crates/sdr-sink-audio/src/coreaudio_impl.rs
+++ b/crates/sdr-sink-audio/src/coreaudio_impl.rs
@@ -21,11 +21,15 @@
 //!   the high-level [`coreaudio::audio_unit::AudioUnit`] wrapper.
 //! - Format: 48 kHz f32 stereo, **non-interleaved** — the canonical
 //!   format for Mac AudioUnits per Apple's *Core Audio Overview*.
-//! - The render callback **never allocates**: it uses a stack scratch
-//!   buffer sized for `MAX_CB_FRAMES = 4096` and degrades to silence on
-//!   overflow rather than falling back to the heap. CoreAudio quanta are
-//!   typically 256–512 frames; 4096 is generous headroom for aggregate
-//!   or pro-audio devices.
+//! - The render callback **never allocates**. The de-interleave scratch
+//!   buffer is a single `Vec<f32>` allocated **once** in `open_unit()`
+//!   on the cold start path (sized to `MAX_CB_FRAMES * 2` f32s) and
+//!   moved into the render closure by value. The callback reuses that
+//!   buffer for the lifetime of the AudioUnit and degrades to silence
+//!   on quanta larger than `MAX_CB_FRAMES` rather than growing the
+//!   buffer on the audio I/O thread. CoreAudio quanta are typically
+//!   256–512 frames; 4096 is generous headroom for aggregate or
+//!   pro-audio devices.
 //!
 //! ## Public surface parity with `pw_impl`
 //!
@@ -45,18 +49,30 @@
 //! `CFString → String` conversion plus an `#[allow(unsafe_code)]`
 //! override of the workspace-wide deny.
 //!
-//! For **v1** we use the device *display name* as `node_name` instead.
-//! This is a v1-only deviation because:
+//! For **v1** we use the **`AudioDeviceID` as a decimal string** instead
+//! of the UID. The ID is unique within the running session — even when
+//! multiple devices share the same display name (e.g., several "USB
+//! Audio CODEC" devices, multiple AirPlay endpoints) — so it's the
+//! right opaque handle for `set_target` selection. The downside is
+//! that AudioDeviceIDs are session-scoped: they don't survive reboots,
+//! plug events, or `coreaudiod` restarts. v2 (issue #237) switches to
+//! the stable CoreAudio device UID at the same time the device picker
+//! lands; until then, the v1 contract works because:
 //!
-//! - The MVP UI does not expose an audio device picker (deferred to v2,
-//!   issue #237). `set_target` is implemented but never called from any
-//!   v1 caller — `node_name` is essentially unused metadata.
-//! - Switching to UID is a clean follow-up: one `unsafe` helper that
-//!   wraps `AudioObjectGetPropertyData(kAudioDevicePropertyDeviceUID, …)`,
-//!   landing alongside the v2 device picker in #237.
+//! - The MVP UI does not expose a persistent device picker (deferred
+//!   to v2). v1 only ever uses the empty-string "system default
+//!   output" path; `set_target` is implemented for completeness and
+//!   for any out-of-tree caller that wants session-scoped routing.
+//! - The "Default" entry (empty `node_name`) is always available and
+//!   resolves through `get_default_device_id` instead of an ID parse,
+//!   so the default-output path is unaffected by the session-scoped
+//!   restriction.
 //!
-//! Documenting this here so the next reviewer doesn't have to re-derive
-//! the trade-off from CodeRabbit history.
+//! Earlier drafts of this PR used the device display name as
+//! `node_name`, which CodeRabbit caught as non-unique on systems with
+//! duplicate names — switched to AudioDeviceID. Documenting both
+//! revisions here so the next reviewer doesn't have to re-derive the
+//! trade-off from CodeRabbit history.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -64,7 +80,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use coreaudio::audio_unit::audio_format::LinearPcmFlags;
 use coreaudio::audio_unit::macos_helpers::{
     audio_unit_from_device_id, get_audio_device_ids_for_scope, get_audio_device_supports_scope,
-    get_default_device_id, get_device_id_from_name, get_device_name,
+    get_default_device_id, get_device_name,
 };
 use coreaudio::audio_unit::render_callback::{self, data};
 use coreaudio::audio_unit::stream_format::StreamFormat;
@@ -99,24 +115,47 @@ const RING_CAPACITY: usize = 96_000;
 /// CodeRabbit on PR #253.
 const INTERLEAVE_BUF_CAPACITY: usize = RING_CAPACITY;
 
-/// Maximum frames per render callback we are willing to service from the
-/// stack scratch buffer. CoreAudio quanta are typically 256 or 512 frames;
-/// 4096 is a generous ceiling that covers any aggregate device or
-/// pro-audio device the user might have configured. The render callback
-/// degrades to silence rather than allocating on the RT thread when a
-/// quantum exceeds this — see the callback body.
+/// Maximum frames per render callback we are willing to service from
+/// the de-interleave scratch buffer. CoreAudio quanta are typically
+/// 256 or 512 frames; 4096 is a generous ceiling that covers any
+/// aggregate device or pro-audio device the user might have configured.
+///
+/// The scratch buffer itself is a heap `Vec<f32>` of length
+/// `MAX_CB_FRAMES * 2` allocated **once** in `open_unit()` (the cold
+/// start path) and moved into the render closure. The audio I/O thread
+/// never allocates: when a quantum exceeds `MAX_CB_FRAMES`, the
+/// callback writes silence to both channels and emits a one-shot
+/// `tracing::warn` rather than growing the buffer.
 const MAX_CB_FRAMES: usize = 4096;
 
 /// An audio sink device with display name and a caller-opaque identifier.
 ///
-/// On CoreAudio, `node_name` is the device's display name in v1 — see
-/// the v1-vs-v2 note in the module-level docs. Empty string means
-/// "system default output".
+/// On CoreAudio, `node_name` is the device's `AudioDeviceID` formatted
+/// as a decimal `u32` string. This is **session-scoped** — it stays
+/// stable for the lifetime of the running process but is not
+/// guaranteed to persist across reboots, plug events, or `coreaudiod`
+/// restarts. v2 (issue #237) will switch this to the device's
+/// CoreAudio UID (`kAudioDevicePropertyDeviceUID`) once we can drop
+/// the unsafe-code helper that currently blocks the upgrade.
+///
+/// **Why not the display name?** Display names are not unique on
+/// CoreAudio: a system can have two "USB Audio CODEC" devices, two
+/// "AirPlay" endpoints, two virtual aggregates with the same label,
+/// etc. Using the name as the caller-opaque handle would make
+/// `set_target` selection non-deterministic across duplicates and
+/// could route audio to the wrong device. AudioDeviceID is unique by
+/// definition within a session, so it's the right opaque handle even
+/// before we can store a fully-stable UID. CodeRabbit caught this on
+/// PR #253.
+///
+/// Empty string means "system default output" on every platform.
 #[derive(Clone, Debug)]
 pub struct AudioDevice {
     /// Human-readable name (from `kAudioObjectPropertyName`).
     pub display_name: String,
-    /// Caller-opaque device identifier. Empty = "system default output".
+    /// Caller-opaque device identifier. On macOS this is the
+    /// `AudioDeviceID` as a decimal string in v1; in v2 it becomes the
+    /// CoreAudio device UID. Empty = "system default output".
     pub node_name: String,
 }
 
@@ -154,18 +193,27 @@ impl AudioSink {
     /// Set the target output device. Empty string routes to the system
     /// default output.
     ///
-    /// In v1 the `node_name` is interpreted as a device **display name**
-    /// (matching what [`list_audio_sinks`] returns); v2 will switch to
-    /// CoreAudio device UID. See the module docs for the rationale.
+    /// `node_name` is interpreted as a CoreAudio `AudioDeviceID`
+    /// formatted as a decimal string (matching what
+    /// [`list_audio_sinks`] returns). The string is parsed lazily on
+    /// the next [`Sink::start`] call so that an invalid value reports
+    /// the failure through the normal start error path rather than
+    /// surprising callers from inside `set_target` itself.
     ///
-    /// If the sink is already running, it is stopped, reconfigured, and
-    /// restarted — same pattern as the PipeWire backend.
+    /// In v2 (issue #237) `node_name` will become the device's
+    /// CoreAudio UID instead, but the parse-lazy-on-start contract
+    /// stays the same.
+    ///
+    /// If the sink is already running, it is stopped, reconfigured,
+    /// and restarted — same pattern as the PipeWire backend.
     ///
     /// # Errors
     ///
-    /// Returns [`SinkError::DeviceNotFound`] (raised by `start` on the
-    /// next open attempt) if the new target cannot be located, or any
-    /// error from `start` / `stop` if the sink was running.
+    /// Returns [`SinkError::InvalidParameter`] (via the next `start`
+    /// call) if `node_name` cannot be parsed as a `u32`, or
+    /// [`SinkError::DeviceNotFound`] if the parsed ID does not name
+    /// a valid output device. Also propagates any error from
+    /// `start` / `stop` if the sink was running.
     pub fn set_target(&mut self, node_name: &str) -> Result<(), SinkError> {
         let was_running = self.audio_unit.is_some();
         if was_running {
@@ -225,13 +273,19 @@ impl AudioSink {
     /// Open the AUHAL output unit, configure format, register the
     /// render callback, and initialize. Called from [`Sink::start`].
     fn open_unit(&mut self) -> Result<AudioUnit, SinkError> {
-        // Pick the device. Empty target_device means "system default output".
+        // Pick the device. Empty target_device means "system default
+        // output"; any non-empty value is parsed as a decimal
+        // AudioDeviceID (the same format `list_audio_sinks` emits).
         let device_id = if self.target_device.is_empty() {
             get_default_device_id(false)
                 .ok_or_else(|| SinkError::DeviceNotFound("system default output".to_string()))?
         } else {
-            get_device_id_from_name(&self.target_device, false)
-                .ok_or_else(|| SinkError::DeviceNotFound(self.target_device.clone()))?
+            self.target_device.parse::<u32>().map_err(|_| {
+                SinkError::InvalidParameter(format!(
+                    "CoreAudio target_device must be a decimal AudioDeviceID, got {:?}",
+                    self.target_device
+                ))
+            })?
         };
 
         // Build the AUHAL output unit bound to this device.
@@ -391,9 +445,11 @@ impl Sink for AudioSink {
 /// Render callback body — extracted from the closure so it has a
 /// nameable type and is unit-testable in principle.
 ///
-/// **Allocates nothing.** The `scratch` slice is owned by the render
-/// closure (allocated once at sink construction) and passed in by
-/// `&mut`. The callback uses `scratch.len() / 2` as the per-quantum
+/// **Allocates nothing.** The `scratch` slice is a heap-allocated
+/// `Vec<f32>` owned by the render closure: it is allocated **once**
+/// in `open_unit()` (the cold start path) and reused for the lifetime
+/// of the AudioUnit. The audio I/O thread never sees an allocator
+/// call. The callback uses `scratch.len() / 2` as the per-quantum
 /// frame ceiling; if a single quantum exceeds it, the callback writes
 /// silence to both channels and emits a `tracing` warning **at most
 /// once per sink lifetime** (gated by the `overflow_warned` atomic)
@@ -485,10 +541,20 @@ fn render_callback_body(
 /// Enumerate available CoreAudio output devices.
 ///
 /// Always prepends a "Default" entry with `node_name = ""` so callers
-/// can route to the system default without knowing its name. Devices
-/// without any output channels (e.g., mic-only inputs) are filtered out.
-/// The system default device is deduplicated against the enumerated
-/// list so it doesn't appear twice in pickers.
+/// can route to the system default without knowing its identifier.
+/// Devices without any output channels (e.g., mic-only inputs) are
+/// filtered out. The system default device is deduplicated against
+/// the enumerated list so it doesn't appear twice in pickers.
+///
+/// `node_name` is the device's [`AudioDeviceID`] formatted as a
+/// decimal `u32` string — uniquely identifies a device within the
+/// running session, even when multiple devices share a display name
+/// (e.g., several "USB Audio CODEC" devices). [`set_target`] parses
+/// this string back into the integer ID directly. v2 (issue #237)
+/// switches `node_name` to a stable CoreAudio device UID; v1 uses
+/// the session-scoped ID because it's the only unique handle the
+/// `coreaudio-rs 0.14` API exposes without dropping into raw
+/// `coreaudio-sys` calls.
 #[must_use]
 pub fn list_audio_sinks() -> Vec<AudioDevice> {
     let mut sinks = vec![AudioDevice {
@@ -517,16 +583,16 @@ pub fn list_audio_sinks() -> Vec<AudioDevice> {
             continue;
         }
 
-        let Ok(name) = get_device_name(device_id) else {
-            continue;
-        };
+        let display_name =
+            get_device_name(device_id).unwrap_or_else(|_| format!("Device {device_id}"));
 
         sinks.push(AudioDevice {
-            display_name: name.clone(),
-            // v1: see the v1-vs-v2 note in the module docs. node_name
-            // is the display name; v2 switches to CoreAudio device UID
-            // alongside the device picker (#237).
-            node_name: name,
+            display_name,
+            // Decimal AudioDeviceID. Unique within the running
+            // session even when display names collide. See the
+            // function docs and the v1-vs-v2 note in the module
+            // docs for the v2 path (#237 → CoreAudio device UID).
+            node_name: device_id.to_string(),
         });
     }
 
@@ -578,5 +644,41 @@ mod tests {
         let default = &devices[0];
         assert_eq!(default.display_name, "Default");
         assert!(default.node_name.is_empty());
+    }
+
+    #[test]
+    fn enumerated_node_names_parse_as_audio_device_ids() {
+        // Every non-default entry's node_name must be a decimal u32
+        // (the AudioDeviceID round-trip contract). This is what
+        // `set_target` will parse it as.
+        let devices = list_audio_sinks();
+        for dev in devices.iter().skip(1) {
+            assert!(
+                !dev.node_name.is_empty(),
+                "non-default device has empty node_name: {dev:?}"
+            );
+            let parsed = dev.node_name.parse::<u32>();
+            assert!(
+                parsed.is_ok(),
+                "node_name {:?} for device {:?} is not a decimal u32",
+                dev.node_name,
+                dev.display_name,
+            );
+        }
+    }
+
+    #[test]
+    fn set_target_with_invalid_id_fails_on_start() {
+        // set_target itself succeeds (lazy parse) but the next start()
+        // surfaces InvalidParameter. We can't actually call start()
+        // without tearing down a real AU, so just verify the parse
+        // path that open_unit takes for a non-empty target.
+        let mut sink = AudioSink::new();
+        sink.set_target("not-a-number")
+            .expect("set_target stores the string without parsing");
+        // open_unit is private; the parse failure surfaces via start()
+        // which we don't exercise here. The contract is enforced via
+        // the parse::<u32>() call in open_unit.
+        assert_eq!(sink.target_device, "not-a-number");
     }
 }

--- a/crates/sdr-sink-audio/src/coreaudio_impl.rs
+++ b/crates/sdr-sink-audio/src/coreaudio_impl.rs
@@ -1,0 +1,522 @@
+//! CoreAudio (AUHAL) audio output sink for macOS.
+//!
+//! Mirrors the [`crate::pw_impl`] PipeWire backend behind the same
+//! [`Sink`] trait so [`crate::lib`]'s cfg dispatch can swap one for the
+//! other based on `target_os`.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! write_samples(&[Stereo])  ──interleave──▶  AudioRingBuffer
+//!                                                  │
+//!                                                  │ (CoreAudio I/O thread)
+//!                                                  ▼
+//!                                          AURenderCallback
+//!                                                  │
+//!                                                  ▼
+//!                                  Default output device (or `set_target` UID)
+//! ```
+//!
+//! - Uses the **default output unit** (`kAudioUnitSubType_DefaultOutput`) from
+//!   the high-level [`coreaudio::audio_unit::AudioUnit`] wrapper.
+//! - Format: 48 kHz f32 stereo, **non-interleaved** — the canonical
+//!   format for Mac AudioUnits per Apple's *Core Audio Overview*.
+//! - The render callback **never allocates**: it uses a stack scratch
+//!   buffer sized for `MAX_CB_FRAMES = 4096` and degrades to silence on
+//!   overflow rather than falling back to the heap. CoreAudio quanta are
+//!   typically 256–512 frames; 4096 is generous headroom for aggregate
+//!   or pro-audio devices.
+//!
+//! ## Public surface parity with `pw_impl`
+//!
+//! The two backends export the same names — [`AudioSink`], [`AudioDevice`],
+//! [`list_audio_sinks`] — and `lib.rs` re-exports whichever one is selected
+//! by cfg. `sdr-core::DspState` constructs `AudioSink::new()` without
+//! knowing which backend it has.
+//!
+//! ## v1 vs v2: `node_name` semantics
+//!
+//! The spec
+//! (`docs/superpowers/specs/2026-04-12-coreaudio-sink-design.md`) says
+//! `AudioDevice::node_name` should be the CoreAudio device UID
+//! (`kAudioDevicePropertyDeviceUID`). `coreaudio-rs 0.14` does not
+//! expose a UID helper, so retrieving the UID would require dropping
+//! into raw `coreaudio-sys` calls plus a `core-foundation` dep for
+//! `CFString → String` conversion plus an `#[allow(unsafe_code)]`
+//! override of the workspace-wide deny.
+//!
+//! For **v1** we use the device *display name* as `node_name` instead.
+//! This is a v1-only deviation because:
+//!
+//! - The MVP UI does not expose an audio device picker (deferred to v2,
+//!   issue #237). `set_target` is implemented but never called from any
+//!   v1 caller — `node_name` is essentially unused metadata.
+//! - Switching to UID is a clean follow-up: one `unsafe` helper that
+//!   wraps `AudioObjectGetPropertyData(kAudioDevicePropertyDeviceUID, …)`,
+//!   landing alongside the v2 device picker in #237.
+//!
+//! Documenting this here so the next reviewer doesn't have to re-derive
+//! the trade-off from CodeRabbit history.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use coreaudio::audio_unit::audio_format::LinearPcmFlags;
+use coreaudio::audio_unit::macos_helpers::{
+    audio_unit_from_device_id, get_audio_device_ids_for_scope, get_audio_device_supports_scope,
+    get_default_device_id, get_device_id_from_name, get_device_name,
+};
+use coreaudio::audio_unit::render_callback::{self, data};
+use coreaudio::audio_unit::stream_format::StreamFormat;
+use coreaudio::audio_unit::{AudioUnit, Element, SampleFormat, Scope};
+
+use sdr_pipeline::sink_manager::Sink;
+use sdr_types::{SinkError, Stereo};
+
+use crate::ring::AudioRingBuffer;
+
+/// Engine-side audio sample rate in Hz. The engine always sees 48 kHz; if
+/// the device runs at something else, AUHAL's internal converter handles
+/// the resampling for us.
+const AUDIO_SAMPLE_RATE: f64 = 48_000.0;
+
+/// Number of audio channels (stereo).
+const AUDIO_CHANNELS: u32 = 2;
+
+/// Audio ring buffer capacity in `f32` samples (interleaved stereo).
+/// ~1 second at 48 kHz stereo = 96,000 samples.
+const RING_CAPACITY: usize = 96_000;
+
+/// Initial capacity for the stereo interleave buffer in `write_samples`.
+const INTERLEAVE_BUF_INITIAL_CAP: usize = 1024;
+
+/// Maximum frames per render callback we are willing to service from the
+/// stack scratch buffer. CoreAudio quanta are typically 256 or 512 frames;
+/// 4096 is a generous ceiling that covers any aggregate device or
+/// pro-audio device the user might have configured. The render callback
+/// degrades to silence rather than allocating on the RT thread when a
+/// quantum exceeds this — see the callback body.
+const MAX_CB_FRAMES: usize = 4096;
+
+/// An audio sink device with display name and a caller-opaque identifier.
+///
+/// On CoreAudio, `node_name` is the device's display name in v1 — see
+/// the v1-vs-v2 note in the module-level docs. Empty string means
+/// "system default output".
+#[derive(Clone, Debug)]
+pub struct AudioDevice {
+    /// Human-readable name (from `kAudioObjectPropertyName`).
+    pub display_name: String,
+    /// Caller-opaque device identifier. Empty = "system default output".
+    pub node_name: String,
+}
+
+/// Audio output sink backed by CoreAudio AUHAL.
+pub struct AudioSink {
+    sample_rate: f64,
+    running: Arc<AtomicBool>,
+    ring: Arc<AudioRingBuffer>,
+    audio_unit: Option<AudioUnit>,
+    /// Target device, set via [`AudioSink::set_target`]. Empty string
+    /// means "system default output".
+    target_device: String,
+    /// Pre-allocated interleave buffer used by `write_samples` so the
+    /// hot path never allocates.
+    interleave_buf: Vec<f32>,
+}
+
+impl AudioSink {
+    /// Create a new sink. Does **not** open the AudioUnit yet — that
+    /// happens in [`AudioSink::start`] so the device pick can be retried
+    /// if the user changes the system default output between sink
+    /// construction and stream start.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            sample_rate: AUDIO_SAMPLE_RATE,
+            running: Arc::new(AtomicBool::new(false)),
+            ring: Arc::new(AudioRingBuffer::new(RING_CAPACITY)),
+            audio_unit: None,
+            target_device: String::new(),
+            interleave_buf: Vec::with_capacity(INTERLEAVE_BUF_INITIAL_CAP),
+        }
+    }
+
+    /// Set the target output device. Empty string routes to the system
+    /// default output.
+    ///
+    /// In v1 the `node_name` is interpreted as a device **display name**
+    /// (matching what [`list_audio_sinks`] returns); v2 will switch to
+    /// CoreAudio device UID. See the module docs for the rationale.
+    ///
+    /// If the sink is already running, it is stopped, reconfigured, and
+    /// restarted — same pattern as the PipeWire backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SinkError::DeviceNotFound`] (raised by `start` on the
+    /// next open attempt) if the new target cannot be located, or any
+    /// error from `start` / `stop` if the sink was running.
+    pub fn set_target(&mut self, node_name: &str) -> Result<(), SinkError> {
+        let was_running = self.audio_unit.is_some();
+        if was_running {
+            self.stop()?;
+        }
+        self.target_device.clear();
+        self.target_device.push_str(node_name);
+        if was_running {
+            self.start()?;
+        }
+        Ok(())
+    }
+
+    /// Send stereo audio samples to CoreAudio for playback.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SinkError::NotRunning`] if the sink has not been started.
+    pub fn write_samples(&mut self, samples: &[Stereo]) -> Result<(), SinkError> {
+        if !self.running.load(Ordering::Acquire) {
+            return Err(SinkError::NotRunning);
+        }
+
+        // Interleave stereo into the pre-allocated scratch buffer (zero
+        // allocation on the hot path) and push it to the ring. The
+        // render callback de-interleaves on the audio thread.
+        self.interleave_buf.clear();
+        for s in samples {
+            self.interleave_buf.push(s.l);
+            self.interleave_buf.push(s.r);
+        }
+
+        self.ring.write(&self.interleave_buf);
+        Ok(())
+    }
+
+    /// Open the AUHAL output unit, configure format, register the
+    /// render callback, and initialize. Called from [`Sink::start`].
+    fn open_unit(&mut self) -> Result<AudioUnit, SinkError> {
+        // Pick the device. Empty target_device means "system default output".
+        let device_id = if self.target_device.is_empty() {
+            get_default_device_id(false)
+                .ok_or_else(|| SinkError::DeviceNotFound("system default output".to_string()))?
+        } else {
+            get_device_id_from_name(&self.target_device, false)
+                .ok_or_else(|| SinkError::DeviceNotFound(self.target_device.clone()))?
+        };
+
+        // Build the AUHAL output unit bound to this device.
+        let mut unit = audio_unit_from_device_id(device_id, false)
+            .map_err(|e| SinkError::OpenFailed(format!("audio_unit_from_device_id: {e}")))?;
+
+        // Set the input-side stream format on element 0 (output bus). On
+        // macOS the canonical AudioUnit format is non-interleaved 32-bit
+        // float; AUHAL converts internally to whatever the device wants,
+        // including any sample-rate conversion needed when the device
+        // runs at a rate other than 48 kHz.
+        let format = StreamFormat {
+            sample_rate: AUDIO_SAMPLE_RATE,
+            sample_format: SampleFormat::F32,
+            flags: LinearPcmFlags::IS_FLOAT
+                | LinearPcmFlags::IS_PACKED
+                | LinearPcmFlags::IS_NON_INTERLEAVED,
+            channels: AUDIO_CHANNELS,
+        };
+        unit.set_stream_format(format, Scope::Input, Element::Output)
+            .map_err(|e| SinkError::OpenFailed(format!("set_stream_format: {e}")))?;
+
+        // Register the render callback. The callback captures an Arc to
+        // the ring buffer plus a heap-allocated scratch buffer used to
+        // de-interleave samples for each quantum. The scratch buffer is
+        // allocated **here** (the cold start path) and reused for the
+        // lifetime of the AudioUnit — the audio I/O thread never
+        // allocates. Ring buffer reads are non-blocking via `try_lock`
+        // so contention with the writer never blocks the callback
+        // thread either.
+        let ring_for_cb = Arc::clone(&self.ring);
+        let mut scratch_buf: Vec<f32> = vec![0.0; MAX_CB_FRAMES * 2];
+        unit.set_render_callback(
+            move |args: render_callback::Args<data::NonInterleaved<f32>>| {
+                render_callback_body(&ring_for_cb, &mut scratch_buf, args);
+                // The inner function is infallible by construction —
+                // every code path in it writes silence on degraded
+                // quanta rather than returning an error. The Result
+                // wrapping is required by `set_render_callback`'s
+                // signature (`FnMut(Args<D>) -> Result<(), ()>`).
+                Ok(())
+            },
+        )
+        .map_err(|e| SinkError::OpenFailed(format!("set_render_callback: {e}")))?;
+
+        // Initialize and we're ready to start.
+        unit.initialize()
+            .map_err(|e| SinkError::OpenFailed(format!("audio_unit.initialize: {e}")))?;
+
+        Ok(unit)
+    }
+}
+
+impl Default for AudioSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sink for AudioSink {
+    fn name(&self) -> &str {
+        "Audio"
+    }
+
+    fn start(&mut self) -> Result<(), SinkError> {
+        if self.running.load(Ordering::Acquire) {
+            return Err(SinkError::AlreadyRunning);
+        }
+
+        // Drain any stale samples from a previous run before opening the
+        // unit. This matches the PipeWire impl's ordering.
+        self.ring.clear();
+
+        // Set running BEFORE starting the unit so write_samples can
+        // queue audio the moment the render callback fires for the
+        // first time. (Same ordering as `pw_impl`.)
+        self.running.store(true, Ordering::Release);
+
+        let mut unit = match self.open_unit() {
+            Ok(u) => u,
+            Err(e) => {
+                // Roll back the running flag if open failed.
+                self.running.store(false, Ordering::Release);
+                return Err(e);
+            }
+        };
+
+        if let Err(e) = unit.start() {
+            self.running.store(false, Ordering::Release);
+            return Err(SinkError::OpenFailed(format!("audio_unit.start: {e}")));
+        }
+
+        self.audio_unit = Some(unit);
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<(), SinkError> {
+        if !self.running.load(Ordering::Acquire) {
+            return Err(SinkError::NotRunning);
+        }
+
+        if let Some(mut unit) = self.audio_unit.take() {
+            // Best-effort: stop the unit. If stop returns an error we
+            // still want to drop the unit and clear the running flag,
+            // so we log-and-continue rather than propagating up.
+            if let Err(e) = unit.stop() {
+                tracing::warn!("audio_unit.stop returned error: {e}");
+            }
+            // Dropping `unit` here uninitializes and disposes the AU.
+            drop(unit);
+        }
+
+        self.running.store(false, Ordering::Release);
+        self.ring.clear();
+        Ok(())
+    }
+
+    fn set_sample_rate(&mut self, rate: f64) -> Result<(), SinkError> {
+        // Engine-side rate is fixed at 48 kHz. Anything else is an
+        // engine-config bug — the engine should never ask the sink to
+        // run at a different rate.
+        if !rate.is_finite() || rate <= 0.0 {
+            return Err(SinkError::InvalidParameter(format!(
+                "sample rate must be positive and finite, got {rate}"
+            )));
+        }
+        if (rate - AUDIO_SAMPLE_RATE).abs() > f64::EPSILON {
+            return Err(SinkError::InvalidParameter(format!(
+                "CoreAudio sink only supports {AUDIO_SAMPLE_RATE} Hz (got {rate})"
+            )));
+        }
+        self.sample_rate = rate;
+        Ok(())
+    }
+
+    fn sample_rate(&self) -> f64 {
+        self.sample_rate
+    }
+}
+
+/// Render callback body — extracted from the closure so it has a
+/// nameable type and is unit-testable in principle.
+///
+/// **Allocates nothing.** The `scratch` slice is owned by the render
+/// closure (allocated once at sink construction) and passed in by
+/// `&mut`. The callback uses `scratch.len() / 2` as the per-quantum
+/// frame ceiling; if a single quantum exceeds it, the callback writes
+/// silence to both channels and emits a `tracing` warning rather than
+/// growing the scratch on the audio thread. Heap allocation on the
+/// CoreAudio render thread can block on the system allocator and miss
+/// a deadline; silence is the correct safe degradation. Debug builds
+/// also `debug_assert!` so the overflow path fires loudly during dev.
+fn render_callback_body(
+    ring: &AudioRingBuffer,
+    scratch: &mut [f32],
+    mut args: render_callback::Args<data::NonInterleaved<f32>>,
+) {
+    let frames = args.num_frames;
+    // Scratch is laid out as interleaved stereo, so the per-quantum
+    // frame ceiling is half its slice length.
+    let max_frames = scratch.len() / 2;
+
+    // Pull out the two channel slices. AUHAL on macOS gives us exactly
+    // one buffer per channel; if for some reason there's only one
+    // channel (mono device?) we render silence and bail.
+    let mut channels = args.data.channels_mut();
+    let Some(left) = channels.next() else {
+        return;
+    };
+    let Some(right) = channels.next() else {
+        // Mono output — fill the one channel with silence and stop.
+        for v in left.iter_mut().take(frames) {
+            *v = 0.0;
+        }
+        return;
+    };
+
+    debug_assert!(
+        frames <= max_frames,
+        "CoreAudio render quantum {frames} exceeded scratch capacity {max_frames}"
+    );
+
+    if frames > max_frames {
+        // Release-build degradation: write silence to both channels and
+        // log once. Cannot allocate on the RT thread; cannot panic on
+        // the RT thread either. Silence is the correct safe fallback.
+        tracing::warn!(
+            frames,
+            max_frames,
+            "CoreAudio render quantum exceeded scratch buffer; rendering silence"
+        );
+        for v in left.iter_mut().take(frames) {
+            *v = 0.0;
+        }
+        for v in right.iter_mut().take(frames) {
+            *v = 0.0;
+        }
+        return;
+    }
+
+    let want_samples = frames * 2;
+    let read = ring.read(&mut scratch[..want_samples]);
+
+    // De-interleave into the two channel slices. If the ring didn't
+    // have enough samples (underrun, or first-tick before the engine
+    // has produced anything), the trailing slots get silence.
+    for i in 0..frames {
+        let l_idx = i * 2;
+        let r_idx = i * 2 + 1;
+        if r_idx < read {
+            left[i] = scratch[l_idx];
+            right[i] = scratch[r_idx];
+        } else {
+            left[i] = 0.0;
+            right[i] = 0.0;
+        }
+    }
+}
+
+/// Enumerate available CoreAudio output devices.
+///
+/// Always prepends a "Default" entry with `node_name = ""` so callers
+/// can route to the system default without knowing its name. Devices
+/// without any output channels (e.g., mic-only inputs) are filtered out.
+/// The system default device is deduplicated against the enumerated
+/// list so it doesn't appear twice in pickers.
+#[must_use]
+pub fn list_audio_sinks() -> Vec<AudioDevice> {
+    let mut sinks = vec![AudioDevice {
+        display_name: "Default".to_string(),
+        node_name: String::new(),
+    }];
+
+    let default_id = get_default_device_id(false);
+
+    let Ok(all_ids) = get_audio_device_ids_for_scope(Scope::Global) else {
+        // Could not enumerate — return just the default entry. The
+        // caller can still route audio.
+        return sinks;
+    };
+
+    for device_id in all_ids {
+        // Skip devices without output channels.
+        match get_audio_device_supports_scope(device_id, Scope::Output) {
+            Ok(true) => {}
+            Ok(false) | Err(_) => continue,
+        }
+
+        // Skip the system default — it's already represented by the
+        // "Default" entry above.
+        if Some(device_id) == default_id {
+            continue;
+        }
+
+        let Ok(name) = get_device_name(device_id) else {
+            continue;
+        };
+
+        sinks.push(AudioDevice {
+            display_name: name.clone(),
+            // v1: see the v1-vs-v2 note in the module docs. node_name
+            // is the display name; v2 switches to CoreAudio device UID
+            // alongside the device picker (#237).
+            node_name: name,
+        });
+    }
+
+    sinks
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_does_not_panic() {
+        let sink = AudioSink::new();
+        assert_eq!(sink.name(), "Audio");
+        assert!((sink.sample_rate() - AUDIO_SAMPLE_RATE).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn write_before_start_returns_not_running() {
+        let mut sink = AudioSink::new();
+        let samples = [Stereo::new(0.0, 0.0)];
+        assert!(
+            matches!(sink.write_samples(&samples), Err(SinkError::NotRunning)),
+            "write_samples should fail before start"
+        );
+    }
+
+    #[test]
+    fn stop_before_start_returns_not_running() {
+        let mut sink = AudioSink::new();
+        assert!(matches!(sink.stop(), Err(SinkError::NotRunning)));
+    }
+
+    #[test]
+    fn set_sample_rate_validation() {
+        let mut sink = AudioSink::new();
+        assert!(sink.set_sample_rate(AUDIO_SAMPLE_RATE).is_ok());
+        assert!(sink.set_sample_rate(44100.0).is_err());
+        assert!(sink.set_sample_rate(-1.0).is_err());
+        assert!(sink.set_sample_rate(f64::NAN).is_err());
+        assert!(sink.set_sample_rate(f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn list_audio_sinks_includes_default() {
+        let devices = list_audio_sinks();
+        assert!(!devices.is_empty(), "list must always include 'Default'");
+        let default = &devices[0];
+        assert_eq!(default.display_name, "Default");
+        assert!(default.node_name.is_empty());
+    }
+}

--- a/crates/sdr-sink-audio/src/coreaudio_impl.rs
+++ b/crates/sdr-sink-audio/src/coreaudio_impl.rs
@@ -14,7 +14,7 @@
 //!                                          AURenderCallback
 //!                                                  │
 //!                                                  ▼
-//!                                  Default output device (or `set_target` UID)
+//!                                  Default output device (or `set_target` AudioDeviceID)
 //! ```
 //!
 //! - Uses the **default output unit** (`kAudioUnitSubType_DefaultOutput`) from
@@ -226,6 +226,15 @@ impl AudioSink {
         // unit. Catches the easy class of failures (typos, garbage,
         // wrong-type values) without any teardown.
         parse_target_device(node_name)?;
+
+        // Idempotent fast path: if the requested target matches the
+        // current one, do nothing. Avoids a stop/start cycle (and the
+        // audible glitch + failure surface that comes with it) when
+        // callers re-set the same device, e.g., after a settings
+        // window confirms its current selection.
+        if self.target_device == node_name {
+            return Ok(());
+        }
 
         let was_running = self.audio_unit.is_some();
 
@@ -781,6 +790,28 @@ mod tests {
             sink.target_device, "7",
             "failed pre-validation must not disturb the previous target"
         );
+    }
+
+    #[test]
+    fn set_target_is_idempotent_for_unchanged_target() {
+        // Re-setting the same target should be a no-op fast path —
+        // no stop/start cycle, no audible glitch, no failure surface
+        // expansion. We can't observe the lack of a stop/start
+        // directly here (no real AudioUnit involved on an idle
+        // sink), but we can prove that the call returns Ok and
+        // leaves target_device exactly equal to what was already
+        // there.
+        let mut sink = AudioSink::new();
+        sink.set_target("42").expect("baseline");
+        sink.set_target("42")
+            .expect("re-setting the same target should succeed as a no-op");
+        assert_eq!(sink.target_device, "42");
+
+        // Same for the empty-string ("default device") case.
+        sink.set_target("").expect("switch to default");
+        sink.set_target("")
+            .expect("re-setting empty should succeed as a no-op");
+        assert!(sink.target_device.is_empty());
     }
 
     #[test]

--- a/crates/sdr-sink-audio/src/coreaudio_impl.rs
+++ b/crates/sdr-sink-audio/src/coreaudio_impl.rs
@@ -195,36 +195,94 @@ impl AudioSink {
     ///
     /// `node_name` is interpreted as a CoreAudio `AudioDeviceID`
     /// formatted as a decimal string (matching what
-    /// [`list_audio_sinks`] returns). The string is parsed lazily on
-    /// the next [`Sink::start`] call so that an invalid value reports
-    /// the failure through the normal start error path rather than
-    /// surprising callers from inside `set_target` itself.
+    /// [`list_audio_sinks`] returns). The format is **pre-validated
+    /// up front** before touching the running AudioUnit, so a
+    /// completely invalid string returns [`SinkError::InvalidParameter`]
+    /// without disturbing audio playback. In v2 (issue #237)
+    /// `node_name` will become the device's CoreAudio UID instead,
+    /// but the pre-validate-then-swap contract stays the same.
     ///
-    /// In v2 (issue #237) `node_name` will become the device's
-    /// CoreAudio UID instead, but the parse-lazy-on-start contract
-    /// stays the same.
-    ///
-    /// If the sink is already running, it is stopped, reconfigured,
-    /// and restarted — same pattern as the PipeWire backend.
+    /// If the sink is already running, the swap is **transactional**:
+    /// the old `target_device` is preserved, the unit is stopped, the
+    /// new target is installed, and `start()` is called. If the start
+    /// fails (e.g., the new ID is stale after a plug/unplug, or the
+    /// device disappeared between `list_audio_sinks` and now), the old
+    /// `target_device` is restored and `start()` is called a second
+    /// time to bring the previous working route back. Only if both
+    /// the swap **and** the rollback fail does the sink end up
+    /// stopped — and in that case the function returns the original
+    /// swap error so the caller knows what was attempted, with a
+    /// `tracing::error` covering the rollback failure.
     ///
     /// # Errors
     ///
-    /// Returns [`SinkError::InvalidParameter`] (via the next `start`
-    /// call) if `node_name` cannot be parsed as a `u32`, or
-    /// [`SinkError::DeviceNotFound`] if the parsed ID does not name
-    /// a valid output device. Also propagates any error from
-    /// `start` / `stop` if the sink was running.
+    /// Returns [`SinkError::InvalidParameter`] if `node_name` cannot
+    /// be parsed as a `u32`, [`SinkError::DeviceNotFound`] if the
+    /// parsed ID does not name a valid output device when `start()`
+    /// runs, or any error from `stop` / `start`. On failure to swap
+    /// AND failure to roll back, the original swap error is returned.
     pub fn set_target(&mut self, node_name: &str) -> Result<(), SinkError> {
+        // Pre-validate the new target *before* touching the running
+        // unit. Catches the easy class of failures (typos, garbage,
+        // wrong-type values) without any teardown.
+        parse_target_device(node_name)?;
+
         let was_running = self.audio_unit.is_some();
-        if was_running {
-            self.stop()?;
+
+        if !was_running {
+            // Idle sink: store and return. The next `start()` call
+            // will run open_unit and surface any device-resolution
+            // failure.
+            self.target_device.clear();
+            self.target_device.push_str(node_name);
+            return Ok(());
         }
+
+        // Running sink: transactional swap with rollback on failure.
+        let old_target = std::mem::take(&mut self.target_device);
+
+        if let Err(stop_err) = self.stop() {
+            // Could not even stop the old unit cleanly. Put the old
+            // target back so subsequent calls see consistent state and
+            // bail; the sink may or may not still be running depending
+            // on what stop() actually did.
+            self.target_device = old_target;
+            return Err(stop_err);
+        }
+
         self.target_device.clear();
         self.target_device.push_str(node_name);
-        if was_running {
-            self.start()?;
+
+        match self.start() {
+            Ok(()) => Ok(()),
+            Err(swap_err) => {
+                // Rollback path: the new target failed to start.
+                // Restore the old target_device and try to bring the
+                // previous working route back so audio playback
+                // resumes instead of staying dead.
+                tracing::warn!(
+                    error = %swap_err,
+                    new_target = node_name,
+                    old_target = old_target.as_str(),
+                    "set_target failed; rolling back to previous device"
+                );
+                self.target_device.clear();
+                self.target_device.push_str(&old_target);
+
+                if let Err(rollback_err) = self.start() {
+                    // Both the swap and the rollback failed. The sink
+                    // is now stopped. Surface the original error so
+                    // the caller sees what they tried to do; the
+                    // rollback error gets a tracing::error of its own.
+                    tracing::error!(
+                        swap_error = %swap_err,
+                        rollback_error = %rollback_err,
+                        "set_target rollback also failed; sink is now stopped"
+                    );
+                }
+                Err(swap_err)
+            }
         }
-        Ok(())
     }
 
     /// Send stereo audio samples to CoreAudio for playback.
@@ -276,16 +334,10 @@ impl AudioSink {
         // Pick the device. Empty target_device means "system default
         // output"; any non-empty value is parsed as a decimal
         // AudioDeviceID (the same format `list_audio_sinks` emits).
-        let device_id = if self.target_device.is_empty() {
-            get_default_device_id(false)
-                .ok_or_else(|| SinkError::DeviceNotFound("system default output".to_string()))?
-        } else {
-            self.target_device.parse::<u32>().map_err(|_| {
-                SinkError::InvalidParameter(format!(
-                    "CoreAudio target_device must be a decimal AudioDeviceID, got {:?}",
-                    self.target_device
-                ))
-            })?
+        let device_id = match parse_target_device(&self.target_device)? {
+            Some(id) => id,
+            None => get_default_device_id(false)
+                .ok_or_else(|| SinkError::DeviceNotFound("system default output".to_string()))?,
         };
 
         // Build the AUHAL output unit bound to this device.
@@ -440,6 +492,28 @@ impl Sink for AudioSink {
     fn sample_rate(&self) -> f64 {
         self.sample_rate
     }
+}
+
+/// Parse a `target_device` string into an [`AudioDeviceID`] selection.
+///
+/// - Empty string → `Ok(None)` (caller resolves the system default).
+/// - Decimal `u32` string → `Ok(Some(id))`.
+/// - Anything else → `Err(SinkError::InvalidParameter)`.
+///
+/// Extracted from [`AudioSink::open_unit`] so it can be unit-tested in
+/// isolation and so [`AudioSink::set_target`] can pre-validate a new
+/// target before tearing down the running AudioUnit (avoiding the
+/// "stop-and-fail leaves the sink dead" hazard CodeRabbit caught on
+/// PR #253).
+fn parse_target_device(target_device: &str) -> Result<Option<u32>, SinkError> {
+    if target_device.is_empty() {
+        return Ok(None);
+    }
+    target_device.parse::<u32>().map(Some).map_err(|_| {
+        SinkError::InvalidParameter(format!(
+            "CoreAudio target_device must be a decimal AudioDeviceID, got {target_device:?}"
+        ))
+    })
 }
 
 /// Render callback body — extracted from the closure so it has a
@@ -668,17 +742,86 @@ mod tests {
     }
 
     #[test]
-    fn set_target_with_invalid_id_fails_on_start() {
-        // set_target itself succeeds (lazy parse) but the next start()
-        // surfaces InvalidParameter. We can't actually call start()
-        // without tearing down a real AU, so just verify the parse
-        // path that open_unit takes for a non-empty target.
+    fn set_target_stores_valid_id_when_idle() {
+        // On an idle sink (audio_unit = None), set_target pre-validates
+        // the format and then stores the string. No AudioUnit work
+        // happens because there's nothing to swap; the next start()
+        // will call open_unit and surface any device-resolution
+        // failure (stale ID, etc.).
         let mut sink = AudioSink::new();
-        sink.set_target("not-a-number")
-            .expect("set_target stores the string without parsing");
-        // open_unit is private; the parse failure surfaces via start()
-        // which we don't exercise here. The contract is enforced via
-        // the parse::<u32>() call in open_unit.
-        assert_eq!(sink.target_device, "not-a-number");
+        sink.set_target("42")
+            .expect("set_target with a valid id should succeed on an idle sink");
+        assert_eq!(sink.target_device, "42");
+    }
+
+    #[test]
+    fn set_target_pre_validation_rejects_garbage_without_disturbing_state() {
+        // The pre-validation step in set_target catches malformed
+        // strings BEFORE touching the running AudioUnit (or, on an
+        // idle sink, before mutating target_device). This is the
+        // "doesn't take down a working sink for a typo" guarantee
+        // CodeRabbit caught on PR #253.
+        let mut sink = AudioSink::new();
+
+        // Establish a known target so we can prove it survives the
+        // failed call.
+        sink.set_target("7").expect("baseline set_target");
+        assert_eq!(sink.target_device, "7");
+
+        let err = sink
+            .set_target("not-a-number")
+            .expect_err("set_target with garbage should fail pre-validation");
+        assert!(
+            matches!(err, SinkError::InvalidParameter(_)),
+            "expected InvalidParameter, got {err:?}",
+        );
+
+        // target_device must NOT have been touched.
+        assert_eq!(
+            sink.target_device, "7",
+            "failed pre-validation must not disturb the previous target"
+        );
+    }
+
+    #[test]
+    fn set_target_empty_string_clears_to_default() {
+        // Empty string = "system default output". The pre-validation
+        // path treats it as Ok(None), so set_target accepts it and
+        // clears the stored target.
+        let mut sink = AudioSink::new();
+        sink.set_target("42").expect("baseline");
+        sink.set_target("")
+            .expect("empty string should resolve to default device");
+        assert!(sink.target_device.is_empty());
+    }
+
+    #[test]
+    fn parse_target_device_empty_means_default() {
+        assert_eq!(parse_target_device("").unwrap(), None);
+    }
+
+    #[test]
+    fn parse_target_device_decimal_id_round_trips() {
+        assert_eq!(parse_target_device("0").unwrap(), Some(0));
+        assert_eq!(parse_target_device("42").unwrap(), Some(42));
+        assert_eq!(
+            parse_target_device(&u32::MAX.to_string()).unwrap(),
+            Some(u32::MAX)
+        );
+    }
+
+    #[test]
+    fn parse_target_device_rejects_garbage() {
+        // Anything that isn't an empty string and isn't a decimal u32
+        // surfaces InvalidParameter — both via the helper directly and
+        // via open_unit when start() runs.
+        for bad in ["not-a-number", "1.5", "0x42", "-1", "  ", "42abc"] {
+            let err = parse_target_device(bad)
+                .expect_err(&format!("expected parse_target_device({bad:?}) to fail"));
+            assert!(
+                matches!(err, SinkError::InvalidParameter(_)),
+                "expected InvalidParameter for {bad:?}, got {err:?}"
+            );
+        }
     }
 }

--- a/crates/sdr-sink-audio/src/coreaudio_impl.rs
+++ b/crates/sdr-sink-audio/src/coreaudio_impl.rs
@@ -87,8 +87,17 @@ const AUDIO_CHANNELS: u32 = 2;
 /// ~1 second at 48 kHz stereo = 96,000 samples.
 const RING_CAPACITY: usize = 96_000;
 
-/// Initial capacity for the stereo interleave buffer in `write_samples`.
-const INTERLEAVE_BUF_INITIAL_CAP: usize = 1024;
+/// Capacity for the stereo interleave buffer in `write_samples`.
+///
+/// Sized to match the ring buffer (the largest write that could ever
+/// fit in the ring without dropping data) so the hot path **never**
+/// reallocates: the buffer is `clear()`ed and re-pushed each call,
+/// but never grows beyond its initial capacity for any input within
+/// the ring's natural ceiling. The previous value of 1024 was a
+/// historical artifact from `pw_impl.rs` and silently grew the Vec
+/// for any write larger than 512 stereo frames — caught by
+/// CodeRabbit on PR #253.
+const INTERLEAVE_BUF_CAPACITY: usize = RING_CAPACITY;
 
 /// Maximum frames per render callback we are willing to service from the
 /// stack scratch buffer. CoreAudio quanta are typically 256 or 512 frames;
@@ -138,7 +147,7 @@ impl AudioSink {
             ring: Arc::new(AudioRingBuffer::new(RING_CAPACITY)),
             audio_unit: None,
             target_device: String::new(),
-            interleave_buf: Vec::with_capacity(INTERLEAVE_BUF_INITIAL_CAP),
+            interleave_buf: Vec::with_capacity(INTERLEAVE_BUF_CAPACITY),
         }
     }
 
@@ -172,6 +181,18 @@ impl AudioSink {
 
     /// Send stereo audio samples to CoreAudio for playback.
     ///
+    /// The interleave buffer is pre-sized to [`INTERLEAVE_BUF_CAPACITY`]
+    /// (= [`RING_CAPACITY`] f32s = ~48,000 stereo frames). For any input
+    /// up to that ceiling the call is **allocation-free** — the buffer
+    /// is `clear()`ed (which only resets `len`, leaving `capacity`
+    /// alone) and then `push()`ed back up to the new size without ever
+    /// calling the allocator. Inputs larger than that ceiling would
+    /// also overflow the ring buffer itself, so they're a contract
+    /// violation; debug builds `debug_assert!` to catch this loudly,
+    /// release builds let `Vec::push` reallocate once and then proceed
+    /// with the larger capacity (a one-time cost we accept as a graceful
+    /// degradation rather than dropping samples).
+    ///
     /// # Errors
     ///
     /// Returns [`SinkError::NotRunning`] if the sink has not been started.
@@ -180,9 +201,17 @@ impl AudioSink {
             return Err(SinkError::NotRunning);
         }
 
+        debug_assert!(
+            samples.len() * 2 <= INTERLEAVE_BUF_CAPACITY,
+            "write_samples called with {} stereo frames, exceeds interleave buffer capacity {} (would overflow the ring buffer too)",
+            samples.len(),
+            INTERLEAVE_BUF_CAPACITY / 2
+        );
+
         // Interleave stereo into the pre-allocated scratch buffer (zero
-        // allocation on the hot path) and push it to the ring. The
-        // render callback de-interleaves on the audio thread.
+        // allocation on the hot path under normal sizing) and push it
+        // to the ring. The render callback de-interleaves on the audio
+        // thread.
         self.interleave_buf.clear();
         for s in samples {
             self.interleave_buf.push(s.l);

--- a/crates/sdr-sink-audio/src/lib.rs
+++ b/crates/sdr-sink-audio/src/lib.rs
@@ -1,36 +1,82 @@
 #![allow(clippy::doc_markdown, clippy::unnecessary_literal_bound)]
-//! Audio output sink — PipeWire (Linux).
+//! Audio output sink — PipeWire (Linux) / CoreAudio (macOS).
 //!
 //! When the `pipewire` feature is enabled, spawns a PipeWire main loop thread,
 //! creates a playback stream at 48 kHz stereo f32, and feeds audio from the
 //! DSP controller through a bounded channel.
 //!
-//! When the feature is disabled, provides a stub that logs a warning.
+//! When the `coreaudio` feature is enabled, opens an AUHAL default-output
+//! AudioUnit and feeds audio through the same shared ring buffer pattern as
+//! the PipeWire backend.
+//!
+//! When neither backend feature is enabled, provides a stub that logs a
+//! warning.
 
-#[cfg(feature = "pipewire")]
+// Shared SPSC ring buffer used by both real backends. The stub backend
+// doesn't need it, but it's cheap to compile in unconditionally — about
+// 200 lines of plain Rust with no external deps.
+mod ring;
+
+// ---------------------------------------------------------------------
+//  Backend dispatch
+// ---------------------------------------------------------------------
+//
+// Exactly one backend module compiles in based on cfg + feature flags:
+//
+//   • Linux + `pipewire` feature  → pw_impl
+//   • macOS + `coreaudio` feature → coreaudio_impl
+//   • everything else             → stub_impl (logs and discards)
+//
+// `sdr-core/Cargo.toml` enables the right feature per `target_os` so
+// downstream crates don't have to think about it. The stub fallback
+// keeps `cargo build --workspace` working on bare Linux/macOS without
+// either feature flag (e.g., for fast feature-less syntax checks).
+
+#[cfg(all(target_os = "linux", feature = "pipewire"))]
 mod pw_impl;
-
-#[cfg(feature = "pipewire")]
+#[cfg(all(target_os = "linux", feature = "pipewire"))]
 pub use pw_impl::{AudioDevice, AudioSink, list_audio_sinks};
 
-#[cfg(not(feature = "pipewire"))]
-mod stub_impl;
+#[cfg(all(target_os = "macos", feature = "coreaudio"))]
+mod coreaudio_impl;
+#[cfg(all(target_os = "macos", feature = "coreaudio"))]
+pub use coreaudio_impl::{AudioDevice, AudioSink, list_audio_sinks};
 
-#[cfg(not(feature = "pipewire"))]
+// Fallback stub: any target without an explicit backend feature lands
+// here. The workspace baseline `cargo build` on macOS used this until
+// the `coreaudio` feature shipped (now wired via sdr-core); it remains
+// the fallback for unusual build configurations and for the workspace
+// no-default-features check.
+#[cfg(not(any(
+    all(target_os = "linux", feature = "pipewire"),
+    all(target_os = "macos", feature = "coreaudio"),
+)))]
+mod stub_impl;
+#[cfg(not(any(
+    all(target_os = "linux", feature = "pipewire"),
+    all(target_os = "macos", feature = "coreaudio"),
+)))]
 pub use stub_impl::AudioSink;
 
-/// Audio device info (stub for non-PipeWire builds).
-#[cfg(not(feature = "pipewire"))]
+/// Audio device info (stub backend).
+#[cfg(not(any(
+    all(target_os = "linux", feature = "pipewire"),
+    all(target_os = "macos", feature = "coreaudio"),
+)))]
 #[derive(Clone, Debug)]
 pub struct AudioDevice {
     /// Human-readable name.
     pub display_name: String,
-    /// PipeWire node name.
+    /// Caller-opaque device identifier — empty means "system default".
     pub node_name: String,
 }
 
-/// Stub for non-PipeWire builds — returns only "Default".
-#[cfg(not(feature = "pipewire"))]
+/// Stub `list_audio_sinks` — returns only "Default".
+#[cfg(not(any(
+    all(target_os = "linux", feature = "pipewire"),
+    all(target_os = "macos", feature = "coreaudio"),
+)))]
+#[must_use]
 pub fn list_audio_sinks() -> Vec<AudioDevice> {
     vec![AudioDevice {
         display_name: "Default".to_string(),

--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -6,6 +6,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use sdr_pipeline::sink_manager::Sink;
 use sdr_types::{SinkError, Stereo};
 
+use crate::ring::AudioRingBuffer;
+
 /// Audio sample rate in Hz.
 const AUDIO_SAMPLE_RATE: u32 = 48_000;
 
@@ -28,87 +30,6 @@ const FRAME_SIZE: usize = (AUDIO_CHANNELS as usize) * std::mem::size_of::<f32>()
 
 /// Sentinel message sent via the PipeWire channel to request shutdown.
 struct Quit;
-
-/// Lock-based SPSC ring buffer for interleaved audio samples.
-///
-/// Pre-allocated at startup — zero allocation during streaming.
-/// The Mutex is held only for memcpy duration (microseconds).
-struct AudioRingBuffer {
-    buf: std::sync::Mutex<AudioRingInner>,
-}
-
-struct AudioRingInner {
-    data: Vec<f32>,
-    read_pos: usize,
-    write_pos: usize,
-    count: usize,
-    capacity: usize,
-}
-
-impl AudioRingBuffer {
-    fn new(capacity: usize) -> Self {
-        Self {
-            buf: std::sync::Mutex::new(AudioRingInner {
-                data: vec![0.0; capacity],
-                read_pos: 0,
-                write_pos: 0,
-                count: 0,
-                capacity,
-            }),
-        }
-    }
-
-    /// Write samples into the ring buffer. Drops oldest data if full.
-    fn write(&self, samples: &[f32]) {
-        let Ok(mut inner) = self.buf.lock() else {
-            return;
-        };
-        let cap = inner.capacity;
-        let mut wp = inner.write_pos;
-        let mut rp = inner.read_pos;
-        let mut cnt = inner.count;
-        for &s in samples {
-            inner.data[wp] = s;
-            wp = (wp + 1) % cap;
-            if cnt < cap {
-                cnt += 1;
-            } else {
-                rp = (rp + 1) % cap;
-            }
-        }
-        inner.write_pos = wp;
-        inner.read_pos = rp;
-        inner.count = cnt;
-    }
-
-    /// Clear the ring buffer (used on start/stop to avoid replaying stale audio).
-    fn clear(&self) {
-        let Ok(mut inner) = self.buf.lock() else {
-            return;
-        };
-        inner.read_pos = 0;
-        inner.write_pos = 0;
-        inner.count = 0;
-    }
-
-    /// Read up to `output.len()` samples. Returns count read.
-    /// Uses `try_lock` to avoid blocking the PipeWire RT callback thread.
-    fn read(&self, output: &mut [f32]) -> usize {
-        let Ok(mut inner) = self.buf.try_lock() else {
-            return 0; // Contended — return silence this cycle.
-        };
-        let to_read = output.len().min(inner.count);
-        let mut rp = inner.read_pos;
-        let cap = inner.capacity;
-        for out in output.iter_mut().take(to_read) {
-            *out = inner.data[rp];
-            rp = (rp + 1) % cap;
-        }
-        inner.read_pos = rp;
-        inner.count -= to_read;
-        to_read
-    }
-}
 
 /// Audio output sink backed by PipeWire.
 pub struct AudioSink {

--- a/crates/sdr-sink-audio/src/pw_impl.rs
+++ b/crates/sdr-sink-audio/src/pw_impl.rs
@@ -18,8 +18,17 @@ const AUDIO_CHANNELS: u32 = 2;
 /// ~1 second at 48 kHz stereo = 96,000 samples.
 const RING_CAPACITY: usize = 96_000;
 
-/// Initial capacity for the stereo interleave buffer in `write_samples`.
-const INTERLEAVE_BUF_INITIAL_CAP: usize = 1024;
+/// Capacity for the stereo interleave buffer in `write_samples`.
+///
+/// Sized to match the ring buffer (the largest write that could ever
+/// fit in the ring without dropping data) so the hot path **never**
+/// reallocates: the buffer is `clear()`ed and re-pushed each call but
+/// never grows beyond its initial capacity for any input within the
+/// ring's natural ceiling. The previous value of 1024 silently grew
+/// the Vec for any write larger than 512 stereo frames — caught by
+/// CodeRabbit on PR #253 (against the parallel CoreAudio backend
+/// which inherited the same constant from this file).
+const INTERLEAVE_BUF_CAPACITY: usize = RING_CAPACITY;
 
 /// Initial sample capacity for the PipeWire callback read buffer.
 /// 4x typical quantum (1024 frames x 2 channels) to avoid RT reallocation.
@@ -157,7 +166,7 @@ impl AudioSink {
             quit_tx: None,
             pw_thread: None,
             target_node: String::new(),
-            interleave_buf: Vec::with_capacity(INTERLEAVE_BUF_INITIAL_CAP),
+            interleave_buf: Vec::with_capacity(INTERLEAVE_BUF_CAPACITY),
         }
     }
 
@@ -182,6 +191,16 @@ impl AudioSink {
 
     /// Send stereo audio samples to PipeWire for playback.
     ///
+    /// The interleave buffer is pre-sized to `INTERLEAVE_BUF_CAPACITY`
+    /// (= `RING_CAPACITY` f32s = ~48,000 stereo frames). For any input
+    /// up to that ceiling the call is **allocation-free**. Inputs
+    /// larger than that ceiling would also overflow the ring buffer
+    /// itself, so they're a contract violation; debug builds
+    /// `debug_assert!` to catch this loudly, release builds let
+    /// `Vec::push` reallocate once and then proceed with the larger
+    /// capacity (a one-time cost we accept as graceful degradation
+    /// rather than dropping samples).
+    ///
     /// # Errors
     ///
     /// Returns `SinkError::NotRunning` if the sink has not been started.
@@ -191,7 +210,15 @@ impl AudioSink {
             return Err(SinkError::NotRunning);
         }
 
-        // Interleave stereo into pre-allocated buffer (zero allocation).
+        debug_assert!(
+            samples.len() * 2 <= INTERLEAVE_BUF_CAPACITY,
+            "write_samples called with {} stereo frames, exceeds interleave buffer capacity {} (would overflow the ring buffer too)",
+            samples.len(),
+            INTERLEAVE_BUF_CAPACITY / 2
+        );
+
+        // Interleave stereo into pre-allocated buffer (zero allocation
+        // under normal sizing).
         self.interleave_buf.clear();
         for s in samples {
             self.interleave_buf.push(s.l);

--- a/crates/sdr-sink-audio/src/ring.rs
+++ b/crates/sdr-sink-audio/src/ring.rs
@@ -41,7 +41,18 @@ struct AudioRingInner {
 impl AudioRingBuffer {
     /// Create a new ring buffer with the given capacity in `f32` samples.
     /// For interleaved stereo audio, capacity should be `frames * 2`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero. The write/read paths use `% capacity`
+    /// arithmetic and would panic on the first call against a zero-cap
+    /// ring; failing fast at construction surfaces the bug at the call
+    /// site instead of inside the audio I/O thread later. The constant
+    /// callers (`pw_impl::RING_CAPACITY`, `coreaudio_impl::RING_CAPACITY`)
+    /// always pass non-zero values, so in practice this assert only
+    /// fires for tests or future callers that compute capacity dynamically.
     pub(crate) fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "AudioRingBuffer capacity must be non-zero");
         Self {
             buf: std::sync::Mutex::new(AudioRingInner {
                 data: vec![0.0; capacity],
@@ -222,5 +233,14 @@ mod tests {
         let n = ring.read(&mut out);
         assert_eq!(n, 4);
         assert_eq!(out, [10.0, 20.0, 30.0, 40.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be non-zero")]
+    fn zero_capacity_panics_at_construction() {
+        // Surfaces the bug at the call site instead of letting an
+        // invalid ring survive until the first write tries to do
+        // `% 0` on the audio I/O thread.
+        let _ = AudioRingBuffer::new(0);
     }
 }

--- a/crates/sdr-sink-audio/src/ring.rs
+++ b/crates/sdr-sink-audio/src/ring.rs
@@ -55,14 +55,14 @@ impl AudioRingBuffer {
 
     /// Write samples into the ring buffer. Drops oldest data if full.
     ///
-    /// Mutex poisoning is silently dropped on the producer side: a panic
-    /// in a previous holder of the lock should not propagate into the
-    /// DSP thread, which has no useful recovery action. The frame is
-    /// lost; the next frame will succeed (the lock is released even on
-    /// poison).
+    /// Mutex poisoning is recovered via [`PoisonError::into_inner`]
+    /// rather than dropped silently. A panic in a previous holder of
+    /// the lock should not permanently mute the buffer for the rest
+    /// of the process — the next frame must still get through.
     pub(crate) fn write(&self, samples: &[f32]) {
-        let Ok(mut inner) = self.buf.lock() else {
-            return;
+        let mut inner = match self.buf.lock() {
+            Ok(inner) => inner,
+            Err(poisoned) => poisoned.into_inner(),
         };
         let cap = inner.capacity;
         let mut wp = inner.write_pos;
@@ -83,9 +83,12 @@ impl AudioRingBuffer {
     }
 
     /// Clear the ring buffer (used on start/stop to avoid replaying stale audio).
+    ///
+    /// Mutex poisoning is recovered the same way as [`Self::write`].
     pub(crate) fn clear(&self) {
-        let Ok(mut inner) = self.buf.lock() else {
-            return;
+        let mut inner = match self.buf.lock() {
+            Ok(inner) => inner,
+            Err(poisoned) => poisoned.into_inner(),
         };
         inner.read_pos = 0;
         inner.write_pos = 0;
@@ -95,11 +98,17 @@ impl AudioRingBuffer {
     /// Read up to `output.len()` samples. Returns count read.
     ///
     /// Uses `try_lock` to avoid blocking the audio I/O callback thread.
-    /// Returns 0 on contention; the caller renders silence for that
-    /// quantum and tries again on the next callback.
+    /// Returns 0 on contention (`WouldBlock`); the caller renders
+    /// silence for that quantum and tries again on the next callback.
+    /// Mutex poisoning is recovered via `into_inner()` so a previous
+    /// panic does not permanently mute the audio path.
     pub(crate) fn read(&self, output: &mut [f32]) -> usize {
-        let Ok(mut inner) = self.buf.try_lock() else {
-            return 0; // Contended — return silence this cycle.
+        use std::sync::TryLockError;
+
+        let mut inner = match self.buf.try_lock() {
+            Ok(inner) => inner,
+            Err(TryLockError::WouldBlock) => return 0, // Contended this cycle.
+            Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
         };
         let to_read = output.len().min(inner.count);
         let mut rp = inner.read_pos;

--- a/crates/sdr-sink-audio/src/ring.rs
+++ b/crates/sdr-sink-audio/src/ring.rs
@@ -1,0 +1,217 @@
+//! Lock-based SPSC ring buffer for interleaved audio samples.
+//!
+//! Used by both backend implementations (`pw_impl` for PipeWire on Linux,
+//! `coreaudio_impl` for AUHAL on macOS). Pre-allocated at startup; the
+//! mutex is held only for memcpy duration (single-digit microseconds in
+//! practice), so it never blocks the audio I/O thread for a meaningful
+//! length of time. The reader uses `try_lock` and returns "0 samples"
+//! on contention, which manifests as a single missed quantum (≈5–10 ms
+//! of silence) — preferable to blocking the real-time callback.
+//!
+//! Behavior is intentionally simple:
+//!
+//! - **Producer side** (`write`) drops the oldest data when the buffer
+//!   is full. The DSP thread always wins; we'd rather smear time than
+//!   block the audio path.
+//! - **Consumer side** (`read`) is non-blocking via `try_lock` and
+//!   returns the number of samples actually copied (zero on contention
+//!   or empty buffer).
+//! - **`clear`** is used on stream start/stop to avoid replaying stale
+//!   audio when the source is restarted.
+//!
+//! This module is `pub(crate)` — it's an internal primitive shared by
+//! the two backends, not part of the crate's public surface.
+
+/// Lock-based SPSC ring buffer for interleaved audio samples.
+///
+/// Pre-allocated at startup — zero allocation during streaming.
+/// The mutex is held only for memcpy duration.
+pub(crate) struct AudioRingBuffer {
+    buf: std::sync::Mutex<AudioRingInner>,
+}
+
+struct AudioRingInner {
+    data: Vec<f32>,
+    read_pos: usize,
+    write_pos: usize,
+    count: usize,
+    capacity: usize,
+}
+
+impl AudioRingBuffer {
+    /// Create a new ring buffer with the given capacity in `f32` samples.
+    /// For interleaved stereo audio, capacity should be `frames * 2`.
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            buf: std::sync::Mutex::new(AudioRingInner {
+                data: vec![0.0; capacity],
+                read_pos: 0,
+                write_pos: 0,
+                count: 0,
+                capacity,
+            }),
+        }
+    }
+
+    /// Write samples into the ring buffer. Drops oldest data if full.
+    ///
+    /// Mutex poisoning is silently dropped on the producer side: a panic
+    /// in a previous holder of the lock should not propagate into the
+    /// DSP thread, which has no useful recovery action. The frame is
+    /// lost; the next frame will succeed (the lock is released even on
+    /// poison).
+    pub(crate) fn write(&self, samples: &[f32]) {
+        let Ok(mut inner) = self.buf.lock() else {
+            return;
+        };
+        let cap = inner.capacity;
+        let mut wp = inner.write_pos;
+        let mut rp = inner.read_pos;
+        let mut cnt = inner.count;
+        for &s in samples {
+            inner.data[wp] = s;
+            wp = (wp + 1) % cap;
+            if cnt < cap {
+                cnt += 1;
+            } else {
+                rp = (rp + 1) % cap;
+            }
+        }
+        inner.write_pos = wp;
+        inner.read_pos = rp;
+        inner.count = cnt;
+    }
+
+    /// Clear the ring buffer (used on start/stop to avoid replaying stale audio).
+    pub(crate) fn clear(&self) {
+        let Ok(mut inner) = self.buf.lock() else {
+            return;
+        };
+        inner.read_pos = 0;
+        inner.write_pos = 0;
+        inner.count = 0;
+    }
+
+    /// Read up to `output.len()` samples. Returns count read.
+    ///
+    /// Uses `try_lock` to avoid blocking the audio I/O callback thread.
+    /// Returns 0 on contention; the caller renders silence for that
+    /// quantum and tries again on the next callback.
+    pub(crate) fn read(&self, output: &mut [f32]) -> usize {
+        let Ok(mut inner) = self.buf.try_lock() else {
+            return 0; // Contended — return silence this cycle.
+        };
+        let to_read = output.len().min(inner.count);
+        let mut rp = inner.read_pos;
+        let cap = inner.capacity;
+        for out in output.iter_mut().take(to_read) {
+            *out = inner.data[rp];
+            rp = (rp + 1) % cap;
+        }
+        inner.read_pos = rp;
+        inner.count -= to_read;
+        to_read
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    // The ring buffer copies samples bit-for-bit; comparing exact f32
+    // values here is correct because no arithmetic is performed on the
+    // values between write and read.
+    clippy::float_cmp,
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_then_read_round_trip() {
+        let ring = AudioRingBuffer::new(16);
+        ring.write(&[1.0, 2.0, 3.0, 4.0]);
+
+        let mut out = [0.0_f32; 4];
+        let n = ring.read(&mut out);
+
+        assert_eq!(n, 4);
+        assert_eq!(out, [1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn read_returns_zero_when_empty() {
+        let ring = AudioRingBuffer::new(16);
+        let mut out = [0.0_f32; 4];
+        assert_eq!(ring.read(&mut out), 0);
+    }
+
+    #[test]
+    fn read_partial_when_buffer_smaller_than_request() {
+        let ring = AudioRingBuffer::new(16);
+        ring.write(&[1.0, 2.0]);
+
+        let mut out = [0.0_f32; 4];
+        let n = ring.read(&mut out);
+
+        assert_eq!(n, 2);
+        assert_eq!(out[..2], [1.0, 2.0]);
+        // Trailing slots are untouched.
+        assert_eq!(out[2..], [0.0, 0.0]);
+    }
+
+    #[test]
+    fn write_overflow_drops_oldest() {
+        // Capacity 4: write 6, expect to read the most recent 4.
+        let ring = AudioRingBuffer::new(4);
+        ring.write(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let mut out = [0.0_f32; 4];
+        let n = ring.read(&mut out);
+
+        assert_eq!(n, 4);
+        assert_eq!(out, [3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn clear_resets_state() {
+        let ring = AudioRingBuffer::new(16);
+        ring.write(&[1.0, 2.0, 3.0]);
+        ring.clear();
+
+        let mut out = [0.0_f32; 4];
+        assert_eq!(ring.read(&mut out), 0);
+    }
+
+    #[test]
+    fn write_then_read_then_write_continues_correctly() {
+        let ring = AudioRingBuffer::new(8);
+        ring.write(&[1.0, 2.0, 3.0]);
+
+        let mut out = [0.0_f32; 2];
+        assert_eq!(ring.read(&mut out), 2);
+        assert_eq!(out, [1.0, 2.0]);
+
+        ring.write(&[4.0, 5.0]);
+
+        let mut out = [0.0_f32; 4];
+        let n = ring.read(&mut out);
+        assert_eq!(n, 3);
+        assert_eq!(out[..3], [3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn wraparound_across_buffer_end() {
+        // Capacity 4. Write 3, read 3, then write 4 — the writes wrap.
+        let ring = AudioRingBuffer::new(4);
+        ring.write(&[1.0, 2.0, 3.0]);
+
+        let mut out = [0.0_f32; 3];
+        ring.read(&mut out);
+
+        ring.write(&[10.0, 20.0, 30.0, 40.0]);
+
+        let mut out = [0.0_f32; 4];
+        let n = ring.read(&mut out);
+        assert_eq!(n, 4);
+        assert_eq!(out, [10.0, 20.0, 30.0, 40.0]);
+    }
+}


### PR DESCRIPTION
Closes #231.

Adds a CoreAudio backend to `sdr-sink-audio` that satisfies the existing `Sink` trait, mirroring the PipeWire impl behind the same interface. After this PR, `cargo build --workspace` on macOS produces an audio path that talks to AUHAL instead of falling through to the no-op stub. Linux remains unchanged.

This PR folds together both sub-PRs the spec called for (extract `AudioRingBuffer` + new `coreaudio_impl.rs`), per the agreement to keep PRs beefy enough that the rate limit doesn't bite.

## What's in this PR

### PR A — Shared `AudioRingBuffer` extraction

- New `crates/sdr-sink-audio/src/ring.rs`. The lock-based SPSC ring buffer that used to live inline in `pw_impl.rs` is now `pub(crate)` so both backends can reuse it. Behavior identical (memcpy-only critical sections, drop-oldest on overflow, `try_lock` reads on the consumer side so the audio I/O thread never blocks).
- Adds **7 unit tests** the original code never had: round-trip, empty-read, partial-read, overflow drops oldest, clear, write-read-write continuity, and wraparound across the buffer end.
- `pw_impl.rs` strips ~80 lines of inline ring buffer and imports from `crate::ring`. Existing PipeWire tests pass unchanged.

### PR B — `coreaudio_impl.rs` and the cfg dispatch

- New `crates/sdr-sink-audio/src/coreaudio_impl.rs`. Uses the `coreaudio-rs 0.14` high-level wrapper around AUHAL's \`kAudioUnitSubType_DefaultOutput\` audio unit. Format is the canonical Mac AudioUnit format: 48 kHz f32 stereo, non-interleaved linear PCM. AUHAL's internal converter handles any sample-rate mismatch with the device.
- The render callback is **fully allocation-free**. The de-interleave scratch buffer is heap-allocated **once** at sink construction (cold path) and passed into the callback closure by `&mut`. The callback uses \`scratch.len() / 2\` as the per-quantum frame ceiling and degrades to silence + a throttled `tracing::warn` on overflow rather than allocating on the audio I/O thread. Heap allocation on the CoreAudio render thread can block on the system allocator and miss a deadline; silence is the correct safe fallback. Debug builds also \`debug_assert!\` so the overflow path fires loudly during dev.
- `list_audio_sinks` enumerates output devices via \`get_audio_device_ids_for_scope(Scope::Global)\`, filters via \`get_audio_device_supports_scope(_, Scope::Output)\`, dedupes the system default against the enumerated list, and always prepends a "Default" entry with empty \`node_name\`.
- `set_target` is implemented but unused by the v1 MVP — see the spec deviations below.
- **5 unit tests**: lifecycle (\`new\`, \`write_before_start\`, \`stop_before_start\`), \`set_sample_rate\` validation, and a real CoreAudio call to \`list_audio_sinks\` that verifies the "Default" entry exists.

### Wiring

- \`crates/sdr-sink-audio/Cargo.toml\` adds a \`coreaudio\` cargo feature and a target-conditional \`coreaudio-rs\` dep on macOS. The crate builds on Linux with \`pipewire\`, on macOS with \`coreaudio\`, and falls through to the stub on bare configurations.
- \`crates/sdr-sink-audio/src/lib.rs\` cfg-dispatches between the three backends. The stub stays as a fallback for unusual configurations (Windows builds, or \`--no-default-features\` on macOS or Linux).
- \`crates/sdr-core/Cargo.toml\` swaps the unconditional \`sdr-sink-audio.workspace = true\` for two \`[target.'cfg(target_os = …)']\` overrides that pull in the right backend feature automatically. Downstream crates don't have to think about it.
- Root \`Cargo.toml\` adds \`coreaudio-rs = "0.14"\` to \`[workspace.dependencies]\`.

## Spec deviations from \`docs/superpowers/specs/2026-04-12-coreaudio-sink-design.md\`

1. **\`coreaudio-rs 0.14\` instead of the spec's 0.12.** 0.12 is no longer maintained; 0.14 is the current release with the same surface for what we use.

2. **\`AudioDevice::node_name\` is the device display name in v1**, not the CoreAudio device UID the spec called for. \`coreaudio-rs 0.14\` does not expose a UID helper, so the spec'd approach would require dropping into raw \`coreaudio-sys\` plus a \`core-foundation\` dep for \`CFString → String\` plus an \`#[allow(unsafe_code)]\` workspace-lint override. **In v1 nothing observes \`node_name\`** (the device picker is v2 issue #237 and \`set_target\` is never called from MVP code), so I deferred the UID switch to the same PR that lands the picker. Documented in module-level comments inside \`coreaudio_impl.rs\` so the next reviewer doesn't have to re-derive the trade-off.

3. **No \`sdr-dsp\` resampler upstream** of the ring buffer for non-48kHz devices. The spec called for explicit pre-resampling; this PR lets AUHAL's internal converter handle it instead. The engine still always sees 48 kHz at the \`Sink\` interface. If quality issues with non-default device rates surface, swapping in \`sdr-dsp::Resampler\` is a localized change.

4. **Render scratch buffer is heap-allocated once at sink construction** instead of stack-allocated per-callback. The spec described a stack array of \`[f32; MAX_CB_FRAMES * 2]\` (32 KB); clippy's \`large_stack_arrays\` lint correctly objected (32 KB > 16 KB threshold), and the heap-once pattern is strictly better anyway: zero allocation on the audio thread, lower per-callback overhead, no stack pressure on the CoreAudio I/O thread. The contract — *no allocation on the RT thread* — is preserved; only the *location* of the one-time allocation changed.

## Local validation (macOS, stable 1.94.1)

Rebased on top of #252 (sherpa-cpu Linux build fix):

| Check | Result |
|---|---|
| \`cargo build --workspace\` | ✅ |
| \`cargo test --workspace\` | ✅ — **533 passing**, 0 failed, 12 ignored (hardware-gated) |
| \`cargo clippy --all-targets --workspace -- -D warnings\` | ✅ |
| \`cargo fmt --all -- --check\` | ✅ |

The 12 new tests are: **7 in \`ring\`** (extracted ring buffer tests it never had) + **5 in \`coreaudio_impl\`** (lifecycle + a real CoreAudio call to \`list_audio_sinks\` that confirms device enumeration works on this Mac).

## What I could not validate locally

- **No audible end-to-end smoke test.** I don't have an RTL-SDR plugged into this Mac, and the GTK frontend that drives the engine is Linux-only. The unit tests confirm \`list_audio_sinks\` enumerates real devices and the build links \`AudioUnit.framework\` cleanly, but actually opening the AU and pumping audio through to speakers is unverified locally. CodeRabbit + manual testing on a real RTL-SDR macOS box is the safety net here. (M6 will fold in the Xcode-side smoke testing — see issue #234.)
- **Stop-during-callback race.** Dropping the AudioUnit calls \`Drop\` on the closure (which drops the captured Arc and scratch buffer). I'm relying on \`coreaudio-rs\` to make this clean. If a callback fires *during* \`unit.stop()\`, the closure environment is still alive (the Arc to the ring buffer is non-null) so the read is safe. Worth keeping an eye on if anyone reports occasional crashes on stop.

## Test plan

- [ ] CodeRabbit review of the CoreAudio backend and the spec deviations
- [ ] Linux CI: \`cargo build --workspace\` + \`cargo test --workspace\` + \`cargo clippy\` (verifies the ring buffer extraction didn't break PipeWire)
- [ ] Manual macOS smoke test on a real box: build, run \`list_audio_sinks\` example (or whatever ad-hoc), confirm devices enumerate
- [ ] Eventually (M6): plug an RTL-SDR into a Mac, build the SwiftUI app, tune FM 100.7, verify audio through built-in speakers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native CoreAudio output on macOS with selectable output devices and a visible "Default".
  * Platform-specific audio backends: PipeWire on Linux, CoreAudio on macOS, with a safe fallback.

* **Chores**
  * Scoped macOS dependency and feature gating for CoreAudio.
  * Shared, preallocated internal audio ring buffer and allocation-reduced interleave path.
  * Engine sample rate fixed to 48 kHz; backend dispatch updated for OS + feature.

* **Tests**
  * Unit tests covering buffer behavior (read/write, overwrite, clear, wraparound).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->