### PR TITLE
AGC type selector + file loop-on-EOF — ABI 0.13 (closes #357, #236)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -253,9 +253,45 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(sdr_core_set_gain(handle, gainDb))
     }
 
-    /// Enable or disable tuner AGC.
+    /// Enable or disable tuner AGC (hardware loop only).
+    ///
+    /// Legacy two-state setter preserved for backward-compat.
+    /// Modern callers should use `setAgcType(_:)` which
+    /// dispatches both the hardware and software loops in
+    /// one call; this setter only touches hardware, so a
+    /// consumer calling `setAgc(false)` while software AGC
+    /// is on would leave software on unexpectedly.
     public func setAgc(_ enabled: Bool) throws {
         try checkRc(sdr_core_set_agc(handle, enabled))
+    }
+
+    /// Three-state AGC selector. `.off` / `.hardware` /
+    /// `.software` — the engine's two AGC loops are mutually
+    /// exclusive at the UI policy layer, and this setter
+    /// enforces that by dispatching both underlying commands
+    /// atomically. Default on fresh installs is `.software`
+    /// (sidesteps the tuner-AGC pumping behavior). Per issue
+    /// #357 (ABI 0.13).
+    public enum AgcType: Int32, Sendable, CaseIterable, Codable {
+        case off      = 0
+        case hardware = 1
+        case software = 2
+
+        public var label: String {
+            switch self {
+            case .off:      return "Off"
+            case .hardware: return "Hardware"
+            case .software: return "Software"
+            }
+        }
+    }
+
+    /// Set the active AGC type. See `AgcType` for the
+    /// single-loop-on policy — this call flips BOTH the
+    /// hardware (`set_agc`) and software (`set_software_agc`)
+    /// loops in one FFI transaction.
+    public func setAgcType(_ type: AgcType) throws {
+        try checkRc(sdr_core_set_agc_type(handle, type.rawValue))
     }
 
     /// Set the active demodulation mode.
@@ -377,6 +413,17 @@ public final class SdrCore: @unchecked Sendable {
         try checkRc(path.withCString { cPath in
             sdr_core_set_file_path(handle, cPath)
         })
+    }
+
+    /// Toggle loop-on-EOF for the file playback source.
+    /// `true` rewinds to the start of the WAV file at EOF
+    /// and keeps streaming; `false` stops the source at EOF.
+    /// Applies both to the running source (effective from
+    /// the next EOF onward) and to future source rebuilds.
+    /// No-op when the active source isn't `.file`. Per issue
+    /// #236 (ABI 0.13).
+    public func setFileLooping(_ looping: Bool) throws {
+        try checkRc(sdr_core_set_file_looping(handle, looping))
     }
 
     // ==========================================================

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -418,10 +418,18 @@ public final class SdrCore: @unchecked Sendable {
     /// Toggle loop-on-EOF for the file playback source.
     /// `true` rewinds to the start of the WAV file at EOF
     /// and keeps streaming; `false` stops the source at EOF.
-    /// Applies both to the running source (effective from
-    /// the next EOF onward) and to future source rebuilds.
-    /// No-op when the active source isn't `.file`. Per issue
-    /// #236 (ABI 0.13).
+    ///
+    /// The engine always persists the value on its state
+    /// regardless of the currently-active source — a later
+    /// switch to `.file` picks up the stored value rather
+    /// than resetting to the constructor default.
+    ///
+    /// When the active source is `.file`, the setting is
+    /// also applied to the running source (effective from
+    /// the next EOF onward). When the active source is
+    /// anything else the immediate apply is a no-op but
+    /// the stored value still takes effect on the next
+    /// switch to file playback. Per issue #236 (ABI 0.13).
     public func setFileLooping(_ looping: Bool) throws {
         try checkRc(sdr_core_set_file_looping(handle, looping))
     }

--- a/apps/macos/SDRMac/Models/Bookmark.swift
+++ b/apps/macos/SDRMac/Models/Bookmark.swift
@@ -38,9 +38,23 @@ struct Bookmark: Codable, Identifiable, Hashable {
     var autoSquelchEnabled: Bool?
     var squelchDb: Float?
     var gainDb: Double?
+
+    /// Legacy AGC boolean — kept for backward-compat with
+    /// pre-#357 bookmarks.json. `true` recalls to hardware
+    /// (the old default when it was Bool), `false` to off.
+    /// Modern bookmarks also carry the tristate `agcType` below
+    /// and the apply path prefers that when present. Same
+    /// dual-field pattern the Linux side uses (agc + agc_type)
+    /// so cross-frontend schemas stay aligned.
     var agcEnabled: Bool?
+
     var volume: Float?
     var deemphasis: Deemphasis?
+
+    /// Tristate AGC — Off / Hardware / Software. Takes
+    /// precedence over `agcEnabled` on recall when present.
+    /// Per issue #357.
+    var agcType: SdrCore.AgcType?
 
     // MARK: Organization
 
@@ -72,5 +86,6 @@ struct Bookmark: Codable, Identifiable, Hashable {
         case volume
         case deemphasis
         case rrCategory = "rr_category"
+        case agcType = "agc_type"
     }
 }

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -189,6 +189,13 @@ final class CoreModel {
     /// validation here.
     var filePath: String = ""
 
+    /// Loop-on-EOF for the file playback source. `false`
+    /// default matches the engine's `FileSource::new`
+    /// constructor default (stop at EOF). Persisted via
+    /// `UserDefaults` under `SDRMac.fileLooping`. Per issue
+    /// #236.
+    var fileLoopingEnabled: Bool = false
+
     // ==========================================================
     //  Tuner
     // ==========================================================
@@ -747,6 +754,9 @@ final class CoreModel {
             let raw = Int32(UserDefaults.standard.integer(forKey: Self.agcTypeDefaultsKey))
             agcType = SdrCore.AgcType(rawValue: raw) ?? .software
         }
+        if UserDefaults.standard.object(forKey: Self.fileLoopingDefaultsKey) != nil {
+            fileLoopingEnabled = UserDefaults.standard.bool(forKey: Self.fileLoopingDefaultsKey)
+        }
         if let host = UserDefaults.standard.string(forKey: Self.networkSourceHostDefaultsKey),
            !host.isEmpty {
             networkSourceHost = host
@@ -1181,6 +1191,11 @@ final class CoreModel {
         if !filePath.isEmpty {
             setFilePath(filePath)
         }
+        // File-loop flag is applied regardless of the current
+        // filePath — the engine stores it on DspState so a
+        // future `.file` source-type switch picks it up even
+        // if no path is set yet. Per issue #236.
+        setFileLooping(fileLoopingEnabled)
         setSourceType(sourceType)
         setCenter(centerFrequencyHz)
         setVfoOffset(vfoOffsetHz)
@@ -1407,6 +1422,22 @@ final class CoreModel {
     /// UserDefaults key for the persisted AGC type. Absent
     /// key leaves the default (`.software`) intact.
     static let agcTypeDefaultsKey = "SDRMac.agcType"
+
+    /// Toggle loop-on-EOF for the file playback source. `true`
+    /// rewinds to the start of the WAV file on EOF and keeps
+    /// streaming; `false` stops at EOF. Persisted so the user's
+    /// choice survives launches. Engine applies it both to the
+    /// running source (next EOF) and to future source rebuilds.
+    /// Per issue #236.
+    func setFileLooping(_ looping: Bool) {
+        fileLoopingEnabled = looping
+        UserDefaults.standard.set(looping, forKey: Self.fileLoopingDefaultsKey)
+        capture { try core?.setFileLooping(looping) }
+    }
+
+    /// UserDefaults key for the persisted file-loop flag.
+    /// Absent key leaves the default (`false`) intact.
+    static let fileLoopingDefaultsKey = "SDRMac.fileLooping"
 
     func setSquelchDb(_ db: Float) {
         clearActiveBookmark()

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -195,7 +195,20 @@ final class CoreModel {
 
     var availableGains: [Double] = []
     var gainDb: Double = 0
-    var agcEnabled: Bool = false
+
+    /// Active AGC type — tristate selector that replaced the
+    /// two-state `agcEnabled: Bool`. Default `.software` on
+    /// fresh installs (sidesteps tuner-AGC pumping behavior).
+    /// Persisted via `UserDefaults` under `SDRMac.agcType`.
+    /// Per issue #357.
+    var agcType: SdrCore.AgcType = .software
+
+    /// `true` when either AGC loop is on. Convenience shim for
+    /// call sites that previously read `agcEnabled: Bool` —
+    /// gain-slider disable, bookmark capture, etc. The source
+    /// of truth is `agcType`; this is a computed view.
+    var agcEnabled: Bool { agcType != .off }
+
     var deviceInfo: String = ""
 
     /// `true` when a local RTL-SDR dongle was detected on the
@@ -730,6 +743,10 @@ final class CoreModel {
             let raw = Int32(UserDefaults.standard.integer(forKey: Self.sourceTypeDefaultsKey))
             sourceType = SourceType(rawValue: raw) ?? .rtlSdr
         }
+        if UserDefaults.standard.object(forKey: Self.agcTypeDefaultsKey) != nil {
+            let raw = Int32(UserDefaults.standard.integer(forKey: Self.agcTypeDefaultsKey))
+            agcType = SdrCore.AgcType(rawValue: raw) ?? .software
+        }
         if let host = UserDefaults.standard.string(forKey: Self.networkSourceHostDefaultsKey),
            !host.isEmpty {
             networkSourceHost = host
@@ -1094,9 +1111,13 @@ final class CoreModel {
             autoSquelchEnabled: autoSquelchEnabled,
             squelchDb: squelchDb,
             gainDb: gainDb,
+            // Legacy boolean kept for backward-compat with
+            // pre-#357 bookmarks.json (same dual-field pattern
+            // the Linux side uses — agc_type alongside agc).
             agcEnabled: agcEnabled,
             volume: nil,       // feels more like env setting than per-bookmark
-            deemphasis: deemphasis
+            deemphasis: deemphasis,
+            agcType: agcType
         )
     }
 
@@ -1124,7 +1145,12 @@ final class CoreModel {
         if let db = bookmark.squelchDb         { setSquelchDb(db) }
         if let auto = bookmark.autoSquelchEnabled { setAutoSquelch(auto) }
         if let g = bookmark.gainDb             { setGain(g) }
-        if let agc = bookmark.agcEnabled       { setAgc(agc) }
+        // Prefer the tristate `agcType` field when present —
+        // pre-#357 bookmarks only carry the legacy `agcEnabled`
+        // boolean, which `setAgc(_:)` forwards to the tristate
+        // as a fallback.
+        if let type = bookmark.agcType         { setAgcType(type) }
+        else if let agc = bookmark.agcEnabled  { setAgc(agc) }
         if let v = bookmark.volume             { setVolume(v) }
         if let d = bookmark.deemphasis         { setDeemphasis(d) }
         activeBookmarkId = bookmark.id
@@ -1169,7 +1195,7 @@ final class CoreModel {
         setIqCorrection(iqCorrectionEnabled)
         setPpm(ppmCorrection)
         setGain(gainDb)
-        setAgc(agcEnabled)
+        setAgcType(agcType)
         setDemodMode(demodMode)
         setBandwidth(bandwidthHz)
         setSquelchEnabled(squelchEnabled)
@@ -1356,11 +1382,31 @@ final class CoreModel {
         capture { try core?.setGain(db) }
     }
 
+    /// Legacy two-state AGC setter — now a thin forwarder
+    /// onto the tristate `setAgcType(_:)` so a bookmark saved
+    /// under the old `agcEnabled: Bool` schema still recalls
+    /// correctly. `true` maps to `.hardware` (the pre-#357
+    /// default); `false` maps to `.off`. New call sites should
+    /// use `setAgcType(_:)` directly.
     func setAgc(_ on: Bool) {
-        clearActiveBookmark()
-        agcEnabled = on
-        capture { try core?.setAgc(on) }
+        setAgcType(on ? .hardware : .off)
     }
+
+    /// Tristate AGC setter. Persists to `UserDefaults` so the
+    /// user's choice survives launches (fresh install default:
+    /// `.software` — see `agcType` field docs). Dispatches
+    /// both the hardware and software AGC loops atomically
+    /// through the ABI 0.13 `setAgcType` FFI.
+    func setAgcType(_ type: SdrCore.AgcType) {
+        clearActiveBookmark()
+        agcType = type
+        UserDefaults.standard.set(Int(type.rawValue), forKey: Self.agcTypeDefaultsKey)
+        capture { try core?.setAgcType(type) }
+    }
+
+    /// UserDefaults key for the persisted AGC type. Absent
+    /// key leaves the default (`.software`) intact.
+    static let agcTypeDefaultsKey = "SDRMac.agcType"
 
     func setSquelchDb(_ db: Float) {
         clearActiveBookmark()

--- a/apps/macos/SDRMac/Views/RadioReferenceDialog.swift
+++ b/apps/macos/SDRMac/Views/RadioReferenceDialog.swift
@@ -361,7 +361,8 @@ struct RadioReferenceDialog: View {
             gainDb: nil,
             agcEnabled: nil,
             volume: nil,
-            deemphasis: nil
+            deemphasis: nil,
+            agcType: nil
         )
     }
 

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -282,10 +282,25 @@ struct SourceSection: View {
             }
         }
 
-        Toggle("AGC", isOn: Binding(
-            get: { model.agcEnabled },
-            set: { model.setAgc($0) }
-        ))
+        // Three-way AGC selector — #357. Replaced the former
+        // binary Toggle so users can pick Software (new default,
+        // sidesteps tuner-AGC pumping) while still letting the
+        // tuner's hardware loop drive gain when preferred. The
+        // gain slider above reads `agcEnabled` (a computed
+        // `agcType != .off`) so either AGC type disables the
+        // manual slider the same way.
+        LabeledContent("AGC") {
+            Picker("", selection: Binding(
+                get: { model.agcType },
+                set: { model.setAgcType($0) }
+            )) {
+                ForEach(SdrCore.AgcType.allCases, id: \.self) { t in
+                    Text(t.label).tag(t)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+        }
 
         LabeledContent("PPM") {
             Stepper(value: Binding(

--- a/apps/macos/SDRMac/Views/SourceSection.swift
+++ b/apps/macos/SDRMac/Views/SourceSection.swift
@@ -410,6 +410,18 @@ struct SourceSection: View {
                 .truncationMode(.middle)
                 .textSelection(.enabled)
         }
+
+        // Loop-on-EOF toggle — #236. Applies live to an active
+        // .file source (the engine flips `FileSource::set_looping`
+        // at next EOF) and is persisted via UserDefaults so the
+        // choice survives launches. Always visible in the .file
+        // arm so the user can pre-configure before picking a
+        // WAV, not just after.
+        Toggle("Loop playback", isOn: Binding(
+            get: { model.fileLoopingEnabled },
+            set: { model.setFileLooping($0) }
+        ))
+
         if pendingType != model.sourceType {
             Text("Source switches to File playback after you pick a WAV.")
                 .font(.caption)

--- a/apps/macos/SDRMacTests/BookmarkTests.swift
+++ b/apps/macos/SDRMacTests/BookmarkTests.swift
@@ -1,0 +1,90 @@
+//
+// BookmarkTests.swift — JSON schema regression tests for the
+// Bookmark struct.
+//
+// The on-disk format is shared with the Linux GTK frontend
+// (`crates/sdr-ui/src/sidebar/navigation_panel.rs::Bookmark`),
+// so silent schema drift between the two sides would break
+// cross-frontend round-tripping of `bookmarks.json`. These
+// tests guard the wire contract — they encode and decode a
+// representative Bookmark and assert that both the legacy
+// fields (`agcEnabled: Bool?`) and modern fields
+// (`agcType: AgcType?`, JSON key `agc_type`) survive
+// intact.
+
+import XCTest
+@testable import SDRMac
+import SdrCoreKit
+
+final class BookmarkTests: XCTestCase {
+    /// Mirrors Linux's `bookmark_full_roundtrip` regression
+    /// guard (see `crates/sdr-ui/src/sidebar/navigation_panel.rs`).
+    /// Builds a Bookmark with BOTH the legacy `agcEnabled`
+    /// boolean and the modern `agcType` enum set, JSON-
+    /// encodes, decodes, and asserts both fields come back
+    /// unchanged. A serde-shape change on `AgcType` or a
+    /// dropped CodingKey would fail this test loudly instead
+    /// of silently breaking the shared schema. Per `CodeRabbit`
+    /// round 1 on PR #371.
+    func testBookmarkDualFieldAgcRoundTrip() throws {
+        let original = Bookmark(
+            name: "WWV 5 MHz",
+            centerFrequencyHz: 5_000_000,
+            demodMode: .am,
+            bandwidthHz: 10_000,
+            squelchEnabled: nil,
+            autoSquelchEnabled: nil,
+            squelchDb: nil,
+            gainDb: 20.0,
+            agcEnabled: true,
+            volume: nil,
+            deemphasis: nil,
+            agcType: .software
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+
+        // Raw key check — the on-disk spelling must be
+        // `agc_type` (snake_case) so the Linux side can
+        // decode what Mac wrote.
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(
+            json.contains("\"agc_type\""),
+            "expected snake_case `agc_type` key in JSON; got: \(json)"
+        )
+        XCTAssertTrue(
+            json.contains("\"agcEnabled\""),
+            "expected legacy `agcEnabled` key in JSON; got: \(json)"
+        )
+
+        let back = try JSONDecoder().decode(Bookmark.self, from: data)
+        XCTAssertEqual(back.agcEnabled, true, "legacy bool must round-trip")
+        XCTAssertEqual(back.agcType, .software, "modern enum must round-trip")
+        XCTAssertEqual(back.name, original.name)
+        XCTAssertEqual(back.centerFrequencyHz, original.centerFrequencyHz)
+        XCTAssertEqual(back.demodMode, original.demodMode)
+        XCTAssertEqual(back.id, original.id)
+    }
+
+    /// Legacy bookmark (pre-#357) contains only `agcEnabled`,
+    /// not `agc_type`. Guard that it still decodes without
+    /// the new field and `agcType` comes back nil rather
+    /// than failing the whole decode.
+    func testLegacyBookmarkWithoutAgcTypeDecodes() throws {
+        let legacyJson = """
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "name": "Legacy NOAA",
+              "updatedAt": 0,
+              "centerFrequencyHz": 162550000,
+              "agcEnabled": false
+            }
+            """
+        let data = try XCTUnwrap(legacyJson.data(using: .utf8))
+        let bm = try JSONDecoder().decode(Bookmark.self, from: data)
+        XCTAssertEqual(bm.agcEnabled, false)
+        XCTAssertNil(bm.agcType, "pre-#357 bookmarks carry no agc_type; should decode as nil")
+        XCTAssertEqual(bm.name, "Legacy NOAA")
+    }
+}

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -283,6 +283,12 @@ struct DspState {
     network_port: u16,
     network_protocol: sdr_types::Protocol,
     file_path: std::path::PathBuf,
+    /// Loop-on-EOF flag for the file playback source. Default
+    /// `false` (stop at EOF). Updated by `UiToDsp::SetFileLooping`
+    /// and applied both to the currently-running source (if any)
+    /// and to the newly-opened source when the source is rebuilt
+    /// from a path or source-type change. Per issue #236.
+    file_looping: bool,
 
     // Pre-allocated buffers
     iq_buf: Vec<Complex>,
@@ -413,6 +419,7 @@ impl DspState {
             network_port: 1234,
             network_protocol: sdr_types::Protocol::TcpClient,
             file_path: std::path::PathBuf::new(),
+            file_looping: false,
             iq_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             processed_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             fft_buf: vec![0.0; DEFAULT_FFT_SIZE],
@@ -1241,6 +1248,23 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             state.file_path = path;
         }
 
+        UiToDsp::SetFileLooping(looping) => {
+            // Store on the state so a source rebuild (e.g. after
+            // a file-path change) picks up the latest setting,
+            // and also apply to the live source so an already-
+            // playing file starts / stops looping at its next
+            // EOF. Non-file sources silently accept per the
+            // trait default. Per issue #236.
+            tracing::debug!(looping, "set file looping");
+            state.file_looping = looping;
+            if let Some(source) = &mut state.source
+                && let Err(e) = source.set_looping(looping)
+            {
+                tracing::warn!("set file looping failed: {e}");
+                let _ = dsp_tx.send(DspToUi::Error(format!("File looping failed: {e}")));
+            }
+        }
+
         UiToDsp::SetBiasTee(enabled) => {
             tracing::debug!(enabled, "set bias tee");
             if let Some(source) = &mut state.source
@@ -1490,7 +1514,16 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
             state.network_port,
             state.network_protocol,
         )),
-        SourceType::File => Box::new(sdr_source_file::FileSource::new(&state.file_path)),
+        SourceType::File => {
+            // Apply the persisted loop flag to the freshly-
+            // constructed source so a replay after a path
+            // change honors the latest setting — without
+            // this, switching files would reset looping to
+            // the constructor default. Per issue #236.
+            let mut fs = sdr_source_file::FileSource::new(&state.file_path);
+            fs.set_looping(state.file_looping);
+            Box::new(fs)
+        }
         // rtl_tcp client: connects to a remote `rtl_tcp`-compatible
         // server, handshakes the 12-byte RTL0 header, and routes
         // future tune / gain / PPM messages through the 5-byte

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -621,6 +621,15 @@ mod tests {
             UiToDsp::SetFilePath(ref p) if p == std::path::Path::new("/tmp/test.wav")
         ));
 
+        // Loop-on-EOF toggle — both polarities, since the
+        // controller's handler branches on the value and we
+        // want a shape regression on either to fail loudly.
+        // Per `CodeRabbit` round 1 on PR #371.
+        let loop_on = UiToDsp::SetFileLooping(true);
+        assert!(matches!(loop_on, UiToDsp::SetFileLooping(true)));
+        let loop_off = UiToDsp::SetFileLooping(false);
+        assert!(matches!(loop_off, UiToDsp::SetFileLooping(false)));
+
         let ppm = UiToDsp::SetPpmCorrection(42);
         assert!(matches!(ppm, UiToDsp::SetPpmCorrection(42)));
 

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -213,6 +213,11 @@ pub enum UiToDsp {
     },
     /// Set the file path for file source playback.
     SetFilePath(std::path::PathBuf),
+    /// Toggle loop-on-EOF for the file playback source. `true`
+    /// rewinds to the start of the file on EOF and keeps
+    /// streaming; `false` stops the source at EOF. No-op when
+    /// the active source isn't `.file`. Per issue #236.
+    SetFileLooping(bool),
     /// Set PPM frequency correction for RTL-SDR crystal offset.
     SetPpmCorrection(i32),
     // ------------------------------------------------------

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -278,9 +278,63 @@ pub unsafe extern "C" fn sdr_core_set_gain(handle: *mut SdrCore, gain_db: f64) -
 }
 
 /// Enable or disable tuner AGC.
+///
+/// Legacy two-state setter preserved for backward-compat with
+/// hosts that don't need the tristate selector. Only touches the
+/// hardware (tuner) AGC; does NOT turn off software AGC. Modern
+/// hosts should use `sdr_core_set_agc_type` which dispatches both
+/// loops atomically according to the requested type. Per issue
+/// #357.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_set_agc(handle: *mut SdrCore, enabled: bool) -> i32 {
     unsafe { with_core(handle, |core| send(core, UiToDsp::SetAgc(enabled))) }
+}
+
+// --- AGC type selector (#357, ABI 0.13) -------------------
+//
+// Discriminants mirror `SdrAgcType` in `include/sdr_core.h`.
+// Reordering would silently break ABI — add new variants at the
+// end with a minor version bump.
+
+/// AGC Off — both hardware (tuner) and software IF loops
+/// disabled. Gain slider controls the tuner gain directly.
+pub const SDR_AGC_OFF: i32 = 0;
+/// AGC Hardware — tuner's internal AGC loop on, software IF
+/// AGC off. The RTL2832 sets gain automatically in hardware.
+pub const SDR_AGC_HARDWARE: i32 = 1;
+/// AGC Software — software IF AGC on (engine-side post-IQ
+/// AGC), hardware tuner AGC off. Gives finer control than
+/// hardware at the cost of CPU. Default on fresh installs.
+pub const SDR_AGC_SOFTWARE: i32 = 2;
+
+/// Set the active AGC type. Dispatches both the hardware
+/// (`UiToDsp::SetAgc`) and software (`UiToDsp::SetSoftwareAgc`)
+/// variants in one call — the two loops are mutually exclusive
+/// at the UI policy layer but independent at the DSP layer, so
+/// the FFI enforces the policy by always issuing both commands.
+///
+/// Accepts `SDR_AGC_OFF` / `SDR_AGC_HARDWARE` / `SDR_AGC_SOFTWARE`;
+/// any other value returns `SDR_CORE_ERR_INVALID_ARG`. Per
+/// issue #357 (ABI 0.13).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_agc_type(handle: *mut SdrCore, agc_type: i32) -> i32 {
+    unsafe {
+        with_core(handle, |core| match agc_type {
+            SDR_AGC_OFF => send(core, UiToDsp::SetAgc(false))
+                .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false))),
+            SDR_AGC_HARDWARE => send(core, UiToDsp::SetAgc(true))
+                .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false))),
+            SDR_AGC_SOFTWARE => send(core, UiToDsp::SetAgc(false))
+                .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(true))),
+            _ => {
+                set_last_error(format!(
+                    "sdr_core_set_agc_type: invalid type {agc_type} \
+                     (expected {SDR_AGC_OFF}..={SDR_AGC_SOFTWARE})"
+                ));
+                Err(SdrCoreError::InvalidArg)
+            }
+        })
+    }
 }
 
 // ============================================================
@@ -797,6 +851,24 @@ pub unsafe extern "C" fn sdr_core_set_file_path(
             send(core, UiToDsp::SetFilePath(std::path::PathBuf::from(path)))
         })
     }
+}
+
+/// Toggle loop-on-EOF for the file playback source. When
+/// `looping` is `true` the source rewinds to the start of the
+/// WAV file on EOF and keeps streaming; when `false` the source
+/// stops at EOF.
+///
+/// Applies both to the running source (effective from the next
+/// EOF onward) and to future source rebuilds — the engine keeps
+/// the latest value on its state so a source-type switch or
+/// file-path change doesn't reset to the constructor default.
+///
+/// No-op when the active source isn't `SDR_SOURCE_FILE`; the
+/// trait's default `set_looping` impl silently accepts. Per
+/// issue #236 (ABI 0.13).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_file_looping(handle: *mut SdrCore, looping: bool) -> i32 {
+    unsafe { with_core(handle, |core| send(core, UiToDsp::SetFileLooping(looping))) }
 }
 
 // ============================================================
@@ -1987,6 +2059,67 @@ mod tests {
             SdrCoreError::InvalidArg.as_int()
         );
         destroy(h);
+    }
+
+    #[test]
+    fn set_file_looping_round_trips() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_file_looping(h, true) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_file_looping(h, false) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_file_looping_rejects_null_handle() {
+        assert_eq!(
+            unsafe { sdr_core_set_file_looping(std::ptr::null_mut(), true) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+    }
+
+    // ------------------------------------------------------
+    //  AGC type selector (#357, ABI 0.13)
+    // ------------------------------------------------------
+
+    #[test]
+    fn set_agc_type_accepts_valid_variants() {
+        let h = make_handle();
+        for t in [SDR_AGC_OFF, SDR_AGC_HARDWARE, SDR_AGC_SOFTWARE] {
+            assert_eq!(
+                unsafe { sdr_core_set_agc_type(h, t) },
+                SdrCoreError::Ok.as_int(),
+                "AGC type {t} should be accepted"
+            );
+        }
+        destroy(h);
+    }
+
+    #[test]
+    fn set_agc_type_rejects_out_of_range() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_agc_type(h, SDR_AGC_SOFTWARE + 1) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_agc_type(h, SDR_AGC_OFF - 1) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_agc_type_rejects_null_handle() {
+        assert_eq!(
+            unsafe { sdr_core_set_agc_type(std::ptr::null_mut(), SDR_AGC_OFF) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
     }
 
     // ------------------------------------------------------

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -277,32 +277,6 @@ pub unsafe extern "C" fn sdr_core_set_gain(handle: *mut SdrCore, gain_db: f64) -
     }
 }
 
-/// Enable or disable tuner AGC.
-///
-/// Legacy two-state setter preserved for backward-compat with
-/// hosts that don't need the tristate selector. Forwards to the
-/// `sdr_core_set_agc_type` semantics so the engine's single-
-/// loop-on policy is preserved: `true` maps to
-/// `SDR_AGC_HARDWARE` (tuner on, software off), `false` maps to
-/// `SDR_AGC_OFF` (both loops off). A pre-0.13 host dropping to
-/// `false` after software AGC had been enabled elsewhere still
-/// gets a true "manual gain, no AGC" state. Per `CodeRabbit`
-/// round 1 on PR #371 and issue #357.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sdr_core_set_agc(handle: *mut SdrCore, enabled: bool) -> i32 {
-    unsafe {
-        with_core(handle, |core| {
-            if enabled {
-                send(core, UiToDsp::SetAgc(true))
-                    .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false)))
-            } else {
-                send(core, UiToDsp::SetAgc(false))
-                    .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false)))
-            }
-        })
-    }
-}
-
 // --- AGC type selector (#357, ABI 0.13) -------------------
 //
 // Discriminants mirror `SdrAgcType` in `include/sdr_core.h`.
@@ -320,6 +294,57 @@ pub const SDR_AGC_HARDWARE: i32 = 1;
 /// hardware at the cost of CPU. Default on fresh installs.
 pub const SDR_AGC_SOFTWARE: i32 = 2;
 
+/// Shared AGC-policy dispatch — the single source of truth
+/// for which pair of `UiToDsp::SetAgc` + `UiToDsp::SetSoftwareAgc`
+/// commands maps to each tristate value. Both the legacy
+/// `sdr_core_set_agc(bool)` shim and the modern
+/// `sdr_core_set_agc_type(i32)` call through here so a future
+/// policy change (e.g. allowing both loops on) only needs to be
+/// written once. Per `CodeRabbit` round 2 on PR #371.
+///
+/// Returns `Err(InvalidArg)` on an unknown `agc_type` and sets
+/// the last-error message. Caller is responsible for not
+/// passing a tristate value that isn't one of the `SDR_AGC_*`
+/// constants.
+fn send_agc_policy(core: &SdrCore, agc_type: i32) -> Result<(), SdrCoreError> {
+    match agc_type {
+        SDR_AGC_OFF => send(core, UiToDsp::SetAgc(false))
+            .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false))),
+        SDR_AGC_HARDWARE => send(core, UiToDsp::SetAgc(true))
+            .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false))),
+        SDR_AGC_SOFTWARE => send(core, UiToDsp::SetAgc(false))
+            .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(true))),
+        _ => {
+            set_last_error(format!(
+                "sdr_core_set_agc_type: invalid type {agc_type} \
+                 (expected {SDR_AGC_OFF}..={SDR_AGC_SOFTWARE})"
+            ));
+            Err(SdrCoreError::InvalidArg)
+        }
+    }
+}
+
+/// Enable or disable tuner AGC.
+///
+/// Legacy two-state setter preserved for backward-compat with
+/// hosts that don't need the tristate selector. Forwards to the
+/// `sdr_core_set_agc_type` semantics via the shared
+/// `send_agc_policy` helper: `true` → `SDR_AGC_HARDWARE`
+/// (tuner on, software off), `false` → `SDR_AGC_OFF` (both off).
+/// A pre-0.13 host dropping to `false` after software AGC had
+/// been enabled elsewhere still gets a true "manual gain, no
+/// AGC" state. Per `CodeRabbit` round 1 on PR #371 and issue
+/// #357.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_agc(handle: *mut SdrCore, enabled: bool) -> i32 {
+    let agc_type = if enabled {
+        SDR_AGC_HARDWARE
+    } else {
+        SDR_AGC_OFF
+    };
+    unsafe { with_core(handle, |core| send_agc_policy(core, agc_type)) }
+}
+
 /// Set the active AGC type. Dispatches both the hardware
 /// (`UiToDsp::SetAgc`) and software (`UiToDsp::SetSoftwareAgc`)
 /// variants in one call — the two loops are mutually exclusive
@@ -331,23 +356,7 @@ pub const SDR_AGC_SOFTWARE: i32 = 2;
 /// issue #357 (ABI 0.13).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_set_agc_type(handle: *mut SdrCore, agc_type: i32) -> i32 {
-    unsafe {
-        with_core(handle, |core| match agc_type {
-            SDR_AGC_OFF => send(core, UiToDsp::SetAgc(false))
-                .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false))),
-            SDR_AGC_HARDWARE => send(core, UiToDsp::SetAgc(true))
-                .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false))),
-            SDR_AGC_SOFTWARE => send(core, UiToDsp::SetAgc(false))
-                .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(true))),
-            _ => {
-                set_last_error(format!(
-                    "sdr_core_set_agc_type: invalid type {agc_type} \
-                     (expected {SDR_AGC_OFF}..={SDR_AGC_SOFTWARE})"
-                ));
-                Err(SdrCoreError::InvalidArg)
-            }
-        })
-    }
+    unsafe { with_core(handle, |core| send_agc_policy(core, agc_type)) }
 }
 
 // ============================================================
@@ -2103,6 +2112,31 @@ mod tests {
     // ------------------------------------------------------
     //  AGC type selector (#357, ABI 0.13)
     // ------------------------------------------------------
+
+    // Legacy bool entry point — pins the tristate-forwarding
+    // semantics so a future refactor can't silently break
+    // pre-0.13 hosts. Per `CodeRabbit` round 2 on PR #371.
+    #[test]
+    fn set_agc_legacy_bool_round_trips() {
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_agc(h, true) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_agc(h, false) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn set_agc_legacy_bool_rejects_null_handle() {
+        assert_eq!(
+            unsafe { sdr_core_set_agc(std::ptr::null_mut(), false) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+    }
 
     #[test]
     fn set_agc_type_accepts_valid_variants() {

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -280,14 +280,27 @@ pub unsafe extern "C" fn sdr_core_set_gain(handle: *mut SdrCore, gain_db: f64) -
 /// Enable or disable tuner AGC.
 ///
 /// Legacy two-state setter preserved for backward-compat with
-/// hosts that don't need the tristate selector. Only touches the
-/// hardware (tuner) AGC; does NOT turn off software AGC. Modern
-/// hosts should use `sdr_core_set_agc_type` which dispatches both
-/// loops atomically according to the requested type. Per issue
-/// #357.
+/// hosts that don't need the tristate selector. Forwards to the
+/// `sdr_core_set_agc_type` semantics so the engine's single-
+/// loop-on policy is preserved: `true` maps to
+/// `SDR_AGC_HARDWARE` (tuner on, software off), `false` maps to
+/// `SDR_AGC_OFF` (both loops off). A pre-0.13 host dropping to
+/// `false` after software AGC had been enabled elsewhere still
+/// gets a true "manual gain, no AGC" state. Per `CodeRabbit`
+/// round 1 on PR #371 and issue #357.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_set_agc(handle: *mut SdrCore, enabled: bool) -> i32 {
-    unsafe { with_core(handle, |core| send(core, UiToDsp::SetAgc(enabled))) }
+    unsafe {
+        with_core(handle, |core| {
+            if enabled {
+                send(core, UiToDsp::SetAgc(true))
+                    .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false)))
+            } else {
+                send(core, UiToDsp::SetAgc(false))
+                    .and_then(|()| send(core, UiToDsp::SetSoftwareAgc(false)))
+            }
+        })
+    }
 }
 
 // --- AGC type selector (#357, ABI 0.13) -------------------
@@ -858,14 +871,18 @@ pub unsafe extern "C" fn sdr_core_set_file_path(
 /// WAV file on EOF and keeps streaming; when `false` the source
 /// stops at EOF.
 ///
-/// Applies both to the running source (effective from the next
-/// EOF onward) and to future source rebuilds — the engine keeps
-/// the latest value on its state so a source-type switch or
-/// file-path change doesn't reset to the constructor default.
+/// The engine always persists the value on `DspState` regardless
+/// of the currently-active source — a later `SDR_SOURCE_FILE`
+/// activation or a source rebuild after a file-path change
+/// picks up the stored value rather than resetting to the
+/// constructor default.
 ///
-/// No-op when the active source isn't `SDR_SOURCE_FILE`; the
-/// trait's default `set_looping` impl silently accepts. Per
-/// issue #236 (ABI 0.13).
+/// When the ACTIVE source is `.file`, the setting is also
+/// applied to the running source (effective from the next EOF
+/// onward). When the active source is anything else the
+/// immediate apply is a no-op (trait default), but the stored
+/// value still takes effect on the next switch to file
+/// playback. Per issue #236 (ABI 0.13).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_core_set_file_looping(handle: *mut SdrCore, looping: bool) -> i32 {
     unsafe { with_core(handle, |core| send(core, UiToDsp::SetFileLooping(looping))) }

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 12;
+pub const ABI_VERSION_MINOR: u32 = 13;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 12);
+        assert!(ABI_VERSION_MINOR == 13);
     };
 
     #[test]

--- a/crates/sdr-pipeline/src/source_manager.rs
+++ b/crates/sdr-pipeline/src/source_manager.rs
@@ -113,6 +113,15 @@ pub trait Source: Send {
     fn set_gain_by_index(&mut self, _index: u32) -> Result<(), SourceError> {
         Ok(())
     }
+
+    /// Toggle loop-on-EOF for the file playback source. `true`
+    /// rewinds to the start of the file at EOF and keeps
+    /// streaming; `false` stops the source at EOF. Only the
+    /// `FileSource` honors this; other sources accept silently.
+    /// Per issue #236.
+    fn set_looping(&mut self, _looping: bool) -> Result<(), SourceError> {
+        Ok(())
+    }
 }
 
 /// Manages available IQ sources and the active source lifecycle.

--- a/crates/sdr-source-file/src/lib.rs
+++ b/crates/sdr-source-file/src/lib.rs
@@ -225,6 +225,15 @@ impl Source for FileSource {
     fn read_samples(&mut self, output: &mut [Complex]) -> Result<usize, SourceError> {
         self.read_samples_impl(output)
     }
+
+    /// Override the trait's no-op default — route through the
+    /// inherent `set_looping` setter (line 71) so the read loop
+    /// honors the new value from the next EOF onward. Per issue
+    /// #236.
+    fn set_looping(&mut self, looping: bool) -> Result<(), SourceError> {
+        self.set_looping(looping);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,7 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 12
+#define SDR_CORE_ABI_VERSION_MINOR 13
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -346,7 +346,42 @@ int32_t sdr_core_set_ppm_correction(SdrCore* handle, int32_t ppm);
 /* --- Tuner gain --------------------------------------------------- */
 
 int32_t sdr_core_set_gain(SdrCore* handle, double gain_db);
+
+/*
+ * Legacy two-state AGC setter (retained for ABI compat). Only
+ * touches the hardware (tuner) AGC; does NOT turn off software
+ * AGC. Modern hosts should use `sdr_core_set_agc_type` below
+ * which dispatches both loops atomically.
+ */
 int32_t sdr_core_set_agc(SdrCore* handle, bool enabled);
+
+/* --- AGC type selector (issue #357, ABI 0.13) -------------- */
+/*
+ * Three-state AGC selector mirroring `UiToDsp::SetAgc` +
+ * `UiToDsp::SetSoftwareAgc` on the engine side. The two loops
+ * are mutually exclusive at the UI policy layer but independent
+ * at the DSP layer, so this FFI dispatches BOTH commands based
+ * on the requested type and leaves the engine in a consistent
+ * single-loop-on state.
+ *
+ * Stable discriminants — never reorder. Add new variants at the
+ * end with a minor ABI bump.
+ */
+typedef enum SdrAgcType {
+    /* Both loops disabled — gain slider controls tuner directly. */
+    SDR_AGC_OFF      = 0,
+    /* Hardware (tuner) AGC on, software IF AGC off. */
+    SDR_AGC_HARDWARE = 1,
+    /* Software IF AGC on, hardware tuner AGC off. Default on
+     * fresh installs — sidesteps tuner AGC's pumping behavior. */
+    SDR_AGC_SOFTWARE = 2,
+} SdrAgcType;
+
+/*
+ * Set the active AGC type. Any value outside `SDR_AGC_*`
+ * returns `SDR_CORE_ERR_INVALID_ARG`.
+ */
+int32_t sdr_core_set_agc_type(SdrCore* handle, int32_t agc_type);
 
 /* --- Demodulation ------------------------------------------------- */
 
@@ -576,6 +611,22 @@ int32_t sdr_core_set_network_config(
  * when the source actually starts.
  */
 int32_t sdr_core_set_file_path(SdrCore* handle, const char* path_utf8);
+
+/*
+ * Toggle loop-on-EOF for the file playback source (issue #236,
+ * ABI 0.13). When `looping` is `true` the source rewinds to the
+ * start of the WAV file on EOF and keeps streaming; when
+ * `false` it stops at EOF.
+ *
+ * Applies both to the running source (effective from the next
+ * EOF onward) and to future source rebuilds — the engine keeps
+ * the latest value on its state so a source-type switch or
+ * file-path change doesn't reset to the constructor default.
+ *
+ * No-op when the active source isn't `SDR_SOURCE_FILE` — the
+ * `Source` trait's default `set_looping` impl silently accepts.
+ */
+int32_t sdr_core_set_file_looping(SdrCore* handle, bool looping);
 
 /* --- rtl_tcp-specific client commands (issue #325, ABI 0.11) --- */
 /*

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -618,13 +618,18 @@ int32_t sdr_core_set_file_path(SdrCore* handle, const char* path_utf8);
  * start of the WAV file on EOF and keeps streaming; when
  * `false` it stops at EOF.
  *
- * Applies both to the running source (effective from the next
- * EOF onward) and to future source rebuilds — the engine keeps
- * the latest value on its state so a source-type switch or
- * file-path change doesn't reset to the constructor default.
+ * The engine always persists the value on its state, regardless
+ * of the currently-active source type — a later
+ * `SDR_SOURCE_FILE` activation (or a source rebuild after a
+ * file-path change) picks up the stored value rather than
+ * resetting to the constructor default.
  *
- * No-op when the active source isn't `SDR_SOURCE_FILE` — the
- * `Source` trait's default `set_looping` impl silently accepts.
+ * When the ACTIVE source is `SDR_SOURCE_FILE`, the setting is
+ * also applied to the running source (effective from the next
+ * EOF onward). When the active source is anything else, the
+ * immediate apply is a no-op — the `Source` trait's default
+ * `set_looping` silently accepts — but the stored value still
+ * takes effect on the next switch to file playback.
  */
 int32_t sdr_core_set_file_looping(SdrCore* handle, bool looping);
 


### PR DESCRIPTION
## Summary

Two macOS-frontend features landing together because they share an ABI minor bump:

- **#357** — Tristate AGC selector (Off / Hardware / Software) replacing the binary Toggle in SourceSection's .rtlSdr arm. Mirrors the Linux GTK shape from PR #359.
- **#236** — Loop-on-EOF toggle for the file playback source. The rest of #236 (fileImporter, setFilePath FFI, source-type plumbing) was already delivered in earlier Mac UI work; this closes the last bullet.

FFI ABI bumped 0.12 → 0.13.

## Commits

1. **FFI + engine** — additive `sdr_core_set_agc_type` + `sdr_core_set_file_looping`, `SdrAgcType` C enum, `UiToDsp::SetFileLooping`, controller handler + `DspState.file_looping`, new `Source::set_looping` trait method (default no-op, overridden in FileSource). 5 new unit tests; fmt/clippy clean.
2. **SdrCoreKit wrappers** — `SdrCore.AgcType` nested enum + `setAgcType(_:)` + `setFileLooping(_:)`. Legacy `setAgc(_: Bool)` docstring updated to nudge callers toward the tristate.
3. **CoreModel migration** — `agcEnabled: Bool` stored → `agcType: SdrCore.AgcType` stored + `agcEnabled: Bool` computed shim. `setAgc(_:)` forwards to `setAgcType(on ? .hardware : .off)` so legacy callers (bookmark recall from pre-#357 JSON) still route cleanly. Bookmark schema gains `agcType: AgcType?` with `agc_type` snake_case key (matches Linux); legacy `agcEnabled: Bool?` retained; `apply(_:)` prefers tristate and falls back to bool. UserDefaults persistence + bootstrap restore.
4. **SourceSection AGC Picker** — segmented picker in the .rtlSdr arm; gain slider's disable reads the unchanged `agcEnabled` shim so either AGC type hides the slider. RTL-TCP's "Tuner AGC" toggle left alone (wire-protocol 0x03 is specifically hardware).
5. **SourceSection file loop** — Toggle "Loop playback" in the .file arm, always visible so users can pre-configure. CoreModel gains `fileLoopingEnabled` + `setFileLooping` + UserDefaults key + bootstrap restore + syncToEngine replay.

## Engine surface audit

The engine already had both DSP loops exposed as separate `UiToDsp` variants (`SetAgc`/`SetSoftwareAgc`) with a UI-policy-level mutual exclusion comment, and FileSource already had `set_looping` with tests — neither feature required engine-level DSP work, just FFI wrapping + Swift binding. Software AGC had not been exposed via FFI at all before this PR.

## Test plan

- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 5 new FFI tests pass
- [x] `xcodebuild test` on both `CoreModelTests` + `CoreModelIntegrationTests` — all 15 pass
- [ ] Launch app → AGC row shows segmented Picker with Software selected by default on fresh install
- [ ] Toggle between Off / Hardware / Software → gain slider disables for anything but Off
- [ ] Save a bookmark with Software AGC → relaunch → bookmark carries `agc_type: "software"` and recalls correctly
- [ ] Pre-#357 bookmark with only `agc: true` → recalls as Hardware (legacy bool path)
- [ ] Pick a short WAV, enable "Loop playback" → file plays continuously
- [ ] Disable "Loop playback" mid-stream → playback stops at next EOF
- [ ] Quit + relaunch → loop toggle reflects last choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AGC control now offers three modes: Off, Hardware, Software, exposed in the UI as a three-way selector.
  * Added a persistent file playback "Loop playback" toggle.

* **Bug Fixes / Compatibility**
  * Bookmarks now store and prefer the new AGC mode while remaining backward-compatible with legacy AGC settings.

* **Tests**
  * Added regression tests for bookmark AGC serialization.

* **Documentation**
  * Clarified legacy two-state AGC behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->