### PR TITLE
macOS: live USB hotplug monitor for RTL-SDR detection (closes #363)

### DIFF
--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -68,16 +68,15 @@ struct ContentView: View {
         // cross-scene `@Observable` propagation ever drops an
         // update, scenePhase change acts as the safety net.
         //
-        // Also re-probe the USB bus for RTL-SDR hardware on
-        // refocus — without IOKit hotplug monitoring (tracked
-        // in issue #363) a dongle plugged in after launch would
-        // otherwise stay invisible to `hasLocalRtlSdr` and hide
-        // the rtl_tcp server panel until the next launch.
-        // Refocus covers the common "plug it in, return to the
-        // app" flow; a dongle inserted while the window is
-        // already focused still won't surface until focus
-        // flips, which is what #363 fixes properly. Per
-        // `CodeRabbit` round 6 on PR #362.
+        // Re-probe the USB bus for RTL-SDR hardware on refocus
+        // as a safety-net fallback alongside the live IOKit
+        // hotplug monitor wired in `CoreModel.bootstrap()`.
+        // The monitor delivers plug/unplug events immediately
+        // in the normal case (closed issue #363); this hook
+        // catches edge cases where the monitor might miss a
+        // transition (OS sleep/wake with a dongle swap,
+        // notification port restarted underneath us). Cheap
+        // enough to keep even if redundant.
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
                 model.refreshRadioReferenceCredentialsFlag()

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -538,6 +538,15 @@ final class CoreModel {
     /// slider position on reconnect to a different server.
     var rtlTcpGainIndex: UInt32 = 0
 
+    /// Live USB hotplug monitor. Calls `refreshDeviceInfo()`
+    /// on any plug / unplug event so `hasLocalRtlSdr` stays
+    /// in sync with reality without the user having to flip
+    /// focus or restart the app. Per issue #363. `nil` if
+    /// IOKit registration failed at bootstrap — the
+    /// scenePhase-on-active probe in `ContentView` remains as
+    /// a fallback safety net either way.
+    private var usbHotplugMonitor: UsbHotplugMonitor? = nil
+
     /// Live mDNS browser handle. Started in `bootstrap()` and
     /// stopped in `shutdown()`; `nil` if the OS denied browser
     /// start (rare — mDNS doesn't need special entitlements on
@@ -651,6 +660,16 @@ final class CoreModel {
         // This is a handle-free libusb device-list query; no USB
         // control transfers, no hardware open.
         refreshDeviceInfo()
+
+        // Wire up live USB hotplug notifications via IOKit so
+        // plug / unplug events flip `hasLocalRtlSdr` without
+        // waiting for a window-focus refresh. `onChange` is
+        // already MainActor-isolated (the IOKit notification
+        // port is attached to the main run loop) so we can
+        // call refreshDeviceInfo() directly. Per issue #363.
+        usbHotplugMonitor = UsbHotplugMonitor { [weak self] in
+            self?.refreshDeviceInfo()
+        }
 
         // Start the rtl_tcp mDNS browser early so the picker is
         // already populated when the user first expands it. No-
@@ -855,6 +874,14 @@ final class CoreModel {
         // dispatcher thread so no stray callbacks arrive after
         // the model deinits. Per issue #326.
         stopRtlTcpBrowser()
+
+        // Release the USB hotplug monitor's IOKit notification
+        // port so no stray plug/unplug callbacks fire after
+        // shutdown. `deinit` would do this too, but dropping
+        // the reference explicitly here removes any ambiguity
+        // about when the IOKit resources get released. Per
+        // issue #363.
+        usbHotplugMonitor = nil
         if let core {
             // Best-effort stop — a thrown error shouldn't leave
             // the model claiming `isRunning == true` alongside a
@@ -874,12 +901,12 @@ final class CoreModel {
     /// "not found" string). Handle-free — calls straight into
     /// `sdr-rtlsdr` via the C ABI; no engine instance needed.
     ///
-    /// Called from `bootstrap()` so the device state shows up
-    /// on first paint rather than only after Play, and from
-    /// `ContentView`'s `scenePhase` hook on main-window refocus
-    /// as a stop-gap for the "user plugged in a dongle after
-    /// launch" case. Proper IOKit USB hotplug monitoring is
-    /// tracked in issue #363.
+    /// Called from `bootstrap()` for the initial probe, from
+    /// the live `UsbHotplugMonitor` on every USB plug/unplug
+    /// event (closed issue #363), and from `ContentView`'s
+    /// `scenePhase` hook on main-window refocus as a safety-net
+    /// fallback. Safe to call repeatedly — the underlying
+    /// libusb device-list query is cheap (<1 ms typical).
     func refreshDeviceInfo() {
         let count = SdrCore.deviceCount
         hasLocalRtlSdr = count > 0

--- a/apps/macos/SDRMac/Models/UsbHotplugMonitor.swift
+++ b/apps/macos/SDRMac/Models/UsbHotplugMonitor.swift
@@ -1,0 +1,176 @@
+//
+// UsbHotplugMonitor.swift — live USB plug/unplug notifications.
+//
+// Wraps IOKit's `IOServiceAddMatchingNotification` for
+// `IOUSBDevice` matched + terminated events. On any plug or
+// unplug (of any USB device, not just RTL-SDR), the `onChange`
+// closure fires on the main actor. The consumer is expected to
+// re-probe via `CoreModel.refreshDeviceInfo()` — libusb's
+// enumeration inside that probe already filters to the RTL-SDR
+// known-devices table, so we don't need to filter by VID/PID
+// here. Unrelated USB events (keyboard plug, storage mount)
+// cause a cheap no-op probe that leaves `hasLocalRtlSdr`
+// unchanged; RTL-SDR events flip the flag live, no focus-flip
+// or restart required.
+//
+// Addresses issue #363 — the scenePhase-on-active fallback
+// from PR #362 round 6 was a stop-gap for this proper IOKit
+// path.
+
+import Foundation
+import IOKit
+import IOKit.usb
+
+/// Live USB hotplug monitor. One instance owned by
+/// `CoreModel`; starts in `bootstrap()`, tears down in
+/// `shutdown()`. Failing to construct (rare — IOKit is always
+/// available on macOS) yields `nil` and the app continues
+/// without hotplug detection (falls back to the scenePhase
+/// probe safety net).
+final class UsbHotplugMonitor {
+    /// Handler invoked on every USB added or removed event.
+    /// `@MainActor` because the notification port is attached
+    /// to the main run loop, so the C trampoline fires on the
+    /// main thread; callers can mutate `@Observable` state
+    /// directly without hopping.
+    typealias OnChange = @MainActor () -> Void
+
+    /// Notification port + two iterators, one per event kind
+    /// (matched = plug, terminated = unplug). IOKit routes
+    /// events through the port's run-loop source on each
+    /// iterator, and the callback MUST drain its iterator each
+    /// time or no further events arrive for that subscription.
+    private let notifyPort: IONotificationPortRef
+    private var addedIterator: io_iterator_t = IO_OBJECT_NULL
+    private var removedIterator: io_iterator_t = IO_OBJECT_NULL
+
+    /// Retained box passed as `refCon` to the C trampoline.
+    /// Lives for the monitor's lifetime so the callback can
+    /// recover it via `takeUnretainedValue`. Pattern matches
+    /// the `SdrRtlTcpBrowser` wrapper.
+    private let callbackBox: CallbackBox
+
+    private final class CallbackBox {
+        let handler: OnChange
+        init(handler: @escaping OnChange) {
+            self.handler = handler
+        }
+    }
+
+    /// Construct and start the monitor. Returns `nil` if the
+    /// notification port or the initial `IOServiceAddMatchingNotification`
+    /// registration fails. Both outcomes are rare on macOS —
+    /// IOKit is always present — and the app falls back to the
+    /// scenePhase probe if construction fails.
+    init?(onChange: @escaping OnChange) {
+        let box = CallbackBox(handler: onChange)
+        self.callbackBox = box
+
+        guard let port = IONotificationPortCreate(kIOMainPortDefault) else {
+            return nil
+        }
+        self.notifyPort = port
+
+        // Attach the port's run-loop source to the main run
+        // loop so callbacks fire on the main thread. Using
+        // `.commonModes` means events still fire while the UI
+        // is in modal presentation (sheets, menus) rather than
+        // getting deferred until the user dismisses.
+        let source = IONotificationPortGetRunLoopSource(port).takeUnretainedValue()
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+
+        let refCon = Unmanaged.passUnretained(box).toOpaque()
+
+        // Register for device-added events. `IOServiceMatching`
+        // with `kIOUSBDeviceClassName` matches every USB device
+        // — we filter to RTL-SDR inside `refreshDeviceInfo()`
+        // via libusb's known-devices table, so a broad subscription
+        // here is simpler and cheap.
+        //
+        // Note: `IOServiceAddMatchingNotification` consumes the
+        // matching dict, so we re-create a fresh dict for the
+        // second (removed) registration below.
+        let addedMatching = IOServiceMatching(kIOUSBDeviceClassName)
+        let addedRc = IOServiceAddMatchingNotification(
+            port,
+            kIOMatchedNotification,
+            addedMatching,
+            Self.notificationCallback,
+            refCon,
+            &addedIterator
+        )
+        guard addedRc == KERN_SUCCESS else {
+            IONotificationPortDestroy(port)
+            return nil
+        }
+        // Drain the initial batch to arm the iterator. On first
+        // registration IOKit delivers the set of already-matching
+        // devices through the iterator; we don't invoke the
+        // user's handler for those (bootstrap already probed),
+        // but we MUST drain or no future events arrive.
+        Self.drainIterator(addedIterator)
+
+        let removedMatching = IOServiceMatching(kIOUSBDeviceClassName)
+        let removedRc = IOServiceAddMatchingNotification(
+            port,
+            kIOTerminatedNotification,
+            removedMatching,
+            Self.notificationCallback,
+            refCon,
+            &removedIterator
+        )
+        guard removedRc == KERN_SUCCESS else {
+            IOObjectRelease(addedIterator)
+            IONotificationPortDestroy(port)
+            return nil
+        }
+        Self.drainIterator(removedIterator)
+    }
+
+    deinit {
+        if addedIterator != IO_OBJECT_NULL {
+            IOObjectRelease(addedIterator)
+        }
+        if removedIterator != IO_OBJECT_NULL {
+            IOObjectRelease(removedIterator)
+        }
+        IONotificationPortDestroy(notifyPort)
+    }
+
+    // ----------------------------------------------------------
+    //  C trampoline
+    // ----------------------------------------------------------
+
+    /// Shared callback for both `kIOMatchedNotification` and
+    /// `kIOTerminatedNotification` — we don't distinguish
+    /// between plug and unplug at this layer because the
+    /// consumer re-probes either way. The iterator must be
+    /// drained before the callback returns or IOKit stops
+    /// delivering events on that subscription.
+    private static let notificationCallback: IOServiceMatchingCallback = { refCon, iterator in
+        guard let refCon else { return }
+        let box = Unmanaged<CallbackBox>.fromOpaque(refCon).takeUnretainedValue()
+        drainIterator(iterator)
+        // The run-loop source was added to `CFRunLoopGetMain()`
+        // in `init`, so this callback is running on the main
+        // thread. Assume MainActor isolation to invoke the
+        // `@MainActor` handler synchronously — skips the
+        // `Task { @MainActor in … }` indirection that the
+        // dispatcher-threaded `SdrRtlTcpBrowser` needs.
+        MainActor.assumeIsolated {
+            box.handler()
+        }
+    }
+
+    /// Drain an `io_iterator_t` by repeatedly calling
+    /// `IOIteratorNext` and releasing each returned object.
+    /// IOKit requires this — an un-drained iterator silently
+    /// stops delivering events.
+    private static func drainIterator(_ iterator: io_iterator_t) {
+        var obj = IOIteratorNext(iterator)
+        while obj != IO_OBJECT_NULL {
+            IOObjectRelease(obj)
+            obj = IOIteratorNext(iterator)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New \`UsbHotplugMonitor\` wraps IOKit's \`IOServiceAddMatchingNotification\` for matched (plug) and terminated (unplug) events on \`IOUSBDevice\`.
- \`CoreModel\` owns one instance, started in \`bootstrap()\` and released in \`shutdown()\`; the handler calls \`refreshDeviceInfo()\` so \`hasLocalRtlSdr\` flips live on any plug/unplug — no focus-flip or restart required.

Closes #363. The scenePhase-on-active fallback from PR #362 round 6 stays in place as a safety net.

## Design notes

**One subscription, broad match.** The monitor subscribes to every USB device (\`IOServiceMatching(kIOUSBDeviceClassName)\`) rather than filtering by Realtek's 42 known VID/PID pairs at the IOKit layer. \`refreshDeviceInfo()\`'s underlying libusb enumeration already filters to the RTL2832-based known-devices table (\`crates/sdr-rtlsdr/src/constants.rs::KNOWN_DEVICES\`), so a broad subscription costs a cheap no-op probe (\`< 1 ms\`) on unrelated USB events (keyboard, storage, iPhone). Much simpler than maintaining a per-vendor matching dict or iterating 42 separate iterators.

**Main-thread callback.** The port's run-loop source is attached to \`CFRunLoopGetMain()\` with \`.commonModes\`, so the C trampoline fires on the main thread. The callback invokes the \`@MainActor\` handler via \`MainActor.assumeIsolated { … }\` — skips the \`Task { @MainActor in … }\` indirection that the dispatcher-threaded \`SdrRtlTcpBrowser\` needs.

**Initial iterator drain.** IOKit delivers the set of currently-matching devices on registration. We drain those silently (bootstrap already probed) but MUST drain or no future events arrive. Same for every callback invocation — the iterator must be drained before returning.

## Test plan

- [ ] \`xcodebuild\` debug — build succeeds (confirmed locally)
- [ ] Launch app with no dongle connected → \`hasLocalRtlSdr == false\`, rtl_tcp server panel caption shows "No local RTL-SDR dongle detected"
- [ ] Plug in an RTL-SDR dongle while the app has focus → within ~100 ms, server panel appears with the dongle's device name
- [ ] Unplug the dongle → server panel returns to the "no dongle" caption
- [ ] Repeat rapid plug/unplug cycles → no crashes, no leaks, panel state always matches reality
- [ ] Plug in an unrelated USB device (keyboard/phone) → no visible change (probe runs but returns 0 RTL-SDR devices)
- [ ] Quit the app while the monitor is running → no assertion/leak warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * USB devices are now automatically detected when plugged in or disconnected without requiring the application window to regain focus, providing real-time device availability updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->