### PR TITLE
feat(#317): scanner engine — sdr-scanner crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,6 +2055,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdr-scanner"
+version = "0.1.0"
+dependencies = [
+ "sdr-dsp",
+ "sdr-radio",
+ "sdr-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "sdr-server-rtltcp"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ members = [
     "crates/sdr-source-network",
     "crates/sdr-server-rtltcp",
     "crates/sdr-rtltcp-discovery",
+    "crates/sdr-scanner",
     "crates/sdr-source-file",
     "crates/sdr-sink-audio",
     "crates/sdr-sink-network",
@@ -134,6 +135,7 @@ sdr-source-rtlsdr = { path = "crates/sdr-source-rtlsdr" }
 sdr-source-network = { path = "crates/sdr-source-network" }
 sdr-server-rtltcp = { path = "crates/sdr-server-rtltcp" }
 sdr-rtltcp-discovery = { path = "crates/sdr-rtltcp-discovery" }
+sdr-scanner = { path = "crates/sdr-scanner" }
 sdr-source-file = { path = "crates/sdr-source-file" }
 sdr-sink-audio = { path = "crates/sdr-sink-audio" }
 sdr-sink-network = { path = "crates/sdr-sink-network" }

--- a/crates/sdr-scanner/Cargo.toml
+++ b/crates/sdr-scanner/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sdr-scanner"
+version = "0.1.0"
+description = "Scanner state machine — sequential channel monitoring for SDR pipelines"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+sdr-types.workspace = true
+sdr-dsp.workspace = true
+sdr-radio.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/sdr-scanner/src/channel.rs
+++ b/crates/sdr-scanner/src/channel.rs
@@ -18,10 +18,13 @@ pub struct ChannelKey {
 /// these from `Bookmark` entries at scan-start or on
 /// `ChannelsChanged`; the state machine operates on them directly
 /// and has no notion of bookmark storage.
+///
+/// Frequency lives on the `key` — deliberately NOT duplicated as
+/// a top-level field, so identity (used for lockout + active-
+/// channel tracking) and the retune target can't drift apart.
 #[derive(Debug, Clone)]
 pub struct ScannerChannel {
     pub key: ChannelKey,
-    pub frequency_hz: u64,
     pub demod_mode: DemodMode,
     pub bandwidth: f64,
     pub ctcss: Option<sdr_radio::af_chain::CtcssMode>,
@@ -32,4 +35,13 @@ pub struct ScannerChannel {
     pub dwell_ms: u32,
     /// Resolved hang time in ms (per-channel override folded in).
     pub hang_ms: u32,
+}
+
+impl ScannerChannel {
+    /// Convenience accessor — reads through to `key.frequency_hz`.
+    #[inline]
+    #[must_use]
+    pub fn frequency_hz(&self) -> u64 {
+        self.key.frequency_hz
+    }
 }

--- a/crates/sdr-scanner/src/channel.rs
+++ b/crates/sdr-scanner/src/channel.rs
@@ -1,0 +1,35 @@
+//! Channel identity and per-channel config. `ScannerChannel` is
+//! the resolved runtime shape — dwell/hang are already folded from
+//! overrides + defaults; the scanner state machine doesn't need to
+//! know about `Option`s here.
+
+use sdr_types::DemodMode;
+
+/// Stable identity for a channel across rebuilds of the channel
+/// list. `(name, frequency_hz)` — same convention the bookmarks
+/// flyout uses for the active-bookmark highlight.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChannelKey {
+    pub name: String,
+    pub frequency_hz: u64,
+}
+
+/// Fully-resolved scanner channel. The UI / controller builds
+/// these from `Bookmark` entries at scan-start or on
+/// `ChannelsChanged`; the state machine operates on them directly
+/// and has no notion of bookmark storage.
+#[derive(Debug, Clone)]
+pub struct ScannerChannel {
+    pub key: ChannelKey,
+    pub frequency_hz: u64,
+    pub demod_mode: DemodMode,
+    pub bandwidth: f64,
+    pub ctcss: Option<sdr_radio::af_chain::CtcssMode>,
+    pub voice_squelch: Option<sdr_dsp::voice_squelch::VoiceSquelchMode>,
+    /// 0 = normal rotation, >=1 = priority (checked more often).
+    pub priority: u8,
+    /// Resolved dwell time in ms (per-channel override folded in).
+    pub dwell_ms: u32,
+    /// Resolved hang time in ms (per-channel override folded in).
+    pub hang_ms: u32,
+}

--- a/crates/sdr-scanner/src/commands.rs
+++ b/crates/sdr-scanner/src/commands.rs
@@ -1,0 +1,38 @@
+//! Commands emitted by the scanner in response to events.
+//! The DSP controller applies these — scanner itself never
+//! touches the source, sink, or radio module directly.
+
+use crate::channel::ChannelKey;
+use crate::state::ScannerState;
+
+#[derive(Debug, Clone)]
+pub enum ScannerCommand {
+    /// Retune the source and reconfigure the radio module to this
+    /// channel. Controller dispatches `source.set_center_freq`,
+    /// `radio_module.set_demod_mode`, `set_bandwidth`,
+    /// `set_ctcss_mode`, `set_voice_squelch_mode` in order.
+    Retune {
+        freq_hz: u64,
+        demod_mode: sdr_types::DemodMode,
+        bandwidth: f64,
+        ctcss: Option<sdr_radio::af_chain::CtcssMode>,
+        voice_squelch: Option<sdr_dsp::voice_squelch::VoiceSquelchMode>,
+    },
+
+    /// Gate the final PCM stream to the audio device. DSP chain
+    /// keeps running so squelch edges still fire; only user-
+    /// audible output is silenced.
+    MuteAudio(bool),
+
+    /// UI-facing: active channel changed. `None` during Idle.
+    ActiveChannelChanged(Option<ChannelKey>),
+
+    /// UI-facing: scanner phase indicator updated.
+    StateChanged(ScannerState),
+
+    /// Emitted when the active rotation is fully empty — every
+    /// channel is either removed, disabled, or locked out.
+    /// UI surfaces as a toast; scanner transitions to Idle
+    /// afterwards.
+    EmptyRotation,
+}

--- a/crates/sdr-scanner/src/events.rs
+++ b/crates/sdr-scanner/src/events.rs
@@ -2,6 +2,8 @@
 //! No wall-clock time anywhere — sample-count is the only timing
 //! primitive, matching the `AutoBreakMachine` pattern.
 
+use std::num::NonZeroU32;
+
 use crate::channel::{ChannelKey, ScannerChannel};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,9 +17,16 @@ pub enum ScannerEvent {
     /// Fired by the DSP controller on every IQ block arrival.
     /// `samples_consumed` is block length; `sample_rate_hz`
     /// anchors the ms→sample conversion for dwell/hang/settle.
+    ///
+    /// Typed as `NonZeroU32` so the ms→sample math's zero-rate
+    /// invariant is enforced at compile time rather than via a
+    /// runtime debug-assert that silently degrades in release
+    /// builds. Callers wrap the source sample rate with
+    /// `NonZeroU32::new(rate).expect("source rate > 0")` — this
+    /// is always true for any live SDR source.
     SampleTick {
         samples_consumed: u32,
-        sample_rate_hz: u32,
+        sample_rate_hz: NonZeroU32,
     },
 
     /// Edge-triggered squelch transition, identical to the stream

--- a/crates/sdr-scanner/src/events.rs
+++ b/crates/sdr-scanner/src/events.rs
@@ -1,0 +1,43 @@
+//! Events fed into the scanner by the DSP controller or UI.
+//! No wall-clock time anywhere — sample-count is the only timing
+//! primitive, matching the `AutoBreakMachine` pattern.
+
+use crate::channel::{ChannelKey, ScannerChannel};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SquelchState {
+    Open,
+    Closed,
+}
+
+#[derive(Debug, Clone)]
+pub enum ScannerEvent {
+    /// Fired by the DSP controller on every IQ block arrival.
+    /// `samples_consumed` is block length; `sample_rate_hz`
+    /// anchors the ms→sample conversion for dwell/hang/settle.
+    SampleTick {
+        samples_consumed: u32,
+        sample_rate_hz: u32,
+    },
+
+    /// Edge-triggered squelch transition, identical to the stream
+    /// already fed to the transcription tap for Auto Break.
+    SquelchEdge(SquelchState),
+
+    /// User added / removed / edited a scannable bookmark.
+    /// Scanner swaps its channel list and recovers a sensible
+    /// rotation position.
+    ChannelsChanged(Vec<ScannerChannel>),
+
+    /// Master scanner on/off toggle.
+    SetEnabled(bool),
+
+    /// Session-scoped lockout — channel is skipped in rotation
+    /// until unlocked or scanner is disabled.
+    LockoutChannel(ChannelKey),
+    UnlockoutChannel(ChannelKey),
+
+    /// Global default dwell/hang changes from the UI sliders.
+    SetDefaultDwellMs(u32),
+    SetDefaultHangMs(u32),
+}

--- a/crates/sdr-scanner/src/events.rs
+++ b/crates/sdr-scanner/src/events.rs
@@ -36,8 +36,4 @@ pub enum ScannerEvent {
     /// until unlocked or scanner is disabled.
     LockoutChannel(ChannelKey),
     UnlockoutChannel(ChannelKey),
-
-    /// Global default dwell/hang changes from the UI sliders.
-    SetDefaultDwellMs(u32),
-    SetDefaultHangMs(u32),
 }

--- a/crates/sdr-scanner/src/events.rs
+++ b/crates/sdr-scanner/src/events.rs
@@ -35,5 +35,5 @@ pub enum ScannerEvent {
     /// Session-scoped lockout — channel is skipped in rotation
     /// until unlocked or scanner is disabled.
     LockoutChannel(ChannelKey),
-    UnlockoutChannel(ChannelKey),
+    UnlockChannel(ChannelKey),
 }

--- a/crates/sdr-scanner/src/lib.rs
+++ b/crates/sdr-scanner/src/lib.rs
@@ -1,0 +1,36 @@
+//! Scanner state machine — sequential channel monitoring for SDR
+//! pipelines. Pure no-I/O logic: consumes events, emits commands,
+//! leaves all actual radio/audio wiring to the DSP controller that
+//! owns an instance.
+//!
+//! See docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
+//! for the design decisions behind this crate's shape.
+
+pub mod channel;
+pub mod commands;
+pub mod events;
+pub mod scanner;
+pub mod state;
+
+pub use channel::{ChannelKey, ScannerChannel};
+pub use commands::ScannerCommand;
+pub use events::{ScannerEvent, SquelchState};
+pub use scanner::Scanner;
+pub use state::ScannerState;
+
+/// Default dwell time in ms when a channel doesn't override it.
+pub const DEFAULT_DWELL_MS: u32 = 100;
+
+/// Default hang time in ms when a channel doesn't override it.
+pub const DEFAULT_HANG_MS: u32 = 2000;
+
+/// Settle window in ms after a retune before the scanner honors
+/// squelch edges on the new channel. Covers PLL lock + filter
+/// warm-up transients — scanner decisions during this window are
+/// unreliable.
+pub const SETTLE_MS: u32 = 30;
+
+/// How often (in normal-channel hops) the scanner sweeps priority
+/// channels between normal rotations. `5` means every 5 normal
+/// hops, all priority-1 channels get a check before resuming.
+pub const PRIORITY_CHECK_INTERVAL: u32 = 5;

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -18,7 +18,8 @@ enum Phase {
     Idle,
     Retuning {
         target_idx: usize,
-        samples_until_settled: u64,
+        /// `None` → seed on next `SampleTick`; `Some(n)` → n samples remaining.
+        samples_until_settled: Option<u64>,
     },
     Dwelling {
         idx: usize,
@@ -29,8 +30,15 @@ enum Phase {
     },
     Hanging {
         idx: usize,
-        samples_until_timeout: u64,
+        /// `None` → seed on next `SampleTick`; `Some(n)` → n samples remaining.
+        samples_until_timeout: Option<u64>,
     },
+    /// Transition marker: advance rotation after a Dwelling timeout.
+    /// Never stored in `self.phase`; used only inside `handle_sample_tick`.
+    AdvanceFromDwell,
+    /// Transition marker: advance rotation after a Hanging timeout.
+    /// Never stored in `self.phase`; used only inside `handle_sample_tick`.
+    AdvanceFromHang,
 }
 
 impl Phase {
@@ -41,6 +49,9 @@ impl Phase {
             Phase::Dwelling { .. } => ScannerState::Dwelling,
             Phase::Listening { .. } => ScannerState::Listening,
             Phase::Hanging { .. } => ScannerState::Hanging,
+            Phase::AdvanceFromDwell | Phase::AdvanceFromHang => {
+                unreachable!("advance markers should never sit as the phase")
+            }
         }
     }
 }
@@ -106,7 +117,7 @@ impl Scanner {
                 sample_rate_hz,
             } => self.handle_sample_tick(samples_consumed, sample_rate_hz),
             ScannerEvent::LockoutChannel(key) => self.handle_lockout(key),
-            ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(key),
+            ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(&key),
             ScannerEvent::SetDefaultDwellMs(ms) => {
                 self.default_dwell_ms = ms;
                 Vec::new()
@@ -153,8 +164,8 @@ impl Scanner {
     }
 
     /// Begin or resume rotation from the current cursor. Emits
-    /// Retune + MuteAudio + ActiveChannelChanged + StateChanged.
-    /// Returns EmptyRotation if no scannable + unlocked channels
+    /// Retune + `MuteAudio` + `ActiveChannelChanged` + `StateChanged`.
+    /// Returns `EmptyRotation` if no scannable + unlocked channels
     /// exist, and transitions to Idle.
     fn start_rotation(&mut self) -> Vec<ScannerCommand> {
         let Some(idx) = self.pick_next_channel() else {
@@ -181,20 +192,20 @@ impl Scanner {
 
     /// Emit the retune command set for the given channel index
     /// and move to Retuning phase. Settle window initialized on
-    /// the first SampleTick after entering Retuning (the sample
+    /// the first `SampleTick` after entering Retuning (the sample
     /// rate isn't known here).
     fn enter_retuning(&mut self, idx: usize) -> Vec<ScannerCommand> {
         let channel = &self.channels[idx];
         self.phase = Phase::Retuning {
             target_idx: idx,
-            samples_until_settled: 0, // seeded on first SampleTick
+            samples_until_settled: None, // seeded on first SampleTick
         };
         vec![
             ScannerCommand::Retune {
                 freq_hz: channel.frequency_hz,
                 demod_mode: channel.demod_mode,
                 bandwidth: channel.bandwidth,
-                ctcss: channel.ctcss.clone(),
+                ctcss: channel.ctcss,
                 voice_squelch: channel.voice_squelch,
             },
             ScannerCommand::MuteAudio(true),
@@ -274,10 +285,32 @@ impl Scanner {
     }
 
     fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
-        // TODO (Task 1.6): honor post-settle; drive Dwelling→Listening
-        // and Listening→Hanging transitions.
-        let _ = state;
-        Vec::new()
+        match (&self.phase, state) {
+            (Phase::Retuning { .. }, _) => {
+                // Ignore edges during settle window.
+                Vec::new()
+            }
+            (Phase::Dwelling { idx, .. } | Phase::Hanging { idx, .. }, SquelchState::Open) => {
+                let idx = *idx;
+                self.phase = Phase::Listening { idx };
+                vec![
+                    ScannerCommand::MuteAudio(false),
+                    ScannerCommand::StateChanged(ScannerState::Listening),
+                ]
+            }
+            (Phase::Listening { idx }, SquelchState::Closed) => {
+                let idx = *idx;
+                self.phase = Phase::Hanging {
+                    idx,
+                    samples_until_timeout: None, // seed on first tick
+                };
+                vec![
+                    ScannerCommand::MuteAudio(true),
+                    ScannerCommand::StateChanged(ScannerState::Hanging),
+                ]
+            }
+            _ => Vec::new(),
+        }
     }
 
     fn handle_sample_tick(
@@ -285,10 +318,106 @@ impl Scanner {
         samples_consumed: u32,
         sample_rate_hz: u32,
     ) -> Vec<ScannerCommand> {
-        // TODO (Task 1.6): countdown settle / dwell / hang windows,
-        // advance on timeout.
-        let _ = (samples_consumed, sample_rate_hz);
-        Vec::new()
+        let samples = u64::from(samples_consumed);
+        let next_phase: Option<Phase> = match &mut self.phase {
+            Phase::Idle | Phase::Listening { .. } => return Vec::new(),
+            Phase::Retuning {
+                target_idx,
+                samples_until_settled,
+            } => {
+                let remaining = match samples_until_settled {
+                    None => {
+                        let seeded = ms_to_samples(SETTLE_MS, sample_rate_hz)
+                            .saturating_sub(samples);
+                        *samples_until_settled = Some(seeded);
+                        seeded
+                    }
+                    Some(remaining) => {
+                        *remaining = remaining.saturating_sub(samples);
+                        *remaining
+                    }
+                };
+                if remaining == 0 {
+                    let idx = *target_idx;
+                    let dwell_ms = self.channels[idx].dwell_ms;
+                    Some(Phase::Dwelling {
+                        idx,
+                        samples_until_timeout: ms_to_samples(dwell_ms, sample_rate_hz),
+                    })
+                } else {
+                    None
+                }
+            }
+            Phase::Dwelling {
+                samples_until_timeout,
+                ..
+            } => {
+                *samples_until_timeout = samples_until_timeout.saturating_sub(samples);
+                if *samples_until_timeout == 0 {
+                    Some(Phase::AdvanceFromDwell)
+                } else {
+                    None
+                }
+            }
+            Phase::Hanging {
+                idx,
+                samples_until_timeout,
+            } => {
+                let remaining = match samples_until_timeout {
+                    None => {
+                        let hang_ms = self.channels[*idx].hang_ms;
+                        let seeded = ms_to_samples(hang_ms, sample_rate_hz)
+                            .saturating_sub(samples);
+                        *samples_until_timeout = Some(seeded);
+                        seeded
+                    }
+                    Some(remaining) => {
+                        *remaining = remaining.saturating_sub(samples);
+                        *remaining
+                    }
+                };
+                if remaining == 0 {
+                    Some(Phase::AdvanceFromHang)
+                } else {
+                    None
+                }
+            }
+            Phase::AdvanceFromDwell | Phase::AdvanceFromHang => {
+                unreachable!("advance markers should never sit as the phase")
+            }
+        };
+
+        match next_phase {
+            Some(Phase::Dwelling {
+                idx,
+                samples_until_timeout,
+            }) => {
+                self.phase = Phase::Dwelling {
+                    idx,
+                    samples_until_timeout,
+                };
+                vec![ScannerCommand::StateChanged(ScannerState::Dwelling)]
+            }
+            Some(Phase::AdvanceFromDwell | Phase::AdvanceFromHang) => {
+                self.hops_since_priority_sweep += 1;
+                self.advance_rotation()
+            }
+            None | Some(_) => Vec::new(),
+        }
+    }
+
+    fn advance_rotation(&mut self) -> Vec<ScannerCommand> {
+        if let Some(idx) = self.pick_next_channel() {
+            self.enter_retuning(idx)
+        } else {
+            self.phase = Phase::Idle;
+            vec![
+                ScannerCommand::EmptyRotation,
+                ScannerCommand::MuteAudio(false),
+                ScannerCommand::ActiveChannelChanged(None),
+                ScannerCommand::StateChanged(ScannerState::Idle),
+            ]
+        }
     }
 
     fn handle_lockout(&mut self, key: ChannelKey) -> Vec<ScannerCommand> {
@@ -298,19 +427,18 @@ impl Scanner {
         Vec::new()
     }
 
-    fn handle_unlockout(&mut self, key: ChannelKey) -> Vec<ScannerCommand> {
-        self.locked_out.remove(&key);
+    fn handle_unlockout(&mut self, key: &ChannelKey) -> Vec<ScannerCommand> {
+        self.locked_out.remove(key);
         Vec::new()
     }
 }
 
-/// Convert ms to samples at the given sample rate. Rounded up so
-/// a 30 ms window at 48000 Hz = 1440 samples (exact), and a 30 ms
-/// at 44100 = 1323. Caller uses this to seed `samples_until_*`.
-#[allow(clippy::cast_possible_truncation)]
+/// Convert milliseconds to a sample count at the given sample rate,
+/// rounding up. Uses `div_ceil` so 30 ms at 48 000 Hz = 1440 samples
+/// (exact), 30 ms at 44 100 Hz = 1323 samples. Caller uses this to
+/// seed `samples_until_*`.
 fn ms_to_samples(ms: u32, sample_rate_hz: u32) -> u64 {
-    // (ms * rate + 999) / 1000 — ceiling division.
-    (u64::from(ms) * u64::from(sample_rate_hz) + 999) / 1000
+    (u64::from(ms) * u64::from(sample_rate_hz)).div_ceil(1000)
 }
 
 #[cfg(test)]
@@ -381,5 +509,119 @@ mod tests {
         let commands = s.handle_event(ScannerEvent::SetEnabled(true));
         assert_eq!(s.state(), ScannerState::Idle);
         assert!(matches!(commands[0], ScannerCommand::EmptyRotation));
+    }
+
+    /// 48 kHz rate, so 30ms settle = 1440 samples, 100ms dwell = 4800 samples.
+    const RATE: u32 = 48_000;
+
+    fn tick(samples: u32) -> ScannerEvent {
+        ScannerEvent::SampleTick {
+            samples_consumed: samples,
+            sample_rate_hz: RATE,
+        }
+    }
+
+    #[test]
+    fn settle_window_ignores_squelch_open() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // Feed a squelch open during the settle window.
+        s.handle_event(tick(500));
+        let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // No MuteAudio(false) should have been emitted.
+        assert!(
+            !commands.iter().any(|c| matches!(c, ScannerCommand::MuteAudio(false))),
+            "mute was released during settle window"
+        );
+    }
+
+    #[test]
+    fn post_settle_squelch_open_transitions_to_listening() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // Elapse the settle window (1440 samples for 30ms at 48kHz).
+        s.handle_event(tick(1500));
+        assert_eq!(s.state(), ScannerState::Dwelling);
+        let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::MuteAudio(false))));
+    }
+
+    #[test]
+    fn dwell_elapsed_without_squelch_advances_to_next() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // Skip settle window.
+        s.handle_event(tick(1500));
+        assert_eq!(s.state(), ScannerState::Dwelling);
+        // Dwell is 100ms = 4800 samples at 48kHz. Tick past it.
+        let commands = s.handle_event(tick(5000));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // Should have retuned to channel B (frequency 162_550_000).
+        assert!(commands.iter().any(|c| matches!(
+            c,
+            ScannerCommand::Retune { freq_hz: 162_550_000, .. }
+        )));
+    }
+
+    #[test]
+    fn squelch_close_in_listening_enters_hanging_and_mutes() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(1500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+        let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
+        assert_eq!(s.state(), ScannerState::Hanging);
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::MuteAudio(true))));
+    }
+
+    #[test]
+    fn squelch_reopen_before_hang_end_returns_to_listening() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(1500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
+        assert_eq!(s.state(), ScannerState::Hanging);
+        // Advance partway into hang (2000ms hang = 96000 samples).
+        s.handle_event(tick(10_000));
+        let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::MuteAudio(false))));
+    }
+
+    #[test]
+    fn hang_elapsed_advances_to_next_channel() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(1500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
+        let commands = s.handle_event(tick(100_000));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        assert!(commands.iter().any(|c| matches!(
+            c,
+            ScannerCommand::Retune { freq_hz: 162_550_000, .. }
+        )));
     }
 }

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -9,7 +9,7 @@ use crate::channel::{ChannelKey, ScannerChannel};
 use crate::commands::ScannerCommand;
 use crate::events::{ScannerEvent, SquelchState};
 use crate::state::ScannerState;
-use crate::{DEFAULT_DWELL_MS, DEFAULT_HANG_MS, PRIORITY_CHECK_INTERVAL, SETTLE_MS};
+use crate::{PRIORITY_CHECK_INTERVAL, SETTLE_MS};
 
 /// Internal phase carrying per-phase bookkeeping. The outer
 /// `ScannerState` surfaced to the UI is a flattened view of this.
@@ -58,12 +58,17 @@ impl Phase {
 
 /// Scanner state machine. Instantiate once, feed events, apply
 /// emitted commands. All methods are synchronous and cheap.
+///
+/// Timing defaults (dwell, hang) live OUTSIDE the scanner — the
+/// UI folds them into each `ScannerChannel` at projection time.
+/// Scanner only sees resolved per-channel `dwell_ms` / `hang_ms`,
+/// so a default-slider change on the UI side triggers a fresh
+/// `ChannelsChanged` push rather than a separate "update defaults"
+/// signal the scanner would otherwise have to propagate.
 pub struct Scanner {
     enabled: bool,
     channels: Vec<ScannerChannel>,
     locked_out: HashSet<ChannelKey>,
-    default_dwell_ms: u32,
-    default_hang_ms: u32,
     phase: Phase,
     /// Rotation index into the current sub-list. Normal and
     /// priority rotations are advanced independently.
@@ -83,8 +88,6 @@ impl Default for Scanner {
             enabled: false,
             channels: Vec::new(),
             locked_out: HashSet::new(),
-            default_dwell_ms: DEFAULT_DWELL_MS,
-            default_hang_ms: DEFAULT_HANG_MS,
             phase: Phase::Idle,
             normal_cursor: 0,
             priority_cursor: 0,
@@ -118,14 +121,6 @@ impl Scanner {
             } => self.handle_sample_tick(samples_consumed, sample_rate_hz),
             ScannerEvent::LockoutChannel(key) => self.handle_lockout(key),
             ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(&key),
-            ScannerEvent::SetDefaultDwellMs(ms) => {
-                self.default_dwell_ms = ms;
-                Vec::new()
-            }
-            ScannerEvent::SetDefaultHangMs(ms) => {
-                self.default_hang_ms = ms;
-                Vec::new()
-            }
         }
     }
 
@@ -139,6 +134,14 @@ impl Scanner {
         if enabled {
             self.start_rotation()
         } else {
+            // Session-scoped state clears on disable so re-enabling
+            // starts fresh rather than carrying stale lockouts or
+            // mid-cycle rotation cursors into the next session.
+            self.locked_out.clear();
+            self.normal_cursor = 0;
+            self.priority_cursor = 0;
+            self.hops_since_priority_sweep = 0;
+            self.in_priority_sweep = false;
             self.stop_rotation()
         }
     }
@@ -148,17 +151,20 @@ impl Scanner {
         // Any stale lockout keys for channels that no longer exist
         // are harmless (the set is only consulted against the
         // live channel list), but we'll prune for cleanliness.
-        let valid: HashSet<ChannelKey> =
-            self.channels.iter().map(|c| c.key.clone()).collect();
+        let valid: HashSet<ChannelKey> = self.channels.iter().map(|c| c.key.clone()).collect();
         self.locked_out.retain(|k| valid.contains(k));
 
         if !self.enabled {
             return Vec::new();
         }
         // Currently-scanning mid-list-change: recover from wherever
-        // the phase left us by re-starting rotation.
+        // the phase left us by re-starting rotation. Also reset
+        // the priority-hop counter so a list edit doesn't trigger
+        // an immediate priority sweep just because the pre-edit
+        // session had accumulated hops.
         self.normal_cursor = 0;
         self.priority_cursor = 0;
+        self.hops_since_priority_sweep = 0;
         self.in_priority_sweep = false;
         self.start_rotation()
     }
@@ -202,7 +208,7 @@ impl Scanner {
         };
         vec![
             ScannerCommand::Retune {
-                freq_hz: channel.frequency_hz,
+                freq_hz: channel.key.frequency_hz,
                 demod_mode: channel.demod_mode,
                 bandwidth: channel.bandwidth,
                 ctcss: channel.ctcss,
@@ -327,8 +333,8 @@ impl Scanner {
             } => {
                 let remaining = match samples_until_settled {
                     None => {
-                        let seeded = ms_to_samples(SETTLE_MS, sample_rate_hz)
-                            .saturating_sub(samples);
+                        let seeded =
+                            ms_to_samples(SETTLE_MS, sample_rate_hz).saturating_sub(samples);
                         *samples_until_settled = Some(seeded);
                         seeded
                     }
@@ -366,8 +372,7 @@ impl Scanner {
                 let remaining = match samples_until_timeout {
                     None => {
                         let hang_ms = self.channels[*idx].hang_ms;
-                        let seeded = ms_to_samples(hang_ms, sample_rate_hz)
-                            .saturating_sub(samples);
+                        let seeded = ms_to_samples(hang_ms, sample_rate_hz).saturating_sub(samples);
                         *samples_until_timeout = Some(seeded);
                         seeded
                     }
@@ -447,6 +452,7 @@ fn ms_to_samples(ms: u32, sample_rate_hz: u32) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{DEFAULT_DWELL_MS, DEFAULT_HANG_MS};
     use sdr_types::DemodMode;
 
     fn ch(name: &str, freq: u64, priority: u8) -> ScannerChannel {
@@ -455,7 +461,6 @@ mod tests {
                 name: name.to_string(),
                 frequency_hz: freq,
             },
-            frequency_hz: freq,
             demod_mode: DemodMode::Nfm,
             bandwidth: 12_500.0,
             ctcss: None,
@@ -476,7 +481,13 @@ mod tests {
         let commands = s.handle_event(ScannerEvent::SetEnabled(true));
         assert_eq!(s.state(), ScannerState::Retuning);
         // Expect Retune → MuteAudio(true) → ActiveChannelChanged → StateChanged
-        assert!(matches!(commands[0], ScannerCommand::Retune { freq_hz: 146_520_000, .. }));
+        assert!(matches!(
+            commands[0],
+            ScannerCommand::Retune {
+                freq_hz: 146_520_000,
+                ..
+            }
+        ));
         assert!(matches!(commands[1], ScannerCommand::MuteAudio(true)));
         assert!(matches!(
             commands[2],
@@ -535,7 +546,9 @@ mod tests {
         assert_eq!(s.state(), ScannerState::Retuning);
         // No MuteAudio(false) should have been emitted.
         assert!(
-            !commands.iter().any(|c| matches!(c, ScannerCommand::MuteAudio(false))),
+            !commands
+                .iter()
+                .any(|c| matches!(c, ScannerCommand::MuteAudio(false))),
             "mute was released during settle window"
         );
     }
@@ -550,9 +563,11 @@ mod tests {
         assert_eq!(s.state(), ScannerState::Dwelling);
         let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         assert_eq!(s.state(), ScannerState::Listening);
-        assert!(commands
-            .iter()
-            .any(|c| matches!(c, ScannerCommand::MuteAudio(false))));
+        assert!(
+            commands
+                .iter()
+                .any(|c| matches!(c, ScannerCommand::MuteAudio(false)))
+        );
     }
 
     #[test]
@@ -572,7 +587,10 @@ mod tests {
         // Should have retuned to channel B (frequency 162_550_000).
         assert!(commands.iter().any(|c| matches!(
             c,
-            ScannerCommand::Retune { freq_hz: 162_550_000, .. }
+            ScannerCommand::Retune {
+                freq_hz: 162_550_000,
+                ..
+            }
         )));
     }
 
@@ -586,9 +604,11 @@ mod tests {
         assert_eq!(s.state(), ScannerState::Listening);
         let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
         assert_eq!(s.state(), ScannerState::Hanging);
-        assert!(commands
-            .iter()
-            .any(|c| matches!(c, ScannerCommand::MuteAudio(true))));
+        assert!(
+            commands
+                .iter()
+                .any(|c| matches!(c, ScannerCommand::MuteAudio(true)))
+        );
     }
 
     #[test]
@@ -604,9 +624,11 @@ mod tests {
         s.handle_event(tick(10_000));
         let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         assert_eq!(s.state(), ScannerState::Listening);
-        assert!(commands
-            .iter()
-            .any(|c| matches!(c, ScannerCommand::MuteAudio(false))));
+        assert!(
+            commands
+                .iter()
+                .any(|c| matches!(c, ScannerCommand::MuteAudio(false)))
+        );
     }
 
     #[test]
@@ -624,7 +646,10 @@ mod tests {
         assert_eq!(s.state(), ScannerState::Retuning);
         assert!(commands.iter().any(|c| matches!(
             c,
-            ScannerCommand::Retune { freq_hz: 162_550_000, .. }
+            ScannerCommand::Retune {
+                freq_hz: 162_550_000,
+                ..
+            }
         )));
     }
 
@@ -686,9 +711,11 @@ mod tests {
             frequency_hz: 146_520_000,
         }));
         let commands = s.handle_event(ScannerEvent::SetEnabled(true));
-        assert!(commands
-            .iter()
-            .any(|c| matches!(c, ScannerCommand::EmptyRotation)));
+        assert!(
+            commands
+                .iter()
+                .any(|c| matches!(c, ScannerCommand::EmptyRotation))
+        );
         assert_eq!(s.state(), ScannerState::Idle);
     }
 
@@ -733,9 +760,13 @@ mod tests {
         // Scanner recovers by restarting rotation at cursor 0.
         assert_eq!(s.state(), ScannerState::Retuning);
         // First retune after list change goes to A.
-        assert!(commands
-            .iter()
-            .any(|c| matches!(c, ScannerCommand::Retune { freq_hz: 146_520_000, .. })));
+        assert!(commands.iter().any(|c| matches!(
+            c,
+            ScannerCommand::Retune {
+                freq_hz: 146_520_000,
+                ..
+            }
+        )));
     }
 
     #[test]
@@ -751,12 +782,38 @@ mod tests {
         ]));
         s.handle_event(ScannerEvent::LockoutChannel(key_a.clone()));
         // Remove A.
-        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch(
-            "B",
-            162_550_000,
-            0,
-        )]));
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("B", 162_550_000, 0)]));
         // Internal set should have pruned.
         assert!(!s.locked_out.contains(&key_a));
+    }
+
+    #[test]
+    fn disable_clears_session_state() {
+        // Re-enabling after a disable should start fresh — no
+        // carried-over lockouts, cursors, or hop counter.
+        let mut s = Scanner::new();
+        let key_a = ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        };
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(ScannerEvent::LockoutChannel(key_a.clone()));
+        // Advance through a few hops so cursors + priority counter are non-zero.
+        s.handle_event(tick(1500));
+        s.handle_event(tick(5000));
+        assert!(s.locked_out.contains(&key_a));
+        assert!(s.hops_since_priority_sweep > 0);
+
+        s.handle_event(ScannerEvent::SetEnabled(false));
+        // Session state should be fully clear after disable.
+        assert!(s.locked_out.is_empty(), "locked_out not cleared on disable");
+        assert_eq!(s.normal_cursor, 0);
+        assert_eq!(s.priority_cursor, 0);
+        assert_eq!(s.hops_since_priority_sweep, 0);
+        assert!(!s.in_priority_sweep);
     }
 }

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -49,8 +49,17 @@ impl Phase {
             Phase::Dwelling { .. } => ScannerState::Dwelling,
             Phase::Listening { .. } => ScannerState::Listening,
             Phase::Hanging { .. } => ScannerState::Hanging,
+            // `AdvanceFromDwell` / `AdvanceFromHang` are synthetic
+            // transition markers returned from `handle_sample_tick`
+            // and immediately consumed by its downstream match — they
+            // should never appear here. Debug builds assert, release
+            // falls back to `Idle` rather than panicking a library.
             Phase::AdvanceFromDwell | Phase::AdvanceFromHang => {
-                unreachable!("advance markers should never sit as the phase")
+                debug_assert!(
+                    false,
+                    "advance markers should never sit as the active phase"
+                );
+                ScannerState::Idle
             }
         }
     }
@@ -388,7 +397,15 @@ impl Scanner {
                 }
             }
             Phase::AdvanceFromDwell | Phase::AdvanceFromHang => {
-                unreachable!("advance markers should never sit as the phase")
+                // Defensive: see comment on `Phase::as_state`. These
+                // markers are only ever returned from the inner
+                // match; hitting them here would be a state-machine
+                // bug, but panicking a library for it is wrong.
+                debug_assert!(
+                    false,
+                    "advance markers should never sit as the active phase"
+                );
+                None
             }
         };
 
@@ -436,7 +453,15 @@ impl Scanner {
     }
 
     fn handle_unlockout(&mut self, key: &ChannelKey) -> Vec<ScannerCommand> {
-        self.locked_out.remove(key);
+        let removed = self.locked_out.remove(key);
+        // If the scanner stalled into `Idle` because every channel
+        // was locked out (EmptyRotation → Idle), unlocking a
+        // channel while still enabled should resume scanning
+        // automatically — otherwise the user would have to
+        // disable + re-enable to kick it back into motion.
+        if removed && self.enabled && matches!(self.phase, Phase::Idle) {
+            return self.start_rotation();
+        }
         Vec::new()
     }
 }
@@ -785,6 +810,34 @@ mod tests {
         s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("B", 162_550_000, 0)]));
         // Internal set should have pruned.
         assert!(!s.locked_out.contains(&key_a));
+    }
+
+    #[test]
+    fn unlockout_resumes_scanning_from_empty_rotation_idle() {
+        // Scenario: scanner is enabled but all channels are locked
+        // out, so it drained to Idle via EmptyRotation. Unlocking
+        // a channel should kick rotation back into motion rather
+        // than leaving the scanner stuck until some unrelated
+        // event fires.
+        let mut s = Scanner::new();
+        let key_a = ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        };
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::LockoutChannel(key_a.clone()));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        assert_eq!(s.state(), ScannerState::Idle);
+
+        let commands = s.handle_event(ScannerEvent::UnlockoutChannel(key_a));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        assert!(commands.iter().any(|c| matches!(
+            c,
+            ScannerCommand::Retune {
+                freq_hz: 146_520_000,
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -11,6 +11,14 @@ use crate::events::{ScannerEvent, SquelchState};
 use crate::state::ScannerState;
 use crate::{PRIORITY_CHECK_INTERVAL, SETTLE_MS};
 
+/// Lowest `ScannerChannel::priority` value that counts as
+/// "priority" for the priority-sweep logic. Channels at or above
+/// this tier are pulled into the priority sub-list; below are
+/// normal rotation. Single-tier in Phase 1 — `1` is the only
+/// promoted value — but centralizing the threshold makes the
+/// multi-tier #365 work a one-constant change.
+const MIN_PRIORITY_TIER: u8 = 1;
+
 /// Internal phase carrying per-phase bookkeeping. The outer
 /// `ScannerState` surfaced to the UI is a flattened view of this.
 #[derive(Debug, Clone)]
@@ -89,6 +97,13 @@ pub struct Scanner {
     hops_since_priority_sweep: u32,
     /// Set while a priority sweep is in progress.
     in_priority_sweep: bool,
+    /// Latched squelch state. Updated on every `SquelchEdge`
+    /// event regardless of phase so a persistent-open carrier
+    /// that triggered during the settle window (where phase
+    /// transitions ignore edges) isn't forgotten — we consult
+    /// this at settle expiry to decide Dwelling vs direct
+    /// Listening. Reset to `false` on every retune entry.
+    squelch_open: bool,
 }
 
 impl Default for Scanner {
@@ -102,6 +117,7 @@ impl Default for Scanner {
             priority_cursor: 0,
             hops_since_priority_sweep: 0,
             in_priority_sweep: false,
+            squelch_open: false,
         }
     }
 }
@@ -129,7 +145,7 @@ impl Scanner {
                 sample_rate_hz,
             } => self.handle_sample_tick(samples_consumed, sample_rate_hz),
             ScannerEvent::LockoutChannel(key) => self.handle_lockout(key),
-            ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(&key),
+            ScannerEvent::UnlockChannel(key) => self.handle_unlockout(&key),
         }
     }
 
@@ -211,6 +227,12 @@ impl Scanner {
     /// rate isn't known here).
     fn enter_retuning(&mut self, idx: usize) -> Vec<ScannerCommand> {
         let channel = &self.channels[idx];
+        // Clear the latched squelch state — previous channel's
+        // open/closed state is irrelevant post-retune, and samples
+        // arriving during the new channel's settle window will
+        // update the latch so the settle-expiry decision has the
+        // right information.
+        self.squelch_open = false;
         self.phase = Phase::Retuning {
             target_idx: idx,
             samples_until_settled: None, // seeded on first SampleTick
@@ -236,7 +258,10 @@ impl Scanner {
         // Trigger priority sweep if due.
         if !self.in_priority_sweep
             && self.hops_since_priority_sweep >= PRIORITY_CHECK_INTERVAL
-            && self.channels.iter().any(|c| c.priority >= 1)
+            && self
+                .channels
+                .iter()
+                .any(|c| c.priority >= MIN_PRIORITY_TIER)
         {
             self.in_priority_sweep = true;
             self.priority_cursor = 0;
@@ -247,7 +272,9 @@ impl Scanner {
                 .channels
                 .iter()
                 .enumerate()
-                .filter(|(_, c)| c.priority >= 1 && !self.locked_out.contains(&c.key))
+                .filter(|(_, c)| {
+                    c.priority >= MIN_PRIORITY_TIER && !self.locked_out.contains(&c.key)
+                })
                 .map(|(i, _)| i)
                 .collect();
             if self.priority_cursor < pri_indices.len() {
@@ -300,9 +327,18 @@ impl Scanner {
     }
 
     fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
+        // Always latch the current squelch state, regardless of
+        // phase. Retuning drops the phase transition (transients
+        // would false-trigger) but must still remember that a
+        // carrier is present, otherwise settle-expiry on a
+        // persistent-open channel would hop straight to
+        // `Dwelling` and wait indefinitely for an edge that
+        // already fired.
+        self.squelch_open = matches!(state, SquelchState::Open);
         match (&self.phase, state) {
             (Phase::Retuning { .. }, _) => {
-                // Ignore edges during settle window.
+                // Ignore edges during settle window — `squelch_open`
+                // latch is consulted when settle expires.
                 Vec::new()
             }
             (Phase::Dwelling { idx, .. } | Phase::Hanging { idx, .. }, SquelchState::Open) => {
@@ -354,11 +390,22 @@ impl Scanner {
                 };
                 if remaining == 0 {
                     let idx = *target_idx;
-                    let dwell_ms = self.channels[idx].dwell_ms;
-                    Some(Phase::Dwelling {
-                        idx,
-                        samples_until_timeout: ms_to_samples(dwell_ms, sample_rate_hz),
-                    })
+                    // Settle complete. If the channel's squelch was
+                    // already open (persistent carrier, tracked via
+                    // the `squelch_open` latch through the ignored-
+                    // edges settle window), jump directly to
+                    // Listening rather than Dwelling — otherwise
+                    // we'd sit silent waiting for a second edge
+                    // that the squelch detector already fired.
+                    if self.squelch_open {
+                        Some(Phase::Listening { idx })
+                    } else {
+                        let dwell_ms = self.channels[idx].dwell_ms;
+                        Some(Phase::Dwelling {
+                            idx,
+                            samples_until_timeout: ms_to_samples(dwell_ms, sample_rate_hz),
+                        })
+                    }
                 } else {
                     None
                 }
@@ -419,6 +466,14 @@ impl Scanner {
                     samples_until_timeout,
                 };
                 vec![ScannerCommand::StateChanged(ScannerState::Dwelling)]
+            }
+            Some(Phase::Listening { idx }) => {
+                // Persistent-open-carrier path from settle expiry.
+                self.phase = Phase::Listening { idx };
+                vec![
+                    ScannerCommand::MuteAudio(false),
+                    ScannerCommand::StateChanged(ScannerState::Listening),
+                ]
             }
             Some(Phase::AdvanceFromDwell | Phase::AdvanceFromHang) => {
                 self.hops_since_priority_sweep += 1;
@@ -813,6 +868,34 @@ mod tests {
     }
 
     #[test]
+    fn persistent_open_during_settle_goes_directly_to_listening() {
+        // Real-world scenario: scanner hops to a channel that
+        // already has a carrier active. The squelch detector
+        // fires Open during the retune's settle window, which
+        // phase transitions ignore — but the latch still
+        // records it. Settle expiry must consult the latch and
+        // go straight to Listening, not sit in Dwelling waiting
+        // for an edge that already fired.
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // During settle: feed a squelch-open edge. Phase stays
+        // Retuning; latch moves to open.
+        s.handle_event(tick(500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // Settle expires. Scanner should land in Listening
+        // directly, with audio unmuted.
+        let commands = s.handle_event(tick(2000));
+        assert_eq!(s.state(), ScannerState::Listening);
+        assert!(
+            commands
+                .iter()
+                .any(|c| matches!(c, ScannerCommand::MuteAudio(false)))
+        );
+    }
+
+    #[test]
     fn unlockout_resumes_scanning_from_empty_rotation_idle() {
         // Scenario: scanner is enabled but all channels are locked
         // out, so it drained to Idle via EmptyRotation. Unlocking
@@ -829,7 +912,7 @@ mod tests {
         s.handle_event(ScannerEvent::SetEnabled(true));
         assert_eq!(s.state(), ScannerState::Idle);
 
-        let commands = s.handle_event(ScannerEvent::UnlockoutChannel(key_a));
+        let commands = s.handle_event(ScannerEvent::UnlockChannel(key_a));
         assert_eq!(s.state(), ScannerState::Retuning);
         assert!(commands.iter().any(|c| matches!(
             c,

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -269,55 +269,71 @@ impl Scanner {
         }
 
         if self.in_priority_sweep {
-            let pri_count = self.count_matching(|c| {
+            let is_priority = |c: &ScannerChannel| {
                 c.priority >= MIN_PRIORITY_TIER && !self.locked_out.contains(&c.key)
-            });
+            };
+            let pri_count = self.count_matching(is_priority);
             if self.priority_cursor < pri_count {
-                let chosen = self
-                    .nth_matching(self.priority_cursor, |c| {
-                        c.priority >= MIN_PRIORITY_TIER && !self.locked_out.contains(&c.key)
-                    })
-                    .expect("priority_cursor < pri_count guarantees a match");
-                self.priority_cursor += 1;
-                return Some(chosen);
+                if let Some(chosen) = self.nth_matching(self.priority_cursor, is_priority) {
+                    self.priority_cursor += 1;
+                    return Some(chosen);
+                }
+                // Invariant violation: cursor < count but nth returned
+                // None. Should be impossible — assert in debug, recover
+                // in release by treating the sweep as exhausted and
+                // falling through to normal rotation.
+                debug_assert!(
+                    false,
+                    "priority_cursor < pri_count but nth_matching returned None"
+                );
             }
-            // Priority sweep exhausted.
+            // Priority sweep exhausted (or invariant-fallback).
             self.in_priority_sweep = false;
             self.priority_cursor = 0;
             self.hops_since_priority_sweep = 0;
             // Fall through to normal rotation.
         }
 
-        let normal_count =
-            self.count_matching(|c| c.priority == 0 && !self.locked_out.contains(&c.key));
+        let is_normal = |c: &ScannerChannel| c.priority == 0 && !self.locked_out.contains(&c.key);
+        let normal_count = self.count_matching(is_normal);
 
         if normal_count == 0 {
             // No normal channels — fall back to any unlocked channel
             // (priority-only lists).
-            let any_count = self.count_matching(|c| !self.locked_out.contains(&c.key));
+            let is_unlocked = |c: &ScannerChannel| !self.locked_out.contains(&c.key);
+            let any_count = self.count_matching(is_unlocked);
             if any_count == 0 {
                 return None;
             }
             if self.normal_cursor >= any_count {
                 self.normal_cursor = 0;
             }
-            let chosen = self
-                .nth_matching(self.normal_cursor, |c| !self.locked_out.contains(&c.key))
-                .expect("normal_cursor < any_count guarantees a match");
-            self.normal_cursor = (self.normal_cursor + 1) % any_count;
-            return Some(chosen);
+            let chosen = self.nth_matching(self.normal_cursor, is_unlocked);
+            debug_assert!(
+                chosen.is_some(),
+                "normal_cursor < any_count but nth_matching returned None"
+            );
+            if let Some(chosen) = chosen {
+                self.normal_cursor = (self.normal_cursor + 1) % any_count;
+                return Some(chosen);
+            }
+            return None;
         }
 
         if self.normal_cursor >= normal_count {
             self.normal_cursor = 0;
         }
-        let chosen = self
-            .nth_matching(self.normal_cursor, |c| {
-                c.priority == 0 && !self.locked_out.contains(&c.key)
-            })
-            .expect("normal_cursor < normal_count guarantees a match");
-        self.normal_cursor = (self.normal_cursor + 1) % normal_count;
-        Some(chosen)
+        let chosen = self.nth_matching(self.normal_cursor, is_normal);
+        debug_assert!(
+            chosen.is_some(),
+            "normal_cursor < normal_count but nth_matching returned None"
+        );
+        if let Some(chosen) = chosen {
+            self.normal_cursor = (self.normal_cursor + 1) % normal_count;
+            Some(chosen)
+        } else {
+            None
+        }
     }
 
     /// Count channels matching `predicate`. Allocation-free —

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -88,16 +88,38 @@ pub struct Scanner {
     channels: Vec<ScannerChannel>,
     locked_out: HashSet<ChannelKey>,
     phase: Phase,
-    /// Rotation index into the current sub-list. Normal and
-    /// priority rotations are advanced independently.
-    normal_cursor: usize,
-    priority_cursor: usize,
-    /// Count of completed normal hops since the last priority
-    /// sweep. When this hits `PRIORITY_CHECK_INTERVAL`, the next
-    /// rotation pass runs priority before normal.
+    /// Absolute position in `self.channels` to consider first on
+    /// the next `pick_next_channel` call. Wrap-around semantics
+    /// (`(i + 1) % channels.len()`) after every pick.
+    ///
+    /// Deliberately an absolute index rather than a position
+    /// inside a filtered sub-list: lockouts and channel-list
+    /// edits change the sub-list shape, but the absolute index
+    /// remains a stable anchor. Any channel that no longer
+    /// matches the selection criteria (locked / priority filter
+    /// mismatch) is just skipped by the forward scan — no
+    /// cursor rebase needed.
+    next_channel_idx: usize,
+    /// Count of completed NORMAL-ROTATION hops since the last
+    /// priority sweep. Only incremented in the normal-pick
+    /// branch of `pick_next_channel` — fallback (any-unlocked)
+    /// and priority-sweep picks do NOT advance this counter.
+    /// When it reaches `PRIORITY_CHECK_INTERVAL` AND there's at
+    /// least one unlocked priority channel, a priority sweep is
+    /// armed on the next pick.
     hops_since_priority_sweep: u32,
-    /// Set while a priority sweep is in progress.
-    in_priority_sweep: bool,
+    /// Channel keys visited during the current priority sweep.
+    /// `None` means no sweep in progress; `Some(set)` means the
+    /// scanner is mid-sweep and the set tracks which priority
+    /// channels have already been picked this sweep. When the
+    /// set size equals the count of priority+unlocked channels,
+    /// the sweep ends and normal rotation resumes.
+    ///
+    /// Using `Option<HashSet>` rather than `HashSet::new()` as a
+    /// sentinel because an empty in-progress sweep (just
+    /// started, no picks yet) and a non-sweep state must be
+    /// distinguishable.
+    priority_sweep_visited: Option<HashSet<ChannelKey>>,
     /// Latched squelch state. Updated on every `SquelchEdge`
     /// event regardless of phase so a persistent-open carrier
     /// that triggered during the settle window (where phase
@@ -114,10 +136,9 @@ impl Default for Scanner {
             channels: Vec::new(),
             locked_out: HashSet::new(),
             phase: Phase::Idle,
-            normal_cursor: 0,
-            priority_cursor: 0,
+            next_channel_idx: 0,
             hops_since_priority_sweep: 0,
-            in_priority_sweep: false,
+            priority_sweep_visited: None,
             squelch_open: false,
         }
     }
@@ -164,10 +185,9 @@ impl Scanner {
             // starts fresh rather than carrying stale lockouts or
             // mid-cycle rotation cursors into the next session.
             self.locked_out.clear();
-            self.normal_cursor = 0;
-            self.priority_cursor = 0;
+            self.next_channel_idx = 0;
             self.hops_since_priority_sweep = 0;
-            self.in_priority_sweep = false;
+            self.priority_sweep_visited = None;
             self.stop_rotation()
         }
     }
@@ -185,13 +205,13 @@ impl Scanner {
         }
         // Currently-scanning mid-list-change: recover from wherever
         // the phase left us by re-starting rotation. Also reset
-        // the priority-hop counter so a list edit doesn't trigger
-        // an immediate priority sweep just because the pre-edit
+        // the rotation cursor + sweep state + hops counter so a
+        // list edit doesn't leave stale pointers or trigger an
+        // immediate priority sweep just because the pre-edit
         // session had accumulated hops.
-        self.normal_cursor = 0;
-        self.priority_cursor = 0;
+        self.next_channel_idx = 0;
         self.hops_since_priority_sweep = 0;
-        self.in_priority_sweep = false;
+        self.priority_sweep_visited = None;
         self.start_rotation()
     }
 
@@ -256,108 +276,101 @@ impl Scanner {
     /// priority-sweep state. Returns None if no scannable+unlocked
     /// channels exist.
     fn pick_next_channel(&mut self) -> Option<usize> {
-        // Trigger priority sweep if due.
-        if !self.in_priority_sweep
+        if self.channels.is_empty() {
+            return None;
+        }
+
+        // Arm a priority sweep if hops since last sweep crossed
+        // the threshold AND at least one unlocked priority
+        // channel exists.
+        if self.priority_sweep_visited.is_none()
             && self.hops_since_priority_sweep >= PRIORITY_CHECK_INTERVAL
             && self
                 .channels
                 .iter()
-                .any(|c| c.priority >= MIN_PRIORITY_TIER)
+                .any(|c| c.priority >= MIN_PRIORITY_TIER && !self.locked_out.contains(&c.key))
         {
-            self.in_priority_sweep = true;
-            self.priority_cursor = 0;
+            self.priority_sweep_visited = Some(HashSet::new());
         }
 
-        if self.in_priority_sweep {
-            let is_priority = |c: &ScannerChannel| {
-                c.priority >= MIN_PRIORITY_TIER && !self.locked_out.contains(&c.key)
-            };
-            let pri_count = self.count_matching(is_priority);
-            if self.priority_cursor < pri_count {
-                if let Some(chosen) = self.nth_matching(self.priority_cursor, is_priority) {
-                    self.priority_cursor += 1;
-                    return Some(chosen);
+        // --- Priority sweep path ---
+        if self.priority_sweep_visited.is_some() {
+            let chosen = self.scan_forward(|c| {
+                c.priority >= MIN_PRIORITY_TIER
+                    && !self.locked_out.contains(&c.key)
+                    && !self
+                        .priority_sweep_visited
+                        .as_ref()
+                        .is_some_and(|v| v.contains(&c.key))
+            });
+            if let Some(idx) = chosen {
+                let key = self.channels[idx].key.clone();
+                if let Some(visited) = self.priority_sweep_visited.as_mut() {
+                    visited.insert(key);
                 }
-                // Invariant violation: cursor < count but nth returned
-                // None. Should be impossible — assert in debug, recover
-                // in release by treating the sweep as exhausted and
-                // falling through to normal rotation.
-                debug_assert!(
-                    false,
-                    "priority_cursor < pri_count but nth_matching returned None"
-                );
+                self.advance_cursor_past(idx);
+                return Some(idx);
             }
-            // Priority sweep exhausted (or invariant-fallback).
-            self.in_priority_sweep = false;
-            self.priority_cursor = 0;
+            // Sweep exhausted — no more unvisited + unlocked priorities.
+            self.priority_sweep_visited = None;
             self.hops_since_priority_sweep = 0;
             // Fall through to normal rotation.
         }
 
-        let is_normal = |c: &ScannerChannel| c.priority == 0 && !self.locked_out.contains(&c.key);
-        let normal_count = self.count_matching(is_normal);
+        // --- Normal rotation path ---
+        if let Some(idx) =
+            self.scan_forward(|c| c.priority == 0 && !self.locked_out.contains(&c.key))
+        {
+            self.advance_cursor_past(idx);
+            // Only normal-rotation picks count toward the next
+            // priority sweep. Fallback (any-unlocked) and sweep
+            // picks do NOT — they don't represent "normal hops
+            // seen between sweeps."
+            self.hops_since_priority_sweep = self.hops_since_priority_sweep.saturating_add(1);
+            return Some(idx);
+        }
 
-        if normal_count == 0 {
-            // No normal channels — fall back to any unlocked channel
-            // (priority-only lists).
-            let is_unlocked = |c: &ScannerChannel| !self.locked_out.contains(&c.key);
-            let any_count = self.count_matching(is_unlocked);
-            if any_count == 0 {
-                return None;
-            }
-            if self.normal_cursor >= any_count {
-                self.normal_cursor = 0;
-            }
-            let chosen = self.nth_matching(self.normal_cursor, is_unlocked);
-            debug_assert!(
-                chosen.is_some(),
-                "normal_cursor < any_count but nth_matching returned None"
-            );
-            if let Some(chosen) = chosen {
-                self.normal_cursor = (self.normal_cursor + 1) % any_count;
-                return Some(chosen);
-            }
+        // --- Fallback: any unlocked channel (priority-only lists) ---
+        if let Some(idx) = self.scan_forward(|c| !self.locked_out.contains(&c.key)) {
+            self.advance_cursor_past(idx);
+            // Deliberately NOT incrementing `hops_since_priority_sweep`
+            // here: on a priority-only list there is no "normal
+            // rotation" to count against, and arming another
+            // sweep would be redundant (the fallback is already
+            // visiting priorities) — could cause out-of-order
+            // replay via sweep↔fallback mode flipping.
+            return Some(idx);
+        }
+
+        None
+    }
+
+    /// Scan `self.channels` starting at `next_channel_idx`, wrapping
+    /// around once, returning the index of the first channel that
+    /// satisfies `predicate`. Allocation-free; single pass.
+    fn scan_forward<F>(&self, predicate: F) -> Option<usize>
+    where
+        F: Fn(&ScannerChannel) -> bool,
+    {
+        let n = self.channels.len();
+        if n == 0 {
             return None;
         }
-
-        if self.normal_cursor >= normal_count {
-            self.normal_cursor = 0;
-        }
-        let chosen = self.nth_matching(self.normal_cursor, is_normal);
-        debug_assert!(
-            chosen.is_some(),
-            "normal_cursor < normal_count but nth_matching returned None"
-        );
-        if let Some(chosen) = chosen {
-            self.normal_cursor = (self.normal_cursor + 1) % normal_count;
-            Some(chosen)
-        } else {
-            None
-        }
+        (0..n)
+            .map(|offset| (self.next_channel_idx + offset) % n)
+            .find(|&idx| predicate(&self.channels[idx]))
     }
 
-    /// Count channels matching `predicate`. Allocation-free —
-    /// single pass over `self.channels`.
-    fn count_matching<F>(&self, predicate: F) -> usize
-    where
-        F: Fn(&ScannerChannel) -> bool,
-    {
-        self.channels.iter().filter(|c| predicate(c)).count()
-    }
-
-    /// Index (into `self.channels`) of the `n`th channel matching
-    /// `predicate`. Allocation-free — uses `Iterator::nth` which
-    /// streams without collecting.
-    fn nth_matching<F>(&self, n: usize, predicate: F) -> Option<usize>
-    where
-        F: Fn(&ScannerChannel) -> bool,
-    {
-        self.channels
-            .iter()
-            .enumerate()
-            .filter(|(_, c)| predicate(c))
-            .nth(n)
-            .map(|(i, _)| i)
+    /// Advance the absolute cursor past the just-picked index so
+    /// the next `scan_forward` starts at the subsequent position
+    /// (with wrap).
+    fn advance_cursor_past(&mut self, idx: usize) {
+        let n = self.channels.len();
+        if n == 0 {
+            self.next_channel_idx = 0;
+            return;
+        }
+        self.next_channel_idx = (idx + 1) % n;
     }
 
     fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
@@ -1085,9 +1098,11 @@ mod tests {
         s.handle_event(ScannerEvent::SetEnabled(false));
         // Session state should be fully clear after disable.
         assert!(s.locked_out.is_empty(), "locked_out not cleared on disable");
-        assert_eq!(s.normal_cursor, 0);
-        assert_eq!(s.priority_cursor, 0);
+        assert_eq!(s.next_channel_idx, 0);
         assert_eq!(s.hops_since_priority_sweep, 0);
-        assert!(!s.in_priority_sweep);
+        assert!(
+            s.priority_sweep_visited.is_none(),
+            "priority sweep state not cleared on disable"
+        );
     }
 }

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -422,8 +422,11 @@ impl Scanner {
 
     fn handle_lockout(&mut self, key: ChannelKey) -> Vec<ScannerCommand> {
         self.locked_out.insert(key);
-        // TODO (Task 1.7): if active channel got locked out,
-        // advance rotation.
+        // Locked-out channels are filtered at `pick_next_channel`
+        // time, so the currently-active channel (if locked) will
+        // be skipped on the next rotation advance (dwell timeout,
+        // hang timeout, or squelch close → hang → advance). No
+        // explicit eviction needed here for Phase 1.
         Vec::new()
     }
 
@@ -623,5 +626,137 @@ mod tests {
             c,
             ScannerCommand::Retune { freq_hz: 162_550_000, .. }
         )));
+    }
+
+    #[test]
+    fn priority_sweep_triggers_after_interval_hops() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+            ch("P", 121_500_000, 1), // priority
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+
+        // Burn through 5+ normal hops. Each hop = Retuning→Dwelling→advance.
+        // Need to settle (tick past 30ms), then timeout dwell (tick past 100ms).
+        let mut retune_freqs: Vec<u64> = Vec::new();
+        for _ in 0..6 {
+            s.handle_event(tick(1500)); // settle
+            let cmds = s.handle_event(tick(5000)); // dwell timeout → next retune
+            for c in &cmds {
+                if let ScannerCommand::Retune { freq_hz, .. } = c {
+                    retune_freqs.push(*freq_hz);
+                }
+            }
+        }
+        // After 5 normal hops, the priority channel should have appeared.
+        assert!(
+            retune_freqs.contains(&121_500_000),
+            "priority channel should have appeared after 5 normal hops, got {retune_freqs:?}"
+        );
+    }
+
+    #[test]
+    fn lockout_skips_channel() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::LockoutChannel(ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        }));
+        let commands = s.handle_event(ScannerEvent::SetEnabled(true));
+        // First retune should skip A and go to B.
+        let first_retune = commands.iter().find_map(|c| match c {
+            ScannerCommand::Retune { freq_hz, .. } => Some(*freq_hz),
+            _ => None,
+        });
+        assert_eq!(first_retune, Some(162_550_000));
+    }
+
+    #[test]
+    fn all_channels_locked_emits_empty_rotation() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::LockoutChannel(ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        }));
+        let commands = s.handle_event(ScannerEvent::SetEnabled(true));
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::EmptyRotation)));
+        assert_eq!(s.state(), ScannerState::Idle);
+    }
+
+    #[test]
+    fn channel_override_respected_for_dwell() {
+        let mut s = Scanner::new();
+        let mut longer = ch("L", 146_520_000, 0);
+        longer.dwell_ms = 500;
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            longer,
+            ch("N", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // Settle.
+        s.handle_event(tick(1500));
+        // Default dwell would be 100ms = 4800 samples. Channel
+        // overrides to 500ms = 24000 samples. Tick 5000 — should
+        // still be Dwelling (not advanced) because override kicks in.
+        s.handle_event(tick(5000));
+        assert_eq!(s.state(), ScannerState::Dwelling);
+        // Tick past 500ms → advance.
+        s.handle_event(tick(25_000));
+        assert_eq!(s.state(), ScannerState::Retuning);
+    }
+
+    #[test]
+    fn channels_changed_mid_scan_recovers() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(1500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+        // User deletes channel B and adds C.
+        let commands = s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("C", 28_400_000, 0),
+        ]));
+        // Scanner recovers by restarting rotation at cursor 0.
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // First retune after list change goes to A.
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::Retune { freq_hz: 146_520_000, .. })));
+    }
+
+    #[test]
+    fn lockout_cleared_when_channel_removed() {
+        let mut s = Scanner::new();
+        let key_a = ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        };
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::LockoutChannel(key_a.clone()));
+        // Remove A.
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch(
+            "B",
+            162_550_000,
+            0,
+        )]));
+        // Internal set should have pruned.
+        assert!(!s.locked_out.contains(&key_a));
     }
 }

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -4,6 +4,7 @@
 //! returned commands.
 
 use std::collections::HashSet;
+use std::num::NonZeroU32;
 
 use crate::channel::{ChannelKey, ScannerChannel};
 use crate::commands::ScannerCommand;
@@ -371,17 +372,11 @@ impl Scanner {
     fn handle_sample_tick(
         &mut self,
         samples_consumed: u32,
-        sample_rate_hz: u32,
+        sample_rate_hz: NonZeroU32,
     ) -> Vec<ScannerCommand> {
-        if sample_rate_hz == 0 {
-            // `ms_to_samples(_, 0)` returns 0, which would make
-            // every seeded timer expire on first tick — settle
-            // immediately "complete", dwell immediately "time
-            // out", etc. Drop the tick; debug builds assert the
-            // caller invariant.
-            debug_assert!(false, "sample_rate_hz must be > 0");
-            return Vec::new();
-        }
+        // `sample_rate_hz > 0` is now enforced at the event-type
+        // level via `NonZeroU32` — no runtime guard needed.
+        let sample_rate_hz = sample_rate_hz.get();
         let samples = u64::from(samples_consumed);
         let next_phase: Option<Phase> = match &mut self.phase {
             Phase::Idle | Phase::Listening { .. } => return Vec::new(),
@@ -664,7 +659,7 @@ mod tests {
     fn tick(samples: u32) -> ScannerEvent {
         ScannerEvent::SampleTick {
             samples_consumed: samples,
-            sample_rate_hz: RATE,
+            sample_rate_hz: NonZeroU32::new(RATE).expect("RATE > 0"),
         }
     }
 

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -121,15 +121,156 @@ impl Scanner {
     // --- Event handlers (stub bodies; next tasks fill in) -----
 
     fn handle_set_enabled(&mut self, enabled: bool) -> Vec<ScannerCommand> {
-        // TODO (Task 1.5): Idle↔Retuning transitions.
-        let _ = enabled;
-        Vec::new()
+        if self.enabled == enabled {
+            return Vec::new();
+        }
+        self.enabled = enabled;
+        if enabled {
+            self.start_rotation()
+        } else {
+            self.stop_rotation()
+        }
     }
 
     fn handle_channels_changed(&mut self, channels: Vec<ScannerChannel>) -> Vec<ScannerCommand> {
-        // TODO (Task 1.5): list swap + rotation recovery.
         self.channels = channels;
-        Vec::new()
+        // Any stale lockout keys for channels that no longer exist
+        // are harmless (the set is only consulted against the
+        // live channel list), but we'll prune for cleanliness.
+        let valid: HashSet<ChannelKey> =
+            self.channels.iter().map(|c| c.key.clone()).collect();
+        self.locked_out.retain(|k| valid.contains(k));
+
+        if !self.enabled {
+            return Vec::new();
+        }
+        // Currently-scanning mid-list-change: recover from wherever
+        // the phase left us by re-starting rotation.
+        self.normal_cursor = 0;
+        self.priority_cursor = 0;
+        self.in_priority_sweep = false;
+        self.start_rotation()
+    }
+
+    /// Begin or resume rotation from the current cursor. Emits
+    /// Retune + MuteAudio + ActiveChannelChanged + StateChanged.
+    /// Returns EmptyRotation if no scannable + unlocked channels
+    /// exist, and transitions to Idle.
+    fn start_rotation(&mut self) -> Vec<ScannerCommand> {
+        let Some(idx) = self.pick_next_channel() else {
+            // No scannable channels available.
+            self.phase = Phase::Idle;
+            return vec![
+                ScannerCommand::EmptyRotation,
+                ScannerCommand::MuteAudio(false),
+                ScannerCommand::ActiveChannelChanged(None),
+                ScannerCommand::StateChanged(ScannerState::Idle),
+            ];
+        };
+        self.enter_retuning(idx)
+    }
+
+    fn stop_rotation(&mut self) -> Vec<ScannerCommand> {
+        self.phase = Phase::Idle;
+        vec![
+            ScannerCommand::MuteAudio(false),
+            ScannerCommand::ActiveChannelChanged(None),
+            ScannerCommand::StateChanged(ScannerState::Idle),
+        ]
+    }
+
+    /// Emit the retune command set for the given channel index
+    /// and move to Retuning phase. Settle window initialized on
+    /// the first SampleTick after entering Retuning (the sample
+    /// rate isn't known here).
+    fn enter_retuning(&mut self, idx: usize) -> Vec<ScannerCommand> {
+        let channel = &self.channels[idx];
+        self.phase = Phase::Retuning {
+            target_idx: idx,
+            samples_until_settled: 0, // seeded on first SampleTick
+        };
+        vec![
+            ScannerCommand::Retune {
+                freq_hz: channel.frequency_hz,
+                demod_mode: channel.demod_mode,
+                bandwidth: channel.bandwidth,
+                ctcss: channel.ctcss.clone(),
+                voice_squelch: channel.voice_squelch,
+            },
+            ScannerCommand::MuteAudio(true),
+            ScannerCommand::ActiveChannelChanged(Some(channel.key.clone())),
+            ScannerCommand::StateChanged(ScannerState::Retuning),
+        ]
+    }
+
+    /// Pick the next channel to scan given current cursor and
+    /// priority-sweep state. Returns None if no scannable+unlocked
+    /// channels exist.
+    fn pick_next_channel(&mut self) -> Option<usize> {
+        // Trigger priority sweep if due.
+        if !self.in_priority_sweep
+            && self.hops_since_priority_sweep >= PRIORITY_CHECK_INTERVAL
+            && self.channels.iter().any(|c| c.priority >= 1)
+        {
+            self.in_priority_sweep = true;
+            self.priority_cursor = 0;
+        }
+
+        if self.in_priority_sweep {
+            let pri_indices: Vec<usize> = self
+                .channels
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| c.priority >= 1 && !self.locked_out.contains(&c.key))
+                .map(|(i, _)| i)
+                .collect();
+            if self.priority_cursor < pri_indices.len() {
+                let chosen = pri_indices[self.priority_cursor];
+                self.priority_cursor += 1;
+                return Some(chosen);
+            }
+            // Priority sweep exhausted.
+            self.in_priority_sweep = false;
+            self.priority_cursor = 0;
+            self.hops_since_priority_sweep = 0;
+            // Fall through to normal rotation.
+        }
+
+        let normal_indices: Vec<usize> = self
+            .channels
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.priority == 0 && !self.locked_out.contains(&c.key))
+            .map(|(i, _)| i)
+            .collect();
+
+        if normal_indices.is_empty() {
+            // If no normal channels, fall back to any unlocked
+            // channel (priority-only lists).
+            let any_unlocked: Vec<usize> = self
+                .channels
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| !self.locked_out.contains(&c.key))
+                .map(|(i, _)| i)
+                .collect();
+            if any_unlocked.is_empty() {
+                return None;
+            }
+            if self.normal_cursor >= any_unlocked.len() {
+                self.normal_cursor = 0;
+            }
+            let chosen = any_unlocked[self.normal_cursor];
+            self.normal_cursor = (self.normal_cursor + 1) % any_unlocked.len();
+            return Some(chosen);
+        }
+
+        if self.normal_cursor >= normal_indices.len() {
+            self.normal_cursor = 0;
+        }
+        let chosen = normal_indices[self.normal_cursor];
+        self.normal_cursor = (self.normal_cursor + 1) % normal_indices.len();
+        Some(chosen)
     }
 
     fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
@@ -170,4 +311,75 @@ impl Scanner {
 fn ms_to_samples(ms: u32, sample_rate_hz: u32) -> u64 {
     // (ms * rate + 999) / 1000 — ceiling division.
     (u64::from(ms) * u64::from(sample_rate_hz) + 999) / 1000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sdr_types::DemodMode;
+
+    fn ch(name: &str, freq: u64, priority: u8) -> ScannerChannel {
+        ScannerChannel {
+            key: ChannelKey {
+                name: name.to_string(),
+                frequency_hz: freq,
+            },
+            frequency_hz: freq,
+            demod_mode: DemodMode::Nfm,
+            bandwidth: 12_500.0,
+            ctcss: None,
+            voice_squelch: None,
+            priority,
+            dwell_ms: DEFAULT_DWELL_MS,
+            hang_ms: DEFAULT_HANG_MS,
+        }
+    }
+
+    #[test]
+    fn enable_with_channels_transitions_to_retuning() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        let commands = s.handle_event(ScannerEvent::SetEnabled(true));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // Expect Retune → MuteAudio(true) → ActiveChannelChanged → StateChanged
+        assert!(matches!(commands[0], ScannerCommand::Retune { freq_hz: 146_520_000, .. }));
+        assert!(matches!(commands[1], ScannerCommand::MuteAudio(true)));
+        assert!(matches!(
+            commands[2],
+            ScannerCommand::ActiveChannelChanged(Some(_))
+        ));
+        assert!(matches!(
+            commands[3],
+            ScannerCommand::StateChanged(ScannerState::Retuning)
+        ));
+    }
+
+    #[test]
+    fn disable_emits_idle_transition() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        let commands = s.handle_event(ScannerEvent::SetEnabled(false));
+        assert_eq!(s.state(), ScannerState::Idle);
+        assert!(matches!(commands[0], ScannerCommand::MuteAudio(false)));
+        assert!(matches!(
+            commands[1],
+            ScannerCommand::ActiveChannelChanged(None)
+        ));
+        assert!(matches!(
+            commands[2],
+            ScannerCommand::StateChanged(ScannerState::Idle)
+        ));
+    }
+
+    #[test]
+    fn enable_with_no_channels_emits_empty_rotation() {
+        let mut s = Scanner::new();
+        let commands = s.handle_event(ScannerEvent::SetEnabled(true));
+        assert_eq!(s.state(), ScannerState::Idle);
+        assert!(matches!(commands[0], ScannerCommand::EmptyRotation));
+    }
 }

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -1,0 +1,173 @@
+//! Scanner state machine. Owns rotation position, phase, timing
+//! counters, and session lockouts. No threading, no I/O — the
+//! DSP controller drives it via `handle_event` and applies the
+//! returned commands.
+
+use std::collections::HashSet;
+
+use crate::channel::{ChannelKey, ScannerChannel};
+use crate::commands::ScannerCommand;
+use crate::events::{ScannerEvent, SquelchState};
+use crate::state::ScannerState;
+use crate::{DEFAULT_DWELL_MS, DEFAULT_HANG_MS, PRIORITY_CHECK_INTERVAL, SETTLE_MS};
+
+/// Internal phase carrying per-phase bookkeeping. The outer
+/// `ScannerState` surfaced to the UI is a flattened view of this.
+#[derive(Debug, Clone)]
+enum Phase {
+    Idle,
+    Retuning {
+        target_idx: usize,
+        samples_until_settled: u64,
+    },
+    Dwelling {
+        idx: usize,
+        samples_until_timeout: u64,
+    },
+    Listening {
+        idx: usize,
+    },
+    Hanging {
+        idx: usize,
+        samples_until_timeout: u64,
+    },
+}
+
+impl Phase {
+    fn as_state(&self) -> ScannerState {
+        match self {
+            Phase::Idle => ScannerState::Idle,
+            Phase::Retuning { .. } => ScannerState::Retuning,
+            Phase::Dwelling { .. } => ScannerState::Dwelling,
+            Phase::Listening { .. } => ScannerState::Listening,
+            Phase::Hanging { .. } => ScannerState::Hanging,
+        }
+    }
+}
+
+/// Scanner state machine. Instantiate once, feed events, apply
+/// emitted commands. All methods are synchronous and cheap.
+pub struct Scanner {
+    enabled: bool,
+    channels: Vec<ScannerChannel>,
+    locked_out: HashSet<ChannelKey>,
+    default_dwell_ms: u32,
+    default_hang_ms: u32,
+    phase: Phase,
+    /// Rotation index into the current sub-list. Normal and
+    /// priority rotations are advanced independently.
+    normal_cursor: usize,
+    priority_cursor: usize,
+    /// Count of completed normal hops since the last priority
+    /// sweep. When this hits `PRIORITY_CHECK_INTERVAL`, the next
+    /// rotation pass runs priority before normal.
+    hops_since_priority_sweep: u32,
+    /// Set while a priority sweep is in progress.
+    in_priority_sweep: bool,
+}
+
+impl Default for Scanner {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            channels: Vec::new(),
+            locked_out: HashSet::new(),
+            default_dwell_ms: DEFAULT_DWELL_MS,
+            default_hang_ms: DEFAULT_HANG_MS,
+            phase: Phase::Idle,
+            normal_cursor: 0,
+            priority_cursor: 0,
+            hops_since_priority_sweep: 0,
+            in_priority_sweep: false,
+        }
+    }
+}
+
+impl Scanner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Current public-facing phase. Cheap (no allocation).
+    pub fn state(&self) -> ScannerState {
+        self.phase.as_state()
+    }
+
+    /// Feed an event, receive zero or more commands. Commands
+    /// are returned in order of emission — caller applies them
+    /// in sequence.
+    pub fn handle_event(&mut self, event: ScannerEvent) -> Vec<ScannerCommand> {
+        match event {
+            ScannerEvent::SetEnabled(enabled) => self.handle_set_enabled(enabled),
+            ScannerEvent::ChannelsChanged(channels) => self.handle_channels_changed(channels),
+            ScannerEvent::SquelchEdge(state) => self.handle_squelch_edge(state),
+            ScannerEvent::SampleTick {
+                samples_consumed,
+                sample_rate_hz,
+            } => self.handle_sample_tick(samples_consumed, sample_rate_hz),
+            ScannerEvent::LockoutChannel(key) => self.handle_lockout(key),
+            ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(key),
+            ScannerEvent::SetDefaultDwellMs(ms) => {
+                self.default_dwell_ms = ms;
+                Vec::new()
+            }
+            ScannerEvent::SetDefaultHangMs(ms) => {
+                self.default_hang_ms = ms;
+                Vec::new()
+            }
+        }
+    }
+
+    // --- Event handlers (stub bodies; next tasks fill in) -----
+
+    fn handle_set_enabled(&mut self, enabled: bool) -> Vec<ScannerCommand> {
+        // TODO (Task 1.5): Idle↔Retuning transitions.
+        let _ = enabled;
+        Vec::new()
+    }
+
+    fn handle_channels_changed(&mut self, channels: Vec<ScannerChannel>) -> Vec<ScannerCommand> {
+        // TODO (Task 1.5): list swap + rotation recovery.
+        self.channels = channels;
+        Vec::new()
+    }
+
+    fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
+        // TODO (Task 1.6): honor post-settle; drive Dwelling→Listening
+        // and Listening→Hanging transitions.
+        let _ = state;
+        Vec::new()
+    }
+
+    fn handle_sample_tick(
+        &mut self,
+        samples_consumed: u32,
+        sample_rate_hz: u32,
+    ) -> Vec<ScannerCommand> {
+        // TODO (Task 1.6): countdown settle / dwell / hang windows,
+        // advance on timeout.
+        let _ = (samples_consumed, sample_rate_hz);
+        Vec::new()
+    }
+
+    fn handle_lockout(&mut self, key: ChannelKey) -> Vec<ScannerCommand> {
+        self.locked_out.insert(key);
+        // TODO (Task 1.7): if active channel got locked out,
+        // advance rotation.
+        Vec::new()
+    }
+
+    fn handle_unlockout(&mut self, key: ChannelKey) -> Vec<ScannerCommand> {
+        self.locked_out.remove(&key);
+        Vec::new()
+    }
+}
+
+/// Convert ms to samples at the given sample rate. Rounded up so
+/// a 30 ms window at 48000 Hz = 1440 samples (exact), and a 30 ms
+/// at 44100 = 1323. Caller uses this to seed `samples_until_*`.
+#[allow(clippy::cast_possible_truncation)]
+fn ms_to_samples(ms: u32, sample_rate_hz: u32) -> u64 {
+    // (ms * rate + 999) / 1000 — ceiling division.
+    (u64::from(ms) * u64::from(sample_rate_hz) + 999) / 1000
+}

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -269,17 +269,15 @@ impl Scanner {
         }
 
         if self.in_priority_sweep {
-            let pri_indices: Vec<usize> = self
-                .channels
-                .iter()
-                .enumerate()
-                .filter(|(_, c)| {
-                    c.priority >= MIN_PRIORITY_TIER && !self.locked_out.contains(&c.key)
-                })
-                .map(|(i, _)| i)
-                .collect();
-            if self.priority_cursor < pri_indices.len() {
-                let chosen = pri_indices[self.priority_cursor];
+            let pri_count = self.count_matching(|c| {
+                c.priority >= MIN_PRIORITY_TIER && !self.locked_out.contains(&c.key)
+            });
+            if self.priority_cursor < pri_count {
+                let chosen = self
+                    .nth_matching(self.priority_cursor, |c| {
+                        c.priority >= MIN_PRIORITY_TIER && !self.locked_out.contains(&c.key)
+                    })
+                    .expect("priority_cursor < pri_count guarantees a match");
                 self.priority_cursor += 1;
                 return Some(chosen);
             }
@@ -290,41 +288,60 @@ impl Scanner {
             // Fall through to normal rotation.
         }
 
-        let normal_indices: Vec<usize> = self
-            .channels
-            .iter()
-            .enumerate()
-            .filter(|(_, c)| c.priority == 0 && !self.locked_out.contains(&c.key))
-            .map(|(i, _)| i)
-            .collect();
+        let normal_count =
+            self.count_matching(|c| c.priority == 0 && !self.locked_out.contains(&c.key));
 
-        if normal_indices.is_empty() {
-            // If no normal channels, fall back to any unlocked
-            // channel (priority-only lists).
-            let any_unlocked: Vec<usize> = self
-                .channels
-                .iter()
-                .enumerate()
-                .filter(|(_, c)| !self.locked_out.contains(&c.key))
-                .map(|(i, _)| i)
-                .collect();
-            if any_unlocked.is_empty() {
+        if normal_count == 0 {
+            // No normal channels — fall back to any unlocked channel
+            // (priority-only lists).
+            let any_count = self.count_matching(|c| !self.locked_out.contains(&c.key));
+            if any_count == 0 {
                 return None;
             }
-            if self.normal_cursor >= any_unlocked.len() {
+            if self.normal_cursor >= any_count {
                 self.normal_cursor = 0;
             }
-            let chosen = any_unlocked[self.normal_cursor];
-            self.normal_cursor = (self.normal_cursor + 1) % any_unlocked.len();
+            let chosen = self
+                .nth_matching(self.normal_cursor, |c| !self.locked_out.contains(&c.key))
+                .expect("normal_cursor < any_count guarantees a match");
+            self.normal_cursor = (self.normal_cursor + 1) % any_count;
             return Some(chosen);
         }
 
-        if self.normal_cursor >= normal_indices.len() {
+        if self.normal_cursor >= normal_count {
             self.normal_cursor = 0;
         }
-        let chosen = normal_indices[self.normal_cursor];
-        self.normal_cursor = (self.normal_cursor + 1) % normal_indices.len();
+        let chosen = self
+            .nth_matching(self.normal_cursor, |c| {
+                c.priority == 0 && !self.locked_out.contains(&c.key)
+            })
+            .expect("normal_cursor < normal_count guarantees a match");
+        self.normal_cursor = (self.normal_cursor + 1) % normal_count;
         Some(chosen)
+    }
+
+    /// Count channels matching `predicate`. Allocation-free —
+    /// single pass over `self.channels`.
+    fn count_matching<F>(&self, predicate: F) -> usize
+    where
+        F: Fn(&ScannerChannel) -> bool,
+    {
+        self.channels.iter().filter(|c| predicate(c)).count()
+    }
+
+    /// Index (into `self.channels`) of the `n`th channel matching
+    /// `predicate`. Allocation-free — uses `Iterator::nth` which
+    /// streams without collecting.
+    fn nth_matching<F>(&self, n: usize, predicate: F) -> Option<usize>
+    where
+        F: Fn(&ScannerChannel) -> bool,
+    {
+        self.channels
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| predicate(c))
+            .nth(n)
+            .map(|(i, _)| i)
     }
 
     fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
@@ -506,13 +523,36 @@ impl Scanner {
     }
 
     fn handle_lockout(&mut self, key: ChannelKey) -> Vec<ScannerCommand> {
+        // If the user locks out the currently-active channel, the
+        // "skip on next rotation advance" strategy isn't enough:
+        // a persistent-open carrier never triggers an advance
+        // (no dwell-timeout / hang-elapse / squelch-close fires),
+        // so the scanner would sit indefinitely on a channel the
+        // user just asked to skip. Force-advance now.
+        let lock_current = self.enabled
+            && self
+                .current_channel_key()
+                .is_some_and(|current| current == &key);
         self.locked_out.insert(key);
-        // Locked-out channels are filtered at `pick_next_channel`
-        // time, so the currently-active channel (if locked) will
-        // be skipped on the next rotation advance (dwell timeout,
-        // hang timeout, or squelch close → hang → advance). No
-        // explicit eviction needed here for Phase 1.
-        Vec::new()
+        if lock_current {
+            self.advance_rotation()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Identity of the channel the scanner currently considers
+    /// active, regardless of phase. Returns `None` when idle or
+    /// mid-transition-marker (which should never persist in
+    /// `self.phase` anyway).
+    fn current_channel_key(&self) -> Option<&ChannelKey> {
+        match &self.phase {
+            Phase::Retuning { target_idx, .. } => self.channels.get(*target_idx).map(|c| &c.key),
+            Phase::Dwelling { idx, .. } | Phase::Listening { idx } | Phase::Hanging { idx, .. } => {
+                self.channels.get(*idx).map(|c| &c.key)
+            }
+            Phase::Idle | Phase::AdvanceFromDwell | Phase::AdvanceFromHang => None,
+        }
     }
 
     fn handle_unlockout(&mut self, key: &ChannelKey) -> Vec<ScannerCommand> {
@@ -941,6 +981,40 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, ScannerCommand::MuteAudio(false)))
         );
+    }
+
+    #[test]
+    fn lockout_of_active_channel_advances_immediately() {
+        // Real scenario: scanner stopped on a channel with a
+        // persistent-open carrier; user hits "lockout current
+        // channel" to escape. Without force-advance the scanner
+        // would sit forever — no dwell timeout, no hang-elapse,
+        // no squelch-close fires.
+        let mut s = Scanner::new();
+        let key_a = ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        };
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(TICK_PAST_SETTLE));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+
+        // Lockout the channel the scanner is currently listening on.
+        let commands = s.handle_event(ScannerEvent::LockoutChannel(key_a));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // Next channel in rotation is B.
+        assert!(commands.iter().any(|c| matches!(
+            c,
+            ScannerCommand::Retune {
+                freq_hz: 162_550_000,
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -364,11 +364,24 @@ impl Scanner {
         }
     }
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "state-machine match arms with per-phase countdown logic + downstream dispatch — splitting would fragment a single conceptual transition"
+    )]
     fn handle_sample_tick(
         &mut self,
         samples_consumed: u32,
         sample_rate_hz: u32,
     ) -> Vec<ScannerCommand> {
+        if sample_rate_hz == 0 {
+            // `ms_to_samples(_, 0)` returns 0, which would make
+            // every seeded timer expire on first tick — settle
+            // immediately "complete", dwell immediately "time
+            // out", etc. Drop the tick; debug builds assert the
+            // caller invariant.
+            debug_assert!(false, "sample_rate_hz must be > 0");
+            return Vec::new();
+        }
         let samples = u64::from(samples_consumed);
         let next_phase: Option<Phase> = match &mut self.phase {
             Phase::Idle | Phase::Listening { .. } => return Vec::new(),
@@ -605,8 +618,48 @@ mod tests {
         assert!(matches!(commands[0], ScannerCommand::EmptyRotation));
     }
 
-    /// 48 kHz rate, so 30ms settle = 1440 samples, 100ms dwell = 4800 samples.
+    /// Test sample rate. At 48 kHz, `SETTLE_MS = 30` resolves to
+    /// 1440 samples, `DEFAULT_DWELL_MS = 100` to 4800 samples,
+    /// and `DEFAULT_HANG_MS = 2000` to 96000 samples — the
+    /// constants below are sized to land inside / past those
+    /// windows with a small margin.
     const RATE: u32 = 48_000;
+
+    /// Sample count well short of the 1440-sample settle window.
+    /// Used when a test needs the scanner to be mid-settle
+    /// (ignoring edges, not yet transitioning to Dwelling).
+    const TICK_IN_SETTLE: u32 = 500;
+
+    /// Sample count that clears the 1440-sample settle window
+    /// with margin. Most tests use this to get past settle into
+    /// `Dwelling` (or directly `Listening` if squelch latched
+    /// open during settle).
+    const TICK_PAST_SETTLE: u32 = 1500;
+
+    /// Slightly larger settle-clearing tick used in the
+    /// persistent-open-carrier test, where two ticks are fed in
+    /// sequence and the second one must finish draining the
+    /// settle counter that was partially consumed by the first.
+    const TICK_SETTLE_COMPLETE: u32 = 2000;
+
+    /// Sample count that clears the 4800-sample default dwell
+    /// window (`DEFAULT_DWELL_MS = 100` at 48 kHz). Causes a
+    /// Dwelling → advance transition when squelch never opened.
+    const TICK_PAST_DWELL: u32 = 5000;
+
+    /// Sample count well inside the 96000-sample default hang
+    /// window. Used to advance part of the hang before a
+    /// squelch-reopen event.
+    const TICK_INSIDE_HANG: u32 = 10_000;
+
+    /// Sample count that clears a 500 ms channel-level dwell
+    /// override (= 24000 samples at 48 kHz) with margin. Used
+    /// by the `dwell_ms_override` test.
+    const TICK_PAST_OVERRIDE_DWELL: u32 = 25_000;
+
+    /// Sample count that clears the 96000-sample default hang
+    /// window with margin.
+    const TICK_PAST_HANG: u32 = 100_000;
 
     fn tick(samples: u32) -> ScannerEvent {
         ScannerEvent::SampleTick {
@@ -621,7 +674,7 @@ mod tests {
         s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
         s.handle_event(ScannerEvent::SetEnabled(true));
         // Feed a squelch open during the settle window.
-        s.handle_event(tick(500));
+        s.handle_event(tick(TICK_IN_SETTLE));
         let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         assert_eq!(s.state(), ScannerState::Retuning);
         // No MuteAudio(false) should have been emitted.
@@ -639,7 +692,7 @@ mod tests {
         s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
         s.handle_event(ScannerEvent::SetEnabled(true));
         // Elapse the settle window (1440 samples for 30ms at 48kHz).
-        s.handle_event(tick(1500));
+        s.handle_event(tick(TICK_PAST_SETTLE));
         assert_eq!(s.state(), ScannerState::Dwelling);
         let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         assert_eq!(s.state(), ScannerState::Listening);
@@ -659,10 +712,10 @@ mod tests {
         ]));
         s.handle_event(ScannerEvent::SetEnabled(true));
         // Skip settle window.
-        s.handle_event(tick(1500));
+        s.handle_event(tick(TICK_PAST_SETTLE));
         assert_eq!(s.state(), ScannerState::Dwelling);
         // Dwell is 100ms = 4800 samples at 48kHz. Tick past it.
-        let commands = s.handle_event(tick(5000));
+        let commands = s.handle_event(tick(TICK_PAST_DWELL));
         assert_eq!(s.state(), ScannerState::Retuning);
         // Should have retuned to channel B (frequency 162_550_000).
         assert!(commands.iter().any(|c| matches!(
@@ -679,7 +732,7 @@ mod tests {
         let mut s = Scanner::new();
         s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
         s.handle_event(ScannerEvent::SetEnabled(true));
-        s.handle_event(tick(1500));
+        s.handle_event(tick(TICK_PAST_SETTLE));
         s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         assert_eq!(s.state(), ScannerState::Listening);
         let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
@@ -696,12 +749,12 @@ mod tests {
         let mut s = Scanner::new();
         s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
         s.handle_event(ScannerEvent::SetEnabled(true));
-        s.handle_event(tick(1500));
+        s.handle_event(tick(TICK_PAST_SETTLE));
         s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
         assert_eq!(s.state(), ScannerState::Hanging);
         // Advance partway into hang (2000ms hang = 96000 samples).
-        s.handle_event(tick(10_000));
+        s.handle_event(tick(TICK_INSIDE_HANG));
         let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         assert_eq!(s.state(), ScannerState::Listening);
         assert!(
@@ -719,10 +772,10 @@ mod tests {
             ch("B", 162_550_000, 0),
         ]));
         s.handle_event(ScannerEvent::SetEnabled(true));
-        s.handle_event(tick(1500));
+        s.handle_event(tick(TICK_PAST_SETTLE));
         s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
-        let commands = s.handle_event(tick(100_000));
+        let commands = s.handle_event(tick(TICK_PAST_HANG));
         assert_eq!(s.state(), ScannerState::Retuning);
         assert!(commands.iter().any(|c| matches!(
             c,
@@ -747,8 +800,8 @@ mod tests {
         // Need to settle (tick past 30ms), then timeout dwell (tick past 100ms).
         let mut retune_freqs: Vec<u64> = Vec::new();
         for _ in 0..6 {
-            s.handle_event(tick(1500)); // settle
-            let cmds = s.handle_event(tick(5000)); // dwell timeout → next retune
+            s.handle_event(tick(TICK_PAST_SETTLE)); // settle
+            let cmds = s.handle_event(tick(TICK_PAST_DWELL)); // dwell timeout → next retune
             for c in &cmds {
                 if let ScannerCommand::Retune { freq_hz, .. } = c {
                     retune_freqs.push(*freq_hz);
@@ -810,14 +863,14 @@ mod tests {
         ]));
         s.handle_event(ScannerEvent::SetEnabled(true));
         // Settle.
-        s.handle_event(tick(1500));
+        s.handle_event(tick(TICK_PAST_SETTLE));
         // Default dwell would be 100ms = 4800 samples. Channel
         // overrides to 500ms = 24000 samples. Tick 5000 — should
         // still be Dwelling (not advanced) because override kicks in.
-        s.handle_event(tick(5000));
+        s.handle_event(tick(TICK_PAST_DWELL));
         assert_eq!(s.state(), ScannerState::Dwelling);
         // Tick past 500ms → advance.
-        s.handle_event(tick(25_000));
+        s.handle_event(tick(TICK_PAST_OVERRIDE_DWELL));
         assert_eq!(s.state(), ScannerState::Retuning);
     }
 
@@ -829,7 +882,7 @@ mod tests {
             ch("B", 162_550_000, 0),
         ]));
         s.handle_event(ScannerEvent::SetEnabled(true));
-        s.handle_event(tick(1500));
+        s.handle_event(tick(TICK_PAST_SETTLE));
         s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         assert_eq!(s.state(), ScannerState::Listening);
         // User deletes channel B and adds C.
@@ -881,12 +934,12 @@ mod tests {
         s.handle_event(ScannerEvent::SetEnabled(true));
         // During settle: feed a squelch-open edge. Phase stays
         // Retuning; latch moves to open.
-        s.handle_event(tick(500));
+        s.handle_event(tick(TICK_IN_SETTLE));
         s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
         assert_eq!(s.state(), ScannerState::Retuning);
         // Settle expires. Scanner should land in Listening
         // directly, with audio unmuted.
-        let commands = s.handle_event(tick(2000));
+        let commands = s.handle_event(tick(TICK_SETTLE_COMPLETE));
         assert_eq!(s.state(), ScannerState::Listening);
         assert!(
             commands
@@ -939,8 +992,8 @@ mod tests {
         s.handle_event(ScannerEvent::SetEnabled(true));
         s.handle_event(ScannerEvent::LockoutChannel(key_a.clone()));
         // Advance through a few hops so cursors + priority counter are non-zero.
-        s.handle_event(tick(1500));
-        s.handle_event(tick(5000));
+        s.handle_event(tick(TICK_PAST_SETTLE));
+        s.handle_event(tick(TICK_PAST_DWELL));
         assert!(s.locked_out.contains(&key_a));
         assert!(s.hops_since_priority_sweep > 0);
 

--- a/crates/sdr-scanner/src/state.rs
+++ b/crates/sdr-scanner/src/state.rs
@@ -1,0 +1,19 @@
+//! Scanner phase enum surfaced to the UI + internal state variants
+//! carrying per-phase bookkeeping.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScannerState {
+    /// Scanner off, or on with no channels enabled.
+    Idle,
+    /// Retune command emitted, audio muted, waiting for settle
+    /// window to close before honoring squelch on the new channel.
+    Retuning,
+    /// Settled on the target channel, audio still muted,
+    /// listening for squelch-open within the dwell window.
+    Dwelling,
+    /// Squelch open post-settle, audio flowing.
+    Listening,
+    /// Squelch closed, audio muted, counting down hang window
+    /// before advancing to next channel.
+    Hanging,
+}

--- a/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
+++ b/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
@@ -229,12 +229,10 @@ pub enum ScannerEvent {
     /// until unlocked or scanner is disabled.
     LockoutChannel(ChannelKey),
     UnlockoutChannel(ChannelKey),
-
-    /// Global default dwell/hang changes from the UI sliders.
-    SetDefaultDwellMs(u32),
-    SetDefaultHangMs(u32),
 }
 ```
+
+Note: timing defaults (dwell, hang) live UI-side only. Slider changes re-project the bookmark list into `ScannerChannel`s with resolved per-channel `dwell_ms` / `hang_ms` and dispatch `UpdateScannerChannels` — there's no scanner-level "set default" event.
 
 - [ ] **Step 2: Write `commands.rs`**
 
@@ -336,7 +334,7 @@ use crate::channel::{ChannelKey, ScannerChannel};
 use crate::commands::ScannerCommand;
 use crate::events::{ScannerEvent, SquelchState};
 use crate::state::ScannerState;
-use crate::{DEFAULT_DWELL_MS, DEFAULT_HANG_MS, PRIORITY_CHECK_INTERVAL, SETTLE_MS};
+use crate::{PRIORITY_CHECK_INTERVAL, SETTLE_MS};
 
 /// Internal phase carrying per-phase bookkeeping. The outer
 /// `ScannerState` surfaced to the UI is a flattened view of this.
@@ -378,8 +376,6 @@ pub struct Scanner {
     enabled: bool,
     channels: Vec<ScannerChannel>,
     locked_out: HashSet<ChannelKey>,
-    default_dwell_ms: u32,
-    default_hang_ms: u32,
     phase: Phase,
     /// Rotation index into the current sub-list. Normal and
     /// priority rotations are advanced independently.
@@ -399,8 +395,6 @@ impl Default for Scanner {
             enabled: false,
             channels: Vec::new(),
             locked_out: HashSet::new(),
-            default_dwell_ms: DEFAULT_DWELL_MS,
-            default_hang_ms: DEFAULT_HANG_MS,
             phase: Phase::Idle,
             normal_cursor: 0,
             priority_cursor: 0,
@@ -433,15 +427,7 @@ impl Scanner {
                 sample_rate_hz,
             } => self.handle_sample_tick(samples_consumed, sample_rate_hz),
             ScannerEvent::LockoutChannel(key) => self.handle_lockout(key),
-            ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(key),
-            ScannerEvent::SetDefaultDwellMs(ms) => {
-                self.default_dwell_ms = ms;
-                Vec::new()
-            }
-            ScannerEvent::SetDefaultHangMs(ms) => {
-                self.default_hang_ms = ms;
-                Vec::new()
-            }
+            ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(&key),
         }
     }
 
@@ -1181,7 +1167,7 @@ And update `enter_retuning` initializer from `samples_until_settled: 0` to `samp
 - [ ] **Step 6: Run all tests**
 
 Run: `cargo test -p sdr-scanner --lib`
-Expected: 9/9 tests PASS.
+Expected: 9 tests PASS (3 from Task 1.5 + 6 new here).
 
 - [ ] **Step 7: Commit**
 
@@ -1360,7 +1346,7 @@ Expected: All 4 new tests PASS (the logic is already in place from Task 1.5/1.6)
 - [ ] **Step 4: Run all tests**
 
 Run: `cargo test -p sdr-scanner --lib`
-Expected: 13/13 tests PASS.
+Expected: all tests from Tasks 1.5 + 1.6 + 1.7 pass. Current baseline on shipped PR #368 is 17 tests (3 + 6 + 6 priority/lockout/edge + 1 `disable_clears_session_state` + 1 `unlockout_resumes_scanning_from_empty_rotation_idle`). If you're following the plan exactly, you'll see 15 at this checkpoint; the two regression tests landed via CR feedback after the initial task sequence.
 
 - [ ] **Step 5: Run clippy**
 
@@ -1525,10 +1511,9 @@ Open `crates/sdr-core/src/messages.rs`. Locate `pub enum UiToDsp`. Add new varia
     /// Session-scoped lockout.
     LockoutScannerChannel(sdr_scanner::ChannelKey),
     UnlockoutScannerChannel(sdr_scanner::ChannelKey),
-    /// Global default timings (user moved the sidebar sliders).
-    SetScannerDefaultDwellMs(u32),
-    SetScannerDefaultHangMs(u32),
 ```
+
+Timing defaults do NOT get their own UiToDsp variants — the UI folds them into each `ScannerChannel` at projection time (see Task 3.4 / PR 3) and dispatches `UpdateScannerChannels` on slider change.
 
 - [ ] **Step 3: Add `sdr-scanner` dependency on `sdr-core`**
 
@@ -1747,19 +1732,9 @@ And arms for the rest:
             .handle_event(sdr_scanner::ScannerEvent::UnlockoutChannel(key));
         self.apply_scanner_commands(cmds);
     }
-    UiToDsp::SetScannerDefaultDwellMs(ms) => {
-        let cmds = self
-            .scanner
-            .handle_event(sdr_scanner::ScannerEvent::SetDefaultDwellMs(ms));
-        self.apply_scanner_commands(cmds);
-    }
-    UiToDsp::SetScannerDefaultHangMs(ms) => {
-        let cmds = self
-            .scanner
-            .handle_event(sdr_scanner::ScannerEvent::SetDefaultHangMs(ms));
-        self.apply_scanner_commands(cmds);
-    }
 ```
+
+Defaults have no controller arm — they're UI-only. The UI reprojects bookmarks → `ScannerChannel`s with resolved per-channel `dwell_ms` / `hang_ms` and dispatches `UpdateScannerChannels` when a slider moves.
 
 - [ ] **Step 4: Feed SampleTick on every IQ block**
 
@@ -2173,34 +2148,47 @@ fn connect_scanner_panel(
         glib::Propagation::Proceed
     });
 
-    // Default dwell slider.
-    let state_dwell = Rc::clone(state);
+    // Default dwell + hang sliders. Each change persists to
+    // config AND triggers a bookmark re-projection — defaults
+    // are UI-side, folded into `ScannerChannel::dwell_ms` /
+    // `hang_ms` at projection time. We push the refreshed
+    // channel list via `UpdateScannerChannels` so the scanner
+    // picks up the new resolved values on its next rotation.
+    //
+    // `project_and_push_scanner_channels(panels, state, config)`
+    // is a small helper defined in Task 3.4 that:
+    //   1. reads the current bookmark list
+    //   2. reads the default dwell/hang from config
+    //   3. calls `project_scanner_channels(bookmarks, defaults)`
+    //   4. dispatches `UiToDsp::UpdateScannerChannels(channels)`
     let cfg_dwell = std::sync::Arc::clone(config);
+    let panels_dwell = panels.clone_for_scanner(); // or appropriate weak/clone pattern
+    let state_dwell = Rc::clone(state);
     scanner
         .default_dwell_row
         .connect_value_notify(move |row| {
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let ms = row.value() as u32;
-            state_dwell.send_dsp(UiToDsp::SetScannerDefaultDwellMs(ms));
             cfg_dwell.write(|v| {
                 v[sidebar::scanner_panel::CONFIG_KEY_DEFAULT_DWELL_MS] =
                     serde_json::json!(ms);
             });
+            project_and_push_scanner_channels(&panels_dwell, &state_dwell, &cfg_dwell);
         });
 
-    // Default hang slider.
-    let state_hang = Rc::clone(state);
     let cfg_hang = std::sync::Arc::clone(config);
+    let panels_hang = panels.clone_for_scanner();
+    let state_hang = Rc::clone(state);
     scanner
         .default_hang_row
         .connect_value_notify(move |row| {
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let ms = row.value() as u32;
-            state_hang.send_dsp(UiToDsp::SetScannerDefaultHangMs(ms));
             cfg_hang.write(|v| {
                 v[sidebar::scanner_panel::CONFIG_KEY_DEFAULT_HANG_MS] =
                     serde_json::json!(ms);
             });
+            project_and_push_scanner_channels(&panels_hang, &state_hang, &cfg_hang);
         });
 
     // Restore persisted defaults.
@@ -2403,10 +2391,9 @@ In `build_bookmark_row` (after the existing `delete_btn` append):
             b.scan_enabled = enabled;
         }
         save_bookmarks(&bms);
-        // Push the new channel list to the scanner.
-        let channels = project_scanner_channels(&bms);
         drop(bms);
-        state_scan.send_dsp(UiToDsp::UpdateScannerChannels(channels));
+        // Re-project with the current UI defaults and push.
+        project_and_push_scanner_channels(panels, state, config);
     });
     row.add_suffix(&scan_check);
 
@@ -2444,9 +2431,8 @@ In `build_bookmark_row` (after the existing `delete_btn` append):
             b.priority = priority;
         }
         save_bookmarks(&bms);
-        let channels = project_scanner_channels(&bms);
         drop(bms);
-        state_pri.send_dsp(UiToDsp::UpdateScannerChannels(channels));
+        project_and_push_scanner_channels(panels, state, config);
     });
     row.add_suffix(&pri_btn);
 ```
@@ -2457,12 +2443,14 @@ Update `build_bookmark_row`'s signature to take `state: &Rc<AppState>` so the to
 
 ```rust
 /// Project the bookmark list into `ScannerChannel`s. Only
-/// includes bookmarks with `scan_enabled = true`. Override
-/// fields are folded against the scanner defaults at projection
-/// time so the scanner state machine doesn't need to know about
-/// Options.
+/// includes bookmarks with `scan_enabled = true`. Defaults are
+/// UI-side — the caller reads them from config (or the live
+/// spin-row values) and passes them in. Override fields on the
+/// bookmark win; missing overrides fall back to the defaults.
 pub fn project_scanner_channels(
     bookmarks: &[Bookmark],
+    default_dwell_ms: u32,
+    default_hang_ms: u32,
 ) -> Vec<sdr_scanner::ScannerChannel> {
     bookmarks
         .iter()
@@ -2472,31 +2460,55 @@ pub fn project_scanner_channels(
                 name: b.name.clone(),
                 frequency_hz: b.frequency,
             },
-            frequency_hz: b.frequency,
             demod_mode: parse_demod_mode(&b.demod_mode),
             bandwidth: b.bandwidth,
-            ctcss: b.ctcss_mode.clone(),
+            ctcss: b.ctcss_mode,
             voice_squelch: b.voice_squelch_mode,
             priority: b.priority,
-            dwell_ms: b
-                .dwell_ms_override
-                .unwrap_or(sdr_scanner::DEFAULT_DWELL_MS),
-            hang_ms: b
-                .hang_ms_override
-                .unwrap_or(sdr_scanner::DEFAULT_HANG_MS),
+            dwell_ms: b.dwell_ms_override.unwrap_or(default_dwell_ms),
+            hang_ms: b.hang_ms_override.unwrap_or(default_hang_ms),
         })
         .collect()
+}
+
+/// Convenience helper: read current defaults from config, project
+/// the current bookmark list, and dispatch `UpdateScannerChannels`.
+/// Called from the default-slider handlers and the bookmark
+/// add/delete/import paths so every scanner-visible mutation
+/// refreshes the channel list atomically.
+pub fn project_and_push_scanner_channels(
+    panels: &SidebarPanels,
+    state: &Rc<AppState>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
+    let default_dwell = config.read(|v| {
+        v.get(sidebar::scanner_panel::CONFIG_KEY_DEFAULT_DWELL_MS)
+            .and_then(serde_json::Value::as_u64)
+            .map_or(sdr_scanner::DEFAULT_DWELL_MS, |v| v as u32)
+    });
+    let default_hang = config.read(|v| {
+        v.get(sidebar::scanner_panel::CONFIG_KEY_DEFAULT_HANG_MS)
+            .and_then(serde_json::Value::as_u64)
+            .map_or(sdr_scanner::DEFAULT_HANG_MS, |v| v as u32)
+    });
+    let channels = project_scanner_channels(
+        &panels.bookmarks.bookmarks.borrow(),
+        default_dwell,
+        default_hang,
+    );
+    state.send_dsp(UiToDsp::UpdateScannerChannels(channels));
 }
 ```
 
 - [ ] **Step 3: Also push `UpdateScannerChannels` on Add / Delete / RR import paths**
 
-Locate the add-bookmark click handler, delete-button click handler (inside `build_bookmark_row`), and the RR browse post-import callback. After each `save_bookmarks` call, add:
+Locate the add-bookmark click handler, delete-button click handler (inside `build_bookmark_row`), and the RR browse post-import callback. After each `save_bookmarks` call, invoke the helper:
 
 ```rust
-    let channels = project_scanner_channels(&bm_rc.borrow());
-    state_clone.send_dsp(UiToDsp::UpdateScannerChannels(channels));
+    sidebar::navigation_panel::project_and_push_scanner_channels(panels, state, config);
 ```
+
+This keeps every call site that mutates the bookmark list (including default-slider changes that re-resolve the per-channel timing) on one path.
 
 - [ ] **Step 4: Compile**
 
@@ -2591,14 +2603,13 @@ git commit -m "sdr-ui: lockout button + manual-tune force-disables scanner"
 In `build_window` after the panels are wired up, push the initial channel list to the scanner:
 
 ```rust
-    // Seed the scanner with the persisted bookmark list — scanner
-    // starts Idle so no retune happens, but the channels are in
-    // place if the user flips the switch on.
-    let initial_channels =
-        sidebar::navigation_panel::project_scanner_channels(
-            &panels.bookmarks.bookmarks.borrow(),
-        );
-    state.send_dsp(UiToDsp::UpdateScannerChannels(initial_channels));
+    // Seed the scanner with the persisted bookmark list —
+    // scanner starts Idle so no retune happens, but the channels
+    // are in place if the user flips the switch on. Defaults
+    // come from config via the shared helper.
+    sidebar::navigation_panel::project_and_push_scanner_channels(
+        &panels, &state, config,
+    );
 ```
 
 - [ ] **Step 2: Add F8 shortcut to toggle scanner**

--- a/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
+++ b/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
@@ -108,10 +108,9 @@ And in `[workspace.dependencies]` after `sdr-rtltcp-discovery`:
 sdr-scanner = { path = "crates/sdr-scanner" }
 ```
 
-- [ ] **Step 4: Verify crate compiles**
+- [ ] **Step 4: Verify crate compiles (skip — expected to fail)**
 
-Run: `cargo build -p sdr-scanner`
-Expected: Clean build (just the empty `lib.rs` + submodule stubs, which we'll fill next). The submodule files don't exist yet, so this will fail — that's fine, proceed to Step 5.
+Running `cargo build -p sdr-scanner` at this stage will FAIL because `lib.rs` declares five submodules (`channel`, `commands`, `events`, `scanner`, `state`) that don't exist yet. Tasks 1.2 and 1.3 create them. Don't try to fix the build here; skip the `cargo build` check and proceed directly to Step 5. `cargo check` / `cargo metadata` on the workspace root will still succeed and validate your Cargo.toml syntax.
 
 - [ ] **Step 5: Commit scaffolding**
 
@@ -1882,12 +1881,17 @@ git commit -m "sdr-core: scanner ↔ recording/transcription mutex"
 **Files:**
 - Modify: `crates/sdr-core/src/sink_manager.rs` (or wherever `SinkManager` lives)
 
-- [ ] **Step 1: Add `scanner_mute: bool` field**
+- [ ] **Step 1: Add `scanner_mute: bool` + reusable silence scratch buffer**
 
 ```rust
 pub struct SinkManager {
     // ... existing fields ...
     scanner_mute: bool,
+    /// Reusable silence buffer grown-in-place during mute windows.
+    /// `Vec` initialized empty and only resized on the mute path;
+    /// capacity is sticky across calls so the steady-state has no
+    /// allocation. Only touched on the audio thread via `&mut self`.
+    scanner_silence_scratch: Vec<f32>,
 }
 
 impl SinkManager {
@@ -1899,20 +1903,24 @@ impl SinkManager {
 
 - [ ] **Step 2: Gate in the audio write path**
 
-Wherever the manager writes PCM to the audio device, wrap the buffer:
+Wherever the manager writes PCM to the audio device, swap the buffer on mute. Do NOT allocate a fresh `vec![0.0; len]` per block — reuse the scratch buffer:
 
 ```rust
     pub fn write_audio(&mut self, audio: &[f32]) {
-        if self.scanner_mute {
-            let silence = vec![0.0_f32; audio.len()];
-            // ... write silence to current sink ...
+        let out = if self.scanner_mute {
+            // Ensure capacity matches; `resize` reuses existing
+            // allocation when the buffer is already large enough,
+            // so steady-state mute is allocation-free.
+            self.scanner_silence_scratch.resize(audio.len(), 0.0);
+            &self.scanner_silence_scratch[..]
         } else {
-            // ... write audio as-is ...
-        }
+            audio
+        };
+        // ... write `out` to current sink ...
     }
 ```
 
-If there's a single hot path, hoist the branch out of the per-sample loop.
+If there's a single hot path, hoist the branch out of the per-sample loop. Never allocate per block — real-time audio pipelines can't tolerate heap churn on every buffer.
 
 - [ ] **Step 3: Compile**
 

--- a/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
+++ b/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
@@ -228,7 +228,7 @@ pub enum ScannerEvent {
     /// Session-scoped lockout — channel is skipped in rotation
     /// until unlocked or scanner is disabled.
     LockoutChannel(ChannelKey),
-    UnlockoutChannel(ChannelKey),
+    UnlockChannel(ChannelKey),
 }
 ```
 
@@ -427,7 +427,7 @@ impl Scanner {
                 sample_rate_hz,
             } => self.handle_sample_tick(samples_consumed, sample_rate_hz),
             ScannerEvent::LockoutChannel(key) => self.handle_lockout(key),
-            ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(&key),
+            ScannerEvent::UnlockChannel(key) => self.handle_unlockout(&key),
         }
     }
 
@@ -1510,7 +1510,7 @@ Open `crates/sdr-core/src/messages.rs`. Locate `pub enum UiToDsp`. Add new varia
     UpdateScannerChannels(Vec<sdr_scanner::ScannerChannel>),
     /// Session-scoped lockout.
     LockoutScannerChannel(sdr_scanner::ChannelKey),
-    UnlockoutScannerChannel(sdr_scanner::ChannelKey),
+    UnlockScannerChannel(sdr_scanner::ChannelKey),
 ```
 
 Timing defaults do NOT get their own UiToDsp variants — the UI folds them into each `ScannerChannel` at projection time (see Task 3.4 / PR 3) and dispatches `UpdateScannerChannels` on slider change.
@@ -1726,10 +1726,10 @@ And arms for the rest:
             .handle_event(sdr_scanner::ScannerEvent::LockoutChannel(key));
         self.apply_scanner_commands(cmds);
     }
-    UiToDsp::UnlockoutScannerChannel(key) => {
+    UiToDsp::UnlockScannerChannel(key) => {
         let cmds = self
             .scanner
-            .handle_event(sdr_scanner::ScannerEvent::UnlockoutChannel(key));
+            .handle_event(sdr_scanner::ScannerEvent::UnlockChannel(key));
         self.apply_scanner_commands(cmds);
     }
 ```

--- a/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
+++ b/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
@@ -1,0 +1,2713 @@
+# Scanner Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship classic sequential-scanner behavior (#317) on top of the existing SDR pipeline: retune through scannable favorites, dwell on each, stop-and-play on squelch-open, resume when hang elapses. Single-tier priority cycling, session-scoped lockout, no per-hit recording/transcription (scanner mutually exclusive with both). Split across three PRs for manageable CR cycles.
+
+**Architecture:** Pure state machine in a new `sdr-scanner` crate (no I/O, no threading) consumes events (sample ticks, squelch edges, user toggles) and emits commands (retune, mute, active-channel). `sdr-core::DspController` owns a `Scanner` instance, feeds it events, applies emitted commands. Mirrors the `AutoBreakMachine` pattern from #273. UI surface is a new sidebar panel at the bottom of the left column plus scan/priority toggles on bookmark rows.
+
+**Tech Stack:** Rust 2024, `thiserror` for errors, `serde` for bookmark schema extensions, GTK4 + libadwaita for UI, `tracing` for diagnostics. Unit tests only in PR 1 (pure state machine); PRs 2 and 3 verify via log inspection and manual smoke test.
+
+**Design doc:** `docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md` (read first if unsure about a decision).
+
+---
+
+## PR 1 — `sdr-scanner` crate (engine only)
+
+**Branch:** `feature/scanner-engine`
+**Scope:** New workspace crate containing the pure state machine, types, and unit tests. Zero integration with other crates. ~600 lines.
+
+---
+
+### Task 1.1: Crate scaffolding
+
+**Files:**
+- Create: `crates/sdr-scanner/Cargo.toml`
+- Create: `crates/sdr-scanner/src/lib.rs`
+- Modify: `Cargo.toml` (workspace members + workspace.dependencies)
+
+- [ ] **Step 1: Create `crates/sdr-scanner/Cargo.toml`**
+
+```toml
+[package]
+name = "sdr-scanner"
+version = "0.1.0"
+description = "Scanner state machine — sequential channel monitoring for SDR pipelines"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+sdr-types.workspace = true
+sdr-dsp.workspace = true
+sdr-radio.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 2: Create stub `crates/sdr-scanner/src/lib.rs`**
+
+```rust
+//! Scanner state machine — sequential channel monitoring for SDR
+//! pipelines. Pure no-I/O logic: consumes events, emits commands,
+//! leaves all actual radio/audio wiring to the DSP controller that
+//! owns an instance.
+//!
+//! See docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
+//! for the design decisions behind this crate's shape.
+
+pub mod channel;
+pub mod commands;
+pub mod events;
+pub mod scanner;
+pub mod state;
+
+pub use channel::{ChannelKey, ScannerChannel};
+pub use commands::ScannerCommand;
+pub use events::{ScannerEvent, SquelchState};
+pub use scanner::Scanner;
+pub use state::ScannerState;
+
+/// Default dwell time in ms when a channel doesn't override it.
+pub const DEFAULT_DWELL_MS: u32 = 100;
+
+/// Default hang time in ms when a channel doesn't override it.
+pub const DEFAULT_HANG_MS: u32 = 2000;
+
+/// Settle window in ms after a retune before the scanner honors
+/// squelch edges on the new channel. Covers PLL lock + filter
+/// warm-up transients — scanner decisions during this window are
+/// unreliable.
+pub const SETTLE_MS: u32 = 30;
+
+/// How often (in normal-channel hops) the scanner sweeps priority
+/// channels between normal rotations. `5` means every 5 normal
+/// hops, all priority-1 channels get a check before resuming.
+pub const PRIORITY_CHECK_INTERVAL: u32 = 5;
+```
+
+- [ ] **Step 3: Add crate to root workspace**
+
+In `Cargo.toml` at root, add `"crates/sdr-scanner"` to `[workspace] members` list (alphabetical position after `sdr-rtltcp-discovery`):
+
+```toml
+members = [
+    # ... existing entries ...
+    "crates/sdr-rtltcp-discovery",
+    "crates/sdr-scanner",
+    "crates/sdr-source-file",
+    # ... rest ...
+]
+```
+
+And in `[workspace.dependencies]` after `sdr-rtltcp-discovery`:
+
+```toml
+sdr-scanner = { path = "crates/sdr-scanner" }
+```
+
+- [ ] **Step 4: Verify crate compiles**
+
+Run: `cargo build -p sdr-scanner`
+Expected: Clean build (just the empty `lib.rs` + submodule stubs, which we'll fill next). The submodule files don't exist yet, so this will fail — that's fine, proceed to Step 5.
+
+- [ ] **Step 5: Commit scaffolding**
+
+```bash
+git checkout -b feature/scanner-engine
+git add crates/sdr-scanner/ Cargo.toml
+git commit -m "scaffold sdr-scanner crate (#317)"
+```
+
+---
+
+### Task 1.2: Channel types (`channel.rs`)
+
+**Files:**
+- Create: `crates/sdr-scanner/src/channel.rs`
+
+- [ ] **Step 1: Write `channel.rs` with `ChannelKey` + `ScannerChannel`**
+
+```rust
+//! Channel identity and per-channel config. `ScannerChannel` is
+//! the resolved runtime shape — dwell/hang are already folded from
+//! overrides + defaults; the scanner state machine doesn't need to
+//! know about `Option`s here.
+
+use sdr_types::DemodMode;
+
+/// Stable identity for a channel across rebuilds of the channel
+/// list. `(name, frequency_hz)` — same convention the bookmarks
+/// flyout uses for the active-bookmark highlight.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChannelKey {
+    pub name: String,
+    pub frequency_hz: u64,
+}
+
+/// Fully-resolved scanner channel. The UI / controller builds
+/// these from `Bookmark` entries at scan-start or on
+/// `ChannelsChanged`; the state machine operates on them directly
+/// and has no notion of bookmark storage.
+#[derive(Debug, Clone)]
+pub struct ScannerChannel {
+    pub key: ChannelKey,
+    pub frequency_hz: u64,
+    pub demod_mode: DemodMode,
+    pub bandwidth: f64,
+    pub ctcss: Option<sdr_radio::af_chain::CtcssMode>,
+    pub voice_squelch: Option<sdr_dsp::voice_squelch::VoiceSquelchMode>,
+    /// 0 = normal rotation, >=1 = priority (checked more often).
+    pub priority: u8,
+    /// Resolved dwell time in ms (per-channel override folded in).
+    pub dwell_ms: u32,
+    /// Resolved hang time in ms (per-channel override folded in).
+    pub hang_ms: u32,
+}
+```
+
+- [ ] **Step 2: Compile-check**
+
+Run: `cargo build -p sdr-scanner`
+Expected: FAIL — other modules not yet created.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-scanner/src/channel.rs
+git commit -m "sdr-scanner: ChannelKey + ScannerChannel types"
+```
+
+---
+
+### Task 1.3: Event and command types (`events.rs`, `commands.rs`, `state.rs`)
+
+**Files:**
+- Create: `crates/sdr-scanner/src/events.rs`
+- Create: `crates/sdr-scanner/src/commands.rs`
+- Create: `crates/sdr-scanner/src/state.rs`
+
+- [ ] **Step 1: Write `events.rs`**
+
+```rust
+//! Events fed into the scanner by the DSP controller or UI.
+//! No wall-clock time anywhere — sample-count is the only timing
+//! primitive, matching the `AutoBreakMachine` pattern.
+
+use crate::channel::{ChannelKey, ScannerChannel};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SquelchState {
+    Open,
+    Closed,
+}
+
+#[derive(Debug, Clone)]
+pub enum ScannerEvent {
+    /// Fired by the DSP controller on every IQ block arrival.
+    /// `samples_consumed` is block length; `sample_rate_hz`
+    /// anchors the ms→sample conversion for dwell/hang/settle.
+    SampleTick {
+        samples_consumed: u32,
+        sample_rate_hz: u32,
+    },
+
+    /// Edge-triggered squelch transition, identical to the stream
+    /// already fed to the transcription tap for Auto Break.
+    SquelchEdge(SquelchState),
+
+    /// User added / removed / edited a scannable bookmark.
+    /// Scanner swaps its channel list and recovers a sensible
+    /// rotation position.
+    ChannelsChanged(Vec<ScannerChannel>),
+
+    /// Master scanner on/off toggle.
+    SetEnabled(bool),
+
+    /// Session-scoped lockout — channel is skipped in rotation
+    /// until unlocked or scanner is disabled.
+    LockoutChannel(ChannelKey),
+    UnlockoutChannel(ChannelKey),
+
+    /// Global default dwell/hang changes from the UI sliders.
+    SetDefaultDwellMs(u32),
+    SetDefaultHangMs(u32),
+}
+```
+
+- [ ] **Step 2: Write `commands.rs`**
+
+```rust
+//! Commands emitted by the scanner in response to events.
+//! The DSP controller applies these — scanner itself never
+//! touches the source, sink, or radio module directly.
+
+use crate::channel::ChannelKey;
+use crate::state::ScannerState;
+
+#[derive(Debug, Clone)]
+pub enum ScannerCommand {
+    /// Retune the source and reconfigure the radio module to this
+    /// channel. Controller dispatches `source.set_center_freq`,
+    /// `radio_module.set_demod_mode`, `set_bandwidth`,
+    /// `set_ctcss_mode`, `set_voice_squelch_mode` in order.
+    Retune {
+        freq_hz: u64,
+        demod_mode: sdr_types::DemodMode,
+        bandwidth: f64,
+        ctcss: Option<sdr_radio::af_chain::CtcssMode>,
+        voice_squelch: Option<sdr_dsp::voice_squelch::VoiceSquelchMode>,
+    },
+
+    /// Gate the final PCM stream to the audio device. DSP chain
+    /// keeps running so squelch edges still fire; only user-
+    /// audible output is silenced.
+    MuteAudio(bool),
+
+    /// UI-facing: active channel changed. `None` during Idle.
+    ActiveChannelChanged(Option<ChannelKey>),
+
+    /// UI-facing: scanner phase indicator updated.
+    StateChanged(ScannerState),
+
+    /// Emitted when the active rotation is fully empty — every
+    /// channel is either removed, disabled, or locked out.
+    /// UI surfaces as a toast; scanner transitions to Idle
+    /// afterwards.
+    EmptyRotation,
+}
+```
+
+- [ ] **Step 3: Write `state.rs`**
+
+```rust
+//! Scanner phase enum surfaced to the UI + internal state variants
+//! carrying per-phase bookkeeping.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScannerState {
+    /// Scanner off, or on with no channels enabled.
+    Idle,
+    /// Retune command emitted, audio muted, waiting for settle
+    /// window to close before honoring squelch on the new channel.
+    Retuning,
+    /// Settled on the target channel, audio still muted,
+    /// listening for squelch-open within the dwell window.
+    Dwelling,
+    /// Squelch open post-settle, audio flowing.
+    Listening,
+    /// Squelch closed, audio muted, counting down hang window
+    /// before advancing to next channel.
+    Hanging,
+}
+```
+
+- [ ] **Step 4: Verify compile**
+
+Run: `cargo build -p sdr-scanner`
+Expected: Clean build — all pub names in `lib.rs` now resolve.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-scanner/src/events.rs crates/sdr-scanner/src/commands.rs crates/sdr-scanner/src/state.rs
+git commit -m "sdr-scanner: event / command / state types"
+```
+
+---
+
+### Task 1.4: Scanner struct skeleton (`scanner.rs`)
+
+**Files:**
+- Create: `crates/sdr-scanner/src/scanner.rs`
+
+- [ ] **Step 1: Write scanner skeleton with public API**
+
+```rust
+//! Scanner state machine. Owns rotation position, phase, timing
+//! counters, and session lockouts. No threading, no I/O — the
+//! DSP controller drives it via `handle_event` and applies the
+//! returned commands.
+
+use std::collections::HashSet;
+
+use crate::channel::{ChannelKey, ScannerChannel};
+use crate::commands::ScannerCommand;
+use crate::events::{ScannerEvent, SquelchState};
+use crate::state::ScannerState;
+use crate::{DEFAULT_DWELL_MS, DEFAULT_HANG_MS, PRIORITY_CHECK_INTERVAL, SETTLE_MS};
+
+/// Internal phase carrying per-phase bookkeeping. The outer
+/// `ScannerState` surfaced to the UI is a flattened view of this.
+#[derive(Debug, Clone)]
+enum Phase {
+    Idle,
+    Retuning {
+        target_idx: usize,
+        samples_until_settled: u64,
+    },
+    Dwelling {
+        idx: usize,
+        samples_until_timeout: u64,
+    },
+    Listening {
+        idx: usize,
+    },
+    Hanging {
+        idx: usize,
+        samples_until_timeout: u64,
+    },
+}
+
+impl Phase {
+    fn as_state(&self) -> ScannerState {
+        match self {
+            Phase::Idle => ScannerState::Idle,
+            Phase::Retuning { .. } => ScannerState::Retuning,
+            Phase::Dwelling { .. } => ScannerState::Dwelling,
+            Phase::Listening { .. } => ScannerState::Listening,
+            Phase::Hanging { .. } => ScannerState::Hanging,
+        }
+    }
+}
+
+/// Scanner state machine. Instantiate once, feed events, apply
+/// emitted commands. All methods are synchronous and cheap.
+pub struct Scanner {
+    enabled: bool,
+    channels: Vec<ScannerChannel>,
+    locked_out: HashSet<ChannelKey>,
+    default_dwell_ms: u32,
+    default_hang_ms: u32,
+    phase: Phase,
+    /// Rotation index into the current sub-list. Normal and
+    /// priority rotations are advanced independently.
+    normal_cursor: usize,
+    priority_cursor: usize,
+    /// Count of completed normal hops since the last priority
+    /// sweep. When this hits `PRIORITY_CHECK_INTERVAL`, the next
+    /// rotation pass runs priority before normal.
+    hops_since_priority_sweep: u32,
+    /// Set while a priority sweep is in progress.
+    in_priority_sweep: bool,
+}
+
+impl Default for Scanner {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            channels: Vec::new(),
+            locked_out: HashSet::new(),
+            default_dwell_ms: DEFAULT_DWELL_MS,
+            default_hang_ms: DEFAULT_HANG_MS,
+            phase: Phase::Idle,
+            normal_cursor: 0,
+            priority_cursor: 0,
+            hops_since_priority_sweep: 0,
+            in_priority_sweep: false,
+        }
+    }
+}
+
+impl Scanner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Current public-facing phase. Cheap (no allocation).
+    pub fn state(&self) -> ScannerState {
+        self.phase.as_state()
+    }
+
+    /// Feed an event, receive zero or more commands. Commands
+    /// are returned in order of emission — caller applies them
+    /// in sequence.
+    pub fn handle_event(&mut self, event: ScannerEvent) -> Vec<ScannerCommand> {
+        match event {
+            ScannerEvent::SetEnabled(enabled) => self.handle_set_enabled(enabled),
+            ScannerEvent::ChannelsChanged(channels) => self.handle_channels_changed(channels),
+            ScannerEvent::SquelchEdge(state) => self.handle_squelch_edge(state),
+            ScannerEvent::SampleTick {
+                samples_consumed,
+                sample_rate_hz,
+            } => self.handle_sample_tick(samples_consumed, sample_rate_hz),
+            ScannerEvent::LockoutChannel(key) => self.handle_lockout(key),
+            ScannerEvent::UnlockoutChannel(key) => self.handle_unlockout(key),
+            ScannerEvent::SetDefaultDwellMs(ms) => {
+                self.default_dwell_ms = ms;
+                Vec::new()
+            }
+            ScannerEvent::SetDefaultHangMs(ms) => {
+                self.default_hang_ms = ms;
+                Vec::new()
+            }
+        }
+    }
+
+    // --- Event handlers (stub bodies; next tasks fill in) -----
+
+    fn handle_set_enabled(&mut self, enabled: bool) -> Vec<ScannerCommand> {
+        // TODO (Task 1.5): Idle↔Retuning transitions.
+        let _ = enabled;
+        Vec::new()
+    }
+
+    fn handle_channels_changed(&mut self, channels: Vec<ScannerChannel>) -> Vec<ScannerCommand> {
+        // TODO (Task 1.5): list swap + rotation recovery.
+        self.channels = channels;
+        Vec::new()
+    }
+
+    fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
+        // TODO (Task 1.6): honor post-settle; drive Dwelling→Listening
+        // and Listening→Hanging transitions.
+        let _ = state;
+        Vec::new()
+    }
+
+    fn handle_sample_tick(
+        &mut self,
+        samples_consumed: u32,
+        sample_rate_hz: u32,
+    ) -> Vec<ScannerCommand> {
+        // TODO (Task 1.6): countdown settle / dwell / hang windows,
+        // advance on timeout.
+        let _ = (samples_consumed, sample_rate_hz);
+        Vec::new()
+    }
+
+    fn handle_lockout(&mut self, key: ChannelKey) -> Vec<ScannerCommand> {
+        self.locked_out.insert(key);
+        // TODO (Task 1.7): if active channel got locked out,
+        // advance rotation.
+        Vec::new()
+    }
+
+    fn handle_unlockout(&mut self, key: ChannelKey) -> Vec<ScannerCommand> {
+        self.locked_out.remove(&key);
+        Vec::new()
+    }
+}
+
+/// Convert ms to samples at the given sample rate. Rounded up so
+/// a 30 ms window at 48000 Hz = 1440 samples (exact), and a 30 ms
+/// at 44100 = 1323. Caller uses this to seed `samples_until_*`.
+#[allow(clippy::cast_possible_truncation)]
+fn ms_to_samples(ms: u32, sample_rate_hz: u32) -> u64 {
+    // (ms * rate + 999) / 1000 — ceiling division.
+    (u64::from(ms) * u64::from(sample_rate_hz) + 999) / 1000
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cargo build -p sdr-scanner`
+Expected: Clean build with several `unused` warnings on the TODO stubs — that's fine for now.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-scanner/src/scanner.rs
+git commit -m "sdr-scanner: Scanner skeleton with event dispatch"
+```
+
+---
+
+### Task 1.5: Rotation logic + enable/disable
+
+**Files:**
+- Modify: `crates/sdr-scanner/src/scanner.rs`
+
+- [ ] **Step 1: Write a failing test for the enable flow**
+
+Append to `scanner.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sdr_types::DemodMode;
+
+    fn ch(name: &str, freq: u64, priority: u8) -> ScannerChannel {
+        ScannerChannel {
+            key: ChannelKey {
+                name: name.to_string(),
+                frequency_hz: freq,
+            },
+            frequency_hz: freq,
+            demod_mode: DemodMode::Nfm,
+            bandwidth: 12_500.0,
+            ctcss: None,
+            voice_squelch: None,
+            priority,
+            dwell_ms: DEFAULT_DWELL_MS,
+            hang_ms: DEFAULT_HANG_MS,
+        }
+    }
+
+    #[test]
+    fn enable_with_channels_transitions_to_retuning() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        let commands = s.handle_event(ScannerEvent::SetEnabled(true));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // Expect Retune → MuteAudio(true) → ActiveChannelChanged → StateChanged
+        assert!(matches!(commands[0], ScannerCommand::Retune { freq_hz: 146_520_000, .. }));
+        assert!(matches!(commands[1], ScannerCommand::MuteAudio(true)));
+        assert!(matches!(
+            commands[2],
+            ScannerCommand::ActiveChannelChanged(Some(_))
+        ));
+        assert!(matches!(
+            commands[3],
+            ScannerCommand::StateChanged(ScannerState::Retuning)
+        ));
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p sdr-scanner --lib enable_with_channels_transitions_to_retuning -- --nocapture`
+Expected: FAIL — `assertion failed: matches!(commands[0], ScannerCommand::Retune { .. })` because `handle_set_enabled` stub returns empty.
+
+- [ ] **Step 3: Implement `handle_set_enabled` + helpers**
+
+Replace `handle_set_enabled`, `handle_channels_changed` stub bodies and add new helper methods in the `impl Scanner` block:
+
+```rust
+    fn handle_set_enabled(&mut self, enabled: bool) -> Vec<ScannerCommand> {
+        if self.enabled == enabled {
+            return Vec::new();
+        }
+        self.enabled = enabled;
+        if enabled {
+            self.start_rotation()
+        } else {
+            self.stop_rotation()
+        }
+    }
+
+    fn handle_channels_changed(&mut self, channels: Vec<ScannerChannel>) -> Vec<ScannerCommand> {
+        self.channels = channels;
+        // Any stale lockout keys for channels that no longer exist
+        // are harmless (the set is only consulted against the
+        // live channel list), but we'll prune for cleanliness.
+        let valid: HashSet<ChannelKey> =
+            self.channels.iter().map(|c| c.key.clone()).collect();
+        self.locked_out.retain(|k| valid.contains(k));
+
+        if !self.enabled {
+            return Vec::new();
+        }
+        // Currently-scanning mid-list-change: recover from wherever
+        // the phase left us by re-starting rotation.
+        self.normal_cursor = 0;
+        self.priority_cursor = 0;
+        self.in_priority_sweep = false;
+        self.start_rotation()
+    }
+
+    /// Begin or resume rotation from the current cursor. Emits
+    /// Retune + MuteAudio + ActiveChannelChanged + StateChanged.
+    /// Returns EmptyRotation if no scannable + unlocked channels
+    /// exist, and transitions to Idle.
+    fn start_rotation(&mut self) -> Vec<ScannerCommand> {
+        let Some(idx) = self.pick_next_channel() else {
+            // No scannable channels available.
+            self.phase = Phase::Idle;
+            return vec![
+                ScannerCommand::EmptyRotation,
+                ScannerCommand::MuteAudio(false),
+                ScannerCommand::ActiveChannelChanged(None),
+                ScannerCommand::StateChanged(ScannerState::Idle),
+            ];
+        };
+        self.enter_retuning(idx)
+    }
+
+    fn stop_rotation(&mut self) -> Vec<ScannerCommand> {
+        self.phase = Phase::Idle;
+        vec![
+            ScannerCommand::MuteAudio(false),
+            ScannerCommand::ActiveChannelChanged(None),
+            ScannerCommand::StateChanged(ScannerState::Idle),
+        ]
+    }
+
+    /// Emit the retune command set for the given channel index
+    /// and move to Retuning phase. Settle window initialized on
+    /// the first SampleTick after entering Retuning (the sample
+    /// rate isn't known here).
+    fn enter_retuning(&mut self, idx: usize) -> Vec<ScannerCommand> {
+        let channel = &self.channels[idx];
+        self.phase = Phase::Retuning {
+            target_idx: idx,
+            samples_until_settled: 0, // seeded on first SampleTick
+        };
+        vec![
+            ScannerCommand::Retune {
+                freq_hz: channel.frequency_hz,
+                demod_mode: channel.demod_mode,
+                bandwidth: channel.bandwidth,
+                ctcss: channel.ctcss.clone(),
+                voice_squelch: channel.voice_squelch,
+            },
+            ScannerCommand::MuteAudio(true),
+            ScannerCommand::ActiveChannelChanged(Some(channel.key.clone())),
+            ScannerCommand::StateChanged(ScannerState::Retuning),
+        ]
+    }
+
+    /// Pick the next channel to scan given current cursor and
+    /// priority-sweep state. Returns None if no scannable+unlocked
+    /// channels exist.
+    fn pick_next_channel(&mut self) -> Option<usize> {
+        // Trigger priority sweep if due.
+        if !self.in_priority_sweep
+            && self.hops_since_priority_sweep >= PRIORITY_CHECK_INTERVAL
+            && self.channels.iter().any(|c| c.priority >= 1)
+        {
+            self.in_priority_sweep = true;
+            self.priority_cursor = 0;
+        }
+
+        if self.in_priority_sweep {
+            let pri_indices: Vec<usize> = self
+                .channels
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| c.priority >= 1 && !self.locked_out.contains(&c.key))
+                .map(|(i, _)| i)
+                .collect();
+            if self.priority_cursor < pri_indices.len() {
+                let chosen = pri_indices[self.priority_cursor];
+                self.priority_cursor += 1;
+                return Some(chosen);
+            }
+            // Priority sweep exhausted.
+            self.in_priority_sweep = false;
+            self.priority_cursor = 0;
+            self.hops_since_priority_sweep = 0;
+            // Fall through to normal rotation.
+        }
+
+        let normal_indices: Vec<usize> = self
+            .channels
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.priority == 0 && !self.locked_out.contains(&c.key))
+            .map(|(i, _)| i)
+            .collect();
+
+        if normal_indices.is_empty() {
+            // If no normal channels, fall back to any unlocked
+            // channel (priority-only lists).
+            let any_unlocked: Vec<usize> = self
+                .channels
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| !self.locked_out.contains(&c.key))
+                .map(|(i, _)| i)
+                .collect();
+            if any_unlocked.is_empty() {
+                return None;
+            }
+            if self.normal_cursor >= any_unlocked.len() {
+                self.normal_cursor = 0;
+            }
+            let chosen = any_unlocked[self.normal_cursor];
+            self.normal_cursor = (self.normal_cursor + 1) % any_unlocked.len();
+            return Some(chosen);
+        }
+
+        if self.normal_cursor >= normal_indices.len() {
+            self.normal_cursor = 0;
+        }
+        let chosen = normal_indices[self.normal_cursor];
+        self.normal_cursor = (self.normal_cursor + 1) % normal_indices.len();
+        Some(chosen)
+    }
+```
+
+- [ ] **Step 4: Run test to verify PASS**
+
+Run: `cargo test -p sdr-scanner --lib enable_with_channels_transitions_to_retuning`
+Expected: PASS.
+
+- [ ] **Step 5: Add disable test + empty-channels test**
+
+Append in `mod tests`:
+
+```rust
+    #[test]
+    fn disable_emits_idle_transition() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        let commands = s.handle_event(ScannerEvent::SetEnabled(false));
+        assert_eq!(s.state(), ScannerState::Idle);
+        assert!(matches!(commands[0], ScannerCommand::MuteAudio(false)));
+        assert!(matches!(
+            commands[1],
+            ScannerCommand::ActiveChannelChanged(None)
+        ));
+        assert!(matches!(
+            commands[2],
+            ScannerCommand::StateChanged(ScannerState::Idle)
+        ));
+    }
+
+    #[test]
+    fn enable_with_no_channels_emits_empty_rotation() {
+        let mut s = Scanner::new();
+        let commands = s.handle_event(ScannerEvent::SetEnabled(true));
+        assert_eq!(s.state(), ScannerState::Idle);
+        assert!(matches!(commands[0], ScannerCommand::EmptyRotation));
+    }
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p sdr-scanner --lib`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-scanner: rotation logic + enable/disable transitions"
+```
+
+---
+
+### Task 1.6: Sample-tick countdown + squelch-edge transitions
+
+**Files:**
+- Modify: `crates/sdr-scanner/src/scanner.rs`
+
+- [ ] **Step 1: Write failing tests for the settle + dwell + listen flow**
+
+Append to `mod tests`:
+
+```rust
+    /// 48 kHz rate, so 30ms settle = 1440 samples, 100ms dwell = 4800 samples.
+    const RATE: u32 = 48_000;
+
+    fn tick(samples: u32) -> ScannerEvent {
+        ScannerEvent::SampleTick {
+            samples_consumed: samples,
+            sample_rate_hz: RATE,
+        }
+    }
+
+    #[test]
+    fn settle_window_ignores_squelch_open() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // Feed a squelch open during the settle window.
+        s.handle_event(tick(500));
+        let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // No MuteAudio(false) should have been emitted.
+        assert!(
+            !commands.iter().any(|c| matches!(c, ScannerCommand::MuteAudio(false))),
+            "mute was released during settle window"
+        );
+    }
+
+    #[test]
+    fn post_settle_squelch_open_transitions_to_listening() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // Elapse the settle window (1440 samples for 30ms at 48kHz).
+        s.handle_event(tick(1500));
+        assert_eq!(s.state(), ScannerState::Dwelling);
+        let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::MuteAudio(false))));
+    }
+
+    #[test]
+    fn dwell_elapsed_without_squelch_advances_to_next() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // Skip settle window.
+        s.handle_event(tick(1500));
+        assert_eq!(s.state(), ScannerState::Dwelling);
+        // Dwell is 100ms = 4800 samples at 48kHz. Tick past it.
+        let commands = s.handle_event(tick(5000));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // Should have retuned to channel B (frequency 162_550_000).
+        assert!(commands.iter().any(|c| matches!(
+            c,
+            ScannerCommand::Retune { freq_hz: 162_550_000, .. }
+        )));
+    }
+
+    #[test]
+    fn squelch_close_in_listening_enters_hanging_and_mutes() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(1500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+        let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
+        assert_eq!(s.state(), ScannerState::Hanging);
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::MuteAudio(true))));
+    }
+
+    #[test]
+    fn squelch_reopen_before_hang_end_returns_to_listening() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(1500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
+        assert_eq!(s.state(), ScannerState::Hanging);
+        // Advance partway into hang (2000ms hang = 96000 samples).
+        s.handle_event(tick(10_000));
+        let commands = s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::MuteAudio(false))));
+    }
+
+    #[test]
+    fn hang_elapsed_advances_to_next_channel() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(1500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Closed));
+        let commands = s.handle_event(tick(100_000));
+        assert_eq!(s.state(), ScannerState::Retuning);
+        assert!(commands.iter().any(|c| matches!(
+            c,
+            ScannerCommand::Retune { freq_hz: 162_550_000, .. }
+        )));
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p sdr-scanner --lib`
+Expected: 6 new tests FAIL — sample tick + squelch handlers are still stubs.
+
+- [ ] **Step 3: Implement `handle_sample_tick`**
+
+Replace the stub body:
+
+```rust
+    fn handle_sample_tick(
+        &mut self,
+        samples_consumed: u32,
+        sample_rate_hz: u32,
+    ) -> Vec<ScannerCommand> {
+        let samples = u64::from(samples_consumed);
+        let new_phase = match &mut self.phase {
+            Phase::Idle | Phase::Listening { .. } => return Vec::new(),
+            Phase::Retuning {
+                target_idx,
+                samples_until_settled,
+            } => {
+                if *samples_until_settled == 0 {
+                    // First tick after retune — seed countdown.
+                    *samples_until_settled = ms_to_samples(SETTLE_MS, sample_rate_hz);
+                }
+                *samples_until_settled = samples_until_settled.saturating_sub(samples);
+                if *samples_until_settled == 0 {
+                    let idx = *target_idx;
+                    let dwell_ms = self.channels[idx].dwell_ms;
+                    Some(Phase::Dwelling {
+                        idx,
+                        samples_until_timeout: ms_to_samples(dwell_ms, sample_rate_hz),
+                    })
+                } else {
+                    None
+                }
+            }
+            Phase::Dwelling {
+                idx,
+                samples_until_timeout,
+            } => {
+                *samples_until_timeout = samples_until_timeout.saturating_sub(samples);
+                if *samples_until_timeout == 0 {
+                    // Dwell elapsed silently — advance rotation.
+                    let _ = idx;
+                    Some(Phase::__AdvanceFromDwell)
+                } else {
+                    None
+                }
+            }
+            Phase::Hanging {
+                idx,
+                samples_until_timeout,
+            } => {
+                *samples_until_timeout = samples_until_timeout.saturating_sub(samples);
+                if *samples_until_timeout == 0 {
+                    let _ = idx;
+                    Some(Phase::__AdvanceFromHang)
+                } else {
+                    None
+                }
+            }
+        };
+
+        match new_phase {
+            None => Vec::new(),
+            Some(Phase::Dwelling {
+                idx,
+                samples_until_timeout,
+            }) => {
+                self.phase = Phase::Dwelling {
+                    idx,
+                    samples_until_timeout,
+                };
+                vec![ScannerCommand::StateChanged(ScannerState::Dwelling)]
+            }
+            Some(Phase::__AdvanceFromDwell) | Some(Phase::__AdvanceFromHang) => {
+                self.hops_since_priority_sweep += 1;
+                self.advance_rotation()
+            }
+            Some(_) => Vec::new(),
+        }
+    }
+
+    fn advance_rotation(&mut self) -> Vec<ScannerCommand> {
+        match self.pick_next_channel() {
+            Some(idx) => self.enter_retuning(idx),
+            None => {
+                self.phase = Phase::Idle;
+                vec![
+                    ScannerCommand::EmptyRotation,
+                    ScannerCommand::MuteAudio(false),
+                    ScannerCommand::ActiveChannelChanged(None),
+                    ScannerCommand::StateChanged(ScannerState::Idle),
+                ]
+            }
+        }
+    }
+```
+
+Also add the two synthetic `Phase` variants used as transition markers at the top of the `Phase` enum (these never appear in `self.phase`, they're just carriers):
+
+```rust
+enum Phase {
+    // ... existing variants ...
+    __AdvanceFromDwell,
+    __AdvanceFromHang,
+}
+```
+
+And add `__AdvanceFromDwell | __AdvanceFromHang` to the wildcard arm in `as_state`:
+
+```rust
+    fn as_state(&self) -> ScannerState {
+        match self {
+            // ... existing arms ...
+            Phase::__AdvanceFromDwell | Phase::__AdvanceFromHang => {
+                unreachable!("advance markers should never sit as the phase")
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Implement `handle_squelch_edge`**
+
+Replace stub body:
+
+```rust
+    fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
+        match (&self.phase, state) {
+            (Phase::Retuning { .. }, _) => {
+                // Ignore edges during settle window.
+                Vec::new()
+            }
+            (Phase::Dwelling { idx, .. }, SquelchState::Open) => {
+                let idx = *idx;
+                self.phase = Phase::Listening { idx };
+                vec![
+                    ScannerCommand::MuteAudio(false),
+                    ScannerCommand::StateChanged(ScannerState::Listening),
+                ]
+            }
+            (Phase::Listening { idx }, SquelchState::Closed) => {
+                let idx = *idx;
+                let hang_ms = self.channels[idx].hang_ms;
+                // We have the rate from the most recent SampleTick,
+                // but Hanging is sample-counted so we seed on first
+                // tick after entering. Initial value 0 means "seed
+                // on next tick" — matches Retuning's pattern.
+                self.phase = Phase::Hanging {
+                    idx,
+                    samples_until_timeout: u64::MAX, // sentinel: seed on first tick
+                };
+                // Actually: since hang resume-from-Listening also
+                // depends on ms, and we need the current rate, we
+                // store the _ms_ and convert on first tick. Simpler:
+                // add a Hanging field carrying the ms plus a seeded
+                // flag. See Step 5 for the clean fix.
+                let _ = hang_ms;
+                vec![
+                    ScannerCommand::MuteAudio(true),
+                    ScannerCommand::StateChanged(ScannerState::Hanging),
+                ]
+            }
+            (Phase::Hanging { idx, .. }, SquelchState::Open) => {
+                let idx = *idx;
+                self.phase = Phase::Listening { idx };
+                vec![
+                    ScannerCommand::MuteAudio(false),
+                    ScannerCommand::StateChanged(ScannerState::Listening),
+                ]
+            }
+            _ => Vec::new(),
+        }
+    }
+```
+
+- [ ] **Step 5: Fix the Hanging seeding**
+
+The `u64::MAX` sentinel is ugly. Replace `Phase::Hanging` with a seed-on-first-tick variant shape:
+
+```rust
+enum Phase {
+    // ...
+    Hanging {
+        idx: usize,
+        /// None → seed on next SampleTick (we just entered Hanging
+        /// from Listening and don't yet know the sample rate).
+        /// Some(n) → samples remaining before rotation advances.
+        samples_until_timeout: Option<u64>,
+    },
+}
+```
+
+Update the two match sites:
+- In `handle_squelch_edge`, entering Hanging: `samples_until_timeout: None`.
+- In `handle_sample_tick`, Hanging arm:
+
+```rust
+            Phase::Hanging {
+                idx,
+                samples_until_timeout,
+            } => {
+                let remaining = match samples_until_timeout {
+                    None => {
+                        let hang_ms = self.channels[*idx].hang_ms;
+                        let seeded = ms_to_samples(hang_ms, sample_rate_hz)
+                            .saturating_sub(samples);
+                        *samples_until_timeout = Some(seeded);
+                        seeded
+                    }
+                    Some(remaining) => {
+                        *remaining = remaining.saturating_sub(samples);
+                        *remaining
+                    }
+                };
+                if remaining == 0 {
+                    Some(Phase::__AdvanceFromHang)
+                } else {
+                    None
+                }
+            }
+```
+
+Apply the same `Option<u64>` treatment to `Phase::Retuning::samples_until_settled` for symmetry:
+
+```rust
+    Retuning {
+        target_idx: usize,
+        samples_until_settled: Option<u64>,
+    },
+```
+
+And update its match in `handle_sample_tick`:
+
+```rust
+            Phase::Retuning {
+                target_idx,
+                samples_until_settled,
+            } => {
+                let remaining = match samples_until_settled {
+                    None => {
+                        let seeded = ms_to_samples(SETTLE_MS, sample_rate_hz)
+                            .saturating_sub(samples);
+                        *samples_until_settled = Some(seeded);
+                        seeded
+                    }
+                    Some(remaining) => {
+                        *remaining = remaining.saturating_sub(samples);
+                        *remaining
+                    }
+                };
+                if remaining == 0 {
+                    let idx = *target_idx;
+                    let dwell_ms = self.channels[idx].dwell_ms;
+                    Some(Phase::Dwelling {
+                        idx,
+                        samples_until_timeout: ms_to_samples(dwell_ms, sample_rate_hz),
+                    })
+                } else {
+                    None
+                }
+            }
+```
+
+And update `enter_retuning` initializer from `samples_until_settled: 0` to `samples_until_settled: None`.
+
+- [ ] **Step 6: Run all tests**
+
+Run: `cargo test -p sdr-scanner --lib`
+Expected: 9/9 tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-scanner: sample-tick countdown + squelch-edge state transitions"
+```
+
+---
+
+### Task 1.7: Priority sweep, lockout, edge cases
+
+**Files:**
+- Modify: `crates/sdr-scanner/src/scanner.rs`
+
+- [ ] **Step 1: Add priority sweep test**
+
+Append to `mod tests`:
+
+```rust
+    #[test]
+    fn priority_sweep_triggers_after_interval_hops() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+            ch("P", 121_500_000, 1), // priority
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+
+        // Burn through 5 normal hops. Each hop = Retuning→Dwelling→advance.
+        // Need to settle (tick past 30ms), then timeout dwell (tick past 100ms).
+        let mut retune_freqs: Vec<u64> = Vec::new();
+        for _ in 0..6 {
+            s.handle_event(tick(1500)); // settle
+            let cmds = s.handle_event(tick(5000)); // dwell timeout → next retune
+            for c in &cmds {
+                if let ScannerCommand::Retune { freq_hz, .. } = c {
+                    retune_freqs.push(*freq_hz);
+                }
+            }
+        }
+        // After 5 normal hops, the 6th should be the priority channel.
+        assert!(
+            retune_freqs.contains(&121_500_000),
+            "priority channel should have appeared after 5 normal hops, got {retune_freqs:?}"
+        );
+    }
+
+    #[test]
+    fn lockout_skips_channel() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::LockoutChannel(ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        }));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // First retune should skip A and go to B.
+        // Check the initial retune command emitted from SetEnabled.
+        // We re-derive by inspecting state: the phase should be
+        // Retuning targeting B (index 1).
+        let mut s2 = Scanner::new();
+        s2.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s2.handle_event(ScannerEvent::LockoutChannel(ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        }));
+        let commands = s2.handle_event(ScannerEvent::SetEnabled(true));
+        let first_retune = commands.iter().find_map(|c| match c {
+            ScannerCommand::Retune { freq_hz, .. } => Some(*freq_hz),
+            _ => None,
+        });
+        assert_eq!(first_retune, Some(162_550_000));
+    }
+
+    #[test]
+    fn all_channels_locked_emits_empty_rotation() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch("A", 146_520_000, 0)]));
+        s.handle_event(ScannerEvent::LockoutChannel(ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        }));
+        let commands = s.handle_event(ScannerEvent::SetEnabled(true));
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::EmptyRotation)));
+        assert_eq!(s.state(), ScannerState::Idle);
+    }
+
+    #[test]
+    fn channel_override_respected_for_dwell() {
+        let mut s = Scanner::new();
+        let mut longer = ch("L", 146_520_000, 0);
+        longer.dwell_ms = 500;
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            longer,
+            ch("N", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        // Settle.
+        s.handle_event(tick(1500));
+        // Default dwell would be 100ms = 4800 samples. Channel
+        // overrides to 500ms = 24000 samples. Tick 5000 — should
+        // still be Dwelling (not advanced) because override kicks in.
+        s.handle_event(tick(5000));
+        assert_eq!(s.state(), ScannerState::Dwelling);
+        // Tick past 500ms → advance.
+        s.handle_event(tick(25_000));
+        assert_eq!(s.state(), ScannerState::Retuning);
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p sdr-scanner --lib`
+Expected: All 4 new tests PASS (the logic is already in place from Task 1.5/1.6). If one fails, inspect and adjust.
+
+- [ ] **Step 3: Add edge-case test: channels changed during scanning**
+
+```rust
+    #[test]
+    fn channels_changed_mid_scan_recovers() {
+        let mut s = Scanner::new();
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::SetEnabled(true));
+        s.handle_event(tick(1500));
+        s.handle_event(ScannerEvent::SquelchEdge(SquelchState::Open));
+        assert_eq!(s.state(), ScannerState::Listening);
+        // User deletes channel B and adds C.
+        let commands = s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("C", 28_400_000, 0),
+        ]));
+        // Scanner should recover — we chose to restart rotation at 0.
+        assert_eq!(s.state(), ScannerState::Retuning);
+        // First retune after list change goes to A.
+        assert!(commands
+            .iter()
+            .any(|c| matches!(c, ScannerCommand::Retune { freq_hz: 146_520_000, .. })));
+    }
+
+    #[test]
+    fn lockout_cleared_when_channel_removed() {
+        let mut s = Scanner::new();
+        let key_a = ChannelKey {
+            name: "A".to_string(),
+            frequency_hz: 146_520_000,
+        };
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![
+            ch("A", 146_520_000, 0),
+            ch("B", 162_550_000, 0),
+        ]));
+        s.handle_event(ScannerEvent::LockoutChannel(key_a.clone()));
+        // Remove A.
+        s.handle_event(ScannerEvent::ChannelsChanged(vec![ch(
+            "B",
+            162_550_000,
+            0,
+        )]));
+        // Internal set should have pruned.
+        assert!(!s.locked_out.contains(&key_a));
+    }
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `cargo test -p sdr-scanner --lib`
+Expected: 13/13 tests PASS.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy -p sdr-scanner --all-targets -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-scanner: priority sweep + lockout + edge-case tests"
+```
+
+---
+
+### Task 1.8: Finalize PR 1 — open PR
+
+- [ ] **Step 1: Verify workspace build**
+
+Run: `cargo build --workspace`
+Expected: Clean — the new crate slots in without breaking anything.
+
+- [ ] **Step 2: Run workspace tests**
+
+Run: `cargo test --workspace --features sdr-ui/whisper-cpu`
+Expected: All existing tests still pass; new scanner tests pass.
+
+- [ ] **Step 3: Rebase on latest main and push**
+
+```bash
+git fetch origin
+git rebase origin/main
+git push -u origin feature/scanner-engine
+```
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --title "feat(#317): scanner engine — sdr-scanner crate" --body "..."
+```
+
+Body should summarize: pure state machine, no I/O, zero integration. Lists the test coverage. References the design doc at `docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md`. Notes that PR 2 wires it into DspController.
+
+- [ ] **Step 5: Address CodeRabbit rounds as they come in**
+
+Follow the same pattern from prior PRs — fix, push, reply to each inline comment.
+
+- [ ] **Step 6: Merge and move to PR 2**
+
+After merge, sync main locally: `git checkout main && git pull --ff-only && git branch -D feature/scanner-engine`.
+
+---
+
+## PR 2 — `DspController` integration + bookmark schema
+
+**Branch:** `feature/scanner-integration`
+**Scope:** Wire the scanner into `DspController`, extend `Bookmark` schema, add UiToDsp/DspToUi variants, implement mutex with recording + transcription. No UI panel yet — smoke-testable via debug logs. ~500 lines.
+
+---
+
+### Task 2.1: Extend `Bookmark` schema
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/navigation_panel.rs` (Bookmark struct + tests)
+
+- [ ] **Step 1: Add the four new fields**
+
+In `navigation_panel.rs`, extend the `Bookmark` struct inline after `voice_squelch_mode`:
+
+```rust
+    /// Include in scanner rotation. Default false so existing
+    /// bookmarks don't start getting scanned without opt-in.
+    #[serde(default)]
+    pub scan_enabled: bool,
+    /// Priority tier. 0 = normal, 1 = priority (checked more
+    /// often). Higher tiers reserved for future phases.
+    #[serde(default)]
+    pub priority: u8,
+    /// Per-channel dwell override in ms. None → scanner default.
+    #[serde(default)]
+    pub dwell_ms_override: Option<u32>,
+    /// Per-channel hang override in ms. None → scanner default.
+    #[serde(default)]
+    pub hang_ms_override: Option<u32>,
+```
+
+Initialize them in `Bookmark::new` (the simple constructor) and `Bookmark::with_profile`:
+
+```rust
+    // ... existing inits ...
+    scan_enabled: false,
+    priority: 0,
+    dwell_ms_override: None,
+    hang_ms_override: None,
+```
+
+- [ ] **Step 2: Write a backward-compat serde roundtrip test**
+
+In the `#[cfg(test)] mod tests` at bottom of `navigation_panel.rs`:
+
+```rust
+    #[test]
+    fn bookmark_scanner_fields_default_on_old_json() {
+        // Old pre-scanner bookmark JSON (no scanner fields present).
+        let old_json = r#"{"name":"Old","frequency":162550000,"demod_mode":"NFM","bandwidth":12500.0}"#;
+        let bm: Bookmark = serde_json::from_str(old_json).unwrap();
+        assert!(!bm.scan_enabled);
+        assert_eq!(bm.priority, 0);
+        assert!(bm.dwell_ms_override.is_none());
+        assert!(bm.hang_ms_override.is_none());
+    }
+
+    #[test]
+    fn bookmark_scanner_fields_roundtrip() {
+        let mut bm = Bookmark::new("Test", 146_520_000, DemodMode::Nfm, 12_500.0);
+        bm.scan_enabled = true;
+        bm.priority = 1;
+        bm.dwell_ms_override = Some(200);
+        bm.hang_ms_override = Some(3000);
+        let json = serde_json::to_string(&bm).unwrap();
+        let back: Bookmark = serde_json::from_str(&json).unwrap();
+        assert!(back.scan_enabled);
+        assert_eq!(back.priority, 1);
+        assert_eq!(back.dwell_ms_override, Some(200));
+        assert_eq!(back.hang_ms_override, Some(3000));
+    }
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p sdr-ui --features whisper-cpu bookmark_scanner`
+Expected: Both PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git checkout -b feature/scanner-integration
+git add -A
+git commit -m "bookmark: add scanner fields (#317)"
+```
+
+---
+
+### Task 2.2: Add `UiToDsp` variants for scanner
+
+**Files:**
+- Modify: `crates/sdr-core/src/messages.rs`
+
+- [ ] **Step 1: Identify insertion point**
+
+Open `crates/sdr-core/src/messages.rs`. Locate `pub enum UiToDsp`. Add new variants before the closing brace (alphabetical isn't enforced elsewhere in this enum; group the scanner variants together).
+
+- [ ] **Step 2: Add the variants**
+
+```rust
+    // --- Scanner ---
+    /// Master scanner on/off toggle.
+    SetScannerEnabled(bool),
+    /// Replace the scanner's channel list. UI projects bookmarks
+    /// with `scan_enabled = true` into `ScannerChannel`s.
+    UpdateScannerChannels(Vec<sdr_scanner::ScannerChannel>),
+    /// Session-scoped lockout.
+    LockoutScannerChannel(sdr_scanner::ChannelKey),
+    UnlockoutScannerChannel(sdr_scanner::ChannelKey),
+    /// Global default timings (user moved the sidebar sliders).
+    SetScannerDefaultDwellMs(u32),
+    SetScannerDefaultHangMs(u32),
+```
+
+- [ ] **Step 3: Add `sdr-scanner` dependency on `sdr-core`**
+
+In `crates/sdr-core/Cargo.toml` `[dependencies]`:
+
+```toml
+sdr-scanner.workspace = true
+```
+
+- [ ] **Step 4: Verify compile**
+
+Run: `cargo build -p sdr-core`
+Expected: Clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-core: add scanner UiToDsp variants"
+```
+
+---
+
+### Task 2.3: Add `DspToUi` variants for scanner
+
+**Files:**
+- Modify: `crates/sdr-core/src/messages.rs`
+
+- [ ] **Step 1: Add variants near other DspToUi scanner-adjacent events**
+
+In `pub enum DspToUi`:
+
+```rust
+    // --- Scanner (#317) ---
+    ScannerActiveChannelChanged {
+        key: Option<sdr_scanner::ChannelKey>,
+        freq_hz: u64,
+        demod_mode: sdr_types::DemodMode,
+        bandwidth: f64,
+        name: String,
+    },
+    ScannerStateChanged(sdr_scanner::ScannerState),
+    /// Scanner emitted EmptyRotation — UI surfaces a toast.
+    ScannerEmptyRotation,
+    /// Scanner forced recording/transcription off (or vice versa).
+    ScannerMutexStopped(ScannerMutexReason),
+```
+
+And define the reason enum in the same file:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub enum ScannerMutexReason {
+    RecordingStoppedForScanner,
+    TranscriptionStoppedForScanner,
+    ScannerStoppedForRecording,
+    ScannerStoppedForTranscription,
+}
+```
+
+For the `ScannerActiveChannelChanged::key = None` case, the other fields should carry sensible defaults (0 freq, Nfm, 0 bw, empty name) — UI handler treats `key = None` as "scanner gone idle, clear display."
+
+- [ ] **Step 2: Compile**
+
+Run: `cargo build -p sdr-core`
+Expected: Clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-core: add scanner DspToUi variants + mutex reason enum"
+```
+
+---
+
+### Task 2.4: Wire scanner into `DspController`
+
+**Files:**
+- Modify: `crates/sdr-core/src/controller.rs`
+
+- [ ] **Step 1: Add scanner field to the controller struct**
+
+Near the other state fields in `DspController`:
+
+```rust
+    /// Scanner state machine. Fed sample ticks from the IQ loop
+    /// and squelch edges from the existing transcription edge
+    /// detector. Commands applied inline.
+    scanner: sdr_scanner::Scanner,
+```
+
+Initialize in `DspController::new` (or equivalent constructor) with `sdr_scanner::Scanner::new()`.
+
+- [ ] **Step 2: Handle the new UiToDsp variants**
+
+In the controller's message dispatch (match over `UiToDsp`), add arms forwarding events into the scanner and applying commands. Create a helper `apply_scanner_commands(&mut self, commands: Vec<ScannerCommand>)` that translates each command:
+
+```rust
+    fn apply_scanner_commands(&mut self, commands: Vec<sdr_scanner::ScannerCommand>) {
+        use sdr_scanner::ScannerCommand;
+        for cmd in commands {
+            match cmd {
+                ScannerCommand::Retune {
+                    freq_hz,
+                    demod_mode,
+                    bandwidth,
+                    ctcss,
+                    voice_squelch,
+                } => {
+                    // Apply to source + radio module directly (same
+                    // path the Tune / SetBandwidth / SetDemodMode
+                    // handlers use).
+                    if let Some(source) = self.source.as_mut() {
+                        let _ = source.set_center_freq(freq_hz);
+                    }
+                    self.radio_module.set_demod_mode(demod_mode);
+                    self.radio_module.set_bandwidth(bandwidth);
+                    if let Some(m) = ctcss {
+                        self.radio_module.set_ctcss_mode(m);
+                    }
+                    if let Some(m) = voice_squelch {
+                        self.radio_module.set_voice_squelch_mode(m);
+                    }
+                    // Emit ScannerActiveChannelChanged so UI syncs.
+                    // Name resolved from current channel list; if
+                    // scanner just advanced we need the key — pull
+                    // from the ActiveChannelChanged emission
+                    // elsewhere. Simplest: cache last emitted key
+                    // on self and look up name when Retune fires.
+                    // See Step 3 for the helper.
+                }
+                ScannerCommand::MuteAudio(muted) => {
+                    self.sink_manager.set_scanner_mute(muted);
+                }
+                ScannerCommand::ActiveChannelChanged(key) => {
+                    self.emit_scanner_active_channel(key);
+                }
+                ScannerCommand::StateChanged(state) => {
+                    let _ = self.dsp_to_ui_tx.send(
+                        DspToUi::ScannerStateChanged(state),
+                    );
+                }
+                ScannerCommand::EmptyRotation => {
+                    let _ = self
+                        .dsp_to_ui_tx
+                        .send(DspToUi::ScannerEmptyRotation);
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Write `emit_scanner_active_channel`**
+
+Add as a private method on `DspController`:
+
+```rust
+    fn emit_scanner_active_channel(
+        &self,
+        key: Option<sdr_scanner::ChannelKey>,
+    ) {
+        // Resolve to full-channel info so the UI can drive its
+        // frequency selector / spectrum / status bar without
+        // needing its own copy of the scanner channel list.
+        let channel = key.as_ref().and_then(|k| {
+            self.scanner_channels
+                .iter()
+                .find(|c| c.key == *k)
+                .cloned()
+        });
+        let msg = DspToUi::ScannerActiveChannelChanged {
+            key: key.clone(),
+            freq_hz: channel.as_ref().map_or(0, |c| c.frequency_hz),
+            demod_mode: channel
+                .as_ref()
+                .map_or(sdr_types::DemodMode::Nfm, |c| c.demod_mode),
+            bandwidth: channel.as_ref().map_or(0.0, |c| c.bandwidth),
+            name: channel.map_or_else(String::new, |c| c.key.name),
+        };
+        let _ = self.dsp_to_ui_tx.send(msg);
+    }
+```
+
+Also add a parallel field: `scanner_channels: Vec<sdr_scanner::ScannerChannel>` initialized empty, updated on `UpdateScannerChannels`:
+
+```rust
+    UiToDsp::UpdateScannerChannels(channels) => {
+        self.scanner_channels = channels.clone();
+        let cmds = self
+            .scanner
+            .handle_event(sdr_scanner::ScannerEvent::ChannelsChanged(channels));
+        self.apply_scanner_commands(cmds);
+    }
+```
+
+And arms for the rest:
+
+```rust
+    UiToDsp::SetScannerEnabled(enabled) => {
+        self.handle_scanner_mutex(enabled);
+        let cmds = self
+            .scanner
+            .handle_event(sdr_scanner::ScannerEvent::SetEnabled(enabled));
+        self.apply_scanner_commands(cmds);
+    }
+    UiToDsp::LockoutScannerChannel(key) => {
+        let cmds = self
+            .scanner
+            .handle_event(sdr_scanner::ScannerEvent::LockoutChannel(key));
+        self.apply_scanner_commands(cmds);
+    }
+    UiToDsp::UnlockoutScannerChannel(key) => {
+        let cmds = self
+            .scanner
+            .handle_event(sdr_scanner::ScannerEvent::UnlockoutChannel(key));
+        self.apply_scanner_commands(cmds);
+    }
+    UiToDsp::SetScannerDefaultDwellMs(ms) => {
+        let cmds = self
+            .scanner
+            .handle_event(sdr_scanner::ScannerEvent::SetDefaultDwellMs(ms));
+        self.apply_scanner_commands(cmds);
+    }
+    UiToDsp::SetScannerDefaultHangMs(ms) => {
+        let cmds = self
+            .scanner
+            .handle_event(sdr_scanner::ScannerEvent::SetDefaultHangMs(ms));
+        self.apply_scanner_commands(cmds);
+    }
+```
+
+- [ ] **Step 4: Feed SampleTick on every IQ block**
+
+Locate the IQ-block processing loop (where `radio_module.process` is called). After that call, add:
+
+```rust
+    let tick_cmds = self.scanner.handle_event(
+        sdr_scanner::ScannerEvent::SampleTick {
+            samples_consumed: block_samples as u32,
+            sample_rate_hz: source_sample_rate as u32,
+        },
+    );
+    self.apply_scanner_commands(tick_cmds);
+```
+
+- [ ] **Step 5: Feed SquelchEdge alongside existing transcription edge emission**
+
+Find the existing `SquelchOpened / SquelchClosed` emission site (line ~1846 of controller.rs per prior grep). Add scanner feed alongside:
+
+```rust
+    // Existing transcription emission:
+    sdr_transcription::TranscriptionInput::SquelchOpened
+    // New scanner feed:
+    let scan_cmds = self.scanner.handle_event(
+        sdr_scanner::ScannerEvent::SquelchEdge(
+            sdr_scanner::SquelchState::Open,
+        ),
+    );
+    self.apply_scanner_commands(scan_cmds);
+```
+
+Same pattern for the `SquelchClosed` branch.
+
+- [ ] **Step 6: Compile**
+
+Run: `cargo build -p sdr-core`
+Expected: Clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-core: wire scanner into DspController"
+```
+
+---
+
+### Task 2.5: Implement scanner ↔ recording / transcription mutex
+
+**Files:**
+- Modify: `crates/sdr-core/src/controller.rs`
+
+- [ ] **Step 1: Add mutex enforcement in `handle_scanner_mutex`**
+
+```rust
+    fn handle_scanner_mutex(&mut self, scanner_becoming_active: bool) {
+        if !scanner_becoming_active {
+            return;
+        }
+        // Stop active recording.
+        if self.recording_active {
+            self.stop_recording(); // existing method
+            let _ = self
+                .dsp_to_ui_tx
+                .send(DspToUi::ScannerMutexStopped(
+                    ScannerMutexReason::RecordingStoppedForScanner,
+                ));
+        }
+        // Stop active transcription.
+        if self.transcription_active() {
+            self.stop_transcription(); // existing method
+            let _ = self
+                .dsp_to_ui_tx
+                .send(DspToUi::ScannerMutexStopped(
+                    ScannerMutexReason::TranscriptionStoppedForScanner,
+                ));
+        }
+    }
+```
+
+- [ ] **Step 2: Reject recording/transcription start while scanner is on**
+
+In the existing `UiToDsp::StartRecording` / transcription start handlers, add a pre-check:
+
+```rust
+    UiToDsp::StartRecording { .. } => {
+        if self.scanner.state() != sdr_scanner::ScannerState::Idle {
+            // Scanner is active — stop it before starting recording.
+            let cmds = self
+                .scanner
+                .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
+            self.apply_scanner_commands(cmds);
+            let _ = self.dsp_to_ui_tx.send(DspToUi::ScannerMutexStopped(
+                ScannerMutexReason::ScannerStoppedForRecording,
+            ));
+        }
+        // ... existing recording start logic ...
+    }
+```
+
+Similar for transcription start.
+
+- [ ] **Step 3: Compile**
+
+Run: `cargo build -p sdr-core`
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-core: scanner ↔ recording/transcription mutex"
+```
+
+---
+
+### Task 2.6: Sink mute plumbing
+
+**Files:**
+- Modify: `crates/sdr-core/src/sink_manager.rs` (or wherever `SinkManager` lives)
+
+- [ ] **Step 1: Add `scanner_mute: bool` field**
+
+```rust
+pub struct SinkManager {
+    // ... existing fields ...
+    scanner_mute: bool,
+}
+
+impl SinkManager {
+    pub fn set_scanner_mute(&mut self, muted: bool) {
+        self.scanner_mute = muted;
+    }
+}
+```
+
+- [ ] **Step 2: Gate in the audio write path**
+
+Wherever the manager writes PCM to the audio device, wrap the buffer:
+
+```rust
+    pub fn write_audio(&mut self, audio: &[f32]) {
+        if self.scanner_mute {
+            let silence = vec![0.0_f32; audio.len()];
+            // ... write silence to current sink ...
+        } else {
+            // ... write audio as-is ...
+        }
+    }
+```
+
+If there's a single hot path, hoist the branch out of the per-sample loop.
+
+- [ ] **Step 3: Compile**
+
+Run: `cargo build --workspace`
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "sink-manager: scanner_mute gate at audio output"
+```
+
+---
+
+### Task 2.7: Verify + open PR 2
+
+- [ ] **Step 1: Run the full workspace test suite**
+
+Run: `cargo test --workspace --features sdr-ui/whisper-cpu`
+Expected: All tests pass. Scanner crate tests (13) + bookmark roundtrip tests (2 new) + everything existing.
+
+- [ ] **Step 2: Clippy check**
+
+Run: `cargo clippy --workspace --features sdr-ui/whisper-cpu --all-targets -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 3: Smoke-test via debug-build logs**
+
+Add temporary `tracing::info!` calls in `apply_scanner_commands` if they're not already there. Run: `make install && sdr-rs`. Observe log stream while triggering scanner via a dev-only UiToDsp dispatch (no UI panel yet — can poke via a test hook or defer to PR 3 smoke).
+
+If no easy way to trigger scanner without UI, document as a known constraint of PR 2 — actual end-to-end smoke happens in PR 3.
+
+- [ ] **Step 4: Rebase + push + PR**
+
+```bash
+git fetch origin
+git rebase origin/main
+git push -u origin feature/scanner-integration
+gh pr create --title "feat(#317): scanner ↔ DspController integration + bookmark schema" --body "..."
+```
+
+Body: references PR 1 (scanner engine), notes bookmark schema extension, mutex with recording/transcription, UI surface still deferred to PR 3.
+
+- [ ] **Step 5: CR rounds → merge**
+
+---
+
+## PR 3 — UI surface
+
+**Branch:** `feature/scanner-ui`
+**Scope:** Sidebar scanner panel at the bottom of the left column, bookmark row Scan checkbox + Priority toggle, full UI sync wiring, mutex UI behavior, manual-tune-force-disables-scanner. User smoke test before merge. Closes #317.
+
+---
+
+### Task 3.1: Create scanner panel module
+
+**Files:**
+- Create: `crates/sdr-ui/src/sidebar/scanner_panel.rs`
+- Modify: `crates/sdr-ui/src/sidebar/mod.rs`
+
+- [ ] **Step 1: Write `scanner_panel.rs`**
+
+```rust
+//! Scanner control panel at the bottom of the left sidebar.
+//!
+//! Master switch, active-channel / state display, default
+//! dwell/hang sliders (collapsed expander), and session lockout
+//! button (visible only when scanner is on an active channel).
+//! UI wiring of user actions → `UiToDsp::*` commands lives in
+//! `window.rs::connect_scanner_panel`.
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+
+pub struct ScannerPanel {
+    pub widget: gtk4::Box,
+    pub master_switch: gtk4::Switch,
+    pub active_channel_label: gtk4::Label,
+    pub state_label: gtk4::Label,
+    pub default_dwell_row: adw::SpinRow,
+    pub default_hang_row: adw::SpinRow,
+    pub lockout_button: gtk4::Button,
+}
+
+pub const DWELL_MIN_MS: f64 = 50.0;
+pub const DWELL_MAX_MS: f64 = 500.0;
+pub const HANG_MIN_MS: f64 = 500.0;
+pub const HANG_MAX_MS: f64 = 5000.0;
+
+pub const CONFIG_KEY_DEFAULT_DWELL_MS: &str = "scanner_default_dwell_ms";
+pub const CONFIG_KEY_DEFAULT_HANG_MS: &str = "scanner_default_hang_ms";
+
+#[must_use]
+pub fn build_scanner_panel() -> ScannerPanel {
+    let widget = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(8)
+        .build();
+
+    let heading = gtk4::Label::builder()
+        .label("Scanner")
+        .css_classes(["heading"])
+        .halign(gtk4::Align::Start)
+        .build();
+    widget.append(&heading);
+
+    // Master switch row.
+    let switch_row = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .spacing(8)
+        .build();
+    let switch_label = gtk4::Label::builder()
+        .label("Scanner")
+        .hexpand(true)
+        .halign(gtk4::Align::Start)
+        .build();
+    let master_switch = gtk4::Switch::builder().halign(gtk4::Align::End).build();
+    switch_row.append(&switch_label);
+    switch_row.append(&master_switch);
+    widget.append(&switch_row);
+
+    // Active channel label.
+    let active_channel_label = gtk4::Label::builder()
+        .label("Active: —")
+        .halign(gtk4::Align::Start)
+        .css_classes(["caption"])
+        .build();
+    widget.append(&active_channel_label);
+
+    // State label.
+    let state_label = gtk4::Label::builder()
+        .label("State: Off")
+        .halign(gtk4::Align::Start)
+        .css_classes(["caption", "dim-label"])
+        .build();
+    widget.append(&state_label);
+
+    // Lockout button (hidden until listening/hanging).
+    let lockout_button = gtk4::Button::builder()
+        .label("Lockout current channel")
+        .css_classes(["destructive-action", "flat"])
+        .visible(false)
+        .build();
+    widget.append(&lockout_button);
+
+    // Settings expander.
+    let expander = adw::ExpanderRow::builder().title("Settings").build();
+    let default_dwell_row = adw::SpinRow::builder()
+        .title("Default dwell (ms)")
+        .adjustment(&gtk4::Adjustment::new(
+            100.0,
+            DWELL_MIN_MS,
+            DWELL_MAX_MS,
+            10.0,
+            50.0,
+            0.0,
+        ))
+        .digits(0)
+        .build();
+    let default_hang_row = adw::SpinRow::builder()
+        .title("Default hang (ms)")
+        .adjustment(&gtk4::Adjustment::new(
+            2000.0,
+            HANG_MIN_MS,
+            HANG_MAX_MS,
+            100.0,
+            500.0,
+            0.0,
+        ))
+        .digits(0)
+        .build();
+    expander.add_row(&default_dwell_row);
+    expander.add_row(&default_hang_row);
+
+    // Wrap expander in a ListBox for proper styling.
+    let settings_group = gtk4::ListBox::builder()
+        .selection_mode(gtk4::SelectionMode::None)
+        .css_classes(["boxed-list"])
+        .build();
+    settings_group.append(&expander);
+    widget.append(&settings_group);
+
+    ScannerPanel {
+        widget,
+        master_switch,
+        active_channel_label,
+        state_label,
+        default_dwell_row,
+        default_hang_row,
+        lockout_button,
+    }
+}
+```
+
+- [ ] **Step 2: Register in `sidebar/mod.rs`**
+
+Add `pub mod scanner_panel;` near the other `pub mod` lines, and `pub use scanner_panel::{ScannerPanel, build_scanner_panel};`.
+
+Add field to `SidebarPanels`:
+
+```rust
+    /// Scanner control panel at bottom of left sidebar.
+    pub scanner: ScannerPanel,
+```
+
+In `build_sidebar`, construct and append to `sidebar_box` after `display.widget`:
+
+```rust
+    let scanner = build_scanner_panel();
+    sidebar_box.append(&scanner.widget);
+```
+
+And include in the returned struct.
+
+- [ ] **Step 3: Compile**
+
+Run: `cargo clippy -p sdr-ui --features whisper-cpu --all-targets -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git checkout -b feature/scanner-ui
+git add -A
+git commit -m "sdr-ui: scanner panel scaffolding"
+```
+
+---
+
+### Task 3.2: Wire master switch + default sliders → UiToDsp
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs` (new `connect_scanner_panel` fn)
+
+- [ ] **Step 1: Write `connect_scanner_panel`**
+
+```rust
+fn connect_scanner_panel(
+    panels: &SidebarPanels,
+    state: &Rc<AppState>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
+    let scanner = &panels.scanner;
+
+    // Master switch → SetScannerEnabled.
+    let state_switch = Rc::clone(state);
+    scanner.master_switch.connect_state_set(move |_, active| {
+        state_switch.send_dsp(UiToDsp::SetScannerEnabled(active));
+        glib::Propagation::Proceed
+    });
+
+    // Default dwell slider.
+    let state_dwell = Rc::clone(state);
+    let cfg_dwell = std::sync::Arc::clone(config);
+    scanner
+        .default_dwell_row
+        .connect_value_notify(move |row| {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let ms = row.value() as u32;
+            state_dwell.send_dsp(UiToDsp::SetScannerDefaultDwellMs(ms));
+            cfg_dwell.write(|v| {
+                v[sidebar::scanner_panel::CONFIG_KEY_DEFAULT_DWELL_MS] =
+                    serde_json::json!(ms);
+            });
+        });
+
+    // Default hang slider.
+    let state_hang = Rc::clone(state);
+    let cfg_hang = std::sync::Arc::clone(config);
+    scanner
+        .default_hang_row
+        .connect_value_notify(move |row| {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let ms = row.value() as u32;
+            state_hang.send_dsp(UiToDsp::SetScannerDefaultHangMs(ms));
+            cfg_hang.write(|v| {
+                v[sidebar::scanner_panel::CONFIG_KEY_DEFAULT_HANG_MS] =
+                    serde_json::json!(ms);
+            });
+        });
+
+    // Restore persisted defaults.
+    let saved_dwell = config.read(|v| {
+        v.get(sidebar::scanner_panel::CONFIG_KEY_DEFAULT_DWELL_MS)
+            .and_then(serde_json::Value::as_u64)
+            .map_or(100.0_f64, |v| v as f64)
+    });
+    scanner.default_dwell_row.set_value(saved_dwell);
+
+    let saved_hang = config.read(|v| {
+        v.get(sidebar::scanner_panel::CONFIG_KEY_DEFAULT_HANG_MS)
+            .and_then(serde_json::Value::as_u64)
+            .map_or(2000.0_f64, |v| v as f64)
+    });
+    scanner.default_hang_row.set_value(saved_hang);
+}
+```
+
+- [ ] **Step 2: Call from `build_window`**
+
+In the main wiring block:
+
+```rust
+    connect_scanner_panel(&panels, &state, config);
+```
+
+- [ ] **Step 3: Compile + lint**
+
+Run: `cargo clippy -p sdr-ui --features whisper-cpu --all-targets -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-ui: scanner master switch + default sliders wired"
+```
+
+---
+
+### Task 3.3: Handle `DspToUi::Scanner*` events → UI updates
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs` (event dispatch)
+
+- [ ] **Step 1: Add arms to the DspToUi handler**
+
+In the existing match over `DspToUi` events, add:
+
+```rust
+    DspToUi::ScannerActiveChannelChanged {
+        key,
+        freq_hz,
+        demod_mode,
+        bandwidth,
+        name,
+    } => {
+        let scanner = &panels.scanner;
+        if key.is_some() {
+            scanner.active_channel_label.set_text(&format!(
+                "Active: {} — {}",
+                name,
+                sidebar::navigation_panel::format_frequency(freq_hz),
+            ));
+            // Sync all existing UI surfaces to the new tune.
+            freq_selector.set_frequency(freq_hz);
+            #[allow(clippy::cast_precision_loss)]
+            spectrum_handle.set_center_frequency(freq_hz as f64);
+            #[allow(clippy::cast_precision_loss)]
+            status_bar_demod.update_frequency(freq_hz as f64);
+            let label = header::demod_mode_label(demod_mode);
+            status_bar_demod.update_demod(label, bandwidth);
+            // Demod dropdown + bandwidth row updates (see Task 3.4
+            // for the suppress-notify guard pattern).
+            state.suppress_demod_notify.set(true);
+            if let Some(idx) =
+                header::demod_selector::demod_mode_to_index(demod_mode)
+            {
+                demod_dropdown.set_selected(idx);
+            }
+            state.suppress_demod_notify.set(false);
+            state.suppress_bandwidth_notify.set(true);
+            panels.radio.bandwidth_row.set_value(bandwidth);
+            state.suppress_bandwidth_notify.set(false);
+            // Show lockout button (hidden while Idle/Retuning).
+            panels.scanner.lockout_button.set_visible(true);
+        } else {
+            scanner.active_channel_label.set_text("Active: —");
+            panels.scanner.lockout_button.set_visible(false);
+        }
+    }
+    DspToUi::ScannerStateChanged(scanner_state) => {
+        let label = match scanner_state {
+            sdr_scanner::ScannerState::Idle => "Off",
+            sdr_scanner::ScannerState::Retuning => "Scanning…",
+            sdr_scanner::ScannerState::Dwelling => "Listening…",
+            sdr_scanner::ScannerState::Listening => "Listening",
+            sdr_scanner::ScannerState::Hanging => "Hang…",
+        };
+        panels
+            .scanner
+            .state_label
+            .set_text(&format!("State: {}", label));
+    }
+    DspToUi::ScannerEmptyRotation => {
+        toast_overlay.add_toast(
+            adw::Toast::builder()
+                .title("Scanner has no active channels")
+                .timeout(3)
+                .build(),
+        );
+        panels.scanner.master_switch.set_state(false);
+    }
+    DspToUi::ScannerMutexStopped(reason) => {
+        let msg = match reason {
+            sdr_core::messages::ScannerMutexReason::RecordingStoppedForScanner =>
+                "Recording stopped — scanner activated",
+            sdr_core::messages::ScannerMutexReason::TranscriptionStoppedForScanner =>
+                "Transcription stopped — scanner activated",
+            sdr_core::messages::ScannerMutexReason::ScannerStoppedForRecording =>
+                "Scanner stopped — recording started",
+            sdr_core::messages::ScannerMutexReason::ScannerStoppedForTranscription =>
+                "Scanner stopped — transcription started",
+        };
+        toast_overlay.add_toast(
+            adw::Toast::builder().title(msg).timeout(3).build(),
+        );
+    }
+```
+
+- [ ] **Step 2: Add `suppress_demod_notify: Cell<bool>` to `AppState`**
+
+In `crates/sdr-ui/src/state.rs`:
+
+```rust
+    /// Mirror of `suppress_bandwidth_notify` for the demod dropdown.
+    /// Set true when we're programmatically changing the selected
+    /// demod mode so the dropdown's `connect_selected_notify`
+    /// doesn't bounce a `SetDemodMode` command back to DSP.
+    pub suppress_demod_notify: Cell<bool>,
+```
+
+Initialize to `Cell::new(false)` in constructor. Add a guard check in `demod_dropdown.connect_selected_notify` at wiring time:
+
+```rust
+    dd.connect_selected_notify(move |row| {
+        if state.suppress_demod_notify.get() {
+            return;
+        }
+        // ... existing dispatch logic ...
+    });
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `cargo clippy -p sdr-ui --features whisper-cpu --all-targets -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-ui: handle scanner DspToUi events + sync UI surfaces"
+```
+
+---
+
+### Task 3.4: Bookmark row Scan + Priority toggles
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/navigation_panel.rs` (row builder)
+
+- [ ] **Step 1: Extend `build_bookmark_row` with two new suffix widgets**
+
+In `build_bookmark_row` (after the existing `delete_btn` append):
+
+```rust
+    // Scan checkbox — binds to bookmark.scan_enabled.
+    let scan_check = gtk4::CheckButton::builder()
+        .tooltip_text("Include in scanner")
+        .valign(gtk4::Align::Center)
+        .active(bm.scan_enabled)
+        .build();
+    scan_check.update_property(&[gtk4::accessible::Property::Label(
+        "Include in scanner",
+    )]);
+    let bm_rc_scan = std::rc::Rc::clone(bookmarks);
+    let entry_scan = name_entry.clone();
+    let sig_name = bm.name.clone();
+    let sig_freq = bm.frequency;
+    let state_scan = state.clone();
+    scan_check.connect_toggled(move |btn| {
+        let enabled = btn.is_active();
+        let mut bms = bm_rc_scan.borrow_mut();
+        if let Some(b) = bms
+            .iter_mut()
+            .find(|b| b.name == sig_name && b.frequency == sig_freq)
+        {
+            b.scan_enabled = enabled;
+        }
+        save_bookmarks(&bms);
+        // Push the new channel list to the scanner.
+        let channels = project_scanner_channels(&bms);
+        drop(bms);
+        state_scan.send_dsp(UiToDsp::UpdateScannerChannels(channels));
+    });
+    row.add_suffix(&scan_check);
+
+    // Priority star — binds to bookmark.priority (0 or 1 in Phase 1).
+    let pri_btn = gtk4::ToggleButton::builder()
+        .icon_name(if bm.priority >= 1 {
+            "starred-symbolic"
+        } else {
+            "non-starred-symbolic"
+        })
+        .tooltip_text("Scanner priority channel")
+        .css_classes(["flat"])
+        .valign(gtk4::Align::Center)
+        .active(bm.priority >= 1)
+        .build();
+    pri_btn.update_property(&[gtk4::accessible::Property::Label(
+        "Scanner priority channel",
+    )]);
+    let bm_rc_pri = std::rc::Rc::clone(bookmarks);
+    let pri_name = bm.name.clone();
+    let pri_freq = bm.frequency;
+    let state_pri = state.clone();
+    pri_btn.connect_toggled(move |btn| {
+        let priority = if btn.is_active() { 1 } else { 0 };
+        btn.set_icon_name(if btn.is_active() {
+            "starred-symbolic"
+        } else {
+            "non-starred-symbolic"
+        });
+        let mut bms = bm_rc_pri.borrow_mut();
+        if let Some(b) = bms
+            .iter_mut()
+            .find(|b| b.name == pri_name && b.frequency == pri_freq)
+        {
+            b.priority = priority;
+        }
+        save_bookmarks(&bms);
+        let channels = project_scanner_channels(&bms);
+        drop(bms);
+        state_pri.send_dsp(UiToDsp::UpdateScannerChannels(channels));
+    });
+    row.add_suffix(&pri_btn);
+```
+
+Update `build_bookmark_row`'s signature to take `state: &Rc<AppState>` so the toggles can dispatch. Threads through `rebuild_bookmark_list` as another parameter. Update all call sites.
+
+- [ ] **Step 2: Write `project_scanner_channels` in navigation_panel.rs**
+
+```rust
+/// Project the bookmark list into `ScannerChannel`s. Only
+/// includes bookmarks with `scan_enabled = true`. Override
+/// fields are folded against the scanner defaults at projection
+/// time so the scanner state machine doesn't need to know about
+/// Options.
+pub fn project_scanner_channels(
+    bookmarks: &[Bookmark],
+) -> Vec<sdr_scanner::ScannerChannel> {
+    bookmarks
+        .iter()
+        .filter(|b| b.scan_enabled)
+        .map(|b| sdr_scanner::ScannerChannel {
+            key: sdr_scanner::ChannelKey {
+                name: b.name.clone(),
+                frequency_hz: b.frequency,
+            },
+            frequency_hz: b.frequency,
+            demod_mode: parse_demod_mode(&b.demod_mode),
+            bandwidth: b.bandwidth,
+            ctcss: b.ctcss_mode.clone(),
+            voice_squelch: b.voice_squelch_mode,
+            priority: b.priority,
+            dwell_ms: b
+                .dwell_ms_override
+                .unwrap_or(sdr_scanner::DEFAULT_DWELL_MS),
+            hang_ms: b
+                .hang_ms_override
+                .unwrap_or(sdr_scanner::DEFAULT_HANG_MS),
+        })
+        .collect()
+}
+```
+
+- [ ] **Step 3: Also push `UpdateScannerChannels` on Add / Delete / RR import paths**
+
+Locate the add-bookmark click handler, delete-button click handler (inside `build_bookmark_row`), and the RR browse post-import callback. After each `save_bookmarks` call, add:
+
+```rust
+    let channels = project_scanner_channels(&bm_rc.borrow());
+    state_clone.send_dsp(UiToDsp::UpdateScannerChannels(channels));
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `cargo clippy -p sdr-ui --features whisper-cpu --all-targets -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-ui: bookmark row scan checkbox + priority toggle"
+```
+
+---
+
+### Task 3.5: Lockout button + manual-tune-force-disables-scanner
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs` (lockout click + manual tune hook)
+
+- [ ] **Step 1: Wire lockout button**
+
+In `connect_scanner_panel`:
+
+```rust
+    // Lockout button. The active channel's key is captured via
+    // the most recent ScannerActiveChannelChanged — stash it on
+    // AppState for the click handler to read.
+    let state_lockout = Rc::clone(state);
+    scanner.lockout_button.connect_clicked(move |_| {
+        if let Some(key) = state_lockout.scanner_active_key.borrow().clone() {
+            state_lockout.send_dsp(UiToDsp::LockoutScannerChannel(key));
+        }
+    });
+```
+
+- [ ] **Step 2: Add `scanner_active_key` field to `AppState`**
+
+```rust
+    /// Scanner's currently-active channel key (if any). Updated
+    /// on every `ScannerActiveChannelChanged` event. Read by the
+    /// lockout button to know what to lock out.
+    pub scanner_active_key: RefCell<Option<sdr_scanner::ChannelKey>>,
+```
+
+Update the `ScannerActiveChannelChanged` handler from Task 3.3 to write this field:
+
+```rust
+    *state.scanner_active_key.borrow_mut() = key.clone();
+```
+
+- [ ] **Step 3: Force-disable scanner on manual tune**
+
+Locate the `frequency_selector.connect_frequency_changed` handler (or whatever signal fires on manual tune). Add a pre-dispatch:
+
+```rust
+    if panels.scanner.master_switch.state() {
+        panels.scanner.master_switch.set_state(false);
+        toast_overlay.add_toast(
+            adw::Toast::builder()
+                .title("Scanner stopped — manual tune")
+                .timeout(3)
+                .build(),
+        );
+    }
+```
+
+Same pattern for demod dropdown changes, bandwidth changes, and preset selection.
+
+- [ ] **Step 4: Compile**
+
+Run: `cargo clippy -p sdr-ui --features whisper-cpu --all-targets -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-ui: lockout button + manual-tune force-disables scanner"
+```
+
+---
+
+### Task 3.6: Initial channel list push + keyboard shortcut
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs`
+- Modify: `crates/sdr-ui/src/shortcuts.rs`
+
+- [ ] **Step 1: Push scanner channels on app startup**
+
+In `build_window` after the panels are wired up, push the initial channel list to the scanner:
+
+```rust
+    // Seed the scanner with the persisted bookmark list — scanner
+    // starts Idle so no retune happens, but the channels are in
+    // place if the user flips the switch on.
+    let initial_channels =
+        sidebar::navigation_panel::project_scanner_channels(
+            &panels.bookmarks.bookmarks.borrow(),
+        );
+    state.send_dsp(UiToDsp::UpdateScannerChannels(initial_channels));
+```
+
+- [ ] **Step 2: Add F8 shortcut to toggle scanner**
+
+In `crates/sdr-ui/src/shortcuts.rs` `setup_shortcuts`, add a new block mirroring the F9 sidebar-toggle block:
+
+```rust
+    // F8: Toggle scanner master switch.
+    let scanner_switch_weak = scanner_switch.downgrade();
+    let trigger_f8 = gtk4::ShortcutTrigger::parse_string("F8");
+    if let Some(trigger) = trigger_f8 {
+        let action = gtk4::CallbackAction::new(move |_widget, _args| {
+            if let Some(sw) = scanner_switch_weak.upgrade() {
+                sw.set_state(!sw.state());
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        let shortcut = gtk4::Shortcut::new(Some(trigger), Some(action));
+        controller.add_shortcut(shortcut);
+    }
+```
+
+Update `setup_shortcuts`'s signature to take `scanner_switch: &gtk4::Switch`.
+
+Update the `SHORTCUT_CATALOG` to include the new shortcut:
+
+```rust
+    (
+        "Navigation",
+        &[
+            ("F9", "Toggle sidebar"),
+            ("Ctrl+B", "Toggle bookmarks panel"),
+            ("F8", "Toggle scanner"),
+        ],
+    ),
+```
+
+Update the call site in `window.rs`:
+
+```rust
+    shortcuts::setup_shortcuts(
+        &window,
+        &play_button,
+        &sidebar_toggle,
+        &bookmarks_toggle,
+        &panels.scanner.master_switch,
+        &demod_dropdown,
+    );
+```
+
+- [ ] **Step 3: Compile + lint**
+
+Run: `cargo clippy -p sdr-ui --features whisper-cpu --all-targets -- -D warnings`
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "sdr-ui: initial channel seed + F8 scanner shortcut"
+```
+
+---
+
+### Task 3.7: Final build, smoke test, open PR
+
+- [ ] **Step 1: Full workspace build + tests**
+
+Run:
+```bash
+cargo clippy --workspace --features sdr-ui/whisper-cpu --all-targets -- -D warnings
+cargo test --workspace --features sdr-ui/whisper-cpu
+```
+Expected: All clean.
+
+- [ ] **Step 2: Install and hand off to user for smoke test**
+
+```bash
+make install CARGO_FLAGS="--release --features whisper-cuda"
+```
+
+Give the user the smoke test checklist:
+- Enable scan on 5+ bookmarks (NFM mix across bands).
+- Mark 1-2 as priority.
+- Flip scanner switch on.
+- Verify: frequency selector + spectrum flick through channels; state label cycles Scanning / Listening / Hanging; audio silent during retune, active during listening; priority channels get checked more often.
+- Lockout current channel during Listening; verify it's skipped next cycle.
+- Try to start recording while scanner on → verify scanner stops with toast.
+- Try to start transcription while scanner on → same.
+- Manually tune via spectrum click → verify scanner stops with toast.
+- F8 toggles scanner.
+- Persistence: set default dwell to 200ms, restart, verify slider shows 200.
+
+- [ ] **Step 3: Rebase + push + PR**
+
+```bash
+git fetch origin
+git rebase origin/main
+git push -u origin feature/scanner-ui
+gh pr create --title "feat(#317): scanner UI + closes scanner Phase 1" --body "..."
+```
+
+Body: Closes #317. References PR 1 + PR 2. Lists smoke-test checklist, notes what's in scope vs. what's deferred to follow-up issues.
+
+- [ ] **Step 4: CR rounds → merge**
+
+---
+
+## After all three PRs merge
+
+- File follow-up tickets (per spec "Out of scope" + "Follow-up issues" sections):
+  - Per-hit recording
+  - Per-hit transcription log
+  - Band / category scanning
+  - Mac-side SwiftUI scanner
+
+- Update `memory/project_current_state.md` with a new "Scanner Phase 1 — shipped" section summarizing the three PRs, mutex behavior, UI surface, deferred follow-ups. Mirror the format used for #361, #359, etc.
+
+- If priority-interrupt-during-listening (#365) becomes relevant, re-read the state machine and plan it as an extension.

--- a/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
+++ b/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
@@ -394,6 +394,13 @@ pub struct Scanner {
     hops_since_priority_sweep: u32,
     /// Set while a priority sweep is in progress.
     in_priority_sweep: bool,
+    /// Latched squelch state, updated on every `SquelchEdge`
+    /// regardless of phase. Retuning drops phase transitions
+    /// (retune-transient suppression) but the latch carries
+    /// open/closed through to `handle_sample_tick`'s settle-
+    /// expiry decision: `true` → direct Listening; `false` →
+    /// Dwelling. Reset to `false` on retune entry.
+    squelch_open: bool,
 }
 
 impl Default for Scanner {
@@ -407,6 +414,7 @@ impl Default for Scanner {
             priority_cursor: 0,
             hops_since_priority_sweep: 0,
             in_priority_sweep: false,
+            squelch_open: false,
         }
     }
 }
@@ -528,7 +536,6 @@ mod tests {
                 name: name.to_string(),
                 frequency_hz: freq,
             },
-            frequency_hz: freq,
             demod_mode: DemodMode::Nfm,
             bandwidth: 12_500.0,
             ctcss: None,
@@ -638,16 +645,21 @@ Replace `handle_set_enabled`, `handle_channels_changed` stub bodies and add new 
     /// rate isn't known here).
     fn enter_retuning(&mut self, idx: usize) -> Vec<ScannerCommand> {
         let channel = &self.channels[idx];
+        // Clear the squelch latch — previous channel's state
+        // is irrelevant after retune, and edges arriving during
+        // the new channel's settle window will update the latch
+        // so settle-expiry has accurate information.
+        self.squelch_open = false;
         self.phase = Phase::Retuning {
             target_idx: idx,
             samples_until_settled: 0, // seeded on first SampleTick
         };
         vec![
             ScannerCommand::Retune {
-                freq_hz: channel.frequency_hz,
+                freq_hz: channel.key.frequency_hz,
                 demod_mode: channel.demod_mode,
                 bandwidth: channel.bandwidth,
-                ctcss: channel.ctcss.clone(),
+                ctcss: channel.ctcss,
                 voice_squelch: channel.voice_squelch,
             },
             ScannerCommand::MuteAudio(true),
@@ -932,11 +944,20 @@ Replace the stub body:
                 *samples_until_settled = samples_until_settled.saturating_sub(samples);
                 if *samples_until_settled == 0 {
                     let idx = *target_idx;
-                    let dwell_ms = self.channels[idx].dwell_ms;
-                    Some(Phase::Dwelling {
-                        idx,
-                        samples_until_timeout: ms_to_samples(dwell_ms, sample_rate_hz),
-                    })
+                    // Settle complete. If the squelch latched open
+                    // during settle (persistent carrier), skip
+                    // Dwelling and jump straight to Listening —
+                    // otherwise we'd wait forever for a second
+                    // edge that already fired.
+                    if self.squelch_open {
+                        Some(Phase::Listening { idx })
+                    } else {
+                        let dwell_ms = self.channels[idx].dwell_ms;
+                        Some(Phase::Dwelling {
+                            idx,
+                            samples_until_timeout: ms_to_samples(dwell_ms, sample_rate_hz),
+                        })
+                    }
                 } else {
                     None
                 }
@@ -979,6 +1000,14 @@ Replace the stub body:
                     samples_until_timeout,
                 };
                 vec![ScannerCommand::StateChanged(ScannerState::Dwelling)]
+            }
+            Some(Phase::Listening { idx }) => {
+                // Persistent-open-carrier path from settle expiry.
+                self.phase = Phase::Listening { idx };
+                vec![
+                    ScannerCommand::MuteAudio(false),
+                    ScannerCommand::StateChanged(ScannerState::Listening),
+                ]
             }
             Some(Phase::__AdvanceFromDwell) | Some(Phase::__AdvanceFromHang) => {
                 self.hops_since_priority_sweep += 1;
@@ -1033,9 +1062,21 @@ Replace stub body:
 
 ```rust
     fn handle_squelch_edge(&mut self, state: SquelchState) -> Vec<ScannerCommand> {
+        // Always latch the current squelch state, regardless of
+        // phase. Retuning drops phase transitions (transients
+        // would false-trigger) but must still track carrier
+        // presence — a persistent-open channel must be visible
+        // to `handle_sample_tick`'s settle-expiry decision, which
+        // consults `self.squelch_open` to choose direct Listening
+        // vs standard Dwelling. `enter_retuning` resets the
+        // latch so previous-channel state doesn't bleed in.
+        self.squelch_open = matches!(state, SquelchState::Open);
         match (&self.phase, state) {
             (Phase::Retuning { .. }, _) => {
-                // Ignore edges during settle window.
+                // Ignore edges for phase transitions during the
+                // settle window — latch above is the mechanism
+                // that carries the open/closed information to
+                // settle expiry.
                 Vec::new()
             }
             (Phase::Dwelling { idx, .. }, SquelchState::Open) => {
@@ -1353,7 +1394,7 @@ Expected: All 4 new tests PASS (the logic is already in place from Task 1.5/1.6)
 - [ ] **Step 4: Run all tests**
 
 Run: `cargo test -p sdr-scanner --lib`
-Expected: all tests from Tasks 1.5 + 1.6 + 1.7 pass. Current baseline on shipped PR #368 is 17 tests (3 + 6 + 6 priority/lockout/edge + 1 `disable_clears_session_state` + 1 `unlockout_resumes_scanning_from_empty_rotation_idle`). If you're following the plan exactly, you'll see 15 at this checkpoint; the two regression tests landed via CR feedback after the initial task sequence.
+Expected: all tests from Tasks 1.5 + 1.6 + 1.7 pass. Baseline on shipped PR #368 (as of April 2026) is 18 tests (3 + 6 + 6 priority/lockout/edge + 1 `disable_clears_session_state` + 1 `unlockout_resumes_scanning_from_empty_rotation_idle` + 1 `persistent_open_during_settle_goes_directly_to_listening`). If you're following the plan exactly, you'll see 15 at this checkpoint; the three regression tests landed via CR feedback rounds 2–3 after the initial task sequence.
 
 - [ ] **Step 5: Run clippy**
 

--- a/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
+++ b/docs/superpowers/plans/2026-04-21-scanner-phase-1.md
@@ -153,7 +153,6 @@ pub struct ChannelKey {
 #[derive(Debug, Clone)]
 pub struct ScannerChannel {
     pub key: ChannelKey,
-    pub frequency_hz: u64,
     pub demod_mode: DemodMode,
     pub bandwidth: f64,
     pub ctcss: Option<sdr_radio::af_chain::CtcssMode>,
@@ -164,6 +163,14 @@ pub struct ScannerChannel {
     pub dwell_ms: u32,
     /// Resolved hang time in ms (per-channel override folded in).
     pub hang_ms: u32,
+}
+
+impl ScannerChannel {
+    #[inline]
+    #[must_use]
+    pub fn frequency_hz(&self) -> u64 {
+        self.key.frequency_hz
+    }
 }
 ```
 
@@ -1632,9 +1639,25 @@ In the controller's message dispatch (match over `UiToDsp`), add arms forwarding
                     }
                     self.radio_module.set_demod_mode(demod_mode);
                     self.radio_module.set_bandwidth(bandwidth);
-                    if let Some(m) = ctcss {
-                        self.radio_module.set_ctcss_mode(m);
+                    // CTCSS is per-channel: if the target channel
+                    // has no tone configured, explicitly clear to
+                    // `Off`. Otherwise a channel with a tone
+                    // configured earlier in the scan would leave
+                    // its tone gate active when the scanner hops
+                    // to a plain-FM channel, silencing that
+                    // channel even though no tone was set on it.
+                    match ctcss {
+                        Some(m) => self.radio_module.set_ctcss_mode(m),
+                        None => self
+                            .radio_module
+                            .set_ctcss_mode(sdr_radio::af_chain::CtcssMode::Off),
                     }
+                    // Voice squelch is device-level (a speech-
+                    // detection policy, not per-frequency
+                    // configuration). Apply when the channel
+                    // overrides it; preserve the currently-live
+                    // setting when `None`. Matches the established
+                    // per-channel vs global pattern from #290.
                     if let Some(m) = voice_squelch {
                         self.radio_module.set_voice_squelch_mode(m);
                     }

--- a/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
@@ -104,6 +104,14 @@ pub enum ScannerCommand {
     /// UI-facing: scanner phase indicator ("Scanning" / "Listening" /
     /// "Hanging" / "Off"). Emitted on every phase transition.
     StateChanged(ScannerState),
+
+    /// Rotation is fully exhausted — every scannable channel is
+    /// either absent, lockoutʼd, or otherwise unreachable.
+    /// Emitted before the accompanying `ActiveChannelChanged(None)`
+    /// + `StateChanged(Idle)` so the UI can surface a toast or
+    /// status hint ("All scannable channels are locked out")
+    /// before the display resets.
+    EmptyRotation,
 }
 ```
 
@@ -149,13 +157,13 @@ pub enum ScannerCommand {
 
 **`Idle`**: Scanner off, or enabled but no channels. Mute off (user might be listening to manually-tuned audio). No retunes, no commands emitted except state/active-channel transitions on entry.
 
-**`Retuning { target_idx, samples_until_settled }`**: Emit `Retune(...)` command on entry, `MuteAudio(true)`, `ActiveChannelChanged(Some(target))`, `StateChanged(Retuning)`. Count down `SETTLE_MS`-worth of samples. Ignore all `SquelchEdge` events during this window — retune transients produce spurious squelch behavior we don't want to act on. Transition to `Dwelling` when settled.
+**`Retuning { target_idx, samples_until_settled }`**: Emit `Retune(...)` command on entry, `MuteAudio(true)`, `ActiveChannelChanged(Some(target))`, `StateChanged(Retuning)`. `enter_retuning` resets the `squelch_open` latch to `false` (previous-channel state is irrelevant after retune). Count down `SETTLE_MS`-worth of samples. During this window, `SquelchEdge` events DO NOT drive phase transitions (retune transients would false-trip), but they DO update the `squelch_open` latch. On settle expiry, consult the latch: if `true` → transition directly to `Listening` + emit `MuteAudio(false)` (captures persistent-open carriers); if `false` → transition to `Dwelling`.
 
-**`Dwelling { idx, samples_until_timeout }`**: Audio still muted. Listen for `SquelchEdge(Open)` to transition to `Listening`. If `DEFAULT_DWELL_MS` (or channel's `dwell_ms_override`) elapses without an open, hop to next channel via `Retuning`.
+**`Dwelling { idx, samples_until_timeout }`**: Audio still muted. Listen for `SquelchEdge(Open)` to transition to `Listening`. If the channel's resolved `dwell_ms` (per `ScannerChannel`) elapses without an open, hop to next channel via `Retuning`.
 
 **`Listening { idx }`**: Emit `MuteAudio(false)` on entry, `StateChanged(Listening)`. No sample counter running — we stay here as long as the squelch holds open. On `SquelchEdge(Closed)` transition to `Hanging`.
 
-**`Hanging { idx, samples_until_timeout }`**: Emit `MuteAudio(true)` on entry (user said cut immediately on squelch close — classic scanner). `StateChanged(Hanging)`. Count down hang window. If squelch reopens before timeout → back to `Listening`. If hang elapses → `Retuning` to next channel.
+**`Hanging { idx, samples_until_timeout }`**: Emit `MuteAudio(true)` on entry (user said cut immediately on squelch close — classic scanner). `StateChanged(Hanging)`. Count down the channel's resolved `hang_ms` (per `ScannerChannel`). If squelch reopens before timeout → back to `Listening`. If hang elapses → `Retuning` to next channel.
 
 ### Priority cycling (single tier)
 

--- a/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
@@ -185,7 +185,7 @@ The scanner internally maintains the rotation index in two sub-lists (`normal_in
 - **Active channel removed**: if user deletes the currently-`Listening`-on bookmark, treat as squelch close → move to `Hanging` with shortened hang? Or just transition directly to next `Retuning`? Pick the latter — cleaner model, no surprise silence after a bookmark delete.
 - **All remaining channels locked out**: transition to `Idle` with a `ScannerCommand::EmptyRotation` signal (UI can toast "All scannable channels are locked out").
 - **SampleTick before Retune acknowledged**: scanner accumulates the tick but emits no command. SETTLE_MS accumulates from the first tick after entering `Retuning`.
-- **SquelchEdge during Retuning**: ignored (documented; covered by a specific unit test).
+- **SquelchEdge during Retuning**: latched into `squelch_open` but does NOT drive a phase transition (retune transients would false-trip). The latch is consulted at settle expiry — `true` → direct to `Listening`, `false` → `Dwelling`. Two unit tests: `settle_window_ignores_squelch_open` (verifies no phase transition mid-settle) and `persistent_open_during_settle_goes_directly_to_listening` (verifies the latched-open settle-expiry branch).
 
 ---
 

--- a/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
@@ -1,7 +1,7 @@
 # Scanner Phase 1 — Sequential Scanner Design
 
 **Issue**: #317 (Phase 1 of scanner epic #316)
-**Status**: Design approved; implementation plan next
+**Status**: Design + plan approved; execution in progress (PR 1 of 3 filed as #368)
 **Date**: 2026-04-21
 
 ---
@@ -22,7 +22,7 @@ A pure state machine with zero I/O, zero threading, no GTK, no audio, no USB. Co
 
 **Workspace entry**:
 
-```
+```text
 crates/sdr-scanner/
   Cargo.toml
   src/
@@ -113,7 +113,7 @@ pub enum ScannerCommand {
 
 ### Phases
 
-```
+```text
                 +--------+
                 |  Idle  |
                 +---+----+
@@ -253,15 +253,13 @@ Scanner projects each scannable bookmark into a `ScannerChannel`:
 
 ```rust
 pub struct ScannerChannel {
-    pub key: ChannelKey,                              // (name, freq_hz) for identity
-    pub name: String,
-    pub frequency_hz: u64,
+    pub key: ChannelKey,           // (name, freq_hz) — sole owner of freq + name
     pub demod_mode: DemodMode,
     pub bandwidth: f64,
     pub ctcss: Option<CtcssMode>,
     pub voice_squelch: Option<VoiceSquelchMode>,
     pub priority: u8,
-    pub dwell_ms: u32,  // resolved: override or default
+    pub dwell_ms: u32,             // resolved: override or UI default
     pub hang_ms: u32,
 }
 
@@ -270,6 +268,8 @@ pub struct ChannelKey {
     pub frequency_hz: u64,
 }
 ```
+
+Frequency is NOT duplicated on `ScannerChannel` — it lives only on `key`, so identity (used for lockout + active-channel tracking) and the retune target can't drift apart. `ScannerChannel::frequency_hz()` is an accessor on the struct that reads through to the key.
 
 Projection happens in `sdr-ui` at scanner-start and on `ChannelsChanged` pushes. Scanner is decoupled from bookmark persistence format; future non-bookmark channel sources slot in at the same projection boundary.
 
@@ -283,7 +283,7 @@ Lockout state lives inside the scanner (`HashSet<ChannelKey>`), never serialized
 
 Rough layout (Adwaita widgets):
 
-```
+```text
 ┌─ Scanner ──────────────────────────┐
 │  [•] Scanner On/Off      (Switch)  │
 │                                    │

--- a/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
@@ -70,10 +70,6 @@ pub enum ScannerEvent {
     /// Session-scoped lockout (not persisted to config or bookmarks).
     LockoutChannel(ChannelKey),
     UnlockoutChannel(ChannelKey),
-
-    /// Default dwell/hang timing changed (user moved the sidebar sliders).
-    SetDefaultDwellMs(u32),
-    SetDefaultHangMs(u32),
 }
 
 pub enum SquelchState { Open, Closed }
@@ -352,7 +348,7 @@ Estimate: ~600 lines including tests. One commit per logical piece (types, state
 ### PR 2 — `DspController` integration + bookmark schema
 
 - Extend `Bookmark` with 4 new fields + backward-compat tests.
-- New `UiToDsp` variants: `SetScannerEnabled(bool)`, `UpdateScannerChannels(Vec<ScannerChannel>)`, `LockoutScannerChannel(ChannelKey)`, `UnlockoutScannerChannel(ChannelKey)`, `SetScannerDefaultDwellMs(u32)`, `SetScannerDefaultHangMs(u32)`.
+- New `UiToDsp` variants: `SetScannerEnabled(bool)`, `UpdateScannerChannels(Vec<ScannerChannel>)`, `LockoutScannerChannel(ChannelKey)`, `UnlockoutScannerChannel(ChannelKey)`. Timing defaults are UI-side only — slider changes re-project bookmarks into `ScannerChannel`s with resolved `dwell_ms` / `hang_ms` and dispatch `UpdateScannerChannels`; the scanner itself has no "set default" event.
 - New `DspToUi` variants: `ScannerActiveChannelChanged { ... }`, `ScannerStateChanged(ScannerState)`.
 - `DspController` adds `scanner: Scanner` field, wires sample ticks + squelch edges + UI commands into it, applies scanner-emitted commands.
 - Mutex enforcement: `SetScannerEnabled(true)` stops recording + transcription with toasts. Recording / transcription start rejected when scanner is active.

--- a/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
@@ -34,7 +34,7 @@ crates/sdr-scanner/
     state.rs           -- ScannerState enum (Idle / Retuning / Dwelling / Listening / Hanging)
 ```
 
-Dependencies (workspace-pinned): `sdr-types` (for `DemodMode`), `sdr-radio` (for `CtcssMode`, `VoiceSquelchMode`), `thiserror`. No GTK, no tokio, no I/O crates. Workspace lints inherited.
+Dependencies (workspace-pinned): `sdr-types` (for `DemodMode`), `sdr-radio` (for `CtcssMode`), `sdr-dsp` (for `VoiceSquelchMode`), `thiserror`. No GTK, no tokio, no I/O crates. Workspace lints inherited.
 
 ### Integration via `sdr-core::DspController`
 
@@ -69,7 +69,7 @@ pub enum ScannerEvent {
 
     /// Session-scoped lockout (not persisted to config or bookmarks).
     LockoutChannel(ChannelKey),
-    UnlockoutChannel(ChannelKey),
+    UnlockChannel(ChannelKey),
 }
 
 pub enum SquelchState { Open, Closed }
@@ -169,7 +169,7 @@ The scanner internally maintains the rotation index in two sub-lists (`normal_in
 
 ### Channel lockout
 
-`LockoutChannel(key)` adds the key to an in-memory `HashSet<ChannelKey>`. The rotation step skips locked channels. `UnlockoutChannel(key)` removes it. State resets on `SetEnabled(false)` or when `ChannelsChanged` fires (a channel gone from the bookmark list can't be locked out of a list that doesn't include it anymore).
+`LockoutChannel(key)` adds the key to an in-memory `HashSet<ChannelKey>`. The rotation step skips locked channels. `UnlockChannel(key)` removes it. State resets on `SetEnabled(false)` or when `ChannelsChanged` fires (a channel gone from the bookmark list can't be locked out of a list that doesn't include it anymore).
 
 ### Edge cases
 
@@ -348,7 +348,7 @@ Estimate: ~600 lines including tests. One commit per logical piece (types, state
 ### PR 2 — `DspController` integration + bookmark schema
 
 - Extend `Bookmark` with 4 new fields + backward-compat tests.
-- New `UiToDsp` variants: `SetScannerEnabled(bool)`, `UpdateScannerChannels(Vec<ScannerChannel>)`, `LockoutScannerChannel(ChannelKey)`, `UnlockoutScannerChannel(ChannelKey)`. Timing defaults are UI-side only — slider changes re-project bookmarks into `ScannerChannel`s with resolved `dwell_ms` / `hang_ms` and dispatch `UpdateScannerChannels`; the scanner itself has no "set default" event.
+- New `UiToDsp` variants: `SetScannerEnabled(bool)`, `UpdateScannerChannels(Vec<ScannerChannel>)`, `LockoutScannerChannel(ChannelKey)`, `UnlockScannerChannel(ChannelKey)`. Timing defaults are UI-side only — slider changes re-project bookmarks into `ScannerChannel`s with resolved `dwell_ms` / `hang_ms` and dispatch `UpdateScannerChannels`; the scanner itself has no "set default" event.
 - New `DspToUi` variants: `ScannerActiveChannelChanged { ... }`, `ScannerStateChanged(ScannerState)`.
 - `DspController` adds `scanner: Scanner` field, wires sample ticks + squelch edges + UI commands into it, applies scanner-emitted commands.
 - Mutex enforcement: `SetScannerEnabled(true)` stops recording + transcription with toasts. Recording / transcription start rejected when scanner is active.

--- a/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md
@@ -1,0 +1,444 @@
+# Scanner Phase 1 — Sequential Scanner Design
+
+**Issue**: #317 (Phase 1 of scanner epic #316)
+**Status**: Design approved; implementation plan next
+**Date**: 2026-04-21
+
+---
+
+## Goal
+
+Ship the 80% use case: retune through N scannable favorites in sequence, dwell on each long enough to evaluate squelch, stop-and-play on squelch-open, resume sequencing when the transmission ends and a hang window elapses. Classic police-scanner behavior built on top of the existing single-source pipeline — no new DSP infrastructure required for Phase 1.
+
+Phase 2 (simultaneous channelizer) and Phase 3 (hybrid band-grouped) build on the config / state / UI plumbing this PR establishes. Not in scope here.
+
+---
+
+## Architecture
+
+### New crate: `sdr-scanner`
+
+A pure state machine with zero I/O, zero threading, no GTK, no audio, no USB. Consumes events, emits commands. Mirrors the `AutoBreakMachine` pattern established in #273 — trivially unit-testable in isolation, which pays for itself on first correctness bug.
+
+**Workspace entry**:
+
+```
+crates/sdr-scanner/
+  Cargo.toml
+  src/
+    lib.rs
+    scanner.rs         -- state machine + Scanner struct
+    channel.rs         -- ScannerChannel + ChannelKey types
+    events.rs          -- ScannerEvent enum
+    commands.rs        -- ScannerCommand enum
+    state.rs           -- ScannerState enum (Idle / Retuning / Dwelling / Listening / Hanging)
+```
+
+Dependencies (workspace-pinned): `sdr-types` (for `DemodMode`), `sdr-radio` (for `CtcssMode`, `VoiceSquelchMode`), `thiserror`. No GTK, no tokio, no I/O crates. Workspace lints inherited.
+
+### Integration via `sdr-core::DspController`
+
+`DspController` owns a `Scanner` instance. On every IQ block arrival, the controller feeds it `SampleTick { samples, sample_rate_hz }`. On every squelch edge (already emitted for Auto Break), the controller feeds `SquelchEdge(SquelchState::{Open,Closed})`. UI commands (enable/disable scanner, update channel list, lockout channel) arrive via new `UiToDsp::*` variants and are forwarded to the scanner. The scanner's emitted commands (retune, mute, active-channel-changed) are applied by the controller — `source.set_center_freq`, `sink_manager.set_scanner_mute`, and `DspToUi::ScannerActiveChannelChanged` event emission respectively.
+
+The scanner **does not** own the source or the sink — it tells the controller what to do. This keeps the crate boundary clean and lets the same state machine run in the Mac-side FFI controller if/when that path wants a scanner.
+
+---
+
+## State machine
+
+### Events in (inputs)
+
+```rust
+pub enum ScannerEvent {
+    /// Fired on every IQ block from the source. `samples_consumed` is the
+    /// block length; `sample_rate_hz` lets the scanner convert dwell/hang
+    /// targets in ms to sample counts. No wall-clock used anywhere.
+    SampleTick { samples_consumed: u32, sample_rate_hz: u32 },
+
+    /// Edge-triggered squelch transition, already emitted by the DSP
+    /// controller for Auto Break transcription. Scanner consumes the
+    /// same stream.
+    SquelchEdge(SquelchState),
+
+    /// User added / removed / edited a scannable bookmark. Scanner
+    /// snapshots the new list and resumes from a sensible position.
+    ChannelsChanged(Vec<ScannerChannel>),
+
+    /// Master scanner on/off toggle.
+    SetEnabled(bool),
+
+    /// Session-scoped lockout (not persisted to config or bookmarks).
+    LockoutChannel(ChannelKey),
+    UnlockoutChannel(ChannelKey),
+
+    /// Default dwell/hang timing changed (user moved the sidebar sliders).
+    SetDefaultDwellMs(u32),
+    SetDefaultHangMs(u32),
+}
+
+pub enum SquelchState { Open, Closed }
+```
+
+### Commands out (outputs)
+
+```rust
+pub enum ScannerCommand {
+    /// Retune the source to this channel. Controller translates to
+    /// source.set_center_freq(freq_hz), demod/bandwidth/ctcss/vsq updates
+    /// on the radio module.
+    Retune {
+        freq_hz: u64,
+        demod_mode: DemodMode,
+        bandwidth: f64,
+        ctcss: Option<CtcssMode>,
+        voice_squelch: Option<VoiceSquelchMode>,
+    },
+
+    /// Gate audio output at the sink. DSP chain keeps running so squelch
+    /// state stays live; only the final PCM stream to the audio device
+    /// is silenced.
+    MuteAudio(bool),
+
+    /// UI-facing: which channel (if any) the scanner currently considers
+    /// the "active" channel. None during Idle, Some during all other
+    /// phases. Emitted on every phase transition so the UI can update
+    /// frequency selector / spectrum / status bar / demod dropdown.
+    ActiveChannelChanged(Option<ChannelKey>),
+
+    /// UI-facing: scanner phase indicator ("Scanning" / "Listening" /
+    /// "Hanging" / "Off"). Emitted on every phase transition.
+    StateChanged(ScannerState),
+}
+```
+
+### Phases
+
+```
+                +--------+
+                |  Idle  |
+                +---+----+
+                    | SetEnabled(true) + channel list non-empty
+                    v
+            +-------+-------+
+            |   Retuning    |<--------------------+
+            |   target_idx  |                     |
+            +-------+-------+                     |
+                    | sample_counter >= SETTLE_MS |
+                    v                             |
+            +-------+-------+                     |
+            |   Dwelling    |                     |
+            |   idx         |                     |
+            +-------+-------+                     |
+                    | squelch OPEN after settle   |
+                    v                             |
+            +-------+-------+                     |
+            |   Listening   |                     |
+            |   idx         |                     |
+            +-------+-------+                     |
+                    | squelch CLOSE               |
+                    v                             |
+            +-------+-------+                     |
+            |    Hanging    |                     |
+            |    idx        |                     |
+            +-------+-------+                     |
+           hang     |           squelch OPEN      |
+          elapsed   |           before hang end   |
+       (next ch.)   |           (back to Listen)  |
+                    +-----------------------------+
+
+          dwell elapsed silently → next channel (Retuning)
+```
+
+### Phase behaviors
+
+**`Idle`**: Scanner off, or enabled but no channels. Mute off (user might be listening to manually-tuned audio). No retunes, no commands emitted except state/active-channel transitions on entry.
+
+**`Retuning { target_idx, samples_until_settled }`**: Emit `Retune(...)` command on entry, `MuteAudio(true)`, `ActiveChannelChanged(Some(target))`, `StateChanged(Retuning)`. Count down `SETTLE_MS`-worth of samples. Ignore all `SquelchEdge` events during this window — retune transients produce spurious squelch behavior we don't want to act on. Transition to `Dwelling` when settled.
+
+**`Dwelling { idx, samples_until_timeout }`**: Audio still muted. Listen for `SquelchEdge(Open)` to transition to `Listening`. If `DEFAULT_DWELL_MS` (or channel's `dwell_ms_override`) elapses without an open, hop to next channel via `Retuning`.
+
+**`Listening { idx }`**: Emit `MuteAudio(false)` on entry, `StateChanged(Listening)`. No sample counter running — we stay here as long as the squelch holds open. On `SquelchEdge(Closed)` transition to `Hanging`.
+
+**`Hanging { idx, samples_until_timeout }`**: Emit `MuteAudio(true)` on entry (user said cut immediately on squelch close — classic scanner). `StateChanged(Hanging)`. Count down hang window. If squelch reopens before timeout → back to `Listening`. If hang elapses → `Retuning` to next channel.
+
+### Priority cycling (single tier)
+
+Scanner maintains a `hop_counter: u32` incremented on every `Retuning → Dwelling` transition. Every `PRIORITY_CHECK_INTERVAL` hops (constant, 5), the next rotation pass inserts all `priority >= 1` channels before resuming normal rotation. No interruption of active `Listening` — that's deferred to follow-up #365.
+
+Example with channels [A(p=0), B(p=1), C(p=0), D(p=0), E(p=1), F(p=0)] and interval=5:
+- Normal hops (priority 0 only): A → C → D → F → A → C → D → F → A → ... every hop on the outer loop.
+- After 5 normal hops, insert a priority sweep: A → C → D → F → A → **B → E** → C → D → F → ...
+
+The scanner internally maintains the rotation index in two sub-lists (`normal_indices`, `priority_indices`) rather than one, advancing them independently. Simple implementation.
+
+### Channel lockout
+
+`LockoutChannel(key)` adds the key to an in-memory `HashSet<ChannelKey>`. The rotation step skips locked channels. `UnlockoutChannel(key)` removes it. State resets on `SetEnabled(false)` or when `ChannelsChanged` fires (a channel gone from the bookmark list can't be locked out of a list that doesn't include it anymore).
+
+### Edge cases
+
+- **Channel list becomes empty while scanning**: transition to `Idle`, emit `ActiveChannelChanged(None)`, `MuteAudio(false)`, `StateChanged(Idle)`. User's manual frequency / mode is preserved (the controller doesn't un-tune on scanner shutdown).
+- **Active channel removed**: if user deletes the currently-`Listening`-on bookmark, treat as squelch close → move to `Hanging` with shortened hang? Or just transition directly to next `Retuning`? Pick the latter — cleaner model, no surprise silence after a bookmark delete.
+- **All remaining channels locked out**: transition to `Idle` with a `ScannerCommand::EmptyRotation` signal (UI can toast "All scannable channels are locked out").
+- **SampleTick before Retune acknowledged**: scanner accumulates the tick but emits no command. SETTLE_MS accumulates from the first tick after entering `Retuning`.
+- **SquelchEdge during Retuning**: ignored (documented; covered by a specific unit test).
+
+---
+
+## UI sync contract
+
+Scanner retunes must update every sync surface a bookmark recall already touches. When `DspController` applies a scanner-emitted `Retune` it also emits `DspToUi::ScannerActiveChannelChanged { freq_hz, demod_mode, bandwidth, name }` to the UI event loop.
+
+UI handler for this event fans out to:
+- `FrequencySelector::set_frequency(freq_hz)` — no callback fire
+- `spectrum_handle.set_center_frequency(freq_hz as f64)` — updates plot axis + VFO marker
+- `status_bar.update_frequency(freq_hz as f64)` + `update_demod(label, bandwidth)`
+- `demod_dropdown.set_selected(idx)` — with a `suppress_demod_notify: Cell<bool>` guard on AppState mirroring the existing `suppress_bandwidth_notify` pattern (#342)
+- `radio_panel.bandwidth_row.set_value(bandwidth)` — existing `suppress_bandwidth_notify` guard handles this
+- `panels.bookmarks.active_bookmark` is **not** updated — scanner is a separate mode from manual recall, the active-bookmark highlight in the flyout should stay on the last manually-selected channel (if any) so the user knows where they were before scanning. UI shows scanner-active state via the scanner panel's "active channel" label, not by highlighting in the bookmark flyout.
+
+During rapid retune hops (~100 ms apart), the frequency selector and spectrum will flick visibly through each channel — exactly what classic scanners do. During `Listening`, the display parks on the active channel until hang elapses.
+
+---
+
+## Scanner ↔ recording / transcription mutex
+
+Scanner is mutually exclusive with recording and transcription. Activating scanner stops any active session of either. Activating recording or transcription stops scanner. Symmetric mutex at the controller level.
+
+Rationale: per-hit recording and channel-tagged transcription are deferred Phase 2+ concerns. For Phase 1, users who want to scan don't need mid-scan recordings (and vice versa). Cleaner to make the mutex explicit than leave recording/transcription running on a frequency that's about to retune 100 ms later.
+
+UI behavior:
+- Scanner master switch ON → recording button grays out (with "Scanner active" tooltip). If a recording session was active, stop it with a toast *"Recording stopped — scanner activated"*. Same for transcription.
+- Recording button click while scanner is on → toast *"Stop scanner to record"* and no-op (or offer a "Stop scanner and start recording" flow — defer to UX iteration).
+- Same pattern reversed: transcription start while scanner is on is rejected with toast guidance.
+
+Implementation: new `DspController` state field `scanner_active: bool`, gated inside the existing `start_recording`, `start_transcription` handlers and the new `UiToDsp::SetScannerEnabled` handler. Emission of `DspToUi::ScannerStateChanged` lets the UI gray/ungray the mutex'd controls.
+
+---
+
+## Schema changes to `Bookmark`
+
+Extend the existing `Bookmark` struct with four scanner-related fields. All optional / defaulted for backward compat — any existing `bookmarks.json` file deserializes cleanly.
+
+```rust
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Bookmark {
+    // ... existing fields ...
+
+    /// Include this bookmark in the scanner's rotation when scanner is on.
+    /// Default false so existing bookmarks don't suddenly start getting
+    /// scanned without explicit opt-in.
+    #[serde(default)]
+    pub scan_enabled: bool,
+
+    /// Priority tier. 0 = normal, 1 = priority (checked more often).
+    /// Higher tiers reserved for later phases.
+    #[serde(default)]
+    pub priority: u8,
+
+    /// Per-channel dwell override in ms. None → scanner uses its configured
+    /// default (100 ms at ship). Useful for bands where PLL settle is slower
+    /// or user wants longer sampling.
+    #[serde(default)]
+    pub dwell_ms_override: Option<u32>,
+
+    /// Per-channel hang override in ms. None → scanner default (2000 ms).
+    /// Useful for channels with irregular transmission patterns.
+    #[serde(default)]
+    pub hang_ms_override: Option<u32>,
+}
+```
+
+Scanner projects each scannable bookmark into a `ScannerChannel`:
+
+```rust
+pub struct ScannerChannel {
+    pub key: ChannelKey,                              // (name, freq_hz) for identity
+    pub name: String,
+    pub frequency_hz: u64,
+    pub demod_mode: DemodMode,
+    pub bandwidth: f64,
+    pub ctcss: Option<CtcssMode>,
+    pub voice_squelch: Option<VoiceSquelchMode>,
+    pub priority: u8,
+    pub dwell_ms: u32,  // resolved: override or default
+    pub hang_ms: u32,
+}
+
+pub struct ChannelKey {
+    pub name: String,
+    pub frequency_hz: u64,
+}
+```
+
+Projection happens in `sdr-ui` at scanner-start and on `ChannelsChanged` pushes. Scanner is decoupled from bookmark persistence format; future non-bookmark channel sources slot in at the same projection boundary.
+
+Lockout state lives inside the scanner (`HashSet<ChannelKey>`), never serialized.
+
+---
+
+## UI surface
+
+### Sidebar scanner panel (bottom of left sidebar)
+
+Rough layout (Adwaita widgets):
+
+```
+┌─ Scanner ──────────────────────────┐
+│  [•] Scanner On/Off      (Switch)  │
+│                                    │
+│  Active: 98.1 MHz — FM Broadcast   │
+│  State: Listening                  │
+│                                    │
+│  ▽ Settings                        │
+│    Default dwell:   [100] ms       │
+│    Default hang:    [2000] ms      │
+│                                    │
+│  [Lockout current channel]         │
+└────────────────────────────────────┘
+```
+
+Master switch drives `UiToDsp::SetScannerEnabled`. Active channel + state labels update from `DspToUi::ScannerActiveChannelChanged` + `ScannerStateChanged`. Settings expander holds the two default sliders (persisted via new config keys `scanner_default_dwell_ms`, `scanner_default_hang_ms`). Lockout button appears visible only when state is `Listening` or `Hanging` — locks out the active channel for the session.
+
+Panel goes at the **bottom** of the existing left sidebar (below Display panel). Layout redesign deferred per user — this placement is intentionally provisional.
+
+### Bookmark row additions
+
+In the right-side bookmarks flyout (#361), each `AdwActionRow` grows two suffix widgets:
+
+- **Scan checkbox** (`gtk4::CheckButton`, small/compact css class) — binds to `bookmark.scan_enabled`, toggles via the same `save_bookmarks` path used for other bookmark edits.
+- **Priority star** (`gtk4::ToggleButton` with `starred-symbolic` / `non-starred-symbolic` icon swap) — toggles priority between 0 and 1 (Phase 1 single-tier).
+
+Both are persistent bookmark-level settings. Saving re-writes the bookmarks.json and calls `UpdateScannerChannels` so the running scanner sees the change immediately.
+
+Accessibility labels on both controls ("Include in scanner" / "Scanner priority channel"), matching the icon-only control pattern established in #340 and reinforced in #361.
+
+### Header bar
+
+No header-bar indicator in v1. The sidebar panel is the canonical scanner display surface. Follow-up if user wants a persistent header presence.
+
+---
+
+## Defaults
+
+All hardcoded module-level constants in `sdr-scanner`:
+
+```rust
+pub const DEFAULT_DWELL_MS: u32 = 100;
+pub const DEFAULT_HANG_MS: u32 = 2000;
+pub const SETTLE_MS: u32 = 30;                 // not user-configurable
+pub const PRIORITY_CHECK_INTERVAL: u32 = 5;    // not user-configurable
+```
+
+Slider ranges in UI:
+- Default dwell: 50–500 ms
+- Default hang: 500–5000 ms
+
+Rationale docstrings on each constant tying the value to scanner-retune timing reality (I2C command ~1-5ms + PLL lock ~10-20ms + squelch estimate ~30-50ms).
+
+---
+
+## PR split
+
+### PR 1 — `sdr-scanner` crate (engine only)
+
+- New crate scaffolding (Cargo.toml, workspace entry, lints).
+- `Scanner`, `ScannerChannel`, `ChannelKey`, `ScannerEvent`, `ScannerCommand`, `ScannerState` types.
+- Complete state machine with unit tests (12+ cases per testing strategy below).
+- Zero integration, zero dependencies on `sdr-core` or `sdr-ui`.
+
+Estimate: ~600 lines including tests. One commit per logical piece (types, state machine, priority sweep, lockout, edge cases).
+
+### PR 2 — `DspController` integration + bookmark schema
+
+- Extend `Bookmark` with 4 new fields + backward-compat tests.
+- New `UiToDsp` variants: `SetScannerEnabled(bool)`, `UpdateScannerChannels(Vec<ScannerChannel>)`, `LockoutScannerChannel(ChannelKey)`, `UnlockoutScannerChannel(ChannelKey)`, `SetScannerDefaultDwellMs(u32)`, `SetScannerDefaultHangMs(u32)`.
+- New `DspToUi` variants: `ScannerActiveChannelChanged { ... }`, `ScannerStateChanged(ScannerState)`.
+- `DspController` adds `scanner: Scanner` field, wires sample ticks + squelch edges + UI commands into it, applies scanner-emitted commands.
+- Mutex enforcement: `SetScannerEnabled(true)` stops recording + transcription with toasts. Recording / transcription start rejected when scanner is active.
+- Smoke test via debug-build log inspection — scanner can be toggled, retunes happen, mute works, state transitions emit.
+
+Estimate: ~500 lines. One commit per logical piece (schema, new enum variants, controller integration, mutex).
+
+### PR 3 — UI surface + wiring
+
+- New `sidebar/scanner_panel.rs` with the layout above. Master switch, active-channel + state labels, settings expander, lockout button.
+- Existing `sidebar/bookmarks_panel.rs` / `navigation_panel.rs`: add Scan checkbox + priority star to each bookmark row. Persistence via existing `save_bookmarks` path. Project bookmarks → `Vec<ScannerChannel>` on change, dispatch `UpdateScannerChannels`.
+- UI handlers for `ScannerActiveChannelChanged` / `ScannerStateChanged` — fan out to frequency selector / spectrum / status bar / demod dropdown / bandwidth row with re-entrancy guards (`suppress_demod_notify` added mirror of `suppress_bandwidth_notify`).
+- Config persistence for `scanner_default_dwell_ms`, `scanner_default_hang_ms`.
+- Toast messages for scanner/recording/transcription mutex events.
+- Closes #317.
+
+Estimate: ~800 lines including the UI panel + row extensions. Multi-commit, smoke-tested by user before merge.
+
+---
+
+## Testing strategy
+
+### PR 1 unit tests (target ~12–14 covering the state machine)
+
+1. `idle_stays_idle_with_no_channels_enabled` — turning scanner on with empty list is a no-op.
+2. `enable_with_channels_transitions_to_retuning` — sets first channel as target.
+3. `settle_window_ignores_squelch_open` — feed `SquelchEdge(Open)` during `Retuning`; state must stay `Retuning`.
+4. `post_settle_squelch_open_transitions_to_listening` — open after settle → `Listening`, `MuteAudio(false)` emitted.
+5. `dwell_elapsed_without_squelch_advances_to_next_channel` — dwell samples accumulate past `DEFAULT_DWELL_MS * rate / 1000`, no squelch open → `Retuning` next channel.
+6. `squelch_close_in_listening_enters_hanging_and_mutes` — `MuteAudio(true)` emitted immediately on squelch close.
+7. `squelch_reopen_before_hang_end_returns_to_listening` — un-mute re-emitted.
+8. `hang_elapsed_without_reopen_advances_to_next_channel` — hop counter increments.
+9. `priority_sweep_triggers_every_five_hops` — after 5 normal hops, priority channels scheduled next.
+10. `lockout_skips_channel_in_rotation` — locked channel doesn't appear in `Retuning` sequence.
+11. `all_channels_locked_transitions_to_idle_with_signal` — drains rotation → `Idle` + toast signal.
+12. `channel_removed_mid_listening_transitions_to_retuning_next` — active-channel vanish recovers cleanly.
+13. `disable_while_listening_transitions_to_idle_with_mute_release` — scanner off clears mute, emits `ActiveChannelChanged(None)`.
+14. `dwell_ms_override_on_channel_respected` — channel-specific override used instead of default.
+
+### PR 2 integration verification
+
+No automated integration tests (would need a full DSP harness). Smoke-test path:
+- Debug-build log at scanner enable, expect `Retune` dispatched.
+- Manual bookmark table with 2–3 entries, toggle `scan_enabled` via in-memory edit, toggle scanner on, observe log sequence.
+- Verify mutex: start recording → try to enable scanner → expect rejection or recording-stop.
+
+### PR 3 smoke test (manual)
+
+User runs real scanner workflow:
+- Populate 5–10 scannable bookmarks across 2m / FM broadcast / NOAA.
+- Enable scanner. Verify: frequency selector flickering through channels; spectrum center updating; state indicator cycling Scanning / Listening / Hanging appropriately; audio silent during retune, active during Listening.
+- Mark one channel as priority, observe it gets checked more often.
+- Lockout a channel while it's listening, verify next cycle skips it.
+- Verify recording + transcription disabled while scanner is on.
+
+---
+
+## Out of scope (explicitly)
+
+- Per-hit recording (per-channel WAV files with timestamp filenames).
+- Per-hit transcription log with channel tagging.
+- Band/category-based scanning (use existing bookmarks only; category filter is a later enhancement).
+- Multi-tier priority (priority-1 + priority-2 with separate intervals).
+- Priority interrupt during listening — filed as follow-up #365.
+- Scheduled scanning (scan only at certain times).
+- Multi-dongle scanning.
+- Trunked radio protocols (P25, DMR, etc.) — separate epic.
+- Mac-side SwiftUI scanner — file as follow-up once Linux scanner stabilizes.
+
+---
+
+## Risks + mitigations
+
+- **Rapid retune CPU cost**: 100 ms dwell × 10 channels = 10 retunes/sec. Each retune is a single libusb command; negligible CPU. RTL-SDR tolerates this rate well (tested in original librtlsdr). Mitigation: if user scales to 100 channels and hits I/O pressure, the scanner will self-throttle via natural latency of retunes. No pre-emptive limits.
+- **Spectrum flicker**: user-requested, matches classic scanner UX. Not a bug.
+- **Transient audio pops on mute/unmute edges**: sink already has click-suppression via the audio envelope from #343. Scanner mute piggybacks on it — envelope ramp smooths the transition.
+- **Squelch behavior variation across demod modes**: NFM with CTCSS, WFM broadcast, SSB all have different squelch characteristics. Scanner reads the AND-gate output of the existing squelch stack (power + CTCSS + voice), so it inherits whatever the user has configured per-channel. Mitigation: document that mixing CTCSS-gated channels with non-CTCSS in a scan rotation works fine as long as each channel's squelch is set up correctly.
+- **Manual retune during scan**: user clicks a frequency on the spectrum while scanner is on. Current design: this would fight the scanner — scanner would retune back on its next hop. Mitigation: manual frequency/demod/bandwidth changes during scan-active should force-disable scanner with a toast *"Scanner stopped — manual tune"*. Add to PR 3 UI wiring.
+
+---
+
+## Follow-up issues (to file after Phase 1 ships)
+
+- Per-hit recording (WAV per hit).
+- Per-hit transcription with channel-tagged entries.
+- Priority interrupt during listening (already filed as #365).
+- Band / category-based scanner channel filtering.
+- Mac-side SwiftUI scanner panel (file once Linux scanner is stable).
+- Scheduled scanning (file if demand exists).


### PR DESCRIPTION
## Summary

First PR of three for the scanner epic (#316, Phase 1 = #317). Ships a new `sdr-scanner` workspace crate: a pure state machine with zero I/O and zero threading that drives classic sequential-scanner behavior (retune → dwell → listen-on-squelch-open → hang → advance). Consumes events, emits commands — the `DspController` will wire it up in PR 2 and the UI panel lands in PR 3.

**Design:** [`docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md`](../blob/feature/scanner-engine/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md)
**Plan:** [`docs/superpowers/plans/2026-04-21-scanner-phase-1.md`](../blob/feature/scanner-engine/docs/superpowers/plans/2026-04-21-scanner-phase-1.md)

## What's in this PR

- New `sdr-scanner` crate: `Scanner`, `ScannerChannel`, `ChannelKey`, `ScannerEvent`, `ScannerCommand`, `ScannerState` types + state machine.
- State machine phases: `Idle`, `Retuning`, `Dwelling`, `Listening`, `Hanging`. Two internal transition-marker variants (`AdvanceFromDwell`, `AdvanceFromHang`) never stored in `self.phase`.
- Sample-count-driven timing (no wall clock anywhere) — settle window (30 ms post-retune), per-channel dwell (default 100 ms), per-channel hang (default 2000 ms). `Option<u64>` seed-on-first-tick pattern for Retuning + Hanging because sample rate isn't known at phase entry.
- Single-tier priority cycling: every 5 normal hops, sweep all priority channels before resuming normal rotation.
- Session-scoped lockout via `HashSet<ChannelKey>`. Pruned automatically on `ChannelsChanged`.
- Settle-window guard: squelch edges during retune transients are ignored.

## Test coverage

15 unit tests in `scanner.rs`:

1. `enable_with_channels_transitions_to_retuning`
2. `disable_emits_idle_transition`
3. `enable_with_no_channels_emits_empty_rotation`
4. `settle_window_ignores_squelch_open` — retune transient suppression
5. `post_settle_squelch_open_transitions_to_listening` — mute released on active
6. `dwell_elapsed_without_squelch_advances_to_next`
7. `squelch_close_in_listening_enters_hanging_and_mutes` — immediate cut on squelch close
8. `squelch_reopen_before_hang_end_returns_to_listening`
9. `hang_elapsed_advances_to_next_channel`
10. `priority_sweep_triggers_after_interval_hops` — priority channel reached after 5 normal hops
11. `lockout_skips_channel`
12. `all_channels_locked_emits_empty_rotation`
13. `channel_override_respected_for_dwell` — per-channel dwell override honored
14. `channels_changed_mid_scan_recovers` — mid-scan list edit restarts rotation cleanly
15. `lockout_cleared_when_channel_removed` — stale lockouts pruned on list change

## No integration yet

This PR is the foundation only. The scanner is not reachable from any UI path — that happens in PR 2 (`DspController` wiring + bookmark schema) and PR 3 (sidebar panel + bookmark row toggles). PR 1 is self-contained and mergeable on its own: it ships a crate with comprehensive unit tests that the workspace now builds against.

## Next

- **PR 2**: wire `Scanner` into `DspController`, add bookmark schema (`scan_enabled`, `priority`, `dwell_ms_override`, `hang_ms_override`), add new `UiToDsp` / `DspToUi` variants, implement scanner↔recording/transcription mutex.
- **PR 3**: sidebar scanner panel + bookmark row Scan/Priority toggles + UI sync wiring. Closes #317.

## Test plan

- [x] `cargo test -p sdr-scanner --lib` — 15/15 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] Full workspace `cargo test --workspace --features sdr-ui/whisper-cpu` — existing tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a scanner engine: sequential channel scanning with phases (Idle, Retuning, Dwelling, Listening, Hanging), sample-count timing, squelch-aware behavior, per-channel lockouts, priority-aware hopping, and emitted commands for retune, audio mute gating, active-channel updates, and empty-rotation signaling.

* **Chores**
  * Adds a new workspace crate exposing the scanner API and default timing/configuration constants.

* **Tests**
  * Adds a comprehensive unit-test suite covering timing, state transitions, priority sweep, lockouts, and recovery scenarios.

* **Documentation**
  * Adds rollout plan and detailed design spec describing behavior, integration points, timing, UI expectations, and smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->