### PR TITLE
SwiftUI source pickers: network IQ + file playback (closes #235, #236)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -341,6 +341,44 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(uid.withCString { sdr_core_set_audio_device(handle, $0) })
     }
 
+    /// Switch the active IQ source between the local RTL-SDR
+    /// dongle, a network IQ stream, a WAV file, or an rtl_tcp
+    /// client. The engine stops the current source, rebuilds
+    /// from the persisted per-type config (network host/port,
+    /// file path, etc.), and restarts if the engine is running.
+    /// Per issues #235, #236.
+    public func setSourceType(_ type: SourceType) throws {
+        try checkRc(sdr_core_set_source_type(handle, type.rawValue))
+    }
+
+    /// Configure the network IQ source endpoint. `hostname`
+    /// must be non-empty; `port` is the TCP / UDP port;
+    /// `protocol` picks the transport. The engine stores the
+    /// values; they take effect on the next switch into
+    /// `.network` (or when the engine restarts while `.network`
+    /// is already active).
+    public func setNetworkConfig(
+        hostname: String,
+        port: UInt16,
+        protocol proto: NetworkSourceProtocol
+    ) throws {
+        try checkRc(hostname.withCString { cHost in
+            sdr_core_set_network_config(handle, cHost, port, proto.rawValue)
+        })
+    }
+
+    /// Set the filesystem path the file-playback source reads
+    /// from the next time `.file` is activated (or the source
+    /// is restarted while `.file` is already active). The
+    /// engine does not open the file here — only stores the
+    /// path. Open errors surface as `.error(...)` /
+    /// `.sourceStopped` events once the source actually starts.
+    public func setFilePath(_ path: String) throws {
+        try checkRc(path.withCString { cPath in
+            sdr_core_set_file_path(handle, cPath)
+        })
+    }
+
     /// Switch the active audio sink between the local output
     /// device and the network stream. The engine stops the
     /// current sink, builds the replacement from the persisted

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
@@ -69,6 +69,53 @@ public enum Deemphasis: Int32, Sendable, CaseIterable, Codable {
     }
 }
 
+/// Active IQ source. Matches `SdrSourceType` in the C header.
+/// `.rtlSdr` drives a locally-connected dongle over USB,
+/// `.network` streams IQ from a remote server via TCP or UDP,
+/// `.file` replays a WAV file on disk, `.rtlTcp` is a
+/// protocol-level rtl_tcp client (separate pipeline from
+/// `.network`, see issue #304). Per issues #235, #236.
+public enum SourceType: Int32, Sendable, CaseIterable, Codable {
+    case rtlSdr  = 0
+    case network = 1
+    case file    = 2
+    case rtlTcp  = 3
+
+    public var label: String {
+        switch self {
+        case .rtlSdr:  return "RTL-SDR (USB)"
+        case .network: return "Network IQ"
+        case .file:    return "File playback"
+        case .rtlTcp:  return "RTL-TCP"
+        }
+    }
+}
+
+/// Transport for the network IQ source. Matches
+/// `SdrSourceProtocol` in the C header.
+///
+/// Note: this is **not** the same enum as the audio-sink
+/// `NetworkProtocol`. Both map to the same underlying Rust
+/// `Protocol` variant, but the wire direction is opposite:
+/// on the sink side `Protocol::TcpClient` means "device
+/// listens as TCP server for audio clients" (hence the sink
+/// label `.tcpServer`), while on the source side the same
+/// variant means "device connects outbound as TCP client to
+/// a remote IQ server". The C ABI uses the neutral names
+/// `SDR_SOURCE_PROTOCOL_TCP` / `_UDP` on this side to avoid
+/// importing the sink-side confusion. Per issue #235.
+public enum NetworkSourceProtocol: Int32, Sendable, CaseIterable, Codable {
+    case tcp = 0
+    case udp = 1
+
+    public var label: String {
+        switch self {
+        case .tcp: return "TCP"
+        case .udp: return "UDP"
+        }
+    }
+}
+
 /// Active audio sink selection. Matches `SdrAudioSinkType` in the
 /// C header. `.local` routes to a `CoreAudio` output device; `.network`
 /// streams post-demod audio to the configured host:port over

--- a/apps/macos/Packages/SdrCoreKit/Tests/SdrCoreKitTests/SdrCoreTests.swift
+++ b/apps/macos/Packages/SdrCoreKit/Tests/SdrCoreKitTests/SdrCoreTests.swift
@@ -17,14 +17,15 @@ final class SdrCoreTests: XCTestCase {
 
     func testAbiVersionMatchesCurrent() {
         // Lock in that the Swift wrapper parses the packed
-        // version from the C side consistently. Current: 0.9
+        // version from the C side consistently. Current: 0.10
         // (0.2 device enumeration; 0.3 auto-squelch;
         // 0.4 audio routing + recording; 0.5 IQ recording;
         // 0.6 RadioReference; 0.7 advanced demod; 0.8 audio tap;
-        // 0.9 network audio sink — issue #247.)
+        // 0.9 network audio sink; 0.10 source selection + network
+        // / file config — issues #235, #236.)
         let v = SdrCore.abiVersion
         XCTAssertEqual(v.major, 0)
-        XCTAssertEqual(v.minor, 9)
+        XCTAssertEqual(v.minor, 10)
     }
 
     func testInitLoggingIsIdempotent() {
@@ -177,6 +178,49 @@ final class SdrCoreTests: XCTestCase {
     // ==========================================================
     //  Error message round-trip
     // ==========================================================
+
+    // ==========================================================
+    //  Source selection (ABI 0.10, issues #235, #236)
+    // ==========================================================
+
+    func testSetSourceTypeRoundTripsAllVariants() throws {
+        let core = try SdrCore(configPath: nil)
+        for t in SourceType.allCases {
+            try core.setSourceType(t)
+        }
+    }
+
+    func testSetNetworkConfigAcceptsValidInput() throws {
+        let core = try SdrCore(configPath: nil)
+        try core.setNetworkConfig(hostname: "127.0.0.1", port: 1234, protocol: .tcp)
+        try core.setNetworkConfig(hostname: "iq.example.com", port: 9000, protocol: .udp)
+    }
+
+    func testSetNetworkConfigRejectsEmptyHostAndZeroPort() throws {
+        let core = try SdrCore(configPath: nil)
+        XCTAssertThrowsError(
+            try core.setNetworkConfig(hostname: "", port: 1234, protocol: .tcp)
+        ) { error in
+            XCTAssertEqual((error as? SdrCoreError)?.code, .invalidArg)
+        }
+        XCTAssertThrowsError(
+            try core.setNetworkConfig(hostname: "127.0.0.1", port: 0, protocol: .tcp)
+        ) { error in
+            XCTAssertEqual((error as? SdrCoreError)?.code, .invalidArg)
+        }
+    }
+
+    func testSetFilePathAcceptsValidPath() throws {
+        let core = try SdrCore(configPath: nil)
+        try core.setFilePath("/tmp/some-iq.wav")
+    }
+
+    func testSetFilePathRejectsEmpty() throws {
+        let core = try SdrCore(configPath: nil)
+        XCTAssertThrowsError(try core.setFilePath("")) { error in
+            XCTAssertEqual((error as? SdrCoreError)?.code, .invalidArg)
+        }
+    }
 
     // ==========================================================
     //  Network audio sink (ABI 0.9, issue #247)

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -161,6 +161,35 @@ final class CoreModel {
     /// engine default (`sdr_pipeline::iq_frontend::DEFAULT_DECIM`).
     var decimationFactor: UInt32 = 8
 
+    // ----------------------------------------------------------
+    //  Source selection — issues #235, #236 (ABI 0.10)
+    // ----------------------------------------------------------
+
+    /// Active IQ source. Default is `.rtlSdr` to match the
+    /// engine's startup state (`SourceType::RtlSdr` in
+    /// `crates/sdr-core/src/controller.rs`). Persisted to
+    /// `UserDefaults` so the pick survives relaunches.
+    var sourceType: SourceType = .rtlSdr
+
+    /// Network IQ source hostname. Default "localhost" mirrors
+    /// the GTK source panel's initial value.
+    var networkSourceHost: String = "localhost"
+
+    /// Network IQ source port. Default 1234 matches the
+    /// canonical rtl_tcp / IQ-server port convention.
+    var networkSourcePort: UInt16 = 1234
+
+    /// Network IQ source transport. Defaults to TCP (dial
+    /// outbound); UDP is the "device binds locally and receives
+    /// datagrams" mode.
+    var networkSourceProtocol: NetworkSourceProtocol = .tcp
+
+    /// File-playback source filesystem path. Empty until the
+    /// user picks a file. The engine rejects the source start
+    /// on an empty / nonexistent / non-WAV path; no local
+    /// validation here.
+    var filePath: String = ""
+
     // ==========================================================
     //  Tuner
     // ==========================================================
@@ -387,6 +416,33 @@ final class CoreModel {
             selectedAudioDeviceUid = saved
         }
         refreshAudioDevices()
+
+        // Restore source-selection preferences — issues #235, #236.
+        // Same additive pattern as the audio-sink block below:
+        // absent keys leave the SourceType default (.rtlSdr) and
+        // the Rust-side defaults intact.
+        if UserDefaults.standard.object(forKey: Self.sourceTypeDefaultsKey) != nil {
+            let raw = Int32(UserDefaults.standard.integer(forKey: Self.sourceTypeDefaultsKey))
+            sourceType = SourceType(rawValue: raw) ?? .rtlSdr
+        }
+        if let host = UserDefaults.standard.string(forKey: Self.networkSourceHostDefaultsKey),
+           !host.isEmpty {
+            networkSourceHost = host
+        }
+        if UserDefaults.standard.object(forKey: Self.networkSourcePortDefaultsKey) != nil {
+            let stored = UserDefaults.standard.integer(forKey: Self.networkSourcePortDefaultsKey)
+            if (1...Int(UInt16.max)).contains(stored) {
+                networkSourcePort = UInt16(stored)
+            }
+        }
+        if UserDefaults.standard.object(forKey: Self.networkSourceProtocolDefaultsKey) != nil {
+            let raw = Int32(UserDefaults.standard.integer(forKey: Self.networkSourceProtocolDefaultsKey))
+            networkSourceProtocol = NetworkSourceProtocol(rawValue: raw) ?? .tcp
+        }
+        if let path = UserDefaults.standard.string(forKey: Self.filePathDefaultsKey),
+           !path.isEmpty {
+            filePath = path
+        }
 
         // Restore network audio sink preferences — issue #247.
         // Each field is independent; a partial write from a
@@ -653,6 +709,21 @@ final class CoreModel {
 
     func syncToEngine() {
         guard core != nil else { return }
+        // Push source-selection state first so the engine has
+        // the right network/file config in place before the
+        // source actually opens on Start. Per issues #235, #236.
+        // Host configs are pushed before the type switch so a
+        // restored `.network` / `.file` source opens with the
+        // user's values rather than the engine defaults.
+        applyNetworkSourceConfig(
+            host: networkSourceHost,
+            port: networkSourcePort,
+            protocol: networkSourceProtocol
+        )
+        if !filePath.isEmpty {
+            setFilePath(filePath)
+        }
+        setSourceType(sourceType)
         setCenter(centerFrequencyHz)
         setVfoOffset(vfoOffsetHz)
         setSampleRate(sourceSampleRateHz)
@@ -1026,6 +1097,71 @@ final class CoreModel {
             try core?.setNetworkSinkConfig(hostname: trimmed, port: port, protocol: proto)
         }
     }
+
+    // ----------------------------------------------------------
+    //  Source selection setters — issues #235, #236
+    // ----------------------------------------------------------
+
+    /// Switch the active IQ source. Optimistic — flips the UI
+    /// field before dispatching so dependent sections redraw
+    /// immediately. A source-open error lands later as an
+    /// `.error(...)` / `.sourceStopped` event.
+    func setSourceType(_ type: SourceType) {
+        sourceType = type
+        UserDefaults.standard.set(Int(type.rawValue), forKey: Self.sourceTypeDefaultsKey)
+        capture { try core?.setSourceType(type) }
+    }
+
+    /// Apply the current network-source host/port/protocol to
+    /// the engine. Called on explicit Apply in the Source pane
+    /// rather than per-keystroke — the engine rebuilds the
+    /// connection on receipt, so typing into the host field
+    /// shouldn't thrash it.
+    func applyNetworkSourceConfig(
+        host: String,
+        port: UInt16,
+        protocol proto: NetworkSourceProtocol
+    ) {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            lastError = "Network source host cannot be empty"
+            return
+        }
+        networkSourceHost = trimmed
+        networkSourcePort = port
+        networkSourceProtocol = proto
+        UserDefaults.standard.set(trimmed, forKey: Self.networkSourceHostDefaultsKey)
+        UserDefaults.standard.set(Int(port), forKey: Self.networkSourcePortDefaultsKey)
+        UserDefaults.standard.set(Int(proto.rawValue), forKey: Self.networkSourceProtocolDefaultsKey)
+        capture {
+            try core?.setNetworkConfig(hostname: trimmed, port: port, protocol: proto)
+        }
+    }
+
+    /// Set the file-playback source path. Empty input is
+    /// rejected locally to match the FFI contract — opening
+    /// with an empty path is an InvalidArg anyway, but failing
+    /// here keeps the UI responsive.
+    func setFilePath(_ path: String) {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            lastError = "File path cannot be empty"
+            return
+        }
+        filePath = trimmed
+        UserDefaults.standard.set(trimmed, forKey: Self.filePathDefaultsKey)
+        capture { try core?.setFilePath(trimmed) }
+    }
+
+    /// UserDefaults keys for the persisted source-selection
+    /// state. Matches the `audioDeviceDefaultsKey` / network-sink
+    /// pattern. The Rust config layer doesn't round-trip these
+    /// yet — tracked against the larger v3 config alignment.
+    static let sourceTypeDefaultsKey            = "SDRMac.sourceType"
+    static let networkSourceHostDefaultsKey     = "SDRMac.networkSourceHost"
+    static let networkSourcePortDefaultsKey     = "SDRMac.networkSourcePort"
+    static let networkSourceProtocolDefaultsKey = "SDRMac.networkSourceProtocol"
+    static let filePathDefaultsKey              = "SDRMac.filePath"
 
     /// UserDefaults keys for the persisted network-sink config.
     /// Matches the existing `audioDeviceDefaultsKey` pattern —

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -1106,7 +1106,18 @@ final class CoreModel {
     /// field before dispatching so dependent sections redraw
     /// immediately. A source-open error lands later as an
     /// `.error(...)` / `.sourceStopped` event.
+    ///
+    /// Guards against `.file` with an empty `filePath` — that
+    /// would tear down the current source and immediately fail
+    /// at open time. Callers (including `syncToEngine` on a
+    /// fresh install where the user hasn't picked a WAV yet)
+    /// should either set the path first or stay on the previous
+    /// source. Per `CodeRabbit` round 1 on PR #358.
     func setSourceType(_ type: SourceType) {
+        if type == .file && filePath.isEmpty {
+            lastError = "Choose a WAV file before switching to File playback"
+            return
+        }
         sourceType = type
         UserDefaults.standard.set(Int(type.rawValue), forKey: Self.sourceTypeDefaultsKey)
         capture { try core?.setSourceType(type) }
@@ -1127,6 +1138,15 @@ final class CoreModel {
             lastError = "Network source host cannot be empty"
             return
         }
+        // Mirror the FFI boundary check (`sdr_core_set_network_config`
+        // rejects port 0) at the model so non-UI callers — e.g.
+        // `syncToEngine`, future programmatic paths — can't
+        // persist a bogus endpoint. Per `CodeRabbit` round 1 on
+        // PR #358.
+        guard port != 0 else {
+            lastError = "Network source port must be in 1…65535"
+            return
+        }
         networkSourceHost = trimmed
         networkSourcePort = port
         networkSourceProtocol = proto
@@ -1142,15 +1162,24 @@ final class CoreModel {
     /// rejected locally to match the FFI contract — opening
     /// with an empty path is an InvalidArg anyway, but failing
     /// here keeps the UI responsive.
+    ///
+    /// The path itself is **not** trimmed or otherwise
+    /// normalized. macOS filesystem paths can legally begin or
+    /// end with whitespace (or any non-NUL byte, really), and
+    /// silently rewriting the string would break playback for
+    /// a valid-but-unusual filename that `fileImporter`
+    /// returned. Validation uses a trimmed copy only; the
+    /// stored / persisted / dispatched value is the exact
+    /// caller-supplied string. Per `CodeRabbit` round 1 on
+    /// PR #358.
     func setFilePath(_ path: String) {
-        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
+        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             lastError = "File path cannot be empty"
             return
         }
-        filePath = trimmed
-        UserDefaults.standard.set(trimmed, forKey: Self.filePathDefaultsKey)
-        capture { try core?.setFilePath(trimmed) }
+        filePath = path
+        UserDefaults.standard.set(path, forKey: Self.filePathDefaultsKey)
+        capture { try core?.setFilePath(path) }
     }
 
     /// UserDefaults keys for the persisted source-selection

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -283,6 +283,10 @@ struct SourceSection: View {
             set: { proto in
                 // Protocol changes count as endpoint changes —
                 // push through immediately if host/port parse.
+                // The picker is disabled below when that's not
+                // true, so this branch is always reachable, but
+                // the guard stays as defence against a future
+                // regression that loosens the `.disabled`.
                 let host = normalizedHost
                 if !host.isEmpty, let port = portValue() {
                     model.applyNetworkSourceConfig(
@@ -297,6 +301,11 @@ struct SourceSection: View {
                 Text(p.label).tag(p)
             }
         }
+        // Same validity gate as the Apply button — without
+        // this the picker visually flips on bad host/port and
+        // snaps back on the next SwiftUI pass, which reads as a
+        // flaky control. Per `CodeRabbit` round 2 on PR #358.
+        .disabled(applyButtonDisabled)
 
         HStack {
             Button {

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -1,17 +1,23 @@
 //
 // SourceSection.swift — sidebar panel for source/tuner controls.
 //
-// MVP scope: RTL-SDR only (no device picker). Sample rate, gain
-// (discrete when AGC off), AGC, PPM. The device-picker and the
-// Network/File source forms land in v2 behind feature flags.
+// Device picker at top (RTL-SDR / Network IQ / File playback)
+// followed by per-source forms: RTL-SDR exposes the USB
+// tuner's sample rate / gain / AGC / PPM; Network exposes a
+// host/port/protocol triple with an Apply button; File exposes
+// a path text field with a "Choose WAV…" button. RTL-TCP is a
+// future source type (see issue #326 for its dedicated panel).
 //
 // Advanced controls (DC blocking, IQ inversion, IQ correction,
 // decimation) live in a collapsible "Advanced" DisclosureGroup
-// at the bottom, default-collapsed so the MVP layout stays
-// clean. Mirrors GTK's "Advanced" expander in its Source panel
-// (issue #246).
+// at the bottom, default-collapsed so the layout stays clean.
+// They apply to every source type because they sit in the IQ
+// frontend, not in the source itself. Mirrors GTK's "Advanced"
+// expander in its Source panel (issues #235, #236, #246).
 
 import SwiftUI
+import SdrCoreKit
+import UniformTypeIdentifiers
 
 /// RTL-SDR supported sample rates (in Hz). Matches
 /// `crates/sdr-rtlsdr::RATE_OPTIONS`.
@@ -27,61 +33,69 @@ private let rtlSdrSampleRates: [Double] = [
 /// `sdr-ui::sidebar::source_panel::DECIMATION_FACTORS`.
 private let decimationFactors: [UInt32] = [1, 2, 4, 8, 16]
 
+/// Source types offered in the top-of-section picker. RTL-TCP
+/// is deliberately omitted — it gets its own dedicated panel in
+/// issue #326 with the full rtl_tcp control surface (client
+/// picker, connection state, per-command gains/ppm/bias-T).
+/// Putting it in this generic picker would imply equal
+/// treatment it doesn't have yet.
+private let supportedSourceTypes: [SourceType] = [.rtlSdr, .network, .file]
+
 struct SourceSection: View {
     @Environment(CoreModel.self) private var model
 
+    /// Local edit buffer for the network host. Mirrors the
+    /// pattern from `SettingsView.AudioPane` — TextField edits
+    /// shouldn't rebuild the connection per keystroke.
+    @State private var hostEdit: String = ""
+
+    /// Local edit buffer for the network port.
+    @State private var portEdit: String = ""
+
+    /// One-shot latch so the initial `.onAppear` seeds the
+    /// local edit buffers from the model without clobbering
+    /// in-progress user edits when SwiftUI re-fires `.onAppear`
+    /// on sibling state changes. Same pattern as the audio
+    /// pane.
+    @State private var didPrefill: Bool = false
+
+    /// Backing state for the `fileImporter` sheet.
+    @State private var fileImporterPresented: Bool = false
+
     var body: some View {
         Section("Source") {
-            LabeledContent("Device") {
-                Text(model.deviceInfo.isEmpty ? "—" : model.deviceInfo)
-                    .foregroundStyle(.secondary)
-            }
-
-            LabeledContent("Sample rate") {
+            LabeledContent("Type") {
                 Picker("", selection: Binding(
-                    get: { model.sourceSampleRateHz },
-                    set: { model.setSampleRate($0) }
+                    get: { model.sourceType },
+                    set: { model.setSourceType($0) }
                 )) {
-                    ForEach(rtlSdrSampleRates, id: \.self) {
-                        Text(formatRate($0)).tag($0)
+                    ForEach(supportedSourceTypes, id: \.self) { t in
+                        Text(t.label).tag(t)
                     }
                 }
                 .labelsHidden()
             }
 
-            LabeledContent("Gain") {
-                if model.agcEnabled {
-                    Text("AGC").foregroundStyle(.secondary)
-                } else if model.availableGains.isEmpty {
-                    Text("—").foregroundStyle(.secondary)
-                } else {
-                    GainSlider(
-                        steps: model.availableGains,
-                        value: model.gainDb,
-                        commit: { model.setGain($0) }
-                    )
-                }
+            // Per-source content — one `@ViewBuilder` block per
+            // type keeps the outer `body` readable. Only the
+            // active type's fields render; switching sources
+            // collapses the rest.
+            switch model.sourceType {
+            case .rtlSdr: rtlSdrControls
+            case .network: networkControls
+            case .file: fileControls
+            case .rtlTcp:
+                // Defensive arm — not reachable through the
+                // picker but the persisted `sourceType` could
+                // restore to `.rtlTcp` from a future build.
+                // Show a note pointing at the dedicated panel.
+                Text("RTL-TCP has a dedicated panel (see issue #326).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
-            Toggle("AGC", isOn: Binding(
-                get: { model.agcEnabled },
-                set: { model.setAgc($0) }
-            ))
-
-            LabeledContent("PPM") {
-                Stepper(value: Binding(
-                    get: { model.ppmCorrection },
-                    set: { model.setPpm($0) }
-                ), in: -100...100) {
-                    Text("\(model.ppmCorrection)")
-                }
-            }
-
-            // Collapsible "Advanced" group — default-collapsed
-            // because most users never touch these toggles. The
-            // four FFI commands have existed since the M2 ABI;
-            // this commit just surfaces them. Mirrors the GTK
-            // Source panel's expander (#246).
+            // "Advanced" group applies to every source — lives
+            // in the IQ frontend, not the source itself.
             DisclosureGroup("Advanced") {
                 Toggle("DC blocking", isOn: Binding(
                     get: { model.dcBlockingEnabled },
@@ -112,6 +126,173 @@ struct SourceSection: View {
                 }
             }
         }
+        .onAppear {
+            guard !didPrefill else { return }
+            didPrefill = true
+            hostEdit = model.networkSourceHost
+            portEdit = String(model.networkSourcePort)
+        }
+        .fileImporter(
+            isPresented: $fileImporterPresented,
+            allowedContentTypes: [.wav, .audio],
+            allowsMultipleSelection: false
+        ) { result in
+            if case .success(let urls) = result, let url = urls.first {
+                model.setFilePath(url.path)
+            }
+        }
+    }
+
+    /// Parse `portEdit` into a `UInt16` in the legal range.
+    /// Returns `nil` on empty / non-numeric / out-of-range input.
+    /// Matches the audio-pane helper shape.
+    private func portValue() -> UInt16? {
+        guard let raw = Int(portEdit.trimmingCharacters(in: .whitespaces)),
+              (1...Int(UInt16.max)).contains(raw) else {
+            return nil
+        }
+        return UInt16(raw)
+    }
+
+    /// Host with leading/trailing whitespace stripped — single
+    /// source of truth for the normalization step.
+    private var normalizedHost: String {
+        hostEdit.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var applyButtonDisabled: Bool {
+        normalizedHost.isEmpty || portValue() == nil
+    }
+
+    // ----------------------------------------------------------
+    //  Per-source form fragments
+    // ----------------------------------------------------------
+
+    @ViewBuilder
+    private var rtlSdrControls: some View {
+        LabeledContent("Device") {
+            Text(model.deviceInfo.isEmpty ? "—" : model.deviceInfo)
+                .foregroundStyle(.secondary)
+        }
+
+        LabeledContent("Sample rate") {
+            Picker("", selection: Binding(
+                get: { model.sourceSampleRateHz },
+                set: { model.setSampleRate($0) }
+            )) {
+                ForEach(rtlSdrSampleRates, id: \.self) {
+                    Text(formatRate($0)).tag($0)
+                }
+            }
+            .labelsHidden()
+        }
+
+        LabeledContent("Gain") {
+            if model.agcEnabled {
+                Text("AGC").foregroundStyle(.secondary)
+            } else if model.availableGains.isEmpty {
+                Text("—").foregroundStyle(.secondary)
+            } else {
+                GainSlider(
+                    steps: model.availableGains,
+                    value: model.gainDb,
+                    commit: { model.setGain($0) }
+                )
+            }
+        }
+
+        Toggle("AGC", isOn: Binding(
+            get: { model.agcEnabled },
+            set: { model.setAgc($0) }
+        ))
+
+        LabeledContent("PPM") {
+            Stepper(value: Binding(
+                get: { model.ppmCorrection },
+                set: { model.setPpm($0) }
+            ), in: -100...100) {
+                Text("\(model.ppmCorrection)")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var networkControls: some View {
+        TextField("Host", text: $hostEdit)
+            .textFieldStyle(.roundedBorder)
+            .disableAutocorrection(true)
+        TextField("Port", text: $portEdit)
+            .textFieldStyle(.roundedBorder)
+        Picker("Protocol", selection: Binding(
+            get: { model.networkSourceProtocol },
+            set: { proto in
+                // Protocol changes count as endpoint changes —
+                // push through immediately if host/port parse.
+                let host = normalizedHost
+                if !host.isEmpty, let port = portValue() {
+                    model.applyNetworkSourceConfig(
+                        host: host,
+                        port: port,
+                        protocol: proto
+                    )
+                }
+            }
+        )) {
+            ForEach(NetworkSourceProtocol.allCases, id: \.self) { p in
+                Text(p.label).tag(p)
+            }
+        }
+
+        HStack {
+            Button {
+                let host = normalizedHost
+                guard !host.isEmpty, let port = portValue() else { return }
+                model.applyNetworkSourceConfig(
+                    host: host,
+                    port: port,
+                    protocol: model.networkSourceProtocol
+                )
+            } label: {
+                Label("Apply", systemImage: "arrow.up.circle")
+            }
+            .disabled(applyButtonDisabled)
+        }
+
+        Text(
+            "TCP dials outbound to a remote IQ server. UDP binds locally and receives datagrams."
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder
+    private var fileControls: some View {
+        LabeledContent("File") {
+            // Path is read-only text; edits go through
+            // `fileImporter` below so we can round-trip a
+            // sandboxed URL if the app ever gets sandboxed.
+            Text(model.filePath.isEmpty ? "—" : (model.filePath as NSString).lastPathComponent)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+        Button {
+            fileImporterPresented = true
+        } label: {
+            Label("Choose WAV…", systemImage: "folder")
+        }
+        if !model.filePath.isEmpty {
+            Text(model.filePath)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+        Text("Plays back a two-channel (I/Q) WAV file. Sample rate is read from the file header.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
     }
 }
 

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -44,6 +44,19 @@ private let supportedSourceTypes: [SourceType] = [.rtlSdr, .network, .file]
 struct SourceSection: View {
     @Environment(CoreModel.self) private var model
 
+    /// User's currently-visible-but-possibly-uncommitted source
+    /// selection. Seeded from `model.sourceType` on first appear
+    /// and updated by the picker. Distinct from
+    /// `model.sourceType` so the picker can show the intended
+    /// type while the user is still configuring its endpoint —
+    /// switching to `.network` or `.file` **without** first
+    /// knowing a valid host/port or file path would tear down
+    /// the current source and leave the engine on a broken one
+    /// until the user manually fixed it. `.rtlSdr` commits
+    /// immediately since it needs no config. Per `CodeRabbit`
+    /// round 1 on PR #358.
+    @State private var pendingType: SourceType = .rtlSdr
+
     /// Local edit buffer for the network host. Mirrors the
     /// pattern from `SettingsView.AudioPane` — TextField edits
     /// shouldn't rebuild the connection per keystroke.
@@ -66,8 +79,21 @@ struct SourceSection: View {
         Section("Source") {
             LabeledContent("Type") {
                 Picker("", selection: Binding(
-                    get: { model.sourceType },
-                    set: { model.setSourceType($0) }
+                    get: { pendingType },
+                    set: { newType in
+                        pendingType = newType
+                        // `.rtlSdr` needs no per-source config,
+                        // so commit immediately — matches user
+                        // expectation that "I picked RTL-SDR"
+                        // means the engine switches now.
+                        // `.network` and `.file` defer to the
+                        // Apply / Choose buttons below. `.rtlTcp`
+                        // is filtered out of `supportedSourceTypes`
+                        // so we never see it as a user selection.
+                        if newType == .rtlSdr {
+                            model.setSourceType(.rtlSdr)
+                        }
+                    }
                 )) {
                     ForEach(supportedSourceTypes, id: \.self) { t in
                         Text(t.label).tag(t)
@@ -76,19 +102,26 @@ struct SourceSection: View {
                 .labelsHidden()
             }
 
-            // Per-source content — one `@ViewBuilder` block per
-            // type keeps the outer `body` readable. Only the
+            // Per-source content follows the **pending** type so
+            // the user can configure before commit. Only the
             // active type's fields render; switching sources
-            // collapses the rest.
-            switch model.sourceType {
+            // collapses the rest. `model.sourceType` still
+            // determines what the engine is actually running,
+            // and a small caption below flags an uncommitted
+            // change so the picker doesn't feel like a no-op
+            // while the user is mid-configure.
+            switch pendingType {
             case .rtlSdr: rtlSdrControls
             case .network: networkControls
             case .file: fileControls
             case .rtlTcp:
-                // Defensive arm — not reachable through the
-                // picker but the persisted `sourceType` could
-                // restore to `.rtlTcp` from a future build.
-                // Show a note pointing at the dedicated panel.
+                // Defensive arm — filtered out of
+                // `supportedSourceTypes` so not reachable
+                // through the picker, but the persisted value
+                // from a future build could restore `.rtlTcp`
+                // into `model.sourceType` (and via the
+                // `.onAppear` sync into `pendingType`). Show a
+                // breadcrumb rather than a broken form.
                 Text("RTL-TCP has a dedicated panel (see issue #326).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -129,16 +162,38 @@ struct SourceSection: View {
         .onAppear {
             guard !didPrefill else { return }
             didPrefill = true
+            pendingType = model.sourceType
             hostEdit = model.networkSourceHost
             portEdit = String(model.networkSourcePort)
         }
+        .onChange(of: model.sourceType) { _, new in
+            // Sync the picker back to engine-side changes
+            // (bookmark apply, programmatic updates, etc.)
+            // without clobbering an in-progress user selection:
+            // only track if the pending choice matches the
+            // previous committed value.
+            if pendingType != new { pendingType = new }
+        }
         .fileImporter(
             isPresented: $fileImporterPresented,
-            allowedContentTypes: [.wav, .audio],
+            // WAV-only. The playback path is documented as
+            // two-channel (I/Q) WAV; widening to `.audio` would
+            // let the user pick files that only fail at engine
+            // open time. Per `CodeRabbit` round 1 on PR #358.
+            allowedContentTypes: [.wav],
             allowsMultipleSelection: false
         ) { result in
             if case .success(let urls) = result, let url = urls.first {
+                // Path first, then commit the source-type
+                // switch. `setFilePath` populates
+                // `model.filePath`; only then does
+                // `setSourceType(.file)`'s guard pass. Same
+                // engine-command ordering is important for
+                // correctness — the mpsc channel preserves
+                // order, so the engine sees the path update
+                // before the source-type change.
                 model.setFilePath(url.path)
+                model.setSourceType(.file)
             }
         }
     }
@@ -252,10 +307,25 @@ struct SourceSection: View {
                     port: port,
                     protocol: model.networkSourceProtocol
                 )
+                // Commit the source-type switch only AFTER the
+                // endpoint landed — avoids tearing down the
+                // current source before the new one has a
+                // valid address. When `.network` is already the
+                // active source this reduces to a no-op on the
+                // type but still triggers an engine-side
+                // reopen via the stored config. Per `CodeRabbit`
+                // round 1 on PR #358.
+                model.setSourceType(.network)
             } label: {
-                Label("Apply", systemImage: "arrow.up.circle")
+                Label(model.sourceType == .network ? "Apply" : "Use this source", systemImage: "arrow.up.circle")
             }
             .disabled(applyButtonDisabled)
+        }
+
+        if pendingType != model.sourceType {
+            Text("Source switches to Network IQ when you hit Apply.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
 
         Text(
@@ -280,7 +350,7 @@ struct SourceSection: View {
         Button {
             fileImporterPresented = true
         } label: {
-            Label("Choose WAV…", systemImage: "folder")
+            Label(model.sourceType == .file ? "Choose another WAV…" : "Choose WAV…", systemImage: "folder")
         }
         if !model.filePath.isEmpty {
             Text(model.filePath)
@@ -289,6 +359,11 @@ struct SourceSection: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .textSelection(.enabled)
+        }
+        if pendingType != model.sourceType {
+            Text("Source switches to File playback after you pick a WAV.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
         Text("Plays back a two-channel (I/Q) WAV file. Sample rate is read from the file header.")
             .font(.caption)

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -27,10 +27,10 @@
 use std::ffi::{CStr, c_char};
 use std::path::PathBuf;
 
-use sdr_core::UiToDsp;
+use sdr_core::{SourceType, UiToDsp};
 use sdr_pipeline::iq_frontend::FftWindow;
 use sdr_radio::DeemphasisMode;
-use sdr_types::DemodMode;
+use sdr_types::{DemodMode, Protocol};
 
 use crate::error::{SdrCoreError, clear_last_error, set_last_error};
 use crate::handle::SdrCore;
@@ -522,6 +522,151 @@ pub unsafe extern "C" fn sdr_core_set_audio_device(
         with_core(handle, |core| {
             let uid = cstr_to_string("sdr_core_set_audio_device", uid_utf8)?;
             send(core, UiToDsp::SetAudioDevice(uid))
+        })
+    }
+}
+
+// ============================================================
+//  Source selection (#235, #236) — switch the active IQ
+//  source and configure the per-source connection details.
+//
+//  Discriminants mirror the matching `Sdr*` enums in
+//  `include/sdr_core.h`. Reordering would silently break ABI.
+// ============================================================
+
+pub const SDR_SOURCE_RTLSDR: i32 = 0;
+pub const SDR_SOURCE_NETWORK: i32 = 1;
+pub const SDR_SOURCE_FILE: i32 = 2;
+pub const SDR_SOURCE_RTLTCP: i32 = 3;
+
+fn source_type_from_c(v: i32) -> Option<SourceType> {
+    match v {
+        SDR_SOURCE_RTLSDR => Some(SourceType::RtlSdr),
+        SDR_SOURCE_NETWORK => Some(SourceType::Network),
+        SDR_SOURCE_FILE => Some(SourceType::File),
+        SDR_SOURCE_RTLTCP => Some(SourceType::RtlTcp),
+        _ => None,
+    }
+}
+
+// The network **source** protocol discriminants live next to the
+// source commands rather than piggy-backing on
+// `SDR_NETWORK_PROTOCOL_TCP_SERVER` from the audio sink side.
+// Why: same underlying `sdr_types::Protocol` enum, but the
+// wire direction is opposite. On the sink side `TcpClient`
+// means "device listens as TCP server for audio clients" — the
+// C ABI name `TCP_SERVER` reflects that. On the source side
+// the same `TcpClient` means "device connects outbound as TCP
+// client to a remote IQ server". Reusing `TCP_SERVER` here
+// would be actively misleading for host authors. Per #235.
+
+pub const SDR_SOURCE_PROTOCOL_TCP: i32 = 0;
+pub const SDR_SOURCE_PROTOCOL_UDP: i32 = 1;
+
+fn source_protocol_from_c(v: i32) -> Option<Protocol> {
+    match v {
+        SDR_SOURCE_PROTOCOL_TCP => Some(Protocol::TcpClient),
+        SDR_SOURCE_PROTOCOL_UDP => Some(Protocol::Udp),
+        _ => None,
+    }
+}
+
+/// Switch the active IQ source. `source_type` must be one of
+/// `SDR_SOURCE_*`. The engine tears down the current source,
+/// rebuilds from the persisted per-type config (network host /
+/// port / protocol for Network, file path for File, etc.), and
+/// restarts if the engine is currently running. Returns
+/// `SDR_CORE_ERR_INVALID_ARG` for an unknown value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_source_type(handle: *mut SdrCore, source_type: i32) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let Some(t) = source_type_from_c(source_type) else {
+                set_last_error(format!(
+                    "sdr_core_set_source_type: unknown source_type {source_type}"
+                ));
+                return Err(SdrCoreError::InvalidArg);
+            };
+            send(core, UiToDsp::SetSourceType(t))
+        })
+    }
+}
+
+/// Configure the network IQ source endpoint. `hostname_utf8`
+/// must be a non-null, non-empty NUL-terminated UTF-8 C string.
+/// `port` must be in `1..=65535`. `protocol` must be one of
+/// `SDR_SOURCE_PROTOCOL_*`. The engine stores the config; a
+/// subsequent `sdr_core_set_source_type(SDR_SOURCE_NETWORK)`
+/// (or a source restart while Network is already active) uses
+/// the stored values to open the connection.
+///
+/// # Safety
+///
+/// `hostname_utf8` must be a NUL-terminated UTF-8 C string or
+/// null (null returns `SDR_CORE_ERR_INVALID_ARG`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_network_config(
+    handle: *mut SdrCore,
+    hostname_utf8: *const c_char,
+    port: u16,
+    protocol: i32,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let hostname = cstr_to_string("sdr_core_set_network_config", hostname_utf8)?;
+            if hostname.is_empty() {
+                set_last_error("sdr_core_set_network_config: hostname is empty");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            // Same zero-port rejection as `sdr_core_set_network_sink_config`
+            // — unusable endpoint on either direction.
+            if port == 0 {
+                set_last_error("sdr_core_set_network_config: port must be in 1..=65535, got 0");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            let Some(proto) = source_protocol_from_c(protocol) else {
+                set_last_error(format!(
+                    "sdr_core_set_network_config: unknown protocol {protocol}"
+                ));
+                return Err(SdrCoreError::InvalidArg);
+            };
+            send(
+                core,
+                UiToDsp::SetNetworkConfig {
+                    hostname,
+                    port,
+                    protocol: proto,
+                },
+            )
+        })
+    }
+}
+
+/// Set the filesystem path the file-playback source reads from
+/// the next time `SDR_SOURCE_FILE` is activated (or the source
+/// is restarted while File is already active). `path_utf8` must
+/// be a non-null, non-empty NUL-terminated UTF-8 C string. The
+/// engine does not open the file here — only stores the path.
+/// Open errors surface as `SDR_EVT_ERROR` / `SDR_EVT_SOURCE_STOPPED`
+/// when the source actually starts.
+///
+/// # Safety
+///
+/// `path_utf8` must be a NUL-terminated UTF-8 C string or null
+/// (null returns `SDR_CORE_ERR_INVALID_ARG`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_file_path(
+    handle: *mut SdrCore,
+    path_utf8: *const c_char,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let path = cstr_to_string("sdr_core_set_file_path", path_utf8)?;
+            if path.is_empty() {
+                set_last_error("sdr_core_set_file_path: path is empty");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            send(core, UiToDsp::SetFilePath(std::path::PathBuf::from(path)))
         })
     }
 }
@@ -1384,6 +1529,177 @@ mod tests {
                 "notch_frequency must reject {bad}"
             );
         }
+        destroy(h);
+    }
+
+    // ------------------------------------------------------
+    //  Source selection (#235, #236, ABI 0.10)
+    // ------------------------------------------------------
+
+    #[test]
+    fn source_type_from_c_covers_all_variants() {
+        assert_eq!(
+            source_type_from_c(SDR_SOURCE_RTLSDR),
+            Some(SourceType::RtlSdr)
+        );
+        assert_eq!(
+            source_type_from_c(SDR_SOURCE_NETWORK),
+            Some(SourceType::Network)
+        );
+        assert_eq!(source_type_from_c(SDR_SOURCE_FILE), Some(SourceType::File));
+        assert_eq!(
+            source_type_from_c(SDR_SOURCE_RTLTCP),
+            Some(SourceType::RtlTcp)
+        );
+        assert_eq!(source_type_from_c(99), None);
+        assert_eq!(source_type_from_c(-1), None);
+    }
+
+    #[test]
+    fn source_protocol_from_c_covers_all_variants() {
+        assert_eq!(
+            source_protocol_from_c(SDR_SOURCE_PROTOCOL_TCP),
+            Some(Protocol::TcpClient)
+        );
+        assert_eq!(
+            source_protocol_from_c(SDR_SOURCE_PROTOCOL_UDP),
+            Some(Protocol::Udp)
+        );
+        assert_eq!(source_protocol_from_c(99), None);
+    }
+
+    #[test]
+    fn set_source_type_accepts_all_variants() {
+        let h = make_handle();
+        for t in [
+            SDR_SOURCE_RTLSDR,
+            SDR_SOURCE_NETWORK,
+            SDR_SOURCE_FILE,
+            SDR_SOURCE_RTLTCP,
+        ] {
+            assert_eq!(
+                unsafe { sdr_core_set_source_type(h, t) },
+                SdrCoreError::Ok.as_int(),
+                "source type {t} should be accepted"
+            );
+        }
+        destroy(h);
+    }
+
+    #[test]
+    fn set_source_type_rejects_out_of_range_value() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_source_type(h, 99) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_source_type(h, -1) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_network_config_accepts_valid_input() {
+        let h = make_handle();
+        let host = CString::new(TEST_NETWORK_HOST_LOOPBACK).unwrap();
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_config(
+                    h,
+                    host.as_ptr(),
+                    TEST_NETWORK_PORT_TCP,
+                    SDR_SOURCE_PROTOCOL_TCP,
+                )
+            },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_config(
+                    h,
+                    host.as_ptr(),
+                    TEST_NETWORK_PORT_UDP,
+                    SDR_SOURCE_PROTOCOL_UDP,
+                )
+            },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_network_config_rejects_null_and_empty_hostname() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_config(
+                    h,
+                    std::ptr::null(),
+                    TEST_NETWORK_PORT_TCP,
+                    SDR_SOURCE_PROTOCOL_TCP,
+                )
+            },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        let empty = CString::new("").unwrap();
+        assert_eq!(
+            unsafe {
+                sdr_core_set_network_config(
+                    h,
+                    empty.as_ptr(),
+                    TEST_NETWORK_PORT_TCP,
+                    SDR_SOURCE_PROTOCOL_TCP,
+                )
+            },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_network_config_rejects_zero_port_and_unknown_protocol() {
+        let h = make_handle();
+        let host = CString::new(TEST_NETWORK_HOST_LOOPBACK).unwrap();
+        assert_eq!(
+            unsafe { sdr_core_set_network_config(h, host.as_ptr(), 0, SDR_SOURCE_PROTOCOL_TCP) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_network_config(h, host.as_ptr(), TEST_NETWORK_PORT_TCP, 99) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_network_config(h, host.as_ptr(), TEST_NETWORK_PORT_TCP, -1) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_file_path_accepts_valid_path() {
+        let h = make_handle();
+        let path = CString::new("/tmp/some-iq.wav").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_set_file_path(h, path.as_ptr()) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_file_path_rejects_null_and_empty() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_file_path(h, std::ptr::null()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        let empty = CString::new("").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_set_file_path(h, empty.as_ptr()) },
+            SdrCoreError::InvalidArg.as_int()
+        );
         destroy(h);
     }
 

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 9;
+pub const ABI_VERSION_MINOR: u32 = 10;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 9);
+        assert!(ABI_VERSION_MINOR == 10);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 9
+#define SDR_CORE_ABI_VERSION_MINOR 10
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -501,6 +501,81 @@ int32_t sdr_core_set_network_sink_config(
     uint16_t    port,
     int32_t     protocol
 );
+
+/* --- Source selection (issues #235, #236, ABI 0.10) --- */
+/*
+ * Switch the active IQ source (RTL-SDR dongle / network IQ /
+ * WAV file / rtl_tcp) and configure the per-source connection
+ * details. The engine tears down the current source and
+ * rebuilds from the stored config on the next start (or inline
+ * if the engine is already running).
+ */
+
+/*
+ * Active IQ source. Mirrors `sdr_core::SourceType` on the Rust
+ * side. Stable discriminants — never reorder.
+ */
+typedef enum SdrSourceType {
+    SDR_SOURCE_RTLSDR  = 0,
+    SDR_SOURCE_NETWORK = 1,
+    SDR_SOURCE_FILE    = 2,
+    SDR_SOURCE_RTLTCP  = 3,
+} SdrSourceType;
+
+/*
+ * Network IQ source transport. Stable discriminants — never
+ * reorder.
+ *
+ * Intentionally separate from `SdrNetworkProtocol` above even
+ * though both map to `sdr_types::Protocol`. On the sink side
+ * `TcpClient` means "device listens as TCP **server** for
+ * audio clients"; on the source side it means "device connects
+ * outbound as TCP **client** to a remote IQ server". Same
+ * enum, opposite direction. Reusing the sink-side name here
+ * would be misleading.
+ */
+typedef enum SdrSourceProtocol {
+    SDR_SOURCE_PROTOCOL_TCP = 0,
+    SDR_SOURCE_PROTOCOL_UDP = 1,
+} SdrSourceProtocol;
+
+/*
+ * Switch the active IQ source. `source_type` must be one of
+ * `SDR_SOURCE_*`. Returns `SDR_CORE_ERR_INVALID_ARG` for
+ * unknown values. The engine re-opens the source from the
+ * per-type stored config (network host:port, file path, etc.).
+ */
+int32_t sdr_core_set_source_type(SdrCore* handle, int32_t source_type);
+
+/*
+ * Configure the network IQ source endpoint. `hostname_utf8`
+ * must be non-null, non-empty, NUL-terminated UTF-8.
+ * `port` must be in `1..=65535`. `protocol` must be one of
+ * `SDR_SOURCE_PROTOCOL_*`.
+ *
+ * The engine stores the values; a subsequent switch into
+ * `SDR_SOURCE_NETWORK` (or a source restart while Network is
+ * already active) uses them to open the connection.
+ */
+int32_t sdr_core_set_network_config(
+    SdrCore*    handle,
+    const char* hostname_utf8,
+    uint16_t    port,
+    int32_t     protocol
+);
+
+/*
+ * Set the filesystem path the file-playback source reads from
+ * the next time `SDR_SOURCE_FILE` is activated (or the source
+ * is restarted while File is already active). `path_utf8` must
+ * be a non-null, non-empty NUL-terminated UTF-8 path.
+ *
+ * The engine does not open the file here — only stores the
+ * path. Open errors (missing file, bad format, unsupported
+ * sample format) surface as `SDR_EVT_ERROR` / `SDR_EVT_SOURCE_STOPPED`
+ * when the source actually starts.
+ */
+int32_t sdr_core_set_file_path(SdrCore* handle, const char* path_utf8);
 
 /*
  * Start / stop recording the demodulated audio stream to a 16-bit


### PR DESCRIPTION
## Summary

Exposes the engine's existing `SourceType::Network` and `SourceType::File` source handlers to the macOS SwiftUI app. Closes both v2 backlog items in one PR since the wiring is shape-identical — splitting would be churn.

- **FFI (ABI 0.9 → 0.10)** — three new commands (`sdr_core_set_source_type`, `sdr_core_set_network_config`, `sdr_core_set_file_path`) plus matching `SdrSourceType` + `SdrSourceProtocol` C enums. `SdrSourceProtocol` is intentionally separate from the sink-side `SdrNetworkProtocol` even though both map to the same Rust variant — the wire direction is opposite (sink listens as TCP server, source dials outbound as TCP client) and sharing the label would be actively misleading.
- **SdrCoreKit** — `SourceType` and `NetworkSourceProtocol` Swift enums with label helpers; three throwing wrapper methods on `SdrCore`; ABI-version test bumped to 0.10; six new Swift regression tests covering happy paths and rejection modes (empty host, zero port, empty path).
- **SwiftUI host** — `SourceSection` gains a Type picker at the top followed by per-source form fragments. RTL-SDR keeps the existing sample-rate/gain/AGC/PPM stack. Network adds a host + port + protocol form with an Apply button (endpoint commits don't thrash per keystroke). File adds a `fileImporter`-backed "Choose WAV…" button. `CoreModel` gains observable state + `UserDefaults` persistence matching the audio-sink pattern.
- **Deliberately out of scope** — RTL-TCP. The FFI enum includes the discriminant for ABI completeness (engine already dispatches it), but the picker hides it. RTL-TCP gets its own panel under issue #326 with the full control surface (connection state, per-command gains / ppm / bias-T, etc.). A persisted `.rtlTcp` from a future build falls through to a breadcrumb pointing at #326.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo test --workspace -p sdr-ffi --tests` — 95 tests (12 new for the source commands)
- [x] `make ffi-header-check` — header matches cbindgen output
- [x] `swift test` (SdrCoreKit) — 21 tests (6 new)
- [x] `xcodebuild -scheme SDRMac -configuration Debug build` — succeeds, zero warnings from changed code
- [x] Smoke test on the Mac app: flip source to Network, enter `127.0.0.1:1234`, start another SDR serving IQ on that port, verify the Mac picks it up; switch to File, pick a recorded `.wav`, verify playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source type selector: choose RTL‑SDR, Network IQ, or File playback with per‑source panels and Apply/commit flow.
  * Network IQ: hostname, port and protocol fields with validation and explicit Apply action.
  * File playback: WAV chooser with guarded commit and persisted file path.
  * Persistent settings: source, network and file selections saved and restored.

* **Tests**
  * Added unit and integration tests covering source selection, validation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->