### PR TITLE
feat(ctcss): wire tone detector into af_chain with HPF override (#269 PR 2/3)

### DIFF
--- a/crates/sdr-radio/src/af_chain.rs
+++ b/crates/sdr-radio/src/af_chain.rs
@@ -5,7 +5,7 @@
 
 use sdr_dsp::filter::{DeemphasisFilter, NotchFilter};
 use sdr_dsp::multirate::RationalResampler;
-use sdr_dsp::tone_detect::{CTCSS_SAMPLE_RATE_HZ, CtcssDetector, ctcss_tone_index};
+use sdr_dsp::tone_detect::{CtcssDetector, ctcss_tone_index};
 use sdr_types::{Complex, DspError, Stereo};
 
 /// Default audio output sample rate (Hz).
@@ -303,7 +303,18 @@ impl AfChain {
                         "CTCSS frequency {hz} Hz is not a known tone"
                     )));
                 }
-                let detector = CtcssDetector::new(hz, CTCSS_SAMPLE_RATE_HZ)?;
+                // Pass the instance's actual audio_sample_rate (not
+                // the CTCSS_SAMPLE_RATE_HZ constant) so the
+                // detector's internal rate-validation catches a
+                // misconfigured AF chain at setter time rather than
+                // silently running 19200-sample windows at the
+                // wrong duration. CtcssDetector::new enforces
+                // equality with CTCSS_SAMPLE_RATE_HZ within a
+                // 0.5 Hz tolerance and returns
+                // DspError::InvalidParameter on mismatch — that's
+                // exactly the contract we want here.
+                #[allow(clippy::cast_possible_truncation)]
+                let detector = CtcssDetector::new(hz, self.audio_sample_rate as f32)?;
                 self.ctcss_mode = CtcssMode::Tone(hz);
                 self.ctcss_detector = Some(detector);
             }

--- a/crates/sdr-radio/src/af_chain.rs
+++ b/crates/sdr-radio/src/af_chain.rs
@@ -5,6 +5,7 @@
 
 use sdr_dsp::filter::{DeemphasisFilter, NotchFilter};
 use sdr_dsp::multirate::RationalResampler;
+use sdr_dsp::tone_detect::{CTCSS_SAMPLE_RATE_HZ, CtcssDetector, ctcss_tone_index};
 use sdr_types::{Complex, DspError, Stereo};
 
 /// Default audio output sample rate (Hz).
@@ -12,6 +13,33 @@ const DEFAULT_AUDIO_RATE: f64 = 48_000.0;
 
 /// Default high-pass cutoff frequency (Hz) for voice modes.
 const HIGH_PASS_CUTOFF_HZ: f64 = 300.0;
+
+/// CTCSS sub-audible tone squelch mode.
+///
+/// `Off` is the default — audio passes through unchanged and the
+/// detector is not constructed. `Tone(hz)` must name one of the
+/// frequencies in [`sdr_dsp::tone_detect::CTCSS_TONES_HZ`]; any
+/// other value is rejected by [`AfChain::set_ctcss_mode`].
+///
+/// When in `Tone` mode, the AF chain:
+///
+/// 1. Runs the [`CtcssDetector`] on the post-resample, post-deemph,
+///    **pre-high-pass** mono signal so the detector sees the full
+///    67–254 Hz sub-audible band.
+/// 2. Force-enables the 300 Hz high-pass filter on the speaker path
+///    so the user doesn't hear the tone as a low buzz, regardless
+///    of the user's explicit high-pass preference.
+/// 3. Zeros the output block whenever the detector reports
+///    `sustained == false` (no tone confirmed yet, or tone has
+///    dropped out for at least `CTCSS_MIN_HITS` consecutive
+///    windows).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CtcssMode {
+    /// No CTCSS gating. Audio passes through unchanged.
+    Off,
+    /// Gate the speaker path on the given CTCSS tone frequency.
+    Tone(f32),
+}
 
 /// Guard padding for resampler output buffer to handle worst-case rounding.
 const RESAMPLER_OUTPUT_PADDING: usize = 16;
@@ -65,12 +93,32 @@ pub struct AfChain {
     deemp_enabled: bool,
     hp_l: Option<HighPassFilter>,
     hp_r: Option<HighPassFilter>,
-    hp_enabled: bool,
+    /// User's explicit high-pass preference, independent of CTCSS.
+    /// The effective filter state is `hp_user_enabled || ctcss is
+    /// Tone(_)`; CTCSS force-enables the HPF to strip the sub-
+    /// audible tone from the speaker path regardless of the user's
+    /// setting. Restored to the exact user value when CTCSS returns
+    /// to `Off`.
+    hp_user_enabled: bool,
     notch_l: NotchFilter,
     notch_r: NotchFilter,
     resampler: Option<RationalResampler>,
     af_sample_rate: f64,
     audio_sample_rate: f64,
+    /// Active CTCSS gating mode. `Off` means the detector is not
+    /// constructed and audio passes through; `Tone(hz)` means the
+    /// detector runs on every block and the output is muted until
+    /// the sustained gate opens.
+    ctcss_mode: CtcssMode,
+    /// CTCSS detector instance, constructed lazily from
+    /// [`Self::set_ctcss_mode`] when the mode flips to `Tone(_)`.
+    /// Dropped when the mode flips back to `Off`. The detector
+    /// owns its own per-window hysteresis state so swapping it out
+    /// is the right way to reset between tones.
+    ctcss_detector: Option<CtcssDetector>,
+    /// Mono downmix scratch buffer fed to the detector. Reused
+    /// across calls to avoid per-block allocation on the hot path.
+    ctcss_mono_buf: Vec<f32>,
     /// Scratch buffer for deemphasis L input channel.
     deemp_buf_l: Vec<f32>,
     /// Scratch buffer for deemphasis R input channel.
@@ -116,12 +164,15 @@ impl AfChain {
             deemp_enabled: false,
             hp_l: None,
             hp_r: None,
-            hp_enabled: false,
+            hp_user_enabled: false,
             notch_l: NotchFilter::new(audio_rate_f32),
             notch_r: NotchFilter::new(audio_rate_f32),
             resampler,
             af_sample_rate,
             audio_sample_rate,
+            ctcss_mode: CtcssMode::Off,
+            ctcss_detector: None,
+            ctcss_mono_buf: Vec::new(),
             deemp_buf_l: Vec::new(),
             deemp_out_l: Vec::new(),
             deemp_out_r: Vec::new(),
@@ -165,12 +216,43 @@ impl AfChain {
         Ok(())
     }
 
-    /// Enable or disable the high-pass filter (voice modes).
+    /// Set the user's high-pass filter preference.
     ///
-    /// Removes low-frequency hum and rumble below 300 Hz.
+    /// Removes low-frequency hum and rumble below 300 Hz. The
+    /// effective filter state is `user_preference || CTCSS active`
+    /// — the CTCSS squelch force-engages the HPF to strip its
+    /// sub-audible tone from the speaker path regardless of this
+    /// setting, so toggling it off while CTCSS is active only
+    /// records the preference for when CTCSS returns to `Off`.
     pub fn set_high_pass_enabled(&mut self, enabled: bool) {
-        self.hp_enabled = enabled;
-        if enabled && self.hp_l.is_none() {
+        self.hp_user_enabled = enabled;
+        self.apply_effective_high_pass();
+    }
+
+    /// Returns the user's high-pass preference. See also
+    /// [`Self::effective_high_pass_enabled`] for the state that
+    /// actually gates the signal, which can differ when CTCSS is
+    /// active.
+    pub fn high_pass_enabled(&self) -> bool {
+        self.hp_user_enabled
+    }
+
+    /// Returns the effective high-pass state — `true` if either
+    /// the user has explicitly enabled it OR CTCSS squelch is
+    /// active (and therefore force-enables the HPF to strip its
+    /// sub-audible tone from the speaker path).
+    pub fn effective_high_pass_enabled(&self) -> bool {
+        self.hp_user_enabled || matches!(self.ctcss_mode, CtcssMode::Tone(_))
+    }
+
+    /// Allocate or drop the HPF biquad state to match the current
+    /// effective enabled state. Called from `set_high_pass_enabled`
+    /// and `set_ctcss_mode`; the former changes the user preference
+    /// and the latter changes the force-on override. Either can
+    /// flip the effective state.
+    fn apply_effective_high_pass(&mut self) {
+        let effective = self.effective_high_pass_enabled();
+        if effective && self.hp_l.is_none() {
             self.hp_l = Some(HighPassFilter::new(
                 HIGH_PASS_CUTOFF_HZ,
                 self.audio_sample_rate,
@@ -179,15 +261,69 @@ impl AfChain {
                 HIGH_PASS_CUTOFF_HZ,
                 self.audio_sample_rate,
             ));
-        } else if !enabled {
+        } else if !effective {
             self.hp_l = None;
             self.hp_r = None;
         }
     }
 
-    /// Returns whether the high-pass filter is enabled.
-    pub fn high_pass_enabled(&self) -> bool {
-        self.hp_enabled
+    /// Set the CTCSS sub-audible tone squelch mode.
+    ///
+    /// `Off` drops the detector (if any) and restores the user's
+    /// high-pass preference. `Tone(hz)` validates `hz` against
+    /// [`sdr_dsp::tone_detect::CTCSS_TONES_HZ`], constructs a fresh
+    /// detector (with its own per-window hysteresis state), and
+    /// force-enables the 300 Hz high-pass filter so the user
+    /// doesn't hear the tone.
+    ///
+    /// Switching between two `Tone(_)` values rebuilds the detector
+    /// from scratch — there's no way to retune a
+    /// [`CtcssDetector`] in place because its neighbor-dominance
+    /// filters are calibrated against the table entry, not the
+    /// tone in isolation. Rebuilding is cheap (no allocations on
+    /// the hot path; the mono downmix buffer is preserved across
+    /// swaps) and matches how a user-driven tone change will look
+    /// from the UI in PR 3.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DspError::InvalidParameter`] if `Tone(hz)` names a
+    /// frequency that isn't in the CTCSS table, or if the detector
+    /// constructor rejects it for any other reason (non-finite
+    /// input, etc. — see [`CtcssDetector::new`] for the full list).
+    pub fn set_ctcss_mode(&mut self, mode: CtcssMode) -> Result<(), DspError> {
+        match mode {
+            CtcssMode::Off => {
+                self.ctcss_mode = CtcssMode::Off;
+                self.ctcss_detector = None;
+            }
+            CtcssMode::Tone(hz) => {
+                if ctcss_tone_index(hz).is_none() {
+                    return Err(DspError::InvalidParameter(format!(
+                        "CTCSS frequency {hz} Hz is not a known tone"
+                    )));
+                }
+                let detector = CtcssDetector::new(hz, CTCSS_SAMPLE_RATE_HZ)?;
+                self.ctcss_mode = CtcssMode::Tone(hz);
+                self.ctcss_detector = Some(detector);
+            }
+        }
+        self.apply_effective_high_pass();
+        Ok(())
+    }
+
+    /// Returns the current CTCSS squelch mode.
+    pub fn ctcss_mode(&self) -> CtcssMode {
+        self.ctcss_mode
+    }
+
+    /// Returns the CTCSS detector's sustained-gate state, or
+    /// `false` if CTCSS is currently `Off`. Exposed for UI level-
+    /// meter / status-light display in PR 3 and for testing.
+    pub fn ctcss_sustained(&self) -> bool {
+        self.ctcss_detector
+            .as_ref()
+            .is_some_and(CtcssDetector::is_sustained)
     }
 
     /// Enable or disable the notch filter.
@@ -235,7 +371,11 @@ impl AfChain {
     /// # Errors
     ///
     /// Returns `DspError` on buffer size or processing errors.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::too_many_lines
+    )]
     pub fn process(&mut self, input: &[Stereo], output: &mut [Stereo]) -> Result<usize, DspError> {
         if input.is_empty() {
             return Ok(0);
@@ -314,11 +454,31 @@ impl AfChain {
             }
         }
 
-        // Stage 3: High-pass filter at audio output rate.
+        // Stage 3a: CTCSS detector tap.
+        // Runs BEFORE the high-pass filter so the detector sees
+        // the full-bandwidth AF including the sub-audible tone
+        // (67–254 Hz). Feeds a mono downmix of the post-deemph
+        // signal; the detector buffers internally and only returns
+        // a decision once it has a full 400 ms / 19200-sample
+        // window. Sustained state is sticky across calls.
+        if let Some(detector) = self.ctcss_detector.as_mut() {
+            self.ctcss_mono_buf.clear();
+            self.ctcss_mono_buf.reserve(resamp_count);
+            for s in &output[..resamp_count] {
+                // (L + R) / 2 downmix — for NFM (the only mode
+                // that uses CTCSS in practice) L and R are
+                // identical, but averaging is cheap and safe for
+                // any stereo content.
+                self.ctcss_mono_buf.push(0.5 * (s.l + s.r));
+            }
+            let _ = detector.accept_samples(&self.ctcss_mono_buf);
+        }
+
+        // Stage 3b: High-pass filter at audio output rate.
         // Removes low-frequency hum and rumble (cutoff ~300 Hz).
-        if self.hp_enabled
-            && let (Some(hp_l), Some(hp_r)) = (&mut self.hp_l, &mut self.hp_r)
-        {
+        // Effective-enabled bit above also picks up the CTCSS
+        // force-on override.
+        if let (Some(hp_l), Some(hp_r)) = (&mut self.hp_l, &mut self.hp_r) {
             for s in &mut output[..resamp_count] {
                 s.l = hp_l.process_sample(s.l);
                 s.r = hp_r.process_sample(s.r);
@@ -352,6 +512,32 @@ impl AfChain {
                     .zip(self.notch_out_r[..resamp_count].iter()),
             ) {
                 *out = Stereo::new(l, r);
+            }
+        }
+
+        // Stage 5: CTCSS squelch gate.
+        // Zeroes the entire block when the detector's sustained
+        // gate is closed. This runs LAST so the preceding filters
+        // (HPF/notch) still update their state on the real signal
+        // — keeping the gate close doesn't desync the filters, so
+        // the first block after the gate reopens doesn't have a
+        // transient from state that lagged behind the signal.
+        //
+        // Note the asymmetry: the detector in Stage 3a is fed the
+        // pre-HPF signal (it needs to see the sub-audible tone to
+        // detect it), while the output we zero here is the post-
+        // HPF signal (the user would otherwise hear the tone as a
+        // low buzz). Zeroing post-HPF is cheaper than zeroing pre-
+        // HPF anyway — a fresh zero passed through an active IIR
+        // is not quite zero, so zeroing last skips that subtlety.
+        if matches!(self.ctcss_mode, CtcssMode::Tone(_))
+            && self
+                .ctcss_detector
+                .as_ref()
+                .is_some_and(|d| !d.is_sustained())
+        {
+            for s in &mut output[..resamp_count] {
+                *s = Stereo::new(0.0, 0.0);
             }
         }
 
@@ -464,5 +650,177 @@ mod tests {
         let chain = AfChain::with_default_rate(24_000.0).unwrap();
         assert!((chain.audio_sample_rate() - 48_000.0).abs() < 1.0);
         assert!((chain.af_sample_rate() - 24_000.0).abs() < 1.0);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // CTCSS tests (PR 2 of #269)
+    // ─────────────────────────────────────────────────────────────
+
+    use sdr_dsp::tone_detect::{CTCSS_MIN_HITS, CTCSS_WINDOW_SAMPLES};
+
+    /// Build a stereo block of a pure CTCSS tone at 48 kHz with
+    /// amplitude 1.0 on both channels. Enough samples to cover
+    /// `windows` full detector windows.
+    fn ctcss_tone_block(freq_hz: f32, windows: usize) -> Vec<Stereo> {
+        let n = CTCSS_WINDOW_SAMPLES * windows;
+        let mut out = Vec::with_capacity(n);
+        let dt = 1.0 / 48_000.0_f32;
+        for i in 0..n {
+            #[allow(clippy::cast_precision_loss)]
+            let t = i as f32 * dt;
+            let v = (core::f32::consts::TAU * freq_hz * t).sin();
+            out.push(Stereo::new(v, v));
+        }
+        out
+    }
+
+    #[test]
+    fn test_ctcss_off_passes_audio_through_unchanged() {
+        // Baseline: with CTCSS off the chain behaves exactly like
+        // the existing passthrough. No zeroing, no forced HPF,
+        // no detector state.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        assert_eq!(chain.ctcss_mode(), CtcssMode::Off);
+        assert!(!chain.effective_high_pass_enabled());
+
+        let input = vec![Stereo::new(0.5, -0.5); 1000];
+        let mut output = vec![Stereo::default(); 1000];
+        let count = chain.process(&input, &mut output).unwrap();
+        assert_eq!(count, 1000);
+        assert_eq!(output[0].l, 0.5);
+        assert_eq!(output[500].r, -0.5);
+    }
+
+    #[test]
+    fn test_ctcss_set_mode_rejects_non_table_frequency() {
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        let err = chain.set_ctcss_mode(CtcssMode::Tone(123.456));
+        assert!(err.is_err(), "non-CTCSS frequency must be rejected");
+        assert_eq!(chain.ctcss_mode(), CtcssMode::Off);
+    }
+
+    #[test]
+    fn test_ctcss_tone_mode_force_enables_high_pass() {
+        // User explicitly has HPF off. CTCSS should still engage
+        // the filter to strip the sub-audible tone from the
+        // speaker path.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain.set_high_pass_enabled(false);
+        assert!(!chain.high_pass_enabled());
+        assert!(!chain.effective_high_pass_enabled());
+
+        chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+        assert!(
+            !chain.high_pass_enabled(),
+            "user preference must not be silently flipped"
+        );
+        assert!(
+            chain.effective_high_pass_enabled(),
+            "CTCSS should force-enable the HPF"
+        );
+    }
+
+    #[test]
+    fn test_ctcss_off_restores_user_high_pass_preference() {
+        // User sets HPF off, CTCSS force-engages it, then CTCSS
+        // goes back to Off. The user's original preference must
+        // re-take effect — no leaked force-on state.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain.set_high_pass_enabled(false);
+        chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+        assert!(chain.effective_high_pass_enabled());
+
+        chain.set_ctcss_mode(CtcssMode::Off).unwrap();
+        assert!(!chain.effective_high_pass_enabled());
+
+        // And the opposite: user sets HPF on first, CTCSS toggles
+        // around it. User preference survives unchanged.
+        let mut chain2 = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain2.set_high_pass_enabled(true);
+        chain2.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+        assert!(chain2.effective_high_pass_enabled());
+        chain2.set_ctcss_mode(CtcssMode::Off).unwrap();
+        assert!(chain2.effective_high_pass_enabled());
+        assert!(chain2.high_pass_enabled());
+    }
+
+    #[test]
+    fn test_ctcss_wrong_tone_mutes_output() {
+        // Detector targets 100 Hz but the audio is a 131.8 Hz
+        // tone. After several windows the sustained gate should
+        // still be closed and the output should be muted.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+
+        // Feed 4 windows so the detector has had plenty of time
+        // to confirm (or reject) a signal. A bit more than
+        // `CTCSS_MIN_HITS` gives a margin for the first window
+        // which may partially overlap warmup.
+        let windows = CTCSS_MIN_HITS + 1;
+        let input = ctcss_tone_block(131.8, windows);
+        let mut output = vec![Stereo::default(); input.len()];
+        chain.process(&input, &mut output).unwrap();
+
+        assert!(!chain.ctcss_sustained(), "wrong-tone must not sustain");
+        // Later samples (past the HPF warmup transient) must all
+        // be exactly zero — the muting happens in a single pass
+        // at the end of process, so every output sample is 0.0.
+        let last_window = &output[CTCSS_WINDOW_SAMPLES * CTCSS_MIN_HITS..];
+        for (i, s) in last_window.iter().enumerate() {
+            assert_eq!(s.l, 0.0, "sample {i} L should be muted, got {}", s.l);
+            assert_eq!(s.r, 0.0, "sample {i} R should be muted, got {}", s.r);
+        }
+    }
+
+    #[test]
+    fn test_ctcss_correct_tone_opens_gate_after_min_hits() {
+        // Detector targets 100 Hz and the audio is a 100 Hz tone.
+        // After `CTCSS_MIN_HITS` windows the sustained gate must
+        // open and the output must contain audible signal (post-
+        // HPF, so the 100 Hz tone itself is attenuated, but some
+        // residual energy remains).
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+
+        let windows = CTCSS_MIN_HITS + 2;
+        let input = ctcss_tone_block(100.0, windows);
+        let mut output = vec![Stereo::default(); input.len()];
+        chain.process(&input, &mut output).unwrap();
+
+        assert!(
+            chain.ctcss_sustained(),
+            "correct-tone must open the sustained gate"
+        );
+        // With the gate open the muting step is skipped, so the
+        // later windows are NOT all zero. The HPF attenuates 100
+        // Hz heavily but doesn't null it — we should still see
+        // nonzero samples somewhere in the last window.
+        let last_window_start = CTCSS_WINDOW_SAMPLES * (windows - 1);
+        let any_nonzero = output[last_window_start..]
+            .iter()
+            .any(|s| s.l.abs() > 1e-6 || s.r.abs() > 1e-6);
+        assert!(
+            any_nonzero,
+            "open gate must pass some signal through (even after HPF)"
+        );
+    }
+
+    #[test]
+    fn test_ctcss_mode_change_resets_detector() {
+        // Switching target tones rebuilds the detector from
+        // scratch; the sustained state should NOT carry over
+        // from the previous tone.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+
+        // Open the gate on 100 Hz.
+        let input = ctcss_tone_block(100.0, CTCSS_MIN_HITS + 1);
+        let mut output = vec![Stereo::default(); input.len()];
+        chain.process(&input, &mut output).unwrap();
+        assert!(chain.ctcss_sustained());
+
+        // Switch to 131.8 Hz. Sustained state must reset.
+        chain.set_ctcss_mode(CtcssMode::Tone(131.8)).unwrap();
+        assert!(!chain.ctcss_sustained());
     }
 }

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -12,7 +12,7 @@ use sdr_dsp::filter::{DEEMPHASIS_TAU_EU, DEEMPHASIS_TAU_US};
 use sdr_dsp::multirate::RationalResampler;
 use sdr_types::{Complex, DemodMode, DspError, Stereo};
 
-use af_chain::AfChain;
+use af_chain::{AfChain, CtcssMode};
 use demod::{DemodConfig, Demodulator, create_demodulator};
 
 /// Tolerance for considering two sample rates equal (skip resampling).
@@ -71,6 +71,11 @@ pub struct RadioModule {
     high_pass_enabled: bool,
     notch_enabled: bool,
     notch_frequency: f32,
+    /// Persisted CTCSS squelch mode. Reapplied to the new AF chain
+    /// on mode switch (when the demod rate changes the AF chain is
+    /// rebuilt from scratch, so the CTCSS state has to be restored
+    /// the same way deemphasis / notch / high-pass are).
+    ctcss_mode: CtcssMode,
     audio_sample_rate: f64,
     /// Input sample rate from the IQ frontend (Hz).
     input_sample_rate: f64,
@@ -107,6 +112,7 @@ impl RadioModule {
             high_pass_enabled: false,
             notch_enabled: false,
             notch_frequency: sdr_dsp::filter::DEFAULT_NOTCH_FREQ_HZ,
+            ctcss_mode: CtcssMode::Off,
             audio_sample_rate,
             input_sample_rate: 0.0,
             input_resampler: None,
@@ -172,6 +178,16 @@ impl RadioModule {
         // correct when the user re-enables after a mode switch.
         af_chain.set_notch_frequency(self.notch_frequency);
         af_chain.set_notch_enabled(self.notch_enabled);
+        // Restore CTCSS mode. The sustained-gate state intentionally
+        // resets to closed on mode switch — a new mode means the
+        // user retuned or changed decode, and holding an old
+        // "tone confirmed" latch across that transition would let
+        // stray audio through before the detector re-confirmed on
+        // the new signal. `set_ctcss_mode` rebuilds the detector
+        // from scratch so this is the natural behavior.
+        af_chain
+            .set_ctcss_mode(self.ctcss_mode)
+            .map_err(|e| RadioError::ModeSwitchFailed(format!("failed to set CTCSS mode: {e}")))?;
 
         // Update IF chain feature flags based on new mode capabilities
         if !fm_if_nr_allowed {
@@ -370,6 +386,42 @@ impl RadioModule {
     pub fn set_notch_frequency(&mut self, freq: f32) {
         self.notch_frequency = freq;
         self.af_chain.set_notch_frequency(freq);
+    }
+
+    /// Set the CTCSS sub-audible tone squelch mode.
+    ///
+    /// `CtcssMode::Off` disables the detector and restores the
+    /// user's explicit high-pass preference. `CtcssMode::Tone(hz)`
+    /// validates `hz` against the standard 51-entry CTCSS table,
+    /// constructs a fresh detector at the current audio rate, and
+    /// force-enables the 300 Hz speaker-path high-pass filter so
+    /// the user doesn't hear the sub-audible tone as a low buzz.
+    ///
+    /// Persists across mode changes — reapplied when the AF chain
+    /// is rebuilt. See [`AfChain::set_ctcss_mode`] for details on
+    /// the detector's window / hysteresis behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RadioError::Dsp`] if the frequency isn't a known
+    /// CTCSS tone or the detector constructor rejects it.
+    pub fn set_ctcss_mode(&mut self, mode: CtcssMode) -> Result<(), RadioError> {
+        self.af_chain.set_ctcss_mode(mode)?;
+        self.ctcss_mode = mode;
+        Ok(())
+    }
+
+    /// Returns the current CTCSS squelch mode.
+    pub fn ctcss_mode(&self) -> CtcssMode {
+        self.ctcss_mode
+    }
+
+    /// Returns the CTCSS sustained-gate state: `true` when the
+    /// target tone has been confirmed present for at least
+    /// [`sdr_dsp::tone_detect::CTCSS_MIN_HITS`] consecutive
+    /// windows. Always `false` when CTCSS is `Off`.
+    pub fn ctcss_sustained(&self) -> bool {
+        self.af_chain.ctcss_sustained()
     }
 
     /// Enable or disable WFM stereo decode.


### PR DESCRIPTION
## Summary

Second PR of three for issue #269 (CTCSS sub-audible tone squelch). PR 1 (#285) shipped the pure-DSP Goertzel detector with neighbor-dominance gating and sustained-hit hysteresis. This PR wires that detector into the radio module's AF chain so a user-selected tone actually gates the speaker path.

- `CtcssMode { Off | Tone(f32) }` on `AfChain` — validated against the 51-entry CTCSS table at setter time.
- `AfChain::set_ctcss_mode` builds/drops the detector and force-enables the 300 Hz speaker HPF so the sub-audible tone doesn't reach the user's ears. `hp_enabled` is split into `hp_user_enabled` (user pref) + `effective_high_pass_enabled()` = `user || ctcss_active`, so toggling CTCSS never clobbers the user's explicit HPF setting — it re-takes effect exactly when CTCSS returns to `Off`.
- `AfChain::process` — detector tap (mono downmix, reused scratch buffer) runs **pre-HPF** so it sees the full 67–254 Hz band; output zeroing happens **post-notch** so the HPF/notch filter state stays consistent with the real signal and there's no desynced-state transient when the gate reopens.
- `RadioModule::set_ctcss_mode` plumbs through and caches the mode so `set_mode()` reapplies it after the AF chain rebuild. Sustained-gate state intentionally resets on mode switch.

## Tests

7 new tests in `af_chain.rs`:

1. CTCSS Off = passthrough unchanged
2. Non-table frequency rejected
3. Tone mode force-enables effective HPF (preserves user pref)
4. CTCSS Off restores user HPF preference exactly (both directions)
5. Wrong-tone mutes output to exactly 0.0
6. Correct tone opens gate after `CTCSS_MIN_HITS` windows, passes signal through
7. Mode change resets the sustained state

14 af_chain tests + 63 sdr-radio tests + full workspace pass. Triple-flavor clippy clean (whisper-cpu default, sherpa-cpu, sherpa-cuda). cargo fmt clean.

## Out of scope

- Per-bookmark UI + tone-frequency dropdown — PR 3
- Config/bookmark persistence — PR 3
- User-tunable threshold slider — PR 3 (uses `CTCSS_DEFAULT_THRESHOLD` for now)
- DCS (digital code squelch) — separate future PR, needs PLL + Golay decoder

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (whisper-cpu)
- [x] `cargo clippy --all-targets --workspace --no-default-features --features sherpa-cpu -- -D warnings` clean
- [x] `cargo clippy --all-targets --workspace --no-default-features --features sherpa-cuda -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual smoke test: UI wiring comes in PR 3, so runtime verification is "the radio module still builds, runs, and passes existing tests" — full end-to-end goes in PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CTCSS squelch mode with selectable tone frequencies.
  * Audio output is muted when the configured CTCSS tone is not detected.
  * High-pass filter now automatically enables when CTCSS tone mode is active.
  * Exposed controls to set/query CTCSS mode and to check whether the CTCSS detector currently reports sustained tone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->