### PR TITLE
feat(#317): scanner ↔ DspController integration + bookmark schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,7 @@ dependencies = [
  "sdr-pipeline",
  "sdr-radio",
  "sdr-rtlsdr",
+ "sdr-scanner",
  "sdr-sink-audio",
  "sdr-sink-network",
  "sdr-source-file",

--- a/crates/sdr-core/Cargo.toml
+++ b/crates/sdr-core/Cargo.toml
@@ -26,6 +26,7 @@ sdr-config.workspace = true
 sdr-dsp.workspace = true
 sdr-pipeline.workspace = true
 sdr-radio.workspace = true
+sdr-scanner.workspace = true
 sdr-rtlsdr.workspace = true
 sdr-source-rtlsdr.workspace = true
 sdr-source-network.workspace = true

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1697,6 +1697,25 @@ fn apply_scanner_commands(
 /// Build the `ScannerActiveChannelChanged` payload by looking
 /// up the full channel info for the given key in the cached
 /// channel list.
+///
+/// If `key` is `Some(k)` but `k` isn't in `scanner_channels`
+/// (a race between `UpdateScannerChannels` and
+/// `ActiveChannelChanged`), we degrade to the idle-shape payload
+/// (`key = None`, zeroed fields) rather than sending a non-None
+/// key with zeroed freq/bandwidth/name — the UI can't tell
+/// those apart from a valid zero-frequency channel, and the
+/// resulting display would be incoherent (key says "active
+/// channel X" but fields say "no channel"). A warning log
+/// surfaces the cache miss so this stays diagnosable if it ever
+/// fires in practice.
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "owned key is passed from ScannerCommand::ActiveChannelChanged \
+              and this helper decides whether it lands in the outgoing DspToUi \
+              payload (cache hit) or gets logged + dropped (cache miss); \
+              taking a reference would force callers to clone unnecessarily \
+              on the common-case hit path"
+)]
 fn emit_scanner_active_channel(
     state: &DspState,
     dsp_tx: &mpsc::Sender<DspToUi>,
@@ -1705,14 +1724,28 @@ fn emit_scanner_active_channel(
     let channel = key
         .as_ref()
         .and_then(|k| state.scanner_channels.iter().find(|c| c.key == *k).cloned());
-    let msg = DspToUi::ScannerActiveChannelChanged {
-        freq_hz: channel.as_ref().map_or(0, |c| c.key.frequency_hz),
-        demod_mode: channel
-            .as_ref()
-            .map_or(sdr_types::DemodMode::Nfm, |c| c.demod_mode),
-        bandwidth: channel.as_ref().map_or(0.0, |c| c.bandwidth),
-        name: channel.map_or_else(String::new, |c| c.key.name),
-        key,
+    if key.is_some() && channel.is_none() {
+        tracing::warn!(
+            ?key,
+            "scanner active-channel key not found in cached ScannerChannels — \
+             degrading to idle payload; likely an UpdateScannerChannels race"
+        );
+    }
+    let msg = match channel {
+        Some(c) => DspToUi::ScannerActiveChannelChanged {
+            freq_hz: c.key.frequency_hz,
+            demod_mode: c.demod_mode,
+            bandwidth: c.bandwidth,
+            name: c.key.name.clone(),
+            key: Some(c.key),
+        },
+        None => DspToUi::ScannerActiveChannelChanged {
+            freq_hz: 0,
+            demod_mode: sdr_types::DemodMode::Nfm,
+            bandwidth: 0.0,
+            name: String::new(),
+            key: None,
+        },
     };
     let _ = dsp_tx.send(msg);
 }

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1727,6 +1727,20 @@ fn apply_scanner_commands(
                     if let Err(e) = state.radio.set_mode(demod_mode) {
                         tracing::warn!(?e, "scanner retune: set_mode failed");
                     } else {
+                        // Generic audio tap: same hard-boundary
+                        // treatment the `UiToDsp::SetDemodMode` path
+                        // applies. Scanner retunes deliberately
+                        // suppress `DemodModeChanged` to the UI
+                        // (per-hop chatter would be noise), which
+                        // means FFI tap consumers never see the
+                        // normal restart signal — so without this
+                        // reset, one audio stream would span mixed
+                        // demod outputs with stale 3:1 decimation
+                        // phase state. Mirrors the treatment at
+                        // L652-657 for the user-driven mode switch.
+                        state.audio_tap_tx = None;
+                        state.audio_tap_phase = 0;
+
                         // Auto-adjust decimation for the new
                         // demod's IF rate.
                         let if_rate = state.radio.demod_config().if_sample_rate;

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -382,6 +382,15 @@ struct DspState {
     /// scanner itself emits only the `ChannelKey` and the UI
     /// payload needs the full freq/demod/bandwidth/name tuple.
     scanner_channels: Vec<sdr_scanner::ScannerChannel>,
+    /// Scanner-driven audio mute flag. Set by
+    /// `ScannerCommand::MuteAudio(true)` during Retuning /
+    /// Dwelling / Hanging phases, cleared on Listening entry.
+    /// When `true`, the audio-sink write path fills `audio_buf`
+    /// with silence in-place so the user hears nothing during
+    /// retune / no-activity windows while the DSP chain still
+    /// runs (squelch edges still fire → scanner state machine
+    /// stays live).
+    scanner_muted: bool,
 }
 
 impl DspState {
@@ -451,6 +460,7 @@ impl DspState {
             rtl_tcp_poll_at: std::time::Instant::now(),
             scanner: sdr_scanner::Scanner::new(),
             scanner_channels: Vec::new(),
+            scanner_muted: false,
         })
     }
 }
@@ -1670,10 +1680,7 @@ fn apply_scanner_commands(
                 }
             }
             sdr_scanner::ScannerCommand::MuteAudio(muted) => {
-                // Sink-side mute plumbing lands in Task 2.6;
-                // for now just record intent via log so Task
-                // 2.6's integration verification can observe.
-                tracing::debug!(?muted, "scanner mute — sink wiring in Task 2.6");
+                state.scanner_muted = muted;
             }
             sdr_scanner::ScannerCommand::ActiveChannelChanged(key) => {
                 emit_scanner_active_channel(state, dsp_tx, key);
@@ -2242,6 +2249,18 @@ fn process_iq_block(
                             let _ = dsp_tx
                                 .send(DspToUi::Error("Audio recording write failed".to_string()));
                             let _ = dsp_tx.send(DspToUi::AudioRecordingStopped);
+                        }
+
+                        // Scanner mute: fill the audio buffer with
+                        // silence in-place when the scanner is in a
+                        // non-Listening phase (Retuning / Dwelling /
+                        // Hanging). The DSP chain still runs — we only
+                        // silence the PCM that reaches the audio device.
+                        // No allocation per block; `slice.fill` overwrites
+                        // existing contents.
+                        if state.scanner_muted {
+                            state.audio_buf[..audio_count]
+                                .fill(sdr_types::Stereo::default());
                         }
 
                         // Send to the audio sink (PipeWire on Linux,

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1666,8 +1666,7 @@ fn apply_scanner_commands(
                 // CTCSS is per-channel: force-Off when the new
                 // channel doesn't carry a tone, otherwise stale
                 // tone gates would silence the new channel.
-                let ctcss_mode = ctcss
-                    .unwrap_or(sdr_radio::af_chain::CtcssMode::Off);
+                let ctcss_mode = ctcss.unwrap_or(sdr_radio::af_chain::CtcssMode::Off);
                 if let Err(e) = state.radio.set_ctcss_mode(ctcss_mode) {
                     tracing::warn!(?e, "scanner retune: set_ctcss_mode failed");
                 }
@@ -1703,13 +1702,9 @@ fn emit_scanner_active_channel(
     dsp_tx: &mpsc::Sender<DspToUi>,
     key: Option<sdr_scanner::ChannelKey>,
 ) {
-    let channel = key.as_ref().and_then(|k| {
-        state
-            .scanner_channels
-            .iter()
-            .find(|c| c.key == *k)
-            .cloned()
-    });
+    let channel = key
+        .as_ref()
+        .and_then(|k| state.scanner_channels.iter().find(|c| c.key == *k).cloned());
     let msg = DspToUi::ScannerActiveChannelChanged {
         freq_hz: channel.as_ref().map_or(0, |c| c.key.frequency_hz),
         demod_mode: channel
@@ -2083,9 +2078,9 @@ fn process_iq_block(
                             } else {
                                 sdr_scanner::SquelchState::Closed
                             };
-                            let scan_cmds = state.scanner.handle_event(
-                                sdr_scanner::ScannerEvent::SquelchEdge(scanner_edge),
-                            );
+                            let scan_cmds = state
+                                .scanner
+                                .handle_event(sdr_scanner::ScannerEvent::SquelchEdge(scanner_edge));
                             apply_scanner_commands(state, dsp_tx, scan_cmds);
                         }
 
@@ -2259,8 +2254,7 @@ fn process_iq_block(
                         // No allocation per block; `slice.fill` overwrites
                         // existing contents.
                         if state.scanner_muted {
-                            state.audio_buf[..audio_count]
-                                .fill(sdr_types::Stereo::default());
+                            state.audio_buf[..audio_count].fill(sdr_types::Stereo::default());
                         }
 
                         // Send to the audio sink (PipeWire on Linux,
@@ -2334,12 +2328,12 @@ fn process_iq_block(
             let sample_rate_hz = std::num::NonZeroU32::new(state.sample_rate as u32)
                 .expect("source sample rate must be > 0");
             #[allow(clippy::cast_possible_truncation)]
-            let tick_cmds = state.scanner.handle_event(
-                sdr_scanner::ScannerEvent::SampleTick {
+            let tick_cmds = state
+                .scanner
+                .handle_event(sdr_scanner::ScannerEvent::SampleTick {
                     samples_consumed: iq_count as u32,
                     sample_rate_hz,
-                },
-            );
+                });
             apply_scanner_commands(state, dsp_tx, tick_cmds);
         }
         Err(e) => {

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -370,6 +370,18 @@ struct DspState {
     /// UI cadence doesn't need sub-second resolution to render the
     /// "Connecting… / Connected / Retrying in N s" text.
     rtl_tcp_poll_at: std::time::Instant,
+
+    /// Scanner state machine. Fed sample ticks + squelch edges
+    /// from the IQ loop + UI command events from `handle_command`.
+    /// Emitted commands are applied inline via
+    /// `apply_scanner_commands`.
+    scanner: sdr_scanner::Scanner,
+    /// Cache of the last-pushed `ScannerChannel` list — read by
+    /// `emit_scanner_active_channel` when building the
+    /// `DspToUi::ScannerActiveChannelChanged` payload, since the
+    /// scanner itself emits only the `ChannelKey` and the UI
+    /// payload needs the full freq/demod/bandwidth/name tuple.
+    scanner_channels: Vec<sdr_scanner::ScannerChannel>,
 }
 
 impl DspState {
@@ -437,6 +449,8 @@ impl DspState {
             diag_log_at: std::time::Instant::now(),
             last_rtl_tcp_state: RtlTcpConnectionState::Disconnected,
             rtl_tcp_poll_at: std::time::Instant::now(),
+            scanner: sdr_scanner::Scanner::new(),
+            scanner_channels: Vec::new(),
         })
     }
 }
@@ -1502,20 +1516,122 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 }
             }
         }
-        // --- Scanner (#317) — handlers wired in Task 2.4 ---
-        UiToDsp::SetScannerEnabled(_enabled) => {
-            tracing::debug!("SetScannerEnabled: handler not yet wired (Task 2.4)");
+        // --- Scanner (#317) ---
+        UiToDsp::SetScannerEnabled(enabled) => {
+            let cmds = state
+                .scanner
+                .handle_event(sdr_scanner::ScannerEvent::SetEnabled(enabled));
+            apply_scanner_commands(state, dsp_tx, cmds);
         }
-        UiToDsp::UpdateScannerChannels(_channels) => {
-            tracing::debug!("UpdateScannerChannels: handler not yet wired (Task 2.4)");
+        UiToDsp::UpdateScannerChannels(channels) => {
+            state.scanner_channels.clone_from(&channels);
+            let cmds = state
+                .scanner
+                .handle_event(sdr_scanner::ScannerEvent::ChannelsChanged(channels));
+            apply_scanner_commands(state, dsp_tx, cmds);
         }
-        UiToDsp::LockoutScannerChannel(_key) => {
-            tracing::debug!("LockoutScannerChannel: handler not yet wired (Task 2.4)");
+        UiToDsp::LockoutScannerChannel(key) => {
+            let cmds = state
+                .scanner
+                .handle_event(sdr_scanner::ScannerEvent::LockoutChannel(key));
+            apply_scanner_commands(state, dsp_tx, cmds);
         }
-        UiToDsp::UnlockScannerChannel(_key) => {
-            tracing::debug!("UnlockScannerChannel: handler not yet wired (Task 2.4)");
+        UiToDsp::UnlockScannerChannel(key) => {
+            let cmds = state
+                .scanner
+                .handle_event(sdr_scanner::ScannerEvent::UnlockChannel(key));
+            apply_scanner_commands(state, dsp_tx, cmds);
         }
     }
+}
+
+/// Apply scanner-emitted commands to the DSP state.
+fn apply_scanner_commands(
+    state: &mut DspState,
+    dsp_tx: &mpsc::Sender<DspToUi>,
+    commands: Vec<sdr_scanner::ScannerCommand>,
+) {
+    for cmd in commands {
+        match cmd {
+            sdr_scanner::ScannerCommand::Retune {
+                freq_hz,
+                demod_mode,
+                bandwidth,
+                ctcss,
+                voice_squelch,
+            } => {
+                // Apply to source + radio module directly. Same
+                // path as the manual `Tune` / `SetBandwidth` /
+                // `SetDemodMode` handlers above.
+                if let Some(source) = state.source.as_mut() {
+                    #[allow(clippy::cast_precision_loss)]
+                    let freq_f64 = freq_hz as f64;
+                    let _ = source.tune(freq_f64);
+                }
+                if let Err(e) = state.radio.set_mode(demod_mode) {
+                    tracing::warn!(?e, "scanner retune: set_mode failed");
+                }
+                state.radio.set_bandwidth(bandwidth);
+                // CTCSS is per-channel: force-Off when the new
+                // channel doesn't carry a tone, otherwise stale
+                // tone gates would silence the new channel.
+                let ctcss_mode = ctcss
+                    .unwrap_or(sdr_radio::af_chain::CtcssMode::Off);
+                if let Err(e) = state.radio.set_ctcss_mode(ctcss_mode) {
+                    tracing::warn!(?e, "scanner retune: set_ctcss_mode failed");
+                }
+                // Voice squelch is device-level — preserve
+                // current setting when `None`.
+                if let Some(m) = voice_squelch
+                    && let Err(e) = state.radio.set_voice_squelch_mode(m)
+                {
+                    tracing::warn!(?e, "scanner retune: set_voice_squelch_mode failed");
+                }
+            }
+            sdr_scanner::ScannerCommand::MuteAudio(muted) => {
+                // Sink-side mute plumbing lands in Task 2.6;
+                // for now just record intent via log so Task
+                // 2.6's integration verification can observe.
+                tracing::debug!(?muted, "scanner mute — sink wiring in Task 2.6");
+            }
+            sdr_scanner::ScannerCommand::ActiveChannelChanged(key) => {
+                emit_scanner_active_channel(state, dsp_tx, key);
+            }
+            sdr_scanner::ScannerCommand::StateChanged(scanner_state) => {
+                let _ = dsp_tx.send(DspToUi::ScannerStateChanged(scanner_state));
+            }
+            sdr_scanner::ScannerCommand::EmptyRotation => {
+                let _ = dsp_tx.send(DspToUi::ScannerEmptyRotation);
+            }
+        }
+    }
+}
+
+/// Build the `ScannerActiveChannelChanged` payload by looking
+/// up the full channel info for the given key in the cached
+/// channel list.
+fn emit_scanner_active_channel(
+    state: &DspState,
+    dsp_tx: &mpsc::Sender<DspToUi>,
+    key: Option<sdr_scanner::ChannelKey>,
+) {
+    let channel = key.as_ref().and_then(|k| {
+        state
+            .scanner_channels
+            .iter()
+            .find(|c| c.key == *k)
+            .cloned()
+    });
+    let msg = DspToUi::ScannerActiveChannelChanged {
+        freq_hz: channel.as_ref().map_or(0, |c| c.key.frequency_hz),
+        demod_mode: channel
+            .as_ref()
+            .map_or(sdr_types::DemodMode::Nfm, |c| c.demod_mode),
+        bandwidth: channel.as_ref().map_or(0.0, |c| c.bandwidth),
+        name: channel.map_or_else(String::new, |c| c.key.name),
+        key,
+    };
+    let _ = dsp_tx.send(msg);
 }
 
 /// Open the active IQ source and configure it for streaming.
@@ -1866,6 +1982,25 @@ fn process_iq_block(
                             state.voice_squelch_was_open = now_voice;
                         }
 
+                        // Feed the scanner the squelch edge regardless of demod
+                        // mode — the scanner's rotation state transitions
+                        // (Dwelling→Listening, Listening→Hanging) apply to any
+                        // mode. This runs outside the transcription gate below so
+                        // the scanner sees every transition even when the
+                        // transcription tap is inactive.
+                        let now_open = state.radio.if_chain().squelch_open();
+                        if now_open != state.squelch_was_open {
+                            let scanner_edge = if now_open {
+                                sdr_scanner::SquelchState::Open
+                            } else {
+                                sdr_scanner::SquelchState::Closed
+                            };
+                            let scan_cmds = state.scanner.handle_event(
+                                sdr_scanner::ScannerEvent::SquelchEdge(scanner_edge),
+                            );
+                            apply_scanner_commands(state, dsp_tx, scan_cmds);
+                        }
+
                         // Send audio copy to transcription worker BEFORE volume
                         // scaling so recognition isn't affected by the volume knob. Also
                         // emit squelch edge events on open/close transitions so offline
@@ -1873,7 +2008,6 @@ fn process_iq_block(
                         // boundaries. Edge events are NFM-only — WFM and other modes
                         // don't have meaningful squelch transitions for speech.
                         if let Some(ref tx) = state.transcription_tx {
-                            let now_open = state.radio.if_chain().squelch_open();
                             let mut send_error = false;
                             // True unless we tried to send an edge event and hit
                             // `TrySendError::Full`. Squelch edges are one-shot
@@ -1937,6 +2071,11 @@ fn process_iq_block(
                                     "transcription receiver disconnected, disabling tap"
                                 );
                             }
+                        } else {
+                            // No transcription tap: advance the tracker
+                            // unconditionally so the scanner doesn't see
+                            // the same edge repeatedly on every block.
+                            state.squelch_was_open = now_open;
                         }
 
                         // Generic audio tap: downsample to 16 kHz mono
@@ -2083,6 +2222,25 @@ fn process_iq_block(
                     }
                 }
             } // end if processed_count > 0
+
+            // Feed the sample tick into the scanner. Scanner uses this to
+            // drive settle/dwell/hang countdowns — decoupled from radio
+            // output. `NonZeroU32` is enforced at the event type level;
+            // expect here is OK because any live source has a non-zero
+            // rate (source.sample_rate() always > 0 in practice).
+            // Uses `iq_count` (source-rate samples) paired with
+            // `state.sample_rate` so the ms→sample math is consistent.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let sample_rate_hz = std::num::NonZeroU32::new(state.sample_rate as u32)
+                .expect("source sample rate must be > 0");
+            #[allow(clippy::cast_possible_truncation)]
+            let tick_cmds = state.scanner.handle_event(
+                sdr_scanner::ScannerEvent::SampleTick {
+                    samples_consumed: iq_count as u32,
+                    sample_rate_hz,
+                },
+            );
+            apply_scanner_commands(state, dsp_tx, tick_cmds);
         }
         Err(e) => {
             tracing::warn!("frontend processing error: {e}");

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1502,6 +1502,19 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 }
             }
         }
+        // --- Scanner (#317) — handlers wired in Task 2.4 ---
+        UiToDsp::SetScannerEnabled(_enabled) => {
+            tracing::debug!("SetScannerEnabled: handler not yet wired (Task 2.4)");
+        }
+        UiToDsp::UpdateScannerChannels(_channels) => {
+            tracing::debug!("UpdateScannerChannels: handler not yet wired (Task 2.4)");
+        }
+        UiToDsp::LockoutScannerChannel(_key) => {
+            tracing::debug!("LockoutScannerChannel: handler not yet wired (Task 2.4)");
+        }
+        UiToDsp::UnlockScannerChannel(_key) => {
+            tracing::debug!("UnlockScannerChannel: handler not yet wired (Task 2.4)");
+        }
     }
 }
 

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1400,7 +1400,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         UiToDsp::StartAudioRecording(path) => {
             // If scanner is active, stop it first — scanner and
             // per-hit recording are mutually exclusive in Phase 1.
-            if state.scanner.state() != sdr_scanner::ScannerState::Idle {
+            if state.scanner.is_enabled() {
                 let cmds = state
                     .scanner
                     .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
@@ -1432,7 +1432,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         UiToDsp::StartIqRecording(path) => {
             // If scanner is active, stop it first — scanner and
             // per-hit recording are mutually exclusive in Phase 1.
-            if state.scanner.state() != sdr_scanner::ScannerState::Idle {
+            if state.scanner.is_enabled() {
                 let cmds = state
                     .scanner
                     .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
@@ -1463,7 +1463,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::EnableTranscription(tx) => {
-            if state.scanner.state() != sdr_scanner::ScannerState::Idle {
+            if state.scanner.is_enabled() {
                 let cmds = state
                     .scanner
                     .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
@@ -1651,27 +1651,96 @@ fn apply_scanner_commands(
                 ctcss,
                 voice_squelch,
             } => {
-                // Apply to source + radio module directly. Same
-                // path as the manual `Tune` / `SetBandwidth` /
-                // `SetDemodMode` handlers above.
-                if let Some(source) = state.source.as_mut() {
-                    #[allow(clippy::cast_precision_loss)]
-                    let freq_f64 = freq_hz as f64;
-                    let _ = source.tune(freq_f64);
+                // Mirror the manual `Tune` / `SetDemodMode` /
+                // `SetBandwidth` handlers so scanner hops end up
+                // with the same persisted state + VFO rebuild
+                // behavior. Omissions would leave `state.center_freq`
+                // / `state.bandwidth` / the RxVfo config stale —
+                // a subsequent `open_source()` restart would tune
+                // back to whatever the user manually picked before
+                // scanner started, and the IF filter width could
+                // stay locked to the previous channel's mode.
+                //
+                // Deliberately NOT emitting the corresponding
+                // `DspToUi::SampleRateChanged` / `DisplayBandwidth`
+                // / `DemodModeChanged` / `BandwidthChanged` events
+                // the manual handlers send — those are UI-sync
+                // signals for user-initiated changes. Scanner
+                // retunes carry their own `ScannerActiveChannelChanged`
+                // payload with freq/mode/bandwidth/name that the
+                // UI handler fans out to the same widgets; emitting
+                // both paths would double-drive the sync.
+
+                // 1. Center frequency (mirrors `UiToDsp::Tune`).
+                #[allow(clippy::cast_precision_loss)]
+                let freq_f64 = freq_hz as f64;
+                state.center_freq = freq_f64;
+                if let Some(source) = state.source.as_mut()
+                    && let Err(e) = source.tune(freq_f64)
+                {
+                    tracing::warn!(?e, "scanner retune: source.tune failed");
                 }
-                if let Err(e) = state.radio.set_mode(demod_mode) {
-                    tracing::warn!(?e, "scanner retune: set_mode failed");
+
+                // 2. Demod mode + VFO rebuild on change (mirrors
+                // `UiToDsp::SetDemodMode`). The scanner doesn't
+                // emit retune commands redundantly — each Retune
+                // marks a new channel — but the target mode may
+                // equal the current mode (rotation pass on same-
+                // mode channels), so guard to avoid gratuitous
+                // rebuilds.
+                let old_mode = state.radio.current_mode();
+                if old_mode != demod_mode {
+                    if let Err(e) = state.radio.set_mode(demod_mode) {
+                        tracing::warn!(?e, "scanner retune: set_mode failed");
+                    } else {
+                        // Auto-adjust decimation for the new
+                        // demod's IF rate.
+                        let if_rate = state.radio.demod_config().if_sample_rate;
+                        let auto_decim = auto_decimation_ratio(state.sample_rate, if_rate);
+                        if auto_decim != state.frontend.decim_ratio()
+                            && let Err(e) = state.frontend.set_decimation(auto_decim)
+                        {
+                            tracing::warn!(?e, "scanner retune: auto-decimation failed");
+                        }
+                        // Rebuild the VFO for the new demod's IF
+                        // rate + bandwidth. Bandwidth is set
+                        // below; rebuild picks it up via
+                        // `state.bandwidth`.
+                        state.bandwidth = bandwidth;
+                        if let Err(e) = rebuild_vfo(state) {
+                            tracing::warn!(?e, "scanner retune: VFO rebuild failed");
+                        }
+                    }
+                }
+
+                // 3. Bandwidth (mirrors `UiToDsp::SetBandwidth`).
+                // Applied to the VFO channel filter first; only
+                // persist on success. For same-mode retunes the
+                // VFO already exists; for mode-change retunes the
+                // rebuild above already used `state.bandwidth`
+                // so the two paths converge.
+                if let Some(vfo) = &mut state.vfo {
+                    match vfo.set_bandwidth(bandwidth) {
+                        Ok(()) => state.bandwidth = bandwidth,
+                        Err(e) => {
+                            tracing::warn!(?e, "scanner retune: VFO bandwidth update failed");
+                        }
+                    }
+                } else {
+                    state.bandwidth = bandwidth;
                 }
                 state.radio.set_bandwidth(bandwidth);
-                // CTCSS is per-channel: force-Off when the new
-                // channel doesn't carry a tone, otherwise stale
-                // tone gates would silence the new channel.
+
+                // 4. CTCSS is per-channel: force-Off when the new
+                // channel doesn't carry a tone, otherwise a stale
+                // tone gate would silence the new channel.
                 let ctcss_mode = ctcss.unwrap_or(sdr_radio::af_chain::CtcssMode::Off);
                 if let Err(e) = state.radio.set_ctcss_mode(ctcss_mode) {
                     tracing::warn!(?e, "scanner retune: set_ctcss_mode failed");
                 }
-                // Voice squelch is device-level — preserve
-                // current setting when `None`.
+                // 5. Voice squelch is device-level — preserve
+                // current setting when the channel doesn't
+                // override it.
                 if let Some(m) = voice_squelch
                     && let Err(e) = state.radio.set_voice_squelch_mode(m)
                 {
@@ -2352,22 +2421,29 @@ fn process_iq_block(
 
             // Feed the sample tick into the scanner. Scanner uses this to
             // drive settle/dwell/hang countdowns — decoupled from radio
-            // output. `NonZeroU32` is enforced at the event type level;
-            // expect here is OK because any live source has a non-zero
-            // rate (source.sample_rate() always > 0 in practice).
-            // Uses `iq_count` (source-rate samples) paired with
-            // `state.sample_rate` so the ms→sample math is consistent.
+            // output. `NonZeroU32` enforces the rate invariant at the
+            // event type level; if `state.sample_rate` ever truncates
+            // to 0 we skip the tick and warn rather than panicking the
+            // DSP thread. Any live source has a non-zero rate; this is
+            // defense against future state-init bugs, not a hot-path
+            // concern.
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            let sample_rate_hz = std::num::NonZeroU32::new(state.sample_rate as u32)
-                .expect("source sample rate must be > 0");
-            #[allow(clippy::cast_possible_truncation)]
-            let tick_cmds = state
-                .scanner
-                .handle_event(sdr_scanner::ScannerEvent::SampleTick {
-                    samples_consumed: iq_count as u32,
-                    sample_rate_hz,
-                });
-            apply_scanner_commands(state, dsp_tx, tick_cmds);
+            let sample_rate_u32 = state.sample_rate as u32;
+            if let Some(sample_rate_hz) = std::num::NonZeroU32::new(sample_rate_u32) {
+                #[allow(clippy::cast_possible_truncation)]
+                let tick_cmds = state
+                    .scanner
+                    .handle_event(sdr_scanner::ScannerEvent::SampleTick {
+                        samples_consumed: iq_count as u32,
+                        sample_rate_hz,
+                    });
+                apply_scanner_commands(state, dsp_tx, tick_cmds);
+            } else {
+                tracing::warn!(
+                    sample_rate = state.sample_rate,
+                    "scanner sample tick skipped: source sample rate is 0 after u32 cast"
+                );
+            }
         }
         Err(e) => {
             tracing::warn!("frontend processing error: {e}");

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1407,8 +1407,8 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             match WavWriter::new(&path, AUDIO_SAMPLE_RATE, AUDIO_CHANNELS) {
                 Ok(writer) => {
                     // Recording committed — now apply the mutex.
-                    // Scanner and per-hit recording are mutually
-                    // exclusive in Phase 1.
+                    // Scanner, per-hit recording, and transcription
+                    // are mutually exclusive in Phase 1.
                     if state.scanner.is_enabled() {
                         let cmds = state
                             .scanner
@@ -1418,6 +1418,13 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                             ScannerMutexReason::ScannerStoppedForRecording,
                         ));
                     }
+                    // Recording ↔ transcription leg: stop any active
+                    // transcription tap so the two don't run concurrently.
+                    // `stop_transcription` is silent (no DspToUi event) —
+                    // the transcription lifecycle has no feedback channel
+                    // today, matching the existing DisableTranscription
+                    // path. UI-switch resync is a known follow-up.
+                    stop_transcription(state);
                     state.audio_writer = Some(writer);
                     let _ = dsp_tx.send(DspToUi::AudioRecordingStarted(path));
                 }
@@ -1452,6 +1459,9 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                             ScannerMutexReason::ScannerStoppedForRecording,
                         ));
                     }
+                    // Recording ↔ transcription mutex — see
+                    // StartAudioRecording for rationale.
+                    stop_transcription(state);
                     state.iq_writer = Some(writer);
                     let _ = dsp_tx.send(DspToUi::IqRecordingStarted(path));
                 }
@@ -1478,6 +1488,11 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                     ScannerMutexReason::ScannerStoppedForTranscription,
                 ));
             }
+            // Recording ↔ transcription leg of the mutex. Both
+            // `stop_any_recording` sends cover the UI (it emits
+            // `AudioRecordingStopped` / `IqRecordingStopped`), so
+            // the recording buttons flip off automatically.
+            stop_any_recording(state, dsp_tx);
             // Reset the squelch edge tracker when a new tap is wired up.
             // Without this, a previous session that ended with squelch open
             // leaves `squelch_was_open == true`, so the first chunk of the

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1398,20 +1398,26 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::StartAudioRecording(path) => {
-            // If scanner is active, stop it first — scanner and
-            // per-hit recording are mutually exclusive in Phase 1.
-            if state.scanner.is_enabled() {
-                let cmds = state
-                    .scanner
-                    .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
-                apply_scanner_commands(state, dsp_tx, cmds);
-                let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
-                    ScannerMutexReason::ScannerStoppedForRecording,
-                ));
-            }
             tracing::info!(?path, "start audio recording");
+            // Open the writer FIRST. If it fails we want to leave
+            // the scanner untouched — sending `ScannerMutexStopped`
+            // before knowing the recording actually started would
+            // visibly kill the scanner in the UI and misleadingly
+            // tell the user recording started.
             match WavWriter::new(&path, AUDIO_SAMPLE_RATE, AUDIO_CHANNELS) {
                 Ok(writer) => {
+                    // Recording committed — now apply the mutex.
+                    // Scanner and per-hit recording are mutually
+                    // exclusive in Phase 1.
+                    if state.scanner.is_enabled() {
+                        let cmds = state
+                            .scanner
+                            .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
+                        apply_scanner_commands(state, dsp_tx, cmds);
+                        let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
+                            ScannerMutexReason::ScannerStoppedForRecording,
+                        ));
+                    }
                     state.audio_writer = Some(writer);
                     let _ = dsp_tx.send(DspToUi::AudioRecordingStarted(path));
                 }
@@ -1430,22 +1436,22 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::StartIqRecording(path) => {
-            // If scanner is active, stop it first — scanner and
-            // per-hit recording are mutually exclusive in Phase 1.
-            if state.scanner.is_enabled() {
-                let cmds = state
-                    .scanner
-                    .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
-                apply_scanner_commands(state, dsp_tx, cmds);
-                let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
-                    ScannerMutexReason::ScannerStoppedForRecording,
-                ));
-            }
             tracing::info!(?path, "start IQ recording");
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let iq_rate = state.sample_rate as u32;
+            // Open-first, apply-mutex-on-success — same rationale
+            // as `StartAudioRecording` above.
             match WavWriter::new(&path, iq_rate, IQ_CHANNELS) {
                 Ok(writer) => {
+                    if state.scanner.is_enabled() {
+                        let cmds = state
+                            .scanner
+                            .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
+                        apply_scanner_commands(state, dsp_tx, cmds);
+                        let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
+                            ScannerMutexReason::ScannerStoppedForRecording,
+                        ));
+                    }
                     state.iq_writer = Some(writer);
                     let _ = dsp_tx.send(DspToUi::IqRecordingStarted(path));
                 }
@@ -1670,6 +1676,19 @@ fn apply_scanner_commands(
                 // payload with freq/mode/bandwidth/name that the
                 // UI handler fans out to the same widgets; emitting
                 // both paths would double-drive the sync.
+
+                // Re-arm the controller's squelch-edge tracker for
+                // the new channel. Without this, if the previous
+                // channel ended open and the new channel is also
+                // open during settle, the `now_open != squelch_was_open`
+                // comparison in the IQ loop would suppress the
+                // fresh `SquelchEdge::Open` — scanner's latch
+                // would stay `false`, settle expiry would go to
+                // `Dwelling` instead of directly to `Listening`,
+                // and the `persistent_open_during_settle_goes_directly_to_listening`
+                // invariant the scanner crate tests would break
+                // at integration.
+                state.squelch_was_open = false;
 
                 // 1. Center frequency (mirrors `UiToDsp::Tune`).
                 #[allow(clippy::cast_precision_loss)]

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -35,7 +35,7 @@ use sdr_source_rtlsdr::RtlSdrSource;
 use sdr_types::{Complex, RtlTcpConnectionState, SinkError, Stereo};
 
 use crate::fft_buffer::SharedFftBuffer;
-use crate::messages::{DspToUi, SourceType, UiToDsp};
+use crate::messages::{DspToUi, ScannerMutexReason, SourceType, UiToDsp};
 use crate::wav_writer::WavWriter;
 
 /// Number of IQ sample pairs per USB bulk read.
@@ -1388,6 +1388,17 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::StartAudioRecording(path) => {
+            // If scanner is active, stop it first — scanner and
+            // per-hit recording are mutually exclusive in Phase 1.
+            if state.scanner.state() != sdr_scanner::ScannerState::Idle {
+                let cmds = state
+                    .scanner
+                    .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
+                apply_scanner_commands(state, dsp_tx, cmds);
+                let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
+                    ScannerMutexReason::ScannerStoppedForRecording,
+                ));
+            }
             tracing::info!(?path, "start audio recording");
             match WavWriter::new(&path, AUDIO_SAMPLE_RATE, AUDIO_CHANNELS) {
                 Ok(writer) => {
@@ -1409,6 +1420,17 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::StartIqRecording(path) => {
+            // If scanner is active, stop it first — scanner and
+            // per-hit recording are mutually exclusive in Phase 1.
+            if state.scanner.state() != sdr_scanner::ScannerState::Idle {
+                let cmds = state
+                    .scanner
+                    .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
+                apply_scanner_commands(state, dsp_tx, cmds);
+                let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
+                    ScannerMutexReason::ScannerStoppedForRecording,
+                ));
+            }
             tracing::info!(?path, "start IQ recording");
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let iq_rate = state.sample_rate as u32;
@@ -1431,6 +1453,15 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::EnableTranscription(tx) => {
+            if state.scanner.state() != sdr_scanner::ScannerState::Idle {
+                let cmds = state
+                    .scanner
+                    .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
+                apply_scanner_commands(state, dsp_tx, cmds);
+                let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
+                    ScannerMutexReason::ScannerStoppedForTranscription,
+                ));
+            }
             // Reset the squelch edge tracker when a new tap is wired up.
             // Without this, a previous session that ended with squelch open
             // leaves `squelch_was_open == true`, so the first chunk of the
@@ -1518,6 +1549,18 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
         // --- Scanner (#317) ---
         UiToDsp::SetScannerEnabled(enabled) => {
+            if enabled {
+                if stop_any_recording(state, dsp_tx) {
+                    let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
+                        ScannerMutexReason::RecordingStoppedForScanner,
+                    ));
+                }
+                if stop_transcription(state) {
+                    let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
+                        ScannerMutexReason::TranscriptionStoppedForScanner,
+                    ));
+                }
+            }
             let cmds = state
                 .scanner
                 .handle_event(sdr_scanner::ScannerEvent::SetEnabled(enabled));
@@ -1542,6 +1585,44 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 .handle_event(sdr_scanner::ScannerEvent::UnlockChannel(key));
             apply_scanner_commands(state, dsp_tx, cmds);
         }
+    }
+}
+
+/// Is audio or IQ recording currently active?
+///
+/// Used by future scanner tasks; suppress the unused-function lint
+/// so it survives until the first call site arrives.
+#[allow(dead_code)]
+fn recording_active(state: &DspState) -> bool {
+    state.audio_writer.is_some() || state.iq_writer.is_some()
+}
+
+/// Stop any active recording. Returns `true` if anything was
+/// actually stopped (caller emits a mutex-stopped event only in
+/// that case, avoiding spurious toasts when scanner enables
+/// with nothing to stop).
+fn stop_any_recording(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) -> bool {
+    let mut stopped = false;
+    if state.audio_writer.take().is_some() {
+        let _ = dsp_tx.send(DspToUi::AudioRecordingStopped);
+        stopped = true;
+    }
+    if state.iq_writer.take().is_some() {
+        let _ = dsp_tx.send(DspToUi::IqRecordingStopped);
+        stopped = true;
+    }
+    stopped
+}
+
+/// Stop the transcription tap. Returns `true` if it was active.
+fn stop_transcription(state: &mut DspState) -> bool {
+    if state.transcription_tx.take().is_some() {
+        // Mirror the reset from the explicit DisableTranscription
+        // handler — next EnableTranscription starts fresh.
+        state.squelch_was_open = false;
+        true
+    } else {
+        false
     }
 }
 

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -787,4 +787,110 @@ mod tests {
         let msg = UiToDsp::SetSourceType(SourceType::RtlTcp);
         assert!(matches!(msg, UiToDsp::SetSourceType(SourceType::RtlTcp)));
     }
+
+    #[test]
+    fn test_scanner_dsp_to_ui_variants() {
+        // Shape regression for the four scanner events added in
+        // PR 2 of #317. Catches silent payload changes — if a
+        // field gets renamed or the tuple arity changes, the
+        // pattern match here fails at compile or runtime.
+        let key = sdr_scanner::ChannelKey {
+            name: "Test".to_string(),
+            frequency_hz: 162_550_000,
+        };
+        let active = DspToUi::ScannerActiveChannelChanged {
+            key: Some(key.clone()),
+            freq_hz: 162_550_000,
+            demod_mode: sdr_types::DemodMode::Nfm,
+            bandwidth: TEST_BANDWIDTH_HZ,
+            name: "Test".to_string(),
+        };
+        assert!(matches!(
+            active,
+            DspToUi::ScannerActiveChannelChanged {
+                key: Some(_),
+                freq_hz: 162_550_000,
+                demod_mode: sdr_types::DemodMode::Nfm,
+                ..
+            }
+        ));
+
+        let idle = DspToUi::ScannerActiveChannelChanged {
+            key: None,
+            freq_hz: 0,
+            demod_mode: sdr_types::DemodMode::Nfm,
+            bandwidth: 0.0,
+            name: String::new(),
+        };
+        assert!(matches!(
+            idle,
+            DspToUi::ScannerActiveChannelChanged { key: None, .. }
+        ));
+
+        let state_changed = DspToUi::ScannerStateChanged(sdr_scanner::ScannerState::Listening);
+        assert!(matches!(
+            state_changed,
+            DspToUi::ScannerStateChanged(sdr_scanner::ScannerState::Listening)
+        ));
+
+        let empty = DspToUi::ScannerEmptyRotation;
+        assert!(matches!(empty, DspToUi::ScannerEmptyRotation));
+
+        // Pin each mutex-reason variant — the UI toast text is
+        // selected by matching these, so a silent rename would
+        // misroute toasts rather than fail compilation.
+        let mutex_rec =
+            DspToUi::ScannerMutexStopped(ScannerMutexReason::RecordingStoppedForScanner);
+        assert!(matches!(
+            mutex_rec,
+            DspToUi::ScannerMutexStopped(ScannerMutexReason::RecordingStoppedForScanner)
+        ));
+        let mutex_trans =
+            DspToUi::ScannerMutexStopped(ScannerMutexReason::TranscriptionStoppedForScanner);
+        assert!(matches!(
+            mutex_trans,
+            DspToUi::ScannerMutexStopped(ScannerMutexReason::TranscriptionStoppedForScanner)
+        ));
+        let mutex_scan_rec =
+            DspToUi::ScannerMutexStopped(ScannerMutexReason::ScannerStoppedForRecording);
+        assert!(matches!(
+            mutex_scan_rec,
+            DspToUi::ScannerMutexStopped(ScannerMutexReason::ScannerStoppedForRecording)
+        ));
+        let mutex_scan_trans =
+            DspToUi::ScannerMutexStopped(ScannerMutexReason::ScannerStoppedForTranscription);
+        assert!(matches!(
+            mutex_scan_trans,
+            DspToUi::ScannerMutexStopped(ScannerMutexReason::ScannerStoppedForTranscription)
+        ));
+    }
+
+    #[test]
+    fn test_scanner_ui_to_dsp_variants() {
+        // Shape regression for the four scanner commands the UI
+        // dispatches. Same rationale as the DspToUi test above —
+        // enum-shape drift fails here first.
+        let key = sdr_scanner::ChannelKey {
+            name: "Test".to_string(),
+            frequency_hz: 146_520_000,
+        };
+
+        let enable = UiToDsp::SetScannerEnabled(true);
+        assert!(matches!(enable, UiToDsp::SetScannerEnabled(true)));
+
+        let disable = UiToDsp::SetScannerEnabled(false);
+        assert!(matches!(disable, UiToDsp::SetScannerEnabled(false)));
+
+        let update = UiToDsp::UpdateScannerChannels(Vec::new());
+        assert!(matches!(
+            update,
+            UiToDsp::UpdateScannerChannels(ref v) if v.is_empty()
+        ));
+
+        let lockout = UiToDsp::LockoutScannerChannel(key.clone());
+        assert!(matches!(lockout, UiToDsp::LockoutScannerChannel(_)));
+
+        let unlock = UiToDsp::UnlockScannerChannel(key);
+        assert!(matches!(unlock, UiToDsp::UnlockScannerChannel(_)));
+    }
 }

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -6,6 +6,21 @@ use sdr_types::{DemodMode, Protocol, RtlTcpConnectionState};
 
 use crate::sink_slot::{AudioSinkType, NetworkSinkStatus};
 
+/// Why the scanner↔recording/transcription mutex fired.
+/// Surfaced to the UI via `DspToUi::ScannerMutexStopped` so the
+/// appropriate toast can be shown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScannerMutexReason {
+    /// Scanner activation stopped a running recording.
+    RecordingStoppedForScanner,
+    /// Scanner activation stopped a running transcription.
+    TranscriptionStoppedForScanner,
+    /// Recording start stopped an active scanner.
+    ScannerStoppedForRecording,
+    /// Transcription start stopped an active scanner.
+    ScannerStoppedForTranscription,
+}
+
 /// Messages sent from the DSP pipeline thread to the UI main loop.
 #[derive(Debug)]
 pub enum DspToUi {
@@ -84,6 +99,28 @@ pub enum DspToUi {
     /// when streaming, red with the message on failure. Per
     /// issue #247.
     NetworkSinkStatus(NetworkSinkStatus),
+    // --- Scanner (#317) ---
+    /// Scanner's active channel changed. UI uses this to sync
+    /// the frequency selector, spectrum center, status bar,
+    /// demod dropdown, and bandwidth row. `key = None` means
+    /// scanner went idle (clear the display).
+    ScannerActiveChannelChanged {
+        key: Option<sdr_scanner::ChannelKey>,
+        freq_hz: u64,
+        demod_mode: sdr_types::DemodMode,
+        bandwidth: f64,
+        name: String,
+    },
+    /// Scanner phase transition — UI updates the state label.
+    ScannerStateChanged(sdr_scanner::ScannerState),
+    /// Rotation exhausted because all channels are absent or
+    /// locked out. UI surfaces a toast before the sidebar
+    /// display resets.
+    ScannerEmptyRotation,
+    /// Scanner stopped recording/transcription (or vice versa)
+    /// via the mutex. UI shows a toast describing the
+    /// transition.
+    ScannerMutexStopped(ScannerMutexReason),
 }
 
 /// Available source types for IQ input.

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -283,6 +283,21 @@ pub enum UiToDsp {
     /// wait for the current exponential-backoff delay to expire.
     /// No-op when the active source is not `RtlTcp`.
     RetryRtlTcpNow,
+    // --- Scanner (#317) ---
+    /// Master scanner on/off toggle.
+    SetScannerEnabled(bool),
+    /// Replace the scanner's channel list. UI projects bookmarks
+    /// with `scan_enabled = true` into `ScannerChannel`s (folding
+    /// defaults + overrides at projection time) and dispatches
+    /// this on startup + any bookmark/default change.
+    UpdateScannerChannels(Vec<sdr_scanner::ScannerChannel>),
+    /// Session-scoped lockout — scanner skips this channel until
+    /// unlocked or scanner is disabled.
+    LockoutScannerChannel(sdr_scanner::ChannelKey),
+    /// Clear a lockout. If scanner stalled into `Idle` via
+    /// `EmptyRotation` (all channels locked) this resumes
+    /// rotation automatically.
+    UnlockScannerChannel(sdr_scanner::ChannelKey),
 }
 
 #[cfg(test)]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -494,6 +494,13 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         //     light up in the macOS UI whenever the CTCSS / voice-
         //     squelch panels get ported (no specific backlog issue
         //     yet — part of the full-parity backlog under #228).
+        //   - `ScannerActiveChannelChanged`, `ScannerStateChanged`,
+        //     `ScannerEmptyRotation`, `ScannerMutexStopped` are the
+        //     scanner Phase 1 UI events (#317). Intentionally
+        //     withheld from ABI v1; the Mac-side scanner ticket
+        //     (tracked separately) will add them when the SwiftUI
+        //     scanner panel is designed — likely as a group at
+        //     the next minor bump.
         //
         // Adding any of these to the ABI is additive (new
         // `SDR_EVT_*` discriminant + new payload struct or reuse

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -560,7 +560,11 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         | DspToUi::DemodModeChanged(_)
         | DspToUi::BandwidthChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
-        | DspToUi::VoiceSquelchOpenChanged(_) => return None,
+        | DspToUi::VoiceSquelchOpenChanged(_)
+        | DspToUi::ScannerActiveChannelChanged { .. }
+        | DspToUi::ScannerStateChanged(_)
+        | DspToUi::ScannerEmptyRotation
+        | DspToUi::ScannerMutexStopped(_) => return None,
     };
 
     Some((event, owned_cstring, owned_vec))

--- a/crates/sdr-scanner/src/scanner.rs
+++ b/crates/sdr-scanner/src/scanner.rs
@@ -154,6 +154,19 @@ impl Scanner {
         self.phase.as_state()
     }
 
+    /// Whether the scanner is user-enabled. Distinct from
+    /// `state() != Idle` because `Idle` is also the rest phase
+    /// after `EmptyRotation` (enabled scanner with every channel
+    /// locked) — callers gating "scanner is active" on phase
+    /// alone miss that case. The mutex with
+    /// recording/transcription wants `is_enabled()` so a pending
+    /// re-resume via `UnlockScannerChannel` / `UpdateScannerChannels`
+    /// counts as "scanner active."
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
     /// Feed an event, receive zero or more commands. Commands
     /// are returned in order of emission — caller applies them
     /// in sequence.

--- a/crates/sdr-ui/src/radioreference/frequency_list.rs
+++ b/crates/sdr-ui/src/radioreference/frequency_list.rs
@@ -281,6 +281,10 @@ mod tests {
             ctcss_mode: None,
             ctcss_threshold: None,
             voice_squelch_mode: None,
+            scan_enabled: false,
+            priority: 0,
+            dwell_ms_override: None,
+            hang_ms_override: None,
         };
 
         let freq = sample_freq("42", 999_999_999, "FM", "test");
@@ -312,6 +316,10 @@ mod tests {
             ctcss_mode: None,
             ctcss_threshold: None,
             voice_squelch_mode: None,
+            scan_enabled: false,
+            priority: 0,
+            dwell_ms_override: None,
+            hang_ms_override: None,
         };
 
         let freq = sample_freq("99", 155_000_000, "FM", "test");
@@ -343,6 +351,10 @@ mod tests {
             ctcss_mode: None,
             ctcss_threshold: None,
             voice_squelch_mode: None,
+            scan_enabled: false,
+            priority: 0,
+            dwell_ms_override: None,
+            hang_ms_override: None,
         };
 
         let freq = sample_freq("99", 155_000_000, "FM", "test");

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -201,6 +201,20 @@ pub struct Bookmark {
     /// squelch setting alone."
     #[serde(default)]
     pub voice_squelch_mode: Option<sdr_dsp::voice_squelch::VoiceSquelchMode>,
+    /// Include in scanner rotation. Default false so existing
+    /// bookmarks don't start getting scanned without opt-in.
+    #[serde(default)]
+    pub scan_enabled: bool,
+    /// Priority tier. 0 = normal, 1 = priority (checked more
+    /// often). Higher tiers reserved for future phases.
+    #[serde(default)]
+    pub priority: u8,
+    /// Per-channel dwell override in ms. None → scanner default.
+    #[serde(default)]
+    pub dwell_ms_override: Option<u32>,
+    /// Per-channel hang override in ms. None → scanner default.
+    #[serde(default)]
+    pub hang_ms_override: Option<u32>,
 }
 
 impl Bookmark {
@@ -229,6 +243,10 @@ impl Bookmark {
             ctcss_mode: None,
             ctcss_threshold: None,
             voice_squelch_mode: None,
+            scan_enabled: false,
+            priority: 0,
+            dwell_ms_override: None,
+            hang_ms_override: None,
         }
     }
 
@@ -274,6 +292,10 @@ impl Bookmark {
             ctcss_mode: profile.ctcss_mode,
             ctcss_threshold: profile.ctcss_threshold,
             voice_squelch_mode: profile.voice_squelch_mode,
+            scan_enabled: false,
+            priority: 0,
+            dwell_ms_override: None,
+            hang_ms_override: None,
         }
     }
 
@@ -1138,5 +1160,31 @@ mod tests {
         assert!(bookmark_matches_filter(&bm, "dispatch"));
         assert!(bookmark_matches_filter(&bm, "law"));
         assert!(!bookmark_matches_filter(&bm, "fire"));
+    }
+
+    #[test]
+    fn bookmark_scanner_fields_default_on_old_json() {
+        // Old pre-scanner bookmark JSON (no scanner fields present).
+        let old_json = r#"{"name":"Old","frequency":162550000,"demod_mode":"NFM","bandwidth":12500.0}"#;
+        let bm: Bookmark = serde_json::from_str(old_json).unwrap();
+        assert!(!bm.scan_enabled);
+        assert_eq!(bm.priority, 0);
+        assert!(bm.dwell_ms_override.is_none());
+        assert!(bm.hang_ms_override.is_none());
+    }
+
+    #[test]
+    fn bookmark_scanner_fields_roundtrip() {
+        let mut bm = Bookmark::new("Test", 146_520_000, DemodMode::Nfm, 12_500.0);
+        bm.scan_enabled = true;
+        bm.priority = 1;
+        bm.dwell_ms_override = Some(200);
+        bm.hang_ms_override = Some(3000);
+        let json = serde_json::to_string(&bm).unwrap();
+        let back: Bookmark = serde_json::from_str(&json).unwrap();
+        assert!(back.scan_enabled);
+        assert_eq!(back.priority, 1);
+        assert_eq!(back.dwell_ms_override, Some(200));
+        assert_eq!(back.hang_ms_override, Some(3000));
     }
 }

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -209,10 +209,15 @@ pub struct Bookmark {
     /// often). Higher tiers reserved for future phases.
     #[serde(default)]
     pub priority: u8,
-    /// Per-channel dwell override in ms. None → scanner default.
+    /// Per-channel dwell override in ms. `None` → resolved to the
+    /// UI-side default at `ScannerChannel` projection time (scanner
+    /// itself doesn't own a default; timing defaults live in the
+    /// UI layer per the design).
     #[serde(default)]
     pub dwell_ms_override: Option<u32>,
-    /// Per-channel hang override in ms. None → scanner default.
+    /// Per-channel hang override in ms. `None` → resolved to the
+    /// UI-side default at `ScannerChannel` projection time (same
+    /// ownership contract as `dwell_ms_override`).
     #[serde(default)]
     pub hang_ms_override: Option<u32>,
 }

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -1165,7 +1165,8 @@ mod tests {
     #[test]
     fn bookmark_scanner_fields_default_on_old_json() {
         // Old pre-scanner bookmark JSON (no scanner fields present).
-        let old_json = r#"{"name":"Old","frequency":162550000,"demod_mode":"NFM","bandwidth":12500.0}"#;
+        let old_json =
+            r#"{"name":"Old","frequency":162550000,"demod_mode":"NFM","bandwidth":12500.0}"#;
         let bm: Bookmark = serde_json::from_str(old_json).unwrap();
         assert!(!bm.scan_enabled);
         assert_eq!(bm.priority, 0);

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -1176,16 +1176,25 @@ mod tests {
 
     #[test]
     fn bookmark_scanner_fields_roundtrip() {
+        /// Override dwell in ms; distinct from the scanner's
+        /// `DEFAULT_DWELL_MS` (100) so the roundtrip assertion
+        /// would fail if serde dropped the override field and
+        /// the default re-hydrated.
+        const TEST_SCANNER_DWELL_MS: u32 = 200;
+        /// Override hang in ms; same rationale — distinct from
+        /// the scanner default (2000).
+        const TEST_SCANNER_HANG_MS: u32 = 3_000;
+
         let mut bm = Bookmark::new("Test", 146_520_000, DemodMode::Nfm, 12_500.0);
         bm.scan_enabled = true;
         bm.priority = 1;
-        bm.dwell_ms_override = Some(200);
-        bm.hang_ms_override = Some(3000);
+        bm.dwell_ms_override = Some(TEST_SCANNER_DWELL_MS);
+        bm.hang_ms_override = Some(TEST_SCANNER_HANG_MS);
         let json = serde_json::to_string(&bm).unwrap();
         let back: Bookmark = serde_json::from_str(&json).unwrap();
         assert!(back.scan_enabled);
         assert_eq!(back.priority, 1);
-        assert_eq!(back.dwell_ms_override, Some(200));
-        assert_eq!(back.hang_ms_override, Some(3000));
+        assert_eq!(back.dwell_ms_override, Some(TEST_SCANNER_DWELL_MS));
+        assert_eq!(back.hang_ms_override, Some(TEST_SCANNER_HANG_MS));
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -732,7 +732,18 @@ fn handle_dsp_message(
                 apply_network_sink_status(&row, &status);
             }
         }
-        // --- Scanner (#317) — UI integration wired in Task 2.7+ ---
+        // --- Scanner (#317) ---
+        //
+        // `ScannerActiveChannelChanged` and `ScannerStateChanged`
+        // are still stubs here — their fan-out to the frequency
+        // selector, spectrum, status bar, demod dropdown, and
+        // bandwidth row is PR 3 work. `ScannerEmptyRotation` and
+        // `ScannerMutexStopped` ARE promoted to real toasts +
+        // widget deactivation in this PR because they fire
+        // immediately as soon as the mutex kicks in (which
+        // happens as soon as a future caller dispatches
+        // `UiToDsp::SetScannerEnabled(true)`, which could be
+        // driven by a test harness before the PR 3 panel lands).
         DspToUi::ScannerActiveChannelChanged {
             key,
             freq_hz,
@@ -746,17 +757,50 @@ fn handle_dsp_message(
                 ?demod_mode,
                 bandwidth,
                 name,
-                "scanner active channel changed"
+                "scanner active channel changed — UI fan-out lands in PR 3"
             );
         }
         DspToUi::ScannerStateChanged(scanner_state) => {
-            tracing::debug!(?scanner_state, "scanner state changed");
+            tracing::debug!(
+                ?scanner_state,
+                "scanner state changed — scanner-panel wiring lands in PR 3"
+            );
         }
         DspToUi::ScannerEmptyRotation => {
-            tracing::debug!("scanner rotation empty");
+            tracing::info!("scanner rotation empty");
+            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                overlay.add_toast(adw::Toast::new(
+                    "Scanner has no active channels (all locked or disabled)",
+                ));
+            }
         }
         DspToUi::ScannerMutexStopped(reason) => {
-            tracing::debug!(?reason, "scanner mutex stopped");
+            tracing::info!(?reason, "scanner mutex stopped");
+            // Widget state for recording deactivates automatically
+            // via the paired `AudioRecordingStopped` /
+            // `IqRecordingStopped` events that `stop_any_recording`
+            // emits in the controller. Transcription doesn't have
+            // a matching stopped-event — deactivate the enable row
+            // explicitly here.
+            let message = match reason {
+                sdr_core::messages::ScannerMutexReason::RecordingStoppedForScanner => {
+                    "Recording stopped — Scanner activated"
+                }
+                sdr_core::messages::ScannerMutexReason::TranscriptionStoppedForScanner => {
+                    transcription_enable_row.set_active(false);
+                    "Transcription stopped — Scanner activated"
+                }
+                sdr_core::messages::ScannerMutexReason::ScannerStoppedForRecording => {
+                    // Scanner widget state sync lands in PR 3.
+                    "Scanner stopped — recording started"
+                }
+                sdr_core::messages::ScannerMutexReason::ScannerStoppedForTranscription => {
+                    "Scanner stopped — transcription started"
+                }
+            };
+            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                overlay.add_toast(adw::Toast::new(message));
+            }
         }
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -732,6 +732,32 @@ fn handle_dsp_message(
                 apply_network_sink_status(&row, &status);
             }
         }
+        // --- Scanner (#317) — UI integration wired in Task 2.7+ ---
+        DspToUi::ScannerActiveChannelChanged {
+            key,
+            freq_hz,
+            demod_mode,
+            bandwidth,
+            name,
+        } => {
+            tracing::debug!(
+                ?key,
+                freq_hz,
+                ?demod_mode,
+                bandwidth,
+                name,
+                "scanner active channel changed"
+            );
+        }
+        DspToUi::ScannerStateChanged(scanner_state) => {
+            tracing::debug!(?scanner_state, "scanner state changed");
+        }
+        DspToUi::ScannerEmptyRotation => {
+            tracing::debug!("scanner rotation empty");
+        }
+        DspToUi::ScannerMutexStopped(reason) => {
+            tracing::debug!(?reason, "scanner mutex stopped");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Second PR of three for the scanner epic (#316, Phase 1 = #317). PR 1 (#368) shipped the pure `sdr-scanner` state machine. This PR wires it into `DspController`: feeds sample ticks + squelch edges from the IQ loop, applies emitted commands, extends the `Bookmark` schema with scanner fields, and enforces mutual exclusion with recording + transcription. PR 3 ships the UI.

## What's in this PR

- **Bookmark schema**: four new `#[serde(default)]` fields on `Bookmark` — `scan_enabled: bool`, `priority: u8`, `dwell_ms_override: Option<u32>`, `hang_ms_override: Option<u32>`. Backward-compat tests confirm old JSON deserializes cleanly with defaults. `TuningProfile` untouched — scanner config is orthogonal to the tuning-profile path.

- **`UiToDsp` variants**: `SetScannerEnabled(bool)`, `UpdateScannerChannels(Vec<ScannerChannel>)`, `LockoutScannerChannel(ChannelKey)`, `UnlockScannerChannel(ChannelKey)`. No `SetScannerDefault*` variants — timing defaults live UI-side per the design (UI re-projects bookmarks into `ScannerChannel`s on slider change and re-dispatches `UpdateScannerChannels`).

- **`DspToUi` variants**: `ScannerActiveChannelChanged { key, freq_hz, demod_mode, bandwidth, name }`, `ScannerStateChanged(ScannerState)`, `ScannerEmptyRotation`, `ScannerMutexStopped(ScannerMutexReason)`. New `ScannerMutexReason` enum with four variants covering both mutex directions.

- **`DspController` wiring**: `DspState` gets `scanner: Scanner` + `scanner_channels: Vec<ScannerChannel>` + `scanner_muted: bool` fields. `apply_scanner_commands` free function handles `Retune` (drives source + radio module with CTCSS force-Off-on-None / voice-squelch preserve-on-None asymmetry from PR 1 CR round 4), `MuteAudio` (sets state flag), `ActiveChannelChanged` (via `emit_scanner_active_channel` helper that looks up the full channel info), `StateChanged`, `EmptyRotation`. `SampleTick` fed on every IQ block via `NonZeroU32::new(state.sample_rate as u32)`. `SquelchEdge` fed before the Nfm-gated transcription emission, mode-agnostic — scanner cares about edges on any demod mode.

- **Scanner ↔ recording ↔ transcription mutex**: symmetric three-way exclusion. Scanner activation stops active recording + transcription with `ScannerMutexStopped(RecordingStoppedForScanner / TranscriptionStoppedForScanner)`. Recording + transcription starts stop active scanner with `ScannerMutexStopped(ScannerStoppedForRecording / ScannerStoppedForTranscription)`. No spurious events — mutex events only emit when something was actually stopped.

- **Audio mute at sink**: `scanner_muted` flag gate before the `audio_sink.write_samples` call fills `audio_buf[..audio_count].fill(Stereo::default())` in-place. Zero allocation per block, DSP chain runs normally (squelch state stays live for scanner decisions), recording sees real audio ordering-wise (though mutex'd off when scanner is active).

## Commits

1. `bd04d83` — bookmark: add scanner fields (#317)
2. `ed31ab6` — sdr-core: add scanner UiToDsp variants (#317)
3. `c9fb405` — sdr-core: add scanner DspToUi variants + mutex reason enum (#317)
4. `a75aefd` — sdr-core: wire scanner into DspController (#317)
5. `c501016` — sdr-core: scanner ↔ recording/transcription mutex (#317)
6. `9a3ffa2` — sdr-core: scanner audio-mute at sink write (#317)
7. `4dd2576` — cargo fmt (PR 2)

## What's NOT in this PR

- **UI panel** — the scanner is reachable via `UiToDsp::SetScannerEnabled` but there's no sidebar panel yet. PR 3 lands the panel, bookmark-row Scan checkbox + Priority toggle, active-channel / state display, default dwell/hang sliders, lockout button, and the `⌘B`-style keyboard shortcut.

- **UI sync on retune** — `DspToUi::ScannerActiveChannelChanged` is emitted but the UI handler is a stub `tracing::debug!` (unblocks the exhaustive match). PR 3 fans it out to the frequency selector, spectrum, status bar, demod dropdown, and bandwidth row.

## Design

Plan: [`docs/superpowers/plans/2026-04-21-scanner-phase-1.md`](../blob/feature/scanner-integration/docs/superpowers/plans/2026-04-21-scanner-phase-1.md) (now landed on main via PR 1).
Spec: [`docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md`](../blob/feature/scanner-integration/docs/superpowers/specs/2026-04-21-scanner-phase-1-design.md).

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --features sdr-ui/whisper-cpu --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --features sdr-ui/whisper-cpu` — all existing tests pass + 2 new bookmark backward-compat tests
- [ ] Smoke test — deferred to PR 3 since there's no UI to drive the scanner yet. Log-inspection possible via a test harness but not automated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scanner integration: channel management, enable/disable and lock/unlock controls; scanner now pauses recordings/transcription and emits active-channel, state, empty-rotation, and mutex notifications (UI shows toasts for empty-rotation and mutex events).
  * Bookmarks extended with scanner settings (scan enabled, priority, dwell/hang overrides) and load backward‑compatibly from legacy files.
  * Scanner exposes an is-enabled query.

* **Tests**
  * Added/updated tests for scanner messages and bookmark serialization/deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->