### PR TITLE
fix(squelch): recover auto-squelch from overshoot settle (#348)

### DIFF
--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -13,6 +13,23 @@ use sdr_types::{Complex, DspError};
 /// Small values track slowly, avoiding false adaptation to transient signals.
 const NOISE_FLOOR_ALPHA: f32 = 0.02;
 
+/// Slow-creep EMA coefficient used when auto-squelch is open
+/// AND the measured signal sits well above the tracked noise
+/// floor. Without this, the "only update when closed or near
+/// noise" rule below locks `noise_floor_db` at whatever it
+/// converged to at the end of the settle window. On a channel
+/// with a persistent carrier that settle often overshoots, and
+/// the gate stays open forever.
+///
+/// Picked so a carrier 25 dB above noise pulls the floor close
+/// enough to the close-margin in ~7 seconds (25 dB * 0.002 per
+/// block * 50 blocks/sec ≈ 2.5 dB/sec → needs ~8s to close the
+/// gap to the 6 dB close margin). Slow enough that a 1-2 sec
+/// voice burst doesn't materially shift the floor (EMA rise in
+/// 2s at this alpha ≈ 0.2 * gap → negligible for short bursts).
+/// Per issue #348.
+const NOISE_FLOOR_STUCK_RECOVERY_ALPHA: f32 = 0.002;
+
 /// Fast alpha used during the initial convergence period.
 ///
 /// Allows the noise floor to quickly reach the actual noise level from the
@@ -231,6 +248,10 @@ pub struct PowerSquelch {
     /// Number of blocks processed since auto-squelch was enabled.
     /// Used to detect the initial convergence period.
     settle_count: u32,
+    /// Last `measured_db` this processor computed. Exposed via
+    /// `diagnostic_snapshot` for issue #348 investigation; no
+    /// behavioral effect.
+    last_measured_db: f32,
 }
 
 impl PowerSquelch {
@@ -244,6 +265,7 @@ impl PowerSquelch {
             auto_squelch: false,
             noise_floor_db: NOISE_FLOOR_INITIAL_DB,
             settle_count: 0,
+            last_measured_db: NOISE_FLOOR_INITIAL_DB,
         }
     }
 
@@ -312,6 +334,7 @@ impl PowerSquelch {
         // Convert to standard dB: 20*log10(amplitude) = 10*log10(power).
         // This matches the standard dBFS convention used by most SDR tools.
         let measured_db = 20.0 * mean_amplitude.max(f32::MIN_POSITIVE).log10();
+        self.last_measured_db = measured_db;
 
         let threshold_db = if self.auto_squelch {
             // During the initial settling period, use a fast alpha so the
@@ -338,8 +361,33 @@ impl PowerSquelch {
                 );
             } else if !self.open || measured_db < self.noise_floor_db + AUTO_SQUELCH_CLOSE_MARGIN_DB
             {
+                // Near-noise regime: gate is closed or the
+                // signal is within close-margin of the tracked
+                // floor. Track at the normal alpha; this is the
+                // hot path whenever the channel is actually
+                // quiet.
                 self.noise_floor_db = NOISE_FLOOR_ALPHA
                     .mul_add(measured_db, (1.0 - NOISE_FLOOR_ALPHA) * self.noise_floor_db);
+            } else {
+                // Gate is open AND signal is well above the
+                // tracked floor — typical mid-transmission
+                // case. Previous behavior: skip the update
+                // entirely (keeps the floor from being dragged
+                // up by a brief signal). Problem: on a channel
+                // with a persistent carrier, OR when the
+                // settle window happened to capture live
+                // signal, the floor never recovers and the
+                // gate is stuck open forever. Fix: creep
+                // upward at a much slower alpha so a truly
+                // persistent signal pulls the floor close
+                // enough to the close margin within ~7
+                // seconds, restoring normal gate dynamics.
+                // Brief voice bursts barely move the floor at
+                // this rate. Per issue #348.
+                self.noise_floor_db = NOISE_FLOOR_STUCK_RECOVERY_ALPHA.mul_add(
+                    measured_db,
+                    (1.0 - NOISE_FLOOR_STUCK_RECOVERY_ALPHA) * self.noise_floor_db,
+                );
             }
 
             // During settling, keep squelch open (pass audio through) so
@@ -376,6 +424,33 @@ impl PowerSquelch {
         }
         Ok(input.len())
     }
+
+    /// Snapshot of squelch internals for callers that want to
+    /// log state at their layer (tracing belongs in the crate
+    /// that already depends on it — `sdr-dsp` stays pure).
+    pub fn diagnostic_snapshot(&self) -> PowerSquelchDiagnostic {
+        PowerSquelchDiagnostic {
+            auto_squelch: self.auto_squelch,
+            open: self.open,
+            noise_floor_db: self.noise_floor_db,
+            settle_count: self.settle_count,
+            level_db: self.level_db,
+            last_measured_db: self.last_measured_db,
+        }
+    }
+}
+
+/// Snapshot of [`PowerSquelch`] internals for diagnostic logging
+/// by higher-level crates that already depend on `tracing`.
+/// Never correlated with audio content — just gate state.
+#[derive(Debug, Clone, Copy)]
+pub struct PowerSquelchDiagnostic {
+    pub auto_squelch: bool,
+    pub open: bool,
+    pub noise_floor_db: f32,
+    pub settle_count: u32,
+    pub level_db: f32,
+    pub last_measured_db: f32,
 }
 
 /// Noise blanker — attenuates impulse noise spikes.
@@ -710,6 +785,86 @@ mod tests {
         assert!(
             output[0].re.abs() < 1e-10,
             "output should be zeroed when squelch closed"
+        );
+    }
+
+    #[test]
+    fn test_auto_squelch_recovers_from_overshoot_settle() {
+        // Regression for issue #348.
+        //
+        // Scenario: user enables auto-squelch while a strong
+        // carrier is on the channel. The 50-block settle window
+        // pulls `noise_floor_db` UP to the carrier level, so
+        // post-settle the gate correctly reports open. Before
+        // the slow-creep recovery fix, `noise_floor_db` then
+        // locked at that elevated value because the post-settle
+        // update rule only fired when the gate was closed OR
+        // the measurement was within the close margin — neither
+        // is true for a persistent carrier above the close
+        // margin. The gate stayed open forever.
+        //
+        // This test: enable auto-squelch with strong signal
+        // throughout the settle window, then keep the same
+        // signal running for enough post-settle blocks to
+        // exercise the slow-creep path. Assert `noise_floor_db`
+        // visibly creeps toward the signal level — proving the
+        // recovery path is active — and that after enough time
+        // it's climbed far enough that a subsequent drop below
+        // the original floor closes the gate.
+        let mut squelch = PowerSquelch::new(-60.0);
+        squelch.set_auto_squelch(true);
+
+        // Strong signal (amplitude 0.1 → -20 dB).
+        let strong = vec![Complex::new(0.1, 0.0); 128];
+        let mut out = vec![Complex::default(); 128];
+
+        // Drive 50 settle blocks; capture the post-settle floor.
+        for _ in 0..50 {
+            squelch.process(&strong, &mut out).unwrap();
+        }
+        let floor_after_settle = squelch.noise_floor_db();
+        assert!(
+            squelch.is_open(),
+            "strong signal must open the gate during / after settle"
+        );
+
+        // Now 500 post-settle blocks of the same strong signal.
+        // With the stuck-recovery fix the slow-creep alpha
+        // pulls the floor upward toward the signal level;
+        // without it the floor stays frozen at the settle value
+        // forever.
+        for _ in 0..500 {
+            squelch.process(&strong, &mut out).unwrap();
+        }
+        let floor_after_creep = squelch.noise_floor_db();
+
+        // The exact delta depends on the settle overshoot and
+        // the recovery alpha; empirically ~35 dB of climb at
+        // alpha=0.002 over 500 blocks starting from the typical
+        // post-settle floor. Assert a conservative "it moved
+        // meaningfully" threshold (≥ 10 dB upward) rather than
+        // pinning the specific value, so minor tuning of the
+        // alpha doesn't force a test rewrite.
+        let climb_db = floor_after_creep - floor_after_settle;
+        assert!(
+            climb_db > 10.0,
+            "stuck-recovery must pull noise_floor up under persistent signal; \
+             observed climb of only {climb_db:.2} dB \
+             ({floor_after_settle:.2} dB → {floor_after_creep:.2} dB) (#348)"
+        );
+
+        // Now drop the signal well below the new floor. With
+        // the fix the gate closes promptly because the floor
+        // has already climbed (so the close-margin gate of the
+        // EMA update fires + fast track-down), returning the
+        // squelch to its normal closed-on-silence behavior.
+        let silence = vec![Complex::new(0.000_01, 0.0); 128];
+        for _ in 0..50 {
+            squelch.process(&silence, &mut out).unwrap();
+        }
+        assert!(
+            !squelch.is_open(),
+            "after recovery + silence the gate must close"
         );
     }
 

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -324,6 +324,11 @@ impl PowerSquelch {
         }
         if input.is_empty() {
             self.open = false;
+            // Reset the diagnostic field so an empty-input
+            // call that closes the gate doesn't surface the
+            // previous block's power in downstream logs. Per
+            // CodeRabbit round 1 on PR #350.
+            self.last_measured_db = f32::NEG_INFINITY;
             return Ok(0);
         }
 
@@ -788,6 +793,48 @@ mod tests {
         );
     }
 
+    /// Block size used by the #348 regression test. Arbitrary
+    /// small value — any power of two ≥ 16 produces the same
+    /// qualitative behavior; 128 is close to typical live DSP
+    /// audio block sizes.
+    const STUCK_RECOVERY_BLOCK_LEN: usize = 128;
+
+    /// Number of post-settle blocks to drive through a
+    /// persistent strong carrier to exercise the slow-creep
+    /// recovery path. Sized so the EMA climbs measurably
+    /// (~35 dB at `NOISE_FLOOR_STUCK_RECOVERY_ALPHA = 0.002`)
+    /// while keeping the test fast.
+    const STUCK_RECOVERY_BLOCKS: usize = 500;
+
+    /// Minimum noise-floor climb (dB) that the post-settle
+    /// creep path must produce over `STUCK_RECOVERY_BLOCKS` of
+    /// persistent signal. Picked as a conservative floor under
+    /// the empirical ≈ 35 dB climb so minor tuning of the
+    /// recovery alpha doesn't rewrite the test.
+    const STUCK_RECOVERY_MIN_CLIMB_DB: f32 = 10.0;
+
+    /// Signal amplitude used as the "persistent carrier" in the
+    /// stuck-open scenario. 0.1 → -20 dB, comfortably above any
+    /// reasonable noise floor.
+    const STUCK_RECOVERY_CARRIER_AMPLITUDE: f32 = 0.1;
+
+    /// Signal amplitude used as "silence" in the recovery-then-
+    /// close assertion. Well below the floor after recovery so
+    /// the EMA clearly drops and the gate closes.
+    const STUCK_RECOVERY_SILENCE_AMPLITUDE: f32 = 0.000_01;
+
+    /// Number of silence blocks to drive after the creep window
+    /// to verify the gate closes. Order-of-magnitude matches
+    /// `NOISE_FLOOR_SETTLE_BLOCKS` so we're not timing-sensitive.
+    const STUCK_RECOVERY_SILENCE_BLOCKS: usize = 50;
+
+    /// Manual squelch threshold the stuck-recovery test uses
+    /// when constructing `PowerSquelch::new`. The test switches
+    /// to auto-squelch immediately so the manual value is
+    /// irrelevant to the behavior under test — kept as a
+    /// constant to avoid a bare `-60.0` in the body.
+    const STUCK_RECOVERY_IDLE_LEVEL_DB: f32 = -60.0;
+
     #[test]
     fn test_auto_squelch_recovers_from_overshoot_settle() {
         // Regression for issue #348.
@@ -811,15 +858,15 @@ mod tests {
         // recovery path is active — and that after enough time
         // it's climbed far enough that a subsequent drop below
         // the original floor closes the gate.
-        let mut squelch = PowerSquelch::new(-60.0);
+        let mut squelch = PowerSquelch::new(STUCK_RECOVERY_IDLE_LEVEL_DB);
         squelch.set_auto_squelch(true);
 
-        // Strong signal (amplitude 0.1 → -20 dB).
-        let strong = vec![Complex::new(0.1, 0.0); 128];
-        let mut out = vec![Complex::default(); 128];
+        let strong =
+            vec![Complex::new(STUCK_RECOVERY_CARRIER_AMPLITUDE, 0.0); STUCK_RECOVERY_BLOCK_LEN];
+        let mut out = vec![Complex::default(); STUCK_RECOVERY_BLOCK_LEN];
 
-        // Drive 50 settle blocks; capture the post-settle floor.
-        for _ in 0..50 {
+        // Drive the settle window; capture the post-settle floor.
+        for _ in 0..NOISE_FLOOR_SETTLE_BLOCKS {
             squelch.process(&strong, &mut out).unwrap();
         }
         let floor_after_settle = squelch.noise_floor_db();
@@ -828,38 +875,31 @@ mod tests {
             "strong signal must open the gate during / after settle"
         );
 
-        // Now 500 post-settle blocks of the same strong signal.
-        // With the stuck-recovery fix the slow-creep alpha
-        // pulls the floor upward toward the signal level;
-        // without it the floor stays frozen at the settle value
-        // forever.
-        for _ in 0..500 {
+        // Now STUCK_RECOVERY_BLOCKS of the same strong signal.
+        // With the fix the slow-creep alpha pulls the floor
+        // upward toward the signal level; without it the floor
+        // stays frozen at the settle value forever.
+        for _ in 0..STUCK_RECOVERY_BLOCKS {
             squelch.process(&strong, &mut out).unwrap();
         }
         let floor_after_creep = squelch.noise_floor_db();
 
-        // The exact delta depends on the settle overshoot and
-        // the recovery alpha; empirically ~35 dB of climb at
-        // alpha=0.002 over 500 blocks starting from the typical
-        // post-settle floor. Assert a conservative "it moved
-        // meaningfully" threshold (≥ 10 dB upward) rather than
-        // pinning the specific value, so minor tuning of the
-        // alpha doesn't force a test rewrite.
         let climb_db = floor_after_creep - floor_after_settle;
         assert!(
-            climb_db > 10.0,
+            climb_db > STUCK_RECOVERY_MIN_CLIMB_DB,
             "stuck-recovery must pull noise_floor up under persistent signal; \
              observed climb of only {climb_db:.2} dB \
              ({floor_after_settle:.2} dB → {floor_after_creep:.2} dB) (#348)"
         );
 
-        // Now drop the signal well below the new floor. With
-        // the fix the gate closes promptly because the floor
-        // has already climbed (so the close-margin gate of the
-        // EMA update fires + fast track-down), returning the
-        // squelch to its normal closed-on-silence behavior.
-        let silence = vec![Complex::new(0.000_01, 0.0); 128];
-        for _ in 0..50 {
+        // Drop the signal well below the new floor. With the
+        // fix the gate closes promptly because the floor has
+        // already climbed (so the close-margin gate of the EMA
+        // update fires + fast track-down), returning the squelch
+        // to its normal closed-on-silence behavior.
+        let silence =
+            vec![Complex::new(STUCK_RECOVERY_SILENCE_AMPLITUDE, 0.0); STUCK_RECOVERY_BLOCK_LEN];
+        for _ in 0..STUCK_RECOVERY_SILENCE_BLOCKS {
             squelch.process(&silence, &mut out).unwrap();
         }
         assert!(

--- a/crates/sdr-radio/src/if_chain.rs
+++ b/crates/sdr-radio/src/if_chain.rs
@@ -177,6 +177,14 @@ impl IfChain {
 
         // Stage 2: Squelch (manual or auto)
         if squelch_active {
+            // Snapshot before processing so we can log
+            // open↔closed transitions when auto-squelch is
+            // active — rare (once per voice burst) and useful
+            // for diagnosing gate behavior in the field
+            // (e.g. issue #348). The snapshot is cheap and
+            // gated on `auto_squelch` so manual-only paths pay
+            // nothing.
+            let pre_snapshot = self.squelch.diagnostic_snapshot();
             if current_is_a {
                 self.squelch
                     .process(&self.buf_a[..n], &mut self.buf_b[..n])?;
@@ -185,6 +193,17 @@ impl IfChain {
                     .process(&self.buf_b[..n], &mut self.buf_a[..n])?;
             }
             current_is_a = !current_is_a;
+
+            if pre_snapshot.auto_squelch && pre_snapshot.open != self.squelch.is_open() {
+                let post = self.squelch.diagnostic_snapshot();
+                tracing::debug!(
+                    transition = if post.open { "open" } else { "closed" },
+                    measured_db = post.last_measured_db,
+                    noise_floor_db = post.noise_floor_db,
+                    settle_count = post.settle_count,
+                    "auto-squelch gate transition"
+                );
+            }
         }
 
         // Stage 3: FM IF noise reduction


### PR DESCRIPTION
## Summary

- Auto-squelch has been silently broken on channels with a persistent carrier (NFM LMR/trunked control channels, strong-signal WFM, etc.): once the 50-block settle window captured live signal, `noise_floor_db` locked high and the gate stayed open forever. Manual squelch was fine; auto had "no effect." Reproduced on both the macOS SwiftUI build and the Linux GTK build since they share the same algorithm — not a regression from any recent PR, likely an always-present algorithmic corner that the empirical-testing PRs happened to expose.
- Root cause: `PowerSquelch::process`'s post-settle EMA update only fired when the gate was closed OR the measurement was within `AUTO_SQUELCH_CLOSE_MARGIN_DB` of the floor. On a persistent carrier neither is ever true, so the floor never moved and the close threshold (`noise_floor + CLOSE_MARGIN`) never rose to meet the signal.
- Fix: second post-settle branch — when the gate is open AND the signal is above close margin, still update the floor but at a very slow alpha (`NOISE_FLOOR_STUCK_RECOVERY_ALPHA = 0.002`). A persistent 25 dB carrier pulls the floor into the close margin in ~7 seconds; short voice bursts (1–2 s) barely move the floor.

## Before / after (live RTL-SDR on 453.950 MHz, NFM)

**Before** — heartbeat snapshot, `noise_floor` frozen at -74.99, gate `open=true` indefinitely despite intermittent voice traffic.

**After** — real transitions on voice bursts, floor tracks ambient:
\`\`\`
22:44:27.185  transition→open   measured=-45.8  noise_floor=-65.8
22:44:28.272  transition→closed measured=-53.5  noise_floor=-58.1
\`\`\`

## Changes

- `crates/sdr-dsp/src/noise.rs`
  - New const `NOISE_FLOOR_STUCK_RECOVERY_ALPHA = 0.002` with math in the docstring.
  - New else-branch in `process()` post-settle that updates the floor at the slow alpha.
  - New `last_measured_db` field on `PowerSquelch` + `PowerSquelchDiagnostic` struct + `diagnostic_snapshot()` getter — lets higher-level crates log state without dragging `tracing` into `sdr-dsp` (which stays pure-DSP per CLAUDE.md).
  - Regression test \`test_auto_squelch_recovers_from_overshoot_settle\`: drives 50 settle blocks + 500 post-settle blocks of persistent carrier, asserts ≥ 10 dB floor climb, then asserts the gate closes on silence. Without the fix the floor stays flat and the gate never closes.
- `crates/sdr-radio/src/if_chain.rs`
  - Emits a \`tracing::debug!\` on every auto-squelch open↔closed transition. Rare (once per voice burst), valuable for field diagnosis.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p sdr-dsp --lib\` — 29 pass (includes the new regression test)
- [x] \`cargo build --workspace --release\`
- [x] \`make ffi-header-check\`
- [x] \`xcodebuild -scheme SDRMac -configuration Debug\` — BUILD SUCCEEDED
- [x] Live RTL-SDR on NFM 453.950 MHz: gate now transitions open/closed with actual voice traffic; `noise_floor` stabilizes ~-55 to -59 dB; audio cuts between transmissions as expected

Closes #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-squelch recovery improved: noise floor now gradually rises during sustained strong signals to avoid getting stuck open.
  * Added runtime diagnostic snapshot exposing last-measured level and squelch state.

* **Tests**
  * Regression test validating auto-squelch recovery and gate behavior after sustained carrier then silence.

* **Chores**
  * Added conditional debug logging for auto-squelch open/close transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->