### PR TITLE
Fix splash subprocess icon on Wayland (hyprland)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ install-icon:
 install-desktop:
 	@mkdir -p $(DESKTOPDIR)
 	cp data/com.sdr.rs.desktop $(DESKTOPDIR)/com.sdr.rs.desktop
+	cp data/com.sdr.rs.splash.desktop $(DESKTOPDIR)/com.sdr.rs.splash.desktop
 	@update-desktop-database $(DESKTOPDIR) 2>/dev/null || true
 
 # ─────────────────────────────────────────────────────────────────────
@@ -191,6 +192,7 @@ uninstall:
 	rm -rf $(LIBDIR)
 	rm -f $(ICONDIR)/com.sdr.rs.svg
 	rm -f $(DESKTOPDIR)/com.sdr.rs.desktop
+	rm -f $(DESKTOPDIR)/com.sdr.rs.splash.desktop
 	@update-desktop-database $(DESKTOPDIR) 2>/dev/null || true
 	@echo "SDR-RS uninstalled"
 	@echo "  (NVIDIA redist cache at $(CUDA_REDIST_CACHE) preserved;"

--- a/crates/sdr-splash-gtk/src/lib.rs
+++ b/crates/sdr-splash-gtk/src/lib.rs
@@ -175,6 +175,7 @@ mod linux_impl {
             .default_width(420)
             .default_height(180)
             .resizable(false)
+            .icon_name("com.sdr.rs")
             .content(&vbox)
             .build();
 

--- a/data/com.sdr.rs.splash.desktop
+++ b/data/com.sdr.rs.splash.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=SDR-RS Splash
+GenericName=Software-Defined Radio (Loading)
+Comment=SDR-RS initialization splash
+Exec=sdr-rs --splash
+Icon=com.sdr.rs
+Terminal=false
+Categories=Audio;HamRadio;Science;
+NoDisplay=true


### PR DESCRIPTION
## Summary

Fixes #276. The sherpa-onnx init splash showed the generic fallback icon in Wayland compositors that resolve icons by matching xdg_toplevel app_id against installed \`.desktop\` files (confirmed in hyprland). The splash subprocess registers as \`com.sdr.rs.splash\` on the D-Bus but only \`com.sdr.rs.desktop\` was ever installed, so there was no app_id match.

Option 2 from the issue (unify the app_id) is now blocked by #261 — the main process registers \`com.sdr.rs\` on the session bus before spawning the splash, so a subprocess claiming the same ID would see the parent as remote and activate it instead of opening the splash window. Taking Option 3 instead.

## Changes

- **New file** \`data/com.sdr.rs.splash.desktop\` — same \`Icon=com.sdr.rs\` as the main desktop file, \`NoDisplay=true\` so it doesn't show up in app launchers. Hyprland resolves the splash window's app_id to this entry and finds the existing icon.
- **Makefile** — \`install-desktop\` and \`uninstall\` targets copy/remove the new file alongside the main one.
- **\`sdr-splash-gtk\`** — the splash \`ApplicationWindow::builder\` now sets \`.icon_name(\"com.sdr.rs\")\` explicitly as defense-in-depth for X11 and mixed configurations.

## Test plan

- [ ] \`make install\` — \`com.sdr.rs.splash.desktop\` lands in \`~/.local/share/applications/\`
- [ ] Launch \`sdr-rs\` on hyprland with a fresh sherpa bundle (or deleted cache) so the splash stays up long enough to verify — splash shows the SDR-RS icon
- [ ] Launch on GNOME / KDE — splash still works, main window still shows the icon
- [ ] Re-launch second \`sdr-rs\` — still forwards activate to the primary per #261 (splash shouldn't even run)
- [ ] \`make uninstall\` — both desktop files are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated launcher for the splash screen, enabling users to launch it as a standalone application when needed.

* **Style**
  * Updated the application window to display with a proper system icon visible in window decorations, taskbars, and application menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->