### PR TITLE
feat(macos): Group B.3 — RadioReference frequency browser (#241)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "coreaudio-rs"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1089,8 @@ checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "dbus-secret-service",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
  "zeroize",
 ]
 
@@ -1955,12 +1983,16 @@ name = "sdr-ffi"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "sdr-config",
  "sdr-core",
  "sdr-pipeline",
  "sdr-radio",
+ "sdr-radioreference",
  "sdr-rtlsdr",
  "sdr-sink-audio",
  "sdr-types",
+ "serde",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2162,6 +2194,42 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,17 @@ sdr-ui = { path = "crates/sdr-ui" }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 quick-xml = "0.37"
 
-# Secure credential storage
-keyring = { version = "3", features = ["sync-secret-service"] }
+# Secure credential storage.
+#
+# Keyring 3.x requires an explicit backend feature per target
+# OS. The defaults give you a silent **mock** backend that
+# accepts writes and returns Ok but persists nothing — learned
+# the hard way on PR #346 while building the RadioReference
+# credentials flow on macOS. Enable both native backends so
+# the same binary works on Linux and macOS:
+#   * `sync-secret-service` → Linux (GNOME Keyring / KeePassXC)
+#   * `apple-native`        → macOS Keychain (uses Security.framework)
+keyring = { version = "3", features = ["sync-secret-service", "apple-native"] }
 
 # Whisper speech-to-text
 whisper-rs = "0.16"

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
@@ -33,6 +33,25 @@ public enum DemodMode: Int32, Sendable, CaseIterable, Codable {
         case .raw: return "RAW"
         }
     }
+
+    /// Parse the mode label the engine uses as a string (e.g. the
+    /// `demodMode` field returned by
+    /// `SdrCore.searchRadioReference` — which is already mapped
+    /// on the Rust side via `sdr_radioreference::mode_map`).
+    /// Returns `nil` for unknown strings.
+    public init?(engineLabel: String) {
+        switch engineLabel.uppercased() {
+        case "WFM": self = .wfm
+        case "NFM": self = .nfm
+        case "AM":  self = .am
+        case "USB": self = .usb
+        case "LSB": self = .lsb
+        case "DSB": self = .dsb
+        case "CW":  self = .cw
+        case "RAW": self = .raw
+        default: return nil
+        }
+    }
 }
 
 /// FM de-emphasis mode. Matches `SdrDeemphasis` in the C header.

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreError.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreError.swift
@@ -32,6 +32,7 @@ public struct SdrCoreError: Error, Equatable, CustomStringConvertible {
         case audio
         case io
         case config
+        case auth
         case unknown(Int32)
 
         init(raw: Int32) {
@@ -44,6 +45,7 @@ public struct SdrCoreError: Error, Equatable, CustomStringConvertible {
             case -6: self = .audio
             case -7: self = .io
             case -8: self = .config
+            case -9: self = .auth
             default: self = .unknown(raw)
             }
         }
@@ -59,6 +61,7 @@ public struct SdrCoreError: Error, Equatable, CustomStringConvertible {
             case .audio: return -6
             case .io: return -7
             case .config: return -8
+            case .auth: return -9
             case .unknown(let v): return v
             }
         }

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
@@ -164,12 +164,22 @@ extension SdrCore {
     // MARK: - Test + search
 
     /// Outcome of `testRadioReferenceCredentials`. Split from
-    /// plain throw/no-throw so the Settings UI can render
-    /// "invalid credentials" (actionable by the user) distinctly
-    /// from network errors (retry might fix).
+    /// plain throw/no-throw so the Settings UI can render each
+    /// actionable case distinctly:
+    ///   - `.valid` — credentials work
+    ///   - `.invalidCredentials` — RadioReference rejected
+    ///     the login (user should fix their password)
+    ///   - `.invalidInput` — local validation failed before
+    ///     any network call (e.g. empty user / password). Keeps
+    ///     these out of the "network error" bucket so users
+    ///     don't think the API is down when they just forgot
+    ///     to fill in a field. Per CodeRabbit round 4.
+    ///   - `.networkError` — everything else (HTTP, SOAP,
+    ///     SSL, …). Retry might fix.
     public enum RadioReferenceTestResult: Sendable {
         case valid
         case invalidCredentials(String)
+        case invalidInput(String)
         case networkError(String)
     }
 
@@ -194,6 +204,8 @@ extension SdrCore {
         switch err.code {
         case .auth:
             return .invalidCredentials(err.message)
+        case .invalidArg:
+            return .invalidInput(err.message)
         default:
             return .networkError(err.message)
         }

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
@@ -1,0 +1,307 @@
+//
+// SdrCoreRadioReference.swift — Swift wrapper for the FFI
+// RadioReference surface (credentials + search, issue #241).
+//
+// All of these are handle-free — they talk to the keyring or the
+// RadioReference.com SOAP API, never to the engine. The FFI
+// contract is documented in `include/sdr_core.h`; this file
+// translates between the caller-allocated-buffer C conventions
+// and Swift-native types.
+//
+// Threading: the search call is synchronous blocking HTTP. Hosts
+// MUST dispatch it off the main actor — `Task.detached` in a
+// `@MainActor` context is the standard pattern.
+
+import Foundation
+@preconcurrency import sdr_core_c
+
+// MARK: - Public types (Codable, mirror the FFI JSON schema)
+
+extension SdrCore {
+    /// One frequency row returned by `searchRadioReference(zip:)`.
+    /// Mirrors the `WireFrequency` struct on the Rust side; Codable
+    /// keys match the JSON schema documented in
+    /// `include/sdr_core.h` → `sdr_core_radioreference_search_zip`.
+    public struct RadioReferenceFrequency: Codable, Hashable, Identifiable, Sendable {
+        /// Opaque RadioReference frequency ID — stable for this
+        /// row but not human-meaningful. Use for dedup / import
+        /// tracking.
+        public let id: String
+
+        /// Tuner frequency in Hz.
+        public let freqHz: UInt64
+
+        /// Raw RR mode string as returned by RadioReference
+        /// ("FM", "FMN", "FMW", "AM", "USB", "LSB", "CW", …).
+        /// Surfaced for display; bookmarks use `demodMode` instead.
+        public let rrMode: String
+
+        /// Engine demod mode name, already mapped via
+        /// `sdr_radioreference::mode_map::map_rr_mode` on the Rust
+        /// side ("NFM", "WFM", "AM", "USB", "LSB", "CW"). This is
+        /// what a bookmark should carry.
+        public let demodMode: String
+
+        /// Channel bandwidth in Hz, also from the mode map.
+        public let bandwidthHz: Double
+
+        /// CTCSS / PL tone in Hz, or `nil` when absent. Stored
+        /// in the bookmark for future restore; not applied to
+        /// the DSP during import.
+        public let toneHz: Float?
+
+        /// Human-readable description.
+        public let description: String
+
+        /// Short label (e.g. "SJ RPTR"). Preferred over
+        /// `description` for display when non-empty — matches
+        /// the GTK list's title field.
+        public let alphaTag: String
+
+        /// First tag description, used as the "Category" filter
+        /// key in the sidebar. Empty when the row has no tags.
+        public let category: String
+
+        /// All tag descriptions in order (usually just one).
+        public let tags: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case freqHz       = "freq_hz"
+            case rrMode       = "rr_mode"
+            case demodMode    = "demod_mode"
+            case bandwidthHz  = "bandwidth_hz"
+            case toneHz       = "tone_hz"
+            case description
+            case alphaTag     = "alpha_tag"
+            case category
+            case tags
+        }
+    }
+
+    /// Result of a ZIP search: the resolved county plus the full
+    /// frequency list. Mirrors `WireSearchResult` on the Rust side.
+    public struct RadioReferenceSearchResult: Codable, Sendable {
+        public let countyId: UInt32
+        public let countyName: String
+        public let stateId: UInt32
+        public let city: String
+        public let frequencies: [RadioReferenceFrequency]
+
+        enum CodingKeys: String, CodingKey {
+            case countyId    = "county_id"
+            case countyName  = "county_name"
+            case stateId     = "state_id"
+            case city
+            case frequencies
+        }
+    }
+
+    // MARK: - Credentials
+
+    /// Persist RadioReference credentials to the macOS Keychain
+    /// (same keychain item the Linux GTK build uses — they stay
+    /// in sync if both are installed).
+    public static func saveRadioReferenceCredentials(user: String, password: String) throws {
+        let rc = user.withCString { uPtr in
+            password.withCString { pPtr in
+                sdr_core_radioreference_save_credentials(uPtr, pPtr)
+            }
+        }
+        try checkRc(rc)
+    }
+
+    /// Load the stored credentials. Returns `nil` if either field
+    /// is missing or empty (the FFI reports `.io` with a
+    /// "credential not found" message — we map that to `nil`
+    /// since "not stored" is a normal state, not an error).
+    public static func loadRadioReferenceCredentials() throws -> (user: String, password: String)? {
+        var userBuf = [CChar](repeating: 0, count: Self.credentialBufferSize)
+        var passBuf = [CChar](repeating: 0, count: Self.credentialBufferSize)
+        let rc = userBuf.withUnsafeMutableBufferPointer { uBuf -> Int32 in
+            passBuf.withUnsafeMutableBufferPointer { pBuf -> Int32 in
+                guard let uBase = uBuf.baseAddress, let pBase = pBuf.baseAddress else {
+                    return -1
+                }
+                return sdr_core_radioreference_load_credentials(
+                    uBase, uBuf.count,
+                    pBase, pBuf.count
+                )
+            }
+        }
+        if rc == 0 {
+            return (String(cString: userBuf), String(cString: passBuf))
+        }
+        // .io from the FFI specifically signals "not stored"
+        // (the FFI stashes "credential not found" in the last-
+        // error). Treat that as `nil`, not a thrown error.
+        let err = SdrCoreError.fromCurrentError(rawCode: rc)
+        if case .io = err.code {
+            return nil
+        }
+        throw err
+    }
+
+    /// Remove any stored credentials. Idempotent — calling this
+    /// when no credentials are saved is a no-op.
+    public static func deleteRadioReferenceCredentials() throws {
+        try checkRc(sdr_core_radioreference_delete_credentials())
+    }
+
+    /// True when a non-empty username AND password are stored.
+    /// Doesn't load the values — use this to gate "show
+    /// RadioReference panel" without surfacing the password.
+    public static var hasRadioReferenceCredentials: Bool {
+        sdr_core_radioreference_has_credentials()
+    }
+
+    // MARK: - Test + search
+
+    /// Outcome of `testRadioReferenceCredentials`. Split from
+    /// plain throw/no-throw so the Settings UI can render
+    /// "invalid credentials" (actionable by the user) distinctly
+    /// from network errors (retry might fix).
+    public enum RadioReferenceTestResult: Sendable {
+        case valid
+        case invalidCredentials(String)
+        case networkError(String)
+    }
+
+    /// Probe RadioReference with the given credentials (does a
+    /// `getZipcodeInfo("90210")` under the hood — the same check
+    /// the Linux "Test & Save" button uses). Safe to call from
+    /// any thread; callers should still dispatch off the main
+    /// actor because the underlying HTTP is blocking.
+    public static func testRadioReferenceCredentials(
+        user: String,
+        password: String
+    ) -> RadioReferenceTestResult {
+        let rc = user.withCString { uPtr in
+            password.withCString { pPtr in
+                sdr_core_radioreference_test_credentials(uPtr, pPtr)
+            }
+        }
+        if rc == 0 {
+            return .valid
+        }
+        let err = SdrCoreError.fromCurrentError(rawCode: rc)
+        switch err.code {
+        case .auth:
+            return .invalidCredentials(err.message)
+        default:
+            return .networkError(err.message)
+        }
+    }
+
+    /// Search RadioReference for all frequencies covering `zip`
+    /// (a 5-digit US ZIP code). The FFI does `getZipInfo(zip)` +
+    /// `getCountyFrequencies(county)` in one round-trip and
+    /// returns a JSON blob that Codable decodes into
+    /// `RadioReferenceSearchResult`.
+    ///
+    /// **Blocking.** Callers MUST dispatch off the main actor.
+    /// Typical pattern:
+    ///
+    ///     Task.detached(priority: .userInitiated) {
+    ///         let result = try SdrCore.searchRadioReference(
+    ///             user: u, password: p, zip: "90210"
+    ///         )
+    ///         await MainActor.run { ... }
+    ///     }
+    ///
+    /// Uses a grow-if-needed buffer: starts at 64 KB (typical
+    /// counties return 30-300 frequencies, ~100-300 bytes each,
+    /// so 64 KB fits most) and resizes once if the FFI reports
+    /// a larger payload. Two calls in the worst case; one in
+    /// the typical case.
+    public static func searchRadioReference(
+        user: String,
+        password: String,
+        zip: String
+    ) throws -> RadioReferenceSearchResult {
+        let json = try callSearchZip(user: user, password: password, zip: zip)
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(RadioReferenceSearchResult.self, from: json)
+        } catch {
+            throw SdrCoreError(
+                code: .internal,
+                message: "JSON decode failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    // MARK: - Private plumbing
+
+    /// Buffer size used for credential load. 512 bytes fits any
+    /// realistic username / password; truncation is not an error
+    /// per the FFI contract.
+    private static let credentialBufferSize = 512
+
+    /// Initial buffer size for the search JSON — large enough
+    /// that most counties fit in one round-trip. See
+    /// `searchRadioReference(user:password:zip:)`.
+    private static let initialSearchBufferSize = 64 * 1024
+
+    /// Invoke the FFI search twice when the first call reports a
+    /// larger-than-buffer payload. Returns the JSON bytes ready
+    /// for `Codable` decoding.
+    private static func callSearchZip(
+        user: String,
+        password: String,
+        zip: String
+    ) throws -> Data {
+        var buffer = [CChar](repeating: 0, count: initialSearchBufferSize)
+        var required: Int = 0
+
+        let rc = runSearch(
+            user: user, password: password, zip: zip,
+            buffer: &buffer, required: &required
+        )
+        try checkRc(rc)
+
+        // If the FFI reported a required size larger than our
+        // buffer, retry once with exactly that capacity (+1 for
+        // the NUL the FFI always writes).
+        if required >= buffer.count {
+            buffer = [CChar](repeating: 0, count: required + 1)
+            let retryRc = runSearch(
+                user: user, password: password, zip: zip,
+                buffer: &buffer, required: &required
+            )
+            try checkRc(retryRc)
+        }
+
+        // Convert to Data by reading up to the first NUL. The
+        // FFI guarantees NUL termination when rc == 0.
+        return buffer.withUnsafeBufferPointer { buf -> Data in
+            guard let base = buf.baseAddress else { return Data() }
+            let len = strnlen(base, buf.count)
+            let raw = UnsafeRawPointer(base)
+            return Data(bytes: raw, count: len)
+        }
+    }
+
+    private static func runSearch(
+        user: String,
+        password: String,
+        zip: String,
+        buffer: inout [CChar],
+        required: inout Int
+    ) -> Int32 {
+        user.withCString { uPtr in
+            password.withCString { pPtr in
+                zip.withCString { zPtr in
+                    buffer.withUnsafeMutableBufferPointer { buf -> Int32 in
+                        guard let base = buf.baseAddress else { return -1 }
+                        return sdr_core_radioreference_search_zip(
+                            uPtr, pPtr, zPtr,
+                            base, buf.count,
+                            &required
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
@@ -111,10 +111,13 @@ extension SdrCore {
         try checkRc(rc)
     }
 
-    /// Load the stored credentials. Returns `nil` if either field
-    /// is missing or empty (the FFI reports `.io` with a
-    /// "credential not found" message — we map that to `nil`
-    /// since "not stored" is a normal state, not an error).
+    /// Load the stored credentials. Returns `nil` when no
+    /// credentials are stored, throws on a genuine keyring
+    /// backend failure. Distinguishes the two cases via the
+    /// FFI contract:
+    ///   - rc == 0 and both buffers non-empty → `(user, pass)`
+    ///   - rc == 0 and either buffer empty → `nil` ("not stored")
+    ///   - rc != 0 → throws with the FFI error code + message
     public static func loadRadioReferenceCredentials() throws -> (user: String, password: String)? {
         var userBuf = [CChar](repeating: 0, count: Self.credentialBufferSize)
         var passBuf = [CChar](repeating: 0, count: Self.credentialBufferSize)
@@ -129,17 +132,20 @@ extension SdrCore {
                 )
             }
         }
-        if rc == 0 {
-            return (String(cString: userBuf), String(cString: passBuf))
-        }
-        // .io from the FFI specifically signals "not stored"
-        // (the FFI stashes "credential not found" in the last-
-        // error). Treat that as `nil`, not a thrown error.
-        let err = SdrCoreError.fromCurrentError(rawCode: rc)
-        if case .io = err.code {
+        try checkRc(rc)
+        let user = String(cString: userBuf)
+        let pass = String(cString: passBuf)
+        // FFI returns OK with empty buffers for the "not stored"
+        // case (see `sdr_core_radioreference_load_credentials`
+        // in `include/sdr_core.h`). Distinct from `.io` which is
+        // now reserved for real backend failures — the rabbit
+        // caught this on round 1 of PR #346: the earlier shape
+        // lumped both into the same error code, so a broken
+        // keychain looked identical to "no creds saved."
+        if user.isEmpty || pass.isEmpty {
             return nil
         }
-        throw err
+        return (user, pass)
     }
 
     /// Remove any stored credentials. Idempotent — calling this

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
@@ -249,9 +249,17 @@ extension SdrCore {
     /// `searchRadioReference(user:password:zip:)`.
     private static let initialSearchBufferSize = 64 * 1024
 
-    /// Invoke the FFI search twice when the first call reports a
-    /// larger-than-buffer payload. Returns the JSON bytes ready
-    /// for `Codable` decoding.
+    /// Invoke the FFI search, retrying once with a
+    /// larger buffer when the first call reports the payload
+    /// won't fit. Returns the JSON bytes ready for `Codable`
+    /// decoding.
+    ///
+    /// Retry contract: as of PR #346 round 3, the FFI returns
+    /// `INVALID_ARG` when `out_buf` is too small (previously it
+    /// returned OK and silently truncated the JSON). On that
+    /// specific error, `required` is set to the exact
+    /// NUL-inclusive size and we reallocate + retry once. Any
+    /// other error propagates as-is.
     private static func callSearchZip(
         user: String,
         password: String,
@@ -260,23 +268,27 @@ extension SdrCore {
         var buffer = [CChar](repeating: 0, count: initialSearchBufferSize)
         var required: Int = 0
 
-        let rc = runSearch(
+        var rc = runSearch(
             user: user, password: password, zip: zip,
             buffer: &buffer, required: &required
         )
-        try checkRc(rc)
 
-        // If the FFI reported a required size larger than our
-        // buffer, retry once with exactly that capacity (+1 for
-        // the NUL the FFI always writes).
-        if required >= buffer.count {
-            buffer = [CChar](repeating: 0, count: required + 1)
-            let retryRc = runSearch(
+        // Buffer too small → FFI returns InvalidArg with
+        // `required` filled in. Distinct from a genuine
+        // malformed-input InvalidArg because `required` is the
+        // signal: non-zero AND greater than the buffer we just
+        // passed means "grow and retry."
+        if rc == SdrCoreError.Code.invalidArg.rawValue
+            && required > 0
+            && required > buffer.count
+        {
+            buffer = [CChar](repeating: 0, count: required)
+            rc = runSearch(
                 user: user, password: password, zip: zip,
                 buffer: &buffer, required: &required
             )
-            try checkRc(retryRc)
         }
+        try checkRc(rc)
 
         // Convert to Data by reading up to the first NUL. The
         // FFI guarantees NUL termination when rc == 0.

--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -12,6 +12,14 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(CoreModel.self) private var model
+    @Environment(\.scenePhase) private var scenePhase
+    /// Sheet state lives up here (not inside the toolbar)
+    /// because the subview-wrapped version of the RR button
+    /// didn't render in the toolbar — inlining the button in
+    /// the ToolbarItem closure did. Hoisting `@State` here
+    /// keeps the toolbar closure flat while letting `.sheet`
+    /// attach to a plain View that renders the dialog.
+    @State private var showingRadioReference: Bool = false
 
     var body: some View {
         NavigationSplitView {
@@ -23,7 +31,26 @@ struct ContentView: View {
                 StatusBar()
             }
         }
-        .toolbar { HeaderToolbar() }
+        .toolbar { HeaderToolbar(showingRadioReference: $showingRadioReference) }
+        .sheet(isPresented: $showingRadioReference) {
+            RadioReferenceDialog()
+        }
+        // Re-sync the RadioReference credentials flag whenever
+        // the main window becomes active. Handles the case where
+        // something outside the app's Settings flow changed the
+        // keychain (Keychain Access, another process, another
+        // build of the app) — the next time the user focuses
+        // this window, the toolbar reflects reality.
+        //
+        // The Settings save flow ALSO updates the flag directly,
+        // so in the happy path this is a no-op double-check. If
+        // cross-scene `@Observable` propagation ever drops an
+        // update, scenePhase change acts as the safety net.
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                model.refreshRadioReferenceCredentialsFlag()
+            }
+        }
         // Fatal ABI-mismatch modal. The binding's setter is a
         // no-op so dismissing the alert is impossible — the
         // only action is Quit. Matches the spec ("fail launch

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -196,6 +196,24 @@ final class CoreModel {
     var iqRecordingPath: String? = nil
 
     // ==========================================================
+    //  RadioReference
+    // ==========================================================
+
+    /// Cached "has stored credentials" flag so SwiftUI views that
+    /// gate on it (the sidebar RR section, the Settings pane's
+    /// "Clear stored" button) update reactively when credentials
+    /// are saved or deleted. `SdrCore.hasRadioReferenceCredentials`
+    /// is a static so it doesn't drive view invalidation on its
+    /// own — `refreshRadioReferenceCredentialsFlag()` is the
+    /// mutation hook that writes this @Observable field after
+    /// a save / delete.
+    ///
+    /// Initialized from the keyring at bootstrap; stays accurate
+    /// for the lifetime of the app as long as every mutation
+    /// path goes through `refreshRadioReferenceCredentialsFlag`.
+    var radioReferenceHasCredentials: Bool = false
+
+    // ==========================================================
     //  Display
     // ==========================================================
 
@@ -280,6 +298,12 @@ final class CoreModel {
             selectedAudioDeviceUid = saved
         }
         refreshAudioDevices()
+
+        // Seed the RadioReference credentials flag from the
+        // keyring so the sidebar panel / settings pane render
+        // correctly on first paint without waiting for a user
+        // action.
+        refreshRadioReferenceCredentialsFlag()
 
         do {
             let c = try SdrCore(configPath: configPath)
@@ -760,6 +784,14 @@ final class CoreModel {
     /// clears `iqRecordingPath`.
     func stopIqRecording() {
         capture { try core?.stopIqRecording() }
+    }
+
+    /// Re-read the keyring to sync the observable
+    /// `radioReferenceHasCredentials` flag. Callers that mutate
+    /// credentials (save/delete in Settings) must invoke this so
+    /// views depending on the flag redraw.
+    func refreshRadioReferenceCredentialsFlag() {
+        radioReferenceHasCredentials = SdrCore.hasRadioReferenceCredentials
     }
 
     func setFftSize(_ n: Int) {

--- a/apps/macos/SDRMac/Views/HeaderToolbar.swift
+++ b/apps/macos/SDRMac/Views/HeaderToolbar.swift
@@ -11,6 +11,7 @@ import SdrCoreKit
 
 struct HeaderToolbar: ToolbarContent {
     @Environment(CoreModel.self) private var model
+    @Binding var showingRadioReference: Bool
 
     var body: some ToolbarContent {
         ToolbarItem(placement: .navigation) {
@@ -31,12 +32,6 @@ struct HeaderToolbar: ToolbarContent {
         }
 
         ToolbarItem(placement: .primaryAction) {
-            // Route through the model setter (not `$m.demodMode`
-            // directly) so the binding's set path fires
-            // `setDemodMode` exactly once — the straightforward
-            // two-way binding would write the property first, then
-            // the onChange handler would write it again via the
-            // setter, which both worked and smelled.
             Picker("Mode", selection: Binding(
                 get: { model.demodMode },
                 set: { model.setDemodMode($0) }
@@ -48,6 +43,53 @@ struct HeaderToolbar: ToolbarContent {
             .pickerStyle(.menu)
             .frame(width: 110)
         }
+
+        // RadioReference button — mirrors the GTK header-bar
+        // entry point.
+        //
+        // Always visible (not gated on saved credentials) for
+        // two reasons:
+        //   1. SwiftUI's macOS toolbar didn't re-lay out
+        //      reliably when we gated on
+        //      `model.radioReferenceHasCredentials` — the
+        //      button stayed hidden even after credentials
+        //      were saved. An always-present item sidesteps
+        //      the layout-caching quirk entirely.
+        //   2. The dialog already handles the no-credentials
+        //      case with a "configure in Settings → RadioReference"
+        //      message, so clicking the button is always
+        //      actionable — either search or guidance to
+        //      set up auth.
+        //
+        // **Inline** — no `RadioReferenceToolbarButton`
+        // subview wrapper. During debugging (v4/v5), wrapping
+        // the button in a separate View struct caused
+        // ToolbarItem not to render on macOS; inlining the
+        // Button + Label directly in the ToolbarItem closure
+        // works reliably. Sheet presentation state lives on
+        // ContentView so this ToolbarContent struct doesn't
+        // need its own `@State`.
+        //
+        // **`Label(text, systemImage:)`** — not a bare
+        // `Image`. macOS toolbars have a user-controlled
+        // display mode (Icon Only / Icon and Text / Text
+        // Only via right-click). A bare `Image` whose symbol
+        // isn't recognized on the current macOS version
+        // renders nothing in Icon Only mode. The `Label`
+        // falls back to text so the button surfaces
+        // regardless. Per PR #346 debugging and the
+        // `feedback_swiftui_toolbar_placement` memory.
+        ToolbarItem(placement: .automatic) {
+            Button {
+                showingRadioReference = true
+            } label: {
+                Label(
+                    "RadioReference",
+                    systemImage: "antenna.radiowaves.left.and.right"
+                )
+            }
+            .help("RadioReference Frequency Browser")
+        }
     }
 }
 
@@ -55,3 +97,4 @@ struct HeaderToolbar: ToolbarContent {
 // individual digits with click/scroll/keyboard per digit,
 // matching the GTK widget. The old `FrequencyEntry` text-field
 // approach was removed in favor of the digit grid.
+

--- a/apps/macos/SDRMac/Views/RadioReferenceDialog.swift
+++ b/apps/macos/SDRMac/Views/RadioReferenceDialog.swift
@@ -205,11 +205,17 @@ struct RadioReferenceDialog: View {
 
     private func triggerSearch() {
         guard zipIsValid else { return }
+        // Clear the previous result set before kicking off the
+        // next search. Without this, the old rows + their
+        // import action stay live while the spinner runs — a
+        // user could import stale bookmarks from the previous
+        // ZIP mid-search. Per CodeRabbit round 1 on PR #346.
         selectedIds = []
         categoryFilter = ""
         agencyFilter = ""
         statusMessage = ""
         statusIsError = false
+        searchResult = nil
         isSearching = true
 
         let zip = zipInput

--- a/apps/macos/SDRMac/Views/RadioReferenceDialog.swift
+++ b/apps/macos/SDRMac/Views/RadioReferenceDialog.swift
@@ -1,0 +1,441 @@
+//
+// RadioReferenceDialog.swift — modal sheet for the RadioReference
+// frequency lookup (issue #241).
+//
+// Mirrors the GTK UI's mount point: a 700×600 modal dialog
+// triggered by a header-bar button (see
+// `RadioReferenceToolbarButton`). The button is only visible
+// when credentials are saved, so this view assumes the keyring
+// has them by the time it renders.
+//
+// Flow (unchanged from the earlier sidebar version — only the
+// chrome moved):
+//   1. ZIP entry + Search
+//   2. Async detached search via `SdrCore.searchRadioReference`
+//   3. Category + Agency filters populated from the result set
+//   4. Checkbox-select rows → "Import Selected (N)" bulk-adds
+//      bookmarks with mapped demod mode + bandwidth
+//   5. On successful import, the sheet auto-closes (matches GTK)
+//
+// The engine-side crate (`sdr-radioreference`) does the HTTP;
+// we surface it through three handle-free FFI functions
+// documented in `SdrCoreRadioReference.swift`.
+
+import SwiftUI
+import SdrCoreKit
+
+struct RadioReferenceDialog: View {
+    @Environment(CoreModel.self) private var model
+    @Environment(BookmarksStore.self) private var bookmarksStore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var zipInput: String = ""
+    @State private var isSearching: Bool = false
+    @State private var searchResult: SdrCore.RadioReferenceSearchResult?
+    @State private var statusMessage: String = ""
+    @State private var statusIsError: Bool = false
+
+    /// Rows the user has checked for import. Keyed by
+    /// `RadioReferenceFrequency.id` — stable per row within a
+    /// single search, reset on every new search.
+    @State private var selectedIds: Set<String> = []
+
+    /// User-chosen category filter; `""` means "All".
+    @State private var categoryFilter: String = ""
+
+    /// User-chosen agency (alpha_tag) filter; `""` means "All".
+    @State private var agencyFilter: String = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            searchBar
+            if isSearching {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Searching RadioReference…")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+            }
+            if !statusMessage.isEmpty {
+                Text(statusMessage)
+                    .font(.callout)
+                    .foregroundStyle(statusIsError ? .red : .secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 6)
+            }
+            if let result = searchResult {
+                filtersBar(for: result)
+                Divider()
+                resultsList(for: result)
+                Divider()
+                footer(for: result)
+            } else {
+                // Pin the header/search bar to the top in the
+                // empty / searching states. Without this,
+                // `VStack` centers its content vertically in
+                // the fixed 600-pt frame and the header
+                // visibly jumps downward while loading, then
+                // snaps back up once the results fill in.
+                Spacer()
+            }
+        }
+        .frame(width: 700, height: 600, alignment: .top)
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        HStack {
+            Label("RadioReference", systemImage: "antenna.radiowaves.left.and.right")
+                .font(.headline)
+            Spacer()
+            Button("Close") { dismiss() }
+                .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: 8) {
+            TextField("ZIP code (e.g. 90210)", text: $zipInput)
+                .textFieldStyle(.roundedBorder)
+                .disabled(isSearching)
+                .onSubmit { triggerSearch() }
+                .frame(maxWidth: 200)
+            Button {
+                triggerSearch()
+            } label: {
+                Label("Search", systemImage: "magnifyingglass")
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!zipIsValid || isSearching)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func filtersBar(for result: SdrCore.RadioReferenceSearchResult) -> some View {
+        HStack(spacing: 12) {
+            Picker("Category", selection: $categoryFilter) {
+                Text("All").tag("")
+                ForEach(uniqueCategories(in: result), id: \.self) { category in
+                    Text(category).tag(category)
+                }
+            }
+            .frame(maxWidth: 260)
+
+            Picker("Agency", selection: $agencyFilter) {
+                Text("All").tag("")
+                ForEach(uniqueAgencies(in: result), id: \.self) { agency in
+                    Text(agency).tag(agency)
+                }
+            }
+            .frame(maxWidth: 260)
+
+            Spacer()
+
+            let filtered = filteredFrequencies(in: result)
+            Text("\(filtered.count) / \(result.frequencies.count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+
+    private func resultsList(for result: SdrCore.RadioReferenceSearchResult) -> some View {
+        let filtered = filteredFrequencies(in: result)
+        return ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(filtered) { row in
+                    RadioReferenceRow(
+                        frequency: row,
+                        isSelected: selectedIds.contains(row.id),
+                        alreadyBookmarked: alreadyBookmarked(row),
+                        toggle: {
+                            if selectedIds.contains(row.id) {
+                                selectedIds.remove(row.id)
+                            } else {
+                                selectedIds.insert(row.id)
+                            }
+                        }
+                    )
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private func footer(for result: SdrCore.RadioReferenceSearchResult) -> some View {
+        let filtered = filteredFrequencies(in: result)
+        let importable = filtered.filter {
+            selectedIds.contains($0.id) && !alreadyBookmarked($0)
+        }
+        return HStack {
+            Text("\(result.city), \(result.countyName)")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button {
+                importSelected(importable)
+            } label: {
+                if importable.isEmpty {
+                    Text("Import Selected")
+                } else {
+                    Text("Import Selected (\(importable.count))")
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(importable.isEmpty)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Actions
+
+    private func triggerSearch() {
+        guard zipIsValid else { return }
+        selectedIds = []
+        categoryFilter = ""
+        agencyFilter = ""
+        statusMessage = ""
+        statusIsError = false
+        isSearching = true
+
+        let zip = zipInput
+        Task.detached(priority: .userInitiated) {
+            // Resolve credentials. Three outcomes:
+            //   - stored OK       → proceed
+            //   - not stored      → "open Settings → RadioReference"
+            //   - keychain threw  → surface the underlying error
+            let creds: (user: String, password: String)
+            do {
+                guard let pair = try SdrCore.loadRadioReferenceCredentials() else {
+                    await MainActor.run {
+                        self.isSearching = false
+                        self.searchResult = nil
+                        self.statusMessage =
+                            "No stored credentials. Open Settings → RadioReference to add them."
+                        self.statusIsError = true
+                    }
+                    return
+                }
+                creds = pair
+            } catch let err as SdrCoreError {
+                await MainActor.run {
+                    self.isSearching = false
+                    self.searchResult = nil
+                    self.statusMessage = "Couldn't read keychain: \(err.message)"
+                    self.statusIsError = true
+                }
+                return
+            } catch {
+                await MainActor.run {
+                    self.isSearching = false
+                    self.searchResult = nil
+                    self.statusMessage = "Unexpected keychain error: \(error.localizedDescription)"
+                    self.statusIsError = true
+                }
+                return
+            }
+
+
+            do {
+                let result = try SdrCore.searchRadioReference(
+                    user: creds.user,
+                    password: creds.password,
+                    zip: zip
+                )
+                await MainActor.run {
+                    self.isSearching = false
+                    self.searchResult = result
+                    if result.frequencies.isEmpty {
+                        self.statusMessage = "No frequencies found for \(result.city), \(result.countyName)."
+                        self.statusIsError = true
+                    } else {
+                        self.statusMessage = ""
+                    }
+                }
+            } catch let err as SdrCoreError {
+                await MainActor.run {
+                    self.isSearching = false
+                    self.searchResult = nil
+                    self.statusMessage = Self.friendlyMessage(for: err)
+                    self.statusIsError = true
+                }
+            } catch {
+                await MainActor.run {
+                    self.isSearching = false
+                    self.searchResult = nil
+                    self.statusMessage = "Search failed: \(error.localizedDescription)"
+                    self.statusIsError = true
+                }
+            }
+        }
+    }
+
+    private func importSelected(_ rows: [SdrCore.RadioReferenceFrequency]) {
+        for row in rows {
+            let bookmark = Self.makeBookmark(from: row)
+            bookmarksStore.add(bookmark)
+        }
+        // GTK auto-closes the dialog after import — match that so
+        // the user lands back on the tuner and can click the
+        // freshly-created bookmark.
+        dismiss()
+    }
+
+    // MARK: - Helpers
+
+    private var zipIsValid: Bool {
+        zipInput.count == 5 && zipInput.allSatisfy(\.isNumber)
+    }
+
+    private func uniqueCategories(in result: SdrCore.RadioReferenceSearchResult) -> [String] {
+        let all = result.frequencies.map(\.category).filter { !$0.isEmpty }
+        return Array(Set(all)).sorted()
+    }
+
+    private func uniqueAgencies(in result: SdrCore.RadioReferenceSearchResult) -> [String] {
+        let all = result.frequencies.map(\.alphaTag).filter { !$0.isEmpty }
+        return Array(Set(all)).sorted()
+    }
+
+    private func filteredFrequencies(
+        in result: SdrCore.RadioReferenceSearchResult
+    ) -> [SdrCore.RadioReferenceFrequency] {
+        result.frequencies.filter { row in
+            (categoryFilter.isEmpty || row.category == categoryFilter)
+                && (agencyFilter.isEmpty || row.alphaTag == agencyFilter)
+        }
+    }
+
+    /// Matches on freq + demod mode — two RR rows at the same
+    /// frequency but different modes (rare but possible for
+    /// AM/USB overlays) stay distinct.
+    private func alreadyBookmarked(_ row: SdrCore.RadioReferenceFrequency) -> Bool {
+        let rowHz = Double(row.freqHz)
+        let mode = DemodMode(engineLabel: row.demodMode)
+        return bookmarksStore.bookmarks.contains { b in
+            b.centerFrequencyHz == rowHz && b.demodMode == mode
+        }
+    }
+
+    private static func makeBookmark(from row: SdrCore.RadioReferenceFrequency) -> Bookmark {
+        let name: String
+        if row.alphaTag.isEmpty {
+            name = row.description.isEmpty
+                ? String(format: "%.4f MHz", Double(row.freqHz) / 1_000_000)
+                : row.description
+        } else if row.description.isEmpty {
+            name = row.alphaTag
+        } else {
+            name = "\(row.alphaTag) — \(row.description)"
+        }
+
+        let demod = DemodMode(engineLabel: row.demodMode)
+        return Bookmark(
+            name: name,
+            centerFrequencyHz: Double(row.freqHz),
+            demodMode: demod,
+            bandwidthHz: row.bandwidthHz,
+            squelchEnabled: nil,
+            autoSquelchEnabled: nil,
+            squelchDb: nil,
+            gainDb: nil,
+            agcEnabled: nil,
+            volume: nil,
+            deemphasis: nil
+        )
+    }
+
+    private static func friendlyMessage(for err: SdrCoreError) -> String {
+        switch err.code {
+        case .auth:
+            return "Invalid credentials — update them in Settings → RadioReference."
+        case .io:
+            return "Network error: \(err.message)"
+        case .invalidArg:
+            return "Invalid input: \(err.message)"
+        default:
+            return "Search failed: \(err.message)"
+        }
+    }
+}
+
+/// One row in the results list. Bookmarked rows render with a
+/// checkmark and are not toggleable — matches GTK where already-
+/// imported rows are disabled.
+private struct RadioReferenceRow: View {
+    let frequency: SdrCore.RadioReferenceFrequency
+    let isSelected: Bool
+    let alreadyBookmarked: Bool
+    let toggle: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            if alreadyBookmarked {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .frame(width: 18)
+                    .accessibilityLabel("Already bookmarked")
+            } else {
+                Button(action: toggle) {
+                    Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                        .frame(width: 18)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isSelected ? "Deselect" : "Select for import")
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.callout)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 16)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if !alreadyBookmarked { toggle() }
+        }
+        .opacity(alreadyBookmarked ? 0.55 : 1.0)
+    }
+
+    private var title: String {
+        frequency.alphaTag.isEmpty ? frequency.description : frequency.alphaTag
+    }
+
+    private var subtitle: String {
+        var parts: [String] = []
+        let mhz = Double(frequency.freqHz) / 1_000_000
+        parts.append(String(format: "%.4f MHz", mhz))
+        parts.append(frequency.demodMode)
+        if let tone = frequency.toneHz {
+            parts.append(String(format: "PL %.1f", tone))
+        }
+        if !frequency.description.isEmpty && !frequency.alphaTag.isEmpty {
+            parts.append(frequency.description)
+        }
+        return parts.joined(separator: "  ·  ")
+    }
+}

--- a/apps/macos/SDRMac/Views/SettingsView.swift
+++ b/apps/macos/SDRMac/Views/SettingsView.swift
@@ -107,6 +107,14 @@ private struct RadioReferencePane: View {
     @State private var isWorking: Bool = false
     @State private var statusMessage: String = ""
     @State private var statusIsError: Bool = false
+    /// One-shot latch so `prefillFromKeychain` only runs on the
+    /// first `.onAppear`. In a TabView, switching tabs away and
+    /// back re-fires `.onAppear`, which would otherwise clobber
+    /// any username edits the user made (password isn't affected
+    /// because it's never prefilled, but that asymmetry was
+    /// exactly the mixed-pair risk the rabbit flagged in round 5
+    /// of PR #346).
+    @State private var didPrefill: Bool = false
 
     var body: some View {
         Form {
@@ -169,7 +177,11 @@ private struct RadioReferencePane: View {
                 }
             }
         }
-        .onAppear(perform: prefillFromKeychain)
+        .onAppear {
+            guard !didPrefill else { return }
+            didPrefill = true
+            prefillFromKeychain()
+        }
     }
 
     /// Load the stored username (if any) into the TextField so

--- a/apps/macos/SDRMac/Views/SettingsView.swift
+++ b/apps/macos/SDRMac/Views/SettingsView.swift
@@ -223,6 +223,9 @@ private struct RadioReferencePane: View {
         case .invalidCredentials(let msg):
             statusMessage = "Invalid credentials: \(msg)"
             statusIsError = true
+        case .invalidInput(let msg):
+            statusMessage = "\(msg)"
+            statusIsError = true
         case .networkError(let msg):
             statusMessage = "Network error: \(msg)"
             statusIsError = true

--- a/apps/macos/SDRMac/Views/SettingsView.swift
+++ b/apps/macos/SDRMac/Views/SettingsView.swift
@@ -237,8 +237,16 @@ private struct RadioReferencePane: View {
             username = ""
             password = ""
             model.refreshRadioReferenceCredentialsFlag()
+        } catch let err as SdrCoreError {
+            // Match the save path: surface the FFI message so
+            // backend failures stay actionable. `localizedDescription`
+            // on our SdrCoreError collapses to a generic "The
+            // operation couldn't be completed" string. Per
+            // CodeRabbit round 1 on PR #346.
+            statusMessage = "Delete failed: [\(err.code)] \(err.message)"
+            statusIsError = true
         } catch {
-            statusMessage = "Delete failed: \(error.localizedDescription)"
+            statusMessage = "Delete failed: \(error)"
             statusIsError = true
         }
     }

--- a/apps/macos/SDRMac/Views/SettingsView.swift
+++ b/apps/macos/SDRMac/Views/SettingsView.swift
@@ -1,8 +1,9 @@
 //
 // SettingsView.swift — Cmd-, settings scene.
 //
-// Three panes: General (config file location, log level), Audio
-// (output device picker deferred to v2), Advanced (ABI version).
+// Panes: General (config file location), Audio (output device +
+// volume), RadioReference (credentials — issue #241), Advanced
+// (ABI version).
 
 import SwiftUI
 import SdrCoreKit
@@ -14,11 +15,13 @@ struct SettingsView: View {
                 .tabItem { Label("General", systemImage: "gear") }
             AudioPane()
                 .tabItem { Label("Audio", systemImage: "speaker.wave.2") }
+            RadioReferencePane()
+                .tabItem { Label("RadioReference", systemImage: "antenna.radiowaves.left.and.right") }
             AdvancedPane()
                 .tabItem { Label("Advanced", systemImage: "wrench.and.screwdriver") }
         }
         .padding(20)
-        .frame(width: 480, height: 320)
+        .frame(width: 520, height: 360)
     }
 }
 
@@ -87,6 +90,156 @@ private struct AudioPane: View {
                     }
                 )
             }
+        }
+    }
+}
+
+/// RadioReference credential management — mirrors the GTK
+/// Preferences → Accounts page. Saved credentials live in the
+/// macOS Keychain (same keychain item the Linux build uses so
+/// cross-platform installs share a login). The pane offers
+/// test-before-save and a one-click delete.
+private struct RadioReferencePane: View {
+    @Environment(CoreModel.self) private var model
+
+    @State private var username: String = ""
+    @State private var password: String = ""
+    @State private var isWorking: Bool = false
+    @State private var statusMessage: String = ""
+    @State private var statusIsError: Bool = false
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Username", text: $username)
+                    .textContentType(.username)
+                    .disableAutocorrection(true)
+                SecureField("Password", text: $password)
+                    .textContentType(.password)
+            } header: {
+                Text("Account")
+            } footer: {
+                Text(
+                    """
+                    Requires a RadioReference.com account with API access. \
+                    Credentials are stored in your macOS Keychain and are \
+                    never written to the app's config file.
+                    """
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Section {
+                HStack {
+                    Button {
+                        Task { await testAndSave() }
+                    } label: {
+                        Label("Test & Save", systemImage: "checkmark.seal")
+                    }
+                    .disabled(isWorking || username.isEmpty || password.isEmpty)
+
+                    Button(role: .destructive) {
+                        deleteCredentials()
+                    } label: {
+                        Label("Clear stored", systemImage: "trash")
+                    }
+                    .disabled(isWorking || !model.radioReferenceHasCredentials)
+
+                    if isWorking {
+                        ProgressView().controlSize(.small)
+                    }
+                }
+
+                if !statusMessage.isEmpty {
+                    Text(statusMessage)
+                        .font(.callout)
+                        .foregroundStyle(statusIsError ? .red : .green)
+                        .textSelection(.enabled)
+                }
+
+                if model.radioReferenceHasCredentials {
+                    Text("Credentials are currently stored.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("No credentials stored.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .onAppear(perform: prefillFromKeychain)
+    }
+
+    /// Load the stored username (if any) into the TextField so
+    /// the user can see which account is currently active. We
+    /// deliberately DON'T prefill the password — SecureField +
+    /// stored password is a bad combination (copy/paste risk,
+    /// visible on clear-password-field toggles). The user
+    /// re-enters it only if they want to change it.
+    private func prefillFromKeychain() {
+        // `try?` flattens the function's `(String, String)?` return
+        // into a single optional, so `guard let` gives us a
+        // non-optional tuple.
+        guard let creds = try? SdrCore.loadRadioReferenceCredentials() else { return }
+        username = creds.user
+    }
+
+    private func testAndSave() async {
+        isWorking = true
+        defer { isWorking = false }
+        statusMessage = "Testing credentials…"
+        statusIsError = false
+
+        let user = username
+        let pass = password
+        let result = await Task.detached(priority: .userInitiated) {
+            SdrCore.testRadioReferenceCredentials(user: user, password: pass)
+        }.value
+
+        switch result {
+        case .valid:
+            // Credentials check out — persist them. A save error
+            // here would be a keyring-backend issue, surfaced as
+            // a red status without invalidating the test result.
+            do {
+                try SdrCore.saveRadioReferenceCredentials(user: user, password: pass)
+                statusMessage = "Credentials saved."
+                statusIsError = false
+                password = ""
+                model.refreshRadioReferenceCredentialsFlag()
+            } catch let err as SdrCoreError {
+                // Surface the FFI message directly — the default
+                // `localizedDescription` for our error type is an
+                // unhelpful "The operation couldn't be completed"
+                // string, which eats the real reason.
+                statusMessage = "Credentials valid, but save failed: [\(err.code)] \(err.message)"
+                statusIsError = true
+            } catch {
+                statusMessage = "Credentials valid, but save failed: \(error)"
+                statusIsError = true
+            }
+        case .invalidCredentials(let msg):
+            statusMessage = "Invalid credentials: \(msg)"
+            statusIsError = true
+        case .networkError(let msg):
+            statusMessage = "Network error: \(msg)"
+            statusIsError = true
+        }
+    }
+
+    private func deleteCredentials() {
+        do {
+            try SdrCore.deleteRadioReferenceCredentials()
+            statusMessage = "Stored credentials cleared."
+            statusIsError = false
+            username = ""
+            password = ""
+            model.refreshRadioReferenceCredentialsFlag()
+        } catch {
+            statusMessage = "Delete failed: \(error.localizedDescription)"
+            statusIsError = true
         }
     }
 }

--- a/crates/sdr-ffi/Cargo.toml
+++ b/crates/sdr-ffi/Cargo.toml
@@ -42,6 +42,15 @@ sdr-rtlsdr.workspace = true
 # `list_audio_sinks()` snapshots of CoreAudio / PipeWire state,
 # so they bypass the engine dispatch path.
 sdr-sink-audio.workspace = true
+# RadioReference integration for the SwiftUI panel (issue #241).
+# Handle-free: the SOAP client is stateless per-call and the
+# credential store (`sdr-config::KeyringStore`) has no engine
+# coupling. Network I/O means these never belong on the DSP
+# thread.
+sdr-radioreference.workspace = true
+sdr-config.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 libc.workspace = true

--- a/crates/sdr-ffi/src/error.rs
+++ b/crates/sdr-ffi/src/error.rs
@@ -42,6 +42,12 @@ pub enum SdrCoreError {
     Io = -7,
     /// Configuration load/save error.
     Config = -8,
+    /// Authentication failed — credentials rejected by a remote
+    /// service. Added for the RadioReference login path (issue
+    /// #241) so the host can distinguish "bad username/password"
+    /// (actionable: ask the user) from "server is down" (transient,
+    /// retry might work). ABI 0.5 → 0.6.
+    Auth = -9,
 }
 
 impl SdrCoreError {
@@ -175,5 +181,6 @@ mod tests {
         assert_eq!(SdrCoreError::Audio.as_int(), -6);
         assert_eq!(SdrCoreError::Io.as_int(), -7);
         assert_eq!(SdrCoreError::Config.as_int(), -8);
+        assert_eq!(SdrCoreError::Auth.as_int(), -9);
     }
 }

--- a/crates/sdr-ffi/src/lib.rs
+++ b/crates/sdr-ffi/src/lib.rs
@@ -48,6 +48,7 @@ pub mod event;
 pub mod fft;
 pub mod handle;
 pub mod lifecycle;
+pub mod radioreference;
 
 // Re-export the FFI symbols at the crate root so consumers that link
 // the rlib (in-tree integration tests) can reference them via
@@ -75,4 +76,9 @@ pub use fft::{SdrFftCallback, SdrFftFrame, sdr_core_pull_fft};
 pub use handle::SdrCore;
 pub use lifecycle::{
     sdr_core_abi_version, sdr_core_create, sdr_core_destroy, sdr_core_init_logging,
+};
+pub use radioreference::{
+    sdr_core_radioreference_delete_credentials, sdr_core_radioreference_has_credentials,
+    sdr_core_radioreference_load_credentials, sdr_core_radioreference_save_credentials,
+    sdr_core_radioreference_search_zip, sdr_core_radioreference_test_credentials,
 };

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 5;
+pub const ABI_VERSION_MINOR: u32 = 6;
 
 /// Return the ABI version the library was built with.
 ///
@@ -326,7 +326,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 5);
+        assert!(ABI_VERSION_MINOR == 6);
     };
 
     #[test]

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -164,11 +164,14 @@ unsafe fn write_cstr_to_buf(bytes: &[u8], out_buf: *mut c_char, buf_len: usize) 
 
 /// Save RadioReference credentials to the OS keyring.
 ///
-/// Both `user_utf8` and `pass_utf8` must be non-null NUL-terminated
-/// UTF-8 strings. Empty strings are accepted and stored as-is (the
-/// keyring backend doesn't distinguish "empty value" from "no
-/// value", so consumers should use `sdr_core_radioreference_has_credentials`
-/// to probe existence rather than round-tripping through load).
+/// Both `user_utf8` and `pass_utf8` must be non-null, NUL-terminated,
+/// **non-empty** UTF-8 strings. Empty inputs are rejected with
+/// `INVALID_ARG` — the rest of the ABI (has / load) treats
+/// "empty" as the "not stored" sentinel, so accepting an empty
+/// save would leave the credentials ABI self-inconsistent: save
+/// would succeed, but `has_credentials` would immediately return
+/// false and `load_credentials` would fall into the empty-buffer
+/// sentinel. Per CodeRabbit round 3 on PR #346.
 ///
 /// # Safety
 ///
@@ -192,6 +195,17 @@ pub unsafe extern "C" fn sdr_core_radioreference_save_credentials(
             Ok(s) => s,
             Err(e) => return e.as_int(),
         };
+        // Reject empty fields up front — see the function-level
+        // docstring above for the "not stored" sentinel
+        // consistency argument. Clean InvalidArg + descriptive
+        // message is friendlier than a successful-looking save
+        // that never actually appears on the next read.
+        if user.is_empty() || pass.is_empty() {
+            set_last_error(
+                "sdr_core_radioreference_save_credentials: empty user or password — both fields must be non-empty",
+            );
+            return SdrCoreError::InvalidArg.as_int();
+        }
 
         let store = KeyringStore::new(KEYRING_SERVICE);
         if let Err(e) = store.set(KEY_RR_USERNAME, &user) {
@@ -518,16 +532,19 @@ struct WireFrequency {
 /// }
 /// ```
 ///
-/// Buffer growth: `out_required` (optional) is filled with the
-/// JSON payload size **in bytes** (not counting the NUL). Callers
-/// that pass a too-small buffer get truncated JSON AND a non-zero
-/// `out_required` they can use to reallocate + retry. Pass NULL
-/// when you don't need it.
+/// Buffer sizing: `out_required` (optional — pass NULL to ignore)
+/// is filled with the exact number of bytes the caller must
+/// allocate to receive the full payload, **including the
+/// trailing NUL**. Callers that pass a too-small buffer get
+/// `INVALID_ARG` (not a silently-truncated body) with
+/// `out_required` set to the correct allocation size so they
+/// can retry.
 ///
 /// Returns `OK` on successful search + serialization, `AUTH` on
-/// bad credentials, `IO` on network failure, `INVALID_ARG` on bad
-/// inputs, `INTERNAL` on JSON encoding failure (shouldn't happen
-/// for the types involved).
+/// bad credentials, `IO` on network failure, `INVALID_ARG` on
+/// bad inputs **or a too-small output buffer** (check
+/// `out_required` to distinguish), `INTERNAL` on JSON encoding
+/// failure (shouldn't happen for the types involved).
 ///
 /// # Safety
 ///
@@ -535,6 +552,13 @@ struct WireFrequency {
 /// NUL-terminated UTF-8 C string. `out_buf` must point to at
 /// least `out_buf_len` writable bytes. `out_required` must be
 /// either null or point to a writable `usize`.
+///
+/// The `#[allow(clippy::too_many_lines)]` is deliberate — this
+/// function's body is a single top-to-bottom dispatch:
+/// validate → HTTP round-trip → map response → serialize →
+/// emit. Splitting it would just spread the same linear flow
+/// across helpers without any meaningful reuse.
+#[allow(clippy::too_many_lines)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_radioreference_search_zip(
     user_utf8: *const c_char,
@@ -637,17 +661,36 @@ pub unsafe extern "C" fn sdr_core_radioreference_search_zip(
         };
 
         let bytes = json.as_bytes();
-        // Report the required size regardless of buffer adequacy.
-        // Callers can detect truncation by comparing with buf_len.
+        // Total bytes the caller must allocate to receive the
+        // full payload — the JSON plus one byte for the trailing
+        // NUL that `write_cstr_to_buf` always emits. Report this
+        // whether or not we're about to truncate so callers can
+        // reallocate + retry. Per CodeRabbit round 3 on PR #346.
+        let required_len = bytes.len().saturating_add(1);
         if !out_required.is_null() {
             // SAFETY: non-null check above; caller contract says
             // the pointer is writable.
             unsafe {
-                *out_required = bytes.len();
+                *out_required = required_len;
             }
         }
 
-        // SAFETY: out_buf null + zero-length checked above.
+        // If the buffer isn't big enough for the payload plus
+        // NUL, return `INVALID_ARG` rather than OK with a
+        // silently-truncated body. The previous shape let C
+        // callers who passed `out_required = NULL` miss the
+        // truncation entirely — caller then parsed invalid JSON.
+        // Swift sees InvalidArg + a populated `out_required`,
+        // reallocates, and retries.
+        if required_len > out_buf_len {
+            set_last_error(format!(
+                "sdr_core_radioreference_search_zip: output buffer too small ({required_len} needed, got {out_buf_len})"
+            ));
+            return SdrCoreError::InvalidArg.as_int();
+        }
+
+        // SAFETY: out_buf null + zero-length checked above;
+        // size fit check immediately above.
         unsafe {
             write_cstr_to_buf(bytes, out_buf, out_buf_len);
         }
@@ -678,6 +721,29 @@ mod tests {
     fn save_rejects_null_pointers() {
         assert_eq!(
             unsafe { sdr_core_radioreference_save_credentials(std::ptr::null(), std::ptr::null()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+    }
+
+    #[test]
+    fn save_rejects_empty_fields() {
+        // Empty user or password must be rejected — otherwise
+        // save would succeed but `has_credentials` / `load_credentials`
+        // would immediately report "not stored" because they use
+        // the empty-buffer sentinel. Regression for CodeRabbit
+        // round 3 on PR #346.
+        let empty = CString::new("").unwrap();
+        let real = CString::new("jason").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_radioreference_save_credentials(empty.as_ptr(), real.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_radioreference_save_credentials(real.as_ptr(), empty.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_radioreference_save_credentials(empty.as_ptr(), empty.as_ptr()) },
             SdrCoreError::InvalidArg.as_int()
         );
     }

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -52,6 +52,13 @@ const KEY_RR_USERNAME: &str = "radioreference-username";
 /// Keyring key for the RadioReference password.
 const KEY_RR_PASSWORD: &str = "radioreference-password";
 
+/// Expected length of a US ZIP code in ASCII digits.
+/// RadioReference only serves US frequencies, so callers must
+/// pass a 5-digit zip; we validate on our side before hitting
+/// the network so a typo doesn't round-trip to RR as a generic
+/// SOAP fault.
+const RR_ZIP_LEN: usize = 5;
+
 /// Upper bound on usernames / passwords we'll round-trip through
 /// the load call. RadioReference usernames and passwords don't
 /// have documented length limits, but 512 bytes each is
@@ -212,15 +219,17 @@ pub unsafe extern "C" fn sdr_core_radioreference_save_credentials(
             return map_keyring_error("sdr_core_radioreference_save_credentials", &e).as_int();
         }
         if let Err(e) = store.set(KEY_RR_PASSWORD, &pass) {
-            // If the password write fails, the username is
-            // already in the keyring — leaving it there paired
-            // with whatever stale password existed before would
-            // create a mixed-credentials state later (future
-            // load returns that stale pair as if it were valid).
-            // Clean up the username so the caller sees "no
-            // credentials stored" on the next load. Per
-            // CodeRabbit round 2 on PR #346.
+            // Break the pair from BOTH sides. Deleting only the
+            // username would leave a prior-session's stale
+            // password still sitting in the keyring, which —
+            // paired with the just-written username — would
+            // surface on the next load as valid credentials.
+            // Delete both so the caller sees "no credentials
+            // stored" on the next load, regardless of which
+            // delete succeeds. Per CodeRabbit round 2 + 5 on
+            // PR #346.
             let _ = store.delete(KEY_RR_USERNAME);
+            let _ = store.delete(KEY_RR_PASSWORD);
             return map_keyring_error("sdr_core_radioreference_save_credentials", &e).as_int();
         }
 
@@ -602,8 +611,9 @@ pub unsafe extern "C" fn sdr_core_radioreference_search_zip(
 
         // RR expects a 5-digit US ZIP — validate on our side so a
         // typo doesn't round-trip to the network and come back as
-        // a generic SOAP fault.
-        if zip.len() != 5 || !zip.chars().all(|c| c.is_ascii_digit()) {
+        // a generic SOAP fault. The exact length lives at the
+        // top of the module as `RR_ZIP_LEN`.
+        if zip.len() != RR_ZIP_LEN || !zip.chars().all(|c| c.is_ascii_digit()) {
             set_last_error(format!(
                 "sdr_core_radioreference_search_zip: zip must be 5 digits, got {zip:?}"
             ));

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -60,13 +60,18 @@ const KEY_RR_PASSWORD: &str = "radioreference-password";
 const RR_ZIP_LEN: usize = 5;
 
 /// Upper bound on usernames / passwords we'll round-trip through
-/// the load call. RadioReference usernames and passwords don't
-/// have documented length limits, but 512 bytes each is
-/// comfortably more than any human typed. If a longer value shows
-/// up in the wild, `_load_credentials` truncates to `buf_len - 1`
-/// and the caller can bump its buffer — truncation does not set
-/// an error.
-#[allow(dead_code)]
+/// the save/load pair. This is the buffer size `load_credentials`
+/// uses on the Swift side, so any stored value that exceeds it
+/// would silently truncate on read — producing a different
+/// credential than the one saved, which then mysteriously fails
+/// auth.
+///
+/// Enforced on the SAVE side: `save_credentials` rejects inputs
+/// whose UTF-8 byte length exceeds this cap with `InvalidArg`.
+/// RadioReference has no documented limit but 512 bytes each is
+/// comfortably more than any human typed, and matches the
+/// SwiftUI wrapper's fixed buffer. Per CodeRabbit round 6 on
+/// PR #346.
 const MAX_CREDENTIAL_FIELD_LEN: usize = 512;
 
 // ============================================================
@@ -106,9 +111,18 @@ fn map_keyring_error(fn_name: &str, err: &KeyringError) -> SdrCoreError {
             SdrCoreError::Io
         }
         KeyringError::NoBackend => {
+            // Generic message is correct on every platform —
+            // on macOS, the Apple Keychain backend failing is
+            // a platform issue, not a missing install. Linux
+            // actually benefits from a remediation hint since
+            // the secret-service daemon might not be running.
+            // Per CodeRabbit round 6 on PR #346.
+            #[cfg(target_os = "linux")]
             set_last_error(format!(
-                "{fn_name}: no secure storage available — install GNOME Keyring or KeePassXC (Linux)"
+                "{fn_name}: no secure storage available — install GNOME Keyring or KeePassXC"
             ));
+            #[cfg(not(target_os = "linux"))]
+            set_last_error(format!("{fn_name}: no secure storage available"));
             SdrCoreError::Io
         }
         KeyringError::Platform(_) => {
@@ -211,6 +225,19 @@ pub unsafe extern "C" fn sdr_core_radioreference_save_credentials(
             set_last_error(
                 "sdr_core_radioreference_save_credentials: empty user or password — both fields must be non-empty",
             );
+            return SdrCoreError::InvalidArg.as_int();
+        }
+        // Reject values that the fixed-size load buffer can't
+        // round-trip. Without this cap, a user could save an
+        // over-long credential, and the next load would silently
+        // return a truncated value — which then fails auth at
+        // RadioReference and surfaces as "wrong password"
+        // instead of "your keychain got cut off at 512 bytes."
+        // Per CodeRabbit round 6 on PR #346.
+        if user.len() > MAX_CREDENTIAL_FIELD_LEN || pass.len() > MAX_CREDENTIAL_FIELD_LEN {
+            set_last_error(format!(
+                "sdr_core_radioreference_save_credentials: user or password exceeds {MAX_CREDENTIAL_FIELD_LEN}-byte cap"
+            ));
             return SdrCoreError::InvalidArg.as_int();
         }
 
@@ -747,6 +774,24 @@ mod tests {
     }
 
     #[test]
+    fn save_rejects_oversize_fields() {
+        // save_credentials must refuse values longer than
+        // MAX_CREDENTIAL_FIELD_LEN so they don't silently
+        // truncate on the next load. Regression for
+        // CodeRabbit round 6 on PR #346.
+        let real = CString::new("jason").unwrap();
+        let long = CString::new("x".repeat(MAX_CREDENTIAL_FIELD_LEN + 1)).unwrap();
+        assert_eq!(
+            unsafe { sdr_core_radioreference_save_credentials(long.as_ptr(), real.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_radioreference_save_credentials(real.as_ptr(), long.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+    }
+
+    #[test]
     fn save_rejects_empty_fields() {
         // Empty user or password must be rejected — otherwise
         // save would succeed but `has_credentials` / `load_credentials`
@@ -795,6 +840,41 @@ mod tests {
             },
             SdrCoreError::InvalidArg.as_int()
         );
+    }
+
+    /// Pin the "not stored" sentinel contract: after delete,
+    /// load must return OK with both buffers NUL-only (i.e.
+    /// first byte == 0). Distinct from IO (backend error) so
+    /// the Swift wrapper can return `nil` instead of throwing
+    /// — see the function-level docstring above. Per
+    /// CodeRabbit round 6 on PR #346.
+    ///
+    /// **Marked `#[ignore]`** because it deletes the
+    /// shared-service credentials from the user's real
+    /// keyring. A developer running `cargo test` with their
+    /// RadioReference login saved would lose it. Run
+    /// explicitly with `cargo test ... -- --ignored` when
+    /// vetting this contract; CI skips it.
+    #[test]
+    #[ignore = "deletes real keyring credentials — run only with --ignored after vetting"]
+    fn load_returns_ok_with_empty_buffers_when_not_stored() {
+        let handle = std::thread::spawn(|| {
+            let _ = sdr_core_radioreference_delete_credentials();
+            let mut u = [0_u8; CREDENTIAL_BUF_LEN];
+            let mut p = [0_u8; CREDENTIAL_BUF_LEN];
+            let rc = unsafe {
+                sdr_core_radioreference_load_credentials(
+                    u.as_mut_ptr().cast::<c_char>(),
+                    CREDENTIAL_BUF_LEN,
+                    p.as_mut_ptr().cast::<c_char>(),
+                    CREDENTIAL_BUF_LEN,
+                )
+            };
+            assert_eq!(rc, SdrCoreError::Ok.as_int());
+            assert_eq!(u[0], 0, "user buffer should be NUL-only when not stored");
+            assert_eq!(p[0], 0, "pass buffer should be NUL-only when not stored");
+        });
+        handle.join().expect("thread should exit cleanly");
     }
 
     #[test]

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -589,6 +589,17 @@ pub unsafe extern "C" fn sdr_core_radioreference_search_zip(
             Err(e) => return e.as_int(),
         };
 
+        // Reject empty credentials before any network call. Save
+        // and test already do this; search was the last path
+        // that silently tried to HTTP with an empty auth header
+        // and returned an AuthFailed from RR, which looks like
+        // "wrong password" to the caller instead of "you didn't
+        // enter one." Per CodeRabbit round 4 on PR #346.
+        if user.is_empty() || pass.is_empty() {
+            set_last_error("sdr_core_radioreference_search_zip: empty user or password");
+            return SdrCoreError::InvalidArg.as_int();
+        }
+
         // RR expects a 5-digit US ZIP — validate on our side so a
         // typo doesn't round-trip to the network and come back as
         // a generic SOAP fault.

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -59,19 +59,18 @@ const KEY_RR_PASSWORD: &str = "radioreference-password";
 /// SOAP fault.
 const RR_ZIP_LEN: usize = 5;
 
-/// Upper bound on usernames / passwords we'll round-trip through
-/// the save/load pair. This is the buffer size `load_credentials`
-/// uses on the Swift side, so any stored value that exceeds it
-/// would silently truncate on read — producing a different
-/// credential than the one saved, which then mysteriously fails
-/// auth.
+/// Size of the caller-allocated load buffer on the Swift side.
+/// `write_cstr_to_buf` reserves one byte for the NUL terminator,
+/// so the maximum UTF-8 payload that will round-trip intact is
+/// `MAX_CREDENTIAL_FIELD_LEN - 1` (511 bytes). `save_credentials`
+/// enforces a strict `len < MAX_CREDENTIAL_FIELD_LEN` guard (via
+/// `validate_rr_credentials`) so an exact-buffer-sized value
+/// can't sneak in and later reload truncated. Per CodeRabbit
+/// rounds 6 + 10 on PR #346.
 ///
-/// Enforced on the SAVE side: `save_credentials` rejects inputs
-/// whose UTF-8 byte length exceeds this cap with `InvalidArg`.
-/// RadioReference has no documented limit but 512 bytes each is
+/// RadioReference has no documented limit; 511 bytes each is
 /// comfortably more than any human typed, and matches the
-/// SwiftUI wrapper's fixed buffer. Per CodeRabbit round 6 on
-/// PR #346.
+/// SwiftUI wrapper's fixed buffer minus the NUL.
 const MAX_CREDENTIAL_FIELD_LEN: usize = 512;
 
 // ============================================================
@@ -155,9 +154,15 @@ fn validate_rr_credentials(fn_name: &str, user: &str, pass: &str) -> Result<(), 
         set_last_error(format!("{fn_name}: empty user or password"));
         return Err(SdrCoreError::InvalidArg);
     }
-    if user.len() > MAX_CREDENTIAL_FIELD_LEN || pass.len() > MAX_CREDENTIAL_FIELD_LEN {
+    // Strict `>=` — the load buffer reserves one byte for the
+    // NUL terminator, so the largest payload that round-trips
+    // intact is `MAX_CREDENTIAL_FIELD_LEN - 1`. A value exactly
+    // equal to the buffer size would truncate silently on
+    // reload. Per CodeRabbit round 10 on PR #346.
+    if user.len() >= MAX_CREDENTIAL_FIELD_LEN || pass.len() >= MAX_CREDENTIAL_FIELD_LEN {
         set_last_error(format!(
-            "{fn_name}: user or password exceeds {MAX_CREDENTIAL_FIELD_LEN}-byte cap"
+            "{fn_name}: user or password must fit in {} UTF-8 bytes plus NUL",
+            MAX_CREDENTIAL_FIELD_LEN - 1
         ));
         return Err(SdrCoreError::InvalidArg);
     }
@@ -379,13 +384,29 @@ pub unsafe extern "C" fn sdr_core_radioreference_load_credentials(
             }
         };
 
+        // Partial-keyring guard: the sentinel contract says
+        // "either buffer empty ⇒ nothing stored." If we copy an
+        // orphaned username through while the password is empty
+        // (or vice versa), a caller that only inspects one
+        // buffer before checking the other would see a "live"
+        // value even though the ABI is signaling "not stored."
+        // Collapse both sides to empty on any partial state so
+        // the sentinel is self-consistent no matter which buffer
+        // the caller reads first. Per CodeRabbit round 10 on PR
+        // #346.
+        let (user_bytes, pass_bytes) = if user_opt.is_empty() || pass_opt.is_empty() {
+            (&b""[..], &b""[..])
+        } else {
+            (user_opt.as_bytes(), pass_opt.as_bytes())
+        };
+
         // SAFETY: null + zero-length checked above; buffers are
-        // writable per the caller contract. Empty `user_opt` /
-        // `pass_opt` produce a single NUL byte in each output
+        // writable per the caller contract. Empty `user_bytes` /
+        // `pass_bytes` produce a single NUL byte in each output
         // buffer — the "no credentials stored" sentinel.
         unsafe {
-            write_cstr_to_buf(user_opt.as_bytes(), out_user, user_buf_len);
-            write_cstr_to_buf(pass_opt.as_bytes(), out_pass, pass_buf_len);
+            write_cstr_to_buf(user_bytes, out_user, user_buf_len);
+            write_cstr_to_buf(pass_bytes, out_pass, pass_buf_len);
         }
         clear_last_error();
         SdrCoreError::Ok.as_int()
@@ -819,18 +840,30 @@ mod tests {
 
     #[test]
     fn save_rejects_oversize_fields() {
-        // save_credentials must refuse values longer than
-        // MAX_CREDENTIAL_FIELD_LEN so they don't silently
-        // truncate on the next load. Regression for
-        // CodeRabbit round 6 on PR #346.
+        // save_credentials must refuse values whose UTF-8 length
+        // is >= MAX_CREDENTIAL_FIELD_LEN — the load buffer
+        // reserves one byte for the NUL, so a value exactly
+        // MAX_CREDENTIAL_FIELD_LEN bytes would truncate silently
+        // on the next load. Regression for CodeRabbit rounds
+        // 6 + 10 on PR #346. The exact-size case guards the
+        // off-by-one explicitly.
         let real = CString::new("jason").unwrap();
         let long = CString::new("x".repeat(MAX_CREDENTIAL_FIELD_LEN + 1)).unwrap();
+        let at_cap = CString::new("x".repeat(MAX_CREDENTIAL_FIELD_LEN)).unwrap();
         assert_eq!(
             unsafe { sdr_core_radioreference_save_credentials(long.as_ptr(), real.as_ptr()) },
             SdrCoreError::InvalidArg.as_int()
         );
         assert_eq!(
             unsafe { sdr_core_radioreference_save_credentials(real.as_ptr(), long.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_radioreference_save_credentials(at_cap.as_ptr(), real.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_radioreference_save_credentials(real.as_ptr(), at_cap.as_ptr()) },
             SdrCoreError::InvalidArg.as_int()
         );
     }

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -268,32 +268,38 @@ pub unsafe extern "C" fn sdr_core_radioreference_load_credentials(
         }
 
         let store = KeyringStore::new(KEYRING_SERVICE);
-        let user = match store.get(KEY_RR_USERNAME) {
-            Ok(Some(s)) if !s.is_empty() => s,
-            Ok(_) => {
-                set_last_error("sdr_core_radioreference_load_credentials: username not stored");
-                return SdrCoreError::Io.as_int();
-            }
+        // Distinguish three cases:
+        //   - `Ok(Some(non-empty))` → real stored value; copy out.
+        //   - `Ok(None)` or `Ok(Some(""))` → nothing stored;
+        //     return `OK` with an empty NUL-terminated buffer so
+        //     the caller can tell "no credentials" apart from a
+        //     keyring backend error. Per CodeRabbit round 1 on
+        //     PR #346 (the earlier shape collapsed both into
+        //     `SDR_CORE_ERR_IO`, which the Swift wrapper then
+        //     mapped to `nil` — masking real keyring failures).
+        //   - `Err(_)` → genuine keyring backend error; propagate
+        //     as `SDR_CORE_ERR_IO` with a descriptive last-error
+        //     message so hosts can surface it to the user.
+        let user_opt = match store.get(KEY_RR_USERNAME) {
+            Ok(v) => v.unwrap_or_default(),
             Err(e) => {
                 return map_keyring_error("sdr_core_radioreference_load_credentials", &e).as_int();
             }
         };
-        let pass = match store.get(KEY_RR_PASSWORD) {
-            Ok(Some(s)) if !s.is_empty() => s,
-            Ok(_) => {
-                set_last_error("sdr_core_radioreference_load_credentials: password not stored");
-                return SdrCoreError::Io.as_int();
-            }
+        let pass_opt = match store.get(KEY_RR_PASSWORD) {
+            Ok(v) => v.unwrap_or_default(),
             Err(e) => {
                 return map_keyring_error("sdr_core_radioreference_load_credentials", &e).as_int();
             }
         };
 
         // SAFETY: null + zero-length checked above; buffers are
-        // writable per the caller contract.
+        // writable per the caller contract. Empty `user_opt` /
+        // `pass_opt` produce a single NUL byte in each output
+        // buffer — the "no credentials stored" sentinel.
         unsafe {
-            write_cstr_to_buf(user.as_bytes(), out_user, user_buf_len);
-            write_cstr_to_buf(pass.as_bytes(), out_pass, pass_buf_len);
+            write_cstr_to_buf(user_opt.as_bytes(), out_user, user_buf_len);
+            write_cstr_to_buf(pass_opt.as_bytes(), out_pass, pass_buf_len);
         }
         clear_last_error();
         SdrCoreError::Ok.as_int()
@@ -310,10 +316,23 @@ pub unsafe extern "C" fn sdr_core_radioreference_load_credentials(
 pub extern "C" fn sdr_core_radioreference_delete_credentials() -> i32 {
     let result = std::panic::catch_unwind(|| {
         let store = KeyringStore::new(KEYRING_SERVICE);
-        if let Err(e) = store.delete(KEY_RR_USERNAME) {
-            return map_keyring_error("sdr_core_radioreference_delete_credentials", &e).as_int();
-        }
-        if let Err(e) = store.delete(KEY_RR_PASSWORD) {
+        // Attempt BOTH deletes even if the first raises a
+        // non-NotFound error — leaving one secret behind when
+        // the other is already removed is worse than reporting
+        // a partial failure. Then pick whichever real error
+        // happened (preferring the username path for message
+        // ordering). `KeyringError::NotFound` is treated as
+        // success — matches the header's "idempotent" contract.
+        // Per CodeRabbit round 1 on PR #346.
+        let user_err = match store.delete(KEY_RR_USERNAME) {
+            Ok(()) | Err(KeyringError::NotFound) => None,
+            Err(e) => Some(e),
+        };
+        let pass_err = match store.delete(KEY_RR_PASSWORD) {
+            Ok(()) | Err(KeyringError::NotFound) => None,
+            Err(e) => Some(e),
+        };
+        if let Some(e) = user_err.or(pass_err) {
             return map_keyring_error("sdr_core_radioreference_delete_credentials", &e).as_int();
         }
         clear_last_error();

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -142,6 +142,28 @@ fn map_keyring_error(fn_name: &str, err: &KeyringError) -> SdrCoreError {
 //  Small utility shared by the command-style FFIs here.
 // ============================================================
 
+/// Enforce the credential contract (non-empty + within the
+/// round-trip cap) in one place so `save`, `test`, and `search`
+/// all agree. Without this shared guard, an inconsistent state
+/// was possible: a 1 KB password could be tested successfully
+/// against RadioReference but then fail the length check on
+/// save, or vice versa — confusing the user with different
+/// errors depending on button order. Per CodeRabbit round 8 on
+/// PR #346.
+fn validate_rr_credentials(fn_name: &str, user: &str, pass: &str) -> Result<(), SdrCoreError> {
+    if user.is_empty() || pass.is_empty() {
+        set_last_error(format!("{fn_name}: empty user or password"));
+        return Err(SdrCoreError::InvalidArg);
+    }
+    if user.len() > MAX_CREDENTIAL_FIELD_LEN || pass.len() > MAX_CREDENTIAL_FIELD_LEN {
+        set_last_error(format!(
+            "{fn_name}: user or password exceeds {MAX_CREDENTIAL_FIELD_LEN}-byte cap"
+        ));
+        return Err(SdrCoreError::InvalidArg);
+    }
+    Ok(())
+}
+
 /// Decode a caller-provided NUL-terminated UTF-8 pointer to an
 /// owned `String`. Returns `InvalidArg` on null / non-UTF-8.
 ///
@@ -222,29 +244,14 @@ pub unsafe extern "C" fn sdr_core_radioreference_save_credentials(
             Ok(s) => s,
             Err(e) => return e.as_int(),
         };
-        // Reject empty fields up front — see the function-level
-        // docstring above for the "not stored" sentinel
-        // consistency argument. Clean InvalidArg + descriptive
-        // message is friendlier than a successful-looking save
-        // that never actually appears on the next read.
-        if user.is_empty() || pass.is_empty() {
-            set_last_error(
-                "sdr_core_radioreference_save_credentials: empty user or password — both fields must be non-empty",
-            );
-            return SdrCoreError::InvalidArg.as_int();
-        }
-        // Reject values that the fixed-size load buffer can't
-        // round-trip. Without this cap, a user could save an
-        // over-long credential, and the next load would silently
-        // return a truncated value — which then fails auth at
-        // RadioReference and surfaces as "wrong password"
-        // instead of "your keychain got cut off at 512 bytes."
-        // Per CodeRabbit round 6 on PR #346.
-        if user.len() > MAX_CREDENTIAL_FIELD_LEN || pass.len() > MAX_CREDENTIAL_FIELD_LEN {
-            set_last_error(format!(
-                "sdr_core_radioreference_save_credentials: user or password exceeds {MAX_CREDENTIAL_FIELD_LEN}-byte cap"
-            ));
-            return SdrCoreError::InvalidArg.as_int();
+        // Enforce the shared credential contract (non-empty +
+        // within round-trip cap). Keeps save / test / search
+        // consistent — see `validate_rr_credentials` for the
+        // rationale. Per CodeRabbit rounds 3/6/8 on PR #346.
+        if let Err(e) =
+            validate_rr_credentials("sdr_core_radioreference_save_credentials", &user, &pass)
+        {
+            return e.as_int();
         }
 
         let store = KeyringStore::new(KEYRING_SERVICE);
@@ -476,9 +483,12 @@ pub unsafe extern "C" fn sdr_core_radioreference_test_credentials(
             Err(e) => return e.as_int(),
         };
 
-        if user.is_empty() || pass.is_empty() {
-            set_last_error("sdr_core_radioreference_test_credentials: empty user or password");
-            return SdrCoreError::InvalidArg.as_int();
+        // Match the save contract — reject empties and values
+        // longer than the round-trip cap before the network call.
+        if let Err(e) =
+            validate_rr_credentials("sdr_core_radioreference_test_credentials", &user, &pass)
+        {
+            return e.as_int();
         }
 
         let client = match RrClient::new(&user, &pass) {
@@ -631,15 +641,15 @@ pub unsafe extern "C" fn sdr_core_radioreference_search_zip(
             Err(e) => return e.as_int(),
         };
 
-        // Reject empty credentials before any network call. Save
-        // and test already do this; search was the last path
-        // that silently tried to HTTP with an empty auth header
-        // and returned an AuthFailed from RR, which looks like
-        // "wrong password" to the caller instead of "you didn't
-        // enter one." Per CodeRabbit round 4 on PR #346.
-        if user.is_empty() || pass.is_empty() {
-            set_last_error("sdr_core_radioreference_search_zip: empty user or password");
-            return SdrCoreError::InvalidArg.as_int();
+        // Match the save contract — reject empties and values
+        // longer than the round-trip cap before the network call.
+        // Previously search was the only credential-taking path
+        // that let an over-length value HTTP round-trip to
+        // RadioReference before failing, which was inconsistent
+        // with save's pre-check.
+        if let Err(e) = validate_rr_credentials("sdr_core_radioreference_search_zip", &user, &pass)
+        {
+            return e.as_int();
         }
 
         // RR expects a 5-digit US ZIP — validate on our side so a

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -439,13 +439,27 @@ pub extern "C" fn sdr_core_radioreference_delete_credentials() -> i32 {
 /// password into memory until an actual search happens.
 #[unsafe(no_mangle)]
 pub extern "C" fn sdr_core_radioreference_has_credentials() -> bool {
+    // Clear the thread-local last-error slot on BOTH the success
+    // path and the catch_unwind path. Without this, a stale
+    // message from an earlier failing FFI call (e.g. a failed
+    // save) would remain visible through
+    // `sdr_core_last_error_message` after a later probe here
+    // succeeded — and since this is the only credential FFI
+    // that swallows backend failures into a bool rather than
+    // returning a non-zero rc, it was the one path that silently
+    // inherited whatever was in the slot. Per CodeRabbit round
+    // 9 on PR #346.
     std::panic::catch_unwind(|| {
         let store = KeyringStore::new(KEYRING_SERVICE);
         let user = matches!(store.get(KEY_RR_USERNAME), Ok(Some(s)) if !s.is_empty());
         let pass = matches!(store.get(KEY_RR_PASSWORD), Ok(Some(s)) if !s.is_empty());
+        clear_last_error();
         user && pass
     })
-    .unwrap_or(false)
+    .unwrap_or_else(|_| {
+        clear_last_error();
+        false
+    })
 }
 
 // ============================================================

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -104,10 +104,16 @@ fn map_keyring_error(fn_name: &str, err: &KeyringError) -> SdrCoreError {
     match err {
         KeyringError::NotFound => {
             set_last_error(format!("{fn_name}: credential not found"));
-            // Not strictly an error for some callers — but we return
-            // a distinct code and let the caller decide. The Swift
-            // wrapper maps `NotFound` to returning `nil` rather than
-            // throwing.
+            // Callers: `load_credentials` doesn't even reach this
+            // arm any more — it uses the OK-plus-empty-buffer
+            // sentinel for the "not stored" case and reserves
+            // `Io` strictly for backend failures. This branch is
+            // kept for other keyring operations (delete's
+            // `NotFound`, for instance, is absorbed upstream in
+            // `delete_credentials`'s idempotent handling). The
+            // Swift wrapper propagates every non-zero rc via
+            // `checkRc`, so anything hitting this path surfaces
+            // as an `SdrCoreError` with the message above.
             SdrCoreError::Io
         }
         KeyringError::NoBackend => {
@@ -765,6 +771,20 @@ mod tests {
     /// password — sanity, not a hard ABI bound.
     const CREDENTIAL_BUF_LEN: usize = 512;
 
+    /// Output-buffer size for `search_zip` rejection tests.
+    /// The tests fail before any JSON is written (bad zip,
+    /// null buffers, empty credentials), so this is never
+    /// filled — it just has to be nonzero so the initial
+    /// out_buf / out_buf_len validation doesn't trip on it.
+    /// Per CodeRabbit round 7 on PR #346.
+    const SEARCH_REJECTION_BUF_LEN: usize = 128;
+
+    /// `out_buf_len` passed alongside a null `out_buf` in
+    /// `search_zip_rejects_null_buf`. Nonzero so the null
+    /// check is what trips, not the `out_buf_len == 0`
+    /// check — the exact value is arbitrary.
+    const NULL_BUF_PROBE_LEN: usize = 64;
+
     #[test]
     fn save_rejects_null_pointers() {
         assert_eq!(
@@ -882,7 +902,7 @@ mod tests {
         let u = CString::new("user").unwrap();
         let p = CString::new("pass").unwrap();
         let bad = CString::new("9021").unwrap(); // 4 digits
-        let mut buf = [0_u8; 128];
+        let mut buf = [0_u8; SEARCH_REJECTION_BUF_LEN];
         let rc = unsafe {
             sdr_core_radioreference_search_zip(
                 u.as_ptr(),
@@ -901,7 +921,7 @@ mod tests {
         let u = CString::new("user").unwrap();
         let p = CString::new("pass").unwrap();
         let bad = CString::new("abcde").unwrap();
-        let mut buf = [0_u8; 128];
+        let mut buf = [0_u8; SEARCH_REJECTION_BUF_LEN];
         let rc = unsafe {
             sdr_core_radioreference_search_zip(
                 u.as_ptr(),
@@ -926,7 +946,7 @@ mod tests {
                 p.as_ptr(),
                 zip.as_ptr(),
                 std::ptr::null_mut(),
-                64,
+                NULL_BUF_PROBE_LEN,
                 std::ptr::null_mut(),
             )
         };

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -1,0 +1,742 @@
+//! RadioReference C ABI — credentials (keyring) + search.
+//!
+//! All functions in this module are **handle-free**. They don't touch
+//! the DSP engine because:
+//!   - Credentials live in `sdr_config::KeyringStore` (OS keychain on
+//!     macOS / libsecret on Linux), completely independent of the
+//!     live engine state.
+//!   - Search calls are synchronous blocking HTTP via
+//!     `sdr_radioreference::RrClient`; running them on the DSP thread
+//!     would stall audio. Callers are expected to dispatch these on
+//!     a background thread (SwiftUI does this via `Task` detached
+//!     from the main actor).
+//!
+//! Credential storage mirrors the GTK side exactly — same keyring
+//! service (`"sdr-rs"`) and key names (`"radioreference-username"` /
+//! `"radioreference-password"`). A user who has GTK + SDRMac on the
+//! same machine shares one set of stored credentials.
+//!
+//! Search returns a JSON document instead of a bespoke struct layout
+//! for two reasons:
+//!   - The result is a variable-length list of records with nested
+//!     optional fields (tone, tags). A caller-allocated-buffer
+//!     pattern per field would balloon the ABI surface.
+//!   - SwiftUI's `Codable` can decode the JSON into native structs
+//!     cheaply (~1000 frequencies ≈ 100 KB — negligible).
+//!
+//! Mode mapping (RadioReference mode string → engine demod mode +
+//! bandwidth) is done on the Rust side via
+//! `sdr_radioreference::mode_map::map_rr_mode` so Swift consumers
+//! don't need a parallel lookup table.
+
+use std::ffi::{CStr, c_char};
+
+use sdr_config::KeyringStore;
+use sdr_config::keyring_store::KeyringError;
+use sdr_radioreference::{RrClient, SoapError};
+use serde::Serialize;
+
+use crate::error::{SdrCoreError, clear_last_error, set_last_error};
+
+// ============================================================
+//  Keyring addressing — must match the GTK side byte-for-byte
+//  so credentials saved from one app show up in the other.
+// ============================================================
+
+/// Keyring service (the "app" within the OS keyring namespace).
+const KEYRING_SERVICE: &str = "sdr-rs";
+
+/// Keyring key for the RadioReference username.
+const KEY_RR_USERNAME: &str = "radioreference-username";
+
+/// Keyring key for the RadioReference password.
+const KEY_RR_PASSWORD: &str = "radioreference-password";
+
+/// Upper bound on usernames / passwords we'll round-trip through
+/// the load call. RadioReference usernames and passwords don't
+/// have documented length limits, but 512 bytes each is
+/// comfortably more than any human typed. If a longer value shows
+/// up in the wild, `_load_credentials` truncates to `buf_len - 1`
+/// and the caller can bump its buffer — truncation does not set
+/// an error.
+#[allow(dead_code)]
+const MAX_CREDENTIAL_FIELD_LEN: usize = 512;
+
+// ============================================================
+//  Error translation
+// ============================================================
+
+/// Map a `SoapError` to the matching C ABI error code and set a
+/// descriptive thread-local last-error message for the FFI
+/// caller.
+fn map_soap_error(fn_name: &str, err: &SoapError) -> SdrCoreError {
+    match err {
+        SoapError::AuthFailed => {
+            set_last_error(format!("{fn_name}: authentication failed: {err}"));
+            SdrCoreError::Auth
+        }
+        SoapError::Http(_) | SoapError::Io(_) | SoapError::Fault(_) => {
+            set_last_error(format!("{fn_name}: network error: {err}"));
+            SdrCoreError::Io
+        }
+        SoapError::Xml(_) | SoapError::Unexpected(_) => {
+            set_last_error(format!("{fn_name}: unexpected response: {err}"));
+            SdrCoreError::Internal
+        }
+    }
+}
+
+/// Map a `KeyringError` to the matching C ABI error code and set a
+/// descriptive thread-local last-error message.
+fn map_keyring_error(fn_name: &str, err: &KeyringError) -> SdrCoreError {
+    match err {
+        KeyringError::NotFound => {
+            set_last_error(format!("{fn_name}: credential not found"));
+            // Not strictly an error for some callers — but we return
+            // a distinct code and let the caller decide. The Swift
+            // wrapper maps `NotFound` to returning `nil` rather than
+            // throwing.
+            SdrCoreError::Io
+        }
+        KeyringError::NoBackend => {
+            set_last_error(format!(
+                "{fn_name}: no secure storage available — install GNOME Keyring or KeePassXC (Linux)"
+            ));
+            SdrCoreError::Io
+        }
+        KeyringError::Platform(_) => {
+            set_last_error(format!("{fn_name}: keyring error: {err}"));
+            SdrCoreError::Io
+        }
+    }
+}
+
+// ============================================================
+//  Small utility shared by the command-style FFIs here.
+// ============================================================
+
+/// Decode a caller-provided NUL-terminated UTF-8 pointer to an
+/// owned `String`. Returns `InvalidArg` on null / non-UTF-8.
+///
+/// # Safety
+///
+/// `ptr` must be null or a pointer to a NUL-terminated UTF-8 C
+/// string.
+unsafe fn cstr_to_string(fn_name: &str, ptr: *const c_char) -> Result<String, SdrCoreError> {
+    if ptr.is_null() {
+        set_last_error(format!("{fn_name}: string pointer is null"));
+        return Err(SdrCoreError::InvalidArg);
+    }
+    // SAFETY: caller contract.
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    if let Ok(s) = cstr.to_str() {
+        Ok(s.to_string())
+    } else {
+        set_last_error(format!("{fn_name}: string is not valid UTF-8"));
+        Err(SdrCoreError::InvalidArg)
+    }
+}
+
+/// Write `bytes` into a caller-allocated buffer with truncation.
+/// Returns the number of bytes written (not counting the NUL).
+///
+/// # Safety
+///
+/// `out_buf` must point to at least `buf_len` writable bytes.
+/// `buf_len` must be at least 1 (a single NUL fits).
+unsafe fn write_cstr_to_buf(bytes: &[u8], out_buf: *mut c_char, buf_len: usize) -> usize {
+    let max_payload = buf_len.saturating_sub(1); // reserve 1 for NUL
+    let to_copy = bytes.len().min(max_payload);
+    // SAFETY: caller contract guarantees `out_buf` is writable for
+    // `buf_len` bytes. `to_copy <= buf_len - 1 < buf_len` and the
+    // NUL write at `out_buf.add(to_copy)` is within `buf_len`
+    // because `to_copy <= buf_len - 1`.
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf.cast::<u8>(), to_copy);
+        *out_buf.add(to_copy) = 0;
+    }
+    to_copy
+}
+
+// ============================================================
+//  Credentials — keyring-backed
+// ============================================================
+
+/// Save RadioReference credentials to the OS keyring.
+///
+/// Both `user_utf8` and `pass_utf8` must be non-null NUL-terminated
+/// UTF-8 strings. Empty strings are accepted and stored as-is (the
+/// keyring backend doesn't distinguish "empty value" from "no
+/// value", so consumers should use `sdr_core_radioreference_has_credentials`
+/// to probe existence rather than round-tripping through load).
+///
+/// # Safety
+///
+/// Both pointers must be either null (returns `INVALID_ARG`) or
+/// NUL-terminated UTF-8 C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_radioreference_save_credentials(
+    user_utf8: *const c_char,
+    pass_utf8: *const c_char,
+) -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        let user = match unsafe {
+            cstr_to_string("sdr_core_radioreference_save_credentials", user_utf8)
+        } {
+            Ok(s) => s,
+            Err(e) => return e.as_int(),
+        };
+        let pass = match unsafe {
+            cstr_to_string("sdr_core_radioreference_save_credentials", pass_utf8)
+        } {
+            Ok(s) => s,
+            Err(e) => return e.as_int(),
+        };
+
+        let store = KeyringStore::new(KEYRING_SERVICE);
+        if let Err(e) = store.set(KEY_RR_USERNAME, &user) {
+            return map_keyring_error("sdr_core_radioreference_save_credentials", &e).as_int();
+        }
+        if let Err(e) = store.set(KEY_RR_PASSWORD, &pass) {
+            return map_keyring_error("sdr_core_radioreference_save_credentials", &e).as_int();
+        }
+
+        // Defensive readback: a `set` success with a failing
+        // `get` is the smoking gun for a misconfigured keyring
+        // backend (notably keyring 3.x's mock fallback when
+        // `apple-native` / `sync-secret-service` isn't enabled —
+        // see the `feedback_keyring_crate_features` memory).
+        // Catching it here, right after the write, means a
+        // future regression never silently ships.
+        let verify_user = store.get(KEY_RR_USERNAME);
+        let verify_pass = store.get(KEY_RR_PASSWORD);
+        match (verify_user, verify_pass) {
+            (Ok(Some(u)), Ok(Some(_))) if !u.is_empty() => {
+                // Save round-tripped.
+            }
+            (u, p) => {
+                set_last_error(format!(
+                    "sdr_core_radioreference_save_credentials: set returned Ok but readback failed: user={:?} pass={:?}",
+                    u.map(|o| o.is_some()),
+                    p.map(|o| o.is_some())
+                ));
+                return SdrCoreError::Io.as_int();
+            }
+        }
+
+        clear_last_error();
+        SdrCoreError::Ok.as_int()
+    });
+    result.unwrap_or_else(|_| {
+        set_last_error("sdr_core_radioreference_save_credentials: panic");
+        SdrCoreError::Internal.as_int()
+    })
+}
+
+/// Load RadioReference credentials from the OS keyring into
+/// caller-allocated UTF-8 buffers.
+///
+/// Both `out_user` and `out_pass` are NUL-terminated on success.
+/// Truncation is not an error: if the stored value doesn't fit,
+/// the output is truncated at `buf_len - 1` and NUL-terminated.
+/// Callers that want guaranteed fidelity should pass large
+/// buffers (`MAX_CREDENTIAL_FIELD_LEN` is a safe ceiling in
+/// practice).
+///
+/// Returns `OK` if both fields were found and written. Returns
+/// `IO` (with a `"credential not found"` last-error) if either
+/// field is missing. Checking
+/// `sdr_core_radioreference_has_credentials` first avoids the
+/// error-message churn for the expected-empty case.
+///
+/// # Safety
+///
+/// Both output buffers must point to at least their respective
+/// `_buf_len` writable bytes and `_buf_len` must be ≥ 1 (room for
+/// the NUL).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_radioreference_load_credentials(
+    out_user: *mut c_char,
+    user_buf_len: usize,
+    out_pass: *mut c_char,
+    pass_buf_len: usize,
+) -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        if out_user.is_null() || out_pass.is_null() || user_buf_len == 0 || pass_buf_len == 0 {
+            set_last_error("sdr_core_radioreference_load_credentials: null buffer or zero length");
+            return SdrCoreError::InvalidArg.as_int();
+        }
+
+        let store = KeyringStore::new(KEYRING_SERVICE);
+        let user = match store.get(KEY_RR_USERNAME) {
+            Ok(Some(s)) if !s.is_empty() => s,
+            Ok(_) => {
+                set_last_error("sdr_core_radioreference_load_credentials: username not stored");
+                return SdrCoreError::Io.as_int();
+            }
+            Err(e) => {
+                return map_keyring_error("sdr_core_radioreference_load_credentials", &e).as_int();
+            }
+        };
+        let pass = match store.get(KEY_RR_PASSWORD) {
+            Ok(Some(s)) if !s.is_empty() => s,
+            Ok(_) => {
+                set_last_error("sdr_core_radioreference_load_credentials: password not stored");
+                return SdrCoreError::Io.as_int();
+            }
+            Err(e) => {
+                return map_keyring_error("sdr_core_radioreference_load_credentials", &e).as_int();
+            }
+        };
+
+        // SAFETY: null + zero-length checked above; buffers are
+        // writable per the caller contract.
+        unsafe {
+            write_cstr_to_buf(user.as_bytes(), out_user, user_buf_len);
+            write_cstr_to_buf(pass.as_bytes(), out_pass, pass_buf_len);
+        }
+        clear_last_error();
+        SdrCoreError::Ok.as_int()
+    });
+    result.unwrap_or_else(|_| {
+        set_last_error("sdr_core_radioreference_load_credentials: panic");
+        SdrCoreError::Internal.as_int()
+    })
+}
+
+/// Delete stored RadioReference credentials. Returns `OK` whether
+/// or not credentials were present — "already gone" is idempotent.
+#[unsafe(no_mangle)]
+pub extern "C" fn sdr_core_radioreference_delete_credentials() -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        let store = KeyringStore::new(KEYRING_SERVICE);
+        if let Err(e) = store.delete(KEY_RR_USERNAME) {
+            return map_keyring_error("sdr_core_radioreference_delete_credentials", &e).as_int();
+        }
+        if let Err(e) = store.delete(KEY_RR_PASSWORD) {
+            return map_keyring_error("sdr_core_radioreference_delete_credentials", &e).as_int();
+        }
+        clear_last_error();
+        SdrCoreError::Ok.as_int()
+    });
+    result.unwrap_or_else(|_| {
+        set_last_error("sdr_core_radioreference_delete_credentials: panic");
+        SdrCoreError::Internal.as_int()
+    })
+}
+
+/// Return `true` if both username and password are stored AND
+/// non-empty. Returns `false` if either is missing, empty, or the
+/// keyring backend is unavailable.
+///
+/// This is a cheap existence probe — it doesn't return the values,
+/// so UIs can gate "show Connect button" without loading the
+/// password into memory until an actual search happens.
+#[unsafe(no_mangle)]
+pub extern "C" fn sdr_core_radioreference_has_credentials() -> bool {
+    std::panic::catch_unwind(|| {
+        let store = KeyringStore::new(KEYRING_SERVICE);
+        let user = matches!(store.get(KEY_RR_USERNAME), Ok(Some(s)) if !s.is_empty());
+        let pass = matches!(store.get(KEY_RR_PASSWORD), Ok(Some(s)) if !s.is_empty());
+        user && pass
+    })
+    .unwrap_or(false)
+}
+
+// ============================================================
+//  Test connection — minimal roundtrip, no results
+// ============================================================
+
+/// Validate credentials by issuing a lightweight RadioReference
+/// query (zipcode 90210 — the canonical "is the API reachable +
+/// is this account authorized" probe used by the RR crate and
+/// mirrored from the GTK side's "Test & Save" button).
+///
+/// Returns `OK` on success, `AUTH` on bad credentials, `IO` on
+/// network errors.
+///
+/// # Safety
+///
+/// `user_utf8` / `pass_utf8` must be either null or NUL-terminated
+/// UTF-8 C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_radioreference_test_credentials(
+    user_utf8: *const c_char,
+    pass_utf8: *const c_char,
+) -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        let user = match unsafe {
+            cstr_to_string("sdr_core_radioreference_test_credentials", user_utf8)
+        } {
+            Ok(s) => s,
+            Err(e) => return e.as_int(),
+        };
+        let pass = match unsafe {
+            cstr_to_string("sdr_core_radioreference_test_credentials", pass_utf8)
+        } {
+            Ok(s) => s,
+            Err(e) => return e.as_int(),
+        };
+
+        if user.is_empty() || pass.is_empty() {
+            set_last_error("sdr_core_radioreference_test_credentials: empty user or password");
+            return SdrCoreError::InvalidArg.as_int();
+        }
+
+        let client = match RrClient::new(&user, &pass) {
+            Ok(c) => c,
+            Err(e) => {
+                return map_soap_error("sdr_core_radioreference_test_credentials", &e).as_int();
+            }
+        };
+        if let Err(e) = client.test_connection() {
+            return map_soap_error("sdr_core_radioreference_test_credentials", &e).as_int();
+        }
+        clear_last_error();
+        SdrCoreError::Ok.as_int()
+    });
+    result.unwrap_or_else(|_| {
+        set_last_error("sdr_core_radioreference_test_credentials: panic");
+        SdrCoreError::Internal.as_int()
+    })
+}
+
+// ============================================================
+//  Search — zip → county → frequencies, returned as one JSON blob
+// ============================================================
+
+/// JSON wire format for `sdr_core_radioreference_search_zip`.
+/// Kept separate from `sdr_radioreference::RrFrequency` so the
+/// ABI isn't coupled to the upstream crate's internal layout —
+/// if that struct grows or is reshaped, the JSON stays stable.
+#[derive(Serialize)]
+struct WireSearchResult {
+    county_id: u32,
+    county_name: String,
+    state_id: u32,
+    city: String,
+    frequencies: Vec<WireFrequency>,
+}
+
+/// JSON wire format for a single frequency row.
+#[derive(Serialize)]
+struct WireFrequency {
+    /// Opaque RadioReference frequency ID (for future dedup /
+    /// import-tracking use; Mac treats it as a string).
+    id: String,
+    freq_hz: u64,
+    /// Raw RR mode string ("FM", "FMN", "FMW", …) — surfaced so
+    /// power users can see what RR reported.
+    rr_mode: String,
+    /// Engine demod mode name ("NFM", "WFM", …) mapped via
+    /// `sdr_radioreference::mode_map::map_rr_mode`. Swift uses
+    /// this directly without re-implementing the lookup.
+    demod_mode: String,
+    /// Channel bandwidth in Hz (mapped alongside `demod_mode`).
+    bandwidth_hz: f64,
+    /// CTCSS / PL tone in Hz when present. Not sent to the DSP on
+    /// import — stored in the bookmark for later restore.
+    tone_hz: Option<f32>,
+    description: String,
+    alpha_tag: String,
+    /// First tag description, used as the "Category" filter key
+    /// in the GTK UI. Empty string when the row has no tags.
+    category: String,
+    /// All tag descriptions, in order. Mostly the first is the
+    /// same as `category`; surfaced in full for future UIs.
+    tags: Vec<String>,
+}
+
+/// Search RadioReference for frequencies covering a US ZIP code.
+///
+/// Does `get_zip_info(zip)` then `get_county_frequencies(county_id)`
+/// and serializes the combined result as JSON into `out_buf`:
+///
+/// ```json
+/// {
+///   "county_id": 2437,
+///   "county_name": "Santa Clara",
+///   "state_id": 5,
+///   "city": "San Jose",
+///   "frequencies": [
+///     {
+///       "id": "123",
+///       "freq_hz": 146520000,
+///       "rr_mode": "FM",
+///       "demod_mode": "NFM",
+///       "bandwidth_hz": 12500.0,
+///       "tone_hz": 127.3,
+///       "description": "Main call",
+///       "alpha_tag": "SJ RPTR",
+///       "category": "Amateur Repeaters",
+///       "tags": ["Amateur Repeaters"]
+///     },
+///     ...
+///   ]
+/// }
+/// ```
+///
+/// Buffer growth: `out_required` (optional) is filled with the
+/// JSON payload size **in bytes** (not counting the NUL). Callers
+/// that pass a too-small buffer get truncated JSON AND a non-zero
+/// `out_required` they can use to reallocate + retry. Pass NULL
+/// when you don't need it.
+///
+/// Returns `OK` on successful search + serialization, `AUTH` on
+/// bad credentials, `IO` on network failure, `INVALID_ARG` on bad
+/// inputs, `INTERNAL` on JSON encoding failure (shouldn't happen
+/// for the types involved).
+///
+/// # Safety
+///
+/// `user_utf8`, `pass_utf8`, `zip_utf8` must each be null or a
+/// NUL-terminated UTF-8 C string. `out_buf` must point to at
+/// least `out_buf_len` writable bytes. `out_required` must be
+/// either null or point to a writable `usize`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_radioreference_search_zip(
+    user_utf8: *const c_char,
+    pass_utf8: *const c_char,
+    zip_utf8: *const c_char,
+    out_buf: *mut c_char,
+    out_buf_len: usize,
+    out_required: *mut usize,
+) -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        if out_buf.is_null() || out_buf_len == 0 {
+            set_last_error("sdr_core_radioreference_search_zip: out_buf null or zero length");
+            return SdrCoreError::InvalidArg.as_int();
+        }
+
+        let user = match unsafe { cstr_to_string("sdr_core_radioreference_search_zip", user_utf8) }
+        {
+            Ok(s) => s,
+            Err(e) => return e.as_int(),
+        };
+        let pass = match unsafe { cstr_to_string("sdr_core_radioreference_search_zip", pass_utf8) }
+        {
+            Ok(s) => s,
+            Err(e) => return e.as_int(),
+        };
+        let zip = match unsafe { cstr_to_string("sdr_core_radioreference_search_zip", zip_utf8) } {
+            Ok(s) => s,
+            Err(e) => return e.as_int(),
+        };
+
+        // RR expects a 5-digit US ZIP — validate on our side so a
+        // typo doesn't round-trip to the network and come back as
+        // a generic SOAP fault.
+        if zip.len() != 5 || !zip.chars().all(|c| c.is_ascii_digit()) {
+            set_last_error(format!(
+                "sdr_core_radioreference_search_zip: zip must be 5 digits, got {zip:?}"
+            ));
+            return SdrCoreError::InvalidArg.as_int();
+        }
+
+        let client = match RrClient::new(&user, &pass) {
+            Ok(c) => c,
+            Err(e) => return map_soap_error("sdr_core_radioreference_search_zip", &e).as_int(),
+        };
+
+        let zip_info = match client.get_zip_info(&zip) {
+            Ok(info) => info,
+            Err(e) => return map_soap_error("sdr_core_radioreference_search_zip", &e).as_int(),
+        };
+
+        let (county_name, freqs) = match client.get_county_frequencies(zip_info.county_id) {
+            Ok(pair) => pair,
+            Err(e) => return map_soap_error("sdr_core_radioreference_search_zip", &e).as_int(),
+        };
+
+        // Translate to wire format, mapping RR modes to engine
+        // demod modes + bandwidths so Swift doesn't re-implement
+        // the lookup.
+        let frequencies: Vec<WireFrequency> = freqs
+            .into_iter()
+            .map(|f| {
+                let mapped = sdr_radioreference::mode_map::map_rr_mode(&f.mode);
+                let category = f
+                    .tags
+                    .first()
+                    .map(|t| t.description.clone())
+                    .unwrap_or_default();
+                let tags = f.tags.into_iter().map(|t| t.description).collect();
+                WireFrequency {
+                    id: f.id,
+                    freq_hz: f.freq_hz,
+                    rr_mode: f.mode,
+                    demod_mode: mapped.demod_mode.to_string(),
+                    bandwidth_hz: mapped.bandwidth,
+                    tone_hz: f.tone,
+                    description: f.description,
+                    alpha_tag: f.alpha_tag,
+                    category,
+                    tags,
+                }
+            })
+            .collect();
+
+        let wire = WireSearchResult {
+            county_id: zip_info.county_id,
+            county_name,
+            state_id: zip_info.state_id,
+            city: zip_info.city,
+            frequencies,
+        };
+
+        let json = match serde_json::to_string(&wire) {
+            Ok(s) => s,
+            Err(e) => {
+                set_last_error(format!(
+                    "sdr_core_radioreference_search_zip: serialization failed: {e}"
+                ));
+                return SdrCoreError::Internal.as_int();
+            }
+        };
+
+        let bytes = json.as_bytes();
+        // Report the required size regardless of buffer adequacy.
+        // Callers can detect truncation by comparing with buf_len.
+        if !out_required.is_null() {
+            // SAFETY: non-null check above; caller contract says
+            // the pointer is writable.
+            unsafe {
+                *out_required = bytes.len();
+            }
+        }
+
+        // SAFETY: out_buf null + zero-length checked above.
+        unsafe {
+            write_cstr_to_buf(bytes, out_buf, out_buf_len);
+        }
+        clear_last_error();
+        SdrCoreError::Ok.as_int()
+    });
+    result.unwrap_or_else(|_| {
+        set_last_error("sdr_core_radioreference_search_zip: panic");
+        SdrCoreError::Internal.as_int()
+    })
+}
+
+// ============================================================
+//  Tests
+// ============================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    /// Size big enough for the longest realistic RR username /
+    /// password — sanity, not a hard ABI bound.
+    const CREDENTIAL_BUF_LEN: usize = 512;
+
+    #[test]
+    fn save_rejects_null_pointers() {
+        assert_eq!(
+            unsafe { sdr_core_radioreference_save_credentials(std::ptr::null(), std::ptr::null()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+    }
+
+    #[test]
+    fn load_rejects_null_or_zero_length_buffers() {
+        let mut u = [0_u8; CREDENTIAL_BUF_LEN];
+        let mut p = [0_u8; CREDENTIAL_BUF_LEN];
+        assert_eq!(
+            unsafe {
+                sdr_core_radioreference_load_credentials(
+                    std::ptr::null_mut(),
+                    CREDENTIAL_BUF_LEN,
+                    p.as_mut_ptr().cast::<c_char>(),
+                    CREDENTIAL_BUF_LEN,
+                )
+            },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe {
+                sdr_core_radioreference_load_credentials(
+                    u.as_mut_ptr().cast::<c_char>(),
+                    0,
+                    p.as_mut_ptr().cast::<c_char>(),
+                    CREDENTIAL_BUF_LEN,
+                )
+            },
+            SdrCoreError::InvalidArg.as_int()
+        );
+    }
+
+    #[test]
+    fn search_zip_rejects_bad_zip() {
+        let u = CString::new("user").unwrap();
+        let p = CString::new("pass").unwrap();
+        let bad = CString::new("9021").unwrap(); // 4 digits
+        let mut buf = [0_u8; 128];
+        let rc = unsafe {
+            sdr_core_radioreference_search_zip(
+                u.as_ptr(),
+                p.as_ptr(),
+                bad.as_ptr(),
+                buf.as_mut_ptr().cast::<c_char>(),
+                buf.len(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+    }
+
+    #[test]
+    fn search_zip_rejects_non_digit_zip() {
+        let u = CString::new("user").unwrap();
+        let p = CString::new("pass").unwrap();
+        let bad = CString::new("abcde").unwrap();
+        let mut buf = [0_u8; 128];
+        let rc = unsafe {
+            sdr_core_radioreference_search_zip(
+                u.as_ptr(),
+                p.as_ptr(),
+                bad.as_ptr(),
+                buf.as_mut_ptr().cast::<c_char>(),
+                buf.len(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+    }
+
+    #[test]
+    fn search_zip_rejects_null_buf() {
+        let u = CString::new("user").unwrap();
+        let p = CString::new("pass").unwrap();
+        let zip = CString::new("90210").unwrap();
+        let rc = unsafe {
+            sdr_core_radioreference_search_zip(
+                u.as_ptr(),
+                p.as_ptr(),
+                zip.as_ptr(),
+                std::ptr::null_mut(),
+                64,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+    }
+
+    #[test]
+    fn test_credentials_rejects_empty() {
+        let empty = CString::new("").unwrap();
+        let rc =
+            unsafe { sdr_core_radioreference_test_credentials(empty.as_ptr(), empty.as_ptr()) };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+    }
+
+    #[test]
+    fn has_credentials_is_callable() {
+        // Runs on any CI host without requiring a configured
+        // keyring backend — the panic guard + "false on error"
+        // fallback makes this safe to exercise.
+        let _ = sdr_core_radioreference_has_credentials();
+    }
+}

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -198,23 +198,40 @@ pub unsafe extern "C" fn sdr_core_radioreference_save_credentials(
             return map_keyring_error("sdr_core_radioreference_save_credentials", &e).as_int();
         }
         if let Err(e) = store.set(KEY_RR_PASSWORD, &pass) {
+            // If the password write fails, the username is
+            // already in the keyring — leaving it there paired
+            // with whatever stale password existed before would
+            // create a mixed-credentials state later (future
+            // load returns that stale pair as if it were valid).
+            // Clean up the username so the caller sees "no
+            // credentials stored" on the next load. Per
+            // CodeRabbit round 2 on PR #346.
+            let _ = store.delete(KEY_RR_USERNAME);
             return map_keyring_error("sdr_core_radioreference_save_credentials", &e).as_int();
         }
 
-        // Defensive readback: a `set` success with a failing
-        // `get` is the smoking gun for a misconfigured keyring
-        // backend (notably keyring 3.x's mock fallback when
-        // `apple-native` / `sync-secret-service` isn't enabled —
-        // see the `feedback_keyring_crate_features` memory).
-        // Catching it here, right after the write, means a
-        // future regression never silently ships.
+        // Defensive readback: a `set` success whose `get`
+        // doesn't return the value we just wrote is the smoking
+        // gun for a misconfigured keyring backend — notably
+        // keyring 3.x's mock fallback when `apple-native` /
+        // `sync-secret-service` isn't enabled (see the
+        // `feedback_keyring_crate_features` memory). Strict
+        // equality, not just "non-empty": if the keyring
+        // silently ignored the password write and left a prior
+        // stored password in place, an "any non-empty" check
+        // would still pass and we'd ship a mixed pair. On any
+        // mismatch, delete both secrets so the next load
+        // reports "not stored" cleanly instead of returning a
+        // stale half-written pair. Per CodeRabbit round 2.
         let verify_user = store.get(KEY_RR_USERNAME);
         let verify_pass = store.get(KEY_RR_PASSWORD);
         match (verify_user, verify_pass) {
-            (Ok(Some(u)), Ok(Some(_))) if !u.is_empty() => {
-                // Save round-tripped.
+            (Ok(Some(u)), Ok(Some(p))) if u == user && p == pass => {
+                // Save round-tripped, values match exactly.
             }
             (u, p) => {
+                let _ = store.delete(KEY_RR_USERNAME);
+                let _ = store.delete(KEY_RR_PASSWORD);
                 set_last_error(format!(
                     "sdr_core_radioreference_save_credentials: set returned Ok but readback failed: user={:?} pass={:?}",
                     u.map(|o| o.is_some()),
@@ -243,11 +260,17 @@ pub unsafe extern "C" fn sdr_core_radioreference_save_credentials(
 /// buffers (`MAX_CREDENTIAL_FIELD_LEN` is a safe ceiling in
 /// practice).
 ///
-/// Returns `OK` if both fields were found and written. Returns
-/// `IO` (with a `"credential not found"` last-error) if either
-/// field is missing. Checking
-/// `sdr_core_radioreference_has_credentials` first avoids the
-/// error-message churn for the expected-empty case.
+/// Returns `OK` in both normal cases:
+///   - both fields non-empty → credentials are present and
+///     were written to the buffers
+///   - either field empty (only the NUL) → nothing is stored;
+///     this is the "not yet configured" sentinel, not an error
+///
+/// Returns `IO` only for genuine keyring backend failures
+/// (backend unavailable, platform error, …). Callers can use
+/// `sdr_core_radioreference_has_credentials` as a cheap probe
+/// that captures the presence-check in a single bool without
+/// round-tripping through this call.
 ///
 /// # Safety
 ///

--- a/crates/sdr-ffi/src/radioreference.rs
+++ b/crates/sdr-ffi/src/radioreference.rs
@@ -343,8 +343,12 @@ pub unsafe extern "C" fn sdr_core_radioreference_save_credentials(
 /// # Safety
 ///
 /// Both output buffers must point to at least their respective
-/// `_buf_len` writable bytes and `_buf_len` must be ≥ 1 (room for
-/// the NUL).
+/// `_buf_len` writable bytes and each `_buf_len` must be ≥ 2
+/// (one byte of payload + the NUL terminator). A 1-byte buffer
+/// can only hold the NUL, which would collide with the
+/// "empty ⇒ not stored" sentinel — a caller asking for exactly
+/// one byte would get `OK` with an empty buffer whether or not
+/// credentials were stored. Per CodeRabbit round 11 on PR #346.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_radioreference_load_credentials(
     out_user: *mut c_char,
@@ -353,8 +357,11 @@ pub unsafe extern "C" fn sdr_core_radioreference_load_credentials(
     pass_buf_len: usize,
 ) -> i32 {
     let result = std::panic::catch_unwind(|| {
-        if out_user.is_null() || out_pass.is_null() || user_buf_len == 0 || pass_buf_len == 0 {
-            set_last_error("sdr_core_radioreference_load_credentials: null buffer or zero length");
+        // `< 2` — a 1-byte buffer can only fit the NUL, which
+        // would silently alias stored credentials to the
+        // "not stored" sentinel. See the `# Safety` docs above.
+        if out_user.is_null() || out_pass.is_null() || user_buf_len < 2 || pass_buf_len < 2 {
+            set_last_error("sdr_core_radioreference_load_credentials: null buffer or buf_len < 2");
             return SdrCoreError::InvalidArg.as_int();
         }
 
@@ -892,7 +899,10 @@ mod tests {
     }
 
     #[test]
-    fn load_rejects_null_or_zero_length_buffers() {
+    fn load_rejects_null_or_short_buffers() {
+        // Per CodeRabbit round 11: load requires buf_len >= 2
+        // so a 1-byte buffer can't silently alias stored creds
+        // to the "not stored" sentinel (only the NUL fits).
         let mut u = [0_u8; CREDENTIAL_BUF_LEN];
         let mut p = [0_u8; CREDENTIAL_BUF_LEN];
         assert_eq!(
@@ -906,17 +916,32 @@ mod tests {
             },
             SdrCoreError::InvalidArg.as_int()
         );
-        assert_eq!(
-            unsafe {
-                sdr_core_radioreference_load_credentials(
-                    u.as_mut_ptr().cast::<c_char>(),
-                    0,
-                    p.as_mut_ptr().cast::<c_char>(),
-                    CREDENTIAL_BUF_LEN,
-                )
-            },
-            SdrCoreError::InvalidArg.as_int()
-        );
+        for bad_len in [0_usize, 1] {
+            assert_eq!(
+                unsafe {
+                    sdr_core_radioreference_load_credentials(
+                        u.as_mut_ptr().cast::<c_char>(),
+                        bad_len,
+                        p.as_mut_ptr().cast::<c_char>(),
+                        CREDENTIAL_BUF_LEN,
+                    )
+                },
+                SdrCoreError::InvalidArg.as_int(),
+                "user buf_len={bad_len} must be rejected"
+            );
+            assert_eq!(
+                unsafe {
+                    sdr_core_radioreference_load_credentials(
+                        u.as_mut_ptr().cast::<c_char>(),
+                        CREDENTIAL_BUF_LEN,
+                        p.as_mut_ptr().cast::<c_char>(),
+                        bad_len,
+                    )
+                },
+                SdrCoreError::InvalidArg.as_int(),
+                "pass buf_len={bad_len} must be rejected"
+            );
+        }
     }
 
     /// Pin the "not stored" sentinel contract: after delete,

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -480,10 +480,21 @@ int32_t sdr_core_radioreference_save_credentials(
 /*
  * Load stored credentials into caller-allocated buffers. Both
  * buffers are NUL-terminated on success; values longer than the
- * buffer are truncated (not an error). Returns `SDR_CORE_OK`
- * when both fields were present, `SDR_CORE_ERR_IO` when either
- * is missing, `SDR_CORE_ERR_INVALID_ARG` on null buffers or
- * zero-length buffers.
+ * buffer are truncated (not an error).
+ *
+ * Return semantics:
+ *   - `SDR_CORE_OK` with both buffers filled → credentials
+ *     present and copied out.
+ *   - `SDR_CORE_OK` with either buffer containing only the NUL
+ *     terminator (empty string) → no credentials stored. This
+ *     is a normal state, not an error — callers check for an
+ *     empty output buffer to detect "not yet configured."
+ *   - `SDR_CORE_ERR_IO` → the keyring backend itself failed
+ *     (service unavailable, platform error, …). Distinct from
+ *     the empty-output "not stored" case so a broken backend
+ *     doesn't masquerade as "no credentials."
+ *   - `SDR_CORE_ERR_INVALID_ARG` → null buffers or zero-length
+ *     buffers.
  */
 int32_t sdr_core_radioreference_load_credentials(
     char*  out_user,

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -468,9 +468,12 @@ int32_t sdr_core_stop_iq_recording(SdrCore* handle);
 
 /*
  * Store RadioReference credentials in the OS keyring. Both
- * pointers must be non-null NUL-terminated UTF-8 strings.
- * Returns `SDR_CORE_OK` on success, `SDR_CORE_ERR_INVALID_ARG`
- * on null pointers, `SDR_CORE_ERR_IO` on keyring backend errors.
+ * pointers must be non-null, non-empty, NUL-terminated UTF-8
+ * strings. Returns `SDR_CORE_OK` on success,
+ * `SDR_CORE_ERR_INVALID_ARG` on null pointers or empty fields
+ * (the rest of the ABI uses empty-buffer as the "not stored"
+ * sentinel, so an empty save would be self-inconsistent),
+ * `SDR_CORE_ERR_IO` on keyring backend errors.
  */
 int32_t sdr_core_radioreference_save_credentials(
     const char* user_utf8,
@@ -539,8 +542,14 @@ int32_t sdr_core_radioreference_test_credentials(
  * `getCountyFrequencies(county_id)` to fetch all tagged
  * frequencies.
  *
- * Writes a JSON document to `out_buf` (NUL-terminated,
- * truncated if the buffer is too small). The schema is:
+ * Writes a JSON document to `out_buf` when the buffer is
+ * large enough to hold the full payload plus a trailing NUL.
+ * If it isn't, the function returns
+ * `SDR_CORE_ERR_INVALID_ARG`, writes the required allocation
+ * size (NUL-inclusive) to `out_required` when non-null, and
+ * leaves `out_buf` untouched — callers should reallocate to
+ * `*out_required` bytes and retry. A truncated JSON body is
+ * never returned. The schema is:
  *
  *   {
  *     "county_id":   <u32>,

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 5
+#define SDR_CORE_ABI_VERSION_MINOR 6
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -83,6 +83,7 @@ typedef enum SdrCoreError {
     SDR_CORE_ERR_AUDIO          = -6, /* Audio backend error.           */
     SDR_CORE_ERR_IO             = -7, /* File / network I/O error.      */
     SDR_CORE_ERR_CONFIG         = -8, /* Config load/save error.        */
+    SDR_CORE_ERR_AUTH           = -9, /* Remote service rejected credentials (RadioReference). */
 } SdrCoreError;
 
 /*
@@ -443,6 +444,137 @@ int32_t sdr_core_stop_audio_recording(SdrCore* handle);
  */
 int32_t sdr_core_start_iq_recording(SdrCore* handle, const char* path_utf8);
 int32_t sdr_core_stop_iq_recording(SdrCore* handle);
+
+/* ================================================================ */
+/*  RadioReference integration                                      */
+/* ================================================================ */
+
+/*
+ * Credential storage and frequency lookups against RadioReference.com
+ * (issue #241). All handle-free — they don't touch the engine or
+ * DSP thread.
+ *
+ * Credentials are kept in the OS keyring (Keychain on macOS,
+ * libsecret / KeePassXC on Linux) under the SAME service name +
+ * key names the GTK UI uses, so a user running both apps on one
+ * machine shares a single login.
+ *
+ * Search (`_search_zip`) returns a JSON document in a caller-
+ * allocated buffer — see the function contract for the schema.
+ * Callers SHOULD dispatch these calls on a background thread; the
+ * underlying HTTP is synchronous blocking and can take multiple
+ * seconds on a slow connection.
+ */
+
+/*
+ * Store RadioReference credentials in the OS keyring. Both
+ * pointers must be non-null NUL-terminated UTF-8 strings.
+ * Returns `SDR_CORE_OK` on success, `SDR_CORE_ERR_INVALID_ARG`
+ * on null pointers, `SDR_CORE_ERR_IO` on keyring backend errors.
+ */
+int32_t sdr_core_radioreference_save_credentials(
+    const char* user_utf8,
+    const char* pass_utf8
+);
+
+/*
+ * Load stored credentials into caller-allocated buffers. Both
+ * buffers are NUL-terminated on success; values longer than the
+ * buffer are truncated (not an error). Returns `SDR_CORE_OK`
+ * when both fields were present, `SDR_CORE_ERR_IO` when either
+ * is missing, `SDR_CORE_ERR_INVALID_ARG` on null buffers or
+ * zero-length buffers.
+ */
+int32_t sdr_core_radioreference_load_credentials(
+    char*  out_user,
+    size_t user_buf_len,
+    char*  out_pass,
+    size_t pass_buf_len
+);
+
+/*
+ * Delete any stored credentials. Idempotent — returns
+ * `SDR_CORE_OK` whether or not credentials were present.
+ */
+int32_t sdr_core_radioreference_delete_credentials(void);
+
+/*
+ * Cheap existence probe — returns `true` if both username and
+ * password are stored AND non-empty, `false` otherwise.
+ * Does not load the values into caller memory; use this to gate
+ * "show RadioReference panel" in the UI without surfacing the
+ * password.
+ */
+bool sdr_core_radioreference_has_credentials(void);
+
+/*
+ * Test credentials with a lightweight RadioReference API probe
+ * (ZIP 90210). Returns `SDR_CORE_OK` on valid credentials,
+ * `SDR_CORE_ERR_AUTH` when RR rejected the login,
+ * `SDR_CORE_ERR_IO` on network failure,
+ * `SDR_CORE_ERR_INVALID_ARG` on empty or null inputs.
+ *
+ * Does not touch the keyring — caller supplies the credentials
+ * to test (typically from a Settings-pane form before saving).
+ */
+int32_t sdr_core_radioreference_test_credentials(
+    const char* user_utf8,
+    const char* pass_utf8
+);
+
+/*
+ * Search RadioReference for frequencies covering a US ZIP code.
+ * Performs `getZipcodeInfo(zip)` to resolve the county, then
+ * `getCountyFrequencies(county_id)` to fetch all tagged
+ * frequencies.
+ *
+ * Writes a JSON document to `out_buf` (NUL-terminated,
+ * truncated if the buffer is too small). The schema is:
+ *
+ *   {
+ *     "county_id":   <u32>,
+ *     "county_name": "<string>",
+ *     "state_id":    <u32>,
+ *     "city":        "<string>",
+ *     "frequencies": [
+ *       {
+ *         "id":           "<string>",      // opaque RR frequency ID
+ *         "freq_hz":      <u64>,
+ *         "rr_mode":      "<string>",      // raw RR mode ("FM", "FMN", …)
+ *         "demod_mode":   "<string>",      // engine mode ("NFM", "WFM", …)
+ *         "bandwidth_hz": <f64>,           // mapped channel bandwidth
+ *         "tone_hz":      <f32 | null>,    // CTCSS / PL tone if present
+ *         "description":  "<string>",
+ *         "alpha_tag":    "<string>",
+ *         "category":     "<string>",      // first tag description
+ *         "tags":         ["<string>", …]  // all tag descriptions
+ *       },
+ *       ...
+ *     ]
+ *   }
+ *
+ * If `out_required` is non-null, it is filled with the
+ * serialized JSON size in bytes (not counting the NUL) whether
+ * or not the buffer was large enough. Callers that got truncated
+ * output can reallocate + retry.
+ *
+ * Returns `SDR_CORE_OK` on success, `SDR_CORE_ERR_AUTH` on
+ * rejected credentials, `SDR_CORE_ERR_IO` on network failure,
+ * `SDR_CORE_ERR_INVALID_ARG` on malformed ZIP or null buffers,
+ * `SDR_CORE_ERR_INTERNAL` on JSON encoding failure.
+ *
+ * Blocking: this is synchronous HTTP against RadioReference.com.
+ * Callers MUST dispatch it on a background thread so the UI /
+ * event loop stays responsive.
+ */
+int32_t sdr_core_radioreference_search_zip(
+    const char* user_utf8,
+    const char* pass_utf8,
+    const char* zip_utf8,
+    char*       out_buf,
+    size_t      out_buf_len,
+    size_t*     out_required
+);
 
 /* --- IQ frontend -------------------------------------------------- */
 

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -564,14 +564,16 @@ int32_t sdr_core_radioreference_test_credentials(
  *     ]
  *   }
  *
- * If `out_required` is non-null, it is filled with the
- * serialized JSON size in bytes (not counting the NUL) whether
- * or not the buffer was large enough. Callers that got truncated
- * output can reallocate + retry.
+ * If `out_required` is non-null, it is filled with the exact
+ * number of bytes the caller must allocate to receive the full
+ * payload — **including the trailing NUL** — whether or not the
+ * buffer was large enough.
  *
  * Returns `SDR_CORE_OK` on success, `SDR_CORE_ERR_AUTH` on
  * rejected credentials, `SDR_CORE_ERR_IO` on network failure,
- * `SDR_CORE_ERR_INVALID_ARG` on malformed ZIP or null buffers,
+ * `SDR_CORE_ERR_INVALID_ARG` on malformed ZIP, null buffers,
+ * **or a too-small output buffer** (the caller should read
+ * `out_required` and retry with a larger allocation),
  * `SDR_CORE_ERR_INTERNAL` on JSON encoding failure.
  *
  * Blocking: this is synchronous HTTP against RadioReference.com.

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -496,8 +496,12 @@ int32_t sdr_core_radioreference_save_credentials(
  *     (service unavailable, platform error, …). Distinct from
  *     the empty-output "not stored" case so a broken backend
  *     doesn't masquerade as "no credentials."
- *   - `SDR_CORE_ERR_INVALID_ARG` → null buffers or zero-length
- *     buffers.
+ *   - `SDR_CORE_ERR_INVALID_ARG` → null buffers, or either
+ *     `_buf_len` < 2. A 1-byte buffer can only hold the NUL,
+ *     which would collide with the "empty ⇒ not stored"
+ *     sentinel — callers must pass at least two bytes so a
+ *     single-character credential can still be distinguished
+ *     from "nothing stored."
  */
 int32_t sdr_core_radioreference_load_credentials(
     char*  out_user,


### PR DESCRIPTION
## Summary

Expose the existing `sdr-radioreference` crate in the SwiftUI app, mirroring the GTK layout exactly: a header-bar button opens a 700×600 modal dialog for ZIP-based frequency lookup, and a new Settings tab manages credentials (stored in the macOS Keychain under the same service + key names the GTK build uses, so cross-platform installs share one login).

Closes #241.

## Engine audit (no Swift-side reinvention)

| Feature | Engine source of truth | Swift work |
|---|---|---|
| Credentials storage | `sdr-config::KeyringStore` (OS keyring via `keyring` crate — Keychain on macOS, libsecret on Linux) | FFI wrap |
| SOAP client | `sdr-radioreference::RrClient` — sync blocking HTTP, `get_zip_info`, `get_county_frequencies`, `test_connection` | FFI wrap |
| RR mode → engine demod + bandwidth | `sdr-radioreference::mode_map::map_rr_mode` | Performed on the Rust side; returned in the JSON so Swift doesn't reimplement the lookup |

## Scope decision (ZIP-based, bulk-import-as-bookmarks)

Issue #241 mentions "state/county pickers" and "per-row Tune buttons," but the GTK implementation uses ZIP search with checkbox select + bulk import and no per-row tune. Per user direction, mirror GTK exactly — no county picker (RadioReference's `getZipcodeInfo` returns a single county per ZIP), no per-row Tune (user clicks an imported bookmark to tune).

## What changed

**sdr-ffi (ABI 0.5 → 0.6, additive):**
- `sdr_core_radioreference_save/load/delete/has/test_credentials` — keyring-backed.
- `sdr_core_radioreference_search_zip(user, pass, zip, out_buf, out_buf_len, out_required)` — JSON response, grow-if-needed buffer.
- `SDR_CORE_ERR_AUTH = -9` — new error code for credential rejection (distinct from transient network failures).
- Defensive save-then-readback tripwire in the save path — catches mock-backend / keyring-config regressions on the write side.
- 7 new FFI unit tests.

**SdrCoreKit:**
- `SdrCore.RadioReferenceSearchResult` + `.RadioReferenceFrequency` Codable structs matching the JSON schema.
- `save/load/delete/has/test/search` wrappers. `testRadioReferenceCredentials` returns typed `.valid / .invalidCredentials / .networkError`.
- `DemodMode(engineLabel:)` initializer parses the engine's mode string into the Swift enum.

**SDRMac:**
- **Settings → RadioReference**: username/password, Test & Save (runs on a detached task), Clear stored, status. Prefills username from keychain on appear; never prefills password.
- **Header-bar toolbar button**: antenna icon + \"RadioReference\" text Label, opens the modal search dialog. Visible whenever the dialog can be opened; the dialog's empty state directs the user to Settings if no creds.
- **RadioReferenceDialog**: 700×600 modal sheet with ZIP entry, async detached search, Category + Agency filter Pickers populated from results, checkbox-select results list, already-imported rows rendered with a green checkmark and non-toggleable, \"Import Selected (N)\" bulk-adds bookmarks. Auto-closes on successful import. Top-pinned frame so the layout doesn't jump while searching.
- `CoreModel.radioReferenceHasCredentials` @Observable + refresh via `.onChange(of: scenePhase)` when the main window becomes active.

## Critical workspace fix — `keyring` backend feature

The `keyring` crate 3.x uses feature-gated backends per OS. The workspace previously enabled only `sync-secret-service` (Linux). Without `apple-native`, macOS silently uses a **mock** backend that accepts writes, returns Ok, and persists nothing. Save looked successful; every subsequent load returned nil. The Settings pane would happily say \"Credentials saved\" while the keychain stayed empty.

Fix: enable both `sync-secret-service` + `apple-native` at the workspace level. Captured in a new `feedback_keyring_crate_features` memory alongside the detection recipe (immediate save-then-readback probe inside the FFI).

## Other debugging lessons captured as memory

- **ToolbarItem placements are mutually exclusive** — two items at the same placement silently drop one. Fixed earlier with `.automatic`.
- **Inline-declared ToolbarItem content renders reliably; a subview-struct wrapper did not on macOS** — sheet presentation state hoisted to `ContentView` to keep the Button inline.
- **Bare `Image(systemName:)` in a toolbar Button disappears under \"Icon Only\" display mode** if the SF Symbol isn't recognized on the user's macOS version. Use `Label(text, systemImage:)` for text-fallback safety.

All three captured in `feedback_swiftui_toolbar_placement` + `feedback_keyring_crate_features`.

## Tests

- `cargo test --workspace -p sdr-ffi`: **63 passed, 0 failed** (7 new).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `make ffi-header-check`: clean.
- `cargo fmt --all -- --check`: clean.
- Release Mac app (`make mac-app`) smoke-tested end-to-end: save creds in Settings → click toolbar button → search ZIP → filter by category + agency → import several rows as bookmarks → bookmark sidebar shows them → clicking a bookmark tunes correctly.

## Test plan

- [x] FFI unit tests green
- [x] Clippy + header drift lint clean
- [x] Release Mac build succeeds
- [x] Settings → RadioReference saves credentials (verified via save-then-readback)
- [x] Toolbar button present and opens dialog
- [x] ZIP search resolves to county + populates results
- [x] Category + Agency filters narrow the list live
- [x] Already-imported rows disabled with green checkmark
- [x] Bulk import creates bookmarks with mapped demod mode + bandwidth
- [x] Dialog auto-closes on successful import
- [x] Dialog layout doesn't jump while searching
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RadioReference Frequency Browser: ZIP search, filter, select and import frequencies into bookmarks.
  * RadioReference account management: Test & Save, Clear stored, credential presence probe, and credential-backed import.

* **UI**
  * Toolbar button + modal sheet to open the RadioReference browser.
  * Settings window widened with a new RadioReference pane for credentials and status messaging; app refreshes credential state on window focus.

* **Other**
  * Credential storage now also uses macOS native keychain.
  * Improved demod-mode label handling and explicit authentication error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->