### PR TITLE
bookmarks: right-side flyout + search + categories on macOS (#339)

### DIFF
--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -28,6 +28,27 @@ struct ContentView: View {
     /// stopping transcription.
     @State private var showingTranscription: Bool = false
 
+    /// Right-side bookmarks flyout visibility. Mirrors the GTK
+    /// bookmarks_panel.rs flyout (issue #339). Toggled from the
+    /// header toolbar / `⌘B`, persisted across launches in
+    /// UserDefaults so the user's last-chosen layout sticks.
+    /// Mutually exclusive with `showingTranscription` — the
+    /// content area only has room for one right-side flyout;
+    /// the `.onChange` handlers below enforce that.
+    @State private var showingBookmarks: Bool =
+        UserDefaults.standard.bool(forKey: ContentView.bookmarksFlyoutOpenKey)
+
+    /// UserDefaults key for persisting the bookmarks flyout's
+    /// open/closed state. Matches the Linux `bookmarks_flyout_open`
+    /// config key so both frontends share wording.
+    static let bookmarksFlyoutOpenKey = "SDRMac.bookmarks.flyoutOpen"
+
+    /// Right-side flyout slide transition duration, in seconds.
+    /// Shared between the transcription and bookmarks revealers
+    /// so they stay in lockstep if one is tweaked. Matches GTK's
+    /// 200 ms `Revealer.transition_duration`.
+    static let rightFlyoutTransitionSeconds: Double = 0.2
+
     var body: some View {
         NavigationSplitView {
             SidebarView()
@@ -43,15 +64,48 @@ struct ContentView: View {
                     TranscriptionPanel()
                         .transition(.move(edge: .trailing))
                 }
+                if showingBookmarks {
+                    Divider()
+                    BookmarksPanel(isPresented: $showingBookmarks)
+                        .transition(.move(edge: .trailing))
+                }
             }
-            // Match GTK's 200 ms Revealer SlideLeft animation.
-            .animation(.easeInOut(duration: 0.2), value: showingTranscription)
+            // Match GTK's Revealer SlideLeft animation. Shared
+            // duration constant so both flyouts stay in lockstep.
+            .animation(
+                .easeInOut(duration: ContentView.rightFlyoutTransitionSeconds),
+                value: showingTranscription
+            )
+            .animation(
+                .easeInOut(duration: ContentView.rightFlyoutTransitionSeconds),
+                value: showingBookmarks
+            )
         }
         .toolbar {
             HeaderToolbar(
                 showingRadioReference: $showingRadioReference,
-                showingTranscription: $showingTranscription
+                showingTranscription: $showingTranscription,
+                showingBookmarks: $showingBookmarks
             )
+        }
+        // Mutual exclusivity between the two right-side flyouts.
+        // Opening one closes the other rather than stacking,
+        // matching the Linux treatment (a793cdc) and fitting
+        // the content area's single-flyout width budget. Also
+        // persists the bookmarks flyout's open/closed state —
+        // the transcription panel is ephemeral, but bookmarks
+        // is a durable browse surface the user wants back where
+        // they left it.
+        .onChange(of: showingBookmarks) { _, newValue in
+            if newValue && showingTranscription {
+                showingTranscription = false
+            }
+            UserDefaults.standard.set(newValue, forKey: ContentView.bookmarksFlyoutOpenKey)
+        }
+        .onChange(of: showingTranscription) { _, newValue in
+            if newValue && showingBookmarks {
+                showingBookmarks = false
+            }
         }
         .sheet(isPresented: $showingRadioReference) {
             RadioReferenceDialog()

--- a/apps/macos/SDRMac/Models/Bookmark.swift
+++ b/apps/macos/SDRMac/Models/Bookmark.swift
@@ -41,4 +41,36 @@ struct Bookmark: Codable, Identifiable, Hashable {
     var agcEnabled: Bool?
     var volume: Float?
     var deemphasis: Deemphasis?
+
+    // MARK: Organization
+
+    /// `RadioReference` category label (e.g. "Law Dispatch",
+    /// "Fire Tac"). Schema parity with the Linux `Bookmark`
+    /// struct's `rr_category` field — a future RadioReference
+    /// → bookmark import path on macOS will populate this.
+    /// Manually-created bookmarks leave it `nil`, which groups
+    /// them under the "Uncategorized" sentinel in the flyout.
+    /// Per issue #339 (flyout) / #241 (RadioReference import).
+    var rrCategory: String?
+
+    /// JSON key mapping so the on-disk schema matches the
+    /// Linux side's snake_case field name (`rr_category`).
+    /// Enables a user who runs both frontends to share the
+    /// same `bookmarks.json` without round-trip drift.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case updatedAt
+        case centerFrequencyHz
+        case demodMode
+        case bandwidthHz
+        case squelchEnabled
+        case autoSquelchEnabled
+        case squelchDb
+        case gainDb
+        case agcEnabled
+        case volume
+        case deemphasis
+        case rrCategory = "rr_category"
+    }
 }

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -560,6 +560,16 @@ final class CoreModel {
     /// writing. Mirrors `DspToUi::AudioRecordingStarted/Stopped`
     /// — the engine is authoritative; the UI never flips this
     /// optimistically.
+    /// ID of the bookmark currently applied to the engine state.
+    /// Set by `apply(_:)` after all its setters run; cleared by
+    /// any user-facing setter a bookmark would also touch
+    /// (`setCenter`, `setDemodMode`, `setBandwidth`, …) via
+    /// `clearActiveBookmark()`, so tuning away from a recalled
+    /// bookmark — through ANY path (slider, picker, keyboard
+    /// shortcut, spectrum click) — invalidates the flyout's
+    /// highlight immediately. Per issue #339.
+    var activeBookmarkId: UUID? = nil
+
     var audioRecordingPath: String? = nil
 
     /// Active IQ-recording state. Same engine-authoritative flip
@@ -1098,6 +1108,16 @@ final class CoreModel {
     /// bookmark saved without a squelch setting won't unintentionally
     /// flip the user's current squelch state.
     func apply(_ bookmark: Bookmark) {
+        // Each setter below calls `clearActiveBookmark()` as
+        // its first line — that's the normal "user tuned away"
+        // path. For bookmark recall we re-set the id at the
+        // tail after all setters have run, so the flyout
+        // highlight lands on this bookmark even though the
+        // setters cleared it transiently.
+        //
+        // NOTE: if a new field is added to `Bookmark`, the
+        // matching setter here AND its `clearActiveBookmark()`
+        // call must both land to keep the highlight coherent.
         if let hz = bookmark.centerFrequencyHz { setCenter(hz) }
         if let m = bookmark.demodMode          { setDemodMode(m) }
         if let bw = bookmark.bandwidthHz       { setBandwidth(bw) }
@@ -1108,6 +1128,16 @@ final class CoreModel {
         if let agc = bookmark.agcEnabled       { setAgc(agc) }
         if let v = bookmark.volume             { setVolume(v) }
         if let d = bookmark.deemphasis         { setDeemphasis(d) }
+        activeBookmarkId = bookmark.id
+    }
+
+    /// Clear the active-bookmark highlight. Called at the top
+    /// of every setter a bookmark would also touch so tuning
+    /// away from a recalled bookmark via any path invalidates
+    /// the flyout indicator immediately. `apply(_:)` re-sets
+    /// the id at its tail.
+    private func clearActiveBookmark() {
+        activeBookmarkId = nil
     }
 
     func syncToEngine() {
@@ -1202,6 +1232,7 @@ final class CoreModel {
     static let maxCenterFrequencyHz: Double = 999_999_999_999
 
     func setCenter(_ hz: Double) {
+        clearActiveBookmark()
         // Clamp non-finite and out-of-range values before both
         // the UI write and the engine call. Prevents NaN / Inf /
         // negative tune commands from any caller (per #327 review).
@@ -1309,41 +1340,49 @@ final class CoreModel {
     }
 
     func setDemodMode(_ m: DemodMode) {
+        clearActiveBookmark()
         demodMode = m
         capture { try core?.setDemodMode(m) }
     }
 
     func setBandwidth(_ hz: Double) {
+        clearActiveBookmark()
         bandwidthHz = hz
         capture { try core?.setBandwidth(hz) }
     }
 
     func setGain(_ db: Double) {
+        clearActiveBookmark()
         gainDb = db
         capture { try core?.setGain(db) }
     }
 
     func setAgc(_ on: Bool) {
+        clearActiveBookmark()
         agcEnabled = on
         capture { try core?.setAgc(on) }
     }
 
     func setSquelchDb(_ db: Float) {
+        clearActiveBookmark()
         squelchDb = db
         capture { try core?.setSquelchDb(db) }
     }
 
     func setSquelchEnabled(_ on: Bool) {
+        clearActiveBookmark()
         squelchEnabled = on
         capture { try core?.setSquelchEnabled(on) }
     }
 
     func setAutoSquelch(_ on: Bool) {
+        clearActiveBookmark()
         autoSquelchEnabled = on
         capture { try core?.setAutoSquelch(on) }
     }
 
     func setDeemphasis(_ m: Deemphasis) {
+        clearActiveBookmark()
         deemphasis = m
         capture { try core?.setDeemphasis(m) }
     }
@@ -1436,6 +1475,7 @@ final class CoreModel {
     }
 
     func setVolume(_ v: Float) {
+        clearActiveBookmark()
         volume = v
         capture { try core?.setVolume(v) }
     }

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -555,11 +555,6 @@ final class CoreModel {
     /// callback closure.
     private var rtlTcpBrowser: SdrRtlTcpBrowser? = nil
 
-    /// Active audio-recording state. `nil` = not recording,
-    /// `some(path)` = engine confirmed it opened `path` for
-    /// writing. Mirrors `DspToUi::AudioRecordingStarted/Stopped`
-    /// — the engine is authoritative; the UI never flips this
-    /// optimistically.
     /// ID of the bookmark currently applied to the engine state.
     /// Set by `apply(_:)` after all its setters run; cleared by
     /// any user-facing setter a bookmark would also touch
@@ -570,6 +565,11 @@ final class CoreModel {
     /// highlight immediately. Per issue #339.
     var activeBookmarkId: UUID? = nil
 
+    /// Active audio-recording state. `nil` = not recording,
+    /// `some(path)` = engine confirmed it opened `path` for
+    /// writing. Mirrors `DspToUi::AudioRecordingStarted/Stopped`
+    /// — the engine is authoritative; the UI never flips this
+    /// optimistically.
     var audioRecordingPath: String? = nil
 
     /// Active IQ-recording state. Same engine-authoritative flip

--- a/apps/macos/SDRMac/Views/BookmarksPanel.swift
+++ b/apps/macos/SDRMac/Views/BookmarksPanel.swift
@@ -358,36 +358,69 @@ struct BookmarksPanel: View {
 
 struct BookmarkListRow: View {
     @Environment(CoreModel.self) private var model
+    @Environment(BookmarksStore.self) private var store
     let bookmark: Bookmark
 
     var body: some View {
-        Button {
-            model.apply(bookmark)
-        } label: {
-            HStack(spacing: 8) {
-                if isActive {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(Color.accentColor)
-                        .font(.caption)
-                } else {
-                    Image(systemName: "bookmark")
-                        .foregroundStyle(.secondary)
-                        .font(.caption)
+        HStack(spacing: 8) {
+            // Tap on the leading area applies the bookmark —
+            // split from the trailing delete button so the
+            // "click to recall" affordance stays obvious even
+            // when the delete icon is close by.
+            Button {
+                model.apply(bookmark)
+            } label: {
+                HStack(spacing: 8) {
+                    if isActive {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(Color.accentColor)
+                            .font(.caption)
+                    } else {
+                        Image(systemName: "bookmark")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(bookmark.name)
+                            .lineLimit(1)
+                            .fontWeight(isActive ? .semibold : .regular)
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
                 }
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(bookmark.name)
-                        .lineLimit(1)
-                        .fontWeight(isActive ? .semibold : .regular)
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                Spacer()
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+
+            // Trailing per-row delete. Icon-only so it doesn't
+            // crowd the row, with both a tooltip AND an
+            // accessibility label — PR #361 round 1 flagged
+            // icon-only buttons missing both as a Minor
+            // finding (#3120080308, #3120155767). Deletes by
+            // UUID so duplicates-with-same-name only drop the
+            // clicked row, not every match.
+            Button {
+                store.remove(id: bookmark.id)
+            } label: {
+                Image(systemName: "trash")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Delete bookmark")
+            .accessibilityLabel("Delete bookmark")
         }
-        .buttonStyle(.plain)
+        // Right-click context menu — second surface for
+        // delete, matches the pre-refactor sidebar behavior.
+        .contextMenu {
+            Button(role: .destructive) {
+                store.remove(id: bookmark.id)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
     }
 
     private var isActive: Bool {

--- a/apps/macos/SDRMac/Views/BookmarksPanel.swift
+++ b/apps/macos/SDRMac/Views/BookmarksPanel.swift
@@ -14,10 +14,6 @@
 // Mutual-exclusive with the transcription panel (the sidebar
 // has room for one right-side flyout at a time). Open/closed
 // state persists across launches via `UserDefaults`.
-//
-// This commit ships the shell + empty state + header chrome.
-// Search row, category grouping, and per-row actions land in
-// the next two commits.
 
 import SwiftUI
 // `DemodMode.label` lives in SdrCoreKit — used by the row
@@ -56,7 +52,21 @@ struct BookmarksPanel: View {
     /// regression where the Linux side conflated the two
     /// states and collapsed groups stayed stuck open after
     /// search cleared.
-    @State private var manuallyExpanded: [String: Bool] = [:]
+    ///
+    /// Hydrated synchronously in `init` rather than
+    /// `.onAppear` so categories persisted as collapsed
+    /// render collapsed on the first frame. Loading post-
+    /// appear caused a visible snap (every group drew as
+    /// expanded then closed on the next tick). Per
+    /// `CodeRabbit` round 3 on PR #369.
+    @State private var manuallyExpanded: [String: Bool]
+
+    init(isPresented: Binding<Bool>) {
+        self._isPresented = isPresented
+        self._manuallyExpanded = State(
+            initialValue: Self.loadPersistedExpansionState()
+        )
+    }
 
     /// Sentinel key for bookmarks without an `rrCategory`.
     /// Matches the Linux `"Uncategorized"` title; used both
@@ -83,7 +93,6 @@ struct BookmarksPanel: View {
         }
         .frame(width: BookmarksPanel.width)
         .background(Color(nsColor: .windowBackgroundColor))
-        .onAppear { loadManuallyExpanded() }
     }
 
     // MARK: - Search
@@ -301,13 +310,17 @@ struct BookmarksPanel: View {
         )
     }
 
-    private func loadManuallyExpanded() {
+    /// Static so it can be called from `init` before `self`
+    /// is available — synchronously seeding `@State` avoids
+    /// the first-frame expand-then-snap flicker that an
+    /// `onAppear` loader creates.
+    private static func loadPersistedExpansionState() -> [String: Bool] {
         guard let json = UserDefaults.standard.string(forKey: Self.expansionStateKey),
               let data = json.data(using: .utf8),
               let decoded = try? JSONDecoder().decode([String: Bool].self, from: data) else {
-            return
+            return [:]
         }
-        manuallyExpanded = decoded
+        return decoded
     }
 
     private func persistManuallyExpanded() {
@@ -347,14 +360,13 @@ struct BookmarksPanel: View {
 }
 
 // ============================================================
-//  BookmarkListRow — placeholder shell
+//  BookmarkListRow
 // ============================================================
 //
-//  Minimal row for the shell commit. Displays name + frequency
-//  subtitle + an "active" checkmark when this bookmark matches
-//  the engine's current `activeBookmarkId`. Tap applies. Real
-//  per-row actions (save-over, delete, context menu) land in a
-//  follow-up commit.
+//  Displays name + frequency subtitle with an "active"
+//  checkmark when this bookmark matches the engine's current
+//  `activeBookmarkId`. Tap the label area to apply; trailing
+//  icon button and right-click context menu both delete.
 
 struct BookmarkListRow: View {
     @Environment(CoreModel.self) private var model

--- a/apps/macos/SDRMac/Views/BookmarksPanel.swift
+++ b/apps/macos/SDRMac/Views/BookmarksPanel.swift
@@ -41,6 +41,38 @@ struct BookmarksPanel: View {
     /// finding; landing it from day one here.
     @State private var filterText: String = ""
 
+    /// User's manual per-category expansion preference —
+    /// category name (or the `uncategorizedKey` sentinel)
+    /// maps to `true` for expanded, `false` for collapsed.
+    /// Persisted to UserDefaults so it survives across
+    /// sessions; absent keys default to expanded.
+    ///
+    /// Kept SEPARATE from search-driven force-open: while
+    /// `filterText` is non-empty, every matching group is
+    /// rendered expanded regardless of this map, and the map
+    /// is NOT updated from those force-open toggles. So
+    /// clearing search snaps groups back to the user's
+    /// manual preference — PR #361 round 2 caught a Major
+    /// regression where the Linux side conflated the two
+    /// states and collapsed groups stayed stuck open after
+    /// search cleared.
+    @State private var manuallyExpanded: [String: Bool] = [:]
+
+    /// Sentinel key for bookmarks without an `rrCategory`.
+    /// Matches the Linux `"Uncategorized"` title; used both
+    /// as the DisclosureGroup label AND as the dictionary
+    /// key above. Any real category label that happens to
+    /// equal this string collides — acceptable risk; the
+    /// Linux side makes the same call.
+    private static let uncategorizedKey = "Uncategorized"
+
+    /// UserDefaults key for `manuallyExpanded`. JSON-encoded
+    /// `[String: Bool]` so the whole map round-trips in one
+    /// value. Shape matches nothing on the Linux side yet —
+    /// GTK state lives in widget memory, not config — so no
+    /// cross-frontend parity concern here.
+    private static let expansionStateKey = "SDRMac.bookmarks.manualExpansionState"
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -51,6 +83,7 @@ struct BookmarksPanel: View {
         }
         .frame(width: BookmarksPanel.width)
         .background(Color(nsColor: .windowBackgroundColor))
+        .onAppear { loadManuallyExpanded() }
     }
 
     // MARK: - Search
@@ -154,9 +187,32 @@ struct BookmarksPanel: View {
             let filtered = filteredBookmarks
             if filtered.isEmpty {
                 emptyState(.noMatches)
+            } else if usesCategories {
+                // Grouped rendering — one DisclosureGroup per
+                // unique rrCategory, plus an "Uncategorized"
+                // sentinel group if any bookmark lacks a
+                // category. Mirrors the Linux GTK panel's
+                // AdwExpanderRow grouping (#339).
+                List {
+                    ForEach(groupedBookmarks(filtered), id: \.0) { (category, bms) in
+                        Section {
+                            DisclosureGroup(isExpanded: expansionBinding(for: category)) {
+                                ForEach(bms) { bm in
+                                    BookmarkListRow(bookmark: bm)
+                                }
+                            } label: {
+                                categoryHeader(category, count: bms.count)
+                            }
+                        }
+                    }
+                }
+                .listStyle(.inset)
             } else {
-                // Flat list for this commit; category grouping
-                // via DisclosureGroup lands in the next.
+                // Flat list when no bookmark has a category —
+                // matches the Linux `uses_categories` fallback
+                // so first-time users don't see a single
+                // "Uncategorized" group swallowing the whole
+                // list.
                 List {
                     ForEach(filtered) { bm in
                         BookmarkListRow(bookmark: bm)
@@ -165,6 +221,99 @@ struct BookmarksPanel: View {
                 .listStyle(.inset)
             }
         }
+    }
+
+    /// `true` when at least one bookmark carries an
+    /// `rrCategory`. Matches the Linux `uses_categories`
+    /// check — only the grouped rendering path kicks in when
+    /// categorization is actually in use; a fresh install
+    /// with hand-saved bookmarks stays as a flat list.
+    private var usesCategories: Bool {
+        store.bookmarks.contains { $0.rrCategory != nil }
+    }
+
+    /// Group bookmarks by `rrCategory`, returning sorted
+    /// tuples for stable UI rendering. Nil categories bucket
+    /// into the `uncategorizedKey` sentinel at the end so
+    /// named categories sort alphabetically at the top and
+    /// the catch-all always lands last.
+    private func groupedBookmarks(
+        _ bookmarks: [Bookmark]
+    ) -> [(String, [Bookmark])] {
+        var buckets: [String: [Bookmark]] = [:]
+        for bm in bookmarks {
+            let key = bm.rrCategory ?? Self.uncategorizedKey
+            buckets[key, default: []].append(bm)
+        }
+        // Stable category order: alphabetical, sentinel last.
+        let named = buckets.keys
+            .filter { $0 != Self.uncategorizedKey }
+            .sorted()
+        var ordered: [(String, [Bookmark])] = named.map { ($0, buckets[$0] ?? []) }
+        if let uncat = buckets[Self.uncategorizedKey] {
+            ordered.append((Self.uncategorizedKey, uncat))
+        }
+        return ordered
+    }
+
+    /// Header row for a category DisclosureGroup. Shows the
+    /// category name + bookmark count; count label lets the
+    /// user see at a glance how large a collapsed category is.
+    private func categoryHeader(_ category: String, count: Int) -> some View {
+        HStack(spacing: 6) {
+            Text(category)
+                .font(.callout)
+                .fontWeight(.medium)
+            Text("(\(count))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Expansion state (manual vs. search-forced)
+
+    /// Build the `isExpanded` binding for a category.
+    ///
+    /// - Read: while search is active, always `true` so
+    ///   every group is visible (the list is already filtered
+    ///   to matches). While search is empty, consult the
+    ///   user's persisted manual preference (default: expanded).
+    /// - Write: only persist when search is empty. Writes
+    ///   during search would capture the force-open state as
+    ///   manual intent and leave groups stuck open after
+    ///   search clears — the exact regression PR #361 round
+    ///   2 caught on the Linux side.
+    private func expansionBinding(for category: String) -> Binding<Bool> {
+        Binding(
+            get: {
+                if !filterText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return true
+                }
+                return manuallyExpanded[category] ?? true
+            },
+            set: { newValue in
+                guard filterText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    return
+                }
+                manuallyExpanded[category] = newValue
+                persistManuallyExpanded()
+            }
+        )
+    }
+
+    private func loadManuallyExpanded() {
+        guard let json = UserDefaults.standard.string(forKey: Self.expansionStateKey),
+              let data = json.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String: Bool].self, from: data) else {
+            return
+        }
+        manuallyExpanded = decoded
+    }
+
+    private func persistManuallyExpanded() {
+        guard let data = try? JSONEncoder().encode(manuallyExpanded),
+              let json = String(data: data, encoding: .utf8) else { return }
+        UserDefaults.standard.set(json, forKey: Self.expansionStateKey)
     }
 
     /// Two flavors of empty state so the user gets a helpful

--- a/apps/macos/SDRMac/Views/BookmarksPanel.swift
+++ b/apps/macos/SDRMac/Views/BookmarksPanel.swift
@@ -1,0 +1,173 @@
+//
+// BookmarksPanel.swift — right-side slide-out panel listing
+// saved tuning profiles (#339).
+//
+// Mirrors the Linux GTK `bookmarks_panel.rs` layout: a 360pt
+// wide column with a header (title + close button), a search
+// row, a scrolling list of bookmark rows grouped by category
+// via `DisclosureGroup`, and an empty-state caption when no
+// bookmarks are saved. The sidebar's `BookmarksSection` keeps
+// only the quick-add affordance (name entry + Save button) —
+// browse / search / manage all live here.
+//
+// Toggled from the header toolbar bookmark button or `⌘B`.
+// Mutual-exclusive with the transcription panel (the sidebar
+// has room for one right-side flyout at a time). Open/closed
+// state persists across launches via `UserDefaults`.
+//
+// This commit ships the shell + empty state + header chrome.
+// Search row, category grouping, and per-row actions land in
+// the next two commits.
+
+import SwiftUI
+// `DemodMode.label` lives in SdrCoreKit — used by the row
+// subtitle renderer below.
+import SdrCoreKit
+
+struct BookmarksPanel: View {
+    @Environment(CoreModel.self) private var model
+    @Environment(BookmarksStore.self) private var store
+
+    /// Close-button binding — hands control back to the
+    /// header toolbar / keyboard shortcut state that owns the
+    /// open/closed flag in `ContentView`.
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            body_list
+        }
+        .frame(width: BookmarksPanel.width)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    /// Panel width. Matches the Linux flyout's 360 px — wide
+    /// enough for a long nickname + tuner/gain subtitle + the
+    /// apply/save/delete affordances without wrapping.
+    static let width: CGFloat = 360
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Text("Bookmarks")
+                .font(.headline)
+            Spacer()
+            Button {
+                isPresented = false
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Close Bookmarks Panel")
+            .accessibilityLabel("Close Bookmarks Panel")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - List
+
+    @ViewBuilder
+    private var body_list: some View {
+        if store.bookmarks.isEmpty {
+            emptyState
+        } else {
+            // Placeholder pending search + category grouping
+            // in the next commits. Flat List of names so the
+            // shell is visually complete while we land the
+            // richer behavior in pieces.
+            List {
+                ForEach(store.bookmarks) { bm in
+                    BookmarkListRow(bookmark: bm)
+                }
+            }
+            .listStyle(.inset)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "bookmark")
+                .font(.largeTitle)
+                .foregroundStyle(.tertiary)
+            Text("No bookmarks yet")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text("Save the current tuning from the sidebar to start a list.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// ============================================================
+//  BookmarkListRow — placeholder shell
+// ============================================================
+//
+//  Minimal row for the shell commit. Displays name + frequency
+//  subtitle + an "active" checkmark when this bookmark matches
+//  the engine's current `activeBookmarkId`. Tap applies. Real
+//  per-row actions (save-over, delete, context menu) land in a
+//  follow-up commit.
+
+struct BookmarkListRow: View {
+    @Environment(CoreModel.self) private var model
+    let bookmark: Bookmark
+
+    var body: some View {
+        Button {
+            model.apply(bookmark)
+        } label: {
+            HStack(spacing: 8) {
+                if isActive {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(Color.accentColor)
+                        .font(.caption)
+                } else {
+                    Image(systemName: "bookmark")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(bookmark.name)
+                        .lineLimit(1)
+                        .fontWeight(isActive ? .semibold : .regular)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var isActive: Bool {
+        model.activeBookmarkId == bookmark.id
+    }
+
+    /// Format used by the frequency column. Matches the
+    /// sidebar's pre-refactor format (`formatRate(_:)` in
+    /// SourceSection) so users see identical strings across
+    /// both surfaces. Falls back to the demod-mode label
+    /// alone if the bookmark has no center frequency.
+    private var subtitle: String {
+        var parts: [String] = []
+        if let hz = bookmark.centerFrequencyHz {
+            parts.append(formatRate(hz))
+        }
+        if let mode = bookmark.demodMode {
+            parts.append(mode.label)
+        }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/apps/macos/SDRMac/Views/BookmarksPanel.swift
+++ b/apps/macos/SDRMac/Views/BookmarksPanel.swift
@@ -33,14 +33,89 @@ struct BookmarksPanel: View {
     /// open/closed flag in `ContentView`.
     @Binding var isPresented: Bool
 
+    /// Live search filter. Case-insensitive substring match
+    /// against `name`, the formatted frequency subtitle, and
+    /// `rrCategory`. Mirrors the Linux predicate in
+    /// `navigation_panel.rs::bookmark_matches_filter` — PR
+    /// #361 round 1 flagged category-missing as a Major
+    /// finding; landing it from day one here.
+    @State private var filterText: String = ""
+
     var body: some View {
         VStack(spacing: 0) {
             header
+            Divider()
+            searchRow
             Divider()
             body_list
         }
         .frame(width: BookmarksPanel.width)
         .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    // MARK: - Search
+
+    private var searchRow: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+            TextField("Search bookmarks", text: $filterText)
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+            if !filterText.isEmpty {
+                Button {
+                    filterText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.borderless)
+                .help("Clear search")
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    /// Filtered list reflecting `filterText`. Case-insensitive
+    /// substring match against name, subtitle string, and
+    /// `rrCategory`. Empty `filterText` passes everything
+    /// through untouched.
+    private var filteredBookmarks: [Bookmark] {
+        let needle = filterText
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard !needle.isEmpty else { return store.bookmarks }
+        return store.bookmarks.filter { Self.matchesFilter($0, needle: needle) }
+    }
+
+    /// Shared filter predicate — exposed as a `static` so
+    /// future category-header renderers (next commit) can
+    /// reuse the same match rules without diverging. Matches
+    /// the Linux `bookmark_matches_filter` intent.
+    static func matchesFilter(_ bm: Bookmark, needle: String) -> Bool {
+        if needle.isEmpty { return true }
+        if bm.name.lowercased().contains(needle) { return true }
+        if Self.subtitleFor(bm).lowercased().contains(needle) { return true }
+        if let cat = bm.rrCategory?.lowercased(), cat.contains(needle) { return true }
+        return false
+    }
+
+    /// Formatted subtitle used by the filter predicate AND by
+    /// `BookmarkListRow` below. Single source of truth so a
+    /// row that visually matches "145.7 MHz · NFM" is also
+    /// findable by searching that string.
+    static func subtitleFor(_ bm: Bookmark) -> String {
+        var parts: [String] = []
+        if let hz = bm.centerFrequencyHz {
+            parts.append(formatRate(hz))
+        }
+        if let mode = bm.demodMode {
+            parts.append(mode.label)
+        }
+        return parts.joined(separator: " · ")
     }
 
     /// Panel width. Matches the Linux flyout's 360 px — wide
@@ -74,34 +149,49 @@ struct BookmarksPanel: View {
     @ViewBuilder
     private var body_list: some View {
         if store.bookmarks.isEmpty {
-            emptyState
+            emptyState(.empty)
         } else {
-            // Placeholder pending search + category grouping
-            // in the next commits. Flat List of names so the
-            // shell is visually complete while we land the
-            // richer behavior in pieces.
-            List {
-                ForEach(store.bookmarks) { bm in
-                    BookmarkListRow(bookmark: bm)
+            let filtered = filteredBookmarks
+            if filtered.isEmpty {
+                emptyState(.noMatches)
+            } else {
+                // Flat list for this commit; category grouping
+                // via DisclosureGroup lands in the next.
+                List {
+                    ForEach(filtered) { bm in
+                        BookmarkListRow(bookmark: bm)
+                    }
                 }
+                .listStyle(.inset)
             }
-            .listStyle(.inset)
         }
     }
 
-    private var emptyState: some View {
+    /// Two flavors of empty state so the user gets a helpful
+    /// prompt rather than a mysterious blank pane.
+    private enum EmptyStateKind {
+        case empty       // Zero bookmarks saved
+        case noMatches   // Filter matches nothing
+    }
+
+    @ViewBuilder
+    private func emptyState(_ kind: EmptyStateKind) -> some View {
         VStack(spacing: 8) {
-            Image(systemName: "bookmark")
+            Image(systemName: kind == .empty ? "bookmark" : "magnifyingglass")
                 .font(.largeTitle)
                 .foregroundStyle(.tertiary)
-            Text("No bookmarks yet")
+            Text(kind == .empty ? "No bookmarks yet" : "No matches")
                 .font(.headline)
                 .foregroundStyle(.secondary)
-            Text("Save the current tuning from the sidebar to start a list.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 24)
+            Text(
+                kind == .empty
+                    ? "Save the current tuning from the sidebar to start a list."
+                    : "No bookmarks match \"\(filterText)\"."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 24)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -155,19 +245,11 @@ struct BookmarkListRow: View {
         model.activeBookmarkId == bookmark.id
     }
 
-    /// Format used by the frequency column. Matches the
-    /// sidebar's pre-refactor format (`formatRate(_:)` in
-    /// SourceSection) so users see identical strings across
-    /// both surfaces. Falls back to the demod-mode label
-    /// alone if the bookmark has no center frequency.
+    /// Use the panel's shared subtitle formatter so the
+    /// displayed string and the filter predicate always see
+    /// the same text (a row visually labelled "145.7 MHz ·
+    /// NFM" is findable by searching that string).
     private var subtitle: String {
-        var parts: [String] = []
-        if let hz = bookmark.centerFrequencyHz {
-            parts.append(formatRate(hz))
-        }
-        if let mode = bookmark.demodMode {
-            parts.append(mode.label)
-        }
-        return parts.joined(separator: " · ")
+        BookmarksPanel.subtitleFor(bookmark)
     }
 }

--- a/apps/macos/SDRMac/Views/BookmarksPanel.swift
+++ b/apps/macos/SDRMac/Views/BookmarksPanel.swift
@@ -95,7 +95,7 @@ struct BookmarksPanel: View {
                 .font(.caption)
             TextField("Search bookmarks", text: $filterText)
                 .textFieldStyle(.roundedBorder)
-                .disableAutocorrection(true)
+                .autocorrectionDisabled()
             if !filterText.isEmpty {
                 Button {
                     filterText = ""

--- a/apps/macos/SDRMac/Views/BookmarksPanel.swift
+++ b/apps/macos/SDRMac/Views/BookmarksPanel.swift
@@ -79,7 +79,7 @@ struct BookmarksPanel: View {
             Divider()
             searchRow
             Divider()
-            body_list
+            bodyList
         }
         .frame(width: BookmarksPanel.width)
         .background(Color(nsColor: .windowBackgroundColor))
@@ -180,7 +180,7 @@ struct BookmarksPanel: View {
     // MARK: - List
 
     @ViewBuilder
-    private var body_list: some View {
+    private var bodyList: some View {
         if store.bookmarks.isEmpty {
             emptyState(.empty)
         } else {

--- a/apps/macos/SDRMac/Views/BookmarksSection.swift
+++ b/apps/macos/SDRMac/Views/BookmarksSection.swift
@@ -1,21 +1,23 @@
 //
-// BookmarksSection.swift — sidebar panel listing saved
-// tuning profiles (#240).
+// BookmarksSection.swift — sidebar "quick add" affordance for
+// saving the current tuning as a bookmark (#339 / #240).
 //
-// Simple CRUD on top of `BookmarksStore`:
-// - "Add current" snapshots the model's tuning state.
-// - Tapping a row applies that bookmark to the model.
-// - Context menu / swipe offers delete.
-// - Drag-to-reorder via SwiftUI's native `onMove` support.
+// Previously hosted the full bookmark list with delete,
+// reorder, and apply actions. Those moved to the right-side
+// `BookmarksPanel` flyout (toggled from the header toolbar /
+// ⌘B) in the #339 retool so the sidebar stays focused on
+// setup/config and the right flyout handles browse/manage.
 //
-// v1 intentionally excludes editing an existing bookmark's
-// tuning fields in place — users can delete + re-save. An
-// "Edit" sheet could come as a follow-up if users want name /
-// field edits without re-tuning.
+// What remains here is just the quick-save entry point:
+// a "Save current" button that opens a sheet prompting for
+// a name. The button stays in the sidebar — not moved into
+// the flyout — so users who keep the flyout closed don't
+// need to open it just to stash a frequency. Matches the
+// Linux GTK split where the sidebar's Navigation panel keeps
+// the name-entry + Add button while the flyout is the
+// browse surface (bookmarks_panel.rs header comment).
 
 import SwiftUI
-// `DemodMode.label` lives in SdrCoreKit — the enum is re-used
-// by SwiftUI-side Bookmark rendering.
 import SdrCoreKit
 
 struct BookmarksSection: View {
@@ -26,41 +28,20 @@ struct BookmarksSection: View {
 
     var body: some View {
         Section("Bookmarks") {
-            if store.bookmarks.isEmpty {
-                Text("No saved frequencies")
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-            } else {
-                ForEach(store.bookmarks) { bm in
-                    // Button (rather than `onTapGesture`) so
-                    // keyboard / VoiceOver / switch-control
-                    // activation works the same as a mouse
-                    // click. `.plain` keeps the row from picking
-                    // up button chrome.
-                    Button {
-                        model.apply(bm)
-                    } label: {
-                        BookmarkRow(bookmark: bm)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .contextMenu {
-                        Button(role: .destructive) {
-                            store.remove(id: bm.id)
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                    }
-                }
-                .onMove { source, destination in
-                    store.move(fromOffsets: source, toOffset: destination)
-                }
-            }
-
             Button {
                 showingAddSheet = true
             } label: {
                 Label("Save current", systemImage: "plus.circle")
+            }
+
+            // Tiny caption so first-time users know where the
+            // list went. Only shown when nothing's saved yet,
+            // so the sidebar stays terse once the user has
+            // stashed a frequency or two.
+            if store.bookmarks.isEmpty {
+                Text("Open the Bookmarks panel (⌘B) to browse saved frequencies.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
         }
         .sheet(isPresented: $showingAddSheet) {
@@ -73,48 +54,14 @@ struct BookmarksSection: View {
 }
 
 // ============================================================
-//  BookmarkRow
-// ============================================================
-
-private struct BookmarkRow: View {
-    let bookmark: Bookmark
-
-    var body: some View {
-        HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(bookmark.name)
-                    .lineLimit(1)
-                if let hz = bookmark.centerFrequencyHz {
-                    HStack(spacing: 6) {
-                        Text(formatRate(hz))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        if let mode = bookmark.demodMode {
-                            Text(mode.label)
-                                .font(.caption2)
-                                .padding(.horizontal, 4)
-                                .padding(.vertical, 1)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 3)
-                                        .fill(Color.secondary.opacity(0.15))
-                                )
-                        }
-                    }
-                }
-            }
-            Spacer()
-        }
-        .padding(.vertical, 2)
-    }
-}
-
-// ============================================================
 //  AddBookmarkSheet
 // ============================================================
 //
 //  Tiny modal: just a name field pre-filled with the current
-//  formatted frequency. Submit saves; Cancel dismisses. Full
-//  editable-profile form is a v2 polish item.
+//  formatted frequency. Submit saves; Cancel dismisses. Kept
+//  in-file (vs. hoisted to its own file) because it's tightly
+//  coupled to this section's "Save current" button — the only
+//  caller.
 
 private struct AddBookmarkSheet: View {
     @Environment(\.dismiss) private var dismiss

--- a/apps/macos/SDRMac/Views/HeaderToolbar.swift
+++ b/apps/macos/SDRMac/Views/HeaderToolbar.swift
@@ -13,6 +13,7 @@ struct HeaderToolbar: ToolbarContent {
     @Environment(CoreModel.self) private var model
     @Binding var showingRadioReference: Bool
     @Binding var showingTranscription: Bool
+    @Binding var showingBookmarks: Bool
 
     var body: some ToolbarContent {
         ToolbarItem(placement: .navigation) {
@@ -64,6 +65,34 @@ struct HeaderToolbar: ToolbarContent {
                 )
             }
             .help(showingTranscription ? "Hide Transcription Panel" : "Show Transcription Panel")
+        }
+
+        // Bookmarks panel toggle — mirrors the GTK bookmarks
+        // flyout button (issue #339). Same inline-Button +
+        // Label-with-text shape as the other right-flyout and
+        // RadioReference buttons; see the comment block on the
+        // RadioReference item below for the macOS-toolbar
+        // display-mode rationale. `⌘B` opens or closes the
+        // flyout, matching the Linux `Ctrl+B` binding.
+        //
+        // Mutual exclusivity with the transcription panel is
+        // handled at the ContentView level via `.onChange`
+        // handlers — the content area has room for one
+        // right-side flyout at a time, and coordinating the
+        // two `Binding<Bool>`s inside this toolbar closure
+        // would pull ContentView state into the toolbar
+        // struct unnecessarily.
+        ToolbarItem(placement: .automatic) {
+            Button {
+                showingBookmarks.toggle()
+            } label: {
+                Label(
+                    "Bookmarks",
+                    systemImage: showingBookmarks ? "bookmark.fill" : "bookmark"
+                )
+            }
+            .keyboardShortcut("b", modifiers: .command)
+            .help(showingBookmarks ? "Hide Bookmarks Panel (⌘B)" : "Show Bookmarks Panel (⌘B)")
         }
 
         // RadioReference button — mirrors the GTK header-bar

--- a/apps/macos/SDRMac/Views/SettingsView.swift
+++ b/apps/macos/SDRMac/Views/SettingsView.swift
@@ -118,7 +118,7 @@ private struct AudioPane: View {
                 if model.audioSinkType == .network {
                     TextField("Host", text: $hostEdit)
                         .textFieldStyle(.roundedBorder)
-                        .disableAutocorrection(true)
+                        .autocorrectionDisabled()
                     TextField("Port", text: $portEdit)
                         .textFieldStyle(.roundedBorder)
                     Picker("Protocol", selection: Binding(
@@ -264,7 +264,7 @@ private struct RadioReferencePane: View {
             Section {
                 TextField("Username", text: $username)
                     .textContentType(.username)
-                    .disableAutocorrection(true)
+                    .autocorrectionDisabled()
                 SecureField("Password", text: $password)
                     .textContentType(.password)
             } header: {

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -301,7 +301,7 @@ struct SourceSection: View {
     private var networkControls: some View {
         TextField("Host", text: $hostEdit)
             .textFieldStyle(.roundedBorder)
-            .disableAutocorrection(true)
+            .autocorrectionDisabled()
         TextField("Port", text: $portEdit)
             .textFieldStyle(.roundedBorder)
         Picker("Protocol", selection: Binding(
@@ -514,7 +514,7 @@ struct SourceSection: View {
         // Manual-entry host + port + Connect.
         TextField("Host", text: $rtlTcpHostEdit)
             .textFieldStyle(.roundedBorder)
-            .disableAutocorrection(true)
+            .autocorrectionDisabled()
             .textContentType(.URL)
         LabeledContent("Port") {
             TextField("1234", text: $rtlTcpPortEdit)


### PR DESCRIPTION
## Summary

Full parity with the Linux GTK retool from PR #361. The sidebar's "everything" bookmarks section splits into two surfaces: a terse quick-add in the sidebar, and a right-side slide-out flyout (⌘B) that hosts browse / search / manage.

Closes the macOS side of #339.

## What lands

1. **\`rrCategory\` on \`Bookmark\`** — schema parity with Linux, snake_case \`CodingKeys\` so a shared \`bookmarks.json\` round-trips between frontends. Currently unused on macOS until a RadioReference→bookmark import path lands, but the field is ready.
2. **\`activeBookmarkId\` on CoreModel** — \`@Observable\` id set by \`apply(_:)\` at its tail, cleared by every user-facing setter a bookmark touches (\`setCenter\`, \`setDemodMode\`, ...) via \`clearActiveBookmark()\`. Any path that tunes away invalidates the flyout highlight immediately.
3. **Flyout shell + ⌘B** — 360 pt wide \`BookmarksPanel\`, toggled from the header toolbar + \`⌘B\`. Open/closed persists in UserDefaults (\`SDRMac.bookmarks.flyoutOpen\`). Mutually exclusive with TranscriptionPanel (enforced via \`.onChange\` at ContentView level — mirrors Linux a793cdc). Shared \`rightFlyoutTransitionSeconds = 0.2\` constant between both flyouts.
4. **Search row + filter predicate** — case-insensitive substring match against \`name\` + formatted frequency/mode subtitle + \`rrCategory\`. Subtitle format is a static helper shared by the row renderer AND the filter so a visually-labelled "145.7 MHz · NFM" row is findable by searching any part.
5. **Category grouping + dual-state expansion** — \`DisclosureGroup\` per unique \`rrCategory\` with "Uncategorized" sentinel at the tail, alphabetical otherwise. First-time installs (no category yet) render flat. User's per-category manual expansion preference persists separately from search-driven force-open — writes during search are suppressed so previously-collapsed categories snap back when search clears.
6. **Sidebar \`BookmarksSection\` shrunk to quick-add** — just "Save current" button + a ⌘B pointer when the list is empty. Row actions (delete) moved to flyout rows with both tooltip + \`.accessibilityLabel\`.

## Getting ahead of the rabbit

Folding in durable lessons from PR #361's 11 findings from day one:

- **Filter must include category** (#361 round 1 Major) — landed in commit 4.
- **\`.accessibilityLabel\` on every icon-only button** (#361 round 1 Minor ×2) — every icon-only Button in BookmarksPanel carries \`.accessibilityLabel(...)\` + \`.help(...)\`.
- **Delete by UUID, not name+frequency** (#361 round 1 Major) — already safe on macOS (Bookmark has stable \`id: UUID\`), used throughout.
- **Manual expansion state separate from search force-open** (#361 round 2 Major) — commit 5 builds a \`Binding<Bool>\` where writes are suppressed while the filter is active, so the force-open state never pollutes the persisted manual map.
- **Shared flyout transition duration constant** (#361 round 1 Refactor Major) — \`ContentView.rightFlyoutTransitionSeconds\` consumed by both \`.animation\` modifiers.

## Test plan

- [ ] Launch app → sidebar shows minimal "Bookmarks" section with Save-current + ⌘B pointer
- [ ] Press ⌘B → flyout slides in from the right, empty-state caption visible
- [ ] Save a bookmark from the sidebar → shows up in the flyout list, highlighted as active (accent checkmark)
- [ ] Tune the slider → active highlight clears
- [ ] Click the bookmark row → tuning restores, highlight returns
- [ ] Click the trailing trash icon → bookmark removed
- [ ] Right-click row → context menu shows Delete; click deletes
- [ ] Open the Transcription panel → Bookmarks panel closes automatically (and vice versa)
- [ ] Quit + relaunch with Bookmarks open → flyout opens automatically
- [ ] Save two bookmarks, edit one to have \`rrCategory = "Test"\` via a future import path (or manually in \`bookmarks.json\`) → flyout groups into "Test" + "Uncategorized" sections
- [ ] Search for a category name → matching group stays expanded; toggle collapse on a non-matching group; clear search → collapsed category stays collapsed
- [ ] Type in the search box → filter narrows live; clear button clears text; empty-match state shows "No matches for \"foo\""

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-side bookmarks panel (toggle/⌘B) with search, category grouping, per-bookmark apply/delete, and a compact sidebar “Save current” control.

* **Behavior**
  * Bookmarks panel and transcription panel are mutually exclusive; opening one closes the other.
  * Panel open/closed state and per-category expansion persist across launches.
  * Applied bookmarks are visually highlighted; highlight clears when tuning changes.

* **Style**
  * Updated TextField autocorrection API usage in settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->