### PR TITLE
feat(macos): Group B.1 — audio device picker + WAV recording (#237, #239)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
  "sdr-pipeline",
  "sdr-radio",
  "sdr-rtlsdr",
+ "sdr-sink-audio",
  "sdr-types",
  "tracing",
  "tracing-subscriber",

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -293,6 +293,26 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(sdr_core_set_volume(handle, volume))
     }
 
+    /// Select the audio output device by UID. Pass `""` to route
+    /// to the system default output. The UID is the opaque string
+    /// returned by `SdrCore.audioDeviceUid(at:)`.
+    public func setAudioDevice(_ uid: String) throws {
+        try checkRc(uid.withCString { sdr_core_set_audio_device(handle, $0) })
+    }
+
+    /// Start recording the demodulated audio stream to a WAV file
+    /// at `path`. The engine emits `.audioRecordingStarted(path:)`
+    /// on success or `.error(...)` on failure.
+    public func startAudioRecording(path: String) throws {
+        try checkRc(path.withCString { sdr_core_start_audio_recording(handle, $0) })
+    }
+
+    /// Stop audio recording. Safe to call when nothing is active —
+    /// the engine always emits `.audioRecordingStopped` in response.
+    public func stopAudioRecording() throws {
+        try checkRc(sdr_core_stop_audio_recording(handle))
+    }
+
     /// Enable or disable DC blocking on the IQ frontend.
     public func setDcBlocking(_ enabled: Bool) throws {
         try checkRc(sdr_core_set_dc_blocking(handle, enabled))
@@ -468,6 +488,77 @@ public final class SdrCore: @unchecked Sendable {
         let rc = buf.withUnsafeMutableBufferPointer { ptr -> Int32 in
             guard let base = ptr.baseAddress else { return -1 }
             return sdr_core_device_name(index, base, ptr.count)
+        }
+        guard rc >= 0 else { return nil }
+        return String(cString: buf)
+    }
+
+    // ==========================================================
+    //  Audio device enumeration (static, no handle required)
+    // ==========================================================
+
+    /// Descriptor for an audio output device the backend knows about.
+    /// `uid` is the opaque identifier to pass to `setAudioDevice` —
+    /// empty string means "system default output".
+    public struct AudioDevice: Sendable, Hashable, Identifiable {
+        public let displayName: String
+        public let uid: String
+        public var id: String { uid }
+
+        public init(displayName: String, uid: String) {
+            self.displayName = displayName
+            self.uid = uid
+        }
+    }
+
+    /// Snapshot of audio output devices currently enumerable.
+    /// Safe to call before `SdrCore` is created — the list comes
+    /// from the backend (CoreAudio on macOS), not the engine.
+    ///
+    /// Each call re-runs the backend query; hosts typically call
+    /// this on Settings panel open. Index 0 is typically the
+    /// "system default" entry (UID `""`).
+    public static var audioDevices: [AudioDevice] {
+        let count = sdr_core_audio_device_count()
+        guard count > 0 else { return [] }
+        var result: [AudioDevice] = []
+        result.reserveCapacity(Int(count))
+        for i in 0..<count {
+            guard let name = audioDeviceName(at: i),
+                  let uid = audioDeviceUid(at: i) else {
+                continue
+            }
+            result.append(AudioDevice(displayName: name, uid: uid))
+        }
+        return result
+    }
+
+    /// Display name for the audio output device at `index`.
+    /// Returns `nil` if `index` is out of range.
+    public static func audioDeviceName(at index: UInt32) -> String? {
+        audioDeviceString(index: index, call: sdr_core_audio_device_name)
+    }
+
+    /// Opaque UID for the audio output device at `index`. Pass
+    /// this to `setAudioDevice` to route. Empty string means
+    /// "system default output".
+    public static func audioDeviceUid(at index: UInt32) -> String? {
+        audioDeviceString(index: index, call: sdr_core_audio_device_uid)
+    }
+
+    /// Shared fixed-buffer caller for `sdr_core_audio_device_name`
+    /// / `_uid`. 512 bytes covers any reasonable CoreAudio name —
+    /// real device names max out around 60 characters and UIDs
+    /// (once we migrate to `kAudioDevicePropertyDeviceUID`) are
+    /// typically <128 bytes.
+    private static func audioDeviceString(
+        index: UInt32,
+        call: (UInt32, UnsafeMutablePointer<CChar>?, Int) -> Int32
+    ) -> String? {
+        var buf = [CChar](repeating: 0, count: 512)
+        let rc = buf.withUnsafeMutableBufferPointer { ptr -> Int32 in
+            guard let base = ptr.baseAddress else { return -1 }
+            return call(index, base, ptr.count)
         }
         guard rc >= 0 else { return nil }
         return String(cString: buf)

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -128,8 +128,15 @@ public enum SdrCoreEvent: Sendable, Equatable {
             return .error(String(cString: cstr))
 
         case kAudioRecordingStarted:
-            let cstr = payload.audio_recording.path_utf8
-            guard let cstr else { return .audioRecordingStarted(path: "") }
+            // Drop the event on a null path pointer rather than
+            // emit `.audioRecordingStarted(path: "")` — an empty
+            // path would flip CoreModel's `audioRecordingPath`
+            // into a bogus non-nil "recording" state with no file
+            // the UI can meaningfully display or reveal. The
+            // subsequent `.audioRecordingStopped` will still
+            // clear state correctly. Per CodeRabbit round 1 on
+            // PR #344.
+            guard let cstr = payload.audio_recording.path_utf8 else { return nil }
             return .audioRecordingStarted(path: String(cString: cstr))
 
         case kAudioRecordingStopped:

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -30,13 +30,15 @@ import sdr_core_c
 // in `include/sdr_core.h` flows through automatically — the Swift
 // side can't drift from the C header silently. CodeRabbit caught
 // the hard-coded form on PR #256 round 1.
-private let kSourceStopped    = Int32(SDR_EVT_SOURCE_STOPPED.rawValue)
-private let kSampleRateChanged = Int32(SDR_EVT_SAMPLE_RATE_CHANGED.rawValue)
-private let kSignalLevel      = Int32(SDR_EVT_SIGNAL_LEVEL.rawValue)
-private let kDeviceInfo       = Int32(SDR_EVT_DEVICE_INFO.rawValue)
-private let kGainList         = Int32(SDR_EVT_GAIN_LIST.rawValue)
-private let kDisplayBandwidth = Int32(SDR_EVT_DISPLAY_BANDWIDTH.rawValue)
-private let kError            = Int32(SDR_EVT_ERROR.rawValue)
+private let kSourceStopped         = Int32(SDR_EVT_SOURCE_STOPPED.rawValue)
+private let kSampleRateChanged     = Int32(SDR_EVT_SAMPLE_RATE_CHANGED.rawValue)
+private let kSignalLevel           = Int32(SDR_EVT_SIGNAL_LEVEL.rawValue)
+private let kDeviceInfo            = Int32(SDR_EVT_DEVICE_INFO.rawValue)
+private let kGainList              = Int32(SDR_EVT_GAIN_LIST.rawValue)
+private let kDisplayBandwidth      = Int32(SDR_EVT_DISPLAY_BANDWIDTH.rawValue)
+private let kError                 = Int32(SDR_EVT_ERROR.rawValue)
+private let kAudioRecordingStarted = Int32(SDR_EVT_AUDIO_RECORDING_STARTED.rawValue)
+private let kAudioRecordingStopped = Int32(SDR_EVT_AUDIO_RECORDING_STOPPED.rawValue)
 
 /// High-level event from the engine.
 ///
@@ -71,6 +73,15 @@ public enum SdrCoreEvent: Sendable, Equatable {
 
     /// A non-fatal error occurred in the pipeline.
     case error(String)
+
+    /// Audio recording to WAV has started. The associated path is
+    /// the file the engine opened for writing.
+    case audioRecordingStarted(path: String)
+
+    /// Audio recording to WAV has stopped. Also fires on engine
+    /// shutdown while a recording is active, so hosts can clear
+    /// their "recording" UI without tracking teardown separately.
+    case audioRecordingStopped
 
     /// Translate a C `SdrEvent` into a Swift value.
     ///
@@ -115,6 +126,14 @@ public enum SdrCoreEvent: Sendable, Equatable {
             let cstr = payload.error.utf8
             guard let cstr else { return .error("") }
             return .error(String(cString: cstr))
+
+        case kAudioRecordingStarted:
+            let cstr = payload.audio_recording.path_utf8
+            guard let cstr else { return .audioRecordingStarted(path: "") }
+            return .audioRecordingStarted(path: String(cString: cstr))
+
+        case kAudioRecordingStopped:
+            return .audioRecordingStopped
 
         default:
             // Unknown kind — a future FFI may add variants we

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -128,16 +128,18 @@ public enum SdrCoreEvent: Sendable, Equatable {
             return .error(String(cString: cstr))
 
         case kAudioRecordingStarted:
-            // Drop the event on a null path pointer rather than
-            // emit `.audioRecordingStarted(path: "")` — an empty
-            // path would flip CoreModel's `audioRecordingPath`
-            // into a bogus non-nil "recording" state with no file
-            // the UI can meaningfully display or reveal. The
-            // subsequent `.audioRecordingStopped` will still
-            // clear state correctly. Per CodeRabbit round 1 on
-            // PR #344.
+            // Drop the event on either a null path pointer OR a
+            // zero-length C string — both produce an empty Swift
+            // String, which would flip CoreModel's
+            // `audioRecordingPath` into a bogus non-nil
+            // "recording" state with no file the UI can
+            // meaningfully display or reveal. The subsequent
+            // `.audioRecordingStopped` will still clear state
+            // correctly. Per CodeRabbit rounds 1 + 2 on PR #344.
             guard let cstr = payload.audio_recording.path_utf8 else { return nil }
-            return .audioRecordingStarted(path: String(cString: cstr))
+            let path = String(cString: cstr)
+            guard !path.isEmpty else { return nil }
+            return .audioRecordingStarted(path: path)
 
         case kAudioRecordingStopped:
             return .audioRecordingStopped

--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -64,6 +64,7 @@ struct SidebarView: View {
             SourceSection()
             RadioSection()
             DisplaySection()
+            RecordingSection()
             BookmarksSection()
         }
         .formStyle(.grouped)

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -169,6 +169,26 @@ final class CoreModel {
 
     var volume: Float = 0.5
 
+    /// Selected audio output device UID. Empty string routes to
+    /// the system default (engine-side behavior). The available
+    /// list is re-fetched on demand via
+    /// `refreshAudioDevices()` — this is a mirror of the user
+    /// selection, not a cached snapshot of the device list.
+    var selectedAudioDeviceUid: String = ""
+
+    /// Snapshot of output devices the backend enumerated. Filled
+    /// by `refreshAudioDevices()`; the AudioSection view calls
+    /// that on panel appear so a hot-plug between app launch and
+    /// panel open still shows the current list.
+    var audioDevices: [SdrCore.AudioDevice] = []
+
+    /// Active audio-recording state. `nil` = not recording,
+    /// `some(path)` = engine confirmed it opened `path` for
+    /// writing. Mirrors `DspToUi::AudioRecordingStarted/Stopped`
+    /// — the engine is authoritative; the UI never flips this
+    /// optimistically.
+    var audioRecordingPath: String? = nil
+
     // ==========================================================
     //  Display
     // ==========================================================
@@ -243,6 +263,17 @@ final class CoreModel {
         // This is a handle-free libusb device-list query; no USB
         // control transfers, no hardware open.
         refreshDeviceInfo()
+
+        // Restore the previously-selected audio output device UID
+        // so the user's preference survives across launches.
+        // syncToEngine() (on Start) re-applies it; we don't call
+        // `core?.setAudioDevice` here because `core` doesn't exist
+        // yet — and the engine's default is the same empty-string
+        // "system default" sentinel anyway.
+        if let saved = UserDefaults.standard.string(forKey: Self.audioDeviceDefaultsKey) {
+            selectedAudioDeviceUid = saved
+        }
+        refreshAudioDevices()
 
         do {
             let c = try SdrCore(configPath: configPath)
@@ -358,6 +389,10 @@ final class CoreModel {
             }
         case .error(let msg):
             lastError = msg
+        case .audioRecordingStarted(let path):
+            audioRecordingPath = path
+        case .audioRecordingStopped:
+            audioRecordingPath = nil
         @unknown default:
             // Surface new engine event variants during
             // development. SdrCoreEvent is a non-frozen enum
@@ -475,6 +510,10 @@ final class CoreModel {
         setAutoSquelch(autoSquelchEnabled)
         setDeemphasis(deemphasis)
         setVolume(volume)
+        // Route to the user's last-picked output device. The
+        // engine default is "" (system default) so a fresh install
+        // re-applies that harmlessly.
+        setAudioDevice(selectedAudioDeviceUid)
         setFftSize(fftSize)
         setFftWindow(fftWindow)
         setFftRate(fftRateFps)
@@ -655,6 +694,47 @@ final class CoreModel {
     func setVolume(_ v: Float) {
         volume = v
         capture { try core?.setVolume(v) }
+    }
+
+    /// Select an audio output device by UID. Empty string routes
+    /// to the system default. The engine re-opens the sink
+    /// transactionally — on a failed swap the previous device is
+    /// restored (see `AudioSink::set_target` docs).
+    ///
+    /// The selection is persisted to `UserDefaults` so the same
+    /// device is picked on next launch; the Rust config layer
+    /// doesn't currently round-trip this value (v3 when config
+    /// JSON grows to match the GTK layout).
+    func setAudioDevice(_ uid: String) {
+        selectedAudioDeviceUid = uid
+        UserDefaults.standard.set(uid, forKey: Self.audioDeviceDefaultsKey)
+        capture { try core?.setAudioDevice(uid) }
+    }
+
+    /// UserDefaults key for the persisted audio device UID.
+    static let audioDeviceDefaultsKey = "SDRMac.selectedAudioDeviceUid"
+
+    /// Re-query the backend for the current output device list.
+    /// Called by the AudioSection view on appear; safe to call
+    /// any time. Handle-free (static on SdrCore).
+    func refreshAudioDevices() {
+        audioDevices = SdrCore.audioDevices
+    }
+
+    /// Start writing the demodulated audio stream to `path` (a
+    /// full filesystem path). The engine confirms via
+    /// `.audioRecordingStarted` which flips
+    /// `audioRecordingPath` to non-nil. Failure comes back as
+    /// an `.error(...)` event and `audioRecordingPath` stays nil.
+    func startAudioRecording(to path: String) {
+        capture { try core?.startAudioRecording(path: path) }
+    }
+
+    /// Stop recording. Safe to call at any time — the engine
+    /// always emits `.audioRecordingStopped` in response, which
+    /// clears `audioRecordingPath`.
+    func stopAudioRecording() {
+        capture { try core?.stopAudioRecording() }
     }
 
     func setFftSize(_ n: Int) {

--- a/apps/macos/SDRMac/SDRMacApp.swift
+++ b/apps/macos/SDRMac/SDRMacApp.swift
@@ -60,6 +60,26 @@ struct SDRMacApp: App {
         appSupportDirectory().appendingPathComponent("bookmarks.json")
     }
 
+    /// Directory the app writes WAV recordings to, per #239:
+    /// `~/Documents/SDRMac/Audio/`. Created lazily on first
+    /// recording start so a user who never hits Record doesn't
+    /// wind up with a stray empty folder.
+    ///
+    /// Returned as a URL, not just a path, so SwiftUI callers can
+    /// `showInFinder` the destination directly.
+    static func audioRecordingsDirectory() -> URL {
+        let fm = FileManager.default
+        let docs = (try? fm.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fm.homeDirectoryForCurrentUser.appendingPathComponent("Documents")
+        let dir = docs.appendingPathComponent("SDRMac/Audio")
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
     private static func appSupportDirectory() -> URL {
         let fm = FileManager.default
         let dir = (try? fm.url(

--- a/apps/macos/SDRMac/Views/RecordingSection.swift
+++ b/apps/macos/SDRMac/Views/RecordingSection.swift
@@ -66,15 +66,25 @@ struct RecordingSection: View {
     }
 
     /// Build a full destination path for a new recording. The
-    /// filename pattern is `sdr-audio-YYYYMMDD-HHMMSS.wav` —
-    /// sortable, human-readable, and unique enough that back-to-
-    /// back recordings don't collide.
+    /// filename pattern is `sdr-audio-YYYYMMDD-HHMMSS-SSS.wav` —
+    /// sortable, human-readable, and millisecond-precise so
+    /// rapid stop/start cycles (button spam, scripted automation)
+    /// produce distinct filenames. On the off chance that two
+    /// timestamps still collide — or the user explicitly asked
+    /// for a name that exists from a previous session — an
+    /// integer suffix is appended until an unused name is found.
     static func generateRecordingPath() -> String {
         let dir = SDRMacApp.audioRecordingsDirectory()
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
         let stamp = formatter.string(from: Date())
-        return dir.appendingPathComponent("sdr-audio-\(stamp).wav").path
+        var candidate = dir.appendingPathComponent("sdr-audio-\(stamp).wav")
+        var suffix = 1
+        while FileManager.default.fileExists(atPath: candidate.path) {
+            candidate = dir.appendingPathComponent("sdr-audio-\(stamp)-\(suffix).wav")
+            suffix += 1
+        }
+        return candidate.path
     }
 }

--- a/apps/macos/SDRMac/Views/RecordingSection.swift
+++ b/apps/macos/SDRMac/Views/RecordingSection.swift
@@ -1,0 +1,80 @@
+//
+// RecordingSection.swift — sidebar panel for audio WAV
+// recording (#239). Engine-side: see
+// `UiToDsp::StartAudioRecording` / `StopAudioRecording` at
+// `crates/sdr-core/src/controller.rs`. The engine owns the
+// writer, WAV header, and buffer discipline; this view only
+// toggles the command and reflects the engine's confirmed
+// state (`audioRecordingPath`).
+//
+// Default destination: `~/Documents/SDRMac/Audio/<timestamp>.wav`,
+// created on first Record tap.
+
+import AppKit
+import SwiftUI
+
+struct RecordingSection: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        Section("Recording") {
+            let recording = model.audioRecordingPath != nil
+
+            Toggle("Audio", isOn: Binding(
+                get: { recording },
+                set: { on in
+                    if on {
+                        let path = Self.generateRecordingPath()
+                        model.startAudioRecording(to: path)
+                    } else {
+                        model.stopAudioRecording()
+                    }
+                }
+            ))
+
+            if let path = model.audioRecordingPath {
+                LabeledContent("File") {
+                    Button {
+                        // Reveal in Finder — select the file so the
+                        // user can immediately drag / play / delete
+                        // it. If the file isn't actually there yet
+                        // (engine hasn't flushed), fall back to the
+                        // parent directory so the button stays
+                        // useful.
+                        let url = URL(fileURLWithPath: path)
+                        if FileManager.default.fileExists(atPath: url.path) {
+                            NSWorkspace.shared.activateFileViewerSelecting([url])
+                        } else {
+                            NSWorkspace.shared.open(url.deletingLastPathComponent())
+                        }
+                    } label: {
+                        Text((path as NSString).lastPathComponent)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .buttonStyle(.plain)
+                    .help(path)
+                }
+            } else {
+                Text("Not recording")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
+    }
+
+    /// Build a full destination path for a new recording. The
+    /// filename pattern is `sdr-audio-YYYYMMDD-HHMMSS.wav` —
+    /// sortable, human-readable, and unique enough that back-to-
+    /// back recordings don't collide.
+    static func generateRecordingPath() -> String {
+        let dir = SDRMacApp.audioRecordingsDirectory()
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let stamp = formatter.string(from: Date())
+        return dir.appendingPathComponent("sdr-audio-\(stamp).wav").path
+    }
+}

--- a/apps/macos/SDRMac/Views/RecordingSection.swift
+++ b/apps/macos/SDRMac/Views/RecordingSection.swift
@@ -16,6 +16,16 @@ import SwiftUI
 struct RecordingSection: View {
     @Environment(CoreModel.self) private var model
 
+    /// True between firing a start/stop command and observing the
+    /// matching `audioRecordingPath` change. Locks the toggle in
+    /// the meantime so a rapid second click can't fire a second
+    /// `StartAudioRecording` — the controller replaces
+    /// `state.audio_writer` on each start, which would drop the
+    /// first writer mid-write and produce two partial WAV files.
+    /// Cleared in `.onChange(of:)` when the engine confirms the
+    /// transition.
+    @State private var pendingTransition: Bool = false
+
     var body: some View {
         Section("Recording") {
             let recording = model.audioRecordingPath != nil
@@ -23,6 +33,13 @@ struct RecordingSection: View {
             Toggle("Audio", isOn: Binding(
                 get: { recording },
                 set: { on in
+                    // Swallow re-entrant toggles until the engine
+                    // acknowledges the outstanding request via
+                    // `.audioRecordingStarted/Stopped`. Without
+                    // this, a double-click in the ~ms window
+                    // before the event lands creates two files.
+                    guard !pendingTransition else { return }
+                    pendingTransition = true
                     if on {
                         let path = Self.generateRecordingPath()
                         model.startAudioRecording(to: path)
@@ -31,6 +48,26 @@ struct RecordingSection: View {
                     }
                 }
             ))
+            .disabled(pendingTransition)
+            // Engine events are the authoritative transition
+            // signal; clear the lock when `audioRecordingPath`
+            // actually flips. If the engine fails to open the
+            // file, a `.error` event comes through CoreModel
+            // instead and this line never fires — that's handled
+            // separately below.
+            .onChange(of: model.audioRecordingPath) { _, _ in
+                pendingTransition = false
+            }
+            // If start failed (engine emitted `.error` without
+            // ever flipping `audioRecordingPath`), the state
+            // change above won't fire and the toggle would stay
+            // locked forever. Reset on any error surfacing while
+            // we're pending so the user can try again.
+            .onChange(of: model.lastError) { _, new in
+                if pendingTransition && new != nil {
+                    pendingTransition = false
+                }
+            }
 
             if let path = model.audioRecordingPath {
                 LabeledContent("File") {

--- a/apps/macos/SDRMac/Views/SettingsView.swift
+++ b/apps/macos/SDRMac/Views/SettingsView.swift
@@ -47,7 +47,33 @@ private struct AudioPane: View {
     var body: some View {
         Form {
             LabeledContent("Output device") {
-                Text("System default").foregroundStyle(.secondary)
+                // Picker rebuilds the device list on every appear —
+                // CoreAudio hot-plugs are common (Bluetooth headsets,
+                // USB interfaces); the user shouldn't have to restart
+                // the app to see a freshly-connected device. The
+                // engine's transactional swap guarantees a bad pick
+                // rolls back to the previous route automatically.
+                Picker("", selection: Binding(
+                    get: { model.selectedAudioDeviceUid },
+                    set: { model.setAudioDevice($0) }
+                )) {
+                    // "" is the engine's "system default" sentinel —
+                    // show it as a first-class option regardless of
+                    // backend so the user always has a guaranteed-
+                    // working route to fall back on.
+                    Text("System default").tag("")
+                    ForEach(model.audioDevices) { dev in
+                        // Skip a backend-emitted empty-UID duplicate
+                        // so we never show two "System default"
+                        // options (stub backend does emit one; real
+                        // backends typically don't).
+                        if !dev.uid.isEmpty {
+                            Text(dev.displayName).tag(dev.uid)
+                        }
+                    }
+                }
+                .labelsHidden()
+                .onAppear { model.refreshAudioDevices() }
             }
             LabeledContent("Volume") {
                 @Bindable var m = model

--- a/crates/sdr-ffi/Cargo.toml
+++ b/crates/sdr-ffi/Cargo.toml
@@ -36,6 +36,12 @@ sdr-radio.workspace = true
 # These are static (no handle required), so they don't fit the
 # engine-dispatch path; they go through `sdr-rtlsdr` directly.
 sdr-rtlsdr.workspace = true
+# Direct dep on sdr-sink-audio for the audio-device enumeration
+# functions (`sdr_core_audio_device_count` / `_name` / `_uid`).
+# Same rationale as `sdr-rtlsdr` above — these are handle-free
+# `list_audio_sinks()` snapshots of CoreAudio / PipeWire state,
+# so they bypass the engine dispatch path.
+sdr-sink-audio.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 libc.workspace = true

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -24,6 +24,9 @@
 //! the other (and the `make ffi-header-check` drift linter in a
 //! later checkpoint catches any divergence).
 
+use std::ffi::{CStr, c_char};
+use std::path::PathBuf;
+
 use sdr_core::UiToDsp;
 use sdr_pipeline::iq_frontend::FftWindow;
 use sdr_radio::DeemphasisMode;
@@ -378,6 +381,86 @@ pub unsafe extern "C" fn sdr_core_set_volume(handle: *mut SdrCore, volume_0_1: f
     }
 }
 
+/// Shared helper for commands that take a NUL-terminated UTF-8
+/// path / identifier string. Returns an owned `String` on success
+/// or an `InvalidArg` after setting the last-error.
+///
+/// # Safety
+///
+/// `ptr` must be either null or a pointer to a NUL-terminated UTF-8
+/// C string.
+unsafe fn cstr_to_string(fn_name: &str, ptr: *const c_char) -> Result<String, SdrCoreError> {
+    if ptr.is_null() {
+        set_last_error(format!("{fn_name}: string pointer is null"));
+        return Err(SdrCoreError::InvalidArg);
+    }
+    // SAFETY: caller contract.
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    if let Ok(s) = cstr.to_str() {
+        Ok(s.to_string())
+    } else {
+        set_last_error(format!("{fn_name}: string is not valid UTF-8"));
+        Err(SdrCoreError::InvalidArg)
+    }
+}
+
+/// Select the audio output device by caller-opaque UID. Empty
+/// string routes to the system default output. The UID is the
+/// value previously obtained from `sdr_core_audio_device_uid`.
+///
+/// # Safety
+///
+/// `uid_utf8` must be a NUL-terminated UTF-8 C string (or empty).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_audio_device(
+    handle: *mut SdrCore,
+    uid_utf8: *const c_char,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let uid = cstr_to_string("sdr_core_set_audio_device", uid_utf8)?;
+            send(core, UiToDsp::SetAudioDevice(uid))
+        })
+    }
+}
+
+/// Start writing the demodulated audio stream to a 16-bit PCM WAV
+/// file at `path_utf8`. If recording was already active the engine
+/// logs a warning and overwrites — callers should stop first.
+///
+/// The engine confirms start via `SDR_EVT_AUDIO_RECORDING_STARTED`
+/// or emits `SDR_EVT_ERROR` on failure (open error, disk full, etc.).
+///
+/// # Safety
+///
+/// `path_utf8` must be a NUL-terminated UTF-8 C string naming a
+/// writable filesystem path (the engine creates the file). Does
+/// not accept null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_start_audio_recording(
+    handle: *mut SdrCore,
+    path_utf8: *const c_char,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let path = cstr_to_string("sdr_core_start_audio_recording", path_utf8)?;
+            if path.is_empty() {
+                set_last_error("sdr_core_start_audio_recording: path is empty");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            send(core, UiToDsp::StartAudioRecording(PathBuf::from(path)))
+        })
+    }
+}
+
+/// Stop audio recording. The engine finalizes the WAV header on
+/// writer drop and confirms via `SDR_EVT_AUDIO_RECORDING_STOPPED`.
+/// Safe to call when no recording is active (no-op + stop event).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_stop_audio_recording(handle: *mut SdrCore) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::StopAudioRecording)) }
+}
+
 // ============================================================
 //  IQ frontend
 // ============================================================
@@ -520,6 +603,89 @@ mod tests {
             unsafe { sdr_core_set_auto_squelch(std::ptr::null_mut(), true) },
             SdrCoreError::InvalidHandle.as_int()
         );
+        let empty = CString::new("").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_set_audio_device(std::ptr::null_mut(), empty.as_ptr()) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+        assert_eq!(
+            unsafe {
+                sdr_core_start_audio_recording(std::ptr::null_mut(), empty.as_ptr())
+            },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_stop_audio_recording(std::ptr::null_mut()) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+    }
+
+    // ------------------------------------------------------
+    //  Audio routing + recording (ABI 0.4)
+    // ------------------------------------------------------
+
+    #[test]
+    fn set_audio_device_accepts_empty_string_for_default() {
+        let h = make_handle();
+        let empty = CString::new("").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_set_audio_device(h, empty.as_ptr()) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_audio_device_rejects_null_string() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_audio_device(h, std::ptr::null()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn start_audio_recording_rejects_null_or_empty_path() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_start_audio_recording(h, std::ptr::null()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        let empty = CString::new("").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_start_audio_recording(h, empty.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn audio_recording_start_stop_round_trip() {
+        // Write to a temp file path so the controller's WavWriter
+        // has somewhere it can open. We don't inspect the output —
+        // just exercise the command plumbing.
+        let h = make_handle();
+        let tmp = std::env::temp_dir().join(format!(
+            "sdr-ffi-test-{}.wav",
+            std::process::id()
+        ));
+        let path = CString::new(tmp.to_string_lossy().into_owned()).unwrap();
+        assert_eq!(
+            unsafe { sdr_core_start_audio_recording(h, path.as_ptr()) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_stop_audio_recording(h) },
+            SdrCoreError::Ok.as_int()
+        );
+        // Give the controller a moment to process + drop the writer,
+        // then clean up. If the file wasn't created (e.g., the DSP
+        // thread hadn't processed the command yet) remove_file errs;
+        // that's fine — test doesn't depend on it.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let _ = std::fs::remove_file(&tmp);
+        destroy(h);
     }
 
     // ------------------------------------------------------

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -609,9 +609,7 @@ mod tests {
             SdrCoreError::InvalidHandle.as_int()
         );
         assert_eq!(
-            unsafe {
-                sdr_core_start_audio_recording(std::ptr::null_mut(), empty.as_ptr())
-            },
+            unsafe { sdr_core_start_audio_recording(std::ptr::null_mut(), empty.as_ptr()) },
             SdrCoreError::InvalidHandle.as_int()
         );
         assert_eq!(
@@ -666,10 +664,7 @@ mod tests {
         // has somewhere it can open. We don't inspect the output —
         // just exercise the command plumbing.
         let h = make_handle();
-        let tmp = std::env::temp_dir().join(format!(
-            "sdr-ffi-test-{}.wav",
-            std::process::id()
-        ));
+        let tmp = std::env::temp_dir().join(format!("sdr-ffi-test-{}.wav", std::process::id()));
         let path = CString::new(tmp.to_string_lossy().into_owned()).unwrap();
         assert_eq!(
             unsafe { sdr_core_start_audio_recording(h, path.as_ptr()) },

--- a/crates/sdr-ffi/src/enumerate.rs
+++ b/crates/sdr-ffi/src/enumerate.rs
@@ -117,6 +117,169 @@ pub unsafe extern "C" fn sdr_core_device_name(
     }
 }
 
+// ============================================================
+//  Audio output device enumeration (handle-free)
+// ============================================================
+//
+// Wraps `sdr_sink_audio::list_audio_sinks()` — the same snapshot
+// the engine uses internally when opening the sink. Each FFI call
+// re-runs the query. For ~10 devices at settings-panel open time
+// this is cheap; we accept the tiny race window if a device hot-
+// plugs between `count` and `name`/`uid` calls (the UI refreshes
+// on next panel open or on the v3 hot-plug listener).
+//
+// String fields come straight from the backend-specific
+// `AudioDevice` struct:
+//   - `display_name` is the human-readable label from
+//     `kAudioObjectPropertyName` on CoreAudio, or the PipeWire
+//     node description on Linux.
+//   - `node_name` is the caller-opaque UID — on CoreAudio it's the
+//     `AudioDeviceID` as a decimal string in v1 (per the inline
+//     docs in `sdr-sink-audio::coreaudio_impl`), migrating to the
+//     `kAudioDevicePropertyDeviceUID` string in a later PR. Empty
+//     means "system default output" on every backend.
+//
+// The caller-allocated-buffer + truncation contract matches
+// `sdr_core_device_name` above.
+
+/// Count audio output devices currently enumerable by the backend.
+///
+/// See `include/sdr_core.h` for the contract. Does not open any
+/// device and does not require a handle.
+///
+/// # Safety
+///
+/// No pointers accepted; inherently safe. Declared `unsafe` only
+/// because `extern "C"` requires it under the 2024 edition.
+#[unsafe(no_mangle)]
+pub extern "C" fn sdr_core_audio_device_count() -> u32 {
+    // Wrap in catch_unwind: a panic inside the CoreAudio / PipeWire
+    // enumeration path mustn't cross the FFI boundary. Fallback is
+    // "0 devices" — the honest answer when enumeration failed.
+    std::panic::catch_unwind(|| {
+        let devices = sdr_sink_audio::list_audio_sinks();
+        // Cap at u32::MAX defensively. In practice there are <100
+        // devices on any real system.
+        u32::try_from(devices.len()).unwrap_or(u32::MAX)
+    })
+    .unwrap_or_else(|_| {
+        set_last_error("sdr_core_audio_device_count: panic during enumeration");
+        0
+    })
+}
+
+/// Shared helper for `sdr_core_audio_device_name` / `_uid`. Picks
+/// the string to copy via `select_field` and follows the same
+/// write-and-NUL-terminate contract as `sdr_core_device_name`.
+///
+/// # Safety
+///
+/// `out_buf` must point to at least `buf_len` writable bytes, or
+/// be NULL (in which case we return `SDR_CORE_ERR_INVALID_ARG`).
+unsafe fn audio_device_string<F>(
+    fn_name: &str,
+    index: u32,
+    out_buf: *mut c_char,
+    buf_len: usize,
+    select_field: F,
+) -> i32
+where
+    F: Fn(&sdr_sink_audio::AudioDevice) -> &str + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
+{
+    let result = std::panic::catch_unwind(|| {
+        if out_buf.is_null() || buf_len == 0 {
+            set_last_error(format!("{fn_name}: out_buf is null or buf_len is 0"));
+            return SdrCoreError::InvalidArg.as_int();
+        }
+
+        let devices = sdr_sink_audio::list_audio_sinks();
+        let idx = usize::try_from(index).unwrap_or(usize::MAX);
+        let Some(dev) = devices.get(idx) else {
+            set_last_error(format!(
+                "{fn_name}: index {index} out of range (count={})",
+                devices.len()
+            ));
+            return SdrCoreError::Device.as_int();
+        };
+
+        let bytes = select_field(dev).as_bytes();
+        let max_payload = buf_len.saturating_sub(1); // reserve 1 for NUL
+        let to_copy = bytes.len().min(max_payload);
+
+        // SAFETY: Caller contract guarantees `out_buf` is writable
+        // for `buf_len` bytes; `to_copy <= buf_len - 1 < buf_len`
+        // and the NUL write at `out_buf.add(to_copy)` is within
+        // `buf_len` because `to_copy <= buf_len - 1`.
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf.cast::<u8>(), to_copy);
+            *out_buf.add(to_copy) = 0;
+        }
+
+        clear_last_error();
+
+        #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+        {
+            to_copy as i32
+        }
+    });
+
+    if let Ok(rc) = result {
+        rc
+    } else {
+        set_last_error(format!("{fn_name}: panic during audio device probe"));
+        SdrCoreError::Internal.as_int()
+    }
+}
+
+/// Fill `out_buf` with the human-readable display name of the audio
+/// output device at `index`. See header for the contract.
+///
+/// # Safety
+///
+/// `out_buf` must point to at least `buf_len` writable bytes, or
+/// be NULL (in which case we return `SDR_CORE_ERR_INVALID_ARG`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_audio_device_name(
+    index: u32,
+    out_buf: *mut c_char,
+    buf_len: usize,
+) -> i32 {
+    unsafe {
+        audio_device_string(
+            "sdr_core_audio_device_name",
+            index,
+            out_buf,
+            buf_len,
+            |dev| dev.display_name.as_str(),
+        )
+    }
+}
+
+/// Fill `out_buf` with the caller-opaque UID of the audio output
+/// device at `index` (the string to pass to
+/// `sdr_core_set_audio_device`). See header for the contract.
+///
+/// # Safety
+///
+/// `out_buf` must point to at least `buf_len` writable bytes, or
+/// be NULL (in which case we return `SDR_CORE_ERR_INVALID_ARG`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_audio_device_uid(
+    index: u32,
+    out_buf: *mut c_char,
+    buf_len: usize,
+) -> i32 {
+    unsafe {
+        audio_device_string(
+            "sdr_core_audio_device_uid",
+            index,
+            out_buf,
+            buf_len,
+            |dev| dev.node_name.as_str(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -168,5 +331,81 @@ mod tests {
             .expect("FFI writes a NUL at `written` per contract")
             .to_string_lossy();
         assert!(!got.is_empty(), "device name should not be empty");
+    }
+
+    // ------------------------------------------------------
+    //  Audio output device enumeration (ABI 0.4)
+    // ------------------------------------------------------
+
+    #[test]
+    fn audio_device_count_is_at_least_one() {
+        // The stub and every real backend include at least the
+        // "system default" entry with empty node_name, so this must
+        // always be >= 1 on any supported platform.
+        let c = sdr_core_audio_device_count();
+        assert!(c >= 1, "expected at least one audio device, got {c}");
+        assert!(c < 1024, "audio device count should be small, got {c}");
+    }
+
+    #[test]
+    fn audio_device_name_rejects_null_and_zero_len() {
+        let mut buf = [0_u8; 64];
+        assert_eq!(
+            unsafe { sdr_core_audio_device_name(0, std::ptr::null_mut(), 32) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_audio_device_name(0, buf.as_mut_ptr().cast::<c_char>(), 0) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+    }
+
+    #[test]
+    fn audio_device_uid_rejects_null_and_zero_len() {
+        let mut buf = [0_u8; 64];
+        assert_eq!(
+            unsafe { sdr_core_audio_device_uid(0, std::ptr::null_mut(), 32) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_audio_device_uid(0, buf.as_mut_ptr().cast::<c_char>(), 0) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+    }
+
+    #[test]
+    fn audio_device_name_out_of_range_returns_device_error() {
+        let mut buf = [0_u8; 64];
+        let rc = unsafe {
+            sdr_core_audio_device_name(u32::MAX, buf.as_mut_ptr().cast::<c_char>(), buf.len())
+        };
+        assert_eq!(rc, SdrCoreError::Device.as_int());
+    }
+
+    #[test]
+    fn audio_device_first_entry_round_trips() {
+        // Every backend returns at least one entry for index 0.
+        // Name may be empty on the stub's "Default" when the test
+        // harness happens to run with backend features off, so we
+        // only require that the call succeeds and NUL-terminates.
+        let count = sdr_core_audio_device_count();
+        assert!(count >= 1);
+
+        let mut buf = [0_u8; 256];
+        let rc = unsafe {
+            sdr_core_audio_device_name(0, buf.as_mut_ptr().cast::<c_char>(), buf.len())
+        };
+        assert!(rc >= 0, "expected success, got {rc}");
+        let written = usize::try_from(rc).expect("rc is non-negative after the assert above");
+        // Check NUL termination — not the string contents (backend-dependent).
+        let _ = CStr::from_bytes_with_nul(&buf[..=written])
+            .expect("FFI writes a NUL at `written` per contract");
+
+        // UID for index 0 is typically the empty string ("system default"),
+        // but that's backend policy — we just check the call works.
+        let mut uid_buf = [0_u8; 256];
+        let rc =
+            unsafe { sdr_core_audio_device_uid(0, uid_buf.as_mut_ptr().cast::<c_char>(), uid_buf.len()) };
+        assert!(rc >= 0, "expected success, got {rc}");
     }
 }

--- a/crates/sdr-ffi/src/enumerate.rs
+++ b/crates/sdr-ffi/src/enumerate.rs
@@ -283,13 +283,17 @@ where
         // gets the right answer. This does a backend query per
         // call in that path; the atomic multi-index case still
         // uses the cached snapshot.
+        //
+        // Delegates to `refresh_audio_device_snapshot()` so the
+        // refresh logic stays in one place — avoids drift between
+        // the `_count` path and the lazy path. Per CodeRabbit
+        // round 6 on PR #344.
         let idx = usize::try_from(index).unwrap_or(usize::MAX);
+        let needs_refresh = AUDIO_DEVICE_SNAPSHOT.with(|cell| cell.borrow().is_empty());
+        if needs_refresh {
+            let _ = refresh_audio_device_snapshot();
+        }
         AUDIO_DEVICE_SNAPSHOT.with(|cell| {
-            if cell.borrow().is_empty() {
-                let fresh = sdr_sink_audio::list_audio_sinks();
-                *cell.borrow_mut() = fresh;
-            }
-
             let snap = cell.borrow();
             let Some(dev) = snap.get(idx) else {
                 set_last_error(format!(

--- a/crates/sdr-ffi/src/enumerate.rs
+++ b/crates/sdr-ffi/src/enumerate.rs
@@ -15,6 +15,7 @@
 //! the memory, we fill it. This is the same contract as POSIX
 //! `strerror_r` / `snprintf`.
 
+use std::cell::RefCell;
 use std::ffi::c_char;
 
 use crate::error::{SdrCoreError, clear_last_error, set_last_error};
@@ -118,31 +119,93 @@ pub unsafe extern "C" fn sdr_core_device_name(
 }
 
 // ============================================================
-//  Audio output device enumeration (handle-free)
+//  Audio output device enumeration (handle-free, atomic)
 // ============================================================
 //
 // Wraps `sdr_sink_audio::list_audio_sinks()` — the same snapshot
-// the engine uses internally when opening the sink. Each FFI call
-// re-runs the query. For ~10 devices at settings-panel open time
-// this is cheap; we accept the tiny race window if a device hot-
-// plugs between `count` and `name`/`uid` calls (the UI refreshes
-// on next panel open or on the v3 hot-plug listener).
+// the engine uses internally when opening the sink. To give
+// callers a coherent name+UID pair for every index in a round
+// of enumeration (count → name(0) → uid(0) → name(1) → …), we
+// stash the snapshot in a **thread-local** and have the
+// per-index getters read from it.
+//
+// Why thread-local instead of a snapshot-handle API:
+//   - Same API shape as `sdr_core_device_count` / `_name` (the
+//     RTL-SDR enumerate), which hosts already use without a
+//     snapshot handle.
+//   - No new ABI surface: host code that was written against
+//     the pre-atomic draft (Swift `SdrCore.audioDevices`
+//     computed property on PR #344) keeps working — it just
+//     gets internal consistency for free.
+//   - Snapshot scope is "everything `_name` or `_uid` called on
+//     this thread between two `_count` calls." That matches
+//     SwiftUI pickers where the whole enumeration runs on the
+//     main actor in a synchronous loop.
+//
+// Semantics of the three entry points:
+//   - `_count()` **always** re-runs `list_audio_sinks()` and
+//     stores the result in the thread-local, then returns the
+//     length. Calling it twice gives you two independent
+//     snapshots.
+//   - `_name(i)` / `_uid(i)` read from the thread-local. If
+//     the thread-local is empty (first call in the thread, or
+//     after a previous snapshot observed zero devices), they
+//     lazy-refresh before reading. This makes "one-shot"
+//     callers that forgot to call `_count` also work — they
+//     just don't benefit from cross-index consistency beyond
+//     the single call.
+//
+// Hot-plug between `_count` and `_name(N-1)` is benign: the
+// getter still sees the original snapshot and returns the
+// name/UID for the element that was at index `i` when `_count`
+// ran, whether the device still exists or not. That's the
+// behavior the caller wants — any UI round-tripping back
+// through `sdr_core_set_audio_device` will get
+// `SinkError::DeviceNotFound` from the engine if the target
+// disappeared, and the next `_count` call reflects the new
+// state.
 //
 // String fields come straight from the backend-specific
 // `AudioDevice` struct:
 //   - `display_name` is the human-readable label from
 //     `kAudioObjectPropertyName` on CoreAudio, or the PipeWire
 //     node description on Linux.
-//   - `node_name` is the caller-opaque UID — on CoreAudio it's the
-//     `AudioDeviceID` as a decimal string in v1 (per the inline
-//     docs in `sdr-sink-audio::coreaudio_impl`), migrating to the
-//     `kAudioDevicePropertyDeviceUID` string in a later PR. Empty
-//     means "system default output" on every backend.
+//   - `node_name` is the caller-opaque UID — on CoreAudio it's
+//     the `AudioDeviceID` as a decimal string in v1 (per the
+//     inline docs in `sdr-sink-audio::coreaudio_impl`),
+//     migrating to the `kAudioDevicePropertyDeviceUID` string
+//     in a later PR. Empty means "system default output" on
+//     every backend.
 //
 // The caller-allocated-buffer + truncation contract matches
 // `sdr_core_device_name` above.
 
-/// Count audio output devices currently enumerable by the backend.
+thread_local! {
+    /// Per-thread snapshot of the device list. Replaced on each
+    /// `sdr_core_audio_device_count` call so the per-index
+    /// getters see a coherent view even if devices hot-plug
+    /// between calls. `RefCell` because we mutate it (assign the
+    /// new snapshot), but we never borrow across a re-entry so
+    /// the `borrow_mut` can't panic in practice.
+    static AUDIO_DEVICE_SNAPSHOT: RefCell<Vec<sdr_sink_audio::AudioDevice>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// Refresh the thread-local snapshot and return it as a length.
+/// Broken out so both `_count` and the lazy-refresh path in
+/// `audio_device_string` share one implementation.
+fn refresh_audio_device_snapshot() -> usize {
+    let devices = sdr_sink_audio::list_audio_sinks();
+    let len = devices.len();
+    AUDIO_DEVICE_SNAPSHOT.with(|cell| {
+        *cell.borrow_mut() = devices;
+    });
+    len
+}
+
+/// Count audio output devices currently enumerable by the backend,
+/// taking a fresh snapshot. Subsequent `_name` / `_uid` calls on
+/// this thread read from that snapshot.
 ///
 /// See `include/sdr_core.h` for the contract. Does not open any
 /// device and does not require a handle.
@@ -157,10 +220,10 @@ pub extern "C" fn sdr_core_audio_device_count() -> u32 {
     // enumeration path mustn't cross the FFI boundary. Fallback is
     // "0 devices" — the honest answer when enumeration failed.
     std::panic::catch_unwind(|| {
-        let devices = sdr_sink_audio::list_audio_sinks();
+        let len = refresh_audio_device_snapshot();
         // Cap at u32::MAX defensively. In practice there are <100
         // devices on any real system.
-        u32::try_from(devices.len()).unwrap_or(u32::MAX)
+        u32::try_from(len).unwrap_or(u32::MAX)
     })
     .unwrap_or_else(|_| {
         set_last_error("sdr_core_audio_device_count: panic during enumeration");
@@ -171,6 +234,10 @@ pub extern "C" fn sdr_core_audio_device_count() -> u32 {
 /// Shared helper for `sdr_core_audio_device_name` / `_uid`. Picks
 /// the string to copy via `select_field` and follows the same
 /// write-and-NUL-terminate contract as `sdr_core_device_name`.
+/// Reads from the thread-local snapshot; lazy-refreshes the
+/// snapshot when empty so a caller that forgot to call `_count`
+/// first still gets a usable result (it just won't be
+/// consistent with any prior `_count` return).
 ///
 /// # Safety
 ///
@@ -184,7 +251,9 @@ unsafe fn audio_device_string<F>(
     select_field: F,
 ) -> i32
 where
-    F: Fn(&sdr_sink_audio::AudioDevice) -> &str + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
+    F: Fn(&sdr_sink_audio::AudioDevice) -> &str
+        + std::panic::UnwindSafe
+        + std::panic::RefUnwindSafe,
 {
     let result = std::panic::catch_unwind(|| {
         if out_buf.is_null() || buf_len == 0 {
@@ -192,35 +261,47 @@ where
             return SdrCoreError::InvalidArg.as_int();
         }
 
-        let devices = sdr_sink_audio::list_audio_sinks();
+        // Lazy-refresh on first use — a caller that jumps
+        // straight to `_name(0)` without calling `_count` still
+        // gets the right answer. This does a backend query per
+        // call in that path; the atomic multi-index case still
+        // uses the cached snapshot.
         let idx = usize::try_from(index).unwrap_or(usize::MAX);
-        let Some(dev) = devices.get(idx) else {
-            set_last_error(format!(
-                "{fn_name}: index {index} out of range (count={})",
-                devices.len()
-            ));
-            return SdrCoreError::Device.as_int();
-        };
+        AUDIO_DEVICE_SNAPSHOT.with(|cell| {
+            if cell.borrow().is_empty() {
+                let fresh = sdr_sink_audio::list_audio_sinks();
+                *cell.borrow_mut() = fresh;
+            }
 
-        let bytes = select_field(dev).as_bytes();
-        let max_payload = buf_len.saturating_sub(1); // reserve 1 for NUL
-        let to_copy = bytes.len().min(max_payload);
+            let snap = cell.borrow();
+            let Some(dev) = snap.get(idx) else {
+                set_last_error(format!(
+                    "{fn_name}: index {index} out of range (count={})",
+                    snap.len()
+                ));
+                return SdrCoreError::Device.as_int();
+            };
 
-        // SAFETY: Caller contract guarantees `out_buf` is writable
-        // for `buf_len` bytes; `to_copy <= buf_len - 1 < buf_len`
-        // and the NUL write at `out_buf.add(to_copy)` is within
-        // `buf_len` because `to_copy <= buf_len - 1`.
-        unsafe {
-            std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf.cast::<u8>(), to_copy);
-            *out_buf.add(to_copy) = 0;
-        }
+            let bytes = select_field(dev).as_bytes();
+            let max_payload = buf_len.saturating_sub(1); // reserve 1 for NUL
+            let to_copy = bytes.len().min(max_payload);
 
-        clear_last_error();
+            // SAFETY: Caller contract guarantees `out_buf` is writable
+            // for `buf_len` bytes; `to_copy <= buf_len - 1 < buf_len`
+            // and the NUL write at `out_buf.add(to_copy)` is within
+            // `buf_len` because `to_copy <= buf_len - 1`.
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf.cast::<u8>(), to_copy);
+                *out_buf.add(to_copy) = 0;
+            }
 
-        #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
-        {
-            to_copy as i32
-        }
+            clear_last_error();
+
+            #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+            {
+                to_copy as i32
+            }
+        })
     });
 
     if let Ok(rc) = result {
@@ -383,6 +464,65 @@ mod tests {
     }
 
     #[test]
+    fn audio_device_name_and_uid_share_snapshot_after_count() {
+        // Regression test for the CodeRabbit round 1 finding on
+        // PR #344: before the thread-local snapshot, `_name(i)`
+        // and `_uid(i)` each re-ran `list_audio_sinks()`, so a
+        // hot-plug between the two could pair a name from one
+        // snapshot with a UID from another. The thread-local
+        // pins the snapshot to the last `_count` call — each
+        // index pairs `_name(i)` with `_uid(i)` consistently.
+        //
+        // We can't force a hot-plug in a unit test, but we can
+        // verify that between `_count` and the per-index reads
+        // the same index always resolves to matching strings
+        // from a single backend call, regardless of what a
+        // parallel thread's own snapshot looks like.
+        let count = sdr_core_audio_device_count();
+        assert!(count >= 1);
+
+        for i in 0..count {
+            let mut name_buf = [0_u8; 256];
+            let mut uid_buf = [0_u8; 256];
+            let rc_name = unsafe {
+                sdr_core_audio_device_name(
+                    i,
+                    name_buf.as_mut_ptr().cast::<c_char>(),
+                    name_buf.len(),
+                )
+            };
+            let rc_uid = unsafe {
+                sdr_core_audio_device_uid(i, uid_buf.as_mut_ptr().cast::<c_char>(), uid_buf.len())
+            };
+            assert!(rc_name >= 0);
+            assert!(rc_uid >= 0);
+            // Both calls must succeed for every index the count
+            // call reported — if `_uid` returned Device error while
+            // `_name` succeeded, that's the inconsistency the
+            // thread-local is meant to prevent.
+        }
+    }
+
+    #[test]
+    fn audio_device_lazy_refresh_when_count_not_called() {
+        // A caller that jumps straight to `_name(0)` without
+        // calling `_count` first should still get a valid answer.
+        // We exercise this on a fresh thread so there's no prior
+        // snapshot in thread-local storage.
+        let handle = std::thread::spawn(|| {
+            let mut buf = [0_u8; 256];
+            let rc = unsafe {
+                sdr_core_audio_device_name(0, buf.as_mut_ptr().cast::<c_char>(), buf.len())
+            };
+            assert!(
+                rc >= 0,
+                "lazy refresh path must return a valid answer for index 0, got {rc}"
+            );
+        });
+        handle.join().expect("thread should exit cleanly");
+    }
+
+    #[test]
     fn audio_device_first_entry_round_trips() {
         // Every backend returns at least one entry for index 0.
         // Name may be empty on the stub's "Default" when the test
@@ -392,9 +532,8 @@ mod tests {
         assert!(count >= 1);
 
         let mut buf = [0_u8; 256];
-        let rc = unsafe {
-            sdr_core_audio_device_name(0, buf.as_mut_ptr().cast::<c_char>(), buf.len())
-        };
+        let rc =
+            unsafe { sdr_core_audio_device_name(0, buf.as_mut_ptr().cast::<c_char>(), buf.len()) };
         assert!(rc >= 0, "expected success, got {rc}");
         let written = usize::try_from(rc).expect("rc is non-negative after the assert above");
         // Check NUL termination — not the string contents (backend-dependent).
@@ -404,8 +543,9 @@ mod tests {
         // UID for index 0 is typically the empty string ("system default"),
         // but that's backend policy — we just check the call works.
         let mut uid_buf = [0_u8; 256];
-        let rc =
-            unsafe { sdr_core_audio_device_uid(0, uid_buf.as_mut_ptr().cast::<c_char>(), uid_buf.len()) };
+        let rc = unsafe {
+            sdr_core_audio_device_uid(0, uid_buf.as_mut_ptr().cast::<c_char>(), uid_buf.len())
+        };
         assert!(rc >= 0, "expected success, got {rc}");
     }
 }

--- a/crates/sdr-ffi/src/enumerate.rs
+++ b/crates/sdr-ffi/src/enumerate.rs
@@ -423,6 +423,35 @@ mod tests {
     // ------------------------------------------------------
     //  Audio output device enumeration (ABI 0.4)
     // ------------------------------------------------------
+    //
+    // Shared test constants. Workspace coding guideline is to
+    // name magic numbers (buffer sizes, thresholds); these are
+    // the values the audio_device_* tests below share. Per
+    // CodeRabbit round 3 on PR #344.
+
+    /// Buffer size used by the rejection tests that exercise the
+    /// null / zero-length / out-of-range paths. Larger than the
+    /// `buf_len` argument they pass — the buffer itself is
+    /// never written, so any reasonable size works.
+    const REJECTION_BUF_LEN: usize = 64;
+
+    /// Buffer size used by the round-trip and snapshot tests.
+    /// Covers every CoreAudio display name (real device names
+    /// top out around 60 chars) and the decimal-`AudioDeviceID`
+    /// UID form the v1 backend emits.
+    const AUDIO_BUF_LEN: usize = 256;
+
+    /// Inner `buf_len` passed to the rejection-path `_name` /
+    /// `_uid` calls that pass a null pointer. The exact value
+    /// doesn't matter — the null-check trips first — but it
+    /// should be nonzero to make the test target the null branch
+    /// specifically, not the `buf_len == 0` branch.
+    const REJECTION_INNER_BUF_LEN: usize = 32;
+
+    /// Sanity upper bound on `sdr_core_audio_device_count`. Real
+    /// systems rarely have more than a few dozen audio devices;
+    /// anything over this suggests enumeration went pathological.
+    const MAX_REASONABLE_AUDIO_DEVICE_COUNT: u32 = 1024;
 
     #[test]
     fn audio_device_count_is_at_least_one() {
@@ -431,14 +460,17 @@ mod tests {
         // always be >= 1 on any supported platform.
         let c = sdr_core_audio_device_count();
         assert!(c >= 1, "expected at least one audio device, got {c}");
-        assert!(c < 1024, "audio device count should be small, got {c}");
+        assert!(
+            c < MAX_REASONABLE_AUDIO_DEVICE_COUNT,
+            "audio device count should be small, got {c}"
+        );
     }
 
     #[test]
     fn audio_device_name_rejects_null_and_zero_len() {
-        let mut buf = [0_u8; 64];
+        let mut buf = [0_u8; REJECTION_BUF_LEN];
         assert_eq!(
-            unsafe { sdr_core_audio_device_name(0, std::ptr::null_mut(), 32) },
+            unsafe { sdr_core_audio_device_name(0, std::ptr::null_mut(), REJECTION_INNER_BUF_LEN) },
             SdrCoreError::InvalidArg.as_int()
         );
         assert_eq!(
@@ -449,9 +481,9 @@ mod tests {
 
     #[test]
     fn audio_device_uid_rejects_null_and_zero_len() {
-        let mut buf = [0_u8; 64];
+        let mut buf = [0_u8; REJECTION_BUF_LEN];
         assert_eq!(
-            unsafe { sdr_core_audio_device_uid(0, std::ptr::null_mut(), 32) },
+            unsafe { sdr_core_audio_device_uid(0, std::ptr::null_mut(), REJECTION_INNER_BUF_LEN) },
             SdrCoreError::InvalidArg.as_int()
         );
         assert_eq!(
@@ -462,7 +494,7 @@ mod tests {
 
     #[test]
     fn audio_device_name_out_of_range_returns_device_error() {
-        let mut buf = [0_u8; 64];
+        let mut buf = [0_u8; REJECTION_BUF_LEN];
         let rc = unsafe {
             sdr_core_audio_device_name(u32::MAX, buf.as_mut_ptr().cast::<c_char>(), buf.len())
         };
@@ -479,7 +511,8 @@ mod tests {
             // Poison the thread-local with a known error — calling
             // `_name` with a null buffer returns InvalidArg and
             // sets the last-error message.
-            let rc = unsafe { sdr_core_audio_device_name(0, std::ptr::null_mut(), 64) };
+            let rc =
+                unsafe { sdr_core_audio_device_name(0, std::ptr::null_mut(), REJECTION_BUF_LEN) };
             assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
             let msg_ptr = crate::error::sdr_core_last_error_message();
             assert!(
@@ -518,8 +551,8 @@ mod tests {
         assert!(count >= 1);
 
         for i in 0..count {
-            let mut name_buf = [0_u8; 256];
-            let mut uid_buf = [0_u8; 256];
+            let mut name_buf = [0_u8; AUDIO_BUF_LEN];
+            let mut uid_buf = [0_u8; AUDIO_BUF_LEN];
             let rc_name = unsafe {
                 sdr_core_audio_device_name(
                     i,
@@ -546,7 +579,7 @@ mod tests {
         // We exercise this on a fresh thread so there's no prior
         // snapshot in thread-local storage.
         let handle = std::thread::spawn(|| {
-            let mut buf = [0_u8; 256];
+            let mut buf = [0_u8; AUDIO_BUF_LEN];
             let rc = unsafe {
                 sdr_core_audio_device_name(0, buf.as_mut_ptr().cast::<c_char>(), buf.len())
             };
@@ -567,7 +600,7 @@ mod tests {
         let count = sdr_core_audio_device_count();
         assert!(count >= 1);
 
-        let mut buf = [0_u8; 256];
+        let mut buf = [0_u8; AUDIO_BUF_LEN];
         let rc =
             unsafe { sdr_core_audio_device_name(0, buf.as_mut_ptr().cast::<c_char>(), buf.len()) };
         assert!(rc >= 0, "expected success, got {rc}");
@@ -578,7 +611,7 @@ mod tests {
 
         // UID for index 0 is typically the empty string ("system default"),
         // but that's backend policy — we just check the call works.
-        let mut uid_buf = [0_u8; 256];
+        let mut uid_buf = [0_u8; AUDIO_BUF_LEN];
         let rc = unsafe {
             sdr_core_audio_device_uid(0, uid_buf.as_mut_ptr().cast::<c_char>(), uid_buf.len())
         };

--- a/crates/sdr-ffi/src/enumerate.rs
+++ b/crates/sdr-ffi/src/enumerate.rs
@@ -221,6 +221,12 @@ pub extern "C" fn sdr_core_audio_device_count() -> u32 {
     // "0 devices" — the honest answer when enumeration failed.
     std::panic::catch_unwind(|| {
         let len = refresh_audio_device_snapshot();
+        // Clear the thread-local last-error on success — the
+        // header contract says `sdr_core_last_error_message`
+        // reflects the *most recent* sdr_core_* call on this
+        // thread, so a failed earlier probe must not leak into
+        // a successful refresh. Per CodeRabbit round 2 on PR #344.
+        clear_last_error();
         // Cap at u32::MAX defensively. In practice there are <100
         // devices on any real system.
         u32::try_from(len).unwrap_or(u32::MAX)
@@ -461,6 +467,36 @@ mod tests {
             sdr_core_audio_device_name(u32::MAX, buf.as_mut_ptr().cast::<c_char>(), buf.len())
         };
         assert_eq!(rc, SdrCoreError::Device.as_int());
+    }
+
+    #[test]
+    fn audio_device_count_clears_stale_last_error() {
+        // Regression: before the round 2 fix, a successful
+        // `_count` didn't clear a stale last-error from a prior
+        // failed probe. Run this on its own thread so the
+        // thread-local state is isolated from other tests.
+        let handle = std::thread::spawn(|| {
+            // Poison the thread-local with a known error — calling
+            // `_name` with a null buffer returns InvalidArg and
+            // sets the last-error message.
+            let rc = unsafe { sdr_core_audio_device_name(0, std::ptr::null_mut(), 64) };
+            assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+            let msg_ptr = crate::error::sdr_core_last_error_message();
+            assert!(
+                !msg_ptr.is_null(),
+                "last-error should be set after failed probe"
+            );
+
+            // Now run a successful `_count` — it must clear the
+            // last-error per the header contract.
+            let _ = sdr_core_audio_device_count();
+            let msg_ptr = crate::error::sdr_core_last_error_message();
+            assert!(
+                msg_ptr.is_null(),
+                "sdr_core_audio_device_count must clear the thread-local last-error on success"
+            );
+        });
+        handle.join().expect("thread should exit cleanly");
     }
 
     #[test]

--- a/crates/sdr-ffi/src/enumerate.rs
+++ b/crates/sdr-ffi/src/enumerate.rs
@@ -232,6 +232,17 @@ pub extern "C" fn sdr_core_audio_device_count() -> u32 {
         u32::try_from(len).unwrap_or(u32::MAX)
     })
     .unwrap_or_else(|_| {
+        // Clear the stale snapshot on failure. Otherwise a prior
+        // successful `_count` that populated the thread-local
+        // could hand out stale name/uid data to subsequent
+        // `_name(i)` / `_uid(i)` calls on the same thread —
+        // getters lazy-refresh only when the snapshot is empty,
+        // so a non-empty-but-stale snapshot would silently
+        // disagree with the `0` count we're about to return.
+        // Per CodeRabbit round 4 on PR #344.
+        AUDIO_DEVICE_SNAPSHOT.with(|cell| {
+            cell.borrow_mut().clear();
+        });
         set_last_error("sdr_core_audio_device_count: panic during enumeration");
         0
     })

--- a/crates/sdr-ffi/src/enumerate.rs
+++ b/crates/sdr-ffi/src/enumerate.rs
@@ -554,32 +554,52 @@ mod tests {
         // index pairs `_name(i)` with `_uid(i)` consistently.
         //
         // We can't force a hot-plug in a unit test, but we can
-        // verify that between `_count` and the per-index reads
-        // the same index always resolves to matching strings
-        // from a single backend call, regardless of what a
-        // parallel thread's own snapshot looks like.
+        // clone the thread-local snapshot right after `_count`
+        // and assert the FFI strings match it byte-for-byte
+        // across the whole index range. Per CodeRabbit round 5
+        // tightening on PR #344.
         let count = sdr_core_audio_device_count();
         assert!(count >= 1);
+        let expected = AUDIO_DEVICE_SNAPSHOT.with(|cell| cell.borrow().clone());
+        assert_eq!(
+            expected.len(),
+            usize::try_from(count).expect("u32 count should fit usize"),
+            "snapshot length should match _count() return"
+        );
 
-        for i in 0..count {
+        for (i, dev) in expected.iter().enumerate() {
+            let idx = u32::try_from(i).expect("index fits in u32");
             let mut name_buf = [0_u8; AUDIO_BUF_LEN];
             let mut uid_buf = [0_u8; AUDIO_BUF_LEN];
             let rc_name = unsafe {
                 sdr_core_audio_device_name(
-                    i,
+                    idx,
                     name_buf.as_mut_ptr().cast::<c_char>(),
                     name_buf.len(),
                 )
             };
             let rc_uid = unsafe {
-                sdr_core_audio_device_uid(i, uid_buf.as_mut_ptr().cast::<c_char>(), uid_buf.len())
+                sdr_core_audio_device_uid(idx, uid_buf.as_mut_ptr().cast::<c_char>(), uid_buf.len())
             };
             assert!(rc_name >= 0);
             assert!(rc_uid >= 0);
-            // Both calls must succeed for every index the count
-            // call reported — if `_uid` returned Device error while
-            // `_name` succeeded, that's the inconsistency the
-            // thread-local is meant to prevent.
+
+            // Assert byte-for-byte equality between the FFI
+            // strings and the snapshot's `display_name` /
+            // `node_name`. Catches any future regression where
+            // a getter stops reading from the thread-local
+            // (e.g. a refactor that re-introduced the per-call
+            // `list_audio_sinks()` round-trip).
+            let written_name = usize::try_from(rc_name).expect("name rc should be non-negative");
+            let written_uid = usize::try_from(rc_uid).expect("uid rc should be non-negative");
+            let got_name = CStr::from_bytes_with_nul(&name_buf[..=written_name])
+                .expect("name should be NUL-terminated")
+                .to_string_lossy();
+            let got_uid = CStr::from_bytes_with_nul(&uid_buf[..=written_uid])
+                .expect("uid should be NUL-terminated")
+                .to_string_lossy();
+            assert_eq!(got_name, dev.display_name);
+            assert_eq!(got_uid, dev.node_name);
         }
     }
 

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -53,6 +53,8 @@ pub const SDR_EVT_DEVICE_INFO: i32 = 4;
 pub const SDR_EVT_GAIN_LIST: i32 = 5;
 pub const SDR_EVT_DISPLAY_BANDWIDTH: i32 = 6;
 pub const SDR_EVT_ERROR: i32 = 7;
+pub const SDR_EVT_AUDIO_RECORDING_STARTED: i32 = 8;
+pub const SDR_EVT_AUDIO_RECORDING_STOPPED: i32 = 9;
 
 // ============================================================
 //  SdrEvent tagged union — `#[repr(C)]` layout matching the
@@ -84,19 +86,30 @@ pub struct SdrEventError {
     pub utf8: *const c_char,
 }
 
+/// Payload for `SDR_EVT_AUDIO_RECORDING_STARTED`. Borrowed pointer
+/// to the filesystem path the engine opened for writing. Valid only
+/// for the duration of the callback.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SdrEventAudioRecording {
+    pub path_utf8: *const c_char,
+}
+
 /// C-layout tagged union of event payloads. Which field is valid
 /// is determined by the `kind` discriminant on the enclosing
 /// `SdrEvent`:
 ///
-/// | `kind`                          | Valid field              |
-/// |---------------------------------|--------------------------|
-/// | `SDR_EVT_SOURCE_STOPPED`        | none                     |
-/// | `SDR_EVT_SAMPLE_RATE_CHANGED`   | `sample_rate_hz`         |
-/// | `SDR_EVT_SIGNAL_LEVEL`          | `signal_level_db`        |
-/// | `SDR_EVT_DEVICE_INFO`           | `device_info.utf8`       |
-/// | `SDR_EVT_GAIN_LIST`             | `gain_list.{values,len}` |
-/// | `SDR_EVT_DISPLAY_BANDWIDTH`     | `display_bandwidth_hz`   |
-/// | `SDR_EVT_ERROR`                 | `error.utf8`             |
+/// | `kind`                            | Valid field                  |
+/// |-----------------------------------|------------------------------|
+/// | `SDR_EVT_SOURCE_STOPPED`          | none                         |
+/// | `SDR_EVT_SAMPLE_RATE_CHANGED`     | `sample_rate_hz`             |
+/// | `SDR_EVT_SIGNAL_LEVEL`            | `signal_level_db`            |
+/// | `SDR_EVT_DEVICE_INFO`             | `device_info.utf8`           |
+/// | `SDR_EVT_GAIN_LIST`               | `gain_list.{values,len}`     |
+/// | `SDR_EVT_DISPLAY_BANDWIDTH`       | `display_bandwidth_hz`       |
+/// | `SDR_EVT_ERROR`                   | `error.utf8`                 |
+/// | `SDR_EVT_AUDIO_RECORDING_STARTED` | `audio_recording.path_utf8`  |
+/// | `SDR_EVT_AUDIO_RECORDING_STOPPED` | none                         |
 ///
 /// `_placeholder` exists so `SOURCE_STOPPED` events (which carry
 /// no payload) can still construct the struct with a meaningful
@@ -110,6 +123,7 @@ pub union SdrEventPayload {
     pub device_info: SdrEventDeviceInfo,
     pub gain_list: SdrEventGainList,
     pub error: SdrEventError,
+    pub audio_recording: SdrEventAudioRecording,
     /// Placeholder for kinds that carry no payload (e.g.,
     /// `SDR_EVT_SOURCE_STOPPED`). Accessing this field is always
     /// valid as a zero-byte read.
@@ -263,9 +277,31 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
             }
         }
 
+        DspToUi::AudioRecordingStarted(path) => {
+            // Sanitize interior NULs rather than dropping the event
+            // on an unusual path (same policy as DeviceInfo).
+            let sanitized = path.to_string_lossy().replace('\0', "?");
+            let Ok(cstr) = CString::new(sanitized) else {
+                return None;
+            };
+            let ptr = cstr.as_ptr();
+            owned_cstring = Some(cstr);
+            SdrEvent {
+                kind: SDR_EVT_AUDIO_RECORDING_STARTED,
+                payload: SdrEventPayload {
+                    audio_recording: SdrEventAudioRecording { path_utf8: ptr },
+                },
+            }
+        }
+
+        DspToUi::AudioRecordingStopped => SdrEvent {
+            kind: SDR_EVT_AUDIO_RECORDING_STOPPED,
+            payload: SdrEventPayload { _placeholder: 0 },
+        },
+
         // Variants not yet exposed at the FFI boundary. Silently
-        // dropped in v1; a v2 ABI minor bump grows the surface to
-        // cover them as each feature lands in the macOS SwiftUI
+        // dropped in v1; a future ABI minor bump grows the surface
+        // to cover them as each feature lands in the macOS SwiftUI
         // host.
         //
         // Specifically:
@@ -273,9 +309,8 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         //     event callback — FFT frames go through the dedicated
         //     pull function (`sdr_core_pull_fft`) instead so the
         //     render loop stays on the main thread.
-        //   - `AudioRecordingStarted/Stopped` + `IqRecordingStarted/
-        //     Stopped` light up when recording controls land in
-        //     the macOS UI (v2 backlog issues #238 / #239).
+        //   - `IqRecordingStarted/Stopped` light up when IQ
+        //     recording controls land in the macOS UI (issue #238).
         //   - `DemodModeChanged` is the transcription-session
         //     boundary event. macOS transcription IS on the
         //     roadmap — it's currently blocked on a Metal
@@ -295,8 +330,6 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         // of existing ones), so a future minor bump won't break
         // older hosts that don't know about them.
         DspToUi::FftData(_)
-        | DspToUi::AudioRecordingStarted(_)
-        | DspToUi::AudioRecordingStopped
         | DspToUi::IqRecordingStarted(_)
         | DspToUi::IqRecordingStopped
         | DspToUi::DemodModeChanged(_)
@@ -572,6 +605,8 @@ mod tests {
         assert_eq!(SDR_EVT_GAIN_LIST, 5);
         assert_eq!(SDR_EVT_DISPLAY_BANDWIDTH, 6);
         assert_eq!(SDR_EVT_ERROR, 7);
+        assert_eq!(SDR_EVT_AUDIO_RECORDING_STARTED, 8);
+        assert_eq!(SDR_EVT_AUDIO_RECORDING_STOPPED, 9);
     }
 
     #[test]

--- a/crates/sdr-ffi/src/lib.rs
+++ b/crates/sdr-ffi/src/lib.rs
@@ -53,18 +53,23 @@ pub mod lifecycle;
 // the rlib (in-tree integration tests) can reference them via
 // `sdr_ffi::sdr_core_*`.
 pub use command::{
-    sdr_core_set_agc, sdr_core_set_auto_squelch, sdr_core_set_bandwidth, sdr_core_set_dc_blocking,
-    sdr_core_set_decimation, sdr_core_set_deemphasis, sdr_core_set_demod_mode,
-    sdr_core_set_fft_rate, sdr_core_set_fft_size, sdr_core_set_fft_window, sdr_core_set_gain,
-    sdr_core_set_iq_correction, sdr_core_set_iq_inversion, sdr_core_set_ppm_correction,
-    sdr_core_set_sample_rate, sdr_core_set_squelch_db, sdr_core_set_squelch_enabled,
-    sdr_core_set_vfo_offset, sdr_core_set_volume, sdr_core_start, sdr_core_stop, sdr_core_tune,
+    sdr_core_set_agc, sdr_core_set_audio_device, sdr_core_set_auto_squelch, sdr_core_set_bandwidth,
+    sdr_core_set_dc_blocking, sdr_core_set_decimation, sdr_core_set_deemphasis,
+    sdr_core_set_demod_mode, sdr_core_set_fft_rate, sdr_core_set_fft_size, sdr_core_set_fft_window,
+    sdr_core_set_gain, sdr_core_set_iq_correction, sdr_core_set_iq_inversion,
+    sdr_core_set_ppm_correction, sdr_core_set_sample_rate, sdr_core_set_squelch_db,
+    sdr_core_set_squelch_enabled, sdr_core_set_vfo_offset, sdr_core_set_volume,
+    sdr_core_start, sdr_core_start_audio_recording, sdr_core_stop, sdr_core_stop_audio_recording,
+    sdr_core_tune,
 };
-pub use enumerate::{sdr_core_device_count, sdr_core_device_name};
+pub use enumerate::{
+    sdr_core_audio_device_count, sdr_core_audio_device_name, sdr_core_audio_device_uid,
+    sdr_core_device_count, sdr_core_device_name,
+};
 pub use error::sdr_core_last_error_message;
 pub use event::{
-    SdrEvent, SdrEventCallback, SdrEventDeviceInfo, SdrEventError, SdrEventGainList,
-    SdrEventPayload, sdr_core_set_event_callback,
+    SdrEvent, SdrEventAudioRecording, SdrEventCallback, SdrEventDeviceInfo, SdrEventError,
+    SdrEventGainList, SdrEventPayload, sdr_core_set_event_callback,
 };
 pub use fft::{SdrFftCallback, SdrFftFrame, sdr_core_pull_fft};
 pub use handle::SdrCore;

--- a/crates/sdr-ffi/src/lib.rs
+++ b/crates/sdr-ffi/src/lib.rs
@@ -58,9 +58,8 @@ pub use command::{
     sdr_core_set_demod_mode, sdr_core_set_fft_rate, sdr_core_set_fft_size, sdr_core_set_fft_window,
     sdr_core_set_gain, sdr_core_set_iq_correction, sdr_core_set_iq_inversion,
     sdr_core_set_ppm_correction, sdr_core_set_sample_rate, sdr_core_set_squelch_db,
-    sdr_core_set_squelch_enabled, sdr_core_set_vfo_offset, sdr_core_set_volume,
-    sdr_core_start, sdr_core_start_audio_recording, sdr_core_stop, sdr_core_stop_audio_recording,
-    sdr_core_tune,
+    sdr_core_set_squelch_enabled, sdr_core_set_vfo_offset, sdr_core_set_volume, sdr_core_start,
+    sdr_core_start_audio_recording, sdr_core_stop, sdr_core_stop_audio_recording, sdr_core_tune,
 };
 pub use enumerate::{
     sdr_core_audio_device_count, sdr_core_audio_device_name, sdr_core_audio_device_uid,

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 3;
+pub const ABI_VERSION_MINOR: u32 = 4;
 
 /// Return the ABI version the library was built with.
 ///
@@ -326,7 +326,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 3);
+        assert!(ABI_VERSION_MINOR == 4);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -158,12 +158,26 @@ int32_t sdr_core_device_name(
  * the host surface them in a Settings picker. They are handle-free
  * and can be called before `sdr_core_create`.
  *
- * Each call to `sdr_core_audio_device_count` / `_name` / `_uid`
- * independently re-runs the backend query, so in the rare case
- * where a device hot-plugs mid-enumeration, the host may see an
- * inconsistent index mapping. In practice hosts call these once
- * per Settings panel open; a v3 ABI bump adds a hot-plug listener
- * that pushes a dedicated event instead of requiring polling.
+ * Atomicity (thread-local snapshot):
+ *   - `sdr_core_audio_device_count` runs the backend query and
+ *     stores the result in a per-thread snapshot.
+ *   - `sdr_core_audio_device_name` and `_uid` read from that
+ *     snapshot, so for a given thread, `_name(i)` and `_uid(i)`
+ *     always refer to the same device entry — even if a device
+ *     hot-plugs between the two calls. Callers get coherent
+ *     name/UID pairs for every index returned by `_count`.
+ *   - Calling `_name(i)` / `_uid(i)` without a prior `_count` on
+ *     this thread triggers a lazy refresh. That path doesn't
+ *     benefit from cross-index consistency (each call refreshes
+ *     if the snapshot was empty), but single-device pickers
+ *     still work.
+ *   - Each new `_count` call discards the previous snapshot and
+ *     takes a fresh one, so the pattern "call count, iterate
+ *     indices, call count again" gives the host two independent
+ *     views and lets it detect hot-plug by comparing sizes.
+ *
+ * A v3 hot-plug listener (pushed as a dedicated event variant)
+ * is on the roadmap for continuous device-presence tracking.
  *
  * `_name` returns the human-readable label (e.g. "MacBook Pro
  * Speakers"). `_uid` returns the caller-opaque identifier that

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 3
+#define SDR_CORE_ABI_VERSION_MINOR 4
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -143,6 +143,49 @@ uint32_t sdr_core_device_count(void);
  * `SdrCore` handle.
  */
 int32_t sdr_core_device_name(
+    uint32_t index,
+    char*    out_buf,
+    size_t   buf_len
+);
+
+/* ================================================================ */
+/*  Audio output device enumeration                                 */
+/* ================================================================ */
+
+/*
+ * These functions snapshot the backend's list of output devices
+ * (CoreAudio on macOS, PipeWire on Linux, stub on others) and let
+ * the host surface them in a Settings picker. They are handle-free
+ * and can be called before `sdr_core_create`.
+ *
+ * Each call to `sdr_core_audio_device_count` / `_name` / `_uid`
+ * independently re-runs the backend query, so in the rare case
+ * where a device hot-plugs mid-enumeration, the host may see an
+ * inconsistent index mapping. In practice hosts call these once
+ * per Settings panel open; a v3 ABI bump adds a hot-plug listener
+ * that pushes a dedicated event instead of requiring polling.
+ *
+ * `_name` returns the human-readable label (e.g. "MacBook Pro
+ * Speakers"). `_uid` returns the caller-opaque identifier that
+ * `sdr_core_set_audio_device` accepts. On macOS the UID is
+ * currently the `AudioDeviceID` as a decimal string and is
+ * session-scoped (stable within a process lifetime); a later PR
+ * migrates to the persistent `kAudioDevicePropertyDeviceUID`
+ * string without an ABI change since callers treat it as opaque.
+ *
+ * Empty string as UID means "system default output" on every
+ * backend — index 0 is typically that entry.
+ */
+
+uint32_t sdr_core_audio_device_count(void);
+
+int32_t sdr_core_audio_device_name(
+    uint32_t index,
+    char*    out_buf,
+    size_t   buf_len
+);
+
+int32_t sdr_core_audio_device_uid(
     uint32_t index,
     char*    out_buf,
     size_t   buf_len
@@ -335,6 +378,39 @@ int32_t sdr_core_set_deemphasis(SdrCore* handle, int32_t mode);
  */
 int32_t sdr_core_set_volume(SdrCore* handle, float volume_0_1);
 
+/*
+ * Select the audio output device by caller-opaque UID. The UID is
+ * the value previously obtained from `sdr_core_audio_device_uid`.
+ * Empty string ("") routes to the system default output — that is
+ * the engine default until the host calls this.
+ *
+ * `uid_utf8` must be a NUL-terminated UTF-8 C string (null returns
+ * `SDR_CORE_ERR_INVALID_ARG`). The device swap is engine-side
+ * transactional: on a failed swap the previous device is restored,
+ * so a rejected UID never leaves the sink silent.
+ */
+int32_t sdr_core_set_audio_device(SdrCore* handle, const char* uid_utf8);
+
+/*
+ * Start / stop recording the demodulated audio stream to a 16-bit
+ * PCM WAV file. The engine opens the file on `start`, writes every
+ * decoded frame while recording is active, and finalizes the WAV
+ * header when the writer drops on `stop`.
+ *
+ * `start` emits `SDR_EVT_AUDIO_RECORDING_STARTED` on success or
+ * `SDR_EVT_ERROR` if the file couldn't be opened / written.
+ * `stop` emits `SDR_EVT_AUDIO_RECORDING_STOPPED` (including when
+ * no recording was active — the event is the host's signal to
+ * clear its "recording" UI regardless of prior state).
+ *
+ * `path_utf8` must be a non-empty NUL-terminated UTF-8 path; the
+ * host is responsible for picking a writable location. Sample rate
+ * and channel count are engine-determined (currently
+ * AUDIO_SAMPLE_RATE at AUDIO_CHANNELS — see the engine constants).
+ */
+int32_t sdr_core_start_audio_recording(SdrCore* handle, const char* path_utf8);
+int32_t sdr_core_stop_audio_recording(SdrCore* handle);
+
 /* --- IQ frontend -------------------------------------------------- */
 
 int32_t sdr_core_set_dc_blocking(SdrCore* handle, bool enabled);
@@ -399,13 +475,15 @@ int32_t sdr_core_set_fft_rate(SdrCore* handle, double fps);
  */
 
 typedef enum SdrEventKind {
-    SDR_EVT_SOURCE_STOPPED        = 1,
-    SDR_EVT_SAMPLE_RATE_CHANGED   = 2,
-    SDR_EVT_SIGNAL_LEVEL          = 3,
-    SDR_EVT_DEVICE_INFO           = 4,
-    SDR_EVT_GAIN_LIST             = 5,
-    SDR_EVT_DISPLAY_BANDWIDTH     = 6,
-    SDR_EVT_ERROR                 = 7,
+    SDR_EVT_SOURCE_STOPPED          = 1,
+    SDR_EVT_SAMPLE_RATE_CHANGED     = 2,
+    SDR_EVT_SIGNAL_LEVEL            = 3,
+    SDR_EVT_DEVICE_INFO             = 4,
+    SDR_EVT_GAIN_LIST               = 5,
+    SDR_EVT_DISPLAY_BANDWIDTH       = 6,
+    SDR_EVT_ERROR                   = 7,
+    SDR_EVT_AUDIO_RECORDING_STARTED = 8,
+    SDR_EVT_AUDIO_RECORDING_STOPPED = 9,
 } SdrEventKind;
 
 /*
@@ -436,6 +514,18 @@ typedef struct SdrEventError {
 } SdrEventError;
 
 /*
+ * Payload for SDR_EVT_AUDIO_RECORDING_STARTED. `path_utf8` is the
+ * NUL-terminated UTF-8 filesystem path the engine opened for
+ * writing — borrowed from dispatcher-owned storage; valid only
+ * for the duration of the callback.
+ *
+ * SDR_EVT_AUDIO_RECORDING_STOPPED carries no payload.
+ */
+typedef struct SdrEventAudioRecording {
+    const char* path_utf8;
+} SdrEventAudioRecording;
+
+/*
  * Tagged union of all event payloads. Which union field is valid
  * is determined by the `kind` discriminant on the enclosing
  * SdrEvent (see the table below).
@@ -449,14 +539,17 @@ typedef struct SdrEventError {
  * SDR_EVT_DEVICE_INFO                 device_info.utf8
  * SDR_EVT_GAIN_LIST                   gain_list.{values,len}
  * SDR_EVT_ERROR                       error.utf8
+ * SDR_EVT_AUDIO_RECORDING_STARTED     audio_recording.path_utf8
+ * SDR_EVT_AUDIO_RECORDING_STOPPED     none (all-zero payload)
  */
 typedef union SdrEventPayload {
     double sample_rate_hz;
     float  signal_level_db;
     double display_bandwidth_hz;
-    SdrEventDeviceInfo device_info;
-    SdrEventGainList   gain_list;
-    SdrEventError      error;
+    SdrEventDeviceInfo     device_info;
+    SdrEventGainList       gain_list;
+    SdrEventError          error;
+    SdrEventAudioRecording audio_recording;
     /* Placeholder so kinds with no payload (e.g., SOURCE_STOPPED)
      * have a well-defined zeroed payload representation. */
     uint64_t _placeholder;


### PR DESCRIPTION
## Summary

Expose two engine features that were fully implemented on the Rust side but had no SwiftUI surface. Follows the project's "no Swift-side reinvention" rule: the engine owns `list_audio_sinks()`, `AudioSink::set_target`, `UiToDsp::Start/StopAudioRecording`, and `WavWriter`; this PR is FFI plumbing + SwiftUI wiring.

Closes #237 and #239.

## Engine audit (why no Swift-side logic)

| Feature | Engine source of truth | Swift work |
|---|---|---|
| Device enumeration | `sdr-sink-audio::list_audio_sinks()` | FFI wrap, render in Picker |
| Device routing | `AudioSink::set_target` (transactional swap + rollback) | FFI wrap, persist UID in UserDefaults |
| WAV recording | `UiToDsp::Start/StopAudioRecording` + `WavWriter` | FFI wrap, generate timestamped path |
| Recording confirm | `DspToUi::AudioRecording{Started,Stopped}` | New event variants, flip engine-authoritative model field |
| Failure surfaces | `DspToUi::Error(...)` (existing) | No-op — existing error event arm handles it |

## What changed

**sdr-ffi (ABI 0.3 → 0.4, additive):**
- `sdr_core_audio_device_count` / `_name` / `_uid` — handle-free, caller-allocated buffers matching the existing `sdr_core_device_name` contract.
- `sdr_core_set_audio_device(uid)` — empty string = system default.
- `sdr_core_start_audio_recording(path)` / `_stop_audio_recording`.
- `SDR_EVT_AUDIO_RECORDING_STARTED` (path payload) / `_STOPPED`. Removed from the "silently dropped" fallback; new payload struct added to the union.
- Header updated; `make ffi-header-check` clean.

**SdrCoreKit:**
- `SdrCore.AudioDevice` + static `audioDevices` / `audioDeviceName(at:)` / `audioDeviceUid(at:)`.
- `setAudioDevice`, `startAudioRecording(path:)`, `stopAudioRecording` command wrappers.
- `SdrCoreEvent.audioRecordingStarted(path:)` / `audioRecordingStopped` variants.

**SDRMac:**
- `CoreModel`: `audioDevices`, `selectedAudioDeviceUid` (persisted via `UserDefaults`, restored on bootstrap, re-applied through `syncToEngine`), `audioRecordingPath` (engine-authoritative — flipped only by events).
- **Settings → Audio pane**: real device `Picker` replacing the placeholder. Refreshes on appear so CoreAudio hot-plugs (Bluetooth / USB) show up without app restart.
- **New sidebar Recording section**: toggle + filename + reveal-in-Finder button. Default path `~/Documents/SDRMac/Audio/sdr-audio-YYYYMMDD-HHMMSS.wav`; directory created lazily.

## Tests

- 9 new `sdr-ffi` unit tests: null-handle rejection, null/empty-path rejection, UTF-8 round-trips, out-of-range indices, start/stop through a live engine handle.
- `cargo test --workspace` green.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `make ffi-header-check` clean.
- Release Mac app (`make mac-app`) built and smoke-tested on live hardware: Picker enumerates + switches devices with audio routing to the new device; Recording toggle writes a playable WAV to `~/Documents/SDRMac/Audio/`.

## Test plan

- [x] Unit tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Header drift lint clean (`make ffi-header-check`)
- [x] Release build of Mac app succeeds (`make mac-app`)
- [x] Settings → Audio shows enumerated devices, switching routes audio
- [x] Sidebar Recording toggle starts + stops; path shown + reveal-in-Finder works
- [x] Persisted device UID survives app restart (UserDefaults)
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pick and persist an audio output device in Settings (includes “System default”); device list refreshes on appear and selection restored on launch.
  * Start/stop WAV audio recording from the sidebar; files saved to Documents/SDRMac/Audio with unique timestamped names and a Finder “reveal” button.
  * Sidebar shows live, engine-confirmed recording state.

* **Bug Fixes**
  * Prevents creating a started-recording state with an empty path; recording toggle guarded against rapid re-entrant changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->