### PR TITLE
feat(macos): finish M5 — ABI guard, digit-based frequency entry, BandwidthEntry

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -402,6 +402,20 @@ public final class SdrCore: @unchecked Sendable {
         )
     }
 
+    /// ABI version the Swift wrapper was COMPILED against, pulled
+    /// from the C header's `SDR_CORE_ABI_VERSION_*` `#define`s at
+    /// build time via Clang's macro import. Compare with
+    /// `abiVersion` (runtime) at launch to catch a catastrophic
+    /// packaging bug where the Swift side and the statically-
+    /// linked `libsdr_ffi.a` drifted apart — a mismatched major
+    /// means struct layouts / enum discriminants likely differ
+    /// and the engine will misbehave unpredictably. Fail fast
+    /// instead.
+    public static let compiledAbiVersion: (major: UInt16, minor: UInt16) = (
+        UInt16(SDR_CORE_ABI_VERSION_MAJOR),
+        UInt16(SDR_CORE_ABI_VERSION_MINOR)
+    )
+
     /// Initialize `tracing` log routing to stderr. Optional —
     /// call once before creating any `SdrCore` instance if you
     /// want Rust-side log output visible.

--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -7,6 +7,7 @@
 // spectrum/waterfall + status bar, with the header toolbar
 // attached via `.toolbar`.
 
+import AppKit
 import SwiftUI
 
 struct ContentView: View {
@@ -23,6 +24,34 @@ struct ContentView: View {
             }
         }
         .toolbar { HeaderToolbar() }
+        // Fatal ABI-mismatch modal. The binding's setter is a
+        // no-op so dismissing the alert is impossible — the
+        // only action is Quit. Matches the spec ("fail launch
+        // with a dialog, since nothing else will work") in
+        // `2026-04-12-swift-ui-surface-design.md`.
+        .alert(
+            "SDR engine version mismatch",
+            isPresented: Binding(
+                get: { model.abiMismatch != nil },
+                set: { _ in }
+            ),
+            presenting: model.abiMismatch
+        ) { _ in
+            Button("Quit", role: .destructive) {
+                NSApplication.shared.terminate(nil)
+            }
+        } message: { mismatch in
+            Text("""
+                This build of SDR was compiled against engine \
+                ABI \(mismatch.compiled.major).\(mismatch.compiled.minor), \
+                but the linked library reports \
+                \(mismatch.runtime.major).\(mismatch.runtime.minor). \
+                A major-version difference means the Swift side \
+                and the Rust engine disagree on fundamental data \
+                layouts; running anyway would crash or produce \
+                bad output. Reinstall a matching build.
+                """)
+        }
     }
 }
 

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -53,6 +53,15 @@ final class CoreModel {
     var isRunning: Bool = false
     var lastError: String? = nil
 
+    /// True when the Swift side's compiled-against ABI major
+    /// version differs from the runtime library's. Set by
+    /// `bootstrap(configPath:)` before any engine work. The UI
+    /// presents a fatal modal and skips `SdrCore` creation — the
+    /// app can't do anything useful against a mismatched ABI, so
+    /// the only option is Quit.
+    var abiMismatch: (compiled: (major: UInt16, minor: UInt16),
+                      runtime: (major: UInt16, minor: UInt16))?
+
     // ==========================================================
     //  Tuning
     // ==========================================================
@@ -191,6 +200,25 @@ final class CoreModel {
     /// if the engine is already up.
     func bootstrap(configPath: URL) async {
         guard core == nil else { return }
+
+        // ABI guard. Runs BEFORE any engine work so a mismatched
+        // lib can't silently misbehave — a major-version drift
+        // between the compiled Swift wrapper and the statically-
+        // linked `libsdr_ffi.a` means struct layouts / enum
+        // discriminants likely differ and the engine would crash
+        // or misinterpret commands. Catch it at the front door.
+        let compiled = SdrCore.compiledAbiVersion
+        let runtime = SdrCore.abiVersion
+        if compiled.major != runtime.major {
+            abiMismatch = (compiled: compiled, runtime: runtime)
+            lastError = """
+                SDR engine ABI major mismatch: compiled against \
+                \(compiled.major).\(compiled.minor), runtime reports \
+                \(runtime.major).\(runtime.minor). The app can't start.
+                """
+            return
+        }
+
         // Install the Rust tracing subscriber once at process
         // start so engine errors and info logs land on stderr
         // (captured by Console.app / the xcrun log stream).

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -443,9 +443,27 @@ final class CoreModel {
     //  Commands — optimistic setters
     // ==========================================================
 
+    /// Upper bound for center frequency in Hz. Matches the
+    /// 12-digit display range in `FrequencyDigitsEntry`
+    /// (999.999.999.999 Hz — well above any known SDR tuner).
+    /// The clamp in `setCenter` is the canonical validation
+    /// point for every tune path — digit entry, VFO click-to-
+    /// tune retune, menu shortcuts, engine-event syncs —
+    /// instead of each caller reinventing the check.
+    static let maxCenterFrequencyHz: Double = 999_999_999_999
+
     func setCenter(_ hz: Double) {
-        centerFrequencyHz = hz
-        capture { try core?.tune(hz) }
+        // Clamp non-finite and out-of-range values before both
+        // the UI write and the engine call. Prevents NaN / Inf /
+        // negative tune commands from any caller (per #327 review).
+        let clamped: Double
+        if !hz.isFinite {
+            clamped = centerFrequencyHz
+        } else {
+            clamped = max(0, min(Self.maxCenterFrequencyHz, hz))
+        }
+        centerFrequencyHz = clamped
+        capture { try core?.tune(clamped) }
     }
 
     func setSampleRate(_ hz: Double) {

--- a/apps/macos/SDRMac/Views/BandwidthEntry.swift
+++ b/apps/macos/SDRMac/Views/BandwidthEntry.swift
@@ -1,0 +1,108 @@
+//
+// BandwidthEntry.swift — compact text field + demod-aware
+// preset picker for the Radio sidebar's bandwidth row.
+//
+// The plain `TextField` + `.formatted(.number)` it replaces
+// forced the user to type an exact Hz value every time — fine
+// for precision but hostile to the common case of "give me
+// standard WFM broadcast", which every SDR app has as a preset.
+//
+// This view wraps the same permissive parse rules as the big
+// `FrequencyEntry` (accepts "200k", "12.5kHz", "2.4M", etc.)
+// plus a pop-up menu of bandwidths per demod mode:
+//
+//   WFM: 150k / 200k / 250k
+//   NFM: 6.25k / 12.5k / 25k
+//   AM:  3k / 6k / 9k / 10k
+//   SSB: 1.8k / 2.4k / 2.7k / 3k           (USB & LSB share)
+//   DSB: 6k / 10k / 16k
+//   CW:  100 / 250 / 500 / 1k
+//   RAW: no presets (user picks raw bandwidth)
+//
+// Presets come from typical amateur / broadcast bandwidths — a
+// future GitHub issue can surface them in Settings if users
+// want to customize. For v1 the list is hardcoded and matches
+// what the GTK panel offers.
+
+import SwiftUI
+import SdrCoreKit
+
+struct BandwidthEntry: View {
+    @Binding var hz: Double
+    let mode: DemodMode
+    var commit: (Double) -> Void
+
+    @State private var text: String = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack(spacing: 2) {
+            TextField("Hz", text: $text)
+                .textFieldStyle(.roundedBorder)
+                .monospacedDigit()
+                .focused($focused)
+                .onAppear { text = formatRate(hz) }
+                .onChange(of: hz) { _, new in
+                    if !focused { text = formatRate(new) }
+                }
+                .onChange(of: mode) { _, _ in
+                    // Mode switched — don't auto-pick a preset
+                    // (the engine handles that on its side), but
+                    // re-render in case units cross a threshold
+                    // after the model's bandwidth settles.
+                    if !focused { text = formatRate(hz) }
+                }
+                .onSubmit(commitFromField)
+
+            // Chevron-down menu for presets. Hidden entirely for
+            // `raw` mode where a canonical preset list doesn't
+            // exist.
+            if !Self.presets(for: mode).isEmpty {
+                Menu {
+                    ForEach(Self.presets(for: mode), id: \.self) { preset in
+                        Button(formatRate(preset)) {
+                            apply(preset)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "chevron.down")
+                        .imageScale(.small)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("Bandwidth presets for \(mode.label)")
+            }
+        }
+    }
+
+    private func commitFromField() {
+        if let v = parseHzFrequency(text), v > 0 {
+            apply(v)
+        } else {
+            // Revert on parse failure — same contract as
+            // FrequencyEntry.
+            text = formatRate(hz)
+        }
+    }
+
+    private func apply(_ value: Double) {
+        hz = value
+        commit(value)
+        text = formatRate(value)
+    }
+
+    /// Common bandwidths per demod mode. Hz. Ordered narrow →
+    /// wide so the menu reads naturally.
+    static func presets(for mode: DemodMode) -> [Double] {
+        switch mode {
+        case .wfm:        return [150_000, 200_000, 250_000]
+        case .nfm:        return [6_250, 12_500, 25_000]
+        case .am:         return [3_000, 6_000, 9_000, 10_000]
+        case .usb, .lsb:  return [1_800, 2_400, 2_700, 3_000]
+        case .dsb:        return [6_000, 10_000, 16_000]
+        case .cw:         return [100, 250, 500, 1_000]
+        case .raw:        return []
+        }
+    }
+}

--- a/apps/macos/SDRMac/Views/Formatters.swift
+++ b/apps/macos/SDRMac/Views/Formatters.swift
@@ -26,8 +26,9 @@ func formatRate(_ hz: Double) -> String {
 /// interior whitespace, accepts a leading `+`. Rejects negative
 /// inputs — callers treat `nil` as "revert to last value".
 ///
-/// Shared by `FrequencyEntry` (big tuner display) and
-/// `BandwidthEntry` (Radio sidebar). Both want the same
+/// Shared by the bandwidth / frequency text-entry surfaces
+/// (currently `BandwidthEntry`; the big tuner now uses a
+/// digit grid and parses nothing). These inputs want the same
 /// permissive parse rules.
 func parseHzFrequency(_ s: String) -> Double? {
     var trimmed = s.trimmingCharacters(in: .whitespaces).lowercased()

--- a/apps/macos/SDRMac/Views/Formatters.swift
+++ b/apps/macos/SDRMac/Views/Formatters.swift
@@ -31,6 +31,14 @@ func formatRate(_ hz: Double) -> String {
 /// digit grid and parses nothing). These inputs want the same
 /// permissive parse rules.
 func parseHzFrequency(_ s: String) -> Double? {
+    // Sanity cap — 1 THz is well above any known SDR tunable
+    // range, so anything larger is almost certainly a typo
+    // (trailing digit, missing decimal, etc.). Letting
+    // `Double("1e309")` through returns `.infinity`, which then
+    // crashes any downstream `UInt64(hz)` / `Int64(hz)` cast.
+    // Reject non-finite and out-of-range up front.
+    let maxHz: Double = 1e12
+
     var trimmed = s.trimmingCharacters(in: .whitespaces).lowercased()
     if trimmed.hasPrefix("-") { return nil }
     if trimmed.hasPrefix("+") { trimmed = String(trimmed.dropFirst()) }
@@ -42,8 +50,12 @@ func parseHzFrequency(_ s: String) -> Double? {
     ]
     for (suffix, mult) in multipliers where trimmed.hasSuffix(suffix) {
         let body = trimmed.dropLast(suffix.count).trimmingCharacters(in: .whitespaces)
-        if let v = Double(body), v >= 0 { return v * mult }
+        guard let v = Double(body), v.isFinite, v >= 0 else { return nil }
+        let hz = v * mult
+        guard hz.isFinite, hz <= maxHz else { return nil }
+        return hz
     }
-    guard let v = Double(trimmed), v >= 0 else { return nil }
+    guard let v = Double(trimmed),
+          v.isFinite, v >= 0, v <= maxHz else { return nil }
     return v
 }

--- a/apps/macos/SDRMac/Views/Formatters.swift
+++ b/apps/macos/SDRMac/Views/Formatters.swift
@@ -8,8 +8,8 @@ import Foundation
 /// Human-readable sample-rate / bandwidth string. Picks MHz,
 /// kHz, or Hz based on magnitude.
 ///
-/// Used by the Source sidebar panel (sample-rate picker) and
-/// the status bar (effective sample rate).
+/// Used by the Source sidebar panel (sample-rate picker), the
+/// status bar (effective sample rate), and `BandwidthEntry`.
 func formatRate(_ hz: Double) -> String {
     if hz >= 1_000_000 {
         return String(format: "%.3f MHz", hz / 1_000_000)
@@ -18,4 +18,31 @@ func formatRate(_ hz: Double) -> String {
     } else {
         return String(format: "%.0f Hz", hz)
     }
+}
+
+/// Parse a human-typed frequency / bandwidth string. Accepts
+/// plain Hz or `GHz`/`MHz`/`kHz` suffixes and their single-letter
+/// variants ("100.7M", "446k", "2.4G"). Case-insensitive, ignores
+/// interior whitespace, accepts a leading `+`. Rejects negative
+/// inputs — callers treat `nil` as "revert to last value".
+///
+/// Shared by `FrequencyEntry` (big tuner display) and
+/// `BandwidthEntry` (Radio sidebar). Both want the same
+/// permissive parse rules.
+func parseHzFrequency(_ s: String) -> Double? {
+    var trimmed = s.trimmingCharacters(in: .whitespaces).lowercased()
+    if trimmed.hasPrefix("-") { return nil }
+    if trimmed.hasPrefix("+") { trimmed = String(trimmed.dropFirst()) }
+    let multipliers: [(String, Double)] = [
+        ("ghz", 1_000_000_000), ("g", 1_000_000_000),
+        ("mhz", 1_000_000),     ("m", 1_000_000),
+        ("khz", 1_000),         ("k", 1_000),
+        ("hz", 1),
+    ]
+    for (suffix, mult) in multipliers where trimmed.hasSuffix(suffix) {
+        let body = trimmed.dropLast(suffix.count).trimmingCharacters(in: .whitespaces)
+        if let v = Double(body), v >= 0 { return v * mult }
+    }
+    guard let v = Double(trimmed), v >= 0 else { return nil }
+    return v
 }

--- a/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
+++ b/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
@@ -155,12 +155,26 @@ struct FrequencyDigitsEntry: View {
 
     /// Step the frequency by ±(10^position). Positive delta =
     /// increase, negative = decrease. Clamped to the valid range.
+    ///
+    /// Clamp `hz` into range BEFORE converting, not just after.
+    /// If a caller set an out-of-range value externally (e.g. a
+    /// tune command that the engine clamps silently), the base
+    /// we step from must be the clamped value, not the stale
+    /// binding — otherwise `+1` on an already-too-big number
+    /// produces garbage. Per #327 review.
     private func step(digit position: Int, by delta: Int) {
         let stepHz = Self.digitStep(position)
-        let current = UInt64(max(0, hz))
+        let current = UInt64(
+            max(0, min(Double(Self.maxFrequencyHz), hz))
+        )
         let new: UInt64
         if delta > 0 {
-            new = min(Self.maxFrequencyHz, current &+ stepHz)
+            // Plain `+` (not `&+`) so an unforeseen overflow
+            // traps loudly instead of wrapping silently. The
+            // `min` above guarantees we can't actually overflow
+            // a UInt64 here — maxFrequencyHz + 100_000_000_000
+            // is nowhere near UInt64.max.
+            new = min(Self.maxFrequencyHz, current + stepHz)
         } else {
             new = current >= stepHz ? current - stepHz : 0
         }
@@ -194,9 +208,15 @@ struct FrequencyDigitsEntry: View {
     /// and ignores separator dots. Close enough for scroll
     /// intent; click-to-select uses `.onTapGesture` on the
     /// digit views directly so it's pixel-accurate.
+    ///
+    /// Multiply by `numDigits` (not `numDigits - 1`) so each
+    /// digit owns an equal 1/12 slice of the width. Using
+    /// `numDigits - 1` made the rightmost slice reachable only
+    /// at exactly frac == 1.0, which effectively hid the 1 Hz
+    /// digit from the scroll path. Per #327 review.
     private func digitIndex(atFraction frac: CGFloat) -> Int {
         let f = max(0, min(1, frac))
-        let idx = Int(f * CGFloat(Self.numDigits - 1))
+        let idx = Int(f * CGFloat(Self.numDigits))
         return max(0, min(Self.numDigits - 1, idx))
     }
 

--- a/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
+++ b/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
@@ -1,0 +1,342 @@
+//
+// FrequencyDigitsEntry.swift — the big tuner display in the
+// header toolbar. 12 digits grouped as DDD.DDD.DDD.DDD Hz, one
+// selected at a time. Ports the GTK widget at
+// `crates/sdr-ui/src/header/frequency_selector.rs` so both apps
+// feel the same at the spot users interact with most.
+//
+// ## Interactions
+//
+// - **Click a digit** → selects it (and focuses the control so
+//   keyboard input works).
+// - **Scroll wheel over a digit** → steps that digit (up = +,
+//   down = −). Doesn't require the control to be focused.
+// - **↑ / ↓** → step the SELECTED digit.
+// - **← / →** → move the selection one position.
+// - **0–9 typed** → sets the selected digit to that value and
+//   advances the selection to the next position.
+//
+// Leading zeros are rendered dimmed so the displayed magnitude
+// reads at a glance. Negative / out-of-range values are clamped
+// to `[0, 999_999_999_999]` Hz (999.999.999.999 — way past any
+// real SDR's tunable range).
+
+import AppKit
+import SwiftUI
+
+struct FrequencyDigitsEntry: View {
+    @Binding var hz: Double
+    var commit: (Double) -> Void
+
+    @State private var digits: [UInt8] = Array(repeating: 0, count: Self.numDigits)
+    @State private var selectedIndex: Int = Self.numDigits - 1  // rightmost (Hz) by default
+    @FocusState private var focused: Bool
+
+    static let numDigits: Int = 12
+    static let maxFrequencyHz: UInt64 = 999_999_999_999
+
+    private static let digitFont: Font = .system(.title3, design: .monospaced)
+    private static let separatorFont: Font = .system(.title3, design: .monospaced)
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(0..<Self.numDigits, id: \.self) { i in
+                digitLabel(at: i)
+                // Separator dots after digits 2, 5, 8 — matches
+                // the GTK `DDD.DDD.DDD.DDD` grouping.
+                if i == 2 || i == 5 || i == 8 {
+                    Text(".")
+                        .font(Self.separatorFont)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(.separator, lineWidth: 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color(nsColor: .textBackgroundColor))
+                )
+        )
+        .focusable()
+        .focused($focused)
+        // Per-digit scroll wheel step. Consumes scrollWheel only
+        // when the cursor is over the frequency control so
+        // scrolls elsewhere (spectrum, sidebar) still work.
+        .background(
+            DigitScrollCatcher { fracX in
+                let i = digitIndex(atFraction: fracX)
+                selectedIndex = i
+                return i
+            } onStep: { i, delta in
+                step(digit: i, by: delta)
+            }
+            .allowsHitTesting(false)
+        )
+        .onAppear { syncDigitsFromHz() }
+        .onChange(of: hz) { _, _ in syncDigitsFromHz() }
+        .onKeyPress(phases: .down) { handleKey($0) }
+        .help("""
+            Click a digit and use arrow keys: ↑/↓ step the \
+            selected digit, ←/→ move selection, 0–9 set the \
+            digit. Scroll wheel also works over any digit.
+            """)
+    }
+
+    // ----------------------------------------------------------
+    //  Digit rendering
+    // ----------------------------------------------------------
+
+    private func digitLabel(at i: Int) -> some View {
+        let firstNonzero = digits.firstIndex(where: { $0 != 0 }) ?? Self.numDigits
+        let isLeading = i < firstNonzero && i != Self.numDigits - 1
+        let isSelected = focused && i == selectedIndex
+
+        return Text("\(digits[i])")
+            .font(Self.digitFont)
+            .foregroundStyle(isLeading ? .tertiary : .primary)
+            .frame(minWidth: 12)
+            .background(
+                isSelected
+                    ? Color.accentColor.opacity(0.35)
+                    : Color.clear
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                selectedIndex = i
+                focused = true
+            }
+    }
+
+    // ----------------------------------------------------------
+    //  Key handling
+    // ----------------------------------------------------------
+
+    private func handleKey(_ press: KeyPress) -> KeyPress.Result {
+        switch press.key {
+        case .upArrow:
+            step(digit: selectedIndex, by: +1)
+            return .handled
+        case .downArrow:
+            step(digit: selectedIndex, by: -1)
+            return .handled
+        case .leftArrow:
+            if selectedIndex > 0 { selectedIndex -= 1 }
+            return .handled
+        case .rightArrow:
+            if selectedIndex < Self.numDigits - 1 { selectedIndex += 1 }
+            return .handled
+        default:
+            break
+        }
+        // Digit keys 0-9. `press.characters` includes the typed
+        // string form (including keypad digits).
+        if let ch = press.characters.first,
+           let n = ch.wholeNumberValue,
+           (0...9).contains(n)
+        {
+            setDigit(UInt8(n))
+            return .handled
+        }
+        return .ignored
+    }
+
+    // ----------------------------------------------------------
+    //  State mutations
+    // ----------------------------------------------------------
+
+    private func syncDigitsFromHz() {
+        let clamped = UInt64(max(0, min(Double(Self.maxFrequencyHz), hz)))
+        digits = Self.freqToDigits(clamped)
+    }
+
+    /// Step the frequency by ±(10^position). Positive delta =
+    /// increase, negative = decrease. Clamped to the valid range.
+    private func step(digit position: Int, by delta: Int) {
+        let stepHz = Self.digitStep(position)
+        let current = UInt64(max(0, hz))
+        let new: UInt64
+        if delta > 0 {
+            new = min(Self.maxFrequencyHz, current &+ stepHz)
+        } else {
+            new = current >= stepHz ? current - stepHz : 0
+        }
+        commitFrequency(new)
+    }
+
+    /// Set the selected digit to `value` and advance selection.
+    private func setDigit(_ value: UInt8) {
+        var d = digits
+        d[selectedIndex] = value
+        let new = min(Self.maxFrequencyHz, Self.digitsToFreq(d))
+        commitFrequency(new)
+        if selectedIndex < Self.numDigits - 1 {
+            selectedIndex += 1
+        }
+    }
+
+    private func commitFrequency(_ newFreq: UInt64) {
+        let f = Double(newFreq)
+        digits = Self.freqToDigits(newFreq)
+        hz = f
+        commit(f)
+    }
+
+    // ----------------------------------------------------------
+    //  Hit-test helper for scroll wheel
+    // ----------------------------------------------------------
+
+    /// Map a 0..1 fraction across the control's width to a
+    /// digit index. Approximate — assumes uniform digit widths
+    /// and ignores separator dots. Close enough for scroll
+    /// intent; click-to-select uses `.onTapGesture` on the
+    /// digit views directly so it's pixel-accurate.
+    private func digitIndex(atFraction frac: CGFloat) -> Int {
+        let f = max(0, min(1, frac))
+        let idx = Int(f * CGFloat(Self.numDigits - 1))
+        return max(0, min(Self.numDigits - 1, idx))
+    }
+
+    // ----------------------------------------------------------
+    //  Digit arithmetic (ported from frequency_selector.rs)
+    // ----------------------------------------------------------
+
+    static func freqToDigits(_ freq: UInt64) -> [UInt8] {
+        var digits = Array(repeating: UInt8(0), count: numDigits)
+        var remaining = min(freq, maxFrequencyHz)
+        for i in stride(from: numDigits - 1, through: 0, by: -1) {
+            digits[i] = UInt8(remaining % 10)
+            remaining /= 10
+        }
+        return digits
+    }
+
+    static func digitsToFreq(_ digits: [UInt8]) -> UInt64 {
+        var freq: UInt64 = 0
+        for d in digits {
+            freq = freq * 10 + UInt64(d)
+        }
+        return freq
+    }
+
+    /// Step size (Hz) for a digit position.
+    /// Position 0 = 100 GHz (10^11); position 11 = 1 Hz (10^0).
+    static func digitStep(_ position: Int) -> UInt64 {
+        precondition(position >= 0 && position < numDigits,
+                     "digit position out of range")
+        // Precomputed; `pow(10, ...)` on UInt64 isn't free at
+        // runtime and this is hot during arrow-key repeat.
+        let steps: [UInt64] = [
+            100_000_000_000,  // 100 GHz
+            10_000_000_000,   // 10 GHz
+            1_000_000_000,    // 1 GHz
+            100_000_000,      // 100 MHz
+            10_000_000,       // 10 MHz
+            1_000_000,        // 1 MHz
+            100_000,          // 100 kHz
+            10_000,           // 10 kHz
+            1_000,            // 1 kHz
+            100,              // 100 Hz
+            10,               // 10 Hz
+            1,                // 1 Hz
+        ]
+        return steps[position]
+    }
+}
+
+// ============================================================
+//  DigitScrollCatcher — NSEvent local monitor for per-digit
+//  scroll-wheel stepping.
+// ============================================================
+//
+//  Same pattern as `ScrollWheelZoomCatcher` in CenterView but
+//  with a finer-grained callback: instead of one zoom delta, we
+//  pass (digit_index, +1/-1) so the parent view can route each
+//  event to the right digit.
+
+private struct DigitScrollCatcher: NSViewRepresentable {
+    /// Map the cursor's 0..1 fractional x-position across the
+    /// view to a digit index. Called on each scroll event.
+    let digitAtFraction: (CGFloat) -> Int
+    /// Called with the chosen digit + step direction (+1 up,
+    /// -1 down).
+    let onStep: (Int, Int) -> Void
+
+    func makeNSView(context: Context) -> MonitorView {
+        MonitorView(digitAtFraction: digitAtFraction, onStep: onStep)
+    }
+
+    func updateNSView(_ nsView: MonitorView, context: Context) {
+        nsView.digitAtFraction = digitAtFraction
+        nsView.onStep = onStep
+    }
+
+    final class MonitorView: NSView {
+        var digitAtFraction: (CGFloat) -> Int
+        var onStep: (Int, Int) -> Void
+        private var monitor: Any?
+
+        init(
+            digitAtFraction: @escaping (CGFloat) -> Int,
+            onStep: @escaping (Int, Int) -> Void
+        ) {
+            self.digitAtFraction = digitAtFraction
+            self.onStep = onStep
+            super.init(frame: .zero)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("DigitScrollCatcher.MonitorView does not support NSCoder init")
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if window != nil {
+                startMonitor()
+            } else {
+                stopMonitor()
+            }
+        }
+
+        deinit {
+            stopMonitor()
+        }
+
+        private func startMonitor() {
+            guard monitor == nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                guard let self, let window = self.window,
+                      event.window === window else { return event }
+                let locInView = self.convert(event.locationInWindow, from: nil)
+                guard self.bounds.contains(locInView) else { return event }
+                // Skip the trackpad momentum tail — same reason
+                // as CenterView's zoom: a flick would advance 40
+                // digits.
+                if !event.momentumPhase.isEmpty {
+                    return event
+                }
+                let fracX = self.bounds.width > 0
+                    ? locInView.x / self.bounds.width
+                    : 0.5
+                let idx = self.digitAtFraction(fracX)
+                // dy > 0 on trackpad = natural scroll up, i.e.
+                // content moves up, meaning the user wants to
+                // see larger numbers. Step +1.
+                let direction = event.scrollingDeltaY > 0 ? 1 : -1
+                self.onStep(idx, direction)
+                return nil
+            }
+        }
+
+        private func stopMonitor() {
+            if let m = monitor {
+                NSEvent.removeMonitor(m)
+                monitor = nil
+            }
+        }
+    }
+}

--- a/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
+++ b/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
@@ -51,18 +51,21 @@ struct FrequencyDigitsEntry: View {
                 }
             }
         }
-        .padding(.horizontal, 4)
+        // Horizontal padding sizes the native toolbar pill — the
+        // pill hugs the content, so a bit of breathing room
+        // inside the HStack translates to a wider, less-cramped
+        // pill.
+        .padding(.horizontal, 12)
         .padding(.vertical, 2)
-        .background(
-            RoundedRectangle(cornerRadius: 4)
-                .stroke(.separator, lineWidth: 1)
-                .background(
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color(nsColor: .textBackgroundColor))
-                )
-        )
         .focusable()
         .focused($focused)
+        // Suppress SwiftUI's default focus ring (the blue
+        // rectangle that wraps the whole digit row when the
+        // control gains keyboard focus). The selected-digit
+        // underline is our intentional selection indicator —
+        // the focus ring is redundant + clashes with the
+        // toolbar pill behind it.
+        .focusEffectDisabled()
         // Per-digit scroll wheel step. Consumes scrollWheel only
         // when the cursor is over the frequency control so
         // scrolls elsewhere (spectrum, sidebar) still work.
@@ -99,11 +102,7 @@ struct FrequencyDigitsEntry: View {
             .font(Self.digitFont)
             .foregroundStyle(isLeading ? .tertiary : .primary)
             .frame(minWidth: 12)
-            .background(
-                isSelected
-                    ? Color.accentColor.opacity(0.35)
-                    : Color.clear
-            )
+            .underline(isSelected, color: .accentColor)
             .contentShape(Rectangle())
             .onTapGesture {
                 selectedIndex = i
@@ -195,6 +194,12 @@ struct FrequencyDigitsEntry: View {
     private func commitFrequency(_ newFreq: UInt64) {
         let f = Double(newFreq)
         digits = Self.freqToDigits(newFreq)
+        // Skip the engine round-trip when the frequency is
+        // unchanged. Hitting the clamp floor / ceiling or
+        // re-entering a digit with the same value would
+        // otherwise spam duplicate `setCenter(...)` calls onto
+        // the DSP command channel. Per #327 review.
+        guard hz != f else { return }
         hz = f
         commit(f)
     }
@@ -343,10 +348,17 @@ private struct DigitScrollCatcher: NSViewRepresentable {
                     ? locInView.x / self.bounds.width
                     : 0.5
                 let idx = self.digitAtFraction(fracX)
+                // Horizontal-only trackpad gestures still
+                // deliver scrollWheel events with dy == 0.
+                // Treating 0 as "negative" would decrement the
+                // digit on every stray horizontal swipe; skip
+                // those cleanly. Per #327 review.
+                let dy = event.scrollingDeltaY
+                guard dy != 0 else { return event }
                 // dy > 0 on trackpad = natural scroll up, i.e.
                 // content moves up, meaning the user wants to
                 // see larger numbers. Step +1.
-                let direction = event.scrollingDeltaY > 0 ? 1 : -1
+                let direction = dy > 0 ? 1 : -1
                 self.onStep(idx, direction)
                 return nil
             }

--- a/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
+++ b/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
@@ -87,6 +87,57 @@ struct FrequencyDigitsEntry: View {
             selected digit, ←/→ move selection, 0–9 set the \
             digit. Scroll wheel also works over any digit.
             """)
+        // Accessibility: expose the row as a single adjustable
+        // element. VoiceOver reads the current frequency + the
+        // selected digit, and increment/decrement drive
+        // `step(digit:by:)` on the selected digit. Per-digit
+        // access is still available to sighted users via click /
+        // arrow keys, but a single-element adjustable is what
+        // screen readers expect for a numeric spinner.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Frequency")
+        .accessibilityValue(accessibilityValue)
+        .accessibilityHint("Adjustable. Increment or decrement the selected digit.")
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment:
+                step(digit: selectedIndex, by: +1)
+            case .decrement:
+                step(digit: selectedIndex, by: -1)
+            @unknown default:
+                break
+            }
+        }
+        .accessibilityAction(named: "Select next digit") {
+            if selectedIndex < Self.numDigits - 1 {
+                selectedIndex += 1
+            }
+        }
+        .accessibilityAction(named: "Select previous digit") {
+            if selectedIndex > 0 {
+                selectedIndex -= 1
+            }
+        }
+    }
+
+    /// VoiceOver-friendly rendering of the current state. Reads
+    /// like "100.700 megahertz, selecting 10 kilohertz digit"
+    /// so the user knows both the value and what the next
+    /// increment/decrement will affect.
+    private var accessibilityValue: String {
+        let freq = formatRate(hz)
+            .replacingOccurrences(of: "MHz", with: "megahertz")
+            .replacingOccurrences(of: "kHz", with: "kilohertz")
+            .replacingOccurrences(of: "Hz", with: "hertz")
+        let stepSize = Self.digitStep(selectedIndex)
+        let stepLabel: String
+        switch stepSize {
+        case 1_000_000_000...: stepLabel = "\(stepSize / 1_000_000_000) gigahertz"
+        case 1_000_000...:     stepLabel = "\(stepSize / 1_000_000) megahertz"
+        case 1_000...:         stepLabel = "\(stepSize / 1_000) kilohertz"
+        default:               stepLabel = "\(stepSize) hertz"
+        }
+        return "\(freq), selecting \(stepLabel) digit"
     }
 
     // ----------------------------------------------------------
@@ -247,28 +298,31 @@ struct FrequencyDigitsEntry: View {
         return freq
     }
 
+    /// Step size (Hz) for each digit position. Module-private
+    /// static so key-repeat / scroll events don't re-allocate a
+    /// 12-entry array on every invocation.
+    /// Position 0 = 100 GHz (10^11); position 11 = 1 Hz (10^0).
+    private static let digitStepTable: [UInt64] = [
+        100_000_000_000,  // 100 GHz
+        10_000_000_000,   // 10 GHz
+        1_000_000_000,    // 1 GHz
+        100_000_000,      // 100 MHz
+        10_000_000,       // 10 MHz
+        1_000_000,        // 1 MHz
+        100_000,          // 100 kHz
+        10_000,           // 10 kHz
+        1_000,             // 1 kHz
+        100,              // 100 Hz
+        10,               // 10 Hz
+        1,                // 1 Hz
+    ]
+
     /// Step size (Hz) for a digit position.
     /// Position 0 = 100 GHz (10^11); position 11 = 1 Hz (10^0).
     static func digitStep(_ position: Int) -> UInt64 {
         precondition(position >= 0 && position < numDigits,
                      "digit position out of range")
-        // Precomputed; `pow(10, ...)` on UInt64 isn't free at
-        // runtime and this is hot during arrow-key repeat.
-        let steps: [UInt64] = [
-            100_000_000_000,  // 100 GHz
-            10_000_000_000,   // 10 GHz
-            1_000_000_000,    // 1 GHz
-            100_000_000,      // 100 MHz
-            10_000_000,       // 10 MHz
-            1_000_000,        // 1 MHz
-            100_000,          // 100 kHz
-            10_000,           // 10 kHz
-            1_000,            // 1 kHz
-            100,              // 100 Hz
-            10,               // 10 Hz
-            1,                // 1 Hz
-        ]
-        return steps[position]
+        return digitStepTable[position]
     }
 }
 

--- a/apps/macos/SDRMac/Views/HeaderToolbar.swift
+++ b/apps/macos/SDRMac/Views/HeaderToolbar.swift
@@ -25,10 +25,9 @@ struct HeaderToolbar: ToolbarContent {
 
         ToolbarItem(placement: .principal) {
             @Bindable var m = model
-            FrequencyEntry(hz: $m.centerFrequencyHz) { hz in
+            FrequencyDigitsEntry(hz: $m.centerFrequencyHz) { hz in
                 model.setCenter(hz)
             }
-            .frame(width: 220)
         }
 
         ToolbarItem(placement: .primaryAction) {
@@ -52,67 +51,7 @@ struct HeaderToolbar: ToolbarContent {
     }
 }
 
-/// Simple frequency text field. Accepts plain Hz, or MHz/kHz
-/// suffixes ("100.7M", "446k"). Commits via `onSubmit` and
-/// reverts on parse failure.
-///
-/// v1: no per-digit arrow-key step, no tab between digit groups.
-/// Good enough for the first milestone — the polished entry
-/// widget (per-digit steppers, scroll-to-tune) is a v2 follow-up.
-struct FrequencyEntry: View {
-    @Binding var hz: Double
-    var commit: (Double) -> Void
-
-    @State private var text: String = ""
-    @FocusState private var focused: Bool
-
-    var body: some View {
-        TextField("Hz", text: $text)
-            .textFieldStyle(.roundedBorder)
-            .font(.system(.title3, design: .monospaced))
-            .multilineTextAlignment(.center)
-            .focused($focused)
-            .onAppear { text = formatHz(hz) }
-            .onChange(of: hz) { _, new in
-                if !focused { text = formatHz(new) }
-            }
-            .onSubmit {
-                if let v = parseHz(text) {
-                    hz = v
-                    commit(v)
-                    text = formatHz(v)
-                } else {
-                    text = formatHz(hz)
-                }
-            }
-    }
-}
-
-private func formatHz(_ hz: Double) -> String {
-    let mhz = hz / 1_000_000
-    return String(format: "%.4f MHz", mhz)
-}
-
-private func parseHz(_ s: String) -> Double? {
-    var trimmed = s.trimmingCharacters(in: .whitespaces).lowercased()
-    // Reject negative frequencies up front — the engine would
-    // reject them too, but we can give faster feedback here
-    // (FrequencyEntry's onSubmit reverts to the last good value
-    // on nil) rather than letting a doomed tune command flow all
-    // the way to the DSP thread. Accept a leading `+` as a
-    // no-op so "+100M" isn't surprising.
-    if trimmed.hasPrefix("-") { return nil }
-    if trimmed.hasPrefix("+") { trimmed = String(trimmed.dropFirst()) }
-    let multipliers: [(String, Double)] = [
-        ("ghz", 1_000_000_000), ("g", 1_000_000_000),
-        ("mhz", 1_000_000),     ("m", 1_000_000),
-        ("khz", 1_000),         ("k", 1_000),
-        ("hz", 1),
-    ]
-    for (suffix, mult) in multipliers where trimmed.hasSuffix(suffix) {
-        let body = trimmed.dropLast(suffix.count).trimmingCharacters(in: .whitespaces)
-        if let v = Double(body), v >= 0 { return v * mult }
-    }
-    guard let v = Double(trimmed), v >= 0 else { return nil }
-    return v
-}
+// The big tuner display lives in `FrequencyDigitsEntry` — 12
+// individual digits with click/scroll/keyboard per digit,
+// matching the GTK widget. The old `FrequencyEntry` text-field
+// approach was removed in favor of the digit grid.

--- a/apps/macos/SDRMac/Views/RadioSection.swift
+++ b/apps/macos/SDRMac/Views/RadioSection.swift
@@ -15,9 +15,12 @@ struct RadioSection: View {
         Section("Radio") {
             LabeledContent("Bandwidth") {
                 @Bindable var m = model
-                TextField("Hz", value: $m.bandwidthHz, format: .number)
-                    .textFieldStyle(.roundedBorder)
-                    .onSubmit { model.setBandwidth(model.bandwidthHz) }
+                BandwidthEntry(
+                    hz: $m.bandwidthHz,
+                    mode: model.demodMode
+                ) { hz in
+                    model.setBandwidth(hz)
+                }
             }
 
             Toggle("Squelch", isOn: Binding(

--- a/apps/macos/SDRMacTests/CoreModelTests.swift
+++ b/apps/macos/SDRMacTests/CoreModelTests.swift
@@ -36,4 +36,39 @@ final class CoreModelTests: XCTestCase {
         XCTAssertEqual(m.minDb, -90)
         XCTAssertEqual(m.maxDb, -10)
     }
+
+    // ==========================================================
+    //  setCenter clamping (guards all tune paths uniformly)
+    // ==========================================================
+
+    func testSetCenterClampsBelowZero() {
+        let m = CoreModel()
+        m.setCenter(-1_000_000)
+        XCTAssertEqual(m.centerFrequencyHz, 0)
+    }
+
+    func testSetCenterClampsAboveMax() {
+        let m = CoreModel()
+        m.setCenter(10_000_000_000_000)  // 10 THz — over the cap
+        XCTAssertEqual(m.centerFrequencyHz, CoreModel.maxCenterFrequencyHz)
+    }
+
+    func testSetCenterIgnoresNonFinite() {
+        let m = CoreModel()
+        m.setCenter(1_000_000)
+        m.setCenter(.infinity)
+        // Should leave the previous valid value in place rather
+        // than write Inf / NaN.
+        XCTAssertEqual(m.centerFrequencyHz, 1_000_000)
+        m.setCenter(.nan)
+        XCTAssertEqual(m.centerFrequencyHz, 1_000_000)
+    }
+
+    func testSetCenterKeepsInRangeValues() {
+        let m = CoreModel()
+        m.setCenter(88_500_000)
+        XCTAssertEqual(m.centerFrequencyHz, 88_500_000)
+        m.setCenter(1_700_000_000)  // 1.7 GHz — real RTL-SDR top end
+        XCTAssertEqual(m.centerFrequencyHz, 1_700_000_000)
+    }
 }


### PR DESCRIPTION
## Summary

Closes the three remaining gaps in M5 (SwiftUI surface) per
`docs/superpowers/specs/2026-04-12-swift-ui-surface-design.md`:

- **Sub-PR 6**: ABI major-version guard at launch.
- **Sub-PR 2**: big tuner display redesigned as a 12-digit grid ported from the GTK widget.
- **Sub-PR 3**: Bandwidth row upgraded to a compact entry with demod-aware preset menu.

After this, the MVP cut of M5 is feature-complete and ready for M6 (signing / notarization / CI).

## Commits

- `c63d047` **ABI major-mismatch guard** — `SdrCore.compiledAbiVersion` imported from the C header at build time via Clang's macro bridge; compared against `SdrCore.abiVersion` in `CoreModel.bootstrap`. On major drift, skip engine create and present a fatal modal with both versions and a single Quit button.
- `4654feb` **FrequencyDigitsEntry** — 12 digit labels grouped as `DDD.DDD.DDD.DDD` Hz. Click a digit to select, ↑/↓ step the selected digit, ←/→ move the selection, 0–9 set the digit and advance, scroll wheel over any digit steps it. Leading zeros render dimmed. Replaces the old auto-formatting text-field approach entirely. Ports semantics from `crates/sdr-ui/src/header/frequency_selector.rs`.
- `dd9e461` **BandwidthEntry** — text field + chevron-down menu of per-demod presets (WFM 150/200/250 k, NFM 6.25/12.5/25 k, AM 3/6/9/10 k, SSB 1.8/2.4/2.7/3 k, DSB 6/10/16 k, CW 0.1/0.25/0.5/1 k, RAW hidden). Shared permissive parser lives in `Formatters.swift` so both frequency / bandwidth accept the same `"100k"` / `"2.4M"` syntax.

Merged current `main` (rtl-tcp discovery + client picker landed via #324) on top clean — no conflicts. `make lint` + `make mac-test` both green end-to-end.

## Test plan

- [x] `make lint` passes (fmt, clippy `-D warnings`, test, deny, audit, ffi-header-check).
- [x] `make mac-test` — 28 tests, all pass.
- [x] `make mac-app` release build succeeds on top of `main`.
- [x] Smoke: ABI guard doesn't false-fire on a normal build (compiled == runtime).
- [x] Smoke: click + keyboard + scroll-wheel all drive the digit entry as expected.
- [x] Smoke: bandwidth presets change correctly across demod-mode switches; RAW hides the menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup ABI compatibility check that shows a non‑dismissable alert with a Quit option on mismatch, displaying compiled and runtime ABI versions
  * Redesigned frequency entry: 12‑digit grid with per‑digit editing, scroll‑wheel, arrow keys, and direct input
  * New compact bandwidth editor with demodulation‑mode presets
  * Improved frequency/bandwidth parsing supporting Hz/kHz/MHz/GHz suffixes and flexible input formats
<!-- end of auto-generated comment: release notes by coderabbit.ai -->