### PR TITLE
feat(macos): spectrum UX follow-ups (#311 + #305 + #306 + #312)

### DIFF
--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -296,6 +296,7 @@ final class CoreModel {
         case .gainList(let gains):
             availableGains = gains
         case .displayBandwidth(let hz):
+            let oldBandwidth = displayBandwidthHz
             // Engine-reported raw (pre-decimation) sample rate
             // — the full FFT span, distinct from the post-
             // decimation `effectiveSampleRateHz` published by
@@ -306,6 +307,17 @@ final class CoreModel {
             // while `SampleRateChanged` only updates the status
             // bar.
             displayBandwidthHz = hz
+            // Keep zoom state consistent with the new full-span
+            // value. Without this, a tuner/source switch that
+            // shrinks the reported bandwidth leaves
+            // `displayedCenterOffsetHz` pointing outside the new
+            // range; `SpectrumRenderer.applyZoomWindow` then
+            // clamps both fractions to the same edge, collapsing
+            // the view to a sliver until the user manually
+            // resets zoom. Per #320 review.
+            if oldBandwidth != hz {
+                normalizeZoomState()
+            }
         case .error(let msg):
             lastError = msg
         @unknown default:
@@ -430,7 +442,12 @@ final class CoreModel {
     /// Matches the GTK behaviour in
     /// `crates/sdr-ui/src/spectrum/vfo_overlay.rs::zoom`.
     func zoomView(by factor: Double, around focalOffsetHz: Double) {
-        guard displayBandwidthHz > 0, factor > 0, factor.isFinite else { return }
+        // Reject non-finite inputs before they propagate into
+        // `displayedCenterOffsetHz` and later into grid math /
+        // renderer uniforms. Per #320 review.
+        guard displayBandwidthHz > 0,
+              factor > 0, factor.isFinite,
+              focalOffsetHz.isFinite else { return }
         let oldSpan = effectiveDisplayedSpanHz
         let rawSpan = oldSpan / factor
         let newSpan = max(Self.minDisplayedSpanHz, min(displayBandwidthHz, rawSpan))
@@ -460,6 +477,40 @@ final class CoreModel {
     func resetZoom() {
         displayedSpanHz = 0
         displayedCenterOffsetHz = 0
+    }
+
+    /// Clamp the stored zoom state into the current
+    /// `displayBandwidthHz` range. Called when the engine
+    /// reports a new full-span value so a shrinking bandwidth
+    /// doesn't leave the viewport pointing outside anything.
+    ///
+    /// Safe to call at any time — a no-op when span / center
+    /// are already inside bounds.
+    private func normalizeZoomState() {
+        guard displayBandwidthHz > 0 else {
+            // Can't normalize against a bogus bandwidth — punt
+            // until a sane value arrives.
+            return
+        }
+        // Span: 0 means "full span", no clamp needed.
+        // Anything >= displayBandwidthHz collapses back to full.
+        if displayedSpanHz > displayBandwidthHz {
+            displayedSpanHz = 0
+        }
+        // Center: keep the viewport inside the FFT range. Use
+        // the resolved effective span for the bounds so a
+        // fully-zoomed-out viewport (span == 0) collapses to
+        // center == 0 cleanly.
+        let effSpan = effectiveDisplayedSpanHz
+        let halfBw = displayBandwidthHz / 2
+        let halfSpan = effSpan / 2
+        let minCenter = -halfBw + halfSpan
+        let maxCenter = halfBw - halfSpan
+        if minCenter <= maxCenter {
+            displayedCenterOffsetHz = max(minCenter, min(maxCenter, displayedCenterOffsetHz))
+        } else {
+            displayedCenterOffsetHz = 0
+        }
     }
 
     func setDemodMode(_ m: DemodMode) {

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -98,6 +98,41 @@ final class CoreModel {
     /// `crates/sdr-ui/src/spectrum/mod.rs:244`): two rates,
     /// distinct semantics.
     var displayBandwidthHz: Double = 2_048_000
+
+    /// Scroll / pinch zoom state. When `displayedSpanHz == 0` OR
+    /// `>= displayBandwidthHz`, the viewport shows the full FFT
+    /// span (no zoom). A smaller value zooms in: only bins whose
+    /// frequency falls in
+    /// `[displayedCenterOffsetHz - displayedSpanHz/2,
+    ///   displayedCenterOffsetHz + displayedSpanHz/2]`
+    /// are shown, stretched across the view.
+    ///
+    /// `displayedCenterOffsetHz` is the center of the viewport,
+    /// measured as offset from the tuner center (same frame as
+    /// `vfoOffsetHz`). 0 = the tuner-center is the viewport
+    /// center; positive = viewport is shifted right.
+    ///
+    /// Matches the GTK `VfoState::display_start_hz` /
+    /// `display_end_hz` concept (see
+    /// `crates/sdr-ui/src/spectrum/vfo_overlay.rs::zoom`), but
+    /// stored as (center, span) which is friendlier for
+    /// cursor-centered zoom math.
+    var displayedSpanHz: Double = 0
+    var displayedCenterOffsetHz: Double = 0
+
+    /// Minimum displayed span in Hz. Matches GTK's
+    /// `MIN_DISPLAY_SPAN_HZ = 1000`.
+    static let minDisplayedSpanHz: Double = 1_000
+
+    /// Effective viewport span — resolves the "0 means full" rule
+    /// once, everywhere else reads this instead of
+    /// `displayedSpanHz` directly.
+    var effectiveDisplayedSpanHz: Double {
+        displayedSpanHz > 0 && displayedSpanHz < displayBandwidthHz
+            ? displayedSpanHz
+            : displayBandwidthHz
+    }
+
     var ppmCorrection: Int = 0
 
     // ==========================================================
@@ -381,6 +416,50 @@ final class CoreModel {
     func setVfoOffset(_ hz: Double) {
         vfoOffsetHz = hz
         capture { try core?.setVfoOffset(hz) }
+    }
+
+    /// Apply a cursor-centered zoom to the display viewport.
+    /// `factor > 1` zooms IN (narrower visible span); `factor < 1`
+    /// zooms OUT. `focalOffsetHz` is the frequency under the
+    /// cursor (or pinch centroid), measured as an offset from
+    /// the tuner center — it stays at the same relative viewport
+    /// position through the zoom so the thing you're looking at
+    /// doesn't drift out of view.
+    ///
+    /// Display-only state — does not send anything to the engine.
+    /// Matches the GTK behaviour in
+    /// `crates/sdr-ui/src/spectrum/vfo_overlay.rs::zoom`.
+    func zoomView(by factor: Double, around focalOffsetHz: Double) {
+        guard displayBandwidthHz > 0, factor > 0, factor.isFinite else { return }
+        let oldSpan = effectiveDisplayedSpanHz
+        let rawSpan = oldSpan / factor
+        let newSpan = max(Self.minDisplayedSpanHz, min(displayBandwidthHz, rawSpan))
+
+        // Cursor-centered rescale: keep focalOffsetHz at the
+        // same relative fraction of the viewport before and
+        // after.
+        let oldLeft = displayedCenterOffsetHz - oldSpan / 2
+        let frac = oldSpan > 0 ? (focalOffsetHz - oldLeft) / oldSpan : 0.5
+        var newCenter = focalOffsetHz - (frac - 0.5) * newSpan
+
+        // Keep viewport inside the full FFT range.
+        let halfBw = displayBandwidthHz / 2
+        let minCenter = -halfBw + newSpan / 2
+        let maxCenter = halfBw - newSpan / 2
+        if minCenter <= maxCenter {
+            newCenter = max(minCenter, min(maxCenter, newCenter))
+        } else {
+            newCenter = 0
+        }
+
+        displayedSpanHz = newSpan
+        displayedCenterOffsetHz = newCenter
+    }
+
+    /// Reset the viewport to show the full FFT span.
+    func resetZoom() {
+        displayedSpanHz = 0
+        displayedCenterOffsetHz = 0
     }
 
     func setDemodMode(_ m: DemodMode) {

--- a/apps/macos/SDRMac/Renderer/MetalSpectrumNSView.swift
+++ b/apps/macos/SDRMac/Renderer/MetalSpectrumNSView.swift
@@ -266,4 +266,20 @@ final class MetalSpectrumNSView: NSView, CAMetalDisplayLinkDelegate {
     func applyBindings(minDb: Float, maxDb: Float) {
         renderer.applyBindings(minDb: minDb, maxDb: maxDb)
     }
+
+    /// Forward the current zoom window to the renderer so the
+    /// Metal shader remaps bin-index / viewport-uv accordingly.
+    /// Called from `updateNSView` whenever CoreModel's zoom
+    /// state changes.
+    func applyZoom(
+        displayedCenterOffsetHz: Double,
+        displayedSpanHz: Double,
+        displayBandwidthHz: Double
+    ) {
+        renderer.applyZoomWindow(
+            displayedCenterOffsetHz: displayedCenterOffsetHz,
+            displayedSpanHz: displayedSpanHz,
+            displayBandwidthHz: displayBandwidthHz
+        )
+    }
 }

--- a/apps/macos/SDRMac/Renderer/Shaders.metal
+++ b/apps/macos/SDRMac/Renderer/Shaders.metal
@@ -18,12 +18,21 @@ using namespace metal;
 // descending so Swift's default struct alignment matches MSL's
 // — no explicit `alignas` needed on either side for this size.
 struct Uniforms {
-    float min_db;         // bottom of visible dB range
-    float max_db;         // top of visible dB range
-    uint  bin_count;      // current FFT bin count
-    uint  history_rows;   // waterfall texture height (sub-PR 2)
-    uint  write_row;      // waterfall ring cursor (sub-PR 2)
-    uint  _pad0;          // keep 8-byte multiple for Swift interop
+    float min_db;             // bottom of visible dB range
+    float max_db;             // top of visible dB range
+    uint  bin_count;          // current FFT bin count
+    uint  history_rows;       // waterfall texture height
+    uint  write_row;          // waterfall ring cursor
+    // Zoom window expressed as fractions of the full FFT span.
+    // 0.0 = left edge of FFT, 1.0 = right edge. With no zoom
+    // these are (0, 1); zooming in shifts them inward. Spectrum
+    // bins whose fraction falls outside [left, right] map to
+    // clip-space x outside [-1, 1] and get clipped. Waterfall
+    // uv.x is remapped from viewport space to bin-index space
+    // via the same pair.
+    float display_left_frac;
+    float display_right_frac;
+    uint  _pad0;              // keep 8-byte multiple for Swift interop
 };
 
 // --------------------------------------------------------------
@@ -54,7 +63,15 @@ vertex SpectrumVertexOut spectrum_vert(
     // practice, but returning off-screen is safer than dividing
     // by zero.
     float denom = max(1.0, float(u.bin_count - 1));
-    float x = 2.0 * (float(vid) / denom) - 1.0;
+    float bin_frac = float(vid) / denom;
+
+    // Zoom: remap bin_frac [0,1] (full FFT) to viewport-x [-1,1]
+    // using the display window [left, right]. Without zoom the
+    // window is (0, 1) and this collapses to the old
+    // `2 * bin_frac - 1`. Bins outside the window get x outside
+    // [-1, 1] and are clipped by the viewport.
+    float span = max(0.0001, u.display_right_frac - u.display_left_frac);
+    float x = 2.0 * (bin_frac - u.display_left_frac) / span - 1.0;
 
     float db = mags_db[vid];
     float t  = saturate((db - u.min_db) / max(0.001, u.max_db - u.min_db));
@@ -100,7 +117,11 @@ vertex SpectrumVertexOut spectrum_fill_vert(
     bool  is_top = (vid & 1u) == 0u;
 
     float denom = max(1.0, float(u.bin_count - 1));
-    float x = 2.0 * (float(bin) / denom) - 1.0;
+    float bin_frac = float(bin) / denom;
+
+    // Same zoom-window remapping as `spectrum_vert`.
+    float span = max(0.0001, u.display_right_frac - u.display_left_frac);
+    float x = 2.0 * (bin_frac - u.display_left_frac) / span - 1.0;
 
     float db = mags_db[bin];
     float t  = saturate((db - u.min_db) / max(0.001, u.max_db - u.min_db));
@@ -194,7 +215,16 @@ fragment float4 waterfall_frag(
     float newest_row  = float(u.write_row);
     float sample_y    = fract((newest_row + hist_rows_f - age_rows) / hist_rows_f);
 
-    float db  = history.sample(hist_s, float2(in.uv.x, sample_y)).r;
+    // Zoom: uv.x is viewport space (0..1 across the visible
+    // portion of the spectrum). Remap into bin-index space
+    // (0..1 across the full FFT) before sampling the history
+    // texture, so a zoomed view stretches the appropriate bin
+    // range across the waterfall viewport. No zoom → this is an
+    // identity remap.
+    float span = max(0.0001, u.display_right_frac - u.display_left_frac);
+    float hist_uv_x = u.display_left_frac + in.uv.x * span;
+
+    float db  = history.sample(hist_s, float2(hist_uv_x, sample_y)).r;
     float t   = saturate((db - u.min_db) / max(0.001, u.max_db - u.min_db));
     return palette.sample(pal_s, float2(t, 0.5));
 }

--- a/apps/macos/SDRMac/Renderer/SpectrumRenderer.swift
+++ b/apps/macos/SDRMac/Renderer/SpectrumRenderer.swift
@@ -549,7 +549,12 @@ final class SpectrumRenderer {
             mipmapped: false
         )
         desc.storageMode = .private
-        desc.usage = [.shaderRead]
+        // `.renderTarget` in addition to `.shaderRead` so we can
+        // one-shot clear the texture to the floor value via a
+        // render-pass `loadAction = .clear`. The render path
+        // writes every texel in a single encoder — no per-row
+        // blit loop, no staging buffer. See `fillHistoryToFloor`.
+        desc.usage = [.shaderRead, .renderTarget]
         guard let tex = device.makeTexture(descriptor: desc) else {
             return nil
         }
@@ -569,43 +574,34 @@ final class SpectrumRenderer {
         return tex
     }
 
-    /// One-shot blit-fill of the whole history texture to the
-    /// floor dB value. Called at texture creation; not part of
-    /// the per-frame hot path.
+    /// One-shot clear of the whole history texture to the floor
+    /// dB value. Issues a single render pass with `loadAction =
+    /// .clear` — Metal writes every texel via the GPU's fast
+    /// clear hardware path, no extra encoder / staging buffer /
+    /// blit-loop required. Called at texture creation; not part
+    /// of the per-frame hot path.
+    ///
+    /// Uses `MTLClearColor.red` as the r32Float write value —
+    /// for a single-channel r32Float target, only `.red` is
+    /// consumed. The other components are ignored by the
+    /// hardware but must be present in the struct.
     private func fillHistoryToFloor(_ texture: MTLTexture) {
-        let width = texture.width
-        let rowFloats = width
-        let rowBytes = rowFloats * MemoryLayout<Float>.stride
-        guard let clearBuf = device.makeBuffer(
-            length: rowBytes,
-            options: .storageModeShared
-        ) else {
-            return
-        }
-        let ptr = clearBuf.contents().bindMemory(to: Float.self, capacity: rowFloats)
-        for i in 0..<rowFloats {
-            ptr[i] = Self.floorDb
-        }
+        let passDesc = MTLRenderPassDescriptor()
+        passDesc.colorAttachments[0].texture = texture
+        passDesc.colorAttachments[0].loadAction = .clear
+        passDesc.colorAttachments[0].storeAction = .store
+        passDesc.colorAttachments[0].clearColor = MTLClearColor(
+            red: Double(Self.floorDb),
+            green: 0, blue: 0, alpha: 0
+        )
 
         guard let cmd = commandQueue.makeCommandBuffer(),
-              let blit = cmd.makeBlitCommandEncoder() else {
+              let enc = cmd.makeRenderCommandEncoder(descriptor: passDesc) else {
             return
         }
-        blit.label = "history_floor_init"
-        for row in 0..<texture.height {
-            blit.copy(
-                from: clearBuf,
-                sourceOffset: 0,
-                sourceBytesPerRow: rowBytes,
-                sourceBytesPerImage: rowBytes,
-                sourceSize: MTLSizeMake(width, 1, 1),
-                to: texture,
-                destinationSlice: 0,
-                destinationLevel: 0,
-                destinationOrigin: MTLOriginMake(0, row, 0)
-            )
-        }
-        blit.endEncoding()
+        enc.label = "history_floor_init"
+        // Zero draw calls — the clear happens at loadAction time.
+        enc.endEncoding()
         cmd.commit()
         // Don't wait — the next render-pass command buffer will
         // naturally order after this via Metal's scheduling

--- a/apps/macos/SDRMac/Renderer/SpectrumRenderer.swift
+++ b/apps/macos/SDRMac/Renderer/SpectrumRenderer.swift
@@ -57,6 +57,13 @@ struct RendererUniforms {
     var binCount: UInt32 = 2048
     var historyRows: UInt32 = 1024
     var writeRow: UInt32 = 0
+    // Display zoom window as fractions of the full FFT span.
+    // `(0, 1)` = no zoom; narrower pair = zoomed in. The shader
+    // uses these to remap bin-index → clip-space (spectrum) and
+    // viewport-uv → texture-uv (waterfall). Drives #306's
+    // scroll / pinch zoom.
+    var displayLeftFrac: Float = 0
+    var displayRightFrac: Float = 1
     var _pad0: UInt32 = 0
 }
 
@@ -296,6 +303,33 @@ final class SpectrumRenderer {
     func applyBindings(minDb: Float, maxDb: Float) {
         if minDb.isFinite { uniforms.minDb = minDb }
         if maxDb.isFinite { uniforms.maxDb = max(minDb + 1.0, maxDb) }
+    }
+
+    /// Update the zoom window. `displayedCenterOffsetHz` is the
+    /// viewport center in offset-from-tuner Hz; `displayedSpanHz`
+    /// is the visible span; `displayBandwidthHz` is the full FFT
+    /// span. Converts to the `(left_frac, right_frac)` pair the
+    /// shader consumes.
+    func applyZoomWindow(
+        displayedCenterOffsetHz: Double,
+        displayedSpanHz: Double,
+        displayBandwidthHz: Double
+    ) {
+        guard displayBandwidthHz > 0 else {
+            uniforms.displayLeftFrac = 0
+            uniforms.displayRightFrac = 1
+            return
+        }
+        // FFT range is centered at 0 offset, spans ±bw/2.
+        let halfBw = displayBandwidthHz / 2
+        let halfSpan = displayedSpanHz / 2
+        let leftHz = displayedCenterOffsetHz - halfSpan
+        let rightHz = displayedCenterOffsetHz + halfSpan
+        // Convert to fraction of full FFT range.
+        let leftFrac = (leftHz + halfBw) / displayBandwidthHz
+        let rightFrac = (rightHz + halfBw) / displayBandwidthHz
+        uniforms.displayLeftFrac = Float(max(0, min(1, leftFrac)))
+        uniforms.displayRightFrac = Float(max(0, min(1, rightFrac)))
     }
 
     // ----------------------------------------------------------

--- a/apps/macos/SDRMac/Renderer/SpectrumWaterfallView.swift
+++ b/apps/macos/SDRMac/Renderer/SpectrumWaterfallView.swift
@@ -45,7 +45,19 @@ struct SpectrumWaterfallView: NSViewRepresentable {
     }
 
     func updateNSView(_ view: NSView, context: Context) {
-        (view as? MetalSpectrumNSView)?.applyBindings(minDb: minDb, maxDb: maxDb)
+        guard let mtk = view as? MetalSpectrumNSView else { return }
+        mtk.applyBindings(minDb: minDb, maxDb: maxDb)
+        // Push the zoom window every update. Reads of
+        // `@Observable` CoreModel properties during
+        // `updateNSView` re-trigger this method when they
+        // change, so a scroll/pinch → `model.zoomView(...)` →
+        // model property change → updateNSView → renderer sees
+        // the new window next frame.
+        mtk.applyZoom(
+            displayedCenterOffsetHz: model.displayedCenterOffsetHz,
+            displayedSpanHz: model.effectiveDisplayedSpanHz,
+            displayBandwidthHz: model.displayBandwidthHz
+        )
     }
 
     private func makeFallbackView() -> NSView {

--- a/apps/macos/SDRMac/Views/CenterView.swift
+++ b/apps/macos/SDRMac/Views/CenterView.swift
@@ -8,11 +8,29 @@
 // maps the dB range to the visible vertical axis. The renderer
 // also pulls FFT frames directly from `model.core` on each
 // display-link tick.
+//
+// Two zoom gestures are layered on top:
+// - **Scroll wheel** (mouse wheel or two-finger trackpad
+//   scroll). `NSEvent.addLocalMonitorForEvents` hooks all
+//   scroll events in the window and we filter by view bounds.
+//   Cursor-centered zoom — the frequency under the cursor stays
+//   under the cursor through the zoom.
+// - **Pinch** (trackpad magnify / iPad pinch). SwiftUI
+//   `MagnifyGesture` is cross-platform, so this carries over to
+//   iPad for free. View-center-centered zoom.
+//
+// Both drive `CoreModel.zoomView(by:around:)`.
 
+import AppKit
 import SwiftUI
 
 struct CenterView: View {
     @Environment(CoreModel.self) private var model
+
+    /// Snapshot of `displayedSpanHz` at pinch start so
+    /// `MagnifyGesture.value.magnification` (a cumulative
+    /// multiplier) can be converted into an absolute span.
+    @State private var pinchStartSpanHz: Double = 0
 
     var body: some View {
         @Bindable var m = model
@@ -33,5 +51,147 @@ struct CenterView: View {
             VfoOverlayView(model: model)
         }
         .frame(minHeight: 300)
+        // Pinch zoom — cross-platform via SwiftUI's gesture.
+        // MagnifyGesture.value.magnification is a cumulative
+        // multiplier from 1.0 at gesture start, so we snapshot
+        // the span at start and apply the ratio each tick.
+        .gesture(
+            MagnifyGesture()
+                .onChanged { value in
+                    if pinchStartSpanHz == 0 {
+                        pinchStartSpanHz = model.effectiveDisplayedSpanHz
+                    }
+                    let factor = max(0.01, min(100, value.magnification))
+                    let oldSpan = model.effectiveDisplayedSpanHz
+                    let targetSpan = pinchStartSpanHz / factor
+                    // Convert the target span into a zoom factor
+                    // relative to CURRENT span so `zoomView` can
+                    // clamp + cursor-center around the viewport
+                    // middle. Pinch doesn't expose a focal point
+                    // on macOS, so we center on the viewport.
+                    let zoomFactor = oldSpan / targetSpan
+                    model.zoomView(
+                        by: zoomFactor,
+                        around: model.displayedCenterOffsetHz
+                    )
+                }
+                .onEnded { _ in
+                    pinchStartSpanHz = 0
+                }
+        )
+        // Scroll-wheel zoom. Catches scroll events in the
+        // window's event stream and filters by view bounds so
+        // clicks, drags, etc. still work on the VFO overlay
+        // underneath.
+        .overlay(
+            ScrollWheelZoomCatcher { deltaY, fracX in
+                // GTK uses ZOOM_FACTOR = 1.2 per notch (see
+                // `vfo_overlay.rs:40`). Positive deltaY (scroll
+                // up / away from user) zooms in; negative zooms
+                // out. On trackpads, deltaY arrives as small
+                // fractional values — scale so gentle swipes
+                // still zoom noticeably.
+                let step = 1.0 + 0.2 * min(1.0, abs(Double(deltaY)))
+                let factor = deltaY > 0 ? step : 1.0 / step
+                // Cursor-centered: compute the Hz under the
+                // cursor and zoom around that.
+                let span = model.effectiveDisplayedSpanHz
+                let focalOffsetHz =
+                    model.displayedCenterOffsetHz + (Double(fracX) - 0.5) * span
+                model.zoomView(by: factor, around: focalOffsetHz)
+            }
+            .allowsHitTesting(false)
+        )
+        // Double-click resets zoom (common convention — matches
+        // what most trackpad-first macOS apps do for "fit view").
+        .onTapGesture(count: 2) {
+            model.resetZoom()
+        }
+    }
+}
+
+// ============================================================
+//  ScrollWheelZoomCatcher
+// ============================================================
+//
+//  SwiftUI doesn't expose scroll-wheel events on arbitrary
+//  views (only inside `ScrollView`). Register a local event
+//  monitor with AppKit and filter by view bounds.
+//
+//  Using `.overlay(...).allowsHitTesting(false)` so clicks
+//  still land on the VFO layer below — the monitor taps into
+//  the event stream at the window level, not via hit-testing.
+
+private struct ScrollWheelZoomCatcher: NSViewRepresentable {
+    /// Called on each scroll event over this view's bounds.
+    /// `deltaY` is `event.scrollingDeltaY` (positive = scroll
+    /// up, zoom in). `fracX` is 0…1 cursor position across
+    /// the view's width.
+    let onScroll: (CGFloat, CGFloat) -> Void
+
+    func makeNSView(context: Context) -> MonitorView {
+        MonitorView(onScroll: onScroll)
+    }
+
+    func updateNSView(_ nsView: MonitorView, context: Context) {
+        nsView.onScroll = onScroll
+    }
+
+    final class MonitorView: NSView {
+        var onScroll: (CGFloat, CGFloat) -> Void
+        private var monitor: Any?
+
+        init(onScroll: @escaping (CGFloat, CGFloat) -> Void) {
+            self.onScroll = onScroll
+            super.init(frame: .zero)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("ScrollWheelZoomCatcher.MonitorView does not support NSCoder init")
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if window != nil {
+                startMonitor()
+            } else {
+                stopMonitor()
+            }
+        }
+
+        deinit {
+            stopMonitor()
+        }
+
+        private func startMonitor() {
+            guard monitor == nil else { return }
+            // Local monitor: fires for events in OUR process's
+            // event queue. Return `nil` from the block to consume
+            // (so the scroll doesn't also scroll any ancestor
+            // ScrollView); return the event to pass it on.
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                guard let self, let window = self.window else { return event }
+                // Only our window, only when cursor is over this
+                // view. Don't consume scrolls over the sidebar
+                // or header.
+                guard event.window === window else { return event }
+                let locInView = self.convert(event.locationInWindow, from: nil)
+                guard self.bounds.contains(locInView) else { return event }
+
+                let fracX = self.bounds.width > 0
+                    ? locInView.x / self.bounds.width
+                    : 0.5
+                self.onScroll(event.scrollingDeltaY, fracX)
+                return nil
+            }
+        }
+
+        private func stopMonitor() {
+            if let m = monitor {
+                NSEvent.removeMonitor(m)
+                monitor = nil
+            }
+        }
     }
 }

--- a/apps/macos/SDRMac/Views/CenterView.swift
+++ b/apps/macos/SDRMac/Views/CenterView.swift
@@ -179,6 +179,16 @@ private struct ScrollWheelZoomCatcher: NSViewRepresentable {
                 let locInView = self.convert(event.locationInWindow, from: nil)
                 guard self.bounds.contains(locInView) else { return event }
 
+                // Skip trackpad momentum tails. A flick-scroll
+                // delivers dozens of momentum events after the
+                // fingers leave the pad; zooming on each one
+                // rockets past the user's intent. Keep only
+                // discrete wheel clicks and active-touch scrolls
+                // — `.momentumPhase == []` covers both.
+                if !event.momentumPhase.isEmpty {
+                    return event
+                }
+
                 let fracX = self.bounds.width > 0
                     ? locInView.x / self.bounds.width
                     : 0.5

--- a/apps/macos/SDRMac/Views/FrequencyAxis.swift
+++ b/apps/macos/SDRMac/Views/FrequencyAxis.swift
@@ -1,0 +1,82 @@
+//
+// FrequencyAxis.swift — pure frequency-label / grid-step helpers
+// for the spectrum grid overlay. Broken out from SpectrumGridView
+// so it can be unit-tested against a snapshot of Linux's
+// `crates/sdr-ui/src/spectrum/frequency_axis.rs` output — see
+// `SDRMacTests/FrequencyAxisTests.swift` for the parity fixture.
+//
+// These are byte-for-byte ports of the Linux implementations:
+//   - `STEP_CANDIDATES` ↔ `stepCandidates`
+//   - `format_frequency` ↔ `formatFrequency`
+//   - `compute_grid_lines` ↔ `computeGridLines`
+//
+// If the Linux side changes, the test fixture fails on the next
+// build and whoever updates Linux also updates the Mac snapshot.
+// That's the "drift check" — not automated cross-platform sync,
+// but a loud tripwire.
+
+import Foundation
+
+enum FrequencyAxis {
+    /// Candidate step sizes in Hz, smallest to largest.
+    /// Verbatim copy of `STEP_CANDIDATES` from
+    /// `crates/sdr-ui/src/spectrum/frequency_axis.rs:48-77`.
+    static let stepCandidates: [Double] = [
+        1, 2, 5,
+        10, 20, 50,
+        100, 200, 500,
+        1_000, 2_000, 5_000,
+        10_000, 20_000, 50_000,
+        100_000, 200_000, 500_000,
+        1_000_000, 2_000_000, 5_000_000,
+        10_000_000, 20_000_000, 50_000_000,
+        100_000_000, 200_000_000, 500_000_000,
+        1_000_000_000,
+    ]
+
+    /// Human-readable Hz → string. Port of `format_frequency` in
+    /// `crates/sdr-ui/src/spectrum/frequency_axis.rs:31-44`.
+    /// Same thresholds, same precision per unit.
+    static func formatFrequency(_ hz: Double) -> String {
+        let abs = Swift.abs(hz)
+        let sign = hz < 0 ? "-" : ""
+        switch abs {
+        case 1_000_000_000...:
+            return String(format: "%@%.3f GHz", sign, abs / 1_000_000_000)
+        case 1_000_000...:
+            return String(format: "%@%.3f MHz", sign, abs / 1_000_000)
+        case 1_000...:
+            return String(format: "%@%.1f kHz", sign, abs / 1_000)
+        default:
+            return String(format: "%@%.1f Hz", sign, abs)
+        }
+    }
+
+    /// Compute grid-line positions + labels for a frequency axis.
+    /// Port of `compute_grid_lines` from
+    /// `crates/sdr-ui/src/spectrum/frequency_axis.rs:90-117`.
+    /// `startHz` / `endHz` are absolute frequencies. Returns
+    /// `[(freqHz, label)]` spaced at a round step that yields at
+    /// most `maxLines` entries.
+    static func computeGridLines(
+        startHz: Double,
+        endHz: Double,
+        maxLines: Int
+    ) -> [(Double, String)] {
+        guard maxLines > 0, endHz > startHz else { return [] }
+        let span = endHz - startHz
+        // Find smallest step that yields strictly fewer than
+        // `maxLines` entries. Strict `<` matches Linux; the line
+        // count is `floor(span/step) + 1` worst-case.
+        let step = stepCandidates.first(where: { (span / $0) < Double(maxLines) })
+            ?? span * 2
+        let first = (startHz / step).rounded(.up) * step
+        var lines: [(Double, String)] = []
+        var freq = first
+        while freq <= endHz {
+            lines.append((freq, formatFrequency(freq)))
+            freq += step
+        }
+        return lines
+    }
+}

--- a/apps/macos/SDRMac/Views/FrequencyAxis.swift
+++ b/apps/macos/SDRMac/Views/FrequencyAxis.swift
@@ -68,14 +68,34 @@ enum FrequencyAxis {
         // Find smallest step that yields strictly fewer than
         // `maxLines` entries. Strict `<` matches Linux; the line
         // count is `floor(span/step) + 1` worst-case.
+        //
+        // Fallback `span * 2`: if no candidate fits (very
+        // narrow span with high `maxLines`, or `maxLines == 1`),
+        // the step exceeds the span so `first` lands past
+        // `endHz` and the loop emits zero lines. That's
+        // deliberate — better to show no grid than a crowded
+        // one on pathological inputs.
         let step = stepCandidates.first(where: { (span / $0) < Double(maxLines) })
             ?? span * 2
         let first = (startHz / step).rounded(.up) * step
+
+        // Index-based iteration avoids floating-point drift
+        // accumulating across many `freq += step` additions.
+        // Matters at high line counts + sub-Hz precision; for
+        // the ≤20 lines we typically ask for it's overkill but
+        // the same cost. Per #320 review.
+        let remaining = endHz - first
+        guard remaining >= 0, step > 0 else { return [] }
+        let count = Int(floor(remaining / step)) + 1
         var lines: [(Double, String)] = []
-        var freq = first
-        while freq <= endHz {
+        lines.reserveCapacity(count)
+        for i in 0..<count {
+            let freq = first + Double(i) * step
+            // Defensive `<= endHz` guard — floor + step math is
+            // exact for power-of-ten steps but protect against
+            // any weird edge case.
+            if freq > endHz { break }
             lines.append((freq, formatFrequency(freq)))
-            freq += step
         }
         return lines
     }

--- a/apps/macos/SDRMac/Views/SpectrumGridView.swift
+++ b/apps/macos/SDRMac/Views/SpectrumGridView.swift
@@ -153,66 +153,22 @@ struct SpectrumGridView: View {
     }
 
     // ----------------------------------------------------------
-    //  Frequency grid computation (port of Linux frequency_axis)
+    //  Frequency grid computation
     // ----------------------------------------------------------
+    //
+    //  Delegates to `FrequencyAxis` so the pure math is testable
+    //  without a live view (see
+    //  `SDRMacTests/FrequencyAxisTests.swift`).
 
-    /// Candidate step sizes in Hz, smallest to largest. Copied
-    /// verbatim from `frequency_axis.rs::STEP_CANDIDATES`.
-    private static let stepCandidates: [Double] = [
-        1, 2, 5,
-        10, 20, 50,
-        100, 200, 500,
-        1_000, 2_000, 5_000,
-        10_000, 20_000, 50_000,
-        100_000, 200_000, 500_000,
-        1_000_000, 2_000_000, 5_000_000,
-        10_000_000, 20_000_000, 50_000_000,
-        100_000_000, 200_000_000, 500_000_000,
-        1_000_000_000,
-    ]
-
-    /// Return `[(absoluteHz, label)]` pairs spaced at round
-    /// intervals across the visible span. Centered on the
-    /// tuner frequency.
     private func frequencyGridLines(span: Double, center: Double)
         -> [(Double, String)]
     {
         guard span > 0 else { return [] }
         let halfSpan = span / 2
-        let startHz = center - halfSpan
-        let endHz = center + halfSpan
-        let maxLines = Self.freqGridMaxLines
-
-        // Find smallest step that yields strictly fewer than
-        // `maxLines` lines. Same algorithm as Linux.
-        let step = Self.stepCandidates.first(where: { (span / $0) < Double(maxLines) })
-            ?? span * 2
-
-        let first = (startHz / step).rounded(.up) * step
-        var lines: [(Double, String)] = []
-        var freq = first
-        while freq <= endHz {
-            lines.append((freq, Self.formatFrequency(freq)))
-            freq += step
-        }
-        return lines
-    }
-
-    /// Human-readable Hz formatter. Port of
-    /// `frequency_axis::format_frequency` — same thresholds,
-    /// same precision per unit.
-    static func formatFrequency(_ hz: Double) -> String {
-        let abs = Swift.abs(hz)
-        let sign = hz < 0 ? "-" : ""
-        switch abs {
-        case 1_000_000_000...:
-            return String(format: "%@%.3f GHz", sign, abs / 1_000_000_000)
-        case 1_000_000...:
-            return String(format: "%@%.3f MHz", sign, abs / 1_000_000)
-        case 1_000...:
-            return String(format: "%@%.1f kHz", sign, abs / 1_000)
-        default:
-            return String(format: "%@%.1f Hz", sign, abs)
-        }
+        return FrequencyAxis.computeGridLines(
+            startHz: center - halfSpan,
+            endHz: center + halfSpan,
+            maxLines: Self.freqGridMaxLines
+        )
     }
 }

--- a/apps/macos/SDRMac/Views/SpectrumGridView.swift
+++ b/apps/macos/SDRMac/Views/SpectrumGridView.swift
@@ -43,15 +43,20 @@ struct SpectrumGridView: View {
 
     var body: some View {
         Canvas { context, size in
+            // Use the DISPLAYED span + center so the grid zooms
+            // with the waterfall. Unzoomed, these collapse to
+            // the full FFT span centered on the tuner, same
+            // behaviour as before.
+            let span = model.effectiveDisplayedSpanHz
+            let center = model.centerFrequencyHz + model.displayedCenterOffsetHz
             // Compute frequency grid lines once per draw and share
             // them between the grid-line and label passes — the
             // positions are identical and the step-size lookup
             // isn't free. Canvas redraws are cheap, but there's no
             // reason to do the same work twice.
-            let freqLines = frequencyGridLines(span: model.displayBandwidthHz,
-                                               center: model.centerFrequencyHz)
-            drawGrid(context: context, size: size, freqLines: freqLines)
-            drawLabels(context: context, size: size, freqLines: freqLines)
+            let freqLines = frequencyGridLines(span: span, center: center)
+            drawGrid(context: context, size: size, freqLines: freqLines, span: span, center: center)
+            drawLabels(context: context, size: size, freqLines: freqLines, span: span, center: center)
         }
         .allowsHitTesting(false)
     }
@@ -60,7 +65,13 @@ struct SpectrumGridView: View {
     //  Grid lines (drawn under labels)
     // ----------------------------------------------------------
 
-    private func drawGrid(context: GraphicsContext, size: CGSize, freqLines: [(Double, String)]) {
+    private func drawGrid(
+        context: GraphicsContext,
+        size: CGSize,
+        freqLines: [(Double, String)],
+        span: Double,
+        center: Double
+    ) {
         let w = size.width
         let h = size.height
         let spectrumH = (h * Self.spectrumFraction).rounded()
@@ -77,12 +88,11 @@ struct SpectrumGridView: View {
         context.stroke(dbPath, with: .color(Self.gridColor), lineWidth: 1)
 
         // --- Vertical frequency grid (spans full height)
-        guard !freqLines.isEmpty, model.displayBandwidthHz > 0 else { return }
+        guard !freqLines.isEmpty, span > 0 else { return }
         var freqPath = Path()
-        let halfSpan = model.displayBandwidthHz / 2
-        let leftHz = model.centerFrequencyHz - halfSpan
+        let leftHz = center - span / 2
         for (freq, _) in freqLines {
-            let frac = (freq - leftHz) / model.displayBandwidthHz
+            let frac = (freq - leftHz) / span
             let x = (w * CGFloat(frac)).rounded() + 0.5
             freqPath.move(to: CGPoint(x: x, y: 0))
             freqPath.addLine(to: CGPoint(x: x, y: h))
@@ -94,17 +104,22 @@ struct SpectrumGridView: View {
     //  Labels (drawn on top of grid)
     // ----------------------------------------------------------
 
-    private func drawLabels(context: GraphicsContext, size: CGSize, freqLines: [(Double, String)]) {
+    private func drawLabels(
+        context: GraphicsContext,
+        size: CGSize,
+        freqLines: [(Double, String)],
+        span: Double,
+        center: Double
+    ) {
         let w = size.width
         let h = size.height
         let spectrumH = (h * Self.spectrumFraction).rounded()
 
         // --- Frequency labels at top of spectrum
-        if model.displayBandwidthHz > 0 {
-            let halfSpan = model.displayBandwidthHz / 2
-            let leftHz = model.centerFrequencyHz - halfSpan
+        if span > 0 {
+            let leftHz = center - span / 2
             for (freq, label) in freqLines {
-                let frac = (freq - leftHz) / model.displayBandwidthHz
+                let frac = (freq - leftHz) / span
                 let x = w * CGFloat(frac)
                 let text = Text(label)
                     .font(.system(size: Self.labelFontSize, design: .monospaced))

--- a/apps/macos/SDRMac/Views/VfoOverlayView.swift
+++ b/apps/macos/SDRMac/Views/VfoOverlayView.swift
@@ -81,23 +81,22 @@ struct VfoOverlayView: View {
         GeometryReader { geo in
             let width = geo.size.width
             let height = geo.size.height
-            // Full frequency span painted by the Metal renderer.
-            // The FFT is computed on the RAW (pre-decimation)
-            // IQ stream so the spectrum shows the full tuner
-            // bandwidth — same convention as the GTK UI (see
-            // `crates/sdr-ui/src/spectrum/mod.rs:244` and
-            // `crates/sdr-pipeline/src/iq_frontend.rs:156`).
-            // Updated from `DisplayBandwidth` events, not
-            // `SampleRateChanged` (which carries the post-
-            // decimation passband).
-            let span = model.displayBandwidthHz
+            // Use the displayed-viewport span (not the full FFT
+            // span) — so the overlay zooms with the waterfall.
+            // When there's no zoom this equals
+            // `displayBandwidthHz` and the math collapses to the
+            // unzoomed case.
+            let span = model.effectiveDisplayedSpanHz
+            // Viewport center in offset-from-tuner-center Hz. 0
+            // when unzoomed.
+            let viewCenter = model.displayedCenterOffsetHz
 
             // Pixel positions derived from current state. We
             // fall through to zero-width when span is 0 so the
             // overlay degrades to invisible rather than dividing
             // by zero.
             let centerPx = span > 0
-                ? (model.vfoOffsetHz / span + 0.5) * width
+                ? ((model.vfoOffsetHz - viewCenter) / span + 0.5) * width
                 : width / 2
             let bwPixels = span > 0
                 ? model.bandwidthHz / span * width
@@ -238,10 +237,15 @@ struct VfoOverlayView: View {
     /// DC where the demod can lock onto it.
     private func retuneAt(x: CGFloat, width: CGFloat, span: Double) {
         let frac = max(0, min(1, x / width))
-        // Absolute Hz = tuner center + (offset from center on the
-        // visible axis). `span` is `displayBandwidthHz`, the full
-        // FFT span.
-        let absoluteHz = model.centerFrequencyHz + (Double(frac) - 0.5) * span
+        // Absolute Hz = tuner center + viewport-center offset +
+        // position-within-viewport. `span` is the DISPLAYED
+        // span (may be narrower than the full FFT when zoomed);
+        // `viewCenter` is the zoom viewport's center offset (0
+        // when unzoomed). Unzoomed, this collapses to the old
+        // `center + (frac - 0.5) * fullSpan` formula.
+        let viewCenter = model.displayedCenterOffsetHz
+        let absoluteHz =
+            model.centerFrequencyHz + viewCenter + (Double(frac) - 0.5) * span
         guard absoluteHz > 0 else { return }
         model.setCenter(absoluteHz)
         if model.vfoOffsetHz != 0 {
@@ -259,9 +263,12 @@ struct VfoOverlayView: View {
     /// so the user can't produce negative / nonsensical sizes.
     private func resize(edge: ResizeEdge, currentX: CGFloat, width: CGFloat, span: Double) {
         // Drag position in offset-from-tuner-center Hz (same
-        // frame as `vfoOffsetHz` / `bandwidthHz`).
+        // frame as `vfoOffsetHz` / `bandwidthHz`). `span` is the
+        // displayed-viewport span; the viewport may be offset
+        // from tuner center when zoomed, so add that in.
         let frac = max(0, min(1, currentX / width))
-        let dragOffsetHz = (Double(frac) - 0.5) * span
+        let viewCenter = model.displayedCenterOffsetHz
+        let dragOffsetHz = viewCenter + (Double(frac) - 0.5) * span
 
         // Pinned opposite edge in offset-Hz.
         let leftAtStart = dragStartVfoOffsetHz - dragStartBandwidthHz / 2

--- a/apps/macos/SDRMac/Views/VfoOverlayView.swift
+++ b/apps/macos/SDRMac/Views/VfoOverlayView.swift
@@ -46,6 +46,37 @@ struct VfoOverlayView: View {
     private static let bandColor = Color(red: 0.2, green: 0.6, blue: 1.0)
     private static let centerColor = Color(red: 0.3, green: 0.7, blue: 1.0)
 
+    /// Pixel radius for "grabbing" a bandwidth edge. Matches the
+    /// GTK `BW_HANDLE_THRESHOLD_PX = 8.0` in `vfo_overlay.rs`.
+    /// Within this distance of a passband edge, a drag resizes
+    /// the bandwidth instead of retuning the tuner.
+    private static let edgeThresholdPx: CGFloat = 8
+
+    /// Bandwidth clamp — matches GTK's MIN_BANDWIDTH_HZ (500) /
+    /// MAX_BANDWIDTH_HZ (250 kHz) in `vfo_overlay.rs`. Prevents
+    /// the user from dragging an edge past the VFO center
+    /// (negative bandwidth) or past the visible span.
+    private static let minBandwidthHz: Double = 500
+    private static let maxBandwidthHz: Double = 250_000
+
+    /// Classification of the active drag gesture. Captured on
+    /// the first `.onChanged` event of each drag and honored for
+    /// the rest so a drag that *starts* near an edge keeps
+    /// resizing even when the mouse wanders toward the center.
+    private enum DragKind {
+        case idle
+        case retune
+        case resizeLeft
+        case resizeRight
+    }
+    @State private var dragKind: DragKind = .idle
+
+    /// Snapshot of the VFO state at drag start, so edge-resize
+    /// math can pin the opposite edge in Hz space regardless of
+    /// how far the drag moves.
+    @State private var dragStartVfoOffsetHz: Double = 0
+    @State private var dragStartBandwidthHz: Double = 0
+
     var body: some View {
         GeometryReader { geo in
             let width = geo.size.width
@@ -123,39 +154,141 @@ struct VfoOverlayView: View {
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        applyDrag(at: value.location.x, width: width, span: span)
+                        handleDrag(
+                            currentX: value.location.x,
+                            startX: value.startLocation.x,
+                            width: width,
+                            span: span,
+                            centerPx: centerPx,
+                            bwPixels: bwPixels
+                        )
+                    }
+                    .onEnded { _ in
+                        dragKind = .idle
                     }
             )
         }
+    }
+
+    /// Top-level drag handler. Classifies the drag on its first
+    /// frame (retune vs edge-resize) and dispatches to the
+    /// appropriate helper. The classification sticks for the
+    /// duration of the drag so the gesture doesn't flip modes
+    /// when the mouse crosses another edge mid-drag.
+    private func handleDrag(
+        currentX: CGFloat,
+        startX: CGFloat,
+        width: CGFloat,
+        span: Double,
+        centerPx: CGFloat,
+        bwPixels: CGFloat
+    ) {
+        guard width > 0, span > 0 else { return }
+
+        if dragKind == .idle {
+            dragKind = classify(
+                startX: startX,
+                centerPx: centerPx,
+                bwPixels: bwPixels
+            )
+            dragStartVfoOffsetHz = model.vfoOffsetHz
+            dragStartBandwidthHz = model.bandwidthHz
+        }
+
+        switch dragKind {
+        case .idle, .retune:
+            retuneAt(x: currentX, width: width, span: span)
+        case .resizeLeft:
+            resize(edge: .left, currentX: currentX, width: width, span: span)
+        case .resizeRight:
+            resize(edge: .right, currentX: currentX, width: width, span: span)
+        }
+    }
+
+    /// Hit-test the drag's starting x against the passband edges.
+    /// Within `edgeThresholdPx` of either edge = resize; anywhere
+    /// else = retune.
+    private func classify(
+        startX: CGFloat,
+        centerPx: CGFloat,
+        bwPixels: CGFloat
+    ) -> DragKind {
+        let leftPx = centerPx - bwPixels / 2
+        let rightPx = centerPx + bwPixels / 2
+        if abs(startX - leftPx) <= Self.edgeThresholdPx {
+            return .resizeLeft
+        }
+        if abs(startX - rightPx) <= Self.edgeThresholdPx {
+            return .resizeRight
+        }
+        return .retune
     }
 
     /// Convert the drag's x-pixel to an absolute frequency and
     /// RETUNE the hardware tuner to center on it, parking the
     /// VFO offset at 0.
     ///
-    /// This matches the GTK UI's click-to-tune behaviour (see
-    /// `crates/sdr-ui/src/window.rs:270` — the VFO offset change
+    /// Matches the GTK UI's click-to-tune behaviour
+    /// (`crates/sdr-ui/src/window.rs:270` — the VFO-offset-change
     /// callback pulls `center + offset` and calls `Tune(...)`).
     /// Setting `vfoOffset` directly doesn't work for clicks
     /// outside ±effective_sample_rate/2 because the demod only
     /// processes the post-decimation passband; retuning the
     /// tuner to the clicked frequency puts the signal back at
     /// DC where the demod can lock onto it.
-    private func applyDrag(at x: CGFloat, width: CGFloat, span: Double) {
-        guard width > 0, span > 0 else { return }
+    private func retuneAt(x: CGFloat, width: CGFloat, span: Double) {
         let frac = max(0, min(1, x / width))
         // Absolute Hz = tuner center + (offset from center on the
         // visible axis). `span` is `displayBandwidthHz`, the full
         // FFT span.
         let absoluteHz = model.centerFrequencyHz + (Double(frac) - 0.5) * span
-        // Reject obviously-bad clicks (e.g. if centerFrequencyHz
-        // is uninitialised). Negative Hz never makes sense.
         guard absoluteHz > 0 else { return }
         model.setCenter(absoluteHz)
-        // Park the VFO at the new center; the demod now sees
-        // the desired signal at DC.
         if model.vfoOffsetHz != 0 {
             model.setVfoOffset(0)
+        }
+    }
+
+    private enum ResizeEdge { case left, right }
+
+    /// Resize the passband by dragging one edge. The OPPOSITE
+    /// edge stays pinned in Hz space (snapshot at drag start),
+    /// so the visual mental model — "I'm dragging THIS edge" —
+    /// holds regardless of how far the drag goes. New
+    /// bandwidth is clamped to [minBandwidthHz, maxBandwidthHz]
+    /// so the user can't produce negative / nonsensical sizes.
+    private func resize(edge: ResizeEdge, currentX: CGFloat, width: CGFloat, span: Double) {
+        // Drag position in offset-from-tuner-center Hz (same
+        // frame as `vfoOffsetHz` / `bandwidthHz`).
+        let frac = max(0, min(1, currentX / width))
+        let dragOffsetHz = (Double(frac) - 0.5) * span
+
+        // Pinned opposite edge in offset-Hz.
+        let leftAtStart = dragStartVfoOffsetHz - dragStartBandwidthHz / 2
+        let rightAtStart = dragStartVfoOffsetHz + dragStartBandwidthHz / 2
+
+        let newLeft: Double
+        let newRight: Double
+        switch edge {
+        case .left:
+            newLeft = min(dragOffsetHz, rightAtStart - Self.minBandwidthHz)
+            newRight = rightAtStart
+        case .right:
+            newRight = max(dragOffsetHz, leftAtStart + Self.minBandwidthHz)
+            newLeft = leftAtStart
+        }
+
+        let newBandwidth = max(Self.minBandwidthHz, min(Self.maxBandwidthHz, newRight - newLeft))
+        let newCenter = (newLeft + newRight) / 2
+
+        // Only push to the engine when the values actually
+        // changed — avoids a flood of identical commands on
+        // tiny pixel movements.
+        if abs(newBandwidth - model.bandwidthHz) > 0.5 {
+            model.setBandwidth(newBandwidth)
+        }
+        if abs(newCenter - model.vfoOffsetHz) > 0.5 {
+            model.setVfoOffset(newCenter)
         }
     }
 }

--- a/apps/macos/SDRMac/Views/VfoOverlayView.swift
+++ b/apps/macos/SDRMac/Views/VfoOverlayView.swift
@@ -195,7 +195,13 @@ struct VfoOverlayView: View {
         }
 
         switch dragKind {
-        case .idle, .retune:
+        case .idle:
+            // Unreachable in practice — `classify(...)` above
+            // never returns `.idle`. Explicit no-op here so a
+            // future classifier change defaults to "do nothing"
+            // rather than silently retuning on an unknown drag.
+            return
+        case .retune:
             retuneAt(x: currentX, width: width, span: span)
         case .resizeLeft:
             resize(edge: .left, currentX: currentX, width: width, span: span)
@@ -286,7 +292,21 @@ struct VfoOverlayView: View {
         }
 
         let newBandwidth = max(Self.minBandwidthHz, min(Self.maxBandwidthHz, newRight - newLeft))
-        let newCenter = (newLeft + newRight) / 2
+        // Derive center from the PINNED edge + the clamped
+        // bandwidth. Using `(newLeft + newRight) / 2` directly
+        // would let the center drift past the pinned edge when
+        // the user drags into the min/max-bandwidth clamp — the
+        // VFO would slide sideways even though the visible
+        // bandwidth stopped changing. Per #320 review.
+        let newCenter: Double
+        switch edge {
+        case .left:
+            // Right edge pinned; derive center from it.
+            newCenter = rightAtStart - newBandwidth / 2
+        case .right:
+            // Left edge pinned; derive center from it.
+            newCenter = leftAtStart + newBandwidth / 2
+        }
 
         // Only push to the engine when the values actually
         // changed — avoids a flood of identical commands on

--- a/apps/macos/SDRMacTests/CoreModelTests.swift
+++ b/apps/macos/SDRMacTests/CoreModelTests.swift
@@ -12,7 +12,11 @@ final class CoreModelTests: XCTestCase {
         let m = CoreModel()
         XCTAssertFalse(m.isRunning)
         XCTAssertNil(m.lastError)
-        XCTAssertEqual(m.centerFrequencyHz, 100_700_000)
+        // Default center freq aligns with the Rust engine's
+        // `DEFAULT_CENTER_FREQ` (100.000 MHz) so Linux / Mac
+        // both paint the same tuner state at first launch —
+        // see commit 31e7f7f.
+        XCTAssertEqual(m.centerFrequencyHz, 100_000_000)
         XCTAssertEqual(m.demodMode, .wfm)
         XCTAssertEqual(m.fftSize, 2048)
     }

--- a/apps/macos/SDRMacTests/FrequencyAxisTests.swift
+++ b/apps/macos/SDRMacTests/FrequencyAxisTests.swift
@@ -1,0 +1,124 @@
+//
+// FrequencyAxisTests.swift — parity fixture for the port of
+// `crates/sdr-ui/src/spectrum/frequency_axis.rs`.
+//
+// Every test name below maps 1:1 to a Rust test in the source
+// file; the assertions mirror the Linux `assert_eq!` calls
+// verbatim. If either side drifts (new step-candidate added,
+// precision changed, threshold tier adjusted) one of these tests
+// fails on the next Mac build and the fixture has to be updated
+// alongside the Rust side.
+//
+// See issue #312 — "Snapshot parity test for freq-axis
+// formatter". A full shared source (Option B from the issue) is
+// the long-term answer if drift becomes a habit; this test is
+// the cheap, effective tripwire for now.
+
+import XCTest
+@testable import SDRMac
+
+final class FrequencyAxisTests: XCTestCase {
+
+    // ==========================================================
+    //  format_frequency parity
+    // ==========================================================
+
+    func testFormatHz() {
+        // Rust: `format_hz`
+        XCTAssertEqual(FrequencyAxis.formatFrequency(455), "455.0 Hz")
+        XCTAssertEqual(FrequencyAxis.formatFrequency(0), "0.0 Hz")
+    }
+
+    func testFormatKHz() {
+        // Rust: `format_khz`
+        XCTAssertEqual(FrequencyAxis.formatFrequency(7_055), "7.1 kHz")
+        XCTAssertEqual(FrequencyAxis.formatFrequency(1_000), "1.0 kHz")
+    }
+
+    func testFormatMHz() {
+        // Rust: `format_mhz`
+        XCTAssertEqual(FrequencyAxis.formatFrequency(100_000_000), "100.000 MHz")
+        XCTAssertEqual(FrequencyAxis.formatFrequency(433_500_000), "433.500 MHz")
+        XCTAssertEqual(FrequencyAxis.formatFrequency(7_055_000), "7.055 MHz")
+    }
+
+    func testFormatGHz() {
+        // Rust: `format_ghz`
+        XCTAssertEqual(FrequencyAxis.formatFrequency(1_200_000_000), "1.200 GHz")
+        XCTAssertEqual(FrequencyAxis.formatFrequency(2_400_000_000), "2.400 GHz")
+    }
+
+    func testFormatNegative() {
+        // Rust: `format_negative`
+        XCTAssertEqual(FrequencyAxis.formatFrequency(-100_000_000), "-100.000 MHz")
+    }
+
+    // ==========================================================
+    //  compute_grid_lines parity
+    // ==========================================================
+
+    func testGridLinesEmptyOnZeroMax() {
+        // Rust: `grid_lines_empty_on_zero_max`
+        let lines = FrequencyAxis.computeGridLines(
+            startHz: 0, endHz: 1_000_000, maxLines: 0)
+        XCTAssertTrue(lines.isEmpty)
+    }
+
+    func testGridLinesEmptyOnInvertedRange() {
+        // Rust: `grid_lines_empty_on_inverted_range`
+        let lines = FrequencyAxis.computeGridLines(
+            startHz: 1_000_000, endHz: 0, maxLines: 10)
+        XCTAssertTrue(lines.isEmpty)
+    }
+
+    func testGridLinesReasonableCount() {
+        // Rust: `grid_lines_reasonable_count`
+        // 2 MHz span, up to 10 lines
+        let lines = FrequencyAxis.computeGridLines(
+            startHz: 99_000_000, endHz: 101_000_000, maxLines: 10)
+        XCTAssertFalse(lines.isEmpty)
+        XCTAssertLessThanOrEqual(lines.count, 10)
+    }
+
+    func testGridLinesWithinRange() {
+        // Rust: `grid_lines_within_range`
+        let start = 100_000_000.0
+        let end = 102_000_000.0
+        let lines = FrequencyAxis.computeGridLines(
+            startHz: start, endHz: end, maxLines: 10)
+        for (freq, _) in lines {
+            XCTAssertGreaterThanOrEqual(freq, start)
+            XCTAssertLessThanOrEqual(freq, end)
+        }
+    }
+
+    func testGridLinesAreSorted() {
+        // Rust: `grid_lines_are_sorted`
+        let lines = FrequencyAxis.computeGridLines(
+            startHz: 88_000_000, endHz: 108_000_000, maxLines: 20)
+        for pair in zip(lines, lines.dropFirst()) {
+            XCTAssertLessThan(pair.0.0, pair.1.0)
+        }
+    }
+
+    // ==========================================================
+    //  Additional sanity — step-table ordering invariant
+    // ==========================================================
+
+    /// Catches accidental reorderings or deletions in
+    /// `stepCandidates`. The Rust side is "smallest → largest,
+    /// including common SI-ish prefixes" — check the Mac copy
+    /// matches that invariant even if individual values change.
+    func testStepCandidatesAreMonotonicallyIncreasing() {
+        let steps = FrequencyAxis.stepCandidates
+        XCTAssertFalse(steps.isEmpty)
+        for (prev, next) in zip(steps, steps.dropFirst()) {
+            XCTAssertLessThan(prev, next)
+        }
+        // Catch if someone removes the 1 Hz floor or the 1 GHz
+        // ceiling — would change visible label density on small
+        // / large spans respectively.
+        XCTAssertEqual(steps.first, 1)
+        XCTAssertEqual(steps.last, 1_000_000_000)
+    }
+}


### PR DESCRIPTION
## Summary

Knocks out the four follow-up issues filed off of PR #309 (M4 Metal renderer):

- **#311 perf** — one-shot render-clear for the history floor-fill, replacing the 1024-iteration blit loop.
- **#305 feat** — VFO bandwidth-edge drag gesture, matching the GTK UI's 8-pixel edge handles.
- **#306 feat** — scroll-wheel + trackpad pinch zoom on the spectrum/waterfall, cursor-centered.
- **#312 test** — parity snapshot test for the frequency-axis formatter/step-table so Mac + Linux don't silently drift.

All four are self-contained and don't overlap with each other's surface area (except #305 and #306 both live in the VFO overlay and #306 restructures the overlay's coordinate frame to use the zoomed display span).

## Commits (oldest first)

- `1ff34be` **#311** — history texture now uses `.renderTarget` usage; a single render-pass with `loadAction = .clear` and `MTLClearColor.red = floorDb` writes every texel via the fast-clear path. Zero draw calls, zero staging buffer, zero-loop.
- `d201394` **#305** — `DragKind` enum + `@State` classifies the drag on its first `.onChanged`. Edge-resize pins the opposite edge in Hz space from a drag-start snapshot, clamped to 500 Hz–250 kHz (matching GTK).
- `afca091` **#306** — new `CoreModel.displayedSpanHz` + `displayedCenterOffsetHz` drive a zoom window that's independent of the full FFT span. Scroll wheel via `NSEvent.addLocalMonitorForEvents` (cursor-centered), pinch via SwiftUI `MagnifyGesture` (cross-platform for future iPad work), double-click resets. Metal shader gets two new uniforms (`display_left_frac` / `display_right_frac`) and remaps bin-index → clip-space through the zoom window; waterfall fragment remaps viewport uv.x → history-texture uv.x via the same pair. VFO overlay + grid updated to read the displayed span/center instead of the raw FFT span, so all three layers zoom in lockstep.
- `7db8542` **#312** — extracts `formatFrequency` / `computeGridLines` / `stepCandidates` from `SpectrumGridView`'s private scope into a new `FrequencyAxis` enum and adds `FrequencyAxisTests` that mirrors `crates/sdr-ui/src/spectrum/frequency_axis.rs::tests` case-for-case. Drift on either side trips the test on next build.

## What's NOT in this PR

- **Shared Rust formatter via FFI (Option B in #312)** — the cheap snapshot test is enough to catch drift; the shared-source rewrite stays open as future work.
- **Blit-batching rewrite (#311)** was the rabbit's original suggestion and still makes sense for a hypothetical frequent-FFT-size-change workload. Current render-clear approach is simpler and faster; kept as an alternative if #311 reopens.

## Related issues

- Closes #311, #305, #306, #312.
- #314 (SpeechAnalyzer backend) filed during development — parked for post-M5/M6.

## Test plan

- [x] `make lint` (fmt-check, clippy `-D warnings`, test, cargo deny, cargo audit, ffi-header-check) green.
- [x] `make mac-test` — 28 tests (17 pre-existing + 11 new parity).
- [x] `make mac-app` release build succeeds on top of current `main` (post rtl-tcp merge).
- [x] Smoke: dormant spectrum paints the floor cold at launch (#311).
- [x] Smoke: drag inside the VFO band retunes; drag within ~8 pt of either edge resizes, with the opposite edge pinned (#305).
- [x] Smoke: scroll wheel zooms cursor-centered; pinch zooms view-center; double-click resets (#306).
- [x] Smoke: grid labels + VFO stay aligned to the same span as the waterfall through zoom (#306).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pinch, scroll-wheel and double-tap zoom controls with focal-aware zooming
  * Zoomable viewport propagated to spectrum renderer and waterfall
  * Edge-based VFO bandwidth resizing via drag
  * Frequency grid and axis rendering adapt to the zoomed viewport
  * Improved history texture initialization for renderer performance

* **Tests**
  * New tests for frequency formatting and grid-line generation; updated core-model default expectation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->