### PR TITLE
feat(#339): bookmarks slide-out panel

### DIFF
--- a/crates/sdr-ui/src/shortcuts.rs
+++ b/crates/sdr-ui/src/shortcuts.rs
@@ -15,6 +15,7 @@ pub fn setup_shortcuts(
     window: &adw::ApplicationWindow,
     play_button: &gtk4::ToggleButton,
     sidebar_toggle: &gtk4::ToggleButton,
+    bookmarks_toggle: &gtk4::ToggleButton,
     demod_dropdown: &gtk4::DropDown,
 ) {
     let controller = gtk4::ShortcutController::new();
@@ -72,6 +73,26 @@ pub fn setup_shortcuts(
         controller.add_shortcut(shortcut);
     }
 
+    // Ctrl+B: Toggle bookmarks flyout. Routed through the header
+    // toggle button so the button's visual state stays in sync
+    // with the flyout — same indirection pattern as F9 /
+    // sidebar_toggle above. "B" is the bookmarks mnemonic; F10
+    // was considered but conflicts with the GNOME menu
+    // convention some shell extensions bind.
+    let bookmarks_toggle_weak = bookmarks_toggle.downgrade();
+    let trigger_ctrl_b = gtk4::ShortcutTrigger::parse_string("<Ctrl>b");
+    if let Some(trigger) = trigger_ctrl_b {
+        let action = gtk4::CallbackAction::new(move |_widget, _args| {
+            if let Some(btn) = bookmarks_toggle_weak.upgrade() {
+                btn.set_active(!btn.is_active());
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        let shortcut = gtk4::Shortcut::new(Some(trigger), Some(action));
+        controller.add_shortcut(shortcut);
+    }
+
     window.add_controller(controller);
 }
 
@@ -81,7 +102,13 @@ const SHORTCUT_CATALOG: &[(&str, &[(&str, &str)])] = &[
         "Playback",
         &[("Space", "Play / Stop"), ("M", "Cycle demod mode")],
     ),
-    ("Navigation", &[("F9", "Toggle sidebar")]),
+    (
+        "Navigation",
+        &[
+            ("F9", "Toggle sidebar"),
+            ("Ctrl+B", "Toggle bookmarks panel"),
+        ],
+    ),
     (
         "Application",
         &[

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -19,12 +19,13 @@
 //!
 //! Commits that land on this file:
 //! - Layout scaffolding (prior commit).
-//! - List + row actions relocated from `NavigationPanel` (THIS commit).
-//! - Filter / search row (next commit).
+//! - List + row actions relocated from `NavigationPanel` (prior commit).
+//! - Filter / search row (THIS commit).
 //! - Category grouping via `AdwExpanderRow` (later commit).
 
 use gtk4::prelude::*;
 use libadwaita as adw;
+use libadwaita::prelude::*;
 
 use super::navigation_panel::{
     ActiveBookmark, Bookmark, NavigationCallback, SaveCallback, load_bookmarks,
@@ -120,6 +121,16 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         .build();
     widget.append(&heading);
 
+    // Search entry — live-filters the list via
+    // `ListBox::set_filter_func` below. Case-insensitive substring
+    // match against the row's title (bookmark name) and subtitle
+    // (demod + frequency). `gtk4::SearchEntry` already handles the
+    // clear-button affordance and Ctrl+F keyboard shortcut.
+    let search_entry = gtk4::SearchEntry::builder()
+        .placeholder_text("Search bookmarks")
+        .build();
+    widget.append(&search_entry);
+
     let bookmark_list = gtk4::ListBox::builder()
         .selection_mode(gtk4::SelectionMode::None)
         .css_classes(["boxed-list"])
@@ -138,6 +149,41 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         std::rc::Rc::new(std::cell::RefCell::new(None));
     let active_bookmark = std::rc::Rc::new(std::cell::RefCell::new(ActiveBookmark::default()));
     let on_save: SaveCallback = std::rc::Rc::new(std::cell::RefCell::new(None));
+
+    // Current search needle (lowercased). Shared between the
+    // filter function (which reads it per row) and the search
+    // entry (which writes it on every keystroke). Persists
+    // across list rebuilds — `set_filter_func` is sticky, and
+    // newly-appended rows inherit the active filter.
+    let filter_text = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
+
+    let filter_text_for_filter = std::rc::Rc::clone(&filter_text);
+    bookmark_list.set_filter_func(move |row| {
+        let needle = filter_text_for_filter.borrow();
+        if needle.is_empty() {
+            return true;
+        }
+        let Some(action_row) = row.downcast_ref::<adw::ActionRow>() else {
+            // Non-ActionRow children shouldn't exist in this list,
+            // but don't hide anything unexpectedly.
+            return true;
+        };
+        let title = action_row.title().to_lowercase();
+        let subtitle = action_row
+            .subtitle()
+            .map(|s| s.to_lowercase())
+            .unwrap_or_default();
+        title.contains(needle.as_str()) || subtitle.contains(needle.as_str())
+    });
+
+    let filter_text_for_entry = std::rc::Rc::clone(&filter_text);
+    let list_weak = bookmark_list.downgrade();
+    search_entry.connect_search_changed(move |entry| {
+        *filter_text_for_entry.borrow_mut() = entry.text().to_lowercase();
+        if let Some(lb) = list_weak.upgrade() {
+            lb.invalidate_filter();
+        }
+    });
 
     // Seed the list with the restored bookmarks.
     rebuild_bookmark_list(

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -20,12 +20,11 @@
 //! Commits that land on this file:
 //! - Layout scaffolding (prior commit).
 //! - List + row actions relocated from `NavigationPanel` (prior commit).
-//! - Filter / search row (THIS commit).
-//! - Category grouping via `AdwExpanderRow` (later commit).
+//! - Filter / search row (prior commit).
+//! - Category grouping via `AdwExpanderRow` (THIS commit).
 
 use gtk4::prelude::*;
 use libadwaita as adw;
-use libadwaita::prelude::*;
 
 use super::navigation_panel::{
     ActiveBookmark, Bookmark, NavigationCallback, SaveCallback, load_bookmarks,
@@ -79,6 +78,13 @@ pub struct BookmarksPanel {
     /// active" button on the active list row. Captures current
     /// tuning state at call time.
     pub on_save: SaveCallback,
+    /// Current search needle (lowercased). Shared between the
+    /// search-entry `search-changed` handler and the list
+    /// rebuild path — the rebuild consults this on every call
+    /// and omits non-matching rows. Stored on the panel so
+    /// rebuilds triggered by external mutations (add, delete,
+    /// `RadioReference` import) respect the active filter.
+    pub filter_text: std::rc::Rc<std::cell::RefCell<String>>,
 }
 
 impl BookmarksPanel {
@@ -90,6 +96,25 @@ impl BookmarksPanel {
     /// Register a callback invoked when the user clicks save on the active bookmark.
     pub fn connect_save<F: Fn() + 'static>(&self, f: F) {
         *self.on_save.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Rebuild the flyout's bookmark list from the backing store,
+    /// honoring the current search filter. Preferred over calling
+    /// [`rebuild_bookmark_list`](super::navigation_panel::rebuild_bookmark_list)
+    /// directly — packs up all the shared `Rc` state owned by
+    /// this panel so callers only need to hand in the
+    /// `NavigationPanel`-owned `name_entry` reference.
+    pub fn rebuild(&self, name_entry: &adw::EntryRow) {
+        super::navigation_panel::rebuild_bookmark_list(
+            &self.bookmark_list,
+            &self.bookmark_scroll,
+            &self.bookmarks,
+            &self.on_navigate,
+            &self.active_bookmark,
+            name_entry,
+            &self.on_save,
+            &self.filter_text,
+        );
     }
 }
 
@@ -149,40 +174,36 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         std::rc::Rc::new(std::cell::RefCell::new(None));
     let active_bookmark = std::rc::Rc::new(std::cell::RefCell::new(ActiveBookmark::default()));
     let on_save: SaveCallback = std::rc::Rc::new(std::cell::RefCell::new(None));
-
-    // Current search needle (lowercased). Shared between the
-    // filter function (which reads it per row) and the search
-    // entry (which writes it on every keystroke). Persists
-    // across list rebuilds — `set_filter_func` is sticky, and
-    // newly-appended rows inherit the active filter.
     let filter_text = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
 
-    let filter_text_for_filter = std::rc::Rc::clone(&filter_text);
-    bookmark_list.set_filter_func(move |row| {
-        let needle = filter_text_for_filter.borrow();
-        if needle.is_empty() {
-            return true;
-        }
-        let Some(action_row) = row.downcast_ref::<adw::ActionRow>() else {
-            // Non-ActionRow children shouldn't exist in this list,
-            // but don't hide anything unexpectedly.
-            return true;
-        };
-        let title = action_row.title().to_lowercase();
-        let subtitle = action_row
-            .subtitle()
-            .map(|s| s.to_lowercase())
-            .unwrap_or_default();
-        title.contains(needle.as_str()) || subtitle.contains(needle.as_str())
-    });
-
-    let filter_text_for_entry = std::rc::Rc::clone(&filter_text);
-    let list_weak = bookmark_list.downgrade();
+    // Search-changed → update needle + rebuild. We rebuild the
+    // list instead of using `ListBox::set_filter_func` because
+    // the categorized view uses nested `AdwExpanderRow` widgets:
+    // the outer `ListBox` filter function only sees expanders,
+    // not the child rows inside them, so it cannot drive child
+    // visibility. Rebuilding on keystroke is cheap (dozens of
+    // rows in practice) and keeps the filter + grouping logic
+    // in one place.
+    let filter_for_entry = std::rc::Rc::clone(&filter_text);
+    let list_for_entry = bookmark_list.clone();
+    let scroll_for_entry = bookmark_scroll.clone();
+    let bookmarks_for_entry = std::rc::Rc::clone(&bookmarks);
+    let on_navigate_for_entry = std::rc::Rc::clone(&on_navigate);
+    let active_for_entry = std::rc::Rc::clone(&active_bookmark);
+    let on_save_for_entry = std::rc::Rc::clone(&on_save);
+    let name_entry_for_entry = name_entry.clone();
     search_entry.connect_search_changed(move |entry| {
-        *filter_text_for_entry.borrow_mut() = entry.text().to_lowercase();
-        if let Some(lb) = list_weak.upgrade() {
-            lb.invalidate_filter();
-        }
+        *filter_for_entry.borrow_mut() = entry.text().to_lowercase();
+        rebuild_bookmark_list(
+            &list_for_entry,
+            &scroll_for_entry,
+            &bookmarks_for_entry,
+            &on_navigate_for_entry,
+            &active_for_entry,
+            &name_entry_for_entry,
+            &on_save_for_entry,
+            &filter_for_entry,
+        );
     });
 
     // Seed the list with the restored bookmarks.
@@ -194,6 +215,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         &active_bookmark,
         name_entry,
         &on_save,
+        &filter_text,
     );
 
     BookmarksPanel {
@@ -204,5 +226,6 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         active_bookmark,
         on_navigate,
         on_save,
+        filter_text,
     }
 }

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -167,11 +167,13 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         .build();
     widget.append(&heading);
 
-    // Search entry — live-filters the list via
-    // `ListBox::set_filter_func` below. Case-insensitive substring
-    // match against the row's title (bookmark name) and subtitle
-    // (demod + frequency). `gtk4::SearchEntry` already handles the
-    // clear-button affordance and Ctrl+F keyboard shortcut.
+    // Search entry — live-filters the list by updating
+    // `filter_text` and rebuilding on every `search-changed`
+    // (see handler below). Case-insensitive substring match
+    // against the bookmark's name, subtitle (demod + frequency),
+    // and `rr_category` — see `bookmark_matches_filter`.
+    // `gtk4::SearchEntry` already handles the clear-button
+    // affordance and `Ctrl+F` keyboard shortcut.
     let search_entry = gtk4::SearchEntry::builder()
         .placeholder_text("Search bookmarks")
         .build();

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -92,6 +92,16 @@ pub struct BookmarksPanel {
     /// rebuilds triggered by external mutations (add, delete,
     /// `RadioReference` import) respect the active filter.
     pub filter_text: std::rc::Rc<std::cell::RefCell<String>>,
+    /// Category titles the user has manually expanded, tracked
+    /// across rebuilds. Distinct from "currently expanded
+    /// widgets" because the search path force-opens every
+    /// expander — snapshotting widget state on every rebuild
+    /// would treat those search-forced opens as manual intent
+    /// and keep them open after the search clears. Only updated
+    /// when the user toggles an expander while no filter is
+    /// active (see `expanded-notify` handler in
+    /// `rebuild_bookmark_list`).
+    pub manual_expanded: std::rc::Rc<std::cell::RefCell<std::collections::HashSet<String>>>,
 }
 
 impl BookmarksPanel {
@@ -121,6 +131,7 @@ impl BookmarksPanel {
             name_entry,
             &self.on_save,
             &self.filter_text,
+            &self.manual_expanded,
         );
     }
 }
@@ -185,6 +196,9 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
     let active_bookmark = std::rc::Rc::new(std::cell::RefCell::new(ActiveBookmark::default()));
     let on_save: SaveCallback = std::rc::Rc::new(std::cell::RefCell::new(None));
     let filter_text = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
+    let manual_expanded = std::rc::Rc::new(std::cell::RefCell::new(std::collections::HashSet::<
+        String,
+    >::new()));
 
     // Search-changed → update needle + rebuild. We rebuild the
     // list instead of using `ListBox::set_filter_func` because
@@ -201,6 +215,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
     let on_navigate_for_entry = std::rc::Rc::clone(&on_navigate);
     let active_for_entry = std::rc::Rc::clone(&active_bookmark);
     let on_save_for_entry = std::rc::Rc::clone(&on_save);
+    let manual_expanded_for_entry = std::rc::Rc::clone(&manual_expanded);
     let name_entry_for_entry = name_entry.clone();
     search_entry.connect_search_changed(move |entry| {
         *filter_for_entry.borrow_mut() = entry.text().to_lowercase();
@@ -213,6 +228,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
             &name_entry_for_entry,
             &on_save_for_entry,
             &filter_for_entry,
+            &manual_expanded_for_entry,
         );
     });
 
@@ -226,6 +242,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         name_entry,
         &on_save,
         &filter_text,
+        &manual_expanded,
     );
 
     BookmarksPanel {
@@ -237,5 +254,6 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         on_navigate,
         on_save,
         filter_text,
+        manual_expanded,
     }
 }

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -128,12 +128,15 @@ impl BookmarksPanel {
 /// Build the bookmarks flyout panel.
 ///
 /// Takes a reference to the left sidebar's `name_entry` so the list
-/// rebuild path — which lives in this module and is called from both
-/// panels — can keep the entry field in sync (e.g. clearing it on
-/// delete-of-active-bookmark, populating it when the user clicks a
-/// row to prepare for a rename). The entry field belongs to
-/// `NavigationPanel` because the Add button is packed with it; this
-/// panel just holds a reference.
+/// rebuild path — which lives in this module and is called from
+/// both panels — can keep the entry field in sync with the active
+/// bookmark. The entry is **create-only context** for the Add
+/// Bookmark button: recall populates it as an informational
+/// reminder of which bookmark is loaded (and cleared on
+/// delete-of-active), but the Add button always pushes a new
+/// `Bookmark` — there's no in-place rename path. The entry field
+/// belongs to `NavigationPanel` because the Add button is packed
+/// with it; this panel just holds a reference.
 #[must_use]
 pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
     let widget = gtk4::Box::builder()

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -8,39 +8,101 @@
 //!
 //! The widget built here is packed into a `gtk4::Revealer` alongside
 //! the transcript revealer in `window.rs::build_split_view`. Slide
-//! transition matches the transcript pattern (300 ms slide from the
+//! transition matches the transcript pattern (200 ms slide from the
 //! right edge of the content area).
 //!
-//! This is a scaffolding stub — the bookmark list itself still lives
-//! in `NavigationPanel` for now. Subsequent commits on this branch
-//! migrate the list + row actions over and add search + category
-//! grouping.
+//! Owns the bookmark list state: the `Rc<RefCell<Vec<Bookmark>>>`
+//! backing store, active-bookmark highlight, navigate / save
+//! callbacks. `NavigationPanel`'s Add button wires into this state
+//! via shared `Rc` clones — both panels render views of the same
+//! underlying list.
+//!
+//! Commits that land on this file:
+//! - Layout scaffolding (prior commit).
+//! - List + row actions relocated from `NavigationPanel` (THIS commit).
+//! - Filter / search row (next commit).
+//! - Category grouping via `AdwExpanderRow` (later commit).
 
 use gtk4::prelude::*;
+use libadwaita as adw;
+
+use super::navigation_panel::{
+    ActiveBookmark, Bookmark, NavigationCallback, SaveCallback, load_bookmarks,
+    rebuild_bookmark_list,
+};
 
 /// Default width of the bookmarks flyout, in pixels. Wide enough for
 /// a long bookmark nickname + a recall button + a delete affordance
-/// without wrapping. Matches the transcript revealer's width request
-/// so the two side panels have consistent visual weight when both
-/// are open.
+/// without wrapping. Slightly wider than the transcript revealer
+/// (320 px) because bookmark rows carry more suffix widgets (active
+/// indicator, save button, delete button) than transcript items.
 pub const BOOKMARKS_PANEL_WIDTH_PX: i32 = 360;
 
-/// Widget handles exposed from the bookmarks flyout — the root
-/// container for packing into the revealer, and references that
-/// the window wiring layer needs (list widget for search/filter
-/// rebinds in subsequent commits, active-bookmark state for
-/// highlight).
+/// Widget handles + shared state exposed from the bookmarks flyout.
+///
+/// Fields that external callers reach into:
+/// - `widget` — root container packed into the revealer.
+/// - `bookmark_list` / `bookmark_scroll` — list widget + scroll,
+///   used by the `rebuild_bookmark_list` helper when the backing
+///   store mutates (add, delete, import from `RadioReference`).
+/// - `bookmarks` / `active_bookmark` / `on_navigate` / `on_save` —
+///   shared `Rc`-backed state. `NavigationPanel`'s Add button
+///   mutates `bookmarks` and calls `rebuild_bookmark_list`; the
+///   preset row clears `active_bookmark` when a band preset is
+///   selected. The `connect_navigate` / `connect_save` methods
+///   register the callbacks the list rows invoke on click.
 pub struct BookmarksPanel {
     /// Root container for the flyout — packed into the revealer.
     pub widget: gtk4::Box,
+    /// Bookmark list widget. Rebuilt in place on every add /
+    /// delete / import via [`rebuild_bookmark_list`].
+    pub bookmark_list: gtk4::ListBox,
+    /// Scrolled window wrapping `bookmark_list`. The rebuild
+    /// helper uses it to enforce a max visible height so the
+    /// panel grows only up to a cap before scrolling kicks in.
+    pub bookmark_scroll: gtk4::ScrolledWindow,
+    /// Shared bookmark backing store. Loaded once on startup via
+    /// [`load_bookmarks`]; every mutation is followed by a
+    /// [`save_bookmarks`](super::navigation_panel::save_bookmarks)
+    /// persist.
+    pub bookmarks: std::rc::Rc<std::cell::RefCell<Vec<Bookmark>>>,
+    /// Identity of the bookmark currently loaded into the tuning
+    /// state, used for the in-list "active" highlight + save
+    /// button. Cleared by band-preset selection.
+    pub active_bookmark: std::rc::Rc<std::cell::RefCell<ActiveBookmark>>,
+    /// Callback invoked when the user clicks a list row — fed
+    /// the `Bookmark` so window.rs can dispatch tune / bandwidth
+    /// / profile-restore commands.
+    pub on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>>,
+    /// Callback invoked when the user clicks the "save over
+    /// active" button on the active list row. Captures current
+    /// tuning state at call time.
+    pub on_save: SaveCallback,
 }
 
-/// Build an empty bookmarks flyout panel. The list content is still
-/// rendered in the left-sidebar `NavigationPanel` for the duration
-/// of this scaffolding commit; the next commit on this branch
-/// relocates it here.
+impl BookmarksPanel {
+    /// Register a callback invoked when the user selects a bookmark.
+    pub fn connect_navigate<F: Fn(&Bookmark) + 'static>(&self, f: F) {
+        *self.on_navigate.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Register a callback invoked when the user clicks save on the active bookmark.
+    pub fn connect_save<F: Fn() + 'static>(&self, f: F) {
+        *self.on_save.borrow_mut() = Some(Box::new(f));
+    }
+}
+
+/// Build the bookmarks flyout panel.
+///
+/// Takes a reference to the left sidebar's `name_entry` so the list
+/// rebuild path — which lives in this module and is called from both
+/// panels — can keep the entry field in sync (e.g. clearing it on
+/// delete-of-active-bookmark, populating it when the user clicks a
+/// row to prepare for a rename). The entry field belongs to
+/// `NavigationPanel` because the Add button is packed with it; this
+/// panel just holds a reference.
 #[must_use]
-pub fn build_bookmarks_panel() -> BookmarksPanel {
+pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
     let widget = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
         .spacing(12)
@@ -58,15 +120,43 @@ pub fn build_bookmarks_panel() -> BookmarksPanel {
         .build();
     widget.append(&heading);
 
-    // Placeholder caption while the list migration is pending.
-    // Removed when the list lands in the follow-up commit.
-    let placeholder = gtk4::Label::builder()
-        .label("Bookmark list moves here in the next commit.")
-        .css_classes(["dim-label"])
-        .wrap(true)
-        .halign(gtk4::Align::Start)
+    let bookmark_list = gtk4::ListBox::builder()
+        .selection_mode(gtk4::SelectionMode::None)
+        .css_classes(["boxed-list"])
         .build();
-    widget.append(&placeholder);
 
-    BookmarksPanel { widget }
+    let bookmark_scroll = gtk4::ScrolledWindow::builder()
+        .child(&bookmark_list)
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .vscrollbar_policy(gtk4::PolicyType::Automatic)
+        .vexpand(true)
+        .build();
+    widget.append(&bookmark_scroll);
+
+    let bookmarks = std::rc::Rc::new(std::cell::RefCell::new(load_bookmarks()));
+    let on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>> =
+        std::rc::Rc::new(std::cell::RefCell::new(None));
+    let active_bookmark = std::rc::Rc::new(std::cell::RefCell::new(ActiveBookmark::default()));
+    let on_save: SaveCallback = std::rc::Rc::new(std::cell::RefCell::new(None));
+
+    // Seed the list with the restored bookmarks.
+    rebuild_bookmark_list(
+        &bookmark_list,
+        &bookmark_scroll,
+        &bookmarks,
+        &on_navigate,
+        &active_bookmark,
+        name_entry,
+        &on_save,
+    );
+
+    BookmarksPanel {
+        widget,
+        bookmark_list,
+        bookmark_scroll,
+        bookmarks,
+        active_bookmark,
+        on_navigate,
+        on_save,
+    }
 }

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -21,7 +21,8 @@
 //! - Layout scaffolding (prior commit).
 //! - List + row actions relocated from `NavigationPanel` (prior commit).
 //! - Filter / search row (prior commit).
-//! - Category grouping via `AdwExpanderRow` (THIS commit).
+//! - Category grouping via `AdwExpanderRow` (prior commit).
+//! - Persist flyout open/closed state across restarts (THIS commit).
 
 use gtk4::prelude::*;
 use libadwaita as adw;
@@ -37,6 +38,12 @@ use super::navigation_panel::{
 /// (320 px) because bookmark rows carry more suffix widgets (active
 /// indicator, save button, delete button) than transcript items.
 pub const BOOKMARKS_PANEL_WIDTH_PX: i32 = 360;
+
+/// Config key for whether the bookmarks flyout was open at last
+/// shutdown. Read once on startup to restore the reveal state +
+/// the header toggle button's visual pressed state; written on
+/// every toggle change.
+pub const CONFIG_KEY_FLYOUT_OPEN: &str = "bookmarks_flyout_open";
 
 /// Widget handles + shared state exposed from the bookmarks flyout.
 ///

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -1,0 +1,72 @@
+//! Right-side bookmarks slide-out panel (#339).
+//!
+//! Complementary to the left sidebar's `NavigationPanel`: the sidebar
+//! keeps the quick-add controls (name entry + Add button) so the user
+//! can stash a bookmark without opening the flyout, while this panel
+//! is the browse / search / manage surface for the full bookmark
+//! list. Toggled from the header bar bookmark icon or `Ctrl+B`.
+//!
+//! The widget built here is packed into a `gtk4::Revealer` alongside
+//! the transcript revealer in `window.rs::build_split_view`. Slide
+//! transition matches the transcript pattern (300 ms slide from the
+//! right edge of the content area).
+//!
+//! This is a scaffolding stub — the bookmark list itself still lives
+//! in `NavigationPanel` for now. Subsequent commits on this branch
+//! migrate the list + row actions over and add search + category
+//! grouping.
+
+use gtk4::prelude::*;
+
+/// Default width of the bookmarks flyout, in pixels. Wide enough for
+/// a long bookmark nickname + a recall button + a delete affordance
+/// without wrapping. Matches the transcript revealer's width request
+/// so the two side panels have consistent visual weight when both
+/// are open.
+pub const BOOKMARKS_PANEL_WIDTH_PX: i32 = 360;
+
+/// Widget handles exposed from the bookmarks flyout — the root
+/// container for packing into the revealer, and references that
+/// the window wiring layer needs (list widget for search/filter
+/// rebinds in subsequent commits, active-bookmark state for
+/// highlight).
+pub struct BookmarksPanel {
+    /// Root container for the flyout — packed into the revealer.
+    pub widget: gtk4::Box,
+}
+
+/// Build an empty bookmarks flyout panel. The list content is still
+/// rendered in the left-sidebar `NavigationPanel` for the duration
+/// of this scaffolding commit; the next commit on this branch
+/// relocates it here.
+#[must_use]
+pub fn build_bookmarks_panel() -> BookmarksPanel {
+    let widget = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(12)
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .width_request(BOOKMARKS_PANEL_WIDTH_PX)
+        .build();
+
+    let heading = gtk4::Label::builder()
+        .label("Bookmarks")
+        .css_classes(["title-2"])
+        .halign(gtk4::Align::Start)
+        .build();
+    widget.append(&heading);
+
+    // Placeholder caption while the list migration is pending.
+    // Removed when the list lands in the follow-up commit.
+    let placeholder = gtk4::Label::builder()
+        .label("Bookmark list moves here in the next commit.")
+        .css_classes(["dim-label"])
+        .wrap(true)
+        .halign(gtk4::Align::Start)
+        .build();
+    widget.append(&placeholder);
+
+    BookmarksPanel { widget }
+}

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -37,8 +37,14 @@ pub struct SidebarPanels {
     pub radio: RadioPanel,
     /// Display / spectrum settings.
     pub display: DisplayPanel,
-    /// Navigation — band presets and bookmarks.
+    /// Navigation — band presets and the left-sidebar bookmark
+    /// quick-add (name entry + Add button). The full bookmark
+    /// list lives in [`bookmarks`](Self::bookmarks).
     pub navigation: NavigationPanel,
+    /// Right-side bookmarks flyout — owns the bookmark list,
+    /// backing store, and row-action callbacks. Toggled via
+    /// the header bookmark button / `Ctrl+B`.
+    pub bookmarks: BookmarksPanel,
     /// Share-over-network (`rtl_tcp` server) controls. Hidden by
     /// default; `window.rs` reveals it when a local RTL-SDR dongle
     /// is plugged in and not currently the active source.
@@ -49,6 +55,8 @@ pub struct SidebarPanels {
 ///
 /// Returns both the scroll widget (for embedding in the split view) and the
 /// `SidebarPanels` struct (for DSP bridge signal wiring — see issue #92).
+/// The returned `SidebarPanels::bookmarks` is the right-side flyout widget;
+/// `window.rs` packs it into the bookmarks revealer.
 pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     let source = build_source_panel();
     let server = build_server_panel();
@@ -56,6 +64,16 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     let radio = build_radio_panel();
     let display = build_display_panel();
     let navigation = build_navigation_panel();
+    // Flyout is built after navigation because it borrows the
+    // left-sidebar `name_entry` — its row actions (recall,
+    // delete-of-active) sync the entry field.
+    let bookmarks = build_bookmarks_panel(&navigation.name_entry);
+    // Preset selection clears the active-bookmark highlight and
+    // rebuilds the flyout list. Wiring lives outside
+    // `build_navigation_panel` because it closes over state owned
+    // by the flyout.
+    navigation_panel::connect_preset_to_bookmarks(&navigation, &bookmarks);
+
     let sidebar_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
         .spacing(SIDEBAR_SPACING)
@@ -87,6 +105,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
         radio,
         display,
         navigation,
+        bookmarks,
         server,
     };
 

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! The transcript panel lives in a separate right-side revealer, not here.
 
+use std::rc::Rc;
+
 use gtk4::prelude::*;
 
 pub mod audio_panel;
@@ -51,7 +53,7 @@ pub struct SidebarPanels {
     /// internal `Rc` field. The Save closure uses `Rc::downgrade`
     /// to break the otherwise-cyclic `on_save → stored closure`
     /// reference chain.
-    pub bookmarks: std::rc::Rc<BookmarksPanel>,
+    pub bookmarks: Rc<BookmarksPanel>,
     /// Share-over-network (`rtl_tcp` server) controls. Hidden by
     /// default; `window.rs` reveals it when a local RTL-SDR dongle
     /// is plugged in and not currently the active source.
@@ -83,7 +85,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     // clone — wiring it through an `Rc<BookmarksPanel>` would
     // add an unnecessary upgrade dance on every preset click.
     navigation_panel::connect_preset_to_bookmarks(&navigation, &bookmarks);
-    let bookmarks = std::rc::Rc::new(bookmarks);
+    let bookmarks = Rc::new(bookmarks);
 
     let sidebar_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -44,7 +44,14 @@ pub struct SidebarPanels {
     /// Right-side bookmarks flyout — owns the bookmark list,
     /// backing store, and row-action callbacks. Toggled via
     /// the header bookmark button / `Ctrl+B`.
-    pub bookmarks: BookmarksPanel,
+    ///
+    /// Wrapped in `Rc` so long-lived GTK closures (RR import,
+    /// Add button, Save button) can capture a clone and call
+    /// [`BookmarksPanel::rebuild`] without hand-threading each
+    /// internal `Rc` field. The Save closure uses `Rc::downgrade`
+    /// to break the otherwise-cyclic `on_save → stored closure`
+    /// reference chain.
+    pub bookmarks: std::rc::Rc<BookmarksPanel>,
     /// Share-over-network (`rtl_tcp` server) controls. Hidden by
     /// default; `window.rs` reveals it when a local RTL-SDR dongle
     /// is plugged in and not currently the active source.
@@ -71,8 +78,12 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     // Preset selection clears the active-bookmark highlight and
     // rebuilds the flyout list. Wiring lives outside
     // `build_navigation_panel` because it closes over state owned
-    // by the flyout.
+    // by the flyout. Done before the `Rc` wrap below so the
+    // preset handler keeps capturing individual `Rc` fields by
+    // clone — wiring it through an `Rc<BookmarksPanel>` would
+    // add an unnecessary upgrade dance on every preset click.
     navigation_panel::connect_preset_to_bookmarks(&navigation, &bookmarks);
+    let bookmarks = std::rc::Rc::new(bookmarks);
 
     let sidebar_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -5,6 +5,7 @@
 use gtk4::prelude::*;
 
 pub mod audio_panel;
+pub mod bookmarks_panel;
 pub mod display_panel;
 pub mod navigation_panel;
 pub mod radio_panel;
@@ -13,6 +14,7 @@ pub mod source_panel;
 pub mod transcript_panel;
 
 pub use audio_panel::{AudioPanel, build_audio_panel};
+pub use bookmarks_panel::{BookmarksPanel, build_bookmarks_panel};
 pub use display_panel::{DisplayPanel, build_display_panel};
 pub use navigation_panel::{NavigationPanel, build_navigation_panel};
 pub use radio_panel::{RadioPanel, build_radio_panel};

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -505,35 +505,43 @@ pub fn connect_preset_to_bookmarks(
 
     navigation.preset_row.connect_selected_notify(move |row| {
         let idx = row.selected() as usize;
-        if let Some(preset) = BAND_PRESETS.get(idx)
-            && let Some(cb) = on_nav.borrow().as_ref()
-        {
-            // Clear active bookmark — we're tuning via preset, not bookmark.
-            *active.borrow_mut() = ActiveBookmark::default();
-            name_entry.set_text("");
-            let bm = Bookmark::new(
-                preset.name,
-                preset.frequency,
-                preset.demod_mode,
-                preset.bandwidth,
-            );
+        let Some(preset) = BAND_PRESETS.get(idx) else {
+            return;
+        };
+        // Apply preset-driven UI state regardless of whether a
+        // navigate callback is registered — the active-bookmark
+        // reset, name-entry clear, and list rebuild describe
+        // "we're tuning via preset, not bookmark" and that's
+        // true whether or not anyone's listening. Gating these
+        // on `on_nav` being Some would leave stale highlight /
+        // name-entry state visible in the rare window between
+        // panel construction and callback registration.
+        *active.borrow_mut() = ActiveBookmark::default();
+        name_entry.set_text("");
+        let bm = Bookmark::new(
+            preset.name,
+            preset.frequency,
+            preset.demod_mode,
+            preset.bandwidth,
+        );
+        if let Some(cb) = on_nav.borrow().as_ref() {
             cb(&bm);
-            // Rebuild to remove stale highlight
-            if let Some(lb) = list_weak.upgrade()
-                && let Some(sc) = scroll_weak.upgrade()
-            {
-                rebuild_bookmark_list(
-                    &lb,
-                    &sc,
-                    &bm_rc,
-                    &on_nav,
-                    &active,
-                    &name_entry,
-                    &on_save,
-                    &filter_text,
-                    &manual_expanded,
-                );
-            }
+        }
+        // Rebuild to remove stale highlight
+        if let Some(lb) = list_weak.upgrade()
+            && let Some(sc) = scroll_weak.upgrade()
+        {
+            rebuild_bookmark_list(
+                &lb,
+                &sc,
+                &bm_rc,
+                &on_nav,
+                &active,
+                &name_entry,
+                &on_save,
+                &filter_text,
+                &manual_expanded,
+            );
         }
     });
 }
@@ -570,11 +578,13 @@ fn bookmark_matches_filter(bm: &Bookmark, needle: &str) -> bool {
 
 /// Rebuild the bookmark `ListBox` from the current bookmark list.
 ///
-/// Honors the search filter in `filter_text` (lowercase substring
-/// match against name + subtitle). Emits an `AdwExpanderRow` per
-/// unique `rr_category` when any bookmark is categorized; falls
-/// back to a flat list when all bookmarks are uncategorized so
-/// users who don't import from `RadioReference` keep the original
+/// Honors the search filter in `filter_text` by delegating to
+/// [`bookmark_matches_filter`] — lowercase substring match
+/// against the bookmark's name, subtitle (demod + frequency),
+/// and `rr_category`. Emits an `AdwExpanderRow` per unique
+/// `rr_category` when any bookmark is categorized; falls back
+/// to a flat list when all bookmarks are uncategorized so users
+/// who don't import from `RadioReference` keep the original
 /// single-level view.
 #[allow(
     clippy::too_many_arguments,

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -793,9 +793,20 @@ fn build_bookmark_row(
                 entry_del.set_text("");
             }
         }
-        bm_rc
-            .borrow_mut()
-            .retain(|b| !(b.name == del_name && b.frequency == del_freq));
+        // Remove only the first matching bookmark rather than
+        // every entry with the same (name, frequency). Quick-add
+        // intentionally always creates a new `Bookmark`, so
+        // duplicates are a supported state — one click on the
+        // trash icon should delete the one row the user pointed
+        // at, not wipe the whole set. Stable bookmark IDs will
+        // supersede this first-match contract once they land.
+        let remove_idx = bm_rc
+            .borrow()
+            .iter()
+            .position(|b| b.name == del_name && b.frequency == del_freq);
+        if let Some(idx) = remove_idx {
+            bm_rc.borrow_mut().remove(idx);
+        }
         save_bookmarks(&bm_rc.borrow());
         if let Some(lb) = list_ref.upgrade()
             && let Some(sc) = scroll_ref.upgrade()

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -550,15 +550,20 @@ pub type SaveCallback = std::rc::Rc<std::cell::RefCell<Option<Box<dyn Fn()>>>>;
 /// flat, skipping expander grouping entirely.
 const UNCATEGORIZED_LABEL: &str = "Uncategorized";
 
-/// Does the bookmark's name or subtitle contain the (already-
-/// lowercased) search needle? Empty needle matches everything.
+/// Does the bookmark's name, subtitle, or category contain the
+/// (already-lowercased) search needle? Empty needle matches
+/// everything. Category matching lets users filter by the
+/// `rr_category` label (e.g., typing "dispatch" or "fire")
+/// when bookmarks are imported from `RadioReference`, not just
+/// by name or demod/frequency.
 fn bookmark_matches_filter(bm: &Bookmark, needle: &str) -> bool {
     if needle.is_empty() {
         return true;
     }
     let name_lc = bm.name.to_lowercase();
     let subtitle_lc = bm.settings_subtitle().to_lowercase();
-    name_lc.contains(needle) || subtitle_lc.contains(needle)
+    let category_lc = bm.rr_category.as_deref().unwrap_or_default().to_lowercase();
+    name_lc.contains(needle) || subtitle_lc.contains(needle) || category_lc.contains(needle)
 }
 
 /// Rebuild the bookmark `ListBox` from the current bookmark list.
@@ -633,9 +638,7 @@ pub fn rebuild_bookmark_list(
         // search results into a previously-collapsed section).
         let active_category = bm_list
             .iter()
-            .find(|b| {
-                b.name == current_active.name && b.frequency == current_active.frequency
-            })
+            .find(|b| b.name == current_active.name && b.frequency == current_active.frequency)
             .map(|b| {
                 b.rr_category
                     .clone()
@@ -724,7 +727,7 @@ pub fn rebuild_bookmark_list(
 /// row's behavior is identical regardless of whether it's a
 /// top-level child of the `ListBox` or nested under an
 /// `AdwExpanderRow`.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn build_bookmark_row(
     bm: &Bookmark,
     current_active: &ActiveBookmark,
@@ -767,6 +770,7 @@ fn build_bookmark_row(
     let delete_btn = gtk4::Button::builder()
         .icon_name("user-trash-symbolic")
         .valign(gtk4::Align::Center)
+        .tooltip_text("Delete bookmark")
         .css_classes(["flat"])
         .build();
 
@@ -797,7 +801,14 @@ fn build_bookmark_row(
             && let Some(sc) = scroll_ref.upgrade()
         {
             rebuild_bookmark_list(
-                &lb, &sc, &bm_rc, &nav_rc, &active_rc, &entry_del, &save_del, &filter_del,
+                &lb,
+                &sc,
+                &bm_rc,
+                &nav_rc,
+                &active_rc,
+                &entry_del,
+                &save_del,
+                &filter_del,
             );
         }
     });
@@ -1052,5 +1063,17 @@ mod tests {
     fn filter_no_match_hides_bookmark() {
         let bm = Bookmark::new("Weather", 162_550_000, DemodMode::Nfm, 12_500.0);
         assert!(!bookmark_matches_filter(&bm, "xyz-no-match"));
+    }
+
+    #[test]
+    fn filter_matches_rr_category() {
+        // Users who import from RadioReference expect to search
+        // by category ("dispatch", "fire") even when that text
+        // isn't in the bookmark's name or subtitle.
+        let mut bm = Bookmark::new("Unit 14", 462_562_500, DemodMode::Nfm, 12_500.0);
+        bm.rr_category = Some("Law Dispatch".to_string());
+        assert!(bookmark_matches_filter(&bm, "dispatch"));
+        assert!(bookmark_matches_filter(&bm, "law"));
+        assert!(!bookmark_matches_filter(&bm, "fire"));
     }
 }

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -498,6 +498,7 @@ pub fn connect_preset_to_bookmarks(
     let bm_rc = std::rc::Rc::clone(&bookmarks.bookmarks);
     let on_save = std::rc::Rc::clone(&bookmarks.on_save);
     let filter_text = std::rc::Rc::clone(&bookmarks.filter_text);
+    let manual_expanded = std::rc::Rc::clone(&bookmarks.manual_expanded);
     let list_weak = bookmarks.bookmark_list.downgrade();
     let scroll_weak = bookmarks.bookmark_scroll.downgrade();
     let name_entry = navigation.name_entry.clone();
@@ -530,6 +531,7 @@ pub fn connect_preset_to_bookmarks(
                     &name_entry,
                     &on_save,
                     &filter_text,
+                    &manual_expanded,
                 );
             }
         }
@@ -574,7 +576,12 @@ fn bookmark_matches_filter(bm: &Bookmark, needle: &str) -> bool {
 /// back to a flat list when all bookmarks are uncategorized so
 /// users who don't import from `RadioReference` keep the original
 /// single-level view.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::implicit_hasher,
+    reason = "manual_expanded is a private handle passed Rc-clone-style between internal callers — the default `RandomState` hasher is fine and genericizing would force every caller site to spell the hasher"
+)]
 pub fn rebuild_bookmark_list(
     list_box: &gtk4::ListBox,
     scroll: &gtk4::ScrolledWindow,
@@ -584,27 +591,8 @@ pub fn rebuild_bookmark_list(
     name_entry: &adw::EntryRow,
     on_save: &SaveCallback,
     filter_text: &std::rc::Rc<std::cell::RefCell<String>>,
+    manual_expanded: &std::rc::Rc<std::cell::RefCell<std::collections::HashSet<String>>>,
 ) {
-    // Snapshot which categories are currently expanded so the
-    // rebuild can restore them. Without this the list collapses
-    // every expander on every rebuild — clicking a bookmark
-    // triggers a rebuild for the active-row highlight, and the
-    // user would watch the section they just clicked into snap
-    // closed.
-    let previously_expanded: std::collections::HashSet<String> = {
-        let mut set = std::collections::HashSet::new();
-        let mut child = list_box.first_child();
-        while let Some(widget) = child {
-            if let Some(exp) = widget.downcast_ref::<adw::ExpanderRow>()
-                && exp.is_expanded()
-            {
-                set.insert(exp.title().to_string());
-            }
-            child = widget.next_sibling();
-        }
-        set
-    };
-
     // Remove all existing rows.
     while let Some(child) = list_box.first_child() {
         list_box.remove(&child);
@@ -614,6 +602,16 @@ pub fn rebuild_bookmark_list(
     let current_active = active.borrow().clone();
     let needle = filter_text.borrow().clone();
     let uses_categories = bm_list.iter().any(|b| b.rr_category.is_some());
+    // Read manual expansion state separately from widget state.
+    // We can't snapshot widget expansion on every rebuild: the
+    // search path force-opens every expander, and if the user
+    // then clears the search, we'd treat those forced opens as
+    // manual intent. Instead `manual_expanded` is only mutated
+    // by the `expanded-notify` handler below, and only when no
+    // filter is active — so programmatic expansions (search,
+    // active-category restore, initial apply on rebuild) never
+    // pollute it.
+    let manual_open: std::collections::HashSet<String> = manual_expanded.borrow().clone();
 
     if uses_categories {
         // Collect bookmarks into category buckets, preserving
@@ -657,14 +655,41 @@ pub fn rebuild_bookmark_list(
                 ))
                 .build();
             // Expand when: a filter is active (so matches
-            // surface without a manual click); this category
-            // was expanded before the rebuild (preserve user
-            // intent); or this category holds the active
-            // bookmark (so recall keeps its section open).
+            // surface without a manual click); the user
+            // manually expanded this category before (preserved
+            // across rebuilds via `manual_expanded`); or this
+            // category holds the active bookmark (so recall
+            // keeps its section open).
             let keep_expanded = !needle.is_empty()
-                || previously_expanded.contains(&cat)
+                || manual_open.contains(&cat)
                 || active_category.as_deref() == Some(cat.as_str());
             expander.set_expanded(keep_expanded);
+
+            // Track user-driven expansion toggles. Connects
+            // *after* the initial `set_expanded` above so the
+            // programmatic apply doesn't fire the handler —
+            // GLib signals only reach handlers connected at the
+            // time of emission. Gated on filter being empty
+            // because during search all expanders are force-
+            // open; a user toggle under those conditions
+            // reflects "show/hide matches in this category
+            // right now", not lasting intent.
+            let manual_for_notify = std::rc::Rc::clone(manual_expanded);
+            let filter_for_notify = std::rc::Rc::clone(filter_text);
+            let cat_for_notify = cat.clone();
+            expander.connect_expanded_notify(move |row| {
+                if !filter_for_notify.borrow().is_empty() {
+                    return;
+                }
+                if row.is_expanded() {
+                    manual_for_notify
+                        .borrow_mut()
+                        .insert(cat_for_notify.clone());
+                } else {
+                    manual_for_notify.borrow_mut().remove(&cat_for_notify);
+                }
+            });
+
             for bm in items {
                 let row = build_bookmark_row(
                     bm,
@@ -677,6 +702,7 @@ pub fn rebuild_bookmark_list(
                     name_entry,
                     on_save,
                     filter_text,
+                    manual_expanded,
                 );
                 expander.add_row(&row);
             }
@@ -698,6 +724,7 @@ pub fn rebuild_bookmark_list(
                 name_entry,
                 on_save,
                 filter_text,
+                manual_expanded,
             );
             list_box.append(&row);
         }
@@ -707,12 +734,18 @@ pub fn rebuild_bookmark_list(
     // the flyout is vexpand and doesn't need a min height. Keep
     // the 3-row cap for flat lists (where this function is still
     // called from the sidebar's pre-flyout code path) and skip
-    // entirely for expander-grouped views.
+    // entirely for expander-grouped views. Use the filtered row
+    // count, not the total — when a search is active the scroll
+    // region should shrink with the visible list rather than
+    // reserving space for filtered-out rows.
     if uses_categories {
         scroll.set_height_request(-1);
     } else {
         #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-        let count = bm_list.len() as i32;
+        let count = bm_list
+            .iter()
+            .filter(|bm| bookmark_matches_filter(bm, &needle))
+            .count() as i32;
         let visible = count.clamp(0, MAX_VISIBLE_BOOKMARKS);
         let height = visible * BOOKMARK_ROW_HEIGHT;
         scroll.set_height_request(height);
@@ -739,6 +772,7 @@ fn build_bookmark_row(
     name_entry: &adw::EntryRow,
     on_save: &SaveCallback,
     filter_text: &std::rc::Rc<std::cell::RefCell<String>>,
+    manual_expanded: &std::rc::Rc<std::cell::RefCell<std::collections::HashSet<String>>>,
 ) -> adw::ActionRow {
     let is_active = bm.name == current_active.name && bm.frequency == current_active.frequency;
     let row = adw::ActionRow::builder()
@@ -783,6 +817,7 @@ fn build_bookmark_row(
     let active_rc = std::rc::Rc::clone(active);
     let save_del = std::rc::Rc::clone(on_save);
     let filter_del = std::rc::Rc::clone(filter_text);
+    let manual_expanded_del = std::rc::Rc::clone(manual_expanded);
     let list_ref = list_box.downgrade();
     let scroll_ref = scroll.downgrade();
     let entry_del = name_entry.clone();
@@ -824,6 +859,7 @@ fn build_bookmark_row(
                 &entry_del,
                 &save_del,
                 &filter_del,
+                &manual_expanded_del,
             );
         }
     });
@@ -834,6 +870,7 @@ fn build_bookmark_row(
     let active_recall = std::rc::Rc::clone(active);
     let save_recall = std::rc::Rc::clone(on_save);
     let filter_recall = std::rc::Rc::clone(filter_text);
+    let manual_expanded_recall = std::rc::Rc::clone(manual_expanded);
     let bm_recall = std::rc::Rc::clone(bookmarks);
     let list_recall = list_box.downgrade();
     let scroll_recall = scroll.downgrade();
@@ -862,6 +899,7 @@ fn build_bookmark_row(
                 &entry_recall,
                 &save_recall,
                 &filter_recall,
+                &manual_expanded_recall,
             );
             let adj = sc.vadjustment();
             glib::idle_add_local_once(move || {

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -456,7 +456,7 @@ pub fn build_navigation_panel() -> NavigationPanel {
     bookmarks_group.append(&bookmarks_label);
 
     let bookmarks_hint = gtk4::Label::builder()
-        .label("Press Ctrl+B or use the bookmark icon to browse")
+        .label("Use the bookmark icon or keyboard shortcut to browse")
         .css_classes(["caption", "dim-label"])
         .halign(gtk4::Align::Start)
         .wrap(true)

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -758,6 +758,9 @@ fn build_bookmark_row(
             .tooltip_text("Save current settings to this bookmark")
             .css_classes(["flat"])
             .build();
+        save_btn.update_property(&[gtk4::accessible::Property::Label(
+            "Save current settings to this bookmark",
+        )]);
         let save_cb = std::rc::Rc::clone(on_save);
         save_btn.connect_clicked(move |_| {
             if let Some(cb) = save_cb.borrow().as_ref() {
@@ -773,6 +776,7 @@ fn build_bookmark_row(
         .tooltip_text("Delete bookmark")
         .css_classes(["flat"])
         .build();
+    delete_btn.update_property(&[gtk4::accessible::Property::Label("Delete bookmark")]);
 
     let bm_rc = std::rc::Rc::clone(bookmarks);
     let nav_rc = std::rc::Rc::clone(on_navigate);

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -388,46 +388,44 @@ pub struct ActiveBookmark {
     pub frequency: u64,
 }
 
-/// Navigation panel containing band presets and frequency bookmarks.
+/// Navigation panel containing band presets and the left-sidebar
+/// "Add Bookmark" quick-entry controls.
+///
+/// The full bookmark list (browse, recall, delete, save-over-active)
+/// lives in [`crate::sidebar::BookmarksPanel`] — the right-side
+/// flyout — so this panel intentionally does **not** own the list
+/// widget or the backing store. Both panels share the `name_entry`:
+/// this struct owns it, the flyout panel borrows it at build time
+/// and captures clones in its row callbacks.
 pub struct NavigationPanel {
     /// Band presets group widget.
     pub presets_widget: adw::PreferencesGroup,
-    /// Bookmarks container widget.
+    /// Left-sidebar bookmark quick-add container (heading +
+    /// name entry + Add button). The full list is in the flyout
+    /// — see [`crate::sidebar::BookmarksPanel`].
     pub bookmarks_widget: gtk4::Box,
     /// Band preset combo row (for connection in window.rs).
     pub preset_row: adw::ComboRow,
     /// Bookmark name entry (user-editable, defaults to formatted frequency).
+    /// Owned here because the Add button sits next to it; the
+    /// flyout panel borrows a reference for its row actions.
     pub name_entry: adw::EntryRow,
-    /// Add bookmark button.
+    /// Add bookmark button. Lives on the left sidebar so users
+    /// can stash a bookmark without opening the flyout.
     pub add_button: gtk4::Button,
-    /// Bookmark scroll container (height adjusted dynamically).
-    pub bookmark_scroll: gtk4::ScrolledWindow,
-    /// Bookmark list box (rebuilt on add/remove).
-    pub bookmark_list: gtk4::ListBox,
-    /// Current bookmarks (shared state for closures).
-    pub bookmarks: std::rc::Rc<std::cell::RefCell<Vec<Bookmark>>>,
-    /// Callback fired when a preset or bookmark is recalled.
-    pub on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>>,
-    /// Currently active bookmark identity (for visual highlighting).
-    pub active_bookmark: std::rc::Rc<std::cell::RefCell<ActiveBookmark>>,
-    /// Callback fired when the user clicks save on the active bookmark.
-    pub on_save: SaveCallback,
 }
 
-impl NavigationPanel {
-    /// Register a callback invoked when the user selects a preset or bookmark.
-    pub fn connect_navigate<F: Fn(&Bookmark) + 'static>(&self, f: F) {
-        *self.on_navigate.borrow_mut() = Some(Box::new(f));
-    }
-
-    /// Register a callback invoked when the user clicks save on the active bookmark.
-    pub fn connect_save<F: Fn() + 'static>(&self, f: F) {
-        *self.on_save.borrow_mut() = Some(Box::new(f));
-    }
-}
-
-/// Build the complete navigation panel (band presets + bookmarks).
-#[allow(clippy::too_many_lines)]
+/// Build the navigation panel — band presets + left-sidebar
+/// bookmark quick-add.
+///
+/// Does not build the bookmark list widget; that lives in the
+/// right-side flyout and is constructed by
+/// [`build_bookmarks_panel`](crate::sidebar::build_bookmarks_panel).
+/// The preset row's selection handler also lives outside this
+/// function — see [`connect_preset_to_bookmarks`] — because it
+/// needs access to the flyout's shared state (active-bookmark
+/// highlight, list rebuild, navigation callback) which only
+/// exists after both panels have been built.
 pub fn build_navigation_panel() -> NavigationPanel {
     // --- Band Presets ---
     let presets_group = adw::PreferencesGroup::builder()
@@ -444,8 +442,7 @@ pub fn build_navigation_panel() -> NavigationPanel {
         .build();
     presets_group.add(&preset_row);
 
-    // --- Bookmarks ---
-    // Use a plain Box instead of PreferencesGroup so ScrolledWindow sizing works.
+    // --- Left-sidebar bookmark quick-add ---
     let bookmarks_group = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
         .spacing(8)
@@ -458,20 +455,16 @@ pub fn build_navigation_panel() -> NavigationPanel {
         .build();
     bookmarks_group.append(&bookmarks_label);
 
+    let bookmarks_hint = gtk4::Label::builder()
+        .label("Press Ctrl+B or use the bookmark icon to browse")
+        .css_classes(["caption", "dim-label"])
+        .halign(gtk4::Align::Start)
+        .wrap(true)
+        .build();
+    bookmarks_group.append(&bookmarks_hint);
+
     let name_entry = adw::EntryRow::builder().title("Name").build();
     bookmarks_group.append(&name_entry);
-
-    let bookmark_list = gtk4::ListBox::builder()
-        .selection_mode(gtk4::SelectionMode::None)
-        .css_classes(["boxed-list"])
-        .build();
-
-    let bookmark_scroll = gtk4::ScrolledWindow::builder()
-        .child(&bookmark_list)
-        .hscrollbar_policy(gtk4::PolicyType::Never)
-        .vscrollbar_policy(gtk4::PolicyType::Automatic)
-        .build();
-    bookmarks_group.append(&bookmark_scroll);
 
     let add_button = gtk4::Button::builder()
         .label("Add Bookmark")
@@ -479,40 +472,43 @@ pub fn build_navigation_panel() -> NavigationPanel {
         .build();
     bookmarks_group.append(&add_button);
 
-    let bookmarks = std::rc::Rc::new(std::cell::RefCell::new(load_bookmarks()));
-    let on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>> =
-        std::rc::Rc::new(std::cell::RefCell::new(None));
+    NavigationPanel {
+        presets_widget: presets_group,
+        bookmarks_widget: bookmarks_group,
+        preset_row,
+        name_entry,
+        add_button,
+    }
+}
 
-    let active_bookmark = std::rc::Rc::new(std::cell::RefCell::new(ActiveBookmark::default()));
-    let on_save: SaveCallback = std::rc::Rc::new(std::cell::RefCell::new(None));
+/// Wire the band-preset combo row to the bookmark flyout state.
+///
+/// Selecting a preset clears the active-bookmark highlight,
+/// clears the name entry, fires the shared navigate callback,
+/// and rebuilds the flyout's bookmark list. This wiring can't
+/// live inside [`build_navigation_panel`] because the state it
+/// closes over is owned by the flyout panel, which is built
+/// afterwards.
+pub fn connect_preset_to_bookmarks(
+    navigation: &NavigationPanel,
+    bookmarks: &crate::sidebar::BookmarksPanel,
+) {
+    let on_nav = std::rc::Rc::clone(&bookmarks.on_navigate);
+    let active = std::rc::Rc::clone(&bookmarks.active_bookmark);
+    let bm_rc = std::rc::Rc::clone(&bookmarks.bookmarks);
+    let on_save = std::rc::Rc::clone(&bookmarks.on_save);
+    let list_weak = bookmarks.bookmark_list.downgrade();
+    let scroll_weak = bookmarks.bookmark_scroll.downgrade();
+    let name_entry = navigation.name_entry.clone();
 
-    // Build initial bookmark list
-    rebuild_bookmark_list(
-        &bookmark_list,
-        &bookmark_scroll,
-        &bookmarks,
-        &on_navigate,
-        &active_bookmark,
-        &name_entry,
-        &on_save,
-    );
-
-    // Connect preset row — auto-tune on selection, clear active bookmark
-    let on_nav_preset = std::rc::Rc::clone(&on_navigate);
-    let active_for_preset = std::rc::Rc::clone(&active_bookmark);
-    let entry_for_preset = name_entry.clone();
-    let list_for_preset = bookmark_list.downgrade();
-    let scroll_for_preset = bookmark_scroll.downgrade();
-    let bm_for_preset = std::rc::Rc::clone(&bookmarks);
-    let save_for_preset = std::rc::Rc::clone(&on_save);
-    preset_row.connect_selected_notify(move |row| {
+    navigation.preset_row.connect_selected_notify(move |row| {
         let idx = row.selected() as usize;
         if let Some(preset) = BAND_PRESETS.get(idx)
-            && let Some(cb) = on_nav_preset.borrow().as_ref()
+            && let Some(cb) = on_nav.borrow().as_ref()
         {
             // Clear active bookmark — we're tuning via preset, not bookmark.
-            *active_for_preset.borrow_mut() = ActiveBookmark::default();
-            entry_for_preset.set_text("");
+            *active.borrow_mut() = ActiveBookmark::default();
+            name_entry.set_text("");
             let bm = Bookmark::new(
                 preset.name,
                 preset.frequency,
@@ -521,35 +517,15 @@ pub fn build_navigation_panel() -> NavigationPanel {
             );
             cb(&bm);
             // Rebuild to remove stale highlight
-            if let Some(lb) = list_for_preset.upgrade()
-                && let Some(sc) = scroll_for_preset.upgrade()
+            if let Some(lb) = list_weak.upgrade()
+                && let Some(sc) = scroll_weak.upgrade()
             {
                 rebuild_bookmark_list(
-                    &lb,
-                    &sc,
-                    &bm_for_preset,
-                    &on_nav_preset,
-                    &active_for_preset,
-                    &entry_for_preset,
-                    &save_for_preset,
+                    &lb, &sc, &bm_rc, &on_nav, &active, &name_entry, &on_save,
                 );
             }
         }
     });
-
-    NavigationPanel {
-        presets_widget: presets_group,
-        bookmarks_widget: bookmarks_group,
-        preset_row,
-        name_entry,
-        add_button,
-        bookmark_scroll,
-        bookmark_list,
-        bookmarks,
-        on_navigate,
-        active_bookmark,
-        on_save,
-    }
 }
 
 /// Approximate height of one `AdwActionRow` with subtitle in pixels.

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -569,7 +569,7 @@ fn bookmark_matches_filter(bm: &Bookmark, needle: &str) -> bool {
 /// back to a flat list when all bookmarks are uncategorized so
 /// users who don't import from `RadioReference` keep the original
 /// single-level view.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub fn rebuild_bookmark_list(
     list_box: &gtk4::ListBox,
     scroll: &gtk4::ScrolledWindow,
@@ -580,6 +580,26 @@ pub fn rebuild_bookmark_list(
     on_save: &SaveCallback,
     filter_text: &std::rc::Rc<std::cell::RefCell<String>>,
 ) {
+    // Snapshot which categories are currently expanded so the
+    // rebuild can restore them. Without this the list collapses
+    // every expander on every rebuild — clicking a bookmark
+    // triggers a rebuild for the active-row highlight, and the
+    // user would watch the section they just clicked into snap
+    // closed.
+    let previously_expanded: std::collections::HashSet<String> = {
+        let mut set = std::collections::HashSet::new();
+        let mut child = list_box.first_child();
+        while let Some(widget) = child {
+            if let Some(exp) = widget.downcast_ref::<adw::ExpanderRow>()
+                && exp.is_expanded()
+            {
+                set.insert(exp.title().to_string());
+            }
+            child = widget.next_sibling();
+        }
+        set
+    };
+
     // Remove all existing rows.
     while let Some(child) = list_box.first_child() {
         list_box.remove(&child);
@@ -607,18 +627,41 @@ pub fn rebuild_bookmark_list(
                 .unwrap_or_else(|| UNCATEGORIZED_LABEL.to_string());
             groups.entry(cat).or_default().push(bm);
         }
+        // The category containing the active bookmark, so we can
+        // guarantee it stays expanded even if the user hadn't
+        // opened it before the recall (e.g., clicking through
+        // search results into a previously-collapsed section).
+        let active_category = bm_list
+            .iter()
+            .find(|b| {
+                b.name == current_active.name && b.frequency == current_active.frequency
+            })
+            .map(|b| {
+                b.rr_category
+                    .clone()
+                    .unwrap_or_else(|| UNCATEGORIZED_LABEL.to_string())
+            });
         for (cat, items) in groups {
             if items.is_empty() {
                 continue;
             }
             let expander = adw::ExpanderRow::builder()
                 .title(&cat)
-                .subtitle(format!("{} bookmark{}", items.len(), if items.len() == 1 { "" } else { "s" }))
+                .subtitle(format!(
+                    "{} bookmark{}",
+                    items.len(),
+                    if items.len() == 1 { "" } else { "s" }
+                ))
                 .build();
-            // Auto-expand when a filter is active so matches
-            // surface without a manual click; leave collapsed
-            // otherwise to keep long lists scannable.
-            expander.set_expanded(!needle.is_empty());
+            // Expand when: a filter is active (so matches
+            // surface without a manual click); this category
+            // was expanded before the rebuild (preserve user
+            // intent); or this category holds the active
+            // bookmark (so recall keeps its section open).
+            let keep_expanded = !needle.is_empty()
+                || previously_expanded.contains(&cat)
+                || active_category.as_deref() == Some(cat.as_str());
+            expander.set_expanded(keep_expanded);
             for bm in items {
                 let row = build_bookmark_row(
                     bm,

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -497,6 +497,7 @@ pub fn connect_preset_to_bookmarks(
     let active = std::rc::Rc::clone(&bookmarks.active_bookmark);
     let bm_rc = std::rc::Rc::clone(&bookmarks.bookmarks);
     let on_save = std::rc::Rc::clone(&bookmarks.on_save);
+    let filter_text = std::rc::Rc::clone(&bookmarks.filter_text);
     let list_weak = bookmarks.bookmark_list.downgrade();
     let scroll_weak = bookmarks.bookmark_scroll.downgrade();
     let name_entry = navigation.name_entry.clone();
@@ -521,7 +522,14 @@ pub fn connect_preset_to_bookmarks(
                 && let Some(sc) = scroll_weak.upgrade()
             {
                 rebuild_bookmark_list(
-                    &lb, &sc, &bm_rc, &on_nav, &active, &name_entry, &on_save,
+                    &lb,
+                    &sc,
+                    &bm_rc,
+                    &on_nav,
+                    &active,
+                    &name_entry,
+                    &on_save,
+                    &filter_text,
                 );
             }
         }
@@ -536,8 +544,32 @@ const MAX_VISIBLE_BOOKMARKS: i32 = 3;
 /// Callback type for save actions on the active bookmark.
 pub type SaveCallback = std::rc::Rc<std::cell::RefCell<Option<Box<dyn Fn()>>>>;
 
+/// Sentinel category title for bookmarks without an `rr_category`.
+/// Only shown when the list contains a mix of categorized and
+/// uncategorized bookmarks — pure-uncategorized lists render
+/// flat, skipping expander grouping entirely.
+const UNCATEGORIZED_LABEL: &str = "Uncategorized";
+
+/// Does the bookmark's name or subtitle contain the (already-
+/// lowercased) search needle? Empty needle matches everything.
+fn bookmark_matches_filter(bm: &Bookmark, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let name_lc = bm.name.to_lowercase();
+    let subtitle_lc = bm.settings_subtitle().to_lowercase();
+    name_lc.contains(needle) || subtitle_lc.contains(needle)
+}
+
 /// Rebuild the bookmark `ListBox` from the current bookmark list.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+///
+/// Honors the search filter in `filter_text` (lowercase substring
+/// match against name + subtitle). Emits an `AdwExpanderRow` per
+/// unique `rr_category` when any bookmark is categorized; falls
+/// back to a flat list when all bookmarks are uncategorized so
+/// users who don't import from `RadioReference` keep the original
+/// single-level view.
+#[allow(clippy::too_many_arguments)]
 pub fn rebuild_bookmark_list(
     list_box: &gtk4::ListBox,
     scroll: &gtk4::ScrolledWindow,
@@ -546,6 +578,7 @@ pub fn rebuild_bookmark_list(
     active: &std::rc::Rc<std::cell::RefCell<ActiveBookmark>>,
     name_entry: &adw::EntryRow,
     on_save: &SaveCallback,
+    filter_text: &std::rc::Rc<std::cell::RefCell<String>>,
 ) {
     // Remove all existing rows.
     while let Some(child) = list_box.first_child() {
@@ -554,130 +587,221 @@ pub fn rebuild_bookmark_list(
 
     let bm_list = bookmarks.borrow();
     let current_active = active.borrow().clone();
-    for bm in bm_list.iter() {
-        let is_active = bm.name == current_active.name && bm.frequency == current_active.frequency;
-        let row = adw::ActionRow::builder()
-            .title(&bm.name)
-            .subtitle(bm.settings_subtitle())
-            .activatable(true)
-            .build();
+    let needle = filter_text.borrow().clone();
+    let uses_categories = bm_list.iter().any(|b| b.rr_category.is_some());
 
-        // Highlight the active bookmark with an accent icon + save button.
-        if is_active {
-            let icon = gtk4::Image::from_icon_name("media-playback-start-symbolic");
-            icon.set_valign(gtk4::Align::Center);
-            row.add_prefix(&icon);
-
-            // Save button — updates the active bookmark with current settings.
-            let save_btn = gtk4::Button::builder()
-                .icon_name("media-floppy-symbolic")
-                .valign(gtk4::Align::Center)
-                .tooltip_text("Save current settings to this bookmark")
-                .css_classes(["flat"])
-                .build();
-            let save_cb = std::rc::Rc::clone(on_save);
-            save_btn.connect_clicked(move |_| {
-                if let Some(cb) = save_cb.borrow().as_ref() {
-                    cb();
-                }
-            });
-            row.add_suffix(&save_btn);
+    if uses_categories {
+        // Collect bookmarks into category buckets, preserving
+        // within-category insertion order. `BTreeMap` gives
+        // deterministic alphabetical category ordering; use
+        // a single `Uncategorized` bucket for loose bookmarks.
+        let mut groups: std::collections::BTreeMap<String, Vec<&Bookmark>> =
+            std::collections::BTreeMap::new();
+        for bm in bm_list.iter() {
+            if !bookmark_matches_filter(bm, &needle) {
+                continue;
+            }
+            let cat = bm
+                .rr_category
+                .clone()
+                .unwrap_or_else(|| UNCATEGORIZED_LABEL.to_string());
+            groups.entry(cat).or_default().push(bm);
         }
-
-        // Delete button — identify by name + frequency rather than index
-        let delete_btn = gtk4::Button::builder()
-            .icon_name("user-trash-symbolic")
-            .valign(gtk4::Align::Center)
-            .css_classes(["flat"])
-            .build();
-
-        let bm_rc = std::rc::Rc::clone(bookmarks);
-        let nav_rc = std::rc::Rc::clone(on_navigate);
-        let active_rc = std::rc::Rc::clone(active);
-        let save_del = std::rc::Rc::clone(on_save);
-        let list_ref = list_box.downgrade();
-        let scroll_ref = scroll.downgrade();
-        let entry_del = name_entry.clone();
-        let del_name = bm.name.clone();
-        let del_freq = bm.frequency;
-        delete_btn.connect_clicked(move |_| {
-            // Clear active state if deleting the active bookmark.
-            {
-                let active = active_rc.borrow();
-                if active.name == del_name && active.frequency == del_freq {
-                    drop(active);
-                    *active_rc.borrow_mut() = ActiveBookmark::default();
-                    entry_del.set_text("");
-                }
+        for (cat, items) in groups {
+            if items.is_empty() {
+                continue;
             }
-            bm_rc
-                .borrow_mut()
-                .retain(|b| !(b.name == del_name && b.frequency == del_freq));
-            save_bookmarks(&bm_rc.borrow());
-            if let Some(lb) = list_ref.upgrade()
-                && let Some(sc) = scroll_ref.upgrade()
-            {
-                rebuild_bookmark_list(&lb, &sc, &bm_rc, &nav_rc, &active_rc, &entry_del, &save_del);
-            }
-        });
-        row.add_suffix(&delete_btn);
-
-        // Recall on row activation — set active, update name entry, rebuild list
-        let recall_bookmark = bm.clone();
-        let on_nav_recall = std::rc::Rc::clone(on_navigate);
-        let active_recall = std::rc::Rc::clone(active);
-        let save_recall = std::rc::Rc::clone(on_save);
-        let bm_recall = std::rc::Rc::clone(bookmarks);
-        let list_recall = list_box.downgrade();
-        let scroll_recall = scroll.downgrade();
-        let entry_recall = name_entry.clone();
-        row.connect_activated(move |_| {
-            // Set this bookmark as active
-            *active_recall.borrow_mut() = ActiveBookmark {
-                name: recall_bookmark.name.clone(),
-                frequency: recall_bookmark.frequency,
-            };
-            // Show the active bookmark name in the entry (read-only indication)
-            entry_recall.set_text(&recall_bookmark.name);
-
-            // Fire the navigate callback with the full bookmark
-            if let Some(cb) = on_nav_recall.borrow().as_ref() {
-                cb(&recall_bookmark);
-            }
-
-            // Rebuild list to update active highlighting, preserving scroll position.
-            if let Some(lb) = list_recall.upgrade()
-                && let Some(sc) = scroll_recall.upgrade()
-            {
-                let saved_scroll = sc.vadjustment().value();
-                rebuild_bookmark_list(
-                    &lb,
-                    &sc,
-                    &bm_recall,
-                    &on_nav_recall,
-                    &active_recall,
-                    &entry_recall,
-                    &save_recall,
+            let expander = adw::ExpanderRow::builder()
+                .title(&cat)
+                .subtitle(format!("{} bookmark{}", items.len(), if items.len() == 1 { "" } else { "s" }))
+                .build();
+            // Auto-expand when a filter is active so matches
+            // surface without a manual click; leave collapsed
+            // otherwise to keep long lists scannable.
+            expander.set_expanded(!needle.is_empty());
+            for bm in items {
+                let row = build_bookmark_row(
+                    bm,
+                    &current_active,
+                    list_box,
+                    scroll,
+                    bookmarks,
+                    on_navigate,
+                    active,
+                    name_entry,
+                    on_save,
+                    filter_text,
                 );
-                // Restore scroll position after GTK finishes re-laying out the
-                // rebuilt list — an idle callback ensures the adjustment range
-                // has been recalculated.
-                let adj = sc.vadjustment();
-                glib::idle_add_local_once(move || {
-                    adj.set_value(saved_scroll);
-                });
+                expander.add_row(&row);
             }
-        });
-
-        list_box.append(&row);
+            list_box.append(&expander);
+        }
+    } else {
+        for bm in bm_list.iter() {
+            if !bookmark_matches_filter(bm, &needle) {
+                continue;
+            }
+            let row = build_bookmark_row(
+                bm,
+                &current_active,
+                list_box,
+                scroll,
+                bookmarks,
+                on_navigate,
+                active,
+                name_entry,
+                on_save,
+                filter_text,
+            );
+            list_box.append(&row);
+        }
     }
 
-    // Dynamically size: show all items up to 3, then scroll.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let count = bm_list.len() as i32;
-    let visible = count.clamp(0, MAX_VISIBLE_BOOKMARKS);
-    let height = visible * BOOKMARK_ROW_HEIGHT;
-    scroll.set_height_request(height);
+    // Left-sidebar legacy sizing only makes sense in flat mode —
+    // the flyout is vexpand and doesn't need a min height. Keep
+    // the 3-row cap for flat lists (where this function is still
+    // called from the sidebar's pre-flyout code path) and skip
+    // entirely for expander-grouped views.
+    if uses_categories {
+        scroll.set_height_request(-1);
+    } else {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let count = bm_list.len() as i32;
+        let visible = count.clamp(0, MAX_VISIBLE_BOOKMARKS);
+        let height = visible * BOOKMARK_ROW_HEIGHT;
+        scroll.set_height_request(height);
+    }
+}
+
+/// Build a single bookmark `ActionRow` with its active-highlight
+/// prefix, save/delete suffix buttons, and recall-on-activate
+/// handler wired up.
+///
+/// Shared between the flat and categorized rebuild paths so the
+/// row's behavior is identical regardless of whether it's a
+/// top-level child of the `ListBox` or nested under an
+/// `AdwExpanderRow`.
+#[allow(clippy::too_many_arguments)]
+fn build_bookmark_row(
+    bm: &Bookmark,
+    current_active: &ActiveBookmark,
+    list_box: &gtk4::ListBox,
+    scroll: &gtk4::ScrolledWindow,
+    bookmarks: &std::rc::Rc<std::cell::RefCell<Vec<Bookmark>>>,
+    on_navigate: &std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>>,
+    active: &std::rc::Rc<std::cell::RefCell<ActiveBookmark>>,
+    name_entry: &adw::EntryRow,
+    on_save: &SaveCallback,
+    filter_text: &std::rc::Rc<std::cell::RefCell<String>>,
+) -> adw::ActionRow {
+    let is_active = bm.name == current_active.name && bm.frequency == current_active.frequency;
+    let row = adw::ActionRow::builder()
+        .title(&bm.name)
+        .subtitle(bm.settings_subtitle())
+        .activatable(true)
+        .build();
+
+    if is_active {
+        let icon = gtk4::Image::from_icon_name("media-playback-start-symbolic");
+        icon.set_valign(gtk4::Align::Center);
+        row.add_prefix(&icon);
+
+        let save_btn = gtk4::Button::builder()
+            .icon_name("media-floppy-symbolic")
+            .valign(gtk4::Align::Center)
+            .tooltip_text("Save current settings to this bookmark")
+            .css_classes(["flat"])
+            .build();
+        let save_cb = std::rc::Rc::clone(on_save);
+        save_btn.connect_clicked(move |_| {
+            if let Some(cb) = save_cb.borrow().as_ref() {
+                cb();
+            }
+        });
+        row.add_suffix(&save_btn);
+    }
+
+    let delete_btn = gtk4::Button::builder()
+        .icon_name("user-trash-symbolic")
+        .valign(gtk4::Align::Center)
+        .css_classes(["flat"])
+        .build();
+
+    let bm_rc = std::rc::Rc::clone(bookmarks);
+    let nav_rc = std::rc::Rc::clone(on_navigate);
+    let active_rc = std::rc::Rc::clone(active);
+    let save_del = std::rc::Rc::clone(on_save);
+    let filter_del = std::rc::Rc::clone(filter_text);
+    let list_ref = list_box.downgrade();
+    let scroll_ref = scroll.downgrade();
+    let entry_del = name_entry.clone();
+    let del_name = bm.name.clone();
+    let del_freq = bm.frequency;
+    delete_btn.connect_clicked(move |_| {
+        {
+            let active = active_rc.borrow();
+            if active.name == del_name && active.frequency == del_freq {
+                drop(active);
+                *active_rc.borrow_mut() = ActiveBookmark::default();
+                entry_del.set_text("");
+            }
+        }
+        bm_rc
+            .borrow_mut()
+            .retain(|b| !(b.name == del_name && b.frequency == del_freq));
+        save_bookmarks(&bm_rc.borrow());
+        if let Some(lb) = list_ref.upgrade()
+            && let Some(sc) = scroll_ref.upgrade()
+        {
+            rebuild_bookmark_list(
+                &lb, &sc, &bm_rc, &nav_rc, &active_rc, &entry_del, &save_del, &filter_del,
+            );
+        }
+    });
+    row.add_suffix(&delete_btn);
+
+    let recall_bookmark = bm.clone();
+    let on_nav_recall = std::rc::Rc::clone(on_navigate);
+    let active_recall = std::rc::Rc::clone(active);
+    let save_recall = std::rc::Rc::clone(on_save);
+    let filter_recall = std::rc::Rc::clone(filter_text);
+    let bm_recall = std::rc::Rc::clone(bookmarks);
+    let list_recall = list_box.downgrade();
+    let scroll_recall = scroll.downgrade();
+    let entry_recall = name_entry.clone();
+    row.connect_activated(move |_| {
+        *active_recall.borrow_mut() = ActiveBookmark {
+            name: recall_bookmark.name.clone(),
+            frequency: recall_bookmark.frequency,
+        };
+        entry_recall.set_text(&recall_bookmark.name);
+
+        if let Some(cb) = on_nav_recall.borrow().as_ref() {
+            cb(&recall_bookmark);
+        }
+
+        if let Some(lb) = list_recall.upgrade()
+            && let Some(sc) = scroll_recall.upgrade()
+        {
+            let saved_scroll = sc.vadjustment().value();
+            rebuild_bookmark_list(
+                &lb,
+                &sc,
+                &bm_recall,
+                &on_nav_recall,
+                &active_recall,
+                &entry_recall,
+                &save_recall,
+                &filter_recall,
+            );
+            let adj = sc.vadjustment();
+            glib::idle_add_local_once(move || {
+                adj.set_value(saved_scroll);
+            });
+        }
+    });
+
+    row
 }
 
 #[cfg(test)]
@@ -855,5 +979,35 @@ mod tests {
         // Compact format: "NFM 162.550 MHz"
         assert!(sub.contains("NFM"));
         assert!(sub.contains("162.550 MHz"));
+    }
+
+    #[test]
+    fn filter_empty_needle_matches_everything() {
+        let bm = Bookmark::new("Anything", 162_550_000, DemodMode::Nfm, 12_500.0);
+        assert!(bookmark_matches_filter(&bm, ""));
+    }
+
+    #[test]
+    fn filter_matches_name_case_insensitive() {
+        let bm = Bookmark::new("Weather", 162_550_000, DemodMode::Nfm, 12_500.0);
+        // `bookmark_matches_filter` assumes the caller has already
+        // lowercased the needle (the search-entry handler does so).
+        assert!(bookmark_matches_filter(&bm, "weather"));
+        assert!(!bookmark_matches_filter(&bm, "aviation"));
+    }
+
+    #[test]
+    fn filter_matches_subtitle_demod_and_frequency() {
+        let bm = Bookmark::new("Stuff", 162_550_000, DemodMode::Nfm, 12_500.0);
+        // Subtitle is "NFM 162.550 MHz" — lowercase matches both parts.
+        assert!(bookmark_matches_filter(&bm, "nfm"));
+        assert!(bookmark_matches_filter(&bm, "162.550"));
+        assert!(bookmark_matches_filter(&bm, "mhz"));
+    }
+
+    #[test]
+    fn filter_no_match_hides_bookmark() {
+        let bm = Bookmark::new("Weather", 162_550_000, DemodMode::Nfm, 12_500.0);
+        assert!(!bookmark_matches_filter(&bm, "xyz-no-match"));
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -273,6 +273,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         let active_bm = panels.bookmarks.active_bookmark.clone();
         let name_entry = panels.navigation.name_entry.clone();
         let on_save = panels.bookmarks.on_save.clone();
+        let filter_text = panels.bookmarks.filter_text.clone();
 
         rr_button.connect_clicked(move |btn| {
             let bm_list = bm_list.clone();
@@ -282,6 +283,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
             let active_bm = active_bm.clone();
             let name_entry = name_entry.clone();
             let on_save = on_save.clone();
+            let filter_text = filter_text.clone();
 
             crate::radioreference::show_browse_dialog(btn, move || {
                 // Reload bookmarks from disk and rebuild the sidebar list.
@@ -294,6 +296,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                     &active_bm,
                     &name_entry,
                     &on_save,
+                    &filter_text,
                 );
             });
         });
@@ -4492,6 +4495,7 @@ fn connect_navigation_panel(
     let on_nav = bm.on_navigate.clone();
     let active_bm = bm.active_bookmark.clone();
     let on_save_bm = bm.on_save.clone();
+    let filter_text_add = bm.filter_text.clone();
     let name_entry = nav.name_entry.clone();
 
     nav.add_button.connect_clicked(move |_| {
@@ -4552,6 +4556,7 @@ fn connect_navigation_panel(
             &active_bm,
             &name_entry,
             &on_save_bm,
+            &filter_text_add,
         );
         name_entry.set_text("");
     });
@@ -4563,6 +4568,7 @@ fn connect_navigation_panel(
     let save_bm_scroll = bm.bookmark_scroll.clone();
     let save_on_nav = bm.on_navigate.clone();
     let save_on_save = bm.on_save.clone();
+    let save_filter_text = bm.filter_text.clone();
     let save_name_entry = nav.name_entry.clone();
     let save_state = Rc::clone(state);
     let save_radio_bw = panels.radio.bandwidth_row.clone();
@@ -4674,6 +4680,7 @@ fn connect_navigation_panel(
             &save_active,
             &save_name_entry,
             &save_on_save,
+            &save_filter_text,
         );
         tracing::info!("bookmark saved: {}", active.name);
     });

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -115,6 +115,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         status_bar,
         transcript_panel,
         transcript_revealer,
+        bookmarks_revealer,
     ) = build_split_view(&state, config);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
     let sidebar_toggle = build_sidebar_toggle(&split_view);
@@ -127,6 +128,23 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         rr_button,
         favorites_handle,
     ) = build_header_bar(&sidebar_toggle, &state);
+
+    // Bookmarks flyout toggle — packed `pack_end` first so it
+    // ends up LEFT of the transcript toggle in the header's
+    // right cluster. `pack_end` stacks right-to-left, so the
+    // last `pack_end` call sits furthest from the right edge.
+    // Keeping bookmarks near the far edge matches the visual
+    // mapping "click the icon → panel slides in from directly
+    // under it on the right."
+    let bookmarks_toggle = gtk4::ToggleButton::builder()
+        .icon_name("user-bookmarks-symbolic")
+        .tooltip_text("Toggle bookmarks panel (Ctrl+B)")
+        .build();
+    header.pack_end(&bookmarks_toggle);
+    let bookmarks_revealer_clone = bookmarks_revealer.clone();
+    bookmarks_toggle.connect_toggled(move |btn| {
+        bookmarks_revealer_clone.set_reveal_child(btn.is_active());
+    });
 
     // Transcript toggle button in header bar.
     let transcript_button = gtk4::ToggleButton::builder()
@@ -186,7 +204,13 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     });
 
     // --- Keyboard shortcuts ---
-    shortcuts::setup_shortcuts(&window, &play_button, &sidebar_toggle, &demod_dropdown);
+    shortcuts::setup_shortcuts(
+        &window,
+        &play_button,
+        &sidebar_toggle,
+        &bookmarks_toggle,
+        &demod_dropdown,
+    );
 
     // Ctrl+? shows keyboard shortcuts dialog.
     let window_for_shortcuts = window.downgrade();
@@ -725,6 +749,10 @@ fn apply_rtl_tcp_connection_state(
 /// and status bar.
 ///
 /// Returns the split view, sidebar panels, spectrum display handle, and status bar.
+#[allow(
+    clippy::type_complexity,
+    reason = "splitting into a struct would trade one named return for one named struct whose fields are used exactly once by the caller — net neutral for readability, net negative for locality of widget construction"
+)]
 fn build_split_view(
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
@@ -734,6 +762,7 @@ fn build_split_view(
     spectrum::SpectrumHandle,
     StatusBar,
     sidebar::transcript_panel::TranscriptPanel,
+    gtk4::Revealer,
     gtk4::Revealer,
 ) {
     // Sidebar — configuration panels.
@@ -780,12 +809,35 @@ fn build_split_view(
         .hexpand(false)
         .build();
 
-    // Wrap content + transcript revealer in an HBox.
+    // Bookmarks flyout — slides out from the right, outermost of
+    // the two right-side panels so the header `Ctrl+B` toggle
+    // reveals an unambiguously right-edge element. Uses the same
+    // `SlideLeft` + 200 ms transition as the transcript revealer
+    // for visual consistency when either panel opens.
+    let bookmarks_panel = sidebar::bookmarks_panel::build_bookmarks_panel();
+    let bookmarks_scroll = gtk4::ScrolledWindow::builder()
+        .child(&bookmarks_panel.widget)
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .vexpand(true)
+        .build();
+    let bookmarks_revealer = gtk4::Revealer::builder()
+        .transition_type(gtk4::RevealerTransitionType::SlideLeft)
+        .transition_duration(200)
+        .reveal_child(false)
+        .child(&bookmarks_scroll)
+        .hexpand(false)
+        .build();
+
+    // Wrap content + both side revealers in an HBox. Bookmarks
+    // sits rightmost so the header-bar bookmark icon (which is
+    // itself at the far right of the header via `pack_end`) maps
+    // visually to the panel that appears when the user clicks it.
     let content_with_transcript = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Horizontal)
         .build();
     content_with_transcript.append(&content_box);
     content_with_transcript.append(&transcript_revealer);
+    content_with_transcript.append(&bookmarks_revealer);
 
     let split_view = adw::OverlaySplitView::builder()
         .sidebar(&sidebar_scroll)
@@ -800,6 +852,7 @@ fn build_split_view(
         status_bar,
         transcript_panel,
         transcript_revealer,
+        bookmarks_revealer,
     )
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -141,9 +141,30 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         .tooltip_text("Toggle bookmarks panel (Ctrl+B)")
         .build();
     header.pack_end(&bookmarks_toggle);
+
+    // Restore the flyout open/closed state saved at last shutdown.
+    // Set the toggle's `active` property before wiring the handler
+    // so the initial `set_active` doesn't feed a no-op write back
+    // through `connect_toggled` — `connect_toggled` fires only on
+    // changes, but explicitly wiring the handler after the initial
+    // state is set keeps the "saved state → initial reveal" path
+    // free of config round-trips.
+    let bookmarks_initial_open = config.read(|v| {
+        v.get(sidebar::bookmarks_panel::CONFIG_KEY_FLYOUT_OPEN)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    });
+    bookmarks_toggle.set_active(bookmarks_initial_open);
+    bookmarks_revealer.set_reveal_child(bookmarks_initial_open);
+
     let bookmarks_revealer_clone = bookmarks_revealer.clone();
+    let bookmarks_config = std::sync::Arc::clone(config);
     bookmarks_toggle.connect_toggled(move |btn| {
-        bookmarks_revealer_clone.set_reveal_child(btn.is_active());
+        let open = btn.is_active();
+        bookmarks_revealer_clone.set_reveal_child(open);
+        bookmarks_config.write(|v| {
+            v[sidebar::bookmarks_panel::CONFIG_KEY_FLYOUT_OPEN] = serde_json::json!(open);
+        });
     });
 
     // Transcript toggle button in header bar.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -338,6 +338,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         let name_entry = panels.navigation.name_entry.clone();
         let on_save = panels.bookmarks.on_save.clone();
         let filter_text = panels.bookmarks.filter_text.clone();
+        let manual_expanded = panels.bookmarks.manual_expanded.clone();
 
         rr_button.connect_clicked(move |btn| {
             let bm_list = bm_list.clone();
@@ -348,6 +349,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
             let name_entry = name_entry.clone();
             let on_save = on_save.clone();
             let filter_text = filter_text.clone();
+            let manual_expanded = manual_expanded.clone();
 
             crate::radioreference::show_browse_dialog(btn, move || {
                 // Reload bookmarks from disk and rebuild the sidebar list.
@@ -361,6 +363,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                     &name_entry,
                     &on_save,
                     &filter_text,
+                    &manual_expanded,
                 );
             });
         });
@@ -4561,6 +4564,7 @@ fn connect_navigation_panel(
     let active_bm = bm.active_bookmark.clone();
     let on_save_bm = bm.on_save.clone();
     let filter_text_add = bm.filter_text.clone();
+    let manual_expanded_add = bm.manual_expanded.clone();
     let name_entry = nav.name_entry.clone();
 
     nav.add_button.connect_clicked(move |_| {
@@ -4622,6 +4626,7 @@ fn connect_navigation_panel(
             &name_entry,
             &on_save_bm,
             &filter_text_add,
+            &manual_expanded_add,
         );
         name_entry.set_text("");
     });
@@ -4634,6 +4639,7 @@ fn connect_navigation_panel(
     let save_on_nav = bm.on_navigate.clone();
     let save_on_save = bm.on_save.clone();
     let save_filter_text = bm.filter_text.clone();
+    let save_manual_expanded = bm.manual_expanded.clone();
     let save_name_entry = nav.name_entry.clone();
     let save_state = Rc::clone(state);
     let save_radio_bw = panels.radio.bandwidth_row.clone();
@@ -4746,6 +4752,7 @@ fn connect_navigation_panel(
             &save_name_entry,
             &save_on_save,
             &save_filter_text,
+            &save_manual_expanded,
         );
         tracing::info!("bookmark saved: {}", active.name);
     });

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -266,13 +266,13 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
 
     // Wire RadioReference browse button.
     {
-        let bm_list = panels.navigation.bookmark_list.clone();
-        let bm_scroll = panels.navigation.bookmark_scroll.clone();
-        let bm_rc = panels.navigation.bookmarks.clone();
-        let on_nav = panels.navigation.on_navigate.clone();
-        let active_bm = panels.navigation.active_bookmark.clone();
+        let bm_list = panels.bookmarks.bookmark_list.clone();
+        let bm_scroll = panels.bookmarks.bookmark_scroll.clone();
+        let bm_rc = panels.bookmarks.bookmarks.clone();
+        let on_nav = panels.bookmarks.on_navigate.clone();
+        let active_bm = panels.bookmarks.active_bookmark.clone();
         let name_entry = panels.navigation.name_entry.clone();
-        let on_save = panels.navigation.on_save.clone();
+        let on_save = panels.bookmarks.on_save.clone();
 
         rr_button.connect_clicked(move |btn| {
             let bm_list = bm_list.clone();
@@ -814,17 +814,18 @@ fn build_split_view(
     // reveals an unambiguously right-edge element. Uses the same
     // `SlideLeft` + 200 ms transition as the transcript revealer
     // for visual consistency when either panel opens.
-    let bookmarks_panel = sidebar::bookmarks_panel::build_bookmarks_panel();
-    let bookmarks_scroll = gtk4::ScrolledWindow::builder()
-        .child(&bookmarks_panel.widget)
-        .hscrollbar_policy(gtk4::PolicyType::Never)
-        .vexpand(true)
-        .build();
+    //
+    // The flyout widget is built by `build_sidebar` (so it can
+    // share state with the left-sidebar `NavigationPanel`) and
+    // returned on `panels.bookmarks`; here we just pack it into
+    // the revealer. The panel widget already contains its own
+    // vertical scroll for the bookmark list, so no outer scroll
+    // wrap is needed.
     let bookmarks_revealer = gtk4::Revealer::builder()
         .transition_type(gtk4::RevealerTransitionType::SlideLeft)
         .transition_duration(200)
         .reveal_child(false)
-        .child(&bookmarks_scroll)
+        .child(&panels.bookmarks.widget)
         .hexpand(false)
         .build();
 
@@ -4424,7 +4425,7 @@ fn connect_navigation_panel(
     let source_nav_gain = panels.source.gain_row.clone();
     let source_nav_agc = panels.source.agc_row.clone();
 
-    panels.navigation.connect_navigate(move |bookmark| {
+    panels.bookmarks.connect_navigate(move |bookmark| {
         let freq = bookmark.frequency;
         let mode = sidebar::navigation_panel::parse_demod_mode(&bookmark.demod_mode);
         let bw = bookmark.bandwidth;
@@ -4484,12 +4485,13 @@ fn connect_navigation_panel(
     let source_gain_bm = panels.source.gain_row.clone();
     let source_agc_bm = panels.source.agc_row.clone();
     let nav = &panels.navigation;
-    let bm_rc = nav.bookmarks.clone();
-    let bm_list = nav.bookmark_list.clone();
-    let bm_scroll = nav.bookmark_scroll.clone();
-    let on_nav = nav.on_navigate.clone();
-    let active_bm = nav.active_bookmark.clone();
-    let on_save_bm = nav.on_save.clone();
+    let bm = &panels.bookmarks;
+    let bm_rc = bm.bookmarks.clone();
+    let bm_list = bm.bookmark_list.clone();
+    let bm_scroll = bm.bookmark_scroll.clone();
+    let on_nav = bm.on_navigate.clone();
+    let active_bm = bm.active_bookmark.clone();
+    let on_save_bm = bm.on_save.clone();
     let name_entry = nav.name_entry.clone();
 
     nav.add_button.connect_clicked(move |_| {
@@ -4555,12 +4557,12 @@ fn connect_navigation_panel(
     });
 
     // Save button — update the active bookmark with current settings.
-    let save_bm_rc = nav.bookmarks.clone();
-    let save_active = nav.active_bookmark.clone();
-    let save_bm_list = nav.bookmark_list.clone();
-    let save_bm_scroll = nav.bookmark_scroll.clone();
-    let save_on_nav = nav.on_navigate.clone();
-    let save_on_save = nav.on_save.clone();
+    let save_bm_rc = bm.bookmarks.clone();
+    let save_active = bm.active_bookmark.clone();
+    let save_bm_list = bm.bookmark_list.clone();
+    let save_bm_scroll = bm.bookmark_scroll.clone();
+    let save_on_nav = bm.on_navigate.clone();
+    let save_on_save = bm.on_save.clone();
     let save_name_entry = nav.name_entry.clone();
     let save_state = Rc::clone(state);
     let save_radio_bw = panels.radio.bandwidth_row.clone();
@@ -4578,7 +4580,7 @@ fn connect_navigation_panel(
     let save_radio_voice_squelch_threshold = panels.radio.voice_squelch_threshold_row.clone();
     let save_source_gain = panels.source.gain_row.clone();
     let save_source_agc = panels.source.agc_row.clone();
-    nav.connect_save(move || {
+    bm.connect_save(move || {
         let active = save_active.borrow().clone();
         if active.name.is_empty() && active.frequency == 0 {
             return; // No active bookmark to save.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -44,6 +44,13 @@ const DEFAULT_HEIGHT: i32 = 800;
 /// Sidebar collapse breakpoint width in pixels.
 const SIDEBAR_BREAKPOINT_PX: f64 = 800.0;
 
+/// Slide-in/out duration for right-side flyouts (transcript,
+/// bookmarks) in milliseconds. Centralized so the two
+/// revealers stay in lockstep — drifting values would make
+/// one panel feel snappier than the other when the user
+/// toggles between them.
+const RIGHT_FLYOUT_TRANSITION_MS: u32 = 200;
+
 /// FFT sizes — re-exported from display panel (single source of truth).
 use crate::sidebar::display_panel::FFT_SIZES;
 #[cfg(feature = "sherpa")]
@@ -140,6 +147,12 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         .icon_name("user-bookmarks-symbolic")
         .tooltip_text("Toggle bookmarks panel (Ctrl+B)")
         .build();
+    // `tooltip_text` alone isn't reliably announced by screen
+    // readers — set the accessible label explicitly, matching
+    // the pattern used for the other icon-only controls in this
+    // file (pinned servers menu, copy server address, etc.).
+    bookmarks_toggle
+        .update_property(&[gtk4::accessible::Property::Label("Toggle bookmarks panel")]);
     header.pack_end(&bookmarks_toggle);
 
     // Restore the flyout open/closed state saved at last shutdown.
@@ -857,7 +870,7 @@ fn build_split_view(
 
     let transcript_revealer = gtk4::Revealer::builder()
         .transition_type(gtk4::RevealerTransitionType::SlideLeft)
-        .transition_duration(200)
+        .transition_duration(RIGHT_FLYOUT_TRANSITION_MS)
         .reveal_child(false)
         .child(&transcript_scroll)
         .hexpand(false)
@@ -865,9 +878,10 @@ fn build_split_view(
 
     // Bookmarks flyout — slides out from the right, outermost of
     // the two right-side panels so the header `Ctrl+B` toggle
-    // reveals an unambiguously right-edge element. Uses the same
-    // `SlideLeft` + 200 ms transition as the transcript revealer
-    // for visual consistency when either panel opens.
+    // reveals an unambiguously right-edge element. Shares the
+    // `SlideLeft` + `RIGHT_FLYOUT_TRANSITION_MS` transition with
+    // the transcript revealer for visual consistency when either
+    // panel opens.
     //
     // The flyout widget is built by `build_sidebar` (so it can
     // share state with the left-sidebar `NavigationPanel`) and
@@ -877,7 +891,7 @@ fn build_split_view(
     // wrap is needed.
     let bookmarks_revealer = gtk4::Revealer::builder()
         .transition_type(gtk4::RevealerTransitionType::SlideLeft)
-        .transition_duration(200)
+        .transition_duration(RIGHT_FLYOUT_TRANSITION_MS)
         .reveal_child(false)
         .child(&panels.bookmarks.widget)
         .hexpand(false)

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -179,6 +179,36 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         revealer_clone.set_reveal_child(btn.is_active());
     });
 
+    // Mutual exclusion between the two right-side flyouts —
+    // opening one closes the other so the content area doesn't
+    // end up with both panels stacked. Each toggle's mutex
+    // handler is added AFTER its primary handler (which does the
+    // reveal + config write), so on activation the primary fires
+    // first and the mutex then deactivates the sibling toggle;
+    // the sibling's primary handler in turn hides its revealer.
+    // `set_active(false)` on an already-inactive toggle is a
+    // no-op (GTK suppresses the `toggled` signal when the state
+    // doesn't change), so closing either panel manually doesn't
+    // cascade.
+    let transcript_btn_weak = transcript_button.downgrade();
+    bookmarks_toggle.connect_toggled(move |btn| {
+        if btn.is_active()
+            && let Some(other) = transcript_btn_weak.upgrade()
+            && other.is_active()
+        {
+            other.set_active(false);
+        }
+    });
+    let bookmarks_toggle_weak = bookmarks_toggle.downgrade();
+    transcript_button.connect_toggled(move |btn| {
+        if btn.is_active()
+            && let Some(other) = bookmarks_toggle_weak.upgrade()
+            && other.is_active()
+        {
+            other.set_active(false);
+        }
+    });
+
     let toolbar_view = build_toolbar_view(&header, &split_view);
     let breakpoint = build_breakpoint(&split_view);
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -330,41 +330,21 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
 
     // Wire RadioReference browse button.
     {
-        let bm_list = panels.bookmarks.bookmark_list.clone();
-        let bm_scroll = panels.bookmarks.bookmark_scroll.clone();
-        let bm_rc = panels.bookmarks.bookmarks.clone();
-        let on_nav = panels.bookmarks.on_navigate.clone();
-        let active_bm = panels.bookmarks.active_bookmark.clone();
-        let name_entry = panels.navigation.name_entry.clone();
-        let on_save = panels.bookmarks.on_save.clone();
-        let filter_text = panels.bookmarks.filter_text.clone();
-        let manual_expanded = panels.bookmarks.manual_expanded.clone();
+        let bookmarks_for_rr = Rc::clone(&panels.bookmarks);
+        let name_entry_for_rr = panels.navigation.name_entry.clone();
 
         rr_button.connect_clicked(move |btn| {
-            let bm_list = bm_list.clone();
-            let bm_scroll = bm_scroll.clone();
-            let bm_rc = bm_rc.clone();
-            let on_nav = on_nav.clone();
-            let active_bm = active_bm.clone();
-            let name_entry = name_entry.clone();
-            let on_save = on_save.clone();
-            let filter_text = filter_text.clone();
-            let manual_expanded = manual_expanded.clone();
+            let bookmarks_for_rr = Rc::clone(&bookmarks_for_rr);
+            let name_entry_for_rr = name_entry_for_rr.clone();
 
             crate::radioreference::show_browse_dialog(btn, move || {
-                // Reload bookmarks from disk and rebuild the sidebar list.
-                *bm_rc.borrow_mut() = sidebar::navigation_panel::load_bookmarks();
-                sidebar::navigation_panel::rebuild_bookmark_list(
-                    &bm_list,
-                    &bm_scroll,
-                    &bm_rc,
-                    &on_nav,
-                    &active_bm,
-                    &name_entry,
-                    &on_save,
-                    &filter_text,
-                    &manual_expanded,
-                );
+                // Reload bookmarks from disk and rebuild the flyout.
+                // `BookmarksPanel::rebuild` keeps this call site on
+                // the panel boundary rather than reaching through
+                // the panel's individual `Rc` fields.
+                *bookmarks_for_rr.bookmarks.borrow_mut() =
+                    sidebar::navigation_panel::load_bookmarks();
+                bookmarks_for_rr.rebuild(&name_entry_for_rr);
             });
         });
     }
@@ -4557,14 +4537,7 @@ fn connect_navigation_panel(
     let source_agc_bm = panels.source.agc_row.clone();
     let nav = &panels.navigation;
     let bm = &panels.bookmarks;
-    let bm_rc = bm.bookmarks.clone();
-    let bm_list = bm.bookmark_list.clone();
-    let bm_scroll = bm.bookmark_scroll.clone();
-    let on_nav = bm.on_navigate.clone();
-    let active_bm = bm.active_bookmark.clone();
-    let on_save_bm = bm.on_save.clone();
-    let filter_text_add = bm.filter_text.clone();
-    let manual_expanded_add = bm.manual_expanded.clone();
+    let bm_for_add = Rc::clone(bm);
     let name_entry = nav.name_entry.clone();
 
     nav.add_button.connect_clicked(move |_| {
@@ -4615,31 +4588,19 @@ fn connect_navigation_panel(
         };
         let bookmark =
             sidebar::navigation_panel::Bookmark::with_profile(&name, freq_u64, mode, bw, &profile);
-        bm_rc.borrow_mut().push(bookmark);
-        sidebar::navigation_panel::save_bookmarks(&bm_rc.borrow());
-        sidebar::navigation_panel::rebuild_bookmark_list(
-            &bm_list,
-            &bm_scroll,
-            &bm_rc,
-            &on_nav,
-            &active_bm,
-            &name_entry,
-            &on_save_bm,
-            &filter_text_add,
-            &manual_expanded_add,
-        );
+        bm_for_add.bookmarks.borrow_mut().push(bookmark);
+        sidebar::navigation_panel::save_bookmarks(&bm_for_add.bookmarks.borrow());
+        bm_for_add.rebuild(&name_entry);
         name_entry.set_text("");
     });
 
     // Save button — update the active bookmark with current settings.
-    let save_bm_rc = bm.bookmarks.clone();
-    let save_active = bm.active_bookmark.clone();
-    let save_bm_list = bm.bookmark_list.clone();
-    let save_bm_scroll = bm.bookmark_scroll.clone();
-    let save_on_nav = bm.on_navigate.clone();
-    let save_on_save = bm.on_save.clone();
-    let save_filter_text = bm.filter_text.clone();
-    let save_manual_expanded = bm.manual_expanded.clone();
+    // Capture the bookmarks panel via `Weak` so the stored closure
+    // doesn't keep the panel alive: the closure lives inside
+    // `panel.on_save`, and cloning `Rc<BookmarksPanel>` into it
+    // would form a cycle (panel → on_save → closure → panel)
+    // that prevents the panel from dropping on window teardown.
+    let save_bm_weak = std::rc::Rc::downgrade(bm);
     let save_name_entry = nav.name_entry.clone();
     let save_state = Rc::clone(state);
     let save_radio_bw = panels.radio.bandwidth_row.clone();
@@ -4658,7 +4619,16 @@ fn connect_navigation_panel(
     let save_source_gain = panels.source.gain_row.clone();
     let save_source_agc = panels.source.agc_row.clone();
     bm.connect_save(move || {
-        let active = save_active.borrow().clone();
+        // `save_bm_weak` is the ONLY reference this closure holds
+        // to the panel. Upgrading on entry gives us a live handle
+        // for the duration of the save; dropping it at the end of
+        // the call lets the panel drop cleanly on teardown even
+        // though the closure itself is stored inside
+        // `panel.on_save`.
+        let Some(save_bm) = save_bm_weak.upgrade() else {
+            return;
+        };
+        let active = save_bm.active_bookmark.borrow().clone();
         if active.name.is_empty() && active.frequency == 0 {
             return; // No active bookmark to save.
         }
@@ -4701,7 +4671,7 @@ fn connect_navigation_panel(
             }),
         };
         // Find and update the active bookmark in the list.
-        let mut bms = save_bm_rc.borrow_mut();
+        let mut bms = save_bm.bookmarks.borrow_mut();
         if let Some(bm) = bms
             .iter_mut()
             .find(|b| b.name == active.name && b.frequency == active.frequency)
@@ -4735,7 +4705,7 @@ fn connect_navigation_panel(
             bm.ctcss_threshold = profile.ctcss_threshold;
             bm.voice_squelch_mode = profile.voice_squelch_mode;
             // Keep ActiveBookmark in sync with the updated frequency.
-            *save_active.borrow_mut() = sidebar::navigation_panel::ActiveBookmark {
+            *save_bm.active_bookmark.borrow_mut() = sidebar::navigation_panel::ActiveBookmark {
                 name: active.name.clone(),
                 frequency: freq_u64,
             };
@@ -4743,17 +4713,7 @@ fn connect_navigation_panel(
         sidebar::navigation_panel::save_bookmarks(&bms);
         drop(bms);
         // Rebuild to update subtitle.
-        sidebar::navigation_panel::rebuild_bookmark_list(
-            &save_bm_list,
-            &save_bm_scroll,
-            &save_bm_rc,
-            &save_on_nav,
-            &save_active,
-            &save_name_entry,
-            &save_on_save,
-            &save_filter_text,
-            &save_manual_expanded,
-        );
+        save_bm.rebuild(&save_name_entry);
         tracing::info!("bookmark saved: {}", active.name);
     });
 }


### PR DESCRIPTION
## Summary

Relocates the bookmark list into a right-side slide-out flyout that mirrors the existing transcript panel pattern. The left sidebar keeps the "Add Bookmark" quick-add (name entry + button) so users can stash a bookmark without opening the flyout — the flyout is for browsing / searching / managing the full list. Toggled from a new header bookmark icon or `Ctrl+B`.

Closes #339.

## What's in this PR

- **Scaffolding** — right-side `gtk4::Revealer` mirroring the transcript panel's `SlideLeft` transition, header toggle button (`pack_end` so it sits at the right edge under which the panel slides out), `Ctrl+B` shortcut wired into `ShortcutController`, help dialog catalog updated
- **List relocation** — bookmark list widget, backing store (`Rc<RefCell<Vec<Bookmark>>>`), and row actions (recall, delete, save-over-active) moved from `NavigationPanel` into a new `BookmarksPanel`. `NavigationPanel` still owns the `name_entry` widget; `BookmarksPanel` borrows it at build time for its row callbacks
- **Search row** — `gtk4::SearchEntry` at the top of the flyout, live filters by name / demod / frequency (case-insensitive substring)
- **Category grouping** — when any bookmark has `rr_category` (from the RadioReference import path), groups render under `AdwExpanderRow` with sibling `Uncategorized` bucket for loose entries; pure-uncategorized lists stay flat. Categories auto-expand on search, preserve manual expand/collapse state across rebuilds, and always keep the active bookmark's category open
- **Mutual exclusion** — opening the bookmarks flyout closes the transcript flyout and vice versa, so the content area never ends up with both panels stacked
- **State persistence** — flyout open/closed state saved under `bookmarks_flyout_open` config key; on launch the flyout restores to whatever it was at shutdown without the open-animation playing

## Commits

1. `feat(#339)`: scaffolding — right-side bookmarks flyout + Ctrl+B
2. move bookmark list + row actions to the right flyout
3. add search/filter row to bookmarks flyout
4. group bookmarks by category under AdwExpanderRow
5. persist bookmarks flyout open/closed state
6. preserve expander state across rebuild on bookmark recall
7. make transcript and bookmarks flyouts mutually exclusive

## Test plan

- [x] `cargo build --workspace --features sdr-ui/whisper-cpu`
- [x] `cargo clippy --workspace --features sdr-ui/whisper-cpu --all-targets -- -D warnings`
- [x] `cargo test --workspace --features sdr-ui/whisper-cpu` — 130 sdr-ui tests pass (4 new for `bookmark_matches_filter`)
- [x] Smoke test with RTL-SDR: header toggle + `Ctrl+B` open/close flyout, bookmarks recall/add/delete/save, search filters live, categorized bookmarks group correctly, expander state preserved on recall, flyout persists across app restart, opening one flyout closes the other

## Follow-up

After merge, file a parallel Mac-side ticket for the same bookmarks slide-out affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-side Bookmarks flyout with header toggle and Ctrl+B shortcut.
  * Search/filter within bookmarks with immediate results.

* **Improvements**
  * Bookmarks grouped by category and preserve expand/collapse state.
  * Flyout open/closed state persists and mutually excludes the transcript panel.
  * Preset selection, add, and save actions update the flyout immediately.

* **Refactor**
  * Left sidebar simplified to a quick-add area; full bookmark list moved to the flyout.

* **Tests**
  * Unit tests validating bookmark filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->