### PR TITLE
feat(transcription): NVIDIA Parakeet-TDT 0.6b v3 + VAD threshold slider (#223)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ sdr-sink-audio      → PipeWire/CoreAudio output (depends on: types, pipeline, 
 sdr-sink-network    → TCP/UDP audio output (depends on: types, pipeline, config)
 sdr-radio           → Radio decoder, demod, IF/AF chains (depends on: types, dsp, pipeline)
 sdr-radioreference  → RadioReference.com SOAP client (depends on: types, config)
-sdr-transcription   → Whisper OR sherpa-onnx backend, Silero VAD, spectral denoiser
+sdr-transcription   → Whisper OR Sherpa-onnx backend, Silero VAD, spectral denoiser
 sdr-core            → Headless cross-platform engine facade (macOS port path)
 sdr-splash          → Cross-platform splash subprocess controller (stdin wire protocol)
 sdr-splash-gtk      → Linux GTK4 splash window implementation
@@ -32,6 +32,7 @@ sdr (binary)        → Entry point (depends on: ui, core, splash, transcription
 **Whisper and Sherpa-onnx are mutually exclusive cargo features.** The `sdr-transcription` crate has `compile_error!` guards enforcing exactly one. This was a PR 2-era workaround for a heap corruption between whisper-rs's libstdc++ state and ONNX Runtime's `ParseSemVerVersion` regex constructors that only manifests when both C++ dep trees are in the same binary.
 
 **Build flavors:**
+
 ```bash
 # Whisper (default) — multilingual, mature GPU acceleration
 make install CARGO_FLAGS="--release"                                # Whisper CPU

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,23 +4,48 @@ Rust port of SDR++ — software-defined radio application with GTK4 UI.
 
 ## Architecture
 
-13-crate workspace with clear dependency boundaries:
+17-crate workspace with clear dependency boundaries:
 
 ```text
 sdr-types           → Foundation types, errors, constants (no internal deps)
 sdr-dsp             → Pure DSP: math, filters, FFT, demod, resampling (depends on: types)
-sdr-config          → JSON configuration persistence (depends on: types)
+sdr-config          → JSON configuration persistence + OS keyring (depends on: types)
 sdr-pipeline        → Threading, streaming, signal path (depends on: types, dsp, config)
-sdr-rtlsdr          → Pure Rust librtlsdr port — USB, tuner drivers (no internal deps)
+sdr-rtlsdr          → Rust port of librtlsdr over rusb — 5 tuner families (no internal deps)
 sdr-source-rtlsdr   → RTL-SDR source module (depends on: types, pipeline, rtlsdr, config)
 sdr-source-network  → TCP/UDP IQ source (depends on: types, pipeline, config)
 sdr-source-file     → WAV file playback source (depends on: types, pipeline, config)
 sdr-sink-audio      → PipeWire/CoreAudio output (depends on: types, pipeline, config)
 sdr-sink-network    → TCP/UDP audio output (depends on: types, pipeline, config)
 sdr-radio           → Radio decoder, demod, IF/AF chains (depends on: types, dsp, pipeline)
-sdr-ui              → GTK4/libadwaita UI (depends on: all above)
-sdr (binary)        → Entry point (depends on: ui, pipeline, config, sources, sinks)
+sdr-radioreference  → RadioReference.com SOAP client (depends on: types, config)
+sdr-transcription   → Whisper OR sherpa-onnx backend, Silero VAD, spectral denoiser
+sdr-core            → Headless cross-platform engine facade (macOS port path)
+sdr-splash          → Cross-platform splash subprocess controller (stdin wire protocol)
+sdr-splash-gtk      → Linux GTK4 splash window implementation
+sdr-ui              → GTK4/libadwaita UI — Linux-only (depends on: all above)
+sdr (binary)        → Entry point (depends on: ui, core, splash, transcription, …)
 ```
+
+## Transcription backend feature mutex
+
+**Whisper and Sherpa-onnx are mutually exclusive cargo features.** The `sdr-transcription` crate has `compile_error!` guards enforcing exactly one. This was a PR 2-era workaround for a heap corruption between whisper-rs's libstdc++ state and ONNX Runtime's `ParseSemVerVersion` regex constructors that only manifests when both C++ dep trees are in the same binary.
+
+**Build flavors:**
+```bash
+# Whisper (default) — multilingual, mature GPU acceleration
+make install CARGO_FLAGS="--release"                                # Whisper CPU
+make install CARGO_FLAGS="--release --features whisper-cuda"        # User's daily driver (RTX 4080 Super)
+make install CARGO_FLAGS="--release --features whisper-hipblas"     # AMD ROCm
+make install CARGO_FLAGS="--release --features whisper-vulkan"      # Cross-vendor GPU
+
+# Sherpa-onnx — Zipformer / Moonshine / Parakeet, English-only, CPU today
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"
+```
+
+**Dual-build testing rule:** any change to `sdr-transcription` or its callers MUST be tested with BOTH `whisper-cuda` AND `sherpa-cpu` builds sequentially. The cfg gates make it easy to break one without noticing. CI runs both flavors.
+
+Runtime model selection for Sherpa builds is in-place (drop-old-recognizer-build-new) and does NOT require a restart — PR 5 architecture. The PR 2 "pre-GTK init" half of the heap-corruption workaround turned out to be unnecessary once the feature mutex was in place; only the first recognizer needs pre-GTK creation, and subsequent swaps post-GTK work fine.
 
 ## Build & Test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Rust port of SDR++ — software-defined radio application with GTK4 UI.
 
 ## Architecture
 
-17-crate workspace with clear dependency boundaries:
+18-member workspace (root binary + 17 library crates) with clear dependency boundaries:
 
 ```text
 sdr-types           → Foundation types, errors, constants (no internal deps)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "sdr-transcription",
  "sdr-types",
  "sdr-ui",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ sdr-sink-audio.workspace = true
 sdr-sink-network.workspace = true
 sdr-splash.workspace = true
 sdr-transcription.workspace = true
+serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow.workspace = true

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Two mutually exclusive backends, selected at build time (see the install section
 
 ### Under the Hood
 
-- 17-crate workspace with clear dependency boundaries
+- 18-member workspace (root binary + 17 library crates) with clear dependency boundaries
 - Pure DSP functions (no threading, no I/O, no side effects)
 - Zero per-frame heap allocations on hot paths
 - Lock-based SPSC audio ring buffer between DSP and audio threads
@@ -179,7 +179,7 @@ sdr-rs
 
 ## Architecture
 
-17-crate workspace with clear dependency boundaries:
+18-member workspace (root binary + 17 library crates) with clear dependency boundaries:
 
 ```text
 sdr (binary)              Entry point

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 ### Radio
 
 - 8 demodulation modes: WFM, NFM, AM, DSB, USB, LSB, CW, RAW
-- RTL-SDR hardware support (pure Rust USB driver, no C library needed)
+- RTL-SDR hardware support — pure Rust port of `librtlsdr` (all 5 tuner families) over `rusb` (libusb wrapper)
 - TCP/UDP network IQ source and sink
 - WAV file IQ playback with looping
 - Audio notch filter (biquad IIR, 20-20,000 Hz)
+- Auto-squelch with noise floor tracking
 - Bookmark tuning profiles with full state capture/restore
 
 ### Display
@@ -31,12 +32,27 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 
 ### Transcription
 
-- Live speech-to-text via Whisper — 5 model sizes from tiny (75 MB) to large-v3 (3.1 GB)
-- Optional GPU acceleration: CUDA (NVIDIA), ROCm/HIP (AMD), Vulkan, Metal (macOS)
-- Slide-out transcript panel with timestamped log and model selector
+Two mutually exclusive backends, selected at build time (see the install section below):
+
+**Whisper backend** — OpenAI's Whisper via `whisper-rs`, multilingual, mature GPU support
+- 5 model sizes from tiny (75 MB) to large-v3 (3.1 GB)
+- Optional GPU acceleration: CUDA (NVIDIA), ROCm/HIP (AMD), Vulkan, Metal
+- RMS-gated chunked inference with configurable silence threshold
+
+**Sherpa-onnx backend** — k2-fsa's sherpa-onnx, English only (today), streaming + offline
+- **Streaming Zipformer** — true real-time transcription with word-by-word live captions
+- **Moonshine Tiny / Base** — UsefulSensors' edge-optimized offline models (27M / 61M params)
+- **Parakeet-TDT 0.6b v3** — NVIDIA, #1 on the OpenASR leaderboard (600M params, highest accuracy)
+- **Runtime model swap** — change models from the dropdown without restarting the app
+- **Live captions with display mode toggle** — streaming models render an in-place italic line below the commit log; user can switch to "Final only" mode
+- **Silero VAD** — offline models use Silero voice activity detection with a user-tunable threshold slider for noisy RF audio (NFM/scanner)
+- Auto-downloads models and VAD on first use with a bundled progress splash
+
+**Both backends share:**
+- Slide-out transcript panel with timestamped commit log
 - FFT-based spectral noise gate preprocessor for cleaner recognition
-- Auto-downloads selected model on first use
 - Volume-independent audio tap (transcription unaffected by volume knob)
+- Settings lock during active session to prevent mid-session configuration races
 
 ### Integration
 
@@ -48,7 +64,7 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 
 ### Under the Hood
 
-- 15-crate workspace with clear dependency boundaries
+- 17-crate workspace with clear dependency boundaries
 - Pure DSP functions (no threading, no I/O, no side effects)
 - Zero per-frame heap allocations on hot paths
 - Lock-based SPSC audio ring buffer between DSP and audio threads
@@ -59,31 +75,40 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 
 ### Dependencies
 
+**Always required:**
 - **Rust** 1.85+ (2024 edition)
 - **GTK 4.10+** and **libadwaita 1.5+**
 - **PipeWire** development libraries (Linux audio)
 - **libusb** (for RTL-SDR USB access)
 - **libdbus** (for secure credential storage)
+
+**Whisper backend only** (not needed for Sherpa builds):
 - **cmake** + **C++ compiler** (build-time, for whisper.cpp)
-- **libclang** (build-time, for bindgen if needed)
+- **libclang** (build-time, for bindgen)
 
 #### Arch Linux
 
 ```bash
-sudo pacman -S gtk4 libadwaita pipewire libusb dbus clang cmake
+sudo pacman -S gtk4 libadwaita pipewire libusb dbus
+# Whisper builds also need:
+sudo pacman -S clang cmake
 ```
 
 #### Ubuntu / Debian
 
 ```bash
 sudo apt install libgtk-4-dev libadwaita-1-dev libpipewire-0.3-dev \
-  libusb-1.0-0-dev libdbus-1-dev libclang-dev cmake g++
+  libusb-1.0-0-dev libdbus-1-dev
+# Whisper builds also need:
+sudo apt install libclang-dev cmake g++
 ```
 
 #### macOS
 
 ```bash
-brew install gtk4 libadwaita libusb llvm cmake
+brew install gtk4 libadwaita libusb
+# Whisper builds also need:
+brew install llvm cmake
 ```
 
 ### Compile
@@ -100,17 +125,22 @@ make install
 
 Installs the binary, desktop entry, and icon for app launcher integration.
 
-### Transcription backend (optional)
+### Transcription backend (pick one)
+
+Whisper and Sherpa-onnx are mutually exclusive cargo features — you build with exactly one backend. Default is `whisper-cpu`. Whisper GPU builds require the corresponding toolkit (CUDA, ROCm, Vulkan SDK).
 
 ```bash
-make install CARGO_FLAGS="--release --features whisper-cuda"      # NVIDIA
-make install CARGO_FLAGS="--release --features whisper-hipblas"   # AMD ROCm
-make install CARGO_FLAGS="--release --features whisper-vulkan"    # Cross-vendor
+# Whisper backend (default) — multilingual, mature GPU acceleration
 make install CARGO_FLAGS="--release"                               # Whisper CPU (default)
-make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"  # Sherpa CPU
+make install CARGO_FLAGS="--release --features whisper-cuda"       # NVIDIA GPU
+make install CARGO_FLAGS="--release --features whisper-hipblas"    # AMD ROCm
+make install CARGO_FLAGS="--release --features whisper-vulkan"     # Cross-vendor GPU
+
+# Sherpa-onnx backend — Zipformer / Moonshine / Parakeet, English-only, CPU today
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"
 ```
 
-Requires the corresponding GPU toolkit (CUDA toolkit, ROCm, Vulkan SDK).
+With a Sherpa build, you pick the specific model (Zipformer, Moonshine Tiny/Base, or Parakeet) at runtime from the transcript panel dropdown — no rebuild required, and switching is an in-place recognizer swap.
 
 ### Run tests
 
@@ -149,19 +179,22 @@ sdr-rs
 
 ## Architecture
 
-15-crate workspace with clear dependency boundaries:
+17-crate workspace with clear dependency boundaries:
 
 ```text
 sdr (binary)              Entry point
-sdr-ui                    GTK4/libadwaita UI
+sdr-ui                    GTK4/libadwaita UI (Linux-only)
+sdr-core                  Headless engine facade — cross-platform (macOS port)
 sdr-radio                 Radio decoder, demod, IF/AF chains
 sdr-pipeline              Threading, streaming, signal path
 sdr-dsp                   Pure DSP: math, filters, FFT, demod, resampling
 sdr-types                 Foundation types, errors, constants
 sdr-config                JSON config persistence + OS keyring access
-sdr-rtlsdr                Pure Rust RTL-SDR USB driver (5 tuner chips)
+sdr-rtlsdr                Rust port of librtlsdr (5 tuner families) over rusb
 sdr-radioreference        RadioReference.com SOAP API client
-sdr-transcription         Live speech-to-text via Whisper + spectral denoiser
+sdr-transcription         Whisper / Sherpa-onnx backends + spectral denoiser + Silero VAD
+sdr-splash                Cross-platform splash controller (subprocess driver)
+sdr-splash-gtk            Linux GTK4 splash window implementation
 sdr-source-rtlsdr         RTL-SDR source module
 sdr-source-network        TCP/UDP IQ source
 sdr-source-file           WAV file playback source
@@ -169,7 +202,9 @@ sdr-sink-audio            PipeWire/CoreAudio audio output
 sdr-sink-network          TCP/UDP audio output
 ```
 
-**Signal chain:** Source -> Decimation -> Channel filter -> Demodulator -> AF filter -> Audio sink
+**Signal chain:** Source → Decimation → Channel filter → Demodulator → IF chain (squelch) → AF chain → Audio sink
+
+**Transcription tap:** branches off AFTER the demodulator and AF filter but BEFORE volume scaling, so the recognizer always sees full-amplitude audio regardless of what the speaker side is doing.
 
 DSP functions are pure (no threading, no I/O). Threading and streaming live in `sdr-pipeline`.
 

--- a/crates/sdr-transcription/src/backend.rs
+++ b/crates/sdr-transcription/src/backend.rs
@@ -11,6 +11,18 @@ use std::sync::mpsc;
 #[cfg(feature = "whisper")]
 use crate::model::WhisperModel;
 
+/// Minimum allowed value for [`BackendConfig::vad_threshold`].
+pub const VAD_THRESHOLD_MIN: f32 = 0.10;
+
+/// Maximum allowed value for [`BackendConfig::vad_threshold`].
+pub const VAD_THRESHOLD_MAX: f32 = 0.90;
+
+/// Default value for [`BackendConfig::vad_threshold`]. Matches
+/// sherpa-onnx's upstream Silero VAD default and works well on clean
+/// broadcast audio (WFM talk radio). Drop to ~0.25-0.30 for noisy
+/// scanner/NFM sources.
+pub const VAD_THRESHOLD_DEFAULT: f32 = 0.50;
+
 /// Configuration handed to a backend at `start` time.
 ///
 /// `model` selects which ASR model the backend should load. Additional
@@ -21,9 +33,10 @@ pub struct BackendConfig {
     pub silence_threshold: f32,
     pub noise_gate_ratio: f32,
     /// Silero VAD speech detection threshold (offline models only).
-    /// Range 0.10..=0.90. Default 0.50.
-    /// Lower catches quieter audio (NFM/scanner); higher is stricter
-    /// (talk radio). Ignored by Whisper (no Silero VAD).
+    /// Clamp to `VAD_THRESHOLD_MIN..=VAD_THRESHOLD_MAX`.
+    /// Default `VAD_THRESHOLD_DEFAULT`. Lower catches quieter audio
+    /// (NFM/scanner); higher is stricter (talk radio). Ignored by
+    /// Whisper (no Silero VAD).
     pub vad_threshold: f32,
 }
 

--- a/crates/sdr-transcription/src/backend.rs
+++ b/crates/sdr-transcription/src/backend.rs
@@ -20,6 +20,11 @@ pub struct BackendConfig {
     pub model: ModelChoice,
     pub silence_threshold: f32,
     pub noise_gate_ratio: f32,
+    /// Silero VAD speech detection threshold (offline models only).
+    /// Range 0.10..=0.90. Default 0.50.
+    /// Lower catches quieter audio (NFM/scanner); higher is stricter
+    /// (talk radio). Ignored by Whisper (no Silero VAD).
+    pub vad_threshold: f32,
 }
 
 /// User-facing model selection.

--- a/crates/sdr-transcription/src/backends/mock.rs
+++ b/crates/sdr-transcription/src/backends/mock.rs
@@ -99,7 +99,7 @@ mod tests {
             model,
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
-            vad_threshold: 0.5,
+            vad_threshold: crate::VAD_THRESHOLD_DEFAULT,
         }
     }
 

--- a/crates/sdr-transcription/src/backends/mock.rs
+++ b/crates/sdr-transcription/src/backends/mock.rs
@@ -99,6 +99,7 @@ mod tests {
             model,
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
+            vad_threshold: 0.5,
         }
     }
 

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -26,6 +26,13 @@ pub(super) const AUDIO_RECV_TIMEOUT: Duration = Duration::from_millis(100);
 /// Sample rate sherpa-onnx expects from `accept_waveform`.
 pub(super) const SHERPA_SAMPLE_RATE_HZ: i32 = 16_000;
 
+/// Absolute-difference tolerance for VAD threshold rebuild comparison.
+/// If the requested threshold differs from the currently-held VAD's
+/// threshold by more than this, the worker rebuilds Silero at session
+/// start. Keeps the rebuild policy in sync with the UI's slider step
+/// (0.05) — anything smaller than a slider step is just float drift.
+const VAD_THRESHOLD_REBUILD_EPSILON: f32 = 0.01;
+
 /// Process-wide singleton for the sherpa-onnx host. Stores either a ready
 /// host or the error message from a failed initialization. Set exactly once
 /// by the first successful worker thread.
@@ -303,7 +310,9 @@ fn run_host_loop(
                         let requested = params.vad_threshold;
                         // Treat differences smaller than the slider step as
                         // "same" to avoid pointless rebuilds from float drift.
-                        if (vad.current_threshold() - requested).abs() > 0.01 {
+                        if (vad.current_threshold() - requested).abs()
+                            > VAD_THRESHOLD_REBUILD_EPSILON
+                        {
                             tracing::info!(
                                 old = vad.current_threshold(),
                                 new = requested,

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -132,6 +132,10 @@ pub(super) struct SessionParams {
     pub audio_rx: mpsc::Receiver<Vec<f32>>,
     pub event_tx: mpsc::Sender<TranscriptionEvent>,
     pub noise_gate_ratio: f32,
+    /// Silero VAD threshold requested for this session (offline models only).
+    /// The worker rebuilds the VAD if this differs from the currently-held
+    /// VAD's threshold.
+    pub vad_threshold: f32,
 }
 
 /// Commands sent to the host worker thread.
@@ -291,6 +295,33 @@ fn run_host_loop(
                         super::streaming::run_session(recognizer, params);
                     }
                     RecognizerState::Offline { recognizer, vad } => {
+                        // Check if the user's requested VAD threshold differs
+                        // from the currently-held VAD's threshold. If so,
+                        // rebuild the VAD before starting the session. The
+                        // rebuild is ~50-100ms of ONNX model load — only
+                        // happens when the slider value actually changed.
+                        let requested = params.vad_threshold;
+                        // Treat differences smaller than the slider step as
+                        // "same" to avoid pointless rebuilds from float drift.
+                        if (vad.current_threshold() - requested).abs() > 0.01 {
+                            tracing::info!(
+                                old = vad.current_threshold(),
+                                new = requested,
+                                "rebuilding Silero VAD with new threshold"
+                            );
+                            let vad_path = sherpa_model::silero_vad_path();
+                            match super::silero_vad::SherpaSileroVad::new(&vad_path, requested) {
+                                Ok(new_vad) => {
+                                    *vad = new_vad;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        "VAD rebuild failed; reusing existing VAD"
+                                    );
+                                }
+                            }
+                        }
                         super::offline::run_session(recognizer, vad, params);
                     }
                 }
@@ -425,8 +456,11 @@ fn init_offline(
     tracing::info!("OfflineRecognizer created successfully");
 
     // --- Build SherpaSileroVad ---
+    // Use the default threshold at startup (Option A): if the user has a
+    // persisted non-default threshold, it will cause a ~50-100ms VAD
+    // rebuild on the first session start (in the StartSession handler below).
     let vad_path = sherpa_model::silero_vad_path();
-    let vad = match SherpaSileroVad::new(&vad_path) {
+    let vad = match SherpaSileroVad::new(&vad_path, super::silero_vad::SILERO_THRESHOLD) {
         Ok(v) => v,
         Err(e) => {
             let msg = format!("Silero VAD creation failed: {e}");

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -248,10 +248,15 @@ fn run_host_loop(
             Ok(state) => state,
             Err(()) => return, // init_online already published Failed and stored the error
         },
-        ModelKind::OfflineMoonshine => match init_offline(model, &event_tx) {
-            Ok(state) => state,
-            Err(()) => return,
-        },
+        // Both offline kinds share init_offline — only the recognizer
+        // config builder differs, and that branching happens inside
+        // init_offline based on model.kind() again.
+        ModelKind::OfflineMoonshine | ModelKind::OfflineNemoTransducer => {
+            match init_offline(model, &event_tx) {
+                Ok(state) => state,
+                Err(()) => return,
+            }
+        }
     };
 
     // --- Phase 3: build SherpaHost and store in SHERPA_HOST ---
@@ -305,7 +310,8 @@ fn run_host_loop(
                     crate::sherpa_model::ModelKind::OnlineTransducer => {
                         init_online(new_model, &event_tx)
                     }
-                    crate::sherpa_model::ModelKind::OfflineMoonshine => {
+                    crate::sherpa_model::ModelKind::OfflineMoonshine
+                    | crate::sherpa_model::ModelKind::OfflineNemoTransducer => {
                         init_offline(new_model, &event_tx)
                     }
                 };
@@ -359,11 +365,16 @@ fn init_online(
     Ok(RecognizerState::Online(recognizer))
 }
 
-/// Phase 1-2 for the `OfflineMoonshine` path: download the Silero VAD
-/// model if missing, download the Moonshine bundle if missing, then
-/// create the `OfflineRecognizer` + `SherpaSileroVad`. Returns `Err(())`
-/// on any failure — the error has already been stored in `SHERPA_HOST`
-/// and emitted as `InitEvent::Failed`.
+/// Phase 1-2 for any offline model (`OfflineMoonshine` or
+/// `OfflineNemoTransducer`): download the Silero VAD if missing,
+/// download the model bundle if missing, then build the right
+/// `OfflineRecognizerConfig` for the model's kind and create the
+/// `OfflineRecognizer` + `SherpaSileroVad`.
+///
+/// The recognizer config builder is selected via `model.kind()` so
+/// callers don't need to know which offline family they're using.
+/// Returns `Err(())` on any failure — the error has already been
+/// stored in `SHERPA_HOST` and emitted as `InitEvent::Failed`.
 fn init_offline(
     model: SherpaModel,
     event_tx: &mpsc::Sender<InitEvent>,
@@ -385,12 +396,27 @@ fn init_offline(
 
     // --- Build OfflineRecognizer ---
     let _ = event_tx.send(InitEvent::CreatingRecognizer);
-    let recognizer_config = super::offline::build_moonshine_recognizer_config(model, "cpu");
-    tracing::info!(?model, "creating sherpa-onnx OfflineRecognizer (Moonshine)");
+    // Both offline kinds use OfflineRecognizer but with different config
+    // builders. Branch here so init_offline's Phase 1-2 (download VAD +
+    // bundle) stays generic across all offline models.
+    let recognizer_config = match model.kind() {
+        crate::sherpa_model::ModelKind::OfflineMoonshine => {
+            super::offline::build_moonshine_recognizer_config(model, "cpu")
+        }
+        crate::sherpa_model::ModelKind::OfflineNemoTransducer => {
+            super::offline::build_nemo_transducer_recognizer_config(model, "cpu")
+        }
+        crate::sherpa_model::ModelKind::OnlineTransducer => {
+            unreachable!("init_offline called with an online model")
+        }
+    };
+    tracing::info!(?model, "creating sherpa-onnx OfflineRecognizer");
 
     let Some(recognizer) = OfflineRecognizer::create(&recognizer_config) else {
-        let msg =
-            "OfflineRecognizer::create returned None — check Moonshine model files".to_owned();
+        let msg = format!(
+            "OfflineRecognizer::create returned None for {} — check model files and model_type",
+            model.label()
+        );
         tracing::error!(%msg);
         store_init_failure(BackendError::Init(msg.clone()));
         let _ = event_tx.send(InitEvent::Failed { message: msg });

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -340,40 +340,67 @@ fn run_host_loop(
                 model: new_model,
                 event_tx,
             } => {
-                tracing::info!(?new_model, "sherpa-host: reloading recognizer");
-                // Drop the old recognizer (and VAD if offline) BEFORE building
-                // the new one — we can't hold two at once because they share
-                // the ONNX Runtime singleton and memory budget.
-                recognizer_state = None;
-
-                let new_state = match new_model.kind() {
-                    crate::sherpa_model::ModelKind::OnlineTransducer => {
-                        init_online(new_model, &event_tx)
-                    }
-                    crate::sherpa_model::ModelKind::OfflineMoonshine
-                    | crate::sherpa_model::ModelKind::OfflineNemoTransducer => {
-                        init_offline(new_model, &event_tx)
-                    }
-                };
-
-                match new_state {
-                    Ok(state) => {
-                        tracing::info!(?new_model, "sherpa-host: reload complete");
-                        recognizer_state = Some(state);
-                        let _ = event_tx.send(InitEvent::Ready);
-                    }
-                    Err(()) => {
-                        // init_online/init_offline already emitted Failed through
-                        // event_tx AND stored the error in SHERPA_HOST (via
-                        // store_init_failure). Leave recognizer_state as None so
-                        // the next StartSession returns the error above.
-                        tracing::warn!(?new_model, "sherpa-host: reload failed");
-                    }
-                }
+                handle_reload_recognizer(new_model, &event_tx, &mut recognizer_state);
             }
         }
     }
     tracing::info!("sherpa-host worker exiting");
+}
+
+/// Handle a `HostCommand::ReloadRecognizer` by building the new
+/// recognizer WITHOUT dropping the current one first, then swapping
+/// only if the new recognizer is ready.
+///
+/// If the new recognizer fails to build (transient download error,
+/// missing files, `model_type` mismatch, etc.) the existing
+/// `*recognizer_state` is left untouched so `StartSession` continues
+/// to find the previous working recognizer.
+///
+/// Previous implementation dropped the current state up front which
+/// stranded the host on any init failure — every subsequent session
+/// until the next manual reload was rejected with "no recognizer
+/// loaded". The brief double-RAM footprint during the transition
+/// (~2x the model size; worst case ~1.2 GB for a Parakeet-to-Parakeet
+/// swap) is tolerable on personal-use hardware.
+fn handle_reload_recognizer(
+    new_model: SherpaModel,
+    event_tx: &mpsc::Sender<InitEvent>,
+    recognizer_state: &mut Option<RecognizerState>,
+) {
+    tracing::info!(?new_model, "sherpa-host: reloading recognizer");
+
+    let new_state = match new_model.kind() {
+        crate::sherpa_model::ModelKind::OnlineTransducer => init_online(new_model, event_tx),
+        crate::sherpa_model::ModelKind::OfflineMoonshine
+        | crate::sherpa_model::ModelKind::OfflineNemoTransducer => {
+            init_offline(new_model, event_tx)
+        }
+    };
+
+    match new_state {
+        Ok(state) => {
+            tracing::info!(
+                ?new_model,
+                "sherpa-host: reload complete, replacing old recognizer"
+            );
+            // Assignment drops the old recognizer at end of statement.
+            // Both recognizers exist in memory for exactly one
+            // expression evaluation.
+            *recognizer_state = Some(state);
+            let _ = event_tx.send(InitEvent::Ready);
+        }
+        Err(()) => {
+            // init_online/init_offline already emitted
+            // InitEvent::Failed through event_tx. The old
+            // `recognizer_state` is left untouched so StartSession
+            // continues to find the previous recognizer. No
+            // host-stranding.
+            tracing::warn!(
+                ?new_model,
+                "sherpa-host: reload failed, keeping previous recognizer"
+            );
+        }
+    }
 }
 
 /// Phase 1-2 for the `OnlineTransducer` path: download the bundle if
@@ -439,6 +466,13 @@ fn init_offline(
     // Both offline kinds use OfflineRecognizer but with different config
     // builders. Branch here so init_offline's Phase 1-2 (download VAD +
     // bundle) stays generic across all offline models.
+    //
+    // The `OnlineTransducer` arm should be unreachable in practice —
+    // every caller of `init_offline` (the two places in `run_host_loop`
+    // that dispatch on `model.kind()`) only routes `OfflineMoonshine`
+    // and `OfflineNemoTransducer` here. Still, library crates forbid
+    // `panic!` / `unreachable!` so we route through the normal init
+    // failure path instead of aborting the process.
     let recognizer_config = match model.kind() {
         crate::sherpa_model::ModelKind::OfflineMoonshine => {
             super::offline::build_moonshine_recognizer_config(model, "cpu")
@@ -447,7 +481,14 @@ fn init_offline(
             super::offline::build_nemo_transducer_recognizer_config(model, "cpu")
         }
         crate::sherpa_model::ModelKind::OnlineTransducer => {
-            unreachable!("init_offline called with an online model")
+            let msg = format!(
+                "init_offline called with online model {} — engine routing bug",
+                model.label()
+            );
+            tracing::error!(%msg);
+            store_init_failure(BackendError::Init(msg.clone()));
+            let _ = event_tx.send(InitEvent::Failed { message: msg });
+            return Err(());
         }
     };
     tracing::info!(?model, "creating sherpa-onnx OfflineRecognizer");

--- a/crates/sdr-transcription/src/backends/sherpa/mod.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/mod.rs
@@ -113,6 +113,7 @@ impl TranscriptionBackend for SherpaBackend {
             audio_rx,
             event_tx,
             noise_gate_ratio: config.noise_gate_ratio,
+            vad_threshold: config.vad_threshold,
         })?;
 
         tracing::info!("sherpa backend session requested");

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -14,6 +14,7 @@ use std::sync::mpsc;
 
 use sherpa_onnx::{
     OfflineModelConfig, OfflineMoonshineModelConfig, OfflineRecognizer, OfflineRecognizerConfig,
+    OfflineTransducerModelConfig,
 };
 
 use crate::backend::TranscriptionEvent;
@@ -67,6 +68,55 @@ pub(super) fn build_moonshine_recognizer_config(
         tokens: Some(tokens.to_string_lossy().into_owned()),
         provider: Some(provider.to_owned()),
         num_threads: SHERPA_NUM_THREADS,
+        ..OfflineModelConfig::default()
+    };
+
+    OfflineRecognizerConfig {
+        model_config,
+        ..OfflineRecognizerConfig::default()
+    }
+}
+
+/// Build the `OfflineRecognizerConfig` for a NeMo Parakeet-TDT model.
+///
+/// Uses sherpa-onnx's offline transducer config (4 files: encoder,
+/// decoder, joiner, tokens) with `model_type = "nemo_transducer"`.
+/// The model_type field is required — without it, sherpa-onnx tries
+/// to use the generic transducer decode loop which doesn't understand
+/// NeMo's TDT (Token-and-Duration Transducer) joiner output shape.
+///
+/// Mirrors the upstream `rust-api-examples/examples/nemo_parakeet.rs`
+/// example.
+pub(super) fn build_nemo_transducer_recognizer_config(
+    model: SherpaModel,
+    provider: &str,
+) -> OfflineRecognizerConfig {
+    let ModelFilePaths::Transducer {
+        encoder,
+        decoder,
+        joiner,
+        tokens,
+    } = sherpa_model::model_file_paths(model)
+    else {
+        unreachable!(
+            "offline::build_nemo_transducer_recognizer_config called with non-Transducer layout"
+        )
+    };
+
+    let transducer = OfflineTransducerModelConfig {
+        encoder: Some(encoder.to_string_lossy().into_owned()),
+        decoder: Some(decoder.to_string_lossy().into_owned()),
+        joiner: Some(joiner.to_string_lossy().into_owned()),
+    };
+
+    let model_config = OfflineModelConfig {
+        transducer,
+        tokens: Some(tokens.to_string_lossy().into_owned()),
+        provider: Some(provider.to_owned()),
+        num_threads: SHERPA_NUM_THREADS,
+        // Required — tells sherpa-onnx to use NeMo's TDT decode loop
+        // instead of the generic transducer path.
+        model_type: Some("nemo_transducer".to_owned()),
         ..OfflineModelConfig::default()
     };
 

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -77,13 +77,13 @@ pub(super) fn build_moonshine_recognizer_config(
     }
 }
 
-/// Build the `OfflineRecognizerConfig` for a NeMo Parakeet-TDT model.
+/// Build the `OfflineRecognizerConfig` for a `NeMo` Parakeet-TDT model.
 ///
 /// Uses sherpa-onnx's offline transducer config (4 files: encoder,
 /// decoder, joiner, tokens) with `model_type = "nemo_transducer"`.
-/// The model_type field is required — without it, sherpa-onnx tries
+/// The `model_type` field is required — without it, sherpa-onnx tries
 /// to use the generic transducer decode loop which doesn't understand
-/// NeMo's TDT (Token-and-Duration Transducer) joiner output shape.
+/// `NeMo`'s TDT (Token-and-Duration Transducer) joiner output shape.
 ///
 /// Mirrors the upstream `rust-api-examples/examples/nemo_parakeet.rs`
 /// example.

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -33,6 +33,15 @@ const SESSION_MONO_BUFFER_CAPACITY: usize = 16_000;
 /// pipeline.
 const SHERPA_NUM_THREADS: i32 = 1;
 
+/// sherpa-onnx `model_type` field value that selects `NeMo`'s Token-and-Duration
+/// Transducer decode loop. Without this exact string, sherpa-onnx falls back
+/// to the generic transducer decode path which doesn't understand TDT's
+/// joiner output shape, and `OfflineRecognizer::create` returns `None` at
+/// runtime — silent failure mode.
+///
+/// Mirrors the upstream `rust-api-examples/examples/nemo_parakeet.rs` example.
+const NEMO_TRANSDUCER_MODEL_TYPE: &str = "nemo_transducer";
+
 /// Build the `OfflineRecognizerConfig` for a Moonshine v1 model.
 ///
 /// k2-fsa's int8 Moonshine releases use the v1 layout with five files:
@@ -116,7 +125,7 @@ pub(super) fn build_nemo_transducer_recognizer_config(
         num_threads: SHERPA_NUM_THREADS,
         // Required — tells sherpa-onnx to use NeMo's TDT decode loop
         // instead of the generic transducer path.
-        model_type: Some("nemo_transducer".to_owned()),
+        model_type: Some(NEMO_TRANSDUCER_MODEL_TYPE.to_owned()),
         ..OfflineModelConfig::default()
     };
 

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -100,6 +100,18 @@ pub(super) fn build_nemo_transducer_recognizer_config(
     model: SherpaModel,
     provider: &str,
 ) -> OfflineRecognizerConfig {
+    // `ModelFilePaths::Transducer` also matches `StreamingZipformerEn`
+    // (same 4-file layout), so the destructuring alone wouldn't catch
+    // a caller that passed the online Zipformer variant by mistake.
+    // Guard on kind at the boundary so misuse fails loudly here
+    // rather than silently building a NeMo config around Zipformer
+    // files at runtime.
+    debug_assert_eq!(
+        model.kind(),
+        crate::sherpa_model::ModelKind::OfflineNemoTransducer,
+        "build_nemo_transducer_recognizer_config called with non-OfflineNemoTransducer model"
+    );
+
     let ModelFilePaths::Transducer {
         encoder,
         decoder,

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -148,6 +148,7 @@ pub(super) fn run_session(
         audio_rx,
         event_tx,
         noise_gate_ratio,
+        vad_threshold: _,
     } = params;
 
     // Clear any residual state from a previous session.

--- a/crates/sdr-transcription/src/backends/sherpa/silero_vad.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/silero_vad.rs
@@ -23,7 +23,10 @@ use super::host::SHERPA_SAMPLE_RATE_HZ;
 /// Silero VAD default hyperparameters. These match the sherpa-onnx
 /// upstream `moonshine_v2.rs` example and are appropriate for radio
 /// audio (short bursts, occasional long silences).
-const SILERO_THRESHOLD: f32 = 0.5;
+///
+/// Exposed as `pub(super)` so `host.rs::init_offline` can use it as
+/// the initial threshold before any user-configured session runs.
+pub(super) const SILERO_THRESHOLD: f32 = 0.5;
 const SILERO_MIN_SILENCE_DURATION: f32 = 0.25;
 const SILERO_MIN_SPEECH_DURATION: f32 = 0.25;
 const SILERO_MAX_SPEECH_DURATION: f32 = 20.0;
@@ -38,15 +41,22 @@ const VAD_BUFFER_SIZE_SECONDS: f32 = 30.0;
 /// Sherpa-onnx-backed Silero VAD.
 pub struct SherpaSileroVad {
     inner: SherpaVad,
+    /// The threshold this VAD was created with. Used by the host worker to
+    /// detect when a new session requests a different threshold so it can
+    /// rebuild the VAD before starting.
+    current_threshold: f32,
 }
 
 impl SherpaSileroVad {
-    /// Create a new Silero VAD using the ONNX file at `model_path`.
+    /// Create a new Silero VAD using the ONNX file at `model_path` and
+    /// the given `threshold` (0.10..=0.90).
+    ///
+    /// Use [`SILERO_THRESHOLD`] as `threshold` for the default value.
     /// The file is typically installed by [`crate::sherpa_model::download_silero_vad`].
-    pub fn new(model_path: &Path) -> Result<Self, BackendError> {
+    pub fn new(model_path: &Path, threshold: f32) -> Result<Self, BackendError> {
         let silero_config = SileroVadModelConfig {
             model: Some(model_path.to_string_lossy().into_owned()),
-            threshold: SILERO_THRESHOLD,
+            threshold,
             min_silence_duration: SILERO_MIN_SILENCE_DURATION,
             min_speech_duration: SILERO_MIN_SPEECH_DURATION,
             max_speech_duration: SILERO_MAX_SPEECH_DURATION,
@@ -69,7 +79,15 @@ impl SherpaSileroVad {
             ))
         })?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            current_threshold: threshold,
+        })
+    }
+
+    /// The threshold this VAD was built with.
+    pub fn current_threshold(&self) -> f32 {
+        self.current_threshold
     }
 }
 

--- a/crates/sdr-transcription/src/backends/sherpa/silero_vad.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/silero_vad.rs
@@ -24,9 +24,11 @@ use super::host::SHERPA_SAMPLE_RATE_HZ;
 /// upstream `moonshine_v2.rs` example and are appropriate for radio
 /// audio (short bursts, occasional long silences).
 ///
-/// Exposed as `pub(super)` so `host.rs::init_offline` can use it as
-/// the initial threshold before any user-configured session runs.
-pub(super) const SILERO_THRESHOLD: f32 = 0.5;
+/// Aliased to the canonical `backend::VAD_THRESHOLD_DEFAULT` — the
+/// two represent the same value, this alias exists so `host.rs::init_offline`
+/// has a `pub(super)` name to reach for without dragging the public
+/// backend module into scope.
+pub(super) const SILERO_THRESHOLD: f32 = crate::backend::VAD_THRESHOLD_DEFAULT;
 const SILERO_MIN_SILENCE_DURATION: f32 = 0.25;
 const SILERO_MIN_SPEECH_DURATION: f32 = 0.25;
 const SILERO_MAX_SPEECH_DURATION: f32 = 20.0;

--- a/crates/sdr-transcription/src/backends/sherpa/streaming.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/streaming.rs
@@ -74,6 +74,7 @@ pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) 
         audio_rx,
         event_tx,
         noise_gate_ratio,
+        vad_threshold: _,
     } = params;
 
     let stream = recognizer.create_stream();

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -44,7 +44,7 @@ pub mod sherpa_model;
 
 pub use backend::{
     BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
-    TranscriptionEvent,
+    TranscriptionEvent, VAD_THRESHOLD_DEFAULT, VAD_THRESHOLD_MAX, VAD_THRESHOLD_MIN,
 };
 
 #[cfg(feature = "whisper")]
@@ -203,7 +203,7 @@ mod tests {
             model,
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
-            vad_threshold: 0.5,
+            vad_threshold: crate::VAD_THRESHOLD_DEFAULT,
         }
     }
 

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -203,6 +203,7 @@ mod tests {
             model,
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
+            vad_threshold: 0.5,
         }
     }
 

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -72,9 +72,9 @@ pub enum ModelKind {
     /// Uses `OfflineRecognizer` with `OfflineMoonshineModelConfig`
     /// + the offline session loop in `backends/sherpa/offline.rs`.
     OfflineMoonshine,
-    /// Offline transducer-style model from NVIDIA NeMo: Parakeet-TDT
+    /// Offline transducer-style model from NVIDIA `NeMo`: Parakeet-TDT
     /// today. Uses `OfflineRecognizer` with `OfflineTransducerModelConfig`
-    /// + `model_type = "nemo_transducer"`. Shares the same VAD-gated
+    /// and `model_type = "nemo_transducer"`. Shares the same VAD-gated
     /// offline session loop as `OfflineMoonshine`; only the recognizer
     /// config builder differs.
     OfflineNemoTransducer,
@@ -94,9 +94,9 @@ pub enum SherpaModel {
     /// latency. Offline (VAD-gated) decode.
     MoonshineBaseEn,
     /// NVIDIA Parakeet-TDT-0.6b v3 (English, int8). ~600M params,
-    /// ~600MB bundle. Highest accuracy — currently #1 on the OpenASR
+    /// ~600MB bundle. Highest accuracy — currently #1 on the `OpenASR`
     /// leaderboard. CPU-only today (sherpa-cuda follow-up tracked).
-    /// Offline (VAD-gated) batch decode through a NeMo transducer.
+    /// Offline (VAD-gated) batch decode through a `NeMo` transducer.
     ParakeetTdt06bV3En,
 }
 

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -64,12 +64,20 @@ fn cleanup_scratch_state(model: SherpaModel) -> Result<(), SherpaModelError> {
 /// offline models run through `OfflineRecognizer` + external VAD.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelKind {
-    /// Streaming transducer: Zipformer today, Parakeet-TDT in a future PR.
-    /// Uses `OnlineRecognizer` + streaming session loop.
+    /// Streaming transducer: Zipformer today. Uses `OnlineRecognizer`
+    /// + streaming session loop in `backends/sherpa/streaming.rs`.
     OnlineTransducer,
-    /// Offline encoder-decoder: Moonshine v2. Requires external VAD
-    /// to detect utterance boundaries before batch decoding.
+    /// Offline encoder-decoder: Moonshine v1. Requires external VAD
+    /// (Silero) to detect utterance boundaries before batch decoding.
+    /// Uses `OfflineRecognizer` with `OfflineMoonshineModelConfig`
+    /// + the offline session loop in `backends/sherpa/offline.rs`.
     OfflineMoonshine,
+    /// Offline transducer-style model from NVIDIA NeMo: Parakeet-TDT
+    /// today. Uses `OfflineRecognizer` with `OfflineTransducerModelConfig`
+    /// + `model_type = "nemo_transducer"`. Shares the same VAD-gated
+    /// offline session loop as `OfflineMoonshine`; only the recognizer
+    /// config builder differs.
+    OfflineNemoTransducer,
 }
 
 /// Available sherpa-onnx model variants.

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -650,14 +650,20 @@ mod tests {
     }
 
     #[test]
-    fn streaming_zipformer_archive_inner_dir_matches_filename_stem() {
-        let model = SherpaModel::StreamingZipformerEn;
-        let archive = model.archive_filename();
-        let inner = model.archive_inner_directory();
+    fn all_archives_have_inner_dir_matching_filename_stem() {
         // Inner directory name should equal the archive filename minus
         // the .tar.bz2 suffix — sanity check that we'll find the right
-        // directory after extraction.
-        assert_eq!(format!("{inner}.tar.bz2"), archive);
+        // directory after extraction. Loops over every variant in ALL
+        // so adding a new model auto-extends this protection.
+        for model in SherpaModel::ALL {
+            let archive = model.archive_filename();
+            let inner = model.archive_inner_directory();
+            assert_eq!(
+                format!("{inner}.tar.bz2"),
+                archive,
+                "archive_inner_directory + .tar.bz2 != archive_filename for {model:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -93,6 +93,11 @@ pub enum SherpaModel {
     /// ~380MB bundle. More accurate than Tiny, higher per-utterance
     /// latency. Offline (VAD-gated) decode.
     MoonshineBaseEn,
+    /// NVIDIA Parakeet-TDT-0.6b v3 (English, int8). ~600M params,
+    /// ~600MB bundle. Highest accuracy — currently #1 on the OpenASR
+    /// leaderboard. CPU-only today (sherpa-cuda follow-up tracked).
+    /// Offline (VAD-gated) batch decode through a NeMo transducer.
+    ParakeetTdt06bV3En,
 }
 
 impl SherpaModel {
@@ -102,6 +107,7 @@ impl SherpaModel {
             Self::StreamingZipformerEn => "Streaming Zipformer (English)",
             Self::MoonshineTinyEn => "Moonshine Tiny (English)",
             Self::MoonshineBaseEn => "Moonshine Base (English)",
+            Self::ParakeetTdt06bV3En => "Parakeet TDT 0.6b v3 (English)",
         }
     }
 
@@ -112,6 +118,7 @@ impl SherpaModel {
             Self::StreamingZipformerEn => "streaming-zipformer-en",
             Self::MoonshineTinyEn => "moonshine-tiny-en",
             Self::MoonshineBaseEn => "moonshine-base-en",
+            Self::ParakeetTdt06bV3En => "parakeet-tdt-0.6b-v3-en",
         }
     }
 
@@ -123,6 +130,7 @@ impl SherpaModel {
             Self::StreamingZipformerEn => "sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2",
             Self::MoonshineTinyEn => "sherpa-onnx-moonshine-tiny-en-int8.tar.bz2",
             Self::MoonshineBaseEn => "sherpa-onnx-moonshine-base-en-int8.tar.bz2",
+            Self::ParakeetTdt06bV3En => "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2",
         }
     }
 
@@ -136,6 +144,7 @@ impl SherpaModel {
             Self::StreamingZipformerEn => "sherpa-onnx-streaming-zipformer-en-2023-06-26",
             Self::MoonshineTinyEn => "sherpa-onnx-moonshine-tiny-en-int8",
             Self::MoonshineBaseEn => "sherpa-onnx-moonshine-base-en-int8",
+            Self::ParakeetTdt06bV3En => "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8",
         }
     }
 
@@ -156,6 +165,7 @@ impl SherpaModel {
         match self {
             Self::StreamingZipformerEn => ModelKind::OnlineTransducer,
             Self::MoonshineTinyEn | Self::MoonshineBaseEn => ModelKind::OfflineMoonshine,
+            Self::ParakeetTdt06bV3En => ModelKind::OfflineNemoTransducer,
         }
     }
 
@@ -169,7 +179,7 @@ impl SherpaModel {
     pub fn supports_partials(self) -> bool {
         match self.kind() {
             ModelKind::OnlineTransducer => true,
-            ModelKind::OfflineMoonshine => false,
+            ModelKind::OfflineMoonshine | ModelKind::OfflineNemoTransducer => false,
         }
     }
 
@@ -178,6 +188,7 @@ impl SherpaModel {
         Self::StreamingZipformerEn,
         Self::MoonshineTinyEn,
         Self::MoonshineBaseEn,
+        Self::ParakeetTdt06bV3En,
     ];
 }
 
@@ -354,6 +365,17 @@ pub fn model_file_paths(model: SherpaModel) -> ModelFilePaths {
             encoder: dir.join("encode.int8.onnx"),
             uncached_decoder: dir.join("uncached_decode.int8.onnx"),
             cached_decoder: dir.join("cached_decode.int8.onnx"),
+            tokens: dir.join("tokens.txt"),
+        },
+        // Parakeet-TDT v3 int8 layout: standard 4-file transducer
+        // (encoder + decoder + joiner + tokens), structurally identical
+        // to Zipformer. The `Transducer` ModelFilePaths variant is
+        // reused — kind() tells the host which recognizer API to feed
+        // them into (online for Zipformer vs offline for Parakeet).
+        SherpaModel::ParakeetTdt06bV3En => ModelFilePaths::Transducer {
+            encoder: dir.join("encoder.int8.onnx"),
+            decoder: dir.join("decoder.int8.onnx"),
+            joiner: dir.join("joiner.int8.onnx"),
             tokens: dir.join("tokens.txt"),
         },
     }
@@ -726,8 +748,52 @@ mod tests {
     }
 
     #[test]
-    fn all_contains_three_variants() {
-        assert_eq!(SherpaModel::ALL.len(), 3);
+    fn all_contains_four_variants() {
+        assert_eq!(SherpaModel::ALL.len(), 4);
+    }
+
+    #[test]
+    fn parakeet_is_offline_nemo_transducer_kind() {
+        assert_eq!(
+            SherpaModel::ParakeetTdt06bV3En.kind(),
+            ModelKind::OfflineNemoTransducer
+        );
+    }
+
+    #[test]
+    fn parakeet_does_not_support_partials() {
+        assert!(!SherpaModel::ParakeetTdt06bV3En.supports_partials());
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn parakeet_has_transducer_file_layout() {
+        let paths = model_file_paths(SherpaModel::ParakeetTdt06bV3En);
+        let ModelFilePaths::Transducer {
+            encoder,
+            decoder,
+            joiner,
+            tokens,
+        } = paths
+        else {
+            panic!("ParakeetTdt06bV3En should be a Transducer layout");
+        };
+        assert!(encoder.ends_with("encoder.int8.onnx"));
+        assert!(decoder.ends_with("decoder.int8.onnx"));
+        assert!(joiner.ends_with("joiner.int8.onnx"));
+        assert!(tokens.ends_with("tokens.txt"));
+        assert_ne!(encoder, decoder);
+        assert_ne!(decoder, joiner);
+    }
+
+    #[test]
+    fn parakeet_archive_url_is_well_formed() {
+        let url = SherpaModel::ParakeetTdt06bV3En.archive_url();
+        assert!(url.starts_with("https://github.com/k2-fsa/sherpa-onnx/"));
+        assert!(url.ends_with(".tar.bz2"));
+        assert!(url.contains("parakeet"));
+        assert!(url.contains("tdt"));
+        assert!(url.contains("v3"));
     }
 
     #[test]

--- a/crates/sdr-transcription/tests/sherpa_uninitialized.rs
+++ b/crates/sdr-transcription/tests/sherpa_uninitialized.rs
@@ -23,7 +23,7 @@ fn sherpa_backend_start_returns_init_error_when_host_not_initialized() {
         model: ModelChoice::Sherpa(SherpaModel::StreamingZipformerEn),
         silence_threshold: 0.007,
         noise_gate_ratio: 3.0,
-        vad_threshold: 0.5,
+        vad_threshold: sdr_transcription::VAD_THRESHOLD_DEFAULT,
     };
     let result = backend.start(config);
     match result {

--- a/crates/sdr-transcription/tests/sherpa_uninitialized.rs
+++ b/crates/sdr-transcription/tests/sherpa_uninitialized.rs
@@ -23,6 +23,7 @@ fn sherpa_backend_start_returns_init_error_when_host_not_initialized() {
         model: ModelChoice::Sherpa(SherpaModel::StreamingZipformerEn),
         silence_threshold: 0.007,
         noise_gate_ratio: 3.0,
+        vad_threshold: 0.5,
     };
     let result = backend.start(config);
     match result {

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -346,6 +346,23 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         });
     }
 
+    // Always clear the live line on model change. The visibility-toggle
+    // handler earlier hides display_mode_row when switching to a
+    // non-partial-emitting model, but it can't see live_line_label
+    // (which is built after that handler runs) so it leaves any stale
+    // live-line content visible. Without this third chained handler, a
+    // user who ran a Zipformer session and then switched to Moonshine
+    // or Parakeet would see leftover italic text dangling under the
+    // text view.
+    #[cfg(feature = "sherpa")]
+    {
+        let live_line_for_model_change = live_line_label.clone();
+        model_row.connect_selected_notify(move |_| {
+            live_line_for_model_change.set_text("");
+            live_line_for_model_change.set_visible(false);
+        });
+    }
+
     let status_label = gtk4::Label::builder()
         .halign(gtk4::Align::Start)
         .css_classes(["dim-label"])

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -23,6 +23,10 @@ const KEY_SHERPA_MODEL: &str = "transcription_sherpa_model";
 /// Config key for the persisted transcript display mode.
 /// Values: `"live"` (default) or `"final"`.
 const KEY_DISPLAY_MODE: &str = "transcription_display_mode";
+#[cfg(feature = "sherpa")]
+/// Config key for the persisted Silero VAD threshold.
+/// Sherpa-only — only meaningful for offline models (Moonshine, Parakeet).
+const KEY_SHERPA_VAD_THRESHOLD: &str = "sherpa_vad_threshold";
 
 #[cfg(feature = "sherpa")]
 const DISPLAY_MODE_LIVE_IDX: u32 = 0;
@@ -47,6 +51,22 @@ const SILENCE_THRESHOLD_PAGE: f64 = 0.01;
 
 // Noise gate slider defaults and range.
 const DEFAULT_NOISE_GATE: f64 = 3.0;
+
+// VAD threshold slider defaults and range. Sherpa-only — only matters
+// for offline models (Moonshine, Parakeet) which use Silero VAD to
+// detect utterance boundaries. Default 0.5 matches sherpa-onnx's
+// upstream Silero default. Lower for noisy NFM/scanner audio; higher
+// for clean broadcast.
+#[cfg(feature = "sherpa")]
+const DEFAULT_SHERPA_VAD_THRESHOLD: f64 = 0.50;
+#[cfg(feature = "sherpa")]
+const SHERPA_VAD_THRESHOLD_MIN: f64 = 0.10;
+#[cfg(feature = "sherpa")]
+const SHERPA_VAD_THRESHOLD_MAX: f64 = 0.90;
+#[cfg(feature = "sherpa")]
+const SHERPA_VAD_THRESHOLD_STEP: f64 = 0.05;
+#[cfg(feature = "sherpa")]
+const SHERPA_VAD_THRESHOLD_PAGE: f64 = 0.10;
 const NOISE_GATE_MIN: f64 = 1.0;
 const NOISE_GATE_MAX: f64 = 10.0;
 const NOISE_GATE_STEP: f64 = 0.5;
@@ -72,6 +92,11 @@ pub struct TranscriptPanel {
     /// Whisper has no `Partial` events to render.
     #[cfg(feature = "sherpa")]
     pub display_mode_row: adw::ComboRow,
+    /// VAD threshold spin row. Sherpa-only — only visible when an
+    /// offline model (Moonshine, Parakeet) is selected. Online
+    /// models (Zipformer) don't use Silero VAD.
+    #[cfg(feature = "sherpa")]
+    pub vad_threshold_row: adw::SpinRow,
     /// Dimmed italic label below the text view that renders in-progress
     /// Sherpa partials. Sherpa-only.
     #[cfg(feature = "sherpa")]
@@ -234,6 +259,48 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         });
     });
 
+    // --- VAD threshold slider (Sherpa + offline models only) ---
+    //
+    // Only visible when an offline model (Moonshine, Parakeet) is selected.
+    // The Silero VAD's default 0.5 threshold is too strict for noisy NFM
+    // scanner audio — this slider lets the user tune it per source.
+    // Visibility is toggled in the sherpa block below alongside display_mode_row.
+    #[cfg(feature = "sherpa")]
+    let vad_threshold_row = {
+        let saved_vad_threshold = config.read(|v| {
+            v.get(KEY_SHERPA_VAD_THRESHOLD)
+                .and_then(serde_json::Value::as_f64)
+                .map_or(DEFAULT_SHERPA_VAD_THRESHOLD, |val| {
+                    val.clamp(SHERPA_VAD_THRESHOLD_MIN, SHERPA_VAD_THRESHOLD_MAX)
+                })
+        });
+
+        let row = adw::SpinRow::builder()
+            .title("VAD threshold")
+            .subtitle("Lower catches quieter audio (NFM); higher is stricter (talk radio)")
+            .adjustment(&gtk4::Adjustment::new(
+                saved_vad_threshold,
+                SHERPA_VAD_THRESHOLD_MIN,
+                SHERPA_VAD_THRESHOLD_MAX,
+                SHERPA_VAD_THRESHOLD_STEP,
+                SHERPA_VAD_THRESHOLD_PAGE,
+                0.0,
+            ))
+            .digits(2)
+            .build();
+        group.add(&row);
+
+        let config_vad = Arc::clone(config);
+        row.connect_value_notify(move |r| {
+            let val = r.value();
+            config_vad.write(|v| {
+                v[KEY_SHERPA_VAD_THRESHOLD] = serde_json::json!(val);
+            });
+        });
+
+        row
+    };
+
     // --- Display mode selector (Sherpa only) ---
     //
     // Whisper builds never compile this in — Whisper does not emit
@@ -276,27 +343,34 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         row
     };
 
-    // Toggle display_mode_row visibility based on whether the selected
-    // model emits partial hypotheses. Models like Moonshine are offline
-    // and decode once per utterance — the Live/Final distinction is
-    // meaningless and the row is hidden entirely. Initial visibility
-    // is set here based on the currently-saved model index.
+    // Toggle display_mode_row and vad_threshold_row visibility based on
+    // whether the selected model emits partial hypotheses:
+    //   - display_mode_row: visible for online models (supports_partials)
+    //   - vad_threshold_row: visible for offline models (!supports_partials)
+    // Models like Moonshine/Parakeet are offline — the Live/Final distinction
+    // is meaningless so display_mode_row is hidden; but they DO use Silero
+    // VAD so vad_threshold_row is shown. Zipformer is streaming so
+    // display_mode_row is shown and vad_threshold_row is hidden.
+    // Initial visibility is set here based on the currently-saved model index.
     #[cfg(feature = "sherpa")]
     {
-        let initial_visible = sdr_transcription::SherpaModel::ALL
+        let initial_supports_partials = sdr_transcription::SherpaModel::ALL
             .get(saved_model_idx as usize)
             .copied()
             .is_some_and(sdr_transcription::SherpaModel::supports_partials);
-        display_mode_row.set_visible(initial_visible);
+        display_mode_row.set_visible(initial_supports_partials);
+        vad_threshold_row.set_visible(!initial_supports_partials);
 
         let display_mode_row_for_visibility = display_mode_row.clone();
+        let vad_threshold_row_for_visibility = vad_threshold_row.clone();
         model_row.connect_selected_notify(move |r| {
             let idx = r.selected() as usize;
-            let visible = sdr_transcription::SherpaModel::ALL
+            let supports_partials = sdr_transcription::SherpaModel::ALL
                 .get(idx)
                 .copied()
                 .is_some_and(sdr_transcription::SherpaModel::supports_partials);
-            display_mode_row_for_visibility.set_visible(visible);
+            display_mode_row_for_visibility.set_visible(supports_partials);
+            vad_threshold_row_for_visibility.set_visible(!supports_partials);
         });
     }
 
@@ -437,6 +511,8 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         noise_gate_row,
         #[cfg(feature = "sherpa")]
         display_mode_row,
+        #[cfg(feature = "sherpa")]
+        vad_threshold_row,
         #[cfg(feature = "sherpa")]
         live_line_label,
         status_label,

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -18,7 +18,13 @@ const KEY_SILENCE_THRESHOLD: &str = "transcription_silence_threshold";
 const KEY_NOISE_GATE: &str = "transcription_noise_gate";
 #[cfg(feature = "sherpa")]
 /// Config key for the persisted Sherpa model index.
-const KEY_SHERPA_MODEL: &str = "transcription_sherpa_model";
+///
+/// `pub(crate)` so `window.rs` can write to it from the reload
+/// handler's `InitEvent::Ready` branch — sherpa persistence is
+/// deferred until the recognizer swap succeeds, so a failed reload
+/// can't leave a broken model index in config and wedge next
+/// startup's `init_sherpa_host`.
+pub(crate) const KEY_SHERPA_MODEL: &str = "transcription_sherpa_model";
 #[cfg(feature = "sherpa")]
 /// Config key for the persisted transcript display mode.
 /// Values: `"live"` (default) or `"final"`.
@@ -57,12 +63,15 @@ const DEFAULT_NOISE_GATE: f64 = 3.0;
 // detect utterance boundaries. Default 0.5 matches sherpa-onnx's
 // upstream Silero default. Lower for noisy NFM/scanner audio; higher
 // for clean broadcast.
+// UI slider values are f64 (adw::SpinRow takes f64). The canonical
+// f32 constants live in `sdr_transcription::backend` — these are
+// widened casts so the slider can't drift from the backend defaults.
 #[cfg(feature = "sherpa")]
-const DEFAULT_SHERPA_VAD_THRESHOLD: f64 = 0.50;
+const DEFAULT_SHERPA_VAD_THRESHOLD: f64 = sdr_transcription::VAD_THRESHOLD_DEFAULT as f64;
 #[cfg(feature = "sherpa")]
-const SHERPA_VAD_THRESHOLD_MIN: f64 = 0.10;
+const SHERPA_VAD_THRESHOLD_MIN: f64 = sdr_transcription::VAD_THRESHOLD_MIN as f64;
 #[cfg(feature = "sherpa")]
-const SHERPA_VAD_THRESHOLD_MAX: f64 = 0.90;
+const SHERPA_VAD_THRESHOLD_MAX: f64 = sdr_transcription::VAD_THRESHOLD_MAX as f64;
 #[cfg(feature = "sherpa")]
 const SHERPA_VAD_THRESHOLD_STEP: f64 = 0.05;
 #[cfg(feature = "sherpa")]
@@ -179,15 +188,36 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
     group.add(&model_row);
 
     // Persist model selection on change.
-    let config_model = Arc::clone(config);
-    model_row.connect_selected_notify(move |row| {
-        let idx = row.selected();
-        if idx < max_model_idx {
-            config_model.write(|v| {
-                v[key_for_persistence] = serde_json::json!(idx);
-            });
-        }
-    });
+    //
+    // Whisper persists immediately: Whisper has no runtime model swap,
+    // so the selection only matters at next launch. Saving it now is
+    // harmless even if the user later picks a broken model.
+    //
+    // Sherpa does NOT persist here. The reload handler in `window.rs`
+    // writes `KEY_SHERPA_MODEL` to config only after `InitEvent::Ready`
+    // fires — deferring persistence until the recognizer swap actually
+    // succeeds. If the reload fails, the previous (working) model
+    // stays in config, and next startup's `init_sherpa_host` won't
+    // retry a known-broken selection.
+    #[cfg(feature = "whisper")]
+    {
+        let config_model = Arc::clone(config);
+        model_row.connect_selected_notify(move |row| {
+            let idx = row.selected();
+            if idx < max_model_idx {
+                config_model.write(|v| {
+                    v[key_for_persistence] = serde_json::json!(idx);
+                });
+            }
+        });
+    }
+    #[cfg(feature = "sherpa")]
+    {
+        // Reference the local so it's not flagged as unused in sherpa
+        // builds — the sherpa reload handler in window.rs owns the
+        // persistence logic for this key.
+        let _ = key_for_persistence;
+    }
 
     // --- Tuning sliders ---
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1501,6 +1501,7 @@ fn unlock_transcription_session_rows(
     #[cfg(feature = "whisper")] silence_row: &glib::WeakRef<adw::SpinRow>,
     noise_gate_row: &glib::WeakRef<adw::SpinRow>,
     #[cfg(feature = "sherpa")] display_mode_row: &glib::WeakRef<adw::ComboRow>,
+    #[cfg(feature = "sherpa")] vad_threshold_row: &glib::WeakRef<adw::SpinRow>,
 ) {
     if let Some(row) = model_row.upgrade() {
         row.set_sensitive(true);
@@ -1514,6 +1515,10 @@ fn unlock_transcription_session_rows(
     }
     #[cfg(feature = "sherpa")]
     if let Some(row) = display_mode_row.upgrade() {
+        row.set_sensitive(true);
+    }
+    #[cfg(feature = "sherpa")]
+    if let Some(row) = vad_threshold_row.upgrade() {
         row.set_sensitive(true);
     }
 }
@@ -1552,9 +1557,13 @@ fn connect_transcript_panel(
     #[cfg(feature = "sherpa")]
     let display_mode_row = transcript.display_mode_row.clone();
     #[cfg(feature = "sherpa")]
+    let vad_threshold_row = transcript.vad_threshold_row.clone();
+    #[cfg(feature = "sherpa")]
     let live_line_label = transcript.live_line_label.clone();
     #[cfg(feature = "sherpa")]
     let display_mode_row_weak = display_mode_row.downgrade();
+    #[cfg(feature = "sherpa")]
+    let vad_threshold_row_weak = vad_threshold_row.downgrade();
     #[cfg(feature = "sherpa")]
     let live_line_weak = live_line_label.downgrade();
 
@@ -1697,6 +1706,8 @@ fn connect_transcript_panel(
             // exception. User stops, changes, starts.
             #[cfg(feature = "sherpa")]
             display_mode_row.set_sensitive(false);
+            #[cfg(feature = "sherpa")]
+            vad_threshold_row.set_sensitive(false);
 
             let model_idx = model_row.selected() as usize;
 
@@ -1730,10 +1741,18 @@ fn connect_transcript_panel(
                 sdr_transcription::ModelChoice::Sherpa(sherpa_model)
             };
 
+            #[cfg(feature = "sherpa")]
+            #[allow(clippy::cast_possible_truncation)]
+            let vad_threshold = vad_threshold_row.value() as f32;
+            // Whisper builds compile the field but ignore it (no Silero VAD).
+            #[cfg(feature = "whisper")]
+            let vad_threshold: f32 = 0.5;
+
             let config = sdr_transcription::BackendConfig {
                 model,
                 silence_threshold,
                 noise_gate_ratio,
+                vad_threshold,
             };
 
             // Scope the borrow so it's dropped before any potential re-entry
@@ -1763,6 +1782,8 @@ fn connect_transcript_panel(
                     let noise_gate_row_weak = noise_gate_row_weak.clone();
                     #[cfg(feature = "sherpa")]
                     let display_mode_row_weak = display_mode_row_weak.clone();
+                    #[cfg(feature = "sherpa")]
+                    let vad_threshold_row_weak = vad_threshold_row_weak.clone();
                     #[cfg(feature = "sherpa")]
                     let live_line_weak = live_line_weak.clone();
 
@@ -1799,12 +1820,37 @@ fn connect_transcript_panel(
                                     TranscriptionEvent::Partial { text } => {
                                         #[cfg(feature = "sherpa")]
                                         {
-                                            // Read the current display mode
-                                            // from the combo row (the user may
-                                            // have changed it mid-session; we
-                                            // deliberately don't lock it).
-                                            let show_live =
-                                                display_mode_row_weak.upgrade().is_some_and(
+                                            // Belt-and-suspenders: only paint
+                                            // the live line if (a) the current
+                                            // model actually supports partials
+                                            // and (b) display mode is Live.
+                                            //
+                                            // (a) defends against a future bug
+                                            // where an offline model accidentally
+                                            // emits a Partial event — today the
+                                            // offline session loop never does,
+                                            // but the UI shouldn't trust that.
+                                            // Without this check, italics would
+                                            // appear on Moonshine/Parakeet on
+                                            // any spurious Partial.
+                                            //
+                                            // (b) honors the user's display-mode
+                                            // preference for partial-emitting
+                                            // models. Re-read on every event so
+                                            // mid-session toggle takes effect.
+                                            let model_supports_partials = model_row_weak
+                                                .upgrade()
+                                                .is_some_and(|row| {
+                                                    let idx = row.selected() as usize;
+                                                    sdr_transcription::SherpaModel::ALL
+                                                        .get(idx)
+                                                        .copied()
+                                                        .is_some_and(
+                                                            sdr_transcription::SherpaModel::supports_partials,
+                                                        )
+                                                });
+                                            let show_live = model_supports_partials
+                                                && display_mode_row_weak.upgrade().is_some_and(
                                                     |row| row.selected() != DISPLAY_MODE_FINAL_IDX,
                                                 );
                                             if show_live
@@ -1857,6 +1903,8 @@ fn connect_transcript_panel(
                                             &noise_gate_row_weak,
                                             #[cfg(feature = "sherpa")]
                                             &display_mode_row_weak,
+                                            #[cfg(feature = "sherpa")]
+                                            &vad_threshold_row_weak,
                                         );
                                         if let Some(enable) = enable_row_weak.upgrade() {
                                             enable.set_active(false);
@@ -1922,6 +1970,8 @@ fn connect_transcript_panel(
                                         &noise_gate_row_weak,
                                         #[cfg(feature = "sherpa")]
                                         &display_mode_row_weak,
+                                        #[cfg(feature = "sherpa")]
+                                        &vad_threshold_row_weak,
                                     );
                                     if let Some(enable) = enable_row_weak.upgrade() {
                                         enable.set_active(false);
@@ -1951,6 +2001,8 @@ fn connect_transcript_panel(
                         &noise_gate_row.downgrade(),
                         #[cfg(feature = "sherpa")]
                         &display_mode_row.downgrade(),
+                        #[cfg(feature = "sherpa")]
+                        &vad_threshold_row.downgrade(),
                     );
                     // Reset the toggle FIRST (the else branch clears
                     // status_label as part of its normal teardown), then
@@ -1971,6 +2023,8 @@ fn connect_transcript_panel(
                 &noise_gate_row.downgrade(),
                 #[cfg(feature = "sherpa")]
                 &display_mode_row.downgrade(),
+                #[cfg(feature = "sherpa")]
+                &vad_threshold_row.downgrade(),
             );
             state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
             engine_clone.borrow_mut().shutdown_nonblocking();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1877,14 +1877,44 @@ fn connect_transcript_panel(
                                 },
                                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                                    // Backend channel dropped without a
-                                    // terminal Error event. Mirror the Error
-                                    // arm's teardown so the locked controls
-                                    // (model_row, silence_row, noise_gate_row,
-                                    // display_mode_row, enable_row) all
-                                    // recover instead of staying frozen.
+                                    // Distinguish a normal user-initiated stop
+                                    // from a spontaneous backend death:
+                                    //
+                                    // - User stop: the off branch of
+                                    //   enable_row.connect_active_notify already
+                                    //   ran (it dropped audio_tx, which is what
+                                    //   caused the worker to exit and drop
+                                    //   event_tx, which we're now seeing as
+                                    //   Disconnected). The toggle is already
+                                    //   inactive and all the rows have been
+                                    //   re-enabled. Nothing to do here — the
+                                    //   off branch did the cleanup. Without
+                                    //   this check the disconnect arm overwrote
+                                    //   the off branch's clean state with a
+                                    //   spurious "Transcription stopped
+                                    //   unexpectedly" error message on every
+                                    //   normal stop.
+                                    //
+                                    // - Spontaneous death: the worker dropped
+                                    //   event_tx without the user clicking
+                                    //   anything. The toggle is still active.
+                                    //   Mirror the Error arm's teardown so the
+                                    //   UI doesn't strand the user with locked
+                                    //   controls and a stale "Listening..."
+                                    //   status.
+                                    let was_user_stop = enable_row_weak
+                                        .upgrade()
+                                        .is_none_or(|e| !e.is_active());
+
+                                    if was_user_stop {
+                                        tracing::debug!(
+                                            "transcription event channel closed (user stop)"
+                                        );
+                                        return glib::ControlFlow::Break;
+                                    }
+
                                     tracing::warn!(
-                                        "transcription event channel disconnected without terminal event"
+                                        "transcription event channel disconnected unexpectedly"
                                     );
                                     unlock_transcription_session_rows(
                                         &model_row_weak,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -134,7 +134,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     setup_app_actions(app, &window, config, &rr_button);
 
     // Wire transcript panel (separate from sidebar panels).
-    let transcription_engine = connect_transcript_panel(&transcript_panel, &state);
+    let transcription_engine = connect_transcript_panel(&transcript_panel, &state, config);
 
     // On window close, signal the worker to stop without blocking.
     window.connect_close_request(move |_| {
@@ -1530,6 +1530,9 @@ fn unlock_transcription_session_rows(
 fn connect_transcript_panel(
     transcript: &sidebar::transcript_panel::TranscriptPanel,
     state: &Rc<AppState>,
+    #[cfg_attr(not(feature = "sherpa"), allow(unused_variables))] config: &std::sync::Arc<
+        sdr_config::ConfigManager,
+    >,
 ) -> Rc<RefCell<sdr_transcription::TranscriptionEngine>> {
     use sdr_transcription::{TranscriptionEngine, TranscriptionEvent};
 
@@ -1572,6 +1575,11 @@ fn connect_transcript_panel(
         let status_label_reload = status_label.clone();
         let progress_bar_reload = progress_bar.clone();
         let enable_row_reload = transcript.enable_row.clone();
+        // Config handle for the deferred-persistence path. We write
+        // KEY_SHERPA_MODEL only after InitEvent::Ready fires so a
+        // failed recognizer swap can't leave a broken model idx in
+        // config that would wedge next startup's init_sherpa_host.
+        let config_for_reload_persist = std::sync::Arc::clone(config);
         transcript.model_row.connect_selected_notify(move |row| {
             let idx = row.selected() as usize;
             let Some(new_model) = sdr_transcription::SherpaModel::ALL.get(idx).copied() else {
@@ -1608,6 +1616,11 @@ fn connect_transcript_panel(
             let status_weak = status_label_reload.downgrade();
             let progress_weak = progress_bar_reload.downgrade();
             let mut current_component: String = new_model.label().to_owned();
+            // Capture an Arc clone + the new idx for the deferred
+            // persistence path — written to config on Ready, dropped
+            // silently on Failed/Disconnected.
+            let config_for_this_reload = std::sync::Arc::clone(&config_for_reload_persist);
+            let persist_idx = idx;
             glib::timeout_add_local(Duration::from_millis(100), move || {
                 let Some(status) = status_weak.upgrade() else {
                     // Widgets are gone (window closing); model row is too,
@@ -1648,6 +1661,16 @@ fn connect_transcript_panel(
                             if let Some(enable_row) = enable_row_reload_weak.upgrade() {
                                 enable_row.set_sensitive(true);
                             }
+                            // Deferred persistence: the recognizer swap
+                            // succeeded, so it's now safe to save the
+                            // new selection to config. If this Ready
+                            // arm never fires (reload failed), config
+                            // keeps the previous model idx and next
+                            // startup gets a known-working recognizer.
+                            config_for_this_reload.write(|v| {
+                                v[crate::sidebar::transcript_panel::KEY_SHERPA_MODEL] =
+                                    serde_json::json!(persist_idx);
+                            });
                             return glib::ControlFlow::Break;
                         }
                         Ok(sdr_transcription::InitEvent::Failed { message }) => {
@@ -1746,7 +1769,7 @@ fn connect_transcript_panel(
             let vad_threshold = vad_threshold_row.value() as f32;
             // Whisper builds compile the field but ignore it (no Silero VAD).
             #[cfg(feature = "whisper")]
-            let vad_threshold: f32 = 0.5;
+            let vad_threshold: f32 = sdr_transcription::VAD_THRESHOLD_DEFAULT;
 
             let config = sdr_transcription::BackendConfig {
                 model,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1902,9 +1902,8 @@ fn connect_transcript_panel(
                                     //   UI doesn't strand the user with locked
                                     //   controls and a stale "Listening..."
                                     //   status.
-                                    let was_user_stop = enable_row_weak
-                                        .upgrade()
-                                        .is_none_or(|e| !e.is_active());
+                                    let was_user_stop =
+                                        enable_row_weak.upgrade().is_none_or(|e| !e.is_active());
 
                                     if was_user_stop {
                                         tracing::debug!(

--- a/docs/superpowers/plans/2026-04-13-parakeet-integration.md
+++ b/docs/superpowers/plans/2026-04-13-parakeet-integration.md
@@ -1,0 +1,932 @@
+# Parakeet-TDT Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add NVIDIA Parakeet-TDT-0.6b-v3 as a fourth selectable `SherpaModel` variant, slotting into the existing offline (VAD-gated) recognizer path that PR 5 built for Moonshine.
+
+**Architecture:** Parakeet is offline in sherpa-onnx 1.12, not online. Adds one new `ModelKind` variant (`OfflineNemoTransducer`), one new `SherpaModel` variant (`ParakeetTdt06bV3En`), and one new recognizer config builder (`build_nemo_transducer_recognizer_config`) that wraps `OfflineTransducerModelConfig` + `model_type = "nemo_transducer"`. The host `init_offline` function gains a `match model.kind()` dispatch to pick the right config builder. The session loop, VAD, UI, and runtime model reload are all unchanged — they're already generic over offline recognizers.
+
+**Tech Stack:** Rust 2024, sherpa-onnx 1.12.36 (`OfflineRecognizer` + `OfflineTransducerModelConfig` with `nemo_transducer` model type), existing PR 5 offline session loop, existing PR 5 runtime model reload.
+
+---
+
+## File Structure
+
+**Modified files only — no new files:**
+
+- `crates/sdr-transcription/src/sherpa_model.rs` — add `OfflineNemoTransducer` to `ModelKind`, add `ParakeetTdt06bV3En` to `SherpaModel`, extend all match arms (`label`, `dir_name`, `archive_filename`, `archive_inner_directory`, `kind`, `supports_partials`), extend `model_file_paths`, extend `ALL`, update existing `all_contains_three_variants` test → four, add new Parakeet unit tests
+- `crates/sdr-transcription/src/backends/sherpa/offline.rs` — add `build_nemo_transducer_recognizer_config` function alongside the existing `build_moonshine_recognizer_config`
+- `crates/sdr-transcription/src/backends/sherpa/host.rs` — extend three `match model.kind()` locations (initial dispatch in `run_host_loop`, `ReloadRecognizer` arm, recognizer config selection inside `init_offline`); update `init_offline` doc comment to be generic across offline kinds; update `ModelKind` doc comments to mention the new variant
+
+That's it. No new files, no new modules. PR 5 already built every piece of infrastructure Parakeet needs.
+
+---
+
+## Task 1: Add `OfflineNemoTransducer` to `ModelKind`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/sherpa_model.rs`
+
+This task adds the new ModelKind variant in isolation. Match arms in `kind()`, `supports_partials()`, and the host file all break temporarily because they're exhaustive — Task 2 and Task 4 fix them. We keep the build broken between this and Task 2 because the change is mechanically forced by the compiler and Task 2 lands within minutes.
+
+> **Important:** Tasks 1, 2, 3, and 4 must be executed as a sequential block without spec/quality reviews between them — Task 1 leaves the build broken (compile errors in `kind()`, `supports_partials()`, `model_file_paths()`, and three locations in `host.rs`), and the build only goes green again at the end of Task 4. Run all four tasks, verify the combined build, then do a single review pass covering all four commits.
+
+- [ ] **Step 1: Update the `ModelKind` enum**
+
+In `crates/sdr-transcription/src/sherpa_model.rs`, find:
+
+```rust
+/// Which sherpa-onnx recognizer family a model belongs to.
+///
+/// Drives host init branching and session loop dispatch. Online
+/// models run through `OnlineRecognizer` + streaming chunks;
+/// offline models run through `OfflineRecognizer` + external VAD.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelKind {
+    /// Streaming transducer: Zipformer today, Parakeet-TDT in a future PR.
+    /// Uses `OnlineRecognizer` + streaming session loop.
+    OnlineTransducer,
+    /// Offline encoder-decoder: Moonshine v2. Requires external VAD
+    /// to detect utterance boundaries before batch decoding.
+    OfflineMoonshine,
+}
+```
+
+Replace with:
+
+```rust
+/// Which sherpa-onnx recognizer family a model belongs to.
+///
+/// Drives host init branching and session loop dispatch. Online
+/// models run through `OnlineRecognizer` + streaming chunks;
+/// offline models run through `OfflineRecognizer` + external VAD.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelKind {
+    /// Streaming transducer: Zipformer today. Uses `OnlineRecognizer`
+    /// + streaming session loop in `backends/sherpa/streaming.rs`.
+    OnlineTransducer,
+    /// Offline encoder-decoder: Moonshine v1. Requires external VAD
+    /// (Silero) to detect utterance boundaries before batch decoding.
+    /// Uses `OfflineRecognizer` with `OfflineMoonshineModelConfig`
+    /// + the offline session loop in `backends/sherpa/offline.rs`.
+    OfflineMoonshine,
+    /// Offline transducer-style model from NVIDIA NeMo: Parakeet-TDT
+    /// today. Uses `OfflineRecognizer` with `OfflineTransducerModelConfig`
+    /// + `model_type = "nemo_transducer"`. Shares the same VAD-gated
+    /// offline session loop as `OfflineMoonshine`; only the recognizer
+    /// config builder differs.
+    OfflineNemoTransducer,
+}
+```
+
+Note: the previous `OnlineTransducer` doc said "Parakeet-TDT in a future PR" — that was wrong (Parakeet is offline). The corrected doc removes the misleading claim.
+
+- [ ] **Step 2: Commit (build is intentionally broken until Task 4)**
+
+```bash
+git add crates/sdr-transcription/src/sherpa_model.rs
+git commit -m "feat(transcription): add OfflineNemoTransducer to ModelKind
+
+Adds the third ModelKind variant for NVIDIA NeMo offline transducer
+models (Parakeet-TDT today). Shares the offline session loop with
+Moonshine; only the recognizer config builder differs.
+
+Also corrects the OnlineTransducer doc comment which previously
+claimed Parakeet was a future streaming addition — Parakeet turned
+out to be offline-only in sherpa-onnx 1.12.
+
+Build is intentionally broken at this commit: exhaustive matches on
+ModelKind in supports_partials(), the host run_host_loop dispatch,
+the ReloadRecognizer dispatch, and init_offline are all missing the
+new arm. Tasks 2-4 close the build.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add `ParakeetTdt06bV3En` to `SherpaModel`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/sherpa_model.rs`
+
+Adds the variant + every match arm + tests. Single task with multiple steps, single commit at the end. After this task the `sherpa_model.rs` file compiles cleanly on its own; `host.rs` still has compile errors waiting for Task 4.
+
+- [ ] **Step 1: Add the variant to `SherpaModel`**
+
+In `crates/sdr-transcription/src/sherpa_model.rs`, find:
+
+```rust
+/// Available sherpa-onnx model variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SherpaModel {
+    /// Streaming Zipformer English (k2-fsa, 2023-06-26).
+    StreamingZipformerEn,
+    /// Moonshine Tiny (`UsefulSensors`, English, int8). ~27M params,
+    /// ~170MB bundle. Fastest Moonshine variant — best for CPU-only
+    /// and low-end hardware. Offline (VAD-gated) decode.
+    MoonshineTinyEn,
+    /// Moonshine Base (`UsefulSensors`, English, int8). ~61M params,
+    /// ~380MB bundle. More accurate than Tiny, higher per-utterance
+    /// latency. Offline (VAD-gated) decode.
+    MoonshineBaseEn,
+}
+```
+
+Replace with:
+
+```rust
+/// Available sherpa-onnx model variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SherpaModel {
+    /// Streaming Zipformer English (k2-fsa, 2023-06-26).
+    StreamingZipformerEn,
+    /// Moonshine Tiny (`UsefulSensors`, English, int8). ~27M params,
+    /// ~170MB bundle. Fastest Moonshine variant — best for CPU-only
+    /// and low-end hardware. Offline (VAD-gated) decode.
+    MoonshineTinyEn,
+    /// Moonshine Base (`UsefulSensors`, English, int8). ~61M params,
+    /// ~380MB bundle. More accurate than Tiny, higher per-utterance
+    /// latency. Offline (VAD-gated) decode.
+    MoonshineBaseEn,
+    /// NVIDIA Parakeet-TDT-0.6b v3 (English, int8). ~600M params,
+    /// ~600MB bundle. Highest accuracy — currently #1 on the OpenASR
+    /// leaderboard. CPU-only today (sherpa-cuda follow-up tracked).
+    /// Offline (VAD-gated) batch decode through a NeMo transducer.
+    ParakeetTdt06bV3En,
+}
+```
+
+- [ ] **Step 2: Extend `label()`**
+
+Replace the `label` method body:
+
+```rust
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "Streaming Zipformer (English)",
+            Self::MoonshineTinyEn => "Moonshine Tiny (English)",
+            Self::MoonshineBaseEn => "Moonshine Base (English)",
+            Self::ParakeetTdt06bV3En => "Parakeet TDT 0.6b v3 (English)",
+        }
+    }
+```
+
+- [ ] **Step 3: Extend `dir_name()`**
+
+Replace the `dir_name` method body:
+
+```rust
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "streaming-zipformer-en",
+            Self::MoonshineTinyEn => "moonshine-tiny-en",
+            Self::MoonshineBaseEn => "moonshine-base-en",
+            Self::ParakeetTdt06bV3En => "parakeet-tdt-0.6b-v3-en",
+        }
+    }
+```
+
+- [ ] **Step 4: Extend `archive_filename()`**
+
+Replace the `archive_filename` method body:
+
+```rust
+    pub fn archive_filename(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2",
+            Self::MoonshineTinyEn => "sherpa-onnx-moonshine-tiny-en-int8.tar.bz2",
+            Self::MoonshineBaseEn => "sherpa-onnx-moonshine-base-en-int8.tar.bz2",
+            Self::ParakeetTdt06bV3En => "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2",
+        }
+    }
+```
+
+- [ ] **Step 5: Extend `archive_inner_directory()`**
+
+Replace the `archive_inner_directory` method body:
+
+```rust
+    pub fn archive_inner_directory(self) -> &'static str {
+        match self {
+            Self::StreamingZipformerEn => "sherpa-onnx-streaming-zipformer-en-2023-06-26",
+            Self::MoonshineTinyEn => "sherpa-onnx-moonshine-tiny-en-int8",
+            Self::MoonshineBaseEn => "sherpa-onnx-moonshine-base-en-int8",
+            Self::ParakeetTdt06bV3En => "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8",
+        }
+    }
+```
+
+- [ ] **Step 6: Extend `kind()`**
+
+Replace the `kind` method body:
+
+```rust
+    pub fn kind(self) -> ModelKind {
+        match self {
+            Self::StreamingZipformerEn => ModelKind::OnlineTransducer,
+            Self::MoonshineTinyEn | Self::MoonshineBaseEn => ModelKind::OfflineMoonshine,
+            Self::ParakeetTdt06bV3En => ModelKind::OfflineNemoTransducer,
+        }
+    }
+```
+
+- [ ] **Step 7: Extend `supports_partials()`**
+
+Replace the `supports_partials` method body:
+
+```rust
+    pub fn supports_partials(self) -> bool {
+        match self.kind() {
+            ModelKind::OnlineTransducer => true,
+            ModelKind::OfflineMoonshine | ModelKind::OfflineNemoTransducer => false,
+        }
+    }
+```
+
+- [ ] **Step 8: Extend `ALL`**
+
+Replace the `ALL` constant:
+
+```rust
+    pub const ALL: &[Self] = &[
+        Self::StreamingZipformerEn,
+        Self::MoonshineTinyEn,
+        Self::MoonshineBaseEn,
+        Self::ParakeetTdt06bV3En,
+    ];
+```
+
+- [ ] **Step 9: Extend `model_file_paths()`**
+
+Locate the `model_file_paths` function. Add a new arm for Parakeet — it reuses the existing `Transducer` variant (same 4-file shape as Zipformer):
+
+```rust
+pub fn model_file_paths(model: SherpaModel) -> ModelFilePaths {
+    let dir = model_directory(model);
+    match model {
+        SherpaModel::StreamingZipformerEn => ModelFilePaths::Transducer {
+            encoder: dir.join("encoder-epoch-99-avg-1-chunk-16-left-128.onnx"),
+            decoder: dir.join("decoder-epoch-99-avg-1-chunk-16-left-128.onnx"),
+            joiner: dir.join("joiner-epoch-99-avg-1-chunk-16-left-128.onnx"),
+            tokens: dir.join("tokens.txt"),
+        },
+        // Moonshine v1 five-file layout (k2-fsa int8 releases): the
+        // preprocessor is NOT quantized (`preprocess.onnx`, not `.int8.onnx`).
+        SherpaModel::MoonshineTinyEn | SherpaModel::MoonshineBaseEn => ModelFilePaths::Moonshine {
+            preprocessor: dir.join("preprocess.onnx"),
+            encoder: dir.join("encode.int8.onnx"),
+            uncached_decoder: dir.join("uncached_decode.int8.onnx"),
+            cached_decoder: dir.join("cached_decode.int8.onnx"),
+            tokens: dir.join("tokens.txt"),
+        },
+        // Parakeet-TDT v3 int8 layout: standard 4-file transducer
+        // (encoder + decoder + joiner + tokens), structurally identical
+        // to Zipformer. The `Transducer` ModelFilePaths variant is
+        // reused — kind() tells the host which recognizer API to feed
+        // them into (online for Zipformer vs offline for Parakeet).
+        SherpaModel::ParakeetTdt06bV3En => ModelFilePaths::Transducer {
+            encoder: dir.join("encoder.int8.onnx"),
+            decoder: dir.join("decoder.int8.onnx"),
+            joiner: dir.join("joiner.int8.onnx"),
+            tokens: dir.join("tokens.txt"),
+        },
+    }
+}
+```
+
+- [ ] **Step 10: Update the existing `all_contains_three_variants` test**
+
+Find:
+
+```rust
+    #[test]
+    fn all_contains_three_variants() {
+        assert_eq!(SherpaModel::ALL.len(), 3);
+    }
+```
+
+Replace with:
+
+```rust
+    #[test]
+    fn all_contains_four_variants() {
+        assert_eq!(SherpaModel::ALL.len(), 4);
+    }
+```
+
+- [ ] **Step 11: Add new Parakeet unit tests**
+
+In the same `#[cfg(test)] mod tests` block, add these four tests right after `all_contains_four_variants`:
+
+```rust
+    #[test]
+    fn parakeet_is_offline_nemo_transducer_kind() {
+        assert_eq!(
+            SherpaModel::ParakeetTdt06bV3En.kind(),
+            ModelKind::OfflineNemoTransducer
+        );
+    }
+
+    #[test]
+    fn parakeet_does_not_support_partials() {
+        assert!(!SherpaModel::ParakeetTdt06bV3En.supports_partials());
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn parakeet_has_transducer_file_layout() {
+        let paths = model_file_paths(SherpaModel::ParakeetTdt06bV3En);
+        let ModelFilePaths::Transducer {
+            encoder,
+            decoder,
+            joiner,
+            tokens,
+        } = paths
+        else {
+            panic!("ParakeetTdt06bV3En should be a Transducer layout");
+        };
+        assert!(encoder.ends_with("encoder.int8.onnx"));
+        assert!(decoder.ends_with("decoder.int8.onnx"));
+        assert!(joiner.ends_with("joiner.int8.onnx"));
+        assert!(tokens.ends_with("tokens.txt"));
+        assert_ne!(encoder, decoder);
+        assert_ne!(decoder, joiner);
+    }
+
+    #[test]
+    fn parakeet_archive_url_is_well_formed() {
+        let url = SherpaModel::ParakeetTdt06bV3En.archive_url();
+        assert!(url.starts_with("https://github.com/k2-fsa/sherpa-onnx/"));
+        assert!(url.ends_with(".tar.bz2"));
+        assert!(url.contains("parakeet"));
+        assert!(url.contains("tdt"));
+        assert!(url.contains("v3"));
+    }
+```
+
+- [ ] **Step 12: Verify sherpa_model.rs compiles cleanly in isolation**
+
+Run:
+```bash
+cargo build -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -20
+```
+Expected: FAIL with errors only in `backends/sherpa/host.rs` — specifically the three exhaustive matches on `ModelKind` and the `init_offline` body referencing `build_moonshine_recognizer_config`. NO errors should appear in `sherpa_model.rs` itself. If there are errors in `sherpa_model.rs`, STOP and report BLOCKED.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add crates/sdr-transcription/src/sherpa_model.rs
+git commit -m "feat(transcription): add ParakeetTdt06bV3En to SherpaModel
+
+Adds the variant with full metadata (label, dir_name, archive_filename,
+archive_inner_directory). kind() returns OfflineNemoTransducer.
+supports_partials() returns false (offline model — no partials, same
+as Moonshine). model_file_paths reuses ModelFilePaths::Transducer
+because Parakeet ships the standard 4-file transducer layout
+(encoder/decoder/joiner/tokens) — same shape as Zipformer, only the
+recognizer family differs.
+
+ALL extended to four variants. Renames the all_contains_three_variants
+test to all_contains_four_variants. Adds four new Parakeet tests:
+kind, supports_partials, file layout, archive URL.
+
+Build still broken in host.rs — Task 4 closes it.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add `build_nemo_transducer_recognizer_config` in `offline.rs`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa/offline.rs`
+
+Adds the new builder function alongside the existing `build_moonshine_recognizer_config`. After this task the offline.rs file compiles cleanly on its own; host.rs still has compile errors until Task 4.
+
+- [ ] **Step 1: Add `OfflineTransducerModelConfig` to the imports**
+
+In `crates/sdr-transcription/src/backends/sherpa/offline.rs`, find the existing `use sherpa_onnx::` block. It currently looks like:
+
+```rust
+use sherpa_onnx::{
+    OfflineModelConfig, OfflineMoonshineModelConfig, OfflineRecognizer, OfflineRecognizerConfig,
+};
+```
+
+Replace with:
+
+```rust
+use sherpa_onnx::{
+    OfflineModelConfig, OfflineMoonshineModelConfig, OfflineRecognizer, OfflineRecognizerConfig,
+    OfflineTransducerModelConfig,
+};
+```
+
+- [ ] **Step 2: Add the `build_nemo_transducer_recognizer_config` function**
+
+In the same file, find the existing `build_moonshine_recognizer_config` function. Immediately after its closing `}`, insert this new function:
+
+```rust
+/// Build the `OfflineRecognizerConfig` for a NeMo Parakeet-TDT model.
+///
+/// Uses sherpa-onnx's offline transducer config (4 files: encoder,
+/// decoder, joiner, tokens) with `model_type = "nemo_transducer"`.
+/// The model_type field is required — without it, sherpa-onnx tries
+/// to use the generic transducer decode loop which doesn't understand
+/// NeMo's TDT (Token-and-Duration Transducer) joiner output shape.
+///
+/// Mirrors the upstream `rust-api-examples/examples/nemo_parakeet.rs`
+/// example.
+pub(super) fn build_nemo_transducer_recognizer_config(
+    model: SherpaModel,
+    provider: &str,
+) -> OfflineRecognizerConfig {
+    let ModelFilePaths::Transducer {
+        encoder,
+        decoder,
+        joiner,
+        tokens,
+    } = sherpa_model::model_file_paths(model)
+    else {
+        unreachable!(
+            "offline::build_nemo_transducer_recognizer_config called with non-Transducer layout"
+        )
+    };
+
+    let transducer = OfflineTransducerModelConfig {
+        encoder: Some(encoder.to_string_lossy().into_owned()),
+        decoder: Some(decoder.to_string_lossy().into_owned()),
+        joiner: Some(joiner.to_string_lossy().into_owned()),
+    };
+
+    let model_config = OfflineModelConfig {
+        transducer,
+        tokens: Some(tokens.to_string_lossy().into_owned()),
+        provider: Some(provider.to_owned()),
+        num_threads: SHERPA_NUM_THREADS,
+        // Required — tells sherpa-onnx to use NeMo's TDT decode loop
+        // instead of the generic transducer path.
+        model_type: Some("nemo_transducer".to_owned()),
+        ..OfflineModelConfig::default()
+    };
+
+    OfflineRecognizerConfig {
+        model_config,
+        ..OfflineRecognizerConfig::default()
+    }
+}
+```
+
+- [ ] **Step 3: Verify offline.rs compiles cleanly in isolation**
+
+Run:
+```bash
+cargo build -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -20
+```
+Expected: still FAILS, but the failure should now be ONLY about `host.rs` exhaustive matches. NO errors should mention `offline.rs`. If there are errors in `offline.rs`, STOP and report BLOCKED.
+
+Common failure modes to watch:
+- If `OfflineTransducerModelConfig` has additional fields beyond `encoder`/`decoder`/`joiner` in this version of sherpa-onnx, the compiler will say "missing field". The plan was verified against sherpa-onnx 1.12.36 where the struct is exactly those three `Option<String>` fields. If the version drifted, read the struct definition at `~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sherpa-onnx-1.12.36/src/offline_asr.rs:49` and adjust.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa/offline.rs
+git commit -m "feat(transcription): add Parakeet (nemo_transducer) recognizer builder
+
+New build_nemo_transducer_recognizer_config alongside the existing
+build_moonshine_recognizer_config. Wraps OfflineTransducerModelConfig
+with model_type = 'nemo_transducer' per the upstream nemo_parakeet.rs
+example.
+
+Build still broken in host.rs — Task 4 closes it.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Branch host init on `OfflineNemoTransducer`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa/host.rs`
+
+Updates the three `match model.kind()` locations in `host.rs` to handle the new variant, and adds the recognizer config dispatch inside `init_offline`. After this task the build is fully green again.
+
+- [ ] **Step 1: Update the initial dispatch in `run_host_loop`**
+
+In `crates/sdr-transcription/src/backends/sherpa/host.rs`, find this block inside `run_host_loop`:
+
+```rust
+    use crate::sherpa_model::ModelKind;
+
+    let recognizer_state = match model.kind() {
+        ModelKind::OnlineTransducer => match init_online(model, &event_tx) {
+            Ok(state) => state,
+            Err(()) => return, // init_online already published Failed and stored the error
+        },
+        ModelKind::OfflineMoonshine => match init_offline(model, &event_tx) {
+            Ok(state) => state,
+            Err(()) => return,
+        },
+    };
+```
+
+Replace with:
+
+```rust
+    use crate::sherpa_model::ModelKind;
+
+    let recognizer_state = match model.kind() {
+        ModelKind::OnlineTransducer => match init_online(model, &event_tx) {
+            Ok(state) => state,
+            Err(()) => return, // init_online already published Failed and stored the error
+        },
+        // Both offline kinds share init_offline — only the recognizer
+        // config builder differs, and that branching happens inside
+        // init_offline based on model.kind() again.
+        ModelKind::OfflineMoonshine | ModelKind::OfflineNemoTransducer => {
+            match init_offline(model, &event_tx) {
+                Ok(state) => state,
+                Err(()) => return,
+            }
+        }
+    };
+```
+
+- [ ] **Step 2: Update the `ReloadRecognizer` dispatch**
+
+Still in `host.rs`, find this block inside the `HostCommand::ReloadRecognizer` arm:
+
+```rust
+                let new_state = match new_model.kind() {
+                    crate::sherpa_model::ModelKind::OnlineTransducer => {
+                        init_online(new_model, &event_tx)
+                    }
+                    crate::sherpa_model::ModelKind::OfflineMoonshine => {
+                        init_offline(new_model, &event_tx)
+                    }
+                };
+```
+
+Replace with:
+
+```rust
+                let new_state = match new_model.kind() {
+                    crate::sherpa_model::ModelKind::OnlineTransducer => {
+                        init_online(new_model, &event_tx)
+                    }
+                    crate::sherpa_model::ModelKind::OfflineMoonshine
+                    | crate::sherpa_model::ModelKind::OfflineNemoTransducer => {
+                        init_offline(new_model, &event_tx)
+                    }
+                };
+```
+
+- [ ] **Step 3: Update `init_offline` to dispatch on model kind**
+
+Still in `host.rs`, find the `init_offline` function. Locate this part of its body (the existing `let recognizer_config = ... build_moonshine_recognizer_config ...` line):
+
+```rust
+    let _ = event_tx.send(InitEvent::CreatingRecognizer);
+    let recognizer_config = super::offline::build_moonshine_recognizer_config(model, "cpu");
+    tracing::info!(?model, "creating sherpa-onnx OfflineRecognizer (Moonshine)");
+
+    let Some(recognizer) = OfflineRecognizer::create(&recognizer_config) else {
+        let msg = "OfflineRecognizer::create returned None — check Moonshine model files".to_owned();
+```
+
+Replace with:
+
+```rust
+    let _ = event_tx.send(InitEvent::CreatingRecognizer);
+    // Both offline kinds use OfflineRecognizer but with different config
+    // builders. Branch here so init_offline's Phase 1-2 (download VAD +
+    // bundle) stays generic across all offline models.
+    let recognizer_config = match model.kind() {
+        crate::sherpa_model::ModelKind::OfflineMoonshine => {
+            super::offline::build_moonshine_recognizer_config(model, "cpu")
+        }
+        crate::sherpa_model::ModelKind::OfflineNemoTransducer => {
+            super::offline::build_nemo_transducer_recognizer_config(model, "cpu")
+        }
+        crate::sherpa_model::ModelKind::OnlineTransducer => {
+            unreachable!("init_offline called with an online model")
+        }
+    };
+    tracing::info!(?model, "creating sherpa-onnx OfflineRecognizer");
+
+    let Some(recognizer) = OfflineRecognizer::create(&recognizer_config) else {
+        let msg = format!(
+            "OfflineRecognizer::create returned None for {} — check model files and model_type",
+            model.label()
+        );
+```
+
+Note two adjustments:
+- The `tracing::info!` message drops the "(Moonshine)" parenthetical because it now applies to both offline kinds.
+- The error message becomes generic across both offline kinds AND mentions `model_type` since that's a common Parakeet-specific failure mode.
+
+The next line in the existing code is `tracing::error!(%msg);`. Since the `msg` is now constructed via `format!` instead of `to_owned()`, no other changes needed — the rest of the error-reporting flow uses `msg.clone()` and is unaffected.
+
+- [ ] **Step 4: Update `init_offline`'s doc comment to be generic**
+
+Still in `host.rs`, find the doc comment immediately above `fn init_offline`:
+
+```rust
+/// Phase 1-2 for the `OfflineMoonshine` path: download the Silero VAD
+/// model if missing, download the Moonshine bundle if missing, then
+/// create the `OfflineRecognizer` + `SherpaSileroVad`. Returns `Err(())`
+/// on any failure — the error has already been stored in `SHERPA_HOST`
+/// and emitted as `InitEvent::Failed`.
+fn init_offline(
+```
+
+Replace with:
+
+```rust
+/// Phase 1-2 for any offline model (`OfflineMoonshine` or
+/// `OfflineNemoTransducer`): download the Silero VAD if missing,
+/// download the model bundle if missing, then build the right
+/// `OfflineRecognizerConfig` for the model's kind and create the
+/// `OfflineRecognizer` + `SherpaSileroVad`.
+///
+/// The recognizer config builder is selected via `model.kind()` so
+/// callers don't need to know which offline family they're using.
+/// Returns `Err(())` on any failure — the error has already been
+/// stored in `SHERPA_HOST` and emitted as `InitEvent::Failed`.
+fn init_offline(
+```
+
+- [ ] **Step 5: Verify both builds compile + clippy clean**
+
+Run:
+```bash
+cargo build --workspace --no-default-features --features sherpa-cpu 2>&1 | tail -10
+cargo build --workspace 2>&1 | tail -10
+cargo clippy --all-targets --workspace --no-default-features --features sherpa-cpu -- -D warnings 2>&1 | tail -10
+cargo clippy --all-targets --workspace -- -D warnings 2>&1 | tail -10
+cargo test -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -25
+```
+Expected: all PASS. The build was broken from Task 1 through Task 3; this is the commit that closes it.
+
+If clippy complains about `match self.kind() { ... | ... => false, _ => true }` style issues in `supports_partials` from Task 2, normalize using whatever pattern clippy prefers and report the adjustment.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa/host.rs
+git commit -m "feat(transcription): branch host init on OfflineNemoTransducer
+
+Updates all three match locations in host.rs to handle the new
+ModelKind::OfflineNemoTransducer variant:
+
+1. run_host_loop initial dispatch — both offline kinds share
+   init_offline, only the recognizer config builder differs
+2. ReloadRecognizer arm — same pattern
+3. init_offline body — branches on model.kind() to call either
+   build_moonshine_recognizer_config or
+   build_nemo_transducer_recognizer_config
+
+init_offline doc comment generalized to mention both offline
+families. Recognizer creation error message now mentions model_type
+since that's a common Parakeet-specific misconfiguration mode.
+
+Closes the build that was intentionally broken from Task 1 onward.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full lint + fmt + test sweep both flavors
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: cargo fmt check**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS with no output. If it reports differences, run `cargo fmt --all` and commit the result with `chore: cargo fmt`.
+
+- [ ] **Step 2: Whisper clippy**
+
+Run: `cargo clippy --all-targets --workspace -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 3: Whisper tests**
+
+Run: `cargo test --workspace 2>&1 | tail -20`
+Expected: all passing.
+
+- [ ] **Step 4: Sherpa clippy**
+
+Run: `cargo clippy --all-targets --workspace --no-default-features --features sherpa-cpu -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 5: Sherpa tests**
+
+Run: `cargo test --workspace --no-default-features --features sherpa-cpu 2>&1 | tail -25`
+Expected: all passing, including the four new Parakeet tests from Task 2 Step 11 and the renamed `all_contains_four_variants` test.
+
+- [ ] **Step 6: Commit any fmt cleanup**
+
+If fmt produced fixes, commit them with `chore: cargo fmt`. Otherwise skip.
+
+---
+
+## Task 6: File the sherpa-cuda follow-up issue
+
+**Files:** none (GitHub API action)
+
+- [ ] **Step 1: Create the issue via gh CLI**
+
+```bash
+gh issue create --title "Add sherpa-onnx CUDA provider support for large offline models" --body "$(cat <<'EOF'
+## Context
+
+PR 6 (#TBD) ships NVIDIA Parakeet-TDT-0.6b-v3 as a fourth selectable Sherpa model. Parakeet has 600M parameters — roughly 10x the size of Moonshine Base — and runs through sherpa-onnx's CPU execution provider today.
+
+## Problem
+
+Per-utterance latency on CPU is significant for a model this size. Users with CUDA-capable GPUs (the maintainer's daily-driver RTX 4080 Super, for instance) get no benefit from their hardware.
+
+## Proposed change
+
+Add a \`sherpa-cuda\` cargo feature alongside the existing \`sherpa-cpu\` feature in \`crates/sdr-transcription/Cargo.toml\`:
+
+1. Investigate which sherpa-onnx 1.12 cargo feature flag enables the CUDA execution provider (likely \`cuda\` or \`cuda-provider\` — verify at https://crates.io/crates/sherpa-onnx).
+2. Add \`sherpa-cuda = [\"dep:sherpa-onnx\", \"sherpa-onnx/cuda\", \"dep:tar\", \"dep:bzip2\"]\` (adjust the inner feature name to match upstream).
+3. Update the hardcoded \`\"cpu\"\` provider strings in \`crates/sdr-transcription/src/backends/sherpa/host.rs::init_online\` and \`init_offline\` to be selected via \`#[cfg]\`:
+   \`\`\`rust
+   #[cfg(feature = \"sherpa-cuda\")]
+   const SHERPA_PROVIDER: &str = \"cuda\";
+   #[cfg(not(feature = \"sherpa-cuda\"))]
+   const SHERPA_PROVIDER: &str = \"cpu\";
+   \`\`\`
+4. Pass \`SHERPA_PROVIDER\` to both \`build_recognizer_config\` (streaming) and the offline config builders (\`build_moonshine_recognizer_config\`, \`build_nemo_transducer_recognizer_config\`).
+5. Update the install commands documented in CLAUDE.md and \`project_current_state.md\` memory to include the new flag:
+   \`\`\`
+   make install CARGO_FLAGS=\"--release --no-default-features --features sherpa-cuda\"
+   \`\`\`
+
+## Constraints
+
+- **Must remain mutually exclusive with whisper features** — extend the existing \`compile_error!\` guards in \`crates/sdr-transcription/src/lib.rs\` to forbid \`whisper-*\` + \`sherpa-cuda\` combinations.
+- **Must not break the dual-build CI smoke test** — CI continues to exercise \`whisper-cuda\` (default) and \`sherpa-cpu\`. The new \`sherpa-cuda\` build is opt-in for users with the right hardware.
+- Initial PR can leave \`sherpa-cuda\` out of CI to avoid the GPU-runner cost. Add it to a separate runner later if it proves important.
+
+## Acceptance criteria
+
+- \`make install CARGO_FLAGS=\"--release --no-default-features --features sherpa-cuda\"\` builds on a machine with CUDA installed
+- sherpa-onnx logs confirm the CUDA execution provider is in use at recognizer creation
+- Parakeet decode latency drops to GPU-acceptable levels (target: <100ms per utterance for typical radio chatter on RTX 4080-class hardware)
+- Whisper, Zipformer, and Moonshine still work in their respective builds
+- Dual-build smoke test (\`whisper-cuda\` + \`sherpa-cpu\`) still passes
+
+## Labels
+
+\`enhancement\`, \`transcription\`
+EOF
+)" --label enhancement 2>&1 | tail -3
+```
+
+Note the issue number it returns. It will be referenced in the PR description (Task 8).
+
+---
+
+## Task 7: Manual smoke test (user-executed)
+
+**Files:** none (manual verification)
+
+This task is for the human reviewer. The subagent running this plan should stop before this task, report "Ready for manual smoke test", and hand off.
+
+- [ ] **Step 1: Install the sherpa-cpu build**
+
+```bash
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"
+```
+
+- [ ] **Step 2: Zipformer regression**
+
+- Launch `sdr-rs`. Whatever model is currently persisted in config loads at startup as usual.
+- In the transcript panel, switch model to "Streaming Zipformer (English)" if not already selected.
+- Display mode row should be VISIBLE (Zipformer supports partials).
+- Enable transcription on a known audio source (talk radio, RadioReference stream, etc.).
+- Verify live captions stream in place exactly as PR 5 shipped. No regression.
+
+- [ ] **Step 3: Moonshine regression**
+
+- Switch to "Moonshine Tiny (English)". Display mode row should HIDE.
+- Enable transcription, verify per-utterance commits work and accuracy is what you remember from PR 5.
+- Switch to "Moonshine Base (English)". Same checks.
+
+- [ ] **Step 4: Parakeet clean first-run**
+
+- Confirm Parakeet bundle is NOT yet downloaded:
+  ```bash
+  ls ~/.local/share/sdr-rs/models/sherpa/parakeet-tdt-0.6b-v3-en/ 2>&1
+  ```
+  Should report "No such file or directory".
+- Switch model to "Parakeet TDT 0.6b v3 (English)" in the dropdown.
+- Status label should appear: "Reloading Parakeet TDT 0.6b v3 (English)..."
+- Splash-style progress should show:
+  - "Downloading Parakeet TDT 0.6b v3 (English)..." with percent (Silero VAD already cached from PR 5 testing — won't re-download)
+  - "Extracting Parakeet TDT 0.6b v3 (English)..."
+  - "Creating recognizer..." (this is the moment of truth — Parakeet's first-ever creation in this binary)
+  - Status clears
+- Display mode row should HIDE (Parakeet is offline).
+- Enable transcription, feed real radio chatter.
+- Verify text commits land in the text view per utterance. Note the latency.
+
+- [ ] **Step 5: Parakeet accuracy spot-check**
+
+- Find a radio source with tricky content (call signs, numbers, accented speakers).
+- Compare Parakeet's commits against your memory of Moonshine Base on similar audio.
+- Subjective expectation: Parakeet should be noticeably more accurate, especially on numbers and proper nouns.
+- Note: latency may be uncomfortable on CPU. That's expected and the sherpa-cuda issue you just filed is the answer.
+
+- [ ] **Step 6: Runtime swap stress test**
+
+- With transcription stopped, switch among all four models in succession: Zipformer → Moonshine Tiny → Moonshine Base → Parakeet → Zipformer.
+- Each switch should reload cleanly, no crashes, status label flashes "Reloading..." then clears.
+- Re-enable transcription on each to confirm the recognizer is actually live for each switch.
+
+- [ ] **Step 7: Whisper regression (deferred OK)**
+
+- Skip unless you want to verify before the PR opens. Risk is near-zero since all changes are sherpa-gated.
+- If running:
+  ```bash
+  make install CARGO_FLAGS="--release --features whisper-cuda"
+  ```
+- Launch, enable transcription on the existing Whisper model. Confirm Display mode row is NOT present, no Parakeet in the dropdown, existing Whisper behavior unchanged.
+
+- [ ] **Step 8: Report outcome**
+
+Report: all smoke-test steps passed (or list any failures). Include rough Parakeet latency observation so the sherpa-cuda issue can be appropriately prioritized.
+
+---
+
+## Task 8: Push and open PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feature/parakeet-integration
+```
+
+- [ ] **Step 2: Create the PR**
+
+Replace `<CUDA_ISSUE_NUMBER>` with the issue number from Task 6.
+
+```bash
+gh pr create --title "feat(transcription): NVIDIA Parakeet-TDT 0.6b v3 via offline path (#223)" --body "$(cat <<'EOF'
+## Summary
+
+Adds NVIDIA Parakeet-TDT-0.6b-v3 as a fourth selectable Sherpa model — currently #1 on the OpenASR leaderboard and the highest-accuracy ASR option in the dropdown. Slots into the offline (VAD-gated) recognizer path PR 5 built for Moonshine; no new infrastructure, just data + one new recognizer config builder + one new ModelKind dispatch arm.
+
+Closes #223. Part of #204 (sherpa-onnx integration epic) — this is PR 6 of the roadmap.
+
+## Critical correction to PR 5's memory
+
+Yesterday's notes claimed Parakeet would slot into the existing `OnlineTransducer` streaming path because Parakeet is "RNNT family". That was wrong — sherpa-onnx 1.12 only exposes Parakeet through `OfflineRecognizer` (verified against the upstream `rust-api-examples/examples/nemo_parakeet.rs` example). Parakeet shares the offline UX with Moonshine: per-utterance commits, no live captions, Display mode toggle hidden.
+
+## What's new
+
+- **`SherpaModel::ParakeetTdt06bV3En`** — fourth dropdown entry, ~600MB int8 bundle, ~600M parameters.
+- **`ModelKind::OfflineNemoTransducer`** — third recognizer family, distinguishes Parakeet from Moonshine for config-builder dispatch.
+- **`build_nemo_transducer_recognizer_config`** in `backends/sherpa/offline.rs` — wraps `OfflineTransducerModelConfig` with `model_type = "nemo_transducer"` per the upstream example.
+- **`init_offline` dispatches on `model.kind()`** to pick the right recognizer config builder. Phase 1-2 (download VAD + model bundle) stays generic across all offline kinds.
+- **`ModelFilePaths::Transducer` reused** — Parakeet ships the standard 4-file transducer layout (encoder/decoder/joiner/tokens), structurally identical to Zipformer. The variant is overloaded by intent; `kind()` discriminates the recognizer family.
+- **Doc-comment cleanup** — corrected the `OnlineTransducer` doc that previously claimed Parakeet was a future streaming addition.
+
+## What's NOT in this PR
+
+- `streaming.rs`, `silero_vad.rs`, `vad.rs` — unchanged
+- UI code (`transcript_panel.rs`, `window.rs`) — unchanged. PR 5's display-mode-row visibility logic and runtime model reload already handle Parakeet without modification because they delegate to `supports_partials()` and `SherpaModel::ALL`.
+- `main.rs` — splash driver unchanged. Parakeet downloads route through PR 5's component-labeled `InitEvent::DownloadStart` flow.
+
+## Follow-up
+
+Filed #<CUDA_ISSUE_NUMBER> — add sherpa-onnx CUDA provider support for large offline models. Parakeet's 600M parameters are CPU-acceptable but not snappy; users with GPU horsepower (RTX 4080 Super daily driver) deserve to use it. CUDA is a separate PR because it touches Cargo.toml feature gates and the dual-build CI matrix.
+
+## Test plan
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets --workspace -- -D warnings` (Whisper)
+- [x] `cargo clippy --all-targets --workspace --no-default-features --features sherpa-cpu -- -D warnings` (Sherpa)
+- [x] `cargo test --workspace` (both flavors)
+- [x] Manual (sherpa-cpu): Zipformer regression, both Moonshines regression, Parakeet clean first-run via runtime model swap, Parakeet decode on real radio chatter, runtime swap stress test across all four models
+- [ ] Manual (whisper-cuda): deferred to next-day regression check — near-zero risk since all changes are `#[cfg(feature = "sherpa")]`-gated
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Return the PR URL**
+
+Report the PR URL so the user can follow CodeRabbit review.

--- a/docs/superpowers/plans/2026-04-13-parakeet-integration.md
+++ b/docs/superpowers/plans/2026-04-13-parakeet-integration.md
@@ -394,9 +394,11 @@ In the same `#[cfg(test)] mod tests` block, add these four tests right after `al
 - [ ] **Step 12: Verify sherpa_model.rs compiles cleanly in isolation**
 
 Run:
+
 ```bash
 cargo build -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -20
 ```
+
 Expected: FAIL with errors only in `backends/sherpa/host.rs` — specifically the three exhaustive matches on `ModelKind` and the `init_offline` body referencing `build_moonshine_recognizer_config`. NO errors should appear in `sherpa_model.rs` itself. If there are errors in `sherpa_model.rs`, STOP and report BLOCKED.
 
 - [ ] **Step 13: Commit**
@@ -508,9 +510,11 @@ pub(super) fn build_nemo_transducer_recognizer_config(
 - [ ] **Step 3: Verify offline.rs compiles cleanly in isolation**
 
 Run:
+
 ```bash
 cargo build -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -20
 ```
+
 Expected: still FAILS, but the failure should now be ONLY about `host.rs` exhaustive matches. NO errors should mention `offline.rs`. If there are errors in `offline.rs`, STOP and report BLOCKED.
 
 Common failure modes to watch:
@@ -689,6 +693,7 @@ fn init_offline(
 - [ ] **Step 5: Verify both builds compile + clippy clean**
 
 Run:
+
 ```bash
 cargo build --workspace --no-default-features --features sherpa-cpu 2>&1 | tail -10
 cargo build --workspace 2>&1 | tail -10
@@ -696,6 +701,7 @@ cargo clippy --all-targets --workspace --no-default-features --features sherpa-c
 cargo clippy --all-targets --workspace -- -D warnings 2>&1 | tail -10
 cargo test -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -25
 ```
+
 Expected: all PASS. The build was broken from Task 1 through Task 3; this is the commit that closes it.
 
 If clippy complains about `match self.kind() { ... | ... => false, _ => true }` style issues in `supports_partials` from Task 2, normalize using whatever pattern clippy prefers and report the adjustment.

--- a/docs/superpowers/plans/2026-04-13-parakeet-integration.md
+++ b/docs/superpowers/plans/2026-04-13-parakeet-integration.md
@@ -12,13 +12,39 @@
 
 ## File Structure
 
-**Modified files only — no new files:**
+### As originally planned (Tasks 1-4 + sherpa-cuda follow-up issue)
+
+Modified files only — no new files. PR 5 built every piece of infrastructure Parakeet needs:
 
 - `crates/sdr-transcription/src/sherpa_model.rs` — add `OfflineNemoTransducer` to `ModelKind`, add `ParakeetTdt06bV3En` to `SherpaModel`, extend all match arms (`label`, `dir_name`, `archive_filename`, `archive_inner_directory`, `kind`, `supports_partials`), extend `model_file_paths`, extend `ALL`, update existing `all_contains_three_variants` test → four, add new Parakeet unit tests
 - `crates/sdr-transcription/src/backends/sherpa/offline.rs` — add `build_nemo_transducer_recognizer_config` function alongside the existing `build_moonshine_recognizer_config`
 - `crates/sdr-transcription/src/backends/sherpa/host.rs` — extend three `match model.kind()` locations (initial dispatch in `run_host_loop`, `ReloadRecognizer` arm, recognizer config selection inside `init_offline`); update `init_offline` doc comment to be generic across offline kinds; update `ModelKind` doc comments to mention the new variant
 
-That's it. No new files, no new modules. PR 5 already built every piece of infrastructure Parakeet needs.
+### Added mid-PR during manual smoke test (scope creep but necessary)
+
+Manual smoke testing surfaced bugs and one scope-creep-but-necessary feature. These files were also modified before the PR landed:
+
+- `crates/sdr-transcription/src/backend.rs` — add `vad_threshold: f32` field to `BackendConfig` + `VAD_THRESHOLD_MIN/MAX/DEFAULT` pub constants
+- `crates/sdr-transcription/src/backends/sherpa/silero_vad.rs` — `SherpaSileroVad` tracks `current_threshold`, `new()` takes a threshold parameter, `current_threshold()` getter, `SILERO_THRESHOLD` aliased to the canonical `backend::VAD_THRESHOLD_DEFAULT`
+- `crates/sdr-transcription/src/backends/sherpa/mod.rs` — threads `config.vad_threshold` through `SessionParams`
+- `crates/sdr-transcription/src/backends/sherpa/streaming.rs` — destructures the new `SessionParams.vad_threshold` field (ignored, streaming path uses `OnlineRecognizer`'s own endpoint detection)
+- `crates/sdr-transcription/src/backends/mock.rs` + `src/lib.rs` tests + `tests/sherpa_uninitialized.rs` — test fixtures updated for the new `BackendConfig` field
+- `crates/sdr-ui/src/sidebar/transcript_panel.rs` — `vad_threshold_row` SpinRow (sherpa, offline models only), visibility toggle, persistence via new `KEY_SHERPA_VAD_THRESHOLD` config key, a third GLib-chained handler on `model_row` that clears the live caption line on every selection change (addresses the "stale italics on Zipformer → Parakeet swap" bug)
+- `crates/sdr-ui/src/window.rs` — `connect_transcript_panel` now takes `&Arc<ConfigManager>` so the sherpa reload handler can defer `KEY_SHERPA_MODEL` persistence until `InitEvent::Ready` fires (prevents failed reloads from wedging next startup); extended `unlock_transcription_session_rows` helper with the new `vad_threshold_row`; distinguishes user-stop from spontaneous backend death in the session timeout's Disconnect arm (via `enable_row.is_active()`); defensive `model.supports_partials()` check in the `TranscriptionEvent::Partial` handler
+- `src/main.rs` — reads the persisted sherpa model from config before calling `init_sherpa_host` instead of hardcoding `StreamingZipformerEn` (was a latent bug from PR 5 — UI showed saved selection but host was always Zipformer)
+- `Cargo.toml` — adds `serde_json` as a workspace dependency on the root binary so `main.rs` can access `ConfigManager::load` with a defaults value
+
+### New artifact files also committed
+
+- `docs/superpowers/specs/2026-04-13-parakeet-integration-design.md` — design spec (this plan's companion)
+- `docs/superpowers/plans/2026-04-13-parakeet-integration.md` — this file
+
+### Follow-up issues filed during the PR
+
+- **#262** — Add sherpa-onnx CUDA provider support for large offline models
+- **#263** — Auto-tune Silero VAD threshold per demod type
+- **#264** — Bookmark doesn't persist auto-squelch state (unrelated pre-existing bug found during testing)
+- **#265** — Squelch-gate the transcription audio feed (skip noise floor + flush VAD on close)
 
 ---
 

--- a/docs/superpowers/specs/2026-04-13-parakeet-integration-design.md
+++ b/docs/superpowers/specs/2026-04-13-parakeet-integration-design.md
@@ -1,0 +1,253 @@
+# Parakeet-TDT Integration Design
+
+**Status:** Design approved 2026-04-13
+**Tracking:** #223 (parent: #204 — sherpa-onnx integration epic)
+**Branch:** `feature/parakeet-integration`
+
+## Goal
+
+Add NVIDIA Parakeet-TDT-0.6b-v3 as a fourth selectable `SherpaModel` variant. Parakeet is the current top-of-leaderboard ASR model on OpenASR, with 600M parameters and very high accuracy on noisy/spontaneous speech — exactly the radio-chatter use case `sdr-rs` exists for. Users with hardware budget for a 600MB bundle and a chunky decode pass get the best accuracy available; everyone else stays on Zipformer or Moonshine.
+
+## Critical correction to PR 5's memory
+
+Yesterday's `project_current_state.md` claimed Parakeet would slot into the existing `OnlineTransducer` streaming path because Parakeet is "RNNT family". **That was wrong.** sherpa-onnx 1.12 only supports Parakeet through the `OfflineRecognizer` API, not `OnlineRecognizer`. Confirmed by reading `~/.cargo/registry/.../sherpa-onnx-1.12.36/src/offline_asr.rs` — the upstream example `rust-api-examples/examples/nemo_parakeet.rs` uses `OfflineRecognizerConfig` with `OfflineTransducerModelConfig` and `model_type = "nemo_transducer"`.
+
+This means Parakeet slots into the **offline** path PR 5 built (VAD-driven batch decode via `OfflineRecognizer`), not the streaming path. Same UX as Moonshine: offline → no partials → Display mode toggle hides automatically.
+
+## Bundle target
+
+- **Archive**: `sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2` from the k2-fsa releases page (~600MB)
+- **Inner directory**: `sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8`
+- **Files**: standard 4-file transducer layout
+  - `encoder.int8.onnx`
+  - `decoder.int8.onnx`
+  - `joiner.int8.onnx`
+  - `tokens.txt`
+- **Note: v3, not v2.** Issue #223 mentions v2; current k2-fsa releases are on v3. We ship v3.
+
+## Non-goals
+
+- **Not** adding sherpa-onnx CUDA provider support. Parakeet on CPU at 600M params will be noticeably slower than Moonshine Base — acceptable for users who chose accuracy over speed. CUDA support is a follow-up issue (filed before merge).
+- **Not** adding Parakeet v2 (the issue body's reference). v3 is current; we don't want to maintain two versions.
+- **Not** generalizing `ModelKind` further than necessary. Three variants (`OnlineTransducer`, `OfflineMoonshine`, `OfflineNemoTransducer`) is the minimum for PR 6; future families add new variants as needed.
+- **Not** new UI affordances. Parakeet uses the same dropdown, the same status label, the same runtime reload path that PR 5 shipped. Zero UI code changes.
+
+## Architecture
+
+### Data type changes
+
+**`SherpaModel` adds one variant:**
+
+```rust
+pub enum SherpaModel {
+    StreamingZipformerEn,    // existing
+    MoonshineTinyEn,         // existing
+    MoonshineBaseEn,         // existing
+    ParakeetTdt06bV3En,      // NEW
+}
+```
+
+**`ModelKind` adds one variant:**
+
+```rust
+pub enum ModelKind {
+    OnlineTransducer,        // Zipformer
+    OfflineMoonshine,        // Moonshine v1
+    OfflineNemoTransducer,   // NEW — Parakeet (and any future NeMo transducer)
+}
+```
+
+**`ModelFilePaths::Transducer` is reused** — both Zipformer (online) and Parakeet (offline) ship 4 transducer files with the same struct shape (`encoder/decoder/joiner/tokens`). The `ModelKind` discriminant tells the host which recognizer API to feed them into; the `ModelFilePaths` variant only describes the file layout. No new `ModelFilePaths` variant.
+
+**`SherpaModel::ALL` extends to 4 entries** in dropdown order:
+
+```rust
+pub const ALL: &[Self] = &[
+    Self::StreamingZipformerEn,
+    Self::MoonshineTinyEn,
+    Self::MoonshineBaseEn,
+    Self::ParakeetTdt06bV3En,
+];
+```
+
+### Method extensions
+
+All match arms in `impl SherpaModel` get a Parakeet branch:
+
+- `label()` → `"Parakeet TDT 0.6b v3 (English)"`
+- `dir_name()` → `"parakeet-tdt-0.6b-v3-en"`
+- `archive_filename()` → `"sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2"`
+- `archive_inner_directory()` → `"sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8"`
+- `kind()` → `ModelKind::OfflineNemoTransducer`
+- `supports_partials()` already delegates to `kind()`, returns `false` for `OfflineNemoTransducer`
+
+`model_file_paths` adds:
+
+```rust
+SherpaModel::ParakeetTdt06bV3En => ModelFilePaths::Transducer {
+    encoder: dir.join("encoder.int8.onnx"),
+    decoder: dir.join("decoder.int8.onnx"),
+    joiner: dir.join("joiner.int8.onnx"),
+    tokens: dir.join("tokens.txt"),
+},
+```
+
+`model_exists` is unchanged — it already pattern-matches on `ModelFilePaths::Transducer { encoder, decoder, joiner, tokens }` and checks all four exist.
+
+### Host init branching
+
+`backends/sherpa/host.rs::init_offline` currently hardcodes Moonshine in its Phase 3 (build OfflineRecognizer config). After PR 6 it dispatches based on `model.kind()`:
+
+```rust
+fn init_offline(model: SherpaModel, event_tx: &mpsc::Sender<InitEvent>) -> Result<RecognizerState, ()> {
+    // Phase 1: Silero VAD (unchanged — both offline kinds need it)
+    if !sherpa_model::silero_vad_exists() { /* download */ }
+
+    // Phase 2: model bundle (unchanged — generic per-model)
+    if !sherpa_model::model_exists(model) { /* download + extract */ }
+
+    // Phase 3: build OfflineRecognizer config (NEW BRANCH)
+    let _ = event_tx.send(InitEvent::CreatingRecognizer);
+    let recognizer_config = match model.kind() {
+        ModelKind::OfflineMoonshine =>
+            super::offline::build_moonshine_recognizer_config(model, "cpu"),
+        ModelKind::OfflineNemoTransducer =>
+            super::offline::build_nemo_transducer_recognizer_config(model, "cpu"),
+        ModelKind::OnlineTransducer => unreachable!("init_offline called with online model"),
+    };
+
+    let Some(recognizer) = OfflineRecognizer::create(&recognizer_config) else {
+        // existing error handling
+    };
+
+    // Phase 4: Silero VAD construction (unchanged)
+    let vad = SherpaSileroVad::new(&sherpa_model::silero_vad_path())?;
+    Ok(RecognizerState::Offline { recognizer, vad })
+}
+```
+
+### New recognizer config builder
+
+`backends/sherpa/offline.rs` gains a sibling to `build_moonshine_recognizer_config`:
+
+```rust
+/// Build the `OfflineRecognizerConfig` for a NeMo Parakeet-TDT model.
+///
+/// Uses sherpa-onnx's offline transducer config with the `nemo_transducer`
+/// model_type field, matching the upstream `rust-api-examples/examples/
+/// nemo_parakeet.rs` pattern.
+pub(super) fn build_nemo_transducer_recognizer_config(
+    model: SherpaModel,
+    provider: &str,
+) -> OfflineRecognizerConfig {
+    let ModelFilePaths::Transducer { encoder, decoder, joiner, tokens } =
+        sherpa_model::model_file_paths(model)
+    else {
+        unreachable!("nemo_transducer config called with non-Transducer layout")
+    };
+
+    let transducer = OfflineTransducerModelConfig {
+        encoder: Some(encoder.to_string_lossy().into_owned()),
+        decoder: Some(decoder.to_string_lossy().into_owned()),
+        joiner: Some(joiner.to_string_lossy().into_owned()),
+    };
+
+    let model_config = OfflineModelConfig {
+        transducer,
+        tokens: Some(tokens.to_string_lossy().into_owned()),
+        provider: Some(provider.to_owned()),
+        num_threads: SHERPA_NUM_THREADS,
+        // Required: tells sherpa-onnx to use NeMo's transducer
+        // decode loop instead of the generic transducer path.
+        // Mirrors the upstream nemo_parakeet.rs example.
+        model_type: Some("nemo_transducer".to_owned()),
+        ..OfflineModelConfig::default()
+    };
+
+    OfflineRecognizerConfig {
+        model_config,
+        ..OfflineRecognizerConfig::default()
+    }
+}
+```
+
+### Session loop is unchanged
+
+`offline.rs::run_session` already takes a `&OfflineRecognizer` and feeds it audio segments via `SherpaSileroVad`. It doesn't care which decode path the recognizer wraps internally. PR 5's offline loop is now exercising its abstraction for the first time on a second backend, exactly as designed.
+
+### What does NOT change
+
+- `streaming.rs` — Zipformer path untouched
+- `silero_vad.rs` — Silero VAD wrapper unchanged
+- `vad.rs` — `VoiceActivityDetector` trait unchanged
+- `main.rs` — splash driver unchanged (Parakeet's downloads route through the existing `InitEvent::DownloadStart { component }` flow with the new model's label)
+- `transcript_panel.rs` — UI dropdown auto-populates from `SherpaModel::ALL`; the `display_mode_row` visibility toggle from PR 5 already calls `supports_partials()` and will hide for Parakeet automatically
+- `window.rs` — runtime model reload from PR 5 already handles any new variant for free; row-lock helper from PR 5 is shared
+- All download infrastructure — `download_sherpa_archive` and `extract_sherpa_archive` are model-agnostic
+
+## UX notes
+
+1. **Same offline UX as Moonshine**: text appears per-utterance after VAD detects end-of-speech (~100-300ms latency for Moonshine, expected to be ~500ms-1.5s for Parakeet on CPU due to model size). Display mode row hidden. Live captions toggle is meaningless (offline).
+
+2. **First-run download is large**: 600MB Parakeet bundle + 2MB Silero VAD if not already cached. Splash shows component-labeled progress. Users on slow connections will wait.
+
+3. **CPU latency reality check**: Moonshine Base (61M params) was already noticeable per-utterance. Parakeet at 600M is roughly 10x bigger. Real-world latency on RTX 4080 Super (CPU only — no sherpa CUDA yet) needs to be measured during smoke test. If it's unusable, ship anyway and file the CUDA follow-up; users self-select.
+
+4. **Runtime model swap from PR 5 covers Parakeet for free**: switching to/from Parakeet works the same as switching between Zipformer and Moonshine — no restart, no special handling, the existing reload flow rebuilds the recognizer in place.
+
+## Error handling
+
+All error paths reuse PR 5's infrastructure:
+- Bundle download failure → `InitEvent::Failed` → splash shows error → user retries by switching models
+- Bundle file missing after extract → `OfflineRecognizer::create` returns None → existing error path emits `InitEvent::Failed`
+- Model creation failure (e.g., wrong file format) → existing error path
+- Mid-session backend death → existing `TranscriptionEvent::Error` arm in `connect_transcript_panel` handles teardown via `unlock_transcription_session_rows`
+
+No new error variants needed.
+
+## Testing strategy
+
+**Unit tests added in `sherpa_model.rs`**:
+- `parakeet_is_offline_nemo_transducer_kind` — `kind()` returns `OfflineNemoTransducer`
+- `parakeet_does_not_support_partials` — `supports_partials()` returns `false`
+- `parakeet_has_transducer_file_layout` — `model_file_paths` returns `ModelFilePaths::Transducer` with the four expected filenames
+- `parakeet_archive_url_is_well_formed` — URL contains `parakeet`, ends with `.tar.bz2`, starts with the k2-fsa releases prefix
+- `all_contains_four_variants` — `ALL.len() == 4` (existing test renamed/extended from `_three_`)
+
+**Build matrix (dual-build rule)**:
+- `cargo build --workspace` (Whisper CUDA default) — must compile clean
+- `cargo build --workspace --no-default-features --features sherpa-cpu` — must compile clean
+- `cargo clippy --all-targets --workspace -- -D warnings` (both flavors)
+- `cargo test --workspace` (both flavors)
+- `cargo fmt --all -- --check`
+
+**Manual smoke test (user-driven)**:
+1. **Zipformer regression** — confirm streaming captions still work exactly as PR 5 shipped
+2. **Moonshine regression** — confirm both Tiny and Base still commit per-utterance
+3. **Parakeet clean first-run** — clear `~/.local/share/sdr-rs/models/sherpa/parakeet-tdt-0.6b-v3-en/`, switch model in dropdown, watch splash show "Downloading Parakeet TDT 0.6b v3 (English)..." (and Silero VAD if not cached), then "Extracting...", then "Creating recognizer...", then ready
+4. **Parakeet decode** — feed real radio chatter, confirm utterance commits land in the text view, accuracy is noticeably better than Moonshine on a tricky sample (call signs, numbers, etc.)
+5. **Latency feel check** — note per-utterance latency on CPU, decide if the CUDA follow-up is "nice to have" or "actually blocking"
+6. **Runtime swap exercise** — switch among all four models in succession, confirm reload completes for each, no crashes
+7. **Whisper regression** — `make install CARGO_FLAGS="--release --features whisper-cuda"`, confirm whisper-cuda build still works (deferred to next-day check, near-zero risk since all changes are sherpa-gated)
+
+## Follow-up issues to file before merge
+
+**Title**: Add sherpa-onnx CUDA provider support for large offline models
+
+**Body outline**:
+- Context: PR 6 ships Parakeet-TDT-0.6b which has 600M parameters and runs on CPU only today.
+- Problem: per-utterance latency on CPU is significant for a model this size. Users with CUDA-capable GPUs (like the daily-driver RTX 4080 Super) get no benefit from their hardware.
+- Proposed change: add a `sherpa-cuda` cargo feature alongside `sherpa-cpu`. The sherpa-onnx 1.12 crate supports CUDA via its `cuda` feature flag — verify which provider string to pass (`"cuda"` likely) and update the hardcoded `"cpu"` provider in `init_online`/`init_offline` to be feature-driven.
+- Acceptance: `make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"` builds, sherpa-onnx uses CUDA execution provider, Parakeet decode latency drops to GPU-acceptable levels.
+- Caveat: must remain mutually exclusive with whisper features (the feature-mutex pattern from #249).
+- Labels: `enhancement`, `transcription`
+
+## Risks / unknowns
+
+1. **Sherpa-onnx CPU latency on a 600M model is unverified**. We're guessing it'll be 500ms-1.5s per utterance. Could be 5+ seconds on weaker CPUs. Mitigation: ship anyway, label clearly as "highest accuracy, slowest", file CUDA follow-up.
+
+2. **The `model_type = "nemo_transducer"` magic string is brittle**. If sherpa-onnx ever renames it (e.g., `"nemo_transducer_v2"`) the recognizer creation silently returns None. Mitigation: tracked by the existing `OfflineRecognizer::create returned None` error message which already points users at "check Moonshine model files" — we should generalize that message in PR 6 to mention model_type misconfigurations too.
+
+3. **Bundle filename drift**. The k2-fsa releases page sometimes renames assets between versions. We hardcode `sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2`; if upstream renames it, downloads 404. Mitigation: same as the four other models we already pin.
+
+4. **Whisper code path remains untouched** — the dual-build smoke test is the only safety net against accidental regressions. The existing CI exercises both flavors so this is fine.

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,43 @@ fn main() -> glib::ExitCode {
     #[cfg(feature = "sherpa")]
     {
         use sdr_splash::SplashController;
-        use sdr_transcription::InitEvent;
+        use sdr_transcription::{InitEvent, SherpaModel};
+
+        // Read the persisted sherpa model selection from the user's
+        // config so we initialize the recognizer they actually want.
+        // Without this, init_sherpa_host always built Zipformer and
+        // any other selection in the dropdown only took effect after
+        // the user manually round-tripped the dropdown to trigger
+        // the runtime reload from PR 5. Confusing UX — the dropdown
+        // would show e.g. Parakeet but the recognizer was Zipformer
+        // until the user clicked away and back.
+        let saved_model = {
+            let config_path = gtk4::glib::user_config_dir()
+                .join("sdr-rs")
+                .join("config.json");
+            let defaults = serde_json::json!({});
+            let mgr =
+                sdr_config::ConfigManager::load(&config_path, &defaults).unwrap_or_else(|e| {
+                    tracing::warn!(
+                        "config load failed for sherpa model selection, using default: {e}"
+                    );
+                    sdr_config::ConfigManager::in_memory(&defaults)
+                });
+            let saved_idx = mgr.read(|v| {
+                v.get("transcription_sherpa_model")
+                    .and_then(serde_json::Value::as_u64)
+                    .and_then(|idx| usize::try_from(idx).ok())
+                    .unwrap_or(0)
+            });
+            SherpaModel::ALL
+                .get(saved_idx)
+                .copied()
+                .unwrap_or(SherpaModel::StreamingZipformerEn)
+        };
+        tracing::info!(
+            ?saved_model,
+            "initializing sherpa host with persisted model"
+        );
 
         // Spawn the splash subprocess BEFORE init_sherpa_host. If the
         // model is already cached, the recognizer creation takes ~1-2
@@ -62,9 +98,7 @@ fn main() -> glib::ExitCode {
         // SplashController::try_spawn for the failure modes.
         let mut splash = SplashController::try_spawn("Initializing sherpa-onnx...");
 
-        let event_rx = sdr_transcription::init_sherpa_host(
-            sdr_transcription::SherpaModel::StreamingZipformerEn,
-        );
+        let event_rx = sdr_transcription::init_sherpa_host(saved_model);
 
         let mut current_component: &'static str = "sherpa-onnx";
         loop {


### PR DESCRIPTION
## Summary

Adds **NVIDIA Parakeet-TDT-0.6b-v3** as a fourth selectable Sherpa model — currently #1 on the OpenASR leaderboard. Slots into the offline (VAD-gated) recognizer path PR 5 built for Moonshine. Turned into a slightly bigger PR than originally planned because manual smoke testing surfaced several related bugs and a scope-creep-but-necessary VAD tuning control.

Closes #223. Part of #204 (sherpa-onnx integration epic) — this is PR 6 of the roadmap.

## Critical correction to PR 5's memory

Yesterday's notes claimed Parakeet would slot into the existing \`OnlineTransducer\` streaming path because Parakeet is \"RNNT family\". That was wrong — sherpa-onnx 1.12 only exposes Parakeet through \`OfflineRecognizer\` (verified against the upstream \`rust-api-examples/examples/nemo_parakeet.rs\` example). Parakeet shares the offline UX with Moonshine: per-utterance commits, no live captions, Display mode toggle hidden.

## What's new

- **\`SherpaModel::ParakeetTdt06bV3En\`** — fourth dropdown entry, ~600MB int8 bundle, ~600M parameters.
- **\`ModelKind::OfflineNemoTransducer\`** — third recognizer family, distinguishes Parakeet from Moonshine for config-builder dispatch.
- **\`build_nemo_transducer_recognizer_config\`** in \`backends/sherpa/offline.rs\` — wraps \`OfflineTransducerModelConfig\` with \`model_type = \"nemo_transducer\"\` per the upstream example. The magic string is extracted as \`NEMO_TRANSDUCER_MODEL_TYPE\` const (CR-feedback-driven).
- **\`init_offline\` dispatches on \`model.kind()\`** to pick the right recognizer config builder. Phase 1-2 (download VAD + model bundle) stays generic across all offline kinds.
- **\`ModelFilePaths::Transducer\` reused** — Parakeet ships the standard 4-file transducer layout (encoder/decoder/joiner/tokens), structurally identical to Zipformer. The variant is overloaded by intent; \`kind()\` discriminates the recognizer family.

## User-tunable Silero VAD threshold (added mid-PR after smoke test)

Manual smoke testing found that both Moonshine and Parakeet produced zero transcripts on noisy NFM scanner audio — Silero VAD's hardcoded 0.5 threshold was too strict. Clean WFM talk radio worked fine.

Added a **\"VAD threshold\" SpinRow** to the transcript panel:
- Range 0.10–0.90, step 0.05, default 0.50
- Subtitle: \"Lower catches quieter audio (NFM); higher is stricter (talk radio)\"
- Sherpa-only, **visible only when an offline model is selected** (inverted from the \`display_mode_row\` visibility toggle)
- Persisted via new config key \`sherpa_vad_threshold\`
- Locked during active transcription alongside the other settings rows

**Backend plumbing:** \`BackendConfig\` and \`SessionParams\` gain \`vad_threshold: f32\`. \`SherpaSileroVad\` tracks its current threshold as a struct field and exposes \`current_threshold()\`. The worker's \`StartSession\` handler checks if the held VAD's threshold matches the requested one and rebuilds the VAD (~50-100ms ONNX load) if not — only happens when the user actually changed the slider AND clicked Enable.

User-tested on NFM scanner audio at thresholds 0.25-0.30 and the difference is night and day. Issue #263 is filed to auto-tune by demod type in a future PR.

## Bug fixes surfaced by smoke testing

1. **\`main.rs\` hardcoded Zipformer** — regardless of the user's saved Sherpa model, \`init_sherpa_host\` was always called with \`StreamingZipformerEn\`. The UI dropdown showed the user's choice but the actual recognizer was Zipformer until a manual dropdown round-trip triggered PR 5's runtime reload. Now reads \`transcription_sherpa_model\` from config at startup and picks the right variant.

2. **\"Transcription stopped unexpectedly\"** fired on every normal user-stop — the session timeout's disconnect arm was treating ALL disconnects as spontaneous backend death, but Sherpa session loops only exit via audio-channel-disconnect (which IS the normal stop path). Distinguishes via \`enable_row.is_active()\`: toggle already inactive → off branch already cleaned up → no-op. Still active → real spontaneous death → full teardown + error.

3. **Stale italics on model swap** — the visibility-toggle handler hid \`display_mode_row\` when switching to a non-partials model but couldn't touch \`live_line_label\` (built later in the function, not in scope). Added a third GLib-chained handler on \`model_row\` that clears the live line on every selection change.

4. **Partial-handler defensive check** — added a \`model.supports_partials()\` check to the \`TranscriptionEvent::Partial\` handler as belt-and-suspenders. Offline session loops never emit Partial today, but if a future bug did, the UI would have happily painted italics on Parakeet. Now it won't.

## Follow-ups filed

- **#262** — Add sherpa-onnx CUDA provider support for large offline models (Parakeet on CPU is acceptable but not fast)
- **#263** — Auto-tune Silero VAD threshold per demod type (WFM clean, NFM loose, etc.) — the slider stays as the manual override
- **#264** — Bookmark doesn't persist auto-squelch state (unrelated bug found during testing)
- **#265** — Squelch-gate the transcription audio feed (skip noise floor + flush VAD on close — real optimization, out of scope for PR 6)

## Docs refresh

README and CLAUDE.md updated to reflect PR 4-6 state:
- Transcription section rewritten to cover both backends side-by-side (Whisper vs Sherpa-onnx, all 4 Sherpa models)
- Architecture: 15 → 17 crates (added the missing \`sdr-core\`, \`sdr-splash\`, \`sdr-splash-gtk\`, \`sdr-radioreference\`, \`sdr-transcription\`)
- Dependencies split into \"always required\" vs \"Whisper only\" — Sherpa builds don't need cmake/g++/clang
- Fixed a stale claim that RTL-SDR support was \"pure Rust with no C library needed\" (it's \`rusb\`, a libusb wrapper)
- New CLAUDE.md section on the transcription backend feature mutex + dual-build testing rule

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` (Whisper)
- [x] \`cargo clippy --all-targets --workspace --no-default-features --features sherpa-cpu -- -D warnings\` (Sherpa)
- [x] \`cargo test --workspace\` (both flavors, 42 tests pass on sherpa-cpu)
- [x] Manual: Zipformer regression (live captions still stream)
- [x] Manual: Moonshine Tiny + Base regression (per-utterance commits)
- [x] Manual: Parakeet clean first-run via runtime model swap (~600MB download + VAD download if not cached)
- [x] Manual: Parakeet decode on real talk radio (accurate, slower than Moonshine on CPU — confirms #262 matters)
- [x] Manual: Runtime swap stress test across all four models
- [x] Manual: VAD threshold slider at 0.25-0.30 unblocks NFM transcription (both Moonshine and Parakeet)
- [x] Manual: Stop button doesn't produce spurious \"stopped unexpectedly\" error
- [x] Manual: First launch with persisted Parakeet selection actually initializes Parakeet (not silently Zipformer)
- [x] Manual (whisper-cuda): deferred to next-day regression check — near-zero risk since all changes are \`#[cfg(feature = \"sherpa\")]\`-gated except the two main.rs / BackendConfig plumbing tweaks which were verified to build cleanly in both flavors

## RAM footprint

~1.1 GB total process RSS with Parakeet loaded. Steady across runtime model swaps — no leaks in the VAD rebuild or recognizer swap paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Silero VAD threshold slider for offline transcription (live tuning & persisted).
  * Added Parakeet offline transducer model and runtime model switching without rebuild.
  * Auto-squelch with dynamic noise-floor tracking.

* **Behavior Changes**
  * Sherpa model selection is persisted only after a successful init; Whisper persistence unchanged.
  * Transcription backends documented as mutually exclusive build-time choices.
  * UI shows VAD controls only for offline models; live captioning tightened.

* **Documentation**
  * Expanded architecture, workspace, build/install, and transcription backend guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->