### PR TITLE
feat(#341): VFO reset affordances — floating button + per-field bandwidth reset

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -913,6 +913,12 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             if let Some(vfo) = &mut state.vfo {
                 vfo.set_offset(offset);
             }
+            // Echo so UI paths that trigger this indirectly
+            // (reset-to-defaults button, future scanner / scripting
+            // hooks) reflect the new offset in their overlay /
+            // frequency readout without optimistically guessing
+            // locally. Matches the `BandwidthChanged` echo above.
+            let _ = dsp_tx.send(DspToUi::VfoOffsetChanged(offset));
         }
 
         UiToDsp::SetNbLevel(level) => {

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -69,6 +69,14 @@ pub enum DspToUi {
     /// negligible and emitting unconditionally keeps the controller
     /// free of per-field before/after comparisons.
     BandwidthChanged(f64),
+    /// VFO offset (Hz from tuner center) changed by the DSP.
+    /// Symmetric with [`Self::BandwidthChanged`] — lets UI paths
+    /// that trigger a VFO offset change indirectly (e.g. a
+    /// "reset VFO" button that dispatches `SetVfoOffset(0)`)
+    /// receive an echo and update the spectrum overlay without
+    /// having to optimistically guess the new value locally.
+    /// Per issue #341.
+    VfoOffsetChanged(f64),
     /// CTCSS sustained-gate state changed. Emitted only on edges
     /// (closed → open / open → closed), not per-window, so the UI
     /// status indicator can subscribe without flooding the channel.
@@ -409,6 +417,17 @@ mod tests {
         let bw = DspToUi::BandwidthChanged(TEST_BANDWIDTH_HZ);
         assert!(
             matches!(bw, DspToUi::BandwidthChanged(v) if (v - TEST_BANDWIDTH_HZ).abs() < f64::EPSILON)
+        );
+    }
+
+    #[test]
+    fn vfo_offset_changed_message_constructs() {
+        // Same shape regression as `bandwidth_changed_message_constructs`
+        // — future refactors that change the f64 carrier type
+        // fail here first.
+        let offset = DspToUi::VfoOffsetChanged(25_000.0);
+        assert!(
+            matches!(offset, DspToUi::VfoOffsetChanged(v) if (v - 25_000.0).abs() < f64::EPSILON)
         );
     }
 

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -367,6 +367,13 @@ mod tests {
     /// construct + match and documents the choice of value.
     const TEST_BANDWIDTH_HZ: f64 = 12_500.0;
 
+    /// Fixed VFO offset used by the `VfoOffsetChanged` round-trip
+    /// test. 25 kHz is a representative non-zero offset that
+    /// click-to-tune / drag flows routinely emit — same hoisting
+    /// rationale as `TEST_BANDWIDTH_HZ`: avoids a magic-number
+    /// duplicated between construct and match.
+    const TEST_VFO_OFFSET_HZ: f64 = 25_000.0;
+
     #[test]
     fn test_dsp_to_ui_variants() {
         let fft = DspToUi::FftData(vec![1.0, 2.0, 3.0]);
@@ -425,10 +432,11 @@ mod tests {
         // Same shape regression as `bandwidth_changed_message_constructs`
         // — future refactors that change the f64 carrier type
         // fail here first.
-        let offset = DspToUi::VfoOffsetChanged(25_000.0);
-        assert!(
-            matches!(offset, DspToUi::VfoOffsetChanged(v) if (v - 25_000.0).abs() < f64::EPSILON)
-        );
+        let offset = DspToUi::VfoOffsetChanged(TEST_VFO_OFFSET_HZ);
+        assert!(matches!(
+            offset,
+            DspToUi::VfoOffsetChanged(v) if (v - TEST_VFO_OFFSET_HZ).abs() < f64::EPSILON
+        ));
     }
 
     #[test]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -494,6 +494,11 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         //     light up in the macOS UI whenever the CTCSS / voice-
         //     squelch panels get ported (no specific backlog issue
         //     yet — part of the full-parity backlog under #228).
+        //   - `BandwidthChanged` and `VfoOffsetChanged` are the
+        //     VFO-drag + "reset VFO" feedback-echo events
+        //     (#336 / #341). Linux-only for now; macOS SwiftUI
+        //     gets them when the equivalent VFO overlay +
+        //     reset affordances land on that side.
         //   - `ScannerActiveChannelChanged`, `ScannerStateChanged`,
         //     `ScannerEmptyRotation`, `ScannerMutexStopped` are the
         //     scanner Phase 1 UI events (#317). Intentionally
@@ -566,6 +571,7 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         DspToUi::FftData(_)
         | DspToUi::DemodModeChanged(_)
         | DspToUi::BandwidthChanged(_)
+        | DspToUi::VfoOffsetChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
         | DspToUi::VoiceSquelchOpenChanged(_)
         | DspToUi::ScannerActiveChannelChanged { .. }

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -1060,6 +1060,21 @@ mod tests {
     }
 
     #[test]
+    fn vfo_offset_changed_is_intentionally_dropped_at_ffi() {
+        // Regression guard for the ABI-v1 "intentionally withheld"
+        // contract. `VfoOffsetChanged` is the VFO-reset feedback
+        // echo (#341) — Linux-only for now; macOS SwiftUI gets it
+        // when the equivalent VFO overlay + reset affordances
+        // land on that side. If a future refactor accidentally
+        // routes this variant through `translate_event`, the
+        // assertion below flips and the ABI change becomes
+        // visible at test time rather than at a downstream host
+        // that suddenly starts receiving an unknown event kind.
+        use sdr_core::DspToUi;
+        assert!(translate_event(&DspToUi::VfoOffsetChanged(25_000.0)).is_none());
+    }
+
+    #[test]
     fn sdr_event_payload_size_is_reasonable() {
         // Sanity check on the union layout. The largest payload
         // today is `SdrEventRtlTcpConnectionState` (kind i32 +

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -1070,8 +1070,11 @@ mod tests {
         // assertion below flips and the ABI change becomes
         // visible at test time rather than at a downstream host
         // that suddenly starts receiving an unknown event kind.
+        /// Representative non-zero VFO offset — 25 kHz is typical
+        /// of what click-to-tune and drag flows emit in practice.
+        const TEST_VFO_OFFSET_HZ: f64 = 25_000.0;
         use sdr_core::DspToUi;
-        assert!(translate_event(&DspToUi::VfoOffsetChanged(25_000.0)).is_none());
+        assert!(translate_event(&DspToUi::VfoOffsetChanged(TEST_VFO_OFFSET_HZ)).is_none());
     }
 
     #[test]

--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -149,6 +149,20 @@ pub fn create_demodulator(
     }
 }
 
+/// Default passband bandwidth (Hz) for a given demod mode.
+///
+/// Instantiates a demodulator and reads its `config().default_bandwidth`
+/// — keeps a single source of truth (the per-demod module constants)
+/// without re-declaring them here. Cost is one `Box::new` per call;
+/// callers should cache if they need it in a hot path, but UI
+/// comparisons on every demod-mode change are cheap enough. Falls
+/// back to 0.0 if demod construction fails (unexpected — every mode
+/// in [`sdr_types::DemodMode`] has a valid construction).
+#[must_use]
+pub fn default_bandwidth_for_mode(mode: sdr_types::DemodMode) -> f64 {
+    create_demodulator(mode).map_or(0.0, |d| d.config().default_bandwidth)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {

--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -155,12 +155,17 @@ pub fn create_demodulator(
 /// — keeps a single source of truth (the per-demod module constants)
 /// without re-declaring them here. Cost is one `Box::new` per call;
 /// callers should cache if they need it in a hot path, but UI
-/// comparisons on every demod-mode change are cheap enough. Falls
-/// back to 0.0 if demod construction fails (unexpected — every mode
-/// in [`sdr_types::DemodMode`] has a valid construction).
-#[must_use]
-pub fn default_bandwidth_for_mode(mode: sdr_types::DemodMode) -> f64 {
-    create_demodulator(mode).map_or(0.0, |d| d.config().default_bandwidth)
+/// comparisons on every demod-mode change are cheap enough.
+///
+/// # Errors
+///
+/// Returns `DspError` if demod construction fails. This isn't
+/// expected for any variant in [`sdr_types::DemodMode`] — every
+/// mode has a valid constructor today — but propagating the error
+/// is better than coercing to `0.0`, which would leave callers
+/// dispatching `SetBandwidth(0.0)` and silently break the radio.
+pub fn default_bandwidth_for_mode(mode: sdr_types::DemodMode) -> Result<f64, DspError> {
+    Ok(create_demodulator(mode)?.config().default_bandwidth)
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -112,6 +112,12 @@ pub struct RadioPanel {
     pub widget: adw::PreferencesGroup,
     /// Bandwidth control.
     pub bandwidth_row: adw::SpinRow,
+    /// "Reset bandwidth to default for current demod mode" button,
+    /// packed as a suffix on `bandwidth_row`. Sensitive only when
+    /// the current bandwidth differs from the mode's default;
+    /// otherwise the button grays out so it doesn't lie about
+    /// having something to do. Per issue #341.
+    pub bandwidth_reset_button: gtk4::Button,
     /// Squelch enable toggle.
     pub squelch_enabled_row: adw::SwitchRow,
     /// Squelch level control.
@@ -481,6 +487,25 @@ pub fn build_radio_panel() -> RadioPanel {
         .digits(0)
         .build();
 
+    // "Reset bandwidth to default for current demod mode" —
+    // packed as a suffix so it sits inline with the spin row.
+    // Flat + valign(Center) matches the affordance pattern other
+    // sidebar rows use for secondary actions.
+    let bandwidth_reset_button = gtk4::Button::builder()
+        .icon_name("edit-undo-symbolic")
+        .tooltip_text("Reset bandwidth to default for current demod mode")
+        .css_classes(["flat"])
+        .valign(gtk4::Align::Center)
+        // Start insensitive — the initial bandwidth is the
+        // mode default. The value-notify + DemodModeChanged
+        // handlers in window.rs update sensitivity from here.
+        .sensitive(false)
+        .build();
+    bandwidth_reset_button.update_property(&[gtk4::accessible::Property::Label(
+        "Reset bandwidth to default",
+    )]);
+    bandwidth_row.add_suffix(&bandwidth_reset_button);
+
     // --- Squelch ---
     let squelch_enabled_row = adw::SwitchRow::builder().title("Squelch").build();
 
@@ -695,6 +720,7 @@ pub fn build_radio_panel() -> RadioPanel {
     RadioPanel {
         widget: group,
         bandwidth_row,
+        bandwidth_reset_button,
         squelch_enabled_row,
         squelch_level_row,
         auto_squelch_row,

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -267,6 +267,30 @@ impl SpectrumHandle {
         self.waterfall_area.queue_draw();
     }
 
+    /// Programmatically update the VFO overlay's offset-from-center.
+    ///
+    /// Called from the `DspToUi::VfoOffsetChanged` handler so DSP-
+    /// originated offset changes (e.g. a "reset VFO" button that
+    /// dispatches `SetVfoOffset(0)`, or a future scripting hook)
+    /// reflect on the overlay immediately. Click-to-tune and
+    /// drag paths update `vfo_state.offset_hz` directly inline
+    /// with the gesture, so they don't need to go through this
+    /// method. Per issue #341.
+    pub fn set_vfo_offset(&self, offset_hz: f64) {
+        self.vfo_state.borrow_mut().offset_hz = offset_hz;
+        self.fft_area.queue_draw();
+        self.waterfall_area.queue_draw();
+    }
+
+    /// Current VFO offset (Hz from tuner center). Used by the
+    /// reset-affordance visibility logic so the floating button
+    /// can decide whether the VFO is in a non-default state
+    /// without replicating the state cache. Per issue #341.
+    #[must_use]
+    pub fn vfo_offset_hz(&self) -> f64 {
+        self.vfo_state.borrow().offset_hz
+    }
+
     /// Push a signal level sample (in dB) into the history graph.
     ///
     /// Call this from the GTK main loop when `DspToUi::SignalLevel` arrives.

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -106,6 +106,13 @@ pub struct SpectrumHandle {
     full_bandwidth: Rc<Cell<f64>>,
     /// Tuner center frequency in Hz (for absolute frequency labels).
     center_freq: Rc<Cell<f64>>,
+    /// Floating "Reset VFO" button overlaid on the top-right of
+    /// the spectrum area. Visibility is driven by window.rs:
+    /// visible when bandwidth ≠ mode default OR vfo offset ≠ 0.
+    /// `window.rs` also wires the click handler (needs access to
+    /// `AppState` to compute the mode's default bandwidth).
+    /// Per issue #341.
+    pub vfo_reset_button: gtk4::Button,
 }
 
 impl SpectrumHandle {
@@ -413,6 +420,33 @@ pub fn build_spectrum_view(
         }
     });
 
+    // Floating "Reset VFO" button in the top-right of the
+    // spectrum area. Hidden by default; `window.rs` toggles
+    // visibility whenever the VFO enters or leaves a non-default
+    // state. Uses the `osd` CSS class for a translucent overlay
+    // feel that doesn't steal too much visual weight from the
+    // spectrum underneath.
+    let vfo_reset_button = gtk4::Button::builder()
+        .icon_name("edit-undo-symbolic")
+        .tooltip_text("Reset VFO to defaults")
+        .css_classes(["osd", "circular"])
+        .halign(gtk4::Align::End)
+        .valign(gtk4::Align::Start)
+        .margin_top(8)
+        .margin_end(8)
+        .visible(false)
+        .build();
+    vfo_reset_button.update_property(&[gtk4::accessible::Property::Label(
+        "Reset VFO bandwidth and offset to defaults",
+    )]);
+
+    // Wrap the paned in an Overlay so the floating button can
+    // sit on top of both the FFT plot and the waterfall without
+    // shifting their layout.
+    let spectrum_overlay = gtk4::Overlay::builder().hexpand(true).vexpand(true).build();
+    spectrum_overlay.set_child(Some(&paned));
+    spectrum_overlay.add_overlay(&vfo_reset_button);
+
     // Wrap the signal history DrawingArea in a collapsible expander.
     let expander = gtk4::Expander::builder()
         .label("Signal History")
@@ -420,14 +454,14 @@ pub fn build_spectrum_view(
         .build();
     expander.set_child(Some(&signal_history_area));
 
-    // Combine the FFT+waterfall paned and the signal history expander
-    // into a vertical box.
+    // Combine the FFT+waterfall overlay and the signal history
+    // expander into a vertical box.
     let outer_box = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
         .hexpand(true)
         .vexpand(true)
         .build();
-    outer_box.append(&paned);
+    outer_box.append(&spectrum_overlay);
     outer_box.append(&expander);
 
     let handle = SpectrumHandle {
@@ -447,6 +481,7 @@ pub fn build_spectrum_view(
         vfo_offset_callback,
         full_bandwidth,
         center_freq,
+        vfo_reset_button,
     };
 
     (outer_box, handle)

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -44,6 +44,11 @@ const DEFAULT_MIN_DB: f32 = -70.0;
 /// Default maximum display level in dB.
 const DEFAULT_MAX_DB: f32 = 0.0;
 
+/// Margin (px) between the floating "Reset VFO" overlay button
+/// and the top-right edge of the spectrum area. 8 px is a visual
+/// match with the GNOME Adwaita toast-overlay button inset.
+const VFO_RESET_BUTTON_MARGIN_PX: i32 = 8;
+
 /// Exponential moving average smoothing factor for `RunningAvg` mode.
 const AVERAGING_ALPHA: f32 = 0.3;
 
@@ -432,8 +437,8 @@ pub fn build_spectrum_view(
         .css_classes(["osd", "circular"])
         .halign(gtk4::Align::End)
         .valign(gtk4::Align::Start)
-        .margin_top(8)
-        .margin_end(8)
+        .margin_top(VFO_RESET_BUTTON_MARGIN_PX)
+        .margin_end(VFO_RESET_BUTTON_MARGIN_PX)
         .visible(false)
         .build();
     vfo_reset_button.update_property(&[gtk4::accessible::Property::Label(

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -4435,21 +4435,25 @@ fn update_vfo_reset_button_visibility(
     state: &AppState,
 ) {
     let mode = state.demod_mode.get();
-    // Same conservative fallback as `update_bandwidth_reset_sensitivity`
-    // — if we can't resolve the mode's default bandwidth, hide
-    // the button rather than showing it with a broken click
-    // action.
+    // Offset-at-zero is resolvable without the demod lookup, so
+    // compute it first. If the bandwidth lookup below fails, we
+    // can still decide visibility based on offset alone — the
+    // click handler's `SetVfoOffset(0.0)` dispatch remains
+    // useful even when the bandwidth reset path is broken.
+    let offset_at_zero = spectrum.vfo_offset_hz().abs() < VFO_OFFSET_RESET_TOLERANCE_HZ;
     let Ok(default_bw) = sdr_radio::demod::default_bandwidth_for_mode(mode) else {
         tracing::warn!(
             ?mode,
-            "default_bandwidth_for_mode failed — hiding floating reset button"
+            "default_bandwidth_for_mode failed — floating reset button \
+             falls back to offset-only visibility"
         );
-        spectrum.vfo_reset_button.set_visible(false);
+        // Button stays available when the user has a nonzero
+        // offset to clear; hides when both paths would no-op.
+        spectrum.vfo_reset_button.set_visible(!offset_at_zero);
         return;
     };
     let current_bw = radio.bandwidth_row.value();
     let bandwidth_at_default = (current_bw - default_bw).abs() < BANDWIDTH_RESET_TOLERANCE_HZ;
-    let offset_at_zero = spectrum.vfo_offset_hz().abs() < VFO_OFFSET_RESET_TOLERANCE_HZ;
     spectrum
         .vfo_reset_button
         .set_visible(!(bandwidth_at_default && offset_at_zero));

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -499,17 +499,36 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let status_bar_for_bw = Rc::clone(&status_bar_demod);
     let state_for_bw = Rc::clone(&state);
     let radio_for_bw_reset = panels.radio.clone();
+    let spectrum_for_bw_reset = Rc::clone(&spectrum_handle);
     panels.radio.bandwidth_row.connect_value_notify(move |row| {
         let mode = state_for_bw.demod_mode.get();
         let label = header::demod_mode_label(mode);
         status_bar_for_bw.update_demod(label, row.value());
-        // Reset button tracks the spin-row value on EVERY
+        // Reset affordances track the spin-row value on EVERY
         // change — user-initiated edits AND DSP echoes. Lives
         // in this handler (not the `connect_radio_panel` one)
         // because that one short-circuits on the
         // `suppress_bandwidth_notify` flag and would miss VFO
         // drag echoes. Per issue #341.
         update_bandwidth_reset_sensitivity(&radio_for_bw_reset, &state_for_bw);
+        update_vfo_reset_button_visibility(
+            &radio_for_bw_reset,
+            &spectrum_for_bw_reset,
+            &state_for_bw,
+        );
+    });
+
+    // Floating "Reset VFO" button on the spectrum — routes
+    // through the DSP for both dispatches so the echoes
+    // (`BandwidthChanged`, `VfoOffsetChanged`) drive the UI
+    // reflection. No direct widget manipulation that would
+    // skip the DSP / scanner-mutex / force-disable machinery.
+    let state_for_vfo_reset = Rc::clone(&state);
+    spectrum_handle.vfo_reset_button.connect_clicked(move |_| {
+        let mode = state_for_vfo_reset.demod_mode.get();
+        let default_bw = sdr_radio::demod::default_bandwidth_for_mode(mode);
+        state_for_vfo_reset.send_dsp(UiToDsp::SetBandwidth(default_bw));
+        state_for_vfo_reset.send_dsp(UiToDsp::SetVfoOffset(0.0));
     });
 
     // --- Poll DspToUi channel and shared FFT buffer from the GTK main loop ---
@@ -831,9 +850,11 @@ fn handle_dsp_message(
             }
 
             // Mode change shifts the default bandwidth — refresh
-            // the reset button's sensitivity so it tracks the new
-            // mode's default. Per issue #341.
+            // both the per-field sensitivity AND the floating
+            // button's visibility so they track the new mode's
+            // default. Per issue #341.
             update_bandwidth_reset_sensitivity(radio_panel, state);
+            update_vfo_reset_button_visibility(radio_panel, spectrum_handle, state);
         }
         DspToUi::BandwidthChanged(bw) => {
             // DSP-originated bandwidth change (typically a VFO drag
@@ -865,6 +886,11 @@ fn handle_dsp_message(
             let tuned_u64 = tuned.max(0.0) as u64;
             freq_selector.set_frequency(tuned_u64);
             status_bar.update_frequency(tuned);
+            // Offset change is one of the two inputs to the
+            // floating reset button's visibility — refresh it so
+            // clicking reset hides the button and a subsequent
+            // user drag re-shows it. Per issue #341.
+            update_vfo_reset_button_visibility(radio_panel, spectrum_handle, state);
         }
         DspToUi::CtcssSustainedChanged(sustained) => {
             tracing::debug!(sustained, "CTCSS sustained-gate edge");
@@ -4362,6 +4388,29 @@ fn update_bandwidth_reset_sensitivity(radio: &sidebar::radio_panel::RadioPanel, 
     let current = radio.bandwidth_row.value();
     let at_default = (current - default).abs() < BANDWIDTH_RESET_TOLERANCE_HZ;
     radio.bandwidth_reset_button.set_sensitive(!at_default);
+}
+
+/// Tolerance (Hz) for the "VFO offset is at 0" comparison in
+/// the floating reset button's visibility logic.
+const VFO_OFFSET_RESET_TOLERANCE_HZ: f64 = 0.5;
+
+/// Update the floating "Reset VFO" button's visibility — shown
+/// only when the VFO is in a non-default state, i.e. bandwidth
+/// differs from the mode default OR offset is nonzero. Per
+/// issue #341.
+fn update_vfo_reset_button_visibility(
+    radio: &sidebar::radio_panel::RadioPanel,
+    spectrum: &spectrum::SpectrumHandle,
+    state: &AppState,
+) {
+    let mode = state.demod_mode.get();
+    let default_bw = sdr_radio::demod::default_bandwidth_for_mode(mode);
+    let current_bw = radio.bandwidth_row.value();
+    let bandwidth_at_default = (current_bw - default_bw).abs() < BANDWIDTH_RESET_TOLERANCE_HZ;
+    let offset_at_zero = spectrum.vfo_offset_hz().abs() < VFO_OFFSET_RESET_TOLERANCE_HZ;
+    spectrum
+        .vfo_reset_button
+        .set_visible(!(bandwidth_at_default && offset_at_zero));
 }
 
 /// Connect radio panel controls to DSP commands.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -498,10 +498,18 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // --- Wire radio panel bandwidth changes to status bar ---
     let status_bar_for_bw = Rc::clone(&status_bar_demod);
     let state_for_bw = Rc::clone(&state);
+    let radio_for_bw_reset = panels.radio.clone();
     panels.radio.bandwidth_row.connect_value_notify(move |row| {
         let mode = state_for_bw.demod_mode.get();
         let label = header::demod_mode_label(mode);
         status_bar_for_bw.update_demod(label, row.value());
+        // Reset button tracks the spin-row value on EVERY
+        // change — user-initiated edits AND DSP echoes. Lives
+        // in this handler (not the `connect_radio_panel` one)
+        // because that one short-circuits on the
+        // `suppress_bandwidth_notify` flag and would miss VFO
+        // drag echoes. Per issue #341.
+        update_bandwidth_reset_sensitivity(&radio_for_bw_reset, &state_for_bw);
     });
 
     // --- Poll DspToUi channel and shared FFT buffer from the GTK main loop ---
@@ -821,6 +829,11 @@ fn handle_dsp_message(
                     overlay.add_toast(toast);
                 }
             }
+
+            // Mode change shifts the default bandwidth — refresh
+            // the reset button's sensitivity so it tracks the new
+            // mode's default. Per issue #341.
+            update_bandwidth_reset_sensitivity(radio_panel, state);
         }
         DspToUi::BandwidthChanged(bw) => {
             // DSP-originated bandwidth change (typically a VFO drag
@@ -4332,6 +4345,25 @@ fn connect_source_panel(
         });
 }
 
+/// Tolerance (Hz) for the "bandwidth is at its mode default"
+/// comparison. The bandwidth `SpinRow` uses `digits(0)` so values
+/// are already integer-aligned; this tolerance is just a
+/// float-comparison guard, not a user-visible fuzziness.
+const BANDWIDTH_RESET_TOLERANCE_HZ: f64 = 0.5;
+
+/// Update the bandwidth reset button's sensitivity: active only
+/// when the spin row's current value differs from the current
+/// demod mode's default bandwidth. Called from anywhere either
+/// input (current bandwidth OR demod mode) can change. Per
+/// issue #341.
+fn update_bandwidth_reset_sensitivity(radio: &sidebar::radio_panel::RadioPanel, state: &AppState) {
+    let mode = state.demod_mode.get();
+    let default = sdr_radio::demod::default_bandwidth_for_mode(mode);
+    let current = radio.bandwidth_row.value();
+    let at_default = (current - default).abs() < BANDWIDTH_RESET_TOLERANCE_HZ;
+    radio.bandwidth_reset_button.set_sensitive(!at_default);
+}
+
 /// Connect radio panel controls to DSP commands.
 #[allow(clippy::too_many_lines)]
 fn connect_radio_panel(
@@ -4360,6 +4392,20 @@ fn connect_radio_panel(
         force_disable_bw.trigger("manual bandwidth change");
         state_bw.send_dsp(UiToDsp::SetBandwidth(row.value()));
     });
+
+    // Bandwidth reset button → `SetBandwidth(mode_default)`. Per
+    // #341. Routes through DSP so the echo updates the spin row
+    // — no direct `set_value` manipulation that would skip the
+    // DSP / scanner-mutex / force-disable machinery.
+    let state_bw_reset = Rc::clone(state);
+    panels
+        .radio
+        .bandwidth_reset_button
+        .connect_clicked(move |_| {
+            let mode = state_bw_reset.demod_mode.get();
+            let default = sdr_radio::demod::default_bandwidth_for_mode(mode);
+            state_bw_reset.send_dsp(UiToDsp::SetBandwidth(default));
+        });
 
     // Squelch enable
     let state_squelch_en = Rc::clone(state);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -524,10 +524,30 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // reflection. No direct widget manipulation that would
     // skip the DSP / scanner-mutex / force-disable machinery.
     let state_for_vfo_reset = Rc::clone(&state);
+    let force_disable_vfo_reset = Rc::clone(&scanner_force_disable);
     spectrum_handle.vfo_reset_button.connect_clicked(move |_| {
+        // Reset is a manual change — stop the scanner first so a
+        // retune on the user's cleaned-up channel doesn't race
+        // with the reset dispatch (same contract every other
+        // manual-change site in `build_window` obeys).
+        force_disable_vfo_reset.trigger("manual VFO reset");
         let mode = state_for_vfo_reset.demod_mode.get();
-        let default_bw = sdr_radio::demod::default_bandwidth_for_mode(mode);
-        state_for_vfo_reset.send_dsp(UiToDsp::SetBandwidth(default_bw));
+        // If the mode default is unresolvable (unreachable for
+        // any current variant), skip the bandwidth reset rather
+        // than dispatching `SetBandwidth(0.0)`; the offset reset
+        // still lands. Error already logged by the helper.
+        match sdr_radio::demod::default_bandwidth_for_mode(mode) {
+            Ok(default_bw) => {
+                state_for_vfo_reset.send_dsp(UiToDsp::SetBandwidth(default_bw));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    ?mode,
+                    error = %e,
+                    "default_bandwidth_for_mode failed on VFO reset — skipping bandwidth dispatch"
+                );
+            }
+        }
         state_for_vfo_reset.send_dsp(UiToDsp::SetVfoOffset(0.0));
     });
 
@@ -4384,7 +4404,18 @@ const BANDWIDTH_RESET_TOLERANCE_HZ: f64 = 0.5;
 /// issue #341.
 fn update_bandwidth_reset_sensitivity(radio: &sidebar::radio_panel::RadioPanel, state: &AppState) {
     let mode = state.demod_mode.get();
-    let default = sdr_radio::demod::default_bandwidth_for_mode(mode);
+    // Conservative fallback: if we can't resolve the mode's
+    // default (unreachable today — every DemodMode has a valid
+    // ctor), keep the reset button inactive rather than claim
+    // a comparison we can't actually compute.
+    let Ok(default) = sdr_radio::demod::default_bandwidth_for_mode(mode) else {
+        tracing::warn!(
+            ?mode,
+            "default_bandwidth_for_mode failed — disabling bandwidth reset button"
+        );
+        radio.bandwidth_reset_button.set_sensitive(false);
+        return;
+    };
     let current = radio.bandwidth_row.value();
     let at_default = (current - default).abs() < BANDWIDTH_RESET_TOLERANCE_HZ;
     radio.bandwidth_reset_button.set_sensitive(!at_default);
@@ -4404,7 +4435,18 @@ fn update_vfo_reset_button_visibility(
     state: &AppState,
 ) {
     let mode = state.demod_mode.get();
-    let default_bw = sdr_radio::demod::default_bandwidth_for_mode(mode);
+    // Same conservative fallback as `update_bandwidth_reset_sensitivity`
+    // — if we can't resolve the mode's default bandwidth, hide
+    // the button rather than showing it with a broken click
+    // action.
+    let Ok(default_bw) = sdr_radio::demod::default_bandwidth_for_mode(mode) else {
+        tracing::warn!(
+            ?mode,
+            "default_bandwidth_for_mode failed — hiding floating reset button"
+        );
+        spectrum.vfo_reset_button.set_visible(false);
+        return;
+    };
     let current_bw = radio.bandwidth_row.value();
     let bandwidth_at_default = (current_bw - default_bw).abs() < BANDWIDTH_RESET_TOLERANCE_HZ;
     let offset_at_zero = spectrum.vfo_offset_hz().abs() < VFO_OFFSET_RESET_TOLERANCE_HZ;
@@ -4447,13 +4489,29 @@ fn connect_radio_panel(
     // — no direct `set_value` manipulation that would skip the
     // DSP / scanner-mutex / force-disable machinery.
     let state_bw_reset = Rc::clone(state);
+    let force_disable_bw_reset = Rc::clone(scanner_force_disable);
     panels
         .radio
         .bandwidth_reset_button
         .connect_clicked(move |_| {
+            // Reset is a manual change — stop the scanner first
+            // so the cleaned-up bandwidth doesn't race the next
+            // scanner retune. Same contract as the manual
+            // bandwidth-row edit above.
+            force_disable_bw_reset.trigger("manual bandwidth reset");
             let mode = state_bw_reset.demod_mode.get();
-            let default = sdr_radio::demod::default_bandwidth_for_mode(mode);
-            state_bw_reset.send_dsp(UiToDsp::SetBandwidth(default));
+            match sdr_radio::demod::default_bandwidth_for_mode(mode) {
+                Ok(default) => {
+                    state_bw_reset.send_dsp(UiToDsp::SetBandwidth(default));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        ?mode,
+                        error = %e,
+                        "default_bandwidth_for_mode failed on reset click — no dispatch"
+                    );
+                }
+            }
         });
 
     // Squelch enable

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -839,6 +839,20 @@ fn handle_dsp_message(
             radio_panel.bandwidth_row.set_value(bw);
             state.suppress_bandwidth_notify.set(false);
         }
+        DspToUi::VfoOffsetChanged(offset) => {
+            // DSP-originated VFO offset change — typically a
+            // "reset VFO offset" button that dispatched
+            // `SetVfoOffset(0)`. Update the overlay + frequency
+            // display so the UI reflects the new offset without
+            // the caller having to optimistically guess locally.
+            // Per issue #341.
+            spectrum_handle.set_vfo_offset(offset);
+            let tuned = state.center_frequency.get() + offset;
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let tuned_u64 = tuned.max(0.0) as u64;
+            freq_selector.set_frequency(tuned_u64);
+            status_bar.update_frequency(tuned);
+        }
         DspToUi::CtcssSustainedChanged(sustained) => {
             tracing::debug!(sustained, "CTCSS sustained-gate edge");
             radio_panel.set_ctcss_sustained(sustained);


### PR DESCRIPTION
## Summary

Two reset affordances for the VFO, per issue #341. A user can drag the VFO, not like the result, and get back to defaults fast.

1. **Floating "Reset VFO" button** in the top-right of the spectrum area, visible only when the VFO is in a non-default state. Click resets both bandwidth AND offset in one action.
2. **Per-field bandwidth reset icon** as a suffix on the Radio panel's bandwidth spin row, sensitive only when the current bandwidth differs from the current demod mode's default. Click resets bandwidth only, leaves offset alone.

Per-field VFO-offset reset is deferred — the issue notes it needs UI surfacing first (Offset isn't currently a sidebar field), which is a design call worth a separate conversation. The floating button covers the offset-reset case for now.

Closes #341.

## Commits

Three logical commits for reviewability:
1. `c04bf4d` — plumbing: `DspToUi::VfoOffsetChanged` event + `default_bandwidth_for_mode` helper + `SpectrumHandle::{set_vfo_offset, vfo_offset_hz}` accessors. No user-visible behavior change.
2. `dcfc358` — per-field bandwidth reset button on the Radio panel.
3. `430bb02` — floating "Reset VFO" button on the spectrum.

## Design notes

**Every reset routes through the DSP.** Click handlers dispatch `UiToDsp::SetBandwidth` / `UiToDsp::SetVfoOffset`; the controller echoes `DspToUi::BandwidthChanged` / `DspToUi::VfoOffsetChanged`, and those echoes drive the UI reflection. No direct widget `set_value` manipulation — satisfies the acceptance criterion about not skipping the DSP.

**`DspToUi::VfoOffsetChanged(f64)` is new** — symmetric with the existing `BandwidthChanged` echo. The FFI ABI-v1 block is updated with the intentionally-withheld rationale, matching the `BandwidthChanged` pattern.

**Visibility logic** — button / sensitivity are refreshed from every site that can change either input:
- `bandwidth_row.connect_value_notify` in the status-bar handler (fires on all value changes, including DSP-suppressed echoes — the `connect_radio_panel` handler short-circuits on `suppress_bandwidth_notify` and misses those).
- `DspToUi::DemodModeChanged` handler (mode change shifts the default that drives the comparison).
- `DspToUi::VfoOffsetChanged` handler (offset edits from drag, click, or reset).

Two named tolerance constants at 0.5 Hz: the bandwidth SpinRow is `digits(0)` so values are integer-aligned; tolerances are float-comparison guards, not user-visible fuzziness.

## Test plan

- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace --lib` clean (148 passing — includes new `vfo_offset_changed_message_constructs` shape test)
- [ ] Live smoke test on RTL-SDR (after `make install`):
  - Per-field reset: change bandwidth, button becomes sensitive; click it, bandwidth snaps to mode default, button grays out.
  - Per-field + mode switch: change bandwidth, switch demod, button still sensitive (value now diverges from new mode's default); click resets to NEW mode's default.
  - Floating button: starts hidden. Drag VFO off-center → appears. Click → bandwidth + offset reset, button hides. Change bandwidth via spin → appears. Change offset only via click-to-tune → appears.
  - Floating button hides after a manual frequency selector tune (which is a full retune — VFO stays centered, bandwidth stays at whatever it was, which may already be the mode default).
  - Accessibility: tooltip + accessible name distinct on both buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Reset bandwidth to default for current demod mode" button in radio settings.
  * Floating "Reset VFO" overlay button in the spectrum view to quickly zero the VFO offset.
  * Reset buttons apply defaults and update the frequency selector and status bar.

* **Improvements**
  * Bandwidth reset button enables/disables based on tolerance to the mode default.
  * UI now reliably reflects VFO offset changes for better DSP↔UI synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->