### PR TITLE
feat(macos): Group B.2 — IQ recording to WAV (#238)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -313,6 +313,22 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(sdr_core_stop_audio_recording(handle))
     }
 
+    /// Start recording the raw IQ stream to a WAV file at `path`.
+    /// The engine writes at the current tuner sample rate with
+    /// two channels (I / Q); file size per second scales with
+    /// the source rate, so fast source rates produce large files.
+    /// Emits `.iqRecordingStarted(path:)` on success or
+    /// `.error(...)` on failure.
+    public func startIqRecording(path: String) throws {
+        try checkRc(path.withCString { sdr_core_start_iq_recording(handle, $0) })
+    }
+
+    /// Stop IQ recording. Safe to call when nothing is active —
+    /// the engine always emits `.iqRecordingStopped` in response.
+    public func stopIqRecording() throws {
+        try checkRc(sdr_core_stop_iq_recording(handle))
+    }
+
     /// Enable or disable DC blocking on the IQ frontend.
     public func setDcBlocking(_ enabled: Bool) throws {
         try checkRc(sdr_core_set_dc_blocking(handle, enabled))

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -39,6 +39,8 @@ private let kDisplayBandwidth      = Int32(SDR_EVT_DISPLAY_BANDWIDTH.rawValue)
 private let kError                 = Int32(SDR_EVT_ERROR.rawValue)
 private let kAudioRecordingStarted = Int32(SDR_EVT_AUDIO_RECORDING_STARTED.rawValue)
 private let kAudioRecordingStopped = Int32(SDR_EVT_AUDIO_RECORDING_STOPPED.rawValue)
+private let kIqRecordingStarted    = Int32(SDR_EVT_IQ_RECORDING_STARTED.rawValue)
+private let kIqRecordingStopped    = Int32(SDR_EVT_IQ_RECORDING_STOPPED.rawValue)
 
 /// High-level event from the engine.
 ///
@@ -82,6 +84,17 @@ public enum SdrCoreEvent: Sendable, Equatable {
     /// shutdown while a recording is active, so hosts can clear
     /// their "recording" UI without tracking teardown separately.
     case audioRecordingStopped
+
+    /// IQ recording to WAV has started. The associated path is
+    /// the file the engine opened for writing. Unlike audio
+    /// recording, the WAV is written at the current tuner sample
+    /// rate (two-channel I/Q), not a fixed 48 kHz, so file size
+    /// scales with the selected source rate.
+    case iqRecordingStarted(path: String)
+
+    /// IQ recording to WAV has stopped. Also fires on engine
+    /// shutdown while a recording is active.
+    case iqRecordingStopped
 
     /// Translate a C `SdrEvent` into a Swift value.
     ///
@@ -143,6 +156,18 @@ public enum SdrCoreEvent: Sendable, Equatable {
 
         case kAudioRecordingStopped:
             return .audioRecordingStopped
+
+        case kIqRecordingStarted:
+            // Same null/empty guard as audio. An empty path would
+            // flip CoreModel's `iqRecordingPath` into a bogus
+            // "recording" state with no file to display / reveal.
+            guard let cstr = payload.iq_recording.path_utf8 else { return nil }
+            let path = String(cString: cstr)
+            guard !path.isEmpty else { return nil }
+            return .iqRecordingStarted(path: path)
+
+        case kIqRecordingStopped:
+            return .iqRecordingStopped
 
         default:
             // Unknown kind — a future FFI may add variants we

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -189,6 +189,12 @@ final class CoreModel {
     /// optimistically.
     var audioRecordingPath: String? = nil
 
+    /// Active IQ-recording state. Same engine-authoritative flip
+    /// as `audioRecordingPath` above, but for the raw IQ stream.
+    /// Mirrors `DspToUi::IqRecordingStarted/Stopped`. Independent
+    /// from audio recording — both can be active simultaneously.
+    var iqRecordingPath: String? = nil
+
     // ==========================================================
     //  Display
     // ==========================================================
@@ -393,6 +399,10 @@ final class CoreModel {
             audioRecordingPath = path
         case .audioRecordingStopped:
             audioRecordingPath = nil
+        case .iqRecordingStarted(let path):
+            iqRecordingPath = path
+        case .iqRecordingStopped:
+            iqRecordingPath = nil
         @unknown default:
             // Surface new engine event variants during
             // development. SdrCoreEvent is a non-frozen enum
@@ -735,6 +745,21 @@ final class CoreModel {
     /// clears `audioRecordingPath`.
     func stopAudioRecording() {
         capture { try core?.stopAudioRecording() }
+    }
+
+    /// Start writing the raw IQ stream to `path`. The engine
+    /// confirms via `.iqRecordingStarted` which flips
+    /// `iqRecordingPath` to non-nil. Failure comes back as an
+    /// `.error(...)` event and `iqRecordingPath` stays nil.
+    func startIqRecording(to path: String) {
+        capture { try core?.startIqRecording(path: path) }
+    }
+
+    /// Stop IQ recording. Safe to call at any time — the engine
+    /// always emits `.iqRecordingStopped` in response, which
+    /// clears `iqRecordingPath`.
+    func stopIqRecording() {
+        capture { try core?.stopIqRecording() }
     }
 
     func setFftSize(_ n: Int) {

--- a/apps/macos/SDRMac/SDRMacApp.swift
+++ b/apps/macos/SDRMac/SDRMacApp.swift
@@ -60,14 +60,36 @@ struct SDRMacApp: App {
         appSupportDirectory().appendingPathComponent("bookmarks.json")
     }
 
-    /// Directory the app writes WAV recordings to, per #239:
-    /// `~/Documents/SDRMac/Audio/`. Created lazily on first
+    /// Directory the app writes audio WAV recordings to, per
+    /// #239: `~/Documents/SDRMac/Audio/`. Created lazily on first
     /// recording start so a user who never hits Record doesn't
     /// wind up with a stray empty folder.
     ///
     /// Returned as a URL, not just a path, so SwiftUI callers can
     /// `showInFinder` the destination directly.
-    static func audioRecordingsDirectory() -> URL {
+    ///
+    /// `nonisolated` because FileManager calls don't need the
+    /// main actor — lets the sibling `RecordingSection` generators
+    /// stay callable from a nonisolated context too.
+    nonisolated static func audioRecordingsDirectory() -> URL {
+        recordingsSubdirectory(named: "Audio")
+    }
+
+    /// Directory the app writes raw IQ WAV captures to, per #238:
+    /// `~/Documents/SDRMac/IQ/`. Separate from the audio folder
+    /// so the much larger IQ files are easy to audit / clean
+    /// without sifting through demodulated audio recordings.
+    /// Created lazily on first IQ-record start.
+    nonisolated static func iqRecordingsDirectory() -> URL {
+        recordingsSubdirectory(named: "IQ")
+    }
+
+    /// Shared creator for `~/Documents/SDRMac/<name>/`. Falls back
+    /// to the home directory if `.documentDirectory` can't be
+    /// resolved (shouldn't happen on a standard Mac install, but
+    /// guards against weird sandboxing / missing-entitlement edge
+    /// cases).
+    private nonisolated static func recordingsSubdirectory(named name: String) -> URL {
         let fm = FileManager.default
         let docs = (try? fm.url(
             for: .documentDirectory,
@@ -75,7 +97,7 @@ struct SDRMacApp: App {
             appropriateFor: nil,
             create: true
         )) ?? fm.homeDirectoryForCurrentUser.appendingPathComponent("Documents")
-        let dir = docs.appendingPathComponent("SDRMac/Audio")
+        let dir = docs.appendingPathComponent("SDRMac/\(name)")
         try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
     }

--- a/apps/macos/SDRMac/Views/RecordingSection.swift
+++ b/apps/macos/SDRMac/Views/RecordingSection.swift
@@ -1,14 +1,23 @@
 //
-// RecordingSection.swift — sidebar panel for audio WAV
-// recording (#239). Engine-side: see
-// `UiToDsp::StartAudioRecording` / `StopAudioRecording` at
-// `crates/sdr-core/src/controller.rs`. The engine owns the
-// writer, WAV header, and buffer discipline; this view only
-// toggles the command and reflects the engine's confirmed
-// state (`audioRecordingPath`).
+// RecordingSection.swift — sidebar panel for WAV recording.
 //
-// Default destination: `~/Documents/SDRMac/Audio/<timestamp>.wav`,
-// created on first Record tap.
+// Two engine-side features colocated in one sidebar section:
+//   - Audio (#239): demodulated audio at AUDIO_SAMPLE_RATE,
+//     `UiToDsp::StartAudioRecording` / `StopAudioRecording`.
+//     ~96 KB/s mono @ 16-bit / 48 kHz — small files.
+//   - IQ (#238): raw complex samples at the current tuner
+//     rate, `UiToDsp::StartIqRecording` / `StopIqRecording`.
+//     Two-channel @ the source rate — at 2.048 MHz that's
+//     ~15 MB/s, so files grow quickly.
+//
+// The engine owns the writers, WAV headers, and buffer
+// discipline; this view only toggles the commands and
+// reflects the engine's confirmed state
+// (`audioRecordingPath` / `iqRecordingPath`).
+//
+// Default destinations:
+//   Audio → `~/Documents/SDRMac/Audio/sdr-audio-<timestamp>.wav`
+//   IQ    → `~/Documents/SDRMac/IQ/sdr-iq-<timestamp>.wav`
 
 import AppKit
 import SwiftUI
@@ -16,112 +25,144 @@ import SwiftUI
 struct RecordingSection: View {
     @Environment(CoreModel.self) private var model
 
-    /// True between firing a start/stop command and observing the
-    /// matching `audioRecordingPath` change. Locks the toggle in
-    /// the meantime so a rapid second click can't fire a second
-    /// `StartAudioRecording` — the controller replaces
-    /// `state.audio_writer` on each start, which would drop the
-    /// first writer mid-write and produce two partial WAV files.
-    /// Cleared in `.onChange(of:)` when the engine confirms the
-    /// transition.
-    @State private var pendingTransition: Bool = false
-
     var body: some View {
         Section("Recording") {
-            let recording = model.audioRecordingPath != nil
+            RecordingToggleRow(
+                title: "Audio",
+                recordingPath: model.audioRecordingPath,
+                generatePath: Self.generateAudioRecordingPath,
+                start: { path in model.startAudioRecording(to: path) },
+                stop: { model.stopAudioRecording() }
+            )
 
-            Toggle("Audio", isOn: Binding(
-                get: { recording },
-                set: { on in
-                    // Swallow re-entrant toggles until the engine
-                    // acknowledges the outstanding request via
-                    // `.audioRecordingStarted/Stopped`. Without
-                    // this, a double-click in the ~ms window
-                    // before the event lands creates two files.
-                    guard !pendingTransition else { return }
-                    pendingTransition = true
-                    if on {
-                        let path = Self.generateRecordingPath()
-                        model.startAudioRecording(to: path)
-                    } else {
-                        model.stopAudioRecording()
-                    }
-                }
-            ))
-            .disabled(pendingTransition)
-            // Engine events are the authoritative transition
-            // signal; clear the lock when `audioRecordingPath`
-            // actually flips. If the engine fails to open the
-            // file, a `.error` event comes through CoreModel
-            // instead and this line never fires — that's handled
-            // separately below.
-            .onChange(of: model.audioRecordingPath) { _, _ in
-                pendingTransition = false
-            }
-            // If start failed (engine emitted `.error` without
-            // ever flipping `audioRecordingPath`), the state
-            // change above won't fire and the toggle would stay
-            // locked forever. Reset on any error surfacing while
-            // we're pending so the user can try again.
-            .onChange(of: model.lastError) { _, new in
-                if pendingTransition && new != nil {
-                    pendingTransition = false
-                }
-            }
-
-            if let path = model.audioRecordingPath {
-                LabeledContent("File") {
-                    Button {
-                        // Reveal in Finder — select the file so the
-                        // user can immediately drag / play / delete
-                        // it. If the file isn't actually there yet
-                        // (engine hasn't flushed), fall back to the
-                        // parent directory so the button stays
-                        // useful.
-                        let url = URL(fileURLWithPath: path)
-                        if FileManager.default.fileExists(atPath: url.path) {
-                            NSWorkspace.shared.activateFileViewerSelecting([url])
-                        } else {
-                            NSWorkspace.shared.open(url.deletingLastPathComponent())
-                        }
-                    } label: {
-                        Text((path as NSString).lastPathComponent)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
-                    .buttonStyle(.plain)
-                    .help(path)
-                }
-            } else {
-                Text("Not recording")
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-            }
+            RecordingToggleRow(
+                title: "IQ",
+                recordingPath: model.iqRecordingPath,
+                generatePath: Self.generateIqRecordingPath,
+                start: { path in model.startIqRecording(to: path) },
+                stop: { model.stopIqRecording() }
+            )
         }
     }
 
-    /// Build a full destination path for a new recording. The
-    /// filename pattern is `sdr-audio-YYYYMMDD-HHMMSS-SSS.wav` —
-    /// sortable, human-readable, and millisecond-precise so
-    /// rapid stop/start cycles (button spam, scripted automation)
-    /// produce distinct filenames. On the off chance that two
-    /// timestamps still collide — or the user explicitly asked
-    /// for a name that exists from a previous session — an
-    /// integer suffix is appended until an unused name is found.
-    static func generateRecordingPath() -> String {
-        let dir = SDRMacApp.audioRecordingsDirectory()
+    /// Audio WAV destination path. Filename pattern
+    /// `sdr-audio-YYYYMMDD-HHMMSS-SSS.wav` — sortable,
+    /// human-readable, and millisecond-precise so rapid
+    /// stop/start cycles produce distinct filenames. An
+    /// integer suffix is appended on the off chance two
+    /// timestamps still collide.
+    ///
+    /// `nonisolated` because these only touch `FileManager`,
+    /// `DateFormatter`, and path-building — no main-actor
+    /// state — and the `RecordingToggleRow` closure params
+    /// need a callable type that's safe from any isolation
+    /// domain.
+    nonisolated static func generateAudioRecordingPath() -> String {
+        generateRecordingPath(
+            in: SDRMacApp.audioRecordingsDirectory(),
+            prefix: "sdr-audio"
+        )
+    }
+
+    /// IQ WAV destination path. Same filename pattern as
+    /// audio but lives under `~/Documents/SDRMac/IQ/`.
+    nonisolated static func generateIqRecordingPath() -> String {
+        generateRecordingPath(
+            in: SDRMacApp.iqRecordingsDirectory(),
+            prefix: "sdr-iq"
+        )
+    }
+
+    /// Shared path builder for both recording kinds.
+    private nonisolated static func generateRecordingPath(in dir: URL, prefix: String) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
         let stamp = formatter.string(from: Date())
-        var candidate = dir.appendingPathComponent("sdr-audio-\(stamp).wav")
+        var candidate = dir.appendingPathComponent("\(prefix)-\(stamp).wav")
         var suffix = 1
         while FileManager.default.fileExists(atPath: candidate.path) {
-            candidate = dir.appendingPathComponent("sdr-audio-\(stamp)-\(suffix).wav")
+            candidate = dir.appendingPathComponent("\(prefix)-\(stamp)-\(suffix).wav")
             suffix += 1
         }
         return candidate.path
+    }
+}
+
+/// One toggle + filename + reveal-in-Finder row for a recording
+/// feature. Parameterized so audio and IQ share the exact same
+/// UX without copy-pasted event-watching code.
+///
+/// Each row owns its own `pendingTransition` lock — audio and IQ
+/// commands are independent; a pending IQ start shouldn't block
+/// the user from also starting audio recording.
+private struct RecordingToggleRow: View {
+    @Environment(CoreModel.self) private var model
+
+    let title: String
+    let recordingPath: String?
+    let generatePath: () -> String
+    let start: (String) -> Void
+    let stop: () -> Void
+
+    /// True between firing a start/stop command and observing
+    /// the matching `recordingPath` change. Locks this toggle in
+    /// the meantime so a rapid double-click can't fire two
+    /// Start* commands (the controller replaces the writer on
+    /// each start, dropping the first writer mid-write → two
+    /// partial WAV files). Cleared in `.onChange(of:)` when the
+    /// engine confirms the transition, or when a `lastError`
+    /// arrives while we're pending (start failed).
+    @State private var pendingTransition: Bool = false
+
+    var body: some View {
+        let recording = recordingPath != nil
+
+        Toggle(title, isOn: Binding(
+            get: { recording },
+            set: { on in
+                guard !pendingTransition else { return }
+                pendingTransition = true
+                if on {
+                    start(generatePath())
+                } else {
+                    stop()
+                }
+            }
+        ))
+        .disabled(pendingTransition)
+        .onChange(of: recordingPath) { _, _ in
+            pendingTransition = false
+        }
+        .onChange(of: model.lastError) { _, new in
+            if pendingTransition && new != nil {
+                pendingTransition = false
+            }
+        }
+
+        if let path = recordingPath {
+            LabeledContent("File") {
+                Button {
+                    // Reveal in Finder. Falls back to the parent
+                    // directory if the file isn't on disk yet
+                    // (engine may not have flushed the first
+                    // frame by the time the user clicks).
+                    let url = URL(fileURLWithPath: path)
+                    if FileManager.default.fileExists(atPath: url.path) {
+                        NSWorkspace.shared.activateFileViewerSelecting([url])
+                    } else {
+                        NSWorkspace.shared.open(url.deletingLastPathComponent())
+                    }
+                } label: {
+                    Text((path as NSString).lastPathComponent)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .buttonStyle(.plain)
+                .help(path)
+            }
+        }
     }
 }

--- a/apps/macos/SDRMac/Views/RecordingSection.swift
+++ b/apps/macos/SDRMac/Views/RecordingSection.swift
@@ -111,9 +111,25 @@ private struct RecordingToggleRow: View {
     /// Start* commands (the controller replaces the writer on
     /// each start, dropping the first writer mid-write → two
     /// partial WAV files). Cleared in `.onChange(of:)` when the
-    /// engine confirms the transition, or when a `lastError`
-    /// arrives while we're pending (start failed).
+    /// engine confirms the transition, or by the watchdog below
+    /// if the engine never confirms (failed-start path).
     @State private var pendingTransition: Bool = false
+
+    /// Cancellable watchdog that force-unlocks `pendingTransition`
+    /// if the engine doesn't confirm the transition within a
+    /// grace period. Per CodeRabbit round 1 on PR #345: an earlier
+    /// approach watched `model.lastError`, but (a) that's a shared
+    /// slot so any app error would unlock the wrong row, and
+    /// (b) `onChange` doesn't fire when the same error value is
+    /// reassigned, so repeated identical failures would wedge
+    /// the toggle forever.
+    ///
+    /// The watchdog covers only the failed-**start** case. Stops
+    /// always emit `AudioRecordingStopped` / `IqRecordingStopped`
+    /// (including on shutdown), so `onChange(of: recordingPath)`
+    /// is reliable for them. Starts that fail at the WAV-open
+    /// stage emit only a `DspToUi::Error(...)` with no path flip.
+    @State private var watchdogTask: Task<Void, Never>?
 
     var body: some View {
         let recording = recordingPath != nil
@@ -128,16 +144,20 @@ private struct RecordingToggleRow: View {
                 } else {
                     stop()
                 }
+                armWatchdog()
             }
         ))
         .disabled(pendingTransition)
         .onChange(of: recordingPath) { _, _ in
+            // Engine confirmed the transition — happy path.
+            // Cancel the watchdog (harmless if it already fired)
+            // and unlock.
+            watchdogTask?.cancel()
+            watchdogTask = nil
             pendingTransition = false
         }
-        .onChange(of: model.lastError) { _, new in
-            if pendingTransition && new != nil {
-                pendingTransition = false
-            }
+        .onDisappear {
+            watchdogTask?.cancel()
         }
 
         if let path = recordingPath {
@@ -162,6 +182,32 @@ private struct RecordingToggleRow: View {
                 }
                 .buttonStyle(.plain)
                 .help(path)
+            }
+        }
+    }
+
+    /// Grace period before the watchdog force-unlocks the toggle.
+    /// Real confirmation latency is sub-millisecond — the engine
+    /// opens the WAV file synchronously on the controller thread
+    /// after the mpsc hop. 5 seconds is "much longer than any
+    /// healthy round-trip" so a legitimate slow start (e.g.,
+    /// controller queue is briefly backed up) still has headroom
+    /// to confirm before the watchdog intervenes.
+    private static let watchdogGrace: Duration = .seconds(5)
+
+    /// (Re)arm the watchdog. Cancels any previous pending task so
+    /// back-to-back start/stop clicks don't leave stale watchdogs
+    /// that would later clobber a newer `pendingTransition`.
+    private func armWatchdog() {
+        watchdogTask?.cancel()
+        watchdogTask = Task { @MainActor in
+            try? await Task.sleep(for: Self.watchdogGrace)
+            if !Task.isCancelled {
+                // Engine never confirmed. Unlock so the user can
+                // retry. A genuine (eventual) confirmation that
+                // arrives after this is a no-op — the path flip
+                // just sets pendingTransition = false again.
+                pendingTransition = false
             }
         }
     }

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -646,6 +646,21 @@ mod tests {
     /// the command.
     const WAV_HEADER_BYTES: u64 = 44;
 
+    /// Build a collision-resistant temp WAV path. PID alone would
+    /// reuse the same filename across reruns of the same test
+    /// binary — if a prior run crashed before its cleanup, a
+    /// stale file could mask a broken `_start_*_recording` by
+    /// making the `metadata().expect(...)` assertion pass against
+    /// the old artifact. Adding a nanosecond timestamp gives each
+    /// test a unique name even when `cargo test` reuses a binary.
+    /// Per CodeRabbit round 4 on PR #345.
+    fn unique_temp_wav(prefix: &str) -> std::path::PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}.wav", std::process::id()))
+    }
+
     /// Helper: make a live engine handle for the duration of a test.
     fn make_handle() -> *mut SdrCore {
         let path = CString::new("").unwrap();
@@ -755,7 +770,7 @@ mod tests {
         // controller-side open failure would otherwise pass
         // silently here even though `send_command` returned OK.
         let h = make_handle();
-        let tmp = std::env::temp_dir().join(format!("sdr-ffi-test-{}.wav", std::process::id()));
+        let tmp = unique_temp_wav("sdr-ffi-test");
         let path = CString::new(tmp.to_string_lossy().into_owned()).unwrap();
         assert_eq!(
             unsafe { sdr_core_start_audio_recording(h, path.as_ptr()) },
@@ -800,7 +815,7 @@ mod tests {
         // file, not just that `send_command` returned OK. Per
         // CodeRabbit round 2 on PR #345.
         let h = make_handle();
-        let tmp = std::env::temp_dir().join(format!("sdr-ffi-iq-test-{}.wav", std::process::id()));
+        let tmp = unique_temp_wav("sdr-ffi-iq-test");
         let path = CString::new(tmp.to_string_lossy().into_owned()).unwrap();
         assert_eq!(
             unsafe { sdr_core_start_iq_recording(h, path.as_ptr()) },

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -461,6 +461,45 @@ pub unsafe extern "C" fn sdr_core_stop_audio_recording(handle: *mut SdrCore) -> 
     unsafe { with_core(handle, |core| send(core, UiToDsp::StopAudioRecording)) }
 }
 
+/// Start writing the raw IQ sample stream to a WAV file at
+/// `path_utf8`. Unlike audio recording, the IQ WAV is written at
+/// the current tuner sample rate (not a fixed 48 kHz) with two
+/// channels (I / Q), so the file size per second varies with the
+/// source sample rate selection.
+///
+/// The engine confirms start via `SDR_EVT_IQ_RECORDING_STARTED`
+/// or emits `SDR_EVT_ERROR` on failure (open error, disk full, etc.).
+///
+/// # Safety
+///
+/// `path_utf8` must be a NUL-terminated UTF-8 C string naming a
+/// writable filesystem path (the engine creates the file). Does
+/// not accept null or empty.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_start_iq_recording(
+    handle: *mut SdrCore,
+    path_utf8: *const c_char,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let path = cstr_to_string("sdr_core_start_iq_recording", path_utf8)?;
+            if path.is_empty() {
+                set_last_error("sdr_core_start_iq_recording: path is empty");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            send(core, UiToDsp::StartIqRecording(PathBuf::from(path)))
+        })
+    }
+}
+
+/// Stop IQ recording. The engine finalizes the WAV header on
+/// writer drop and confirms via `SDR_EVT_IQ_RECORDING_STOPPED`.
+/// Safe to call when no recording is active (no-op + stop event).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_stop_iq_recording(handle: *mut SdrCore) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::StopIqRecording)) }
+}
+
 // ============================================================
 //  IQ frontend
 // ============================================================
@@ -616,6 +655,14 @@ mod tests {
             unsafe { sdr_core_stop_audio_recording(std::ptr::null_mut()) },
             SdrCoreError::InvalidHandle.as_int()
         );
+        assert_eq!(
+            unsafe { sdr_core_start_iq_recording(std::ptr::null_mut(), empty.as_ptr()) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_stop_iq_recording(std::ptr::null_mut()) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
     }
 
     // ------------------------------------------------------
@@ -678,6 +725,42 @@ mod tests {
         // then clean up. If the file wasn't created (e.g., the DSP
         // thread hadn't processed the command yet) remove_file errs;
         // that's fine — test doesn't depend on it.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let _ = std::fs::remove_file(&tmp);
+        destroy(h);
+    }
+
+    #[test]
+    fn start_iq_recording_rejects_null_or_empty_path() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_start_iq_recording(h, std::ptr::null()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        let empty = CString::new("").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_start_iq_recording(h, empty.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn iq_recording_start_stop_round_trip() {
+        // Same shape as the audio recording round-trip test —
+        // exercise the command plumbing without inspecting the
+        // WAV output.
+        let h = make_handle();
+        let tmp = std::env::temp_dir().join(format!("sdr-ffi-iq-test-{}.wav", std::process::id()));
+        let path = CString::new(tmp.to_string_lossy().into_owned()).unwrap();
+        assert_eq!(
+            unsafe { sdr_core_start_iq_recording(h, path.as_ptr()) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_stop_iq_recording(h) },
+            SdrCoreError::Ok.as_int()
+        );
         std::thread::sleep(std::time::Duration::from_millis(50));
         let _ = std::fs::remove_file(&tmp);
         destroy(h);

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -604,6 +604,14 @@ mod tests {
     use crate::lifecycle::sdr_core_create;
     use std::ffi::CString;
 
+    /// Small grace period the round-trip recording tests wait
+    /// after `stop` so the controller thread has time to drop
+    /// the writer (which finalizes the WAV header on `Drop`)
+    /// before the test cleans up the file. Sub-second so the
+    /// test suite stays fast; large enough to comfortably cover
+    /// the mpsc hop plus file-close syscall on any CI host.
+    const RECORDING_FLUSH_WAIT_MS: u64 = 50;
+
     /// Helper: make a live engine handle for the duration of a test.
     fn make_handle() -> *mut SdrCore {
         let path = CString::new("").unwrap();
@@ -725,7 +733,7 @@ mod tests {
         // then clean up. If the file wasn't created (e.g., the DSP
         // thread hadn't processed the command yet) remove_file errs;
         // that's fine — test doesn't depend on it.
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::thread::sleep(std::time::Duration::from_millis(RECORDING_FLUSH_WAIT_MS));
         let _ = std::fs::remove_file(&tmp);
         destroy(h);
     }
@@ -761,7 +769,7 @@ mod tests {
             unsafe { sdr_core_stop_iq_recording(h) },
             SdrCoreError::Ok.as_int()
         );
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::thread::sleep(std::time::Duration::from_millis(RECORDING_FLUSH_WAIT_MS));
         let _ = std::fs::remove_file(&tmp);
         destroy(h);
     }

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -424,6 +424,32 @@ pub unsafe extern "C" fn sdr_core_set_audio_device(
     }
 }
 
+/// Shared helper for the two `start_*_recording` commands. Validates
+/// `path_utf8` (non-null, UTF-8, non-empty) and dispatches the
+/// appropriate `UiToDsp` variant via `build_cmd`. Keeps the path
+/// validation in one place so a future rule (e.g., rejecting
+/// directory paths, normalizing trailing whitespace) lands in
+/// both start paths at once.
+///
+/// # Safety
+///
+/// `path_utf8` must be a NUL-terminated UTF-8 C string or null
+/// (null returns `SDR_CORE_ERR_INVALID_ARG`). `core` must be a
+/// valid engine reference.
+unsafe fn start_recording_with_path(
+    core: &SdrCore,
+    fn_name: &str,
+    path_utf8: *const c_char,
+    build_cmd: impl FnOnce(PathBuf) -> UiToDsp,
+) -> Result<(), SdrCoreError> {
+    let path = unsafe { cstr_to_string(fn_name, path_utf8) }?;
+    if path.is_empty() {
+        set_last_error(format!("{fn_name}: path is empty"));
+        return Err(SdrCoreError::InvalidArg);
+    }
+    send(core, build_cmd(PathBuf::from(path)))
+}
+
 /// Start writing the demodulated audio stream to a 16-bit PCM WAV
 /// file at `path_utf8`. If recording was already active the engine
 /// logs a warning and overwrites — callers should stop first.
@@ -443,12 +469,12 @@ pub unsafe extern "C" fn sdr_core_start_audio_recording(
 ) -> i32 {
     unsafe {
         with_core(handle, |core| {
-            let path = cstr_to_string("sdr_core_start_audio_recording", path_utf8)?;
-            if path.is_empty() {
-                set_last_error("sdr_core_start_audio_recording: path is empty");
-                return Err(SdrCoreError::InvalidArg);
-            }
-            send(core, UiToDsp::StartAudioRecording(PathBuf::from(path)))
+            start_recording_with_path(
+                core,
+                "sdr_core_start_audio_recording",
+                path_utf8,
+                UiToDsp::StartAudioRecording,
+            )
         })
     }
 }
@@ -482,12 +508,12 @@ pub unsafe extern "C" fn sdr_core_start_iq_recording(
 ) -> i32 {
     unsafe {
         with_core(handle, |core| {
-            let path = cstr_to_string("sdr_core_start_iq_recording", path_utf8)?;
-            if path.is_empty() {
-                set_last_error("sdr_core_start_iq_recording: path is empty");
-                return Err(SdrCoreError::InvalidArg);
-            }
-            send(core, UiToDsp::StartIqRecording(PathBuf::from(path)))
+            start_recording_with_path(
+                core,
+                "sdr_core_start_iq_recording",
+                path_utf8,
+                UiToDsp::StartIqRecording,
+            )
         })
     }
 }

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -612,6 +612,14 @@ mod tests {
     /// the mpsc hop plus file-close syscall on any CI host.
     const RECORDING_FLUSH_WAIT_MS: u64 = 50;
 
+    /// Minimum size of a well-formed empty WAV file: the 44-byte
+    /// header `WavWriter::new` writes before any samples arrive
+    /// (RIFF/WAVE + fmt chunk + data chunk header). Used by the
+    /// round-trip recording tests to prove the controller
+    /// actually opened + wrote the header, not just enqueued
+    /// the command.
+    const WAV_HEADER_BYTES: u64 = 44;
+
     /// Helper: make a live engine handle for the duration of a test.
     fn make_handle() -> *mut SdrCore {
         let path = CString::new("").unwrap();
@@ -716,8 +724,10 @@ mod tests {
     #[test]
     fn audio_recording_start_stop_round_trip() {
         // Write to a temp file path so the controller's WavWriter
-        // has somewhere it can open. We don't inspect the output —
-        // just exercise the command plumbing.
+        // has somewhere it can open. We verify the controller
+        // actually created + finalized the WAV header — a
+        // controller-side open failure would otherwise pass
+        // silently here even though `send_command` returned OK.
         let h = make_handle();
         let tmp = std::env::temp_dir().join(format!("sdr-ffi-test-{}.wav", std::process::id()));
         let path = CString::new(tmp.to_string_lossy().into_owned()).unwrap();
@@ -729,12 +739,16 @@ mod tests {
             unsafe { sdr_core_stop_audio_recording(h) },
             SdrCoreError::Ok.as_int()
         );
-        // Give the controller a moment to process + drop the writer,
-        // then clean up. If the file wasn't created (e.g., the DSP
-        // thread hadn't processed the command yet) remove_file errs;
-        // that's fine — test doesn't depend on it.
+        // Give the controller a moment to process both commands
+        // and drop the writer (Drop finalizes the WAV header).
         std::thread::sleep(std::time::Duration::from_millis(RECORDING_FLUSH_WAIT_MS));
-        let _ = std::fs::remove_file(&tmp);
+        let metadata = std::fs::metadata(&tmp)
+            .expect("audio recording should create a WAV file before cleanup");
+        assert!(
+            metadata.len() >= WAV_HEADER_BYTES,
+            "audio recording should finalize at least a WAV header"
+        );
+        std::fs::remove_file(&tmp).unwrap();
         destroy(h);
     }
 
@@ -756,8 +770,9 @@ mod tests {
     #[test]
     fn iq_recording_start_stop_round_trip() {
         // Same shape as the audio recording round-trip test —
-        // exercise the command plumbing without inspecting the
-        // WAV output.
+        // verifies the controller opened + finalized the WAV
+        // file, not just that `send_command` returned OK. Per
+        // CodeRabbit round 2 on PR #345.
         let h = make_handle();
         let tmp = std::env::temp_dir().join(format!("sdr-ffi-iq-test-{}.wav", std::process::id()));
         let path = CString::new(tmp.to_string_lossy().into_owned()).unwrap();
@@ -770,7 +785,13 @@ mod tests {
             SdrCoreError::Ok.as_int()
         );
         std::thread::sleep(std::time::Duration::from_millis(RECORDING_FLUSH_WAIT_MS));
-        let _ = std::fs::remove_file(&tmp);
+        let metadata =
+            std::fs::metadata(&tmp).expect("IQ recording should create a WAV file before cleanup");
+        assert!(
+            metadata.len() >= WAV_HEADER_BYTES,
+            "IQ recording should finalize at least a WAV header"
+        );
+        std::fs::remove_file(&tmp).unwrap();
         destroy(h);
     }
 

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -55,6 +55,8 @@ pub const SDR_EVT_DISPLAY_BANDWIDTH: i32 = 6;
 pub const SDR_EVT_ERROR: i32 = 7;
 pub const SDR_EVT_AUDIO_RECORDING_STARTED: i32 = 8;
 pub const SDR_EVT_AUDIO_RECORDING_STOPPED: i32 = 9;
+pub const SDR_EVT_IQ_RECORDING_STARTED: i32 = 10;
+pub const SDR_EVT_IQ_RECORDING_STOPPED: i32 = 11;
 
 // ============================================================
 //  SdrEvent tagged union — `#[repr(C)]` layout matching the
@@ -95,6 +97,18 @@ pub struct SdrEventAudioRecording {
     pub path_utf8: *const c_char,
 }
 
+/// Payload for `SDR_EVT_IQ_RECORDING_STARTED`. Same layout as
+/// `SdrEventAudioRecording` but declared separately so the union
+/// field name stays self-documenting for hosts and so the two
+/// feature paths can diverge in the future (e.g. if IQ recording
+/// grows a sample-rate field in the payload) without touching the
+/// audio path.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SdrEventIqRecording {
+    pub path_utf8: *const c_char,
+}
+
 /// C-layout tagged union of event payloads. Which field is valid
 /// is determined by the `kind` discriminant on the enclosing
 /// `SdrEvent`:
@@ -110,6 +124,8 @@ pub struct SdrEventAudioRecording {
 /// | `SDR_EVT_ERROR`                   | `error.utf8`                 |
 /// | `SDR_EVT_AUDIO_RECORDING_STARTED` | `audio_recording.path_utf8`  |
 /// | `SDR_EVT_AUDIO_RECORDING_STOPPED` | none                         |
+/// | `SDR_EVT_IQ_RECORDING_STARTED`    | `iq_recording.path_utf8`     |
+/// | `SDR_EVT_IQ_RECORDING_STOPPED`    | none                         |
 ///
 /// `_placeholder` exists so `SOURCE_STOPPED` events (which carry
 /// no payload) can still construct the struct with a meaningful
@@ -124,6 +140,7 @@ pub union SdrEventPayload {
     pub gain_list: SdrEventGainList,
     pub error: SdrEventError,
     pub audio_recording: SdrEventAudioRecording,
+    pub iq_recording: SdrEventIqRecording,
     /// Placeholder for kinds that carry no payload (e.g.,
     /// `SDR_EVT_SOURCE_STOPPED`). Accessing this field is always
     /// valid as a zero-byte read.
@@ -199,6 +216,16 @@ fn dispatcher_loop(rx: &mpsc::Receiver<DspToUi>, callback_guard: &EventCallbackG
 /// paths. If profiling ever shows contention here, we can reuse
 /// per-dispatcher scratch buffers like the CoreAudio render
 /// callback does.
+///
+/// The `#[allow(clippy::too_many_lines)]` here is deliberate: the
+/// function is a single `match` on the `DspToUi` enum where each
+/// arm is the minimum translation for one variant. Splitting it
+/// into per-variant helpers would push the `owned_cstring` /
+/// `owned_vec` lifetime plumbing across function boundaries
+/// without making the logic easier to read. The length grows
+/// linearly with each new event kind — that's inherent to this
+/// file's job.
+#[allow(clippy::too_many_lines)]
 fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<Vec<f64>>)> {
     let mut owned_cstring: Option<CString> = None;
     let mut owned_vec: Option<Vec<f64>> = None;
@@ -299,6 +326,27 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
             payload: SdrEventPayload { _placeholder: 0 },
         },
 
+        DspToUi::IqRecordingStarted(path) => {
+            // Same sanitize-then-CString pattern as AudioRecordingStarted.
+            let sanitized = path.to_string_lossy().replace('\0', "?");
+            let Ok(cstr) = CString::new(sanitized) else {
+                return None;
+            };
+            let ptr = cstr.as_ptr();
+            owned_cstring = Some(cstr);
+            SdrEvent {
+                kind: SDR_EVT_IQ_RECORDING_STARTED,
+                payload: SdrEventPayload {
+                    iq_recording: SdrEventIqRecording { path_utf8: ptr },
+                },
+            }
+        }
+
+        DspToUi::IqRecordingStopped => SdrEvent {
+            kind: SDR_EVT_IQ_RECORDING_STOPPED,
+            payload: SdrEventPayload { _placeholder: 0 },
+        },
+
         // Variants not yet exposed at the FFI boundary. Silently
         // dropped in v1; a future ABI minor bump grows the surface
         // to cover them as each feature lands in the macOS SwiftUI
@@ -309,8 +357,6 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         //     event callback — FFT frames go through the dedicated
         //     pull function (`sdr_core_pull_fft`) instead so the
         //     render loop stays on the main thread.
-        //   - `IqRecordingStarted/Stopped` light up when IQ
-        //     recording controls land in the macOS UI (issue #238).
         //   - `DemodModeChanged` is the transcription-session
         //     boundary event. macOS transcription IS on the
         //     roadmap — it's currently blocked on a Metal
@@ -330,8 +376,6 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         // of existing ones), so a future minor bump won't break
         // older hosts that don't know about them.
         DspToUi::FftData(_)
-        | DspToUi::IqRecordingStarted(_)
-        | DspToUi::IqRecordingStopped
         | DspToUi::DemodModeChanged(_)
         | DspToUi::BandwidthChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
@@ -607,6 +651,8 @@ mod tests {
         assert_eq!(SDR_EVT_ERROR, 7);
         assert_eq!(SDR_EVT_AUDIO_RECORDING_STARTED, 8);
         assert_eq!(SDR_EVT_AUDIO_RECORDING_STOPPED, 9);
+        assert_eq!(SDR_EVT_IQ_RECORDING_STARTED, 10);
+        assert_eq!(SDR_EVT_IQ_RECORDING_STOPPED, 11);
     }
 
     #[test]

--- a/crates/sdr-ffi/src/lib.rs
+++ b/crates/sdr-ffi/src/lib.rs
@@ -59,7 +59,8 @@ pub use command::{
     sdr_core_set_gain, sdr_core_set_iq_correction, sdr_core_set_iq_inversion,
     sdr_core_set_ppm_correction, sdr_core_set_sample_rate, sdr_core_set_squelch_db,
     sdr_core_set_squelch_enabled, sdr_core_set_vfo_offset, sdr_core_set_volume, sdr_core_start,
-    sdr_core_start_audio_recording, sdr_core_stop, sdr_core_stop_audio_recording, sdr_core_tune,
+    sdr_core_start_audio_recording, sdr_core_start_iq_recording, sdr_core_stop,
+    sdr_core_stop_audio_recording, sdr_core_stop_iq_recording, sdr_core_tune,
 };
 pub use enumerate::{
     sdr_core_audio_device_count, sdr_core_audio_device_name, sdr_core_audio_device_uid,
@@ -68,7 +69,7 @@ pub use enumerate::{
 pub use error::sdr_core_last_error_message;
 pub use event::{
     SdrEvent, SdrEventAudioRecording, SdrEventCallback, SdrEventDeviceInfo, SdrEventError,
-    SdrEventGainList, SdrEventPayload, sdr_core_set_event_callback,
+    SdrEventGainList, SdrEventIqRecording, SdrEventPayload, sdr_core_set_event_callback,
 };
 pub use fft::{SdrFftCallback, SdrFftFrame, sdr_core_pull_fft};
 pub use handle::SdrCore;

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 4;
+pub const ABI_VERSION_MINOR: u32 = 5;
 
 /// Return the ABI version the library was built with.
 ///
@@ -326,7 +326,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 4);
+        assert!(ABI_VERSION_MINOR == 5);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 4
+#define SDR_CORE_ABI_VERSION_MINOR 5
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -425,6 +425,25 @@ int32_t sdr_core_set_audio_device(SdrCore* handle, const char* uid_utf8);
 int32_t sdr_core_start_audio_recording(SdrCore* handle, const char* path_utf8);
 int32_t sdr_core_stop_audio_recording(SdrCore* handle);
 
+/*
+ * Start / stop recording the raw IQ sample stream to a WAV file.
+ * Unlike audio recording — which writes at a fixed 48 kHz —
+ * the IQ WAV is written at the current tuner sample rate with
+ * two channels (I / Q), so file size per second varies with
+ * the source sample rate selection.
+ *
+ * `start` emits `SDR_EVT_IQ_RECORDING_STARTED` on success or
+ * `SDR_EVT_ERROR` if the file couldn't be opened / written.
+ * `stop` emits `SDR_EVT_IQ_RECORDING_STOPPED` (including when
+ * no recording was active — the event is the host's signal to
+ * clear its "recording" UI regardless of prior state).
+ *
+ * `path_utf8` must be a non-empty NUL-terminated UTF-8 path;
+ * the host is responsible for picking a writable location.
+ */
+int32_t sdr_core_start_iq_recording(SdrCore* handle, const char* path_utf8);
+int32_t sdr_core_stop_iq_recording(SdrCore* handle);
+
 /* --- IQ frontend -------------------------------------------------- */
 
 int32_t sdr_core_set_dc_blocking(SdrCore* handle, bool enabled);
@@ -498,6 +517,8 @@ typedef enum SdrEventKind {
     SDR_EVT_ERROR                   = 7,
     SDR_EVT_AUDIO_RECORDING_STARTED = 8,
     SDR_EVT_AUDIO_RECORDING_STOPPED = 9,
+    SDR_EVT_IQ_RECORDING_STARTED    = 10,
+    SDR_EVT_IQ_RECORDING_STOPPED    = 11,
 } SdrEventKind;
 
 /*
@@ -540,6 +561,20 @@ typedef struct SdrEventAudioRecording {
 } SdrEventAudioRecording;
 
 /*
+ * Payload for SDR_EVT_IQ_RECORDING_STARTED. Same layout as
+ * SdrEventAudioRecording but declared separately so hosts can
+ * switch cleanly on `kind` without needing to remember which
+ * union field to read, and so the two feature paths can diverge
+ * in a later version (e.g. if IQ recording grows a sample-rate
+ * field).
+ *
+ * SDR_EVT_IQ_RECORDING_STOPPED carries no payload.
+ */
+typedef struct SdrEventIqRecording {
+    const char* path_utf8;
+} SdrEventIqRecording;
+
+/*
  * Tagged union of all event payloads. Which union field is valid
  * is determined by the `kind` discriminant on the enclosing
  * SdrEvent (see the table below).
@@ -555,6 +590,8 @@ typedef struct SdrEventAudioRecording {
  * SDR_EVT_ERROR                       error.utf8
  * SDR_EVT_AUDIO_RECORDING_STARTED     audio_recording.path_utf8
  * SDR_EVT_AUDIO_RECORDING_STOPPED     none (all-zero payload)
+ * SDR_EVT_IQ_RECORDING_STARTED        iq_recording.path_utf8
+ * SDR_EVT_IQ_RECORDING_STOPPED        none (all-zero payload)
  */
 typedef union SdrEventPayload {
     double sample_rate_hz;
@@ -564,6 +601,7 @@ typedef union SdrEventPayload {
     SdrEventGainList       gain_list;
     SdrEventError          error;
     SdrEventAudioRecording audio_recording;
+    SdrEventIqRecording    iq_recording;
     /* Placeholder so kinds with no payload (e.g., SOURCE_STOPPED)
      * have a well-defined zeroed payload representation. */
     uint64_t _placeholder;


### PR DESCRIPTION
## Summary

Mirror the #239 audio-recording plumbing for the raw IQ stream. Engine-side was already complete on both counts (`UiToDsp::Start/StopIqRecording` + `WavWriter` at the current tuner sample rate); this PR is pure FFI + SwiftUI wiring.

Closes #238.

## Engine audit (why no Swift-side logic)

Same shape as Group B.1:

| Feature | Engine source of truth | Swift work |
|---|---|---|
| Start / stop | `UiToDsp::StartIqRecording(PathBuf)` / `StopIqRecording` at `controller.rs:927` / `:943` | FFI wrap |
| WAV writer | `WavWriter::new(&path, iq_rate, IQ_CHANNELS)` — uses `state.sample_rate as u32`, not the fixed 48 kHz audio rate | Host does nothing |
| Auto-stop on shutdown | `controller.rs:1260` already emits `IqRecordingStopped` on teardown | Receive via event |
| Errors | `DspToUi::Error("IQ record failed: …")` | Existing error event arm |
| Path format | — | Host-only: `~/Documents/SDRMac/IQ/sdr-iq-<timestamp>.wav` |

## What changed

**sdr-ffi (ABI 0.4 → 0.5, additive):**
- `sdr_core_start_iq_recording(path)` / `_stop_iq_recording`.
- `SDR_EVT_IQ_RECORDING_STARTED` (=10, path payload) / `_STOPPED` (=11). New `SdrEventIqRecording` payload struct (same layout as `SdrEventAudioRecording` but declared separately so union-field access stays self-documenting, and so the two feature paths can diverge later — e.g. if IQ gains a sample-rate field).
- Removed `Iq*` variants from the "silently dropped" fallback in `translate_event`.
- Added `#[allow(clippy::too_many_lines)]` to `translate_event` with a justification comment: the function is a single match and splitting into per-variant helpers would push `owned_cstring`/`owned_vec` lifetime plumbing across function boundaries without improving readability.
- Header updated; `make ffi-header-check` clean.

**SdrCoreKit:**
- `SdrCore.startIqRecording(path:)` / `stopIqRecording`.
- `.iqRecordingStarted(path:)` / `.iqRecordingStopped` event variants with the same null-or-empty-path drop guard the audio variants got in #344 round 2.

**SDRMac:**
- `CoreModel.iqRecordingPath` + setters + event handlers. Independent from audio — both can record simultaneously.
- `SDRMacApp.iqRecordingsDirectory()` → `~/Documents/SDRMac/IQ/` via new shared `recordingsSubdirectory(named:)` helper. Both directory statics are `nonisolated` so the view-side path generators can call them without crossing actor boundaries.
- **RecordingSection refactored**: extracted a parameterized `RecordingToggleRow` subview so Audio and IQ share identical UX (toggle + filename + reveal-in-Finder + debounce) without copy-paste. Each row owns its own `pendingTransition` lock — audio and IQ transitions don't block each other.

## Tests

- 2 new `sdr-ffi` tests: null/empty path rejection + start/stop round-trip via a live engine handle.
- `cargo test --workspace -p sdr-ffi`: 56 tests, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `make ffi-header-check`: clean.
- Release Mac app (`make mac-app`) built and smoke-tested. Recording section shows both toggles; starting IQ recording produces a playable 2-channel WAV at the source rate under `~/Documents/SDRMac/IQ/`.

## Test plan

- [x] Unit tests pass
- [x] Clippy clean
- [x] Header drift lint clean
- [x] Release Mac app build succeeds
- [x] Sidebar Recording section shows both Audio and IQ toggles
- [x] IQ toggle starts + stops; path shown + reveal-in-Finder works
- [x] Both recordings can be active simultaneously
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IQ (In-phase/Quadrature) stream recording with independent start/stop controls and engine events.
  * UI shows separate Audio and IQ recording rows, each displaying file path and a reveal action.
  * IQ recordings saved to a dedicated IQ recordings directory; file-path generation exposed for both types.

* **Reliability**
  * Improved validation/error handling for recording starts and a short (5s) watchdog to avoid stuck pending starts; stronger recording-confirmation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->