### PR TITLE
fix: UI↔DSP sync for VFO-drag bandwidth + RTL-SDR device probe (closes #336, #297)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -524,6 +524,13 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             }
             // Also pass to the radio module (some demods use it internally).
             state.radio.set_bandwidth(bw);
+            // Notify UI so widgets that initiate bandwidth changes
+            // via a different path (VFO drag handles on the
+            // spectrum) can reflect the new value in the Radio
+            // panel's bandwidth spin row. The `bandwidth_row`'s
+            // own `set_value` path guards against feedback loops
+            // via a `suppress_notify` flag on the UI side.
+            let _ = dsp_tx.send(DspToUi::BandwidthChanged(state.bandwidth));
         }
 
         UiToDsp::SetSquelch(level) => {

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -248,6 +248,18 @@ mod tests {
     }
 
     #[test]
+    fn bandwidth_changed_message_constructs() {
+        // Pins the variant shape + payload round-trip so future
+        // refactors that accidentally change the f64 carrier
+        // (e.g. to `u32` Hz or a `Bandwidth` newtype) trip this
+        // test. Value is NFM's default bandwidth, matching what
+        // the VFO-drag feedback loop most commonly emits in
+        // practice.
+        let bw = DspToUi::BandwidthChanged(12_500.0);
+        assert!(matches!(bw, DspToUi::BandwidthChanged(v) if (v - 12_500.0).abs() < f64::EPSILON));
+    }
+
+    #[test]
     fn ctcss_sustained_changed_message_constructs() {
         let open = DspToUi::CtcssSustainedChanged(true);
         assert!(matches!(open, DspToUi::CtcssSustainedChanged(true)));

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -206,6 +206,13 @@ pub enum UiToDsp {
 mod tests {
     use super::*;
 
+    /// Fixed bandwidth used by the message-variant round-trip
+    /// tests. 12.5 kHz is NFM's default and the value the VFO-drag
+    /// feedback loop most commonly emits in practice — hoisting it
+    /// to a const both removes the magic-number duplication in the
+    /// construct + match and documents the choice of value.
+    const TEST_BANDWIDTH_HZ: f64 = 12_500.0;
+
     #[test]
     fn test_dsp_to_ui_variants() {
         let fft = DspToUi::FftData(vec![1.0, 2.0, 3.0]);
@@ -252,11 +259,11 @@ mod tests {
         // Pins the variant shape + payload round-trip so future
         // refactors that accidentally change the f64 carrier
         // (e.g. to `u32` Hz or a `Bandwidth` newtype) trip this
-        // test. Value is NFM's default bandwidth, matching what
-        // the VFO-drag feedback loop most commonly emits in
-        // practice.
-        let bw = DspToUi::BandwidthChanged(12_500.0);
-        assert!(matches!(bw, DspToUi::BandwidthChanged(v) if (v - 12_500.0).abs() < f64::EPSILON));
+        // test.
+        let bw = DspToUi::BandwidthChanged(TEST_BANDWIDTH_HZ);
+        assert!(
+            matches!(bw, DspToUi::BandwidthChanged(v) if (v - TEST_BANDWIDTH_HZ).abs() < f64::EPSILON)
+        );
     }
 
     #[test]

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -38,6 +38,20 @@ pub enum DspToUi {
     /// transcription session (band change = new session boundary) and
     /// to re-run Auto Break row visibility rules.
     DemodModeChanged(DemodMode),
+    /// Channel bandwidth changed. Emitted from the controller's
+    /// `SetBandwidth` handler after the new value has been applied
+    /// to `state.vfo`, `state.radio`, and `state.bandwidth`. Lets
+    /// the Radio sidebar panel's bandwidth spin row reflect drags
+    /// initiated from the spectrum VFO handles — without this, the
+    /// spin row would go stale relative to the DSP and confuse the
+    /// user about the active filter width.
+    ///
+    /// Emitted on every successful `SetBandwidth` application, not
+    /// edge-filtered — the spin row's `set_value` is idempotent
+    /// when called with its current value, so the cost is
+    /// negligible and emitting unconditionally keeps the controller
+    /// free of per-field before/after comparisons.
+    BandwidthChanged(f64),
     /// CTCSS sustained-gate state changed. Emitted only on edges
     /// (closed → open / open → closed), not per-window, so the UI
     /// status indicator can subscribe without flooding the channel.

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -300,6 +300,7 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         | DspToUi::IqRecordingStarted(_)
         | DspToUi::IqRecordingStopped
         | DspToUi::DemodModeChanged(_)
+        | DspToUi::BandwidthChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
         | DspToUi::VoiceSquelchOpenChanged(_)
         | DspToUi::RtlTcpConnectionState(_) => return None,

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -36,6 +36,39 @@ pub const DEVICE_FILE: u32 = 2;
 /// Device selector index for RTL-TCP (rtl_tcp-protocol network client).
 pub const DEVICE_RTLTCP: u32 = 3;
 
+/// Label shown in the source combo's RTL-SDR slot when no dongle
+/// is detected on the USB bus. Kept as a pub const so the hotplug
+/// poller and the probe helper render identical text.
+pub const RTLSDR_ABSENT_LABEL: &str = "No RTL-SDR device found";
+
+/// Probe the USB bus for an RTL-SDR dongle and return the label
+/// to show in the source combo's RTL-SDR slot (index 0).
+///
+/// Returns the librtlsdr device name of the first matching device
+/// when present (e.g. `"Generic RTL2832U OEM"`), or
+/// [`RTLSDR_ABSENT_LABEL`] when the bus has no dongle. Cheap
+/// enough to call from a 3 s hotplug poller on the GTK main
+/// thread — `sdr_rtlsdr::get_device_count` is a libusb enumerate
+/// filtered by vendor/product ID, and `get_device_name` re-runs
+/// the same enumerate to reach the Nth match.
+///
+/// When `get_device_count` reports > 0 but `get_device_name`
+/// returns an empty string (shouldn't happen outside of a race
+/// where the device was unplugged between the two enumerate
+/// calls), we fall back to the generic "RTL-SDR" label so the
+/// UI stays usable rather than rendering an empty combo entry.
+pub fn probe_rtlsdr_device_label() -> String {
+    if sdr_rtlsdr::get_device_count() == 0 {
+        return RTLSDR_ABSENT_LABEL.to_string();
+    }
+    let name = sdr_rtlsdr::get_device_name(0);
+    if name.is_empty() {
+        "RTL-SDR".to_string()
+    } else {
+        name
+    }
+}
+
 /// Default subtitle for the RTL-TCP status row before any
 /// `DspToUi::RtlTcpConnectionState` event has arrived (or after a
 /// Disconnect). Kept as a const so the empty-at-startup and
@@ -107,6 +140,12 @@ pub struct SourcePanel {
     pub widget: adw::PreferencesGroup,
     /// Device type selector (RTL-SDR, Network).
     pub device_row: adw::ComboRow,
+    /// Backing `StringList` for `device_row`. Exposed so a
+    /// hotplug poller can update the RTL-SDR slot's label (entry
+    /// index 0) via `splice` when the probed device name or
+    /// presence changes, without replacing the whole model (which
+    /// would reset the selection).
+    pub device_model: gtk4::StringList,
     /// RTL-SDR sample rate selector.
     pub sample_rate_row: adw::ComboRow,
     /// RTL-SDR gain control.
@@ -384,7 +423,17 @@ pub fn build_source_panel() -> SourcePanel {
     // Order is load-bearing — matches `DEVICE_RTLSDR / NETWORK / FILE /
     // RTLTCP` index constants. If you change the order here, update the
     // constants AND the `SourceType` match in window.rs at the same time.
-    let device_model = gtk4::StringList::new(&["RTL-SDR", "Network", "File", "RTL-TCP (network)"]);
+    // Initial label for the RTL-SDR slot — probed against the USB
+    // bus so a first-launch user without a dongle sees "No RTL-SDR
+    // device found" instead of the app lying that a dongle is
+    // present. Kept in sync with hotplug events by the probe
+    // poller wired in `connect_source_rtlsdr_probe` in window.rs.
+    let device_model = gtk4::StringList::new(&[
+        &probe_rtlsdr_device_label(),
+        "Network",
+        "File",
+        "RTL-TCP (network)",
+    ]);
     let device_row = adw::ComboRow::builder()
         .title("Device")
         .model(&device_model)
@@ -512,6 +561,7 @@ pub fn build_source_panel() -> SourcePanel {
     SourcePanel {
         widget: group,
         device_row,
+        device_model,
         sample_rate_row,
         gain_row,
         agc_row,

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -23,6 +23,15 @@ pub struct AppState {
     pub demod_mode: Cell<DemodMode>,
     /// Sender for dispatching commands to the DSP thread.
     pub ui_tx: mpsc::Sender<UiToDsp>,
+    /// Re-entrancy guard for programmatic `bandwidth_row.set_value`
+    /// calls from the `DspToUi::BandwidthChanged` handler. Toggled
+    /// true before the `set_value`, cleared after, and checked in
+    /// the spin row's `connect_value_notify` handler — prevents a DSP-
+    /// originated bandwidth update (e.g. from a VFO drag) from
+    /// bouncing back as a redundant `UiToDsp::SetBandwidth` dispatch
+    /// which would in turn re-emit `BandwidthChanged` and waste a
+    /// round trip per UI reflection.
+    pub suppress_bandwidth_notify: Cell<bool>,
 }
 
 impl AppState {
@@ -35,6 +44,7 @@ impl AppState {
             center_frequency: Cell::new(DEFAULT_CENTER_FREQUENCY_HZ),
             demod_mode: Cell::new(DemodMode::Wfm),
             ui_tx,
+            suppress_bandwidth_notify: Cell::new(false),
         })
     }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3301,12 +3301,25 @@ fn connect_source_rtlsdr_probe(panels: &SidebarPanels) {
     let widget_weak = panels.source.widget.downgrade();
     let model_weak = panels.source.device_model.downgrade();
     // Cached label from the last tick so we only rewrite on a
-    // real edge. Seeded to match the initial label set in
-    // `build_source_panel` so the first tick doesn't flip the
-    // slot back to itself.
-    let last_label: Rc<RefCell<String>> = Rc::new(RefCell::new(
-        sidebar::source_panel::probe_rtlsdr_device_label(),
-    ));
+    // real edge. Seed from the model's current `DEVICE_RTLSDR`
+    // entry — NOT from a fresh probe — so we're comparing
+    // subsequent probes against what the UI is actually showing.
+    //
+    // A second probe here would race the USB state: if the user
+    // unplugs their dongle between `build_source_panel` (which
+    // ran the initial probe + seed) and this wiring point, a
+    // second probe would read the new bus state, cache it as
+    // `last_label`, and then every subsequent tick's probe would
+    // match the cache — the combo would stay on the stale plugged-
+    // in name forever (or until the NEXT plug / unplug edge
+    // briefly desynced them again). Reading the model directly
+    // guarantees first-tick reconciliation.
+    let seed_label = panels
+        .source
+        .device_model
+        .string(DEVICE_RTLSDR)
+        .map_or_else(String::new, |s| s.to_string());
+    let last_label: Rc<RefCell<String>> = Rc::new(RefCell::new(seed_label));
     let _ = glib::timeout_add_local(SOURCE_RTLSDR_PROBE_INTERVAL, move || {
         if widget_weak.upgrade().is_none() {
             return glib::ControlFlow::Break;

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -608,6 +608,23 @@ fn handle_dsp_message(
                 }
             }
         }
+        DspToUi::BandwidthChanged(bw) => {
+            // DSP-originated bandwidth change (typically a VFO drag
+            // on the spectrum). Reflect it in the Radio panel's
+            // spin row so the numeric readout stays in lockstep
+            // with the active filter width.
+            //
+            // Set the suppress flag around the `set_value` call so
+            // the spin's `connect_value_notify` handler knows this
+            // update is DSP-originated and doesn't dispatch a
+            // redundant `UiToDsp::SetBandwidth` back to the
+            // controller. Restored after the set_value returns so
+            // user-originated edits from the next event loop tick
+            // are dispatched normally.
+            state.suppress_bandwidth_notify.set(true);
+            radio_panel.bandwidth_row.set_value(bw);
+            state.suppress_bandwidth_notify.set(false);
+        }
         DspToUi::CtcssSustainedChanged(sustained) => {
             tracing::debug!(sustained, "CTCSS sustained-gate edge");
             radio_panel.set_ctcss_sustained(sustained);
@@ -3545,9 +3562,19 @@ fn connect_source_panel(
 /// Connect radio panel controls to DSP commands.
 #[allow(clippy::too_many_lines)]
 fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
-    // Bandwidth
+    // Bandwidth. The DSP can originate a change too (VFO drag on
+    // the spectrum dispatches `UiToDsp::SetBandwidth` directly,
+    // and the controller echoes `DspToUi::BandwidthChanged` so the
+    // spin row reflects the drag). The echo path updates this row
+    // via `set_value` which re-fires `connect_value_notify` —
+    // `suppress_bandwidth_notify` breaks the cycle by telling this
+    // handler to skip the DSP dispatch when the change originated
+    // on the DSP side.
     let state_bw = Rc::clone(state);
     panels.radio.bandwidth_row.connect_value_notify(move |row| {
+        if state_bw.suppress_bandwidth_notify.get() {
+            return;
+        }
         state_bw.send_dsp(UiToDsp::SetBandwidth(row.value()));
     });
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3322,13 +3322,17 @@ fn connect_source_rtlsdr_probe(panels: &SidebarPanels) {
                 current = %current,
                 "source panel: RTL-SDR slot label updated",
             );
-            // Replace entry 0 in the StringList. `splice(pos, n,
-            // additions)` removes `n` items at `pos` and inserts
-            // `additions` — so `(0, 1, &[&current])` is a
-            // single-entry in-place swap. Leaves Network / File /
-            // RTL-TCP entries untouched so their indices stay
-            // pinned to the `DEVICE_*` constants.
-            model.splice(0, 1, &[&current]);
+            // Replace the RTL-SDR slot in the StringList.
+            // `splice(pos, n, additions)` removes `n` items at
+            // `pos` and inserts `additions` — so `(DEVICE_RTLSDR,
+            // 1, &[&current])` is a single-entry in-place swap.
+            // Using the shared `DEVICE_RTLSDR` constant instead
+            // of a literal `0` keeps the probe aligned with the
+            // rest of the source-row selection logic; all four
+            // `DEVICE_*` indices are the one source of truth for
+            // slot positions. Leaves Network / File / RTL-TCP
+            // entries untouched.
+            model.splice(DEVICE_RTLSDR, 1, &[&current]);
             *last = current;
         }
         glib::ControlFlow::Continue

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1074,6 +1074,7 @@ fn connect_sidebar_panels(
     let server_running: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
 
     connect_source_panel(panels, state, toast_overlay, Rc::clone(&server_running));
+    connect_source_rtlsdr_probe(panels);
     connect_rtl_tcp_discovery(panels, state, config, favorites_header);
     connect_server_panel(panels, toast_overlay, server_running);
     connect_radio_panel(panels, state);
@@ -3265,6 +3266,73 @@ fn format_age(elapsed: Duration) -> String {
     } else {
         format!("{}h ago", secs / 3600)
     }
+}
+
+/// Interval for refreshing the source combo's RTL-SDR slot label
+/// against the live USB bus. Low-frequency enough to be
+/// negligible CPU-wise; fast enough that a user plugging in their
+/// dongle after app launch sees the slot update to the real
+/// device name within a few seconds without having to restart.
+///
+/// Shares cadence with `SERVER_PANEL_HOTPLUG_POLL_INTERVAL` as a
+/// deliberate choice — both pollers watch the same libusb bus for
+/// the same vendor/product-filtered device set, so users see
+/// both the source combo and the server panel update on the same
+/// tick. Kept as a separate constant so each poller's sizing can
+/// evolve independently.
+const SOURCE_RTLSDR_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Install a hotplug poller on the source panel that keeps the
+/// RTL-SDR slot label (`device_row` entry 0) in sync with the
+/// live USB bus. Seeded once at build-time (inside
+/// `build_source_panel`); this helper adds the ongoing refresh.
+///
+/// Compared against a cached last-seen label so the `splice` fires
+/// only on real edges — plugging in, unplugging, or USB string
+/// changing. Without the edge gate we'd churn the combo's model
+/// every 3 s and risk transient selection flicker (though GTK's
+/// `ComboRow` is robust to same-value splices, the no-op is
+/// cheaper to skip than to perform).
+///
+/// Weak ref on the source panel's `widget` so the poller tears
+/// down cleanly on window close — upgrade returns `None` and the
+/// `ControlFlow::Break` arm fires.
+fn connect_source_rtlsdr_probe(panels: &SidebarPanels) {
+    let widget_weak = panels.source.widget.downgrade();
+    let model_weak = panels.source.device_model.downgrade();
+    // Cached label from the last tick so we only rewrite on a
+    // real edge. Seeded to match the initial label set in
+    // `build_source_panel` so the first tick doesn't flip the
+    // slot back to itself.
+    let last_label: Rc<RefCell<String>> = Rc::new(RefCell::new(
+        sidebar::source_panel::probe_rtlsdr_device_label(),
+    ));
+    let _ = glib::timeout_add_local(SOURCE_RTLSDR_PROBE_INTERVAL, move || {
+        if widget_weak.upgrade().is_none() {
+            return glib::ControlFlow::Break;
+        }
+        let Some(model) = model_weak.upgrade() else {
+            return glib::ControlFlow::Break;
+        };
+        let current = sidebar::source_panel::probe_rtlsdr_device_label();
+        let mut last = last_label.borrow_mut();
+        if *last != current {
+            tracing::debug!(
+                previous = %*last,
+                current = %current,
+                "source panel: RTL-SDR slot label updated",
+            );
+            // Replace entry 0 in the StringList. `splice(pos, n,
+            // additions)` removes `n` items at `pos` and inserts
+            // `additions` — so `(0, 1, &[&current])` is a
+            // single-entry in-place swap. Leaves Network / File /
+            // RTL-TCP entries untouched so their indices stay
+            // pinned to the `DEVICE_*` constants.
+            model.splice(0, 1, &[&current]);
+            *last = current;
+        }
+        glib::ControlFlow::Continue
+    });
 }
 
 #[allow(


### PR DESCRIPTION
Two related but independent UI↔DSP sync fixes. Both ride the feedback-event pattern that `SampleRateChanged` / `DemodModeChanged` / `RtlTcpConnectionState` already established in earlier rtl_tcp work — DSP is the authority for this state, UI reflects.

## Summary

- **#336**: VFO drag handles on the spectrum dispatched `UiToDsp::SetBandwidth` correctly, but the Radio sidebar's bandwidth spin row had no echo path — went stale relative to the active filter width. New `DspToUi::BandwidthChanged(f64)` variant emitted from the controller's `SetBandwidth` handler after the VFO + radio module apply succeeds. UI handler calls `bandwidth_row.set_value(bw)` with a `suppress_bandwidth_notify: Cell<bool>` re-entrancy guard on `AppState` so the programmatic update doesn't bounce back as a redundant `UiToDsp::SetBandwidth` dispatch.
- **#297**: Source panel device combo was hardcoded to `["RTL-SDR", "Network", "File", "RTL-TCP"]`, so a first-launch user with no dongle saw "RTL-SDR" and got an error on Play. `probe_rtlsdr_device_label()` runs `sdr_rtlsdr::get_device_count` + `get_device_name(0)` and returns either the detected device name or "No RTL-SDR device found". `build_source_panel` seeds entry 0 at startup; `connect_source_rtlsdr_probe` installs a 3 s hotplug poller that updates entry 0 via `StringList::splice(0, 1, &[label])` on label edges — Network/File/RTL-TCP indices stay pinned to the `DEVICE_*` constants.

## Commits

1. `fix(#336): feedback DspToUi::BandwidthChanged so VFO drag syncs the spin row` — `sdr-core` messages + controller, `sdr-ui` handler + `suppress_bandwidth_notify` flag, `sdr-ffi` adds to the GTK-UI-internal event list alongside `DemodModeChanged`
2. `fix(#297): probe USB bus for RTL-SDR and reflect in source combo` — `sdr-ui::sidebar::source_panel::probe_rtlsdr_device_label` + `SourcePanel.device_model` field + `connect_source_rtlsdr_probe` hotplug poller

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — all green, no regressions
- [x] `cargo fmt -- --check` clean
- [x] `cargo deny` + `cargo audit` clean
- [x] Smoke tested on Linux + `sherpa-cuda`:
  - VFO drag (both handles, both directions) updates the Radio panel bandwidth spin row in real time; manual spin edits still dispatch cleanly; bookmark save captures drag-derived bandwidth
  - Device combo probes correctly: dongle plugged in → device name, unplugged → "No RTL-SDR device found", hotplug flips within ~3 s either direction, no restart needed
  - Network / File / RTL-TCP entries preserved across label updates

## Out of scope / follow-ups

- **#341** — VFO reset affordances (on-spectrum floating button for one-click undo + per-field reset icons on bandwidth / offset rows). Design discussed during smoke-test; deferred to its own ticket so this PR stays focused on the sync bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bandwidth changes now notify the UI so all bandwidth controls stay synchronized.
  * RTL‑SDR slot shows actual device names or a clear "No RTL‑SDR device found" label and exposes the device list model for hotplug updates.
  * Device list is refreshed automatically on a periodic probe.

* **Bug Fixes**
  * Added a guard to prevent feedback loops when programmatic bandwidth updates propagate between UI and DSP.

* **Tests**
  * Added a unit test verifying the bandwidth-change message payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->