### PR TITLE
feat(#296): add Whisper large-v3-turbo as a selectable model

### DIFF
--- a/crates/sdr-transcription/src/model.rs
+++ b/crates/sdr-transcription/src/model.rs
@@ -15,6 +15,23 @@ pub enum WhisperModel {
     SmallEn,
     MediumEn,
     LargeV3,
+    /// Large v3 turbo — distilled-decoder variant of `LargeV3`.
+    /// Roughly half the disk footprint (~1.6 GB vs 3.1 GB) and
+    /// ~8× faster inference for near-`LargeV3` English accuracy.
+    /// Fills the "medium is too weak, large-v3 is too slow" gap.
+    ///
+    /// Appended at the end of [`Self::ALL`] rather than inserted
+    /// between `MediumEn` and `LargeV3` because the UI persists
+    /// the user's model choice as an index into `ALL`; inserting
+    /// mid-list would silently upgrade every existing `LargeV3`
+    /// user to turbo on next launch. Order follows stability
+    /// over aesthetics.
+    ///
+    /// Naming follows the upstream ggerganov filename
+    /// (`ggml-large-v3-turbo.bin`, no `.en` suffix — turbo is
+    /// English-focused by design rather than being an `.en`
+    /// fine-tune of multilingual weights).
+    LargeV3Turbo,
 }
 
 impl WhisperModel {
@@ -26,6 +43,7 @@ impl WhisperModel {
             Self::SmallEn => "ggml-small.en.bin",
             Self::MediumEn => "ggml-medium.en.bin",
             Self::LargeV3 => "ggml-large-v3.bin",
+            Self::LargeV3Turbo => "ggml-large-v3-turbo.bin",
         }
     }
 
@@ -42,16 +60,21 @@ impl WhisperModel {
             Self::SmallEn => "Small — 466 MB",
             Self::MediumEn => "Medium — 1.5 GB (GPU)",
             Self::LargeV3 => "Large v3 — 3.1 GB (GPU)",
+            Self::LargeV3Turbo => "Large v3 Turbo — 1.6 GB (GPU, ~8× faster than Large v3)",
         }
     }
 
-    /// All available variants in order.
+    /// All available variants in order. Append-only by contract —
+    /// the UI persists the user's model choice as an index into
+    /// this slice, so reordering or inserting mid-list would
+    /// silently remap every existing user's selection.
     pub const ALL: &[Self] = &[
         Self::TinyEn,
         Self::BaseEn,
         Self::SmallEn,
         Self::MediumEn,
         Self::LargeV3,
+        Self::LargeV3Turbo,
     ];
 }
 
@@ -167,5 +190,40 @@ mod tests {
         for model in WhisperModel::ALL {
             assert!(model.url().contains(model.filename()));
         }
+    }
+
+    #[test]
+    fn large_v3_turbo_filename_matches_upstream() {
+        // Upstream ggerganov HF filename pin — deliberate literal
+        // test rather than deriving from the enum, so a future
+        // edit that accidentally changes the filename fails here
+        // rather than silently breaking every user's download.
+        assert_eq!(
+            WhisperModel::LargeV3Turbo.filename(),
+            "ggml-large-v3-turbo.bin"
+        );
+        assert!(
+            WhisperModel::LargeV3Turbo
+                .url()
+                .ends_with("ggml-large-v3-turbo.bin"),
+            "url must resolve to the canonical turbo filename"
+        );
+    }
+
+    #[test]
+    fn all_models_preserves_legacy_indices() {
+        // Persistence contract: `ALL` is append-only. The UI
+        // stores the user's model choice as an index into this
+        // slice, so reordering or inserting mid-list would
+        // silently change existing users' selections on next
+        // launch. Pinning the leading indices here catches any
+        // accidental reordering.
+        let models = WhisperModel::ALL;
+        assert_eq!(models[0], WhisperModel::TinyEn);
+        assert_eq!(models[1], WhisperModel::BaseEn);
+        assert_eq!(models[2], WhisperModel::SmallEn);
+        assert_eq!(models[3], WhisperModel::MediumEn);
+        assert_eq!(models[4], WhisperModel::LargeV3);
+        assert_eq!(models[5], WhisperModel::LargeV3Turbo);
     }
 }


### PR DESCRIPTION
## Summary

Adds `WhisperModel::LargeV3Turbo` as a sixth selectable Whisper model. Distilled-decoder variant of large-v3 — ~1.6 GB (vs 3.1 GB for large-v3), ~8× faster inference, near-large-v3 English accuracy. Fills the middle-ground gap for users who find medium too weak and large-v3 too slow.

Closes #296.

## Design decisions

**Ordering in `ALL`.** The natural place is between `MediumEn` and `LargeV3` (sorted by increasing quality/cost). But the UI persists the user's model choice as an *index* into `WhisperModel::ALL` (`transcript_panel.rs:344`), so inserting mid-list would silently upgrade every existing `LargeV3` user to turbo on next launch. Appended at the end instead — stability wins. Doc comment on the enum variant + a dedicated test (`all_models_preserves_legacy_indices`) pin the append-only contract for future edits.

**Naming.** `LargeV3Turbo`, not `LargeV3TurboEn`. The upstream ggerganov filename is `ggml-large-v3-turbo.bin` (no `.en` suffix) — turbo is English-focused by design, not an `.en` fine-tune of multilingual weights like `ggml-medium.en.bin`.

## Test plan

- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p sdr-transcription --lib --features whisper-cpu` — 57 passing, includes 2 new tests:
  - `large_v3_turbo_filename_matches_upstream` — literal filename pin
  - `all_models_preserves_legacy_indices` — order contract
- [x] `cargo test --workspace --lib` clean
- [ ] Live smoke test: `make install CARGO_FLAGS="--release --features whisper-cuda"`, open Transcription panel → new "Large v3 Turbo" entry in model dropdown, first selection triggers download from the canonical HF URL.

## Scope

UI auto-picks up the new variant via the existing `WhisperModel::ALL.iter().map(|m| m.label())` binding in `transcript_panel.rs` — no sidebar changes needed. Download logic is model-agnostic (`MODEL_BASE_URL + filename()`), so no download path changes.

No behavior change for existing users: the index contract is preserved, existing `LargeV3` selections stay at index 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Whisper's Large v3 Turbo model—a faster transcription option (approximately 8× faster than Large v3) with 1.6 GB size, optimized for GPU inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->