### PR TITLE
feat(transcription): audio enhancement mode selector (partial #281)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/sdr-transcription/src/backend.rs
+++ b/crates/sdr-transcription/src/backend.rs
@@ -130,6 +130,19 @@ pub struct BackendConfig {
     /// `AUTO_BREAK_MIN_SEGMENT_MS_MIN..=AUTO_BREAK_MIN_SEGMENT_MS_MAX`.
     /// Only read when `segmentation_mode == AutoBreak`.
     pub auto_break_min_segment_ms: u32,
+    /// Audio enhancement mode applied to the mono buffer before it
+    /// reaches the recognizer. Shared across all recognizer paths
+    /// (sherpa offline VAD, sherpa offline Auto Break, sherpa
+    /// streaming, whisper) — every call site routes through
+    /// [`crate::denoise::apply`] with this value.
+    ///
+    /// Default [`AudioEnhancement::VoiceBand`] matches the behavior
+    /// shipped in PR #282 (voice-prior weighted spectral gate).
+    /// Users can switch to [`AudioEnhancement::Broadband`] to work
+    /// around #281 (Moonshine returning empty text on voice-band
+    /// preprocessed NFM audio) or to [`AudioEnhancement::Off`] for
+    /// troubleshooting / pristine source material.
+    pub audio_enhancement: crate::denoise::AudioEnhancement,
 }
 
 /// User-facing model selection.

--- a/crates/sdr-transcription/src/backends/mock.rs
+++ b/crates/sdr-transcription/src/backends/mock.rs
@@ -105,6 +105,7 @@ mod tests {
             auto_break_min_open_ms: crate::AUTO_BREAK_MIN_OPEN_MS_DEFAULT,
             auto_break_tail_ms: crate::AUTO_BREAK_TAIL_MS_DEFAULT,
             auto_break_min_segment_ms: crate::AUTO_BREAK_MIN_SEGMENT_MS_DEFAULT,
+            audio_enhancement: crate::denoise::AudioEnhancement::default(),
         }
     }
 

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -142,6 +142,13 @@ pub(super) struct SessionParams {
     /// Auto Break timing parameters, read by `run_session_auto_break`.
     /// Ignored in VAD mode and by the streaming path.
     pub auto_break_thresholds: AutoBreakThresholds,
+    /// Audio enhancement mode applied to the mono buffer before
+    /// the recognizer sees it. Read once per session by the I/O
+    /// thread — changing the user's selection takes effect at the
+    /// next session start. See [`crate::denoise::AudioEnhancement`]
+    /// for the three modes and issue #281 for the motivating
+    /// Moonshine-specific workaround.
+    pub audio_enhancement: crate::denoise::AudioEnhancement,
 }
 
 /// Auto Break timing parameters consumed by the state machine in

--- a/crates/sdr-transcription/src/backends/sherpa/mod.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/mod.rs
@@ -150,6 +150,7 @@ impl TranscriptionBackend for SherpaBackend {
                     .auto_break_min_segment_ms
                     .clamp(AUTO_BREAK_MIN_SEGMENT_MS_MIN, AUTO_BREAK_MIN_SEGMENT_MS_MAX),
             },
+            audio_enhancement: config.audio_enhancement,
         })?;
 
         tracing::info!("sherpa backend session requested");

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -518,7 +518,17 @@ fn decode_segment(
 
     if !text.is_empty() {
         let timestamp = crate::util::wall_clock_timestamp();
-        tracing::debug!(%timestamp, %text, "offline recognizer committed utterance");
+        // Log metadata only — the raw transcript stays inside the
+        // recognizer process boundary until the UI renders it. This
+        // matches the established privacy contract for partials and
+        // finals across the crate: we count characters for observability
+        // but never write user speech to a log file that could be
+        // collected by a `RUST_LOG=debug` run.
+        tracing::debug!(
+            %timestamp,
+            text_chars = text.chars().count(),
+            "offline recognizer committed utterance"
+        );
         let _ = event_tx.send(TranscriptionEvent::Text { timestamp, text });
     }
 }

--- a/crates/sdr-transcription/src/backends/sherpa/offline.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/offline.rs
@@ -309,6 +309,7 @@ fn run_session_vad(recognizer: &OfflineRecognizer, params: SessionParams) {
         vad_threshold,
         segmentation_mode: _,
         auto_break_thresholds: _,
+        audio_enhancement,
     } = params;
 
     let (decode_tx, decode_rx) = mpsc::channel::<DecodeRequest>();
@@ -328,6 +329,7 @@ fn run_session_vad(recognizer: &OfflineRecognizer, params: SessionParams) {
                 decode_tx,
                 noise_gate_ratio,
                 vad_threshold,
+                audio_enhancement,
             });
         });
     let io_thread = match io_thread {
@@ -362,6 +364,7 @@ struct SessionIoVadParams {
     decode_tx: mpsc::Sender<DecodeRequest>,
     noise_gate_ratio: f32,
     vad_threshold: f32,
+    audio_enhancement: denoise::AudioEnhancement,
 }
 
 /// Session I/O loop for VAD segmentation. Runs on the spawned I/O
@@ -376,6 +379,7 @@ fn session_io_loop_vad(params: SessionIoVadParams) {
         decode_tx,
         noise_gate_ratio,
         vad_threshold,
+        audio_enhancement,
     } = params;
 
     // Build Silero on this thread. `SherpaSileroVad` holds an onnxruntime
@@ -432,7 +436,7 @@ fn session_io_loop_vad(params: SessionIoVadParams) {
             continue;
         }
 
-        denoise::enhance_speech(&mut mono_buf, noise_gate_ratio);
+        denoise::apply(&mut mono_buf, audio_enhancement, noise_gate_ratio);
 
         vad.accept(&mono_buf);
 
@@ -459,21 +463,62 @@ fn session_io_loop_vad(params: SessionIoVadParams) {
 /// Batch-decode a single speech segment and emit a `Text` event if
 /// the recognizer produced any text. Called by [`decoder_service_loop`]
 /// on the sherpa-host thread — never on the session I/O thread.
+///
+/// Diagnostic tracing added for issue #281 (Moonshine produces no text
+/// while Parakeet produces correct text on the same audio). When run
+/// with `RUST_LOG=sdr_transcription=debug`, every decode call emits a
+/// `decode_segment` log event showing:
+///
+/// - `segment_len` — samples at 16 kHz mono, confirms the I/O thread is
+///   actually forwarding segments to the decoder
+/// - `got_result` — whether `stream.get_result()` returned `Some`
+///   (recognizer produced an output object at all)
+/// - `raw_text_len` — character count of the recognizer's text BEFORE
+///   trim, so we can distinguish between "sherpa returned nothing" and
+///   "sherpa returned whitespace-only output that trim wipes"
+/// - `trimmed_text_len` — post-trim length, the one that actually drives
+///   the `TranscriptionEvent::Text` emission
+///
+/// Once the root cause is nailed down the tracing will be downgraded or
+/// removed — this is an investigation scaffold, not a permanent
+/// observability layer.
 fn decode_segment(
     recognizer: &OfflineRecognizer,
     segment: &[f32],
     event_tx: &mpsc::Sender<TranscriptionEvent>,
 ) {
+    let segment_len = segment.len();
     let stream = recognizer.create_stream();
     stream.accept_waveform(SHERPA_SAMPLE_RATE_HZ, segment);
     recognizer.decode(&stream);
-    let Some(result) = stream.get_result() else {
+
+    let result = stream.get_result();
+    let got_result = result.is_some();
+    let Some(result) = result else {
+        tracing::debug!(
+            segment_len,
+            got_result = false,
+            "decode_segment: recognizer returned None"
+        );
         return;
     };
-    let text = result.text.trim().to_owned();
+
+    let raw_text = result.text;
+    let raw_text_len = raw_text.len();
+    let text = raw_text.trim().to_owned();
+    let trimmed_text_len = text.len();
+
+    tracing::debug!(
+        segment_len,
+        got_result,
+        raw_text_len,
+        trimmed_text_len,
+        "decode_segment: recognizer returned result"
+    );
+
     if !text.is_empty() {
         let timestamp = crate::util::wall_clock_timestamp();
-        tracing::debug!(%timestamp, %text, "moonshine committed utterance");
+        tracing::debug!(%timestamp, %text, "offline recognizer committed utterance");
         let _ = event_tx.send(TranscriptionEvent::Text { timestamp, text });
     }
 }
@@ -699,6 +744,7 @@ fn run_session_auto_break(recognizer: &OfflineRecognizer, params: SessionParams)
         vad_threshold: _,
         segmentation_mode: _,
         auto_break_thresholds,
+        audio_enhancement,
     } = params;
 
     let (decode_tx, decode_rx) = mpsc::channel::<DecodeRequest>();
@@ -715,6 +761,7 @@ fn run_session_auto_break(recognizer: &OfflineRecognizer, params: SessionParams)
                 decode_tx,
                 noise_gate_ratio,
                 auto_break_thresholds,
+                audio_enhancement,
             });
         });
     let io_thread = match io_thread {
@@ -743,12 +790,14 @@ struct SessionIoAutoBreakParams {
     decode_tx: mpsc::Sender<DecodeRequest>,
     noise_gate_ratio: f32,
     auto_break_thresholds: super::host::AutoBreakThresholds,
+    audio_enhancement: denoise::AudioEnhancement,
 }
 
 /// Session I/O loop for Auto Break segmentation. Runs on the spawned
 /// I/O thread — drives an `AutoBreakMachine` from the audio channel and
 /// forwards flushed segments to `decode_tx` (resampled + denoised
 /// before the send so the decoder thread stays zero-prep).
+#[allow(clippy::too_many_lines)]
 fn session_io_loop_auto_break(params: SessionIoAutoBreakParams) {
     let SessionIoAutoBreakParams {
         cancel,
@@ -757,6 +806,7 @@ fn session_io_loop_auto_break(params: SessionIoAutoBreakParams) {
         decode_tx,
         noise_gate_ratio,
         auto_break_thresholds,
+        audio_enhancement,
     } = params;
 
     if event_tx.send(TranscriptionEvent::Ready).is_err() {
@@ -770,7 +820,12 @@ fn session_io_loop_auto_break(params: SessionIoAutoBreakParams) {
     loop {
         if cancel.load(Ordering::Relaxed) {
             tracing::info!("sherpa Auto Break I/O thread cancelled");
-            drain_auto_break_on_exit(&mut machine, noise_gate_ratio, &decode_tx);
+            drain_auto_break_on_exit(
+                &mut machine,
+                noise_gate_ratio,
+                audio_enhancement,
+                &decode_tx,
+            );
             return;
         }
 
@@ -797,8 +852,13 @@ fn session_io_loop_auto_break(params: SessionIoAutoBreakParams) {
                     );
                     let stereo_buf = machine.take_buffer();
                     machine.reset_after_force_flush(AutoBreakState::Recording);
-                    if dispatch_auto_break_segment(&stereo_buf, noise_gate_ratio, &decode_tx)
-                        .is_err()
+                    if dispatch_auto_break_segment(
+                        &stereo_buf,
+                        noise_gate_ratio,
+                        audio_enhancement,
+                        &decode_tx,
+                    )
+                    .is_err()
                     {
                         return;
                     }
@@ -823,6 +883,7 @@ fn session_io_loop_auto_break(params: SessionIoAutoBreakParams) {
                             if dispatch_auto_break_segment(
                                 &stereo_buf,
                                 noise_gate_ratio,
+                                audio_enhancement,
                                 &decode_tx,
                             )
                             .is_err()
@@ -843,7 +904,12 @@ fn session_io_loop_auto_break(params: SessionIoAutoBreakParams) {
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 tracing::info!("sherpa Auto Break I/O thread ended (channel disconnected)");
-                drain_auto_break_on_exit(&mut machine, noise_gate_ratio, &decode_tx);
+                drain_auto_break_on_exit(
+                    &mut machine,
+                    noise_gate_ratio,
+                    audio_enhancement,
+                    &decode_tx,
+                );
                 return;
             }
         }
@@ -857,6 +923,7 @@ fn session_io_loop_auto_break(params: SessionIoAutoBreakParams) {
 fn dispatch_auto_break_segment(
     stereo_buf: &[f32],
     noise_gate_ratio: f32,
+    audio_enhancement: denoise::AudioEnhancement,
     decode_tx: &mpsc::Sender<DecodeRequest>,
 ) -> Result<(), ()> {
     if stereo_buf.is_empty() {
@@ -865,7 +932,7 @@ fn dispatch_auto_break_segment(
     let mut mono_buf: Vec<f32> =
         Vec::with_capacity(stereo_buf.len() / STEREO_48K_TO_MONO_16K_CAPACITY_DIVISOR);
     resampler::downsample_stereo_to_mono_16k(stereo_buf, &mut mono_buf);
-    denoise::enhance_speech(&mut mono_buf, noise_gate_ratio);
+    denoise::apply(&mut mono_buf, audio_enhancement, noise_gate_ratio);
     decode_tx
         .send(DecodeRequest { mono: mono_buf })
         .map_err(|_| ())
@@ -887,6 +954,7 @@ fn dispatch_auto_break_segment(
 fn drain_auto_break_on_exit(
     machine: &mut AutoBreakMachine,
     noise_gate_ratio: f32,
+    audio_enhancement: denoise::AudioEnhancement,
     decode_tx: &mpsc::Sender<DecodeRequest>,
 ) {
     if matches!(machine.state(), AutoBreakState::Idle) {
@@ -910,7 +978,12 @@ fn drain_auto_break_on_exit(
             "Auto Break: flushing in-flight segment on session exit"
         );
         let stereo_buf = machine.take_buffer();
-        let _ = dispatch_auto_break_segment(&stereo_buf, noise_gate_ratio, decode_tx);
+        let _ = dispatch_auto_break_segment(
+            &stereo_buf,
+            noise_gate_ratio,
+            audio_enhancement,
+            decode_tx,
+        );
     }
     machine.reset_after_force_flush(AutoBreakState::Idle);
 }
@@ -1223,6 +1296,7 @@ mod auto_break_tests {
                     decode_tx,
                     noise_gate_ratio: 1.0,
                     auto_break_thresholds: super::super::host::AutoBreakThresholds::defaults(),
+                    audio_enhancement: denoise::AudioEnhancement::default(),
                 });
             }
         });

--- a/crates/sdr-transcription/src/backends/sherpa/streaming.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/streaming.rs
@@ -77,6 +77,7 @@ pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) 
         vad_threshold: _,
         segmentation_mode,
         auto_break_thresholds: _,
+        audio_enhancement,
     } = params;
 
     if segmentation_mode == crate::backend::SegmentationMode::AutoBreak {
@@ -130,7 +131,7 @@ pub(super) fn run_session(recognizer: &OnlineRecognizer, params: SessionParams) 
             continue;
         }
 
-        denoise::enhance_speech(&mut mono_buf, noise_gate_ratio);
+        denoise::apply(&mut mono_buf, audio_enhancement, noise_gate_ratio);
 
         stream.accept_waveform(SHERPA_SAMPLE_RATE_HZ, &mono_buf);
 

--- a/crates/sdr-transcription/src/backends/whisper.rs
+++ b/crates/sdr-transcription/src/backends/whisper.rs
@@ -84,6 +84,7 @@ impl TranscriptionBackend for WhisperBackend {
         let cancel = Arc::clone(&self.cancel);
         let silence_threshold = config.silence_threshold;
         let noise_gate_ratio = config.noise_gate_ratio;
+        let audio_enhancement = config.audio_enhancement;
 
         let handle = std::thread::Builder::new()
             .name("whisper-worker".into())
@@ -95,6 +96,7 @@ impl TranscriptionBackend for WhisperBackend {
                     whisper_model,
                     silence_threshold,
                     noise_gate_ratio,
+                    audio_enhancement,
                 );
             })?;
 
@@ -130,6 +132,7 @@ impl TranscriptionBackend for WhisperBackend {
 /// * `model` — which Whisper model to load
 /// * `silence_threshold` — RMS below which a chunk is skipped
 /// * `noise_gate_ratio` — spectral gate multiplier over noise floor
+/// * `audio_enhancement` — which denoise strategy to apply per segment
 fn run_worker(
     audio_rx: &mpsc::Receiver<TranscriptionInput>,
     event_tx: &mpsc::Sender<TranscriptionEvent>,
@@ -137,6 +140,7 @@ fn run_worker(
     model: model::WhisperModel,
     silence_threshold: f32,
     noise_gate_ratio: f32,
+    audio_enhancement: denoise::AudioEnhancement,
 ) {
     if let Err(e) = run_worker_inner(
         audio_rx,
@@ -145,6 +149,7 @@ fn run_worker(
         model,
         silence_threshold,
         noise_gate_ratio,
+        audio_enhancement,
     ) {
         let _ = event_tx.send(TranscriptionEvent::Error(e));
     }
@@ -160,6 +165,7 @@ fn run_worker_inner(
     model: model::WhisperModel,
     silence_threshold: f32,
     noise_gate_ratio: f32,
+    audio_enhancement: denoise::AudioEnhancement,
 ) -> Result<(), String> {
     // --- Model download / load ---
     let model_path = if model::model_exists(model) {
@@ -276,7 +282,13 @@ fn run_worker_inner(
                 tracing::info!("transcription cancelled, worker exiting");
                 return Ok(());
             }
-            decode_and_emit_segment(&mut state, &mut segment, event_tx, noise_gate_ratio);
+            decode_and_emit_segment(
+                &mut state,
+                &mut segment,
+                event_tx,
+                noise_gate_ratio,
+                audio_enhancement,
+            );
         }
     }
 
@@ -284,7 +296,13 @@ fn run_worker_inner(
     // VAD so the last utterance isn't silently dropped.
     vad.flush();
     while let Some(mut segment) = vad.pop_segment() {
-        decode_and_emit_segment(&mut state, &mut segment, event_tx, noise_gate_ratio);
+        decode_and_emit_segment(
+            &mut state,
+            &mut segment,
+            event_tx,
+            noise_gate_ratio,
+            audio_enhancement,
+        );
     }
 
     tracing::info!("audio channel closed, worker exiting");
@@ -302,12 +320,15 @@ fn decode_and_emit_segment(
     segment: &mut [f32],
     event_tx: &mpsc::Sender<TranscriptionEvent>,
     noise_gate_ratio: f32,
+    audio_enhancement: denoise::AudioEnhancement,
 ) {
-    // Voice-band shaped spectral gate (#274) — remove broadband
-    // static, rumble, PL tones, and above-voice hiss before Whisper
-    // sees the audio. Runs per segment rather than per chunk now that
-    // segmentation lives upstream.
-    denoise::enhance_speech(segment, noise_gate_ratio);
+    // Audio enhancement dispatcher (#281) — routes to
+    // `enhance_speech` (default voice-band), `spectral_denoise`
+    // (broadband), or no-op (Off) based on the user-selected
+    // mode threaded through from `BackendConfig`. Runs per
+    // segment rather than per chunk now that segmentation lives
+    // upstream.
+    denoise::apply(segment, audio_enhancement, noise_gate_ratio);
 
     let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
     params.set_language(Some("en"));

--- a/crates/sdr-transcription/src/denoise.rs
+++ b/crates/sdr-transcription/src/denoise.rs
@@ -793,19 +793,50 @@ mod tests {
     // the VoiceBand / Broadband branches would be caught here, and
     // the config-string round-trip is load-bearing for persistence.
 
+    // --- three_tone_signal helper constants ---
+    //
+    // The buffer length and tone frequencies below are test
+    // fixtures, not tuning knobs — but per CLAUDE.md they're
+    // still worth naming because the dispatcher tests below rely
+    // on specific properties of each band (one in every voice-
+    // prior weight region) and a future refactor shouldn't have
+    // to decode the math from bare literals.
+
+    /// Length of the test buffer in samples at 16 kHz =
+    /// `SAMPLE_RATE_HZ`. 4096 samples = 256 ms, comfortably above
+    /// [`MIN_FFT_LEN`] so all three modes take the FFT path.
+    const THREE_TONE_SIGNAL_LEN: usize = 4096;
+    /// Fundamental-band tone. Lands in the 80–300 Hz region that
+    /// [`enhance_speech`] half-weights — so `VoiceBand`'s output
+    /// must differ from `Broadband`'s here.
+    const THREE_TONE_FUNDAMENTAL_HZ: f32 = 100.0;
+    /// Formant-band tone. Lands in the 300–3400 Hz region that
+    /// gets full weight (1.0) — so `VoiceBand` preserves this
+    /// close to unchanged.
+    const THREE_TONE_FORMANT_HZ: f32 = 1_000.0;
+    /// Sibilance-band tone. Lands in the 3400–7500 Hz ramp where
+    /// `VoiceBand` tapers the weight. `Broadband` preserves it
+    /// unchanged, so the two modes must differ.
+    const THREE_TONE_SIBILANCE_HZ: f32 = 6_000.0;
+    /// Per-component amplitude. 0.3 × 3 tones = 0.9 peak which
+    /// avoids clipping at f32 [-1, 1].
+    const THREE_TONE_COMPONENT_AMP: f32 = 0.3;
+
     /// Helper: build a test signal that all three modes can process
     /// and compare — a sum of three tones at 100 Hz (fundamental
     /// band), 1000 Hz (formant band), and 6000 Hz (sibilance band).
-    /// 4096 samples at 16 kHz = 256 ms, comfortably above
-    /// `MIN_FFT_LEN`.
+    /// See the `THREE_TONE_*` constants above for per-tone rationale.
     fn three_tone_signal() -> Vec<f32> {
-        let n = 4096;
+        let n = THREE_TONE_SIGNAL_LEN;
         let mut buf = Vec::with_capacity(n);
         for i in 0..n {
             let t = i as f32 / SAMPLE_RATE_HZ;
-            let sample = 0.3 * (2.0 * std::f32::consts::PI * 100.0 * t).sin()
-                + 0.3 * (2.0 * std::f32::consts::PI * 1000.0 * t).sin()
-                + 0.3 * (2.0 * std::f32::consts::PI * 6000.0 * t).sin();
+            let sample = THREE_TONE_COMPONENT_AMP
+                * (2.0 * std::f32::consts::PI * THREE_TONE_FUNDAMENTAL_HZ * t).sin()
+                + THREE_TONE_COMPONENT_AMP
+                    * (2.0 * std::f32::consts::PI * THREE_TONE_FORMANT_HZ * t).sin()
+                + THREE_TONE_COMPONENT_AMP
+                    * (2.0 * std::f32::consts::PI * THREE_TONE_SIBILANCE_HZ * t).sin();
             buf.push(sample);
         }
         buf

--- a/crates/sdr-transcription/src/denoise.rs
+++ b/crates/sdr-transcription/src/denoise.rs
@@ -88,6 +88,117 @@ const NOISE_FLOOR_PERCENTILE: f32 = 0.20;
 /// in one place.
 const MIN_FFT_LEN: usize = 64;
 
+/// User-selectable audio enhancement mode applied to mono
+/// transcription audio before it reaches the recognizer.
+///
+/// Every call site in the transcription pipeline (sherpa offline
+/// VAD, sherpa offline Auto Break, sherpa streaming, whisper)
+/// dispatches through [`apply`] using the mode configured on the
+/// session. Switching modes takes effect at the next session
+/// start — the session I/O threads read the config once and use
+/// it for the session's lifetime.
+///
+/// # Issue #281 context
+///
+/// The default [`VoiceBand`] path shaves audio outside ~80–7500 Hz
+/// with a voice-prior weight function. Some recognizers — notably
+/// Moonshine Tiny/Base in the sherpa-onnx int8 releases — have a
+/// convolutional frontend that appears to be more sensitive to
+/// these hard cutoffs than `Parakeet`'s `NeMo` fbank frontend, and
+/// produce empty text on the same NFM audio where `Parakeet`
+/// transcribes correctly. Switching the affected session to
+/// [`Broadband`] (flat noise-floor gate, no voice-prior) restores
+/// Moonshine's output. See issue #281 for the investigation and
+/// trace data.
+///
+/// # Variants
+///
+/// - [`VoiceBand`] — [`enhance_speech`], bandpass-shaped gate with
+///   voice-prior weights. Default for most users on most audio.
+/// - [`Broadband`] — [`spectral_denoise`], flat noise-floor gate
+///   without voice-prior weights. Use when [`VoiceBand`] is
+///   suppressing recognizer output (e.g. Moonshine on NFM).
+/// - [`Off`] — no enhancement. Pass the audio straight to the
+///   recognizer. Useful as a baseline for troubleshooting or when
+///   the source is already clean (file playback of pre-cleaned
+///   audio, etc.).
+///
+/// [`VoiceBand`]: AudioEnhancement::VoiceBand
+/// [`Broadband`]: AudioEnhancement::Broadband
+/// [`Off`]: AudioEnhancement::Off
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub enum AudioEnhancement {
+    /// Voice-prior weighted spectral gate — default.
+    /// See [`enhance_speech`] for the algorithm.
+    #[default]
+    VoiceBand,
+    /// Flat-weight spectral gate — the original PR #227 broadband
+    /// path. See [`spectral_denoise`].
+    Broadband,
+    /// No enhancement. Pass audio through unchanged.
+    Off,
+}
+
+impl AudioEnhancement {
+    /// Stable string identifier for config persistence. Paired
+    /// with [`Self::from_config_str`].
+    ///
+    /// Snake-case so it looks natural in the JSON config file
+    /// alongside other transcription keys like `display_mode`.
+    #[must_use]
+    pub fn as_config_str(self) -> &'static str {
+        match self {
+            Self::VoiceBand => "voice_band",
+            Self::Broadband => "broadband",
+            Self::Off => "off",
+        }
+    }
+
+    /// Parse a config-string identifier produced by
+    /// [`Self::as_config_str`]. Unknown values (old configs, typos,
+    /// future-reserved names) fall back to the default
+    /// [`AudioEnhancement::VoiceBand`] rather than erroring — a
+    /// missing or invalid audio-enhancement config key should
+    /// never fail a session start.
+    #[must_use]
+    pub fn from_config_str(s: &str) -> Self {
+        match s {
+            "broadband" => Self::Broadband,
+            "off" => Self::Off,
+            // "voice_band" and unknown both fall through to the
+            // default, per the lenient-parsing contract documented
+            // on the function.
+            _ => Self::VoiceBand,
+        }
+    }
+}
+
+/// Apply the selected audio enhancement to `samples` in place.
+///
+/// Central dispatcher for all transcription call sites. Every
+/// recognizer path should route its mono buffer through here
+/// instead of calling [`enhance_speech`] / [`spectral_denoise`]
+/// directly so the user's mode selection is honored.
+///
+/// `gate_ratio` is passed through to whichever FFT-based path
+/// runs; it has no effect in [`AudioEnhancement::Off`] mode.
+/// Buffers shorter than [`MIN_FFT_LEN`] are left unchanged by the
+/// underlying functions (same as the existing short-buffer
+/// behavior) so very short segments at session boundaries still
+/// reach the recognizer without being gated by a degenerate FFT.
+pub fn apply(samples: &mut [f32], enhancement: AudioEnhancement, gate_ratio: f32) {
+    match enhancement {
+        AudioEnhancement::VoiceBand => enhance_speech(samples, gate_ratio),
+        AudioEnhancement::Broadband => spectral_denoise(samples, gate_ratio),
+        AudioEnhancement::Off => {
+            // No-op — leave samples untouched. This is the
+            // escape hatch for users whose audio is already
+            // clean or whose recognizer behaves badly with any
+            // spectral gate.
+        }
+    }
+}
+
 /// Apply spectral noise gating to a mono f32 audio buffer in-place.
 ///
 /// The buffer is FFT'd, noise floor is estimated from the quietest bins,
@@ -673,5 +784,142 @@ mod tests {
             "200 Hz survivor should be scaled to approximately VOICE_W_FUND² = {}× input power, got ratio={ratio} (p_input={p_input}, p_output={p_output})",
             VOICE_W_FUND * VOICE_W_FUND
         );
+    }
+
+    // ─── AudioEnhancement dispatcher tests ──────────────────────
+    //
+    // The dispatcher is a thin routing function, but pinning its
+    // behavior matters: a future refactor that accidentally swaps
+    // the VoiceBand / Broadband branches would be caught here, and
+    // the config-string round-trip is load-bearing for persistence.
+
+    /// Helper: build a test signal that all three modes can process
+    /// and compare — a sum of three tones at 100 Hz (fundamental
+    /// band), 1000 Hz (formant band), and 6000 Hz (sibilance band).
+    /// 4096 samples at 16 kHz = 256 ms, comfortably above
+    /// `MIN_FFT_LEN`.
+    fn three_tone_signal() -> Vec<f32> {
+        let n = 4096;
+        let mut buf = Vec::with_capacity(n);
+        for i in 0..n {
+            let t = i as f32 / SAMPLE_RATE_HZ;
+            let sample = 0.3 * (2.0 * std::f32::consts::PI * 100.0 * t).sin()
+                + 0.3 * (2.0 * std::f32::consts::PI * 1000.0 * t).sin()
+                + 0.3 * (2.0 * std::f32::consts::PI * 6000.0 * t).sin();
+            buf.push(sample);
+        }
+        buf
+    }
+
+    #[test]
+    fn audio_enhancement_off_is_identity() {
+        // Off mode must leave the buffer byte-identical. This is
+        // load-bearing for users who want to feed pre-cleaned audio
+        // directly to the recognizer without any spectral gate.
+        let input = three_tone_signal();
+        let mut buf = input.clone();
+        apply(&mut buf, AudioEnhancement::Off, GATE_RATIO);
+        assert_eq!(
+            buf, input,
+            "Off mode must not mutate the input buffer in any way"
+        );
+    }
+
+    #[test]
+    fn audio_enhancement_voice_band_matches_enhance_speech() {
+        // VoiceBand must route to enhance_speech. A bit-exact
+        // comparison against a side-by-side enhance_speech call on
+        // an identical input buffer pins the dispatch — a future
+        // refactor that silently swapped the VoiceBand branch to a
+        // different function would produce different output and
+        // fail this assertion.
+        let input = three_tone_signal();
+        let mut via_apply = input.clone();
+        let mut via_direct = input.clone();
+        apply(&mut via_apply, AudioEnhancement::VoiceBand, GATE_RATIO);
+        enhance_speech(&mut via_direct, GATE_RATIO);
+        assert_eq!(
+            via_apply, via_direct,
+            "VoiceBand dispatcher must produce bit-identical output to enhance_speech"
+        );
+    }
+
+    #[test]
+    fn audio_enhancement_broadband_matches_spectral_denoise() {
+        // Same contract for Broadband → spectral_denoise.
+        let input = three_tone_signal();
+        let mut via_apply = input.clone();
+        let mut via_direct = input.clone();
+        apply(&mut via_apply, AudioEnhancement::Broadband, GATE_RATIO);
+        spectral_denoise(&mut via_direct, GATE_RATIO);
+        assert_eq!(
+            via_apply, via_direct,
+            "Broadband dispatcher must produce bit-identical output to spectral_denoise"
+        );
+    }
+
+    #[test]
+    fn audio_enhancement_modes_produce_different_outputs() {
+        // Sanity check that the three modes actually differ on the
+        // same input — if this ever asserts `==` the tests above
+        // are comparing against themselves and would silently pass
+        // even with a busted dispatcher.
+        let input = three_tone_signal();
+        let mut off = input.clone();
+        let mut voice = input.clone();
+        let mut broad = input.clone();
+        apply(&mut off, AudioEnhancement::Off, GATE_RATIO);
+        apply(&mut voice, AudioEnhancement::VoiceBand, GATE_RATIO);
+        apply(&mut broad, AudioEnhancement::Broadband, GATE_RATIO);
+        assert_ne!(
+            off, voice,
+            "Off and VoiceBand should differ on a noisy signal"
+        );
+        assert_ne!(
+            off, broad,
+            "Off and Broadband should differ on a noisy signal"
+        );
+        assert_ne!(
+            voice, broad,
+            "VoiceBand and Broadband should differ on a signal with out-of-voice content"
+        );
+    }
+
+    #[test]
+    fn audio_enhancement_config_str_round_trip() {
+        // as_config_str ↔ from_config_str must round-trip for all
+        // three variants.
+        for mode in [
+            AudioEnhancement::VoiceBand,
+            AudioEnhancement::Broadband,
+            AudioEnhancement::Off,
+        ] {
+            let s = mode.as_config_str();
+            let parsed = AudioEnhancement::from_config_str(s);
+            assert_eq!(parsed, mode, "round-trip failed for {mode:?} via {s:?}");
+        }
+    }
+
+    #[test]
+    fn audio_enhancement_config_str_unknown_falls_back_to_default() {
+        // Unknown / stale / typo config values must fall back to
+        // the default, not error. This matters because a missing
+        // audio-enhancement key in an old config file (from before
+        // this feature shipped) will deserialize to an empty
+        // string which should land on VoiceBand, not some noisy
+        // error.
+        assert_eq!(
+            AudioEnhancement::from_config_str(""),
+            AudioEnhancement::default()
+        );
+        assert_eq!(
+            AudioEnhancement::from_config_str("nonsense"),
+            AudioEnhancement::default()
+        );
+        assert_eq!(
+            AudioEnhancement::from_config_str("VoiceBand"), // wrong case
+            AudioEnhancement::default()
+        );
+        assert_eq!(AudioEnhancement::default(), AudioEnhancement::VoiceBand);
     }
 }

--- a/crates/sdr-transcription/src/lib.rs
+++ b/crates/sdr-transcription/src/lib.rs
@@ -238,6 +238,7 @@ mod tests {
             auto_break_min_open_ms: crate::AUTO_BREAK_MIN_OPEN_MS_DEFAULT,
             auto_break_tail_ms: crate::AUTO_BREAK_TAIL_MS_DEFAULT,
             auto_break_min_segment_ms: crate::AUTO_BREAK_MIN_SEGMENT_MS_DEFAULT,
+            audio_enhancement: crate::denoise::AudioEnhancement::default(),
         }
     }
 

--- a/crates/sdr-transcription/tests/sherpa_uninitialized.rs
+++ b/crates/sdr-transcription/tests/sherpa_uninitialized.rs
@@ -28,6 +28,7 @@ fn sherpa_backend_start_returns_init_error_when_host_not_initialized() {
         auto_break_min_open_ms: sdr_transcription::AUTO_BREAK_MIN_OPEN_MS_DEFAULT,
         auto_break_tail_ms: sdr_transcription::AUTO_BREAK_TAIL_MS_DEFAULT,
         auto_break_min_segment_ms: sdr_transcription::AUTO_BREAK_MIN_SEGMENT_MS_DEFAULT,
+        audio_enhancement: sdr_transcription::denoise::AudioEnhancement::default(),
     };
     let result = backend.start(config);
     match result {

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -73,7 +73,6 @@ const KEY_AUDIO_ENHANCEMENT: &str = "transcription_audio_enhancement";
 /// matches [`AUDIO_ENHANCEMENT_LABELS`] below. `pub(crate)` so
 /// `window.rs` can match on them at `BackendConfig` construction
 /// time without re-deriving the parse logic.
-#[allow(dead_code)]
 pub(crate) const AUDIO_ENHANCEMENT_VOICE_BAND_IDX: u32 = 0;
 pub(crate) const AUDIO_ENHANCEMENT_BROADBAND_IDX: u32 = 1;
 pub(crate) const AUDIO_ENHANCEMENT_OFF_IDX: u32 = 2;
@@ -506,19 +505,32 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         let config_enhancement = Arc::clone(config);
         row.connect_selected_notify(move |r| {
             // Map combo index → AudioEnhancement → stable config
-            // string. The round-trip goes through the enum so a
-            // future addition of a fourth mode only has to touch
-            // the enum + labels + one match arm here.
-            let value = match r.selected() {
-                AUDIO_ENHANCEMENT_BROADBAND_IDX => {
-                    sdr_transcription::denoise::AudioEnhancement::Broadband
+            // string. Only persist if the index matches one of
+            // the three known-valid values. GTK `ComboRow` emits
+            // `selected-notify` with transient out-of-range
+            // indices during intermediate widget state changes
+            // (e.g. during model repopulation), and the lenient
+            // "fall through to VoiceBand" pattern the ACTIVE
+            // dispatch path uses is dangerous here — it would
+            // silently overwrite a user's Broadband or Off
+            // workaround with the default on a spurious signal.
+            // Runtime dispatch (window.rs BackendConfig build) can
+            // still be lenient because it reads the current value
+            // once at session start; this persistence handler is
+            // the one that cares about transient signals.
+            let Some(value) = (match r.selected() {
+                AUDIO_ENHANCEMENT_VOICE_BAND_IDX => {
+                    Some(sdr_transcription::denoise::AudioEnhancement::VoiceBand)
                 }
-                AUDIO_ENHANCEMENT_OFF_IDX => sdr_transcription::denoise::AudioEnhancement::Off,
-                // VoiceBand and any out-of-range fall through to
-                // the default, mirroring
-                // `AudioEnhancement::from_config_str`'s lenient
-                // parsing contract.
-                _ => sdr_transcription::denoise::AudioEnhancement::VoiceBand,
+                AUDIO_ENHANCEMENT_BROADBAND_IDX => {
+                    Some(sdr_transcription::denoise::AudioEnhancement::Broadband)
+                }
+                AUDIO_ENHANCEMENT_OFF_IDX => {
+                    Some(sdr_transcription::denoise::AudioEnhancement::Off)
+                }
+                _ => None,
+            }) else {
+                return;
             };
             config_enhancement.write(|v| {
                 v[KEY_AUDIO_ENHANCEMENT] = serde_json::json!(value.as_config_str());

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -59,6 +59,28 @@ const KEY_AUTO_BREAK_TAIL_MS: &str = "transcription_auto_break_tail_ms";
 #[cfg(feature = "sherpa")]
 const KEY_AUTO_BREAK_MIN_SEGMENT_MS: &str = "transcription_auto_break_min_segment_ms";
 
+/// Config key for the persisted audio-enhancement mode. Values are
+/// the `AudioEnhancement::as_config_str` strings: `"voice_band"`,
+/// `"broadband"`, or `"off"`. Default `"voice_band"`. Applies to
+/// both whisper and sherpa — the audio enhancement dispatcher lives
+/// in `sdr-transcription::denoise` and all four recognizer call
+/// sites route through it. Added in PR for issue #281 so users who
+/// hit voice-band preprocessor issues (notably Moonshine) have a
+/// user-visible workaround without rebuilding.
+const KEY_AUDIO_ENHANCEMENT: &str = "transcription_audio_enhancement";
+
+/// Combo row indices for the audio-enhancement selector. Order
+/// matches [`AUDIO_ENHANCEMENT_LABELS`] below. `pub(crate)` so
+/// `window.rs` can match on them at `BackendConfig` construction
+/// time without re-deriving the parse logic.
+#[allow(dead_code)]
+pub(crate) const AUDIO_ENHANCEMENT_VOICE_BAND_IDX: u32 = 0;
+pub(crate) const AUDIO_ENHANCEMENT_BROADBAND_IDX: u32 = 1;
+pub(crate) const AUDIO_ENHANCEMENT_OFF_IDX: u32 = 2;
+/// User-visible labels for the audio-enhancement combo row. Order
+/// must match the `AUDIO_ENHANCEMENT_*_IDX` constants above.
+const AUDIO_ENHANCEMENT_LABELS: &[&str] = &["Voice-band (default)", "Broadband", "Off"];
+
 #[cfg(feature = "sherpa")]
 const DISPLAY_MODE_LIVE_IDX: u32 = 0;
 /// `pub(crate)` so `window.rs` can gate the `Partial` handler on it.
@@ -156,6 +178,12 @@ pub struct TranscriptPanel {
     pub silence_row: adw::SpinRow,
     /// Noise gate spin row.
     pub noise_gate_row: adw::SpinRow,
+    /// Audio enhancement mode selector (Voice-band / Broadband /
+    /// Off). Applies to both whisper and sherpa backends — the
+    /// dispatcher in `sdr-transcription::denoise` routes every
+    /// recognizer call site through the user's choice. Default is
+    /// Voice-band, which matches the pre-#281 behavior.
+    pub audio_enhancement_row: adw::ComboRow,
     /// Display-mode selector (Live captions vs Final only). Sherpa-only —
     /// Whisper has no `Partial` events to render.
     #[cfg(feature = "sherpa")]
@@ -435,6 +463,70 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
             v[KEY_NOISE_GATE] = serde_json::json!(val);
         });
     });
+
+    // --- Audio enhancement mode selector ---
+    //
+    // Applies to all recognizer backends (whisper + both sherpa
+    // paths). Default Voice-band matches the pre-#281 behavior;
+    // users hitting voice-band preprocessor issues (e.g. Moonshine
+    // silently returning empty text on NFM speech) can switch to
+    // Broadband or Off as a workaround. Persisted as a stable
+    // string id via `AudioEnhancement::as_config_str` so future
+    // schema migrations don't rely on u32 index stability.
+    let audio_enhancement_row = {
+        let list = gtk4::StringList::new(AUDIO_ENHANCEMENT_LABELS);
+
+        let saved_idx = config.read(|v| {
+            let s = v
+                .get(KEY_AUDIO_ENHANCEMENT)
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("voice_band");
+            match sdr_transcription::denoise::AudioEnhancement::from_config_str(s) {
+                sdr_transcription::denoise::AudioEnhancement::VoiceBand => {
+                    AUDIO_ENHANCEMENT_VOICE_BAND_IDX
+                }
+                sdr_transcription::denoise::AudioEnhancement::Broadband => {
+                    AUDIO_ENHANCEMENT_BROADBAND_IDX
+                }
+                sdr_transcription::denoise::AudioEnhancement::Off => AUDIO_ENHANCEMENT_OFF_IDX,
+            }
+        });
+
+        let row = adw::ComboRow::builder()
+            .title("Audio enhancement")
+            .subtitle(
+                "Voice-band (recommended) • Broadband if your recognizer returns no text \
+                 • Off for pristine source audio",
+            )
+            .model(&list)
+            .selected(saved_idx)
+            .build();
+        group.add(&row);
+
+        let config_enhancement = Arc::clone(config);
+        row.connect_selected_notify(move |r| {
+            // Map combo index → AudioEnhancement → stable config
+            // string. The round-trip goes through the enum so a
+            // future addition of a fourth mode only has to touch
+            // the enum + labels + one match arm here.
+            let value = match r.selected() {
+                AUDIO_ENHANCEMENT_BROADBAND_IDX => {
+                    sdr_transcription::denoise::AudioEnhancement::Broadband
+                }
+                AUDIO_ENHANCEMENT_OFF_IDX => sdr_transcription::denoise::AudioEnhancement::Off,
+                // VoiceBand and any out-of-range fall through to
+                // the default, mirroring
+                // `AudioEnhancement::from_config_str`'s lenient
+                // parsing contract.
+                _ => sdr_transcription::denoise::AudioEnhancement::VoiceBand,
+            };
+            config_enhancement.write(|v| {
+                v[KEY_AUDIO_ENHANCEMENT] = serde_json::json!(value.as_config_str());
+            });
+        });
+
+        row
+    };
 
     // --- VAD threshold slider (Sherpa + offline models only) ---
     //
@@ -819,6 +911,7 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         #[cfg(feature = "whisper")]
         silence_row,
         noise_gate_row,
+        audio_enhancement_row,
         #[cfg(feature = "sherpa")]
         display_mode_row,
         #[cfg(feature = "sherpa")]

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1649,6 +1649,7 @@ fn unlock_transcription_session_rows(
     model_row: &glib::WeakRef<adw::ComboRow>,
     #[cfg(feature = "whisper")] silence_row: &glib::WeakRef<adw::SpinRow>,
     noise_gate_row: &glib::WeakRef<adw::SpinRow>,
+    audio_enhancement_row: &glib::WeakRef<adw::ComboRow>,
     #[cfg(feature = "sherpa")] display_mode_row: &glib::WeakRef<adw::ComboRow>,
     #[cfg(feature = "sherpa")] vad_threshold_row: &glib::WeakRef<adw::SpinRow>,
     #[cfg(feature = "sherpa")] auto_break_row: &glib::WeakRef<adw::SwitchRow>,
@@ -1664,6 +1665,9 @@ fn unlock_transcription_session_rows(
         row.set_sensitive(true);
     }
     if let Some(row) = noise_gate_row.upgrade() {
+        row.set_sensitive(true);
+    }
+    if let Some(row) = audio_enhancement_row.upgrade() {
         row.set_sensitive(true);
     }
     #[cfg(feature = "sherpa")]
@@ -1720,6 +1724,7 @@ fn connect_transcript_panel(
     #[cfg(feature = "whisper")]
     let silence_row = transcript.silence_row.clone();
     let noise_gate_row = transcript.noise_gate_row.clone();
+    let audio_enhancement_row = transcript.audio_enhancement_row.clone();
     // Weak refs used by the async event-loop closure to drive the same
     // teardown the synchronous error path does (see below) when the
     // backend fires TranscriptionEvent::Error mid-session. Weak so the
@@ -1729,6 +1734,7 @@ fn connect_transcript_panel(
     #[cfg(feature = "whisper")]
     let silence_row_weak = silence_row.downgrade();
     let noise_gate_row_weak = noise_gate_row.downgrade();
+    let audio_enhancement_row_weak = audio_enhancement_row.downgrade();
     #[cfg(feature = "sherpa")]
     let display_mode_row = transcript.display_mode_row.clone();
     #[cfg(feature = "sherpa")]
@@ -1967,6 +1973,7 @@ fn connect_transcript_panel(
             #[cfg(feature = "whisper")]
             silence_row.set_sensitive(false);
             noise_gate_row.set_sensitive(false);
+            audio_enhancement_row.set_sensitive(false);
             // All settings lock during a session for mid-session fault
             // tolerance — walks back PR 4's earlier display_mode_row
             // exception. User stops, changes, starts.
@@ -2049,6 +2056,21 @@ fn connect_transcript_panel(
             let auto_break_min_segment_ms =
                 sdr_transcription::AUTO_BREAK_MIN_SEGMENT_MS_DEFAULT;
 
+            // Audio enhancement mode from the transcript panel
+            // combo row. The row's persisted index is captured at
+            // session start (not subscribed to — matches the
+            // existing "lock during session" behavior for all
+            // transcription settings).
+            let audio_enhancement = match audio_enhancement_row.selected() {
+                sidebar::transcript_panel::AUDIO_ENHANCEMENT_BROADBAND_IDX => {
+                    sdr_transcription::denoise::AudioEnhancement::Broadband
+                }
+                sidebar::transcript_panel::AUDIO_ENHANCEMENT_OFF_IDX => {
+                    sdr_transcription::denoise::AudioEnhancement::Off
+                }
+                _ => sdr_transcription::denoise::AudioEnhancement::VoiceBand,
+            };
+
             let config = sdr_transcription::BackendConfig {
                 model,
                 silence_threshold,
@@ -2058,6 +2080,7 @@ fn connect_transcript_panel(
                 auto_break_min_open_ms,
                 auto_break_tail_ms,
                 auto_break_min_segment_ms,
+                audio_enhancement,
             };
 
             // Scope the borrow so it's dropped before any potential re-entry
@@ -2085,6 +2108,7 @@ fn connect_transcript_panel(
                     #[cfg(feature = "whisper")]
                     let silence_row_weak = silence_row_weak.clone();
                     let noise_gate_row_weak = noise_gate_row_weak.clone();
+                    let audio_enhancement_row_weak = audio_enhancement_row_weak.clone();
                     #[cfg(feature = "sherpa")]
                     let display_mode_row_weak = display_mode_row_weak.clone();
                     #[cfg(feature = "sherpa")]
@@ -2215,6 +2239,7 @@ fn connect_transcript_panel(
                                             #[cfg(feature = "whisper")]
                                             &silence_row_weak,
                                             &noise_gate_row_weak,
+                                            &audio_enhancement_row_weak,
                                             #[cfg(feature = "sherpa")]
                                             &display_mode_row_weak,
                                             #[cfg(feature = "sherpa")]
@@ -2290,6 +2315,7 @@ fn connect_transcript_panel(
                                         #[cfg(feature = "whisper")]
                                         &silence_row_weak,
                                         &noise_gate_row_weak,
+                                        &audio_enhancement_row_weak,
                                         #[cfg(feature = "sherpa")]
                                         &display_mode_row_weak,
                                         #[cfg(feature = "sherpa")]
@@ -2329,6 +2355,7 @@ fn connect_transcript_panel(
                         #[cfg(feature = "whisper")]
                         &silence_row.downgrade(),
                         &noise_gate_row.downgrade(),
+                        &audio_enhancement_row.downgrade(),
                         #[cfg(feature = "sherpa")]
                         &display_mode_row.downgrade(),
                         #[cfg(feature = "sherpa")]
@@ -2359,6 +2386,7 @@ fn connect_transcript_panel(
                 #[cfg(feature = "whisper")]
                 &silence_row.downgrade(),
                 &noise_gate_row.downgrade(),
+                &audio_enhancement_row.downgrade(),
                 #[cfg(feature = "sherpa")]
                 &display_mode_row.downgrade(),
                 #[cfg(feature = "sherpa")]


### PR DESCRIPTION
## Summary

User-visible combo row in the transcript panel for picking between three audio preprocessing modes that feed the recognizer. **Partial fix for #281** — fixes Moonshine on the sherpa VAD path, but **does NOT** fix Moonshine on the Auto Break path (investigation still in progress as of this PR).

- **Voice-band** (default, unchanged from PR #282) — \`enhance_speech\`, bandpass-shaped voice-prior gate
- **Broadband** — \`spectral_denoise\`, flat noise-floor gate without voice-prior weights
- **Off** — raw audio passthrough

Single dispatcher \`denoise::apply\` replaces four scattered direct \`enhance_speech\` calls (sherpa streaming, sherpa offline VAD, sherpa offline Auto Break, whisper). \`BackendConfig.audio_enhancement\` threaded through \`SessionParams\` + whisper worker params; each I/O thread reads the value once at session start (matches existing \"lock during active session\" pattern).

## Relationship to #281

The Moonshine Tiny / Base variants in sherpa-onnx 1.12's int8 releases have a convolutional ONNX frontend that silently returns empty text when fed voice-band-shaped audio from \`enhance_speech\` on the VAD segmentation path. User testing confirmed:

- Voice-band + Moonshine + VAD → empty
- **Broadband + Moonshine + VAD → real transcripts** ✅
- Voice-band + Parakeet → real transcripts (unaffected)

**However**, smoke testing on the Auto Break segmentation path found that Broadband alone is NOT enough — Moonshine still produces empty text on short Auto Break segments regardless of the audio enhancement mode. Root cause of the Auto Break failure is still under investigation; two candidate theories:

1. Moonshine's int8 decoder may need longer audio context than Auto Break's 3-9s transmissions provide
2. Auto Break's segment-level denoise FFT path may damage Moonshine's input differently than VAD's per-chunk path

This PR ships the toggle and fixes VAD. #281 stays open pending Auto Break investigation — follow-up PR will address it based on whichever theory checks out.

## Architecture highlights

- **\`AudioEnhancement\` enum** in \`denoise.rs\` with \`Default\` landing on \`VoiceBand\` so missing config keys resolve to the shipping default
- **\`as_config_str\` / \`from_config_str\`** for stable JSON persistence with lenient fallback on unknown values
- **Diagnostic tracing** retained on \`decode_segment\` (debug-level, shows segment_len / got_result / raw/trimmed text lengths) — invaluable for #281 investigation, cheap to leave in

## Tests

6 new tests in \`denoise::tests\`:
- Off mode is bit-exact passthrough
- VoiceBand dispatch = bit-identical to direct \`enhance_speech\` call
- Broadband dispatch = bit-identical to direct \`spectral_denoise\` call
- All three modes produce different outputs (catches dispatcher regression)
- Config string round-trip for all variants
- Lenient parsing: empty string, typo, wrong case all land on VoiceBand default

## Follow-ups

1. **Moonshine + Auto Break empty-text investigation** (still owned by #281) — disambiguate segment-length vs denoise-shape hypothesis with Off-mode smoke test, then fix based on the answer
2. **Proper \`enhance_speech\` fix for Moonshine compatibility** — soften the 80 Hz / 7500 Hz hard cutoffs so voice-band can be the universal default again
3. **Whisper-cuda regression check** — smoke tested on sherpa-cuda only; whisper-cuda path is mechanically identical

## Test plan

- [x] \`cargo test --workspace\` — all tests pass (17 denoise tests, full workspace)
- [x] Triple-flavor clippy clean (whisper-cpu default, sherpa-cpu, sherpa-cuda)
- [x] \`cargo fmt --all -- --check\` clean
- [x] **Live smoke test on sherpa-cuda**:
  - [x] Visibility: combo row appears between \"Noise gate\" and VAD / Auto Break rows
  - [x] Moonshine + VAD: Voice-band empty → Broadband produces real transcripts
  - [x] Parakeet unaffected by mode changes (no regression)
  - [x] Session lock during active transcription
  - [x] Persistence across app restart
  - [ ] **Moonshine + Auto Break**: still empty on Broadband (confirmed broken, investigation continues)
- [ ] Whisper-cuda regression check (user discretion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio enhancement mode selection to transcription preferences. Users can now choose between Voice Band (optimized for speech), Broadband (general enhancement), or Off. The selected mode applies to all subsequent transcription sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->