### PR TITLE
rtl_tcp: mDNS discovery + GTK client picker (#302, #321)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "sdr-radio",
  "sdr-radioreference",
  "sdr-rtlsdr",
+ "sdr-rtltcp-discovery",
  "sdr-sink-audio",
  "sdr-source-rtlsdr",
  "sdr-transcription",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +393,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -976,6 +993,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1226,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "mdns-sd"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451927183d65d600e52b4e877a1251e051576f84fa01e5b4a50b450dfaaa537c"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
 ]
 
 [[package]]
@@ -1230,6 +1281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1822,6 +1874,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sdr"
 version = "0.1.0"
 dependencies = [
@@ -1952,12 +2010,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdr-rtltcp-discovery"
+version = "0.1.0"
+dependencies = [
+ "mdns-sd",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "sdr-server-rtltcp"
 version = "0.1.0"
 dependencies = [
  "libc",
  "rusb",
  "sdr-rtlsdr",
+ "sdr-rtltcp-discovery",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
@@ -2216,6 +2284,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2302,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ dependencies = [
 name = "sdr-rtltcp-discovery"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "mdns-sd",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
     "crates/sdr-source-rtlsdr",
     "crates/sdr-source-network",
     "crates/sdr-server-rtltcp",
+    "crates/sdr-rtltcp-discovery",
     "crates/sdr-source-file",
     "crates/sdr-sink-audio",
     "crates/sdr-sink-network",
@@ -132,6 +133,7 @@ sdr-rtlsdr = { path = "crates/sdr-rtlsdr" }
 sdr-source-rtlsdr = { path = "crates/sdr-source-rtlsdr" }
 sdr-source-network = { path = "crates/sdr-source-network" }
 sdr-server-rtltcp = { path = "crates/sdr-server-rtltcp" }
+sdr-rtltcp-discovery = { path = "crates/sdr-rtltcp-discovery" }
 sdr-source-file = { path = "crates/sdr-source-file" }
 sdr-sink-audio = { path = "crates/sdr-sink-audio" }
 sdr-sink-network = { path = "crates/sdr-sink-network" }
@@ -200,6 +202,10 @@ coreaudio-rs = "0.14"
 
 # WAV files
 hound = "3"
+
+# mDNS-SD service discovery (_rtl_tcp._tcp.local) — pure Rust, no
+# Avahi/Bonjour system dependency, no async runtime required.
+mdns-sd = "0.19"
 
 # Zero-copy type casting
 bytemuck = { version = "1", features = ["derive"] }

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -892,6 +892,16 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
             state.network_protocol,
         )),
         SourceType::File => Box::new(sdr_source_file::FileSource::new(&state.file_path)),
+        // rtl_tcp client: connects to a remote `rtl_tcp`-compatible
+        // server, handshakes the 12-byte RTL0 header, and routes
+        // future tune / gain / PPM messages through the 5-byte
+        // command channel. Reuses the `network_host` + `network_port`
+        // config fields since the connection shape is the same (no
+        // separate RtlTcpConfig state field needed).
+        SourceType::RtlTcp => Box::new(sdr_source_network::RtlTcpSource::new(
+            &state.network_host,
+            state.network_port,
+        )),
     };
 
     if let Err(e) = source.set_sample_rate(state.configured_sample_rate) {
@@ -902,7 +912,10 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
         }
     }
 
-    if state.source_type == SourceType::RtlSdr {
+    // Tune is a meaningful operation for both the local RTL-SDR and
+    // any remote (RtlTcp) — both need the initial center frequency.
+    // Network raw-IQ and File sources ignore it.
+    if matches!(state.source_type, SourceType::RtlSdr | SourceType::RtlTcp) {
         source.tune(state.center_freq).map_err(|e| e.to_string())?;
     }
 

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -420,11 +420,32 @@ mod tests {
 
     #[test]
     fn test_source_type_variants() {
+        // Equality + discrimination across all four variants. RtlTcp
+        // is the rtl_tcp-protocol network client added alongside the
+        // existing raw Network variant; keep them distinct at the
+        // type level.
         assert_eq!(SourceType::RtlSdr, SourceType::RtlSdr);
         assert_ne!(SourceType::RtlSdr, SourceType::Network);
         assert_ne!(SourceType::Network, SourceType::File);
+        assert_ne!(SourceType::Network, SourceType::RtlTcp);
+        assert_ne!(SourceType::RtlTcp, SourceType::RtlSdr);
 
-        let types = [SourceType::RtlSdr, SourceType::Network, SourceType::File];
-        assert_eq!(types.len(), 3);
+        let types = [
+            SourceType::RtlSdr,
+            SourceType::Network,
+            SourceType::File,
+            SourceType::RtlTcp,
+        ];
+        assert_eq!(types.len(), 4);
+    }
+
+    #[test]
+    fn test_set_source_type_rtl_tcp_message() {
+        // Regression coverage for the new variant — make sure the
+        // message wraps it and pattern-matches cleanly, same shape as
+        // the existing RtlSdr / Network / File branches elsewhere in
+        // this test suite.
+        let msg = UiToDsp::SetSourceType(SourceType::RtlTcp);
+        assert!(matches!(msg, UiToDsp::SetSourceType(SourceType::RtlTcp)));
     }
 }

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -58,10 +58,15 @@ pub enum DspToUi {
 pub enum SourceType {
     /// RTL-SDR USB dongle.
     RtlSdr,
-    /// TCP/UDP network IQ stream.
+    /// Raw TCP/UDP network IQ stream (generic, fixed-format).
     Network,
     /// WAV file playback.
     File,
+    /// rtl_tcp-protocol network source — speaks the RTL0 handshake,
+    /// supports discovery via mDNS, and tunes the remote dongle via
+    /// the 5-byte command channel. Distinct from `Network` because
+    /// the wire protocol and feature set diverge.
+    RtlTcp,
 }
 
 /// Messages sent from the UI thread to the DSP pipeline thread.

--- a/crates/sdr-rtltcp-discovery/Cargo.toml
+++ b/crates/sdr-rtltcp-discovery/Cargo.toml
@@ -13,6 +13,11 @@ tracing.workspace = true
 # Version kept in sync with the workspace so future crates can share
 # the same dependency if they need discovery.
 mdns-sd = { workspace = true }
+# libc::gethostname for portable hostname lookup across Unix flavors
+# (Linux, macOS, BSD). The `/proc/sys/kernel/hostname` + `/etc/hostname`
+# path we used before is Linux-only; `gethostname(3)` works on every
+# Unix. See the `unix`-gated block in advertiser::local_hostname.
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-rtltcp-discovery/Cargo.toml
+++ b/crates/sdr-rtltcp-discovery/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sdr-rtltcp-discovery"
+version = "0.1.0"
+description = "mDNS/DNS-SD discovery for rtl_tcp servers — announce from sdr-server-rtltcp, browse from sdr-source-network clients. Service type _rtl_tcp._tcp.local."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+thiserror.workspace = true
+tracing.workspace = true
+# Pure-Rust mDNS-SD — no Avahi/Bonjour system dep, no async runtime.
+# Version kept in sync with the workspace so future crates can share
+# the same dependency if they need discovery.
+mdns-sd = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/sdr-rtltcp-discovery/src/advertiser.rs
+++ b/crates/sdr-rtltcp-discovery/src/advertiser.rs
@@ -1,0 +1,141 @@
+//! Advertiser: publish a single `_rtl_tcp._tcp.local.` registration.
+
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+
+use crate::SERVICE_TYPE;
+use crate::error::DiscoveryError;
+use crate::txt::TxtRecord;
+
+/// Options for [`Advertiser::announce`]. All values except `port` have
+/// reasonable defaults derivable from the local environment, but the
+/// caller usually has richer metadata (tuner, gain count) already at
+/// hand from the server that's being advertised.
+#[derive(Debug, Clone)]
+pub struct AdvertiseOptions {
+    /// TCP port the rtl_tcp server is listening on.
+    pub port: u16,
+
+    /// Instance name as it appears in DNS-SD. Usually a combination of
+    /// hostname + nickname. Must be unique on the LAN — if two servers
+    /// advertise the same name, clients can't distinguish them.
+    ///
+    /// Example: `"jason-desk rtl-sdr"` or `"shack-pi weather"`.
+    pub instance_name: String,
+
+    /// mDNS hostname for A/AAAA lookup. Conventionally ends with
+    /// `.local.` (note the trailing dot). Passing an empty string
+    /// triggers auto-derivation from the local system hostname.
+    pub hostname: String,
+
+    /// TXT record payload — tuner / version / gains / nickname.
+    pub txt: TxtRecord,
+}
+
+/// Active advertisement. Drops → unregisters.
+///
+/// The underlying `ServiceDaemon` is kept alive inside `Advertiser` so
+/// the registration stays valid. Dropping the `Advertiser` both
+/// unregisters the service AND shuts the daemon down.
+pub struct Advertiser {
+    daemon: ServiceDaemon,
+    /// Full service name as registered, e.g.
+    /// `jason-desk rtl-sdr._rtl_tcp._tcp.local.`. Needed by
+    /// `ServiceDaemon::unregister` when we drop.
+    full_name: String,
+}
+
+impl Advertiser {
+    /// Register a new advertisement. On success the service is live and
+    /// will respond to mDNS queries from the LAN within seconds.
+    pub fn announce(opts: AdvertiseOptions) -> Result<Self, DiscoveryError> {
+        let daemon = ServiceDaemon::new()?;
+        let props = opts.txt.to_properties()?;
+
+        let host = if opts.hostname.is_empty() {
+            local_hostname()?
+        } else {
+            opts.hostname.clone()
+        };
+
+        // Empty-string host IPs + `enable_addr_auto()` tells mdns-sd to
+        // auto-populate A/AAAA records from the machine's interface
+        // list. Matches the "announce on all local addresses" pattern
+        // we want — users don't have to think about which interface.
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &opts.instance_name,
+            &host,
+            "",
+            opts.port,
+            Some(props),
+        )?
+        .enable_addr_auto();
+
+        let full_name = info.get_fullname().to_string();
+        daemon.register(info)?;
+        tracing::info!(
+            service = %full_name,
+            port = opts.port,
+            "rtl_tcp mDNS advertisement registered"
+        );
+        Ok(Self { daemon, full_name })
+    }
+
+    /// Stop advertising and shut the daemon down. Equivalent to
+    /// dropping the `Advertiser`, but lets the caller propagate errors.
+    pub fn stop(self) -> Result<(), DiscoveryError> {
+        let rx = self.daemon.unregister(&self.full_name)?;
+        // `unregister` returns a Receiver for the completion status so
+        // the caller can wait for unregistration to finish. Short
+        // timeout is fine; if mDNS is wedged we still want to exit.
+        let _ = rx.recv_timeout(std::time::Duration::from_secs(1));
+        // Shutdown follows the same pattern.
+        let _ = self.daemon.shutdown();
+        Ok(())
+    }
+}
+
+impl Drop for Advertiser {
+    fn drop(&mut self) {
+        // Best-effort teardown — we don't want Drop to panic even if
+        // the mDNS daemon has already shut down or a mutex is poisoned.
+        if let Ok(rx) = self.daemon.unregister(&self.full_name) {
+            let _ = rx.recv_timeout(std::time::Duration::from_secs(1));
+        }
+        let _ = self.daemon.shutdown();
+    }
+}
+
+/// Best-effort local hostname lookup. Uses `gethostname` via the
+/// `hostname::get` crate? — we avoid a new dependency by reading
+/// `/etc/hostname` on Unix and falling back to `localhost` otherwise.
+///
+/// The returned string is passed to mDNS as the A/AAAA host; mDNS
+/// will normalize / append `.local.` if needed.
+fn local_hostname() -> Result<String, DiscoveryError> {
+    // std's hostname accessor is nightly-only, so we roll our own for
+    // Unix. The `"localhost"` fallback keeps the advertisement alive on
+    // an unusual system rather than erroring out.
+    #[cfg(unix)]
+    {
+        // Read /proc/sys/kernel/hostname on Linux, /etc/hostname
+        // elsewhere. Both are plain text, one line.
+        match std::fs::read_to_string("/proc/sys/kernel/hostname")
+            .or_else(|_| std::fs::read_to_string("/etc/hostname"))
+        {
+            Ok(s) => {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    Ok("localhost.local.".to_string())
+                } else {
+                    Ok(format!("{trimmed}.local."))
+                }
+            }
+            Err(e) => Err(DiscoveryError::Hostname(e)),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        Ok("localhost.local.".to_string())
+    }
+}

--- a/crates/sdr-rtltcp-discovery/src/advertiser.rs
+++ b/crates/sdr-rtltcp-discovery/src/advertiser.rs
@@ -1,10 +1,19 @@
 //! Advertiser: publish a single `_rtl_tcp._tcp.local.` registration.
 
+use std::time::Duration;
+
 use mdns_sd::{ServiceDaemon, ServiceInfo};
 
 use crate::SERVICE_TYPE;
 use crate::error::DiscoveryError;
 use crate::txt::TxtRecord;
+
+/// How long we wait for mDNS unregister / shutdown completion before
+/// proceeding. Short timeout is intentional — if the daemon is wedged
+/// we prefer to exit promptly; the registration will time out on the
+/// LAN side via its normal TTL regardless of whether our explicit
+/// unregister succeeded.
+const UNREGISTER_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Options for [`Advertiser::announce`]. All values except `port` have
 /// reasonable defaults derivable from the local environment, but the
@@ -120,7 +129,7 @@ impl Advertiser {
         // `unregister` returns a Receiver for the completion status so
         // the caller can wait for unregistration to finish. Short
         // timeout is fine; if mDNS is wedged we still want to exit.
-        let _ = rx.recv_timeout(std::time::Duration::from_secs(1));
+        let _ = rx.recv_timeout(UNREGISTER_TIMEOUT);
         // Shutdown follows the same pattern.
         let _ = daemon.shutdown();
         Ok(())
@@ -138,7 +147,7 @@ impl Drop for Advertiser {
         // Best-effort teardown — we don't want Drop to panic even if
         // the mDNS daemon has already shut down or a mutex is poisoned.
         if let Ok(rx) = daemon.unregister(&self.full_name) {
-            let _ = rx.recv_timeout(std::time::Duration::from_secs(1));
+            let _ = rx.recv_timeout(UNREGISTER_TIMEOUT);
         }
         let _ = daemon.shutdown();
     }

--- a/crates/sdr-rtltcp-discovery/src/advertiser.rs
+++ b/crates/sdr-rtltcp-discovery/src/advertiser.rs
@@ -36,8 +36,14 @@ pub struct AdvertiseOptions {
 /// The underlying `ServiceDaemon` is kept alive inside `Advertiser` so
 /// the registration stays valid. Dropping the `Advertiser` both
 /// unregisters the service AND shuts the daemon down.
+///
+/// `daemon` is wrapped in `Option` so [`Advertiser::stop`] can take it
+/// out explicitly, leaving `Drop::drop` as a no-op for already-stopped
+/// instances — otherwise callers who `stop()` would pay for two rounds
+/// of unregister + shutdown against the same (potentially already
+/// dead) daemon.
 pub struct Advertiser {
-    daemon: ServiceDaemon,
+    daemon: Option<ServiceDaemon>,
     /// Full service name as registered, e.g.
     /// `jason-desk rtl-sdr._rtl_tcp._tcp.local.`. Needed by
     /// `ServiceDaemon::unregister` when we drop.
@@ -52,7 +58,10 @@ impl Advertiser {
         let props = opts.txt.to_properties()?;
 
         let host = if opts.hostname.is_empty() {
-            local_hostname()?
+            // Auto-derive the mDNS hostname from the OS hostname.
+            // `local_hostname()` returns the bare name (no suffix);
+            // mDNS wants fully-qualified, so we append `.local.` here.
+            format!("{}.local.", local_hostname())
         } else {
             opts.hostname.clone()
         };
@@ -78,73 +87,107 @@ impl Advertiser {
             port = opts.port,
             "rtl_tcp mDNS advertisement registered"
         );
-        Ok(Self { daemon, full_name })
+        Ok(Self {
+            daemon: Some(daemon),
+            full_name,
+        })
     }
 
     /// Stop advertising and shut the daemon down. Equivalent to
     /// dropping the `Advertiser`, but lets the caller propagate errors.
-    pub fn stop(self) -> Result<(), DiscoveryError> {
-        let rx = self.daemon.unregister(&self.full_name)?;
+    /// Taking the daemon out of `Option` here means the subsequent
+    /// `Drop` call is a no-op for an already-stopped advertiser.
+    pub fn stop(mut self) -> Result<(), DiscoveryError> {
+        let Some(daemon) = self.daemon.take() else {
+            return Ok(());
+        };
+        let rx = daemon.unregister(&self.full_name)?;
         // `unregister` returns a Receiver for the completion status so
         // the caller can wait for unregistration to finish. Short
         // timeout is fine; if mDNS is wedged we still want to exit.
         let _ = rx.recv_timeout(std::time::Duration::from_secs(1));
         // Shutdown follows the same pattern.
-        let _ = self.daemon.shutdown();
+        let _ = daemon.shutdown();
         Ok(())
     }
 }
 
 impl Drop for Advertiser {
     fn drop(&mut self) {
+        // No-op if `stop()` already consumed the daemon — the Option
+        // lets us distinguish "still owned, need teardown" from
+        // "already torn down by an explicit stop()."
+        let Some(daemon) = self.daemon.take() else {
+            return;
+        };
         // Best-effort teardown — we don't want Drop to panic even if
         // the mDNS daemon has already shut down or a mutex is poisoned.
-        if let Ok(rx) = self.daemon.unregister(&self.full_name) {
+        if let Ok(rx) = daemon.unregister(&self.full_name) {
             let _ = rx.recv_timeout(std::time::Duration::from_secs(1));
         }
-        let _ = self.daemon.shutdown();
+        let _ = daemon.shutdown();
     }
 }
 
-/// Best-effort local hostname lookup. Uses `gethostname` via the
-/// `hostname::get` crate? — we avoid a new dependency by reading
-/// `/etc/hostname` on Unix and falling back to `localhost` otherwise.
+/// Best-effort local hostname lookup, returning the **bare** hostname
+/// without any `.local.` suffix. Useful as a default nickname for
+/// advertisement (callers who want the full mDNS form can append
+/// `.local.` themselves).
 ///
-/// The returned string is passed to mDNS as the A/AAAA host; mDNS
-/// will normalize / append `.local.` if needed.
-fn local_hostname() -> Result<String, DiscoveryError> {
-    // std's hostname accessor is nightly-only, so we roll our own for
-    // Unix. The `"localhost"` fallback keeps the advertisement alive on
-    // an unusual system rather than erroring out.
-    #[cfg(unix)]
-    {
-        // Read /proc/sys/kernel/hostname on Linux, /etc/hostname
-        // elsewhere. Both are plain text, one line.
-        match std::fs::read_to_string("/proc/sys/kernel/hostname")
-            .or_else(|_| std::fs::read_to_string("/etc/hostname"))
-        {
-            Ok(s) => {
-                // Defensive: strip any trailing `.local` / `.local.`
-                // before re-appending, so an `/etc/hostname` that
-                // already contains the suffix doesn't produce
-                // `foo.local..local.`. mDNS daemons typically
-                // normalize this but costing a single `trim_end_matches`
-                // pair per registration is cheap insurance.
-                let trimmed = s
-                    .trim()
-                    .trim_end_matches(".local.")
-                    .trim_end_matches(".local");
-                if trimmed.is_empty() {
-                    Ok("localhost.local.".to_string())
-                } else {
-                    Ok(format!("{trimmed}.local."))
-                }
-            }
-            Err(e) => Err(DiscoveryError::Hostname(e)),
-        }
+/// Uses `libc::gethostname(3)` on Unix — portable across Linux, macOS,
+/// and the BSDs, unlike the `/proc/sys/kernel/hostname` + `/etc/hostname`
+/// reads we had before (Linux-only). On the exceedingly rare failure
+/// path — `gethostname()` cannot actually fail on a modern OS except
+/// for `EFAULT` against a buffer we control — we log and return
+/// `"localhost"` so a degraded system still gets an advertisement
+/// rather than a cryptic mDNS registration error.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+pub fn local_hostname() -> String {
+    // POSIX caps HOST_NAME_MAX at 255; 256 includes the NUL and
+    // leaves room for any OS that returns a non-NUL-terminated
+    // buffer at full capacity.
+    const BUFFER_LEN: usize = 256;
+    let mut buf = [0u8; BUFFER_LEN];
+    // SAFETY: `buf` is a fixed-size stack array whose lifetime
+    // outlives the syscall. We pass its length via `size_of_val`, so
+    // `gethostname()` cannot write past the end. The result is read
+    // only after we confirm success.
+    let rc = unsafe {
+        libc::gethostname(
+            buf.as_mut_ptr().cast::<libc::c_char>(),
+            std::mem::size_of_val(&buf),
+        )
+    };
+    if rc != 0 {
+        tracing::warn!("gethostname() failed, using 'localhost' as nickname default");
+        return String::from("localhost");
     }
-    #[cfg(not(unix))]
-    {
-        Ok("localhost.local.".to_string())
+    // gethostname does NOT guarantee NUL-termination when the name
+    // fills the buffer, but POSIX HOST_NAME_MAX is well under 256, so
+    // in practice every returned hostname is NUL-terminated and the
+    // NUL scan is safe. Still, defensively cap the length.
+    let name_len = buf.iter().position(|&b| b == 0).unwrap_or(BUFFER_LEN);
+    let Ok(name) = std::str::from_utf8(&buf[..name_len]) else {
+        tracing::warn!("gethostname() returned non-UTF-8 bytes, using 'localhost'");
+        return String::from("localhost");
+    };
+    let trimmed = name
+        .trim()
+        .trim_end_matches(".local.")
+        .trim_end_matches(".local");
+    if trimmed.is_empty() {
+        String::from("localhost")
+    } else {
+        trimmed.to_string()
     }
+}
+
+/// Non-Unix stub. `sdr-rtl-tcp` bin is `compile_error!`-gated to Unix
+/// already, so this path is only reachable from library consumers on
+/// exotic platforms. Returns `"localhost"` so they still get a valid
+/// (if boring) default nickname.
+#[cfg(not(unix))]
+pub fn local_hostname() -> String {
+    String::from("localhost")
 }

--- a/crates/sdr-rtltcp-discovery/src/advertiser.rs
+++ b/crates/sdr-rtltcp-discovery/src/advertiser.rs
@@ -125,13 +125,22 @@ impl Advertiser {
         let Some(daemon) = self.daemon.take() else {
             return Ok(());
         };
-        let rx = daemon.unregister(&self.full_name)?;
-        // `unregister` returns a Receiver for the completion status so
-        // the caller can wait for unregistration to finish. Short
-        // timeout is fine; if mDNS is wedged we still want to exit.
-        let _ = rx.recv_timeout(UNREGISTER_TIMEOUT);
-        // Shutdown follows the same pattern.
+        // Run shutdown unconditionally. The Option::take above has
+        // already disarmed Drop, so if we bailed here via `?` on an
+        // unregister error the daemon thread and its mDNS sockets
+        // would leak for the rest of the process lifetime.
+        // `unregister` returns a Receiver for the completion status;
+        // short timeout is fine because if mDNS is wedged we still
+        // want to exit.
+        let unregister_result = daemon.unregister(&self.full_name);
+        if let Ok(rx) = &unregister_result {
+            let _ = rx.recv_timeout(UNREGISTER_TIMEOUT);
+        }
         let _ = daemon.shutdown();
+        // Surface the unregister error (if any) to the caller after
+        // the daemon is fully torn down. Discard the Receiver on the
+        // Ok path — we already awaited it above.
+        unregister_result?;
         Ok(())
     }
 }

--- a/crates/sdr-rtltcp-discovery/src/advertiser.rs
+++ b/crates/sdr-rtltcp-discovery/src/advertiser.rs
@@ -57,13 +57,28 @@ impl Advertiser {
         let daemon = ServiceDaemon::new()?;
         let props = opts.txt.to_properties()?;
 
-        let host = if opts.hostname.is_empty() {
-            // Auto-derive the mDNS hostname from the OS hostname.
-            // `local_hostname()` returns the bare name (no suffix);
-            // mDNS wants fully-qualified, so we append `.local.` here.
-            format!("{}.local.", local_hostname())
+        // Normalize the mDNS hostname identically for both the
+        // auto-derived and caller-provided paths. Previously only the
+        // empty-string branch appended `.local.`; a caller that
+        // passed this crate's own `local_hostname()` output (which
+        // returns the bare name by contract) would have registered
+        // under a non-qualified hostname while the auto-derive path
+        // registered under `.local.`. Trimming defensively on both
+        // paths also lets a caller pass `"foo.local."` without
+        // producing `foo.local..local.`.
+        let raw_host = if opts.hostname.is_empty() {
+            local_hostname()
         } else {
             opts.hostname.clone()
+        };
+        let trimmed = raw_host
+            .trim()
+            .trim_end_matches(".local.")
+            .trim_end_matches(".local");
+        let host = if trimmed.is_empty() {
+            String::from("localhost.local.")
+        } else {
+            format!("{trimmed}.local.")
         };
 
         // Empty-string host IPs + `enable_addr_auto()` tells mdns-sd to

--- a/crates/sdr-rtltcp-discovery/src/advertiser.rs
+++ b/crates/sdr-rtltcp-discovery/src/advertiser.rs
@@ -124,7 +124,16 @@ fn local_hostname() -> Result<String, DiscoveryError> {
             .or_else(|_| std::fs::read_to_string("/etc/hostname"))
         {
             Ok(s) => {
-                let trimmed = s.trim();
+                // Defensive: strip any trailing `.local` / `.local.`
+                // before re-appending, so an `/etc/hostname` that
+                // already contains the suffix doesn't produce
+                // `foo.local..local.`. mDNS daemons typically
+                // normalize this but costing a single `trim_end_matches`
+                // pair per registration is cheap insurance.
+                let trimmed = s
+                    .trim()
+                    .trim_end_matches(".local.")
+                    .trim_end_matches(".local");
                 if trimmed.is_empty() {
                     Ok("localhost.local.".to_string())
                 } else {

--- a/crates/sdr-rtltcp-discovery/src/browser.rs
+++ b/crates/sdr-rtltcp-discovery/src/browser.rs
@@ -1,0 +1,199 @@
+//! Browser: watch the LAN for `_rtl_tcp._tcp.local.` advertisements.
+
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use mdns_sd::{ServiceDaemon, ServiceEvent};
+
+use crate::SERVICE_TYPE;
+use crate::error::DiscoveryError;
+use crate::txt::TxtRecord;
+
+/// A server visible on the local network.
+#[derive(Debug, Clone)]
+pub struct DiscoveredServer {
+    /// Full DNS-SD instance name, e.g.
+    /// `jason-desk rtl-sdr._rtl_tcp._tcp.local.`. Use this as the
+    /// stable identifier for a discovered entry — the nickname in
+    /// `txt` is user-editable and may change.
+    pub instance_name: String,
+
+    /// mDNS hostname the service registered with (e.g. `jason-desk.local.`).
+    pub hostname: String,
+
+    /// Port the rtl_tcp server is listening on.
+    pub port: u16,
+
+    /// Resolved addresses. IPv4 comes first when both are present so
+    /// clients that prefer v4 (the rtl_tcp protocol itself is
+    /// address-family-agnostic, but some embedded clients only do v4)
+    /// have a predictable default.
+    pub addresses: Vec<IpAddr>,
+
+    /// TXT record payload (tuner / version / gains / nickname / txbuf).
+    pub txt: TxtRecord,
+
+    /// When we last saw a `ServiceResolved` for this entry. Lets the
+    /// UI show "last seen 5 s ago" style freshness indicators and
+    /// garbage-collect servers that have gone silent but haven't
+    /// produced a `ServiceRemoved` yet.
+    pub last_seen: Instant,
+}
+
+/// Events the browser emits to its callback.
+#[derive(Debug, Clone)]
+pub enum DiscoveryEvent {
+    /// A server appeared or an existing one re-resolved with fresh
+    /// metadata. Re-resolution fires as TTLs refresh, typically every
+    /// 60-120 s depending on the responder.
+    ServerAnnounced(DiscoveredServer),
+
+    /// A server explicitly withdrew (its responder sent a goodbye
+    /// packet). Not every disappearance produces this event —
+    /// silently-dying servers just stop re-announcing.
+    ServerWithdrawn {
+        /// Full DNS-SD instance name, same shape as
+        /// `DiscoveredServer::instance_name`.
+        instance_name: String,
+    },
+}
+
+/// Live browser. Drops → stops listening and shuts the daemon down.
+pub struct Browser {
+    daemon: ServiceDaemon,
+    shutdown: Arc<AtomicBool>,
+    listener: Option<JoinHandle<()>>,
+}
+
+impl Browser {
+    /// Start browsing for `_rtl_tcp._tcp.local.` services. The callback
+    /// runs on a dedicated background thread — it's invoked for every
+    /// new / refreshed / withdrawn service.
+    ///
+    /// Callback errors are not propagated. If your callback can fail,
+    /// handle it inline (log, send to a channel, etc.).
+    pub fn start<F>(mut on_event: F) -> Result<Self, DiscoveryError>
+    where
+        F: FnMut(DiscoveryEvent) + Send + 'static,
+    {
+        let daemon = ServiceDaemon::new()?;
+        let receiver = daemon.browse(SERVICE_TYPE)?;
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let listener_shutdown = shutdown.clone();
+
+        let listener = thread::Builder::new()
+            .name("rtl_tcp-discovery-browser".into())
+            .spawn(move || {
+                // Poll with a short timeout so we notice `shutdown`
+                // flips within ~100 ms of Browser::stop / Drop.
+                //
+                // `mdns-sd` re-exports `flume::Receiver`; rather than
+                // name its error type explicitly we distinguish the
+                // two error cases (Timeout vs. Disconnected) by asking
+                // the receiver whether the channel is still live.
+                while !listener_shutdown.load(Ordering::Relaxed) {
+                    match receiver.recv_timeout(Duration::from_millis(100)) {
+                        Ok(event) => {
+                            if let Some(e) = translate(event) {
+                                on_event(e);
+                            }
+                        }
+                        Err(_) if receiver.is_disconnected() => {
+                            tracing::debug!("mDNS browser channel closed, exiting listener thread");
+                            return;
+                        }
+                        Err(_) => {}
+                    }
+                }
+            })
+            .map_err(DiscoveryError::Hostname)?;
+
+        Ok(Self {
+            daemon,
+            shutdown,
+            listener: Some(listener),
+        })
+    }
+
+    /// Stop browsing and shut down. Equivalent to dropping the `Browser`.
+    pub fn stop(mut self) {
+        self.initiate_shutdown();
+        if let Some(h) = self.listener.take() {
+            let _ = h.join();
+        }
+    }
+
+    fn initiate_shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.daemon.stop_browse(SERVICE_TYPE);
+        let _ = self.daemon.shutdown();
+    }
+}
+
+impl Drop for Browser {
+    fn drop(&mut self) {
+        self.initiate_shutdown();
+        if let Some(h) = self.listener.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Translate an `mdns-sd` event into our domain event.
+///
+/// Returns `None` for events that don't carry actionable info (search
+/// started / stopped) — those fire on daemon lifecycle and we only
+/// care about resolution / removal.
+fn translate(event: ServiceEvent) -> Option<DiscoveryEvent> {
+    match event {
+        ServiceEvent::ServiceResolved(resolved) => {
+            // `ServiceResolved` carries `Box<ResolvedService>` in
+            // mdns-sd 0.19. Extract its address set (HashSet<ScopedIp>)
+            // and flatten to plain IpAddr via ScopedIp::to_ip_addr(),
+            // dropping the scope metadata. Sort IPv4 first so clients
+            // that prefer v4 (or have issues with v6 link-local) pick
+            // the first address deterministically.
+            let mut addresses: Vec<IpAddr> = resolved
+                .get_addresses()
+                .iter()
+                .map(mdns_sd::ScopedIp::to_ip_addr)
+                .collect();
+            addresses.sort_by_key(|ip| match ip {
+                IpAddr::V4(_) => 0,
+                IpAddr::V6(_) => 1,
+            });
+
+            // TxtProperties exposes an iterator over (&TxtProperty);
+            // hand key/val strings to `TxtRecord::from_properties` so
+            // missing / unknown fields fall back to sensible defaults.
+            let txt = TxtRecord::from_properties(
+                resolved
+                    .get_properties()
+                    .iter()
+                    .map(|p| (p.key().to_string(), p.val_str().to_string())),
+            );
+
+            Some(DiscoveryEvent::ServerAnnounced(DiscoveredServer {
+                instance_name: resolved.get_fullname().to_string(),
+                hostname: resolved.get_hostname().to_string(),
+                port: resolved.get_port(),
+                addresses,
+                txt,
+                last_seen: Instant::now(),
+            }))
+        }
+        ServiceEvent::ServiceRemoved(_, name) => Some(DiscoveryEvent::ServerWithdrawn {
+            instance_name: name,
+        }),
+        ServiceEvent::SearchStarted(_)
+        | ServiceEvent::SearchStopped(_)
+        | ServiceEvent::ServiceFound(_, _) => None,
+        // `ServiceEvent` is marked `#[non_exhaustive]` upstream — any
+        // future variants are unknown-by-design and we ignore them
+        // rather than fail to compile on crate upgrades.
+        _ => None,
+    }
+}

--- a/crates/sdr-rtltcp-discovery/src/browser.rs
+++ b/crates/sdr-rtltcp-discovery/src/browser.rs
@@ -109,7 +109,7 @@ impl Browser {
                     }
                 }
             })
-            .map_err(DiscoveryError::Hostname)?;
+            .map_err(DiscoveryError::Io)?;
 
         Ok(Self {
             daemon,

--- a/crates/sdr-rtltcp-discovery/src/error.rs
+++ b/crates/sdr-rtltcp-discovery/src/error.rs
@@ -22,4 +22,11 @@ pub enum DiscoveryError {
     /// explicit nickname to bypass.
     #[error("failed to determine local hostname: {0}")]
     Hostname(std::io::Error),
+
+    /// Generic IO error — thread spawn failures, socket operations
+    /// that surface an unrelated error, etc. Distinct from `Hostname`
+    /// so a downstream error-matcher doesn't conflate "hostname
+    /// lookup failed" with "couldn't spawn a worker thread."
+    #[error("IO error: {0}")]
+    Io(std::io::Error),
 }

--- a/crates/sdr-rtltcp-discovery/src/error.rs
+++ b/crates/sdr-rtltcp-discovery/src/error.rs
@@ -1,0 +1,25 @@
+//! Error types.
+
+use thiserror::Error;
+
+/// Errors from advertiser / browser setup and runtime.
+#[derive(Debug, Error)]
+pub enum DiscoveryError {
+    /// Passed through from the underlying `mdns-sd` crate. Covers
+    /// daemon startup failures, bind errors, and malformed service
+    /// registrations.
+    #[error("mDNS daemon error: {0}")]
+    Mdns(#[from] mdns_sd::Error),
+
+    /// A TXT record field contained content that mDNS can't carry
+    /// (e.g. a NUL byte, a value too long for the 255-byte per-entry
+    /// cap, or a key with an `=` in it).
+    #[error("invalid TXT record field: {0}")]
+    InvalidTxt(String),
+
+    /// Local hostname lookup failed. We need it to build the mDNS
+    /// registration's default instance name; callers can pass an
+    /// explicit nickname to bypass.
+    #[error("failed to determine local hostname: {0}")]
+    Hostname(std::io::Error),
+}

--- a/crates/sdr-rtltcp-discovery/src/error.rs
+++ b/crates/sdr-rtltcp-discovery/src/error.rs
@@ -17,16 +17,11 @@ pub enum DiscoveryError {
     #[error("invalid TXT record field: {0}")]
     InvalidTxt(String),
 
-    /// Local hostname lookup failed. We need it to build the mDNS
-    /// registration's default instance name; callers can pass an
-    /// explicit nickname to bypass.
-    #[error("failed to determine local hostname: {0}")]
-    Hostname(std::io::Error),
-
     /// Generic IO error — thread spawn failures, socket operations
-    /// that surface an unrelated error, etc. Distinct from `Hostname`
-    /// so a downstream error-matcher doesn't conflate "hostname
-    /// lookup failed" with "couldn't spawn a worker thread."
+    /// that surface an unrelated error, etc. Hostname lookup no
+    /// longer errors (it uses `libc::gethostname` + a
+    /// `"localhost"` fallback), but kept broad so future discovery
+    /// paths can reuse.
     #[error("IO error: {0}")]
     Io(std::io::Error),
 }

--- a/crates/sdr-rtltcp-discovery/src/lib.rs
+++ b/crates/sdr-rtltcp-discovery/src/lib.rs
@@ -112,6 +112,21 @@ mod tests {
         use std::sync::{Arc, Mutex};
         use std::time::{Duration, Instant};
 
+        /// Arbitrary high port for the fake advertisement — outside
+        /// the upstream rtl_tcp default (1234) so a stray real server
+        /// doesn't alias this test.
+        const MDNS_ROUNDTRIP_PORT: u16 = 31_234;
+        /// How long to wait for mDNS propagation across the loopback
+        /// multicast path. Typical resolution is 1-2 s; 5 s is slack
+        /// for slower loopbacks / loaded machines.
+        const MDNS_PROPAGATION_TIMEOUT: Duration = Duration::from_secs(5);
+        /// Poll cadence while waiting. Short enough that the test
+        /// doesn't sleep meaningfully past the actual resolution.
+        const MDNS_POLL_INTERVAL: Duration = Duration::from_millis(100);
+        /// Expected gain count in the TXT payload — R820T standard
+        /// step count.
+        const R820T_GAIN_COUNT: u32 = 29;
+
         let observed: Arc<Mutex<Vec<DiscoveredServer>>> = Arc::new(Mutex::new(Vec::new()));
         let obs_clone = observed.clone();
         let browser = Browser::start(move |event| {
@@ -125,27 +140,25 @@ mod tests {
 
         // Advertise a fake server.
         let _advertiser = Advertiser::announce(AdvertiseOptions {
-            port: 31234,
+            port: MDNS_ROUNDTRIP_PORT,
             instance_name: "sdr-rtltcp-integration-test".into(),
             hostname: String::new(),
             txt: TxtRecord {
                 tuner: "R820T".into(),
                 version: env!("CARGO_PKG_VERSION").into(),
-                gains: 29,
+                gains: R820T_GAIN_COUNT,
                 nickname: "integration-test-nick".into(),
                 txbuf: None,
             },
         })
         .expect("announce");
 
-        // Give mDNS ~5 s to propagate. Typical resolution is 1-2 s on
-        // loopback.
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + MDNS_PROPAGATION_TIMEOUT;
         while Instant::now() < deadline {
             if !observed.lock().unwrap().is_empty() {
                 break;
             }
-            std::thread::sleep(Duration::from_millis(100));
+            std::thread::sleep(MDNS_POLL_INTERVAL);
         }
 
         browser.stop();
@@ -156,9 +169,9 @@ mod tests {
             "browser never observed the advertised service"
         );
         let server = &seen[0];
-        assert_eq!(server.port, 31234);
+        assert_eq!(server.port, MDNS_ROUNDTRIP_PORT);
         assert_eq!(server.txt.tuner, "R820T");
         assert_eq!(server.txt.nickname, "integration-test-nick");
-        assert_eq!(server.txt.gains, 29);
+        assert_eq!(server.txt.gains, R820T_GAIN_COUNT);
     }
 }

--- a/crates/sdr-rtltcp-discovery/src/lib.rs
+++ b/crates/sdr-rtltcp-discovery/src/lib.rs
@@ -44,7 +44,7 @@ mod browser;
 mod error;
 mod txt;
 
-pub use advertiser::{AdvertiseOptions, Advertiser};
+pub use advertiser::{AdvertiseOptions, Advertiser, local_hostname};
 pub use browser::{Browser, DiscoveredServer, DiscoveryEvent};
 pub use error::DiscoveryError;
 pub use txt::TxtRecord;
@@ -59,6 +59,32 @@ pub const SERVICE_TYPE: &str = "_rtl_tcp._tcp.local.";
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn local_hostname_returns_bare_non_empty_name_without_local_suffix() {
+        // Contract: non-empty, no trailing `.local.` / `.local`.
+        // `libc::gethostname` on CI runners and dev machines returns a
+        // real name; if the syscall ever failed it'd fall back to
+        // "localhost" which still satisfies the contract.
+        let host = local_hostname();
+        assert!(!host.is_empty(), "local_hostname() returned empty string");
+        // clippy::case_sensitive_file_extension_comparisons wants
+        // `.rsplit('.').next()` — but this is a hostname-suffix check
+        // that is genuinely case-sensitive per DNS labels (though
+        // mDNS normalizes case in practice, our local_hostname()
+        // contract is byte-exact). Allow the lint locally.
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
+        let ends_bad = host.ends_with(".local.") || host.ends_with(".local");
+        assert!(
+            !ends_bad,
+            "local_hostname() must return bare name, not mDNS-qualified: {host:?}"
+        );
+        // mDNS DNS-SD instance-name components aren't allowed to
+        // contain NUL bytes. gethostname should never produce one, but
+        // our UTF-8 trim path should have stripped any interior NUL
+        // regardless.
+        assert!(!host.contains('\0'));
+    }
 
     #[test]
     fn service_type_matches_dns_sd_shape() {

--- a/crates/sdr-rtltcp-discovery/src/lib.rs
+++ b/crates/sdr-rtltcp-discovery/src/lib.rs
@@ -1,0 +1,138 @@
+#![allow(
+    // Service / event names duplicate across docs and code; no gain
+    // from backtick-wrapping every mention.
+    clippy::doc_markdown,
+    // `AdvertiseOptions` is moved-in deliberately; Browser & Advertiser
+    // both have owned state paths that don't consume the input fully.
+    clippy::needless_pass_by_value,
+    // Folding `ServiceEvent::SearchStarted | SearchStopped | ServiceFound => None`
+    // with the `_ => None` catch-all loses the explicit variant list we
+    // want future-readers to see.
+    clippy::match_same_arms
+)]
+//! mDNS/DNS-SD discovery for `rtl_tcp`-compatible servers.
+//!
+//! Provides:
+//! - [`Advertiser`] — used by [`sdr-server-rtltcp`][server] to announce
+//!   a running server on the local network
+//! - [`Browser`] — used by [`sdr-source-network`]'s rtl_tcp client to
+//!   find servers without manually typing host:port
+//!
+//! Service type: `_rtl_tcp._tcp.local.` This is not an IANA-registered
+//! type — the SDR ecosystem uses it by convention (ShinySDR,
+//! rtl_tcp_client, etc.). Picking the same string means interop with
+//! those tools where they implement discovery.
+//!
+//! [server]: https://docs.rs/sdr-server-rtltcp
+//!
+//! ## Why a separate crate
+//!
+//! Keeps [`sdr-server-rtltcp`][server] free of the `mdns-sd` dependency
+//! tree — a CLI user who wants `sdr-rtl-tcp` without LAN advertising
+//! can build without it. The UI composes both crates when it wants
+//! discovery.
+//!
+//! ## Pure-Rust stack
+//!
+//! Uses `mdns-sd` — no Avahi / Bonjour system dependency, no async
+//! runtime. The daemon runs on its own thread internally; the
+//! [`Browser`] spawns a second thread that translates `mdns-sd`'s
+//! event channel into our domain events.
+
+mod advertiser;
+mod browser;
+mod error;
+mod txt;
+
+pub use advertiser::{AdvertiseOptions, Advertiser};
+pub use browser::{Browser, DiscoveredServer, DiscoveryEvent};
+pub use error::DiscoveryError;
+pub use txt::TxtRecord;
+
+/// Fully-qualified mDNS service type used by every rtl_tcp
+/// advertisement. This string is load-bearing for interop — any other
+/// tool that wants to browse us (or that we want to browse) must use
+/// the same literal.
+pub const SERVICE_TYPE: &str = "_rtl_tcp._tcp.local.";
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_type_matches_dns_sd_shape() {
+        // `_service._transport.domain.` — trailing dot means
+        // fully-qualified in DNS. This exact string is used for both
+        // registration and browse queries; regressing it silently
+        // breaks interop.
+        assert_eq!(SERVICE_TYPE, "_rtl_tcp._tcp.local.");
+        assert!(SERVICE_TYPE.starts_with("_rtl_tcp."));
+        assert!(SERVICE_TYPE.contains("._tcp."));
+        assert!(SERVICE_TYPE.ends_with("local."));
+    }
+
+    /// Live integration test: start an Advertiser on localhost, start
+    /// a Browser, and verify we see our own advertisement come back.
+    ///
+    /// `#[ignore]` because it requires a functioning mDNS multicast
+    /// layer (UDP 5353 on 224.0.0.251) — works fine on dev machines
+    /// but unreliable in sandboxed CI environments.
+    ///
+    /// Run manually with `cargo test --ignored mdns_roundtrip`.
+    #[test]
+    #[ignore = "needs multicast network; run with --ignored locally"]
+    fn mdns_roundtrip() {
+        use std::sync::{Arc, Mutex};
+        use std::time::{Duration, Instant};
+
+        let observed: Arc<Mutex<Vec<DiscoveredServer>>> = Arc::new(Mutex::new(Vec::new()));
+        let obs_clone = observed.clone();
+        let browser = Browser::start(move |event| {
+            if let DiscoveryEvent::ServerAnnounced(s) = event
+                && s.instance_name.contains("sdr-rtltcp-integration-test")
+            {
+                obs_clone.lock().unwrap().push(s);
+            }
+        })
+        .expect("start browser");
+
+        // Advertise a fake server.
+        let _advertiser = Advertiser::announce(AdvertiseOptions {
+            port: 31234,
+            instance_name: "sdr-rtltcp-integration-test".into(),
+            hostname: String::new(),
+            txt: TxtRecord {
+                tuner: "R820T".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                gains: 29,
+                nickname: "integration-test-nick".into(),
+                txbuf: None,
+            },
+        })
+        .expect("announce");
+
+        // Give mDNS ~5 s to propagate. Typical resolution is 1-2 s on
+        // loopback.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if !observed.lock().unwrap().is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        browser.stop();
+
+        let seen = observed.lock().unwrap();
+        assert!(
+            !seen.is_empty(),
+            "browser never observed the advertised service"
+        );
+        let server = &seen[0];
+        assert_eq!(server.port, 31234);
+        assert_eq!(server.txt.tuner, "R820T");
+        assert_eq!(server.txt.nickname, "integration-test-nick");
+        assert_eq!(server.txt.gains, 29);
+    }
+}

--- a/crates/sdr-rtltcp-discovery/src/txt.rs
+++ b/crates/sdr-rtltcp-discovery/src/txt.rs
@@ -1,0 +1,229 @@
+//! TXT record schema for `_rtl_tcp._tcp.local.` advertisements.
+//!
+//! Keys are kept short (under 10 chars) because mDNS packs TXT entries
+//! into a single DNS record limited to 400 bytes in practice. Under
+//! that limit, clients see the record in one resolve without follow-up
+//! queries.
+
+use std::collections::HashMap;
+
+use crate::error::DiscoveryError;
+
+/// TXT record payload attached to a server advertisement. Each field
+/// serializes to `key=value` in the mDNS TXT record; missing fields
+/// are omitted entirely so older clients don't see empty-string junk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxtRecord {
+    /// Tuner family as reported by the dongle (e.g. "R820T", "E4000").
+    /// Lets the client show "this is an R820T" without connecting.
+    pub tuner: String,
+
+    /// Advertiser version — our crate version. Clients can use this to
+    /// show "running sdr-rs 0.x.y" vs. "unknown rtl_tcp source."
+    pub version: String,
+
+    /// Number of discrete gain steps the tuner exposes. The actual
+    /// gain table is NOT in TXT — clients assume the R820T table for
+    /// dB display or drive via set-gain-by-index and show step N of M.
+    pub gains: u32,
+
+    /// Human-readable nickname (user-editable). Defaults to the host's
+    /// hostname on the server side; clients render this as the primary
+    /// label in the discovered-servers list.
+    pub nickname: String,
+
+    /// Optional buffer-depth hint (bytes) for latency awareness.
+    pub txbuf: Option<usize>,
+}
+
+impl TxtRecord {
+    /// Maximum combined TXT byte count we'll emit. mDNS DNS records can
+    /// be larger in theory, but staying under 400 bytes keeps the whole
+    /// registration in a single UDP packet and avoids the "truncated,
+    /// follow up with a query" path that some clients handle poorly.
+    pub const MAX_TOTAL_BYTES: usize = 400;
+
+    /// Render as an `mdns-sd` properties map. Omits `txbuf` when None
+    /// so the field is simply absent rather than stored as `"txbuf="`.
+    /// Returns `Err(InvalidTxt)` if any value contains a NUL byte or
+    /// is too long for a single TXT entry (255 bytes).
+    pub fn to_properties(&self) -> Result<HashMap<String, String>, DiscoveryError> {
+        let mut m = HashMap::new();
+        insert_checked(&mut m, "tuner", &self.tuner)?;
+        insert_checked(&mut m, "version", &self.version)?;
+        insert_checked(&mut m, "gains", &self.gains.to_string())?;
+        insert_checked(&mut m, "nickname", &self.nickname)?;
+        if let Some(n) = self.txbuf {
+            insert_checked(&mut m, "txbuf", &n.to_string())?;
+        }
+        let total: usize = m.iter().map(|(k, v)| k.len() + v.len() + 2).sum();
+        if total > Self::MAX_TOTAL_BYTES {
+            return Err(DiscoveryError::InvalidTxt(format!(
+                "TXT record total {total} bytes exceeds {} byte cap",
+                Self::MAX_TOTAL_BYTES
+            )));
+        }
+        Ok(m)
+    }
+
+    /// Parse an mDNS properties slice back into a `TxtRecord`. Missing
+    /// fields get sensible defaults ("unknown" / 0) so a partial /
+    /// corrupt advertisement still renders instead of dropping the
+    /// server entry.
+    pub fn from_properties<I, K, V>(properties: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let mut tuner = String::from("unknown");
+        let mut version = String::from("unknown");
+        let mut gains: u32 = 0;
+        let mut nickname = String::new();
+        let mut txbuf: Option<usize> = None;
+        for (k, v) in properties {
+            match k.as_ref() {
+                "tuner" => tuner = v.as_ref().to_string(),
+                "version" => version = v.as_ref().to_string(),
+                "gains" => gains = v.as_ref().parse().unwrap_or(0),
+                "nickname" => nickname = v.as_ref().to_string(),
+                "txbuf" => txbuf = v.as_ref().parse().ok(),
+                _ => {
+                    tracing::trace!(
+                        key = %k.as_ref(),
+                        "unknown rtl_tcp TXT key, ignoring"
+                    );
+                }
+            }
+        }
+        Self {
+            tuner,
+            version,
+            gains,
+            nickname,
+            txbuf,
+        }
+    }
+}
+
+/// TXT entry checker — rejects NUL bytes (mDNS doesn't allow them in
+/// keys OR values) and anything over 255 bytes for a single entry.
+fn insert_checked(
+    m: &mut HashMap<String, String>,
+    key: &str,
+    value: &str,
+) -> Result<(), DiscoveryError> {
+    if key.contains('\0') || value.contains('\0') {
+        return Err(DiscoveryError::InvalidTxt(format!(
+            "key or value for `{key}` contains NUL byte"
+        )));
+    }
+    let entry_len = key.len() + value.len() + 1; // +1 for the `=`
+    if entry_len > 255 {
+        return Err(DiscoveryError::InvalidTxt(format!(
+            "`{key}` entry is {entry_len} bytes, exceeds 255 byte cap"
+        )));
+    }
+    m.insert(key.to_string(), value.to_string());
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn sample() -> TxtRecord {
+        TxtRecord {
+            tuner: "R820T".into(),
+            version: "0.1.0".into(),
+            gains: 29,
+            nickname: "home-scanner".into(),
+            txbuf: Some(128 * 1024),
+        }
+    }
+
+    #[test]
+    fn to_properties_includes_all_fields() {
+        let props = sample().to_properties().unwrap();
+        assert_eq!(props.get("tuner").map(String::as_str), Some("R820T"));
+        assert_eq!(props.get("version").map(String::as_str), Some("0.1.0"));
+        assert_eq!(props.get("gains").map(String::as_str), Some("29"));
+        assert_eq!(
+            props.get("nickname").map(String::as_str),
+            Some("home-scanner")
+        );
+        assert_eq!(props.get("txbuf").map(String::as_str), Some("131072"));
+    }
+
+    #[test]
+    fn to_properties_omits_missing_txbuf() {
+        let mut r = sample();
+        r.txbuf = None;
+        let props = r.to_properties().unwrap();
+        assert!(!props.contains_key("txbuf"));
+    }
+
+    #[test]
+    fn from_properties_fills_defaults_for_missing_fields() {
+        let r = TxtRecord::from_properties(std::iter::empty::<(&str, &str)>());
+        assert_eq!(r.tuner, "unknown");
+        assert_eq!(r.version, "unknown");
+        assert_eq!(r.gains, 0);
+        assert_eq!(r.nickname, "");
+        assert_eq!(r.txbuf, None);
+    }
+
+    #[test]
+    fn roundtrip_preserves_fields() {
+        let original = sample();
+        let props = original.to_properties().unwrap();
+        let roundtripped =
+            TxtRecord::from_properties(props.iter().map(|(k, v)| (k.clone(), v.clone())));
+        assert_eq!(original, roundtripped);
+    }
+
+    #[test]
+    fn rejects_nul_bytes_in_values() {
+        let mut r = sample();
+        r.nickname = "has\0nul".into();
+        assert!(matches!(
+            r.to_properties(),
+            Err(DiscoveryError::InvalidTxt(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_single_entry() {
+        // Single entry above 255 bytes should fail. Nickname is the
+        // user-controlled one most likely to be pathological.
+        let mut r = sample();
+        r.nickname = "x".repeat(300);
+        assert!(matches!(
+            r.to_properties(),
+            Err(DiscoveryError::InvalidTxt(_))
+        ));
+    }
+
+    #[test]
+    fn from_properties_ignores_unknown_keys() {
+        // A server running a future schema that added a `compression`
+        // key shouldn't break our client — we just ignore it.
+        let r = TxtRecord::from_properties([
+            ("tuner", "R820T"),
+            ("version", "2.0.0"),
+            ("compression", "zstd"),
+            ("future_field", "surprise"),
+        ]);
+        assert_eq!(r.tuner, "R820T");
+        assert_eq!(r.version, "2.0.0");
+    }
+
+    #[test]
+    fn gains_parse_failure_becomes_zero_not_error() {
+        // Corrupt / non-numeric `gains` shouldn't prevent the server
+        // from showing up in the list — just render "0 gain steps."
+        let r = TxtRecord::from_properties([("gains", "not-a-number")]);
+        assert_eq!(r.gains, 0);
+    }
+}

--- a/crates/sdr-server-rtltcp/Cargo.toml
+++ b/crates/sdr-server-rtltcp/Cargo.toml
@@ -19,6 +19,10 @@ rusb.workspace = true
 # Binary only — enables `-s info` style env-filter logging for the CLI.
 # Kept in regular deps (not dev-deps) because the `[[bin]]` target needs it.
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+# mDNS advertise for the `sdr-rtl-tcp` bin. The lib crate stays free of
+# this dep; only the binary composes it (so a downstream consumer that
+# just wants the Server API doesn't pull in mdns-sd).
+sdr-rtltcp-discovery.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-server-rtltcp/Cargo.toml
+++ b/crates/sdr-server-rtltcp/Cargo.toml
@@ -6,6 +6,18 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# Default includes `mdns-advertise` so the CLI binary and sdr-rs'
+# bundled build keep their announce-by-default UX. Library consumers
+# who only want the Server API can build with
+# `default-features = false` and skip the mdns-sd dep tree entirely.
+default = ["mdns-advertise"]
+# Pulls in `sdr-rtltcp-discovery` so the bin target can advertise via
+# mDNS. The library itself never references this dep; gating it here
+# enforces the stated design intent ("lib stays free of this dep")
+# at the manifest level rather than relying on source-level hygiene.
+mdns-advertise = ["dep:sdr-rtltcp-discovery"]
+
 [dependencies]
 sdr-rtlsdr.workspace = true
 thiserror.workspace = true
@@ -19,10 +31,9 @@ rusb.workspace = true
 # Binary only — enables `-s info` style env-filter logging for the CLI.
 # Kept in regular deps (not dev-deps) because the `[[bin]]` target needs it.
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-# mDNS advertise for the `sdr-rtl-tcp` bin. The lib crate stays free of
-# this dep; only the binary composes it (so a downstream consumer that
-# just wants the Server API doesn't pull in mdns-sd).
-sdr-rtltcp-discovery.workspace = true
+# Optional — only pulled in when `mdns-advertise` is enabled. The bin
+# target requires this feature (see `required-features` below).
+sdr-rtltcp-discovery = { workspace = true, optional = true }
 
 [lints]
 workspace = true
@@ -30,4 +41,9 @@ workspace = true
 [[bin]]
 name = "sdr-rtl-tcp"
 path = "src/bin/sdr-rtl-tcp.rs"
+# The bin invokes `sdr_rtltcp_discovery::{Advertiser, ...}` directly,
+# so its build MUST enable `mdns-advertise`. This ties the feature to
+# the binary target specifically without forcing library consumers to
+# opt out.
+required-features = ["mdns-advertise"]
 

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -40,7 +40,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use sdr_rtltcp_discovery::{AdvertiseOptions, Advertiser, TxtRecord};
+use sdr_rtltcp_discovery::{AdvertiseOptions, Advertiser, TxtRecord, local_hostname};
 use sdr_server_rtltcp::server::{DEFAULT_SAMPLE_RATE_HZ, Server, ServerConfig};
 use sdr_server_rtltcp::{DEFAULT_BUFFER_CAPACITY, DEFAULT_PORT};
 
@@ -370,10 +370,13 @@ fn announce_over_mdns(
     discovery: &DiscoveryOptions,
 ) -> Result<Advertiser, sdr_rtltcp_discovery::DiscoveryError> {
     let tuner = server.tuner_info();
-    let nickname = discovery
-        .nickname
-        .clone()
-        .unwrap_or_else(|| "sdr-rtl-tcp".to_string());
+    // Fallback nickname: system hostname via libc::gethostname.
+    // Previously this was hardcoded to "sdr-rtl-tcp" — which meant
+    // two stock servers on the same LAN would show up as the same
+    // label in the discovery list (and could collide on the DNS-SD
+    // instance name). Matches the help text's "defaults to hostname"
+    // promise.
+    let nickname = discovery.nickname.clone().unwrap_or_else(local_hostname);
     let txt = TxtRecord {
         tuner: tuner.name.clone(),
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -384,7 +387,7 @@ fn announce_over_mdns(
     Advertiser::announce(AdvertiseOptions {
         port: server.bind_address().port(),
         instance_name: format!("{nickname} rtl-sdr"),
-        hostname: String::new(), // auto-derive from /etc/hostname
+        hostname: String::new(), // auto-derive in the advertiser
         txt,
     })
 }

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -40,6 +40,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use sdr_rtltcp_discovery::{AdvertiseOptions, Advertiser, TxtRecord};
 use sdr_server_rtltcp::server::{DEFAULT_SAMPLE_RATE_HZ, Server, ServerConfig};
 use sdr_server_rtltcp::{DEFAULT_BUFFER_CAPACITY, DEFAULT_PORT};
 
@@ -101,6 +102,14 @@ fn usage(exit_code: i32) -> ! {
         out,
         "    -D           Enable direct sampling (mode 2, Q branch)"
     );
+    let _ = writeln!(
+        out,
+        "    -N <name>    mDNS nickname for this server (defaults to hostname)"
+    );
+    let _ = writeln!(
+        out,
+        "    --no-announce  Skip mDNS advertisement (default: advertise)"
+    );
     let _ = writeln!(out, "    -h, --help   Show this help");
     std::process::exit(exit_code);
 }
@@ -119,13 +128,31 @@ fn main() -> ExitCode {
     if args.iter().any(|a| a == "-h" || a == "--help") {
         usage(0);
     }
-    let Ok(config) = parse_args(&args) else {
+    let Ok(parsed) = parse_args(&args) else {
         usage(1);
     };
+    let (config, discovery) = parsed;
 
     match Server::start(config) {
         Ok(server) => {
             tracing::info!(bind = %server.bind_address(), "rtl_tcp server running");
+
+            // Advertise via mDNS if the user didn't opt out. Keep the
+            // Advertiser alive for the rest of main's scope so its
+            // Drop-based unregister fires on normal shutdown.
+            let _advertiser = if discovery.announce {
+                match announce_over_mdns(&server, &discovery) {
+                    Ok(a) => Some(a),
+                    Err(e) => {
+                        tracing::warn!(%e, "mDNS advertise failed — server is running but won't be auto-discovered");
+                        None
+                    }
+                }
+            } else {
+                tracing::info!("mDNS advertise disabled (--no-announce)");
+                None
+            };
+
             // Install the signal handler BEFORE entering the sleep loop.
             // The loop has no alternate shutdown path, so a failed install
             // leaves the process unkillable without SIGKILL — fatal, not
@@ -207,10 +234,32 @@ fn ctrlc_handler() -> std::io::Result<()> {
 #[derive(Debug)]
 struct ParseError;
 
-fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<ServerConfig, ParseError> {
+/// CLI-only mDNS settings. Lives alongside `ServerConfig` in the parsed
+/// result because the server crate deliberately doesn't know about
+/// discovery (different dep tree).
+#[derive(Debug, Clone)]
+struct DiscoveryOptions {
+    /// `--no-announce` flips this off. Default: advertise.
+    announce: bool,
+    /// `-N <name>` override. None → derive from system hostname at
+    /// advertise time.
+    nickname: Option<String>,
+}
+
+impl Default for DiscoveryOptions {
+    fn default() -> Self {
+        Self {
+            announce: true,
+            nickname: None,
+        }
+    }
+}
+
+fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<(ServerConfig, DiscoveryOptions), ParseError> {
     // `default_loopback()` seeds `initial` via `InitialDeviceState::default()`,
     // which already uses `DEFAULT_SAMPLE_RATE_HZ`. No need to re-assign here.
     let mut config = ServerConfig::default_loopback();
+    let mut discovery = DiscoveryOptions::default();
 
     let mut i = 0;
     while i < args.len() {
@@ -296,11 +345,48 @@ fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<ServerConfig, ParseError> {
                 config.initial.direct_sampling = DIRECT_SAMPLING_Q_BRANCH;
                 i += 1;
             }
+            "-N" => {
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
+                discovery.nickname = Some(v.to_string());
+                i += 2;
+            }
+            "--no-announce" => {
+                discovery.announce = false;
+                i += 1;
+            }
             _ => return Err(ParseError),
         }
     }
 
-    Ok(config)
+    Ok((config, discovery))
+}
+
+/// Register the running server in mDNS so clients can discover it
+/// without manual host:port entry. Builds the instance name from the
+/// user-provided nickname (falling back to "sdr-rtl-tcp") and pulls
+/// tuner metadata from `Server::tuner_info()`.
+fn announce_over_mdns(
+    server: &Server,
+    discovery: &DiscoveryOptions,
+) -> Result<Advertiser, sdr_rtltcp_discovery::DiscoveryError> {
+    let tuner = server.tuner_info();
+    let nickname = discovery
+        .nickname
+        .clone()
+        .unwrap_or_else(|| "sdr-rtl-tcp".to_string());
+    let txt = TxtRecord {
+        tuner: tuner.name.clone(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        gains: tuner.gain_count,
+        nickname: nickname.clone(),
+        txbuf: None,
+    };
+    Advertiser::announce(AdvertiseOptions {
+        port: server.bind_address().port(),
+        instance_name: format!("{nickname} rtl-sdr"),
+        hostname: String::new(), // auto-derive from /etc/hostname
+        txt,
+    })
 }
 
 /// Port of upstream `atofs()` — accepts `k` / `M` / `G` suffix multipliers.
@@ -362,7 +448,7 @@ mod tests {
 
     #[test]
     fn parse_defaults_are_loopback_and_upstream_port() {
-        let cfg = parse_args::<&str>(&[]).unwrap();
+        let (cfg, _disc) = parse_args::<&str>(&[]).unwrap();
         assert_eq!(cfg.bind.ip().to_string(), "127.0.0.1");
         assert_eq!(cfg.bind.port(), DEFAULT_PORT);
     }
@@ -370,21 +456,21 @@ mod tests {
     #[test]
     fn parse_auto_gain_is_none() {
         let args = vec!["-g".to_string(), "0".to_string()];
-        let cfg = parse_args(&args).unwrap();
+        let (cfg, _disc) = parse_args(&args).unwrap();
         assert!(cfg.initial.gain_tenths_db.is_none());
     }
 
     #[test]
     fn parse_manual_gain_rounds_to_tenths() {
         let args = vec!["-g".to_string(), "28.2".to_string()];
-        let cfg = parse_args(&args).unwrap();
+        let (cfg, _disc) = parse_args(&args).unwrap();
         assert_eq!(cfg.initial.gain_tenths_db, Some(282));
     }
 
     #[test]
     fn parse_direct_sampling_hardcodes_mode_2() {
         let args = vec!["-D".to_string()];
-        let cfg = parse_args(&args).unwrap();
+        let (cfg, _disc) = parse_args(&args).unwrap();
         assert_eq!(cfg.initial.direct_sampling, 2);
     }
 
@@ -446,7 +532,7 @@ mod tests {
             ("-5", Some(-50)),
         ] {
             let args = vec!["-g".to_string(), v.to_string()];
-            let cfg = parse_args(&args).unwrap();
+            let (cfg, _disc) = parse_args(&args).unwrap();
             assert_eq!(cfg.initial.gain_tenths_db, want, "gain {v}");
         }
     }
@@ -537,7 +623,7 @@ mod tests {
         .iter()
         .map(ToString::to_string)
         .collect();
-        let cfg = parse_args(&args).unwrap();
+        let (cfg, _disc) = parse_args(&args).unwrap();
         assert_eq!(cfg.bind.ip().to_string(), "10.0.0.5");
         assert_eq!(cfg.bind.port(), 12_345);
         assert_eq!(cfg.initial.center_freq_hz, 433_920_000);
@@ -551,9 +637,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_args_discovery_defaults_on() {
+        let (_cfg, disc) = parse_args::<&str>(&[]).unwrap();
+        assert!(disc.announce, "mDNS advertise should default to on");
+        assert!(disc.nickname.is_none());
+    }
+
+    #[test]
+    fn parse_no_announce_flag_disables_mdns() {
+        let args = vec!["--no-announce".to_string()];
+        let (_cfg, disc) = parse_args(&args).unwrap();
+        assert!(!disc.announce);
+    }
+
+    #[test]
+    fn parse_nickname_flag_captures_name() {
+        let args = vec!["-N".to_string(), "attic-pi".to_string()];
+        let (_cfg, disc) = parse_args(&args).unwrap();
+        assert_eq!(disc.nickname.as_deref(), Some("attic-pi"));
+    }
+
+    #[test]
     fn parse_bind_override() {
         let args = vec!["-a".to_string(), "0.0.0.0".to_string()];
-        let cfg = parse_args(&args).unwrap();
+        let (cfg, _disc) = parse_args(&args).unwrap();
         assert_eq!(cfg.bind.ip().to_string(), "0.0.0.0");
     }
 }

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -40,5 +40,5 @@ pub use protocol::{
 };
 pub use server::{
     DEFAULT_BUFFER_CAPACITY, DEFAULT_CENTER_FREQ_HZ, DEFAULT_SAMPLE_RATE_HZ, InitialDeviceState,
-    READ_BUFFER_LEN, Server, ServerConfig, ServerStats,
+    READ_BUFFER_LEN, Server, ServerConfig, ServerStats, TunerAdvertiseInfo,
 };

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -155,6 +155,18 @@ pub struct ServerStats {
     pub last_command: Option<(CommandOp, Instant)>,
 }
 
+/// Tuner metadata captured at open time, exposed for callers that
+/// need to advertise it (e.g. the `sdr-rtltcp-discovery` advertiser
+/// populating mDNS TXT fields).
+#[derive(Debug, Clone)]
+pub struct TunerAdvertiseInfo {
+    /// Human-readable tuner name, e.g. `"R820T"`. Rendered from the
+    /// driver's `TunerType` enum via `Debug`.
+    pub name: String,
+    /// Number of discrete gain steps the tuner exposes.
+    pub gain_count: u32,
+}
+
 /// Running server handle.
 pub struct Server {
     shutdown: Arc<AtomicBool>,
@@ -162,6 +174,7 @@ pub struct Server {
     accept_thread: Option<JoinHandle<()>>,
     stats: Arc<Mutex<ServerStats>>,
     bind: SocketAddr,
+    tuner: TunerAdvertiseInfo,
 }
 
 impl Server {
@@ -203,10 +216,14 @@ impl Server {
         let mut device = RtlSdrDevice::open(config.device_index)?;
         apply_initial_state(&mut device, &config.initial)?;
 
+        let tuner = TunerAdvertiseInfo {
+            name: format!("{:?}", device.tuner_type()),
+            gain_count: device.tuner_gains().len() as u32,
+        };
         tracing::info!(
             bind = %actual_bind,
-            tuner = ?device.tuner_type(),
-            gain_count = device.tuner_gains().len(),
+            tuner = %tuner.name,
+            gain_count = tuner.gain_count,
             "rtl_tcp server listening"
         );
 
@@ -237,6 +254,7 @@ impl Server {
             accept_thread: Some(accept_thread),
             stats,
             bind: actual_bind,
+            tuner,
         })
     }
 
@@ -248,6 +266,14 @@ impl Server {
     /// The address the server is bound to.
     pub fn bind_address(&self) -> SocketAddr {
         self.bind
+    }
+
+    /// Tuner metadata captured at `start()` time. Callers that want to
+    /// advertise the server (e.g. via mDNS) read this for the tuner
+    /// name + gain-count fields; we don't pull in a discovery dep here
+    /// to keep the server crate free of mDNS deps.
+    pub fn tuner_info(&self) -> &TunerAdvertiseInfo {
+        &self.tuner
     }
 
     /// Has the accept thread exited (either via `stop()` or an

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -1065,6 +1065,24 @@ impl Source for RtlTcpSource {
         rx.drain(..take_bytes);
         Ok(take_pairs)
     }
+
+    /// Route the workspace-wide "set gain" message to the remote dongle
+    /// via the typed setter. Implementing these Source-trait hooks
+    /// means the existing UI controls (which dispatch
+    /// `UiToDsp::SetGain` / `SetAgc` / `SetPpmCorrection` to the
+    /// active `Source`) "just work" when the active source is an
+    /// rtl_tcp client — no source-type branching in the controller.
+    fn set_gain(&mut self, gain_tenths: i32) -> Result<(), SourceError> {
+        self.set_tuner_gain_tenths_db(gain_tenths)
+    }
+
+    fn set_gain_mode(&mut self, manual: bool) -> Result<(), SourceError> {
+        self.set_gain_mode_manual(manual)
+    }
+
+    fn set_ppm_correction(&mut self, ppm: i32) -> Result<(), SourceError> {
+        self.set_freq_correction_ppm(ppm)
+    }
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -48,6 +48,9 @@ sdr-source-rtlsdr.workspace = true
 sdr-sink-audio.workspace = true
 sdr-radioreference.workspace = true
 sdr-transcription.workspace = true
+# Discovery for the rtl_tcp client picker — Browser events feed the
+# AdwExpanderRow under the source panel.
+sdr-rtltcp-discovery.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -1,4 +1,5 @@
-//! Source device configuration panel — device selector, RTL-SDR / Network controls.
+//! Source device configuration panel — device selector, RTL-SDR /
+//! Network / File / RTL-TCP controls.
 
 use gtk4::glib;
 use gtk4::prelude::*;
@@ -11,6 +12,8 @@ const DEVICE_RTLSDR: u32 = 0;
 const DEVICE_NETWORK: u32 = 1;
 /// Device selector index for File.
 const DEVICE_FILE: u32 = 2;
+/// Device selector index for RTL-TCP (rtl_tcp-protocol network client).
+pub const DEVICE_RTLTCP: u32 = 3;
 
 /// Default gain in dB.
 const DEFAULT_GAIN_DB: f64 = 0.0;
@@ -77,6 +80,12 @@ pub struct SourcePanel {
     pub decimation_row: adw::ComboRow,
     /// Toggle to start/stop IQ recording.
     pub record_iq_row: adw::SwitchRow,
+    /// Discovered `rtl_tcp` servers (live from mDNS). Collapsed by
+    /// default; expands when servers are seen.
+    pub rtl_tcp_discovered_row: adw::ExpanderRow,
+    /// Connection-state label for `rtl_tcp` (Connecting / Connected /
+    /// Retrying / Failed / Disconnected).
+    pub rtl_tcp_status_row: adw::ActionRow,
 }
 
 /// Default sample rate selector index (2.4 MHz = index 7).
@@ -223,14 +232,25 @@ fn connect_device_visibility(
             let is_rtlsdr = selected == DEVICE_RTLSDR;
             let is_network = selected == DEVICE_NETWORK;
             let is_file = selected == DEVICE_FILE;
+            let is_rtltcp = selected == DEVICE_RTLTCP;
 
-            sample_rate_row.set_visible(is_rtlsdr);
-            gain_row.set_visible(is_rtlsdr);
-            agc_row.set_visible(is_rtlsdr);
-            ppm_row.set_visible(is_rtlsdr);
+            // Tuning controls are meaningful for both the local dongle
+            // AND a remote rtl_tcp server (they route through the
+            // Source trait's set_gain / set_gain_mode / set_ppm_correction
+            // hooks, which RtlTcpSource implements by forwarding wire
+            // commands). Sample-rate row too — UiToDsp::SetSampleRate
+            // goes through Source::set_sample_rate either way.
+            let tune_controls_visible = is_rtlsdr || is_rtltcp;
+            sample_rate_row.set_visible(tune_controls_visible);
+            gain_row.set_visible(tune_controls_visible);
+            agc_row.set_visible(tune_controls_visible);
+            ppm_row.set_visible(tune_controls_visible);
 
-            hostname_row.set_visible(is_network);
-            port_row.set_visible(is_network);
+            // Hostname / port entry is shared between raw-IQ Network
+            // and RTL-TCP modes. Protocol (TCP/UDP) only applies to
+            // raw Network — RTL-TCP always rides on TCP.
+            hostname_row.set_visible(is_network || is_rtltcp);
+            port_row.set_visible(is_network || is_rtltcp);
             protocol_row.set_visible(is_network);
 
             file_path_row.set_visible(is_file);
@@ -247,7 +267,10 @@ pub fn build_source_panel() -> SourcePanel {
         .description("Device and input configuration")
         .build();
 
-    let device_model = gtk4::StringList::new(&["RTL-SDR", "Network", "File"]);
+    // Order is load-bearing — matches `DEVICE_RTLSDR / NETWORK / FILE /
+    // RTLTCP` index constants. If you change the order here, update the
+    // constants AND the `SourceType` match in window.rs at the same time.
+    let device_model = gtk4::StringList::new(&["RTL-SDR", "Network", "File", "RTL-TCP (network)"]);
     let device_row = adw::ComboRow::builder()
         .title("Device")
         .model(&device_model)
@@ -268,6 +291,20 @@ pub fn build_source_panel() -> SourcePanel {
         .subtitle("Raw IQ samples to WAV")
         .build();
 
+    // RTL-TCP-specific rows. Built always, shown only when the RTL-TCP
+    // source type is selected (see connect_device_visibility + the
+    // initial-visibility block below).
+    let rtl_tcp_discovered_row = adw::ExpanderRow::builder()
+        .title("Discovered rtl_tcp servers")
+        .subtitle("No servers discovered on the local network yet.")
+        .visible(false)
+        .build();
+    let rtl_tcp_status_row = adw::ActionRow::builder()
+        .title("Connection")
+        .subtitle("Disconnected")
+        .visible(false)
+        .build();
+
     // Add all rows to the group.
     group.add(&device_row);
     group.add(&sample_rate_row);
@@ -283,20 +320,26 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&iq_inversion_row);
     group.add(&decimation_row);
     group.add(&record_iq_row);
+    group.add(&rtl_tcp_discovered_row);
+    group.add(&rtl_tcp_status_row);
 
     // Derive initial visibility from the selected device.
     let selected = device_row.selected();
     let is_rtlsdr = selected == DEVICE_RTLSDR;
     let is_network = selected == DEVICE_NETWORK;
     let is_file = selected == DEVICE_FILE;
-    sample_rate_row.set_visible(is_rtlsdr);
-    gain_row.set_visible(is_rtlsdr);
-    agc_row.set_visible(is_rtlsdr);
-    ppm_row.set_visible(is_rtlsdr);
-    hostname_row.set_visible(is_network);
-    port_row.set_visible(is_network);
+    let is_rtltcp = selected == DEVICE_RTLTCP;
+    let tune_controls_visible = is_rtlsdr || is_rtltcp;
+    sample_rate_row.set_visible(tune_controls_visible);
+    gain_row.set_visible(tune_controls_visible);
+    agc_row.set_visible(tune_controls_visible);
+    ppm_row.set_visible(tune_controls_visible);
+    hostname_row.set_visible(is_network || is_rtltcp);
+    port_row.set_visible(is_network || is_rtltcp);
     protocol_row.set_visible(is_network);
     file_path_row.set_visible(is_file);
+    rtl_tcp_discovered_row.set_visible(is_rtltcp);
+    rtl_tcp_status_row.set_visible(is_rtltcp);
 
     connect_device_visibility(
         &device_row,
@@ -309,6 +352,7 @@ pub fn build_source_panel() -> SourcePanel {
         &protocol_row,
         &file_path_row,
     );
+    connect_rtl_tcp_visibility(&device_row, &rtl_tcp_discovered_row, &rtl_tcp_status_row);
 
     // Controls connected to DSP pipeline via window.rs
 
@@ -328,7 +372,30 @@ pub fn build_source_panel() -> SourcePanel {
         iq_inversion_row,
         decimation_row,
         record_iq_row,
+        rtl_tcp_discovered_row,
+        rtl_tcp_status_row,
     }
+}
+
+/// Toggle visibility of the RTL-TCP-specific rows based on the device
+/// selector. Kept separate from `connect_device_visibility` so the
+/// existing function's argument list doesn't grow further.
+fn connect_rtl_tcp_visibility(
+    device_row: &adw::ComboRow,
+    rtl_tcp_discovered_row: &adw::ExpanderRow,
+    rtl_tcp_status_row: &adw::ActionRow,
+) {
+    device_row.connect_selected_notify(glib::clone!(
+        #[weak]
+        rtl_tcp_discovered_row,
+        #[weak]
+        rtl_tcp_status_row,
+        move |row| {
+            let is_rtltcp = row.selected() == DEVICE_RTLTCP;
+            rtl_tcp_discovered_row.set_visible(is_rtltcp);
+            rtl_tcp_status_row.set_visible(is_rtltcp);
+        }
+    ));
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -7,13 +7,21 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 /// Device selector index for RTL-SDR.
-const DEVICE_RTLSDR: u32 = 0;
+pub const DEVICE_RTLSDR: u32 = 0;
 /// Device selector index for Network.
-const DEVICE_NETWORK: u32 = 1;
+pub const DEVICE_NETWORK: u32 = 1;
 /// Device selector index for File.
-const DEVICE_FILE: u32 = 2;
+pub const DEVICE_FILE: u32 = 2;
 /// Device selector index for RTL-TCP (rtl_tcp-protocol network client).
 pub const DEVICE_RTLTCP: u32 = 3;
+
+/// Network protocol selector index for TCP (client). Load-bearing:
+/// both `build_network_rows()` (protocol `StringList`) and callers in
+/// `window.rs` that set or read this row rely on this exact mapping.
+/// Reorder the `StringList` and these constants must move in lockstep.
+pub const NETWORK_PROTOCOL_TCPCLIENT_IDX: u32 = 0;
+/// Network protocol selector index for UDP.
+pub const NETWORK_PROTOCOL_UDP_IDX: u32 = 1;
 
 /// Default gain in dB.
 const DEFAULT_GAIN_DB: f64 = 0.0;
@@ -155,6 +163,8 @@ fn build_network_rows() -> (adw::EntryRow, adw::SpinRow, adw::ComboRow) {
         .digits(0)
         .build();
 
+    // Order is load-bearing — must match
+    // `NETWORK_PROTOCOL_TCPCLIENT_IDX` / `NETWORK_PROTOCOL_UDP_IDX`.
     let protocol_model = gtk4::StringList::new(&["TCP", "UDP"]);
     let protocol_row = adw::ComboRow::builder()
         .title("Protocol")

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -417,6 +417,15 @@ mod tests {
 
     #[test]
     fn device_indices_are_distinct() {
+        // Full pairwise distinctness — adding a 5th source type
+        // without updating this test would let a collision slip
+        // through. The device_row -> SourceType match in window.rs
+        // depends on these being unique integer indices.
         assert_ne!(DEVICE_RTLSDR, DEVICE_NETWORK);
+        assert_ne!(DEVICE_RTLSDR, DEVICE_FILE);
+        assert_ne!(DEVICE_RTLSDR, DEVICE_RTLTCP);
+        assert_ne!(DEVICE_NETWORK, DEVICE_FILE);
+        assert_ne!(DEVICE_NETWORK, DEVICE_RTLTCP);
+        assert_ne!(DEVICE_FILE, DEVICE_RTLTCP);
     }
 }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -83,9 +83,6 @@ pub struct SourcePanel {
     /// Discovered `rtl_tcp` servers (live from mDNS). Collapsed by
     /// default; expands when servers are seen.
     pub rtl_tcp_discovered_row: adw::ExpanderRow,
-    /// Connection-state label for `rtl_tcp` (Connecting / Connected /
-    /// Retrying / Failed / Disconnected).
-    pub rtl_tcp_status_row: adw::ActionRow,
 }
 
 /// Default sample rate selector index (2.4 MHz = index 7).
@@ -294,14 +291,16 @@ pub fn build_source_panel() -> SourcePanel {
     // RTL-TCP-specific rows. Built always, shown only when the RTL-TCP
     // source type is selected (see connect_device_visibility + the
     // initial-visibility block below).
+    //
+    // Connection-state display (Connecting / Connected / Retrying /
+    // Failed) is intentionally deferred to #323 — wiring it requires
+    // a new DspToUi event from the controller that polls
+    // RtlTcpSource::connection_state(), which is outside this PR's
+    // scope. Shipping the row without that plumbing would leave it
+    // stuck on "Disconnected" misleadingly.
     let rtl_tcp_discovered_row = adw::ExpanderRow::builder()
         .title("Discovered rtl_tcp servers")
         .subtitle("No servers discovered on the local network yet.")
-        .visible(false)
-        .build();
-    let rtl_tcp_status_row = adw::ActionRow::builder()
-        .title("Connection")
-        .subtitle("Disconnected")
         .visible(false)
         .build();
 
@@ -321,7 +320,6 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&decimation_row);
     group.add(&record_iq_row);
     group.add(&rtl_tcp_discovered_row);
-    group.add(&rtl_tcp_status_row);
 
     // Derive initial visibility from the selected device.
     let selected = device_row.selected();
@@ -339,7 +337,6 @@ pub fn build_source_panel() -> SourcePanel {
     protocol_row.set_visible(is_network);
     file_path_row.set_visible(is_file);
     rtl_tcp_discovered_row.set_visible(is_rtltcp);
-    rtl_tcp_status_row.set_visible(is_rtltcp);
 
     connect_device_visibility(
         &device_row,
@@ -352,7 +349,7 @@ pub fn build_source_panel() -> SourcePanel {
         &protocol_row,
         &file_path_row,
     );
-    connect_rtl_tcp_visibility(&device_row, &rtl_tcp_discovered_row, &rtl_tcp_status_row);
+    connect_rtl_tcp_visibility(&device_row, &rtl_tcp_discovered_row);
 
     // Controls connected to DSP pipeline via window.rs
 
@@ -373,7 +370,6 @@ pub fn build_source_panel() -> SourcePanel {
         decimation_row,
         record_iq_row,
         rtl_tcp_discovered_row,
-        rtl_tcp_status_row,
     }
 }
 
@@ -383,17 +379,13 @@ pub fn build_source_panel() -> SourcePanel {
 fn connect_rtl_tcp_visibility(
     device_row: &adw::ComboRow,
     rtl_tcp_discovered_row: &adw::ExpanderRow,
-    rtl_tcp_status_row: &adw::ActionRow,
 ) {
     device_row.connect_selected_notify(glib::clone!(
         #[weak]
         rtl_tcp_discovered_row,
-        #[weak]
-        rtl_tcp_status_row,
         move |row| {
             let is_rtltcp = row.selected() == DEVICE_RTLTCP;
             rtl_tcp_discovered_row.set_visible(is_rtltcp);
-            rtl_tcp_status_row.set_visible(is_rtltcp);
         }
     ));
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -893,16 +893,40 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     /// Connect button from offering a dead endpoint.
     const STALE_ROW_GRACE: std::time::Duration = std::time::Duration::from_mins(3);
 
+    /// Poll cadence for the mDNS discovery event channel. 200 ms is
+    /// fast enough that newly-announced servers appear "instantly" to
+    /// the user and cheap enough to be always-on even when RTL-TCP is
+    /// not the selected source type.
+    const DISCOVERY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
+
+    /// Subtitle shown on the discovered-servers expander when mDNS
+    /// discovery is non-functional (either `Browser::start` failed or
+    /// the browser thread exited at runtime). Distinguishes "nothing
+    /// to see yet" from "we gave up listening" — without this the UI
+    /// would lie by showing the idle "No servers discovered…" state.
+    const DISCOVERY_UNAVAILABLE_SUBTITLE: &str = "Discovery unavailable on this system.";
+
     let (disc_tx, disc_rx) = mpsc::channel::<DiscoveryEvent>();
     let browser = match Browser::start(move |event| {
         // Ignore send errors — means the UI thread dropped the rx,
         // which only happens on shutdown.
         let _ = disc_tx.send(event);
     }) {
-        Ok(b) => Some(b),
+        Ok(b) => b,
         Err(e) => {
+            // Surface the failure in the UI and return early. Without
+            // the early return the timeout below would still spawn,
+            // and because `disc_tx` was moved into the failed
+            // `Browser::start` call its drop has already disconnected
+            // `disc_rx` — the poller would spin forever returning
+            // `TryRecvError::Disconnected` while the UI kept showing
+            // the benign idle "No servers discovered…" subtitle.
             tracing::warn!(%e, "mDNS browser failed to start — discovery disabled");
-            None
+            panels
+                .source
+                .rtl_tcp_discovered_row
+                .set_subtitle(DISCOVERY_UNAVAILABLE_SUBTITLE);
+            return;
         }
     };
 
@@ -924,10 +948,10 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     let device_row = panels.source.device_row.clone();
     let state = Rc::clone(state);
 
-    // Poll the discovery channel from the main thread every 200 ms.
-    // Cheap enough to be always-on; discovery events are bursty at
-    // start and then idle.
-    let _ = glib::timeout_add_local(Duration::from_millis(200), move || {
+    // Poll the discovery channel from the main thread. Cheap enough
+    // to be always-on; discovery events are bursty at start and then
+    // idle.
+    let _ = glib::timeout_add_local(DISCOVERY_POLL_INTERVAL, move || {
         // Keep the Browser alive as long as the timeout closure is
         // attached.
         let _keep_browser = &browser;
@@ -965,7 +989,23 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
             }
         }
 
-        while let Ok(event) = disc_rx.try_recv() {
+        loop {
+            let event = match disc_rx.try_recv() {
+                Ok(event) => event,
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    // Browser thread exited — `disc_tx` dropped. Stop
+                    // polling and surface the degraded state; without
+                    // the Break this timeout would spin forever and
+                    // the UI would keep claiming "No servers
+                    // discovered yet" when we've in fact given up.
+                    tracing::warn!(
+                        "mDNS discovery channel disconnected — stopping discovery poller"
+                    );
+                    expander.set_subtitle(DISCOVERY_UNAVAILABLE_SUBTITLE);
+                    return glib::ControlFlow::Break;
+                }
+            };
             match event {
                 DiscoveryEvent::ServerAnnounced(server) => {
                     let mut rows = displayed_rows.borrow_mut();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -906,6 +906,7 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     let expander = panels.source.rtl_tcp_discovered_row.clone();
     let hostname_row = panels.source.hostname_row.clone();
     let port_row = panels.source.port_row.clone();
+    let protocol_row = panels.source.protocol_row.clone();
     let device_row = panels.source.device_row.clone();
     let state = Rc::clone(state);
 
@@ -961,12 +962,22 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     let endpoint_for_click = Rc::clone(&endpoint);
                     let hr = hostname_row.clone();
                     let pr = port_row.clone();
+                    let protor = protocol_row.clone();
                     let dr = device_row.clone();
                     let st = Rc::clone(&state);
                     connect_btn.connect_clicked(move |_| {
                         let (current_host, current_port) = endpoint_for_click.borrow().clone();
                         hr.set_text(&current_host);
                         pr.set_value(f64::from(current_port));
+                        // Force the shared protocol row to TCP. rtl_tcp
+                        // is always TCP, and the hostname_row /
+                        // port_row edit handlers re-read this widget
+                        // when dispatching SetNetworkConfig — leaving
+                        // it on UDP (the previous Network-source
+                        // selection) would silently overwrite our
+                        // protocol on the next hostname edit. Index 0
+                        // = TcpClient; see protocol_row builder.
+                        protor.set_selected(0);
                         dr.set_selected(crate::sidebar::source_panel::DEVICE_RTLTCP);
                         st.send_dsp(UiToDsp::SetNetworkConfig {
                             hostname: current_host,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -874,6 +874,20 @@ fn connect_sidebar_panels(
 /// UX immediate instead of "wait 5 s for the first advertisement."
 fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     use std::collections::HashMap;
+    use std::time::Instant;
+
+    /// Grace window after which a server that has stopped
+    /// re-announcing gets pruned from the UI list. A healthy mDNS
+    /// responder re-announces well before its TTL (default 120 s on
+    /// most daemons) expires; 3 minutes without a refresh means the
+    /// responder is either dead or network-partitioned.
+    ///
+    /// Defense-in-depth: mdns-sd's daemon SHOULD fire
+    /// `ServiceRemoved` on TTL expiry, but a crashed server that
+    /// vanishes without a goodbye may leave the cache entry around
+    /// longer than the client wants. Expiring client-side keeps the
+    /// Connect button from offering a dead endpoint.
+    const STALE_ROW_GRACE: std::time::Duration = std::time::Duration::from_mins(3);
 
     let (disc_tx, disc_rx) = mpsc::channel::<DiscoveryEvent>();
     let browser = match Browser::start(move |event| {
@@ -889,16 +903,11 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     };
 
     // Tracks the `AdwActionRow` per-server so we can remove it on
-    // `ServerWithdrawn`. Keyed by full DNS-SD instance name (stable
-    // across nickname changes).
-    //
-    // No interior-mutability cell on the endpoint: on re-announce we
-    // remove-and-rebuild the row so the Connect closure always captures
-    // the current (host, port). Simpler than a shared cell, at the
-    // cost of a brief row flicker during the rare re-resolve — which
-    // typically only fires on a server's address change, not every
-    // TTL refresh.
-    let displayed_rows: Rc<RefCell<HashMap<String, adw::ActionRow>>> =
+    // `ServerWithdrawn` OR when the row goes stale past
+    // `STALE_ROW_GRACE`. Keyed by full DNS-SD instance name (stable
+    // across nickname changes). Value carries the row widget + a
+    // `last_seen` Instant updated on every `ServerAnnounced`.
+    let displayed_rows: Rc<RefCell<HashMap<String, (adw::ActionRow, Instant)>>> =
         Rc::new(RefCell::new(HashMap::new()));
 
     // Weak ref on the expander so the timeout closure doesn't keep
@@ -925,6 +934,33 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
         let Some(expander) = expander_weak.upgrade() else {
             return glib::ControlFlow::Break;
         };
+        // Prune stale rows before processing incoming events. A
+        // responder that crashed or network-partitioned won't send
+        // ServerWithdrawn, so without this pass the Connect button
+        // for a dead server keeps showing until mDNS cache TTL fires
+        // (if it fires at all). 3-minute grace is long enough that
+        // a healthy responder's re-announce keeps its row alive.
+        {
+            let mut rows = displayed_rows.borrow_mut();
+            let now = Instant::now();
+            let stale_names: Vec<String> = rows
+                .iter()
+                .filter(|(_, (_, seen))| now.duration_since(*seen) > STALE_ROW_GRACE)
+                .map(|(name, _)| name.clone())
+                .collect();
+            for name in stale_names {
+                if let Some((row, _)) = rows.remove(&name) {
+                    tracing::debug!(instance = %name, "pruning stale rtl_tcp discovery row");
+                    expander.remove(&row);
+                }
+            }
+            if rows.is_empty() {
+                expander.set_subtitle("No servers discovered on the local network yet.");
+            } else {
+                expander.set_subtitle(&format!("{} server(s) visible", rows.len()));
+            }
+        }
+
         while let Ok(event) = disc_rx.try_recv() {
             match event {
                 DiscoveryEvent::ServerAnnounced(server) => {
@@ -949,7 +985,7 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     // the new Connect closure; otherwise the stale
                     // values from first-announce would stick. See the
                     // displayed_rows docstring above.
-                    if let Some(existing_row) = rows.remove(&server.instance_name) {
+                    if let Some((existing_row, _)) = rows.remove(&server.instance_name) {
                         expander.remove(&existing_row);
                     }
 
@@ -969,6 +1005,17 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     let dr = device_row.clone();
                     let st = Rc::clone(&state);
                     connect_btn.connect_clicked(move |_| {
+                        // Remember whether the device row was already
+                        // on RTL-TCP. If it WAS, `set_selected` below
+                        // is a no-op and the `device_row` notify
+                        // handler doesn't fire, so we need to send
+                        // SetSourceType ourselves to force the
+                        // controller to reopen the source against the
+                        // new endpoint. If it WASN'T, the notify
+                        // handler will dispatch SetSourceType for us
+                        // and an explicit send would double-open.
+                        let already_rtl_tcp =
+                            dr.selected() == crate::sidebar::source_panel::DEVICE_RTLTCP;
                         hr.set_text(&click_host);
                         pr.set_value(f64::from(click_port));
                         // Force the shared protocol row to TCP. rtl_tcp
@@ -986,17 +1033,22 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                             port: click_port,
                             protocol: sdr_types::Protocol::TcpClient,
                         });
-                        st.send_dsp(UiToDsp::SetSourceType(SourceType::RtlTcp));
+                        if already_rtl_tcp {
+                            // device_row notify handler did NOT fire
+                            // (we were already on RTL-TCP); force the
+                            // source reopen so the new endpoint takes.
+                            st.send_dsp(UiToDsp::SetSourceType(SourceType::RtlTcp));
+                        }
                     });
                     row.add_suffix(&connect_btn);
                     expander.add_row(&row);
-                    rows.insert(server.instance_name.clone(), row);
+                    rows.insert(server.instance_name.clone(), (row, Instant::now()));
 
                     expander.set_subtitle(&format!("{} server(s) visible", rows.len()));
                 }
                 DiscoveryEvent::ServerWithdrawn { instance_name } => {
                     let mut rows = displayed_rows.borrow_mut();
-                    if let Some(row) = rows.remove(&instance_name) {
+                    if let Some((row, _seen)) = rows.remove(&instance_name) {
                         expander.remove(&row);
                     }
                     if rows.is_empty() {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -875,13 +875,6 @@ fn connect_sidebar_panels(
 fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     use std::collections::HashMap;
 
-    // Shared cell that lets the Connect closure read the current
-    // (host, port) for a given row. Re-announces update the cell
-    // in-place without rebuilding the button closure, so a server
-    // that comes back on a new address doesn't leave the UI dialing
-    // the stale endpoint.
-    type EndpointCell = Rc<RefCell<(String, u16)>>;
-
     let (disc_tx, disc_rx) = mpsc::channel::<DiscoveryEvent>();
     let browser = match Browser::start(move |event| {
         // Ignore send errors — means the UI thread dropped the rx,
@@ -897,13 +890,21 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
 
     // Tracks the `AdwActionRow` per-server so we can remove it on
     // `ServerWithdrawn`. Keyed by full DNS-SD instance name (stable
-    // across nickname changes). The per-row value bundles the row
-    // widget with its `EndpointCell` — see the type-alias docstring
-    // for why that separation matters.
-    let displayed_rows: Rc<RefCell<HashMap<String, (adw::ActionRow, EndpointCell)>>> =
+    // across nickname changes).
+    //
+    // No interior-mutability cell on the endpoint: on re-announce we
+    // remove-and-rebuild the row so the Connect closure always captures
+    // the current (host, port). Simpler than a shared cell, at the
+    // cost of a brief row flicker during the rare re-resolve — which
+    // typically only fires on a server's address change, not every
+    // TTL refresh.
+    let displayed_rows: Rc<RefCell<HashMap<String, adw::ActionRow>>> =
         Rc::new(RefCell::new(HashMap::new()));
 
-    let expander = panels.source.rtl_tcp_discovered_row.clone();
+    // Weak ref on the expander so the timeout closure doesn't keep
+    // the window alive after close — upgrade() returns None on a
+    // destroyed widget and the poller breaks out.
+    let expander_weak = panels.source.rtl_tcp_discovered_row.downgrade();
     let hostname_row = panels.source.hostname_row.clone();
     let port_row = panels.source.port_row.clone();
     let protocol_row = panels.source.protocol_row.clone();
@@ -915,8 +916,15 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     // start and then idle.
     let _ = glib::timeout_add_local(Duration::from_millis(200), move || {
         // Keep the Browser alive as long as the timeout closure is
-        // attached (i.e., for the app's lifetime).
+        // attached.
         let _keep_browser = &browser;
+        // If the window / expander has been destroyed, stop polling
+        // and let the browser + closure captures drop. Prevents leaked
+        // pollers after a hypothetical close-and-reopen of the main
+        // window.
+        let Some(expander) = expander_weak.upgrade() else {
+            return glib::ControlFlow::Break;
+        };
         while let Ok(event) = disc_rx.try_recv() {
             match event {
                 DiscoveryEvent::ServerAnnounced(server) => {
@@ -935,16 +943,14 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                         host, server.port, server.txt.tuner, server.txt.gains
                     );
 
-                    if let Some((existing_row, endpoint)) = rows.get(&server.instance_name) {
-                        // Resolve fired again (TTL refresh) — update
-                        // labels AND the shared endpoint cell so the
-                        // existing Connect button dials the current
-                        // (possibly moved) server, not the stale one
-                        // captured at first-announce time.
-                        existing_row.set_title(&title);
-                        existing_row.set_subtitle(&subtitle);
-                        *endpoint.borrow_mut() = (host.clone(), server.port);
-                        continue;
+                    // Re-announce for a known instance_name: remove the
+                    // old row and fall through to build a fresh one.
+                    // Rebuilding captures the current (host, port) in
+                    // the new Connect closure; otherwise the stale
+                    // values from first-announce would stick. See the
+                    // displayed_rows docstring above.
+                    if let Some(existing_row) = rows.remove(&server.instance_name) {
+                        expander.remove(&existing_row);
                     }
 
                     let row = adw::ActionRow::builder()
@@ -955,20 +961,16 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     connect_btn.add_css_class("suggested-action");
                     connect_btn.set_valign(gtk4::Align::Center);
 
-                    // Shared endpoint cell — the Connect closure reads
-                    // the latest (host, port) at click time, not the
-                    // values captured when the row was first built.
-                    let endpoint: EndpointCell = Rc::new(RefCell::new((host.clone(), server.port)));
-                    let endpoint_for_click = Rc::clone(&endpoint);
+                    let click_host = host.clone();
+                    let click_port = server.port;
                     let hr = hostname_row.clone();
                     let pr = port_row.clone();
                     let protor = protocol_row.clone();
                     let dr = device_row.clone();
                     let st = Rc::clone(&state);
                     connect_btn.connect_clicked(move |_| {
-                        let (current_host, current_port) = endpoint_for_click.borrow().clone();
-                        hr.set_text(&current_host);
-                        pr.set_value(f64::from(current_port));
+                        hr.set_text(&click_host);
+                        pr.set_value(f64::from(click_port));
                         // Force the shared protocol row to TCP. rtl_tcp
                         // is always TCP, and the hostname_row /
                         // port_row edit handlers re-read this widget
@@ -980,21 +982,21 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                         protor.set_selected(0);
                         dr.set_selected(crate::sidebar::source_panel::DEVICE_RTLTCP);
                         st.send_dsp(UiToDsp::SetNetworkConfig {
-                            hostname: current_host,
-                            port: current_port,
+                            hostname: click_host.clone(),
+                            port: click_port,
                             protocol: sdr_types::Protocol::TcpClient,
                         });
                         st.send_dsp(UiToDsp::SetSourceType(SourceType::RtlTcp));
                     });
                     row.add_suffix(&connect_btn);
                     expander.add_row(&row);
-                    rows.insert(server.instance_name.clone(), (row, endpoint));
+                    rows.insert(server.instance_name.clone(), row);
 
                     expander.set_subtitle(&format!("{} server(s) visible", rows.len()));
                 }
                 DiscoveryEvent::ServerWithdrawn { instance_name } => {
                     let mut rows = displayed_rows.borrow_mut();
-                    if let Some((row, _endpoint)) = rows.remove(&instance_name) {
+                    if let Some(row) = rows.remove(&instance_name) {
                         expander.remove(&row);
                     }
                     if rows.is_empty() {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -13,6 +13,7 @@ use libadwaita::prelude::*;
 use sdr_core::Engine;
 use sdr_pipeline::iq_frontend::FftWindow;
 use sdr_radio::DeemphasisMode;
+use sdr_rtltcp_discovery::{Browser, DiscoveryEvent};
 use sdr_source_rtlsdr::SAMPLE_RATES;
 
 use crate::header;
@@ -843,6 +844,7 @@ fn connect_sidebar_panels(
     status_bar: &Rc<StatusBar>,
 ) {
     connect_source_panel(panels, state);
+    connect_rtl_tcp_discovery(panels, state);
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
@@ -859,6 +861,133 @@ fn connect_sidebar_panels(
 
 /// Connect source panel controls to DSP commands.
 #[allow(clippy::too_many_lines)]
+/// Spawn an mDNS browser for `_rtl_tcp._tcp.local.` services and wire
+/// its events into the `rtl_tcp_discovered_row` expander. Each
+/// discovered server gets an `AdwActionRow` with a Connect button that
+/// populates hostname/port and switches the source type.
+///
+/// The `Browser` handle is moved into the `timeout_add_local` closure
+/// so it lives for the lifetime of the main context (= the app), and
+/// mDNS discovery runs continuously whether or not the RTL-TCP source
+/// is currently selected. That's fine — discovery is cheap and having
+/// the list pre-populated when the user switches to RTL-TCP makes the
+/// UX immediate instead of "wait 5 s for the first advertisement."
+fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
+    use std::collections::HashMap;
+
+    let (disc_tx, disc_rx) = mpsc::channel::<DiscoveryEvent>();
+    let browser = match Browser::start(move |event| {
+        // Ignore send errors — means the UI thread dropped the rx,
+        // which only happens on shutdown.
+        let _ = disc_tx.send(event);
+    }) {
+        Ok(b) => Some(b),
+        Err(e) => {
+            tracing::warn!(%e, "mDNS browser failed to start — discovery disabled");
+            None
+        }
+    };
+
+    // Tracks the AdwActionRow per-server so we can remove it on
+    // `ServerWithdrawn`. Keyed by full DNS-SD instance name (stable
+    // across nickname changes).
+    let displayed_rows: Rc<RefCell<HashMap<String, adw::ActionRow>>> =
+        Rc::new(RefCell::new(HashMap::new()));
+
+    let expander = panels.source.rtl_tcp_discovered_row.clone();
+    let hostname_row = panels.source.hostname_row.clone();
+    let port_row = panels.source.port_row.clone();
+    let device_row = panels.source.device_row.clone();
+    let state = Rc::clone(state);
+
+    // Poll the discovery channel from the main thread every 200 ms.
+    // Cheap enough to be always-on; discovery events are bursty at
+    // start and then idle.
+    let _ = glib::timeout_add_local(Duration::from_millis(200), move || {
+        // Keep the Browser alive as long as the timeout closure is
+        // attached (i.e., for the app's lifetime).
+        let _keep_browser = &browser;
+        while let Ok(event) = disc_rx.try_recv() {
+            match event {
+                DiscoveryEvent::ServerAnnounced(server) => {
+                    let mut rows = displayed_rows.borrow_mut();
+                    let title = if server.txt.nickname.is_empty() {
+                        server.instance_name.clone()
+                    } else {
+                        server.txt.nickname.clone()
+                    };
+                    let host = server
+                        .addresses
+                        .first()
+                        .map_or_else(|| server.hostname.clone(), ToString::to_string);
+                    let subtitle = format!(
+                        "{}:{} — {} ({} gain steps)",
+                        host, server.port, server.txt.tuner, server.txt.gains
+                    );
+
+                    if let Some(existing) = rows.get(&server.instance_name) {
+                        // Resolve fired again (TTL refresh) — update
+                        // subtitle in case nickname / tuner changed.
+                        existing.set_title(&title);
+                        existing.set_subtitle(&subtitle);
+                        continue;
+                    }
+
+                    let row = adw::ActionRow::builder()
+                        .title(&title)
+                        .subtitle(&subtitle)
+                        .build();
+                    let connect_btn = gtk4::Button::with_label("Connect");
+                    connect_btn.add_css_class("suggested-action");
+                    connect_btn.set_valign(gtk4::Align::Center);
+
+                    // Capture by clone into the click handler. Each
+                    // discovered server spawns its own independent
+                    // closure — no cross-row coupling.
+                    let host_clone = host.clone();
+                    let port = server.port;
+                    let hr = hostname_row.clone();
+                    let pr = port_row.clone();
+                    let dr = device_row.clone();
+                    let st = Rc::clone(&state);
+                    connect_btn.connect_clicked(move |_| {
+                        hr.set_text(&host_clone);
+                        pr.set_value(f64::from(port));
+                        dr.set_selected(crate::sidebar::source_panel::DEVICE_RTLTCP);
+                        st.send_dsp(UiToDsp::SetNetworkConfig {
+                            hostname: host_clone.clone(),
+                            port,
+                            protocol: sdr_types::Protocol::TcpClient,
+                        });
+                        st.send_dsp(UiToDsp::SetSourceType(SourceType::RtlTcp));
+                    });
+                    row.add_suffix(&connect_btn);
+                    expander.add_row(&row);
+                    rows.insert(server.instance_name.clone(), row);
+
+                    expander.set_subtitle(&format!("{} server(s) visible", rows.len()));
+                }
+                DiscoveryEvent::ServerWithdrawn { instance_name } => {
+                    let mut rows = displayed_rows.borrow_mut();
+                    if let Some(row) = rows.remove(&instance_name) {
+                        expander.remove(&row);
+                    }
+                    if rows.is_empty() {
+                        expander.set_subtitle("No servers discovered on the local network yet.");
+                    } else {
+                        expander.set_subtitle(&format!("{} server(s) visible", rows.len()));
+                    }
+                }
+            }
+        }
+        glib::ControlFlow::Continue
+    });
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "GTK signal-wiring panel; splitting would fragment the control mapping"
+)]
 fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
     // Sample rate selector
     let state_sr = Rc::clone(state);
@@ -940,6 +1069,7 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
                 0 => SourceType::RtlSdr,
                 1 => SourceType::Network,
                 2 => SourceType::File,
+                3 => SourceType::RtlTcp,
                 _ => return, // ignore transient indices
             };
             state_source.send_dsp(UiToDsp::SetSourceType(source_type));

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -22,6 +22,10 @@ use crate::messages::{DspToUi, SourceType, UiToDsp};
 use crate::shortcuts;
 use crate::sidebar;
 use crate::sidebar::SidebarPanels;
+use crate::sidebar::source_panel::{
+    DEVICE_FILE, DEVICE_NETWORK, DEVICE_RTLSDR, DEVICE_RTLTCP, NETWORK_PROTOCOL_TCPCLIENT_IDX,
+    NETWORK_PROTOCOL_UDP_IDX,
+};
 use crate::spectrum;
 use crate::state::AppState;
 use crate::status_bar::{self, StatusBar};
@@ -1014,8 +1018,7 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                         // new endpoint. If it WASN'T, the notify
                         // handler will dispatch SetSourceType for us
                         // and an explicit send would double-open.
-                        let already_rtl_tcp =
-                            dr.selected() == crate::sidebar::source_panel::DEVICE_RTLTCP;
+                        let already_rtl_tcp = dr.selected() == DEVICE_RTLTCP;
                         hr.set_text(&click_host);
                         pr.set_value(f64::from(click_port));
                         // Force the shared protocol row to TCP. rtl_tcp
@@ -1024,10 +1027,9 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                         // when dispatching SetNetworkConfig — leaving
                         // it on UDP (the previous Network-source
                         // selection) would silently overwrite our
-                        // protocol on the next hostname edit. Index 0
-                        // = TcpClient; see protocol_row builder.
-                        protor.set_selected(0);
-                        dr.set_selected(crate::sidebar::source_panel::DEVICE_RTLTCP);
+                        // protocol on the next hostname edit.
+                        protor.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
+                        dr.set_selected(DEVICE_RTLTCP);
                         st.send_dsp(UiToDsp::SetNetworkConfig {
                             hostname: click_host.clone(),
                             port: click_port,
@@ -1145,10 +1147,10 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         .device_row
         .connect_selected_notify(move |row| {
             let source_type = match row.selected() {
-                0 => SourceType::RtlSdr,
-                1 => SourceType::Network,
-                2 => SourceType::File,
-                3 => SourceType::RtlTcp,
+                DEVICE_RTLSDR => SourceType::RtlSdr,
+                DEVICE_NETWORK => SourceType::Network,
+                DEVICE_FILE => SourceType::File,
+                DEVICE_RTLTCP => SourceType::RtlTcp,
                 _ => return, // ignore transient indices
             };
             state_source.send_dsp(UiToDsp::SetSourceType(source_type));
@@ -1162,7 +1164,7 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         let hostname = row.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = port_for_host.value() as u16;
-        let protocol = if proto_for_host.selected() == 1 {
+        let protocol = if proto_for_host.selected() == NETWORK_PROTOCOL_UDP_IDX {
             sdr_types::Protocol::Udp
         } else {
             sdr_types::Protocol::TcpClient
@@ -1182,7 +1184,7 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         let hostname = host_for_port.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = row.value() as u16;
-        let protocol = if proto_for_port.selected() == 1 {
+        let protocol = if proto_for_port.selected() == NETWORK_PROTOCOL_UDP_IDX {
             sdr_types::Protocol::Udp
         } else {
             sdr_types::Protocol::TcpClient
@@ -1206,8 +1208,8 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let port = port_for_proto.value() as u16;
             let protocol = match row.selected() {
-                0 => sdr_types::Protocol::TcpClient,
-                1 => sdr_types::Protocol::Udp,
+                NETWORK_PROTOCOL_TCPCLIENT_IDX => sdr_types::Protocol::TcpClient,
+                NETWORK_PROTOCOL_UDP_IDX => sdr_types::Protocol::Udp,
                 _ => return, // ignore transient indices
             };
             state_proto.send_dsp(UiToDsp::SetNetworkConfig {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -875,6 +875,13 @@ fn connect_sidebar_panels(
 fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     use std::collections::HashMap;
 
+    // Shared cell that lets the Connect closure read the current
+    // (host, port) for a given row. Re-announces update the cell
+    // in-place without rebuilding the button closure, so a server
+    // that comes back on a new address doesn't leave the UI dialing
+    // the stale endpoint.
+    type EndpointCell = Rc<RefCell<(String, u16)>>;
+
     let (disc_tx, disc_rx) = mpsc::channel::<DiscoveryEvent>();
     let browser = match Browser::start(move |event| {
         // Ignore send errors — means the UI thread dropped the rx,
@@ -888,10 +895,12 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
         }
     };
 
-    // Tracks the AdwActionRow per-server so we can remove it on
+    // Tracks the `AdwActionRow` per-server so we can remove it on
     // `ServerWithdrawn`. Keyed by full DNS-SD instance name (stable
-    // across nickname changes).
-    let displayed_rows: Rc<RefCell<HashMap<String, adw::ActionRow>>> =
+    // across nickname changes). The per-row value bundles the row
+    // widget with its `EndpointCell` — see the type-alias docstring
+    // for why that separation matters.
+    let displayed_rows: Rc<RefCell<HashMap<String, (adw::ActionRow, EndpointCell)>>> =
         Rc::new(RefCell::new(HashMap::new()));
 
     let expander = panels.source.rtl_tcp_discovered_row.clone();
@@ -925,11 +934,15 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                         host, server.port, server.txt.tuner, server.txt.gains
                     );
 
-                    if let Some(existing) = rows.get(&server.instance_name) {
+                    if let Some((existing_row, endpoint)) = rows.get(&server.instance_name) {
                         // Resolve fired again (TTL refresh) — update
-                        // subtitle in case nickname / tuner changed.
-                        existing.set_title(&title);
-                        existing.set_subtitle(&subtitle);
+                        // labels AND the shared endpoint cell so the
+                        // existing Connect button dials the current
+                        // (possibly moved) server, not the stale one
+                        // captured at first-announce time.
+                        existing_row.set_title(&title);
+                        existing_row.set_subtitle(&subtitle);
+                        *endpoint.borrow_mut() = (host.clone(), server.port);
                         continue;
                     }
 
@@ -941,35 +954,36 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     connect_btn.add_css_class("suggested-action");
                     connect_btn.set_valign(gtk4::Align::Center);
 
-                    // Capture by clone into the click handler. Each
-                    // discovered server spawns its own independent
-                    // closure — no cross-row coupling.
-                    let host_clone = host.clone();
-                    let port = server.port;
+                    // Shared endpoint cell — the Connect closure reads
+                    // the latest (host, port) at click time, not the
+                    // values captured when the row was first built.
+                    let endpoint: EndpointCell = Rc::new(RefCell::new((host.clone(), server.port)));
+                    let endpoint_for_click = Rc::clone(&endpoint);
                     let hr = hostname_row.clone();
                     let pr = port_row.clone();
                     let dr = device_row.clone();
                     let st = Rc::clone(&state);
                     connect_btn.connect_clicked(move |_| {
-                        hr.set_text(&host_clone);
-                        pr.set_value(f64::from(port));
+                        let (current_host, current_port) = endpoint_for_click.borrow().clone();
+                        hr.set_text(&current_host);
+                        pr.set_value(f64::from(current_port));
                         dr.set_selected(crate::sidebar::source_panel::DEVICE_RTLTCP);
                         st.send_dsp(UiToDsp::SetNetworkConfig {
-                            hostname: host_clone.clone(),
-                            port,
+                            hostname: current_host,
+                            port: current_port,
                             protocol: sdr_types::Protocol::TcpClient,
                         });
                         st.send_dsp(UiToDsp::SetSourceType(SourceType::RtlTcp));
                     });
                     row.add_suffix(&connect_btn);
                     expander.add_row(&row);
-                    rows.insert(server.instance_name.clone(), row);
+                    rows.insert(server.instance_name.clone(), (row, endpoint));
 
                     expander.set_subtitle(&format!("{} server(s) visible", rows.len()));
                 }
                 DiscoveryEvent::ServerWithdrawn { instance_name } => {
                     let mut rows = displayed_rows.borrow_mut();
-                    if let Some(row) = rows.remove(&instance_name) {
+                    if let Some((row, _endpoint)) = rows.remove(&instance_name) {
                         expander.remove(&row);
                     }
                     if rows.is_empty() {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -13,7 +13,7 @@ use libadwaita::prelude::*;
 use sdr_core::Engine;
 use sdr_pipeline::iq_frontend::FftWindow;
 use sdr_radio::DeemphasisMode;
-use sdr_rtltcp_discovery::{Browser, DiscoveryEvent};
+use sdr_rtltcp_discovery::{Browser, DiscoveredServer, DiscoveryEvent};
 use sdr_source_rtlsdr::SAMPLE_RATES;
 
 use crate::header;
@@ -933,9 +933,11 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     // Tracks the `AdwActionRow` per-server so we can remove it on
     // `ServerWithdrawn` OR when the row goes stale past
     // `STALE_ROW_GRACE`. Keyed by full DNS-SD instance name (stable
-    // across nickname changes). Value carries the row widget + a
-    // `last_seen` Instant updated on every `ServerAnnounced`.
-    let displayed_rows: Rc<RefCell<HashMap<String, (adw::ActionRow, Instant)>>> =
+    // across nickname changes). Value carries the row widget + the
+    // last `DiscoveredServer` payload seen for that instance —
+    // `server.last_seen` drives both staleness pruning and the
+    // per-tick freshness indicator rendered in the row subtitle.
+    let displayed_rows: Rc<RefCell<HashMap<String, (adw::ActionRow, DiscoveredServer)>>> =
         Rc::new(RefCell::new(HashMap::new()));
 
     // Weak ref on the expander so the timeout closure doesn't keep
@@ -973,7 +975,9 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
             let now = Instant::now();
             let stale_names: Vec<String> = rows
                 .iter()
-                .filter(|(_, (_, seen))| now.duration_since(*seen) > STALE_ROW_GRACE)
+                .filter(|(_, (_, server))| {
+                    now.saturating_duration_since(server.last_seen) > STALE_ROW_GRACE
+                })
                 .map(|(name, _)| name.clone())
                 .collect();
             for name in stale_names {
@@ -981,6 +985,17 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     tracing::debug!(instance = %name, "pruning stale rtl_tcp discovery row");
                     expander.remove(&row);
                 }
+            }
+            // Refresh each surviving row's subtitle with a fresh
+            // "seen N ago" stamp. Without this per-tick refresh the
+            // age text would freeze at whatever it said when the row
+            // was built (or last re-announced) and silently mislead
+            // the user about how recent a server is. GTK short-
+            // circuits the set_subtitle call when the string is
+            // unchanged, so this is nearly free on quiescent rows.
+            for (row, server) in rows.values() {
+                let elapsed = now.saturating_duration_since(server.last_seen);
+                row.set_subtitle(&format_discovery_subtitle(server, elapsed));
             }
             if rows.is_empty() {
                 expander.set_subtitle("No servers discovered on the local network yet.");
@@ -1018,10 +1033,12 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                         .addresses
                         .first()
                         .map_or_else(|| server.hostname.clone(), ToString::to_string);
-                    let subtitle = format!(
-                        "{}:{} — {} ({} gain steps)",
-                        host, server.port, server.txt.tuner, server.txt.gains
-                    );
+                    // Age is effectively 0 here — `server.last_seen` was
+                    // stamped by the browser thread a few ms ago —
+                    // `format_age` will render "just now". Subsequent
+                    // poll ticks refresh this with the actual age.
+                    let elapsed = Instant::now().saturating_duration_since(server.last_seen);
+                    let subtitle = format_discovery_subtitle(&server, elapsed);
 
                     // Re-announce for a known instance_name: remove the
                     // old row and fall through to build a fresh one.
@@ -1084,13 +1101,13 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     });
                     row.add_suffix(&connect_btn);
                     expander.add_row(&row);
-                    rows.insert(server.instance_name.clone(), (row, Instant::now()));
+                    rows.insert(server.instance_name.clone(), (row, server));
 
                     expander.set_subtitle(&format!("{} server(s) visible", rows.len()));
                 }
                 DiscoveryEvent::ServerWithdrawn { instance_name } => {
                     let mut rows = displayed_rows.borrow_mut();
-                    if let Some((row, _seen)) = rows.remove(&instance_name) {
+                    if let Some((row, _)) = rows.remove(&instance_name) {
                         expander.remove(&row);
                     }
                     if rows.is_empty() {
@@ -1103,6 +1120,82 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
         }
         glib::ControlFlow::Continue
     });
+}
+
+/// Format the subtitle string for a discovered `rtl_tcp` server row.
+///
+/// Emits three pieces separated by ` • `:
+///
+/// 1. `{connect_target}:{port}` — the address the Connect button will
+///    dial (IPv4 address if we have one, otherwise the advertised
+///    hostname).
+/// 2. advertised mDNS hostname — only when it's non-empty AND
+///    genuinely different from the connect target (i.e., we have an
+///    IP and want to show the friendly name alongside it). The
+///    hostname is stripped of any trailing `.local.` so we show
+///    `shack-pi` instead of `shack-pi.local.`.
+/// 3. `{tuner} · {gains} gains · seen {age}` — hardware info plus
+///    the freshness indicator from `format_age`.
+///
+/// Kept as a free function (not a method on `DiscoveredServer`) so the
+/// age-stamp convention stays a UI concern and the discovery crate
+/// doesn't need to think about human-readable timestamps.
+fn format_discovery_subtitle(server: &DiscoveredServer, elapsed: Duration) -> String {
+    let connect_target = server
+        .addresses
+        .first()
+        .map_or_else(|| server.hostname.clone(), ToString::to_string);
+    let bare_hostname = bare_local_host(&server.hostname);
+    // Compare `bare_hostname` against a similarly-trimmed view of the
+    // connect target so the no-IP fallback (target = hostname) doesn't
+    // render "shack-pi.local.:1234 • shack-pi • …" — one name twice.
+    let bare_connect_target = bare_local_host(&connect_target);
+    let mut parts: Vec<String> = Vec::with_capacity(3);
+    parts.push(format!("{connect_target}:{}", server.port));
+    if !bare_hostname.is_empty() && bare_hostname != bare_connect_target {
+        parts.push(bare_hostname.to_string());
+    }
+    parts.push(format!(
+        "{} · {} gains · seen {}",
+        server.txt.tuner,
+        server.txt.gains,
+        format_age(elapsed)
+    ));
+    parts.join(" • ")
+}
+
+/// Strip a trailing `.local.` / `.local` / `.` suffix from an mDNS
+/// hostname so the user sees `shack-pi` instead of `shack-pi.local.`.
+/// Purely presentational — resolution still happens against the full
+/// name in the Connect button's dial path.
+fn bare_local_host(host: &str) -> &str {
+    host.trim_end_matches('.')
+        .trim_end_matches(".local")
+        .trim_end_matches('.')
+}
+
+/// Render an elapsed duration as a short human-readable age string.
+///
+/// Buckets:
+/// - under 5 s → `"just now"` (avoids flicker on the 200 ms poll tick)
+/// - 5 s – 60 s → `"Ns ago"`
+/// - 1 m – 60 m → `"Nm ago"`
+/// - 60 m and up → `"Nh ago"`
+///
+/// Coarse by design — the point is to tell "freshly re-announced" from
+/// "cached and possibly dead", not to replace an NTP timestamp.
+fn format_age(elapsed: Duration) -> String {
+    const FRESH_THRESHOLD: Duration = Duration::from_secs(5);
+    let secs = elapsed.as_secs();
+    if elapsed < FRESH_THRESHOLD {
+        "just now".to_string()
+    } else if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else {
+        format!("{}h ago", secs / 3600)
+    }
 }
 
 #[allow(
@@ -2878,4 +2971,117 @@ fn recording_path(prefix: &str) -> std::path::PathBuf {
         .and_then(|dt| dt.format("%Y-%m-%d-%H%M%S"))
         .map_or_else(|_| "unknown".to_string(), |s| s.to_string());
     base.join(format!("{prefix}-{timestamp}.wav"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod rtl_tcp_discovery_format_tests {
+    use std::net::IpAddr;
+    use std::time::{Duration, Instant};
+
+    use sdr_rtltcp_discovery::{DiscoveredServer, TxtRecord};
+
+    use super::{format_age, format_discovery_subtitle};
+
+    fn sample_server(addresses: Vec<IpAddr>, hostname: &str) -> DiscoveredServer {
+        DiscoveredServer {
+            instance_name: "shack-pi weather._rtl_tcp._tcp.local.".into(),
+            hostname: hostname.into(),
+            port: 1234,
+            addresses,
+            txt: TxtRecord {
+                tuner: "R820T".into(),
+                version: "0.1.0".into(),
+                gains: 29,
+                nickname: "weather".into(),
+                txbuf: None,
+            },
+            last_seen: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn format_age_buckets_seconds_minutes_hours() {
+        // < 5 s bucket → "just now" (debounces the 200 ms refresh
+        // from showing "0s ago / 1s ago" noise).
+        assert_eq!(format_age(Duration::from_millis(0)), "just now");
+        assert_eq!(format_age(Duration::from_secs(4)), "just now");
+        // 5 s – 59 s → "Ns ago"
+        assert_eq!(format_age(Duration::from_secs(5)), "5s ago");
+        assert_eq!(format_age(Duration::from_secs(59)), "59s ago");
+        // 1 m – 59 m → "Nm ago"
+        assert_eq!(format_age(Duration::from_mins(1)), "1m ago");
+        assert_eq!(format_age(Duration::from_secs(125)), "2m ago");
+        assert_eq!(format_age(Duration::from_secs(3599)), "59m ago");
+        // 1 h+ → "Nh ago"
+        assert_eq!(format_age(Duration::from_hours(1)), "1h ago");
+        assert_eq!(format_age(Duration::from_hours(2)), "2h ago");
+    }
+
+    #[test]
+    fn subtitle_with_ip_shows_hostname_and_freshness() {
+        // When we have a resolved IP, the subtitle includes both the
+        // IP (the Connect button's target) AND the advertised
+        // hostname (the friendly name the user recognises).
+        let ip: IpAddr = "192.168.1.5".parse().unwrap();
+        let server = sample_server(vec![ip], "shack-pi.local.");
+        let subtitle = format_discovery_subtitle(&server, Duration::from_secs(12));
+        assert!(
+            subtitle.contains("192.168.1.5:1234"),
+            "subtitle missing connect target: {subtitle}"
+        );
+        assert!(
+            subtitle.contains("shack-pi"),
+            "subtitle missing advertised hostname: {subtitle}"
+        );
+        assert!(
+            !subtitle.contains(".local"),
+            "subtitle should strip .local suffix: {subtitle}"
+        );
+        assert!(
+            subtitle.contains("R820T"),
+            "subtitle missing tuner: {subtitle}"
+        );
+        assert!(
+            subtitle.contains("29 gains"),
+            "subtitle missing gain count: {subtitle}"
+        );
+        assert!(
+            subtitle.contains("seen 12s ago"),
+            "subtitle missing freshness: {subtitle}"
+        );
+    }
+
+    #[test]
+    fn subtitle_without_ip_omits_duplicate_hostname_segment() {
+        // No resolved addresses: connect target falls back to the
+        // hostname itself. Showing it twice (once as target, once as
+        // hostname segment) would be noise, so the hostname segment
+        // is suppressed when it would duplicate the target.
+        let server = sample_server(vec![], "shack-pi.local.");
+        let subtitle = format_discovery_subtitle(&server, Duration::from_secs(1));
+        assert!(
+            subtitle.starts_with("shack-pi.local.:1234"),
+            "subtitle should use hostname as target: {subtitle}"
+        );
+        // Exactly two ` • ` separators: target + hardware/freshness.
+        assert_eq!(
+            subtitle.matches(" • ").count(),
+            1,
+            "expected one bullet separator when hostname segment is suppressed: {subtitle}"
+        );
+    }
+
+    #[test]
+    fn subtitle_fresh_announce_reads_just_now() {
+        // On the initial announce, elapsed is effectively 0 — the
+        // subtitle should say "just now" rather than "0s ago".
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        let server = sample_server(vec![ip], "radio.local.");
+        let subtitle = format_discovery_subtitle(&server, Duration::from_millis(50));
+        assert!(
+            subtitle.ends_with("seen just now"),
+            "subtitle should read 'seen just now' for sub-5s age: {subtitle}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Second PR of epic #299, delivering the two independent children that together take the rtl_tcp stack from "works via manual host:port entry" to "works by clicking a server in the sidebar":

- **#302** — mDNS/DNS-SD auto-discovery. New `sdr-rtltcp-discovery` crate with `Advertiser` + `Browser`, plus `-N <name>` / `--no-announce` CLI flags on `sdr-rtl-tcp` so the server advertises by default.
- **#321** — GTK client picker. New `SourceType::RtlTcp` variant, live discovered-servers list in the source panel, Connect buttons that wire hostname/port and switch source type, tuning controls (gain/AGC/PPM/sample rate) route to the remote dongle.

## Key design calls

**No Advertiser in the server crate.** Discovery lives in its own crate so `sdr-server-rtltcp` stays free of an `mdns-sd` dependency. A caller who just wants the `Server` API doesn't pull in the mDNS tree; the CLI binary composes both.

**`Source` trait reuse for remote tuning.** `RtlTcpSource` now implements the optional `Source::set_gain` / `set_gain_mode` / `set_ppm_correction` hooks by delegating to the typed setters from #301. The existing `UiToDsp::SetGain` / `SetAgc` / `SetPpmCorrection` messages route through unchanged — zero controller-side branching on source type, zero UI duplication. Saved ~200 lines of plumbing vs. the "duplicate every control" alternative that SDR++ uses.

**`AtomicU64` f64 bit-patterns for the sample-rate / center-freq cache.** Prior CR round caught a split-brain where `set_sample_rate_hz()` updated the wire but not the cached getter value. Moved both caches to `SharedState` as atomic bit-patterns so every setter path (trait `&mut self` + typed `&self`) reads/writes the same source of truth.

## Deferred to siblings

- **#322 Server panel** — next PR. Share-over-network toggle, dongle-presence detection, activity log, server stats row.
- **#323 Integration polish** — after #322. Local-vs-network exclusivity guards, config persistence, connection-state UX (Connecting / Retrying / Failed in the status row), currently-connected metadata card, bandwidth advisory at high sample rates.

## Test plan

- [ ] `cargo test --workspace` — 822 passing, 1 ignored (multicast-dependent mDNS roundtrip; run locally with `cargo test --ignored mdns_roundtrip`)
- [ ] `make install CARGO_FLAGS=\"--release\"` — then smoke:
  - [ ] Run `sdr-rtl-tcp` with a real dongle, verify `[INFO] rtl_tcp mDNS advertisement registered` log line
  - [ ] `avahi-browse _rtl_tcp._tcp` from another terminal — see the advertised service with TXT fields (tuner, version, gains, nickname)
  - [ ] Open the GTK UI, switch source to "RTL-TCP (network)" — discovered list should populate within ~5 s
  - [ ] Click Connect on the discovered row — hostname/port populate, source switches to RTL-TCP
  - [ ] Click Play — spectrum/audio live, tune via the frequency dial (routes to remote dongle via 5-byte command)
  - [ ] Adjust gain slider — verify gain change reaches the remote dongle
  - [ ] Stop + kill the server binary, verify the row disappears from the discovered list within ~30 s (mDNS TTL)

## Linked issues

Part of epic **#299**.
Closes **#302**.
Closes **#321**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RTL‑TCP: new source type added (selectable in UI) with tuning, gain/AGC and PPM controls and hostname/port fields.
  * LAN discovery: built‑in mDNS browser lists _rtl_tcp._tcp.local. servers, prunes stale entries, and adds per‑server Connect rows that populate host/port and select RTL‑TCP.
  * mDNS advertising: optional server announce with CLI nickname/disable flag; structured TXT metadata includes tuner info.
  * New optional discovery crate and UI wiring to enable advertise/discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->