### PR TITLE
feat(transcription): add sherpa-cuda feature with sideloaded CUDA 12 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,45 @@ jobs:
 
       - name: cargo-audit
         run: cargo audit
+
+  sherpa-check:
+    name: Sherpa backends check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+        with:
+          # Share cache between sherpa-cpu and sherpa-cuda runs, but keep
+          # it separate from the main `check` job's cache because the
+          # sherpa-onnx sys crate downloads a different prebuilt archive
+          # under each link mode.
+          key: sherpa-backends
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config cmake \
+            libgtk-4-dev libadwaita-1-dev libusb-1.0-0-dev \
+            libpipewire-0.3-dev libclang-dev libdbus-1-dev
+
+      # `cargo check` does not invoke the linker, so the CUDA variant
+      # works on a runner without CUDA/cuDNN installed. The build.rs
+      # download of the 235 MB CUDA prebuilt archive still runs on the
+      # first cold cache and is the main cost of this job.
+
+      - name: cargo check (sherpa-cpu)
+        run: cargo check --workspace --locked --no-default-features --features sherpa-cpu
+
+      - name: cargo check (sherpa-cuda)
+        run: cargo check --workspace --locked --no-default-features --features sherpa-cuda
+
+      - name: Install cargo-deny
+        run: cargo install --locked cargo-deny
+
+      # The default `check` job runs deny under the whisper-cpu feature
+      # graph, which doesn't see the sherpa-onnx git source. Re-run deny
+      # here under the sherpa-cuda graph so the fork allowlist entry in
+      # deny.toml is actually exercised by CI.
+      - name: cargo-deny (sherpa-cuda graph)
+        run: cargo deny --no-default-features --features sherpa-cuda check sources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,22 +29,25 @@ sdr (binary)        → Entry point (depends on: ui, core, splash, transcription
 
 ## Transcription backend feature mutex
 
-**Whisper and Sherpa-onnx are mutually exclusive cargo features.** The `sdr-transcription` crate has `compile_error!` guards enforcing exactly one. This was a PR 2-era workaround for a heap corruption between whisper-rs's libstdc++ state and ONNX Runtime's `ParseSemVerVersion` regex constructors that only manifests when both C++ dep trees are in the same binary.
+**Whisper and Sherpa-onnx are mutually exclusive cargo features**, and within Sherpa, `sherpa-cpu` and `sherpa-cuda` are also mutually exclusive. The `sdr-transcription` crate has `compile_error!` guards enforcing exactly one. This was originally a PR 2-era workaround for a heap corruption between whisper-rs's libstdc++ state and ONNX Runtime's `ParseSemVerVersion` regex constructors that only manifests when both C++ dep trees are in the same binary; the sherpa-cpu/sherpa-cuda split additionally reflects that the sys crate's CUDA feature rebuilds against a different upstream prebuilt archive.
 
 **Build flavors:**
 
 ```bash
-# Whisper (default) — multilingual, mature GPU acceleration
-make install CARGO_FLAGS="--release"                                # Whisper CPU
+# Whisper — multilingual, mature GPU acceleration
+make install CARGO_FLAGS="--release"                                # Whisper CPU (default)
 make install CARGO_FLAGS="--release --features whisper-cuda"        # User's daily driver (RTX 4080 Super)
 make install CARGO_FLAGS="--release --features whisper-hipblas"     # AMD ROCm
 make install CARGO_FLAGS="--release --features whisper-vulkan"      # Cross-vendor GPU
 
-# Sherpa-onnx — Zipformer / Moonshine / Parakeet, English-only, CPU today
-make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"
+# Sherpa-onnx — Zipformer / Moonshine / Parakeet, English-only
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"   # Sherpa CPU
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"  # Sherpa + NVIDIA GPU
 ```
 
-**Dual-build testing rule:** any change to `sdr-transcription` or its callers MUST be tested with BOTH `whisper-cuda` AND `sherpa-cpu` builds sequentially. The cfg gates make it easy to break one without noticing. CI runs both flavors.
+**`sherpa-cuda` requires CUDA 12.x + cuDNN 9.x installed system-wide** (onnxruntime dlopens `libcudnn.so.9` / `libcublas.so.12` at startup). Linux x86_64 only. The first build downloads a ~235 MB CUDA prebuilt archive from k2-fsa releases. During the PR window the sherpa-onnx dep is pinned to the [jasonherald/sherpa-onnx](https://github.com/jasonherald/sherpa-onnx) fork on branch `feat/rust-sys-cuda-support`; swap back to a crates.io version pin once the upstream PR merges and releases.
+
+**Triple-build testing rule:** any change to `sdr-transcription` or its callers MUST be tested with `whisper-cuda`, `sherpa-cpu`, AND `sherpa-cuda` builds sequentially before pushing. The cfg gates make it easy to break one without noticing. CI runs `cargo check` on sherpa-cpu and sherpa-cuda (adding CUDA toolkit to CI runners is not worth the minutes, so whisper-cuda is user-verified locally).
 
 Runtime model selection for Sherpa builds is in-place (drop-old-recognizer-build-new) and does NOT require a restart — PR 5 architecture. The PR 2 "pre-GTK init" half of the heap-corruption workaround turned out to be unnecessary once the feature mutex was in place; only the first recognizer needs pre-GTK creation, and subsequent swaps post-GTK work fine.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,11 @@ make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"
 make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"  # Sherpa + NVIDIA GPU
 ```
 
-**`sherpa-cuda` requires CUDA 12.x + cuDNN 9.x installed system-wide** (onnxruntime dlopens `libcudnn.so.9` / `libcublas.so.12` at startup). Linux x86_64 only. The first build downloads a ~235 MB CUDA prebuilt archive from k2-fsa releases. During the PR window the sherpa-onnx dep is pinned to the [jasonherald/sherpa-onnx](https://github.com/jasonherald/sherpa-onnx) fork on branch `feat/rust-sys-cuda-support`; swap back to a crates.io version pin once the upstream PR merges and releases.
+**`sherpa-cuda` needs CUDA 12.x + cuDNN 9.x runtime libraries** because sherpa-onnx's CUDA prebuilt is pinned to onnxruntime 1.23.2 built against that toolchain. CUDA majors are not ABI-compatible, and Arch ships CUDA 13 today, so we **sideload the exact set of CUDA 12 runtime libs** NVIDIA publishes as a developer redistributable rather than requiring a parallel system install.
+
+`make install CARGO_FLAGS="... --features sherpa-cuda"` automatically runs `scripts/fetch-cuda-redist.sh`, which downloads ~1.83 GB of NVIDIA tarballs (cudart, cublas, cufft, curand, cudnn) into `$HOME/.cache/sdr-rs/cuda-redist/`, verifies SHA-256, extracts the runtime `.so` files while preserving the symlink chain, and installs them into `$(BINDIR)/sdr-rs-libs/` alongside the binary. The binary's `DT_RPATH` — forced to old-style via `-Wl,--disable-new-dtags` in `build.rs` so it cascades to libraries loaded via `dlopen` — resolves them at runtime.
+
+The only system-level requirement is a working NVIDIA kernel driver (`libcuda.so.1`, packaged with `nvidia`/`nvidia-utils` on Arch); everything in userspace is self-contained. Linux x86_64 only. The first build also downloads a ~235 MB sherpa-onnx CUDA prebuilt from k2-fsa. During the PR window the sherpa-onnx dep is pinned to the [jasonherald/sherpa-onnx](https://github.com/jasonherald/sherpa-onnx) fork on branch `feat/rust-sys-cuda-support`; swap back to a crates.io version pin once the upstream PR merges and releases.
 
 **Triple-build testing rule:** any change to `sdr-transcription` or its callers MUST be tested with `whisper-cuda`, `sherpa-cpu`, AND `sherpa-cuda` builds sequentially before pushing. The cfg gates make it easy to break one without noticing. CI runs `cargo check` on sherpa-cpu and sherpa-cuda (adding CUDA toolkit to CI runners is not worth the minutes, so whisper-cuda is user-verified locally).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17271ffcd5a3cce62e8dbe18924c0894fe125945c5f484d0820a75c2f21a4421"
+checksum = "401b600a9795c46ff45890146968b712c96ce4e9393798804133e137bd81d89c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02856b71413e175be50eff37fe0aefa53e227054ee3d96196faee8a0823cac80"
+checksum = "a1b7df55594e0e787d1560e23f7e12d7360d0b22e7b7c228ec2488b9e59b1b6b"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -826,15 +826,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -969,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1010,9 +1009,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1070,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libdbus-sys"
@@ -1431,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -1577,9 +1576,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1761,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -1786,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2126,8 +2125,7 @@ dependencies = [
 [[package]]
 name = "sherpa-onnx"
 version = "1.12.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69ec9bc7c245dc7b976e7662c8529b32236efb04ab9d53427af2c4b8393b0da"
+source = "git+https://github.com/jasonherald/sherpa-onnx.git?rev=628c333f9851101e9d2c228a49833f21337ebf06#628c333f9851101e9d2c228a49833f21337ebf06"
 dependencies = [
  "serde",
  "serde_json",
@@ -2137,8 +2135,7 @@ dependencies = [
 [[package]]
 name = "sherpa-onnx-sys"
 version = "1.12.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78e254a3030040d015edcdc4adfa1ea4714d3284dba0034f120feccbbde4aff"
+source = "git+https://github.com/jasonherald/sherpa-onnx.git?rev=628c333f9851101e9d2c228a49833f21337ebf06#628c333f9851101e9d2c228a49833f21337ebf06"
 dependencies = [
  "bzip2",
  "tar",
@@ -2631,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2644,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2654,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2664,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2677,18 +2674,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,11 @@ whisper-metal = ["whisper", "gtk-frontend", "sdr-transcription/whisper-metal", "
 whisper-intel-sycl = ["whisper", "gtk-frontend", "sdr-transcription/whisper-intel-sycl", "sdr-ui?/whisper-intel-sycl"]
 whisper-openblas = ["whisper", "gtk-frontend", "sdr-transcription/whisper-openblas", "sdr-ui?/whisper-openblas"]
 
-# Sherpa backend (CPU only for now — GPU support tracked separately):
+# Sherpa backend — pick exactly one link mode:
+#   sherpa-cpu  — CPU static link
+#   sherpa-cuda — NVIDIA GPU via CUDA 12.x + cuDNN 9.x shared link (linux-x86_64 only)
 sherpa-cpu = ["sherpa", "gtk-frontend", "sdr-transcription/sherpa-cpu", "sdr-ui?/sherpa-cpu"]
+sherpa-cuda = ["sherpa", "gtk-frontend", "sdr-transcription/sherpa-cuda", "sdr-ui?/sherpa-cuda"]
 
 # GTK frontend stack — Linux only. The `sdr` binary on non-Linux targets
 # falls back to a stub `main()` (see src/main.rs) that prints a message
@@ -148,8 +151,18 @@ keyring = { version = "3", features = ["sync-secret-service"] }
 # Whisper speech-to-text
 whisper-rs = "0.16"
 
-# Sherpa-onnx streaming ASR
-sherpa-onnx = "1.12"
+# Sherpa-onnx streaming ASR.
+#
+# Pinned to jasonherald/sherpa-onnx fork while the `cuda` feature awaits
+# upstream merge in k2-fsa/sherpa-onnx. The fork adds a `cuda` cargo
+# feature that links against the CUDA 12.x + cuDNN 9.x prebuilt archive;
+# everything else is upstream v1.12.36. Switch back to a crates.io
+# version pin once the upstream PR is merged and released.
+#
+# `default-features = false` means the downstream feature set (sherpa-cpu
+# or sherpa-cuda in sdr-transcription) is responsible for picking a link
+# mode (static, shared, or cuda). See crates/sdr-transcription/Cargo.toml.
+sherpa-onnx = { git = "https://github.com/jasonherald/sherpa-onnx.git", rev = "628c333f9851101e9d2c228a49833f21337ebf06", default-features = false }
 
 # System directories / libc
 dirs-next = "2"

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ DESKTOPDIR  ?= $(DATADIR)/applications
 CARGO       ?= cargo
 CARGO_FLAGS ?= --release
 
-.PHONY: all build install install-bin install-icon install-desktop \
-        uninstall test clippy fmt fmt-check lint deny audit scan clean help
+.PHONY: all build install install-bin install-sherpa-runtime-libs \
+        install-icon install-desktop uninstall test clippy fmt fmt-check \
+        lint deny audit scan clean help
 
 # ─────────────────────────────────────────────────────────────────────
 # Default
@@ -44,7 +45,7 @@ build:
 # Install
 # ─────────────────────────────────────────────────────────────────────
 
-install: build install-bin install-icon install-desktop
+install: build install-bin install-sherpa-runtime-libs install-icon install-desktop
 	@echo ""
 	@echo "SDR-RS installed successfully!"
 	@echo "  Binary:   $(BINDIR)/sdr-rs"
@@ -57,6 +58,28 @@ install: build install-bin install-icon install-desktop
 install-bin:
 	@mkdir -p $(BINDIR)
 	install -m 755 target/release/sdr $(BINDIR)/sdr-rs
+
+# When a sherpa-cuda build is active, sherpa-onnx is linked as a shared
+# library (the CUDA prebuilt doesn't ship a static archive). The sys
+# crate drops the runtime .so files next to the binary in target/release/
+# at build time, and the binary crate's build.rs injects -rpath=$$ORIGIN
+# so the dynamic loader finds them relative to the installed binary.
+# This target copies those .so files into BINDIR alongside the binary;
+# it's a no-op for static-linked builds (sherpa-cpu, whisper-*) because
+# the glob matches nothing.
+install-sherpa-runtime-libs:
+	@mkdir -p $(BINDIR)
+	@for so in target/release/libsherpa-onnx-c-api.so \
+	           target/release/libsherpa-onnx-cxx-api.so \
+	           target/release/libonnxruntime.so \
+	           target/release/libonnxruntime_providers_cuda.so \
+	           target/release/libonnxruntime_providers_shared.so \
+	           target/release/libonnxruntime_providers_tensorrt.so; do \
+		if [ -f "$$so" ]; then \
+			install -m 644 "$$so" $(BINDIR)/; \
+			echo "  installed $$(basename $$so)"; \
+		fi; \
+	done
 
 install-icon:
 	@mkdir -p $(ICONDIR)
@@ -79,6 +102,12 @@ install-desktop:
 
 uninstall:
 	rm -f $(BINDIR)/sdr-rs
+	rm -f $(BINDIR)/libsherpa-onnx-c-api.so
+	rm -f $(BINDIR)/libsherpa-onnx-cxx-api.so
+	rm -f $(BINDIR)/libonnxruntime.so
+	rm -f $(BINDIR)/libonnxruntime_providers_cuda.so
+	rm -f $(BINDIR)/libonnxruntime_providers_shared.so
+	rm -f $(BINDIR)/libonnxruntime_providers_tensorrt.so
 	rm -f $(ICONDIR)/com.sdr.rs.svg
 	rm -f $(DESKTOPDIR)/com.sdr.rs.desktop
 	@update-desktop-database $(DESKTOPDIR) 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,30 @@ CUDA_REDIST_SENTINEL  := $(CUDA_REDIST_CACHE)/.sentinel-v1
         fetch-cuda-redist test clippy fmt fmt-check \
         lint deny audit scan clean help
 
-# Conditionally chain the NVIDIA redist fetch into the install flow
-# when the user asked for a sherpa-cuda build. `findstring` returns
-# the matched substring on hit, empty on miss, so `ifneq (,...)` is
-# "if the flag is present". Whisper and sherpa-cpu builds skip the
-# download path entirely and never touch the ~1.8 GB cache.
+# Runtime library copy targets are conditionally chained into `install`
+# only when the user asked for a sherpa-cuda build. This is important
+# because cargo does NOT clean `target/release/*.so*` or the persistent
+# NVIDIA redist staging cache when switching feature sets — so if a
+# user built with sherpa-cuda once, then later ran
 #
-# The dep is added to `install-cuda-redist-libs` (not to `install`
-# directly) so that the fetch is guaranteed to happen BEFORE the copy
-# from staging into $(LIBDIR). Adding it to `install` would just
-# append it to the existing prereq list, running the fetch after the
-# copy — which is the bug that bit us the first time around.
+#     make install CARGO_FLAGS="--release --features whisper-cuda"
+#
+# an unconditional copy step would happily repopulate $(LIBDIR) from
+# the stale sherpa/CUDA artifacts left behind in target/release/ and
+# ~/.cache/sdr-rs/cuda-redist/staging/, producing a whisper binary
+# with a 2 GB subdirectory of dead CUDA libraries sitting next to it.
+#
+# `findstring` returns the matched substring on hit, empty on miss,
+# so `ifneq (,...)` is "if the flag is present". Whisper and
+# sherpa-cpu builds skip the runtime-lib plumbing entirely.
+INSTALL_RUNTIME_LIB_TARGETS :=
 ifneq (,$(findstring sherpa-cuda,$(CARGO_FLAGS)))
+INSTALL_RUNTIME_LIB_TARGETS += install-sherpa-runtime-libs install-cuda-redist-libs
+# Chain the fetch dep onto install-cuda-redist-libs (NOT onto `install`
+# directly) so the fetch runs BEFORE the copy from staging into
+# $(LIBDIR). Adding it to `install` would just append it to the
+# existing prereq list and run the fetch after the copy — which is
+# the bug that bit us the first time around.
 install-cuda-redist-libs: fetch-cuda-redist
 endif
 
@@ -70,7 +82,7 @@ build:
 # Install
 # ─────────────────────────────────────────────────────────────────────
 
-install: build install-bin install-sherpa-runtime-libs install-cuda-redist-libs install-icon install-desktop
+install: build install-bin $(INSTALL_RUNTIME_LIB_TARGETS) install-icon install-desktop
 	@echo ""
 	@echo "SDR-RS installed successfully!"
 	@echo "  Binary:   $(BINDIR)/sdr-rs"

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,40 @@
 # Makefile for building, installing, and managing
 
 BINDIR      ?= $(HOME)/.cargo/bin
+LIBDIR      ?= $(BINDIR)/sdr-rs-libs
 DATADIR     ?= $(HOME)/.local/share
 ICONDIR     ?= $(DATADIR)/icons/hicolor/scalable/apps
 DESKTOPDIR  ?= $(DATADIR)/applications
 CARGO       ?= cargo
 CARGO_FLAGS ?= --release
 
+# Persistent cache for downloaded NVIDIA CUDA 12 redistributables
+# (see the `fetch-cuda-redist` target). Sits outside the cargo target
+# dir on purpose so `cargo clean` doesn't nuke ~1.8 GB of blobs.
+CUDA_REDIST_CACHE     ?= $(HOME)/.cache/sdr-rs/cuda-redist
+CUDA_REDIST_DOWNLOADS := $(CUDA_REDIST_CACHE)/downloads
+CUDA_REDIST_STAGING   := $(CUDA_REDIST_CACHE)/staging
+CUDA_REDIST_SENTINEL  := $(CUDA_REDIST_CACHE)/.sentinel-v1
+
 .PHONY: all build install install-bin install-sherpa-runtime-libs \
-        install-icon install-desktop uninstall test clippy fmt fmt-check \
+        install-cuda-redist-libs install-icon install-desktop uninstall \
+        fetch-cuda-redist test clippy fmt fmt-check \
         lint deny audit scan clean help
+
+# Conditionally chain the NVIDIA redist fetch into the install flow
+# when the user asked for a sherpa-cuda build. `findstring` returns
+# the matched substring on hit, empty on miss, so `ifneq (,...)` is
+# "if the flag is present". Whisper and sherpa-cpu builds skip the
+# download path entirely and never touch the ~1.8 GB cache.
+#
+# The dep is added to `install-cuda-redist-libs` (not to `install`
+# directly) so that the fetch is guaranteed to happen BEFORE the copy
+# from staging into $(LIBDIR). Adding it to `install` would just
+# append it to the existing prereq list, running the fetch after the
+# copy — which is the bug that bit us the first time around.
+ifneq (,$(findstring sherpa-cuda,$(CARGO_FLAGS)))
+install-cuda-redist-libs: fetch-cuda-redist
+endif
 
 # ─────────────────────────────────────────────────────────────────────
 # Default
@@ -45,10 +70,13 @@ build:
 # Install
 # ─────────────────────────────────────────────────────────────────────
 
-install: build install-bin install-sherpa-runtime-libs install-icon install-desktop
+install: build install-bin install-sherpa-runtime-libs install-cuda-redist-libs install-icon install-desktop
 	@echo ""
 	@echo "SDR-RS installed successfully!"
 	@echo "  Binary:   $(BINDIR)/sdr-rs"
+	@if [ -d $(LIBDIR) ] && [ -n "$$(ls -A $(LIBDIR) 2>/dev/null)" ]; then \
+		echo "  Libs:     $(LIBDIR)/"; \
+	fi
 	@echo "  Icon:     $(ICONDIR)/com.sdr.rs.svg"
 	@echo "  Desktop:  $(DESKTOPDIR)/com.sdr.rs.desktop"
 	@echo ""
@@ -62,24 +90,70 @@ install-bin:
 # When a sherpa-cuda build is active, sherpa-onnx is linked as a shared
 # library (the CUDA prebuilt doesn't ship a static archive). The sys
 # crate drops the runtime .so files next to the binary in target/release/
-# at build time, and the binary crate's build.rs injects -rpath=$$ORIGIN
-# so the dynamic loader finds them relative to the installed binary.
-# This target copies those .so files into BINDIR alongside the binary;
-# it's a no-op for static-linked builds (sherpa-cpu, whisper-*) because
-# the glob matches nothing.
+# at build time, and the binary crate's build.rs injects an rpath of
+# `$ORIGIN:$ORIGIN/sdr-rs-libs` so the loader finds them either in the
+# cargo target/release layout (dev builds) or in the adjacent
+# sdr-rs-libs/ subdirectory (installed builds).
+#
+# This target copies those .so files into $(LIBDIR). It's a no-op for
+# static-linked builds (sherpa-cpu, whisper-*) because the glob matches
+# nothing.
+#
+# `libonnxruntime_providers_tensorrt.so` is deliberately excluded — it
+# needs libnvinfer/libnvonnxparser which we don't provision, and
+# onnxruntime only ever dlopens it when a consumer asks for the
+# TensorRT provider. sdr-rs only asks for "cuda", so the tensorrt
+# provider is never loaded and shipping it would be dead weight.
 install-sherpa-runtime-libs:
-	@mkdir -p $(BINDIR)
-	@for so in target/release/libsherpa-onnx-c-api.so \
-	           target/release/libsherpa-onnx-cxx-api.so \
-	           target/release/libonnxruntime.so \
-	           target/release/libonnxruntime_providers_cuda.so \
-	           target/release/libonnxruntime_providers_shared.so \
-	           target/release/libonnxruntime_providers_tensorrt.so; do \
-		if [ -f "$$so" ]; then \
-			install -m 644 "$$so" $(BINDIR)/; \
-			echo "  installed $$(basename $$so)"; \
-		fi; \
-	done
+	@if ls target/release/libsherpa-onnx-c-api.so >/dev/null 2>&1; then \
+		mkdir -p $(LIBDIR); \
+		for so in target/release/libsherpa-onnx-c-api.so \
+		          target/release/libsherpa-onnx-cxx-api.so \
+		          target/release/libonnxruntime.so \
+		          target/release/libonnxruntime_providers_cuda.so \
+		          target/release/libonnxruntime_providers_shared.so; do \
+			if [ -f "$$so" ] || [ -L "$$so" ]; then \
+				cp -a "$$so" $(LIBDIR)/; \
+				echo "  installed $$(basename $$so)"; \
+			fi; \
+		done; \
+	fi
+
+# Copy NVIDIA CUDA 12 runtime libs from the persistent cache into
+# $(LIBDIR). The cache is populated by `fetch-cuda-redist`, which the
+# `install` target pulls in automatically when `sherpa-cuda` is in
+# CARGO_FLAGS. No-op for non-cuda builds because the staging dir
+# doesn't exist.
+#
+# `cp -a` (not `install -m 644`!) is required here to preserve the
+# symlink chain from the staging dir. The libraries form sonames like
+# `libfoo.so -> libfoo.so.12 -> libfoo.so.12.6.4.1`; the loader looks
+# up NEEDED entries against the middle link, and a plain `install`
+# dereferences the symlinks and produces three identical full-size
+# copies with different names, wasting gigabytes and breaking the
+# soname resolution.
+install-cuda-redist-libs:
+	@if [ -d $(CUDA_REDIST_STAGING) ] && [ -n "$$(ls -A $(CUDA_REDIST_STAGING) 2>/dev/null)" ]; then \
+		mkdir -p $(LIBDIR); \
+		cp -a $(CUDA_REDIST_STAGING)/. $(LIBDIR)/; \
+		echo "  installed $$(find $(CUDA_REDIST_STAGING) -maxdepth 1 \( -type f -o -type l \) -name 'lib*.so*' | wc -l) files from NVIDIA redist cache"; \
+	fi
+
+# Download and stage NVIDIA CUDA 12 + cuDNN 9 runtime libraries so
+# that a `sherpa-cuda` build runs on hosts that do not have CUDA 12
+# installed system-wide (notably Arch Linux, which ships CUDA 13).
+# The actual download/verify/extract logic lives in
+# `scripts/fetch-cuda-redist.sh` — see its header for the full
+# rationale and the list of libraries we pull. A sentinel file at
+# $(CUDA_REDIST_SENTINEL) short-circuits the target once the cache is
+# fully populated, so subsequent `make install` runs are instant.
+fetch-cuda-redist: $(CUDA_REDIST_SENTINEL)
+
+$(CUDA_REDIST_SENTINEL):
+	@./scripts/fetch-cuda-redist.sh \
+	    $(CUDA_REDIST_DOWNLOADS) \
+	    $(CUDA_REDIST_STAGING) \
+	    $(CUDA_REDIST_SENTINEL)
 
 install-icon:
 	@mkdir -p $(ICONDIR)
@@ -102,16 +176,13 @@ install-desktop:
 
 uninstall:
 	rm -f $(BINDIR)/sdr-rs
-	rm -f $(BINDIR)/libsherpa-onnx-c-api.so
-	rm -f $(BINDIR)/libsherpa-onnx-cxx-api.so
-	rm -f $(BINDIR)/libonnxruntime.so
-	rm -f $(BINDIR)/libonnxruntime_providers_cuda.so
-	rm -f $(BINDIR)/libonnxruntime_providers_shared.so
-	rm -f $(BINDIR)/libonnxruntime_providers_tensorrt.so
+	rm -rf $(LIBDIR)
 	rm -f $(ICONDIR)/com.sdr.rs.svg
 	rm -f $(DESKTOPDIR)/com.sdr.rs.desktop
 	@update-desktop-database $(DESKTOPDIR) 2>/dev/null || true
 	@echo "SDR-RS uninstalled"
+	@echo "  (NVIDIA redist cache at $(CUDA_REDIST_CACHE) preserved;"
+	@echo "   remove manually with: rm -rf $(CUDA_REDIST_CACHE))"
 
 # ─────────────────────────────────────────────────────────────────────
 # Quality

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Installs the binary, desktop entry, and icon for app launcher integration.
 
 ### Transcription backend (pick one)
 
-Whisper and Sherpa-onnx are mutually exclusive cargo features — you build with exactly one backend. Default is `whisper-cpu`. GPU builds require the corresponding toolkit (CUDA, ROCm, Vulkan SDK).
+Whisper and Sherpa-onnx are mutually exclusive cargo features — you build with exactly one backend. Default is `whisper-cpu`. **Whisper** GPU builds require the corresponding toolkit installed on the build host (CUDA, ROCm, Vulkan SDK), because `whisper-rs` compiles its own kernels at build time. **Sherpa-cuda** is different: `make install` sideloads the required CUDA 12 / cuDNN 9 runtime libraries automatically into `~/.cargo/bin/sdr-rs-libs/` and only needs the NVIDIA kernel driver present on the host — see the Sherpa CUDA notes below.
 
 ```bash
 # Whisper backend (default) — multilingual, mature GPU acceleration

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Installs the binary, desktop entry, and icon for app launcher integration.
 
 ### Transcription backend (pick one)
 
-Whisper and Sherpa-onnx are mutually exclusive cargo features — you build with exactly one backend. Default is `whisper-cpu`. Whisper GPU builds require the corresponding toolkit (CUDA, ROCm, Vulkan SDK).
+Whisper and Sherpa-onnx are mutually exclusive cargo features — you build with exactly one backend. Default is `whisper-cpu`. GPU builds require the corresponding toolkit (CUDA, ROCm, Vulkan SDK).
 
 ```bash
 # Whisper backend (default) — multilingual, mature GPU acceleration
@@ -136,11 +136,20 @@ make install CARGO_FLAGS="--release --features whisper-cuda"       # NVIDIA GPU
 make install CARGO_FLAGS="--release --features whisper-hipblas"    # AMD ROCm
 make install CARGO_FLAGS="--release --features whisper-vulkan"     # Cross-vendor GPU
 
-# Sherpa-onnx backend — Zipformer / Moonshine / Parakeet, English-only, CPU today
-make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"
+# Sherpa-onnx backend — Zipformer / Moonshine / Parakeet, English-only
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cpu"   # Sherpa CPU
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"  # Sherpa + NVIDIA GPU
 ```
 
 With a Sherpa build, you pick the specific model (Zipformer, Moonshine Tiny/Base, or Parakeet) at runtime from the transcript panel dropdown — no rebuild required, and switching is an in-place recognizer swap.
+
+**Sherpa CUDA notes:**
+
+- `sherpa-cuda` is currently linux-x86_64 only. The first build downloads a ~235 MB CUDA prebuilt archive from the k2-fsa releases page.
+- Requires CUDA 12.x and cuDNN 9.x system libraries at runtime — onnxruntime dlopens `libcudnn.so.9`, `libcublas.so.12`, and related libraries at process startup.
+- On Arch Linux: `sudo pacman -S cuda cudnn`
+- On Ubuntu/Debian: install the NVIDIA CUDA 12 toolkit and cuDNN 9 packages from NVIDIA's repo. The Ubuntu-packaged `libcudnn9-cuda-12` is also fine.
+- During the PR stabilization window the sherpa-onnx crate is pulled from the [jasonherald/sherpa-onnx](https://github.com/jasonherald/sherpa-onnx) fork (branch `feat/rust-sys-cuda-support`), which adds a `cuda` cargo feature to the upstream sys crate. An upstream PR to k2-fsa is planned; once it merges and a release ships, the fork dependency will be swapped back to a crates.io version pin.
 
 ### Run tests
 

--- a/README.md
+++ b/README.md
@@ -145,10 +145,11 @@ With a Sherpa build, you pick the specific model (Zipformer, Moonshine Tiny/Base
 
 **Sherpa CUDA notes:**
 
-- `sherpa-cuda` is currently linux-x86_64 only. The first build downloads a ~235 MB CUDA prebuilt archive from the k2-fsa releases page.
-- Requires CUDA 12.x and cuDNN 9.x system libraries at runtime — onnxruntime dlopens `libcudnn.so.9`, `libcublas.so.12`, and related libraries at process startup.
-- On Arch Linux: `sudo pacman -S cuda cudnn`
-- On Ubuntu/Debian: install the NVIDIA CUDA 12 toolkit and cuDNN 9 packages from NVIDIA's repo. The Ubuntu-packaged `libcudnn9-cuda-12` is also fine.
+- `sherpa-cuda` is currently linux-x86_64 only. It builds against the k2-fsa sherpa-onnx prebuilt, which is hard-pinned to an internal onnxruntime 1.23.2 build compiled against CUDA 12.x + cuDNN 9.x. CUDA major versions are not ABI-compatible, so hosts running CUDA 13 (e.g. current Arch Linux) cannot use their system libraries.
+- **You do NOT need to install CUDA 12 or cuDNN 9 on your system.** `make install` with the `sherpa-cuda` feature automatically downloads the minimum set of NVIDIA CUDA 12 runtime libraries (cudart, cublas, cufft, curand, cudnn) from NVIDIA's developer redist server and packages them alongside the binary. Your system CUDA install — if any — is untouched.
+- **First-build cost:** ~1.83 GB download, ~1.2 GB extracted. Downloads are cached in `$HOME/.cache/sdr-rs/cuda-redist/` (survives `cargo clean`); re-installs are instant. Plus the one-time ~235 MB sherpa-onnx CUDA prebuilt from k2-fsa under `target/sherpa-onnx-prebuilt/`.
+- **Install layout:** the binary lives at `~/.cargo/bin/sdr-rs`; the runtime libraries live in an adjacent `~/.cargo/bin/sdr-rs-libs/` subdirectory so they don't clutter `$BINDIR`. The binary's ELF `DT_RPATH` resolves them automatically. Nothing is installed system-wide.
+- You still need a working NVIDIA driver installed (`nvidia` / `nvidia-utils` on Arch) — the userspace driver library `libcuda.so.1` comes from the kernel driver package and cannot be redistributed, and it must match your installed GPU hardware.
 - During the PR stabilization window the sherpa-onnx crate is pulled from the [jasonherald/sherpa-onnx](https://github.com/jasonherald/sherpa-onnx) fork (branch `feat/rust-sys-cuda-support`), which adds a `cuda` cargo feature to the upstream sys crate. An upstream PR to k2-fsa is planned; once it merges and a release ships, the fork dependency will be swapped back to a crates.io version pin.
 
 ### Run tests

--- a/build.rs
+++ b/build.rs
@@ -30,9 +30,20 @@
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_SHERPA_CUDA");
 
-    #[cfg(all(feature = "sherpa-cuda", target_os = "linux"))]
-    {
+    // Read build *target* state from cargo env vars rather than
+    // `#[cfg(target_os = ...)]` / `#[cfg(feature = ...)]`. The `cfg`
+    // form would reflect the HOST that's running `build.rs`, not the
+    // architecture we're compiling for — wrong for any future
+    // cross-compilation setup. CARGO_CFG_TARGET_OS and
+    // CARGO_FEATURE_* are the canonical cargo-provided values for
+    // the build-target state.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let sherpa_cuda = std::env::var_os("CARGO_FEATURE_SHERPA_CUDA").is_some();
+
+    if sherpa_cuda && target_os == "linux" {
         // `$ORIGIN` must reach `ld` as a literal dollar sign; cargo
         // passes `rustc-link-arg` values straight through without
         // shell expansion, so we escape nothing here.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,34 @@
+// Workspace root binary build script.
+//
+// The only job here is to make `sherpa-cuda` builds actually runnable
+// after `make install`. The `sherpa-onnx-sys` build script tries to
+// emit `-Wl,-rpath,$ORIGIN` on its own, but `cargo:rustc-link-arg`
+// only affects the link step of the crate that emits it — and the sys
+// crate builds an rlib, so the link arg never reaches the final
+// binary. Without an rpath hint the dynamic loader has no way to find
+// the sherpa-onnx / onnxruntime shared libraries sitting next to the
+// installed binary, and you get:
+//
+//     error while loading shared libraries: libsherpa-onnx-c-api.so:
+//     cannot open shared object file: No such file or directory
+//
+// The fix is to have the BINARY crate (this one) inject the rpath at
+// its own link step. `$ORIGIN` is resolved by the loader to the
+// directory of the running executable, so as long as the `.so` files
+// are copied alongside the installed binary (see the `install` target
+// in Makefile for the sherpa-cuda branch), everything Just Works.
+//
+// This is feature-gated so static-linked builds (`sherpa-cpu`,
+// `whisper-*`) get no extra link args — they don't need an rpath
+// because all the C++ code is linked into the binary directly.
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    #[cfg(all(feature = "sherpa-cuda", target_os = "linux"))]
+    {
+        // `\$ORIGIN` must reach ld as a literal dollar sign; cargo
+        // passes the value straight through, so we escape nothing here.
+        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -15,8 +15,14 @@
 // The fix is to have the BINARY crate (this one) inject the rpath at
 // its own link step. `$ORIGIN` is resolved by the loader to the
 // directory of the running executable, so as long as the `.so` files
-// are copied alongside the installed binary (see the `install` target
-// in Makefile for the sherpa-cuda branch), everything Just Works.
+// live either next to the binary (the cargo target/release layout
+// that `cargo run` uses) or in an adjacent `sdr-rs-libs/` subdirectory
+// (the `make install` layout that keeps `~/.cargo/bin/` uncluttered),
+// everything Just Works.
+//
+// Multi-entry rpath with `:` separator is standard ELF semantics. The
+// loader walks entries left to right; the first one catches cargo run
+// builds, the second one catches installed builds.
 //
 // This is feature-gated so static-linked builds (`sherpa-cpu`,
 // `whisper-*`) get no extra link args — they don't need an rpath
@@ -27,8 +33,33 @@ fn main() {
 
     #[cfg(all(feature = "sherpa-cuda", target_os = "linux"))]
     {
-        // `\$ORIGIN` must reach ld as a literal dollar sign; cargo
-        // passes the value straight through, so we escape nothing here.
-        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+        // `$ORIGIN` must reach `ld` as a literal dollar sign; cargo
+        // passes `rustc-link-arg` values straight through without
+        // shell expansion, so we escape nothing here.
+        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN:$ORIGIN/sdr-rs-libs");
+
+        // Use the old-style DT_RPATH tag instead of the modern
+        // DT_RUNPATH. This matters because onnxruntime calls
+        // `dlopen("libonnxruntime_providers_cuda.so")` at recognizer
+        // creation time, and the provider .so's own NEEDED entries
+        // (libcublasLt.so.12, libcudnn.so.9, etc.) then have to be
+        // resolved by the dynamic loader.
+        //
+        // DT_RUNPATH (the default modern tag) is ONLY consulted when
+        // resolving the direct NEEDED deps of the ELF object that
+        // declares it; it does not cascade to libraries opened via
+        // dlopen or to their transitive NEEDED entries. DT_RPATH on
+        // the executable, by contrast, IS consulted for every library
+        // load regardless of how it was triggered, which is exactly
+        // the behavior we want: sdr-rs-libs/ contains both the
+        // directly-linked sherpa+onnxruntime libs and the CUDA
+        // runtime libs that onnxruntime's dlopen'd providers need,
+        // and we want a single rpath entry to cover both.
+        //
+        // `--disable-new-dtags` is widely supported on GNU ld and
+        // lld. DT_RPATH is deprecated for new ELF but still honored
+        // by every glibc-based loader, so the ergonomic cost of
+        // using it here is basically nil.
+        println!("cargo:rustc-link-arg=-Wl,--disable-new-dtags");
     }
 }

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -26,8 +26,17 @@ whisper-metal = ["whisper", "whisper-rs/metal"]
 whisper-intel-sycl = ["whisper", "whisper-rs/intel-sycl"]
 whisper-openblas = ["whisper", "whisper-rs/openblas"]
 
-# Sherpa backend (CPU only for now):
-sherpa-cpu = ["sherpa"]
+# Sherpa backend — pick exactly one:
+#
+#   sherpa-cpu  — CPU-only, static link against k2-fsa's CPU prebuilt
+#   sherpa-cuda — NVIDIA GPU via CUDA 12.x + cuDNN 9.x prebuilt. Downloads
+#                 a ~235MB archive on first build. Linux x86_64 only.
+#                 Requires libcudnn.so.9 / libcublas.so.12 installed
+#                 system-wide; onnxruntime dlopens them at startup.
+#
+# These are mutually exclusive (see the `compile_error!` guards in lib.rs).
+sherpa-cpu = ["sherpa", "sherpa-onnx/static"]
+sherpa-cuda = ["sherpa", "sherpa-onnx/cuda"]
 
 [dependencies]
 whisper-rs = { workspace = true, optional = true }

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -29,10 +29,15 @@ whisper-openblas = ["whisper", "whisper-rs/openblas"]
 # Sherpa backend — pick exactly one:
 #
 #   sherpa-cpu  — CPU-only, static link against k2-fsa's CPU prebuilt
-#   sherpa-cuda — NVIDIA GPU via CUDA 12.x + cuDNN 9.x prebuilt. Downloads
-#                 a ~235MB archive on first build. Linux x86_64 only.
-#                 Requires libcudnn.so.9 / libcublas.so.12 installed
-#                 system-wide; onnxruntime dlopens them at startup.
+#   sherpa-cuda — NVIDIA GPU via CUDA 12.x + cuDNN 9.x prebuilt. Linux
+#                 x86_64 only. First build downloads a ~235 MB sherpa
+#                 CUDA archive from k2-fsa plus ~1.83 GB of NVIDIA
+#                 CUDA 12 / cuDNN 9 runtime libraries — the latter are
+#                 vendored into `$(BINDIR)/sdr-rs-libs/` by
+#                 `make install`, so no parallel system-wide CUDA 12
+#                 install is required. Only the NVIDIA kernel driver
+#                 has to come from the host. See the README's Sherpa
+#                 CUDA section for the full install story.
 #
 # These are mutually exclusive (see the `compile_error!` guards in lib.rs).
 sherpa-cpu = ["sherpa", "sherpa-onnx/static"]

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -418,8 +418,13 @@ fn init_online(
     }
 
     let _ = event_tx.send(InitEvent::CreatingRecognizer);
-    let recognizer_config = super::streaming::build_recognizer_config(model, "cpu");
-    tracing::info!(?model, "creating sherpa-onnx OnlineRecognizer");
+    let recognizer_config =
+        super::streaming::build_recognizer_config(model, super::SHERPA_PROVIDER);
+    tracing::info!(
+        ?model,
+        provider = super::SHERPA_PROVIDER,
+        "creating sherpa-onnx OnlineRecognizer"
+    );
 
     let Some(recognizer) = OnlineRecognizer::create(&recognizer_config) else {
         let msg = "OnlineRecognizer::create returned None — check model file paths".to_owned();
@@ -475,10 +480,10 @@ fn init_offline(
     // failure path instead of aborting the process.
     let recognizer_config = match model.kind() {
         crate::sherpa_model::ModelKind::OfflineMoonshine => {
-            super::offline::build_moonshine_recognizer_config(model, "cpu")
+            super::offline::build_moonshine_recognizer_config(model, super::SHERPA_PROVIDER)
         }
         crate::sherpa_model::ModelKind::OfflineNemoTransducer => {
-            super::offline::build_nemo_transducer_recognizer_config(model, "cpu")
+            super::offline::build_nemo_transducer_recognizer_config(model, super::SHERPA_PROVIDER)
         }
         crate::sherpa_model::ModelKind::OnlineTransducer => {
             let msg = format!(
@@ -491,7 +496,11 @@ fn init_offline(
             return Err(());
         }
     };
-    tracing::info!(?model, "creating sherpa-onnx OfflineRecognizer");
+    tracing::info!(
+        ?model,
+        provider = super::SHERPA_PROVIDER,
+        "creating sherpa-onnx OfflineRecognizer"
+    );
 
     let Some(recognizer) = OfflineRecognizer::create(&recognizer_config) else {
         let msg = format!(

--- a/crates/sdr-transcription/src/backends/sherpa/mod.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/mod.rs
@@ -31,8 +31,10 @@ mod streaming;
 pub use host::{init_sherpa_host, reload_sherpa_host};
 pub use silero_vad::SherpaSileroVad;
 
-/// ONNX Runtime execution provider string passed to every sherpa-onnx
-/// recognizer and VAD config built by this backend.
+/// ONNX Runtime execution provider string passed to sherpa-onnx
+/// **recognizer** configs built by this backend (online streaming,
+/// offline Moonshine, offline NeMo Parakeet). The Silero VAD stays
+/// on CPU regardless — see `silero_vad.rs` for that rationale.
 ///
 /// Selected at compile time by the `sherpa-cpu` / `sherpa-cuda` cargo
 /// feature mutex (enforced in `lib.rs`). `"cuda"` is only valid when the

--- a/crates/sdr-transcription/src/backends/sherpa/mod.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/mod.rs
@@ -31,6 +31,19 @@ mod streaming;
 pub use host::{init_sherpa_host, reload_sherpa_host};
 pub use silero_vad::SherpaSileroVad;
 
+/// ONNX Runtime execution provider string passed to every sherpa-onnx
+/// recognizer and VAD config built by this backend.
+///
+/// Selected at compile time by the `sherpa-cpu` / `sherpa-cuda` cargo
+/// feature mutex (enforced in `lib.rs`). `"cuda"` is only valid when the
+/// sys crate was built against the CUDA prebuilt — otherwise onnxruntime
+/// falls back to CPU silently, which would waste a bunch of binary and
+/// disk for no benefit, so we gate it behind the dedicated feature.
+#[cfg(feature = "sherpa-cuda")]
+pub(crate) const SHERPA_PROVIDER: &str = "cuda";
+#[cfg(not(feature = "sherpa-cuda"))]
+pub(crate) const SHERPA_PROVIDER: &str = "cpu";
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
 

--- a/crates/sdr-transcription/src/backends/sherpa/silero_vad.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/silero_vad.rs
@@ -65,6 +65,11 @@ impl SherpaSileroVad {
             window_size: SILERO_WINDOW_SIZE,
         };
 
+        // Silero VAD is ~2 MB and per-chunk inference is trivial; always
+        // run it on CPU regardless of `SHERPA_PROVIDER`. Sending every
+        // 32 ms window across the PCIe bus to the GPU would cost more
+        // than the compute itself, and it avoids cross-provider
+        // onnxruntime state that we don't otherwise need.
         let vad_config = VadModelConfig {
             silero_vad: silero_config,
             sample_rate: SHERPA_SAMPLE_RATE_HZ,

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -29,6 +29,22 @@ compile_error!(
      the CUDA 12.x + cuDNN 9.x prebuilt)."
 );
 
+// `sherpa` is an internal umbrella feature activated by the two
+// user-facing link-mode features (`sherpa-cpu`, `sherpa-cuda`). If a
+// caller enables `sherpa` directly without picking a link mode, the
+// sherpa-onnx dependency would be pulled in with no link configured
+// and fail at link time with a confusing error. Catch it here with a
+// clear actionable message.
+#[cfg(all(
+    feature = "sherpa",
+    not(any(feature = "sherpa-cpu", feature = "sherpa-cuda"))
+))]
+compile_error!(
+    "the internal `sherpa` feature requires exactly one user-facing link mode. \
+     Enable either `sherpa-cpu` (CPU static link) or `sherpa-cuda` (shared link \
+     against the CUDA 12.x + cuDNN 9.x prebuilt) instead of `sherpa` directly."
+);
+
 #[cfg(not(any(feature = "whisper", feature = "sherpa")))]
 compile_error!(
     "exactly one transcription backend must be enabled. The default is \

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -17,13 +17,23 @@ compile_error!(
      Pick exactly one user-facing feature: \
      `whisper-cpu` (default), `whisper-cuda`, `whisper-hipblas`, \
      `whisper-vulkan`, `whisper-metal`, `whisper-intel-sycl`, `whisper-openblas`, \
-     or `sherpa-cpu`. For sherpa, pass `--no-default-features --features sherpa-cpu`."
+     `sherpa-cpu`, or `sherpa-cuda`. \
+     For sherpa, pass `--no-default-features --features sherpa-cpu` (or `sherpa-cuda`)."
+);
+
+#[cfg(all(feature = "sherpa-cpu", feature = "sherpa-cuda"))]
+compile_error!(
+    "the `sherpa-cpu` and `sherpa-cuda` features are mutually exclusive. \
+     Pick exactly one link mode for the sherpa-onnx prebuilt: \
+     `sherpa-cpu` (CPU static link) or `sherpa-cuda` (shared link against \
+     the CUDA 12.x + cuDNN 9.x prebuilt)."
 );
 
 #[cfg(not(any(feature = "whisper", feature = "sherpa")))]
 compile_error!(
     "exactly one transcription backend must be enabled. The default is \
-     `whisper-cpu`. For sherpa, pass `--no-default-features --features sherpa-cpu`."
+     `whisper-cpu`. For sherpa, pass `--no-default-features --features sherpa-cpu` \
+     (or `sherpa-cuda` for NVIDIA GPU acceleration)."
 );
 
 pub mod backend;

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -22,6 +22,7 @@ whisper-intel-sycl = ["whisper", "sdr-transcription/whisper-intel-sycl"]
 whisper-openblas = ["whisper", "sdr-transcription/whisper-openblas"]
 
 sherpa-cpu = ["sherpa", "sdr-transcription/sherpa-cpu"]
+sherpa-cuda = ["sherpa", "sdr-transcription/sherpa-cuda"]
 
 # sdr-ui is the GTK4 + libadwaita frontend and builds only on Linux. On other
 # platforms (macOS, Windows) the crate compiles to an empty rlib via the

--- a/deny.toml
+++ b/deny.toml
@@ -70,10 +70,25 @@ skip = []
 skip-tree = []
 
 # =============================================================================
-# Sources — only allow crates from crates.io
+# Sources — only allow crates from crates.io, plus explicitly-pinned
+# git deps that are tracked as temporary overrides in workspace
+# Cargo.toml (see the `sherpa-onnx` comment in the root Cargo.toml for
+# the re-unification plan once upstream merges).
 # =============================================================================
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = [
+    # `sherpa-onnx` is pinned to jasonherald/sherpa-onnx while the `cuda`
+    # feature awaits upstream merge into k2-fsa/sherpa-onnx. Switch back
+    # to a crates.io version pin once upstream ships a release with the
+    # cuda feature, and remove this entry at that time.
+    #
+    # This allowlist entry is only exercised by cargo-deny runs under
+    # sherpa-* feature graphs (see the sherpa-check job in ci.yml); the
+    # default `check` job uses the whisper-cpu graph and will not see
+    # this git source, so an "unmatched-source" warning there is
+    # expected and harmless.
+    "https://github.com/jasonherald/sherpa-onnx",
+]

--- a/docs/superpowers/scratch/sherpa-onnx-sys-cuda-patch.md
+++ b/docs/superpowers/scratch/sherpa-onnx-sys-cuda-patch.md
@@ -203,7 +203,7 @@ git rev of your fork:
 1. Workspace `Cargo.toml`: replace `sherpa-onnx = "1.12"` with a `git =` dep pointing at your fork + pinned rev.
 2. `crates/sdr-transcription/Cargo.toml`: add `sherpa-cuda = ["sherpa", "sherpa-onnx/cuda"]` feature alongside `sherpa-cpu`. The `sherpa-onnx/cuda` passthrough requires `sherpa-onnx`'s own `Cargo.toml` to re-export the feature (may need a micro-patch there too — TBD during implementation).
 3. `backends/sherpa/host.rs:421`, `:478`, `:481`: replace hardcoded `"cpu"` with a const that switches on `cfg(feature = "sherpa-cuda")`.
-4. `backends/sherpa/silero_vad.rs:72`: same treatment for the VAD provider string.
+4. `backends/sherpa/silero_vad.rs:72`: **no change** — Silero VAD intentionally stays on CPU even in `sherpa-cuda` builds. Per-chunk inference on a ~2 MB model is trivial, and sending every 32 ms window across the PCIe bus to the GPU would cost more than the compute itself. Keeping it pinned to `"cpu"` also avoids any cross-provider onnxruntime state we don't otherwise need.
 5. Makefile: document the new build flavor.
 6. README.md / CLAUDE.md: document the CUDA 12.x + cuDNN 9.x runtime requirement, install commands for Arch/Ubuntu.
 7. CI: add a `sherpa-cuda` build job (cargo check only — runners don't have GPUs, but the link step and archive download still get exercised).

--- a/docs/superpowers/scratch/sherpa-onnx-sys-cuda-patch.md
+++ b/docs/superpowers/scratch/sherpa-onnx-sys-cuda-patch.md
@@ -1,0 +1,209 @@
+# sherpa-onnx-sys CUDA patch (scratch)
+
+Target: `sherpa-onnx/rust/sherpa-onnx-sys/` in a fork of `k2-fsa/sherpa-onnx`.
+Version in scope: 1.12.36 (matches our workspace pin).
+
+## Scope of changes
+
+Only two files touched:
+
+1. `sherpa-onnx/rust/sherpa-onnx-sys/Cargo.toml`
+2. `sherpa-onnx/rust/sherpa-onnx-sys/build.rs`
+
+No changes to the high-level `sherpa-onnx` wrapper crate, no changes to
+bindings, no changes to C/C++ code. `provider: "cuda"` is a runtime string —
+it's already accepted by the existing Rust API. We're only teaching the
+sys crate how to link against the CUDA prebuilt instead of the CPU prebuilt.
+
+The `copy_unix_runtime_libs` helper already globs `*.so*` from the `lib/`
+directory and copies everything it finds into the target output dir. The
+CUDA archive's `libonnxruntime_providers_cuda.so`,
+`libonnxruntime_providers_shared.so`, and `libonnxruntime_providers_tensorrt.so`
+all live in that same `lib/`, so they come along for free with zero extra code.
+
+The CUDA archive extracts to `sherpa-onnx-v{version}-cuda-12.x-cudnn-9.x-linux-x64-gpu/lib/`.
+The existing `archive_stem` → `extracted_dir.join("lib")` math already handles
+this pattern (confirmed against the CPU archive layout). No path changes.
+
+---
+
+## Diff 1: `Cargo.toml`
+
+```diff
+ [features]
+ default = ["static"]
+ shared = []
+ static = []
++
++# Link against a CUDA + cuDNN prebuilt of sherpa-onnx.
++#
++# Implies `shared` — the CUDA prebuilts are only published as shared
++# libraries; there is no CUDA static archive on the k2-fsa releases page.
++# Explicit combination `static + cuda` is rejected in build.rs with a
++# clear error.
++#
++# Linux x86_64 only today. The CUDA archive on the k2-fsa releases page is
++# pinned to CUDA 12.x + cuDNN 9.x; users are responsible for having those
++# runtime libraries installed on their system (onnxruntime dlopens them).
++cuda = ["shared"]
+```
+
+Rationale for `cuda = ["shared"]`: activating cuda without activating shared
+would leave `resolve_link_mode` in the Static arm, which has no CUDA archive.
+Implying `shared` from `cuda` avoids a footgun and keeps the feature
+self-contained for downstream users.
+
+---
+
+## Diff 2: `build.rs`
+
+### Change A — `resolve_link_mode()` (around line 80)
+
+```diff
+ fn resolve_link_mode() -> Result<LinkMode, DynError> {
+     let static_enabled = env::var_os("CARGO_FEATURE_STATIC").is_some();
+     let shared_enabled = env::var_os("CARGO_FEATURE_SHARED").is_some();
++    let cuda_enabled = env::var_os("CARGO_FEATURE_CUDA").is_some();
+
+     if static_enabled && shared_enabled {
+         return Err("Features `static` and `shared` cannot be enabled at the same time".into());
+     }
+
++    if cuda_enabled && static_enabled {
++        return Err(
++            "Feature `cuda` requires shared linking; \
++             the k2-fsa CUDA prebuilt is only published as a shared library. \
++             Enable `shared` (or disable `static`) when using `cuda`."
++                .into(),
++        );
++    }
++
+     if shared_enabled {
+         Ok(LinkMode::Shared)
+     } else {
+         Ok(LinkMode::Static)
+     }
+ }
+```
+
+Note: when `cuda` is enabled, `shared` is also enabled (via the
+`cuda = ["shared"]` feature declaration), so the existing `if shared_enabled`
+arm takes care of returning `LinkMode::Shared`. We don't need a `LinkMode::Cuda`
+variant — CUDA is a *which archive* question, not a *how to link* question.
+
+### Change B — `archive_name()` (around line 194)
+
+Add a CUDA branch at the top of the match, so it wins over the plain
+`(LinkMode::Shared, "linux", "x86_64")` arm when the feature is enabled.
+The `target_os` and `target_arch` are passed in; we also need to know
+whether `cuda` is on, which means threading it through.
+
+Two options for threading:
+
+- **Option 1**: read `CARGO_FEATURE_CUDA` inside `archive_name`. Simple, no
+  signature change, but couples the function to env var reads.
+- **Option 2**: pass a `cuda: bool` parameter from `try_main` → `download_prebuilt_libs`
+  → `archive_name`. More explicit, threads through one more layer.
+
+I'd go with **Option 1** for minimal diff and to match the existing style
+(`resolve_link_mode` already reads env vars directly). Upstream reviewers
+tend to prefer minimal surface-area changes.
+
+```diff
+ fn archive_name(
+     link_mode: LinkMode,
+     target_os: &str,
+     target_arch: &str,
+ ) -> Result<String, DynError> {
+     let version = env!("CARGO_PKG_VERSION");
++    let cuda_enabled = env::var_os("CARGO_FEATURE_CUDA").is_some();
++
++    if cuda_enabled {
++        // CUDA prebuilts are shared-only and currently linux-x64 only.
++        // The archive is pinned to CUDA 12.x + cuDNN 9.x; users must have
++        // compatible system libraries (libcudnn.so.9, libcublas.so.12) at
++        // runtime — onnxruntime dlopens them.
++        return match (link_mode, target_os, target_arch) {
++            (LinkMode::Shared, "linux", "x86_64") => Ok(format!(
++                "sherpa-onnx-v{version}-cuda-12.x-cudnn-9.x-linux-x64-gpu.tar.bz2"
++            )),
++            _ => Err(format!(
++                "Feature `cuda` is only supported on linux-x86_64 with shared linking. \
++                 Got: link_mode={link_mode:?}, os={target_os}, arch={target_arch}"
++            )
++            .into()),
++        };
++    }
++
+     let name = match (link_mode, target_os, target_arch) {
+         (LinkMode::Static, "linux", "x86_64") => {
+             format!("sherpa-onnx-v{version}-linux-x64-static-lib.tar.bz2")
+         }
+         // ... rest of existing match unchanged ...
+```
+
+That's the entire upstream patch. **No other file changes.**
+
+---
+
+## Local-fork-only commit (second commit on our branch)
+
+Root-level `Cargo.toml` for cargo-git-dep discovery. This is **not** part of
+the upstream PR — cherry-pick only Diffs 1 and 2 onto a clean upstream PR
+branch.
+
+Create `/Cargo.toml` at the repo root with:
+
+```toml
+# Minimal virtual workspace so cargo git-dependencies can discover
+# `sherpa-onnx-sys` and `sherpa-onnx` without needing a `subdir` hint.
+#
+# NOT FOR UPSTREAM — local-fork-only. See the upstream PR branch for the
+# clean build.rs / Cargo.toml changes without this file.
+[workspace]
+resolver = "2"
+members = [
+    "sherpa-onnx/rust/sherpa-onnx",
+    "sherpa-onnx/rust/sherpa-onnx-sys",
+]
+```
+
+Commit message: `chore(workspace): add root Cargo.toml for cargo git-dep discovery [local-fork-only, not for upstream]`
+
+---
+
+## Verification (before we wire it into SDR-RS)
+
+On the fork branch, in `sherpa-onnx/rust/`:
+
+```bash
+cargo check -p sherpa-onnx-sys --no-default-features --features cuda
+```
+
+Expected: build.rs downloads the CUDA archive (~235MB, one-time), extracts
+to `target/sherpa-onnx-prebuilt/sherpa-onnx-v1.12.36-cuda-12.x-cudnn-9.x-linux-x64-gpu/lib/`,
+links against the libs, succeeds. Warnings from the existing code about
+shared runtime lib copy are expected.
+
+Then negative test:
+
+```bash
+cargo check -p sherpa-onnx-sys --no-default-features --features "cuda static"
+```
+
+Expected: build fails with the new error message about cuda requiring shared.
+
+---
+
+## SDR-RS side — what changes after the fork is ready
+
+Separate PR (`feature/sherpa-cuda`) on our repo, depending on a specific
+git rev of your fork:
+
+1. Workspace `Cargo.toml`: replace `sherpa-onnx = "1.12"` with a `git =` dep pointing at your fork + pinned rev.
+2. `crates/sdr-transcription/Cargo.toml`: add `sherpa-cuda = ["sherpa", "sherpa-onnx/cuda"]` feature alongside `sherpa-cpu`. The `sherpa-onnx/cuda` passthrough requires `sherpa-onnx`'s own `Cargo.toml` to re-export the feature (may need a micro-patch there too — TBD during implementation).
+3. `backends/sherpa/host.rs:421`, `:478`, `:481`: replace hardcoded `"cpu"` with a const that switches on `cfg(feature = "sherpa-cuda")`.
+4. `backends/sherpa/silero_vad.rs:72`: same treatment for the VAD provider string.
+5. Makefile: document the new build flavor.
+6. README.md / CLAUDE.md: document the CUDA 12.x + cuDNN 9.x runtime requirement, install commands for Arch/Ubuntu.
+7. CI: add a `sherpa-cuda` build job (cargo check only — runners don't have GPUs, but the link step and archive download still get exercised).

--- a/scripts/fetch-cuda-redist.sh
+++ b/scripts/fetch-cuda-redist.sh
@@ -53,8 +53,18 @@ DOWNLOADS_DIR="$1"
 STAGING_DIR="$2"
 SENTINEL="$3"
 
-if [ -f "$SENTINEL" ]; then
-    echo "  [cached] NVIDIA CUDA redist libs already fetched"
+# The sentinel file alone isn't enough to short-circuit — if the
+# staging directory got wiped (e.g. the user ran `rm -rf ~/.cache/sdr-rs`
+# selectively, or a distro upgrade pruned XDG caches) while the
+# sentinel survived, we'd skip the extract step and leave install-
+# cuda-redist-libs with nothing to copy. Validate that staging still
+# has at least one library file before trusting the cache; otherwise
+# fall through to the fetch/extract path, which itself is idempotent
+# on the already-downloaded archives.
+if [ -f "$SENTINEL" ] \
+    && [ -d "$STAGING_DIR" ] \
+    && [ -n "$(find "$STAGING_DIR" -maxdepth 1 \( -type f -o -type l \) -name 'lib*.so*' -print -quit 2>/dev/null)" ]; then
+    echo "  [cached] NVIDIA CUDA redist libs already fetched and staged"
     exit 0
 fi
 

--- a/scripts/fetch-cuda-redist.sh
+++ b/scripts/fetch-cuda-redist.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Fetch NVIDIA CUDA 12 + cuDNN 9 runtime libraries for sherpa-cuda builds.
+#
+# Downloads a minimal set of NVIDIA redistributable tarballs from the
+# developer.download.nvidia.com server, verifies SHA-256, and extracts
+# just the runtime .so files we need into a staging directory. The
+# caller (`make fetch-cuda-redist`) then copies the staged libs into
+# the install prefix's `sdr-rs-libs/` subdirectory.
+#
+# This dance is necessary because the sherpa-onnx project ships a
+# pre-patched onnxruntime 1.23.2 binary (see
+# `sherpa-onnx/cmake/onnxruntime-linux-x86_64-gpu.cmake`) that is
+# hard-linked against CUDA 12.x + cuDNN 9.x. CUDA major versions are
+# NOT ABI-compatible, so hosts that have newer CUDA (e.g. Arch Linux,
+# which ships CUDA 13 by default) can't run sherpa-cuda without these
+# libraries provided separately. Rather than require users to install
+# a parallel CUDA 12 toolkit, we sideload the exact runtime libs that
+# `libonnxruntime_providers_cuda.so` needs.
+#
+# Selected components are determined by inspecting the NEEDED entries
+# of the provider .so:
+#
+#     $ readelf -d libonnxruntime_providers_cuda.so | grep NEEDED
+#       libcublasLt.so.12   <- libcublas archive
+#       libcublas.so.12     <- libcublas archive (same file, two sonames)
+#       libcurand.so.10     <- libcurand archive
+#       libcufft.so.11      <- libcufft archive
+#       libcudart.so.12     <- cuda_cudart archive
+#       libcudnn.so.9       <- cudnn archive (plus cuDNN 9's dlopen'd sublibs)
+#
+# Components NOT fetched (not in NEEDED, not used by the sherpa path):
+#
+#     libcusparse, libcusolver, libnvrtc, libnvjitlink, libnvinfer (TensorRT)
+#
+# Static libraries inside each archive are filtered out during extract
+# to avoid shipping ~1 GB of .a files we never link against.
+#
+# Usage:
+#     scripts/fetch-cuda-redist.sh <downloads-dir> <staging-dir> <sentinel-path>
+#
+# The script is idempotent: if the sentinel file exists, it exits 0
+# immediately. To force a re-download, delete the sentinel (or the
+# entire cache directory).
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <downloads-dir> <staging-dir> <sentinel-path>" >&2
+    exit 2
+fi
+
+DOWNLOADS_DIR="$1"
+STAGING_DIR="$2"
+SENTINEL="$3"
+
+if [ -f "$SENTINEL" ]; then
+    echo "  [cached] NVIDIA CUDA redist libs already fetched"
+    exit 0
+fi
+
+CUDA_BASE="https://developer.download.nvidia.com/compute/cuda/redist"
+CUDNN_BASE="https://developer.download.nvidia.com/compute/cudnn/redist"
+
+# url sha256 — one pair per line
+# shellcheck disable=SC2034
+ARCHIVES=(
+    "${CUDA_BASE}/cuda_cudart/linux-x86_64/cuda_cudart-linux-x86_64-12.6.77-archive.tar.xz"
+    "f74689258a60fd9c5bdfa7679458527a55e22442691ba678dcfaeffbf4391ef9"
+
+    "${CUDA_BASE}/libcublas/linux-x86_64/libcublas-linux-x86_64-12.6.4.1-archive.tar.xz"
+    "ec682bac6387f9cdfd0c20b25a16cd6ed0b8b3b7ff42be9eaeb41828e3a72572"
+
+    "${CUDA_BASE}/libcufft/linux-x86_64/libcufft-linux-x86_64-11.3.0.4-archive.tar.xz"
+    "63a046d51a45388e10612c3fd423bb7fa5127496aa9bb3951a609e8b9d996852"
+
+    "${CUDA_BASE}/libcurand/linux-x86_64/libcurand-linux-x86_64-10.3.7.77-archive.tar.xz"
+    "981339cc86d7b8779e9a3c17e72d8c5e1a8a2d06c24db692eecabed8e746a3c7"
+
+    "${CUDNN_BASE}/cudnn/linux-x86_64/cudnn-linux-x86_64-9.5.1.17_cuda12-archive.tar.xz"
+    "35dd20b9c68324ae1288ac36f66ab1f318d2bfecfafb703a82617aa283272be4"
+)
+
+echo ""
+echo "Fetching NVIDIA CUDA 12 + cuDNN 9 runtime libs for sherpa-cuda"
+echo "  Downloads: $DOWNLOADS_DIR"
+echo "  Staging:   $STAGING_DIR"
+echo "  Size:      ~1.83 GB download, ~1.2 GB staged"
+echo ""
+
+mkdir -p "$DOWNLOADS_DIR"
+
+# Walk pairs (url, sha) from the array
+i=0
+while [ "$i" -lt "${#ARCHIVES[@]}" ]; do
+    url="${ARCHIVES[$i]}"
+    sha="${ARCHIVES[$((i + 1))]}"
+    name="$(basename "$url")"
+    dest="$DOWNLOADS_DIR/$name"
+
+    if [ -f "$dest" ]; then
+        echo "  [cached] $name"
+    else
+        echo "  [fetch ] $name"
+        curl -fL --progress-bar "$url" -o "$dest.part"
+        mv "$dest.part" "$dest"
+    fi
+
+    # Verify checksum (stdin format: "<sha>  <path>")
+    if ! echo "$sha  $dest" | sha256sum -c --status -; then
+        echo "  sha256 mismatch for $name; discarding and aborting" >&2
+        rm -f "$dest"
+        exit 1
+    fi
+
+    i=$((i + 2))
+done
+
+echo ""
+echo "Extracting runtime .so files to $STAGING_DIR"
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR"
+
+# Per-archive extract. A few subtleties matter here:
+#
+#   1. Each NVIDIA redist archive contains a `lib/` tree AND a
+#      `lib/stubs/` subdirectory. The stubs are build-time linker
+#      shims (e.g. `lib/stubs/libcuda.so` is a shim for the real
+#      NVIDIA driver library that lives in /usr/lib on installed
+#      systems). Shipping these as runtime libs is dangerous — the
+#      libcuda stub in particular would shadow the real driver — so
+#      we `-prune` the stubs/ subtree out of the find traversal.
+#
+#   2. The runtime .so files in lib/ form a symlink chain like
+#        libfoo.so         -> libfoo.so.N
+#        libfoo.so.N       -> libfoo.so.N.M.P
+#        libfoo.so.N.M.P   (real file)
+#      The ELF loader resolves NEEDED entries against the soname
+#      (`libfoo.so.N`), which is the middle link. If we flatten the
+#      chain to just the real file we lose the soname entry and the
+#      loader fails. So we preserve symlinks as symlinks via `cp -a`,
+#      and match both regular files and symlinks with `find \( -type
+#      f -o -type l \)`.
+#
+#   3. We filter out:
+#        - static libraries (*.a, *_static.so*) — we link dynamically
+#        - libnvblas, libcufftw — compat wrappers we don't use
+#        - unversioned `lib*.so` at the top of the symlink chain IS
+#          kept, because stripping it breaks nothing and the size
+#          cost is just the symlink node itself
+for archive in "$DOWNLOADS_DIR"/*.tar.xz; do
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    tar -xf "$archive" -C "$tmp"
+
+    find "$tmp" \
+        -type d -name stubs -prune -o \
+        \( -type f -o -type l \) \
+        \( -name 'lib*.so' -o -name 'lib*.so.*' \) \
+        ! -name '*_static*' \
+        ! -name 'libnvblas*' \
+        ! -name 'libcufftw*' \
+        -print0 \
+        | xargs -0 --no-run-if-empty cp -a -t "$STAGING_DIR/"
+
+    rm -rf "$tmp"
+    trap - EXIT
+done
+
+count="$(find "$STAGING_DIR" -maxdepth 1 \( -type f -o -type l \) -name 'lib*.so*' | wc -l)"
+echo "  staged $count library files"
+
+# Atomic-ish sentinel: only touched when everything above succeeded,
+# so a partially-completed run leaves the next invocation to retry
+# from the beginning (downloads already present will hit the cache).
+touch "$SENTINEL"
+echo ""


### PR DESCRIPTION
## Summary

- Adds a new `sherpa-cuda` cargo feature that runs sherpa-onnx (Zipformer, Moonshine, Parakeet) on NVIDIA GPUs via `onnxruntime`'s CUDA execution provider
- Pins the `sherpa-onnx` crate at the [jasonherald/sherpa-onnx](https://github.com/jasonherald/sherpa-onnx) fork (rev `628c333f`) until the upstream PR to k2-fsa merges — the fork adds a `cuda` cargo feature to `sherpa-onnx-sys` with ~50 lines of surgical build.rs changes that pull the CUDA prebuilt tarball instead of the CPU one
- **`make install` auto-provisions CUDA 12 + cuDNN 9 runtime libraries** next to the binary so users do NOT need to install a parallel CUDA 12 toolkit on hosts running CUDA 13 (e.g. Arch Linux). Downloads ~1.83 GB of NVIDIA redistributable tarballs with SHA-256 verification, extracts just the runtime `.so` files (skipping stubs, static archives, and unused compat wrappers), and installs them into `\$(BINDIR)/sdr-rs-libs/` with symlink chains preserved. See #267 for the full design writeup of this sideload mechanism.
- Adds a new CI job `sherpa-check` that runs `cargo check` under both `sherpa-cpu` and `sherpa-cuda` feature graphs plus a targeted `cargo deny check sources` so the new git dependency is actually exercised by CI

## Why the sideload?

sherpa-onnx's CUDA prebuilt is hard-pinned to onnxruntime 1.23.2 built against CUDA 12.x + cuDNN 9.x. CUDA major versions are not ABI-compatible. Arch Linux ships CUDA 13.2.0 today; cuDNN 9 is not in the main repo at all. Rather than require users to install CUDA 12 from AUR alongside CUDA 13, `make install CARGO_FLAGS="... --features sherpa-cuda"` automatically downloads the minimum set of NVIDIA CUDA 12 runtime libraries that `libonnxruntime_providers_cuda.so` declares as NEEDED and ships them next to the binary. The user's system CUDA install stays untouched.

## Install layout

\`\`\`
~/.cargo/bin/
├── sdr-rs                          (binary, DT_RPATH = \$ORIGIN:\$ORIGIN/sdr-rs-libs)
└── sdr-rs-libs/                    (runtime libs, ~2.1 GB with symlinks preserved)
    ├── libsherpa-onnx-c-api.so     (from k2-fsa CUDA prebuilt)
    ├── libonnxruntime.so
    ├── libonnxruntime_providers_cuda.so
    ├── libonnxruntime_providers_shared.so
    ├── libcudart.so{,.12,.12.6.77}          (from NVIDIA cuda_cudart)
    ├── libcublas.so{,.12,.12.6.4.1}         (from NVIDIA libcublas)
    ├── libcublasLt.so{,.12,.12.6.4.1}       ↗
    ├── libcufft.so{,.11,.11.3.0.4}          (from NVIDIA libcufft)
    ├── libcurand.so{,.10,.10.3.7.77}        (from NVIDIA libcurand)
    └── libcudnn*.so{,.9,.9.5.1}             (from NVIDIA cuDNN 9)
\`\`\`

The binary's `DT_RPATH` is forced to old-style (not `DT_RUNPATH`) via `-Wl,--disable-new-dtags` in the new top-level `build.rs` because onnxruntime `dlopen`'s the CUDA provider at recognizer creation and \`DT_RUNPATH\` does not cascade to dlopen'd libraries' NEEDED resolution. See the code comment in `build.rs` for the full story.

Downloads are cached persistently at \`\$HOME/.cache/sdr-rs/cuda-redist/\` (outside the cargo target dir) so \`cargo clean\` and branch switches don't discard the 1.83 GB.

## Triple-build verification

| Check                        | whisper-cpu (default) | whisper-cuda | sherpa-cpu | sherpa-cuda |
|------------------------------|-----------------------|--------------|------------|-------------|
| \`cargo check --workspace\`  | ✅                    | ✅           | ✅         | ✅          |
| \`cargo clippy -D warnings\` | ✅                    | —            | ✅         | ✅          |
| \`cargo test --workspace\`   | ✅                    | —            | —          | —           |
| \`cargo deny check sources\` | ✅                    | —            | —          | ✅          |
| \`cargo fmt --check\`        | ✅                    | ✅           | ✅         | ✅          |
| \`cargo audit\`              | ✅                    | —            | —          | —           |
| \`make install\` + runtime   | —                     | ✅           | —          | ✅          |

## Manual smoke test (RTX 4080 Super on Arch CUDA 13 host)

- [x] \`make install CARGO_FLAGS=\"--release --no-default-features --features sherpa-cuda\"\` — downloads 1.83 GB, installs cleanly into \`sdr-rs-libs/\`, no runtime errors
- [x] \`sdr-rs\` launches without the libcublasLt error that plagued earlier attempts
- [x] **Streaming Zipformer EN** — real-time streaming captions, GPU-loaded
- [x] **Moonshine Tiny + Base** — VAD-gated offline decode, GPU-loaded
- [x] **Parakeet-TDT 0.6b v3** — VAD-gated offline decode, VRAM allocation confirmed via nvidia-smi during inference
- [x] Existing whisper-cuda build on the same host still works unchanged (separate cargo feature, compiles its own kernels against system CUDA 13)
- [x] Test other sherpa models produce sensible output on NFM scanner audio (user to verify in day-to-day use)
- [x] Measure Parakeet decode latency delta CPU→GPU and note in #262 if worth closing

## What's NOT in this PR

- A sherpa-cuda version of the k2-fsa CUDA 13 story. They don't ship CUDA 13 prebuilts yet; we wait.
- A deb/rpm package story for distro installs. Layout uses \`~/.cargo/bin/sdr-rs-libs/\` which is user-local only.
- System-level CUDA install scripts. The sideload is the whole point.

## Linked

- Tracked by #267 (sideload design writeup, re-unification plan, follow-up work)
- Depends on the \`feat/rust-sys-cuda-support\` branch of [jasonherald/sherpa-onnx](https://github.com/jasonherald/sherpa-onnx/tree/feat/rust-sys-cuda-support) — upstream PR to k2-fsa will be opened separately
- Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional NVIDIA CUDA GPU acceleration for the Sherpa transcription backend; pick exactly one Sherpa backend (CPU or CUDA).
  * make install can package and install runtime CUDA libraries for a runnable CUDA build.

* **Documentation**
  * Expanded build/install docs: Sherpa CUDA instructions, runtime requirements, cache and install layout, and feature selection guidance.

* **Chores**
  * CI: added a dedicated CUDA-aware workspace check and isolated cache for Sherpa backends; cargo-deny source allowlist updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->