### PR TITLE
Expose network audio sink in Mac SwiftUI app (closes #247)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -341,6 +341,35 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(uid.withCString { sdr_core_set_audio_device(handle, $0) })
     }
 
+    /// Switch the active audio sink between the local output
+    /// device and the network stream. The engine stops the
+    /// current sink, builds the replacement from the persisted
+    /// device / network config, and restarts it if the engine is
+    /// currently running. Status transitions land on the
+    /// `events` stream as `.networkSinkStatus(...)` — hosts use
+    /// them to drive a status row in the audio settings panel.
+    /// Per issue #247.
+    public func setAudioSinkType(_ type: AudioSinkType) throws {
+        try checkRc(sdr_core_set_audio_sink_type(handle, type.rawValue))
+    }
+
+    /// Configure the network audio sink endpoint. `hostname`
+    /// must be non-empty; `port` is the TCP / UDP port the
+    /// engine should listen / send on; `protocol` picks the
+    /// transport. If the network sink is currently active the
+    /// engine rebuilds it inline so the new endpoint takes
+    /// effect immediately; otherwise the values are stored for
+    /// the next `setAudioSinkType(.network)` switch.
+    public func setNetworkSinkConfig(
+        hostname: String,
+        port: UInt16,
+        protocol proto: NetworkProtocol
+    ) throws {
+        try checkRc(hostname.withCString { cHost in
+            sdr_core_set_network_sink_config(handle, cHost, port, proto.rawValue)
+        })
+    }
+
     /// Start recording the demodulated audio stream to a WAV file
     /// at `path`. The engine emits `.audioRecordingStarted(path:)`
     /// on success or `.error(...)` on failure.
@@ -547,7 +576,7 @@ public final class SdrCore: @unchecked Sendable {
             return sdr_core_device_name(index, base, ptr.count)
         }
         guard rc >= 0 else { return nil }
-        return String(cString: buf)
+        return cStringToSwiftString(buf)
     }
 
     // ==========================================================
@@ -618,6 +647,20 @@ public final class SdrCore: @unchecked Sendable {
             return call(index, base, ptr.count)
         }
         guard rc >= 0 else { return nil }
-        return String(cString: buf)
+        return cStringToSwiftString(buf)
+    }
+}
+
+/// Shared helper that decodes a NUL-terminated `[CChar]` buffer
+/// into a Swift `String`. Used in place of `String(cString: [CChar])`
+/// which was deprecated in the Swift 6.2 standard library in favor
+/// of a bring-your-own-truncation API. Using the `UnsafePointer`
+/// form of `init(cString:)` is still valid and picks the NUL up
+/// natively, so route the array through its base pointer.
+@inline(__always)
+func cStringToSwiftString(_ buf: [CChar]) -> String {
+    buf.withUnsafeBufferPointer { ptr in
+        guard let base = ptr.baseAddress else { return "" }
+        return String(cString: base)
     }
 }

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
@@ -69,6 +69,62 @@ public enum Deemphasis: Int32, Sendable, CaseIterable, Codable {
     }
 }
 
+/// Active audio sink selection. Matches `SdrAudioSinkType` in the
+/// C header. `.local` routes to a `CoreAudio` output device; `.network`
+/// streams post-demod audio to the configured host:port over
+/// TCP or UDP (see `NetworkProtocol`). Per issue #247.
+public enum AudioSinkType: Int32, Sendable, CaseIterable, Codable {
+    case local   = 0
+    case network = 1
+
+    public var label: String {
+        switch self {
+        case .local:   return "Local device"
+        case .network: return "Network stream"
+        }
+    }
+}
+
+/// Network stream protocol for the network audio sink. Matches
+/// `SdrNetworkProtocol` in the C header.
+///
+/// The `.tcpServer` name reflects the actual wire role: the
+/// device listens on the configured port and streams to clients
+/// that connect. (The Rust side spells the same thing as
+/// `Protocol::TcpClient` for historical SDR++ compatibility;
+/// the C ABI uses the clearer name.)
+public enum NetworkProtocol: Int32, Sendable, CaseIterable, Codable {
+    case tcpServer = 0
+    case udp       = 1
+
+    public var label: String {
+        switch self {
+        case .tcpServer: return "TCP server"
+        case .udp:       return "UDP"
+        }
+    }
+}
+
+/// Network sink status surfaced via the `networkSinkStatus`
+/// engine event. Mirrors
+/// `sdr_core::sink_slot::NetworkSinkStatus` on the Rust side.
+///
+/// - `.inactive` — the network sink is not currently the
+///   active audio output (either never selected, replaced by
+///   another sink, or the engine stopped).
+/// - `.active(endpoint:protocol:)` — the network sink started
+///   successfully. `endpoint` is the host:port the engine is
+///   bound to (TCP) or sending to (UDP); hosts typically show
+///   it in a Settings status row.
+/// - `.error(message:)` — a startup or write failure took the
+///   network sink offline. `message` is a human-readable
+///   description suitable for a toast or status line.
+public enum NetworkSinkStatus: Sendable, Equatable {
+    case inactive
+    case active(endpoint: String, protocol: NetworkProtocol)
+    case error(message: String)
+}
+
 /// FFT window function. Matches `SdrFftWindow` in the C header.
 ///
 /// Only three variants because that's what

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreError.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreError.swift
@@ -23,7 +23,7 @@ public struct SdrCoreError: Error, Equatable, CustomStringConvertible {
     /// `SdrCoreError` enum in `include/sdr_core.h` byte-for-byte;
     /// unknown values are mapped to `.unknown(Int32)` so a future
     /// FFI that grows the enum doesn't crash an older host.
-    public enum Code: Equatable {
+    public enum Code: Equatable, Sendable {
         case `internal`
         case invalidHandle
         case invalidArg

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -41,6 +41,7 @@ private let kAudioRecordingStarted = Int32(SDR_EVT_AUDIO_RECORDING_STARTED.rawVa
 private let kAudioRecordingStopped = Int32(SDR_EVT_AUDIO_RECORDING_STOPPED.rawValue)
 private let kIqRecordingStarted    = Int32(SDR_EVT_IQ_RECORDING_STARTED.rawValue)
 private let kIqRecordingStopped    = Int32(SDR_EVT_IQ_RECORDING_STOPPED.rawValue)
+private let kNetworkSinkStatus     = Int32(SDR_EVT_NETWORK_SINK_STATUS.rawValue)
 
 /// High-level event from the engine.
 ///
@@ -95,6 +96,13 @@ public enum SdrCoreEvent: Sendable, Equatable {
     /// IQ recording to WAV has stopped. Also fires on engine
     /// shutdown while a recording is active.
     case iqRecordingStopped
+
+    /// Network audio sink lifecycle / error update. Fires when
+    /// the network sink becomes the active audio output
+    /// (`.active`), when it is replaced by another sink or the
+    /// engine stops (`.inactive`), or when a startup / write
+    /// failure takes it offline (`.error`). Per issue #247.
+    case networkSinkStatus(NetworkSinkStatus)
 
     /// Translate a C `SdrEvent` into a Swift value.
     ///
@@ -168,6 +176,35 @@ public enum SdrCoreEvent: Sendable, Equatable {
 
         case kIqRecordingStopped:
             return .iqRecordingStopped
+
+        case kNetworkSinkStatus:
+            let status = payload.network_sink_status
+            switch status.kind {
+            case Int32(SDR_NETWORK_SINK_STATUS_INACTIVE.rawValue):
+                return .networkSinkStatus(.inactive)
+            case Int32(SDR_NETWORK_SINK_STATUS_ACTIVE.rawValue):
+                // `active` always carries a non-null endpoint
+                // string from the Rust side. Drop the event if
+                // the string is somehow missing rather than
+                // fabricate an empty endpoint that the UI would
+                // render as "Streaming to :" — clearer to skip.
+                guard let cstr = status.utf8 else { return nil }
+                let endpoint = String(cString: cstr)
+                let proto = NetworkProtocol(rawValue: status.protocol) ?? .tcpServer
+                return .networkSinkStatus(.active(endpoint: endpoint, protocol: proto))
+            case Int32(SDR_NETWORK_SINK_STATUS_ERROR.rawValue):
+                let message: String
+                if let cstr = status.utf8 {
+                    message = String(cString: cstr)
+                } else {
+                    message = ""
+                }
+                return .networkSinkStatus(.error(message: message))
+            default:
+                // Unknown sub-kind — future ABI extension. Drop
+                // silently, same policy as the outer `default`.
+                return nil
+            }
 
         default:
             // Unknown kind — a future FFI may add variants we

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -183,14 +183,18 @@ public enum SdrCoreEvent: Sendable, Equatable {
             case Int32(SDR_NETWORK_SINK_STATUS_INACTIVE.rawValue):
                 return .networkSinkStatus(.inactive)
             case Int32(SDR_NETWORK_SINK_STATUS_ACTIVE.rawValue):
-                // `active` always carries a non-null endpoint
-                // string from the Rust side. Drop the event if
-                // the string is somehow missing rather than
-                // fabricate an empty endpoint that the UI would
-                // render as "Streaming to :" — clearer to skip.
+                // `active` requires both a non-null, non-empty
+                // endpoint string AND a known protocol value.
+                // Defaulting an unknown protocol to `.tcpServer`
+                // would let a future ABI extension masquerade as
+                // a plausible-but-wrong status row — drop the
+                // event instead. Per `CodeRabbit` round 1.
                 guard let cstr = status.utf8 else { return nil }
                 let endpoint = String(cString: cstr)
-                let proto = NetworkProtocol(rawValue: status.protocol) ?? .tcpServer
+                guard !endpoint.isEmpty,
+                      let proto = NetworkProtocol(rawValue: status.protocol) else {
+                    return nil
+                }
                 return .networkSinkStatus(.active(endpoint: endpoint, protocol: proto))
             case Int32(SDR_NETWORK_SINK_STATUS_ERROR.rawValue):
                 let message: String

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreRadioReference.swift
@@ -133,8 +133,8 @@ extension SdrCore {
             }
         }
         try checkRc(rc)
-        let user = String(cString: userBuf)
-        let pass = String(cString: passBuf)
+        let user = cStringToSwiftString(userBuf)
+        let pass = cStringToSwiftString(passBuf)
         // FFI returns OK with empty buffers for the "not stored"
         // case (see `sdr_core_radioreference_load_credentials`
         // in `include/sdr_core.h`). Distinct from `.io` which is

--- a/apps/macos/Packages/SdrCoreKit/Tests/SdrCoreKitTests/SdrCoreTests.swift
+++ b/apps/macos/Packages/SdrCoreKit/Tests/SdrCoreKitTests/SdrCoreTests.swift
@@ -204,6 +204,64 @@ final class SdrCoreTests: XCTestCase {
         }
     }
 
+    /// Switching to the network sink on a stopped engine must
+    /// not fabricate an `.active` status — the engine only
+    /// emits `.active` after `audio_sink.start()` succeeds with
+    /// the engine running. Before then the status is either
+    /// `.inactive` (initial state) or `.error(...)` (startup
+    /// failure). We subscribe to the event stream, flip the
+    /// sink type, and assert no `.active` arrives. Per
+    /// `CodeRabbit` round 1 on PR #352.
+    func testSwitchingSinkToNetworkOnStoppedEngineDoesNotEmitActive() async throws {
+        // Same lifetime trick as `testEventStreamDelivers…`:
+        // launch the drain task up top, bound the engine's
+        // strong reference inside a `do { }` block so its
+        // deinit (and thus the stream's `finish()`) fires
+        // when the block ends. Awaiting `drainTask.value`
+        // outside the block then returns cleanly once the
+        // stream terminates, instead of blocking forever on
+        // a live engine that isn't producing events.
+        let drainTask: Task<[NetworkSinkStatus], Never>
+        do {
+            let core = try SdrCore(configPath: nil)
+            let events = core.events
+
+            drainTask = Task {
+                var collected: [NetworkSinkStatus] = []
+                for await event in events {
+                    if case .networkSinkStatus(let s) = event {
+                        collected.append(s)
+                    }
+                    // Defensive cap: terminate if the controller
+                    // ever emits an unreasonable flood.
+                    if collected.count > 32 { break }
+                }
+                return collected
+            }
+
+            try core.setNetworkSinkConfig(hostname: "127.0.0.1", port: 1234, protocol: .tcpServer)
+            try core.setAudioSinkType(.network)
+
+            // Small window for the controller to react before
+            // we drop the engine.
+            try await Task.sleep(nanoseconds: 150_000_000)
+        }
+        // Engine dropped above → stream finishes → drain exits.
+        // Bound the wait so a regression can't hang the suite.
+        let statuses = try await withTimeout(seconds: 3) {
+            await drainTask.value
+        }
+
+        // Engine was never started, so no `.active` event
+        // should fire. `.inactive` / `.error` are fine —
+        // we only guard against a bogus `.active`.
+        for status in statuses {
+            if case .active = status {
+                XCTFail("unexpected .active status on stopped engine: \(statuses)")
+            }
+        }
+    }
+
     func testErrorMessageIsCopiedIntoOwnedString() throws {
         let core = try SdrCore(configPath: nil)
         do {

--- a/apps/macos/Packages/SdrCoreKit/Tests/SdrCoreKitTests/SdrCoreTests.swift
+++ b/apps/macos/Packages/SdrCoreKit/Tests/SdrCoreKitTests/SdrCoreTests.swift
@@ -17,13 +17,14 @@ final class SdrCoreTests: XCTestCase {
 
     func testAbiVersionMatchesCurrent() {
         // Lock in that the Swift wrapper parses the packed
-        // version from the C side consistently. Current: 0.3
-        // (0.2 added device enumeration: sdr_core_device_count
-        // + sdr_core_device_name. 0.3 added
-        // sdr_core_set_auto_squelch.)
+        // version from the C side consistently. Current: 0.9
+        // (0.2 device enumeration; 0.3 auto-squelch;
+        // 0.4 audio routing + recording; 0.5 IQ recording;
+        // 0.6 RadioReference; 0.7 advanced demod; 0.8 audio tap;
+        // 0.9 network audio sink — issue #247.)
         let v = SdrCore.abiVersion
         XCTAssertEqual(v.major, 0)
-        XCTAssertEqual(v.minor, 3)
+        XCTAssertEqual(v.minor, 9)
     }
 
     func testInitLoggingIsIdempotent() {
@@ -176,6 +177,32 @@ final class SdrCoreTests: XCTestCase {
     // ==========================================================
     //  Error message round-trip
     // ==========================================================
+
+    // ==========================================================
+    //  Network audio sink (ABI 0.9, issue #247)
+    // ==========================================================
+
+    func testSetAudioSinkTypeRoundTrips() throws {
+        let core = try SdrCore(configPath: nil)
+        try core.setAudioSinkType(.local)
+        try core.setAudioSinkType(.network)
+        try core.setAudioSinkType(.local)
+    }
+
+    func testSetNetworkSinkConfigAcceptsValidInput() throws {
+        let core = try SdrCore(configPath: nil)
+        try core.setNetworkSinkConfig(hostname: "127.0.0.1", port: 1234, protocol: .tcpServer)
+        try core.setNetworkSinkConfig(hostname: "localhost", port: 9000, protocol: .udp)
+    }
+
+    func testSetNetworkSinkConfigRejectsEmptyHostname() throws {
+        let core = try SdrCore(configPath: nil)
+        XCTAssertThrowsError(
+            try core.setNetworkSinkConfig(hostname: "", port: 1234, protocol: .tcpServer)
+        ) { error in
+            XCTAssertEqual((error as? SdrCoreError)?.code, .invalidArg)
+        }
+    }
 
     func testErrorMessageIsCopiedIntoOwnedString() throws {
         let core = try SdrCore(configPath: nil)

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -235,6 +235,42 @@ final class CoreModel {
     /// panel open still shows the current list.
     var audioDevices: [SdrCore.AudioDevice] = []
 
+    // ----------------------------------------------------------
+    //  Network audio sink — issue #247 (ABI 0.9)
+    // ----------------------------------------------------------
+
+    /// Active audio sink. `.local` routes to the selected
+    /// CoreAudio device (the default); `.network` streams to a
+    /// configured host:port. Optimistic — the engine applies on
+    /// the next command cycle; status confirmation arrives via
+    /// the `.networkSinkStatus` event below. Persisted to
+    /// `UserDefaults` so the choice survives relaunches.
+    var audioSinkType: AudioSinkType = .local
+
+    /// Network sink host. Defaults to "localhost" to mirror the
+    /// engine's `DEFAULT_NETWORK_SINK_HOST`. Edited via the
+    /// Settings Audio pane; committed on explicit Apply (avoids
+    /// per-keystroke engine rebuilds).
+    var networkSinkHost: String = "localhost"
+
+    /// Network sink port. Default 1234 matches the engine's
+    /// `DEFAULT_NETWORK_SINK_PORT` and the historical SDR++
+    /// convention.
+    var networkSinkPort: UInt16 = 1234
+
+    /// Network sink protocol. TCP server by default (engine
+    /// accepts client connections); UDP is unicast to the
+    /// configured endpoint.
+    var networkSinkProtocol: NetworkProtocol = .tcpServer
+
+    /// Last status the engine reported for the network sink.
+    /// Drives the status row in the Settings Audio pane —
+    /// `.inactive` on first launch / after a switch back to
+    /// local; `.active(...)` once the engine successfully
+    /// starts streaming; `.error(...)` on a startup or write
+    /// failure.
+    var networkSinkStatus: NetworkSinkStatus = .inactive
+
     /// Active audio-recording state. `nil` = not recording,
     /// `some(path)` = engine confirmed it opened `path` for
     /// writing. Mirrors `DspToUi::AudioRecordingStarted/Stopped`
@@ -351,6 +387,33 @@ final class CoreModel {
             selectedAudioDeviceUid = saved
         }
         refreshAudioDevices()
+
+        // Restore network audio sink preferences — issue #247.
+        // Each field is independent; a partial write from a
+        // previous version (e.g., only host was set) still
+        // upgrades cleanly because the `.object(forKey:)` nil
+        // branch leaves the Rust-default value untouched.
+        if UserDefaults.standard.object(forKey: Self.audioSinkTypeDefaultsKey) != nil {
+            let raw = Int32(UserDefaults.standard.integer(forKey: Self.audioSinkTypeDefaultsKey))
+            audioSinkType = AudioSinkType(rawValue: raw) ?? .local
+        }
+        if let host = UserDefaults.standard.string(forKey: Self.networkSinkHostDefaultsKey),
+           !host.isEmpty {
+            networkSinkHost = host
+        }
+        if UserDefaults.standard.object(forKey: Self.networkSinkPortDefaultsKey) != nil {
+            let stored = UserDefaults.standard.integer(forKey: Self.networkSinkPortDefaultsKey)
+            // Clamp to UInt16 range — a stored value outside that
+            // range would come from a previous bug or a manual
+            // defaults write; fall back to the default port.
+            if (0...Int(UInt16.max)).contains(stored) {
+                networkSinkPort = UInt16(stored)
+            }
+        }
+        if UserDefaults.standard.object(forKey: Self.networkSinkProtocolDefaultsKey) != nil {
+            let raw = Int32(UserDefaults.standard.integer(forKey: Self.networkSinkProtocolDefaultsKey))
+            networkSinkProtocol = NetworkProtocol(rawValue: raw) ?? .tcpServer
+        }
 
         // Seed the RadioReference credentials flag from the
         // keyring so the sidebar panel / settings pane render
@@ -480,6 +543,12 @@ final class CoreModel {
             iqRecordingPath = path
         case .iqRecordingStopped:
             iqRecordingPath = nil
+        case .networkSinkStatus(let status):
+            // Engine is authoritative — trust its view of whether
+            // the network sink is up, down, or errored. The UI
+            // reads this field to render the status row; we don't
+            // locally flip state on the setter return code.
+            networkSinkStatus = status
         @unknown default:
             // Surface new engine event variants during
             // development. SdrCoreEvent is a non-frozen enum
@@ -618,6 +687,16 @@ final class CoreModel {
         // engine default is "" (system default) so a fresh install
         // re-applies that harmlessly.
         setAudioDevice(selectedAudioDeviceUid)
+        // Audio sink type + network endpoint — issue #247.
+        // Push the endpoint first so a switch to `.network` lands
+        // with the user's chosen host/port instead of the engine
+        // defaults.
+        applyNetworkSinkConfig(
+            host: networkSinkHost,
+            port: networkSinkPort,
+            protocol: networkSinkProtocol
+        )
+        setAudioSinkType(audioSinkType)
         setFftSize(fftSize)
         setFftWindow(fftWindow)
         setFftRate(fftRateFps)
@@ -904,6 +983,59 @@ final class CoreModel {
 
     /// UserDefaults key for the persisted audio device UID.
     static let audioDeviceDefaultsKey = "SDRMac.selectedAudioDeviceUid"
+
+    // ----------------------------------------------------------
+    //  Network audio sink setters — issue #247
+    // ----------------------------------------------------------
+
+    /// Switch between local and network audio sinks. Optimistic:
+    /// flip the UI field before dispatching so the Settings
+    /// picker tracks the tap immediately. Engine status
+    /// transitions come back via `.networkSinkStatus` events.
+    func setAudioSinkType(_ type: AudioSinkType) {
+        audioSinkType = type
+        UserDefaults.standard.set(Int(type.rawValue), forKey: Self.audioSinkTypeDefaultsKey)
+        capture { try core?.setAudioSinkType(type) }
+    }
+
+    /// Apply the current host/port/protocol to the engine.
+    /// Called on explicit Apply in the Settings pane rather than
+    /// on every keystroke — the engine rebuilds the listener /
+    /// socket on receipt, so per-keystroke commits would thrash
+    /// TCP/UDP state while the user is still typing.
+    func applyNetworkSinkConfig(
+        host: String,
+        port: UInt16,
+        protocol proto: NetworkProtocol
+    ) {
+        // Guard against an empty host that the FFI would reject
+        // anyway — surface a local error without the FFI round-trip
+        // so the Settings pane can point at the field cleanly.
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            lastError = "Network sink host cannot be empty"
+            return
+        }
+        networkSinkHost = trimmed
+        networkSinkPort = port
+        networkSinkProtocol = proto
+        UserDefaults.standard.set(trimmed, forKey: Self.networkSinkHostDefaultsKey)
+        UserDefaults.standard.set(Int(port), forKey: Self.networkSinkPortDefaultsKey)
+        UserDefaults.standard.set(Int(proto.rawValue), forKey: Self.networkSinkProtocolDefaultsKey)
+        capture {
+            try core?.setNetworkSinkConfig(hostname: trimmed, port: port, protocol: proto)
+        }
+    }
+
+    /// UserDefaults keys for the persisted network-sink config.
+    /// Matches the existing `audioDeviceDefaultsKey` pattern —
+    /// the Rust config layer doesn't round-trip these values yet
+    /// (tracked against the larger v3 config alignment), so the
+    /// Mac app persists locally in the meantime.
+    static let audioSinkTypeDefaultsKey      = "SDRMac.audioSinkType"
+    static let networkSinkHostDefaultsKey    = "SDRMac.networkSinkHost"
+    static let networkSinkPortDefaultsKey    = "SDRMac.networkSinkPort"
+    static let networkSinkProtocolDefaultsKey = "SDRMac.networkSinkProtocol"
 
     /// Re-query the backend for the current output device list.
     /// Called by the AudioSection view on appear; safe to call

--- a/apps/macos/SDRMac/Views/SettingsView.swift
+++ b/apps/macos/SDRMac/Views/SettingsView.swift
@@ -47,29 +47,27 @@ private struct GeneralPane: View {
 private struct AudioPane: View {
     @Environment(CoreModel.self) private var model
 
+    /// Local edit buffer for the network sink port. Bound to a
+    /// `TextField` so the user can backspace through the value
+    /// without triggering a per-keystroke engine command. An
+    /// empty string parses as "no port chosen" and the Apply
+    /// button disables. Committed on Apply.
+    @State private var portEdit: String = ""
+
+    /// Local edit buffer for the host. Same rationale as
+    /// `portEdit` — host edits shouldn't rebuild the listener on
+    /// every character.
+    @State private var hostEdit: String = ""
+
     var body: some View {
         Form {
             LabeledContent("Output device") {
-                // Picker rebuilds the device list on every appear —
-                // CoreAudio hot-plugs are common (Bluetooth headsets,
-                // USB interfaces); the user shouldn't have to restart
-                // the app to see a freshly-connected device. The
-                // engine's transactional swap guarantees a bad pick
-                // rolls back to the previous route automatically.
                 Picker("", selection: Binding(
                     get: { model.selectedAudioDeviceUid },
                     set: { model.setAudioDevice($0) }
                 )) {
-                    // "" is the engine's "system default" sentinel —
-                    // show it as a first-class option regardless of
-                    // backend so the user always has a guaranteed-
-                    // working route to fall back on.
                     Text("System default").tag("")
                     ForEach(model.audioDevices) { dev in
-                        // Skip a backend-emitted empty-UID duplicate
-                        // so we never show two "System default"
-                        // options (stub backend does emit one; real
-                        // backends typically don't).
                         if !dev.uid.isEmpty {
                             Text(dev.displayName).tag(dev.uid)
                         }
@@ -77,6 +75,11 @@ private struct AudioPane: View {
                 }
                 .labelsHidden()
                 .onAppear { model.refreshAudioDevices() }
+                // Greyed out while the network sink is active —
+                // the setting still round-trips to the engine, but
+                // it only affects audio once the user switches the
+                // sink back to `.local`.
+                .disabled(model.audioSinkType == .network)
             }
             LabeledContent("Volume") {
                 @Bindable var m = model
@@ -90,6 +93,127 @@ private struct AudioPane: View {
                     }
                 )
             }
+
+            // --------------------------------------------------
+            //  Network audio sink — issue #247
+            // --------------------------------------------------
+            Section {
+                Picker("Sink", selection: Binding(
+                    get: { model.audioSinkType },
+                    set: { model.setAudioSinkType($0) }
+                )) {
+                    ForEach(AudioSinkType.allCases, id: \.self) { t in
+                        Text(t.label).tag(t)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                if model.audioSinkType == .network {
+                    TextField("Host", text: $hostEdit)
+                        .textFieldStyle(.roundedBorder)
+                        .disableAutocorrection(true)
+                    TextField("Port", text: $portEdit)
+                        .textFieldStyle(.roundedBorder)
+                    Picker("Protocol", selection: Binding(
+                        get: { model.networkSinkProtocol },
+                        set: { proto in
+                            // Protocol changes count as endpoint
+                            // changes — rebuild with the buffered
+                            // host/port instead of letting the
+                            // picker drift out of sync with the
+                            // engine. Bad port input keeps the
+                            // engine's current endpoint.
+                            if let port = portValue() {
+                                model.applyNetworkSinkConfig(
+                                    host: hostEdit,
+                                    port: port,
+                                    protocol: proto
+                                )
+                            }
+                        }
+                    )) {
+                        ForEach(NetworkProtocol.allCases, id: \.self) { p in
+                            Text(p.label).tag(p)
+                        }
+                    }
+
+                    HStack {
+                        Button {
+                            guard let port = portValue() else { return }
+                            model.applyNetworkSinkConfig(
+                                host: hostEdit,
+                                port: port,
+                                protocol: model.networkSinkProtocol
+                            )
+                        } label: {
+                            Label("Apply", systemImage: "arrow.up.circle")
+                        }
+                        .disabled(applyButtonDisabled)
+                    }
+
+                    networkStatusRow
+                }
+            } header: {
+                Text("Network stream")
+            } footer: {
+                Text(
+                    """
+                    Stream post-demod audio (48 kHz stereo) to a TCP or UDP \
+                    endpoint. TCP server mode has the app listen on the \
+                    configured port for client connections. UDP sends \
+                    unicast packets to the chosen host.
+                    """
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .onAppear {
+            // Seed the local edit buffers from the model on
+            // every appear — picks up external mutations (e.g.
+            // bookmark restore, programmatic updates) that
+            // happened while the pane was off-screen.
+            hostEdit = model.networkSinkHost
+            portEdit = String(model.networkSinkPort)
+        }
+    }
+
+    /// Parse the current port-edit buffer into a `UInt16`.
+    /// Returns `nil` on empty / out-of-range / non-numeric
+    /// input; the Apply button and protocol-change side effect
+    /// disable/no-op in that case instead of pushing a bad value.
+    private func portValue() -> UInt16? {
+        guard let raw = Int(portEdit.trimmingCharacters(in: .whitespaces)),
+              (1...Int(UInt16.max)).contains(raw) else {
+            return nil
+        }
+        return UInt16(raw)
+    }
+
+    private var applyButtonDisabled: Bool {
+        let trimmedHost = hostEdit.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedHost.isEmpty || portValue() == nil
+    }
+
+    /// Render the engine-reported network sink status below the
+    /// form. Colors mirror the RadioReference pane's convention
+    /// (red = error, green = success, secondary = idle).
+    @ViewBuilder
+    private var networkStatusRow: some View {
+        switch model.networkSinkStatus {
+        case .inactive:
+            Text("Status: inactive")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .active(let endpoint, let proto):
+            Text("Status: streaming to \(endpoint) over \(proto.label)")
+                .font(.caption)
+                .foregroundStyle(.green)
+        case .error(let msg):
+            Text("Status: \(msg)")
+                .font(.caption)
+                .foregroundStyle(.red)
+                .textSelection(.enabled)
         }
     }
 }

--- a/apps/macos/SDRMac/Views/SettingsView.swift
+++ b/apps/macos/SDRMac/Views/SettingsView.swift
@@ -59,6 +59,13 @@ private struct AudioPane: View {
     /// every character.
     @State private var hostEdit: String = ""
 
+    /// One-shot latch so `.onAppear` only seeds `hostEdit` /
+    /// `portEdit` from the model the first time this pane is
+    /// rendered. Without it, tabbing away from Audio and back
+    /// clobbers any in-progress endpoint edits (same pattern
+    /// `RadioReferencePane` uses). Per `CodeRabbit` round 1.
+    @State private var didPrefill: Bool = false
+
     var body: some View {
         Form {
             LabeledContent("Output device") {
@@ -121,11 +128,13 @@ private struct AudioPane: View {
                             // changes — rebuild with the buffered
                             // host/port instead of letting the
                             // picker drift out of sync with the
-                            // engine. Bad port input keeps the
-                            // engine's current endpoint.
-                            if let port = portValue() {
+                            // engine. Empty / whitespace-only host
+                            // or bad port input keeps the engine's
+                            // current endpoint.
+                            let host = normalizedHost
+                            if !host.isEmpty, let port = portValue() {
                                 model.applyNetworkSinkConfig(
-                                    host: hostEdit,
+                                    host: host,
                                     port: port,
                                     protocol: proto
                                 )
@@ -139,9 +148,10 @@ private struct AudioPane: View {
 
                     HStack {
                         Button {
-                            guard let port = portValue() else { return }
+                            let host = normalizedHost
+                            guard !host.isEmpty, let port = portValue() else { return }
                             model.applyNetworkSinkConfig(
-                                host: hostEdit,
+                                host: host,
                                 port: port,
                                 protocol: model.networkSinkProtocol
                             )
@@ -169,10 +179,13 @@ private struct AudioPane: View {
             }
         }
         .onAppear {
-            // Seed the local edit buffers from the model on
-            // every appear — picks up external mutations (e.g.
-            // bookmark restore, programmatic updates) that
-            // happened while the pane was off-screen.
+            // One-shot prefill: seed the local edit buffers from
+            // the model only on first appear. Repeated .onAppear
+            // fires when tabbing away and back in the TabView
+            // would otherwise clobber any in-progress edits the
+            // user hadn't hit Apply on yet.
+            guard !didPrefill else { return }
+            didPrefill = true
             hostEdit = model.networkSinkHost
             portEdit = String(model.networkSinkPort)
         }
@@ -190,9 +203,15 @@ private struct AudioPane: View {
         return UInt16(raw)
     }
 
+    /// Host with leading/trailing whitespace stripped. Single
+    /// source of truth for the normalization step every
+    /// push-to-engine path runs through.
+    private var normalizedHost: String {
+        hostEdit.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var applyButtonDisabled: Bool {
-        let trimmedHost = hostEdit.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmedHost.isEmpty || portValue() == nil
+        normalizedHost.isEmpty || portValue() == nil
     }
 
     /// Render the engine-reported network sink status below the

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -526,6 +526,93 @@ pub unsafe extern "C" fn sdr_core_set_audio_device(
     }
 }
 
+// ============================================================
+//  Audio sink selection (#247) — switch between local audio
+//  device and network stream, configure the network endpoint.
+//
+//  Discriminants below mirror the matching `Sdr*` enums in
+//  `include/sdr_core.h`. Reordering would silently break ABI.
+// ============================================================
+
+pub const SDR_AUDIO_SINK_LOCAL: i32 = 0;
+pub const SDR_AUDIO_SINK_NETWORK: i32 = 1;
+
+fn audio_sink_type_from_c(v: i32) -> Option<sdr_core::AudioSinkType> {
+    match v {
+        SDR_AUDIO_SINK_LOCAL => Some(sdr_core::AudioSinkType::Local),
+        SDR_AUDIO_SINK_NETWORK => Some(sdr_core::AudioSinkType::Network),
+        _ => None,
+    }
+}
+
+fn protocol_from_c(v: i32) -> Option<sdr_types::Protocol> {
+    match v {
+        crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER => Some(sdr_types::Protocol::TcpClient),
+        crate::event::SDR_NETWORK_PROTOCOL_UDP => Some(sdr_types::Protocol::Udp),
+        _ => None,
+    }
+}
+
+/// Switch between the local audio device sink and the network
+/// stream sink. `sink_type` must be one of `SDR_AUDIO_SINK_*`.
+/// The engine stops the current sink, builds the replacement
+/// from the persisted device / network config, and restarts it
+/// if the engine is currently running. Returns `SDR_CORE_OK` on
+/// success or `SDR_CORE_ERR_INVALID_ARG` for an unknown
+/// `sink_type` value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_audio_sink_type(handle: *mut SdrCore, sink_type: i32) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let Some(t) = audio_sink_type_from_c(sink_type) else {
+                set_last_error(format!(
+                    "sdr_core_set_audio_sink_type: unknown sink_type {sink_type}"
+                ));
+                return Err(SdrCoreError::InvalidArg);
+            };
+            send(core, UiToDsp::SetAudioSinkType(t))
+        })
+    }
+}
+
+/// Configure the network audio sink endpoint. `hostname_utf8`
+/// must be a non-null NUL-terminated UTF-8 C string. `protocol`
+/// must be one of `SDR_NETWORK_PROTOCOL_*`. The engine stores
+/// the config; if the network sink is currently active the
+/// underlying `NetworkSink` is rebuilt inline so the new
+/// endpoint takes effect immediately.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_network_sink_config(
+    handle: *mut SdrCore,
+    hostname_utf8: *const c_char,
+    port: u16,
+    protocol: i32,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let hostname = cstr_to_string("sdr_core_set_network_sink_config", hostname_utf8)?;
+            if hostname.is_empty() {
+                set_last_error("sdr_core_set_network_sink_config: hostname is empty");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            let Some(proto) = protocol_from_c(protocol) else {
+                set_last_error(format!(
+                    "sdr_core_set_network_sink_config: unknown protocol {protocol}"
+                ));
+                return Err(SdrCoreError::InvalidArg);
+            };
+            send(
+                core,
+                UiToDsp::SetNetworkSinkConfig {
+                    hostname,
+                    port,
+                    protocol: proto,
+                },
+            )
+        })
+    }
+}
+
 /// Shared helper for the two `start_*_recording` commands. Validates
 /// `path_utf8` (non-null, UTF-8, non-empty) and dispatches the
 /// appropriate `UiToDsp` variant via `build_cmd`. Keeps the path

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -841,6 +841,31 @@ mod tests {
     /// the mpsc hop plus file-close syscall on any CI host.
     const RECORDING_FLUSH_WAIT_MS: u64 = 50;
 
+    /// Loopback host string reused across the network-sink
+    /// setter tests. Plain IPv4 loopback avoids any resolver
+    /// step so the tests don't depend on `/etc/hosts` entries
+    /// or DNS availability on the CI host.
+    const TEST_NETWORK_HOST_LOOPBACK: &str = "127.0.0.1";
+
+    /// Default port the network-sink defaults advertise (see
+    /// `sdr_core::sink_slot::DEFAULT_NETWORK_SINK_PORT`). Used
+    /// in the TCP-path happy case. Named so a future default
+    /// change flows through the tests.
+    const TEST_NETWORK_PORT_TCP: u16 = 1234;
+
+    /// A second distinct port for the UDP-path happy case —
+    /// keeps the two setter tests exercising different values
+    /// so a silently-ignored parameter won't pass both by
+    /// coincidence.
+    const TEST_NETWORK_PORT_UDP: u16 = 9000;
+
+    /// Smallest legal UDP / TCP port (port 0 is reserved at
+    /// the ABI boundary — see the zero-port rejection test).
+    /// Named so the "minimum accepted" assertion expresses
+    /// intent instead of using a bare `1`. Per `CodeRabbit`
+    /// round 3 on PR #352.
+    const TEST_NETWORK_MIN_VALID_PORT: u16 = 1;
+
     /// Minimum size of a well-formed empty WAV file: the 44-byte
     /// header `WavWriter::new` writes before any samples arrive
     /// (RIFF/WAVE + fmt chunk + data chunk header). Used by the
@@ -1397,13 +1422,13 @@ mod tests {
     #[test]
     fn set_network_sink_config_accepts_valid_input() {
         let h = make_handle();
-        let host = CString::new("127.0.0.1").unwrap();
+        let host = CString::new(TEST_NETWORK_HOST_LOOPBACK).unwrap();
         assert_eq!(
             unsafe {
                 sdr_core_set_network_sink_config(
                     h,
                     host.as_ptr(),
-                    1234,
+                    TEST_NETWORK_PORT_TCP,
                     crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
                 )
             },
@@ -1414,7 +1439,7 @@ mod tests {
                 sdr_core_set_network_sink_config(
                     h,
                     host.as_ptr(),
-                    9000,
+                    TEST_NETWORK_PORT_UDP,
                     crate::event::SDR_NETWORK_PROTOCOL_UDP,
                 )
             },
@@ -1431,7 +1456,7 @@ mod tests {
                 sdr_core_set_network_sink_config(
                     h,
                     std::ptr::null(),
-                    1234,
+                    TEST_NETWORK_PORT_TCP,
                     crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
                 )
             },
@@ -1449,7 +1474,7 @@ mod tests {
                 sdr_core_set_network_sink_config(
                     h,
                     empty.as_ptr(),
-                    1234,
+                    TEST_NETWORK_PORT_TCP,
                     crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
                 )
             },
@@ -1465,7 +1490,7 @@ mod tests {
         // mode would bind an undiscoverable ephemeral port.
         // Per `CodeRabbit` round 2 on PR #352.
         let h = make_handle();
-        let host = CString::new("127.0.0.1").unwrap();
+        let host = CString::new(TEST_NETWORK_HOST_LOOPBACK).unwrap();
         assert_eq!(
             unsafe {
                 sdr_core_set_network_sink_config(
@@ -1477,13 +1502,13 @@ mod tests {
             },
             SdrCoreError::InvalidArg.as_int()
         );
-        // And accepts 1 at the boundary as a sanity check.
+        // And accepts the minimum legal port as a boundary check.
         assert_eq!(
             unsafe {
                 sdr_core_set_network_sink_config(
                     h,
                     host.as_ptr(),
-                    1,
+                    TEST_NETWORK_MIN_VALID_PORT,
                     crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
                 )
             },
@@ -1495,13 +1520,17 @@ mod tests {
     #[test]
     fn set_network_sink_config_rejects_out_of_range_protocol() {
         let h = make_handle();
-        let host = CString::new("127.0.0.1").unwrap();
+        let host = CString::new(TEST_NETWORK_HOST_LOOPBACK).unwrap();
         assert_eq!(
-            unsafe { sdr_core_set_network_sink_config(h, host.as_ptr(), 1234, 99) },
+            unsafe {
+                sdr_core_set_network_sink_config(h, host.as_ptr(), TEST_NETWORK_PORT_TCP, 99)
+            },
             SdrCoreError::InvalidArg.as_int()
         );
         assert_eq!(
-            unsafe { sdr_core_set_network_sink_config(h, host.as_ptr(), 1234, -1) },
+            unsafe {
+                sdr_core_set_network_sink_config(h, host.as_ptr(), TEST_NETWORK_PORT_TCP, -1)
+            },
             SdrCoreError::InvalidArg.as_int()
         );
         destroy(h);

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -595,6 +595,20 @@ pub unsafe extern "C" fn sdr_core_set_network_sink_config(
                 set_last_error("sdr_core_set_network_sink_config: hostname is empty");
                 return Err(SdrCoreError::InvalidArg);
             }
+            // Port 0 has no useful meaning here: UDP would
+            // silently drop packets to a bogus destination, and
+            // TCP server mode would bind a random ephemeral
+            // port the host can't discover. The Swift UI
+            // already constrains the picker to 1..=65535, but
+            // non-Swift hosts and direct FFI callers go through
+            // this path too — reject at the boundary.
+            // Per `CodeRabbit` round 2 on PR #352.
+            if port == 0 {
+                set_last_error(
+                    "sdr_core_set_network_sink_config: port must be in 1..=65535, got 0",
+                );
+                return Err(SdrCoreError::InvalidArg);
+            }
             let Some(proto) = protocol_from_c(protocol) else {
                 set_last_error(format!(
                     "sdr_core_set_network_sink_config: unknown protocol {protocol}"
@@ -1440,6 +1454,40 @@ mod tests {
                 )
             },
             SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_network_sink_config_rejects_zero_port() {
+        // Port 0 is rejected at the ABI boundary — UDP would
+        // silently drop to a bogus destination and TCP server
+        // mode would bind an undiscoverable ephemeral port.
+        // Per `CodeRabbit` round 2 on PR #352.
+        let h = make_handle();
+        let host = CString::new("127.0.0.1").unwrap();
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_sink_config(
+                    h,
+                    host.as_ptr(),
+                    0,
+                    crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
+                )
+            },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        // And accepts 1 at the boundary as a sanity check.
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_sink_config(
+                    h,
+                    host.as_ptr(),
+                    1,
+                    crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
+                )
+            },
+            SdrCoreError::Ok.as_int()
         );
         destroy(h);
     }

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -1348,6 +1348,144 @@ mod tests {
         destroy(h);
     }
 
+    // ------------------------------------------------------
+    //  Audio sink selection (#247, ABI 0.9)
+    // ------------------------------------------------------
+
+    #[test]
+    fn set_audio_sink_type_accepts_both_variants() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_audio_sink_type(h, SDR_AUDIO_SINK_LOCAL) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_audio_sink_type(h, SDR_AUDIO_SINK_NETWORK) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_audio_sink_type_rejects_out_of_range_value() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_audio_sink_type(h, 99) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_audio_sink_type(h, -1) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_network_sink_config_accepts_valid_input() {
+        let h = make_handle();
+        let host = CString::new("127.0.0.1").unwrap();
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_sink_config(
+                    h,
+                    host.as_ptr(),
+                    1234,
+                    crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
+                )
+            },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_sink_config(
+                    h,
+                    host.as_ptr(),
+                    9000,
+                    crate::event::SDR_NETWORK_PROTOCOL_UDP,
+                )
+            },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_network_sink_config_rejects_null_hostname() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_sink_config(
+                    h,
+                    std::ptr::null(),
+                    1234,
+                    crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
+                )
+            },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_network_sink_config_rejects_empty_hostname() {
+        let h = make_handle();
+        let empty = CString::new("").unwrap();
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_sink_config(
+                    h,
+                    empty.as_ptr(),
+                    1234,
+                    crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER,
+                )
+            },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_network_sink_config_rejects_out_of_range_protocol() {
+        let h = make_handle();
+        let host = CString::new("127.0.0.1").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_set_network_sink_config(h, host.as_ptr(), 1234, 99) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_network_sink_config(h, host.as_ptr(), 1234, -1) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn audio_sink_type_from_c_covers_all_variants() {
+        assert_eq!(
+            audio_sink_type_from_c(SDR_AUDIO_SINK_LOCAL),
+            Some(sdr_core::AudioSinkType::Local)
+        );
+        assert_eq!(
+            audio_sink_type_from_c(SDR_AUDIO_SINK_NETWORK),
+            Some(sdr_core::AudioSinkType::Network)
+        );
+        assert_eq!(audio_sink_type_from_c(99), None);
+        assert_eq!(audio_sink_type_from_c(-1), None);
+    }
+
+    #[test]
+    fn protocol_from_c_covers_all_variants() {
+        assert_eq!(
+            protocol_from_c(crate::event::SDR_NETWORK_PROTOCOL_TCP_SERVER),
+            Some(sdr_types::Protocol::TcpClient)
+        );
+        assert_eq!(
+            protocol_from_c(crate::event::SDR_NETWORK_PROTOCOL_UDP),
+            Some(sdr_types::Protocol::Udp)
+        );
+        assert_eq!(protocol_from_c(99), None);
+    }
+
     #[test]
     fn advanced_demod_bool_setters_accept_both_polarities() {
         // The four bool-typed advanced setters have no validation

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -57,6 +57,28 @@ pub const SDR_EVT_AUDIO_RECORDING_STARTED: i32 = 8;
 pub const SDR_EVT_AUDIO_RECORDING_STOPPED: i32 = 9;
 pub const SDR_EVT_IQ_RECORDING_STARTED: i32 = 10;
 pub const SDR_EVT_IQ_RECORDING_STOPPED: i32 = 11;
+pub const SDR_EVT_NETWORK_SINK_STATUS: i32 = 12;
+
+// ============================================================
+//  Network sink status discriminants — must match the
+//  matching `SdrNetworkSinkStatusKind` enum in
+//  `include/sdr_core.h`. Never reorder or renumber.
+// ============================================================
+
+pub const SDR_NETWORK_SINK_STATUS_INACTIVE: i32 = 0;
+pub const SDR_NETWORK_SINK_STATUS_ACTIVE: i32 = 1;
+pub const SDR_NETWORK_SINK_STATUS_ERROR: i32 = 2;
+
+// ============================================================
+//  Network protocol discriminants — must match the matching
+//  `SdrNetworkProtocol` enum in `include/sdr_core.h`. Reused
+//  by both `sdr_core_set_network_sink_config` (command path)
+//  and the network-sink-status payload (event path). Never
+//  reorder or renumber.
+// ============================================================
+
+pub const SDR_NETWORK_PROTOCOL_TCP_SERVER: i32 = 0;
+pub const SDR_NETWORK_PROTOCOL_UDP: i32 = 1;
 
 // ============================================================
 //  SdrEvent tagged union — `#[repr(C)]` layout matching the
@@ -109,6 +131,25 @@ pub struct SdrEventIqRecording {
     pub path_utf8: *const c_char,
 }
 
+/// Payload for `SDR_EVT_NETWORK_SINK_STATUS`. Tagged by `kind`
+/// (one of `SDR_NETWORK_SINK_STATUS_*`):
+///
+/// | `kind`                                | `utf8`             | `protocol`              |
+/// |---------------------------------------|--------------------|-------------------------|
+/// | `SDR_NETWORK_SINK_STATUS_INACTIVE`    | NULL               | -1 (unused)             |
+/// | `SDR_NETWORK_SINK_STATUS_ACTIVE`      | endpoint host:port | `SDR_NETWORK_PROTOCOL_*`|
+/// | `SDR_NETWORK_SINK_STATUS_ERROR`       | error message      | -1 (unused)             |
+///
+/// `utf8` is a borrowed pointer into dispatcher-owned storage;
+/// valid only for the duration of the callback. Per issue #247.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SdrEventNetworkSinkStatus {
+    pub kind: i32,
+    pub utf8: *const c_char,
+    pub protocol: i32,
+}
+
 /// C-layout tagged union of event payloads. Which field is valid
 /// is determined by the `kind` discriminant on the enclosing
 /// `SdrEvent`:
@@ -141,6 +182,7 @@ pub union SdrEventPayload {
     pub error: SdrEventError,
     pub audio_recording: SdrEventAudioRecording,
     pub iq_recording: SdrEventIqRecording,
+    pub network_sink_status: SdrEventNetworkSinkStatus,
     /// Placeholder for kinds that carry no payload (e.g.,
     /// `SDR_EVT_SOURCE_STOPPED`). Accessing this field is always
     /// valid as a zero-byte read.
@@ -347,6 +389,51 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
             payload: SdrEventPayload { _placeholder: 0 },
         },
 
+        DspToUi::NetworkSinkStatus(status) => {
+            use sdr_core::NetworkSinkStatus;
+            // Translate the three status variants into the C
+            // tagged-payload shape. Borrowed strings get
+            // promoted to `CString` so they outlive the
+            // dispatcher's call into the host callback.
+            // Per issue #247 PR 2.
+            let (kind, message_cstr, protocol_int) = match status {
+                NetworkSinkStatus::Inactive => (SDR_NETWORK_SINK_STATUS_INACTIVE, None, -1_i32),
+                NetworkSinkStatus::Active { endpoint, protocol } => {
+                    let sanitized = endpoint.replace('\0', "?");
+                    let Ok(cstr) = CString::new(sanitized) else {
+                        // Unreachable: replace stripped NULs.
+                        return None;
+                    };
+                    let proto = match protocol {
+                        sdr_types::Protocol::TcpClient => SDR_NETWORK_PROTOCOL_TCP_SERVER,
+                        sdr_types::Protocol::Udp => SDR_NETWORK_PROTOCOL_UDP,
+                    };
+                    (SDR_NETWORK_SINK_STATUS_ACTIVE, Some(cstr), proto)
+                }
+                NetworkSinkStatus::Error { message } => {
+                    let sanitized = message.replace('\0', "?");
+                    let Ok(cstr) = CString::new(sanitized) else {
+                        return None;
+                    };
+                    (SDR_NETWORK_SINK_STATUS_ERROR, Some(cstr), -1_i32)
+                }
+            };
+            let utf8 = message_cstr
+                .as_ref()
+                .map_or(std::ptr::null(), |c| c.as_ptr());
+            owned_cstring = message_cstr;
+            SdrEvent {
+                kind: SDR_EVT_NETWORK_SINK_STATUS,
+                payload: SdrEventPayload {
+                    network_sink_status: SdrEventNetworkSinkStatus {
+                        kind,
+                        utf8,
+                        protocol: protocol_int,
+                    },
+                },
+            }
+        }
+
         // Variants not yet exposed at the FFI boundary. Silently
         // dropped in v1; a future ABI minor bump grows the surface
         // to cover them as each feature lands in the macOS SwiftUI
@@ -380,14 +467,7 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         | DspToUi::BandwidthChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
         | DspToUi::VoiceSquelchOpenChanged(_)
-        | DspToUi::RtlTcpConnectionState(_)
-        // `NetworkSinkStatus` is engine-only in PR 1 (issue #247
-        // engine-side plumbing). The FFI surface gains a
-        // matching `SDR_EVT_NETWORK_SINK_STATUS` variant in PR 2
-        // alongside the FFI command wrappers; until then drop
-        // the event silently rather than dispatching it as a
-        // generic error.
-        | DspToUi::NetworkSinkStatus(_) => return None,
+        | DspToUi::RtlTcpConnectionState(_) => return None,
     };
 
     Some((event, owned_cstring, owned_vec))

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -740,6 +740,129 @@ mod tests {
         assert_eq!(SDR_EVT_AUDIO_RECORDING_STOPPED, 9);
         assert_eq!(SDR_EVT_IQ_RECORDING_STARTED, 10);
         assert_eq!(SDR_EVT_IQ_RECORDING_STOPPED, 11);
+        assert_eq!(SDR_EVT_NETWORK_SINK_STATUS, 12);
+    }
+
+    #[test]
+    fn network_sink_status_discriminants_match_header() {
+        // Same lock-in for the tagged-payload sub-discriminants
+        // and the protocol values — these are part of the ABI
+        // just like the outer event kinds. Per `CodeRabbit`
+        // round 1 on PR #352.
+        assert_eq!(SDR_NETWORK_SINK_STATUS_INACTIVE, 0);
+        assert_eq!(SDR_NETWORK_SINK_STATUS_ACTIVE, 1);
+        assert_eq!(SDR_NETWORK_SINK_STATUS_ERROR, 2);
+        assert_eq!(SDR_NETWORK_PROTOCOL_TCP_SERVER, 0);
+        assert_eq!(SDR_NETWORK_PROTOCOL_UDP, 1);
+    }
+
+    // ------------------------------------------------------
+    //  translate_event — network sink status (ABI 0.9, #247)
+    //
+    //  Direct Rust-side coverage of the three NetworkSinkStatus
+    //  arms, including NULL vs non-NULL string cases and the
+    //  `Protocol::TcpClient` → `SDR_NETWORK_PROTOCOL_TCP_SERVER`
+    //  name-bridge. Locks the contract in before Swift decoding
+    //  sees it. Per `CodeRabbit` round 1 on PR #352.
+    // ------------------------------------------------------
+
+    #[test]
+    fn translate_network_sink_status_inactive_has_null_utf8_and_unused_protocol() {
+        use sdr_core::{DspToUi, NetworkSinkStatus};
+        let (event, owned_cstring, owned_vec) =
+            translate_event(&DspToUi::NetworkSinkStatus(NetworkSinkStatus::Inactive))
+                .expect("inactive event should translate");
+        assert_eq!(event.kind, SDR_EVT_NETWORK_SINK_STATUS);
+        // SAFETY: kind dispatch above narrows the union field.
+        let payload = unsafe { event.payload.network_sink_status };
+        assert_eq!(payload.kind, SDR_NETWORK_SINK_STATUS_INACTIVE);
+        assert!(payload.utf8.is_null());
+        assert_eq!(payload.protocol, -1);
+        assert!(owned_cstring.is_none());
+        assert!(owned_vec.is_none());
+    }
+
+    #[test]
+    fn translate_network_sink_status_active_tcp_maps_to_tcp_server() {
+        use sdr_core::{DspToUi, NetworkSinkStatus};
+        let status = NetworkSinkStatus::Active {
+            endpoint: "127.0.0.1:1234".to_string(),
+            protocol: sdr_types::Protocol::TcpClient,
+        };
+        let (event, owned_cstring, _) = translate_event(&DspToUi::NetworkSinkStatus(status))
+            .expect("active event should translate");
+        assert_eq!(event.kind, SDR_EVT_NETWORK_SINK_STATUS);
+        let payload = unsafe { event.payload.network_sink_status };
+        assert_eq!(payload.kind, SDR_NETWORK_SINK_STATUS_ACTIVE);
+        assert!(!payload.utf8.is_null());
+        // Rust-side `TcpClient` bridges to the clearer C name
+        // `TCP_SERVER`. This is the contract the Swift side
+        // relies on — lock it here.
+        assert_eq!(payload.protocol, SDR_NETWORK_PROTOCOL_TCP_SERVER);
+
+        // SAFETY: utf8 points into `owned_cstring` which is kept
+        // alive by the `_` binding in the destructure above for
+        // the duration of this test.
+        let cstr = unsafe { std::ffi::CStr::from_ptr(payload.utf8) };
+        assert_eq!(cstr.to_str().unwrap(), "127.0.0.1:1234");
+        assert!(owned_cstring.is_some(), "endpoint CString must be owned");
+    }
+
+    #[test]
+    fn translate_network_sink_status_active_udp_maps_to_udp_constant() {
+        use sdr_core::{DspToUi, NetworkSinkStatus};
+        let status = NetworkSinkStatus::Active {
+            endpoint: "192.168.1.10:9000".to_string(),
+            protocol: sdr_types::Protocol::Udp,
+        };
+        let (event, _owned_cstring, _) = translate_event(&DspToUi::NetworkSinkStatus(status))
+            .expect("active event should translate");
+        let payload = unsafe { event.payload.network_sink_status };
+        assert_eq!(payload.kind, SDR_NETWORK_SINK_STATUS_ACTIVE);
+        assert_eq!(payload.protocol, SDR_NETWORK_PROTOCOL_UDP);
+    }
+
+    #[test]
+    fn translate_network_sink_status_error_carries_message_and_unused_protocol() {
+        use sdr_core::{DspToUi, NetworkSinkStatus};
+        let status = NetworkSinkStatus::Error {
+            message: "bind failed: address already in use".to_string(),
+        };
+        let (event, owned_cstring, _) = translate_event(&DspToUi::NetworkSinkStatus(status))
+            .expect("error event should translate");
+        let payload = unsafe { event.payload.network_sink_status };
+        assert_eq!(payload.kind, SDR_NETWORK_SINK_STATUS_ERROR);
+        assert!(!payload.utf8.is_null());
+        // Protocol is unused for the error arm per the ABI doc.
+        assert_eq!(payload.protocol, -1);
+        let cstr = unsafe { std::ffi::CStr::from_ptr(payload.utf8) };
+        assert_eq!(
+            cstr.to_str().unwrap(),
+            "bind failed: address already in use"
+        );
+        assert!(
+            owned_cstring.is_some(),
+            "error message CString must be owned"
+        );
+    }
+
+    #[test]
+    fn translate_network_sink_status_sanitizes_interior_nul_in_endpoint() {
+        // Regression guard: a stray NUL in an endpoint string
+        // must not drop the event silently. The translate path
+        // replaces interior NULs with `?` before `CString::new`,
+        // same as the DeviceInfo and Error paths.
+        use sdr_core::{DspToUi, NetworkSinkStatus};
+        let status = NetworkSinkStatus::Active {
+            endpoint: "host\0injected:1234".to_string(),
+            protocol: sdr_types::Protocol::TcpClient,
+        };
+        let (event, _owned, _) = translate_event(&DspToUi::NetworkSinkStatus(status))
+            .expect("sanitized active event should translate");
+        let payload = unsafe { event.payload.network_sink_status };
+        assert!(!payload.utf8.is_null());
+        let cstr = unsafe { std::ffi::CStr::from_ptr(payload.utf8) };
+        assert_eq!(cstr.to_str().unwrap(), "host?injected:1234");
     }
 
     #[test]

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 8;
+pub const ABI_VERSION_MINOR: u32 = 9;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 8);
+        assert!(ABI_VERSION_MINOR == 9);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 8
+#define SDR_CORE_ABI_VERSION_MINOR 9
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -444,6 +444,64 @@ int32_t sdr_core_set_volume(SdrCore* handle, float volume_0_1);
  */
 int32_t sdr_core_set_audio_device(SdrCore* handle, const char* uid_utf8);
 
+/* --- Audio sink selection (issue #247, ABI 0.9) --- */
+/*
+ * Switch between local audio output and TCP/UDP network
+ * streaming, and configure the network endpoint. Stops the
+ * current sink, builds the replacement using the persisted
+ * device / network config, and restarts it if the engine is
+ * running. Status updates are surfaced through the new
+ * `SDR_EVT_NETWORK_SINK_STATUS` event below — hosts use it
+ * to drive a status row in the audio settings panel.
+ */
+
+/*
+ * Active audio sink. Mirrors `crate::sink_slot::AudioSinkType`
+ * on the Rust side. Stable discriminants — never reorder.
+ */
+typedef enum SdrAudioSinkType {
+    SDR_AUDIO_SINK_LOCAL   = 0,
+    SDR_AUDIO_SINK_NETWORK = 1,
+} SdrAudioSinkType;
+
+/*
+ * Network stream protocol. Reused by the network audio sink
+ * config command and the matching status payload below. Stable
+ * discriminants — never reorder.
+ *
+ * Note: `TCP_SERVER` mirrors `sdr_types::Protocol::TcpClient`
+ * on the Rust side. The historical "client" naming there comes
+ * from SDR++ — the device acts as the TCP **server** accepting
+ * client connections. The C ABI uses the clearer name.
+ */
+typedef enum SdrNetworkProtocol {
+    SDR_NETWORK_PROTOCOL_TCP_SERVER = 0,
+    SDR_NETWORK_PROTOCOL_UDP        = 1,
+} SdrNetworkProtocol;
+
+/*
+ * Switch the active audio sink type. `sink_type` must be one
+ * of `SDR_AUDIO_SINK_*`. Returns `SDR_CORE_ERR_INVALID_ARG`
+ * for unknown values.
+ */
+int32_t sdr_core_set_audio_sink_type(SdrCore* handle, int32_t sink_type);
+
+/*
+ * Configure the network audio sink endpoint. `hostname_utf8`
+ * must be non-null, non-empty, NUL-terminated UTF-8.
+ * `protocol` must be one of `SDR_NETWORK_PROTOCOL_*`.
+ *
+ * If the network sink is currently active the engine rebuilds
+ * it inline so the new endpoint takes effect immediately;
+ * otherwise the values are stored for the next switch.
+ */
+int32_t sdr_core_set_network_sink_config(
+    SdrCore*    handle,
+    const char* hostname_utf8,
+    uint16_t    port,
+    int32_t     protocol
+);
+
 /*
  * Start / stop recording the demodulated audio stream to a 16-bit
  * PCM WAV file. The engine opens the file on `start`, writes every
@@ -715,7 +773,17 @@ typedef enum SdrEventKind {
     SDR_EVT_AUDIO_RECORDING_STOPPED = 9,
     SDR_EVT_IQ_RECORDING_STARTED    = 10,
     SDR_EVT_IQ_RECORDING_STOPPED    = 11,
+    SDR_EVT_NETWORK_SINK_STATUS     = 12, /* ABI 0.9 — issue #247 */
 } SdrEventKind;
+
+/* Discriminants for the `kind` field of `SdrEventNetworkSinkStatus`
+ * below. Stable — never reorder.
+ */
+typedef enum SdrNetworkSinkStatusKind {
+    SDR_NETWORK_SINK_STATUS_INACTIVE = 0,
+    SDR_NETWORK_SINK_STATUS_ACTIVE   = 1,
+    SDR_NETWORK_SINK_STATUS_ERROR    = 2,
+} SdrNetworkSinkStatusKind;
 
 /*
  * Payload for SDR_EVT_DEVICE_INFO. `utf8` is a NUL-terminated
@@ -771,6 +839,25 @@ typedef struct SdrEventIqRecording {
 } SdrEventIqRecording;
 
 /*
+ * Payload for SDR_EVT_NETWORK_SINK_STATUS. Tagged by `kind`
+ * (one of `SDR_NETWORK_SINK_STATUS_*`):
+ *
+ * | kind                              | utf8                  | protocol                |
+ * |-----------------------------------|-----------------------|-------------------------|
+ * | SDR_NETWORK_SINK_STATUS_INACTIVE  | NULL                  | -1 (unused)             |
+ * | SDR_NETWORK_SINK_STATUS_ACTIVE    | endpoint host:port    | SDR_NETWORK_PROTOCOL_*  |
+ * | SDR_NETWORK_SINK_STATUS_ERROR     | error message         | -1 (unused)             |
+ *
+ * `utf8` is borrowed from dispatcher-owned storage; valid only
+ * for the duration of the callback. Per issue #247.
+ */
+typedef struct SdrEventNetworkSinkStatus {
+    int32_t     kind;
+    const char* utf8;
+    int32_t     protocol;
+} SdrEventNetworkSinkStatus;
+
+/*
  * Tagged union of all event payloads. Which union field is valid
  * is determined by the `kind` discriminant on the enclosing
  * SdrEvent (see the table below).
@@ -788,16 +875,18 @@ typedef struct SdrEventIqRecording {
  * SDR_EVT_AUDIO_RECORDING_STOPPED     none (all-zero payload)
  * SDR_EVT_IQ_RECORDING_STARTED        iq_recording.path_utf8
  * SDR_EVT_IQ_RECORDING_STOPPED        none (all-zero payload)
+ * SDR_EVT_NETWORK_SINK_STATUS         network_sink_status.{kind,utf8,protocol}
  */
 typedef union SdrEventPayload {
     double sample_rate_hz;
     float  signal_level_db;
     double display_bandwidth_hz;
-    SdrEventDeviceInfo     device_info;
-    SdrEventGainList       gain_list;
-    SdrEventError          error;
-    SdrEventAudioRecording audio_recording;
-    SdrEventIqRecording    iq_recording;
+    SdrEventDeviceInfo        device_info;
+    SdrEventGainList          gain_list;
+    SdrEventError             error;
+    SdrEventAudioRecording    audio_recording;
+    SdrEventIqRecording       iq_recording;
+    SdrEventNetworkSinkStatus network_sink_status;
     /* Placeholder so kinds with no payload (e.g., SOURCE_STOPPED)
      * have a well-defined zeroed payload representation. */
     uint64_t _placeholder;


### PR DESCRIPTION
## Summary

Second and final PR for the network audio sink feature tracked by issue #247. Builds on #351 (the engine-side plumbing) to expose the feature to the macOS SwiftUI host.

- **FFI (ABI 0.8 → 0.9)** — adds `sdr_core_set_audio_sink_type` and `sdr_core_set_network_sink_config` commands plus the `SDR_EVT_NETWORK_SINK_STATUS` event variant with a three-kind tagged payload (`inactive` / `active{endpoint,protocol}` / `error{message}`).
- **SdrCoreKit** — matching Swift enums (`AudioSinkType`, `NetworkProtocol`, `NetworkSinkStatus`), `.networkSinkStatus` variant on `SdrCoreEvent`, and typed throwing wrappers (`setAudioSinkType`, `setNetworkSinkConfig`). Also fixes deprecation / Sendable warnings that had accumulated across earlier ABI bumps.
- **SwiftUI host** — `CoreModel` gains observable state (sink type, host/port/protocol, last status) with `UserDefaults` persistence and setter methods; the Settings → Audio pane grows a sink-type segmented picker, a network endpoint form, an Apply button, and a color-coded status row.

Together with #351 this closes #247.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `make ffi-header-check`
- [x] `swift test` (SdrCoreKit — 15 passed)
- [x] `xcodebuild -scheme SDRMac -configuration Debug build` — succeeds, zero warnings
- [ ] Smoke test on macOS: flip sink to Network, verify TCP server binds and status row lights up; verify flipping back to Local reconnects CoreAudio; kill the network backend mid-stream and verify the Error status renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network audio streaming support (TCP & UDP) and UI to switch output between local and network
  * Settings page to configure network sink endpoint (hostname, port, protocol) with Apply action
  * Live network sink status shown as inactive / active(endpoint, protocol) / error

* **Bug Fixes**
  * More robust C-string decoding and improved concurrency safety for error types

* **Tests**
  * Expanded tests for sink switching, config validation, and network-sink event handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->