### PR TITLE
feat(squelch): voice-activity squelch — syllabic + SNR-ratio (closes #270, #271)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,8 @@ version = "0.1.0"
 dependencies = [
  "rustfft",
  "sdr-types",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Software-defined radio application in Rust -- a port of [SDR++](https://github.c
 - WAV file IQ playback with looping
 - Audio notch filter (biquad IIR, 20-20,000 Hz)
 - Auto-squelch with noise floor tracking
-- Bookmark tuning profiles with full state capture/restore
+- CTCSS tone squelch — 51 standard sub-audible tones (67.0–254.1 Hz), Goertzel-filter detection with neighbor-dominance gating and sustained-hit debouncing; per-bookmark tone selection and threshold tuning
+- Voice-activity squelch — syllabic envelope detector (2–10 Hz speech cadence) and SNR-ratio detector (voice-band vs out-of-band power), gates the speaker path alongside CTCSS and power squelch
+- Bookmark tuning profiles with full state capture/restore (including CTCSS + voice squelch per-channel)
 
 ### Display
 

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -212,6 +212,15 @@ struct DspState {
     /// flooded at detector-window rate. Initialized to `false` to
     /// match the detector's initial closed state.
     ctcss_was_sustained: bool,
+
+    /// Last observed voice-squelch open state. Mirrors the CTCSS
+    /// tracker pattern — we only emit edge events, and the UI
+    /// status indicator subscribes to those. The initial value
+    /// intentionally starts as `true` to match the `Off` default
+    /// (gate permanently open); the first real edge fires when
+    /// the user picks Syllabic or Snr and the fresh detector
+    /// reports closed.
+    voice_squelch_was_open: bool,
 }
 
 impl DspState {
@@ -264,6 +273,7 @@ impl DspState {
             transcription_tx: None,
             squelch_was_open: false,
             ctcss_was_sustained: false,
+            voice_squelch_was_open: true,
         })
     }
 }
@@ -390,9 +400,16 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                     state.transcription_tx = None;
                     state.squelch_was_open = false;
                     // Mode switch rebuilds the AF chain + CTCSS
-                    // detector — edge tracker must match the new
-                    // closed state.
+                    // detector + voice squelch — edge trackers
+                    // must match the new closed state.
                     state.ctcss_was_sustained = false;
+                    // Voice squelch reset to closed in an active
+                    // mode; in Off mode it's still "open" so the
+                    // tracker should track whatever the AF chain
+                    // reports after the rebuild. Simpler to just
+                    // snapshot it here and let the next process
+                    // iteration emit an edge if anything changed.
+                    state.voice_squelch_was_open = state.radio.voice_squelch_open();
                     let _ = dsp_tx.send(DspToUi::DemodModeChanged(mode));
                 }
             }
@@ -674,6 +691,24 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             if let Err(e) = state.radio.set_ctcss_threshold(threshold) {
                 tracing::warn!("CTCSS threshold set failed: {e}");
                 let _ = dsp_tx.send(DspToUi::Error(format!("CTCSS threshold failed: {e}")));
+            }
+        }
+
+        UiToDsp::SetVoiceSquelchMode(mode) => {
+            tracing::debug!(?mode, "set voice squelch mode");
+            if let Err(e) = state.radio.set_voice_squelch_mode(mode) {
+                tracing::warn!("voice squelch mode set failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("Voice squelch failed: {e}")));
+            }
+        }
+
+        UiToDsp::SetVoiceSquelchThreshold(threshold) => {
+            tracing::debug!(threshold, "set voice squelch threshold");
+            if let Err(e) = state.radio.set_voice_squelch_threshold(threshold) {
+                tracing::warn!("voice squelch threshold set failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!(
+                    "Voice squelch threshold failed: {e}"
+                )));
             }
         }
 
@@ -1085,6 +1120,18 @@ fn process_iq_block(
                         if now_ctcss != state.ctcss_was_sustained {
                             let _ = dsp_tx.send(DspToUi::CtcssSustainedChanged(now_ctcss));
                             state.ctcss_was_sustained = now_ctcss;
+                        }
+
+                        // Voice squelch edges — same pattern, different
+                        // source. Gate state comes from the AF-chain
+                        // voice squelch which uses a rolling RMS
+                        // window, so edges happen on timescales of
+                        // ~100 ms (the RMS integration length) rather
+                        // than CTCSS's 400 ms windows.
+                        let now_voice = state.radio.voice_squelch_open();
+                        if now_voice != state.voice_squelch_was_open {
+                            let _ = dsp_tx.send(DspToUi::VoiceSquelchOpenChanged(now_voice));
+                            state.voice_squelch_was_open = now_voice;
                         }
 
                         // Send audio copy to transcription worker BEFORE volume

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -1,5 +1,6 @@
 //! Message types for communication between the DSP thread and the UI thread.
 
+use sdr_dsp::voice_squelch::VoiceSquelchMode;
 use sdr_radio::{DeemphasisMode, af_chain::CtcssMode};
 use sdr_types::DemodMode;
 
@@ -42,6 +43,14 @@ pub enum DspToUi {
     /// status indicator can subscribe without flooding the channel.
     /// Always `false` when CTCSS is currently `Off`.
     CtcssSustainedChanged(bool),
+    /// Voice-squelch gate state changed. Same edge-triggered
+    /// contract as `CtcssSustainedChanged`: only emitted on
+    /// closed→open / open→closed transitions. Always `true`
+    /// when voice squelch is `Off` (the gate is permanently
+    /// open in that mode, so the edge is just a one-shot at
+    /// mode-entry that the controller handles by resetting the
+    /// tracker).
+    VoiceSquelchOpenChanged(bool),
 }
 
 /// Available source types for IQ input.
@@ -118,6 +127,12 @@ pub enum UiToDsp {
     SetCtcssMode(CtcssMode),
     /// Set the CTCSS detection threshold (normalized magnitude, `(0, 1]`).
     SetCtcssThreshold(f32),
+    /// Set the voice-activity squelch mode (Off / Syllabic / Snr).
+    SetVoiceSquelchMode(VoiceSquelchMode),
+    /// Set the voice-squelch threshold for the currently active
+    /// mode. Unit depends on the mode: normalized envelope ratio
+    /// for Syllabic, dB for Snr. No-op when mode is Off.
+    SetVoiceSquelchThreshold(f32),
     /// Set the audio output device by `PipeWire` node name.
     SetAudioDevice(String),
     /// Switch the source type (stops current source if running).
@@ -197,6 +212,14 @@ mod tests {
         assert!(matches!(open, DspToUi::CtcssSustainedChanged(true)));
         let closed = DspToUi::CtcssSustainedChanged(false);
         assert!(matches!(closed, DspToUi::CtcssSustainedChanged(false)));
+    }
+
+    #[test]
+    fn voice_squelch_open_changed_message_constructs() {
+        let open = DspToUi::VoiceSquelchOpenChanged(true);
+        assert!(matches!(open, DspToUi::VoiceSquelchOpenChanged(true)));
+        let closed = DspToUi::VoiceSquelchOpenChanged(false);
+        assert!(matches!(closed, DspToUi::VoiceSquelchOpenChanged(false)));
     }
 
     #[test]
@@ -306,6 +329,31 @@ mod tests {
         let ctcss_thresh = UiToDsp::SetCtcssThreshold(0.15);
         assert!(
             matches!(ctcss_thresh, UiToDsp::SetCtcssThreshold(t) if (t - 0.15).abs() < f32::EPSILON)
+        );
+
+        let vs_off = UiToDsp::SetVoiceSquelchMode(VoiceSquelchMode::Off);
+        assert!(matches!(
+            vs_off,
+            UiToDsp::SetVoiceSquelchMode(VoiceSquelchMode::Off)
+        ));
+
+        let vs_syl = UiToDsp::SetVoiceSquelchMode(VoiceSquelchMode::Syllabic { threshold: 0.15 });
+        assert!(matches!(
+            vs_syl,
+            UiToDsp::SetVoiceSquelchMode(VoiceSquelchMode::Syllabic { threshold })
+                if (threshold - 0.15).abs() < f32::EPSILON
+        ));
+
+        let vs_snr = UiToDsp::SetVoiceSquelchMode(VoiceSquelchMode::Snr { threshold_db: 6.0 });
+        assert!(matches!(
+            vs_snr,
+            UiToDsp::SetVoiceSquelchMode(VoiceSquelchMode::Snr { threshold_db })
+                if (threshold_db - 6.0).abs() < f32::EPSILON
+        ));
+
+        let vs_thresh = UiToDsp::SetVoiceSquelchThreshold(0.2);
+        assert!(
+            matches!(vs_thresh, UiToDsp::SetVoiceSquelchThreshold(t) if (t - 0.2).abs() < f32::EPSILON)
         );
 
         let device = UiToDsp::SetAudioDevice("default".to_string());

--- a/crates/sdr-dsp/Cargo.toml
+++ b/crates/sdr-dsp/Cargo.toml
@@ -9,7 +9,11 @@ repository.workspace = true
 [dependencies]
 sdr-types.workspace = true
 rustfft.workspace = true
+serde.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-dsp/src/lib.rs
+++ b/crates/sdr-dsp/src/lib.rs
@@ -21,4 +21,5 @@ pub mod noise;
 pub mod stereo;
 pub mod taps;
 pub mod tone_detect;
+pub mod voice_squelch;
 pub mod window;

--- a/crates/sdr-dsp/src/voice_squelch.rs
+++ b/crates/sdr-dsp/src/voice_squelch.rs
@@ -1,0 +1,945 @@
+//! Voice-activity squelch — speech-shape detectors that gate the
+//! speaker path after the RF-level [`PowerSquelch`] and any
+//! CTCSS tone gate have already opened.
+//!
+//! Two detection strategies, selectable at runtime:
+//!
+//! - **Syllabic** (#270) — detects the 2–10 Hz envelope modulation
+//!   characteristic of human speech. Audio is full-wave rectified
+//!   to extract its amplitude envelope, bandpass filtered to the
+//!   syllabic rate band, and the short-term RMS of that filtered
+//!   envelope is compared against a threshold. Speech produces
+//!   strong envelope modulation in the ~4 Hz region that music,
+//!   continuous tones, hiss, and most data modes lack.
+//! - **Snr** (#271) — detects voice-band signal energy above
+//!   out-of-voice-band noise energy. Parallel bandpass filters
+//!   carve the audio into an in-voice-band region (telephone
+//!   voice ~300–3000 Hz) and an out-of-voice-band reference
+//!   (below 200 Hz + above 5000 Hz); the ratio of their RMS
+//!   values, expressed in dB, is compared against a threshold.
+//!   Scale-invariant across fading.
+//!
+//! Both run on the post-demod mono 48 kHz signal in
+//! [`sdr_radio::af_chain::AfChain`] and produce a boolean gate
+//! state via [`VoiceSquelch::is_open`]. The gate state is
+//! sampled per block; block-level AND-gating with other squelch
+//! stages lives in the AF chain, not here.
+//!
+//! [`PowerSquelch`]: crate::noise::PowerSquelch
+
+use sdr_types::DspError;
+
+/// Canonical audio sample rate the detectors are calibrated for.
+/// Matches `sdr-radio::af_chain::DEFAULT_AUDIO_RATE`. Both biquad
+/// coefficient sets and the RMS window length depend on this value
+/// — a different sample rate would land the filters on different
+/// physical frequencies and break the detection bands.
+pub const VOICE_SQUELCH_SAMPLE_RATE_HZ: f32 = 48_000.0;
+
+/// Short-window RMS integration length in milliseconds.
+///
+/// 100 ms is long enough to smooth out normal syllabic structure
+/// (one syllable is ~150–300 ms so the RMS window sees at least a
+/// few cycles of envelope at the 4 Hz syllabic rate) and short
+/// enough that the gate opens/closes within one utterance boundary
+/// rather than lagging by a full second.
+pub const VOICE_SQUELCH_RMS_WINDOW_MS: f32 = 100.0;
+
+/// Short-window RMS length in samples, derived from
+/// [`VOICE_SQUELCH_RMS_WINDOW_MS`] at
+/// [`VOICE_SQUELCH_SAMPLE_RATE_HZ`].
+///
+/// Integer literal because the const-eval float → usize cast
+/// trips clippy's `cast_*` lints in const context. The compile-
+/// time assertion below catches drift if either input constant
+/// changes.
+pub const VOICE_SQUELCH_RMS_WINDOW_SAMPLES: usize = 4_800;
+
+// Sanity check: if anyone touches the ms or sample rate constants
+// without also updating VOICE_SQUELCH_RMS_WINDOW_SAMPLES, this
+// fails to compile.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::float_cmp
+)]
+const _: () = {
+    let derived = (VOICE_SQUELCH_RMS_WINDOW_MS * VOICE_SQUELCH_SAMPLE_RATE_HZ / 1000.0) as usize;
+    assert!(
+        derived == VOICE_SQUELCH_RMS_WINDOW_SAMPLES,
+        "VOICE_SQUELCH_RMS_WINDOW_SAMPLES out of sync with MS / SAMPLE_RATE"
+    );
+};
+
+/// Tolerance for matching a caller-supplied sample rate against
+/// [`VOICE_SQUELCH_SAMPLE_RATE_HZ`]. The biquad coefficients
+/// encode the physical sample rate at construction time, so
+/// running the detector at a different rate would land the
+/// filter bands on the wrong frequencies and break detection.
+/// The constructor rejects any rate outside this tolerance.
+const SAMPLE_RATE_MATCH_EPSILON_HZ: f32 = 0.5;
+
+// ─── Syllabic detector parameters ────────────────────────────
+
+/// Center frequency of the syllabic-envelope bandpass (Hz).
+///
+/// Human speech has a characteristic ~4 Hz syllable rate; the
+/// BPF centered here with moderate Q captures the 2–10 Hz
+/// region where syllable-rate modulation lives while rejecting
+/// both DC (slow level changes) and higher-frequency envelope
+/// components (which would come from speech formants, not
+/// syllabic structure).
+const SYLLABIC_BPF_CENTER_HZ: f32 = 4.0;
+
+/// Q factor for the syllabic-envelope bandpass. `Q = 1.5` gives
+/// a ~2.7 Hz half-power bandwidth centered at 4 Hz, which
+/// approximately covers the 2–6 Hz core of natural speech
+/// syllable rate without bleeding into 10+ Hz phonetic detail.
+const SYLLABIC_BPF_Q: f32 = 1.5;
+
+/// Default detection threshold for the syllabic detector —
+/// unitless because the syllabic envelope RMS is normalized by
+/// the full-signal RMS to make it scale-invariant. See
+/// [`SyllabicDetector::process`] for the exact ratio definition.
+///
+/// 0.15 is an empirically reasonable starting point; the value
+/// will likely want tuning once real-world scanner audio is
+/// available.
+pub const VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD: f32 = 0.15;
+
+// ─── SNR detector parameters ─────────────────────────────────
+
+/// In-voice-band BPF center frequency (Hz) — roughly the
+/// geometric midpoint of the telephone voice band 300–3400 Hz.
+const SNR_IN_BAND_CENTER_HZ: f32 = 1_000.0;
+
+/// In-voice-band BPF Q. `Q = 0.7` gives a ~1400 Hz bandwidth
+/// centered at 1 kHz, roughly spanning 300–1700 Hz — covers
+/// the fundamental + first two formants of typical speech
+/// where the bulk of voice energy lives.
+const SNR_IN_BAND_Q: f32 = 0.7;
+
+/// Out-of-voice-band BPF center frequency (Hz) — high enough
+/// to miss sibilance (which has voice energy up to ~7.5 kHz),
+/// low enough to catch broadband hiss and adjacent-channel bleed
+/// that sits well above the voice band.
+const SNR_OUT_OF_BAND_CENTER_HZ: f32 = 12_000.0;
+
+/// Out-of-band BPF Q. Matched to the in-band Q so the two
+/// filters have comparable bandwidth; makes the ratio easier
+/// to reason about as "power in a typical-voice-bandwidth
+/// slice of one region vs. the other."
+const SNR_OUT_OF_BAND_Q: f32 = 0.7;
+
+/// Default SNR threshold in dB. `+6 dB` means the in-voice-band
+/// RMS has to be at least 2× the out-of-voice-band RMS for the
+/// gate to open — comfortable for intelligible voice, tight
+/// enough to reject music and pure noise.
+pub const VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB: f32 = 6.0;
+
+/// Noise floor clamp (linear) for the SNR ratio divisor. Without
+/// this, a silent out-of-voice-band slice produces a division by
+/// near-zero and the SNR blows up to +∞, opening the gate on
+/// pure silence. Clamping the denominator at a small positive
+/// value caps the maximum reported SNR at a sane finite number.
+const SNR_OUT_OF_BAND_FLOOR: f32 = 1e-6;
+
+/// User-selectable voice-activity squelch mode.
+///
+/// `Off` is the default; no gate is applied and audio passes
+/// through unchanged (the detectors are not even constructed).
+/// `Syllabic(threshold)` and `Snr(threshold_db)` carry their
+/// per-variant threshold inline so the DSP layer only has to
+/// look at the variant to know what comparison to apply.
+///
+/// Serialized form: `{"kind":"off"}`,
+/// `{"kind":"syllabic","threshold":0.15}`, or
+/// `{"kind":"snr","threshold_db":6.0}` — tagged representation
+/// so bookmark JSON is self-describing and round-trips cleanly
+/// through serde.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum VoiceSquelchMode {
+    /// No voice squelch — audio passes through unchanged.
+    Off,
+    /// Syllabic detector: speech-cadence envelope modulation.
+    /// Threshold is unitless (normalized envelope ratio).
+    Syllabic {
+        /// Detection threshold; compare against
+        /// `VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD`.
+        threshold: f32,
+    },
+    /// SNR detector: voice-band vs out-of-voice-band energy ratio.
+    /// Threshold is in dB.
+    Snr {
+        /// Detection threshold in dB; compare against
+        /// `VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB`.
+        threshold_db: f32,
+    },
+}
+
+impl VoiceSquelchMode {
+    /// Returns `true` if the mode is anything other than
+    /// [`Self::Off`] — convenient for the UI's "should I show
+    /// a threshold slider" check.
+    #[must_use]
+    pub fn is_active(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+}
+
+// ─── Biquad BPF ──────────────────────────────────────────────
+
+/// Second-order IIR bandpass biquad, constant-skirt-gain form.
+///
+/// Coefficients follow the Audio EQ Cookbook (Robert Bristow-
+/// Johnson, 2005-09-04):
+/// ```text
+/// w0    = 2π · f_center / f_s
+/// alpha = sin(w0) / (2·Q)
+/// b0    =  sin(w0) / 2   (= Q · alpha)
+/// b1    =  0
+/// b2    = -sin(w0) / 2
+/// a0    = 1 + alpha
+/// a1    = -2·cos(w0)
+/// a2    = 1 - alpha
+/// ```
+/// Coefficients are normalized by `a0` at construction time so
+/// the per-sample loop is six multiplies and four adds with no
+/// divisions.
+///
+/// Private to this module — the syllabic and SNR detectors are
+/// the only callers. The existing `sdr-dsp::filter::NotchFilter`
+/// has very similar shape but is a band-REJECT filter, not band-
+/// PASS, and the cookbook formulas differ in the numerator.
+struct BandpassBiquad {
+    b0: f32,
+    b2: f32,
+    a1: f32,
+    a2: f32,
+    x1: f32,
+    x2: f32,
+    y1: f32,
+    y2: f32,
+}
+
+impl BandpassBiquad {
+    fn new(center_hz: f32, q: f32, sample_rate_hz: f32) -> Self {
+        let w0 = core::f32::consts::TAU * center_hz / sample_rate_hz;
+        let (sin_w0, cos_w0) = w0.sin_cos();
+        let alpha = sin_w0 / (2.0 * q);
+
+        // Constant-skirt-gain bandpass (b0 = sin(w0)/2 = Q·alpha).
+        let b0_raw = sin_w0 / 2.0;
+        let b2_raw = -sin_w0 / 2.0;
+        let a0 = 1.0 + alpha;
+        let a1 = -2.0 * cos_w0;
+        let a2 = 1.0 - alpha;
+
+        Self {
+            b0: b0_raw / a0,
+            b2: b2_raw / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
+            x1: 0.0,
+            x2: 0.0,
+            y1: 0.0,
+            y2: 0.0,
+        }
+    }
+
+    /// Reset delay elements to zero — used on mode change so
+    /// stale history doesn't leak across sessions.
+    fn reset(&mut self) {
+        self.x1 = 0.0;
+        self.x2 = 0.0;
+        self.y1 = 0.0;
+        self.y2 = 0.0;
+    }
+
+    /// Process a single sample through the BPF, Direct Form I.
+    /// Hot path — marked `#[inline]` so the enclosing loop can
+    /// flatten the call. Note that `b1 = 0` for the constant-
+    /// skirt-gain bandpass so that term is omitted entirely.
+    #[inline]
+    fn process_sample(&mut self, x: f32) -> f32 {
+        let y = self.b0 * x + self.b2 * self.x2 - self.a1 * self.y1 - self.a2 * self.y2;
+        self.x2 = self.x1;
+        self.x1 = x;
+        self.y2 = self.y1;
+        self.y1 = y;
+        y
+    }
+}
+
+// ─── Rolling RMS ─────────────────────────────────────────────
+
+/// Rolling sum-of-squares over the last
+/// [`VOICE_SQUELCH_RMS_WINDOW_SAMPLES`] samples, implemented as
+/// a ring buffer over squared inputs. RMS is recovered on demand
+/// by dividing by the window length and taking the square root.
+///
+/// Constant-time per sample regardless of window length — each
+/// update adds one squared sample, subtracts the outgoing one,
+/// and advances the ring pointer.
+struct RollingRms {
+    squares: Vec<f32>,
+    head: usize,
+    sum_sq: f32,
+}
+
+impl RollingRms {
+    fn new() -> Self {
+        Self {
+            squares: vec![0.0; VOICE_SQUELCH_RMS_WINDOW_SAMPLES],
+            head: 0,
+            sum_sq: 0.0,
+        }
+    }
+
+    fn reset(&mut self) {
+        for v in &mut self.squares {
+            *v = 0.0;
+        }
+        self.head = 0;
+        self.sum_sq = 0.0;
+    }
+
+    /// Push one sample and update the rolling sum.
+    #[inline]
+    fn push(&mut self, x: f32) {
+        let sq = x * x;
+        // Subtract the oldest squared sample being overwritten,
+        // add the new one. Clamp to 0 on the lower bound so f32
+        // rounding can't drive sum_sq negative over long runs.
+        self.sum_sq = (self.sum_sq - self.squares[self.head] + sq).max(0.0);
+        self.squares[self.head] = sq;
+        self.head = (self.head + 1) % VOICE_SQUELCH_RMS_WINDOW_SAMPLES;
+    }
+
+    /// Current RMS over the window.
+    #[inline]
+    fn rms(&self) -> f32 {
+        #[allow(clippy::cast_precision_loss)]
+        let n = VOICE_SQUELCH_RMS_WINDOW_SAMPLES as f32;
+        (self.sum_sq / n).sqrt()
+    }
+}
+
+// ─── Syllabic detector ───────────────────────────────────────
+
+/// Syllabic-envelope voice squelch implementation.
+///
+/// Pipeline per sample:
+/// 1. Full-wave rectify: `|x|`
+/// 2. Bandpass the rectified envelope at ~4 Hz (syllable rate)
+/// 3. Update rolling RMS of the BPF output (envelope RMS)
+/// 4. Update rolling RMS of the raw input (signal RMS) for
+///    normalization — the gate decision compares the envelope
+///    RMS against a fraction of the signal RMS, which makes
+///    the threshold scale-invariant to audio level
+///
+/// Gate opens when `envelope_rms > threshold * signal_rms` AND
+/// `signal_rms` is above a tiny floor (pure-silence rejection).
+struct SyllabicDetector {
+    envelope_bpf: BandpassBiquad,
+    envelope_rms: RollingRms,
+    signal_rms: RollingRms,
+    threshold: f32,
+}
+
+impl SyllabicDetector {
+    fn new(threshold: f32, sample_rate_hz: f32) -> Self {
+        Self {
+            envelope_bpf: BandpassBiquad::new(
+                SYLLABIC_BPF_CENTER_HZ,
+                SYLLABIC_BPF_Q,
+                sample_rate_hz,
+            ),
+            envelope_rms: RollingRms::new(),
+            signal_rms: RollingRms::new(),
+            threshold,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.envelope_bpf.reset();
+        self.envelope_rms.reset();
+        self.signal_rms.reset();
+    }
+
+    fn set_threshold(&mut self, threshold: f32) {
+        self.threshold = threshold;
+    }
+
+    /// Feed a block of mono audio samples and return the gate
+    /// state at the END of the block. Caller gets one bool per
+    /// process call regardless of block size.
+    fn process(&mut self, samples: &[f32]) -> bool {
+        for &x in samples {
+            // Full-wave rectify for envelope extraction. Using
+            // abs() rather than x² + sqrt because the BPF that
+            // follows is linear and the spectral content we care
+            // about (syllabic rate) sits in the rectified
+            // envelope regardless of whether we take |x| or x².
+            let rectified = x.abs();
+            let envelope = self.envelope_bpf.process_sample(rectified);
+            self.envelope_rms.push(envelope);
+            self.signal_rms.push(x);
+        }
+
+        let env = self.envelope_rms.rms();
+        let sig = self.signal_rms.rms();
+        // Pure-silence guard: if the whole signal is effectively
+        // zero, don't let the ratio blow up. The raw RMS must
+        // also clear a tiny floor before we even consider the
+        // envelope ratio.
+        if sig < SNR_OUT_OF_BAND_FLOOR {
+            return false;
+        }
+        env > self.threshold * sig
+    }
+}
+
+// ─── SNR detector ────────────────────────────────────────────
+
+/// Voice-band vs out-of-voice-band SNR detector.
+///
+/// Pipeline per sample:
+/// 1. Feed the in-band BPF (300–1700 Hz) and update its RMS
+/// 2. Feed the out-of-band BPF (high-pass reference region) and
+///    update its RMS
+/// 3. At end of block, compute `20·log10(in_rms / max(out_rms, floor))`
+/// 4. Gate opens when SNR (dB) > threshold
+struct SnrDetector {
+    in_band_bpf: BandpassBiquad,
+    out_of_band_bpf: BandpassBiquad,
+    in_band_rms: RollingRms,
+    out_of_band_rms: RollingRms,
+    threshold_db: f32,
+}
+
+impl SnrDetector {
+    fn new(threshold_db: f32, sample_rate_hz: f32) -> Self {
+        Self {
+            in_band_bpf: BandpassBiquad::new(SNR_IN_BAND_CENTER_HZ, SNR_IN_BAND_Q, sample_rate_hz),
+            out_of_band_bpf: BandpassBiquad::new(
+                SNR_OUT_OF_BAND_CENTER_HZ,
+                SNR_OUT_OF_BAND_Q,
+                sample_rate_hz,
+            ),
+            in_band_rms: RollingRms::new(),
+            out_of_band_rms: RollingRms::new(),
+            threshold_db,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.in_band_bpf.reset();
+        self.out_of_band_bpf.reset();
+        self.in_band_rms.reset();
+        self.out_of_band_rms.reset();
+    }
+
+    fn set_threshold_db(&mut self, threshold_db: f32) {
+        self.threshold_db = threshold_db;
+    }
+
+    fn process(&mut self, samples: &[f32]) -> bool {
+        for &x in samples {
+            let in_band = self.in_band_bpf.process_sample(x);
+            let out_band = self.out_of_band_bpf.process_sample(x);
+            self.in_band_rms.push(in_band);
+            self.out_of_band_rms.push(out_band);
+        }
+
+        let in_rms = self.in_band_rms.rms();
+        let out_rms = self.out_of_band_rms.rms().max(SNR_OUT_OF_BAND_FLOOR);
+        // Pure-silence guard: if the in-band is at or below the
+        // floor too, skip the ratio entirely — nothing to gate.
+        if in_rms < SNR_OUT_OF_BAND_FLOOR {
+            return false;
+        }
+        let snr_db = 20.0 * (in_rms / out_rms).log10();
+        snr_db > self.threshold_db
+    }
+}
+
+// ─── Public VoiceSquelch ─────────────────────────────────────
+
+/// Top-level voice-activity squelch. Owns the active detector
+/// (if any) and the current gate state. Construct once per
+/// session, feed blocks of mono audio via
+/// [`Self::accept_samples`], and consume the boolean returned
+/// by [`Self::is_open`].
+///
+/// Off mode is cheap: no detector is constructed, `accept_samples`
+/// is a no-op, and `is_open` always returns `true` (gate is
+/// permanently open). Caller can treat `is_open` uniformly.
+pub struct VoiceSquelch {
+    mode: VoiceSquelchMode,
+    sample_rate_hz: f32,
+    syllabic: Option<SyllabicDetector>,
+    snr: Option<SnrDetector>,
+    open: bool,
+}
+
+impl VoiceSquelch {
+    /// Construct a new voice squelch in the given mode at the
+    /// canonical sample rate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DspError::InvalidParameter`] if `sample_rate_hz`
+    /// differs from [`VOICE_SQUELCH_SAMPLE_RATE_HZ`] by more than
+    /// [`SAMPLE_RATE_MATCH_EPSILON_HZ`], or if the mode carries a
+    /// non-finite threshold.
+    pub fn new(mode: VoiceSquelchMode, sample_rate_hz: f32) -> Result<Self, DspError> {
+        if !sample_rate_hz.is_finite() {
+            return Err(DspError::InvalidParameter(format!(
+                "voice squelch sample rate must be finite, got {sample_rate_hz}"
+            )));
+        }
+        if (sample_rate_hz - VOICE_SQUELCH_SAMPLE_RATE_HZ).abs() > SAMPLE_RATE_MATCH_EPSILON_HZ {
+            return Err(DspError::InvalidParameter(format!(
+                "voice squelch is calibrated for {VOICE_SQUELCH_SAMPLE_RATE_HZ} Hz, got {sample_rate_hz}"
+            )));
+        }
+
+        let (syllabic, snr) = match mode {
+            VoiceSquelchMode::Off => (None, None),
+            VoiceSquelchMode::Syllabic { threshold } => {
+                if !threshold.is_finite() || threshold <= 0.0 {
+                    return Err(DspError::InvalidParameter(format!(
+                        "syllabic threshold must be finite and positive, got {threshold}"
+                    )));
+                }
+                (Some(SyllabicDetector::new(threshold, sample_rate_hz)), None)
+            }
+            VoiceSquelchMode::Snr { threshold_db } => {
+                if !threshold_db.is_finite() {
+                    return Err(DspError::InvalidParameter(format!(
+                        "SNR threshold must be finite, got {threshold_db}"
+                    )));
+                }
+                (None, Some(SnrDetector::new(threshold_db, sample_rate_hz)))
+            }
+        };
+
+        // Off mode starts open (gate is permanently open); other
+        // modes start closed and have to warm up the detector
+        // before opening. This matches the CTCSS behavior — gate
+        // is closed at start and has to confirm before it opens.
+        let open = matches!(mode, VoiceSquelchMode::Off);
+
+        Ok(Self {
+            mode,
+            sample_rate_hz,
+            syllabic,
+            snr,
+            open,
+        })
+    }
+
+    /// Current squelch mode.
+    pub fn mode(&self) -> VoiceSquelchMode {
+        self.mode
+    }
+
+    /// Current gate state. `true` means audio should flow through
+    /// to the speaker; `false` means mute. Always `true` in Off
+    /// mode.
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Reset detector state to "closed" and drop any history
+    /// that survived from the previous block. Called on mode
+    /// change or session boundary.
+    pub fn reset(&mut self) {
+        if let Some(s) = &mut self.syllabic {
+            s.reset();
+        }
+        if let Some(s) = &mut self.snr {
+            s.reset();
+        }
+        self.open = matches!(self.mode, VoiceSquelchMode::Off);
+    }
+
+    /// Swap the mode in place. Drops the previous detector (if
+    /// any) and constructs a new one. Cheap — the detectors
+    /// allocate one ring buffer each, which is ~19 KiB at the
+    /// current window length, per detector.
+    ///
+    /// # Errors
+    ///
+    /// Propagates validation errors from [`Self::new`] with the
+    /// previous state preserved unchanged on failure.
+    pub fn set_mode(&mut self, mode: VoiceSquelchMode) -> Result<(), DspError> {
+        // Build the replacement first. If it errors we leave
+        // `self` unchanged so a bad setter call doesn't leave
+        // the caller with a half-constructed squelch.
+        let replacement = Self::new(mode, self.sample_rate_hz)?;
+        *self = replacement;
+        Ok(())
+    }
+
+    /// Update the threshold of the active detector. Returns
+    /// [`DspError::InvalidParameter`] if the threshold is non-
+    /// finite; the setter is a silent no-op in Off mode.
+    pub fn set_threshold(&mut self, threshold: f32) -> Result<(), DspError> {
+        if !threshold.is_finite() {
+            return Err(DspError::InvalidParameter(format!(
+                "voice squelch threshold must be finite, got {threshold}"
+            )));
+        }
+        match &mut self.mode {
+            VoiceSquelchMode::Off => {}
+            VoiceSquelchMode::Syllabic { threshold: t } => {
+                if threshold <= 0.0 {
+                    return Err(DspError::InvalidParameter(format!(
+                        "syllabic threshold must be positive, got {threshold}"
+                    )));
+                }
+                *t = threshold;
+                if let Some(s) = &mut self.syllabic {
+                    s.set_threshold(threshold);
+                }
+            }
+            VoiceSquelchMode::Snr { threshold_db } => {
+                *threshold_db = threshold;
+                if let Some(s) = &mut self.snr {
+                    s.set_threshold_db(threshold);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Feed a block of mono audio samples and update the gate
+    /// state. Returns the post-update `is_open` value so callers
+    /// that only care about the latest state don't have to follow
+    /// up with a separate call.
+    pub fn accept_samples(&mut self, samples: &[f32]) -> bool {
+        if samples.is_empty() {
+            return self.open;
+        }
+        self.open = match self.mode {
+            VoiceSquelchMode::Off => true,
+            VoiceSquelchMode::Syllabic { .. } => {
+                self.syllabic.as_mut().is_some_and(|d| d.process(samples))
+            }
+            VoiceSquelchMode::Snr { .. } => self.snr.as_mut().is_some_and(|d| d.process(samples)),
+        };
+        self.open
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    clippy::unwrap_used,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+mod tests {
+    use super::*;
+
+    /// Build a 48 kHz mono tone at the given frequency + amplitude
+    /// for `ms` milliseconds.
+    fn tone(freq_hz: f32, amplitude: f32, ms: usize) -> Vec<f32> {
+        let n = (VOICE_SQUELCH_SAMPLE_RATE_HZ * (ms as f32) / 1000.0) as usize;
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let t = (i as f32) / VOICE_SQUELCH_SAMPLE_RATE_HZ;
+            out.push(amplitude * (core::f32::consts::TAU * freq_hz * t).sin());
+        }
+        out
+    }
+
+    /// Build a 48 kHz mono "syllable-modulated" signal: a 1 kHz
+    /// carrier whose amplitude is itself modulated by a slow
+    /// sine at `syllable_hz`. Approximates speech envelope
+    /// structure closely enough to exercise the syllabic
+    /// detector.
+    fn syllable_modulated(carrier_hz: f32, syllable_hz: f32, ms: usize) -> Vec<f32> {
+        let n = (VOICE_SQUELCH_SAMPLE_RATE_HZ * (ms as f32) / 1000.0) as usize;
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let t = (i as f32) / VOICE_SQUELCH_SAMPLE_RATE_HZ;
+            // Envelope is raised cosine so it stays non-negative
+            // and looks like speech loudness structure. 0.5 + 0.5·cos
+            // oscillates between 0 and 1.
+            let envelope = 0.5 + 0.5 * (core::f32::consts::TAU * syllable_hz * t).cos();
+            let carrier = (core::f32::consts::TAU * carrier_hz * t).sin();
+            out.push(0.5 * envelope * carrier);
+        }
+        out
+    }
+
+    /// Pseudo-random white noise with bounded peak amplitude.
+    /// Uses a cheap LCG; no need for a real PRNG just for tests.
+    fn white_noise(amplitude: f32, ms: usize, seed: u64) -> Vec<f32> {
+        let n = (VOICE_SQUELCH_SAMPLE_RATE_HZ * (ms as f32) / 1000.0) as usize;
+        let mut out = Vec::with_capacity(n);
+        let mut state: u64 = seed;
+        for _ in 0..n {
+            // LCG constants from Numerical Recipes.
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            // Top 24 bits → unit float → [-1, 1]
+            let u = ((state >> 40) as f32) / ((1u64 << 24) as f32);
+            out.push(amplitude * (u * 2.0 - 1.0));
+        }
+        out
+    }
+
+    #[test]
+    fn mode_is_active_helper() {
+        assert!(!VoiceSquelchMode::Off.is_active());
+        assert!(VoiceSquelchMode::Syllabic { threshold: 0.15 }.is_active());
+        assert!(VoiceSquelchMode::Snr { threshold_db: 6.0 }.is_active());
+    }
+
+    #[test]
+    fn off_mode_always_open_and_passes_samples_through() {
+        let mut vs =
+            VoiceSquelch::new(VoiceSquelchMode::Off, VOICE_SQUELCH_SAMPLE_RATE_HZ).unwrap();
+        assert!(vs.is_open(), "Off mode should start open");
+        let samples = tone(1000.0, 0.5, 50);
+        assert!(vs.accept_samples(&samples));
+        // An empty block after any previous state shouldn't
+        // toggle the gate.
+        assert!(vs.accept_samples(&[]));
+    }
+
+    #[test]
+    fn constructor_rejects_non_canonical_sample_rate() {
+        let err = VoiceSquelch::new(VoiceSquelchMode::Off, 44_100.0);
+        assert!(err.is_err());
+        let err = VoiceSquelch::new(VoiceSquelchMode::Off, f32::NAN);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn constructor_rejects_non_finite_threshold() {
+        for t in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let err = VoiceSquelch::new(
+                VoiceSquelchMode::Syllabic { threshold: t },
+                VOICE_SQUELCH_SAMPLE_RATE_HZ,
+            );
+            assert!(err.is_err(), "syllabic threshold {t} should be rejected");
+            let err = VoiceSquelch::new(
+                VoiceSquelchMode::Snr { threshold_db: t },
+                VOICE_SQUELCH_SAMPLE_RATE_HZ,
+            );
+            assert!(err.is_err(), "snr threshold {t} should be rejected");
+        }
+    }
+
+    #[test]
+    fn syllabic_constructor_rejects_zero_or_negative_threshold() {
+        for t in [0.0_f32, -0.1, -1.0] {
+            let err = VoiceSquelch::new(
+                VoiceSquelchMode::Syllabic { threshold: t },
+                VOICE_SQUELCH_SAMPLE_RATE_HZ,
+            );
+            assert!(err.is_err(), "threshold {t} should be rejected");
+        }
+    }
+
+    #[test]
+    fn syllabic_detects_syllable_rate_modulation() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic {
+                threshold: VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+
+        // Feed 2 seconds of syllable-modulated audio at 4 Hz.
+        // That's plenty of time for the BPF to ring up and the
+        // RMS window to saturate.
+        let signal = syllable_modulated(1_000.0, 4.0, 2_000);
+        vs.accept_samples(&signal);
+        assert!(
+            vs.is_open(),
+            "syllabic detector should open on 4 Hz-modulated 1 kHz carrier"
+        );
+    }
+
+    #[test]
+    fn syllabic_rejects_continuous_tone() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic {
+                threshold: VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+
+        // Pure 1 kHz tone with constant amplitude — no syllabic
+        // modulation. Envelope is flat after the rectifier so
+        // the 4 Hz BPF sees ~0 energy.
+        let signal = tone(1_000.0, 0.5, 2_000);
+        vs.accept_samples(&signal);
+        assert!(
+            !vs.is_open(),
+            "syllabic detector should reject a continuous unmodulated tone"
+        );
+    }
+
+    #[test]
+    fn syllabic_rejects_silence() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic {
+                threshold: VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        let silence = vec![0.0_f32; 48_000];
+        vs.accept_samples(&silence);
+        assert!(!vs.is_open(), "silence should not open the gate");
+    }
+
+    #[test]
+    fn snr_detects_strong_in_band_signal() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Snr {
+                threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        // Strong 1 kHz tone — well inside the in-voice-band BPF
+        // center — and no out-of-voice-band content beyond what
+        // the biquad's finite Q leaks. SNR should be very high.
+        let signal = tone(1_000.0, 0.8, 2_000);
+        vs.accept_samples(&signal);
+        assert!(
+            vs.is_open(),
+            "SNR detector should open on strong in-voice-band tone"
+        );
+    }
+
+    #[test]
+    fn snr_rejects_broadband_noise() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Snr {
+                threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        // White noise — equal energy in every bin — so the
+        // in-band BPF and out-of-band BPF pick up the same
+        // amount once bandwidth-normalized. SNR ~ 0 dB.
+        let signal = white_noise(0.5, 2_000, 0xDEAD_BEEF);
+        vs.accept_samples(&signal);
+        assert!(!vs.is_open(), "SNR detector should reject broadband noise");
+    }
+
+    #[test]
+    fn snr_rejects_silence() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Snr {
+                threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        let silence = vec![0.0_f32; 48_000];
+        vs.accept_samples(&silence);
+        assert!(!vs.is_open(), "silence should not open the gate");
+    }
+
+    #[test]
+    fn mode_change_resets_gate_state() {
+        // Open the gate with syllabic, then switch to SNR on
+        // fresh content — gate should start closed again.
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic {
+                threshold: VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        let signal = syllable_modulated(1_000.0, 4.0, 2_000);
+        vs.accept_samples(&signal);
+        assert!(vs.is_open());
+
+        vs.set_mode(VoiceSquelchMode::Snr {
+            threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+        })
+        .unwrap();
+        assert!(!vs.is_open(), "mode change should reset gate to closed");
+    }
+
+    #[test]
+    fn mode_change_to_off_opens_gate() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic {
+                threshold: VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        assert!(!vs.is_open());
+        vs.set_mode(VoiceSquelchMode::Off).unwrap();
+        assert!(
+            vs.is_open(),
+            "Off mode should leave the gate permanently open"
+        );
+    }
+
+    #[test]
+    fn set_threshold_rejects_non_finite() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic { threshold: 0.15 },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        assert!(vs.set_threshold(f32::NAN).is_err());
+        assert!(vs.set_threshold(f32::INFINITY).is_err());
+        assert!(vs.set_threshold(f32::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn set_threshold_rejects_non_positive_for_syllabic() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic { threshold: 0.15 },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        assert!(vs.set_threshold(0.0).is_err());
+        assert!(vs.set_threshold(-0.1).is_err());
+    }
+
+    #[test]
+    fn mode_serde_round_trip() {
+        let off = VoiceSquelchMode::Off;
+        let syl = VoiceSquelchMode::Syllabic { threshold: 0.15 };
+        let snr = VoiceSquelchMode::Snr { threshold_db: 6.0 };
+        for m in [off, syl, snr] {
+            let json = serde_json::to_string(&m).unwrap();
+            let back: VoiceSquelchMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, m, "serde round-trip failed for {m:?}");
+        }
+    }
+
+    #[test]
+    fn empty_block_does_not_flip_state() {
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic { threshold: 0.15 },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+        assert!(!vs.is_open());
+        // Feeding an empty slice should be a no-op regardless
+        // of state.
+        assert!(!vs.accept_samples(&[]));
+        assert!(!vs.is_open());
+    }
+}

--- a/crates/sdr-dsp/src/voice_squelch.rs
+++ b/crates/sdr-dsp/src/voice_squelch.rs
@@ -45,6 +45,44 @@ pub const VOICE_SQUELCH_SAMPLE_RATE_HZ: f32 = 48_000.0;
 /// rather than lagging by a full second.
 pub const VOICE_SQUELCH_RMS_WINDOW_MS: f32 = 100.0;
 
+/// Hold-open time after the last "strong" detector evaluation
+/// before the gate actually closes. This is the hang time that
+/// keeps brief envelope dips during consonants, pauses between
+/// words, or momentary signal fades from chopping audio mid-
+/// utterance.
+///
+/// 500 ms is a common scanner-radio hang time — long enough to
+/// bridge the inter-word gap in natural speech (typical 200–400
+/// ms) plus a margin for consonants that briefly dip below the
+/// detector threshold, short enough that the gate still closes
+/// within one comfortable beat after a real transmission ends.
+///
+/// Works by decrementing a sample-count counter on every weak
+/// block and resetting it to the full value on every strong
+/// block; the gate only actually flips to closed when the
+/// counter hits zero. See [`VoiceSquelch::accept_samples`] for
+/// the exact state machine.
+pub const VOICE_SQUELCH_HANG_TIME_MS: f32 = 500.0;
+
+/// Hang time in samples at [`VOICE_SQUELCH_SAMPLE_RATE_HZ`].
+/// Integer literal with a compile-time sanity check below so
+/// a future retune of the ms / rate constants can't silently
+/// desync.
+pub const VOICE_SQUELCH_HANG_TIME_SAMPLES: usize = 24_000;
+
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::float_cmp
+)]
+const _: () = {
+    let derived = (VOICE_SQUELCH_HANG_TIME_MS * VOICE_SQUELCH_SAMPLE_RATE_HZ / 1000.0) as usize;
+    assert!(
+        derived == VOICE_SQUELCH_HANG_TIME_SAMPLES,
+        "VOICE_SQUELCH_HANG_TIME_SAMPLES out of sync with MS / SAMPLE_RATE"
+    );
+};
+
 /// Short-window RMS length in samples, derived from
 /// [`VOICE_SQUELCH_RMS_WINDOW_MS`] at
 /// [`VOICE_SQUELCH_SAMPLE_RATE_HZ`].
@@ -482,6 +520,12 @@ pub struct VoiceSquelch {
     syllabic: Option<SyllabicDetector>,
     snr: Option<SnrDetector>,
     open: bool,
+    /// Samples remaining before the gate actually transitions
+    /// from open to closed. Driven by [`VOICE_SQUELCH_HANG_TIME_SAMPLES`]
+    /// — see [`Self::accept_samples`] for the state machine. Zero
+    /// when the gate is closed OR when the mode is `Off` (which
+    /// is always-open anyway).
+    hang_samples_remaining: usize,
 }
 
 impl VoiceSquelch {
@@ -500,7 +544,23 @@ impl VoiceSquelch {
                 "voice squelch sample rate must be finite, got {sample_rate_hz}"
             )));
         }
-        if (sample_rate_hz - VOICE_SQUELCH_SAMPLE_RATE_HZ).abs() > SAMPLE_RATE_MATCH_EPSILON_HZ {
+        // Only enforce the canonical-sample-rate check when the
+        // mode actually builds a detector. `Off` constructs no
+        // filters and never touches the RMS path, so gating it
+        // on the 48 kHz sample rate would break headless or
+        // future non-48-kHz audio pipelines whose `AfChain`
+        // instantiates `VoiceSquelch::new(Off, rate)`
+        // unconditionally at startup — the detector wouldn't be
+        // active but the constructor would still fail. The rate
+        // is baked into each biquad's coefficients at build
+        // time, so when the user does flip to Syllabic or Snr
+        // on a non-48-kHz chain, `set_mode` will surface the
+        // mismatch then (and the AfChain-level rate check has
+        // already rejected non-48-kHz chains at
+        // [`sdr_radio::af_chain::AfChain::new`] in practice).
+        if mode.is_active()
+            && (sample_rate_hz - VOICE_SQUELCH_SAMPLE_RATE_HZ).abs() > SAMPLE_RATE_MATCH_EPSILON_HZ
+        {
             return Err(DspError::InvalidParameter(format!(
                 "voice squelch is calibrated for {VOICE_SQUELCH_SAMPLE_RATE_HZ} Hz, got {sample_rate_hz}"
             )));
@@ -538,6 +598,7 @@ impl VoiceSquelch {
             syllabic,
             snr,
             open,
+            hang_samples_remaining: 0,
         })
     }
 
@@ -564,6 +625,7 @@ impl VoiceSquelch {
             s.reset();
         }
         self.open = matches!(self.mode, VoiceSquelchMode::Off);
+        self.hang_samples_remaining = 0;
     }
 
     /// Swap the mode in place. Drops the previous detector (if
@@ -620,17 +682,73 @@ impl VoiceSquelch {
     /// state. Returns the post-update `is_open` value so callers
     /// that only care about the latest state don't have to follow
     /// up with a separate call.
+    ///
+    /// # Hang-time hysteresis
+    ///
+    /// The gate does NOT flip straight from open to closed on a
+    /// single weak-block evaluation. That would chop audio mid-
+    /// word whenever a consonant or brief pause dips below the
+    /// detector's threshold. Instead:
+    ///
+    /// - Each "strong" block (detector reports open) resets a
+    ///   `hang_samples_remaining` counter to
+    ///   [`VOICE_SQUELCH_HANG_TIME_SAMPLES`] (500 ms by default).
+    /// - Each "weak" block (detector reports closed) decrements
+    ///   the counter by `samples.len()`.
+    /// - The gate only actually transitions to closed when the
+    ///   counter hits zero — i.e. after 500 ms of sustained
+    ///   weakness with no intervening strong block.
+    ///
+    /// Opening is immediate (first strong block after a closed
+    /// state flips the gate open and resets the counter); only
+    /// the close direction is gated by hang time. This is the
+    /// standard scanner-squelch pattern.
+    ///
+    /// `Off` mode bypasses the whole state machine and always
+    /// returns `true`.
     pub fn accept_samples(&mut self, samples: &[f32]) -> bool {
         if samples.is_empty() {
             return self.open;
         }
-        self.open = match self.mode {
-            VoiceSquelchMode::Off => true,
+
+        // Off mode short-circuit: no detector, gate permanently
+        // open, hang counter irrelevant.
+        if matches!(self.mode, VoiceSquelchMode::Off) {
+            self.open = true;
+            return true;
+        }
+
+        let strong = match self.mode {
+            VoiceSquelchMode::Off => unreachable!("handled above"),
             VoiceSquelchMode::Syllabic { .. } => {
                 self.syllabic.as_mut().is_some_and(|d| d.process(samples))
             }
             VoiceSquelchMode::Snr { .. } => self.snr.as_mut().is_some_and(|d| d.process(samples)),
         };
+
+        if strong {
+            // Strong verdict: open the gate immediately and
+            // fully reload the hang counter so the next weak
+            // block has the full 500 ms to elapse before we
+            // consider closing.
+            self.open = true;
+            self.hang_samples_remaining = VOICE_SQUELCH_HANG_TIME_SAMPLES;
+        } else if self.open {
+            // Weak verdict while the gate is open: bleed the
+            // hang counter down by this block's sample length.
+            // `saturating_sub` is important — the final block
+            // before close might carry more samples than the
+            // remaining budget, and we don't want an underflow
+            // panic.
+            self.hang_samples_remaining = self.hang_samples_remaining.saturating_sub(samples.len());
+            if self.hang_samples_remaining == 0 {
+                self.open = false;
+            }
+        }
+        // Weak verdict while already closed: stay closed. No
+        // state change. (Hang counter is already at 0 in this
+        // branch so nothing to decrement anyway.)
+
         self.open
     }
 }
@@ -714,11 +832,32 @@ mod tests {
     }
 
     #[test]
-    fn constructor_rejects_non_canonical_sample_rate() {
-        let err = VoiceSquelch::new(VoiceSquelchMode::Off, 44_100.0);
+    fn constructor_rejects_non_canonical_sample_rate_for_active_modes() {
+        // Active modes (Syllabic / Snr) must reject non-48-kHz
+        // rates because their biquad coefficients are calibrated
+        // to the canonical rate.
+        let err = VoiceSquelch::new(VoiceSquelchMode::Syllabic { threshold: 0.15 }, 44_100.0);
         assert!(err.is_err());
+        let err = VoiceSquelch::new(VoiceSquelchMode::Snr { threshold_db: 6.0 }, 44_100.0);
+        assert!(err.is_err());
+
+        // Non-finite rate is rejected for ANY mode (Off included)
+        // because the finite check comes before the mode dispatch.
         let err = VoiceSquelch::new(VoiceSquelchMode::Off, f32::NAN);
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn off_mode_accepts_any_finite_sample_rate() {
+        // Off mode bypasses the sample-rate calibration check
+        // because it constructs no detector and never touches the
+        // biquad path. A headless `AfChain` configured for an
+        // exotic audio sink (e.g. 44.1 kHz CoreAudio) must be
+        // able to construct a `VoiceSquelch` in its default Off
+        // state without failing.
+        assert!(VoiceSquelch::new(VoiceSquelchMode::Off, 44_100.0).is_ok());
+        assert!(VoiceSquelch::new(VoiceSquelchMode::Off, 96_000.0).is_ok());
+        assert!(VoiceSquelch::new(VoiceSquelchMode::Off, 16_000.0).is_ok());
     }
 
     #[test]
@@ -927,6 +1066,68 @@ mod tests {
             let back: VoiceSquelchMode = serde_json::from_str(&json).unwrap();
             assert_eq!(back, m, "serde round-trip failed for {m:?}");
         }
+    }
+
+    #[test]
+    fn syllabic_hang_time_bridges_brief_silence_gap() {
+        // Simulates a "word + consonant pause + word" structure
+        // by concatenating two 1-second syllable-modulated
+        // segments with a 200 ms silence gap in between. The gap
+        // is shorter than VOICE_SQUELCH_HANG_TIME_MS (500 ms),
+        // so the gate should stay open through the whole
+        // sequence instead of chopping on the silence.
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic {
+                threshold: VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+
+        // Word 1 — warm up and open the gate.
+        let word1 = syllable_modulated(1_000.0, 4.0, 1_000);
+        vs.accept_samples(&word1);
+        assert!(vs.is_open(), "gate should open on first word");
+
+        // 200 ms of silence — half the 500 ms hang time. The
+        // gate should stay open because the counter hasn't
+        // decremented all the way to zero yet.
+        let short_gap = vec![0.0_f32; (VOICE_SQUELCH_SAMPLE_RATE_HZ * 0.2) as usize];
+        vs.accept_samples(&short_gap);
+        assert!(
+            vs.is_open(),
+            "200 ms silence gap < 500 ms hang should NOT close the gate mid-word"
+        );
+    }
+
+    #[test]
+    fn syllabic_hang_time_closes_after_sustained_silence() {
+        // Opposite of the bridging test — after the gate opens,
+        // feed sustained silence longer than the hang time and
+        // verify the gate actually closes.
+        let mut vs = VoiceSquelch::new(
+            VoiceSquelchMode::Syllabic {
+                threshold: VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            },
+            VOICE_SQUELCH_SAMPLE_RATE_HZ,
+        )
+        .unwrap();
+
+        let word = syllable_modulated(1_000.0, 4.0, 1_000);
+        vs.accept_samples(&word);
+        assert!(vs.is_open(), "gate should open on speech");
+
+        // 1 second of silence — double the 500 ms hang time.
+        // After feeding it in 100 ms chunks the hang counter
+        // must eventually hit zero and close the gate.
+        let silence_chunk = vec![0.0_f32; (VOICE_SQUELCH_SAMPLE_RATE_HZ * 0.1) as usize];
+        for _ in 0..10 {
+            vs.accept_samples(&silence_chunk);
+        }
+        assert!(
+            !vs.is_open(),
+            "1 second of silence must eventually close the gate"
+        );
     }
 
     #[test]

--- a/crates/sdr-radio/src/af_chain.rs
+++ b/crates/sdr-radio/src/af_chain.rs
@@ -6,6 +6,7 @@
 use sdr_dsp::filter::{DeemphasisFilter, NotchFilter};
 use sdr_dsp::multirate::RationalResampler;
 use sdr_dsp::tone_detect::{CTCSS_DEFAULT_THRESHOLD, CtcssDetector, ctcss_tone_index};
+use sdr_dsp::voice_squelch::{VoiceSquelch, VoiceSquelchMode};
 use sdr_types::{Complex, DspError, Stereo};
 
 /// Default audio output sample rate (Hz).
@@ -131,6 +132,15 @@ pub struct AfChain {
     /// Mono downmix scratch buffer fed to the detector. Reused
     /// across calls to avoid per-block allocation on the hot path.
     ctcss_mono_buf: Vec<f32>,
+    /// Voice-activity squelch (syllabic or SNR). Runs on the
+    /// same post-deemph mono downmix as the CTCSS detector and
+    /// contributes a second AF-level gate. Unlike CTCSS the
+    /// `VoiceSquelch` always exists — `Off` mode is represented
+    /// inside the type and returns `is_open() == true`
+    /// unconditionally, so the hot path never branches on
+    /// `Option::is_some`. See `sdr_dsp::voice_squelch` for the
+    /// detector algorithms.
+    voice_squelch: VoiceSquelch,
     /// Scratch buffer for deemphasis L input channel.
     deemp_buf_l: Vec<f32>,
     /// Scratch buffer for deemphasis R input channel.
@@ -170,6 +180,14 @@ impl AfChain {
         #[allow(clippy::cast_possible_truncation)]
         let audio_rate_f32 = audio_sample_rate as f32;
 
+        // Voice squelch defaults to Off (permanently open), which
+        // matches the pre-PR behavior — existing users see no
+        // audio change until they explicitly pick Syllabic or
+        // Snr from the UI. Constructor error propagates (can
+        // only happen on a non-canonical sample rate, matching
+        // the CTCSS detector's validation contract).
+        let voice_squelch = VoiceSquelch::new(VoiceSquelchMode::Off, audio_rate_f32)?;
+
         Ok(Self {
             deemp_l: None,
             deemp_r: None,
@@ -186,6 +204,7 @@ impl AfChain {
             ctcss_threshold: CTCSS_DEFAULT_THRESHOLD,
             ctcss_detector: None,
             ctcss_mono_buf: Vec::new(),
+            voice_squelch,
             deemp_buf_l: Vec::new(),
             deemp_out_l: Vec::new(),
             deemp_out_r: Vec::new(),
@@ -391,6 +410,45 @@ impl AfChain {
         self.ctcss_threshold
     }
 
+    /// Set the voice-activity squelch mode. `Off` passes audio
+    /// through unchanged (the detector is permanently open).
+    /// `Syllabic(threshold)` runs a 4 Hz envelope-modulation
+    /// detector for speech-cadence detection. `Snr(threshold_db)`
+    /// runs an in-voice-band vs out-of-voice-band power-ratio
+    /// detector. Mode change resets the gate to closed — the
+    /// new detector has to warm up before the gate opens.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DspError::InvalidParameter`] if the mode carries
+    /// a non-finite or out-of-range threshold (see
+    /// [`VoiceSquelch::new`] for the full contract).
+    pub fn set_voice_squelch_mode(&mut self, mode: VoiceSquelchMode) -> Result<(), DspError> {
+        self.voice_squelch.set_mode(mode)
+    }
+
+    /// Returns the current voice-squelch mode.
+    pub fn voice_squelch_mode(&self) -> VoiceSquelchMode {
+        self.voice_squelch.mode()
+    }
+
+    /// Returns the voice squelch's current gate state.
+    /// Always `true` in Off mode (gate is permanently open).
+    pub fn voice_squelch_open(&self) -> bool {
+        self.voice_squelch.is_open()
+    }
+
+    /// Update the voice-squelch threshold for the currently
+    /// active mode. No-op when the mode is Off.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DspError::InvalidParameter`] if the threshold
+    /// is non-finite, or (for syllabic mode) non-positive.
+    pub fn set_voice_squelch_threshold(&mut self, threshold: f32) -> Result<(), DspError> {
+        self.voice_squelch.set_threshold(threshold)
+    }
+
     /// Enable or disable the notch filter.
     pub fn set_notch_enabled(&mut self, enabled: bool) {
         self.notch_l.set_enabled(enabled);
@@ -519,24 +577,35 @@ impl AfChain {
             }
         }
 
-        // Stage 3a: CTCSS detector tap.
-        // Runs BEFORE the high-pass filter so the detector sees
-        // the full-bandwidth AF including the sub-audible tone
-        // (67–254 Hz). Feeds a mono downmix of the post-deemph
-        // signal; the detector buffers internally and only returns
-        // a decision once it has a full 400 ms / 19200-sample
-        // window. Sustained state is sticky across calls.
-        if let Some(detector) = self.ctcss_detector.as_mut() {
+        // Stage 3a: mono downmix tap for CTCSS and voice squelch.
+        // Both detectors consume the same post-deemph mono signal
+        // so we build the downmix once and feed both. Reuses a
+        // single scratch buffer (`ctcss_mono_buf`) to avoid per-
+        // block allocation on the hot path — the original name
+        // is kept for minimal churn, even though it now backs
+        // both detectors.
+        //
+        // Runs BEFORE the high-pass filter so CTCSS sees the
+        // full-bandwidth AF including the sub-audible tone
+        // (67–254 Hz); the voice squelch also gets the wideband
+        // signal, which is fine because its BPFs are narrow.
+        let needs_mono_tap = self.ctcss_detector.is_some() || self.voice_squelch.mode().is_active();
+        if needs_mono_tap {
             self.ctcss_mono_buf.clear();
             self.ctcss_mono_buf.reserve(resamp_count);
             for s in &output[..resamp_count] {
-                // (L + R) / 2 downmix — for NFM (the only mode
-                // that uses CTCSS in practice) L and R are
+                // (L + R) / 2 downmix — for NFM (the dominant
+                // CTCSS / voice-squelch use case) L and R are
                 // identical, but averaging is cheap and safe for
                 // any stereo content.
                 self.ctcss_mono_buf.push(0.5 * (s.l + s.r));
             }
-            let _ = detector.accept_samples(&self.ctcss_mono_buf);
+            if let Some(detector) = self.ctcss_detector.as_mut() {
+                let _ = detector.accept_samples(&self.ctcss_mono_buf);
+            }
+            if self.voice_squelch.mode().is_active() {
+                self.voice_squelch.accept_samples(&self.ctcss_mono_buf);
+            }
         }
 
         // Stage 3b: High-pass filter at audio output rate.
@@ -580,27 +649,37 @@ impl AfChain {
             }
         }
 
-        // Stage 5: CTCSS squelch gate.
-        // Zeroes the entire block when the detector's sustained
-        // gate is closed. This runs LAST so the preceding filters
-        // (HPF/notch) still update their state on the real signal
-        // — keeping the gate close doesn't desync the filters, so
-        // the first block after the gate reopens doesn't have a
+        // Stage 5: AF-level squelch gates (CTCSS + voice squelch).
+        //
+        // Zeroes the entire block when EITHER CTCSS (if in Tone
+        // mode and the sustained gate is closed) OR voice squelch
+        // (if in an active mode and the detector reports closed)
+        // rejects this block. The two gates AND together: both
+        // must be "open" for audio to flow. This matches real
+        // scanners where you might combine a CTCSS tone check
+        // with a voice-activity detector to reject dispatchers
+        // keying up without voice.
+        //
+        // This runs LAST so the preceding filters (HPF/notch)
+        // still update their state on the real signal — keeping
+        // the gate closed doesn't desync the filters, so the
+        // first block after the gate reopens doesn't have a
         // transient from state that lagged behind the signal.
         //
-        // Note the asymmetry: the detector in Stage 3a is fed the
-        // pre-HPF signal (it needs to see the sub-audible tone to
-        // detect it), while the output we zero here is the post-
-        // HPF signal (the user would otherwise hear the tone as a
-        // low buzz). Zeroing post-HPF is cheaper than zeroing pre-
-        // HPF anyway — a fresh zero passed through an active IIR
-        // is not quite zero, so zeroing last skips that subtlety.
-        if matches!(self.ctcss_mode, CtcssMode::Tone(_))
+        // Note the asymmetry: the detectors in Stage 3a are fed
+        // the pre-HPF signal (CTCSS needs to see the sub-audible
+        // tone, and feeding voice squelch from the same tap
+        // avoids a second downmix pass), while the output we zero
+        // here is the post-HPF signal. Zeroing post-HPF skips
+        // the subtlety of "a fresh zero passed through an active
+        // IIR is not quite zero."
+        let ctcss_closed = matches!(self.ctcss_mode, CtcssMode::Tone(_))
             && self
                 .ctcss_detector
                 .as_ref()
-                .is_some_and(|d| !d.is_sustained())
-        {
+                .is_some_and(|d| !d.is_sustained());
+        let voice_closed = self.voice_squelch.mode().is_active() && !self.voice_squelch.is_open();
+        if ctcss_closed || voice_closed {
             for s in &mut output[..resamp_count] {
                 *s = Stereo::new(0.0, 0.0);
             }
@@ -947,5 +1026,201 @@ mod tests {
         // Switch to 131.8 Hz. Sustained state must reset.
         chain.set_ctcss_mode(CtcssMode::Tone(131.8)).unwrap();
         assert!(!chain.ctcss_sustained());
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Voice squelch tests
+    //
+    // The exhaustive algorithmic tests live in
+    // `sdr_dsp::voice_squelch`. These are integration tests that
+    // prove the AF chain wires the voice squelch correctly:
+    //
+    // - Off mode leaves audio unchanged
+    // - Active modes actually gate the stereo output
+    // - Mode change resets state
+    // - Threshold update propagates
+    // - Voice squelch ANDs with CTCSS (both must be open)
+    // ─────────────────────────────────────────────────────────
+
+    use sdr_dsp::voice_squelch::{
+        VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB, VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+        VoiceSquelchMode,
+    };
+
+    #[test]
+    fn test_voice_squelch_defaults_to_off_and_passes_through() {
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        assert_eq!(chain.voice_squelch_mode(), VoiceSquelchMode::Off);
+        assert!(chain.voice_squelch_open(), "Off mode gate must start open");
+
+        // Feed a pure 1 kHz tone — should pass through unchanged
+        // because the gate is permanently open in Off mode.
+        let input = (0..4800)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f32 / 48_000.0_f32;
+                let v = 0.5 * (core::f32::consts::TAU * 1_000.0 * t).sin();
+                Stereo::new(v, v)
+            })
+            .collect::<Vec<_>>();
+        let mut output = vec![Stereo::default(); 4800];
+        chain.process(&input, &mut output).unwrap();
+        // First sample of the tone should survive untouched (up
+        // to HPF warmup — we're at sample 0 which hasn't rung
+        // through the HPF yet and HPF is off by default anyway).
+        assert!(output[100].l.abs() > 0.01);
+    }
+
+    #[test]
+    fn test_voice_squelch_snr_rejects_silence() {
+        // SNR mode with default threshold fed 100 ms of silence:
+        // gate must stay closed and the output must be zeroed.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain
+            .set_voice_squelch_mode(VoiceSquelchMode::Snr {
+                threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+            })
+            .unwrap();
+
+        let input = vec![Stereo::new(0.0, 0.0); 4800];
+        let mut output = vec![Stereo::default(); 4800];
+        chain.process(&input, &mut output).unwrap();
+
+        assert!(!chain.voice_squelch_open());
+        assert!(
+            output.iter().all(|s| s.l == 0.0 && s.r == 0.0),
+            "silence in → zero out regardless"
+        );
+    }
+
+    #[test]
+    fn test_voice_squelch_snr_opens_on_strong_tone() {
+        // Strong in-voice-band tone — the SNR detector should
+        // open the gate after ingesting enough audio, and the
+        // output should contain the signal.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain
+            .set_voice_squelch_mode(VoiceSquelchMode::Snr {
+                threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+            })
+            .unwrap();
+
+        // 2 seconds of 1 kHz at 0.8 — well above the detector's
+        // noise floor and inside the in-band BPF's passband.
+        let n = 96_000;
+        let input = (0..n)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f32 / 48_000.0_f32;
+                let v = 0.8 * (core::f32::consts::TAU * 1_000.0 * t).sin();
+                Stereo::new(v, v)
+            })
+            .collect::<Vec<_>>();
+        let mut output = vec![Stereo::default(); n];
+        chain.process(&input, &mut output).unwrap();
+
+        assert!(
+            chain.voice_squelch_open(),
+            "SNR gate must open on strong in-band tone"
+        );
+        // Output should contain audible signal (beyond the first
+        // RMS window's warmup).
+        let late_window = &output[48_000..];
+        assert!(late_window.iter().any(|s| s.l.abs() > 0.01));
+    }
+
+    #[test]
+    fn test_voice_squelch_mode_change_resets_gate() {
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain
+            .set_voice_squelch_mode(VoiceSquelchMode::Snr {
+                threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+            })
+            .unwrap();
+
+        // Open on a strong tone.
+        let n = 96_000;
+        let input = (0..n)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f32 / 48_000.0_f32;
+                let v = 0.8 * (core::f32::consts::TAU * 1_000.0 * t).sin();
+                Stereo::new(v, v)
+            })
+            .collect::<Vec<_>>();
+        let mut output = vec![Stereo::default(); n];
+        chain.process(&input, &mut output).unwrap();
+        assert!(chain.voice_squelch_open());
+
+        // Switch to a different mode — gate must reset.
+        chain
+            .set_voice_squelch_mode(VoiceSquelchMode::Syllabic {
+                threshold: VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            })
+            .unwrap();
+        assert!(
+            !chain.voice_squelch_open(),
+            "mode change must reset gate to closed"
+        );
+    }
+
+    #[test]
+    fn test_voice_squelch_and_gates_with_ctcss() {
+        // When BOTH voice squelch and CTCSS are active, audio
+        // should only pass if both gates agree. Here CTCSS is on
+        // a tone that isn't present → CTCSS closed → output
+        // muted regardless of voice squelch state.
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
+        chain
+            .set_voice_squelch_mode(VoiceSquelchMode::Snr {
+                threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+            })
+            .unwrap();
+
+        // Feed a strong 1 kHz tone. Voice squelch should open
+        // (strong in-band energy), CTCSS should NOT open (wrong
+        // tone / no sub-audible 100 Hz), so the output must be
+        // zeroed by the CTCSS half of the AND gate.
+        let n = 96_000;
+        let input = (0..n)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f32 / 48_000.0_f32;
+                let v = 0.8 * (core::f32::consts::TAU * 1_000.0 * t).sin();
+                Stereo::new(v, v)
+            })
+            .collect::<Vec<_>>();
+        let mut output = vec![Stereo::default(); n];
+        chain.process(&input, &mut output).unwrap();
+
+        assert!(
+            !chain.ctcss_sustained(),
+            "CTCSS should stay closed without a 100 Hz sub-audible tone"
+        );
+        // The last block should be muted (CTCSS is the
+        // controlling gate here).
+        let tail = &output[48_000..];
+        assert!(
+            tail.iter().all(|s| s.l == 0.0 && s.r == 0.0),
+            "CTCSS closed must mute output regardless of voice squelch state"
+        );
+    }
+
+    #[test]
+    fn test_voice_squelch_threshold_update_validates() {
+        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        chain
+            .set_voice_squelch_mode(VoiceSquelchMode::Syllabic { threshold: 0.15 })
+            .unwrap();
+
+        // Valid update.
+        assert!(chain.set_voice_squelch_threshold(0.2).is_ok());
+        // Non-finite rejected.
+        assert!(chain.set_voice_squelch_threshold(f32::NAN).is_err());
+        assert!(chain.set_voice_squelch_threshold(f32::INFINITY).is_err());
+        // Non-positive rejected (syllabic mode only).
+        assert!(chain.set_voice_squelch_threshold(0.0).is_err());
+        assert!(chain.set_voice_squelch_threshold(-0.1).is_err());
     }
 }

--- a/crates/sdr-radio/src/af_chain.rs
+++ b/crates/sdr-radio/src/af_chain.rs
@@ -1047,43 +1047,102 @@ mod tests {
         VoiceSquelchMode,
     };
 
+    // Test-only fixture constants. Per CLAUDE.md's "named
+    // constants for all magic numbers" rule, even test values
+    // with load-bearing intent get names + rationale so a
+    // future detector retune can find them in one place.
+
+    /// Sample rate for all voice-squelch AF-chain tests. Matches
+    /// the canonical 48 kHz the DSP layer is calibrated against
+    /// (see `VOICE_SQUELCH_SAMPLE_RATE_HZ`). Passed to
+    /// `AfChain::new` for both `af_sample_rate` and
+    /// `audio_sample_rate` so the tests don't exercise the
+    /// resampler — voice-squelch behavior is the focus.
+    const VS_TEST_SAMPLE_RATE: f64 = 48_000.0;
+
+    /// Length in samples of a 100 ms short-window test block.
+    /// Matches `VOICE_SQUELCH_RMS_WINDOW_MS` so silence-rejection
+    /// tests feed exactly one RMS integration window.
+    const VS_SHORT_BLOCK_SAMPLES: usize = 4_800;
+
+    /// Length in samples of a 2-second long block used by the
+    /// detector-opens tests. Hang time is 500 ms and the RMS
+    /// window is 100 ms, so 2 seconds is comfortably long enough
+    /// for the detector to ring up, the gate to open, and the
+    /// post-warmup tail to have audible signal.
+    const VS_LONG_BLOCK_SAMPLES: usize = 96_000;
+
+    /// Offset into `VS_LONG_BLOCK_SAMPLES` where we check the
+    /// output for post-warmup audible signal. 1 second in — past
+    /// both the HPF warmup transient and the detector ring-up,
+    /// but still inside the long block.
+    const VS_LONG_BLOCK_TAIL_OFFSET: usize = 48_000;
+
+    /// In-voice-band carrier frequency (Hz) used by all the
+    /// "strong tone opens the gate" tests. Chosen to land inside
+    /// both the SNR detector's in-band BPF passband (centered
+    /// at 1 kHz) and the voice-band weight region used by
+    /// `enhance_speech` elsewhere.
+    const VS_TEST_CARRIER_HZ: f32 = 1_000.0;
+
+    /// "Strong signal" amplitude — well above the detector's
+    /// noise floor. 0.8 peak leaves headroom under f32 [-1, 1]
+    /// so a single-channel stereo dupe doesn't clip.
+    const VS_STRONG_AMPLITUDE: f32 = 0.8;
+
+    /// "Normal signal" amplitude used by the Off-mode passthrough
+    /// test where we just need to verify audio reaches the
+    /// output, not open a gate.
+    const VS_NORMAL_AMPLITUDE: f32 = 0.5;
+
+    /// Build a stereo buffer of the given length filled with a
+    /// pure sine tone at `VS_TEST_CARRIER_HZ` and the given
+    /// amplitude, duplicated across both channels. Shared by
+    /// all three "strong tone" tests to avoid the same
+    /// generator being copy-pasted three times.
+    fn stereo_tone(n: usize, amplitude: f32) -> Vec<Stereo> {
+        #[allow(clippy::cast_possible_truncation)]
+        let sample_rate = VS_TEST_SAMPLE_RATE as f32;
+        (0..n)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f32 / sample_rate;
+                let v = amplitude * (core::f32::consts::TAU * VS_TEST_CARRIER_HZ * t).sin();
+                Stereo::new(v, v)
+            })
+            .collect()
+    }
+
     #[test]
     fn test_voice_squelch_defaults_to_off_and_passes_through() {
-        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        let mut chain = AfChain::new(VS_TEST_SAMPLE_RATE, VS_TEST_SAMPLE_RATE).unwrap();
         assert_eq!(chain.voice_squelch_mode(), VoiceSquelchMode::Off);
         assert!(chain.voice_squelch_open(), "Off mode gate must start open");
 
-        // Feed a pure 1 kHz tone — should pass through unchanged
+        // Feed a pure in-band tone — should pass through unchanged
         // because the gate is permanently open in Off mode.
-        let input = (0..4800)
-            .map(|i| {
-                #[allow(clippy::cast_precision_loss)]
-                let t = i as f32 / 48_000.0_f32;
-                let v = 0.5 * (core::f32::consts::TAU * 1_000.0 * t).sin();
-                Stereo::new(v, v)
-            })
-            .collect::<Vec<_>>();
-        let mut output = vec![Stereo::default(); 4800];
+        let input = stereo_tone(VS_SHORT_BLOCK_SAMPLES, VS_NORMAL_AMPLITUDE);
+        let mut output = vec![Stereo::default(); VS_SHORT_BLOCK_SAMPLES];
         chain.process(&input, &mut output).unwrap();
-        // First sample of the tone should survive untouched (up
-        // to HPF warmup — we're at sample 0 which hasn't rung
-        // through the HPF yet and HPF is off by default anyway).
+        // Sample 100 should survive untouched (HPF is off by
+        // default and any warmup is well before this point).
         assert!(output[100].l.abs() > 0.01);
     }
 
     #[test]
     fn test_voice_squelch_snr_rejects_silence() {
-        // SNR mode with default threshold fed 100 ms of silence:
-        // gate must stay closed and the output must be zeroed.
-        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        // SNR mode with default threshold fed one 100 ms window
+        // of silence: gate must stay closed and the output must
+        // be zeroed.
+        let mut chain = AfChain::new(VS_TEST_SAMPLE_RATE, VS_TEST_SAMPLE_RATE).unwrap();
         chain
             .set_voice_squelch_mode(VoiceSquelchMode::Snr {
                 threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
             })
             .unwrap();
 
-        let input = vec![Stereo::new(0.0, 0.0); 4800];
-        let mut output = vec![Stereo::default(); 4800];
+        let input = vec![Stereo::new(0.0, 0.0); VS_SHORT_BLOCK_SAMPLES];
+        let mut output = vec![Stereo::default(); VS_SHORT_BLOCK_SAMPLES];
         chain.process(&input, &mut output).unwrap();
 
         assert!(!chain.voice_squelch_open());
@@ -1096,42 +1155,30 @@ mod tests {
     #[test]
     fn test_voice_squelch_snr_opens_on_strong_tone() {
         // Strong in-voice-band tone — the SNR detector should
-        // open the gate after ingesting enough audio, and the
-        // output should contain the signal.
-        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        // open the gate after ingesting the 2 s block, and the
+        // post-warmup output must contain audible signal.
+        let mut chain = AfChain::new(VS_TEST_SAMPLE_RATE, VS_TEST_SAMPLE_RATE).unwrap();
         chain
             .set_voice_squelch_mode(VoiceSquelchMode::Snr {
                 threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
             })
             .unwrap();
 
-        // 2 seconds of 1 kHz at 0.8 — well above the detector's
-        // noise floor and inside the in-band BPF's passband.
-        let n = 96_000;
-        let input = (0..n)
-            .map(|i| {
-                #[allow(clippy::cast_precision_loss)]
-                let t = i as f32 / 48_000.0_f32;
-                let v = 0.8 * (core::f32::consts::TAU * 1_000.0 * t).sin();
-                Stereo::new(v, v)
-            })
-            .collect::<Vec<_>>();
-        let mut output = vec![Stereo::default(); n];
+        let input = stereo_tone(VS_LONG_BLOCK_SAMPLES, VS_STRONG_AMPLITUDE);
+        let mut output = vec![Stereo::default(); VS_LONG_BLOCK_SAMPLES];
         chain.process(&input, &mut output).unwrap();
 
         assert!(
             chain.voice_squelch_open(),
             "SNR gate must open on strong in-band tone"
         );
-        // Output should contain audible signal (beyond the first
-        // RMS window's warmup).
-        let late_window = &output[48_000..];
+        let late_window = &output[VS_LONG_BLOCK_TAIL_OFFSET..];
         assert!(late_window.iter().any(|s| s.l.abs() > 0.01));
     }
 
     #[test]
     fn test_voice_squelch_mode_change_resets_gate() {
-        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        let mut chain = AfChain::new(VS_TEST_SAMPLE_RATE, VS_TEST_SAMPLE_RATE).unwrap();
         chain
             .set_voice_squelch_mode(VoiceSquelchMode::Snr {
                 threshold_db: VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
@@ -1139,16 +1186,8 @@ mod tests {
             .unwrap();
 
         // Open on a strong tone.
-        let n = 96_000;
-        let input = (0..n)
-            .map(|i| {
-                #[allow(clippy::cast_precision_loss)]
-                let t = i as f32 / 48_000.0_f32;
-                let v = 0.8 * (core::f32::consts::TAU * 1_000.0 * t).sin();
-                Stereo::new(v, v)
-            })
-            .collect::<Vec<_>>();
-        let mut output = vec![Stereo::default(); n];
+        let input = stereo_tone(VS_LONG_BLOCK_SAMPLES, VS_STRONG_AMPLITUDE);
+        let mut output = vec![Stereo::default(); VS_LONG_BLOCK_SAMPLES];
         chain.process(&input, &mut output).unwrap();
         assert!(chain.voice_squelch_open());
 
@@ -1170,7 +1209,7 @@ mod tests {
         // should only pass if both gates agree. Here CTCSS is on
         // a tone that isn't present → CTCSS closed → output
         // muted regardless of voice squelch state.
-        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        let mut chain = AfChain::new(VS_TEST_SAMPLE_RATE, VS_TEST_SAMPLE_RATE).unwrap();
         chain.set_ctcss_mode(CtcssMode::Tone(100.0)).unwrap();
         chain
             .set_voice_squelch_mode(VoiceSquelchMode::Snr {
@@ -1178,29 +1217,19 @@ mod tests {
             })
             .unwrap();
 
-        // Feed a strong 1 kHz tone. Voice squelch should open
-        // (strong in-band energy), CTCSS should NOT open (wrong
-        // tone / no sub-audible 100 Hz), so the output must be
-        // zeroed by the CTCSS half of the AND gate.
-        let n = 96_000;
-        let input = (0..n)
-            .map(|i| {
-                #[allow(clippy::cast_precision_loss)]
-                let t = i as f32 / 48_000.0_f32;
-                let v = 0.8 * (core::f32::consts::TAU * 1_000.0 * t).sin();
-                Stereo::new(v, v)
-            })
-            .collect::<Vec<_>>();
-        let mut output = vec![Stereo::default(); n];
+        // Strong in-band tone — voice squelch should open (high
+        // in-band energy) but CTCSS should NOT open (no 100 Hz
+        // sub-audible tone present), so CTCSS wins the AND and
+        // the output must be zeroed.
+        let input = stereo_tone(VS_LONG_BLOCK_SAMPLES, VS_STRONG_AMPLITUDE);
+        let mut output = vec![Stereo::default(); VS_LONG_BLOCK_SAMPLES];
         chain.process(&input, &mut output).unwrap();
 
         assert!(
             !chain.ctcss_sustained(),
             "CTCSS should stay closed without a 100 Hz sub-audible tone"
         );
-        // The last block should be muted (CTCSS is the
-        // controlling gate here).
-        let tail = &output[48_000..];
+        let tail = &output[VS_LONG_BLOCK_TAIL_OFFSET..];
         assert!(
             tail.iter().all(|s| s.l == 0.0 && s.r == 0.0),
             "CTCSS closed must mute output regardless of voice squelch state"
@@ -1209,7 +1238,7 @@ mod tests {
 
     #[test]
     fn test_voice_squelch_threshold_update_validates() {
-        let mut chain = AfChain::new(48_000.0, 48_000.0).unwrap();
+        let mut chain = AfChain::new(VS_TEST_SAMPLE_RATE, VS_TEST_SAMPLE_RATE).unwrap();
         chain
             .set_voice_squelch_mode(VoiceSquelchMode::Syllabic { threshold: 0.15 })
             .unwrap();

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -14,6 +14,7 @@ use sdr_types::{Complex, DemodMode, DspError, Stereo};
 
 use af_chain::{AfChain, CtcssMode};
 use demod::{DemodConfig, Demodulator, create_demodulator};
+use sdr_dsp::voice_squelch::VoiceSquelchMode;
 
 /// Tolerance for considering two sample rates equal (skip resampling).
 const RATE_TOLERANCE: f64 = 1.0;
@@ -79,6 +80,10 @@ pub struct RadioModule {
     /// Persisted CTCSS detection threshold, paired with
     /// `ctcss_mode`. Same reapply-on-rebuild pattern.
     ctcss_threshold: f32,
+    /// Persisted voice-activity squelch mode (Off / Syllabic /
+    /// Snr). Reapplied to the new AF chain on mode switch the
+    /// same way CTCSS is.
+    voice_squelch_mode: VoiceSquelchMode,
     audio_sample_rate: f64,
     /// Input sample rate from the IQ frontend (Hz).
     input_sample_rate: f64,
@@ -117,6 +122,7 @@ impl RadioModule {
             notch_frequency: sdr_dsp::filter::DEFAULT_NOTCH_FREQ_HZ,
             ctcss_mode: CtcssMode::Off,
             ctcss_threshold: sdr_dsp::tone_detect::CTCSS_DEFAULT_THRESHOLD,
+            voice_squelch_mode: VoiceSquelchMode::Off,
             audio_sample_rate,
             input_sample_rate: 0.0,
             input_resampler: None,
@@ -199,6 +205,15 @@ impl RadioModule {
         af_chain
             .set_ctcss_mode(self.ctcss_mode)
             .map_err(|e| RadioError::ModeSwitchFailed(format!("failed to set CTCSS mode: {e}")))?;
+        // Restore voice squelch mode. Like CTCSS, the gate state
+        // intentionally resets to closed on mode switch — the new
+        // AF chain is a fresh detector and has to warm up before
+        // opening.
+        af_chain
+            .set_voice_squelch_mode(self.voice_squelch_mode)
+            .map_err(|e| {
+                RadioError::ModeSwitchFailed(format!("failed to set voice squelch mode: {e}"))
+            })?;
 
         // Update IF chain feature flags based on new mode capabilities
         if !fm_if_nr_allowed {
@@ -453,6 +468,67 @@ impl RadioModule {
     /// Returns the current CTCSS detection threshold.
     pub fn ctcss_threshold(&self) -> f32 {
         self.ctcss_threshold
+    }
+
+    /// Set the voice-activity squelch mode. `Off` is the default
+    /// (audio passes through unchanged). `Syllabic(threshold)` runs
+    /// a ~4 Hz envelope-modulation detector for speech-cadence
+    /// detection. `Snr(threshold_db)` runs a voice-band vs out-of-
+    /// voice-band power ratio detector. Persists across mode
+    /// changes.
+    ///
+    /// See [`sdr_dsp::voice_squelch`] for the underlying DSP.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RadioError::Dsp`] if the mode carries a non-
+    /// finite or otherwise invalid threshold.
+    pub fn set_voice_squelch_mode(&mut self, mode: VoiceSquelchMode) -> Result<(), RadioError> {
+        self.af_chain.set_voice_squelch_mode(mode)?;
+        self.voice_squelch_mode = mode;
+        Ok(())
+    }
+
+    /// Returns the current voice-squelch mode.
+    pub fn voice_squelch_mode(&self) -> VoiceSquelchMode {
+        self.voice_squelch_mode
+    }
+
+    /// Returns the voice-squelch gate state: `true` when the
+    /// detector has opened (speech-like content present) or when
+    /// the mode is `Off` (gate permanently open). `false` when
+    /// an active detector has the gate closed.
+    pub fn voice_squelch_open(&self) -> bool {
+        self.af_chain.voice_squelch_open()
+    }
+
+    /// Update the voice-squelch threshold. The interpretation of
+    /// `threshold` depends on the currently active mode: for
+    /// `Syllabic` it's a normalized envelope-ratio value
+    /// (positive, unitless), for `Snr` it's dB. No-op when the
+    /// mode is `Off`.
+    ///
+    /// Updates the persisted mode's inline threshold so
+    /// subsequent mode reloads (e.g. on `set_mode`) carry the
+    /// tuned value forward.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RadioError::Dsp`] if the threshold is non-finite
+    /// or (for syllabic) non-positive.
+    pub fn set_voice_squelch_threshold(&mut self, threshold: f32) -> Result<(), RadioError> {
+        self.af_chain.set_voice_squelch_threshold(threshold)?;
+        // Mirror the update into the cached mode so set_mode's
+        // reapply picks up the tuned value. `Off` variant has no
+        // threshold to update — no-op, matching the AF chain.
+        self.voice_squelch_mode = match self.voice_squelch_mode {
+            VoiceSquelchMode::Off => VoiceSquelchMode::Off,
+            VoiceSquelchMode::Syllabic { .. } => VoiceSquelchMode::Syllabic { threshold },
+            VoiceSquelchMode::Snr { .. } => VoiceSquelchMode::Snr {
+                threshold_db: threshold,
+            },
+        };
+        Ok(())
     }
 
     /// Enable or disable WFM stereo decode.

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -205,12 +205,39 @@ impl RadioModule {
         af_chain
             .set_ctcss_mode(self.ctcss_mode)
             .map_err(|e| RadioError::ModeSwitchFailed(format!("failed to set CTCSS mode: {e}")))?;
-        // Restore voice squelch mode. Like CTCSS, the gate state
-        // intentionally resets to closed on mode switch — the new
-        // AF chain is a fresh detector and has to warm up before
-        // opening.
+        // Voice squelch: apply LIVE only when the new mode is
+        // NFM. Syllabic and Snr detectors are calibrated around
+        // human speech shape — on WFM broadcast audio they'd
+        // mangle music and non-speech content, on AM/SSB the
+        // signal characteristics are different, and on DSB/CW/
+        // RAW the concept doesn't apply at all. Rather than let
+        // a stale cached Syllabic or Snr mode silently gate the
+        // speaker on WFM, we force the live AF chain to Off for
+        // any non-NFM mode.
+        //
+        // **Important**: we do NOT clear `self.voice_squelch_mode`
+        // here — the cached setting is preserved across the
+        // mode switch. When the user returns to NFM later, the
+        // cached mode is reapplied live and their tuning
+        // survives. This is a cleaner model than the
+        // force-clear-on-leave pattern CTCSS uses: the user's
+        // voice squelch configuration is "armed" and will
+        // automatically re-engage on NFM without requiring
+        // manual reselection.
+        //
+        // The UI layer's `apply_demod_visibility` hides the
+        // voice squelch rows on non-NFM modes (same as CTCSS),
+        // so the user never sees controls for a feature that
+        // isn't currently live. Their cached selection is
+        // preserved in the combo row as well so the roundtrip
+        // is seamless.
+        let live_voice_squelch_mode = if mode == DemodMode::Nfm {
+            self.voice_squelch_mode
+        } else {
+            VoiceSquelchMode::Off
+        };
         af_chain
-            .set_voice_squelch_mode(self.voice_squelch_mode)
+            .set_voice_squelch_mode(live_voice_squelch_mode)
             .map_err(|e| {
                 RadioError::ModeSwitchFailed(format!("failed to set voice squelch mode: {e}"))
             })?;
@@ -887,39 +914,77 @@ mod tests {
         use sdr_dsp::voice_squelch::VoiceSquelchMode;
 
         let mut radio = RadioModule::with_default_rate().unwrap();
-        // Baseline: default mode is Off at both levels.
+        // Baseline: default mode is Off at both levels. Radio
+        // starts in WFM mode (RadioModule default).
         assert_eq!(radio.voice_squelch_mode(), VoiceSquelchMode::Off);
         assert_eq!(radio.af_chain().voice_squelch_mode(), VoiceSquelchMode::Off);
+        assert_eq!(radio.current_mode(), DemodMode::Wfm);
 
-        // Set a non-default Syllabic mode and verify both
-        // layers report it.
+        // Set a non-default Syllabic mode via the direct setter.
+        // On the CURRENT (WFM) AF chain the direct setter applies
+        // unconditionally — the NFM-only gate lives only in the
+        // `set_mode` rebuild path, not in the direct setter. This
+        // is deliberate: the user's intent on the direct setter
+        // is "use this mode now if applicable," and if they're
+        // on WFM that's their own choice; the gate keeps stale
+        // cached state from re-arming on non-NFM modes across
+        // rebuilds, not from the user's explicit current action.
         let syl = VoiceSquelchMode::Syllabic { threshold: 0.22 };
         radio.set_voice_squelch_mode(syl).unwrap();
         assert_eq!(radio.voice_squelch_mode(), syl);
         assert_eq!(radio.af_chain().voice_squelch_mode(), syl);
 
-        // Mode switch: the AF chain is rebuilt from scratch.
-        // The cached voice-squelch mode must be reapplied by
-        // set_mode's replay block, so both the RadioModule
-        // cache AND the new AF chain instance must still
-        // report Syllabic at the same threshold.
+        // Mode switch to NFM: the AF chain is rebuilt from
+        // scratch. The NFM gate passes, so the cached Syllabic
+        // mode applies live on the new chain.
         radio.set_mode(DemodMode::Nfm).unwrap();
         assert_eq!(radio.voice_squelch_mode(), syl);
         assert_eq!(radio.af_chain().voice_squelch_mode(), syl);
 
-        // Another mode switch — same invariant must hold.
+        // Switch AWAY from NFM to AM. The cache must preserve
+        // the user's Syllabic setting, but the live AF chain
+        // must be forced to Off — voice squelch is calibrated
+        // for speech and doesn't apply to AM.
         radio.set_mode(DemodMode::Am).unwrap();
-        assert_eq!(radio.voice_squelch_mode(), syl);
-        assert_eq!(radio.af_chain().voice_squelch_mode(), syl);
+        assert_eq!(
+            radio.voice_squelch_mode(),
+            syl,
+            "cache must preserve user's setting across non-NFM transitions"
+        );
+        assert_eq!(
+            radio.af_chain().voice_squelch_mode(),
+            VoiceSquelchMode::Off,
+            "live AF chain must NOT run voice squelch on AM"
+        );
 
-        // Flip to Snr and run the same gauntlet.
+        // Back to NFM — the cached Syllabic must re-apply live
+        // without user intervention. This is the core reason
+        // we preserve the cache across non-NFM modes: the user
+        // doesn't have to re-pick voice squelch every time they
+        // visit a non-NFM band and come back.
+        radio.set_mode(DemodMode::Nfm).unwrap();
+        assert_eq!(radio.voice_squelch_mode(), syl);
+        assert_eq!(
+            radio.af_chain().voice_squelch_mode(),
+            syl,
+            "cached setting must re-arm on NFM re-entry"
+        );
+
+        // Flip to Snr and run a NFM → WFM → NFM gauntlet.
         let snr = VoiceSquelchMode::Snr { threshold_db: 9.0 };
         radio.set_voice_squelch_mode(snr).unwrap();
+        radio.set_mode(DemodMode::Wfm).unwrap();
+        assert_eq!(radio.voice_squelch_mode(), snr);
+        assert_eq!(
+            radio.af_chain().voice_squelch_mode(),
+            VoiceSquelchMode::Off,
+            "WFM must not run voice squelch live"
+        );
         radio.set_mode(DemodMode::Nfm).unwrap();
         assert_eq!(radio.voice_squelch_mode(), snr);
         assert_eq!(radio.af_chain().voice_squelch_mode(), snr);
 
-        // Back to Off — must also round-trip through set_mode.
+        // Explicitly set Off — must stay Off through any mode.
         radio.set_voice_squelch_mode(VoiceSquelchMode::Off).unwrap();
         radio.set_mode(DemodMode::Wfm).unwrap();
         assert_eq!(radio.voice_squelch_mode(), VoiceSquelchMode::Off);

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -871,4 +871,97 @@ mod tests {
             );
         }
     }
+
+    // ─── Voice squelch persistence regression tests ─────────
+    //
+    // Mirror the CTCSS dual-level assertion pattern: after each
+    // mode switch, assert both the RadioModule cache AND the
+    // live AfChain value so a broken reapply path (cache
+    // updated but af_chain not) can't hide behind the cached
+    // field alone. Tests three transitions (Off → Syllabic,
+    // Syllabic → Snr, mode switch) to cover the
+    // reconstruct-the-AF-chain-on-set_mode code path.
+
+    #[test]
+    fn test_radio_module_voice_squelch_persists_across_set_mode() {
+        use sdr_dsp::voice_squelch::VoiceSquelchMode;
+
+        let mut radio = RadioModule::with_default_rate().unwrap();
+        // Baseline: default mode is Off at both levels.
+        assert_eq!(radio.voice_squelch_mode(), VoiceSquelchMode::Off);
+        assert_eq!(radio.af_chain().voice_squelch_mode(), VoiceSquelchMode::Off);
+
+        // Set a non-default Syllabic mode and verify both
+        // layers report it.
+        let syl = VoiceSquelchMode::Syllabic { threshold: 0.22 };
+        radio.set_voice_squelch_mode(syl).unwrap();
+        assert_eq!(radio.voice_squelch_mode(), syl);
+        assert_eq!(radio.af_chain().voice_squelch_mode(), syl);
+
+        // Mode switch: the AF chain is rebuilt from scratch.
+        // The cached voice-squelch mode must be reapplied by
+        // set_mode's replay block, so both the RadioModule
+        // cache AND the new AF chain instance must still
+        // report Syllabic at the same threshold.
+        radio.set_mode(DemodMode::Nfm).unwrap();
+        assert_eq!(radio.voice_squelch_mode(), syl);
+        assert_eq!(radio.af_chain().voice_squelch_mode(), syl);
+
+        // Another mode switch — same invariant must hold.
+        radio.set_mode(DemodMode::Am).unwrap();
+        assert_eq!(radio.voice_squelch_mode(), syl);
+        assert_eq!(radio.af_chain().voice_squelch_mode(), syl);
+
+        // Flip to Snr and run the same gauntlet.
+        let snr = VoiceSquelchMode::Snr { threshold_db: 9.0 };
+        radio.set_voice_squelch_mode(snr).unwrap();
+        radio.set_mode(DemodMode::Nfm).unwrap();
+        assert_eq!(radio.voice_squelch_mode(), snr);
+        assert_eq!(radio.af_chain().voice_squelch_mode(), snr);
+
+        // Back to Off — must also round-trip through set_mode.
+        radio.set_voice_squelch_mode(VoiceSquelchMode::Off).unwrap();
+        radio.set_mode(DemodMode::Wfm).unwrap();
+        assert_eq!(radio.voice_squelch_mode(), VoiceSquelchMode::Off);
+        assert_eq!(radio.af_chain().voice_squelch_mode(), VoiceSquelchMode::Off);
+    }
+
+    #[test]
+    fn test_radio_module_voice_squelch_threshold_updates_cached_mode() {
+        // `set_voice_squelch_threshold` has to mirror the new
+        // value into the cached `voice_squelch_mode` variant
+        // so that `set_mode`'s replay carries the tuned value
+        // forward. Regression test: tune a threshold, switch
+        // modes, confirm the tuned value is what gets reapplied.
+        use sdr_dsp::voice_squelch::VoiceSquelchMode;
+
+        let mut radio = RadioModule::with_default_rate().unwrap();
+        radio
+            .set_voice_squelch_mode(VoiceSquelchMode::Syllabic { threshold: 0.15 })
+            .unwrap();
+        radio.set_voice_squelch_threshold(0.30).unwrap();
+
+        // Cached mode should now carry the tuned threshold, not
+        // the construction-time default.
+        assert_eq!(
+            radio.voice_squelch_mode(),
+            VoiceSquelchMode::Syllabic { threshold: 0.30 }
+        );
+        assert_eq!(
+            radio.af_chain().voice_squelch_mode(),
+            VoiceSquelchMode::Syllabic { threshold: 0.30 }
+        );
+
+        // Mode switch rebuilds the AF chain; the tuned 0.30
+        // must survive through the replay.
+        radio.set_mode(DemodMode::Nfm).unwrap();
+        assert_eq!(
+            radio.voice_squelch_mode(),
+            VoiceSquelchMode::Syllabic { threshold: 0.30 }
+        );
+        assert_eq!(
+            radio.af_chain().voice_squelch_mode(),
+            VoiceSquelchMode::Syllabic { threshold: 0.30 }
+        );
+    }
 }

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -635,6 +635,43 @@ mod tests {
     const INVALID_CTCSS_THRESHOLDS: [f32; 6] =
         [0.0, -0.1, 1.001, f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
 
+    // ─── Voice-squelch test fixtures ────────────────────────────
+    // Same "named constants with rationale" pattern as CTCSS.
+    // These feed `test_radio_module_voice_squelch_*`; a future
+    // DSP retune of the default thresholds or the accepted range
+    // should touch these in one place rather than hunting down
+    // bare literals scattered across the tests.
+
+    /// Non-default Syllabic threshold used by the persistence
+    /// test. Chosen inside the DSP-layer `(0, 1]` range and
+    /// clearly different from
+    /// `VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD` (0.15) so a
+    /// regression that silently reverts to the default fails
+    /// loudly. Also distinct from
+    /// `VS_SYLLABIC_TUNED_THRESHOLD` below so the two syllabic
+    /// tests can't contaminate each other through shared state.
+    const VS_SYLLABIC_PERSIST_THRESHOLD: f32 = 0.22;
+
+    /// Non-default Snr threshold (dB) used by the persistence
+    /// test's Snr gauntlet. Chosen inside the 0–20 dB UI range
+    /// and clearly above `VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB`
+    /// (6.0) so a regression that reverts to the default fails
+    /// loudly.
+    const VS_SNR_PERSIST_THRESHOLD_DB: f32 = 9.0;
+
+    /// Construction baseline for the threshold-updates-cached-mode
+    /// test. Equals `VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD`
+    /// — we start the test at the default so the `set_voice_squelch_mode`
+    /// call exercises the default-construction path.
+    const VS_SYLLABIC_BASELINE_THRESHOLD: f32 = 0.15;
+
+    /// Tuned Syllabic threshold for the threshold-updates-cached-
+    /// mode test. Distinct from BOTH
+    /// `VS_SYLLABIC_BASELINE_THRESHOLD` (so the update is
+    /// observable) AND `VS_SYLLABIC_PERSIST_THRESHOLD` (so the
+    /// two syllabic tests are independent).
+    const VS_SYLLABIC_TUNED_THRESHOLD: f32 = 0.30;
+
     #[test]
     fn test_radio_module_default_mode() {
         let radio = RadioModule::with_default_rate().unwrap();
@@ -929,7 +966,9 @@ mod tests {
         // on WFM that's their own choice; the gate keeps stale
         // cached state from re-arming on non-NFM modes across
         // rebuilds, not from the user's explicit current action.
-        let syl = VoiceSquelchMode::Syllabic { threshold: 0.22 };
+        let syl = VoiceSquelchMode::Syllabic {
+            threshold: VS_SYLLABIC_PERSIST_THRESHOLD,
+        };
         radio.set_voice_squelch_mode(syl).unwrap();
         assert_eq!(radio.voice_squelch_mode(), syl);
         assert_eq!(radio.af_chain().voice_squelch_mode(), syl);
@@ -971,7 +1010,9 @@ mod tests {
         );
 
         // Flip to Snr and run a NFM → WFM → NFM gauntlet.
-        let snr = VoiceSquelchMode::Snr { threshold_db: 9.0 };
+        let snr = VoiceSquelchMode::Snr {
+            threshold_db: VS_SNR_PERSIST_THRESHOLD_DB,
+        };
         radio.set_voice_squelch_mode(snr).unwrap();
         radio.set_mode(DemodMode::Wfm).unwrap();
         assert_eq!(radio.voice_squelch_mode(), snr);
@@ -1002,31 +1043,43 @@ mod tests {
 
         let mut radio = RadioModule::with_default_rate().unwrap();
         radio
-            .set_voice_squelch_mode(VoiceSquelchMode::Syllabic { threshold: 0.15 })
+            .set_voice_squelch_mode(VoiceSquelchMode::Syllabic {
+                threshold: VS_SYLLABIC_BASELINE_THRESHOLD,
+            })
             .unwrap();
-        radio.set_voice_squelch_threshold(0.30).unwrap();
+        radio
+            .set_voice_squelch_threshold(VS_SYLLABIC_TUNED_THRESHOLD)
+            .unwrap();
 
         // Cached mode should now carry the tuned threshold, not
         // the construction-time default.
         assert_eq!(
             radio.voice_squelch_mode(),
-            VoiceSquelchMode::Syllabic { threshold: 0.30 }
+            VoiceSquelchMode::Syllabic {
+                threshold: VS_SYLLABIC_TUNED_THRESHOLD
+            }
         );
         assert_eq!(
             radio.af_chain().voice_squelch_mode(),
-            VoiceSquelchMode::Syllabic { threshold: 0.30 }
+            VoiceSquelchMode::Syllabic {
+                threshold: VS_SYLLABIC_TUNED_THRESHOLD
+            }
         );
 
-        // Mode switch rebuilds the AF chain; the tuned 0.30
+        // Mode switch rebuilds the AF chain; the tuned value
         // must survive through the replay.
         radio.set_mode(DemodMode::Nfm).unwrap();
         assert_eq!(
             radio.voice_squelch_mode(),
-            VoiceSquelchMode::Syllabic { threshold: 0.30 }
+            VoiceSquelchMode::Syllabic {
+                threshold: VS_SYLLABIC_TUNED_THRESHOLD
+            }
         );
         assert_eq!(
             radio.af_chain().voice_squelch_mode(),
-            VoiceSquelchMode::Syllabic { threshold: 0.30 }
+            VoiceSquelchMode::Syllabic {
+                threshold: VS_SYLLABIC_TUNED_THRESHOLD
+            }
         );
     }
 }

--- a/crates/sdr-ui/src/radioreference/frequency_list.rs
+++ b/crates/sdr-ui/src/radioreference/frequency_list.rs
@@ -279,6 +279,7 @@ mod tests {
             rr_import_id: Some("42".to_string()),
             ctcss_mode: None,
             ctcss_threshold: None,
+            voice_squelch_mode: None,
         };
 
         let freq = sample_freq("42", 999_999_999, "FM", "test");
@@ -308,6 +309,7 @@ mod tests {
             rr_import_id: None,
             ctcss_mode: None,
             ctcss_threshold: None,
+            voice_squelch_mode: None,
         };
 
         let freq = sample_freq("99", 155_000_000, "FM", "test");
@@ -337,6 +339,7 @@ mod tests {
             rr_import_id: Some("10".to_string()),
             ctcss_mode: None,
             ctcss_threshold: None,
+            voice_squelch_mode: None,
         };
 
         let freq = sample_freq("99", 155_000_000, "FM", "test");

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -113,6 +113,11 @@ pub struct TuningProfile {
     /// CTCSS detection threshold (normalized magnitude, `(0, 1]`).
     /// Same backward-compat semantics as `ctcss_mode`.
     pub ctcss_threshold: Option<f32>,
+    /// Voice-activity squelch mode — tagged enum carrying its
+    /// threshold inline. Same backward-compat contract as CTCSS:
+    /// `None` on restore means leave the current voice squelch
+    /// setting alone.
+    pub voice_squelch_mode: Option<sdr_dsp::voice_squelch::VoiceSquelchMode>,
 }
 
 /// A user-saved frequency bookmark with optional tuning profile fields.
@@ -169,6 +174,13 @@ pub struct Bookmark {
     /// semantics as `ctcss_mode`.
     #[serde(default)]
     pub ctcss_threshold: Option<f32>,
+    /// Voice-activity squelch mode — tagged `VoiceSquelchMode`
+    /// enum carrying its threshold inline. Added in the voice-
+    /// squelch PR; pre-PR bookmarks deserialize to `None` which
+    /// the restore path interprets as "leave the current voice
+    /// squelch setting alone."
+    #[serde(default)]
+    pub voice_squelch_mode: Option<sdr_dsp::voice_squelch::VoiceSquelchMode>,
 }
 
 impl Bookmark {
@@ -195,6 +207,7 @@ impl Bookmark {
             rr_import_id: None,
             ctcss_mode: None,
             ctcss_threshold: None,
+            voice_squelch_mode: None,
         }
     }
 
@@ -227,6 +240,7 @@ impl Bookmark {
             rr_import_id: None,
             ctcss_mode: profile.ctcss_mode,
             ctcss_threshold: profile.ctcss_threshold,
+            voice_squelch_mode: profile.voice_squelch_mode,
         }
     }
 
@@ -742,6 +756,9 @@ mod tests {
             high_pass: Some(false),
             ctcss_mode: Some(sdr_radio::af_chain::CtcssMode::Tone(100.0)),
             ctcss_threshold: Some(0.15),
+            voice_squelch_mode: Some(sdr_dsp::voice_squelch::VoiceSquelchMode::Snr {
+                threshold_db: 9.0,
+            }),
         };
         let bm = Bookmark::with_profile("Full", 98_100_000, DemodMode::Wfm, 150_000.0, &profile);
         let json = serde_json::to_string(&bm).unwrap();
@@ -763,6 +780,10 @@ mod tests {
             Some(sdr_radio::af_chain::CtcssMode::Tone(100.0))
         );
         assert_eq!(back.ctcss_threshold, Some(0.15));
+        assert_eq!(
+            back.voice_squelch_mode,
+            Some(sdr_dsp::voice_squelch::VoiceSquelchMode::Snr { threshold_db: 9.0 })
+        );
     }
 
     #[test]
@@ -776,6 +797,11 @@ mod tests {
         let bm: Bookmark = serde_json::from_str(old_json).unwrap();
         assert!(bm.ctcss_mode.is_none());
         assert!(bm.ctcss_threshold.is_none());
+        // Voice squelch is newer than CTCSS, so pre-PR bookmarks
+        // also lack this key — must deserialize to None which
+        // restore_bookmark_profile interprets as "leave current
+        // voice squelch setting alone."
+        assert!(bm.voice_squelch_mode.is_none());
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -288,10 +288,27 @@ impl RadioPanel {
     /// (shouldn't happen with the fixed 3-entry model) fall
     /// back to `Off` — same contract as CTCSS.
     ///
-    /// The caller passes the current threshold so this helper
-    /// doesn't have to know about the spin row; it's shared
-    /// between the save path and the DSP-dispatch path in
-    /// `window.rs`.
+    /// **Important**: the caller must ensure `threshold` is in
+    /// the correct units for the target `index`. Syllabic
+    /// expects a normalized envelope ratio (~0.05–0.50); Snr
+    /// expects a dB value (~0.0–20.0). Passing 0.15 to Snr or
+    /// 6.0 to Syllabic would leave the detector far outside its
+    /// tuning range and either always-open or never-open.
+    ///
+    /// Used by two call sites with different threshold sources:
+    ///
+    /// - **Save path** (bookmark save) — threshold is read from
+    ///   the spin row, which is already in the current mode's
+    ///   units, so the combo index and threshold are in sync.
+    /// - **Restore path** (bookmark load) — threshold is
+    ///   extracted from the persisted [`VoiceSquelchMode`] enum
+    ///   which carries it inline in the correct units.
+    ///
+    /// For the **mode-change** path (user flips the combo), the
+    /// caller must use [`Self::voice_squelch_default_threshold_for_index`]
+    /// to get the target mode's per-variant default, NOT the
+    /// current spin-row value from the previous mode. Otherwise
+    /// the units don't match.
     #[must_use]
     pub fn voice_squelch_mode_from_index(index: u32, threshold: f32) -> VoiceSquelchMode {
         match index {
@@ -300,6 +317,24 @@ impl RadioPanel {
                 threshold_db: threshold,
             },
             _ => VoiceSquelchMode::Off,
+        }
+    }
+
+    /// Return the default threshold for a voice-squelch combo
+    /// index, in the correct units for that variant. Used by
+    /// the combo-change signal handler in `window.rs` to seed
+    /// a mode switch with a sane per-mode default rather than
+    /// carrying the previous mode's threshold (which would be in
+    /// the wrong units).
+    ///
+    /// Returns 0.0 for `Off` because `Off` has no threshold to
+    /// apply — the caller should ignore the value on that path.
+    #[must_use]
+    pub fn voice_squelch_default_threshold_for_index(index: u32) -> f32 {
+        match index {
+            VOICE_SQUELCH_SYLLABIC_IDX => VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            VOICE_SQUELCH_SNR_IDX => VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB,
+            _ => 0.0,
         }
     }
 

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -3,6 +3,10 @@
 use libadwaita as adw;
 use libadwaita::prelude::*;
 use sdr_dsp::tone_detect::{CTCSS_DEFAULT_THRESHOLD, CTCSS_TONES_HZ};
+use sdr_dsp::voice_squelch::{
+    VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB, VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+    VoiceSquelchMode,
+};
 use sdr_radio::af_chain::CtcssMode;
 
 /// Default bandwidth in Hz.
@@ -37,6 +41,44 @@ const MAX_NB_LEVEL: f64 = 20.0;
 const NB_LEVEL_STEP: f64 = 0.5;
 /// Noise blanker page increment.
 const NB_LEVEL_PAGE: f64 = 1.0;
+
+// ─── Voice squelch UI tuning ──────────────────────────────────
+//
+// The threshold spin row has to cover two different units (a
+// normalized envelope ratio for Syllabic, dB for SNR), so we
+// keep per-mode min/max/step/default constants and update the
+// adjustment when the mode changes.
+
+/// Combo row indices for the voice-squelch selector. Must match
+/// the order of [`VOICE_SQUELCH_MODE_LABELS`] below. `pub(crate)`
+/// so `window.rs` can translate the selection back to a
+/// [`VoiceSquelchMode`] at `BackendConfig` build time without
+/// re-deriving the match.
+pub(crate) const VOICE_SQUELCH_OFF_IDX: u32 = 0;
+pub(crate) const VOICE_SQUELCH_SYLLABIC_IDX: u32 = 1;
+pub(crate) const VOICE_SQUELCH_SNR_IDX: u32 = 2;
+/// User-visible combo labels. Order matches the `*_IDX` constants.
+const VOICE_SQUELCH_MODE_LABELS: &[&str] = &["Off", "Syllabic", "SNR ratio"];
+
+/// Syllabic threshold range — normalized envelope ratio. The
+/// DSP default is `VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD`
+/// (0.15). Range picked to cover the useful tuning window:
+/// below 0.05 even hiss opens the gate, above 0.5 clear speech
+/// is often rejected.
+const SYLLABIC_THRESHOLD_MIN: f64 = 0.05;
+const SYLLABIC_THRESHOLD_MAX: f64 = 0.50;
+const SYLLABIC_THRESHOLD_STEP: f64 = 0.01;
+const SYLLABIC_THRESHOLD_PAGE: f64 = 0.05;
+
+/// SNR threshold range — dB above the out-of-voice-band noise
+/// floor. DSP default is `VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB`
+/// (6.0 dB = 2× ratio). Below 0 dB the gate is trivially
+/// satisfied by any broadband noise; above 20 dB you need a
+/// near-studio-quality signal to open.
+const SNR_THRESHOLD_DB_MIN: f64 = 0.0;
+const SNR_THRESHOLD_DB_MAX: f64 = 20.0;
+const SNR_THRESHOLD_DB_STEP: f64 = 0.5;
+const SNR_THRESHOLD_DB_PAGE: f64 = 2.0;
 
 /// Default CTCSS detection threshold (matches
 /// [`sdr_dsp::tone_detect::CTCSS_DEFAULT_THRESHOLD`] = 0.1).
@@ -104,6 +146,18 @@ pub struct RadioPanel {
     /// `DspToUi::CtcssSustainedChanged` messages via
     /// [`Self::set_ctcss_sustained`].
     pub ctcss_status_row: adw::ActionRow,
+    /// Voice-activity squelch mode selector. Off / Syllabic /
+    /// SNR ratio. The threshold spin row below relabels and
+    /// re-ranges based on the selection — one row, two units.
+    pub voice_squelch_row: adw::ComboRow,
+    /// Voice-squelch threshold. Range + subtitle change based
+    /// on the mode selected above; see
+    /// [`Self::apply_voice_squelch_mode_ui`].
+    pub voice_squelch_threshold_row: adw::SpinRow,
+    /// Read-only status row for the voice squelch gate. Updated
+    /// from `DspToUi::VoiceSquelchOpenChanged` via
+    /// [`Self::set_voice_squelch_open`].
+    pub voice_squelch_status_row: adw::ActionRow,
 }
 
 impl RadioPanel {
@@ -138,6 +192,28 @@ impl RadioPanel {
         // was already Off.
         if !ctcss_allowed {
             self.ctcss_row.set_selected(0);
+        }
+
+        // Voice squelch is also NFM-oriented. Syllabic is
+        // designed around human speech cadence and Snr keys on
+        // a voice-band-centered BPF — neither makes sense on
+        // WFM broadcast or SSB where the audio content is
+        // structurally different. Same "force to Off on leave"
+        // pattern as CTCSS to avoid a hidden-but-active state
+        // leak.
+        let voice_squelch_allowed = mode == sdr_types::DemodMode::Nfm;
+        self.voice_squelch_row.set_visible(voice_squelch_allowed);
+        self.voice_squelch_status_row
+            .set_visible(voice_squelch_allowed);
+        // Threshold row visibility depends on BOTH the demod
+        // mode (must allow voice squelch) AND the current voice
+        // squelch mode (must be active, not Off). When the mode
+        // is Off the row is hidden even on NFM.
+        let voice_squelch_active = self.voice_squelch_row.selected() != VOICE_SQUELCH_OFF_IDX;
+        self.voice_squelch_threshold_row
+            .set_visible(voice_squelch_allowed && voice_squelch_active);
+        if !voice_squelch_allowed {
+            self.voice_squelch_row.set_selected(VOICE_SQUELCH_OFF_IDX);
         }
     }
 
@@ -205,6 +281,122 @@ impl RadioPanel {
             "Waiting for tone"
         };
         self.ctcss_status_row.set_subtitle(text);
+    }
+
+    /// Convert a voice-squelch combo index + current threshold
+    /// value to a [`VoiceSquelchMode`]. Out-of-range indices
+    /// (shouldn't happen with the fixed 3-entry model) fall
+    /// back to `Off` — same contract as CTCSS.
+    ///
+    /// The caller passes the current threshold so this helper
+    /// doesn't have to know about the spin row; it's shared
+    /// between the save path and the DSP-dispatch path in
+    /// `window.rs`.
+    #[must_use]
+    pub fn voice_squelch_mode_from_index(index: u32, threshold: f32) -> VoiceSquelchMode {
+        match index {
+            VOICE_SQUELCH_SYLLABIC_IDX => VoiceSquelchMode::Syllabic { threshold },
+            VOICE_SQUELCH_SNR_IDX => VoiceSquelchMode::Snr {
+                threshold_db: threshold,
+            },
+            _ => VoiceSquelchMode::Off,
+        }
+    }
+
+    /// Inverse of [`Self::voice_squelch_mode_from_index`] — used
+    /// by bookmark restore to map a persisted mode back to a
+    /// combo index.
+    #[must_use]
+    pub fn voice_squelch_index_from_mode(mode: VoiceSquelchMode) -> u32 {
+        match mode {
+            VoiceSquelchMode::Off => VOICE_SQUELCH_OFF_IDX,
+            VoiceSquelchMode::Syllabic { .. } => VOICE_SQUELCH_SYLLABIC_IDX,
+            VoiceSquelchMode::Snr { .. } => VOICE_SQUELCH_SNR_IDX,
+        }
+    }
+
+    /// Extract the current threshold value from a mode. `Off`
+    /// has no threshold; we return the syllabic default so the
+    /// caller can plug it into the spin row without a special
+    /// case. Syllabic and Snr return their inline value.
+    #[must_use]
+    pub fn voice_squelch_threshold_from_mode(mode: VoiceSquelchMode) -> f32 {
+        match mode {
+            VoiceSquelchMode::Off => VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
+            VoiceSquelchMode::Syllabic { threshold } => threshold,
+            VoiceSquelchMode::Snr { threshold_db } => threshold_db,
+        }
+    }
+
+    /// Reconfigure the threshold spin row's adjustment for the
+    /// given mode — each voice-squelch variant uses different
+    /// units (normalized ratio vs dB) and different ranges.
+    /// Called on startup and whenever the combo row changes.
+    ///
+    /// The threshold spin row is hidden in Off mode (nothing to
+    /// tune) and shown in Syllabic / Snr mode with the right
+    /// subtitle and adjustment range.
+    pub fn apply_voice_squelch_mode_ui(&self, mode: VoiceSquelchMode) {
+        match mode {
+            VoiceSquelchMode::Off => {
+                self.voice_squelch_threshold_row.set_visible(false);
+                self.voice_squelch_status_row.set_subtitle("Off");
+            }
+            VoiceSquelchMode::Syllabic { threshold } => {
+                self.voice_squelch_threshold_row.set_visible(true);
+                self.voice_squelch_threshold_row
+                    .set_subtitle("Envelope ratio (0.05 = permissive, 0.5 = strict)");
+                let adj = gtk4::Adjustment::new(
+                    f64::from(threshold),
+                    SYLLABIC_THRESHOLD_MIN,
+                    SYLLABIC_THRESHOLD_MAX,
+                    SYLLABIC_THRESHOLD_STEP,
+                    SYLLABIC_THRESHOLD_PAGE,
+                    0.0,
+                );
+                self.voice_squelch_threshold_row.set_adjustment(Some(&adj));
+                self.voice_squelch_threshold_row.set_digits(2);
+                self.voice_squelch_status_row
+                    .set_subtitle("Waiting for speech");
+            }
+            VoiceSquelchMode::Snr { threshold_db } => {
+                self.voice_squelch_threshold_row.set_visible(true);
+                self.voice_squelch_threshold_row
+                    .set_subtitle("dB above noise floor (0 = permissive, 20 = strict)");
+                let adj = gtk4::Adjustment::new(
+                    f64::from(threshold_db),
+                    SNR_THRESHOLD_DB_MIN,
+                    SNR_THRESHOLD_DB_MAX,
+                    SNR_THRESHOLD_DB_STEP,
+                    SNR_THRESHOLD_DB_PAGE,
+                    0.0,
+                );
+                self.voice_squelch_threshold_row.set_adjustment(Some(&adj));
+                self.voice_squelch_threshold_row.set_digits(1);
+                self.voice_squelch_status_row
+                    .set_subtitle("Waiting for signal");
+            }
+        }
+    }
+
+    /// Update the voice-squelch status row from a gate edge
+    /// event. Off-mode guarded: if the combo currently says Off
+    /// we keep the "Off" subtitle regardless of the incoming
+    /// bool, matching CTCSS's Off-first pattern.
+    pub fn set_voice_squelch_open(&self, open: bool) {
+        if self.voice_squelch_row.selected() == VOICE_SQUELCH_OFF_IDX {
+            self.voice_squelch_status_row.set_subtitle("Off");
+            return;
+        }
+        self.voice_squelch_status_row.set_subtitle(if open {
+            "Signal present — gate open"
+        } else {
+            match self.voice_squelch_row.selected() {
+                VOICE_SQUELCH_SYLLABIC_IDX => "Waiting for speech",
+                VOICE_SQUELCH_SNR_IDX => "Waiting for signal",
+                _ => "Waiting",
+            }
+        });
     }
 }
 
@@ -365,6 +557,59 @@ pub fn build_radio_panel() -> RadioPanel {
         .visible(false)
         .build();
 
+    // --- Voice squelch ---
+    // Three-entry combo: Off / Syllabic / SNR ratio. Threshold
+    // spin row + status row start hidden (Off is the default);
+    // they're revealed by `apply_voice_squelch_mode_ui` when
+    // the combo changes to an active mode.
+    let voice_squelch_model = gtk4::StringList::new(VOICE_SQUELCH_MODE_LABELS);
+    let voice_squelch_row = adw::ComboRow::builder()
+        .title("Voice squelch")
+        .subtitle("Speech / signal detector, gates alongside CTCSS")
+        .model(&voice_squelch_model)
+        .build();
+
+    // Threshold spin row — starts in syllabic-default range but
+    // the adjustment is overwritten by `apply_voice_squelch_mode_ui`
+    // whenever the mode changes, so the initial range is just a
+    // placeholder.
+    let voice_squelch_threshold_adj = gtk4::Adjustment::new(
+        f64::from(VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD),
+        SYLLABIC_THRESHOLD_MIN,
+        SYLLABIC_THRESHOLD_MAX,
+        SYLLABIC_THRESHOLD_STEP,
+        SYLLABIC_THRESHOLD_PAGE,
+        0.0,
+    );
+    let voice_squelch_threshold_row = adw::SpinRow::builder()
+        .title("Voice squelch threshold")
+        .subtitle("Select a mode first")
+        .adjustment(&voice_squelch_threshold_adj)
+        .digits(2)
+        .visible(false)
+        .build();
+
+    let voice_squelch_status_row = adw::ActionRow::builder()
+        .title("Voice squelch status")
+        .subtitle("Off")
+        .visible(false)
+        .build();
+
+    // Sanity-check that the DSP-layer defaults haven't drifted
+    // from the UI's tuning range. If someone bumps the DSP
+    // default out of the UI range, this debug_assert forces them
+    // to update the UI bounds too.
+    debug_assert!(
+        f64::from(VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD) >= SYLLABIC_THRESHOLD_MIN
+            && f64::from(VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD) <= SYLLABIC_THRESHOLD_MAX,
+        "syllabic default threshold outside UI range"
+    );
+    debug_assert!(
+        f64::from(VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB) >= SNR_THRESHOLD_DB_MIN
+            && f64::from(VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB) <= SNR_THRESHOLD_DB_MAX,
+        "SNR default threshold outside UI range"
+    );
+
     group.add(&bandwidth_row);
     group.add(&squelch_enabled_row);
     group.add(&squelch_level_row);
@@ -379,6 +624,9 @@ pub fn build_radio_panel() -> RadioPanel {
     group.add(&ctcss_row);
     group.add(&ctcss_threshold_row);
     group.add(&ctcss_status_row);
+    group.add(&voice_squelch_row);
+    group.add(&voice_squelch_threshold_row);
+    group.add(&voice_squelch_status_row);
 
     // All rows connected to DSP pipeline via window.rs
 
@@ -398,6 +646,9 @@ pub fn build_radio_panel() -> RadioPanel {
         ctcss_row,
         ctcss_threshold_row,
         ctcss_status_row,
+        voice_squelch_row,
+        voice_squelch_threshold_row,
+        voice_squelch_status_row,
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -198,9 +198,23 @@ impl RadioPanel {
         // designed around human speech cadence and Snr keys on
         // a voice-band-centered BPF — neither makes sense on
         // WFM broadcast or SSB where the audio content is
-        // structurally different. Same "force to Off on leave"
-        // pattern as CTCSS to avoid a hidden-but-active state
-        // leak.
+        // structurally different.
+        //
+        // Unlike CTCSS (which force-clears the combo on leave-
+        // NFM), voice squelch PRESERVES the user's selection
+        // across non-NFM transitions. The DSP layer has a
+        // matching gate in `RadioModule::set_mode` that forces
+        // the live AF chain to `Off` for non-NFM modes while
+        // keeping the cached mode intact. So on WFM the combo
+        // still shows "Syllabic" (or whatever the user picked)
+        // but the detector isn't actually running — and on NFM
+        // re-entry everything re-arms automatically without the
+        // user having to reselect the mode.
+        //
+        // The rows just hide/show based on demod mode. The
+        // combo selection is left alone — the user's
+        // configuration survives round-trips through non-NFM
+        // bands.
         let voice_squelch_allowed = mode == sdr_types::DemodMode::Nfm;
         self.voice_squelch_row.set_visible(voice_squelch_allowed);
         self.voice_squelch_status_row
@@ -212,8 +226,16 @@ impl RadioPanel {
         let voice_squelch_active = self.voice_squelch_row.selected() != VOICE_SQUELCH_OFF_IDX;
         self.voice_squelch_threshold_row
             .set_visible(voice_squelch_allowed && voice_squelch_active);
-        if !voice_squelch_allowed {
-            self.voice_squelch_row.set_selected(VOICE_SQUELCH_OFF_IDX);
+        // On re-entry to NFM with a cached active voice-squelch
+        // mode, the status row subtitle might still say
+        // "Signal present — gate open" from the last session if
+        // the DSP detector happened to be open when the user
+        // last left NFM. The fresh AF chain starts closed, so
+        // reset the label to the mode-appropriate "waiting"
+        // text. The first real DSP edge after re-entry will
+        // override this if the detector actually opens.
+        if voice_squelch_allowed && voice_squelch_active {
+            self.set_voice_squelch_open(false);
         }
     }
 
@@ -602,6 +624,11 @@ pub fn build_radio_panel() -> RadioPanel {
         .title("Voice squelch")
         .subtitle("Speech / signal detector, gates alongside CTCSS")
         .model(&voice_squelch_model)
+        // Start hidden — `apply_demod_visibility` reveals it on
+        // NFM. Without this the row would flash briefly on the
+        // default non-NFM startup path before the visibility
+        // handler kicks in, mirroring the CTCSS pattern.
+        .visible(false)
         .build();
 
     // Threshold spin row — starts in syllabic-default range but

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1155,12 +1155,22 @@ fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         .voice_squelch_row
         .connect_selected_notify(move |row| {
             let idx = row.selected();
-            // Pull the current threshold from the spin row so the
-            // mode-change dispatch carries a sane initial value.
-            // For Off this doesn't matter (the helper ignores it),
-            // for Syllabic/Snr it seeds the detector.
-            #[allow(clippy::cast_possible_truncation)]
-            let threshold = radio_for_vs.voice_squelch_threshold_row.value() as f32;
+            // Use the DEFAULT threshold for the target mode, NOT
+            // the current spin-row value. The previous mode's
+            // threshold is in different units (normalized ratio
+            // for Syllabic, dB for Snr), so forwarding it to the
+            // new variant would land far outside the new
+            // detector's tuning range — e.g. Off → Snr seeding
+            // 0.15 dB, or Snr → Syllabic seeding 6.0 as a
+            // normalized ratio. Both fail the detector.
+            //
+            // `apply_voice_squelch_mode_ui` below reconfigures
+            // the spin row's adjustment range AND seeds its
+            // value from the mode's inline threshold, so the
+            // UI and DSP end up aligned on the same default
+            // value in the same units.
+            let threshold =
+                sidebar::radio_panel::RadioPanel::voice_squelch_default_threshold_for_index(idx);
             let mode =
                 sidebar::radio_panel::RadioPanel::voice_squelch_mode_from_index(idx, threshold);
             state_vs_mode.send_dsp(UiToDsp::SetVoiceSquelchMode(mode));

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -558,6 +558,10 @@ fn handle_dsp_message(
             tracing::debug!(sustained, "CTCSS sustained-gate edge");
             radio_panel.set_ctcss_sustained(sustained);
         }
+        DspToUi::VoiceSquelchOpenChanged(open) => {
+            tracing::debug!(open, "voice squelch gate edge");
+            radio_panel.set_voice_squelch_open(open);
+        }
     }
 }
 
@@ -1008,6 +1012,7 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
 }
 
 /// Connect radio panel controls to DSP commands.
+#[allow(clippy::too_many_lines)]
 fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
     // Bandwidth
     let state_bw = Rc::clone(state);
@@ -1127,6 +1132,50 @@ fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         .connect_value_notify(move |row| {
             #[allow(clippy::cast_possible_truncation)]
             state_ctcss_thresh.send_dsp(UiToDsp::SetCtcssThreshold(row.value() as f32));
+        });
+
+    // Voice squelch mode
+    //
+    // On mode change: tell the AF chain to rebuild its detector,
+    // reconfigure the threshold spin row (units + range + default
+    // value), and push the status row label to the appropriate
+    // "waiting" / "Off" text so it doesn't lag behind the first
+    // real detector edge.
+    //
+    // The initial startup layout is Off, so nothing else needs
+    // to fire — `apply_voice_squelch_mode_ui(Off)` is called
+    // here too to make the starting state consistent.
+    panels
+        .radio
+        .apply_voice_squelch_mode_ui(sdr_dsp::voice_squelch::VoiceSquelchMode::Off);
+    let state_vs_mode = Rc::clone(state);
+    let radio_for_vs = panels.radio.clone();
+    panels
+        .radio
+        .voice_squelch_row
+        .connect_selected_notify(move |row| {
+            let idx = row.selected();
+            // Pull the current threshold from the spin row so the
+            // mode-change dispatch carries a sane initial value.
+            // For Off this doesn't matter (the helper ignores it),
+            // for Syllabic/Snr it seeds the detector.
+            #[allow(clippy::cast_possible_truncation)]
+            let threshold = radio_for_vs.voice_squelch_threshold_row.value() as f32;
+            let mode =
+                sidebar::radio_panel::RadioPanel::voice_squelch_mode_from_index(idx, threshold);
+            state_vs_mode.send_dsp(UiToDsp::SetVoiceSquelchMode(mode));
+            radio_for_vs.apply_voice_squelch_mode_ui(mode);
+            radio_for_vs.set_voice_squelch_open(false);
+        });
+
+    // Voice squelch threshold
+    let state_vs_thresh = Rc::clone(state);
+    panels
+        .radio
+        .voice_squelch_threshold_row
+        .connect_value_notify(move |row| {
+            #[allow(clippy::cast_possible_truncation)]
+            state_vs_thresh.send_dsp(UiToDsp::SetVoiceSquelchThreshold(row.value() as f32));
         });
 }
 
@@ -1359,6 +1408,28 @@ fn restore_bookmark_profile(
                 mode,
             ));
     }
+    // Voice squelch mode — the enum carries its threshold
+    // inline, so a single field captures both. Dispatch to the
+    // DSP first, then update the UI combo + threshold row to
+    // reflect the restored state.
+    if let Some(mode) = bookmark.voice_squelch_mode {
+        state.send_dsp(UiToDsp::SetVoiceSquelchMode(mode));
+        let idx = sidebar::radio_panel::RadioPanel::voice_squelch_index_from_mode(mode);
+        radio.voice_squelch_row.set_selected(idx);
+        let threshold = sidebar::radio_panel::RadioPanel::voice_squelch_threshold_from_mode(mode);
+        #[allow(clippy::cast_lossless)]
+        radio
+            .voice_squelch_threshold_row
+            .set_value(threshold as f64);
+        // Push the threshold over the wire explicitly too —
+        // `SetVoiceSquelchMode` already carries it inline on an
+        // active variant, but sending the dedicated threshold
+        // message keeps the radio module's cached mode variant
+        // in sync in case a future refactor routes the two
+        // updates through different code paths.
+        state.send_dsp(UiToDsp::SetVoiceSquelchThreshold(threshold));
+        radio.apply_voice_squelch_mode_ui(mode);
+    }
 }
 
 /// Connect navigation panel (band presets + bookmarks) to DSP commands.
@@ -1481,6 +1552,12 @@ fn connect_navigation_panel(
                 radio_bm.ctcss_row.selected(),
             )),
             ctcss_threshold: Some(radio_bm.ctcss_threshold_row.value() as f32),
+            voice_squelch_mode: Some(
+                sidebar::radio_panel::RadioPanel::voice_squelch_mode_from_index(
+                    radio_bm.voice_squelch_row.selected(),
+                    radio_bm.voice_squelch_threshold_row.value() as f32,
+                ),
+            ),
         };
         let bookmark =
             sidebar::navigation_panel::Bookmark::with_profile(&name, freq_u64, mode, bw, &profile);
@@ -1518,6 +1595,8 @@ fn connect_navigation_panel(
     let save_radio_stereo = panels.radio.stereo_row.clone();
     let save_radio_ctcss = panels.radio.ctcss_row.clone();
     let save_radio_ctcss_threshold = panels.radio.ctcss_threshold_row.clone();
+    let save_radio_voice_squelch = panels.radio.voice_squelch_row.clone();
+    let save_radio_voice_squelch_threshold = panels.radio.voice_squelch_threshold_row.clone();
     let save_source_gain = panels.source.gain_row.clone();
     let save_source_agc = panels.source.agc_row.clone();
     nav.connect_save(move || {
@@ -1550,6 +1629,14 @@ fn connect_navigation_panel(
             )),
             #[allow(clippy::cast_possible_truncation)]
             ctcss_threshold: Some(save_radio_ctcss_threshold.value() as f32),
+            voice_squelch_mode: Some({
+                #[allow(clippy::cast_possible_truncation)]
+                let t = save_radio_voice_squelch_threshold.value() as f32;
+                sidebar::radio_panel::RadioPanel::voice_squelch_mode_from_index(
+                    save_radio_voice_squelch.selected(),
+                    t,
+                )
+            }),
         };
         // Find and update the active bookmark in the list.
         let mut bms = save_bm_rc.borrow_mut();
@@ -1574,6 +1661,7 @@ fn connect_navigation_panel(
             bm.high_pass = profile.high_pass;
             bm.ctcss_mode = profile.ctcss_mode;
             bm.ctcss_threshold = profile.ctcss_threshold;
+            bm.voice_squelch_mode = profile.voice_squelch_mode;
             // Keep ActiveBookmark in sync with the updated frequency.
             *save_active.borrow_mut() = sidebar::navigation_panel::ActiveBookmark {
                 name: active.name.clone(),


### PR DESCRIPTION
## Summary

Third orthogonal squelch stage after IF-level power squelch and AF-level CTCSS. Two speech-shape detectors selectable at runtime, tuned per-bookmark, ANDed with CTCSS so both must be open for audio to flow.

**Syllabic (#270)** — detects 2–10 Hz envelope modulation of human speech. Full-wave rectify → 4 Hz BPF → rolling RMS normalized by signal RMS → threshold. Rejects continuous tones, music, hiss, silence.

**SNR ratio (#271)** — in-voice-band vs out-of-voice-band power ratio in dB. Parallel BPFs at 1 kHz (voice core) and 12 kHz (above voice) → rolling RMS → \`20·log10(in/out)\` → dB threshold. Scale-invariant, rejects broadband noise.

## Architecture

- **\`sdr-dsp::voice_squelch\`** — new pure-DSP module, tagged \`VoiceSquelchMode { Off, Syllabic { threshold }, Snr { threshold_db } }\` enum carrying per-variant threshold inline. 17 unit tests.
- **\`sdr-radio::af_chain\`** — shared mono-downmix tap feeds both CTCSS and voice squelch in one pass. Stage 5 gate ANDs all three squelch types (IF power + CTCSS + voice). Force-clear on mode switch leaves.
- **\`sdr-radio::RadioModule\`** — \`set_voice_squelch_mode\` / \`set_voice_squelch_threshold\` persisted across \`set_mode\` rebuilds alongside CTCSS.
- **Messages** — \`UiToDsp::SetVoiceSquelchMode/Threshold\`, \`DspToUi::VoiceSquelchOpenChanged\` edge-triggered for the UI status indicator.
- **UI** — three NFM-only rows in the radio panel: mode combo, threshold spin (per-mode relabeling — normalized ratio for Syllabic, dB for Snr), status row with Off-first guard matching CTCSS. Mode-change dispatches \`apply_voice_squelch_mode_ui\` to reconfigure the threshold adjustment on the fly.
- **Bookmark schema** — \`voice_squelch_mode: Option<VoiceSquelchMode>\` with \`serde(default)\` for backward compat. The tagged enum means one field captures both mode + threshold.
- **README** — feature list updated with both voice squelch AND CTCSS (which was missing from the previous PR).

## Tests

- 17 new \`voice_squelch\` unit tests (Off passthrough, syllable detection on synthetic modulated signals, tone rejection, silence rejection, SNR broadband noise rejection, mode-change reset, threshold validation, serde round-trip)
- 6 new \`af_chain\` integration tests (defaults-to-off, SNR gates silence to zero, strong tone opens, mode change resets, CTCSS ANDs with voice squelch, threshold validation)
- 2 new \`sdr-core::messages\` smoke tests for the new message variants
- Backward-compat JSON test: pre-PR bookmarks load \`voice_squelch_mode = None\`
- Full workspace tests pass, triple-flavor clippy clean (whisper-cpu default, sherpa-cpu, sherpa-cuda), fmt clean, \`cargo deny\` + \`cargo audit\` clean

## Live smoke test (sherpa-cuda)

All verified on the user's NFM scanner:
- Visibility: rows appear on NFM, hide on WFM/AM/other
- Off mode passes audio unchanged
- Syllabic opens on voice cadence, rejects music/tones/silence
- SNR opens on strong in-band signal, rejects noise/silence
- Threshold drag live-adjusts sensitivity in both modes
- Both gates AND with CTCSS — either closed → mute
- Mode-switch leave-clearing works (syllabic → WFM → NFM = Off)
- Bookmark round-trip including app-restart persistence
- Status labels never lie (Off-first guard verified)

## Test plan

- [x] \`cargo test --workspace\` — 0 failures
- [x] Triple-flavor clippy clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo deny check\` clean
- [x] \`cargo audit\` exit 0
- [x] Live smoke test on sherpa-cuda (user-verified, see checklist above)

Closes #270, closes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice-activity squelch added (Off / Syllabic / SNR) with UI controls for mode, threshold, and live gate status; UI shows gate open/closed events.
  * CTCSS tone squelch added (51 standard tones) with per-channel tone selection and tuning.
  * Audio is gated so output passes only when both CTCSS and voice squelch permit it.

* **Bookmarks**
  * Bookmarks/tuning profiles now capture and restore per-channel CTCSS and voice-squelch mode/threshold.

* **Documentation**
  * README updated to document squelch features and bookmark persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->