### PR TITLE
chore(deps): bump rustc pin 1.94.1 → 1.95.0 + fix new clippy lints

### DIFF
--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -164,8 +164,7 @@ fn dispatcher_loop(rx: &mpsc::Receiver<DspToUi>, callback_guard: &EventCallbackG
         let has_callback = callback_guard
             .state
             .lock()
-            .map(|guard| guard.slot.is_some())
-            .unwrap_or(false);
+            .is_ok_and(|guard| guard.slot.is_some());
         if !has_callback {
             continue;
         }

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -234,8 +234,8 @@ pub unsafe extern "C" fn sdr_core_destroy(handle: *mut SdrCore) {
         let dispatcher_handle = core
             .dispatcher_handle
             .lock()
-            .map(|mut guard| guard.take())
-            .unwrap_or(None);
+            .ok()
+            .and_then(|mut guard| guard.take());
 
         // Drop the Engine explicitly before the join so the
         // event channel closes and the dispatcher's `recv()`

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -209,6 +209,27 @@ const SILERO_VAD_DIR_NAME: &str = "silero-vad";
 const SILERO_VAD_URL: &str =
     "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx";
 
+/// Total-request timeout for the Silero VAD download. The
+/// file is ~2 MB but the releases CDN is occasionally slow on
+/// cold cache or from specific regions — 5 minutes gives
+/// rural broadband / hotel `WiFi` a reasonable envelope without
+/// letting a genuinely broken connection hang forever. The
+/// separate `connect_timeout(30s)` catches the "can't reach
+/// github at all" case fast.
+const SILERO_VAD_REQUEST_TIMEOUT_MINS: u64 = 5;
+
+/// Total-request timeout for the sherpa-onnx ASR bundle
+/// downloads. These are tarballs in the 250 MB – 1.2 GB range
+/// depending on the model (Parakeet is the largest), and
+/// unlike the VAD file they can legitimately take a long time
+/// over rural broadband. 1 hour is our "give up" threshold —
+/// generous enough that a user on a 5 Mbps connection can
+/// still download the largest bundle (Parakeet ≈ 30 min at
+/// that speed), tight enough that a dead connection eventually
+/// surfaces as an error instead of a permanent "Downloading…"
+/// spinner.
+const SHERPA_ARCHIVE_REQUEST_TIMEOUT_HOURS: u64 = 1;
+
 /// Full path to the Silero VAD ONNX file on disk.
 pub fn silero_vad_path() -> PathBuf {
     sherpa_models_dir()
@@ -263,7 +284,7 @@ pub fn download_silero_vad(
 
     let client = reqwest::blocking::Client::builder()
         .connect_timeout(Duration::from_secs(30))
-        .timeout(Duration::from_mins(5))
+        .timeout(Duration::from_mins(SILERO_VAD_REQUEST_TIMEOUT_MINS))
         .build()?;
 
     let response = client.get(SILERO_VAD_URL).send()?.error_for_status()?;
@@ -467,7 +488,7 @@ pub fn download_sherpa_archive(
     // legitimate for users on rural broadband or hotel WiFi).
     let client = reqwest::blocking::Client::builder()
         .connect_timeout(Duration::from_secs(30))
-        .timeout(Duration::from_hours(1))
+        .timeout(Duration::from_hours(SHERPA_ARCHIVE_REQUEST_TIMEOUT_HOURS))
         .build()?;
 
     let response = client.get(&archive_url).send()?.error_for_status()?;

--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -263,7 +263,7 @@ pub fn download_silero_vad(
 
     let client = reqwest::blocking::Client::builder()
         .connect_timeout(Duration::from_secs(30))
-        .timeout(Duration::from_secs(300))
+        .timeout(Duration::from_mins(5))
         .build()?;
 
     let response = client.get(SILERO_VAD_URL).send()?.error_for_status()?;
@@ -467,7 +467,7 @@ pub fn download_sherpa_archive(
     // legitimate for users on rural broadband or hotel WiFi).
     let client = reqwest::blocking::Client::builder()
         .connect_timeout(Duration::from_secs(30))
-        .timeout(Duration::from_mins(60))
+        .timeout(Duration::from_hours(1))
         .build()?;
 
     let response = client.get(&archive_url).send()?.error_for_status()?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Rust 1.95.0 shipped 2026-04-14. Project was pinned to 1.94.1 in \`rust-toolchain.toml\`. Bumps the pin and fixes the four new clippy lints 1.95 surfaced — all true positives.

## Changes

| File | Lint | Fix |
|---|---|---|
| \`rust-toolchain.toml\` | — | channel 1.94.1 → 1.95.0 |
| \`sdr-ffi/src/event.rs:164\` | \`manual_is_ok_and\` (\`Result\`) | \`map().unwrap_or(false)\` → \`is_ok_and(...)\` |
| \`sdr-ffi/src/lifecycle.rs:234\` | \`manual_and_then\` (\`Result\`) | \`map().unwrap_or(None)\` → \`.ok().and_then(...)\` |
| \`sdr-transcription/src/sherpa_model.rs:266\` | \`unnecessary_duration_subsec\` | \`Duration::from_secs(300)\` → \`from_mins(5)\` |
| \`sdr-transcription/src/sherpa_model.rs:470\` | \`unnecessary_duration_subsec\` | \`Duration::from_mins(60)\` → \`from_hours(1)\` |

\`Duration::from_mins\` / \`Duration::from_hours\` are stable as of 1.95 — the lint only fires when the suggestion is actually usable.

## Why bump the pin

Staying behind stable indefinitely means new lints and stdlib additions accumulate. Bumping close to the release cadence keeps the delta small — four lint fixes today, vs. potentially dozens across a multi-version jump later.

## Test plan

- [x] \`cargo test --workspace\` — 40/40 suites pass on 1.95.0
- [x] Triple-flavor clippy clean (whisper-cpu default, sherpa-cpu, sherpa-cuda)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo deny check\` — advisories/bans/licenses/sources ok
- [x] \`cargo audit\` — exit 0
- [x] \`make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"\` — succeeds end-to-end, user validating for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain to version 1.95.0
  * Simplified internal synchronization error handling to treat failed mutex acquisition as "no callback" where applicable
  * Increased download timeouts for model and VAD assets to improve reliability for larger transfers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->