### PR TITLE
feat(transcription): Auto Break segmentation + universal stop-on-mode-change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,7 @@ dependencies = [
  "sdr-source-file",
  "sdr-source-network",
  "sdr-source-rtlsdr",
+ "sdr-transcription",
  "sdr-types",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/sdr-core/Cargo.toml
+++ b/crates/sdr-core/Cargo.toml
@@ -45,6 +45,7 @@ bytemuck.workspace = true
 # `["coreaudio"]`, and on every other target the feature list is empty
 # and the crate's `lib.rs` cfg dispatch resolves to the stub backend.
 sdr-sink-audio.workspace = true
+sdr-transcription.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sdr-sink-audio = { workspace = true, features = ["pipewire"] }

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -333,6 +333,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetDemodMode(mode) => {
             tracing::debug!(?mode, "set demod mode");
+            let old_mode = state.radio.current_mode();
             if let Err(e) = state.radio.set_mode(mode) {
                 tracing::warn!("set demod mode failed: {e}");
                 let _ = dsp_tx.send(DspToUi::Error(format!("Mode switch failed: {e}")));
@@ -361,6 +362,13 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 let _ = dsp_tx.send(DspToUi::DisplayBandwidth(
                     state.frontend.effective_sample_rate(),
                 ));
+
+                // Notify the UI of the mode transition (edge detection — only
+                // when the mode actually changed so idempotent refreshes do not
+                // trigger the transcript-session boundary logic in Task 16).
+                if old_mode != mode {
+                    let _ = dsp_tx.send(DspToUi::DemodModeChanged(mode));
+                }
             }
         }
 

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -365,8 +365,22 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
                 // Notify the UI of the mode transition (edge detection — only
                 // when the mode actually changed so idempotent refreshes do not
-                // trigger the transcript-session boundary logic in Task 16).
+                // trigger the transcript-session boundary logic).
+                //
+                // The UI layer's response to `DemodModeChanged` is to toggle
+                // the transcription enable row off, which eventually drops
+                // the transcription channel via `DisableTranscription`. That
+                // round-trip is async — until it completes the DSP thread
+                // would otherwise keep pushing post-switch audio into the old
+                // session, violating the "band change = hard session
+                // boundary" contract in the Auto Break design spec. Drop the
+                // tap locally FIRST so no post-switch samples leak into the
+                // old backend, then notify the UI. The UI's eventual
+                // `DisableTranscription` is idempotent on an already-cleared
+                // tap.
                 if old_mode != mode {
+                    state.transcription_tx = None;
+                    state.squelch_was_open = false;
                     let _ = dsp_tx.send(DspToUi::DemodModeChanged(mode));
                 }
             }
@@ -758,11 +772,22 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::EnableTranscription(tx) => {
+            // Reset the squelch edge tracker when a new tap is wired up.
+            // Without this, a previous session that ended with squelch open
+            // leaves `squelch_was_open == true`, so the first chunk of the
+            // new session sees `now_open == was_open` and no SquelchOpened
+            // edge is emitted — the offline Auto Break state machine would
+            // stay in Idle and drop the entire current transmission until
+            // the next open/close cycle.
+            state.squelch_was_open = false;
             state.transcription_tx = Some(tx);
             tracing::info!("transcription audio tap enabled");
         }
         UiToDsp::DisableTranscription => {
             state.transcription_tx = None;
+            // Mirror the reset on disable so a subsequent EnableTranscription
+            // always starts from a known state.
+            state.squelch_was_open = false;
             tracing::info!("transcription audio tap disabled");
         }
     }
@@ -1033,6 +1058,15 @@ fn process_iq_block(
                         if let Some(ref tx) = state.transcription_tx {
                             let now_open = state.radio.if_chain().squelch_open();
                             let mut send_error = false;
+                            // True unless we tried to send an edge event and hit
+                            // `TrySendError::Full`. Squelch edges are one-shot
+                            // state transitions — if we advance `squelch_was_open`
+                            // without the downstream having received the edge,
+                            // the Auto Break state machine misses the transition
+                            // entirely and gets stuck in Idle/Recording until the
+                            // 30s safety flush fires. Retry on the next block by
+                            // leaving the tracker unchanged.
+                            let mut advance_tracker = true;
 
                             if now_open != state.squelch_was_open
                                 && state.radio.current_mode() == sdr_types::DemodMode::Nfm
@@ -1042,13 +1076,28 @@ fn process_iq_block(
                                 } else {
                                     sdr_transcription::TranscriptionInput::SquelchClosed
                                 };
-                                if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
-                                    tx.try_send(edge)
-                                {
-                                    send_error = true;
+                                match tx.try_send(edge) {
+                                    Ok(()) => {}
+                                    Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                                        send_error = true;
+                                    }
+                                    Err(std::sync::mpsc::TrySendError::Full(_)) => {
+                                        // Backend is busy (likely decoding an
+                                        // earlier segment). Don't advance the
+                                        // tracker so we retry this edge on the
+                                        // next audio block instead of silently
+                                        // dropping it.
+                                        advance_tracker = false;
+                                        tracing::warn!(
+                                            ?now_open,
+                                            "transcription channel full; retrying squelch edge next block"
+                                        );
+                                    }
                                 }
                             }
-                            state.squelch_was_open = now_open;
+                            if advance_tracker {
+                                state.squelch_was_open = now_open;
+                            }
 
                             if !send_error {
                                 let mut interleaved = Vec::with_capacity(audio_count * 2);

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -190,7 +190,7 @@ struct DspState {
     iq_writer: Option<WavWriter>,
 
     /// Transcription audio tap — when Some, audio is copied to this channel.
-    transcription_tx: Option<std::sync::mpsc::SyncSender<Vec<f32>>>,
+    transcription_tx: Option<std::sync::mpsc::SyncSender<sdr_transcription::TranscriptionInput>>,
 }
 
 impl DspState {
@@ -1010,7 +1010,7 @@ fn process_iq_block(
                                 interleaved.push(s.r);
                             }
                             if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
-                                tx.try_send(interleaved)
+                                tx.try_send(sdr_transcription::TranscriptionInput::Samples(interleaved))
                             {
                                 state.transcription_tx = None;
                                 tracing::info!(

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -147,6 +147,14 @@ fn dsp_thread_main(
 }
 
 /// Mutable state owned by the DSP thread.
+///
+/// This is a god-struct that holds every piece of DSP-thread state by
+/// design — the DSP thread owns everything exclusively. The
+/// `struct_excessive_bools` lint triggers at 4 bools (`running`,
+/// `dc_blocking`, `invert_iq`, `squelch_was_open`); splitting them
+/// into an enum state machine would be a significant refactor for
+/// zero runtime benefit, so suppress locally.
+#[allow(clippy::struct_excessive_bools)]
 struct DspState {
     source: Option<Box<dyn Source>>,
     frontend: IqFrontend,
@@ -191,6 +199,12 @@ struct DspState {
 
     /// Transcription audio tap — when Some, audio is copied to this channel.
     transcription_tx: Option<std::sync::mpsc::SyncSender<sdr_transcription::TranscriptionInput>>,
+
+    /// Last known squelch gate state, used to detect open/close edge
+    /// transitions so we only emit one `SquelchOpened` / `SquelchClosed`
+    /// event per transition instead of one per audio chunk. Initialized
+    /// to `false` (matches `IfChain`'s initial closed state).
+    squelch_was_open: bool,
 }
 
 impl DspState {
@@ -241,6 +255,7 @@ impl DspState {
             audio_writer: None,
             iq_writer: None,
             transcription_tx: None,
+            squelch_was_open: false,
         })
     }
 }
@@ -1002,16 +1017,47 @@ fn process_iq_block(
                         }
 
                         // Send audio copy to transcription worker BEFORE volume
-                        // scaling so recognition isn't affected by the volume knob.
+                        // scaling so recognition isn't affected by the volume knob. Also
+                        // emit squelch edge events on open/close transitions so offline
+                        // sherpa backends can use them as Auto Break segmentation
+                        // boundaries. Edge events are NFM-only — WFM and other modes
+                        // don't have meaningful squelch transitions for speech.
                         if let Some(ref tx) = state.transcription_tx {
-                            let mut interleaved = Vec::with_capacity(audio_count * 2);
-                            for s in &state.audio_buf[..audio_count] {
-                                interleaved.push(s.l);
-                                interleaved.push(s.r);
-                            }
-                            if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
-                                tx.try_send(sdr_transcription::TranscriptionInput::Samples(interleaved))
+                            let now_open = state.radio.if_chain().squelch_open();
+                            let mut send_error = false;
+
+                            if now_open != state.squelch_was_open
+                                && state.radio.current_mode() == sdr_types::DemodMode::Nfm
                             {
+                                let edge = if now_open {
+                                    sdr_transcription::TranscriptionInput::SquelchOpened
+                                } else {
+                                    sdr_transcription::TranscriptionInput::SquelchClosed
+                                };
+                                if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
+                                    tx.try_send(edge)
+                                {
+                                    send_error = true;
+                                }
+                            }
+                            state.squelch_was_open = now_open;
+
+                            if !send_error {
+                                let mut interleaved = Vec::with_capacity(audio_count * 2);
+                                for s in &state.audio_buf[..audio_count] {
+                                    interleaved.push(s.l);
+                                    interleaved.push(s.r);
+                                }
+                                if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
+                                    tx.try_send(sdr_transcription::TranscriptionInput::Samples(
+                                        interleaved,
+                                    ))
+                                {
+                                    send_error = true;
+                                }
+                            }
+
+                            if send_error {
                                 state.transcription_tx = None;
                                 tracing::info!(
                                     "transcription receiver disconnected, disabling tap"

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1056,8 +1056,8 @@ fn process_iq_block(
                                     interleaved.push(s.l);
                                     interleaved.push(s.r);
                                 }
-                                if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
-                                    tx.try_send(sdr_transcription::TranscriptionInput::Samples(
+                                if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) = tx
+                                    .try_send(sdr_transcription::TranscriptionInput::Samples(
                                         interleaved,
                                     ))
                                 {

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -30,6 +30,13 @@ pub enum DspToUi {
     IqRecordingStarted(std::path::PathBuf),
     /// IQ recording stopped.
     IqRecordingStopped,
+    /// Demodulator mode changed. Emitted when `UiToDsp::SetDemodMode`
+    /// actually changes the active demod mode (edge detection — not
+    /// emitted if the requested mode matches the current mode). The
+    /// transcript panel subscribes to this to stop any active
+    /// transcription session (band change = new session boundary) and
+    /// to re-run Auto Break row visibility rules.
+    DemodModeChanged(DemodMode),
 }
 
 /// Available source types for IQ input.
@@ -167,6 +174,12 @@ mod tests {
 
         let iq_stop = DspToUi::IqRecordingStopped;
         assert!(matches!(iq_stop, DspToUi::IqRecordingStopped));
+    }
+
+    #[test]
+    fn demod_mode_changed_message_constructs() {
+        let m = DspToUi::DemodModeChanged(DemodMode::Nfm);
+        assert!(matches!(m, DspToUi::DemodModeChanged(DemodMode::Nfm)));
     }
 
     #[test]

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -125,7 +125,7 @@ pub enum UiToDsp {
     /// Stop IQ recording and finalize the WAV file.
     StopIqRecording,
     /// Start sending audio to the transcription engine.
-    EnableTranscription(std::sync::mpsc::SyncSender<Vec<f32>>),
+    EnableTranscription(std::sync::mpsc::SyncSender<sdr_transcription::TranscriptionInput>),
     /// Stop sending audio to the transcription engine.
     DisableTranscription,
 }
@@ -313,7 +313,7 @@ mod tests {
         let iq_stop = UiToDsp::StopIqRecording;
         assert!(matches!(iq_stop, UiToDsp::StopIqRecording));
 
-        let (tx, _rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(1);
+        let (tx, _rx) = std::sync::mpsc::sync_channel::<sdr_transcription::TranscriptionInput>(1);
         let enable = UiToDsp::EnableTranscription(tx);
         assert!(matches!(enable, UiToDsp::EnableTranscription(_)));
 

--- a/crates/sdr-transcription/src/backend.rs
+++ b/crates/sdr-transcription/src/backend.rs
@@ -23,6 +23,48 @@ pub const VAD_THRESHOLD_MAX: f32 = 0.90;
 /// scanner/NFM sources.
 pub const VAD_THRESHOLD_DEFAULT: f32 = 0.50;
 
+/// Frames sent from the DSP controller into a transcription backend.
+///
+/// Carries both raw audio samples and segmentation-boundary hints. The
+/// boundary variants are emitted by `sdr-core::controller` only when the
+/// current demod mode is NFM — backends never need to gate on mode
+/// themselves.
+///
+/// Backends that don't care about squelch-based segmentation (Whisper,
+/// streaming Zipformer, offline sherpa in `SegmentationMode::Vad`)
+/// pattern-match on `Samples` and drop the other variants.
+#[derive(Debug, Clone)]
+pub enum TranscriptionInput {
+    /// Interleaved-stereo f32 PCM at 48 kHz. Always emitted, gap-free.
+    Samples(Vec<f32>),
+
+    /// Radio squelch just opened. Edge event, emitted exactly once per
+    /// close→open transition. NFM demod only.
+    SquelchOpened,
+
+    /// Radio squelch just closed. Edge event, emitted exactly once per
+    /// open→close transition. NFM demod only.
+    SquelchClosed,
+}
+
+/// Which segmentation engine drives utterance boundaries for an offline
+/// sherpa transcription session.
+///
+/// Mutex: exactly one is active per session. Streaming Zipformer always
+/// uses `Vad` (its own endpoint detection handles the rest).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SegmentationMode {
+    /// Silero VAD drives segmentation. Default for backward compatibility
+    /// and the only valid mode for streaming Zipformer.
+    #[default]
+    Vad,
+
+    /// Auto Break: the radio's squelch gate drives segmentation. Valid
+    /// only for offline sherpa models on NFM demod. See the Auto Break
+    /// state machine in `backends/sherpa/offline.rs`.
+    AutoBreak,
+}
+
 /// Configuration handed to a backend at `start` time.
 ///
 /// `model` selects which ASR model the backend should load. Additional
@@ -36,8 +78,13 @@ pub struct BackendConfig {
     /// Clamp to `VAD_THRESHOLD_MIN..=VAD_THRESHOLD_MAX`.
     /// Default `VAD_THRESHOLD_DEFAULT`. Lower catches quieter audio
     /// (NFM/scanner); higher is stricter (talk radio). Ignored by
-    /// Whisper (no Silero VAD).
+    /// Whisper (no Silero VAD) and ignored when
+    /// `segmentation_mode == SegmentationMode::AutoBreak`.
     pub vad_threshold: f32,
+    /// How utterance boundaries are detected in an offline sherpa
+    /// session. See `SegmentationMode` for valid values. Streaming
+    /// Zipformer rejects `AutoBreak` at session start.
+    pub segmentation_mode: SegmentationMode,
 }
 
 /// User-facing model selection.
@@ -82,8 +129,9 @@ pub enum TranscriptionEvent {
 /// Returned by [`TranscriptionBackend::start`]. Carries the channels the
 /// engine wires through to its caller.
 pub struct BackendHandle {
-    /// Push 48 kHz interleaved stereo f32 samples into the backend.
-    pub audio_tx: mpsc::SyncSender<Vec<f32>>,
+    /// Push audio frames + squelch edge events into the backend. See
+    /// [`TranscriptionInput`] for the wire format.
+    pub audio_tx: mpsc::SyncSender<TranscriptionInput>,
     /// Receive transcription events from the backend.
     pub event_rx: mpsc::Receiver<TranscriptionEvent>,
 }
@@ -148,4 +196,21 @@ pub trait TranscriptionBackend: Send {
     /// `recv` to see `Disconnected` if the cancel flag hasn't already
     /// short-circuited the loop.
     fn shutdown_nonblocking(&mut self);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcription_input_variants_construct() {
+        let _samples = TranscriptionInput::Samples(vec![0.0_f32; 16]);
+        let _opened = TranscriptionInput::SquelchOpened;
+        let _closed = TranscriptionInput::SquelchClosed;
+    }
+
+    #[test]
+    fn segmentation_mode_default_is_vad() {
+        assert_eq!(SegmentationMode::default(), SegmentationMode::Vad);
+    }
 }

--- a/crates/sdr-transcription/src/backend.rs
+++ b/crates/sdr-transcription/src/backend.rs
@@ -204,9 +204,18 @@ mod tests {
 
     #[test]
     fn transcription_input_variants_construct() {
-        let _samples = TranscriptionInput::Samples(vec![0.0_f32; 16]);
-        let _opened = TranscriptionInput::SquelchOpened;
-        let _closed = TranscriptionInput::SquelchClosed;
+        assert!(matches!(
+            TranscriptionInput::Samples(vec![0.0_f32; 16]),
+            TranscriptionInput::Samples(_)
+        ));
+        assert!(matches!(
+            TranscriptionInput::SquelchOpened,
+            TranscriptionInput::SquelchOpened
+        ));
+        assert!(matches!(
+            TranscriptionInput::SquelchClosed,
+            TranscriptionInput::SquelchClosed
+        ));
     }
 
     #[test]

--- a/crates/sdr-transcription/src/backends/mock.rs
+++ b/crates/sdr-transcription/src/backends/mock.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex, mpsc};
 
 use crate::backend::{
     BackendConfig, BackendError, BackendHandle, TranscriptionBackend, TranscriptionEvent,
+    TranscriptionInput,
 };
 
 /// Records what the engine did to a backend. Cloneable handle so tests
@@ -65,7 +66,7 @@ impl TranscriptionBackend for MockBackend {
     fn start(&mut self, _config: BackendConfig) -> Result<BackendHandle, BackendError> {
         self.state.start_count.fetch_add(1, Ordering::Relaxed);
 
-        let (audio_tx, _audio_rx) = mpsc::sync_channel(8);
+        let (audio_tx, _audio_rx) = mpsc::sync_channel::<TranscriptionInput>(8);
         let (event_tx, event_rx) = mpsc::channel();
 
         // Stash the event_tx so tests can push events through it.
@@ -86,7 +87,7 @@ impl TranscriptionBackend for MockBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::ModelChoice;
+    use crate::backend::{ModelChoice, SegmentationMode};
     #[cfg(feature = "whisper")]
     use crate::model::WhisperModel;
 
@@ -100,6 +101,7 @@ mod tests {
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
             vad_threshold: crate::VAD_THRESHOLD_DEFAULT,
+            segmentation_mode: SegmentationMode::default(),
         }
     }
 

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use sherpa_onnx::{OfflineRecognizer, OnlineRecognizer};
 
-use crate::backend::{BackendError, TranscriptionEvent};
+use crate::backend::{BackendError, TranscriptionEvent, TranscriptionInput};
 use crate::init_event::InitEvent;
 use crate::sherpa_model::{self, SherpaModel};
 
@@ -136,7 +136,7 @@ pub(super) fn global_sherpa_host() -> Option<&'static Result<SherpaHost, Arc<Bac
 /// Parameters handed to the host worker for one transcription session.
 pub(super) struct SessionParams {
     pub cancel: Arc<std::sync::atomic::AtomicBool>,
-    pub audio_rx: mpsc::Receiver<Vec<f32>>,
+    pub audio_rx: mpsc::Receiver<TranscriptionInput>,
     pub event_tx: mpsc::Sender<TranscriptionEvent>,
     pub noise_gate_ratio: f32,
     /// Silero VAD threshold requested for this session (offline models only).

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -312,27 +312,38 @@ fn run_host_loop(
                         // rebuild the VAD before starting the session. The
                         // rebuild is ~50-100ms of ONNX model load — only
                         // happens when the slider value actually changed.
-                        let requested = params.vad_threshold;
-                        // Treat differences smaller than the slider step as
-                        // "same" to avoid pointless rebuilds from float drift.
-                        if (vad.current_threshold() - requested).abs()
-                            > VAD_THRESHOLD_REBUILD_EPSILON
-                        {
-                            tracing::info!(
-                                old = vad.current_threshold(),
-                                new = requested,
-                                "rebuilding Silero VAD with new threshold"
-                            );
-                            let vad_path = sherpa_model::silero_vad_path();
-                            match super::silero_vad::SherpaSileroVad::new(&vad_path, requested) {
-                                Ok(new_vad) => {
-                                    *vad = new_vad;
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        error = %e,
-                                        "VAD rebuild failed; reusing existing VAD"
-                                    );
+                        //
+                        // Skip the rebuild entirely when Auto Break mode is
+                        // selected — the Silero VAD is unused in that path
+                        // (the squelch gate drives segmentation), so paying
+                        // the rebuild cost is pure waste. The rebuild still
+                        // runs on the next Vad-mode session if the threshold
+                        // has drifted.
+                        if params.segmentation_mode == crate::backend::SegmentationMode::Vad {
+                            let requested = params.vad_threshold;
+                            // Treat differences smaller than the slider step
+                            // as "same" to avoid pointless rebuilds from
+                            // float drift.
+                            if (vad.current_threshold() - requested).abs()
+                                > VAD_THRESHOLD_REBUILD_EPSILON
+                            {
+                                tracing::info!(
+                                    old = vad.current_threshold(),
+                                    new = requested,
+                                    "rebuilding Silero VAD with new threshold"
+                                );
+                                let vad_path = sherpa_model::silero_vad_path();
+                                match super::silero_vad::SherpaSileroVad::new(&vad_path, requested)
+                                {
+                                    Ok(new_vad) => {
+                                        *vad = new_vad;
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            error = %e,
+                                            "VAD rebuild failed; reusing existing VAD"
+                                        );
+                                    }
                                 }
                             }
                         }

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -139,10 +139,15 @@ pub(super) struct SessionParams {
     pub audio_rx: mpsc::Receiver<TranscriptionInput>,
     pub event_tx: mpsc::Sender<TranscriptionEvent>,
     pub noise_gate_ratio: f32,
-    /// Silero VAD threshold requested for this session (offline models only).
+    /// Silero VAD threshold requested for this session (offline VAD mode only).
     /// The worker rebuilds the VAD if this differs from the currently-held
-    /// VAD's threshold.
+    /// VAD's threshold. Ignored when `segmentation_mode == AutoBreak`.
     pub vad_threshold: f32,
+    /// Which segmentation engine drives utterance boundaries. Validated
+    /// against the model kind at the top of the session runner — streaming
+    /// online models reject `AutoBreak` (Task 4), and the offline session
+    /// loop dispatches VAD vs Auto Break on this field (Task 11).
+    pub segmentation_mode: crate::backend::SegmentationMode,
 }
 
 /// Commands sent to the host worker thread.

--- a/crates/sdr-transcription/src/backends/sherpa/mod.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/mod.rs
@@ -129,6 +129,7 @@ impl TranscriptionBackend for SherpaBackend {
             event_tx,
             noise_gate_ratio: config.noise_gate_ratio,
             vad_threshold: config.vad_threshold,
+            segmentation_mode: config.segmentation_mode,
         })?;
 
         tracing::info!("sherpa backend session requested");

--- a/crates/sdr-transcription/src/backends/sherpa/mod.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/mod.rs
@@ -33,7 +33,7 @@ pub use silero_vad::SherpaSileroVad;
 
 /// ONNX Runtime execution provider string passed to sherpa-onnx
 /// **recognizer** configs built by this backend (online streaming,
-/// offline Moonshine, offline NeMo Parakeet). The Silero VAD stays
+/// offline Moonshine, offline `NeMo` Parakeet). The Silero VAD stays
 /// on CPU regardless — see `silero_vad.rs` for that rationale.
 ///
 /// Selected at compile time by the `sherpa-cpu` / `sherpa-cuda` cargo

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -17,7 +17,7 @@ use sherpa_onnx::{
     OfflineTransducerModelConfig,
 };
 
-use crate::backend::TranscriptionEvent;
+use crate::backend::{TranscriptionEvent, TranscriptionInput};
 use crate::sherpa_model::{self, ModelFilePaths, SherpaModel};
 use crate::vad::VoiceActivityDetector;
 use crate::{denoise, resampler};
@@ -179,10 +179,14 @@ pub(super) fn run_session(
             return;
         }
 
-        let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
+        let input = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
             Ok(d) => d,
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+        let interleaved = match input {
+            TranscriptionInput::Samples(s) => s,
+            TranscriptionInput::SquelchOpened | TranscriptionInput::SquelchClosed => continue,
         };
 
         // Resample 48 kHz stereo → 16 kHz mono.
@@ -194,7 +198,9 @@ pub(super) fn run_session(
                 drain_vad_on_exit(recognizer, vad, &event_tx);
                 return;
             }
-            resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
+            if let TranscriptionInput::Samples(s) = extra {
+                resampler::downsample_stereo_to_mono_16k(&s, &mut mono_buf);
+            }
         }
 
         if mono_buf.is_empty() {

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -42,6 +42,27 @@ const SHERPA_NUM_THREADS: i32 = 1;
 /// Mirrors the upstream `rust-api-examples/examples/nemo_parakeet.rs` example.
 const NEMO_TRANSDUCER_MODEL_TYPE: &str = "nemo_transducer";
 
+/// Squelch openings shorter than this are treated as noise spikes and
+/// produce no segment. Chosen to exclude sub-syllable blips while still
+/// catching short single-word transmissions ("copy").
+const AUTO_BREAK_MIN_OPEN_MS: u32 = 100;
+
+/// Continue buffering audio for this long after the squelch closes, so
+/// the last syllable isn't chopped by a tight squelch-close timing.
+/// Covers typical `PowerSquelch` fall time plus ~100 ms of spoken tail.
+const AUTO_BREAK_TAIL_MS: u32 = 200;
+
+/// Segments shorter than this are discarded instead of decoded.
+/// Moonshine and Parakeet both hallucinate on sub-word fragments, so
+/// dropping them is an accuracy improvement, not a loss.
+const AUTO_BREAK_MIN_SEGMENT_MS: u32 = 400;
+
+/// Safety cap: if squelch stays open longer than this, flush anyway.
+/// Protects against pathological stuck-open situations (bad auto-squelch,
+/// carrier jam, band opening) that would otherwise cause unbounded
+/// memory growth in the segment buffer.
+const AUTO_BREAK_MAX_SEGMENT_MS: u32 = 30_000;
+
 /// Build the `OfflineRecognizerConfig` for a Moonshine v1 model.
 ///
 /// k2-fsa's int8 Moonshine releases use the v1 layout with five files:

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -168,10 +168,27 @@ pub(super) fn build_nemo_transducer_recognizer_config(
     }
 }
 
-/// One offline transcription session. Feeds audio through the VAD,
-/// batch-decodes each detected speech segment, and emits `Text` events.
-/// Never emits `Partial`.
+/// One offline transcription session. Dispatches to the VAD or Auto Break
+/// implementation based on `params.segmentation_mode`.
 pub(super) fn run_session(
+    recognizer: &OfflineRecognizer,
+    vad: &mut SherpaSileroVad,
+    params: SessionParams,
+) {
+    match params.segmentation_mode {
+        crate::backend::SegmentationMode::Vad => {
+            run_session_vad(recognizer, vad, params);
+        }
+        crate::backend::SegmentationMode::AutoBreak => {
+            run_session_auto_break(recognizer, params);
+        }
+    }
+}
+
+/// VAD-driven offline session (unchanged from the pre-Auto-Break behavior).
+/// Feeds audio through the VAD, batch-decodes each detected speech segment,
+/// and emits `Text` events. Never emits `Partial`.
+fn run_session_vad(
     recognizer: &OfflineRecognizer,
     vad: &mut SherpaSileroVad,
     params: SessionParams,
@@ -270,6 +287,260 @@ fn decode_segment(
     }
 }
 
+/// The three possible outcomes of a `HoldingOff` tail-timer expiration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FlushDecision {
+    /// Buffer is a valid utterance — decode and emit.
+    Decode,
+    /// Buffer is too short to decode reliably (sub-word fragment).
+    DiscardShort,
+    /// Buffer is too short to even be a real transmission (phantom open).
+    DiscardPhantom,
+}
+
+/// Internal state of the Auto Break segmentation machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutoBreakState {
+    /// No transmission in progress. Samples are discarded.
+    Idle,
+    /// Squelch is open, buffering the active transmission.
+    Recording,
+    /// Squelch recently closed; still buffering trailing audio until
+    /// the tail timer expires, at which point we flush.
+    HoldingOff,
+}
+
+/// Pure state machine for Auto Break segmentation. Holds no I/O handles
+/// so it can be unit-tested. The real session loop owns one of these
+/// and drives it from the `TranscriptionInput` channel + a `recv_timeout`
+/// tail timer — on flush, the loop calls `take_buffer` and hands the
+/// audio off to `decode_segment`.
+struct AutoBreakMachine {
+    state: AutoBreakState,
+    /// Accumulated stereo interleaved f32 samples at 48 kHz.
+    buffer: Vec<f32>,
+}
+
+impl AutoBreakMachine {
+    fn new() -> Self {
+        Self {
+            state: AutoBreakState::Idle,
+            buffer: Vec::new(),
+        }
+    }
+
+    /// Current buffer duration in ms, assuming 48 kHz stereo interleaved.
+    #[allow(clippy::cast_possible_truncation)]
+    fn buffer_duration_ms(&self) -> u32 {
+        let frames = self.buffer.len() / 2;
+        ((frames as u64 * 1000) / 48_000) as u32
+    }
+
+    fn on_samples(&mut self, samples: &[f32]) {
+        if matches!(
+            self.state,
+            AutoBreakState::Recording | AutoBreakState::HoldingOff
+        ) {
+            self.buffer.extend_from_slice(samples);
+        }
+        // Idle: discard
+    }
+
+    fn on_squelch_opened(&mut self) {
+        match self.state {
+            AutoBreakState::Idle => {
+                self.buffer.clear();
+                self.state = AutoBreakState::Recording;
+            }
+            AutoBreakState::HoldingOff => {
+                // Hysteresis blip — cancel deferred flush, stay with same buffer.
+                self.state = AutoBreakState::Recording;
+            }
+            AutoBreakState::Recording => {
+                // Redundant; ignore.
+            }
+        }
+    }
+
+    fn on_squelch_closed(&mut self) {
+        if matches!(self.state, AutoBreakState::Recording) {
+            self.state = AutoBreakState::HoldingOff;
+        }
+    }
+
+    /// Called when the tail timer expires while in `HoldingOff`. Returns
+    /// the flush decision based on the buffer duration, and resets to
+    /// `Idle`. Returns `None` if called outside `HoldingOff` (no-op).
+    fn on_tail_timeout(&mut self) -> Option<FlushDecision> {
+        if !matches!(self.state, AutoBreakState::HoldingOff) {
+            return None;
+        }
+        let duration = self.buffer_duration_ms();
+        let decision = if duration < AUTO_BREAK_MIN_OPEN_MS {
+            FlushDecision::DiscardPhantom
+        } else if duration < AUTO_BREAK_MIN_SEGMENT_MS {
+            FlushDecision::DiscardShort
+        } else {
+            FlushDecision::Decode
+        };
+        // Note: the caller is responsible for taking the buffer for
+        // decoding AFTER this call, if the decision is Decode.
+        // We reset to Idle here but leave the buffer alone so the
+        // caller can still `take_buffer` for Decode cases.
+        self.state = AutoBreakState::Idle;
+        if !matches!(decision, FlushDecision::Decode) {
+            self.buffer.clear();
+        }
+        Some(decision)
+    }
+
+    /// Take ownership of the current buffer, leaving the machine's
+    /// internal buffer empty. Used by the session loop to hand audio
+    /// to the recognizer on flush.
+    fn take_buffer(&mut self) -> Vec<f32> {
+        std::mem::take(&mut self.buffer)
+    }
+
+    /// Return current state (used by the session loop to decide
+    /// whether to trigger the max-segment safety flush).
+    fn state(&self) -> AutoBreakState {
+        self.state
+    }
+
+    /// Force-reset to Idle and clear the buffer. Used by the
+    /// max-segment safety flush path: the session loop takes the
+    /// buffer via `take_buffer` and then calls `reset_after_force_flush`.
+    fn reset_after_force_flush(&mut self) {
+        self.state = AutoBreakState::Idle;
+    }
+}
+
+/// Auto Break offline session. Drives an `AutoBreakMachine` from the
+/// transcription input channel and a hold-off timer implemented via
+/// `recv_timeout`. Buffers stereo 48 kHz interleaved samples during
+/// `Recording` / `HoldingOff` states; on flush, resamples to 16 kHz mono,
+/// applies the spectral denoiser, and decodes through the recognizer.
+fn run_session_auto_break(recognizer: &OfflineRecognizer, params: SessionParams) {
+    let SessionParams {
+        cancel,
+        audio_rx,
+        event_tx,
+        noise_gate_ratio,
+        vad_threshold: _,
+        segmentation_mode: _,
+    } = params;
+
+    if event_tx.send(TranscriptionEvent::Ready).is_err() {
+        return;
+    }
+
+    let tail_duration = std::time::Duration::from_millis(u64::from(AUTO_BREAK_TAIL_MS));
+    let mut machine = AutoBreakMachine::new();
+    // When Some, we're in HoldingOff and waiting until this instant before flushing.
+    let mut pending_flush_deadline: Option<std::time::Instant> = None;
+
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            tracing::info!("sherpa Auto Break session cancelled");
+            return;
+        }
+
+        // Choose recv timeout: if we're holding off, use the remaining
+        // tail duration so we wake up on time to flush. Otherwise use
+        // the standard audio polling interval so we can check `cancel`.
+        let timeout = match pending_flush_deadline {
+            Some(deadline) => deadline
+                .checked_duration_since(std::time::Instant::now())
+                .unwrap_or_else(|| std::time::Duration::from_millis(0)),
+            None => AUDIO_RECV_TIMEOUT,
+        };
+
+        match audio_rx.recv_timeout(timeout) {
+            Ok(crate::backend::TranscriptionInput::Samples(samples)) => {
+                machine.on_samples(&samples);
+                // Max-segment safety check: if buffer has grown past the
+                // cap, force-flush regardless of squelch state.
+                if !matches!(machine.state(), AutoBreakState::Idle)
+                    && machine.buffer_duration_ms() >= AUTO_BREAK_MAX_SEGMENT_MS
+                {
+                    tracing::warn!(
+                        ms = machine.buffer_duration_ms(),
+                        cap = AUTO_BREAK_MAX_SEGMENT_MS,
+                        "Auto Break buffer exceeded max segment cap — forcing flush (check squelch configuration)"
+                    );
+                    let stereo_buf = machine.take_buffer();
+                    machine.reset_after_force_flush();
+                    flush_auto_break_segment(
+                        recognizer,
+                        &stereo_buf,
+                        noise_gate_ratio,
+                        &event_tx,
+                    );
+                    pending_flush_deadline = None;
+                }
+            }
+            Ok(crate::backend::TranscriptionInput::SquelchOpened) => {
+                machine.on_squelch_opened();
+                pending_flush_deadline = None;
+            }
+            Ok(crate::backend::TranscriptionInput::SquelchClosed) => {
+                machine.on_squelch_closed();
+                pending_flush_deadline = Some(std::time::Instant::now() + tail_duration);
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Check if the tail deadline has expired.
+                if let Some(deadline) = pending_flush_deadline
+                    && std::time::Instant::now() >= deadline
+                {
+                    match machine.on_tail_timeout() {
+                        Some(FlushDecision::Decode) => {
+                            let stereo_buf = machine.take_buffer();
+                            flush_auto_break_segment(
+                                recognizer,
+                                &stereo_buf,
+                                noise_gate_ratio,
+                                &event_tx,
+                            );
+                        }
+                        Some(FlushDecision::DiscardPhantom) => {
+                            tracing::debug!("Auto Break: discarded phantom open");
+                        }
+                        Some(FlushDecision::DiscardShort) => {
+                            tracing::debug!("Auto Break: discarded sub-min segment");
+                        }
+                        None => {
+                            // Not in HoldingOff anymore — nothing to do.
+                        }
+                    }
+                    pending_flush_deadline = None;
+                }
+                // Otherwise just loop back and recv again.
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                tracing::info!("sherpa Auto Break session ended (channel disconnected)");
+                return;
+            }
+        }
+    }
+}
+
+/// Resample + denoise + decode a completed Auto Break segment, emit
+/// a `Text` event if the recognizer produced non-empty output.
+fn flush_auto_break_segment(
+    recognizer: &OfflineRecognizer,
+    stereo_buf: &[f32],
+    noise_gate_ratio: f32,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+) {
+    if stereo_buf.is_empty() {
+        return;
+    }
+    let mut mono_buf: Vec<f32> = Vec::with_capacity(stereo_buf.len() / 6);
+    resampler::downsample_stereo_to_mono_16k(stereo_buf, &mut mono_buf);
+    denoise::spectral_denoise(&mut mono_buf, noise_gate_ratio);
+    decode_segment(recognizer, &mono_buf, event_tx);
+}
+
 /// Flush the VAD on session exit and drain every remaining segment —
 /// including any in-flight utterance Silero hadn't yet finalized.
 ///
@@ -289,4 +560,126 @@ fn drain_vad_on_exit(
         decode_segment(recognizer, &segment, event_tx);
     }
     vad.reset();
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct AutoBreakFlushCounts {
+    decodes_flushed: u32,
+    discarded_short: u32,
+    discarded_phantom: u32,
+}
+
+#[cfg(test)]
+impl AutoBreakFlushCounts {
+    fn record(&mut self, decision: FlushDecision) {
+        match decision {
+            FlushDecision::Decode => self.decodes_flushed += 1,
+            FlushDecision::DiscardShort => self.discarded_short += 1,
+            FlushDecision::DiscardPhantom => self.discarded_phantom += 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod auto_break_tests {
+    use super::*;
+
+    // 48 kHz stereo interleaved → a `ms` duration requires `frames = 48 * ms`
+    // and `2 * frames` samples.
+    fn samples_for_ms(ms: u32) -> Vec<f32> {
+        let frames = (48 * ms) as usize;
+        vec![0.5_f32; frames * 2]
+    }
+
+    #[test]
+    fn clean_utterance_produces_one_decode() {
+        let mut machine = AutoBreakMachine::new();
+        let mut counts = AutoBreakFlushCounts::default();
+
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(1_000));
+        machine.on_squelch_closed();
+        if let Some(decision) = machine.on_tail_timeout() {
+            counts.record(decision);
+        }
+
+        assert_eq!(counts.decodes_flushed, 1);
+        assert_eq!(counts.discarded_short, 0);
+        assert_eq!(counts.discarded_phantom, 0);
+    }
+
+    #[test]
+    fn hysteresis_blip_single_utterance() {
+        let mut machine = AutoBreakMachine::new();
+        let mut counts = AutoBreakFlushCounts::default();
+
+        // Open, record, close, re-open before tail timeout, record more, close, timeout.
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(500));
+        machine.on_squelch_closed();
+        // Hysteresis blip: squelch re-opens before tail fires.
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(500));
+        machine.on_squelch_closed();
+        if let Some(decision) = machine.on_tail_timeout() {
+            counts.record(decision);
+        }
+
+        // One decode, not two — the blip should be absorbed into a single utterance.
+        assert_eq!(counts.decodes_flushed, 1);
+    }
+
+    #[test]
+    fn phantom_open_below_min_open_ms_discarded() {
+        let mut machine = AutoBreakMachine::new();
+        let mut counts = AutoBreakFlushCounts::default();
+
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(50)); // < MIN_OPEN_MS (100)
+        machine.on_squelch_closed();
+        if let Some(decision) = machine.on_tail_timeout() {
+            counts.record(decision);
+        }
+
+        assert_eq!(counts.decodes_flushed, 0);
+        assert_eq!(counts.discarded_phantom, 1);
+    }
+
+    #[test]
+    fn sub_min_segment_discarded() {
+        let mut machine = AutoBreakMachine::new();
+        let mut counts = AutoBreakFlushCounts::default();
+
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(300)); // > MIN_OPEN (100) but < MIN_SEGMENT (400)
+        machine.on_squelch_closed();
+        if let Some(decision) = machine.on_tail_timeout() {
+            counts.record(decision);
+        }
+
+        assert_eq!(counts.decodes_flushed, 0);
+        assert_eq!(counts.discarded_short, 1);
+    }
+
+    #[test]
+    fn max_segment_safety_cap_triggers_flush() {
+        let mut machine = AutoBreakMachine::new();
+
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(31_000)); // > MAX_SEGMENT_MS (30_000)
+
+        // At this point the machine should have buffer_duration_ms >= MAX,
+        // so the external loop (or a check inside the state machine) should
+        // treat it as a force-flush condition. We verify via the public API:
+        assert!(machine.buffer_duration_ms() >= AUTO_BREAK_MAX_SEGMENT_MS);
+        // The state machine itself doesn't flush on sample receipt — the
+        // session loop driver checks the buffer duration after each
+        // `on_samples` call and force-flushes. Test the take_buffer path.
+        let buf = machine.take_buffer();
+        assert!(
+            !buf.is_empty(),
+            "take_buffer should return the captured samples"
+        );
+    }
 }

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -470,12 +470,7 @@ fn run_session_auto_break(recognizer: &OfflineRecognizer, params: SessionParams)
                     );
                     let stereo_buf = machine.take_buffer();
                     machine.reset_after_force_flush();
-                    flush_auto_break_segment(
-                        recognizer,
-                        &stereo_buf,
-                        noise_gate_ratio,
-                        &event_tx,
-                    );
+                    flush_auto_break_segment(recognizer, &stereo_buf, noise_gate_ratio, &event_tx);
                     pending_flush_deadline = None;
                 }
             }

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -345,6 +345,16 @@ struct AutoBreakMachine {
     state: AutoBreakState,
     /// Accumulated stereo interleaved f32 samples at 48 kHz.
     buffer: Vec<f32>,
+    /// Snapshot of `buffer.len()` at the instant the squelch transitioned
+    /// from `Recording` → `HoldingOff`. Used by `on_tail_timeout` to
+    /// evaluate the phantom/short/decode thresholds against the *actual*
+    /// transmission length, NOT the tail-extended buffer — otherwise a
+    /// 200–399 ms transmission would cross the 400 ms `MIN_SEGMENT`
+    /// threshold once the fixed 200 ms tail is included, and a sub-100 ms
+    /// phantom open would cross `MIN_OPEN_MS`. Semantic meaning only
+    /// applies during `HoldingOff`; reset to 0 in every other state
+    /// transition.
+    closed_len_samples: usize,
 }
 
 impl AutoBreakMachine {
@@ -352,15 +362,43 @@ impl AutoBreakMachine {
         Self {
             state: AutoBreakState::Idle,
             buffer: Vec::new(),
+            closed_len_samples: 0,
         }
     }
 
-    /// Current buffer duration in ms, assuming the wire format is
+    /// Raw buffer duration in ms, assuming the wire format is
     /// `TRANSCRIPTION_INPUT_CHANNELS`-interleaved f32 at
     /// `TRANSCRIPTION_INPUT_SAMPLE_RATE_HZ`.
+    ///
+    /// Used by the max-segment safety cap check in the session loop
+    /// (which cares about actual buffered memory, not semantic
+    /// transmission length). For the phantom/short/decode decisions in
+    /// `on_tail_timeout` and the drain-on-exit helper, use
+    /// [`Self::transmission_duration_ms`] instead.
     #[allow(clippy::cast_possible_truncation)]
     fn buffer_duration_ms(&self) -> u32 {
         let frames = self.buffer.len() / TRANSCRIPTION_INPUT_CHANNELS;
+        ((frames as u64 * 1000) / TRANSCRIPTION_INPUT_SAMPLE_RATE_HZ) as u32
+    }
+
+    /// Semantic "how long was the transmission" in ms — the length of
+    /// the audio the recognizer SHOULD see as one utterance, ignoring
+    /// the tail-capture window that's applied after the squelch closes.
+    ///
+    ///   - `Idle`: 0 (no transmission)
+    ///   - `Recording`: full buffer (the close event hasn't fired yet
+    ///     so the snapshot doesn't exist; the current buffer IS the
+    ///     transmission length so far)
+    ///   - `HoldingOff`: pre-close snapshot (`closed_len_samples`) so
+    ///     the 200 ms tail doesn't inflate the count past a threshold
+    #[allow(clippy::cast_possible_truncation)]
+    fn transmission_duration_ms(&self) -> u32 {
+        let samples = match self.state {
+            AutoBreakState::Idle => 0,
+            AutoBreakState::Recording => self.buffer.len(),
+            AutoBreakState::HoldingOff => self.closed_len_samples,
+        };
+        let frames = samples / TRANSCRIPTION_INPUT_CHANNELS;
         ((frames as u64 * 1000) / TRANSCRIPTION_INPUT_SAMPLE_RATE_HZ) as u32
     }
 
@@ -378,10 +416,16 @@ impl AutoBreakMachine {
         match self.state {
             AutoBreakState::Idle => {
                 self.buffer.clear();
+                self.closed_len_samples = 0;
                 self.state = AutoBreakState::Recording;
             }
             AutoBreakState::HoldingOff => {
-                // Hysteresis blip — cancel deferred flush, stay with same buffer.
+                // Hysteresis blip — cancel deferred flush, stay with
+                // the same buffer. Clear the snapshot so the NEXT
+                // close event captures the full "has been continuously
+                // open since this blip" length rather than inheriting
+                // a stale value from the previous close.
+                self.closed_len_samples = 0;
                 self.state = AutoBreakState::Recording;
             }
             AutoBreakState::Recording => {
@@ -392,18 +436,26 @@ impl AutoBreakMachine {
 
     fn on_squelch_closed(&mut self) {
         if matches!(self.state, AutoBreakState::Recording) {
+            // Snapshot buffer length at the moment the squelch closed.
+            // `on_tail_timeout` uses this to evaluate discard
+            // thresholds against the actual transmission length, not
+            // the tail-extended buffer length.
+            self.closed_len_samples = self.buffer.len();
             self.state = AutoBreakState::HoldingOff;
         }
     }
 
     /// Called when the tail timer expires while in `HoldingOff`. Returns
-    /// the flush decision based on the buffer duration, and resets to
-    /// `Idle`. Returns `None` if called outside `HoldingOff` (no-op).
+    /// the flush decision based on the *pre-close* transmission length,
+    /// and resets to `Idle`. Returns `None` if called outside
+    /// `HoldingOff` (no-op).
     fn on_tail_timeout(&mut self) -> Option<FlushDecision> {
         if !matches!(self.state, AutoBreakState::HoldingOff) {
             return None;
         }
-        let duration = self.buffer_duration_ms();
+        // Evaluate against the snapshot, not the current (tail-extended)
+        // buffer. See the `closed_len_samples` docstring for why.
+        let duration = self.transmission_duration_ms();
         let decision = if duration < AUTO_BREAK_MIN_OPEN_MS {
             FlushDecision::DiscardPhantom
         } else if duration < AUTO_BREAK_MIN_SEGMENT_MS {
@@ -412,10 +464,14 @@ impl AutoBreakMachine {
             FlushDecision::Decode
         };
         // Note: the caller is responsible for taking the buffer for
-        // decoding AFTER this call, if the decision is Decode.
-        // We reset to Idle here but leave the buffer alone so the
-        // caller can still `take_buffer` for Decode cases.
+        // decoding AFTER this call, if the decision is Decode. The
+        // caller gets the FULL (tail-extended) buffer even though the
+        // decision was made against the pre-close snapshot — that's
+        // deliberate: the 200 ms tail is captured audio we want the
+        // recognizer to see, we just don't want it counted toward the
+        // length gate.
         self.state = AutoBreakState::Idle;
+        self.closed_len_samples = 0;
         if !matches!(decision, FlushDecision::Decode) {
             self.buffer.clear();
         }
@@ -435,11 +491,27 @@ impl AutoBreakMachine {
         self.state
     }
 
-    /// Force-reset to Idle and clear the buffer. Used by the
-    /// max-segment safety flush path: the session loop takes the
-    /// buffer via `take_buffer` and then calls `reset_after_force_flush`.
-    fn reset_after_force_flush(&mut self) {
-        self.state = AutoBreakState::Idle;
+    /// Clear the buffer and transition to `next_state` after a forced
+    /// flush. Used by the max-segment safety cap path: the session loop
+    /// takes the buffer via `take_buffer`, calls this to resume in the
+    /// appropriate state, and then hands the taken buffer to the
+    /// recognizer.
+    ///
+    /// **The caller chooses the next state deliberately**:
+    ///
+    ///   - Pass `AutoBreakState::Recording` from the max-segment safety
+    ///     cap in the session loop's `Samples` handler — the squelch is
+    ///     still open, the transmission is continuing, and we want the
+    ///     30 s cap to SPLIT the transmission rather than truncate it.
+    ///     Passing `Idle` here would strand the remainder of the
+    ///     transmission until the next close→open edge, silently
+    ///     dropping everything after the 30 s mark.
+    ///   - Pass `AutoBreakState::Idle` from shutdown/drain paths where
+    ///     the session is ending.
+    fn reset_after_force_flush(&mut self, next_state: AutoBreakState) {
+        self.buffer.clear();
+        self.closed_len_samples = 0;
+        self.state = next_state;
     }
 }
 
@@ -489,6 +561,14 @@ fn run_session_auto_break(recognizer: &OfflineRecognizer, params: SessionParams)
                 machine.on_samples(&samples);
                 // Max-segment safety check: if buffer has grown past the
                 // cap, force-flush regardless of squelch state.
+                //
+                // Resume in `Recording`, NOT `Idle`. The controller only
+                // emits `SquelchOpened` on state transitions, so if the
+                // carrier stays up past the 30 s cap and we transitioned
+                // to Idle, the remainder of that same transmission would
+                // be silently dropped until the next close→open edge.
+                // Staying in Recording splits a long transmission into
+                // 30 s chunks rather than truncating it.
                 if !matches!(machine.state(), AutoBreakState::Idle)
                     && machine.buffer_duration_ms() >= AUTO_BREAK_MAX_SEGMENT_MS
                 {
@@ -498,7 +578,7 @@ fn run_session_auto_break(recognizer: &OfflineRecognizer, params: SessionParams)
                         "Auto Break buffer exceeded max segment cap — forcing flush (check squelch configuration)"
                     );
                     let stereo_buf = machine.take_buffer();
-                    machine.reset_after_force_flush();
+                    machine.reset_after_force_flush(AutoBreakState::Recording);
                     flush_auto_break_segment(recognizer, &stereo_buf, noise_gate_ratio, &event_tx);
                     pending_flush_deadline = None;
                 }
@@ -588,7 +668,11 @@ fn drain_auto_break_on_exit(
         return;
     }
 
-    let duration = machine.buffer_duration_ms();
+    // Use `transmission_duration_ms` here so the pre-close snapshot
+    // governs the discard decision when we're caught in HoldingOff —
+    // same reasoning as `on_tail_timeout`. In Recording state the
+    // snapshot is unused and this falls back to the full buffer length.
+    let duration = machine.transmission_duration_ms();
     if duration < AUTO_BREAK_MIN_OPEN_MS {
         tracing::debug!(
             ms = duration,
@@ -607,7 +691,9 @@ fn drain_auto_break_on_exit(
         let stereo_buf = machine.take_buffer();
         flush_auto_break_segment(recognizer, &stereo_buf, noise_gate_ratio, event_tx);
     }
-    machine.reset_after_force_flush();
+    // Session is ending — go back to Idle, not Recording, so a fresh
+    // session starts from a clean state.
+    machine.reset_after_force_flush(AutoBreakState::Idle);
 }
 
 /// Flush the VAD on session exit and drain every remaining segment —
@@ -753,5 +839,105 @@ mod auto_break_tests {
             !buf.is_empty(),
             "take_buffer should return the captured samples"
         );
+    }
+
+    #[test]
+    fn tail_extension_does_not_inflate_discard_decision() {
+        // Regression: a 300 ms transmission + 200 ms of tail-capture
+        // samples (simulating the ~AUTO_BREAK_TAIL_MS of audio the
+        // session loop buffers between SquelchClosed and the tail
+        // timer expiration) pushes the raw buffer duration to 500 ms,
+        // which would cross the 400 ms MIN_SEGMENT threshold. The
+        // decision MUST still be DiscardShort because the actual
+        // transmission was only 300 ms.
+        let mut machine = AutoBreakMachine::new();
+        let mut counts = AutoBreakFlushCounts::default();
+
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(300)); // 300 ms of open transmission
+        machine.on_squelch_closed(); // Snapshot should fire here
+        machine.on_samples(&samples_for_ms(200)); // 200 ms tail during HoldingOff
+
+        // Raw buffer is now 500 ms, BUT transmission_duration_ms
+        // should be the pre-close snapshot of 300 ms.
+        assert_eq!(
+            machine.buffer_duration_ms(),
+            500,
+            "raw buffer includes the tail-capture audio"
+        );
+        assert_eq!(
+            machine.transmission_duration_ms(),
+            300,
+            "transmission duration reflects only the pre-close samples"
+        );
+
+        if let Some(decision) = machine.on_tail_timeout() {
+            counts.record(decision);
+        }
+
+        assert_eq!(
+            counts.decodes_flushed, 0,
+            "sub-min transmission must NOT be decoded even though tail-extended buffer crossed the threshold"
+        );
+        assert_eq!(counts.discarded_short, 1);
+    }
+
+    #[test]
+    fn phantom_open_with_tail_does_not_cross_min_open_threshold() {
+        // Matching regression for the phantom-open lower bound. A 50 ms
+        // open + 200 ms tail = 250 ms raw buffer, which would cross
+        // MIN_OPEN_MS (100). The decision MUST still be DiscardPhantom.
+        let mut machine = AutoBreakMachine::new();
+        let mut counts = AutoBreakFlushCounts::default();
+
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(50)); // 50 ms open (phantom)
+        machine.on_squelch_closed();
+        machine.on_samples(&samples_for_ms(200)); // 200 ms tail
+
+        assert_eq!(machine.transmission_duration_ms(), 50);
+        assert!(machine.buffer_duration_ms() >= AUTO_BREAK_MIN_OPEN_MS);
+
+        if let Some(decision) = machine.on_tail_timeout() {
+            counts.record(decision);
+        }
+
+        assert_eq!(counts.decodes_flushed, 0);
+        assert_eq!(
+            counts.discarded_phantom, 1,
+            "phantom open must still be discarded even with tail-inflated buffer"
+        );
+    }
+
+    #[test]
+    fn max_segment_safety_flush_resumes_recording_not_idle() {
+        // Regression: after the 30 s safety cap fires on a carrier that
+        // stays open, the state machine MUST resume in Recording (so
+        // subsequent samples continue to buffer and the next cap splits
+        // the transmission) rather than Idle (which would silently drop
+        // all samples until the next close→open edge that never comes).
+        let mut machine = AutoBreakMachine::new();
+        machine.on_squelch_opened();
+        machine.on_samples(&samples_for_ms(31_000)); // trigger safety cap
+
+        // Simulate the session loop's force-flush path.
+        let _ = machine.take_buffer();
+        machine.reset_after_force_flush(AutoBreakState::Recording);
+
+        assert_eq!(
+            machine.state(),
+            AutoBreakState::Recording,
+            "safety cap must resume in Recording to split a long transmission"
+        );
+        assert_eq!(
+            machine.buffer_duration_ms(),
+            0,
+            "buffer must be empty after reset"
+        );
+
+        // And subsequent samples should still be captured (proving the
+        // resume state is effective, not just nominal).
+        machine.on_samples(&samples_for_ms(1_000));
+        assert_eq!(machine.buffer_duration_ms(), 1_000);
     }
 }

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -161,6 +161,7 @@ pub(super) fn run_session(
         event_tx,
         noise_gate_ratio,
         vad_threshold: _,
+        segmentation_mode: _,
     } = params;
 
     // Clear any residual state from a previous session.

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -654,11 +654,14 @@ impl AutoBreakFlushCounts {
 mod auto_break_tests {
     use super::*;
 
-    // 48 kHz stereo interleaved → a `ms` duration requires `frames = 48 * ms`
-    // and `2 * frames` samples.
+    // Build a test audio chunk corresponding to `ms` of stereo
+    // interleaved silence at the wire format rate. Uses the same
+    // constants the production buffer-duration math uses so the two
+    // stay in sync if the wire format ever changes.
     fn samples_for_ms(ms: u32) -> Vec<f32> {
-        let frames = (48 * ms) as usize;
-        vec![0.5_f32; frames * 2]
+        let frames_per_ms = (TRANSCRIPTION_INPUT_SAMPLE_RATE_HZ / 1000) as usize;
+        let frames = frames_per_ms * (ms as usize);
+        vec![0.5_f32; frames * TRANSCRIPTION_INPUT_CHANNELS]
     }
 
     #[test]

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -63,6 +63,32 @@ const AUTO_BREAK_MIN_SEGMENT_MS: u32 = 400;
 /// memory growth in the segment buffer.
 const AUTO_BREAK_MAX_SEGMENT_MS: u32 = 30_000;
 
+/// Sample rate of incoming `TranscriptionInput::Samples` frames. The DSP
+/// controller emits interleaved stereo f32 at 48 kHz (see
+/// `sdr-core::controller::process_iq_block`). Extracted as a named
+/// constant so the Auto Break buffer-duration math stays in sync if the
+/// wire format ever changes.
+const TRANSCRIPTION_INPUT_SAMPLE_RATE_HZ: u64 = 48_000;
+
+/// Channel count of incoming `TranscriptionInput::Samples` frames
+/// (interleaved stereo = 2 f32 values per audio frame).
+const TRANSCRIPTION_INPUT_CHANNELS: usize = 2;
+
+/// Target sample rate of the mono buffer handed to the recognizer, as a
+/// `usize` for capacity math. `SHERPA_SAMPLE_RATE_HZ` in `host.rs` is an
+/// `i32` that sherpa-onnx wants for its `accept_waveform` API; this
+/// mirror lives here in usize form so the capacity divisor below stays
+/// pure integer math without casts.
+const RECOGNIZER_SAMPLE_RATE_HZ_USIZE: usize = 16_000;
+
+/// Mono-16k capacity heuristic for converting a stereo-48k buffer. The
+/// target size is `len / CHANNELS / (48_000 / 16_000)` = `len / 6`, used
+/// as the `Vec::with_capacity` hint when resampling Auto Break segments.
+/// All integer math in usize to keep clippy's
+/// `cast_possible_truncation` quiet on 32-bit targets.
+const STEREO_48K_TO_MONO_16K_CAPACITY_DIVISOR: usize =
+    TRANSCRIPTION_INPUT_CHANNELS * (48_000 / RECOGNIZER_SAMPLE_RATE_HZ_USIZE);
+
 /// Build the `OfflineRecognizerConfig` for a Moonshine v1 model.
 ///
 /// k2-fsa's int8 Moonshine releases use the v1 layout with five files:
@@ -329,11 +355,13 @@ impl AutoBreakMachine {
         }
     }
 
-    /// Current buffer duration in ms, assuming 48 kHz stereo interleaved.
+    /// Current buffer duration in ms, assuming the wire format is
+    /// `TRANSCRIPTION_INPUT_CHANNELS`-interleaved f32 at
+    /// `TRANSCRIPTION_INPUT_SAMPLE_RATE_HZ`.
     #[allow(clippy::cast_possible_truncation)]
     fn buffer_duration_ms(&self) -> u32 {
-        let frames = self.buffer.len() / 2;
-        ((frames as u64 * 1000) / 48_000) as u32
+        let frames = self.buffer.len() / TRANSCRIPTION_INPUT_CHANNELS;
+        ((frames as u64 * 1000) / TRANSCRIPTION_INPUT_SAMPLE_RATE_HZ) as u32
     }
 
     fn on_samples(&mut self, samples: &[f32]) {
@@ -442,6 +470,7 @@ fn run_session_auto_break(recognizer: &OfflineRecognizer, params: SessionParams)
     loop {
         if cancel.load(Ordering::Relaxed) {
             tracing::info!("sherpa Auto Break session cancelled");
+            drain_auto_break_on_exit(recognizer, &mut machine, noise_gate_ratio, &event_tx);
             return;
         }
 
@@ -513,6 +542,7 @@ fn run_session_auto_break(recognizer: &OfflineRecognizer, params: SessionParams)
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 tracing::info!("sherpa Auto Break session ended (channel disconnected)");
+                drain_auto_break_on_exit(recognizer, &mut machine, noise_gate_ratio, &event_tx);
                 return;
             }
         }
@@ -530,10 +560,54 @@ fn flush_auto_break_segment(
     if stereo_buf.is_empty() {
         return;
     }
-    let mut mono_buf: Vec<f32> = Vec::with_capacity(stereo_buf.len() / 6);
+    let mut mono_buf: Vec<f32> =
+        Vec::with_capacity(stereo_buf.len() / STEREO_48K_TO_MONO_16K_CAPACITY_DIVISOR);
     resampler::downsample_stereo_to_mono_16k(stereo_buf, &mut mono_buf);
     denoise::spectral_denoise(&mut mono_buf, noise_gate_ratio);
     decode_segment(recognizer, &mono_buf, event_tx);
+}
+
+/// Finalize an Auto Break session on cancellation or channel disconnect.
+///
+/// Mirrors the `drain_vad_on_exit` semantics from the VAD path: if the
+/// user stops transcription mid-transmission (including the hard stop
+/// triggered by a demod mode change), whatever is in the buffer is
+/// either decoded as a legitimate final utterance or discarded as a
+/// sub-threshold fragment, applying the same length-gate rules the tail
+/// timeout path uses. Without this, the final utterance was silently
+/// thrown away whenever the session ended during `Recording` or
+/// `HoldingOff`.
+fn drain_auto_break_on_exit(
+    recognizer: &OfflineRecognizer,
+    machine: &mut AutoBreakMachine,
+    noise_gate_ratio: f32,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+) {
+    if matches!(machine.state(), AutoBreakState::Idle) {
+        // Nothing captured — nothing to drain.
+        return;
+    }
+
+    let duration = machine.buffer_duration_ms();
+    if duration < AUTO_BREAK_MIN_OPEN_MS {
+        tracing::debug!(
+            ms = duration,
+            "Auto Break: discarded phantom open on session exit"
+        );
+    } else if duration < AUTO_BREAK_MIN_SEGMENT_MS {
+        tracing::debug!(
+            ms = duration,
+            "Auto Break: discarded sub-min segment on session exit"
+        );
+    } else {
+        tracing::info!(
+            ms = duration,
+            "Auto Break: flushing in-flight segment on session exit"
+        );
+        let stereo_buf = machine.take_buffer();
+        flush_auto_break_segment(recognizer, &stereo_buf, noise_gate_ratio, event_tx);
+    }
+    machine.reset_after_force_flush();
 }
 
 /// Flush the VAD on session exit and drain every remaining segment —

--- a/crates/sdr-transcription/src/backends/sherpa/streaming.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/streaming.rs
@@ -75,8 +75,16 @@ pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) 
         event_tx,
         noise_gate_ratio,
         vad_threshold: _,
-        segmentation_mode: _,
+        segmentation_mode,
     } = params;
+
+    if segmentation_mode == crate::backend::SegmentationMode::AutoBreak {
+        let msg = "streaming Zipformer does not support Auto Break segmentation \
+                   — it has its own endpoint detection. Use SegmentationMode::Vad.";
+        tracing::error!(%msg);
+        let _ = event_tx.send(TranscriptionEvent::Error(msg.to_owned()));
+        return;
+    }
 
     let stream = recognizer.create_stream();
 

--- a/crates/sdr-transcription/src/backends/sherpa/streaming.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/streaming.rs
@@ -9,7 +9,7 @@ use std::sync::mpsc;
 
 use sherpa_onnx::{OnlineRecognizer, OnlineRecognizerConfig, OnlineStream};
 
-use crate::backend::TranscriptionEvent;
+use crate::backend::{TranscriptionEvent, TranscriptionInput};
 use crate::sherpa_model::{self, ModelFilePaths, SherpaModel};
 use crate::{denoise, resampler};
 
@@ -93,10 +93,14 @@ pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) 
             return;
         }
 
-        let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
+        let input = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
             Ok(d) => d,
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+        let interleaved = match input {
+            TranscriptionInput::Samples(s) => s,
+            TranscriptionInput::SquelchOpened | TranscriptionInput::SquelchClosed => continue,
         };
 
         mono_buf.clear();
@@ -107,7 +111,9 @@ pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) 
                 finalize_session(recognizer, &stream, &last_partial, &event_tx);
                 return;
             }
-            resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
+            if let TranscriptionInput::Samples(s) = extra {
+                resampler::downsample_stereo_to_mono_16k(&s, &mut mono_buf);
+            }
         }
 
         if mono_buf.is_empty() {

--- a/crates/sdr-transcription/src/backends/sherpa/streaming.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/streaming.rs
@@ -75,6 +75,7 @@ pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) 
         event_tx,
         noise_gate_ratio,
         vad_threshold: _,
+        segmentation_mode: _,
     } = params;
 
     let stream = recognizer.create_stream();

--- a/crates/sdr-transcription/src/backends/whisper.rs
+++ b/crates/sdr-transcription/src/backends/whisper.rs
@@ -13,7 +13,7 @@ use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextPar
 
 use crate::backend::{
     BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
-    TranscriptionEvent,
+    TranscriptionEvent, TranscriptionInput,
 };
 use crate::{denoise, model, resampler};
 
@@ -76,7 +76,7 @@ impl TranscriptionBackend for WhisperBackend {
 
         self.cancel.store(false, Ordering::Relaxed);
 
-        let (audio_tx, audio_rx) = mpsc::sync_channel(AUDIO_CHANNEL_CAPACITY);
+        let (audio_tx, audio_rx) = mpsc::sync_channel::<TranscriptionInput>(AUDIO_CHANNEL_CAPACITY);
         let (event_tx, event_rx) = mpsc::channel();
 
         let cancel = Arc::clone(&self.cancel);
@@ -129,7 +129,7 @@ impl TranscriptionBackend for WhisperBackend {
 /// * `silence_threshold` — RMS below which a chunk is skipped
 /// * `noise_gate_ratio` — spectral gate multiplier over noise floor
 fn run_worker(
-    audio_rx: &mpsc::Receiver<Vec<f32>>,
+    audio_rx: &mpsc::Receiver<TranscriptionInput>,
     event_tx: &mpsc::Sender<TranscriptionEvent>,
     cancel: &Arc<AtomicBool>,
     model: model::WhisperModel,
@@ -152,7 +152,7 @@ fn run_worker(
 /// can forward them as `TranscriptionEvent::Error`.
 #[allow(clippy::too_many_lines)]
 fn run_worker_inner(
-    audio_rx: &mpsc::Receiver<Vec<f32>>,
+    audio_rx: &mpsc::Receiver<TranscriptionInput>,
     event_tx: &mpsc::Sender<TranscriptionEvent>,
     cancel: &Arc<AtomicBool>,
     model: model::WhisperModel,
@@ -213,10 +213,14 @@ fn run_worker_inner(
             return Ok(());
         }
 
-        let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
+        let input = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
             Ok(data) => data,
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+        let interleaved = match input {
+            TranscriptionInput::Samples(s) => s,
+            TranscriptionInput::SquelchOpened | TranscriptionInput::SquelchClosed => continue,
         };
 
         resampler::downsample_stereo_to_mono_16k(&interleaved, &mut mono_buf);
@@ -228,7 +232,9 @@ fn run_worker_inner(
                 tracing::info!("transcription cancelled, worker exiting");
                 return Ok(());
             }
-            resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
+            if let TranscriptionInput::Samples(s) = extra {
+                resampler::downsample_stereo_to_mono_16k(&s, &mut mono_buf);
+            }
         }
 
         while mono_buf.len() >= CHUNK_SAMPLES {

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -70,8 +70,8 @@ pub mod sherpa_model;
 
 pub use backend::{
     BackendConfig, BackendError, BackendHandle, ModelChoice, SegmentationMode,
-    TranscriptionBackend, TranscriptionEvent, TranscriptionInput,
-    VAD_THRESHOLD_DEFAULT, VAD_THRESHOLD_MAX, VAD_THRESHOLD_MIN,
+    TranscriptionBackend, TranscriptionEvent, TranscriptionInput, VAD_THRESHOLD_DEFAULT,
+    VAD_THRESHOLD_MAX, VAD_THRESHOLD_MIN,
 };
 
 #[cfg(feature = "whisper")]

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -69,8 +69,9 @@ pub mod init_event;
 pub mod sherpa_model;
 
 pub use backend::{
-    BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
-    TranscriptionEvent, VAD_THRESHOLD_DEFAULT, VAD_THRESHOLD_MAX, VAD_THRESHOLD_MIN,
+    BackendConfig, BackendError, BackendHandle, ModelChoice, SegmentationMode,
+    TranscriptionBackend, TranscriptionEvent, TranscriptionInput,
+    VAD_THRESHOLD_DEFAULT, VAD_THRESHOLD_MAX, VAD_THRESHOLD_MIN,
 };
 
 #[cfg(feature = "whisper")]
@@ -111,7 +112,7 @@ pub enum TranscriptionError {
 /// `sdr-ui` need no changes.
 pub struct TranscriptionEngine {
     backend: Option<Box<dyn TranscriptionBackend>>,
-    audio_tx: Option<mpsc::SyncSender<Vec<f32>>>,
+    audio_tx: Option<mpsc::SyncSender<TranscriptionInput>>,
 }
 
 impl Default for TranscriptionEngine {
@@ -192,7 +193,7 @@ impl TranscriptionEngine {
     }
 
     /// Get a clone of the audio sender for feeding samples from the DSP thread.
-    pub fn audio_sender(&self) -> Option<mpsc::SyncSender<Vec<f32>>> {
+    pub fn audio_sender(&self) -> Option<mpsc::SyncSender<TranscriptionInput>> {
         self.audio_tx.clone()
     }
 
@@ -230,6 +231,7 @@ mod tests {
             silence_threshold: 0.007,
             noise_gate_ratio: 3.0,
             vad_threshold: crate::VAD_THRESHOLD_DEFAULT,
+            segmentation_mode: SegmentationMode::default(),
         }
     }
 

--- a/crates/sdr-transcription/tests/sherpa_uninitialized.rs
+++ b/crates/sdr-transcription/tests/sherpa_uninitialized.rs
@@ -24,6 +24,7 @@ fn sherpa_backend_start_returns_init_error_when_host_not_initialized() {
         silence_threshold: 0.007,
         noise_gate_ratio: 3.0,
         vad_threshold: sdr_transcription::VAD_THRESHOLD_DEFAULT,
+        segmentation_mode: sdr_transcription::SegmentationMode::Vad,
     };
     let result = backend.start(config);
     match result {

--- a/crates/sdr-ui/src/header/demod_selector.rs
+++ b/crates/sdr-ui/src/header/demod_selector.rs
@@ -36,7 +36,7 @@ pub fn build_demod_selector() -> (gtk4::DropDown, Rc<Cell<DemodMode>>) {
     let dropdown = gtk4::DropDown::builder()
         .model(&model)
         .selected(DEFAULT_MODE_INDEX)
-        .tooltip_text("Demodulation mode — changing band stops active transcription")
+        .tooltip_text("Demodulation mode — changing modes stops active transcription")
         .build();
 
     let mode = Rc::new(Cell::new(DEMOD_MODES[DEFAULT_MODE_INDEX as usize]));

--- a/crates/sdr-ui/src/header/demod_selector.rs
+++ b/crates/sdr-ui/src/header/demod_selector.rs
@@ -36,7 +36,7 @@ pub fn build_demod_selector() -> (gtk4::DropDown, Rc<Cell<DemodMode>>) {
     let dropdown = gtk4::DropDown::builder()
         .model(&model)
         .selected(DEFAULT_MODE_INDEX)
-        .tooltip_text("Demodulation mode")
+        .tooltip_text("Demodulation mode — changing band stops active transcription")
         .build();
 
     let mode = Rc::new(Cell::new(DEMOD_MODES[DEFAULT_MODE_INDEX as usize]));

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -351,7 +351,9 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
 
         let row = adw::SwitchRow::builder()
             .title("Auto Break")
-            .subtitle("Use the radio's squelch as the transcription boundary instead of VAD. NFM only.")
+            .subtitle(
+                "Use the radio's squelch as the transcription boundary instead of VAD. NFM only.",
+            )
             .active(saved)
             .build();
         group.add(&row);

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -424,19 +424,49 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
             .get(saved_model_idx as usize)
             .copied()
             .is_some_and(sdr_transcription::SherpaModel::supports_partials);
+        let initial_is_offline = !initial_supports_partials;
+        let initial_auto_break_active = auto_break_row.is_active();
+
         display_mode_row.set_visible(initial_supports_partials);
-        vad_threshold_row.set_visible(!initial_supports_partials);
+        // VAD slider visible only when offline model AND Auto Break is OFF.
+        // When Auto Break is ON, it replaces the VAD slider functionally so
+        // showing both would confuse the user about which one is driving
+        // segmentation.
+        vad_threshold_row.set_visible(initial_is_offline && !initial_auto_break_active);
+        // Auto Break toggle visible only when an offline model is selected.
+        // The additional NFM demod-mode gate is applied by window.rs's
+        // DemodModeChanged handler (Task 16) — at widget-build time we
+        // don't yet know the demod mode and assume NFM is the common case.
+        auto_break_row.set_visible(initial_is_offline);
 
         let display_mode_row_for_visibility = display_mode_row.clone();
         let vad_threshold_row_for_visibility = vad_threshold_row.clone();
+        let auto_break_row_for_model_change = auto_break_row.clone();
         model_row.connect_selected_notify(move |r| {
             let idx = r.selected() as usize;
             let supports_partials = sdr_transcription::SherpaModel::ALL
                 .get(idx)
                 .copied()
                 .is_some_and(sdr_transcription::SherpaModel::supports_partials);
+            let is_offline = !supports_partials;
+            let ab_active = auto_break_row_for_model_change.is_active();
+
             display_mode_row_for_visibility.set_visible(supports_partials);
-            vad_threshold_row_for_visibility.set_visible(!supports_partials);
+            vad_threshold_row_for_visibility.set_visible(is_offline && !ab_active);
+            auto_break_row_for_model_change.set_visible(is_offline);
+        });
+
+        // Mutex: toggling Auto Break hides/shows the VAD threshold slider.
+        // Only applies when Auto Break itself is currently visible (i.e., an
+        // offline model is selected). If the row is hidden — streaming
+        // Zipformer is selected — the mutex doesn't apply because the VAD
+        // slider is already hidden by the offline-model check.
+        let vad_threshold_row_for_mutex = vad_threshold_row.clone();
+        let auto_break_row_for_mutex = auto_break_row.clone();
+        auto_break_row.connect_active_notify(move |r| {
+            if auto_break_row_for_mutex.is_visible() {
+                vad_threshold_row_for_mutex.set_visible(!r.is_active());
+            }
         });
     }
 

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -33,6 +33,12 @@ const KEY_DISPLAY_MODE: &str = "transcription_display_mode";
 /// Config key for the persisted Silero VAD threshold.
 /// Sherpa-only — only meaningful for offline models (Moonshine, Parakeet).
 const KEY_SHERPA_VAD_THRESHOLD: &str = "sherpa_vad_threshold";
+#[cfg(feature = "sherpa")]
+/// Config key for persisting the Auto Break segmentation preference.
+/// When true, offline sherpa sessions use squelch edges as utterance
+/// boundaries instead of Silero VAD. Default false (preserve existing
+/// behavior for existing config files).
+pub(crate) const KEY_AUTO_BREAK_ENABLED: &str = "transcription_auto_break_enabled";
 
 #[cfg(feature = "sherpa")]
 const DISPLAY_MODE_LIVE_IDX: u32 = 0;
@@ -106,6 +112,10 @@ pub struct TranscriptPanel {
     /// models (Zipformer) don't use Silero VAD.
     #[cfg(feature = "sherpa")]
     pub vad_threshold_row: adw::SpinRow,
+    /// Auto Break toggle. Sherpa-only — when enabled, uses squelch
+    /// edges as utterance boundaries instead of Silero VAD. NFM only.
+    #[cfg(feature = "sherpa")]
+    pub auto_break_row: adw::SwitchRow,
     /// Dimmed italic label below the text view that renders in-progress
     /// Sherpa partials. Sherpa-only.
     #[cfg(feature = "sherpa")]
@@ -331,6 +341,32 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         row
     };
 
+    #[cfg(feature = "sherpa")]
+    let auto_break_row = {
+        let saved = config.read(|v| {
+            v.get(KEY_AUTO_BREAK_ENABLED)
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false)
+        });
+
+        let row = adw::SwitchRow::builder()
+            .title("Auto Break")
+            .subtitle("Use the radio's squelch as the transcription boundary instead of VAD. NFM only.")
+            .active(saved)
+            .build();
+        group.add(&row);
+
+        let config_ab = Arc::clone(config);
+        row.connect_active_notify(move |r| {
+            let active = r.is_active();
+            config_ab.write(|v| {
+                v[KEY_AUTO_BREAK_ENABLED] = serde_json::json!(active);
+            });
+        });
+
+        row
+    };
+
     // --- Display mode selector (Sherpa only) ---
     //
     // Whisper builds never compile this in — Whisper does not emit
@@ -543,6 +579,8 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         display_mode_row,
         #[cfg(feature = "sherpa")]
         vad_threshold_row,
+        #[cfg(feature = "sherpa")]
+        auto_break_row,
         #[cfg(feature = "sherpa")]
         live_line_label,
         status_label,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -312,6 +312,10 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let record_audio_for_dsp = panels.audio.record_audio_row.clone();
     let record_iq_for_dsp = panels.source.record_iq_row.clone();
     let transcription_enable_for_dsp = transcript_panel.enable_row.clone();
+    #[cfg(feature = "sherpa")]
+    let auto_break_row_for_dsp = transcript_panel.auto_break_row.clone();
+    #[cfg(feature = "sherpa")]
+    let model_row_for_dsp = transcript_panel.model_row.clone();
     let engine_for_dsp = Rc::clone(&engine);
     // We deliberately discard the SourceId returned by `timeout_add_local`:
     // the window-lifecycle gate at the top of the closure returns
@@ -354,6 +358,10 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                         &record_audio_for_dsp,
                         &record_iq_for_dsp,
                         &transcription_enable_for_dsp,
+                        #[cfg(feature = "sherpa")]
+                        &auto_break_row_for_dsp,
+                        #[cfg(feature = "sherpa")]
+                        &model_row_for_dsp,
                     );
                 }
                 Err(mpsc::TryRecvError::Empty) => break,
@@ -370,7 +378,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
 }
 
 /// Handle a single message from the DSP thread.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn handle_dsp_message(
     msg: DspToUi,
     spectrum_handle: &Rc<spectrum::SpectrumHandle>,
@@ -382,6 +390,8 @@ fn handle_dsp_message(
     record_audio_row: &adw::SwitchRow,
     record_iq_row: &adw::SwitchRow,
     transcription_enable_row: &adw::SwitchRow,
+    #[cfg(feature = "sherpa")] auto_break_row: &adw::SwitchRow,
+    #[cfg(feature = "sherpa")] model_row: &adw::ComboRow,
 ) {
     match msg {
         DspToUi::FftData(_) => {
@@ -472,10 +482,44 @@ fn handle_dsp_message(
                 overlay.add_toast(toast);
             }
         }
-        // Task 16 will wire up the full UI response (stop transcription session,
-        // re-run Auto Break row visibility rules). For now just log the event.
-        DspToUi::DemodModeChanged(mode) => {
-            tracing::debug!(?mode, "demod mode changed (Task 16 handler pending)");
+        DspToUi::DemodModeChanged(new_mode) => {
+            tracing::info!(?new_mode, "demod mode changed");
+
+            // Re-run Auto Break row visibility rules with the new mode.
+            // The row is only visible when the current mode is NFM AND an
+            // offline sherpa model is selected. Task 13 installed the
+            // "offline model" check as a signal-chain reaction to model_row
+            // changes; this layer adds the NFM gate on top, fired by the
+            // demod-mode-change event.
+            #[cfg(feature = "sherpa")]
+            {
+                let is_nfm = new_mode == sdr_types::DemodMode::Nfm;
+                let model_idx = model_row.selected() as usize;
+                let selected_is_offline = sdr_transcription::SherpaModel::ALL
+                    .get(model_idx)
+                    .copied()
+                    .is_some_and(|m| !m.supports_partials());
+                auto_break_row.set_visible(is_nfm && selected_is_offline);
+            }
+
+            // If a transcription session is currently active, stop it and
+            // surface a toast. The band has conceptually changed, so the
+            // session must restart from scratch — session config (model,
+            // VAD threshold, Auto Break toggle) is preserved; the user
+            // clicks Start to resume on the new band.
+            if transcription_enable_row.is_active() {
+                tracing::info!("stopping active transcription due to demod mode change");
+                // Toggling enable_row off triggers the existing stop path
+                // (connect_active_notify handler wired elsewhere in window.rs).
+                transcription_enable_row.set_active(false);
+
+                if let Some(overlay) = toast_overlay_weak.upgrade() {
+                    let toast = adw::Toast::new(
+                        "Transcription stopped — demod mode changed. Press Start to resume.",
+                    );
+                    overlay.add_toast(toast);
+                }
+            }
         }
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1789,13 +1789,44 @@ fn connect_transcript_panel(
 
     transcript.enable_row.connect_active_notify(move |row| {
         if row.is_active() {
-            // Auto Break precondition: squelch must be enabled so the radio
-            // produces the open/close transitions the state machine needs
-            // for segmentation. Without squelch enabled, the session would
-            // sit in Idle indefinitely producing zero transcripts — silent
-            // failure mode. Block session start with an actionable toast.
+            // Read the selected model index once at the top of the
+            // session-start branch; the Auto Break eligibility check
+            // below needs it, and the BackendConfig construction
+            // below reuses it.
+            let model_idx = model_row.selected() as usize;
+
+            // Auto Break is eligible ONLY when all three conditions
+            // hold: (1) the toggle itself is on, (2) the current demod
+            // mode is NFM, and (3) the selected sherpa model is offline
+            // (Moonshine, Parakeet). The toggle is persisted, so
+            // without this computed gate it would still report "on"
+            // after a restart into WFM, or after the user switched to
+            // streaming Zipformer and the row went invisible — either
+            // of which would produce an unsupported session
+            // (streaming Zipformer rejects AutoBreak at session start;
+            // non-NFM modes never emit squelch edges so the state
+            // machine sits in Idle forever). Compute the effective
+            // value once here and use it for both the precondition
+            // check and the BackendConfig assignment.
             #[cfg(feature = "sherpa")]
-            if auto_break_row.is_active() && !squelch_enabled_row_for_session.is_active() {
+            let auto_break_enabled = {
+                let selected_is_offline = sdr_transcription::SherpaModel::ALL
+                    .get(model_idx)
+                    .copied()
+                    .is_some_and(|m| !m.supports_partials());
+                auto_break_row.is_active()
+                    && state_clone.demod_mode.get() == sdr_types::DemodMode::Nfm
+                    && selected_is_offline
+            };
+
+            // Auto Break precondition: squelch must be enabled so the
+            // radio produces the open/close transitions the state
+            // machine needs for segmentation. Without squelch enabled,
+            // the session would sit in Idle indefinitely producing
+            // zero transcripts — silent failure mode. Block session
+            // start with an actionable toast.
+            #[cfg(feature = "sherpa")]
+            if auto_break_enabled && !squelch_enabled_row_for_session.is_active() {
                 let toast = adw::Toast::new(
                     "Auto Break needs squelch enabled to detect transmission boundaries. \
                      Enable squelch in the radio panel, or turn off Auto Break to use VAD.",
@@ -1810,7 +1841,6 @@ fn connect_transcript_panel(
                 return;
             }
 
-            // Read selected model from dropdown.
             // Lock model and tuning controls while transcription is active.
             model_row.set_sensitive(false);
             #[cfg(feature = "whisper")]
@@ -1825,8 +1855,6 @@ fn connect_transcript_panel(
             vad_threshold_row.set_sensitive(false);
             #[cfg(feature = "sherpa")]
             auto_break_row.set_sensitive(false);
-
-            let model_idx = model_row.selected() as usize;
 
             // Read tuning slider values.
             #[cfg(feature = "whisper")]
@@ -1866,7 +1894,7 @@ fn connect_transcript_panel(
             let vad_threshold: f32 = sdr_transcription::VAD_THRESHOLD_DEFAULT;
 
             #[cfg(feature = "sherpa")]
-            let segmentation_mode = if auto_break_row.is_active() {
+            let segmentation_mode = if auto_break_enabled {
                 sdr_transcription::SegmentationMode::AutoBreak
             } else {
                 sdr_transcription::SegmentationMode::Vad

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1595,8 +1595,7 @@ fn connect_transcript_panel(
     >,
     #[cfg_attr(not(feature = "sherpa"), allow(unused_variables))]
     squelch_enabled_row: &adw::SwitchRow,
-    #[cfg_attr(not(feature = "sherpa"), allow(unused_variables))]
-    toast_overlay: &adw::ToastOverlay,
+    #[cfg_attr(not(feature = "sherpa"), allow(unused_variables))] toast_overlay: &adw::ToastOverlay,
 ) -> Rc<RefCell<sdr_transcription::TranscriptionEngine>> {
     use sdr_transcription::{TranscriptionEngine, TranscriptionEvent};
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -472,6 +472,11 @@ fn handle_dsp_message(
                 overlay.add_toast(toast);
             }
         }
+        // Task 16 will wire up the full UI response (stop transcription session,
+        // re-run Auto Break row visibility rules). For now just log the event.
+        DspToUi::DemodModeChanged(mode) => {
+            tracing::debug!(?mode, "demod mode changed (Task 16 handler pending)");
+        }
     }
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1507,6 +1507,7 @@ fn unlock_transcription_session_rows(
     noise_gate_row: &glib::WeakRef<adw::SpinRow>,
     #[cfg(feature = "sherpa")] display_mode_row: &glib::WeakRef<adw::ComboRow>,
     #[cfg(feature = "sherpa")] vad_threshold_row: &glib::WeakRef<adw::SpinRow>,
+    #[cfg(feature = "sherpa")] auto_break_row: &glib::WeakRef<adw::SwitchRow>,
 ) {
     if let Some(row) = model_row.upgrade() {
         row.set_sensitive(true);
@@ -1524,6 +1525,10 @@ fn unlock_transcription_session_rows(
     }
     #[cfg(feature = "sherpa")]
     if let Some(row) = vad_threshold_row.upgrade() {
+        row.set_sensitive(true);
+    }
+    #[cfg(feature = "sherpa")]
+    if let Some(row) = auto_break_row.upgrade() {
         row.set_sensitive(true);
     }
 }
@@ -1567,11 +1572,15 @@ fn connect_transcript_panel(
     #[cfg(feature = "sherpa")]
     let vad_threshold_row = transcript.vad_threshold_row.clone();
     #[cfg(feature = "sherpa")]
+    let auto_break_row = transcript.auto_break_row.clone();
+    #[cfg(feature = "sherpa")]
     let live_line_label = transcript.live_line_label.clone();
     #[cfg(feature = "sherpa")]
     let display_mode_row_weak = display_mode_row.downgrade();
     #[cfg(feature = "sherpa")]
     let vad_threshold_row_weak = vad_threshold_row.downgrade();
+    #[cfg(feature = "sherpa")]
+    let auto_break_row_weak = auto_break_row.downgrade();
     #[cfg(feature = "sherpa")]
     let live_line_weak = live_line_label.downgrade();
 
@@ -1736,6 +1745,8 @@ fn connect_transcript_panel(
             display_mode_row.set_sensitive(false);
             #[cfg(feature = "sherpa")]
             vad_threshold_row.set_sensitive(false);
+            #[cfg(feature = "sherpa")]
+            auto_break_row.set_sensitive(false);
 
             let model_idx = model_row.selected() as usize;
 
@@ -1776,15 +1787,21 @@ fn connect_transcript_panel(
             #[cfg(feature = "whisper")]
             let vad_threshold: f32 = sdr_transcription::VAD_THRESHOLD_DEFAULT;
 
+            #[cfg(feature = "sherpa")]
+            let segmentation_mode = if auto_break_row.is_active() {
+                sdr_transcription::SegmentationMode::AutoBreak
+            } else {
+                sdr_transcription::SegmentationMode::Vad
+            };
+            #[cfg(feature = "whisper")]
+            let segmentation_mode = sdr_transcription::SegmentationMode::Vad;
+
             let config = sdr_transcription::BackendConfig {
                 model,
                 silence_threshold,
                 noise_gate_ratio,
                 vad_threshold,
-                // Task 14 replaces this hardcoded default with a read
-                // from the auto_break_row toggle. For now, default to
-                // Vad so Tasks 7-13 can build the workspace.
-                segmentation_mode: sdr_transcription::SegmentationMode::Vad,
+                segmentation_mode,
             };
 
             // Scope the borrow so it's dropped before any potential re-entry
@@ -1816,6 +1833,8 @@ fn connect_transcript_panel(
                     let display_mode_row_weak = display_mode_row_weak.clone();
                     #[cfg(feature = "sherpa")]
                     let vad_threshold_row_weak = vad_threshold_row_weak.clone();
+                    #[cfg(feature = "sherpa")]
+                    let auto_break_row_weak = auto_break_row_weak.clone();
                     #[cfg(feature = "sherpa")]
                     let live_line_weak = live_line_weak.clone();
 
@@ -1937,6 +1956,8 @@ fn connect_transcript_panel(
                                             &display_mode_row_weak,
                                             #[cfg(feature = "sherpa")]
                                             &vad_threshold_row_weak,
+                                            #[cfg(feature = "sherpa")]
+                                            &auto_break_row_weak,
                                         );
                                         if let Some(enable) = enable_row_weak.upgrade() {
                                             enable.set_active(false);
@@ -2004,6 +2025,8 @@ fn connect_transcript_panel(
                                         &display_mode_row_weak,
                                         #[cfg(feature = "sherpa")]
                                         &vad_threshold_row_weak,
+                                        #[cfg(feature = "sherpa")]
+                                        &auto_break_row_weak,
                                     );
                                     if let Some(enable) = enable_row_weak.upgrade() {
                                         enable.set_active(false);
@@ -2035,6 +2058,8 @@ fn connect_transcript_panel(
                         &display_mode_row.downgrade(),
                         #[cfg(feature = "sherpa")]
                         &vad_threshold_row.downgrade(),
+                        #[cfg(feature = "sherpa")]
+                        &auto_break_row.downgrade(),
                     );
                     // Reset the toggle FIRST (the else branch clears
                     // status_label as part of its normal teardown), then
@@ -2057,6 +2082,8 @@ fn connect_transcript_panel(
                 &display_mode_row.downgrade(),
                 #[cfg(feature = "sherpa")]
                 &vad_threshold_row.downgrade(),
+                #[cfg(feature = "sherpa")]
+                &auto_break_row.downgrade(),
             );
             state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
             engine_clone.borrow_mut().shutdown_nonblocking();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1776,6 +1776,10 @@ fn connect_transcript_panel(
                 silence_threshold,
                 noise_gate_ratio,
                 vad_threshold,
+                // Task 14 replaces this hardcoded default with a read
+                // from the auto_break_row toggle. For now, default to
+                // Vad so Tasks 7-13 can build the workspace.
+                segmentation_mode: sdr_transcription::SegmentationMode::Vad,
             };
 
             // Scope the borrow so it's dropped before any potential re-entry

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -134,7 +134,13 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     setup_app_actions(app, &window, config, &rr_button);
 
     // Wire transcript panel (separate from sidebar panels).
-    let transcription_engine = connect_transcript_panel(&transcript_panel, &state, config);
+    let transcription_engine = connect_transcript_panel(
+        &transcript_panel,
+        &state,
+        config,
+        &panels.radio.squelch_enabled_row,
+        &toast_overlay,
+    );
 
     // On window close, signal the worker to stop without blocking.
     window.connect_close_request(move |_| {
@@ -1587,6 +1593,10 @@ fn connect_transcript_panel(
     #[cfg_attr(not(feature = "sherpa"), allow(unused_variables))] config: &std::sync::Arc<
         sdr_config::ConfigManager,
     >,
+    #[cfg_attr(not(feature = "sherpa"), allow(unused_variables))]
+    squelch_enabled_row: &adw::SwitchRow,
+    #[cfg_attr(not(feature = "sherpa"), allow(unused_variables))]
+    toast_overlay: &adw::ToastOverlay,
 ) -> Rc<RefCell<sdr_transcription::TranscriptionEngine>> {
     use sdr_transcription::{TranscriptionEngine, TranscriptionEvent};
 
@@ -1617,6 +1627,10 @@ fn connect_transcript_panel(
     let vad_threshold_row = transcript.vad_threshold_row.clone();
     #[cfg(feature = "sherpa")]
     let auto_break_row = transcript.auto_break_row.clone();
+    #[cfg(feature = "sherpa")]
+    let squelch_enabled_row_for_session = squelch_enabled_row.clone();
+    #[cfg(feature = "sherpa")]
+    let toast_overlay_for_session = toast_overlay.downgrade();
     #[cfg(feature = "sherpa")]
     let live_line_label = transcript.live_line_label.clone();
     #[cfg(feature = "sherpa")]
@@ -1776,6 +1790,27 @@ fn connect_transcript_panel(
 
     transcript.enable_row.connect_active_notify(move |row| {
         if row.is_active() {
+            // Auto Break precondition: squelch must be enabled so the radio
+            // produces the open/close transitions the state machine needs
+            // for segmentation. Without squelch enabled, the session would
+            // sit in Idle indefinitely producing zero transcripts — silent
+            // failure mode. Block session start with an actionable toast.
+            #[cfg(feature = "sherpa")]
+            if auto_break_row.is_active() && !squelch_enabled_row_for_session.is_active() {
+                let toast = adw::Toast::new(
+                    "Auto Break needs squelch enabled to detect transmission boundaries. \
+                     Enable squelch in the radio panel, or turn off Auto Break to use VAD.",
+                );
+                if let Some(overlay) = toast_overlay_for_session.upgrade() {
+                    overlay.add_toast(toast);
+                }
+                // Revert the enable toggle so the user can take action first.
+                // The OFF branch of the handler is a safe no-op on an
+                // inactive session (it just drops any backend channels).
+                row.set_active(false);
+                return;
+            }
+
             // Read selected model from dropdown.
             // Lock model and tuning controls while transcription is active.
             model_row.set_sensitive(false);

--- a/docs/superpowers/plans/2026-04-13-auto-break-segmentation.md
+++ b/docs/superpowers/plans/2026-04-13-auto-break-segmentation.md
@@ -1,0 +1,1903 @@
+# Auto Break Segmentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a squelch-driven utterance segmentation mode ("Auto Break") for offline sherpa models on NFM demod, mutex with Silero VAD, and make any demod-mode change stop active transcription cleanly with an explainer toast.
+
+**Architecture:** Replace the raw `mpsc::SyncSender<Vec<f32>>` audio-tap contract with a `TranscriptionInput` enum carrying both samples and squelch edge events. The DSP controller emits `SquelchOpened`/`SquelchClosed` edge events from the existing `IfChain::squelch_open()` gate, gated on `current_mode() == DemodMode::Nfm`. The offline sherpa session loop runs either Silero VAD (existing path) or a new Auto Break state machine (`Idle → Recording → HoldingOff`) based on `BackendConfig::segmentation_mode`. On any demod-mode change the transcript panel stops the active session and shows a toast; the setting is persisted so the user can click Start to resume on the new band.
+
+**Tech Stack:** Rust 2024, `mpsc::sync_channel`, `gtk4-rs` 0.11 + `libadwaita`, `sherpa-onnx` 1.12 (fork pinned for sherpa-cuda), `serde_json` config.
+
+**Spec:** [`docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md`](../specs/2026-04-13-auto-break-segmentation-design.md)
+
+**Pre-plan correction vs. spec:** The spec called out adding a new `IfChain::is_squelch_configured()` accessor as a "small API addition." On reading `crates/sdr-radio/src/if_chain.rs:82`, the existing `pub fn squelch_enabled(&self) -> bool` accessor already returns exactly what we need — it's the flag set by `IfChain::set_squelch_enabled(bool)`, which the UI's `radio_panel.squelch_enabled_row` dispatches through `UiToDsp::SetSquelchEnabled`. The plan uses `squelch_enabled()` directly and adds no new API. The spec's "risk item 2" is retired as a no-op.
+
+---
+
+## File Structure
+
+### Crates touched
+
+| Crate | Files modified | What for |
+|---|---|---|
+| `sdr-transcription` | `src/backend.rs` | New `TranscriptionInput` enum, new `SegmentationMode` enum, `BackendConfig.segmentation_mode` field, `BackendHandle.audio_tx` type change |
+| `sdr-transcription` | `src/lib.rs` | Re-export new public types |
+| `sdr-transcription` | `src/backends/whisper.rs` | Pattern-match `TranscriptionInput::Samples`, ignore squelch variants |
+| `sdr-transcription` | `src/backends/sherpa/host.rs` | `SessionParams.audio_rx` type change; add `segmentation_mode` to params; reject `AutoBreak` for online models |
+| `sdr-transcription` | `src/backends/sherpa/mod.rs` | Pass `segmentation_mode` from `BackendConfig` through `SessionParams` |
+| `sdr-transcription` | `src/backends/sherpa/streaming.rs` | Pattern-match `Samples`, ignore edge events |
+| `sdr-transcription` | `src/backends/sherpa/offline.rs` | Split `run_session` into `run_session_vad` + `run_session_auto_break`; new state machine; new constants |
+| `sdr-core` | `src/messages.rs` | New `DspToUi::DemodModeChanged(DemodMode)` variant; change `UiToDsp::EnableTranscription` payload type |
+| `sdr-core` | `src/controller.rs` | `transcription_tx` type change; add `squelch_was_open: bool`; emit edge events on NFM; emit `DemodModeChanged` on demod switch |
+| `sdr-ui` | `src/sidebar/transcript_panel.rs` | New `auto_break_row`; visibility rules; persistence key; mutex with VAD slider |
+| `sdr-ui` | `src/sidebar/radio_panel.rs` | Subtitle on demod mode selector row |
+| `sdr-ui` | `src/window.rs` | Subscribe to `DemodModeChanged`; stop-on-mode-change + toast; squelch-enabled precondition check; pass `segmentation_mode` when building `BackendConfig` |
+
+### New files
+
+None.
+
+### Deleted files
+
+None.
+
+---
+
+## Phase A: Foundation types
+
+Add the new enums and refactor the audio-tap channel type to carry edge events alongside samples. Everything compiles after Phase B; nothing runs correctly yet.
+
+### Task 1: Add `TranscriptionInput` enum and `SegmentationMode` to `sdr-transcription/src/backend.rs`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backend.rs`
+- Modify: `crates/sdr-transcription/src/lib.rs`
+
+- [ ] **Step 1: Add `TranscriptionInput` and `SegmentationMode` to backend.rs**
+
+At `crates/sdr-transcription/src/backend.rs` just above the existing `BackendConfig` struct (line 26):
+
+```rust
+/// Frames sent from the DSP controller into a transcription backend.
+///
+/// Carries both raw audio samples and segmentation-boundary hints. The
+/// boundary variants are emitted by `sdr-core::controller` only when the
+/// current demod mode is NFM — backends never need to gate on mode
+/// themselves.
+///
+/// Backends that don't care about squelch-based segmentation (Whisper,
+/// streaming Zipformer, offline sherpa in `SegmentationMode::Vad`)
+/// pattern-match on `Samples` and drop the other variants.
+#[derive(Debug, Clone)]
+pub enum TranscriptionInput {
+    /// Interleaved-stereo f32 PCM at 48 kHz. Always emitted, gap-free.
+    Samples(Vec<f32>),
+
+    /// Radio squelch just opened. Edge event, emitted exactly once per
+    /// close→open transition. NFM demod only.
+    SquelchOpened,
+
+    /// Radio squelch just closed. Edge event, emitted exactly once per
+    /// open→close transition. NFM demod only.
+    SquelchClosed,
+}
+
+/// Which segmentation engine drives utterance boundaries for an offline
+/// sherpa transcription session.
+///
+/// Mutex: exactly one is active per session. Streaming Zipformer always
+/// uses `Vad` (its own endpoint detection handles the rest).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SegmentationMode {
+    /// Silero VAD drives segmentation. Default for backward compatibility
+    /// and the only valid mode for streaming Zipformer.
+    #[default]
+    Vad,
+
+    /// Auto Break: the radio's squelch gate drives segmentation. Valid
+    /// only for offline sherpa models on NFM demod. See the Auto Break
+    /// state machine in `backends/sherpa/offline.rs`.
+    AutoBreak,
+}
+```
+
+- [ ] **Step 2: Add `segmentation_mode` field to `BackendConfig`**
+
+Modify the existing `BackendConfig` struct at `crates/sdr-transcription/src/backend.rs:30-41`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BackendConfig {
+    pub model: ModelChoice,
+    pub silence_threshold: f32,
+    pub noise_gate_ratio: f32,
+    /// Silero VAD speech detection threshold (offline models only).
+    /// Clamp to `VAD_THRESHOLD_MIN..=VAD_THRESHOLD_MAX`.
+    /// Default `VAD_THRESHOLD_DEFAULT`. Lower catches quieter audio
+    /// (NFM/scanner); higher is stricter (talk radio). Ignored by
+    /// Whisper (no Silero VAD) and ignored when
+    /// `segmentation_mode == SegmentationMode::AutoBreak`.
+    pub vad_threshold: f32,
+    /// How utterance boundaries are detected in an offline sherpa
+    /// session. See `SegmentationMode` for valid values. Streaming
+    /// Zipformer rejects `AutoBreak` at session start.
+    pub segmentation_mode: SegmentationMode,
+}
+```
+
+- [ ] **Step 3: Change `BackendHandle.audio_tx` type to `SyncSender<TranscriptionInput>`**
+
+Modify `crates/sdr-transcription/src/backend.rs:84-89`:
+
+```rust
+pub struct BackendHandle {
+    /// Push audio frames + squelch edge events into the backend. See
+    /// [`TranscriptionInput`] for the wire format.
+    pub audio_tx: mpsc::SyncSender<TranscriptionInput>,
+    /// Receive transcription events from the backend.
+    pub event_rx: mpsc::Receiver<TranscriptionEvent>,
+}
+```
+
+- [ ] **Step 4: Re-export the new types from lib.rs**
+
+Modify `crates/sdr-transcription/src/lib.rs` — extend the `pub use backend::{...}` block (around line 45):
+
+```rust
+pub use backend::{
+    BackendConfig, BackendError, BackendHandle, ModelChoice, SegmentationMode,
+    TranscriptionBackend, TranscriptionEvent, TranscriptionInput,
+    VAD_THRESHOLD_DEFAULT, VAD_THRESHOLD_MAX, VAD_THRESHOLD_MIN,
+};
+```
+
+- [ ] **Step 5: Write the unit test — new types are constructible and `SegmentationMode::default()` is `Vad`**
+
+Append to `crates/sdr-transcription/src/backend.rs` (at the bottom, inside a new `#[cfg(test)] mod tests { ... }` block or an existing one if present):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcription_input_variants_construct() {
+        let _samples = TranscriptionInput::Samples(vec![0.0_f32; 16]);
+        let _opened = TranscriptionInput::SquelchOpened;
+        let _closed = TranscriptionInput::SquelchClosed;
+    }
+
+    #[test]
+    fn segmentation_mode_default_is_vad() {
+        assert_eq!(SegmentationMode::default(), SegmentationMode::Vad);
+    }
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cargo test -p sdr-transcription --lib backend::tests 2>&1 | tail -20
+```
+
+Expected: 2 tests pass.
+
+The rest of the workspace WILL NOT COMPILE yet (the channel type change breaks every consumer). This is expected; Phase B fixes it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backend.rs crates/sdr-transcription/src/lib.rs
+git commit -m "feat(transcription): add TranscriptionInput + SegmentationMode types"
+```
+
+---
+
+## Phase B: Refactor consumers so the workspace compiles again
+
+The `TranscriptionInput` channel type change breaks every consumer. Fix them all in a single cohesive pass and verify the triple-build matrix still compiles before moving on.
+
+### Task 2: Update Whisper backend to consume `TranscriptionInput`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/whisper.rs`
+
+- [ ] **Step 1: Change the channel type in `WhisperBackend::start`**
+
+At `crates/sdr-transcription/src/backends/whisper.rs:79`:
+
+```rust
+let (audio_tx, audio_rx) = mpsc::sync_channel::<crate::backend::TranscriptionInput>(AUDIO_CHANNEL_CAPACITY);
+```
+
+- [ ] **Step 2: Change the receiver parameter types in `run_worker` and `run_worker_inner`**
+
+At lines 131-138 and 154-161, change both signatures:
+
+```rust
+fn run_worker(
+    audio_rx: &mpsc::Receiver<crate::backend::TranscriptionInput>,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+    cancel: &Arc<AtomicBool>,
+    model: model::WhisperModel,
+    silence_threshold: f32,
+    noise_gate_ratio: f32,
+) {
+```
+
+And identically for `run_worker_inner`.
+
+- [ ] **Step 3: Pattern-match `Samples` in the audio loop, drop edge events**
+
+At `crates/sdr-transcription/src/backends/whisper.rs:216-220`:
+
+```rust
+let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
+    Ok(crate::backend::TranscriptionInput::Samples(data)) => data,
+    Ok(crate::backend::TranscriptionInput::SquelchOpened)
+    | Ok(crate::backend::TranscriptionInput::SquelchClosed) => {
+        // Whisper doesn't use squelch edge events (no Auto Break support
+        // in v1). Dropping the frame and continuing the loop returns to
+        // the recv on the next iteration.
+        continue;
+    }
+    Err(mpsc::RecvTimeoutError::Timeout) => continue,
+    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+};
+```
+
+Also update the `while let Ok(extra) = audio_rx.try_recv()` drain loop at 226-232 to handle the enum:
+
+```rust
+while let Ok(input) = audio_rx.try_recv() {
+    if cancel.load(Ordering::Relaxed) {
+        tracing::info!("transcription cancelled, worker exiting");
+        return Ok(());
+    }
+    match input {
+        crate::backend::TranscriptionInput::Samples(extra) => {
+            resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
+        }
+        crate::backend::TranscriptionInput::SquelchOpened
+        | crate::backend::TranscriptionInput::SquelchClosed => {
+            // no-op: Whisper ignores squelch events
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build check (whisper default)**
+
+```bash
+cargo build -p sdr-transcription 2>&1 | tail -10
+```
+
+Expected: compiles clean. If any use of `audio_rx` returns `Vec<f32>` directly, it will fail — find and pattern-match all of them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/whisper.rs
+git commit -m "refactor(whisper): consume TranscriptionInput, ignore squelch variants"
+```
+
+### Task 3: Update Sherpa session params and host to thread `TranscriptionInput`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa/host.rs`
+- Modify: `crates/sdr-transcription/src/backends/sherpa/mod.rs`
+
+- [ ] **Step 1: Change `SessionParams.audio_rx` type and add `segmentation_mode` field**
+
+At `crates/sdr-transcription/src/backends/sherpa/host.rs:137-146`:
+
+```rust
+/// Parameters handed to the host worker for one transcription session.
+pub(super) struct SessionParams {
+    pub cancel: Arc<std::sync::atomic::AtomicBool>,
+    pub audio_rx: mpsc::Receiver<crate::backend::TranscriptionInput>,
+    pub event_tx: mpsc::Sender<TranscriptionEvent>,
+    pub noise_gate_ratio: f32,
+    /// Silero VAD threshold requested for this session (offline VAD mode only).
+    /// The worker rebuilds the VAD if this differs from the currently-held
+    /// VAD's threshold. Ignored when `segmentation_mode == AutoBreak`.
+    pub vad_threshold: f32,
+    /// Which segmentation engine drives utterance boundaries. Validated
+    /// against the model kind at the top of `run_host_loop`'s `StartSession`
+    /// arm — streaming online models reject `AutoBreak`.
+    pub segmentation_mode: crate::backend::SegmentationMode,
+}
+```
+
+- [ ] **Step 2: Thread `segmentation_mode` through `SherpaBackend::start` in sherpa/mod.rs**
+
+At `crates/sdr-transcription/src/backends/sherpa/mod.rs:108` (inside `TranscriptionBackend::start`'s body where `SessionParams { ... }` is constructed), change:
+
+```rust
+host.start_session(SessionParams {
+    cancel: Arc::clone(&self.cancel),
+    audio_rx,
+    event_tx,
+    noise_gate_ratio: config.noise_gate_ratio,
+    vad_threshold: config.vad_threshold,
+    segmentation_mode: config.segmentation_mode,
+})?;
+```
+
+Also change the channel creation above it:
+
+```rust
+let (audio_tx, audio_rx) = mpsc::sync_channel::<crate::backend::TranscriptionInput>(AUDIO_CHANNEL_CAPACITY);
+```
+
+- [ ] **Step 3: Build check (sherpa-cpu)**
+
+```bash
+cargo build -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -10
+```
+
+Expected: fails in `streaming.rs` and `offline.rs` because those session loops still try to consume `Vec<f32>` directly. Those are Tasks 4 and 5; fix them next.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa/host.rs \
+        crates/sdr-transcription/src/backends/sherpa/mod.rs
+git commit -m "refactor(sherpa): SessionParams carries TranscriptionInput + segmentation_mode"
+```
+
+### Task 4: Update streaming session loop to consume `TranscriptionInput` and reject `AutoBreak`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa/streaming.rs`
+
+- [ ] **Step 1: Reject `SegmentationMode::AutoBreak` at session start**
+
+At the top of `run_session` in `crates/sdr-transcription/src/backends/sherpa/streaming.rs:71`, after the `SessionParams` destructure, add:
+
+```rust
+pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
+    let SessionParams {
+        cancel,
+        audio_rx,
+        event_tx,
+        noise_gate_ratio,
+        vad_threshold: _,
+        segmentation_mode,
+    } = params;
+
+    if segmentation_mode == crate::backend::SegmentationMode::AutoBreak {
+        let msg = "streaming Zipformer does not support Auto Break segmentation \
+                   — it has its own endpoint detection. Use SegmentationMode::Vad.";
+        tracing::error!(%msg);
+        let _ = event_tx.send(TranscriptionEvent::Error(msg.to_owned()));
+        return;
+    }
+
+    let stream = recognizer.create_stream();
+    // ... existing code unchanged from here ...
+```
+
+- [ ] **Step 2: Pattern-match `Samples` in the recv loop**
+
+At `crates/sdr-transcription/src/backends/sherpa/streaming.rs:96-100`:
+
+```rust
+let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
+    Ok(crate::backend::TranscriptionInput::Samples(data)) => data,
+    Ok(crate::backend::TranscriptionInput::SquelchOpened)
+    | Ok(crate::backend::TranscriptionInput::SquelchClosed) => continue,
+    Err(mpsc::RecvTimeoutError::Timeout) => continue,
+    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+};
+```
+
+And update the `try_recv` drain loop at line 105-111:
+
+```rust
+while let Ok(input) = audio_rx.try_recv() {
+    if cancel.load(Ordering::Relaxed) {
+        finalize_session(recognizer, &stream, &last_partial, &event_tx);
+        return;
+    }
+    match input {
+        crate::backend::TranscriptionInput::Samples(extra) => {
+            resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
+        }
+        crate::backend::TranscriptionInput::SquelchOpened
+        | crate::backend::TranscriptionInput::SquelchClosed => {
+            // no-op for streaming — endpoint detection handles boundaries
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa/streaming.rs
+git commit -m "refactor(sherpa-streaming): consume TranscriptionInput, reject AutoBreak mode"
+```
+
+### Task 5: Update offline session loop to consume `TranscriptionInput` (VAD path only, no Auto Break yet)
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa/offline.rs`
+
+- [ ] **Step 1: Pattern-match in the VAD recv loop**
+
+At `crates/sdr-transcription/src/backends/sherpa/offline.rs:158-164`, destructure `segmentation_mode` (unused in VAD path):
+
+```rust
+pub(super) fn run_session(
+    recognizer: &OfflineRecognizer,
+    vad: &mut SherpaSileroVad,
+    params: SessionParams,
+) {
+    let SessionParams {
+        cancel,
+        audio_rx,
+        event_tx,
+        noise_gate_ratio,
+        vad_threshold: _,
+        segmentation_mode: _, // handled later in Task 10
+    } = params;
+```
+
+At lines 182-186:
+
+```rust
+let interleaved = match audio_rx.recv_timeout(AUDIO_RECV_TIMEOUT) {
+    Ok(crate::backend::TranscriptionInput::Samples(data)) => data,
+    Ok(crate::backend::TranscriptionInput::SquelchOpened)
+    | Ok(crate::backend::TranscriptionInput::SquelchClosed) => continue,
+    Err(mpsc::RecvTimeoutError::Timeout) => continue,
+    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+};
+```
+
+At lines 192-198:
+
+```rust
+while let Ok(input) = audio_rx.try_recv() {
+    if cancel.load(Ordering::Relaxed) {
+        drain_vad_on_exit(recognizer, vad, &event_tx);
+        return;
+    }
+    match input {
+        crate::backend::TranscriptionInput::Samples(extra) => {
+            resampler::downsample_stereo_to_mono_16k(&extra, &mut mono_buf);
+        }
+        crate::backend::TranscriptionInput::SquelchOpened
+        | crate::backend::TranscriptionInput::SquelchClosed => {
+            // VAD path ignores squelch events; Task 10 adds the AutoBreak branch
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build check (sherpa-cpu)**
+
+```bash
+cargo build -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -10
+```
+
+Expected: clean compile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa/offline.rs
+git commit -m "refactor(sherpa-offline): consume TranscriptionInput in VAD path"
+```
+
+### Task 6: Update `sdr-core` controller `transcription_tx` type and `UiToDsp::EnableTranscription`
+
+**Files:**
+- Modify: `crates/sdr-core/src/messages.rs`
+- Modify: `crates/sdr-core/src/controller.rs`
+
+- [ ] **Step 1: Change `UiToDsp::EnableTranscription` payload type**
+
+At `crates/sdr-core/src/messages.rs:128`:
+
+```rust
+EnableTranscription(std::sync::mpsc::SyncSender<sdr_transcription::TranscriptionInput>),
+```
+
+Also update the test around line 316-318:
+
+```rust
+#[test]
+fn enable_transcription_message_constructs() {
+    let (tx, _rx) = std::sync::mpsc::sync_channel::<sdr_transcription::TranscriptionInput>(1);
+    let enable = UiToDsp::EnableTranscription(tx);
+    assert!(matches!(enable, UiToDsp::EnableTranscription(_)));
+}
+```
+
+- [ ] **Step 2: Change `DspState.transcription_tx` type**
+
+At `crates/sdr-core/src/controller.rs:193`:
+
+```rust
+transcription_tx: Option<std::sync::mpsc::SyncSender<sdr_transcription::TranscriptionInput>>,
+```
+
+- [ ] **Step 3: Wrap sample sends in `TranscriptionInput::Samples`**
+
+At `crates/sdr-core/src/controller.rs:1004-1020`:
+
+```rust
+// Send audio copy to transcription worker BEFORE volume
+// scaling so recognition isn't affected by the volume knob.
+if let Some(ref tx) = state.transcription_tx {
+    let mut interleaved = Vec::with_capacity(audio_count * 2);
+    for s in &state.audio_buf[..audio_count] {
+        interleaved.push(s.l);
+        interleaved.push(s.r);
+    }
+    if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
+        tx.try_send(sdr_transcription::TranscriptionInput::Samples(interleaved))
+    {
+        state.transcription_tx = None;
+        tracing::info!(
+            "transcription receiver disconnected, disabling tap"
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Add the `sdr-transcription` dep to `sdr-core` if not already present**
+
+Check `crates/sdr-core/Cargo.toml`:
+
+```bash
+grep sdr-transcription crates/sdr-core/Cargo.toml
+```
+
+If not present, add under `[dependencies]`:
+
+```toml
+sdr-transcription.workspace = true
+```
+
+(It's very likely already present since EnableTranscription is already a variant; just verify.)
+
+- [ ] **Step 5: Build check — triple flavor**
+
+```bash
+cargo check --workspace 2>&1 | tail -5
+cargo check --workspace --no-default-features --features sherpa-cpu 2>&1 | tail -5
+cargo check --workspace --no-default-features --features sherpa-cuda 2>&1 | tail -5
+```
+
+Expected: all three compile clean.
+
+- [ ] **Step 6: Run existing tests to catch regressions**
+
+```bash
+cargo test --workspace 2>&1 | tail -10
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/sdr-core/src/messages.rs crates/sdr-core/src/controller.rs crates/sdr-core/Cargo.toml
+git commit -m "refactor(sdr-core): transcription tap carries TranscriptionInput"
+```
+
+**Phase B checkpoint: the workspace now compiles on all feature flavors and all pre-existing tests pass, but nothing has NEW behavior yet.**
+
+---
+
+## Phase C: Controller emits squelch edge events and demod-mode-change events
+
+### Task 7: Add `squelch_was_open: bool` to `DspState` and emit edge events on NFM
+
+**Files:**
+- Modify: `crates/sdr-core/src/controller.rs`
+
+- [ ] **Step 1: Add the field to `DspState`**
+
+At `crates/sdr-core/src/controller.rs` in the `DspState` struct definition (around line 180-260), add next to `transcription_tx`:
+
+```rust
+/// Last known squelch gate state, used to detect open/close edge
+/// transitions so we only emit one `SquelchOpened` / `SquelchClosed`
+/// event per transition instead of one per audio chunk. Initialized
+/// to `false` (matches `IfChain`'s initial closed state).
+squelch_was_open: bool,
+```
+
+And initialize it in the struct's `::new()` / `::default()` (around line 243):
+
+```rust
+squelch_was_open: false,
+```
+
+- [ ] **Step 2: Emit edge events on transitions, gated on NFM**
+
+Modify the transcription-tap block at `crates/sdr-core/src/controller.rs:1004-1020`:
+
+```rust
+// Send audio copy to transcription worker BEFORE volume
+// scaling so recognition isn't affected by the volume knob.
+if let Some(ref tx) = state.transcription_tx {
+    // Detect squelch edge transitions. We only care about them on NFM,
+    // where a closed squelch means "no transmission" and the transition
+    // is a meaningful segment boundary for Auto Break.
+    let now_open = state.radio.if_chain().squelch_open();
+    let mut send_error = false;
+
+    if now_open != state.squelch_was_open
+        && state.radio.current_mode() == sdr_types::DemodMode::Nfm
+    {
+        let edge = if now_open {
+            sdr_transcription::TranscriptionInput::SquelchOpened
+        } else {
+            sdr_transcription::TranscriptionInput::SquelchClosed
+        };
+        if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) = tx.try_send(edge) {
+            send_error = true;
+        }
+    }
+    state.squelch_was_open = now_open;
+
+    if !send_error {
+        let mut interleaved = Vec::with_capacity(audio_count * 2);
+        for s in &state.audio_buf[..audio_count] {
+            interleaved.push(s.l);
+            interleaved.push(s.r);
+        }
+        if let Err(std::sync::mpsc::TrySendError::Disconnected(_)) =
+            tx.try_send(sdr_transcription::TranscriptionInput::Samples(interleaved))
+        {
+            send_error = true;
+        }
+    }
+
+    if send_error {
+        state.transcription_tx = None;
+        tracing::info!("transcription receiver disconnected, disabling tap");
+    }
+}
+```
+
+- [ ] **Step 3: Build check**
+
+```bash
+cargo check --workspace --no-default-features --features sherpa-cuda 2>&1 | tail -5
+```
+
+Expected: clean. If `state.radio.if_chain()` doesn't exist as a borrow, check the existing accessors on `RadioModule` — there may be a pass-through like `state.radio.squelch_open()`. Use whichever exists:
+
+```bash
+grep -n "squelch_open\|fn if_chain" crates/sdr-radio/src/lib.rs | head -10
+```
+
+Adjust the accessor call to match.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-core/src/controller.rs
+git commit -m "feat(sdr-core): emit squelch edge events on NFM transitions"
+```
+
+### Task 8: Add `DspToUi::DemodModeChanged` and emit it on mode change
+
+**Files:**
+- Modify: `crates/sdr-core/src/messages.rs`
+- Modify: `crates/sdr-core/src/controller.rs`
+
+- [ ] **Step 1: Add the variant**
+
+At `crates/sdr-core/src/messages.rs`, inside the `DspToUi` enum (around line 8-33), add:
+
+```rust
+    /// Demodulator mode changed. Emitted when `UiToDsp::SetDemodMode`
+    /// actually changes the active demod mode. Used by the transcript
+    /// panel to stop any active session (band change = session boundary)
+    /// and to re-run Auto Break visibility rules on mode transitions.
+    DemodModeChanged(DemodMode),
+```
+
+- [ ] **Step 2: Add a test for the new variant**
+
+In the `#[cfg(test)] mod tests` block at the bottom of `messages.rs`:
+
+```rust
+#[test]
+fn demod_mode_changed_message_constructs() {
+    let m = DspToUi::DemodModeChanged(DemodMode::Nfm);
+    assert!(matches!(m, DspToUi::DemodModeChanged(DemodMode::Nfm)));
+}
+```
+
+- [ ] **Step 3: Emit the event from the controller when `SetDemodMode` actually changes the mode**
+
+Find the `UiToDsp::SetDemodMode` handler in `crates/sdr-core/src/controller.rs`:
+
+```bash
+grep -n "SetDemodMode" crates/sdr-core/src/controller.rs
+```
+
+In the match arm for `UiToDsp::SetDemodMode(mode)`, after the existing `state.radio.set_mode(mode)` call (or equivalent), add:
+
+```rust
+UiToDsp::SetDemodMode(mode) => {
+    let old_mode = state.radio.current_mode();
+    state.radio.set_mode(mode);
+    if old_mode != mode {
+        let _ = dsp_tx.send(DspToUi::DemodModeChanged(mode));
+    }
+}
+```
+
+(Read the current handler first — the existing body may already have different logic; preserve it and just add the emission.)
+
+- [ ] **Step 4: Run the new message test**
+
+```bash
+cargo test -p sdr-core --lib 2>&1 | tail -10
+```
+
+Expected: the new `demod_mode_changed_message_constructs` test passes alongside the existing `messages` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-core/src/messages.rs crates/sdr-core/src/controller.rs
+git commit -m "feat(sdr-core): DspToUi::DemodModeChanged event on mode transitions"
+```
+
+---
+
+## Phase D: Auto Break state machine in the offline session loop
+
+### Task 9: Add Auto Break constants to `offline.rs`
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa/offline.rs`
+
+- [ ] **Step 1: Add the four constants near the top of the file**
+
+At `crates/sdr-transcription/src/backends/sherpa/offline.rs`, after the existing `SHERPA_NUM_THREADS` / `NEMO_TRANSDUCER_MODEL_TYPE` consts (around line 44):
+
+```rust
+/// Squelch openings shorter than this are treated as noise spikes and
+/// produce no segment. Chosen to exclude sub-syllable blips while still
+/// catching short single-word transmissions ("copy").
+const AUTO_BREAK_MIN_OPEN_MS: u32 = 100;
+
+/// Continue buffering audio for this long after the squelch closes, so
+/// the last syllable isn't chopped by a tight squelch-close timing.
+/// Covers typical PowerSquelch fall time plus ~100 ms of spoken tail.
+const AUTO_BREAK_TAIL_MS: u32 = 200;
+
+/// Segments shorter than this are discarded instead of decoded.
+/// Moonshine and Parakeet both hallucinate on sub-word fragments, so
+/// dropping them is an accuracy improvement, not a loss.
+const AUTO_BREAK_MIN_SEGMENT_MS: u32 = 400;
+
+/// Safety cap: if squelch stays open longer than this, flush anyway.
+/// Protects against pathological stuck-open situations (bad auto-squelch,
+/// carrier jam, band opening) that would otherwise cause unbounded
+/// memory growth in the segment buffer.
+const AUTO_BREAK_MAX_SEGMENT_MS: u32 = 30_000;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa/offline.rs
+git commit -m "feat(sherpa-offline): add Auto Break timing constants"
+```
+
+### Task 10: Split offline `run_session` into VAD + Auto Break dispatch
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa/offline.rs`
+
+- [ ] **Step 1: Rename current `run_session` to `run_session_vad` and add a new `run_session` dispatcher**
+
+At `crates/sdr-transcription/src/backends/sherpa/offline.rs:153`, rename the existing function:
+
+```rust
+/// One offline transcription session. Dispatches to the VAD or Auto Break
+/// implementation based on `params.segmentation_mode`.
+pub(super) fn run_session(
+    recognizer: &OfflineRecognizer,
+    vad: &mut SherpaSileroVad,
+    params: SessionParams,
+) {
+    match params.segmentation_mode {
+        crate::backend::SegmentationMode::Vad => run_session_vad(recognizer, vad, params),
+        crate::backend::SegmentationMode::AutoBreak => {
+            run_session_auto_break(recognizer, params)
+        }
+    }
+}
+
+/// VAD-driven offline session. Unchanged from the pre-Auto-Break behavior;
+/// feeds incoming audio into Silero, batch-decodes each segment Silero
+/// emits, and ignores any squelch edge events in the stream.
+fn run_session_vad(
+    recognizer: &OfflineRecognizer,
+    vad: &mut SherpaSileroVad,
+    params: SessionParams,
+) {
+    let SessionParams {
+        cancel,
+        audio_rx,
+        event_tx,
+        noise_gate_ratio,
+        vad_threshold: _,
+        segmentation_mode: _,
+    } = params;
+    // ... paste the rest of the old run_session body here, unchanged ...
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cargo check -p sdr-transcription --no-default-features --features sherpa-cpu 2>&1 | tail -5
+```
+
+Expected: fails — `run_session_auto_break` is not yet defined. Task 11 fixes it.
+
+- [ ] **Step 3: Commit (even though it doesn't build yet — short-lived intermediate state)**
+
+Skip commit here; Task 11 completes the split in a single commit. Do **not** push.
+
+### Task 11: Implement the Auto Break state machine
+
+**Files:**
+- Modify: `crates/sdr-transcription/src/backends/sherpa/offline.rs`
+
+- [ ] **Step 1: Write the failing test suite FIRST (TDD)**
+
+At the bottom of `offline.rs`, in the `#[cfg(test)] mod tests` block (create if missing), add the state machine tests. These drive the implementation shape — each test names a state transition we need to handle:
+
+```rust
+#[cfg(test)]
+mod auto_break_tests {
+    use super::*;
+
+    // Simulated ms → sample count at 48 kHz stereo interleaved
+    fn samples_for_ms(ms: u32) -> Vec<f32> {
+        let frames = (48 * ms) as usize;
+        vec![0.5_f32; frames * 2] // stereo
+    }
+
+    #[test]
+    fn clean_utterance_produces_one_decode() {
+        let machine = AutoBreakMachine::new();
+        let events = machine
+            .feed_sequence(&[
+                AutoBreakEvent::Opened,
+                AutoBreakEvent::Samples(samples_for_ms(1_000)),
+                AutoBreakEvent::Closed,
+                AutoBreakEvent::TailTimeout,
+            ])
+            .expect("state machine should run cleanly");
+        assert_eq!(events.decodes_flushed, 1);
+        assert_eq!(events.discarded_short, 0);
+        assert_eq!(events.discarded_phantom, 0);
+    }
+
+    #[test]
+    fn hysteresis_blip_single_utterance() {
+        let machine = AutoBreakMachine::new();
+        let events = machine
+            .feed_sequence(&[
+                AutoBreakEvent::Opened,
+                AutoBreakEvent::Samples(samples_for_ms(500)),
+                AutoBreakEvent::Closed,
+                AutoBreakEvent::Opened, // blip within hold-off
+                AutoBreakEvent::Samples(samples_for_ms(500)),
+                AutoBreakEvent::Closed,
+                AutoBreakEvent::TailTimeout,
+            ])
+            .expect("state machine should fold blip into one utterance");
+        assert_eq!(events.decodes_flushed, 1);
+    }
+
+    #[test]
+    fn phantom_open_below_min_open_ms_discarded() {
+        let machine = AutoBreakMachine::new();
+        let events = machine
+            .feed_sequence(&[
+                AutoBreakEvent::Opened,
+                AutoBreakEvent::Samples(samples_for_ms(50)), // < MIN_OPEN_MS (100)
+                AutoBreakEvent::Closed,
+                AutoBreakEvent::TailTimeout,
+            ])
+            .expect("state machine should discard phantom");
+        assert_eq!(events.decodes_flushed, 0);
+        assert_eq!(events.discarded_phantom, 1);
+    }
+
+    #[test]
+    fn sub_min_segment_discarded() {
+        let machine = AutoBreakMachine::new();
+        let events = machine
+            .feed_sequence(&[
+                AutoBreakEvent::Opened,
+                AutoBreakEvent::Samples(samples_for_ms(300)), // > MIN_OPEN but < MIN_SEGMENT (400)
+                AutoBreakEvent::Closed,
+                AutoBreakEvent::TailTimeout,
+            ])
+            .expect("state machine should discard sub-min segment");
+        assert_eq!(events.decodes_flushed, 0);
+        assert_eq!(events.discarded_short, 1);
+    }
+
+    #[test]
+    fn max_segment_safety_flush() {
+        let machine = AutoBreakMachine::new();
+        let events = machine
+            .feed_sequence(&[
+                AutoBreakEvent::Opened,
+                AutoBreakEvent::Samples(samples_for_ms(31_000)), // > MAX_SEGMENT_MS (30_000)
+                // no Close event — squelch is "stuck open"
+            ])
+            .expect("state machine should hit max-segment safety cap");
+        assert_eq!(events.decodes_flushed, 1);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL with "AutoBreakMachine not defined"**
+
+```bash
+cargo test -p sdr-transcription --no-default-features --features sherpa-cpu --lib auto_break_tests 2>&1 | tail -20
+```
+
+Expected: compile errors referencing `AutoBreakMachine`, `AutoBreakEvent`.
+
+- [ ] **Step 3: Implement `AutoBreakEvent` and `AutoBreakMachine`**
+
+In `offline.rs`, above the `#[cfg(test)] mod auto_break_tests`, add:
+
+```rust
+/// Events consumed by the Auto Break state machine. The real session
+/// loop translates incoming `TranscriptionInput` variants + a
+/// `recv_timeout` timer into this shape; the state machine itself is
+/// pure so it can be unit-tested without a running recognizer.
+#[cfg_attr(not(test), allow(dead_code))]
+enum AutoBreakEvent {
+    Samples(Vec<f32>),
+    Opened,
+    Closed,
+    /// Hold-off timer expired (hit `AUTO_BREAK_TAIL_MS` with no new events).
+    TailTimeout,
+}
+
+/// Counters returned by a test-only simulation of the state machine.
+/// Only exists to give tests something observable — the real session
+/// loop wires the same transitions into `decode_segment` / `tracing`.
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct AutoBreakFlushCounts {
+    decodes_flushed: u32,
+    discarded_short: u32,
+    discarded_phantom: u32,
+}
+
+/// Pure state machine for Auto Break segmentation. Holds no I/O handles
+/// so it can be unit-tested. The real session loop owns one and drives
+/// it from the channel recv loop + hold-off timer.
+struct AutoBreakMachine {
+    state: AutoBreakState,
+    /// Accumulated stereo interleaved samples for the current segment.
+    buffer: Vec<f32>,
+}
+
+enum AutoBreakState {
+    Idle,
+    Recording,
+    HoldingOff,
+}
+
+impl AutoBreakMachine {
+    fn new() -> Self {
+        Self {
+            state: AutoBreakState::Idle,
+            buffer: Vec::new(),
+        }
+    }
+
+    /// Duration in ms currently held in the buffer, assuming 48 kHz
+    /// stereo interleaved input.
+    fn buffer_duration_ms(&self) -> u32 {
+        let frames = self.buffer.len() / 2;
+        #[allow(clippy::cast_possible_truncation)]
+        let ms = (frames as u64 * 1000 / 48_000) as u32;
+        ms
+    }
+
+    /// Test-only: drive the machine through a scripted sequence of
+    /// events and return the flush-decision counters. A real session
+    /// loop would call `decode_segment` instead of incrementing a counter.
+    #[cfg(test)]
+    fn feed_sequence(
+        mut self,
+        events: &[AutoBreakEvent],
+    ) -> Result<AutoBreakFlushCounts, String> {
+        let mut counts = AutoBreakFlushCounts::default();
+        for ev in events {
+            match ev {
+                AutoBreakEvent::Samples(s) => self.on_samples(s.clone()),
+                AutoBreakEvent::Opened => self.on_squelch_opened(),
+                AutoBreakEvent::Closed => self.on_squelch_closed(),
+                AutoBreakEvent::TailTimeout => {
+                    if let Some(decision) = self.on_tail_timeout() {
+                        match decision {
+                            FlushDecision::Decode => counts.decodes_flushed += 1,
+                            FlushDecision::DiscardPhantom => counts.discarded_phantom += 1,
+                            FlushDecision::DiscardShort => counts.discarded_short += 1,
+                        }
+                    }
+                }
+            }
+            // Max-segment safety check runs after every event that grows
+            // the buffer.
+            if matches!(self.state, AutoBreakState::Recording | AutoBreakState::HoldingOff)
+                && self.buffer_duration_ms() >= AUTO_BREAK_MAX_SEGMENT_MS
+            {
+                // Force-flush as if the tail timer had fired, but without
+                // the phantom check — the buffer is way past MIN_SEGMENT by
+                // definition, so it's always a real utterance.
+                counts.decodes_flushed += 1;
+                self.state = AutoBreakState::Idle;
+                self.buffer.clear();
+            }
+        }
+        Ok(counts)
+    }
+
+    fn on_samples(&mut self, samples: Vec<f32>) {
+        if matches!(self.state, AutoBreakState::Recording | AutoBreakState::HoldingOff) {
+            self.buffer.extend_from_slice(&samples);
+        }
+        // Idle: discard — no transmission is happening
+    }
+
+    fn on_squelch_opened(&mut self) {
+        match self.state {
+            AutoBreakState::Idle => {
+                self.buffer.clear();
+                self.state = AutoBreakState::Recording;
+            }
+            AutoBreakState::HoldingOff => {
+                // Hysteresis blip — cancel the deferred flush, stay with
+                // the same buffer.
+                self.state = AutoBreakState::Recording;
+            }
+            AutoBreakState::Recording => {
+                // Already recording (redundant event); ignore.
+            }
+        }
+    }
+
+    fn on_squelch_closed(&mut self) {
+        if matches!(self.state, AutoBreakState::Recording) {
+            self.state = AutoBreakState::HoldingOff;
+        }
+    }
+
+    fn on_tail_timeout(&mut self) -> Option<FlushDecision> {
+        if !matches!(self.state, AutoBreakState::HoldingOff) {
+            return None;
+        }
+        let duration = self.buffer_duration_ms();
+        let decision = if duration < AUTO_BREAK_MIN_OPEN_MS {
+            FlushDecision::DiscardPhantom
+        } else if duration < AUTO_BREAK_MIN_SEGMENT_MS {
+            FlushDecision::DiscardShort
+        } else {
+            FlushDecision::Decode
+        };
+        self.state = AutoBreakState::Idle;
+        self.buffer.clear();
+        Some(decision)
+    }
+
+    /// Take the accumulated buffer for decoding. Used by the real session
+    /// loop (NOT the test feed_sequence path) to hand samples off without
+    /// re-allocating.
+    #[allow(dead_code)]
+    fn take_buffer(&mut self) -> Vec<f32> {
+        std::mem::take(&mut self.buffer)
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+enum FlushDecision {
+    Decode,
+    DiscardShort,
+    DiscardPhantom,
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cargo test -p sdr-transcription --no-default-features --features sherpa-cpu --lib auto_break_tests 2>&1 | tail -20
+```
+
+Expected: 5 tests pass (`clean_utterance_produces_one_decode`, `hysteresis_blip_single_utterance`, `phantom_open_below_min_open_ms_discarded`, `sub_min_segment_discarded`, `max_segment_safety_flush`).
+
+- [ ] **Step 5: Implement `run_session_auto_break` driving the state machine from the real channel**
+
+Below `run_session_vad` in `offline.rs`, add:
+
+```rust
+/// Auto Break offline session. Drives an `AutoBreakMachine` from the
+/// transcription input channel + a hold-off timer implemented via
+/// `recv_timeout`. Buffers stereo 48 kHz interleaved samples during
+/// Recording / HoldingOff states; on flush, resamples to 16 kHz mono,
+/// applies the spectral denoiser, and decodes through the recognizer.
+fn run_session_auto_break(
+    recognizer: &OfflineRecognizer,
+    params: SessionParams,
+) {
+    let SessionParams {
+        cancel,
+        audio_rx,
+        event_tx,
+        noise_gate_ratio,
+        vad_threshold: _,
+        segmentation_mode: _,
+    } = params;
+
+    if event_tx.send(TranscriptionEvent::Ready).is_err() {
+        return;
+    }
+
+    let tail_duration = std::time::Duration::from_millis(u64::from(AUTO_BREAK_TAIL_MS));
+    let mut machine = AutoBreakMachine::new();
+    // `pending_flush_deadline` is Some only while we're in HoldingOff.
+    // When it expires we synthesize a TailTimeout event for the machine.
+    let mut pending_flush_deadline: Option<std::time::Instant> = None;
+
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            tracing::info!("sherpa Auto Break session cancelled");
+            return;
+        }
+
+        // Choose timeout: if we're waiting for a tail flush, recv_timeout
+        // at the remaining deadline; otherwise just block on the audio
+        // polling interval so we can check `cancel`.
+        let timeout = match pending_flush_deadline {
+            Some(deadline) => deadline
+                .checked_duration_since(std::time::Instant::now())
+                .unwrap_or_else(|| std::time::Duration::from_millis(0)),
+            None => AUDIO_RECV_TIMEOUT,
+        };
+
+        let recv = audio_rx.recv_timeout(timeout);
+        match recv {
+            Ok(crate::backend::TranscriptionInput::Samples(samples)) => {
+                machine.on_samples(samples);
+                // Max-segment safety cap
+                if machine.buffer_duration_ms() >= AUTO_BREAK_MAX_SEGMENT_MS {
+                    tracing::warn!(
+                        "Auto Break buffer exceeded {}ms — forcing flush, check squelch config",
+                        AUTO_BREAK_MAX_SEGMENT_MS
+                    );
+                    flush_auto_break_buffer(
+                        recognizer,
+                        &mut machine,
+                        &event_tx,
+                        noise_gate_ratio,
+                    );
+                    pending_flush_deadline = None;
+                }
+            }
+            Ok(crate::backend::TranscriptionInput::SquelchOpened) => {
+                machine.on_squelch_opened();
+                pending_flush_deadline = None;
+            }
+            Ok(crate::backend::TranscriptionInput::SquelchClosed) => {
+                machine.on_squelch_closed();
+                pending_flush_deadline =
+                    Some(std::time::Instant::now() + tail_duration);
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if let Some(deadline) = pending_flush_deadline
+                    && std::time::Instant::now() >= deadline
+                {
+                    if let Some(decision) = machine.on_tail_timeout() {
+                        match decision {
+                            FlushDecision::Decode => flush_auto_break_buffer(
+                                recognizer,
+                                &mut machine,
+                                &event_tx,
+                                noise_gate_ratio,
+                            ),
+                            FlushDecision::DiscardPhantom => {
+                                tracing::debug!("Auto Break: discarded phantom open");
+                            }
+                            FlushDecision::DiscardShort => {
+                                tracing::debug!("Auto Break: discarded sub-min segment");
+                            }
+                        }
+                    }
+                    pending_flush_deadline = None;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                tracing::info!("sherpa Auto Break session ended (channel disconnected)");
+                return;
+            }
+        }
+    }
+}
+
+/// Resample + denoise + decode the current Auto Break buffer, emit a
+/// `Text` event if the recognizer produced non-empty output. Resets the
+/// machine's internal buffer after decoding.
+fn flush_auto_break_buffer(
+    recognizer: &OfflineRecognizer,
+    machine: &mut AutoBreakMachine,
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+    noise_gate_ratio: f32,
+) {
+    let stereo_buf = machine.take_buffer();
+    if stereo_buf.is_empty() {
+        return;
+    }
+    let mut mono_buf: Vec<f32> = Vec::with_capacity(stereo_buf.len() / 6); // rough: /2 for mono, /3 for 48k→16k
+    resampler::downsample_stereo_to_mono_16k(&stereo_buf, &mut mono_buf);
+    denoise::spectral_denoise(&mut mono_buf, noise_gate_ratio);
+    decode_segment(recognizer, &mono_buf, event_tx);
+}
+```
+
+- [ ] **Step 6: Build + test**
+
+```bash
+cargo test -p sdr-transcription --no-default-features --features sherpa-cpu --lib 2>&1 | tail -15
+```
+
+Expected: all existing tests + the 5 new Auto Break state machine tests pass.
+
+- [ ] **Step 7: Build check on sherpa-cuda**
+
+```bash
+cargo check --workspace --no-default-features --features sherpa-cuda 2>&1 | tail -5
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Clippy + fmt**
+
+```bash
+cargo clippy --all-targets --workspace --no-default-features --features sherpa-cpu -- -D warnings 2>&1 | tail -10
+cargo fmt --all
+```
+
+Expected: clippy clean, fmt makes no changes (or minor whitespace).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/sdr-transcription/src/backends/sherpa/offline.rs
+git commit -m "feat(sherpa-offline): Auto Break state machine + session dispatch"
+```
+
+---
+
+## Phase E: UI wiring
+
+### Task 12: Add the Auto Break toggle row + persistence in `transcript_panel.rs`
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/transcript_panel.rs`
+
+- [ ] **Step 1: Add a config key constant near the top of the file**
+
+Near the existing `KEY_SHERPA_VAD_THRESHOLD` const in `transcript_panel.rs` (search with `grep -n KEY_SHERPA transcript_panel.rs`):
+
+```rust
+/// Config key for persisting the Auto Break segmentation preference.
+/// When true, offline sherpa sessions use squelch edges as utterance
+/// boundaries instead of Silero VAD. Default false (preserve existing
+/// behavior for existing config files).
+#[cfg(feature = "sherpa")]
+pub(crate) const KEY_AUTO_BREAK_ENABLED: &str = "transcription_auto_break_enabled";
+```
+
+- [ ] **Step 2: Build the `auto_break_row` widget and add it to the preferences group**
+
+In `build_transcript_panel()`, after the `vad_threshold_row` block (around line 332 in current source):
+
+```rust
+#[cfg(feature = "sherpa")]
+let auto_break_row = {
+    let saved = config.read(|v| {
+        v.get(KEY_AUTO_BREAK_ENABLED)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    });
+
+    let row = adw::SwitchRow::builder()
+        .title("Auto Break")
+        .subtitle("Use the radio's squelch as the transcription boundary instead of VAD. NFM only.")
+        .active(saved)
+        .build();
+    group.add(&row);
+
+    let config_ab = Arc::clone(config);
+    row.connect_active_notify(move |r| {
+        let active = r.is_active();
+        config_ab.write(|v| {
+            v[KEY_AUTO_BREAK_ENABLED] = serde_json::json!(active);
+        });
+    });
+
+    row
+};
+```
+
+- [ ] **Step 3: Add the row to the `TranscriptPanel` struct and return it**
+
+Find the `TranscriptPanel` struct definition (search `grep -n "pub struct TranscriptPanel" transcript_panel.rs`). Add:
+
+```rust
+#[cfg(feature = "sherpa")]
+pub auto_break_row: adw::SwitchRow,
+```
+
+And at the bottom of `build_transcript_panel()` in the returned struct literal, add:
+
+```rust
+#[cfg(feature = "sherpa")]
+auto_break_row,
+```
+
+- [ ] **Step 4: Build check**
+
+```bash
+cargo check -p sdr-ui --no-default-features --features sherpa-cpu 2>&1 | tail -10
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-ui/src/sidebar/transcript_panel.rs
+git commit -m "feat(ui): add Auto Break toggle row to transcript panel"
+```
+
+### Task 13: Wire visibility rules for the Auto Break toggle (offline model + NFM gate + mutex with VAD slider)
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/transcript_panel.rs`
+
+- [ ] **Step 1: Initial visibility based on saved model + assume NFM at startup**
+
+The existing visibility block at lines 385-405 sets `vad_threshold_row` visibility based on `supports_partials`. Extend it to also handle the new `auto_break_row`:
+
+```rust
+#[cfg(feature = "sherpa")]
+{
+    let initial_supports_partials = sdr_transcription::SherpaModel::ALL
+        .get(saved_model_idx as usize)
+        .copied()
+        .is_some_and(sdr_transcription::SherpaModel::supports_partials);
+    let initial_is_offline = !initial_supports_partials;
+    let initial_auto_break_active = auto_break_row.is_active();
+
+    display_mode_row.set_visible(initial_supports_partials);
+    // VAD slider visible only when offline model AND Auto Break is OFF
+    vad_threshold_row.set_visible(initial_is_offline && !initial_auto_break_active);
+    // Auto Break toggle visible only when offline model (NFM gate added
+    // by DemodModeChanged handler in window.rs; initial state assumes NFM
+    // because that's the most common startup mode for transcription use).
+    auto_break_row.set_visible(initial_is_offline);
+
+    let display_mode_row_for_visibility = display_mode_row.clone();
+    let vad_threshold_row_for_visibility = vad_threshold_row.clone();
+    let auto_break_row_for_visibility = auto_break_row.clone();
+    model_row.connect_selected_notify(move |r| {
+        let idx = r.selected() as usize;
+        let supports_partials = sdr_transcription::SherpaModel::ALL
+            .get(idx)
+            .copied()
+            .is_some_and(sdr_transcription::SherpaModel::supports_partials);
+        let is_offline = !supports_partials;
+        let ab_active = auto_break_row_for_visibility.is_active();
+
+        display_mode_row_for_visibility.set_visible(supports_partials);
+        vad_threshold_row_for_visibility.set_visible(is_offline && !ab_active);
+        auto_break_row_for_visibility.set_visible(is_offline);
+    });
+
+    // Mutex: toggling Auto Break hides/shows the VAD threshold slider.
+    let vad_threshold_row_for_mutex = vad_threshold_row.clone();
+    let auto_break_row_clone = auto_break_row.clone();
+    auto_break_row.connect_active_notify(move |r| {
+        // Only re-evaluate visibility if Auto Break is currently visible
+        // at all (i.e., we're on an offline model). If the row is hidden
+        // it means a streaming model is selected and the mutex doesn't apply.
+        if auto_break_row_clone.is_visible() {
+            vad_threshold_row_for_mutex.set_visible(!r.is_active());
+        }
+    });
+}
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cargo check -p sdr-ui --no-default-features --features sherpa-cpu 2>&1 | tail -5
+cargo check -p sdr-ui --no-default-features --features sherpa-cuda 2>&1 | tail -5
+```
+
+Expected: both clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-ui/src/sidebar/transcript_panel.rs
+git commit -m "feat(ui): Auto Break visibility rules + VAD slider mutex"
+```
+
+### Task 14: Pass `segmentation_mode` into `BackendConfig` in window.rs
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs`
+
+- [ ] **Step 1: Read `auto_break_row.is_active()` when building the config**
+
+At `crates/sdr-ui/src/window.rs:1774-1779`, the `BackendConfig { ... }` construction:
+
+```rust
+#[cfg(feature = "sherpa")]
+let segmentation_mode = if auto_break_row.is_active() {
+    sdr_transcription::SegmentationMode::AutoBreak
+} else {
+    sdr_transcription::SegmentationMode::Vad
+};
+#[cfg(feature = "whisper")]
+let segmentation_mode = sdr_transcription::SegmentationMode::Vad;
+
+let config = sdr_transcription::BackendConfig {
+    model,
+    silence_threshold,
+    noise_gate_ratio,
+    vad_threshold,
+    segmentation_mode,
+};
+```
+
+The `auto_break_row` reference needs to be cloned into the closure at the top of `connect_transcript_panel`. Find the existing `let vad_threshold_row = ...` clone block earlier in the file and add an analogous `let auto_break_row = transcript.auto_break_row.clone();` (gated on `#[cfg(feature = "sherpa")]`).
+
+- [ ] **Step 2: Lock `auto_break_row` during active session**
+
+In the same connect handler where `vad_threshold_row.set_sensitive(false)` is called (line 1733 in current source):
+
+```rust
+#[cfg(feature = "sherpa")]
+vad_threshold_row.set_sensitive(false);
+#[cfg(feature = "sherpa")]
+auto_break_row.set_sensitive(false);
+```
+
+And where session-end re-enables rows (search for `set_sensitive(true)` in the same function):
+
+```rust
+#[cfg(feature = "sherpa")]
+auto_break_row.set_sensitive(true);
+```
+
+Mirror every existing `vad_threshold_row.set_sensitive(...)` line with an `auto_break_row.set_sensitive(...)` counterpart.
+
+- [ ] **Step 3: Build check**
+
+```bash
+cargo check -p sdr-ui --no-default-features --features sherpa-cpu 2>&1 | tail -5
+cargo check --workspace 2>&1 | tail -5
+```
+
+Expected: both clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "feat(ui): pass Auto Break selection into BackendConfig + session lock"
+```
+
+### Task 15: Add the proactive demod mode selector subtitle
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/radio_panel.rs`
+
+- [ ] **Step 1: Find the demod mode selector ComboRow**
+
+```bash
+grep -n "demod\|DemodMode\|ComboRow" crates/sdr-ui/src/sidebar/radio_panel.rs | head -20
+```
+
+Locate the line where the demod mode row is built (e.g., `let demod_row = adw::ComboRow::builder()...`).
+
+- [ ] **Step 2: Add the subtitle**
+
+Add `.subtitle("Changing band stops active transcription")` to the builder chain. Example (actual field names will match whatever is in the source):
+
+```rust
+let demod_row = adw::ComboRow::builder()
+    .title("Demodulator")
+    .subtitle("Changing band stops active transcription")
+    .model(&demod_list)
+    .build();
+```
+
+- [ ] **Step 3: Build check**
+
+```bash
+cargo check -p sdr-ui 2>&1 | tail -5
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/sidebar/radio_panel.rs
+git commit -m "feat(ui): add proactive subtitle to demod mode selector"
+```
+
+### Task 16: Subscribe to `DemodModeChanged` in window.rs — stop active transcription + toast
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs`
+
+- [ ] **Step 1: Find the existing `DspToUi` event router**
+
+```bash
+grep -n "DspToUi::\|dsp_rx\|glib::MainContext" crates/sdr-ui/src/window.rs | head -30
+```
+
+The project uses a `glib::MainContext` channel with a `attach`/`while let` pattern to route `DspToUi` events into UI updates. Find the big `match` on `DspToUi` variants.
+
+- [ ] **Step 2: Add a `DspToUi::DemodModeChanged` arm that stops transcription + shows a toast**
+
+In the `match` arm, add:
+
+```rust
+crate::messages::DspToUi::DemodModeChanged(new_mode) => {
+    tracing::info!(?new_mode, "demod mode changed");
+
+    // Update Auto Break toggle visibility based on new mode. The row
+    // is only visible when the current mode is NFM AND the selected
+    // model is offline — offline check is handled by the existing
+    // model-change handler in transcript_panel, so we just gate on
+    // mode here.
+    #[cfg(feature = "sherpa")]
+    {
+        let is_nfm = new_mode == sdr_types::DemodMode::Nfm;
+        // If not NFM, force the Auto Break row hidden (overrides the
+        // offline-model check). If NFM, restore the offline-model
+        // visibility rule.
+        let selected_is_offline = {
+            let idx = panels.transcript.model_row.selected() as usize;
+            sdr_transcription::SherpaModel::ALL
+                .get(idx)
+                .copied()
+                .is_some_and(|m| !m.supports_partials())
+        };
+        panels
+            .transcript
+            .auto_break_row
+            .set_visible(is_nfm && selected_is_offline);
+    }
+
+    // If a transcription session is currently active, stop it and
+    // toast the user. The session's BackendConfig and row settings
+    // are preserved — the user clicks Start to resume on the new band.
+    if panels.transcript.enable_row.is_active() {
+        tracing::info!("stopping active transcription due to demod mode change");
+        // Toggling enable_row off triggers the existing stop path
+        // (connect_active_notify handler at around window.rs:1719).
+        panels.transcript.enable_row.set_active(false);
+
+        let toast = adw::Toast::new(
+            "Transcription stopped — demod mode changed. Press Start to resume.",
+        );
+        toast_overlay.add_toast(toast);
+    }
+}
+```
+
+Note: `toast_overlay` is the existing `AdwToastOverlay` reference already bound in scope; `panels` is the existing panels aggregate. If the exact binding names differ, match whatever is in use.
+
+- [ ] **Step 3: Build check**
+
+```bash
+cargo check -p sdr-ui 2>&1 | tail -10
+cargo check --workspace 2>&1 | tail -5
+cargo check --workspace --no-default-features --features sherpa-cpu 2>&1 | tail -5
+cargo check --workspace --no-default-features --features sherpa-cuda 2>&1 | tail -5
+```
+
+Expected: all four clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "feat(ui): stop transcription on demod mode change + toast"
+```
+
+### Task 17: Squelch-enabled precondition check on session start
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs`
+
+- [ ] **Step 1: Check `radio.squelch_enabled_row.is_active()` before starting with Auto Break**
+
+In the `transcript.enable_row.connect_active_notify` handler at `crates/sdr-ui/src/window.rs:1719`, at the very start of the `if row.is_active()` branch (before any config building):
+
+```rust
+#[cfg(feature = "sherpa")]
+{
+    // Auto Break precondition: squelch must be enabled so the radio
+    // actually produces open/close transitions. If squelch is off, the
+    // session would run forever in Idle with no segments.
+    if auto_break_row.is_active() && !radio_panel.squelch_enabled_row.is_active() {
+        let toast = adw::Toast::new(
+            "Auto Break needs squelch enabled to detect transmission boundaries. \
+             Enable squelch in the radio panel, or turn off Auto Break to use VAD.",
+        );
+        toast_overlay.add_toast(toast);
+        // Revert the toggle — user has to take action first.
+        row.set_active(false);
+        return;
+    }
+}
+```
+
+`radio_panel.squelch_enabled_row` needs to be cloned into the closure. Find the existing panel reference clones at the top of `connect_transcript_panel` and add a clone for `radio_panel.squelch_enabled_row`.
+
+- [ ] **Step 2: Build check**
+
+```bash
+cargo check -p sdr-ui --no-default-features --features sherpa-cuda 2>&1 | tail -5
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "feat(ui): Auto Break precondition — require squelch enabled"
+```
+
+---
+
+## Phase F: Verification and close-out
+
+### Task 18: Full triple-build + clippy verification
+
+- [ ] **Step 1: Triple-flavor cargo check**
+
+```bash
+cargo check --workspace 2>&1 | tail -5
+cargo check --workspace --features whisper-cuda 2>&1 | tail -5
+cargo check --workspace --no-default-features --features sherpa-cpu 2>&1 | tail -5
+cargo check --workspace --no-default-features --features sherpa-cuda 2>&1 | tail -5
+```
+
+Expected: all four clean.
+
+- [ ] **Step 2: Clippy on each flavor**
+
+```bash
+cargo clippy --all-targets --workspace -- -D warnings 2>&1 | tail -15
+cargo clippy --all-targets --workspace --no-default-features --features sherpa-cpu -- -D warnings 2>&1 | tail -15
+cargo clippy --all-targets --workspace --no-default-features --features sherpa-cuda -- -D warnings 2>&1 | tail -15
+```
+
+Expected: clean on all three.
+
+- [ ] **Step 3: Test workspace**
+
+```bash
+cargo test --workspace 2>&1 | grep -E "test result|FAILED" | tail -20
+```
+
+Expected: all pre-existing + new tests pass, zero failures.
+
+- [ ] **Step 4: Format check**
+
+```bash
+cargo fmt --all -- --check 2>&1 | tail -5
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Deny check for both graphs**
+
+```bash
+cargo deny check 2>&1 | tail -10
+cargo deny --no-default-features --features sherpa-cuda check sources 2>&1 | tail -5
+```
+
+Expected: both pass.
+
+- [ ] **Step 6: If anything fails, fix and re-run; if all pass, commit any fmt adjustments**
+
+```bash
+git status
+# If files were modified by cargo fmt:
+git add -u
+git commit -m "chore: cargo fmt"
+```
+
+### Task 19: User-driven pre-PR smoke test
+
+This is the checklist from the spec's "Pre-PR smoke test checklist" section. The user runs through it manually on a running `sdr-rs` binary.
+
+- [ ] **Step 1: Install the sherpa-cuda build**
+
+```bash
+make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"
+```
+
+Expected: clean build, install succeeds.
+
+- [ ] **Step 2: Run the full spec checklist**
+
+Work through every item in `docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md` under "Pre-PR smoke test checklist (user-driven, runs before the PR is opened)". Items are grouped by category:
+
+- Build + launch sanity (3 items)
+- Sherpa model regression with Auto Break OFF (3 items)
+- VAD threshold slider regression (3 items)
+- Auto Break new feature (12 items)
+- Universal mode-change stop (5 items)
+- Whisper regression (1 item)
+
+Each checkbox is a concrete observable behavior. Check it only after verifying on the running binary.
+
+- [ ] **Step 3: Record the filled-in checklist**
+
+Copy the completed checklist into a scratch note for use as the PR body's test plan.
+
+### Task 20: File follow-up issue for slider tuning
+
+- [ ] **Step 1: Create the GitHub issue**
+
+```bash
+gh issue create --title "Expose Auto Break timing parameters as user-tunable sliders" --body "Context: PR for #265 ships Auto Break with hardcoded constants in \`crates/sdr-transcription/src/backends/sherpa/offline.rs\`:
+
+- \`AUTO_BREAK_MIN_OPEN_MS = 100\`
+- \`AUTO_BREAK_TAIL_MS = 200\`
+- \`AUTO_BREAK_MIN_SEGMENT_MS = 400\`
+- \`AUTO_BREAK_MAX_SEGMENT_MS = 30_000\`
+
+Problem: there is no one-size-fits-all for real-world NFM — different bands, repeaters, mobile signals, and scanner use cases have different optimal hold-off values. The VAD threshold slider in PR 6 is precedent for exactly this kind of tuning surface.
+
+Proposed: add three new SpinRows to the transcript panel under the Auto Break toggle (visible only when Auto Break is on). Persist as \`transcription_auto_break_min_open_ms\` / \`_tail_ms\` / \`_min_segment_ms\` config keys. Defaults match the v1 hardcoded values.
+
+Acceptance: real-world scanner testing with the slider values tuned produces cleaner segment boundaries than the defaults on at least one representative recording.
+
+Labels: enhancement, transcription, ui" --label enhancement
+```
+
+- [ ] **Step 2: Record the issue number for the PR description**
+
+### Task 21: Commit, push, open PR
+
+- [ ] **Step 1: Final status check**
+
+```bash
+git status
+git log --oneline feature/auto-break-segmentation ^main
+```
+
+Expected: clean working tree, a sequence of feature commits on the branch.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feature/auto-break-segmentation
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "feat(transcription): Auto Break segmentation + universal stop-on-mode-change" --body "$(cat <<'EOF'
+## Summary
+- Adds a new `sherpa-cuda`-and-`sherpa-cpu`-compatible `Auto Break` segmentation mode for offline sherpa models (Moonshine, Parakeet) that uses the radio's squelch gate as the utterance boundary instead of Silero VAD. NFM demod only; mutex with VAD per session.
+- Introduces a universal behavior change: any demod mode change while transcription is active now stops the session cleanly with an explainer toast. Applies to BOTH Auto Break and VAD modes — this is a deliberate UX simplification.
+- Refactors the internal audio-tap channel from `mpsc::SyncSender<Vec<f32>>` to `mpsc::SyncSender<TranscriptionInput>` so squelch edge events can flow alongside samples. Whisper pattern-matches on `Samples` and ignores the edge variants.
+
+## Test plan
+(Paste the filled-in pre-PR smoke test checklist from the spec here.)
+
+## Design docs
+- Spec: `docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md`
+- Plan: `docs/superpowers/plans/2026-04-13-auto-break-segmentation.md`
+
+## Behavior change for existing VAD users
+PRs 1–6 let VAD mode transcription continue across demod mode changes. This PR changes that to a universal stop. The project has one user today (the owner), who confirmed during design that the change is actively preferable — the old behavior was quietly lossy across band changes because different bands have different noise characteristics.
+
+## Follow-up
+- #XXX (filed during this PR) — expose Auto Break timing parameters as user-tunable sliders after real-world testing
+
+Closes #265.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" 2>&1 | tail -3
+```
+
+Replace `#XXX` with the actual issue number from Task 20.
+
+- [ ] **Step 4: Record the PR URL**
+
+---
+
+## Self-review
+
+### Spec coverage
+
+Walking through each spec section:
+
+- **Goal / Motivation / Non-goals** — captured in plan header, no tasks needed
+- **Architecture / Data flow** — Tasks 1-8 (channel refactor + edge-event emission)
+- **`TranscriptionInput` enum** — Task 1 Step 1
+- **`SegmentationMode` enum + `BackendConfig` field** — Task 1 Steps 1-2
+- **Controller-side changes (squelch_was_open, edge events, NFM gate)** — Task 7
+- **Offline session loop state machine** — Tasks 9-11
+- **`run_session` dispatch** — Task 10
+- **Hardcoded timing constants** — Task 9
+- **Hysteresis blip behavior** — covered by `hysteresis_blip_single_utterance` test in Task 11 Step 1
+- **Max-segment safety cap** — covered by `max_segment_safety_flush` test + implementation in Task 11
+- **Mode-change universal stop** — Tasks 8 (emit event) + 16 (UI subscriber)
+- **UI transcript panel row + visibility** — Tasks 12-14
+- **Demod selector subtitle** — Task 15
+- **Toast on mode change** — Task 16 Step 2
+- **Precondition check** — Task 17
+- **Streaming rejection of AutoBreak** — Task 4 Step 1
+- **Whisper compatibility (ignore edge events)** — Task 2
+- **Config key persistence** — Task 12 Steps 1-2
+- **Session lock** — Task 14 Step 2
+- **Testing strategy unit tests** — Task 11 Step 1 (5 Auto Break state machine tests)
+- **Mode-change stop unit tests** — NOT covered by a unit test task; gap noted below
+- **Pre-PR smoke test checklist** — Task 19
+- **Follow-up issue for sliders** — Task 20
+- **Triple-build verification** — Task 18
+
+**Gaps found:**
+
+1. **Mode-change stop unit tests** — the spec lists 4 unit tests (`mode_change_stops_active_transcription_vad_mode`, `_auto_break_mode`, `mode_change_preserves_config`, `mode_change_without_active_session_is_noop`) but these test UI-layer behavior that requires a running GTK context. Testing them properly needs either a headless GTK harness (not in scope today) or a refactor that extracts the decision logic into a pure function. **Accepting the gap**: the smoke test checklist Task 19 covers all four scenarios as user-driven verification. Noted in the plan's Task 19 so it's not forgotten.
+
+### Placeholder scan
+
+Ran: `grep -ni "tbd\|todo\|fill in\|handle the case" docs/superpowers/plans/2026-04-13-auto-break-segmentation.md`
+
+No hits on "TBD", "TODO", or "fill in". Some tasks reference "the existing handler at line N" — that's a pointer into specific code locations, not a placeholder.
+
+### Type consistency
+
+- `TranscriptionInput::{Samples, SquelchOpened, SquelchClosed}` — used consistently across Tasks 1, 2, 3, 4, 5, 6, 7, 11. No drift.
+- `SegmentationMode::{Vad, AutoBreak}` — consistent across Tasks 1, 3, 4, 10, 14.
+- `AutoBreakMachine::{new, on_samples, on_squelch_opened, on_squelch_closed, on_tail_timeout, buffer_duration_ms, take_buffer, feed_sequence}` — method names defined in Task 11 Step 3 and used in Task 11 Steps 1 (test) and 5 (session loop). Consistent.
+- `KEY_AUTO_BREAK_ENABLED` — defined in Task 12 Step 1, used in Task 12 Steps 1-2 only (not referenced from window.rs; state lives in the row widget).
+- `auto_break_row` — field name consistent across Tasks 12, 13, 14, 16, 17.
+- `DemodMode::Nfm` — used consistently, correct enum path via `sdr_types::DemodMode`.
+- `DspToUi::DemodModeChanged(DemodMode)` — defined in Task 8 Step 1, consumed in Task 16 Step 2. Consistent.
+
+No type drift found.

--- a/docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md
@@ -45,7 +45,7 @@ sdr-core::controller::DspState
     |  detects edge transitions on squelch_open()
     |  AND gates emission on current_mode == DemodMode::Nfm
     v
-mpsc::Sender<TranscriptionInput>   [type change, previously Sender<Vec<f32>>]
+mpsc::SyncSender<TranscriptionInput>   [type change, previously SyncSender<Vec<f32>>]
     |
     v
 sdr-transcription::backends::sherpa::host::SherpaHost
@@ -96,7 +96,7 @@ pub enum TranscriptionInput {
 }
 ```
 
-The existing `sdr-core::DspState::transcription_tx: Option<mpsc::Sender<Vec<f32>>>` field changes to `Option<mpsc::Sender<TranscriptionInput>>`. All producer and consumer sites update together.
+The existing `sdr-core::DspState::transcription_tx: Option<mpsc::SyncSender<Vec<f32>>>` field changes to `Option<mpsc::SyncSender<TranscriptionInput>>`. All producer and consumer sites update together. Keeping the channel bounded (via `SyncSender` rather than unbounded `Sender`) is deliberate: backpressure on the DSP thread prevents unbounded memory growth if the backend stalls, and the `TrySendError::Full` path on squelch edge events drives the retry-next-block logic in the controller that preserves state-machine transition integrity under load.
 
 #### `sdr-transcription::backend::SegmentationMode`
 
@@ -258,7 +258,7 @@ State machine — implemented as a Rust enum + `recv_timeout` loop, no extra thr
 
 **User-facing explainer**:
 
-- **Proactive**: the demod mode selector row in the radio panel gains a subtitle reading *"Changing band stops active transcription"*. Warns users before they trigger the stop.
+- **Proactive**: the demod mode selector (a `gtk4::DropDown` in the header bar — not an `AdwComboRow`, so it has no subtitle slot) gains an extended `tooltip_text` reading *"Demodulation mode — changing modes stops active transcription"*. Hover-visible warning before the user triggers the stop. This was a late adjustment from an earlier spec draft that assumed the selector was an `AdwComboRow` with a subtitle slot; the tooltip is the closest equivalent on the actual header `DropDown` widget.
 - **Reactive**: when transcription actually stops due to a mode change, the transcript panel (or the main window's toast overlay) shows an `AdwToast` titled *"Transcription stopped — demod mode changed. Press Start to resume."* — 65 characters, one line even in a narrow window.
 
 **What this replaces**: the earlier draft of this spec proposed fallback semantics for Auto Break on non-NFM modes (state machine stays idle indefinitely, transcription silently goes quiet). That approach is now dropped in favor of the universal stop, which produces equivalent behavior with a much clearer user signal (explicit toast vs silent quiet).
@@ -369,7 +369,7 @@ No new `BackendError` variants needed.
 7. **Mode switch with VAD mode on (behavior change regression)** — same as #6 but with Auto Break OFF (plain VAD mode). Verify transcription ALSO stops on mode change and shows the same toast. This is a behavior change from PR 1–6 and needs an explicit confirm-this-is-what-we-want check.
 8. **Squelch-disabled precondition** — disable squelch entirely in the radio panel, try to start transcription with Auto Break on, verify toast appears and session does not start
 9. **VAD regression (within a session)** — disable Auto Break, verify VAD threshold slider reappears and existing PR 6 VAD behavior within a single-mode session is unchanged
-10. **Demod selector subtitle** — verify the demod mode selector row shows the proactive subtitle *"Changing band stops active transcription"* and that it's readable in a narrow window
+10. **Demod selector tooltip** — hover over the demod mode `DropDown` in the header bar and verify the tooltip reads *"Demodulation mode — changing modes stops active transcription"*
 
 **Pre-PR smoke test checklist (user-driven, runs before the PR is opened)**:
 
@@ -410,7 +410,7 @@ This is the structured regression pass that catches anything the unit tests and 
 
 **Universal mode-change stop — new behavior**:
 
-- [ ] Proactive subtitle *"Changing band stops active transcription"* visible on the demod mode selector row, readable in both narrow and wide window sizes
+- [ ] Proactive tooltip *"Demodulation mode — changing modes stops active transcription"* visible on hover over the header-bar demod mode `DropDown`
 - [ ] VAD mode active + switch NFM → WFM: transcription stops, toast appears with exact text *"Transcription stopped — demod mode changed. Press Start to resume."*
 - [ ] Auto Break mode active + switch NFM → WFM: same stop + same toast
 - [ ] After mode-change stop, click Start: transcription resumes on the new band with configuration preserved (model, VAD threshold, Auto Break setting if applicable)
@@ -443,7 +443,7 @@ This is the structured regression pass that catches anything the unit tests and 
 
 4. **Demod mode change plumbing.** We need a `DspToUi::DemodModeChanged` event so the transcript panel can re-run visibility checks AND trigger the stop-on-mode-change behavior. This is net-new message-enum work — small, but the messages crate is shared between several consumers and needs a clean add. Risk: low, but the touch surface grows slightly.
 
-5. **Behavior change vs PRs 1–6.** PRs 1–6 let VAD mode transcription continue across demod mode changes; this PR changes that to a universal stop. The project has one user today (the owner), who confirmed during design that the change is fine and actively preferable — the old behavior was quietly lossy (cross-band noise characteristics break recognition quality) and the new behavior gives a clear explicit signal via toast. No soft-launch / opt-out gate is included. The PR description will still call the change out prominently for CodeRabbit and future readers, and the proactive subtitle on the demod selector acts as a passive explainer.
+5. **Behavior change vs PRs 1–6.** PRs 1–6 let VAD mode transcription continue across demod mode changes; this PR changes that to a universal stop. The project has one user today (the owner), who confirmed during design that the change is fine and actively preferable — the old behavior was quietly lossy (cross-band noise characteristics break recognition quality) and the new behavior gives a clear explicit signal via toast. No soft-launch / opt-out gate is included. The PR description will still call the change out prominently for CodeRabbit and future readers, and the proactive tooltip on the demod selector acts as a passive explainer.
 
 6. **Auto Break follow-up issue for sliders.** User agreed to ship hardcoded constants with a follow-up issue to add sliders once real-world testing is in. The follow-up issue needs to be filed before merge so we don't forget.
 

--- a/docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md
@@ -1,0 +1,464 @@
+# Auto Break Segmentation Design
+
+**Status:** Design approved 2026-04-13
+**Tracking:** #265 (from PR 6 follow-up batch)
+**Branch:** `feature/auto-break-segmentation` (not yet created)
+
+## Goal
+
+Add a new segmentation mode for offline sherpa transcription (Moonshine Tiny/Base, Parakeet-TDT) that uses the radio's existing squelch gate as the utterance boundary instead of Silero VAD. On NFM scanner audio, the radio's squelch is a cleaner physical-layer answer to "is there a transmission to transcribe right now" than running a speech/non-speech classifier over audio that already went through a signal-detection gate. The user's scanner testing of the sherpa-cuda PR 7 build showed the GPU is effectively free for Parakeet inference and the remaining bottleneck is VAD accuracy on noisy RF input — Auto Break is the feature that takes advantage of that spare compute.
+
+## Motivation
+
+Current behavior on NFM scanner use:
+
+- Silero VAD runs over the AF-chain audio and produces segment boundaries based on generic speech/non-speech classification
+- The AF audio always includes squelch-tail hiss and occasional false openings, which Silero sometimes misclassifies as speech
+- User-tuned `vad_threshold` (from PR 6) helps but is fighting the underlying problem — Silero was trained on clean speech, not narrow-band RF with squelch-noise contamination
+
+Proposed: use the physical squelch gate, which the radio already tracks, as the ground truth for "a transmission is happening." The radio knows when signal crossed the noise floor; it shouldn't have to ask a machine learning model to also figure that out.
+
+## Non-goals
+
+- **Not** replacing VAD globally — Silero VAD remains the default for offline sherpa models when Auto Break is off, and the only supported segmentation for the streaming Zipformer path. Auto Break is an opt-in alternative, not a replacement.
+- **Not** applying to streaming Zipformer. Zipformer's own endpoint detection already handles within-transmission phrase boundaries; Auto Break would introduce races with it. Scoped to offline models only.
+- **Not** adding user-tunable sliders for the hold-off timing constants in v1. Ship sensible defaults, file a follow-up issue to expose sliders if and only if real-world testing shows the defaults fail.
+- **Not** touching the Whisper backend. `TranscriptionInput`'s new enum variants are passed through but ignored by the Whisper session loop in v1. Whisper retrofit is tracked separately in #259.
+- **Not** adding a visual squelch open/close indicator to the UI. Orthogonal improvement, candidate for a separate small PR.
+- **Not** changing how auto-squelch works. Auto Break consumes whatever squelch state the user has configured (auto or manual); the transcription setting never reaches over and modifies radio state.
+
+## Critical correction to the PR 6 follow-up-issue notes
+
+Issue #265 was filed under the working title "squelch-gated transcription." The naming during this design session shifted to "Auto Break" because the feature is really about using the natural gaps between transmissions as segmentation markers rather than about gating audio feed to the recognizer. Functionally they're close, but "Auto Break" is the user-facing name going forward — matches scanner radio terminology and is what the UI toggle will read.
+
+## Architecture
+
+### Data flow
+
+```text
+RadioModule::if_chain::squelch_open() -> bool   [exists today, unchanged]
+    |
+    |  (polled once per AF chunk)
+    v
+sdr-core::controller::DspState
+    |
+    |  detects edge transitions on squelch_open()
+    |  AND gates emission on current_mode == DemodMode::Nfm
+    v
+mpsc::Sender<TranscriptionInput>   [type change, previously Sender<Vec<f32>>]
+    |
+    v
+sdr-transcription::backends::sherpa::host::SherpaHost
+    |
+    v
+sdr-transcription::backends::sherpa::offline::run_session
+    |
+    v
+Auto Break state machine  (new, mutex with Silero VAD path)
+    |
+    v
+OfflineRecognizer::decode()   [existing, unchanged]
+```
+
+The `sdr-core` controller is the only place that sees both squelch state AND demod mode, so it's the natural producer of squelch events. Keeping emission gated on `demod == DemodMode::Nfm` means downstream backends never have to worry about whether squelch events are meaningful — if they arrive, they are.
+
+### Data type changes
+
+#### `sdr-transcription::backend::TranscriptionInput`
+
+New enum that replaces the current `Vec<f32>` audio-tap contract:
+
+```rust
+/// Frames sent from the DSP controller into a transcription backend.
+///
+/// Carries both raw audio samples and segmentation-boundary hints. The
+/// boundary variants are emitted only when the current demod mode is
+/// NFM — the controller handles the gating so backends don't have to.
+///
+/// Backends that don't care about squelch-based segmentation (Whisper,
+/// streaming Zipformer, offline sherpa in `SegmentationMode::Vad`)
+/// pattern-match on `Samples` and drop the other variants.
+#[derive(Debug)]
+pub enum TranscriptionInput {
+    /// Interleaved-stereo f32 PCM at `SAMPLE_RATE_HZ`. Always emitted,
+    /// gap-free, at a cadence determined by the audio pipeline.
+    Samples(Vec<f32>),
+
+    /// Radio squelch just opened. Edge event, emitted exactly once per
+    /// close→open transition. Only emitted when the current demod mode
+    /// is NFM.
+    SquelchOpened,
+
+    /// Radio squelch just closed. Edge event, emitted exactly once per
+    /// open→close transition. Only emitted when the current demod mode
+    /// is NFM.
+    SquelchClosed,
+}
+```
+
+The existing `sdr-core::DspState::transcription_tx: Option<mpsc::Sender<Vec<f32>>>` field changes to `Option<mpsc::Sender<TranscriptionInput>>`. All producer and consumer sites update together.
+
+#### `sdr-transcription::backend::SegmentationMode`
+
+New enum on `BackendConfig` that decides which segmentation engine drives the offline session:
+
+```rust
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SegmentationMode {
+    /// Silero VAD drives segmentation. The only valid mode for streaming
+    /// Zipformer, and the default for offline sherpa models unless the
+    /// user explicitly opts into Auto Break.
+    #[default]
+    Vad,
+
+    /// Auto Break: use the radio's squelch gate as the segmentation
+    /// boundary. Valid only for offline sherpa models in NFM mode.
+    /// See `backends/sherpa/offline.rs` for the state machine that
+    /// consumes `SquelchOpened` / `SquelchClosed` events.
+    AutoBreak,
+}
+```
+
+`BackendConfig` gains one field:
+
+```rust
+pub struct BackendConfig {
+    // ... existing fields ...
+    pub vad_threshold: f32,           // existing, only read when mode == Vad
+    pub segmentation_mode: SegmentationMode,  // NEW
+}
+```
+
+### Controller-side changes (sdr-core)
+
+`DspState` grows a `squelch_was_open: bool` field initialized to `false`. On each AF chunk emitted from the radio module:
+
+1. Read `radio.if_chain().squelch_open()` → `now_open: bool`
+2. Send `TranscriptionInput::Samples(chunk)` unconditionally (gap-free audio preserved)
+3. If `now_open != squelch_was_open` AND `radio.current_mode() == DemodMode::Nfm`:
+   - Emit `SquelchOpened` or `SquelchClosed` to the transcription channel
+4. Update `squelch_was_open = now_open`
+
+Gating on `current_mode == DemodMode::Nfm` means a mid-session mode switch to WFM simply stops the squelch event stream. The transcription session in Auto Break mode sees `Samples` continue to flow but no more boundary events — which rolls cleanly into the fallback behavior described below.
+
+### Offline session loop state machine
+
+`backends/sherpa/offline.rs::run_session` currently assumes Silero VAD drives segmentation. It gains a branch on `config.segmentation_mode`:
+
+```rust
+match config.segmentation_mode {
+    SegmentationMode::Vad => run_session_vad(...),       // existing code, renamed
+    SegmentationMode::AutoBreak => run_session_auto_break(...),  // NEW
+}
+```
+
+Hardcoded timing constants at the top of the offline module:
+
+```rust
+/// Squelch openings shorter than this are treated as noise spikes and
+/// produce no segment. Chosen to exclude sub-syllable blips while still
+/// catching short single-word transmissions ("copy").
+const AUTO_BREAK_MIN_OPEN_MS: u32 = 100;
+
+/// Continue buffering audio for this long after the squelch closes, so
+/// the last syllable of the transmission isn't chopped by a tight
+/// squelch-close timing. Chosen empirically from the typical fall time
+/// of a PowerSquelch transition plus ~100 ms of spoken-word tail.
+const AUTO_BREAK_TAIL_MS: u32 = 200;
+
+/// Segments shorter than this are discarded instead of being fed to
+/// the recognizer. Moonshine and Parakeet both hallucinate badly on
+/// sub-word fragments, so dropping them is an accuracy improvement,
+/// not a loss.
+const AUTO_BREAK_MIN_SEGMENT_MS: u32 = 400;
+
+/// Safety cap: if squelch stays open longer than this, flush the
+/// buffer anyway. Protects against pathological stuck-open situations
+/// (bad auto-squelch, carrier jam, band opening) that would otherwise
+/// cause unbounded memory growth.
+const AUTO_BREAK_MAX_SEGMENT_MS: u32 = 30_000;
+```
+
+State machine — implemented as a Rust enum + `recv_timeout` loop, no extra threads:
+
+```text
+┌─────────────────────────────┐
+│ Idle                        │
+│  - buffer: empty             │
+│  - waiting for SquelchOpened │
+└─────────────────────────────┘
+    │
+    │ SquelchOpened
+    │ (record open_time, clear buffer)
+    v
+┌─────────────────────────────┐
+│ Recording(open_time)        │
+│  - buffer: growing           │
+│  - append incoming Samples   │
+└─────────────────────────────┘
+    │
+    │ SquelchClosed
+    v
+┌─────────────────────────────┐
+│ HoldingOff(close_time)      │
+│  - buffer: still growing     │
+│    (capture trailing tail)  │
+│  - recv_timeout = TAIL_MS    │
+└─────────────────────────────┘
+    │
+    ├─── SquelchOpened ─────────┐
+    │    (cancel hold-off,       │
+    │     back to Recording,     │
+    │     same buffer — this is │
+    │     a hysteresis blip)     │
+    │                            │
+    │ ◄──────────────────────────┘
+    │
+    │ timeout(TAIL_MS)
+    v
+┌─────────────────────────────┐
+│ Evaluate buffer:             │
+│                              │
+│ if duration < MIN_OPEN_MS:   │
+│   discard (phantom open)     │
+│                              │
+│ elif duration < MIN_SEGMENT: │
+│   discard (too short for     │
+│   recognizer accuracy)       │
+│                              │
+│ else:                        │
+│   OfflineRecognizer::decode()│
+│   emit Text event            │
+│                              │
+│ → Idle                       │
+└─────────────────────────────┘
+```
+
+**Max-segment safety**: in the `Recording` state, if the current buffer duration exceeds `AUTO_BREAK_MAX_SEGMENT_MS`, the state machine force-transitions to an evaluation step as if `HoldingOff` had timed out. This catches stuck-open squelch situations without letting the buffer grow unbounded.
+
+**recv_timeout plumbing**: the session loop already uses an mpsc receiver. Switch to `recv_timeout` in the `HoldingOff` state with the remaining hold-off duration. `Recording` state uses a blocking `recv` (no timer needed). `Idle` state uses blocking `recv`. Single-threaded, no extra coordination primitives.
+
+### Mode-change behavior — universal transcription stop
+
+**Demod mode is a top-level boundary. Any change to `current_mode` while transcription is active stops the session, regardless of which segmentation mode is configured (VAD or Auto Break).** This is a behavior change from PRs 1–6 — today, mid-session mode changes continue transcription in whatever state the recognizer happens to be in. The new behavior treats the demod mode as part of the session's conceptual identity, so changing it requires an explicit restart.
+
+**Rationale**:
+
+- "Changing band" (in user language) is the top-level "I'm listening to something different now" signal. Tying transcription to it matches scanner/radio user intuition.
+- Eliminates the WFM fallback question entirely for Auto Break — no state-machine edge cases around Samples-flowing-without-events, no "Auto Break is configured but inert" mental-model trap.
+- Applies uniformly to VAD mode too, which benefits — Whisper's RMS gating in particular drifts badly across band changes because different bands have different noise characteristics, so a clean restart is an accuracy improvement.
+- Simpler state model: no mid-session dual-mode handoff logic anywhere.
+
+**Implementation**:
+
+- A new `DspToUi::DemodModeChanged(DemodMode)` event is emitted by the controller whenever `current_mode` changes. This event already exists in the spec for UI visibility-rule updates on the Auto Break toggle; we reuse it here.
+- The transcript panel subscribes to `DemodModeChanged`. If transcription is currently active when the event fires, it calls `backend.stop()` via the existing stop path and shows a toast (see below).
+- Backend config (including `segmentation_mode`, `vad_threshold`, model selection) is preserved across the stop — the user's configuration is intact, they just need to click Start to resume on the new band.
+- Config persistence is unchanged — config keys remain valid across the stop/start cycle.
+
+**User-facing explainer**:
+
+- **Proactive**: the demod mode selector row in the radio panel gains a subtitle reading *"Changing band stops active transcription"*. Warns users before they trigger the stop.
+- **Reactive**: when transcription actually stops due to a mode change, the transcript panel (or the main window's toast overlay) shows an `AdwToast` titled *"Transcription stopped — demod mode changed. Press Start to resume."* — 65 characters, one line even in a narrow window.
+
+**What this replaces**: the earlier draft of this spec proposed fallback semantics for Auto Break on non-NFM modes (state machine stays idle indefinitely, transcription silently goes quiet). That approach is now dropped in favor of the universal stop, which produces equivalent behavior with a much clearer user signal (explicit toast vs silent quiet).
+
+### UI — transcript panel
+
+One new `AdwSwitchRow` added to the transcript panel below the VAD threshold SpinRow:
+
+```text
+┌──────────────────────────────────────────────┐
+│ Transcription                                │
+│                                              │
+│ [Model       ] [Parakeet TDT 0.6b      ▾]    │
+│ [Enable      ] [ ○ ]                         │
+│                                              │
+│ [VAD threshold]  ├─────●──────┤   0.30       │  ← hidden when Auto Break ON
+│                                              │
+│ [Auto Break  ] [ ● ]                         │  ← NEW, NFM + offline only
+│   Use the radio's squelch as the             │
+│   transcription boundary instead of VAD.     │
+│   NFM only.                                  │
+│                                              │
+│ ┌────────────────── transcript ─────────┐    │
+│ │                                        │    │
+│ └────────────────────────────────────────┘    │
+└──────────────────────────────────────────────┘
+```
+
+**Visibility rules**: the Auto Break row is visible when ALL of:
+
+1. The selected sherpa model is offline (`!SherpaModel::supports_partials()`)
+2. The current demod mode is `DemodMode::Nfm`
+3. The `sherpa` cargo feature is active (automatically true if this panel is rendering)
+
+**Mutex visibility with VAD threshold slider**: when the Auto Break toggle is ON, the VAD threshold SpinRow hides. When the Auto Break toggle is OFF, the VAD threshold SpinRow shows as today. Both rows share the offline-model visibility check; the mutex is a second layer on top.
+
+**Subtitle copy**: `"Use the radio's squelch as the transcription boundary instead of VAD. NFM only."` — matches AdwPreferencesRow subtitle slot, serves as inline explainer for operators who don't yet understand the segmentation system.
+
+**Demod mode reactivity**: transcript panel currently has no `mode-changed` signal input from the engine. We add one — a new `DspToUi::DemodModeChanged(DemodMode)` event emitted from the controller whenever `current_mode` changes, subscribed to by the transcript panel to re-run visibility checks. Small plumbing addition, reusable later for other mode-gated UI.
+
+**Persistence**: new config key `transcription_auto_break_enabled: bool`, default `false`. Session-locked during active transcription per the PR 5 pattern — the Auto Break toggle and the VAD threshold slider both become insensitive when a session is running.
+
+**Precondition check at session start**: if the user has Auto Break enabled AND the radio has squelch fully disabled (not auto-squelch, not manual threshold — literally off), session start is blocked with a toast:
+
+```
+Auto Break needs squelch enabled to detect transmission boundaries.
+Enable squelch in the radio panel, or turn off Auto Break to use VAD.
+```
+
+The user clears the error by either enabling squelch or turning off Auto Break, then re-clicks Start. The precondition check reads a new public accessor `IfChain::is_squelch_configured() -> bool` which returns `true` when either auto-squelch is enabled OR a manual threshold is set, and `false` only when squelch is fully disabled. `sdr-radio` currently exposes `squelch_open() -> bool` (runtime gate state) but not the configuration state, so this is a small API addition: two lines in `PowerSquelch` to track the "enabled" flag and one forwarding method on `IfChain`.
+
+### Backend selection guard
+
+`backends/sherpa/offline.rs::run_session` validates at entry:
+
+```rust
+if config.segmentation_mode == SegmentationMode::AutoBreak
+    && !matches!(model.kind(), ModelKind::OfflineMoonshine | ModelKind::OfflineNemoTransducer)
+{
+    return Err(BackendError::Init(
+        "Auto Break is only supported for offline sherpa models \
+         (Moonshine, Parakeet). Streaming Zipformer must use Vad.".to_owned()
+    ));
+}
+```
+
+Streaming Zipformer's session loop asserts the same precondition but in `run_session_online` — rejects `SegmentationMode::AutoBreak` with a clear error. Should never fire because UI prevents the combination, but defensive guard protects against config file corruption or API misuse.
+
+## Error handling
+
+All error paths reuse the existing sherpa backend infrastructure:
+
+- Squelch-disabled precondition failure → toast + session start blocked, no new error variant
+- Auto Break + streaming Zipformer combination → rejected at session start with `BackendError::Init`, caught by the existing session-init error path in `window.rs`
+- Max-segment safety flush → emits a tracing `warn!` log line ("Auto Break buffer exceeded 30s — forcing flush, consider checking squelch configuration") and proceeds to normal decode
+- Segment discarded due to MIN_OPEN or MIN_SEGMENT filter → tracing `debug!` line, no user-visible event (these are expected in normal operation)
+- Recognizer decode failure inside `OfflineRecognizer::decode()` → existing error path emits `TranscriptionEvent::Error`
+
+No new `BackendError` variants needed.
+
+## Testing strategy
+
+**Unit tests in `backends/sherpa/offline.rs`**:
+
+- `auto_break_state_machine_clean_utterance` — simulate `SquelchOpened → Samples × N → SquelchClosed → timeout`, assert single decode call with the buffered samples
+- `auto_break_hysteresis_blip_single_utterance` — simulate `Open → Samples → Close → Samples → Open → Samples → Close → timeout`, assert single decode call containing all samples (blip ignored)
+- `auto_break_phantom_open_discarded` — simulate `Open → Close` within MIN_OPEN_MS, assert zero decode calls
+- `auto_break_sub_min_segment_discarded` — simulate `Open → 300 ms of samples → Close`, assert zero decode calls (below MIN_SEGMENT_MS)
+- `auto_break_max_segment_safety_flush` — simulate `Open → 31 s of samples`, assert decode call triggered by the safety cap, state returns to Recording-equivalent for the remaining stream
+- `auto_break_rejects_streaming_model` — `BackendConfig { segmentation_mode: AutoBreak, model: StreamingZipformerEn }` at session start returns `BackendError::Init` with the expected message
+- `auto_break_vad_mutex_default_is_vad` — `BackendConfig::default().segmentation_mode == SegmentationMode::Vad`
+
+**Unit tests for the mode-change stop behavior** (in `sdr-ui::sidebar::transcript_panel` or equivalent):
+
+- `mode_change_stops_active_transcription_vad_mode` — given an active session in `SegmentationMode::Vad`, simulate a `DemodModeChanged` event, assert the backend stop path is invoked and the toast is shown with the expected copy
+- `mode_change_stops_active_transcription_auto_break_mode` — same scenario but with `SegmentationMode::AutoBreak`, assert equivalent behavior (universal, not feature-gated)
+- `mode_change_preserves_config` — after the stop triggered by mode change, assert that `BackendConfig` (VAD threshold, segmentation mode, model selection) is unchanged in the panel state
+- `mode_change_without_active_session_is_noop` — simulate `DemodModeChanged` when transcription is not running, assert no toast, no spurious stop calls, config unchanged
+
+**Integration smoke test (user-driven)**:
+
+1. **Clean regression pass** — with Auto Break OFF, all three sherpa models still work per PR 7 baseline
+2. **Auto Break with Parakeet on NFM scanner** — enable Auto Break, scanner for 10 minutes on a real NFM frequency, verify transcript shows one entry per transmission with no mid-transmission splits and no squelch-tail garbage
+3. **Auto Break with Moonshine Base on NFM scanner** — same test as above, Moonshine should produce shorter transcripts faster
+4. **Hysteresis blip test** — find a weak station that drops below squelch briefly mid-transmission, verify the transmission is captured as one segment not two
+5. **Phantom open test** — tune to a dead channel with auto-squelch, verify no spurious transcript entries from noise-spike openings
+6. **Mode switch with Auto Break on** — switch NFM → WFM mid-session, verify transcription stops cleanly, verify the toast appears reading *"Transcription stopped — demod mode changed. Press Start to resume."*, switch back to NFM, click Start, verify session resumes with Auto Break configuration intact
+7. **Mode switch with VAD mode on (behavior change regression)** — same as #6 but with Auto Break OFF (plain VAD mode). Verify transcription ALSO stops on mode change and shows the same toast. This is a behavior change from PR 1–6 and needs an explicit confirm-this-is-what-we-want check.
+8. **Squelch-disabled precondition** — disable squelch entirely in the radio panel, try to start transcription with Auto Break on, verify toast appears and session does not start
+9. **VAD regression (within a session)** — disable Auto Break, verify VAD threshold slider reappears and existing PR 6 VAD behavior within a single-mode session is unchanged
+10. **Demod selector subtitle** — verify the demod mode selector row shows the proactive subtitle *"Changing band stops active transcription"* and that it's readable in a narrow window
+
+**Pre-PR smoke test checklist (user-driven, runs before the PR is opened)**:
+
+This is the structured regression pass that catches anything the unit tests and CI don't cover — end-to-end user flows on real RF, touching both the new Auto Break feature and everything it might accidentally break via the `TranscriptionInput` channel refactor. Every item is a concrete observable behavior; check each box only after verifying it on the running binary.
+
+**Build + launch sanity (covers the channel refactor on non-sherpa paths)**:
+
+- [ ] `make install CARGO_FLAGS="--release"` (default whisper-cpu) builds and `sdr-rs` launches without error
+- [ ] `make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"` builds and `sdr-rs` launches without error
+- [ ] Whisper default: start transcription on a live NFM signal, confirm RMS-gated commits still appear in the transcript (if the channel refactor broke the Whisper consumer, this is where it surfaces)
+
+**Sherpa model regression pass (Auto Break OFF, VAD mode)**:
+
+- [ ] Zipformer streaming: live caption line renders partials, commits on endpoint detection, no crashes on mode switch within NFM (e.g. freq change, same demod)
+- [ ] Moonshine Base: VAD-gated offline commits appear per utterance on an NFM scanner recording, VAD threshold slider visible and responsive
+- [ ] Parakeet-TDT: VAD-gated offline commits appear per utterance on an NFM scanner recording, GPU allocation visible in `nvidia-smi` during inference
+
+**VAD threshold slider regression**:
+
+- [ ] VAD threshold SpinRow visible when an offline model is selected AND Auto Break is OFF
+- [ ] VAD threshold SpinRow hidden when Zipformer is selected (streaming has its own endpoint detection)
+- [ ] VAD threshold value persists across app restart (existing PR 6 behavior)
+
+**Auto Break — new feature**:
+
+- [ ] Auto Break toggle visible when `(offline model)` AND `(current demod mode == NFM)`
+- [ ] Auto Break toggle hidden when current demod mode is WFM / AM / other
+- [ ] Auto Break toggle hidden when Zipformer is selected, even on NFM
+- [ ] Auto Break ON → VAD threshold SpinRow hides (mutex visibility)
+- [ ] Auto Break OFF → VAD threshold SpinRow reappears
+- [ ] Auto Break toggle is disabled during an active transcription session (session lock)
+- [ ] Auto Break setting persists across app restart (`transcription_auto_break_enabled` config key)
+- [ ] Auto Break ON + Moonshine Base + real NFM scanner audio: one clean transcript entry per transmission, no squelch-tail garbage, no mid-utterance splits on brief dips
+- [ ] Auto Break ON + Parakeet + real NFM scanner audio: same as above, with noticeably higher recognition accuracy
+- [ ] Auto Break ON + Parakeet + dead channel (auto-squelch, no signal): zero spurious transcript entries from noise-spike openings
+- [ ] Auto Break ON + squelch disabled in the radio panel + click Start: precondition toast appears, session does NOT start
+- [ ] Auto Break ON + squelch re-enabled + click Start: session starts normally
+
+**Universal mode-change stop — new behavior**:
+
+- [ ] Proactive subtitle *"Changing band stops active transcription"* visible on the demod mode selector row, readable in both narrow and wide window sizes
+- [ ] VAD mode active + switch NFM → WFM: transcription stops, toast appears with exact text *"Transcription stopped — demod mode changed. Press Start to resume."*
+- [ ] Auto Break mode active + switch NFM → WFM: same stop + same toast
+- [ ] After mode-change stop, click Start: transcription resumes on the new band with configuration preserved (model, VAD threshold, Auto Break setting if applicable)
+- [ ] Mode change while transcription is NOT running: no toast, no error, no state change — the demod mode just switches silently as it does today
+
+**Whisper regression (feature mutex is intact)**:
+
+- [ ] `make install CARGO_FLAGS="--release --features whisper-cuda"` builds and `sdr-rs` launches — the `TranscriptionInput` channel refactor MUST NOT break the Whisper feature path; Whisper pattern-matches on `Samples` only and ignores the squelch variants
+
+**Deliverable of this checklist**: a paste of the filled-in list in the PR description, so CodeRabbit and future readers can see exactly what was validated before merge.
+
+**Triple-build verification (per transcription-feature protocol)**:
+
+- `cargo check --workspace` (default whisper-cpu)
+- `cargo check --workspace --features whisper-cuda`
+- `cargo check --workspace --no-default-features --features sherpa-cpu`
+- `cargo check --workspace --no-default-features --features sherpa-cuda`
+- `cargo clippy --all-targets --workspace -- -D warnings` (default + sherpa-cpu + sherpa-cuda)
+- `cargo test --workspace` (default)
+- `cargo fmt --all -- --check`
+- `cargo deny check sources` (default + sherpa-cuda graph)
+
+## Risks and unknowns
+
+1. **Hardcoded timing constants may be wrong for real-world NFM.** Mitigation: ship with the user's local scanner testing as the validation signal; if defaults are wrong, we have the follow-up issue ready to add sliders. The constants are one-line changes if tuning is needed before ship.
+
+2. **Squelch configuration accessor doesn't exist yet.** `IfChain` exposes `squelch_open() -> bool` but not the user's configured level or the enable flag. We need to add one new accessor so the precondition check can tell "squelch is off" from "squelch is set but not currently open." Small public API addition to `sdr-radio`; risk is low.
+
+3. **Channel type change to `TranscriptionInput`.** Breaking change to the internal audio-tap contract, touches at least: `sdr-core::controller`, `sdr-transcription::backend`, `sdr-transcription::backends::sherpa::host`, `sdr-transcription::backends::sherpa::offline`, `sdr-transcription::backends::sherpa::streaming`, `sdr-transcription::backends::whisper::*`. All edits are mechanical (wrap `Vec<f32>` in `TranscriptionInput::Samples(...)` at the producer, pattern-match at consumers) but the patch is wide. Mitigation: test each transcription flavor before committing.
+
+4. **Demod mode change plumbing.** We need a `DspToUi::DemodModeChanged` event so the transcript panel can re-run visibility checks AND trigger the stop-on-mode-change behavior. This is net-new message-enum work — small, but the messages crate is shared between several consumers and needs a clean add. Risk: low, but the touch surface grows slightly.
+
+5. **Behavior change vs PRs 1–6.** PRs 1–6 let VAD mode transcription continue across demod mode changes; this PR changes that to a universal stop. The project has one user today (the owner), who confirmed during design that the change is fine and actively preferable — the old behavior was quietly lossy (cross-band noise characteristics break recognition quality) and the new behavior gives a clear explicit signal via toast. No soft-launch / opt-out gate is included. The PR description will still call the change out prominently for CodeRabbit and future readers, and the proactive subtitle on the demod selector acts as a passive explainer.
+
+6. **Auto Break follow-up issue for sliders.** User agreed to ship hardcoded constants with a follow-up issue to add sliders once real-world testing is in. The follow-up issue needs to be filed before merge so we don't forget.
+
+## Follow-up issues to file before merge
+
+**Title**: Expose Auto Break timing parameters as user-tunable sliders
+
+**Body outline**:
+
+- Context: PR for #265 ships Auto Break with hardcoded `MIN_OPEN_MS`, `TAIL_MS`, `MIN_SEGMENT_MS` constants in `backends/sherpa/offline.rs`.
+- Problem: no one-size-fits-all for real-world NFM — different bands, repeaters, mobile signals, and scanner use cases have different optimal hold-off values. The VAD threshold slider in PR 6 is precedent for exactly this kind of tuning surface.
+- Proposed: add three new SpinRows to the transcript panel under the Auto Break toggle (visible only when Auto Break is on). Persist as `transcription_auto_break_min_open_ms` / `_tail_ms` / `_min_segment_ms` config keys. Defaults match the v1 hardcoded values.
+- Acceptance: real-world scanner testing with the slider values tuned produces cleaner segment boundaries than the defaults on at least one representative recording.
+- Labels: `enhancement`, `transcription`, `ui`
+
+## Open questions
+
+None. All design decisions confirmed with user during brainstorming on 2026-04-13.

--- a/docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md
@@ -308,24 +308,28 @@ Auto Break needs squelch enabled to detect transmission boundaries.
 Enable squelch in the radio panel, or turn off Auto Break to use VAD.
 ```
 
-The user clears the error by either enabling squelch or turning off Auto Break, then re-clicks Start. The precondition check reads a new public accessor `IfChain::is_squelch_configured() -> bool` which returns `true` when either auto-squelch is enabled OR a manual threshold is set, and `false` only when squelch is fully disabled. `sdr-radio` currently exposes `squelch_open() -> bool` (runtime gate state) but not the configuration state, so this is a small API addition: two lines in `PowerSquelch` to track the "enabled" flag and one forwarding method on `IfChain`.
+The user clears the error by either enabling squelch or turning off Auto Break, then re-clicks Start. The precondition check lives entirely in the UI layer (the transcription enable handler in `crates/sdr-ui/src/window.rs`): it reads the existing radio-panel state via `panels.radio.squelch_enabled_row.is_active()`, which is the same switch that dispatches `UiToDsp::SetSquelchEnabled(bool)` on user toggle. No new accessor is needed on `IfChain` — `squelch_enabled()` already exists there and reflects the same flag, and `auto_squelch_enabled()` is orthogonal (auto-squelch is a tracking mode for the threshold, not a separate enable gate). The "squelch fully off" condition is exactly `!squelch_enabled`.
 
 ### Backend selection guard
 
-`backends/sherpa/offline.rs::run_session` validates at entry:
+`SegmentationMode::AutoBreak` + streaming Zipformer is rejected in the streaming session entry point (`backends/sherpa/streaming.rs::run_session`), not in the offline dispatcher. The offline `run_session` in `backends/sherpa/offline.rs` is a unit-return match that dispatches on `segmentation_mode` to either `run_session_vad` or `run_session_auto_break` — model-kind validation happens one layer up, where the sherpa host worker selects the session runner based on the recognizer state:
 
 ```rust
-if config.segmentation_mode == SegmentationMode::AutoBreak
-    && !matches!(model.kind(), ModelKind::OfflineMoonshine | ModelKind::OfflineNemoTransducer)
-{
-    return Err(BackendError::Init(
-        "Auto Break is only supported for offline sherpa models \
-         (Moonshine, Parakeet). Streaming Zipformer must use Vad.".to_owned()
-    ));
+// In crates/sdr-transcription/src/backends/sherpa/streaming.rs:
+pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) {
+    let SessionParams { segmentation_mode, event_tx, .. } = params;
+    if segmentation_mode == crate::backend::SegmentationMode::AutoBreak {
+        let msg = "streaming Zipformer does not support Auto Break segmentation \
+                   — it has its own endpoint detection. Use SegmentationMode::Vad.";
+        tracing::error!(%msg);
+        let _ = event_tx.send(TranscriptionEvent::Error(msg.to_owned()));
+        return;
+    }
+    // ... normal streaming session ...
 }
 ```
 
-Streaming Zipformer's session loop asserts the same precondition but in `run_session_online` — rejects `SegmentationMode::AutoBreak` with a clear error. Should never fire because UI prevents the combination, but defensive guard protects against config file corruption or API misuse.
+Should never fire because the UI layer prevents the combination via the `auto_break_enabled = switch && is_nfm && model_is_offline` eligibility gate computed at session start in `window.rs`, but the defensive guard protects against config file corruption or API misuse.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md
@@ -139,7 +139,7 @@ pub struct BackendConfig {
    - Emit `SquelchOpened` or `SquelchClosed` to the transcription channel
 4. Update `squelch_was_open = now_open`
 
-Gating on `current_mode == DemodMode::Nfm` means a mid-session mode switch to WFM simply stops the squelch event stream. The transcription session in Auto Break mode sees `Samples` continue to flow but no more boundary events — which rolls cleanly into the fallback behavior described below.
+Gating on `current_mode == DemodMode::Nfm` means the DSP controller only emits squelch events on NFM; WFM / AM / other modes never see them. Mid-session mode changes are handled separately by the universal stop-on-mode-change behavior described below — when the user switches band, transcription stops cleanly before any cross-mode sample leakage can reach the session loop.
 
 ### Offline session loop state machine
 
@@ -303,7 +303,7 @@ One new `AdwSwitchRow` added to the transcript panel below the VAD threshold Spi
 
 **Precondition check at session start**: if the user has Auto Break enabled AND the radio has squelch fully disabled (not auto-squelch, not manual threshold — literally off), session start is blocked with a toast:
 
-```
+```text
 Auto Break needs squelch enabled to detect transmission boundaries.
 Enable squelch in the radio panel, or turn off Auto Break to use VAD.
 ```


### PR DESCRIPTION
## Summary

- **Auto Break segmentation mode** for offline sherpa models (Moonshine, Parakeet) that uses the radio's squelch gate as the utterance boundary instead of Silero VAD. NFM demod only, mutex with VAD per session, gated on \`offline-model + NFM\`. The radio already classifies \"is there a transmission\" at the physical layer — on NFM that's cleaner than running a speech/non-speech classifier over squelch-tail-contaminated audio.
- **Universal stop-on-mode-change**: any demod mode change while transcription is active now stops the session cleanly with an explanatory toast. Applies to BOTH VAD and Auto Break. This is a deliberate behavior change from PRs 1–6 — see the callout below.
- **\`TranscriptionInput\` channel refactor**: internal audio-tap channel type changes from \`mpsc::SyncSender<Vec<f32>>\` to \`mpsc::SyncSender<TranscriptionInput>\` (enum carrying \`Samples(Vec<f32>)\` / \`SquelchOpened\` / \`SquelchClosed\`). The DSP controller emits edge events on squelch open/close transitions, gated on \`current_mode == Nfm\`. Whisper pattern-matches on \`Samples\` and ignores the edge variants.

## Design

Full design writeup:
- Spec: \`docs/superpowers/specs/2026-04-13-auto-break-segmentation-design.md\` (464 lines, committed before implementation)
- Plan: \`docs/superpowers/plans/2026-04-13-auto-break-segmentation.md\` (1903 lines, 21 bite-sized tasks executed via subagent-driven development)

The offline session loop now dispatches on \`config.segmentation_mode\`:
- \`Vad\` → existing Silero-driven path (unchanged)
- \`AutoBreak\` → new \`AutoBreakMachine\` state machine (Idle → Recording → HoldingOff) driven from the channel \`recv_timeout\` loop

Hardcoded timing constants for v1 (tunable via sliders tracked in #272):
- \`AUTO_BREAK_MIN_OPEN_MS = 100\` — phantom-open filter
- \`AUTO_BREAK_TAIL_MS = 200\` — trailing-syllable capture after squelch close
- \`AUTO_BREAK_MIN_SEGMENT_MS = 400\` — sub-word fragment filter
- \`AUTO_BREAK_MAX_SEGMENT_MS = 30_000\` — stuck-squelch safety cap

The state machine is pure (no I/O handles) and unit-tested with 5 TDD test cases covering clean utterance, hysteresis blip absorption, phantom-open discard, sub-min segment discard, and max-segment safety cap.

## Behavior change for existing users

**PRs 1–6 let VAD mode transcription continue across demod mode changes. This PR changes that to a universal stop.** Any demod mode change while transcription is active now stops the session with the toast *\"Transcription stopped — demod mode changed. Press Start to resume.\"*

Rationale: band change = new session boundary in scanner/radio user intuition; the old behavior was quietly lossy because different bands have different noise characteristics and Whisper's RMS gating in particular drifts badly across band changes; and treating it as a hard stop eliminates the edge-case mental model where \"Auto Break is configured but inert on WFM.\"

The project has one user today (the owner), who confirmed during design that the change is actively preferable. No soft-launch / opt-out gate is included.

Proactive explainer: the demod selector dropdown tooltip now reads *\"Demodulation mode — changing band stops active transcription\"*.

## Test plan (pre-PR smoke test, user-driven)

### Build + launch sanity
- [x] \`make install CARGO_FLAGS=\"--release --no-default-features --features sherpa-cuda\"\` — installed cleanly
- [x] \`sdr-rs\` launches without error
- [x] \`make install CARGO_FLAGS=\"--release --features whisper-cuda\"\` — also installed cleanly, Whisper regression verified

### Sherpa model regression (Auto Break OFF)
- [x] Zipformer streaming — live caption partials render, endpoint commits land
- [x] Moonshine Base — VAD-gated offline commits per utterance on NFM
- [x] Parakeet-TDT — VAD-gated offline commits, GPU alloc visible in nvidia-smi

### VAD threshold slider regression
- [x] Visible for offline model + Auto Break OFF
- [x] Hidden for Zipformer
- [x] Value persists across app restart

### Auto Break — new feature
- [x] Toggle visible on NFM + offline model
- [x] Toggle hidden on WFM / AM
- [x] Toggle hidden on Zipformer even when NFM
- [x] Auto Break ON → VAD threshold slider hides (mutex)
- [x] Auto Break OFF → VAD threshold slider reappears
- [x] Toggle disabled during active session (session lock)
- [x] Setting persists across app restart
- [x] Auto Break + Moonshine Base on real NFM scanner: clean entry per transmission, no mid-utterance splits, no squelch-tail garbage
- [x] Auto Break + Parakeet on real NFM scanner: same, with noticeably better chunk digestion vs VAD
- [x] Auto Break + dead channel: no spurious transcripts
- [x] Precondition toast fires when Auto Break ON + squelch disabled, session start blocked
- [x] Session starts normally after squelch re-enabled

### Universal mode-change stop
- [x] Demod selector tooltip shows the proactive explainer
- [x] VAD mode active + mode switch: transcription stops, toast appears with the exact spec copy
- [x] Auto Break mode active + mode switch: same stop + toast
- [x] After stop + click Start: session resumes with config preserved
- [x] Mode change when transcription not running: silent, no toast

### Whisper regression
- [x] whisper-cuda build installs and runs cleanly — RMS-gated commits still flow, TranscriptionInput refactor does not break the Whisper path

User observation: *\"new feature tests out great — no regressions (which is wild). Initial accuracy impression is really good — it seems to digest the chunks better based on the squelch breaks.\"*

## Triple-build verification (automated)

| Check | whisper-cpu | whisper-cuda | sherpa-cpu | sherpa-cuda |
|---|---|---|---|---|
| \`cargo check --workspace\` | ✅ | ✅ | ✅ | ✅ |
| \`cargo clippy --all-targets -- -D warnings\` | ✅ | — | ✅ | ✅ |
| \`cargo test --workspace\` | ✅ (includes 5 new Auto Break state machine tests) | — | — | — |
| \`cargo fmt --check\` | ✅ | ✅ | ✅ | ✅ |
| \`cargo deny check sources\` | ✅ | — | — | ✅ |
| \`cargo audit\` | ✅ | — | — | — |

## Follow-up

- #272 — expose Auto Break timing parameters as user-tunable sliders (planned as a follow-up after real-world scanner testing with the v1 hardcoded defaults)

Closes #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto Break mode: offline speech recognition segments utterances using squelch open/close edges (NFM-only).
  * Transcription input now carries both audio and squelch edge events; segmentation mode selectable (VAD default / Auto Break).

* **Behavior Changes**
  * Changing demodulation mode stops active transcription, shows a toast, and requires restart.
  * Streaming models reject Auto Break; Auto Break affects VAD handling.

* **User Interface**
  * Auto Break toggle with persisted setting, visibility rules, and precondition (requires squelch enabled); demod tooltip updated.

* **Documentation**
  * Added design and plan docs for Auto Break segmentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->