### PR TITLE
fix(#376): recenter VFO overlay on every tuner center change

### DIFF
--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -245,9 +245,21 @@ impl SpectrumHandle {
     }
 
     /// Update the tuner center frequency for frequency axis labels.
+    ///
+    /// Also resets the VFO overlay offset to 0 so the passband rectangle
+    /// tracks the new center. Every caller that sets the tuner center
+    /// is placing the tuner ON a specific channel (manual header tune,
+    /// click-to-tune, bookmark recall, preset, scanner retune), so the
+    /// VFO's offset-from-center should be zero afterwards. Without this
+    /// reset the rectangle would stick at the previous center-relative
+    /// offset — visually drifting across the waterfall as center moves,
+    /// even though the tuner is centered on the new frequency. Per
+    /// issue #376.
     pub fn set_center_frequency(&self, freq_hz: f64) {
         self.center_freq.set(freq_hz);
+        self.vfo_state.borrow_mut().offset_hz = 0.0;
         self.fft_area.queue_draw();
+        self.waterfall_area.queue_draw();
     }
 
     /// Push a signal level sample (in dB) into the history graph.

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -247,14 +247,19 @@ impl SpectrumHandle {
     /// Update the tuner center frequency for frequency axis labels.
     ///
     /// Also resets the VFO overlay offset to 0 so the passband rectangle
-    /// tracks the new center. Every caller that sets the tuner center
-    /// is placing the tuner ON a specific channel (manual header tune,
-    /// click-to-tune, bookmark recall, preset, scanner retune), so the
-    /// VFO's offset-from-center should be zero afterwards. Without this
-    /// reset the rectangle would stick at the previous center-relative
-    /// offset — visually drifting across the waterfall as center moves,
-    /// even though the tuner is centered on the new frequency. Per
+    /// tracks the new center. Every caller of this method is placing the
+    /// tuner ON a specific channel — manual header tune, bookmark recall,
+    /// preset selection, scanner retune — so the VFO's
+    /// offset-from-center should be zero afterwards. Without this reset
+    /// the rectangle would stick at the previous center-relative offset,
+    /// visually drifting across the waterfall as center moves, even
+    /// though the tuner is centered on the new frequency. Per
     /// issue #376.
+    ///
+    /// Note: click-to-tune does NOT go through this path. It dispatches
+    /// `UiToDsp::SetVfoOffset(offset)` with the clicked offset,
+    /// deliberately keeping the tuner center fixed and sliding the VFO
+    /// passband to the click position instead.
     pub fn set_center_frequency(&self, freq_hz: f64) {
         self.center_freq.set(freq_hz);
         self.vfo_state.borrow_mut().offset_hz = 0.0;


### PR DESCRIPTION
## Summary

The VFO passband rectangle on the spectrum/waterfall was sticking at its previous center-relative offset whenever the tuner center moved. Most visible during scanner rotation — the active-channel label flicked through the channels while the VFO rectangle looked frozen. Same bug affected manual header tune and bookmark/preset recall on a smaller scale (one-time redraw artifact that only resolved when the user clicked-to-tune or dragged the VFO).

Closes #376.

## Fix

One-line-ish change in `SpectrumHandle::set_center_frequency`:
- Reset `VfoState::offset_hz = 0.0`
- Queue the waterfall redraw (so the VFO overlay repaints, not just the FFT axis labels)

Every caller is explicitly retuning the tuner to land on a specific channel, so an offset-from-center of zero is the right semantic across all three call sites:
- `freq_selector.connect_frequency_changed` — manual header tune
- `DspToUi::ScannerActiveChannelChanged` — scanner retune fan-out
- `panels.bookmarks.connect_navigate` — bookmark recall / preset selection

Click-to-tune is unaffected — that path doesn't go through `set_center_frequency`. It dispatches `UiToDsp::SetVfoOffset(offset)` which deliberately keeps center fixed and moves the VFO offset.

## Test plan

- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo test --workspace --lib` clean (147 passing)
- [x] `cargo fmt --all -- --check` clean
- [ ] Live smoke test (after `make install`):
  - Enable scanner on several bookmarks across bands → VFO rectangle should track the active channel on each hop, not stick to the previous position.
  - Manual header tune → rectangle recenters on the new tuner frequency immediately (previously only recentered on the next FFT frame or user interaction).
  - Recall a bookmark → rectangle recenters.
  - Click-to-tune → rectangle still moves to the clicked offset (not recentered — click-to-tune's whole point is picking an offset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VFO/passband overlay offset now resets to zero when the center frequency is changed, ensuring the passband recenters correctly.
  * Waterfall visualization now refreshes alongside the FFT spectrum when the center frequency is adjusted, keeping both displays in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->