### PR TITLE
feat(#322): rtl_tcp server panel (share-over-network UI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,6 +2152,7 @@ dependencies = [
  "sdr-radioreference",
  "sdr-rtlsdr",
  "sdr-rtltcp-discovery",
+ "sdr-server-rtltcp",
  "sdr-sink-audio",
  "sdr-source-rtlsdr",
  "sdr-transcription",

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -146,13 +146,50 @@ impl Default for InitialDeviceState {
 }
 
 /// Live server statistics for UI consumption.
+///
+/// Each field is either a session-scoped counter (reset when the
+/// current client disconnects — `bytes_sent`, `buffers_dropped`,
+/// `last_command`, and the `current_*` commanded fields) or a
+/// session-identity hint (`connected_client`, `connected_since`).
+/// UI callers snapshot the struct via `Server::stats()` on a timer
+/// and compute deltas (e.g. data-rate) across consecutive snapshots.
 #[derive(Debug, Clone, Default)]
 pub struct ServerStats {
+    /// Socket address of the currently-connected client. `None`
+    /// means the accept loop is waiting.
     pub connected_client: Option<SocketAddr>,
+    /// Wall-clock moment the current session began. Paired with
+    /// `connected_client`: both are `Some` or both are `None`.
     pub connected_since: Option<Instant>,
+    /// Bytes written to the client socket across the current
+    /// session. Reset to 0 on connect / disconnect.
     pub bytes_sent: u64,
+    /// Buffer-drop count: how many times the USB→TCP queue was
+    /// full when a new IQ block arrived, forcing us to discard.
+    /// Reset to 0 on connect / disconnect.
     pub buffers_dropped: u64,
+    /// Most recent command received from the client, with the
+    /// moment it was dispatched. UI renders this as the "activity
+    /// log" preview. Reset to `None` on disconnect.
     pub last_command: Option<(CommandOp, Instant)>,
+    /// Most recent `SetCenterFreq` value requested by the client,
+    /// in Hz. Populated from the wire param so it reflects what
+    /// the client asked for even if the device layer rejected it;
+    /// UI treats this as "the client thinks we're tuned here."
+    /// Reset on disconnect.
+    pub current_freq_hz: Option<u32>,
+    /// Most recent `SetSampleRate` request, in Hz. Same "client's
+    /// view" semantics as `current_freq_hz`.
+    pub current_sample_rate_hz: Option<u32>,
+    /// Most recent `SetTunerGain` request, in tenths of dB
+    /// (negative is legal per upstream). `None` means the client
+    /// hasn't requested a manual gain since connecting.
+    pub current_gain_tenths_db: Option<i32>,
+    /// `true` when the client most recently sent
+    /// `SetGainMode(auto)`, `false` on `SetGainMode(manual)`,
+    /// `None` when it hasn't sent one this session. UI renders
+    /// "auto" vs "manual" accordingly.
+    pub current_gain_auto: Option<bool>,
 }
 
 /// Tuner metadata captured at open time, exposed for callers that
@@ -560,6 +597,10 @@ fn update_stats_on_connect(stats: &Arc<Mutex<ServerStats>>, peer: SocketAddr) {
         s.bytes_sent = 0;
         s.buffers_dropped = 0;
         s.last_command = None;
+        s.current_freq_hz = None;
+        s.current_sample_rate_hz = None;
+        s.current_gain_tenths_db = None;
+        s.current_gain_auto = None;
     }
 }
 
@@ -575,6 +616,10 @@ fn update_stats_on_disconnect(stats: &Arc<Mutex<ServerStats>>) {
         s.bytes_sent = 0;
         s.buffers_dropped = 0;
         s.last_command = None;
+        s.current_freq_hz = None;
+        s.current_sample_rate_hz = None;
+        s.current_gain_tenths_db = None;
+        s.current_gain_auto = None;
     }
 }
 
@@ -889,6 +934,32 @@ fn command_worker(
         drop(dev);
         if let Ok(mut s) = stats.lock() {
             s.last_command = Some((cmd.op, Instant::now()));
+            // Capture the commanded state alongside the
+            // last-command stamp. We record what the CLIENT
+            // requested (not what the device ultimately applied)
+            // because: (a) the dispatch layer already logs device
+            // failures at warn!, (b) if a SetCenterFreq request is
+            // rejected by the device, the client will re-request,
+            // and (c) showing the client's view helps debug
+            // client-side bugs ("why is GQRX stuck on 145 MHz?").
+            match cmd.op {
+                CommandOp::SetCenterFreq => s.current_freq_hz = Some(cmd.param),
+                CommandOp::SetSampleRate => s.current_sample_rate_hz = Some(cmd.param),
+                CommandOp::SetTunerGain => {
+                    #[allow(
+                        clippy::cast_possible_wrap,
+                        reason = "gain param is signed tenths-of-dB on the wire, u32 is a raw-bits transport"
+                    )]
+                    let gain = cmd.param as i32;
+                    s.current_gain_tenths_db = Some(gain);
+                }
+                CommandOp::SetGainMode => {
+                    // Upstream: 0 = auto, nonzero = manual. Store
+                    // the auto bool for the UI status-row renderer.
+                    s.current_gain_auto = Some(cmd.param == 0);
+                }
+                _ => {}
+            }
         }
     }
 }
@@ -978,15 +1049,21 @@ mod tests {
     #[test]
     fn update_stats_on_disconnect_clears_per_session_counters() {
         // Session-scoped counters (bytes_sent, buffers_dropped,
-        // last_command) must be cleared when the client disconnects —
-        // otherwise a UI polling ServerStats would see stale data from
-        // the prior session while connected_client = None.
+        // last_command, current_* commanded fields) must be cleared
+        // when the client disconnects — otherwise a UI polling
+        // ServerStats would see stale data from the prior session
+        // while connected_client = None, e.g. the status row would
+        // still show "100.3 MHz @ 2.4 MHz" for a dead session.
         let stats = Arc::new(Mutex::new(ServerStats {
             connected_client: Some(SocketAddr::from(([127, 0, 0, 1], 42_000))),
             connected_since: Some(Instant::now()),
             bytes_sent: 12345,
             buffers_dropped: 7,
             last_command: Some((CommandOp::SetCenterFreq, Instant::now())),
+            current_freq_hz: Some(100_300_000),
+            current_sample_rate_hz: Some(2_400_000),
+            current_gain_tenths_db: Some(200),
+            current_gain_auto: Some(false),
         }));
         update_stats_on_disconnect(&stats);
         let s = stats.lock().unwrap();
@@ -995,6 +1072,10 @@ mod tests {
         assert_eq!(s.bytes_sent, 0);
         assert_eq!(s.buffers_dropped, 0);
         assert!(s.last_command.is_none());
+        assert!(s.current_freq_hz.is_none());
+        assert!(s.current_sample_rate_hz.is_none());
+        assert!(s.current_gain_tenths_db.is_none());
+        assert!(s.current_gain_auto.is_none());
     }
 
     #[test]
@@ -1005,6 +1086,10 @@ mod tests {
         assert_eq!(stats.bytes_sent, 0);
         assert_eq!(stats.buffers_dropped, 0);
         assert!(stats.last_command.is_none());
+        assert!(stats.current_freq_hz.is_none());
+        assert!(stats.current_sample_rate_hz.is_none());
+        assert!(stats.current_gain_tenths_db.is_none());
+        assert!(stats.current_gain_auto.is_none());
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -17,6 +17,7 @@
 //! command_worker (TCP recv → dispatch). First worker to exit signals
 //! the others via the shutdown flag.
 
+use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -79,6 +80,14 @@ pub const DEFAULT_SAMPLE_RATE_HZ: u32 = 2_048_000;
 /// Default center frequency in Hz, matching upstream rtl_tcp's
 /// `frequency = 100000000` default at rtl_tcp.c:389.
 pub const DEFAULT_CENTER_FREQ_HZ: u32 = 100_000_000;
+
+/// Maximum number of recent `(CommandOp, Instant)` entries retained
+/// in `ServerStats::recent_commands`. 50 covers a typical rtl_tcp
+/// session's worth of tuning / gain / mode changes — enough to
+/// debug "why didn't my tune command land?" scenarios without
+/// unbounded memory growth on long-running servers. Oldest entries
+/// are popped when the ring fills.
+pub const RECENT_COMMANDS_CAPACITY: usize = 50;
 
 /// Server configuration.
 #[derive(Debug, Clone)]
@@ -190,6 +199,13 @@ pub struct ServerStats {
     /// `None` when it hasn't sent one this session. UI renders
     /// "auto" vs "manual" accordingly.
     pub current_gain_auto: Option<bool>,
+    /// Ring buffer of recent commands received this session, bounded
+    /// at `RECENT_COMMANDS_CAPACITY` entries. Newest-first ordering
+    /// is the UI's responsibility; this preserves insertion order
+    /// (oldest at front, newest at back) so the producer stays cheap
+    /// (`push_back` + `pop_front` at cap). Reset on connect /
+    /// disconnect along with the other per-session counters.
+    pub recent_commands: VecDeque<(CommandOp, Instant)>,
 }
 
 /// Tuner metadata captured at open time, exposed for callers that
@@ -601,6 +617,7 @@ fn update_stats_on_connect(stats: &Arc<Mutex<ServerStats>>, peer: SocketAddr) {
         s.current_sample_rate_hz = None;
         s.current_gain_tenths_db = None;
         s.current_gain_auto = None;
+        s.recent_commands.clear();
     }
 }
 
@@ -620,6 +637,7 @@ fn update_stats_on_disconnect(stats: &Arc<Mutex<ServerStats>>) {
         s.current_sample_rate_hz = None;
         s.current_gain_tenths_db = None;
         s.current_gain_auto = None;
+        s.recent_commands.clear();
     }
 }
 
@@ -933,7 +951,16 @@ fn command_worker(
         dispatch(&mut dev, cmd);
         drop(dev);
         if let Ok(mut s) = stats.lock() {
-            s.last_command = Some((cmd.op, Instant::now()));
+            let now = Instant::now();
+            s.last_command = Some((cmd.op, now));
+            // Push onto the bounded ring. Pop the oldest entry when
+            // we'd otherwise exceed the cap — keeps memory bounded
+            // on long-running sessions without a dedicated ring-
+            // buffer crate.
+            if s.recent_commands.len() >= RECENT_COMMANDS_CAPACITY {
+                s.recent_commands.pop_front();
+            }
+            s.recent_commands.push_back((cmd.op, now));
             // Capture the commanded state alongside the
             // last-command stamp. We record what the CLIENT
             // requested (not what the device ultimately applied)
@@ -1054,6 +1081,9 @@ mod tests {
         // ServerStats would see stale data from the prior session
         // while connected_client = None, e.g. the status row would
         // still show "100.3 MHz @ 2.4 MHz" for a dead session.
+        let mut recent = VecDeque::new();
+        recent.push_back((CommandOp::SetCenterFreq, Instant::now()));
+        recent.push_back((CommandOp::SetTunerGain, Instant::now()));
         let stats = Arc::new(Mutex::new(ServerStats {
             connected_client: Some(SocketAddr::from(([127, 0, 0, 1], 42_000))),
             connected_since: Some(Instant::now()),
@@ -1064,6 +1094,7 @@ mod tests {
             current_sample_rate_hz: Some(2_400_000),
             current_gain_tenths_db: Some(200),
             current_gain_auto: Some(false),
+            recent_commands: recent,
         }));
         update_stats_on_disconnect(&stats);
         let s = stats.lock().unwrap();
@@ -1076,6 +1107,10 @@ mod tests {
         assert!(s.current_sample_rate_hz.is_none());
         assert!(s.current_gain_tenths_db.is_none());
         assert!(s.current_gain_auto.is_none());
+        assert!(
+            s.recent_commands.is_empty(),
+            "activity log ring must clear on disconnect to avoid stale entries in the next session"
+        );
     }
 
     #[test]
@@ -1090,6 +1125,15 @@ mod tests {
         assert!(stats.current_sample_rate_hz.is_none());
         assert!(stats.current_gain_tenths_db.is_none());
         assert!(stats.current_gain_auto.is_none());
+        assert!(stats.recent_commands.is_empty());
+    }
+
+    #[test]
+    fn recent_commands_capacity_matches_documented_bound() {
+        // Sanity check on the published const. If the UI side starts
+        // depending on a specific size for pagination, changing the
+        // constant becomes a contract break this test catches.
+        assert_eq!(RECENT_COMMANDS_CAPACITY, 50);
     }
 
     #[test]

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -51,6 +51,12 @@ sdr-transcription.workspace = true
 # Discovery for the rtl_tcp client picker — Browser events feed the
 # AdwExpanderRow under the source panel.
 sdr-rtltcp-discovery.workspace = true
+# Server for the share-over-network panel. `default-features = false`
+# because we already depend on `sdr-rtltcp-discovery` directly — no
+# need for the server crate to pull in its own (feature-gated) copy.
+# Using the path form (not `workspace = true`) because current cargo
+# rejects child-side `default-features = false` when inheriting.
+sdr-server-rtltcp = { path = "../sdr-server-rtltcp", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -8,6 +8,7 @@ pub mod audio_panel;
 pub mod display_panel;
 pub mod navigation_panel;
 pub mod radio_panel;
+pub mod server_panel;
 pub mod source_panel;
 pub mod transcript_panel;
 
@@ -15,6 +16,7 @@ pub use audio_panel::{AudioPanel, build_audio_panel};
 pub use display_panel::{DisplayPanel, build_display_panel};
 pub use navigation_panel::{NavigationPanel, build_navigation_panel};
 pub use radio_panel::{RadioPanel, build_radio_panel};
+pub use server_panel::{ServerPanel, build_server_panel};
 pub use source_panel::{SourcePanel, build_source_panel};
 pub use transcript_panel::{TranscriptPanel, build_transcript_panel};
 
@@ -35,6 +37,10 @@ pub struct SidebarPanels {
     pub display: DisplayPanel,
     /// Navigation — band presets and bookmarks.
     pub navigation: NavigationPanel,
+    /// Share-over-network (`rtl_tcp` server) controls. Hidden by
+    /// default; `window.rs` reveals it when a local RTL-SDR dongle
+    /// is plugged in and not currently the active source.
+    pub server: ServerPanel,
 }
 
 /// Build the complete sidebar `ScrolledWindow` containing all configuration panels.
@@ -43,6 +49,7 @@ pub struct SidebarPanels {
 /// `SidebarPanels` struct (for DSP bridge signal wiring — see issue #92).
 pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     let source = build_source_panel();
+    let server = build_server_panel();
     let audio = build_audio_panel();
     let radio = build_radio_panel();
     let display = build_display_panel();
@@ -59,6 +66,10 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     sidebar_box.append(&navigation.presets_widget);
     sidebar_box.append(&navigation.bookmarks_widget);
     sidebar_box.append(&source.widget);
+    // Server panel sits directly under Source so the "consume local
+    // dongle" vs "share local dongle" decision is one visual group.
+    // Hidden by default; revealed dynamically by the wiring layer.
+    sidebar_box.append(&server.widget);
     sidebar_box.append(&audio.widget);
     sidebar_box.append(&radio.widget);
     sidebar_box.append(&display.widget);
@@ -74,6 +85,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
         radio,
         display,
         navigation,
+        server,
     };
 
     (scroll, panels)

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -156,6 +156,94 @@ pub struct ServerPanel {
     /// Direct-sampling toggle (Q-branch) applied on server open.
     /// Only useful for HF experimentation; off for normal use.
     pub direct_sampling_row: adw::SwitchRow,
+    /// Collapsible "Server status" expander shown only while the
+    /// server is running. Children below render the live state
+    /// pulled from `ServerStats` every
+    /// `STATUS_POLL_INTERVAL`.
+    pub status_row: adw::ExpanderRow,
+    /// "Client: …" — connected peer socket address or "Waiting for
+    /// client" when the accept loop is idle.
+    pub status_client_row: adw::ActionRow,
+    /// "Uptime: …" — wall-clock time since the current client
+    /// connected. Hidden when no client.
+    pub status_uptime_row: adw::ActionRow,
+    /// "Data rate: …" — rolling Mbps computed from `bytes_sent`
+    /// deltas between status polls.
+    pub status_data_rate_row: adw::ActionRow,
+    /// "Tuned to: …" — reflects the client's most recent
+    /// `SetCenterFreq` / `SetSampleRate` / `SetTunerGain` commands.
+    pub status_commanded_row: adw::ActionRow,
+    /// Stop button packed as a suffix on the expander row. Flips
+    /// the master `share_row` switch off, which is the same control
+    /// path the user would hit to stop manually.
+    pub status_stop_button: gtk4::Button,
+}
+
+/// Subtitle shown on `status_client_row` when the accept loop is
+/// idle. Kept as a const so future i18n can swap every occurrence
+/// at once and the "no client yet" vs "some degraded state" render
+/// can't drift.
+pub const STATUS_WAITING_FOR_CLIENT_SUBTITLE: &str = "Waiting for client";
+/// Subtitle shown on data-rate / uptime / commanded rows when the
+/// accept loop is idle — same no-client state, different row.
+pub const STATUS_IDLE_VALUE_SUBTITLE: &str = "—";
+
+/// Aggregated status rows rendered under the "Server status"
+/// expander. Grouped so the builder stays readable and the
+/// top-level `build_server_panel` stays inside clippy's
+/// `too_many_lines` limit.
+#[allow(
+    clippy::struct_field_names,
+    reason = "all fields are GTK *Row widgets — shared suffix reads clearly at the call sites"
+)]
+struct StatusRows {
+    expander: adw::ExpanderRow,
+    client_row: adw::ActionRow,
+    uptime_row: adw::ActionRow,
+    data_rate_row: adw::ActionRow,
+    commanded_row: adw::ActionRow,
+    stop_button: gtk4::Button,
+}
+
+fn build_status_rows() -> StatusRows {
+    let expander = adw::ExpanderRow::builder()
+        .title("Server status")
+        .subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE)
+        .expanded(true)
+        .visible(false)
+        .build();
+    let client_row = adw::ActionRow::builder()
+        .title("Client")
+        .subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE)
+        .build();
+    let uptime_row = adw::ActionRow::builder()
+        .title("Uptime")
+        .subtitle(STATUS_IDLE_VALUE_SUBTITLE)
+        .build();
+    let data_rate_row = adw::ActionRow::builder()
+        .title("Data rate")
+        .subtitle(STATUS_IDLE_VALUE_SUBTITLE)
+        .build();
+    let commanded_row = adw::ActionRow::builder()
+        .title("Tuned to")
+        .subtitle(STATUS_IDLE_VALUE_SUBTITLE)
+        .build();
+    let stop_button = gtk4::Button::with_label("Stop");
+    stop_button.add_css_class("destructive-action");
+    stop_button.set_valign(gtk4::Align::Center);
+    expander.add_suffix(&stop_button);
+    expander.add_row(&client_row);
+    expander.add_row(&uptime_row);
+    expander.add_row(&data_rate_row);
+    expander.add_row(&commanded_row);
+    StatusRows {
+        expander,
+        client_row,
+        uptime_row,
+        data_rate_row,
+        commanded_row,
+        stop_button,
+    }
 }
 
 /// Rows applied-on-start that live inside the "Device defaults"
@@ -332,12 +420,22 @@ pub fn build_server_panel() -> ServerPanel {
     device_defaults_row.add_row(&bias_tee_row);
     device_defaults_row.add_row(&direct_sampling_row);
 
+    let StatusRows {
+        expander: status_row,
+        client_row: status_client_row,
+        uptime_row: status_uptime_row,
+        data_rate_row: status_data_rate_row,
+        commanded_row: status_commanded_row,
+        stop_button: status_stop_button,
+    } = build_status_rows();
+
     widget.add(&share_row);
     widget.add(&nickname_row);
     widget.add(&port_row);
     widget.add(&bind_row);
     widget.add(&advertise_row);
     widget.add(&device_defaults_row);
+    widget.add(&status_row);
 
     ServerPanel {
         widget,
@@ -353,5 +451,11 @@ pub fn build_server_panel() -> ServerPanel {
         ppm_row,
         bias_tee_row,
         direct_sampling_row,
+        status_row,
+        status_client_row,
+        status_uptime_row,
+        status_data_rate_row,
+        status_commanded_row,
+        status_stop_button,
     }
 }

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -177,6 +177,16 @@ pub struct ServerPanel {
     /// the master `share_row` switch off, which is the same control
     /// path the user would hit to stop manually.
     pub status_stop_button: gtk4::Button,
+    /// Collapsible "Activity log" expander, listing the last
+    /// `sdr_server_rtltcp::RECENT_COMMANDS_CAPACITY` commands the
+    /// server has received with timestamps. Hidden while the
+    /// server isn't running.
+    pub activity_log_row: adw::ExpanderRow,
+    /// `ListBox` child of `activity_log_row` where individual
+    /// activity entries are appended. Held separately from the
+    /// expander so the stats poller can rebuild it on updates
+    /// without walking the expander's `AdwActionRow` children.
+    pub activity_log_list: gtk4::ListBox,
 }
 
 /// Subtitle shown on `status_client_row` when the accept loop is
@@ -187,6 +197,18 @@ pub const STATUS_WAITING_FOR_CLIENT_SUBTITLE: &str = "Waiting for client";
 /// Subtitle shown on data-rate / uptime / commanded rows when the
 /// accept loop is idle — same no-client state, different row.
 pub const STATUS_IDLE_VALUE_SUBTITLE: &str = "—";
+
+/// Subtitle shown on the activity-log expander when no commands
+/// have been received yet. Empty-state text that distinguishes
+/// "nothing to show" from "the ring buffer cleared after disconnect"
+/// (which also renders as empty but is a different journey).
+pub const ACTIVITY_LOG_EMPTY_SUBTITLE: &str = "No commands received yet";
+
+/// Max height the activity-log `ScrolledWindow` grows before
+/// scrolling kicks in. Small enough to fit inside the sidebar
+/// without dominating it; the expander is collapsed by default so
+/// users opt in to seeing the log at all.
+const ACTIVITY_LOG_MAX_HEIGHT_PX: i32 = 240;
 
 /// Aggregated status rows rendered under the "Server status"
 /// expander. Grouped so the builder stays readable and the
@@ -203,6 +225,35 @@ struct StatusRows {
     data_rate_row: adw::ActionRow,
     commanded_row: adw::ActionRow,
     stop_button: gtk4::Button,
+}
+
+/// Build the "Activity log" expander plus its scrollable child
+/// `ListBox`. The `ListBox` is wrapped in a `ScrolledWindow` with
+/// an `ACTIVITY_LOG_MAX_HEIGHT_PX` cap so the expander doesn't grow
+/// the sidebar taller than the viewport when the ring fills up.
+fn build_activity_log_row() -> (adw::ExpanderRow, gtk4::ListBox) {
+    let row = adw::ExpanderRow::builder()
+        .title("Activity log")
+        .subtitle(ACTIVITY_LOG_EMPTY_SUBTITLE)
+        .visible(false)
+        .build();
+    let list = gtk4::ListBox::builder()
+        .selection_mode(gtk4::SelectionMode::None)
+        .css_classes(["boxed-list"])
+        .build();
+    let scroll = gtk4::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .propagate_natural_height(true)
+        .max_content_height(ACTIVITY_LOG_MAX_HEIGHT_PX)
+        .child(&list)
+        .build();
+    // Wrap the scroll in an ActionRow so the expander's layout
+    // machinery (which expects rows) renders it correctly. Empty
+    // title/subtitle pushes the scroll widget into the row body.
+    let wrapper = adw::ActionRow::builder().activatable(false).build();
+    wrapper.add_prefix(&scroll);
+    row.add_row(&wrapper);
+    (row, list)
 }
 
 fn build_status_rows() -> StatusRows {
@@ -429,6 +480,8 @@ pub fn build_server_panel() -> ServerPanel {
         stop_button: status_stop_button,
     } = build_status_rows();
 
+    let (activity_log_row, activity_log_list) = build_activity_log_row();
+
     widget.add(&share_row);
     widget.add(&nickname_row);
     widget.add(&port_row);
@@ -436,6 +489,7 @@ pub fn build_server_panel() -> ServerPanel {
     widget.add(&advertise_row);
     widget.add(&device_defaults_row);
     widget.add(&status_row);
+    widget.add(&activity_log_row);
 
     ServerPanel {
         widget,
@@ -457,5 +511,7 @@ pub fn build_server_panel() -> ServerPanel {
         status_data_rate_row,
         status_commanded_row,
         status_stop_button,
+        activity_log_row,
+        activity_log_list,
     }
 }

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -1,0 +1,357 @@
+//! Server panel — "Share over network" controls exposing a local
+//! RTL-SDR dongle to remote `rtl_tcp` clients.
+//!
+//! This panel is hidden by default. It becomes visible when a local
+//! RTL-SDR dongle is detected AND it's not currently the active
+//! source — exposing the same dongle over `rtl_tcp` while also
+//! receiving from it locally would cause a USB-device double-open,
+//! so the UI gates the panel on the incompatible state.
+//!
+//! The panel itself only builds widgets; the wire-up (start/stop,
+//! stats polling, activity log) lives in `window.rs` alongside the
+//! rest of the DSP/UI bridge. Keeping this file widget-only mirrors
+//! the pattern in `source_panel.rs` / `audio_panel.rs` / etc.
+
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Default TCP port for `rtl_tcp`. Matches upstream `rtl_tcp.c` and
+/// every ecosystem client's default. Changing it means users have to
+/// know the custom port on every client — keep as a knob but default
+/// to the well-known value.
+pub const DEFAULT_SERVER_PORT: f64 = 1234.0;
+/// Lowest TCP port we'll accept. 1023 and below are privileged on
+/// Unix and require `CAP_NET_BIND_SERVICE` / root — we're not going
+/// to run as root, so refuse up front.
+pub const MIN_SERVER_PORT: f64 = 1024.0;
+/// Highest legal TCP port (16-bit unsigned max).
+pub const MAX_SERVER_PORT: f64 = 65_535.0;
+/// Spin-row per-click step for the port field.
+const SERVER_PORT_STEP: f64 = 1.0;
+/// Spin-row page step (`PgUp` / `PgDn`) for the port field.
+const SERVER_PORT_PAGE: f64 = 100.0;
+
+/// Bind-address selector index: loopback-only (127.0.0.1). The
+/// default — limits exposure to clients running on the same machine
+/// until the user opts into broader access.
+pub const BIND_LOOPBACK_IDX: u32 = 0;
+/// Bind-address selector index: all interfaces (0.0.0.0).
+pub const BIND_ALL_INTERFACES_IDX: u32 = 1;
+
+/// Server device-defaults: center frequency default (Hz) applied on
+/// start, before the first client connects. Upstream `rtl_tcp.c:389`
+/// default. Clients typically tune immediately after connecting, so
+/// this only affects the "waiting for client" idle state and any
+/// client that doesn't send `SetCenterFreq` before reading data.
+const DEFAULT_CENTER_FREQ_HZ: f64 = 100_000_000.0;
+/// Minimum tunable frequency (Hz). Real RTL-SDR dongles go lower
+/// (~24 MHz native, down to DC in direct-sampling mode), but for
+/// defaults-on-start the UI caps at 24 MHz to stay in the dongle's
+/// documented range.
+const MIN_CENTER_FREQ_HZ: f64 = 24_000_000.0;
+/// Maximum tunable frequency (Hz). R820T / R828D top out ~1.7 GHz
+/// depending on the tuner; 1.766 GHz is the driver's stated ceiling.
+const MAX_CENTER_FREQ_HZ: f64 = 1_766_000_000.0;
+/// Frequency spin-row step (1 kHz per click).
+const CENTER_FREQ_STEP_HZ: f64 = 1_000.0;
+/// Frequency spin-row page step (1 MHz per PgUp/PgDn).
+const CENTER_FREQ_PAGE_HZ: f64 = 1_000_000.0;
+
+/// Server device-defaults: sample-rate selector index (2.4 MHz = 7).
+/// Same ordering as `source_panel::build_rtlsdr_rows` so keyboard
+/// muscle memory matches.
+const DEFAULT_SERVER_SAMPLE_RATE_INDEX: u32 = 7;
+
+/// Server device-defaults: gain default (dB). 0.0 dB matches
+/// upstream's "auto" gain interpretation when the CLI passes `-g 0`.
+/// UI treats 0.0 as auto; any positive value is a manual setting.
+const DEFAULT_SERVER_GAIN_DB: f64 = 0.0;
+/// Minimum server-gain spin-row value (dB).
+const MIN_SERVER_GAIN_DB: f64 = 0.0;
+/// Maximum server-gain spin-row value (dB) — widest R820T range.
+const MAX_SERVER_GAIN_DB: f64 = 49.6;
+/// Server-gain spin-row step (dB).
+const SERVER_GAIN_STEP_DB: f64 = 0.1;
+/// Server-gain spin-row page step (dB).
+const SERVER_GAIN_PAGE_DB: f64 = 1.0;
+
+/// Server device-defaults: PPM correction default. 0 is "no
+/// correction" — the user can override if they know their crystal
+/// offset.
+const DEFAULT_SERVER_PPM: f64 = 0.0;
+/// Minimum server PPM correction.
+const MIN_SERVER_PPM: f64 = -200.0;
+/// Maximum server PPM correction.
+const MAX_SERVER_PPM: f64 = 200.0;
+/// PPM spin-row step.
+const SERVER_PPM_STEP: f64 = 1.0;
+/// PPM spin-row page step.
+const SERVER_PPM_PAGE: f64 = 10.0;
+
+/// Default server nickname shown until the user edits it. Kept
+/// generic — a hostname is substituted at `Server::start()` time in
+/// `window.rs`, mirroring the CLI's `sdr-rtl-tcp` default-nickname
+/// logic in `sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs`.
+const DEFAULT_NICKNAME: &str = "sdr-rtl-tcp";
+
+// Compile-time invariants for the port and frequency bounds. Moves
+// "did I accidentally flip min/max or push the port into privileged
+// space" checks from runtime-only test assertions (clippy flags them
+// as tautologies on consts) to build-time hard errors.
+const _: () = {
+    assert!(
+        MIN_SERVER_PORT >= 1024.0,
+        "server port must be unprivileged"
+    );
+    assert!(MAX_SERVER_PORT <= 65_535.0, "server port must fit in a u16");
+    assert!(MIN_SERVER_PORT <= DEFAULT_SERVER_PORT);
+    assert!(DEFAULT_SERVER_PORT <= MAX_SERVER_PORT);
+    assert!(MIN_CENTER_FREQ_HZ <= DEFAULT_CENTER_FREQ_HZ);
+    assert!(DEFAULT_CENTER_FREQ_HZ <= MAX_CENTER_FREQ_HZ);
+    assert!(BIND_LOOPBACK_IDX != BIND_ALL_INTERFACES_IDX);
+};
+
+/// Server-panel widget handles — packed into the sidebar as an
+/// `AdwPreferencesGroup` and handed to `window.rs` for signal
+/// wiring.
+///
+/// Every row except `widget` / `device_defaults_row` is a leaf
+/// control; `window.rs` reads their values at `Server::start()`
+/// time and disables them while the server is running so the user
+/// can't mutate config out from under a live session.
+pub struct ServerPanel {
+    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
+    /// Hidden by default — `window.rs` toggles visibility based on
+    /// USB hotplug + active-source state.
+    pub widget: adw::PreferencesGroup,
+    /// Master share-over-network switch. On → start Server. Off →
+    /// stop Server.
+    pub share_row: adw::SwitchRow,
+    /// User-editable server nickname. Becomes the mDNS TXT
+    /// `nickname` field when advertising is on.
+    pub nickname_row: adw::EntryRow,
+    /// TCP port the server binds to (1024-65535, default 1234).
+    pub port_row: adw::SpinRow,
+    /// Bind address selector (Loopback / All interfaces).
+    pub bind_row: adw::ComboRow,
+    /// Whether to announce the running server over mDNS. Defaults
+    /// on; the user can turn it off to run locally without LAN
+    /// advertisement.
+    pub advertise_row: adw::SwitchRow,
+    /// Collapsible group of device-defaults (freq / sample rate /
+    /// gain / PPM / bias tee / direct sampling) applied on server
+    /// start. Clients override these live via the `rtl_tcp` command
+    /// channel — these are just the "before first client" defaults.
+    pub device_defaults_row: adw::ExpanderRow,
+    /// Center-frequency default applied on server open.
+    pub center_freq_row: adw::SpinRow,
+    /// Sample-rate default applied on server open.
+    pub sample_rate_row: adw::ComboRow,
+    /// Tuner-gain default applied on server open. 0.0 = auto.
+    pub gain_row: adw::SpinRow,
+    /// PPM frequency-correction default applied on server open.
+    pub ppm_row: adw::SpinRow,
+    /// Bias-tee power-output toggle applied on server open.
+    pub bias_tee_row: adw::SwitchRow,
+    /// Direct-sampling toggle (Q-branch) applied on server open.
+    /// Only useful for HF experimentation; off for normal use.
+    pub direct_sampling_row: adw::SwitchRow,
+}
+
+/// Rows applied-on-start that live inside the "Device defaults"
+/// expander. Return tuple grouped so the top-level builder stays
+/// under clippy's `too_many_lines` limit.
+#[allow(
+    clippy::struct_field_names,
+    reason = "all fields are GTK *Row widgets — the shared suffix matches the rest of sidebar/ and reads clearly at call sites"
+)]
+struct DeviceDefaultsRows {
+    center_freq_row: adw::SpinRow,
+    sample_rate_row: adw::ComboRow,
+    gain_row: adw::SpinRow,
+    ppm_row: adw::SpinRow,
+    bias_tee_row: adw::SwitchRow,
+    direct_sampling_row: adw::SwitchRow,
+}
+
+fn build_device_defaults_rows() -> DeviceDefaultsRows {
+    let freq_adj = gtk4::Adjustment::new(
+        DEFAULT_CENTER_FREQ_HZ,
+        MIN_CENTER_FREQ_HZ,
+        MAX_CENTER_FREQ_HZ,
+        CENTER_FREQ_STEP_HZ,
+        CENTER_FREQ_PAGE_HZ,
+        0.0,
+    );
+    let center_freq_row = adw::SpinRow::builder()
+        .title("Center frequency (Hz)")
+        .adjustment(&freq_adj)
+        .digits(0)
+        .build();
+
+    // Sample-rate list mirrors the client-side source panel so a
+    // user familiar with one knows the other. 2.4 MHz is the default
+    // to stay inside RTL-SDR's stable-without-dropouts range.
+    let sample_rate_model = gtk4::StringList::new(&[
+        "250 kHz",
+        "1.024 MHz",
+        "1.536 MHz",
+        "1.792 MHz",
+        "1.920 MHz",
+        "2.048 MHz",
+        "2.160 MHz",
+        "2.4 MHz",
+        "2.560 MHz",
+        "2.880 MHz",
+        "3.2 MHz",
+    ]);
+    let sample_rate_row = adw::ComboRow::builder()
+        .title("Sample rate")
+        .model(&sample_rate_model)
+        .selected(DEFAULT_SERVER_SAMPLE_RATE_INDEX)
+        .build();
+
+    let gain_adj = gtk4::Adjustment::new(
+        DEFAULT_SERVER_GAIN_DB,
+        MIN_SERVER_GAIN_DB,
+        MAX_SERVER_GAIN_DB,
+        SERVER_GAIN_STEP_DB,
+        SERVER_GAIN_PAGE_DB,
+        0.0,
+    );
+    let gain_row = adw::SpinRow::builder()
+        .title("Tuner gain (dB)")
+        .subtitle("0 = auto gain")
+        .adjustment(&gain_adj)
+        .digits(1)
+        .build();
+
+    let ppm_adj = gtk4::Adjustment::new(
+        DEFAULT_SERVER_PPM,
+        MIN_SERVER_PPM,
+        MAX_SERVER_PPM,
+        SERVER_PPM_STEP,
+        SERVER_PPM_PAGE,
+        0.0,
+    );
+    let ppm_row = adw::SpinRow::builder()
+        .title("Frequency correction (PPM)")
+        .adjustment(&ppm_adj)
+        .digits(0)
+        .build();
+
+    let bias_tee_row = adw::SwitchRow::builder()
+        .title("Bias tee")
+        .subtitle("Power remote LNA via antenna connector")
+        .build();
+
+    let direct_sampling_row = adw::SwitchRow::builder()
+        .title("Direct sampling (Q branch)")
+        .subtitle("HF mode — bypasses the tuner")
+        .build();
+
+    DeviceDefaultsRows {
+        center_freq_row,
+        sample_rate_row,
+        gain_row,
+        ppm_row,
+        bias_tee_row,
+        direct_sampling_row,
+    }
+}
+
+/// Build the server-panel widgets. The panel is hidden by default;
+/// `window.rs` toggles `widget.set_visible(true)` once a local dongle
+/// is detected and the active source is not RTL-SDR.
+pub fn build_server_panel() -> ServerPanel {
+    let widget = adw::PreferencesGroup::builder()
+        .title("Share over network")
+        .description("Expose this machine's RTL-SDR dongle to remote rtl_tcp clients")
+        .visible(false)
+        .build();
+
+    let share_row = adw::SwitchRow::builder()
+        .title("Share over network")
+        .subtitle("Start the rtl_tcp server and advertise it on the LAN")
+        .build();
+
+    let nickname_row = adw::EntryRow::builder()
+        .title("Server nickname")
+        .text(DEFAULT_NICKNAME)
+        .build();
+
+    let port_adj = gtk4::Adjustment::new(
+        DEFAULT_SERVER_PORT,
+        MIN_SERVER_PORT,
+        MAX_SERVER_PORT,
+        SERVER_PORT_STEP,
+        SERVER_PORT_PAGE,
+        0.0,
+    );
+    let port_row = adw::SpinRow::builder()
+        .title("Port")
+        .adjustment(&port_adj)
+        .digits(0)
+        .build();
+
+    // Order is load-bearing — matches `BIND_LOOPBACK_IDX` /
+    // `BIND_ALL_INTERFACES_IDX`. A third "specific interface" option
+    // is deferred to #323 because it needs an interface enumerator
+    // we haven't wired up yet.
+    let bind_model = gtk4::StringList::new(&["Loopback only", "All interfaces"]);
+    let bind_row = adw::ComboRow::builder()
+        .title("Bind address")
+        .model(&bind_model)
+        .selected(BIND_LOOPBACK_IDX)
+        .build();
+
+    let advertise_row = adw::SwitchRow::builder()
+        .title("Announce via mDNS")
+        .subtitle("Let LAN clients discover this server by name")
+        .active(true)
+        .build();
+
+    let device_defaults_row = adw::ExpanderRow::builder()
+        .title("Device defaults")
+        .subtitle("Applied when the server opens the dongle — clients override live")
+        .build();
+
+    let DeviceDefaultsRows {
+        center_freq_row,
+        sample_rate_row,
+        gain_row,
+        ppm_row,
+        bias_tee_row,
+        direct_sampling_row,
+    } = build_device_defaults_rows();
+
+    device_defaults_row.add_row(&center_freq_row);
+    device_defaults_row.add_row(&sample_rate_row);
+    device_defaults_row.add_row(&gain_row);
+    device_defaults_row.add_row(&ppm_row);
+    device_defaults_row.add_row(&bias_tee_row);
+    device_defaults_row.add_row(&direct_sampling_row);
+
+    widget.add(&share_row);
+    widget.add(&nickname_row);
+    widget.add(&port_row);
+    widget.add(&bind_row);
+    widget.add(&advertise_row);
+    widget.add(&device_defaults_row);
+
+    ServerPanel {
+        widget,
+        share_row,
+        nickname_row,
+        port_row,
+        bind_row,
+        advertise_row,
+        device_defaults_row,
+        center_freq_row,
+        sample_rate_row,
+        gain_row,
+        ppm_row,
+        bias_tee_row,
+        direct_sampling_row,
+    }
+}

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1267,7 +1267,17 @@ fn connect_server_panel(panels: &SidebarPanels, toast_overlay: &adw::ToastOverla
     // authority on server lifecycle — on toggle we either start a
     // new `Server` (+ optional `Advertiser`) and store the handle,
     // or drop the handle so the accept thread tears down.
-    connect_share_switch(panels, toast_overlay, Rc::clone(&running), apply_visibility);
+    connect_share_switch(
+        panels,
+        toast_overlay,
+        Rc::clone(&running),
+        apply_visibility.clone(),
+    );
+
+    // Poll `Server::stats()` on a timer, render the status rows,
+    // and auto-stop the server if `has_stopped()` becomes true
+    // (e.g. USB unplug or accept-thread failure).
+    connect_server_status_polling(panels, Rc::clone(&running), apply_visibility);
 }
 
 /// Extracted out of `connect_server_panel` so the parent function
@@ -1320,6 +1330,7 @@ fn connect_share_switch(
                         None
                     };
                     set_controls_locked(&server_panel, true);
+                    server_panel.status_row.set_visible(true);
                     *running.borrow_mut() = Some(RunningServer { server, advertiser });
                 }
                 Err(e) => {
@@ -1352,6 +1363,8 @@ fn connect_share_switch(
                 drop(handle.server);
             }
             set_controls_locked(&server_panel, false);
+            server_panel.status_row.set_visible(false);
+            reset_status_rows(&server_panel);
         }
         apply_visibility();
     });
@@ -1376,7 +1389,266 @@ fn clone_server_panel(panel: &sidebar::ServerPanel) -> sidebar::ServerPanel {
         ppm_row: panel.ppm_row.clone(),
         bias_tee_row: panel.bias_tee_row.clone(),
         direct_sampling_row: panel.direct_sampling_row.clone(),
+        status_row: panel.status_row.clone(),
+        status_client_row: panel.status_client_row.clone(),
+        status_uptime_row: panel.status_uptime_row.clone(),
+        status_data_rate_row: panel.status_data_rate_row.clone(),
+        status_commanded_row: panel.status_commanded_row.clone(),
+        status_stop_button: panel.status_stop_button.clone(),
     }
+}
+
+/// Cadence for the server-stats poll that renders the "Server
+/// status" rows. 500 ms is fast enough that "connected / waiting"
+/// transitions feel instant while keeping the `ServerStats` clone +
+/// row-subtitle churn off the critical path.
+const SERVER_STATUS_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Bits-per-byte conversion used in the Mbps formatter. Kept behind
+/// a named constant so the arithmetic at the call site reads as
+/// unit math ("bytes * `BITS_PER_BYTE` / duration / MEGA") instead
+/// of opaque `8`s and `1_000_000`s.
+const BITS_PER_BYTE: u64 = 8;
+/// Megabits divisor for rendering Mbps. `1_000_000` matches
+/// telecom/carrier conventions for transport rates.
+const BITS_PER_MEGABIT: f64 = 1_000_000.0;
+
+/// Poll `Server::stats()` on a fixed cadence, render the four
+/// status rows from the snapshot, and auto-stop the server if
+/// `has_stopped()` becomes true (e.g. USB dongle unplugged or
+/// accept-thread error).
+///
+/// Auto-stop flips the `share_row` back off, which re-enters the
+/// switch's `connect_active_notify` handler — that branch drops the
+/// `RunningServer` handle and releases the dongle for subsequent
+/// reopens. Without this the UI would lie about the server's
+/// running state indefinitely.
+///
+/// Data-rate is computed from the delta in `bytes_sent` between
+/// consecutive poll ticks. Counter resets (on disconnect) produce
+/// negative deltas which we clamp to zero so the row reads "0 bps"
+/// instead of a bogus megabit-scale number during the transient.
+fn connect_server_status_polling(
+    panels: &SidebarPanels,
+    running: Rc<RefCell<Option<RunningServer>>>,
+    apply_visibility: impl Fn() + 'static,
+) {
+    use std::cell::Cell;
+
+    let server_panel = clone_server_panel(&panels.server);
+    let share_row_weak = panels.server.share_row.downgrade();
+    let widget_weak = panels.server.widget.downgrade();
+    let last_bytes_sent = Rc::new(Cell::new(0u64));
+
+    // Separate subscription on the Stop button. Flipping the switch
+    // off is the single canonical stop path — pointing the button
+    // there avoids a second teardown codepath that could drift.
+    let stop_share_row_weak = share_row_weak.clone();
+    panels.server.status_stop_button.connect_clicked(move |_| {
+        if let Some(share) = stop_share_row_weak.upgrade() {
+            share.set_active(false);
+        }
+    });
+
+    let _ = glib::timeout_add_local(SERVER_STATUS_POLL_INTERVAL, move || {
+        // Tear the poller down if the panel widget is gone (window
+        // closed). Prevents leaking `server.stats()` locks past
+        // window lifetime.
+        if widget_weak.upgrade().is_none() {
+            return glib::ControlFlow::Break;
+        }
+        // Snapshot `Server::stats()` under the borrow. `stats()`
+        // internally locks a Mutex — the return is a Clone, so the
+        // borrow scope is tight.
+        let snapshot = running
+            .borrow()
+            .as_ref()
+            .map(|h| (h.server.stats(), h.server.has_stopped()));
+        let Some((stats, stopped)) = snapshot else {
+            // No server running — nothing to render, keep ticking
+            // (the share switch handler will spin us up again).
+            return glib::ControlFlow::Continue;
+        };
+
+        // If the accept thread exited on its own (USB unplug,
+        // fatal error), auto-flip the share switch off. Re-enters
+        // the switch handler, which drops the server handle.
+        if stopped {
+            tracing::warn!("rtl_tcp server stopped on its own — flipping share switch off");
+            if let Some(share) = share_row_weak.upgrade() {
+                share.set_active(false);
+            }
+            apply_visibility();
+            return glib::ControlFlow::Continue;
+        }
+
+        render_status_rows(&server_panel, &stats, &last_bytes_sent);
+        glib::ControlFlow::Continue
+    });
+}
+
+/// Write the current `ServerStats` snapshot into the four status
+/// rows. Uses `last_bytes_sent` to compute a rolling data-rate from
+/// delta-over-poll-interval.
+fn render_status_rows(
+    panel: &sidebar::ServerPanel,
+    stats: &sdr_server_rtltcp::ServerStats,
+    last_bytes_sent: &Rc<std::cell::Cell<u64>>,
+) {
+    use crate::sidebar::server_panel::{
+        STATUS_IDLE_VALUE_SUBTITLE, STATUS_WAITING_FOR_CLIENT_SUBTITLE,
+    };
+
+    // Client row + expander subtitle.
+    if let Some(peer) = stats.connected_client {
+        let peer_str = peer.to_string();
+        panel.status_client_row.set_subtitle(&peer_str);
+        panel
+            .status_row
+            .set_subtitle(&format!("Connected: {peer_str}"));
+    } else {
+        panel
+            .status_client_row
+            .set_subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE);
+        panel
+            .status_row
+            .set_subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE);
+    }
+
+    // Uptime row.
+    panel
+        .status_uptime_row
+        .set_subtitle(&stats.connected_since.map_or_else(
+            || STATUS_IDLE_VALUE_SUBTITLE.to_string(),
+            |since| format_uptime(since.elapsed()),
+        ));
+
+    // Data-rate row. Counter reset on disconnect produces a
+    // negative delta in the u64 arithmetic; clamp to 0 so the row
+    // doesn't read a bogus Mbps number on the transient.
+    let current_bytes = stats.bytes_sent;
+    let delta = current_bytes.saturating_sub(last_bytes_sent.get());
+    last_bytes_sent.set(current_bytes);
+    panel
+        .status_data_rate_row
+        .set_subtitle(&format_data_rate(delta, SERVER_STATUS_POLL_INTERVAL));
+
+    // Commanded-state row. "Tuned to" means "what the client has
+    // most recently requested." Assembled one piece at a time; an
+    // unset field shows its upstream default stamp from
+    // `InitialDeviceState::default()` rather than blanking out.
+    panel
+        .status_commanded_row
+        .set_subtitle(&format_commanded_state(stats));
+}
+
+/// Render a `Duration` as `Nh Nm Ns` / `Nm Ns` / `Ns` depending on
+/// magnitude. Keeps the row readable at a glance without fighting a
+/// full clock component.
+fn format_uptime(elapsed: Duration) -> String {
+    let total_secs = elapsed.as_secs();
+    let hours = total_secs / 3600;
+    let minutes = (total_secs % 3600) / 60;
+    let seconds = total_secs % 60;
+    if hours > 0 {
+        format!("{hours}h {minutes}m {seconds}s")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+/// Render bytes/interval as a human-readable data rate. Picks the
+/// right unit automatically: kbps when we're below 1 Mbps (quiet
+/// clients), Mbps otherwise. `rtl_tcp` IQ streams at 2.4 MS/s × 2
+/// bytes per sample = ~4.8 Mbps, so the Mbps case dominates in
+/// practice.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "intermediate f64 conversion for rate math; Mbps precision is cosmetic"
+)]
+fn format_data_rate(bytes: u64, interval: Duration) -> String {
+    let secs = interval.as_secs_f64();
+    if secs <= 0.0 {
+        return "—".to_string();
+    }
+    let bits_per_sec = (bytes as f64 * BITS_PER_BYTE as f64) / secs;
+    if bits_per_sec < BITS_PER_MEGABIT {
+        format!("{:.1} kbps", bits_per_sec / 1_000.0)
+    } else {
+        format!("{:.2} Mbps", bits_per_sec / BITS_PER_MEGABIT)
+    }
+}
+
+/// Render the "Tuned to" row subtitle. Combines frequency, sample
+/// rate and gain into one line. Unset fields show their upstream
+/// default stamp from `InitialDeviceState::default()` — which is
+/// what the server applied on open — rather than blanking out, so
+/// the row never looks broken during the pre-first-command window.
+fn format_commanded_state(stats: &sdr_server_rtltcp::ServerStats) -> String {
+    let freq_hz = stats
+        .current_freq_hz
+        .unwrap_or(sdr_server_rtltcp::DEFAULT_CENTER_FREQ_HZ);
+    let sample_rate_hz = stats
+        .current_sample_rate_hz
+        .unwrap_or(sdr_server_rtltcp::DEFAULT_SAMPLE_RATE_HZ);
+    let gain_text = match (stats.current_gain_auto, stats.current_gain_tenths_db) {
+        (Some(true), _) => "auto".to_string(),
+        (_, Some(gain_tenths)) => {
+            #[allow(clippy::cast_precision_loss, reason = "gain tenths-of-dB, cosmetic")]
+            let db = f64::from(gain_tenths) / 10.0;
+            format!("{db:.1} dB")
+        }
+        _ => "initial".to_string(),
+    };
+    format!(
+        "{} @ {} • gain {}",
+        format_hz(freq_hz),
+        format_hz(sample_rate_hz),
+        gain_text
+    )
+}
+
+/// Short Hz formatter — kHz / MHz / GHz depending on magnitude.
+/// Kept local to this module because the status row's formatting
+/// needs differ from the header-bar frequency selector (which has
+/// its own 12-digit grid display).
+fn format_hz(hz: u32) -> String {
+    let hz_f = f64::from(hz);
+    if hz >= 1_000_000_000 {
+        format!("{:.3} GHz", hz_f / 1_000_000_000.0)
+    } else if hz >= 1_000_000 {
+        format!("{:.3} MHz", hz_f / 1_000_000.0)
+    } else if hz >= 1_000 {
+        format!("{:.3} kHz", hz_f / 1_000.0)
+    } else {
+        format!("{hz} Hz")
+    }
+}
+
+/// Reset status rows to their idle-no-client state. Called when the
+/// server stops so the user doesn't see stale "connected at 127.0.0.1"
+/// / "uptime 5m" data after they flipped the share switch off.
+fn reset_status_rows(panel: &sidebar::ServerPanel) {
+    use crate::sidebar::server_panel::{
+        STATUS_IDLE_VALUE_SUBTITLE, STATUS_WAITING_FOR_CLIENT_SUBTITLE,
+    };
+    panel
+        .status_row
+        .set_subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE);
+    panel
+        .status_client_row
+        .set_subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE);
+    panel
+        .status_uptime_row
+        .set_subtitle(STATUS_IDLE_VALUE_SUBTITLE);
+    panel
+        .status_data_rate_row
+        .set_subtitle(STATUS_IDLE_VALUE_SUBTITLE);
+    panel
+        .status_commanded_row
+        .set_subtitle(STATUS_IDLE_VALUE_SUBTITLE);
 }
 
 /// Read the server panel widget values and build a `ServerConfig`
@@ -3470,6 +3742,126 @@ mod rtl_tcp_discovery_format_tests {
         assert!(
             subtitle.ends_with("seen just now"),
             "subtitle should read 'seen just now' for sub-5s age: {subtitle}"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod server_panel_format_tests {
+    use std::time::Duration;
+
+    use sdr_server_rtltcp::ServerStats;
+
+    use super::{
+        SERVER_STATUS_POLL_INTERVAL, format_commanded_state, format_data_rate, format_hz,
+        format_uptime,
+    };
+
+    #[test]
+    fn format_uptime_uses_compact_unit_picker() {
+        // Sub-minute: just seconds.
+        assert_eq!(format_uptime(Duration::from_secs(5)), "5s");
+        // Sub-hour: minutes + seconds, no hours prefix.
+        assert_eq!(format_uptime(Duration::from_secs(61)), "1m 1s");
+        assert_eq!(format_uptime(Duration::from_secs(3599)), "59m 59s");
+        // Hour+: full triple.
+        assert_eq!(format_uptime(Duration::from_secs(3661)), "1h 1m 1s");
+        assert_eq!(format_uptime(Duration::from_secs(7322)), "2h 2m 2s");
+    }
+
+    #[test]
+    fn format_data_rate_picks_kbps_below_mbps_boundary() {
+        // 0.5 Mbps worth of bytes over the 500 ms interval → 0.5 Mbps
+        // → still kbps under the 1 Mbps switchover. (1 Mbps =
+        // 125_000 bytes/s, so 500 ms of 0.5 Mbps is 31_250 bytes.)
+        assert_eq!(
+            format_data_rate(31_250, SERVER_STATUS_POLL_INTERVAL),
+            "500.0 kbps"
+        );
+        // ~4.8 Mbps (the rtl_tcp canonical rate) over 500 ms.
+        // 4.8 Mbps * 0.5 s = 2.4 Mbit = 300_000 bytes.
+        assert_eq!(
+            format_data_rate(300_000, SERVER_STATUS_POLL_INTERVAL),
+            "4.80 Mbps"
+        );
+        // Zero bytes → "0.0 kbps" not a panic.
+        assert_eq!(format_data_rate(0, SERVER_STATUS_POLL_INTERVAL), "0.0 kbps");
+    }
+
+    #[test]
+    fn format_data_rate_handles_zero_interval() {
+        // A degenerate 0-second interval would divide by zero; fn
+        // must return a safe sentinel so the row renders instead of
+        // crashing.
+        assert_eq!(format_data_rate(100, Duration::ZERO), "—");
+    }
+
+    #[test]
+    fn format_hz_picks_unit_by_magnitude() {
+        assert_eq!(format_hz(500), "500 Hz");
+        assert_eq!(format_hz(1_500), "1.500 kHz");
+        assert_eq!(format_hz(100_300_000), "100.300 MHz");
+        assert_eq!(format_hz(1_500_000_000), "1.500 GHz");
+    }
+
+    #[test]
+    fn format_commanded_state_uses_upstream_defaults_when_client_silent() {
+        // A brand-new session that hasn't sent any commands should
+        // still render a sensible line — we show the upstream
+        // rtl_tcp.c defaults (100 MHz @ 2.048 MHz, gain "initial")
+        // rather than blanking the row.
+        let stats = ServerStats::default();
+        let subtitle = format_commanded_state(&stats);
+        assert!(
+            subtitle.contains("100.000 MHz"),
+            "default freq should show: {subtitle}"
+        );
+        assert!(
+            subtitle.contains("2.048 MHz"),
+            "default sample rate should show: {subtitle}"
+        );
+        assert!(
+            subtitle.contains("gain initial"),
+            "default gain hint should show: {subtitle}"
+        );
+    }
+
+    #[test]
+    fn format_commanded_state_renders_client_auto_gain_preference() {
+        // When the client has sent SetGainMode(auto), "auto" wins
+        // regardless of any previous manual gain value.
+        let stats = ServerStats {
+            current_freq_hz: Some(145_500_000),
+            current_sample_rate_hz: Some(2_400_000),
+            current_gain_tenths_db: Some(200),
+            current_gain_auto: Some(true),
+            ..ServerStats::default()
+        };
+        let subtitle = format_commanded_state(&stats);
+        assert!(subtitle.contains("145.500 MHz"));
+        assert!(subtitle.contains("2.400 MHz"));
+        assert!(
+            subtitle.contains("gain auto"),
+            "auto should override manual gain value: {subtitle}"
+        );
+    }
+
+    #[test]
+    fn format_commanded_state_renders_manual_gain_in_db() {
+        // SetTunerGain records tenths-of-dB; the render converts to
+        // full dB with one decimal.
+        let stats = ServerStats {
+            current_freq_hz: Some(100_000_000),
+            current_sample_rate_hz: Some(2_400_000),
+            current_gain_tenths_db: Some(496),
+            current_gain_auto: Some(false),
+            ..ServerStats::default()
+        };
+        let subtitle = format_commanded_state(&stats);
+        assert!(
+            subtitle.contains("gain 49.6 dB"),
+            "49.6 dB should render from 496 tenths: {subtitle}"
         );
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1322,10 +1322,27 @@ fn connect_share_switch(
                 Ok(server) => {
                     // If advertising is on, build the TXT record
                     // from the tuner metadata the Server exposes.
-                    // An Advertiser failure is non-fatal — the
-                    // server keeps running without mDNS.
+                    // An Advertiser failure is non-fatal for the
+                    // server itself (the accept loop keeps running
+                    // without mDNS), but the user explicitly asked
+                    // for LAN announcement so they need to KNOW the
+                    // intent failed — surface a toast and leave
+                    // `advertiser = None` so the stop path doesn't
+                    // try to unregister something that never
+                    // registered.
                     let advertiser = if server_panel.advertise_row.is_active() {
-                        build_advertiser(&server, &server_panel.nickname_row.text())
+                        match build_advertiser(&server, &server_panel.nickname_row.text()) {
+                            Ok(adv) => Some(adv),
+                            Err(e) => {
+                                tracing::warn!(error = %e, "mDNS advertiser failed; server running without LAN advertisement");
+                                if let Some(overlay) = toast_overlay_weak.upgrade() {
+                                    overlay.add_toast(adw::Toast::new(&format!(
+                                        "Server running, but mDNS advertising failed: {e}"
+                                    )));
+                                }
+                                None
+                            }
+                        }
                     } else {
                         None
                     };
@@ -1418,6 +1435,71 @@ const BITS_PER_BYTE: u64 = 8;
 /// telecom/carrier conventions for transport rates.
 const BITS_PER_MEGABIT: f64 = 1_000_000.0;
 
+/// Weak references to every widget the server-status poll tick
+/// touches. Held by the poll closure INSTEAD of a strong
+/// `ServerPanel` clone so the closure doesn't bump the widgets'
+/// `GObject` refcounts past window lifetime.
+///
+/// The original design cloned the whole `ServerPanel` into the
+/// closure and relied on a single `widget_weak.upgrade().is_none()`
+/// break gate — but the clone held strong refs to every widget,
+/// including the group itself, so the weak check could never fire
+/// and the 500 ms timer leaked past window close. Every
+/// panel-touching closure in this file now uses weak refs for the
+/// same reason (see `connect_rtl_tcp_discovery`'s pattern).
+struct ServerStatusWidgetsWeak {
+    status_row: glib::WeakRef<adw::ExpanderRow>,
+    status_client_row: glib::WeakRef<adw::ActionRow>,
+    status_uptime_row: glib::WeakRef<adw::ActionRow>,
+    status_data_rate_row: glib::WeakRef<adw::ActionRow>,
+    status_commanded_row: glib::WeakRef<adw::ActionRow>,
+    activity_log_row: glib::WeakRef<adw::ExpanderRow>,
+    activity_log_list: glib::WeakRef<gtk4::ListBox>,
+}
+
+/// Snapshot of upgraded strong references held for the duration of
+/// a single poll tick. All seven widgets upgrade together or we
+/// `Break` the timer — render functions then read these fields
+/// directly without needing their own weak-ref fallbacks.
+struct ServerStatusWidgets {
+    status_row: adw::ExpanderRow,
+    status_client_row: adw::ActionRow,
+    status_uptime_row: adw::ActionRow,
+    status_data_rate_row: adw::ActionRow,
+    status_commanded_row: adw::ActionRow,
+    activity_log_row: adw::ExpanderRow,
+    activity_log_list: gtk4::ListBox,
+}
+
+impl ServerStatusWidgetsWeak {
+    fn from_panel(panel: &sidebar::ServerPanel) -> Self {
+        Self {
+            status_row: panel.status_row.downgrade(),
+            status_client_row: panel.status_client_row.downgrade(),
+            status_uptime_row: panel.status_uptime_row.downgrade(),
+            status_data_rate_row: panel.status_data_rate_row.downgrade(),
+            status_commanded_row: panel.status_commanded_row.downgrade(),
+            activity_log_row: panel.activity_log_row.downgrade(),
+            activity_log_list: panel.activity_log_list.downgrade(),
+        }
+    }
+
+    /// Upgrade all seven weak refs atomically. Returns `None` if
+    /// any one widget has been destroyed — the caller breaks its
+    /// timer instead of rendering against a partially-dead panel.
+    fn upgrade(&self) -> Option<ServerStatusWidgets> {
+        Some(ServerStatusWidgets {
+            status_row: self.status_row.upgrade()?,
+            status_client_row: self.status_client_row.upgrade()?,
+            status_uptime_row: self.status_uptime_row.upgrade()?,
+            status_data_rate_row: self.status_data_rate_row.upgrade()?,
+            status_commanded_row: self.status_commanded_row.upgrade()?,
+            activity_log_row: self.activity_log_row.upgrade()?,
+            activity_log_list: self.activity_log_list.upgrade()?,
+        })
+    }
+}
+
 /// Poll `Server::stats()` on a fixed cadence, render the four
 /// status rows from the snapshot, and auto-stop the server if
 /// `has_stopped()` becomes true (e.g. USB dongle unplugged or
@@ -1440,9 +1522,8 @@ fn connect_server_status_polling(
 ) {
     use std::cell::Cell;
 
-    let server_panel = clone_server_panel(&panels.server);
+    let widgets_weak = ServerStatusWidgetsWeak::from_panel(&panels.server);
     let share_row_weak = panels.server.share_row.downgrade();
-    let widget_weak = panels.server.widget.downgrade();
     let last_bytes_sent = Rc::new(Cell::new(0u64));
     // Activity-log diff key: (ring_len, newest_instant). Rendering
     // is cheap but clearing the ListBox resets any user scroll
@@ -1460,12 +1541,14 @@ fn connect_server_status_polling(
     });
 
     let _ = glib::timeout_add_local(SERVER_STATUS_POLL_INTERVAL, move || {
-        // Tear the poller down if the panel widget is gone (window
-        // closed). Prevents leaking `server.stats()` locks past
-        // window lifetime.
-        if widget_weak.upgrade().is_none() {
+        // Upgrade all the status widgets in one shot. If any is gone
+        // (window closed → sidebar dropped → widgets orphaned), tear
+        // the timer down. Strong refs live only for the duration of
+        // this tick — dropped at function return — so they never
+        // contribute to the long-running GObject refcount.
+        let Some(widgets) = widgets_weak.upgrade() else {
             return glib::ControlFlow::Break;
-        }
+        };
         // Snapshot `Server::stats()` under the borrow. `stats()`
         // internally locks a Mutex — the return is a Clone, so the
         // borrow scope is tight.
@@ -1491,17 +1574,20 @@ fn connect_server_status_polling(
             return glib::ControlFlow::Continue;
         }
 
-        render_status_rows(&server_panel, &stats, &last_bytes_sent);
-        render_activity_log(&server_panel, &stats, &last_activity_key);
+        render_status_rows(&widgets, &stats, &last_bytes_sent);
+        render_activity_log(&widgets, &stats, &last_activity_key);
         glib::ControlFlow::Continue
     });
 }
 
 /// Write the current `ServerStats` snapshot into the four status
 /// rows. Uses `last_bytes_sent` to compute a rolling data-rate from
-/// delta-over-poll-interval.
+/// delta-over-poll-interval. Takes upgraded `ServerStatusWidgets`
+/// — strong refs held only for this call's duration — so the poll
+/// closure itself doesn't contribute to the long-running `GObject`
+/// refcount.
 fn render_status_rows(
-    panel: &sidebar::ServerPanel,
+    widgets: &ServerStatusWidgets,
     stats: &sdr_server_rtltcp::ServerStats,
     last_bytes_sent: &Rc<std::cell::Cell<u64>>,
 ) {
@@ -1512,21 +1598,21 @@ fn render_status_rows(
     // Client row + expander subtitle.
     if let Some(peer) = stats.connected_client {
         let peer_str = peer.to_string();
-        panel.status_client_row.set_subtitle(&peer_str);
-        panel
+        widgets.status_client_row.set_subtitle(&peer_str);
+        widgets
             .status_row
             .set_subtitle(&format!("Connected: {peer_str}"));
     } else {
-        panel
+        widgets
             .status_client_row
             .set_subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE);
-        panel
+        widgets
             .status_row
             .set_subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE);
     }
 
     // Uptime row.
-    panel
+    widgets
         .status_uptime_row
         .set_subtitle(&stats.connected_since.map_or_else(
             || STATUS_IDLE_VALUE_SUBTITLE.to_string(),
@@ -1539,7 +1625,7 @@ fn render_status_rows(
     let current_bytes = stats.bytes_sent;
     let delta = current_bytes.saturating_sub(last_bytes_sent.get());
     last_bytes_sent.set(current_bytes);
-    panel
+    widgets
         .status_data_rate_row
         .set_subtitle(&format_data_rate(delta, SERVER_STATUS_POLL_INTERVAL));
 
@@ -1547,7 +1633,7 @@ fn render_status_rows(
     // most recently requested." Assembled one piece at a time; an
     // unset field shows its upstream default stamp from
     // `InitialDeviceState::default()` rather than blanking out.
-    panel
+    widgets
         .status_commanded_row
         .set_subtitle(&format_commanded_state(stats));
 }
@@ -1643,7 +1729,7 @@ fn format_hz(hz: u32) -> String {
 /// so we skip the clear-and-rebuild on idle ticks — preserves any
 /// scroll position the user has in the `ListBox`.
 fn render_activity_log(
-    panel: &sidebar::ServerPanel,
+    widgets: &ServerStatusWidgets,
     stats: &sdr_server_rtltcp::ServerStats,
     last_rendered: &Rc<std::cell::Cell<(usize, Option<Instant>)>>,
 ) {
@@ -1658,18 +1744,18 @@ fn render_activity_log(
 
     // Clear the ListBox children. GTK4 ListBox has no mass-remove,
     // so walk the child list.
-    while let Some(child) = panel.activity_log_list.first_child() {
-        panel.activity_log_list.remove(&child);
+    while let Some(child) = widgets.activity_log_list.first_child() {
+        widgets.activity_log_list.remove(&child);
     }
 
     if stats.recent_commands.is_empty() {
-        panel
+        widgets
             .activity_log_row
             .set_subtitle(ACTIVITY_LOG_EMPTY_SUBTITLE);
         return;
     }
 
-    panel
+    widgets
         .activity_log_row
         .set_subtitle(&format!("{} commands", stats.recent_commands.len()));
     // Newest first so the user doesn't have to scroll to see the
@@ -1681,7 +1767,7 @@ fn render_activity_log(
             .subtitle(format_log_age(now.saturating_duration_since(*at)))
             .activatable(false)
             .build();
-        panel.activity_log_list.append(&row);
+        widgets.activity_log_list.append(&row);
     }
 }
 
@@ -1741,6 +1827,19 @@ fn reset_status_rows(panel: &sidebar::ServerPanel) {
         .set_subtitle(STATUS_IDLE_VALUE_SUBTITLE);
 }
 
+/// Upstream `rtl_tcp`'s `-D` flag accepts 0 = off, 2 = Q-branch
+/// direct sampling. Only those two values are meaningful for the
+/// UI switch; I-branch (1) is deliberately not exposed because
+/// upstream's CLI also hardcodes 2 for `-D`.
+const DIRECT_SAMPLING_OFF: i32 = 0;
+/// See [`DIRECT_SAMPLING_OFF`]. 2 selects the Q branch.
+const DIRECT_SAMPLING_Q_BRANCH: i32 = 2;
+/// Buffer-capacity sentinel passed to `ServerConfig`. `0` tells
+/// the server crate to use its internal `DEFAULT_BUFFER_CAPACITY`,
+/// keeping the UI honest about "we're not overriding this" rather
+/// than pinning a value the server may later tune.
+const SERVER_BUFFER_CAPACITY_DEFAULT: usize = 0;
+
 /// Read the server panel widget values and build a `ServerConfig`
 /// off them. Takes the full `ServerPanel` by reference so the arg
 /// list stays short and the fn signature documents the "this reads
@@ -1797,9 +1896,9 @@ fn build_server_config_from_panel(panel: &sidebar::ServerPanel) -> ServerConfig 
     let ppm = panel.ppm_row.value() as i32;
     let bias_tee = panel.bias_tee_row.is_active();
     let direct_sampling = if panel.direct_sampling_row.is_active() {
-        2 // Q branch — upstream rtl_tcp hardcodes 2 for -D.
+        DIRECT_SAMPLING_Q_BRANCH
     } else {
-        0
+        DIRECT_SAMPLING_OFF
     };
 
     ServerConfig {
@@ -1813,15 +1912,19 @@ fn build_server_config_from_panel(panel: &sidebar::ServerPanel) -> ServerConfig 
             bias_tee,
             direct_sampling,
         },
-        buffer_capacity: 0, // 0 = crate default
+        buffer_capacity: SERVER_BUFFER_CAPACITY_DEFAULT,
     }
 }
 
 /// Start an mDNS advertiser for the running `Server` using the
-/// user's chosen nickname (falling back to `local_hostname()` if the
-/// entry is empty or whitespace). Returns `None` on failure — the
-/// server itself keeps running, just without LAN advertising.
-fn build_advertiser(server: &Server, nickname_raw: &str) -> Option<Advertiser> {
+/// user's chosen nickname (falling back to `local_hostname()` if
+/// the entry is empty or whitespace). Errors propagate to the
+/// caller so the UI can toast them — the server itself keeps
+/// running regardless, just without LAN advertising.
+fn build_advertiser(
+    server: &Server,
+    nickname_raw: &str,
+) -> Result<Advertiser, sdr_rtltcp_discovery::DiscoveryError> {
     let nickname = nickname_raw.trim();
     let nickname = if nickname.is_empty() {
         local_hostname()
@@ -1850,13 +1953,7 @@ fn build_advertiser(server: &Server, nickname_raw: &str) -> Option<Advertiser> {
             txbuf: None,
         },
     };
-    match Advertiser::announce(opts) {
-        Ok(adv) => Some(adv),
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to start mDNS advertiser; server running without LAN advertisement");
-            None
-        }
-    }
+    Advertiser::announce(opts)
 }
 
 /// Lock or unlock the server-config rows. Called with `true` on

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use gtk4::gio;
 use gtk4::glib;
@@ -1331,6 +1331,7 @@ fn connect_share_switch(
                     };
                     set_controls_locked(&server_panel, true);
                     server_panel.status_row.set_visible(true);
+                    server_panel.activity_log_row.set_visible(true);
                     *running.borrow_mut() = Some(RunningServer { server, advertiser });
                 }
                 Err(e) => {
@@ -1364,7 +1365,9 @@ fn connect_share_switch(
             }
             set_controls_locked(&server_panel, false);
             server_panel.status_row.set_visible(false);
+            server_panel.activity_log_row.set_visible(false);
             reset_status_rows(&server_panel);
+            reset_activity_log(&server_panel);
         }
         apply_visibility();
     });
@@ -1395,6 +1398,8 @@ fn clone_server_panel(panel: &sidebar::ServerPanel) -> sidebar::ServerPanel {
         status_data_rate_row: panel.status_data_rate_row.clone(),
         status_commanded_row: panel.status_commanded_row.clone(),
         status_stop_button: panel.status_stop_button.clone(),
+        activity_log_row: panel.activity_log_row.clone(),
+        activity_log_list: panel.activity_log_list.clone(),
     }
 }
 
@@ -1439,6 +1444,10 @@ fn connect_server_status_polling(
     let share_row_weak = panels.server.share_row.downgrade();
     let widget_weak = panels.server.widget.downgrade();
     let last_bytes_sent = Rc::new(Cell::new(0u64));
+    // Activity-log diff key: (ring_len, newest_instant). Rendering
+    // is cheap but clearing the ListBox resets any user scroll
+    // position, so we short-circuit on unchanged ticks.
+    let last_activity_key: Rc<Cell<(usize, Option<Instant>)>> = Rc::new(Cell::new((0, None)));
 
     // Separate subscription on the Stop button. Flipping the switch
     // off is the single canonical stop path — pointing the button
@@ -1483,6 +1492,7 @@ fn connect_server_status_polling(
         }
 
         render_status_rows(&server_panel, &stats, &last_bytes_sent);
+        render_activity_log(&server_panel, &stats, &last_activity_key);
         glib::ControlFlow::Continue
     });
 }
@@ -1624,6 +1634,86 @@ fn format_hz(hz: u32) -> String {
         format!("{:.3} kHz", hz_f / 1_000.0)
     } else {
         format!("{hz} Hz")
+    }
+}
+
+/// Rebuild the activity-log list from the `ServerStats` ring if
+/// it has actually changed since the last render. The "changed?"
+/// check uses the ring length + the timestamp of the newest entry
+/// so we skip the clear-and-rebuild on idle ticks — preserves any
+/// scroll position the user has in the `ListBox`.
+fn render_activity_log(
+    panel: &sidebar::ServerPanel,
+    stats: &sdr_server_rtltcp::ServerStats,
+    last_rendered: &Rc<std::cell::Cell<(usize, Option<Instant>)>>,
+) {
+    use crate::sidebar::server_panel::ACTIVITY_LOG_EMPTY_SUBTITLE;
+
+    let newest = stats.recent_commands.back().map(|(_, t)| *t);
+    let current_key = (stats.recent_commands.len(), newest);
+    if current_key == last_rendered.get() {
+        return;
+    }
+    last_rendered.set(current_key);
+
+    // Clear the ListBox children. GTK4 ListBox has no mass-remove,
+    // so walk the child list.
+    while let Some(child) = panel.activity_log_list.first_child() {
+        panel.activity_log_list.remove(&child);
+    }
+
+    if stats.recent_commands.is_empty() {
+        panel
+            .activity_log_row
+            .set_subtitle(ACTIVITY_LOG_EMPTY_SUBTITLE);
+        return;
+    }
+
+    panel
+        .activity_log_row
+        .set_subtitle(&format!("{} commands", stats.recent_commands.len()));
+    // Newest first so the user doesn't have to scroll to see the
+    // most recent activity.
+    let now = Instant::now();
+    for (op, at) in stats.recent_commands.iter().rev() {
+        let row = adw::ActionRow::builder()
+            .title(format!("{op:?}"))
+            .subtitle(format_log_age(now.saturating_duration_since(*at)))
+            .activatable(false)
+            .build();
+        panel.activity_log_list.append(&row);
+    }
+}
+
+/// Reset activity-log list + subtitle on stop. Without this the
+/// list would persist after the server stopped — misleading users
+/// into thinking the log reflects a currently-running session.
+fn reset_activity_log(panel: &sidebar::ServerPanel) {
+    use crate::sidebar::server_panel::ACTIVITY_LOG_EMPTY_SUBTITLE;
+    while let Some(child) = panel.activity_log_list.first_child() {
+        panel.activity_log_list.remove(&child);
+    }
+    panel
+        .activity_log_row
+        .set_subtitle(ACTIVITY_LOG_EMPTY_SUBTITLE);
+}
+
+/// Render an elapsed duration as a compact "age" string for the
+/// activity-log rows. Narrower set of buckets than the discovery
+/// formatter — commands arrive in bursts during a session, so the
+/// "just now" / seconds-ago distinction matters but hours isn't
+/// common in a single session.
+fn format_log_age(elapsed: Duration) -> String {
+    const JUST_NOW_THRESHOLD: Duration = Duration::from_secs(2);
+    let secs = elapsed.as_secs();
+    if elapsed < JUST_NOW_THRESHOLD {
+        "just now".to_string()
+    } else if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else {
+        format!("{}h ago", secs / 3600)
     }
 }
 
@@ -3863,5 +3953,24 @@ mod server_panel_format_tests {
             subtitle.contains("gain 49.6 dB"),
             "49.6 dB should render from 496 tenths: {subtitle}"
         );
+    }
+
+    #[test]
+    fn format_log_age_buckets() {
+        use super::format_log_age;
+        // < 2 s → "just now" debounces the 500 ms poll from showing
+        // "0s ago" / "1s ago" noise on the most-recent entry.
+        assert_eq!(format_log_age(Duration::from_millis(0)), "just now");
+        assert_eq!(format_log_age(Duration::from_millis(1999)), "just now");
+        // 2 s – 59 s → "Ns ago"
+        assert_eq!(format_log_age(Duration::from_secs(2)), "2s ago");
+        assert_eq!(format_log_age(Duration::from_secs(59)), "59s ago");
+        // 1 m – 59 m → "Nm ago"
+        assert_eq!(format_log_age(Duration::from_mins(1)), "1m ago");
+        assert_eq!(format_log_age(Duration::from_secs(3599)), "59m ago");
+        // 1 h+ → "Nh ago" (rare — single-session command histories
+        // almost never live long enough, but the bucket keeps the
+        // formatter total).
+        assert_eq!(format_log_age(Duration::from_hours(1)), "1h ago");
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -849,6 +849,7 @@ fn connect_sidebar_panels(
 ) {
     connect_source_panel(panels, state);
     connect_rtl_tcp_discovery(panels, state);
+    connect_server_panel_visibility(panels);
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
@@ -1117,6 +1118,109 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     }
                 }
             }
+        }
+        glib::ControlFlow::Continue
+    });
+}
+
+/// Cadence for the USB hotplug poll that drives server-panel
+/// visibility. 3 s is the sweet spot: fast enough that a user
+/// plugging in a dongle sees the panel within the time it takes them
+/// to reach the sidebar with the mouse, slow enough that the
+/// per-tick `rusb::devices()` USB-bus enumerate is invisible in
+/// profile traces.
+const SERVER_PANEL_HOTPLUG_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Wire the server panel's visibility to USB hotplug state and the
+/// currently-selected source type. The panel appears only when both
+/// hold:
+///
+/// 1. at least one RTL-SDR dongle is visible on the local USB bus
+///    (`sdr_rtlsdr::get_device_count() > 0`), and
+/// 2. the active source type is **not** RTL-SDR — re-exposing the
+///    same dongle over `rtl_tcp` while a local `RtlSdrSource` is
+///    holding it would cause a USB-device double-open.
+///
+/// Visibility is recomputed on two triggers so the panel feels
+/// responsive without polling the world: a low-frequency timer that
+/// handles the USB side (hotplug has no GTK signal we can subscribe
+/// to) and a `device_row.connect_selected_notify` handler that fires
+/// on every source-type change. A `Cell<u32>` tracks the last-seen
+/// device count so we only pay the widget-state-update cost on an
+/// actual edge.
+fn connect_server_panel_visibility(panels: &SidebarPanels) {
+    use std::cell::Cell;
+
+    let server_widget_weak = panels.server.widget.downgrade();
+    let device_row = panels.source.device_row.clone();
+    let last_seen_count = Rc::new(Cell::new(u32::MAX));
+
+    // Pure function: does the combined rule say "show"?
+    let should_be_visible = |dongle_count: u32, selected: u32| -> bool {
+        dongle_count > 0 && selected != DEVICE_RTLSDR
+    };
+
+    // Apply visibility, using the cached dongle count. Shared
+    // between the poll tick and the device-row notify handler so
+    // the two callers stay in lockstep.
+    let apply_visibility = {
+        let server_widget_weak = server_widget_weak.clone();
+        let device_row = device_row.clone();
+        let last_seen_count = Rc::clone(&last_seen_count);
+        move || {
+            let Some(widget) = server_widget_weak.upgrade() else {
+                return;
+            };
+            let count = last_seen_count.get();
+            // First invocation before any poll: count is u32::MAX,
+            // which would evaluate true for `> 0`. Treat the
+            // pre-first-tick state as "no dongle yet" so the panel
+            // stays hidden until we actually know — prevents a
+            // flash-of-unwanted-panel during startup.
+            let effective_count = if count == u32::MAX { 0 } else { count };
+            widget.set_visible(should_be_visible(effective_count, device_row.selected()));
+        }
+    };
+
+    // Reapply on source-type change. Cloned because
+    // `connect_selected_notify` takes an `Fn(&ComboRow)` and we want
+    // the same logic as the poll tick.
+    let apply_on_device_change = apply_visibility.clone();
+    panels
+        .source
+        .device_row
+        .connect_selected_notify(move |_| apply_on_device_change());
+
+    // Seed `last_seen_count` on the first tick. Using a glib timer
+    // (rather than running the USB probe synchronously during
+    // wiring) keeps the window-build path fast and avoids a libusb
+    // session init on a thread that may not have one ready.
+    let apply_on_tick = apply_visibility;
+    let _ = glib::timeout_add_local(SERVER_PANEL_HOTPLUG_POLL_INTERVAL, move || {
+        // If the widget is gone, tear the poller down — nothing to
+        // show, and we don't want to leak `rusb::devices()` calls
+        // past window close.
+        if server_widget_weak.upgrade().is_none() {
+            return glib::ControlFlow::Break;
+        }
+        // `sdr_rtlsdr::get_device_count()` is a libusb enumerate
+        // (vendor/product-ID filter over `rusb::devices()`). Fast
+        // enough for the UI thread at a 3 s cadence; no syscall
+        // churn worth moving to a worker.
+        let count = sdr_rtlsdr::get_device_count();
+        // First tick ALWAYS flips the cache off `u32::MAX`, so this
+        // branch fires at least once even if the real count is 0 —
+        // that's the "resolve the panel out of its pre-first-tick
+        // hidden state" moment. Subsequent ticks only apply on a
+        // real edge so we don't churn widget state every 3 s.
+        if count != last_seen_count.get() {
+            tracing::debug!(
+                previous = last_seen_count.get(),
+                current = count,
+                "rtl_tcp server panel: local dongle count changed"
+            );
+            last_seen_count.set(count);
+            apply_on_tick();
         }
         glib::ControlFlow::Continue
     });

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -13,7 +13,11 @@ use libadwaita::prelude::*;
 use sdr_core::Engine;
 use sdr_pipeline::iq_frontend::FftWindow;
 use sdr_radio::DeemphasisMode;
-use sdr_rtltcp_discovery::{Browser, DiscoveredServer, DiscoveryEvent};
+use sdr_rtltcp_discovery::{
+    AdvertiseOptions, Advertiser, Browser, DiscoveredServer, DiscoveryEvent, TxtRecord,
+    local_hostname,
+};
+use sdr_server_rtltcp::{InitialDeviceState, Server, ServerConfig};
 use sdr_source_rtlsdr::SAMPLE_RATES;
 
 use crate::header;
@@ -198,6 +202,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         &freq_selector,
         &demod_dropdown,
         &status_bar_demod,
+        &toast_overlay,
     );
 
     // Wire waterfall screenshot button.
@@ -846,10 +851,11 @@ fn connect_sidebar_panels(
     freq_selector: &header::frequency_selector::FrequencySelector,
     demod_dropdown: &gtk4::DropDown,
     status_bar: &Rc<StatusBar>,
+    toast_overlay: &adw::ToastOverlay,
 ) {
     connect_source_panel(panels, state);
     connect_rtl_tcp_discovery(panels, state);
-    connect_server_panel_visibility(panels);
+    connect_server_panel(panels, toast_overlay);
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
@@ -1131,42 +1137,67 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
 /// profile traces.
 const SERVER_PANEL_HOTPLUG_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
-/// Wire the server panel's visibility to USB hotplug state and the
-/// currently-selected source type. The panel appears only when both
-/// hold:
+/// Owned handle for a running `rtl_tcp` server + optional mDNS
+/// advertisement. Drops in reverse order: advertiser first (so
+/// peers see the goodbye packet before the server stops), then the
+/// server itself (which consumes its accept thread + USB device).
 ///
+/// `Advertiser` is an `Option` because the user can run the server
+/// without LAN advertising via the "Announce via mDNS" switch.
+struct RunningServer {
+    server: Server,
+    advertiser: Option<Advertiser>,
+}
+
+/// Wire the server panel end-to-end: visibility gating, the master
+/// share-over-network switch, and its downstream start/stop effects.
+/// Errors surface via the `toast_overlay`, and the switch auto-
+/// reverts to its off state so the UI never lies about whether a
+/// server is actually running.
+///
+/// Visibility rule:
 /// 1. at least one RTL-SDR dongle is visible on the local USB bus
 ///    (`sdr_rtlsdr::get_device_count() > 0`), and
 /// 2. the active source type is **not** RTL-SDR — re-exposing the
 ///    same dongle over `rtl_tcp` while a local `RtlSdrSource` is
-///    holding it would cause a USB-device double-open.
+///    holding it would cause a USB-device double-open, and
+/// 3. OR the server is already running (keep the panel visible so
+///    the user can reach the Stop switch no matter what).
 ///
-/// Visibility is recomputed on two triggers so the panel feels
+/// Visibility is recomputed on three triggers so the panel feels
 /// responsive without polling the world: a low-frequency timer that
 /// handles the USB side (hotplug has no GTK signal we can subscribe
-/// to) and a `device_row.connect_selected_notify` handler that fires
-/// on every source-type change. A `Cell<u32>` tracks the last-seen
-/// device count so we only pay the widget-state-update cost on an
-/// actual edge.
-fn connect_server_panel_visibility(panels: &SidebarPanels) {
+/// to), a `device_row.connect_selected_notify` handler that fires
+/// on every source-type change, and the share-row start/stop path
+/// itself. A `Cell<u32>` tracks the last-seen device count so we
+/// only pay the widget-state-update cost on an actual edge.
+#[allow(
+    clippy::too_many_lines,
+    reason = "GTK signal-wiring: visibility + start-stop + control-locking all share state via nested closures — splitting scatters the captures"
+)]
+fn connect_server_panel(panels: &SidebarPanels, toast_overlay: &adw::ToastOverlay) {
     use std::cell::Cell;
 
     let server_widget_weak = panels.server.widget.downgrade();
     let device_row = panels.source.device_row.clone();
     let last_seen_count = Rc::new(Cell::new(u32::MAX));
+    let running: Rc<RefCell<Option<RunningServer>>> = Rc::new(RefCell::new(None));
 
-    // Pure function: does the combined rule say "show"?
-    let should_be_visible = |dongle_count: u32, selected: u32| -> bool {
-        dongle_count > 0 && selected != DEVICE_RTLSDR
+    // Pure function: does the combined rule say "show"? A running
+    // server always wins — the user must be able to reach the Stop
+    // switch regardless of hotplug / source-type state.
+    let should_be_visible = |dongle_count: u32, selected: u32, is_running: bool| -> bool {
+        is_running || (dongle_count > 0 && selected != DEVICE_RTLSDR)
     };
 
     // Apply visibility, using the cached dongle count. Shared
-    // between the poll tick and the device-row notify handler so
-    // the two callers stay in lockstep.
+    // between the poll tick, the device-row notify handler, and the
+    // start/stop path so all three callers stay in lockstep.
     let apply_visibility = {
         let server_widget_weak = server_widget_weak.clone();
         let device_row = device_row.clone();
         let last_seen_count = Rc::clone(&last_seen_count);
+        let running = Rc::clone(&running);
         move || {
             let Some(widget) = server_widget_weak.upgrade() else {
                 return;
@@ -1178,7 +1209,12 @@ fn connect_server_panel_visibility(panels: &SidebarPanels) {
             // stays hidden until we actually know — prevents a
             // flash-of-unwanted-panel during startup.
             let effective_count = if count == u32::MAX { 0 } else { count };
-            widget.set_visible(should_be_visible(effective_count, device_row.selected()));
+            let is_running = running.borrow().is_some();
+            widget.set_visible(should_be_visible(
+                effective_count,
+                device_row.selected(),
+                is_running,
+            ));
         }
     };
 
@@ -1195,12 +1231,14 @@ fn connect_server_panel_visibility(panels: &SidebarPanels) {
     // (rather than running the USB probe synchronously during
     // wiring) keeps the window-build path fast and avoids a libusb
     // session init on a thread that may not have one ready.
-    let apply_on_tick = apply_visibility;
+    let apply_on_tick = apply_visibility.clone();
+    let poll_widget_weak = server_widget_weak.clone();
+    let poll_last_seen_count = Rc::clone(&last_seen_count);
     let _ = glib::timeout_add_local(SERVER_PANEL_HOTPLUG_POLL_INTERVAL, move || {
         // If the widget is gone, tear the poller down — nothing to
         // show, and we don't want to leak `rusb::devices()` calls
         // past window close.
-        if server_widget_weak.upgrade().is_none() {
+        if poll_widget_weak.upgrade().is_none() {
             return glib::ControlFlow::Break;
         }
         // `sdr_rtlsdr::get_device_count()` is a libusb enumerate
@@ -1213,17 +1251,263 @@ fn connect_server_panel_visibility(panels: &SidebarPanels) {
         // that's the "resolve the panel out of its pre-first-tick
         // hidden state" moment. Subsequent ticks only apply on a
         // real edge so we don't churn widget state every 3 s.
-        if count != last_seen_count.get() {
+        if count != poll_last_seen_count.get() {
             tracing::debug!(
-                previous = last_seen_count.get(),
+                previous = poll_last_seen_count.get(),
                 current = count,
                 "rtl_tcp server panel: local dongle count changed"
             );
-            last_seen_count.set(count);
+            poll_last_seen_count.set(count);
             apply_on_tick();
         }
         glib::ControlFlow::Continue
     });
+
+    // Wire the master share-over-network switch. The handler is the
+    // authority on server lifecycle — on toggle we either start a
+    // new `Server` (+ optional `Advertiser`) and store the handle,
+    // or drop the handle so the accept thread tears down.
+    connect_share_switch(panels, toast_overlay, Rc::clone(&running), apply_visibility);
+}
+
+/// Extracted out of `connect_server_panel` so the parent function
+/// stays under clippy's `too_many_lines` limit. Handles exactly one
+/// thing: the `share_row.connect_active_notify` wiring, with its
+/// downstream start/stop effects (build `ServerConfig`, call
+/// `Server::start`, optionally attach an `Advertiser`, lock or
+/// unlock the panel controls, reapply visibility, and surface any
+/// error via a toast while flipping the switch back to off).
+fn connect_share_switch(
+    panels: &SidebarPanels,
+    toast_overlay: &adw::ToastOverlay,
+    running: Rc<RefCell<Option<RunningServer>>>,
+    apply_visibility: impl Fn() + Clone + 'static,
+) {
+    use std::cell::Cell;
+
+    // Guards against our own `set_active(false)` (called when the
+    // user-initiated start path errors out) re-entering the handler
+    // and triggering a spurious stop dispatch on a server that
+    // never started.
+    let reentry_guard = Rc::new(Cell::new(false));
+    let toast_overlay_weak = toast_overlay.downgrade();
+
+    let share_row_weak = panels.server.share_row.downgrade();
+    // Clone the whole ServerPanel Rc-backed widget handles into the
+    // closure. adw/gtk widgets are GObject refs; cloning increments
+    // a refcount, not the data.
+    let server_panel = clone_server_panel(&panels.server);
+
+    panels.server.share_row.connect_active_notify(move |row| {
+        if reentry_guard.get() {
+            return;
+        }
+        let active = row.is_active();
+        if active {
+            // Build a ServerConfig from current panel state. Widget
+            // readers run on the main thread — safe to block-read
+            // the rows synchronously.
+            let config = build_server_config_from_panel(&server_panel);
+            match Server::start(config) {
+                Ok(server) => {
+                    // If advertising is on, build the TXT record
+                    // from the tuner metadata the Server exposes.
+                    // An Advertiser failure is non-fatal — the
+                    // server keeps running without mDNS.
+                    let advertiser = if server_panel.advertise_row.is_active() {
+                        build_advertiser(&server, &server_panel.nickname_row.text())
+                    } else {
+                        None
+                    };
+                    set_controls_locked(&server_panel, true);
+                    *running.borrow_mut() = Some(RunningServer { server, advertiser });
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to start rtl_tcp server");
+                    if let Some(overlay) = toast_overlay_weak.upgrade() {
+                        overlay.add_toast(adw::Toast::new(&format!(
+                            "Couldn't share over network: {e}"
+                        )));
+                    }
+                    // Revert the switch without re-entering this
+                    // same handler — the reentry_guard covers the
+                    // set_active call below.
+                    reentry_guard.set(true);
+                    if let Some(share) = share_row_weak.upgrade() {
+                        share.set_active(false);
+                    }
+                    reentry_guard.set(false);
+                }
+            }
+        } else {
+            // Drop the handle → Server::drop signals shutdown and
+            // joins the accept thread; Advertiser::drop unregisters
+            // the mDNS record. Sequence matters (advertiser first
+            // so peers see the goodbye packet before the server
+            // stops) — field declaration order in `RunningServer`
+            // would drop `server` first, so take the advertiser
+            // explicitly first to reverse.
+            if let Some(mut handle) = running.borrow_mut().take() {
+                drop(handle.advertiser.take());
+                drop(handle.server);
+            }
+            set_controls_locked(&server_panel, false);
+        }
+        apply_visibility();
+    });
+}
+
+/// Deep-clone a `ServerPanel` (via `GObject` refcounts — all fields
+/// are adw/gtk widget handles, not data owners). Used to move a full
+/// panel reference into a long-lived closure without borrowing from
+/// the original `SidebarPanels`.
+fn clone_server_panel(panel: &sidebar::ServerPanel) -> sidebar::ServerPanel {
+    sidebar::ServerPanel {
+        widget: panel.widget.clone(),
+        share_row: panel.share_row.clone(),
+        nickname_row: panel.nickname_row.clone(),
+        port_row: panel.port_row.clone(),
+        bind_row: panel.bind_row.clone(),
+        advertise_row: panel.advertise_row.clone(),
+        device_defaults_row: panel.device_defaults_row.clone(),
+        center_freq_row: panel.center_freq_row.clone(),
+        sample_rate_row: panel.sample_rate_row.clone(),
+        gain_row: panel.gain_row.clone(),
+        ppm_row: panel.ppm_row.clone(),
+        bias_tee_row: panel.bias_tee_row.clone(),
+        direct_sampling_row: panel.direct_sampling_row.clone(),
+    }
+}
+
+/// Read the server panel widget values and build a `ServerConfig`
+/// off them. Takes the full `ServerPanel` by reference so the arg
+/// list stays short and the fn signature documents the "this reads
+/// EVERY relevant row" contract clearly.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "spin-row values are bounded to u16/u32 ranges at the widget level"
+)]
+fn build_server_config_from_panel(panel: &sidebar::ServerPanel) -> ServerConfig {
+    use std::net::SocketAddr;
+
+    use crate::sidebar::server_panel::{BIND_ALL_INTERFACES_IDX, BIND_LOOPBACK_IDX};
+
+    let port = panel.port_row.value() as u16;
+    // Match arm bodies duplicate between `BIND_LOOPBACK_IDX` and the
+    // wildcard intentionally: the explicit arm documents the
+    // expected value at a glance, and the wildcard catches transient
+    // out-of-range indices GTK can emit during widget churn. Folding
+    // them loses the at-a-glance enumeration of legal indices next
+    // to the feature-flag constants.
+    #[allow(
+        clippy::match_same_arms,
+        reason = "explicit legal-index arms document the rule"
+    )]
+    let bind = match panel.bind_row.selected() {
+        BIND_LOOPBACK_IDX => SocketAddr::from(([127, 0, 0, 1], port)),
+        BIND_ALL_INTERFACES_IDX => SocketAddr::from(([0, 0, 0, 0], port)),
+        _ => SocketAddr::from(([127, 0, 0, 1], port)),
+    };
+
+    let center_freq_hz = panel.center_freq_row.value() as u32;
+    // Sample-rate rows share the SAMPLE_RATES table via
+    // `source_panel::build_rtlsdr_rows` ordering. `SAMPLE_RATES`
+    // holds f64 values; the server API wants u32 Hz, so round on
+    // the way across. Out-of-range selectors fall back on the
+    // upstream rtl_tcp.c default.
+    let sample_rate_hz = SAMPLE_RATES
+        .get(panel.sample_rate_row.selected() as usize)
+        .copied()
+        .map_or(sdr_server_rtltcp::DEFAULT_SAMPLE_RATE_HZ, |rate| {
+            rate.round() as u32
+        });
+
+    // UI treats gain = 0.0 as auto (None), matching upstream's
+    // `-g 0` semantics. Any positive value becomes tenths-of-dB.
+    let gain_db = panel.gain_row.value();
+    let gain_tenths_db = if gain_db > 0.0 {
+        Some((gain_db * 10.0).round() as i32)
+    } else {
+        None
+    };
+
+    let ppm = panel.ppm_row.value() as i32;
+    let bias_tee = panel.bias_tee_row.is_active();
+    let direct_sampling = if panel.direct_sampling_row.is_active() {
+        2 // Q branch — upstream rtl_tcp hardcodes 2 for -D.
+    } else {
+        0
+    };
+
+    ServerConfig {
+        bind,
+        device_index: 0,
+        initial: InitialDeviceState {
+            center_freq_hz,
+            sample_rate_hz,
+            gain_tenths_db,
+            ppm,
+            bias_tee,
+            direct_sampling,
+        },
+        buffer_capacity: 0, // 0 = crate default
+    }
+}
+
+/// Start an mDNS advertiser for the running `Server` using the
+/// user's chosen nickname (falling back to `local_hostname()` if the
+/// entry is empty or whitespace). Returns `None` on failure — the
+/// server itself keeps running, just without LAN advertising.
+fn build_advertiser(server: &Server, nickname_raw: &str) -> Option<Advertiser> {
+    let nickname = nickname_raw.trim();
+    let nickname = if nickname.is_empty() {
+        local_hostname()
+    } else {
+        nickname.to_string()
+    };
+    let host = local_hostname();
+    // DNS-SD instance names must be unique on the LAN. Combine host
+    // + nickname the same way the CLI does in
+    // `sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs::announce_over_mdns`.
+    let instance_name = if nickname == host {
+        nickname.clone()
+    } else {
+        format!("{host} {nickname}")
+    };
+    let tuner_info = server.tuner_info();
+    let opts = AdvertiseOptions {
+        port: server.bind_address().port(),
+        instance_name,
+        hostname: host.clone(),
+        txt: TxtRecord {
+            tuner: tuner_info.name.clone(),
+            version: env!("CARGO_PKG_VERSION").into(),
+            gains: tuner_info.gain_count,
+            nickname,
+            txbuf: None,
+        },
+    };
+    match Advertiser::announce(opts) {
+        Ok(adv) => Some(adv),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to start mDNS advertiser; server running without LAN advertisement");
+            None
+        }
+    }
+}
+
+/// Lock or unlock the server-config rows. Called with `true` on
+/// start (so the user can't mutate config out from under a live
+/// session) and `false` on stop. `share_row` itself stays sensitive
+/// — that's how the user turns things off.
+fn set_controls_locked(panel: &sidebar::ServerPanel, locked: bool) {
+    let sensitive = !locked;
+    panel.nickname_row.set_sensitive(sensitive);
+    panel.port_row.set_sensitive(sensitive);
+    panel.bind_row.set_sensitive(sensitive);
+    panel.advertise_row.set_sensitive(sensitive);
+    panel.device_defaults_row.set_sensitive(sensitive);
 }
 
 /// Format the subtitle string for a discovered `rtl_tcp` server row.


### PR DESCRIPTION
## Summary

Closes #322 — the share-over-network server side of the rtl_tcp UI epic (#299). Sits in the sidebar directly below Source.

Landed as 5 logical commits so the review reads like a story:

1. **Skeleton** (`f1bc689`) — widget-only `ServerPanel` with six top-level rows (share switch, nickname, port, bind address, mDNS toggle, "Device defaults" expander with freq/sample rate/gain/PPM/bias tee/direct sampling) and compile-time invariants on the port and frequency bounds.
2. **Visibility** (`1dcfcbf`) — 3 s USB hotplug poll via `sdr_rtlsdr::get_device_count()` + `device_row.connect_selected_notify`. Panel appears only when a local dongle is present AND not the active source.
3. **Start/stop** (`1654aab`) — master switch wires to `Server::start()` + optional `Advertiser`. Reentry guard on the error-path `set_active(false)`. Controls lock while running. Errors surface via `AdwToast`. `RunningServer` struct drops advertiser first so peers see the mDNS goodbye packet.
4. **Status row** (`ccb7196`) — `ServerStats` grows four commanded-state fields (freq / sample rate / gain tenths / auto bool). 500 ms poll renders Connected-client / Uptime / Data-rate / Tuned-to subtitles. Data rate computed from `bytes_sent` deltas. Stop button in expander suffix. `has_stopped()` auto-flips switch off on USB unplug.
5. **Activity log** (`2738439`) — bounded `VecDeque<(CommandOp, Instant)>` ring at `RECENT_COMMANDS_CAPACITY = 50`. Dispatch pushes, cleared on connect/disconnect. UI diffs on `(ring_len, newest_instant)` to avoid clearing the ListBox on idle ticks (preserves user scroll).

### Architecture choices

- **UI owns the `Server` handle directly** instead of the DSP controller. The server is a sibling service — it opens its own USB device and runs its own accept thread — not part of the receive-path pipeline. Avoided adding `sdr-server-rtltcp` as a `sdr-core` dep this way.
- **`ServerStats` enriched** with client-commanded-state fields so the UI can show "GQRX thinks we're tuned to 145.500 MHz" — useful for debugging client bugs. We record what the CLIENT requested, not what the device applied, because dispatch already warn-logs device failures.
- **500 ms stats poll** with edge-triggered activity-log rebuild: cheap enough to feel live, smart enough not to thrash GTK.

### Pre-commit self-review

Walked each commit against the CR-pattern checklist accumulated from PRs #324 / #295 / #273 / etc. — named consts for every magic number with rationale docstrings, `f64::from` for u32→f64 casts, compile-time `const { assert!(...) }` blocks instead of runtime-tautology tests, `downgrade()` + `upgrade()` on all widget captures, reentry-guard pattern on user-initiated toggles, bucketed formatters with unit tests, `rtl_tcp.c` and other upstream names backticked in docs, `#[allow]` attrs carry `reason = "..."`.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace` — 837 pass (828 before; 9 new: port bounds, freq bounds, bind distinctness via `const { }` asserts, 7 format helpers, stats-struct disconnect cleanup)
- [ ] UI smoke (user, tomorrow): hotplug panel visibility, start/stop happy path, GQRX round-trip (status + activity log), Stop button path, dongle-unplug auto-flip, port-in-use toast path, mDNS on/off, switch back to RTL-SDR source

## Notes for reviewers

- The `rtl_tcp_status_row` scope (connection-state display with Retrying / Failed states) is still deferred to #323 per the memory from PR #324.
- Bind-address "specific interface" dropdown entry is also deferred to #323 — needs an interface enumerator we haven't wired.
- Port-in-use and dongle-not-present error paths produce toasts; no custom error-message polish yet (hook point noted in comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Server panel to sidebar to share RTL‑SDR over rtl_tcp with port, bind, mDNS and device-defaults controls.
  * Live status: connected client, uptime, data rate and current tuning shown in-panel.
  * Activity log shows recent server commands (bounded history) and updates in real time.

* **Bug Fixes / Stability**
  * Panel visibility and server lifecycle now auto-manage with device hotplug, start/stop failures, and disconnect clearing of runtime state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->