### PR TITLE
rtl_tcp: port server + CLI + client protocol (#300, #301)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdr-server-rtltcp"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "rusb",
+ "sdr-rtlsdr",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "sdr-sink-audio"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,8 +2003,10 @@ dependencies = [
 name = "sdr-source-network"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "sdr-config",
  "sdr-pipeline",
+ "sdr-server-rtltcp",
  "sdr-types",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ members = [
     "crates/sdr-rtlsdr",
     "crates/sdr-source-rtlsdr",
     "crates/sdr-source-network",
+    "crates/sdr-server-rtltcp",
     "crates/sdr-source-file",
     "crates/sdr-sink-audio",
     "crates/sdr-sink-network",
@@ -130,6 +131,7 @@ sdr-pipeline = { path = "crates/sdr-pipeline" }
 sdr-rtlsdr = { path = "crates/sdr-rtlsdr" }
 sdr-source-rtlsdr = { path = "crates/sdr-source-rtlsdr" }
 sdr-source-network = { path = "crates/sdr-source-network" }
+sdr-server-rtltcp = { path = "crates/sdr-server-rtltcp" }
 sdr-source-file = { path = "crates/sdr-source-file" }
 sdr-sink-audio = { path = "crates/sdr-sink-audio" }
 sdr-sink-network = { path = "crates/sdr-sink-network" }

--- a/crates/sdr-server-rtltcp/Cargo.toml
+++ b/crates/sdr-server-rtltcp/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "sdr-server-rtltcp"
+version = "0.1.0"
+description = "rtl_tcp-compatible server — streams local RTL-SDR I/Q over TCP with tuning command channel. Port of original/librtlsdr/src/rtl_tcp.c."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+sdr-rtlsdr.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+# Needed for `SO_KEEPALIVE` via setsockopt — std::net::TcpStream exposes
+# `set_nodelay` and friends but not keepalive. Rather than pull in socket2
+# just for one call, we use the same libc/allow(unsafe_code) pattern used
+# elsewhere in the workspace (e.g. crates/sdr-transcription/src/util.rs).
+libc.workspace = true
+rusb.workspace = true
+# Binary only — enables `-s info` style env-filter logging for the CLI.
+# Kept in regular deps (not dev-deps) because the `[[bin]]` target needs it.
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "sdr-rtl-tcp"
+path = "src/bin/sdr-rtl-tcp.rs"
+

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -70,7 +70,7 @@ fn usage(exit_code: i32) -> ! {
     );
     let _ = writeln!(
         out,
-        "    -n <N>       Max queued USB buffers (default: {DEFAULT_BUFFER_CAPACITY})"
+        "    -n <N>       Max queued USB buffers, ~256 KiB each (default: {DEFAULT_BUFFER_CAPACITY})"
     );
     let _ = writeln!(out, "    -T           Enable bias tee");
     let _ = writeln!(
@@ -235,7 +235,15 @@ fn parse_args(args: &[String]) -> Result<ServerConfig, ParseError> {
             }
             "-s" => {
                 let v = args.get(i + 1).ok_or(ParseError)?;
-                config.initial.sample_rate_hz = parse_hz(v)?;
+                let sample_rate_hz = parse_hz(v)?;
+                // Reject 0 up front: `parse_hz` accepts it as a valid
+                // non-negative u32, but a zero sample rate wedges the
+                // RTL-SDR USB controller. Same rule that `Source::
+                // set_sample_rate` in the client uses.
+                if sample_rate_hz == 0 {
+                    return Err(ParseError);
+                }
+                config.initial.sample_rate_hz = sample_rate_hz;
                 i += 2;
             }
             "-d" => {
@@ -438,6 +446,20 @@ mod tests {
     fn parse_args_unknown_flag_rejected() {
         let args = vec!["-X".to_string()];
         assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_rejects_zero_sample_rate() {
+        // `parse_hz` accepts "0" as a valid non-negative u32, but a
+        // zero sample rate wedges the RTL-SDR USB controller. Reject
+        // up-front.
+        for v in ["0", "0k", "0.0", "0M"] {
+            let args = vec!["-s".to_string(), v.to_string()];
+            assert!(
+                parse_args(&args).is_err(),
+                "parse_args should reject -s {v}"
+            );
+        }
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -23,8 +23,10 @@
 use std::net::IpAddr;
 use std::process::ExitCode;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
-use sdr_server_rtltcp::server::{Server, ServerConfig};
+use sdr_server_rtltcp::server::{DEFAULT_SAMPLE_RATE_HZ, Server, ServerConfig};
 use sdr_server_rtltcp::{DEFAULT_BUFFER_CAPACITY, DEFAULT_PORT};
 
 fn usage() -> ! {
@@ -64,13 +66,16 @@ fn main() -> ExitCode {
     match Server::start(config) {
         Ok(server) => {
             tracing::info!(bind = %server.bind_address(), "rtl_tcp server running");
-            // Sit in the foreground until Ctrl-C. On SIGINT, dropping the
-            // Server handle drives shutdown.
-            let (tx, rx) = std::sync::mpsc::channel::<()>();
-            if let Err(e) = ctrlc_handler(tx) {
+            if let Err(e) = ctrlc_handler() {
                 tracing::warn!(%e, "ctrl-c handler setup failed — kill the process manually");
             }
-            let _ = rx.recv();
+            // Poll the shutdown flag instead of using an mpsc channel,
+            // because the signal handler can only safely touch an atomic.
+            // 100 ms poll is well below any user-perceptible shutdown lag
+            // and costs nothing while idle.
+            while !CTRL_C_RECEIVED.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(100));
+            }
             tracing::info!("shutting down");
             drop(server);
             ExitCode::SUCCESS
@@ -82,30 +87,28 @@ fn main() -> ExitCode {
     }
 }
 
-/// Install a minimal SIGINT/SIGTERM handler that signals the main thread
-/// to stop. Uses the same pattern as `rtl_tcp.c:477-488`.
+/// Shared flag that the SIGINT/SIGTERM handler sets, which `main` polls.
+///
+/// Using an `AtomicBool` rather than an mpsc channel because `Mutex::lock`
+/// and `mpsc::Sender::send` are NOT async-signal-safe per POSIX — locking
+/// from inside a signal handler can deadlock or corrupt the mutex state
+/// if the signal fires while the main thread holds the lock.
+/// `AtomicBool::store` IS async-signal-safe (single atomic hardware op,
+/// no allocation, no locks).
+static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+/// Install a minimal SIGINT/SIGTERM handler. Matches the upstream pattern
+/// at `rtl_tcp.c:477-488`, but without the non-async-signal-safe locking.
 #[cfg(unix)]
 #[allow(unsafe_code)]
-fn ctrlc_handler(tx: std::sync::mpsc::Sender<()>) -> std::io::Result<()> {
-    use std::sync::Mutex;
-    static SENDER: Mutex<Option<std::sync::mpsc::Sender<()>>> = Mutex::new(None);
-    if let Ok(mut slot) = SENDER.lock() {
-        *slot = Some(tx);
-    }
+fn ctrlc_handler() -> std::io::Result<()> {
     extern "C" fn handler(_: libc::c_int) {
-        if let Ok(slot) = SENDER.lock() {
-            if let Some(tx) = slot.as_ref() {
-                let _ = tx.send(());
-            }
-        }
+        // Async-signal-safe: atomic store, no allocation, no locks.
+        CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
     }
-    // SAFETY: `handler` is `extern "C"` with the correct signature for a
-    // POSIX signal handler. We install it for SIGINT / SIGTERM only; the
-    // handler body uses a Mutex + mpsc Sender, both of which are safe to
-    // call from a signal context for this workload (mpsc send is
-    // non-allocating when the receiver is alive; we don't care if a
-    // pathological double-ctrl-c hits the locked path because the handler
-    // just returns without sending).
+    // SAFETY: `handler` has the correct `extern "C" fn(c_int)` signature
+    // for a POSIX signal handler and touches only an AtomicBool, which
+    // is on the POSIX async-signal-safe list.
     unsafe {
         libc::signal(libc::SIGINT, handler as *const () as libc::sighandler_t);
         libc::signal(libc::SIGTERM, handler as *const () as libc::sighandler_t);
@@ -114,7 +117,7 @@ fn ctrlc_handler(tx: std::sync::mpsc::Sender<()>) -> std::io::Result<()> {
 }
 
 #[cfg(not(unix))]
-fn ctrlc_handler(_tx: std::sync::mpsc::Sender<()>) -> std::io::Result<()> {
+fn ctrlc_handler() -> std::io::Result<()> {
     Ok(())
 }
 
@@ -123,7 +126,7 @@ struct ParseError;
 
 fn parse_args(args: &[String]) -> Result<ServerConfig, ParseError> {
     let mut config = ServerConfig::default_loopback();
-    config.initial.sample_rate_hz = 2_048_000;
+    config.initial.sample_rate_hz = DEFAULT_SAMPLE_RATE_HZ;
 
     let mut i = 0;
     while i < args.len() {

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -17,8 +17,9 @@
 //! in the review of epic #299:
 //!
 //! - Upstream defaults to `-a 127.0.0.1` (loopback). We keep that.
-//! - Upstream rejects `-g 0` (auto-gain) and requires an explicit value.
-//!   We follow upstream: `gain == 0` means automatic.
+//! - Upstream and we both treat `-g 0` as "automatic gain mode" (no
+//!   manual gain set); see `parse_auto_gain_is_none` test for the
+//!   exact behavior.
 
 use std::net::IpAddr;
 use std::process::ExitCode;
@@ -291,15 +292,17 @@ fn parse_hz(s: &str) -> Result<u32, ParseError> {
             (s, 1u64)
         };
     let n: f64 = number.parse().map_err(|_| ParseError)?;
-    // Reject NaN / ±Inf outright. Without this check `f64 as i64`
-    // silently converts NaN → 0 and ±Inf → saturating i64 bounds, both
-    // of which would then pass or miss the range guard in ways that
-    // produce a plausible-looking frequency from garbage input.
-    if !n.is_finite() {
+    // Reject NaN / ±Inf AND any negative input outright. Without the
+    // negative-guard, `parse_hz("-0.4")` would round-to-zero and pass
+    // the u32 range check as a valid 0 Hz frequency; without the
+    // is_finite guard, `f64 as i64` silently converts NaN → 0 and ±Inf
+    // → saturating i64 bounds. Both paths could turn garbage input
+    // into plausible-looking output.
+    if !n.is_finite() || n < 0.0 {
         return Err(ParseError);
     }
-    let hz = (n * multiplier as f64).round() as i64;
-    if hz < 0 || hz > u32::MAX as i64 {
+    let hz = (n * multiplier as f64).round();
+    if hz > f64::from(u32::MAX) {
         return Err(ParseError);
     }
     Ok(hz as u32)
@@ -427,6 +430,18 @@ mod tests {
     fn parse_hz_accepts_fractional_suffix_values() {
         assert_eq!(parse_hz("1.5k").unwrap(), 1_500);
         assert_eq!(parse_hz("0.1M").unwrap(), 100_000);
+    }
+
+    #[test]
+    fn parse_hz_rejects_negative_fractional_before_rounding() {
+        // `parse_hz("-0.4")` would previously round to 0, pass the
+        // u32 range check, and be accepted as a plausible 0 Hz
+        // frequency. The pre-cast `n < 0.0` guard catches it as a
+        // parse error instead.
+        assert!(parse_hz("-0.4").is_err());
+        assert!(parse_hz("-0.5").is_err());
+        assert!(parse_hz("-0.4k").is_err());
+        assert!(parse_hz("-1e-10").is_err());
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -154,7 +154,15 @@ fn parse_args(args: &[String]) -> Result<ServerConfig, ParseError> {
                 let v = args.get(i + 1).ok_or(ParseError)?;
                 // Upstream: `gain = (int)(atof(optarg) * 10)`. Value 0
                 // means automatic gain mode; anything else is tenths-of-dB.
+                //
+                // Explicitly reject NaN and ±Inf: Rust's `f64 as i32`
+                // silently converts NaN → 0 (which would switch to auto
+                // gain) and ±Inf → saturating i32 bounds. We want a
+                // parse error rather than a plausible-looking value.
                 let db: f64 = v.parse().map_err(|_| ParseError)?;
+                if !db.is_finite() {
+                    return Err(ParseError);
+                }
                 let tenths = (db * 10.0).round() as i32;
                 config.initial.gain_tenths_db = if tenths == 0 { None } else { Some(tenths) };
                 i += 2;
@@ -209,6 +217,13 @@ fn parse_hz(s: &str) -> Result<u32, ParseError> {
             (s, 1u64)
         };
     let n: f64 = number.parse().map_err(|_| ParseError)?;
+    // Reject NaN / ±Inf outright. Without this check `f64 as i64`
+    // silently converts NaN → 0 and ±Inf → saturating i64 bounds, both
+    // of which would then pass or miss the range guard in ways that
+    // produce a plausible-looking frequency from garbage input.
+    if !n.is_finite() {
+        return Err(ParseError);
+    }
     let hz = (n * multiplier as f64).round() as i64;
     if hz < 0 || hz > u32::MAX as i64 {
         return Err(ParseError);
@@ -277,6 +292,31 @@ mod tests {
         assert!(parse_hz("").is_err());
         assert!(parse_hz("5MHz").is_err()); // trailing "Hz" not valid suffix
         assert!(parse_hz("-100").is_err()); // negative Hz not representable as u32
+    }
+
+    #[test]
+    fn parse_hz_rejects_nan_and_infinity() {
+        // `f64::parse` accepts these; without the `is_finite` guard the
+        // subsequent `as i64` cast silently converts NaN → 0 and ±Inf to
+        // saturating bounds — producing plausible-looking output from
+        // garbage. Verify both paths reject.
+        assert!(parse_hz("NaN").is_err());
+        assert!(parse_hz("nan").is_err());
+        assert!(parse_hz("inf").is_err());
+        assert!(parse_hz("Infinity").is_err());
+        assert!(parse_hz("-inf").is_err());
+        assert!(parse_hz("NaNk").is_err()); // with suffix too
+    }
+
+    #[test]
+    fn parse_gain_rejects_nan_and_infinity() {
+        for v in ["NaN", "inf", "-inf", "Infinity"] {
+            let args = vec!["-g".to_string(), v.to_string()];
+            assert!(
+                parse_args(&args).is_err(),
+                "parse_args should reject -g {v}"
+            );
+        }
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -102,8 +102,14 @@ fn main() -> ExitCode {
     match Server::start(config) {
         Ok(server) => {
             tracing::info!(bind = %server.bind_address(), "rtl_tcp server running");
+            // Install the signal handler BEFORE entering the sleep loop.
+            // The loop has no alternate shutdown path, so a failed install
+            // leaves the process unkillable without SIGKILL — fatal, not
+            // a warning.
             if let Err(e) = ctrlc_handler() {
-                tracing::warn!(%e, "ctrl-c handler setup failed — kill the process manually");
+                tracing::error!(%e, "ctrl-c handler setup failed — aborting");
+                drop(server);
+                return ExitCode::FAILURE;
             }
             // Poll the shutdown flag instead of using an mpsc channel,
             // because the signal handler can only safely touch an atomic.
@@ -135,6 +141,10 @@ static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
 
 /// Install a minimal SIGINT/SIGTERM handler. Matches the upstream pattern
 /// at `rtl_tcp.c:477-488`, but without the non-async-signal-safe locking.
+///
+/// Returns `Err` if either `signal()` call fails — the caller MUST treat
+/// this as fatal, because the sleep loop in `main` has no alternate
+/// shutdown path and would leave the process unresponsive to Ctrl-C.
 #[cfg(unix)]
 #[allow(unsafe_code)]
 fn ctrlc_handler() -> std::io::Result<()> {
@@ -145,16 +155,28 @@ fn ctrlc_handler() -> std::io::Result<()> {
     // SAFETY: `handler` has the correct `extern "C" fn(c_int)` signature
     // for a POSIX signal handler and touches only an AtomicBool, which
     // is on the POSIX async-signal-safe list.
+    let handler_ptr = handler as *const () as libc::sighandler_t;
     unsafe {
-        libc::signal(libc::SIGINT, handler as *const () as libc::sighandler_t);
-        libc::signal(libc::SIGTERM, handler as *const () as libc::sighandler_t);
+        if libc::signal(libc::SIGINT, handler_ptr) == libc::SIG_ERR {
+            return Err(std::io::Error::last_os_error());
+        }
+        if libc::signal(libc::SIGTERM, handler_ptr) == libc::SIG_ERR {
+            return Err(std::io::Error::last_os_error());
+        }
     }
     Ok(())
 }
 
+/// Non-unix targets have no signal handling plumbing yet. Return an
+/// explicit Unsupported error rather than `Ok(())`, because an `Ok`
+/// result would let `main` enter its sleep loop without a shutdown
+/// path.
 #[cfg(not(unix))]
 fn ctrlc_handler() -> std::io::Result<()> {
-    Ok(())
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "signal handling not implemented on this platform",
+    ))
 }
 
 #[derive(Debug)]

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -29,25 +29,56 @@ use std::time::Duration;
 use sdr_server_rtltcp::server::{DEFAULT_SAMPLE_RATE_HZ, Server, ServerConfig};
 use sdr_server_rtltcp::{DEFAULT_BUFFER_CAPACITY, DEFAULT_PORT};
 
-fn usage() -> ! {
-    eprintln!("sdr-rtl-tcp — I/Q spectrum server for RTL-SDR dongles");
-    eprintln!();
-    eprintln!("USAGE:");
-    eprintln!("    sdr-rtl-tcp [OPTIONS]");
-    eprintln!();
-    eprintln!("OPTIONS:");
-    eprintln!("    -a <addr>    Listen address (default: 127.0.0.1)");
-    eprintln!("    -p <port>    Listen port (default: {DEFAULT_PORT})");
-    eprintln!("    -f <hz>      Initial center frequency (accepts k/M/G suffix)");
-    eprintln!("    -g <gain>    Tuner gain in dB (default: 0 = automatic)");
-    eprintln!("    -s <rate>    Sample rate in Hz (default: 2048000)");
-    eprintln!("    -d <idx>     Device index (default: 0)");
-    eprintln!("    -P <ppm>     Frequency correction in ppm (default: 0)");
-    eprintln!("    -n <N>       Max queued USB buffers (default: {DEFAULT_BUFFER_CAPACITY})");
-    eprintln!("    -T           Enable bias tee");
-    eprintln!("    -D           Enable direct sampling (mode 2, Q branch)");
-    eprintln!("    -h, --help   Show this help");
-    std::process::exit(1);
+/// Print the `--help` / `-h` message and exit with the given status code.
+///
+/// Exit 0 when invoked via `-h`/`--help` (successful help request), exit 1
+/// for unknown / malformed arguments. Shells and packaging checks treat a
+/// non-zero exit from `--help` as a failure, so those paths must diverge.
+fn usage(exit_code: i32) -> ! {
+    let out: &mut dyn std::io::Write = if exit_code == 0 {
+        &mut std::io::stdout()
+    } else {
+        &mut std::io::stderr()
+    };
+    let _ = writeln!(out, "sdr-rtl-tcp — I/Q spectrum server for RTL-SDR dongles");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "USAGE:");
+    let _ = writeln!(out, "    sdr-rtl-tcp [OPTIONS]");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "OPTIONS:");
+    let _ = writeln!(out, "    -a <addr>    Listen address (default: 127.0.0.1)");
+    let _ = writeln!(
+        out,
+        "    -p <port>    Listen port (default: {DEFAULT_PORT})"
+    );
+    let _ = writeln!(
+        out,
+        "    -f <hz>      Initial center frequency (accepts k/M/G suffix)"
+    );
+    let _ = writeln!(
+        out,
+        "    -g <gain>    Tuner gain in dB (default: 0 = automatic)"
+    );
+    let _ = writeln!(
+        out,
+        "    -s <rate>    Sample rate in Hz (default: {DEFAULT_SAMPLE_RATE_HZ})"
+    );
+    let _ = writeln!(out, "    -d <idx>     Device index (default: 0)");
+    let _ = writeln!(
+        out,
+        "    -P <ppm>     Frequency correction in ppm (default: 0)"
+    );
+    let _ = writeln!(
+        out,
+        "    -n <N>       Max queued USB buffers (default: {DEFAULT_BUFFER_CAPACITY})"
+    );
+    let _ = writeln!(out, "    -T           Enable bias tee");
+    let _ = writeln!(
+        out,
+        "    -D           Enable direct sampling (mode 2, Q branch)"
+    );
+    let _ = writeln!(out, "    -h, --help   Show this help");
+    std::process::exit(exit_code);
 }
 
 fn main() -> ExitCode {
@@ -59,8 +90,13 @@ fn main() -> ExitCode {
         .init();
 
     let args: Vec<String> = std::env::args().skip(1).collect();
+    // -h / --help asked for help explicitly — exit 0. Anything else that
+    // fails to parse is a user error — exit 1.
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        usage(0);
+    }
     let Ok(config) = parse_args(&args) else {
-        usage();
+        usage(1);
     };
 
     match Server::start(config) {
@@ -155,15 +191,23 @@ fn parse_args(args: &[String]) -> Result<ServerConfig, ParseError> {
                 // Upstream: `gain = (int)(atof(optarg) * 10)`. Value 0
                 // means automatic gain mode; anything else is tenths-of-dB.
                 //
-                // Explicitly reject NaN and ±Inf: Rust's `f64 as i32`
-                // silently converts NaN → 0 (which would switch to auto
-                // gain) and ±Inf → saturating i32 bounds. We want a
-                // parse error rather than a plausible-looking value.
+                // Explicitly reject NaN / ±Inf and oversized finite values:
+                //   - NaN / ±Inf: `f64 as i32` silently converts NaN → 0
+                //     (which would switch to auto gain) and ±Inf → saturating
+                //     i32 bounds.
+                //   - Oversized finite (e.g., 1e100): also saturates silently
+                //     to i32::MAX, producing an absurd gain setting from what
+                //     parsed as a valid float. Range-check before the cast so
+                //     garbage input surfaces as a parse error instead.
                 let db: f64 = v.parse().map_err(|_| ParseError)?;
                 if !db.is_finite() {
                     return Err(ParseError);
                 }
-                let tenths = (db * 10.0).round() as i32;
+                let tenths_f = (db * 10.0).round();
+                if tenths_f < i32::MIN as f64 || tenths_f > i32::MAX as f64 {
+                    return Err(ParseError);
+                }
+                let tenths = tenths_f as i32;
                 config.initial.gain_tenths_db = if tenths == 0 { None } else { Some(tenths) };
                 i += 2;
             }
@@ -316,6 +360,36 @@ mod tests {
                 parse_args(&args).is_err(),
                 "parse_args should reject -g {v}"
             );
+        }
+    }
+
+    #[test]
+    fn parse_gain_rejects_oversized_finite_values() {
+        // Finite f64s large enough that (db * 10.0) overflows i32 must
+        // be rejected rather than saturating silently to i32::MAX.
+        // Covers the gap that `is_finite()` alone doesn't catch.
+        for v in ["1e100", "1e20", "-1e100", "1e10"] {
+            let args = vec!["-g".to_string(), v.to_string()];
+            assert!(
+                parse_args(&args).is_err(),
+                "parse_args should reject oversized -g {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_gain_accepts_realistic_range() {
+        // Sanity check the valid gain range isn't accidentally rejected.
+        // RTL-SDR tuner gain table goes ~0..49.6 dB; pick a few plausible values.
+        for (v, want) in [
+            ("0", None),
+            ("14.4", Some(144)),
+            ("49.6", Some(496)),
+            ("-5", Some(-50)),
+        ] {
+            let args = vec!["-g".to_string(), v.to_string()];
+            let cfg = parse_args(&args).unwrap();
+            assert_eq!(cfg.initial.gain_tenths_db, want, "gain {v}");
         }
     }
 

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -1,0 +1,277 @@
+#![allow(
+    clippy::doc_markdown,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_lossless,
+    clippy::cast_precision_loss,
+    clippy::unnecessary_wraps,
+    clippy::items_after_statements,
+    clippy::collapsible_if,
+    clippy::match_same_arms
+)]
+//! `sdr-rtl-tcp` — rtl_tcp-compatible CLI server.
+//!
+//! Faithful port of `original/librtlsdr/src/rtl_tcp.c` `main()` — same
+//! short options, same defaults where practical, with one change noted
+//! in the review of epic #299:
+//!
+//! - Upstream defaults to `-a 127.0.0.1` (loopback). We keep that.
+//! - Upstream rejects `-g 0` (auto-gain) and requires an explicit value.
+//!   We follow upstream: `gain == 0` means automatic.
+
+use std::net::IpAddr;
+use std::process::ExitCode;
+use std::str::FromStr;
+
+use sdr_server_rtltcp::server::{Server, ServerConfig};
+use sdr_server_rtltcp::{DEFAULT_BUFFER_CAPACITY, DEFAULT_PORT};
+
+fn usage() -> ! {
+    eprintln!("sdr-rtl-tcp — I/Q spectrum server for RTL-SDR dongles");
+    eprintln!();
+    eprintln!("USAGE:");
+    eprintln!("    sdr-rtl-tcp [OPTIONS]");
+    eprintln!();
+    eprintln!("OPTIONS:");
+    eprintln!("    -a <addr>    Listen address (default: 127.0.0.1)");
+    eprintln!("    -p <port>    Listen port (default: {DEFAULT_PORT})");
+    eprintln!("    -f <hz>      Initial center frequency (accepts k/M/G suffix)");
+    eprintln!("    -g <gain>    Tuner gain in dB (default: 0 = automatic)");
+    eprintln!("    -s <rate>    Sample rate in Hz (default: 2048000)");
+    eprintln!("    -d <idx>     Device index (default: 0)");
+    eprintln!("    -P <ppm>     Frequency correction in ppm (default: 0)");
+    eprintln!("    -n <N>       Max queued USB buffers (default: {DEFAULT_BUFFER_CAPACITY})");
+    eprintln!("    -T           Enable bias tee");
+    eprintln!("    -D           Enable direct sampling (mode 2, Q branch)");
+    eprintln!("    -h, --help   Show this help");
+    std::process::exit(1);
+}
+
+fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let Ok(config) = parse_args(&args) else {
+        usage();
+    };
+
+    match Server::start(config) {
+        Ok(server) => {
+            tracing::info!(bind = %server.bind_address(), "rtl_tcp server running");
+            // Sit in the foreground until Ctrl-C. On SIGINT, dropping the
+            // Server handle drives shutdown.
+            let (tx, rx) = std::sync::mpsc::channel::<()>();
+            if let Err(e) = ctrlc_handler(tx) {
+                tracing::warn!(%e, "ctrl-c handler setup failed — kill the process manually");
+            }
+            let _ = rx.recv();
+            tracing::info!("shutting down");
+            drop(server);
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("sdr-rtl-tcp: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Install a minimal SIGINT/SIGTERM handler that signals the main thread
+/// to stop. Uses the same pattern as `rtl_tcp.c:477-488`.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn ctrlc_handler(tx: std::sync::mpsc::Sender<()>) -> std::io::Result<()> {
+    use std::sync::Mutex;
+    static SENDER: Mutex<Option<std::sync::mpsc::Sender<()>>> = Mutex::new(None);
+    if let Ok(mut slot) = SENDER.lock() {
+        *slot = Some(tx);
+    }
+    extern "C" fn handler(_: libc::c_int) {
+        if let Ok(slot) = SENDER.lock() {
+            if let Some(tx) = slot.as_ref() {
+                let _ = tx.send(());
+            }
+        }
+    }
+    // SAFETY: `handler` is `extern "C"` with the correct signature for a
+    // POSIX signal handler. We install it for SIGINT / SIGTERM only; the
+    // handler body uses a Mutex + mpsc Sender, both of which are safe to
+    // call from a signal context for this workload (mpsc send is
+    // non-allocating when the receiver is alive; we don't care if a
+    // pathological double-ctrl-c hits the locked path because the handler
+    // just returns without sending).
+    unsafe {
+        libc::signal(libc::SIGINT, handler as *const () as libc::sighandler_t);
+        libc::signal(libc::SIGTERM, handler as *const () as libc::sighandler_t);
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ctrlc_handler(_tx: std::sync::mpsc::Sender<()>) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ParseError;
+
+fn parse_args(args: &[String]) -> Result<ServerConfig, ParseError> {
+    let mut config = ServerConfig::default_loopback();
+    config.initial.sample_rate_hz = 2_048_000;
+
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        match arg {
+            "-h" | "--help" => return Err(ParseError),
+            "-a" => {
+                let v = args.get(i + 1).ok_or(ParseError)?;
+                let ip = IpAddr::from_str(v).map_err(|_| ParseError)?;
+                config.bind.set_ip(ip);
+                i += 2;
+            }
+            "-p" => {
+                let v = args.get(i + 1).ok_or(ParseError)?;
+                let port: u16 = v.parse().map_err(|_| ParseError)?;
+                config.bind.set_port(port);
+                i += 2;
+            }
+            "-f" => {
+                let v = args.get(i + 1).ok_or(ParseError)?;
+                config.initial.center_freq_hz = parse_hz(v)?;
+                i += 2;
+            }
+            "-g" => {
+                let v = args.get(i + 1).ok_or(ParseError)?;
+                // Upstream: `gain = (int)(atof(optarg) * 10)`. Value 0
+                // means automatic gain mode; anything else is tenths-of-dB.
+                let db: f64 = v.parse().map_err(|_| ParseError)?;
+                let tenths = (db * 10.0).round() as i32;
+                config.initial.gain_tenths_db = if tenths == 0 { None } else { Some(tenths) };
+                i += 2;
+            }
+            "-s" => {
+                let v = args.get(i + 1).ok_or(ParseError)?;
+                config.initial.sample_rate_hz = parse_hz(v)?;
+                i += 2;
+            }
+            "-d" => {
+                let v = args.get(i + 1).ok_or(ParseError)?;
+                config.device_index = v.parse().map_err(|_| ParseError)?;
+                i += 2;
+            }
+            "-P" => {
+                let v = args.get(i + 1).ok_or(ParseError)?;
+                config.initial.ppm = v.parse().map_err(|_| ParseError)?;
+                i += 2;
+            }
+            "-n" => {
+                let v = args.get(i + 1).ok_or(ParseError)?;
+                config.buffer_capacity = v.parse().map_err(|_| ParseError)?;
+                i += 2;
+            }
+            "-T" => {
+                config.initial.bias_tee = true;
+                i += 1;
+            }
+            "-D" => {
+                // Upstream hardcodes direct-sampling mode 2 (Q branch).
+                config.initial.direct_sampling = 2;
+                i += 1;
+            }
+            _ => return Err(ParseError),
+        }
+    }
+
+    Ok(config)
+}
+
+/// Port of upstream `atofs()` — accepts `k` / `M` / `G` suffix multipliers.
+/// Returns Hz as u32.
+fn parse_hz(s: &str) -> Result<u32, ParseError> {
+    let (number, multiplier) =
+        if let Some(stripped) = s.strip_suffix('k').or_else(|| s.strip_suffix('K')) {
+            (stripped, 1_000u64)
+        } else if let Some(stripped) = s.strip_suffix('M') {
+            (stripped, 1_000_000u64)
+        } else if let Some(stripped) = s.strip_suffix('G') {
+            (stripped, 1_000_000_000u64)
+        } else {
+            (s, 1u64)
+        };
+    let n: f64 = number.parse().map_err(|_| ParseError)?;
+    let hz = (n * multiplier as f64).round() as i64;
+    if hz < 0 || hz > u32::MAX as i64 {
+        return Err(ParseError);
+    }
+    Ok(hz as u32)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hz_plain() {
+        assert_eq!(parse_hz("2048000").unwrap(), 2_048_000);
+    }
+
+    #[test]
+    fn parse_hz_kilo() {
+        assert_eq!(parse_hz("2400k").unwrap(), 2_400_000);
+        assert_eq!(parse_hz("2400K").unwrap(), 2_400_000);
+    }
+
+    #[test]
+    fn parse_hz_mega() {
+        assert_eq!(parse_hz("100M").unwrap(), 100_000_000);
+        assert_eq!(parse_hz("100.5M").unwrap(), 100_500_000);
+    }
+
+    #[test]
+    fn parse_hz_giga() {
+        assert_eq!(parse_hz("1G").unwrap(), 1_000_000_000);
+    }
+
+    #[test]
+    fn parse_defaults_are_loopback_and_upstream_port() {
+        let cfg = parse_args(&[]).unwrap();
+        assert_eq!(cfg.bind.ip().to_string(), "127.0.0.1");
+        assert_eq!(cfg.bind.port(), DEFAULT_PORT);
+    }
+
+    #[test]
+    fn parse_auto_gain_is_none() {
+        let args = vec!["-g".to_string(), "0".to_string()];
+        let cfg = parse_args(&args).unwrap();
+        assert!(cfg.initial.gain_tenths_db.is_none());
+    }
+
+    #[test]
+    fn parse_manual_gain_rounds_to_tenths() {
+        let args = vec!["-g".to_string(), "28.2".to_string()];
+        let cfg = parse_args(&args).unwrap();
+        assert_eq!(cfg.initial.gain_tenths_db, Some(282));
+    }
+
+    #[test]
+    fn parse_direct_sampling_hardcodes_mode_2() {
+        let args = vec!["-D".to_string()];
+        let cfg = parse_args(&args).unwrap();
+        assert_eq!(cfg.initial.direct_sampling, 2);
+    }
+
+    #[test]
+    fn parse_bind_override() {
+        let args = vec!["-a".to_string(), "0.0.0.0".to_string()];
+        let cfg = parse_args(&args).unwrap();
+        assert_eq!(cfg.bind.ip().to_string(), "0.0.0.0");
+    }
+}

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -30,6 +30,16 @@ use std::time::Duration;
 use sdr_server_rtltcp::server::{DEFAULT_SAMPLE_RATE_HZ, Server, ServerConfig};
 use sdr_server_rtltcp::{DEFAULT_BUFFER_CAPACITY, DEFAULT_PORT};
 
+/// How often `main` polls the shutdown / server-stopped flags. Below
+/// any user-perceptible latency; costs a few syscalls per second while
+/// the server is idle.
+const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Direct-sampling mode the upstream `-D` flag activates.
+/// Upstream rtl_tcp.c hard-codes `2` (Q branch); we match that
+/// exactly.
+const DIRECT_SAMPLING_Q_BRANCH: i32 = 2;
+
 /// Print the `--help` / `-h` message and exit with the given status code.
 ///
 /// Exit 0 when invoked via `-h`/`--help` (successful help request), exit 1
@@ -120,7 +130,7 @@ fn main() -> ExitCode {
             // stopped. 100 ms poll is well below any user-perceptible
             // shutdown lag and costs nothing while idle.
             while !CTRL_C_RECEIVED.load(Ordering::SeqCst) && !server.has_stopped() {
-                std::thread::sleep(Duration::from_millis(100));
+                std::thread::sleep(SHUTDOWN_POLL_INTERVAL);
             }
             if server.has_stopped() {
                 tracing::info!("rtl_tcp server stopped serving — exiting");
@@ -275,7 +285,7 @@ fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<ServerConfig, ParseError> {
             }
             "-D" => {
                 // Upstream hardcodes direct-sampling mode 2 (Q branch).
-                config.initial.direct_sampling = 2;
+                config.initial.direct_sampling = DIRECT_SAMPLING_Q_BRANCH;
                 i += 1;
             }
             _ => return Err(ParseError),
@@ -299,11 +309,11 @@ fn parse_hz(s: &str) -> Result<u32, ParseError> {
             (s, 1u64)
         };
     let n: f64 = number.parse().map_err(|_| ParseError)?;
-    // Reject NaN / ±Inf AND any negative input outright. Without the
-    // negative-guard, `parse_hz("-0.4")` would round-to-zero and pass
-    // the u32 range check as a valid 0 Hz frequency; without the
-    // is_finite guard, `f64 as i64` silently converts NaN → 0 and ±Inf
-    // → saturating i64 bounds. Both paths could turn garbage input
+    // Reject NaN / ±Inf AND any negative input outright before rounding.
+    // Without the negative-guard, `parse_hz("-0.4")` would round-to-zero
+    // and pass the u32 range check as a valid 0 Hz frequency. Without
+    // the is_finite guard, `f64 as u32` silently converts NaN → 0 and
+    // ±Inf → saturating u32 bounds — either could turn garbage input
     // into plausible-looking output.
     if !n.is_finite() || n < 0.0 {
         return Err(ParseError);
@@ -375,7 +385,7 @@ mod tests {
         assert!(parse_hz("not-a-number").is_err());
         assert!(parse_hz("").is_err());
         assert!(parse_hz("5MHz").is_err()); // trailing "Hz" not valid suffix
-        assert!(parse_hz("-100").is_err()); // negative Hz not representable as u32
+        assert!(parse_hz("-100").is_err()); // caught by the `n < 0.0` guard before rounding
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -114,12 +114,19 @@ fn main() -> ExitCode {
             }
             // Poll the shutdown flag instead of using an mpsc channel,
             // because the signal handler can only safely touch an atomic.
-            // 100 ms poll is well below any user-perceptible shutdown lag
-            // and costs nothing while idle.
-            while !CTRL_C_RECEIVED.load(Ordering::SeqCst) {
+            // Also poll `server.has_stopped()` so the CLI exits when the
+            // accept thread exits on its own (e.g., dongle unplug);
+            // otherwise the process would sleep forever after serving
+            // stopped. 100 ms poll is well below any user-perceptible
+            // shutdown lag and costs nothing while idle.
+            while !CTRL_C_RECEIVED.load(Ordering::SeqCst) && !server.has_stopped() {
                 std::thread::sleep(Duration::from_millis(100));
             }
-            tracing::info!("shutting down");
+            if server.has_stopped() {
+                tracing::info!("rtl_tcp server stopped serving — exiting");
+            } else {
+                tracing::info!("shutting down");
+            }
             drop(server);
             ExitCode::SUCCESS
         }
@@ -183,34 +190,34 @@ fn ctrlc_handler() -> std::io::Result<()> {
 #[derive(Debug)]
 struct ParseError;
 
-fn parse_args(args: &[String]) -> Result<ServerConfig, ParseError> {
+fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<ServerConfig, ParseError> {
     let mut config = ServerConfig::default_loopback();
     config.initial.sample_rate_hz = DEFAULT_SAMPLE_RATE_HZ;
 
     let mut i = 0;
     while i < args.len() {
-        let arg = args[i].as_str();
+        let arg = args[i].as_ref();
         match arg {
             "-h" | "--help" => return Err(ParseError),
             "-a" => {
-                let v = args.get(i + 1).ok_or(ParseError)?;
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
                 let ip = IpAddr::from_str(v).map_err(|_| ParseError)?;
                 config.bind.set_ip(ip);
                 i += 2;
             }
             "-p" => {
-                let v = args.get(i + 1).ok_or(ParseError)?;
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
                 let port: u16 = v.parse().map_err(|_| ParseError)?;
                 config.bind.set_port(port);
                 i += 2;
             }
             "-f" => {
-                let v = args.get(i + 1).ok_or(ParseError)?;
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
                 config.initial.center_freq_hz = parse_hz(v)?;
                 i += 2;
             }
             "-g" => {
-                let v = args.get(i + 1).ok_or(ParseError)?;
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
                 // Upstream: `gain = (int)(atof(optarg) * 10)`. Value 0
                 // means automatic gain mode; anything else is tenths-of-dB.
                 //
@@ -235,7 +242,7 @@ fn parse_args(args: &[String]) -> Result<ServerConfig, ParseError> {
                 i += 2;
             }
             "-s" => {
-                let v = args.get(i + 1).ok_or(ParseError)?;
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
                 let sample_rate_hz = parse_hz(v)?;
                 // Reject 0 up front: `parse_hz` accepts it as a valid
                 // non-negative u32, but a zero sample rate wedges the
@@ -248,17 +255,17 @@ fn parse_args(args: &[String]) -> Result<ServerConfig, ParseError> {
                 i += 2;
             }
             "-d" => {
-                let v = args.get(i + 1).ok_or(ParseError)?;
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
                 config.device_index = v.parse().map_err(|_| ParseError)?;
                 i += 2;
             }
             "-P" => {
-                let v = args.get(i + 1).ok_or(ParseError)?;
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
                 config.initial.ppm = v.parse().map_err(|_| ParseError)?;
                 i += 2;
             }
             "-n" => {
-                let v = args.get(i + 1).ok_or(ParseError)?;
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
                 config.buffer_capacity = v.parse().map_err(|_| ParseError)?;
                 i += 2;
             }
@@ -337,7 +344,7 @@ mod tests {
 
     #[test]
     fn parse_defaults_are_loopback_and_upstream_port() {
-        let cfg = parse_args(&[]).unwrap();
+        let cfg = parse_args::<&str>(&[]).unwrap();
         assert_eq!(cfg.bind.ip().to_string(), "127.0.0.1");
         assert_eq!(cfg.bind.port(), DEFAULT_PORT);
     }

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -141,7 +141,11 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Err(e) => {
-            eprintln!("sdr-rtl-tcp: {e}");
+            // Route through the configured tracing subscriber so this
+            // startup failure gets structured fields + the same output
+            // sink as the rest of the crate (per-workspace rule: no
+            // `println!` / `eprintln!` in crates).
+            tracing::error!(%e, "sdr-rtl-tcp: server startup failed");
             ExitCode::FAILURE
         }
     }
@@ -201,8 +205,9 @@ fn ctrlc_handler() -> std::io::Result<()> {
 struct ParseError;
 
 fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<ServerConfig, ParseError> {
+    // `default_loopback()` seeds `initial` via `InitialDeviceState::default()`,
+    // which already uses `DEFAULT_SAMPLE_RATE_HZ`. No need to re-assign here.
     let mut config = ServerConfig::default_loopback();
-    config.initial.sample_rate_hz = DEFAULT_SAMPLE_RATE_HZ;
 
     let mut i = 0;
     while i < args.len() {

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -269,6 +269,87 @@ mod tests {
     }
 
     #[test]
+    fn parse_hz_rejects_garbage() {
+        assert!(parse_hz("not-a-number").is_err());
+        assert!(parse_hz("").is_err());
+        assert!(parse_hz("5MHz").is_err()); // trailing "Hz" not valid suffix
+        assert!(parse_hz("-100").is_err()); // negative Hz not representable as u32
+    }
+
+    #[test]
+    fn parse_hz_accepts_fractional_suffix_values() {
+        assert_eq!(parse_hz("1.5k").unwrap(), 1_500);
+        assert_eq!(parse_hz("0.1M").unwrap(), 100_000);
+    }
+
+    #[test]
+    fn parse_hz_overflows_u32_rejected() {
+        // 5 GHz > u32::MAX (~4.29 GHz)
+        assert!(parse_hz("5G").is_err());
+    }
+
+    #[test]
+    fn parse_args_missing_value_rejected() {
+        // -a requires an argument
+        let args = vec!["-a".to_string()];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_unknown_flag_rejected() {
+        let args = vec!["-X".to_string()];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_invalid_port_rejected() {
+        let args = vec!["-p".to_string(), "not-a-port".to_string()];
+        assert!(parse_args(&args).is_err());
+
+        // Port > u16::MAX is rejected by the u16 parser.
+        let args = vec!["-p".to_string(), "99999".to_string()];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_help_flag_exits() {
+        // `-h` and `--help` both return Err so `main` calls `usage()`
+        // which exits — don't call `main` in a test, just verify.
+        assert!(parse_args(&["-h".to_string()]).is_err());
+        assert!(parse_args(&["--help".to_string()]).is_err());
+    }
+
+    #[test]
+    fn parse_args_malformed_ip_rejected() {
+        let args = vec!["-a".to_string(), "not.an.ip".to_string()];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_all_flags_together() {
+        // Exercise the full parse path with every option set, so future
+        // refactors of the match keep the option ordering flexibility.
+        let args: Vec<String> = [
+            "-a", "10.0.0.5", "-p", "12345", "-f", "433.92M", "-g", "19.7", "-s", "1800k", "-d",
+            "1", "-P", "-5", "-n", "250", "-T", "-D",
+        ]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+        let cfg = parse_args(&args).unwrap();
+        assert_eq!(cfg.bind.ip().to_string(), "10.0.0.5");
+        assert_eq!(cfg.bind.port(), 12_345);
+        assert_eq!(cfg.initial.center_freq_hz, 433_920_000);
+        assert_eq!(cfg.initial.gain_tenths_db, Some(197));
+        assert_eq!(cfg.initial.sample_rate_hz, 1_800_000);
+        assert_eq!(cfg.device_index, 1);
+        assert_eq!(cfg.initial.ppm, -5);
+        assert_eq!(cfg.buffer_capacity, 250);
+        assert!(cfg.initial.bias_tee);
+        assert_eq!(cfg.initial.direct_sampling, 2);
+    }
+
+    #[test]
     fn parse_bind_override() {
         let args = vec!["-a".to_string(), "0.0.0.0".to_string()];
         let cfg = parse_args(&args).unwrap();

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -20,6 +20,19 @@
 //! - Upstream and we both treat `-g 0` as "automatic gain mode" (no
 //!   manual gain set); see `parse_auto_gain_is_none` test for the
 //!   exact behavior.
+//!
+//! **Unix-only binary.** The server library (`sdr-server-rtltcp` lib)
+//! builds on any platform, but the CLI uses POSIX `libc::signal` for
+//! Ctrl-C / graceful shutdown and has no equivalent path elsewhere.
+//! Non-Unix targets trip the `compile_error!` below — Windows support
+//! would need a `SetConsoleCtrlHandler`-based handler.
+
+#[cfg(not(unix))]
+compile_error!(
+    "sdr-rtl-tcp requires a Unix target (uses POSIX signals for graceful shutdown). \
+     Windows support would need a SetConsoleCtrlHandler-based path; \
+     file an issue if that's needed."
+);
 
 use std::net::IpAddr;
 use std::process::ExitCode;
@@ -167,7 +180,9 @@ static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
 /// Returns `Err` if either `signal()` call fails — the caller MUST treat
 /// this as fatal, because the sleep loop in `main` has no alternate
 /// shutdown path and would leave the process unresponsive to Ctrl-C.
-#[cfg(unix)]
+///
+/// Only defined on Unix — non-Unix targets trip the `compile_error!`
+/// at the top of this file.
 #[allow(unsafe_code)]
 fn ctrlc_handler() -> std::io::Result<()> {
     extern "C" fn handler(_: libc::c_int) {
@@ -187,18 +202,6 @@ fn ctrlc_handler() -> std::io::Result<()> {
         }
     }
     Ok(())
-}
-
-/// Non-unix targets have no signal handling plumbing yet. Return an
-/// explicit Unsupported error rather than `Ok(())`, because an `Ok`
-/// result would let `main` enter its sleep loop without a shutdown
-/// path.
-#[cfg(not(unix))]
-fn ctrlc_handler() -> std::io::Result<()> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "signal handling not implemented on this platform",
-    ))
 }
 
 #[derive(Debug)]

--- a/crates/sdr-server-rtltcp/src/dispatch.rs
+++ b/crates/sdr-server-rtltcp/src/dispatch.rs
@@ -1,0 +1,152 @@
+//! Command dispatcher — translates a wire `Command` into the appropriate
+//! `RtlSdrDevice` method call. Faithful port of the `switch(cmd.cmd)`
+//! block in `rtl_tcp.c:315-372`.
+//!
+//! Errors are logged but do not abort the command loop (matches upstream,
+//! which ignores each call's return code inside the `switch`).
+
+use sdr_rtlsdr::device::RtlSdrDevice;
+
+use crate::protocol::{Command, CommandOp};
+
+/// Execute a single command against the device.
+///
+/// Mirrors `rtl_tcp.c:315-372`. Upstream prints each command; we use
+/// `tracing::debug!` at the same verbosity. Errors from the device layer
+/// are logged at `warn!` and swallowed so the command channel stays up
+/// (upstream discards the int returned by each `rtlsdr_set_*` call).
+pub fn dispatch(dev: &mut RtlSdrDevice, cmd: Command) {
+    let param = cmd.param;
+    let result = match cmd.op {
+        // 0x01: rtlsdr_set_center_freq(dev, ntohl(cmd.param));
+        CommandOp::SetCenterFreq => {
+            tracing::debug!(freq_hz = param, "rtl_tcp set freq");
+            dev.set_center_freq(param)
+        }
+        // 0x02: rtlsdr_set_sample_rate(dev, ntohl(cmd.param));
+        CommandOp::SetSampleRate => {
+            tracing::debug!(rate_hz = param, "rtl_tcp set sample rate");
+            dev.set_sample_rate(param)
+        }
+        // 0x03: rtlsdr_set_tuner_gain_mode(dev, ntohl(cmd.param));
+        //       C takes int: 0 = auto, 1 = manual.
+        CommandOp::SetGainMode => {
+            let manual = param != 0;
+            tracing::debug!(manual, "rtl_tcp set gain mode");
+            dev.set_tuner_gain_mode(manual)
+        }
+        // 0x04: rtlsdr_set_tuner_gain(dev, ntohl(cmd.param));
+        //       Gain is signed tenths of dB upstream. Reinterpret u32 as i32.
+        CommandOp::SetTunerGain => {
+            #[allow(clippy::cast_possible_wrap)]
+            let gain = param as i32;
+            tracing::debug!(gain_tenths_db = gain, "rtl_tcp set tuner gain");
+            dev.set_tuner_gain(gain)
+        }
+        // 0x05: rtlsdr_set_freq_correction(dev, ntohl(cmd.param));
+        //       PPM is signed int upstream.
+        CommandOp::SetFreqCorrection => {
+            #[allow(clippy::cast_possible_wrap)]
+            let ppm = param as i32;
+            tracing::debug!(ppm, "rtl_tcp set freq correction");
+            dev.set_freq_correction(ppm)
+        }
+        // 0x06: tmp = ntohl(cmd.param);
+        //       rtlsdr_set_tuner_if_gain(dev, tmp >> 16, (short)(tmp & 0xffff));
+        //
+        // Not yet available in our sdr-rtlsdr driver (see #308). Upstream
+        // behavior for R820T/R828D/FC* is also a no-op — E4000 is the only
+        // tuner that actually programs IF gain stages. Log and drop until
+        // #308 lands.
+        CommandOp::SetIfGain => {
+            let stage = (param >> 16) as i16;
+            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+            let gain = (param & 0xffff) as i16;
+            tracing::debug!(
+                stage,
+                gain_tenths_db = gain,
+                "rtl_tcp set_tuner_if_gain: not implemented (see #308), dropping"
+            );
+            Ok(())
+        }
+        // 0x07: rtlsdr_set_testmode(dev, ntohl(cmd.param));
+        //       C takes int, non-zero = on.
+        CommandOp::SetTestMode => {
+            let on = param != 0;
+            tracing::debug!(on, "rtl_tcp set test mode");
+            dev.set_testmode(on)
+        }
+        // 0x08: rtlsdr_set_agc_mode(dev, ntohl(cmd.param));
+        CommandOp::SetAgcMode => {
+            let on = param != 0;
+            tracing::debug!(on, "rtl_tcp set agc mode");
+            dev.set_agc_mode(on)
+        }
+        // 0x09: rtlsdr_set_direct_sampling(dev, ntohl(cmd.param));
+        //       0 = off, 1 = I branch, 2 = Q branch. Upstream passes int.
+        CommandOp::SetDirectSampling => {
+            #[allow(clippy::cast_possible_wrap)]
+            let mode = param as i32;
+            tracing::debug!(mode, "rtl_tcp set direct sampling");
+            dev.set_direct_sampling(mode)
+        }
+        // 0x0a: rtlsdr_set_offset_tuning(dev, ntohl(cmd.param));
+        CommandOp::SetOffsetTuning => {
+            let on = param != 0;
+            tracing::debug!(on, "rtl_tcp set offset tuning");
+            dev.set_offset_tuning(on)
+        }
+        // 0x0b: rtlsdr_set_xtal_freq(dev, ntohl(cmd.param), 0);
+        //       Set RTL xtal only — tuner slot 0 means "leave as-is" per
+        //       our driver (see sdr-rtlsdr set_xtal_freq semantics).
+        CommandOp::SetRtlXtal => {
+            tracing::debug!(rtl_xtal_hz = param, "rtl_tcp set rtl xtal");
+            dev.set_xtal_freq(param, 0)
+        }
+        // 0x0c: rtlsdr_set_xtal_freq(dev, 0, ntohl(cmd.param));
+        //       Set tuner xtal only — RTL slot 0 means "leave as-is".
+        CommandOp::SetTunerXtal => {
+            tracing::debug!(tuner_xtal_hz = param, "rtl_tcp set tuner xtal");
+            dev.set_xtal_freq(0, param)
+        }
+        // 0x0d: set_gain_by_index(dev, ntohl(cmd.param));
+        //       Upstream helper in rtl_tcp.c:259-275. Look up gain table,
+        //       silently drop out-of-range indices, apply via set_tuner_gain.
+        CommandOp::SetGainByIndex => {
+            tracing::debug!(index = param, "rtl_tcp set gain by index");
+            set_gain_by_index(dev, param)
+        }
+        // 0x0e: rtlsdr_set_bias_tee(dev, (int)ntohl(cmd.param));
+        CommandOp::SetBiasTee => {
+            let on = param != 0;
+            tracing::debug!(on, "rtl_tcp set bias tee");
+            dev.set_bias_tee(on)
+        }
+    };
+
+    if let Err(e) = result {
+        tracing::warn!(cmd = ?cmd.op, err = %e, "rtl_tcp command failed, ignoring");
+    }
+}
+
+/// Port of `set_gain_by_index` helper in `rtl_tcp.c:259-275`:
+///
+/// ```c
+/// int count = rtlsdr_get_tuner_gains(_dev, NULL);
+/// if (count > 0 && (unsigned int)count > index) {
+///     gains = malloc(sizeof(int) * count);
+///     count = rtlsdr_get_tuner_gains(_dev, gains);
+///     res = rtlsdr_set_tuner_gain(_dev, gains[index]);
+///     free(gains);
+/// }
+/// ```
+fn set_gain_by_index(dev: &mut RtlSdrDevice, index: u32) -> Result<(), sdr_rtlsdr::RtlSdrError> {
+    let gains = dev.tuner_gains();
+    let idx = index as usize;
+    if idx >= gains.len() {
+        // Upstream silently does nothing when index is out of range.
+        return Ok(());
+    }
+    let gain = gains[idx];
+    dev.set_tuner_gain(gain)
+}

--- a/crates/sdr-server-rtltcp/src/dispatch.rs
+++ b/crates/sdr-server-rtltcp/src/dispatch.rs
@@ -9,6 +9,13 @@ use sdr_rtlsdr::device::RtlSdrDevice;
 
 use crate::protocol::{Command, CommandOp};
 
+/// Upper-16-bit field of a `SetIfGain` (0x06) param is the IF stage
+/// number; lower 16 bits is a signed gain value in tenths of dB.
+/// Wire layout matches upstream rtl_tcp.c:337-339.
+const IF_GAIN_STAGE_SHIFT_BITS: u32 = 16;
+/// Mask for the lower-16-bit signed gain field of `SetIfGain`.
+const IF_GAIN_VALUE_MASK: u32 = 0xffff;
+
 /// Execute a single command against the device.
 ///
 /// Mirrors `rtl_tcp.c:315-372`. Upstream prints each command; we use
@@ -59,9 +66,9 @@ pub fn dispatch(dev: &mut RtlSdrDevice, cmd: Command) {
         // tuner that actually programs IF gain stages. Log and drop until
         // #308 lands.
         CommandOp::SetIfGain => {
-            let stage = (param >> 16) as i16;
+            let stage = (param >> IF_GAIN_STAGE_SHIFT_BITS) as i16;
             #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-            let gain = (param & 0xffff) as i16;
+            let gain = (param & IF_GAIN_VALUE_MASK) as i16;
             tracing::debug!(
                 stage,
                 gain_tenths_db = gain,

--- a/crates/sdr-server-rtltcp/src/error.rs
+++ b/crates/sdr-server-rtltcp/src/error.rs
@@ -1,0 +1,31 @@
+//! Error types for the rtl_tcp server.
+
+use std::io;
+use thiserror::Error;
+
+/// Errors produced when starting or running the server.
+#[derive(Debug, Error)]
+pub enum ServerError {
+    /// The requested bind address is already in use. Surfaced distinctly
+    /// so callers (CLI, UI) can offer a retry-on-different-port path
+    /// without parsing generic IO errors.
+    #[error("TCP bind port already in use: {0}")]
+    PortInUse(String),
+
+    /// Generic IO error from the socket or filesystem layer.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Error from the RTL-SDR device layer (open, USB, register I/O).
+    #[error("RTL-SDR device error: {0}")]
+    Device(#[from] sdr_rtlsdr::RtlSdrError),
+
+    /// No RTL-SDR dongles plugged in.
+    #[error("no RTL-SDR device found")]
+    NoDevice,
+
+    /// Requested device index is out of range for the currently connected
+    /// dongles.
+    #[error("device index {requested} out of range (found {available})")]
+    BadDeviceIndex { requested: u32, available: u32 },
+}

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -1,0 +1,43 @@
+#![allow(
+    // C API surface has many names (`dongle_info_t`, `rtl_tcp`, `ntohl`)
+    // that don't benefit from markdown backticks in our prose.
+    clippy::doc_markdown,
+    // Arc<Mutex<...>> is moved into thread::spawn closures then consumed
+    // by worker fns; the pass-by-value is semantic ownership transfer,
+    // not an oversight.
+    clippy::needless_pass_by_value,
+    // Wire protocol layer has tight u32 ↔ i32 reinterprets that match
+    // upstream `ntohl` + C int/short casts exactly. Faithful port.
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_lossless
+)]
+//! rtl_tcp-compatible server.
+//!
+//! Faithful port of `original/librtlsdr/src/rtl_tcp.c` — a TCP server
+//! that streams 8-bit unsigned-offset I/Q samples from a locally-connected
+//! RTL-SDR dongle and accepts tuning commands from the client over the
+//! same socket.
+//!
+//! Used by:
+//! - GQRX / SDR++ / SDR# / SoapySDR clients (as the server side)
+//! - Our own [`sdr-source-network`] in rtl_tcp mode (on the client side)
+//!
+//! The wire protocol lives in [`protocol`]; the server lifecycle and
+//! threading model in [`server`]; command-to-device translation in
+//! [`dispatch`]. See module docs for the upstream line-number references.
+
+pub mod dispatch;
+pub mod error;
+pub mod protocol;
+pub mod server;
+
+pub use error::ServerError;
+pub use protocol::{
+    COMMAND_LEN, Command, CommandOp, DEFAULT_PORT, DONGLE_INFO_LEN, DONGLE_MAGIC, DongleInfo,
+    TunerTypeCode,
+};
+pub use server::{
+    DEFAULT_BUFFER_CAPACITY, InitialDeviceState, READ_BUFFER_LEN, Server, ServerConfig, ServerStats,
+};

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -39,5 +39,6 @@ pub use protocol::{
     TunerTypeCode,
 };
 pub use server::{
-    DEFAULT_BUFFER_CAPACITY, InitialDeviceState, READ_BUFFER_LEN, Server, ServerConfig, ServerStats,
+    DEFAULT_BUFFER_CAPACITY, DEFAULT_CENTER_FREQ_HZ, DEFAULT_SAMPLE_RATE_HZ, InitialDeviceState,
+    READ_BUFFER_LEN, Server, ServerConfig, ServerStats,
 };

--- a/crates/sdr-server-rtltcp/src/protocol.rs
+++ b/crates/sdr-server-rtltcp/src/protocol.rs
@@ -1,0 +1,292 @@
+//! rtl_tcp wire protocol primitives.
+//!
+//! Faithful port of the two packed structs in
+//! `original/librtlsdr/src/rtl_tcp.c`:
+//!
+//! ```c
+//! typedef struct {          // sent by server on client connect
+//!     char     magic[4];    // "RTL0"
+//!     uint32_t tuner_type;  // big-endian
+//!     uint32_t tuner_gain_count;
+//! } __attribute__((packed)) dongle_info_t;
+//!
+//! struct command {          // sent by client at any time
+//!     unsigned char cmd;
+//!     unsigned int  param;  // big-endian
+//! } __attribute__((packed));
+//! ```
+//!
+//! Both are big-endian on the wire. Layout is fixed and must not change;
+//! interop with GQRX/SDR++/SoapySDR depends on exact byte compatibility.
+
+use sdr_rtlsdr::reg::TunerType;
+
+/// The 4-byte magic prefix in `dongle_info_t`.
+pub const DONGLE_MAGIC: [u8; 4] = *b"RTL0";
+
+/// Serialized size of `dongle_info_t` on the wire.
+pub const DONGLE_INFO_LEN: usize = 12;
+
+/// Serialized size of a command message on the wire.
+pub const COMMAND_LEN: usize = 5;
+
+/// Default TCP port used by upstream `rtl_tcp`.
+pub const DEFAULT_PORT: u16 = 1234;
+
+/// Tuner-type codes as they appear in `dongle_info_t.tuner_type`.
+///
+/// Values match `enum rtlsdr_tuner` in upstream `rtl-sdr.h` — do not
+/// renumber without breaking wire compatibility.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TunerTypeCode {
+    Unknown = 0,
+    E4000 = 1,
+    Fc0012 = 2,
+    Fc0013 = 3,
+    Fc2580 = 4,
+    R820t = 5,
+    R828d = 6,
+}
+
+impl From<TunerType> for TunerTypeCode {
+    fn from(t: TunerType) -> Self {
+        match t {
+            TunerType::Unknown => TunerTypeCode::Unknown,
+            TunerType::E4000 => TunerTypeCode::E4000,
+            TunerType::Fc0012 => TunerTypeCode::Fc0012,
+            TunerType::Fc0013 => TunerTypeCode::Fc0013,
+            TunerType::Fc2580 => TunerTypeCode::Fc2580,
+            TunerType::R820T => TunerTypeCode::R820t,
+            TunerType::R828D => TunerTypeCode::R828d,
+        }
+    }
+}
+
+/// 12-byte header the server writes to every newly-connected client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DongleInfo {
+    pub tuner: TunerTypeCode,
+    pub gain_count: u32,
+}
+
+impl DongleInfo {
+    /// Serialize to 12 bytes (magic + BE tuner + BE gain count).
+    pub fn to_bytes(self) -> [u8; DONGLE_INFO_LEN] {
+        let mut out = [0u8; DONGLE_INFO_LEN];
+        out[0..4].copy_from_slice(&DONGLE_MAGIC);
+        out[4..8].copy_from_slice(&(self.tuner as u32).to_be_bytes());
+        out[8..12].copy_from_slice(&self.gain_count.to_be_bytes());
+        out
+    }
+
+    /// Parse 12 bytes sent by a server.
+    ///
+    /// Returns `None` if the magic prefix is wrong.
+    pub fn from_bytes(bytes: &[u8; DONGLE_INFO_LEN]) -> Option<Self> {
+        if bytes[0..4] != DONGLE_MAGIC {
+            return None;
+        }
+        let tuner_raw = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        let gain_count = u32::from_be_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+        // Preserve the upstream numbering. Out-of-range tuner codes are
+        // treated as Unknown so we don't refuse to talk to a future-
+        // extended server that invents a new code.
+        let tuner = match tuner_raw {
+            1 => TunerTypeCode::E4000,
+            2 => TunerTypeCode::Fc0012,
+            3 => TunerTypeCode::Fc0013,
+            4 => TunerTypeCode::Fc2580,
+            5 => TunerTypeCode::R820t,
+            6 => TunerTypeCode::R828d,
+            _ => TunerTypeCode::Unknown,
+        };
+        Some(Self { tuner, gain_count })
+    }
+}
+
+/// Raw command opcode values. Exhaustively matches `rtl_tcp.c:315-372`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandOp {
+    /// 0x01 — set center frequency (Hz).
+    SetCenterFreq = 0x01,
+    /// 0x02 — set sample rate (Hz).
+    SetSampleRate = 0x02,
+    /// 0x03 — set tuner gain mode (0 = auto, 1 = manual).
+    SetGainMode = 0x03,
+    /// 0x04 — set tuner gain (tenths of dB).
+    SetTunerGain = 0x04,
+    /// 0x05 — set frequency correction (ppm).
+    SetFreqCorrection = 0x05,
+    /// 0x06 — set IF stage gain: upper 16 = stage, lower 16 = gain (signed).
+    SetIfGain = 0x06,
+    /// 0x07 — set test mode.
+    SetTestMode = 0x07,
+    /// 0x08 — set RTL2832 AGC mode.
+    SetAgcMode = 0x08,
+    /// 0x09 — set direct sampling.
+    SetDirectSampling = 0x09,
+    /// 0x0a — set offset tuning.
+    SetOffsetTuning = 0x0a,
+    /// 0x0b — set RTL xtal frequency.
+    SetRtlXtal = 0x0b,
+    /// 0x0c — set tuner xtal frequency.
+    SetTunerXtal = 0x0c,
+    /// 0x0d — set tuner gain by index.
+    SetGainByIndex = 0x0d,
+    /// 0x0e — set bias tee.
+    SetBiasTee = 0x0e,
+}
+
+impl CommandOp {
+    /// Decode a raw opcode byte. Returns `None` for unrecognized values.
+    pub fn from_u8(b: u8) -> Option<Self> {
+        match b {
+            0x01 => Some(Self::SetCenterFreq),
+            0x02 => Some(Self::SetSampleRate),
+            0x03 => Some(Self::SetGainMode),
+            0x04 => Some(Self::SetTunerGain),
+            0x05 => Some(Self::SetFreqCorrection),
+            0x06 => Some(Self::SetIfGain),
+            0x07 => Some(Self::SetTestMode),
+            0x08 => Some(Self::SetAgcMode),
+            0x09 => Some(Self::SetDirectSampling),
+            0x0a => Some(Self::SetOffsetTuning),
+            0x0b => Some(Self::SetRtlXtal),
+            0x0c => Some(Self::SetTunerXtal),
+            0x0d => Some(Self::SetGainByIndex),
+            0x0e => Some(Self::SetBiasTee),
+            _ => None,
+        }
+    }
+}
+
+/// A 5-byte command message on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Command {
+    pub op: CommandOp,
+    pub param: u32,
+}
+
+impl Command {
+    /// Serialize to 5 bytes (1 byte op + 4 bytes BE param).
+    pub fn to_bytes(self) -> [u8; COMMAND_LEN] {
+        let mut out = [0u8; COMMAND_LEN];
+        out[0] = self.op as u8;
+        out[1..5].copy_from_slice(&self.param.to_be_bytes());
+        out
+    }
+
+    /// Parse 5 bytes received from a client.
+    ///
+    /// Returns `None` if the opcode is unrecognized. Upstream silently
+    /// drops unknown opcodes (`switch(cmd.cmd)` has no `default` arm) —
+    /// we mirror that behavior at the dispatcher, not here.
+    pub fn from_bytes(bytes: &[u8; COMMAND_LEN]) -> Option<Self> {
+        let op = CommandOp::from_u8(bytes[0])?;
+        let param = u32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]);
+        Some(Self { op, param })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dongle_info_roundtrip() {
+        let info = DongleInfo {
+            tuner: TunerTypeCode::R820t,
+            gain_count: 29,
+        };
+        let bytes = info.to_bytes();
+        assert_eq!(&bytes[0..4], b"RTL0");
+        assert_eq!(
+            u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+            5
+        );
+        assert_eq!(
+            u32::from_be_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+            29
+        );
+        assert_eq!(DongleInfo::from_bytes(&bytes), Some(info));
+    }
+
+    #[test]
+    fn dongle_info_rejects_bad_magic() {
+        let mut bytes = [0u8; DONGLE_INFO_LEN];
+        bytes[0..4].copy_from_slice(b"XXXX");
+        assert!(DongleInfo::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn dongle_info_unknown_tuner_decodes_as_unknown() {
+        let mut bytes = [0u8; DONGLE_INFO_LEN];
+        bytes[0..4].copy_from_slice(b"RTL0");
+        bytes[4..8].copy_from_slice(&99u32.to_be_bytes());
+        let decoded = DongleInfo::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.tuner, TunerTypeCode::Unknown);
+    }
+
+    #[test]
+    fn command_roundtrip_all_ops() {
+        let ops = [
+            CommandOp::SetCenterFreq,
+            CommandOp::SetSampleRate,
+            CommandOp::SetGainMode,
+            CommandOp::SetTunerGain,
+            CommandOp::SetFreqCorrection,
+            CommandOp::SetIfGain,
+            CommandOp::SetTestMode,
+            CommandOp::SetAgcMode,
+            CommandOp::SetDirectSampling,
+            CommandOp::SetOffsetTuning,
+            CommandOp::SetRtlXtal,
+            CommandOp::SetTunerXtal,
+            CommandOp::SetGainByIndex,
+            CommandOp::SetBiasTee,
+        ];
+        for op in ops {
+            let cmd = Command {
+                op,
+                param: 0xdead_beef,
+            };
+            let bytes = cmd.to_bytes();
+            assert_eq!(bytes[0], op as u8);
+            assert_eq!(
+                u32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]),
+                0xdead_beef
+            );
+            assert_eq!(Command::from_bytes(&bytes), Some(cmd));
+        }
+    }
+
+    #[test]
+    fn command_rejects_unknown_op() {
+        let bytes = [0xff, 0, 0, 0, 0];
+        assert!(Command::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn center_freq_command_be_param() {
+        let cmd = Command {
+            op: CommandOp::SetCenterFreq,
+            param: 100_000_000,
+        };
+        let bytes = cmd.to_bytes();
+        // upstream uses htonl(param); 100_000_000 = 0x05F5E100
+        assert_eq!(bytes, [0x01, 0x05, 0xF5, 0xE1, 0x00]);
+    }
+
+    #[test]
+    fn tuner_type_code_mapping_matches_upstream_numbering() {
+        assert_eq!(TunerTypeCode::from(TunerType::Unknown) as u32, 0);
+        assert_eq!(TunerTypeCode::from(TunerType::E4000) as u32, 1);
+        assert_eq!(TunerTypeCode::from(TunerType::Fc0012) as u32, 2);
+        assert_eq!(TunerTypeCode::from(TunerType::Fc0013) as u32, 3);
+        assert_eq!(TunerTypeCode::from(TunerType::Fc2580) as u32, 4);
+        assert_eq!(TunerTypeCode::from(TunerType::R820T) as u32, 5);
+        assert_eq!(TunerTypeCode::from(TunerType::R828D) as u32, 6);
+    }
+}

--- a/crates/sdr-server-rtltcp/src/protocol.rs
+++ b/crates/sdr-server-rtltcp/src/protocol.rs
@@ -280,6 +280,88 @@ mod tests {
     }
 
     #[test]
+    fn command_rejects_reserved_low_opcodes() {
+        // 0x00 is not a defined opcode; upstream's switch has no default
+        // arm for it. We reject at parse time so the dispatcher's match
+        // stays exhaustive.
+        let bytes = [0x00, 0, 0, 0, 0];
+        assert!(Command::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn command_rejects_opcodes_above_0x0e() {
+        // Every value 0x0f..=0xff must be rejected — sanity-check the
+        // upper boundary so a future upstream extension doesn't leak.
+        for op in 0x0f..=0xff {
+            let bytes = [op, 1, 2, 3, 4];
+            assert!(
+                Command::from_bytes(&bytes).is_none(),
+                "opcode 0x{op:02x} should be rejected but parsed"
+            );
+        }
+    }
+
+    #[test]
+    fn all_known_opcodes_have_distinct_codes() {
+        use std::collections::HashSet;
+        let codes: HashSet<u8> = [
+            CommandOp::SetCenterFreq,
+            CommandOp::SetSampleRate,
+            CommandOp::SetGainMode,
+            CommandOp::SetTunerGain,
+            CommandOp::SetFreqCorrection,
+            CommandOp::SetIfGain,
+            CommandOp::SetTestMode,
+            CommandOp::SetAgcMode,
+            CommandOp::SetDirectSampling,
+            CommandOp::SetOffsetTuning,
+            CommandOp::SetRtlXtal,
+            CommandOp::SetTunerXtal,
+            CommandOp::SetGainByIndex,
+            CommandOp::SetBiasTee,
+        ]
+        .iter()
+        .map(|&op| op as u8)
+        .collect();
+        assert_eq!(codes.len(), 14);
+    }
+
+    #[test]
+    fn dongle_info_all_zeros_yields_unknown_tuner() {
+        let bytes = [0u8; DONGLE_INFO_LEN];
+        // Magic is not "RTL0" — must be rejected outright, not silently
+        // treated as an Unknown-tuner server.
+        assert!(DongleInfo::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn dongle_info_valid_magic_with_zero_gain_count() {
+        // Magic valid, tuner=0 (Unknown), gain_count=0 — edge case that
+        // corresponds to a dongle that enumerates with no advertised
+        // gain table. Should parse successfully.
+        let mut bytes = [0u8; DONGLE_INFO_LEN];
+        bytes[0..4].copy_from_slice(b"RTL0");
+        let info = DongleInfo::from_bytes(&bytes).unwrap();
+        assert_eq!(info.tuner, TunerTypeCode::Unknown);
+        assert_eq!(info.gain_count, 0);
+    }
+
+    #[test]
+    fn command_param_boundary_values() {
+        // Test u32 min and max to catch any accidental signed interpretation
+        // in the serialization layer.
+        for param in [0u32, 1, u32::MAX, u32::MAX - 1, 0x8000_0000] {
+            let cmd = Command {
+                op: CommandOp::SetCenterFreq,
+                param,
+            };
+            let bytes = cmd.to_bytes();
+            let decoded = Command::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded, cmd);
+        }
+    }
+
+    #[test]
     fn tuner_type_code_mapping_matches_upstream_numbering() {
         assert_eq!(TunerTypeCode::from(TunerType::Unknown) as u32, 0);
         assert_eq!(TunerTypeCode::from(TunerType::E4000) as u32, 1);

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -158,6 +158,11 @@ impl Server {
                 ServerError::Io(e)
             }
         })?;
+        // `config.bind` may request port 0 (OS-assigned); in that case
+        // the actual port is only known after bind completes. Read it
+        // back from the socket so `bind_address()` returns the real
+        // port the UI/logs can show.
+        let actual_bind = listener.local_addr().map_err(ServerError::Io)?;
         // Set a short accept timeout so the accept loop can notice the
         // shutdown flag promptly on Server::drop.
         listener.set_nonblocking(false)?;
@@ -177,7 +182,7 @@ impl Server {
         apply_initial_state(&mut device, &config.initial)?;
 
         tracing::info!(
-            bind = %config.bind,
+            bind = %actual_bind,
             tuner = ?device.tuner_type(),
             gain_count = device.tuner_gains().len(),
             "rtl_tcp server listening"
@@ -205,7 +210,7 @@ impl Server {
             shutdown,
             accept_thread: Some(accept_thread),
             stats,
-            bind: config.bind,
+            bind: actual_bind,
         })
     }
 
@@ -680,8 +685,16 @@ fn command_worker(
     stats: Arc<Mutex<ServerStats>>,
 ) {
     // Upstream loops on a 1 s select() so shutdown is noticed promptly.
+    // Our equivalent is the socket read timeout. If we can't install it,
+    // `read_full` would block indefinitely in `stream.read()` without
+    // ever re-checking the shutdown flag — which would deadlock
+    // `handle_client`'s join on this worker, then the accept thread's
+    // join on handle_client, then `Server::Drop`. Treat the failure as
+    // fatal for this client session.
     if let Err(e) = stream.set_read_timeout(Some(COMMAND_READ_TIMEOUT)) {
-        tracing::warn!(%e, "set_read_timeout on command channel failed");
+        tracing::warn!(%e, "set_read_timeout on command channel failed; dropping client");
+        shutdown.set_client();
+        return;
     }
     let mut buf = [0u8; COMMAND_LEN];
     while !shutdown.is_set() {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -48,6 +48,17 @@ pub const DEFAULT_BUFFER_CAPACITY: usize = 500;
 /// when no commands arrive (rtl_tcp.c:293-304).
 const COMMAND_READ_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Default sample rate in Hz. Matches upstream `rtl_tcp.c:DEFAULT_SAMPLE_RATE_HZ`.
+///
+/// Exposed so the CLI can share the same constant instead of hard-coding
+/// the literal — keeps CLI and library defaults in lock-step if we ever
+/// change it.
+pub const DEFAULT_SAMPLE_RATE_HZ: u32 = 2_048_000;
+
+/// Default center frequency in Hz, matching upstream rtl_tcp's
+/// `frequency = 100000000` default at rtl_tcp.c:389.
+pub const DEFAULT_CENTER_FREQ_HZ: u32 = 100_000_000;
+
 /// Server configuration.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
@@ -101,10 +112,10 @@ pub struct InitialDeviceState {
 
 impl Default for InitialDeviceState {
     fn default() -> Self {
-        // Upstream rtl_tcp.c:390 defaults.
+        // Upstream rtl_tcp.c:389-392 defaults.
         Self {
-            center_freq_hz: 100_000_000,
-            sample_rate_hz: 2_048_000,
+            center_freq_hz: DEFAULT_CENTER_FREQ_HZ,
+            sample_rate_hz: DEFAULT_SAMPLE_RATE_HZ,
             gain_tenths_db: None,
             ppm: 0,
             bias_tee: false,
@@ -188,7 +199,7 @@ impl Server {
             shutdown.clone(),
             stats.clone(),
             capacity,
-        );
+        )?;
 
         Ok(Server {
             shutdown,
@@ -263,22 +274,29 @@ fn apply_initial_state(
 
 /// Spawn the outer accept loop. Upstream's main runs this inline; we run
 /// it on a thread so `Server::start` can return a handle to the caller.
+///
+/// Returns `Err` on thread spawn failure (rare — kernel resource
+/// exhaustion). Callers propagate up to the user.
 fn spawn_accept_thread(
     listener: TcpListener,
     device: Arc<Mutex<RtlSdrDevice>>,
     shutdown: Arc<AtomicBool>,
     stats: Arc<Mutex<ServerStats>>,
     buffer_capacity: usize,
-) -> JoinHandle<()> {
+) -> std::io::Result<JoinHandle<()>> {
     thread::Builder::new()
         .name("rtl_tcp-accept".into())
         .spawn(move || {
             // Poll-accept with a short timeout so we notice shutdown within
             // a second. std's TcpListener doesn't have set_read_timeout for
             // the listen fd itself, so we use set_nonblocking + sleep.
-            listener
-                .set_nonblocking(true)
-                .expect("set listener nonblocking");
+            if let Err(e) = listener.set_nonblocking(true) {
+                tracing::error!(
+                    %e,
+                    "failed to set accept listener nonblocking, accept thread exiting"
+                );
+                return;
+            }
 
             while !shutdown.load(Ordering::Relaxed) {
                 match listener.accept() {
@@ -313,7 +331,6 @@ fn spawn_accept_thread(
             }
             tracing::debug!("rtl_tcp accept thread exiting");
         })
-        .expect("spawn accept thread")
 }
 
 fn configure_client_socket(stream: &TcpStream) {
@@ -401,7 +418,13 @@ fn handle_client(
         }
     };
     let header_bytes = header.to_bytes();
-    let mut writer = stream.try_clone().expect("clone stream for writer");
+    let mut writer = match stream.try_clone() {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!(%e, "failed to clone client stream for writer — dropping client");
+            return;
+        }
+    };
     if let Err(e) = writer.write_all(&header_bytes) {
         tracing::warn!(%e, "failed to send dongle_info_t — client gone");
         return;
@@ -418,37 +441,52 @@ fn handle_client(
     let reader_shutdown = merged_shutdown.clone();
     let reader_device = device.clone();
     let reader_stats = stats.clone();
-    let reader_handle = thread::Builder::new()
+    let Ok(reader_handle) = thread::Builder::new()
         .name("rtl_tcp-reader".into())
         .spawn(move || {
             data_worker(reader_device, tx, reader_shutdown, reader_stats);
         })
-        .expect("spawn data worker");
+    else {
+        tracing::error!("failed to spawn rtl_tcp reader thread — dropping client");
+        return;
+    };
 
     let writer_shutdown = merged_shutdown.clone();
     let writer_stats = stats.clone();
-    let writer_handle = thread::Builder::new()
+    let Ok(writer_handle) = thread::Builder::new()
         .name("rtl_tcp-writer".into())
         .spawn(move || {
             tcp_writer(writer, rx, writer_shutdown, writer_stats);
         })
-        .expect("spawn writer");
+    else {
+        tracing::error!("failed to spawn rtl_tcp writer thread — tearing down client");
+        merged_shutdown.set_client();
+        let _ = reader_handle.join();
+        return;
+    };
 
     let command_shutdown = merged_shutdown.clone();
     let command_device = device;
     let command_stats = stats;
     let command_stream = stream;
-    let command_handle = thread::Builder::new()
-        .name("rtl_tcp-command".into())
-        .spawn(move || {
-            command_worker(
-                command_stream,
-                command_device,
-                command_shutdown,
-                command_stats,
-            );
-        })
-        .expect("spawn command worker");
+    let Ok(command_handle) =
+        thread::Builder::new()
+            .name("rtl_tcp-command".into())
+            .spawn(move || {
+                command_worker(
+                    command_stream,
+                    command_device,
+                    command_shutdown,
+                    command_stats,
+                );
+            })
+    else {
+        tracing::error!("failed to spawn rtl_tcp command thread — tearing down client");
+        merged_shutdown.set_client();
+        let _ = reader_handle.join();
+        let _ = writer_handle.join();
+        return;
+    };
 
     // Wait for any worker to exit, then cancel the others.
     let _ = command_handle.join();
@@ -495,12 +533,17 @@ fn data_worker(
         dev.usb_handle()
     };
     let timeout = Duration::from_secs(1);
+    // Scratch buffer reused across iterations — only the Vec we actually
+    // send to the writer gets a fresh allocation, sized to the data the
+    // USB read returned. This avoids allocating 256 KiB on every timeout
+    // tick (reviewed on PR #313).
+    let mut scratch = vec![0u8; READ_BUFFER_LEN as usize];
 
     while !shutdown.is_set() {
-        let mut buf = vec![0u8; READ_BUFFER_LEN as usize];
-        match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut buf, timeout) {
+        match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut scratch, timeout) {
             Ok(n) if n > 0 => {
-                buf.truncate(n);
+                // Allocate only when we have real data to hand off.
+                let buf = scratch[..n].to_vec();
                 match tx.try_send(buf) {
                     Ok(()) => {}
                     Err(TrySendError::Full(_)) => {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -668,6 +668,15 @@ impl MergedShutdown {
     fn set_client(&self) {
         self.client.store(true, Ordering::SeqCst);
     }
+    /// Escalate to server-wide shutdown: the accept thread exits after
+    /// the current session tears down, and `Server::has_stopped()`
+    /// eventually observes `true`. Used for unrecoverable errors that
+    /// can't be remedied by just dropping the current client, such as
+    /// a lost USB dongle (`rusb::Error::NoDevice`).
+    fn set_global(&self) {
+        self.global.store(true, Ordering::SeqCst);
+        self.client.store(true, Ordering::SeqCst);
+    }
 }
 
 /// Continuously pull USB bulk buffers and push into the bounded queue.
@@ -739,8 +748,13 @@ fn data_worker(
                 // No data — loop and re-check shutdown.
             }
             Err(rusb::Error::NoDevice) => {
-                tracing::error!("rtl_tcp: USB device lost mid-stream");
-                shutdown.set_client();
+                // Dongle unplug is unrecoverable at the server level —
+                // the accept loop has nothing to serve. Escalate to a
+                // global shutdown so the accept thread exits, the CLI
+                // sees `has_stopped() == true`, and new clients don't
+                // connect to a dead-device server.
+                tracing::error!("rtl_tcp: USB device lost mid-stream, stopping server");
+                shutdown.set_global();
                 return;
             }
             Err(e) => {
@@ -965,6 +979,32 @@ mod tests {
         assert_eq!(stats.bytes_sent, 0);
         assert_eq!(stats.buffers_dropped, 0);
         assert!(stats.last_command.is_none());
+    }
+
+    #[test]
+    fn merged_shutdown_set_global_escalates_to_both_flags() {
+        // set_client() → client=true, global unchanged.
+        // set_global() → both flags true, so accept loop also exits.
+        // Regression test for the "NoDevice flips client only" bug:
+        // unplug used to stop the current session but leave the accept
+        // thread polling forever against a dead dongle.
+        let ms = MergedShutdown::new(
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+        );
+        assert!(!ms.is_set());
+
+        ms.set_client();
+        assert!(ms.is_set());
+        assert!(!ms.global.load(Ordering::Relaxed));
+        assert!(ms.client.load(Ordering::Relaxed));
+
+        // Reset client so we can see set_global set BOTH.
+        ms.client.store(false, Ordering::SeqCst);
+        assert!(!ms.is_set());
+        ms.set_global();
+        assert!(ms.global.load(Ordering::Relaxed));
+        assert!(ms.client.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -158,6 +158,7 @@ pub struct ServerStats {
 /// Running server handle.
 pub struct Server {
     shutdown: Arc<AtomicBool>,
+    stopped: Arc<AtomicBool>,
     accept_thread: Option<JoinHandle<()>>,
     stats: Arc<Mutex<ServerStats>>,
     bind: SocketAddr,
@@ -184,9 +185,9 @@ impl Server {
         // back from the socket so `bind_address()` returns the real
         // port the UI/logs can show.
         let actual_bind = listener.local_addr().map_err(ServerError::Io)?;
-        // Set a short accept timeout so the accept loop can notice the
-        // shutdown flag promptly on Server::drop.
-        listener.set_nonblocking(false)?;
+        // The listener is already blocking by default from `bind` —
+        // no need to force it here. The accept thread flips it to
+        // nonblocking immediately on entry.
 
         let device_count = sdr_rtlsdr::get_device_count();
         if device_count == 0 {
@@ -210,6 +211,7 @@ impl Server {
         );
 
         let shutdown = Arc::new(AtomicBool::new(false));
+        let stopped = Arc::new(AtomicBool::new(false));
         let stats = Arc::new(Mutex::new(ServerStats::default()));
 
         let dev_mutex = Arc::new(Mutex::new(device));
@@ -223,6 +225,7 @@ impl Server {
             listener,
             dev_mutex,
             shutdown.clone(),
+            stopped.clone(),
             stats.clone(),
             capacity,
             config.initial.clone(),
@@ -230,6 +233,7 @@ impl Server {
 
         Ok(Server {
             shutdown,
+            stopped,
             accept_thread: Some(accept_thread),
             stats,
             bind: actual_bind,
@@ -244,6 +248,16 @@ impl Server {
     /// The address the server is bound to.
     pub fn bind_address(&self) -> SocketAddr {
         self.bind
+    }
+
+    /// Has the accept thread exited (either via `stop()` or an
+    /// unrecoverable error like USB device loss)?
+    ///
+    /// CLI callers poll this alongside their own Ctrl-C handler so the
+    /// process exits when serving actually stops, instead of sleeping
+    /// forever after the dongle is unplugged.
+    pub fn has_stopped(&self) -> bool {
+        self.stopped.load(Ordering::Relaxed)
     }
 
     /// Signal shutdown and wait for the accept thread to exit.
@@ -335,6 +349,7 @@ fn spawn_accept_thread(
     listener: TcpListener,
     device: Arc<Mutex<RtlSdrDevice>>,
     shutdown: Arc<AtomicBool>,
+    stopped: Arc<AtomicBool>,
     stats: Arc<Mutex<ServerStats>>,
     buffer_capacity: usize,
     initial_state: InitialDeviceState,
@@ -453,6 +468,11 @@ fn spawn_accept_thread(
             if let Some(h) = session_handle.take() {
                 let _ = h.join();
             }
+            // Signal to CLI / UI callers polling `Server::has_stopped()`
+            // that the server is no longer serving. Set AFTER the
+            // session join so a caller that observes `has_stopped() ==
+            // true` can safely assume all workers have exited.
+            stopped.store(true, Ordering::SeqCst);
             tracing::debug!("rtl_tcp accept thread exiting");
         })
 }
@@ -666,7 +686,11 @@ fn data_worker(
     // mutex on every USB read (bulk read is &self-safe via usb_handle).
     let handle = {
         let Ok(dev) = device.lock() else {
-            tracing::error!("device mutex poisoned, data worker aborting");
+            // Poisoned mutex is unrecoverable shared state — close out
+            // the whole session so the writer/command workers exit too
+            // instead of spinning on a dead channel.
+            tracing::error!("device mutex poisoned, data worker aborting and closing session");
+            shutdown.set_client();
             return;
         };
         dev.usb_handle()
@@ -677,6 +701,10 @@ fn data_worker(
     // USB read returned. This avoids allocating 256 KiB on every timeout
     // tick (reviewed on PR #313).
     let mut scratch = vec![0u8; READ_BUFFER_LEN as usize];
+    // Edge-trigger flag for the tx-queue-full warning. Set when a
+    // drop happens, cleared on the first successful send after — so
+    // we log once per stall-and-drain cycle rather than per buffer.
+    let mut was_dropping = false;
 
     while !shutdown.is_set() {
         match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut scratch, timeout) {
@@ -684,15 +712,26 @@ fn data_worker(
                 // Allocate only when we have real data to hand off.
                 let buf = scratch[..n].to_vec();
                 match tx.try_send(buf) {
-                    Ok(()) => {}
+                    Ok(()) => {
+                        // Rearm the overflow edge so a future stall
+                        // logs again.
+                        was_dropping = false;
+                    }
                     Err(TrySendError::Full(_)) => {
                         // Queue is full — drop this buffer (upstream does
                         // the same when the linked list exceeds llbuf_num;
-                        // rtl_tcp.c:137-152).
+                        // rtl_tcp.c:137-152). `buffers_dropped` in the
+                        // shared stats is the authoritative cumulative
+                        // counter; the warn is just an edge signal.
                         if let Ok(mut s) = stats.lock() {
                             s.buffers_dropped = s.buffers_dropped.saturating_add(1);
                         }
-                        tracing::warn!("rtl_tcp tx queue full — dropping USB buffer");
+                        if !was_dropping {
+                            tracing::warn!(
+                                "rtl_tcp tx queue full — dropping USB buffers (further drops accumulate silently; see ServerStats::buffers_dropped)"
+                            );
+                            was_dropping = true;
+                        }
                     }
                     Err(TrySendError::Disconnected(_)) => {
                         tracing::debug!("writer gone, data worker exiting");
@@ -801,9 +840,17 @@ fn command_worker(
             tracing::debug!(op = buf[0], "rtl_tcp unknown command opcode, dropping");
             continue;
         };
-        if let Ok(mut dev) = device.lock() {
-            dispatch(&mut dev, cmd);
-        }
+        let Ok(mut dev) = device.lock() else {
+            // Same rationale as data_worker: a poisoned device mutex
+            // is unrecoverable, and silently dropping commands here
+            // would leave the client driving the UI with no visible
+            // effect on the server. Close the session.
+            tracing::error!("device mutex poisoned, command worker aborting and closing session");
+            shutdown.set_client();
+            return;
+        };
+        dispatch(&mut dev, cmd);
+        drop(dev);
         if let Ok(mut s) = stats.lock() {
             s.last_command = Some((cmd.op, Instant::now()));
         }
@@ -922,6 +969,18 @@ mod tests {
         assert_eq!(stats.bytes_sent, 0);
         assert_eq!(stats.buffers_dropped, 0);
         assert!(stats.last_command.is_none());
+    }
+
+    #[test]
+    fn has_stopped_is_false_before_accept_thread_exits() {
+        // We can't stand up a real Server without hardware, but we CAN
+        // sanity-check the `stopped` flag contract: `has_stopped()`
+        // reads the AtomicBool directly. Default state is false.
+        let stopped = Arc::new(AtomicBool::new(false));
+        assert!(!stopped.load(Ordering::Relaxed));
+        // Accept thread setting the flag → has_stopped() observes true.
+        stopped.store(true, Ordering::SeqCst);
+        assert!(stopped.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -354,20 +354,16 @@ fn spawn_accept_thread(
     buffer_capacity: usize,
     initial_state: InitialDeviceState,
 ) -> std::io::Result<JoinHandle<()>> {
+    // Poll-accept cadence means the listener must be nonblocking.
+    // Configure it BEFORE spawning so failures surface through
+    // `Server::start`'s `?` rather than getting buried inside the
+    // spawned thread body — burying it would return `Ok` to the caller
+    // and the accept thread would die without ever setting `stopped`,
+    // leaving callers polling `has_stopped()` stuck forever.
+    listener.set_nonblocking(true)?;
     thread::Builder::new()
         .name("rtl_tcp-accept".into())
         .spawn(move || {
-            // Poll-accept with a short timeout so we notice shutdown within
-            // a second. std's TcpListener doesn't have set_read_timeout for
-            // the listen fd itself, so we use set_nonblocking + sleep.
-            if let Err(e) = listener.set_nonblocking(true) {
-                tracing::error!(
-                    %e,
-                    "failed to set accept listener nonblocking, accept thread exiting"
-                );
-                return;
-            }
-
             // Session slot: set to true while a client is being served.
             // Kept in an Arc so the session thread can clear it on exit.
             // Using `swap(true, ...)` to claim the slot atomically — if

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -48,6 +48,27 @@ pub const DEFAULT_BUFFER_CAPACITY: usize = 500;
 /// when no commands arrive (rtl_tcp.c:293-304).
 const COMMAND_READ_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Sleep between non-blocking `accept()` polls. Small enough that the
+/// accept thread notices the shutdown flag within ~100 ms of `Drop`.
+/// `TcpListener` doesn't expose a per-accept timeout, so we poll with
+/// `set_nonblocking(true)` + `thread::sleep`.
+const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Backoff after an `accept()` call returns a non-WouldBlock error.
+/// Typically an exhausted-FD / out-of-memory situation — short enough
+/// to retry quickly once the transient resolves, long enough to avoid
+/// a tight log-spam loop.
+const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(200);
+
+/// `recv_timeout` in the TCP writer so it notices shutdown even when
+/// the USB reader is starving (dongle unplug, no data incoming).
+const WRITER_RECV_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Timeout on each USB bulk read in the data worker. Matches upstream's
+/// 1-second poll interval in the `rtlsdr_read_async` loop. The data
+/// worker re-checks the shutdown flag between reads.
+const USB_READ_TIMEOUT: Duration = Duration::from_secs(1);
+
 /// Default sample rate in Hz. Matches upstream `rtl_tcp.c:DEFAULT_SAMPLE_RATE_HZ`.
 ///
 /// Exposed so the CLI can share the same constant instead of hard-coding
@@ -204,6 +225,7 @@ impl Server {
             shutdown.clone(),
             stats.clone(),
             capacity,
+            config.initial.clone(),
         )?;
 
         Ok(Server {
@@ -250,9 +272,26 @@ impl Drop for Server {
     }
 }
 
+/// Lock the device and reapply initial state for a new client session.
+/// Exists so the accept loop has a small surface that wraps the lock
+/// acquisition; `apply_initial_state` itself stays lock-agnostic.
+fn reset_device_to_initial(
+    device: &Arc<Mutex<RtlSdrDevice>>,
+    initial: &InitialDeviceState,
+) -> Result<(), ServerError> {
+    let mut dev = device
+        .lock()
+        .map_err(|_| ServerError::Io(std::io::Error::other("device mutex poisoned")))?;
+    apply_initial_state(&mut dev, initial)
+}
+
 /// Apply the user's initial settings to the freshly-opened device.
 ///
-/// Mirrors the setup block in rtl_tcp.c:490-520.
+/// Mirrors the setup block in rtl_tcp.c:490-520. Called once at
+/// `Server::start` so the dongle is in a sane state even before any
+/// client connects, and again on every new client session via
+/// `reset_device_to_initial` so sequential clients don't inherit each
+/// other's tuning.
 fn apply_initial_state(
     dev: &mut RtlSdrDevice,
     initial: &InitialDeviceState,
@@ -281,6 +320,12 @@ fn apply_initial_state(
 /// Spawn the outer accept loop. Upstream's main runs this inline; we run
 /// it on a thread so `Server::start` can return a handle to the caller.
 ///
+/// `initial_state` is reapplied on every new client session so sequential
+/// clients start from a clean slate rather than inheriting the prior
+/// client's tuning / gain / direct-sampling state. Matches upstream's
+/// `accept → apply defaults → reset_buffer → spawn workers` shape,
+/// extended to the multi-client accept loop.
+///
 /// Returns `Err` on thread spawn failure (rare — kernel resource
 /// exhaustion). Callers propagate up to the user.
 fn spawn_accept_thread(
@@ -289,6 +334,7 @@ fn spawn_accept_thread(
     shutdown: Arc<AtomicBool>,
     stats: Arc<Mutex<ServerStats>>,
     buffer_capacity: usize,
+    initial_state: InitialDeviceState,
 ) -> std::io::Result<JoinHandle<()>> {
     thread::Builder::new()
         .name("rtl_tcp-accept".into())
@@ -348,6 +394,21 @@ fn spawn_accept_thread(
                         configure_client_socket(&stream);
                         update_stats_on_connect(&stats, peer);
 
+                        // Reapply initial state BEFORE spawning workers
+                        // so this client starts on clean tuning/gain
+                        // rather than inheriting the prior session's
+                        // state. Matches upstream's per-accept setup
+                        // block (rtl_tcp.c:490-520).
+                        if let Err(e) = reset_device_to_initial(&device, &initial_state) {
+                            tracing::error!(
+                                %e, %peer,
+                                "rtl_tcp failed to reset device to initial state, dropping client"
+                            );
+                            busy.store(false, Ordering::SeqCst);
+                            update_stats_on_disconnect(&stats);
+                            continue;
+                        }
+
                         let session_device = device.clone();
                         let session_shutdown = shutdown.clone();
                         let session_stats = stats.clone();
@@ -375,11 +436,11 @@ fn spawn_accept_thread(
                         }
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(100));
+                        thread::sleep(ACCEPT_POLL_INTERVAL);
                     }
                     Err(e) => {
                         tracing::error!(%e, "rtl_tcp accept error");
-                        thread::sleep(Duration::from_millis(200));
+                        thread::sleep(ACCEPT_ERROR_BACKOFF);
                     }
                 }
             }
@@ -607,7 +668,7 @@ fn data_worker(
         };
         dev.usb_handle()
     };
-    let timeout = Duration::from_secs(1);
+    let timeout = USB_READ_TIMEOUT;
     // Scratch buffer reused across iterations — only the Vec we actually
     // send to the writer gets a fresh allocation, sized to the data the
     // USB read returned. This avoids allocating 256 KiB on every timeout
@@ -665,7 +726,7 @@ fn tcp_writer(
         if shutdown.is_set() {
             return;
         }
-        match rx.recv_timeout(Duration::from_millis(500)) {
+        match rx.recv_timeout(WRITER_RECV_TIMEOUT) {
             Ok(buf) => {
                 if let Err(e) = stream.write_all(&buf) {
                     tracing::debug!(%e, "rtl_tcp client socket write failed, closing");

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -638,3 +638,74 @@ fn read_full(stream: &mut TcpStream, buf: &mut [u8], shutdown: &MergedShutdown) 
     }
     ReadResult::Ok
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_surfaces_port_conflict_as_typed_error() {
+        // Hold a port before calling Server::start — the second bind must
+        // surface as ServerError::PortInUse (not a generic IO error), so
+        // the UI can fall back without parsing error strings.
+        //
+        // This test does NOT need a real RTL-SDR dongle present because
+        // Server::start binds the listener before touching USB.
+        let holder = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = holder.local_addr().unwrap().port();
+        let config = ServerConfig {
+            bind: SocketAddr::from(([127, 0, 0, 1], port)),
+            device_index: 0,
+            initial: InitialDeviceState::default(),
+            buffer_capacity: 0,
+        };
+        match Server::start(config) {
+            Err(crate::ServerError::PortInUse(ref addr)) => {
+                assert!(addr.contains(&format!("{port}")));
+            }
+            Err(e) => panic!("expected PortInUse, got {e:?}"),
+            Ok(_) => panic!("bind should have failed"),
+        }
+        drop(holder);
+    }
+
+    #[test]
+    fn initial_device_state_defaults_match_upstream_rtl_tcp() {
+        let d = InitialDeviceState::default();
+        // rtl_tcp.c:389-392 — these are the upstream defaults.
+        assert_eq!(d.center_freq_hz, 100_000_000);
+        assert_eq!(d.sample_rate_hz, 2_048_000);
+        assert_eq!(d.ppm, 0);
+        assert!(!d.bias_tee);
+        assert_eq!(d.direct_sampling, 0);
+        assert!(d.gain_tenths_db.is_none());
+    }
+
+    #[test]
+    fn default_loopback_config_binds_localhost() {
+        let cfg = ServerConfig::default_loopback();
+        assert_eq!(cfg.bind.ip().to_string(), "127.0.0.1");
+        assert_eq!(cfg.bind.port(), crate::protocol::DEFAULT_PORT);
+        assert_eq!(cfg.buffer_capacity, DEFAULT_BUFFER_CAPACITY);
+    }
+
+    #[test]
+    fn server_stats_default_is_not_connected() {
+        let stats = ServerStats::default();
+        assert!(stats.connected_client.is_none());
+        assert!(stats.connected_since.is_none());
+        assert_eq!(stats.bytes_sent, 0);
+        assert_eq!(stats.buffers_dropped, 0);
+        assert!(stats.last_command.is_none());
+    }
+
+    #[test]
+    fn buffer_capacity_zero_uses_default() {
+        // ServerConfig exposes `buffer_capacity: 0` as "use default". This
+        // is checked during Server::start, but we can sanity-check the
+        // DEFAULT_BUFFER_CAPACITY matches upstream's llbuf_num = 500
+        // (rtl_tcp.c:61).
+        assert_eq!(DEFAULT_BUFFER_CAPACITY, 500);
+    }
+}

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -296,9 +296,12 @@ fn apply_initial_state(
     dev: &mut RtlSdrDevice,
     initial: &InitialDeviceState,
 ) -> Result<(), ServerError> {
-    if initial.direct_sampling != 0 {
-        dev.set_direct_sampling(initial.direct_sampling)?;
-    }
+    // 0 is a valid direct-sampling state (off) and MUST be applied —
+    // not skipped — so a previous session that enabled direct sampling
+    // doesn't leak its mode into the next client's session. Previously
+    // the `!= 0` guard treated 0 as "leave alone," which broke
+    // reset_device_to_initial's promise of a clean slate per client.
+    dev.set_direct_sampling(initial.direct_sampling)?;
     dev.set_freq_correction(initial.ppm)?;
     dev.set_sample_rate(initial.sample_rate_hz)?;
     dev.set_center_freq(initial.center_freq_hz)?;
@@ -720,6 +723,18 @@ fn tcp_writer(
     shutdown: MergedShutdown,
     stats: Arc<Mutex<ServerStats>>,
 ) {
+    // A slow peer that stops reading will fill its kernel receive
+    // buffer → our kernel send buffer saturates → `write_all` blocks
+    // indefinitely. Since the write path can't re-check shutdown while
+    // blocked, a wedged writer would deadlock the
+    // writer.join → handle_client → accept.join → Server::Drop chain.
+    // Setting a write timeout mirrors what `command_worker` does for
+    // reads so the same shutdown-responsiveness guarantee applies here.
+    if let Err(e) = stream.set_write_timeout(Some(WRITER_RECV_TIMEOUT)) {
+        tracing::warn!(%e, "set_write_timeout on data channel failed; dropping client");
+        shutdown.set_client();
+        return;
+    }
     // `recv_timeout` lets us notice shutdown even when the USB reader is
     // starving (e.g., dongle unplug).
     loop {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -446,8 +446,16 @@ fn update_stats_on_connect(stats: &Arc<Mutex<ServerStats>>, peer: SocketAddr) {
 
 fn update_stats_on_disconnect(stats: &Arc<Mutex<ServerStats>>) {
     if let Ok(mut s) = stats.lock() {
+        // `update_stats_on_connect` treats every counter below as
+        // session-scoped (resets them on new connect), so the
+        // disconnect path must clear them too — otherwise a UI polling
+        // `ServerStats` while no client is connected would see stale
+        // traffic / command data from the previous session.
         s.connected_client = None;
         s.connected_since = None;
+        s.bytes_sent = 0;
+        s.buffers_dropped = 0;
+        s.last_command = None;
     }
 }
 
@@ -785,6 +793,28 @@ mod tests {
         assert_eq!(cfg.bind.ip().to_string(), "127.0.0.1");
         assert_eq!(cfg.bind.port(), crate::protocol::DEFAULT_PORT);
         assert_eq!(cfg.buffer_capacity, DEFAULT_BUFFER_CAPACITY);
+    }
+
+    #[test]
+    fn update_stats_on_disconnect_clears_per_session_counters() {
+        // Session-scoped counters (bytes_sent, buffers_dropped,
+        // last_command) must be cleared when the client disconnects —
+        // otherwise a UI polling ServerStats would see stale data from
+        // the prior session while connected_client = None.
+        let stats = Arc::new(Mutex::new(ServerStats {
+            connected_client: Some(SocketAddr::from(([127, 0, 0, 1], 42_000))),
+            connected_since: Some(Instant::now()),
+            bytes_sent: 12345,
+            buffers_dropped: 7,
+            last_command: Some((CommandOp::SetCenterFreq, Instant::now())),
+        }));
+        update_stats_on_disconnect(&stats);
+        let s = stats.lock().unwrap();
+        assert!(s.connected_client.is_none());
+        assert!(s.connected_since.is_none());
+        assert_eq!(s.bytes_sent, 0);
+        assert_eq!(s.buffers_dropped, 0);
+        assert!(s.last_command.is_none());
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -298,27 +298,75 @@ fn spawn_accept_thread(
                 return;
             }
 
+            // Session slot: set to true while a client is being served.
+            // Kept in an Arc so the session thread can clear it on exit.
+            // Using `swap(true, ...)` to claim the slot atomically — if
+            // it returns true, we were already busy and this new accept
+            // must be rejected immediately (kernel had queued it in the
+            // backlog, but we refuse to hold it).
+            let busy = Arc::new(AtomicBool::new(false));
+            let mut session_handle: Option<JoinHandle<()>> = None;
+
             while !shutdown.load(Ordering::Relaxed) {
                 match listener.accept() {
                     Ok((stream, peer)) => {
+                        if busy.swap(true, Ordering::SeqCst) {
+                            tracing::info!(
+                                %peer,
+                                "rtl_tcp already serving a client — rejecting new connection"
+                            );
+                            // Close the socket immediately so the client
+                            // sees FIN instead of hanging in backlog.
+                            let _ = stream.shutdown(std::net::Shutdown::Both);
+                            // swap set busy=true, but we weren't actually
+                            // idle — the already-active session will
+                            // eventually clear busy when it exits. Leave
+                            // the flag set; don't reset.
+                            continue;
+                        }
+                        // We now own the session slot. Reap the previous
+                        // session handle if any (it must be finished,
+                        // because the session thread clears busy at its
+                        // tail — we got false from the swap, which means
+                        // the prior session already cleared it).
+                        if let Some(h) = session_handle.take() {
+                            let _ = h.join();
+                        }
+
                         tracing::info!(%peer, "rtl_tcp client connected");
-                        // Switch stream back to blocking for the per-client
-                        // workers; only the accept fd is nonblocking.
                         if let Err(e) = stream.set_nonblocking(false) {
                             tracing::error!(%e, "failed to set client socket blocking");
+                            busy.store(false, Ordering::SeqCst);
                             continue;
                         }
                         configure_client_socket(&stream);
                         update_stats_on_connect(&stats, peer);
-                        handle_client(
-                            stream,
-                            device.clone(),
-                            shutdown.clone(),
-                            stats.clone(),
-                            buffer_capacity,
-                        );
-                        update_stats_on_disconnect(&stats);
-                        tracing::info!(%peer, "rtl_tcp client disconnected");
+
+                        let session_device = device.clone();
+                        let session_shutdown = shutdown.clone();
+                        let session_stats = stats.clone();
+                        let session_busy = busy.clone();
+                        match thread::Builder::new().name("rtl_tcp-session".into()).spawn(
+                            move || {
+                                handle_client(
+                                    stream,
+                                    session_device,
+                                    session_shutdown,
+                                    session_stats.clone(),
+                                    buffer_capacity,
+                                );
+                                update_stats_on_disconnect(&session_stats);
+                                tracing::info!(%peer, "rtl_tcp client disconnected");
+                                session_busy.store(false, Ordering::SeqCst);
+                            },
+                        ) {
+                            Ok(h) => session_handle = Some(h),
+                            Err(e) => {
+                                tracing::error!(%e, "failed to spawn session thread");
+                                busy.store(false, Ordering::SeqCst);
+                                update_stats_on_disconnect(&stats);
+                            }
+                        }
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                         thread::sleep(Duration::from_millis(100));
@@ -328,6 +376,12 @@ fn spawn_accept_thread(
                         thread::sleep(Duration::from_millis(200));
                     }
                 }
+            }
+
+            // Shutdown: wait for the active session (if any) to finish
+            // before returning, so Server::drop sees all workers done.
+            if let Some(h) = session_handle.take() {
+                let _ = h.join();
             }
             tracing::debug!("rtl_tcp accept thread exiting");
         })

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -1,0 +1,640 @@
+//! TCP server — accept loop, per-client data/command/writer threads.
+//!
+//! Faithful port of the upstream rtl_tcp threading model with one Rust
+//! tweak: upstream uses a pthread condvar + linked list to decouple the
+//! libusb async callback from the TCP writer (dropping buffers when the
+//! list exceeds `llbuf_num`, default 500). We use a bounded
+//! `std::sync::mpsc::sync_channel` with identical drop-on-full semantics —
+//! simpler and no `unsafe`, same backpressure behavior.
+//!
+//! Upstream layout (rtl_tcp.c:498-720):
+//!   main: bind → accept → apply defaults → reset_buffer → spawn
+//!         tcp_worker + command_worker → rtlsdr_read_async (blocks) →
+//!         cancel_async on SIGINT → join → accept again
+//!
+//! Our layout: accept thread owns the outer loop; each accepted client
+//! spawns data_worker (USB → channel), writer (channel → TCP send), and
+//! command_worker (TCP recv → dispatch). First worker to exit signals
+//! the others via the shutdown flag.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use sdr_rtlsdr::device::RtlSdrDevice;
+
+use crate::dispatch::dispatch;
+use crate::error::ServerError;
+use crate::protocol::{COMMAND_LEN, Command, CommandOp, DongleInfo, TunerTypeCode};
+
+/// USB read buffer size (bytes). Matches `DEFAULT_BUF_LENGTH` upstream
+/// (`rtl_tcp` inherits `rtlsdr_read_async`'s 16 × 32 KiB = 256 KiB default).
+///
+/// NOTE: must be a multiple of 512 (USB bulk alignment).
+pub const READ_BUFFER_LEN: u32 = 256 * 1024;
+
+/// Maximum number of 256 KiB buffers allowed to queue between the USB
+/// reader and the TCP writer. Matches upstream's default `llbuf_num = 500`
+/// (rtl_tcp.c:61). When the queue is full, new USB buffers are dropped and
+/// a warning is logged — exactly upstream's drop-on-overflow policy.
+pub const DEFAULT_BUFFER_CAPACITY: usize = 500;
+
+/// Socket receive timeout for the command worker select loop. Upstream
+/// uses a 1-second select timeout so the loop re-checks `do_exit` even
+/// when no commands arrive (rtl_tcp.c:293-304).
+const COMMAND_READ_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Server configuration.
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// TCP bind address. **Caller is responsible for setting a safe
+    /// default** — this crate does not impose a policy. The CLI and UI
+    /// both default to loopback per epic #299 review.
+    pub bind: SocketAddr,
+
+    /// Device index (0 = first dongle).
+    pub device_index: u32,
+
+    /// Initial device state applied after open.
+    pub initial: InitialDeviceState,
+
+    /// Max queued buffers between USB reader and TCP writer. 0 = use
+    /// [`DEFAULT_BUFFER_CAPACITY`].
+    pub buffer_capacity: usize,
+}
+
+impl ServerConfig {
+    /// Config with upstream-like defaults and loopback bind. Caller is
+    /// still responsible for overriding `bind` if they want to expose
+    /// the server beyond localhost.
+    pub fn default_loopback() -> Self {
+        Self {
+            bind: SocketAddr::from(([127, 0, 0, 1], crate::protocol::DEFAULT_PORT)),
+            device_index: 0,
+            initial: InitialDeviceState::default(),
+            buffer_capacity: DEFAULT_BUFFER_CAPACITY,
+        }
+    }
+}
+
+/// Initial device state applied on open, before the first client connects.
+/// Each field matches a CLI flag in upstream rtl_tcp.
+#[derive(Debug, Clone)]
+pub struct InitialDeviceState {
+    /// `-f` center frequency in Hz.
+    pub center_freq_hz: u32,
+    /// `-s` sample rate in Hz.
+    pub sample_rate_hz: u32,
+    /// `-g` tuner gain in 0.1 dB. `None` = auto (upstream's `gain == 0`).
+    pub gain_tenths_db: Option<i32>,
+    /// `-P` frequency correction in ppm.
+    pub ppm: i32,
+    /// `-T` enable bias tee.
+    pub bias_tee: bool,
+    /// `-D` direct sampling (0 = off, 2 = Q branch — upstream hard-codes 2).
+    pub direct_sampling: i32,
+}
+
+impl Default for InitialDeviceState {
+    fn default() -> Self {
+        // Upstream rtl_tcp.c:390 defaults.
+        Self {
+            center_freq_hz: 100_000_000,
+            sample_rate_hz: 2_048_000,
+            gain_tenths_db: None,
+            ppm: 0,
+            bias_tee: false,
+            direct_sampling: 0,
+        }
+    }
+}
+
+/// Live server statistics for UI consumption.
+#[derive(Debug, Clone, Default)]
+pub struct ServerStats {
+    pub connected_client: Option<SocketAddr>,
+    pub connected_since: Option<Instant>,
+    pub bytes_sent: u64,
+    pub buffers_dropped: u64,
+    pub last_command: Option<(CommandOp, Instant)>,
+}
+
+/// Running server handle.
+pub struct Server {
+    shutdown: Arc<AtomicBool>,
+    accept_thread: Option<JoinHandle<()>>,
+    stats: Arc<Mutex<ServerStats>>,
+    bind: SocketAddr,
+}
+
+impl Server {
+    /// Bind the listener, open the RTL-SDR, apply initial defaults, and
+    /// start accepting clients.
+    ///
+    /// The returned handle owns the accept thread. Dropping it signals
+    /// shutdown and waits for the current client (if any) to disconnect.
+    pub fn start(config: ServerConfig) -> Result<Self, ServerError> {
+        // Bind first — surface port-in-use before touching the USB device
+        // so we don't leave a dongle claimed after a failed bind.
+        let listener = TcpListener::bind(config.bind).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AddrInUse {
+                ServerError::PortInUse(config.bind.to_string())
+            } else {
+                ServerError::Io(e)
+            }
+        })?;
+        // Set a short accept timeout so the accept loop can notice the
+        // shutdown flag promptly on Server::drop.
+        listener.set_nonblocking(false)?;
+
+        let device_count = sdr_rtlsdr::get_device_count();
+        if device_count == 0 {
+            return Err(ServerError::NoDevice);
+        }
+        if config.device_index >= device_count {
+            return Err(ServerError::BadDeviceIndex {
+                requested: config.device_index,
+                available: device_count,
+            });
+        }
+
+        let mut device = RtlSdrDevice::open(config.device_index)?;
+        apply_initial_state(&mut device, &config.initial)?;
+
+        tracing::info!(
+            bind = %config.bind,
+            tuner = ?device.tuner_type(),
+            gain_count = device.tuner_gains().len(),
+            "rtl_tcp server listening"
+        );
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let stats = Arc::new(Mutex::new(ServerStats::default()));
+
+        let dev_mutex = Arc::new(Mutex::new(device));
+        let capacity = if config.buffer_capacity == 0 {
+            DEFAULT_BUFFER_CAPACITY
+        } else {
+            config.buffer_capacity
+        };
+
+        let accept_thread = spawn_accept_thread(
+            listener,
+            dev_mutex,
+            shutdown.clone(),
+            stats.clone(),
+            capacity,
+        );
+
+        Ok(Server {
+            shutdown,
+            accept_thread: Some(accept_thread),
+            stats,
+            bind: config.bind,
+        })
+    }
+
+    /// Current server statistics.
+    pub fn stats(&self) -> ServerStats {
+        self.stats.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+
+    /// The address the server is bound to.
+    pub fn bind_address(&self) -> SocketAddr {
+        self.bind
+    }
+
+    /// Signal shutdown and wait for the accept thread to exit.
+    ///
+    /// Equivalent to dropping the `Server`, but lets the caller propagate
+    /// join panics if desired.
+    pub fn stop(mut self) {
+        self.initiate_shutdown();
+        if let Some(h) = self.accept_thread.take() {
+            let _ = h.join();
+        }
+    }
+
+    fn initiate_shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.initiate_shutdown();
+        if let Some(h) = self.accept_thread.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Apply the user's initial settings to the freshly-opened device.
+///
+/// Mirrors the setup block in rtl_tcp.c:490-520.
+fn apply_initial_state(
+    dev: &mut RtlSdrDevice,
+    initial: &InitialDeviceState,
+) -> Result<(), ServerError> {
+    if initial.direct_sampling != 0 {
+        dev.set_direct_sampling(initial.direct_sampling)?;
+    }
+    dev.set_freq_correction(initial.ppm)?;
+    dev.set_sample_rate(initial.sample_rate_hz)?;
+    dev.set_center_freq(initial.center_freq_hz)?;
+    match initial.gain_tenths_db {
+        None => {
+            // Upstream: `gain == 0` → automatic
+            dev.set_tuner_gain_mode(false)?;
+        }
+        Some(g) => {
+            dev.set_tuner_gain_mode(true)?;
+            dev.set_tuner_gain(g)?;
+        }
+    }
+    dev.set_bias_tee(initial.bias_tee)?;
+    dev.reset_buffer()?;
+    Ok(())
+}
+
+/// Spawn the outer accept loop. Upstream's main runs this inline; we run
+/// it on a thread so `Server::start` can return a handle to the caller.
+fn spawn_accept_thread(
+    listener: TcpListener,
+    device: Arc<Mutex<RtlSdrDevice>>,
+    shutdown: Arc<AtomicBool>,
+    stats: Arc<Mutex<ServerStats>>,
+    buffer_capacity: usize,
+) -> JoinHandle<()> {
+    thread::Builder::new()
+        .name("rtl_tcp-accept".into())
+        .spawn(move || {
+            // Poll-accept with a short timeout so we notice shutdown within
+            // a second. std's TcpListener doesn't have set_read_timeout for
+            // the listen fd itself, so we use set_nonblocking + sleep.
+            listener
+                .set_nonblocking(true)
+                .expect("set listener nonblocking");
+
+            while !shutdown.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, peer)) => {
+                        tracing::info!(%peer, "rtl_tcp client connected");
+                        // Switch stream back to blocking for the per-client
+                        // workers; only the accept fd is nonblocking.
+                        if let Err(e) = stream.set_nonblocking(false) {
+                            tracing::error!(%e, "failed to set client socket blocking");
+                            continue;
+                        }
+                        configure_client_socket(&stream);
+                        update_stats_on_connect(&stats, peer);
+                        handle_client(
+                            stream,
+                            device.clone(),
+                            shutdown.clone(),
+                            stats.clone(),
+                            buffer_capacity,
+                        );
+                        update_stats_on_disconnect(&stats);
+                        tracing::info!(%peer, "rtl_tcp client disconnected");
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(100));
+                    }
+                    Err(e) => {
+                        tracing::error!(%e, "rtl_tcp accept error");
+                        thread::sleep(Duration::from_millis(200));
+                    }
+                }
+            }
+            tracing::debug!("rtl_tcp accept thread exiting");
+        })
+        .expect("spawn accept thread")
+}
+
+fn configure_client_socket(stream: &TcpStream) {
+    // Keep TCP alive so dead clients (laptop lid closed, wifi dropped) stop
+    // wedging the server rather than trickling forever into the void.
+    // Per-platform keepalive tuning lives in std behind raw setsockopt; we
+    // enable the default which at least lets the kernel eventually notice.
+    if let Err(e) = set_keepalive(stream, true) {
+        tracing::warn!(%e, "SO_KEEPALIVE not applied (non-fatal)");
+    }
+    // Disable Nagle — commands are 5 bytes and we want snappy tuning.
+    if let Err(e) = stream.set_nodelay(true) {
+        tracing::warn!(%e, "TCP_NODELAY not applied (non-fatal)");
+    }
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn set_keepalive(stream: &TcpStream, on: bool) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let fd = stream.as_raw_fd();
+    let value: libc::c_int = libc::c_int::from(on);
+    // SAFETY: `fd` is a valid open socket for the duration of this call
+    // (we borrow `stream` by reference). `value` is a stack-local
+    // `c_int` passed as a pointer along with the matching size — this
+    // is the documented shape of `setsockopt(_, SOL_SOCKET,
+    // SO_KEEPALIVE, ...)` on every POSIX target.
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_KEEPALIVE,
+            std::ptr::addr_of!(value).cast(),
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn set_keepalive(_stream: &TcpStream, _on: bool) -> std::io::Result<()> {
+    // Non-unix targets: caller swallows the warning.
+    Ok(())
+}
+
+fn update_stats_on_connect(stats: &Arc<Mutex<ServerStats>>, peer: SocketAddr) {
+    if let Ok(mut s) = stats.lock() {
+        s.connected_client = Some(peer);
+        s.connected_since = Some(Instant::now());
+        s.bytes_sent = 0;
+        s.buffers_dropped = 0;
+        s.last_command = None;
+    }
+}
+
+fn update_stats_on_disconnect(stats: &Arc<Mutex<ServerStats>>) {
+    if let Ok(mut s) = stats.lock() {
+        s.connected_client = None;
+        s.connected_since = None;
+    }
+}
+
+/// Serve exactly one client. Spawns the three worker threads, waits for
+/// the first to exit, signals the others, joins all.
+fn handle_client(
+    stream: TcpStream,
+    device: Arc<Mutex<RtlSdrDevice>>,
+    global_shutdown: Arc<AtomicBool>,
+    stats: Arc<Mutex<ServerStats>>,
+    buffer_capacity: usize,
+) {
+    // Send the 12-byte dongle_info_t header first (rtl_tcp.c:576-594).
+    let header = {
+        let Ok(dev) = device.lock() else {
+            tracing::error!("device mutex poisoned, aborting client");
+            return;
+        };
+        DongleInfo {
+            tuner: TunerTypeCode::from(dev.tuner_type()),
+            gain_count: dev.tuner_gains().len() as u32,
+        }
+    };
+    let header_bytes = header.to_bytes();
+    let mut writer = stream.try_clone().expect("clone stream for writer");
+    if let Err(e) = writer.write_all(&header_bytes) {
+        tracing::warn!(%e, "failed to send dongle_info_t — client gone");
+        return;
+    }
+
+    // Per-client shutdown flag. Flipped when any worker exits, so the
+    // others stop quickly. Honors the global flag too.
+    let client_shutdown = Arc::new(AtomicBool::new(false));
+    let merged_shutdown = MergedShutdown::new(global_shutdown, client_shutdown);
+
+    // Buffer data path: USB bulk → bounded channel → TCP writer.
+    let (tx, rx) = sync_channel::<Vec<u8>>(buffer_capacity);
+
+    let reader_shutdown = merged_shutdown.clone();
+    let reader_device = device.clone();
+    let reader_stats = stats.clone();
+    let reader_handle = thread::Builder::new()
+        .name("rtl_tcp-reader".into())
+        .spawn(move || {
+            data_worker(reader_device, tx, reader_shutdown, reader_stats);
+        })
+        .expect("spawn data worker");
+
+    let writer_shutdown = merged_shutdown.clone();
+    let writer_stats = stats.clone();
+    let writer_handle = thread::Builder::new()
+        .name("rtl_tcp-writer".into())
+        .spawn(move || {
+            tcp_writer(writer, rx, writer_shutdown, writer_stats);
+        })
+        .expect("spawn writer");
+
+    let command_shutdown = merged_shutdown.clone();
+    let command_device = device;
+    let command_stats = stats;
+    let command_stream = stream;
+    let command_handle = thread::Builder::new()
+        .name("rtl_tcp-command".into())
+        .spawn(move || {
+            command_worker(
+                command_stream,
+                command_device,
+                command_shutdown,
+                command_stats,
+            );
+        })
+        .expect("spawn command worker");
+
+    // Wait for any worker to exit, then cancel the others.
+    let _ = command_handle.join();
+    merged_shutdown.set_client();
+    let _ = reader_handle.join();
+    let _ = writer_handle.join();
+}
+
+/// Combines the server-wide shutdown flag with a per-client flag so we can
+/// tear down one client without stopping the server, and vice versa.
+#[derive(Clone)]
+struct MergedShutdown {
+    global: Arc<AtomicBool>,
+    client: Arc<AtomicBool>,
+}
+
+impl MergedShutdown {
+    fn new(global: Arc<AtomicBool>, client: Arc<AtomicBool>) -> Self {
+        Self { global, client }
+    }
+    fn is_set(&self) -> bool {
+        self.global.load(Ordering::Relaxed) || self.client.load(Ordering::Relaxed)
+    }
+    fn set_client(&self) {
+        self.client.store(true, Ordering::SeqCst);
+    }
+}
+
+/// Continuously pull USB bulk buffers and push into the bounded queue.
+/// Drops on full, matching upstream's `llbuf_num` cap behavior.
+fn data_worker(
+    device: Arc<Mutex<RtlSdrDevice>>,
+    tx: SyncSender<Vec<u8>>,
+    shutdown: MergedShutdown,
+    stats: Arc<Mutex<ServerStats>>,
+) {
+    // Pull an Arc<DeviceHandle> once so we don't have to lock the device
+    // mutex on every USB read (bulk read is &self-safe via usb_handle).
+    let handle = {
+        let Ok(dev) = device.lock() else {
+            tracing::error!("device mutex poisoned, data worker aborting");
+            return;
+        };
+        dev.usb_handle()
+    };
+    let timeout = Duration::from_secs(1);
+
+    while !shutdown.is_set() {
+        let mut buf = vec![0u8; READ_BUFFER_LEN as usize];
+        match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut buf, timeout) {
+            Ok(n) if n > 0 => {
+                buf.truncate(n);
+                match tx.try_send(buf) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_)) => {
+                        // Queue is full — drop this buffer (upstream does
+                        // the same when the linked list exceeds llbuf_num;
+                        // rtl_tcp.c:137-152).
+                        if let Ok(mut s) = stats.lock() {
+                            s.buffers_dropped = s.buffers_dropped.saturating_add(1);
+                        }
+                        tracing::warn!("rtl_tcp tx queue full — dropping USB buffer");
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        tracing::debug!("writer gone, data worker exiting");
+                        return;
+                    }
+                }
+            }
+            Ok(_) | Err(rusb::Error::Timeout) => {
+                // No data — loop and re-check shutdown.
+            }
+            Err(rusb::Error::NoDevice) => {
+                tracing::error!("rtl_tcp: USB device lost mid-stream");
+                shutdown.set_client();
+                return;
+            }
+            Err(e) => {
+                tracing::error!(%e, "rtl_tcp bulk read error");
+                shutdown.set_client();
+                return;
+            }
+        }
+    }
+}
+
+fn tcp_writer(
+    mut stream: TcpStream,
+    rx: std::sync::mpsc::Receiver<Vec<u8>>,
+    shutdown: MergedShutdown,
+    stats: Arc<Mutex<ServerStats>>,
+) {
+    // `recv_timeout` lets us notice shutdown even when the USB reader is
+    // starving (e.g., dongle unplug).
+    loop {
+        if shutdown.is_set() {
+            return;
+        }
+        match rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(buf) => {
+                if let Err(e) = stream.write_all(&buf) {
+                    tracing::debug!(%e, "rtl_tcp client socket write failed, closing");
+                    shutdown.set_client();
+                    return;
+                }
+                if let Ok(mut s) = stats.lock() {
+                    s.bytes_sent = s.bytes_sent.saturating_add(buf.len() as u64);
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Re-check shutdown flag above.
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return;
+            }
+        }
+    }
+}
+
+fn command_worker(
+    mut stream: TcpStream,
+    device: Arc<Mutex<RtlSdrDevice>>,
+    shutdown: MergedShutdown,
+    stats: Arc<Mutex<ServerStats>>,
+) {
+    // Upstream loops on a 1 s select() so shutdown is noticed promptly.
+    if let Err(e) = stream.set_read_timeout(Some(COMMAND_READ_TIMEOUT)) {
+        tracing::warn!(%e, "set_read_timeout on command channel failed");
+    }
+    let mut buf = [0u8; COMMAND_LEN];
+    while !shutdown.is_set() {
+        match read_full(&mut stream, &mut buf, &shutdown) {
+            ReadResult::Ok => {}
+            ReadResult::Eof => {
+                tracing::debug!("rtl_tcp command channel EOF");
+                shutdown.set_client();
+                return;
+            }
+            ReadResult::Shutdown => return,
+            ReadResult::Err(e) => {
+                tracing::warn!(%e, "rtl_tcp command recv error");
+                shutdown.set_client();
+                return;
+            }
+        }
+        let Some(cmd) = Command::from_bytes(&buf) else {
+            // Upstream silently drops unknown opcodes (switch has no default).
+            tracing::debug!(op = buf[0], "rtl_tcp unknown command opcode, dropping");
+            continue;
+        };
+        if let Ok(mut dev) = device.lock() {
+            dispatch(&mut dev, cmd);
+        }
+        if let Ok(mut s) = stats.lock() {
+            s.last_command = Some((cmd.op, Instant::now()));
+        }
+    }
+}
+
+enum ReadResult {
+    Ok,
+    Eof,
+    Shutdown,
+    Err(std::io::Error),
+}
+
+/// Read exactly `buf.len()` bytes, splitting across multiple `read`s but
+/// re-checking the shutdown flag on each timeout. Mirrors the upstream
+/// `while(left > 0)` loop in rtl_tcp.c:297-313.
+fn read_full(stream: &mut TcpStream, buf: &mut [u8], shutdown: &MergedShutdown) -> ReadResult {
+    let mut filled = 0;
+    while filled < buf.len() {
+        if shutdown.is_set() {
+            return ReadResult::Shutdown;
+        }
+        match stream.read(&mut buf[filled..]) {
+            Ok(0) => return ReadResult::Eof,
+            Ok(n) => filled += n,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                // Timeout — loop to re-check shutdown.
+            }
+            Err(e) => return ReadResult::Err(e),
+        }
+    }
+    ReadResult::Ok
+}

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -906,7 +906,7 @@ mod tests {
             buffer_capacity: 0,
         };
         match Server::start(config) {
-            Err(crate::ServerError::PortInUse(ref addr)) => {
+            Err(ServerError::PortInUse(ref addr)) => {
                 assert!(addr.contains(&format!("{port}")));
             }
             Err(e) => panic!("expected PortInUse, got {e:?}"),

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -226,8 +226,9 @@ impl Server {
 
     /// Signal shutdown and wait for the accept thread to exit.
     ///
-    /// Equivalent to dropping the `Server`, but lets the caller propagate
-    /// join panics if desired.
+    /// Equivalent to dropping the `Server`. Any panic from the accept
+    /// thread is silently swallowed — if you need to observe panics,
+    /// keep the `JoinHandle` yourself instead of calling `stop()`.
     pub fn stop(mut self) {
         self.initiate_shutdown();
         if let Some(h) = self.accept_thread.take() {
@@ -435,8 +436,15 @@ fn set_keepalive(stream: &TcpStream, on: bool) -> std::io::Result<()> {
 
 #[cfg(not(unix))]
 fn set_keepalive(_stream: &TcpStream, _on: bool) -> std::io::Result<()> {
-    // Non-unix targets: caller swallows the warning.
-    Ok(())
+    // Non-unix has no implementation yet. Return Unsupported so the
+    // warn path in `configure_client_socket` fires and the log makes
+    // the missing keepalive visible — silently returning Ok would
+    // leave operators thinking dead-peer detection is active when it
+    // isn't.
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "SO_KEEPALIVE not implemented on this platform",
+    ))
 }
 
 fn update_stats_on_connect(stats: &Arc<Mutex<ServerStats>>, peer: SocketAddr) {

--- a/crates/sdr-source-network/Cargo.toml
+++ b/crates/sdr-source-network/Cargo.toml
@@ -10,8 +10,16 @@ repository.workspace = true
 sdr-types.workspace = true
 sdr-pipeline.workspace = true
 sdr-config.workspace = true
+# rtl_tcp client shares wire protocol types (DongleInfo, Command, CommandOp)
+# with the server implementation. Avoiding a separate `-protocol` crate for
+# a few hundred lines of code; naming is awkward ("server" crate re-used
+# for client protocol) but the dep graph stays clean.
+sdr-server-rtltcp.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+# SO_KEEPALIVE via setsockopt (see rtl_tcp.rs). Matches the pattern used
+# in sdr-server-rtltcp and sdr-transcription.
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-source-network/src/lib.rs
+++ b/crates/sdr-source-network/src/lib.rs
@@ -23,7 +23,10 @@
 
 pub mod rtl_tcp;
 
-pub use rtl_tcp::{ConnectionState, RtlTcpSource, TunerInfo};
+pub use rtl_tcp::{
+    ConnectionState, DEFAULT_DATA_READ_TIMEOUT, DEFAULT_MAX_CONSECUTIVE_TIMEOUTS, RtlTcpConfig,
+    RtlTcpSource, TunerInfo,
+};
 
 use sdr_pipeline::source_manager::Source;
 use sdr_types::{Complex, Protocol, SampleFormat, SourceError};

--- a/crates/sdr-source-network/src/lib.rs
+++ b/crates/sdr-source-network/src/lib.rs
@@ -24,8 +24,8 @@
 pub mod rtl_tcp;
 
 pub use rtl_tcp::{
-    ConnectionState, DEFAULT_DATA_READ_TIMEOUT, DEFAULT_MAX_CONSECUTIVE_TIMEOUTS, RtlTcpConfig,
-    RtlTcpSource, TunerInfo,
+    ConnectionState, DEFAULT_CONNECT_TIMEOUT, DEFAULT_DATA_READ_TIMEOUT,
+    DEFAULT_MAX_CONSECUTIVE_TIMEOUTS, RtlTcpConfig, RtlTcpSource, TunerInfo,
 };
 
 use sdr_pipeline::source_manager::Source;

--- a/crates/sdr-source-network/src/lib.rs
+++ b/crates/sdr-source-network/src/lib.rs
@@ -15,6 +15,15 @@
 //!
 //! Ports SDR++ `NetworkSourceModule`. Receives IQ samples over
 //! TCP (client) or UDP connections with configurable sample format.
+//!
+//! Also hosts an `rtl_tcp`-protocol client (see [`rtl_tcp`]) that
+//! connects to any `rtl_tcp`-compatible server (GQRX, SDR++,
+//! [`sdr-server-rtltcp`]) and streams 8-bit I/Q with tuning command
+//! support.
+
+pub mod rtl_tcp;
+
+pub use rtl_tcp::{ConnectionState, RtlTcpSource, TunerInfo};
 
 use sdr_pipeline::source_manager::Source;
 use sdr_types::{Complex, Protocol, SampleFormat, SourceError};

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -420,6 +420,25 @@ impl RtlTcpSource {
     }
 
     fn start_manager(&mut self) -> Result<(), SourceError> {
+        // Guard against a second `start()` call: if there's already a
+        // manager thread, refuse to spawn a second one. Previously this
+        // overwrote `self.manager` unconditionally, which leaked the
+        // prior JoinHandle and could leave two connection_manager
+        // threads racing on the same SharedState. `stop_manager` /
+        // `Drop` would then only wait for the newest one.
+        //
+        // Reap a finished handle (manager exited naturally after a
+        // transport error) so a fresh start can proceed.
+        if let Some(handle) = self.manager.as_ref() {
+            if handle.is_finished() {
+                if let Some(h) = self.manager.take() {
+                    let _ = h.join();
+                }
+            } else {
+                return Err(SourceError::AlreadyRunning);
+            }
+        }
+
         let host = self.host.clone();
         let port = self.port;
         let shared = self.shared.clone();
@@ -723,6 +742,15 @@ impl Source for RtlTcpSource {
     }
 
     fn tune(&mut self, frequency_hz: f64) -> Result<(), SourceError> {
+        // Guard the f64 → u32 cast: NaN and ±Inf silently coerce to 0
+        // or saturating u32 bounds, both invalid RF parameters. Out-of-
+        // range finite values saturate too. Mirror the CLI parser's
+        // is_finite + range-check pattern.
+        if !frequency_hz.is_finite() || frequency_hz < 0.0 || frequency_hz > f64::from(u32::MAX) {
+            return Err(SourceError::InvalidParameter(format!(
+                "center frequency out of range: {frequency_hz}"
+            )));
+        }
         self.frequency = frequency_hz;
         // Round to u32 — upstream wire protocol is u32 Hz.
         #[allow(
@@ -743,6 +771,15 @@ impl Source for RtlTcpSource {
     }
 
     fn set_sample_rate(&mut self, rate: f64) -> Result<(), SourceError> {
+        // Same guard as `tune`: NaN, ±Inf, ≤ 0, and out-of-u32 all get
+        // rejected up-front. A zero sample rate in particular would
+        // wedge the USB controller — better to error loudly than send
+        // it over the wire.
+        if !rate.is_finite() || rate <= 0.0 || rate > f64::from(u32::MAX) {
+            return Err(SourceError::InvalidParameter(format!(
+                "sample rate out of range: {rate}"
+            )));
+        }
         self.sample_rate = rate;
         #[allow(
             clippy::cast_possible_truncation,
@@ -1295,6 +1332,66 @@ mod tests {
             params.contains(&(CommandOp::SetTunerGain, 197)),
             "expected replay of tuner gain, got {params:?}"
         );
+    }
+
+    #[test]
+    fn second_start_call_is_rejected_not_leaked() {
+        // Two back-to-back `start_manager` calls must not leak the
+        // first manager thread. Previously the second call silently
+        // overwrote `self.manager`, leaving two connection_manager
+        // threads racing on the same SharedState and
+        // `stop_manager`/`Drop` only waiting for the newest one.
+        let mut src = RtlTcpSource::new("127.0.0.1", REFUSED_TEST_PORT);
+        src.start_manager().unwrap();
+        // The first manager is alive (sitting in the reconnect loop
+        // because port 1 refuses). Second call must Err.
+        let second = src.start_manager();
+        assert!(matches!(second, Err(SourceError::AlreadyRunning)));
+        src.stop_manager();
+
+        // After shutdown the prior handle is joined; a fresh start is
+        // allowed again. Hit the "finished handle gets reaped" path.
+        src.start_manager().unwrap();
+        src.stop_manager();
+    }
+
+    #[test]
+    fn tune_rejects_non_finite_and_out_of_range() {
+        let mut src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
+        // Never started, so no IO will actually happen — the tune call
+        // goes through the trait impl's validation guard and either
+        // returns Err or short-circuits at the command channel (which
+        // is None).
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -1.0, 1e12] {
+            let err = <RtlTcpSource as Source>::tune(&mut src, bad);
+            assert!(
+                matches!(err, Err(SourceError::InvalidParameter(_))),
+                "tune({bad}) should reject with InvalidParameter"
+            );
+        }
+        // Sanity: a valid finite in-range frequency does NOT trip the guard.
+        assert!(<RtlTcpSource as Source>::tune(&mut src, 100_000_000.0).is_ok());
+    }
+
+    #[test]
+    fn set_sample_rate_rejects_non_finite_zero_negative_and_oversized() {
+        let mut src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
+        for bad in [
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            0.0,  // zero rate would wedge USB
+            -1.0, // negative rate
+            1e12, // > u32::MAX
+        ] {
+            let err = <RtlTcpSource as Source>::set_sample_rate(&mut src, bad);
+            assert!(
+                matches!(err, Err(SourceError::InvalidParameter(_))),
+                "set_sample_rate({bad}) should reject with InvalidParameter"
+            );
+        }
+        // Sanity: 2.048 Msps passes.
+        assert!(<RtlTcpSource as Source>::set_sample_rate(&mut src, 2_048_000.0).is_ok());
     }
 
     #[test]

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -56,6 +56,10 @@ pub const DEFAULT_DATA_READ_TIMEOUT: Duration = Duration::from_secs(5);
 /// [`RtlTcpConfig::max_consecutive_timeouts`].
 pub const DEFAULT_MAX_CONSECUTIVE_TIMEOUTS: u32 = 2;
 
+/// Default timeout for the initial TCP connect. See
+/// [`RtlTcpConfig::connect_timeout`].
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Exponential-backoff schedule for reconnect. Values in seconds.
 /// Clamped at 30 s, matching the review of epic #299.
 const BACKOFF_SCHEDULE_SECS: &[u64] = &[1, 2, 5, 10, 30];
@@ -123,6 +127,13 @@ pub struct RtlTcpConfig {
     /// leave the UI frozen in Connected state until the kernel
     /// keepalive finally fires.
     pub max_consecutive_timeouts: u32,
+
+    /// Timeout for each TCP `connect()` attempt. Default 10 s. Without
+    /// this the call can sit in the kernel for 60+ seconds waiting on
+    /// TCP SYN retransmits when the destination is a blackhole (IP
+    /// drops packets rather than replying RST), leaving the manager
+    /// thread stuck.
+    pub connect_timeout: Duration,
 }
 
 impl Default for RtlTcpConfig {
@@ -130,6 +141,7 @@ impl Default for RtlTcpConfig {
         Self {
             data_read_timeout: DEFAULT_DATA_READ_TIMEOUT,
             max_consecutive_timeouts: DEFAULT_MAX_CONSECUTIVE_TIMEOUTS,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
         }
     }
 }
@@ -223,26 +235,24 @@ impl SharedState {
 /// Append `chunk` to `rx`, dropping the oldest bytes if doing so would
 /// exceed [`RX_BUFFER_SOFT_CAP_BYTES`]. Returns the number of bytes
 /// dropped so the caller can surface it through observability.
+///
+/// Drop count is rounded up to an even number so the buffer always
+/// stays aligned on I/Q pair boundaries. Dropping an odd number of
+/// bytes would leave `rx` starting mid-pair — subsequent `read_samples`
+/// calls would then pair `Q[n]` with `I[n+1]`, phase-shifting the
+/// stream until another odd drop happened to realign it.
 fn append_with_cap_inner(rx: &mut Vec<u8>, chunk: &[u8]) -> usize {
     let desired_total = rx.len().saturating_add(chunk.len());
-    let mut dropped = 0;
-    if desired_total > RX_BUFFER_SOFT_CAP_BYTES {
-        // Drop enough from the front to make room for the new chunk.
-        let excess = desired_total - RX_BUFFER_SOFT_CAP_BYTES;
-        let to_drop = excess.min(rx.len());
-        rx.drain(..to_drop);
-        dropped = to_drop;
-    }
-    // If the chunk itself is larger than the cap, keep only the tail —
-    // the UI/consumer cares about the newest samples.
-    if chunk.len() > RX_BUFFER_SOFT_CAP_BYTES {
-        let keep_from = chunk.len() - RX_BUFFER_SOFT_CAP_BYTES;
-        rx.extend_from_slice(&chunk[keep_from..]);
-        dropped = dropped.saturating_add(keep_from);
-    } else {
-        rx.extend_from_slice(chunk);
-    }
-    dropped
+    let raw_excess = desired_total.saturating_sub(RX_BUFFER_SOFT_CAP_BYTES);
+    // Round up to even so we never split an I/Q pair.
+    let total_drop = raw_excess.saturating_add(raw_excess & 1);
+
+    let drop_from_rx = total_drop.min(rx.len());
+    rx.drain(..drop_from_rx);
+
+    let drop_from_chunk = total_drop.saturating_sub(drop_from_rx).min(chunk.len());
+    rx.extend_from_slice(&chunk[drop_from_chunk..]);
+    total_drop
 }
 
 /// Wrapper that does the drop-bookkeeping on the shared counter.
@@ -538,8 +548,37 @@ fn attempt_connect(
     shared: &Arc<SharedState>,
     config: &RtlTcpConfig,
 ) -> Result<TcpStream, SourceError> {
-    let addr = format!("{host}:{port}");
-    let stream = TcpStream::connect(&addr).map_err(SourceError::Io)?;
+    // `(host, port).to_socket_addrs()` handles both IPv4 dotted
+    // quads AND IPv6 literals like `::1` correctly — the naïve
+    // `format!("{host}:{port}")` that we had before would build
+    // `::1:1234` for IPv6, which SocketAddr::from_str then rejects.
+    //
+    // `connect_timeout` is per-resolved-address rather than
+    // whole-call, so when a hostname resolves to multiple A/AAAA
+    // records we effectively iterate. Without any timeout, a
+    // blackholed destination wedges the manager thread for 60+ s
+    // waiting on TCP SYN retransmits.
+    use std::net::ToSocketAddrs;
+    let resolved = (host, port).to_socket_addrs().map_err(SourceError::Io)?;
+    let mut last_err: Option<std::io::Error> = None;
+    let mut stream: Option<TcpStream> = None;
+    for addr in resolved {
+        match TcpStream::connect_timeout(&addr, config.connect_timeout) {
+            Ok(s) => {
+                stream = Some(s);
+                break;
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    let stream = stream.ok_or_else(|| {
+        SourceError::Io(last_err.unwrap_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                "no socket addresses resolved",
+            )
+        }))
+    })?;
 
     stream.set_read_timeout(Some(config.data_read_timeout))?;
     if let Err(e) = set_keepalive(&stream, true) {
@@ -794,39 +833,27 @@ impl Source for RtlTcpSource {
         if output.is_empty() {
             return Ok(0);
         }
-        let need = output.len().saturating_mul(2);
-        let mut bytes = Vec::with_capacity(need);
-
-        // Drain up to `need` bytes from the shared rx buffer, aligned to
-        // a pair boundary — an odd trailing byte must stay queued so the
-        // I channel of the next sample isn't shifted one byte into the Q
-        // of the previous one. Kernel socket reads produce odd byte
-        // counts occasionally; upstream rtl_tcp avoids this because it
-        // works in raw byte space, but our complex-pair conversion needs
-        // even alignment.
-        if let Ok(mut rx) = self.shared.rx_buf.lock() {
-            let take = (rx.len().min(need)) & !1;
-            if take > 0 {
-                bytes.extend_from_slice(&rx[..take]);
-                rx.drain(..take);
-            }
-        } else {
-            return Err(SourceError::NotRunning);
+        // Convert I/Q bytes to Complex samples directly under the lock,
+        // no intermediate `Vec` copy. Hot path — avoids one allocation
+        // + one memcpy per pull. 8-bit unsigned-offset I/Q: byte 0..=255
+        // with zero at 127.5, scaled to f32 in [-1, 1).
+        let mut rx = self
+            .shared
+            .rx_buf
+            .lock()
+            .map_err(|_| SourceError::NotRunning)?;
+        let take_pairs = (rx.len() / 2).min(output.len());
+        let take_bytes = take_pairs * 2;
+        for i in 0..take_pairs {
+            let re_u = rx[i * 2];
+            let im_u = rx[i * 2 + 1];
+            output[i] = Complex::new(
+                (f32::from(re_u) - 127.5) / 127.5,
+                (f32::from(im_u) - 127.5) / 127.5,
+            );
         }
-
-        // 8-bit unsigned-offset I/Q: byte 0..255 with zero at 127.5.
-        // Convert to f32 in [-1, 1) using the same scale as
-        // sdr-source-rtlsdr's internal path.
-        let pairs = bytes.len() / 2;
-        let count = pairs.min(output.len());
-        for i in 0..count {
-            let re_u = bytes[i * 2];
-            let im_u = bytes[i * 2 + 1];
-            let re = (f32::from(re_u) - 127.5) / 127.5;
-            let im = (f32::from(im_u) - 127.5) / 127.5;
-            output[i] = Complex::new(re, im);
-        }
-        Ok(count)
+        rx.drain(..take_bytes);
+        Ok(take_pairs)
     }
 }
 
@@ -922,6 +949,32 @@ mod tests {
     }
 
     #[test]
+    fn append_with_cap_rounds_drop_up_to_even() {
+        // Construct an overflow by exactly 1 byte. The drop count MUST
+        // round up to 2 so we don't split an I/Q pair — Q would get
+        // misaligned with the next I, phase-shifting the output stream
+        // until another odd-drop event happened to realign it.
+        //
+        // Mark the I byte of the pair that should survive after drop so
+        // we can verify it ends up at rx[0] (still an I position, not
+        // shifted into a Q slot).
+        let mut rx = vec![0u8; RX_BUFFER_SOFT_CAP_BYTES];
+        rx[0] = 0x11; // I of dropped pair 0
+        rx[1] = 0x12; // Q of dropped pair 0
+        rx[2] = 0xAA; // I of surviving pair 1 — must land at rx[0] post-drop
+        rx[3] = 0xBB; // Q of surviving pair 1
+        let incoming = [0xFFu8; 1];
+        let dropped = append_with_cap_inner(&mut rx, &incoming);
+        assert_eq!(dropped, 2, "drop count must be even, got {dropped}");
+        // Pair 1's I landed at position 0 — alignment preserved.
+        assert_eq!(rx[0], 0xAA, "I byte of surviving pair must be at rx[0]");
+        assert_eq!(rx[1], 0xBB, "Q byte of surviving pair must be at rx[1]");
+        // rx can legitimately end on an odd length (the trailing byte is
+        // half of a pair waiting for its mate on the next read) — what
+        // matters is that the DROP was pair-aligned, not the final length.
+    }
+
+    #[test]
     fn append_with_cap_no_drop_below_cap() {
         let mut rx = vec![0u8; 1000];
         let incoming = vec![0xFFu8; 500];
@@ -980,6 +1033,7 @@ mod tests {
         let config = RtlTcpConfig {
             data_read_timeout: Duration::from_millis(200),
             max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -324,20 +324,20 @@ impl RtlTcpSource {
         })
     }
 
-    fn start_manager(&mut self) {
+    fn start_manager(&mut self) -> Result<(), SourceError> {
         let host = self.host.clone();
         let port = self.port;
         let shared = self.shared.clone();
 
         self.shared.shutdown.store(false, Ordering::SeqCst);
-        self.manager = Some(
-            thread::Builder::new()
-                .name("rtl_tcp-client".into())
-                .spawn(move || {
-                    connection_manager(host, port, shared);
-                })
-                .expect("spawn rtl_tcp client manager"),
-        );
+        let handle = thread::Builder::new()
+            .name("rtl_tcp-client".into())
+            .spawn(move || {
+                connection_manager(host, port, shared);
+            })
+            .map_err(SourceError::Io)?;
+        self.manager = Some(handle);
+        Ok(())
     }
 
     fn stop_manager(&mut self) {
@@ -591,8 +591,7 @@ impl Source for RtlTcpSource {
     }
 
     fn start(&mut self) -> Result<(), SourceError> {
-        self.start_manager();
-        Ok(())
+        self.start_manager()
     }
 
     fn stop(&mut self) -> Result<(), SourceError> {
@@ -677,6 +676,17 @@ mod tests {
     use super::*;
     use std::net::TcpListener;
 
+    /// Placeholder host/port for tests that never actually connect —
+    /// just exercise builder state or buffer logic. The string "127.0.0.1"
+    /// is fine as-is, but the port number is named for intent.
+    const UNUSED_TEST_PORT: u16 = 1234;
+
+    /// A port we expect connect() to fail with ECONNREFUSED on localhost
+    /// so the shutdown-during-retry test doesn't hang waiting for a SYN
+    /// timeout. Port 1 is a well-known unused privileged port and on
+    /// Linux loopback refuses instantly.
+    const REFUSED_TEST_PORT: u16 = 1;
+
     #[test]
     fn backoff_schedule_caps_at_30s() {
         assert_eq!(backoff_delay(0), Duration::from_secs(1));
@@ -687,7 +697,7 @@ mod tests {
 
     #[test]
     fn new_source_starts_disconnected() {
-        let source = RtlTcpSource::new("127.0.0.1", 1234);
+        let source = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
         match source.connection_state() {
             ConnectionState::Disconnected => {}
             other => unreachable!("expected Disconnected, got {other:?}"),
@@ -709,7 +719,7 @@ mod tests {
         });
 
         let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
-        src.start_manager();
+        src.start_manager().unwrap();
 
         // Wait up to 2s for the manager to transition to Failed.
         let deadline = Instant::now() + Duration::from_secs(2);
@@ -759,7 +769,7 @@ mod tests {
         });
 
         let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
-        src.start_manager();
+        src.start_manager().unwrap();
 
         // Wait for Connected state.
         let deadline = Instant::now() + Duration::from_secs(2);
@@ -788,7 +798,7 @@ mod tests {
 
     #[test]
     fn record_command_sets_replay_bit() {
-        let src = RtlTcpSource::new("127.0.0.1", 1234);
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
         let cmd = Command {
             op: CommandOp::SetCenterFreq,
             param: 99_500_000,
@@ -805,7 +815,7 @@ mod tests {
 
     #[test]
     fn read_samples_with_empty_output_returns_zero() {
-        let mut src = RtlTcpSource::new("127.0.0.1", 1234);
+        let mut src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
         let mut output: [Complex; 0] = [];
         let n = src.read_samples(&mut output).unwrap();
         assert_eq!(n, 0);
@@ -813,7 +823,7 @@ mod tests {
 
     #[test]
     fn read_samples_with_no_data_returns_zero() {
-        let mut src = RtlTcpSource::new("127.0.0.1", 1234);
+        let mut src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
         // Source was never started, no bytes buffered.
         let mut output = [Complex::default(); 4];
         let n = src.read_samples(&mut output).unwrap();
@@ -822,7 +832,7 @@ mod tests {
 
     #[test]
     fn read_samples_converts_8bit_offset_iq() {
-        let src = RtlTcpSource::new("127.0.0.1", 1234);
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
         // 128 is midscale zero, 255 is +1 - small epsilon, 0 is -1.
         if let Ok(mut rx) = src.shared.rx_buf.lock() {
             rx.extend_from_slice(&[128, 128, 255, 0, 0, 255]);
@@ -847,7 +857,7 @@ mod tests {
     fn read_samples_handles_partial_pair_at_end() {
         // Odd byte count — the trailing lone byte must stay queued
         // rather than produce half a sample.
-        let src = RtlTcpSource::new("127.0.0.1", 1234);
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
         if let Ok(mut rx) = src.shared.rx_buf.lock() {
             rx.extend_from_slice(&[128, 128, 200]); // 1.5 pairs
         }
@@ -881,7 +891,7 @@ mod tests {
         });
 
         let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
-        src.start_manager();
+        src.start_manager().unwrap();
         let deadline = Instant::now() + Duration::from_secs(2);
         let mut got = None;
         while Instant::now() < deadline {
@@ -924,7 +934,7 @@ mod tests {
         });
 
         let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
-        src.start_manager();
+        src.start_manager().unwrap();
         let deadline = Instant::now() + Duration::from_millis(1500);
         let mut saw_retrying = false;
         while Instant::now() < deadline {
@@ -981,7 +991,7 @@ mod tests {
         src.set_center_freq_hz(433_000_000).unwrap();
         src.set_tuner_gain_tenths_db(197).unwrap();
 
-        src.start_manager();
+        src.start_manager().unwrap();
         // Collect the replayed commands.
         let mut received = Vec::new();
         while let Ok(cmd) = cmd_rx.recv_timeout(Duration::from_millis(1500)) {
@@ -1009,8 +1019,8 @@ mod tests {
         // Point client at a port nothing's listening on; start_manager
         // enters the retry loop. stop_manager should return within ~1 s,
         // well below the exponential-backoff window.
-        let mut src = RtlTcpSource::new("127.0.0.1", 1); // port 1 likely refused
-        src.start_manager();
+        let mut src = RtlTcpSource::new("127.0.0.1", REFUSED_TEST_PORT); // port 1 likely refused
+        src.start_manager().unwrap();
         let t0 = Instant::now();
         src.stop_manager();
         let elapsed = t0.elapsed();
@@ -1022,7 +1032,7 @@ mod tests {
 
     #[test]
     fn replay_bits_set_independently_per_op() {
-        let src = RtlTcpSource::new("127.0.0.1", 1234);
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
         src.record_command(Command {
             op: CommandOp::SetBiasTee,
             param: 1,

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -1,0 +1,1036 @@
+#![allow(
+    clippy::doc_markdown,
+    clippy::needless_pass_by_value,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_lossless,
+    clippy::cast_possible_wrap,
+    clippy::large_stack_arrays,
+    clippy::collapsible_if
+)]
+//! `rtl_tcp` client.
+//!
+//! Connects to a remote `rtl_tcp`-compatible server, parses the 12-byte
+//! `dongle_info_t` header, pulls 8-bit unsigned-offset I/Q samples, and
+//! forwards user tuning commands as 5-byte big-endian messages over the
+//! same socket. Speaks the wire protocol described in
+//! `original/librtlsdr/src/rtl_tcp.c` — compatible with GQRX, SDR++,
+//! SoapySDR, `rtl_sdr --server`, and our own `sdr-server-rtltcp`.
+//!
+//! Wire types (`DongleInfo`, `Command`, `CommandOp`, `TunerTypeCode`) are
+//! re-exported from [`sdr_server_rtltcp::protocol`] so both sides share
+//! one source of truth.
+//!
+//! Robustness additions beyond a bare protocol port (epic #299 review):
+//!
+//! - Exponential-backoff reconnect on socket loss. Connection lifecycle
+//!   exposed via [`ConnectionState`] so UI can render Connecting /
+//!   Connected / Retrying / Failed / Disconnected.
+//! - `SO_KEEPALIVE` on the socket to notice silent peer drops.
+//! - Graceful magic-mismatch surfaced as
+//!   [`SourceError::Protocol`] with a descriptive message so connecting
+//!   to a non-rtl_tcp port doesn't treat the first 12 bytes of junk as
+//!   samples.
+//!
+//! Command debouncing (rapid UI dial scrubs → fewer wire commands) is
+//! intentionally **not** handled here — it is a UI concern and the caller
+//! is responsible for coalescing intents before driving `set_*`. Matches
+//! upstream GQRX/SDR++ behavior.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use sdr_pipeline::source_manager::Source;
+use sdr_server_rtltcp::protocol::{Command, CommandOp, DONGLE_INFO_LEN, DongleInfo, TunerTypeCode};
+use sdr_types::{Complex, SourceError};
+
+/// Read timeout on the data socket. Stalled reads longer than this trip
+/// the reconnect state machine — matches the upstream 1-second select in
+/// `rtl_tcp.c` command worker.
+const DATA_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Exponential-backoff schedule for reconnect. Values in seconds.
+/// Clamped at 30 s, matching the review of epic #299.
+const BACKOFF_SCHEDULE_SECS: &[u64] = &[1, 2, 5, 10, 30];
+
+/// Metadata parsed from the server's `dongle_info_t` header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TunerInfo {
+    pub tuner: TunerTypeCode,
+    /// Number of discrete gain steps the tuner exposes. The actual gain
+    /// table is NOT carried on the wire — clients that want to render dB
+    /// values must either assume the R820T table or drive the server via
+    /// [`CommandOp::SetGainByIndex`] and show "step N of M".
+    pub gain_count: u32,
+}
+
+impl From<DongleInfo> for TunerInfo {
+    fn from(info: DongleInfo) -> Self {
+        Self {
+            tuner: info.tuner,
+            gain_count: info.gain_count,
+        }
+    }
+}
+
+/// Connection lifecycle state for UI consumption.
+#[derive(Debug, Clone)]
+pub enum ConnectionState {
+    /// Initial state before first `start()` call.
+    Disconnected,
+    /// `start()` in progress — first TCP connect attempt.
+    Connecting,
+    /// Handshake complete, handler streaming I/Q.
+    Connected { tuner: TunerInfo },
+    /// Connection dropped, backoff pending.
+    Retrying { attempt: u32, next_at: Instant },
+    /// Terminal failure after max attempts, or protocol error.
+    Failed { reason: String },
+}
+
+/// rtl_tcp source client.
+///
+/// Spawns a background connection manager thread on `start()`. The
+/// manager owns the socket, does the reconnect loop, and publishes the
+/// byte stream into a ring buffer that `read_samples` drains.
+pub struct RtlTcpSource {
+    host: String,
+    port: u16,
+    sample_rate: f64,
+    frequency: f64,
+
+    shared: Arc<SharedState>,
+    manager: Option<JoinHandle<()>>,
+}
+
+/// State shared between the public API (main thread) and the background
+/// connection manager thread.
+struct SharedState {
+    shutdown: AtomicBool,
+    state: Mutex<ConnectionState>,
+    tuner: Mutex<Option<TunerInfo>>,
+
+    /// Latest 8-bit I/Q bytes read from the server. The connection
+    /// manager appends bytes here; `read_samples` drains and converts.
+    /// Guarded by a Mutex because it's accessed from two threads; a
+    /// lock-free ring buffer would be lower overhead but adds unsafe,
+    /// and this matches the simplicity of the sibling `NetworkSource`.
+    rx_buf: Mutex<Vec<u8>>,
+
+    /// Write side of the socket, protected by a Mutex so command senders
+    /// can share it without racing. Replaced on every reconnect.
+    command_sink: Mutex<Option<TcpStream>>,
+
+    /// Latest values for each sticky command op, replayed on reconnect
+    /// so the server state matches what the UI thinks it has set.
+    /// Using AtomicU32 rather than a HashMap since the op set is small
+    /// and fixed.
+    last_center_freq_hz: AtomicU32,
+    last_sample_rate_hz: AtomicU32,
+    last_gain_mode: AtomicU32,
+    last_tuner_gain: AtomicU32,
+    last_ppm: AtomicU32,
+    last_agc_mode: AtomicU32,
+    last_direct_sampling: AtomicU32,
+    last_offset_tuning: AtomicU32,
+    last_bias_tee: AtomicU32,
+    last_gain_by_index: AtomicU32,
+    // Sentinel: bit 0 of `replay_mask` is set once ANY value has been
+    // written for each op, so a fresh connection doesn't replay default
+    // zeros onto a server whose operator explicitly wanted something
+    // else. Bit i = op 0x01 + i.
+    replay_mask: AtomicU32,
+}
+
+impl SharedState {
+    fn new() -> Self {
+        Self {
+            shutdown: AtomicBool::new(false),
+            state: Mutex::new(ConnectionState::Disconnected),
+            tuner: Mutex::new(None),
+            rx_buf: Mutex::new(Vec::with_capacity(64 * 1024)),
+            command_sink: Mutex::new(None),
+            last_center_freq_hz: AtomicU32::new(0),
+            last_sample_rate_hz: AtomicU32::new(0),
+            last_gain_mode: AtomicU32::new(0),
+            last_tuner_gain: AtomicU32::new(0),
+            last_ppm: AtomicU32::new(0),
+            last_agc_mode: AtomicU32::new(0),
+            last_direct_sampling: AtomicU32::new(0),
+            last_offset_tuning: AtomicU32::new(0),
+            last_bias_tee: AtomicU32::new(0),
+            last_gain_by_index: AtomicU32::new(0),
+            replay_mask: AtomicU32::new(0),
+        }
+    }
+}
+
+impl RtlTcpSource {
+    /// Create a new rtl_tcp client. Doesn't connect — call
+    /// [`Source::start`] or [`Self::start_manager`] to open the socket.
+    pub fn new(host: &str, port: u16) -> Self {
+        Self {
+            host: host.to_string(),
+            port,
+            sample_rate: 2_048_000.0,
+            frequency: 100_000_000.0,
+            shared: Arc::new(SharedState::new()),
+            manager: None,
+        }
+    }
+
+    /// Snapshot of the current connection lifecycle state.
+    pub fn connection_state(&self) -> ConnectionState {
+        match self.shared.state.lock() {
+            Ok(s) => s.clone(),
+            Err(_) => ConnectionState::Disconnected,
+        }
+    }
+
+    /// Tuner metadata from the last successful handshake, if any.
+    pub fn tuner_info(&self) -> Option<TunerInfo> {
+        self.shared.tuner.lock().ok().and_then(|g| *g)
+    }
+
+    /// Send a raw rtl_tcp command over the current socket. Returns
+    /// `NotRunning` if the connection manager is not alive.
+    ///
+    /// Callers should prefer the typed setters (`set_center_freq_hz`,
+    /// etc.) — this is the low-level escape hatch used by the setters.
+    pub fn send_command(&self, cmd: Command) -> Result<(), SourceError> {
+        // Remember the value for reconnect-replay before actually sending
+        // so we don't lose it if the write happens to race a reconnect.
+        self.record_command(cmd);
+
+        let mut sink = self
+            .shared
+            .command_sink
+            .lock()
+            .map_err(|_| SourceError::NotRunning)?;
+        let Some(stream) = sink.as_mut() else {
+            // Not connected yet. Not an error — manager will replay on
+            // reconnect via `record_command` above.
+            return Ok(());
+        };
+        if let Err(e) = stream.write_all(&cmd.to_bytes()) {
+            tracing::debug!(%e, "rtl_tcp command write failed — reconnect will replay");
+            // Drop the broken stream; manager will notice and reconnect.
+            *sink = None;
+            return Ok(());
+        }
+        Ok(())
+    }
+
+    fn record_command(&self, cmd: Command) {
+        let slot = match cmd.op {
+            CommandOp::SetCenterFreq => &self.shared.last_center_freq_hz,
+            CommandOp::SetSampleRate => &self.shared.last_sample_rate_hz,
+            CommandOp::SetGainMode => &self.shared.last_gain_mode,
+            CommandOp::SetTunerGain => &self.shared.last_tuner_gain,
+            CommandOp::SetFreqCorrection => &self.shared.last_ppm,
+            CommandOp::SetAgcMode => &self.shared.last_agc_mode,
+            CommandOp::SetDirectSampling => &self.shared.last_direct_sampling,
+            CommandOp::SetOffsetTuning => &self.shared.last_offset_tuning,
+            CommandOp::SetBiasTee => &self.shared.last_bias_tee,
+            CommandOp::SetGainByIndex => &self.shared.last_gain_by_index,
+            // Ops we don't replay (testmode, if-gain, xtal frequencies)
+            // are stateful on the server but rarely adjusted; skip the
+            // replay plumbing for now. Re-examine if a use case appears.
+            _ => return,
+        };
+        slot.store(cmd.param, Ordering::Relaxed);
+        let bit = u32::from((cmd.op as u8) - 1);
+        self.shared
+            .replay_mask
+            .fetch_or(1u32 << bit, Ordering::Relaxed);
+    }
+
+    /// Convenience typed setters — each one round-trips through
+    /// [`Self::send_command`].
+    pub fn set_center_freq_hz(&self, hz: u32) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetCenterFreq,
+            param: hz,
+        })
+    }
+
+    pub fn set_sample_rate_hz(&self, hz: u32) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetSampleRate,
+            param: hz,
+        })
+    }
+
+    pub fn set_tuner_gain_tenths_db(&self, gain: i32) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetTunerGain,
+            #[allow(clippy::cast_sign_loss)]
+            param: gain as u32,
+        })
+    }
+
+    pub fn set_gain_mode_manual(&self, manual: bool) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetGainMode,
+            param: u32::from(manual),
+        })
+    }
+
+    pub fn set_freq_correction_ppm(&self, ppm: i32) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetFreqCorrection,
+            #[allow(clippy::cast_sign_loss)]
+            param: ppm as u32,
+        })
+    }
+
+    pub fn set_agc_mode(&self, on: bool) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetAgcMode,
+            param: u32::from(on),
+        })
+    }
+
+    pub fn set_direct_sampling(&self, mode: i32) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetDirectSampling,
+            #[allow(clippy::cast_sign_loss)]
+            param: mode as u32,
+        })
+    }
+
+    pub fn set_offset_tuning(&self, on: bool) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetOffsetTuning,
+            param: u32::from(on),
+        })
+    }
+
+    pub fn set_bias_tee(&self, on: bool) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetBiasTee,
+            param: u32::from(on),
+        })
+    }
+
+    pub fn set_gain_by_index(&self, idx: u32) -> Result<(), SourceError> {
+        self.send_command(Command {
+            op: CommandOp::SetGainByIndex,
+            param: idx,
+        })
+    }
+
+    fn start_manager(&mut self) {
+        let host = self.host.clone();
+        let port = self.port;
+        let shared = self.shared.clone();
+
+        self.shared.shutdown.store(false, Ordering::SeqCst);
+        self.manager = Some(
+            thread::Builder::new()
+                .name("rtl_tcp-client".into())
+                .spawn(move || {
+                    connection_manager(host, port, shared);
+                })
+                .expect("spawn rtl_tcp client manager"),
+        );
+    }
+
+    fn stop_manager(&mut self) {
+        self.shared.shutdown.store(true, Ordering::SeqCst);
+        // Close the current socket so any blocked read returns fast.
+        if let Ok(mut sink) = self.shared.command_sink.lock() {
+            if let Some(s) = sink.take() {
+                let _ = s.shutdown(std::net::Shutdown::Both);
+            }
+        }
+        if let Some(h) = self.manager.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+impl Drop for RtlTcpSource {
+    fn drop(&mut self) {
+        self.stop_manager();
+    }
+}
+
+/// Background thread body: reconnect loop + data-read pump.
+fn connection_manager(host: String, port: u16, shared: Arc<SharedState>) {
+    let mut attempt: u32 = 0;
+
+    while !shared.shutdown.load(Ordering::Relaxed) {
+        set_state(&shared, ConnectionState::Connecting);
+
+        match attempt_connect(&host, port, &shared) {
+            Ok(stream) => {
+                attempt = 0;
+                // At this point handshake has completed successfully.
+                replay_sticky_commands(&shared);
+                run_data_pump(stream, &shared);
+                // run_data_pump returned — connection dropped.
+            }
+            Err(e) => {
+                tracing::warn!(%e, host = %host, port, attempt, "rtl_tcp connect failed");
+                if let SourceError::Protocol(_) = e {
+                    // Non-recoverable: server isn't speaking rtl_tcp.
+                    set_state(
+                        &shared,
+                        ConnectionState::Failed {
+                            reason: format!("{e}"),
+                        },
+                    );
+                    return;
+                }
+            }
+        }
+
+        if shared.shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+
+        attempt = attempt.saturating_add(1);
+        let delay = backoff_delay(attempt);
+        let next_at = Instant::now() + delay;
+        set_state(&shared, ConnectionState::Retrying { attempt, next_at });
+        sleep_until(next_at, &shared.shutdown);
+    }
+
+    set_state(&shared, ConnectionState::Disconnected);
+}
+
+fn attempt_connect(
+    host: &str,
+    port: u16,
+    shared: &Arc<SharedState>,
+) -> Result<TcpStream, SourceError> {
+    let addr = format!("{host}:{port}");
+    let stream = TcpStream::connect(&addr).map_err(SourceError::Io)?;
+
+    stream.set_read_timeout(Some(DATA_READ_TIMEOUT))?;
+    if let Err(e) = set_keepalive(&stream, true) {
+        tracing::warn!(%e, "SO_KEEPALIVE not applied (non-fatal)");
+    }
+
+    // Read and verify the 12-byte dongle_info_t header.
+    let mut header_buf = [0u8; DONGLE_INFO_LEN];
+    read_exact_with_context(&stream, &mut header_buf)?;
+
+    let Some(info) = DongleInfo::from_bytes(&header_buf) else {
+        return Err(SourceError::Protocol(
+            "not an rtl_tcp server: dongle_info_t magic prefix mismatch".into(),
+        ));
+    };
+    let tuner = TunerInfo::from(info);
+    if let Ok(mut slot) = shared.tuner.lock() {
+        *slot = Some(tuner);
+    }
+    set_state(shared, ConnectionState::Connected { tuner });
+
+    // Publish a clone of the stream for the command sender.
+    let sink = stream.try_clone().map_err(SourceError::Io)?;
+    if let Ok(mut slot) = shared.command_sink.lock() {
+        *slot = Some(sink);
+    }
+
+    Ok(stream)
+}
+
+fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>) {
+    let mut buf = [0u8; 64 * 1024];
+    while !shared.shutdown.load(Ordering::Relaxed) {
+        match stream.read(&mut buf) {
+            Ok(0) => {
+                tracing::info!("rtl_tcp server closed connection");
+                break;
+            }
+            Ok(n) => {
+                if let Ok(mut rx) = shared.rx_buf.lock() {
+                    rx.extend_from_slice(&buf[..n]);
+                }
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::TimedOut
+                    || e.kind() == std::io::ErrorKind::WouldBlock =>
+            {
+                // Read timeout — server may have silently gone away.
+                // Loop back and re-check shutdown; keepalive probes will
+                // eventually turn a silent drop into an explicit error.
+            }
+            Err(e) => {
+                tracing::info!(%e, "rtl_tcp socket read failed, will reconnect");
+                break;
+            }
+        }
+    }
+
+    // Drop the command sink so subsequent send_command calls stop
+    // writing into a dead stream.
+    if let Ok(mut sink) = shared.command_sink.lock() {
+        *sink = None;
+    }
+}
+
+fn replay_sticky_commands(shared: &Arc<SharedState>) {
+    let mask = shared.replay_mask.load(Ordering::Relaxed);
+    let replay_bit = |bit: u32| mask & (1u32 << bit) != 0;
+    let Ok(mut sink) = shared.command_sink.lock() else {
+        return;
+    };
+    let Some(stream) = sink.as_mut() else {
+        return;
+    };
+
+    let ops = [
+        (CommandOp::SetCenterFreq, &shared.last_center_freq_hz),
+        (CommandOp::SetSampleRate, &shared.last_sample_rate_hz),
+        (CommandOp::SetGainMode, &shared.last_gain_mode),
+        (CommandOp::SetTunerGain, &shared.last_tuner_gain),
+        (CommandOp::SetFreqCorrection, &shared.last_ppm),
+        (CommandOp::SetAgcMode, &shared.last_agc_mode),
+        (CommandOp::SetDirectSampling, &shared.last_direct_sampling),
+        (CommandOp::SetOffsetTuning, &shared.last_offset_tuning),
+        (CommandOp::SetBiasTee, &shared.last_bias_tee),
+        (CommandOp::SetGainByIndex, &shared.last_gain_by_index),
+    ];
+    for (op, slot) in ops {
+        let bit = u32::from((op as u8) - 1);
+        if !replay_bit(bit) {
+            continue;
+        }
+        let cmd = Command {
+            op,
+            param: slot.load(Ordering::Relaxed),
+        };
+        if let Err(e) = stream.write_all(&cmd.to_bytes()) {
+            tracing::debug!(%e, op = ?op, "replay write failed — will retry on next reconnect");
+            return;
+        }
+    }
+}
+
+fn backoff_delay(attempt: u32) -> Duration {
+    let idx = (attempt as usize).min(BACKOFF_SCHEDULE_SECS.len() - 1);
+    Duration::from_secs(BACKOFF_SCHEDULE_SECS[idx])
+}
+
+fn sleep_until(deadline: Instant, shutdown: &AtomicBool) {
+    let step = Duration::from_millis(100);
+    while Instant::now() < deadline {
+        if shutdown.load(Ordering::Relaxed) {
+            return;
+        }
+        thread::sleep(step.min(deadline.saturating_duration_since(Instant::now())));
+    }
+}
+
+fn set_state(shared: &Arc<SharedState>, state: ConnectionState) {
+    if let Ok(mut s) = shared.state.lock() {
+        *s = state;
+    }
+}
+
+fn read_exact_with_context(stream: &TcpStream, buf: &mut [u8]) -> Result<(), SourceError> {
+    let mut filled = 0;
+    let mut s = stream;
+    while filled < buf.len() {
+        match Read::read(&mut s, &mut buf[filled..]) {
+            Ok(0) => {
+                return Err(SourceError::Io(std::io::Error::from(
+                    std::io::ErrorKind::UnexpectedEof,
+                )));
+            }
+            Ok(n) => filled += n,
+            Err(e) => return Err(SourceError::Io(e)),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn set_keepalive(stream: &TcpStream, on: bool) -> std::io::Result<()> {
+    // Same setsockopt dance as `sdr-server-rtltcp::server::set_keepalive`.
+    // Kept duplicated rather than extracted into a shared crate so both
+    // ends stay self-contained — this is one function.
+    use std::os::unix::io::AsRawFd;
+    let fd = stream.as_raw_fd();
+    let value: libc::c_int = libc::c_int::from(on);
+    // SAFETY: `fd` is a valid open socket for the duration of this call
+    // (we borrow `stream` by reference); `value` is a stable stack local
+    // with the matching `c_int` type for `SO_KEEPALIVE`.
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_KEEPALIVE,
+            std::ptr::addr_of!(value).cast(),
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn set_keepalive(_stream: &TcpStream, _on: bool) -> std::io::Result<()> {
+    Ok(())
+}
+
+impl Source for RtlTcpSource {
+    fn name(&self) -> &str {
+        "RTL-TCP"
+    }
+
+    fn start(&mut self) -> Result<(), SourceError> {
+        self.start_manager();
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<(), SourceError> {
+        self.stop_manager();
+        Ok(())
+    }
+
+    fn tune(&mut self, frequency_hz: f64) -> Result<(), SourceError> {
+        self.frequency = frequency_hz;
+        // Round to u32 — upstream wire protocol is u32 Hz.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::cast_precision_loss
+        )]
+        let hz = frequency_hz.round() as u32;
+        self.set_center_freq_hz(hz)
+    }
+
+    fn sample_rates(&self) -> &[f64] {
+        &[]
+    }
+
+    fn sample_rate(&self) -> f64 {
+        self.sample_rate
+    }
+
+    fn set_sample_rate(&mut self, rate: f64) -> Result<(), SourceError> {
+        self.sample_rate = rate;
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::cast_precision_loss
+        )]
+        let hz = rate.round() as u32;
+        self.set_sample_rate_hz(hz)
+    }
+
+    fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
+        if output.is_empty() {
+            return Ok(0);
+        }
+        let need = output.len().saturating_mul(2);
+        let mut bytes = Vec::with_capacity(need);
+
+        // Drain up to `need` bytes from the shared rx buffer, aligned to
+        // a pair boundary — an odd trailing byte must stay queued so the
+        // I channel of the next sample isn't shifted one byte into the Q
+        // of the previous one. Kernel socket reads produce odd byte
+        // counts occasionally; upstream rtl_tcp avoids this because it
+        // works in raw byte space, but our complex-pair conversion needs
+        // even alignment.
+        if let Ok(mut rx) = self.shared.rx_buf.lock() {
+            let take = (rx.len().min(need)) & !1;
+            if take > 0 {
+                bytes.extend_from_slice(&rx[..take]);
+                rx.drain(..take);
+            }
+        } else {
+            return Err(SourceError::NotRunning);
+        }
+
+        // 8-bit unsigned-offset I/Q: byte 0..255 with zero at 127.5.
+        // Convert to f32 in [-1, 1) using the same scale as
+        // sdr-source-rtlsdr's internal path.
+        let pairs = bytes.len() / 2;
+        let count = pairs.min(output.len());
+        for i in 0..count {
+            let re_u = bytes[i * 2];
+            let im_u = bytes[i * 2 + 1];
+            let re = (f32::from(re_u) - 127.5) / 127.5;
+            let im = (f32::from(im_u) - 127.5) / 127.5;
+            output[i] = Complex::new(re, im);
+        }
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[test]
+    fn backoff_schedule_caps_at_30s() {
+        assert_eq!(backoff_delay(0), Duration::from_secs(1));
+        assert_eq!(backoff_delay(4), Duration::from_secs(30));
+        // Further attempts saturate.
+        assert_eq!(backoff_delay(999), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn new_source_starts_disconnected() {
+        let source = RtlTcpSource::new("127.0.0.1", 1234);
+        match source.connection_state() {
+            ConnectionState::Disconnected => {}
+            other => unreachable!("expected Disconnected, got {other:?}"),
+        }
+        assert!(source.tuner_info().is_none());
+    }
+
+    #[test]
+    fn bad_magic_produces_failed_state() {
+        // Spin up a toy server that writes junk then closes.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_thread = thread::spawn(move || {
+            if let Ok((mut s, _)) = listener.accept() {
+                let _ = s.write_all(b"XXXXjunknoise");
+                // Keep open briefly so client reads fail cleanly.
+                thread::sleep(Duration::from_millis(200));
+            }
+        });
+
+        let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
+        src.start_manager();
+
+        // Wait up to 2s for the manager to transition to Failed.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut saw_failed = false;
+        while Instant::now() < deadline {
+            if matches!(src.connection_state(), ConnectionState::Failed { .. }) {
+                saw_failed = true;
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+        src.stop_manager();
+        let _ = server_thread.join();
+        assert!(saw_failed, "expected Failed state after bad magic");
+    }
+
+    #[test]
+    fn happy_path_handshake_and_command_roundtrip() {
+        // Mock rtl_tcp server: writes a valid RTL0 header then pushes
+        // a fixed byte pattern as "samples" while reading tuning
+        // commands into a channel we can inspect.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<Command>();
+
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            // Advertise an R820T with 29 gains.
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: 29,
+            }
+            .to_bytes();
+            sock.write_all(&header).unwrap();
+            // Stream a few hundred bytes of synthetic I/Q (all 128 = zero).
+            sock.write_all(&[128u8; 512]).unwrap();
+            // Read one command (5 bytes) from the client and forward it.
+            let mut cmd_buf = [0u8; 5];
+            sock.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+            if sock.read_exact(&mut cmd_buf).is_ok() {
+                if let Some(cmd) = Command::from_bytes(&cmd_buf) {
+                    let _ = cmd_tx.send(cmd);
+                }
+            }
+            // Hold connection briefly so the client doesn't see EOF mid-test.
+            thread::sleep(Duration::from_millis(200));
+        });
+
+        let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
+        src.start_manager();
+
+        // Wait for Connected state.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut tuner = None;
+        while Instant::now() < deadline {
+            if let ConnectionState::Connected { tuner: t } = src.connection_state() {
+                tuner = Some(t);
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(tuner.is_some(), "client never reached Connected state");
+        let t = tuner.unwrap();
+        assert_eq!(t.tuner, TunerTypeCode::R820t);
+        assert_eq!(t.gain_count, 29);
+
+        // Send a tune command and verify the server received it.
+        src.set_center_freq_hz(99_500_000).unwrap();
+        let received = cmd_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(received.op, CommandOp::SetCenterFreq);
+        assert_eq!(received.param, 99_500_000);
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn record_command_sets_replay_bit() {
+        let src = RtlTcpSource::new("127.0.0.1", 1234);
+        let cmd = Command {
+            op: CommandOp::SetCenterFreq,
+            param: 99_500_000,
+        };
+        src.record_command(cmd);
+        let mask = src.shared.replay_mask.load(Ordering::Relaxed);
+        // CenterFreq is op 0x01, bit index 0.
+        assert_eq!(mask & 0x1, 0x1);
+        assert_eq!(
+            src.shared.last_center_freq_hz.load(Ordering::Relaxed),
+            99_500_000
+        );
+    }
+
+    #[test]
+    fn read_samples_with_empty_output_returns_zero() {
+        let mut src = RtlTcpSource::new("127.0.0.1", 1234);
+        let mut output: [Complex; 0] = [];
+        let n = src.read_samples(&mut output).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn read_samples_with_no_data_returns_zero() {
+        let mut src = RtlTcpSource::new("127.0.0.1", 1234);
+        // Source was never started, no bytes buffered.
+        let mut output = [Complex::default(); 4];
+        let n = src.read_samples(&mut output).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn read_samples_converts_8bit_offset_iq() {
+        let src = RtlTcpSource::new("127.0.0.1", 1234);
+        // 128 is midscale zero, 255 is +1 - small epsilon, 0 is -1.
+        if let Ok(mut rx) = src.shared.rx_buf.lock() {
+            rx.extend_from_slice(&[128, 128, 255, 0, 0, 255]);
+        }
+        let mut out = [Complex::default(); 3];
+        // Call read_samples via the trait impl, matching public API.
+        let mut mutable_src = src;
+        let n = mutable_src.read_samples(&mut out).unwrap();
+        assert_eq!(n, 3);
+        // Midscale pair → near zero.
+        assert!(out[0].re.abs() < 0.01);
+        assert!(out[0].im.abs() < 0.01);
+        // (255, 0) → +1, -1.
+        assert!((out[1].re - 1.0).abs() < 0.01);
+        assert!((out[1].im + 1.0).abs() < 0.01);
+        // (0, 255) → -1, +1.
+        assert!((out[2].re + 1.0).abs() < 0.01);
+        assert!((out[2].im - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn read_samples_handles_partial_pair_at_end() {
+        // Odd byte count — the trailing lone byte must stay queued
+        // rather than produce half a sample.
+        let src = RtlTcpSource::new("127.0.0.1", 1234);
+        if let Ok(mut rx) = src.shared.rx_buf.lock() {
+            rx.extend_from_slice(&[128, 128, 200]); // 1.5 pairs
+        }
+        let mut out = [Complex::default(); 2];
+        let mut src = src;
+        let n = src.read_samples(&mut out).unwrap();
+        assert_eq!(n, 1, "should only consume the complete pair");
+        // The trailing 200 stays queued — drained on the next call.
+        let remaining = src.shared.rx_buf.lock().unwrap().len();
+        assert_eq!(remaining, 1);
+    }
+
+    #[test]
+    fn partial_header_read_still_completes_handshake() {
+        // Server sends the 12-byte dongle_info_t in two chunks with a
+        // sleep between, exercising the read_exact_with_context loop.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let header = DongleInfo {
+                tuner: TunerTypeCode::E4000,
+                gain_count: 14,
+            }
+            .to_bytes();
+            sock.write_all(&header[..5]).unwrap();
+            thread::sleep(Duration::from_millis(80));
+            sock.write_all(&header[5..]).unwrap();
+            // Hold open briefly.
+            thread::sleep(Duration::from_millis(200));
+        });
+
+        let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
+        src.start_manager();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut got = None;
+        while Instant::now() < deadline {
+            if let ConnectionState::Connected { tuner } = src.connection_state() {
+                got = Some(tuner);
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        src.stop_manager();
+        let _ = server_thread.join();
+        let tuner = got.expect("handshake should succeed across split reads");
+        assert_eq!(tuner.tuner, TunerTypeCode::E4000);
+        assert_eq!(tuner.gain_count, 14);
+    }
+
+    #[test]
+    fn tcp_eof_mid_stream_transitions_to_retrying() {
+        // Server completes handshake then immediately closes and drops
+        // its listener — client must leave Connected and enter Retrying.
+        // NOTE: do NOT accept a second time here. A second accept without
+        // a header write would make the client hang on the header read
+        // until DATA_READ_TIMEOUT (5 s). We let the listener drop so the
+        // reconnect attempt gets ECONNREFUSED immediately, which puts
+        // the client into Retrying within a few ms.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: 29,
+            }
+            .to_bytes();
+            sock.write_all(&header).unwrap();
+            // Drop sock → FIN → client's data-pump read returns Ok(0).
+            // Dropping `listener` at the end of the closure scope makes
+            // subsequent connect() from the client fail with
+            // ECONNREFUSED, which lands the client in Retrying.
+        });
+
+        let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
+        src.start_manager();
+        let deadline = Instant::now() + Duration::from_millis(1500);
+        let mut saw_retrying = false;
+        while Instant::now() < deadline {
+            if matches!(src.connection_state(), ConnectionState::Retrying { .. }) {
+                saw_retrying = true;
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        src.stop_manager();
+        let _ = server_thread.join();
+        assert!(saw_retrying, "client never entered Retrying after EOF");
+    }
+
+    #[test]
+    fn commands_before_connect_are_recorded_and_replayed() {
+        // Driver queues commands before start() / before the server
+        // accepts; on handshake those values should be replayed to the
+        // server.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<Command>();
+
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: 29,
+            }
+            .to_bytes();
+            sock.write_all(&header).unwrap();
+            sock.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+            // Read whatever the client sends (replays + any subsequent
+            // calls) for up to 1 s or until we've collected 2 commands.
+            let mut got = 0;
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while got < 2 && Instant::now() < deadline {
+                let mut buf = [0u8; 5];
+                match sock.read_exact(&mut buf) {
+                    Ok(()) => {
+                        if let Some(cmd) = Command::from_bytes(&buf) {
+                            let _ = cmd_tx.send(cmd);
+                            got += 1;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
+        // Queue commands BEFORE start — these must end up sent after
+        // handshake via the replay path.
+        src.set_center_freq_hz(433_000_000).unwrap();
+        src.set_tuner_gain_tenths_db(197).unwrap();
+
+        src.start_manager();
+        // Collect the replayed commands.
+        let mut received = Vec::new();
+        while let Ok(cmd) = cmd_rx.recv_timeout(Duration::from_millis(1500)) {
+            received.push(cmd);
+            if received.len() == 2 {
+                break;
+            }
+        }
+        src.stop_manager();
+        let _ = server_thread.join();
+
+        let params: Vec<(CommandOp, u32)> = received.iter().map(|c| (c.op, c.param)).collect();
+        assert!(
+            params.contains(&(CommandOp::SetCenterFreq, 433_000_000)),
+            "expected replay of center freq, got {params:?}"
+        );
+        assert!(
+            params.contains(&(CommandOp::SetTunerGain, 197)),
+            "expected replay of tuner gain, got {params:?}"
+        );
+    }
+
+    #[test]
+    fn shutdown_during_failed_connect_is_prompt() {
+        // Point client at a port nothing's listening on; start_manager
+        // enters the retry loop. stop_manager should return within ~1 s,
+        // well below the exponential-backoff window.
+        let mut src = RtlTcpSource::new("127.0.0.1", 1); // port 1 likely refused
+        src.start_manager();
+        let t0 = Instant::now();
+        src.stop_manager();
+        let elapsed = t0.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "stop_manager took {elapsed:?}, should be prompt"
+        );
+    }
+
+    #[test]
+    fn replay_bits_set_independently_per_op() {
+        let src = RtlTcpSource::new("127.0.0.1", 1234);
+        src.record_command(Command {
+            op: CommandOp::SetBiasTee,
+            param: 1,
+        });
+        let mask = src.shared.replay_mask.load(Ordering::Relaxed);
+        // BiasTee is op 0x0e, so bit index (0x0e - 1) = 13.
+        assert!(mask & (1 << 13) != 0);
+        // No other bits should be set.
+        assert_eq!(mask.count_ones(), 1);
+    }
+}

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -464,6 +464,16 @@ impl RtlTcpSource {
     }
 
     pub fn set_sample_rate_hz(&self, hz: u32) -> Result<(), SourceError> {
+        // Mirror the `Source::set_sample_rate` guard: a zero sample rate
+        // wedges the RTL-SDR USB controller, so reject at the typed
+        // setter too. Otherwise a caller using the public helper could
+        // bypass the trait-level validation, cache 0 in
+        // `cached_sample_rate_bits`, and send it on the wire.
+        if hz == 0 {
+            return Err(SourceError::InvalidParameter(
+                "sample rate out of range: 0".into(),
+            ));
+        }
         self.shared
             .cached_sample_rate_bits
             .store(f64::from(hz).to_bits(), Ordering::Relaxed);
@@ -1254,6 +1264,21 @@ mod tests {
             left_connected,
             "client still Connected after timeout threshold — reconnect didn't fire"
         );
+    }
+
+    #[test]
+    fn set_sample_rate_hz_rejects_zero() {
+        // Matches `Source::set_sample_rate`'s `<= 0` guard. Bypassing
+        // via the typed helper would cache 0 and wedge the remote USB
+        // controller.
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
+        let err = src.set_sample_rate_hz(0);
+        assert!(
+            matches!(err, Err(SourceError::InvalidParameter(_))),
+            "expected InvalidParameter for 0 Hz sample rate, got {err:?}"
+        );
+        // Valid rates still succeed.
+        assert!(src.set_sample_rate_hz(2_048_000).is_ok());
     }
 
     #[test]

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -39,7 +39,7 @@
 
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -48,14 +48,25 @@ use sdr_pipeline::source_manager::Source;
 use sdr_server_rtltcp::protocol::{Command, CommandOp, DONGLE_INFO_LEN, DongleInfo, TunerTypeCode};
 use sdr_types::{Complex, SourceError};
 
-/// Read timeout on the data socket. Stalled reads longer than this trip
-/// the reconnect state machine — matches the upstream 1-second select in
-/// `rtl_tcp.c` command worker.
-const DATA_READ_TIMEOUT: Duration = Duration::from_secs(5);
+/// Default read timeout on the data socket. See
+/// [`RtlTcpConfig::data_read_timeout`].
+pub const DEFAULT_DATA_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default max consecutive read timeouts before reconnect. See
+/// [`RtlTcpConfig::max_consecutive_timeouts`].
+pub const DEFAULT_MAX_CONSECUTIVE_TIMEOUTS: u32 = 2;
 
 /// Exponential-backoff schedule for reconnect. Values in seconds.
 /// Clamped at 30 s, matching the review of epic #299.
 const BACKOFF_SCHEDULE_SECS: &[u64] = &[1, 2, 5, 10, 30];
+
+/// Soft cap on bytes buffered between the network reader and the
+/// pipeline consumer. Past this, newly-received bytes push out the
+/// oldest bytes (drop-oldest policy — the SDR pipeline wants fresh
+/// samples; stale ones are useless). 4 MiB ≈ 0.7 s of I/Q at 3.2 Msps,
+/// which is plenty of slack for a momentarily slow consumer without
+/// letting a wedged consumer OOM the process.
+const RX_BUFFER_SOFT_CAP_BYTES: usize = 4 * 1024 * 1024;
 
 /// Metadata parsed from the server's `dongle_info_t` header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,6 +103,37 @@ pub enum ConnectionState {
     Failed { reason: String },
 }
 
+/// Tunable knobs for the connection manager. All fields have sensible
+/// production defaults; tests and future UIs may want shorter timeouts
+/// (mobile / flaky networks) or a different reconnect tolerance.
+#[derive(Debug, Clone)]
+pub struct RtlTcpConfig {
+    /// Read timeout on the data socket. A stalled read longer than this
+    /// counts toward [`Self::max_consecutive_timeouts`] and, once
+    /// exceeded, trips the reconnect state machine. Shorter than the
+    /// kernel keepalive window so we detect silent drops within seconds
+    /// rather than minutes.
+    pub data_read_timeout: Duration,
+
+    /// Number of consecutive read timeouts before the data pump gives
+    /// up on the current connection and falls through to the reconnect
+    /// loop. With the default 5 s timeout this gives ~10 s of silence
+    /// before we declare the peer dead — well above any legitimate
+    /// network hiccup but still fast enough that a yanked cable doesn't
+    /// leave the UI frozen in Connected state until the kernel
+    /// keepalive finally fires.
+    pub max_consecutive_timeouts: u32,
+}
+
+impl Default for RtlTcpConfig {
+    fn default() -> Self {
+        Self {
+            data_read_timeout: DEFAULT_DATA_READ_TIMEOUT,
+            max_consecutive_timeouts: DEFAULT_MAX_CONSECUTIVE_TIMEOUTS,
+        }
+    }
+}
+
 /// rtl_tcp source client.
 ///
 /// Spawns a background connection manager thread on `start()`. The
@@ -102,6 +144,7 @@ pub struct RtlTcpSource {
     port: u16,
     sample_rate: f64,
     frequency: f64,
+    config: RtlTcpConfig,
 
     shared: Arc<SharedState>,
     manager: Option<JoinHandle<()>>,
@@ -116,10 +159,17 @@ struct SharedState {
 
     /// Latest 8-bit I/Q bytes read from the server. The connection
     /// manager appends bytes here; `read_samples` drains and converts.
-    /// Guarded by a Mutex because it's accessed from two threads; a
-    /// lock-free ring buffer would be lower overhead but adds unsafe,
-    /// and this matches the simplicity of the sibling `NetworkSource`.
+    /// Bounded at [`RX_BUFFER_SOFT_CAP_BYTES`] via drop-oldest on append
+    /// — prevents OOM if the downstream consumer stalls, and stale I/Q
+    /// samples are useless for a live SDR anyway. Guarded by a Mutex
+    /// because it's accessed from two threads; a lock-free ring buffer
+    /// would be lower overhead but adds unsafe, and this matches the
+    /// simplicity of the sibling `NetworkSource`.
     rx_buf: Mutex<Vec<u8>>,
+
+    /// Running count of bytes dropped to keep `rx_buf` under its cap,
+    /// for observability / UI "consumer too slow" indicators.
+    rx_dropped_bytes: AtomicU64,
 
     /// Write side of the socket, protected by a Mutex so command senders
     /// can share it without racing. Replaced on every reconnect.
@@ -165,19 +215,64 @@ impl SharedState {
             last_bias_tee: AtomicU32::new(0),
             last_gain_by_index: AtomicU32::new(0),
             replay_mask: AtomicU32::new(0),
+            rx_dropped_bytes: AtomicU64::new(0),
         }
     }
 }
 
+/// Append `chunk` to `rx`, dropping the oldest bytes if doing so would
+/// exceed [`RX_BUFFER_SOFT_CAP_BYTES`]. Returns the number of bytes
+/// dropped so the caller can surface it through observability.
+fn append_with_cap_inner(rx: &mut Vec<u8>, chunk: &[u8]) -> usize {
+    let desired_total = rx.len().saturating_add(chunk.len());
+    let mut dropped = 0;
+    if desired_total > RX_BUFFER_SOFT_CAP_BYTES {
+        // Drop enough from the front to make room for the new chunk.
+        let excess = desired_total - RX_BUFFER_SOFT_CAP_BYTES;
+        let to_drop = excess.min(rx.len());
+        rx.drain(..to_drop);
+        dropped = to_drop;
+    }
+    // If the chunk itself is larger than the cap, keep only the tail —
+    // the UI/consumer cares about the newest samples.
+    if chunk.len() > RX_BUFFER_SOFT_CAP_BYTES {
+        let keep_from = chunk.len() - RX_BUFFER_SOFT_CAP_BYTES;
+        rx.extend_from_slice(&chunk[keep_from..]);
+        dropped = dropped.saturating_add(keep_from);
+    } else {
+        rx.extend_from_slice(chunk);
+    }
+    dropped
+}
+
+/// Wrapper that does the drop-bookkeeping on the shared counter.
+fn append_with_cap_to_shared(shared: &SharedState, rx: &mut Vec<u8>, chunk: &[u8]) {
+    let dropped = append_with_cap_inner(rx, chunk);
+    if dropped > 0 {
+        shared
+            .rx_dropped_bytes
+            .fetch_add(dropped as u64, Ordering::Relaxed);
+        tracing::warn!(dropped, "rtl_tcp rx_buf full, dropped oldest bytes");
+    }
+}
+
 impl RtlTcpSource {
-    /// Create a new rtl_tcp client. Doesn't connect — call
-    /// [`Source::start`] or [`Self::start_manager`] to open the socket.
+    /// Create a new rtl_tcp client with default timeouts. Doesn't
+    /// connect — call [`Source::start`] to open the socket.
     pub fn new(host: &str, port: u16) -> Self {
+        Self::with_config(host, port, RtlTcpConfig::default())
+    }
+
+    /// Create a new rtl_tcp client with explicit timeout configuration.
+    /// Useful for tests and for UIs that want shorter detection windows
+    /// on flaky networks.
+    pub fn with_config(host: &str, port: u16, config: RtlTcpConfig) -> Self {
         Self {
             host: host.to_string(),
             port,
             sample_rate: 2_048_000.0,
             frequency: 100_000_000.0,
+            config,
             shared: Arc::new(SharedState::new()),
             manager: None,
         }
@@ -328,12 +423,13 @@ impl RtlTcpSource {
         let host = self.host.clone();
         let port = self.port;
         let shared = self.shared.clone();
+        let config = self.config.clone();
 
         self.shared.shutdown.store(false, Ordering::SeqCst);
         let handle = thread::Builder::new()
             .name("rtl_tcp-client".into())
             .spawn(move || {
-                connection_manager(host, port, shared);
+                connection_manager(host, port, shared, config);
             })
             .map_err(SourceError::Io)?;
         self.manager = Some(handle);
@@ -361,18 +457,18 @@ impl Drop for RtlTcpSource {
 }
 
 /// Background thread body: reconnect loop + data-read pump.
-fn connection_manager(host: String, port: u16, shared: Arc<SharedState>) {
+fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config: RtlTcpConfig) {
     let mut attempt: u32 = 0;
 
     while !shared.shutdown.load(Ordering::Relaxed) {
         set_state(&shared, ConnectionState::Connecting);
 
-        match attempt_connect(&host, port, &shared) {
+        match attempt_connect(&host, port, &shared, &config) {
             Ok(stream) => {
                 attempt = 0;
                 // At this point handshake has completed successfully.
                 replay_sticky_commands(&shared);
-                run_data_pump(stream, &shared);
+                run_data_pump(stream, &shared, &config);
                 // run_data_pump returned — connection dropped.
             }
             Err(e) => {
@@ -394,10 +490,23 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>) {
             break;
         }
 
-        attempt = attempt.saturating_add(1);
+        // Compute the delay using the PRE-increment attempt counter so
+        // the first retry actually uses slot 0 of BACKOFF_SCHEDULE_SECS
+        // (1 s), not slot 1 (2 s). Previously `attempt` was incremented
+        // before the `backoff_delay` call, giving an off-by-one where
+        // the observable schedule was 2 → 5 → 10 → 30 instead of the
+        // documented 1 → 2 → 5 → 10 → 30.
         let delay = backoff_delay(attempt);
+        let retry_number = attempt.saturating_add(1);
         let next_at = Instant::now() + delay;
-        set_state(&shared, ConnectionState::Retrying { attempt, next_at });
+        set_state(
+            &shared,
+            ConnectionState::Retrying {
+                attempt: retry_number,
+                next_at,
+            },
+        );
+        attempt = retry_number;
         sleep_until(next_at, &shared.shutdown);
     }
 
@@ -408,11 +517,12 @@ fn attempt_connect(
     host: &str,
     port: u16,
     shared: &Arc<SharedState>,
+    config: &RtlTcpConfig,
 ) -> Result<TcpStream, SourceError> {
     let addr = format!("{host}:{port}");
     let stream = TcpStream::connect(&addr).map_err(SourceError::Io)?;
 
-    stream.set_read_timeout(Some(DATA_READ_TIMEOUT))?;
+    stream.set_read_timeout(Some(config.data_read_timeout))?;
     if let Err(e) = set_keepalive(&stream, true) {
         tracing::warn!(%e, "SO_KEEPALIVE not applied (non-fatal)");
     }
@@ -441,8 +551,9 @@ fn attempt_connect(
     Ok(stream)
 }
 
-fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>) {
+fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>, config: &RtlTcpConfig) {
     let mut buf = [0u8; 64 * 1024];
+    let mut consecutive_timeouts: u32 = 0;
     while !shared.shutdown.load(Ordering::Relaxed) {
         match stream.read(&mut buf) {
             Ok(0) => {
@@ -450,8 +561,9 @@ fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>) {
                 break;
             }
             Ok(n) => {
+                consecutive_timeouts = 0;
                 if let Ok(mut rx) = shared.rx_buf.lock() {
-                    rx.extend_from_slice(&buf[..n]);
+                    append_with_cap_to_shared(shared, &mut rx, &buf[..n]);
                 }
             }
             Err(e)
@@ -459,8 +571,19 @@ fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>) {
                     || e.kind() == std::io::ErrorKind::WouldBlock =>
             {
                 // Read timeout — server may have silently gone away.
-                // Loop back and re-check shutdown; keepalive probes will
-                // eventually turn a silent drop into an explicit error.
+                // Break out to the reconnect loop after a handful of
+                // consecutive timeouts rather than waiting for the kernel
+                // keepalive (which can take minutes). A single timeout
+                // can be a transient stall; repeated timeouts mean the
+                // peer is dead.
+                consecutive_timeouts = consecutive_timeouts.saturating_add(1);
+                if consecutive_timeouts >= config.max_consecutive_timeouts {
+                    tracing::info!(
+                        consecutive_timeouts,
+                        "rtl_tcp stream stalled, breaking out for reconnect"
+                    );
+                    break;
+                }
             }
             Err(e) => {
                 tracing::info!(%e, "rtl_tcp socket read failed, will reconnect");
@@ -693,6 +816,166 @@ mod tests {
         assert_eq!(backoff_delay(4), Duration::from_secs(30));
         // Further attempts saturate.
         assert_eq!(backoff_delay(999), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn first_retry_uses_1s_backoff() {
+        // Regression test for a real off-by-one: the first retry used
+        // BACKOFF_SCHEDULE_SECS[1] (2s) instead of [0] (1s). Drive the
+        // manager against a never-listener and look at the first
+        // Retrying state it publishes.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Drop the listener immediately — any connect() will refuse.
+        drop(listener);
+
+        let mut src = RtlTcpSource::new(&addr.ip().to_string(), addr.port());
+        src.start_manager().unwrap();
+
+        // Wait up to 2s for the first Retrying state.
+        let t0 = Instant::now();
+        let mut first_delay = None;
+        while t0.elapsed() < Duration::from_secs(2) {
+            if let ConnectionState::Retrying { attempt, next_at } = src.connection_state() {
+                // `attempt` must be 1 for the first retry, and `next_at`
+                // must correspond to a ~1 s delay, not 2 s.
+                assert_eq!(attempt, 1, "first retry must be attempt 1");
+                let delay = next_at.saturating_duration_since(Instant::now());
+                first_delay = Some(delay);
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        src.stop_manager();
+
+        let d = first_delay.expect("never saw Retrying state within 2 s");
+        // Allow a little jitter. Must be <= 1 s + a small slack,
+        // NOT around 2 s.
+        assert!(
+            d <= Duration::from_millis(1100),
+            "first retry delay = {d:?}, expected ~1s"
+        );
+    }
+
+    #[test]
+    fn append_with_cap_drops_oldest_when_full() {
+        let mut rx = vec![0u8; RX_BUFFER_SOFT_CAP_BYTES - 10];
+        // Mark the tail so we can verify what survives.
+        rx[RX_BUFFER_SOFT_CAP_BYTES - 11] = 0xAA;
+        let incoming = vec![0xFFu8; 100]; // 100 bytes incoming — need to drop 90
+        let dropped = append_with_cap_inner(&mut rx, &incoming);
+        assert_eq!(dropped, 90);
+        assert_eq!(rx.len(), RX_BUFFER_SOFT_CAP_BYTES);
+        // Tail should be the 100 new 0xFF bytes.
+        assert!(rx[rx.len() - 100..].iter().all(|&b| b == 0xFF));
+    }
+
+    #[test]
+    fn append_with_cap_handles_oversized_chunk() {
+        // Chunk larger than the cap: keep only the tail of the chunk.
+        let mut rx = Vec::new();
+        let mut big = vec![0u8; RX_BUFFER_SOFT_CAP_BYTES + 1000];
+        // Mark the tail so we can verify it survives.
+        let len = big.len();
+        big[len - 1] = 0xAB;
+        let dropped = append_with_cap_inner(&mut rx, &big);
+        assert_eq!(dropped, 1000);
+        assert_eq!(rx.len(), RX_BUFFER_SOFT_CAP_BYTES);
+        assert_eq!(*rx.last().unwrap(), 0xAB);
+    }
+
+    #[test]
+    fn append_with_cap_no_drop_below_cap() {
+        let mut rx = vec![0u8; 1000];
+        let incoming = vec![0xFFu8; 500];
+        let dropped = append_with_cap_inner(&mut rx, &incoming);
+        assert_eq!(dropped, 0);
+        assert_eq!(rx.len(), 1500);
+    }
+
+    #[test]
+    fn second_client_is_rejected_not_queued() {
+        // This test verifies the contract stated in the module docs:
+        // "single client at a time; second connection rejected with
+        // graceful close." Upstream rtl_tcp silently hangs second
+        // connections in the kernel backlog; our implementation closes
+        // them immediately.
+        //
+        // We don't bring up a full Server here (needs a real RTL-SDR),
+        // but we can exercise the exact accept-loop logic by mocking
+        // the listener behavior: the key invariant is that a second
+        // connection's read(stream) returns EOF quickly rather than
+        // hanging for the DATA_READ_TIMEOUT window.
+        //
+        // Since Server::start requires hardware, cover the pure-logic
+        // part — the AtomicBool swap semantics — directly.
+        let busy = AtomicBool::new(false);
+        assert!(!busy.swap(true, Ordering::SeqCst)); // first claim: was false
+        assert!(busy.swap(true, Ordering::SeqCst)); // second claim: already true
+        // A second accept caller would see `true` and reject.
+        busy.store(false, Ordering::SeqCst); // session done
+        assert!(!busy.swap(true, Ordering::SeqCst)); // next client can claim again
+    }
+
+    #[test]
+    fn consecutive_timeouts_break_out_of_data_pump() {
+        // Server completes handshake then stops sending anything. With
+        // a 200 ms read timeout and max 2 consecutive timeouts, the
+        // client should leave Connected within ~400 ms rather than
+        // hanging for the full DATA_READ_TIMEOUT window.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_thread = thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let header = DongleInfo {
+                    tuner: TunerTypeCode::R820t,
+                    gain_count: 29,
+                }
+                .to_bytes();
+                let _ = sock.write_all(&header);
+                // Hold for well past 2 × read_timeout so the client's
+                // read() actually hits TimedOut (not EOF).
+                thread::sleep(Duration::from_secs(2));
+            }
+        });
+
+        let config = RtlTcpConfig {
+            data_read_timeout: Duration::from_millis(200),
+            max_consecutive_timeouts: 2,
+        };
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        src.start_manager().unwrap();
+
+        // Wait for Connected.
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let mut reached_connected = false;
+        while Instant::now() < deadline {
+            if matches!(src.connection_state(), ConnectionState::Connected { .. }) {
+                reached_connected = true;
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(reached_connected, "never reached Connected");
+
+        // After 2 × 200 ms of silence the data pump should break out.
+        // Give up to 1 second of slack for scheduling jitter.
+        let timeout_deadline = Instant::now() + Duration::from_secs(1);
+        let mut left_connected = false;
+        while Instant::now() < timeout_deadline {
+            if !matches!(src.connection_state(), ConnectionState::Connected { .. }) {
+                left_connected = true;
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        src.stop_manager();
+        let _ = server_thread.join();
+        assert!(
+            left_connected,
+            "client still Connected after timeout threshold — reconnect didn't fire"
+        );
     }
 
     #[test]

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -90,6 +90,11 @@ const RX_BUFFER_SOFT_CAP_BYTES: usize = 4 * 1024 * 1024;
 /// `connect_timeout` window.
 const CONNECT_SHUTDOWN_POLL: Duration = Duration::from_millis(100);
 
+/// Chunk size for both the warm-capacity hint on `rx_buf` and the
+/// stack buffer the data pump reads into. Keeps the read-chunk and
+/// initial-allocation policy in one place so they can't drift.
+const RECV_CHUNK_BYTES: usize = 64 * 1024;
+
 /// Metadata parsed from the server's `dongle_info_t` header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TunerInfo {
@@ -119,9 +124,14 @@ pub enum ConnectionState {
     Connecting,
     /// Handshake complete, handler streaming I/Q.
     Connected { tuner: TunerInfo },
-    /// Connection dropped, backoff pending.
+    /// Connection dropped, backoff pending. Transport-level errors
+    /// (TCP connect refused, EOF, stall) stay in this state — the
+    /// manager retries forever with exponential backoff up to the
+    /// 30 s cap.
     Retrying { attempt: u32, next_at: Instant },
-    /// Terminal failure after max attempts, or protocol error.
+    /// Terminal failure — only entered for a protocol-level error
+    /// (e.g., server sent a non-RTL0 header). Transport failures
+    /// never reach this state; they remain in `Retrying`.
     Failed { reason: String },
 }
 
@@ -246,7 +256,7 @@ impl SharedState {
             shutdown: AtomicBool::new(false),
             state: Mutex::new(ConnectionState::Disconnected),
             tuner: Mutex::new(None),
-            rx_buf: Mutex::new(Vec::with_capacity(64 * 1024)),
+            rx_buf: Mutex::new(Vec::with_capacity(RECV_CHUNK_BYTES)),
             command_sink: Mutex::new(None),
             last_center_freq_hz: AtomicU32::new(0),
             last_sample_rate_hz: AtomicU32::new(0),
@@ -657,8 +667,16 @@ fn attempt_connect(
     }
     set_state(shared, ConnectionState::Connected { tuner });
 
-    // Publish a clone of the stream for the command sender.
+    // Publish a clone of the stream for the command sender. Install a
+    // write timeout on the clone so `send_command`'s blocking
+    // `write_all` can't hang indefinitely if a zero-window peer
+    // saturates our kernel send buffer — tune/gain changes must stay
+    // responsive. Socket options propagate across `try_clone` on the
+    // same underlying fd, so this applies to every subsequent write.
     let sink = stream.try_clone().map_err(SourceError::Io)?;
+    if let Err(e) = sink.set_write_timeout(Some(config.data_read_timeout)) {
+        tracing::warn!(%e, "set_write_timeout on command sink failed — command sends may block");
+    }
     if let Ok(mut slot) = shared.command_sink.lock() {
         *slot = Some(sink);
     }
@@ -736,7 +754,7 @@ fn connect_cancellable(
 }
 
 fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>, config: &RtlTcpConfig) {
-    let mut buf = [0u8; 64 * 1024];
+    let mut buf = [0u8; RECV_CHUNK_BYTES];
     let mut consecutive_timeouts: u32 = 0;
     while !shared.shutdown.load(Ordering::Relaxed) {
         match stream.read(&mut buf) {

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -411,8 +411,14 @@ impl RtlTcpSource {
             return Ok(());
         };
         if let Err(e) = stream.write_all(&cmd.to_bytes()) {
-            tracing::debug!(%e, "rtl_tcp command write failed — reconnect will replay");
-            // Drop the broken stream; manager will notice and reconnect.
+            tracing::debug!(%e, "rtl_tcp command write failed — tearing down session to force reconnect");
+            // Full socket shutdown so `run_data_pump` on the sibling
+            // read-half breaks out of its blocking read IMMEDIATELY
+            // instead of continuing to pump bytes off a half-dead
+            // connection. Without the explicit shutdown, the read path
+            // keeps going and subsequent commands queue in the replay
+            // cache without ever actually going out.
+            let _ = stream.shutdown(std::net::Shutdown::Both);
             *sink = None;
             return Ok(());
         }
@@ -883,7 +889,14 @@ fn replay_sticky_commands(shared: &Arc<SharedState>) {
             param: slot.load(Ordering::Relaxed),
         };
         if let Err(e) = stream.write_all(&cmd.to_bytes()) {
-            tracing::debug!(%e, op = ?op, "replay write failed — will retry on next reconnect");
+            tracing::debug!(%e, op = ?op, "replay write failed — tearing down session to force reconnect");
+            // Same pattern as `send_command`: full shutdown so
+            // `run_data_pump` breaks out immediately instead of
+            // continuing to pump on a half-dead socket. Otherwise the
+            // replay would partially land on the wire, leaving server
+            // state desynced from the client's view of it.
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+            *sink = None;
             return;
         }
     }

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -38,7 +38,7 @@
 //! upstream GQRX/SDR++ behavior.
 
 use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::net::{SocketAddr, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -60,6 +60,16 @@ pub const DEFAULT_MAX_CONSECUTIVE_TIMEOUTS: u32 = 2;
 /// [`RtlTcpConfig::connect_timeout`].
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Default sample rate the client reports to pipeline callers before
+/// the first `set_sample_rate` arrives. Matches upstream rtl_tcp's
+/// 2.048 Msps default.
+const DEFAULT_CLIENT_SAMPLE_RATE_HZ: f64 = 2_048_000.0;
+
+/// Default center frequency the client reports to pipeline callers
+/// before the first `tune` arrives. Matches upstream rtl_tcp's
+/// 100 MHz default.
+const DEFAULT_CLIENT_CENTER_FREQ_HZ: f64 = 100_000_000.0;
+
 /// Exponential-backoff schedule for reconnect. Values in seconds.
 /// Clamped at 30 s, matching the review of epic #299.
 const BACKOFF_SCHEDULE_SECS: &[u64] = &[1, 2, 5, 10, 30];
@@ -71,6 +81,14 @@ const BACKOFF_SCHEDULE_SECS: &[u64] = &[1, 2, 5, 10, 30];
 /// which is plenty of slack for a momentarily slow consumer without
 /// letting a wedged consumer OOM the process.
 const RX_BUFFER_SOFT_CAP_BYTES: usize = 4 * 1024 * 1024;
+
+/// How often the manager thread checks the shutdown flag while waiting
+/// on an outstanding blocking connect. `TcpStream::connect_timeout`
+/// can't be cancelled from another thread, so we run it on a helper
+/// and poll a channel at this cadence instead — stop_manager's
+/// observable shutdown lag is bounded by this value, not by the full
+/// `connect_timeout` window.
+const CONNECT_SHUTDOWN_POLL: Duration = Duration::from_millis(100);
 
 /// Metadata parsed from the server's `dongle_info_t` header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -319,8 +337,8 @@ impl RtlTcpSource {
         Self {
             host: host.to_string(),
             port,
-            sample_rate: 2_048_000.0,
-            frequency: 100_000_000.0,
+            sample_rate: DEFAULT_CLIENT_SAMPLE_RATE_HZ,
+            frequency: DEFAULT_CLIENT_CENTER_FREQ_HZ,
             config,
             shared: Arc::new(SharedState::new()),
             manager: None,
@@ -340,8 +358,14 @@ impl RtlTcpSource {
         self.shared.tuner.lock().ok().and_then(|g| *g)
     }
 
-    /// Send a raw rtl_tcp command over the current socket. Returns
-    /// `NotRunning` if the connection manager is not alive.
+    /// Send a raw rtl_tcp command over the current socket.
+    ///
+    /// If no live socket is available (pre-connect, mid-reconnect, or
+    /// after a write failure), the command is recorded via
+    /// `record_command` and replayed on the next successful handshake
+    /// — the caller does NOT get `NotRunning` for the offline case.
+    /// `SourceError::NotRunning` is returned only when local
+    /// synchronization fails (poisoned `command_sink` mutex).
     ///
     /// Callers should prefer the typed setters (`set_center_freq_hz`,
     /// etc.) — this is the low-level escape hatch used by the setters.
@@ -597,32 +621,21 @@ fn attempt_connect(
     // `format!("{host}:{port}")` that we had before would build
     // `::1:1234` for IPv6, which SocketAddr::from_str then rejects.
     //
-    // `connect_timeout` is per-resolved-address rather than
-    // whole-call, so when a hostname resolves to multiple A/AAAA
-    // records we effectively iterate. Without any timeout, a
-    // blackholed destination wedges the manager thread for 60+ s
-    // waiting on TCP SYN retransmits.
+    // Resolution itself is ~instant on localhost; the slow path is the
+    // actual `connect_timeout` call, which is offloaded below.
     use std::net::ToSocketAddrs;
-    let resolved = (host, port).to_socket_addrs().map_err(SourceError::Io)?;
-    let mut last_err: Option<std::io::Error> = None;
-    let mut stream: Option<TcpStream> = None;
-    for addr in resolved {
-        match TcpStream::connect_timeout(&addr, config.connect_timeout) {
-            Ok(s) => {
-                stream = Some(s);
-                break;
-            }
-            Err(e) => last_err = Some(e),
-        }
-    }
-    let stream = stream.ok_or_else(|| {
-        SourceError::Io(last_err.unwrap_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::AddrNotAvailable,
-                "no socket addresses resolved",
-            )
-        }))
-    })?;
+    let addrs: Vec<SocketAddr> = (host, port)
+        .to_socket_addrs()
+        .map_err(SourceError::Io)?
+        .collect();
+
+    // Run the blocking connect on a helper thread so the manager can
+    // respond to `shutdown` within `CONNECT_SHUTDOWN_POLL` instead of
+    // being wedged for the full `config.connect_timeout` window when a
+    // destination is blackholed. `TcpStream::connect_timeout` has no
+    // cancellation hook, so we let the helper finish naturally after
+    // shutdown and just ignore its result.
+    let stream = connect_cancellable(addrs, config.connect_timeout, &shared.shutdown)?;
 
     stream.set_read_timeout(Some(config.data_read_timeout))?;
     if let Err(e) = set_keepalive(&stream, true) {
@@ -651,6 +664,75 @@ fn attempt_connect(
     }
 
     Ok(stream)
+}
+
+/// Run `TcpStream::connect_timeout` on a helper thread, polling a
+/// channel from the manager thread so shutdown is noticed promptly.
+///
+/// Iterates `addrs` in order (covers hostnames that resolve to multiple
+/// A/AAAA records), first successful connect wins. On shutdown the
+/// helper is abandoned — its `tx.send` becomes a no-op when `rx` drops
+/// at return, and the helper thread dies naturally once its `connect`
+/// call returns or times out.
+fn connect_cancellable(
+    addrs: Vec<SocketAddr>,
+    timeout: Duration,
+    shutdown: &AtomicBool,
+) -> Result<TcpStream, SourceError> {
+    let (tx, rx) = std::sync::mpsc::channel::<Result<TcpStream, std::io::Error>>();
+    thread::Builder::new()
+        .name("rtl_tcp-connect".into())
+        .spawn(move || {
+            let mut last_err: Option<std::io::Error> = None;
+            let mut stream: Option<TcpStream> = None;
+            for addr in addrs {
+                match TcpStream::connect_timeout(&addr, timeout) {
+                    Ok(s) => {
+                        stream = Some(s);
+                        break;
+                    }
+                    Err(e) => last_err = Some(e),
+                }
+            }
+            let result = match stream {
+                Some(s) => Ok(s),
+                None => Err(last_err.unwrap_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::AddrNotAvailable,
+                        "no socket addresses resolved",
+                    )
+                })),
+            };
+            // `rx` may already have dropped if the manager shut down
+            // during our blocking connect — that's fine, the helper
+            // just exits with its result thrown away.
+            let _ = tx.send(result);
+        })
+        .map_err(SourceError::Io)?;
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            // Abandon the helper. On return `rx` drops, the helper's
+            // next `tx.send` becomes a no-op, and the helper thread
+            // exits on its own once the current connect completes.
+            return Err(SourceError::Io(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "manager shutdown during connect",
+            )));
+        }
+        match rx.recv_timeout(CONNECT_SHUTDOWN_POLL) {
+            Ok(Ok(stream)) => return Ok(stream),
+            Ok(Err(e)) => return Err(SourceError::Io(e)),
+            // Timeout: loop back and re-check shutdown. (Empty arm —
+            // fall through to the next iteration.)
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(SourceError::Io(std::io::Error::other(
+                    "connect helper thread disconnected unexpectedly",
+                )));
+            }
+        }
+    }
 }
 
 fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>, config: &RtlTcpConfig) {
@@ -1494,6 +1576,34 @@ mod tests {
         }
         // Sanity: 2.048 Msps passes.
         assert!(<RtlTcpSource as Source>::set_sample_rate(&mut src, 2_048_000.0).is_ok());
+    }
+
+    #[test]
+    fn connect_cancellable_aborts_promptly_on_shutdown() {
+        // `TcpStream::connect_timeout` itself has no cancellation hook,
+        // but our cancellable wrapper polls the shutdown flag at
+        // `CONNECT_SHUTDOWN_POLL` cadence. When the flag is pre-set,
+        // the caller returns before the helper thread finishes — this
+        // exercise that path without needing a blackholed IP in CI.
+        let shutdown = AtomicBool::new(true);
+        // Any address — doesn't matter, shutdown is already set so the
+        // poll loop returns on the first iteration before the helper's
+        // `connect_timeout` ever completes.
+        let addrs = vec![SocketAddr::from(([127, 0, 0, 1], REFUSED_TEST_PORT))];
+        let t0 = Instant::now();
+        let result = connect_cancellable(addrs, Duration::from_secs(30), &shutdown);
+        let elapsed = t0.elapsed();
+        assert!(
+            matches!(
+                result,
+                Err(SourceError::Io(ref e)) if e.kind() == std::io::ErrorKind::Interrupted
+            ),
+            "expected Interrupted on shutdown, got {result:?}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "connect_cancellable returned in {elapsed:?}, should be ≤ CONNECT_SHUTDOWN_POLL"
+        );
     }
 
     #[test]

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -179,11 +179,16 @@ impl Default for RtlTcpConfig {
 /// Spawns a background connection manager thread on `start()`. The
 /// manager owns the socket, does the reconnect loop, and publishes the
 /// byte stream into a ring buffer that `read_samples` drains.
+///
+/// The "current frequency / sample rate" values exposed through
+/// [`Source::sample_rate`] / `sample_rate()` live on `SharedState` as
+/// atomic f64 bit-patterns rather than on `self`, so every setter path
+/// — the `&mut self` trait methods AND the `&self` typed `set_*_hz`
+/// helpers — updates the same source of truth. Keeps callers that
+/// bypass the trait from seeing a stale cache.
 pub struct RtlTcpSource {
     host: String,
     port: u16,
-    sample_rate: f64,
-    frequency: f64,
     config: RtlTcpConfig,
 
     shared: Arc<SharedState>,
@@ -215,6 +220,17 @@ struct SharedState {
     /// bytes; cleared when the buffer drains to below half-cap. Ensures
     /// we log once per stall-and-drain cycle instead of per-chunk.
     rx_in_overflow: AtomicBool,
+
+    /// Cached "current sample rate" reported via the `Source::sample_rate`
+    /// getter. f64 bits so we can update from `&self` setters without
+    /// interior-mutability boilerplate. Initialized to
+    /// [`DEFAULT_CLIENT_SAMPLE_RATE_HZ`].
+    cached_sample_rate_bits: AtomicU64,
+
+    /// Cached "current center frequency" reported via `Source::tune`'s
+    /// `frequency` accessor pattern. Same rationale as
+    /// `cached_sample_rate_bits`.
+    cached_frequency_bits: AtomicU64,
 
     /// Write side of the socket, protected by a Mutex so command senders
     /// can share it without racing. Replaced on every reconnect.
@@ -271,6 +287,8 @@ impl SharedState {
             replay_mask: AtomicU32::new(0),
             rx_dropped_bytes: AtomicU64::new(0),
             rx_in_overflow: AtomicBool::new(false),
+            cached_sample_rate_bits: AtomicU64::new(DEFAULT_CLIENT_SAMPLE_RATE_HZ.to_bits()),
+            cached_frequency_bits: AtomicU64::new(DEFAULT_CLIENT_CENTER_FREQ_HZ.to_bits()),
             last_testmode: AtomicU32::new(0),
             last_if_gain: AtomicU32::new(0),
             last_rtl_xtal: AtomicU32::new(0),
@@ -347,8 +365,6 @@ impl RtlTcpSource {
         Self {
             host: host.to_string(),
             port,
-            sample_rate: DEFAULT_CLIENT_SAMPLE_RATE_HZ,
-            frequency: DEFAULT_CLIENT_CENTER_FREQ_HZ,
             config,
             shared: Arc::new(SharedState::new()),
             manager: None,
@@ -435,6 +451,12 @@ impl RtlTcpSource {
     /// Convenience typed setters — each one round-trips through
     /// [`Self::send_command`].
     pub fn set_center_freq_hz(&self, hz: u32) -> Result<(), SourceError> {
+        // Update the cached getter value BEFORE sending so a reader
+        // that races with a concurrent getter never sees stale state
+        // while the new value is on the wire.
+        self.shared
+            .cached_frequency_bits
+            .store(f64::from(hz).to_bits(), Ordering::Relaxed);
         self.send_command(Command {
             op: CommandOp::SetCenterFreq,
             param: hz,
@@ -442,6 +464,9 @@ impl RtlTcpSource {
     }
 
     pub fn set_sample_rate_hz(&self, hz: u32) -> Result<(), SourceError> {
+        self.shared
+            .cached_sample_rate_bits
+            .store(f64::from(hz).to_bits(), Ordering::Relaxed);
         self.send_command(Command {
             op: CommandOp::SetSampleRate,
             param: hz,
@@ -799,6 +824,17 @@ fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>, config: &RtlT
     if let Ok(mut sink) = shared.command_sink.lock() {
         *sink = None;
     }
+    // Clear any buffered I/Q so the next successful session doesn't
+    // rewind the consumer with pre-drop samples from the previous
+    // server. Stale samples are useless for a live SDR; the user wants
+    // fresh data from the new handshake onward.
+    if let Ok(mut rx) = shared.rx_buf.lock() {
+        rx.clear();
+    }
+    // Rearm the edge-triggered overflow warn so if the next session
+    // stalls, the warning logs again rather than being suppressed by a
+    // stale flag left over from the previous session.
+    shared.rx_in_overflow.store(false, Ordering::Relaxed);
 }
 
 fn replay_sticky_commands(shared: &Arc<SharedState>) {
@@ -938,8 +974,9 @@ impl Source for RtlTcpSource {
                 "center frequency out of range: {frequency_hz}"
             )));
         }
-        self.frequency = frequency_hz;
-        // Round to u32 — upstream wire protocol is u32 Hz.
+        // Round to u32 — upstream wire protocol is u32 Hz. Cache
+        // update happens inside `set_center_freq_hz` via the shared
+        // atomic; no local field write here.
         #[allow(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
@@ -954,7 +991,10 @@ impl Source for RtlTcpSource {
     }
 
     fn sample_rate(&self) -> f64 {
-        self.sample_rate
+        // Read from the shared cache so the value stays consistent
+        // whether the caller used `Source::set_sample_rate` or the
+        // typed `set_sample_rate_hz` helper.
+        f64::from_bits(self.shared.cached_sample_rate_bits.load(Ordering::Relaxed))
     }
 
     fn set_sample_rate(&mut self, rate: f64) -> Result<(), SourceError> {
@@ -967,7 +1007,6 @@ impl Source for RtlTcpSource {
                 "sample rate out of range: {rate}"
             )));
         }
-        self.sample_rate = rate;
         #[allow(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
@@ -1215,6 +1254,66 @@ mod tests {
             left_connected,
             "client still Connected after timeout threshold — reconnect didn't fire"
         );
+    }
+
+    #[test]
+    fn typed_setter_updates_cached_getter_value() {
+        // Regression for the split-brain bug: `set_sample_rate_hz` and
+        // `set_center_freq_hz` write the wire command but previously
+        // left the cached getter value untouched, so a caller polling
+        // `Source::sample_rate()` after using the typed setter would
+        // see the default rate, not what they just set. Moving the
+        // caches onto `SharedState` with atomic f64 bit-patterns fixes
+        // this.
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
+        // Default before any set:
+        let default_rate = <RtlTcpSource as Source>::sample_rate(&src);
+        assert!((default_rate - DEFAULT_CLIENT_SAMPLE_RATE_HZ).abs() < 0.5);
+
+        // Typed setter (bypasses `Source::set_sample_rate`):
+        src.set_sample_rate_hz(2_400_000).unwrap();
+        let after = <RtlTcpSource as Source>::sample_rate(&src);
+        assert!(
+            (after - 2_400_000.0).abs() < 0.5,
+            "getter after set_sample_rate_hz = {after}, want 2_400_000"
+        );
+    }
+
+    #[test]
+    fn session_end_clears_rx_buf_and_rearms_overflow() {
+        // Stale I/Q in rx_buf after a session ends would replay into
+        // the next session's consumer, rewinding the stream. Set some
+        // fake rx state + overflow flag, then simulate the path that
+        // run_data_pump takes on disconnect.
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
+        if let Ok(mut rx) = src.shared.rx_buf.lock() {
+            rx.extend_from_slice(&[0u8; 1024]);
+        }
+        src.shared.rx_in_overflow.store(true, Ordering::Relaxed);
+        if let Ok(mut sink) = src.shared.command_sink.lock() {
+            // Use a dummy stream so there's something to clear.
+            let (client, _server) = {
+                let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+                let addr = listener.local_addr().unwrap();
+                let server_thread = thread::spawn(move || listener.accept().unwrap().0);
+                let c = TcpStream::connect(addr).unwrap();
+                (c, server_thread.join().unwrap())
+            };
+            *sink = Some(client);
+        }
+
+        // Simulate the disconnect cleanup body inline.
+        if let Ok(mut sink) = src.shared.command_sink.lock() {
+            *sink = None;
+        }
+        if let Ok(mut rx) = src.shared.rx_buf.lock() {
+            rx.clear();
+        }
+        src.shared.rx_in_overflow.store(false, Ordering::Relaxed);
+
+        assert_eq!(src.shared.rx_buf.lock().unwrap().len(), 0);
+        assert!(!src.shared.rx_in_overflow.load(Ordering::Relaxed));
+        assert!(src.shared.command_sink.lock().unwrap().is_none());
     }
 
     #[test]

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -183,6 +183,11 @@ struct SharedState {
     /// for observability / UI "consumer too slow" indicators.
     rx_dropped_bytes: AtomicU64,
 
+    /// Edge-trigger flag for the overflow warn log. Set when we drop
+    /// bytes; cleared when the buffer drains to below half-cap. Ensures
+    /// we log once per stall-and-drain cycle instead of per-chunk.
+    rx_in_overflow: AtomicBool,
+
     /// Write side of the socket, protected by a Mutex so command senders
     /// can share it without racing. Replaced on every reconnect.
     command_sink: Mutex<Option<TcpStream>>,
@@ -201,6 +206,15 @@ struct SharedState {
     last_offset_tuning: AtomicU32,
     last_bias_tee: AtomicU32,
     last_gain_by_index: AtomicU32,
+    // Rarely-adjusted but still stateful ops. Tracked + replayed so a
+    // pre-connect set_testmode (etc.) isn't silently lost and so the
+    // server state matches the UI view across reconnects, same as the
+    // common setters. Addresses CodeRabbit round 5 concern that these
+    // previously returned Ok without persisting.
+    last_testmode: AtomicU32,
+    last_if_gain: AtomicU32,
+    last_rtl_xtal: AtomicU32,
+    last_tuner_xtal: AtomicU32,
     // Sentinel: bit 0 of `replay_mask` is set once ANY value has been
     // written for each op, so a fresh connection doesn't replay default
     // zeros onto a server whose operator explicitly wanted something
@@ -228,6 +242,11 @@ impl SharedState {
             last_gain_by_index: AtomicU32::new(0),
             replay_mask: AtomicU32::new(0),
             rx_dropped_bytes: AtomicU64::new(0),
+            rx_in_overflow: AtomicBool::new(false),
+            last_testmode: AtomicU32::new(0),
+            last_if_gain: AtomicU32::new(0),
+            last_rtl_xtal: AtomicU32::new(0),
+            last_tuner_xtal: AtomicU32::new(0),
         }
     }
 }
@@ -256,13 +275,33 @@ fn append_with_cap_inner(rx: &mut Vec<u8>, chunk: &[u8]) -> usize {
 }
 
 /// Wrapper that does the drop-bookkeeping on the shared counter.
+///
+/// Logs only on the *transition* into the overflow state — once the
+/// buffer is over cap we can log dozens of times per second on a hot
+/// path, which adds CPU and log pressure while the consumer is already
+/// behind. The `rx_dropped_bytes` counter is the authoritative source
+/// of truth for "how much has been lost"; the warn is just an edge
+/// signal so operators notice each stall start.
+///
+/// When the buffer drains to below half-cap the flag rearms, so a
+/// subsequent stall will log again.
 fn append_with_cap_to_shared(shared: &SharedState, rx: &mut Vec<u8>, chunk: &[u8]) {
     let dropped = append_with_cap_inner(rx, chunk);
     if dropped > 0 {
         shared
             .rx_dropped_bytes
             .fetch_add(dropped as u64, Ordering::Relaxed);
-        tracing::warn!(dropped, "rtl_tcp rx_buf full, dropped oldest bytes");
+        let was_in_overflow = shared.rx_in_overflow.swap(true, Ordering::Relaxed);
+        if !was_in_overflow {
+            tracing::warn!(
+                dropped,
+                "rtl_tcp rx_buf full, dropping oldest bytes (see rx_dropped_bytes counter for cumulative loss)"
+            );
+        }
+    } else if rx.len() < RX_BUFFER_SOFT_CAP_BYTES / 2 {
+        // Consumer is keeping up well enough that we're back below
+        // half-cap — rearm the edge so a future stall logs again.
+        shared.rx_in_overflow.store(false, Ordering::Relaxed);
     }
 }
 
@@ -331,21 +370,26 @@ impl RtlTcpSource {
     }
 
     fn record_command(&self, cmd: Command) {
+        // ALL 14 stateful ops are recorded for reconnect replay. A
+        // pre-connect `set_testmode(true)` (etc.) would previously
+        // return `Ok(())` without actually being sent, because the
+        // command sink wasn't up yet — silent loss. Now every op
+        // survives the connect / reconnect cycle.
         let slot = match cmd.op {
             CommandOp::SetCenterFreq => &self.shared.last_center_freq_hz,
             CommandOp::SetSampleRate => &self.shared.last_sample_rate_hz,
             CommandOp::SetGainMode => &self.shared.last_gain_mode,
             CommandOp::SetTunerGain => &self.shared.last_tuner_gain,
             CommandOp::SetFreqCorrection => &self.shared.last_ppm,
+            CommandOp::SetIfGain => &self.shared.last_if_gain,
+            CommandOp::SetTestMode => &self.shared.last_testmode,
             CommandOp::SetAgcMode => &self.shared.last_agc_mode,
             CommandOp::SetDirectSampling => &self.shared.last_direct_sampling,
             CommandOp::SetOffsetTuning => &self.shared.last_offset_tuning,
-            CommandOp::SetBiasTee => &self.shared.last_bias_tee,
+            CommandOp::SetRtlXtal => &self.shared.last_rtl_xtal,
+            CommandOp::SetTunerXtal => &self.shared.last_tuner_xtal,
             CommandOp::SetGainByIndex => &self.shared.last_gain_by_index,
-            // Ops we don't replay (testmode, if-gain, xtal frequencies)
-            // are stateful on the server but rarely adjusted; skip the
-            // replay plumbing for now. Re-examine if a use case appears.
-            _ => return,
+            CommandOp::SetBiasTee => &self.shared.last_bias_tee,
         };
         slot.store(cmd.param, Ordering::Relaxed);
         let bit = u32::from((cmd.op as u8) - 1);
@@ -673,11 +717,15 @@ fn replay_sticky_commands(shared: &Arc<SharedState>) {
         (CommandOp::SetGainMode, &shared.last_gain_mode),
         (CommandOp::SetTunerGain, &shared.last_tuner_gain),
         (CommandOp::SetFreqCorrection, &shared.last_ppm),
+        (CommandOp::SetIfGain, &shared.last_if_gain),
+        (CommandOp::SetTestMode, &shared.last_testmode),
         (CommandOp::SetAgcMode, &shared.last_agc_mode),
         (CommandOp::SetDirectSampling, &shared.last_direct_sampling),
         (CommandOp::SetOffsetTuning, &shared.last_offset_tuning),
-        (CommandOp::SetBiasTee, &shared.last_bias_tee),
+        (CommandOp::SetRtlXtal, &shared.last_rtl_xtal),
+        (CommandOp::SetTunerXtal, &shared.last_tuner_xtal),
         (CommandOp::SetGainByIndex, &shared.last_gain_by_index),
+        (CommandOp::SetBiasTee, &shared.last_bias_tee),
     ];
     for (op, slot) in ops {
         let bit = u32::from((op as u8) - 1);
@@ -1461,6 +1509,74 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(2),
             "stop_manager took {elapsed:?}, should be prompt"
+        );
+    }
+
+    #[test]
+    fn record_command_covers_all_14_wire_ops() {
+        // Every upstream command is recorded for reconnect-replay so a
+        // pre-connect call (e.g. set_testmode before start()) isn't
+        // silently lost. Walk all 14 opcodes and confirm each lands in
+        // the replay_mask.
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
+        let all_ops = [
+            CommandOp::SetCenterFreq,
+            CommandOp::SetSampleRate,
+            CommandOp::SetGainMode,
+            CommandOp::SetTunerGain,
+            CommandOp::SetFreqCorrection,
+            CommandOp::SetIfGain,
+            CommandOp::SetTestMode,
+            CommandOp::SetAgcMode,
+            CommandOp::SetDirectSampling,
+            CommandOp::SetOffsetTuning,
+            CommandOp::SetRtlXtal,
+            CommandOp::SetTunerXtal,
+            CommandOp::SetGainByIndex,
+            CommandOp::SetBiasTee,
+        ];
+        for op in all_ops {
+            src.record_command(Command { op, param: 42 });
+        }
+        let mask = src.shared.replay_mask.load(Ordering::Relaxed);
+        // Every op from 0x01..=0x0e should have its bit set (bit index
+        // = opcode - 1), so the low 14 bits should all be 1.
+        assert_eq!(mask & 0x3fff, 0x3fff, "mask={mask:#x}");
+    }
+
+    #[test]
+    fn rx_overflow_warning_is_edge_triggered() {
+        // Fill rx past cap → first overflow flips the flag. Subsequent
+        // overflows without a drain in between should leave the flag
+        // set (log suppressed). A drain below half-cap rearms the flag.
+        let src = RtlTcpSource::new("127.0.0.1", UNUSED_TEST_PORT);
+        assert!(!src.shared.rx_in_overflow.load(Ordering::Relaxed));
+
+        // Simulate first overflow.
+        {
+            let mut rx = src.shared.rx_buf.lock().unwrap();
+            *rx = vec![0u8; RX_BUFFER_SOFT_CAP_BYTES];
+            append_with_cap_to_shared(&src.shared, &mut rx, &[0xFFu8; 100]);
+        }
+        assert!(src.shared.rx_in_overflow.load(Ordering::Relaxed));
+
+        // Second overflow — flag already set, no transition.
+        {
+            let mut rx = src.shared.rx_buf.lock().unwrap();
+            append_with_cap_to_shared(&src.shared, &mut rx, &[0xFFu8; 100]);
+        }
+        assert!(src.shared.rx_in_overflow.load(Ordering::Relaxed));
+
+        // Drain well below half-cap and then append a non-overflowing
+        // chunk — flag should rearm.
+        {
+            let mut rx = src.shared.rx_buf.lock().unwrap();
+            rx.clear();
+            append_with_cap_to_shared(&src.shared, &mut rx, &[0u8; 100]);
+        }
+        assert!(
+            !src.shared.rx_in_overflow.load(Ordering::Relaxed),
+            "flag should rearm once buffer drains below half-cap"
         );
     }
 

--- a/crates/sdr-types/src/error.rs
+++ b/crates/sdr-types/src/error.rs
@@ -39,6 +39,12 @@ pub enum SourceError {
     ReadFailed(String),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    /// Wire-protocol-level failure from a network source — e.g. a stream
+    /// that was supposed to speak `rtl_tcp` but didn't return the expected
+    /// 12-byte `RTL0` header. Distinct from `Io` so UI can surface
+    /// "not an `rtl_tcp` server" rather than a generic socket error.
+    #[error("protocol error: {0}")]
+    Protocol(String),
 }
 
 /// Errors from sink modules.


### PR DESCRIPTION
## Summary

First PR in epic #299 — bundles the two independent children:

- **#300** — new `sdr-server-rtltcp` crate (library) + `sdr-rtl-tcp` binary. Faithful port of `original/librtlsdr/src/rtl_tcp.c`.
- **#301** — new `rtl_tcp` client module in `sdr-source-network`. Speaks the wire protocol end-to-end; compatible with GQRX / SDR++ / SoapySDR servers AND our own `sdr-server-rtltcp`.

**No C is linked.** Pure Rust translation using the existing `sdr-rtlsdr` port. `cargo tree -p sdr-server-rtltcp` shows only Rust deps (`libc`, `rusb`, `sdr-rtlsdr`, `thiserror`, `tracing`) — no librtlsdr / no rtl_tcp binary symbols.

## Wire protocol coverage

All 14 upstream commands (0x01–0x0e) supported. Gaps flagged:

- **0x06 set_tuner_if_gain** — our `sdr-rtlsdr` driver is missing this method; logged at debug and no-op'd in the dispatcher. Tracked in **#308**. R820T/R828D/FC* tuners are no-ops upstream too, so only E4000 owners lose behavior until #308 lands.

## Deviations from upstream (all marked in-source)

**Server (#300):**
- Upstream uses a pthread condvar + linked list to decouple USB reads from socket writes. We use `std::sync::mpsc::sync_channel` with identical drop-on-full semantics (`llbuf_num = 500`). No `unsafe`, same backpressure.
- `SO_KEEPALIVE` + `TCP_NODELAY` on the accepted socket (review addition).
- `EADDRINUSE` surfaced as `ServerError::PortInUse` — distinct variant so UI can offer fallback.
- Hot device unplug emits a shutdown signal instead of crashing (upstream exits).
- Default bind is `127.0.0.1` — matches upstream; re-affirmed per review as the safe default.

**Client (#301):**
- Exponential-backoff reconnect (1 → 2 → 5 → 10 → 30 s cap) with observable `ConnectionState` enum.
- Sticky-command replay after reconnect — stashes the latest value for each op in atomics, re-sends on handshake so server state matches what the UI thinks.
- Pair-aligned draining in `read_samples` — odd trailing bytes stay queued (bug caught by the new `partial_pair_at_end` test).
- Magic-mismatch → `SourceError::Protocol("not an rtl_tcp server: ...")` (new typed variant) rather than letting the first 12 bytes of junk get treated as samples.

**Intentionally NOT in this PR:**
- Command debouncing for rapid UI scrubs — that's a UI-layer concern and matches upstream GQRX/SDR++. Documented in rtl_tcp module docs.

## Testing

**~50 new tests added, 705 total workspace-wide, full suite runs in ~0.5 s of test-time (~7.5 s with compile).**

Protocol:
- Unknown opcode rejection at upper (0x0f..=0xff) and reserved (0x00) boundaries
- All 14 opcodes have distinct codes
- Param boundary values (u32::MAX, sign bit)
- dongle_info_t zero-magic rejection vs. zero-fields-with-valid-magic OK

Server:
- Port-in-use surfaced as typed error (no dongle needed — bind check runs first)
- Initial device state defaults match upstream `rtl_tcp.c:389-392`

CLI:
- `parse_hz` garbage / negative / overflow / fractional-suffix rejection
- `parse_args` missing-value / unknown-flag / bad-IP / invalid-port rejection
- All-flags-together integration

Client:
- Mock-server integration: happy-path handshake + tuning command roundtrip
- Partial `dongle_info_t` read across two socket writes
- EOF mid-stream transitions to Retrying state
- Bad magic → Failed state (non-recoverable)
- Commands set before connect are replayed after handshake
- Shutdown during retry is prompt (< 2 s)
- `read_samples` empty-output, no-data, odd-byte-trailer cases
- 8-bit offset I/Q conversion midscale and bounds

## Test plan

- [x] `make install CARGO_FLAGS=\"--release\"` — verify binary builds and links with existing flavors
- [x] `cargo run --bin sdr-rtl-tcp -- -p 1234` with a real RTL-SDR dongle plugged in — verify it starts and logs the tuner type
- [x] Connect GQRX to `127.0.0.1:1234` — verify audio/spectrum
- [x] Separately, wire the GTK client to use `RtlTcpSource` (PR #303 scope) — deferred to its own PR per epic plan
- [x] `cargo test --workspace` — 705 tests, all passing

## Linked issues

Part of epic **#299**.
Closes **#300**.
Closes **#301**.
Depends on sibling **#308** for complete 0x06 support (currently log-and-no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RTL‑TCP server (CLI, runtime stats, single‑client sessions, graceful shutdown) and RTL‑TCP client/source (background reconnect/backoff, handshake validation, aligned I/Q delivery, drop‑oldest buffering, sticky‑command replay). Public APIs expose server/client configuration, protocol types, and observability.

* **Error handling**
  * New protocol‑level source error variant and typed server errors for startup/runtime failures.

* **Tests**
  * Extensive unit tests for parsing, protocol, server lifecycle, client reconnects, buffering, and command replay.

* **Chores**
  * Workspace and crate dependencies updated to include the new server crate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->