### PR TITLE
fix(#374): re-arm auto-squelch on every engine-side retune

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -584,6 +584,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::Tune(freq) => {
             tracing::debug!(frequency_hz = freq, "tune command");
+            on_tune_change(state);
             state.center_freq = freq;
             if let Some(source) = &mut state.source
                 && let Err(e) = source.tune(freq)
@@ -595,6 +596,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetDemodMode(mode) => {
             tracing::debug!(?mode, "set demod mode");
+            on_tune_change(state);
             let old_mode = state.radio.current_mode();
             if let Err(e) = state.radio.set_mode(mode) {
                 tracing::warn!("set demod mode failed: {e}");
@@ -674,6 +676,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetBandwidth(bw) => {
             tracing::debug!(bandwidth_hz = bw, "set bandwidth");
+            on_tune_change(state);
             // Update the VFO channel filter first; only persist on success.
             if let Some(vfo) = &mut state.vfo {
                 match vfo.set_bandwidth(bw) {
@@ -1619,6 +1622,32 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
     }
 }
 
+/// Reset the per-tune engine state that MUST NOT carry over a
+/// frequency / demod / bandwidth change:
+///
+/// 1. The controller-side squelch-edge tracker
+///    (`state.squelch_was_open`) — so a fresh `SquelchEdge::Open`
+///    at the new channel isn't suppressed by the previous
+///    channel's trailing open state. Originally added for the
+///    scanner retune path (PR #372 round 3); the same risk
+///    applies to every manual tune / mode / bandwidth change.
+///
+/// 2. Auto-squelch noise-floor tracking
+///    (`state.radio.rearm_auto_squelch`) — the floor estimate
+///    settles over seconds; carrying it from one band to
+///    another leaves the threshold pinned to the wrong value,
+///    so the new channel hard-opens (old floor was louder) or
+///    stays hard-closed (old floor was quieter). No-op when
+///    auto-squelch is disabled. Per issue #374.
+///
+/// Call from every UI-origin retune site (`UiToDsp::Tune`,
+/// `SetDemodMode`, `SetBandwidth`) and the scanner retune
+/// path. Cheap — two field writes plus an `if`-guarded reset.
+fn on_tune_change(state: &mut DspState) {
+    state.squelch_was_open = false;
+    state.radio.rearm_auto_squelch();
+}
+
 /// Is audio or IQ recording currently active?
 ///
 /// Used by future scanner tasks; suppress the unused-function lint
@@ -1692,18 +1721,19 @@ fn apply_scanner_commands(
                 // UI handler fans out to the same widgets; emitting
                 // both paths would double-drive the sync.
 
-                // Re-arm the controller's squelch-edge tracker for
-                // the new channel. Without this, if the previous
-                // channel ended open and the new channel is also
-                // open during settle, the `now_open != squelch_was_open`
-                // comparison in the IQ loop would suppress the
-                // fresh `SquelchEdge::Open` — scanner's latch
-                // would stay `false`, settle expiry would go to
-                // `Dwelling` instead of directly to `Listening`,
-                // and the `persistent_open_during_settle_goes_directly_to_listening`
-                // invariant the scanner crate tests would break
-                // at integration.
-                state.squelch_was_open = false;
+                // Reset the squelch edge tracker AND re-arm the
+                // auto-squelch noise-floor estimate for the new
+                // channel. See `on_tune_change` for the full
+                // rationale — both are critical: without the
+                // edge reset a fresh `SquelchEdge::Open` would
+                // be suppressed by a trailing-open state from
+                // the previous channel (scanner invariant
+                // `persistent_open_during_settle_goes_directly_to_listening`
+                // relies on this); without the auto-squelch
+                // re-arm the scanner inherits the previous
+                // band's noise floor, which is the same bug
+                // issue #374 describes for manual tunes.
+                on_tune_change(state);
 
                 // 1. Center frequency (mirrors `UiToDsp::Tune`).
                 #[allow(clippy::cast_precision_loss)]

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -1409,15 +1409,22 @@ mod tests {
     const STRONG_AMP: f32 = 1.0;
     const BORDERLINE_AMP: f32 = 0.003;
 
-    // Manual squelch thresholds used by the rearm tests. Both are
-    // "effectively open" compared to the expected noise amplitude
-    // so the process loop always runs the auto-squelch logic
-    // rather than short-circuiting on the manual gate.
+    // Manual squelch thresholds used by the rearm tests. The two
+    // constants are NOT interchangeable — they're deliberately
+    // picked at different points on the dB scale.
+    //
+    /// "Effectively open" manual threshold versus the expected
+    /// noise amplitude — used by the enabled-rearm test so the
+    /// process loop always exercises the auto-squelch logic
+    /// rather than short-circuiting on the manual gate.
     const REARM_MANUAL_FLOOR_DB: f32 = -100.0;
     /// Manual threshold used specifically by the
-    /// rearm-while-disabled test. Sits between `NOISE_AMP` and
-    /// the initial sentinel so a disabled squelch clearly
-    /// distinguishes from the enabled-and-settled-at-floor state.
+    /// rearm-while-disabled test. Intentionally sits between
+    /// `NOISE_AMP` and `NOISE_FLOOR_INITIAL_DB` so
+    /// "disabled squelch" is unambiguously distinct from
+    /// "enabled and settled at the floor" — protects the test
+    /// against accidentally passing if a future edit makes the
+    /// disabled path mirror the enabled-at-sentinel state.
     const REARM_DISABLED_MANUAL_DB: f32 = -50.0;
     /// Minimum rise above `NOISE_FLOOR_INITIAL_DB` (dB) that counts
     /// as "the EMA converged off the sentinel" — used to confirm

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -1589,10 +1589,33 @@ mod tests {
         // either — cheap guard against a future edit making
         // rearm quietly enable auto-squelch behind the user's
         // back.
+        //
+        // We deliberately drive the floor *off* the sentinel
+        // before disabling — if we started the disabled test
+        // with the floor still at `NOISE_FLOOR_INITIAL_DB`, a
+        // buggy implementation that unconditionally resets to
+        // sentinel would false-pass (sentinel → sentinel). The
+        // pre-rearm assertion below enforces this precondition.
         let mut squelch = PowerSquelch::new(REARM_DISABLED_MANUAL_DB);
-        // Starts with auto_squelch = false, floor at sentinel.
+        squelch.set_auto_squelch(true);
+        let noise = vec![Complex::new(NOISE_AMP, 0.0); TEST_BLOCK_LEN];
+        let mut output = vec![Complex::default(); TEST_BLOCK_LEN];
+        for _ in 0..AUTO_SETTLE_ITERS {
+            squelch.process(&noise, &mut output).unwrap();
+        }
+        // `set_auto_squelch(false)` only flips the flag — it does
+        // not touch the settled floor estimate, which is exactly
+        // the state we want to snapshot for the "rearm is a no-op
+        // when disabled" check.
+        squelch.set_auto_squelch(false);
         assert!(!squelch.auto_squelch_enabled());
         let floor_before = squelch.noise_floor_db();
+        assert!(
+            (floor_before - NOISE_FLOOR_INITIAL_DB).abs() > REARM_SETTLED_MARGIN_DB,
+            "precondition: floor should differ from the sentinel before the \
+             disabled rearm call (got {floor_before}) — without this, a buggy \
+             unconditional-reset would false-pass the final assertion"
+        );
 
         squelch.rearm_auto_squelch();
 

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -292,6 +292,23 @@ impl PowerSquelch {
         }
     }
 
+    /// Re-arm auto-squelch: reset the noise floor estimate and
+    /// settle counter without flipping the enabled state.
+    ///
+    /// Call this whenever the tuning context changes — a retune
+    /// to a new frequency, a demod-mode switch, or a bandwidth
+    /// change — so the auto-squelch tracker re-converges on the
+    /// new band's floor instead of carrying the previous
+    /// channel's settled estimate into a potentially very
+    /// different noise environment. No-op when auto-squelch is
+    /// disabled (manual threshold doesn't track floor).
+    pub fn rearm_auto_squelch(&mut self) {
+        if self.auto_squelch {
+            self.noise_floor_db = NOISE_FLOOR_INITIAL_DB;
+            self.settle_count = 0;
+        }
+    }
+
     /// Returns whether auto-squelch is enabled.
     pub fn auto_squelch_enabled(&self) -> bool {
         self.auto_squelch
@@ -1491,6 +1508,70 @@ mod tests {
         assert!(
             !squelch.is_open(),
             "with auto-squelch off, manual 100 dB threshold should close squelch"
+        );
+    }
+
+    #[test]
+    fn test_rearm_auto_squelch_resets_floor_without_toggling_enabled() {
+        // Repros the core condition of issue #374: auto-squelch
+        // settles on band A's floor, we retune to band B, and
+        // without a re-arm the stale floor drives wrong open/close
+        // decisions. `rearm_auto_squelch` should reset the floor
+        // back to the initial sentinel so the next block starts
+        // re-converging from scratch — while leaving
+        // `auto_squelch_enabled` untouched.
+        let mut squelch = PowerSquelch::new(-100.0);
+        squelch.set_auto_squelch(true);
+
+        // Settle band A's noise floor via repeated blocks.
+        let noise = vec![Complex::new(NOISE_AMP, 0.0); TEST_BLOCK_LEN];
+        let mut output = vec![Complex::default(); TEST_BLOCK_LEN];
+        for _ in 0..AUTO_SETTLE_ITERS {
+            squelch.process(&noise, &mut output).unwrap();
+        }
+        let settled_floor = squelch.noise_floor_db();
+        assert!(
+            settled_floor > NOISE_FLOOR_INITIAL_DB + 1.0,
+            "sanity: noise floor should have converged above the sentinel (got {settled_floor})",
+        );
+        assert!(squelch.auto_squelch_enabled());
+
+        squelch.rearm_auto_squelch();
+
+        // Floor is back to the sentinel; auto-squelch stays on.
+        assert!(
+            (squelch.noise_floor_db() - NOISE_FLOOR_INITIAL_DB).abs() < f32::EPSILON,
+            "rearm should reset noise_floor_db to NOISE_FLOOR_INITIAL_DB (got {})",
+            squelch.noise_floor_db()
+        );
+        assert!(
+            squelch.auto_squelch_enabled(),
+            "rearm must not flip the enabled state"
+        );
+    }
+
+    #[test]
+    fn test_rearm_auto_squelch_is_no_op_when_disabled() {
+        // When auto-squelch is off, the noise_floor_db field is
+        // unused (manual threshold drives decisions). Re-arming
+        // should not touch the floor or flip any other state
+        // either — cheap guard against a future edit making
+        // rearm quietly enable auto-squelch behind the user's
+        // back.
+        let mut squelch = PowerSquelch::new(-50.0);
+        // Starts with auto_squelch = false, floor at sentinel.
+        assert!(!squelch.auto_squelch_enabled());
+        let floor_before = squelch.noise_floor_db();
+
+        squelch.rearm_auto_squelch();
+
+        assert!(
+            !squelch.auto_squelch_enabled(),
+            "rearm must not enable auto-squelch"
+        );
+        assert!(
+            (squelch.noise_floor_db() - floor_before).abs() < f32::EPSILON,
+            "rearm should leave noise_floor_db untouched when disabled"
         );
     }
 }

--- a/crates/sdr-dsp/src/noise.rs
+++ b/crates/sdr-dsp/src/noise.rs
@@ -279,6 +279,17 @@ impl PowerSquelch {
         self.level_db = level_db;
     }
 
+    /// Reset the auto-squelch tracking state — noise floor back
+    /// to the initial sentinel, settle counter to zero — so the
+    /// next block starts converging from scratch. Shared between
+    /// `set_auto_squelch(true)` (enabling the tracker) and
+    /// `rearm_auto_squelch` (re-converging on a new band without
+    /// flipping the enabled flag).
+    fn reset_auto_squelch_tracking(&mut self) {
+        self.noise_floor_db = NOISE_FLOOR_INITIAL_DB;
+        self.settle_count = 0;
+    }
+
     /// Enable or disable auto-squelch (noise floor tracking).
     ///
     /// When enabled, the manual `level_db` is ignored and the threshold
@@ -287,8 +298,7 @@ impl PowerSquelch {
         self.auto_squelch = enabled;
         if enabled {
             // Reset the noise floor estimate so it adapts to the current band.
-            self.noise_floor_db = NOISE_FLOOR_INITIAL_DB;
-            self.settle_count = 0;
+            self.reset_auto_squelch_tracking();
         }
     }
 
@@ -304,8 +314,7 @@ impl PowerSquelch {
     /// disabled (manual threshold doesn't track floor).
     pub fn rearm_auto_squelch(&mut self) {
         if self.auto_squelch {
-            self.noise_floor_db = NOISE_FLOOR_INITIAL_DB;
-            self.settle_count = 0;
+            self.reset_auto_squelch_tracking();
         }
     }
 
@@ -1400,6 +1409,21 @@ mod tests {
     const STRONG_AMP: f32 = 1.0;
     const BORDERLINE_AMP: f32 = 0.003;
 
+    // Manual squelch thresholds used by the rearm tests. Both are
+    // "effectively open" compared to the expected noise amplitude
+    // so the process loop always runs the auto-squelch logic
+    // rather than short-circuiting on the manual gate.
+    const REARM_MANUAL_FLOOR_DB: f32 = -100.0;
+    /// Manual threshold used specifically by the
+    /// rearm-while-disabled test. Sits between `NOISE_AMP` and
+    /// the initial sentinel so a disabled squelch clearly
+    /// distinguishes from the enabled-and-settled-at-floor state.
+    const REARM_DISABLED_MANUAL_DB: f32 = -50.0;
+    /// Minimum rise above `NOISE_FLOOR_INITIAL_DB` (dB) that counts
+    /// as "the EMA converged off the sentinel" — used to confirm
+    /// the settle loop actually moved the floor before we re-arm.
+    const REARM_SETTLED_MARGIN_DB: f32 = 1.0;
+
     #[test]
     fn test_auto_squelch_tracks_noise_floor() {
         let mut squelch = PowerSquelch::new(-100.0);
@@ -1520,7 +1544,7 @@ mod tests {
         // back to the initial sentinel so the next block starts
         // re-converging from scratch — while leaving
         // `auto_squelch_enabled` untouched.
-        let mut squelch = PowerSquelch::new(-100.0);
+        let mut squelch = PowerSquelch::new(REARM_MANUAL_FLOOR_DB);
         squelch.set_auto_squelch(true);
 
         // Settle band A's noise floor via repeated blocks.
@@ -1531,7 +1555,7 @@ mod tests {
         }
         let settled_floor = squelch.noise_floor_db();
         assert!(
-            settled_floor > NOISE_FLOOR_INITIAL_DB + 1.0,
+            settled_floor > NOISE_FLOOR_INITIAL_DB + REARM_SETTLED_MARGIN_DB,
             "sanity: noise floor should have converged above the sentinel (got {settled_floor})",
         );
         assert!(squelch.auto_squelch_enabled());
@@ -1558,7 +1582,7 @@ mod tests {
         // either — cheap guard against a future edit making
         // rearm quietly enable auto-squelch behind the user's
         // back.
-        let mut squelch = PowerSquelch::new(-50.0);
+        let mut squelch = PowerSquelch::new(REARM_DISABLED_MANUAL_DB);
         // Starts with auto_squelch = false, floor at sentinel.
         assert!(!squelch.auto_squelch_enabled());
         let floor_before = squelch.noise_floor_db();

--- a/crates/sdr-radio/src/if_chain.rs
+++ b/crates/sdr-radio/src/if_chain.rs
@@ -160,6 +160,13 @@ impl IfChain {
         self.squelch.set_auto_squelch(enabled);
     }
 
+    /// Re-arm auto-squelch noise-floor tracking without
+    /// flipping the enabled state. See
+    /// [`PowerSquelch::rearm_auto_squelch`] for context.
+    pub fn rearm_auto_squelch(&mut self) {
+        self.squelch.rearm_auto_squelch();
+    }
+
     /// Returns whether auto-squelch is enabled.
     pub fn auto_squelch_enabled(&self) -> bool {
         self.squelch.auto_squelch_enabled()

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -459,6 +459,16 @@ impl RadioModule {
         self.if_chain.set_auto_squelch_enabled(enabled);
     }
 
+    /// Re-arm auto-squelch noise-floor tracking so it re-converges
+    /// at the current tuning context. No-op when auto-squelch is
+    /// disabled. Call on every engine-side retune — frequency
+    /// change, demod switch, bandwidth change — so the tracker
+    /// doesn't carry a prior channel's settled floor into a new
+    /// noise environment. Per issue #374.
+    pub fn rearm_auto_squelch(&mut self) {
+        self.if_chain.rearm_auto_squelch();
+    }
+
     /// Set the deemphasis mode.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

Auto-squelch was never re-measuring the noise floor when the tuning context changed. Click-to-tune, header frequency selector, demod switch, bandwidth change, and (after #317) scanner hops all left the tracker settled on the *previous* band's floor. Symptom: the new channel hard-opens (old floor was louder) or stays hard-closed (old floor was quieter) until the user toggles auto-squelch off and on manually.

Closes #374.

## Fix

Engine-side, single helper covering every retune path.

- **`sdr-dsp`**: `PowerSquelch::rearm_auto_squelch()` resets `noise_floor_db` back to `NOISE_FLOOR_INITIAL_DB` and zeros `settle_count`. No-op when auto-squelch is disabled. Distinct from `set_auto_squelch(true)` (which does the same reset but also flips the enabled state — we want re-arm without a user-visible toggle).
- **`sdr-radio`**: `IfChain::rearm_auto_squelch` + `RadioModule::rearm_auto_squelch` plumb it up.
- **`sdr-core`**: new private `on_tune_change(state)` helper bundles two resets — the `state.squelch_was_open = false` edge-tracker reset already used by the scanner retune path (PR #372 round 3), plus the new auto-squelch re-arm. Called from four sites: `UiToDsp::Tune`, `SetDemodMode`, `SetBandwidth`, and the scanner `Retune` command. The scanner retune's existing inline edge-tracker reset is replaced with the helper call (superset).

## Test plan

- [x] Two new `#[cfg(test)]` unit tests in `sdr-dsp/src/noise.rs`:
  - `test_rearm_auto_squelch_resets_floor_without_toggling_enabled` — settle floor, re-arm, assert floor is back at sentinel AND enabled stays true.
  - `test_rearm_auto_squelch_is_no_op_when_disabled` — re-arm on disabled squelch doesn't flip anything.
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo test --workspace --lib` clean (149 passing: 147 + 2 new)
- [x] `cargo fmt --all -- --check` clean
- [ ] Live smoke test on RTL-SDR (after `make install`):
  - Tune quiet band, let auto-squelch settle.
  - Click-to-tune to a band with noticeably different floor → auto-squelch should re-measure, no hard-open/hard-closed.
  - Same with header freq selector, demod dropdown, bandwidth spin, bookmark recall, preset selection.
  - Enable scanner with auto-squelch on → each hop should re-measure; manual-squelch-equivalent behavior.

## Notes

- Noise floor convergence still takes some blocks after the re-arm (the EMA needs settle time). Users will see a brief moment after a retune where the threshold is at the sentinel; this is expected. The scanner's existing ~100ms dwell covers it; manual tunes hit it faster than the user notices.
- Gain and AGC changes also change measured power but aren't wired to the helper — left out intentionally to keep scope tight. If a future CR finding flags them, the wiring is one line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-squelch noise-floor tracking is now consistently reset and re-armed for manual tuning, demodulation mode changes, bandwidth adjustments, and scanner retunes—preventing stale noise estimates from affecting newly tuned channels and improving settle/threshold behavior.
* **Tests**
  * Added unit tests verifying re-arm behavior when auto-squelch is enabled and confirming no-op behavior when it is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->