### PR TITLE
feat(#308): port rtlsdr_set_tuner_if_gain

### DIFF
--- a/crates/sdr-rtlsdr/src/device/gain.rs
+++ b/crates/sdr-rtlsdr/src/device/gain.rs
@@ -44,6 +44,31 @@ impl RtlSdrDevice {
         }
     }
 
+    /// Set the gain of one of the tuner's IF stages, in tenths of
+    /// dB.
+    ///
+    /// Ports `rtlsdr_set_tuner_if_gain`. Upstream dispatches to the
+    /// active tuner's `set_if_gain` callback; all tuners other than
+    /// the E4000 implement that as a no-op. Our `Tuner` trait has a
+    /// matching no-op default, so this method forwards unconditionally
+    /// and the non-E4000 modules silently return Ok. Returns Ok with
+    /// no side effects when no tuner is attached (mirrors the
+    /// `set_tuner_gain` / `set_tuner_gain_mode` convention above).
+    ///
+    /// `stage` is 1-based (1 through 6 on the E4000). `gain` is
+    /// signed tenths of dB — the same unit the rtl_tcp wire
+    /// protocol uses for command `0x06`.
+    pub fn set_tuner_if_gain(&mut self, stage: i32, gain: i32) -> Result<(), RtlSdrError> {
+        if let Some(tuner) = &mut self.tuner {
+            usb::set_i2c_repeater(&self.handle, true)?;
+            let result = tuner.set_if_gain(&self.handle, stage, gain);
+            usb::set_i2c_repeater(&self.handle, false)?;
+            result
+        } else {
+            Ok(())
+        }
+    }
+
     /// Set RTL2832 AGC mode.
     ///
     /// Ports `rtlsdr_set_agc_mode`.

--- a/crates/sdr-rtlsdr/src/tuner/e4k.rs
+++ b/crates/sdr-rtlsdr/src/tuner/e4k.rs
@@ -1262,6 +1262,40 @@ impl Tuner for E4kTuner {
     ) -> Result<(), RtlSdrError> {
         self.enable_manual_gain(handle, manual)
     }
+
+    fn set_if_gain(
+        &mut self,
+        handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        stage: i32,
+        gain: i32,
+    ) -> Result<(), RtlSdrError> {
+        // Upstream `e4000_set_if_gain` in `tuner_e4000.c`:
+        //
+        //     return e4k_if_gain_set(&devt->e4k_s,
+        //                            (uint8_t)stage,
+        //                            (int8_t)(gain / 10));
+        //
+        // Two-value cast — bare C-style truncation — is the
+        // upstream contract. Stages outside 1..=6 fall through to
+        // `find_stage_gain` which emits a typed `RtlSdrError`;
+        // matches upstream where the out-of-range path bubbles up
+        // as a nonzero return. Integer division on the tenths
+        // floors toward zero, consistent with the C cast (exact
+        // match for non-negative values; negatives round
+        // identically in both languages once the cast truncates).
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "faithful port of upstream's C-style u8/i8 casts — callers that pass out-of-range stages get a typed error from find_stage_gain"
+        )]
+        let stage_u8 = stage as u8;
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "upstream truncates gain/10 to i8 via bare cast; RtlTcp 0x06 command wire gain is tenths-of-dB, E4K internal LUT is integer dB"
+        )]
+        let gain_i8 = (gain / 10) as i8;
+        self.if_gain_set(handle, stage_u8, gain_i8)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sdr-rtlsdr/src/tuner/e4k.rs
+++ b/crates/sdr-rtlsdr/src/tuner/e4k.rs
@@ -24,6 +24,13 @@ pub const CHECK_ADDR: u8 = 0x02;
 /// Expected chip ID value read from `CHECK_ADDR`.
 pub const CHECK_VAL: u8 = 0x40;
 
+/// Divisor for converting tenths-of-dB wire values into integer
+/// dB values the E4K IF-stage gain LUT is indexed by. Matches
+/// upstream `e4000_set_if_gain` in `tuner_e4000.c`, which does
+/// `(int8_t)(gain / 10)` to collapse the rtl_tcp wire unit onto
+/// the driver's internal unit.
+const TENTHS_DB_PER_DB: i32 = 10;
+
 // ---------------------------------------------------------------------------
 // Register addresses
 // ---------------------------------------------------------------------------
@@ -1293,7 +1300,7 @@ impl Tuner for E4kTuner {
             clippy::cast_possible_truncation,
             reason = "upstream truncates gain/10 to i8 via bare cast; RtlTcp 0x06 command wire gain is tenths-of-dB, E4K internal LUT is integer dB"
         )]
-        let gain_i8 = (gain / 10) as i8;
+        let gain_i8 = (gain / TENTHS_DB_PER_DB) as i8;
         self.if_gain_set(handle, stage_u8, gain_i8)
     }
 }

--- a/crates/sdr-rtlsdr/src/tuner/mod.rs
+++ b/crates/sdr-rtlsdr/src/tuner/mod.rs
@@ -55,4 +55,27 @@ pub trait Tuner: Send {
         handle: &rusb::DeviceHandle<rusb::GlobalContext>,
         manual: bool,
     ) -> Result<(), RtlSdrError>;
+
+    /// Set the gain of an IF stage, in tenths of dB.
+    ///
+    /// Ports `rtlsdr_set_tuner_if_gain`. Only the E4000 programs IF
+    /// stages meaningfully — R820T / R828D / FC0012 / FC0013 /
+    /// FC2580 have no IF-stage controls and silently no-op (matches
+    /// upstream librtlsdr's per-tuner `set_if_gain` dispatch where
+    /// those tuners return 0 without side effects). The default
+    /// trait impl captures that no-op behavior so tuner modules
+    /// only override when they actually do something.
+    ///
+    /// `stage` is 1-based (stage 1 through 6 on the E4000).
+    /// `gain` is signed tenths of dB on the wire; E4000 converts
+    /// to integer dB internally because its stage-gain LUTs are
+    /// integer-valued.
+    fn set_if_gain(
+        &mut self,
+        _handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+        _stage: i32,
+        _gain: i32,
+    ) -> Result<(), RtlSdrError> {
+        Ok(())
+    }
 }

--- a/crates/sdr-server-rtltcp/src/dispatch.rs
+++ b/crates/sdr-server-rtltcp/src/dispatch.rs
@@ -61,20 +61,16 @@ pub fn dispatch(dev: &mut RtlSdrDevice, cmd: Command) {
         // 0x06: tmp = ntohl(cmd.param);
         //       rtlsdr_set_tuner_if_gain(dev, tmp >> 16, (short)(tmp & 0xffff));
         //
-        // Not yet available in our sdr-rtlsdr driver (see #308). Upstream
-        // behavior for R820T/R828D/FC* is also a no-op — E4000 is the only
-        // tuner that actually programs IF gain stages. Log and drop until
-        // #308 lands.
+        // Upstream dispatches to the active tuner's `set_if_gain`.
+        // Only the E4000 programs IF stages meaningfully — every
+        // other supported tuner is a no-op there (matched by our
+        // `Tuner::set_if_gain` default). Sign-extending via `i16`
+        // replicates the short cast upstream applies to the wire
+        // gain so negative tenths-of-dB values survive unchanged.
         CommandOp::SetIfGain => {
-            let stage = (param >> IF_GAIN_STAGE_SHIFT_BITS) as i16;
-            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-            let gain = (param & IF_GAIN_VALUE_MASK) as i16;
-            tracing::debug!(
-                stage,
-                gain_tenths_db = gain,
-                "rtl_tcp set_tuner_if_gain: not implemented (see #308), dropping"
-            );
-            Ok(())
+            let (stage, gain) = unpack_if_gain_param(param);
+            tracing::debug!(stage, gain_tenths_db = gain, "rtl_tcp set tuner if gain");
+            dev.set_tuner_if_gain(i32::from(stage), i32::from(gain))
         }
         // 0x07: rtlsdr_set_testmode(dev, ntohl(cmd.param));
         //       C takes int, non-zero = on.
@@ -156,4 +152,67 @@ fn set_gain_by_index(dev: &mut RtlSdrDevice, index: u32) -> Result<(), sdr_rtlsd
     }
     let gain = gains[idx];
     dev.set_tuner_gain(gain)
+}
+
+/// Unpack the `SetIfGain` (0x06) wire param into its two fields.
+///
+/// Upper 16 bits = IF stage index (unsigned, but `i16` preserves
+/// the upstream C prototype `int stage`). Lower 16 bits = signed
+/// gain in tenths of dB — upstream casts to `short`, and we do the
+/// same via `as i16` so negative values sign-extend correctly when
+/// widened back to `i32` for the `set_tuner_if_gain` call.
+///
+/// Pure function for unit-testability; the handler just calls it
+/// and forwards.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    reason = "wire format: rtl_tcp.c:337-339 packs stage in the high 16 bits and signed gain in the low 16 bits of the 32-bit param"
+)]
+fn unpack_if_gain_param(param: u32) -> (i16, i16) {
+    let stage = (param >> IF_GAIN_STAGE_SHIFT_BITS) as i16;
+    let gain = (param & IF_GAIN_VALUE_MASK) as i16;
+    (stage, gain)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unpack_if_gain_param_positive_values() {
+        // stage=3, gain=+50 tenths (= +5 dB). Both values sit in
+        // their respective 16-bit fields.
+        let param = (0x0003_u32 << 16) | 0x0032_u32;
+        assert_eq!(unpack_if_gain_param(param), (3, 50));
+    }
+
+    #[test]
+    fn unpack_if_gain_param_negative_gain_sign_extends() {
+        // stage=2, gain=-50 tenths. Wire stores -50 as a 16-bit
+        // two's-complement value (0xFFCE) in the lower half. The
+        // `as i16` cast must read it back as -50, NOT 0xFFCE
+        // (= 65486) — that's the sign-extension regression this
+        // test pins. Mirrors upstream rtl_tcp.c's `(short)` cast.
+        let gain_wire = u32::from((-50i16) as u16);
+        let param = (0x0002_u32 << 16) | gain_wire;
+        assert_eq!(unpack_if_gain_param(param), (2, -50));
+    }
+
+    #[test]
+    fn unpack_if_gain_param_boundary_values() {
+        // i16::MAX stage + i16::MIN gain — exercises both extremes
+        // of the signed 16-bit interpretation.
+        let stage_wire = u32::from(i16::MAX as u16) << 16;
+        let gain_wire = u32::from(i16::MIN as u16);
+        assert_eq!(
+            unpack_if_gain_param(stage_wire | gain_wire),
+            (i16::MAX, i16::MIN)
+        );
+    }
+
+    #[test]
+    fn unpack_if_gain_param_zero_returns_zero() {
+        assert_eq!(unpack_if_gain_param(0), (0, 0));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #308. Final rtl_tcp dispatch-loop gap — `CommandOp::SetIfGain` (0x06) was a logged no-op pending this driver work. Now dispatches to the real tuner.

Faithful port of upstream librtlsdr:
- `Tuner` trait gains `set_if_gain(handle, stage, gain)` with a default `Ok(())` impl. R820T / R828D / FC0012 / FC0013 / FC2580 inherit the no-op (matches upstream — those tuners have no IF-stage control).
- E4000 overrides with the register-write path, reusing the existing `E4kTuner::if_gain_set`. Gain tenths-of-dB → i8 dB conversion via `(gain / 10) as i8` matches upstream's `(int8_t)(gain / 10)` bare cast.
- `RtlSdrDevice::set_tuner_if_gain` follows the i2c-repeater wrap convention from the existing gain methods.
- Server dispatch wire-decode pulled into a pure `unpack_if_gain_param` helper for unit-testability.

### Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` — **850 pass** (846 before, +4 for `unpack_if_gain_param` positive / negative-sign-extended / boundary / zero coverage)
- [ ] End-to-end smoke: your dongle is R820T so the E4000 register-write path is cosmetic on your hardware. R820T stays a no-op → command 0x06 returns Ok → debug log emits. Verified by spinning a local rtl_tcp server and running `nc 127.0.0.1 1234` with a crafted 0x06 payload, or just exercising a client that emits IF-gain commands (SDR++ doesn't, but GNU Radio's `rtl_tcp` source can).

### Notes for reviewers

- Clippy allows on the `as i16` / `as u8` / `as i8` casts all carry `reason = "..."` attributes naming the upstream C site they mirror.
- No change to existing `set_tuner_gain` / `set_tuner_gain_mode` paths. R820T's gain table-driven behavior is untouched.
- The dispatch-loop arm previously logged at `debug!` and dropped; it now logs + calls the real method. The doc comment at the top of `dispatch.rs` already mentioned this was pending #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IF (intermediate frequency) gain control added: tuners can receive stage-specific IF gain settings; E4000 tuners support the full staged gain LUT and other tuners silently ignore the command.

* **Bug Fixes**
  * Remote "set IF gain" commands are now forwarded to attached tuners instead of being ignored.

* **Tests**
  * Added unit tests for wire parameter unpacking (positive, negative, boundary, zero).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->