### PR TITLE
rtl_tcp: optional LZ4 stream compression with per-connection negotiation (#307)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +2079,7 @@ name = "sdr-server-rtltcp"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "lz4_flex",
  "rusb",
  "sdr-rtlsdr",
  "sdr-rtltcp-discovery",
@@ -2748,6 +2758,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,14 @@ hound = "3"
 # Avahi/Bonjour system dependency, no async runtime required.
 mdns-sd = "0.19"
 
+# LZ4 streaming compression for the rtl_tcp extended protocol
+# (#307). Pure-Rust implementation of the LZ4 block + frame
+# formats, no C dependency. Chosen over `lz4-sys` / `lz4_flex`
+# for its first-class frame-format streaming API that
+# transparently handles chunk framing for our per-connection
+# codec wrapper.
+lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"] }
+
 # Zero-copy type casting
 bytemuck = { version = "1", features = ["derive"] }
 

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -478,6 +478,7 @@ mod tests {
         let connected = DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Connected {
             tuner_name: "R820T".into(),
             gain_count: 29,
+            codec: "None".into(),
         });
         assert!(matches!(
             connected,

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -482,7 +482,11 @@ mod tests {
         });
         assert!(matches!(
             connected,
-            DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Connected { gain_count: 29, .. })
+            DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Connected {
+                gain_count: 29,
+                ref codec,
+                ..
+            }) if codec == "None"
         ));
 
         let retrying = DspToUi::RtlTcpConnectionState(RtlTcpConnectionState::Retrying {

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -528,6 +528,7 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
                 RtlTcpConnectionState::Connected {
                     tuner_name,
                     gain_count,
+                    ..
                 } => {
                     let sanitized = tuner_name.replace('\0', "?");
                     let Ok(cstr) = CString::new(sanitized) else {
@@ -891,6 +892,7 @@ mod tests {
             RtlTcpConnectionState::Connected {
                 tuner_name: "R820T".to_string(),
                 gain_count: 29,
+                codec: "None".to_string(),
             },
         ))
         .expect("Connected event should translate");

--- a/crates/sdr-ffi/src/rtltcp_discovery.rs
+++ b/crates/sdr-ffi/src/rtltcp_discovery.rs
@@ -174,8 +174,10 @@ pub unsafe extern "C" fn sdr_rtltcp_advertiser_start(
                 txbuf,
                 // C ABI host has no codec picker yet — advertise
                 // "unknown / legacy" so vanilla clients keep
-                // working unchanged. #307 follow-up will extend
-                // `SdrRtlTcpAdvertiseOptions` with a `codecs` byte.
+                // working unchanged. Issue #400 tracks extending
+                // `SdrRtlTcpAdvertiseOptions` with `has_codecs` +
+                // `codecs` fields so the Swift macOS app can
+                // advertise compression capability.
                 codecs: None,
             },
         };

--- a/crates/sdr-ffi/src/rtltcp_discovery.rs
+++ b/crates/sdr-ffi/src/rtltcp_discovery.rs
@@ -172,6 +172,11 @@ pub unsafe extern "C" fn sdr_rtltcp_advertiser_start(
                 gains: opts.gains,
                 nickname,
                 txbuf,
+                // C ABI host has no codec picker yet — advertise
+                // "unknown / legacy" so vanilla clients keep
+                // working unchanged. #307 follow-up will extend
+                // `SdrRtlTcpAdvertiseOptions` with a `codecs` byte.
+                codecs: None,
             },
         };
 
@@ -853,6 +858,7 @@ mod tests {
                     String::new()
                 },
                 txbuf,
+                codecs: None,
             },
             last_seen: Instant::now(),
         }

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -321,7 +321,9 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
             buffer_capacity,
             // Compression stays off for the C ABI until the host
             // adds a codec-mask field to `SdrRtlTcpServerConfig`
-            // (issue #307 follow-up). Vanilla clients keep working.
+            // (issue #400 tracks extending the C struct). Vanilla
+            // clients keep working; the Linux GTK path is the only
+            // one that currently offers LZ4.
             compression: CodecMask::NONE_ONLY,
         };
         match Server::start(server_cfg) {

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -22,6 +22,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use sdr_server_rtltcp::{
     InitialDeviceState, Server, ServerConfig, ServerError, ServerStats, TunerAdvertiseInfo,
+    codec::CodecMask,
     protocol::{CommandOp, DEFAULT_PORT},
 };
 
@@ -318,6 +319,10 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
             device_index: cfg.device_index,
             initial,
             buffer_capacity,
+            // Compression stays off for the C ABI until the host
+            // adds a codec-mask field to `SdrRtlTcpServerConfig`
+            // (issue #307 follow-up). Vanilla clients keep working.
+            compression: CodecMask::NONE_ONLY,
         };
         match Server::start(server_cfg) {
             Ok(server) => {

--- a/crates/sdr-rtltcp-discovery/src/lib.rs
+++ b/crates/sdr-rtltcp-discovery/src/lib.rs
@@ -149,6 +149,7 @@ mod tests {
                 gains: R820T_GAIN_COUNT,
                 nickname: "integration-test-nick".into(),
                 txbuf: None,
+                codecs: None,
             },
         })
         .expect("announce");

--- a/crates/sdr-rtltcp-discovery/src/txt.rs
+++ b/crates/sdr-rtltcp-discovery/src/txt.rs
@@ -34,6 +34,19 @@ pub struct TxtRecord {
 
     /// Optional buffer-depth hint (bytes) for latency awareness.
     pub txbuf: Option<usize>,
+
+    /// Optional codec bitmask (`sdr-server-rtltcp::CodecMask`'s raw
+    /// wire byte) advertising which stream codecs the server is
+    /// willing to negotiate in the extended `"RTLX"` handshake.
+    /// `None` means "unknown" — older servers don't publish this
+    /// key; clients should treat its absence as "legacy
+    /// uncompressed only" and NOT send an extended hello (the
+    /// hello corrupts vanilla command framing). Issue #307.
+    ///
+    /// Kept as a plain `u8` here so the discovery crate stays
+    /// independent of the server crate; the caller converts to /
+    /// from `CodecMask` at the boundary.
+    pub codecs: Option<u8>,
 }
 
 impl TxtRecord {
@@ -55,6 +68,9 @@ impl TxtRecord {
         insert_checked(&mut m, "nickname", &self.nickname)?;
         if let Some(n) = self.txbuf {
             insert_checked(&mut m, "txbuf", &n.to_string())?;
+        }
+        if let Some(c) = self.codecs {
+            insert_checked(&mut m, "codecs", &c.to_string())?;
         }
         let total: usize = m.iter().map(|(k, v)| k.len() + v.len() + 2).sum();
         if total > Self::MAX_TOTAL_BYTES {
@@ -81,6 +97,7 @@ impl TxtRecord {
         let mut gains: u32 = 0;
         let mut nickname = String::new();
         let mut txbuf: Option<usize> = None;
+        let mut codecs: Option<u8> = None;
         for (k, v) in properties {
             match k.as_ref() {
                 "tuner" => tuner = v.as_ref().to_string(),
@@ -88,6 +105,7 @@ impl TxtRecord {
                 "gains" => gains = v.as_ref().parse().unwrap_or(0),
                 "nickname" => nickname = v.as_ref().to_string(),
                 "txbuf" => txbuf = v.as_ref().parse().ok(),
+                "codecs" => codecs = v.as_ref().parse().ok(),
                 _ => {
                     tracing::trace!(
                         key = %k.as_ref(),
@@ -102,6 +120,7 @@ impl TxtRecord {
             gains,
             nickname,
             txbuf,
+            codecs,
         }
     }
 }
@@ -140,6 +159,10 @@ mod tests {
             gains: 29,
             nickname: "home-scanner".into(),
             txbuf: Some(128 * 1024),
+            // CodecMask::NONE_AND_LZ4 raw byte — stable wire value
+            // avoided referencing the server crate here to keep the
+            // discovery crate's test independent.
+            codecs: Some(0b11),
         }
     }
 
@@ -154,6 +177,7 @@ mod tests {
             Some("home-scanner")
         );
         assert_eq!(props.get("txbuf").map(String::as_str), Some("131072"));
+        assert_eq!(props.get("codecs").map(String::as_str), Some("3"));
     }
 
     #[test]
@@ -165,6 +189,17 @@ mod tests {
     }
 
     #[test]
+    fn to_properties_omits_missing_codecs() {
+        // An older server that doesn't advertise a codec mask must
+        // not emit an empty `codecs=` entry — clients interpret
+        // absence as "legacy only" per #307.
+        let mut r = sample();
+        r.codecs = None;
+        let props = r.to_properties().unwrap();
+        assert!(!props.contains_key("codecs"));
+    }
+
+    #[test]
     fn from_properties_fills_defaults_for_missing_fields() {
         let r = TxtRecord::from_properties(std::iter::empty::<(&str, &str)>());
         assert_eq!(r.tuner, "unknown");
@@ -172,6 +207,22 @@ mod tests {
         assert_eq!(r.gains, 0);
         assert_eq!(r.nickname, "");
         assert_eq!(r.txbuf, None);
+        assert_eq!(r.codecs, None);
+    }
+
+    #[test]
+    fn from_properties_parses_codecs() {
+        let r = TxtRecord::from_properties([("codecs", "3")]);
+        assert_eq!(r.codecs, Some(3));
+    }
+
+    #[test]
+    fn from_properties_tolerates_garbage_codecs() {
+        // Non-numeric `codecs` value falls back to None (unknown)
+        // rather than rejecting the whole record — same safety
+        // pattern as `gains`.
+        let r = TxtRecord::from_properties([("codecs", "not-a-number")]);
+        assert_eq!(r.codecs, None);
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/Cargo.toml
+++ b/crates/sdr-server-rtltcp/Cargo.toml
@@ -34,6 +34,13 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # Optional — only pulled in when `mdns-advertise` is enabled. The bin
 # target requires this feature (see `required-features` below).
 sdr-rtltcp-discovery = { workspace = true, optional = true }
+# LZ4 streaming compression for the extended handshake (#307). Pulled
+# in unconditionally because the protocol types + codec enum need to
+# know about LZ4 regardless of whether a given build actually uses it
+# — the server declines LZ4 cleanly by advertising a None-only codec
+# mask at handshake time, which doesn't require the codec trait impls
+# to be absent.
+lz4_flex.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -383,6 +383,10 @@ fn announce_over_mdns(
         gains: tuner.gain_count,
         nickname: nickname.clone(),
         txbuf: None,
+        // CLI server advertises whatever mask the user configured,
+        // so compression-capable clients can decide up-front
+        // whether to send an extended hello. #307.
+        codecs: Some(server.compression().to_wire()),
     };
     Advertiser::announce(AdvertiseOptions {
         port: server.bind_address().port(),

--- a/crates/sdr-server-rtltcp/src/codec.rs
+++ b/crates/sdr-server-rtltcp/src/codec.rs
@@ -1,0 +1,335 @@
+//! Stream codecs for the extended rtl_tcp protocol (#307).
+//!
+//! The classic rtl_tcp protocol streams raw 8-bit I/Q samples over
+//! TCP — roughly 4.8 MB/s at 2.4 Msps. On a good LAN that's free;
+//! over Wi-Fi near the edge of range, congested networks, or
+//! travel/hotel routers, it's unusable. Extended clients can
+//! negotiate an optional codec at handshake time to compress the
+//! stream in flight.
+//!
+//! This module defines:
+//!
+//! - [`Codec`] — the scalar code sent in the server's extension
+//!   response, and the trait-object handle used by both client
+//!   and server to wrap their TCP streams.
+//! - [`CodecMask`] — the bitmask a client sends in its hello
+//!   advertising which codecs it understands; the server intersects
+//!   this with its own configured codec set and picks the best
+//!   mutual option.
+//! - The [`Encoder`] / [`Decoder`] trait pair — streaming framing
+//!   that both server and client implementations call per chunk.
+//!
+//! # Compatibility
+//!
+//! Codec negotiation happens entirely inside the [`"RTLX"`]
+//! extension block; legacy clients (GQRX, SDR++, vanilla rtl_tcp)
+//! that don't send a hello time out on the server's 100 ms sniff
+//! window and fall through to the unchanged legacy path at
+//! [`Codec::None`]. No codec-related bytes ever reach a legacy
+//! client.
+//!
+//! [`"RTLX"`]: crate::extension
+
+use std::io::{Read, Write};
+
+use lz4_flex::frame::{FrameDecoder, FrameEncoder};
+
+/// Over-the-wire codec identifier sent by the server in the 8-byte
+/// extension response. Stable scalar values — any future codec
+/// addition MUST append (existing values never change) so that
+/// client libraries compiled against older versions of this crate
+/// don't silently misinterpret the byte as an unrelated codec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum Codec {
+    /// No compression — raw 8-bit I/Q bytes on the wire, same as
+    /// the legacy rtl_tcp protocol. Every compliant server MUST
+    /// support this as the fallback codec.
+    None = 0,
+    /// LZ4 frame format — `lz4_flex` streaming encoder/decoder.
+    /// Good throughput (~500 MB/s on a modern CPU core), modest
+    /// ratio (1.1× to 1.5× on typical I/Q traffic — the signal is
+    /// close to white noise, so entropy coding has limited headroom,
+    /// but voice-rate structure at high SNR does yield some wins).
+    Lz4 = 1,
+    // Reserved for #307 follow-up: Zstd = 2. Additive; current
+    // wire format does not allocate code 2 so legacy clients that
+    // don't understand `Zstd` never receive it (server advertises
+    // only mutually-supported codecs).
+}
+
+impl Codec {
+    /// Human-readable label for UI / log messages.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::None => "None",
+            Self::Lz4 => "LZ4",
+        }
+    }
+
+    /// Decode the 1-byte on-wire value into a [`Codec`]. Returns
+    /// [`None`] for any value the current build doesn't recognize —
+    /// a newer server advertising a future codec code won't crash
+    /// an older client; the client just falls back to legacy.
+    #[must_use]
+    pub fn from_wire(byte: u8) -> Option<Self> {
+        match byte {
+            0 => Some(Self::None),
+            1 => Some(Self::Lz4),
+            _ => None,
+        }
+    }
+
+    /// The 1-byte on-wire value. Inverse of [`Self::from_wire`].
+    #[must_use]
+    pub fn to_wire(self) -> u8 {
+        self as u8
+    }
+
+    /// Bit position in the [`CodecMask`] advertised by clients.
+    /// `Codec::None` is bit 0; every compliant client must set it
+    /// so the server can always fall back. `Codec::Lz4` is bit 1.
+    #[must_use]
+    pub fn mask_bit(self) -> u8 {
+        match self {
+            Self::None => 1 << 0,
+            Self::Lz4 => 1 << 1,
+        }
+    }
+}
+
+/// Bitmask of supported codecs, sent by the client in its hello
+/// and stored by the server as its local configuration ("which
+/// codecs am I willing to offer"). Negotiation is the intersection
+/// — see [`Self::pick`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CodecMask(u8);
+
+impl CodecMask {
+    /// Mask advertising *only* `Codec::None`. Safe default for a
+    /// compliant server that doesn't want to offer compression.
+    pub const NONE_ONLY: Self = Self(1 << 0);
+
+    /// Mask advertising `Codec::None` and `Codec::Lz4`. Typical
+    /// default for a client build that has LZ4 available.
+    pub const NONE_AND_LZ4: Self = Self((1 << 0) | (1 << 1));
+
+    /// Wrap a raw wire byte.
+    #[must_use]
+    pub fn from_wire(byte: u8) -> Self {
+        Self(byte)
+    }
+
+    /// Unwrap the raw wire byte.
+    #[must_use]
+    pub fn to_wire(self) -> u8 {
+        self.0
+    }
+
+    /// Does this mask advertise the given codec?
+    #[must_use]
+    pub fn supports(self, codec: Codec) -> bool {
+        self.0 & codec.mask_bit() != 0
+    }
+
+    /// Pick the best mutual codec between this mask (the server's
+    /// configuration, "what am I willing to offer") and the client's
+    /// advertised support. Preference order: `Lz4` > `None`. Always
+    /// returns at least `Codec::None` because the `None` bit is
+    /// considered implicit — a client that forgets to set it is
+    /// still assumed to accept the legacy uncompressed fallback.
+    #[must_use]
+    pub fn pick(self, client: Self) -> Codec {
+        if self.supports(Codec::Lz4) && client.supports(Codec::Lz4) {
+            Codec::Lz4
+        } else {
+            Codec::None
+        }
+    }
+}
+
+impl std::fmt::Display for Codec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Streaming encoder wrapping an underlying `Write`. The server
+/// writes uncompressed I/Q chunks to this handle; the wrapper
+/// encodes + frames them and forwards the compressed bytes to the
+/// TCP socket.
+pub enum Encoder<W: Write + Send> {
+    /// Pass-through — no framing overhead, identical to writing
+    /// directly to the socket.
+    None(W),
+    /// LZ4 frame format. `FrameEncoder` writes a short frame
+    /// header the first time it's written to; after that every
+    /// flush emits a self-contained LZ4 block. The consumer side
+    /// uses a matching `FrameDecoder` that tolerates any chunk
+    /// boundary (frame blocks are self-delimiting in the LZ4
+    /// frame spec).
+    Lz4(FrameEncoder<W>),
+}
+
+impl<W: Write + Send> Encoder<W> {
+    /// Wrap `inner` using the negotiated codec.
+    pub fn new(codec: Codec, inner: W) -> Self {
+        match codec {
+            Codec::None => Self::None(inner),
+            Codec::Lz4 => Self::Lz4(FrameEncoder::new(inner)),
+        }
+    }
+}
+
+impl<W: Write + Send> Write for Encoder<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::None(w) => w.write(buf),
+            Self::Lz4(w) => w.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::None(w) => w.flush(),
+            Self::Lz4(w) => w.flush(),
+        }
+    }
+}
+
+/// Streaming decoder wrapping an underlying `Read`. The client
+/// reads what looks like a plain I/Q byte stream; the decoder
+/// transparently de-frames LZ4 (or passes bytes through, for
+/// `Codec::None`).
+pub enum Decoder<R: Read> {
+    None(R),
+    Lz4(FrameDecoder<R>),
+}
+
+impl<R: Read> Decoder<R> {
+    /// Wrap `inner` using the negotiated codec.
+    pub fn new(codec: Codec, inner: R) -> Self {
+        match codec {
+            Codec::None => Self::None(inner),
+            Codec::Lz4 => Self::Lz4(FrameDecoder::new(inner)),
+        }
+    }
+}
+
+impl<R: Read> Read for Decoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::None(r) => r.read(buf),
+            Self::Lz4(r) => r.read(buf),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codec_wire_round_trip() {
+        // Every currently-defined codec round-trips through
+        // `to_wire` / `from_wire`. Pins the stable scalar
+        // mapping — a future refactor that renumbers variants
+        // fails here first.
+        assert_eq!(Codec::from_wire(Codec::None.to_wire()), Some(Codec::None));
+        assert_eq!(Codec::from_wire(Codec::Lz4.to_wire()), Some(Codec::Lz4));
+    }
+
+    #[test]
+    fn codec_from_wire_rejects_unknown() {
+        // Future codec values (e.g. Zstd=2 when #307 gets its
+        // follow-up) are `None` under an older client build. Keeps
+        // forward-compat behavior explicit — the client falls back
+        // to legacy rather than treating `2` as garbage.
+        assert!(Codec::from_wire(2).is_none());
+        assert!(Codec::from_wire(99).is_none());
+        assert!(Codec::from_wire(255).is_none());
+    }
+
+    #[test]
+    fn mask_pick_prefers_lz4_when_mutual() {
+        let server = CodecMask::NONE_AND_LZ4;
+        let client = CodecMask::NONE_AND_LZ4;
+        assert_eq!(server.pick(client), Codec::Lz4);
+    }
+
+    #[test]
+    fn mask_pick_falls_back_to_none_when_server_disables_lz4() {
+        // Server config says "I only offer None"; client
+        // advertises Lz4 support. Negotiation lands at None.
+        // This is the scenario from the PR description: sdr-rs
+        // client ↔ LZ4-disabled sdr-rs server → None.
+        let server = CodecMask::NONE_ONLY;
+        let client = CodecMask::NONE_AND_LZ4;
+        assert_eq!(server.pick(client), Codec::None);
+    }
+
+    #[test]
+    fn mask_pick_falls_back_to_none_when_client_lacks_lz4() {
+        // Server offers both; client only supports None.
+        let server = CodecMask::NONE_AND_LZ4;
+        let client = CodecMask::NONE_ONLY;
+        assert_eq!(server.pick(client), Codec::None);
+    }
+
+    #[test]
+    fn lz4_round_trip_preserves_bytes_exactly() {
+        // End-to-end: encode a chunk with the Lz4 encoder, decode
+        // with the matching decoder, assert byte-exact recovery.
+        // Critical — compression is lossless; any divergence is a
+        // framing or library-version bug.
+        let plaintext: Vec<u8> = (0..4096).map(|i| (i % 256) as u8).collect();
+
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = Encoder::Lz4(FrameEncoder::new(&mut buf));
+            encoder.write_all(&plaintext).unwrap();
+            encoder.flush().unwrap();
+            // `FrameEncoder` requires `finish()` for its terminal
+            // end-of-frame block; `Drop` also finalizes but an
+            // explicit finish is clearer in tests.
+            if let Encoder::Lz4(enc) = encoder {
+                enc.finish().unwrap();
+            }
+        }
+        assert!(!buf.is_empty(), "encoder should have emitted bytes");
+        assert!(
+            buf.len() < plaintext.len(),
+            "constant-stride input should compress smaller ({} vs {})",
+            buf.len(),
+            plaintext.len()
+        );
+
+        let mut decoder = Decoder::Lz4(FrameDecoder::new(buf.as_slice()));
+        let mut recovered: Vec<u8> = Vec::new();
+        std::io::copy(&mut decoder, &mut recovered).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn none_codec_is_transparent_passthrough() {
+        // None codec must not alter bytes in either direction.
+        // Confirms the enum's pass-through arm doesn't accidentally
+        // double-buffer or mutate.
+        let plaintext: &[u8] = b"arbitrary \x00\xff binary payload";
+
+        let mut sink: Vec<u8> = Vec::new();
+        {
+            let mut encoder = Encoder::None(&mut sink);
+            encoder.write_all(plaintext).unwrap();
+            encoder.flush().unwrap();
+        }
+        assert_eq!(sink, plaintext);
+
+        let mut decoder = Decoder::None(sink.as_slice());
+        let mut recovered: Vec<u8> = Vec::new();
+        std::io::copy(&mut decoder, &mut recovered).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+}

--- a/crates/sdr-server-rtltcp/src/extension.rs
+++ b/crates/sdr-server-rtltcp/src/extension.rs
@@ -192,11 +192,23 @@ impl ClientHello {
     }
 
     /// Parse from its 8-byte wire representation. Returns `None`
-    /// if the magic doesn't match or the role byte is unknown —
-    /// the server falls through to the legacy path in either case.
+    /// if the magic doesn't match, the schema version doesn't
+    /// match [`PROTOCOL_VERSION`], or the role byte is unknown.
+    /// Callers surface `None` as a protocol error and drop the
+    /// client — letting a peer built for a future wire layout
+    /// through would cause silent mis-negotiation rather than a
+    /// clean version break. Per CodeRabbit round 3 on PR #399.
     #[must_use]
     pub fn from_bytes(bytes: &[u8; CLIENT_HELLO_LEN]) -> Option<Self> {
-        if bytes[..4] != EXTENSION_MAGIC {
+        if bytes[..EXTENSION_MAGIC.len()] != EXTENSION_MAGIC {
+            return None;
+        }
+        // Version gate is strict: peers built against a newer
+        // layout must be rejected, not silently parsed as v1.
+        // If we ever bump PROTOCOL_VERSION we'll add a wider
+        // accept-set here (e.g., `matches!(bytes[7], 1 | 2)`)
+        // once both sides of the upgrade have shipped.
+        if bytes[7] != PROTOCOL_VERSION {
             return None;
         }
         let role = Role::from_wire(bytes[5])?;
@@ -251,12 +263,21 @@ impl ServerExtension {
     }
 
     /// Parse from its 8-byte wire representation. Returns `None`
-    /// when the magic doesn't match (client peeked random IQ
-    /// data) or any enum-typed byte is unknown. Callers fall back
-    /// to the legacy uncompressed path on `None`.
+    /// when the magic doesn't match, the schema version doesn't
+    /// match [`PROTOCOL_VERSION`], or any enum-typed byte is
+    /// unknown. Callers surface `None` as a protocol error and
+    /// drop the connection — a peer built for a future wire
+    /// layout should trigger a clean version break rather than
+    /// silent mis-negotiation as v1. Per CodeRabbit round 3 on
+    /// PR #399.
     #[must_use]
     pub fn from_bytes(bytes: &[u8; SERVER_EXTENSION_LEN]) -> Option<Self> {
-        if bytes[..4] != EXTENSION_MAGIC {
+        if bytes[..EXTENSION_MAGIC.len()] != EXTENSION_MAGIC {
+            return None;
+        }
+        // Strict version gate — see the matching comment in
+        // `ClientHello::from_bytes`.
+        if bytes[7] != PROTOCOL_VERSION {
             return None;
         }
         let codec = Codec::from_wire(bytes[4])?;
@@ -316,6 +337,22 @@ mod tests {
     }
 
     #[test]
+    fn client_hello_rejects_unknown_version() {
+        // Regression test for CodeRabbit round 3 on PR #399: a
+        // future peer that bumps the wire layout must be rejected
+        // so we don't silently mis-negotiate it as v1. Otherwise
+        // `PROTOCOL_VERSION` is dead metadata and a clean protocol
+        // break turns into a subtle runtime bug.
+        let mut bytes = [0u8; CLIENT_HELLO_LEN];
+        bytes[..4].copy_from_slice(&EXTENSION_MAGIC);
+        bytes[4] = CodecMask::NONE_ONLY.to_wire();
+        bytes[5] = Role::Control.to_wire();
+        bytes[6] = 0;
+        bytes[7] = PROTOCOL_VERSION.wrapping_add(1);
+        assert!(ClientHello::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
     fn server_extension_round_trip() {
         let ext = ServerExtension {
             codec: Codec::Lz4,
@@ -352,6 +389,22 @@ mod tests {
         // stay in the TCP read buffer for the next stream read.
         let mut bytes = [0u8; SERVER_EXTENSION_LEN];
         bytes[..4].copy_from_slice(b"\x00\x01\x02\x03"); // unlikely in IQ; arbitrary
+        assert!(ServerExtension::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn server_extension_rejects_unknown_version() {
+        // Same rationale as `client_hello_rejects_unknown_version`
+        // — a newer server's response with an unknown schema
+        // version must cause a clean protocol error at parse time
+        // rather than silently coercing forward-compat fields into
+        // v1 semantics. Per CodeRabbit round 3 on PR #399.
+        let mut bytes = [0u8; SERVER_EXTENSION_LEN];
+        bytes[..4].copy_from_slice(&EXTENSION_MAGIC);
+        bytes[4] = Codec::None.to_wire();
+        bytes[5] = Role::Control.to_wire();
+        bytes[6] = Status::Ok.to_wire();
+        bytes[7] = PROTOCOL_VERSION.wrapping_add(1);
         assert!(ServerExtension::from_bytes(&bytes).is_none());
     }
 

--- a/crates/sdr-server-rtltcp/src/extension.rs
+++ b/crates/sdr-server-rtltcp/src/extension.rs
@@ -1,0 +1,378 @@
+//! Extended rtl_tcp handshake (`"RTLX"` protocol) (#307 + #390).
+//!
+//! Extends the legacy 12-byte `dongle_info_t` hello with a tiny
+//! negotiation framing so sdr-rs-aware clients can opt into
+//! compression today (#307) and, later, role-based multi-client
+//! access (#390) without a version bump on the wire.
+//!
+//! # Wire format
+//!
+//! ## Client → server: 8-byte `ClientHello`
+//!
+//! Sent immediately on TCP connect, before reading anything from
+//! the server. Fixed size so the server's sniff-with-timeout path
+//! is deterministic.
+//!
+//! ```text
+//! off  size  field
+//! 0    4     magic = "RTLX"
+//! 4    1     codec_mask        bitmask of supported codecs (#307)
+//! 5    1     role              0=control, 1=listen (reserved for #392)
+//! 6    1     flags             bit 0=request_takeover (reserved for #393)
+//! 7    1     version           hello schema version, currently 1
+//! ```
+//!
+//! Bytes 5–7 are ignored by the #307 server — it's single-client,
+//! always grants `control`, never honors takeover. A future
+//! #392/#393 implementation will plug real semantics into the
+//! same layout, so the wire format stays stable across the
+//! sub-issues of #390.
+//!
+//! ## Server → client: 8-byte `ServerExtension`
+//!
+//! Written **after** the legacy 12-byte `dongle_info_t`, only if
+//! the server received a valid `ClientHello`. Clients that
+//! negotiated the extension peek the next 4 bytes after
+//! `dongle_info_t` — if they match `"RTLX"`, consume the full
+//! 8-byte block; else treat incoming bytes as the raw I/Q stream
+//! (legacy-server case).
+//!
+//! ```text
+//! off  size  field
+//! 0    4     magic = "RTLX"
+//! 4    1     codec             chosen codec scalar (#307)
+//! 5    1     granted_role      0=control, 1=listen, 255=denied (reserved for #392)
+//! 6    1     status            0=ok, 1=controller_busy, 2=auth_required,
+//!                               3=auth_failed (reserved for #392/#394)
+//! 7    1     version           response schema version, currently 1
+//! ```
+//!
+//! # Compatibility with vanilla `rtl_tcp`
+//!
+//! Vanilla servers receive the 8 bytes and interpret them as one
+//! 5-byte command (`opcode='R'=0x52`, which is not a defined
+//! opcode in upstream `rtl_tcp` and is silently ignored) plus 3
+//! unread bytes that leak into the next command read. Legacy
+//! servers continue to stream the plain legacy `dongle_info_t`;
+//! our sdr-rs client peeks for the `"RTLX"` magic and, not
+//! seeing it, falls back to the legacy uncompressed path without
+//! consuming any bytes from the IQ stream.
+
+use crate::codec::{Codec, CodecMask};
+
+/// 4-byte magic that identifies both sides of the extended
+/// handshake. Chosen because its first byte `'R'=0x52` is not a
+/// defined rtl_tcp command opcode, so vanilla servers treat an
+/// inadvertent hello as a no-op.
+pub const EXTENSION_MAGIC: [u8; 4] = *b"RTLX";
+
+/// Serialized size of [`ClientHello`] on the wire.
+pub const CLIENT_HELLO_LEN: usize = 8;
+
+/// Serialized size of [`ServerExtension`] on the wire.
+pub const SERVER_EXTENSION_LEN: usize = 8;
+
+/// Current protocol schema version for both hello and response.
+/// Bumped only on breaking layout changes — adding codecs or
+/// status codes is additive and doesn't require a version bump
+/// because the over-the-wire bytes keep their positions.
+pub const PROTOCOL_VERSION: u8 = 1;
+
+/// Role a client is requesting (or that the server granted).
+/// Reserved values — #307 only ever uses [`Self::Control`]; #392
+/// adds [`Self::Listen`] semantics and the `255` denied sentinel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Role {
+    /// Full command access — tune, gain, sample rate, etc.
+    Control = 0,
+    /// Passive — receives the IQ stream; commands are dropped
+    /// server-side. Reserved for #392.
+    Listen = 1,
+}
+
+impl Role {
+    /// Decode the 1-byte wire value. Unknown or `255` (denied
+    /// sentinel) → `None`. Current #307 server always writes `0`.
+    #[must_use]
+    pub fn from_wire(byte: u8) -> Option<Self> {
+        match byte {
+            0 => Some(Self::Control),
+            1 => Some(Self::Listen),
+            _ => None,
+        }
+    }
+
+    /// The 1-byte wire value.
+    #[must_use]
+    pub fn to_wire(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Status code in the server's response block. Reserved —
+/// #307 only ever emits [`Self::Ok`]; #392 and #394 use the other
+/// variants when roles / auth are active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Status {
+    /// Negotiation succeeded. Client proceeds to the IQ stream.
+    Ok = 0,
+    /// Controller slot is busy and the client didn't request
+    /// takeover. Reserved for #392.
+    ControllerBusy = 1,
+    /// Server requires an auth key and the client didn't provide
+    /// one. Reserved for #394.
+    AuthRequired = 2,
+    /// Client-provided auth key didn't match. Reserved for #394.
+    AuthFailed = 3,
+}
+
+impl Status {
+    /// Decode the 1-byte wire value. Unknown values → `None` so
+    /// the client can log + treat as a protocol error rather
+    /// than crash.
+    #[must_use]
+    pub fn from_wire(byte: u8) -> Option<Self> {
+        match byte {
+            0 => Some(Self::Ok),
+            1 => Some(Self::ControllerBusy),
+            2 => Some(Self::AuthRequired),
+            3 => Some(Self::AuthFailed),
+            _ => None,
+        }
+    }
+
+    /// The 1-byte wire value.
+    #[must_use]
+    pub fn to_wire(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Client → server hello — 8 bytes on the wire, fixed layout.
+/// See the module docs for the byte-by-byte layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClientHello {
+    /// Codecs the client is willing to negotiate (#307).
+    pub codec_mask: CodecMask,
+    /// Role the client is requesting (#392 — #307 server ignores
+    /// and treats every client as `Control`).
+    pub role: Role,
+    /// Request flags. Bit 0 = request_takeover (#393).
+    pub flags: u8,
+    /// Hello schema version. Always [`PROTOCOL_VERSION`] for
+    /// clients built against this crate; decoded for future-
+    /// compat checks.
+    pub version: u8,
+}
+
+/// Flag bit indicating the client wants to kick the current
+/// controller if the slot is occupied. Reserved for #393.
+pub const FLAG_REQUEST_TAKEOVER: u8 = 1 << 0;
+
+impl ClientHello {
+    /// Serialize to its 8-byte wire representation.
+    #[must_use]
+    pub fn to_bytes(self) -> [u8; CLIENT_HELLO_LEN] {
+        let mut out = [0u8; CLIENT_HELLO_LEN];
+        out[..4].copy_from_slice(&EXTENSION_MAGIC);
+        out[4] = self.codec_mask.to_wire();
+        out[5] = self.role.to_wire();
+        out[6] = self.flags;
+        out[7] = self.version;
+        out
+    }
+
+    /// Parse from its 8-byte wire representation. Returns `None`
+    /// if the magic doesn't match or the role byte is unknown —
+    /// the server falls through to the legacy path in either case.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8; CLIENT_HELLO_LEN]) -> Option<Self> {
+        if bytes[..4] != EXTENSION_MAGIC {
+            return None;
+        }
+        let role = Role::from_wire(bytes[5])?;
+        Some(Self {
+            codec_mask: CodecMask::from_wire(bytes[4]),
+            role,
+            flags: bytes[6],
+            version: bytes[7],
+        })
+    }
+
+    /// Convenience: does the caller's flags byte request takeover?
+    #[must_use]
+    pub fn request_takeover(self) -> bool {
+        self.flags & FLAG_REQUEST_TAKEOVER != 0
+    }
+}
+
+/// Server → client extension response — 8 bytes on the wire,
+/// fixed layout. Written immediately after the legacy
+/// `dongle_info_t` when (and only when) the server accepted a
+/// valid [`ClientHello`]. See the module docs for the layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerExtension {
+    /// Chosen codec for this connection (#307).
+    pub codec: Codec,
+    /// Role the server granted. `None` means denied (wire byte =
+    /// 255) — #392 semantics; #307 server always emits
+    /// `Some(Role::Control)`.
+    pub granted_role: Option<Role>,
+    /// Outcome status (#392/#394). `Status::Ok` in #307.
+    pub status: Status,
+    /// Response schema version.
+    pub version: u8,
+}
+
+/// Sentinel byte used in the `granted_role` field to signal
+/// "request denied" — reserved for #392.
+pub const GRANTED_ROLE_DENIED: u8 = 0xFF;
+
+impl ServerExtension {
+    /// Serialize to its 8-byte wire representation.
+    #[must_use]
+    pub fn to_bytes(self) -> [u8; SERVER_EXTENSION_LEN] {
+        let mut out = [0u8; SERVER_EXTENSION_LEN];
+        out[..4].copy_from_slice(&EXTENSION_MAGIC);
+        out[4] = self.codec.to_wire();
+        out[5] = self.granted_role.map_or(GRANTED_ROLE_DENIED, Role::to_wire);
+        out[6] = self.status.to_wire();
+        out[7] = self.version;
+        out
+    }
+
+    /// Parse from its 8-byte wire representation. Returns `None`
+    /// when the magic doesn't match (client peeked random IQ
+    /// data) or any enum-typed byte is unknown. Callers fall back
+    /// to the legacy uncompressed path on `None`.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8; SERVER_EXTENSION_LEN]) -> Option<Self> {
+        if bytes[..4] != EXTENSION_MAGIC {
+            return None;
+        }
+        let codec = Codec::from_wire(bytes[4])?;
+        let granted_role = if bytes[5] == GRANTED_ROLE_DENIED {
+            None
+        } else {
+            Some(Role::from_wire(bytes[5])?)
+        };
+        let status = Status::from_wire(bytes[6])?;
+        Some(Self {
+            codec,
+            granted_role,
+            status,
+            version: bytes[7],
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_hello_round_trip() {
+        let hello = ClientHello {
+            codec_mask: CodecMask::NONE_AND_LZ4,
+            role: Role::Control,
+            flags: FLAG_REQUEST_TAKEOVER,
+            version: PROTOCOL_VERSION,
+        };
+        let bytes = hello.to_bytes();
+        assert_eq!(bytes.len(), CLIENT_HELLO_LEN);
+        assert_eq!(&bytes[..4], &EXTENSION_MAGIC);
+        assert_eq!(ClientHello::from_bytes(&bytes), Some(hello));
+    }
+
+    #[test]
+    fn client_hello_rejects_bad_magic() {
+        // Legacy commands leak into the hello slot when a client
+        // talks to a vanilla server that didn't consume them
+        // cleanly. Magic mismatch → None, so the server falls
+        // through to its legacy path.
+        let mut bytes = [0u8; CLIENT_HELLO_LEN];
+        bytes[..4].copy_from_slice(b"RTLY"); // wrong
+        assert!(ClientHello::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn client_hello_rejects_unknown_role() {
+        let mut bytes = [0u8; CLIENT_HELLO_LEN];
+        bytes[..4].copy_from_slice(&EXTENSION_MAGIC);
+        bytes[4] = CodecMask::NONE_ONLY.to_wire();
+        bytes[5] = 99; // unknown role byte
+        bytes[7] = PROTOCOL_VERSION;
+        assert!(ClientHello::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn server_extension_round_trip() {
+        let ext = ServerExtension {
+            codec: Codec::Lz4,
+            granted_role: Some(Role::Control),
+            status: Status::Ok,
+            version: PROTOCOL_VERSION,
+        };
+        let bytes = ext.to_bytes();
+        assert_eq!(bytes.len(), SERVER_EXTENSION_LEN);
+        assert_eq!(&bytes[..4], &EXTENSION_MAGIC);
+        assert_eq!(ServerExtension::from_bytes(&bytes), Some(ext));
+    }
+
+    #[test]
+    fn server_extension_denied_role_round_trips() {
+        // #392 path: the server encodes "denied" as the 0xFF
+        // sentinel. Decoder maps it back to `None`.
+        let ext = ServerExtension {
+            codec: Codec::None,
+            granted_role: None,
+            status: Status::ControllerBusy,
+            version: PROTOCOL_VERSION,
+        };
+        let bytes = ext.to_bytes();
+        assert_eq!(bytes[5], GRANTED_ROLE_DENIED);
+        assert_eq!(ServerExtension::from_bytes(&bytes), Some(ext));
+    }
+
+    #[test]
+    fn server_extension_rejects_bad_magic() {
+        // Client peeked random IQ data that happens NOT to match
+        // `"RTLX"`. Decoder returns None → client falls back to
+        // legacy uncompressed read, and those 4 peeked bytes
+        // stay in the TCP read buffer for the next stream read.
+        let mut bytes = [0u8; SERVER_EXTENSION_LEN];
+        bytes[..4].copy_from_slice(b"\x00\x01\x02\x03"); // unlikely in IQ; arbitrary
+        assert!(ServerExtension::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn client_hello_takeover_flag_helper() {
+        let with_flag = ClientHello {
+            codec_mask: CodecMask::NONE_ONLY,
+            role: Role::Control,
+            flags: FLAG_REQUEST_TAKEOVER,
+            version: PROTOCOL_VERSION,
+        };
+        assert!(with_flag.request_takeover());
+
+        let without_flag = ClientHello {
+            flags: 0,
+            ..with_flag
+        };
+        assert!(!without_flag.request_takeover());
+    }
+
+    #[test]
+    fn magic_first_byte_not_a_legacy_opcode() {
+        // Defense-in-depth: if a sdr-rs client accidentally
+        // sends a hello to a vanilla rtl_tcp server, the first
+        // byte `'R' = 0x52` must NOT collide with a real
+        // command opcode, or the server would try to execute it.
+        // Documented opcodes are 0x01..=0x0E (per rtl_tcp.c); our
+        // magic's first byte sits well above that range.
+        assert!(EXTENSION_MAGIC[0] > 0x0E);
+    }
+}

--- a/crates/sdr-server-rtltcp/src/extension.rs
+++ b/crates/sdr-server-rtltcp/src/extension.rs
@@ -171,6 +171,13 @@ pub struct ClientHello {
 /// controller if the slot is occupied. Reserved for #393.
 pub const FLAG_REQUEST_TAKEOVER: u8 = 1 << 0;
 
+/// Full [`ClientHello::flags`] value for the "no flags set" case —
+/// the #307 common path, where the client isn't requesting a
+/// takeover and has no other bits to assert. Named constant so
+/// callers don't litter the codebase with bare `0` literals that
+/// silently mean "don't set any flag bit".
+pub const CLIENT_HELLO_FLAGS_NONE: u8 = 0;
+
 impl ClientHello {
     /// Serialize to its 8-byte wire representation.
     #[must_use]

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -31,6 +31,7 @@
 pub mod codec;
 pub mod dispatch;
 pub mod error;
+pub mod extension;
 pub mod protocol;
 pub mod server;
 

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -28,6 +28,7 @@
 //! threading model in [`server`]; command-to-device translation in
 //! [`dispatch`]. See module docs for the upstream line-number references.
 
+pub mod codec;
 pub mod dispatch;
 pub mod error;
 pub mod protocol;

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -864,16 +864,22 @@ fn handle_client(
         let _ = reader_handle.join();
         return;
     }
-    // Wrap the writer in the negotiated codec. Legacy clients
-    // get a pass-through (`Codec::None`) so the write path
-    // stays byte-identical to the pre-#307 behavior.
-    let encoded_writer = Encoder::new(negotiated_codec.unwrap_or(Codec::None), writer);
+    // Wrap the socket in the stats-tracking adapter BEFORE the
+    // encoder so `bytes_sent` reflects post-compression bytes
+    // (what actually hit the wire), then wrap in the negotiated
+    // codec. Legacy clients get a pass-through (`Codec::None`),
+    // so the write path stays byte-identical to the pre-#307
+    // behavior — on-wire bytes equal payload bytes in that case.
+    let tracked_writer = StatsTrackingWrite {
+        inner: writer,
+        stats: stats.clone(),
+    };
+    let encoded_writer = Encoder::new(negotiated_codec.unwrap_or(Codec::None), tracked_writer);
     let writer_shutdown = merged_shutdown.clone();
-    let writer_stats = stats.clone();
     let Ok(writer_handle) = thread::Builder::new()
         .name("rtl_tcp-writer".into())
         .spawn(move || {
-            tcp_writer(encoded_writer, rx, writer_shutdown, writer_stats);
+            tcp_writer(encoded_writer, rx, writer_shutdown);
         })
     else {
         tracing::error!("failed to spawn rtl_tcp writer thread — tearing down client");
@@ -1028,17 +1034,53 @@ fn data_worker(
     }
 }
 
+/// `Write` adapter that mirrors the underlying [`TcpStream`] but
+/// updates [`ServerStats::bytes_sent`] with the post-compression
+/// byte count from each successful write. Placed between the
+/// [`Encoder`] and the socket so the stat reflects **on-wire**
+/// throughput instead of pre-compression payload size — otherwise
+/// the server-panel's data-rate row would show raw sample rate
+/// even when LZ4 is active and operators couldn't see whether
+/// compression was actually saving bandwidth.
+///
+/// Per CodeRabbit round 1 on PR #399.
+struct StatsTrackingWrite {
+    inner: TcpStream,
+    stats: Arc<Mutex<ServerStats>>,
+}
+
+impl Write for StatsTrackingWrite {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        // Poisoned mutex only happens if a stats reader panicked
+        // while holding the lock — we'd rather keep streaming and
+        // let the stats drift than tear the session down. Matches
+        // the existing lock-use pattern in data_worker.
+        if let Ok(mut s) = self.stats.lock() {
+            s.bytes_sent = s.bytes_sent.saturating_add(n as u64);
+        }
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 fn tcp_writer<W: Write + Send>(
     mut stream: W,
     rx: std::sync::mpsc::Receiver<Vec<u8>>,
     shutdown: MergedShutdown,
-    stats: Arc<Mutex<ServerStats>>,
 ) {
     // Write timeout is installed by the caller on the underlying
     // `TcpStream` before wrapping in the codec — see the comment
     // in `handle_client` where the timeout is set up. Putting it
     // here would lose visibility into the inner stream when
     // `stream` is an `Encoder`.
+    //
+    // `bytes_sent` bookkeeping is handled by `StatsTrackingWrite`
+    // one layer below the encoder, so this function no longer
+    // needs a `stats` arg. On-wire counts land there directly.
     //
     // `recv_timeout` lets us notice shutdown even when the USB
     // reader is starving (e.g., dongle unplug).
@@ -1053,8 +1095,21 @@ fn tcp_writer<W: Write + Send>(
                     shutdown.set_client();
                     return;
                 }
-                if let Ok(mut s) = stats.lock() {
-                    s.bytes_sent = s.bytes_sent.saturating_add(buf.len() as u64);
+                // Flush after every chunk so the LZ4 frame encoder
+                // (when active) doesn't hold a partial block in its
+                // internal buffer waiting for the next USB chunk to
+                // fill it out to the 64 KiB frame-block size. On
+                // low-rate streams that buffering adds minutes of
+                // audio latency and can trip the client's stall-
+                // detection timeout. Pass-through `Codec::None`
+                // flushes to `TcpStream::flush()`, which is a no-op
+                // on Linux (writes go direct to the kernel send
+                // buffer), so the legacy path pays nothing. Per
+                // CodeRabbit round 1 on PR #399.
+                if let Err(e) = stream.flush() {
+                    tracing::debug!(%e, "rtl_tcp client socket flush failed, closing");
+                    shutdown.set_client();
+                    return;
                 }
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -692,23 +692,26 @@ const HELLO_SNIFF_TIMEOUT: Duration = Duration::from_millis(100);
 /// Return cases:
 ///
 /// - `Ok(Some(hello))` — valid 8-byte hello, fully consumed.
-/// - `Ok(None)` — **only** when the peek returned zero bytes or
-///   timed out before any magic prefix arrived. Safe legacy
-///   fallback: bytes (of which there are none) stay in the
-///   receive buffer and the command reader takes over.
-/// - `Err(_)` — protocol error (drop the client). Covers: any
+/// - `Ok(None)` — legacy fallback. Reached either on a zero-byte
+///   timeout/EOF (idle client never sent anything) OR on a
 ///   non-zero peek whose prefix doesn't match [`EXTENSION_MAGIC`]
-///   but that we've nonetheless observed; a `read_exact` timeout
-///   or EOF after the magic already matched (partial-hello); a
-///   parse failure on a fully-received 8-byte block. All of
-///   these would otherwise desync the command stream.
+///   (legacy client sent a command; the bytes stay queued in the
+///   receive buffer so `command_worker` can parse the 5-byte
+///   frame). Nothing is consumed in either sub-case.
+/// - `Err(_)` — protocol error, raised only after the magic
+///   already matched and we committed to reading a full 8 bytes.
+///   Covers `read_exact` timeout or EOF mid-hello (partial hello,
+///   bytes already drained from the stream) and parse failure
+///   on a complete 8-byte block (unknown role, unknown protocol
+///   version, etc.). Falling back to legacy from either of these
+///   states would desync the command stream, so the caller drops
+///   the client.
 ///
-/// Uses `peek()` first so legitimate legacy traffic (a zero-byte
-/// idle client, or a command whose opcode happens to precede the
-/// magic prefix) stays intact. Once the magic matches we commit
-/// to reading the full 8 bytes; partial reads are fatal because
-/// we can't un-consume the half we already read. Per CodeRabbit
-/// round 2 on PR #399.
+/// Uses `peek()` for the initial magic check so legitimate legacy
+/// traffic stays intact. Once the magic matches we commit to
+/// reading the full 8 bytes; partial reads are fatal because we
+/// can't un-consume the half we already read. Per CodeRabbit
+/// round 2 on PR #399 (initial fix) + round 3 (doc alignment).
 fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHello>> {
     stream.set_read_timeout(Some(HELLO_SNIFF_TIMEOUT))?;
     // Peek the first 4 bytes (magic-only check). `peek` maps to

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -245,6 +245,7 @@ pub struct Server {
     stats: Arc<Mutex<ServerStats>>,
     bind: SocketAddr,
     tuner: TunerAdvertiseInfo,
+    compression: crate::codec::CodecMask,
 }
 
 impl Server {
@@ -326,6 +327,7 @@ impl Server {
             stats,
             bind: actual_bind,
             tuner,
+            compression: config.compression,
         })
     }
 
@@ -345,6 +347,15 @@ impl Server {
     /// to keep the server crate free of mDNS deps.
     pub fn tuner_info(&self) -> &TunerAdvertiseInfo {
         &self.tuner
+    }
+
+    /// Codec mask the server is willing to negotiate. The mDNS
+    /// advertiser calls this to stamp a `codecs=` TXT entry so
+    /// clients can decide up-front whether to send the extended
+    /// `"RTLX"` hello (a vanilla client that doesn't recognize the
+    /// key just connects the legacy way — see #307).
+    pub fn compression(&self) -> crate::codec::CodecMask {
+        self.compression
     }
 
     /// Has the accept thread exited (either via `stop()` or an

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -687,30 +687,45 @@ fn update_stats_on_disconnect(stats: &Arc<Mutex<ServerStats>>) {
 const HELLO_SNIFF_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Try to read + parse an extended-protocol [`ClientHello`] from
-/// `stream` within [`HELLO_SNIFF_TIMEOUT`]. Returns `Ok(Some)` on
-/// a valid hello (consuming 8 bytes), `Ok(None)` on timeout or
-/// non-`"RTLX"` leading bytes (legacy path; bytes remain in the
-/// receive buffer for the command reader if they were a command),
-/// `Err` on fatal socket state.
+/// `stream` within [`HELLO_SNIFF_TIMEOUT`].
 ///
-/// Uses `peek()` first so non-hello traffic stays intact — a
-/// legacy command starting with an opcode that happens to be
-/// shorter than 8 bytes isn't lost to a partial `read_exact`.
-/// If the magic matches, only then do we commit to consuming
-/// the full 8-byte hello.
+/// Return cases:
+///
+/// - `Ok(Some(hello))` — valid 8-byte hello, fully consumed.
+/// - `Ok(None)` — **only** when the peek returned zero bytes or
+///   timed out before any magic prefix arrived. Safe legacy
+///   fallback: bytes (of which there are none) stay in the
+///   receive buffer and the command reader takes over.
+/// - `Err(_)` — protocol error (drop the client). Covers: any
+///   non-zero peek whose prefix doesn't match [`EXTENSION_MAGIC`]
+///   but that we've nonetheless observed; a `read_exact` timeout
+///   or EOF after the magic already matched (partial-hello); a
+///   parse failure on a fully-received 8-byte block. All of
+///   these would otherwise desync the command stream.
+///
+/// Uses `peek()` first so legitimate legacy traffic (a zero-byte
+/// idle client, or a command whose opcode happens to precede the
+/// magic prefix) stays intact. Once the magic matches we commit
+/// to reading the full 8 bytes; partial reads are fatal because
+/// we can't un-consume the half we already read. Per CodeRabbit
+/// round 2 on PR #399.
 fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHello>> {
     stream.set_read_timeout(Some(HELLO_SNIFF_TIMEOUT))?;
     // Peek the first 4 bytes (magic-only check). `peek` maps to
     // `recv(…, MSG_PEEK)` which respects `SO_RCVTIMEO`, so this
     // returns WouldBlock / TimedOut after the timeout without
     // consuming bytes.
-    let mut peek_buf = [0u8; 4];
+    let mut peek_buf = [0u8; EXTENSION_MAGIC.len()];
     let peeked = match stream.peek(&mut peek_buf) {
         Ok(n) => n,
         Err(e)
             if e.kind() == std::io::ErrorKind::WouldBlock
                 || e.kind() == std::io::ErrorKind::TimedOut =>
         {
+            // Pure timeout with zero bytes observed — the client
+            // never sent anything, so this is an idle legacy peer
+            // (or a port scanner). Safe to fall back; no bytes
+            // were consumed.
             stream.set_read_timeout(None)?;
             return Ok(None);
         }
@@ -721,26 +736,50 @@ fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHe
             return Err(e);
         }
     };
-    if peeked < 4 || peek_buf[..4] != EXTENSION_MAGIC {
-        // Legacy client — either sent fewer than 4 bytes (most
-        // likely zero; legacy clients idle waiting for
-        // `dongle_info`) or the first bytes aren't the sdr-rs
-        // magic. Either way, leave the bytes in the kernel
-        // buffer for the command reader and return None.
+    if peeked == 0 {
+        // Peer closed cleanly before sending anything. Same
+        // safety as a timeout-with-zero-bytes: no bytes consumed,
+        // nothing to desync.
         stream.set_read_timeout(None)?;
         return Ok(None);
     }
-    // Magic matched — commit to consuming 8 bytes. `read_exact`
-    // may block up to the timeout for the remaining 4 bytes;
-    // if the client sent only 4 bytes and is hanging, we treat
-    // that as a protocol error (return None and fall through).
+    if peeked < EXTENSION_MAGIC.len() || peek_buf[..EXTENSION_MAGIC.len()] != EXTENSION_MAGIC {
+        // Legacy client — either sent fewer than 4 bytes but
+        // something (so we can't tell if they might still be
+        // sending a hello), or the first bytes aren't the
+        // sdr-rs magic. Preserving bytes for the command reader
+        // is only safe when we know they're the start of a
+        // command: a vanilla `SetCenterFreq` starts with 0x01,
+        // no documented opcode begins with 'R' (0x52), so a
+        // mismatch on a full 4-byte peek is a legitimate legacy
+        // command. A short prefix that doesn't match magic is
+        // ambiguous but benign — the command reader will parse
+        // it as a 5-byte command frame and dispatch or log
+        // unknown-opcode.
+        stream.set_read_timeout(None)?;
+        return Ok(None);
+    }
+    // Magic matched — commit to consuming 8 bytes. A timeout or
+    // EOF here is no longer a safe fallback: we've verified the
+    // client started an extended hello and consumed `read_exact`
+    // will have eaten whatever bytes arrived before the stall.
+    // Returning `Ok(None)` would let the legacy path start
+    // against a shifted command stream — exactly the desync
+    // CodeRabbit round 2 flagged. Treat every failure mode as a
+    // protocol error and drop the client.
     let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
     let read_result = stream.read_exact(&mut hello_buf);
     stream.set_read_timeout(None)?;
-    match read_result {
-        Ok(()) => Ok(ClientHello::from_bytes(&hello_buf)),
-        Err(_) => Ok(None),
-    }
+    read_result?;
+    ClientHello::from_bytes(&hello_buf)
+        .map(Some)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "RTLX magic matched but ClientHello body failed to parse (unknown role or \
+             malformed field)",
+            )
+        })
 }
 
 /// Serve exactly one client. Spawns the three worker threads, waits for
@@ -1404,5 +1443,147 @@ mod tests {
         // DEFAULT_BUFFER_CAPACITY matches upstream's llbuf_num = 500
         // (rtl_tcp.c:61).
         assert_eq!(DEFAULT_BUFFER_CAPACITY, 500);
+    }
+
+    // ============================================================
+    // sniff_client_hello regression tests (CodeRabbit round 2 on PR #399)
+    //
+    // The sniff is the only piece of `handle_client` that can run
+    // without a real RTL-SDR dongle, so unit tests live here.
+    // Each test pairs a server-side accept with a client-side TCP
+    // connect + controlled write pattern, verifying that
+    // `sniff_client_hello` classifies the stream correctly.
+    // ============================================================
+
+    /// Accept one TCP client on a loopback listener and hand the
+    /// accepted socket to `sniff_client_hello`. Factored out so
+    /// each scenario test stays focused on what bytes the client
+    /// writes, not the boilerplate of setting up sockets.
+    fn run_sniff_against<F>(client_behavior: F) -> std::io::Result<Option<ClientHello>>
+    where
+        F: FnOnce(TcpStream) + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client_thread = thread::spawn(move || {
+            let client = TcpStream::connect(addr).unwrap();
+            client_behavior(client);
+        });
+        let (server_stream, _peer) = listener.accept().unwrap();
+        let result = sniff_client_hello(&server_stream);
+        // Join best-effort — the client thread may legitimately still
+        // be holding the connection open (partial-hello test). Drop
+        // the server side first so any pending write on the client
+        // side unblocks, then join.
+        drop(server_stream);
+        let _ = client_thread.join();
+        result
+    }
+
+    #[test]
+    fn sniff_client_hello_full_hello_parses_correctly() {
+        // Happy path: client sends a complete 8-byte hello, sniff
+        // returns `Ok(Some)` with the parsed struct. Regression
+        // guard against a future refactor breaking the common case.
+        use crate::codec::CodecMask;
+        use crate::extension::{CLIENT_HELLO_FLAGS_NONE, Role};
+        let hello = ClientHello {
+            codec_mask: CodecMask::NONE_AND_LZ4,
+            role: Role::Control,
+            flags: CLIENT_HELLO_FLAGS_NONE,
+            version: PROTOCOL_VERSION,
+        };
+        let bytes = hello.to_bytes();
+        let result = run_sniff_against(move |mut client| {
+            client.write_all(&bytes).unwrap();
+            // Let the server finish reading before the client
+            // stream drops (which would EOF mid-read).
+            thread::sleep(Duration::from_millis(50));
+        });
+        assert_eq!(result.unwrap(), Some(hello));
+    }
+
+    #[test]
+    fn sniff_client_hello_idle_client_returns_legacy_fallback() {
+        // Legacy rtl_tcp client: connects, then idles waiting for
+        // the server's `dongle_info_t`. Zero bytes reach the sniff
+        // before the timeout fires, so `Ok(None)` is the safe
+        // fallback — nothing consumed, no desync risk.
+        let result = run_sniff_against(|client| {
+            // Hold the socket open well past the sniff timeout.
+            thread::sleep(HELLO_SNIFF_TIMEOUT * 3);
+            drop(client);
+        });
+        match result {
+            Ok(None) => {}
+            other => panic!("expected Ok(None) for idle client, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sniff_client_hello_non_magic_prefix_is_legacy_fallback() {
+        // Vanilla client sends a `SetCenterFreq` command
+        // immediately after connect (opcode 0x01 + 4-byte arg).
+        // Peek reads 4 bytes, magic doesn't match, sniff returns
+        // `Ok(None)` without consuming — so the command_worker
+        // reads the full 5-byte frame cleanly.
+        let result = run_sniff_against(|mut client| {
+            // 5-byte vanilla SetCenterFreq command: opcode=0x01,
+            // freq=100_000_000 Hz big-endian.
+            let cmd: [u8; 5] = [0x01, 0x05, 0xF5, 0xE1, 0x00];
+            client.write_all(&cmd).unwrap();
+            thread::sleep(Duration::from_millis(100));
+        });
+        match result {
+            Ok(None) => {}
+            other => panic!("expected Ok(None) for non-RTLX prefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sniff_client_hello_partial_hello_is_protocol_error() {
+        // **Regression test for CodeRabbit round 2 on PR #399.**
+        // A client that sends the 4-byte `RTLX` magic and then
+        // stalls without sending the remaining 4 hello bytes used
+        // to fall back to the legacy path — which desynced the
+        // command stream by 4 bytes (those magic bytes were
+        // already consumed by `read_exact` before it timed out).
+        // The fix promotes partial-hello to `Err` so the client
+        // gets dropped instead.
+        let result = run_sniff_against(|mut client| {
+            // Send magic only; hold the connection open past the
+            // sniff timeout so `read_exact` observes partial data.
+            client.write_all(&EXTENSION_MAGIC).unwrap();
+            thread::sleep(HELLO_SNIFF_TIMEOUT * 5);
+            drop(client);
+        });
+        assert!(
+            result.is_err(),
+            "partial hello (magic only, body stalled) must surface as Err — \
+             got {result:?} which would desync the command stream on fallback"
+        );
+    }
+
+    #[test]
+    fn sniff_client_hello_malformed_body_is_protocol_error() {
+        // Client sends a full 8 bytes starting with `RTLX` but with
+        // an unknown role byte (0x99). Body parses as `None` →
+        // protocol error. Previously returned `Ok(None)` (legacy
+        // fallback on a shifted stream — desync risk).
+        let mut garbled = [0u8; CLIENT_HELLO_LEN];
+        garbled[..EXTENSION_MAGIC.len()].copy_from_slice(&EXTENSION_MAGIC);
+        garbled[4] = 0x03; // codec mask (NONE+LZ4)
+        garbled[5] = 0x99; // invalid role — from_bytes returns None
+        garbled[6] = 0x00; // flags
+        garbled[7] = PROTOCOL_VERSION;
+        let result = run_sniff_against(move |mut client| {
+            client.write_all(&garbled).unwrap();
+            thread::sleep(Duration::from_millis(50));
+        });
+        assert!(
+            result.is_err(),
+            "malformed hello body (magic matched, unknown role) must surface as Err — \
+             got {result:?}"
+        );
     }
 }

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -28,8 +28,13 @@ use std::time::{Duration, Instant};
 
 use sdr_rtlsdr::device::RtlSdrDevice;
 
+use crate::codec::{Codec, CodecMask, Encoder};
 use crate::dispatch::dispatch;
 use crate::error::ServerError;
+use crate::extension::{
+    CLIENT_HELLO_LEN, ClientHello, EXTENSION_MAGIC, PROTOCOL_VERSION, Role, ServerExtension,
+    Status,
+};
 use crate::protocol::{COMMAND_LEN, Command, CommandOp, DongleInfo, TunerTypeCode};
 
 /// USB read buffer size (bytes). Matches `DEFAULT_BUF_LENGTH` upstream
@@ -106,6 +111,17 @@ pub struct ServerConfig {
     /// Max queued buffers between USB reader and TCP writer. 0 = use
     /// [`DEFAULT_BUFFER_CAPACITY`].
     pub buffer_capacity: usize,
+
+    /// Codecs this server is willing to offer to sdr-rs clients
+    /// that speak the extended `"RTLX"` handshake (#307). Per-
+    /// connection negotiation is the intersection of this mask
+    /// and the client's advertised mask (`CodecMask::pick`):
+    /// legacy / vanilla-rtl_tcp clients that don't send a hello
+    /// always get `Codec::None`; sdr-rs clients supporting LZ4
+    /// get LZ4 iff this mask advertises it. Default:
+    /// [`CodecMask::NONE_ONLY`] — compression is opt-in per-
+    /// server so existing deployments behave identically.
+    pub compression: crate::codec::CodecMask,
 }
 
 impl ServerConfig {
@@ -118,6 +134,7 @@ impl ServerConfig {
             device_index: 0,
             initial: InitialDeviceState::default(),
             buffer_capacity: DEFAULT_BUFFER_CAPACITY,
+            compression: crate::codec::CodecMask::NONE_ONLY,
         }
     }
 }
@@ -299,6 +316,7 @@ impl Server {
             stats.clone(),
             capacity,
             config.initial.clone(),
+            config.compression,
         )?;
 
         Ok(Server {
@@ -424,6 +442,12 @@ fn apply_initial_state(
 ///
 /// Returns `Err` on thread spawn failure (rare — kernel resource
 /// exhaustion). Callers propagate up to the user.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "#307 grew the accept-thread signature with `compression`; \
+              refactoring to a context struct would churn every caller \
+              without improving readability"
+)]
 fn spawn_accept_thread(
     listener: TcpListener,
     device: Arc<Mutex<RtlSdrDevice>>,
@@ -432,6 +456,7 @@ fn spawn_accept_thread(
     stats: Arc<Mutex<ServerStats>>,
     buffer_capacity: usize,
     initial_state: InitialDeviceState,
+    compression: CodecMask,
 ) -> std::io::Result<JoinHandle<()>> {
     // Poll-accept cadence means the listener must be nonblocking.
     // Configure it BEFORE spawning so failures surface through
@@ -506,6 +531,7 @@ fn spawn_accept_thread(
                         let session_shutdown = shutdown.clone();
                         let session_stats = stats.clone();
                         let session_busy = busy.clone();
+                        let session_compression = compression;
                         match thread::Builder::new().name("rtl_tcp-session".into()).spawn(
                             move || {
                                 handle_client(
@@ -514,6 +540,7 @@ fn spawn_accept_thread(
                                     session_shutdown,
                                     session_stats.clone(),
                                     buffer_capacity,
+                                    session_compression,
                                 );
                                 update_stats_on_disconnect(&session_stats);
                                 tracing::info!(%peer, "rtl_tcp client disconnected");
@@ -641,15 +668,116 @@ fn update_stats_on_disconnect(stats: &Arc<Mutex<ServerStats>>) {
     }
 }
 
+/// How long the server waits on a fresh TCP connection for a
+/// `ClientHello` before assuming the client is a legacy vanilla
+/// `rtl_tcp` peer and falling through to the unchanged legacy
+/// path. Short enough to be invisible to the user (RTL-SDR init
+/// takes full seconds anyway); long enough to cover LAN RTT
+/// jitter. Per #307.
+const HELLO_SNIFF_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Try to read + parse an extended-protocol [`ClientHello`] from
+/// `stream` within [`HELLO_SNIFF_TIMEOUT`]. Returns `Ok(Some)` on
+/// a valid hello (consuming 8 bytes), `Ok(None)` on timeout or
+/// non-`"RTLX"` leading bytes (legacy path; bytes remain in the
+/// receive buffer for the command reader if they were a command),
+/// `Err` on fatal socket state.
+///
+/// Uses `peek()` first so non-hello traffic stays intact — a
+/// legacy command starting with an opcode that happens to be
+/// shorter than 8 bytes isn't lost to a partial `read_exact`.
+/// If the magic matches, only then do we commit to consuming
+/// the full 8-byte hello.
+fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHello>> {
+    stream.set_read_timeout(Some(HELLO_SNIFF_TIMEOUT))?;
+    // Peek the first 4 bytes (magic-only check). `peek` maps to
+    // `recv(…, MSG_PEEK)` which respects `SO_RCVTIMEO`, so this
+    // returns WouldBlock / TimedOut after the timeout without
+    // consuming bytes.
+    let mut peek_buf = [0u8; 4];
+    let peeked = match stream.peek(&mut peek_buf) {
+        Ok(n) => n,
+        Err(e)
+            if e.kind() == std::io::ErrorKind::WouldBlock
+                || e.kind() == std::io::ErrorKind::TimedOut =>
+        {
+            stream.set_read_timeout(None)?;
+            return Ok(None);
+        }
+        Err(e) => {
+            // Other errors (ECONNRESET, etc.) → propagate so the
+            // caller tears down cleanly.
+            stream.set_read_timeout(None)?;
+            return Err(e);
+        }
+    };
+    if peeked < 4 || peek_buf[..4] != EXTENSION_MAGIC {
+        // Legacy client — either sent fewer than 4 bytes (most
+        // likely zero; legacy clients idle waiting for
+        // `dongle_info`) or the first bytes aren't the sdr-rs
+        // magic. Either way, leave the bytes in the kernel
+        // buffer for the command reader and return None.
+        stream.set_read_timeout(None)?;
+        return Ok(None);
+    }
+    // Magic matched — commit to consuming 8 bytes. `read_exact`
+    // may block up to the timeout for the remaining 4 bytes;
+    // if the client sent only 4 bytes and is hanging, we treat
+    // that as a protocol error (return None and fall through).
+    let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+    let read_result = stream.read_exact(&mut hello_buf);
+    stream.set_read_timeout(None)?;
+    match read_result {
+        Ok(()) => Ok(ClientHello::from_bytes(&hello_buf)),
+        Err(_) => Ok(None),
+    }
+}
+
 /// Serve exactly one client. Spawns the three worker threads, waits for
 /// the first to exit, signals the others, joins all.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "#307 grew the session signature with compression_offer; \
+              refactoring to a context struct would churn every rtl_tcp \
+              server test without improving readability"
+)]
 fn handle_client(
     stream: TcpStream,
     device: Arc<Mutex<RtlSdrDevice>>,
     global_shutdown: Arc<AtomicBool>,
     stats: Arc<Mutex<ServerStats>>,
     buffer_capacity: usize,
+    compression_offer: CodecMask,
 ) {
+    // Extended handshake (#307). Must happen BEFORE we write the
+    // legacy `dongle_info_t` — if the client sent an `"RTLX"`
+    // hello, we want to write the server response block
+    // immediately after the legacy header, all in one atomic
+    // stretch, so the client's `peek` for the `"RTLX"` magic
+    // lands on our bytes and not on IQ samples the data worker
+    // has queued up.
+    let negotiated_codec = match sniff_client_hello(&stream) {
+        Ok(Some(hello)) => {
+            let codec = compression_offer.pick(hello.codec_mask);
+            tracing::info!(
+                client_mask = hello.codec_mask.to_wire(),
+                server_mask = compression_offer.to_wire(),
+                chosen = %codec,
+                "rtl_tcp extended-handshake negotiated"
+            );
+            Some(codec)
+        }
+        Ok(None) => {
+            tracing::debug!("rtl_tcp no extended-handshake hello — legacy client path");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(%e, "rtl_tcp handshake sniff failed — dropping client");
+            return;
+        }
+    };
+
     // Send the 12-byte dongle_info_t header first (rtl_tcp.c:576-594).
     let header = {
         let Ok(dev) = device.lock() else {
@@ -662,16 +790,36 @@ fn handle_client(
         }
     };
     let header_bytes = header.to_bytes();
-    let mut writer = match stream.try_clone() {
+    let writer_stream = match stream.try_clone() {
         Ok(w) => w,
         Err(e) => {
             tracing::error!(%e, "failed to clone client stream for writer — dropping client");
             return;
         }
     };
+    let mut writer = writer_stream;
     if let Err(e) = writer.write_all(&header_bytes) {
         tracing::warn!(%e, "failed to send dongle_info_t — client gone");
         return;
+    }
+
+    // If we negotiated the extended protocol, emit the
+    // `ServerExtension` block immediately after `dongle_info_t`.
+    // Must land before any IQ data or the client's magic-peek
+    // after `dongle_info` will read random samples instead.
+    if let Some(codec) = negotiated_codec {
+        let ext = ServerExtension {
+            codec,
+            // #307 is single-client; role and status are reserved
+            // for #392/#394 and always report OK / Control here.
+            granted_role: Some(Role::Control),
+            status: Status::Ok,
+            version: PROTOCOL_VERSION,
+        };
+        if let Err(e) = writer.write_all(&ext.to_bytes()) {
+            tracing::warn!(%e, "failed to send RTLX server extension — client gone");
+            return;
+        }
     }
 
     // Per-client shutdown flag. Flipped when any worker exits, so the
@@ -695,12 +843,30 @@ fn handle_client(
         return;
     };
 
+    // Install the write timeout on the underlying TcpStream
+    // BEFORE wrapping in the codec's encoder — the encoder's
+    // `write()` delegates to the inner stream's `write()`, which
+    // in turn enforces `SO_SNDTIMEO`. Setting after-wrap would
+    // lose visibility into the inner stream.
+    if let Err(e) = writer.set_write_timeout(Some(WRITER_RECV_TIMEOUT)) {
+        tracing::warn!(%e, "set_write_timeout on data channel failed; dropping client");
+        merged_shutdown.set_client();
+        let _ = reader_handle.join();
+        return;
+    }
+    // Wrap the writer in the negotiated codec. Legacy clients
+    // get a pass-through (`Codec::None`) so the write path
+    // stays byte-identical to the pre-#307 behavior.
+    let encoded_writer = Encoder::new(
+        negotiated_codec.unwrap_or(Codec::None),
+        writer,
+    );
     let writer_shutdown = merged_shutdown.clone();
     let writer_stats = stats.clone();
     let Ok(writer_handle) = thread::Builder::new()
         .name("rtl_tcp-writer".into())
         .spawn(move || {
-            tcp_writer(writer, rx, writer_shutdown, writer_stats);
+            tcp_writer(encoded_writer, rx, writer_shutdown, writer_stats);
         })
     else {
         tracing::error!("failed to spawn rtl_tcp writer thread — tearing down client");
@@ -855,26 +1021,20 @@ fn data_worker(
     }
 }
 
-fn tcp_writer(
-    mut stream: TcpStream,
+fn tcp_writer<W: Write + Send>(
+    mut stream: W,
     rx: std::sync::mpsc::Receiver<Vec<u8>>,
     shutdown: MergedShutdown,
     stats: Arc<Mutex<ServerStats>>,
 ) {
-    // A slow peer that stops reading will fill its kernel receive
-    // buffer → our kernel send buffer saturates → `write_all` blocks
-    // indefinitely. Since the write path can't re-check shutdown while
-    // blocked, a wedged writer would deadlock the
-    // writer.join → handle_client → accept.join → Server::Drop chain.
-    // Setting a write timeout mirrors what `command_worker` does for
-    // reads so the same shutdown-responsiveness guarantee applies here.
-    if let Err(e) = stream.set_write_timeout(Some(WRITER_RECV_TIMEOUT)) {
-        tracing::warn!(%e, "set_write_timeout on data channel failed; dropping client");
-        shutdown.set_client();
-        return;
-    }
-    // `recv_timeout` lets us notice shutdown even when the USB reader is
-    // starving (e.g., dongle unplug).
+    // Write timeout is installed by the caller on the underlying
+    // `TcpStream` before wrapping in the codec — see the comment
+    // in `handle_client` where the timeout is set up. Putting it
+    // here would lose visibility into the inner stream when
+    // `stream` is an `Encoder`.
+    //
+    // `recv_timeout` lets us notice shutdown even when the USB
+    // reader is starving (e.g., dongle unplug).
     loop {
         if shutdown.is_set() {
             return;
@@ -1042,6 +1202,7 @@ mod tests {
             device_index: 0,
             initial: InitialDeviceState::default(),
             buffer_capacity: 0,
+            compression: CodecMask::NONE_ONLY,
         };
         match Server::start(config) {
             Err(ServerError::PortInUse(ref addr)) => {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -32,8 +32,7 @@ use crate::codec::{Codec, CodecMask, Encoder};
 use crate::dispatch::dispatch;
 use crate::error::ServerError;
 use crate::extension::{
-    CLIENT_HELLO_LEN, ClientHello, EXTENSION_MAGIC, PROTOCOL_VERSION, Role, ServerExtension,
-    Status,
+    CLIENT_HELLO_LEN, ClientHello, EXTENSION_MAGIC, PROTOCOL_VERSION, Role, ServerExtension, Status,
 };
 use crate::protocol::{COMMAND_LEN, Command, CommandOp, DongleInfo, TunerTypeCode};
 
@@ -868,10 +867,7 @@ fn handle_client(
     // Wrap the writer in the negotiated codec. Legacy clients
     // get a pass-through (`Codec::None`) so the write path
     // stays byte-identical to the pre-#307 behavior.
-    let encoded_writer = Encoder::new(
-        negotiated_codec.unwrap_or(Codec::None),
-        writer,
-    );
+    let encoded_writer = Encoder::new(negotiated_codec.unwrap_or(Codec::None), writer);
     let writer_shutdown = merged_shutdown.clone();
     let writer_stats = stats.clone();
     let Ok(writer_handle) = thread::Builder::new()

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -746,7 +746,11 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
 /// compressed bytes as raw I/Q. Per CodeRabbit round 1 on PR #399.
 fn read_server_extension(stream: &TcpStream) -> std::io::Result<ServerExtension> {
     let mut buf = [0u8; SERVER_EXTENSION_LEN];
-    <&TcpStream as std::io::Read>::read_exact(&mut &*stream, &mut buf)?;
+    // `Read` is implemented for `&TcpStream`, so shadow into a
+    // local mut binding and call `read_exact` through the trait
+    // directly — cleaner than a fully-qualified turbofish and
+    // avoids the temporary-rvalue gotcha of `(&*stream).read_exact(…)`.
+    (&mut &*stream).read_exact(&mut buf)?;
     if buf[..EXTENSION_MAGIC.len()] != EXTENSION_MAGIC {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
@@ -811,9 +815,11 @@ fn attempt_connect(
     // framing (hello is 8 bytes = 1.6 commands) and can cause
     // garbage dispatches, so we only send it when we have
     // out-of-band evidence the server speaks the extension
-    // (e.g., mDNS TXT `rtlx=1` or an explicit per-server profile
-    // setting). Default `compression = NONE_ONLY` → no hello →
-    // wire-compatible with every rtl_tcp server on earth. Per #307.
+    // (e.g., mDNS TXT `codecs=3` or an explicit per-server
+    // profile setting — see the `RtlTcpConfig.compression`
+    // doc for the full signal). Default `compression = NONE_ONLY`
+    // → no hello → wire-compatible with every rtl_tcp server on
+    // earth. Per #307.
     let extension_enabled = config.compression != CodecMask::NONE_ONLY;
     if extension_enabled {
         let hello = ClientHello {

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -47,7 +47,8 @@ use std::time::{Duration, Instant};
 use sdr_pipeline::source_manager::Source;
 use sdr_server_rtltcp::codec::{Codec, CodecMask, Decoder};
 use sdr_server_rtltcp::extension::{
-    ClientHello, EXTENSION_MAGIC, PROTOCOL_VERSION, Role, SERVER_EXTENSION_LEN, ServerExtension,
+    CLIENT_HELLO_FLAGS_NONE, ClientHello, EXTENSION_MAGIC, PROTOCOL_VERSION, Role,
+    SERVER_EXTENSION_LEN, ServerExtension, Status,
 };
 use sdr_server_rtltcp::protocol::{Command, CommandOp, DONGLE_INFO_LEN, DongleInfo, TunerTypeCode};
 use sdr_types::{Complex, SourceError};
@@ -743,12 +744,12 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
 fn read_server_extension(stream: &TcpStream) -> std::io::Result<ServerExtension> {
     let mut buf = [0u8; SERVER_EXTENSION_LEN];
     <&TcpStream as std::io::Read>::read_exact(&mut &*stream, &mut buf)?;
-    if buf[..4] != EXTENSION_MAGIC {
+    if buf[..EXTENSION_MAGIC.len()] != EXTENSION_MAGIC {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
                 "rtl_tcp extension handshake: expected `RTLX` magic after dongle_info_t, got {:02x?}",
-                &buf[..4]
+                &buf[..EXTENSION_MAGIC.len()]
             ),
         ));
     }
@@ -817,7 +818,7 @@ fn attempt_connect(
             // #307 is single-client on the server side; role and
             // flags are reserved for #390's multi-client follow-ups.
             role: Role::Control,
-            flags: 0,
+            flags: CLIENT_HELLO_FLAGS_NONE,
             version: PROTOCOL_VERSION,
         };
         if let Err(e) = (&stream).write_all(&hello.to_bytes()) {
@@ -854,6 +855,22 @@ fn attempt_connect(
     let codec = if extension_enabled {
         match read_server_extension(&stream) {
             Ok(ext) => {
+                // A non-OK status means the server parsed our hello
+                // but rejected the session (ControllerBusy,
+                // AuthRequired, AuthFailed — reserved for #392/#394
+                // but forward-compatible here). Proceeding would
+                // surface as "Connected" in the UI for what is in
+                // fact a denial. Abort so the manager retries (or
+                // the user sees the error), rather than silently
+                // appearing connected. Per CodeRabbit round 2 on
+                // PR #399.
+                if ext.status != Status::Ok {
+                    return Err(SourceError::Protocol(format!(
+                        "rtl_tcp extension rejected by server: status={:?} (wire={})",
+                        ext.status,
+                        ext.status.to_wire()
+                    )));
+                }
                 tracing::info!(
                     codec = %ext.codec,
                     status = ext.status.to_wire(),

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -682,8 +682,28 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
                 attempt = 0;
                 // At this point handshake has completed successfully.
                 replay_sticky_commands(&shared);
-                run_data_pump(stream, codec, &shared, &config);
-                // run_data_pump returned — connection dropped.
+                // `run_data_pump` returns `Ok(())` on a normal
+                // transient dropout (EOF, stall, generic socket
+                // error — all reconnect-worthy) and
+                // `Err(SourceError::Protocol(_))` on unrecoverable
+                // stream corruption (LZ4 mid-stream decode
+                // failure — the next reconnect would hit the same
+                // issue). Terminal errors route to `Failed` the
+                // same way a non-recoverable `attempt_connect`
+                // error does; transient errors fall through to
+                // the reconnect-with-backoff loop below. Per
+                // CodeRabbit round 5 on PR #399.
+                if let Err(e) = run_data_pump(stream, codec, &shared, &config) {
+                    tracing::warn!(%e, "rtl_tcp data pump terminated with non-recoverable error");
+                    set_state(
+                        &shared,
+                        ConnectionState::Failed {
+                            reason: format!("{e}"),
+                        },
+                    );
+                    return;
+                }
+                // run_data_pump returned Ok — connection dropped transiently.
             }
             Err(e) => {
                 tracing::warn!(%e, host = %host, port, attempt, "rtl_tcp connect failed");
@@ -845,9 +865,15 @@ fn attempt_connect(
         ));
     };
     let tuner = TunerInfo::from(info);
-    if let Ok(mut slot) = shared.tuner.lock() {
-        *slot = Some(tuner);
-    }
+    // NOTE: `shared.tuner` is NOT published here. Writing it
+    // before the extension read would expose stale tuner metadata
+    // via `tuner_info()` if the extension fails or the server
+    // rejects with a non-OK status — callers would see a
+    // "tuner = R820T" readback for a session that never actually
+    // reached `Connected`. The cache write now lives next to the
+    // `set_state(Connected)` call below, so the tuner is visible
+    // only once the handshake has fully succeeded. Per CodeRabbit
+    // round 5 on PR #399.
 
     // Read the server's `ServerExtension` block BEFORE publishing
     // `Connected` state — the codec is part of the state the UI
@@ -897,6 +923,15 @@ fn attempt_connect(
         Codec::None
     };
 
+    // Publish tuner metadata + Connected state together — both
+    // reflect the same "handshake fully succeeded" point. Order
+    // matters: tuner cache first, then state transition, so any
+    // UI listener that observes Connected and immediately reads
+    // `tuner_info()` sees the fresh value rather than a None
+    // (initial) or stale (previous-session) snapshot.
+    if let Ok(mut slot) = shared.tuner.lock() {
+        *slot = Some(tuner);
+    }
     set_state(shared, ConnectionState::Connected { tuner, codec });
 
     // Publish a clone of the stream for the command sender. Install a
@@ -995,7 +1030,7 @@ fn run_data_pump(
     codec: Codec,
     shared: &Arc<SharedState>,
     config: &RtlTcpConfig,
-) {
+) -> Result<(), SourceError> {
     // Wrap the TCP stream in the negotiated decoder. Legacy /
     // vanilla-server paths hit `Codec::None` which is a
     // zero-overhead pass-through; only LZ4 connections pay the
@@ -1008,6 +1043,11 @@ fn run_data_pump(
     let mut reader = Decoder::new(codec, stream);
     let mut buf = [0u8; RECV_CHUNK_BYTES];
     let mut consecutive_timeouts: u32 = 0;
+    // Default Ok path: any break out of the loop (EOF, stall,
+    // generic socket error) is a reconnect-worthy dropout, not
+    // a terminal failure. Only explicit `return Err(...)` below
+    // for LZ4 decode corruption escapes as terminal.
+    let mut outcome: Result<(), SourceError> = Ok(());
     while !shared.shutdown.load(Ordering::Relaxed) {
         match reader.read(&mut buf) {
             Ok(0) => {
@@ -1039,6 +1079,24 @@ fn run_data_pump(
                     break;
                 }
             }
+            Err(e) if codec != Codec::None && e.kind() == std::io::ErrorKind::InvalidData => {
+                // LZ4 frame corruption mid-stream — either a codec
+                // mismatch we negotiated wrong (server lied about
+                // capability) or an on-the-wire bit flip under a
+                // transport that doesn't guarantee integrity. The
+                // stream state is unrecoverable: the next read
+                // would start mid-block, so every subsequent
+                // reconnect would hit the same corruption.
+                // Surface as `SourceError::Protocol` so the
+                // connection manager routes to terminal
+                // `ConnectionState::Failed` instead of spinning
+                // on the backoff schedule forever. Per CodeRabbit
+                // round 5 on PR #399.
+                outcome = Err(SourceError::Protocol(format!(
+                    "rtl_tcp {codec} decode failed mid-stream (unrecoverable): {e}"
+                )));
+                break;
+            }
             Err(e) => {
                 tracing::info!(%e, "rtl_tcp socket read failed, will reconnect");
                 break;
@@ -1062,6 +1120,8 @@ fn run_data_pump(
     // stalls, the warning logs again rather than being suppressed by a
     // stale flag left over from the previous session.
     shared.rx_in_overflow.store(false, Ordering::Relaxed);
+
+    outcome
 }
 
 fn replay_sticky_commands(shared: &Arc<SharedState>) {

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -1403,6 +1403,10 @@ impl Source for RtlTcpSource {
 mod tests {
     use super::*;
     use std::net::TcpListener;
+    // `CLIENT_HELLO_LEN` is only consumed by the loopback fixtures
+    // in the RTLX handshake tests below — keep it in test scope
+    // so the lib build doesn't warn it as unused.
+    use sdr_server_rtltcp::extension::CLIENT_HELLO_LEN;
 
     /// Placeholder host/port for tests that never actually connect —
     /// just exercise builder state or buffer logic. The string "127.0.0.1"
@@ -1782,6 +1786,164 @@ mod tests {
         let received = cmd_rx.recv_timeout(Duration::from_secs(2)).unwrap();
         assert_eq!(received.op, CommandOp::SetCenterFreq);
         assert_eq!(received.param, 99_500_000);
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_accepted_publishes_codec_and_tuner() {
+        // Regression test for CodeRabbit round 5 on PR #399.
+        // A server that accepts the extended handshake
+        // (`ServerExtension { codec: Lz4, status: Ok }`) must result
+        // in the client reaching `Connected { codec: Lz4, .. }` with
+        // `tuner_info()` populated. This locks in two ordering rules
+        // that earlier rounds introduced:
+        //
+        //   - The negotiated codec is part of the `Connected` state
+        //     (surfaces as the status-row suffix in the UI).
+        //   - `shared.tuner` is published atomically with the
+        //     `Connected` transition, not earlier during
+        //     `dongle_info_t` parsing.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            sock.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+            // Consume the 8-byte `ClientHello` — we just want to
+            // verify the client sent one with the extension magic.
+            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+            sock.read_exact(&mut hello_buf).expect("read hello");
+            assert_eq!(&hello_buf[..EXTENSION_MAGIC.len()], &EXTENSION_MAGIC);
+            // Send dongle_info_t + ServerExtension back-to-back so
+            // the client sees both before the read_timeout window.
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: 29,
+            }
+            .to_bytes();
+            sock.write_all(&header).unwrap();
+            let ext = ServerExtension {
+                codec: Codec::Lz4,
+                granted_role: Some(Role::Control),
+                status: Status::Ok,
+                version: PROTOCOL_VERSION,
+            };
+            sock.write_all(&ext.to_bytes()).unwrap();
+            // Hold the connection briefly so the client state
+            // observer has time to reach Connected before EOF. No
+            // IQ bytes are sent (the LZ4 decoder would need a real
+            // frame); the test only exercises the handshake path.
+            thread::sleep(Duration::from_millis(400));
+        });
+
+        let config = RtlTcpConfig {
+            data_read_timeout: Duration::from_millis(200),
+            max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            compression: CodecMask::NONE_AND_LZ4,
+        };
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        // Before starting the manager, tuner_info must be None —
+        // guards against a false positive where the delayed-publish
+        // ordering is broken but the test happens to read after an
+        // earlier session populated the cache.
+        assert!(src.tuner_info().is_none());
+
+        src.start_manager().unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut connected_codec: Option<Codec> = None;
+        while Instant::now() < deadline {
+            if let ConnectionState::Connected { codec, .. } = src.connection_state() {
+                connected_codec = Some(codec);
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert_eq!(connected_codec, Some(Codec::Lz4));
+        // `shared.tuner` is published together with the Connected
+        // state, so once we observe Connected, `tuner_info()` must
+        // return the R820T metadata from the dongle_info_t header.
+        let ti = src.tuner_info();
+        assert!(ti.is_some(), "tuner_info should be Some after Connected");
+        let ti = ti.unwrap();
+        assert_eq!(ti.tuner, TunerTypeCode::R820t);
+        assert_eq!(ti.gain_count, 29);
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_rejected_fails_and_leaves_tuner_none() {
+        // Regression test for CodeRabbit round 5 on PR #399.
+        // A server that parses our hello but responds with a non-OK
+        // status (`ControllerBusy` here, reserved for #392) must
+        // transition the client to `Failed` and leave `tuner_info()`
+        // at its initial `None`. Failing to gate the tuner write
+        // behind a successful handshake would cache R820T metadata
+        // for a session that never actually connected.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            sock.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+            sock.read_exact(&mut hello_buf).expect("read hello");
+            // Send dongle_info_t (so we pass the first parse step)
+            // and a ServerExtension rejecting the session.
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: 29,
+            }
+            .to_bytes();
+            sock.write_all(&header).unwrap();
+            let ext = ServerExtension {
+                codec: Codec::None,
+                granted_role: None,
+                status: Status::ControllerBusy,
+                version: PROTOCOL_VERSION,
+            };
+            sock.write_all(&ext.to_bytes()).unwrap();
+            // Brief hold to ensure the client finishes reading the
+            // 8-byte extension body before the socket EOFs.
+            thread::sleep(Duration::from_millis(200));
+        });
+
+        let config = RtlTcpConfig {
+            data_read_timeout: Duration::from_millis(200),
+            max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            compression: CodecMask::NONE_AND_LZ4,
+        };
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        assert!(src.tuner_info().is_none());
+
+        src.start_manager().unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut reached_failed = false;
+        while Instant::now() < deadline {
+            if matches!(src.connection_state(), ConnectionState::Failed { .. }) {
+                reached_failed = true;
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            reached_failed,
+            "client should transition to Failed on non-OK ServerExtension status"
+        );
+        // The critical ordering check: `tuner_info()` stays at its
+        // initial `None` because the handshake never reached the
+        // `set_state(Connected)` path where the cache write lives.
+        assert!(
+            src.tuner_info().is_none(),
+            "tuner_info must stay None when the extension handshake is rejected"
+        );
 
         src.stop_manager();
         let _ = server_thread.join();

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -45,6 +45,10 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use sdr_pipeline::source_manager::Source;
+use sdr_server_rtltcp::codec::{Codec, CodecMask, Decoder};
+use sdr_server_rtltcp::extension::{
+    ClientHello, EXTENSION_MAGIC, PROTOCOL_VERSION, Role, SERVER_EXTENSION_LEN, ServerExtension,
+};
 use sdr_server_rtltcp::protocol::{Command, CommandOp, DONGLE_INFO_LEN, DongleInfo, TunerTypeCode};
 use sdr_types::{Complex, SourceError};
 
@@ -197,6 +201,24 @@ pub struct RtlTcpConfig {
     /// drops packets rather than replying RST), leaving the manager
     /// thread stuck.
     pub connect_timeout: Duration,
+
+    /// Codecs this client is willing to negotiate in the extended
+    /// `"RTLX"` handshake (#307). Defaults to [`CodecMask::NONE_ONLY`]
+    /// — no hello sent, behaves identically to the pre-#307 client
+    /// against any server (vanilla rtl_tcp / GQRX / SDR++ / our own).
+    ///
+    /// Opting in with [`CodecMask::NONE_AND_LZ4`] causes the client
+    /// to prepend an 8-byte `ClientHello` to the connection. sdr-rs
+    /// servers parse it and respond with a `ServerExtension` block;
+    /// **vanilla rtl_tcp servers misinterpret those 8 bytes** as
+    /// two 5-byte commands (with hello bytes straddling the
+    /// command-framing boundary), which can cause garbage command
+    /// dispatches. The UI / client-side discovery layer should only
+    /// flip this bit when it has out-of-band evidence that the
+    /// target server speaks the extension — e.g., mDNS TXT
+    /// advertising `rtlx=1` (future commit), or an explicit
+    /// per-server profile setting.
+    pub compression: sdr_server_rtltcp::codec::CodecMask,
 }
 
 impl Default for RtlTcpConfig {
@@ -205,6 +227,7 @@ impl Default for RtlTcpConfig {
             data_read_timeout: DEFAULT_DATA_READ_TIMEOUT,
             max_consecutive_timeouts: DEFAULT_MAX_CONSECUTIVE_TIMEOUTS,
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
         }
     }
 }
@@ -647,11 +670,11 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
         set_state(&shared, ConnectionState::Connecting);
 
         match attempt_connect(&host, port, &shared, &config) {
-            Ok(stream) => {
+            Ok(HandshakeOutcome { stream, codec }) => {
                 attempt = 0;
                 // At this point handshake has completed successfully.
                 replay_sticky_commands(&shared);
-                run_data_pump(stream, &shared, &config);
+                run_data_pump(stream, codec, &shared, &config);
                 // run_data_pump returned — connection dropped.
             }
             Err(e) => {
@@ -696,12 +719,73 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
     set_state(&shared, ConnectionState::Disconnected);
 }
 
+/// Try to read + parse the server's 8-byte [`ServerExtension`]
+/// block. The caller invokes this immediately after reading the
+/// legacy 12-byte `dongle_info_t`. Returns `Ok(Some)` on a valid
+/// extension block (consumed), `Ok(None)` when the server didn't
+/// send one (legacy `rtl_tcp`, or our own server with the
+/// negotiated codec being `None` but the hello not seen — the
+/// magic-peek still correctly falls through).
+///
+/// Uses `peek()` so non-extension bytes stay in the TCP receive
+/// buffer for the IQ stream reader: on a legacy server, the
+/// bytes after `dongle_info_t` are raw I/Q samples and the
+/// fallback path must not lose them.
+fn sniff_server_extension(stream: &TcpStream) -> std::io::Result<Option<ServerExtension>> {
+    let mut peek_buf = [0u8; 4];
+    let peeked = match stream.peek(&mut peek_buf) {
+        Ok(n) => n,
+        Err(e)
+            if e.kind() == std::io::ErrorKind::WouldBlock
+                || e.kind() == std::io::ErrorKind::TimedOut =>
+        {
+            // No bytes in the receive buffer yet — the server
+            // might be a vanilla rtl_tcp that hasn't produced
+            // IQ samples in the intervening microseconds. Treat
+            // as "no extension" and let the data pump block on
+            // its first real IQ read.
+            return Ok(None);
+        }
+        Err(e) => return Err(e),
+    };
+    if peeked < 4 || peek_buf[..4] != EXTENSION_MAGIC {
+        // Vanilla server — no extension block. Peeked bytes
+        // stay in the buffer for the IQ stream reader.
+        return Ok(None);
+    }
+    let mut ext_buf = [0u8; SERVER_EXTENSION_LEN];
+    stream.peek(&mut ext_buf)?;
+    // Only consume the 8 bytes once we've parsed successfully;
+    // a partial server-extension write (magic matched but
+    // payload malformed) leaves the magic bytes in the buffer
+    // and the data pump will fail with a loud protocol error,
+    // which is better than swallowing bytes silently.
+    match ServerExtension::from_bytes(&ext_buf) {
+        Some(ext) => {
+            // Consume the 8 bytes now that parse succeeded.
+            let mut sink = [0u8; SERVER_EXTENSION_LEN];
+            <&TcpStream as std::io::Read>::read_exact(&mut &*stream, &mut sink)?;
+            Ok(Some(ext))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Outcome of an extended-protocol handshake. `stream` is the
+/// TCP socket (still plain `TcpStream`; the caller wraps it in a
+/// [`Decoder`] for reads). `codec` tells the caller which
+/// decoder to use for the IQ stream.
+struct HandshakeOutcome {
+    stream: TcpStream,
+    codec: Codec,
+}
+
 fn attempt_connect(
     host: &str,
     port: u16,
     shared: &Arc<SharedState>,
     config: &RtlTcpConfig,
-) -> Result<TcpStream, SourceError> {
+) -> Result<HandshakeOutcome, SourceError> {
     // `(host, port).to_socket_addrs()` handles both IPv4 dotted
     // quads AND IPv6 literals like `::1` correctly — the naïve
     // `format!("{host}:{port}")` that we had before would build
@@ -728,6 +812,30 @@ fn attempt_connect(
         tracing::warn!(%e, "SO_KEEPALIVE not applied (non-fatal)");
     }
 
+    // Send the extended-protocol `ClientHello` only if the caller
+    // opted into compression. A hello sent to a vanilla
+    // `rtl_tcp` server straddles its 5-byte command-read
+    // framing (hello is 8 bytes = 1.6 commands) and can cause
+    // garbage dispatches, so we only send it when we have
+    // out-of-band evidence the server speaks the extension
+    // (e.g., mDNS TXT `rtlx=1` or an explicit per-server profile
+    // setting). Default `compression = NONE_ONLY` → no hello →
+    // wire-compatible with every rtl_tcp server on earth. Per #307.
+    let extension_enabled = config.compression != CodecMask::NONE_ONLY;
+    if extension_enabled {
+        let hello = ClientHello {
+            codec_mask: config.compression,
+            // #307 is single-client on the server side; role and
+            // flags are reserved for #390's multi-client follow-ups.
+            role: Role::Control,
+            flags: 0,
+            version: PROTOCOL_VERSION,
+        };
+        if let Err(e) = (&stream).write_all(&hello.to_bytes()) {
+            return Err(SourceError::Io(e));
+        }
+    }
+
     // Read and verify the 12-byte dongle_info_t header.
     let mut header_buf = [0u8; DONGLE_INFO_LEN];
     read_exact_with_context(&stream, &mut header_buf)?;
@@ -743,12 +851,47 @@ fn attempt_connect(
     }
     set_state(shared, ConnectionState::Connected { tuner });
 
+    // Peek for the server's `ServerExtension` block — only when
+    // we sent a hello. If we didn't, the server can't have replied
+    // with an extension block, and a rogue peek would risk
+    // consuming IQ data. Sticks the client to legacy path whenever
+    // `compression = NONE_ONLY`.
+    let codec = if extension_enabled {
+        match sniff_server_extension(&stream) {
+            Ok(Some(ext)) => {
+                tracing::info!(
+                    codec = %ext.codec,
+                    status = ext.status.to_wire(),
+                    "rtl_tcp extended-handshake accepted by server"
+                );
+                ext.codec
+            }
+            Ok(None) => {
+                tracing::debug!(
+                    "rtl_tcp server sent no extension block — legacy / uncompressed path"
+                );
+                Codec::None
+            }
+            Err(e) => {
+                tracing::warn!(%e, "rtl_tcp extension sniff failed — treating as legacy");
+                Codec::None
+            }
+        }
+    } else {
+        Codec::None
+    };
+
     // Publish a clone of the stream for the command sender. Install a
     // write timeout on the clone so `send_command`'s blocking
     // `write_all` can't hang indefinitely if a zero-window peer
     // saturates our kernel send buffer — tune/gain changes must stay
     // responsive. Socket options propagate across `try_clone` on the
     // same underlying fd, so this applies to every subsequent write.
+    //
+    // The command sink is ALWAYS the raw TCP stream regardless of
+    // negotiated codec — rtl_tcp commands are 5-byte fixed-width and
+    // are not encoded under the `"RTLX"` extension. Only the
+    // server→client data direction is compressed.
     let sink = stream.try_clone().map_err(SourceError::Io)?;
     if let Err(e) = sink.set_write_timeout(Some(config.data_read_timeout)) {
         tracing::warn!(%e, "set_write_timeout on command sink failed — command sends may block");
@@ -757,7 +900,7 @@ fn attempt_connect(
         *slot = Some(sink);
     }
 
-    Ok(stream)
+    Ok(HandshakeOutcome { stream, codec })
 }
 
 /// Run `TcpStream::connect_timeout` on a helper thread, polling a
@@ -829,11 +972,26 @@ fn connect_cancellable(
     }
 }
 
-fn run_data_pump(mut stream: TcpStream, shared: &Arc<SharedState>, config: &RtlTcpConfig) {
+fn run_data_pump(
+    stream: TcpStream,
+    codec: Codec,
+    shared: &Arc<SharedState>,
+    config: &RtlTcpConfig,
+) {
+    // Wrap the TCP stream in the negotiated decoder. Legacy /
+    // vanilla-server paths hit `Codec::None` which is a
+    // zero-overhead pass-through; only LZ4 connections pay the
+    // framing cost.
+    //
+    // Read timeout was installed in `attempt_connect` on the
+    // underlying TcpStream; `Decoder::Lz4` delegates its `read()`
+    // to the inner stream so `SO_RCVTIMEO` still enforces the
+    // stall-detection path below unchanged.
+    let mut reader = Decoder::new(codec, stream);
     let mut buf = [0u8; RECV_CHUNK_BYTES];
     let mut consecutive_timeouts: u32 = 0;
     while !shared.shutdown.load(Ordering::Relaxed) {
-        match stream.read(&mut buf) {
+        match reader.read(&mut buf) {
             Ok(0) => {
                 tracing::info!("rtl_tcp server closed connection");
                 break;
@@ -1339,6 +1497,7 @@ mod tests {
             data_read_timeout: Duration::from_millis(200),
             max_consecutive_timeouts: 2,
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -132,8 +132,11 @@ pub enum ConnectionState {
     Disconnected,
     /// `start()` in progress — first TCP connect attempt.
     Connecting,
-    /// Handshake complete, handler streaming I/Q.
-    Connected { tuner: TunerInfo },
+    /// Handshake complete, handler streaming I/Q. `codec` reflects
+    /// the negotiated stream codec from the extended `"RTLX"`
+    /// handshake (#307); legacy / uncompressed paths land on
+    /// `Codec::None`.
+    Connected { tuner: TunerInfo, codec: Codec },
     /// Connection dropped, backoff pending. Transport-level errors
     /// (TCP connect refused, EOF, stall) stay in this state — the
     /// manager retries forever with exponential backoff up to the
@@ -150,12 +153,13 @@ impl From<&ConnectionState> for sdr_types::RtlTcpConnectionState {
         match value {
             ConnectionState::Disconnected => Self::Disconnected,
             ConnectionState::Connecting => Self::Connecting,
-            ConnectionState::Connected { tuner } => Self::Connected {
+            ConnectionState::Connected { tuner, codec } => Self::Connected {
                 // `TunerTypeCode`'s `Debug` renders the upstream
                 // tuner name ("R820T", "E4000", etc.) directly —
                 // what the UI wants for the status row subtitle.
                 tuner_name: format!("{:?}", tuner.tuner),
                 gain_count: tuner.gain_count,
+                codec: codec.label().to_string(),
             },
             ConnectionState::Retrying { attempt, next_at } => Self::Retrying {
                 attempt: *attempt,
@@ -849,12 +853,14 @@ fn attempt_connect(
     if let Ok(mut slot) = shared.tuner.lock() {
         *slot = Some(tuner);
     }
-    set_state(shared, ConnectionState::Connected { tuner });
 
-    // Peek for the server's `ServerExtension` block — only when
-    // we sent a hello. If we didn't, the server can't have replied
-    // with an extension block, and a rogue peek would risk
-    // consuming IQ data. Sticks the client to legacy path whenever
+    // Peek for the server's `ServerExtension` block BEFORE publishing
+    // `Connected` state — the codec is part of the state the UI
+    // renders, and landing in `Connected { codec: None }` first and
+    // then updating would cause a subtitle flicker. Only peek when we
+    // sent a hello; otherwise the server can't have replied with an
+    // extension block, and a rogue peek would risk consuming IQ
+    // bytes. Sticks the client to legacy path whenever
     // `compression = NONE_ONLY`.
     let codec = if extension_enabled {
         match sniff_server_extension(&stream) {
@@ -880,6 +886,8 @@ fn attempt_connect(
     } else {
         Codec::None
     };
+
+    set_state(shared, ConnectionState::Connected { tuner, codec });
 
     // Publish a clone of the stream for the command sender. Install a
     // write timeout on the clone so `send_command`'s blocking
@@ -1688,7 +1696,7 @@ mod tests {
         let deadline = Instant::now() + Duration::from_secs(2);
         let mut tuner = None;
         while Instant::now() < deadline {
-            if let ConnectionState::Connected { tuner: t } = src.connection_state() {
+            if let ConnectionState::Connected { tuner: t, .. } = src.connection_state() {
                 tuner = Some(t);
                 break;
             }
@@ -1808,7 +1816,7 @@ mod tests {
         let deadline = Instant::now() + Duration::from_secs(2);
         let mut got = None;
         while Instant::now() < deadline {
-            if let ConnectionState::Connected { tuner } = src.connection_state() {
+            if let ConnectionState::Connected { tuner, .. } = src.connection_state() {
                 got = Some(tuner);
                 break;
             }

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -220,9 +220,12 @@ pub struct RtlTcpConfig {
     /// command-framing boundary), which can cause garbage command
     /// dispatches. The UI / client-side discovery layer should only
     /// flip this bit when it has out-of-band evidence that the
-    /// target server speaks the extension — e.g., mDNS TXT
-    /// advertising `rtlx=1` (future commit), or an explicit
-    /// per-server profile setting.
+    /// target server speaks the extension — the shipped signal is
+    /// the `codecs=` value in the server's mDNS TXT record (see
+    /// `sdr-rtltcp-discovery::TxtRecord::codecs`): `codecs=3`
+    /// means the server advertises both `None` and `Lz4` so it's
+    /// safe to send a hello; an absent or `codecs=1` value means
+    /// legacy-only and we should leave this at `NONE_ONLY`.
     pub compression: sdr_server_rtltcp::codec::CodecMask,
 }
 

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -723,56 +723,41 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
     set_state(&shared, ConnectionState::Disconnected);
 }
 
-/// Try to read + parse the server's 8-byte [`ServerExtension`]
-/// block. The caller invokes this immediately after reading the
-/// legacy 12-byte `dongle_info_t`. Returns `Ok(Some)` on a valid
-/// extension block (consumed), `Ok(None)` when the server didn't
-/// send one (legacy `rtl_tcp`, or our own server with the
-/// negotiated codec being `None` but the hello not seen — the
-/// magic-peek still correctly falls through).
+/// Read the server's 8-byte [`ServerExtension`] block, invoked
+/// immediately after the legacy 12-byte `dongle_info_t`.
 ///
-/// Uses `peek()` so non-extension bytes stay in the TCP receive
-/// buffer for the IQ stream reader: on a legacy server, the
-/// bytes after `dongle_info_t` are raw I/Q samples and the
-/// fallback path must not lose them.
-fn sniff_server_extension(stream: &TcpStream) -> std::io::Result<Option<ServerExtension>> {
-    let mut peek_buf = [0u8; 4];
-    let peeked = match stream.peek(&mut peek_buf) {
-        Ok(n) => n,
-        Err(e)
-            if e.kind() == std::io::ErrorKind::WouldBlock
-                || e.kind() == std::io::ErrorKind::TimedOut =>
-        {
-            // No bytes in the receive buffer yet — the server
-            // might be a vanilla rtl_tcp that hasn't produced
-            // IQ samples in the intervening microseconds. Treat
-            // as "no extension" and let the data pump block on
-            // its first real IQ read.
-            return Ok(None);
-        }
-        Err(e) => return Err(e),
-    };
-    if peeked < 4 || peek_buf[..4] != EXTENSION_MAGIC {
-        // Vanilla server — no extension block. Peeked bytes
-        // stay in the buffer for the IQ stream reader.
-        return Ok(None);
+/// **Only call this when the client has sent a `ClientHello`.**
+/// Once we've committed to the extended protocol the server is
+/// contractually obligated to respond with an 8-byte block whose
+/// first four bytes are [`EXTENSION_MAGIC`]. This function reads
+/// that block with `read_exact` — not `peek` — so partial TCP
+/// deliveries (magic-only first, body later) can't race us into
+/// parsing zero-padded scratch memory and silently mis-negotiating
+/// as `Codec::None` while the server is actually streaming LZ4.
+///
+/// A short read, a magic mismatch, or a malformed body all surface
+/// as [`std::io::ErrorKind::InvalidData`]; the caller promotes
+/// these to `SourceError::Protocol` and aborts the connection
+/// rather than falling back to a legacy path that would read
+/// compressed bytes as raw I/Q. Per CodeRabbit round 1 on PR #399.
+fn read_server_extension(stream: &TcpStream) -> std::io::Result<ServerExtension> {
+    let mut buf = [0u8; SERVER_EXTENSION_LEN];
+    <&TcpStream as std::io::Read>::read_exact(&mut &*stream, &mut buf)?;
+    if buf[..4] != EXTENSION_MAGIC {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "rtl_tcp extension handshake: expected `RTLX` magic after dongle_info_t, got {:02x?}",
+                &buf[..4]
+            ),
+        ));
     }
-    let mut ext_buf = [0u8; SERVER_EXTENSION_LEN];
-    stream.peek(&mut ext_buf)?;
-    // Only consume the 8 bytes once we've parsed successfully;
-    // a partial server-extension write (magic matched but
-    // payload malformed) leaves the magic bytes in the buffer
-    // and the data pump will fail with a loud protocol error,
-    // which is better than swallowing bytes silently.
-    match ServerExtension::from_bytes(&ext_buf) {
-        Some(ext) => {
-            // Consume the 8 bytes now that parse succeeded.
-            let mut sink = [0u8; SERVER_EXTENSION_LEN];
-            <&TcpStream as std::io::Read>::read_exact(&mut &*stream, &mut sink)?;
-            Ok(Some(ext))
-        }
-        None => Ok(None),
-    }
+    ServerExtension::from_bytes(&buf).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "rtl_tcp extension handshake: `RTLX` magic matched but server-extension body failed to parse",
+        )
+    })
 }
 
 /// Outcome of an extended-protocol handshake. `stream` is the
@@ -854,17 +839,21 @@ fn attempt_connect(
         *slot = Some(tuner);
     }
 
-    // Peek for the server's `ServerExtension` block BEFORE publishing
+    // Read the server's `ServerExtension` block BEFORE publishing
     // `Connected` state — the codec is part of the state the UI
     // renders, and landing in `Connected { codec: None }` first and
-    // then updating would cause a subtitle flicker. Only peek when we
-    // sent a hello; otherwise the server can't have replied with an
-    // extension block, and a rogue peek would risk consuming IQ
-    // bytes. Sticks the client to legacy path whenever
-    // `compression = NONE_ONLY`.
+    // then updating would cause a subtitle flicker.
+    //
+    // Only runs when we sent a hello. Once we've committed to the
+    // extended protocol the server MUST respond with an 8-byte block
+    // starting with `RTLX`; any short read, magic mismatch, or
+    // malformed body is a protocol error (not a legacy fallback) —
+    // silently falling back would let a server that picked LZ4
+    // stream compressed bytes into our IQ decoder. Per CodeRabbit
+    // round 1 on PR #399.
     let codec = if extension_enabled {
-        match sniff_server_extension(&stream) {
-            Ok(Some(ext)) => {
+        match read_server_extension(&stream) {
+            Ok(ext) => {
                 tracing::info!(
                     codec = %ext.codec,
                     status = ext.status.to_wire(),
@@ -872,15 +861,10 @@ fn attempt_connect(
                 );
                 ext.codec
             }
-            Ok(None) => {
-                tracing::debug!(
-                    "rtl_tcp server sent no extension block — legacy / uncompressed path"
-                );
-                Codec::None
-            }
             Err(e) => {
-                tracing::warn!(%e, "rtl_tcp extension sniff failed — treating as legacy");
-                Codec::None
+                return Err(SourceError::Protocol(format!(
+                    "rtl_tcp extension handshake failed after sending ClientHello: {e}"
+                )));
             }
         }
     } else {

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -708,7 +708,10 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
             Err(e) => {
                 tracing::warn!(%e, host = %host, port, attempt, "rtl_tcp connect failed");
                 if let SourceError::Protocol(_) = e {
-                    // Non-recoverable: server isn't speaking rtl_tcp.
+                    // Non-recoverable: server isn't speaking
+                    // rtl_tcp, or the extended handshake was
+                    // rejected for a reason that won't clear on
+                    // retry (auth required/failed, parse error).
                     set_state(
                         &shared,
                         ConnectionState::Failed {
@@ -717,6 +720,13 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
                     );
                     return;
                 }
+                // `TemporarilyUnavailable` (e.g. server responded
+                // with `ControllerBusy`) and every other
+                // `SourceError` variant fall through to the
+                // backoff loop below. The condition is expected
+                // to clear on its own — retrying with the normal
+                // schedule is the right behavior. Per CodeRabbit
+                // round 7 on PR #399.
             }
         }
 
@@ -891,14 +901,28 @@ fn attempt_connect(
         match read_server_extension(&stream) {
             Ok(ext) => {
                 // A non-OK status means the server parsed our hello
-                // but rejected the session (ControllerBusy,
-                // AuthRequired, AuthFailed — reserved for #392/#394
-                // but forward-compatible here). Proceeding would
-                // surface as "Connected" in the UI for what is in
-                // fact a denial. Abort so the manager retries (or
-                // the user sees the error), rather than silently
-                // appearing connected. Per CodeRabbit round 2 on
-                // PR #399.
+                // but rejected the session. Two flavors:
+                //
+                // - `ControllerBusy` (#392): another client owns the
+                //   control slot right now. This is **transient** —
+                //   that client will eventually disconnect, so we
+                //   return `SourceError::TemporarilyUnavailable` and
+                //   let the connection manager retry on the normal
+                //   backoff schedule. Per CodeRabbit round 7 on
+                //   PR #399.
+                // - `AuthRequired` / `AuthFailed` (#394) and any
+                //   future non-OK status: terminal. The user must
+                //   take action (set the right auth key) before
+                //   retries have any chance of succeeding, so we
+                //   surface `SourceError::Protocol` and the manager
+                //   transitions to `Failed`.
+                if ext.status == Status::ControllerBusy {
+                    return Err(SourceError::TemporarilyUnavailable(format!(
+                        "rtl_tcp server controller busy: status={:?} (wire={})",
+                        ext.status,
+                        ext.status.to_wire()
+                    )));
+                }
                 if ext.status != Status::Ok {
                     return Err(SourceError::Protocol(format!(
                         "rtl_tcp extension rejected by server: status={:?} (wire={})",
@@ -1399,7 +1423,7 @@ impl Source for RtlTcpSource {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use std::net::TcpListener;
@@ -1791,6 +1815,73 @@ mod tests {
         let _ = server_thread.join();
     }
 
+    // ============================================================
+    // RTLX handshake fixture constants (CodeRabbit round 7 on PR #399)
+    //
+    // Pulled out of the individual tests so the acceptance,
+    // rejection, and retry paths all use the same gain count,
+    // socket timeouts, and state-observation deadlines — avoiding
+    // silent drift between the fixtures.
+    // ============================================================
+
+    /// Gain step count the fixture dongle advertises in its
+    /// `dongle_info_t` header. R820T's published table is 29
+    /// steps; matches upstream rtl-sdr exactly.
+    const RTLX_TEST_GAIN_COUNT: u32 = 29;
+    /// Read timeout the client uses against the fixture server.
+    /// Short (200 ms) so a stalled test exits quickly rather than
+    /// holding the whole suite up.
+    const RTLX_TEST_DATA_READ_TIMEOUT: Duration = Duration::from_millis(200);
+    /// How long the fixture server holds the accepted-connection
+    /// socket open after writing its responses. Must exceed
+    /// `RTLX_TEST_DATA_READ_TIMEOUT` so the client finishes
+    /// reading the extension body before EOF, but short enough
+    /// that the server thread joins quickly at test teardown.
+    const RTLX_TEST_SERVER_HOLD: Duration = Duration::from_millis(400);
+    /// Wall-clock deadline the tests give the client to reach
+    /// its expected state (Connected / Failed / non-Failed).
+    /// Generous enough to absorb CI scheduling jitter.
+    const RTLX_TEST_STATE_DEADLINE: Duration = Duration::from_secs(2);
+    /// Poll interval inside the state-observation loops. Short
+    /// enough to catch brief state visits without pegging a core.
+    const RTLX_TEST_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+    /// Shared fixture setup: listener on loopback + config that
+    /// opts into the extended handshake. Keeps the three RTLX
+    /// handshake tests aligned on compression mask + timeouts.
+    fn rtlx_test_listener_and_config() -> (TcpListener, RtlTcpConfig) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let config = RtlTcpConfig {
+            data_read_timeout: RTLX_TEST_DATA_READ_TIMEOUT,
+            max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            compression: CodecMask::NONE_AND_LZ4,
+        };
+        (listener, config)
+    }
+
+    /// Loopback server behavior for a single RTLX accept: read
+    /// the 8-byte `ClientHello`, write `dongle_info_t`, write the
+    /// caller-supplied `ServerExtension`, then hold the socket
+    /// open for `RTLX_TEST_SERVER_HOLD` so the client reads the
+    /// extension body before EOF.
+    fn rtlx_test_serve_one(listener: &TcpListener, ext: ServerExtension) {
+        let (mut sock, _) = listener.accept().expect("accept");
+        sock.set_read_timeout(Some(RTLX_TEST_STATE_DEADLINE))
+            .unwrap();
+        let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+        sock.read_exact(&mut hello_buf).expect("read hello");
+        assert_eq!(&hello_buf[..EXTENSION_MAGIC.len()], &EXTENSION_MAGIC);
+        let header = DongleInfo {
+            tuner: TunerTypeCode::R820t,
+            gain_count: RTLX_TEST_GAIN_COUNT,
+        }
+        .to_bytes();
+        sock.write_all(&header).unwrap();
+        sock.write_all(&ext.to_bytes()).unwrap();
+        thread::sleep(RTLX_TEST_SERVER_HOLD);
+    }
+
     #[test]
     fn rtlx_handshake_accepted_publishes_codec_and_tuner() {
         // Regression test for CodeRabbit round 5 on PR #399.
@@ -1805,45 +1896,19 @@ mod tests {
         //   - `shared.tuner` is published atomically with the
         //     `Connected` transition, not earlier during
         //     `dongle_info_t` parsing.
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let (listener, config) = rtlx_test_listener_and_config();
         let addr = listener.local_addr().unwrap();
 
         let server_thread = thread::spawn(move || {
-            let (mut sock, _) = listener.accept().expect("accept");
-            sock.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
-            // Consume the 8-byte `ClientHello` — we just want to
-            // verify the client sent one with the extension magic.
-            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
-            sock.read_exact(&mut hello_buf).expect("read hello");
-            assert_eq!(&hello_buf[..EXTENSION_MAGIC.len()], &EXTENSION_MAGIC);
-            // Send dongle_info_t + ServerExtension back-to-back so
-            // the client sees both before the read_timeout window.
-            let header = DongleInfo {
-                tuner: TunerTypeCode::R820t,
-                gain_count: 29,
-            }
-            .to_bytes();
-            sock.write_all(&header).unwrap();
             let ext = ServerExtension {
                 codec: Codec::Lz4,
                 granted_role: Some(Role::Control),
                 status: Status::Ok,
                 version: PROTOCOL_VERSION,
             };
-            sock.write_all(&ext.to_bytes()).unwrap();
-            // Hold the connection briefly so the client state
-            // observer has time to reach Connected before EOF. No
-            // IQ bytes are sent (the LZ4 decoder would need a real
-            // frame); the test only exercises the handshake path.
-            thread::sleep(Duration::from_millis(400));
+            rtlx_test_serve_one(&listener, ext);
         });
 
-        let config = RtlTcpConfig {
-            data_read_timeout: Duration::from_millis(200),
-            max_consecutive_timeouts: 2,
-            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
-            compression: CodecMask::NONE_AND_LZ4,
-        };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         // Before starting the manager, tuner_info must be None —
         // guards against a false positive where the delayed-publish
@@ -1853,14 +1918,14 @@ mod tests {
 
         src.start_manager().unwrap();
 
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + RTLX_TEST_STATE_DEADLINE;
         let mut connected_codec: Option<Codec> = None;
         while Instant::now() < deadline {
             if let ConnectionState::Connected { codec, .. } = src.connection_state() {
                 connected_codec = Some(codec);
                 break;
             }
-            thread::sleep(Duration::from_millis(20));
+            thread::sleep(RTLX_TEST_POLL_INTERVAL);
         }
         assert_eq!(connected_codec, Some(Codec::Lz4));
         // `shared.tuner` is published together with the Connected
@@ -1870,79 +1935,119 @@ mod tests {
         assert!(ti.is_some(), "tuner_info should be Some after Connected");
         let ti = ti.unwrap();
         assert_eq!(ti.tuner, TunerTypeCode::R820t);
-        assert_eq!(ti.gain_count, 29);
+        assert_eq!(ti.gain_count, RTLX_TEST_GAIN_COUNT);
 
         src.stop_manager();
         let _ = server_thread.join();
     }
 
     #[test]
-    fn rtlx_handshake_rejected_fails_and_leaves_tuner_none() {
-        // Regression test for CodeRabbit round 5 on PR #399.
-        // A server that parses our hello but responds with a non-OK
-        // status (`ControllerBusy` here, reserved for #392) must
-        // transition the client to `Failed` and leave `tuner_info()`
-        // at its initial `None`. Failing to gate the tuner write
-        // behind a successful handshake would cache R820T metadata
-        // for a session that never actually connected.
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    fn rtlx_handshake_auth_failed_is_terminal_and_leaves_tuner_none() {
+        // Regression test for CodeRabbit round 5 + round 7 on
+        // PR #399. Originally this test used `ControllerBusy`,
+        // but round 7 correctly pointed out that a busy server is
+        // transient — the other controller will eventually
+        // disconnect and we should retry. `AuthFailed` is the
+        // right terminal substitute: a wrong key will not start
+        // working on retry, so the manager must transition to
+        // `Failed` and stop looping.
+        //
+        // The test also guards the delayed-tuner-publish ordering:
+        // `tuner_info()` must stay `None` because the handshake
+        // never reached the `set_state(Connected)` path where the
+        // cache write lives.
+        let (listener, config) = rtlx_test_listener_and_config();
         let addr = listener.local_addr().unwrap();
 
         let server_thread = thread::spawn(move || {
-            let (mut sock, _) = listener.accept().expect("accept");
-            sock.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
-            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
-            sock.read_exact(&mut hello_buf).expect("read hello");
-            // Send dongle_info_t (so we pass the first parse step)
-            // and a ServerExtension rejecting the session.
-            let header = DongleInfo {
-                tuner: TunerTypeCode::R820t,
-                gain_count: 29,
-            }
-            .to_bytes();
-            sock.write_all(&header).unwrap();
             let ext = ServerExtension {
                 codec: Codec::None,
                 granted_role: None,
-                status: Status::ControllerBusy,
+                status: Status::AuthFailed,
                 version: PROTOCOL_VERSION,
             };
-            sock.write_all(&ext.to_bytes()).unwrap();
-            // Brief hold to ensure the client finishes reading the
-            // 8-byte extension body before the socket EOFs.
-            thread::sleep(Duration::from_millis(200));
+            rtlx_test_serve_one(&listener, ext);
         });
 
-        let config = RtlTcpConfig {
-            data_read_timeout: Duration::from_millis(200),
-            max_consecutive_timeouts: 2,
-            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
-            compression: CodecMask::NONE_AND_LZ4,
-        };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         assert!(src.tuner_info().is_none());
 
         src.start_manager().unwrap();
 
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + RTLX_TEST_STATE_DEADLINE;
         let mut reached_failed = false;
         while Instant::now() < deadline {
             if matches!(src.connection_state(), ConnectionState::Failed { .. }) {
                 reached_failed = true;
                 break;
             }
-            thread::sleep(Duration::from_millis(20));
+            thread::sleep(RTLX_TEST_POLL_INTERVAL);
         }
         assert!(
             reached_failed,
-            "client should transition to Failed on non-OK ServerExtension status"
+            "client should transition to Failed on `AuthFailed` ServerExtension status"
         );
-        // The critical ordering check: `tuner_info()` stays at its
-        // initial `None` because the handshake never reached the
-        // `set_state(Connected)` path where the cache write lives.
         assert!(
             src.tuner_info().is_none(),
             "tuner_info must stay None when the extension handshake is rejected"
+        );
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_controller_busy_is_transient_not_terminal() {
+        // Regression test for CodeRabbit round 7 on PR #399.
+        // `ControllerBusy` means another client currently owns the
+        // control slot (#392). That condition resolves on its own
+        // when the other client disconnects, so the rtl_tcp source
+        // must NOT transition to `Failed` — the connection manager
+        // should keep cycling through the backoff + reconnect path.
+        //
+        // We assert two things:
+        //   1. State never reaches `Failed` within the observation
+        //      window (CR #17 regression guard).
+        //   2. `tuner_info()` stays `None` (the delayed-publish
+        //      ordering holds regardless of status).
+        let (listener, config) = rtlx_test_listener_and_config();
+        let addr = listener.local_addr().unwrap();
+
+        let server_thread = thread::spawn(move || {
+            // Accept a single connection and reject it. The client
+            // will then loop; subsequent accepts would require an
+            // accept loop we don't need for this assertion.
+            let ext = ServerExtension {
+                codec: Codec::None,
+                granted_role: None,
+                status: Status::ControllerBusy,
+                version: PROTOCOL_VERSION,
+            };
+            rtlx_test_serve_one(&listener, ext);
+        });
+
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        assert!(src.tuner_info().is_none());
+
+        src.start_manager().unwrap();
+
+        // Poll for the entire window. If `Failed` shows up at any
+        // point, that's the round-7 regression (ControllerBusy
+        // being treated as terminal).
+        let deadline = Instant::now() + RTLX_TEST_STATE_DEADLINE;
+        while Instant::now() < deadline {
+            if matches!(src.connection_state(), ConnectionState::Failed { .. }) {
+                panic!(
+                    "ControllerBusy must not route to Failed — the server condition \
+                     is transient and the manager should keep retrying. \
+                     Observed state: Failed."
+                );
+            }
+            thread::sleep(RTLX_TEST_POLL_INTERVAL);
+        }
+        assert!(
+            src.tuner_info().is_none(),
+            "tuner_info must stay None across transient busy retries"
         );
 
         src.stop_manager();

--- a/crates/sdr-types/src/error.rs
+++ b/crates/sdr-types/src/error.rs
@@ -43,8 +43,23 @@ pub enum SourceError {
     /// that was supposed to speak `rtl_tcp` but didn't return the expected
     /// 12-byte `RTL0` header. Distinct from `Io` so UI can surface
     /// "not an `rtl_tcp` server" rather than a generic socket error.
+    ///
+    /// Treated as **terminal** by the `rtl_tcp` client's connection manager:
+    /// the backoff loop exits and the state transitions to
+    /// `ConnectionState::Failed`. Use this for errors that won't be fixed
+    /// by retrying (bad server, wrong protocol version, auth rejection).
     #[error("protocol error: {0}")]
     Protocol(String),
+    /// Transient, retryable failure from a network source — e.g. the
+    /// `rtl_tcp` server's extended handshake returned `ControllerBusy`
+    /// because another client is currently controlling the dongle.
+    /// The condition is expected to resolve without user action once
+    /// the other client disconnects, so the connection manager keeps
+    /// retrying on the normal backoff schedule rather than
+    /// transitioning to `Failed`. Distinct from `Protocol` so callers
+    /// can route terminal vs. retry-worthy rejections correctly.
+    #[error("temporarily unavailable: {0}")]
+    TemporarilyUnavailable(String),
 }
 
 /// Errors from sink modules.

--- a/crates/sdr-types/src/rtl_tcp_connection_state.rs
+++ b/crates/sdr-types/src/rtl_tcp_connection_state.rs
@@ -43,6 +43,13 @@ pub enum RtlTcpConnectionState {
         /// the dongle-info header. Lets the UI show
         /// `"R820T, 29 gain steps"` without a second lookup.
         gain_count: u32,
+        /// Human-readable label for the negotiated stream codec
+        /// (e.g. `"None"`, `"LZ4"`). Pre-projected to a plain
+        /// `String` so this type doesn't pull in the codec enum
+        /// from `sdr-server-rtltcp`. Legacy servers and
+        /// uncompressed-by-choice paths both land on `"None"`.
+        /// Issue #307.
+        codec: String,
     },
 
     /// Transport-level error (connect refused, EOF, stall). The
@@ -100,6 +107,7 @@ mod tests {
             RtlTcpConnectionState::Connected {
                 tuner_name: "R820T".into(),
                 gain_count: 29,
+                codec: "None".into(),
             }
             .is_connected()
         );
@@ -126,6 +134,7 @@ mod tests {
             !RtlTcpConnectionState::Connected {
                 tuner_name: "R820T".into(),
                 gain_count: 29,
+                codec: "None".into(),
             }
             .is_in_progress()
         );

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -42,6 +42,11 @@ const KEY_SERVER_DEFAULT_PPM: &str = "rtl_tcp_server_default_ppm";
 const KEY_SERVER_DEFAULT_BIAS_TEE: &str = "rtl_tcp_server_default_bias_tee";
 /// Config key for the persisted default direct-sampling toggle.
 const KEY_SERVER_DEFAULT_DIRECT_SAMPLING: &str = "rtl_tcp_server_default_direct_sampling";
+/// Config key for the persisted compression-codec selector index
+/// (`COMPRESSION_OFF_IDX` / `COMPRESSION_LZ4_IDX`). Stored as an
+/// index so a future addition (e.g. Zstd) doesn't invalidate old
+/// configs — unknown indices fall back to `Off` on restore.
+const KEY_SERVER_COMPRESSION_IDX: &str = "rtl_tcp_server_compression_idx";
 
 /// Default TCP port for `rtl_tcp`. Matches upstream `rtl_tcp.c` and
 /// every ecosystem client's default. Changing it means users have to
@@ -65,6 +70,23 @@ const SERVER_PORT_PAGE: f64 = 100.0;
 pub const BIND_LOOPBACK_IDX: u32 = 0;
 /// Bind-address selector index: all interfaces (0.0.0.0).
 pub const BIND_ALL_INTERFACES_IDX: u32 = 1;
+
+/// Compression selector index: off — advertise `CodecMask::NONE_ONLY`.
+/// Default; preserves wire compatibility with every existing
+/// `rtl_tcp` client (vanilla clients never send a hello, and our own
+/// client refuses to send one when the server's mDNS TXT says
+/// `codecs=1`). See #307.
+pub const COMPRESSION_OFF_IDX: u32 = 0;
+/// Compression selector index: LZ4 available — advertise
+/// `CodecMask::NONE_AND_LZ4`. The server still falls back to
+/// uncompressed for clients that don't hello (legacy) or hello
+/// without the LZ4 bit set (ours with `NONE_ONLY`).
+pub const COMPRESSION_LZ4_IDX: u32 = 1;
+/// Number of entries in the compression `StringList`. Load-bearing
+/// for the persistence validator — indices `>=` this count are
+/// dropped on restore so a future "Zstd" entry doesn't land as
+/// garbage in an older build.
+const COMPRESSION_COUNT: u32 = 2;
 
 /// Server device-defaults: center frequency default (Hz) applied on
 /// start, before the first client connects. Upstream `rtl_tcp.c:389`
@@ -172,6 +194,12 @@ pub struct ServerPanel {
     /// on; the user can turn it off to run locally without LAN
     /// advertisement.
     pub advertise_row: adw::SwitchRow,
+    /// Compression-codec selector. Default `COMPRESSION_OFF_IDX`
+    /// — wire-compatible with every `rtl_tcp` client. `COMPRESSION_LZ4_IDX`
+    /// opts in to offering LZ4 to clients that send a hello; legacy
+    /// clients and our own `NONE_ONLY` clients still get uncompressed
+    /// via the mutual-codec intersection. See #307.
+    pub compression_row: adw::ComboRow,
     /// Collapsible group of device-defaults (freq / sample rate /
     /// gain / PPM / bias tee / direct sampling) applied on server
     /// start. Clients override these live via the `rtl_tcp` command
@@ -494,6 +522,19 @@ pub fn build_server_panel() -> ServerPanel {
         .active(true)
         .build();
 
+    // Compression model — order matches COMPRESSION_OFF_IDX / _LZ4_IDX.
+    // Default is Off to stay wire-compatible with every existing
+    // rtl_tcp client on the LAN; opting in is a deliberate click,
+    // and even then vanilla clients fall through to uncompressed
+    // via the mutual-codec intersection on the server side.
+    let compression_model = gtk4::StringList::new(&["Off", "LZ4 (if client supports)"]);
+    let compression_row = adw::ComboRow::builder()
+        .title("Compression")
+        .subtitle("Negotiated per client — legacy clients always get uncompressed")
+        .model(&compression_model)
+        .selected(COMPRESSION_OFF_IDX)
+        .build();
+
     let device_defaults_row = adw::ExpanderRow::builder()
         .title("Device defaults")
         .subtitle("Applied when the server opens the dongle — clients override live")
@@ -543,6 +584,7 @@ pub fn build_server_panel() -> ServerPanel {
     widget.add(&port_row);
     widget.add(&bind_row);
     widget.add(&advertise_row);
+    widget.add(&compression_row);
     widget.add(&device_defaults_row);
     widget.add(&status_row);
     widget.add(&activity_log_row);
@@ -555,6 +597,7 @@ pub fn build_server_panel() -> ServerPanel {
         port_row,
         bind_row,
         advertise_row,
+        compression_row,
         device_defaults_row,
         center_freq_row,
         sample_rate_row,
@@ -683,6 +726,17 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
         {
             panel.direct_sampling_row.set_active(ds);
         }
+        if let Some(idx) = v
+            .get(KEY_SERVER_COMPRESSION_IDX)
+            .and_then(serde_json::Value::as_u64)
+            && let Ok(idx_u32) = u32::try_from(idx)
+            && idx_u32 < COMPRESSION_COUNT
+        {
+            // Strict bounds check: unknown stored indices fall
+            // back to the widget's build-time default (`Off`) so
+            // a corrupt config can't silently enable compression.
+            panel.compression_row.set_selected(idx_u32);
+        }
     });
 
     // ---- Phase 2: subscribe ----
@@ -787,5 +841,17 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
         cfg_ds.write(|v| {
             v[KEY_SERVER_DEFAULT_DIRECT_SAMPLING] = serde_json::json!(row.is_active());
         });
+    });
+    // Compression codec combo. Same strict-gate policy as
+    // `bind_row` / `sample_rate_row` — only persist in-range
+    // indices so widget-model churn can't corrupt the stored value.
+    let cfg_comp = Arc::clone(config);
+    panel.compression_row.connect_selected_notify(move |row| {
+        let selected = row.selected();
+        if selected < COMPRESSION_COUNT {
+            cfg_comp.write(|v| {
+                v[KEY_SERVER_COMPRESSION_IDX] = serde_json::json!(selected);
+            });
+        }
     });
 }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -304,7 +304,19 @@ pub fn format_rtl_tcp_state(state: &RtlTcpConnectionState) -> String {
         RtlTcpConnectionState::Connected {
             tuner_name,
             gain_count,
-        } => format!("Connected — {tuner_name} ({gain_count} gains)"),
+            codec,
+        } => {
+            // Only surface the codec when it's actually compressing —
+            // the common "None" case (every legacy server, plus our
+            // own server with compression off) stays at the existing
+            // short form so the subtitle doesn't grow a meaningless
+            // "codec: None" suffix on every connection.
+            if codec == "None" {
+                format!("Connected — {tuner_name} ({gain_count} gains)")
+            } else {
+                format!("Connected — {tuner_name} ({gain_count} gains, {codec})")
+            }
+        }
         RtlTcpConnectionState::Retrying { attempt, retry_in } => {
             // Ceil, not floor — `as_secs` truncates fractional
             // seconds, so `1.9 s` would read as "1 s" and the row
@@ -967,14 +979,29 @@ mod tests {
             format_rtl_tcp_state(&RtlTcpConnectionState::Connecting),
             "Connecting…"
         );
-        // Connected carries tuner metadata both the user and the
-        // debugging eye can parse.
+        // Connected with `None` codec keeps the short form — the
+        // common path every legacy server hits, and the default for
+        // our own client. Adding a "(None)" suffix here would noise
+        // up every single connection in exchange for zero signal.
         assert_eq!(
             format_rtl_tcp_state(&RtlTcpConnectionState::Connected {
                 tuner_name: "R820T".into(),
                 gain_count: 29,
+                codec: "None".into(),
             }),
             "Connected — R820T (29 gains)"
+        );
+        // Connected with a non-`None` codec gets an extra suffix so
+        // the user can see which codec actually landed. Signals
+        // that compression is active without forcing them to hunt
+        // through logs.
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::Connected {
+                tuner_name: "R820T".into(),
+                gain_count: 29,
+                codec: "LZ4".into(),
+            }),
+            "Connected — R820T (29 gains, LZ4)"
         );
         // Retrying ceils fractional seconds so the row never
         // understates the delay: 250 ms remaining → "1 s", not

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3726,6 +3726,12 @@ fn build_advertiser(
             gains: tuner_info.gain_count,
             nickname,
             txbuf: None,
+            // Advertise the codec bitmask so our own clients
+            // know up-front whether to send an extended-protocol
+            // hello (`NONE_ONLY` → no hello, vanilla path).
+            // Vanilla mDNS consumers (non-sdr-rs clients that
+            // don't know this key) just ignore it. #307.
+            codecs: Some(server.compression().to_wire()),
         },
     };
     Advertiser::announce(opts)
@@ -6613,6 +6619,7 @@ mod rtl_tcp_discovery_format_tests {
                 gains: 29,
                 nickname: "weather".into(),
                 txbuf: None,
+                codecs: None,
             },
             last_seen: Instant::now(),
         }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3683,6 +3683,11 @@ fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
             direct_sampling,
         },
         buffer_capacity: SERVER_BUFFER_CAPACITY_DEFAULT,
+        // Compression stays off by default — the UI picker lands
+        // in a follow-up commit (#307). Once the picker exists,
+        // this is read from the panel widget alongside the other
+        // initial-state fields.
+        compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
     }
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2957,6 +2957,7 @@ struct ServerSwitchWidgetsWeak {
     port_row: glib::WeakRef<adw::SpinRow>,
     bind_row: glib::WeakRef<adw::ComboRow>,
     advertise_row: glib::WeakRef<adw::SwitchRow>,
+    compression_row: glib::WeakRef<adw::ComboRow>,
     device_defaults_row: glib::WeakRef<adw::ExpanderRow>,
     center_freq_row: glib::WeakRef<adw::SpinRow>,
     sample_rate_row: glib::WeakRef<adw::ComboRow>,
@@ -2984,6 +2985,7 @@ struct ServerSwitchWidgets {
     port_row: adw::SpinRow,
     bind_row: adw::ComboRow,
     advertise_row: adw::SwitchRow,
+    compression_row: adw::ComboRow,
     device_defaults_row: adw::ExpanderRow,
     center_freq_row: adw::SpinRow,
     sample_rate_row: adw::ComboRow,
@@ -3009,6 +3011,7 @@ impl ServerSwitchWidgetsWeak {
             port_row: s.port_row.downgrade(),
             bind_row: s.bind_row.downgrade(),
             advertise_row: s.advertise_row.downgrade(),
+            compression_row: s.compression_row.downgrade(),
             device_defaults_row: s.device_defaults_row.downgrade(),
             center_freq_row: s.center_freq_row.downgrade(),
             sample_rate_row: s.sample_rate_row.downgrade(),
@@ -3035,6 +3038,7 @@ impl ServerSwitchWidgetsWeak {
             port_row: self.port_row.upgrade()?,
             bind_row: self.bind_row.upgrade()?,
             advertise_row: self.advertise_row.upgrade()?,
+            compression_row: self.compression_row.upgrade()?,
             device_defaults_row: self.device_defaults_row.upgrade()?,
             center_freq_row: self.center_freq_row.upgrade()?,
             sample_rate_row: self.sample_rate_row.upgrade()?,
@@ -3671,6 +3675,17 @@ fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
         DIRECT_SAMPLING_OFF
     };
 
+    // Compression combo maps index → CodecMask. Unknown / transient
+    // indices (GTK can emit garbage during widget-model churn) fall
+    // back to `NONE_ONLY` — the wire-safe default that preserves
+    // compatibility with every existing rtl_tcp client.
+    let compression = match panel.compression_row.selected() {
+        crate::sidebar::server_panel::COMPRESSION_LZ4_IDX => {
+            sdr_server_rtltcp::codec::CodecMask::NONE_AND_LZ4
+        }
+        _ => sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
+    };
+
     ServerConfig {
         bind,
         device_index: 0,
@@ -3683,11 +3698,7 @@ fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
             direct_sampling,
         },
         buffer_capacity: SERVER_BUFFER_CAPACITY_DEFAULT,
-        // Compression stays off by default — the UI picker lands
-        // in a follow-up commit (#307). Once the picker exists,
-        // this is read from the panel widget alongside the other
-        // initial-state fields.
-        compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
+        compression,
     }
 }
 
@@ -3747,6 +3758,7 @@ fn set_controls_locked(panel: &ServerSwitchWidgets, locked: bool) {
     panel.port_row.set_sensitive(sensitive);
     panel.bind_row.set_sensitive(sensitive);
     panel.advertise_row.set_sensitive(sensitive);
+    panel.compression_row.set_sensitive(sensitive);
     panel.device_defaults_row.set_sensitive(sensitive);
 }
 


### PR DESCRIPTION
## Summary

Adds **optional LZ4 stream compression** to our `rtl_tcp` server and client, negotiated per-connection over a backwards-compatible extended handshake. Closes #307.

- **Wire format:** new 4-byte magic `"RTLX"` sent by the client, followed by an 8-byte `ClientHello`. The server responds with an 8-byte `ServerExtension` *after* the legacy 12-byte `dongle_info_t`. Magic's first byte (`0x52`) can never be mistaken for a legacy rtl_tcp command opcode (opcodes 0x01-0x0e).
- **Negotiation:** bitmask intersection (`CodecMask::pick`) — `None > Lz4` → `None`, `Lz4 + Lz4` → `Lz4`. Legacy clients / vanilla rtl_tcp servers silently fall through to uncompressed. Mixed LZ4 + legacy clients can connect to the same server concurrently.
- **Opt-in on the client** via `RtlTcpConfig.compression` (default `NONE_ONLY` — no hello sent, wire-compatible with every rtl_tcp server on the LAN). The client decides whether to send a hello based on mDNS TXT `codecs=` field (#307 follow-up will auto-wire this through the discovery path).
- **Opt-in on the server** via a new "Compression" combo row in the "Share over network" panel. Off by default; switching to "LZ4 (if client supports)" advertises `NONE_AND_LZ4` in the mDNS TXT record.

### Why timeout-based hello instead of a separate port?

Operational simplicity: one port, one mDNS record, no extra config for the user. The 100 ms peek window is invisible compared to RTL-SDR init (~500 ms), and the sniff is non-destructive (`TcpStream::peek`) so legacy clients that don't send hellos just get the normal `dongle_info_t` immediately.

### Commit-by-commit

1. `codec` module — `Codec` / `CodecMask` / `Encoder` / `Decoder` with 7 unit tests
2. `extension` module — `ClientHello` / `ServerExtension` wire format with 8 unit tests
3. Server-side — sniff hello, negotiate codec, wrap writer in `Encoder`
4. Client-side — send hello (conditional), parse extension, wrap reader in `Decoder`
5. mDNS TXT — advertise codec bitmask so clients know up-front whether to send hello
6. Server UI — "Compression" combo row with persistence
7. Client status row — surface negotiated codec in the connection state ("Connected — R820T (29 gains, LZ4)")
8. `cargo fmt` cleanup

### Reserved for the multi-client epic (#390)

The hello / extension wire format reserves bytes for `role` (Control / Listen), `flags` (takeover request), and `version` fields. They're shipped as inert reserved fields in this PR so the #390 sub-issues can extend behavior without bumping the protocol version.

## Test plan

- [x] `cargo test --workspace --features whisper-cpu` — 100% pass
- [x] `cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 7 new codec unit tests (wire round-trip, mask negotiation, LZ4 byte-exact round-trip, None passthrough)
- [x] 8 new extension unit tests (including magic-first-byte vs opcode collision check)
- [x] Existing 41 sdr-server-rtltcp tests still pass
- [x] Existing 34 sdr-source-network tests still pass (including handshake + command roundtrip against a vanilla-like mock server — default `NONE_ONLY` skips hello)

Manual UI smoke test (owner):
- [ ] Open Share-over-network panel, verify "Compression" combo shows with "Off" default
- [ ] Start server with Off, connect our own client → "Connected — R820T (N gains)" (no codec suffix)
- [ ] Set Compression to LZ4, restart server, reconnect our client with `NONE_AND_LZ4` → "Connected — R820T (N gains, LZ4)"
- [ ] Connect GQRX or vanilla rtl_tcp client to the LZ4-advertising server → falls back to uncompressed, still works
- [ ] Kill and reconnect mid-stream under LZ4 → clean reconnect
- [ ] mDNS: `avahi-browse -r _rtl_tcp._tcp` shows `codecs=3` when server is in LZ4 mode, `codecs=1` when Off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional LZ4 compression for RTL‑TCP streams with automatic client/server negotiation and transparent encoding/decoding.
  * Server compression setting in UI (Off / LZ4), persisted across runs.
  * Connection status shows negotiated codec (e.g., "None" or "LZ4").
  * mDNS adverts include codec info so clients can decide support up front.
  * Extended handshake to negotiate codec while falling back to legacy behavior.

* **Tests**
  * Added/updated tests for negotiation, encoding/decoding, parsing, fallback, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->