### PR TITLE
feat(macos): Group A UI build-out — display extras, auto-squelch, bookmarks

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -270,6 +270,14 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(sdr_core_set_squelch_enabled(handle, enabled))
     }
 
+    /// Enable or disable auto-squelch (engine-side noise-floor
+    /// tracking). While on, the engine adjusts the squelch
+    /// threshold continuously; manual `setSquelchDb` writes are
+    /// accepted but will be overwritten on the next tracker cycle.
+    public func setAutoSquelch(_ enabled: Bool) throws {
+        try checkRc(sdr_core_set_auto_squelch(handle, enabled))
+    }
+
     /// Set the squelch threshold in dB.
     public func setSquelchDb(_ db: Float) throws {
         try checkRc(sdr_core_set_squelch_db(handle, db))

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
@@ -10,7 +10,7 @@
 import sdr_core_c
 
 /// Demodulation mode. Matches `SdrDemodMode` in the C header.
-public enum DemodMode: Int32, Sendable, CaseIterable {
+public enum DemodMode: Int32, Sendable, CaseIterable, Codable {
     case wfm  = 0
     case nfm  = 1
     case am   = 2
@@ -36,7 +36,7 @@ public enum DemodMode: Int32, Sendable, CaseIterable {
 }
 
 /// FM de-emphasis mode. Matches `SdrDeemphasis` in the C header.
-public enum Deemphasis: Int32, Sendable, CaseIterable {
+public enum Deemphasis: Int32, Sendable, CaseIterable, Codable {
     case none = 0
     case us75 = 1
     case eu50 = 2

--- a/apps/macos/Packages/SdrCoreKit/Tests/SdrCoreKitTests/SdrCoreTests.swift
+++ b/apps/macos/Packages/SdrCoreKit/Tests/SdrCoreKitTests/SdrCoreTests.swift
@@ -17,12 +17,13 @@ final class SdrCoreTests: XCTestCase {
 
     func testAbiVersionMatchesCurrent() {
         // Lock in that the Swift wrapper parses the packed
-        // version from the C side consistently. Current: 0.2
-        // (0.2 added device enumeration: sdr_core_device_count +
-        // sdr_core_device_name).
+        // version from the C side consistently. Current: 0.3
+        // (0.2 added device enumeration: sdr_core_device_count
+        // + sdr_core_device_name. 0.3 added
+        // sdr_core_set_auto_squelch.)
         let v = SdrCore.abiVersion
         XCTAssertEqual(v.major, 0)
-        XCTAssertEqual(v.minor, 2)
+        XCTAssertEqual(v.minor, 3)
     }
 
     func testInitLoggingIsIdempotent() {

--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -64,6 +64,7 @@ struct SidebarView: View {
             SourceSection()
             RadioSection()
             DisplaySection()
+            BookmarksSection()
         }
         .formStyle(.grouped)
     }

--- a/apps/macos/SDRMac/Models/AveragingMode.swift
+++ b/apps/macos/SDRMac/Models/AveragingMode.swift
@@ -1,0 +1,38 @@
+//
+// AveragingMode.swift — display-side spectrum averaging.
+//
+// UI-only feature: the engine doesn't know or care about
+// averaging. The renderer applies the selected mode to each
+// incoming FFT frame before handing the values to the Metal
+// shader. Matches the GTK side's `AveragingMode` in
+// `crates/sdr-ui/src/spectrum/mod.rs` variant-for-variant so
+// the two UIs feel the same.
+
+import Foundation
+
+enum AveragingMode: String, Sendable, CaseIterable {
+    /// No averaging — display raw FFT data.
+    case none
+    /// Hold peak values across frames.
+    case peakHold
+    /// Exponential moving average with fixed alpha. Smooths
+    /// fast transients; signals stay roughly where they are.
+    case runningAvg
+    /// Hold minimum values across frames. Useful for spotting
+    /// noise floor.
+    case minHold
+
+    var label: String {
+        switch self {
+        case .none:       "None"
+        case .peakHold:   "Peak Hold"
+        case .runningAvg: "Running Avg"
+        case .minHold:    "Min Hold"
+        }
+    }
+}
+
+/// Alpha for `.runningAvg` exponential smoothing. Same value
+/// as the GTK side's `AVERAGING_ALPHA` so the two UIs show
+/// identical smoothing behavior at the same FFT rate.
+let averagingAlpha: Float = 0.3

--- a/apps/macos/SDRMac/Models/Bookmark.swift
+++ b/apps/macos/SDRMac/Models/Bookmark.swift
@@ -1,0 +1,53 @@
+//
+// Bookmark.swift — saved tuning profile.
+//
+// Mirrors the GTK `Bookmark` struct in
+// `crates/sdr-ui/src/sidebar/navigation_panel.rs` but stays
+// Swift-native (separate `bookmarks.json`, not round-tripped
+// through sdr-config) — the Linux side also stores bookmarks
+// in their own file rather than in the engine config.
+//
+// All tuning fields are optional. On recall, an absent field
+// means "leave that setting alone", which makes it easy to save
+// e.g. a "weather band VFO bandwidth" bookmark that doesn't
+// override the user's current demod mode.
+
+import Foundation
+import SdrCoreKit
+
+// `DemodMode` / `Deemphasis` are `Int32`-raw-value enums defined
+// in SdrCoreKit. Swift synthesizes `Codable` automatically for
+// `RawRepresentable` enums once conformance is declared — we
+// just need the retroactive conformance for Codable-nested
+// bookmark fields to work. Nothing stored in the JSON except
+// the raw integer.
+extension DemodMode: Codable {}
+extension Deemphasis: Codable {}
+
+struct Bookmark: Codable, Identifiable, Hashable {
+    /// Stable identity for SwiftUI list diffing; randomly
+    /// assigned at creation, persisted across runs.
+    var id: UUID = UUID()
+
+    /// Human-readable name. If the user doesn't supply one we
+    /// format the frequency as the default.
+    var name: String
+
+    /// Creation / last-modified timestamp; shown as a relative
+    /// date ("2 days ago") in the list for quick disambiguation
+    /// when several bookmarks share similar frequencies.
+    var updatedAt: Date = Date()
+
+    // MARK: Tuning fields (all optional)
+
+    var centerFrequencyHz: Double?
+    var demodMode: DemodMode?
+    var bandwidthHz: Double?
+    var squelchEnabled: Bool?
+    var autoSquelchEnabled: Bool?
+    var squelchDb: Float?
+    var gainDb: Double?
+    var agcEnabled: Bool?
+    var volume: Float?
+    var deemphasis: Deemphasis?
+}

--- a/apps/macos/SDRMac/Models/Bookmark.swift
+++ b/apps/macos/SDRMac/Models/Bookmark.swift
@@ -15,15 +15,6 @@
 import Foundation
 import SdrCoreKit
 
-// `DemodMode` / `Deemphasis` are `Int32`-raw-value enums defined
-// in SdrCoreKit. Swift synthesizes `Codable` automatically for
-// `RawRepresentable` enums once conformance is declared — we
-// just need the retroactive conformance for Codable-nested
-// bookmark fields to work. Nothing stored in the JSON except
-// the raw integer.
-extension DemodMode: Codable {}
-extension Deemphasis: Codable {}
-
 struct Bookmark: Codable, Identifiable, Hashable {
     /// Stable identity for SwiftUI list diffing; randomly
     /// assigned at creation, persisted across runs.

--- a/apps/macos/SDRMac/Models/BookmarksStore.swift
+++ b/apps/macos/SDRMac/Models/BookmarksStore.swift
@@ -1,0 +1,108 @@
+//
+// BookmarksStore.swift — observable store for the sidebar
+// bookmarks list. Persists to a standalone JSON file in the
+// app support directory (not round-tripped through sdr-config's
+// main config; matches the GTK side's file split).
+//
+// File path: ~/Library/Application Support/SDRMac/bookmarks.json
+//
+// Storage is pull / push in one: `load()` at bootstrap, `save()`
+// after every mutation. JSON is small (≤ a few KB for typical
+// ham-radio bookmark counts) so there's no need for an async
+// diff / incremental save pattern.
+
+import Foundation
+import Observation
+import OSLog
+// `Array.move(fromOffsets:toOffset:)` lives in SwiftUI — it's
+// the helper SwiftUI's `onMove` reorder action expects.
+import SwiftUI
+
+private let bookmarksLog = Logger(subsystem: "com.sdr.rs", category: "bookmarks")
+
+@MainActor
+@Observable
+final class BookmarksStore {
+    /// User's saved bookmarks, ordered by the user's arrangement.
+    /// Mutations persist to disk via `save()` after the in-memory
+    /// list is updated.
+    private(set) var bookmarks: [Bookmark] = []
+
+    /// File path under Application Support. Resolved lazily so a
+    /// test harness can override; production uses
+    /// `SDRMacApp.defaultBookmarksPath()`.
+    private let storagePath: URL
+
+    init(storagePath: URL) {
+        self.storagePath = storagePath
+        load()
+    }
+
+    // ----------------------------------------------------------
+    //  Mutations — each one saves to disk
+    // ----------------------------------------------------------
+
+    func add(_ bookmark: Bookmark) {
+        bookmarks.append(bookmark)
+        save()
+    }
+
+    func remove(id: UUID) {
+        bookmarks.removeAll { $0.id == id }
+        save()
+    }
+
+    func update(_ bookmark: Bookmark) {
+        guard let i = bookmarks.firstIndex(where: { $0.id == bookmark.id }) else { return }
+        var updated = bookmark
+        updated.updatedAt = Date()
+        bookmarks[i] = updated
+        save()
+    }
+
+    func move(fromOffsets source: IndexSet, toOffset destination: Int) {
+        bookmarks.move(fromOffsets: source, toOffset: destination)
+        save()
+    }
+
+    // ----------------------------------------------------------
+    //  Disk I/O
+    // ----------------------------------------------------------
+
+    private func load() {
+        guard FileManager.default.fileExists(atPath: storagePath.path) else {
+            // First launch — start empty, no error.
+            return
+        }
+        do {
+            let data = try Data(contentsOf: storagePath)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            bookmarks = try decoder.decode([Bookmark].self, from: data)
+        } catch {
+            // Persist failure — don't crash the app; log and
+            // start empty. A future launch with a hand-fixed
+            // file takes precedence.
+            bookmarksLog.error("Failed to load bookmarks: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func save() {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(bookmarks)
+            // Ensure the parent directory exists; app support
+            // subfolder is created at app-init but be safe if
+            // someone hand-deletes it.
+            try FileManager.default.createDirectory(
+                at: storagePath.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: storagePath, options: .atomic)
+        } catch {
+            bookmarksLog.error("Failed to save bookmarks: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/apps/macos/SDRMac/Models/BookmarksStore.swift
+++ b/apps/macos/SDRMac/Models/BookmarksStore.swift
@@ -83,7 +83,11 @@ final class BookmarksStore {
             // Persist failure — don't crash the app; log and
             // start empty. A future launch with a hand-fixed
             // file takes precedence.
-            bookmarksLog.error("Failed to load bookmarks: \(error.localizedDescription, privacy: .public)")
+            // `localizedDescription` can include the absolute file
+            // path (e.g. `/Users/<name>/Library/...`). Leave the
+            // default `.private` privacy so the path doesn't leak
+            // to unified logs.
+            bookmarksLog.error("Failed to load bookmarks: \(error.localizedDescription)")
         }
     }
 
@@ -102,7 +106,7 @@ final class BookmarksStore {
             )
             try data.write(to: storagePath, options: .atomic)
         } catch {
-            bookmarksLog.error("Failed to save bookmarks: \(error.localizedDescription, privacy: .public)")
+            bookmarksLog.error("Failed to save bookmarks: \(error.localizedDescription)")
         }
     }
 }

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -193,6 +193,13 @@ final class CoreModel {
 
     var signalLevelDb: Float = -120
 
+    /// Auto-squelch tracks the noise floor in the DSP and
+    /// self-adjusts the threshold. This is an engine-side
+    /// feature (`sdr-radio::IfChain::set_auto_squelch_enabled`);
+    /// the UI just toggles it. Only meaningful when
+    /// `squelchEnabled` is also on.
+    var autoSquelchEnabled: Bool = false
+
     // ==========================================================
     //  Bootstrap / shutdown
     // ==========================================================
@@ -423,6 +430,7 @@ final class CoreModel {
         setBandwidth(bandwidthHz)
         setSquelchEnabled(squelchEnabled)
         setSquelchDb(squelchDb)
+        setAutoSquelch(autoSquelchEnabled)
         setDeemphasis(deemphasis)
         setVolume(volume)
         setFftSize(fftSize)
@@ -590,6 +598,11 @@ final class CoreModel {
     func setSquelchEnabled(_ on: Bool) {
         squelchEnabled = on
         capture { try core?.setSquelchEnabled(on) }
+    }
+
+    func setAutoSquelch(_ on: Bool) {
+        autoSquelchEnabled = on
+        capture { try core?.setAutoSquelch(on) }
     }
 
     func setDeemphasis(_ m: Deemphasis) {

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -418,6 +418,48 @@ final class CoreModel {
     /// command is a no-op if the value already matches. Errors
     /// land in `lastError` via the individual setters' `capture`
     /// helper.
+    /// Snapshot the current tuning state as a Bookmark. The
+    /// user-visible name defaults to the current center
+    /// frequency; callers can override. Only the fields the user
+    /// would reasonably want to recall are captured; FFT / PPM /
+    /// volume are intentionally NOT part of a bookmark — those
+    /// feel more like environmental settings than per-station
+    /// preferences.
+    func snapshotBookmark(name: String? = nil) -> Bookmark {
+        Bookmark(
+            name: name ?? formatRate(centerFrequencyHz),
+            centerFrequencyHz: centerFrequencyHz,
+            demodMode: demodMode,
+            bandwidthHz: bandwidthHz,
+            squelchEnabled: squelchEnabled,
+            autoSquelchEnabled: autoSquelchEnabled,
+            squelchDb: squelchDb,
+            gainDb: gainDb,
+            agcEnabled: agcEnabled,
+            volume: nil,       // feels more like env setting than per-bookmark
+            deemphasis: deemphasis
+        )
+    }
+
+    /// Apply a saved Bookmark. Each field that's non-nil goes
+    /// through the matching setter (so the engine sees the same
+    /// command stream a user tapping the UI would send). Fields
+    /// left nil are untouched — e.g. a "600 MHz memory channel"
+    /// bookmark saved without a squelch setting won't unintentionally
+    /// flip the user's current squelch state.
+    func apply(_ bookmark: Bookmark) {
+        if let hz = bookmark.centerFrequencyHz { setCenter(hz) }
+        if let m = bookmark.demodMode          { setDemodMode(m) }
+        if let bw = bookmark.bandwidthHz       { setBandwidth(bw) }
+        if let on = bookmark.squelchEnabled    { setSquelchEnabled(on) }
+        if let db = bookmark.squelchDb         { setSquelchDb(db) }
+        if let auto = bookmark.autoSquelchEnabled { setAutoSquelch(auto) }
+        if let g = bookmark.gainDb             { setGain(g) }
+        if let agc = bookmark.agcEnabled       { setAgc(agc) }
+        if let v = bookmark.volume             { setVolume(v) }
+        if let d = bookmark.deemphasis         { setDeemphasis(d) }
+    }
+
     func syncToEngine() {
         guard core != nil else { return }
         setCenter(centerFrequencyHz)

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -176,6 +176,9 @@ final class CoreModel {
     var fftSize: Int = 2048
     var fftWindow: FftWindow = .blackman
     var fftRateFps: Double = 20
+    /// Spectrum averaging mode. Display-only — applied in the
+    /// Swift renderer before blit; the engine is unaware.
+    var averagingMode: AveragingMode = .none
     // Default dB range matches the GTK UI (see
     // `crates/sdr-ui/src/spectrum/mod.rs:58`). -70 dB floor
     // hides the ADC noise floor so the waterfall background is

--- a/apps/macos/SDRMac/Renderer/MetalSpectrumNSView.swift
+++ b/apps/macos/SDRMac/Renderer/MetalSpectrumNSView.swift
@@ -267,6 +267,13 @@ final class MetalSpectrumNSView: NSView, CAMetalDisplayLinkDelegate {
         renderer.applyBindings(minDb: minDb, maxDb: maxDb)
     }
 
+    /// Push the current display-side averaging mode down to the
+    /// renderer. Called from `updateNSView` when CoreModel's
+    /// `averagingMode` changes.
+    func applyAveraging(mode: AveragingMode) {
+        renderer.applyAveraging(mode: mode)
+    }
+
     /// Forward the current zoom window to the renderer so the
     /// Metal shader remaps bin-index / viewport-uv accordingly.
     /// Called from `updateNSView` whenever CoreModel's zoom

--- a/apps/macos/SDRMac/Renderer/SpectrumRenderer.swift
+++ b/apps/macos/SDRMac/Renderer/SpectrumRenderer.swift
@@ -305,6 +305,23 @@ final class SpectrumRenderer {
         if maxDb.isFinite { uniforms.maxDb = max(minDb + 1.0, maxDb) }
     }
 
+    /// Display-side spectrum averaging. None = raw pass-through
+    /// (default). PeakHold / MinHold / RunningAvg accumulate
+    /// across frames in `averagingBuffer`. Mode changes reseed
+    /// the buffer from the next frame to avoid one-frame
+    /// artifacts (e.g. leftover max values polluting a new
+    /// `.runningAvg` run). Matches GTK averaging semantics in
+    /// `crates/sdr-ui/src/spectrum/mod.rs`.
+    func applyAveraging(mode: AveragingMode) {
+        if averagingMode != mode {
+            averagingMode = mode
+            averagingBuffer.removeAll(keepingCapacity: true)
+        }
+    }
+
+    private var averagingMode: AveragingMode = .none
+    private var averagingBuffer: [Float] = []
+
     /// Update the zoom window. `displayedCenterOffsetHz` is the
     /// viewport center in offset-from-tuner Hz; `displayedSpanHz`
     /// is the visible span; `displayBandwidthHz` is the full FFT
@@ -385,8 +402,44 @@ final class SpectrumRenderer {
             newFrameBinCount = count
             let rowBytes = count * MemoryLayout<Float>.stride
             guard let src = buf.baseAddress else { return }
-            memcpy(spectrumVertexBuffer.contents(), src, rowBytes)
-            memcpy(historyStagingBuffer.contents(), src, rowBytes)
+
+            // Apply display-side averaging. Re-seed the buffer
+            // when its size doesn't match the current frame
+            // (size change OR first frame after mode switch, via
+            // `applyAveraging`). After seeding, fold each bin
+            // through the active mode. `.none` skips the
+            // accumulator entirely for minimum overhead.
+            if averagingMode != .none {
+                if averagingBuffer.count != count {
+                    averagingBuffer = Array(UnsafeBufferPointer(start: src, count: count))
+                } else {
+                    averagingBuffer.withUnsafeMutableBufferPointer { acc in
+                        guard let accPtr = acc.baseAddress else { return }
+                        switch averagingMode {
+                        case .peakHold:
+                            for i in 0..<count { accPtr[i] = max(accPtr[i], src[i]) }
+                        case .minHold:
+                            for i in 0..<count { accPtr[i] = min(accPtr[i], src[i]) }
+                        case .runningAvg:
+                            let a = averagingAlpha
+                            for i in 0..<count {
+                                accPtr[i] = a * src[i] + (1 - a) * accPtr[i]
+                            }
+                        case .none:
+                            break  // unreachable — guarded above
+                        }
+                    }
+                }
+                // Write the averaged values into both buffers.
+                averagingBuffer.withUnsafeBufferPointer { buf in
+                    guard let p = buf.baseAddress else { return }
+                    memcpy(spectrumVertexBuffer.contents(), p, rowBytes)
+                    memcpy(historyStagingBuffer.contents(), p, rowBytes)
+                }
+            } else {
+                memcpy(spectrumVertexBuffer.contents(), src, rowBytes)
+                memcpy(historyStagingBuffer.contents(), src, rowBytes)
+            }
         } ?? false
 
         // Ensure the history ring exists. Its width tracks the

--- a/apps/macos/SDRMac/Renderer/SpectrumWaterfallView.swift
+++ b/apps/macos/SDRMac/Renderer/SpectrumWaterfallView.swift
@@ -58,6 +58,7 @@ struct SpectrumWaterfallView: NSViewRepresentable {
             displayedSpanHz: model.effectiveDisplayedSpanHz,
             displayBandwidthHz: model.displayBandwidthHz
         )
+        mtk.applyAveraging(mode: model.averagingMode)
     }
 
     private func makeFallbackView() -> NSView {

--- a/apps/macos/SDRMac/SDRMacApp.swift
+++ b/apps/macos/SDRMac/SDRMacApp.swift
@@ -17,6 +17,7 @@ import SwiftUI
 @main
 struct SDRMacApp: App {
     @State private var core = CoreModel()
+    @State private var bookmarks = BookmarksStore(storagePath: SDRMacApp.defaultBookmarksPath())
 
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
@@ -24,6 +25,7 @@ struct SDRMacApp: App {
         WindowGroup("SDR") {
             ContentView()
                 .environment(core)
+                .environment(bookmarks)
                 .frame(minWidth: 900, minHeight: 600)
                 .task {
                     await core.bootstrap(configPath: Self.defaultConfigPath())
@@ -46,6 +48,19 @@ struct SDRMacApp: App {
     /// a bundle-id or layout change would otherwise make the
     /// displayed path drift from the real one.
     static func defaultConfigPath() -> URL {
+        appSupportDirectory().appendingPathComponent("config.json")
+    }
+
+    /// `~/Library/Application Support/SDRMac/bookmarks.json`.
+    /// Separate file from the engine's `config.json` so bookmark
+    /// mutations don't round-trip through the engine and so
+    /// bookmarks can survive a config schema change. Matches the
+    /// GTK side's file split.
+    static func defaultBookmarksPath() -> URL {
+        appSupportDirectory().appendingPathComponent("bookmarks.json")
+    }
+
+    private static func appSupportDirectory() -> URL {
         let fm = FileManager.default
         let dir = (try? fm.url(
             for: .applicationSupportDirectory,
@@ -55,7 +70,7 @@ struct SDRMacApp: App {
         )) ?? fm.homeDirectoryForCurrentUser
         let appDir = dir.appendingPathComponent("SDRMac")
         try? fm.createDirectory(at: appDir, withIntermediateDirectories: true)
-        return appDir.appendingPathComponent("config.json")
+        return appDir
     }
 }
 

--- a/apps/macos/SDRMac/Views/BookmarksSection.swift
+++ b/apps/macos/SDRMac/Views/BookmarksSection.swift
@@ -1,0 +1,155 @@
+//
+// BookmarksSection.swift — sidebar panel listing saved
+// tuning profiles (#240).
+//
+// Simple CRUD on top of `BookmarksStore`:
+// - "Add current" snapshots the model's tuning state.
+// - Tapping a row applies that bookmark to the model.
+// - Context menu / swipe offers delete.
+// - Drag-to-reorder via SwiftUI's native `onMove` support.
+//
+// v1 intentionally excludes editing an existing bookmark's
+// tuning fields in place — users can delete + re-save. An
+// "Edit" sheet could come as a follow-up if users want name /
+// field edits without re-tuning.
+
+import SwiftUI
+// `DemodMode.label` lives in SdrCoreKit — the enum is re-used
+// by SwiftUI-side Bookmark rendering.
+import SdrCoreKit
+
+struct BookmarksSection: View {
+    @Environment(CoreModel.self) private var model
+    @Environment(BookmarksStore.self) private var store
+
+    @State private var showingAddSheet = false
+
+    var body: some View {
+        Section("Bookmarks") {
+            if store.bookmarks.isEmpty {
+                Text("No saved frequencies")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            } else {
+                ForEach(store.bookmarks) { bm in
+                    BookmarkRow(bookmark: bm)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            model.apply(bm)
+                        }
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                store.remove(id: bm.id)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                }
+                .onMove { source, destination in
+                    store.move(fromOffsets: source, toOffset: destination)
+                }
+            }
+
+            Button {
+                showingAddSheet = true
+            } label: {
+                Label("Save current", systemImage: "plus.circle")
+            }
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            AddBookmarkSheet { name in
+                let bm = model.snapshotBookmark(name: name)
+                store.add(bm)
+            }
+        }
+    }
+}
+
+// ============================================================
+//  BookmarkRow
+// ============================================================
+
+private struct BookmarkRow: View {
+    let bookmark: Bookmark
+
+    var body: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(bookmark.name)
+                    .lineLimit(1)
+                if let hz = bookmark.centerFrequencyHz {
+                    HStack(spacing: 6) {
+                        Text(formatRate(hz))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if let mode = bookmark.demodMode {
+                            Text(mode.label)
+                                .font(.caption2)
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 1)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 3)
+                                        .fill(Color.secondary.opacity(0.15))
+                                )
+                        }
+                    }
+                }
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// ============================================================
+//  AddBookmarkSheet
+// ============================================================
+//
+//  Tiny modal: just a name field pre-filled with the current
+//  formatted frequency. Submit saves; Cancel dismisses. Full
+//  editable-profile form is a v2 polish item.
+
+private struct AddBookmarkSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(CoreModel.self) private var model
+
+    let onSave: (String) -> Void
+
+    @State private var name: String = ""
+    @FocusState private var nameFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Save bookmark")
+                .font(.headline)
+
+            TextField("Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+                .focused($nameFocused)
+                .onSubmit(submit)
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save", action: submit)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 340)
+        .onAppear {
+            // Default name: current formatted frequency.
+            name = formatRate(model.centerFrequencyHz)
+            nameFocused = true
+        }
+    }
+
+    private func submit() {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        onSave(trimmed)
+        dismiss()
+    }
+}

--- a/apps/macos/SDRMac/Views/BookmarksSection.swift
+++ b/apps/macos/SDRMac/Views/BookmarksSection.swift
@@ -32,18 +32,25 @@ struct BookmarksSection: View {
                     .font(.caption)
             } else {
                 ForEach(store.bookmarks) { bm in
-                    BookmarkRow(bookmark: bm)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            model.apply(bm)
+                    // Button (rather than `onTapGesture`) so
+                    // keyboard / VoiceOver / switch-control
+                    // activation works the same as a mouse
+                    // click. `.plain` keeps the row from picking
+                    // up button chrome.
+                    Button {
+                        model.apply(bm)
+                    } label: {
+                        BookmarkRow(bookmark: bm)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .contextMenu {
+                        Button(role: .destructive) {
+                            store.remove(id: bm.id)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
                         }
-                        .contextMenu {
-                            Button(role: .destructive) {
-                                store.remove(id: bm.id)
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
-                        }
+                    }
                 }
                 .onMove { source, destination in
                     store.move(fromOffsets: source, toOffset: destination)
@@ -134,7 +141,7 @@ private struct AddBookmarkSheet: View {
                     .keyboardShortcut(.cancelAction)
                 Button("Save", action: submit)
                     .keyboardShortcut(.defaultAction)
-                    .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
         .padding(20)
@@ -147,7 +154,7 @@ private struct AddBookmarkSheet: View {
     }
 
     private func submit() {
-        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         onSave(trimmed)
         dismiss()

--- a/apps/macos/SDRMac/Views/DisplaySection.swift
+++ b/apps/macos/SDRMac/Views/DisplaySection.swift
@@ -29,6 +29,37 @@ struct DisplaySection: View {
                 }
             }
 
+            // Display-side averaging — pure Swift renderer work,
+            // no engine round-trip. Switching modes reseeds the
+            // averaging buffer so there's no one-frame artifact.
+            Picker("Averaging", selection: Binding(
+                get: { model.averagingMode },
+                set: { model.averagingMode = $0 }
+            )) {
+                ForEach(AveragingMode.allCases, id: \.self) {
+                    Text($0.label).tag($0)
+                }
+            }
+
+            LabeledContent("FFT Rate") {
+                VStack(spacing: 2) {
+                    @Bindable var m = model
+                    Slider(
+                        value: $m.fftRateFps,
+                        in: 5...60,
+                        step: 1,
+                        onEditingChanged: { editing in
+                            if !editing {
+                                model.setFftRate(model.fftRateFps)
+                            }
+                        }
+                    )
+                    Text("\(Int(model.fftRateFps)) fps")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             LabeledContent("Min dB") {
                 VStack(spacing: 2) {
                     @Bindable var m = model

--- a/apps/macos/SDRMac/Views/RadioSection.swift
+++ b/apps/macos/SDRMac/Views/RadioSection.swift
@@ -29,6 +29,15 @@ struct RadioSection: View {
             ))
 
             if model.squelchEnabled {
+                // Auto-squelch tracks the noise floor and writes
+                // the threshold. Only visible alongside the main
+                // squelch toggle — the feature has no meaning
+                // when squelch itself is off.
+                Toggle("Auto", isOn: Binding(
+                    get: { model.autoSquelchEnabled },
+                    set: { model.setAutoSquelch($0) }
+                ))
+
                 LabeledContent("Threshold") {
                     VStack(spacing: 2) {
                         @Bindable var m = model
@@ -49,9 +58,19 @@ struct RadioSection: View {
                                 }
                             }
                         )
-                        Text("\(Int(model.squelchDb)) dB")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        // Slider is disabled while auto-squelch
+                        // owns the threshold — letting the user
+                        // drag against a value that re-sets at
+                        // ~50 Hz is confusing UX. The label still
+                        // shows the live auto-picked value.
+                        .disabled(model.autoSquelchEnabled)
+                        Text(
+                            model.autoSquelchEnabled
+                                ? "Auto: \(Int(model.squelchDb)) dB"
+                                : "\(Int(model.squelchDb)) dB"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                 }
             }

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -516,6 +516,28 @@ mod tests {
             unsafe { sdr_core_set_demod_mode(std::ptr::null_mut(), SDR_DEMOD_NFM) },
             SdrCoreError::InvalidHandle.as_int()
         );
+        assert_eq!(
+            unsafe { sdr_core_set_auto_squelch(std::ptr::null_mut(), true) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+    }
+
+    // ------------------------------------------------------
+    //  Squelch — auto-squelch toggle (ABI 0.3)
+    // ------------------------------------------------------
+
+    #[test]
+    fn set_auto_squelch_round_trip() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_auto_squelch(h, true) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_auto_squelch(h, false) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
     }
 
     // ------------------------------------------------------

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -326,6 +326,15 @@ pub unsafe extern "C" fn sdr_core_set_squelch_enabled(handle: *mut SdrCore, enab
     }
 }
 
+/// Enable or disable auto-squelch (noise-floor tracking).
+/// The engine self-adjusts the squelch threshold while this is
+/// on; manual `sdr_core_set_squelch_db` calls are still accepted
+/// but will be overwritten by the tracker on the next update.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_auto_squelch(handle: *mut SdrCore, enabled: bool) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::SetAutoSquelch(enabled))) }
+}
+
 /// Set the squelch threshold in dB. Value must be finite.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_set_squelch_db(handle: *mut SdrCore, db: f32) -> i32 {

--- a/crates/sdr-ffi/src/lib.rs
+++ b/crates/sdr-ffi/src/lib.rs
@@ -53,12 +53,12 @@ pub mod lifecycle;
 // the rlib (in-tree integration tests) can reference them via
 // `sdr_ffi::sdr_core_*`.
 pub use command::{
-    sdr_core_set_agc, sdr_core_set_bandwidth, sdr_core_set_dc_blocking, sdr_core_set_decimation,
-    sdr_core_set_deemphasis, sdr_core_set_demod_mode, sdr_core_set_fft_rate, sdr_core_set_fft_size,
-    sdr_core_set_fft_window, sdr_core_set_gain, sdr_core_set_iq_correction,
-    sdr_core_set_iq_inversion, sdr_core_set_ppm_correction, sdr_core_set_sample_rate,
-    sdr_core_set_squelch_db, sdr_core_set_squelch_enabled, sdr_core_set_vfo_offset,
-    sdr_core_set_volume, sdr_core_start, sdr_core_stop, sdr_core_tune,
+    sdr_core_set_agc, sdr_core_set_auto_squelch, sdr_core_set_bandwidth, sdr_core_set_dc_blocking,
+    sdr_core_set_decimation, sdr_core_set_deemphasis, sdr_core_set_demod_mode,
+    sdr_core_set_fft_rate, sdr_core_set_fft_size, sdr_core_set_fft_window, sdr_core_set_gain,
+    sdr_core_set_iq_correction, sdr_core_set_iq_inversion, sdr_core_set_ppm_correction,
+    sdr_core_set_sample_rate, sdr_core_set_squelch_db, sdr_core_set_squelch_enabled,
+    sdr_core_set_vfo_offset, sdr_core_set_volume, sdr_core_start, sdr_core_stop, sdr_core_tune,
 };
 pub use enumerate::{sdr_core_device_count, sdr_core_device_name};
 pub use error::sdr_core_last_error_message;

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 2;
+pub const ABI_VERSION_MINOR: u32 = 3;
 
 /// Return the ABI version the library was built with.
 ///
@@ -326,7 +326,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 2);
+        assert!(ABI_VERSION_MINOR == 3);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 2
+#define SDR_CORE_ABI_VERSION_MINOR 3
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -307,6 +307,16 @@ int32_t sdr_core_set_demod_mode(SdrCore* handle, int32_t mode);
 int32_t sdr_core_set_bandwidth(SdrCore* handle, double bw_hz);
 int32_t sdr_core_set_squelch_enabled(SdrCore* handle, bool enabled);
 int32_t sdr_core_set_squelch_db(SdrCore* handle, float db);
+
+/*
+ * Enable or disable auto-squelch (engine-side noise-floor
+ * tracking). Complements `sdr_core_set_squelch_enabled` — while
+ * auto-squelch is on, the engine continuously adjusts the
+ * squelch threshold to sit above the measured noise floor.
+ * Manual `sdr_core_set_squelch_db` writes are accepted but the
+ * tracker will overwrite them on its next cycle.
+ */
+int32_t sdr_core_set_auto_squelch(SdrCore* handle, bool enabled);
 
 typedef enum SdrDeemphasis {
     SDR_DEEMPH_NONE = 0,


### PR DESCRIPTION
## Summary

First wave of the v2 SwiftUI UI build-out. Three focused commits delivering visible value without introducing new engine surface beyond one additive FFI for auto-squelch.

- **#244** — spectrum averaging modes + FFT-rate slider
- **#243** — auto-squelch toggle wired to the engine's existing noise-floor tracker
- **#240** — bookmarks sidebar panel with saved tuning profiles

## Commits

- \`559f703\` **feat(macos): spectrum averaging modes + FFT-rate slider (#244)** — display-side PeakHold / RunningAvg / MinHold + "None" averaging, same α = 0.3 constant as GTK. FFT-rate slider exposes the existing \`setFftRate\` setter. No engine changes.
- \`e08e7d3\` **feat(macos): auto-squelch toggle wired to engine (#243)** — new \`sdr_core_set_auto_squelch\` FFI (additive, ABI 0.2 → 0.3) forwarding \`UiToDsp::SetAutoSquelch\` to the engine's existing \`IfChain::set_auto_squelch_enabled\`. \`syncToEngine\` updated. RadioSection shows the toggle only when squelch is on; threshold slider is disabled while auto-squelch owns it.
- \`34f9abf\` **feat(macos): bookmarks sidebar panel (#240)** — pure Swift-side feature. \`Bookmark\` Codable struct with optional tuning fields, \`BookmarksStore\` @Observable persisting to \`~/Library/Application Support/SDRMac/bookmarks.json\`. Snapshot / apply through existing CoreModel setters. BookmarksSection in the sidebar with save / tap-to-apply / context-delete / drag-reorder.

## Known engine-side bugs surfaced during testing (filed separately)

- **#331** — Squelch gate hard-mutes without attack/release ramp. Produces a loud pop on macOS (AUHAL's 48 → 44.1 kHz SRC rings at the step discontinuity); inaudible on Linux/PipeWire's direct 48 kHz path. Fix belongs in \`sdr-dsp::PowerSquelch\`.
- **#332** — FM demods lack AF-chain AGC, so tuner AGC overshoots cause audio distortion. AM demod already has AF AGC; NFM / WFM need the same treatment.
- **#333** — iCloud sync for bookmarks, filed from user feedback while testing this PR.

None of these block this PR — the UI controls all wire correctly; users just get a rough edge on one audio code path until the engine fixes land.

## Mac-side audit

Verified (via explore-agent) that all 17 \`CoreModel\` setters route cleanly to existing engine commands with no Swift-side reinvention. Only \`setCenter\` does any non-forwarding work (clamping to \`maxCenterFrequencyHz\` per earlier #327 review). Nothing else dup the engine's logic.

## Test plan

- [x] \`make lint\` green (fmt, clippy \`-D warnings\`, test, deny, audit, ffi-header-check).
- [x] \`make mac-test\` passes — 28 tests.
- [x] Smoke: averaging picker switches modes with no glitch; \"Peak Hold\" visibly accumulates; \"Min Hold\" inverts the visible floor.
- [x] Smoke: FFT-rate slider changes the waterfall scroll cadence.
- [x] Smoke: auto-squelch toggle forwards to the engine; threshold label prefixes "Auto:" and slider disables while on.
- [x] Smoke: save bookmark → tune away → tap bookmark → tuner returns to saved state.
- [x] Smoke: bookmarks persist across app launches.
- [x] Smoke: drag-reorder and delete work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-squelch toggle to let the engine track background noise automatically
  * Bookmarks: save/restore tuning profiles with save, delete, and drag-to-reorder UI; persisted to disk
  * Spectrum averaging: Peak Hold, Running Average, and Min Hold display modes with UI picker and renderer support
  * FFT rate control: adjustable spectrum update frequency

* **Chores**
  * Library ABI bumped to 0.3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->