### PR TITLE
Retrofit Whisper backend to use earshot VAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "earshot"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d393a8f23619412e0502df1b94cd148e34855a50a4143d365cc6336cc338b4f4"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1100,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2000,6 +2015,7 @@ version = "0.1.0"
 dependencies = [
  "bzip2",
  "dirs-next",
+ "earshot",
  "libc",
  "reqwest",
  "rustfft",

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -12,7 +12,15 @@ default = []
 # Internal cfg flags. Source code uses #[cfg(feature = "whisper")] /
 # #[cfg(feature = "sherpa")] to gate per-backend code. Pulled in by the
 # user-facing whisper-* / sherpa-* features below.
-whisper = ["dep:whisper-rs"]
+#
+# `earshot` is a tiny (~100 KB binary, ~8 KB runtime) pure-Rust voice
+# activity detector with zero C++ deps — just libm for math. It ships
+# only with whisper builds because whisper-rs has no built-in VAD and
+# was previously using a naive RMS gate. Using a pure-Rust VAD here
+# also side-steps the onnxruntime/libstdc++ state collision that
+# forced the whisper/sherpa feature mutex in the first place (#253) —
+# earshot doesn't need any C++ ONNX runtime.
+whisper = ["dep:whisper-rs", "dep:earshot"]
 sherpa = ["dep:sherpa-onnx", "dep:tar", "dep:bzip2"]
 
 # User-facing build targets — pick exactly one.
@@ -46,6 +54,7 @@ sherpa-cuda = ["sherpa", "sherpa-onnx/cuda"]
 [dependencies]
 whisper-rs = { workspace = true, optional = true }
 sherpa-onnx = { workspace = true, optional = true }
+earshot = { version = "1", optional = true }
 reqwest.workspace = true
 rustfft.workspace = true
 sdr-types.workspace = true

--- a/crates/sdr-transcription/src/backends/earshot_vad.rs
+++ b/crates/sdr-transcription/src/backends/earshot_vad.rs
@@ -86,6 +86,19 @@ const DEFAULT_MIN_SPEECH_FRAMES: usize = (100 * SAMPLE_RATE_HZ) / (FRAME_SIZE * 
 /// buffering forever; mirrors sherpa-onnx's `max_speech_duration`.
 const DEFAULT_MAX_SPEECH_FRAMES: usize = (20 * SAMPLE_RATE_HZ) / FRAME_SIZE;
 
+/// Pre-trigger lookback ring size in frames. When the state machine
+/// transitions `Idle → Speaking` the last N frames of audio from the
+/// ring are prepended to the segment so the first word isn't chopped.
+///
+/// Why lookback is necessary: `earshot::Detector` uses a 3-frame
+/// context window internally, so the first frame of speech after a
+/// long silence often scores below threshold (no recent history to
+/// compare against). Without a lookback buffer the state machine
+/// transitions on frame 2 or 3 and frame 1 — the actual start of
+/// speech — is lost. 4 frames × 16 ms = 64 ms, which covers the
+/// context gap plus the first consonant/vowel attack.
+const DEFAULT_LOOKBACK_FRAMES: usize = 4;
+
 /// State of the segmentation machine — see module docstring.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum State {
@@ -111,11 +124,22 @@ pub struct EarshotVad {
     min_silence_frames: usize,
     min_speech_frames: usize,
     max_speech_frames: usize,
+    lookback_frames: usize,
 
     /// Leftover samples from the last `accept` call that didn't fill
     /// a full 256-sample frame. Prepended to the next batch so no
     /// audio is dropped at batch boundaries.
     partial_frame: Vec<f32>,
+
+    /// Pre-trigger ring buffer of raw audio samples — holds the most
+    /// recent `lookback_frames` frames of audio at all times while in
+    /// `Idle`. On `Idle → Speaking` transition the entire ring is
+    /// drained into `current_segment` so the leading consonant and
+    /// attack of the first word are preserved (earshot needs ~3
+    /// frames of history to score confidently, so the first 1–2
+    /// frames of real speech don't cross the threshold and would
+    /// otherwise be discarded).
+    lookback: Vec<f32>,
 
     /// Samples accumulated into the current in-flight segment. Grows
     /// while in `Speaking`/`HoldingOff`, drained into `completed` on
@@ -151,10 +175,12 @@ impl EarshotVad {
             min_silence_frames: DEFAULT_MIN_SILENCE_FRAMES,
             min_speech_frames: DEFAULT_MIN_SPEECH_FRAMES,
             max_speech_frames: DEFAULT_MAX_SPEECH_FRAMES,
+            lookback_frames: DEFAULT_LOOKBACK_FRAMES,
             partial_frame: Vec::with_capacity(FRAME_SIZE),
             current_segment: Vec::new(),
             speech_frames_in_segment: 0,
             silence_frames_in_holdoff: 0,
+            lookback: Vec::with_capacity(DEFAULT_LOOKBACK_FRAMES * FRAME_SIZE),
             completed: VecDeque::new(),
         }
     }
@@ -169,14 +195,33 @@ impl EarshotVad {
         match self.state {
             State::Idle => {
                 if is_voice {
+                    // Transition to Speaking. Drain the lookback ring
+                    // into the segment so the leading consonant and
+                    // attack of the first word — which earshot scored
+                    // below threshold for lack of context — get
+                    // captured. `append` empties the source so the
+                    // ring starts fresh for any future Idle phase.
                     self.state = State::Speaking;
                     self.current_segment.clear();
                     self.speech_frames_in_segment = 0;
                     self.silence_frames_in_holdoff = 0;
+                    self.current_segment.append(&mut self.lookback);
                     self.current_segment.extend_from_slice(frame);
+                    // Only the current frame scored as voiced — the
+                    // lookback frames are pre-trigger audio and
+                    // shouldn't inflate the min-speech-length gate.
                     self.speech_frames_in_segment += 1;
+                } else {
+                    // Idle + silence: append to lookback ring, cap at
+                    // `lookback_frames`. When full, drop the oldest
+                    // frame's worth of samples from the front.
+                    self.lookback.extend_from_slice(frame);
+                    let cap = self.lookback_frames * FRAME_SIZE;
+                    if self.lookback.len() > cap {
+                        let excess = self.lookback.len() - cap;
+                        self.lookback.drain(..excess);
+                    }
                 }
-                // Idle + silence: discard.
             }
             State::Speaking => {
                 self.current_segment.extend_from_slice(frame);
@@ -281,12 +326,21 @@ impl VoiceActivityDetector for EarshotVad {
 
     fn flush(&mut self) {
         // Force any in-flight segment to finalize so the caller can
-        // still pop it. Drop any partial frame — it's < 16 ms of
-        // audio, not worth worrying about.
-        self.partial_frame.clear();
-        if !matches!(self.state, State::Idle) {
-            self.finalize_segment();
+        // still pop it. If we're mid-segment, the tail of audio
+        // sitting in `partial_frame` (< FRAME_SIZE samples, so it
+        // never scored through earshot) is still real audio and
+        // belongs on the end of the segment — otherwise the last
+        // <16 ms of every session disconnect is silently truncated.
+        // If we're Idle, there's no segment to attach it to, so drop.
+        if matches!(self.state, State::Idle) {
+            self.partial_frame.clear();
+            return;
         }
+        if !self.partial_frame.is_empty() {
+            self.current_segment.extend_from_slice(&self.partial_frame);
+            self.partial_frame.clear();
+        }
+        self.finalize_segment();
     }
 
     fn reset(&mut self) {
@@ -296,6 +350,7 @@ impl VoiceActivityDetector for EarshotVad {
         self.current_segment.clear();
         self.speech_frames_in_segment = 0;
         self.silence_frames_in_holdoff = 0;
+        self.lookback.clear();
         self.completed.clear();
     }
 }
@@ -385,7 +440,80 @@ mod tests {
         assert!(vad.current_segment.is_empty());
         assert_eq!(vad.speech_frames_in_segment, 0);
         assert_eq!(vad.silence_frames_in_holdoff, 0);
+        assert!(vad.lookback.is_empty());
         assert!(vad.completed.is_empty());
+    }
+
+    #[test]
+    fn lookback_caps_at_configured_frames_while_idle() {
+        // Feed enough silence frames to overflow the lookback ring —
+        // the ring should cap at exactly `lookback_frames * FRAME_SIZE`
+        // samples, not grow unboundedly.
+        let mut vad = EarshotVad::new();
+        vad.accept(&silence_frames(DEFAULT_LOOKBACK_FRAMES * 3));
+        assert_eq!(vad.state, State::Idle, "silence should not transition");
+        assert_eq!(
+            vad.lookback.len(),
+            DEFAULT_LOOKBACK_FRAMES * FRAME_SIZE,
+            "lookback ring should hold exactly `lookback_frames` frames"
+        );
+    }
+
+    #[test]
+    fn lookback_prepends_to_segment_on_transition() {
+        // Drive the state machine directly so we don't depend on
+        // earshot's scoring. Pre-seed the lookback ring with a known
+        // pattern (full of 0.7), then manually trigger an Idle →
+        // Speaking transition with a current frame pattern of 0.3
+        // via `process_frame`-equivalent logic.
+        //
+        // Testing the process_frame path would require earshot to
+        // actually score above threshold, which isn't deterministic
+        // for synthetic signals. So we test the field-level logic
+        // that the transition branch performs: drain lookback, push
+        // current frame, set counters.
+        let mut vad = EarshotVad::new();
+
+        // Seed lookback with 3 frames of a distinctive value.
+        let lookback_pattern = 0.7_f32;
+        vad.lookback
+            .extend(std::iter::repeat_n(lookback_pattern, 3 * FRAME_SIZE));
+        assert_eq!(vad.lookback.len(), 3 * FRAME_SIZE);
+
+        // Simulate the Idle → Speaking branch from process_frame.
+        let current_frame: Vec<f32> = vec![0.3_f32; FRAME_SIZE];
+        vad.state = State::Speaking;
+        vad.current_segment.clear();
+        vad.speech_frames_in_segment = 0;
+        vad.silence_frames_in_holdoff = 0;
+        vad.current_segment.append(&mut vad.lookback);
+        vad.current_segment.extend_from_slice(&current_frame);
+        vad.speech_frames_in_segment += 1;
+
+        // Lookback must be fully drained (append leaves it empty).
+        assert!(
+            vad.lookback.is_empty(),
+            "lookback should be empty after drain"
+        );
+        // Segment must hold lookback + current frame, in order.
+        assert_eq!(vad.current_segment.len(), 4 * FRAME_SIZE);
+        // First 3 frames should be the lookback pattern.
+        for &s in &vad.current_segment[..3 * FRAME_SIZE] {
+            assert!(
+                (s - lookback_pattern).abs() < f32::EPSILON,
+                "lookback prefix should preserve pattern, got {s}"
+            );
+        }
+        // Last frame should be the current frame pattern.
+        for &s in &vad.current_segment[3 * FRAME_SIZE..] {
+            assert!(
+                (s - 0.3_f32).abs() < f32::EPSILON,
+                "trailing frame should be current-frame pattern, got {s}"
+            );
+        }
+        // Only one frame counts as voiced — the lookback frames are
+        // pre-trigger audio, not voice-scored content.
+        assert_eq!(vad.speech_frames_in_segment, 1);
     }
 
     #[test]
@@ -427,6 +555,59 @@ mod tests {
             .extend_from_slice(&vec![0.1_f32; above_gate * FRAME_SIZE]);
         vad.finalize_segment();
         assert_eq!(vad.completed.len(), 1, "segment above gate should emit");
+    }
+
+    #[test]
+    fn flush_preserves_partial_frame_tail_on_active_segment() {
+        // Regression for the pre-fix truncation bug: if the session
+        // ends mid-segment with a partial frame (< FRAME_SIZE samples)
+        // of trailing audio stashed, flush() must append it to the
+        // current segment before finalizing — otherwise the last
+        // <16 ms of every active utterance is silently dropped at
+        // disconnect.
+        let mut vad = EarshotVad::new();
+        vad.state = State::Speaking;
+        vad.speech_frames_in_segment = DEFAULT_MIN_SPEECH_FRAMES + 1;
+        vad.current_segment
+            .extend_from_slice(&vec![0.2_f32; 16 * FRAME_SIZE]);
+        // Stash a partial frame of distinctive samples.
+        let tail_pattern = 0.42_f32;
+        let tail_len = FRAME_SIZE / 2;
+        vad.partial_frame
+            .extend(std::iter::repeat_n(tail_pattern, tail_len));
+
+        let before_len = vad.current_segment.len();
+        vad.flush();
+
+        // Segment should be emitted.
+        assert_eq!(vad.completed.len(), 1);
+        let segment = vad
+            .completed
+            .pop_front()
+            .expect("completed queue should have one segment");
+        // Segment length includes the tail.
+        assert_eq!(segment.len(), before_len + tail_len);
+        // Final `tail_len` samples should be the tail pattern.
+        for &s in &segment[before_len..] {
+            assert!(
+                (s - tail_pattern).abs() < f32::EPSILON,
+                "segment tail should preserve partial_frame pattern, got {s}"
+            );
+        }
+        // Partial frame should have been consumed.
+        assert!(vad.partial_frame.is_empty());
+    }
+
+    #[test]
+    fn flush_drops_partial_frame_when_idle() {
+        // If we're Idle at flush time, there's no segment to attach
+        // the partial tail to — dropping it is the right behavior.
+        let mut vad = EarshotVad::new();
+        vad.partial_frame
+            .extend(std::iter::repeat_n(0.42_f32, FRAME_SIZE / 2));
+        vad.flush();
+        assert!(vad.partial_frame.is_empty());
+        assert!(vad.completed.is_empty());
     }
 
     #[test]

--- a/crates/sdr-transcription/src/backends/earshot_vad.rs
+++ b/crates/sdr-transcription/src/backends/earshot_vad.rs
@@ -17,20 +17,33 @@
 //!
 //! The VAD takes 256-sample frames (16 ms at 16 kHz) and returns a
 //! per-frame voice score. This wrapper runs a three-state machine over
-//! those scores to group consecutive voiced frames into segments:
+//! those scores to group voiced frames into segments:
 //!
-//! - **`Idle`** — no speech in flight. Frames below threshold are
-//!   discarded; a frame at or above threshold transitions to
-//!   `Speaking`.
-//! - **`Speaking`** — at least one voiced frame has arrived. Incoming
-//!   frames (voiced or not) are appended to the current segment. A
-//!   voiced frame resets the silence counter; a non-voiced frame
-//!   transitions to `HoldingOff`.
+//! - **`Idle`** — no speech in flight. Each incoming frame is still
+//!   retained in a short (`lookback_frames`) pre-trigger ring so the
+//!   leading consonant of the next utterance isn't clipped — earshot's
+//!   feature extractor needs a few frames of context before its
+//!   scores cross threshold. When a frame at or above threshold
+//!   arrives, the state machine transitions to `Speaking` and drains
+//!   the ring into the new segment before adding the triggering
+//!   frame.
+//! - **`Speaking`** — at least one voiced frame has arrived. Every
+//!   incoming frame (voiced or not) is appended to the current
+//!   segment. A voiced frame increments the voice-frame count; a
+//!   non-voiced frame transitions to `HoldingOff`.
 //! - **`HoldingOff`** — inside a segment but waiting to see if the
 //!   last silence is a pause or a real segment end. Frames are still
-//!   appended (so the decoder sees the trailing audio). Once
-//!   `min_silence_frames` consecutive non-voiced frames accumulate,
-//!   the segment is finalized and pushed onto the completed queue.
+//!   appended (so the decoder sees the trailing audio). A voiced
+//!   frame transitions back to `Speaking`; once `min_silence_frames`
+//!   consecutive non-voiced frames accumulate, the segment is
+//!   finalized and pushed onto the completed queue.
+//!
+//! `speech_frames_in_segment` is a running *total* of voice-scored
+//! frames across the whole segment (not just consecutive ones) —
+//! brief pauses that bounce through `HoldingOff → Speaking` still
+//! contribute to the running count. Lookback frames are pre-trigger
+//! audio and do NOT count toward it, so the min-speech-length gate
+//! measures real voiced content and isn't inflated by pre-roll.
 //!
 //! A `max_speech_frames` cap forces a flush even if the speaker never
 //! pauses, mirroring sherpa-onnx's `rule3_min_utterance_length` —
@@ -139,15 +152,26 @@ pub struct EarshotVad {
     /// frames of history to score confidently, so the first 1–2
     /// frames of real speech don't cross the threshold and would
     /// otherwise be discarded).
-    lookback: Vec<f32>,
+    ///
+    /// Implemented as a `VecDeque` so the hot-path "drop the oldest
+    /// frame when full" operation is O(k) head-advancement rather
+    /// than an O(n) `memmove` over the ring — every additional
+    /// silence frame during a long idle period used to shift the
+    /// whole buffer down with `Vec::drain(..excess)`.
+    lookback: VecDeque<f32>,
 
     /// Samples accumulated into the current in-flight segment. Grows
     /// while in `Speaking`/`HoldingOff`, drained into `completed` on
     /// finalize.
     current_segment: Vec<f32>,
 
-    /// Count of consecutive voiced frames in the current segment —
-    /// drives the min-speech-length discard gate.
+    /// Running total of voice-scored frames across the current
+    /// segment — NOT consecutive. Brief pauses that bounce through
+    /// `HoldingOff → Speaking` keep contributing to this count, and
+    /// lookback (pre-trigger) frames are intentionally excluded so
+    /// the min-speech-length gate only sees real voiced content.
+    /// Drives the `min_speech_frames` discard decision in
+    /// `finalize_segment`.
     speech_frames_in_segment: usize,
 
     /// Count of consecutive non-voiced frames while in `HoldingOff`.
@@ -180,7 +204,7 @@ impl EarshotVad {
             current_segment: Vec::new(),
             speech_frames_in_segment: 0,
             silence_frames_in_holdoff: 0,
-            lookback: Vec::with_capacity(DEFAULT_LOOKBACK_FRAMES * FRAME_SIZE),
+            lookback: VecDeque::with_capacity(DEFAULT_LOOKBACK_FRAMES * FRAME_SIZE),
             completed: VecDeque::new(),
         }
     }
@@ -199,13 +223,13 @@ impl EarshotVad {
                     // into the segment so the leading consonant and
                     // attack of the first word — which earshot scored
                     // below threshold for lack of context — get
-                    // captured. `append` empties the source so the
+                    // captured. `drain(..)` empties the source so the
                     // ring starts fresh for any future Idle phase.
                     self.state = State::Speaking;
                     self.current_segment.clear();
                     self.speech_frames_in_segment = 0;
                     self.silence_frames_in_holdoff = 0;
-                    self.current_segment.append(&mut self.lookback);
+                    self.current_segment.extend(self.lookback.drain(..));
                     self.current_segment.extend_from_slice(frame);
                     // Only the current frame scored as voiced — the
                     // lookback frames are pre-trigger audio and
@@ -213,13 +237,16 @@ impl EarshotVad {
                     self.speech_frames_in_segment += 1;
                 } else {
                     // Idle + silence: append to lookback ring, cap at
-                    // `lookback_frames`. When full, drop the oldest
-                    // frame's worth of samples from the front.
-                    self.lookback.extend_from_slice(frame);
+                    // `lookback_frames` × `FRAME_SIZE` samples. Using
+                    // a `VecDeque` and `pop_front` per excess sample
+                    // keeps this O(excess) with no `memmove` — the
+                    // old `Vec::drain(..excess)` path did an O(n)
+                    // shift per frame which was wasteful during long
+                    // idle periods.
+                    self.lookback.extend(frame.iter().copied());
                     let cap = self.lookback_frames * FRAME_SIZE;
-                    if self.lookback.len() > cap {
-                        let excess = self.lookback.len() - cap;
-                        self.lookback.drain(..excess);
+                    while self.lookback.len() > cap {
+                        self.lookback.pop_front();
                     }
                 }
             }
@@ -486,11 +513,11 @@ mod tests {
         vad.current_segment.clear();
         vad.speech_frames_in_segment = 0;
         vad.silence_frames_in_holdoff = 0;
-        vad.current_segment.append(&mut vad.lookback);
+        vad.current_segment.extend(vad.lookback.drain(..));
         vad.current_segment.extend_from_slice(&current_frame);
         vad.speech_frames_in_segment += 1;
 
-        // Lookback must be fully drained (append leaves it empty).
+        // Lookback must be fully drained.
         assert!(
             vad.lookback.is_empty(),
             "lookback should be empty after drain"

--- a/crates/sdr-transcription/src/backends/earshot_vad.rs
+++ b/crates/sdr-transcription/src/backends/earshot_vad.rs
@@ -115,7 +115,10 @@ const DEFAULT_LOOKBACK_FRAMES: usize = 4;
 /// State of the segmentation machine — see module docstring.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum State {
-    /// No segment in progress. Silence frames are discarded.
+    /// No segment in progress. Incoming frames are retained in
+    /// `lookback` (the pre-trigger ring, capped at `lookback_frames`
+    /// × `FRAME_SIZE` samples) so the first voiced frame can pull
+    /// its leading context along when it transitions to `Speaking`.
     Idle,
     /// At least one voiced frame has arrived; building a segment.
     Speaking,
@@ -612,6 +615,65 @@ mod tests {
             .extend_from_slice(&vec![0.1_f32; above_gate * FRAME_SIZE]);
         vad.finalize_segment();
         assert_eq!(vad.completed.len(), 1, "segment above gate should emit");
+    }
+
+    #[test]
+    fn max_speech_safety_cap_flushes_during_speaking() {
+        // Regression for the max-speech safety flush branch in
+        // `process_frame`. Without this, a long continuous
+        // transmission (e.g. a stuck mic or a siren) would buffer
+        // forever and eventually OOM — the 20-second cap exists
+        // specifically to split the segment and hand it to the
+        // decoder before memory grows unbounded.
+        //
+        // Strategy: seed the VAD into `Speaking` with a
+        // `current_segment` already at exactly the cap and a
+        // speech-frame count well above the min-speech gate (so the
+        // segment is emitted on finalize rather than discarded).
+        // Drive one more frame through `process_frame`. After the
+        // match arm appends the frame, `current_segment.len()` is
+        // over the cap, so the post-match safety check must detect
+        // it and call `finalize_segment`.
+        //
+        // Use a silent frame so the state machine transitions
+        // `Speaking → HoldingOff` inside the match (rather than
+        // staying Speaking or jumping to a completely different
+        // branch). The silence counter increments to 1, well below
+        // `min_silence_frames`, so the HoldingOff branch doesn't
+        // finalize on its own — the cap check is the only reason
+        // finalize fires, which is exactly what this test pins.
+        let mut vad = EarshotVad::new();
+        vad.state = State::Speaking;
+        vad.speech_frames_in_segment = DEFAULT_MIN_SPEECH_FRAMES + 10;
+        let cap_samples = DEFAULT_MAX_SPEECH_FRAMES * FRAME_SIZE;
+        vad.current_segment
+            .extend(std::iter::repeat_n(0.1_f32, cap_samples));
+
+        // Preconditions: segment is exactly at the cap, state is
+        // Speaking, speech-frame count is above the gate, no
+        // silence has been seen yet.
+        assert_eq!(vad.current_segment.len(), cap_samples);
+        assert_eq!(vad.state, State::Speaking);
+        assert!(vad.speech_frames_in_segment > DEFAULT_MIN_SPEECH_FRAMES);
+        assert_eq!(vad.silence_frames_in_holdoff, 0);
+
+        // Process one silent frame — pushes the segment one frame
+        // over the cap, which the post-match safety check must
+        // detect and flush.
+        let silent = vec![0.0_f32; FRAME_SIZE];
+        vad.process_frame(&silent);
+
+        // Post-conditions: segment emitted, state back to Idle,
+        // counters cleared, buffer empty.
+        assert_eq!(
+            vad.completed.len(),
+            1,
+            "max-speech cap breach should emit the segment"
+        );
+        assert_eq!(vad.state, State::Idle, "finalize_segment → Idle");
+        assert_eq!(vad.speech_frames_in_segment, 0);
+        assert_eq!(vad.silence_frames_in_holdoff, 0);
+        assert!(vad.current_segment.is_empty());
     }
 
     #[test]

--- a/crates/sdr-transcription/src/backends/earshot_vad.rs
+++ b/crates/sdr-transcription/src/backends/earshot_vad.rs
@@ -70,10 +70,16 @@ const DEFAULT_VOICE_THRESHOLD: f32 = 0.5;
 const DEFAULT_MIN_SILENCE_FRAMES: usize = (250 * SAMPLE_RATE_HZ) / (FRAME_SIZE * 1000);
 
 /// Minimum voiced frames a segment must contain to be emitted. Shorter
-/// segments are treated as noise spikes and dropped. 15 frames × 16 ms
-/// = 240 ms — again matching sherpa-onnx's Silero default for
-/// `min_speech_duration`.
-const DEFAULT_MIN_SPEECH_FRAMES: usize = (250 * SAMPLE_RATE_HZ) / (FRAME_SIZE * 1000);
+/// segments are treated as noise spikes and dropped.
+///
+/// Tuned empirically against live scanner traffic: the original value
+/// of 250 ms (matching sherpa-onnx's Silero `min_speech_duration`
+/// default) dropped brisk short transmissions like "10-4" whose
+/// voiced portion is ~150–200 ms when spoken quickly. 100 ms is
+/// Silero's absolute speech-duration floor (anything below isn't a
+/// detectable word) and catches two-syllable radio brevity codes
+/// without admitting single-frame noise spikes.
+const DEFAULT_MIN_SPEECH_FRAMES: usize = (100 * SAMPLE_RATE_HZ) / (FRAME_SIZE * 1000);
 
 /// Maximum segment length before a forced flush. 20 seconds at 16 kHz
 /// = 1250 frames. Prevents a pathologically long transmission from
@@ -398,21 +404,27 @@ mod tests {
     fn finalize_segment_respects_min_speech_gate() {
         // Directly test the state machine gate without going through
         // earshot's scoring — append frames to current_segment and
-        // call finalize.
+        // call finalize. Frame counts are expressed relative to the
+        // default so a future retune of `DEFAULT_MIN_SPEECH_FRAMES`
+        // doesn't accidentally land this test in "happens to cross"
+        // territory.
+        let below_gate = DEFAULT_MIN_SPEECH_FRAMES - 1;
+        let above_gate = DEFAULT_MIN_SPEECH_FRAMES + 1;
+
         let mut vad = EarshotVad::new();
         vad.state = State::Speaking;
-        vad.speech_frames_in_segment = 5; // below DEFAULT_MIN_SPEECH_FRAMES
+        vad.speech_frames_in_segment = below_gate;
         vad.current_segment
-            .extend_from_slice(&vec![0.1_f32; 5 * FRAME_SIZE]);
+            .extend_from_slice(&vec![0.1_f32; below_gate * FRAME_SIZE]);
         vad.finalize_segment();
         assert!(vad.completed.is_empty(), "short segment should be dropped");
         assert_eq!(vad.state, State::Idle);
 
         // And a segment above the gate should survive.
         vad.state = State::Speaking;
-        vad.speech_frames_in_segment = DEFAULT_MIN_SPEECH_FRAMES + 1;
+        vad.speech_frames_in_segment = above_gate;
         vad.current_segment
-            .extend_from_slice(&vec![0.1_f32; 16 * FRAME_SIZE]);
+            .extend_from_slice(&vec![0.1_f32; above_gate * FRAME_SIZE]);
         vad.finalize_segment();
         assert_eq!(vad.completed.len(), 1, "segment above gate should emit");
     }

--- a/crates/sdr-transcription/src/backends/earshot_vad.rs
+++ b/crates/sdr-transcription/src/backends/earshot_vad.rs
@@ -1,0 +1,434 @@
+//! Pure-Rust voice activity detector for the Whisper backend (#259).
+//!
+//! Wraps [`earshot::Detector`] behind the feature-agnostic
+//! [`VoiceActivityDetector`] trait so `backends/whisper.rs` can replace
+//! its naive RMS silence gate with segment-aligned inference. The
+//! Whisper backend used to decode fixed 5-second chunks and gate each
+//! chunk by its total RMS, which false-triggered on squelch tails and
+//! frequently split transmissions across two chunks — cutting words in
+//! half and making the committed text noisy.
+//!
+//! `earshot` is a tiny pure-Rust VAD (no ONNX runtime, no C++ state)
+//! so it's safe to ship in whisper builds without risking the same
+//! `libstdc++` state collision that forced the whisper/sherpa feature
+//! mutex in the first place. See `Cargo.toml` for the dependency note.
+//!
+//! # Segmentation model
+//!
+//! The VAD takes 256-sample frames (16 ms at 16 kHz) and returns a
+//! per-frame voice score. This wrapper runs a three-state machine over
+//! those scores to group consecutive voiced frames into segments:
+//!
+//! - **`Idle`** — no speech in flight. Frames below threshold are
+//!   discarded; a frame at or above threshold transitions to
+//!   `Speaking`.
+//! - **`Speaking`** — at least one voiced frame has arrived. Incoming
+//!   frames (voiced or not) are appended to the current segment. A
+//!   voiced frame resets the silence counter; a non-voiced frame
+//!   transitions to `HoldingOff`.
+//! - **`HoldingOff`** — inside a segment but waiting to see if the
+//!   last silence is a pause or a real segment end. Frames are still
+//!   appended (so the decoder sees the trailing audio). Once
+//!   `min_silence_frames` consecutive non-voiced frames accumulate,
+//!   the segment is finalized and pushed onto the completed queue.
+//!
+//! A `max_speech_frames` cap forces a flush even if the speaker never
+//! pauses, mirroring sherpa-onnx's `rule3_min_utterance_length` —
+//! without it a long continuous monologue would never emit a segment
+//! to the recognizer.
+//!
+//! Short-segment discard (`min_speech_frames`) protects against
+//! single-frame noise spikes being emitted as one-frame "utterances".
+
+use std::collections::VecDeque;
+
+use earshot::Detector;
+
+use crate::vad::VoiceActivityDetector;
+
+/// Frame size in samples required by [`earshot::Detector::predict_f32`].
+/// Fixed by the upstream crate.
+const FRAME_SIZE: usize = 256;
+
+/// Target sample rate for all VAD input. Must match the rate whisper
+/// expects (and the rate `resampler::downsample_stereo_to_mono_16k`
+/// produces). Used here for the ms → frames conversion only.
+const SAMPLE_RATE_HZ: usize = 16_000;
+
+/// Voice-score threshold above which a frame counts as speech.
+///
+/// 0.5 is the earshot-recommended default. Lower values catch quieter
+/// speech but also more noise; higher values are more conservative.
+/// Not currently exposed to the UI — follow-up if user tuning turns
+/// out to matter.
+const DEFAULT_VOICE_THRESHOLD: f32 = 0.5;
+
+/// Consecutive non-voiced frames required to finalize a segment.
+/// 15 frames × 16 ms = 240 ms. Matches sherpa-onnx's Silero default
+/// for `min_silence_duration` so whisper and sherpa behave similarly
+/// on the same audio.
+const DEFAULT_MIN_SILENCE_FRAMES: usize = (250 * SAMPLE_RATE_HZ) / (FRAME_SIZE * 1000);
+
+/// Minimum voiced frames a segment must contain to be emitted. Shorter
+/// segments are treated as noise spikes and dropped. 15 frames × 16 ms
+/// = 240 ms — again matching sherpa-onnx's Silero default for
+/// `min_speech_duration`.
+const DEFAULT_MIN_SPEECH_FRAMES: usize = (250 * SAMPLE_RATE_HZ) / (FRAME_SIZE * 1000);
+
+/// Maximum segment length before a forced flush. 20 seconds at 16 kHz
+/// = 1250 frames. Prevents a pathologically long transmission from
+/// buffering forever; mirrors sherpa-onnx's `max_speech_duration`.
+const DEFAULT_MAX_SPEECH_FRAMES: usize = (20 * SAMPLE_RATE_HZ) / FRAME_SIZE;
+
+/// State of the segmentation machine — see module docstring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    /// No segment in progress. Silence frames are discarded.
+    Idle,
+    /// At least one voiced frame has arrived; building a segment.
+    Speaking,
+    /// Inside a segment but currently in a run of silence frames —
+    /// haven't decided yet whether it's a pause or the real end.
+    HoldingOff,
+}
+
+/// `earshot`-backed voice activity detector implementing the
+/// feature-agnostic [`VoiceActivityDetector`] trait. Feed 16 kHz mono
+/// f32 samples via [`VoiceActivityDetector::accept`] and pop completed
+/// speech segments via [`VoiceActivityDetector::pop_segment`].
+pub struct EarshotVad {
+    detector: Detector,
+    state: State,
+
+    /// Config.
+    voice_threshold: f32,
+    min_silence_frames: usize,
+    min_speech_frames: usize,
+    max_speech_frames: usize,
+
+    /// Leftover samples from the last `accept` call that didn't fill
+    /// a full 256-sample frame. Prepended to the next batch so no
+    /// audio is dropped at batch boundaries.
+    partial_frame: Vec<f32>,
+
+    /// Samples accumulated into the current in-flight segment. Grows
+    /// while in `Speaking`/`HoldingOff`, drained into `completed` on
+    /// finalize.
+    current_segment: Vec<f32>,
+
+    /// Count of consecutive voiced frames in the current segment —
+    /// drives the min-speech-length discard gate.
+    speech_frames_in_segment: usize,
+
+    /// Count of consecutive non-voiced frames while in `HoldingOff`.
+    /// Drives the silence → segment-end transition.
+    silence_frames_in_holdoff: usize,
+
+    /// Completed segments waiting to be popped by the caller.
+    completed: VecDeque<Vec<f32>>,
+}
+
+impl Default for EarshotVad {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EarshotVad {
+    /// Build a VAD with the default tuning constants documented at the
+    /// top of the module.
+    pub fn new() -> Self {
+        Self {
+            detector: Detector::default(),
+            state: State::Idle,
+            voice_threshold: DEFAULT_VOICE_THRESHOLD,
+            min_silence_frames: DEFAULT_MIN_SILENCE_FRAMES,
+            min_speech_frames: DEFAULT_MIN_SPEECH_FRAMES,
+            max_speech_frames: DEFAULT_MAX_SPEECH_FRAMES,
+            partial_frame: Vec::with_capacity(FRAME_SIZE),
+            current_segment: Vec::new(),
+            speech_frames_in_segment: 0,
+            silence_frames_in_holdoff: 0,
+            completed: VecDeque::new(),
+        }
+    }
+
+    /// Process one full 256-sample frame and drive the state machine.
+    /// Assumes `frame.len() == FRAME_SIZE`.
+    fn process_frame(&mut self, frame: &[f32]) {
+        debug_assert_eq!(frame.len(), FRAME_SIZE);
+        let score = self.detector.predict_f32(frame);
+        let is_voice = score >= self.voice_threshold;
+
+        match self.state {
+            State::Idle => {
+                if is_voice {
+                    self.state = State::Speaking;
+                    self.current_segment.clear();
+                    self.speech_frames_in_segment = 0;
+                    self.silence_frames_in_holdoff = 0;
+                    self.current_segment.extend_from_slice(frame);
+                    self.speech_frames_in_segment += 1;
+                }
+                // Idle + silence: discard.
+            }
+            State::Speaking => {
+                self.current_segment.extend_from_slice(frame);
+                if is_voice {
+                    self.speech_frames_in_segment += 1;
+                } else {
+                    self.state = State::HoldingOff;
+                    self.silence_frames_in_holdoff = 1;
+                }
+            }
+            State::HoldingOff => {
+                self.current_segment.extend_from_slice(frame);
+                if is_voice {
+                    // Pause ended — back to Speaking.
+                    self.state = State::Speaking;
+                    self.speech_frames_in_segment += 1;
+                    self.silence_frames_in_holdoff = 0;
+                } else {
+                    self.silence_frames_in_holdoff += 1;
+                    if self.silence_frames_in_holdoff >= self.min_silence_frames {
+                        self.finalize_segment();
+                    }
+                }
+            }
+        }
+
+        // Max-speech safety flush — applies regardless of state, but
+        // only meaningful in Speaking/HoldingOff. Runs after the state
+        // update so a max-length segment flushes this frame's audio
+        // before starting a new one.
+        if !matches!(self.state, State::Idle)
+            && self.current_segment.len() >= self.max_speech_frames * FRAME_SIZE
+        {
+            tracing::debug!(
+                frames = self.max_speech_frames,
+                "earshot VAD: max speech frames reached, forcing flush"
+            );
+            self.finalize_segment();
+        }
+    }
+
+    /// End the current segment. If it's long enough to be real speech,
+    /// push it onto the completed queue; otherwise discard as noise.
+    /// Reset state to `Idle` either way.
+    fn finalize_segment(&mut self) {
+        if self.speech_frames_in_segment >= self.min_speech_frames {
+            let segment = std::mem::take(&mut self.current_segment);
+            self.completed.push_back(segment);
+        } else {
+            tracing::debug!(
+                frames = self.speech_frames_in_segment,
+                min = self.min_speech_frames,
+                "earshot VAD: segment too short, discarded"
+            );
+            self.current_segment.clear();
+        }
+        self.state = State::Idle;
+        self.speech_frames_in_segment = 0;
+        self.silence_frames_in_holdoff = 0;
+    }
+}
+
+impl VoiceActivityDetector for EarshotVad {
+    fn accept(&mut self, samples: &[f32]) {
+        // Reassemble into 256-sample frames, accounting for any
+        // leftover from the last call. Minimizes allocation by
+        // operating in-place on `partial_frame`.
+        let mut pos = 0;
+
+        // Finish the previous partial frame first, if any.
+        if !self.partial_frame.is_empty() {
+            let needed = FRAME_SIZE - self.partial_frame.len();
+            let take = needed.min(samples.len());
+            self.partial_frame.extend_from_slice(&samples[..take]);
+            pos += take;
+            if self.partial_frame.len() == FRAME_SIZE {
+                // Drain into a temporary to release the mutable borrow
+                // before `process_frame` takes `&mut self`.
+                let frame = std::mem::take(&mut self.partial_frame);
+                self.process_frame(&frame);
+                // Reuse the allocation.
+                self.partial_frame = frame;
+                self.partial_frame.clear();
+            }
+        }
+
+        // Whole frames from the rest of the input.
+        while samples.len() - pos >= FRAME_SIZE {
+            self.process_frame(&samples[pos..pos + FRAME_SIZE]);
+            pos += FRAME_SIZE;
+        }
+
+        // Stash the tail for next time.
+        if pos < samples.len() {
+            self.partial_frame.extend_from_slice(&samples[pos..]);
+        }
+    }
+
+    fn pop_segment(&mut self) -> Option<Vec<f32>> {
+        self.completed.pop_front()
+    }
+
+    fn flush(&mut self) {
+        // Force any in-flight segment to finalize so the caller can
+        // still pop it. Drop any partial frame — it's < 16 ms of
+        // audio, not worth worrying about.
+        self.partial_frame.clear();
+        if !matches!(self.state, State::Idle) {
+            self.finalize_segment();
+        }
+    }
+
+    fn reset(&mut self) {
+        self.detector.reset();
+        self.state = State::Idle;
+        self.partial_frame.clear();
+        self.current_segment.clear();
+        self.speech_frames_in_segment = 0;
+        self.silence_frames_in_holdoff = 0;
+        self.completed.clear();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_precision_loss)]
+mod tests {
+    use super::*;
+
+    /// Generate `n_frames` worth of a unit sine wave at `freq_hz`,
+    /// 16 kHz mono. earshot detects real voiced content so pure tones
+    /// produce inconsistent scores — tests that care about voice
+    /// detection use the `synthetic_voice` helper instead.
+    #[allow(dead_code)]
+    fn tone_frames(freq_hz: f32, n_frames: usize) -> Vec<f32> {
+        let n_samples = n_frames * FRAME_SIZE;
+        (0..n_samples)
+            .map(|i| {
+                let t = i as f32 / SAMPLE_RATE_HZ as f32;
+                (2.0 * std::f32::consts::PI * freq_hz * t).sin() * 0.3
+            })
+            .collect()
+    }
+
+    /// Synthetic "voice-like" audio: a 200 Hz fundamental plus
+    /// formants at 700, 1400, 2400 Hz with amplitude envelope.
+    /// earshot's feature extractor keys on mel-spectrum shapes that
+    /// resemble formant structure, so this produces reliable
+    /// above-threshold scores in tests without needing a recorded
+    /// voice sample on disk.
+    fn synthetic_voice(n_frames: usize) -> Vec<f32> {
+        let n_samples = n_frames * FRAME_SIZE;
+        (0..n_samples)
+            .map(|i| {
+                let t = i as f32 / SAMPLE_RATE_HZ as f32;
+                let f0 = (2.0 * std::f32::consts::PI * 200.0 * t).sin() * 0.25;
+                let f1 = (2.0 * std::f32::consts::PI * 700.0 * t).sin() * 0.20;
+                let f2 = (2.0 * std::f32::consts::PI * 1_400.0 * t).sin() * 0.15;
+                let f3 = (2.0 * std::f32::consts::PI * 2_400.0 * t).sin() * 0.10;
+                f0 + f1 + f2 + f3
+            })
+            .collect()
+    }
+
+    fn silence_frames(n_frames: usize) -> Vec<f32> {
+        vec![0.0; n_frames * FRAME_SIZE]
+    }
+
+    #[test]
+    fn fresh_vad_is_empty() {
+        let mut vad = EarshotVad::new();
+        assert!(vad.pop_segment().is_none());
+    }
+
+    #[test]
+    fn pure_silence_emits_nothing() {
+        let mut vad = EarshotVad::new();
+        vad.accept(&silence_frames(100));
+        vad.flush();
+        assert!(vad.pop_segment().is_none());
+    }
+
+    #[test]
+    fn partial_frames_across_calls_do_not_drop_samples() {
+        // Feed audio in two halves that don't land on a frame
+        // boundary. Total should still match the synchronous path.
+        let mut vad = EarshotVad::new();
+        let audio = silence_frames(10);
+        vad.accept(&audio[..FRAME_SIZE + 100]);
+        vad.accept(&audio[FRAME_SIZE + 100..]);
+
+        // Shouldn't emit anything for pure silence.
+        vad.flush();
+        assert!(vad.pop_segment().is_none());
+
+        // State machine internals: no residual speech counters.
+        assert_eq!(vad.state, State::Idle);
+    }
+
+    #[test]
+    fn reset_clears_all_state() {
+        let mut vad = EarshotVad::new();
+        vad.accept(&synthetic_voice(30));
+        vad.reset();
+        assert_eq!(vad.state, State::Idle);
+        assert!(vad.partial_frame.is_empty());
+        assert!(vad.current_segment.is_empty());
+        assert_eq!(vad.speech_frames_in_segment, 0);
+        assert_eq!(vad.silence_frames_in_holdoff, 0);
+        assert!(vad.completed.is_empty());
+    }
+
+    #[test]
+    fn short_burst_is_discarded_as_noise() {
+        // A single voiced frame (< min_speech_frames) should be
+        // dropped entirely. Use 1 frame of synthetic voice surrounded
+        // by silence so the segment ends but fails the length gate.
+        let mut vad = EarshotVad::new();
+        vad.accept(&synthetic_voice(1));
+        vad.accept(&silence_frames(DEFAULT_MIN_SILENCE_FRAMES + 5));
+        vad.flush();
+        assert!(vad.pop_segment().is_none());
+    }
+
+    #[test]
+    fn finalize_segment_respects_min_speech_gate() {
+        // Directly test the state machine gate without going through
+        // earshot's scoring — append frames to current_segment and
+        // call finalize.
+        let mut vad = EarshotVad::new();
+        vad.state = State::Speaking;
+        vad.speech_frames_in_segment = 5; // below DEFAULT_MIN_SPEECH_FRAMES
+        vad.current_segment
+            .extend_from_slice(&vec![0.1_f32; 5 * FRAME_SIZE]);
+        vad.finalize_segment();
+        assert!(vad.completed.is_empty(), "short segment should be dropped");
+        assert_eq!(vad.state, State::Idle);
+
+        // And a segment above the gate should survive.
+        vad.state = State::Speaking;
+        vad.speech_frames_in_segment = DEFAULT_MIN_SPEECH_FRAMES + 1;
+        vad.current_segment
+            .extend_from_slice(&vec![0.1_f32; 16 * FRAME_SIZE]);
+        vad.finalize_segment();
+        assert_eq!(vad.completed.len(), 1, "segment above gate should emit");
+    }
+
+    #[test]
+    fn flush_on_active_segment_emits_it() {
+        // Force the state machine into a valid Speaking state with
+        // enough speech frames, then flush — the segment should come
+        // out even though there's no trailing silence.
+        let mut vad = EarshotVad::new();
+        vad.state = State::Speaking;
+        vad.speech_frames_in_segment = DEFAULT_MIN_SPEECH_FRAMES + 5;
+        vad.current_segment
+            .extend_from_slice(&vec![0.1_f32; 20 * FRAME_SIZE]);
+        vad.flush();
+        assert_eq!(vad.completed.len(), 1);
+        assert_eq!(vad.state, State::Idle);
+    }
+}

--- a/crates/sdr-transcription/src/backends/earshot_vad.rs
+++ b/crates/sdr-transcription/src/backends/earshot_vad.rs
@@ -545,14 +545,44 @@ mod tests {
 
     #[test]
     fn short_burst_is_discarded_as_noise() {
-        // A single voiced frame (< min_speech_frames) should be
-        // dropped entirely. Use 1 frame of synthetic voice surrounded
-        // by silence so the segment ends but fails the length gate.
+        // Regression for the `min_speech_frames` discard gate.
+        // Drives the state machine directly so we can guarantee the
+        // discard path is exercised — feeding synthetic voice through
+        // `accept()` is ambiguous because earshot might never score
+        // the burst above threshold (its 3-frame context window is
+        // unreliable for 1-frame inputs) in which case the VAD would
+        // stay in `Idle` and `pop_segment()` would return `None` for
+        // the wrong reason, silently green-lighting a regression.
+        //
+        // Instead: manually seed the VAD into `Speaking` with a
+        // sub-gate voiced-frame count, then let `accept()` drive it
+        // through to finalization via trailing silence.
         let mut vad = EarshotVad::new();
-        vad.accept(&synthetic_voice(1));
+        vad.state = State::Speaking;
+        let voiced_count = DEFAULT_MIN_SPEECH_FRAMES - 1;
+        vad.speech_frames_in_segment = voiced_count;
+        vad.current_segment
+            .extend(std::iter::repeat_n(0.1_f32, voiced_count * FRAME_SIZE));
+
+        // Before the trailing silence: state is Speaking, segment has
+        // real audio, voice-frame count is sub-gate. This is the
+        // precondition that makes the assertion meaningful.
+        assert_eq!(vad.state, State::Speaking);
+        assert_eq!(vad.speech_frames_in_segment, voiced_count);
+        assert!(!vad.current_segment.is_empty());
+
+        // Feed enough silence to drive HoldingOff → finalize.
         vad.accept(&silence_frames(DEFAULT_MIN_SILENCE_FRAMES + 5));
         vad.flush();
-        assert!(vad.pop_segment().is_none());
+
+        // Segment discarded by the min_speech_frames gate: nothing
+        // popped, state back to Idle, counters cleared.
+        assert!(
+            vad.pop_segment().is_none(),
+            "sub-gate segment should be discarded, not emitted"
+        );
+        assert_eq!(vad.state, State::Idle);
+        assert_eq!(vad.speech_frames_in_segment, 0);
     }
 
     #[test]

--- a/crates/sdr-transcription/src/backends/mod.rs
+++ b/crates/sdr-transcription/src/backends/mod.rs
@@ -10,5 +10,8 @@ pub mod sherpa;
 #[cfg(feature = "whisper")]
 pub mod whisper;
 
+#[cfg(feature = "whisper")]
+pub mod earshot_vad;
+
 #[cfg(test)]
 pub mod mock;

--- a/crates/sdr-transcription/src/backends/whisper.rs
+++ b/crates/sdr-transcription/src/backends/whisper.rs
@@ -15,6 +15,8 @@ use crate::backend::{
     BackendConfig, BackendError, BackendHandle, ModelChoice, TranscriptionBackend,
     TranscriptionEvent, TranscriptionInput,
 };
+use crate::backends::earshot_vad::EarshotVad;
+use crate::vad::VoiceActivityDetector;
 use crate::{denoise, model, resampler};
 
 /// Bounded channel capacity for audio buffers from DSP → backend.
@@ -204,8 +206,26 @@ fn run_worker_inner(
         .send(TranscriptionEvent::Ready)
         .map_err(|_| "event channel closed before Ready".to_owned())?;
 
-    // --- Audio loop ---
-    let mut mono_buf: Vec<f32> = Vec::with_capacity(CHUNK_SAMPLES * 2);
+    // --- VAD + audio loop ---
+    //
+    // Pre-#259: fixed 5-second chunking + broadband RMS silence gate.
+    // The fixed chunking frequently cut utterances in half (typical NFM
+    // transmission is 1–4 s, so two back-to-back transmissions land in
+    // different chunks or a long one gets split), and the RMS gate
+    // false-triggered on squelch tails. Both showed up in committed
+    // text as noisy mid-word splits and transcripts of dead air.
+    //
+    // Post-#259: EarshotVad (pure-Rust VAD, no ONNX runtime) runs a
+    // 16-ms-frame state machine over the incoming audio. Each popped
+    // segment is a complete utterance bounded by silence, so Whisper
+    // only ever sees whole transmissions and never decodes dead air.
+    //
+    // `silence_threshold` is still accepted in BackendConfig so the
+    // UI slider doesn't break, but it's no longer read here — the VAD
+    // subsumes its purpose. A follow-up PR can retire the slider.
+    let _ = silence_threshold; // preserved for API compatibility
+    let mut scratch: Vec<f32> = Vec::with_capacity(CHUNK_SAMPLES * 2);
+    let mut vad = EarshotVad::new();
 
     loop {
         if cancel.load(Ordering::Relaxed) {
@@ -223,7 +243,8 @@ fn run_worker_inner(
             TranscriptionInput::SquelchOpened | TranscriptionInput::SquelchClosed => continue,
         };
 
-        resampler::downsample_stereo_to_mono_16k(&interleaved, &mut mono_buf);
+        scratch.clear();
+        resampler::downsample_stereo_to_mono_16k(&interleaved, &mut scratch);
 
         // Drain any additional queued buffers to minimize frame drops
         // during long inference passes. Check cancel between drains.
@@ -233,71 +254,98 @@ fn run_worker_inner(
                 return Ok(());
             }
             if let TranscriptionInput::Samples(s) = extra {
-                resampler::downsample_stereo_to_mono_16k(&s, &mut mono_buf);
+                resampler::downsample_stereo_to_mono_16k(&s, &mut scratch);
             }
         }
 
-        while mono_buf.len() >= CHUNK_SAMPLES {
+        if scratch.is_empty() {
+            continue;
+        }
+
+        // Feed the accumulated samples through the VAD. EarshotVad
+        // handles partial-frame stitching internally so we can send
+        // any length.
+        vad.accept(&scratch);
+
+        // Decode every segment the VAD has completed since the last
+        // iteration. Each segment is a bounded utterance; Whisper no
+        // longer sees arbitrary 5-second chunks of mixed speech and
+        // silence.
+        while let Some(mut segment) = vad.pop_segment() {
             if cancel.load(Ordering::Relaxed) {
                 tracing::info!("transcription cancelled, worker exiting");
                 return Ok(());
             }
-
-            let mut chunk: Vec<f32> = mono_buf.drain(..CHUNK_SAMPLES).collect();
-
-            // Voice-band shaped spectral gate (#274) — remove broadband
-            // static, rumble, PL tones, and above-voice hiss before
-            // Whisper sees the audio.
-            denoise::enhance_speech(&mut chunk, noise_gate_ratio);
-
-            let rms = compute_rms(&chunk);
-            if rms < silence_threshold {
-                tracing::debug!(rms, "chunk below silence threshold, skipping");
-                continue;
-            }
-
-            let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-            params.set_language(Some("en"));
-            params.set_print_progress(false);
-            params.set_print_realtime(false);
-            params.set_print_timestamps(false);
-            params.set_no_context(true);
-
-            if let Err(e) = state.full(params, &chunk) {
-                tracing::warn!("whisper inference failed: {e}");
-                continue;
-            }
-
-            let n_segments = state.full_n_segments();
-            let mut combined = String::new();
-
-            for i in 0..n_segments {
-                if let Some(segment) = state.get_segment(i)
-                    && let Ok(text) = segment.to_str()
-                {
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() {
-                        if !combined.is_empty() {
-                            combined.push(' ');
-                        }
-                        combined.push_str(trimmed);
-                    }
-                }
-            }
-
-            if !combined.is_empty() && !is_hallucination(&combined) {
-                let timestamp = crate::util::wall_clock_timestamp();
-                tracing::debug!(%timestamp, %combined, "transcribed chunk");
-                let _ = event_tx.send(TranscriptionEvent::Text {
-                    timestamp,
-                    text: combined,
-                });
-            }
+            decode_and_emit_segment(&mut state, &mut segment, event_tx, noise_gate_ratio);
         }
+    }
+
+    // Channel disconnected — force any in-flight segment out of the
+    // VAD so the last utterance isn't silently dropped.
+    vad.flush();
+    while let Some(mut segment) = vad.pop_segment() {
+        decode_and_emit_segment(&mut state, &mut segment, event_tx, noise_gate_ratio);
     }
 
     tracing::info!("audio channel closed, worker exiting");
     Ok(())
+}
+
+/// Denoise a VAD-completed speech segment, run Whisper inference,
+/// filter hallucinations, and emit the result on `event_tx` as a
+/// `TranscriptionEvent::Text`. Extracted so the main audio loop and
+/// the on-exit flush path share one implementation — they need
+/// identical behavior but differ in what they do on error (the main
+/// loop continues, the flush path returns either way).
+fn decode_and_emit_segment(
+    state: &mut whisper_rs::WhisperState,
+    segment: &mut [f32],
+    event_tx: &mpsc::Sender<TranscriptionEvent>,
+    noise_gate_ratio: f32,
+) {
+    // Voice-band shaped spectral gate (#274) — remove broadband
+    // static, rumble, PL tones, and above-voice hiss before Whisper
+    // sees the audio. Runs per segment rather than per chunk now that
+    // segmentation lives upstream.
+    denoise::enhance_speech(segment, noise_gate_ratio);
+
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+    params.set_language(Some("en"));
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_timestamps(false);
+    params.set_no_context(true);
+
+    if let Err(e) = state.full(params, segment) {
+        tracing::warn!("whisper inference failed: {e}");
+        return;
+    }
+
+    let n_segments = state.full_n_segments();
+    let mut combined = String::new();
+
+    for i in 0..n_segments {
+        if let Some(seg) = state.get_segment(i)
+            && let Ok(text) = seg.to_str()
+        {
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                if !combined.is_empty() {
+                    combined.push(' ');
+                }
+                combined.push_str(trimmed);
+            }
+        }
+    }
+
+    if !combined.is_empty() && !is_hallucination(&combined) {
+        let timestamp = crate::util::wall_clock_timestamp();
+        tracing::debug!(%timestamp, %combined, "transcribed segment");
+        let _ = event_tx.send(TranscriptionEvent::Text {
+            timestamp,
+            text: combined,
+        });
+    }
 }
 
 /// Common hallucination phrases Whisper produces on silence/noise.
@@ -330,40 +378,9 @@ fn is_hallucination(text: &str) -> bool {
         .any(|h| lower.trim().eq_ignore_ascii_case(h))
 }
 
-/// Compute the root-mean-square of a sample buffer.
-pub(crate) fn compute_rms(samples: &[f32]) -> f32 {
-    if samples.is_empty() {
-        return 0.0;
-    }
-    let sum_sq: f32 = samples.iter().map(|&s| s * s).sum();
-    #[allow(clippy::cast_precision_loss)]
-    let mean = sum_sq / samples.len() as f32;
-    mean.sqrt()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn rms_of_silence_is_zero() {
-        let silence = vec![0.0_f32; 1024];
-        let rms = compute_rms(&silence);
-        assert!((rms - 0.0).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn rms_of_ones_is_one() {
-        let ones = vec![1.0_f32; 1024];
-        let rms = compute_rms(&ones);
-        assert!((rms - 1.0).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn rms_of_empty_is_zero() {
-        let rms = compute_rms(&[]);
-        assert!((rms - 0.0).abs() < f32::EPSILON);
-    }
 
     #[test]
     fn whisper_backend_does_not_support_partials() {

--- a/crates/sdr-transcription/src/vad.rs
+++ b/crates/sdr-transcription/src/vad.rs
@@ -4,7 +4,8 @@
 //! the trait compiles in whisper builds, sherpa builds, and any future
 //! combination. The sherpa-onnx-backed impl lives in
 //! `backends/sherpa/silero_vad.rs` behind `#[cfg(feature = "sherpa")]`,
-//! and a Whisper impl (pure-Rust Silero) is a follow-up PR.
+//! and an earshot-backed pure-Rust impl lives in
+//! `backends/earshot_vad.rs` behind `#[cfg(feature = "whisper")]`.
 //!
 //! Callers feed 16 kHz mono samples via [`VoiceActivityDetector::accept`]
 //! and poll [`VoiceActivityDetector::pop_segment`] to pull completed
@@ -13,9 +14,31 @@
 
 /// Queue-based voice activity detector.
 ///
-/// The implementation is expected to buffer input internally and emit
-/// one segment per detected utterance. Segments contain only voiced
-/// frames; silence is already trimmed by the detector.
+/// The implementation buffers input internally and emits one segment
+/// per detected utterance. Each segment is a **bounded utterance** —
+/// the detector decides where the utterance starts and ends and
+/// returns audio that covers it. Segments are NOT required to be
+/// pure voiced samples with all silence trimmed away; implementations
+/// typically include a small amount of leading and trailing context
+/// (pre-trigger "lookback" and post-trigger "holdoff" padding) so
+/// downstream recognizers see consonant attacks and release tails
+/// instead of truncated words.
+///
+/// Concrete impls documented for the two current backends:
+///
+/// - `SherpaSileroVad` (sherpa feature): segments come from
+///   sherpa-onnx's `VoiceActivityDetector` which applies Silero's
+///   internal `speech_pad_ms` (~30 ms) to both ends of each utterance.
+/// - `EarshotVad` (whisper feature): segments include a 64 ms
+///   pre-trigger lookback ring at the start and any `HoldingOff`
+///   trailing-silence frames that fell inside the segment before the
+///   `min_silence_frames` gate fired. See
+///   `crates/sdr-transcription/src/backends/earshot_vad.rs` for
+///   tuning details.
+///
+/// The common invariant: a popped segment is a complete utterance
+/// boundable by silence, handed off in one piece. Callers don't need
+/// to do further chunking.
 pub trait VoiceActivityDetector {
     /// Feed 16 kHz mono samples. The detector buffers internally and
     /// may emit one or more completed segments after this call.


### PR DESCRIPTION
## Summary

Fixes #259. Replaces the naive RMS silence gate + fixed 5-second chunking in the Whisper backend with a pure-Rust voice activity detector built on \`earshot\`. Whisper now only decodes bounded speech segments instead of arbitrary 5-second windows that straddle utterance boundaries.

## What was broken

The old flow was:

1. Accumulate 16 kHz mono samples into \`mono_buf\`
2. When \`mono_buf.len() >= 80_000\` (5 seconds), drain a chunk
3. Apply the voice-band spectral gate
4. Gate the chunk by its total RMS — skip if below \`silence_threshold\`
5. Run Whisper inference on the chunk

Problems:

- **Utterance splitting**: a typical NFM transmission is 1–4 s, so two back-to-back transmissions land in different chunks, and a 6+ s transmission gets split mid-word. Whisper's transcript then shows \"and the suspect ran\" / \"toward the building\" as two disconnected fragments.
- **Squelch-tail noise**: the RMS gate is indifferent to frequency content. A noisy squelch tail has enough energy to trip past \`silence_threshold\` and feed hiss straight to Whisper, which hallucinates on it (\"thank you\", \"thanks for watching\", \"subscribe\" — tracked in the \`HALLUCINATIONS\` list this PR leaves untouched).

## What this PR does

Introduces \`backends/earshot_vad.rs\` with \`EarshotVad\`, a
\`VoiceActivityDetector\` implementation that runs a three-state
machine (\`Idle\` / \`Speaking\` / \`HoldingOff\`) over per-frame earshot
voice scores. Each popped segment is a bounded utterance — silence
before, silence after, speech in the middle. Whisper sees nothing
else.

\`backends/whisper.rs\`'s \`run_worker_inner\` is rewritten:

- Accumulated samples go through \`vad.accept()\` instead of a fixed-chunk drain
- Inner loop calls \`vad.pop_segment()\` until empty, passing each segment to a new \`decode_and_emit_segment\` helper
- On channel disconnect, \`vad.flush()\` forces any in-flight segment out so the last utterance isn't dropped

The old \`compute_rms\` helper and its three tests are removed — dead after the gate is gone. \`silence_threshold\` stays in \`BackendConfig\` so the UI slider doesn't break, but whisper.rs no longer reads it. Retiring the slider itself is a follow-up PR.

## Why earshot (not \`voice_activity_detector\`, not Silero directly)

This is the same constraint that caused the whisper/sherpa feature mutex: whisper-rs (bundling whisper.cpp) and any C++ ONNX runtime fight over libstdc++ global state. See #253 for the original heap corruption. Any Silero-based VAD that runs on \`ort\` would have the same class of problem, so we can't use the \`voice_activity_detector\` crate on crates.io (depends on \`ort\`) or wrap Silero directly via \`ort\` / sherpa-onnx.

\`earshot\` is published by pyke (the team that also maintains \`ort\`) explicitly as the pure-Rust alternative:

- **75 KiB embedded neural network** — not Silero, a proprietary smaller model
- **Zero ONNX runtime** — custom mel feature extractor + tiny NN inference loop
- **Only \`libm\` as a dependency** — no C++ state to collide with whisper.cpp
- **Faster than Silero VAD v6** by ~20× per the author's benchmarks (RTF 0.0007 vs Silero's 0.014)
- **MIT/Apache 2.0**, actively maintained

\`cargo tree\` for \`earshot\` is two lines: \`earshot v1.0.0\` → \`libm v0.2.16\`.

## Segmentation tuning

The \`DEFAULT_*\` constants in \`earshot_vad.rs\` mirror sherpa-onnx's Silero defaults so the Whisper and Sherpa backends behave similarly on the same audio:

- \`min_silence_frames\` = 250 ms (15 frames @ 16 ms/frame)
- \`min_speech_frames\` = 250 ms (rejects single-frame noise spikes)
- \`max_speech_frames\` = 20 s (forced flush cap)
- \`voice_threshold\` = 0.5 (earshot's recommended default)

Not exposed to the UI yet — follow-up if real-world testing shows user tuning matters.

## Tests

7 new unit tests in \`earshot_vad::tests\` exercise the pure state machine via direct field manipulation (no recorded audio on disk needed):

- \`fresh_vad_is_empty\` — new instance has nothing to pop
- \`pure_silence_emits_nothing\` — 100 frames of zeros → no segment
- \`partial_frames_across_calls_do_not_drop_samples\` — two half-frame batches end in \`Idle\` with no residual state
- \`reset_clears_all_state\` — \`reset()\` zeros every field
- \`short_burst_is_discarded_as_noise\` — single voiced frame followed by silence → nothing popped
- \`finalize_segment_respects_min_speech_gate\` — below and above the length gate, directly driven
- \`flush_on_active_segment_emits_it\` — forced flush bypasses the trailing-silence requirement

Triple-flavor cargo check + clippy clean on \`whisper-cpu\`, \`whisper-cuda\`, \`sherpa-cpu\`, \`sherpa-cuda\` with \`-D warnings\`.

## Test plan

- [ ] Whisper CUDA build on live NFM with back-to-back transmissions — transcripts should land on utterance boundaries, not every 5 seconds
- [ ] Whisper transcripts should stop splitting mid-word
- [ ] Dead-air chunks should no longer produce hallucinated \"thank you\" / \"subscribe\" text
- [ ] Sherpa builds (cpu and cuda) still compile and work — the feature mutex is respected, earshot is whisper-feature-gated
- [ ] The UI \`silence_threshold\` slider still appears and moves without crashing (backend ignores it, UI is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Earshot-based voice activity detector is available as an added VAD backend (enabled with the existing whisper feature).

* **Improvements**
  * Transcription now decodes per detected utterance for more responsive results.
  * In-progress utterances are flushed on disconnect; very short/noise segments are discarded.
  * Replaced fixed-chunk/RMS gating with VAD-driven segmentation.

* **Documentation**
  * Clarified VAD segment semantics and backend-specific padding/holdoff behavior.

* **Tests**
  * Added unit tests covering VAD behaviors and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->