### PR TITLE
feat(sink): wire network audio sink end-to-end — #247 part 1 (engine + GTK)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -240,6 +240,14 @@ struct DspState {
     network_sink_port: u16,
     /// Network sink protocol. Defaults to TCP server.
     network_sink_protocol: sdr_types::Protocol,
+    /// Latched after a terminal `write_samples` failure
+    /// (`SinkError::Disconnected` / `NotRunning`) so the next
+    /// audio block doesn't re-fire the same warning + status
+    /// event. Cleared on every successful `audio_sink.start()`
+    /// — which means a sink-type swap, a network reconfig
+    /// rebuild, or a fresh engine `Start` all rearm the path.
+    /// Per `CodeRabbit` round 2 on PR #351.
+    audio_sink_offline: bool,
     running: bool,
     center_freq: f64,
     sample_rate: f64,
@@ -377,6 +385,7 @@ impl DspState {
             network_sink_host: DEFAULT_NETWORK_SINK_HOST.to_string(),
             network_sink_port: DEFAULT_NETWORK_SINK_PORT,
             network_sink_protocol: DEFAULT_NETWORK_SINK_PROTOCOL,
+            audio_sink_offline: false,
             running: false,
             center_freq: DEFAULT_CENTER_FREQ,
             sample_rate: DEFAULT_SAMPLE_RATE,
@@ -437,6 +446,14 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                     // the UI sees a real `NetworkSinkStatus::Error` event
                     // instead of a generic toast.
                     let start_result = state.audio_sink.start();
+                    // Successful start re-arms the write path —
+                    // see `audio_sink_offline` docstring. We
+                    // clear *before* discriminating success vs
+                    // failure so a successful start never leaves
+                    // the gate latched from a previous session.
+                    if start_result.is_ok() {
+                        state.audio_sink_offline = false;
+                    }
                     let is_network = matches!(state.audio_sink_type, AudioSinkType::Network);
                     if let Err(e) = start_result {
                         tracing::warn!(
@@ -938,6 +955,12 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             if state.audio_sink_type == new_type {
                 return;
             }
+            // Snapshot the previous type so the post-swap
+            // status logic can emit the correct "transitioning
+            // away from network" event even when the
+            // replacement local sink fails to start. Per
+            // CodeRabbit round 2 on PR #351.
+            let prev_type = state.audio_sink_type;
             // Stop the current sink so it releases its underlying
             // resource (audio device handle / socket) before we
             // construct the replacement.
@@ -974,6 +997,9 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             if state.running {
                 match state.audio_sink.start() {
                     Ok(()) => {
+                        // Successful start clears the offline
+                        // latch so the audio write path resumes.
+                        state.audio_sink_offline = false;
                         if matches!(new_type, AudioSinkType::Network) {
                             let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(
                                 NetworkSinkStatus::Active {
@@ -1003,6 +1029,15 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                         } else {
                             let _ = dsp_tx
                                 .send(DspToUi::Error(format!("Audio sink failed to start: {e}")));
+                            // Even on failure, the network sink
+                            // is gone — emit Inactive so the
+                            // panel's status row clears its
+                            // "Active" state. Per CodeRabbit
+                            // round 2 on PR #351.
+                            if matches!(prev_type, AudioSinkType::Network) {
+                                let _ = dsp_tx
+                                    .send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive));
+                            }
                         }
                     }
                 }
@@ -1041,6 +1076,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 if state.running {
                     match state.audio_sink.start() {
                         Ok(()) => {
+                            state.audio_sink_offline = false;
                             let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(
                                 NetworkSinkStatus::Active {
                                     endpoint: format!("{hostname}:{port}"),
@@ -1774,9 +1810,21 @@ fn process_iq_block(
                                 .audio_frames_written
                                 .saturating_add(audio_count as u64);
                         }
-                        if let Err(e) = state
-                            .audio_sink
-                            .write_samples(&state.audio_buf[..audio_count])
+                        // Skip the write if the sink has already
+                        // gone offline this session. Without this
+                        // gate, every audio block would re-trip
+                        // the terminal-error branch below (the
+                        // sink stays in place after stop(), so
+                        // `write_samples` keeps returning
+                        // NotRunning) and re-emit the same
+                        // status/error event at DSP cadence —
+                        // ~50 events/sec of log noise + UI churn.
+                        // Per `CodeRabbit` round 2 on PR #351.
+                        // Cleared on the next successful start.
+                        if !state.audio_sink_offline
+                            && let Err(e) = state
+                                .audio_sink
+                                .write_samples(&state.audio_buf[..audio_count])
                         {
                             // Terminal failures: surface to UI once and stop the sink.
                             if matches!(e, SinkError::Disconnected | SinkError::NotRunning) {
@@ -1800,6 +1848,10 @@ fn process_iq_block(
                                     ));
                                 }
                                 let _ = state.audio_sink.stop();
+                                // Latch — see the docstring on
+                                // `audio_sink_offline` for the
+                                // full one-shot rationale.
+                                state.audio_sink_offline = true;
                             } else {
                                 tracing::debug!("audio write: {e}");
                             }

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -139,7 +139,7 @@ fn dsp_thread_main(
                     Err(mpsc::TryRecvError::Empty) => break,
                     Err(mpsc::TryRecvError::Disconnected) => {
                         tracing::info!("UI channel disconnected — DSP thread exiting");
-                        cleanup(&mut state);
+                        cleanup(&mut state, &dsp_tx);
                         return;
                     }
                 }
@@ -446,14 +446,15 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                     // the UI sees a real `NetworkSinkStatus::Error` event
                     // instead of a generic toast.
                     let start_result = state.audio_sink.start();
-                    // Successful start re-arms the write path —
-                    // see `audio_sink_offline` docstring. We
-                    // clear *before* discriminating success vs
-                    // failure so a successful start never leaves
-                    // the gate latched from a previous session.
-                    if start_result.is_ok() {
-                        state.audio_sink_offline = false;
-                    }
+                    // Re-arm or latch the write path based on
+                    // the start outcome. See the
+                    // `audio_sink_offline` docstring for the
+                    // full one-shot rationale — failed starts
+                    // must latch, otherwise the next DSP block
+                    // would re-fire the same terminal error
+                    // when `write_samples` hits the stopped
+                    // sink. Per CodeRabbit round 6 on PR #351.
+                    state.audio_sink_offline = start_result.is_err();
                     let is_network = matches!(state.audio_sink_type, AudioSinkType::Network);
                     if let Err(e) = start_result {
                         tracing::warn!(
@@ -532,18 +533,12 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             // is tearing down and any registered FFI consumer is about to
             // see a `Disconnected` on their next pull regardless.
             state.audio_tap_tx = None;
-            // If a network sink was streaming, snapshot the type
-            // BEFORE cleanup() takes the sink offline so the
-            // post-cleanup Inactive event reports the right
-            // discriminant. Per CodeRabbit round 1 on PR #351 —
-            // status events must reflect real lifecycle, not
-            // just selected-type.
-            let was_network_sink = matches!(state.audio_sink_type, AudioSinkType::Network);
-            cleanup(state);
+            // `cleanup` now emits `NetworkSinkStatus::Inactive` itself
+            // when the active sink was Network — same path used by the
+            // file-EOF, fatal-source-error, and source-type restart
+            // sites so every real stop transition reports Inactive.
+            cleanup(state, dsp_tx);
             state.running = false;
-            if was_network_sink {
-                let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive));
-            }
             let _ = dsp_tx.send(DspToUi::SourceStopped);
         }
 
@@ -1019,6 +1014,10 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                         }
                     }
                     Err(e) => {
+                        // Latch so the next DSP block doesn't re-fire
+                        // the same terminal error against a stopped
+                        // sink. Per CodeRabbit round 6 on PR #351.
+                        state.audio_sink_offline = true;
                         tracing::warn!("audio sink start after type swap failed: {e}");
                         if matches!(new_type, AudioSinkType::Network) {
                             let _ =
@@ -1084,6 +1083,8 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                             ));
                         }
                         Err(e) => {
+                            // Latch — per CodeRabbit round 6 on PR #351.
+                            state.audio_sink_offline = true;
                             tracing::warn!("network sink restart after reconfig failed: {e}");
                             let _ =
                                 dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
@@ -1103,7 +1104,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             tracing::info!(?source_type, "switching source type");
             let was_running = state.running;
             if was_running {
-                cleanup(state);
+                cleanup(state, dsp_tx);
                 state.running = false;
             }
             state.source_type = source_type;
@@ -1165,6 +1166,8 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                                 }
                             }
                             Err(e) => {
+                                // Latch — per CodeRabbit round 6 on PR #351.
+                                state.audio_sink_offline = true;
                                 tracing::warn!("audio sink restart failed: {e}");
                                 if is_network {
                                     let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(
@@ -1430,14 +1433,27 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
 }
 
 /// Stop the source and release resources.
-fn cleanup(state: &mut DspState) {
+fn cleanup(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
     if let Some(source) = &mut state.source {
         let _ = source.stop();
     }
 
+    // Snapshot whether the network sink was active BEFORE we
+    // stop it so the post-stop status emit reports the right
+    // discriminant. Centralized here (rather than at each
+    // caller) so file-EOF, fatal-source-error, and source-type
+    // restart paths all emit the matching `Inactive` event
+    // alongside the explicit `UiToDsp::Stop` path. Per
+    // `CodeRabbit` round 6 on PR #351.
+    let was_network_sink = matches!(state.audio_sink_type, AudioSinkType::Network);
+
     // Stop the audio sink so it doesn't try to read stale data.
     if let Err(e) = state.audio_sink.stop() {
         tracing::debug!("audio sink stop: {e}");
+    }
+
+    if was_network_sink {
+        let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive));
     }
 
     // Finalize any active recordings (Drop patches the WAV header sizes).
@@ -1538,7 +1554,7 @@ fn process_iq_block(
             // File sources return Ok(0) at EOF — stop playback cleanly
             if state.source_type == SourceType::File {
                 tracing::info!("file source reached EOF");
-                cleanup(state);
+                cleanup(state, dsp_tx);
                 state.running = false;
                 let _ = dsp_tx.send(DspToUi::SourceStopped);
             }
@@ -1588,7 +1604,7 @@ fn process_iq_block(
                 sdr_types::SourceError::ReadFailed(_) | sdr_types::SourceError::NotRunning
             ) {
                 tracing::error!("fatal source error: {e}");
-                cleanup(state);
+                cleanup(state, dsp_tx);
                 state.running = false;
                 let _ = dsp_tx.send(DspToUi::Error(format!("Source error: {e}")));
                 let _ = dsp_tx.send(DspToUi::SourceStopped);

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1129,10 +1129,26 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             if was_running {
                 match open_source(state) {
                     Ok(()) => {
-                        if let Err(e) = state.audio_sink.start() {
-                            tracing::warn!("audio sink restart failed: {e}");
-                            let _ =
-                                dsp_tx.send(DspToUi::Error(format!("Audio output failed: {e}")));
+                        // Clear the audio-sink offline latch on
+                        // a successful restart, same as the
+                        // other successful-start paths (engine
+                        // Start, SetAudioSinkType,
+                        // SetNetworkSinkConfig). Without this,
+                        // a prior-session terminal write
+                        // failure could leave the latch set
+                        // through a source-type swap and gate
+                        // writes off until the next explicit
+                        // Start command. Per `CodeRabbit`
+                        // round 3 on PR #351.
+                        match state.audio_sink.start() {
+                            Ok(()) => {
+                                state.audio_sink_offline = false;
+                            }
+                            Err(e) => {
+                                tracing::warn!("audio sink restart failed: {e}");
+                                let _ = dsp_tx
+                                    .send(DspToUi::Error(format!("Audio output failed: {e}")));
+                            }
                         }
                         state.running = true;
                         // Refresh UI with new source capabilities

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1139,14 +1139,43 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                         // writes off until the next explicit
                         // Start command. Per `CodeRabbit`
                         // round 3 on PR #351.
+                        // Mirror the network-specific lifecycle
+                        // events the other start paths emit
+                        // (engine Start, SetAudioSinkType,
+                        // SetNetworkSinkConfig). Without these,
+                        // a source-type swap could leave the
+                        // GTK network status row stuck on a
+                        // stale Active or Error from before the
+                        // swap. Per `CodeRabbit` round 5 on
+                        // PR #351.
+                        let is_network = matches!(state.audio_sink_type, AudioSinkType::Network);
                         match state.audio_sink.start() {
                             Ok(()) => {
                                 state.audio_sink_offline = false;
+                                if is_network {
+                                    let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(
+                                        NetworkSinkStatus::Active {
+                                            endpoint: format!(
+                                                "{}:{}",
+                                                state.network_sink_host, state.network_sink_port
+                                            ),
+                                            protocol: state.network_sink_protocol,
+                                        },
+                                    ));
+                                }
                             }
                             Err(e) => {
                                 tracing::warn!("audio sink restart failed: {e}");
-                                let _ = dsp_tx
-                                    .send(DspToUi::Error(format!("Audio output failed: {e}")));
+                                if is_network {
+                                    let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(
+                                        NetworkSinkStatus::Error {
+                                            message: format!("{e}"),
+                                        },
+                                    ));
+                                } else {
+                                    let _ = dsp_tx
+                                        .send(DspToUi::Error(format!("Audio output failed: {e}")));
+                                }
                             }
                         }
                         state.running = true;

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -20,10 +20,14 @@ use std::time::Duration;
 
 use sdr_dsp::channel::RxVfo;
 use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
-use sdr_pipeline::sink_manager::Sink;
 use sdr_pipeline::source_manager::Source;
+
+use crate::sink_slot::{AudioSinkSlot, AudioSinkType, NetworkSinkStatus};
 use sdr_radio::RadioModule;
-use sdr_sink_audio::AudioSink;
+// `AudioSink` and `NetworkSink` are no longer used directly here —
+// both live behind `AudioSinkSlot` (see `crate::sink_slot`) so the
+// controller's audio path stays uniform regardless of which sink
+// the user has selected.
 use sdr_source_rtlsdr::RtlSdrSource;
 use sdr_types::{Complex, RtlTcpConnectionState, SinkError, Stereo};
 
@@ -211,7 +215,28 @@ struct DspState {
     source: Option<Box<dyn Source>>,
     frontend: IqFrontend,
     radio: RadioModule,
-    audio_sink: AudioSink,
+    audio_sink: AudioSinkSlot,
+    /// Which sink variant is currently active. Mirror of
+    /// `audio_sink.kind()` kept on the state so handlers can
+    /// branch on type without matching the enum every time. Per
+    /// issue #247.
+    audio_sink_type: AudioSinkType,
+    /// Last user-picked local audio device UID (`PipeWire` node
+    /// name on Linux, `AudioDevice` UID on macOS). Empty string =
+    /// system default. Persisted across sink-type swaps so a
+    /// Network → Local switch reapplies the user's prior device
+    /// pick instead of falling back to default.
+    audio_device_uid: String,
+    /// Network sink hostname. Defaults to `localhost` to match
+    /// the GTK source-network panel's defaults so switching to
+    /// the network sink without an explicit configure step still
+    /// produces a usable bind.
+    network_sink_host: String,
+    /// Network sink port. Defaults to `1234` matching the
+    /// existing IQ source-network port default.
+    network_sink_port: u16,
+    /// Network sink protocol. Defaults to TCP server.
+    network_sink_protocol: sdr_types::Protocol,
     running: bool,
     center_freq: f64,
     sample_rate: f64,
@@ -343,7 +368,12 @@ impl DspState {
             source: None,
             frontend,
             radio,
-            audio_sink: AudioSink::new(),
+            audio_sink: AudioSinkSlot::local_default(),
+            audio_sink_type: AudioSinkType::Local,
+            audio_device_uid: String::new(),
+            network_sink_host: "localhost".to_string(),
+            network_sink_port: 1234,
+            network_sink_protocol: sdr_types::Protocol::TcpClient,
             running: false,
             center_freq: DEFAULT_CENTER_FREQ,
             sample_rate: DEFAULT_SAMPLE_RATE,
@@ -847,9 +877,105 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetAudioDevice(node_name) => {
             tracing::info!(target_node = %node_name, "set audio device");
+            // Persist the UID so a future Network → Local
+            // sink-type swap can re-apply the user's pick
+            // instead of falling back to the system default.
+            // Per issue #247.
+            state.audio_device_uid.clone_from(&node_name);
             if let Err(e) = state.audio_sink.set_target(&node_name) {
                 tracing::warn!("audio device switch failed: {e}");
                 let _ = dsp_tx.send(DspToUi::Error(format!("Audio device switch failed: {e}")));
+            }
+        }
+
+        UiToDsp::SetAudioSinkType(new_type) => {
+            tracing::info!(?new_type, "set audio sink type");
+            if state.audio_sink_type == new_type {
+                return;
+            }
+            // Stop the current sink so it releases its underlying
+            // resource (audio device handle / socket) before we
+            // construct the replacement.
+            if let Err(e) = state.audio_sink.stop() {
+                tracing::warn!("audio sink stop during type swap failed: {e}");
+            }
+            // Build the new sink.
+            state.audio_sink = match new_type {
+                AudioSinkType::Local => AudioSinkSlot::local_default(),
+                AudioSinkType::Network => AudioSinkSlot::network(
+                    &state.network_sink_host,
+                    state.network_sink_port,
+                    state.network_sink_protocol,
+                ),
+            };
+            state.audio_sink_type = new_type;
+            // Re-apply the persisted local-device pick so the
+            // post-swap Local sink routes to the user's last
+            // choice instead of the system default. No-op for
+            // Network.
+            if matches!(new_type, AudioSinkType::Local) {
+                let target = state.audio_device_uid.clone();
+                if let Err(e) = state.audio_sink.set_target(&target) {
+                    tracing::warn!("post-swap set_target failed: {e}");
+                }
+            }
+            // Bring the new sink online if the engine is already
+            // running. Otherwise it'll start on the next Start
+            // command.
+            if state.running
+                && let Err(e) = state.audio_sink.start()
+            {
+                tracing::warn!("audio sink start after type swap failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("Audio sink failed to start: {e}")));
+                if matches!(new_type, AudioSinkType::Network) {
+                    let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
+                        message: format!("{e}"),
+                    }));
+                }
+                return;
+            }
+            // Notify the UI of the new sink state.
+            let event = match new_type {
+                AudioSinkType::Local => NetworkSinkStatus::Inactive,
+                AudioSinkType::Network => NetworkSinkStatus::Active {
+                    endpoint: format!("{}:{}", state.network_sink_host, state.network_sink_port),
+                    protocol: state.network_sink_protocol,
+                },
+            };
+            let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(event));
+        }
+
+        UiToDsp::SetNetworkSinkConfig {
+            hostname,
+            port,
+            protocol,
+        } => {
+            tracing::info!(%hostname, port, ?protocol, "set network sink config");
+            // Persist on state so a future SetAudioSinkType swap
+            // picks the new values up.
+            state.network_sink_host.clone_from(&hostname);
+            state.network_sink_port = port;
+            state.network_sink_protocol = protocol;
+            // If the network sink is currently active, rebuild
+            // it inline so the new endpoint takes effect now.
+            if matches!(state.audio_sink_type, AudioSinkType::Network) {
+                if let Err(e) = state.audio_sink.stop() {
+                    tracing::warn!("network sink stop during reconfig failed: {e}");
+                }
+                state.audio_sink = AudioSinkSlot::network(&hostname, port, protocol);
+                if state.running
+                    && let Err(e) = state.audio_sink.start()
+                {
+                    tracing::warn!("network sink restart after reconfig failed: {e}");
+                    let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
+                        message: format!("{e}"),
+                    }));
+                    return;
+                }
+                let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Active {
+                    endpoint: format!("{hostname}:{port}"),
+                    protocol,
+                }));
             }
         }
 
@@ -1569,10 +1695,25 @@ fn process_iq_block(
                         {
                             // Terminal failures: surface to UI once and stop the sink.
                             if matches!(e, SinkError::Disconnected | SinkError::NotRunning) {
-                                tracing::warn!("audio sink died: {e}");
-                                let _ = dsp_tx.send(DspToUi::Error(
-                                    "Audio output lost — restart playback".to_string(),
-                                ));
+                                tracing::warn!(
+                                    sink_type = ?state.audio_sink_type,
+                                    "audio sink died: {e}"
+                                );
+                                // Distinct event for the network sink so the
+                                // settings panel's status row can update
+                                // independently of the toast for local
+                                // device failures. Per issue #247.
+                                if matches!(state.audio_sink_type, AudioSinkType::Network) {
+                                    let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(
+                                        NetworkSinkStatus::Error {
+                                            message: format!("{e}"),
+                                        },
+                                    ));
+                                } else {
+                                    let _ = dsp_tx.send(DspToUi::Error(
+                                        "Audio output lost — restart playback".to_string(),
+                                    ));
+                                }
                                 let _ = state.audio_sink.stop();
                             } else {
                                 tracing::debug!("audio write: {e}");

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -981,11 +981,10 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             // post-swap Local sink routes to the user's last
             // choice instead of the system default. No-op for
             // Network.
-            if matches!(new_type, AudioSinkType::Local) {
-                let target = state.audio_device_uid.clone();
-                if let Err(e) = state.audio_sink.set_target(&target) {
-                    tracing::warn!("post-swap set_target failed: {e}");
-                }
+            if matches!(new_type, AudioSinkType::Local)
+                && let Err(e) = state.audio_sink.set_target(&state.audio_device_uid)
+            {
+                tracing::warn!("post-swap set_target failed: {e}");
             }
             // Bring the new sink online if the engine is already
             // running. Otherwise it'll start on the next Start

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -22,7 +22,10 @@ use sdr_dsp::channel::RxVfo;
 use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
 use sdr_pipeline::source_manager::Source;
 
-use crate::sink_slot::{AudioSinkSlot, AudioSinkType, NetworkSinkStatus};
+use crate::sink_slot::{
+    AudioSinkSlot, AudioSinkType, DEFAULT_NETWORK_SINK_HOST, DEFAULT_NETWORK_SINK_PORT,
+    DEFAULT_NETWORK_SINK_PROTOCOL, NetworkSinkStatus,
+};
 use sdr_radio::RadioModule;
 // `AudioSink` and `NetworkSink` are no longer used directly here —
 // both live behind `AudioSinkSlot` (see `crate::sink_slot`) so the
@@ -371,9 +374,9 @@ impl DspState {
             audio_sink: AudioSinkSlot::local_default(),
             audio_sink_type: AudioSinkType::Local,
             audio_device_uid: String::new(),
-            network_sink_host: "localhost".to_string(),
-            network_sink_port: 1234,
-            network_sink_protocol: sdr_types::Protocol::TcpClient,
+            network_sink_host: DEFAULT_NETWORK_SINK_HOST.to_string(),
+            network_sink_port: DEFAULT_NETWORK_SINK_PORT,
+            network_sink_protocol: DEFAULT_NETWORK_SINK_PROTOCOL,
             running: false,
             center_freq: DEFAULT_CENTER_FREQ,
             sample_rate: DEFAULT_SAMPLE_RATE,
@@ -429,10 +432,42 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             match open_source(state) {
                 Ok(()) => {
                     // Start the audio sink -- if it fails, log but continue
-                    // so the spectrum display still works.
-                    if let Err(e) = state.audio_sink.start() {
-                        tracing::warn!("audio sink failed to start (spectrum still works): {e}");
-                        let _ = dsp_tx.send(DspToUi::Error(format!("Audio output failed: {e}")));
+                    // so the spectrum display still works. Discriminate the
+                    // error path by sink type so the network status row in
+                    // the UI sees a real `NetworkSinkStatus::Error` event
+                    // instead of a generic toast.
+                    let start_result = state.audio_sink.start();
+                    let is_network = matches!(state.audio_sink_type, AudioSinkType::Network);
+                    if let Err(e) = start_result {
+                        tracing::warn!(
+                            sink_type = ?state.audio_sink_type,
+                            "audio sink failed to start (spectrum still works): {e}"
+                        );
+                        if is_network {
+                            let _ =
+                                dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
+                                    message: format!("{e}"),
+                                }));
+                        } else {
+                            let _ =
+                                dsp_tx.send(DspToUi::Error(format!("Audio output failed: {e}")));
+                        }
+                    } else if is_network {
+                        // Successful start of a network sink — this is the
+                        // moment the panel's status row should flip to
+                        // "Streaming to ...". Driving status from real
+                        // start/stop transitions (rather than the
+                        // sink-type swap) keeps the UI honest about what's
+                        // actually on the wire. Per CodeRabbit round 1 on
+                        // PR #351.
+                        let _ =
+                            dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Active {
+                                endpoint: format!(
+                                    "{}:{}",
+                                    state.network_sink_host, state.network_sink_port
+                                ),
+                                protocol: state.network_sink_protocol,
+                            }));
                     }
                     state.running = true;
                     tracing::info!("DSP pipeline started");
@@ -480,8 +515,18 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             // is tearing down and any registered FFI consumer is about to
             // see a `Disconnected` on their next pull regardless.
             state.audio_tap_tx = None;
+            // If a network sink was streaming, snapshot the type
+            // BEFORE cleanup() takes the sink offline so the
+            // post-cleanup Inactive event reports the right
+            // discriminant. Per CodeRabbit round 1 on PR #351 —
+            // status events must reflect real lifecycle, not
+            // just selected-type.
+            let was_network_sink = matches!(state.audio_sink_type, AudioSinkType::Network);
             cleanup(state);
             state.running = false;
+            if was_network_sink {
+                let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive));
+            }
             let _ = dsp_tx.send(DspToUi::SourceStopped);
         }
 
@@ -921,28 +966,54 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             }
             // Bring the new sink online if the engine is already
             // running. Otherwise it'll start on the next Start
-            // command.
-            if state.running
-                && let Err(e) = state.audio_sink.start()
-            {
-                tracing::warn!("audio sink start after type swap failed: {e}");
-                let _ = dsp_tx.send(DspToUi::Error(format!("Audio sink failed to start: {e}")));
-                if matches!(new_type, AudioSinkType::Network) {
-                    let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
-                        message: format!("{e}"),
-                    }));
+            // command — and we emit `Inactive` rather than
+            // `Active` because the sink isn't really on the wire
+            // yet. Per CodeRabbit round 1 on PR #351, status
+            // events must reflect REAL lifecycle, not just the
+            // user's selected type.
+            if state.running {
+                match state.audio_sink.start() {
+                    Ok(()) => {
+                        if matches!(new_type, AudioSinkType::Network) {
+                            let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(
+                                NetworkSinkStatus::Active {
+                                    endpoint: format!(
+                                        "{}:{}",
+                                        state.network_sink_host, state.network_sink_port
+                                    ),
+                                    protocol: state.network_sink_protocol,
+                                },
+                            ));
+                        } else {
+                            // Switched away from network → that
+                            // sink is no longer streaming. Emit
+                            // Inactive so the panel's status row
+                            // clears.
+                            let _ = dsp_tx
+                                .send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive));
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("audio sink start after type swap failed: {e}");
+                        if matches!(new_type, AudioSinkType::Network) {
+                            let _ =
+                                dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
+                                    message: format!("{e}"),
+                                }));
+                        } else {
+                            let _ = dsp_tx
+                                .send(DspToUi::Error(format!("Audio sink failed to start: {e}")));
+                        }
+                    }
                 }
-                return;
+            } else {
+                // Engine not running — nothing is on the wire.
+                // Always emit Inactive so the panel doesn't
+                // misreport a not-yet-bound sink as Active. The
+                // matching Active will fire from the Start
+                // handler if/when the user starts the engine.
+                let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive));
             }
-            // Notify the UI of the new sink state.
-            let event = match new_type {
-                AudioSinkType::Local => NetworkSinkStatus::Inactive,
-                AudioSinkType::Network => NetworkSinkStatus::Active {
-                    endpoint: format!("{}:{}", state.network_sink_host, state.network_sink_port),
-                    protocol: state.network_sink_protocol,
-                },
-            };
-            let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(event));
         }
 
         UiToDsp::SetNetworkSinkConfig {
@@ -956,26 +1027,40 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             state.network_sink_host.clone_from(&hostname);
             state.network_sink_port = port;
             state.network_sink_protocol = protocol;
-            // If the network sink is currently active, rebuild
+            // If the network sink is currently selected, rebuild
             // it inline so the new endpoint takes effect now.
+            // Status events fire only on the real start
+            // outcome (Active on success, Error on failure,
+            // Inactive when the engine isn't running yet) — per
+            // CodeRabbit round 1 on PR #351.
             if matches!(state.audio_sink_type, AudioSinkType::Network) {
                 if let Err(e) = state.audio_sink.stop() {
                     tracing::warn!("network sink stop during reconfig failed: {e}");
                 }
                 state.audio_sink = AudioSinkSlot::network(&hostname, port, protocol);
-                if state.running
-                    && let Err(e) = state.audio_sink.start()
-                {
-                    tracing::warn!("network sink restart after reconfig failed: {e}");
-                    let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
-                        message: format!("{e}"),
-                    }));
-                    return;
+                if state.running {
+                    match state.audio_sink.start() {
+                        Ok(()) => {
+                            let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(
+                                NetworkSinkStatus::Active {
+                                    endpoint: format!("{hostname}:{port}"),
+                                    protocol,
+                                },
+                            ));
+                        }
+                        Err(e) => {
+                            tracing::warn!("network sink restart after reconfig failed: {e}");
+                            let _ =
+                                dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
+                                    message: format!("{e}"),
+                                }));
+                        }
+                    }
+                } else {
+                    // Engine not running — sink rebuilt but not
+                    // bound. Status stays Inactive.
+                    let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive));
                 }
-                let _ = dsp_tx.send(DspToUi::NetworkSinkStatus(NetworkSinkStatus::Active {
-                    endpoint: format!("{hostname}:{port}"),
-                    protocol,
-                }));
             }
         }
 

--- a/crates/sdr-core/src/lib.rs
+++ b/crates/sdr-core/src/lib.rs
@@ -39,9 +39,11 @@ mod controller;
 pub mod engine;
 pub mod fft_buffer;
 pub mod messages;
+pub mod sink_slot;
 pub mod wav_writer;
 
 pub use engine::{Engine, EngineError};
 pub use fft_buffer::SharedFftBuffer;
 pub use messages::{DspToUi, SourceType, UiToDsp};
+pub use sink_slot::{AudioSinkSlot, AudioSinkType, NetworkSinkStatus};
 pub use wav_writer::WavWriter;

--- a/crates/sdr-core/src/lib.rs
+++ b/crates/sdr-core/src/lib.rs
@@ -45,5 +45,8 @@ pub mod wav_writer;
 pub use engine::{Engine, EngineError};
 pub use fft_buffer::SharedFftBuffer;
 pub use messages::{DspToUi, SourceType, UiToDsp};
-pub use sink_slot::{AudioSinkSlot, AudioSinkType, NetworkSinkStatus};
+pub use sink_slot::{
+    AudioSinkSlot, AudioSinkType, DEFAULT_NETWORK_SINK_HOST, DEFAULT_NETWORK_SINK_PORT,
+    DEFAULT_NETWORK_SINK_PROTOCOL, NetworkSinkStatus,
+};
 pub use wav_writer::WavWriter;

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -366,6 +366,39 @@ mod tests {
             failed,
             DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Failed { .. })
         ));
+
+        // Network audio sink status (issue #247) — three
+        // variants exercising each shape so a future payload
+        // tweak (e.g. adding a bytes_sent counter) trips this
+        // regression net rather than silently going quiet at
+        // the GTK status-row renderer. Per CodeRabbit round 1
+        // on PR #351.
+        let net_active = DspToUi::NetworkSinkStatus(NetworkSinkStatus::Active {
+            endpoint: "0.0.0.0:1234".to_string(),
+            protocol: sdr_types::Protocol::TcpClient,
+        });
+        assert!(matches!(
+            &net_active,
+            DspToUi::NetworkSinkStatus(NetworkSinkStatus::Active {
+                endpoint,
+                protocol: sdr_types::Protocol::TcpClient,
+            }) if endpoint == "0.0.0.0:1234"
+        ));
+
+        let net_inactive = DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive);
+        assert!(matches!(
+            net_inactive,
+            DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive)
+        ));
+
+        let net_err = DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error {
+            message: "bind: Address already in use".to_string(),
+        });
+        assert!(matches!(
+            &net_err,
+            DspToUi::NetworkSinkStatus(NetworkSinkStatus::Error { message })
+                if message == "bind: Address already in use"
+        ));
     }
 
     #[test]
@@ -569,6 +602,37 @@ mod tests {
 
         let disable_tap = UiToDsp::DisableAudioTap;
         assert!(matches!(disable_tap, UiToDsp::DisableAudioTap));
+
+        // Network audio sink (issue #247) — constructed here so a
+        // future signature tweak to AudioSinkType, the
+        // SetNetworkSinkConfig field set, or the Protocol type
+        // fails this regression net rather than silently going
+        // quiet at the controller's handler. Per CodeRabbit
+        // round 1 on PR #351.
+        let set_sink_local = UiToDsp::SetAudioSinkType(crate::sink_slot::AudioSinkType::Local);
+        assert!(matches!(
+            set_sink_local,
+            UiToDsp::SetAudioSinkType(crate::sink_slot::AudioSinkType::Local)
+        ));
+        let set_sink_network = UiToDsp::SetAudioSinkType(crate::sink_slot::AudioSinkType::Network);
+        assert!(matches!(
+            set_sink_network,
+            UiToDsp::SetAudioSinkType(crate::sink_slot::AudioSinkType::Network)
+        ));
+
+        let net_cfg = UiToDsp::SetNetworkSinkConfig {
+            hostname: "192.0.2.1".to_string(),
+            port: 4242,
+            protocol: sdr_types::Protocol::Udp,
+        };
+        assert!(matches!(
+            &net_cfg,
+            UiToDsp::SetNetworkSinkConfig {
+                hostname,
+                port: 4242,
+                protocol: sdr_types::Protocol::Udp,
+            } if hostname == "192.0.2.1"
+        ));
 
         // RTL-TCP connection controls (commit 3 of PR #335) —
         // constructed directly so a future signature change (e.g.

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -2,7 +2,9 @@
 
 use sdr_dsp::voice_squelch::VoiceSquelchMode;
 use sdr_radio::{DeemphasisMode, af_chain::CtcssMode};
-use sdr_types::{DemodMode, RtlTcpConnectionState};
+use sdr_types::{DemodMode, Protocol, RtlTcpConnectionState};
+
+use crate::sink_slot::{AudioSinkType, NetworkSinkStatus};
 
 /// Messages sent from the DSP pipeline thread to the UI main loop.
 #[derive(Debug)]
@@ -75,6 +77,13 @@ pub enum DspToUi {
     /// value to reset on source-type changes without needing a
     /// separate "hide the row" signal.
     RtlTcpConnectionState(RtlTcpConnectionState),
+    /// Lifecycle/health update for the network audio sink.
+    /// Emitted on switch boundaries (`Active` / `Inactive`) and
+    /// on startup or write failure (`Error`). Hosts use it to
+    /// drive a status row in the audio settings panel — green
+    /// when streaming, red with the message on failure. Per
+    /// issue #247.
+    NetworkSinkStatus(NetworkSinkStatus),
 }
 
 /// Available source types for IQ input.
@@ -164,6 +173,24 @@ pub enum UiToDsp {
     SetVoiceSquelchThreshold(f32),
     /// Set the audio output device by `PipeWire` node name.
     SetAudioDevice(String),
+    /// Switch the audio sink type (local audio device vs network
+    /// stream). The controller stops the current sink, swaps to
+    /// the new variant using the persisted device/network config,
+    /// and restarts it if the engine is currently running. Per
+    /// issue #247.
+    SetAudioSinkType(AudioSinkType),
+    /// Configure the network audio sink hostname, port, and
+    /// protocol. The controller stores the config on `DspState`
+    /// so a future switch to `AudioSinkType::Network` (or a
+    /// rebuild of an already-active network sink) picks the new
+    /// values up. If the network sink is currently active, the
+    /// controller also rebuilds it inline so the new endpoint
+    /// takes effect immediately. Per issue #247.
+    SetNetworkSinkConfig {
+        hostname: String,
+        port: u16,
+        protocol: Protocol,
+    },
     /// Switch the source type (stops current source if running).
     SetSourceType(SourceType),
     /// Configure network source hostname, port, and protocol.

--- a/crates/sdr-core/src/sink_slot.rs
+++ b/crates/sdr-core/src/sink_slot.rs
@@ -28,6 +28,22 @@ use sdr_sink_audio::AudioSink;
 use sdr_sink_network::NetworkSink;
 use sdr_types::{Protocol, SinkError, Stereo};
 
+/// Default network audio sink hostname. Single source of truth
+/// shared by the engine controller (initial `DspState` value)
+/// and any UI panel that wants to seed an entry-row default.
+/// Per `CodeRabbit` round 1 on PR #351.
+pub const DEFAULT_NETWORK_SINK_HOST: &str = "localhost";
+
+/// Default network audio sink port. Mirrors the IQ
+/// source-network port default (1234) so users see consistent
+/// numbers across the panels.
+pub const DEFAULT_NETWORK_SINK_PORT: u16 = 1234;
+
+/// Default network audio sink protocol. TCP server (matching
+/// SDR++'s `TcpClient` naming convention — the device acts as
+/// the TCP server, accepting client connections).
+pub const DEFAULT_NETWORK_SINK_PROTOCOL: Protocol = Protocol::TcpClient;
+
 /// User-facing audio sink type. Mirrored on the UI side as a
 /// two-option picker (local audio device vs network stream).
 /// Stored on `DspState` so a sink restart (e.g. mode change,

--- a/crates/sdr-core/src/sink_slot.rs
+++ b/crates/sdr-core/src/sink_slot.rs
@@ -1,0 +1,196 @@
+//! Audio output sink multiplexer used by the DSP controller.
+//!
+//! The controller used to hold a single `sdr_sink_audio::AudioSink`
+//! directly. Issue #247 surfaced the problem: the GTK Audio panel
+//! exposed a "Sink type" combo (Audio / Network) but the engine
+//! never honored the selection — `sdr_sink_network::NetworkSink`
+//! existed in the workspace but had no path into the running
+//! pipeline.
+//!
+//! This module wraps both implementations in a single enum so the
+//! controller's audio path stays uniform regardless of the active
+//! sink type. Switching is a state transition: drop the old sink,
+//! construct the new one, restart it if the engine is already
+//! running. The engine's audio block size, format, and rate are
+//! identical for both variants (48 kHz stereo f32) so callers
+//! never have to reformat per type.
+//!
+//! The two underlying sinks ship slightly different write APIs
+//! (`AudioSink::write_samples` vs `NetworkSink::write_stereo_samples`),
+//! so a `Box<dyn Sink>` (the `sdr_pipeline::sink_manager::Sink`
+//! trait) wouldn't compose cleanly — the trait is lifecycle-only,
+//! deliberately leaving the data path per-impl. This enum is the
+//! adapter layer that gives the controller one `write_samples`
+//! method that does the right thing.
+
+use sdr_pipeline::sink_manager::Sink;
+use sdr_sink_audio::AudioSink;
+use sdr_sink_network::NetworkSink;
+use sdr_types::{Protocol, SinkError, Stereo};
+
+/// User-facing audio sink type. Mirrored on the UI side as a
+/// two-option picker (local audio device vs network stream).
+/// Stored on `DspState` so a sink restart (e.g. mode change,
+/// engine restart) recreates the right variant.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AudioSinkType {
+    /// `PipeWire` (Linux) or `CoreAudio` (macOS) — the local
+    /// audio device.
+    #[default]
+    Local,
+    /// TCP server / UDP unicast — see
+    /// `sdr_sink_network::NetworkSink`.
+    Network,
+}
+
+/// Status events the network sink emits to the UI. Currently
+/// surfaces only switch boundaries and write failures; per-frame
+/// TCP-client connect/disconnect tracking would require deeper
+/// instrumentation in `NetworkSink` itself and is left for a
+/// follow-up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkSinkStatus {
+    /// The network sink is now the active audio output.
+    /// `endpoint` is the host:port the engine is bound to (TCP
+    /// server) or sending to (UDP), useful for a status line in
+    /// the UI.
+    Active {
+        endpoint: String,
+        protocol: Protocol,
+    },
+    /// The network sink was switched off, replaced by another
+    /// sink, or the engine stopped.
+    Inactive,
+    /// A startup or write failure took the network sink offline.
+    /// `message` is a human-readable description suitable for a
+    /// toast or status row.
+    Error { message: String },
+}
+
+/// Active audio sink — holds whichever underlying sink the user
+/// last selected. The two variants share lifecycle hooks
+/// (`start` / `stop`) but have differently-named write methods,
+/// so this wrapper exposes a single `write_samples` API for the
+/// controller's hot path.
+pub enum AudioSinkSlot {
+    Local(AudioSink),
+    Network(NetworkSink),
+}
+
+impl AudioSinkSlot {
+    /// Construct the default local sink. Matches the engine's
+    /// pre-#247 behavior so existing callers that build
+    /// `DspState` without an explicit sink-type choice get the
+    /// same audio path they always had.
+    pub fn local_default() -> Self {
+        Self::Local(AudioSink::new())
+    }
+
+    /// Construct a network sink with the given config. The sink
+    /// is **not** started here — caller must call `start()`
+    /// when the engine is ready (typically immediately, or after
+    /// a sink-type switch when the engine is already running).
+    pub fn network(hostname: &str, port: u16, protocol: Protocol) -> Self {
+        Self::Network(NetworkSink::new(hostname, port, protocol))
+    }
+
+    /// Which variant is currently active.
+    pub fn kind(&self) -> AudioSinkType {
+        match self {
+            Self::Local(_) => AudioSinkType::Local,
+            Self::Network(_) => AudioSinkType::Network,
+        }
+    }
+
+    /// Start the underlying sink (open audio device / bind
+    /// socket). Errors if the variant's specific resource
+    /// (audio device, port) is unavailable.
+    pub fn start(&mut self) -> Result<(), SinkError> {
+        match self {
+            Self::Local(s) => s.start(),
+            // `Sink::start` for `NetworkSink` opens the listener
+            // (TCP server) or resolves + binds the UDP socket.
+            // Use UFCS so we don't need to import the trait at
+            // every call site.
+            Self::Network(s) => Sink::start(s),
+        }
+    }
+
+    /// Stop the underlying sink. Idempotent — safe to call
+    /// when already stopped.
+    pub fn stop(&mut self) -> Result<(), SinkError> {
+        match self {
+            Self::Local(s) => s.stop(),
+            Self::Network(s) => Sink::stop(s),
+        }
+    }
+
+    /// Write a block of stereo audio. Routes to the variant's
+    /// preferred write method (the trait's lifecycle-only
+    /// surface doesn't include data, so each variant defines
+    /// its own).
+    pub fn write_samples(&mut self, samples: &[Stereo]) -> Result<(), SinkError> {
+        match self {
+            Self::Local(s) => s.write_samples(samples),
+            Self::Network(s) => s.write_stereo_samples(samples),
+        }
+    }
+
+    /// Pick a specific local audio device by node name. No-op
+    /// (and returns `Ok`) for the network variant, since
+    /// "device selection" doesn't apply — the network sink's
+    /// destination is configured by the host/port/protocol
+    /// triple, not by a device UID.
+    pub fn set_target(&mut self, name: &str) -> Result<(), SinkError> {
+        match self {
+            Self::Local(s) => s.set_target(name),
+            Self::Network(_) => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_default_kind_is_local() {
+        let slot = AudioSinkSlot::local_default();
+        assert_eq!(slot.kind(), AudioSinkType::Local);
+    }
+
+    #[test]
+    fn network_construction_kind_is_network() {
+        let slot = AudioSinkSlot::network("127.0.0.1", 1234, Protocol::TcpClient);
+        assert_eq!(slot.kind(), AudioSinkType::Network);
+    }
+
+    #[test]
+    fn set_target_is_noop_on_network_variant() {
+        // The network sink doesn't have a concept of device
+        // selection — verify `set_target` returns `Ok` without
+        // touching the underlying NetworkSink. Exercising both
+        // a typical UID and the empty-string "system default"
+        // sentinel since those are the two cases the controller
+        // actually emits.
+        let mut slot = AudioSinkSlot::network("127.0.0.1", 1234, Protocol::Udp);
+        assert!(slot.set_target("anything").is_ok());
+        assert!(slot.set_target("").is_ok());
+    }
+
+    #[test]
+    fn variant_swap_round_trip_preserves_kind() {
+        // Mirrors the controller's swap path: construct local,
+        // verify, swap to network, verify, swap back, verify.
+        // Catches a regression where a future refactor
+        // accidentally drops the kind() match arm for one
+        // variant.
+        let mut slot = AudioSinkSlot::local_default();
+        assert_eq!(slot.kind(), AudioSinkType::Local);
+        slot = AudioSinkSlot::network("localhost", 5555, Protocol::TcpClient);
+        assert_eq!(slot.kind(), AudioSinkType::Network);
+        slot = AudioSinkSlot::local_default();
+        assert_eq!(slot.kind(), AudioSinkType::Local);
+    }
+}

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -380,7 +380,14 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         | DspToUi::BandwidthChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
         | DspToUi::VoiceSquelchOpenChanged(_)
-        | DspToUi::RtlTcpConnectionState(_) => return None,
+        | DspToUi::RtlTcpConnectionState(_)
+        // `NetworkSinkStatus` is engine-only in PR 1 (issue #247
+        // engine-side plumbing). The FFI surface gains a
+        // matching `SDR_EVT_NETWORK_SINK_STATUS` variant in PR 2
+        // alongside the FFI command wrappers; until then drop
+        // the event silently rather than dispatching it as a
+        // generic error.
+        | DspToUi::NetworkSinkStatus(_) => return None,
     };
 
     Some((event, owned_cstring, owned_vec))

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -1,7 +1,40 @@
-//! Audio output configuration panel — device and sink type selection.
+//! Audio output configuration panel — device, sink type, network
+//! sink config, and recording toggle.
 
 use libadwaita as adw;
 use libadwaita::prelude::*;
+use sdr_types::Protocol;
+
+/// Sink-type combo discriminants. Keep stable so the
+/// `connect_selected_notify` handler in `window::connect_audio_panel`
+/// can dispatch the right `UiToDsp::SetAudioSinkType` value without
+/// fragile by-string matching.
+pub const SINK_TYPE_LOCAL_IDX: u32 = 0;
+pub const SINK_TYPE_NETWORK_IDX: u32 = 1;
+
+/// Protocol combo discriminants for the network sink. Order
+/// must match the model strings in `build_audio_panel`.
+pub const NETWORK_SINK_PROTOCOL_TCP_IDX: u32 = 0;
+pub const NETWORK_SINK_PROTOCOL_UDP_IDX: u32 = 1;
+
+/// Default endpoint values. Matches the IQ source-network
+/// defaults so a new install lands on familiar settings.
+pub const NETWORK_SINK_DEFAULT_HOST: &str = "localhost";
+pub const NETWORK_SINK_DEFAULT_PORT: u16 = 1234;
+
+/// Map a combo index to a `Protocol`. Returns `Protocol::TcpClient`
+/// (TCP server mode — see `sdr_sink_network` docs) for the TCP
+/// index, `Protocol::Udp` for the UDP index, and falls back to
+/// TCP server for any unknown index so a future combo expansion
+/// without this lookup updated still produces a sane default.
+#[must_use]
+pub fn protocol_from_combo_idx(idx: u32) -> Protocol {
+    match idx {
+        NETWORK_SINK_PROTOCOL_UDP_IDX => Protocol::Udp,
+        // TCP_IDX (0) and any unknown idx fall through to TCP.
+        _ => Protocol::TcpClient,
+    }
+}
 
 /// Audio output configuration panel with references to interactive rows.
 pub struct AudioPanel {
@@ -15,12 +48,26 @@ pub struct AudioPanel {
     pub device_node_names: Vec<String>,
     /// Toggle to start/stop audio recording.
     pub record_audio_row: adw::SwitchRow,
+    /// Hostname / IP for the network audio sink. Hidden unless
+    /// `Network` is the active sink type.
+    pub network_host_row: adw::EntryRow,
+    /// Port for the network audio sink (1..=65535).
+    pub network_port_row: adw::SpinRow,
+    /// Protocol picker — TCP server (default) or UDP unicast.
+    pub network_protocol_row: adw::ComboRow,
+    /// Status row showing the network sink's current state
+    /// (Active / Inactive / Error). Driven by
+    /// `DspToUi::NetworkSinkStatus` events.
+    pub network_status_row: adw::ActionRow,
 }
 
 /// Build the audio output configuration panel.
 ///
 /// Queries `PipeWire` for available audio output sinks and populates
-/// the device selector dropdown.
+/// the device selector dropdown. The network config rows are built
+/// up front (so the sidebar layout doesn't shift when the user
+/// toggles between sink types) but `set_visible(false)` until
+/// `Network` is the active sink type.
 pub fn build_audio_panel() -> AudioPanel {
     let group = adw::PreferencesGroup::builder()
         .title("Audio")
@@ -43,6 +90,42 @@ pub fn build_audio_panel() -> AudioPanel {
         .model(&sink_model)
         .build();
 
+    // Network config rows — built unconditionally so the
+    // visibility toggle in `connect_audio_panel` is a cheap
+    // `set_visible` rather than a structural insert/remove.
+    let network_host_row = adw::EntryRow::builder()
+        .title("Network host")
+        .text(NETWORK_SINK_DEFAULT_HOST)
+        .visible(false)
+        .build();
+
+    let port_adjustment = gtk4::Adjustment::new(
+        f64::from(NETWORK_SINK_DEFAULT_PORT),
+        1.0,
+        65535.0,
+        1.0,
+        100.0,
+        0.0,
+    );
+    let network_port_row = adw::SpinRow::builder()
+        .title("Port")
+        .adjustment(&port_adjustment)
+        .visible(false)
+        .build();
+
+    let protocol_model = gtk4::StringList::new(&["TCP (server)", "UDP"]);
+    let network_protocol_row = adw::ComboRow::builder()
+        .title("Protocol")
+        .model(&protocol_model)
+        .visible(false)
+        .build();
+
+    let network_status_row = adw::ActionRow::builder()
+        .title("Network sink")
+        .subtitle("Inactive")
+        .visible(false)
+        .build();
+
     let record_audio_row = adw::SwitchRow::builder()
         .title("Record Audio")
         .subtitle("48 kHz stereo WAV")
@@ -50,6 +133,10 @@ pub fn build_audio_panel() -> AudioPanel {
 
     group.add(&device_row);
     group.add(&sink_type_row);
+    group.add(&network_host_row);
+    group.add(&network_port_row);
+    group.add(&network_protocol_row);
+    group.add(&network_status_row);
     group.add(&record_audio_row);
 
     AudioPanel {
@@ -58,5 +145,9 @@ pub fn build_audio_panel() -> AudioPanel {
         sink_type_row,
         device_node_names: node_names,
         record_audio_row,
+        network_host_row,
+        network_port_row,
+        network_protocol_row,
+        network_status_row,
     }
 }

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -17,10 +17,15 @@ pub const SINK_TYPE_NETWORK_IDX: u32 = 1;
 pub const NETWORK_SINK_PROTOCOL_TCP_IDX: u32 = 0;
 pub const NETWORK_SINK_PROTOCOL_UDP_IDX: u32 = 1;
 
-/// Default endpoint values. Matches the IQ source-network
-/// defaults so a new install lands on familiar settings.
-pub const NETWORK_SINK_DEFAULT_HOST: &str = "localhost";
-pub const NETWORK_SINK_DEFAULT_PORT: u16 = 1234;
+// Defaults are owned by `sdr_core::sink_slot` so the engine
+// initializer and the panel always agree. Re-exported here as
+// pub use rather than redefined to keep the audit trail clear
+// — both crates point at the same byte. Per CodeRabbit round 1
+// on PR #351.
+pub use sdr_core::{
+    DEFAULT_NETWORK_SINK_HOST as NETWORK_SINK_DEFAULT_HOST,
+    DEFAULT_NETWORK_SINK_PORT as NETWORK_SINK_DEFAULT_PORT,
+};
 
 /// Map a combo index to a `Protocol`. Returns `Protocol::TcpClient`
 /// (TCP server mode — see `sdr_sink_network` docs) for the TCP

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -666,6 +666,7 @@ fn handle_dsp_message(
 ///   - `Active` → "Streaming to host:port (TCP/UDP)"
 ///   - `Inactive` → "Inactive" (e.g. just switched back to local)
 ///   - `Error { message }` → "Error: <message>"
+///
 /// Per issue #247.
 fn apply_network_sink_status(row: &adw::ActionRow, status: &sdr_core::NetworkSinkStatus) {
     use sdr_core::NetworkSinkStatus;
@@ -4525,9 +4526,23 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         let proto_row = panels.audio.network_protocol_row.clone();
         move || {
             let hostname = host_row.text().to_string();
-            // SpinRow's value clamps to its adjustment range
-            // (1..=65535) so the cast is in-range.
-            let port = port_row.value().round() as u16;
+            // SpinRow's adjustment is bounded (1..=65535), and
+            // we explicitly clamp again here as belt-and-
+            // suspenders against any future code path that
+            // hands us a different adjustment. After the clamp
+            // the value is finite and in [0, 65535] so the
+            // narrowing cast is exact — the clippy lints below
+            // are safe to silence with that justification.
+            let port_clamped = port_row
+                .value()
+                .round()
+                .clamp(f64::from(u16::MIN), f64::from(u16::MAX));
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "clamped to [0, u16::MAX] above"
+            )]
+            let port = port_clamped as u16;
             let protocol = sidebar::audio_panel::protocol_from_combo_idx(proto_row.selected());
             state.send_dsp(UiToDsp::SetNetworkSinkConfig {
                 hostname,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -366,6 +366,10 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let rtl_tcp_status_row_weak = panels.source.rtl_tcp_status_row.downgrade();
     let rtl_tcp_disconnect_button_weak = panels.source.rtl_tcp_disconnect_button.downgrade();
     let rtl_tcp_retry_button_weak = panels.source.rtl_tcp_retry_button.downgrade();
+    // Network audio sink status row — same weak-ref pattern as
+    // the rtl_tcp status row above so a window close can't keep
+    // the row alive past its useful life. Per issue #247.
+    let network_sink_status_row_weak = panels.audio.network_status_row.downgrade();
     let transcription_enable_for_dsp = transcript_panel.enable_row.clone();
     #[cfg(feature = "sherpa")]
     let auto_break_row_for_dsp = transcript_panel.auto_break_row.clone();
@@ -422,6 +426,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                         &rtl_tcp_status_row_weak,
                         &rtl_tcp_disconnect_button_weak,
                         &rtl_tcp_retry_button_weak,
+                        &network_sink_status_row_weak,
                         &transcription_enable_for_dsp,
                         #[cfg(feature = "sherpa")]
                         &auto_break_row_for_dsp,
@@ -464,6 +469,7 @@ fn handle_dsp_message(
     rtl_tcp_status_row_weak: &glib::WeakRef<adw::ActionRow>,
     rtl_tcp_disconnect_button_weak: &glib::WeakRef<gtk4::Button>,
     rtl_tcp_retry_button_weak: &glib::WeakRef<gtk4::Button>,
+    network_sink_status_row_weak: &glib::WeakRef<adw::ActionRow>,
     transcription_enable_row: &adw::SwitchRow,
     #[cfg(feature = "sherpa")] auto_break_row: &adw::SwitchRow,
     #[cfg(feature = "sherpa")] auto_break_min_open_row: &adw::SpinRow,
@@ -646,7 +652,35 @@ fn handle_dsp_message(
                 apply_rtl_tcp_connection_state(&status_row, &disconnect, &retry, &conn_state);
             }
         }
+        DspToUi::NetworkSinkStatus(status) => {
+            tracing::debug!(?status, "network sink status");
+            if let Some(row) = network_sink_status_row_weak.upgrade() {
+                apply_network_sink_status(&row, &status);
+            }
+        }
     }
+}
+
+/// Render a `NetworkSinkStatus` into the audio panel's status row.
+/// Three states map to three subtitles + colors:
+///   - `Active` → "Streaming to host:port (TCP/UDP)"
+///   - `Inactive` → "Inactive" (e.g. just switched back to local)
+///   - `Error { message }` → "Error: <message>"
+/// Per issue #247.
+fn apply_network_sink_status(row: &adw::ActionRow, status: &sdr_core::NetworkSinkStatus) {
+    use sdr_core::NetworkSinkStatus;
+    let subtitle = match status {
+        NetworkSinkStatus::Active { endpoint, protocol } => {
+            let proto_label = match protocol {
+                sdr_types::Protocol::TcpClient => "TCP",
+                sdr_types::Protocol::Udp => "UDP",
+            };
+            format!("Streaming to {endpoint} ({proto_label})")
+        }
+        NetworkSinkStatus::Inactive => "Inactive".to_string(),
+        NetworkSinkStatus::Error { message } => format!("Error: {message}"),
+    };
+    row.set_subtitle(&subtitle);
 }
 
 /// Render a `RtlTcpConnectionState` into the status row + button
@@ -4451,6 +4485,79 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             state_dev.send_dsp(UiToDsp::SetAudioDevice(node_name.clone()));
         }
     });
+
+    // Sink type selector — toggles the engine between local
+    // audio device and network stream, and shows/hides the
+    // network config rows so the sidebar layout reflects the
+    // active mode. Per issue #247.
+    let state_sink_type = Rc::clone(state);
+    let host_row = panels.audio.network_host_row.clone();
+    let port_row = panels.audio.network_port_row.clone();
+    let proto_row = panels.audio.network_protocol_row.clone();
+    let status_row = panels.audio.network_status_row.clone();
+    panels
+        .audio
+        .sink_type_row
+        .connect_selected_notify(move |row| {
+            let idx = row.selected();
+            let new_type = if idx == sidebar::audio_panel::SINK_TYPE_NETWORK_IDX {
+                sdr_core::AudioSinkType::Network
+            } else {
+                sdr_core::AudioSinkType::Local
+            };
+            let network_visible = matches!(new_type, sdr_core::AudioSinkType::Network);
+            host_row.set_visible(network_visible);
+            port_row.set_visible(network_visible);
+            proto_row.set_visible(network_visible);
+            status_row.set_visible(network_visible);
+            state_sink_type.send_dsp(UiToDsp::SetAudioSinkType(new_type));
+        });
+
+    // Helper closure-builder: any change to the network host /
+    // port / protocol triple re-sends the full SetNetworkSinkConfig
+    // so the controller can rebuild the sink atomically. The
+    // engine handler is idempotent — sending the same values
+    // again is harmless. Per issue #247.
+    let push_network_config = {
+        let state = Rc::clone(state);
+        let host_row = panels.audio.network_host_row.clone();
+        let port_row = panels.audio.network_port_row.clone();
+        let proto_row = panels.audio.network_protocol_row.clone();
+        move || {
+            let hostname = host_row.text().to_string();
+            // SpinRow's value clamps to its adjustment range
+            // (1..=65535) so the cast is in-range.
+            let port = port_row.value().round() as u16;
+            let protocol = sidebar::audio_panel::protocol_from_combo_idx(proto_row.selected());
+            state.send_dsp(UiToDsp::SetNetworkSinkConfig {
+                hostname,
+                port,
+                protocol,
+            });
+        }
+    };
+
+    // Hostname commits on Enter / focus-out (the AdwEntryRow's
+    // `connect_apply` signal). connect_changed would fire per
+    // keystroke and reconnect-on-every-character is bad UX.
+    {
+        let push = push_network_config.clone();
+        panels.audio.network_host_row.connect_apply(move |_| push());
+    }
+    {
+        let push = push_network_config.clone();
+        panels
+            .audio
+            .network_port_row
+            .connect_value_notify(move |_| push());
+    }
+    {
+        let push = push_network_config.clone();
+        panels
+            .audio
+            .network_protocol_row
+            .connect_selected_notify(move |_| push());
+    }
 
     // Audio recording toggle
     let state_rec = Rc::clone(state);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -4500,11 +4500,22 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
         .audio
         .sink_type_row
         .connect_selected_notify(move |row| {
-            let idx = row.selected();
-            let new_type = if idx == sidebar::audio_panel::SINK_TYPE_NETWORK_IDX {
-                sdr_core::AudioSinkType::Network
-            } else {
-                sdr_core::AudioSinkType::Local
+            // Match explicitly against both legal indices and
+            // early-return on anything else. The previous shape
+            // mapped any non-Network value to Local, which would
+            // silently dispatch a sink swap on a transient or
+            // future-added combo entry that this handler doesn't
+            // know about. Per CodeRabbit round 2 on PR #351.
+            let new_type = match row.selected() {
+                sidebar::audio_panel::SINK_TYPE_LOCAL_IDX => sdr_core::AudioSinkType::Local,
+                sidebar::audio_panel::SINK_TYPE_NETWORK_IDX => sdr_core::AudioSinkType::Network,
+                unknown => {
+                    tracing::warn!(
+                        selected_idx = unknown,
+                        "audio sink-type combo emitted unknown index; ignoring"
+                    );
+                    return;
+                }
             };
             let network_visible = matches!(new_type, sdr_core::AudioSinkType::Network);
             host_row.set_visible(network_visible);


### PR DESCRIPTION
## Summary

- Issue #247 said the engine was "already wired through SinkManager" — the audit on this branch proved that wrong: `SinkManager` exists but isn't used by the controller, and the GTK Audio panel's "Sink Type" combo (Audio / Network) was purely cosmetic. This PR is the engine-side plumbing + GTK wiring that makes sink-type switching actually take effect on Linux. The follow-up PR will add the FFI surface + SwiftUI Settings panel for the Mac app.
- New `AudioSinkSlot` enum wraps `AudioSink` and `NetworkSink` in a single type with one `write_samples` API. Two new `UiToDsp` messages (`SetAudioSinkType`, `SetNetworkSinkConfig`) and one new `DspToUi` event (`NetworkSinkStatus { Active, Inactive, Error }`).
- GTK panel gains four new widgets — host / port / protocol / status — visible only when Network is the active sink type.
- No FFI surface change in this PR; the FFI dispatcher silently drops `NetworkSinkStatus` until PR 2 lands the `SDR_EVT_NETWORK_SINK_STATUS` event variant alongside the new commands.

## Why this is two PRs

The engine plumbing is the risky part — it touches `DspState`, the audio-write hot path, the GTK panel layout, and adds a sink lifecycle the engine never had before. Reviewing it in isolation (not bundled with the FFI + SwiftUI work) gives CodeRabbit a focused diff to pick at, and lands the Linux fix as a side effect.

## Architecture

`AudioSink` and `NetworkSink` both implement the `Sink` trait but the trait is lifecycle-only — it deliberately doesn't include a write method since the two have differently-named writers (`write_samples` vs `write_stereo_samples`). The new enum is the adapter layer:

```rust
pub enum AudioSinkSlot {
    Local(AudioSink),
    Network(NetworkSink),
}

impl AudioSinkSlot {
    pub fn local_default() -> Self { ... }
    pub fn network(host: &str, port: u16, proto: Protocol) -> Self { ... }
    pub fn kind(&self) -> AudioSinkType { ... }
    pub fn start(&mut self) -> Result<(), SinkError> { ... }
    pub fn stop(&mut self) -> Result<(), SinkError> { ... }
    pub fn write_samples(&mut self, samples: &[Stereo]) -> Result<(), SinkError> { ... }
    pub fn set_target(&mut self, name: &str) -> Result<(), SinkError> { ... }  // no-op on Network
}
```

Switch path: stop current sink, build new variant from persisted config, re-apply the local device pick (if Local), restart if engine is running. Reconfig path: store new values; if network sink is currently active, rebuild it inline so the new endpoint takes effect immediately.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace -p sdr-core --lib\` — 33 passed (up from 29 — 4 new \`sink_slot\` tests)
- [x] \`make ffi-header-check\` — header parity OK (no FFI surface change in this PR)
- [x] \`cargo build --workspace --release\` — Linux binary builds
- [x] \`xcodebuild -scheme SDRMac build\` — Mac app still links (FFI unchanged)
- [x] Manual smoke test on Linux GTK build: open audio panel → flip Sink Type to Network → host/port/protocol form appears → status row shows "Streaming to localhost:1234 (TCP)" — deferred to user. (Mac side smoke test deferred to PR 2 once the SwiftUI panel exists.)

Refs #247. PR 2 will add the FFI commands + Swift wrappers + Settings → Audio "Stream over network" form, completing the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network audio sink support with configurable host, port, and protocol.
  * Sink-type selector to switch between Local and Network outputs.
  * UI network status display showing Active / Inactive / Error states.

* **Improvements**
  * Persisted local device and network settings with immediate apply/restart.
  * Clearer, network-specific status events and automatic UI updates.
  * Offline latch to suppress repeated audio writes after terminal failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->