### PR TITLE
fix(macos): visible selected-digit indicator on FrequencyDigitsEntry (#328)

### DIFF
--- a/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
+++ b/apps/macos/SDRMac/Views/FrequencyDigitsEntry.swift
@@ -147,13 +147,33 @@ struct FrequencyDigitsEntry: View {
     private func digitLabel(at i: Int) -> some View {
         let firstNonzero = digits.firstIndex(where: { $0 != 0 }) ?? Self.numDigits
         let isLeading = i < firstNonzero && i != Self.numDigits - 1
-        let isSelected = focused && i == selectedIndex
+        // Selection is independent of keyboard focus — the user
+        // who clicks a digit and then moves the mouse still has
+        // a meaningful "this is the target digit" expectation.
+        // Paint the selected digit in the system accent color
+        // (bold weight too) so it reads at a glance without any
+        // background chrome. Dim when the control doesn't have
+        // keyboard focus, brighten when focused, so "typing lands
+        // here" vs "click first" is still distinguishable.
+        // Closes #328.
+        let isSelected = i == selectedIndex
+
+        let digitColor: Color
+        if isSelected {
+            digitColor = focused
+                ? .accentColor
+                : .accentColor.opacity(0.65)
+        } else if isLeading {
+            digitColor = .secondary.opacity(0.6)
+        } else {
+            digitColor = .primary
+        }
 
         return Text("\(digits[i])")
             .font(Self.digitFont)
-            .foregroundStyle(isLeading ? .tertiary : .primary)
+            .fontWeight(isSelected ? .bold : .regular)
+            .foregroundStyle(digitColor)
             .frame(minWidth: 12)
-            .underline(isSelected, color: .accentColor)
             .contentShape(Rectangle())
             .onTapGesture {
                 selectedIndex = i


### PR DESCRIPTION
## Summary

Closes #328. The selected digit in the toolbar frequency display now shows a clear accent-blue bold indicator, visible whether or not the control has keyboard focus.

## The bug

Two compounding problems:

1. The visual was gated on SwiftUI's `@FocusState` — \`isSelected = focused && i == selectedIndex\`. A user who clicked a digit and then moved the mouse lost the indicator, even though \`selectedIndex\` was still valid and the next arrow-key press would still step the same digit. SwiftUI focus in a toolbar item is also flaky.

2. The underline style was too subtle to read against macOS Tahoe's liquid-glass toolbar pill.

## The fix

Paint the selected digit in the system accent color with bold weight, always — decouple the visual from the focus state. Focused vs unfocused is a brightness shade (full accent vs 65% opacity) so power users can still tell "typing lands here now" from "click first".

## Test plan

- [x] Click a digit → that digit immediately turns bold accent-blue.
- [x] Move mouse off the toolbar → indicator stays on the clicked digit at a dimmer shade.
- [x] Click back on the toolbar → brightens to full accent.
- [x] Use arrow keys → selection moves and visual follows.
- [x] `make lint` green; no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)