### PR TITLE
fix: engine audio quality — squelch envelope + AGC mutexes + FM AF-AGC (closes #331, #332)

### DIFF
--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -162,12 +162,19 @@ impl SquelchAudioEnvelope {
     /// Both L and R receive the same per-sample gain so stereo
     /// imaging is preserved across the transition.
     pub fn process_stereo(&mut self, buf: &mut [sdr_types::Stereo]) {
+        // `target` is stable for the call, and the rising /
+        // falling direction depends on `target > envelope_gain`.
+        // Within one call `envelope_gain` only crosses the target
+        // asymptotically (IIR, never overshoots by construction)
+        // so the direction — and therefore the coefficient — is
+        // constant for the whole buffer. Hoisting the branch out
+        // of the hot loop removes a per-sample compare.
+        let coeff = if self.target > self.envelope_gain {
+            self.attack_coeff
+        } else {
+            self.release_coeff
+        };
         for s in buf.iter_mut() {
-            let coeff = if self.target > self.envelope_gain {
-                self.attack_coeff
-            } else {
-                self.release_coeff
-            };
             self.envelope_gain += (self.target - self.envelope_gain) * coeff;
             s.l *= self.envelope_gain;
             s.r *= self.envelope_gain;

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -42,6 +42,133 @@ const AUTO_SQUELCH_OPEN_MARGIN_DB: f32 = 10.0;
 /// it stays open until it drops closer to the noise floor.
 const AUTO_SQUELCH_CLOSE_MARGIN_DB: f32 = 6.0;
 
+/// Attack time constant for the squelch gain envelope, in seconds.
+///
+/// 2 ms is short enough that a keying-up transmission's leading edge
+/// isn't audibly ramped (the user doesn't perceive the fade-in), but
+/// long enough that the step discontinuity is smoothed past any
+/// downstream audio-sink resampler's ringing (see issue #331: macOS
+/// AUHAL's internal 48 kHz → 44.1 kHz SRC rings hard on sub-ms steps
+/// and produces the loud pop users reported).
+const SQUELCH_ATTACK_SECONDS: f32 = 0.002;
+
+/// Release time constant for the squelch gain envelope, in seconds.
+///
+/// 5 ms is deliberately longer than the attack so we don't clip the
+/// tail of a word when the squelch closes mid-utterance. The attack-
+/// release asymmetry is a deliberate ergonomic choice: bright on, soft
+/// off — mirrors the SDR++ `PowerSquelch` envelope pattern referenced
+/// in issue #331.
+const SQUELCH_RELEASE_SECONDS: f32 = 0.005;
+
+/// Compute the one-pole IIR coefficient that reaches ~63% of the gap
+/// toward the target in `tau_seconds` at `sample_rate_hz`. Standard
+/// exponential-decay form: `α = 1 - exp(-Δt / τ)` where `Δt = 1 /
+/// sample_rate_hz`. Returns `1.0` (instant transition) on zero or
+/// negative inputs so a misconfigured caller degrades to the pre-
+/// envelope hard-gate behavior rather than panicking on divide-by-zero.
+fn envelope_coefficient(tau_seconds: f32, sample_rate_hz: f32) -> f32 {
+    if sample_rate_hz <= 0.0 || tau_seconds <= 0.0 {
+        return 1.0;
+    }
+    (-1.0 / (tau_seconds * sample_rate_hz))
+        .exp()
+        .mul_add(-1.0, 1.0)
+}
+
+/// Per-sample attack/release envelope applied to the **audio
+/// output** after FM/AM demodulation to smooth squelch gate
+/// transitions. Lives in the AF path (not the IF path) because
+/// FM discriminators are amplitude-invariant — scaling the IQ
+/// input has zero effect on FM audio output, so the gate-
+/// transition pop has to be attenuated post-demod.
+///
+/// The owning module (`RadioModule` today) drives `target` via
+/// [`set_gate_open`] on every process call using the IF-level
+/// `PowerSquelch`'s `is_open()` state; this struct's [`process`]
+/// ramps the per-sample gain toward the target and applies it
+/// uniformly to both stereo channels so imaging is preserved.
+///
+/// Attack/release asymmetry is deliberate: fast open (~2 ms) so
+/// keying-up leading edges aren't audibly faded, slow close
+/// (~5 ms) so tails of dropped words aren't clipped.
+pub struct SquelchAudioEnvelope {
+    envelope_gain: f32,
+    target: f32,
+    attack_coeff: f32,
+    release_coeff: f32,
+}
+
+impl SquelchAudioEnvelope {
+    /// Construct an envelope for audio running at
+    /// `sample_rate_hz`. Coefficients are seeded from the
+    /// `SQUELCH_ATTACK_SECONDS` / `SQUELCH_RELEASE_SECONDS` time
+    /// constants; call [`set_sample_rate`] if the audio rate
+    /// changes at runtime.
+    #[must_use]
+    pub fn new(sample_rate_hz: f32) -> Self {
+        Self {
+            envelope_gain: 0.0,
+            target: 0.0,
+            attack_coeff: envelope_coefficient(SQUELCH_ATTACK_SECONDS, sample_rate_hz),
+            release_coeff: envelope_coefficient(SQUELCH_RELEASE_SECONDS, sample_rate_hz),
+        }
+    }
+
+    /// Update the target gain: `true` (gate open) ramps to 1.0,
+    /// `false` (gate closed) ramps to 0.0. No-op if the target
+    /// matches the current setting so repeated calls from a
+    /// block-level caller are cheap.
+    pub fn set_gate_open(&mut self, open: bool) {
+        self.target = if open { 1.0 } else { 0.0 };
+    }
+
+    /// Recompute the attack / release coefficients for a new
+    /// audio sample rate. Preserves `envelope_gain` so the
+    /// recomputation doesn't snap mid-utterance.
+    pub fn set_sample_rate(&mut self, sample_rate_hz: f32) {
+        self.attack_coeff = envelope_coefficient(SQUELCH_ATTACK_SECONDS, sample_rate_hz);
+        self.release_coeff = envelope_coefficient(SQUELCH_RELEASE_SECONDS, sample_rate_hz);
+    }
+
+    /// Reset the envelope to the closed-gate state. Use when
+    /// swapping the upstream demod (mode change) so stale gain
+    /// state from the previous mode doesn't bleed through the
+    /// first block of the new one.
+    pub fn reset(&mut self) {
+        self.envelope_gain = 0.0;
+        self.target = 0.0;
+    }
+
+    /// Force the envelope to the fully-open state (gain = 1.0,
+    /// target = 1.0). Used by `RadioModule::process` when the
+    /// user has squelch disabled so the envelope doesn't need
+    /// to ramp up from 0 on every block. Keeps state coherent
+    /// for when the user re-enables squelch: first post-enable
+    /// block starts at full passthrough and the normal open /
+    /// close ramping takes over from there.
+    pub fn reset_to_open(&mut self) {
+        self.envelope_gain = 1.0;
+        self.target = 1.0;
+    }
+
+    /// Apply the envelope to a stereo audio buffer in place.
+    /// Both L and R receive the same per-sample gain so stereo
+    /// imaging is preserved across the transition.
+    pub fn process_stereo(&mut self, buf: &mut [sdr_types::Stereo]) {
+        for s in buf.iter_mut() {
+            let coeff = if self.target > self.envelope_gain {
+                self.attack_coeff
+            } else {
+                self.release_coeff
+            };
+            self.envelope_gain += (self.target - self.envelope_gain) * coeff;
+            s.l *= self.envelope_gain;
+            s.r *= self.envelope_gain;
+        }
+    }
+}
+
 /// Power squelch — gates signal based on average power level.
 ///
 /// Ports SDR++ `dsp::noise_reduction::PowerSquelch`. Computes the mean
@@ -188,6 +315,17 @@ impl PowerSquelch {
             output[..input.len()].copy_from_slice(input);
             self.open = true;
         } else {
+            // Hard-zero the IQ on closed state — FM discriminators
+            // are amplitude-invariant (they read atan2 of the phase
+            // delta between consecutive samples, which ignores a
+            // common scaling), so a "smooth" amplitude envelope on
+            // IQ would have zero effect on FM audio output. The
+            // exact zero here gives `atan2(0, 0) = 0`, producing
+            // genuinely silent FM demod output. The transition-
+            // pop smoothing lives in the AF path
+            // (`SquelchAudioEnvelope` in `sdr-radio::lib::RadioModule`)
+            // where it can act on post-demod audio regardless of
+            // modulation type.
             output[..input.len()].fill(Complex::default());
             self.open = false;
         }
@@ -529,6 +667,105 @@ mod tests {
             squelch_open.is_open(),
             "amplitude 0.1 (-20 dB) should be above -25 dB threshold"
         );
+    }
+
+    // --- Squelch audio envelope tests (#331) ---
+
+    /// Fresh envelope starts muted: gate target 0.0, gain 0.0.
+    /// A stereo buffer processed without any `set_gate_open` call
+    /// should stay silent.
+    #[test]
+    fn squelch_audio_envelope_starts_muted() {
+        use sdr_types::Stereo;
+        let mut env = SquelchAudioEnvelope::new(48_000.0);
+        let mut buf = vec![Stereo { l: 0.5, r: 0.5 }; 100];
+        env.process_stereo(&mut buf);
+        for (i, s) in buf.iter().enumerate() {
+            assert!(s.l.abs() < 1e-6, "sample {i} L not silenced: {}", s.l);
+            assert!(s.r.abs() < 1e-6, "sample {i} R not silenced: {}", s.r);
+        }
+    }
+
+    /// Attack ramp: on gate open, the per-sample gain rises
+    /// smoothly toward 1.0. After several ms the envelope has
+    /// converged and the output matches the input.
+    #[test]
+    fn squelch_audio_envelope_ramps_up_on_gate_open() {
+        use sdr_types::Stereo;
+        let mut env = SquelchAudioEnvelope::new(48_000.0);
+        env.set_gate_open(true);
+        let mut buf = vec![Stereo { l: 1.0, r: 1.0 }; 1000];
+        env.process_stereo(&mut buf);
+        // First sample: partially ramped up. Not the full input
+        // (that would be a hard gate), not zero (that would be
+        // stuck muted).
+        assert!(buf[0].l > 0.0 && buf[0].l < 0.5);
+        // By sample 500 (10 ms at 48 kHz = 5 attack time
+        // constants) the envelope has converged.
+        assert!(
+            buf[500].l > 0.99,
+            "envelope should converge by sample 500, got {}",
+            buf[500].l
+        );
+    }
+
+    /// Release ramp on gate close: envelope decays smoothly
+    /// toward 0 across ~5 ms. Tail of the previous block's audio
+    /// is NOT clipped on the first sample after close.
+    #[test]
+    fn squelch_audio_envelope_preserves_tail_on_close() {
+        use sdr_types::Stereo;
+        let mut env = SquelchAudioEnvelope::new(48_000.0);
+        // Open and converge.
+        env.set_gate_open(true);
+        let mut ramp = vec![Stereo { l: 1.0, r: 1.0 }; 1000];
+        env.process_stereo(&mut ramp);
+
+        // Close and feed another block — first sample should
+        // be close to full amplitude (tail preserved), not 0.
+        env.set_gate_open(false);
+        let mut buf = vec![Stereo { l: 1.0, r: 1.0 }; 100];
+        env.process_stereo(&mut buf);
+        assert!(
+            buf[0].l > 0.9,
+            "first post-close sample should preserve the tail, got {}",
+            buf[0].l
+        );
+    }
+
+    /// Reset snaps back to the closed-gate state — used by
+    /// `RadioModule` on demod-mode change to prevent cross-
+    /// pipeline gain bleed.
+    #[test]
+    fn squelch_audio_envelope_reset_clears_gain() {
+        use sdr_types::Stereo;
+        let mut env = SquelchAudioEnvelope::new(48_000.0);
+        env.set_gate_open(true);
+        let mut buf = vec![Stereo { l: 1.0, r: 1.0 }; 1000];
+        env.process_stereo(&mut buf);
+
+        env.reset();
+        // First post-reset block should be silent (gain back to
+        // 0, target back to 0).
+        let mut buf = vec![Stereo { l: 1.0, r: 1.0 }; 100];
+        env.process_stereo(&mut buf);
+        for s in &buf {
+            assert!(s.l.abs() < 1e-6);
+        }
+    }
+
+    /// `envelope_coefficient` pathological-input guards — zero
+    /// or negative rate / tau fall back to instant-transition
+    /// `1.0` so misconfiguration degrades to the hard-gate
+    /// behavior rather than panicking on divide-by-zero.
+    #[test]
+    fn envelope_coefficient_handles_pathological_inputs() {
+        let coeff = envelope_coefficient(0.002, 48_000.0);
+        assert!(coeff > 0.0 && coeff < 1.0);
+        assert_eq!(envelope_coefficient(0.002, 0.0), 1.0);
+        assert_eq!(envelope_coefficient(0.002, -48_000.0), 1.0);
+        assert_eq!(envelope_coefficient(0.0, 48_000.0), 1.0);
+        assert_eq!(envelope_coefficient(-0.002, 48_000.0), 1.0);
     }
 
     // --- Noise Blanker tests ---

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -106,19 +106,42 @@ pub struct SquelchAudioEnvelope {
 }
 
 impl SquelchAudioEnvelope {
+    /// Validate that `sample_rate_hz` is usable for envelope
+    /// coefficient math: finite (not NaN / ±Inf) and strictly
+    /// positive. The inner `envelope_coefficient` helper already
+    /// degrades gracefully to 1.0 on bad inputs, but that
+    /// silently reinstates the exact hard-gate behavior this
+    /// type was introduced to avoid — surfacing the error at
+    /// the public API boundary means upstream misconfiguration
+    /// fails loudly instead of appearing as a stale "pop"
+    /// regression.
+    fn validate_sample_rate(sample_rate_hz: f32) -> Result<(), DspError> {
+        if !sample_rate_hz.is_finite() || sample_rate_hz <= 0.0 {
+            return Err(DspError::InvalidParameter(format!(
+                "sample_rate_hz must be finite and > 0, got {sample_rate_hz}"
+            )));
+        }
+        Ok(())
+    }
+
     /// Construct an envelope for audio running at
     /// `sample_rate_hz`. Coefficients are seeded from the
     /// `SQUELCH_ATTACK_SECONDS` / `SQUELCH_RELEASE_SECONDS` time
     /// constants; call [`set_sample_rate`] if the audio rate
     /// changes at runtime.
-    #[must_use]
-    pub fn new(sample_rate_hz: f32) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` when `sample_rate_hz`
+    /// is non-finite or non-positive.
+    pub fn new(sample_rate_hz: f32) -> Result<Self, DspError> {
+        Self::validate_sample_rate(sample_rate_hz)?;
+        Ok(Self {
             envelope_gain: 0.0,
             target: 0.0,
             attack_coeff: envelope_coefficient(SQUELCH_ATTACK_SECONDS, sample_rate_hz),
             release_coeff: envelope_coefficient(SQUELCH_RELEASE_SECONDS, sample_rate_hz),
-        }
+        })
     }
 
     /// Update the target gain: `true` (gate open) ramps to 1.0,
@@ -132,9 +155,18 @@ impl SquelchAudioEnvelope {
     /// Recompute the attack / release coefficients for a new
     /// audio sample rate. Preserves `envelope_gain` so the
     /// recomputation doesn't snap mid-utterance.
-    pub fn set_sample_rate(&mut self, sample_rate_hz: f32) {
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` when `sample_rate_hz`
+    /// is non-finite or non-positive. The existing `envelope_gain`
+    /// and coefficients are left untouched on error so a bad
+    /// rate update can't corrupt the envelope.
+    pub fn set_sample_rate(&mut self, sample_rate_hz: f32) -> Result<(), DspError> {
+        Self::validate_sample_rate(sample_rate_hz)?;
         self.attack_coeff = envelope_coefficient(SQUELCH_ATTACK_SECONDS, sample_rate_hz);
         self.release_coeff = envelope_coefficient(SQUELCH_RELEASE_SECONDS, sample_rate_hz);
+        Ok(())
     }
 
     /// Reset the envelope to the closed-gate state. Use when
@@ -721,7 +753,7 @@ mod tests {
     #[test]
     fn squelch_audio_envelope_starts_muted() {
         use sdr_types::Stereo;
-        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ);
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ).unwrap();
         // Use a non-zero input so the "output is 0" assertion is
         // actually exercising the envelope (an all-zero input
         // would pass even if the envelope were broken).
@@ -747,7 +779,7 @@ mod tests {
     #[test]
     fn squelch_audio_envelope_ramps_up_on_gate_open() {
         use sdr_types::Stereo;
-        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ);
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ).unwrap();
         env.set_gate_open(true);
         let mut buf = vec![
             Stereo {
@@ -776,7 +808,7 @@ mod tests {
     #[test]
     fn squelch_audio_envelope_preserves_tail_on_close() {
         use sdr_types::Stereo;
-        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ);
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ).unwrap();
         // Open and converge.
         env.set_gate_open(true);
         let mut ramp = vec![
@@ -812,7 +844,7 @@ mod tests {
     #[test]
     fn squelch_audio_envelope_reset_clears_gain() {
         use sdr_types::Stereo;
-        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ);
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ).unwrap();
         env.set_gate_open(true);
         let mut buf = vec![
             Stereo {
@@ -871,6 +903,69 @@ mod tests {
             envelope_coefficient(SQUELCH_ATTACK_SECONDS, f32::INFINITY),
             1.0
         );
+    }
+
+    /// `SquelchAudioEnvelope::new` must reject non-finite / non-
+    /// positive sample rates instead of silently degrading to a
+    /// hard gate — that's the exact pop behavior the type was
+    /// added to eliminate, so a misconfigured caller should get
+    /// a loud error rather than a silent regression.
+    #[test]
+    fn squelch_audio_envelope_new_rejects_invalid_sample_rates() {
+        assert!(matches!(
+            SquelchAudioEnvelope::new(0.0),
+            Err(DspError::InvalidParameter(_))
+        ));
+        assert!(matches!(
+            SquelchAudioEnvelope::new(-ENV_TEST_SAMPLE_RATE_HZ),
+            Err(DspError::InvalidParameter(_))
+        ));
+        assert!(matches!(
+            SquelchAudioEnvelope::new(f32::NAN),
+            Err(DspError::InvalidParameter(_))
+        ));
+        assert!(matches!(
+            SquelchAudioEnvelope::new(f32::INFINITY),
+            Err(DspError::InvalidParameter(_))
+        ));
+        assert!(matches!(
+            SquelchAudioEnvelope::new(f32::NEG_INFINITY),
+            Err(DspError::InvalidParameter(_))
+        ));
+        // Positive rate accepted.
+        assert!(SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ).is_ok());
+    }
+
+    /// `set_sample_rate` applies the same validation as `new`.
+    /// On rejection, the envelope's coefficients and gain state
+    /// must be left untouched so a bad rate update doesn't
+    /// corrupt a working envelope.
+    #[test]
+    fn squelch_audio_envelope_set_sample_rate_rejects_invalid_and_preserves_state() {
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ).unwrap();
+        let attack_before = env.attack_coeff;
+        let release_before = env.release_coeff;
+
+        assert!(matches!(
+            env.set_sample_rate(f32::NAN),
+            Err(DspError::InvalidParameter(_))
+        ));
+        assert!(matches!(
+            env.set_sample_rate(0.0),
+            Err(DspError::InvalidParameter(_))
+        ));
+        assert!(matches!(
+            env.set_sample_rate(-ENV_TEST_SAMPLE_RATE_HZ),
+            Err(DspError::InvalidParameter(_))
+        ));
+
+        // Coefficients must still match the original rate — the
+        // rejected calls should have left them alone.
+        assert_eq!(env.attack_coeff, attack_before);
+        assert_eq!(env.release_coeff, release_before);
+
+        // Valid update applies cleanly.
+        assert!(env.set_sample_rate(2.0 * ENV_TEST_SAMPLE_RATE_HZ).is_ok());
     }
 
     // --- Noise Blanker tests ---

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -64,11 +64,17 @@ const SQUELCH_RELEASE_SECONDS: f32 = 0.005;
 /// Compute the one-pole IIR coefficient that reaches ~63% of the gap
 /// toward the target in `tau_seconds` at `sample_rate_hz`. Standard
 /// exponential-decay form: `α = 1 - exp(-Δt / τ)` where `Δt = 1 /
-/// sample_rate_hz`. Returns `1.0` (instant transition) on zero or
-/// negative inputs so a misconfigured caller degrades to the pre-
-/// envelope hard-gate behavior rather than panicking on divide-by-zero.
+/// sample_rate_hz`. Returns `1.0` (instant transition) on non-finite,
+/// zero, or negative inputs so a misconfigured caller degrades to
+/// the pre-envelope hard-gate behavior rather than panicking on
+/// divide-by-zero OR poisoning the envelope with NaN / Inf that
+/// would propagate into every subsequent `envelope_gain` update.
 fn envelope_coefficient(tau_seconds: f32, sample_rate_hz: f32) -> f32 {
-    if sample_rate_hz <= 0.0 || tau_seconds <= 0.0 {
+    if !sample_rate_hz.is_finite()
+        || !tau_seconds.is_finite()
+        || sample_rate_hz <= 0.0
+        || tau_seconds <= 0.0
+    {
         return 1.0;
     }
     (-1.0 / (tau_seconds * sample_rate_hz))
@@ -85,7 +91,7 @@ fn envelope_coefficient(tau_seconds: f32, sample_rate_hz: f32) -> f32 {
 ///
 /// The owning module (`RadioModule` today) drives `target` via
 /// [`set_gate_open`] on every process call using the IF-level
-/// `PowerSquelch`'s `is_open()` state; this struct's [`process`]
+/// `PowerSquelch`'s `is_open()` state; this struct's [`process_stereo`]
 /// ramps the per-sample gain toward the target and applies it
 /// uniformly to both stereo channels so imaging is preserved.
 ///
@@ -612,6 +618,37 @@ mod tests {
     const SQUELCH_REG_CLOSE_DB: f32 = -15.0;
     const SQUELCH_REG_OPEN_DB: f32 = -25.0;
 
+    // --- Envelope test constants ---
+    //
+    // Canonical AF rate for envelope timing assertions. All block-
+    // size and convergence-sample constants below are derived from
+    // this rate paired with `SQUELCH_ATTACK_SECONDS` /
+    // `SQUELCH_RELEASE_SECONDS` — keeping them centralized makes it
+    // obvious which value to update if the time constants change.
+    const ENV_TEST_SAMPLE_RATE_HZ: f32 = 48_000.0;
+    /// Short block length used for "fresh envelope stays muted" and
+    /// "tail preserved across close" assertions — ~2 ms at 48 kHz.
+    const ENV_SHORT_BLOCK_SAMPLES: usize = 100;
+    /// Long block length used to let the attack envelope converge
+    /// fully before the convergence-sample assertion — 20 ms at
+    /// 48 kHz covers ~10 attack time constants.
+    const ENV_LONG_BLOCK_SAMPLES: usize = 1_000;
+    /// Index at which the attack envelope is expected to have
+    /// converged to within ~1% of the target. 500 samples at
+    /// 48 kHz = 10 ms, which is 5 attack time constants
+    /// (`SQUELCH_ATTACK_SECONDS = 0.002 s`) → `exp(-5) ≈ 0.0067`
+    /// residual, well under the 0.99 gain assertion.
+    const ENV_CONVERGENCE_SAMPLE_IDX: usize = 500;
+    /// Numerical tolerance for "silenced" assertions. Envelope
+    /// gain starts at literal 0.0 so output is exactly 0.0 by
+    /// construction; the epsilon is pro-forma against future
+    /// float-math drift.
+    const ENV_SILENCE_EPSILON: f32 = 1e-6;
+    /// Stereo sample amplitude used in envelope tests — arbitrary
+    /// unit value so gain multiplication reads directly as the
+    /// envelope state.
+    const ENV_STEREO_SAMPLE_AMP: f32 = 1.0;
+
     // --- Power Squelch tests ---
 
     #[test]
@@ -677,12 +714,23 @@ mod tests {
     #[test]
     fn squelch_audio_envelope_starts_muted() {
         use sdr_types::Stereo;
-        let mut env = SquelchAudioEnvelope::new(48_000.0);
-        let mut buf = vec![Stereo { l: 0.5, r: 0.5 }; 100];
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ);
+        // Use a non-zero input so the "output is 0" assertion is
+        // actually exercising the envelope (an all-zero input
+        // would pass even if the envelope were broken).
+        let mut buf = vec![Stereo { l: 0.5, r: 0.5 }; ENV_SHORT_BLOCK_SAMPLES];
         env.process_stereo(&mut buf);
         for (i, s) in buf.iter().enumerate() {
-            assert!(s.l.abs() < 1e-6, "sample {i} L not silenced: {}", s.l);
-            assert!(s.r.abs() < 1e-6, "sample {i} R not silenced: {}", s.r);
+            assert!(
+                s.l.abs() < ENV_SILENCE_EPSILON,
+                "sample {i} L not silenced: {}",
+                s.l
+            );
+            assert!(
+                s.r.abs() < ENV_SILENCE_EPSILON,
+                "sample {i} R not silenced: {}",
+                s.r
+            );
         }
     }
 
@@ -692,20 +740,26 @@ mod tests {
     #[test]
     fn squelch_audio_envelope_ramps_up_on_gate_open() {
         use sdr_types::Stereo;
-        let mut env = SquelchAudioEnvelope::new(48_000.0);
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ);
         env.set_gate_open(true);
-        let mut buf = vec![Stereo { l: 1.0, r: 1.0 }; 1000];
+        let mut buf = vec![
+            Stereo {
+                l: ENV_STEREO_SAMPLE_AMP,
+                r: ENV_STEREO_SAMPLE_AMP
+            };
+            ENV_LONG_BLOCK_SAMPLES
+        ];
         env.process_stereo(&mut buf);
         // First sample: partially ramped up. Not the full input
         // (that would be a hard gate), not zero (that would be
         // stuck muted).
         assert!(buf[0].l > 0.0 && buf[0].l < 0.5);
-        // By sample 500 (10 ms at 48 kHz = 5 attack time
-        // constants) the envelope has converged.
+        // By `ENV_CONVERGENCE_SAMPLE_IDX` (5 attack time constants
+        // at 48 kHz) the envelope is within ~1% of the target.
         assert!(
-            buf[500].l > 0.99,
-            "envelope should converge by sample 500, got {}",
-            buf[500].l
+            buf[ENV_CONVERGENCE_SAMPLE_IDX].l > 0.99,
+            "envelope should converge by sample {ENV_CONVERGENCE_SAMPLE_IDX}, got {}",
+            buf[ENV_CONVERGENCE_SAMPLE_IDX].l
         );
     }
 
@@ -715,16 +769,28 @@ mod tests {
     #[test]
     fn squelch_audio_envelope_preserves_tail_on_close() {
         use sdr_types::Stereo;
-        let mut env = SquelchAudioEnvelope::new(48_000.0);
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ);
         // Open and converge.
         env.set_gate_open(true);
-        let mut ramp = vec![Stereo { l: 1.0, r: 1.0 }; 1000];
+        let mut ramp = vec![
+            Stereo {
+                l: ENV_STEREO_SAMPLE_AMP,
+                r: ENV_STEREO_SAMPLE_AMP
+            };
+            ENV_LONG_BLOCK_SAMPLES
+        ];
         env.process_stereo(&mut ramp);
 
         // Close and feed another block — first sample should
         // be close to full amplitude (tail preserved), not 0.
         env.set_gate_open(false);
-        let mut buf = vec![Stereo { l: 1.0, r: 1.0 }; 100];
+        let mut buf = vec![
+            Stereo {
+                l: ENV_STEREO_SAMPLE_AMP,
+                r: ENV_STEREO_SAMPLE_AMP
+            };
+            ENV_SHORT_BLOCK_SAMPLES
+        ];
         env.process_stereo(&mut buf);
         assert!(
             buf[0].l > 0.9,
@@ -739,33 +805,65 @@ mod tests {
     #[test]
     fn squelch_audio_envelope_reset_clears_gain() {
         use sdr_types::Stereo;
-        let mut env = SquelchAudioEnvelope::new(48_000.0);
+        let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ);
         env.set_gate_open(true);
-        let mut buf = vec![Stereo { l: 1.0, r: 1.0 }; 1000];
+        let mut buf = vec![
+            Stereo {
+                l: ENV_STEREO_SAMPLE_AMP,
+                r: ENV_STEREO_SAMPLE_AMP
+            };
+            ENV_LONG_BLOCK_SAMPLES
+        ];
         env.process_stereo(&mut buf);
 
         env.reset();
         // First post-reset block should be silent (gain back to
         // 0, target back to 0).
-        let mut buf = vec![Stereo { l: 1.0, r: 1.0 }; 100];
+        let mut buf = vec![
+            Stereo {
+                l: ENV_STEREO_SAMPLE_AMP,
+                r: ENV_STEREO_SAMPLE_AMP
+            };
+            ENV_SHORT_BLOCK_SAMPLES
+        ];
         env.process_stereo(&mut buf);
         for s in &buf {
-            assert!(s.l.abs() < 1e-6);
+            assert!(s.l.abs() < ENV_SILENCE_EPSILON);
         }
     }
 
-    /// `envelope_coefficient` pathological-input guards — zero
-    /// or negative rate / tau fall back to instant-transition
-    /// `1.0` so misconfiguration degrades to the hard-gate
-    /// behavior rather than panicking on divide-by-zero.
+    /// `envelope_coefficient` pathological-input guards —
+    /// non-finite, zero, or negative rate / tau fall back to
+    /// instant-transition `1.0` so misconfiguration degrades to
+    /// the hard-gate behavior rather than panicking on divide-
+    /// by-zero OR poisoning the envelope with NaN / Inf.
     #[test]
     fn envelope_coefficient_handles_pathological_inputs() {
-        let coeff = envelope_coefficient(0.002, 48_000.0);
+        let coeff = envelope_coefficient(SQUELCH_ATTACK_SECONDS, ENV_TEST_SAMPLE_RATE_HZ);
         assert!(coeff > 0.0 && coeff < 1.0);
-        assert_eq!(envelope_coefficient(0.002, 0.0), 1.0);
-        assert_eq!(envelope_coefficient(0.002, -48_000.0), 1.0);
-        assert_eq!(envelope_coefficient(0.0, 48_000.0), 1.0);
-        assert_eq!(envelope_coefficient(-0.002, 48_000.0), 1.0);
+        assert_eq!(envelope_coefficient(SQUELCH_ATTACK_SECONDS, 0.0), 1.0);
+        assert_eq!(
+            envelope_coefficient(SQUELCH_ATTACK_SECONDS, -ENV_TEST_SAMPLE_RATE_HZ),
+            1.0
+        );
+        assert_eq!(envelope_coefficient(0.0, ENV_TEST_SAMPLE_RATE_HZ), 1.0);
+        assert_eq!(
+            envelope_coefficient(-SQUELCH_ATTACK_SECONDS, ENV_TEST_SAMPLE_RATE_HZ),
+            1.0
+        );
+        // Non-finite guards: NaN and ±Inf on either input must
+        // fall back to 1.0, not propagate into downstream
+        // `envelope_gain` math where they'd poison every block.
+        assert_eq!(envelope_coefficient(f32::NAN, ENV_TEST_SAMPLE_RATE_HZ), 1.0);
+        assert_eq!(envelope_coefficient(SQUELCH_ATTACK_SECONDS, f32::NAN), 1.0);
+        assert_eq!(
+            envelope_coefficient(f32::INFINITY, ENV_TEST_SAMPLE_RATE_HZ),
+            1.0
+        );
+        assert_eq!(
+            envelope_coefficient(SQUELCH_ATTACK_SECONDS, f32::INFINITY),
+            1.0
+        );
     }
 
     // --- Noise Blanker tests ---

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -937,17 +937,48 @@ mod tests {
     }
 
     /// `set_sample_rate` applies the same validation as `new`.
-    /// On rejection, the envelope's coefficients and gain state
+    /// On rejection, the envelope's coefficients AND gain state
     /// must be left untouched so a bad rate update doesn't
-    /// corrupt a working envelope.
+    /// corrupt a working envelope. Warm up the gain to a non-
+    /// trivial value before the rejection calls so the gain-
+    /// preservation assertion actually exercises the contract
+    /// (a fresh envelope's gain is 0.0, which would trivially
+    /// equal itself after any no-op).
     #[test]
     fn squelch_audio_envelope_set_sample_rate_rejects_invalid_and_preserves_state() {
+        use sdr_types::Stereo;
         let mut env = SquelchAudioEnvelope::new(ENV_TEST_SAMPLE_RATE_HZ).unwrap();
+        // Open the gate and run one block so envelope_gain lands
+        // somewhere nontrivially > 0.0 but < 1.0 — this is the
+        // mid-transition state where a state-clobbering bug in
+        // set_sample_rate would be most visible.
+        env.set_gate_open(true);
+        let mut warmup = vec![
+            Stereo {
+                l: ENV_STEREO_SAMPLE_AMP,
+                r: ENV_STEREO_SAMPLE_AMP,
+            };
+            ENV_SHORT_BLOCK_SAMPLES
+        ];
+        env.process_stereo(&mut warmup);
+        let gain_before = env.envelope_gain;
         let attack_before = env.attack_coeff;
         let release_before = env.release_coeff;
 
+        // All five invalid cases must produce `InvalidParameter`.
+        // ±Inf isn't trivially rejected by the `<= 0.0` clause
+        // alone — it's only caught by the `is_finite` guard, so
+        // including both directions pins the guard explicitly.
         assert!(matches!(
             env.set_sample_rate(f32::NAN),
+            Err(DspError::InvalidParameter(_))
+        ));
+        assert!(matches!(
+            env.set_sample_rate(f32::INFINITY),
+            Err(DspError::InvalidParameter(_))
+        ));
+        assert!(matches!(
+            env.set_sample_rate(f32::NEG_INFINITY),
             Err(DspError::InvalidParameter(_))
         ));
         assert!(matches!(
@@ -959,10 +990,12 @@ mod tests {
             Err(DspError::InvalidParameter(_))
         ));
 
-        // Coefficients must still match the original rate — the
-        // rejected calls should have left them alone.
+        // Coefficients AND gain must all still match the pre-
+        // rejection snapshot — any of these drifting would mean
+        // a rejected call silently mutated state.
         assert_eq!(env.attack_coeff, attack_before);
         assert_eq!(env.release_coeff, release_before);
+        assert_eq!(env.envelope_gain, gain_before);
 
         // Valid update applies cleanly.
         assert!(env.set_sample_rate(2.0 * ENV_TEST_SAMPLE_RATE_HZ).is_ok());

--- a/crates/sdr-radio/src/demod/nfm.rs
+++ b/crates/sdr-radio/src/demod/nfm.rs
@@ -2,6 +2,7 @@
 
 use sdr_dsp::demod::FmDemod;
 use sdr_dsp::filter::{DEEMPHASIS_TAU_US, FirFilter};
+use sdr_dsp::loops::Agc;
 use sdr_dsp::taps;
 use sdr_types::{Complex, DspError, Stereo};
 
@@ -37,6 +38,26 @@ const NFM_NYQUIST_GUARD_HZ: f64 = 1.0;
 /// Passthrough FIR tap (identity filter).
 const NFM_PASSTHROUGH_TAPS: [f32; 1] = [1.0];
 
+// Audio AGC parameters — mirror the AM demod's audio AGC
+// (set_point=1.0, attack=1/300, decay=1/3000, max_gain=1e6,
+// max_output=10.0, init_gain=1.0) so NFM audio levels are
+// normalized across stations with different deviations. Without
+// AGC, a tight-deviation commercial NFM signal (±2.5 kHz) sounds
+// much quieter than a wider-deviation ham signal (±5 kHz) even
+// though the RF level is the same — see #332.
+/// Audio AGC set point (target output amplitude).
+const NFM_AGC_SET_POINT: f32 = 1.0;
+/// Audio AGC attack coefficient.
+const NFM_AGC_ATTACK: f32 = 0.003_333_333;
+/// Audio AGC decay coefficient.
+const NFM_AGC_DECAY: f32 = 0.000_333_333;
+/// Audio AGC maximum gain ceiling.
+const NFM_AGC_MAX_GAIN: f32 = 1e6;
+/// Audio AGC maximum output amplitude (look-ahead clipping cap).
+const NFM_AGC_MAX_OUTPUT: f32 = 10.0;
+/// Audio AGC initial gain (pre-settling).
+const NFM_AGC_INIT_GAIN: f32 = 1.0;
+
 /// Narrowband FM demodulator using `FmDemod` from sdr-dsp.
 ///
 /// Produces mono audio converted to stereo. Includes a post-discriminator
@@ -46,9 +67,18 @@ pub struct NfmDemodulator {
     demod: FmDemod,
     /// Post-discriminator lowpass filter at bandwidth/2.
     audio_lpf: FirFilter,
+    /// Audio-level AGC — normalizes output amplitude so stations
+    /// with different FM deviations play at comparable loudness.
+    /// Applied downstream of the LPF so we're tracking the
+    /// finished audio, not the raw discriminator output (which
+    /// includes above-cutoff noise on weak signals that would
+    /// bias the envelope tracker).
+    audio_agc: Agc,
     config: DemodConfig,
     mono_buf: Vec<f32>,
     lpf_buf: Vec<f32>,
+    /// Scratch buffer for the post-LPF AGC stage.
+    agc_buf: Vec<f32>,
 }
 
 /// Build lowpass FIR taps for post-discriminator filtering at the given bandwidth.
@@ -77,6 +107,14 @@ impl NfmDemodulator {
             Some(taps) => FirFilter::new(taps)?,
             None => FirFilter::new(NFM_PASSTHROUGH_TAPS.to_vec())?, // passthrough
         };
+        let audio_agc = Agc::new(
+            NFM_AGC_SET_POINT,
+            NFM_AGC_ATTACK,
+            NFM_AGC_DECAY,
+            NFM_AGC_MAX_GAIN,
+            NFM_AGC_MAX_OUTPUT,
+            NFM_AGC_INIT_GAIN,
+        )?;
         let config = DemodConfig {
             if_sample_rate: NFM_IF_SAMPLE_RATE,
             af_sample_rate: NFM_AF_SAMPLE_RATE,
@@ -97,9 +135,11 @@ impl NfmDemodulator {
         Ok(Self {
             demod,
             audio_lpf,
+            audio_agc,
             config,
             mono_buf: Vec::new(),
             lpf_buf: Vec::new(),
+            agc_buf: Vec::new(),
         })
     }
 }
@@ -121,7 +161,17 @@ impl Demodulator for NfmDemodulator {
         self.audio_lpf
             .process_f32(&self.mono_buf[..count], &mut self.lpf_buf[..count])?;
 
-        sdr_dsp::convert::mono_to_stereo(&self.lpf_buf[..count], &mut output[..count])?;
+        // Audio-level AGC — normalizes output loudness across
+        // stations with different FM deviations. Closes the FM
+        // side of the "audio distortion with AGC on" bug (#332)
+        // by removing the level dependence on RF input strength,
+        // so the tuner-side AGC's imperfect RF gain tracking no
+        // longer propagates into audible distortion.
+        self.agc_buf.resize(count, 0.0);
+        self.audio_agc
+            .process_f32(&self.lpf_buf[..count], &mut self.agc_buf[..count])?;
+
+        sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
         Ok(count)
     }
 
@@ -162,7 +212,11 @@ impl Demodulator for NfmDemodulator {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::cast_precision_loss)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation
+)]
 mod tests {
     use super::*;
     use core::f32::consts::PI;
@@ -262,6 +316,53 @@ mod tests {
         assert!(
             filtered_jump < baseline_jump * 0.8,
             "LPF should reduce jumps: filtered={filtered_jump}, baseline={baseline_jump}"
+        );
+    }
+
+    #[test]
+    fn test_nfm_audio_agc_normalizes_across_deviations() {
+        // Two FM signals with very different deviations should
+        // produce similar audio levels after the audio AGC
+        // converges. Without AGC, a ±2 kHz-deviation signal
+        // would be audibly quieter than a ±5 kHz one even though
+        // the RF power is the same — the bug that #332 closes.
+        let settle = 2000;
+        let n = 4000;
+        let mod_freq = 1_000.0_f32;
+
+        let mut peaks = Vec::new();
+        for &deviation_hz in &[2_000.0_f32, 5_000.0_f32] {
+            let mut demod = NfmDemodulator::new().unwrap();
+            let input: Vec<Complex> = (0..n)
+                .map(|i| {
+                    let t = i as f32 / NFM_IF_SAMPLE_RATE as f32;
+                    // Integrated sinusoidal modulation: phase(t) =
+                    // deviation * sin(2π·mod_freq·t) / mod_freq.
+                    let phase = deviation_hz * (2.0 * PI * mod_freq * t).sin() / mod_freq;
+                    Complex::new(phase.cos(), phase.sin())
+                })
+                .collect();
+            let mut output = vec![Stereo::default(); n];
+            demod.process(&input, &mut output).unwrap();
+            let peak = output[settle..]
+                .iter()
+                .map(|s| s.l.abs())
+                .fold(0.0_f32, f32::max);
+            peaks.push(peak);
+        }
+
+        // Post-AGC peak ratio should be bounded. Without AGC the
+        // ratio would be ~2.5× (matching the deviation ratio);
+        // with AGC a 3× ceiling leaves margin for the envelope
+        // follower's settling time at the 2000-sample mark.
+        let ratio = if peaks[0] > peaks[1] {
+            peaks[0] / peaks[1].max(1e-10)
+        } else {
+            peaks[1] / peaks[0].max(1e-10)
+        };
+        assert!(
+            ratio < 3.0,
+            "audio AGC should normalize across FM deviations, peaks = {peaks:?}, ratio = {ratio}"
         );
     }
 

--- a/crates/sdr-radio/src/demod/nfm.rs
+++ b/crates/sdr-radio/src/demod/nfm.rs
@@ -352,16 +352,20 @@ mod tests {
         }
 
         // Post-AGC peak ratio should be bounded. Without AGC the
-        // ratio would be ~2.5× (matching the deviation ratio);
-        // with AGC a 3× ceiling leaves margin for the envelope
-        // follower's settling time at the 2000-sample mark.
+        // no-AGC baseline matches the deviation ratio exactly —
+        // 5000/2000 = 2.5× — so the assertion bound must sit
+        // BELOW 2.5 for the test to actually catch an AGC bypass.
+        // A ratio of 2.0 leaves ~20% margin for the envelope
+        // follower's finite settling time at the 2000-sample
+        // mark while still failing decisively if the AGC stage
+        // is removed or short-circuited.
         let ratio = if peaks[0] > peaks[1] {
             peaks[0] / peaks[1].max(1e-10)
         } else {
             peaks[1] / peaks[0].max(1e-10)
         };
         assert!(
-            ratio < 3.0,
+            ratio < 2.0,
             "audio AGC should normalize across FM deviations, peaks = {peaks:?}, ratio = {ratio}"
         );
     }

--- a/crates/sdr-radio/src/demod/wfm.rs
+++ b/crates/sdr-radio/src/demod/wfm.rs
@@ -2,6 +2,7 @@
 
 use sdr_dsp::demod::BroadcastFmDemod;
 use sdr_dsp::filter::{DEEMPHASIS_TAU_EU, FirFilter};
+use sdr_dsp::loops::Agc;
 use sdr_dsp::stereo::FmStereoDecoder;
 use sdr_dsp::taps;
 use sdr_types::{Complex, DspError, Stereo};
@@ -33,6 +34,25 @@ const WFM_MAX_BANDWIDTH: f64 = 250_000.0;
 /// Default frequency snap interval for WFM (Hz) — broadcast FM spacing.
 const WFM_SNAP_INTERVAL: f64 = 100_000.0;
 
+// Audio AGC parameters — same shape as NFM / AM so all three
+// demodulators normalize to comparable output loudness. Broadcast
+// FM stations follow a ±75 kHz deviation standard, but modulation
+// practice varies (compressed / uncompressed music, talk, etc.)
+// and RF path losses shift the discriminator output level too.
+// AGC closes both loops.
+/// Audio AGC set point (target output amplitude).
+const WFM_AGC_SET_POINT: f32 = 1.0;
+/// Audio AGC attack coefficient.
+const WFM_AGC_ATTACK: f32 = 0.003_333_333;
+/// Audio AGC decay coefficient.
+const WFM_AGC_DECAY: f32 = 0.000_333_333;
+/// Audio AGC maximum gain ceiling.
+const WFM_AGC_MAX_GAIN: f32 = 1e6;
+/// Audio AGC maximum output amplitude (look-ahead clipping cap).
+const WFM_AGC_MAX_OUTPUT: f32 = 10.0;
+/// Audio AGC initial gain (pre-settling).
+const WFM_AGC_INIT_GAIN: f32 = 1.0;
+
 /// Wideband FM demodulator using `BroadcastFmDemod` from sdr-dsp.
 ///
 /// Supports both mono and stereo output:
@@ -49,9 +69,19 @@ pub struct WfmDemodulator {
     /// FM stereo decoder — pilot PLL, subcarrier extraction, L/R matrixing.
     /// Used in stereo mode.
     stereo_decoder: FmStereoDecoder,
+    /// Audio-level AGC — normalizes mono output loudness. In
+    /// stereo mode we apply the same AGC's gain to both L and R
+    /// via a shared-gain pass so stereo imaging is preserved
+    /// (independent per-channel AGCs would drift L vs R).
+    audio_agc: Agc,
+    /// Scratch buffer for the post-LPF / post-stereo-decoder
+    /// mono signal that drives the AGC envelope. For stereo, the
+    /// AGC runs on `(L + R) / 2` so stereo imaging is preserved.
+    agc_mono_buf: Vec<f32>,
     config: DemodConfig,
     mono_buf: Vec<f32>,
     lpf_buf: Vec<f32>,
+    agc_buf: Vec<f32>,
     /// When true, perform stereo decode (pilot extraction + L−R matrixing).
     /// Default: false (mono), matching C++ SDR++ `_stereo = false` default.
     stereo: bool,
@@ -79,6 +109,15 @@ impl WfmDemodulator {
 
         let stereo_decoder = FmStereoDecoder::new(WFM_IF_SAMPLE_RATE)?;
 
+        let audio_agc = Agc::new(
+            WFM_AGC_SET_POINT,
+            WFM_AGC_ATTACK,
+            WFM_AGC_DECAY,
+            WFM_AGC_MAX_GAIN,
+            WFM_AGC_MAX_OUTPUT,
+            WFM_AGC_INIT_GAIN,
+        )?;
+
         let config = DemodConfig {
             if_sample_rate: WFM_IF_SAMPLE_RATE,
             af_sample_rate: WFM_AF_SAMPLE_RATE,
@@ -100,9 +139,12 @@ impl WfmDemodulator {
             demod,
             audio_lpf,
             stereo_decoder,
+            audio_agc,
+            agc_mono_buf: Vec::new(),
             config,
             mono_buf: Vec::new(),
             lpf_buf: Vec::new(),
+            agc_buf: Vec::new(),
             stereo: false,
         })
     }
@@ -114,9 +156,16 @@ impl WfmDemodulator {
     /// channels receive the same mono (L+R) signal.
     pub fn set_stereo(&mut self, enabled: bool) {
         if self.stereo != enabled {
-            // Reset stateful blocks to avoid stale history from the inactive path
+            // Reset stateful blocks to avoid stale history from
+            // the inactive path. Audio AGC is reset too — mono
+            // and stereo paths feed the envelope tracker with
+            // different amplitude scales (stereo has the L+R
+            // mono sum which averages vs. the mono LPF output),
+            // so carrying envelope state across the flip would
+            // produce a transient loudness jump.
             self.audio_lpf.reset();
             self.stereo_decoder.reset();
+            self.audio_agc.reset();
         }
         self.stereo = enabled;
         if enabled {
@@ -147,12 +196,45 @@ impl Demodulator for WfmDemodulator {
             // Stereo decode: pilot PLL → 38 kHz subcarrier → L−R → matrix
             self.stereo_decoder
                 .process(&self.mono_buf[..count], &mut output[..count])?;
+
+            // Apply audio AGC with shared L/R gain so stereo
+            // imaging is preserved. Envelope is driven by the
+            // L+R mono sum; the resulting gain is applied
+            // uniformly to both channels. An independent AGC per
+            // channel would let L and R drift relative to each
+            // other on asymmetric content.
+            self.agc_mono_buf.resize(count, 0.0);
+            for (i, s) in output[..count].iter().enumerate() {
+                self.agc_mono_buf[i] = 0.5 * (s.l + s.r);
+            }
+            self.agc_buf.resize(count, 0.0);
+            self.audio_agc
+                .process_f32(&self.agc_mono_buf[..count], &mut self.agc_buf[..count])?;
+            for (i, s) in output[..count].iter_mut().enumerate() {
+                // `gain = agc_output / mono_input`. Guard the
+                // zero-input case so silent samples don't
+                // produce NaN via 0/0.
+                let gain = if self.agc_mono_buf[i].abs() > f32::MIN_POSITIVE {
+                    self.agc_buf[i] / self.agc_mono_buf[i]
+                } else {
+                    1.0
+                };
+                s.l *= gain;
+                s.r *= gain;
+            }
         } else {
-            // Mono: 15 kHz lowpass → dual-mono
+            // Mono: 15 kHz lowpass → AGC → dual-mono
             self.lpf_buf.resize(count, 0.0);
             self.audio_lpf
                 .process_f32(&self.mono_buf[..count], &mut self.lpf_buf[..count])?;
-            sdr_dsp::convert::mono_to_stereo(&self.lpf_buf[..count], &mut output[..count])?;
+            // Audio AGC — see NFM's AGC stage for the rationale.
+            // WFM's deviation is fixed at ±75 kHz by standard but
+            // RF path loss and station modulation practice still
+            // produce varying output levels; AGC normalizes.
+            self.agc_buf.resize(count, 0.0);
+            self.audio_agc
+                .process_f32(&self.lpf_buf[..count], &mut self.agc_buf[..count])?;
+            sdr_dsp::convert::mono_to_stereo(&self.agc_buf[..count], &mut output[..count])?;
         }
 
         Ok(count)
@@ -178,7 +260,11 @@ impl Demodulator for WfmDemodulator {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::cast_precision_loss)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation
+)]
 mod tests {
     use super::*;
 
@@ -201,6 +287,64 @@ mod tests {
         let mut output = vec![Stereo::default(); 1000];
         let count = demod.process(&input, &mut output).unwrap();
         assert_eq!(count, 1000);
+    }
+
+    #[test]
+    fn test_wfm_mono_audio_agc_preserves_channel_match() {
+        // Audio AGC must apply the SAME gain to L and R in mono
+        // mode (they come from a shared mono buffer via
+        // mono_to_stereo), so per-sample L and R should stay
+        // within float epsilon of each other. Pins the invariant
+        // that we're not accidentally running independent L/R
+        // AGCs and losing the mono guarantee.
+        use core::f32::consts::PI;
+        let mut demod = WfmDemodulator::new().unwrap();
+        let mod_freq = 1_000.0_f32;
+        let deviation_hz = 50_000.0_f32;
+        let n = 3000;
+        let input: Vec<Complex> = (0..n)
+            .map(|i| {
+                let t = i as f32 / WFM_IF_SAMPLE_RATE as f32;
+                let phase = deviation_hz * (2.0 * PI * mod_freq * t).sin() / mod_freq;
+                Complex::new(phase.cos(), phase.sin())
+            })
+            .collect();
+        let mut output = vec![Stereo::default(); n];
+        demod.process(&input, &mut output).unwrap();
+        for (i, s) in output.iter().enumerate().skip(1500) {
+            assert!(
+                (s.l - s.r).abs() < 1e-6,
+                "mono WFM must preserve L == R after AGC at sample {i}, got L={} R={}",
+                s.l,
+                s.r
+            );
+        }
+    }
+
+    #[test]
+    fn test_wfm_stereo_audio_agc_preserves_imaging() {
+        // In stereo mode, shared-gain AGC applies the same gain
+        // to both channels (envelope driven by the L+R mono sum).
+        // If L is louder than R in the input, that relationship
+        // should survive AGC — not be flattened by independent
+        // per-channel normalization.
+        let mut demod = WfmDemodulator::new().unwrap();
+        demod.set_stereo(true);
+        // Drive enough samples so the stereo decoder's PLL and
+        // the AGC envelope both settle before measurement.
+        let n = 5000;
+        let input = vec![Complex::new(1.0, 0.0); n];
+        let mut output = vec![Stereo::default(); n];
+        demod.process(&input, &mut output).unwrap();
+        // Constant-frequency input means silence after FM demod
+        // → output amplitude near zero. Exact L == R is expected
+        // (both channels share the zero envelope). This test just
+        // confirms the stereo path compiles, runs, and doesn't
+        // NaN out via 0/0 in the gain calculation.
+        for s in &output[2000..] {
+            assert!(s.l.is_finite(), "stereo AGC produced non-finite L sample");
+            assert!(s.r.is_finite(), "stereo AGC produced non-finite R sample");
+        }
     }
 
     #[test]

--- a/crates/sdr-radio/src/demod/wfm.rs
+++ b/crates/sdr-radio/src/demod/wfm.rs
@@ -335,31 +335,76 @@ mod tests {
 
     #[test]
     fn test_wfm_stereo_audio_agc_preserves_imaging() {
-        // In stereo mode, shared-gain AGC applies the same gain
-        // to both channels (envelope driven by the per-sample
-        // RMS energy `sqrt((L² + R²) / 2)` so anti-phase and
-        // mono-in-one-channel content both drive the AGC
-        // correctly). If L is louder than R in the input, that
-        // relationship
-        // should survive AGC — not be flattened by independent
-        // per-channel normalization.
+        use core::f32::consts::PI;
+        // Synthesize an FM broadcast MPX signal carrying
+        // asymmetric stereo content — L four times louder than
+        // R — and confirm the relationship survives the shared-
+        // gain AGC. An accidental switch to independent L/R
+        // AGCs (each channel normalized to its own envelope)
+        // would flatten the L:R ratio toward 1.0 and fail this
+        // test, where the vacuous silence-only version it
+        // replaces would have passed regardless.
+        let sample_rate = WFM_IF_SAMPLE_RATE as f32;
+        let deviation_hz: f32 = 50_000.0;
+        let audio_freq_hz: f32 = 1_000.0;
+        let pilot_freq_hz: f32 = 19_000.0;
+        let subcarrier_freq_hz: f32 = 2.0 * pilot_freq_hz;
+        // L >> R on the same 1 kHz tone. Amplitudes chosen to
+        // keep the MPX peak under FM's ±75 kHz deviation headroom
+        // and produce a large, measurable L/R ratio after decode.
+        let left_amp: f32 = 0.4;
+        let right_amp: f32 = 0.1;
+
+        // Phase accumulation over 20_000 samples (80 ms at
+        // 250 kHz). Generous settling time for the stereo
+        // decoder's 19 kHz pilot PLL plus the audio AGC's
+        // ~300-sample attack.
+        let n = 20_000;
+        let mut phase: f32 = 0.0;
+        let phase_scale = 2.0 * PI * deviation_hz / sample_rate;
+        let input: Vec<Complex> = (0..n)
+            .map(|i| {
+                let t = i as f32 / sample_rate;
+                let left = left_amp * (2.0 * PI * audio_freq_hz * t).sin();
+                let right = right_amp * (2.0 * PI * audio_freq_hz * t).sin();
+                // Broadcast MPX: mono sum + pilot + DSBSC(L-R).
+                let mono = left + right;
+                let diff = left - right;
+                let pilot = 0.1 * (2.0 * PI * pilot_freq_hz * t).cos();
+                let subcarrier = diff * (2.0 * PI * subcarrier_freq_hz * t).cos();
+                let mpx = mono + pilot + subcarrier;
+                phase += phase_scale * mpx;
+                Complex::new(phase.cos(), phase.sin())
+            })
+            .collect();
+
         let mut demod = WfmDemodulator::new().unwrap();
         demod.set_stereo(true);
-        // Drive enough samples so the stereo decoder's PLL and
-        // the AGC envelope both settle before measurement.
-        let n = 5000;
-        let input = vec![Complex::new(1.0, 0.0); n];
         let mut output = vec![Stereo::default(); n];
         demod.process(&input, &mut output).unwrap();
-        // Constant-frequency input means silence after FM demod
-        // → output amplitude near zero. Exact L == R is expected
-        // (both channels share the zero envelope). This test just
-        // confirms the stereo path compiles, runs, and doesn't
-        // NaN out via 0/0 in the gain calculation.
-        for s in &output[2000..] {
-            assert!(s.l.is_finite(), "stereo AGC produced non-finite L sample");
-            assert!(s.r.is_finite(), "stereo AGC produced non-finite R sample");
-        }
+
+        // Skip PLL + AGC settling, then measure the L / R
+        // envelope-level ratio over the steady-state portion.
+        let settle = 10_000;
+        let mean_abs_l =
+            output[settle..].iter().map(|s| s.l.abs()).sum::<f32>() / (n - settle) as f32;
+        let mean_abs_r =
+            output[settle..].iter().map(|s| s.r.abs()).sum::<f32>() / (n - settle) as f32;
+
+        // Shared-gain AGC must preserve the input 4:1 imbalance
+        // roughly. Floor the ratio at 2.0× so an independent
+        // per-channel AGC (which would push this toward 1.0)
+        // fails decisively, and ceil it at 10× so a catastrophic
+        // bug amplifying one channel wildly also fails.
+        assert!(
+            mean_abs_r > 1e-5,
+            "stereo AGC produced a near-zero R channel: mean_abs_r = {mean_abs_r}"
+        );
+        let ratio = mean_abs_l / mean_abs_r;
+        assert!(
+            ratio > 2.0 && ratio < 10.0,
+            "stereo imaging not preserved: mean_abs_l = {mean_abs_l}, mean_abs_r = {mean_abs_r}, ratio = {ratio}"
+        );
     }
 
     #[test]

--- a/crates/sdr-radio/src/demod/wfm.rs
+++ b/crates/sdr-radio/src/demod/wfm.rs
@@ -74,9 +74,15 @@ pub struct WfmDemodulator {
     /// via a shared-gain pass so stereo imaging is preserved
     /// (independent per-channel AGCs would drift L vs R).
     audio_agc: Agc,
-    /// Scratch buffer for the post-LPF / post-stereo-decoder
-    /// mono signal that drives the AGC envelope. For stereo, the
-    /// AGC runs on `(L + R) / 2` so stereo imaging is preserved.
+    /// Scratch buffer for the mono signal that drives the AGC
+    /// envelope. For the mono path this is the post-LPF output;
+    /// for the stereo path it's the per-sample RMS energy
+    /// estimate `sqrt((L² + R²) / 2)` computed from the stereo-
+    /// decoder output. The RMS form (vs. the naive `(L + R) / 2`)
+    /// avoids anti-phase cancellation and the 3 dB under-count on
+    /// mono-in-one-channel content — see the stereo branch in
+    /// `process` and the `SquelchAudioEnvelope` / #332 notes for
+    /// the full reasoning.
     agc_mono_buf: Vec<f32>,
     config: DemodConfig,
     mono_buf: Vec<f32>,
@@ -330,8 +336,11 @@ mod tests {
     #[test]
     fn test_wfm_stereo_audio_agc_preserves_imaging() {
         // In stereo mode, shared-gain AGC applies the same gain
-        // to both channels (envelope driven by the L+R mono sum).
-        // If L is louder than R in the input, that relationship
+        // to both channels (envelope driven by the per-sample
+        // RMS energy `sqrt((L² + R²) / 2)` so anti-phase and
+        // mono-in-one-channel content both drive the AGC
+        // correctly). If L is louder than R in the input, that
+        // relationship
         // should survive AGC — not be flattened by independent
         // per-channel normalization.
         let mut demod = WfmDemodulator::new().unwrap();

--- a/crates/sdr-radio/src/demod/wfm.rs
+++ b/crates/sdr-radio/src/demod/wfm.rs
@@ -198,23 +198,29 @@ impl Demodulator for WfmDemodulator {
                 .process(&self.mono_buf[..count], &mut output[..count])?;
 
             // Apply audio AGC with shared L/R gain so stereo
-            // imaging is preserved. Envelope is driven by the
-            // L+R mono sum; the resulting gain is applied
-            // uniformly to both channels. An independent AGC per
-            // channel would let L and R drift relative to each
-            // other on asymmetric content.
+            // imaging is preserved. Drive the envelope from a
+            // non-cancelling RMS energy estimate —
+            // `sqrt((L² + R²) / 2)` — instead of the `(L+R)/2`
+            // mono sum: the sum cancels to zero on anti-phase
+            // material (L and R equal and opposite) and drops
+            // 3 dB on left- or right-only content, both of which
+            // would steer the AGC wrong even though the user is
+            // hearing real energy. Energy estimate is always
+            // non-negative and matches what the channels
+            // actually put through the speakers.
             self.agc_mono_buf.resize(count, 0.0);
             for (i, s) in output[..count].iter().enumerate() {
-                self.agc_mono_buf[i] = 0.5 * (s.l + s.r);
+                self.agc_mono_buf[i] = (0.5 * (s.l * s.l + s.r * s.r)).sqrt();
             }
             self.agc_buf.resize(count, 0.0);
             self.audio_agc
                 .process_f32(&self.agc_mono_buf[..count], &mut self.agc_buf[..count])?;
             for (i, s) in output[..count].iter_mut().enumerate() {
-                // `gain = agc_output / mono_input`. Guard the
-                // zero-input case so silent samples don't
-                // produce NaN via 0/0.
-                let gain = if self.agc_mono_buf[i].abs() > f32::MIN_POSITIVE {
+                // `gain = agc_output / rms_energy`. The energy
+                // estimate is non-negative by construction, so a
+                // single positive-magnitude guard covers the
+                // silent-input case without needing `.abs()`.
+                let gain = if self.agc_mono_buf[i] > f32::MIN_POSITIVE {
                     self.agc_buf[i] / self.agc_mono_buf[i]
                 } else {
                     1.0

--- a/crates/sdr-radio/src/if_chain.rs
+++ b/crates/sdr-radio/src/if_chain.rs
@@ -107,6 +107,18 @@ impl IfChain {
         !active || self.squelch.is_open()
     }
 
+    /// Returns whether the squelch is actively gating — i.e.,
+    /// manual squelch is enabled OR auto-squelch is enabled.
+    /// Downstream consumers (the AF-level squelch envelope in
+    /// `RadioModule::process`) skip their per-sample attenuation
+    /// when this is `false` because the gate would never close
+    /// anyway; running the envelope would mute the initial
+    /// audio samples while the envelope ramps up from 0 for no
+    /// reason.
+    pub fn squelch_active(&self) -> bool {
+        self.squelch_enabled || self.squelch.auto_squelch_enabled()
+    }
+
     /// Enable or disable FM IF noise reduction.
     pub fn set_fm_if_nr_enabled(&mut self, enabled: bool) {
         self.fm_if_nr_enabled = enabled;

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -95,6 +95,13 @@ pub struct RadioModule {
     resamp_buf: Vec<Complex>,
     /// Scratch buffer for demod output (stereo, at AF sample rate).
     demod_buf: Vec<Stereo>,
+    /// Per-sample attack / release envelope on the post-demod
+    /// stereo output, driven by the IF-chain squelch's gate
+    /// state. Lives in the AF path because FM discriminators are
+    /// amplitude-invariant — an IQ-side envelope has zero effect
+    /// on FM audio output. See #331 and the
+    /// `SquelchAudioEnvelope` docstring for the full reasoning.
+    squelch_envelope: sdr_dsp::noise::SquelchAudioEnvelope,
 }
 
 impl RadioModule {
@@ -110,6 +117,13 @@ impl RadioModule {
         let demod = create_demodulator(mode)?;
         let if_chain = IfChain::new()?;
         let af_chain = AfChain::new(demod.config().af_sample_rate, audio_sample_rate)?;
+        // Audio-path envelope for smoothing squelch open / close
+        // transitions. Runs at the final `audio_sample_rate`
+        // because it's applied to the stereo output after AfChain's
+        // resampler — see `process()` and #331's bug-fix notes for
+        // why this has to live in the AF path and not at IF.
+        #[allow(clippy::cast_possible_truncation)]
+        let squelch_envelope = sdr_dsp::noise::SquelchAudioEnvelope::new(audio_sample_rate as f32);
 
         Ok(Self {
             mode,
@@ -129,6 +143,7 @@ impl RadioModule {
             if_buf: Vec::new(),
             resamp_buf: Vec::new(),
             demod_buf: Vec::new(),
+            squelch_envelope,
         })
     }
 
@@ -252,6 +267,12 @@ impl RadioModule {
         if !squelch_allowed {
             self.if_chain.set_squelch_enabled(false);
         }
+        // Reset the AF squelch envelope so stale gain state from
+        // the previous mode's audio pipeline doesn't bleed into
+        // the first block on the new mode. Envelope coefficients
+        // stay valid — audio output rate is fixed at construction
+        // and the AfChain resampler normalizes all modes to it.
+        self.squelch_envelope.reset();
 
         self.mode = mode;
         self.demod = new_demod;
@@ -351,6 +372,39 @@ impl RadioModule {
         let af_count = self
             .af_chain
             .process(&self.demod_buf[..demod_count], output)?;
+
+        // Stage 4: Audio squelch envelope — only when the user
+        // has actually enabled squelch (manual or auto). Running
+        // the envelope unconditionally would mute the first
+        // ~2 ms of every block while the envelope ramps up from
+        // 0, even when there's no gate to open in the first
+        // place — a regression on modes like Raw that disable
+        // squelch entirely.
+        //
+        // When active: drives target gain from the IF-chain's
+        // block-level gate state and ramps the stereo output
+        // per-sample toward that target, smoothing the step
+        // discontinuity that otherwise produces loud gate-
+        // transition pops (particularly on macOS CoreAudio's
+        // internal resampler — see #331).
+        //
+        // Why here and not at IF: FM discriminators compute
+        // `atan2(phase delta)` which is amplitude-invariant, so
+        // scaling IQ magnitude has zero effect on FM audio.
+        // Applying the envelope to post-demod audio works for
+        // all modulation types uniformly.
+        if self.if_chain.squelch_active() {
+            self.squelch_envelope
+                .set_gate_open(self.if_chain.squelch_open());
+            self.squelch_envelope
+                .process_stereo(&mut output[..af_count]);
+        } else {
+            // Keep the envelope state coherent for when the user
+            // re-enables squelch mid-session — force it to fully-
+            // open so the first block post-enable doesn't fade in
+            // from silence.
+            self.squelch_envelope.reset_to_open();
+        }
 
         Ok(af_count)
     }

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -122,8 +122,12 @@ impl RadioModule {
         // because it's applied to the stereo output after AfChain's
         // resampler — see `process()` and #331's bug-fix notes for
         // why this has to live in the AF path and not at IF.
+        // `SquelchAudioEnvelope::new` rejects non-finite /
+        // non-positive rates; error propagates via `RadioError::Dsp`
+        // rather than silently collapsing to the pre-envelope hard
+        // gate it was meant to replace.
         #[allow(clippy::cast_possible_truncation)]
-        let squelch_envelope = sdr_dsp::noise::SquelchAudioEnvelope::new(audio_sample_rate as f32);
+        let squelch_envelope = sdr_dsp::noise::SquelchAudioEnvelope::new(audio_sample_rate as f32)?;
 
         Ok(Self {
             mode,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3268,6 +3268,12 @@ fn format_age(elapsed: Duration) -> String {
     }
 }
 
+/// Subtitle text shown on AGC-mutexed rows in the grayed-out
+/// state so the reason for the lock is inline — without it, an
+/// insensitive row is easy to mistake for a bug rather than
+/// intentional behavior.
+const AGC_MUTEX_SUBTITLE: &str = "Disabled while AGC is on";
+
 /// Enforce the tuner AGC ↔ manual gain mutual exclusion on the UI
 /// side: when AGC is on, the gain spin row becomes insensitive
 /// (grayed out, non-interactive). When AGC is off, the row is
@@ -3283,17 +3289,44 @@ fn format_age(elapsed: Duration) -> String {
 /// the restore path still updates `gain_row.set_value` cleanly
 /// even when the row is insensitive — the value displays but the
 /// user can't edit it until AGC is turned off.
-///
-/// The subtitle flips too so the reason for the lock is on-screen.
-/// Without the subtitle, an insensitive row is easy to mistake for
-/// a bug rather than intentional behavior.
 fn apply_agc_gain_mutex(gain_row: &adw::SpinRow, agc_active: bool) {
     gain_row.set_sensitive(!agc_active);
-    gain_row.set_subtitle(if agc_active {
-        "Disabled while AGC is on"
-    } else {
-        ""
-    });
+    gain_row.set_subtitle(if agc_active { AGC_MUTEX_SUBTITLE } else { "" });
+}
+
+/// Enforce the tuner AGC ↔ squelch mutual exclusion on the UI
+/// side: when AGC is on, the squelch controls (manual enable,
+/// manual level, auto-squelch enable) become insensitive.
+///
+/// The mutex exists because RTL-SDR's hardware tuner AGC auto-
+/// normalizes the IF signal amplitude — the tuner's internal
+/// VGA pushes toward a target level regardless of actual RF
+/// input. `PowerSquelch` reads mean IF amplitude and gates
+/// against a threshold, so with AGC on every signal (including
+/// noise on an empty channel) looks like "above threshold" and
+/// the gate stays open. Users see this as "all static all the
+/// time" the moment they enable AGC while squelch is on.
+///
+/// Same UX pattern as `apply_agc_gain_mutex`: gray the rows,
+/// set a subtitle on the first row explaining why, restore
+/// sensitivity when AGC turns off. Both mutexes share the
+/// `AGC_MUTEX_SUBTITLE` string so the explanation reads
+/// identically across the panel.
+fn apply_agc_squelch_mutex(
+    squelch_enabled_row: &adw::SwitchRow,
+    squelch_level_row: &adw::SpinRow,
+    auto_squelch_row: &adw::SwitchRow,
+    agc_active: bool,
+) {
+    squelch_enabled_row.set_sensitive(!agc_active);
+    squelch_level_row.set_sensitive(!agc_active);
+    auto_squelch_row.set_sensitive(!agc_active);
+    // Only one subtitle — the squelch-enabled row is the
+    // "header" of this group in the Radio panel, so that's
+    // where the explanation lands. The other two rows stay
+    // grayed without extra text to avoid repeating the
+    // message three times in a row.
+    squelch_enabled_row.set_subtitle(if agc_active { AGC_MUTEX_SUBTITLE } else { "" });
 }
 
 /// Interval for refreshing the source combo's RTL-SDR slot label
@@ -3500,22 +3533,44 @@ fn connect_source_panel(
     });
 
     // AGC toggle. In addition to dispatching the DSP command,
-    // toggle the gain row's sensitivity so the user can't edit
-    // the gain while tuner AGC is on — matches the macOS app's
-    // behavior and prevents the silent-no-op / tuner-oscillation
-    // failure modes documented in #332.
+    // toggle two mutexes so the UI doesn't lie about controls
+    // that tuner AGC actually disables:
+    //
+    // 1. Gain row — `rtlsdr_set_tuner_gain` silently no-ops on
+    //    most RTL variants when AGC is on.
+    // 2. Squelch rows — RTL-SDR's tuner AGC auto-normalizes IF
+    //    amplitude, so amplitude-based squelch can't distinguish
+    //    signal from noise and the gate just stays open. Without
+    //    this mutex users see "all static all the time" the
+    //    moment they enable AGC with squelch on.
     //
     // Initial state: `AdwSwitchRow` defaults to `active = false`,
-    // which means gain_row starts sensitive. Bookmark restore sets
-    // agc via `agc_row.set_active(agc)`, which fires this handler
-    // and reapplies the mutex — no separate seeding path needed.
+    // which means the gated rows start sensitive. Bookmark
+    // restore sets agc via `agc_row.set_active(agc)`, which
+    // fires this handler and reapplies the mutexes — no
+    // separate seeding path needed.
     apply_agc_gain_mutex(&panels.source.gain_row, panels.source.agc_row.is_active());
+    apply_agc_squelch_mutex(
+        &panels.radio.squelch_enabled_row,
+        &panels.radio.squelch_level_row,
+        &panels.radio.auto_squelch_row,
+        panels.source.agc_row.is_active(),
+    );
     let state_agc = Rc::clone(state);
     let gain_row_for_agc = panels.source.gain_row.clone();
+    let squelch_enabled_for_agc = panels.radio.squelch_enabled_row.clone();
+    let squelch_level_for_agc = panels.radio.squelch_level_row.clone();
+    let auto_squelch_for_agc = panels.radio.auto_squelch_row.clone();
     panels.source.agc_row.connect_active_notify(move |row| {
         let agc_active = row.is_active();
         state_agc.send_dsp(UiToDsp::SetAgc(agc_active));
         apply_agc_gain_mutex(&gain_row_for_agc, agc_active);
+        apply_agc_squelch_mutex(
+            &squelch_enabled_for_agc,
+            &squelch_level_for_agc,
+            &auto_squelch_for_agc,
+            agc_active,
+        );
     });
 
     // IQ correction toggle

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3268,6 +3268,34 @@ fn format_age(elapsed: Duration) -> String {
     }
 }
 
+/// Enforce the tuner AGC ↔ manual gain mutual exclusion on the UI
+/// side: when AGC is on, the gain spin row becomes insensitive
+/// (grayed out, non-interactive). When AGC is off, the row is
+/// fully editable.
+///
+/// The mutex exists because librtlsdr's `rtlsdr_set_tuner_gain`
+/// silently no-ops when AGC mode is active on most RTL variants,
+/// and on some oscillates between the manual target and the AGC
+/// target in a loop that produces audible artifacts. Preventing
+/// the user from editing the control while it would silently fail
+/// is the discoverable fix (see #332). Bookmarks restore the full
+/// tuning profile with AGC-first-then-gain ordering already, so
+/// the restore path still updates `gain_row.set_value` cleanly
+/// even when the row is insensitive — the value displays but the
+/// user can't edit it until AGC is turned off.
+///
+/// The subtitle flips too so the reason for the lock is on-screen.
+/// Without the subtitle, an insensitive row is easy to mistake for
+/// a bug rather than intentional behavior.
+fn apply_agc_gain_mutex(gain_row: &adw::SpinRow, agc_active: bool) {
+    gain_row.set_sensitive(!agc_active);
+    gain_row.set_subtitle(if agc_active {
+        "Disabled while AGC is on"
+    } else {
+        ""
+    });
+}
+
 /// Interval for refreshing the source combo's RTL-SDR slot label
 /// against the live USB bus. Low-frequency enough to be
 /// negligible CPU-wise; fast enough that a user plugging in their
@@ -3458,16 +3486,36 @@ fn connect_source_panel(
             }
         });
 
-    // Gain control
+    // Gain control. Sensitivity is gated by AGC — see the `AGC
+    // toggle` handler below and `apply_agc_gain_mutex` for the
+    // reasoning (librtlsdr silently ignores gain writes when
+    // tuner AGC is on; some variants also oscillate between
+    // manual and AGC targets on mixed writes). Updating
+    // `gain_row.set_value` from bookmark restore still works
+    // even when insensitive — the row just displays the value
+    // and stays locked against user edits.
     let state_gain = Rc::clone(state);
     panels.source.gain_row.connect_value_notify(move |row| {
         state_gain.send_dsp(UiToDsp::SetGain(row.value()));
     });
 
-    // AGC toggle
+    // AGC toggle. In addition to dispatching the DSP command,
+    // toggle the gain row's sensitivity so the user can't edit
+    // the gain while tuner AGC is on — matches the macOS app's
+    // behavior and prevents the silent-no-op / tuner-oscillation
+    // failure modes documented in #332.
+    //
+    // Initial state: `AdwSwitchRow` defaults to `active = false`,
+    // which means gain_row starts sensitive. Bookmark restore sets
+    // agc via `agc_row.set_active(agc)`, which fires this handler
+    // and reapplies the mutex — no separate seeding path needed.
+    apply_agc_gain_mutex(&panels.source.gain_row, panels.source.agc_row.is_active());
     let state_agc = Rc::clone(state);
+    let gain_row_for_agc = panels.source.gain_row.clone();
     panels.source.agc_row.connect_active_notify(move |row| {
-        state_agc.send_dsp(UiToDsp::SetAgc(row.is_active()));
+        let agc_active = row.is_active();
+        state_agc.send_dsp(UiToDsp::SetAgc(agc_active));
+        apply_agc_gain_mutex(&gain_row_for_agc, agc_active);
     });
 
     // IQ correction toggle


### PR DESCRIPTION
Two engine-audio-quality bugs fixed in one PR. Both are pure DSP / UI work with isolated test coverage — no protocol or wire-format changes.

## Summary

### #331 — Audio-path squelch envelope eliminates gate-transition pops
`PowerSquelch.process` was a hard gate on IQ samples, producing a step discontinuity at every open/close transition. macOS CoreAudio's AUHAL resampler rings hard on sub-ms steps and turns it into an audible pop. Fix: keep the IF-chain squelch as a hard gate on IQ (necessary — FM demod needs genuine zeros to silence), and apply the attack/release envelope to the **post-demod stereo audio** in `RadioModule::process`. Works uniformly across all modulation types because it's downstream of the discriminator.

A first attempt placed the envelope on IQ inside `PowerSquelch`. That didn't work: FM discriminators compute `atan2(phase delta)`, which is amplitude-invariant — scaling IQ magnitude has zero effect on FM audio. Caught at smoke-test. Corrected approach is the one shipped.

### #332 — Tuner AGC incompatibilities + FM AF-chain AGC
Three related fixes:
- **Gain ↔ AGC mutex** (commit 2): librtlsdr silently no-ops `set_tuner_gain` when tuner AGC is on. Gray the gain spin row when AGC is active so the user can't edit a control that would silently fail.
- **Squelch ↔ AGC mutex** (commit 4, smoke-test follow-up): tuner AGC auto-normalizes IF amplitude, so `PowerSquelch`'s mean-amplitude measurement has no signal-vs-noise meaning. Every block looks "above threshold", gate stays open, user hears all static. Gray the squelch rows when AGC is active. Same fundamental AGC↔RF-level incompatibility as the gain mutex; both share a single subtitle constant (`"Disabled while AGC is on"`).
- **AF-chain AGC on NFM/WFM** (commit 3): AM already had an audio-level AGC that normalizes amplitude post-envelope; NFM and WFM didn't. Added `sdr_dsp::loops::Agc` stages on both, post-LPF for mono paths. WFM stereo uses a shared-gain approach (envelope driven by the L+R sum, gain applied uniformly to both channels) so stereo imaging survives the normalization.

## Commits

1. `fix(#331): audio-path squelch envelope eliminates gate-transition pops` — new `SquelchAudioEnvelope` in `sdr-dsp::noise`, applied in `RadioModule::process` only when `if_chain.squelch_active()`. Envelope resets on mode change and snaps to fully-open when squelch is disabled so it doesn't fade in on re-enable.
2. `fix(#332): mutex gain slider with AGC switch to prevent silent no-ops` — `apply_agc_gain_mutex` + subtitle.
3. `fix(#332): audio AGC on NFM and WFM demodulators normalizes loudness` — `audio_agc: sdr_dsp::loops::Agc` on both; WFM stereo shared-gain; `set_stereo` resets AGC; 3 new unit tests (NFM deviation normalization, WFM mono L==R invariant, WFM stereo no-NaN on silence).
4. `fix(#332): extend AGC mutex to squelch rows — AGC breaks squelch too` — `apply_agc_squelch_mutex` on the three squelch rows, shared `AGC_MUTEX_SUBTITLE` const with the gain mutex.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — all tests pass including 5 new ones (4 envelope invariants, 1 NFM AGC normalization, 2 WFM AGC correctness)
- [x] `cargo fmt -- --check` clean
- [x] `cargo deny` + `cargo audit` clean
- [x] Smoke tested twice on Linux + `sherpa-cuda`:
  - Round 1: initial IQ-envelope approach broke squelch (FM is amplitude-invariant — bug caught + fixed in-branch before push)
  - Round 2: squelch + auto-squelch work correctly, no pops on voice transitions, AGC+squelch interaction exposed the third mutex need
  - Round 3: all mutexes behave correctly, squelch ineffectiveness under AGC no longer surfaces as "all static"

## Out of scope / follow-ups

- **Amplitude-invariant squelch algorithm** — proper fix for AGC + squelch would be an SNR- or variance-based gate that works under AGC's amplitude normalization. Orthogonal design question, separate ticket material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smooth audio squelch envelope with attack/release, applied post-demodulation and reset on mode changes to avoid audible artifacts
  * Audio-level AGC added to FM demodulators (mono and stereo) to stabilize output across deviation and channel imbalances
  * UI mutexes disable conflicting AGC vs manual gain/squelch controls with explanatory subtitles

* **Tests**
  * Added tests for envelope behavior, AGC settling, and pathological-input guards
<!-- end of auto-generated comment: release notes by coderabbit.ai -->