### PR TITLE
swift-ui group c: advanced demod + advanced source panels (#245, #246)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -288,6 +288,44 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(sdr_core_set_deemphasis(handle, mode.rawValue))
     }
 
+    // ==========================================================
+    //  Advanced demod — #245. Each wraps a one-line FFI call to
+    //  a matching `UiToDsp::Set*` variant. Mode gating (WFM
+    //  stereo only meaningful in WFM, etc.) is left to the host
+    //  UI — the engine no-ops a toggle that doesn't apply to
+    //  the current demod.
+    // ==========================================================
+
+    /// Enable or disable the noise blanker.
+    public func setNoiseBlankerEnabled(_ enabled: Bool) throws {
+        try checkRc(sdr_core_set_nb_enabled(handle, enabled))
+    }
+
+    /// Set the noise-blanker threshold multiplier (>= 1.0).
+    public func setNoiseBlankerLevel(_ level: Float) throws {
+        try checkRc(sdr_core_set_nb_level(handle, level))
+    }
+
+    /// Enable or disable FM IF noise reduction (WFM / NFM only).
+    public func setFmIfNrEnabled(_ enabled: Bool) throws {
+        try checkRc(sdr_core_set_fm_if_nr_enabled(handle, enabled))
+    }
+
+    /// Enable or disable WFM stereo decode.
+    public func setWfmStereo(_ enabled: Bool) throws {
+        try checkRc(sdr_core_set_wfm_stereo(handle, enabled))
+    }
+
+    /// Enable or disable the audio-stage notch filter.
+    public func setNotchEnabled(_ enabled: Bool) throws {
+        try checkRc(sdr_core_set_notch_enabled(handle, enabled))
+    }
+
+    /// Set the audio notch frequency in Hz (> 0).
+    public func setNotchFrequencyHz(_ hz: Float) throws {
+        try checkRc(sdr_core_set_notch_frequency(handle, hz))
+    }
+
     /// Set the audio output volume (clamped internally to `[0, 1]`).
     public func setVolume(_ volume: Float) throws {
         try checkRc(sdr_core_set_volume(handle, volume))

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -805,6 +805,17 @@ final class CoreModel {
     }
 
     func setNoiseBlankerLevel(_ level: Float) {
+        // Guard BEFORE the optimistic write so a programmatic
+        // caller passing NaN / Inf / < 1.0 (the UI slider itself
+        // is bounded at 1.0...10.0, but any Swift call path can
+        // reach this setter) doesn't leave the UI showing a
+        // value the engine rejected. Keeps the ABI-level
+        // constraint from NB_LEVEL_MIN in sync on both sides.
+        // Per CodeRabbit round 2 on PR #347.
+        guard level.isFinite, level >= 1.0 else {
+            lastError = "invalid noise blanker level: \(level)"
+            return
+        }
         noiseBlankerLevel = level
         capture { try core?.setNoiseBlankerLevel(level) }
     }
@@ -825,6 +836,13 @@ final class CoreModel {
     }
 
     func setNotchFrequencyHz(_ hz: Float) {
+        // Matches the FFI's `freq_hz > 0` contract — reject
+        // invalid input up front so UI state can't diverge from
+        // engine state when a caller bypasses the slider bounds.
+        guard hz.isFinite, hz > 0 else {
+            lastError = "invalid notch frequency: \(hz)"
+            return
+        }
         notchFrequencyHz = hz
         capture { try core?.setNotchFrequencyHz(hz) }
     }
@@ -849,6 +867,17 @@ final class CoreModel {
     }
 
     func setDecimation(_ factor: UInt32) {
+        // Engine's `SetDecimation` handler requires a nonzero
+        // power of two. `nonzeroBitCount == 1` is equivalent to
+        // "exactly one bit set," which captures both conditions
+        // in one expression. The UI picker only emits values
+        // from {1, 2, 4, 8, 16}, but a programmatic caller
+        // could pass anything — reject-with-lastError keeps the
+        // UI honest.
+        guard factor.nonzeroBitCount == 1 else {
+            lastError = "invalid decimation factor: \(factor)"
+            return
+        }
         decimationFactor = factor
         capture { try core?.setDecimation(factor) }
     }

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -145,6 +145,23 @@ final class CoreModel {
     var ppmCorrection: Int = 0
 
     // ==========================================================
+    //  Source (advanced) — #246
+    // ==========================================================
+    //
+    //  Defaults match the engine-side defaults in
+    //  `crates/sdr-core/src/controller.rs` so a fresh launch of
+    //  the Mac app and the GTK app both present the same source
+    //  configuration.
+
+    var dcBlockingEnabled: Bool = false
+    var iqInversionEnabled: Bool = false
+    var iqCorrectionEnabled: Bool = false
+
+    /// Power-of-two decimation ratio (1 = none). 8 matches the
+    /// engine default (`sdr_pipeline::iq_frontend::DEFAULT_DECIM`).
+    var decimationFactor: UInt32 = 8
+
+    // ==========================================================
     //  Tuner
     // ==========================================================
 
@@ -162,6 +179,42 @@ final class CoreModel {
     var squelchEnabled: Bool = false
     var squelchDb: Float = -60
     var deemphasis: Deemphasis = .us75
+
+    // ==========================================================
+    //  Demod (advanced) — #245
+    // ==========================================================
+    //
+    //  Mode-gating rules for the Radio panel:
+    //    - FM IF NR: WFM / NFM only
+    //    - WFM stereo: WFM only
+    //    - Noise blanker + notch: universal
+    //
+    //  Defaults mirror the engine-side defaults so a toggle from
+    //  off → on → off exactly reproduces the engine's own
+    //  initial state.
+
+    /// Noise blanker enable (IF stage). Off by default.
+    var noiseBlankerEnabled: Bool = false
+
+    /// Noise-blanker threshold multiplier. Engine clamps to
+    /// `>= 1.0`; we pick 2.0 as a sensible mid-range starting
+    /// point that matches the GTK slider's initial value.
+    var noiseBlankerLevel: Float = 2.0
+
+    /// FM IF noise reduction. Off by default; meaningful only
+    /// when the active demod is an FM mode (WFM or NFM).
+    var fmIfNrEnabled: Bool = false
+
+    /// WFM stereo decode. Off by default; only honored when
+    /// the active demod is WFM.
+    var wfmStereoEnabled: Bool = false
+
+    /// Audio-stage notch filter. Off by default.
+    var notchEnabled: Bool = false
+
+    /// Notch center frequency in Hz. 1 kHz is the common
+    /// starting point (also what the GTK UI defaults to).
+    var notchFrequencyHz: Float = 1_000
 
     // ==========================================================
     //  Audio
@@ -723,6 +776,64 @@ final class CoreModel {
     func setDeemphasis(_ m: Deemphasis) {
         deemphasis = m
         capture { try core?.setDeemphasis(m) }
+    }
+
+    // ----------------------------------------------------------
+    //  Demod (advanced) — #245
+    // ----------------------------------------------------------
+
+    func setNoiseBlankerEnabled(_ on: Bool) {
+        noiseBlankerEnabled = on
+        capture { try core?.setNoiseBlankerEnabled(on) }
+    }
+
+    func setNoiseBlankerLevel(_ level: Float) {
+        noiseBlankerLevel = level
+        capture { try core?.setNoiseBlankerLevel(level) }
+    }
+
+    func setFmIfNrEnabled(_ on: Bool) {
+        fmIfNrEnabled = on
+        capture { try core?.setFmIfNrEnabled(on) }
+    }
+
+    func setWfmStereo(_ on: Bool) {
+        wfmStereoEnabled = on
+        capture { try core?.setWfmStereo(on) }
+    }
+
+    func setNotchEnabled(_ on: Bool) {
+        notchEnabled = on
+        capture { try core?.setNotchEnabled(on) }
+    }
+
+    func setNotchFrequencyHz(_ hz: Float) {
+        notchFrequencyHz = hz
+        capture { try core?.setNotchFrequencyHz(hz) }
+    }
+
+    // ----------------------------------------------------------
+    //  Source (advanced) — #246
+    // ----------------------------------------------------------
+
+    func setDcBlocking(_ on: Bool) {
+        dcBlockingEnabled = on
+        capture { try core?.setDcBlocking(on) }
+    }
+
+    func setIqInversion(_ on: Bool) {
+        iqInversionEnabled = on
+        capture { try core?.setIqInversion(on) }
+    }
+
+    func setIqCorrection(_ on: Bool) {
+        iqCorrectionEnabled = on
+        capture { try core?.setIqCorrection(on) }
+    }
+
+    func setDecimation(_ factor: UInt32) {
+        decimationFactor = factor
+        capture { try core?.setDecimation(factor) }
     }
 
     func setVolume(_ v: Float) {

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -587,6 +587,14 @@ final class CoreModel {
         setCenter(centerFrequencyHz)
         setVfoOffset(vfoOffsetHz)
         setSampleRate(sourceSampleRateHz)
+        // Source (advanced) — #246. Replayed alongside the
+        // basic source fields so a reconnect doesn't leave the
+        // engine at its defaults while the UI shows the user's
+        // last-picked advanced settings.
+        setDecimation(decimationFactor)
+        setDcBlocking(dcBlockingEnabled)
+        setIqInversion(iqInversionEnabled)
+        setIqCorrection(iqCorrectionEnabled)
         setPpm(ppmCorrection)
         setGain(gainDb)
         setAgc(agcEnabled)
@@ -596,6 +604,15 @@ final class CoreModel {
         setSquelchDb(squelchDb)
         setAutoSquelch(autoSquelchEnabled)
         setDeemphasis(deemphasis)
+        // Demod (advanced) — #245. See above comment; replay
+        // keeps startup/reconnect in sync with the UI's
+        // optimistic state.
+        setNoiseBlankerEnabled(noiseBlankerEnabled)
+        setNoiseBlankerLevel(noiseBlankerLevel)
+        setFmIfNrEnabled(fmIfNrEnabled)
+        setWfmStereo(wfmStereoEnabled)
+        setNotchEnabled(notchEnabled)
+        setNotchFrequencyHz(notchFrequencyHz)
         setVolume(volume)
         // Route to the user's last-picked output device. The
         // engine default is "" (system default) so a fresh install

--- a/apps/macos/SDRMac/Views/RadioSection.swift
+++ b/apps/macos/SDRMac/Views/RadioSection.swift
@@ -2,8 +2,13 @@
 // RadioSection.swift — sidebar panel for demod controls.
 //
 // MVP: bandwidth, squelch, de-emphasis (WFM/NFM only), volume.
-// The advanced controls (noise blanker, FM IF NR, WFM stereo,
-// notch) are v2.
+// Advanced (noise blanker, FM IF NR, WFM stereo, notch) lives
+// in a collapsible DisclosureGroup at the bottom — issue #245.
+//
+// Mode-gating rules mirror the GTK UI:
+//   - FM IF NR visible in WFM / NFM only
+//   - WFM stereo visible in WFM only
+//   - Noise blanker + notch are universal
 
 import SwiftUI
 import SdrCoreKit
@@ -98,6 +103,96 @@ struct RadioSection: View {
                         }
                     }
                 )
+            }
+
+            DisclosureGroup("Advanced") {
+                AdvancedDemodControls()
+            }
+        }
+    }
+}
+
+/// Advanced demod controls — noise blanker, FM IF NR, WFM
+/// stereo, notch filter. Pulled into its own subview so
+/// the RadioSection body stays under SwiftUI's expression
+/// complexity budget as more controls accumulate.
+private struct AdvancedDemodControls: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        Toggle("Noise blanker", isOn: Binding(
+            get: { model.noiseBlankerEnabled },
+            set: { model.setNoiseBlankerEnabled($0) }
+        ))
+
+        if model.noiseBlankerEnabled {
+            LabeledContent("NB level") {
+                VStack(spacing: 2) {
+                    @Bindable var m = model
+                    // Range mirrors the GTK slider (1.0...10.0).
+                    // Engine rejects < 1.0 via InvalidArg, so the
+                    // lower bound matches — never push a value
+                    // the FFI will reject.
+                    Slider(
+                        value: $m.noiseBlankerLevel,
+                        in: 1.0...10.0,
+                        onEditingChanged: { editing in
+                            if !editing {
+                                model.setNoiseBlankerLevel(model.noiseBlankerLevel)
+                            }
+                        }
+                    )
+                    Text(String(format: "%.1f×", model.noiseBlankerLevel))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        // FM IF NR is only meaningful in FM demod modes; hide
+        // the toggle outside WFM / NFM so the user can't arm a
+        // control that the engine will silently ignore.
+        if model.demodMode == .wfm || model.demodMode == .nfm {
+            Toggle("FM IF NR", isOn: Binding(
+                get: { model.fmIfNrEnabled },
+                set: { model.setFmIfNrEnabled($0) }
+            ))
+        }
+
+        if model.demodMode == .wfm {
+            Toggle("WFM stereo", isOn: Binding(
+                get: { model.wfmStereoEnabled },
+                set: { model.setWfmStereo($0) }
+            ))
+        }
+
+        Toggle("Notch", isOn: Binding(
+            get: { model.notchEnabled },
+            set: { model.setNotchEnabled($0) }
+        ))
+
+        if model.notchEnabled {
+            LabeledContent("Notch Hz") {
+                VStack(spacing: 2) {
+                    @Bindable var m = model
+                    // Voice-band default range. The engine
+                    // clamps to audio Nyquist internally; this
+                    // range stays well below it for any
+                    // realistic audio sample rate, so the host
+                    // UI doesn't have to chase engine state.
+                    Slider(
+                        value: $m.notchFrequencyHz,
+                        in: 200...4000,
+                        onEditingChanged: { editing in
+                            if !editing {
+                                model.setNotchFrequencyHz(model.notchFrequencyHz)
+                            }
+                        }
+                    )
+                    Text("\(Int(model.notchFrequencyHz)) Hz")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
     }

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -4,6 +4,12 @@
 // MVP scope: RTL-SDR only (no device picker). Sample rate, gain
 // (discrete when AGC off), AGC, PPM. The device-picker and the
 // Network/File source forms land in v2 behind feature flags.
+//
+// Advanced controls (DC blocking, IQ inversion, IQ correction,
+// decimation) live in a collapsible "Advanced" DisclosureGroup
+// at the bottom, default-collapsed so the MVP layout stays
+// clean. Mirrors GTK's "Advanced" expander in its Source panel
+// (issue #246).
 
 import SwiftUI
 
@@ -14,6 +20,12 @@ private let rtlSdrSampleRates: [Double] = [
     2_048_000, 2_160_000, 2_400_000, 2_560_000, 2_880_000,
     3_200_000,
 ]
+
+/// Allowed decimation factors for the Advanced group. Must be
+/// powers of two — the engine's `SetDecimation` handler rejects
+/// non-power-of-two values. Mirrors GTK's
+/// `sdr-ui::sidebar::source_panel::DECIMATION_FACTORS`.
+private let decimationFactors: [UInt32] = [1, 2, 4, 8, 16]
 
 struct SourceSection: View {
     @Environment(CoreModel.self) private var model
@@ -62,6 +74,41 @@ struct SourceSection: View {
                     set: { model.setPpm($0) }
                 ), in: -100...100) {
                     Text("\(model.ppmCorrection)")
+                }
+            }
+
+            // Collapsible "Advanced" group — default-collapsed
+            // because most users never touch these toggles. The
+            // four FFI commands have existed since the M2 ABI;
+            // this commit just surfaces them. Mirrors the GTK
+            // Source panel's expander (#246).
+            DisclosureGroup("Advanced") {
+                Toggle("DC blocking", isOn: Binding(
+                    get: { model.dcBlockingEnabled },
+                    set: { model.setDcBlocking($0) }
+                ))
+
+                Toggle("IQ inversion", isOn: Binding(
+                    get: { model.iqInversionEnabled },
+                    set: { model.setIqInversion($0) }
+                ))
+
+                Toggle("IQ correction", isOn: Binding(
+                    get: { model.iqCorrectionEnabled },
+                    set: { model.setIqCorrection($0) }
+                ))
+
+                LabeledContent("Decimation") {
+                    Picker("", selection: Binding(
+                        get: { model.decimationFactor },
+                        set: { model.setDecimation($0) }
+                    )) {
+                        ForEach(decimationFactors, id: \.self) { f in
+                            Text(f == 1 ? "None" : "1/\(f)").tag(f)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
                 }
             }
         }

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -365,6 +365,92 @@ pub unsafe extern "C" fn sdr_core_set_deemphasis(handle: *mut SdrCore, mode: i32
 }
 
 // ============================================================
+//  Advanced demod — #245 exposure
+// ============================================================
+//
+//  These route straight to the existing `UiToDsp` messages the
+//  GTK UI already drives. Mode-gating (e.g. WFM stereo only
+//  meaningful in WFM) lives on the host side — the engine
+//  accepts the setter in any mode but ignores it when the
+//  active demod doesn't care, which matches the GTK UI's
+//  pattern of still letting the user set the toggle ahead of a
+//  mode switch. Per ABI minor bump 0.7 on PR #347.
+
+/// Enable or disable the noise blanker.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_nb_enabled(handle: *mut SdrCore, enabled: bool) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::SetNbEnabled(enabled))) }
+}
+
+/// Set the noise-blanker threshold multiplier. Must be finite
+/// and `>= 1.0` (the engine treats the level as a multiplier
+/// over the running sample amplitude; `< 1.0` would clip every
+/// sample). Values exceeding 1.0 loosen the blanking threshold.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_nb_level(handle: *mut SdrCore, level: f32) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            require_finite("sdr_core_set_nb_level", f64::from(level))?;
+            if level < 1.0 {
+                set_last_error(format!(
+                    "sdr_core_set_nb_level: level must be >= 1.0, got {level}"
+                ));
+                return Err(SdrCoreError::InvalidArg);
+            }
+            send(core, UiToDsp::SetNbLevel(level))
+        })
+    }
+}
+
+/// Enable or disable FM IF noise reduction. No-op when the
+/// active demod is not an FM mode; host UIs typically hide the
+/// toggle outside WFM / NFM.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_fm_if_nr_enabled(handle: *mut SdrCore, enabled: bool) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            send(core, UiToDsp::SetFmIfNrEnabled(enabled))
+        })
+    }
+}
+
+/// Enable or disable WFM stereo decode. Only meaningful in WFM
+/// mode; the engine ignores the setting in other modes but the
+/// host UI should also gate visibility.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_wfm_stereo(handle: *mut SdrCore, enabled: bool) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::SetWfmStereo(enabled))) }
+}
+
+/// Enable or disable the audio-stage notch filter.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_notch_enabled(handle: *mut SdrCore, enabled: bool) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::SetNotchEnabled(enabled))) }
+}
+
+/// Set the audio-stage notch filter frequency in Hz. Must be
+/// finite and `> 0`. The engine clamps to the audio-rate
+/// Nyquist internally; passing a value above Nyquist is not an
+/// error here because the clamp is sample-rate dependent and
+/// the FFI has no stable reference to that without querying
+/// the engine.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_notch_frequency(handle: *mut SdrCore, freq_hz: f32) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            require_finite("sdr_core_set_notch_frequency", f64::from(freq_hz))?;
+            if freq_hz <= 0.0 {
+                set_last_error(format!(
+                    "sdr_core_set_notch_frequency: frequency must be > 0 Hz, got {freq_hz}"
+                ));
+                return Err(SdrCoreError::InvalidArg);
+            }
+            send(core, UiToDsp::SetNotchFrequency(freq_hz))
+        })
+    }
+}
+
+// ============================================================
 //  Audio
 // ============================================================
 

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -376,6 +376,22 @@ pub unsafe extern "C" fn sdr_core_set_deemphasis(handle: *mut SdrCore, mode: i32
 //  pattern of still letting the user set the toggle ahead of a
 //  mode switch. Per ABI minor bump 0.7 on PR #347.
 
+/// Minimum accepted value for `sdr_core_set_nb_level`. Values
+/// below 1.0 would have the blanker clip every sample (the
+/// engine treats the level as a multiplier over the running
+/// amplitude), producing silent audio instead of a usable
+/// output. Kept as an exclusive-minimum constant so the check
+/// in the setter and the boundary tests can't drift apart. Per
+/// CodeRabbit round 1 on PR #347.
+const NB_LEVEL_MIN: f32 = 1.0;
+
+/// Exclusive lower bound for `sdr_core_set_notch_frequency`.
+/// The notch filter coefficients are undefined at 0 Hz (and
+/// negative frequencies have no physical meaning here), so the
+/// setter rejects `freq_hz <= 0.0`. Per CodeRabbit round 1 on
+/// PR #347.
+const NOTCH_FREQUENCY_MIN_HZ_EXCLUSIVE: f32 = 0.0;
+
 /// Enable or disable the noise blanker.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_set_nb_enabled(handle: *mut SdrCore, enabled: bool) -> i32 {
@@ -391,9 +407,9 @@ pub unsafe extern "C" fn sdr_core_set_nb_level(handle: *mut SdrCore, level: f32)
     unsafe {
         with_core(handle, |core| {
             require_finite("sdr_core_set_nb_level", f64::from(level))?;
-            if level < 1.0 {
+            if level < NB_LEVEL_MIN {
                 set_last_error(format!(
-                    "sdr_core_set_nb_level: level must be >= 1.0, got {level}"
+                    "sdr_core_set_nb_level: level must be >= {NB_LEVEL_MIN}, got {level}"
                 ));
                 return Err(SdrCoreError::InvalidArg);
             }
@@ -439,9 +455,9 @@ pub unsafe extern "C" fn sdr_core_set_notch_frequency(handle: *mut SdrCore, freq
     unsafe {
         with_core(handle, |core| {
             require_finite("sdr_core_set_notch_frequency", f64::from(freq_hz))?;
-            if freq_hz <= 0.0 {
+            if freq_hz <= NOTCH_FREQUENCY_MIN_HZ_EXCLUSIVE {
                 set_last_error(format!(
-                    "sdr_core_set_notch_frequency: frequency must be > 0 Hz, got {freq_hz}"
+                    "sdr_core_set_notch_frequency: frequency must be > {NOTCH_FREQUENCY_MIN_HZ_EXCLUSIVE} Hz, got {freq_hz}"
                 ));
                 return Err(SdrCoreError::InvalidArg);
             }
@@ -1164,6 +1180,111 @@ mod tests {
             SdrCoreError::InvalidArg.as_int()
         );
 
+        destroy(h);
+    }
+
+    // ------------------------------------------------------
+    //  Advanced demod (ABI 0.7) — regression tests for the
+    //  argument contracts established by the `NB_LEVEL_MIN`
+    //  and `NOTCH_FREQUENCY_MIN_HZ_EXCLUSIVE` constants. Per
+    //  CodeRabbit round 1 on PR #347.
+    // ------------------------------------------------------
+
+    #[test]
+    fn set_nb_level_accepts_at_minimum_and_rejects_below() {
+        let h = make_handle();
+        // Exactly at the minimum must be accepted — the engine
+        // treats `1.0` as "no clipping margin," which is the
+        // lower edge of the usable range.
+        assert_eq!(
+            unsafe { sdr_core_set_nb_level(h, NB_LEVEL_MIN) },
+            SdrCoreError::Ok.as_int()
+        );
+        // Any value below minimum must be rejected.
+        assert_eq!(
+            unsafe { sdr_core_set_nb_level(h, NB_LEVEL_MIN - 0.0001) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_nb_level(h, 0.0) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_nb_level(h, -1.0) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_nb_level_rejects_nan_and_infinity() {
+        let h = make_handle();
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(
+                unsafe { sdr_core_set_nb_level(h, bad) },
+                SdrCoreError::InvalidArg.as_int(),
+                "nb_level must reject {bad}"
+            );
+        }
+        destroy(h);
+    }
+
+    #[test]
+    fn set_notch_frequency_accepts_positive_rejects_nonpositive() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_notch_frequency(h, 1_000.0) },
+            SdrCoreError::Ok.as_int()
+        );
+        // Exactly at the exclusive lower bound must be rejected.
+        assert_eq!(
+            unsafe { sdr_core_set_notch_frequency(h, NOTCH_FREQUENCY_MIN_HZ_EXCLUSIVE) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_notch_frequency(h, -50.0) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_notch_frequency_rejects_nan_and_infinity() {
+        let h = make_handle();
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(
+                unsafe { sdr_core_set_notch_frequency(h, bad) },
+                SdrCoreError::InvalidArg.as_int(),
+                "notch_frequency must reject {bad}"
+            );
+        }
+        destroy(h);
+    }
+
+    #[test]
+    fn advanced_demod_bool_setters_accept_both_polarities() {
+        // The four bool-typed advanced setters have no validation
+        // beyond handle + panic catch — this just pins that they
+        // don't silently regress to rejecting a valid input.
+        let h = make_handle();
+        for &on in &[true, false] {
+            assert_eq!(
+                unsafe { sdr_core_set_nb_enabled(h, on) },
+                SdrCoreError::Ok.as_int()
+            );
+            assert_eq!(
+                unsafe { sdr_core_set_fm_if_nr_enabled(h, on) },
+                SdrCoreError::Ok.as_int()
+            );
+            assert_eq!(
+                unsafe { sdr_core_set_wfm_stereo(h, on) },
+                SdrCoreError::Ok.as_int()
+            );
+            assert_eq!(
+                unsafe { sdr_core_set_notch_enabled(h, on) },
+                SdrCoreError::Ok.as_int()
+            );
+        }
         destroy(h);
     }
 }

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 6;
+pub const ABI_VERSION_MINOR: u32 = 7;
 
 /// Return the ABI version the library was built with.
 ///
@@ -326,7 +326,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 6);
+        assert!(ABI_VERSION_MINOR == 7);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 6
+#define SDR_CORE_ABI_VERSION_MINOR 7
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -383,6 +383,44 @@ typedef enum SdrDeemphasis {
 } SdrDeemphasis;
 
 int32_t sdr_core_set_deemphasis(SdrCore* handle, int32_t mode);
+
+/* --- Advanced demod ---------------------------------------------- */
+/*
+ * Route straight to the matching `UiToDsp` messages. Mode-gating
+ * is a host-side concern — e.g. WFM stereo is only meaningful
+ * when the active demod is WFM, but the engine still accepts
+ * the setter in any mode and no-ops outside of WFM. Host UIs
+ * typically hide the controls outside their relevant modes to
+ * avoid pointless toggles. Added in ABI minor 0.7 (issue #245).
+ */
+
+/* Enable or disable the noise blanker. */
+int32_t sdr_core_set_nb_enabled(SdrCore* handle, bool enabled);
+
+/*
+ * Noise-blanker threshold multiplier. Must be finite and
+ * `>= 1.0` — values below 1 would clip every sample. Higher
+ * values loosen the threshold.
+ */
+int32_t sdr_core_set_nb_level(SdrCore* handle, float level);
+
+/* Enable or disable FM IF noise reduction (WFM / NFM only). */
+int32_t sdr_core_set_fm_if_nr_enabled(SdrCore* handle, bool enabled);
+
+/* Enable or disable WFM stereo decode (WFM only). */
+int32_t sdr_core_set_wfm_stereo(SdrCore* handle, bool enabled);
+
+/* Enable or disable the audio-stage notch filter. */
+int32_t sdr_core_set_notch_enabled(SdrCore* handle, bool enabled);
+
+/*
+ * Audio notch center frequency, in Hz. Must be finite and
+ * strictly positive. The engine clamps to the audio Nyquist
+ * internally; values above Nyquist are not a hard FFI error
+ * because the clamp point depends on the active audio sample
+ * rate.
+ */
+int32_t sdr_core_set_notch_frequency(SdrCore* handle, float freq_hz);
 
 /* --- Audio -------------------------------------------------------- */
 


### PR DESCRIPTION
## Summary

- Exposes the GTK-parity "Advanced" controls in the Mac app's Radio and Source sidebar panels. Collapsible `DisclosureGroup`s, default-collapsed, so the MVP layout stays clean.
- **#245 Advanced demod**: noise blanker (toggle + level slider), FM IF NR, WFM stereo, notch (toggle + frequency slider). Mode-gated — FM IF NR hidden outside WFM/NFM, WFM stereo hidden outside WFM, blanker + notch universal.
- **#246 Advanced source**: DC blocking, IQ inversion, IQ correction, decimation (segmented picker over {1, 2, 4, 8, 16}).
- Adds six new FFI commands + Swift wrappers for the demod controls (#245). ABI minor bump **0.6 → 0.7**. #246's four FFI commands already shipped in M2 — this PR just surfaces them in the UI.

## Scope notes

The other two v2 Group C items turned out to be already shipped on main when I audited current state, so this PR doesn't duplicate them:
- **#243 auto-squelch UI** — `autoSquelchEnabled` toggle and squelch-slider gating already wired in `RadioSection.swift`. The noise-floor dashed-line polish the issue also mentions is soft-blocked on an engine-side `SDR_EVT_NOISE_FLOOR` event that doesn't exist yet — deferred with no urgency (the issue itself flags it as "No urgency").
- **#244 display extras** — FFT rate slider and averaging-mode picker already in `DisplaySection.swift`; the peak-hold / running-avg / min-hold rendering is already implemented in `SpectrumRenderer.swift` (lines 315–437).

Both can be closed alongside this merge.

## Commits

1. `cfdbbbe` — add six advanced demod FFI commands + ABI bump 0.6 → 0.7
2. `b806baf` — Swift wrappers on `SdrCore` for the new setters
3. `84e4141` — `CoreModel` state + setters for advanced demod + advanced source
4. `83c9c18` — `SourceSection` Advanced disclosure group (#246)
5. `854c451` — `RadioSection` Advanced disclosure group (#245, mode-gated)

Engine audit confirmed every toggle routes to an existing `UiToDsp` variant — no new engine work.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace -p sdr-ffi --lib` — 65 passed, 1 ignored
- [x] `make ffi-header-check` passes
- [x] `xcodebuild -scheme SDRMac -configuration Debug build` **BUILD SUCCEEDED**
- [x] Smoke test: open app, expand Source → Advanced, toggle each; expand Radio → Advanced, toggle each in each demod mode (verify WFM/NFM gating); tune to a noisy signal and arm the notch / NB sliders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced demodulation controls: noise blanker (enable + level), FM IF noise reduction, WFM stereo, and audio notch (enable + frequency).
  * Added advanced source controls: DC blocking, IQ inversion, IQ correction, and selectable decimation factors.
  * Exposed all advanced options in collapsible "Advanced" sections in Source and Radio UI.

* **Bug Fixes / Validation**
  * Input validation for NB level, notch frequency, and decimation to prevent invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->