### PR TITLE
feat(ctcss): per-bookmark UI + threshold slider (#269 PR 3/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,8 @@ dependencies = [
  "sdr-dsp",
  "sdr-pipeline",
  "sdr-types",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -205,6 +205,13 @@ struct DspState {
     /// event per transition instead of one per audio chunk. Initialized
     /// to `false` (matches `IfChain`'s initial closed state).
     squelch_was_open: bool,
+
+    /// Last observed CTCSS sustained-gate state, used to emit
+    /// `DspToUi::CtcssSustainedChanged` only on edges so the UI
+    /// status indicator can subscribe without the channel being
+    /// flooded at detector-window rate. Initialized to `false` to
+    /// match the detector's initial closed state.
+    ctcss_was_sustained: bool,
 }
 
 impl DspState {
@@ -256,6 +263,7 @@ impl DspState {
             iq_writer: None,
             transcription_tx: None,
             squelch_was_open: false,
+            ctcss_was_sustained: false,
         })
     }
 }
@@ -381,6 +389,10 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 if old_mode != mode {
                     state.transcription_tx = None;
                     state.squelch_was_open = false;
+                    // Mode switch rebuilds the AF chain + CTCSS
+                    // detector — edge tracker must match the new
+                    // closed state.
+                    state.ctcss_was_sustained = false;
                     let _ = dsp_tx.send(DspToUi::DemodModeChanged(mode));
                 }
             }
@@ -647,6 +659,22 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         UiToDsp::SetNotchFrequency(freq) => {
             tracing::debug!(freq, "set notch frequency");
             state.radio.set_notch_frequency(freq);
+        }
+
+        UiToDsp::SetCtcssMode(mode) => {
+            tracing::debug!(?mode, "set CTCSS mode");
+            if let Err(e) = state.radio.set_ctcss_mode(mode) {
+                tracing::warn!("CTCSS mode set failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("CTCSS mode failed: {e}")));
+            }
+        }
+
+        UiToDsp::SetCtcssThreshold(threshold) => {
+            tracing::debug!(threshold, "set CTCSS threshold");
+            if let Err(e) = state.radio.set_ctcss_threshold(threshold) {
+                tracing::warn!("CTCSS threshold set failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("CTCSS threshold failed: {e}")));
+            }
         }
 
         UiToDsp::SetAudioDevice(node_name) => {
@@ -1047,6 +1075,16 @@ fn process_iq_block(
                             let rms = (sum_sq / (2.0 * audio_count as f32)).sqrt();
                             let level_db = 20.0 * rms.max(f32::MIN_POSITIVE).log10();
                             let _ = dsp_tx.send(DspToUi::SignalLevel(level_db));
+                        }
+
+                        // Emit CTCSS sustained-gate edges for the UI
+                        // status indicator. Edge-triggered (not per
+                        // block) so the channel isn't flooded at
+                        // detector-window rate.
+                        let now_ctcss = state.radio.ctcss_sustained();
+                        if now_ctcss != state.ctcss_was_sustained {
+                            let _ = dsp_tx.send(DspToUi::CtcssSustainedChanged(now_ctcss));
+                            state.ctcss_was_sustained = now_ctcss;
                         }
 
                         // Send audio copy to transcription worker BEFORE volume

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -1,6 +1,6 @@
 //! Message types for communication between the DSP thread and the UI thread.
 
-use sdr_radio::DeemphasisMode;
+use sdr_radio::{DeemphasisMode, af_chain::CtcssMode};
 use sdr_types::DemodMode;
 
 /// Messages sent from the DSP pipeline thread to the UI main loop.
@@ -37,6 +37,11 @@ pub enum DspToUi {
     /// transcription session (band change = new session boundary) and
     /// to re-run Auto Break row visibility rules.
     DemodModeChanged(DemodMode),
+    /// CTCSS sustained-gate state changed. Emitted only on edges
+    /// (closed → open / open → closed), not per-window, so the UI
+    /// status indicator can subscribe without flooding the channel.
+    /// Always `false` when CTCSS is currently `Off`.
+    CtcssSustainedChanged(bool),
 }
 
 /// Available source types for IQ input.
@@ -109,6 +114,10 @@ pub enum UiToDsp {
     SetNotchEnabled(bool),
     /// Set the audio notch filter frequency in Hz.
     SetNotchFrequency(f32),
+    /// Set the CTCSS sub-audible tone squelch mode.
+    SetCtcssMode(CtcssMode),
+    /// Set the CTCSS detection threshold (normalized magnitude, `(0, 1]`).
+    SetCtcssThreshold(f32),
     /// Set the audio output device by `PipeWire` node name.
     SetAudioDevice(String),
     /// Switch the source type (stops current source if running).

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -192,6 +192,14 @@ mod tests {
     }
 
     #[test]
+    fn ctcss_sustained_changed_message_constructs() {
+        let open = DspToUi::CtcssSustainedChanged(true);
+        assert!(matches!(open, DspToUi::CtcssSustainedChanged(true)));
+        let closed = DspToUi::CtcssSustainedChanged(false);
+        assert!(matches!(closed, DspToUi::CtcssSustainedChanged(false)));
+    }
+
+    #[test]
     #[allow(clippy::too_many_lines)]
     fn test_ui_to_dsp_variants() {
         let start = UiToDsp::Start;
@@ -284,6 +292,20 @@ mod tests {
         let notch_freq = UiToDsp::SetNotchFrequency(60.0);
         assert!(
             matches!(notch_freq, UiToDsp::SetNotchFrequency(f) if (f - 60.0).abs() < f32::EPSILON)
+        );
+
+        let ctcss_off = UiToDsp::SetCtcssMode(CtcssMode::Off);
+        assert!(matches!(ctcss_off, UiToDsp::SetCtcssMode(CtcssMode::Off)));
+
+        let ctcss_tone = UiToDsp::SetCtcssMode(CtcssMode::Tone(100.0));
+        assert!(matches!(
+            ctcss_tone,
+            UiToDsp::SetCtcssMode(CtcssMode::Tone(hz)) if (hz - 100.0).abs() < f32::EPSILON
+        ));
+
+        let ctcss_thresh = UiToDsp::SetCtcssThreshold(0.15);
+        assert!(
+            matches!(ctcss_thresh, UiToDsp::SetCtcssThreshold(t) if (t - 0.15).abs() < f32::EPSILON)
         );
 
         let device = UiToDsp::SetAudioDevice("default".to_string());

--- a/crates/sdr-radio/Cargo.toml
+++ b/crates/sdr-radio/Cargo.toml
@@ -10,8 +10,12 @@ repository.workspace = true
 sdr-types.workspace = true
 sdr-dsp.workspace = true
 sdr-pipeline.workspace = true
+serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-radio/src/af_chain.rs
+++ b/crates/sdr-radio/src/af_chain.rs
@@ -5,7 +5,7 @@
 
 use sdr_dsp::filter::{DeemphasisFilter, NotchFilter};
 use sdr_dsp::multirate::RationalResampler;
-use sdr_dsp::tone_detect::{CtcssDetector, ctcss_tone_index};
+use sdr_dsp::tone_detect::{CTCSS_DEFAULT_THRESHOLD, CtcssDetector, ctcss_tone_index};
 use sdr_types::{Complex, DspError, Stereo};
 
 /// Default audio output sample rate (Hz).
@@ -33,7 +33,12 @@ const HIGH_PASS_CUTOFF_HZ: f64 = 300.0;
 ///    `sustained == false` (no tone confirmed yet, or tone has
 ///    dropped out for at least `CTCSS_MIN_HITS` consecutive
 ///    windows).
-#[derive(Debug, Clone, Copy, PartialEq)]
+///
+/// Serialized form: `{"kind":"off"}` or `{"kind":"tone","hz":100.0}`
+/// — a tagged representation so bookmark JSON is self-describing
+/// and round-trips cleanly through serde.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", content = "hz", rename_all = "lowercase")]
 pub enum CtcssMode {
     /// No CTCSS gating. Audio passes through unchanged.
     Off,
@@ -110,6 +115,13 @@ pub struct AfChain {
     /// detector runs on every block and the output is muted until
     /// the sustained gate opens.
     ctcss_mode: CtcssMode,
+    /// Current CTCSS detection threshold (0, 1]. Used whenever a
+    /// new detector is constructed — either from
+    /// [`Self::set_ctcss_mode`] or from [`Self::set_ctcss_threshold`]
+    /// (which rebuilds the active detector). Persists across
+    /// Off → Tone → Off cycles so a user-tuned value doesn't snap
+    /// back to default on mode switch.
+    ctcss_threshold: f32,
     /// CTCSS detector instance, constructed lazily from
     /// [`Self::set_ctcss_mode`] when the mode flips to `Tone(_)`.
     /// Dropped when the mode flips back to `Off`. The detector
@@ -171,6 +183,7 @@ impl AfChain {
             af_sample_rate,
             audio_sample_rate,
             ctcss_mode: CtcssMode::Off,
+            ctcss_threshold: CTCSS_DEFAULT_THRESHOLD,
             ctcss_detector: None,
             ctcss_mono_buf: Vec::new(),
             deemp_buf_l: Vec::new(),
@@ -308,13 +321,17 @@ impl AfChain {
                 // detector's internal rate-validation catches a
                 // misconfigured AF chain at setter time rather than
                 // silently running 19200-sample windows at the
-                // wrong duration. CtcssDetector::new enforces
-                // equality with CTCSS_SAMPLE_RATE_HZ within a
-                // 0.5 Hz tolerance and returns
+                // wrong duration. CtcssDetector::with_threshold
+                // enforces equality with CTCSS_SAMPLE_RATE_HZ within
+                // a 0.5 Hz tolerance and returns
                 // DspError::InvalidParameter on mismatch — that's
                 // exactly the contract we want here.
                 #[allow(clippy::cast_possible_truncation)]
-                let detector = CtcssDetector::new(hz, self.audio_sample_rate as f32)?;
+                let detector = CtcssDetector::with_threshold(
+                    hz,
+                    self.audio_sample_rate as f32,
+                    self.ctcss_threshold,
+                )?;
                 self.ctcss_mode = CtcssMode::Tone(hz);
                 self.ctcss_detector = Some(detector);
             }
@@ -335,6 +352,43 @@ impl AfChain {
         self.ctcss_detector
             .as_ref()
             .is_some_and(CtcssDetector::is_sustained)
+    }
+
+    /// Set the CTCSS detection threshold (normalized magnitude
+    /// ratio, must be in `(0, 1]`). The default value is
+    /// [`sdr_dsp::tone_detect::CTCSS_DEFAULT_THRESHOLD`] (0.1).
+    ///
+    /// If CTCSS is currently `Tone(_)`, the active detector is
+    /// rebuilt with the new threshold — this resets the hysteresis
+    /// run counters so the gate has to re-confirm at the new
+    /// threshold. If CTCSS is `Off`, the value is stored and
+    /// applied the next time [`Self::set_ctcss_mode`] enables a
+    /// tone.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DspError::InvalidParameter`] if `threshold` is
+    /// not finite or not in `(0, 1]` (matches
+    /// [`CtcssDetector::with_threshold`]'s contract).
+    pub fn set_ctcss_threshold(&mut self, threshold: f32) -> Result<(), DspError> {
+        if !threshold.is_finite() || threshold <= 0.0 || threshold > 1.0 {
+            return Err(DspError::InvalidParameter(format!(
+                "CTCSS threshold must be finite and in (0, 1], got {threshold}"
+            )));
+        }
+        self.ctcss_threshold = threshold;
+        if let CtcssMode::Tone(hz) = self.ctcss_mode {
+            #[allow(clippy::cast_possible_truncation)]
+            let detector =
+                CtcssDetector::with_threshold(hz, self.audio_sample_rate as f32, threshold)?;
+            self.ctcss_detector = Some(detector);
+        }
+        Ok(())
+    }
+
+    /// Returns the current CTCSS detection threshold.
+    pub fn ctcss_threshold(&self) -> f32 {
+        self.ctcss_threshold
     }
 
     /// Enable or disable the notch filter.
@@ -814,6 +868,66 @@ mod tests {
             any_nonzero,
             "open gate must pass some signal through (even after HPF)"
         );
+    }
+
+    #[test]
+    fn test_ctcss_mode_serde_round_trip() {
+        // Off → {"kind":"off"}
+        let off = CtcssMode::Off;
+        let json = serde_json::to_string(&off).unwrap();
+        assert_eq!(json, r#"{"kind":"off"}"#);
+        let back: CtcssMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, CtcssMode::Off);
+
+        // Tone(100.0) → {"kind":"tone","hz":100.0}
+        let tone = CtcssMode::Tone(100.0);
+        let json = serde_json::to_string(&tone).unwrap();
+        assert_eq!(json, r#"{"kind":"tone","hz":100.0}"#);
+        let back: CtcssMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, CtcssMode::Tone(100.0));
+    }
+
+    #[test]
+    fn test_ctcss_threshold_roundtrip_and_validation() {
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        // Default equals the DSP constant.
+        assert!(
+            (chain.ctcss_threshold() - sdr_dsp::tone_detect::CTCSS_DEFAULT_THRESHOLD).abs() < 1e-6
+        );
+
+        // Valid values are accepted and persist.
+        chain.set_ctcss_threshold(0.25).unwrap();
+        assert!((chain.ctcss_threshold() - 0.25).abs() < 1e-6);
+
+        // Out-of-range / non-finite values are rejected and the
+        // existing value is preserved.
+        assert!(chain.set_ctcss_threshold(0.0).is_err());
+        assert!(chain.set_ctcss_threshold(-0.1).is_err());
+        assert!(chain.set_ctcss_threshold(1.001).is_err());
+        assert!(chain.set_ctcss_threshold(f32::NAN).is_err());
+        assert!((chain.ctcss_threshold() - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_ctcss_threshold_persists_across_mode_and_rebuilds_detector() {
+        // Set a non-default threshold first, then enable a tone.
+        // The built detector must pick up the stored threshold
+        // rather than snapping back to CTCSS_DEFAULT_THRESHOLD.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain.set_ctcss_threshold(0.3).unwrap();
+        chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+
+        // And the reverse order: mode first, then threshold change
+        // should rebuild the active detector.
+        chain.set_ctcss_threshold(0.4).unwrap();
+        assert!((chain.ctcss_threshold() - 0.4).abs() < 1e-6);
+        // Sustained state must be reset after the rebuild.
+        assert!(!chain.ctcss_sustained());
+
+        // Going Off → Tone preserves the user-tuned threshold.
+        chain.set_ctcss_mode(CtcssMode::Off).unwrap();
+        chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+        assert!((chain.ctcss_threshold() - 0.4).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -685,4 +685,47 @@ mod tests {
         // The deemp mode is still Eu50 in the radio, and WFM allows it
         assert!(radio.af_chain().deemp_enabled());
     }
+
+    #[test]
+    fn test_radio_module_ctcss_threshold_persists_across_set_mode() {
+        // RadioModule caches ctcss_threshold and reapplies it to
+        // the new AF chain on mode switch. Without the persistence,
+        // a mode change would snap the threshold back to the
+        // DSP-layer default and silently un-tune the user's setting.
+        let mut radio = RadioModule::with_default_rate().unwrap();
+        radio.set_ctcss_threshold(0.25).unwrap();
+        assert!((radio.ctcss_threshold() - 0.25).abs() < 1e-6);
+        assert!((radio.af_chain().ctcss_threshold() - 0.25).abs() < 1e-6);
+
+        // Mode switch rebuilds the AF chain from scratch. The
+        // cached threshold must survive AND be reapplied to the
+        // new chain, not just stored on the RadioModule.
+        radio.set_mode(DemodMode::Nfm).unwrap();
+        assert!((radio.ctcss_threshold() - 0.25).abs() < 1e-6);
+        assert!((radio.af_chain().ctcss_threshold() - 0.25).abs() < 1e-6);
+
+        radio.set_mode(DemodMode::Am).unwrap();
+        assert!((radio.ctcss_threshold() - 0.25).abs() < 1e-6);
+        assert!((radio.af_chain().ctcss_threshold() - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_radio_module_ctcss_threshold_rejects_invalid() {
+        // Invalid values must fail fast at the RadioModule boundary
+        // (not deep in the DSP layer) and must NOT corrupt the
+        // cached value. The cached value on RadioModule is only
+        // advanced after the AF chain accepts the new value.
+        let mut radio = RadioModule::with_default_rate().unwrap();
+        radio.set_ctcss_threshold(0.2).unwrap();
+
+        assert!(radio.set_ctcss_threshold(0.0).is_err());
+        assert!(radio.set_ctcss_threshold(-0.1).is_err());
+        assert!(radio.set_ctcss_threshold(1.001).is_err());
+        assert!(radio.set_ctcss_threshold(f32::NAN).is_err());
+        assert!(radio.set_ctcss_threshold(f32::INFINITY).is_err());
+        assert!(radio.set_ctcss_threshold(f32::NEG_INFINITY).is_err());
+
+        // Cached value must still be the last successful one.
+        assert!((radio.ctcss_threshold() - 0.2).abs() < 1e-6);
+    }
 }

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -76,6 +76,9 @@ pub struct RadioModule {
     /// rebuilt from scratch, so the CTCSS state has to be restored
     /// the same way deemphasis / notch / high-pass are).
     ctcss_mode: CtcssMode,
+    /// Persisted CTCSS detection threshold, paired with
+    /// `ctcss_mode`. Same reapply-on-rebuild pattern.
+    ctcss_threshold: f32,
     audio_sample_rate: f64,
     /// Input sample rate from the IQ frontend (Hz).
     input_sample_rate: f64,
@@ -113,6 +116,7 @@ impl RadioModule {
             notch_enabled: false,
             notch_frequency: sdr_dsp::filter::DEFAULT_NOTCH_FREQ_HZ,
             ctcss_mode: CtcssMode::Off,
+            ctcss_threshold: sdr_dsp::tone_detect::CTCSS_DEFAULT_THRESHOLD,
             audio_sample_rate,
             input_sample_rate: 0.0,
             input_resampler: None,
@@ -178,13 +182,20 @@ impl RadioModule {
         // correct when the user re-enables after a mode switch.
         af_chain.set_notch_frequency(self.notch_frequency);
         af_chain.set_notch_enabled(self.notch_enabled);
-        // Restore CTCSS mode. The sustained-gate state intentionally
-        // resets to closed on mode switch — a new mode means the
-        // user retuned or changed decode, and holding an old
-        // "tone confirmed" latch across that transition would let
-        // stray audio through before the detector re-confirmed on
-        // the new signal. `set_ctcss_mode` rebuilds the detector
-        // from scratch so this is the natural behavior.
+        // Restore CTCSS threshold FIRST so the detector built by
+        // set_ctcss_mode picks it up instead of the default.
+        // Sustained-gate state intentionally resets to closed on
+        // mode switch — a new mode means the user retuned or
+        // changed decode, and holding an old "tone confirmed"
+        // latch across that transition would let stray audio
+        // through before the detector re-confirmed on the new
+        // signal. `set_ctcss_mode` rebuilds the detector from
+        // scratch so this is the natural behavior.
+        af_chain
+            .set_ctcss_threshold(self.ctcss_threshold)
+            .map_err(|e| {
+                RadioError::ModeSwitchFailed(format!("failed to set CTCSS threshold: {e}"))
+            })?;
         af_chain
             .set_ctcss_mode(self.ctcss_mode)
             .map_err(|e| RadioError::ModeSwitchFailed(format!("failed to set CTCSS mode: {e}")))?;
@@ -422,6 +433,26 @@ impl RadioModule {
     /// windows. Always `false` when CTCSS is `Off`.
     pub fn ctcss_sustained(&self) -> bool {
         self.af_chain.ctcss_sustained()
+    }
+
+    /// Set the CTCSS detection threshold (normalized magnitude
+    /// ratio, `(0, 1]`). Default is
+    /// [`sdr_dsp::tone_detect::CTCSS_DEFAULT_THRESHOLD`] (0.1).
+    /// Persists across mode changes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RadioError::Dsp`] if the value is non-finite or
+    /// out of range.
+    pub fn set_ctcss_threshold(&mut self, threshold: f32) -> Result<(), RadioError> {
+        self.af_chain.set_ctcss_threshold(threshold)?;
+        self.ctcss_threshold = threshold;
+        Ok(())
+    }
+
+    /// Returns the current CTCSS detection threshold.
+    pub fn ctcss_threshold(&self) -> f32 {
+        self.ctcss_threshold
     }
 
     /// Enable or disable WFM stereo decode.

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -500,6 +500,38 @@ mod tests {
     use super::*;
     use core::f32::consts::PI;
 
+    // ─── CTCSS threshold test fixtures ──────────────────────────
+    // Per project convention, test magic numbers (thresholds,
+    // tolerances, invalid-input lists) are named constants. These
+    // feed `test_radio_module_ctcss_threshold_*` — if the DSP
+    // layer's threshold range ever changes, there's one place to
+    // tune the test data.
+
+    /// Float tolerance for CTCSS threshold round-trip equality.
+    /// `1e-6` comfortably exceeds f32 rounding error for the
+    /// single-assignment round-trips the tests exercise.
+    const CTCSS_TEST_EPS: f32 = 1e-6;
+
+    /// Non-default value used by the persistence test. Chosen
+    /// strictly inside the DSP-layer `(0, 1]` range and clearly
+    /// different from the `CTCSS_DEFAULT_THRESHOLD` (0.1) so a
+    /// regression that silently reverts to the default fails
+    /// loudly.
+    const CTCSS_PERSIST_THRESHOLD: f32 = 0.25;
+
+    /// "Last-good" baseline used by the rejection test. Any
+    /// in-range value would work; 0.2 is distinct from both the
+    /// DSP default (0.1) and the persistence test's 0.25 so
+    /// cross-test contamination would be noticeable.
+    const CTCSS_LAST_GOOD_THRESHOLD: f32 = 0.2;
+
+    /// Values that `set_ctcss_threshold` must reject. Covers the
+    /// boundary cases (0.0, just over 1.0), a sub-zero, and all
+    /// three non-finite IEEE-754 values. Used by
+    /// `test_radio_module_ctcss_threshold_rejects_invalid`.
+    const INVALID_CTCSS_THRESHOLDS: [f32; 6] =
+        [0.0, -0.1, 1.001, f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
+
     #[test]
     fn test_radio_module_default_mode() {
         let radio = RadioModule::with_default_rate().unwrap();
@@ -693,20 +725,26 @@ mod tests {
         // a mode change would snap the threshold back to the
         // DSP-layer default and silently un-tune the user's setting.
         let mut radio = RadioModule::with_default_rate().unwrap();
-        radio.set_ctcss_threshold(0.25).unwrap();
-        assert!((radio.ctcss_threshold() - 0.25).abs() < 1e-6);
-        assert!((radio.af_chain().ctcss_threshold() - 0.25).abs() < 1e-6);
+        radio.set_ctcss_threshold(CTCSS_PERSIST_THRESHOLD).unwrap();
+        assert!((radio.ctcss_threshold() - CTCSS_PERSIST_THRESHOLD).abs() < CTCSS_TEST_EPS);
+        assert!(
+            (radio.af_chain().ctcss_threshold() - CTCSS_PERSIST_THRESHOLD).abs() < CTCSS_TEST_EPS
+        );
 
         // Mode switch rebuilds the AF chain from scratch. The
         // cached threshold must survive AND be reapplied to the
         // new chain, not just stored on the RadioModule.
         radio.set_mode(DemodMode::Nfm).unwrap();
-        assert!((radio.ctcss_threshold() - 0.25).abs() < 1e-6);
-        assert!((radio.af_chain().ctcss_threshold() - 0.25).abs() < 1e-6);
+        assert!((radio.ctcss_threshold() - CTCSS_PERSIST_THRESHOLD).abs() < CTCSS_TEST_EPS);
+        assert!(
+            (radio.af_chain().ctcss_threshold() - CTCSS_PERSIST_THRESHOLD).abs() < CTCSS_TEST_EPS
+        );
 
         radio.set_mode(DemodMode::Am).unwrap();
-        assert!((radio.ctcss_threshold() - 0.25).abs() < 1e-6);
-        assert!((radio.af_chain().ctcss_threshold() - 0.25).abs() < 1e-6);
+        assert!((radio.ctcss_threshold() - CTCSS_PERSIST_THRESHOLD).abs() < CTCSS_TEST_EPS);
+        assert!(
+            (radio.af_chain().ctcss_threshold() - CTCSS_PERSIST_THRESHOLD).abs() < CTCSS_TEST_EPS
+        );
     }
 
     #[test]
@@ -722,21 +760,15 @@ mod tests {
         // before the range check, or cache advancing before
         // validation) would slip past a cache-only assertion.
         let mut radio = RadioModule::with_default_rate().unwrap();
-        radio.set_ctcss_threshold(0.2).unwrap();
+        radio
+            .set_ctcss_threshold(CTCSS_LAST_GOOD_THRESHOLD)
+            .unwrap();
 
         // Match on the exact error variant (not just `is_err`) so
         // a future refactor can't mask the failure with a wrong
         // error type (e.g. accidentally promoting to
         // `RadioError::ModeSwitchFailed`).
-        let invalid = [
-            0.0_f32,
-            -0.1,
-            1.001,
-            f32::NAN,
-            f32::INFINITY,
-            f32::NEG_INFINITY,
-        ];
-        for v in invalid {
+        for v in INVALID_CTCSS_THRESHOLDS {
             assert!(
                 matches!(
                     radio.set_ctcss_threshold(v),
@@ -746,18 +778,19 @@ mod tests {
             );
             // After every single rejection, BOTH the cached value
             // and the AF chain's effective value must still be
-            // the last-good 0.2. Re-asserting inside the loop
+            // the last-good baseline. Re-asserting inside the loop
             // (not just after) catches a hypothetical bug where
             // the first rejected value corrupts one layer and
             // subsequent rejected values corrupt the other —
             // a post-loop assertion on the final state would
             // miss that.
             assert!(
-                (radio.ctcss_threshold() - 0.2).abs() < 1e-6,
+                (radio.ctcss_threshold() - CTCSS_LAST_GOOD_THRESHOLD).abs() < CTCSS_TEST_EPS,
                 "RadioModule cache drifted after rejected value {v}"
             );
             assert!(
-                (radio.af_chain().ctcss_threshold() - 0.2).abs() < 1e-6,
+                (radio.af_chain().ctcss_threshold() - CTCSS_LAST_GOOD_THRESHOLD).abs()
+                    < CTCSS_TEST_EPS,
                 "AF chain effective threshold drifted after rejected value {v}"
             );
         }

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -712,20 +712,54 @@ mod tests {
     #[test]
     fn test_radio_module_ctcss_threshold_rejects_invalid() {
         // Invalid values must fail fast at the RadioModule boundary
-        // (not deep in the DSP layer) and must NOT corrupt the
-        // cached value. The cached value on RadioModule is only
-        // advanced after the AF chain accepts the new value.
+        // (not deep in the DSP layer) and must NOT corrupt either
+        // the cached value OR the live AF-chain detector state.
+        // The RadioModule cache advances only after the AF chain
+        // accepts the new value, so a correctly-ordered setter
+        // leaves both in sync on rejection. Checking both levels
+        // pins that invariant — a regression that mutated one
+        // without the other (e.g. af_chain storing the bad value
+        // before the range check, or cache advancing before
+        // validation) would slip past a cache-only assertion.
         let mut radio = RadioModule::with_default_rate().unwrap();
         radio.set_ctcss_threshold(0.2).unwrap();
 
-        assert!(radio.set_ctcss_threshold(0.0).is_err());
-        assert!(radio.set_ctcss_threshold(-0.1).is_err());
-        assert!(radio.set_ctcss_threshold(1.001).is_err());
-        assert!(radio.set_ctcss_threshold(f32::NAN).is_err());
-        assert!(radio.set_ctcss_threshold(f32::INFINITY).is_err());
-        assert!(radio.set_ctcss_threshold(f32::NEG_INFINITY).is_err());
-
-        // Cached value must still be the last successful one.
-        assert!((radio.ctcss_threshold() - 0.2).abs() < 1e-6);
+        // Match on the exact error variant (not just `is_err`) so
+        // a future refactor can't mask the failure with a wrong
+        // error type (e.g. accidentally promoting to
+        // `RadioError::ModeSwitchFailed`).
+        let invalid = [
+            0.0_f32,
+            -0.1,
+            1.001,
+            f32::NAN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+        ];
+        for v in invalid {
+            assert!(
+                matches!(
+                    radio.set_ctcss_threshold(v),
+                    Err(RadioError::Dsp(DspError::InvalidParameter(_)))
+                ),
+                "threshold {v} should produce Err(RadioError::Dsp(DspError::InvalidParameter(_)))"
+            );
+            // After every single rejection, BOTH the cached value
+            // and the AF chain's effective value must still be
+            // the last-good 0.2. Re-asserting inside the loop
+            // (not just after) catches a hypothetical bug where
+            // the first rejected value corrupts one layer and
+            // subsequent rejected values corrupt the other —
+            // a post-loop assertion on the final state would
+            // miss that.
+            assert!(
+                (radio.ctcss_threshold() - 0.2).abs() < 1e-6,
+                "RadioModule cache drifted after rejected value {v}"
+            );
+            assert!(
+                (radio.af_chain().ctcss_threshold() - 0.2).abs() < 1e-6,
+                "AF chain effective threshold drifted after rejected value {v}"
+            );
+        }
     }
 }

--- a/crates/sdr-ui/src/radioreference/frequency_list.rs
+++ b/crates/sdr-ui/src/radioreference/frequency_list.rs
@@ -277,6 +277,8 @@ mod tests {
             high_pass: None,
             rr_category: None,
             rr_import_id: Some("42".to_string()),
+            ctcss_mode: None,
+            ctcss_threshold: None,
         };
 
         let freq = sample_freq("42", 999_999_999, "FM", "test");
@@ -304,6 +306,8 @@ mod tests {
             high_pass: None,
             rr_category: None,
             rr_import_id: None,
+            ctcss_mode: None,
+            ctcss_threshold: None,
         };
 
         let freq = sample_freq("99", 155_000_000, "FM", "test");
@@ -331,6 +335,8 @@ mod tests {
             high_pass: None,
             rr_category: None,
             rr_import_id: Some("10".to_string()),
+            ctcss_mode: None,
+            ctcss_threshold: None,
         };
 
         let freq = sample_freq("99", 155_000_000, "FM", "test");

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -105,6 +105,14 @@ pub struct TuningProfile {
     pub fm_if_nr: bool,
     pub wfm_stereo: bool,
     pub high_pass: Option<bool>,
+    /// CTCSS sub-audible tone squelch mode. `None` means "don't
+    /// touch the current setting on restore" — bookmarks saved
+    /// before PR 3 are all `None` after deserialization so they
+    /// preserve the user's current CTCSS setting when loaded.
+    pub ctcss_mode: Option<sdr_radio::af_chain::CtcssMode>,
+    /// CTCSS detection threshold (normalized magnitude, `(0, 1]`).
+    /// Same backward-compat semantics as `ctcss_mode`.
+    pub ctcss_threshold: Option<f32>,
 }
 
 /// A user-saved frequency bookmark with optional tuning profile fields.
@@ -150,6 +158,17 @@ pub struct Bookmark {
     /// `RadioReference` frequency ID for duplicate detection and future sync.
     #[serde(default)]
     pub rr_import_id: Option<String>,
+    /// CTCSS sub-audible tone squelch mode. Added in PR 3 of #269.
+    /// Serialized as the tagged form `{"kind":"off"}` or
+    /// `{"kind":"tone","hz":100.0}`. Pre-PR-3 bookmarks lack this
+    /// key and deserialize to `None`, which the restore path
+    /// interprets as "leave the current CTCSS setting alone".
+    #[serde(default)]
+    pub ctcss_mode: Option<sdr_radio::af_chain::CtcssMode>,
+    /// CTCSS detection threshold in `(0, 1]`. Same backward-compat
+    /// semantics as `ctcss_mode`.
+    #[serde(default)]
+    pub ctcss_threshold: Option<f32>,
 }
 
 impl Bookmark {
@@ -174,6 +193,8 @@ impl Bookmark {
             high_pass: None,
             rr_category: None,
             rr_import_id: None,
+            ctcss_mode: None,
+            ctcss_threshold: None,
         }
     }
 
@@ -204,6 +225,8 @@ impl Bookmark {
             high_pass: profile.high_pass,
             rr_category: None,
             rr_import_id: None,
+            ctcss_mode: profile.ctcss_mode,
+            ctcss_threshold: profile.ctcss_threshold,
         }
     }
 
@@ -717,6 +740,8 @@ mod tests {
             fm_if_nr: true,
             wfm_stereo: true,
             high_pass: Some(false),
+            ctcss_mode: Some(sdr_radio::af_chain::CtcssMode::Tone(100.0)),
+            ctcss_threshold: Some(0.15),
         };
         let bm = Bookmark::with_profile("Full", 98_100_000, DemodMode::Wfm, 150_000.0, &profile);
         let json = serde_json::to_string(&bm).unwrap();
@@ -733,6 +758,24 @@ mod tests {
         assert_eq!(back.fm_if_nr, Some(true));
         assert_eq!(back.wfm_stereo, Some(true));
         assert_eq!(back.high_pass, Some(false));
+        assert_eq!(
+            back.ctcss_mode,
+            Some(sdr_radio::af_chain::CtcssMode::Tone(100.0))
+        );
+        assert_eq!(back.ctcss_threshold, Some(0.15));
+    }
+
+    #[test]
+    fn bookmark_backward_compat_ctcss_none() {
+        // Old bookmark JSON (pre-PR-3) has neither ctcss_mode nor
+        // ctcss_threshold. Deserialization must yield None for
+        // both, which restore_bookmark_profile interprets as
+        // "leave the current CTCSS setting alone."
+        let old_json =
+            r#"{"name":"Legacy","frequency":162550000,"demod_mode":"NFM","bandwidth":12500.0}"#;
+        let bm: Bookmark = serde_json::from_str(old_json).unwrap();
+        assert!(bm.ctcss_mode.is_none());
+        assert!(bm.ctcss_threshold.is_none());
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -2,6 +2,8 @@
 
 use libadwaita as adw;
 use libadwaita::prelude::*;
+use sdr_dsp::tone_detect::{CTCSS_DEFAULT_THRESHOLD, CTCSS_TONES_HZ};
+use sdr_radio::af_chain::CtcssMode;
 
 /// Default bandwidth in Hz.
 const DEFAULT_BANDWIDTH_HZ: f64 = 12_500.0;
@@ -35,6 +37,20 @@ const MAX_NB_LEVEL: f64 = 20.0;
 const NB_LEVEL_STEP: f64 = 0.5;
 /// Noise blanker page increment.
 const NB_LEVEL_PAGE: f64 = 1.0;
+
+/// Default CTCSS detection threshold (matches
+/// [`sdr_dsp::tone_detect::CTCSS_DEFAULT_THRESHOLD`] = 0.1).
+const DEFAULT_CTCSS_THRESHOLD: f64 = 0.1;
+/// Minimum CTCSS threshold.
+const MIN_CTCSS_THRESHOLD: f64 = 0.05;
+/// Maximum CTCSS threshold — the DSP layer accepts up to 1.0 but
+/// anything above ~0.5 is effectively unreachable for real tones,
+/// so we cap the slider at 0.5 to keep the useful range legible.
+const MAX_CTCSS_THRESHOLD: f64 = 0.5;
+/// Step for keyboard increment / page-down.
+const CTCSS_THRESHOLD_STEP: f64 = 0.01;
+/// Page step (scroll / page-down).
+const CTCSS_THRESHOLD_PAGE: f64 = 0.05;
 
 /// Default squelch level in dB.
 const DEFAULT_SQUELCH_DB: f64 = -100.0;
@@ -74,6 +90,20 @@ pub struct RadioPanel {
     pub notch_enabled_row: adw::SwitchRow,
     /// Notch filter frequency control.
     pub notch_freq_row: adw::SpinRow,
+    /// CTCSS tone squelch selector. Entry 0 is "Off"; entries
+    /// 1..=51 map directly to [`CTCSS_TONES_HZ`] one-to-one.
+    /// Visible only when the demod mode is NFM — CTCSS is a
+    /// sub-audible tone-squelch feature used exclusively on
+    /// narrowband FM in practice.
+    pub ctcss_row: adw::ComboRow,
+    /// CTCSS detection threshold (`(0, 1]` normalized magnitude).
+    /// Visible alongside `ctcss_row`.
+    pub ctcss_threshold_row: adw::SpinRow,
+    /// Read-only status indicator row that shows whether the
+    /// detector's sustained gate is currently open. Updated from
+    /// `DspToUi::CtcssSustainedChanged` messages via
+    /// [`Self::set_ctcss_sustained`].
+    pub ctcss_status_row: adw::ActionRow,
 }
 
 impl RadioPanel {
@@ -87,6 +117,94 @@ impl RadioPanel {
         self.fm_if_nr_row.set_visible(is_fm);
         self.stereo_row
             .set_visible(mode == sdr_types::DemodMode::Wfm);
+        // CTCSS is an NFM-only feature — WFM / AM / SSB / CW
+        // either don't carry sub-audible tones or don't use them
+        // as a squelch keying mechanism in practice.
+        let ctcss_allowed = mode == sdr_types::DemodMode::Nfm;
+        self.ctcss_row.set_visible(ctcss_allowed);
+        self.ctcss_threshold_row.set_visible(ctcss_allowed);
+        self.ctcss_status_row.set_visible(ctcss_allowed);
+
+        // Leaving NFM must force the combo back to "Off" (index 0).
+        // Without this, switching from NFM-with-a-tone to WFM would
+        // hide the combo row while the AF chain continues to gate
+        // the speaker path on the now-inapplicable detector — the
+        // user sees "no audio" with no way to clear the state
+        // because the control is hidden. Setting the combo to 0
+        // fires the `selected-notify` signal wired in
+        // `connect_radio_panel`, which sends `SetCtcssMode(Off)`
+        // through to the DSP controller. GTK only emits the signal
+        // on actual value change, so this is a no-op when CTCSS
+        // was already Off.
+        if !ctcss_allowed {
+            self.ctcss_row.set_selected(0);
+        }
+    }
+
+    /// Convert a combo-row selection index to a
+    /// [`CtcssMode`]. Index 0 is `Off`; indices `1..=51` map to
+    /// [`CTCSS_TONES_HZ`] entries. Out-of-range indices
+    /// (shouldn't happen with the fixed 52-entry model) fall back
+    /// to `Off`.
+    #[must_use]
+    pub fn ctcss_mode_from_index(index: u32) -> CtcssMode {
+        if index == 0 {
+            CtcssMode::Off
+        } else if let Some(&hz) = CTCSS_TONES_HZ.get((index - 1) as usize) {
+            CtcssMode::Tone(hz)
+        } else {
+            CtcssMode::Off
+        }
+    }
+
+    /// Convert a [`CtcssMode`] back to a combo-row index. Used by
+    /// the bookmark-restore path. `Tone(_)` with a non-table
+    /// frequency (shouldn't happen, but serde lets anyone build
+    /// the enum) falls back to `Off` (index 0).
+    #[must_use]
+    pub fn ctcss_index_from_mode(mode: CtcssMode) -> u32 {
+        match mode {
+            CtcssMode::Off => 0,
+            CtcssMode::Tone(hz) => CTCSS_TONES_HZ
+                .iter()
+                .position(|&t| (t - hz).abs() < 0.01)
+                .and_then(|i| u32::try_from(i + 1).ok())
+                .unwrap_or(0),
+        }
+    }
+
+    /// Update the CTCSS status row subtitle from the current
+    /// combo selection and an explicit sustained-gate hint.
+    ///
+    /// Three states — in priority order:
+    ///
+    /// 1. **CTCSS combo is "Off"** → `"Off"` regardless of
+    ///    `sustained`. This is load-bearing: the detector can
+    ///    emit a `CtcssSustainedChanged(false)` edge when the
+    ///    mode flips from `Tone` back to `Off` (because the
+    ///    previous state was `true`), and the handler for that
+    ///    edge calls right back into this method. Without the
+    ///    Off-first guard we'd overwrite "Off" with
+    ///    "Waiting for tone" and mislead the user into thinking
+    ///    the detector is still running.
+    /// 2. **Combo names a tone and `sustained == true`** →
+    ///    `"Tone detected — gate open"`.
+    /// 3. **Combo names a tone and `sustained == false`** →
+    ///    `"Waiting for tone"`.
+    ///
+    /// Called from both the combo-change handler (with
+    /// `sustained = false` — mode switches reset the detector)
+    /// and the `DspToUi::CtcssSustainedChanged` edge handler
+    /// (with the actual bool from the message).
+    pub fn set_ctcss_sustained(&self, sustained: bool) {
+        let text = if self.ctcss_row.selected() == 0 {
+            "Off"
+        } else if sustained {
+            "Tone detected — gate open"
+        } else {
+            "Waiting for tone"
+        };
+        self.ctcss_status_row.set_subtitle(text);
     }
 }
 
@@ -199,6 +317,54 @@ pub fn build_radio_panel() -> RadioPanel {
         .digits(0)
         .build();
 
+    // --- CTCSS tone squelch ---
+    // Build the combo model with "Off" followed by the 51 CTCSS
+    // tones. Each tone is labelled to one decimal place (matching
+    // the hardware convention — e.g. "100.0 Hz", "151.4 Hz").
+    let mut ctcss_labels: Vec<String> = Vec::with_capacity(CTCSS_TONES_HZ.len() + 1);
+    ctcss_labels.push("Off".to_string());
+    for &tone in CTCSS_TONES_HZ {
+        ctcss_labels.push(format!("{tone:.1} Hz"));
+    }
+    let ctcss_label_refs: Vec<&str> = ctcss_labels.iter().map(String::as_str).collect();
+    let ctcss_model = gtk4::StringList::new(&ctcss_label_refs);
+    let ctcss_row = adw::ComboRow::builder()
+        .title("CTCSS Tone Squelch")
+        .subtitle("Sub-audible tone required to open squelch")
+        .model(&ctcss_model)
+        .visible(false) // NFM-only; startup mode sets it
+        .build();
+
+    let ctcss_threshold_adj = gtk4::Adjustment::new(
+        DEFAULT_CTCSS_THRESHOLD,
+        MIN_CTCSS_THRESHOLD,
+        MAX_CTCSS_THRESHOLD,
+        CTCSS_THRESHOLD_STEP,
+        CTCSS_THRESHOLD_PAGE,
+        0.0,
+    );
+    let ctcss_threshold_row = adw::SpinRow::builder()
+        .title("CTCSS Threshold")
+        .subtitle("Higher = more conservative (fewer false triggers)")
+        .adjustment(&ctcss_threshold_adj)
+        .digits(2)
+        .visible(false)
+        .build();
+    // Debug assert the default matches the DSP layer at startup —
+    // a future bump to CTCSS_DEFAULT_THRESHOLD should be
+    // accompanied by a bump to DEFAULT_CTCSS_THRESHOLD so the
+    // slider and the detector agree on the un-tuned default.
+    debug_assert!(
+        (DEFAULT_CTCSS_THRESHOLD - f64::from(CTCSS_DEFAULT_THRESHOLD)).abs() < 1e-6,
+        "UI default CTCSS threshold diverged from DSP default"
+    );
+
+    let ctcss_status_row = adw::ActionRow::builder()
+        .title("CTCSS Status")
+        .subtitle("Off")
+        .visible(false)
+        .build();
+
     group.add(&bandwidth_row);
     group.add(&squelch_enabled_row);
     group.add(&squelch_level_row);
@@ -210,6 +376,9 @@ pub fn build_radio_panel() -> RadioPanel {
     group.add(&stereo_row);
     group.add(&notch_enabled_row);
     group.add(&notch_freq_row);
+    group.add(&ctcss_row);
+    group.add(&ctcss_threshold_row);
+    group.add(&ctcss_status_row);
 
     // All rows connected to DSP pipeline via window.rs
 
@@ -226,6 +395,9 @@ pub fn build_radio_panel() -> RadioPanel {
         stereo_row,
         notch_enabled_row,
         notch_freq_row,
+        ctcss_row,
+        ctcss_threshold_row,
+        ctcss_status_row,
     }
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -317,6 +317,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let gain_row_for_dsp = panels.source.gain_row.clone();
     let record_audio_for_dsp = panels.audio.record_audio_row.clone();
     let record_iq_for_dsp = panels.source.record_iq_row.clone();
+    let radio_panel_for_dsp = panels.radio.clone();
     let transcription_enable_for_dsp = transcript_panel.enable_row.clone();
     #[cfg(feature = "sherpa")]
     let auto_break_row_for_dsp = transcript_panel.auto_break_row.clone();
@@ -369,6 +370,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                         &gain_row_for_dsp,
                         &record_audio_for_dsp,
                         &record_iq_for_dsp,
+                        &radio_panel_for_dsp,
                         &transcription_enable_for_dsp,
                         #[cfg(feature = "sherpa")]
                         &auto_break_row_for_dsp,
@@ -407,6 +409,7 @@ fn handle_dsp_message(
     gain_row: &adw::SpinRow,
     record_audio_row: &adw::SwitchRow,
     record_iq_row: &adw::SwitchRow,
+    radio_panel: &sidebar::radio_panel::RadioPanel,
     transcription_enable_row: &adw::SwitchRow,
     #[cfg(feature = "sherpa")] auto_break_row: &adw::SwitchRow,
     #[cfg(feature = "sherpa")] auto_break_min_open_row: &adw::SpinRow,
@@ -550,6 +553,10 @@ fn handle_dsp_message(
                     overlay.add_toast(toast);
                 }
             }
+        }
+        DspToUi::CtcssSustainedChanged(sustained) => {
+            tracing::debug!(sustained, "CTCSS sustained-gate edge");
+            radio_panel.set_ctcss_sustained(sustained);
         }
     }
 }
@@ -1096,6 +1103,31 @@ fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             #[allow(clippy::cast_possible_truncation)]
             state_notch_freq.send_dsp(UiToDsp::SetNotchFrequency(row.value() as f32));
         });
+
+    // CTCSS tone selector
+    let state_ctcss = Rc::clone(state);
+    let radio_for_ctcss = panels.radio.clone();
+    panels.radio.ctcss_row.connect_selected_notify(move |row| {
+        let mode = sidebar::radio_panel::RadioPanel::ctcss_mode_from_index(row.selected());
+        state_ctcss.send_dsp(UiToDsp::SetCtcssMode(mode));
+        // Push the status row label immediately — the detector
+        // only emits `CtcssSustainedChanged` on actual gate
+        // edges, so without this the label would lag behind a
+        // mode change (stay on "Tone detected" after flipping to
+        // Off, or stay on "Off" after picking a tone until the
+        // first detector window confirms).
+        radio_for_ctcss.set_ctcss_sustained(false);
+    });
+
+    // CTCSS detection threshold
+    let state_ctcss_thresh = Rc::clone(state);
+    panels
+        .radio
+        .ctcss_threshold_row
+        .connect_value_notify(move |row| {
+            #[allow(clippy::cast_possible_truncation)]
+            state_ctcss_thresh.send_dsp(UiToDsp::SetCtcssThreshold(row.value() as f32));
+        });
 }
 
 /// FFT window function options matching the display panel combo.
@@ -1311,6 +1343,22 @@ fn restore_bookmark_profile(
     if let Some(hp) = bookmark.high_pass {
         state.send_dsp(UiToDsp::SetHighPass(hp));
     }
+    // Restore CTCSS threshold BEFORE mode so the detector the
+    // mode setter builds picks up the saved value instead of
+    // defaulting. Mirrors the RadioModule::set_mode order.
+    if let Some(threshold) = bookmark.ctcss_threshold {
+        state.send_dsp(UiToDsp::SetCtcssThreshold(threshold));
+        #[allow(clippy::cast_lossless)]
+        radio.ctcss_threshold_row.set_value(threshold as f64);
+    }
+    if let Some(mode) = bookmark.ctcss_mode {
+        state.send_dsp(UiToDsp::SetCtcssMode(mode));
+        radio
+            .ctcss_row
+            .set_selected(sidebar::radio_panel::RadioPanel::ctcss_index_from_mode(
+                mode,
+            ));
+    }
 }
 
 /// Connect navigation panel (band presets + bookmarks) to DSP commands.
@@ -1429,6 +1477,10 @@ fn connect_navigation_panel(
             fm_if_nr: radio_bm.fm_if_nr_row.is_active(),
             wfm_stereo: radio_bm.stereo_row.is_active(),
             high_pass: None, // No UI widget yet — don't persist.
+            ctcss_mode: Some(sidebar::radio_panel::RadioPanel::ctcss_mode_from_index(
+                radio_bm.ctcss_row.selected(),
+            )),
+            ctcss_threshold: Some(radio_bm.ctcss_threshold_row.value() as f32),
         };
         let bookmark =
             sidebar::navigation_panel::Bookmark::with_profile(&name, freq_u64, mode, bw, &profile);
@@ -1464,6 +1516,8 @@ fn connect_navigation_panel(
     let save_radio_nben_lvl = panels.radio.nb_level_row.clone();
     let save_radio_nr = panels.radio.fm_if_nr_row.clone();
     let save_radio_stereo = panels.radio.stereo_row.clone();
+    let save_radio_ctcss = panels.radio.ctcss_row.clone();
+    let save_radio_ctcss_threshold = panels.radio.ctcss_threshold_row.clone();
     let save_source_gain = panels.source.gain_row.clone();
     let save_source_agc = panels.source.agc_row.clone();
     nav.connect_save(move || {
@@ -1491,6 +1545,11 @@ fn connect_navigation_panel(
             fm_if_nr: save_radio_nr.is_active(),
             wfm_stereo: save_radio_stereo.is_active(),
             high_pass: None,
+            ctcss_mode: Some(sidebar::radio_panel::RadioPanel::ctcss_mode_from_index(
+                save_radio_ctcss.selected(),
+            )),
+            #[allow(clippy::cast_possible_truncation)]
+            ctcss_threshold: Some(save_radio_ctcss_threshold.value() as f32),
         };
         // Find and update the active bookmark in the list.
         let mut bms = save_bm_rc.borrow_mut();
@@ -1513,6 +1572,8 @@ fn connect_navigation_panel(
             bm.fm_if_nr = Some(profile.fm_if_nr);
             bm.wfm_stereo = Some(profile.wfm_stereo);
             bm.high_pass = profile.high_pass;
+            bm.ctcss_mode = profile.ctcss_mode;
+            bm.ctcss_threshold = profile.ctcss_threshold;
             // Keep ActiveBookmark in sync with the updated frequency.
             *save_active.borrow_mut() = sidebar::navigation_panel::ActiveBookmark {
                 name: active.name.clone(),


### PR DESCRIPTION
## Summary

Third and final PR for issue #269 (CTCSS sub-audible tone squelch). PR 1 (#285) shipped the pure-DSP Goertzel detector; PR 2 (#286) wired it into `af_chain` with a speaker-path HPF override and mode-switch persistence. This PR adds the user-facing controls, threshold slider, and bookmark round-trip.

- **CtcssMode serde** — `#[serde(tag = "kind", content = "hz")]` produces clean tagged JSON (`{"kind":"tone","hz":100.0}`).
- **Threshold backend** — new `AfChain::set_ctcss_threshold` / `RadioModule::set_ctcss_threshold` that rebuild the active detector and persist across mode switches. Threshold is applied BEFORE mode on the `set_mode` rebuild path so the constructed detector picks up the stored value.
- **Messages** — `UiToDsp::SetCtcssMode`, `UiToDsp::SetCtcssThreshold`, `DspToUi::CtcssSustainedChanged(bool)` (edge-triggered, only emitted on sustained-gate transitions).
- **RadioPanel UI** — three NFM-only rows: tone combo (Off + 51 tones), threshold spinner (0.05–0.50, default 0.10), read-only status row with three states (Off / Waiting / Detected).
- **State-leak fix** — leaving NFM force-clears the combo to Off so a user who enabled CTCSS on NFM can't end up stuck with muted audio and hidden controls after switching to WFM.
- **Bookmark schema** — `ctcss_mode` and `ctcss_threshold` as `Option<_>` with `#[serde(default)]`. Pre-PR-3 bookmarks deserialize to `None` which restore interprets as "leave current CTCSS alone".

## Out of scope / future

- DCS (digital code squelch) — separate future PR, needs PLL + Golay decoder.
- Auto-detect mode (scan all 51 tones) — not implemented; user picks the tone manually.
- Tone encode / TX — SDR is RX-only for now.

## Test plan

- [x] \`cargo test --workspace\` — 38 test suites pass, 0 failures
- [x] Triple-flavor clippy clean (whisper-cuda default, sherpa-cpu, sherpa-cuda)
- [x] \`cargo fmt --all -- --check\` clean
- [x] **Manual smoke test on whisper-cuda:**
  - [x] Visibility gating (CTCSS rows appear on NFM, hide on WFM/AM/SSB/CW)
  - [x] Combo selection — audio gates on tone mismatch, opens on match
  - [x] Status row label transitions: Off → Waiting → Detected
  - [x] Threshold slider — dragging changes detector sensitivity live
  - [x] Bookmark round-trip — save with CTCSS set, switch to Off, reload bookmark → CTCSS reapplies; app restart preserves it
  - [x] Pre-PR-3 bookmark backward compat — loads without touching current CTCSS
  - [x] Mode-switch state leak fix — NFM-with-tone → WFM returns audio; switching back to NFM leaves combo at Off
  - [x] HPF interaction — user HPF preference survives CTCSS engage/disengage cycles

Closes #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full CTCSS (tone squelch) support in NFM: select from 52 tones, adjust detection threshold, and view sustained-gate status in the radio panel.
  * CTCSS mode and threshold are saved to and restored with bookmarks; UI applies threshold before mode on restore.

* **Bug Fixes**
  * Gate status updates are edge-triggered to avoid redundant notifications.
  * Threshold inputs are validated; invalid updates are rejected and reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->