### PR TITLE
rtl_tcp: Mac SwiftUI client picker (closes #326)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -438,12 +438,18 @@ public final class SdrCore: @unchecked Sendable {
     // ==========================================================
 
     /// Disconnect the rtl_tcp client without changing source
-    /// type. The engine drops the current TCP socket and
-    /// transitions the connection-state machine to
-    /// `.disconnected`. A subsequent `retryRtlTcpNow()` (or any
-    /// engine restart) reopens against the same stored host /
-    /// port. Safe to call when the active source is not
-    /// rtl_tcp — the engine logs and drops the command.
+    /// type. The engine stops the current source, drops the
+    /// source instance, and transitions the connection-state
+    /// machine to `.disconnected`. Source type stays `.rtlTcp`,
+    /// so a subsequent `start()` (normal "Play" path) reopens
+    /// a fresh source from the stored network config.
+    ///
+    /// Note: `retryRtlTcpNow()` is NOT a reconnect path after
+    /// this call — once the source has been dropped, retry is
+    /// a no-op. Call `start()` to reopen.
+    ///
+    /// Safe to call when the active source is not rtl_tcp —
+    /// the engine logs and drops the command.
     public func disconnectRtlTcp() throws {
         try checkRc(sdr_core_rtl_tcp_disconnect(handle))
     }
@@ -451,6 +457,15 @@ public final class SdrCore: @unchecked Sendable {
     /// Retry the rtl_tcp connection immediately, bypassing the
     /// exponential-backoff sleep inside the reconnect loop.
     /// Useful wired to a "Retry now" button on the status row.
+    ///
+    /// Only meaningful while an rtl_tcp source instance is
+    /// still alive — states `.retrying`, `.failed`,
+    /// `.connecting`, or `.connected`. After an explicit
+    /// `disconnectRtlTcp()`, the source instance is gone and
+    /// this call silently returns; hosts should disable the
+    /// Retry button in `.disconnected` and use `start()` to
+    /// reopen.
+    ///
     /// Safe to call when the active source is not rtl_tcp —
     /// the engine logs and drops the command.
     public func retryRtlTcpNow() throws {

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -433,6 +433,30 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(sdr_core_set_gain_by_index(handle, index))
     }
 
+    // ==========================================================
+    //  rtl_tcp client lifecycle (ABI 0.12, issue #326)
+    // ==========================================================
+
+    /// Disconnect the rtl_tcp client without changing source
+    /// type. The engine drops the current TCP socket and
+    /// transitions the connection-state machine to
+    /// `.disconnected`. A subsequent `retryRtlTcpNow()` (or any
+    /// engine restart) reopens against the same stored host /
+    /// port. Safe to call when the active source is not
+    /// rtl_tcp — the engine logs and drops the command.
+    public func disconnectRtlTcp() throws {
+        try checkRc(sdr_core_rtl_tcp_disconnect(handle))
+    }
+
+    /// Retry the rtl_tcp connection immediately, bypassing the
+    /// exponential-backoff sleep inside the reconnect loop.
+    /// Useful wired to a "Retry now" button on the status row.
+    /// Safe to call when the active source is not rtl_tcp —
+    /// the engine logs and drops the command.
+    public func retryRtlTcpNow() throws {
+        try checkRc(sdr_core_rtl_tcp_retry_now(handle))
+    }
+
     /// Switch the active audio sink between the local output
     /// device and the network stream. The engine stops the
     /// current sink, builds the replacement from the persisted

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -1949,6 +1949,81 @@ final class CoreModel {
         }
     }
 
+    /// Connect the engine's rtl_tcp client to `host:port`.
+    /// Mirrors `applyNetworkSourceConfig` + `setSourceType(.rtlTcp)`
+    /// — the engine uses the same stored host/port for both
+    /// `.network` and `.rtlTcp` sources, so this path writes
+    /// to that shared storage and then flips the source type.
+    /// On a successful dispatch, `rtlTcpLastConnected` is
+    /// updated and persisted so the next launch can repopulate
+    /// the manual-entry fields. Connection *progress* (actual
+    /// socket connect, handshake, ready-to-stream) arrives
+    /// asynchronously via `rtlTcpConnectionState` events from
+    /// the engine. Per issue #326.
+    func connectToRtlTcp(host: String, port: UInt16, nickname: String) {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            lastError = "rtl_tcp server host cannot be empty"
+            return
+        }
+        guard port != 0 else {
+            lastError = "rtl_tcp server port must be in 1…65535"
+            return
+        }
+        // Clear any stale error from a prior action so we can
+        // detect whether the FFI calls below introduce a new
+        // one (either validation inside `applyNetworkSourceConfig`
+        // or a `capture {}` failure on the setter).
+        lastError = nil
+        // Write through the shared network-source config path.
+        // `applyNetworkSourceConfig` persists host/port/protocol
+        // in UserDefaults and dispatches `set_network_config` —
+        // both the `.network` IQ source and `.rtlTcp` source
+        // read from the same slot, matching the engine side.
+        applyNetworkSourceConfig(host: trimmed, port: port, protocol: .tcp)
+        if lastError != nil { return }
+        // Remember this endpoint. The nickname falls back to
+        // `host:port` when the caller didn't have a better label
+        // (manual-entry without a matching mDNS announce).
+        let displayNickname = nickname.isEmpty ? "\(trimmed):\(port)" : nickname
+        rtlTcpLastConnected = RtlTcpClientLastConnected(
+            host: trimmed,
+            port: port,
+            nickname: displayNickname
+        )
+        persistRtlTcpLastConnected()
+        // Flip to `.rtlTcp` — the engine tears down whatever is
+        // currently open and builds the rtl_tcp client from the
+        // just-written network config.
+        setSourceType(.rtlTcp)
+    }
+
+    /// Render an `RtlTcpConnectionState` to a one-line status
+    /// string suitable for a picker subtitle row. Matches the
+    /// Linux `format_rtl_tcp_state()` wording (Connected /
+    /// Retrying / Failed / …). Static so views can render it
+    /// without reaching into the model. Per issue #326.
+    static func formatRtlTcpConnectionState(_ state: RtlTcpConnectionState) -> String {
+        switch state {
+        case .disconnected:
+            return "Not connected"
+        case .connecting:
+            return "Connecting…"
+        case .connected(let tunerName, let gainCount):
+            return "Connected — \(tunerName) (\(gainCount) gains)"
+        case .retrying(let attempt, let retryInSecs):
+            // Ceil, not floor — `retryInSecs` of 1.9 would read
+            // as 1 s and understate the wait. Clamp to ≥1 so
+            // sub-1 s retries still display something rather
+            // than "0 s" (which reads like the retry already
+            // fired). Matches Linux treatment.
+            let secs = max(Int(retryInSecs.rounded(.up)), 1)
+            return "Retrying in \(secs) s (attempt \(attempt))"
+        case .failed(let reason):
+            return "Failed — \(reason)"
+        }
+    }
+
     /// Restore favorites + last-connected from `UserDefaults`.
     /// Called from `bootstrap()`. Absent or corrupt entries
     /// degrade to empty / nil silently — a bad JSON blob should

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -480,17 +480,24 @@ final class CoreModel {
     /// sensitivity in the UI.
     var rtlTcpConnectionState: RtlTcpConnectionState = .disconnected
 
-    /// `true` when the selected sample rate is at or above 2.4
-    /// Msps AND the active source is `.rtlTcp`. At 8-bit I/Q
-    /// pairs that works out to ≈38 Mbps on the wire — below
-    /// typical Wi-Fi practical throughput for older routers. The
-    /// UI shows a caption warning about drops; the rate still
-    /// commits because wired gigabit handles it fine. Threshold
-    /// matches `HIGH_BANDWIDTH_SAMPLE_RATE_IDX` in
+    /// `true` when the selected **source** sample rate is at or
+    /// above 2.4 Msps AND the active source is `.rtlTcp`. At
+    /// 8-bit I/Q pairs that works out to ≈38 Mbps on the wire —
+    /// below typical Wi-Fi practical throughput for older
+    /// routers. The UI shows a caption warning about drops; the
+    /// rate still commits because wired gigabit handles it fine.
+    /// Threshold matches `HIGH_BANDWIDTH_SAMPLE_RATE_IDX` in
     /// `sdr-ui/src/sidebar/source_panel.rs` (index 7 = 2.4 MHz).
+    ///
+    /// Keyed on `sourceSampleRateHz` (pre-decimation) NOT
+    /// `effectiveSampleRateHz` (post-decimation) — rtl_tcp
+    /// streams raw IQ samples at the source rate over the
+    /// wire; decimation is applied locally after receive, so
+    /// the network bitrate is insensitive to the decimation
+    /// factor. Per `CodeRabbit` round 1 on PR #366.
     var rtlTcpShowsBandwidthAdvisory: Bool {
         sourceType == .rtlTcp
-            && effectiveSampleRateHz >= Self.rtlTcpHighBandwidthThresholdHz
+            && sourceSampleRateHz >= Self.rtlTcpHighBandwidthThresholdHz
     }
 
     /// Sample-rate threshold (Hz) at which `rtlTcpShowsBandwidthAdvisory`

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -440,6 +440,72 @@ final class CoreModel {
     /// concurrent stop's USB close.
     private var rtlTcpServerLifecycleTask: Task<Void, Never>? = nil
 
+    // ----------------------------------------------------------
+    //  rtl_tcp client — issue #326
+    //
+    //  Observable state for the SwiftUI client picker: discovered
+    //  servers from the mDNS browser, persisted favorites + last-
+    //  connected snapshot, and the live connection state surfaced
+    //  by the engine's `RtlTcpConnectionState` event. Mirrors the
+    //  Linux GTK `source_panel.rs` treatment (favorites keys,
+    //  bandwidth advisory threshold, state formatter) so both
+    //  frontends have parity.
+    // ----------------------------------------------------------
+
+    /// Live mDNS discoveries from `SdrRtlTcpBrowser`, sorted by
+    /// `instanceName` for stable ordering. Browser runs from
+    /// bootstrap to shutdown — discovering while the picker is
+    /// closed is harmless and means the list is already populated
+    /// the first time the user expands it.
+    var rtlTcpDiscoveredServers: [SdrRtlTcpBrowser.DiscoveredServer] = []
+
+    /// User-pinned favorite servers, persisted as a JSON array in
+    /// `UserDefaults`. Starred rows promote to the top of the
+    /// picker (UI layer) and survive across sessions even when
+    /// the server is offline. Mirrors the Linux `FavoriteEntry`
+    /// on-disk schema.
+    var rtlTcpFavorites: [RtlTcpClientFavorite] = []
+
+    /// Most recent server the user actually connected to — host,
+    /// port, nickname. Populated on successful connect, persisted
+    /// in `UserDefaults` so the next launch repopulates the
+    /// manual-entry fields + can auto-reconnect without waiting
+    /// for mDNS rediscovery.
+    var rtlTcpLastConnected: RtlTcpClientLastConnected? = nil
+
+    /// Live connection-state snapshot, mirrored from
+    /// `SdrCoreEvent.rtlTcpConnectionState`. `.disconnected`
+    /// initial value before the engine reports anything. Drives
+    /// the status row's subtitle and the disconnect/retry button
+    /// sensitivity in the UI.
+    var rtlTcpConnectionState: RtlTcpConnectionState = .disconnected
+
+    /// `true` when the selected sample rate is at or above 2.4
+    /// Msps AND the active source is `.rtlTcp`. At 8-bit I/Q
+    /// pairs that works out to ≈38 Mbps on the wire — below
+    /// typical Wi-Fi practical throughput for older routers. The
+    /// UI shows a caption warning about drops; the rate still
+    /// commits because wired gigabit handles it fine. Threshold
+    /// matches `HIGH_BANDWIDTH_SAMPLE_RATE_IDX` in
+    /// `sdr-ui/src/sidebar/source_panel.rs` (index 7 = 2.4 MHz).
+    var rtlTcpShowsBandwidthAdvisory: Bool {
+        sourceType == .rtlTcp
+            && effectiveSampleRateHz >= Self.rtlTcpHighBandwidthThresholdHz
+    }
+
+    /// Sample-rate threshold (Hz) at which `rtlTcpShowsBandwidthAdvisory`
+    /// kicks in. Matches the Linux constant. `Double` to match
+    /// the `effectiveSampleRateHz` @Observable field type.
+    static let rtlTcpHighBandwidthThresholdHz: Double = 2_400_000
+
+    /// Live mDNS browser handle. Started in `bootstrap()` and
+    /// stopped in `shutdown()`; `nil` if the OS denied browser
+    /// start (rare — mDNS doesn't need special entitlements on
+    /// macOS). Events land on a dispatcher thread and hop to
+    /// MainActor via `Task { @MainActor in … }` inside the
+    /// callback closure.
+    private var rtlTcpBrowser: SdrRtlTcpBrowser? = nil
+
     /// Active audio-recording state. `nil` = not recording,
     /// `some(path)` = engine confirmed it opened `path` for
     /// writing. Mirrors `DspToUi::AudioRecordingStarted/Stopped`
@@ -545,6 +611,19 @@ final class CoreModel {
         // This is a handle-free libusb device-list query; no USB
         // control transfers, no hardware open.
         refreshDeviceInfo()
+
+        // Start the rtl_tcp mDNS browser early so the picker is
+        // already populated when the user first expands it. No-
+        // op on macOS without mDNS (Bonjour is always on), but
+        // the failure path is non-fatal either way. Per issue
+        // #326.
+        startRtlTcpBrowser()
+
+        // Restore persisted favorites + last-connected snapshot
+        // so the picker's "Known servers" list and the manual-
+        // entry defaults round-trip across launches. Per issue
+        // #326.
+        restoreRtlTcpClientState()
 
         // Restore the previously-selected audio output device UID
         // so the user's preference survives across launches.
@@ -714,6 +793,10 @@ final class CoreModel {
         // toggle; shutdown runs during app termination where
         // blocking briefly is the desired behavior.
         stopRtlTcpServerSync()
+        // Stop the rtl_tcp mDNS browser on shutdown — joins the
+        // dispatcher thread so no stray callbacks arrive after
+        // the model deinits. Per issue #326.
+        stopRtlTcpBrowser()
         if let core {
             // Best-effort stop — a thrown error shouldn't leave
             // the model claiming `isRunning == true` alongside a
@@ -816,6 +899,14 @@ final class CoreModel {
             // reads this field to render the status row; we don't
             // locally flip state on the setter return code.
             networkSinkStatus = status
+        case .rtlTcpConnectionState(let state):
+            // Engine is authoritative for rtl_tcp client state
+            // — `Connecting`, `Connected(tuner)`, `Retrying(n,
+            // secs)`, `Failed(reason)`, `Disconnected`. The UI
+            // status row subtitle renders `state` directly;
+            // disconnect / retry buttons gate on it. Per issue
+            // #326.
+            rtlTcpConnectionState = state
         @unknown default:
             // Surface new engine event variants during
             // development. SdrCoreEvent is a non-frozen enum
@@ -1723,6 +1814,157 @@ final class CoreModel {
     static let rtlTcpServerInitialPpmKey = "SDRMac.rtlTcpServer.initialPpm"
     static let rtlTcpServerInitialBiasTeeKey = "SDRMac.rtlTcpServer.initialBiasTee"
     static let rtlTcpServerInitialDirectSamplingKey = "SDRMac.rtlTcpServer.initialDirectSampling"
+
+    /// UserDefaults keys for the persisted rtl_tcp *client*
+    /// favorites and last-connected snapshot. Namespaced to
+    /// `SDRMac.rtlTcpClient.*` to stay distinct from the server
+    /// keys above. Stored as JSON strings (arrays / objects via
+    /// `JSONEncoder`) — matches the Linux `source_panel.rs`
+    /// on-disk shape where the same records live under
+    /// `rtl_tcp_client_favorites` / `rtl_tcp_client_last_connected`
+    /// inside the engine `ConfigManager` JSON.
+    static let rtlTcpClientFavoritesKey = "SDRMac.rtlTcpClient.favorites"
+    static let rtlTcpClientLastConnectedKey = "SDRMac.rtlTcpClient.lastConnected"
+
+    // ----------------------------------------------------------
+    //  rtl_tcp client — issue #326
+    // ----------------------------------------------------------
+
+    /// Start the mDNS browser for `_rtl_tcp._tcp.local.`
+    /// announcements. Called from `bootstrap()`; the browser
+    /// runs for the app's lifetime so the discovered list is
+    /// pre-populated the first time the user expands the
+    /// picker, matching the Linux GTK behavior. Failure here is
+    /// a warning — the picker still works via favorites and
+    /// manual entry, just without auto-discovery.
+    private func startRtlTcpBrowser() {
+        // Idempotent — a re-bootstrap (hypothetically) won't
+        // spawn a second browser.
+        if rtlTcpBrowser != nil { return }
+        do {
+            rtlTcpBrowser = try SdrRtlTcpBrowser { [weak self] event in
+                // Callback fires on the browser's dispatcher
+                // thread — hop to MainActor to mutate
+                // `@Observable` state.
+                Task { @MainActor [weak self] in
+                    self?.applyRtlTcpBrowserEvent(event)
+                }
+            }
+        } catch {
+            print("[CoreModel] rtl_tcp mDNS browser failed to start: \(error)")
+            rtlTcpBrowser = nil
+        }
+    }
+
+    /// Stop the browser. Called from `shutdown()` — the
+    /// `deinit` would also release the handle, but explicit
+    /// teardown joins the dispatcher thread before we exit.
+    private func stopRtlTcpBrowser() {
+        rtlTcpBrowser?.stop()
+        rtlTcpBrowser = nil
+    }
+
+    /// Merge one browser event into `rtlTcpDiscoveredServers`,
+    /// keyed on `instanceName` (the mDNS DNS-SD instance name
+    /// is the stable identity; same instance re-announcing from
+    /// a new IP replaces the existing row). Keeps the list
+    /// sorted by instance name for stable UI rendering.
+    private func applyRtlTcpBrowserEvent(_ event: SdrRtlTcpBrowser.Event) {
+        switch event {
+        case .announced(let server):
+            if let idx = rtlTcpDiscoveredServers.firstIndex(where: {
+                $0.instanceName == server.instanceName
+            }) {
+                rtlTcpDiscoveredServers[idx] = server
+            } else {
+                rtlTcpDiscoveredServers.append(server)
+                rtlTcpDiscoveredServers.sort { $0.instanceName < $1.instanceName }
+            }
+            // Refresh cached metadata on any favorite that
+            // matches this announce — so a reopened sidebar
+            // shows current tuner / gain-count / last-seen
+            // even when offline-starred earlier.
+            let key = "\(server.hostname):\(server.port)"
+            if let idx = rtlTcpFavorites.firstIndex(where: { $0.key == key }) {
+                var fav = rtlTcpFavorites[idx]
+                let newNickname = server.nickname.isEmpty
+                    ? server.instanceName
+                    : server.nickname
+                if !newNickname.isEmpty {
+                    fav.nickname = newNickname
+                }
+                if !server.tuner.isEmpty {
+                    fav.tunerName = server.tuner
+                }
+                if server.gains != 0 {
+                    fav.gainCount = server.gains
+                }
+                fav.lastSeenUnix = UInt64(Date().timeIntervalSince1970)
+                rtlTcpFavorites[idx] = fav
+                persistRtlTcpFavorites()
+            }
+        case .withdrawn(let instanceName):
+            rtlTcpDiscoveredServers.removeAll { $0.instanceName == instanceName }
+        }
+    }
+
+    /// Add (or refresh) a favorite for the given key. If an
+    /// entry with the same key already exists, its metadata is
+    /// updated in place rather than duplicated.
+    func addRtlTcpFavorite(_ favorite: RtlTcpClientFavorite) {
+        if let idx = rtlTcpFavorites.firstIndex(where: { $0.key == favorite.key }) {
+            rtlTcpFavorites[idx] = favorite
+        } else {
+            rtlTcpFavorites.append(favorite)
+        }
+        persistRtlTcpFavorites()
+    }
+
+    /// Remove a favorite by key. No-op if the key isn't found.
+    func removeRtlTcpFavorite(key: String) {
+        rtlTcpFavorites.removeAll { $0.key == key }
+        persistRtlTcpFavorites()
+    }
+
+    /// Persist the favorites array to `UserDefaults` as a JSON
+    /// string. Called from `add/removeRtlTcpFavorite` on any
+    /// mutation, and from the browser event handler when it
+    /// refreshes cached metadata for a starred entry.
+    func persistRtlTcpFavorites() {
+        if let data = try? JSONEncoder().encode(rtlTcpFavorites),
+           let json = String(data: data, encoding: .utf8) {
+            UserDefaults.standard.set(json, forKey: Self.rtlTcpClientFavoritesKey)
+        }
+    }
+
+    /// Persist the last-connected snapshot to `UserDefaults`.
+    /// Called on a successful client connect (commit 2).
+    func persistRtlTcpLastConnected() {
+        if let last = rtlTcpLastConnected,
+           let data = try? JSONEncoder().encode(last),
+           let json = String(data: data, encoding: .utf8) {
+            UserDefaults.standard.set(json, forKey: Self.rtlTcpClientLastConnectedKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.rtlTcpClientLastConnectedKey)
+        }
+    }
+
+    /// Restore favorites + last-connected from `UserDefaults`.
+    /// Called from `bootstrap()`. Absent or corrupt entries
+    /// degrade to empty / nil silently — a bad JSON blob should
+    /// never block the app from launching.
+    private func restoreRtlTcpClientState() {
+        if let json = UserDefaults.standard.string(forKey: Self.rtlTcpClientFavoritesKey),
+           let data = json.data(using: .utf8),
+           let decoded = try? JSONDecoder().decode([RtlTcpClientFavorite].self, from: data) {
+            rtlTcpFavorites = decoded
+        }
+        if let json = UserDefaults.standard.string(forKey: Self.rtlTcpClientLastConnectedKey),
+           let data = json.data(using: .utf8),
+           let decoded = try? JSONDecoder().decode(RtlTcpClientLastConnected.self, from: data) {
+            rtlTcpLastConnected = decoded
+        }
+    }
 
     // ----------------------------------------------------------
     //  Source selection setters — issues #235, #236

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -498,6 +498,39 @@ final class CoreModel {
     /// the `effectiveSampleRateHz` @Observable field type.
     static let rtlTcpHighBandwidthThresholdHz: Double = 2_400_000
 
+    /// Bias-T power on the LNA coax. `false` = off (dongle
+    /// default). Optimistic — the UI flip commits immediately
+    /// and the FFI dispatch follows; the engine has no
+    /// observable state event for this toggle so we treat the
+    /// model as the source of truth.
+    var biasTeeEnabled: Bool = false
+
+    /// Tuner offset-tuning. `false` = off.
+    var offsetTuningEnabled: Bool = false
+
+    /// RTL2832 direct-sampling mode. `.off` = normal tuner path.
+    /// Distinct from the analog tuner AGC (`agcEnabled`) which
+    /// controls the gain loop inside the tuner chip; direct
+    /// sampling bypasses the tuner entirely and samples the
+    /// antenna input straight into the ADC.
+    var directSamplingMode: SdrCore.DirectSamplingMode = .off
+
+    /// RTL2832 digital AGC loop. Distinct from the analog tuner
+    /// AGC (`agcEnabled`); an RTL-SDR dongle exposes both
+    /// independently and most real-world setups want tuner
+    /// AGC ON and RTL AGC OFF. Default follows the engine's
+    /// `rtlsdr_set_agc_mode(dev, 0)`.
+    var rtlAgcEnabled: Bool = false
+
+    /// Current rtl_tcp gain-by-index selection. `gain_count`
+    /// from the `Connected` state is the list length; values
+    /// are `0..<gainCount`. Stays at `0` between sessions
+    /// because gain tables aren't comparable across servers
+    /// (a Mini-2+ and an R820T have different tables), so
+    /// persisting the last index would restore a meaningless
+    /// slider position on reconnect to a different server.
+    var rtlTcpGainIndex: UInt32 = 0
+
     /// Live mDNS browser handle. Started in `bootstrap()` and
     /// stopped in `shutdown()`; `nil` if the OS denied browser
     /// start (rare — mDNS doesn't need special entitlements on
@@ -624,6 +657,24 @@ final class CoreModel {
         // entry defaults round-trip across launches. Per issue
         // #326.
         restoreRtlTcpClientState()
+
+        // Restore rtl_tcp-specific toggle state (bias-T, offset
+        // tuning, direct-sampling mode, RTL AGC). Absent keys
+        // leave the defaults intact. Gain index is per-session
+        // so it's not persisted — see `rtlTcpGainIndex` docs.
+        if UserDefaults.standard.object(forKey: Self.rtlTcpBiasTeeKey) != nil {
+            biasTeeEnabled = UserDefaults.standard.bool(forKey: Self.rtlTcpBiasTeeKey)
+        }
+        if UserDefaults.standard.object(forKey: Self.rtlTcpOffsetTuningKey) != nil {
+            offsetTuningEnabled = UserDefaults.standard.bool(forKey: Self.rtlTcpOffsetTuningKey)
+        }
+        if UserDefaults.standard.object(forKey: Self.rtlTcpDirectSamplingKey) != nil {
+            let raw = Int32(UserDefaults.standard.integer(forKey: Self.rtlTcpDirectSamplingKey))
+            directSamplingMode = SdrCore.DirectSamplingMode(rawValue: raw) ?? .off
+        }
+        if UserDefaults.standard.object(forKey: Self.rtlTcpRtlAgcKey) != nil {
+            rtlAgcEnabled = UserDefaults.standard.bool(forKey: Self.rtlTcpRtlAgcKey)
+        }
 
         // Restore the previously-selected audio output device UID
         // so the user's preference survives across launches.
@@ -1997,6 +2048,81 @@ final class CoreModel {
         // just-written network config.
         setSourceType(.rtlTcp)
     }
+
+    /// Disconnect the rtl_tcp client without changing source
+    /// type. The engine tears down the current TCP socket and
+    /// the connection-state machine transitions to
+    /// `.disconnected` (which arrives asynchronously on the
+    /// event stream). Source type stays `.rtlTcp` so a
+    /// subsequent `retryRtlTcpNow()` reopens against the same
+    /// host/port from stored config. Per issue #326.
+    func disconnectRtlTcp() {
+        capture { try core?.disconnectRtlTcp() }
+    }
+
+    /// Retry the rtl_tcp connection immediately, bypassing the
+    /// exponential-backoff sleep the reconnect loop is in after
+    /// a transport failure. Useful wired to a "Retry now"
+    /// button that shouldn't make the user wait out the
+    /// countdown. Per issue #326.
+    func retryRtlTcpNow() {
+        capture { try core?.retryRtlTcpNow() }
+    }
+
+    // ----------------------------------------------------------
+    //  rtl_tcp-specific command setters (ABI 0.11/0.12)
+    //
+    //  These apply to ANY active source per the engine's
+    //  silent-accept contract — but only the .rtlTcp arm of
+    //  SourceSection surfaces the UI. Optimistic pattern:
+    //  flip the observable field first for input responsiveness,
+    //  then dispatch through the FFI. The engine doesn't publish
+    //  state events for these, so the model field is the
+    //  source of truth once it's flipped.
+    // ----------------------------------------------------------
+
+    func setBiasTee(_ on: Bool) {
+        biasTeeEnabled = on
+        UserDefaults.standard.set(on, forKey: Self.rtlTcpBiasTeeKey)
+        capture { try core?.setBiasTee(on) }
+    }
+
+    func setOffsetTuning(_ on: Bool) {
+        offsetTuningEnabled = on
+        UserDefaults.standard.set(on, forKey: Self.rtlTcpOffsetTuningKey)
+        capture { try core?.setOffsetTuning(on) }
+    }
+
+    func setDirectSampling(_ mode: SdrCore.DirectSamplingMode) {
+        directSamplingMode = mode
+        UserDefaults.standard.set(Int(mode.rawValue), forKey: Self.rtlTcpDirectSamplingKey)
+        capture { try core?.setDirectSampling(mode) }
+    }
+
+    func setRtlAgc(_ on: Bool) {
+        rtlAgcEnabled = on
+        UserDefaults.standard.set(on, forKey: Self.rtlTcpRtlAgcKey)
+        capture { try core?.setRtlAgc(on) }
+    }
+
+    /// Dispatch rtl_tcp `set_gain_by_index` (protocol cmd 0x0d).
+    /// The index is bounds-checked by the engine against the
+    /// `Connected` state's `gain_count` field — out-of-range
+    /// surfaces as an `.error(...)` event rather than silently
+    /// failing on the wire. Not persisted across sessions (see
+    /// the `rtlTcpGainIndex` field docs).
+    func setRtlTcpGainIndex(_ index: UInt32) {
+        rtlTcpGainIndex = index
+        capture { try core?.setGainByIndex(index) }
+    }
+
+    // ----------------------------------------------------------
+    //  UserDefaults keys for rtl_tcp-specific command toggles
+    // ----------------------------------------------------------
+    static let rtlTcpBiasTeeKey = "SDRMac.rtlTcpClient.biasTee"
+    static let rtlTcpOffsetTuningKey = "SDRMac.rtlTcpClient.offsetTuning"
+    static let rtlTcpDirectSamplingKey = "SDRMac.rtlTcpClient.directSampling"
+    static let rtlTcpRtlAgcKey = "SDRMac.rtlTcpClient.rtlAgc"
 
     /// Render an `RtlTcpConnectionState` to a one-line status
     /// string suitable for a picker subtitle row. Matches the

--- a/apps/macos/SDRMac/Models/RtlTcpClientFavorite.swift
+++ b/apps/macos/SDRMac/Models/RtlTcpClientFavorite.swift
@@ -1,0 +1,120 @@
+//
+// RtlTcpClientFavorite.swift — persisted rtl_tcp client records.
+//
+// Two types: `RtlTcpClientFavorite` is the user-pinned favorite
+// entry (starred servers that survive across sessions even when
+// offline), and `RtlTcpClientLastConnected` is the most-recent
+// successful connection snapshot used to repopulate the manual-
+// entry fields on next launch.
+//
+// Both are `Codable` so `UserDefaults` can store them as JSON
+// strings — matches the Linux GTK `source_panel.rs` schema so a
+// user who runs both frontends sees the same favorites. The
+// persistence lives in `CoreModel`; these types are pure data.
+//
+// Mirrors `FavoriteEntry` + `LastConnectedServer` in
+// `crates/sdr-ui/src/sidebar/source_panel.rs`. Field names use
+// Swift camelCase; JSON `CodingKeys` map back to the Linux
+// snake_case on-disk form so both frontends round-trip.
+
+import Foundation
+import SdrCoreKit
+
+/// Pinned favorite record. Key identity is `hostname:port`;
+/// display metadata (`nickname`, `tunerName`, `gainCount`,
+/// `lastSeenUnix`) is optional so a freshly-starred server with
+/// no cached announce still round-trips cleanly.
+struct RtlTcpClientFavorite: Codable, Sendable, Equatable, Identifiable {
+    /// Stable identity — `"\(host):\(port)"`. Two entries with
+    /// the same key refer to the same endpoint; the favorites
+    /// list is deduped on this field.
+    let key: String
+
+    /// User-facing label. Preferred source: mDNS TXT `nickname`.
+    /// Fallback: the DNS-SD `instance_name`. For a legacy entry
+    /// that only has a bare `key` persisted, this is the same
+    /// string as `key` until the server re-announces.
+    var nickname: String
+
+    /// Tuner model from the last-seen `DiscoveredServer` TXT
+    /// record, e.g. `"R820T"`. `nil` for offline-only entries
+    /// that haven't been seen since they were pinned.
+    var tunerName: String?
+
+    /// Gain-step count from the same TXT record. `nil` same as
+    /// `tunerName`.
+    var gainCount: UInt32?
+
+    /// Unix timestamp (seconds since epoch) of the most recent
+    /// `.announced` event for this `key`. `nil` when we haven't
+    /// seen the server this session.
+    var lastSeenUnix: UInt64?
+
+    /// `Identifiable` — `key` is already unique by definition.
+    var id: String { key }
+
+    /// Parse `host:port` out of the `key` for use in a connect
+    /// call. Returns `nil` if the key is malformed (missing colon,
+    /// non-numeric port, empty host).
+    var parsedEndpoint: (host: String, port: UInt16)? {
+        guard let colon = key.lastIndex(of: ":") else { return nil }
+        let host = String(key[..<colon])
+        let portStr = key[key.index(after: colon)...]
+        guard !host.isEmpty, let port = UInt16(portStr), port > 0 else {
+            return nil
+        }
+        return (host, port)
+    }
+
+    /// Build a fresh favorite from a live mDNS discovery. The
+    /// `key` is derived from `hostname:port`; display metadata
+    /// comes straight from the announce record.
+    init(from server: SdrRtlTcpBrowser.DiscoveredServer) {
+        self.key = "\(server.hostname):\(server.port)"
+        self.nickname = server.nickname.isEmpty ? server.instanceName : server.nickname
+        self.tunerName = server.tuner.isEmpty ? nil : server.tuner
+        self.gainCount = server.gains == 0 ? nil : server.gains
+        self.lastSeenUnix = UInt64(Date().timeIntervalSince1970)
+    }
+
+    /// Direct init for manual-entry / programmatic paths.
+    init(
+        key: String,
+        nickname: String,
+        tunerName: String? = nil,
+        gainCount: UInt32? = nil,
+        lastSeenUnix: UInt64? = nil
+    ) {
+        self.key = key
+        self.nickname = nickname
+        self.tunerName = tunerName
+        self.gainCount = gainCount
+        self.lastSeenUnix = lastSeenUnix
+    }
+
+    /// JSON key mapping to the Linux GTK on-disk schema
+    /// (`snake_case`), so both frontends share the same file
+    /// format when a user runs them on the same machine.
+    enum CodingKeys: String, CodingKey {
+        case key
+        case nickname
+        case tunerName = "tuner_name"
+        case gainCount = "gain_count"
+        case lastSeenUnix = "last_seen_unix"
+    }
+}
+
+/// Most-recent successfully-connected server. Persisted so next
+/// launch can repopulate the manual-entry host/port/nickname
+/// fields without waiting for mDNS rediscovery.
+struct RtlTcpClientLastConnected: Codable, Sendable, Equatable {
+    /// Hostname or IP literal the Connect button dialed. Either
+    /// a resolved address or an mDNS hostname (`shack-pi.local.`),
+    /// whichever the discovery layer yielded.
+    var host: String
+    /// TCP port.
+    var port: UInt16
+    /// User-facing nickname — normally the mDNS TXT nickname, or
+    /// the `instance_name` when no nickname was published.
+    var nickname: String
+}

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -425,6 +425,37 @@ struct SourceSection: View {
                 .multilineTextAlignment(.trailing)
         }
 
+        // Disconnect + Retry row. Only rendered when the source
+        // type is actually .rtlTcp so the buttons don't appear
+        // on a picker that's mid-configure (the engine would
+        // log and drop the commands anyway, but showing the
+        // controls is misleading). Per issue #326.
+        if model.sourceType == .rtlTcp {
+            HStack(spacing: 8) {
+                Button {
+                    model.disconnectRtlTcp()
+                } label: {
+                    Label("Disconnect", systemImage: "xmark.circle")
+                }
+                .disabled(disconnectDisabled)
+                Button {
+                    model.retryRtlTcpNow()
+                } label: {
+                    Label("Retry now", systemImage: "arrow.clockwise")
+                }
+                .disabled(retryDisabled)
+            }
+        }
+
+        // Tuner control surface — only meaningful when actually
+        // connected (the 0x02-0x0e wire commands need an open
+        // socket). Hidden otherwise so the form doesn't imply
+        // "you can fiddle these pre-connection and they'll
+        // take effect later" (they would be silently dropped).
+        if case .connected(_, let gainCount) = model.rtlTcpConnectionState {
+            rtlTcpControlSurface(gainCount: gainCount)
+        }
+
         // Favorites — user-pinned servers that persist across
         // sessions. Shown whenever non-empty so the user can
         // one-tap recall even before any mDNS discovery lands.
@@ -647,6 +678,130 @@ struct SourceSection: View {
             return "\(endpoint) · \(s.tuner)"
         } else {
             return endpoint
+        }
+    }
+
+    // ----------------------------------------------------------
+    //  Disconnect / Retry enablement
+    // ----------------------------------------------------------
+
+    /// Disconnect is only actionable when there's something to
+    /// disconnect from — .connected, .connecting, or .retrying.
+    private var disconnectDisabled: Bool {
+        switch model.rtlTcpConnectionState {
+        case .connected, .connecting, .retrying: return false
+        case .disconnected, .failed: return true
+        }
+    }
+
+    /// Retry-now is only useful when we're between attempts —
+    /// .retrying (skip the backoff sleep), .failed (manual
+    /// restart), or .disconnected (reopen after an explicit
+    /// disconnect). Active .connected / .connecting states
+    /// have nothing to retry.
+    private var retryDisabled: Bool {
+        switch model.rtlTcpConnectionState {
+        case .retrying, .failed, .disconnected: return false
+        case .connecting, .connected: return true
+        }
+    }
+
+    // ----------------------------------------------------------
+    //  Tuner control surface — issue #326
+    // ----------------------------------------------------------
+
+    /// Wire-protocol command controls exposed when the rtl_tcp
+    /// client is connected: sample rate, gain-by-index, PPM,
+    /// bias-T, offset tuning, direct sampling, RTL (digital)
+    /// AGC, tuner (analog) AGC. Mirrors the Linux GTK panel's
+    /// control set; see the rtl_tcp protocol's 0x01-0x0e
+    /// command map in `crates/sdr-source-network/src/rtl_tcp.rs`.
+    @ViewBuilder
+    private func rtlTcpControlSurface(gainCount: UInt32) -> some View {
+        DisclosureGroup("Tuner controls") {
+            LabeledContent("Sample rate") {
+                Picker("", selection: Binding(
+                    get: { model.sourceSampleRateHz },
+                    set: { model.setSampleRate($0) }
+                )) {
+                    ForEach(rtlSdrSampleRates, id: \.self) {
+                        Text(formatRate($0)).tag($0)
+                    }
+                }
+                .labelsHidden()
+            }
+
+            // Gain — rtl_tcp clients address the server's gain
+            // table by index (the server doesn't publish dB
+            // values over the wire, only a count). Linux shows
+            // this as a slider; matching here with a Stepper +
+            // read-out so the discrete selections feel
+            // concrete. Hidden when gainCount == 0 (rare, but
+            // some servers publish no tuner).
+            if gainCount > 0 {
+                LabeledContent("Gain") {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Stepper(
+                            value: Binding(
+                                get: { Int(model.rtlTcpGainIndex) },
+                                set: {
+                                    let clamped = min(max($0, 0), Int(gainCount - 1))
+                                    model.setRtlTcpGainIndex(UInt32(clamped))
+                                }
+                            ),
+                            in: 0...Int(gainCount - 1)
+                        ) {
+                            Text("#\(model.rtlTcpGainIndex + 1) of \(gainCount)")
+                                .monospacedDigit()
+                        }
+                    }
+                }
+            }
+
+            LabeledContent("PPM") {
+                Stepper(
+                    value: Binding(
+                        get: { model.ppmCorrection },
+                        set: { model.setPpm(Int($0)) }
+                    ),
+                    in: -200...200
+                ) {
+                    Text("\(model.ppmCorrection) ppm").monospacedDigit()
+                }
+            }
+
+            Toggle("Bias-T", isOn: Binding(
+                get: { model.biasTeeEnabled },
+                set: { model.setBiasTee($0) }
+            ))
+
+            Toggle("Offset tuning", isOn: Binding(
+                get: { model.offsetTuningEnabled },
+                set: { model.setOffsetTuning($0) }
+            ))
+
+            LabeledContent("Direct sampling") {
+                Picker("", selection: Binding(
+                    get: { model.directSamplingMode },
+                    set: { model.setDirectSampling($0) }
+                )) {
+                    ForEach(SdrCore.DirectSamplingMode.allCases, id: \.self) { m in
+                        Text(m.label).tag(m)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+            }
+
+            Toggle("RTL AGC", isOn: Binding(
+                get: { model.rtlAgcEnabled },
+                set: { model.setRtlAgc($0) }
+            ))
+
+            Toggle("Tuner AGC", isOn: Binding(
+                get: { model.agcEnabled },
+                set: { model.setAgc($0) }
+            ))
         }
     }
 }

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -1,12 +1,14 @@
 //
 // SourceSection.swift — sidebar panel for source/tuner controls.
 //
-// Device picker at top (RTL-SDR / Network IQ / File playback)
-// followed by per-source forms: RTL-SDR exposes the USB
-// tuner's sample rate / gain / AGC / PPM; Network exposes a
-// host/port/protocol triple with an Apply button; File exposes
-// a path text field with a "Choose WAV…" button. RTL-TCP is a
-// future source type (see issue #326 for its dedicated panel).
+// Device picker at top (RTL-SDR / Network IQ / File playback /
+// RTL-TCP) followed by per-source forms: RTL-SDR exposes the
+// USB tuner's sample rate / gain / AGC / PPM; Network exposes
+// a host/port/protocol triple with an Apply button; File
+// exposes a path text field with a "Choose WAV…" button;
+// RTL-TCP shows a client picker (discovered servers from mDNS,
+// favorites, manual entry) and a live connection-state row.
+// Per issue #326.
 //
 // Advanced controls (DC blocking, IQ inversion, IQ correction,
 // decimation) live in a collapsible "Advanced" DisclosureGroup
@@ -33,13 +35,11 @@ private let rtlSdrSampleRates: [Double] = [
 /// `sdr-ui::sidebar::source_panel::DECIMATION_FACTORS`.
 private let decimationFactors: [UInt32] = [1, 2, 4, 8, 16]
 
-/// Source types offered in the top-of-section picker. RTL-TCP
-/// is deliberately omitted — it gets its own dedicated panel in
-/// issue #326 with the full rtl_tcp control surface (client
-/// picker, connection state, per-command gains/ppm/bias-T).
-/// Putting it in this generic picker would imply equal
-/// treatment it doesn't have yet.
-private let supportedSourceTypes: [SourceType] = [.rtlSdr, .network, .file]
+/// Source types offered in the top-of-section picker. `.rtlTcp`
+/// is included; its form renders a discovered-server list +
+/// favorites + manual-entry path + connection-state row, not
+/// the generic per-command controls. Per issue #326.
+private let supportedSourceTypes: [SourceType] = [.rtlSdr, .network, .file, .rtlTcp]
 
 struct SourceSection: View {
     @Environment(CoreModel.self) private var model
@@ -65,6 +65,14 @@ struct SourceSection: View {
     /// Local edit buffer for the network port.
     @State private var portEdit: String = ""
 
+    /// Local edit buffers for the rtl_tcp client manual-entry
+    /// form. Kept separate from `hostEdit`/`portEdit` so the
+    /// two source types don't clobber each other's in-flight
+    /// edits even though both write to the same engine-side
+    /// storage on Connect.
+    @State private var rtlTcpHostEdit: String = ""
+    @State private var rtlTcpPortEdit: String = ""
+
     /// One-shot latch so the initial `.onAppear` seeds the
     /// local edit buffers from the model without clobbering
     /// in-progress user edits when SwiftUI re-fires `.onAppear`
@@ -86,10 +94,9 @@ struct SourceSection: View {
                         // so commit immediately — matches user
                         // expectation that "I picked RTL-SDR"
                         // means the engine switches now.
-                        // `.network` and `.file` defer to the
-                        // Apply / Choose buttons below. `.rtlTcp`
-                        // is filtered out of `supportedSourceTypes`
-                        // so we never see it as a user selection.
+                        // `.network`, `.file`, and `.rtlTcp`
+                        // defer to their respective Apply /
+                        // Choose / Connect action buttons.
                         if newType == .rtlSdr {
                             model.setSourceType(.rtlSdr)
                         }
@@ -131,17 +138,7 @@ struct SourceSection: View {
             case .rtlSdr: rtlSdrControls
             case .network: networkControls
             case .file: fileControls
-            case .rtlTcp:
-                // Defensive arm — filtered out of
-                // `supportedSourceTypes` so not reachable
-                // through the picker, but the persisted value
-                // from a future build could restore `.rtlTcp`
-                // into `model.sourceType` (and via the
-                // `.onAppear` sync into `pendingType`). Show a
-                // breadcrumb rather than a broken form.
-                Text("RTL-TCP has a dedicated panel (see issue #326).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            case .rtlTcp: rtlTcpControls
             }
 
             // "Advanced" group applies to every source — lives
@@ -182,6 +179,18 @@ struct SourceSection: View {
             pendingType = model.sourceType
             hostEdit = model.networkSourceHost
             portEdit = String(model.networkSourcePort)
+            // Seed the rtl_tcp manual-entry fields from the
+            // persisted last-connected snapshot so the user's
+            // most recent server pre-fills on next launch.
+            // Falls back to the network-source host/port when
+            // no snapshot exists (first-time use). Per #326.
+            if let last = model.rtlTcpLastConnected {
+                rtlTcpHostEdit = last.host
+                rtlTcpPortEdit = String(last.port)
+            } else {
+                rtlTcpHostEdit = model.networkSourceHost
+                rtlTcpPortEdit = String(model.networkSourcePort)
+            }
         }
         .onChange(of: model.sourceType) { _, new in
             // Sync the picker back to engine-side changes
@@ -394,6 +403,112 @@ struct SourceSection: View {
         Text("Plays back a two-channel (I/Q) WAV file. Sample rate is read from the file header.")
             .font(.caption)
             .foregroundStyle(.secondary)
+    }
+
+    // ----------------------------------------------------------
+    //  rtl_tcp client form — issue #326
+    // ----------------------------------------------------------
+
+    @ViewBuilder
+    private var rtlTcpControls: some View {
+        // Connection-state status row. Always visible when the
+        // .rtlTcp arm renders so the user sees the current
+        // engine state — `Not connected` before the first
+        // Connect click, `Connecting…` / `Connected` /
+        // `Retrying in N s` / `Failed — …` after. Subtitle
+        // format matches Linux `format_rtl_tcp_state()`.
+        LabeledContent("Status") {
+            Text(CoreModel.formatRtlTcpConnectionState(model.rtlTcpConnectionState))
+                .foregroundStyle(rtlTcpStatusColor)
+                .font(.callout)
+                .lineLimit(2)
+                .multilineTextAlignment(.trailing)
+        }
+
+        // Manual-entry host + port + Connect. Discovered-server
+        // list and favorites land in the next commit; for now
+        // this is the minimally-useful form.
+        TextField("Host", text: $rtlTcpHostEdit)
+            .textFieldStyle(.roundedBorder)
+            .disableAutocorrection(true)
+            .textContentType(.URL)
+        LabeledContent("Port") {
+            TextField("1234", text: $rtlTcpPortEdit)
+                .textFieldStyle(.roundedBorder)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: 90)
+        }
+        Button {
+            commitRtlTcpConnect()
+        } label: {
+            Label(
+                model.sourceType == .rtlTcp ? "Reconnect" : "Connect",
+                systemImage: "antenna.radiowaves.left.and.right"
+            )
+        }
+        .disabled(rtlTcpConnectDisabled)
+
+        if pendingType != model.sourceType {
+            Text("Source switches to RTL-TCP after you connect.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        if let err = model.lastError, !err.isEmpty {
+            Text(err)
+                .font(.caption)
+                .foregroundStyle(.red)
+                .textSelection(.enabled)
+        }
+    }
+
+    /// Color hint for the status row subtitle — red on failure,
+    /// yellow on in-flight states, secondary otherwise.
+    private var rtlTcpStatusColor: Color {
+        switch model.rtlTcpConnectionState {
+        case .failed: return .red
+        case .retrying, .connecting: return .orange
+        case .connected: return .secondary
+        case .disconnected: return .secondary
+        }
+    }
+
+    /// Parse `rtlTcpPortEdit` into a `UInt16` in `1…65535`.
+    /// Returns `nil` on empty / non-numeric / out-of-range.
+    private func rtlTcpPortValue() -> UInt16? {
+        guard let raw = Int(rtlTcpPortEdit.trimmingCharacters(in: .whitespaces)),
+              (1...Int(UInt16.max)).contains(raw) else {
+            return nil
+        }
+        return UInt16(raw)
+    }
+
+    private var rtlTcpConnectDisabled: Bool {
+        rtlTcpHostEdit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || rtlTcpPortValue() == nil
+    }
+
+    private func commitRtlTcpConnect() {
+        guard let port = rtlTcpPortValue() else { return }
+        let host = rtlTcpHostEdit.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Derive a nickname from a matching mDNS announce if one
+        // exists for this host:port, otherwise fall back to the
+        // raw host:port string. The model applies the same
+        // fallback but checking here lets us pass a better label
+        // through to persistence on first connect.
+        let nickname = discoveredNickname(host: host, port: port)
+        model.connectToRtlTcp(host: host, port: port, nickname: nickname)
+    }
+
+    /// Look up the nickname for an endpoint from the live mDNS
+    /// discovery list. Returns `""` if there's no match — the
+    /// model defaults to `host:port` in that case.
+    private func discoveredNickname(host: String, port: UInt16) -> String {
+        if let ds = model.rtlTcpDiscoveredServers.first(where: {
+            $0.hostname == host && $0.port == port
+        }) {
+            return ds.nickname.isEmpty ? ds.instanceName : ds.nickname
+        }
+        return ""
     }
 }
 

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -720,15 +720,17 @@ struct SourceSection: View {
         }
     }
 
-    /// Retry-now is only useful when we're between attempts —
-    /// .retrying (skip the backoff sleep), .failed (manual
-    /// restart), or .disconnected (reopen after an explicit
-    /// disconnect). Active .connected / .connecting states
-    /// have nothing to retry.
+    /// Retry-now is only useful when there's still a live
+    /// rtl_tcp source instance to bounce — `.retrying` (skip
+    /// the backoff sleep) or `.failed` (manual restart).
+    /// `.disconnected` explicitly excluded because the engine
+    /// drops the source instance on disconnect, so `retry_now`
+    /// is a silent no-op there; the Play path is the right
+    /// surface to reopen. Per `CodeRabbit` round 1 on PR #366.
     private var retryDisabled: Bool {
         switch model.rtlTcpConnectionState {
-        case .retrying, .failed, .disconnected: return false
-        case .connecting, .connected: return true
+        case .retrying, .failed: return false
+        case .connecting, .connected, .disconnected: return true
         }
     }
 

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -456,6 +456,32 @@ struct SourceSection: View {
             rtlTcpControlSurface(gainCount: gainCount)
         }
 
+        // High-bandwidth advisory. Fires when the effective
+        // sample rate is at or above 2.4 Msps and we're on
+        // the .rtlTcp source — at 8-bit I/Q that's ≈38 Mbps
+        // over the network, below typical Wi-Fi practical
+        // throughput for older routers. Matches the Linux
+        // threshold (`HIGH_BANDWIDTH_SAMPLE_RATE_IDX` in
+        // source_panel.rs). Per issue #326.
+        if model.rtlTcpShowsBandwidthAdvisory {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("High sample rate")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                    Text(
+                        "Your network may not keep up " +
+                        "(≈38 Mbps at 2.4 Msps with 8-bit I/Q)."
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+
         // Favorites — user-pinned servers that persist across
         // sessions. Shown whenever non-empty so the user can
         // one-tap recall even before any mDNS discovery lands.

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -425,9 +425,36 @@ struct SourceSection: View {
                 .multilineTextAlignment(.trailing)
         }
 
-        // Manual-entry host + port + Connect. Discovered-server
-        // list and favorites land in the next commit; for now
-        // this is the minimally-useful form.
+        // Favorites — user-pinned servers that persist across
+        // sessions. Shown whenever non-empty so the user can
+        // one-tap recall even before any mDNS discovery lands.
+        if !model.rtlTcpFavorites.isEmpty {
+            DisclosureGroup("Known servers") {
+                ForEach(model.rtlTcpFavorites) { fav in
+                    rtlTcpFavoriteRow(fav)
+                }
+            }
+        }
+
+        // Nearby servers — live mDNS announcements. Collapsed
+        // when empty so the form stays compact on a LAN with
+        // no rtl_tcp peers. Otherwise default-expanded so the
+        // list is visible without an extra tap.
+        DisclosureGroup(
+            "Nearby servers\(model.rtlTcpDiscoveredServers.isEmpty ? "" : " (\(model.rtlTcpDiscoveredServers.count))")"
+        ) {
+            if model.rtlTcpDiscoveredServers.isEmpty {
+                Text("No rtl_tcp servers advertising on this network.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(model.rtlTcpDiscoveredServers, id: \.instanceName) { server in
+                    rtlTcpDiscoveredRow(server)
+                }
+            }
+        }
+
+        // Manual-entry host + port + Connect.
         TextField("Host", text: $rtlTcpHostEdit)
             .textFieldStyle(.roundedBorder)
             .disableAutocorrection(true)
@@ -509,6 +536,118 @@ struct SourceSection: View {
             return ds.nickname.isEmpty ? ds.instanceName : ds.nickname
         }
         return ""
+    }
+
+    // ----------------------------------------------------------
+    //  rtl_tcp row builders — favorites + nearby lists
+    // ----------------------------------------------------------
+
+    /// A row in the "Known servers" (favorites) list. Shows
+    /// nickname + tuner / gain-count / host:port subtitle,
+    /// with a trailing unstar button. Tap the row body to
+    /// prefill the manual-entry fields with this favorite's
+    /// host/port.
+    @ViewBuilder
+    private func rtlTcpFavoriteRow(_ fav: RtlTcpClientFavorite) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "star.fill")
+                .foregroundStyle(.yellow)
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(fav.nickname)
+                    .font(.callout)
+                    .lineLimit(1)
+                Text(favoriteSubtitle(fav))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button {
+                model.removeRtlTcpFavorite(key: fav.key)
+            } label: {
+                Image(systemName: "star.slash")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove from favorites")
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard let (h, p) = fav.parsedEndpoint else { return }
+            rtlTcpHostEdit = h
+            rtlTcpPortEdit = String(p)
+        }
+    }
+
+    /// Subtitle for a favorite row. Prefers tuner + gain-count
+    /// when available (populated from a live announce), falls
+    /// back to the stable `host:port` key when offline and no
+    /// cached metadata is present.
+    private func favoriteSubtitle(_ fav: RtlTcpClientFavorite) -> String {
+        if let tuner = fav.tunerName, let gains = fav.gainCount {
+            return "\(fav.key) · \(tuner) (\(gains) gains)"
+        } else if let tuner = fav.tunerName {
+            return "\(fav.key) · \(tuner)"
+        } else {
+            return fav.key
+        }
+    }
+
+    /// A row in the "Nearby servers" (live mDNS) list. Shows
+    /// nickname + tuner / gain-count / host:port subtitle,
+    /// with a trailing star button to pin as a favorite. Tap
+    /// the row body to prefill the manual-entry fields.
+    @ViewBuilder
+    private func rtlTcpDiscoveredRow(_ server: SdrRtlTcpBrowser.DiscoveredServer) -> some View {
+        let key = "\(server.hostname):\(server.port)"
+        let isFavorited = model.rtlTcpFavorites.contains { $0.key == key }
+        HStack(spacing: 8) {
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(discoveredDisplayName(server))
+                    .font(.callout)
+                    .lineLimit(1)
+                Text(discoveredSubtitle(server))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button {
+                if isFavorited {
+                    model.removeRtlTcpFavorite(key: key)
+                } else {
+                    model.addRtlTcpFavorite(RtlTcpClientFavorite(from: server))
+                }
+            } label: {
+                Image(systemName: isFavorited ? "star.fill" : "star")
+                    .foregroundStyle(isFavorited ? .yellow : .secondary)
+            }
+            .buttonStyle(.borderless)
+            .help(isFavorited ? "Remove from favorites" : "Add to favorites")
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            rtlTcpHostEdit = server.hostname
+            rtlTcpPortEdit = String(server.port)
+        }
+    }
+
+    private func discoveredDisplayName(_ s: SdrRtlTcpBrowser.DiscoveredServer) -> String {
+        s.nickname.isEmpty ? s.instanceName : s.nickname
+    }
+
+    private func discoveredSubtitle(_ s: SdrRtlTcpBrowser.DiscoveredServer) -> String {
+        let endpoint = "\(s.hostname):\(s.port)"
+        if !s.tuner.isEmpty && s.gains != 0 {
+            return "\(endpoint) · \(s.tuner) (\(s.gains) gains)"
+        } else if !s.tuner.isEmpty {
+            return "\(endpoint) · \(s.tuner)"
+        } else {
+            return endpoint
+        }
     }
 }
 

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -610,6 +610,36 @@ pub unsafe extern "C" fn sdr_core_set_gain_by_index(handle: *mut SdrCore, index:
     unsafe { with_core(handle, |core| send(core, UiToDsp::SetGainByIndex(index))) }
 }
 
+/// Disconnect the rtl_tcp client without changing source type.
+/// Tears down the current TCP socket and transitions the
+/// connection-state machine to `Disconnected`. A subsequent
+/// `sdr_core_rtl_tcp_retry_now` (or any engine restart) will
+/// reopen with the same host/port.
+///
+/// Engine behavior when the active source is not rtl_tcp:
+/// the command is logged at `warn` and dropped — safe to
+/// call regardless of current source, matching the
+/// `UiToDsp::DisconnectRtlTcp` contract in `sdr-core`. Per
+/// issue #326.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_rtl_tcp_disconnect(handle: *mut SdrCore) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::DisconnectRtlTcp)) }
+}
+
+/// Retry the rtl_tcp connection immediately, bypassing the
+/// exponential-backoff sleep that the reconnect loop is in
+/// after a transport failure. Useful for a user-visible
+/// "Retry now" button that shouldn't make the user wait out
+/// the countdown.
+///
+/// Engine behavior when the active source is not rtl_tcp:
+/// same as `sdr_core_rtl_tcp_disconnect` — logged + dropped.
+/// Per issue #326.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_rtl_tcp_retry_now(handle: *mut SdrCore) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::RetryRtlTcpNow)) }
+}
+
 // ============================================================
 //  Source selection (#235, #236) — switch the active IQ
 //  source and configure the per-source connection details.
@@ -1725,6 +1755,53 @@ mod tests {
             SdrCoreError::Ok.as_int()
         );
         destroy(h);
+    }
+
+    #[test]
+    fn rtl_tcp_disconnect_dispatches() {
+        // The engine drops `DisconnectRtlTcp` with a warn log
+        // when the active source isn't rtl_tcp — our test
+        // fixture builds a default core which starts on the
+        // RTL-SDR source, so we're exercising the FFI dispatch
+        // path + engine guard, not the actual socket teardown.
+        // That's the right scope for a unit test; the socket
+        // path is covered by `sdr-source-network` tests.
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_rtl_tcp_disconnect(h) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn rtl_tcp_retry_now_dispatches() {
+        // Same coverage as the disconnect test — the engine
+        // drops the message with a warn log outside rtl_tcp;
+        // we're checking that the FFI return code is `Ok`
+        // when the dispatch succeeds. Per issue #326.
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_rtl_tcp_retry_now(h) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn rtl_tcp_disconnect_rejects_null_handle() {
+        assert_eq!(
+            unsafe { sdr_core_rtl_tcp_disconnect(std::ptr::null_mut()) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+    }
+
+    #[test]
+    fn rtl_tcp_retry_now_rejects_null_handle() {
+        assert_eq!(
+            unsafe { sdr_core_rtl_tcp_retry_now(std::ptr::null_mut()) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
     }
 
     // ------------------------------------------------------

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -611,16 +611,22 @@ pub unsafe extern "C" fn sdr_core_set_gain_by_index(handle: *mut SdrCore, index:
 }
 
 /// Disconnect the rtl_tcp client without changing source type.
-/// Tears down the current TCP socket and transitions the
-/// connection-state machine to `Disconnected`. A subsequent
-/// `sdr_core_rtl_tcp_retry_now` (or any engine restart) will
-/// reopen with the same host/port.
+/// Stops the current source, drops the source instance (so the
+/// engine's `rtl_tcp_connection_state` returns `Disconnected`
+/// on the next poll), and emits `DspToUi::SourceStopped`. The
+/// source type stays `RtlTcp`, so a subsequent `sdr_core_start`
+/// (host's normal "Play" path) reopens a fresh rtl_tcp source
+/// from the stored network config.
 ///
-/// Engine behavior when the active source is not rtl_tcp:
-/// the command is logged at `warn` and dropped — safe to
-/// call regardless of current source, matching the
-/// `UiToDsp::DisconnectRtlTcp` contract in `sdr-core`. Per
-/// issue #326.
+/// Note: `sdr_core_rtl_tcp_retry_now` is **not** a reconnect
+/// path after an explicit disconnect — once the source has
+/// been dropped, `retry_now` silently returns. Hosts should
+/// use `sdr_core_start` to reopen.
+///
+/// Engine behavior when the active source is not rtl_tcp: the
+/// command is logged and dropped — safe to call regardless of
+/// current source, matching the `UiToDsp::DisconnectRtlTcp`
+/// contract in `sdr-core`. Per issue #326.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_rtl_tcp_disconnect(handle: *mut SdrCore) -> i32 {
     unsafe { with_core(handle, |core| send(core, UiToDsp::DisconnectRtlTcp)) }
@@ -631,6 +637,14 @@ pub unsafe extern "C" fn sdr_core_rtl_tcp_disconnect(handle: *mut SdrCore) -> i3
 /// after a transport failure. Useful for a user-visible
 /// "Retry now" button that shouldn't make the user wait out
 /// the countdown.
+///
+/// Only meaningful while an rtl_tcp source instance is still
+/// alive — i.e. `Retrying`, `Failed`, `Connecting`, or
+/// `Connected`. After an explicit `sdr_core_rtl_tcp_disconnect`
+/// the source instance is gone and this command silently
+/// returns; hosts should gate UI sensitivity on
+/// `RtlTcpConnectionState` not being `Disconnected`, and use
+/// `sdr_core_start` to reopen.
 ///
 /// Engine behavior when the active source is not rtl_tcp:
 /// same as `sdr_core_rtl_tcp_disconnect` — logged + dropped.

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 11;
+pub const ABI_VERSION_MINOR: u32 = 12;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 11);
+        assert!(ABI_VERSION_MINOR == 12);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -633,17 +633,23 @@ int32_t sdr_core_set_gain_by_index(SdrCore* handle, uint32_t index);
 /* --- rtl_tcp client lifecycle (issue #326, ABI 0.12) --- */
 /*
  * Disconnect the rtl_tcp client without changing source type.
- * Tears down the current TCP socket and drops the connection-
- * state machine back to `Disconnected`. A subsequent
- * `sdr_core_rtl_tcp_retry_now` (or any engine restart) reopens
- * the socket against the same host/port from the stored
- * network config.
+ * Stops the current source, drops the source instance (so the
+ * engine's `rtl_tcp_connection_state` returns `Disconnected`
+ * on the next poll), and emits `SDR_EVT_SOURCE_STOPPED`. The
+ * source type stays `SDR_SOURCE_RTLTCP`, so a subsequent
+ * `sdr_core_start` (host's normal "Play" path) reopens a
+ * fresh rtl_tcp source from the stored network config.
+ *
+ * Note: `sdr_core_rtl_tcp_retry_now` is NOT a reconnect path
+ * after an explicit disconnect — once the source instance has
+ * been dropped, `retry_now` silently returns. Use
+ * `sdr_core_start` to reopen.
  *
  * Engine behavior when the active source is not rtl_tcp: the
- * command is logged at `warn` and dropped — safe to call
- * regardless of current source, so hosts don't need to gate
- * UI buttons on source type. Matches the
- * `UiToDsp::DisconnectRtlTcp` contract in `sdr-core`.
+ * command is logged and dropped — safe to call regardless of
+ * current source, so hosts don't need to gate UI buttons on
+ * source type. Matches the `UiToDsp::DisconnectRtlTcp`
+ * contract in `sdr-core`.
  */
 int32_t sdr_core_rtl_tcp_disconnect(SdrCore* handle);
 
@@ -652,6 +658,14 @@ int32_t sdr_core_rtl_tcp_disconnect(SdrCore* handle);
  * exponential-backoff sleep that the reconnect loop is in
  * after a transport failure. Useful for a "Retry now" button
  * that shouldn't make the user wait out the countdown.
+ *
+ * Only meaningful while an rtl_tcp source instance is still
+ * alive — i.e. states `Retrying`, `Failed`, `Connecting`, or
+ * `Connected` (where it's a no-op teardown + re-open). After
+ * an explicit `sdr_core_rtl_tcp_disconnect`, the source
+ * instance is gone and this command silently returns; hosts
+ * should gate UI sensitivity on `RtlTcpConnectionState` not
+ * being `Disconnected`, and use `sdr_core_start` to reopen.
  *
  * Engine behavior when the active source is not rtl_tcp:
  * same as `sdr_core_rtl_tcp_disconnect` — logged and dropped.

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 11
+#define SDR_CORE_ABI_VERSION_MINOR 12
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -629,6 +629,34 @@ int32_t sdr_core_set_rtl_agc(SdrCore* handle, bool enabled);
  * server decides how to handle it.
  */
 int32_t sdr_core_set_gain_by_index(SdrCore* handle, uint32_t index);
+
+/* --- rtl_tcp client lifecycle (issue #326, ABI 0.12) --- */
+/*
+ * Disconnect the rtl_tcp client without changing source type.
+ * Tears down the current TCP socket and drops the connection-
+ * state machine back to `Disconnected`. A subsequent
+ * `sdr_core_rtl_tcp_retry_now` (or any engine restart) reopens
+ * the socket against the same host/port from the stored
+ * network config.
+ *
+ * Engine behavior when the active source is not rtl_tcp: the
+ * command is logged at `warn` and dropped — safe to call
+ * regardless of current source, so hosts don't need to gate
+ * UI buttons on source type. Matches the
+ * `UiToDsp::DisconnectRtlTcp` contract in `sdr-core`.
+ */
+int32_t sdr_core_rtl_tcp_disconnect(SdrCore* handle);
+
+/*
+ * Retry the rtl_tcp connection immediately, bypassing the
+ * exponential-backoff sleep that the reconnect loop is in
+ * after a transport failure. Useful for a "Retry now" button
+ * that shouldn't make the user wait out the countdown.
+ *
+ * Engine behavior when the active source is not rtl_tcp:
+ * same as `sdr_core_rtl_tcp_disconnect` — logged and dropped.
+ */
+int32_t sdr_core_rtl_tcp_retry_now(SdrCore* handle);
 
 /* ================================================================ */
 /*  rtl_tcp server (issue #325, ABI 0.11)                           */


### PR DESCRIPTION
## Summary

- SwiftUI client picker for rtl_tcp on macOS — auto-discovery, favorites, manual entry, live connection state, and the full tuner control surface (gain-by-index, PPM, bias-T, offset tuning, direct sampling, RTL/tuner AGC, sample rate) when connected.
- Bumps FFI ABI 0.11 → 0.12 for two new handle-only entry points (`sdr_core_rtl_tcp_disconnect` / `sdr_core_rtl_tcp_retry_now`) so the Swift side can drive disconnect + retry-now without reaching into the engine's in-process `UiToDsp::` queue (which only the Linux GTK shell can).

Closes #326.

## Structure

Six commits, each independently buildable:

1. **CoreModel: rtl_tcp client state + mDNS browser lifecycle** — `SdrRtlTcpBrowser` starts in bootstrap, discovered servers land as `@Observable` state, `RtlTcpClientFavorite` + `RtlTcpClientLastConnected` Codable types with JSON keys matching the Linux `source_panel.rs` schema, `UserDefaults` persistence, `rtlTcpConnectionState` wired to the engine event.
2. **SwiftUI: re-enable RTL-TCP in source picker with basic client form** — unblocks `.rtlTcp` in the picker, adds `connectToRtlTcp(host:port:nickname:)` on CoreModel, renders a status row + manual-entry form as the minimally-useful slice.
3. **SwiftUI: discovered list + favorites** — "Known servers" (pinned) and "Nearby servers (N)" (live mDNS) DisclosureGroups with star-toggle + tap-to-prefill. Tap-to-prefill (not auto-connect) to mirror Linux.
4. **FFI: expose rtl_tcp client disconnect/retry (ABI 0.11 → 0.12)** — two new fns in `sdr-ffi`, matching header declarations, Swift wrappers on `SdrCore`, four new tests (dispatch + null-handle reject for each).
5. **SwiftUI: control surface + disconnect/retry** — Disconnect / Retry-now buttons gated on connection state; "Tuner controls" DisclosureGroup renders only when `.connected` and exposes all 8 wire-protocol commands the spec calls for. Four new `@Observable` mirrors on CoreModel (bias-T, offset tuning, direct sampling, RTL AGC) with `SDRMac.rtlTcpClient.*` UserDefaults persistence.
6. **SwiftUI: high-bandwidth advisory caption** — fires at ≥ 2.4 Msps on `.rtlTcp`, matching the Linux threshold + copy.

## Audit trail

Per the repo convention (audit engine surface before writing Swift): the discovery browser, connection-state events, and all tuner setters were already exposed via `SdrCoreKit` (from #325 / ABI 0.11). The only gap was disconnect/retry — the engine's `UiToDsp::DisconnectRtlTcp` / `RetryRtlTcpNow` variants existed in `sdr-core` but had no C ABI surface, so Linux GTK's in-process buttons had no macOS counterpart. Commit 4 closes that with a minor ABI bump.

## Test plan

- [ ] `make test` (full workspace `cargo test`) — the four new `sdr-ffi` tests dispatch + null-handle reject both FFI entry points
- [ ] `xcodebuild ... -scheme SDRMac` debug + release
- [ ] Launch app on a LAN with an rtl_tcp server running (the companion server panel from #353, or an upstream `rtl_tcp` binary) → Picker shows "Nearby servers (N)" populated; tap the row to prefill host/port
- [ ] Star the row → appears under "Known servers"; survives app relaunch
- [ ] Click Connect → status row transitions Connecting → Connected (tuner, gain count); tuner-controls group appears
- [ ] Move the gain-by-index stepper → audio spectrum reflects the change
- [ ] Set sample rate to 2.4 MHz → high-bandwidth advisory caption appears
- [ ] Click Disconnect → status → Disconnected; tuner controls hide
- [ ] Kill the server side → status → Retrying in N s (attempt M); Retry-now button skips the countdown
- [ ] Open a second `.rtlTcp` server with different tuner → `Connected` state's gain-count updates; stepper upper bound updates accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RTL‑TCP remote radio support with Connect, Disconnect and immediate Retry actions
  * mDNS discovery of nearby RTL‑TCP servers, favorites (pin/unpin), and persisted last‑connected host/port
  * RTL‑TCP tuner controls: bias‑T, offset tuning, direct sampling, gain index, and RTL AGC
  * UI: manual host/port entry, known/nearby server lists, connection status with colored indicator and bandwidth advisory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->