### PR TITLE
feat(#323): rtl_tcp integration polish (exclusivity, status row, persistence, favorites)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -25,7 +25,7 @@ use sdr_pipeline::source_manager::Source;
 use sdr_radio::RadioModule;
 use sdr_sink_audio::AudioSink;
 use sdr_source_rtlsdr::RtlSdrSource;
-use sdr_types::{Complex, SinkError, Stereo};
+use sdr_types::{Complex, RtlTcpConnectionState, SinkError, Stereo};
 
 use crate::fft_buffer::SharedFftBuffer;
 use crate::messages::{DspToUi, SourceType, UiToDsp};
@@ -140,6 +140,11 @@ fn dsp_thread_main(
 
             // Read and process one IQ block.
             process_iq_block(&mut state, &dsp_tx, &fft_shared);
+            // Edge-emit rtl_tcp connection-state changes. Poll is
+            // time-throttled inside the helper so at ~106 Hz block
+            // cadence we only hit the source's state mutex twice a
+            // second.
+            poll_rtl_tcp_connection_state(&mut state, &dsp_tx);
         } else {
             // Pipeline stopped — block with timeout to avoid busy-waiting.
             match ui_rx.recv_timeout(Duration::from_millis(RECV_TIMEOUT_MS)) {
@@ -151,6 +156,45 @@ fn dsp_thread_main(
                 }
             }
         }
+    }
+}
+
+/// Poll cadence for the `rtl_tcp` connection-state check. 500 ms
+/// matches the UI-side stats poll on the server panel and is fast
+/// enough that "Connecting → Connected" transitions feel
+/// instantaneous while keeping the per-tick state-mutex lock off
+/// the IQ-block hot path.
+const RTL_TCP_STATE_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Poll the active source's projected `rtl_tcp_connection_state()`
+/// and emit `DspToUi::RtlTcpConnectionState` on edge (state changed
+/// since last emit). Throttled via `state.rtl_tcp_poll_at`.
+///
+/// Non-`RtlTcp` sources return `None` from the trait method — we
+/// map that to `Disconnected` so the UI can track the absence
+/// uniformly (source-type change → status row collapses without a
+/// separate teardown signal).
+fn poll_rtl_tcp_connection_state(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
+    let now = std::time::Instant::now();
+    if now < state.rtl_tcp_poll_at {
+        return;
+    }
+    state.rtl_tcp_poll_at = now + RTL_TCP_STATE_POLL_INTERVAL;
+
+    let current = state
+        .source
+        .as_ref()
+        .and_then(|s| s.rtl_tcp_connection_state())
+        .unwrap_or(RtlTcpConnectionState::Disconnected);
+
+    // `RtlTcpConnectionState` derives PartialEq; Retrying variants
+    // with a different `retry_in` compare unequal, so the poll
+    // emits twice a second during the backoff wait. That's what we
+    // want — the UI renders a live countdown without the status
+    // text going stale between attempt-counter bumps.
+    if state.last_rtl_tcp_state != current {
+        state.last_rtl_tcp_state = current.clone();
+        let _ = dsp_tx.send(DspToUi::RtlTcpConnectionState(current));
     }
 }
 
@@ -243,6 +287,22 @@ struct DspState {
     /// the user picks Syllabic or Snr and the fresh detector
     /// reports closed.
     voice_squelch_was_open: bool,
+
+    /// Last emitted `rtl_tcp` connection state. Edge-filters the
+    /// `DspToUi::RtlTcpConnectionState` emissions so we don't
+    /// flood the channel at poll cadence when the state is static
+    /// (Connected for a long session, Retrying between attempts,
+    /// etc.). Initialized to `Disconnected` — matches the initial
+    /// UI render and the state of a freshly-constructed
+    /// `RtlTcpSource` before its first `start()`.
+    last_rtl_tcp_state: RtlTcpConnectionState,
+    /// Next wall-clock deadline for polling the active source's
+    /// connection state. We poll at ~2 Hz (500 ms) rather than on
+    /// every IQ block because the underlying state is a
+    /// `Mutex<ConnectionState>` lock — cheap but not free, and the
+    /// UI cadence doesn't need sub-second resolution to render the
+    /// "Connecting… / Connected / Retrying in N s" text.
+    rtl_tcp_poll_at: std::time::Instant,
 }
 
 impl DspState {
@@ -299,6 +359,8 @@ impl DspState {
             audio_frames_written: 0,
             iq_samples_read: 0,
             diag_log_at: std::time::Instant::now(),
+            last_rtl_tcp_state: RtlTcpConnectionState::Disconnected,
+            rtl_tcp_poll_at: std::time::Instant::now(),
         })
     }
 }
@@ -755,6 +817,23 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 state.running = false;
             }
             state.source_type = source_type;
+            // Force the rtl_tcp status row to reset when switching
+            // away from RTL-TCP. Without this, a user mid-session
+            // who switches to a different source would see the
+            // stale "Connected — R820T" text linger until the next
+            // poll tick (which won't fire if running=false). Only
+            // emits on an actual edge.
+            if source_type != SourceType::RtlTcp
+                && !matches!(
+                    state.last_rtl_tcp_state,
+                    RtlTcpConnectionState::Disconnected
+                )
+            {
+                state.last_rtl_tcp_state = RtlTcpConnectionState::Disconnected;
+                let _ = dsp_tx.send(DspToUi::RtlTcpConnectionState(
+                    RtlTcpConnectionState::Disconnected,
+                ));
+            }
             // Restart with the new source type if was playing
             if was_running {
                 match open_source(state) {
@@ -878,6 +957,52 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             // always starts from a known state.
             state.squelch_was_open = false;
             tracing::info!("transcription audio tap disabled");
+        }
+        UiToDsp::DisconnectRtlTcp => {
+            // Only meaningful while `RtlTcp` is the active source
+            // type. For any other source we log-and-drop so
+            // misrouted commands from buggy UI paths don't panic.
+            if state.source_type != SourceType::RtlTcp {
+                tracing::debug!(
+                    active = ?state.source_type,
+                    "DisconnectRtlTcp ignored — active source is not RtlTcp"
+                );
+                return;
+            }
+            if let Some(source) = state.source.as_mut()
+                && let Err(e) = source.stop()
+            {
+                tracing::warn!(error = %e, "rtl_tcp source stop failed");
+                let _ = dsp_tx.send(DspToUi::Error(format!("Disconnect failed: {e}")));
+            }
+            // Drop the source outright so `rtl_tcp_connection_state`
+            // returns `None` (→ Disconnected) on the next poll,
+            // cascading into a UI row that reflects reality.
+            state.source = None;
+            state.running = false;
+            let _ = dsp_tx.send(DspToUi::SourceStopped);
+        }
+        UiToDsp::RetryRtlTcpNow => {
+            // Same source-type gate as Disconnect. "Retry now"
+            // implements as stop+start so the current backoff
+            // sleep is short-circuited; the existing start_manager
+            // path tears up a fresh connection from Connecting.
+            if state.source_type != SourceType::RtlTcp {
+                tracing::debug!(
+                    active = ?state.source_type,
+                    "RetryRtlTcpNow ignored — active source is not RtlTcp"
+                );
+                return;
+            }
+            if let Some(source) = state.source.as_mut() {
+                if let Err(e) = source.stop() {
+                    tracing::warn!(error = %e, "rtl_tcp stop before retry failed");
+                }
+                if let Err(e) = source.start() {
+                    tracing::warn!(error = %e, "rtl_tcp restart failed");
+                    let _ = dsp_tx.send(DspToUi::Error(format!("Retry failed: {e}")));
+                }
+            }
         }
     }
 }

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -250,6 +250,53 @@ mod tests {
     }
 
     #[test]
+    fn rtl_tcp_connection_state_message_constructs() {
+        // Constructing each variant through the DspToUi wrapper
+        // exercises the `#[derive(Debug)]` + message plumbing end
+        // to end. Catches the class of bugs where a future refactor
+        // changes the `RtlTcpConnectionState` shape without updating
+        // the message-side re-export — the build would still pass
+        // but the variant wouldn't wrap.
+        let disc = DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Disconnected);
+        assert!(matches!(
+            disc,
+            DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Disconnected)
+        ));
+
+        let connecting = DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Connecting);
+        assert!(matches!(
+            connecting,
+            DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Connecting)
+        ));
+
+        let connected = DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Connected {
+            tuner_name: "R820T".into(),
+            gain_count: 29,
+        });
+        assert!(matches!(
+            connected,
+            DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Connected { gain_count: 29, .. })
+        ));
+
+        let retrying = DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Retrying {
+            attempt: 3,
+            retry_in: std::time::Duration::from_secs(5),
+        });
+        assert!(matches!(
+            retrying,
+            DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Retrying { attempt: 3, .. })
+        ));
+
+        let failed = DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Failed {
+            reason: "bad handshake".into(),
+        });
+        assert!(matches!(
+            failed,
+            DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Failed { .. })
+        ));
+    }
+
+    #[test]
     #[allow(clippy::too_many_lines)]
     fn test_ui_to_dsp_variants() {
         let start = UiToDsp::Start;
@@ -438,6 +485,15 @@ mod tests {
 
         let disable = UiToDsp::DisableTranscription;
         assert!(matches!(disable, UiToDsp::DisableTranscription));
+
+        // RTL-TCP connection controls (commit 3 of PR #335) —
+        // constructed directly so a future signature change (e.g.
+        // adding an instance-selector param) fails this test
+        // rather than silently going quiet at the UI-handler site.
+        let disc = UiToDsp::DisconnectRtlTcp;
+        assert!(matches!(disc, UiToDsp::DisconnectRtlTcp));
+        let retry = UiToDsp::RetryRtlTcpNow;
+        assert!(matches!(retry, UiToDsp::RetryRtlTcpNow));
     }
 
     #[test]

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -2,7 +2,7 @@
 
 use sdr_dsp::voice_squelch::VoiceSquelchMode;
 use sdr_radio::{DeemphasisMode, af_chain::CtcssMode};
-use sdr_types::DemodMode;
+use sdr_types::{DemodMode, RtlTcpConnectionState};
 
 /// Messages sent from the DSP pipeline thread to the UI main loop.
 #[derive(Debug)]
@@ -51,6 +51,16 @@ pub enum DspToUi {
     /// mode-entry that the controller handles by resetting the
     /// tracker).
     VoiceSquelchOpenChanged(bool),
+    /// Connection-lifecycle state for the currently active
+    /// `rtl_tcp` client source. Emitted only on **edge** — when
+    /// the projected `RtlTcpConnectionState` differs from the
+    /// previous snapshot — so the UI can subscribe without
+    /// flooding the channel at the poll cadence. Controller also
+    /// emits `Disconnected` when the active source type is not
+    /// `RtlTcp`, so the UI status row can rely on receiving that
+    /// value to reset on source-type changes without needing a
+    /// separate "hide the row" signal.
+    RtlTcpConnectionState(RtlTcpConnectionState),
 }
 
 /// Available source types for IQ input.
@@ -164,6 +174,18 @@ pub enum UiToDsp {
     EnableTranscription(std::sync::mpsc::SyncSender<sdr_transcription::TranscriptionInput>),
     /// Stop sending audio to the transcription engine.
     DisableTranscription,
+    /// Stop the `rtl_tcp` client connection without changing the
+    /// selected source type. Sends `source.stop()` so the manager
+    /// thread tears down and the connection state transitions to
+    /// `Disconnected`. User can reconnect via the Play button or
+    /// `RetryRtlTcpNow`.
+    DisconnectRtlTcp,
+    /// Force an immediate reconnect of the active `rtl_tcp` client
+    /// by stopping and restarting the source. Useful when the
+    /// server just came back online and the user doesn't want to
+    /// wait for the current exponential-backoff delay to expire.
+    /// No-op when the active source is not `RtlTcp`.
+    RetryRtlTcpNow,
 }
 
 #[cfg(test)]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -301,7 +301,8 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         | DspToUi::IqRecordingStopped
         | DspToUi::DemodModeChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
-        | DspToUi::VoiceSquelchOpenChanged(_) => return None,
+        | DspToUi::VoiceSquelchOpenChanged(_)
+        | DspToUi::RtlTcpConnectionState(_) => return None,
     };
 
     Some((event, owned_cstring, owned_vec))

--- a/crates/sdr-pipeline/src/source_manager.rs
+++ b/crates/sdr-pipeline/src/source_manager.rs
@@ -53,6 +53,18 @@ pub trait Source: Send {
     fn set_ppm_correction(&mut self, _ppm: i32) -> Result<(), SourceError> {
         Ok(())
     }
+
+    /// UI-facing connection state for `rtl_tcp` clients. Only the
+    /// network `RtlTcpSource` implements this meaningfully — every
+    /// other source returns `None`. Lets the UI poll the active
+    /// source without downcasting to the concrete type.
+    ///
+    /// Returns a projected form (`Instant`-free) so the type can
+    /// live in `sdr-types` without pulling in scheduling primitives
+    /// that don't cross crate boundaries cleanly.
+    fn rtl_tcp_connection_state(&self) -> Option<sdr_types::RtlTcpConnectionState> {
+        None
+    }
 }
 
 /// Manages available IQ sources and the active source lifecycle.

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -115,7 +115,13 @@ impl From<DongleInfo> for TunerInfo {
     }
 }
 
-/// Connection lifecycle state for UI consumption.
+/// Connection lifecycle state — internal representation with an
+/// `Instant`-based retry deadline suited to the scheduling loop.
+///
+/// UI consumers receive a projected form without `Instant`s (which
+/// don't cross crate boundaries cleanly) via `connection_state()`
+/// — see the `From<&ConnectionState> for sdr_types::RtlTcpConnectionState`
+/// impl below.
 #[derive(Debug, Clone)]
 pub enum ConnectionState {
     /// Initial state before first `start()` call.
@@ -133,6 +139,35 @@ pub enum ConnectionState {
     /// (e.g., server sent a non-RTL0 header). Transport failures
     /// never reach this state; they remain in `Retrying`.
     Failed { reason: String },
+}
+
+impl From<&ConnectionState> for sdr_types::RtlTcpConnectionState {
+    fn from(value: &ConnectionState) -> Self {
+        match value {
+            ConnectionState::Disconnected => Self::Disconnected,
+            ConnectionState::Connecting => Self::Connecting,
+            ConnectionState::Connected { tuner } => Self::Connected {
+                // `TunerTypeCode`'s `Debug` renders the upstream
+                // tuner name ("R820T", "E4000", etc.) directly —
+                // what the UI wants for the status row subtitle.
+                tuner_name: format!("{:?}", tuner.tuner),
+                gain_count: tuner.gain_count,
+            },
+            ConnectionState::Retrying { attempt, next_at } => Self::Retrying {
+                attempt: *attempt,
+                // Saturating: if the scheduling thread has drifted
+                // past the deadline (which just means the next
+                // attempt is imminent), we render "0 s" rather
+                // than underflow.
+                retry_in: next_at
+                    .checked_duration_since(Instant::now())
+                    .unwrap_or(Duration::ZERO),
+            },
+            ConnectionState::Failed { reason } => Self::Failed {
+                reason: reason.clone(),
+            },
+        }
+    }
 }
 
 /// Tunable knobs for the connection manager. All fields have sensible
@@ -1082,6 +1117,17 @@ impl Source for RtlTcpSource {
 
     fn set_ppm_correction(&mut self, ppm: i32) -> Result<(), SourceError> {
         self.set_freq_correction_ppm(ppm)
+    }
+
+    fn rtl_tcp_connection_state(&self) -> Option<sdr_types::RtlTcpConnectionState> {
+        // Project the internal `ConnectionState` (which carries an
+        // `Instant` for retry scheduling) into the UI-facing form
+        // with a `Duration` "time until next attempt". `From<&...>`
+        // handles the projection in one place.
+        match self.shared.state.lock() {
+            Ok(s) => Some(sdr_types::RtlTcpConnectionState::from(&*s)),
+            Err(_) => Some(sdr_types::RtlTcpConnectionState::Disconnected),
+        }
     }
 }
 

--- a/crates/sdr-types/src/lib.rs
+++ b/crates/sdr-types/src/lib.rs
@@ -4,10 +4,12 @@ mod complex;
 mod constants;
 mod enums;
 mod error;
+mod rtl_tcp_connection_state;
 mod stereo;
 
 pub use complex::Complex;
 pub use constants::*;
 pub use enums::{DemodMode, Protocol, SampleFormat};
 pub use error::{ConfigError, DspError, PipelineError, RtlsdrError, SinkError, SourceError};
+pub use rtl_tcp_connection_state::RtlTcpConnectionState;
 pub use stereo::Stereo;

--- a/crates/sdr-types/src/rtl_tcp_connection_state.rs
+++ b/crates/sdr-types/src/rtl_tcp_connection_state.rs
@@ -1,0 +1,141 @@
+//! UI-facing connection state for `rtl_tcp` network sources.
+//!
+//! Lives in `sdr-types` (not `sdr-source-network`) so the UI layer
+//! can name this enum without depending on the source crate's full
+//! implementation tree. The source-crate implementation keeps its
+//! richer internal state (including `Instant`-based scheduling) as
+//! a private type; a `From` impl projects that internal state into
+//! this public form at the layer boundary.
+
+use std::time::Duration;
+
+/// Rendered state of an `rtl_tcp` client source's connection
+/// lifecycle, as the UI consumes it. Every variant is serializable
+/// to a short human-readable line without needing extra context
+/// from the rest of the crate.
+///
+/// **Time representation:** the internal state machine holds
+/// scheduled events as `Instant`s, which don't cross crate (or
+/// serialization) boundaries cleanly. This type uses `Duration`
+/// "time until" values instead — computed at projection time
+/// (`Instant::checked_duration_since(now)`). UI tick cadence is
+/// fast enough (ideally ≤1 s) that the relative-time staleness is
+/// invisible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RtlTcpConnectionState {
+    /// No connection attempt has begun yet. Initial state on
+    /// source construction, before `start()`.
+    Disconnected,
+
+    /// First TCP connect is in flight. Transient — advances to
+    /// `Connected` on success or `Retrying` / `Failed` on error.
+    Connecting,
+
+    /// Handshake succeeded and the data pump is streaming. Carries
+    /// tuner metadata the UI uses to label the status row.
+    Connected {
+        /// Human-readable tuner name (e.g. `"R820T"`, `"E4000"`).
+        /// Pre-projected to `String` instead of the `TunerTypeCode`
+        /// enum so this type doesn't force downstream consumers to
+        /// depend on `sdr-server-rtltcp`'s protocol module.
+        tuner_name: String,
+        /// Number of discrete gain steps the tuner advertised in
+        /// the dongle-info header. Lets the UI show
+        /// `"R820T, 29 gain steps"` without a second lookup.
+        gain_count: u32,
+    },
+
+    /// Transport-level error (connect refused, EOF, stall). The
+    /// manager is in its reconnect-with-backoff loop; UI can show
+    /// the next retry countdown.
+    Retrying {
+        /// Attempt counter, monotonically increasing across the
+        /// lifetime of this source. Useful for "retry #12" style
+        /// display.
+        attempt: u32,
+        /// Time until the next connect attempt. Computed at the
+        /// projection call site; a saturating subtraction is fine
+        /// because the manager thread will just fire immediately if
+        /// we happen to race past the deadline.
+        retry_in: Duration,
+    },
+
+    /// Terminal failure — only entered on protocol-level errors
+    /// (e.g. a non-RTL0 handshake). Transport failures stay in
+    /// `Retrying` forever. UI treats this as "needs user action"
+    /// (e.g. pick a different server or disconnect).
+    Failed {
+        /// Short reason string suitable for direct display. The
+        /// underlying error type's `Display` should produce this.
+        reason: String,
+    },
+}
+
+impl RtlTcpConnectionState {
+    /// True when the source is actively connected and streaming
+    /// data. Helper so UI code doesn't have to pattern-match the
+    /// full enum when all it wants is a boolean.
+    pub fn is_connected(&self) -> bool {
+        matches!(self, Self::Connected { .. })
+    }
+
+    /// True in the two "activity in progress" states — either
+    /// making the first attempt or cycling through reconnects.
+    /// Used by the status indicator to pick a spinner-vs-icon
+    /// treatment.
+    pub fn is_in_progress(&self) -> bool {
+        matches!(self, Self::Connecting | Self::Retrying { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_connected_matches_only_connected_variant() {
+        assert!(!RtlTcpConnectionState::Disconnected.is_connected());
+        assert!(!RtlTcpConnectionState::Connecting.is_connected());
+        assert!(
+            RtlTcpConnectionState::Connected {
+                tuner_name: "R820T".into(),
+                gain_count: 29,
+            }
+            .is_connected()
+        );
+        assert!(
+            !RtlTcpConnectionState::Retrying {
+                attempt: 1,
+                retry_in: Duration::from_secs(5),
+            }
+            .is_connected()
+        );
+        assert!(
+            !RtlTcpConnectionState::Failed {
+                reason: "bad header".into(),
+            }
+            .is_connected()
+        );
+    }
+
+    #[test]
+    fn is_in_progress_matches_connecting_and_retrying() {
+        assert!(!RtlTcpConnectionState::Disconnected.is_in_progress());
+        assert!(RtlTcpConnectionState::Connecting.is_in_progress());
+        assert!(
+            !RtlTcpConnectionState::Connected {
+                tuner_name: "R820T".into(),
+                gain_count: 29,
+            }
+            .is_in_progress()
+        );
+        assert!(
+            RtlTcpConnectionState::Retrying {
+                attempt: 2,
+                retry_in: Duration::from_secs(3),
+            }
+            .is_in_progress()
+        );
+        assert!(!RtlTcpConnectionState::Failed { reason: "x".into() }.is_in_progress());
+    }
+}

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -12,8 +12,36 @@
 //! rest of the DSP/UI bridge. Keeping this file widget-only mirrors
 //! the pattern in `source_panel.rs` / `audio_panel.rs` / etc.
 
+use std::sync::Arc;
+
 use libadwaita as adw;
 use libadwaita::prelude::*;
+use sdr_config::ConfigManager;
+
+/// Config key for the persisted server nickname (mDNS TXT field).
+const KEY_SERVER_NICKNAME: &str = "rtl_tcp_server_nickname";
+/// Config key for the persisted TCP bind port.
+const KEY_SERVER_PORT: &str = "rtl_tcp_server_port";
+/// Config key for the persisted bind-address selector index
+/// (`BIND_LOOPBACK_IDX` / `BIND_ALL_INTERFACES_IDX`).
+const KEY_SERVER_BIND_IDX: &str = "rtl_tcp_server_bind_idx";
+/// Config key for the persisted "Announce via mDNS" switch state.
+const KEY_SERVER_ADVERTISE: &str = "rtl_tcp_server_advertise";
+/// Config key for the persisted default center frequency (Hz).
+const KEY_SERVER_DEFAULT_FREQ_HZ: &str = "rtl_tcp_server_default_freq_hz";
+/// Config key for the persisted default sample-rate selector
+/// index (0..=10 in the 11-entry list). Stored as an index rather
+/// than a Hz value so a future rate-table edit doesn't break
+/// existing configs.
+const KEY_SERVER_DEFAULT_SR_IDX: &str = "rtl_tcp_server_default_sample_rate_idx";
+/// Config key for the persisted default tuner gain (dB).
+const KEY_SERVER_DEFAULT_GAIN_DB: &str = "rtl_tcp_server_default_gain_db";
+/// Config key for the persisted default PPM correction.
+const KEY_SERVER_DEFAULT_PPM: &str = "rtl_tcp_server_default_ppm";
+/// Config key for the persisted default bias-tee toggle.
+const KEY_SERVER_DEFAULT_BIAS_TEE: &str = "rtl_tcp_server_default_bias_tee";
+/// Config key for the persisted default direct-sampling toggle.
+const KEY_SERVER_DEFAULT_DIRECT_SAMPLING: &str = "rtl_tcp_server_default_direct_sampling";
 
 /// Default TCP port for `rtl_tcp`. Matches upstream `rtl_tcp.c` and
 /// every ecosystem client's default. Changing it means users have to
@@ -538,4 +566,197 @@ pub fn build_server_panel() -> ServerPanel {
         activity_log_list,
         bandwidth_advisory_row,
     }
+}
+
+/// Load saved server-panel values from `config` and wire every
+/// editable row to re-persist on change. Called from `window.rs`
+/// after the panel is built. Two-phase:
+///
+/// 1. **Restore** — read each key, fall back to the widget's
+///    existing default if the key is absent or of the wrong type.
+///    Unknown / corrupt types don't panic; they produce a log at
+///    `warn!` and the widget keeps its default.
+/// 2. **Subscribe** — install a notify handler on each editable
+///    widget that writes its current value back to `config`. The
+///    config manager's auto-save thread picks up the change on
+///    its ~1 s tick.
+///
+/// `GObject` weak refs on the capture side would over-complicate
+/// this signal-handler block; `clone()` is fine here because the
+/// panel's widgets are all held strongly by the sidebar (= window)
+/// lifetime anyway, and the notify handlers only fire on user
+/// action — no leak risk from a long-running timer.
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear sequence of 10 persistence bindings — splitting would just fragment a straightforward contract"
+)]
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "persisted numeric fields (port / freq Hz / ppm) fit well below f64's 52-bit mantissa; the spin rows clamp to u16/u32 ranges at the widget level"
+)]
+pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<ConfigManager>) {
+    // ---- Phase 1: restore ----
+    config.read(|v| {
+        if let Some(nickname) = v
+            .get(KEY_SERVER_NICKNAME)
+            .and_then(serde_json::Value::as_str)
+        {
+            panel.nickname_row.set_text(nickname);
+        }
+        if let Some(port) = v.get(KEY_SERVER_PORT).and_then(serde_json::Value::as_u64) {
+            let clamped = (port as f64).clamp(MIN_SERVER_PORT, MAX_SERVER_PORT);
+            panel.port_row.set_value(clamped);
+        }
+        if let Some(bind_idx) = v
+            .get(KEY_SERVER_BIND_IDX)
+            .and_then(serde_json::Value::as_u64)
+        {
+            // Accept only the legal indices; anything else falls
+            // back to loopback (safest default — never silently
+            // widens exposure).
+            let idx = u32::try_from(bind_idx).unwrap_or(BIND_LOOPBACK_IDX);
+            let legal = if idx == BIND_ALL_INTERFACES_IDX {
+                BIND_ALL_INTERFACES_IDX
+            } else {
+                BIND_LOOPBACK_IDX
+            };
+            panel.bind_row.set_selected(legal);
+        }
+        if let Some(advertise) = v
+            .get(KEY_SERVER_ADVERTISE)
+            .and_then(serde_json::Value::as_bool)
+        {
+            panel.advertise_row.set_active(advertise);
+        }
+        if let Some(freq) = v
+            .get(KEY_SERVER_DEFAULT_FREQ_HZ)
+            .and_then(serde_json::Value::as_u64)
+        {
+            let clamped = (freq as f64).clamp(MIN_CENTER_FREQ_HZ, MAX_CENTER_FREQ_HZ);
+            panel.center_freq_row.set_value(clamped);
+        }
+        if let Some(idx) = v
+            .get(KEY_SERVER_DEFAULT_SR_IDX)
+            .and_then(serde_json::Value::as_u64)
+            && let Ok(idx_u32) = u32::try_from(idx)
+        {
+            panel.sample_rate_row.set_selected(idx_u32);
+        }
+        if let Some(gain) = v
+            .get(KEY_SERVER_DEFAULT_GAIN_DB)
+            .and_then(serde_json::Value::as_f64)
+        {
+            let clamped = gain.clamp(MIN_SERVER_GAIN_DB, MAX_SERVER_GAIN_DB);
+            panel.gain_row.set_value(clamped);
+        }
+        if let Some(ppm) = v
+            .get(KEY_SERVER_DEFAULT_PPM)
+            .and_then(serde_json::Value::as_i64)
+        {
+            let clamped = (ppm as f64).clamp(MIN_SERVER_PPM, MAX_SERVER_PPM);
+            panel.ppm_row.set_value(clamped);
+        }
+        if let Some(bias_tee) = v
+            .get(KEY_SERVER_DEFAULT_BIAS_TEE)
+            .and_then(serde_json::Value::as_bool)
+        {
+            panel.bias_tee_row.set_active(bias_tee);
+        }
+        if let Some(ds) = v
+            .get(KEY_SERVER_DEFAULT_DIRECT_SAMPLING)
+            .and_then(serde_json::Value::as_bool)
+        {
+            panel.direct_sampling_row.set_active(ds);
+        }
+    });
+
+    // ---- Phase 2: subscribe ----
+    // Nickname: AdwEntryRow fires `connect_changed` on every edit.
+    let cfg_nick = Arc::clone(config);
+    panel.nickname_row.connect_changed(move |row| {
+        let text = row.text();
+        cfg_nick.write(|v| {
+            v[KEY_SERVER_NICKNAME] = serde_json::json!(text.as_str());
+        });
+    });
+    // Port spin row.
+    let cfg_port = Arc::clone(config);
+    panel.port_row.connect_value_notify(move |row| {
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "spin row bounded to 1024..=65535 at the widget level"
+        )]
+        let port = row.value() as u64;
+        cfg_port.write(|v| {
+            v[KEY_SERVER_PORT] = serde_json::json!(port);
+        });
+    });
+    // Bind-address combo.
+    let cfg_bind = Arc::clone(config);
+    panel.bind_row.connect_selected_notify(move |row| {
+        cfg_bind.write(|v| {
+            v[KEY_SERVER_BIND_IDX] = serde_json::json!(row.selected());
+        });
+    });
+    // Advertise switch.
+    let cfg_adv = Arc::clone(config);
+    panel.advertise_row.connect_active_notify(move |row| {
+        cfg_adv.write(|v| {
+            v[KEY_SERVER_ADVERTISE] = serde_json::json!(row.is_active());
+        });
+    });
+    // Center frequency spin row (device default).
+    let cfg_freq = Arc::clone(config);
+    panel.center_freq_row.connect_value_notify(move |row| {
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "spin row bounded to u32-valid Hz range at the widget level"
+        )]
+        let hz = row.value() as u64;
+        cfg_freq.write(|v| {
+            v[KEY_SERVER_DEFAULT_FREQ_HZ] = serde_json::json!(hz);
+        });
+    });
+    // Sample-rate combo (device default).
+    let cfg_sr = Arc::clone(config);
+    panel.sample_rate_row.connect_selected_notify(move |row| {
+        cfg_sr.write(|v| {
+            v[KEY_SERVER_DEFAULT_SR_IDX] = serde_json::json!(row.selected());
+        });
+    });
+    // Gain spin row (device default).
+    let cfg_gain = Arc::clone(config);
+    panel.gain_row.connect_value_notify(move |row| {
+        cfg_gain.write(|v| {
+            v[KEY_SERVER_DEFAULT_GAIN_DB] = serde_json::json!(row.value());
+        });
+    });
+    // PPM spin row (device default).
+    let cfg_ppm = Arc::clone(config);
+    panel.ppm_row.connect_value_notify(move |row| {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "spin row bounded to ±200 at the widget level"
+        )]
+        let ppm = row.value() as i64;
+        cfg_ppm.write(|v| {
+            v[KEY_SERVER_DEFAULT_PPM] = serde_json::json!(ppm);
+        });
+    });
+    // Bias-tee switch.
+    let cfg_bt = Arc::clone(config);
+    panel.bias_tee_row.connect_active_notify(move |row| {
+        cfg_bt.write(|v| {
+            v[KEY_SERVER_DEFAULT_BIAS_TEE] = serde_json::json!(row.is_active());
+        });
+    });
+    // Direct-sampling switch.
+    let cfg_ds = Arc::clone(config);
+    panel.direct_sampling_row.connect_active_notify(move |row| {
+        cfg_ds.write(|v| {
+            v[KEY_SERVER_DEFAULT_DIRECT_SAMPLING] = serde_json::json!(row.is_active());
+        });
+    });
 }

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -89,6 +89,12 @@ const CENTER_FREQ_PAGE_HZ: f64 = 1_000_000.0;
 /// Same ordering as `source_panel::build_rtlsdr_rows` so keyboard
 /// muscle memory matches.
 const DEFAULT_SERVER_SAMPLE_RATE_INDEX: u32 = 7;
+/// Number of entries in the sample-rate `StringList`. Load-bearing
+/// for the persistence validator: any index `>=` this count is
+/// treated as a corrupt / transient GTK value and dropped on both
+/// restore and persist. Must match the list literal in
+/// `build_device_defaults_rows`.
+const SAMPLE_RATE_COUNT: u32 = 11;
 
 /// Server device-defaults: gain default (dB). 0.0 dB matches
 /// upstream's "auto" gain interpretation when the CLI passes `-g 0`.
@@ -639,7 +645,13 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
             .get(KEY_SERVER_DEFAULT_SR_IDX)
             .and_then(serde_json::Value::as_u64)
             && let Ok(idx_u32) = u32::try_from(idx)
+            && idx_u32 < SAMPLE_RATE_COUNT
         {
+            // Strict bounds check on the stored index: anything
+            // past the StringList's last entry is discarded (not
+            // silently clamped) so a corrupt config leaves the
+            // widget on its build-time default instead of flipping
+            // to an arbitrary rate. Same policy as `bind_row`.
             panel.sample_rate_row.set_selected(idx_u32);
         }
         if let Some(gain) = v
@@ -692,12 +704,21 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
             v[KEY_SERVER_PORT] = serde_json::json!(port);
         });
     });
-    // Bind-address combo.
+    // Bind-address combo. Only persist legal indices — GTK's
+    // ComboRow can emit transient out-of-range values during
+    // widget-model churn (e.g. a repopulation mid-drag). Writing
+    // those verbatim would corrupt the next startup's restore,
+    // which would then silently fall back to loopback and hide
+    // the drift. Strict gate here + on the restore side keeps
+    // the persisted state well-formed.
     let cfg_bind = Arc::clone(config);
     panel.bind_row.connect_selected_notify(move |row| {
-        cfg_bind.write(|v| {
-            v[KEY_SERVER_BIND_IDX] = serde_json::json!(row.selected());
-        });
+        let selected = row.selected();
+        if selected == BIND_LOOPBACK_IDX || selected == BIND_ALL_INTERFACES_IDX {
+            cfg_bind.write(|v| {
+                v[KEY_SERVER_BIND_IDX] = serde_json::json!(selected);
+            });
+        }
     });
     // Advertise switch.
     let cfg_adv = Arc::clone(config);
@@ -719,12 +740,17 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
             v[KEY_SERVER_DEFAULT_FREQ_HZ] = serde_json::json!(hz);
         });
     });
-    // Sample-rate combo (device default).
+    // Sample-rate combo (device default). Same strict-gate policy
+    // as `bind_row` — don't persist transient out-of-range values
+    // from GTK widget-model churn.
     let cfg_sr = Arc::clone(config);
     panel.sample_rate_row.connect_selected_notify(move |row| {
-        cfg_sr.write(|v| {
-            v[KEY_SERVER_DEFAULT_SR_IDX] = serde_json::json!(row.selected());
-        });
+        let selected = row.selected();
+        if selected < SAMPLE_RATE_COUNT {
+            cfg_sr.write(|v| {
+                v[KEY_SERVER_DEFAULT_SR_IDX] = serde_json::json!(selected);
+            });
+        }
     });
     // Gain spin row (device default).
     let cfg_gain = Arc::clone(config);

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -187,6 +187,12 @@ pub struct ServerPanel {
     /// expander so the stats poller can rebuild it on updates
     /// without walking the expander's `AdwActionRow` children.
     pub activity_log_list: gtk4::ListBox,
+    /// Advisory caption shown when the device-default sample rate
+    /// is at or above the "high bandwidth" threshold. Shared copy
+    /// with the source panel's same-named row so the user sees a
+    /// consistent warning whether they're commanding a high rate
+    /// via the server or the client side.
+    pub bandwidth_advisory_row: adw::ActionRow,
 }
 
 /// Subtitle shown on `status_client_row` when the accept loop is
@@ -402,6 +408,10 @@ fn build_device_defaults_rows() -> DeviceDefaultsRows {
 /// Build the server-panel widgets. The panel is hidden by default;
 /// `window.rs` toggles `widget.set_visible(true)` once a local dongle
 /// is detected and the active source is not RTL-SDR.
+#[allow(
+    clippy::too_many_lines,
+    reason = "widget-assembly function — splitting scatters one-time wire-up across many helpers with no readability win"
+)]
 pub fn build_server_panel() -> ServerPanel {
     let widget = adw::PreferencesGroup::builder()
         .title("Share over network")
@@ -482,6 +492,18 @@ pub fn build_server_panel() -> ServerPanel {
 
     let (activity_log_row, activity_log_list) = build_activity_log_row();
 
+    // Bandwidth advisory — hidden initially. Visibility is toggled
+    // on sample-rate changes via the wiring in window.rs, mirroring
+    // the source-panel path. Copy is intentionally identical to the
+    // source-panel version (shared consts) so users see the same
+    // warning wording no matter which side they're configuring.
+    let bandwidth_advisory_row = adw::ActionRow::builder()
+        .title(crate::sidebar::source_panel::HIGH_BANDWIDTH_ADVISORY_TITLE)
+        .subtitle(crate::sidebar::source_panel::HIGH_BANDWIDTH_ADVISORY_SUBTITLE)
+        .visible(false)
+        .build();
+    bandwidth_advisory_row.add_prefix(&gtk4::Image::from_icon_name("dialog-information-symbolic"));
+
     widget.add(&share_row);
     widget.add(&nickname_row);
     widget.add(&port_row);
@@ -490,6 +512,7 @@ pub fn build_server_panel() -> ServerPanel {
     widget.add(&device_defaults_row);
     widget.add(&status_row);
     widget.add(&activity_log_row);
+    widget.add(&bandwidth_advisory_row);
 
     ServerPanel {
         widget,
@@ -513,5 +536,6 @@ pub fn build_server_panel() -> ServerPanel {
         status_stop_button,
         activity_log_row,
         activity_log_list,
+        bandwidth_advisory_row,
     }
 }

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -580,8 +580,11 @@ pub fn build_server_panel() -> ServerPanel {
 ///
 /// 1. **Restore** — read each key, fall back to the widget's
 ///    existing default if the key is absent or of the wrong type.
-///    Unknown / corrupt types don't panic; they produce a log at
-///    `warn!` and the widget keeps its default.
+///    Unknown / corrupt types are silently dropped (the restore
+///    path is fire-and-forget — `serde_json`'s `as_*` helpers
+///    return `None` on a type mismatch, the `if let Some` guard
+///    skips the apply, and the widget keeps its build-time
+///    default). No panic path.
 /// 2. **Subscribe** — install a notify handler on each editable
 ///    widget that writes its current value back to `config`. The
 ///    config manager's auto-save thread picks up the change on

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -166,9 +166,15 @@ pub fn format_rtl_tcp_state(state: &RtlTcpConnectionState) -> String {
             gain_count,
         } => format!("Connected — {tuner_name} ({gain_count} gains)"),
         RtlTcpConnectionState::Retrying { attempt, retry_in } => {
-            // Round up so "<1 s" still shows something rather than
-            // "0 s" (which would read like the retry already fired).
-            let secs = retry_in.as_secs().max(1);
+            // Ceil, not floor — `as_secs` truncates fractional
+            // seconds, so `1.9 s` would read as "1 s" and the row
+            // would understate the remaining delay. Bump by one
+            // whenever there are any subsec nanos, then clamp to
+            // at least 1 so sub-1 s retries still show something
+            // rather than "0 s" (which reads like the retry
+            // already fired).
+            let secs_ceil = retry_in.as_secs() + u64::from(retry_in.subsec_nanos() > 0);
+            let secs = secs_ceil.max(1);
             format!("Retrying in {secs} s (attempt {attempt})")
         }
         RtlTcpConnectionState::Failed { reason } => format!("Failed — {reason}"),
@@ -583,9 +589,9 @@ mod tests {
             }),
             "Connected — R820T (29 gains)"
         );
-        // Retrying rounds a sub-1-second retry_in up to "1 s" so the
-        // row never displays "Retrying in 0 s" (which would read as
-        // "the retry just fired").
+        // Retrying ceils fractional seconds so the row never
+        // understates the delay: 250 ms remaining → "1 s", not
+        // "0 s" (which would read as "the retry just fired").
         assert_eq!(
             format_rtl_tcp_state(&RtlTcpConnectionState::Retrying {
                 attempt: 3,
@@ -593,6 +599,18 @@ mod tests {
             }),
             "Retrying in 1 s (attempt 3)"
         );
+        // Key regression guard for the ceil semantics — 1.9 s must
+        // read as "2 s", never "1 s". Flooring on `as_secs` would
+        // silently understate the countdown here.
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::Retrying {
+                attempt: 4,
+                retry_in: Duration::from_millis(1_900),
+            }),
+            "Retrying in 2 s (attempt 4)"
+        );
+        // Exact integer seconds must NOT get bumped by the ceil —
+        // 12 s stays at "12 s", not "13 s".
         assert_eq!(
             format_rtl_tcp_state(&RtlTcpConnectionState::Retrying {
                 attempt: 5,

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -1,11 +1,24 @@
 //! Source device configuration panel — device selector, RTL-SDR /
 //! Network / File / RTL-TCP controls.
 
+use std::sync::Arc;
+
 use gtk4::glib;
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
+use sdr_config::ConfigManager;
 use sdr_types::RtlTcpConnectionState;
+
+/// Config key for the persisted list of favorited `rtl_tcp` server
+/// instance names. Stored as a JSON array of strings; unknown /
+/// stale entries are tolerated by the read path.
+pub const KEY_RTL_TCP_CLIENT_FAVORITES: &str = "rtl_tcp_client_favorites";
+/// Config key for the persisted last-connected server. Stored as
+/// a JSON object `{ host, port, nickname }` so we can repopulate
+/// the hostname / port rows on app launch without waiting for
+/// mDNS to rediscover.
+pub const KEY_RTL_TCP_CLIENT_LAST_CONNECTED: &str = "rtl_tcp_client_last_connected";
 
 /// Device selector index for RTL-SDR.
 pub const DEVICE_RTLSDR: u32 = 0;
@@ -593,5 +606,131 @@ mod tests {
             }),
             "Failed — bad handshake"
         );
+    }
+}
+
+/// Snapshot of a previously-connected `rtl_tcp` server. Serialized
+/// into the `rtl_tcp_client_last_connected` config entry so the
+/// next app launch can repopulate the hostname / port / nickname
+/// fields without waiting for mDNS to rediscover.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LastConnectedServer {
+    /// Hostname or IP literal the Connect button dialed — either
+    /// a resolved address (`192.168.1.5`) or an mDNS hostname
+    /// (`shack-pi.local.`), whichever the discovery layer yielded.
+    pub host: String,
+    /// TCP port.
+    pub port: u16,
+    /// User-facing nickname — normally the mDNS TXT nickname, or
+    /// the `instance_name` when no nickname was published.
+    pub nickname: String,
+}
+
+/// Load the list of favorited server instance names. Returns an
+/// empty Vec on first launch / absent / corrupt config. Safe to
+/// call unconditionally.
+pub fn load_favorites(config: &Arc<ConfigManager>) -> Vec<String> {
+    config.read(|v| {
+        v.get(KEY_RTL_TCP_CLIENT_FAVORITES)
+            .and_then(serde_json::Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|entry| entry.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    })
+}
+
+/// Persist the full favorites list. Overwrites the config entry —
+/// callers pass the current UI state of pinned instance names.
+pub fn save_favorites(config: &Arc<ConfigManager>, favorites: &[String]) {
+    config.write(|v| {
+        v[KEY_RTL_TCP_CLIENT_FAVORITES] = serde_json::json!(favorites);
+    });
+}
+
+/// Load the last-connected server snapshot, if any was recorded.
+/// Returns `None` on first launch or when the stored blob fails
+/// to deserialize (schema drift, hand-edited config, etc.).
+pub fn load_last_connected(config: &Arc<ConfigManager>) -> Option<LastConnectedServer> {
+    config.read(|v| {
+        v.get(KEY_RTL_TCP_CLIENT_LAST_CONNECTED)
+            .and_then(|entry| serde_json::from_value(entry.clone()).ok())
+    })
+}
+
+/// Persist a `LastConnectedServer` snapshot. Called from the
+/// discovery-row Connect handler and from any manual-server
+/// connect path once that UI exists.
+pub fn save_last_connected(config: &Arc<ConfigManager>, server: &LastConnectedServer) {
+    config.write(|v| {
+        // Serialize via serde_json::to_value so we don't re-embed
+        // JSON-encoded text inside a JSON string (the common
+        // round-trip mistake here).
+        v[KEY_RTL_TCP_CLIENT_LAST_CONNECTED] =
+            serde_json::to_value(server).unwrap_or(serde_json::Value::Null);
+    });
+}
+
+#[cfg(test)]
+mod client_persistence_tests {
+    use super::*;
+
+    fn make_config() -> Arc<ConfigManager> {
+        Arc::new(ConfigManager::in_memory(&serde_json::json!({})))
+    }
+
+    #[test]
+    fn favorites_round_trip() {
+        let config = make_config();
+        // Fresh config → empty list.
+        assert!(load_favorites(&config).is_empty());
+        let favs = vec![
+            "shack-pi rtl-sdr._rtl_tcp._tcp.local.".to_string(),
+            "attic pi._rtl_tcp._tcp.local.".to_string(),
+        ];
+        save_favorites(&config, &favs);
+        let loaded = load_favorites(&config);
+        assert_eq!(loaded, favs);
+    }
+
+    #[test]
+    fn favorites_loader_tolerates_non_array_entry() {
+        // If someone hand-edits the config file and makes the
+        // entry a string, we shouldn't panic or corrupt state —
+        // just return empty and let the user re-pin.
+        let config = make_config();
+        config.write(|v| {
+            v[KEY_RTL_TCP_CLIENT_FAVORITES] = serde_json::json!("not an array");
+        });
+        assert!(load_favorites(&config).is_empty());
+    }
+
+    #[test]
+    fn last_connected_round_trip() {
+        let config = make_config();
+        assert!(load_last_connected(&config).is_none());
+        let server = LastConnectedServer {
+            host: "192.168.1.5".to_string(),
+            port: 1234,
+            nickname: "shack-pi".to_string(),
+        };
+        save_last_connected(&config, &server);
+        let loaded = load_last_connected(&config).expect("loaded");
+        assert_eq!(loaded.host, server.host);
+        assert_eq!(loaded.port, server.port);
+        assert_eq!(loaded.nickname, server.nickname);
+    }
+
+    #[test]
+    fn last_connected_loader_tolerates_malformed_entry() {
+        // Schema drift: an older version persisted a plain string.
+        // New loader should return None rather than panic.
+        let config = make_config();
+        config.write(|v| {
+            v[KEY_RTL_TCP_CLIENT_LAST_CONNECTED] = serde_json::json!("shack-pi:1234");
+        });
+        assert!(load_last_connected(&config).is_none());
     }
 }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -22,6 +22,24 @@ pub const DEVICE_RTLTCP: u32 = 3;
 /// empty-after-disconnect paths render identical text.
 pub const RTL_TCP_STATUS_DISCONNECTED_SUBTITLE: &str = "Disconnected";
 
+/// Sample-rate selector index at which we start showing the
+/// "high bandwidth" advisory caption. Index 7 = 2.4 MHz, which
+/// at 8-bit I/Q pairs wire-format works out to ~38 Mbps — over
+/// a typical home Wi-Fi link (11/24/54 Mbps practical throughput
+/// for older hardware) this produces silent drops. Anything at
+/// or above this index triggers the caption so the user gets a
+/// heads-up before commanding the remote server.
+pub const HIGH_BANDWIDTH_SAMPLE_RATE_IDX: u32 = 7;
+
+/// Title shown on the advisory row when a network-heavy sample
+/// rate is selected. Kept as a const so source + server panels
+/// render identical copy.
+pub const HIGH_BANDWIDTH_ADVISORY_TITLE: &str = "High sample rate";
+/// Subtitle for the advisory row — the supporting detail under
+/// the title.
+pub const HIGH_BANDWIDTH_ADVISORY_SUBTITLE: &str =
+    "Your network may not keep up (≈38 Mbps at 2.4 Msps with 8-bit I/Q).";
+
 /// Network protocol selector index for TCP (client). Load-bearing:
 /// both `build_network_rows()` (protocol `StringList`) and callers in
 /// `window.rs` that set or read this row rely on this exact mapping.
@@ -114,6 +132,13 @@ pub struct SourcePanel {
     /// indicates we're between attempts (Retrying / Failed /
     /// Disconnected).
     pub rtl_tcp_retry_button: gtk4::Button,
+
+    /// Advisory caption shown when the selected sample rate is at
+    /// or above `HIGH_BANDWIDTH_SAMPLE_RATE_IDX` AND the source
+    /// type routes over the network (RTL-TCP). Silent for local
+    /// RTL-SDR and File sources — the wire-bandwidth concern only
+    /// applies to network paths.
+    pub bandwidth_advisory_row: adw::ActionRow,
 }
 
 /// Render a connection state into a one-line human-readable form
@@ -374,6 +399,17 @@ pub fn build_source_panel() -> SourcePanel {
     rtl_tcp_status_row.add_suffix(&rtl_tcp_disconnect_button);
     rtl_tcp_status_row.add_suffix(&rtl_tcp_retry_button);
 
+    // Bandwidth advisory row — hidden by default. Visibility is
+    // toggled by the sample-rate and device-type notify handlers
+    // in window.rs. Title + subtitle copy come from shared consts
+    // so the source and server panels render identical text.
+    let bandwidth_advisory_row = adw::ActionRow::builder()
+        .title(HIGH_BANDWIDTH_ADVISORY_TITLE)
+        .subtitle(HIGH_BANDWIDTH_ADVISORY_SUBTITLE)
+        .visible(false)
+        .build();
+    bandwidth_advisory_row.add_prefix(&gtk4::Image::from_icon_name("dialog-information-symbolic"));
+
     // Add all rows to the group.
     group.add(&device_row);
     group.add(&sample_rate_row);
@@ -391,6 +427,7 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&record_iq_row);
     group.add(&rtl_tcp_discovered_row);
     group.add(&rtl_tcp_status_row);
+    group.add(&bandwidth_advisory_row);
 
     // Derive initial visibility from the selected device.
     let selected = device_row.selected();
@@ -445,6 +482,7 @@ pub fn build_source_panel() -> SourcePanel {
         rtl_tcp_status_row,
         rtl_tcp_disconnect_button,
         rtl_tcp_retry_button,
+        bandwidth_advisory_row,
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -5,6 +5,7 @@ use gtk4::glib;
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
+use sdr_types::RtlTcpConnectionState;
 
 /// Device selector index for RTL-SDR.
 pub const DEVICE_RTLSDR: u32 = 0;
@@ -14,6 +15,12 @@ pub const DEVICE_NETWORK: u32 = 1;
 pub const DEVICE_FILE: u32 = 2;
 /// Device selector index for RTL-TCP (rtl_tcp-protocol network client).
 pub const DEVICE_RTLTCP: u32 = 3;
+
+/// Default subtitle for the RTL-TCP status row before any
+/// `DspToUi::RtlTcpConnectionState` event has arrived (or after a
+/// Disconnect). Kept as a const so the empty-at-startup and
+/// empty-after-disconnect paths render identical text.
+pub const RTL_TCP_STATUS_DISCONNECTED_SUBTITLE: &str = "Disconnected";
 
 /// Network protocol selector index for TCP (client). Load-bearing:
 /// both `build_network_rows()` (protocol `StringList`) and callers in
@@ -91,6 +98,43 @@ pub struct SourcePanel {
     /// Discovered `rtl_tcp` servers (live from mDNS). Collapsed by
     /// default; expands when servers are seen.
     pub rtl_tcp_discovered_row: adw::ExpanderRow,
+
+    /// Connection status line shown only while the RTL-TCP source
+    /// type is selected. Subtitle reflects the current
+    /// `RtlTcpConnectionState` — "Connected to R820T (29 gains)",
+    /// "Retrying in 5 s (attempt 3)", "Failed: bad handshake", etc.
+    pub rtl_tcp_status_row: adw::ActionRow,
+    /// Stops the current `rtl_tcp` connection without changing
+    /// source type. Packed as a suffix on `rtl_tcp_status_row`,
+    /// sensitive only when there's something to disconnect from.
+    pub rtl_tcp_disconnect_button: gtk4::Button,
+    /// Forces a reconnect attempt immediately, skipping the
+    /// exponential-backoff sleep. Packed as a suffix on
+    /// `rtl_tcp_status_row`, sensitive only when the state
+    /// indicates we're between attempts (Retrying / Failed /
+    /// Disconnected).
+    pub rtl_tcp_retry_button: gtk4::Button,
+}
+
+/// Render a connection state into a one-line human-readable form
+/// for the status row subtitle. Free function + pure formatter so
+/// it's unit-testable without instantiating GTK widgets.
+pub fn format_rtl_tcp_state(state: &RtlTcpConnectionState) -> String {
+    match state {
+        RtlTcpConnectionState::Disconnected => RTL_TCP_STATUS_DISCONNECTED_SUBTITLE.to_string(),
+        RtlTcpConnectionState::Connecting => "Connecting…".to_string(),
+        RtlTcpConnectionState::Connected {
+            tuner_name,
+            gain_count,
+        } => format!("Connected — {tuner_name} ({gain_count} gains)"),
+        RtlTcpConnectionState::Retrying { attempt, retry_in } => {
+            // Round up so "<1 s" still shows something rather than
+            // "0 s" (which would read like the retry already fired).
+            let secs = retry_in.as_secs().max(1);
+            format!("Retrying in {secs} s (attempt {attempt})")
+        }
+        RtlTcpConnectionState::Failed { reason } => format!("Failed — {reason}"),
+    }
 }
 
 /// Default sample rate selector index (2.4 MHz = index 7).
@@ -268,6 +312,10 @@ fn connect_device_visibility(
 }
 
 /// Build the source device configuration panel.
+#[allow(
+    clippy::too_many_lines,
+    reason = "widget-assembly function — splitting would scatter one-time wire-up across many helpers with no readability win"
+)]
 pub fn build_source_panel() -> SourcePanel {
     let group = adw::PreferencesGroup::builder()
         .title("Source")
@@ -301,18 +349,30 @@ pub fn build_source_panel() -> SourcePanel {
     // RTL-TCP-specific rows. Built always, shown only when the RTL-TCP
     // source type is selected (see connect_device_visibility + the
     // initial-visibility block below).
-    //
-    // Connection-state display (Connecting / Connected / Retrying /
-    // Failed) is intentionally deferred to #323 — wiring it requires
-    // a new DspToUi event from the controller that polls
-    // RtlTcpSource::connection_state(), which is outside this PR's
-    // scope. Shipping the row without that plumbing would leave it
-    // stuck on "Disconnected" misleadingly.
     let rtl_tcp_discovered_row = adw::ExpanderRow::builder()
         .title("Discovered rtl_tcp servers")
         .subtitle("No servers discovered on the local network yet.")
         .visible(false)
         .build();
+
+    // Connection-state status row — subtitle updated by the DSP
+    // bridge via `DspToUi::RtlTcpConnectionState`. Suffix buttons
+    // let the user tear down or force-retry the connection without
+    // leaving the RTL-TCP source type.
+    let rtl_tcp_status_row = adw::ActionRow::builder()
+        .title("Connection")
+        .subtitle(RTL_TCP_STATUS_DISCONNECTED_SUBTITLE)
+        .visible(false)
+        .build();
+    let rtl_tcp_disconnect_button = gtk4::Button::with_label("Disconnect");
+    rtl_tcp_disconnect_button.set_valign(gtk4::Align::Center);
+    rtl_tcp_disconnect_button.set_sensitive(false);
+    let rtl_tcp_retry_button = gtk4::Button::with_label("Retry now");
+    rtl_tcp_retry_button.set_valign(gtk4::Align::Center);
+    rtl_tcp_retry_button.add_css_class("suggested-action");
+    rtl_tcp_retry_button.set_sensitive(false);
+    rtl_tcp_status_row.add_suffix(&rtl_tcp_disconnect_button);
+    rtl_tcp_status_row.add_suffix(&rtl_tcp_retry_button);
 
     // Add all rows to the group.
     group.add(&device_row);
@@ -330,6 +390,7 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&decimation_row);
     group.add(&record_iq_row);
     group.add(&rtl_tcp_discovered_row);
+    group.add(&rtl_tcp_status_row);
 
     // Derive initial visibility from the selected device.
     let selected = device_row.selected();
@@ -347,6 +408,7 @@ pub fn build_source_panel() -> SourcePanel {
     protocol_row.set_visible(is_network);
     file_path_row.set_visible(is_file);
     rtl_tcp_discovered_row.set_visible(is_rtltcp);
+    rtl_tcp_status_row.set_visible(is_rtltcp);
 
     connect_device_visibility(
         &device_row,
@@ -359,7 +421,7 @@ pub fn build_source_panel() -> SourcePanel {
         &protocol_row,
         &file_path_row,
     );
-    connect_rtl_tcp_visibility(&device_row, &rtl_tcp_discovered_row);
+    connect_rtl_tcp_visibility(&device_row, &rtl_tcp_discovered_row, &rtl_tcp_status_row);
 
     // Controls connected to DSP pipeline via window.rs
 
@@ -380,6 +442,9 @@ pub fn build_source_panel() -> SourcePanel {
         decimation_row,
         record_iq_row,
         rtl_tcp_discovered_row,
+        rtl_tcp_status_row,
+        rtl_tcp_disconnect_button,
+        rtl_tcp_retry_button,
     }
 }
 
@@ -389,13 +454,17 @@ pub fn build_source_panel() -> SourcePanel {
 fn connect_rtl_tcp_visibility(
     device_row: &adw::ComboRow,
     rtl_tcp_discovered_row: &adw::ExpanderRow,
+    rtl_tcp_status_row: &adw::ActionRow,
 ) {
     device_row.connect_selected_notify(glib::clone!(
         #[weak]
         rtl_tcp_discovered_row,
+        #[weak]
+        rtl_tcp_status_row,
         move |row| {
             let is_rtltcp = row.selected() == DEVICE_RTLTCP;
             rtl_tcp_discovered_row.set_visible(is_rtltcp);
+            rtl_tcp_status_row.set_visible(is_rtltcp);
         }
     ));
 }
@@ -437,5 +506,54 @@ mod tests {
         assert_ne!(DEVICE_NETWORK, DEVICE_FILE);
         assert_ne!(DEVICE_NETWORK, DEVICE_RTLTCP);
         assert_ne!(DEVICE_FILE, DEVICE_RTLTCP);
+    }
+
+    #[test]
+    fn format_rtl_tcp_state_covers_every_variant() {
+        use std::time::Duration;
+
+        // Disconnected → empty-looking but consistent with the const.
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::Disconnected),
+            RTL_TCP_STATUS_DISCONNECTED_SUBTITLE
+        );
+        // Connecting → ellipsis marker (avoids the reader confusing
+        // "Connecting" with "Connected" on a cursory glance).
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::Connecting),
+            "Connecting…"
+        );
+        // Connected carries tuner metadata both the user and the
+        // debugging eye can parse.
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::Connected {
+                tuner_name: "R820T".into(),
+                gain_count: 29,
+            }),
+            "Connected — R820T (29 gains)"
+        );
+        // Retrying rounds a sub-1-second retry_in up to "1 s" so the
+        // row never displays "Retrying in 0 s" (which would read as
+        // "the retry just fired").
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::Retrying {
+                attempt: 3,
+                retry_in: Duration::from_millis(250),
+            }),
+            "Retrying in 1 s (attempt 3)"
+        );
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::Retrying {
+                attempt: 5,
+                retry_in: Duration::from_secs(12),
+            }),
+            "Retrying in 12 s (attempt 5)"
+        );
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::Failed {
+                reason: "bad handshake".into(),
+            }),
+            "Failed — bad handshake"
+        );
     }
 }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -526,6 +526,70 @@ fn connect_rtl_tcp_visibility(
     ));
 }
 
+/// Snapshot of a previously-connected `rtl_tcp` server. Serialized
+/// into the `rtl_tcp_client_last_connected` config entry so the
+/// next app launch can repopulate the hostname / port / nickname
+/// fields without waiting for mDNS to rediscover.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LastConnectedServer {
+    /// Hostname or IP literal the Connect button dialed — either
+    /// a resolved address (`192.168.1.5`) or an mDNS hostname
+    /// (`shack-pi.local.`), whichever the discovery layer yielded.
+    pub host: String,
+    /// TCP port.
+    pub port: u16,
+    /// User-facing nickname — normally the mDNS TXT nickname, or
+    /// the `instance_name` when no nickname was published.
+    pub nickname: String,
+}
+
+/// Load the list of favorited server instance names. Returns an
+/// empty Vec on first launch / absent / corrupt config. Safe to
+/// call unconditionally.
+pub fn load_favorites(config: &Arc<ConfigManager>) -> Vec<String> {
+    config.read(|v| {
+        v.get(KEY_RTL_TCP_CLIENT_FAVORITES)
+            .and_then(serde_json::Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|entry| entry.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    })
+}
+
+/// Persist the full favorites list. Overwrites the config entry —
+/// callers pass the current UI state of pinned instance names.
+pub fn save_favorites(config: &Arc<ConfigManager>, favorites: &[String]) {
+    config.write(|v| {
+        v[KEY_RTL_TCP_CLIENT_FAVORITES] = serde_json::json!(favorites);
+    });
+}
+
+/// Load the last-connected server snapshot, if any was recorded.
+/// Returns `None` on first launch or when the stored blob fails
+/// to deserialize (schema drift, hand-edited config, etc.).
+pub fn load_last_connected(config: &Arc<ConfigManager>) -> Option<LastConnectedServer> {
+    config.read(|v| {
+        v.get(KEY_RTL_TCP_CLIENT_LAST_CONNECTED)
+            .and_then(|entry| serde_json::from_value(entry.clone()).ok())
+    })
+}
+
+/// Persist a `LastConnectedServer` snapshot. Called from the
+/// discovery-row Connect handler and from any manual-server
+/// connect path once that UI exists.
+pub fn save_last_connected(config: &Arc<ConfigManager>, server: &LastConnectedServer) {
+    config.write(|v| {
+        // Serialize via serde_json::to_value so we don't re-embed
+        // JSON-encoded text inside a JSON string (the common
+        // round-trip mistake here).
+        v[KEY_RTL_TCP_CLIENT_LAST_CONNECTED] =
+            serde_json::to_value(server).unwrap_or(serde_json::Value::Null);
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -625,75 +689,8 @@ mod tests {
             "Failed — bad handshake"
         );
     }
-}
 
-/// Snapshot of a previously-connected `rtl_tcp` server. Serialized
-/// into the `rtl_tcp_client_last_connected` config entry so the
-/// next app launch can repopulate the hostname / port / nickname
-/// fields without waiting for mDNS to rediscover.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct LastConnectedServer {
-    /// Hostname or IP literal the Connect button dialed — either
-    /// a resolved address (`192.168.1.5`) or an mDNS hostname
-    /// (`shack-pi.local.`), whichever the discovery layer yielded.
-    pub host: String,
-    /// TCP port.
-    pub port: u16,
-    /// User-facing nickname — normally the mDNS TXT nickname, or
-    /// the `instance_name` when no nickname was published.
-    pub nickname: String,
-}
-
-/// Load the list of favorited server instance names. Returns an
-/// empty Vec on first launch / absent / corrupt config. Safe to
-/// call unconditionally.
-pub fn load_favorites(config: &Arc<ConfigManager>) -> Vec<String> {
-    config.read(|v| {
-        v.get(KEY_RTL_TCP_CLIENT_FAVORITES)
-            .and_then(serde_json::Value::as_array)
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|entry| entry.as_str().map(str::to_string))
-                    .collect()
-            })
-            .unwrap_or_default()
-    })
-}
-
-/// Persist the full favorites list. Overwrites the config entry —
-/// callers pass the current UI state of pinned instance names.
-pub fn save_favorites(config: &Arc<ConfigManager>, favorites: &[String]) {
-    config.write(|v| {
-        v[KEY_RTL_TCP_CLIENT_FAVORITES] = serde_json::json!(favorites);
-    });
-}
-
-/// Load the last-connected server snapshot, if any was recorded.
-/// Returns `None` on first launch or when the stored blob fails
-/// to deserialize (schema drift, hand-edited config, etc.).
-pub fn load_last_connected(config: &Arc<ConfigManager>) -> Option<LastConnectedServer> {
-    config.read(|v| {
-        v.get(KEY_RTL_TCP_CLIENT_LAST_CONNECTED)
-            .and_then(|entry| serde_json::from_value(entry.clone()).ok())
-    })
-}
-
-/// Persist a `LastConnectedServer` snapshot. Called from the
-/// discovery-row Connect handler and from any manual-server
-/// connect path once that UI exists.
-pub fn save_last_connected(config: &Arc<ConfigManager>, server: &LastConnectedServer) {
-    config.write(|v| {
-        // Serialize via serde_json::to_value so we don't re-embed
-        // JSON-encoded text inside a JSON string (the common
-        // round-trip mistake here).
-        v[KEY_RTL_TCP_CLIENT_LAST_CONNECTED] =
-            serde_json::to_value(server).unwrap_or(serde_json::Value::Null);
-    });
-}
-
-#[cfg(test)]
-mod client_persistence_tests {
-    use super::*;
+    // ---- Client-persistence helpers (favorites + last-connected) ----
 
     fn make_config() -> Arc<ConfigManager> {
         Arc::new(ConfigManager::in_memory(&serde_json::json!({})))

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -643,14 +643,22 @@ fn apply_rtl_tcp_connection_state(
             | RtlTcpConnectionState::Connected { .. }
             | RtlTcpConnectionState::Retrying { .. }
     );
-    let is_between_attempts = matches!(
+    // "Retry now" is only meaningful when there's an active source
+    // to short-circuit out of its backoff wait — Retrying (most
+    // common) or Failed (the terminal protocol-error path where the
+    // source is still registered but not advancing). After an
+    // explicit Disconnect the controller drops `state.source`, and
+    // `UiToDsp::RetryRtlTcpNow` is a no-op (it checks
+    // `state.source.as_mut()` → None → early return). Leaving the
+    // button visibly enabled in that state misleads the user into
+    // thinking they can reconnect in one click; the correct
+    // post-Disconnect path is to press Play.
+    let can_retry_now = matches!(
         state,
-        RtlTcpConnectionState::Disconnected
-            | RtlTcpConnectionState::Retrying { .. }
-            | RtlTcpConnectionState::Failed { .. }
+        RtlTcpConnectionState::Retrying { .. } | RtlTcpConnectionState::Failed { .. }
     );
     disconnect_button.set_sensitive(is_active);
-    retry_button.set_sensitive(is_between_attempts);
+    retry_button.set_sensitive(can_retry_now);
 }
 
 /// Build the `AdwOverlaySplitView` with sidebar configuration panels, content,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1614,8 +1614,7 @@ fn connect_server_panel(
         let selected = row.selected();
         let is_legal = (selected as usize) < SAMPLE_RATES.len();
         advisory.set_visible(
-            is_legal
-                && selected >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX,
+            is_legal && selected >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX,
         );
     };
     // Seed initial visibility + subscribe for future changes.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1604,8 +1604,18 @@ fn connect_server_panel(
         let Some(advisory) = advisory_row_weak.upgrade() else {
             return;
         };
+        // Bounds-check the selected index before threshold compare.
+        // `ComboRow::selected()` can emit transient out-of-range
+        // values during widget-model churn (GTK model repopulate,
+        // drag-mid-scroll, etc.) — a bare `>=` would treat those
+        // as high-bandwidth and flash the advisory visible against
+        // no legal selection. Mirrors the `SAMPLE_RATES.get()`
+        // safety pattern used elsewhere in this file.
+        let selected = row.selected();
+        let is_legal = (selected as usize) < SAMPLE_RATES.len();
         advisory.set_visible(
-            row.selected() >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX,
+            is_legal
+                && selected >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX,
         );
     };
     // Seed initial visibility + subscribe for future changes.
@@ -2538,8 +2548,15 @@ fn connect_source_panel(
                 return;
             };
             let is_network_path = device_row.selected() == DEVICE_RTLTCP;
-            let is_high_rate = sample_rate_row.selected()
-                >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX;
+            // Bounds-check the sample-rate index: transient
+            // out-of-range values from widget-model churn would
+            // otherwise satisfy the `>= threshold` compare and
+            // flash the advisory visible with no legal selection.
+            // Same safety pattern as the server-panel advisory
+            // above.
+            let selected = sample_rate_row.selected();
+            let is_high_rate = (selected as usize) < SAMPLE_RATES.len()
+                && selected >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX;
             advisory.set_visible(is_network_path && is_high_rate);
         }
     };

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -853,9 +853,19 @@ fn connect_sidebar_panels(
     status_bar: &Rc<StatusBar>,
     toast_overlay: &adw::ToastOverlay,
 ) {
-    connect_source_panel(panels, state);
+    // Shared "is the rtl_tcp server currently live?" flag. Written by
+    // the server panel's start/stop handler, read by the source
+    // panel's device-type guard so the two panels can enforce the
+    // "local RTL-SDR source and server-sharing-the-dongle are
+    // mutually exclusive" rule without either side owning state the
+    // other has to synthesize. `Rc<Cell<bool>>` is ideal: GTK single-
+    // threaded, no interior locking needed, cheap to clone into
+    // closures.
+    let server_running: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
+
+    connect_source_panel(panels, state, toast_overlay, Rc::clone(&server_running));
     connect_rtl_tcp_discovery(panels, state);
-    connect_server_panel(panels, toast_overlay);
+    connect_server_panel(panels, toast_overlay, server_running);
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
@@ -1175,7 +1185,11 @@ struct RunningServer {
     clippy::too_many_lines,
     reason = "GTK signal-wiring: visibility + start-stop + control-locking all share state via nested closures — splitting scatters the captures"
 )]
-fn connect_server_panel(panels: &SidebarPanels, toast_overlay: &adw::ToastOverlay) {
+fn connect_server_panel(
+    panels: &SidebarPanels,
+    toast_overlay: &adw::ToastOverlay,
+    server_running: Rc<std::cell::Cell<bool>>,
+) {
     use std::cell::Cell;
 
     let server_widget_weak = panels.server.widget.downgrade();
@@ -1272,6 +1286,7 @@ fn connect_server_panel(panels: &SidebarPanels, toast_overlay: &adw::ToastOverla
         toast_overlay,
         Rc::clone(&running),
         apply_visibility.clone(),
+        server_running,
     );
 
     // Poll `Server::stats()` on a timer, render the status rows,
@@ -1292,6 +1307,7 @@ fn connect_share_switch(
     toast_overlay: &adw::ToastOverlay,
     running: Rc<RefCell<Option<RunningServer>>>,
     apply_visibility: impl Fn() + Clone + 'static,
+    server_running: Rc<std::cell::Cell<bool>>,
 ) {
     use std::cell::Cell;
 
@@ -1307,6 +1323,13 @@ fn connect_share_switch(
     // closure. adw/gtk widgets are GObject refs; cloning increments
     // a refcount, not the data.
     let server_panel = clone_server_panel(&panels.server);
+    // Reverse-direction exclusivity guard: we need to read the
+    // source-panel's device_row selection inside this closure to
+    // decline server start when the user still has RTL-SDR picked
+    // as their local source. Cloned (GObject refcount bump) rather
+    // than downgraded because the device_row's lifetime is bound to
+    // the sidebar which outlives the server panel's signal handler.
+    let source_device_row = panels.source.device_row.clone();
 
     panels.server.share_row.connect_active_notify(move |row| {
         if reentry_guard.get() {
@@ -1314,6 +1337,21 @@ fn connect_share_switch(
         }
         let active = row.is_active();
         if active {
+            // Exclusivity guard: can't claim the dongle for the
+            // server while the UI still has RTL-SDR picked as the
+            // local source type. Toast + revert the switch without
+            // touching `running` or widget lock state.
+            if source_device_row.selected() == DEVICE_RTLSDR {
+                if let Some(overlay) = toast_overlay_weak.upgrade() {
+                    overlay.add_toast(adw::Toast::new(
+                        "Switch the source away from local RTL-SDR before sharing over network.",
+                    ));
+                }
+                reentry_guard.set(true);
+                row.set_active(false);
+                reentry_guard.set(false);
+                return;
+            }
             // Build a ServerConfig from current panel state. Widget
             // readers run on the main thread — safe to block-read
             // the rows synchronously.
@@ -1350,6 +1388,11 @@ fn connect_share_switch(
                     server_panel.status_row.set_visible(true);
                     server_panel.activity_log_row.set_visible(true);
                     *running.borrow_mut() = Some(RunningServer { server, advertiser });
+                    // Flip the shared "server is live" flag AFTER
+                    // the handle is stored so the source-panel
+                    // guard can't race against a mid-construction
+                    // state.
+                    server_running.set(true);
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "failed to start rtl_tcp server");
@@ -1380,6 +1423,11 @@ fn connect_share_switch(
                 drop(handle.advertiser.take());
                 drop(handle.server);
             }
+            // Clear the shared "server is live" flag ahead of the
+            // widget-visibility changes so an immediate source-type
+            // re-selection triggered by the user's next action sees
+            // the coherent post-stop state.
+            server_running.set(false);
             set_controls_locked(&server_panel, false);
             server_panel.status_row.set_visible(false);
             server_panel.activity_log_row.set_visible(false);
@@ -2049,7 +2097,12 @@ fn format_age(elapsed: Duration) -> String {
     clippy::too_many_lines,
     reason = "GTK signal-wiring panel; splitting would fragment the control mapping"
 )]
-fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
+fn connect_source_panel(
+    panels: &SidebarPanels,
+    state: &Rc<AppState>,
+    toast_overlay: &adw::ToastOverlay,
+    server_running: Rc<std::cell::Cell<bool>>,
+) {
     // Sample rate selector
     let state_sr = Rc::clone(state);
     panels
@@ -2120,19 +2173,53 @@ fn connect_source_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         state_ppm.send_dsp(UiToDsp::SetPpmCorrection(row.value() as i32));
     });
 
-    // Source type selector — guard against transient out-of-range indices
+    // Source type selector — guard against transient out-of-range
+    // indices AND enforce mutual exclusivity with the rtl_tcp server
+    // (the dongle can only serve one master; re-selecting RTL-SDR
+    // while the server's accept thread has the USB device would
+    // trigger a double-open at the next Play).
     let state_source = Rc::clone(state);
+    let toast_overlay_weak = toast_overlay.downgrade();
+    // Last-known legal selection. Seeded from the current row state
+    // so the revert path on first illegal transition lands on the
+    // value the UI already shows. Updated every time the guard
+    // accepts a new selection.
+    let last_legal_selection: Rc<std::cell::Cell<u32>> =
+        Rc::new(std::cell::Cell::new(panels.source.device_row.selected()));
+    // Re-entry guard against our own `set_selected` (the revert).
+    // Without it the revert would re-enter this handler, see the
+    // previous illegal value as "new", and endlessly toggle.
+    let reverting: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
     panels
         .source
         .device_row
         .connect_selected_notify(move |row| {
-            let source_type = match row.selected() {
+            if reverting.get() {
+                // Our own revert fired this notify — drop it.
+                return;
+            }
+            let selected = row.selected();
+            // Exclusivity guard: can't re-enter the local-source
+            // world while the rtl_tcp server has the dongle claimed.
+            if selected == DEVICE_RTLSDR && server_running.get() {
+                if let Some(overlay) = toast_overlay_weak.upgrade() {
+                    overlay.add_toast(adw::Toast::new(
+                        "Stop the network server first before switching to local RTL-SDR.",
+                    ));
+                }
+                reverting.set(true);
+                row.set_selected(last_legal_selection.get());
+                reverting.set(false);
+                return;
+            }
+            let source_type = match selected {
                 DEVICE_RTLSDR => SourceType::RtlSdr,
                 DEVICE_NETWORK => SourceType::Network,
                 DEVICE_FILE => SourceType::File,
                 DEVICE_RTLTCP => SourceType::RtlTcp,
                 _ => return, // ignore transient indices
             };
+            last_legal_selection.set(selected);
             state_source.send_dsp(UiToDsp::SetSourceType(source_type));
         });
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -992,26 +992,26 @@ fn connect_rtl_tcp_discovery(
     const DISCOVERY_UNAVAILABLE_SUBTITLE: &str = "Discovery unavailable on this system.";
 
     let (disc_tx, disc_rx) = mpsc::channel::<DiscoveryEvent>();
+    // `Option<Browser>` — `None` on mDNS startup failure. We still
+    // need the rest of this function to run so the *manually*-
+    // persisted `last_connected` / favorites restore can repopulate
+    // the client UI. Only the discovery poller is skipped in the
+    // `None` branch (there'd be nothing to poll, and `disc_tx` is
+    // already dropped so `disc_rx` would immediately return
+    // `TryRecvError::Disconnected` and spin forever).
     let browser = match Browser::start(move |event| {
         // Ignore send errors — means the UI thread dropped the rx,
         // which only happens on shutdown.
         let _ = disc_tx.send(event);
     }) {
-        Ok(b) => b,
+        Ok(b) => Some(b),
         Err(e) => {
-            // Surface the failure in the UI and return early. Without
-            // the early return the timeout below would still spawn,
-            // and because `disc_tx` was moved into the failed
-            // `Browser::start` call its drop has already disconnected
-            // `disc_rx` — the poller would spin forever returning
-            // `TryRecvError::Disconnected` while the UI kept showing
-            // the benign idle "No servers discovered…" subtitle.
             tracing::warn!(%e, "mDNS browser failed to start — discovery disabled");
             panels
                 .source
                 .rtl_tcp_discovered_row
                 .set_subtitle(DISCOVERY_UNAVAILABLE_SUBTITLE);
-            return;
+            None
         }
     };
 
@@ -1074,6 +1074,15 @@ fn connect_rtl_tcp_discovery(
     // Poll the discovery channel from the main thread. Cheap enough
     // to be always-on; discovery events are bursty at start and then
     // idle.
+    //
+    // Gated on `Some(browser)` so we don't spawn a poller against a
+    // dead `disc_rx` when mDNS startup failed. The
+    // `DISCOVERY_UNAVAILABLE_SUBTITLE` set in the `Err` branch
+    // stays on the expander as the long-term idle state; the
+    // restore / favorites paths above already ran unconditionally.
+    let Some(browser) = browser else {
+        return;
+    };
     let _ = glib::timeout_add_local(DISCOVERY_POLL_INTERVAL, move || {
         // Keep the Browser alive as long as the timeout closure is
         // attached.
@@ -2381,6 +2390,12 @@ fn connect_source_panel(
             row.set_visible(is_network_path && is_high_rate);
         }
     };
+    // Seed the advisory visibility once at wire-up. Without this,
+    // the caption stays hidden until the user nudges one of the
+    // two rows — which hides it even when the restored config
+    // already has RTL-TCP + a high sample rate selected.
+    apply_source_bandwidth_advisory();
+
     let state_sr = Rc::clone(state);
     let apply_on_sr = apply_source_bandwidth_advisory.clone();
     panels

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1039,6 +1039,17 @@ fn connect_rtl_tcp_discovery(
     // a `LastConnectedServer` snapshot on click.
     let config_for_discovery = std::sync::Arc::clone(config);
 
+    // Favorites set — instance names the user has starred. Loaded
+    // once on startup, mutated by star-toggle handlers, persisted
+    // after each change via `save_favorites`. `Rc<RefCell<HashSet>>`
+    // mirrors the `displayed_rows` pattern — single-threaded GTK
+    // main loop, no lock contention.
+    let favorites: Rc<RefCell<std::collections::HashSet<String>>> = Rc::new(RefCell::new(
+        crate::sidebar::source_panel::load_favorites(&config_for_discovery)
+            .into_iter()
+            .collect(),
+    ));
+
     // Populate the hostname / port fields on startup from the last
     // connected server, if any. Runs once before the poller starts
     // so the user sees "the server they were last on" immediately
@@ -1153,6 +1164,67 @@ fn connect_rtl_tcp_discovery(
                         .title(&title)
                         .subtitle(&subtitle)
                         .build();
+
+                    // Star toggle — prefix icon, pinning this
+                    // server to the top of the discovered list and
+                    // persisting the choice across app launches.
+                    // Using the outlined / filled star icon pair
+                    // so the toggle state reads clearly without
+                    // extra CSS.
+                    let star_btn = gtk4::ToggleButton::builder()
+                        .icon_name(FAVORITE_ICON_OUTLINE)
+                        .valign(gtk4::Align::Center)
+                        .css_classes(["flat"])
+                        .tooltip_text("Pin as favorite")
+                        .build();
+                    let starred_initially = favorites.borrow().contains(&server.instance_name);
+                    star_btn.set_active(starred_initially);
+                    if starred_initially {
+                        star_btn.set_icon_name(FAVORITE_ICON_FILLED);
+                    }
+                    let star_instance = server.instance_name.clone();
+                    let star_favorites = Rc::clone(&favorites);
+                    let star_config = std::sync::Arc::clone(&config_for_discovery);
+                    let star_rows = Rc::clone(&displayed_rows);
+                    let star_expander_weak = expander_weak.clone();
+                    star_btn.connect_toggled(move |btn| {
+                        let active = btn.is_active();
+                        btn.set_icon_name(if active {
+                            FAVORITE_ICON_FILLED
+                        } else {
+                            FAVORITE_ICON_OUTLINE
+                        });
+                        {
+                            let mut favs = star_favorites.borrow_mut();
+                            if active {
+                                favs.insert(star_instance.clone());
+                            } else {
+                                favs.remove(&star_instance);
+                            }
+                            // Persist immediately. Order within
+                            // the persisted list is unspecified —
+                            // sort on read if the UI ever needs a
+                            // stable presentation order for
+                            // favorites management.
+                            let snapshot: Vec<String> = favs.iter().cloned().collect();
+                            crate::sidebar::source_panel::save_favorites(&star_config, &snapshot);
+                        }
+                        // Rebuild the expander so the row moves
+                        // to/from the top per the new favorite
+                        // state. Reuses the `displayed_rows` map
+                        // (strong refs on the AdwActionRow
+                        // widgets) — ordering is the only thing
+                        // that changes.
+                        if let Some(expander) = star_expander_weak.upgrade() {
+                            reorder_discovered_rows(
+                                &expander,
+                                &star_rows.borrow(),
+                                &star_favorites.borrow(),
+                            );
+                        }
+                    });
+                    row.add_prefix(&star_btn);
+
                     let connect_btn = gtk4::Button::with_label("Connect");
                     connect_btn.add_css_class("suggested-action");
                     connect_btn.set_valign(gtk4::Align::Center);
@@ -1222,6 +1294,9 @@ fn connect_rtl_tcp_discovery(
                     row.add_suffix(&connect_btn);
                     expander.add_row(&row);
                     rows.insert(server.instance_name.clone(), (row, server));
+                    // Reorder after insert so favorites float to
+                    // the top of the new view.
+                    reorder_discovered_rows(&expander, &rows, &favorites.borrow());
 
                     expander.set_subtitle(&format!("{} server(s) visible", rows.len()));
                 }
@@ -1249,6 +1324,58 @@ fn connect_rtl_tcp_discovery(
 /// per-tick `rusb::devices()` USB-bus enumerate is invisible in
 /// profile traces.
 const SERVER_PANEL_HOTPLUG_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Icon name for the un-filled ("not pinned") star on discovery
+/// rows. GNOME Symbolic icon set — present on every GTK4 install.
+const FAVORITE_ICON_OUTLINE: &str = "starred-symbolic";
+/// Icon name for the filled ("pinned") star. Uses the same icon
+/// as the outline so the toggle state reads as "emphasis" rather
+/// than two-icon-switcharoo; UI consumers distinguish the two via
+/// the `ToggleButton::is_active` styling.
+///
+/// **Note:** GNOME's `starred-symbolic` is filled and
+/// `non-starred-symbolic` is outlined — we use both for a clearer
+/// visual toggle. Kept as named consts so future icon swaps
+/// (e.g. to a separate checkmark-based treatment) happen in one
+/// place.
+const FAVORITE_ICON_FILLED: &str = "starred-symbolic";
+
+/// Re-add rows to an `AdwExpanderRow` in a deterministic order:
+/// favorites (alphabetical by instance name) first, then
+/// non-favorites (same alpha order). Called after any mutation
+/// that could change the sort — new announce, favorite toggle —
+/// so the user's pinned entries stay glued to the top. GTK4 gives
+/// us no in-place reorder API for expander children, so we
+/// remove-and-re-add. At the expected scale (<50 servers on any
+/// realistic LAN) the reparenting is invisible.
+fn reorder_discovered_rows(
+    expander: &adw::ExpanderRow,
+    rows: &std::collections::HashMap<String, (adw::ActionRow, DiscoveredServer)>,
+    favorites: &std::collections::HashSet<String>,
+) {
+    // Remove every row from the expander — widgets live in the
+    // HashMap, so no drop happens.
+    for (row, _) in rows.values() {
+        expander.remove(row);
+    }
+    // Sort keys: favorites first, then alpha. Stable across calls
+    // so the user doesn't see rows jitter on every re-announce.
+    let mut keys: Vec<&String> = rows.keys().collect();
+    keys.sort_by(|a, b| {
+        let a_fav = favorites.contains(a.as_str());
+        let b_fav = favorites.contains(b.as_str());
+        match (a_fav, b_fav) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.cmp(b),
+        }
+    });
+    for key in keys {
+        if let Some((row, _)) = rows.get(key) {
+            expander.add_row(row);
+        }
+    }
+}
 
 /// Owned handle for a running `rtl_tcp` server + optional mDNS
 /// advertisement. Drops in reverse order: advertiser first (so

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1623,6 +1623,120 @@ fn connect_server_panel(
 /// `Server::start`, optionally attach an `Advertiser`, lock or
 /// unlock the panel controls, reapply visibility, and surface any
 /// error via a toast while flipping the switch back to off).
+/// Weak refs to every widget the share-switch handler reads or
+/// mutates. Mirrors the `ServerStatusWidgetsWeak` pattern: the
+/// closure attached to `share_row.connect_active_notify` would
+/// otherwise create a self-cycle (`share_row` → closure →
+/// `server_panel.share_row` → …) via the previous
+/// `clone_server_panel` capture. With this struct we capture weak
+/// refs only; strong refs live for the duration of one callback
+/// via `upgrade()` and drop at function return, so the widgets can
+/// be released on window close.
+///
+/// `source_device_row` is a sidebar neighbour (not in `ServerPanel`)
+/// and comes along for the exclusivity guard read.
+struct ServerSwitchWidgetsWeak {
+    nickname_row: glib::WeakRef<adw::EntryRow>,
+    port_row: glib::WeakRef<adw::SpinRow>,
+    bind_row: glib::WeakRef<adw::ComboRow>,
+    advertise_row: glib::WeakRef<adw::SwitchRow>,
+    device_defaults_row: glib::WeakRef<adw::ExpanderRow>,
+    center_freq_row: glib::WeakRef<adw::SpinRow>,
+    sample_rate_row: glib::WeakRef<adw::ComboRow>,
+    gain_row: glib::WeakRef<adw::SpinRow>,
+    ppm_row: glib::WeakRef<adw::SpinRow>,
+    bias_tee_row: glib::WeakRef<adw::SwitchRow>,
+    direct_sampling_row: glib::WeakRef<adw::SwitchRow>,
+    status_row: glib::WeakRef<adw::ExpanderRow>,
+    status_client_row: glib::WeakRef<adw::ActionRow>,
+    status_uptime_row: glib::WeakRef<adw::ActionRow>,
+    status_data_rate_row: glib::WeakRef<adw::ActionRow>,
+    status_commanded_row: glib::WeakRef<adw::ActionRow>,
+    activity_log_row: glib::WeakRef<adw::ExpanderRow>,
+    activity_log_list: glib::WeakRef<gtk4::ListBox>,
+    source_device_row: glib::WeakRef<adw::ComboRow>,
+}
+
+/// Upgraded strong refs held for the duration of a single handler
+/// invocation. Field names match `ServerPanel` so the existing
+/// helpers (`build_server_config_from_panel`, `set_controls_locked`,
+/// etc.) keep working after a simple type rename on their `panel`
+/// parameter.
+struct ServerSwitchWidgets {
+    nickname_row: adw::EntryRow,
+    port_row: adw::SpinRow,
+    bind_row: adw::ComboRow,
+    advertise_row: adw::SwitchRow,
+    device_defaults_row: adw::ExpanderRow,
+    center_freq_row: adw::SpinRow,
+    sample_rate_row: adw::ComboRow,
+    gain_row: adw::SpinRow,
+    ppm_row: adw::SpinRow,
+    bias_tee_row: adw::SwitchRow,
+    direct_sampling_row: adw::SwitchRow,
+    status_row: adw::ExpanderRow,
+    status_client_row: adw::ActionRow,
+    status_uptime_row: adw::ActionRow,
+    status_data_rate_row: adw::ActionRow,
+    status_commanded_row: adw::ActionRow,
+    activity_log_row: adw::ExpanderRow,
+    activity_log_list: gtk4::ListBox,
+    source_device_row: adw::ComboRow,
+}
+
+impl ServerSwitchWidgetsWeak {
+    fn from_panels(panels: &SidebarPanels) -> Self {
+        let s = &panels.server;
+        Self {
+            nickname_row: s.nickname_row.downgrade(),
+            port_row: s.port_row.downgrade(),
+            bind_row: s.bind_row.downgrade(),
+            advertise_row: s.advertise_row.downgrade(),
+            device_defaults_row: s.device_defaults_row.downgrade(),
+            center_freq_row: s.center_freq_row.downgrade(),
+            sample_rate_row: s.sample_rate_row.downgrade(),
+            gain_row: s.gain_row.downgrade(),
+            ppm_row: s.ppm_row.downgrade(),
+            bias_tee_row: s.bias_tee_row.downgrade(),
+            direct_sampling_row: s.direct_sampling_row.downgrade(),
+            status_row: s.status_row.downgrade(),
+            status_client_row: s.status_client_row.downgrade(),
+            status_uptime_row: s.status_uptime_row.downgrade(),
+            status_data_rate_row: s.status_data_rate_row.downgrade(),
+            status_commanded_row: s.status_commanded_row.downgrade(),
+            activity_log_row: s.activity_log_row.downgrade(),
+            activity_log_list: s.activity_log_list.downgrade(),
+            source_device_row: panels.source.device_row.downgrade(),
+        }
+    }
+
+    /// Lift every weak ref atomically — any missing widget means
+    /// the window's torn down and we skip the callback entirely.
+    fn upgrade(&self) -> Option<ServerSwitchWidgets> {
+        Some(ServerSwitchWidgets {
+            nickname_row: self.nickname_row.upgrade()?,
+            port_row: self.port_row.upgrade()?,
+            bind_row: self.bind_row.upgrade()?,
+            advertise_row: self.advertise_row.upgrade()?,
+            device_defaults_row: self.device_defaults_row.upgrade()?,
+            center_freq_row: self.center_freq_row.upgrade()?,
+            sample_rate_row: self.sample_rate_row.upgrade()?,
+            gain_row: self.gain_row.upgrade()?,
+            ppm_row: self.ppm_row.upgrade()?,
+            bias_tee_row: self.bias_tee_row.upgrade()?,
+            direct_sampling_row: self.direct_sampling_row.upgrade()?,
+            status_row: self.status_row.upgrade()?,
+            status_client_row: self.status_client_row.upgrade()?,
+            status_uptime_row: self.status_uptime_row.upgrade()?,
+            status_data_rate_row: self.status_data_rate_row.upgrade()?,
+            status_commanded_row: self.status_commanded_row.upgrade()?,
+            activity_log_row: self.activity_log_row.upgrade()?,
+            activity_log_list: self.activity_log_list.upgrade()?,
+            source_device_row: self.source_device_row.upgrade()?,
+        })
+    }
+}
+
 fn connect_share_switch(
     panels: &SidebarPanels,
     toast_overlay: &adw::ToastOverlay,
@@ -1640,29 +1754,29 @@ fn connect_share_switch(
     let toast_overlay_weak = toast_overlay.downgrade();
 
     let share_row_weak = panels.server.share_row.downgrade();
-    // Clone the whole ServerPanel Rc-backed widget handles into the
-    // closure. adw/gtk widgets are GObject refs; cloning increments
-    // a refcount, not the data.
-    let server_panel = clone_server_panel(&panels.server);
-    // Reverse-direction exclusivity guard: we need to read the
-    // source-panel's device_row selection inside this closure to
-    // decline server start when the user still has RTL-SDR picked
-    // as their local source. Cloned (GObject refcount bump) rather
-    // than downgraded because the device_row's lifetime is bound to
-    // the sidebar which outlives the server panel's signal handler.
-    let source_device_row = panels.source.device_row.clone();
+    // Weak refs to every row/widget the handler reads or mutates.
+    // Replaces the previous `clone_server_panel` strong capture,
+    // which bumped share_row's GObject refcount and created a
+    // self-cycle with the `connect_active_notify` subscription.
+    // Upgraded per-callback so strong refs live for one tick only.
+    let widgets_weak = ServerSwitchWidgetsWeak::from_panels(panels);
 
     panels.server.share_row.connect_active_notify(move |row| {
         if reentry_guard.get() {
             return;
         }
+        let Some(widgets) = widgets_weak.upgrade() else {
+            // Window is gone — the signal should stop firing soon.
+            // Belt-and-suspenders early return.
+            return;
+        };
         let active = row.is_active();
         if active {
             // Exclusivity guard: can't claim the dongle for the
             // server while the UI still has RTL-SDR picked as the
             // local source type. Toast + revert the switch without
             // touching `running` or widget lock state.
-            if source_device_row.selected() == DEVICE_RTLSDR {
+            if widgets.source_device_row.selected() == DEVICE_RTLSDR {
                 if let Some(overlay) = toast_overlay_weak.upgrade() {
                     overlay.add_toast(adw::Toast::new(
                         "Switch the source away from local RTL-SDR before sharing over network.",
@@ -1676,7 +1790,7 @@ fn connect_share_switch(
             // Build a ServerConfig from current panel state. Widget
             // readers run on the main thread — safe to block-read
             // the rows synchronously.
-            let config = build_server_config_from_panel(&server_panel);
+            let config = build_server_config_from_panel(&widgets);
             match Server::start(config) {
                 Ok(server) => {
                     // If advertising is on, build the TXT record
@@ -1689,8 +1803,8 @@ fn connect_share_switch(
                     // `advertiser = None` so the stop path doesn't
                     // try to unregister something that never
                     // registered.
-                    let advertiser = if server_panel.advertise_row.is_active() {
-                        match build_advertiser(&server, &server_panel.nickname_row.text()) {
+                    let advertiser = if widgets.advertise_row.is_active() {
+                        match build_advertiser(&server, &widgets.nickname_row.text()) {
                             Ok(adv) => Some(adv),
                             Err(e) => {
                                 tracing::warn!(error = %e, "mDNS advertiser failed; server running without LAN advertisement");
@@ -1705,9 +1819,9 @@ fn connect_share_switch(
                     } else {
                         None
                     };
-                    set_controls_locked(&server_panel, true);
-                    server_panel.status_row.set_visible(true);
-                    server_panel.activity_log_row.set_visible(true);
+                    set_controls_locked(&widgets, true);
+                    widgets.status_row.set_visible(true);
+                    widgets.activity_log_row.set_visible(true);
                     *running.borrow_mut() = Some(RunningServer { server, advertiser });
                     // Flip the shared "server is live" flag AFTER
                     // the handle is stored so the source-panel
@@ -1749,45 +1863,14 @@ fn connect_share_switch(
             // re-selection triggered by the user's next action sees
             // the coherent post-stop state.
             server_running.set(false);
-            set_controls_locked(&server_panel, false);
-            server_panel.status_row.set_visible(false);
-            server_panel.activity_log_row.set_visible(false);
-            reset_status_rows(&server_panel);
-            reset_activity_log(&server_panel);
+            set_controls_locked(&widgets, false);
+            widgets.status_row.set_visible(false);
+            widgets.activity_log_row.set_visible(false);
+            reset_status_rows(&widgets);
+            reset_activity_log(&widgets);
         }
         apply_visibility();
     });
-}
-
-/// Deep-clone a `ServerPanel` (via `GObject` refcounts — all fields
-/// are adw/gtk widget handles, not data owners). Used to move a full
-/// panel reference into a long-lived closure without borrowing from
-/// the original `SidebarPanels`.
-fn clone_server_panel(panel: &sidebar::ServerPanel) -> sidebar::ServerPanel {
-    sidebar::ServerPanel {
-        widget: panel.widget.clone(),
-        share_row: panel.share_row.clone(),
-        nickname_row: panel.nickname_row.clone(),
-        port_row: panel.port_row.clone(),
-        bind_row: panel.bind_row.clone(),
-        advertise_row: panel.advertise_row.clone(),
-        device_defaults_row: panel.device_defaults_row.clone(),
-        center_freq_row: panel.center_freq_row.clone(),
-        sample_rate_row: panel.sample_rate_row.clone(),
-        gain_row: panel.gain_row.clone(),
-        ppm_row: panel.ppm_row.clone(),
-        bias_tee_row: panel.bias_tee_row.clone(),
-        direct_sampling_row: panel.direct_sampling_row.clone(),
-        status_row: panel.status_row.clone(),
-        status_client_row: panel.status_client_row.clone(),
-        status_uptime_row: panel.status_uptime_row.clone(),
-        status_data_rate_row: panel.status_data_rate_row.clone(),
-        status_commanded_row: panel.status_commanded_row.clone(),
-        status_stop_button: panel.status_stop_button.clone(),
-        activity_log_row: panel.activity_log_row.clone(),
-        activity_log_list: panel.activity_log_list.clone(),
-        bandwidth_advisory_row: panel.bandwidth_advisory_row.clone(),
-    }
 }
 
 /// Cadence for the server-stats poll that renders the "Server
@@ -2144,7 +2227,7 @@ fn render_activity_log(
 /// Reset activity-log list + subtitle on stop. Without this the
 /// list would persist after the server stopped — misleading users
 /// into thinking the log reflects a currently-running session.
-fn reset_activity_log(panel: &sidebar::ServerPanel) {
+fn reset_activity_log(panel: &ServerSwitchWidgets) {
     use crate::sidebar::server_panel::ACTIVITY_LOG_EMPTY_SUBTITLE;
     while let Some(child) = panel.activity_log_list.first_child() {
         panel.activity_log_list.remove(&child);
@@ -2176,7 +2259,7 @@ fn format_log_age(elapsed: Duration) -> String {
 /// Reset status rows to their idle-no-client state. Called when the
 /// server stops so the user doesn't see stale "connected at 127.0.0.1"
 /// / "uptime 5m" data after they flipped the share switch off.
-fn reset_status_rows(panel: &sidebar::ServerPanel) {
+fn reset_status_rows(panel: &ServerSwitchWidgets) {
     use crate::sidebar::server_panel::{
         STATUS_IDLE_VALUE_SUBTITLE, STATUS_WAITING_FOR_CLIENT_SUBTITLE,
     };
@@ -2219,7 +2302,7 @@ const SERVER_BUFFER_CAPACITY_DEFAULT: usize = 0;
     clippy::cast_sign_loss,
     reason = "spin-row values are bounded to u16/u32 ranges at the widget level"
 )]
-fn build_server_config_from_panel(panel: &sidebar::ServerPanel) -> ServerConfig {
+fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
     use std::net::SocketAddr;
 
     use crate::sidebar::server_panel::{BIND_ALL_INTERFACES_IDX, BIND_LOOPBACK_IDX};
@@ -2330,7 +2413,7 @@ fn build_advertiser(
 /// start (so the user can't mutate config out from under a live
 /// session) and `false` on stop. `share_row` itself stays sensitive
 /// — that's how the user turns things off.
-fn set_controls_locked(panel: &sidebar::ServerPanel, locked: bool) {
+fn set_controls_locked(panel: &ServerSwitchWidgets, locked: bool) {
     let sensitive = !locked;
     panel.nickname_row.set_sensitive(sensitive);
     panel.port_row.set_sensitive(sensitive);
@@ -2430,19 +2513,34 @@ fn connect_source_panel(
     // selection AND the device-type selection (only network paths
     // care about wire bandwidth). We clone the helper closure into
     // both notify handlers so either trigger re-evaluates.
+    // All three widgets the advisory closure touches are weak-
+    // ref'd. The closure is attached to both `sample_rate_row` and
+    // `device_row`'s `connect_selected_notify` — strong captures
+    // here would create the same self-cycle pattern flagged in
+    // `connect_share_switch` / `connect_server_status_polling`:
+    // `row → closure → row.clone()` keeps the widget alive forever.
     let advisory_row_weak = panels.source.bandwidth_advisory_row.downgrade();
-    let device_row_for_advisory = panels.source.device_row.clone();
-    let sample_rate_row_for_advisory = panels.source.sample_rate_row.clone();
+    let device_row_weak = panels.source.device_row.downgrade();
+    let sample_rate_row_weak = panels.source.sample_rate_row.downgrade();
     let apply_source_bandwidth_advisory = {
         let advisory_row_weak = advisory_row_weak.clone();
+        let device_row_weak = device_row_weak.clone();
+        let sample_rate_row_weak = sample_rate_row_weak.clone();
         move || {
-            let Some(row) = advisory_row_weak.upgrade() else {
+            // Any missing widget means the window has been torn
+            // down; skip the render — subsequent notify events
+            // won't fire against dead widgets.
+            let (Some(advisory), Some(device_row), Some(sample_rate_row)) = (
+                advisory_row_weak.upgrade(),
+                device_row_weak.upgrade(),
+                sample_rate_row_weak.upgrade(),
+            ) else {
                 return;
             };
-            let is_network_path = device_row_for_advisory.selected() == DEVICE_RTLTCP;
-            let is_high_rate = sample_rate_row_for_advisory.selected()
+            let is_network_path = device_row.selected() == DEVICE_RTLTCP;
+            let is_high_rate = sample_rate_row.selected()
                 >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX;
-            row.set_visible(is_network_path && is_high_rate);
+            advisory.set_visible(is_network_path && is_high_rate);
         }
     };
     // Seed the advisory visibility once at wire-up. Without this,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -349,6 +349,14 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let record_audio_for_dsp = panels.audio.record_audio_row.clone();
     let record_iq_for_dsp = panels.source.record_iq_row.clone();
     let radio_panel_for_dsp = panels.radio.clone();
+    // Just the three widgets the rtl_tcp status renderer touches —
+    // cloning the whole SourcePanel would be a lot of refcount
+    // traffic for one signal handler. Weak refs, upgraded per
+    // message, keep the closure from keeping widgets alive past
+    // window close (same pattern as `ServerStatusWidgetsWeak`).
+    let rtl_tcp_status_row_weak = panels.source.rtl_tcp_status_row.downgrade();
+    let rtl_tcp_disconnect_button_weak = panels.source.rtl_tcp_disconnect_button.downgrade();
+    let rtl_tcp_retry_button_weak = panels.source.rtl_tcp_retry_button.downgrade();
     let transcription_enable_for_dsp = transcript_panel.enable_row.clone();
     #[cfg(feature = "sherpa")]
     let auto_break_row_for_dsp = transcript_panel.auto_break_row.clone();
@@ -402,6 +410,9 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                         &record_audio_for_dsp,
                         &record_iq_for_dsp,
                         &radio_panel_for_dsp,
+                        &rtl_tcp_status_row_weak,
+                        &rtl_tcp_disconnect_button_weak,
+                        &rtl_tcp_retry_button_weak,
                         &transcription_enable_for_dsp,
                         #[cfg(feature = "sherpa")]
                         &auto_break_row_for_dsp,
@@ -441,6 +452,9 @@ fn handle_dsp_message(
     record_audio_row: &adw::SwitchRow,
     record_iq_row: &adw::SwitchRow,
     radio_panel: &sidebar::radio_panel::RadioPanel,
+    rtl_tcp_status_row_weak: &glib::WeakRef<adw::ActionRow>,
+    rtl_tcp_disconnect_button_weak: &glib::WeakRef<gtk4::Button>,
+    rtl_tcp_retry_button_weak: &glib::WeakRef<gtk4::Button>,
     transcription_enable_row: &adw::SwitchRow,
     #[cfg(feature = "sherpa")] auto_break_row: &adw::SwitchRow,
     #[cfg(feature = "sherpa")] auto_break_min_open_row: &adw::SpinRow,
@@ -593,7 +607,49 @@ fn handle_dsp_message(
             tracing::debug!(open, "voice squelch gate edge");
             radio_panel.set_voice_squelch_open(open);
         }
+        DspToUi::RtlTcpConnectionState(conn_state) => {
+            tracing::debug!(?conn_state, "rtl_tcp connection state");
+            // Upgrade all three weak refs atomically; any missing
+            // widget means the window's gone, so we drop the event
+            // rather than render a ghost status row.
+            if let (Some(status_row), Some(disconnect), Some(retry)) = (
+                rtl_tcp_status_row_weak.upgrade(),
+                rtl_tcp_disconnect_button_weak.upgrade(),
+                rtl_tcp_retry_button_weak.upgrade(),
+            ) {
+                apply_rtl_tcp_connection_state(&status_row, &disconnect, &retry, &conn_state);
+            }
+        }
     }
+}
+
+/// Render a `RtlTcpConnectionState` into the status row + button
+/// sensitivities. Pulled out of the renderer so the message
+/// handler can call it with individual weak-upgraded widgets
+/// instead of holding a whole `SourcePanel` clone across the
+/// signal-handler boundary.
+fn apply_rtl_tcp_connection_state(
+    status_row: &adw::ActionRow,
+    disconnect_button: &gtk4::Button,
+    retry_button: &gtk4::Button,
+    state: &sdr_types::RtlTcpConnectionState,
+) {
+    use sdr_types::RtlTcpConnectionState;
+    status_row.set_subtitle(&sidebar::source_panel::format_rtl_tcp_state(state));
+    let is_active = matches!(
+        state,
+        RtlTcpConnectionState::Connecting
+            | RtlTcpConnectionState::Connected { .. }
+            | RtlTcpConnectionState::Retrying { .. }
+    );
+    let is_between_attempts = matches!(
+        state,
+        RtlTcpConnectionState::Disconnected
+            | RtlTcpConnectionState::Retrying { .. }
+            | RtlTcpConnectionState::Failed { .. }
+    );
+    disconnect_button.set_sensitive(is_active);
+    retry_button.set_sensitive(is_between_attempts);
 }
 
 /// Build the `AdwOverlaySplitView` with sidebar configuration panels, content,
@@ -2172,6 +2228,27 @@ fn connect_source_panel(
         #[allow(clippy::cast_possible_truncation)]
         state_ppm.send_dsp(UiToDsp::SetPpmCorrection(row.value() as i32));
     });
+
+    // rtl_tcp connection controls — Disconnect + Retry now.
+    // Both route to the DSP controller which owns the active
+    // Source and performs the stop/start teardown. Buttons are
+    // sensitive-gated by the state-change handler in
+    // `handle_dsp_message`, so clicks should only ever reach here
+    // on legal transitions.
+    let state_disconnect = Rc::clone(state);
+    panels
+        .source
+        .rtl_tcp_disconnect_button
+        .connect_clicked(move |_| {
+            state_disconnect.send_dsp(UiToDsp::DisconnectRtlTcp);
+        });
+    let state_retry = Rc::clone(state);
+    panels
+        .source
+        .rtl_tcp_retry_button
+        .connect_clicked(move |_| {
+            state_retry.send_dsp(UiToDsp::RetryRtlTcpNow);
+        });
 
     // Source type selector — guard against transient out-of-range
     // indices AND enforce mutual exclusivity with the rtl_tcp server

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1055,7 +1055,18 @@ fn connect_rtl_tcp_discovery(
     // so the user sees "the server they were last on" immediately
     // instead of having to wait for a fresh mDNS beacon. No-op on
     // first launch / after a config reset.
+    //
+    // Protocol row is forced to TCP *before* the hostname / port
+    // writes. Those writes fire `connect_changed` / `connect_value_
+    // notify` handlers that re-read `protocol_row.selected()` and
+    // dispatch `SetNetworkConfig { protocol: ... }`. If the shared
+    // protocol row was restored to UDP from a prior raw-Network
+    // session, the restore path would otherwise push a UDP
+    // `SetNetworkConfig` against the RTL-TCP endpoint on the very
+    // first tick. Pinning TCP first keeps the restore both silent
+    // to the user and correct end-to-end.
     if let Some(last) = crate::sidebar::source_panel::load_last_connected(&config_for_discovery) {
+        protocol_row.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
         hostname_row.set_text(&last.host);
         port_row.set_value(f64::from(last.port));
     }
@@ -1326,18 +1337,14 @@ fn connect_rtl_tcp_discovery(
 const SERVER_PANEL_HOTPLUG_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 /// Icon name for the un-filled ("not pinned") star on discovery
-/// rows. GNOME Symbolic icon set — present on every GTK4 install.
-const FAVORITE_ICON_OUTLINE: &str = "starred-symbolic";
-/// Icon name for the filled ("pinned") star. Uses the same icon
-/// as the outline so the toggle state reads as "emphasis" rather
-/// than two-icon-switcharoo; UI consumers distinguish the two via
-/// the `ToggleButton::is_active` styling.
-///
-/// **Note:** GNOME's `starred-symbolic` is filled and
-/// `non-starred-symbolic` is outlined — we use both for a clearer
-/// visual toggle. Kept as named consts so future icon swaps
-/// (e.g. to a separate checkmark-based treatment) happen in one
-/// place.
+/// rows. GNOME Symbolic icon set — `non-starred-symbolic` renders
+/// the outline glyph, which is visually distinct from the filled
+/// pinned state so the affordance reads clearly without relying
+/// on the `ToggleButton::is_active` styling alone.
+const FAVORITE_ICON_OUTLINE: &str = "non-starred-symbolic";
+/// Icon name for the filled ("pinned") star. Paired with
+/// `FAVORITE_ICON_OUTLINE` so toggling swaps the glyph, not just
+/// the button chrome.
 const FAVORITE_ICON_FILLED: &str = "starred-symbolic";
 
 /// Re-add rows to an `AdwExpanderRow` in a deterministic order:

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -669,6 +669,11 @@ fn build_split_view(
 ) {
     // Sidebar — configuration panels.
     let (sidebar_scroll, panels) = sidebar::build_sidebar();
+    // Restore saved server-panel settings + subscribe to persist
+    // future changes. Runs as soon as panels are built so the
+    // saved values are visible before any user interaction could
+    // otherwise overwrite them.
+    sidebar::server_panel::connect_server_panel_persistence(&panels.server, config);
 
     // Main content area — spectrum display (FFT plot + waterfall) + status bar.
     let (spectrum_view, spectrum_handle) = spectrum::build_spectrum_view(state.ui_tx.clone());

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1349,6 +1349,26 @@ fn connect_server_panel(
     // and auto-stop the server if `has_stopped()` becomes true
     // (e.g. USB unplug or accept-thread failure).
     connect_server_status_polling(panels, Rc::clone(&running), apply_visibility);
+
+    // Bandwidth advisory — toggled on the device-default sample
+    // rate. Unlike the source panel's advisory (which also gates
+    // on source type), the server is inherently a network path so
+    // only the rate matters.
+    let advisory_row_weak = panels.server.bandwidth_advisory_row.downgrade();
+    let apply_server_bandwidth_advisory = move |row: &adw::ComboRow| {
+        let Some(advisory) = advisory_row_weak.upgrade() else {
+            return;
+        };
+        advisory.set_visible(
+            row.selected() >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX,
+        );
+    };
+    // Seed initial visibility + subscribe for future changes.
+    apply_server_bandwidth_advisory(&panels.server.sample_rate_row);
+    panels
+        .server
+        .sample_rate_row
+        .connect_selected_notify(apply_server_bandwidth_advisory);
 }
 
 /// Extracted out of `connect_server_panel` so the parent function
@@ -1521,6 +1541,7 @@ fn clone_server_panel(panel: &sidebar::ServerPanel) -> sidebar::ServerPanel {
         status_stop_button: panel.status_stop_button.clone(),
         activity_log_row: panel.activity_log_row.clone(),
         activity_log_list: panel.activity_log_list.clone(),
+        bandwidth_advisory_row: panel.bandwidth_advisory_row.clone(),
     }
 }
 
@@ -2159,8 +2180,28 @@ fn connect_source_panel(
     toast_overlay: &adw::ToastOverlay,
     server_running: Rc<std::cell::Cell<bool>>,
 ) {
-    // Sample rate selector
+    // Sample rate selector + bandwidth advisory re-render.
+    // The advisory visibility depends on BOTH the sample-rate
+    // selection AND the device-type selection (only network paths
+    // care about wire bandwidth). We clone the helper closure into
+    // both notify handlers so either trigger re-evaluates.
+    let advisory_row_weak = panels.source.bandwidth_advisory_row.downgrade();
+    let device_row_for_advisory = panels.source.device_row.clone();
+    let sample_rate_row_for_advisory = panels.source.sample_rate_row.clone();
+    let apply_source_bandwidth_advisory = {
+        let advisory_row_weak = advisory_row_weak.clone();
+        move || {
+            let Some(row) = advisory_row_weak.upgrade() else {
+                return;
+            };
+            let is_network_path = device_row_for_advisory.selected() == DEVICE_RTLTCP;
+            let is_high_rate = sample_rate_row_for_advisory.selected()
+                >= crate::sidebar::source_panel::HIGH_BANDWIDTH_SAMPLE_RATE_IDX;
+            row.set_visible(is_network_path && is_high_rate);
+        }
+    };
     let state_sr = Rc::clone(state);
+    let apply_on_sr = apply_source_bandwidth_advisory.clone();
     panels
         .source
         .sample_rate_row
@@ -2169,7 +2210,13 @@ fn connect_source_panel(
             if let Some(&rate) = SAMPLE_RATES.get(idx) {
                 state_sr.send_dsp(UiToDsp::SetSampleRate(rate));
             }
+            apply_on_sr();
         });
+    let apply_on_device = apply_source_bandwidth_advisory;
+    panels
+        .source
+        .device_row
+        .connect_selected_notify(move |_| apply_on_device());
 
     // DC blocking toggle
     let state_dc_block = Rc::clone(state);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1155,6 +1155,19 @@ fn connect_rtl_tcp_discovery(
                     tracing::warn!(
                         "mDNS discovery channel disconnected — stopping discovery poller"
                     );
+                    // Drain any previously announced rows before we
+                    // break out. Without this, they'd linger in the
+                    // expander indefinitely — no more
+                    // `ServerWithdrawn` events will arrive, and the
+                    // stale-age pruner at the top of the tick is
+                    // also about to stop firing. Users would see
+                    // rows that look Connect-able for endpoints
+                    // the UI has already declared unavailable.
+                    let mut rows = displayed_rows.borrow_mut();
+                    for (_, (row, _)) in rows.drain() {
+                        expander.remove(&row);
+                    }
+                    drop(rows);
                     expander.set_subtitle(DISCOVERY_UNAVAILABLE_SUBTITLE);
                     return glib::ControlFlow::Break;
                 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1197,12 +1197,17 @@ fn connect_rtl_tcp_discovery(
                         .css_classes(["flat"])
                         .tooltip_text("Pin as favorite")
                         .build();
-                    let starred_initially = favorites.borrow().contains(&server.instance_name);
+                    // Use the stable hostname+port key, not
+                    // `instance_name`. `instance_name` comes from
+                    // the server's TXT nickname, which the operator
+                    // can edit — keying favorites off it would
+                    // silently drop the star on any rename.
+                    let star_key = favorite_key(&server);
+                    let starred_initially = favorites.borrow().contains(&star_key);
                     star_btn.set_active(starred_initially);
                     if starred_initially {
                         star_btn.set_icon_name(FAVORITE_ICON_FILLED);
                     }
-                    let star_instance = server.instance_name.clone();
                     let star_favorites = Rc::clone(&favorites);
                     let star_config = std::sync::Arc::clone(&config_for_discovery);
                     let star_rows = Rc::clone(&displayed_rows);
@@ -1217,9 +1222,9 @@ fn connect_rtl_tcp_discovery(
                         {
                             let mut favs = star_favorites.borrow_mut();
                             if active {
-                                favs.insert(star_instance.clone());
+                                favs.insert(star_key.clone());
                             } else {
-                                favs.remove(&star_instance);
+                                favs.remove(&star_key);
                             }
                             // Persist immediately. Order within
                             // the persisted list is unspecified —
@@ -1276,16 +1281,23 @@ fn connect_rtl_tcp_discovery(
                         // handler will dispatch SetSourceType for us
                         // and an explicit send would double-open.
                         let already_rtl_tcp = dr.selected() == DEVICE_RTLTCP;
+                        // Force the shared protocol row to TCP
+                        // BEFORE the hostname/port writes below.
+                        // `hr.set_text` and `pr.set_value` fire the
+                        // `connect_changed` / `connect_value_notify`
+                        // handlers on the shared network rows, which
+                        // re-read `protocol_row.selected()` to build
+                        // their `SetNetworkConfig`. If the shared
+                        // protocol row is still on UDP from a prior
+                        // raw-Network session, those handlers would
+                        // dispatch a stale-UDP `SetNetworkConfig`
+                        // for our clicked endpoint before the
+                        // RTL-TCP switch lands — a transient
+                        // retarget of any live raw-Network source.
+                        // rtl_tcp is always TCP.
+                        protor.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
                         hr.set_text(&click_host);
                         pr.set_value(f64::from(click_port));
-                        // Force the shared protocol row to TCP. rtl_tcp
-                        // is always TCP, and the hostname_row /
-                        // port_row edit handlers re-read this widget
-                        // when dispatching SetNetworkConfig — leaving
-                        // it on UDP (the previous Network-source
-                        // selection) would silently overwrite our
-                        // protocol on the next hostname edit.
-                        protor.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
                         dr.set_selected(DEVICE_RTLTCP);
                         st.send_dsp(UiToDsp::SetNetworkConfig {
                             hostname: click_host.clone(),
@@ -1356,6 +1368,21 @@ const FAVORITE_ICON_OUTLINE: &str = "non-starred-symbolic";
 /// the button chrome.
 const FAVORITE_ICON_FILLED: &str = "starred-symbolic";
 
+/// Stable persistence key for a discovered server's favorite
+/// state. We key by **advertised hostname + port**, not by the
+/// DNS-SD `instance_name`, because `instance_name` is derived
+/// from the user-editable TXT nickname — renaming the server
+/// would silently drop the saved favorite on the next announce.
+/// Hostname is the machine's mDNS identity (e.g. `shack-pi.local.`)
+/// which stays put across nickname changes; paired with port it's
+/// unique enough that two servers on the same host (different
+/// ports) remain distinct favorites. A full machine rename breaks
+/// the favorite — acceptable, since a rename semantically IS a
+/// different host.
+fn favorite_key(server: &DiscoveredServer) -> String {
+    format!("{}:{}", server.hostname, server.port)
+}
+
 /// Re-add rows to an `AdwExpanderRow` in a deterministic order:
 /// favorites (alphabetical by instance name) first, then
 /// non-favorites (same alpha order). Called after any mutation
@@ -1374,12 +1401,19 @@ fn reorder_discovered_rows(
     for (row, _) in rows.values() {
         expander.remove(row);
     }
-    // Sort keys: favorites first, then alpha. Stable across calls
-    // so the user doesn't see rows jitter on every re-announce.
+    // Sort keys: favorites first, then alpha. Favorite check goes
+    // through `favorite_key(server)` (hostname+port) so it matches
+    // what the star-toggle persists. Alpha tiebreak uses the
+    // `instance_name` (HashMap key) so rendering order stays
+    // predictable across re-announces.
     let mut keys: Vec<&String> = rows.keys().collect();
     keys.sort_by(|a, b| {
-        let a_fav = favorites.contains(a.as_str());
-        let b_fav = favorites.contains(b.as_str());
+        let a_fav = rows
+            .get(a.as_str())
+            .is_some_and(|(_, srv)| favorites.contains(&favorite_key(srv)));
+        let b_fav = rows
+            .get(b.as_str())
+            .is_some_and(|(_, srv)| favorites.contains(&favorite_key(srv)));
         match (a_fav, b_fav) {
             (true, false) => std::cmp::Ordering::Less,
             (false, true) => std::cmp::Ordering::Greater,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -203,6 +203,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         &demod_dropdown,
         &status_bar_demod,
         &toast_overlay,
+        config,
     );
 
     // Wire waterfall screenshot button.
@@ -905,6 +906,7 @@ fn build_breakpoint(split_view: &adw::OverlaySplitView) -> adw::Breakpoint {
 }
 
 /// Connect all sidebar panel controls to dispatch `UiToDsp` commands.
+#[allow(clippy::too_many_arguments)]
 fn connect_sidebar_panels(
     panels: &SidebarPanels,
     state: &Rc<AppState>,
@@ -913,6 +915,7 @@ fn connect_sidebar_panels(
     demod_dropdown: &gtk4::DropDown,
     status_bar: &Rc<StatusBar>,
     toast_overlay: &adw::ToastOverlay,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
 ) {
     // Shared "is the rtl_tcp server currently live?" flag. Written by
     // the server panel's start/stop handler, read by the source
@@ -925,7 +928,7 @@ fn connect_sidebar_panels(
     let server_running: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
 
     connect_source_panel(panels, state, toast_overlay, Rc::clone(&server_running));
-    connect_rtl_tcp_discovery(panels, state);
+    connect_rtl_tcp_discovery(panels, state, config);
     connect_server_panel(panels, toast_overlay, server_running);
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
@@ -954,7 +957,11 @@ fn connect_sidebar_panels(
 /// is currently selected. That's fine — discovery is cheap and having
 /// the list pre-populated when the user switches to RTL-TCP makes the
 /// UX immediate instead of "wait 5 s for the first advertisement."
-fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
+fn connect_rtl_tcp_discovery(
+    panels: &SidebarPanels,
+    state: &Rc<AppState>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
     use std::collections::HashMap;
     use std::time::Instant;
 
@@ -1027,6 +1034,20 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
     let protocol_row = panels.source.protocol_row.clone();
     let device_row = panels.source.device_row.clone();
     let state = Rc::clone(state);
+    // Shared config handle — the Connect button on each discovered
+    // row clones it once more inside the closure so it can persist
+    // a `LastConnectedServer` snapshot on click.
+    let config_for_discovery = std::sync::Arc::clone(config);
+
+    // Populate the hostname / port fields on startup from the last
+    // connected server, if any. Runs once before the poller starts
+    // so the user sees "the server they were last on" immediately
+    // instead of having to wait for a fresh mDNS beacon. No-op on
+    // first launch / after a config reset.
+    if let Some(last) = crate::sidebar::source_panel::load_last_connected(&config_for_discovery) {
+        hostname_row.set_text(&last.host);
+        port_row.set_value(f64::from(last.port));
+    }
 
     // Poll the discovery channel from the main thread. Cheap enough
     // to be always-on; discovery events are bursty at start and then
@@ -1143,6 +1164,15 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                     let protor = protocol_row.clone();
                     let dr = device_row.clone();
                     let st = Rc::clone(&state);
+                    let cfg = std::sync::Arc::clone(&config_for_discovery);
+                    // Friendly nickname for the persisted snapshot.
+                    // Prefer the TXT nickname if the responder set
+                    // one, fall back to the DNS-SD instance name.
+                    let click_nickname = if server.txt.nickname.is_empty() {
+                        server.instance_name.clone()
+                    } else {
+                        server.txt.nickname.clone()
+                    };
                     connect_btn.connect_clicked(move |_| {
                         // Remember whether the device row was already
                         // on RTL-TCP. If it WAS, `set_selected` below
@@ -1170,6 +1200,18 @@ fn connect_rtl_tcp_discovery(panels: &SidebarPanels, state: &Rc<AppState>) {
                             port: click_port,
                             protocol: sdr_types::Protocol::TcpClient,
                         });
+                        // Persist the choice so next app launch
+                        // pre-populates the hostname / port fields
+                        // with the same server without needing
+                        // another mDNS round-trip.
+                        crate::sidebar::source_panel::save_last_connected(
+                            &cfg,
+                            &crate::sidebar::source_panel::LastConnectedServer {
+                                host: click_host.clone(),
+                                port: click_port,
+                                nickname: click_nickname.clone(),
+                            },
+                        );
                         if already_rtl_tcp {
                             // device_row notify handler did NOT fire
                             // (we were already on RTL-TCP); force the


### PR DESCRIPTION
## Summary

Closes #323 — the cross-cutting polish layer for the rtl_tcp UI epic (#299). Wires the client and server sides together: exclusivity guards, live connection state, bandwidth advisory, full config persistence, and favorites skeleton.

Seven logical commits:

1. **Mutual exclusivity** (`ddc0c04`) — shared `Rc<Cell<bool>>` between source + server panel wire-ups. Bidirectional decline-with-toast: switching to RTL-SDR source while server is running → toast + revert selection; flipping share switch on while device row is RTL-SDR → toast + revert switch.
2. **ConnectionState type promotion** (`20796bb`) — new `sdr_types::RtlTcpConnectionState` (UI-facing, `Duration`-based) plus `From<&InternalConnectionState>` projection. `Source` trait gains `rtl_tcp_connection_state() -> Option<...>`, default None.
3. **Status row** (`78b74ad`) — the previously-deferred `rtl_tcp_status_row` wired to a new `DspToUi::RtlTcpConnectionState` event. DSP controller polls active source every 500 ms, edge-filters emissions. Disconnect + Retry-now buttons dispatch new `UiToDsp::DisconnectRtlTcp` / `RetryRtlTcpNow` commands. `format_rtl_tcp_state` pure fn with 6 variant-coverage unit tests. Button sensitivities track state.
4. **Bandwidth advisory** (`81456ed`) — `AdwActionRow` info caption at `HIGH_BANDWIDTH_SAMPLE_RATE_IDX = 7` (2.4 MHz, ≈38 Mbps). Source panel gates on device type = RTL-TCP; server panel is always network.
5. **Server settings persistence** (`ffdf86b`) — 10 new config keys `rtl_tcp_server_*`. `connect_server_panel_persistence(panel, config)` restores on startup + subscribes every editable row.
6. **Client persistence** (`a5adaac`) — `LastConnectedServer { host, port, nickname }` serde struct. Hostname/port fields repopulated from last-connected on startup; Connect button saves the choice. Favorites `Vec<String>` helpers ready for commit 7. Four round-trip / schema-drift tests via `ConfigManager::in_memory`.
7. **Favorites UI** (`a6c231d`) — prefix star toggle on each discovered row; pinned servers float to the top via `reorder_discovered_rows` after announce/toggle. Persisted + restored via commit 6 helpers. Inline skeleton; #315 slide-out replaces later.

### Architecture notes

- **Type promotion**: `RtlTcpConnectionState` lives in `sdr-types` so the controller + UI + eventual Mac FFI can name it without pulling in `sdr-source-network`. Internal `ConnectionState` (with `Instant`-based scheduling) stays private to the source crate; projection happens at the layer boundary.
- **Weak-ref status-row capture** in `handle_dsp_message` — three `glib::WeakRef` handles (status row + two buttons) per the #329 lesson, so the closure contributes zero persistent GObject refcount.
- **Favorites reorder** via remove-and-re-add every row. GTK4 has no reorder API for `AdwExpanderRow` children; at the expected LAN scale (<50 servers) the reparenting is invisible.

### Pre-commit self-review

Walked the CR-pattern checklist before each commit:
- Named consts for every magic number with rationale docstrings
- Compile-time `const { assert!(...) }` where applicable
- `downgrade()` + `upgrade()` on widget captures that outlive the widget's natural scope
- Re-entry guards on self-triggering `set_selected` / `set_active` paths
- Schema-drift tolerance on all `ConfigManager` load paths (wrong-typed / corrupt entries → safe default, not panic)
- `rtl_tcp` / `WiFi` / `Wi-Fi` / `ListBox` / `GObject` etc. backticked in all `///` docs

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace` — **844 pass** (837 before; 7 new: 2 `RtlTcpConnectionState` helpers, 1 `format_rtl_tcp_state` 6-variant test, 4 client-persistence round-trip/drift tests)
- [ ] UI smoke (user, tomorrow):
  - Exclusivity: start server → try switch to RTL-SDR → declined; activate RTL-SDR → flip share → declined.
  - Connection state: click Connect on a discovered row → status row updates through Connecting / Connected. Kill the remote server → Retrying countdown appears. Fix the server → state returns to Connected.
  - Disconnect + Retry buttons enable/disable per state.
  - Bandwidth advisory: pick 3.2 MHz as client under RTL-TCP → caption visible. Pick 2.048 MHz → hidden. Select Network source with 3.2 MHz → caption hidden (not RTL-TCP).
  - Server settings persist: configure nickname / port / device defaults → restart app → values persist.
  - Client last-connected persist: Connect to a discovered server → restart app → hostname + port repopulated.
  - Favorites: star a discovered server → it pins to top. Unstar → drops to alpha position. Restart app → stars restored.

## Notes for reviewers

- Manual-server entry UI (host/port/nickname list for servers outside mDNS reach) is deferred to #315's slide-out favorites panel — persistence layer lives in this PR but has no producer yet. The `Vec<String>` favorites list is the only client-persistence commit this PR produces UI for.
- Bind-address "specific interface" selector still deferred to the interface-enumerator backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time RTL‑TCP connection monitoring with throttled polling, edge-triggered UI status and formatted “Retrying in …” countdown.
  * Disconnect and “Retry now” controls with immediate feedback and error/warning reporting.
  * RTL‑TCP favorites and last‑connected persistence, server-panel persistence with validation, and deterministic favorites ordering.
  * Bandwidth advisory rows shown/hidden based on device and sample-rate.

* **Bug Fixes**
  * Prevents stale RTL‑TCP status when switching sources and enforces mutual exclusivity between a running server and certain source selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->