### PR TITLE
feat(#317): scanner UI — closes Phase 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "sdr-radioreference",
  "sdr-rtlsdr",
  "sdr-rtltcp-discovery",
+ "sdr-scanner",
  "sdr-server-rtltcp",
  "sdr-sink-audio",
  "sdr-source-rtlsdr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1854,6 +1854,14 @@ fn emit_scanner_active_channel(
             demod_mode: c.demod_mode,
             bandwidth: c.bandwidth,
             name: c.key.name.clone(),
+            // CTCSS + voice-squelch mirror the channel record
+            // verbatim (including `None`). The UI decides how to
+            // interpret `None` — CTCSS forces the row to Off to
+            // match the scanner's engine-side behavior;
+            // voice-squelch leaves the row alone, also matching
+            // the scanner's "no override → preserve" contract.
+            ctcss: c.ctcss,
+            voice_squelch: c.voice_squelch,
             key: Some(c.key),
         },
         None => DspToUi::ScannerActiveChannelChanged {
@@ -1861,6 +1869,8 @@ fn emit_scanner_active_channel(
             demod_mode: sdr_types::DemodMode::Nfm,
             bandwidth: 0.0,
             name: String::new(),
+            ctcss: None,
+            voice_squelch: None,
             key: None,
         },
     };

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -110,6 +110,17 @@ pub enum DspToUi {
         demod_mode: sdr_types::DemodMode,
         bandwidth: f64,
         name: String,
+        /// Per-channel CTCSS mode. `None` on the channel means
+        /// "no channel-level override"; the scanner applies Off
+        /// to the engine in that case, and the UI mirrors that
+        /// by setting the CTCSS row to Off. `Some(mode)` maps
+        /// directly.
+        ctcss: Option<CtcssMode>,
+        /// Per-channel voice-squelch mode. `None` means "don't
+        /// override" — both engine and UI keep the current value.
+        /// `Some(mode)` gets applied by the scanner retune and
+        /// reflected on the voice-squelch widget.
+        voice_squelch: Option<VoiceSquelchMode>,
     },
     /// Scanner phase transition — UI updates the state label.
     ScannerStateChanged(sdr_scanner::ScannerState),
@@ -804,6 +815,8 @@ mod tests {
             demod_mode: sdr_types::DemodMode::Nfm,
             bandwidth: TEST_BANDWIDTH_HZ,
             name: "Test".to_string(),
+            ctcss: Some(CtcssMode::Off),
+            voice_squelch: None,
         };
         assert!(matches!(
             active,
@@ -811,6 +824,8 @@ mod tests {
                 key: Some(_),
                 freq_hz: 162_550_000,
                 demod_mode: sdr_types::DemodMode::Nfm,
+                ctcss: Some(CtcssMode::Off),
+                voice_squelch: None,
                 ..
             }
         ));
@@ -821,6 +836,8 @@ mod tests {
             demod_mode: sdr_types::DemodMode::Nfm,
             bandwidth: 0.0,
             name: String::new(),
+            ctcss: None,
+            voice_squelch: None,
         };
         assert!(matches!(
             idle,

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -45,6 +45,10 @@ sdr-config.workspace = true
 sdr-radio.workspace = true
 sdr-rtlsdr.workspace = true
 sdr-source-rtlsdr.workspace = true
+# Scanner state machine — UI references `ScannerState` to map
+# phase enum variants to human-readable labels and builds
+# `ChannelKey`/`ScannerChannel` values for `UpdateScannerChannels`.
+sdr-scanner.workspace = true
 sdr-sink-audio.workspace = true
 sdr-radioreference.workspace = true
 sdr-transcription.workspace = true

--- a/crates/sdr-ui/src/shortcuts.rs
+++ b/crates/sdr-ui/src/shortcuts.rs
@@ -17,6 +17,7 @@ pub fn setup_shortcuts(
     sidebar_toggle: &gtk4::ToggleButton,
     bookmarks_toggle: &gtk4::ToggleButton,
     demod_dropdown: &gtk4::DropDown,
+    scanner_switch: &gtk4::Switch,
 ) {
     let controller = gtk4::ShortcutController::new();
     controller.set_scope(gtk4::ShortcutScope::Managed);
@@ -93,6 +94,25 @@ pub fn setup_shortcuts(
         controller.add_shortcut(shortcut);
     }
 
+    // F8: Toggle scanner master switch. Uses `set_active` (not
+    // `set_state`) so the switch's `state-set` handler fires and
+    // dispatches `SetScannerEnabled` to the engine — otherwise
+    // the widget would flip visually but the scanner wouldn't
+    // actually start or stop.
+    let scanner_switch_weak = scanner_switch.downgrade();
+    let trigger_f8 = gtk4::ShortcutTrigger::parse_string("F8");
+    if let Some(trigger) = trigger_f8 {
+        let action = gtk4::CallbackAction::new(move |_widget, _args| {
+            if let Some(sw) = scanner_switch_weak.upgrade() {
+                sw.set_active(!sw.is_active());
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        let shortcut = gtk4::Shortcut::new(Some(trigger), Some(action));
+        controller.add_shortcut(shortcut);
+    }
+
     window.add_controller(controller);
 }
 
@@ -107,6 +127,7 @@ const SHORTCUT_CATALOG: &[(&str, &[(&str, &str)])] = &[
         &[
             ("F9", "Toggle sidebar"),
             ("Ctrl+B", "Toggle bookmarks panel"),
+            ("F8", "Toggle scanner"),
         ],
     ),
     (

--- a/crates/sdr-ui/src/shortcuts.rs
+++ b/crates/sdr-ui/src/shortcuts.rs
@@ -94,11 +94,14 @@ pub fn setup_shortcuts(
         controller.add_shortcut(shortcut);
     }
 
-    // F8: Toggle scanner master switch. Uses `set_active` (not
-    // `set_state`) so the switch's `state-set` handler fires and
-    // dispatches `SetScannerEnabled` to the engine — otherwise
-    // the widget would flip visually but the scanner wouldn't
-    // actually start or stop.
+    // F8: Toggle scanner master switch. The master switch is
+    // wired via `connect_active_notify` in `connect_scanner_panel`
+    // — `set_active` changes the active property and fires that
+    // notify, which dispatches `SetScannerEnabled` to the engine.
+    // (Earlier iterations of this code claimed `set_active`
+    // triggers `state-set` on programmatic changes; that's
+    // binding-version-dependent, so we sidestep the ambiguity by
+    // listening to notify::active instead.)
     let scanner_switch_weak = scanner_switch.downgrade();
     let trigger_f8 = gtk4::ShortcutTrigger::parse_string("F8");
     if let Some(trigger) = trigger_f8 {

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -137,6 +137,16 @@ impl BookmarksPanel {
     /// directly — packs up all the shared `Rc` state owned by
     /// this panel so callers only need to hand in the
     /// `NavigationPanel`-owned `name_entry` reference.
+    ///
+    /// This is the method the external mutation paths (Add, Save,
+    /// `RadioReference` import) call after persisting changes —
+    /// they get scanner re-projection for free because `rebuild`
+    /// fires `on_mutated` after the list rebuild. Internal row
+    /// actions (delete, scan checkbox, priority star) call
+    /// [`rebuild_bookmark_list`](super::navigation_panel::rebuild_bookmark_list)
+    /// directly and dispatch `on_mutated` themselves; the
+    /// search-entry handler bypasses both and does not invoke
+    /// `on_mutated` (filter changes aren't mutations).
     pub fn rebuild(&self, name_entry: &adw::EntryRow) {
         super::navigation_panel::rebuild_bookmark_list(
             &self.bookmark_list,
@@ -150,6 +160,13 @@ impl BookmarksPanel {
             &self.manual_expanded,
             &self.on_mutated,
         );
+        // Fire the mutation callback so external callers (Add,
+        // Save, RR import) trigger scanner re-projection without
+        // needing to know the callback's wiring. Idempotent —
+        // the window-level closure just re-projects + dispatches.
+        if let Some(cb) = self.on_mutated.borrow().as_ref() {
+            cb();
+        }
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -131,23 +131,28 @@ impl BookmarksPanel {
         *self.on_mutated.borrow_mut() = Some(Box::new(f));
     }
 
-    /// Rebuild the flyout's bookmark list from the backing store,
-    /// honoring the current search filter. Preferred over calling
-    /// [`rebuild_bookmark_list`](super::navigation_panel::rebuild_bookmark_list)
-    /// directly — packs up all the shared `Rc` state owned by
-    /// this panel so callers only need to hand in the
-    /// `NavigationPanel`-owned `name_entry` reference.
-    ///
-    /// This is the method the external mutation paths (Add, Save,
-    /// `RadioReference` import) call after persisting changes —
-    /// they get scanner re-projection for free because `rebuild`
-    /// fires `on_mutated` after the list rebuild. Internal row
-    /// actions (delete, scan checkbox, priority star) call
-    /// [`rebuild_bookmark_list`](super::navigation_panel::rebuild_bookmark_list)
-    /// directly and dispatch `on_mutated` themselves; the
-    /// search-entry handler bypasses both and does not invoke
-    /// `on_mutated` (filter changes aren't mutations).
+    /// Redraw-only rebuild of the flyout list. Does NOT fire the
+    /// mutation callback — use [`Self::rebuild_after_mutation`]
+    /// for that. Appropriate for paths that change what's
+    /// displayed without changing the backing store's content
+    /// (e.g. highlight-active refresh after a recall click).
     pub fn rebuild(&self, name_entry: &adw::EntryRow) {
+        self.rebuild_inner(name_entry, false);
+    }
+
+    /// Rebuild the flyout list AND fire the mutation callback.
+    /// Call this from external paths that actually change the
+    /// bookmark set (Add, Save, `RadioReference` import) so the
+    /// scanner channel list gets re-projected in the same tick.
+    /// Internal row actions (delete, scan checkbox, priority
+    /// star) dispatch `on_mutated` themselves alongside their
+    /// direct [`rebuild_bookmark_list`](super::navigation_panel::rebuild_bookmark_list)
+    /// calls, so they don't go through this method.
+    pub fn rebuild_after_mutation(&self, name_entry: &adw::EntryRow) {
+        self.rebuild_inner(name_entry, true);
+    }
+
+    fn rebuild_inner(&self, name_entry: &adw::EntryRow, notify_mutated: bool) {
         super::navigation_panel::rebuild_bookmark_list(
             &self.bookmark_list,
             &self.bookmark_scroll,
@@ -160,11 +165,7 @@ impl BookmarksPanel {
             &self.manual_expanded,
             &self.on_mutated,
         );
-        // Fire the mutation callback so external callers (Add,
-        // Save, RR import) trigger scanner re-projection without
-        // needing to know the callback's wiring. Idempotent —
-        // the window-level closure just re-projects + dispatches.
-        if let Some(cb) = self.on_mutated.borrow().as_ref() {
+        if notify_mutated && let Some(cb) = self.on_mutated.borrow().as_ref() {
             cb();
         }
     }

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -28,8 +28,8 @@ use gtk4::prelude::*;
 use libadwaita as adw;
 
 use super::navigation_panel::{
-    ActiveBookmark, Bookmark, NavigationCallback, SaveCallback, load_bookmarks,
-    rebuild_bookmark_list,
+    ActiveBookmark, Bookmark, BookmarksMutatedCallback, NavigationCallback, SaveCallback,
+    load_bookmarks, rebuild_bookmark_list,
 };
 
 /// Default width of the bookmarks flyout, in pixels. Wide enough for
@@ -102,6 +102,14 @@ pub struct BookmarksPanel {
     /// active (see `expanded-notify` handler in
     /// `rebuild_bookmark_list`).
     pub manual_expanded: std::rc::Rc<std::cell::RefCell<std::collections::HashSet<String>>>,
+    /// Fires whenever a per-bookmark scanner-relevant toggle
+    /// mutates the list (scan checkbox, priority star, delete).
+    /// Window-level wiring installs a closure that re-projects
+    /// the bookmark list into scanner channels and dispatches
+    /// `UiToDsp::UpdateScannerChannels`. Stays `None` in tests
+    /// and during the construction window before
+    /// `connect_mutated` is called.
+    pub on_mutated: BookmarksMutatedCallback,
 }
 
 impl BookmarksPanel {
@@ -113,6 +121,14 @@ impl BookmarksPanel {
     /// Register a callback invoked when the user clicks save on the active bookmark.
     pub fn connect_save<F: Fn() + 'static>(&self, f: F) {
         *self.on_save.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Register a callback invoked whenever a scanner-relevant
+    /// bookmark toggle mutates the list. Window-level wiring
+    /// installs a closure that re-projects the bookmark list and
+    /// dispatches `UiToDsp::UpdateScannerChannels`.
+    pub fn connect_mutated<F: Fn() + 'static>(&self, f: F) {
+        *self.on_mutated.borrow_mut() = Some(Box::new(f));
     }
 
     /// Rebuild the flyout's bookmark list from the backing store,
@@ -132,6 +148,7 @@ impl BookmarksPanel {
             &self.on_save,
             &self.filter_text,
             &self.manual_expanded,
+            &self.on_mutated,
         );
     }
 }
@@ -201,6 +218,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
     let manual_expanded = std::rc::Rc::new(std::cell::RefCell::new(std::collections::HashSet::<
         String,
     >::new()));
+    let on_mutated: BookmarksMutatedCallback = std::rc::Rc::new(std::cell::RefCell::new(None));
 
     // Search-changed → update needle + rebuild. We rebuild the
     // list instead of using `ListBox::set_filter_func` because
@@ -218,6 +236,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
     let active_for_entry = std::rc::Rc::clone(&active_bookmark);
     let on_save_for_entry = std::rc::Rc::clone(&on_save);
     let manual_expanded_for_entry = std::rc::Rc::clone(&manual_expanded);
+    let on_mutated_for_entry = std::rc::Rc::clone(&on_mutated);
     let name_entry_for_entry = name_entry.clone();
     search_entry.connect_search_changed(move |entry| {
         *filter_for_entry.borrow_mut() = entry.text().to_lowercase();
@@ -231,6 +250,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
             &on_save_for_entry,
             &filter_for_entry,
             &manual_expanded_for_entry,
+            &on_mutated_for_entry,
         );
     });
 
@@ -245,6 +265,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         &on_save,
         &filter_text,
         &manual_expanded,
+        &on_mutated,
     );
 
     BookmarksPanel {
@@ -257,5 +278,6 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         on_save,
         filter_text,
         manual_expanded,
+        on_mutated,
     }
 }

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -11,6 +11,7 @@ pub mod bookmarks_panel;
 pub mod display_panel;
 pub mod navigation_panel;
 pub mod radio_panel;
+pub mod scanner_panel;
 pub mod server_panel;
 pub mod source_panel;
 pub mod transcript_panel;
@@ -20,6 +21,7 @@ pub use bookmarks_panel::{BookmarksPanel, build_bookmarks_panel};
 pub use display_panel::{DisplayPanel, build_display_panel};
 pub use navigation_panel::{NavigationPanel, build_navigation_panel};
 pub use radio_panel::{RadioPanel, build_radio_panel};
+pub use scanner_panel::{ScannerPanel, build_scanner_panel};
 pub use server_panel::{ServerPanel, build_server_panel};
 pub use source_panel::{SourcePanel, build_source_panel};
 pub use transcript_panel::{TranscriptPanel, build_transcript_panel};
@@ -58,6 +60,10 @@ pub struct SidebarPanels {
     /// default; `window.rs` reveals it when a local RTL-SDR dongle
     /// is plugged in and not currently the active source.
     pub server: ServerPanel,
+    /// Scanner control panel at bottom of left sidebar (Phase 1,
+    /// issue #317). Master switch, active-channel / state
+    /// display, lockout button, default dwell/hang sliders.
+    pub scanner: ScannerPanel,
 }
 
 /// Build the complete sidebar `ScrolledWindow` containing all configuration panels.
@@ -73,6 +79,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     let radio = build_radio_panel();
     let display = build_display_panel();
     let navigation = build_navigation_panel();
+    let scanner = build_scanner_panel();
     // Flyout is built after navigation because it borrows the
     // left-sidebar `name_entry` — its row actions (recall,
     // delete-of-active) sync the entry field.
@@ -106,6 +113,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     sidebar_box.append(&audio.widget);
     sidebar_box.append(&radio.widget);
     sidebar_box.append(&display.widget);
+    sidebar_box.append(&scanner.widget);
 
     let scroll = gtk4::ScrolledWindow::builder()
         .child(&sidebar_box)
@@ -120,6 +128,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
         navigation,
         bookmarks,
         server,
+        scanner,
     };
 
     (scroll, panels)

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -6,6 +6,8 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 use sdr_types::DemodMode;
 
+use crate::messages::UiToDsp;
+
 // ---------------------------------------------------------------------------
 // Band presets — static, well-known frequency bands
 // ---------------------------------------------------------------------------
@@ -382,6 +384,63 @@ pub fn save_bookmarks(bookmarks: &[Bookmark]) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Scanner projection — bookmark list → `Vec<ScannerChannel>`
+// ---------------------------------------------------------------------------
+
+/// Project the in-memory bookmark list into the
+/// [`sdr_scanner::ScannerChannel`] form the scanner state machine
+/// expects. Filters to `scan_enabled == true`, parses the bookmark's
+/// string-form demod mode, and folds per-channel dwell/hang overrides
+/// on top of the UI-provided defaults (the scanner itself has no
+/// notion of defaults — resolution happens at projection time).
+///
+/// Pure function: no I/O, no threading, no global state. The channel
+/// list order mirrors the bookmark list order, which in turn mirrors
+/// save order — keeping the scanner rotation predictable and under
+/// user control.
+#[must_use]
+pub fn project_scanner_channels(
+    bookmarks: &[Bookmark],
+    default_dwell_ms: u32,
+    default_hang_ms: u32,
+) -> Vec<sdr_scanner::ScannerChannel> {
+    bookmarks
+        .iter()
+        .filter(|b| b.scan_enabled)
+        .map(|b| sdr_scanner::ScannerChannel {
+            key: sdr_scanner::ChannelKey {
+                name: b.name.clone(),
+                frequency_hz: b.frequency,
+            },
+            demod_mode: parse_demod_mode(&b.demod_mode),
+            bandwidth: b.bandwidth,
+            ctcss: b.ctcss_mode,
+            voice_squelch: b.voice_squelch_mode,
+            priority: b.priority,
+            dwell_ms: b.dwell_ms_override.unwrap_or(default_dwell_ms),
+            hang_ms: b.hang_ms_override.unwrap_or(default_hang_ms),
+        })
+        .collect()
+}
+
+/// Convenience: read the persisted default dwell/hang from config,
+/// project the bookmark list into scanner channels, and dispatch
+/// `UiToDsp::UpdateScannerChannels` so the running scanner picks up
+/// the change on its next tick. Call sites are every bookmark-list
+/// mutation (Add, Delete, RR import, scan-toggle, priority-toggle)
+/// plus both default-slider notify handlers.
+pub fn project_and_push_scanner_channels(
+    bookmarks: &[Bookmark],
+    state: &std::rc::Rc<crate::state::AppState>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
+    let default_dwell_ms = crate::sidebar::scanner_panel::load_default_dwell_ms(config);
+    let default_hang_ms = crate::sidebar::scanner_panel::load_default_hang_ms(config);
+    let channels = project_scanner_channels(bookmarks, default_dwell_ms, default_hang_ms);
+    state.send_dsp(UiToDsp::UpdateScannerChannels(channels));
+}
+
 /// Format a frequency as a human-readable string (e.g., "98.100 MHz").
 pub fn format_frequency(freq: u64) -> String {
     #[allow(clippy::cast_precision_loss)]
@@ -526,6 +585,7 @@ pub fn connect_preset_to_bookmarks(
     let on_save = std::rc::Rc::clone(&bookmarks.on_save);
     let filter_text = std::rc::Rc::clone(&bookmarks.filter_text);
     let manual_expanded = std::rc::Rc::clone(&bookmarks.manual_expanded);
+    let on_mutated = std::rc::Rc::clone(&bookmarks.on_mutated);
     let list_weak = bookmarks.bookmark_list.downgrade();
     let scroll_weak = bookmarks.bookmark_scroll.downgrade();
     let name_entry = navigation.name_entry.clone();
@@ -568,6 +628,7 @@ pub fn connect_preset_to_bookmarks(
                 &on_save,
                 &filter_text,
                 &manual_expanded,
+                &on_mutated,
             );
         }
     });
@@ -580,6 +641,15 @@ const MAX_VISIBLE_BOOKMARKS: i32 = 3;
 
 /// Callback type for save actions on the active bookmark.
 pub type SaveCallback = std::rc::Rc<std::cell::RefCell<Option<Box<dyn Fn()>>>>;
+
+/// Callback invoked whenever the in-memory bookmark list mutates in
+/// a way that affects scanner projection (scan checkbox toggled,
+/// priority star toggled, row deleted). Window-level wiring installs
+/// a closure that re-projects the bookmark list and dispatches
+/// `UiToDsp::UpdateScannerChannels`; the callback is `Option`-wrapped
+/// so panels can be built standalone (and in tests) without requiring
+/// a live `AppState` / `ConfigManager` pair to register it.
+pub type BookmarksMutatedCallback = std::rc::Rc<std::cell::RefCell<Option<Box<dyn Fn()>>>>;
 
 /// Sentinel category title for bookmarks without an `rr_category`.
 /// Only shown when the list contains a mix of categorized and
@@ -629,6 +699,7 @@ pub fn rebuild_bookmark_list(
     on_save: &SaveCallback,
     filter_text: &std::rc::Rc<std::cell::RefCell<String>>,
     manual_expanded: &std::rc::Rc<std::cell::RefCell<std::collections::HashSet<String>>>,
+    on_mutated: &BookmarksMutatedCallback,
 ) {
     // Remove all existing rows.
     while let Some(child) = list_box.first_child() {
@@ -740,6 +811,7 @@ pub fn rebuild_bookmark_list(
                     on_save,
                     filter_text,
                     manual_expanded,
+                    on_mutated,
                 );
                 expander.add_row(&row);
             }
@@ -762,6 +834,7 @@ pub fn rebuild_bookmark_list(
                 on_save,
                 filter_text,
                 manual_expanded,
+                on_mutated,
             );
             list_box.append(&row);
         }
@@ -810,6 +883,7 @@ fn build_bookmark_row(
     on_save: &SaveCallback,
     filter_text: &std::rc::Rc<std::cell::RefCell<String>>,
     manual_expanded: &std::rc::Rc<std::cell::RefCell<std::collections::HashSet<String>>>,
+    on_mutated: &BookmarksMutatedCallback,
 ) -> adw::ActionRow {
     let is_active = bm.name == current_active.name && bm.frequency == current_active.frequency;
     let row = adw::ActionRow::builder()
@@ -855,6 +929,7 @@ fn build_bookmark_row(
     let save_del = std::rc::Rc::clone(on_save);
     let filter_del = std::rc::Rc::clone(filter_text);
     let manual_expanded_del = std::rc::Rc::clone(manual_expanded);
+    let on_mutated_del = std::rc::Rc::clone(on_mutated);
     let list_ref = list_box.downgrade();
     let scroll_ref = scroll.downgrade();
     let entry_del = name_entry.clone();
@@ -884,6 +959,13 @@ fn build_bookmark_row(
             bm_rc.borrow_mut().remove(idx);
         }
         save_bookmarks(&bm_rc.borrow());
+        // Fire the mutation callback *before* the rebuild so the
+        // scanner sees the post-delete channel list in the same
+        // tick the UI re-renders — no transient "channel still
+        // present" window.
+        if let Some(cb) = on_mutated_del.borrow().as_ref() {
+            cb();
+        }
         if let Some(lb) = list_ref.upgrade()
             && let Some(sc) = scroll_ref.upgrade()
         {
@@ -897,10 +979,89 @@ fn build_bookmark_row(
                 &save_del,
                 &filter_del,
                 &manual_expanded_del,
+                &on_mutated_del,
             );
         }
     });
     row.add_suffix(&delete_btn);
+
+    // --- Scanner scan-enable checkbox ---
+    // Checked = include this bookmark in scanner rotation. Drop
+    // the borrow before firing `on_mutated` so the callback can
+    // itself borrow the bookmarks list (for projection) without
+    // panicking on a nested mutable + immutable borrow.
+    let scan_check = gtk4::CheckButton::builder()
+        .tooltip_text("Include in scanner")
+        .active(bm.scan_enabled)
+        .valign(gtk4::Align::Center)
+        .build();
+    scan_check.update_property(&[gtk4::accessible::Property::Label("Include in scanner")]);
+    let bm_scan = std::rc::Rc::clone(bookmarks);
+    let on_mutated_scan = std::rc::Rc::clone(on_mutated);
+    let scan_name = bm.name.clone();
+    let scan_freq = bm.frequency;
+    scan_check.connect_toggled(move |btn| {
+        let active = btn.is_active();
+        {
+            let mut bms = bm_scan.borrow_mut();
+            if let Some(b) = bms
+                .iter_mut()
+                .find(|b| b.name == scan_name && b.frequency == scan_freq)
+            {
+                b.scan_enabled = active;
+            }
+            save_bookmarks(&bms);
+        }
+        if let Some(cb) = on_mutated_scan.borrow().as_ref() {
+            cb();
+        }
+    });
+    row.add_suffix(&scan_check);
+
+    // --- Scanner priority star toggle ---
+    // Toggled = priority 1 (checked more often by the scanner).
+    // Phase 1 is binary — higher tiers are reserved for later
+    // phases, so the UI exposes on/off rather than a spinner.
+    let pri_btn = gtk4::ToggleButton::builder()
+        .icon_name(if bm.priority >= 1 {
+            "starred-symbolic"
+        } else {
+            "non-starred-symbolic"
+        })
+        .tooltip_text("Scanner priority channel")
+        .css_classes(["flat"])
+        .valign(gtk4::Align::Center)
+        .active(bm.priority >= 1)
+        .build();
+    pri_btn.update_property(&[gtk4::accessible::Property::Label(
+        "Scanner priority channel",
+    )]);
+    let bm_pri = std::rc::Rc::clone(bookmarks);
+    let on_mutated_pri = std::rc::Rc::clone(on_mutated);
+    let pri_name = bm.name.clone();
+    let pri_freq = bm.frequency;
+    pri_btn.connect_toggled(move |btn| {
+        let active = btn.is_active();
+        btn.set_icon_name(if active {
+            "starred-symbolic"
+        } else {
+            "non-starred-symbolic"
+        });
+        {
+            let mut bms = bm_pri.borrow_mut();
+            if let Some(b) = bms
+                .iter_mut()
+                .find(|b| b.name == pri_name && b.frequency == pri_freq)
+            {
+                b.priority = u8::from(active);
+            }
+            save_bookmarks(&bms);
+        }
+        if let Some(cb) = on_mutated_pri.borrow().as_ref() {
+            cb();
+        }
+    });
+    row.add_suffix(&pri_btn);
 
     let recall_bookmark = bm.clone();
     let on_nav_recall = std::rc::Rc::clone(on_navigate);
@@ -908,6 +1069,7 @@ fn build_bookmark_row(
     let save_recall = std::rc::Rc::clone(on_save);
     let filter_recall = std::rc::Rc::clone(filter_text);
     let manual_expanded_recall = std::rc::Rc::clone(manual_expanded);
+    let on_mutated_recall = std::rc::Rc::clone(on_mutated);
     let bm_recall = std::rc::Rc::clone(bookmarks);
     let list_recall = list_box.downgrade();
     let scroll_recall = scroll.downgrade();
@@ -937,6 +1099,7 @@ fn build_bookmark_row(
                 &save_recall,
                 &filter_recall,
                 &manual_expanded_recall,
+                &on_mutated_recall,
             );
             let adj = sc.vadjustment();
             glib::idle_add_local_once(move || {
@@ -1201,5 +1364,81 @@ mod tests {
         assert_eq!(back.priority, 1);
         assert_eq!(back.dwell_ms_override, Some(TEST_SCANNER_DWELL_MS));
         assert_eq!(back.hang_ms_override, Some(TEST_SCANNER_HANG_MS));
+    }
+
+    // ---- project_scanner_channels ----
+
+    /// Test default dwell, distinct from `sdr_scanner::DEFAULT_DWELL_MS`
+    /// (100) so the default-vs-override assertions can tell which one
+    /// the projector resolved.
+    const TEST_DEFAULT_DWELL_MS: u32 = 125;
+    /// Test default hang, distinct from `sdr_scanner::DEFAULT_HANG_MS`
+    /// (2000) for the same reason.
+    const TEST_DEFAULT_HANG_MS: u32 = 1_500;
+    /// A per-channel dwell override distinct from both the scanner
+    /// default and `TEST_DEFAULT_DWELL_MS`, so "override wins" is
+    /// observable as a unique value in assertions.
+    const TEST_OVERRIDE_DWELL_MS: u32 = 250;
+    /// A per-channel hang override distinct from both the scanner
+    /// default and `TEST_DEFAULT_HANG_MS`, same rationale.
+    const TEST_OVERRIDE_HANG_MS: u32 = 3_250;
+
+    #[test]
+    fn project_scanner_channels_filters_disabled() {
+        let mut enabled = Bookmark::new("On", 146_520_000, DemodMode::Nfm, 12_500.0);
+        enabled.scan_enabled = true;
+        let disabled = Bookmark::new("Off", 162_550_000, DemodMode::Nfm, 12_500.0);
+        let bms = vec![enabled, disabled];
+
+        let channels = project_scanner_channels(&bms, TEST_DEFAULT_DWELL_MS, TEST_DEFAULT_HANG_MS);
+
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0].key.name, "On");
+        assert_eq!(channels[0].key.frequency_hz, 146_520_000);
+    }
+
+    #[test]
+    fn project_scanner_channels_override_wins_over_default() {
+        let mut with_overrides = Bookmark::new("Overrides", 146_520_000, DemodMode::Nfm, 12_500.0);
+        with_overrides.scan_enabled = true;
+        with_overrides.dwell_ms_override = Some(TEST_OVERRIDE_DWELL_MS);
+        with_overrides.hang_ms_override = Some(TEST_OVERRIDE_HANG_MS);
+        let mut no_overrides = Bookmark::new("Defaults", 162_550_000, DemodMode::Nfm, 12_500.0);
+        no_overrides.scan_enabled = true;
+        let bms = vec![with_overrides, no_overrides];
+
+        let channels = project_scanner_channels(&bms, TEST_DEFAULT_DWELL_MS, TEST_DEFAULT_HANG_MS);
+
+        assert_eq!(channels.len(), 2);
+        // First bookmark: override wins.
+        assert_eq!(channels[0].dwell_ms, TEST_OVERRIDE_DWELL_MS);
+        assert_eq!(channels[0].hang_ms, TEST_OVERRIDE_HANG_MS);
+        // Second bookmark: no overrides, default folds in.
+        assert_eq!(channels[1].dwell_ms, TEST_DEFAULT_DWELL_MS);
+        assert_eq!(channels[1].hang_ms, TEST_DEFAULT_HANG_MS);
+    }
+
+    #[test]
+    fn project_scanner_channels_propagates_priority_and_squelch() {
+        let mut bm = Bookmark::new("Priority", 146_520_000, DemodMode::Nfm, 12_500.0);
+        bm.scan_enabled = true;
+        bm.priority = 1;
+        bm.ctcss_mode = Some(sdr_radio::af_chain::CtcssMode::Tone(100.0));
+        bm.voice_squelch_mode =
+            Some(sdr_dsp::voice_squelch::VoiceSquelchMode::Snr { threshold_db: 9.0 });
+
+        let channels = project_scanner_channels(&[bm], TEST_DEFAULT_DWELL_MS, TEST_DEFAULT_HANG_MS);
+
+        assert_eq!(channels.len(), 1);
+        let ch = &channels[0];
+        assert_eq!(ch.priority, 1);
+        assert_eq!(ch.ctcss, Some(sdr_radio::af_chain::CtcssMode::Tone(100.0)));
+        assert_eq!(
+            ch.voice_squelch,
+            Some(sdr_dsp::voice_squelch::VoiceSquelchMode::Snr { threshold_db: 9.0 })
+        );
+        // Demod mode is parsed from the string form on the bookmark.
+        assert_eq!(ch.demod_mode, DemodMode::Nfm);
+        assert!((ch.bandwidth - 12_500.0).abs() < f64::EPSILON);
     }
 }

--- a/crates/sdr-ui/src/sidebar/scanner_panel.rs
+++ b/crates/sdr-ui/src/sidebar/scanner_panel.rs
@@ -76,6 +76,28 @@ pub const HANG_STEP_MS: f64 = 100.0;
 /// Hang `SpinRow` page increment (ms).
 pub const HANG_PAGE_MS: f64 = 500.0;
 
+/// Shared parse-fallback-clamp pipeline used by the
+/// default-dwell and default-hang loaders. Pulls a `u64` out of
+/// the config at `key`, narrows to `u32` (silently falling back
+/// to `default` on overflow or missing / non-numeric values),
+/// then clamps into `[min, max]` so an out-of-range persisted
+/// value can't hand the consumer a nonsense number.
+fn load_clamped_u32(
+    config: &Arc<ConfigManager>,
+    key: &str,
+    default: u32,
+    min: u32,
+    max: u32,
+) -> u32 {
+    config.read(|v| {
+        v.get(key)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(default)
+            .clamp(min, max)
+    })
+}
+
 /// Load the persisted default-dwell value, or return
 /// [`DEFAULT_DWELL_MS`] if the key is missing or malformed.
 /// Clamps to `[DWELL_MIN_MS, DWELL_MAX_MS]` so a hand-edited
@@ -83,18 +105,17 @@ pub const HANG_PAGE_MS: f64 = 500.0;
 /// a value it can't display.
 #[must_use]
 pub fn load_default_dwell_ms(config: &Arc<ConfigManager>) -> u32 {
-    config.read(|v| {
-        let raw = v
-            .get(CONFIG_KEY_DEFAULT_DWELL_MS)
-            .and_then(serde_json::Value::as_u64)
-            .and_then(|n| u32::try_from(n).ok())
-            .unwrap_or(DEFAULT_DWELL_MS);
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let min = DWELL_MIN_MS as u32;
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let max = DWELL_MAX_MS as u32;
-        raw.clamp(min, max)
-    })
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let min = DWELL_MIN_MS as u32;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let max = DWELL_MAX_MS as u32;
+    load_clamped_u32(
+        config,
+        CONFIG_KEY_DEFAULT_DWELL_MS,
+        DEFAULT_DWELL_MS,
+        min,
+        max,
+    )
 }
 
 /// Persist the default-dwell value.
@@ -110,18 +131,17 @@ pub fn save_default_dwell_ms(config: &Arc<ConfigManager>, ms: u32) {
 /// `load_default_dwell_ms`.
 #[must_use]
 pub fn load_default_hang_ms(config: &Arc<ConfigManager>) -> u32 {
-    config.read(|v| {
-        let raw = v
-            .get(CONFIG_KEY_DEFAULT_HANG_MS)
-            .and_then(serde_json::Value::as_u64)
-            .and_then(|n| u32::try_from(n).ok())
-            .unwrap_or(DEFAULT_HANG_MS);
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let min = HANG_MIN_MS as u32;
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let max = HANG_MAX_MS as u32;
-        raw.clamp(min, max)
-    })
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let min = HANG_MIN_MS as u32;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let max = HANG_MAX_MS as u32;
+    load_clamped_u32(
+        config,
+        CONFIG_KEY_DEFAULT_HANG_MS,
+        DEFAULT_HANG_MS,
+        min,
+        max,
+    )
 }
 
 /// Persist the default-hang value.
@@ -245,5 +265,109 @@ pub fn build_scanner_panel() -> ScannerPanel {
         default_dwell_row,
         default_hang_row,
         lockout_button,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_config() -> Arc<ConfigManager> {
+        Arc::new(ConfigManager::in_memory(&serde_json::json!({})))
+    }
+
+    #[test]
+    fn dwell_missing_key_returns_default() {
+        let config = make_config();
+        assert_eq!(load_default_dwell_ms(&config), DEFAULT_DWELL_MS);
+    }
+
+    #[test]
+    fn hang_missing_key_returns_default() {
+        let config = make_config();
+        assert_eq!(load_default_hang_ms(&config), DEFAULT_HANG_MS);
+    }
+
+    #[test]
+    fn dwell_malformed_value_falls_back_to_default() {
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            CONFIG_KEY_DEFAULT_DWELL_MS: "not-a-number",
+        })));
+        assert_eq!(load_default_dwell_ms(&config), DEFAULT_DWELL_MS);
+    }
+
+    #[test]
+    fn hang_malformed_value_falls_back_to_default() {
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            CONFIG_KEY_DEFAULT_HANG_MS: [1, 2, 3],
+        })));
+        assert_eq!(load_default_hang_ms(&config), DEFAULT_HANG_MS);
+    }
+
+    #[test]
+    fn dwell_below_min_clamps_up() {
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            CONFIG_KEY_DEFAULT_DWELL_MS: 1_u64,
+        })));
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let min = DWELL_MIN_MS as u32;
+        assert_eq!(load_default_dwell_ms(&config), min);
+    }
+
+    #[test]
+    fn dwell_above_max_clamps_down() {
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            CONFIG_KEY_DEFAULT_DWELL_MS: 999_999_u64,
+        })));
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let max = DWELL_MAX_MS as u32;
+        assert_eq!(load_default_dwell_ms(&config), max);
+    }
+
+    #[test]
+    fn hang_below_min_clamps_up() {
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            CONFIG_KEY_DEFAULT_HANG_MS: 0_u64,
+        })));
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let min = HANG_MIN_MS as u32;
+        assert_eq!(load_default_hang_ms(&config), min);
+    }
+
+    #[test]
+    fn hang_above_max_clamps_down() {
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            CONFIG_KEY_DEFAULT_HANG_MS: 9_999_999_u64,
+        })));
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let max = HANG_MAX_MS as u32;
+        assert_eq!(load_default_hang_ms(&config), max);
+    }
+
+    #[test]
+    fn dwell_save_then_load_round_trips_in_range_value() {
+        let config = make_config();
+        // 150 is inside [DWELL_MIN_MS, DWELL_MAX_MS] = [50, 500].
+        save_default_dwell_ms(&config, 150);
+        assert_eq!(load_default_dwell_ms(&config), 150);
+    }
+
+    #[test]
+    fn hang_save_then_load_round_trips_in_range_value() {
+        let config = make_config();
+        // 3000 is inside [HANG_MIN_MS, HANG_MAX_MS] = [500, 5000].
+        save_default_hang_ms(&config, 3_000);
+        assert_eq!(load_default_hang_ms(&config), 3_000);
+    }
+
+    #[test]
+    fn u32_overflow_from_u64_falls_back_to_default() {
+        // u32::MAX + 1 survives as u64 but can't narrow to u32,
+        // so the `try_from` guard returns `None` and we fall
+        // back to DEFAULT_DWELL_MS (which then clamps into range).
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            CONFIG_KEY_DEFAULT_DWELL_MS: u64::from(u32::MAX) + 1,
+        })));
+        assert_eq!(load_default_dwell_ms(&config), DEFAULT_DWELL_MS);
     }
 }

--- a/crates/sdr-ui/src/sidebar/scanner_panel.rs
+++ b/crates/sdr-ui/src/sidebar/scanner_panel.rs
@@ -1,0 +1,151 @@
+//! Scanner control panel at the bottom of the left sidebar.
+//!
+//! Master switch, active-channel / state display, default
+//! dwell/hang sliders (collapsed expander), and session lockout
+//! button (visible only when scanner is on an active channel).
+//! UI wiring of user actions → `UiToDsp::*` commands lives in
+//! `window.rs::connect_scanner_panel`.
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Widgets for the scanner sidebar panel. The controller layer
+/// in `window.rs` connects signal handlers that dispatch
+/// `UiToDsp::SetScannerEnabled` / `UpdateScannerChannels` /
+/// `LockoutScannerChannel` based on these widgets.
+pub struct ScannerPanel {
+    /// The outer container — append to the sidebar `Box`.
+    pub widget: gtk4::Box,
+    /// Master on/off toggle.
+    pub master_switch: gtk4::Switch,
+    /// "Active: {name} — {freq}" while scanner is Listening /
+    /// Hanging; shows "Active: —" otherwise.
+    pub active_channel_label: gtk4::Label,
+    /// Human-readable phase label — "Off", "Scanning…",
+    /// "Listening…", "Listening", "Hang…".
+    pub state_label: gtk4::Label,
+    /// Default dwell (settle after retune) in ms. Value is
+    /// folded into `ScannerChannel::dwell_ms` at projection time
+    /// when the per-bookmark override is `None`.
+    pub default_dwell_row: adw::SpinRow,
+    /// Default hang (linger after squelch closes) in ms. Same
+    /// projection-time fallback model as `default_dwell_row`.
+    pub default_hang_row: adw::SpinRow,
+    /// "Lockout current channel" — only visible while the
+    /// scanner has an active channel latched.
+    pub lockout_button: gtk4::Button,
+}
+
+/// Minimum default-dwell value exposed in the UI (ms).
+pub const DWELL_MIN_MS: f64 = 50.0;
+/// Maximum default-dwell value exposed in the UI (ms).
+pub const DWELL_MAX_MS: f64 = 500.0;
+/// Minimum default-hang value exposed in the UI (ms).
+pub const HANG_MIN_MS: f64 = 500.0;
+/// Maximum default-hang value exposed in the UI (ms).
+pub const HANG_MAX_MS: f64 = 5000.0;
+
+/// `ConfigManager` key for the default-dwell slider value.
+pub const CONFIG_KEY_DEFAULT_DWELL_MS: &str = "scanner_default_dwell_ms";
+/// `ConfigManager` key for the default-hang slider value.
+pub const CONFIG_KEY_DEFAULT_HANG_MS: &str = "scanner_default_hang_ms";
+
+/// Build the scanner panel and return its owned widgets.
+///
+/// The outer `widget` is appended to the sidebar `Box`; the rest
+/// are captured by the controller layer for signal wiring.
+#[must_use]
+pub fn build_scanner_panel() -> ScannerPanel {
+    let widget = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(8)
+        .build();
+
+    let heading = gtk4::Label::builder()
+        .label("Scanner")
+        .css_classes(["heading"])
+        .halign(gtk4::Align::Start)
+        .build();
+    widget.append(&heading);
+
+    let switch_row = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .spacing(8)
+        .build();
+    let switch_label = gtk4::Label::builder()
+        .label("Scanner")
+        .hexpand(true)
+        .halign(gtk4::Align::Start)
+        .build();
+    let master_switch = gtk4::Switch::builder().halign(gtk4::Align::End).build();
+    switch_row.append(&switch_label);
+    switch_row.append(&master_switch);
+    widget.append(&switch_row);
+
+    let active_channel_label = gtk4::Label::builder()
+        .label("Active: —")
+        .halign(gtk4::Align::Start)
+        .css_classes(["caption"])
+        .build();
+    widget.append(&active_channel_label);
+
+    let state_label = gtk4::Label::builder()
+        .label("State: Off")
+        .halign(gtk4::Align::Start)
+        .css_classes(["caption", "dim-label"])
+        .build();
+    widget.append(&state_label);
+
+    let lockout_button = gtk4::Button::builder()
+        .label("Lockout current channel")
+        .css_classes(["destructive-action", "flat"])
+        .visible(false)
+        .build();
+    widget.append(&lockout_button);
+
+    let expander = adw::ExpanderRow::builder().title("Settings").build();
+    let default_dwell_row = adw::SpinRow::builder()
+        .title("Default dwell (ms)")
+        .adjustment(&gtk4::Adjustment::new(
+            100.0,
+            DWELL_MIN_MS,
+            DWELL_MAX_MS,
+            10.0,
+            50.0,
+            0.0,
+        ))
+        .digits(0)
+        .build();
+    let default_hang_row = adw::SpinRow::builder()
+        .title("Default hang (ms)")
+        .adjustment(&gtk4::Adjustment::new(
+            2000.0,
+            HANG_MIN_MS,
+            HANG_MAX_MS,
+            100.0,
+            500.0,
+            0.0,
+        ))
+        .digits(0)
+        .build();
+    expander.add_row(&default_dwell_row);
+    expander.add_row(&default_hang_row);
+
+    let settings_group = gtk4::ListBox::builder()
+        .selection_mode(gtk4::SelectionMode::None)
+        .css_classes(["boxed-list"])
+        .build();
+    settings_group.append(&expander);
+    widget.append(&settings_group);
+
+    ScannerPanel {
+        widget,
+        master_switch,
+        active_channel_label,
+        state_label,
+        default_dwell_row,
+        default_hang_row,
+        lockout_button,
+    }
+}

--- a/crates/sdr-ui/src/sidebar/scanner_panel.rs
+++ b/crates/sdr-ui/src/sidebar/scanner_panel.rs
@@ -6,9 +6,12 @@
 //! UI wiring of user actions → `UiToDsp::*` commands lives in
 //! `window.rs::connect_scanner_panel`.
 
+use std::sync::Arc;
+
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
+use sdr_config::ConfigManager;
 
 /// Widgets for the scanner sidebar panel. The controller layer
 /// in `window.rs` connects signal handlers that dispatch
@@ -50,6 +53,49 @@ pub const HANG_MAX_MS: f64 = 5000.0;
 pub const CONFIG_KEY_DEFAULT_DWELL_MS: &str = "scanner_default_dwell_ms";
 /// `ConfigManager` key for the default-hang slider value.
 pub const CONFIG_KEY_DEFAULT_HANG_MS: &str = "scanner_default_hang_ms";
+
+/// Default-dwell initial value (ms) when no persisted value exists.
+pub const DEFAULT_DWELL_MS: u32 = 100;
+/// Default-hang initial value (ms) when no persisted value exists.
+pub const DEFAULT_HANG_MS: u32 = 2_000;
+
+/// Load the persisted default-dwell value, or return
+/// [`DEFAULT_DWELL_MS`] if the key is missing or malformed.
+#[must_use]
+pub fn load_default_dwell_ms(config: &Arc<ConfigManager>) -> u32 {
+    config.read(|v| {
+        v.get(CONFIG_KEY_DEFAULT_DWELL_MS)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(DEFAULT_DWELL_MS)
+    })
+}
+
+/// Persist the default-dwell value.
+pub fn save_default_dwell_ms(config: &Arc<ConfigManager>, ms: u32) {
+    config.write(|v| {
+        v[CONFIG_KEY_DEFAULT_DWELL_MS] = serde_json::json!(ms);
+    });
+}
+
+/// Load the persisted default-hang value, or return
+/// [`DEFAULT_HANG_MS`] if the key is missing or malformed.
+#[must_use]
+pub fn load_default_hang_ms(config: &Arc<ConfigManager>) -> u32 {
+    config.read(|v| {
+        v.get(CONFIG_KEY_DEFAULT_HANG_MS)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(DEFAULT_HANG_MS)
+    })
+}
+
+/// Persist the default-hang value.
+pub fn save_default_hang_ms(config: &Arc<ConfigManager>, ms: u32) {
+    config.write(|v| {
+        v[CONFIG_KEY_DEFAULT_HANG_MS] = serde_json::json!(ms);
+    });
+}
 
 /// Build the scanner panel and return its owned widgets.
 ///

--- a/crates/sdr-ui/src/sidebar/scanner_panel.rs
+++ b/crates/sdr-ui/src/sidebar/scanner_panel.rs
@@ -134,9 +134,23 @@ pub fn build_scanner_panel() -> ScannerPanel {
     switch_row.append(&master_switch);
     widget.append(&switch_row);
 
+    // Long bookmark names ("KY State Police District 7 Dispatch —
+    // 154.680 MHz") would otherwise grow the label's natural
+    // width past the sidebar width and shove the whole sidebar
+    // wider on every retune. `ellipsize(End)` + `xalign(0.0)` +
+    // `hexpand(true)` + `max_width_chars(1)` tells GTK: "grow
+    // as much as the parent allows, but stop requesting extra
+    // width past that point — truncate with `…` instead." The
+    // `max_width_chars(1)` is the idiomatic GTK incantation for
+    // "don't let the label's preferred width drive the layout";
+    // actual visible width follows `hexpand`.
     let active_channel_label = gtk4::Label::builder()
         .label("Active: —")
         .halign(gtk4::Align::Start)
+        .xalign(0.0)
+        .hexpand(true)
+        .max_width_chars(1)
+        .ellipsize(gtk4::pango::EllipsizeMode::End)
         .css_classes(["caption"])
         .build();
     widget.append(&active_channel_label);
@@ -144,6 +158,10 @@ pub fn build_scanner_panel() -> ScannerPanel {
     let state_label = gtk4::Label::builder()
         .label("State: Off")
         .halign(gtk4::Align::Start)
+        .xalign(0.0)
+        .hexpand(true)
+        .max_width_chars(1)
+        .ellipsize(gtk4::pango::EllipsizeMode::End)
         .css_classes(["caption", "dim-label"])
         .build();
     widget.append(&state_label);

--- a/crates/sdr-ui/src/sidebar/scanner_panel.rs
+++ b/crates/sdr-ui/src/sidebar/scanner_panel.rs
@@ -177,7 +177,7 @@ pub fn build_scanner_panel() -> ScannerPanel {
     let default_dwell_row = adw::SpinRow::builder()
         .title("Default dwell (ms)")
         .adjustment(&gtk4::Adjustment::new(
-            100.0,
+            f64::from(DEFAULT_DWELL_MS),
             DWELL_MIN_MS,
             DWELL_MAX_MS,
             10.0,
@@ -189,7 +189,7 @@ pub fn build_scanner_panel() -> ScannerPanel {
     let default_hang_row = adw::SpinRow::builder()
         .title("Default hang (ms)")
         .adjustment(&gtk4::Adjustment::new(
-            2000.0,
+            f64::from(DEFAULT_HANG_MS),
             HANG_MIN_MS,
             HANG_MAX_MS,
             100.0,

--- a/crates/sdr-ui/src/sidebar/scanner_panel.rs
+++ b/crates/sdr-ui/src/sidebar/scanner_panel.rs
@@ -17,6 +17,11 @@ use sdr_config::ConfigManager;
 /// in `window.rs` connects signal handlers that dispatch
 /// `UiToDsp::SetScannerEnabled` / `UpdateScannerChannels` /
 /// `LockoutScannerChannel` based on these widgets.
+///
+/// `Clone` is derived so the panel can be cloned into the DSP
+/// timeout callback alongside `RadioPanel` et al — each field
+/// is a `GObject` wrapper, so clone is a cheap refcount bump.
+#[derive(Clone)]
 pub struct ScannerPanel {
     /// The outer container — append to the sidebar `Box`.
     pub widget: gtk4::Box,

--- a/crates/sdr-ui/src/sidebar/scanner_panel.rs
+++ b/crates/sdr-ui/src/sidebar/scanner_panel.rs
@@ -64,15 +64,36 @@ pub const DEFAULT_DWELL_MS: u32 = 100;
 /// Default-hang initial value (ms) when no persisted value exists.
 pub const DEFAULT_HANG_MS: u32 = 2_000;
 
+/// Dwell `SpinRow` step increment (ms). Drives arrow-key nudges
+/// and the ± buttons on the spin row.
+pub const DWELL_STEP_MS: f64 = 10.0;
+/// Dwell `SpinRow` page increment (ms). Drives Page Up/Down and
+/// the scroll-wheel bump.
+pub const DWELL_PAGE_MS: f64 = 50.0;
+/// Hang `SpinRow` step increment (ms) — larger than dwell since
+/// hang is in whole seconds range.
+pub const HANG_STEP_MS: f64 = 100.0;
+/// Hang `SpinRow` page increment (ms).
+pub const HANG_PAGE_MS: f64 = 500.0;
+
 /// Load the persisted default-dwell value, or return
 /// [`DEFAULT_DWELL_MS`] if the key is missing or malformed.
+/// Clamps to `[DWELL_MIN_MS, DWELL_MAX_MS]` so a hand-edited
+/// config with an out-of-range value doesn't hand the `SpinRow`
+/// a value it can't display.
 #[must_use]
 pub fn load_default_dwell_ms(config: &Arc<ConfigManager>) -> u32 {
     config.read(|v| {
-        v.get(CONFIG_KEY_DEFAULT_DWELL_MS)
+        let raw = v
+            .get(CONFIG_KEY_DEFAULT_DWELL_MS)
             .and_then(serde_json::Value::as_u64)
             .and_then(|n| u32::try_from(n).ok())
-            .unwrap_or(DEFAULT_DWELL_MS)
+            .unwrap_or(DEFAULT_DWELL_MS);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let min = DWELL_MIN_MS as u32;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let max = DWELL_MAX_MS as u32;
+        raw.clamp(min, max)
     })
 }
 
@@ -85,13 +106,21 @@ pub fn save_default_dwell_ms(config: &Arc<ConfigManager>, ms: u32) {
 
 /// Load the persisted default-hang value, or return
 /// [`DEFAULT_HANG_MS`] if the key is missing or malformed.
+/// Clamps to `[HANG_MIN_MS, HANG_MAX_MS]` — same rationale as
+/// `load_default_dwell_ms`.
 #[must_use]
 pub fn load_default_hang_ms(config: &Arc<ConfigManager>) -> u32 {
     config.read(|v| {
-        v.get(CONFIG_KEY_DEFAULT_HANG_MS)
+        let raw = v
+            .get(CONFIG_KEY_DEFAULT_HANG_MS)
             .and_then(serde_json::Value::as_u64)
             .and_then(|n| u32::try_from(n).ok())
-            .unwrap_or(DEFAULT_HANG_MS)
+            .unwrap_or(DEFAULT_HANG_MS);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let min = HANG_MIN_MS as u32;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let max = HANG_MAX_MS as u32;
+        raw.clamp(min, max)
     })
 }
 
@@ -180,8 +209,8 @@ pub fn build_scanner_panel() -> ScannerPanel {
             f64::from(DEFAULT_DWELL_MS),
             DWELL_MIN_MS,
             DWELL_MAX_MS,
-            10.0,
-            50.0,
+            DWELL_STEP_MS,
+            DWELL_PAGE_MS,
             0.0,
         ))
         .digits(0)
@@ -192,8 +221,8 @@ pub fn build_scanner_panel() -> ScannerPanel {
             f64::from(DEFAULT_HANG_MS),
             HANG_MIN_MS,
             HANG_MAX_MS,
-            100.0,
-            500.0,
+            HANG_STEP_MS,
+            HANG_PAGE_MS,
             0.0,
         ))
         .digits(0)

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -1,6 +1,6 @@
 //! Application state shared across GTK closures.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::mpsc;
 
@@ -40,6 +40,16 @@ pub struct AppState {
     /// accidentally tear down the scanner-driven retune the UI is
     /// only trying to reflect.
     pub suppress_demod_notify: Cell<bool>,
+    /// Scanner's currently-active channel key (or `None` when
+    /// scanner is Idle / Retuning). Written by the
+    /// `ScannerActiveChannelChanged` fan-out in `handle_dsp_message`
+    /// and read by the lockout button's click handler so a lockout
+    /// click targets whichever channel the scanner latched onto
+    /// most recently. `RefCell` rather than `Cell` because
+    /// `ChannelKey` owns a `String` — `Cell::set` would require
+    /// moving the stored value out, which interferes with the
+    /// borrow-and-clone pattern the button handler uses.
+    pub scanner_active_key: RefCell<Option<sdr_scanner::ChannelKey>>,
 }
 
 impl AppState {
@@ -54,6 +64,7 @@ impl AppState {
             ui_tx,
             suppress_bandwidth_notify: Cell::new(false),
             suppress_demod_notify: Cell::new(false),
+            scanner_active_key: RefCell::new(None),
         })
     }
 

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -32,6 +32,14 @@ pub struct AppState {
     /// which would in turn re-emit `BandwidthChanged` and waste a
     /// round trip per UI reflection.
     pub suppress_bandwidth_notify: Cell<bool>,
+    /// Mirror of `suppress_bandwidth_notify` for the demod dropdown.
+    /// Set true when we're programmatically changing the selected
+    /// demod mode (e.g. the scanner `ScannerActiveChannelChanged`
+    /// fan-out) so the dropdown's `connect_selected_notify` doesn't
+    /// bounce a `UiToDsp::SetDemodMode` command back to DSP and
+    /// accidentally tear down the scanner-driven retune the UI is
+    /// only trying to reflect.
+    pub suppress_demod_notify: Cell<bool>,
 }
 
 impl AppState {
@@ -45,6 +53,7 @@ impl AppState {
             demod_mode: Cell::new(DemodMode::Wfm),
             ui_tx,
             suppress_bandwidth_notify: Cell::new(false),
+            suppress_demod_notify: Cell::new(false),
         })
     }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -415,7 +415,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                 // the panel's individual `Rc` fields.
                 *bookmarks_for_rr.bookmarks.borrow_mut() =
                     sidebar::navigation_panel::load_bookmarks();
-                bookmarks_for_rr.rebuild(&name_entry_for_rr);
+                bookmarks_for_rr.rebuild_after_mutation(&name_entry_for_rr);
             });
         });
     }
@@ -850,6 +850,8 @@ fn handle_dsp_message(
             demod_mode,
             bandwidth,
             name,
+            ctcss,
+            voice_squelch,
         } => {
             // Cache the active channel key for the lockout button
             // click handler in `connect_scanner_panel`. Written
@@ -900,6 +902,33 @@ fn handle_dsp_message(
                 state.suppress_bandwidth_notify.set(true);
                 radio_panel.bandwidth_row.set_value(bandwidth);
                 state.suppress_bandwidth_notify.set(false);
+
+                // CTCSS + voice-squelch widget sync — keeps
+                // Add/Save Bookmark honest when the user stashes
+                // a channel the scanner landed on. The set calls
+                // bounce back through the widgets'
+                // connect_selected_notify handlers as redundant
+                // `SetCtcssMode` / `SetVoiceSquelchMode`
+                // dispatches, which are idempotent at the
+                // engine (the scanner retune has already applied
+                // the same values). Same trade-off the master-
+                // switch `connect_active_notify` migration made
+                // in round 1.
+                //
+                // `None` on the channel:
+                // - CTCSS: scanner forces engine to Off, so the
+                //   row tracks that and goes to Off.
+                // - voice-squelch: scanner leaves engine alone,
+                //   so we leave the widget alone too (what's on
+                //   the widget matches what's on the engine).
+                let ctcss_for_widget = ctcss.unwrap_or(sdr_radio::af_chain::CtcssMode::Off);
+                let ctcss_idx =
+                    sidebar::radio_panel::RadioPanel::ctcss_index_from_mode(ctcss_for_widget);
+                radio_panel.ctcss_row.set_selected(ctcss_idx);
+                if let Some(vs_mode) = voice_squelch {
+                    radio_panel.apply_voice_squelch_mode_ui(vs_mode);
+                }
+
                 scanner_panel.lockout_button.set_visible(true);
             } else {
                 scanner_panel.active_channel_label.set_text("Active: —");
@@ -926,9 +955,11 @@ fn handle_dsp_message(
                 ));
             }
             // Engine is already back to Idle — drop the master
-            // switch to match. `set_state` fires `state-set`; that
-            // handler re-dispatches `SetScannerEnabled(false)`
-            // which is idempotent on the engine side.
+            // switch to match. `set_state` propagates to `active`
+            // and fires `notify::active`, which the master switch's
+            // `connect_active_notify` handler dispatches as a
+            // redundant `SetScannerEnabled(false)` — idempotent on
+            // the engine side (scanner's already Idle), so no harm.
             scanner_panel.master_switch.set_state(false);
         }
         DspToUi::ScannerMutexStopped(reason) => {
@@ -4869,7 +4900,7 @@ fn connect_navigation_panel(
             sidebar::navigation_panel::Bookmark::with_profile(&name, freq_u64, mode, bw, &profile);
         bm_for_add.bookmarks.borrow_mut().push(bookmark);
         sidebar::navigation_panel::save_bookmarks(&bm_for_add.bookmarks.borrow());
-        bm_for_add.rebuild(&name_entry);
+        bm_for_add.rebuild_after_mutation(&name_entry);
         name_entry.set_text("");
     });
 
@@ -4991,8 +5022,10 @@ fn connect_navigation_panel(
         }
         sidebar::navigation_panel::save_bookmarks(&bms);
         drop(bms);
-        // Rebuild to update subtitle.
-        save_bm.rebuild(&save_name_entry);
+        // Rebuild to update subtitle. Fires `on_mutated` so the
+        // scanner re-projects — Save can change `scan_enabled` /
+        // `priority` / override fields on the bookmark.
+        save_bm.rebuild_after_mutation(&save_name_entry);
         tracing::info!("bookmark saved: {}", active.name);
     });
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -72,27 +72,40 @@ const SCANNER_TOAST_TIMEOUT_SECS: u32 = 3;
 /// no-op when the scanner is already off, so wiring it into a
 /// handler that fires during programmatic widget updates is
 /// cheap and idempotent.
+///
+/// Holds `glib::WeakRef`s rather than owned widget clones —
+/// each clone of this helper is captured by a signal handler
+/// that lives on a widget in the window, so a strong ref chain
+/// (handler → this helper → widget → handler) would keep the
+/// window alive after teardown. Upgrade-or-early-return in
+/// `trigger` handles the post-teardown case.
 struct ScannerForceDisable {
-    scanner_panel: sidebar::scanner_panel::ScannerPanel,
-    toast_overlay: adw::ToastOverlay,
+    master_switch: glib::WeakRef<gtk4::Switch>,
+    toast_overlay: glib::WeakRef<adw::ToastOverlay>,
 }
 
 impl ScannerForceDisable {
     /// Force the scanner off and toast the user about why. No-op
-    /// when scanner is already off. Calls `set_active(false)` on
-    /// the master switch — the switch's `connect_active_notify`
+    /// when the master switch has been dropped (post-teardown)
+    /// or when the scanner is already off. Calls `set_active(false)`
+    /// on the master switch — the switch's `connect_active_notify`
     /// handler dispatches `SetScannerEnabled(false)` to the
     /// engine, so no explicit DSP send is needed here.
     fn trigger(&self, reason: &str) {
-        if !self.scanner_panel.master_switch.is_active() {
+        let Some(master_switch) = self.master_switch.upgrade() else {
+            return;
+        };
+        if !master_switch.is_active() {
             return;
         }
-        self.scanner_panel.master_switch.set_active(false);
-        let toast = adw::Toast::builder()
-            .title(format!("Scanner stopped — {reason}"))
-            .timeout(SCANNER_TOAST_TIMEOUT_SECS)
-            .build();
-        self.toast_overlay.add_toast(toast);
+        master_switch.set_active(false);
+        if let Some(overlay) = self.toast_overlay.upgrade() {
+            let toast = adw::Toast::builder()
+                .title(format!("Scanner stopped — {reason}"))
+                .timeout(SCANNER_TOAST_TIMEOUT_SECS)
+                .build();
+            overlay.add_toast(toast);
+        }
     }
 }
 
@@ -331,8 +344,8 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // each handler can hold an independent clone without fighting
     // over ownership; internals are cheap GObject refcount bumps.
     let scanner_force_disable = Rc::new(ScannerForceDisable {
-        scanner_panel: panels.scanner.clone(),
-        toast_overlay: toast_overlay.clone(),
+        master_switch: panels.scanner.master_switch.downgrade(),
+        toast_overlay: toast_overlay.downgrade(),
     });
 
     connect_sidebar_panels(
@@ -445,26 +458,41 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         status_bar_for_freq.update_frequency(freq_f64);
         spectrum_for_freq.set_center_frequency(freq_f64);
     });
+    // Single demod-change handler: gate → force-disable → dispatch
+    // → cosmetic UI updates. Order matters: force-disable must
+    // reach the engine BEFORE SetDemodMode so the scanner isn't
+    // still rotating when the new demod lands. Previously the
+    // dispatch lived in build_header_bar and force-disable here,
+    // which left a race because GTK fires handlers in
+    // registration order.
     let status_bar_for_demod = Rc::clone(&status_bar_demod);
     let bw_row_for_demod = panels.radio.bandwidth_row.clone();
     let radio_for_demod = panels.radio.clone();
     let force_disable_demod = Rc::clone(&scanner_force_disable);
-    let state_demod_suppress = Rc::clone(&state);
+    let state_demod = Rc::clone(&state);
     demod_dropdown.connect_selected_notify(move |dd| {
-        if let Some(mode) = demod_selector::index_to_demod_mode(dd.selected()) {
-            let label = header::demod_mode_label(mode);
-            let bw = bw_row_for_demod.value();
-            status_bar_for_demod.update_demod(label, bw);
-            radio_for_demod.apply_demod_visibility(mode);
-            // Force-disable scanner — but only on a genuinely
-            // user-initiated change. The ScannerActiveChannelChanged
-            // fan-out uses `state.suppress_demod_notify` to mark
-            // scanner-driven dropdown updates; mirror that gate
-            // here so scanner's own retunes don't self-disable.
-            if !state_demod_suppress.suppress_demod_notify.get() {
-                force_disable_demod.trigger("manual demod change");
-            }
+        // DSP-origin guard — when the scanner's
+        // ScannerActiveChannelChanged fan-out programmatically
+        // changes the dropdown, skip EVERYTHING (dispatch and
+        // force-disable and cosmetic updates are all paid for
+        // by the scanner's own widget-sync code).
+        if state_demod.suppress_demod_notify.get() {
+            return;
         }
+        let Some(mode) = demod_selector::index_to_demod_mode(dd.selected()) else {
+            return;
+        };
+        // Stop scanner BEFORE queuing SetDemodMode so the engine
+        // receives the commands in the right order.
+        force_disable_demod.trigger("manual demod change");
+        state_demod.demod_mode.set(mode);
+        state_demod.send_dsp(UiToDsp::SetDemodMode(mode));
+        tracing::debug!(?mode, "demod mode sent to DSP");
+        // Cosmetic UI sync last.
+        let label = header::demod_mode_label(mode);
+        let bw = bw_row_for_demod.value();
+        status_bar_for_demod.update_demod(label, bw);
+        radio_for_demod.apply_demod_visibility(mode);
     });
 
     // --- Wire radio panel bandwidth changes to status bar ---
@@ -1182,24 +1210,13 @@ fn build_header_bar(
     // so it can also update the status bar.
     let freq_selector = header::build_frequency_selector();
 
-    // Demod selector dropdown
+    // Demod selector dropdown. The DSP-dispatch handler used to
+    // live here, but it would race the scanner force-disable
+    // that runs from build_window's handler — scanner would hear
+    // SetDemodMode first, then the stop command. Dispatch wiring
+    // moved to build_window so force-disable + send_dsp can run
+    // in a single handler in the right order.
     let (demod_dropdown, _demod_mode_cell) = header::build_demod_selector();
-    let state_demod = Rc::clone(state);
-    demod_dropdown.connect_selected_notify(move |dd| {
-        // `suppress_demod_notify` is the DSP-origin guard — when
-        // the scanner's `ScannerActiveChannelChanged` fan-out sets
-        // the dropdown programmatically, we do NOT want to dispatch
-        // `SetDemodMode` back to the engine (it'd tear down the
-        // scanner-driven retune the UI is only trying to reflect).
-        if state_demod.suppress_demod_notify.get() {
-            return;
-        }
-        if let Some(mode) = demod_selector::index_to_demod_mode(dd.selected()) {
-            state_demod.demod_mode.set(mode);
-            state_demod.send_dsp(UiToDsp::SetDemodMode(mode));
-            tracing::debug!(?mode, "demod mode sent to DSP");
-        }
-    });
 
     // Volume button (ScaleButton with audio icons)
     let volume_button = gtk4::ScaleButton::new(

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -4752,9 +4752,9 @@ fn connect_navigation_panel(
         // Both bookmark recall AND band-preset selection come in
         // through this callback (the preset handler in
         // `connect_preset_to_bookmarks` invokes `on_navigate` with
-        // a synthesized Bookmark). Treat both as manual tunes
-        // that preempt the scanner.
-        force_disable_nav.trigger("bookmark recall");
+        // a synthesized Bookmark). Keep the toast reason neutral
+        // so a preset click doesn't claim "bookmark recall".
+        force_disable_nav.trigger("preset/bookmark selection");
 
         let freq = bookmark.frequency;
         let mode = sidebar::navigation_panel::parse_demod_mode(&bookmark.demod_mode);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -927,6 +927,14 @@ fn handle_dsp_message(
                 radio_panel.ctcss_row.set_selected(ctcss_idx);
                 if let Some(vs_mode) = voice_squelch {
                     radio_panel.apply_voice_squelch_mode_ui(vs_mode);
+                    // Reset the open/closed badge too — mode
+                    // change rebuilds the voice-squelch detector,
+                    // so a stale "open" from the previous channel
+                    // must not carry over. The next
+                    // `VoiceSquelchOpenChanged` edge from DSP
+                    // repaints it accurately. Mirrors the manual
+                    // selector path at `voice_squelch_row.connect_selected_notify`.
+                    radio_panel.set_voice_squelch_open(false);
                 }
 
                 scanner_panel.lockout_button.set_visible(true);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -890,6 +890,13 @@ fn handle_dsp_message(
                     demod_dropdown.set_selected(idx);
                 }
                 state.suppress_demod_notify.set(false);
+                // Mode-specific row visibility (WFM stereo,
+                // FM-IF-NR, etc.) is normally driven by the
+                // dropdown's `connect_selected_notify` handler,
+                // which we just suppressed. Call it directly so
+                // the radio panel reflects the scanner's channel
+                // instead of the previous mode's row set.
+                radio_panel.apply_demod_visibility(demod_mode);
                 state.suppress_bandwidth_notify.set(true);
                 radio_panel.bandwidth_row.set_value(bandwidth);
                 state.suppress_bandwidth_notify.set(false);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -75,21 +75,19 @@ const SCANNER_TOAST_TIMEOUT_SECS: u32 = 3;
 struct ScannerForceDisable {
     scanner_panel: sidebar::scanner_panel::ScannerPanel,
     toast_overlay: adw::ToastOverlay,
-    state: Rc<AppState>,
 }
 
 impl ScannerForceDisable {
     /// Force the scanner off and toast the user about why. No-op
-    /// when scanner is already off. Uses the explicit dispatch +
-    /// `set_state` pattern so the engine-side teardown lands
-    /// regardless of GTK binding semantics around whether
-    /// `set_state` re-fires `state-set`.
+    /// when scanner is already off. Calls `set_active(false)` on
+    /// the master switch — the switch's `connect_active_notify`
+    /// handler dispatches `SetScannerEnabled(false)` to the
+    /// engine, so no explicit DSP send is needed here.
     fn trigger(&self, reason: &str) {
-        if !self.scanner_panel.master_switch.state() {
+        if !self.scanner_panel.master_switch.is_active() {
             return;
         }
-        self.state.send_dsp(UiToDsp::SetScannerEnabled(false));
-        self.scanner_panel.master_switch.set_state(false);
+        self.scanner_panel.master_switch.set_active(false);
         let toast = adw::Toast::builder()
             .title(format!("Scanner stopped — {reason}"))
             .timeout(SCANNER_TOAST_TIMEOUT_SECS)
@@ -335,7 +333,6 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let scanner_force_disable = Rc::new(ScannerForceDisable {
         scanner_panel: panels.scanner.clone(),
         toast_overlay: toast_overlay.clone(),
-        state: Rc::clone(&state),
     });
 
     connect_sidebar_panels(
@@ -832,6 +829,17 @@ fn handle_dsp_message(
             // during this frame sees the latest key.
             state.scanner_active_key.borrow_mut().clone_from(&key);
             if key.is_some() {
+                // Update the cached tuning state so downstream
+                // reads (bandwidth notify's status-bar rewrite,
+                // Add / Save Bookmark, anything else that reads
+                // `state.center_frequency` / `state.demod_mode`)
+                // see the scanner's current channel, not the
+                // channel the user last tuned manually.
+                #[allow(clippy::cast_precision_loss)]
+                let freq_f64 = freq_hz as f64;
+                state.center_frequency.set(freq_f64);
+                state.demod_mode.set(demod_mode);
+
                 scanner_panel.active_channel_label.set_text(&format!(
                     "Active: {} — {}",
                     name,
@@ -841,8 +849,6 @@ fn handle_dsp_message(
                 // The selector's `set_frequency` does NOT fire its
                 // own callback, so no SetFrequency bounces back.
                 freq_selector.set_frequency(freq_hz);
-                #[allow(clippy::cast_precision_loss)]
-                let freq_f64 = freq_hz as f64;
                 spectrum_handle.set_center_frequency(freq_f64);
                 status_bar.update_frequency(freq_f64);
                 let label = header::demod_selector::demod_mode_label(demod_mode);
@@ -1446,12 +1452,21 @@ fn connect_sidebar_panels(
     // keeps the projection against the live backing store
     // without having to capture the `Rc<RefCell<Vec<Bookmark>>>`
     // separately.
-    let bookmarks_for_mutated = Rc::clone(&panels.bookmarks);
+    // The callback is stored inside `BookmarksPanel.on_mutated`,
+    // so capturing a strong `Rc<BookmarksPanel>` here would close
+    // a retain cycle (panel → on_mutated → closure → panel) and
+    // leak on teardown. Downgrade to `Weak` + upgrade-or-return
+    // inside the closure — same pattern the Save closure uses in
+    // `sidebar::build_sidebar`.
+    let bookmarks_weak = Rc::downgrade(&panels.bookmarks);
     let state_for_mutated = Rc::clone(state);
     let config_for_mutated = std::sync::Arc::clone(config);
     panels.bookmarks.connect_mutated(move || {
+        let Some(bookmarks) = bookmarks_weak.upgrade() else {
+            return;
+        };
         sidebar::navigation_panel::project_and_push_scanner_channels(
-            &bookmarks_for_mutated.bookmarks.borrow(),
+            &bookmarks.bookmarks.borrow(),
             &state_for_mutated,
             &config_for_mutated,
         );
@@ -5171,15 +5186,22 @@ fn connect_scanner_panel(
 ) {
     let scanner = &panels.scanner;
 
-    // Master switch → SetScannerEnabled. `connect_state_set`
-    // fires before the internal state change commits, letting
-    // future work (Task 3.3's empty-rotation recovery) reject a
-    // toggle by returning `glib::Propagation::Stop`. Today every
-    // user toggle proceeds.
+    // Master switch → SetScannerEnabled. Using `connect_active_notify`
+    // (not `connect_state_set`) so programmatic toggles fire too:
+    //   - F8 shortcut calls `set_active` which changes the active
+    //     property and fires notify::active.
+    //   - `ScannerForceDisable::trigger` calls `set_active(false)`
+    //     on the same switch for manual-tune force-disable.
+    //   - DSP-origin widget syncs (ScannerEmptyRotation,
+    //     ScannerMutexStopped::ScannerStopped*) call `set_state`,
+    //     which also propagates to active and fires notify::active.
+    //     The resulting redundant `SetScannerEnabled(false)`
+    //     dispatch is idempotent at the engine — it's cheaper to
+    //     pay one extra message per event than to add a suppress
+    //     flag for every DSP-origin sync site.
     let state_switch = Rc::clone(state);
-    scanner.master_switch.connect_state_set(move |_, active| {
-        state_switch.send_dsp(UiToDsp::SetScannerEnabled(active));
-        glib::Propagation::Proceed
+    scanner.master_switch.connect_active_notify(move |sw| {
+        state_switch.send_dsp(UiToDsp::SetScannerEnabled(sw.is_active()));
     });
 
     // Default dwell slider: persist on every value change, then

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -62,6 +62,42 @@ const DECIMATION_FACTORS: &[u32] = &[1, 2, 4, 8, 16];
 /// Interval in milliseconds for polling the DSP→UI channel.
 const DSP_POLL_INTERVAL_MS: u64 = 16;
 
+/// Toast display time (seconds) for scanner "force-disable" notices.
+const SCANNER_TOAST_TIMEOUT_SECS: u32 = 3;
+
+/// Shared "kill the scanner on a manual tune" hook. Built once in
+/// `build_window` and cloned into every manual-change handler
+/// (frequency selector, demod dropdown, bandwidth row, bookmark
+/// recall / preset selection). Calling [`Self::trigger`] is a
+/// no-op when the scanner is already off, so wiring it into a
+/// handler that fires during programmatic widget updates is
+/// cheap and idempotent.
+struct ScannerForceDisable {
+    scanner_panel: sidebar::scanner_panel::ScannerPanel,
+    toast_overlay: adw::ToastOverlay,
+    state: Rc<AppState>,
+}
+
+impl ScannerForceDisable {
+    /// Force the scanner off and toast the user about why. No-op
+    /// when scanner is already off. Uses the explicit dispatch +
+    /// `set_state` pattern so the engine-side teardown lands
+    /// regardless of GTK binding semantics around whether
+    /// `set_state` re-fires `state-set`.
+    fn trigger(&self, reason: &str) {
+        if !self.scanner_panel.master_switch.state() {
+            return;
+        }
+        self.state.send_dsp(UiToDsp::SetScannerEnabled(false));
+        self.scanner_panel.master_switch.set_state(false);
+        let toast = adw::Toast::builder()
+            .title(format!("Scanner stopped — {reason}"))
+            .timeout(SCANNER_TOAST_TIMEOUT_SECS)
+            .build();
+        self.toast_overlay.add_toast(toast);
+    }
+}
+
 /// Build and present the main application window.
 #[allow(clippy::too_many_lines)]
 pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::ConfigManager>) {
@@ -290,6 +326,17 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // --- Wire sidebar panels and frequency/demod to DSP + status bar ---
     let status_bar_demod = Rc::new(status_bar);
 
+    // Shared force-disable hook — cloned into every manual-change
+    // handler so a user tune / demod switch / bandwidth tweak /
+    // bookmark recall drops the scanner out of rotation. Rc so
+    // each handler can hold an independent clone without fighting
+    // over ownership; internals are cheap GObject refcount bumps.
+    let scanner_force_disable = Rc::new(ScannerForceDisable {
+        scanner_panel: panels.scanner.clone(),
+        toast_overlay: toast_overlay.clone(),
+        state: Rc::clone(&state),
+    });
+
     connect_sidebar_panels(
         &panels,
         &state,
@@ -300,6 +347,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         &toast_overlay,
         config,
         &favorites_handle,
+        &scanner_force_disable,
     );
 
     // Wire waterfall screenshot button.
@@ -372,8 +420,14 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let status_bar_for_freq = Rc::clone(&status_bar_demod);
     let state_freq = Rc::clone(&state);
     let spectrum_for_freq = Rc::clone(&spectrum_handle);
+    let force_disable_freq = Rc::clone(&scanner_force_disable);
     freq_selector.connect_frequency_changed(move |freq| {
         tracing::debug!(frequency_hz = freq, "frequency changed");
+        // Flip scanner off before dispatching the tune so the
+        // engine receives the `SetScannerEnabled(false)` first —
+        // the subsequent `Tune` then lands on an Idle scanner and
+        // doesn't race a retune command.
+        force_disable_freq.trigger("manual tune");
         #[allow(clippy::cast_precision_loss)]
         let freq_f64 = freq as f64;
         state_freq.center_frequency.set(freq_f64);
@@ -384,12 +438,22 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let status_bar_for_demod = Rc::clone(&status_bar_demod);
     let bw_row_for_demod = panels.radio.bandwidth_row.clone();
     let radio_for_demod = panels.radio.clone();
+    let force_disable_demod = Rc::clone(&scanner_force_disable);
+    let state_demod_suppress = Rc::clone(&state);
     demod_dropdown.connect_selected_notify(move |dd| {
         if let Some(mode) = demod_selector::index_to_demod_mode(dd.selected()) {
             let label = header::demod_mode_label(mode);
             let bw = bw_row_for_demod.value();
             status_bar_for_demod.update_demod(label, bw);
             radio_for_demod.apply_demod_visibility(mode);
+            // Force-disable scanner — but only on a genuinely
+            // user-initiated change. The ScannerActiveChannelChanged
+            // fan-out uses `state.suppress_demod_notify` to mark
+            // scanner-driven dropdown updates; mirror that gate
+            // here so scanner's own retunes don't self-disable.
+            if !state_demod_suppress.suppress_demod_notify.get() {
+                force_disable_demod.trigger("manual demod change");
+            }
         }
     });
 
@@ -749,6 +813,11 @@ fn handle_dsp_message(
             bandwidth,
             name,
         } => {
+            // Cache the active channel key for the lockout button
+            // click handler in `connect_scanner_panel`. Written
+            // before the widget sync below so a racing user click
+            // during this frame sees the latest key.
+            state.scanner_active_key.borrow_mut().clone_from(&key);
             if key.is_some() {
                 scanner_panel.active_channel_label.set_text(&format!(
                     "Active: {} — {}",
@@ -1316,6 +1385,7 @@ fn connect_sidebar_panels(
     toast_overlay: &adw::ToastOverlay,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
     favorites_header: &FavoritesHeaderHandle,
+    scanner_force_disable: &Rc<ScannerForceDisable>,
 ) {
     // Shared "is the rtl_tcp server currently live?" flag. Written by
     // the server panel's start/stop handler, read by the source
@@ -1337,7 +1407,7 @@ fn connect_sidebar_panels(
     connect_source_rtlsdr_probe(panels);
     connect_rtl_tcp_discovery(panels, state, config, favorites_header);
     connect_server_panel(panels, toast_overlay, server_running);
-    connect_radio_panel(panels, state);
+    connect_radio_panel(panels, state, scanner_force_disable);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
     connect_scanner_panel(panels, state, config);
@@ -1349,6 +1419,7 @@ fn connect_sidebar_panels(
         demod_dropdown,
         status_bar,
         spectrum_handle,
+        scanner_force_disable,
     );
 
     // Mutation-triggered scanner re-projection. Fires on scan
@@ -4129,7 +4200,11 @@ fn connect_source_panel(
 
 /// Connect radio panel controls to DSP commands.
 #[allow(clippy::too_many_lines)]
-fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
+fn connect_radio_panel(
+    panels: &SidebarPanels,
+    state: &Rc<AppState>,
+    scanner_force_disable: &Rc<ScannerForceDisable>,
+) {
     // Bandwidth. The DSP can originate a change too (VFO drag on
     // the spectrum dispatches `UiToDsp::SetBandwidth` directly,
     // and the controller echoes `DspToUi::BandwidthChanged` so the
@@ -4139,10 +4214,16 @@ fn connect_radio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
     // handler to skip the DSP dispatch when the change originated
     // on the DSP side.
     let state_bw = Rc::clone(state);
+    let force_disable_bw = Rc::clone(scanner_force_disable);
     panels.radio.bandwidth_row.connect_value_notify(move |row| {
         if state_bw.suppress_bandwidth_notify.get() {
             return;
         }
+        // Not a DSP echo → this is the user turning the spin row.
+        // Force-disable scanner so the new bandwidth applies to
+        // the user's chosen channel instead of the scanner's next
+        // hop.
+        force_disable_bw.trigger("manual bandwidth change");
         state_bw.send_dsp(UiToDsp::SetBandwidth(row.value()));
     });
 
@@ -4602,6 +4683,7 @@ fn connect_navigation_panel(
     demod_dropdown: &gtk4::DropDown,
     status_bar: &Rc<StatusBar>,
     spectrum_handle: &Rc<spectrum::SpectrumHandle>,
+    scanner_force_disable: &Rc<ScannerForceDisable>,
 ) {
     // Navigation callback: restore full tuning profile from bookmark.
     let state_nav = Rc::clone(state);
@@ -4612,8 +4694,16 @@ fn connect_navigation_panel(
     let radio_nav = panels.radio.clone();
     let source_nav_gain = panels.source.gain_row.clone();
     let source_nav_agc = panels.source.agc_row.clone();
+    let force_disable_nav = Rc::clone(scanner_force_disable);
 
     panels.bookmarks.connect_navigate(move |bookmark| {
+        // Both bookmark recall AND band-preset selection come in
+        // through this callback (the preset handler in
+        // `connect_preset_to_bookmarks` invokes `on_navigate` with
+        // a synthesized Bookmark). Treat both as manual tunes
+        // that preempt the scanner.
+        force_disable_nav.trigger("bookmark recall");
+
         let freq = bookmark.frequency;
         let mode = sidebar::navigation_panel::parse_demod_mode(&bookmark.demod_mode);
         let bw = bookmark.bandwidth;
@@ -5111,6 +5201,22 @@ fn connect_scanner_panel(
             &state_hang,
             &config_hang_project,
         );
+    });
+
+    // Lockout button → `LockoutScannerChannel(key)`. The active
+    // channel key is updated on every `ScannerActiveChannelChanged`
+    // in `handle_dsp_message` and stashed on `state.scanner_active_key`.
+    // The button is hidden whenever that key is `None` (same
+    // handler), so a click here is guaranteed to have a key —
+    // but we check and early-return defensively in case a click
+    // races a state change.
+    let state_lockout = Rc::clone(state);
+    scanner.lockout_button.connect_clicked(move |_| {
+        let Some(key) = state_lockout.scanner_active_key.borrow().clone() else {
+            tracing::debug!("lockout clicked with no active key — no-op");
+            return;
+        };
+        state_lockout.send_dsp(UiToDsp::LockoutScannerChannel(key));
     });
 
     // Restore persisted slider values. Runs after the notify

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -969,7 +969,7 @@ fn handle_dsp_message(
             let label = match scanner_state {
                 sdr_scanner::ScannerState::Idle => "Off",
                 sdr_scanner::ScannerState::Retuning => "Scanning…",
-                sdr_scanner::ScannerState::Dwelling => "Listening…",
+                sdr_scanner::ScannerState::Dwelling => "Dwelling…",
                 sdr_scanner::ScannerState::Listening => "Listening",
                 sdr_scanner::ScannerState::Hanging => "Hang…",
             };

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1296,6 +1296,7 @@ fn connect_sidebar_panels(
     connect_radio_panel(panels, state);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
+    connect_scanner_panel(panels, state, config);
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
         panels,
@@ -4984,6 +4985,65 @@ fn unlock_transcription_session_rows(
     if let Some(row) = auto_break_min_segment_row.upgrade() {
         row.set_sensitive(true);
     }
+}
+
+/// Connect scanner panel controls to DSP commands.
+///
+/// Wiring in this pass (Task 3.2):
+/// - master switch → `UiToDsp::SetScannerEnabled`
+/// - default dwell / hang sliders → persist to `ConfigManager`
+///
+/// Slider changes do NOT yet dispatch `UpdateScannerChannels` —
+/// that re-projection helper lives in `navigation_panel` and is
+/// added alongside the bookmark scan-checkbox work in Task 3.4.
+/// Until then, slider edits take effect on the next channel-list
+/// mutation (bookmark add / delete / scan-toggle). Acceptable
+/// because sliders and bookmarks ship in the same PR.
+fn connect_scanner_panel(
+    panels: &SidebarPanels,
+    state: &Rc<AppState>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
+    let scanner = &panels.scanner;
+
+    // Master switch → SetScannerEnabled. `connect_state_set`
+    // fires before the internal state change commits, letting
+    // future work (Task 3.3's empty-rotation recovery) reject a
+    // toggle by returning `glib::Propagation::Stop`. Today every
+    // user toggle proceeds.
+    let state_switch = Rc::clone(state);
+    scanner.master_switch.connect_state_set(move |_, active| {
+        state_switch.send_dsp(UiToDsp::SetScannerEnabled(active));
+        glib::Propagation::Proceed
+    });
+
+    // Default dwell slider: persist on every value change. The
+    // channel-list re-projection on slider mutation is wired in
+    // Task 3.4 once the `project_and_push_scanner_channels`
+    // helper lands. Overrides on individual bookmarks win over
+    // this default at projection time.
+    let config_dwell = std::sync::Arc::clone(config);
+    scanner.default_dwell_row.connect_value_notify(move |row| {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let ms = row.value() as u32;
+        sidebar::scanner_panel::save_default_dwell_ms(&config_dwell, ms);
+    });
+
+    // Default hang slider: same pattern as dwell.
+    let config_hang = std::sync::Arc::clone(config);
+    scanner.default_hang_row.connect_value_notify(move |row| {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let ms = row.value() as u32;
+        sidebar::scanner_panel::save_default_hang_ms(&config_hang, ms);
+    });
+
+    // Restore persisted slider values. Runs after the notify
+    // handlers are wired, so `set_value` on a non-default
+    // persisted value re-saves the same value — idempotent.
+    let dwell_ms = sidebar::scanner_panel::load_default_dwell_ms(config);
+    scanner.default_dwell_row.set_value(f64::from(dwell_ms));
+    let hang_ms = sidebar::scanner_panel::load_default_hang_ms(config);
+    scanner.default_hang_row.set_value(f64::from(hang_ms));
 }
 
 /// Connect transcript panel controls to DSP commands.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -635,6 +635,29 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     window.present();
 }
 
+/// Clear the scanner's active-channel UI surfaces back to the
+/// idle look: empty cache, placeholder label, hidden lockout
+/// button. Shared between the four events that mean "scanner
+/// isn't parked on a channel anymore":
+///   - `ScannerActiveChannelChanged { key: None }` (explicit
+///     idle edge)
+///   - `ScannerEmptyRotation` (rotation exhausted)
+///   - `ScannerMutexStopped::ScannerStoppedFor{Recording,Transcription}`
+///     (mutex fired)
+///
+/// Without the helper, those stop paths would depend on the
+/// engine sending a separate `ActiveChannelChanged { key: None }`
+/// event in the same tick — which it does today, but relying on
+/// that ordering across four sites was brittle.
+fn clear_scanner_active_channel_ui(
+    scanner_panel: &sidebar::scanner_panel::ScannerPanel,
+    state: &AppState,
+) {
+    *state.scanner_active_key.borrow_mut() = None;
+    scanner_panel.active_channel_label.set_text("Active: —");
+    scanner_panel.lockout_button.set_visible(false);
+}
+
 /// Handle a single message from the DSP thread.
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn handle_dsp_message(
@@ -939,8 +962,7 @@ fn handle_dsp_message(
 
                 scanner_panel.lockout_button.set_visible(true);
             } else {
-                scanner_panel.active_channel_label.set_text("Active: —");
-                scanner_panel.lockout_button.set_visible(false);
+                clear_scanner_active_channel_ui(scanner_panel, state);
             }
         }
         DspToUi::ScannerStateChanged(scanner_state) => {
@@ -969,6 +991,12 @@ fn handle_dsp_message(
             // redundant `SetScannerEnabled(false)` — idempotent on
             // the engine side (scanner's already Idle), so no harm.
             scanner_panel.master_switch.set_state(false);
+            // Clear the active-channel surfaces locally rather
+            // than waiting for a separate `ActiveChannelChanged
+            // { key: None }` event — the engine sends it today,
+            // but relying on that ordering across four stop
+            // sites was brittle.
+            clear_scanner_active_channel_ui(scanner_panel, state);
         }
         DspToUi::ScannerMutexStopped(reason) => {
             tracing::info!(?reason, "scanner mutex stopped");
@@ -989,10 +1017,12 @@ fn handle_dsp_message(
                 }
                 sdr_core::messages::ScannerMutexReason::ScannerStoppedForRecording => {
                     scanner_panel.master_switch.set_state(false);
+                    clear_scanner_active_channel_ui(scanner_panel, state);
                     "Scanner stopped — recording started"
                 }
                 sdr_core::messages::ScannerMutexReason::ScannerStoppedForTranscription => {
                     scanner_panel.master_switch.set_state(false);
+                    clear_scanner_active_channel_ui(scanner_panel, state);
                     "Scanner stopped — transcription started"
                 }
             };
@@ -5268,6 +5298,19 @@ fn connect_scanner_panel(
         state_switch.send_dsp(UiToDsp::SetScannerEnabled(sw.is_active()));
     });
 
+    // Restore persisted slider values BEFORE wiring the notify
+    // handlers below. `set_value` on a SpinRow fires
+    // `value-changed`, so if we wired first and restored after
+    // we'd trigger a spurious `save_default_*_ms` +
+    // `project_and_push_scanner_channels` during window
+    // construction — plus `build_window` re-seeds the scanner
+    // right after `connect_sidebar_panels` returns, which would
+    // pile on a second redundant dispatch per slider.
+    let dwell_ms = sidebar::scanner_panel::load_default_dwell_ms(config);
+    scanner.default_dwell_row.set_value(f64::from(dwell_ms));
+    let hang_ms = sidebar::scanner_panel::load_default_hang_ms(config);
+    scanner.default_hang_row.set_value(f64::from(hang_ms));
+
     // Default dwell slider: persist on every value change, then
     // re-project the bookmark list so `ScannerChannel::dwell_ms`
     // picks up the new default on channels without an override.
@@ -5317,14 +5360,6 @@ fn connect_scanner_panel(
         };
         state_lockout.send_dsp(UiToDsp::LockoutScannerChannel(key));
     });
-
-    // Restore persisted slider values. Runs after the notify
-    // handlers are wired, so `set_value` on a non-default
-    // persisted value re-saves the same value — idempotent.
-    let dwell_ms = sidebar::scanner_panel::load_default_dwell_ms(config);
-    scanner.default_dwell_row.set_value(f64::from(dwell_ms));
-    let hang_ms = sidebar::scanner_panel::load_default_hang_ms(config);
-    scanner.default_hang_row.set_value(f64::from(hang_ms));
 }
 
 /// Connect transcript panel controls to DSP commands.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1502,16 +1502,15 @@ fn connect_sidebar_panels(
     // this *after* `connect_sidebar_panels` finishes the other
     // panel wiring so early construction-time rebuilds (which
     // pre-date the callback) don't dispatch a spurious empty
-    // `UpdateScannerChannels`. The closure holds an `Rc` clone
-    // of `BookmarksPanel` and reads `.bookmarks` at call time —
-    // keeps the projection against the live backing store
-    // without having to capture the `Rc<RefCell<Vec<Bookmark>>>`
-    // separately.
-    // The callback is stored inside `BookmarksPanel.on_mutated`,
-    // so capturing a strong `Rc<BookmarksPanel>` here would close
-    // a retain cycle (panel → on_mutated → closure → panel) and
-    // leak on teardown. Downgrade to `Weak` + upgrade-or-return
-    // inside the closure — same pattern the Save closure uses in
+    // `UpdateScannerChannels`.
+    //
+    // The callback lives inside `BookmarksPanel.on_mutated`, so
+    // capturing a strong `Rc<BookmarksPanel>` would close a
+    // retain cycle (panel → on_mutated → closure → panel) and
+    // leak on teardown. Downgrade to `Weak` and upgrade-or-return
+    // inside the closure — reads `.bookmarks` via the upgraded
+    // handle so the projection still lands against the live
+    // backing store. Same pattern the Save closure uses in
     // `sidebar::build_sidebar`.
     let bookmarks_weak = Rc::downgrade(&panels.bookmarks);
     let state_for_mutated = Rc::clone(state);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -310,6 +310,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         &sidebar_toggle,
         &bookmarks_toggle,
         &demod_dropdown,
+        &panels.scanner.master_switch,
     );
 
     // Ctrl+? shows keyboard shortcuts dialog.
@@ -348,6 +349,18 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         config,
         &favorites_handle,
         &scanner_force_disable,
+    );
+
+    // Seed the scanner with the persisted bookmark list on
+    // startup. Scanner starts Idle so no retune happens, but
+    // the channels are in place if the user flips F8 or the
+    // master switch. Defaults come from config via the shared
+    // projection helper — matches the on-mutation re-projection
+    // path so initial-load and post-edit semantics are identical.
+    sidebar::navigation_panel::project_and_push_scanner_channels(
+        &panels.bookmarks.bookmarks.borrow(),
+        &state,
+        config,
     );
 
     // Wire waterfall screenshot button.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -432,6 +432,9 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let record_audio_for_dsp = panels.audio.record_audio_row.clone();
     let record_iq_for_dsp = panels.source.record_iq_row.clone();
     let radio_panel_for_dsp = panels.radio.clone();
+    let scanner_panel_for_dsp = panels.scanner.clone();
+    let freq_selector_for_dsp = freq_selector.clone();
+    let demod_dropdown_for_dsp = demod_dropdown.clone();
     // Just the three widgets the rtl_tcp status renderer touches —
     // cloning the whole SourcePanel would be a lot of refcount
     // traffic for one signal handler. Weak refs, upgraded per
@@ -497,6 +500,9 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                         &record_audio_for_dsp,
                         &record_iq_for_dsp,
                         &radio_panel_for_dsp,
+                        &scanner_panel_for_dsp,
+                        &freq_selector_for_dsp,
+                        &demod_dropdown_for_dsp,
                         &rtl_tcp_status_row_weak,
                         &rtl_tcp_disconnect_button_weak,
                         &rtl_tcp_retry_button_weak,
@@ -540,6 +546,9 @@ fn handle_dsp_message(
     record_audio_row: &adw::SwitchRow,
     record_iq_row: &adw::SwitchRow,
     radio_panel: &sidebar::radio_panel::RadioPanel,
+    scanner_panel: &sidebar::scanner_panel::ScannerPanel,
+    freq_selector: &header::frequency_selector::FrequencySelector,
+    demod_dropdown: &gtk4::DropDown,
     rtl_tcp_status_row_weak: &glib::WeakRef<adw::ActionRow>,
     rtl_tcp_disconnect_button_weak: &glib::WeakRef<gtk4::Button>,
     rtl_tcp_retry_button_weak: &glib::WeakRef<gtk4::Button>,
@@ -733,17 +742,6 @@ fn handle_dsp_message(
             }
         }
         // --- Scanner (#317) ---
-        //
-        // `ScannerActiveChannelChanged` and `ScannerStateChanged`
-        // are still stubs here — their fan-out to the frequency
-        // selector, spectrum, status bar, demod dropdown, and
-        // bandwidth row is PR 3 work. `ScannerEmptyRotation` and
-        // `ScannerMutexStopped` ARE promoted to real toasts +
-        // widget deactivation in this PR because they fire
-        // immediately as soon as the mutex kicks in (which
-        // happens as soon as a future caller dispatches
-        // `UiToDsp::SetScannerEnabled(true)`, which could be
-        // driven by a test harness before the PR 3 panel lands).
         DspToUi::ScannerActiveChannelChanged {
             key,
             freq_hz,
@@ -751,20 +749,51 @@ fn handle_dsp_message(
             bandwidth,
             name,
         } => {
-            tracing::debug!(
-                ?key,
-                freq_hz,
-                ?demod_mode,
-                bandwidth,
-                name,
-                "scanner active channel changed — UI fan-out lands in PR 3"
-            );
+            if key.is_some() {
+                scanner_panel.active_channel_label.set_text(&format!(
+                    "Active: {} — {}",
+                    name,
+                    sidebar::navigation_panel::format_frequency(freq_hz),
+                ));
+                // Sync every widget that mirrors the current tune.
+                // The selector's `set_frequency` does NOT fire its
+                // own callback, so no SetFrequency bounces back.
+                freq_selector.set_frequency(freq_hz);
+                #[allow(clippy::cast_precision_loss)]
+                let freq_f64 = freq_hz as f64;
+                spectrum_handle.set_center_frequency(freq_f64);
+                status_bar.update_frequency(freq_f64);
+                let label = header::demod_selector::demod_mode_label(demod_mode);
+                status_bar.update_demod(label, bandwidth);
+                // Programmatic updates of the demod dropdown +
+                // bandwidth row — suppress the notify handlers so
+                // the scanner's retune doesn't ricochet back into
+                // `SetDemodMode` / `SetBandwidth` commands.
+                state.suppress_demod_notify.set(true);
+                if let Some(idx) = header::demod_selector::demod_mode_to_index(demod_mode) {
+                    demod_dropdown.set_selected(idx);
+                }
+                state.suppress_demod_notify.set(false);
+                state.suppress_bandwidth_notify.set(true);
+                radio_panel.bandwidth_row.set_value(bandwidth);
+                state.suppress_bandwidth_notify.set(false);
+                scanner_panel.lockout_button.set_visible(true);
+            } else {
+                scanner_panel.active_channel_label.set_text("Active: —");
+                scanner_panel.lockout_button.set_visible(false);
+            }
         }
         DspToUi::ScannerStateChanged(scanner_state) => {
-            tracing::debug!(
-                ?scanner_state,
-                "scanner state changed — scanner-panel wiring lands in PR 3"
-            );
+            let label = match scanner_state {
+                sdr_scanner::ScannerState::Idle => "Off",
+                sdr_scanner::ScannerState::Retuning => "Scanning…",
+                sdr_scanner::ScannerState::Dwelling => "Listening…",
+                sdr_scanner::ScannerState::Listening => "Listening",
+                sdr_scanner::ScannerState::Hanging => "Hang…",
+            };
+            scanner_panel
+                .state_label
+                .set_text(&format!("State: {label}"));
         }
         DspToUi::ScannerEmptyRotation => {
             tracing::info!("scanner rotation empty");
@@ -773,15 +802,21 @@ fn handle_dsp_message(
                     "Scanner has no active channels (all locked or disabled)",
                 ));
             }
+            // Engine is already back to Idle — drop the master
+            // switch to match. `set_state` fires `state-set`; that
+            // handler re-dispatches `SetScannerEnabled(false)`
+            // which is idempotent on the engine side.
+            scanner_panel.master_switch.set_state(false);
         }
         DspToUi::ScannerMutexStopped(reason) => {
             tracing::info!(?reason, "scanner mutex stopped");
-            // Widget state for recording deactivates automatically
-            // via the paired `AudioRecordingStopped` /
-            // `IqRecordingStopped` events that `stop_any_recording`
-            // emits in the controller. Transcription doesn't have
-            // a matching stopped-event — deactivate the enable row
-            // explicitly here.
+            // Widget-state sync for recording comes for free via
+            // the paired `AudioRecordingStopped` / `IqRecordingStopped`
+            // events that `stop_any_recording` emits in the
+            // controller. Transcription has no matching stopped
+            // event; deactivate the switch here. Scanner sync for
+            // the `ScannerStoppedFor*` variants flips the master
+            // switch so the sidebar reflects the engine state.
             let message = match reason {
                 sdr_core::messages::ScannerMutexReason::RecordingStoppedForScanner => {
                     "Recording stopped — Scanner activated"
@@ -791,10 +826,11 @@ fn handle_dsp_message(
                     "Transcription stopped — Scanner activated"
                 }
                 sdr_core::messages::ScannerMutexReason::ScannerStoppedForRecording => {
-                    // Scanner widget state sync lands in PR 3.
+                    scanner_panel.master_switch.set_state(false);
                     "Scanner stopped — recording started"
                 }
                 sdr_core::messages::ScannerMutexReason::ScannerStoppedForTranscription => {
+                    scanner_panel.master_switch.set_state(false);
                     "Scanner stopped — transcription started"
                 }
             };
@@ -1062,6 +1098,14 @@ fn build_header_bar(
     let (demod_dropdown, _demod_mode_cell) = header::build_demod_selector();
     let state_demod = Rc::clone(state);
     demod_dropdown.connect_selected_notify(move |dd| {
+        // `suppress_demod_notify` is the DSP-origin guard — when
+        // the scanner's `ScannerActiveChannelChanged` fan-out sets
+        // the dropdown programmatically, we do NOT want to dispatch
+        // `SetDemodMode` back to the engine (it'd tear down the
+        // scanner-driven retune the UI is only trying to reflect).
+        if state_demod.suppress_demod_notify.get() {
+            return;
+        }
         if let Some(mode) = demod_selector::index_to_demod_mode(dd.selected()) {
             state_demod.demod_mode.set(mode);
             state_demod.send_dsp(UiToDsp::SetDemodMode(mode));

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1350,6 +1350,28 @@ fn connect_sidebar_panels(
         status_bar,
         spectrum_handle,
     );
+
+    // Mutation-triggered scanner re-projection. Fires on scan
+    // checkbox, priority star, and delete — every per-bookmark
+    // change that affects the projected channel list. Install
+    // this *after* `connect_sidebar_panels` finishes the other
+    // panel wiring so early construction-time rebuilds (which
+    // pre-date the callback) don't dispatch a spurious empty
+    // `UpdateScannerChannels`. The closure holds an `Rc` clone
+    // of `BookmarksPanel` and reads `.bookmarks` at call time —
+    // keeps the projection against the live backing store
+    // without having to capture the `Rc<RefCell<Vec<Bookmark>>>`
+    // separately.
+    let bookmarks_for_mutated = Rc::clone(&panels.bookmarks);
+    let state_for_mutated = Rc::clone(state);
+    let config_for_mutated = std::sync::Arc::clone(config);
+    panels.bookmarks.connect_mutated(move || {
+        sidebar::navigation_panel::project_and_push_scanner_channels(
+            &bookmarks_for_mutated.bookmarks.borrow(),
+            &state_for_mutated,
+            &config_for_mutated,
+        );
+    });
 }
 
 /// Connect source panel controls to DSP commands.
@@ -5033,16 +5055,12 @@ fn unlock_transcription_session_rows(
 
 /// Connect scanner panel controls to DSP commands.
 ///
-/// Wiring in this pass (Task 3.2):
+/// Wiring:
 /// - master switch → `UiToDsp::SetScannerEnabled`
 /// - default dwell / hang sliders → persist to `ConfigManager`
-///
-/// Slider changes do NOT yet dispatch `UpdateScannerChannels` —
-/// that re-projection helper lives in `navigation_panel` and is
-/// added alongside the bookmark scan-checkbox work in Task 3.4.
-/// Until then, slider edits take effect on the next channel-list
-/// mutation (bookmark add / delete / scan-toggle). Acceptable
-/// because sliders and bookmarks ship in the same PR.
+///   and re-project the bookmark list into
+///   `UiToDsp::UpdateScannerChannels` so a running scanner picks
+///   up the new per-channel dwell/hang on its next tick.
 fn connect_scanner_panel(
     panels: &SidebarPanels,
     state: &Rc<AppState>,
@@ -5061,24 +5079,38 @@ fn connect_scanner_panel(
         glib::Propagation::Proceed
     });
 
-    // Default dwell slider: persist on every value change. The
-    // channel-list re-projection on slider mutation is wired in
-    // Task 3.4 once the `project_and_push_scanner_channels`
-    // helper lands. Overrides on individual bookmarks win over
-    // this default at projection time.
+    // Default dwell slider: persist on every value change, then
+    // re-project the bookmark list so `ScannerChannel::dwell_ms`
+    // picks up the new default on channels without an override.
     let config_dwell = std::sync::Arc::clone(config);
+    let bookmarks_dwell = Rc::clone(&panels.bookmarks);
+    let state_dwell = Rc::clone(state);
+    let config_dwell_project = std::sync::Arc::clone(config);
     scanner.default_dwell_row.connect_value_notify(move |row| {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let ms = row.value() as u32;
         sidebar::scanner_panel::save_default_dwell_ms(&config_dwell, ms);
+        sidebar::navigation_panel::project_and_push_scanner_channels(
+            &bookmarks_dwell.bookmarks.borrow(),
+            &state_dwell,
+            &config_dwell_project,
+        );
     });
 
     // Default hang slider: same pattern as dwell.
     let config_hang = std::sync::Arc::clone(config);
+    let bookmarks_hang = Rc::clone(&panels.bookmarks);
+    let state_hang = Rc::clone(state);
+    let config_hang_project = std::sync::Arc::clone(config);
     scanner.default_hang_row.connect_value_notify(move |row| {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let ms = row.value() as u32;
         sidebar::scanner_panel::save_default_hang_ms(&config_hang, ms);
+        sidebar::navigation_panel::project_and_push_scanner_channels(
+            &bookmarks_hang.bookmarks.borrow(),
+            &state_hang,
+            &config_hang_project,
+        );
     });
 
     // Restore persisted slider values. Runs after the notify


### PR DESCRIPTION
## Summary

PR 3 of 3 for scanner Phase 1 (#317). Adds the sidebar scanner panel, bookmark row scan/priority toggles, and all UI fan-out for the scanner DSP events that landed in #372. Closes #317.

- New sidebar Scanner panel at the bottom of the left column: master switch, active-channel + state labels, lockout button, collapsed Settings expander with default dwell/hang sliders.
- Per-bookmark scan checkbox + priority toggle in each flyout row.
- Full UI sync on `ScannerActiveChannelChanged` — frequency selector, spectrum center, demod dropdown (`suppress_demod_notify` guard), bandwidth row (`suppress_bandwidth_notify` guard), status bar all follow scanner retunes.
- Force-disable-on-manual-tune at four paths: frequency selector, demod dropdown, bandwidth row, bookmark recall (which also catches band-preset selection). Each toasts the reason.
- F8 keyboard shortcut toggles the master switch; Ctrl+/ help dialog updated.
- Initial channel seed on startup — persisted bookmarks primed into the scanner at launch so F8 works immediately.
- Mutation-triggered re-projection: scan checkbox, priority star, delete, default-slider edits, and bookmark add/RR-import all refresh the scanner's channel list via the new `BookmarksPanel::connect_mutated` indirection + `project_and_push_scanner_channels` helper.

## Commits

Each task of the 3.x plan is its own commit for review.

1. `eefbe9f` sdr-ui: scanner panel scaffolding (Task 3.1)
2. `be7a818` sdr-ui: scanner master switch + default sliders wired (Task 3.2)
3. `fe6d991` sdr-ui: scanner `DspToUi` events → UI fan-out (Task 3.3)
4. `e95ec7d` sdr-ui: bookmark scan checkbox + priority toggle + projection helper (Task 3.4)
5. `489b8f1` sdr-ui: lockout button + manual-tune force-disables scanner (Task 3.5)
6. `8d825f9` sdr-ui: initial scanner channel seed + F8 shortcut (Task 3.6)
7. `a4b73e5` sdr-ui: ellipsize scanner active-channel + state labels (live-caught during smoke test)

## Key design notes

- **Scanner logic owns state, UI owns defaults.** `ScannerChannel::dwell_ms` / `hang_ms` resolution happens at projection time via `project_scanner_channels` — per-bookmark override wins, else UI-side defaults from `ConfigManager`. Scanner itself has no defaults, matching the Phase 1 design.
- **One indirection for every mutation.** `BookmarksPanel::on_mutated` callback is invoked from scan-checkbox toggle, priority toggle, delete, and the flyout rebuilds; the window.rs-side closure projects bookmarks + dispatches `UpdateScannerChannels`. Keeps the "anything that changes the channel set" contract in one place.
- **`set_state` vs `set_active` on `gtk4::Switch`.** Used `set_state` (does NOT fire `state-set`) for DSP-originated widget sync (e.g. `ScannerEmptyRotation` reflecting engine's return to Idle — no redundant dispatch). Used `set_active` for the F8 shortcut so the engine actually hears the toggle. `ScannerForceDisable` explicitly dispatches + `set_state` because it needs the engine teardown regardless of binding semantics.
- **`suppress_demod_notify` / `suppress_bandwidth_notify`.** Scanner-driven programmatic dropdown / spinrow updates set the guard before and clear it after, so the notify handlers skip both the DSP dispatch AND the force-disable-scanner check. Same re-entrancy pattern the bandwidth row has carried since the VFO-drag work.

## Test plan

- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --workspace --lib` clean (136 sdr-ui tests, 3 new for `project_scanner_channels`).
- [x] Live smoke test on RTL-SDR dongle, whisper-cuda release build:
  - Scanner scaffolding renders; master switch / labels / lockout button / Settings expander all wired.
  - Scan checkbox + priority star toggle and persist across relaunch.
  - Flipping master switch on cycles channels — State label cycles Scanning… / Listening… / Listening / Hang…; active-channel label and frequency selector and spectrum follow the hop.
  - Manual squelch path: audio plays cleanly when a channel is active.
  - Auto-squelch path: **known issue** — see #374 (updated to cover the scanner retune path too). Auto-squelch doesn't re-measure on retune, so with it enabled every hop is distortion. Manual squelch works correctly. This bug predates Phase 1; scanner retune follows the same teardown contract as manual `Tune`/`SetDemodMode`/`SetBandwidth`.
  - Manual-tune force-disable: spectrum click, demod dropdown change, bandwidth spin, bookmark recall all stop the scanner with a reasoned toast.
  - Recording / transcription mutex: starting either while scanner is on drops the scanner with a toast (engine-side fix landed in #372; this PR just wires the UI reflection).
  - F8 toggles scanner; `Ctrl+/` help shows the shortcut.

## Known issues / follow-ups

- **#374 (pre-existing)**: auto-squelch doesn't re-measure on any retune (click-to-tune, header tune, scanner retune, mode switch, etc.). Updated during this PR with scanner-retune confirmation. Fix will likely extract a shared `on_tune_change()` helper in the controller so every retune path gets the same reset set.
- Active-channel / state labels truncate to just `…` when bookmark names are long. Ellipsize guard prevents sidebar width jumping (the real smoke-test bug), but `max_width_chars(1)` is too aggressive and eats more than it should. Left as-is tonight — user has a sidebar polish pass scheduled for tomorrow.
- `ctcss_was_sustained` / `voice_squelch_was_open` edge trackers on the scanner retune mode-change path aren't reset the way `SetDemodMode` resets them (flagged during #372 round 5 reply). Probably worth a small follow-up to match.
- Per-hit recording, per-hit transcription log, band/category scanning, and the Mac SwiftUI scanner port are out of scope for Phase 1 — will open follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New scanner sidebar panel: master switch, active-channel/state display, lockout button, and persisted default dwell/hang controls with validation/clamping.
  * F8 shortcut to toggle the scanner; help entry added.
  * Per-bookmark scan-enable and priority toggles; scanner channels loaded at startup and re-projected after edits.

* **Behavior**
  * Scanner is auto-disabled before manual tune/demod/bandwidth/bookmark actions; UI synchronizes and shows stop notifications.

* **Tests**
  * Unit tests for channel projection and dwell/hang load/save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->