### PR TITLE
rtl_tcp multi-client fan-out broadcaster (#391)

### DIFF
--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 14;
+pub const ABI_VERSION_MINOR: u32 = 15;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 14);
+        assert!(ABI_VERSION_MINOR == 15);
     };
 
     #[test]

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 13;
+pub const ABI_VERSION_MINOR: u32 = 14;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 13);
+        assert!(ABI_VERSION_MINOR == 14);
     };
 
     #[test]

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -89,9 +89,13 @@ pub struct SdrRtlTcpServerConfig {
 #[repr(C)]
 #[derive(Clone, Copy, Default)]
 pub struct SdrRtlTcpServerStats {
-    /// Number of clients currently connected. Callers allocate
-    /// `[SdrRtlTcpClientInfo; connected_count]` and pass it to
-    /// `sdr_rtltcp_server_client_list` for per-client state.
+    /// Number of clients connected at the moment this snapshot
+    /// was taken. `sdr_rtltcp_server_client_list` is a separate
+    /// live read, so membership may change between the two calls.
+    /// Use this as an initial sizing hint for the client array,
+    /// then honor `*out_count` returned by the list call and
+    /// retry with a larger buffer if the returned count exceeds
+    /// the capacity you passed.
     pub connected_count: u32,
     /// Cumulative bytes fanned out across all clients over the
     /// server's lifetime. Monotonic — never reset. UI consumers
@@ -536,9 +540,12 @@ pub unsafe extern "C" fn sdr_rtltcp_server_has_stopped(handle: *mut SdrRtlTcpSer
 /// is not an error. 64 bytes handles any realistic tuner name.
 ///
 /// For per-client state (peer addresses, per-client counters,
-/// commanded frequencies, etc.) call
-/// [`sdr_rtltcp_server_client_list`] after reading
-/// `out_stats.connected_count`.
+/// commanded frequencies, etc.) use `out_stats.connected_count`
+/// as an initial sizing hint for
+/// [`sdr_rtltcp_server_client_list`]. That call is a separate
+/// live read, so membership may change between the two — always
+/// honor the list call's returned `*out_count` and retry with a
+/// larger buffer if it exceeds the capacity you passed.
 ///
 /// # Safety
 ///

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -194,8 +194,35 @@ pub struct SdrRtlTcpClientInfo {
     /// [`sdr_rtltcp_server_recent_commands_json`]'s `out_required`
     /// size-probe path for buffer sizing (length depends on opcode
     /// names and float formatting, not a fixed per-entry byte
-    /// count). Per `CodeRabbit` round 2 on PR #402.
+    /// count).
     pub recent_commands_count: u32,
+    /// `true` once the client has issued at least one command
+    /// this session. Complementary to `recent_commands_count`:
+    /// `recent_commands_count > 0` implies `has_last_command`,
+    /// but `has_last_command` alone means "at least one command
+    /// dispatched" without committing to whether the ring
+    /// already evicted the earliest entries. `last_command_op`
+    /// and `last_command_age_secs` are only valid when this is
+    /// `true`. Per `CodeRabbit` round 6 on PR #402 — surfaces
+    /// the same `last_command` field the Rust UI uses to drive
+    /// `pick_most_recent_commander`, so FFI hosts can replicate
+    /// the "most recent commander" selection without polling /
+    /// parsing the JSON ring for every connected client.
+    pub has_last_command: bool,
+    /// Wire byte of the client's most recently dispatched
+    /// command — matches the opcode values documented in
+    /// `rtl_tcp.c:315-372` (`SetCenterFreq = 0x01`,
+    /// `SetBiasTee = 0x0e`, etc.). Valid only when
+    /// `has_last_command == true`; 0 when the client hasn't
+    /// sent a command yet. Hosts can map this back to a human
+    /// label via [`sdr_rtltcp_server_recent_commands_json`] or
+    /// their own opcode table.
+    pub last_command_op: u8,
+    /// Seconds elapsed since the client's most recent command
+    /// was dispatched. Measured at the moment this snapshot was
+    /// assembled; increases monotonically between polls.
+    /// Valid only when `has_last_command == true`.
+    pub last_command_age_secs: f64,
 }
 
 impl Default for SdrRtlTcpClientInfo {
@@ -214,6 +241,9 @@ impl Default for SdrRtlTcpClientInfo {
             has_current_gain_value: false,
             has_current_gain_mode: false,
             recent_commands_count: 0,
+            has_last_command: false,
+            last_command_op: 0,
+            last_command_age_secs: 0.0,
         }
     }
 }
@@ -792,6 +822,21 @@ fn stats_to_c(stats: &ServerStats, tuner: &TunerAdvertiseInfo) -> SdrRtlTcpServe
 }
 
 fn client_info_to_c(info: &ClientInfo) -> SdrRtlTcpClientInfo {
+    // Project `last_command` onto the flat FFI trio:
+    // `(has_last_command, last_command_op, last_command_age_secs)`.
+    // Computed against `Instant::now()` at projection time so the
+    // reported age reflects the moment the snapshot was assembled,
+    // matching how UI callers interpret the analogous fields on
+    // `ClientInfo`. Per `CodeRabbit` round 6 on PR #402.
+    let (has_last_command, last_command_op, last_command_age_secs) =
+        if let Some((op, at)) = info.last_command {
+            let age = std::time::Instant::now()
+                .saturating_duration_since(at)
+                .as_secs_f64();
+            (true, op as u8, age)
+        } else {
+            (false, 0u8, 0.0)
+        };
     let mut out = SdrRtlTcpClientInfo {
         id: info.id,
         peer_addr: [0; SDR_RTLTCP_CLIENT_PEER_LEN],
@@ -810,6 +855,9 @@ fn client_info_to_c(info: &ClientInfo) -> SdrRtlTcpClientInfo {
             reason = "recent_commands is capped at RECENT_COMMANDS_CAPACITY = 50"
         )]
         recent_commands_count: info.recent_commands.len() as u32,
+        has_last_command,
+        last_command_op,
+        last_command_age_secs,
     };
     // Write peer_addr into the inline byte array, truncating at
     // `len - 1` to leave room for a NUL. Cast via &mut raw ptr
@@ -1189,6 +1237,22 @@ mod tests {
         assert_eq!(c.id, TEST_CLIENT_ID);
         assert_eq!(c.bytes_sent, TEST_CLIENT_BYTES_SENT);
         assert_eq!(c.codec, 1); // LZ4 wire value
+        // `last_command` fixture is `None` for the whole test;
+        // the projection must surface that as `has_last_command
+        // == false` with the op / age fields defaulted to zero
+        // so FFI hosts never read an undefined opcode or age.
+        assert!(!c.has_last_command);
+        assert_eq!(c.last_command_op, 0);
+        // Exact-zero float comparison is correct here — the
+        // `None` branch of the projection assigns the literal
+        // `0.0` without any arithmetic, so a non-zero readback
+        // would mean the projection wrote the age unconditionally.
+        #[allow(
+            clippy::float_cmp,
+            reason = "projection assigns literal 0.0 in the None branch"
+        )]
+        let age_is_zero = c.last_command_age_secs == 0.0;
+        assert!(age_is_zero);
 
         // (Some(v), None) → value set, mode unknown
         info.current_gain_tenths_db = Some(TEST_NONZERO_GAIN_TENTHS);
@@ -1215,6 +1279,66 @@ mod tests {
         assert!(c.has_current_gain_mode);
         assert_eq!(c.current_gain_tenths_db, TEST_NONZERO_GAIN_TENTHS);
         assert!(!c.current_gain_auto);
+    }
+
+    #[test]
+    fn client_info_to_c_projects_last_command_fields() {
+        // **Regression test for `CodeRabbit` round 6 on PR #402.**
+        // `SdrRtlTcpClientInfo` now carries
+        // `(has_last_command, last_command_op, last_command_age_secs)`
+        // so FFI hosts can replicate the Rust UI's
+        // `pick_most_recent_commander` selection without parsing
+        // every client's JSON ring. Verify the projection:
+        //
+        //   `ClientInfo.last_command = None`             → flag=false, op=0, age=0.0
+        //   `ClientInfo.last_command = Some((op, at))`   → flag=true, op=op_byte, age>0
+        //
+        // The `None` case is already covered by the default path
+        // in `client_info_to_c_preserves_independent_gain_validity`;
+        // this test pins the `Some` case — opcode byte maps to
+        // the wire value, and the age is a positive number
+        // matching the injected delta.
+        use sdr_server_rtltcp::codec::Codec;
+        use sdr_server_rtltcp::protocol::CommandOp;
+        let command_age = Duration::from_secs(TEST_COMMAND_AGE_SECS);
+        let dispatched_at = std::time::Instant::now()
+            .checked_sub(command_age)
+            .expect("Instant::now - TEST_COMMAND_AGE_SECS is representable");
+        let info = ClientInfo {
+            id: TEST_CLIENT_ID,
+            peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_GAIN_PEER_PORT)),
+            connected_since: std::time::Instant::now(),
+            codec: Codec::None,
+            bytes_sent: 0,
+            buffers_dropped: 0,
+            // `SetBiasTee` (0x0e) chosen because it's the highest
+            // documented opcode — a projection bug that truncates
+            // to a smaller `u8` range would still surface here.
+            last_command: Some((CommandOp::SetBiasTee, dispatched_at)),
+            current_freq_hz: None,
+            current_sample_rate_hz: None,
+            current_gain_tenths_db: None,
+            current_gain_auto: None,
+            recent_commands: std::collections::VecDeque::new(),
+        };
+        let c = client_info_to_c(&info);
+        assert!(c.has_last_command);
+        assert_eq!(c.last_command_op, CommandOp::SetBiasTee as u8);
+        assert_eq!(c.last_command_op, 0x0e, "opcode wire byte");
+        // The projection computes `Instant::now().saturating_duration_since(at)`
+        // so the age is at least `TEST_COMMAND_AGE_SECS` (and a
+        // few microseconds over, but we don't pin an upper bound
+        // because CI schedulers vary).
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "seconds count fits in f64 mantissa"
+        )]
+        let min_age = TEST_COMMAND_AGE_SECS as f64;
+        assert!(
+            c.last_command_age_secs >= min_age,
+            "expected age >= {min_age}s, got {}s",
+            c.last_command_age_secs
+        );
     }
 
     #[test]

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -933,6 +933,44 @@ mod tests {
     /// Device index = 0 matches the first attached dongle.
     const TEST_DEVICE_INDEX: u32 = 0;
 
+    // ------------------------------------------------------------
+    // `ClientInfo` fixture constants (`CodeRabbit` round 4 on
+    // PR #402). Extracted so the multi-client ABI tests stay
+    // declarative and future per-client assertions inherit the
+    // same values.
+    // ------------------------------------------------------------
+
+    /// Stable test `ClientId`. Arbitrary non-zero — the registry
+    /// allocates ids starting at 0, so a mid-range value here
+    /// proves the FFI path isn't accidentally hard-coding the
+    /// first-slot assumption.
+    const TEST_CLIENT_ID: u64 = 42;
+    /// Peer port for the gain-validity test — high ephemeral
+    /// range so it doesn't collide with anything real, and
+    /// disjoint from `TEST_CLIENT_PEER_ADDR_PORT` below.
+    const TEST_CLIENT_GAIN_PEER_PORT: u16 = 50_100;
+    /// Peer port + full IP for the NUL-termination test. Uses a
+    /// private-range IP to match typical LAN-server scenarios so
+    /// the packed peer string reads like a real deployment.
+    const TEST_CLIENT_PEER_IP: [u8; 4] = [192, 168, 1, 100];
+    const TEST_CLIENT_PEER_PORT: u16 = 1234;
+    /// Synthetic per-client `bytes_sent` used by the gain test
+    /// so the `client_info_to_c` readback confirms the counter
+    /// propagated through the projection.
+    const TEST_CLIENT_BYTES_SENT: u64 = 9_999;
+    /// Synthetic per-client `buffers_dropped` — non-zero so it
+    /// can't pass from a zero-initialized struct by accident.
+    const TEST_CLIENT_BUFFERS_DROPPED: u64 = 1;
+    /// JSON serialization test: how many seconds back in time
+    /// to place the second `recent_commands` entry so the
+    /// `"seconds_ago"` field has a non-trivial value.
+    const TEST_COMMAND_AGE_SECS: u64 = 3;
+    /// Peer port for the JSON serialization tests' synthetic
+    /// `ClientInfo` — arbitrary, just needs to differ from the
+    /// other fixture ports so a cross-test regression pins to
+    /// the right test.
+    const TEST_CLIENT_JSON_PEER_PORT: u16 = 50_200;
+
     /// Build a happy-path `SdrRtlTcpServerConfig`. Tests tweak
     /// a single field to target one validation branch at a
     /// time — that way a future schema addition lands in one
@@ -1123,12 +1161,12 @@ mod tests {
         // now preserved per-client.
         use sdr_server_rtltcp::codec::Codec;
         let mut info = ClientInfo {
-            id: 42,
-            peer: SocketAddr::from(([127, 0, 0, 1], 50_100)),
+            id: TEST_CLIENT_ID,
+            peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_GAIN_PEER_PORT)),
             connected_since: std::time::Instant::now(),
             codec: Codec::Lz4,
-            bytes_sent: 9_999,
-            buffers_dropped: 1,
+            bytes_sent: TEST_CLIENT_BYTES_SENT,
+            buffers_dropped: TEST_CLIENT_BUFFERS_DROPPED,
             last_command: None,
             current_freq_hz: None,
             current_sample_rate_hz: None,
@@ -1141,8 +1179,8 @@ mod tests {
         let c = client_info_to_c(&info);
         assert!(!c.has_current_gain_value);
         assert!(!c.has_current_gain_mode);
-        assert_eq!(c.id, 42);
-        assert_eq!(c.bytes_sent, 9_999);
+        assert_eq!(c.id, TEST_CLIENT_ID);
+        assert_eq!(c.bytes_sent, TEST_CLIENT_BYTES_SENT);
         assert_eq!(c.codec, 1); // LZ4 wire value
 
         // (Some(v), None) → value set, mode unknown
@@ -1180,7 +1218,7 @@ mod tests {
         use sdr_server_rtltcp::codec::Codec;
         let info = ClientInfo {
             id: 1,
-            peer: SocketAddr::from(([192, 168, 1, 100], 1234)),
+            peer: SocketAddr::from((TEST_CLIENT_PEER_IP, TEST_CLIENT_PEER_PORT)),
             connected_since: std::time::Instant::now(),
             codec: Codec::None,
             bytes_sent: 0,
@@ -1243,7 +1281,7 @@ mod tests {
         use sdr_server_rtltcp::codec::Codec;
         ClientInfo {
             id: 1,
-            peer: SocketAddr::from(([127, 0, 0, 1], 50_200)),
+            peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_JSON_PEER_PORT)),
             connected_since: std::time::Instant::now(),
             codec: Codec::None,
             bytes_sent: 0,
@@ -1272,7 +1310,7 @@ mod tests {
         info.recent_commands.push_back((
             CommandOp::SetBiasTee,
             std::time::Instant::now()
-                .checked_sub(Duration::from_secs(3))
+                .checked_sub(Duration::from_secs(TEST_COMMAND_AGE_SECS))
                 .expect("Instant::now - 3s is representable"),
         ));
         let json = recent_commands_to_json(&info).expect("serialize populated ring");
@@ -1282,6 +1320,14 @@ mod tests {
         assert_eq!(arr[0]["op"], "SetCenterFreq");
         assert_eq!(arr[1]["op"], "SetBiasTee");
         let seconds_ago = arr[1]["seconds_ago"].as_f64().unwrap();
-        assert!(seconds_ago >= 3.0, "expected >=3s, got {seconds_ago}");
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "seconds count fits in f64 mantissa"
+        )]
+        let min_seconds_ago = TEST_COMMAND_AGE_SECS as f64;
+        assert!(
+            seconds_ago >= min_seconds_ago,
+            "expected >={min_seconds_ago}s, got {seconds_ago}"
+        );
     }
 }

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -1094,6 +1094,7 @@ mod tests {
             total_bytes_sent: 1_234_567,
             total_buffers_dropped: 3,
             lifetime_accepted: 7,
+            initial: InitialDeviceState::default(),
         };
         let c = stats_to_c(&stats, &tuner);
         assert_eq!(c.connected_count, 0);

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -144,9 +144,15 @@ pub struct SdrRtlTcpClientInfo {
     /// `sdr_server_rtltcp::codec::Codec::to_wire`.
     pub codec: u8,
     /// Bytes written to this client's socket since its handshake.
-    /// Post-compression — `StatsTrackingWrite` counts bytes at
-    /// the TCP level, so the sum of all `bytes_sent` equals the
-    /// server's on-wire total across connected clients.
+    /// Post-compression (`StatsTrackingWrite` counts bytes at
+    /// the TCP level, below the LZ4 encoder). Covers only this
+    /// currently-connected session —
+    /// [`SdrRtlTcpServerStats::total_bytes_sent`] is a separate
+    /// server-lifetime aggregate that also carries contributions
+    /// from previously-disconnected clients, so the sum of
+    /// per-client `bytes_sent` across the live list does NOT
+    /// equal `total_bytes_sent` once at least one disconnect has
+    /// occurred. Per `CodeRabbit` round 3 on PR #402.
     pub bytes_sent: u64,
     /// Buffer drops this client has accrued (broadcaster saw
     /// `TrySendError::Full` against this client's channel).

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -218,10 +218,16 @@ pub struct SdrRtlTcpClientInfo {
     /// label via [`sdr_rtltcp_server_recent_commands_json`] or
     /// their own opcode table.
     pub last_command_op: u8,
-    /// Seconds elapsed since the client's most recent command
-    /// was dispatched. Measured at the moment this snapshot was
-    /// assembled; increases monotonically between polls.
-    /// Valid only when `has_last_command == true`.
+    /// Seconds elapsed between the client's most recent command
+    /// and the moment this snapshot was assembled. A pure
+    /// snapshot-time age — NOT a monotonic counter: a fresh
+    /// command from the client resets it back near zero on the
+    /// next poll, so don't rely on it increasing between
+    /// consecutive samples. Intended for comparing *recency
+    /// across clients within a single snapshot* (smallest age
+    /// wins — replicates the Rust UI's
+    /// `pick_most_recent_commander`). Valid only when
+    /// `has_last_command == true`.
     pub last_command_age_secs: f64,
 }
 
@@ -685,13 +691,22 @@ pub unsafe extern "C" fn sdr_rtltcp_server_client_list(
         // SAFETY: out_count null-checked above.
         unsafe { *out_count = total };
 
+        // Capture the snapshot clock once for the entire array.
+        // Every projected `last_command_age_secs` / `uptime_secs`
+        // references this same `Instant`, so FFI hosts comparing
+        // ages across clients in one snapshot see a consistent
+        // ordering — per-entry `Instant::now()` calls would drift
+        // by a few microseconds across the loop and could flip
+        // the "smallest age wins" selection. Per `CodeRabbit`
+        // round 7 on PR #402.
+        let snapshot_at = std::time::Instant::now();
         let to_write = total.min(capacity);
         for (i, info) in stats.connected_clients.iter().take(to_write).enumerate() {
             // SAFETY: `i < to_write <= capacity` and the caller
             // guaranteed `out_clients` points at `capacity`
             // entries.
             unsafe {
-                *out_clients.add(i) = client_info_to_c(info);
+                *out_clients.add(i) = client_info_to_c(info, snapshot_at);
             }
         }
 
@@ -821,18 +836,21 @@ fn stats_to_c(stats: &ServerStats, tuner: &TunerAdvertiseInfo) -> SdrRtlTcpServe
     }
 }
 
-fn client_info_to_c(info: &ClientInfo) -> SdrRtlTcpClientInfo {
+fn client_info_to_c(info: &ClientInfo, snapshot_at: std::time::Instant) -> SdrRtlTcpClientInfo {
     // Project `last_command` onto the flat FFI trio:
-    // `(has_last_command, last_command_op, last_command_age_secs)`.
-    // Computed against `Instant::now()` at projection time so the
-    // reported age reflects the moment the snapshot was assembled,
-    // matching how UI callers interpret the analogous fields on
-    // `ClientInfo`. Per `CodeRabbit` round 6 on PR #402.
+    // `(has_last_command, last_command_op, last_command_age_secs)`,
+    // and compute `uptime_secs` the same way. Both ages reference
+    // `snapshot_at` — a single `Instant::now()` captured once by
+    // `sdr_rtltcp_server_client_list` — so every entry in the
+    // emitted array is measured against the same clock. Per-client
+    // `Instant::now()` calls would drift by a few microseconds
+    // across the projection loop, which is enough to flip the
+    // "smallest `last_command_age_secs` wins" ordering FFI hosts
+    // use to replicate `pick_most_recent_commander`. Per
+    // `CodeRabbit` round 7 on PR #402.
     let (has_last_command, last_command_op, last_command_age_secs) =
         if let Some((op, at)) = info.last_command {
-            let age = std::time::Instant::now()
-                .saturating_duration_since(at)
-                .as_secs_f64();
+            let age = snapshot_at.saturating_duration_since(at).as_secs_f64();
             (true, op as u8, age)
         } else {
             (false, 0u8, 0.0)
@@ -840,7 +858,9 @@ fn client_info_to_c(info: &ClientInfo) -> SdrRtlTcpClientInfo {
     let mut out = SdrRtlTcpClientInfo {
         id: info.id,
         peer_addr: [0; SDR_RTLTCP_CLIENT_PEER_LEN],
-        uptime_secs: info.connected_since.elapsed().as_secs_f64(),
+        uptime_secs: snapshot_at
+            .saturating_duration_since(info.connected_since)
+            .as_secs_f64(),
         codec: info.codec.to_wire(),
         bytes_sent: info.bytes_sent,
         buffers_dropped: info.buffers_dropped,
@@ -1215,6 +1235,7 @@ mod tests {
         // pre-#391 server-wide struct (CR round 7 on PR #360),
         // now preserved per-client.
         use sdr_server_rtltcp::codec::Codec;
+        let snapshot_at = std::time::Instant::now();
         let mut info = ClientInfo {
             id: TEST_CLIENT_ID,
             peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_GAIN_PEER_PORT)),
@@ -1231,7 +1252,7 @@ mod tests {
         };
 
         // (None, None) → neither set
-        let c = client_info_to_c(&info);
+        let c = client_info_to_c(&info, snapshot_at);
         assert!(!c.has_current_gain_value);
         assert!(!c.has_current_gain_mode);
         assert_eq!(c.id, TEST_CLIENT_ID);
@@ -1257,7 +1278,7 @@ mod tests {
         // (Some(v), None) → value set, mode unknown
         info.current_gain_tenths_db = Some(TEST_NONZERO_GAIN_TENTHS);
         info.current_gain_auto = None;
-        let c = client_info_to_c(&info);
+        let c = client_info_to_c(&info, snapshot_at);
         assert!(c.has_current_gain_value);
         assert!(!c.has_current_gain_mode);
         assert_eq!(c.current_gain_tenths_db, TEST_NONZERO_GAIN_TENTHS);
@@ -1266,7 +1287,7 @@ mod tests {
         // (None, Some(auto)) → mode set, value unknown
         info.current_gain_tenths_db = None;
         info.current_gain_auto = Some(true);
-        let c = client_info_to_c(&info);
+        let c = client_info_to_c(&info, snapshot_at);
         assert!(!c.has_current_gain_value);
         assert!(c.has_current_gain_mode);
         assert!(c.current_gain_auto);
@@ -1274,7 +1295,7 @@ mod tests {
         // (Some(v), Some(manual)) → both set, explicit manual
         info.current_gain_tenths_db = Some(TEST_NONZERO_GAIN_TENTHS);
         info.current_gain_auto = Some(false);
-        let c = client_info_to_c(&info);
+        let c = client_info_to_c(&info, snapshot_at);
         assert!(c.has_current_gain_value);
         assert!(c.has_current_gain_mode);
         assert_eq!(c.current_gain_tenths_db, TEST_NONZERO_GAIN_TENTHS);
@@ -1283,27 +1304,38 @@ mod tests {
 
     #[test]
     fn client_info_to_c_projects_last_command_fields() {
-        // **Regression test for `CodeRabbit` round 6 on PR #402.**
-        // `SdrRtlTcpClientInfo` now carries
+        // **Regression test for `CodeRabbit` round 6 on PR #402**
+        // (initial projection) **+ round 7** (deterministic age
+        // via injected `snapshot_at` — the function now takes
+        // the snapshot clock as a parameter so per-entry drift
+        // can't flip the "smallest age wins" ordering).
+        //
+        // `SdrRtlTcpClientInfo` carries
         // `(has_last_command, last_command_op, last_command_age_secs)`
         // so FFI hosts can replicate the Rust UI's
         // `pick_most_recent_commander` selection without parsing
         // every client's JSON ring. Verify the projection:
         //
         //   `ClientInfo.last_command = None`             → flag=false, op=0, age=0.0
-        //   `ClientInfo.last_command = Some((op, at))`   → flag=true, op=op_byte, age>0
+        //   `ClientInfo.last_command = Some((op, at))`   → flag=true, op=op_byte, age=snapshot_at-at
         //
         // The `None` case is already covered by the default path
         // in `client_info_to_c_preserves_independent_gain_validity`;
         // this test pins the `Some` case — opcode byte maps to
-        // the wire value, and the age is a positive number
-        // matching the injected delta.
+        // the wire value, and the age is exactly the delta
+        // between the injected `snapshot_at` and the dispatched
+        // timestamp (measured in `f64` seconds).
         use sdr_server_rtltcp::codec::Codec;
         use sdr_server_rtltcp::protocol::CommandOp;
         let command_age = Duration::from_secs(TEST_COMMAND_AGE_SECS);
-        let dispatched_at = std::time::Instant::now()
+        let base = std::time::Instant::now();
+        let dispatched_at = base
             .checked_sub(command_age)
             .expect("Instant::now - TEST_COMMAND_AGE_SECS is representable");
+        // `snapshot_at = dispatched_at + command_age` gives an
+        // age of *exactly* TEST_COMMAND_AGE_SECS, so the
+        // assertion doesn't depend on wall-clock jitter.
+        let snapshot_at = dispatched_at + command_age;
         let info = ClientInfo {
             id: TEST_CLIENT_ID,
             peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_GAIN_PEER_PORT)),
@@ -1321,22 +1353,27 @@ mod tests {
             current_gain_auto: None,
             recent_commands: std::collections::VecDeque::new(),
         };
-        let c = client_info_to_c(&info);
+        let c = client_info_to_c(&info, snapshot_at);
         assert!(c.has_last_command);
         assert_eq!(c.last_command_op, CommandOp::SetBiasTee as u8);
         assert_eq!(c.last_command_op, 0x0e, "opcode wire byte");
-        // The projection computes `Instant::now().saturating_duration_since(at)`
-        // so the age is at least `TEST_COMMAND_AGE_SECS` (and a
-        // few microseconds over, but we don't pin an upper bound
-        // because CI schedulers vary).
         #[allow(
             clippy::cast_precision_loss,
             reason = "seconds count fits in f64 mantissa"
         )]
-        let min_age = TEST_COMMAND_AGE_SECS as f64;
+        let expected_age = TEST_COMMAND_AGE_SECS as f64;
+        // Exact-equality float comparison is correct here
+        // because `snapshot_at - dispatched_at` is a whole number
+        // of seconds converted through `Duration::as_secs_f64` —
+        // no accumulated arithmetic, no wall-clock jitter.
+        #[allow(
+            clippy::float_cmp,
+            reason = "deterministic snapshot_at + exact-seconds command_age"
+        )]
+        let age_matches = c.last_command_age_secs == expected_age;
         assert!(
-            c.last_command_age_secs >= min_age,
-            "expected age >= {min_age}s, got {}s",
+            age_matches,
+            "expected age == {expected_age}s with injected snapshot_at, got {}s",
             c.last_command_age_secs
         );
     }
@@ -1361,7 +1398,7 @@ mod tests {
             current_gain_auto: None,
             recent_commands: std::collections::VecDeque::new(),
         };
-        let c = client_info_to_c(&info);
+        let c = client_info_to_c(&info, std::time::Instant::now());
         // Find the NUL byte and decode what's before. `c_char`
         // is `i8` on most platforms; reinterpret-cast the raw
         // bytes as u8 for the UTF-8 decode since ASCII is

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -21,7 +21,8 @@ use std::net::SocketAddr;
 use std::sync::{Mutex, MutexGuard};
 
 use sdr_server_rtltcp::{
-    InitialDeviceState, Server, ServerConfig, ServerError, ServerStats, TunerAdvertiseInfo,
+    ClientInfo, InitialDeviceState, Server, ServerConfig, ServerError, ServerStats,
+    TunerAdvertiseInfo,
     codec::CodecMask,
     protocol::{CommandOp, DEFAULT_PORT},
 };
@@ -79,69 +80,128 @@ pub struct SdrRtlTcpServerConfig {
     pub initial_direct_sampling: i32,
 }
 
-/// Live server statistics snapshot.
+/// Aggregate server-lifetime statistics snapshot.
 ///
-/// `connected_client_addr` and `tuner_name` are filled into
-/// caller-allocated buffers handed to `sdr_rtltcp_server_stats`;
-/// the struct here carries only scalar fields.
+/// Post-#391 (multi-client): carries only cumulative counters and
+/// the tuner's gain count. Per-client session state moved to
+/// [`SdrRtlTcpClientInfo`] — callers use
+/// [`sdr_rtltcp_server_client_list`] to read it.
 #[repr(C)]
 #[derive(Clone, Copy, Default)]
 pub struct SdrRtlTcpServerStats {
-    /// `true` while a client is connected (also implies
-    /// `uptime_secs` / `bytes_sent` are meaningful).
-    pub has_client: bool,
-    /// Seconds since the current client connected. 0 when
-    /// `has_client == false`.
-    pub uptime_secs: f64,
-    /// Bytes streamed to the client this session.
-    pub bytes_sent: u64,
-    /// Buffer-drop count this session.
-    pub buffers_dropped: u64,
-    /// **Client-issued** center frequency override in Hz —
-    /// what the connected client most recently requested via
-    /// `SetCenterFreq`. 0 before the client has issued the
-    /// command; reset on client disconnect. Does **not**
-    /// reflect the server's configured `initial_freq_hz` or
-    /// the live device register — hosts that want "what the
-    /// dongle is actually tuned to" should combine this with
-    /// `SdrRtlTcpServerConfig::initial_freq_hz` when
-    /// `has_client && current_freq_hz == 0`.
-    pub current_freq_hz: u32,
-    /// **Client-issued** sample-rate override, same semantics
-    /// as `current_freq_hz` above (0 until the client sets it;
-    /// resets on disconnect; doesn't reflect the applied
-    /// initial).
-    pub current_sample_rate_hz: u32,
-    /// Most recent client-issued tuner-gain request in 0.1 dB.
-    /// Valid only when `has_current_gain_value == true` — a
-    /// zero value here is ambiguous otherwise (could mean
-    /// "zero-dB manual gain" or "client never set gain").
-    pub current_gain_tenths_db: i32,
-    /// `true` when the client's last gain-mode request was
-    /// auto; `false` when manual. Valid only when
-    /// `has_current_gain_mode == true`.
-    pub current_gain_auto: bool,
-    /// `true` once the client has issued at least one
-    /// `SetTunerGain` command this session. The two gain
-    /// validity bits are tracked independently because a
-    /// client can send `SetGainMode(auto)` without a preceding
-    /// `SetTunerGain` (and vice versa). Per `CodeRabbit`
-    /// round 7 on PR #360.
-    pub has_current_gain_value: bool,
-    /// `true` once the client has issued at least one
-    /// `SetGainMode` command this session. Valid companion to
-    /// `current_gain_auto` — without this flag a `false`
-    /// value would be indistinguishable from "client hasn't
-    /// asked for a gain mode yet."
-    pub has_current_gain_mode: bool,
+    /// Number of clients currently connected. Callers allocate
+    /// `[SdrRtlTcpClientInfo; connected_count]` and pass it to
+    /// `sdr_rtltcp_server_client_list` for per-client state.
+    pub connected_count: u32,
+    /// Cumulative bytes fanned out across all clients over the
+    /// server's lifetime. Monotonic — never reset. UI consumers
+    /// derive data-rate from the delta between consecutive
+    /// snapshots divided by the poll interval.
+    pub total_bytes_sent: u64,
+    /// Cumulative buffer drops across all clients over the
+    /// server's lifetime. Monotonic. A drop is counted when the
+    /// broadcaster's `try_send` into a client's per-client
+    /// bounded channel returns `Full` (that client's listener
+    /// stalled) — other clients drain independently.
+    pub total_buffers_dropped: u64,
+    /// Cumulative count of clients accepted over the server's
+    /// lifetime. Persists across disconnects; use to answer
+    /// "how many sessions has this server served?" without
+    /// walking a vec.
+    pub lifetime_accepted: u64,
     /// Tuner's advertised discrete gain count (from
     /// `dongle_info_t`). Populated by `Server::start` during
     /// the dongle-open phase — non-zero for the entire server
     /// lifetime, including before the first client connects.
     pub gain_count: u32,
-    /// Number of entries in the recent-commands ring — lets
-    /// hosts size a follow-up `_recent_commands_json` buffer.
+}
+
+/// Fixed-size buffer (bytes) for a client's "ip:port" peer
+/// address in [`SdrRtlTcpClientInfo`]. Sized to fit IPv6 literal
+/// forms (`[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535` is
+/// 47 bytes plus NUL); 64 is the next power-of-two round-up.
+pub const SDR_RTLTCP_CLIENT_PEER_LEN: usize = 64;
+
+/// Per-client snapshot, one entry per connected client. Returned
+/// as an array from [`sdr_rtltcp_server_client_list`].
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SdrRtlTcpClientInfo {
+    /// Stable, monotonic identifier assigned at accept time.
+    /// Never reused across the server's lifetime — useful for
+    /// correlating across stats polls ("client 7 went quiet"
+    /// reads more clearly than peer-address equality when the
+    /// same peer reconnects on a fresh port).
+    pub id: u64,
+    /// Peer socket address as "ip:port", NUL-terminated. Space
+    /// padded with zeros after the NUL. Always fits within
+    /// [`SDR_RTLTCP_CLIENT_PEER_LEN`] including the NUL.
+    pub peer_addr: [c_char; SDR_RTLTCP_CLIENT_PEER_LEN],
+    /// Seconds since this client handshake completed.
+    pub uptime_secs: f64,
+    /// Negotiated stream codec wire byte: 0 = None (legacy /
+    /// vanilla rtl_tcp), 1 = LZ4. See
+    /// `sdr_server_rtltcp::codec::Codec::to_wire`.
+    pub codec: u8,
+    /// Bytes written to this client's socket since its handshake.
+    /// Post-compression — `StatsTrackingWrite` counts bytes at
+    /// the TCP level, so the sum of all `bytes_sent` equals the
+    /// server's on-wire total across connected clients.
+    pub bytes_sent: u64,
+    /// Buffer drops this client has accrued (broadcaster saw
+    /// `TrySendError::Full` against this client's channel).
+    pub buffers_dropped: u64,
+    /// Client-issued center-frequency override in Hz. 0 before
+    /// the client has issued `SetCenterFreq` — does not reflect
+    /// the server's `initial_freq_hz` or the live device
+    /// register. Hosts that want "what the dongle is actually
+    /// tuned to" should fall back to
+    /// `SdrRtlTcpServerConfig::initial_freq_hz` when
+    /// `current_freq_hz == 0`.
+    pub current_freq_hz: u32,
+    /// Client-issued sample-rate override, same semantics as
+    /// `current_freq_hz`.
+    pub current_sample_rate_hz: u32,
+    /// Most recent client-issued tuner-gain request in 0.1 dB.
+    /// Valid only when `has_current_gain_value == true`.
+    pub current_gain_tenths_db: i32,
+    /// `true` when the client's last gain-mode request was auto;
+    /// `false` when manual. Valid only when
+    /// `has_current_gain_mode == true`.
+    pub current_gain_auto: bool,
+    /// `true` once the client has issued at least one
+    /// `SetTunerGain` command. Tracked separately from the
+    /// mode flag because a client can send `SetGainMode(auto)`
+    /// without a preceding `SetTunerGain` (and vice versa).
+    pub has_current_gain_value: bool,
+    /// `true` once the client has issued at least one
+    /// `SetGainMode` command. Valid companion to
+    /// `current_gain_auto`.
+    pub has_current_gain_mode: bool,
+    /// Number of entries in this client's recent-commands ring.
+    /// Sizes a follow-up `_recent_commands_json(client_id, …)`
+    /// buffer.
     pub recent_commands_count: u32,
+}
+
+impl Default for SdrRtlTcpClientInfo {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            peer_addr: [0; SDR_RTLTCP_CLIENT_PEER_LEN],
+            uptime_secs: 0.0,
+            codec: 0,
+            bytes_sent: 0,
+            buffers_dropped: 0,
+            current_freq_hz: 0,
+            current_sample_rate_hz: 0,
+            current_gain_tenths_db: 0,
+            current_gain_auto: false,
+            has_current_gain_value: false,
+            has_current_gain_mode: false,
+            recent_commands_count: 0,
+        }
+    }
 }
 
 // ============================================================
@@ -457,14 +517,18 @@ pub unsafe extern "C" fn sdr_rtltcp_server_has_stopped(handle: *mut SdrRtlTcpSer
     }
 }
 
-/// Snapshot the server's live stats into a caller-provided
-/// struct + string buffers.
+/// Snapshot the server's aggregate stats into a caller-provided
+/// struct + tuner-name buffer.
 ///
-/// `out_stats` must be non-null. `out_client_addr` and
-/// `out_tuner_name` are NUL-terminated on success; pass
-/// `NULL` buffers (with corresponding `*_len = 0`) to skip.
-/// Truncation is not an error — the result is NUL-terminated
-/// at `*_len - 1` when the source string is longer.
+/// `out_stats` must be non-null. `out_tuner_name` is an optional
+/// NUL-terminated string buffer (pass `NULL` with
+/// `tuner_name_len = 0` to skip). Truncation at `tuner_name_len - 1`
+/// is not an error. 64 bytes handles any realistic tuner name.
+///
+/// For per-client state (peer addresses, per-client counters,
+/// commanded frequencies, etc.) call
+/// [`sdr_rtltcp_server_client_list`] after reading
+/// `out_stats.connected_count`.
 ///
 /// # Safety
 ///
@@ -474,8 +538,6 @@ pub unsafe extern "C" fn sdr_rtltcp_server_has_stopped(handle: *mut SdrRtlTcpSer
 pub unsafe extern "C" fn sdr_rtltcp_server_stats(
     handle: *mut SdrRtlTcpServer,
     out_stats: *mut SdrRtlTcpServerStats,
-    out_client_addr: *mut c_char,
-    client_addr_len: usize,
     out_tuner_name: *mut c_char,
     tuner_name_len: usize,
 ) -> i32 {
@@ -499,13 +561,8 @@ pub unsafe extern "C" fn sdr_rtltcp_server_stats(
         // SAFETY: out_stats null-checked above.
         unsafe { *out_stats = packed };
 
-        // Copy the string fields into caller buffers (if
-        // provided). Truncate cleanly at `len - 1`.
-        let client_str = stats
-            .connected_client
-            .map_or_else(String::new, |addr| addr.to_string());
-        // SAFETY: caller contract on out_client_addr / len.
-        unsafe { write_cstr(out_client_addr, client_addr_len, &client_str) };
+        // Copy the tuner name into the caller buffer (if provided).
+        // Truncate cleanly at `len - 1`.
         // SAFETY: caller contract on out_tuner_name / len.
         unsafe { write_cstr(out_tuner_name, tuner_name_len, &tuner.name) };
 
@@ -524,26 +581,113 @@ pub unsafe extern "C" fn sdr_rtltcp_server_stats(
     }
 }
 
-/// Write the recent-commands ring to `out_buf` as a JSON array.
-/// Each entry is `{"op": "<name>", "seconds_ago": <f64>}`.
-/// The wire-level 4-byte command param is not in the upstream
-/// `ServerStats::recent_commands` payload (only the opcode +
-/// dispatch time are captured), so the param field is not
-/// surfaced here — matches the contract in `include/sdr_core.h`.
+/// Snapshot every connected client's state into a caller-provided
+/// array.
 ///
-/// On success returns `SDR_CORE_OK` and NUL-terminates the
-/// buffer. On too-small buffer returns `SDR_CORE_ERR_INVALID_ARG`
-/// and writes the required size (including NUL) to `*out_required`
-/// when non-null. On stopped server returns `NOT_RUNNING`.
+/// `out_clients` may be null when `capacity == 0` — in that case
+/// the function populates `*out_count` with the current
+/// connected-client count so the caller can size its buffer and
+/// re-call. When `capacity > 0` and there are more connected
+/// clients than `capacity`, the function fills the first
+/// `capacity` entries and still writes the full count to
+/// `*out_count` (the caller retries with a bigger buffer).
+///
+/// Returns `SDR_CORE_OK` on success (including the query-count
+/// path), `SDR_CORE_ERR_INVALID_ARG` on null `out_count`,
+/// `SDR_CORE_ERR_INVALID_HANDLE` on null handle,
+/// `SDR_CORE_ERR_NOT_RUNNING` if the server was already stopped.
+///
+/// Client ordering is stable within a snapshot (oldest-first) but
+/// may shift across snapshots as clients disconnect. Use
+/// [`SdrRtlTcpClientInfo::id`] for cross-snapshot correlation.
 ///
 /// # Safety
 ///
-/// `out_buf` must point at a writable buffer of at least
-/// `buf_len` bytes. `out_required` is optional (pass null to
-/// skip).
+/// `out_clients` must either be null (with `capacity == 0`) or
+/// point at a writable array of `capacity`
+/// `SdrRtlTcpClientInfo` entries. `out_count` must be non-null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_rtltcp_server_client_list(
+    handle: *mut SdrRtlTcpServer,
+    out_clients: *mut SdrRtlTcpClientInfo,
+    capacity: usize,
+    out_count: *mut usize,
+) -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        if out_count.is_null() {
+            set_last_error("sdr_rtltcp_server_client_list: null out_count");
+            return SdrCoreError::InvalidArg.as_int();
+        }
+        if out_clients.is_null() && capacity > 0 {
+            set_last_error(
+                "sdr_rtltcp_server_client_list: null out_clients with non-zero capacity",
+            );
+            return SdrCoreError::InvalidArg.as_int();
+        }
+        // SAFETY: caller contract.
+        let Some(h) = (unsafe { SdrRtlTcpServer::from_raw(handle) }) else {
+            set_last_error("sdr_rtltcp_server_client_list: invalid handle");
+            return SdrCoreError::InvalidHandle.as_int();
+        };
+        let Some(stats) = h.with_server(Server::stats) else {
+            set_last_error("sdr_rtltcp_server_client_list: server already stopped");
+            return SdrCoreError::NotRunning.as_int();
+        };
+
+        let total = stats.connected_clients.len();
+        // SAFETY: out_count null-checked above.
+        unsafe { *out_count = total };
+
+        let to_write = total.min(capacity);
+        for (i, info) in stats.connected_clients.iter().take(to_write).enumerate() {
+            // SAFETY: `i < to_write <= capacity` and the caller
+            // guaranteed `out_clients` points at `capacity`
+            // entries.
+            unsafe {
+                *out_clients.add(i) = client_info_to_c(info);
+            }
+        }
+
+        clear_last_error();
+        SdrCoreError::Ok.as_int()
+    });
+    match result {
+        Ok(code) => code,
+        Err(payload) => {
+            set_last_error(format!(
+                "sdr_rtltcp_server_client_list: panic: {}",
+                panic_message(&payload)
+            ));
+            SdrCoreError::Internal.as_int()
+        }
+    }
+}
+
+/// Write one client's recent-commands ring to `out_buf` as a
+/// JSON array. Each entry is
+/// `{"op": "<name>", "seconds_ago": <f64>}`.
+///
+/// `client_id` identifies the target client — read it from an
+/// earlier `SdrRtlTcpClientInfo::id` snapshot.
+///
+/// On success returns `SDR_CORE_OK` and NUL-terminates the
+/// buffer. On too-small buffer returns
+/// `SDR_CORE_ERR_INVALID_ARG` and writes the required size
+/// (including NUL) to `*out_required` when non-null. If the
+/// specified client isn't currently connected returns
+/// `SDR_CORE_ERR_INVALID_ARG` with `*out_required = 0` (client
+/// may have disconnected between snapshots). On stopped server
+/// returns `NOT_RUNNING`.
+///
+/// # Safety
+///
+/// `out_buf` must either be null (with `buf_len == 0`) or point
+/// at a writable buffer of at least `buf_len` bytes.
+/// `out_required` is optional (pass null to skip).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sdr_rtltcp_server_recent_commands_json(
     handle: *mut SdrRtlTcpServer,
+    client_id: u64,
     out_buf: *mut c_char,
     buf_len: usize,
     out_required: *mut usize,
@@ -558,7 +702,17 @@ pub unsafe extern "C" fn sdr_rtltcp_server_recent_commands_json(
             set_last_error("sdr_rtltcp_server_recent_commands_json: server already stopped");
             return SdrCoreError::NotRunning.as_int();
         };
-        let json = match recent_commands_to_json(&stats) {
+        let Some(client) = stats.connected_clients.iter().find(|c| c.id == client_id) else {
+            set_last_error(format!(
+                "sdr_rtltcp_server_recent_commands_json: client {client_id} not connected"
+            ));
+            if !out_required.is_null() {
+                // SAFETY: caller contract.
+                unsafe { *out_required = 0 };
+            }
+            return SdrCoreError::InvalidArg.as_int();
+        };
+        let json = match recent_commands_to_json(client) {
             Ok(s) => s,
             Err(e) => {
                 set_last_error(format!(
@@ -607,33 +761,61 @@ pub unsafe extern "C" fn sdr_rtltcp_server_recent_commands_json(
 // ============================================================
 
 fn stats_to_c(stats: &ServerStats, tuner: &TunerAdvertiseInfo) -> SdrRtlTcpServerStats {
-    let uptime_secs = stats
-        .connected_since
-        .map_or(0.0, |t| t.elapsed().as_secs_f64());
     SdrRtlTcpServerStats {
-        has_client: stats.connected_client.is_some(),
-        uptime_secs,
-        bytes_sent: stats.bytes_sent,
-        buffers_dropped: stats.buffers_dropped,
-        current_freq_hz: stats.current_freq_hz.unwrap_or(0),
-        current_sample_rate_hz: stats.current_sample_rate_hz.unwrap_or(0),
-        current_gain_tenths_db: stats.current_gain_tenths_db.unwrap_or(0),
-        current_gain_auto: stats.current_gain_auto.unwrap_or(false),
-        has_current_gain_value: stats.current_gain_tenths_db.is_some(),
-        has_current_gain_mode: stats.current_gain_auto.is_some(),
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "connected_count is bounded by OS FD limits — far below u32::MAX"
+        )]
+        connected_count: stats.connected_clients.len() as u32,
+        total_bytes_sent: stats.total_bytes_sent,
+        total_buffers_dropped: stats.total_buffers_dropped,
+        lifetime_accepted: stats.lifetime_accepted,
         gain_count: tuner.gain_count,
+    }
+}
+
+fn client_info_to_c(info: &ClientInfo) -> SdrRtlTcpClientInfo {
+    let mut out = SdrRtlTcpClientInfo {
+        id: info.id,
+        peer_addr: [0; SDR_RTLTCP_CLIENT_PEER_LEN],
+        uptime_secs: info.connected_since.elapsed().as_secs_f64(),
+        codec: info.codec.to_wire(),
+        bytes_sent: info.bytes_sent,
+        buffers_dropped: info.buffers_dropped,
+        current_freq_hz: info.current_freq_hz.unwrap_or(0),
+        current_sample_rate_hz: info.current_sample_rate_hz.unwrap_or(0),
+        current_gain_tenths_db: info.current_gain_tenths_db.unwrap_or(0),
+        current_gain_auto: info.current_gain_auto.unwrap_or(false),
+        has_current_gain_value: info.current_gain_tenths_db.is_some(),
+        has_current_gain_mode: info.current_gain_auto.is_some(),
         #[allow(
             clippy::cast_possible_truncation,
             reason = "recent_commands is capped at RECENT_COMMANDS_CAPACITY = 50"
         )]
-        recent_commands_count: stats.recent_commands.len() as u32,
+        recent_commands_count: info.recent_commands.len() as u32,
+    };
+    // Write peer_addr into the inline byte array, truncating at
+    // `len - 1` to leave room for a NUL. Cast via &mut raw ptr
+    // so `write_cstr`'s contract (null-or-writable buffer) is
+    // honored uniformly with the other callers.
+    let peer = info.peer.to_string();
+    // SAFETY: `out.peer_addr` is a stack-local array of size
+    // SDR_RTLTCP_CLIENT_PEER_LEN; taking a raw mut ptr to its
+    // first element gives write access for the full length.
+    unsafe {
+        write_cstr(
+            out.peer_addr.as_mut_ptr(),
+            SDR_RTLTCP_CLIENT_PEER_LEN,
+            &peer,
+        );
     }
+    out
 }
 
-fn recent_commands_to_json(stats: &ServerStats) -> Result<String, serde_json::Error> {
+fn recent_commands_to_json(info: &ClientInfo) -> Result<String, serde_json::Error> {
     use serde_json::json;
     let now = std::time::Instant::now();
-    let entries: Vec<_> = stats
+    let entries: Vec<_> = info
         .recent_commands
         .iter()
         .map(|(op, t)| {
@@ -859,11 +1041,36 @@ mod tests {
                 &raw mut stats,
                 std::ptr::null_mut(),
                 0,
-                std::ptr::null_mut(),
-                0,
             )
         };
         assert_eq!(rc, SdrCoreError::InvalidHandle.as_int());
+    }
+
+    #[test]
+    fn client_list_with_null_handle_returns_invalid_handle() {
+        let mut count: usize = 0;
+        let rc = unsafe {
+            sdr_rtltcp_server_client_list(
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0,
+                &raw mut count,
+            )
+        };
+        assert_eq!(rc, SdrCoreError::InvalidHandle.as_int());
+    }
+
+    #[test]
+    fn client_list_with_null_out_count_returns_invalid_arg() {
+        let rc = unsafe {
+            sdr_rtltcp_server_client_list(
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
     }
 
     #[test]
@@ -873,48 +1080,119 @@ mod tests {
     }
 
     #[test]
-    fn stats_to_c_preserves_independent_gain_validity() {
-        // Four-state matrix for the two gain Options on
-        // `ServerStats`. Pins the "don't collapse into a
-        // single `has_current_gain` bit" behavior landed in
-        // round 7. Per `CodeRabbit` round 8 on PR #360.
+    fn stats_to_c_packs_aggregate_counters() {
+        // Post-#391 shape: `SdrRtlTcpServerStats` carries only
+        // aggregate cumulative counters + the tuner gain count.
+        // Per-client state belongs in `SdrRtlTcpClientInfo` and
+        // ships through `sdr_rtltcp_server_client_list`.
         let tuner = TunerAdvertiseInfo {
             name: "R820T".into(),
             gain_count: TEST_TUNER_GAIN_COUNT,
         };
-
-        // (None, None) → neither set (Default leaves both at None).
-        let mut stats = ServerStats::default();
+        let stats = ServerStats {
+            connected_clients: Vec::new(),
+            total_bytes_sent: 1_234_567,
+            total_buffers_dropped: 3,
+            lifetime_accepted: 7,
+        };
         let c = stats_to_c(&stats, &tuner);
+        assert_eq!(c.connected_count, 0);
+        assert_eq!(c.total_bytes_sent, 1_234_567);
+        assert_eq!(c.total_buffers_dropped, 3);
+        assert_eq!(c.lifetime_accepted, 7);
+        assert_eq!(c.gain_count, TEST_TUNER_GAIN_COUNT);
+    }
+
+    #[test]
+    fn client_info_to_c_preserves_independent_gain_validity() {
+        // Four-state matrix for the two gain Options on
+        // `ClientInfo`. Pins the "don't collapse into a single
+        // `has_current_gain` bit" behavior that shipped on the
+        // pre-#391 server-wide struct (CR round 7 on PR #360),
+        // now preserved per-client.
+        use sdr_server_rtltcp::codec::Codec;
+        let mut info = ClientInfo {
+            id: 42,
+            peer: SocketAddr::from(([127, 0, 0, 1], 50_100)),
+            connected_since: std::time::Instant::now(),
+            codec: Codec::Lz4,
+            bytes_sent: 9_999,
+            buffers_dropped: 1,
+            last_command: None,
+            current_freq_hz: None,
+            current_sample_rate_hz: None,
+            current_gain_tenths_db: None,
+            current_gain_auto: None,
+            recent_commands: std::collections::VecDeque::new(),
+        };
+
+        // (None, None) → neither set
+        let c = client_info_to_c(&info);
         assert!(!c.has_current_gain_value);
         assert!(!c.has_current_gain_mode);
+        assert_eq!(c.id, 42);
+        assert_eq!(c.bytes_sent, 9_999);
+        assert_eq!(c.codec, 1); // LZ4 wire value
 
         // (Some(v), None) → value set, mode unknown
-        stats.current_gain_tenths_db = Some(TEST_NONZERO_GAIN_TENTHS);
-        stats.current_gain_auto = None;
-        let c = stats_to_c(&stats, &tuner);
+        info.current_gain_tenths_db = Some(TEST_NONZERO_GAIN_TENTHS);
+        info.current_gain_auto = None;
+        let c = client_info_to_c(&info);
         assert!(c.has_current_gain_value);
         assert!(!c.has_current_gain_mode);
         assert_eq!(c.current_gain_tenths_db, TEST_NONZERO_GAIN_TENTHS);
         assert!(!c.current_gain_auto);
 
         // (None, Some(auto)) → mode set, value unknown
-        stats.current_gain_tenths_db = None;
-        stats.current_gain_auto = Some(true);
-        let c = stats_to_c(&stats, &tuner);
+        info.current_gain_tenths_db = None;
+        info.current_gain_auto = Some(true);
+        let c = client_info_to_c(&info);
         assert!(!c.has_current_gain_value);
         assert!(c.has_current_gain_mode);
         assert!(c.current_gain_auto);
 
         // (Some(v), Some(manual)) → both set, explicit manual
-        stats.current_gain_tenths_db = Some(TEST_NONZERO_GAIN_TENTHS);
-        stats.current_gain_auto = Some(false);
-        let c = stats_to_c(&stats, &tuner);
+        info.current_gain_tenths_db = Some(TEST_NONZERO_GAIN_TENTHS);
+        info.current_gain_auto = Some(false);
+        let c = client_info_to_c(&info);
         assert!(c.has_current_gain_value);
         assert!(c.has_current_gain_mode);
         assert_eq!(c.current_gain_tenths_db, TEST_NONZERO_GAIN_TENTHS);
         assert!(!c.current_gain_auto);
-        assert_eq!(c.gain_count, TEST_TUNER_GAIN_COUNT);
+    }
+
+    #[test]
+    fn client_info_to_c_peer_addr_is_nul_terminated() {
+        // Peer address is packed into a fixed-size byte array;
+        // the slot past the written bytes must be NUL so C
+        // callers see a well-formed string.
+        use sdr_server_rtltcp::codec::Codec;
+        let info = ClientInfo {
+            id: 1,
+            peer: SocketAddr::from(([192, 168, 1, 100], 1234)),
+            connected_since: std::time::Instant::now(),
+            codec: Codec::None,
+            bytes_sent: 0,
+            buffers_dropped: 0,
+            last_command: None,
+            current_freq_hz: None,
+            current_sample_rate_hz: None,
+            current_gain_tenths_db: None,
+            current_gain_auto: None,
+            recent_commands: std::collections::VecDeque::new(),
+        };
+        let c = client_info_to_c(&info);
+        // Find the NUL byte and decode what's before. `c_char`
+        // is `i8` on most platforms; reinterpret-cast the raw
+        // bytes as u8 for the UTF-8 decode since ASCII is
+        // layout-compatible across the signedness boundary.
+        let peer_bytes: Vec<u8> = c.peer_addr.iter().map(|&b| b.to_ne_bytes()[0]).collect();
+        let nul_pos = peer_bytes
+            .iter()
+            .position(|&b| b == 0)
+            .expect("NUL terminator");
+        let peer_str = std::str::from_utf8(&peer_bytes[..nul_pos]).unwrap();
+        assert_eq!(peer_str, "192.168.1.100:1234");
     }
 
     #[test]
@@ -947,26 +1225,46 @@ mod tests {
         assert_eq!(buf[0], FILL_BYTE);
     }
 
+    /// Build a bare-bones `ClientInfo` fixture for the JSON
+    /// serialization tests. Callers mutate the `recent_commands`
+    /// field for their specific assertions.
+    fn empty_client_info() -> ClientInfo {
+        use sdr_server_rtltcp::codec::Codec;
+        ClientInfo {
+            id: 1,
+            peer: SocketAddr::from(([127, 0, 0, 1], 50_200)),
+            connected_since: std::time::Instant::now(),
+            codec: Codec::None,
+            bytes_sent: 0,
+            buffers_dropped: 0,
+            last_command: None,
+            current_freq_hz: None,
+            current_sample_rate_hz: None,
+            current_gain_tenths_db: None,
+            current_gain_auto: None,
+            recent_commands: std::collections::VecDeque::new(),
+        }
+    }
+
     #[test]
     fn recent_commands_json_empty_when_no_commands() {
-        let stats = ServerStats::default();
-        let json = recent_commands_to_json(&stats).expect("serialize empty ring");
+        let info = empty_client_info();
+        let json = recent_commands_to_json(&info).expect("serialize empty ring");
         assert_eq!(json, "[]");
     }
 
     #[test]
     fn recent_commands_json_entries_shape() {
-        let mut stats = ServerStats::default();
-        stats
-            .recent_commands
+        let mut info = empty_client_info();
+        info.recent_commands
             .push_back((CommandOp::SetCenterFreq, std::time::Instant::now()));
-        stats.recent_commands.push_back((
+        info.recent_commands.push_back((
             CommandOp::SetBiasTee,
             std::time::Instant::now()
                 .checked_sub(Duration::from_secs(3))
                 .expect("Instant::now - 3s is representable"),
         ));
-        let json = recent_commands_to_json(&stats).expect("serialize populated ring");
+        let json = recent_commands_to_json(&info).expect("serialize populated ring");
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         let arr = parsed.as_array().unwrap();
         assert_eq!(arr.len(), 2);

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -179,8 +179,12 @@ pub struct SdrRtlTcpClientInfo {
     /// `current_gain_auto`.
     pub has_current_gain_mode: bool,
     /// Number of entries in this client's recent-commands ring.
-    /// Sizes a follow-up `_recent_commands_json(client_id, …)`
-    /// buffer.
+    /// An entry count, not a byte count — callers that want to
+    /// serialize the ring as JSON use
+    /// [`sdr_rtltcp_server_recent_commands_json`]'s `out_required`
+    /// size-probe path for buffer sizing (length depends on opcode
+    /// names and float formatting, not a fixed per-entry byte
+    /// count). Per `CodeRabbit` round 2 on PR #402.
     pub recent_commands_count: u32,
 }
 

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -62,6 +62,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
 use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 use std::time::Instant;
 
 use crate::codec::Codec;
@@ -288,6 +289,19 @@ pub struct ClientRegistry {
     /// callers. Order preserved — roughly "oldest client first" —
     /// so stats snapshots render consistently across polls.
     slots: Mutex<Vec<Arc<ClientSlot>>>,
+    /// Per-client worker `JoinHandle`s parked until server shutdown.
+    /// Each `spawn_client_workers` call pushes two entries (writer +
+    /// command). `Server::drop` drains and joins them after setting
+    /// the global shutdown flag so the dongle's `Arc<Mutex<RtlSdrDevice>>`
+    /// is actually released before `has_stopped()` reports true.
+    ///
+    /// Kept on the registry rather than the slot so a panicked /
+    /// disconnected slot can be pruned without losing its handle —
+    /// the handle still blocks on the panicking thread's actual
+    /// exit during shutdown join.
+    ///
+    /// Per `CodeRabbit` round 1 on PR #402.
+    worker_handles: Mutex<Vec<JoinHandle<()>>>,
     /// Monotonic `ClientId` allocator. Never reused. An atomic so
     /// the accept loop doesn't need to hold `slots` to issue an id.
     next_id: AtomicU64,
@@ -296,10 +310,13 @@ pub struct ClientRegistry {
     /// how many are connected right now; this tells you how many
     /// ever have been. Useful for server-uptime / load diagnostics.
     lifetime_accepted: AtomicU64,
-    /// Cumulative bytes sent across all clients (connected OR
-    /// disconnected). Updated per-client via writer-side stats and
-    /// mirrored here at fan-out time so UI doesn't need to walk the
-    /// slots vec to compute the total. Monotonic; never reset.
+    /// Cumulative bytes actually written to the wire across all
+    /// clients. Incremented by [`Self::record_bytes_sent`] from the
+    /// per-client writer path AFTER the TCP write succeeds so it
+    /// reflects post-compression on-wire bytes, not pre-encoding
+    /// payload. The per-client `ClientStats::bytes_sent` is
+    /// incremented at the same point for the same reason. Monotonic;
+    /// never reset. Per `CodeRabbit` round 1 on PR #402.
     total_bytes_sent: AtomicU64,
     /// Cumulative buffers dropped across all clients. Monotonic.
     total_buffers_dropped: AtomicU64,
@@ -330,6 +347,42 @@ impl ClientRegistry {
         if let Ok(mut guard) = self.slots.lock() {
             guard.push(slot);
         }
+    }
+
+    /// Park a per-client worker `JoinHandle` for later shutdown
+    /// join. Called twice per accepted client — once for the
+    /// writer thread, once for the command thread. Handles are
+    /// drained and joined by [`Self::drain_worker_handles`] during
+    /// `Server::drop`, guaranteeing the threads' cloned device
+    /// `Arc` references are released before shutdown completes.
+    pub fn register_worker_handle(&self, handle: JoinHandle<()>) {
+        if let Ok(mut guard) = self.worker_handles.lock() {
+            guard.push(handle);
+        }
+    }
+
+    /// Take every parked worker handle. Caller joins them. Used by
+    /// `Server::drop` so the dongle's device mutex `Arc` cannot
+    /// linger past the `has_stopped()` transition — otherwise a
+    /// follow-up `Server::start` or engine open would fight a
+    /// ghost worker for USB exclusivity. Per CodeRabbit round 1
+    /// on PR #402.
+    pub fn drain_worker_handles(&self) -> Vec<JoinHandle<()>> {
+        self.worker_handles
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default()
+    }
+
+    /// Increment the cumulative on-wire byte counter by `n`. Called
+    /// from the per-client writer path after a successful TCP
+    /// write so the aggregate tracks post-compression bytes. Per
+    /// CodeRabbit round 1 on PR #402 — moved here from
+    /// `broadcast` (which counted pre-compression payload bytes
+    /// at `try_send` time, double-counting whatever was dropped on
+    /// a full channel).
+    pub fn record_bytes_sent(&self, n: u64) {
+        self.total_bytes_sent.fetch_add(n, Ordering::Relaxed);
     }
 
     /// Number of slots currently in the registry (includes slots
@@ -363,11 +416,13 @@ impl ClientRegistry {
 
     /// Fan one IQ chunk out to every live slot. For each slot:
     ///
-    /// - **Live + channel has room** → `try_send` succeeds, slot's
-    ///   `bytes_sent` increments by `chunk.len()` (the broadcaster
-    ///   sees pre-compression bytes; the slot's writer-side
-    ///   `StatsTrackingWrite` counts post-compression bytes on the
-    ///   socket write — the two are the same when `codec = None`).
+    /// - **Live + channel has room** → `try_send` succeeds. No
+    ///   counter bump happens here — bytes are counted on the
+    ///   per-client writer side after the TCP write succeeds (via
+    ///   [`Self::record_bytes_sent`] + the slot's
+    ///   `bytes_sent` field), so the aggregate and per-client
+    ///   counters reflect post-compression, post-successful-write
+    ///   bytes. Per `CodeRabbit` round 1 on PR #402.
     /// - **Live + channel full** → `TrySendError::Full`; chunk is
     ///   dropped for this slot only, `buffers_dropped` increments.
     /// - **`Receiver` dropped** → `TrySendError::Disconnected`; the
@@ -399,10 +454,15 @@ impl ClientRegistry {
 
         for slot in live {
             let buf = chunk.to_vec();
-            let buf_len = buf.len() as u64;
             match slot.tx.try_send(buf) {
                 Ok(()) => {
-                    self.total_bytes_sent.fetch_add(buf_len, Ordering::Relaxed);
+                    // Bytes are counted at the writer layer after
+                    // the TCP write succeeds (both per-client
+                    // `bytes_sent` and the aggregate
+                    // `total_bytes_sent` increment there). Counting
+                    // here would inflate the aggregate with bytes
+                    // that never reach the wire when a client
+                    // disconnects mid-queue.
                 }
                 Err(TrySendError::Full(_)) => {
                     // Per-slot drop accounting.
@@ -496,7 +556,11 @@ mod tests {
         reg.broadcast(b"hello");
         let received = rx.recv().unwrap();
         assert_eq!(&received[..], b"hello");
-        assert_eq!(reg.total_bytes_sent(), 5);
+        // `total_bytes_sent` is NOT bumped by `broadcast` — it's
+        // counted at the writer layer after the TCP write succeeds
+        // (per CodeRabbit round 1 on PR #402), so this unit test
+        // without a real writer observes zero.
+        assert_eq!(reg.total_bytes_sent(), 0);
     }
 
     #[test]
@@ -511,9 +575,24 @@ mod tests {
 
         assert_eq!(rx1.recv().unwrap(), b"abcde");
         assert_eq!(rx2.recv().unwrap(), b"abcde");
-        // Both clients saw the chunk, so total_bytes_sent reflects
-        // two copies of the 5-byte payload.
-        assert_eq!(reg.total_bytes_sent(), 10);
+        // `total_bytes_sent` is counted on successful TCP write at
+        // the `StatsTrackingWrite` layer — unit tests without a
+        // real writer observe zero. Integration with the writer
+        // is covered in `server.rs`.
+        assert_eq!(reg.total_bytes_sent(), 0);
+    }
+
+    #[test]
+    fn record_bytes_sent_accumulates_in_aggregate() {
+        // The writer path calls `record_bytes_sent(n)` after each
+        // successful TCP write. Here we simulate the calls
+        // directly to pin the aggregate contract.
+        let reg = ClientRegistry::new();
+        assert_eq!(reg.total_bytes_sent(), 0);
+        reg.record_bytes_sent(128);
+        reg.record_bytes_sent(256);
+        reg.record_bytes_sent(64);
+        assert_eq!(reg.total_bytes_sent(), 448);
     }
 
     #[test]
@@ -566,8 +645,6 @@ mod tests {
         // Nothing should have been sent — `try_send` never called
         // against a disconnected slot. The Receiver sees Empty.
         assert!(rx.try_recv().is_err());
-        // And we didn't credit the "total sent" counter either.
-        assert_eq!(reg.total_bytes_sent(), 0);
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -57,12 +57,6 @@
 //! [`ServerConfig`]: crate::server::ServerConfig
 //! [`crate::server`]: crate::server
 
-// Keep module-level `dead_code` allowed for the short window between
-// this commit (types + registry, no wiring) and the data-path flip
-// commit that consumes them. Removed once `server.rs` wires the
-// registry into the accept loop.
-#![allow(dead_code)]
-
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -358,23 +358,69 @@ impl ClientRegistry {
         }
     }
 
-    /// Park a per-client worker `JoinHandle` for later shutdown
-    /// join. Called twice per accepted client — once for the
-    /// writer thread, once for the command thread. Handles are
-    /// drained and joined by [`Self::drain_worker_handles`] during
-    /// `Server::drop`, guaranteeing the threads' cloned device
-    /// `Arc` references are released before shutdown completes.
+    /// Park a per-client worker `JoinHandle` for later join.
+    /// Called twice per accepted client — once for the writer
+    /// thread, once for the command thread. During normal
+    /// runtime, finished handles are reaped on the broadcaster's
+    /// prune cadence via [`Self::reap_finished_worker_handles`];
+    /// any still-running at shutdown are drained + joined by
+    /// [`Self::drain_worker_handles`] so the threads' cloned
+    /// device `Arc` references are released before `stop()` /
+    /// `Drop` returns.
     pub fn register_worker_handle(&self, handle: JoinHandle<()>) {
         if let Ok(mut guard) = self.worker_handles.lock() {
             guard.push(handle);
         }
     }
 
+    /// Join every parked worker handle whose thread has already
+    /// exited. Runs on the broadcaster's prune cadence so a
+    /// long-lived server with heavy connection churn doesn't
+    /// accumulate completed `JoinHandle`s until shutdown — each
+    /// handle keeps the thread's OS resources + TLS around until
+    /// joined, and the list grows without bound even though the
+    /// slots themselves get pruned. Finished handles are cheap
+    /// to join (the thread has already exited), so running this
+    /// on the same ~2.5 s cadence as slot pruning keeps the
+    /// handle list bounded by the number of currently-live
+    /// clients × 2. [`Self::drain_worker_handles`] still owns
+    /// final-shutdown joining for any handles that had not
+    /// finished by the last reap. Returns the number reaped for
+    /// tracing. Per `CodeRabbit` round 5 on PR #402.
+    pub fn reap_finished_worker_handles(&self) -> usize {
+        let Ok(mut guard) = self.worker_handles.lock() else {
+            return 0;
+        };
+        let taken = std::mem::take(&mut *guard);
+        let (finished, running): (Vec<_>, Vec<_>) =
+            taken.into_iter().partition(JoinHandle::is_finished);
+        *guard = running;
+        let reaped = finished.len();
+        // Release the lock before joining; `is_finished == true`
+        // so each join returns immediately, but there's no
+        // reason to hold the mutex across the calls and block
+        // registrations of new per-client handles from the
+        // accept thread.
+        drop(guard);
+        for h in finished {
+            if let Err(payload) = h.join() {
+                // A panicked worker thread would have already
+                // flipped its slot's `disconnected` flag from
+                // inside the unwinding path (slot drop handlers
+                // do so) and a newer CR pass can tighten that
+                // guarantee. For now, log the payload so
+                // regressions surface in tests and tracing.
+                tracing::warn!(?payload, "rtl_tcp reaped panicked worker thread");
+            }
+        }
+        reaped
+    }
+
     /// Take every parked worker handle. Caller joins them. Used by
     /// `Server::drop` so the dongle's device mutex `Arc` cannot
     /// linger past the `has_stopped()` transition — otherwise a
     /// follow-up `Server::start` or engine open would fight a
-    /// ghost worker for USB exclusivity. Per CodeRabbit round 1
+    /// ghost worker for USB exclusivity. Per `CodeRabbit` round 1
     /// on PR #402.
     pub fn drain_worker_handles(&self) -> Vec<JoinHandle<()>> {
         self.worker_handles
@@ -833,6 +879,57 @@ mod tests {
             stats.record_command(CommandOp::SetCenterFreq, t);
         }
         assert_eq!(stats.recent_commands.len(), RECENT_COMMANDS_CAPACITY);
+    }
+
+    #[test]
+    fn reap_finished_worker_handles_joins_finished_keeps_running() {
+        // **Regression test for `CodeRabbit` round 5 on PR #402.**
+        // The registry used to park every worker handle until
+        // shutdown, so a long-lived server with heavy connection
+        // churn accumulated completed handles indefinitely. The
+        // fix reaps finished handles on the broadcaster's prune
+        // cadence, leaving running ones in place.
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Duration;
+
+        let reg = ClientRegistry::new();
+
+        // Register a handle that has already finished. Wait for
+        // `is_finished` to flip true before calling the reaper so
+        // the partition is deterministic.
+        let finished = std::thread::spawn(|| {});
+        while !finished.is_finished() {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        reg.register_worker_handle(finished);
+
+        // Register a handle that's still running (spins on an
+        // atomic flag the test controls).
+        let keep_running = Arc::new(AtomicBool::new(true));
+        let keep_running_clone = Arc::clone(&keep_running);
+        let running = std::thread::spawn(move || {
+            while keep_running_clone.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        });
+        reg.register_worker_handle(running);
+
+        assert_eq!(
+            reg.reap_finished_worker_handles(),
+            1,
+            "exactly the finished handle should be reaped"
+        );
+
+        // Running handle is still in the list — verify by
+        // draining (mimics the shutdown path) and confirm we get
+        // back exactly one handle.
+        keep_running.store(false, Ordering::Relaxed);
+        let remaining = reg.drain_worker_handles();
+        assert_eq!(remaining.len(), 1, "running handle must not be reaped");
+        for h in remaining {
+            h.join()
+                .expect("running thread exits cleanly once flag clears");
+        }
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -494,16 +494,23 @@ impl ClientRegistry {
         before - guard.len()
     }
 
-    /// Project every live slot to a [`ClientInfo`] snapshot for stats
-    /// consumers. Disconnected-but-not-yet-pruned slots are included
-    /// so the UI can render "client 7 last seen at X" continuity
-    /// before the broadcaster's next prune cycle clears it. Order
-    /// preserved from the underlying slot list.
+    /// Project every **live** slot to a [`ClientInfo`] snapshot for
+    /// stats consumers. Disconnected-but-not-yet-pruned slots are
+    /// filtered out — otherwise UI and FFI consumers would briefly
+    /// see dead sessions as live and the FFI could hand callers
+    /// `client_id`s that are already disconnected. Per CodeRabbit
+    /// round 2 on PR #402.
+    ///
+    /// Order preserved from the underlying slot list (oldest-first).
     pub fn snapshot(&self) -> Vec<ClientInfo> {
         let Ok(guard) = self.slots.lock() else {
             return Vec::new();
         };
-        guard.iter().map(|s| s.snapshot()).collect()
+        guard
+            .iter()
+            .filter(|s| !s.is_disconnected())
+            .map(|s| s.snapshot())
+            .collect()
     }
 }
 
@@ -720,18 +727,26 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_includes_disconnected_slots_before_prune() {
-        // Document the contract: snapshot reflects CURRENT slot list,
-        // including disconnected-but-not-yet-pruned entries. This
-        // lets the UI render "client X just disconnected, gone on
-        // next poll" continuity.
+    fn snapshot_excludes_disconnected_slots() {
+        // The contract after CodeRabbit round 2: `snapshot()`
+        // returns only LIVE clients. Disconnected-but-not-yet-pruned
+        // slots are filtered out so UI / FFI consumers don't
+        // briefly see dead sessions as live (FFI clients would
+        // otherwise get stale ids that are already disconnected).
         let reg = ClientRegistry::new();
-        let (slot, _rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
-        reg.register(slot.clone());
-        slot.mark_disconnected();
+        let (live, _live_rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        let (dead, _dead_rx) = ClientSlot::new(reg.allocate_id(), test_peer(2), Codec::None, 4);
+        reg.register(live);
+        reg.register(dead.clone());
 
+        // Both registered → len() == 2 (raw slot count).
+        assert_eq!(reg.len(), 2);
+        // But snapshot() excludes the disconnected one.
+        dead.mark_disconnected();
         assert_eq!(reg.snapshot().len(), 1);
+        // Pruning removes it from `len()` too.
         reg.prune_disconnected();
-        assert_eq!(reg.snapshot().len(), 0);
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.snapshot().len(), 1);
     }
 }

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -1,0 +1,666 @@
+//! Multi-client fan-out broadcaster (#391).
+//!
+//! Replaces the single-client data path from the pre-#391 server. The
+//! previous model had one `data_worker` per connected client pulling USB
+//! bulk bytes into a bounded [`std::sync::mpsc::sync_channel`] drained by
+//! the client's own writer thread. That worked for one client because the
+//! USB device is exclusive — but it couldn't serve a second client at all
+//! (the accept loop rejected any second connection with TCP FIN).
+//!
+//! The new model has **one** USB reader thread (owned by [`Server`])
+//! feeding **many** bounded per-client channels via a [`ClientRegistry`].
+//! Each connected client gets its own [`ClientSlot`] carrying the write
+//! side of its channel, its negotiated codec, its per-client stats, and a
+//! disconnection flag the writer / command threads flip on exit. The USB
+//! reader calls [`ClientRegistry::broadcast`] once per USB chunk; the
+//! registry fans out by cloning the chunk and `try_send`-ing to each
+//! live slot.
+//!
+//! # Backpressure and drop-on-full
+//!
+//! Every slot has its own bounded channel (capacity configurable via
+//! [`ServerConfig`]). When a single slow client stops draining, their
+//! channel fills and subsequent [`TrySendError::Full`] returns are
+//! counted against **that client only** — the drop counter on their
+//! [`ClientSlot`] goes up. Other clients with drained channels keep
+//! receiving bytes uninterrupted. This is the whole point of per-client
+//! channels versus a shared broadcast queue: one slow listener can't
+//! stall the controller.
+//!
+//! # Disconnection lifecycle
+//!
+//! A client's writer or command thread flips [`ClientSlot::disconnected`]
+//! on error / EOF. The broadcaster observes the flag on the next
+//! fan-out tick and skips that slot (its channel is presumed dead).
+//! Periodically the broadcaster calls [`ClientRegistry::prune_disconnected`]
+//! which walks the slot list, removes disconnected entries, and drops
+//! the last `Arc<ClientSlot>` — which closes the channel receiver (if the
+//! writer thread has exited) and releases all per-client resources.
+//!
+//! # Thread-safety
+//!
+//! [`ClientRegistry`] holds its slot list behind a [`Mutex`]. The
+//! broadcaster clones the list of live `Arc<ClientSlot>` under the lock,
+//! then releases it before doing any `try_send` work. This means the
+//! accept thread can [`ClientRegistry::register`] new clients while a
+//! fan-out is in flight (brief lock contention during the clone, nothing
+//! more). Per-slot mutable state (stats, disconnection flag) uses
+//! independent synchronization (Atomic + Mutex) so slots don't
+//! serialize on the registry lock.
+//!
+//! This module ships in isolation in the first commit of #391 — the
+//! public types and registry API compile + test without any wiring
+//! into [`crate::server`] yet. The data-path flip lands in the next
+//! commit.
+//!
+//! [`Server`]: crate::server::Server
+//! [`ServerConfig`]: crate::server::ServerConfig
+//! [`crate::server`]: crate::server
+
+// Keep module-level `dead_code` allowed for the short window between
+// this commit (types + registry, no wiring) and the data-path flip
+// commit that consumes them. Removed once `server.rs` wires the
+// registry into the accept loop.
+#![allow(dead_code)]
+
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use crate::codec::Codec;
+use crate::protocol::CommandOp;
+
+/// Default per-client bounded-channel capacity measured in 256 KiB USB
+/// chunks. Matches the pre-#391 single-client default (`llbuf_num = 500`
+/// in upstream rtl_tcp.c:61) — a fresh per-client buffer now instead of
+/// a shared one. Per-client sizing keeps the memory bound predictable as
+/// the connected-client count grows.
+pub const DEFAULT_PER_CLIENT_BUFFER_DEPTH: usize = 500;
+
+/// Monotonic per-server-lifetime client identifier. Assigned by
+/// [`ClientRegistry::register`] and never reused, even after the client
+/// disconnects. Used by UI and debug logs to correlate stats snapshots
+/// across consecutive polls ("client 7 disconnected, client 8 connected"
+/// reads more clearly than peer-address equality, especially when the
+/// same peer reconnects on a fresh port).
+pub type ClientId = u64;
+
+/// Maximum number of recent `(CommandOp, Instant)` entries retained in
+/// a client's [`ClientStats::recent_commands`] ring. Same bound as the
+/// pre-#391 server-wide ring — just per-client now so one chatty client
+/// can't crowd out another's activity log in the UI.
+pub const RECENT_COMMANDS_CAPACITY: usize = 50;
+
+/// Mutable per-client counters updated by the writer (bytes_sent via the
+/// existing `StatsTrackingWrite`), broadcaster (buffers_dropped on
+/// `TrySendError::Full`), and command worker (last_command +
+/// current_freq/rate/gain + recent_commands on each dispatched command).
+///
+/// Held behind a [`Mutex`] on [`ClientSlot`] — contention is low because
+/// the writer taps it once per USB chunk (hundreds of Hz), commands are
+/// sparse user actions, and UI snapshots happen at poll cadence (~2 Hz).
+#[derive(Debug, Clone, Default)]
+pub struct ClientStats {
+    /// Bytes written to the client's TCP socket since connect.
+    /// Post-compression when the client negotiated a non-`None` codec
+    /// (counted at the `StatsTrackingWrite` adapter below the encoder),
+    /// so the UI's data-rate row reflects on-wire throughput.
+    pub bytes_sent: u64,
+    /// USB chunks dropped for THIS client because its channel was full.
+    /// Incremented by the broadcaster on `TrySendError::Full`. Other
+    /// clients whose channels drained normally are unaffected.
+    pub buffers_dropped: u64,
+    /// Most recently dispatched command. UI renders it as the
+    /// client's "last action" hint.
+    pub last_command: Option<(CommandOp, Instant)>,
+    /// Client's most recent `SetCenterFreq` request, in Hz. We record
+    /// what the client ASKED for, not what the device ultimately
+    /// applied — dispatch logs device-side failures at `warn!`, and a
+    /// client that sees its tune get rejected will just re-ask.
+    pub current_freq_hz: Option<u32>,
+    /// Client's most recent `SetSampleRate` request, in Hz.
+    pub current_sample_rate_hz: Option<u32>,
+    /// Client's most recent `SetTunerGain` request, in tenths of dB
+    /// (negative is legal per upstream).
+    pub current_gain_tenths_db: Option<i32>,
+    /// `true` when the client most recently sent `SetGainMode(auto)`,
+    /// `false` on `SetGainMode(manual)`, `None` when it hasn't sent
+    /// one this session.
+    pub current_gain_auto: Option<bool>,
+    /// Bounded ring of recent dispatched commands. Oldest at front,
+    /// newest at back; capped at [`RECENT_COMMANDS_CAPACITY`].
+    pub recent_commands: VecDeque<(CommandOp, Instant)>,
+}
+
+impl ClientStats {
+    /// Push a dispatched command onto the ring, evicting the oldest
+    /// entry when the capacity is already reached. Centralized so the
+    /// command worker doesn't duplicate the `pop_front` + `push_back`
+    /// dance at each call site.
+    pub fn record_command(&mut self, op: CommandOp, at: Instant) {
+        self.last_command = Some((op, at));
+        if self.recent_commands.len() >= RECENT_COMMANDS_CAPACITY {
+            self.recent_commands.pop_front();
+        }
+        self.recent_commands.push_back((op, at));
+    }
+}
+
+/// Per-client state held by the registry. Owned through `Arc` so the
+/// broadcaster, writer thread, and command thread can each hold a
+/// reference without fighting for ownership — they all do different
+/// things with it but the slot outlives them all via the registry.
+///
+/// Split into immutable identity fields (`id`, `peer`, `connected_since`,
+/// `codec`) and mutable fields (`tx` read-only after construction,
+/// `stats` via Mutex, `disconnected` via Atomic) so the immutable ones
+/// can be read lock-free from anywhere.
+pub struct ClientSlot {
+    /// Stable identifier assigned by the registry.
+    pub id: ClientId,
+    /// Peer address captured at accept time. Stays in the slot for
+    /// its lifetime — never updated even if the underlying socket
+    /// gets torn down.
+    pub peer: SocketAddr,
+    /// Wall-clock moment the handshake completed and the slot was
+    /// registered. Used for uptime displays.
+    pub connected_since: Instant,
+    /// Codec negotiated during the extended `"RTLX"` handshake (or
+    /// [`Codec::None`] for legacy clients). Immutable for the slot's
+    /// lifetime — if the client wants to change codec they must
+    /// reconnect.
+    pub codec: Codec,
+    /// Write half of this client's bounded channel. The broadcaster
+    /// calls [`SyncSender::try_send`] to push USB chunks; the
+    /// client's writer thread owns the matching `Receiver` and
+    /// drains into the encoded socket.
+    pub tx: SyncSender<Vec<u8>>,
+    /// Per-client counters. Held behind a Mutex rather than an
+    /// atomic-field cluster so structured fields (last_command,
+    /// recent_commands) don't need their own synchronization.
+    pub stats: Mutex<ClientStats>,
+    /// Set to `true` by the client's writer or command thread when
+    /// it observes an unrecoverable error (broken socket, EOF,
+    /// mutex poison). The broadcaster skips slots with this flag
+    /// set on its next fan-out; [`ClientRegistry::prune_disconnected`]
+    /// removes them entirely on its next sweep.
+    pub disconnected: AtomicBool,
+}
+
+impl ClientSlot {
+    /// Construct a slot with a freshly-created bounded channel.
+    /// Returns both the slot (ready to register) and the `Receiver`
+    /// that the writer thread consumes.
+    pub fn new(
+        id: ClientId,
+        peer: SocketAddr,
+        codec: Codec,
+        channel_depth: usize,
+    ) -> (Arc<Self>, Receiver<Vec<u8>>) {
+        let (tx, rx) = sync_channel::<Vec<u8>>(channel_depth);
+        let slot = Arc::new(Self {
+            id,
+            peer,
+            connected_since: Instant::now(),
+            codec,
+            tx,
+            stats: Mutex::new(ClientStats::default()),
+            disconnected: AtomicBool::new(false),
+        });
+        (slot, rx)
+    }
+
+    /// Mark the slot as disconnected. Idempotent; safe to call from
+    /// multiple threads (e.g. writer AND command workers both observe
+    /// a broken socket concurrently).
+    pub fn mark_disconnected(&self) {
+        self.disconnected.store(true, Ordering::Release);
+    }
+
+    /// Whether the slot has been marked disconnected by any of its
+    /// worker threads. The broadcaster uses this to skip fan-out to
+    /// dying clients; the pruner uses it to decide which slots to
+    /// remove from the registry.
+    pub fn is_disconnected(&self) -> bool {
+        self.disconnected.load(Ordering::Acquire)
+    }
+
+    /// Read-only projection of the slot's state for stats consumers
+    /// (UI / FFI). Acquires the stats mutex exactly once.
+    pub fn snapshot(&self) -> ClientInfo {
+        // Poisoned-mutex path: return a best-effort snapshot with
+        // zeroed counters rather than failing the whole `snapshot()`
+        // call chain. A UI that misses one update is fine; a crashed
+        // UI thread is not.
+        let stats = self.stats.lock().ok();
+        let stats_clone = stats.as_ref().map(|g| (**g).clone()).unwrap_or_default();
+        ClientInfo {
+            id: self.id,
+            peer: self.peer,
+            connected_since: self.connected_since,
+            codec: self.codec,
+            bytes_sent: stats_clone.bytes_sent,
+            buffers_dropped: stats_clone.buffers_dropped,
+            last_command: stats_clone.last_command,
+            current_freq_hz: stats_clone.current_freq_hz,
+            current_sample_rate_hz: stats_clone.current_sample_rate_hz,
+            current_gain_tenths_db: stats_clone.current_gain_tenths_db,
+            current_gain_auto: stats_clone.current_gain_auto,
+            recent_commands: stats_clone.recent_commands,
+        }
+    }
+}
+
+/// Public snapshot of a client's state, returned by
+/// [`ClientRegistry::snapshot`] and embedded in `ServerStats`. Flat
+/// (not an `Arc`) so stats consumers can clone it freely without
+/// affecting the registry.
+#[derive(Debug, Clone)]
+pub struct ClientInfo {
+    pub id: ClientId,
+    pub peer: SocketAddr,
+    pub connected_since: Instant,
+    pub codec: Codec,
+    pub bytes_sent: u64,
+    pub buffers_dropped: u64,
+    pub last_command: Option<(CommandOp, Instant)>,
+    pub current_freq_hz: Option<u32>,
+    pub current_sample_rate_hz: Option<u32>,
+    pub current_gain_tenths_db: Option<i32>,
+    pub current_gain_auto: Option<bool>,
+    pub recent_commands: VecDeque<(CommandOp, Instant)>,
+}
+
+/// Thread-safe registry of connected clients.
+///
+/// One instance per [`Server`], shared across:
+///
+/// - **Accept loop** — calls [`Self::register`] after a successful
+///   handshake.
+/// - **Broadcaster thread** — calls [`Self::broadcast`] once per USB
+///   chunk and [`Self::prune_disconnected`] periodically.
+/// - **Stats snapshot path** — calls [`Self::snapshot`] when the UI /
+///   FFI polls `Server::stats()`.
+///
+/// [`Server`]: crate::server::Server
+#[derive(Default)]
+pub struct ClientRegistry {
+    /// Live client slots. Slots are held by `Arc` so the broadcaster
+    /// can clone a stable snapshot of them under the lock, release
+    /// the lock, then fan-out without blocking `register` / `prune`
+    /// callers. Order preserved — roughly "oldest client first" —
+    /// so stats snapshots render consistently across polls.
+    slots: Mutex<Vec<Arc<ClientSlot>>>,
+    /// Monotonic `ClientId` allocator. Never reused. An atomic so
+    /// the accept loop doesn't need to hold `slots` to issue an id.
+    next_id: AtomicU64,
+    /// Cumulative count of clients registered since the server started.
+    /// Persists across disconnects — `snapshot().len()` tells you
+    /// how many are connected right now; this tells you how many
+    /// ever have been. Useful for server-uptime / load diagnostics.
+    lifetime_accepted: AtomicU64,
+    /// Cumulative bytes sent across all clients (connected OR
+    /// disconnected). Updated per-client via writer-side stats and
+    /// mirrored here at fan-out time so UI doesn't need to walk the
+    /// slots vec to compute the total. Monotonic; never reset.
+    total_bytes_sent: AtomicU64,
+    /// Cumulative buffers dropped across all clients. Monotonic.
+    total_buffers_dropped: AtomicU64,
+}
+
+impl ClientRegistry {
+    /// Fresh registry with no clients. Normally constructed once by
+    /// `Server::start` and shared via `Arc<ClientRegistry>`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate the next [`ClientId`] without taking the slot lock.
+    /// Called before [`Self::register`] so the caller can stamp the
+    /// id on the slot's `ClientSlot::id` field inside
+    /// [`ClientSlot::new`]. Monotonic, never reuses.
+    pub fn allocate_id(&self) -> ClientId {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Push a slot onto the registry. The slot's `id` field SHOULD
+    /// have been allocated via [`Self::allocate_id`]; the registry
+    /// doesn't enforce this but stats consumers expect ids to be
+    /// monotonic and unique.
+    pub fn register(&self, slot: Arc<ClientSlot>) {
+        self.lifetime_accepted.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut guard) = self.slots.lock() {
+            guard.push(slot);
+        }
+    }
+
+    /// Number of slots currently in the registry (includes slots
+    /// marked disconnected but not yet pruned). Cheap — only locks
+    /// the slot mutex briefly.
+    pub fn len(&self) -> usize {
+        self.slots.lock().map_or(0, |g| g.len())
+    }
+
+    /// True when [`Self::len`] is zero.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Cumulative client count over the server's lifetime. Includes
+    /// clients that have since disconnected. Monotonic.
+    pub fn lifetime_accepted(&self) -> u64 {
+        self.lifetime_accepted.load(Ordering::Relaxed)
+    }
+
+    /// Cumulative bytes fanned out (broadcaster's view, pre-per-client
+    /// compression). Never reset.
+    pub fn total_bytes_sent(&self) -> u64 {
+        self.total_bytes_sent.load(Ordering::Relaxed)
+    }
+
+    /// Cumulative drops across all clients.
+    pub fn total_buffers_dropped(&self) -> u64 {
+        self.total_buffers_dropped.load(Ordering::Relaxed)
+    }
+
+    /// Fan one IQ chunk out to every live slot. For each slot:
+    ///
+    /// - **Live + channel has room** → `try_send` succeeds, slot's
+    ///   `bytes_sent` increments by `chunk.len()` (the broadcaster
+    ///   sees pre-compression bytes; the slot's writer-side
+    ///   `StatsTrackingWrite` counts post-compression bytes on the
+    ///   socket write — the two are the same when `codec = None`).
+    /// - **Live + channel full** → `TrySendError::Full`; chunk is
+    ///   dropped for this slot only, `buffers_dropped` increments.
+    /// - **`Receiver` dropped** → `TrySendError::Disconnected`; the
+    ///   writer thread has exited. Slot is marked disconnected here
+    ///   so it gets pruned on the next sweep.
+    /// - **Already disconnected** → skipped.
+    ///
+    /// The fan-out clones `chunk` per live slot (one heap allocation
+    /// each). At the typical 2.4 Msps rate and ~10 clients this is
+    /// ~48 MB/s of clone traffic — negligible on any hardware that
+    /// can run the server in the first place. Per-slot channels
+    /// means we can't avoid the clone entirely (shared `Arc<Vec<u8>>`
+    /// would serialize drains through the single buffer's strong-ref
+    /// counter; the slow path wins little and the fast path pays
+    /// refcount overhead).
+    ///
+    /// Uses a lock-scope narrowing trick: collect live slots into a
+    /// local Vec under the lock, drop the lock, then do the fan-out
+    /// without holding it. Accept thread can `register` a new slot
+    /// mid-broadcast without blocking.
+    pub fn broadcast(&self, chunk: &[u8]) {
+        // Snapshot the live slots while holding the lock. Skip slots
+        // already marked disconnected so we don't bother cloning the
+        // chunk into a channel whose receiver has gone away.
+        let live: Vec<Arc<ClientSlot>> = match self.slots.lock() {
+            Ok(g) => g.iter().filter(|s| !s.is_disconnected()).cloned().collect(),
+            Err(_) => return,
+        };
+
+        for slot in live {
+            let buf = chunk.to_vec();
+            let buf_len = buf.len() as u64;
+            match slot.tx.try_send(buf) {
+                Ok(()) => {
+                    self.total_bytes_sent.fetch_add(buf_len, Ordering::Relaxed);
+                }
+                Err(TrySendError::Full(_)) => {
+                    // Per-slot drop accounting.
+                    if let Ok(mut s) = slot.stats.lock() {
+                        s.buffers_dropped = s.buffers_dropped.saturating_add(1);
+                    }
+                    self.total_buffers_dropped.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    // Writer thread has exited and dropped the
+                    // `Receiver`. Mark the slot so prune picks it up.
+                    slot.mark_disconnected();
+                }
+            }
+        }
+    }
+
+    /// Remove every slot whose `disconnected` flag is set. Returns the
+    /// number of slots removed, for log/tracing callers that want to
+    /// report churn. The broadcaster calls this periodically (not on
+    /// every chunk — the lock-cost-to-signal ratio isn't worth it at
+    /// the USB cadence).
+    pub fn prune_disconnected(&self) -> usize {
+        let Ok(mut guard) = self.slots.lock() else {
+            return 0;
+        };
+        let before = guard.len();
+        guard.retain(|s| !s.is_disconnected());
+        before - guard.len()
+    }
+
+    /// Project every live slot to a [`ClientInfo`] snapshot for stats
+    /// consumers. Disconnected-but-not-yet-pruned slots are included
+    /// so the UI can render "client 7 last seen at X" continuity
+    /// before the broadcaster's next prune cycle clears it. Order
+    /// preserved from the underlying slot list.
+    pub fn snapshot(&self) -> Vec<ClientInfo> {
+        let Ok(guard) = self.slots.lock() else {
+            return Vec::new();
+        };
+        guard.iter().map(|s| s.snapshot()).collect()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// Convenience constructor for tests that don't care about the
+    /// TCP peer — picks a deterministic placeholder loopback address.
+    fn test_peer(port: u16) -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], port))
+    }
+
+    /// Default channel depth small enough to exercise the Full path
+    /// without needing to push 500 chunks.
+    const TEST_CHANNEL_DEPTH: usize = 2;
+
+    #[test]
+    fn allocate_id_is_monotonic() {
+        let reg = ClientRegistry::new();
+        let a = reg.allocate_id();
+        let b = reg.allocate_id();
+        let c = reg.allocate_id();
+        assert_eq!((a, b, c), (0, 1, 2));
+    }
+
+    #[test]
+    fn register_grows_len_and_lifetime_counter() {
+        let reg = ClientRegistry::new();
+        assert!(reg.is_empty());
+
+        let (slot, _rx) = ClientSlot::new(reg.allocate_id(), test_peer(1234), Codec::None, 4);
+        reg.register(slot);
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.lifetime_accepted(), 1);
+
+        let (slot2, _rx2) = ClientSlot::new(reg.allocate_id(), test_peer(1235), Codec::Lz4, 4);
+        reg.register(slot2);
+        assert_eq!(reg.len(), 2);
+        assert_eq!(reg.lifetime_accepted(), 2);
+    }
+
+    #[test]
+    fn broadcast_delivers_chunk_to_live_slot() {
+        let reg = ClientRegistry::new();
+        let (slot, rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        reg.register(slot);
+
+        reg.broadcast(b"hello");
+        let received = rx.recv().unwrap();
+        assert_eq!(&received[..], b"hello");
+        assert_eq!(reg.total_bytes_sent(), 5);
+    }
+
+    #[test]
+    fn broadcast_fans_out_identical_chunks_to_every_slot() {
+        let reg = ClientRegistry::new();
+        let (s1, rx1) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        let (s2, rx2) = ClientSlot::new(reg.allocate_id(), test_peer(2), Codec::Lz4, 4);
+        reg.register(s1);
+        reg.register(s2);
+
+        reg.broadcast(b"abcde");
+
+        assert_eq!(rx1.recv().unwrap(), b"abcde");
+        assert_eq!(rx2.recv().unwrap(), b"abcde");
+        // Both clients saw the chunk, so total_bytes_sent reflects
+        // two copies of the 5-byte payload.
+        assert_eq!(reg.total_bytes_sent(), 10);
+    }
+
+    #[test]
+    fn broadcast_full_channel_counts_drop_for_that_client_only() {
+        let reg = ClientRegistry::new();
+        // Slow client with a 2-slot channel — we'll stuff it past
+        // capacity and verify the drop accounting.
+        let (slow, _slow_rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(1),
+            Codec::None,
+            TEST_CHANNEL_DEPTH,
+        );
+        // Fast client with generous room — shouldn't drop anything.
+        let (fast, fast_rx) = ClientSlot::new(reg.allocate_id(), test_peer(2), Codec::None, 16);
+        let slow_id = slow.id;
+        reg.register(slow);
+        reg.register(fast);
+
+        // First two broadcasts fit in the slow client's channel, the
+        // third is dropped for slow but delivered to fast.
+        reg.broadcast(b"a");
+        reg.broadcast(b"b");
+        reg.broadcast(b"c");
+
+        // Fast client got all three.
+        assert_eq!(fast_rx.recv().unwrap(), b"a");
+        assert_eq!(fast_rx.recv().unwrap(), b"b");
+        assert_eq!(fast_rx.recv().unwrap(), b"c");
+
+        // Slow client's drop counter registers exactly one drop.
+        let snap = reg.snapshot();
+        let slow_snap = snap
+            .iter()
+            .find(|c| c.id == slow_id)
+            .expect("slow client present in snapshot");
+        assert_eq!(slow_snap.buffers_dropped, 1);
+        assert_eq!(reg.total_buffers_dropped(), 1);
+    }
+
+    #[test]
+    fn broadcast_skips_disconnected_slot() {
+        let reg = ClientRegistry::new();
+        let (slot, rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        reg.register(slot.clone());
+
+        slot.mark_disconnected();
+        reg.broadcast(b"payload");
+
+        // Nothing should have been sent — `try_send` never called
+        // against a disconnected slot. The Receiver sees Empty.
+        assert!(rx.try_recv().is_err());
+        // And we didn't credit the "total sent" counter either.
+        assert_eq!(reg.total_bytes_sent(), 0);
+    }
+
+    #[test]
+    fn broadcast_marks_slot_disconnected_when_receiver_dropped() {
+        let reg = ClientRegistry::new();
+        let (slot, rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        reg.register(slot.clone());
+
+        // Simulate writer thread exit by dropping the receiver.
+        drop(rx);
+
+        // The slot isn't disconnected yet — the flag only flips after
+        // the broadcaster actually observes `TrySendError::Disconnected`.
+        assert!(!slot.is_disconnected());
+
+        reg.broadcast(b"payload");
+
+        // Now it should be flagged.
+        assert!(slot.is_disconnected());
+    }
+
+    #[test]
+    fn prune_disconnected_removes_flagged_slots_only() {
+        let reg = ClientRegistry::new();
+        let (live, _live_rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        let (dead, _dead_rx) = ClientSlot::new(reg.allocate_id(), test_peer(2), Codec::None, 4);
+        dead.mark_disconnected();
+        reg.register(live);
+        reg.register(dead);
+
+        assert_eq!(reg.len(), 2);
+        let removed = reg.prune_disconnected();
+        assert_eq!(removed, 1);
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn snapshot_reflects_registered_slots_with_stats() {
+        let reg = ClientRegistry::new();
+        let (slot, _rx) = ClientSlot::new(reg.allocate_id(), test_peer(4242), Codec::Lz4, 4);
+        let slot_id = slot.id;
+        reg.register(slot.clone());
+
+        // Mutate the per-client stats through the mutex so we can
+        // prove `snapshot` reads the mutated values.
+        if let Ok(mut s) = slot.stats.lock() {
+            s.bytes_sent = 123;
+            s.current_freq_hz = Some(100_000_000);
+            s.record_command(CommandOp::SetCenterFreq, Instant::now());
+        }
+
+        let snap = reg.snapshot();
+        assert_eq!(snap.len(), 1);
+        let info = &snap[0];
+        assert_eq!(info.id, slot_id);
+        assert_eq!(info.peer, test_peer(4242));
+        assert_eq!(info.codec, Codec::Lz4);
+        assert_eq!(info.bytes_sent, 123);
+        assert_eq!(info.current_freq_hz, Some(100_000_000));
+        assert_eq!(info.recent_commands.len(), 1);
+    }
+
+    #[test]
+    fn client_stats_record_command_respects_capacity() {
+        // record_command pops the oldest entry when the ring is
+        // full. Asserts the cap stays bounded under load.
+        let mut stats = ClientStats::default();
+        let t = Instant::now();
+        for _ in 0..(RECENT_COMMANDS_CAPACITY + 5) {
+            stats.record_command(CommandOp::SetCenterFreq, t);
+        }
+        assert_eq!(stats.recent_commands.len(), RECENT_COMMANDS_CAPACITY);
+    }
+
+    #[test]
+    fn snapshot_includes_disconnected_slots_before_prune() {
+        // Document the contract: snapshot reflects CURRENT slot list,
+        // including disconnected-but-not-yet-pruned entries. This
+        // lets the UI render "client X just disconnected, gone on
+        // next poll" continuity.
+        let reg = ClientRegistry::new();
+        let (slot, _rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        reg.register(slot.clone());
+        slot.mark_disconnected();
+
+        assert_eq!(reg.snapshot().len(), 1);
+        reg.prune_disconnected();
+        assert_eq!(reg.snapshot().len(), 0);
+    }
+}

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -291,16 +291,25 @@ pub struct ClientRegistry {
     slots: Mutex<Vec<Arc<ClientSlot>>>,
     /// Per-client worker `JoinHandle`s parked until server shutdown.
     /// Each `spawn_client_workers` call pushes two entries (writer +
-    /// command). `Server::drop` drains and joins them after setting
-    /// the global shutdown flag so the dongle's `Arc<Mutex<RtlSdrDevice>>`
-    /// is actually released before `has_stopped()` reports true.
+    /// command). `Server::stop()` / `Drop` drain and join them after
+    /// setting the global shutdown flag so the dongle's
+    /// `Arc<Mutex<RtlSdrDevice>>` is actually released by the time
+    /// `drop` / `stop` returns.
+    ///
+    /// **Note on `has_stopped()`:** that flag is narrowly scoped —
+    /// it flips when the accept thread exits, which happens BEFORE
+    /// these handles are drained. Callers that need "dongle is
+    /// actually free" must wait for `stop()` / `Drop` to return,
+    /// not poll `has_stopped()`. See `Server::has_stopped` for the
+    /// full contract.
     ///
     /// Kept on the registry rather than the slot so a panicked /
     /// disconnected slot can be pruned without losing its handle —
     /// the handle still blocks on the panicking thread's actual
     /// exit during shutdown join.
     ///
-    /// Per `CodeRabbit` round 1 on PR #402.
+    /// Per `CodeRabbit` round 1 on PR #402 (initial fix) + round 3
+    /// (doc alignment with the `has_stopped` contract).
     worker_handles: Mutex<Vec<JoinHandle<()>>>,
     /// Monotonic `ClientId` allocator. Never reused. An atomic so
     /// the accept loop doesn't need to hold `slots` to issue an id.
@@ -403,8 +412,16 @@ impl ClientRegistry {
         self.lifetime_accepted.load(Ordering::Relaxed)
     }
 
-    /// Cumulative bytes fanned out (broadcaster's view, pre-per-client
-    /// compression). Never reset.
+    /// Cumulative **on-wire** bytes written across all clients for
+    /// the server's lifetime. Counted at the writer layer
+    /// ([`Self::record_bytes_sent`] called from
+    /// `StatsTrackingWrite::write` after the TCP write succeeds)
+    /// so it reflects post-compression bytes for LZ4 sessions and
+    /// matches the sum of per-client writes exactly. Monotonic;
+    /// never reset, including across client disconnects.
+    ///
+    /// Per `CodeRabbit` round 1 on PR #402 (moved counting here
+    /// from `broadcast()`) + round 3 (doc update to match).
     pub fn total_bytes_sent(&self) -> u64 {
         self.total_bytes_sent.load(Ordering::Relaxed)
     }
@@ -525,9 +542,46 @@ mod tests {
         SocketAddr::from(([127, 0, 0, 1], port))
     }
 
-    /// Default channel depth small enough to exercise the Full path
-    /// without needing to push 500 chunks.
-    const TEST_CHANNEL_DEPTH: usize = 2;
+    // ============================================================
+    // Test fixture constants (CodeRabbit round 3 on PR #402).
+    // Extracted so each test's intent reads at a glance — a
+    // "1234" port on its own is noise; `TEST_PORT_GENERIC_A`
+    // plus a bounds docstring is self-documenting.
+    // ============================================================
+
+    /// Generic test port A for tests that register one slot and
+    /// don't care about peer-address distinctness — any
+    /// non-privileged port works.
+    const TEST_PORT_GENERIC_A: u16 = 1_234;
+    /// Generic test port B for tests that register a SECOND slot
+    /// and want peer addresses distinct from `TEST_PORT_GENERIC_A`
+    /// so snapshot assertions can tell them apart.
+    const TEST_PORT_GENERIC_B: u16 = 1_235;
+    /// Third generic port used by tests that register slot A
+    /// and slot B with disjoint port values (1 / 2 are fine
+    /// since we're just disambiguating addresses, not binding).
+    const TEST_PORT_FIRST: u16 = 1;
+    /// Fourth generic port, disjoint from `TEST_PORT_FIRST`.
+    const TEST_PORT_SECOND: u16 = 2;
+    /// Port for the `snapshot_reflects_registered_slots_with_stats`
+    /// test — picked distinct from the others so a cross-test
+    /// regression leaks clearly in the snapshot assertion.
+    const TEST_PORT_SNAPSHOT: u16 = 4_242;
+
+    /// Small channel depth that exercises the `Full` path without
+    /// needing to broadcast 500 chunks.
+    const TEST_CHANNEL_DEPTH_SMALL: usize = 2;
+    /// Moderate channel depth used by tests where the "fast
+    /// client" must drain all broadcasts without any drops.
+    const TEST_CHANNEL_DEPTH_STANDARD: usize = 4;
+    /// Generous channel depth for the "fast neighbor" side of
+    /// the full-channel drop-isolation test — must never fill.
+    const TEST_CHANNEL_DEPTH_GENEROUS: usize = 16;
+
+    /// Kept as an alias to `TEST_CHANNEL_DEPTH_SMALL` for the one
+    /// call site (`broadcast_full_channel_counts_drop_for_that_client_only`)
+    /// that reads better with the original name.
+    const TEST_CHANNEL_DEPTH: usize = TEST_CHANNEL_DEPTH_SMALL;
 
     #[test]
     fn allocate_id_is_monotonic() {
@@ -543,12 +597,22 @@ mod tests {
         let reg = ClientRegistry::new();
         assert!(reg.is_empty());
 
-        let (slot, _rx) = ClientSlot::new(reg.allocate_id(), test_peer(1234), Codec::None, 4);
+        let (slot, _rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_GENERIC_A),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         reg.register(slot);
         assert_eq!(reg.len(), 1);
         assert_eq!(reg.lifetime_accepted(), 1);
 
-        let (slot2, _rx2) = ClientSlot::new(reg.allocate_id(), test_peer(1235), Codec::Lz4, 4);
+        let (slot2, _rx2) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_GENERIC_B),
+            Codec::Lz4,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         reg.register(slot2);
         assert_eq!(reg.len(), 2);
         assert_eq!(reg.lifetime_accepted(), 2);
@@ -557,7 +621,12 @@ mod tests {
     #[test]
     fn broadcast_delivers_chunk_to_live_slot() {
         let reg = ClientRegistry::new();
-        let (slot, rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        let (slot, rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_FIRST),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         reg.register(slot);
 
         reg.broadcast(b"hello");
@@ -573,8 +642,18 @@ mod tests {
     #[test]
     fn broadcast_fans_out_identical_chunks_to_every_slot() {
         let reg = ClientRegistry::new();
-        let (s1, rx1) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
-        let (s2, rx2) = ClientSlot::new(reg.allocate_id(), test_peer(2), Codec::Lz4, 4);
+        let (s1, rx1) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_FIRST),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
+        let (s2, rx2) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_SECOND),
+            Codec::Lz4,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         reg.register(s1);
         reg.register(s2);
 
@@ -609,12 +688,17 @@ mod tests {
         // capacity and verify the drop accounting.
         let (slow, _slow_rx) = ClientSlot::new(
             reg.allocate_id(),
-            test_peer(1),
+            test_peer(TEST_PORT_FIRST),
             Codec::None,
             TEST_CHANNEL_DEPTH,
         );
         // Fast client with generous room — shouldn't drop anything.
-        let (fast, fast_rx) = ClientSlot::new(reg.allocate_id(), test_peer(2), Codec::None, 16);
+        let (fast, fast_rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_SECOND),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_GENEROUS,
+        );
         let slow_id = slow.id;
         reg.register(slow);
         reg.register(fast);
@@ -643,7 +727,12 @@ mod tests {
     #[test]
     fn broadcast_skips_disconnected_slot() {
         let reg = ClientRegistry::new();
-        let (slot, rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        let (slot, rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_FIRST),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         reg.register(slot.clone());
 
         slot.mark_disconnected();
@@ -657,7 +746,12 @@ mod tests {
     #[test]
     fn broadcast_marks_slot_disconnected_when_receiver_dropped() {
         let reg = ClientRegistry::new();
-        let (slot, rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
+        let (slot, rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_FIRST),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         reg.register(slot.clone());
 
         // Simulate writer thread exit by dropping the receiver.
@@ -676,8 +770,18 @@ mod tests {
     #[test]
     fn prune_disconnected_removes_flagged_slots_only() {
         let reg = ClientRegistry::new();
-        let (live, _live_rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
-        let (dead, _dead_rx) = ClientSlot::new(reg.allocate_id(), test_peer(2), Codec::None, 4);
+        let (live, _live_rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_FIRST),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
+        let (dead, _dead_rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_SECOND),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         dead.mark_disconnected();
         reg.register(live);
         reg.register(dead);
@@ -691,7 +795,12 @@ mod tests {
     #[test]
     fn snapshot_reflects_registered_slots_with_stats() {
         let reg = ClientRegistry::new();
-        let (slot, _rx) = ClientSlot::new(reg.allocate_id(), test_peer(4242), Codec::Lz4, 4);
+        let (slot, _rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_SNAPSHOT),
+            Codec::Lz4,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         let slot_id = slot.id;
         reg.register(slot.clone());
 
@@ -707,7 +816,7 @@ mod tests {
         assert_eq!(snap.len(), 1);
         let info = &snap[0];
         assert_eq!(info.id, slot_id);
-        assert_eq!(info.peer, test_peer(4242));
+        assert_eq!(info.peer, test_peer(TEST_PORT_SNAPSHOT));
         assert_eq!(info.codec, Codec::Lz4);
         assert_eq!(info.bytes_sent, 123);
         assert_eq!(info.current_freq_hz, Some(100_000_000));
@@ -734,8 +843,18 @@ mod tests {
         // briefly see dead sessions as live (FFI clients would
         // otherwise get stale ids that are already disconnected).
         let reg = ClientRegistry::new();
-        let (live, _live_rx) = ClientSlot::new(reg.allocate_id(), test_peer(1), Codec::None, 4);
-        let (dead, _dead_rx) = ClientSlot::new(reg.allocate_id(), test_peer(2), Codec::None, 4);
+        let (live, _live_rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_FIRST),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
+        let (dead, _dead_rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(TEST_PORT_SECOND),
+            Codec::None,
+            TEST_CHANNEL_DEPTH_STANDARD,
+        );
         reg.register(live);
         reg.register(dead.clone());
 

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -27,7 +27,13 @@
 //! The wire protocol lives in [`protocol`]; the server lifecycle and
 //! threading model in [`server`]; command-to-device translation in
 //! [`dispatch`]. See module docs for the upstream line-number references.
+//!
+//! The multi-client fan-out infrastructure lives in [`broadcaster`] —
+//! `ClientRegistry` + `ClientSlot` + per-client stats. Introduced by
+//! #391 as the first step of the #390 multi-client epic; the data
+//! path flip that consumes it ships in the next commit.
 
+pub mod broadcaster;
 pub mod codec;
 pub mod dispatch;
 pub mod error;

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -41,6 +41,7 @@ pub mod extension;
 pub mod protocol;
 pub mod server;
 
+pub use broadcaster::{ClientId, ClientInfo};
 pub use error::ServerError;
 pub use protocol::{
     COMMAND_LEN, Command, CommandOp, DEFAULT_PORT, DONGLE_INFO_LEN, DONGLE_MAGIC, DongleInfo,

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -1,33 +1,52 @@
-//! TCP server — accept loop, per-client data/command/writer threads.
+//! TCP server — accept loop, shared USB broadcaster, per-client worker threads.
 //!
-//! Faithful port of the upstream rtl_tcp threading model with one Rust
-//! tweak: upstream uses a pthread condvar + linked list to decouple the
-//! libusb async callback from the TCP writer (dropping buffers when the
-//! list exceeds `llbuf_num`, default 500). We use a bounded
-//! `std::sync::mpsc::sync_channel` with identical drop-on-full semantics —
-//! simpler and no `unsafe`, same backpressure behavior.
+//! Multi-client port of the upstream `rtl_tcp` threading model (#391, epic
+//! #390). Upstream's model is strictly single-client: one USB reader
+//! decoupled from one TCP writer via a condvar + linked list, gated by
+//! `llbuf_num` (default 500). Ours keeps the 500-chunk bound but:
 //!
-//! Upstream layout (rtl_tcp.c:498-720):
+//! - **One USB reader thread** (`broadcaster_worker`) runs for the
+//!   server's lifetime. It fans every USB chunk out to N per-client
+//!   bounded channels via [`ClientRegistry::broadcast`].
+//! - **Per-client writer** drains its own channel to an encoded TCP
+//!   socket. A slow listener only drops chunks against its own
+//!   counter; other clients keep receiving uninterrupted.
+//! - **Per-client command worker** reads 5-byte command frames from
+//!   the client's socket and dispatches to the shared device mutex.
+//!
+//! Pre-#391 upstream layout (`rtl_tcp.c:498-720`):
 //!   main: bind → accept → apply defaults → reset_buffer → spawn
 //!         tcp_worker + command_worker → rtlsdr_read_async (blocks) →
 //!         cancel_async on SIGINT → join → accept again
 //!
-//! Our layout: accept thread owns the outer loop; each accepted client
-//! spawns data_worker (USB → channel), writer (channel → TCP send), and
-//! command_worker (TCP recv → dispatch). First worker to exit signals
-//! the others via the shutdown flag.
+//! Our layout post-#391:
+//!   Server::start: bind → open device → apply defaults → spawn
+//!                  broadcaster_worker → spawn accept thread
+//!   accept thread: accept → handshake → register ClientSlot → spawn
+//!                  per-client writer + command → accept again
+//!   broadcaster:   one shared thread, USB bulk read → ClientRegistry::broadcast
+//!
+//! `apply_initial_state` is called ONCE at [`Server::start`] — not
+//! re-applied on every client accept. Previously (single-client), each
+//! new client got a fresh tune/gain reset so sequential clients didn't
+//! inherit each other's state. In the new multi-client model, every
+//! client shares the live device state — a controller tuning to 145 MHz
+//! means new listeners join on 145 MHz. Matches broadcast-radio
+//! semantics and the epic's "one dongle, shared state" model. Role
+//! enforcement (listeners can't tune) lands in #392.
 
 use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
+use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use sdr_rtlsdr::device::RtlSdrDevice;
 
+use crate::broadcaster::{ClientRegistry, ClientSlot};
 use crate::codec::{Codec, CodecMask, Encoder};
 use crate::dispatch::dispatch;
 use crate::error::ServerError;
@@ -43,14 +62,21 @@ use crate::protocol::{COMMAND_LEN, Command, CommandOp, DongleInfo, TunerTypeCode
 pub const READ_BUFFER_LEN: u32 = 256 * 1024;
 
 /// Maximum number of 256 KiB buffers allowed to queue between the USB
-/// reader and the TCP writer. Matches upstream's default `llbuf_num = 500`
-/// (rtl_tcp.c:61). When the queue is full, new USB buffers are dropped and
-/// a warning is logged — exactly upstream's drop-on-overflow policy.
-pub const DEFAULT_BUFFER_CAPACITY: usize = 500;
+/// reader and the per-client TCP writer. Same bound as upstream's
+/// `llbuf_num = 500` (rtl_tcp.c:61) — now per-client after #391 instead
+/// of shared. When a client's queue fills, subsequent broadcasts drop
+/// for THAT client only; other clients keep draining normally.
+///
+/// Named `DEFAULT_BUFFER_CAPACITY` historically (single-client crate);
+/// preserved as an alias for the `DEFAULT_PER_CLIENT_BUFFER_DEPTH`
+/// broadcaster constant so external callers that referenced it by name
+/// don't have to rename in the same PR that introduces the refactor.
+pub use crate::broadcaster::DEFAULT_PER_CLIENT_BUFFER_DEPTH as DEFAULT_BUFFER_CAPACITY;
 
-/// Socket receive timeout for the command worker select loop. Upstream
+/// Socket receive timeout for the command worker read loop. Upstream
 /// uses a 1-second select timeout so the loop re-checks `do_exit` even
-/// when no commands arrive (rtl_tcp.c:293-304).
+/// when no commands arrive (rtl_tcp.c:293-304). Ours re-checks the
+/// shutdown flag AND the per-slot disconnection flag.
 const COMMAND_READ_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Sleep between non-blocking `accept()` polls. Small enough that the
@@ -66,13 +92,20 @@ const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(200);
 
 /// `recv_timeout` in the TCP writer so it notices shutdown even when
-/// the USB reader is starving (dongle unplug, no data incoming).
+/// the broadcaster is starving (dongle unplug, no data incoming).
 const WRITER_RECV_TIMEOUT: Duration = Duration::from_millis(500);
 
-/// Timeout on each USB bulk read in the data worker. Matches upstream's
-/// 1-second poll interval in the `rtlsdr_read_async` loop. The data
-/// worker re-checks the shutdown flag between reads.
+/// Timeout on each USB bulk read in the broadcaster thread. Matches
+/// upstream's 1-second poll interval in the `rtlsdr_read_async` loop.
+/// The broadcaster re-checks the shutdown flag between reads.
 const USB_READ_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// How often the broadcaster calls [`ClientRegistry::prune_disconnected`]
+/// to reap slots whose workers have exited. Measured in USB-read ticks
+/// rather than wall clock — at ~10 ms per tick under normal traffic
+/// this prunes every ~2.5 s, which is plenty fast without making the
+/// lock + retain work happen per chunk.
+const BROADCASTER_PRUNE_EVERY_N_TICKS: u32 = 256;
 
 /// Default sample rate in Hz. Matches upstream `rtl_tcp.c:DEFAULT_SAMPLE_RATE_HZ`.
 ///
@@ -86,12 +119,10 @@ pub const DEFAULT_SAMPLE_RATE_HZ: u32 = 2_048_000;
 pub const DEFAULT_CENTER_FREQ_HZ: u32 = 100_000_000;
 
 /// Maximum number of recent `(CommandOp, Instant)` entries retained
-/// in `ServerStats::recent_commands`. 50 covers a typical rtl_tcp
-/// session's worth of tuning / gain / mode changes — enough to
-/// debug "why didn't my tune command land?" scenarios without
-/// unbounded memory growth on long-running servers. Oldest entries
-/// are popped when the ring fills.
-pub const RECENT_COMMANDS_CAPACITY: usize = 50;
+/// per-client (see `broadcaster::RECENT_COMMANDS_CAPACITY`). Exposed
+/// at this path for the `stats()` contract — same 50-entry bound as
+/// the pre-#391 server-wide ring.
+pub use crate::broadcaster::RECENT_COMMANDS_CAPACITY;
 
 /// Server configuration.
 #[derive(Debug, Clone)]
@@ -107,8 +138,10 @@ pub struct ServerConfig {
     /// Initial device state applied after open.
     pub initial: InitialDeviceState,
 
-    /// Max queued buffers between USB reader and TCP writer. 0 = use
-    /// [`DEFAULT_BUFFER_CAPACITY`].
+    /// Max queued buffers **per connected client** between the shared
+    /// USB broadcaster and that client's TCP writer. 0 = use
+    /// [`DEFAULT_BUFFER_CAPACITY`]. Per-client after #391: a slow
+    /// listener can't stall the controller.
     pub buffer_capacity: usize,
 
     /// Codecs this server is willing to offer to sdr-rs clients
@@ -172,55 +205,44 @@ impl Default for InitialDeviceState {
 
 /// Live server statistics for UI consumption.
 ///
-/// Each field is either a session-scoped counter (reset when the
-/// current client disconnects — `bytes_sent`, `buffers_dropped`,
-/// `last_command`, and the `current_*` commanded fields) or a
-/// session-identity hint (`connected_client`, `connected_since`).
+/// **Transitional single-client projection** (#391 commit 2a): still
+/// shaped like the pre-multi-client struct, populated from
+/// [`ClientRegistry::snapshot`] via [`project_to_legacy_stats`]. The
+/// "first connected client" fills the per-session fields; second/third
+/// clients are invisible to this view. Commit 2b replaces this with
+/// a per-client `Vec<ClientInfo>` schema and updates all in-tree
+/// consumers (Linux UI + sdr-ffi + C header) in the same change.
+///
 /// UI callers snapshot the struct via `Server::stats()` on a timer
 /// and compute deltas (e.g. data-rate) across consecutive snapshots.
 #[derive(Debug, Clone, Default)]
 pub struct ServerStats {
-    /// Socket address of the currently-connected client. `None`
-    /// means the accept loop is waiting.
+    /// Socket address of the first connected client. `None` means no
+    /// clients are connected.
     pub connected_client: Option<SocketAddr>,
-    /// Wall-clock moment the current session began. Paired with
-    /// `connected_client`: both are `Some` or both are `None`.
+    /// Wall-clock moment the first client's session began. Paired
+    /// with `connected_client`: both are `Some` or both are `None`.
     pub connected_since: Option<Instant>,
-    /// Bytes written to the client socket across the current
-    /// session. Reset to 0 on connect / disconnect.
+    /// Bytes written to the first client's TCP socket for the current
+    /// session. Only reflects one client's traffic in commit 2a — the
+    /// total-across-all-clients rendering ships in 2b.
     pub bytes_sent: u64,
-    /// Buffer-drop count: how many times the USB→TCP queue was
-    /// full when a new IQ block arrived, forcing us to discard.
-    /// Reset to 0 on connect / disconnect.
+    /// Buffer-drop count for the first client. Per-client counter;
+    /// other clients' drops are invisible to this view.
     pub buffers_dropped: u64,
-    /// Most recent command received from the client, with the
-    /// moment it was dispatched. UI renders this as the "activity
-    /// log" preview. Reset to `None` on disconnect.
+    /// Most recent command dispatched for the first client.
     pub last_command: Option<(CommandOp, Instant)>,
-    /// Most recent `SetCenterFreq` value requested by the client,
-    /// in Hz. Populated from the wire param so it reflects what
-    /// the client asked for even if the device layer rejected it;
-    /// UI treats this as "the client thinks we're tuned here."
-    /// Reset on disconnect.
+    /// First client's most recent `SetCenterFreq` request, in Hz.
     pub current_freq_hz: Option<u32>,
-    /// Most recent `SetSampleRate` request, in Hz. Same "client's
-    /// view" semantics as `current_freq_hz`.
+    /// First client's most recent `SetSampleRate` request, in Hz.
     pub current_sample_rate_hz: Option<u32>,
-    /// Most recent `SetTunerGain` request, in tenths of dB
-    /// (negative is legal per upstream). `None` means the client
-    /// hasn't requested a manual gain since connecting.
+    /// First client's most recent `SetTunerGain` request, in tenths
+    /// of dB.
     pub current_gain_tenths_db: Option<i32>,
-    /// `true` when the client most recently sent
-    /// `SetGainMode(auto)`, `false` on `SetGainMode(manual)`,
-    /// `None` when it hasn't sent one this session. UI renders
-    /// "auto" vs "manual" accordingly.
+    /// First client's most recent `SetGainMode` request.
     pub current_gain_auto: Option<bool>,
-    /// Ring buffer of recent commands received this session, bounded
-    /// at `RECENT_COMMANDS_CAPACITY` entries. Newest-first ordering
-    /// is the UI's responsibility; this preserves insertion order
-    /// (oldest at front, newest at back) so the producer stays cheap
-    /// (`push_back` + `pop_front` at cap). Reset on connect /
-    /// disconnect along with the other per-session counters.
+    /// Ring buffer of the first client's recent commands. Bounded at
+    /// [`RECENT_COMMANDS_CAPACITY`].
     pub recent_commands: VecDeque<(CommandOp, Instant)>,
 }
 
@@ -241,7 +263,8 @@ pub struct Server {
     shutdown: Arc<AtomicBool>,
     stopped: Arc<AtomicBool>,
     accept_thread: Option<JoinHandle<()>>,
-    stats: Arc<Mutex<ServerStats>>,
+    broadcaster_thread: Option<JoinHandle<()>>,
+    registry: Arc<ClientRegistry>,
     bind: SocketAddr,
     tuner: TunerAdvertiseInfo,
     compression: crate::codec::CodecMask,
@@ -251,8 +274,9 @@ impl Server {
     /// Bind the listener, open the RTL-SDR, apply initial defaults, and
     /// start accepting clients.
     ///
-    /// The returned handle owns the accept thread. Dropping it signals
-    /// shutdown and waits for the current client (if any) to disconnect.
+    /// The returned handle owns the broadcaster thread and the accept
+    /// thread. Dropping it signals shutdown and waits for both — plus
+    /// any currently-connected clients — to exit cleanly.
     pub fn start(config: ServerConfig) -> Result<Self, ServerError> {
         // Bind first — surface port-in-use before touching the USB device
         // so we don't leave a dongle claimed after a failed bind.
@@ -268,9 +292,6 @@ impl Server {
         // back from the socket so `bind_address()` returns the real
         // port the UI/logs can show.
         let actual_bind = listener.local_addr().map_err(ServerError::Io)?;
-        // The listener is already blocking by default from `bind` —
-        // no need to force it here. The accept thread flips it to
-        // nonblocking immediately on entry.
 
         let device_count = sdr_rtlsdr::get_device_count();
         if device_count == 0 {
@@ -299,23 +320,28 @@ impl Server {
 
         let shutdown = Arc::new(AtomicBool::new(false));
         let stopped = Arc::new(AtomicBool::new(false));
-        let stats = Arc::new(Mutex::new(ServerStats::default()));
-
+        let registry = Arc::new(ClientRegistry::new());
         let dev_mutex = Arc::new(Mutex::new(device));
-        let capacity = if config.buffer_capacity == 0 {
+        let per_client_depth = if config.buffer_capacity == 0 {
             DEFAULT_BUFFER_CAPACITY
         } else {
             config.buffer_capacity
         };
 
+        // Broadcaster runs for the server's lifetime regardless of
+        // connected-client count. Starting it BEFORE the accept thread
+        // means the first client that connects already has a live
+        // broadcaster ready to fan their channel's worth of data.
+        let broadcaster_thread =
+            spawn_broadcaster_thread(dev_mutex.clone(), registry.clone(), shutdown.clone())?;
+
         let accept_thread = spawn_accept_thread(
             listener,
             dev_mutex,
+            registry.clone(),
             shutdown.clone(),
             stopped.clone(),
-            stats.clone(),
-            capacity,
-            config.initial.clone(),
+            per_client_depth,
             config.compression,
         )?;
 
@@ -323,16 +349,22 @@ impl Server {
             shutdown,
             stopped,
             accept_thread: Some(accept_thread),
-            stats,
+            broadcaster_thread: Some(broadcaster_thread),
+            registry,
             bind: actual_bind,
             tuner,
             compression: config.compression,
         })
     }
 
-    /// Current server statistics.
+    /// Current server statistics (transitional single-client projection).
+    ///
+    /// Projects the [`ClientRegistry`] to the old `ServerStats` shape
+    /// via [`project_to_legacy_stats`] so commit 2a keeps the workspace
+    /// compiling. Commit 2b swaps this for a per-client `Vec<ClientInfo>`
+    /// API and updates every consumer in the same change.
     pub fn stats(&self) -> ServerStats {
-        self.stats.lock().map(|s| s.clone()).unwrap_or_default()
+        project_to_legacy_stats(&self.registry)
     }
 
     /// The address the server is bound to.
@@ -357,8 +389,8 @@ impl Server {
         self.compression
     }
 
-    /// Has the accept thread exited (either via `stop()` or an
-    /// unrecoverable error like USB device loss)?
+    /// Has the server exited? Set to `true` after the accept thread
+    /// AND broadcaster thread have joined.
     ///
     /// CLI callers poll this alongside their own Ctrl-C handler so the
     /// process exits when serving actually stops, instead of sleeping
@@ -367,14 +399,18 @@ impl Server {
         self.stopped.load(Ordering::Relaxed)
     }
 
-    /// Signal shutdown and wait for the accept thread to exit.
+    /// Signal shutdown and wait for both the accept and broadcaster
+    /// threads to exit.
     ///
-    /// Equivalent to dropping the `Server`. Any panic from the accept
+    /// Equivalent to dropping the `Server`. Any panic from either
     /// thread is silently swallowed — if you need to observe panics,
     /// keep the `JoinHandle` yourself instead of calling `stop()`.
     pub fn stop(mut self) {
         self.initiate_shutdown();
         if let Some(h) = self.accept_thread.take() {
+            let _ = h.join();
+        }
+        if let Some(h) = self.broadcaster_thread.take() {
             let _ = h.join();
         }
     }
@@ -390,38 +426,29 @@ impl Drop for Server {
         if let Some(h) = self.accept_thread.take() {
             let _ = h.join();
         }
+        if let Some(h) = self.broadcaster_thread.take() {
+            let _ = h.join();
+        }
     }
-}
-
-/// Lock the device and reapply initial state for a new client session.
-/// Exists so the accept loop has a small surface that wraps the lock
-/// acquisition; `apply_initial_state` itself stays lock-agnostic.
-fn reset_device_to_initial(
-    device: &Arc<Mutex<RtlSdrDevice>>,
-    initial: &InitialDeviceState,
-) -> Result<(), ServerError> {
-    let mut dev = device
-        .lock()
-        .map_err(|_| ServerError::Io(std::io::Error::other("device mutex poisoned")))?;
-    apply_initial_state(&mut dev, initial)
 }
 
 /// Apply the user's initial settings to the freshly-opened device.
 ///
 /// Mirrors the setup block in rtl_tcp.c:490-520. Called once at
-/// `Server::start` so the dongle is in a sane state even before any
-/// client connects, and again on every new client session via
-/// `reset_device_to_initial` so sequential clients don't inherit each
-/// other's tuning.
+/// `Server::start` so the dongle is in a sane state before any client
+/// connects. **Not re-called on client accept** post-#391 — every
+/// client shares the device state, so resetting on accept would
+/// disrupt clients already listening.
 fn apply_initial_state(
     dev: &mut RtlSdrDevice,
     initial: &InitialDeviceState,
 ) -> Result<(), ServerError> {
     // 0 is a valid direct-sampling state (off) and MUST be applied —
-    // not skipped — so a previous session that enabled direct sampling
-    // doesn't leak its mode into the next client's session. Previously
-    // the `!= 0` guard treated 0 as "leave alone," which broke
-    // reset_device_to_initial's promise of a clean slate per client.
+    // not skipped — so the device starts on a known state regardless
+    // of whatever mode the previous process (or a crashed prior run)
+    // left the dongle in. Previously the `!= 0` guard treated 0 as
+    // "leave alone," which broke Server::start's promise of a clean
+    // slate per process.
     dev.set_direct_sampling(initial.direct_sampling)?;
     dev.set_freq_correction(initial.ppm)?;
     dev.set_sample_rate(initial.sample_rate_hz)?;
@@ -441,129 +468,72 @@ fn apply_initial_state(
     Ok(())
 }
 
-/// Spawn the outer accept loop. Upstream's main runs this inline; we run
-/// it on a thread so `Server::start` can return a handle to the caller.
+/// Spawn the server-lifetime broadcaster thread. Pulls from USB and
+/// calls [`ClientRegistry::broadcast`] once per chunk. Runs even when
+/// there are zero connected clients — the dongle streams regardless,
+/// matching upstream's always-on async read. When clients connect
+/// they join the stream mid-flow (no per-client reset).
+fn spawn_broadcaster_thread(
+    device: Arc<Mutex<RtlSdrDevice>>,
+    registry: Arc<ClientRegistry>,
+    shutdown: Arc<AtomicBool>,
+) -> std::io::Result<JoinHandle<()>> {
+    thread::Builder::new()
+        .name("rtl_tcp-broadcaster".into())
+        .spawn(move || {
+            broadcaster_worker(device, registry, shutdown);
+        })
+}
+
+/// Spawn the outer accept loop. Per accepted client:
+///   1. handshake (RTLX sniff + dongle_info_t + optional ServerExtension)
+///   2. build `ClientSlot` + register in the `ClientRegistry`
+///   3. spawn a writer thread (drains slot.rx → encoded socket)
+///   4. spawn a command thread (reads socket → dispatches to device)
 ///
-/// `initial_state` is reapplied on every new client session so sequential
-/// clients start from a clean slate rather than inheriting the prior
-/// client's tuning / gain / direct-sampling state. Matches upstream's
-/// `accept → apply defaults → reset_buffer → spawn workers` shape,
-/// extended to the multi-client accept loop.
+/// No `busy` flag, no second-connection reject — that was the
+/// single-client constraint #391 removes. Client lifecycle is
+/// observed by the `ClientSlot::disconnected` flag; the broadcaster
+/// prunes disconnected slots on its own schedule.
 ///
 /// Returns `Err` on thread spawn failure (rare — kernel resource
 /// exhaustion). Callers propagate up to the user.
 #[allow(
     clippy::too_many_arguments,
-    reason = "#307 grew the accept-thread signature with `compression`; \
-              refactoring to a context struct would churn every caller \
-              without improving readability"
+    reason = "accept thread fans state into per-client workers; \
+              refactoring to a context struct would churn every test"
 )]
 fn spawn_accept_thread(
     listener: TcpListener,
     device: Arc<Mutex<RtlSdrDevice>>,
+    registry: Arc<ClientRegistry>,
     shutdown: Arc<AtomicBool>,
     stopped: Arc<AtomicBool>,
-    stats: Arc<Mutex<ServerStats>>,
-    buffer_capacity: usize,
-    initial_state: InitialDeviceState,
+    per_client_buffer_depth: usize,
     compression: CodecMask,
 ) -> std::io::Result<JoinHandle<()>> {
-    // Poll-accept cadence means the listener must be nonblocking.
-    // Configure it BEFORE spawning so failures surface through
-    // `Server::start`'s `?` rather than getting buried inside the
-    // spawned thread body — burying it would return `Ok` to the caller
-    // and the accept thread would die without ever setting `stopped`,
-    // leaving callers polling `has_stopped()` stuck forever.
     listener.set_nonblocking(true)?;
     thread::Builder::new()
         .name("rtl_tcp-accept".into())
         .spawn(move || {
-            // Session slot: set to true while a client is being served.
-            // Kept in an Arc so the session thread can clear it on exit.
-            // Using `swap(true, ...)` to claim the slot atomically — if
-            // it returns true, we were already busy and this new accept
-            // must be rejected immediately (kernel had queued it in the
-            // backlog, but we refuse to hold it).
-            let busy = Arc::new(AtomicBool::new(false));
-            let mut session_handle: Option<JoinHandle<()>> = None;
-
             while !shutdown.load(Ordering::Relaxed) {
                 match listener.accept() {
                     Ok((stream, peer)) => {
-                        if busy.swap(true, Ordering::SeqCst) {
-                            tracing::info!(
-                                %peer,
-                                "rtl_tcp already serving a client — rejecting new connection"
-                            );
-                            // Close the socket immediately so the client
-                            // sees FIN instead of hanging in backlog.
-                            let _ = stream.shutdown(std::net::Shutdown::Both);
-                            // swap set busy=true, but we weren't actually
-                            // idle — the already-active session will
-                            // eventually clear busy when it exits. Leave
-                            // the flag set; don't reset.
-                            continue;
-                        }
-                        // We now own the session slot. Reap the previous
-                        // session handle if any (it must be finished,
-                        // because the session thread clears busy at its
-                        // tail — we got false from the swap, which means
-                        // the prior session already cleared it).
-                        if let Some(h) = session_handle.take() {
-                            let _ = h.join();
-                        }
-
                         tracing::info!(%peer, "rtl_tcp client connected");
                         if let Err(e) = stream.set_nonblocking(false) {
                             tracing::error!(%e, "failed to set client socket blocking");
-                            busy.store(false, Ordering::SeqCst);
                             continue;
                         }
                         configure_client_socket(&stream);
-                        update_stats_on_connect(&stats, peer);
-
-                        // Reapply initial state BEFORE spawning workers
-                        // so this client starts on clean tuning/gain
-                        // rather than inheriting the prior session's
-                        // state. Matches upstream's per-accept setup
-                        // block (rtl_tcp.c:490-520).
-                        if let Err(e) = reset_device_to_initial(&device, &initial_state) {
-                            tracing::error!(
-                                %e, %peer,
-                                "rtl_tcp failed to reset device to initial state, dropping client"
-                            );
-                            busy.store(false, Ordering::SeqCst);
-                            update_stats_on_disconnect(&stats);
-                            continue;
-                        }
-
-                        let session_device = device.clone();
-                        let session_shutdown = shutdown.clone();
-                        let session_stats = stats.clone();
-                        let session_busy = busy.clone();
-                        let session_compression = compression;
-                        match thread::Builder::new().name("rtl_tcp-session".into()).spawn(
-                            move || {
-                                handle_client(
-                                    stream,
-                                    session_device,
-                                    session_shutdown,
-                                    session_stats.clone(),
-                                    buffer_capacity,
-                                    session_compression,
-                                );
-                                update_stats_on_disconnect(&session_stats);
-                                tracing::info!(%peer, "rtl_tcp client disconnected");
-                                session_busy.store(false, Ordering::SeqCst);
-                            },
-                        ) {
-                            Ok(h) => session_handle = Some(h),
-                            Err(e) => {
-                                tracing::error!(%e, "failed to spawn session thread");
-                                busy.store(false, Ordering::SeqCst);
-                                update_stats_on_disconnect(&stats);
-                            }
-                        }
+                        spawn_client_workers(
+                            stream,
+                            peer,
+                            device.clone(),
+                            registry.clone(),
+                            shutdown.clone(),
+                            per_client_buffer_depth,
+                            compression,
+                        );
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                         thread::sleep(ACCEPT_POLL_INTERVAL);
@@ -574,19 +544,182 @@ fn spawn_accept_thread(
                     }
                 }
             }
-
-            // Shutdown: wait for the active session (if any) to finish
-            // before returning, so Server::drop sees all workers done.
-            if let Some(h) = session_handle.take() {
-                let _ = h.join();
-            }
-            // Signal to CLI / UI callers polling `Server::has_stopped()`
-            // that the server is no longer serving. Set AFTER the
-            // session join so a caller that observes `has_stopped() ==
-            // true` can safely assume all workers have exited.
+            // Mark stopped AFTER the loop exits so callers polling
+            // `has_stopped()` observe the server is fully done. The
+            // broadcaster thread is joined by `Server::drop` — we
+            // don't wait for it here because `Server` owns that
+            // handle.
             stopped.store(true, Ordering::SeqCst);
             tracing::debug!("rtl_tcp accept thread exiting");
         })
+}
+
+/// Do the handshake on a freshly-accepted socket, build a
+/// [`ClientSlot`], register it, and spawn this client's writer +
+/// command threads. Fire-and-forget — the accept thread doesn't wait
+/// for this client's workers; lifecycle is observed via the slot's
+/// disconnection flag.
+///
+/// If the handshake fails at any step (sniff error, socket clone
+/// fails, header write fails, thread spawn fails), the client is
+/// silently dropped — no slot is registered, no stats are updated.
+/// The caller (accept thread) moves on to the next accept.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "accept-time client setup fans state"
+)]
+fn spawn_client_workers(
+    stream: TcpStream,
+    peer: SocketAddr,
+    device: Arc<Mutex<RtlSdrDevice>>,
+    registry: Arc<ClientRegistry>,
+    shutdown: Arc<AtomicBool>,
+    per_client_buffer_depth: usize,
+    compression_offer: CodecMask,
+) {
+    // Extended handshake (#307). Must run BEFORE we write the legacy
+    // `dongle_info_t` — if the client sent an `"RTLX"` hello, the
+    // server response block must be emitted immediately after the
+    // legacy header, all in one atomic stretch, so the client's peek
+    // for the `"RTLX"` magic lands on our bytes and not on IQ samples
+    // a racing broadcaster may have queued.
+    let negotiated_codec = match sniff_client_hello(&stream) {
+        Ok(Some(hello)) => {
+            let codec = compression_offer.pick(hello.codec_mask);
+            tracing::info!(
+                %peer,
+                client_mask = hello.codec_mask.to_wire(),
+                server_mask = compression_offer.to_wire(),
+                chosen = %codec,
+                "rtl_tcp extended-handshake negotiated"
+            );
+            Some(codec)
+        }
+        Ok(None) => {
+            tracing::debug!(%peer, "rtl_tcp no extended-handshake hello — legacy client path");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(%peer, %e, "rtl_tcp handshake sniff failed — dropping client");
+            return;
+        }
+    };
+
+    // Send the 12-byte dongle_info_t header (rtl_tcp.c:576-594).
+    let header = {
+        let Ok(dev) = device.lock() else {
+            tracing::error!(%peer, "device mutex poisoned, aborting client");
+            return;
+        };
+        DongleInfo {
+            tuner: TunerTypeCode::from(dev.tuner_type()),
+            gain_count: dev.tuner_gains().len() as u32,
+        }
+    };
+    let header_bytes = header.to_bytes();
+    let writer_stream = match stream.try_clone() {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!(%peer, %e, "failed to clone client stream for writer — dropping client");
+            return;
+        }
+    };
+    let mut writer = writer_stream;
+    if let Err(e) = writer.write_all(&header_bytes) {
+        tracing::warn!(%peer, %e, "failed to send dongle_info_t — client gone");
+        return;
+    }
+
+    // Emit the `ServerExtension` block immediately after
+    // `dongle_info_t` when we negotiated the extended protocol. Must
+    // land before any IQ data or the client's magic-peek will read
+    // random samples instead.
+    if let Some(codec) = negotiated_codec {
+        let ext = ServerExtension {
+            codec,
+            // #391 is still single-controller; role always reports
+            // Control until #392 plugs in the actual role gate.
+            granted_role: Some(Role::Control),
+            status: Status::Ok,
+            version: PROTOCOL_VERSION,
+        };
+        if let Err(e) = writer.write_all(&ext.to_bytes()) {
+            tracing::warn!(%peer, %e, "failed to send RTLX server extension — client gone");
+            return;
+        }
+    }
+
+    // Install the write timeout BEFORE wrapping in the codec's
+    // encoder — the encoder's `write()` delegates to the inner
+    // stream's `write()`, which in turn enforces `SO_SNDTIMEO`.
+    // Setting after-wrap would lose visibility into the inner stream.
+    if let Err(e) = writer.set_write_timeout(Some(WRITER_RECV_TIMEOUT)) {
+        tracing::warn!(%peer, %e, "set_write_timeout on data channel failed; dropping client");
+        return;
+    }
+
+    // Build the slot, allocating a fresh id + per-client channel.
+    let id = registry.allocate_id();
+    let codec = negotiated_codec.unwrap_or(Codec::None);
+    let (slot, rx) = ClientSlot::new(id, peer, codec, per_client_buffer_depth);
+
+    // Spawn the writer first so that by the time we register, the
+    // receiver end of the slot's channel is already being drained.
+    // If spawn fails, bail without registering — no half-registered
+    // clients to clean up.
+    let writer_slot = slot.clone();
+    let writer_shutdown = shutdown.clone();
+    let tracked_writer = StatsTrackingWrite {
+        inner: writer,
+        slot: slot.clone(),
+    };
+    let encoded_writer = Encoder::new(codec, tracked_writer);
+    let writer_handle = match thread::Builder::new()
+        .name(format!("rtl_tcp-writer-{id}"))
+        .spawn(move || {
+            tcp_writer(encoded_writer, rx, writer_slot, writer_shutdown);
+        }) {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!(%peer, %e, "failed to spawn rtl_tcp writer thread — dropping client");
+            return;
+        }
+    };
+
+    // Spawn the command thread. If it fails, mark the slot
+    // disconnected so the writer exits too — don't leak it.
+    let command_slot = slot.clone();
+    let command_shutdown = shutdown.clone();
+    let command_device = device;
+    let command_stream = stream;
+    let command_result = thread::Builder::new()
+        .name(format!("rtl_tcp-command-{id}"))
+        .spawn(move || {
+            command_worker(
+                command_stream,
+                command_device,
+                command_slot,
+                command_shutdown,
+            );
+        });
+    if let Err(e) = command_result {
+        tracing::error!(%peer, %e, "failed to spawn rtl_tcp command thread — tearing down client");
+        slot.mark_disconnected();
+        let _ = writer_handle.join();
+        return;
+    }
+
+    // All three threads (writer, command, broadcaster-observing-this-slot)
+    // are now set up. Register the slot so the broadcaster starts
+    // fanning out to it. Registration order matters: before register,
+    // the broadcaster can't find the slot; after register, the
+    // broadcaster discovers it on its next tick.
+    registry.register(slot);
+
+    // Fire and forget — neither the writer nor the command handle is
+    // joined here. Both exit independently when they observe the
+    // shutdown flag or the slot's disconnection flag. The slot itself
+    // is retained by the registry until it's pruned.
 }
 
 fn configure_client_socket(stream: &TcpStream) {
@@ -643,38 +776,37 @@ fn set_keepalive(_stream: &TcpStream, _on: bool) -> std::io::Result<()> {
     ))
 }
 
-fn update_stats_on_connect(stats: &Arc<Mutex<ServerStats>>, peer: SocketAddr) {
-    if let Ok(mut s) = stats.lock() {
-        s.connected_client = Some(peer);
-        s.connected_since = Some(Instant::now());
-        s.bytes_sent = 0;
-        s.buffers_dropped = 0;
-        s.last_command = None;
-        s.current_freq_hz = None;
-        s.current_sample_rate_hz = None;
-        s.current_gain_tenths_db = None;
-        s.current_gain_auto = None;
-        s.recent_commands.clear();
-    }
-}
-
-fn update_stats_on_disconnect(stats: &Arc<Mutex<ServerStats>>) {
-    if let Ok(mut s) = stats.lock() {
-        // `update_stats_on_connect` treats every counter below as
-        // session-scoped (resets them on new connect), so the
-        // disconnect path must clear them too — otherwise a UI polling
-        // `ServerStats` while no client is connected would see stale
-        // traffic / command data from the previous session.
-        s.connected_client = None;
-        s.connected_since = None;
-        s.bytes_sent = 0;
-        s.buffers_dropped = 0;
-        s.last_command = None;
-        s.current_freq_hz = None;
-        s.current_sample_rate_hz = None;
-        s.current_gain_tenths_db = None;
-        s.current_gain_auto = None;
-        s.recent_commands.clear();
+/// **Transitional**: project the multi-client registry snapshot into
+/// the legacy single-client [`ServerStats`] shape so commit 2a of
+/// #391 can land without breaking downstream consumers. Takes the
+/// oldest-still-connected client as "the client" for every
+/// per-session field, and zeroes everything else when no clients
+/// are connected.
+///
+/// Commit 2b replaces this with a direct `Vec<ClientInfo>` on
+/// `ServerStats` and updates every consumer (Linux UI + FFI).
+fn project_to_legacy_stats(registry: &Arc<ClientRegistry>) -> ServerStats {
+    // `ClientRegistry::snapshot` includes disconnected-but-not-yet-
+    // pruned slots by design (so UI rows survive one poll tick
+    // after a client drops). The legacy projection picks the
+    // first-registered slot regardless — commit 2b introduces a
+    // per-client Vec where disconnected slots render with a "just
+    // left" hint explicitly.
+    let clients = registry.snapshot();
+    let Some(first) = clients.into_iter().next() else {
+        return ServerStats::default();
+    };
+    ServerStats {
+        connected_client: Some(first.peer),
+        connected_since: Some(first.connected_since),
+        bytes_sent: first.bytes_sent,
+        buffers_dropped: first.buffers_dropped,
+        last_command: first.last_command,
+        current_freq_hz: first.current_freq_hz,
+        current_sample_rate_hz: first.current_sample_rate_hz,
+        current_gain_tenths_db: first.current_gain_tenths_db,
+        current_gain_auto: first.current_gain_auto,
+        recent_commands: first.recent_commands,
     }
 }
 
@@ -785,320 +917,24 @@ fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHe
         })
 }
 
-/// Serve exactly one client. Spawns the three worker threads, waits for
-/// the first to exit, signals the others, joins all.
-#[allow(
-    clippy::too_many_arguments,
-    clippy::too_many_lines,
-    reason = "#307 grew the session signature with compression_offer; \
-              refactoring to a context struct would churn every rtl_tcp \
-              server test without improving readability"
-)]
-fn handle_client(
-    stream: TcpStream,
-    device: Arc<Mutex<RtlSdrDevice>>,
-    global_shutdown: Arc<AtomicBool>,
-    stats: Arc<Mutex<ServerStats>>,
-    buffer_capacity: usize,
-    compression_offer: CodecMask,
-) {
-    // Extended handshake (#307). Must happen BEFORE we write the
-    // legacy `dongle_info_t` — if the client sent an `"RTLX"`
-    // hello, we want to write the server response block
-    // immediately after the legacy header, all in one atomic
-    // stretch, so the client's `peek` for the `"RTLX"` magic
-    // lands on our bytes and not on IQ samples the data worker
-    // has queued up.
-    let negotiated_codec = match sniff_client_hello(&stream) {
-        Ok(Some(hello)) => {
-            let codec = compression_offer.pick(hello.codec_mask);
-            tracing::info!(
-                client_mask = hello.codec_mask.to_wire(),
-                server_mask = compression_offer.to_wire(),
-                chosen = %codec,
-                "rtl_tcp extended-handshake negotiated"
-            );
-            Some(codec)
-        }
-        Ok(None) => {
-            tracing::debug!("rtl_tcp no extended-handshake hello — legacy client path");
-            None
-        }
-        Err(e) => {
-            tracing::warn!(%e, "rtl_tcp handshake sniff failed — dropping client");
-            return;
-        }
-    };
-
-    // Send the 12-byte dongle_info_t header first (rtl_tcp.c:576-594).
-    let header = {
-        let Ok(dev) = device.lock() else {
-            tracing::error!("device mutex poisoned, aborting client");
-            return;
-        };
-        DongleInfo {
-            tuner: TunerTypeCode::from(dev.tuner_type()),
-            gain_count: dev.tuner_gains().len() as u32,
-        }
-    };
-    let header_bytes = header.to_bytes();
-    let writer_stream = match stream.try_clone() {
-        Ok(w) => w,
-        Err(e) => {
-            tracing::error!(%e, "failed to clone client stream for writer — dropping client");
-            return;
-        }
-    };
-    let mut writer = writer_stream;
-    if let Err(e) = writer.write_all(&header_bytes) {
-        tracing::warn!(%e, "failed to send dongle_info_t — client gone");
-        return;
-    }
-
-    // If we negotiated the extended protocol, emit the
-    // `ServerExtension` block immediately after `dongle_info_t`.
-    // Must land before any IQ data or the client's magic-peek
-    // after `dongle_info` will read random samples instead.
-    if let Some(codec) = negotiated_codec {
-        let ext = ServerExtension {
-            codec,
-            // #307 is single-client; role and status are reserved
-            // for #392/#394 and always report OK / Control here.
-            granted_role: Some(Role::Control),
-            status: Status::Ok,
-            version: PROTOCOL_VERSION,
-        };
-        if let Err(e) = writer.write_all(&ext.to_bytes()) {
-            tracing::warn!(%e, "failed to send RTLX server extension — client gone");
-            return;
-        }
-    }
-
-    // Per-client shutdown flag. Flipped when any worker exits, so the
-    // others stop quickly. Honors the global flag too.
-    let client_shutdown = Arc::new(AtomicBool::new(false));
-    let merged_shutdown = MergedShutdown::new(global_shutdown, client_shutdown);
-
-    // Buffer data path: USB bulk → bounded channel → TCP writer.
-    let (tx, rx) = sync_channel::<Vec<u8>>(buffer_capacity);
-
-    let reader_shutdown = merged_shutdown.clone();
-    let reader_device = device.clone();
-    let reader_stats = stats.clone();
-    let Ok(reader_handle) = thread::Builder::new()
-        .name("rtl_tcp-reader".into())
-        .spawn(move || {
-            data_worker(reader_device, tx, reader_shutdown, reader_stats);
-        })
-    else {
-        tracing::error!("failed to spawn rtl_tcp reader thread — dropping client");
-        return;
-    };
-
-    // Install the write timeout on the underlying TcpStream
-    // BEFORE wrapping in the codec's encoder — the encoder's
-    // `write()` delegates to the inner stream's `write()`, which
-    // in turn enforces `SO_SNDTIMEO`. Setting after-wrap would
-    // lose visibility into the inner stream.
-    if let Err(e) = writer.set_write_timeout(Some(WRITER_RECV_TIMEOUT)) {
-        tracing::warn!(%e, "set_write_timeout on data channel failed; dropping client");
-        merged_shutdown.set_client();
-        let _ = reader_handle.join();
-        return;
-    }
-    // Wrap the socket in the stats-tracking adapter BEFORE the
-    // encoder so `bytes_sent` reflects post-compression bytes
-    // (what actually hit the wire), then wrap in the negotiated
-    // codec. Legacy clients get a pass-through (`Codec::None`),
-    // so the write path stays byte-identical to the pre-#307
-    // behavior — on-wire bytes equal payload bytes in that case.
-    let tracked_writer = StatsTrackingWrite {
-        inner: writer,
-        stats: stats.clone(),
-    };
-    let encoded_writer = Encoder::new(negotiated_codec.unwrap_or(Codec::None), tracked_writer);
-    let writer_shutdown = merged_shutdown.clone();
-    let Ok(writer_handle) = thread::Builder::new()
-        .name("rtl_tcp-writer".into())
-        .spawn(move || {
-            tcp_writer(encoded_writer, rx, writer_shutdown);
-        })
-    else {
-        tracing::error!("failed to spawn rtl_tcp writer thread — tearing down client");
-        merged_shutdown.set_client();
-        let _ = reader_handle.join();
-        return;
-    };
-
-    let command_shutdown = merged_shutdown.clone();
-    let command_device = device;
-    let command_stats = stats;
-    let command_stream = stream;
-    let Ok(command_handle) =
-        thread::Builder::new()
-            .name("rtl_tcp-command".into())
-            .spawn(move || {
-                command_worker(
-                    command_stream,
-                    command_device,
-                    command_shutdown,
-                    command_stats,
-                );
-            })
-    else {
-        tracing::error!("failed to spawn rtl_tcp command thread — tearing down client");
-        merged_shutdown.set_client();
-        let _ = reader_handle.join();
-        let _ = writer_handle.join();
-        return;
-    };
-
-    // Wait for any worker to exit, then cancel the others.
-    let _ = command_handle.join();
-    merged_shutdown.set_client();
-    let _ = reader_handle.join();
-    let _ = writer_handle.join();
-}
-
-/// Combines the server-wide shutdown flag with a per-client flag so we can
-/// tear down one client without stopping the server, and vice versa.
-#[derive(Clone)]
-struct MergedShutdown {
-    global: Arc<AtomicBool>,
-    client: Arc<AtomicBool>,
-}
-
-impl MergedShutdown {
-    fn new(global: Arc<AtomicBool>, client: Arc<AtomicBool>) -> Self {
-        Self { global, client }
-    }
-    fn is_set(&self) -> bool {
-        self.global.load(Ordering::Relaxed) || self.client.load(Ordering::Relaxed)
-    }
-    fn set_client(&self) {
-        self.client.store(true, Ordering::SeqCst);
-    }
-    /// Escalate to server-wide shutdown: the accept thread exits after
-    /// the current session tears down, and `Server::has_stopped()`
-    /// eventually observes `true`. Used for unrecoverable errors that
-    /// can't be remedied by just dropping the current client, such as
-    /// a lost USB dongle (`rusb::Error::NoDevice`).
-    fn set_global(&self) {
-        self.global.store(true, Ordering::SeqCst);
-        self.client.store(true, Ordering::SeqCst);
-    }
-}
-
-/// Continuously pull USB bulk buffers and push into the bounded queue.
-/// Drops on full, matching upstream's `llbuf_num` cap behavior.
-fn data_worker(
-    device: Arc<Mutex<RtlSdrDevice>>,
-    tx: SyncSender<Vec<u8>>,
-    shutdown: MergedShutdown,
-    stats: Arc<Mutex<ServerStats>>,
-) {
-    // Pull an Arc<DeviceHandle> once so we don't have to lock the device
-    // mutex on every USB read (bulk read is &self-safe via usb_handle).
-    let handle = {
-        let Ok(dev) = device.lock() else {
-            // Poisoned mutex is unrecoverable shared state — close out
-            // the whole session so the writer/command workers exit too
-            // instead of spinning on a dead channel.
-            tracing::error!("device mutex poisoned, data worker aborting and closing session");
-            shutdown.set_client();
-            return;
-        };
-        dev.usb_handle()
-    };
-    let timeout = USB_READ_TIMEOUT;
-    // Scratch buffer reused across iterations — only the Vec we actually
-    // send to the writer gets a fresh allocation, sized to the data the
-    // USB read returned. This avoids allocating 256 KiB on every timeout
-    // tick (reviewed on PR #313).
-    let mut scratch = vec![0u8; READ_BUFFER_LEN as usize];
-    // Edge-trigger flag for the tx-queue-full warning. Set when a
-    // drop happens, cleared on the first successful send after — so
-    // we log once per stall-and-drain cycle rather than per buffer.
-    let mut was_dropping = false;
-
-    while !shutdown.is_set() {
-        match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut scratch, timeout) {
-            Ok(n) if n > 0 => {
-                // Allocate only when we have real data to hand off.
-                let buf = scratch[..n].to_vec();
-                match tx.try_send(buf) {
-                    Ok(()) => {
-                        // Rearm the overflow edge so a future stall
-                        // logs again.
-                        was_dropping = false;
-                    }
-                    Err(TrySendError::Full(_)) => {
-                        // Queue is full — drop this buffer (upstream does
-                        // the same when the linked list exceeds llbuf_num;
-                        // rtl_tcp.c:137-152). `buffers_dropped` in the
-                        // shared stats is the authoritative cumulative
-                        // counter; the warn is just an edge signal.
-                        if let Ok(mut s) = stats.lock() {
-                            s.buffers_dropped = s.buffers_dropped.saturating_add(1);
-                        }
-                        if !was_dropping {
-                            tracing::warn!(
-                                "rtl_tcp tx queue full — dropping USB buffers (further drops accumulate silently; see ServerStats::buffers_dropped)"
-                            );
-                            was_dropping = true;
-                        }
-                    }
-                    Err(TrySendError::Disconnected(_)) => {
-                        tracing::debug!("writer gone, data worker exiting");
-                        return;
-                    }
-                }
-            }
-            Ok(_) | Err(rusb::Error::Timeout) => {
-                // No data — loop and re-check shutdown.
-            }
-            Err(rusb::Error::NoDevice) => {
-                // Dongle unplug is unrecoverable at the server level —
-                // the accept loop has nothing to serve. Escalate to a
-                // global shutdown so the accept thread exits, the CLI
-                // sees `has_stopped() == true`, and new clients don't
-                // connect to a dead-device server.
-                tracing::error!("rtl_tcp: USB device lost mid-stream, stopping server");
-                shutdown.set_global();
-                return;
-            }
-            Err(e) => {
-                tracing::error!(%e, "rtl_tcp bulk read error");
-                shutdown.set_client();
-                return;
-            }
-        }
-    }
-}
-
-/// `Write` adapter that mirrors the underlying [`TcpStream`] but
-/// updates [`ServerStats::bytes_sent`] with the post-compression
-/// byte count from each successful write. Placed between the
-/// [`Encoder`] and the socket so the stat reflects **on-wire**
-/// throughput instead of pre-compression payload size — otherwise
-/// the server-panel's data-rate row would show raw sample rate
-/// even when LZ4 is active and operators couldn't see whether
-/// compression was actually saving bandwidth.
-///
-/// Per CodeRabbit round 1 on PR #399.
+/// `Write` adapter sitting between the negotiated `Encoder` and the
+/// raw `TcpStream`. Updates the slot's per-client `bytes_sent` counter
+/// with the on-wire (post-compression) byte count from each
+/// successful write, so the UI's data-rate row reflects actual
+/// bandwidth rather than pre-compression payload size.
 struct StatsTrackingWrite {
     inner: TcpStream,
-    stats: Arc<Mutex<ServerStats>>,
+    slot: Arc<ClientSlot>,
 }
 
 impl Write for StatsTrackingWrite {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let n = self.inner.write(buf)?;
         // Poisoned mutex only happens if a stats reader panicked
-        // while holding the lock — we'd rather keep streaming and
-        // let the stats drift than tear the session down. Matches
-        // the existing lock-use pattern in data_worker.
-        if let Ok(mut s) = self.stats.lock() {
+        // while holding the lock — keep streaming and let the
+        // stats drift; a crashed UI thread is worse than a dropped
+        // counter bump.
+        if let Ok(mut s) = self.slot.stats.lock() {
             s.bytes_sent = s.bytes_sent.saturating_add(n as u64);
         }
         Ok(n)
@@ -1111,30 +947,25 @@ impl Write for StatsTrackingWrite {
 
 fn tcp_writer<W: Write + Send>(
     mut stream: W,
-    rx: std::sync::mpsc::Receiver<Vec<u8>>,
-    shutdown: MergedShutdown,
+    rx: Receiver<Vec<u8>>,
+    slot: Arc<ClientSlot>,
+    shutdown: Arc<AtomicBool>,
 ) {
-    // Write timeout is installed by the caller on the underlying
-    // `TcpStream` before wrapping in the codec — see the comment
-    // in `handle_client` where the timeout is set up. Putting it
-    // here would lose visibility into the inner stream when
-    // `stream` is an `Encoder`.
+    // Write timeout installed by the caller on the underlying
+    // `TcpStream` before wrapping in the codec — see
+    // `spawn_client_workers` where the timeout is set up.
     //
-    // `bytes_sent` bookkeeping is handled by `StatsTrackingWrite`
-    // one layer below the encoder, so this function no longer
-    // needs a `stats` arg. On-wire counts land there directly.
-    //
-    // `recv_timeout` lets us notice shutdown even when the USB
-    // reader is starving (e.g., dongle unplug).
+    // `recv_timeout` lets us notice shutdown even when the
+    // broadcaster is starving (e.g., dongle unplug).
     loop {
-        if shutdown.is_set() {
+        if shutdown.load(Ordering::Relaxed) || slot.is_disconnected() {
             return;
         }
         match rx.recv_timeout(WRITER_RECV_TIMEOUT) {
             Ok(buf) => {
                 if let Err(e) = stream.write_all(&buf) {
-                    tracing::debug!(%e, "rtl_tcp client socket write failed, closing");
-                    shutdown.set_client();
+                    tracing::debug!(%e, client_id = slot.id, "rtl_tcp client socket write failed, closing");
+                    slot.mark_disconnected();
                     return;
                 }
                 // Flush after every chunk so the LZ4 frame encoder
@@ -1149,15 +980,19 @@ fn tcp_writer<W: Write + Send>(
                 // buffer), so the legacy path pays nothing. Per
                 // CodeRabbit round 1 on PR #399.
                 if let Err(e) = stream.flush() {
-                    tracing::debug!(%e, "rtl_tcp client socket flush failed, closing");
-                    shutdown.set_client();
+                    tracing::debug!(%e, client_id = slot.id, "rtl_tcp client socket flush failed, closing");
+                    slot.mark_disconnected();
                     return;
                 }
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                // Re-check shutdown flag above.
+                // Re-check shutdown + slot flags above.
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                // Broadcaster dropped our sender. Only happens when
+                // the registry prunes our slot AFTER our sender got
+                // dropped, which in turn requires slot.disconnected
+                // to be set. The writer exits cleanly.
                 return;
             }
         }
@@ -1167,64 +1002,64 @@ fn tcp_writer<W: Write + Send>(
 fn command_worker(
     mut stream: TcpStream,
     device: Arc<Mutex<RtlSdrDevice>>,
-    shutdown: MergedShutdown,
-    stats: Arc<Mutex<ServerStats>>,
+    slot: Arc<ClientSlot>,
+    shutdown: Arc<AtomicBool>,
 ) {
     // Upstream loops on a 1 s select() so shutdown is noticed promptly.
     // Our equivalent is the socket read timeout. If we can't install it,
     // `read_full` would block indefinitely in `stream.read()` without
     // ever re-checking the shutdown flag — which would deadlock
-    // `handle_client`'s join on this worker, then the accept thread's
-    // join on handle_client, then `Server::Drop`. Treat the failure as
-    // fatal for this client session.
+    // `Server::drop`. Treat the failure as fatal for this client.
     if let Err(e) = stream.set_read_timeout(Some(COMMAND_READ_TIMEOUT)) {
-        tracing::warn!(%e, "set_read_timeout on command channel failed; dropping client");
-        shutdown.set_client();
+        tracing::warn!(%e, client_id = slot.id, "set_read_timeout on command channel failed; dropping client");
+        slot.mark_disconnected();
         return;
     }
     let mut buf = [0u8; COMMAND_LEN];
-    while !shutdown.is_set() {
-        match read_full(&mut stream, &mut buf, &shutdown) {
+    loop {
+        if shutdown.load(Ordering::Relaxed) || slot.is_disconnected() {
+            return;
+        }
+        match read_full(&mut stream, &mut buf, &slot, &shutdown) {
             ReadResult::Ok => {}
             ReadResult::Eof => {
-                tracing::debug!("rtl_tcp command channel EOF");
-                shutdown.set_client();
+                tracing::debug!(client_id = slot.id, "rtl_tcp command channel EOF");
+                slot.mark_disconnected();
                 return;
             }
             ReadResult::Shutdown => return,
             ReadResult::Err(e) => {
-                tracing::warn!(%e, "rtl_tcp command recv error");
-                shutdown.set_client();
+                tracing::warn!(%e, client_id = slot.id, "rtl_tcp command recv error");
+                slot.mark_disconnected();
                 return;
             }
         }
         let Some(cmd) = Command::from_bytes(&buf) else {
             // Upstream silently drops unknown opcodes (switch has no default).
-            tracing::debug!(op = buf[0], "rtl_tcp unknown command opcode, dropping");
+            tracing::debug!(
+                op = buf[0],
+                client_id = slot.id,
+                "rtl_tcp unknown command opcode, dropping"
+            );
             continue;
         };
         let Ok(mut dev) = device.lock() else {
-            // Same rationale as data_worker: a poisoned device mutex
-            // is unrecoverable, and silently dropping commands here
-            // would leave the client driving the UI with no visible
-            // effect on the server. Close the session.
-            tracing::error!("device mutex poisoned, command worker aborting and closing session");
-            shutdown.set_client();
+            // Same rationale as the broadcaster: a poisoned device
+            // mutex is unrecoverable, and silently dropping commands
+            // here would leave the client driving the UI with no
+            // visible effect on the server. Close this client.
+            tracing::error!(
+                client_id = slot.id,
+                "device mutex poisoned, command worker aborting and closing this client"
+            );
+            slot.mark_disconnected();
             return;
         };
         dispatch(&mut dev, cmd);
         drop(dev);
-        if let Ok(mut s) = stats.lock() {
+        if let Ok(mut s) = slot.stats.lock() {
             let now = Instant::now();
-            s.last_command = Some((cmd.op, now));
-            // Push onto the bounded ring. Pop the oldest entry when
-            // we'd otherwise exceed the cap — keeps memory bounded
-            // on long-running sessions without a dedicated ring-
-            // buffer crate.
-            if s.recent_commands.len() >= RECENT_COMMANDS_CAPACITY {
-                s.recent_commands.pop_front();
-            }
-            s.recent_commands.push_back((cmd.op, now));
+            s.record_command(cmd.op, now);
             // Capture the commanded state alongside the
             // last-command stamp. We record what the CLIENT
             // requested (not what the device ultimately applied)
@@ -1255,6 +1090,75 @@ fn command_worker(
     }
 }
 
+fn broadcaster_worker(
+    device: Arc<Mutex<RtlSdrDevice>>,
+    registry: Arc<ClientRegistry>,
+    shutdown: Arc<AtomicBool>,
+) {
+    // Pull the USB handle once so we don't lock the device mutex on
+    // every bulk read. The handle is Arc-cloneable and thread-safe
+    // for bulk reads; the mutex-guarded device is still required for
+    // command dispatch and configuration changes, which run on
+    // per-client command workers.
+    let handle = {
+        let Ok(dev) = device.lock() else {
+            tracing::error!(
+                "device mutex poisoned, broadcaster aborting and signalling server shutdown"
+            );
+            shutdown.store(true, Ordering::SeqCst);
+            return;
+        };
+        dev.usb_handle()
+    };
+    // Scratch buffer reused across iterations — only the Vec<u8>
+    // that the registry clones per-client gets a fresh allocation,
+    // sized to the data the USB read actually returned.
+    let mut scratch = vec![0u8; READ_BUFFER_LEN as usize];
+    let mut ticks_since_prune: u32 = 0;
+
+    while !shutdown.load(Ordering::Relaxed) {
+        match handle.read_bulk(
+            sdr_rtlsdr::constants::BULK_ENDPOINT,
+            &mut scratch,
+            USB_READ_TIMEOUT,
+        ) {
+            Ok(n) if n > 0 => {
+                registry.broadcast(&scratch[..n]);
+                ticks_since_prune = ticks_since_prune.saturating_add(1);
+                if ticks_since_prune >= BROADCASTER_PRUNE_EVERY_N_TICKS {
+                    let removed = registry.prune_disconnected();
+                    if removed > 0 {
+                        tracing::debug!(removed, "rtl_tcp pruned disconnected client slots");
+                    }
+                    ticks_since_prune = 0;
+                }
+            }
+            Ok(_) | Err(rusb::Error::Timeout) => {
+                // No data — loop and re-check shutdown.
+            }
+            Err(rusb::Error::NoDevice) => {
+                // Dongle unplug is unrecoverable at the server level.
+                // Escalate to a global shutdown so the accept thread
+                // exits, the CLI sees `has_stopped() == true`, and
+                // connected clients' command / writer loops observe
+                // the flag and tear down.
+                tracing::error!("rtl_tcp: USB device lost mid-stream, stopping server");
+                shutdown.store(true, Ordering::SeqCst);
+                return;
+            }
+            Err(e) => {
+                tracing::error!(%e, "rtl_tcp bulk read error — stopping server");
+                shutdown.store(true, Ordering::SeqCst);
+                return;
+            }
+        }
+    }
+    // Final prune on exit so the pruned-slots metric doesn't
+    // indefinitely lag behind truth when the server stops with
+    // dead slots still registered.
+    registry.prune_disconnected();
+}
+
 enum ReadResult {
     Ok,
     Eof,
@@ -1265,10 +1169,15 @@ enum ReadResult {
 /// Read exactly `buf.len()` bytes, splitting across multiple `read`s but
 /// re-checking the shutdown flag on each timeout. Mirrors the upstream
 /// `while(left > 0)` loop in rtl_tcp.c:297-313.
-fn read_full(stream: &mut TcpStream, buf: &mut [u8], shutdown: &MergedShutdown) -> ReadResult {
+fn read_full(
+    stream: &mut TcpStream,
+    buf: &mut [u8],
+    slot: &Arc<ClientSlot>,
+    shutdown: &Arc<AtomicBool>,
+) -> ReadResult {
     let mut filled = 0;
     while filled < buf.len() {
-        if shutdown.is_set() {
+        if shutdown.load(Ordering::Relaxed) || slot.is_disconnected() {
             return ReadResult::Shutdown;
         }
         match stream.read(&mut buf[filled..]) {
@@ -1339,46 +1248,6 @@ mod tests {
     }
 
     #[test]
-    fn update_stats_on_disconnect_clears_per_session_counters() {
-        // Session-scoped counters (bytes_sent, buffers_dropped,
-        // last_command, current_* commanded fields) must be cleared
-        // when the client disconnects — otherwise a UI polling
-        // ServerStats would see stale data from the prior session
-        // while connected_client = None, e.g. the status row would
-        // still show "100.3 MHz @ 2.4 MHz" for a dead session.
-        let mut recent = VecDeque::new();
-        recent.push_back((CommandOp::SetCenterFreq, Instant::now()));
-        recent.push_back((CommandOp::SetTunerGain, Instant::now()));
-        let stats = Arc::new(Mutex::new(ServerStats {
-            connected_client: Some(SocketAddr::from(([127, 0, 0, 1], 42_000))),
-            connected_since: Some(Instant::now()),
-            bytes_sent: 12345,
-            buffers_dropped: 7,
-            last_command: Some((CommandOp::SetCenterFreq, Instant::now())),
-            current_freq_hz: Some(100_300_000),
-            current_sample_rate_hz: Some(2_400_000),
-            current_gain_tenths_db: Some(200),
-            current_gain_auto: Some(false),
-            recent_commands: recent,
-        }));
-        update_stats_on_disconnect(&stats);
-        let s = stats.lock().unwrap();
-        assert!(s.connected_client.is_none());
-        assert!(s.connected_since.is_none());
-        assert_eq!(s.bytes_sent, 0);
-        assert_eq!(s.buffers_dropped, 0);
-        assert!(s.last_command.is_none());
-        assert!(s.current_freq_hz.is_none());
-        assert!(s.current_sample_rate_hz.is_none());
-        assert!(s.current_gain_tenths_db.is_none());
-        assert!(s.current_gain_auto.is_none());
-        assert!(
-            s.recent_commands.is_empty(),
-            "activity log ring must clear on disconnect to avoid stale entries in the next session"
-        );
-    }
-
-    #[test]
     fn server_stats_default_is_not_connected() {
         let stats = ServerStats::default();
         assert!(stats.connected_client.is_none());
@@ -1402,32 +1271,6 @@ mod tests {
     }
 
     #[test]
-    fn merged_shutdown_set_global_escalates_to_both_flags() {
-        // set_client() → client=true, global unchanged.
-        // set_global() → both flags true, so accept loop also exits.
-        // Regression test for the "NoDevice flips client only" bug:
-        // unplug used to stop the current session but leave the accept
-        // thread polling forever against a dead dongle.
-        let ms = MergedShutdown::new(
-            Arc::new(AtomicBool::new(false)),
-            Arc::new(AtomicBool::new(false)),
-        );
-        assert!(!ms.is_set());
-
-        ms.set_client();
-        assert!(ms.is_set());
-        assert!(!ms.global.load(Ordering::Relaxed));
-        assert!(ms.client.load(Ordering::Relaxed));
-
-        // Reset client so we can see set_global set BOTH.
-        ms.client.store(false, Ordering::SeqCst);
-        assert!(!ms.is_set());
-        ms.set_global();
-        assert!(ms.global.load(Ordering::Relaxed));
-        assert!(ms.client.load(Ordering::Relaxed));
-    }
-
-    #[test]
     fn has_stopped_is_false_before_accept_thread_exits() {
         // We can't stand up a real Server without hardware, but we CAN
         // sanity-check the `stopped` flag contract: `has_stopped()`
@@ -1448,11 +1291,70 @@ mod tests {
         assert_eq!(DEFAULT_BUFFER_CAPACITY, 500);
     }
 
+    #[test]
+    fn project_to_legacy_stats_empty_registry_returns_default() {
+        // No clients connected → the legacy-shape projection must
+        // return the same zero-filled struct a fresh
+        // `ServerStats::default()` returns. Guards the UI's
+        // "Waiting for client" rendering: a non-None connected_client
+        // in the projection would be a phantom client.
+        let registry = Arc::new(ClientRegistry::new());
+        let stats = project_to_legacy_stats(&registry);
+        let expected = ServerStats::default();
+        assert_eq!(stats.connected_client, expected.connected_client);
+        assert_eq!(stats.bytes_sent, expected.bytes_sent);
+        assert_eq!(stats.buffers_dropped, expected.buffers_dropped);
+        assert!(stats.recent_commands.is_empty());
+    }
+
+    #[test]
+    fn project_to_legacy_stats_picks_first_registered_client() {
+        // Multiple clients → the projection returns the FIRST (oldest)
+        // registered client's session fields. Second+ clients are
+        // invisible in the legacy shape; commit 2b makes all clients
+        // visible via `Vec<ClientInfo>`.
+        use crate::broadcaster::ClientSlot;
+        let registry = Arc::new(ClientRegistry::new());
+
+        let (slot_a, _rx_a) = ClientSlot::new(
+            registry.allocate_id(),
+            SocketAddr::from(([127, 0, 0, 1], 42_001)),
+            Codec::None,
+            4,
+        );
+        if let Ok(mut s) = slot_a.stats.lock() {
+            s.bytes_sent = 100;
+            s.current_freq_hz = Some(145_500_000);
+        }
+        registry.register(slot_a);
+
+        let (slot_b, _rx_b) = ClientSlot::new(
+            registry.allocate_id(),
+            SocketAddr::from(([127, 0, 0, 1], 42_002)),
+            Codec::Lz4,
+            4,
+        );
+        if let Ok(mut s) = slot_b.stats.lock() {
+            s.bytes_sent = 999;
+            s.current_freq_hz = Some(100_000_000);
+        }
+        registry.register(slot_b);
+
+        let stats = project_to_legacy_stats(&registry);
+        // First client's peer + session fields.
+        assert_eq!(
+            stats.connected_client,
+            Some(SocketAddr::from(([127, 0, 0, 1], 42_001)))
+        );
+        assert_eq!(stats.bytes_sent, 100);
+        assert_eq!(stats.current_freq_hz, Some(145_500_000));
+    }
+
     // ============================================================
     // sniff_client_hello regression tests (CodeRabbit round 2 on PR #399)
     //
-    // The sniff is the only piece of `handle_client` that can run
-    // without a real RTL-SDR dongle, so unit tests live here.
+    // The sniff is the only piece of the per-client handshake that
+    // can run without a real RTL-SDR dongle, so unit tests live here.
     // Each test pairs a server-side accept with a client-side TCP
     // connect + controlled write pattern, verifying that
     // `sniff_client_hello` classifies the stream correctly.

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -803,11 +803,16 @@ fn spawn_client_workers(
     // broadcaster discovers it on its next tick.
     registry.register(slot);
 
-    // Park both worker handles on the registry so `Server::drop` can
-    // join them during shutdown — without this, the threads'
-    // `Arc<Mutex<RtlSdrDevice>>` clones could outlive
+    // Park both worker handles on the registry so `Server::drop`
+    // can join any still running at shutdown — without this, the
+    // threads' `Arc<Mutex<RtlSdrDevice>>` clones could outlive
     // `has_stopped() == true` and leave the dongle claimed for a
-    // follow-up `Server::start`. Per `CodeRabbit` round 1 on PR #402.
+    // follow-up `Server::start`. During normal runtime the
+    // broadcaster calls `reap_finished_worker_handles()` on its
+    // prune cadence so completed handles from disconnected
+    // clients get joined promptly and don't accumulate under
+    // connection churn. Per `CodeRabbit` round 1 on PR #402
+    // (shutdown join) + round 5 (runtime reap).
     registry.register_worker_handle(writer_handle);
     registry.register_worker_handle(command_handle);
 
@@ -885,84 +890,140 @@ const HELLO_SNIFF_TIMEOUT: Duration = Duration::from_millis(100);
 /// Return cases:
 ///
 /// - `Ok(Some(hello))` — valid 8-byte hello, fully consumed.
-/// - `Ok(None)` — legacy fallback. Reached either on a zero-byte
+/// - `Ok(None)` — legacy fallback. Reached on a zero-byte
 ///   timeout/EOF (idle client never sent anything) OR on a
-///   non-zero peek whose prefix doesn't match [`EXTENSION_MAGIC`]
-///   (legacy client sent a command; the bytes stay queued in the
-///   receive buffer so `command_worker` can parse the 5-byte
-///   frame). Nothing is consumed in either sub-case.
-/// - `Err(_)` — protocol error, raised only after the magic
-///   already matched and we committed to reading a full 8 bytes.
-///   Covers `read_exact` timeout or EOF mid-hello (partial hello,
-///   bytes already drained from the stream) and parse failure
-///   on a complete 8-byte block (unknown role, unknown protocol
-///   version, etc.). Falling back to legacy from either of these
-///   states would desync the command stream, so the caller drops
-///   the client.
+///   peek whose observed prefix definitively does NOT match
+///   [`EXTENSION_MAGIC`] (legacy client sent a command; the
+///   bytes stay queued in the receive buffer so `command_worker`
+///   can parse the frame). Nothing is consumed in either case.
+/// - `Err(_)` — protocol error. Raised when the magic already
+///   matched and we committed to reading a full 8 bytes — covers
+///   `read_exact` timeout or EOF mid-hello (partial hello, bytes
+///   already drained from the stream) and parse failure on a
+///   complete 8-byte block (unknown role, unknown protocol
+///   version, etc.). Also raised when a 1–3 byte prefix of the
+///   magic arrived but the remaining magic bytes never completed
+///   within the sniff budget: returning `Ok(None)` there would
+///   shift the command reader by the prefix bytes still queued
+///   in the receive buffer, corrupting the legacy stream.
 ///
-/// Uses `peek()` for the initial magic check so legitimate legacy
-/// traffic stays intact. Once the magic matches we commit to
-/// reading the full 8 bytes; partial reads are fatal because we
-/// can't un-consume the half we already read. Per CodeRabbit
-/// round 2 on PR #399 (initial fix) + round 3 (doc alignment).
+/// Uses `peek()` for the magic check so legitimate legacy traffic
+/// stays intact. A fragmented `RTLX` hello whose bytes arrive
+/// across two TCP segments surfaces as a short peek; the poll
+/// loop waits for more bytes as long as the observed prefix
+/// still matches `EXTENSION_MAGIC[..n]`. Once the full magic
+/// matches we commit to reading the full 8 bytes — partial reads
+/// are fatal because we can't un-consume bytes already drained.
+/// Per `CodeRabbit` round 2 on PR #399 (initial fix),
+/// round 3 (doc alignment), and round 5 on PR #402
+/// (partial-prefix handling for fragmented RTLX).
 fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHello>> {
-    stream.set_read_timeout(Some(HELLO_SNIFF_TIMEOUT))?;
-    // Peek the first 4 bytes (magic-only check). `peek` maps to
-    // `recv(…, MSG_PEEK)` which respects `SO_RCVTIMEO`, so this
-    // returns WouldBlock / TimedOut after the timeout without
-    // consuming bytes.
+    // Poll cadence for the peek retry loop. Small enough that a
+    // fragmented `RTLX` hello whose trailing bytes land within a
+    // few ms gets re-checked before the sniff deadline; large
+    // enough to avoid spinning at 100 % CPU while waiting.
+    const PEEK_POLL_INTERVAL: Duration = Duration::from_millis(2);
+
+    let deadline = Instant::now() + HELLO_SNIFF_TIMEOUT;
     let mut peek_buf = [0u8; EXTENSION_MAGIC.len()];
-    let peeked = match stream.peek(&mut peek_buf) {
-        Ok(n) => n,
-        Err(e)
-            if e.kind() == std::io::ErrorKind::WouldBlock
-                || e.kind() == std::io::ErrorKind::TimedOut =>
-        {
-            // Pure timeout with zero bytes observed — the client
-            // never sent anything, so this is an idle legacy peer
-            // (or a port scanner). Safe to fall back; no bytes
-            // were consumed.
+    let mut observed_any_prefix = false;
+
+    // Peek loop. `peek` maps to `recv(…, MSG_PEEK)` — returns as
+    // soon as any data is available, so a fragmented 4-byte
+    // magic (e.g. `RT` then `LX` across two TCP segments)
+    // surfaces here as a short peek. Keep waiting while the
+    // observed bytes are still a prefix of `EXTENSION_MAGIC`;
+    // only fall back to legacy when we have a definite non-magic
+    // prefix, an EOF, or a zero-byte timeout.
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
             stream.set_read_timeout(None)?;
+            if observed_any_prefix {
+                // Partial magic-prefix observed but full 4 bytes
+                // never arrived. Returning `Ok(None)` (legacy
+                // fallback) would shift the command reader by
+                // the 1–3 prefix bytes still queued in the
+                // receive buffer — parsing `R` / `RT` / `RTL`
+                // as opcodes corrupts the command stream. Same
+                // reasoning as the post-magic-match failure
+                // modes below; drop the client.
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "RTLX magic prefix observed but full 4-byte magic did not complete \
+                     within HELLO_SNIFF_TIMEOUT",
+                ));
+            }
+            // Zero bytes ever observed — idle legacy peer or
+            // port scanner. Nothing consumed, safe to fall back.
             return Ok(None);
         }
-        Err(e) => {
-            // Other errors (ECONNRESET, etc.) → propagate so the
-            // caller tears down cleanly.
-            stream.set_read_timeout(None)?;
-            return Err(e);
+        // Per-iteration read timeout capped by `PEEK_POLL_INTERVAL`
+        // so we wake up to re-check the deadline if the kernel
+        // blocks waiting for bytes.
+        let this_timeout = remaining.min(PEEK_POLL_INTERVAL);
+        stream.set_read_timeout(Some(this_timeout))?;
+        match stream.peek(&mut peek_buf) {
+            Ok(0) => {
+                // Peer closed cleanly. Connection is gone so
+                // there's no stream left to desync — safe
+                // fallback regardless of whether a prefix had
+                // been observed.
+                stream.set_read_timeout(None)?;
+                return Ok(None);
+            }
+            Ok(n) if n >= EXTENSION_MAGIC.len() => break,
+            Ok(n) => {
+                // 0 < n < EXTENSION_MAGIC.len() — partial peek.
+                observed_any_prefix = true;
+                if peek_buf[..n] != EXTENSION_MAGIC[..n] {
+                    // Definite non-magic prefix — legacy command
+                    // sender whose opcode byte (plus whatever
+                    // arg bytes already arrived) doesn't start
+                    // with `R`. Bytes stay queued for
+                    // `command_worker`.
+                    stream.set_read_timeout(None)?;
+                    return Ok(None);
+                }
+                // Prefix still a candidate `RTLX`. Brief yield
+                // so the kernel receive buffer can fill before
+                // the next peek.
+                thread::sleep(PEEK_POLL_INTERVAL);
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                // No bytes arrived this slice — loop and
+                // re-check the deadline.
+            }
+            Err(e) => {
+                // Other errors (ECONNRESET, etc.) → propagate
+                // so the caller tears down cleanly.
+                stream.set_read_timeout(None)?;
+                return Err(e);
+            }
         }
-    };
-    if peeked == 0 {
-        // Peer closed cleanly before sending anything. Same
-        // safety as a timeout-with-zero-bytes: no bytes consumed,
-        // nothing to desync.
-        stream.set_read_timeout(None)?;
-        return Ok(None);
     }
-    if peeked < EXTENSION_MAGIC.len() || peek_buf[..EXTENSION_MAGIC.len()] != EXTENSION_MAGIC {
-        // Legacy client — either sent fewer than 4 bytes but
-        // something (so we can't tell if they might still be
-        // sending a hello), or the first bytes aren't the
-        // sdr-rs magic. Preserving bytes for the command reader
-        // is only safe when we know they're the start of a
-        // command: a vanilla `SetCenterFreq` starts with 0x01,
-        // no documented opcode begins with 'R' (0x52), so a
-        // mismatch on a full 4-byte peek is a legitimate legacy
-        // command. A short prefix that doesn't match magic is
-        // ambiguous but benign — the command reader will parse
-        // it as a 5-byte command frame and dispatch or log
-        // unknown-opcode.
+    if peek_buf != EXTENSION_MAGIC {
+        // Full 4-byte peek and no match — legacy client. A
+        // vanilla `SetCenterFreq` starts with 0x01; no
+        // documented opcode begins with 0x52 ('R'), so four
+        // non-magic bytes at the head are a legitimate legacy
+        // command frame. Bytes stay queued for the command
+        // reader.
         stream.set_read_timeout(None)?;
         return Ok(None);
     }
     // Magic matched — commit to consuming 8 bytes. A timeout or
     // EOF here is no longer a safe fallback: we've verified the
-    // client started an extended hello and consumed `read_exact`
-    // will have eaten whatever bytes arrived before the stall.
+    // client started an extended hello and `read_exact` will
+    // have eaten whatever bytes arrived before the stall.
     // Returning `Ok(None)` would let the legacy path start
     // against a shifted command stream — exactly the desync
-    // CodeRabbit round 2 flagged. Treat every failure mode as a
-    // protocol error and drop the client.
+    // `CodeRabbit` round 2 on PR #399 flagged. Treat every
+    // failure mode as a protocol error and drop the client.
+    stream.set_read_timeout(Some(HELLO_SNIFF_TIMEOUT))?;
     let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
     let read_result = stream.read_exact(&mut hello_buf);
     stream.set_read_timeout(None)?;
@@ -1199,6 +1260,19 @@ fn broadcaster_worker(
                     let removed = registry.prune_disconnected();
                     if removed > 0 {
                         tracing::debug!(removed, "rtl_tcp pruned disconnected client slots");
+                    }
+                    // Reap finished per-client worker handles on
+                    // the same cadence — otherwise a long-lived
+                    // server with connection churn would keep
+                    // every completed writer/command handle alive
+                    // until shutdown (OS thread resources + TLS
+                    // linger). Per `CodeRabbit` round 5 on PR #402.
+                    let reaped = registry.reap_finished_worker_handles();
+                    if reaped > 0 {
+                        tracing::debug!(
+                            reaped,
+                            "rtl_tcp reaped finished per-client worker threads"
+                        );
                     }
                     ticks_since_prune = 0;
                 }
@@ -1572,6 +1646,118 @@ mod tests {
             result.is_err(),
             "partial hello (magic only, body stalled) must surface as Err — \
              got {result:?} which would desync the command stream on fallback"
+        );
+    }
+
+    #[test]
+    fn sniff_client_hello_fragmented_magic_completes_successfully() {
+        // **Regression test for `CodeRabbit` round 5 on PR #402.**
+        // A well-behaved RTLX client whose `ClientHello` bytes
+        // span two TCP segments (e.g. `RT` in one, `LX` + body
+        // in the next) previously fell back to legacy on the
+        // first short peek — corrupting the command stream for
+        // the unlucky RTLX client. The fix retries the peek
+        // while the observed bytes are a prefix of
+        // `EXTENSION_MAGIC`, so a fragmented magic still reaches
+        // the full `read_exact` path.
+        use crate::codec::CodecMask;
+        use crate::extension::{CLIENT_HELLO_FLAGS_NONE, Role};
+        let hello = ClientHello {
+            codec_mask: CodecMask::NONE_AND_LZ4,
+            role: Role::Control,
+            flags: CLIENT_HELLO_FLAGS_NONE,
+            version: PROTOCOL_VERSION,
+        };
+        let bytes = hello.to_bytes();
+        let result = run_sniff_against(move |mut client| {
+            // Send the first 2 magic bytes, flush, pause briefly
+            // to force a short peek on the server side, then
+            // send the remaining 6 bytes.
+            client.write_all(&bytes[..2]).unwrap();
+            client.flush().unwrap();
+            thread::sleep(Duration::from_millis(10));
+            client.write_all(&bytes[2..]).unwrap();
+            // Keep the client alive long enough for the server
+            // to finish `read_exact` before we drop and EOF.
+            thread::sleep(Duration::from_millis(50));
+        });
+        assert_eq!(
+            result.unwrap(),
+            Some(hello),
+            "fragmented RTLX hello must not fall back to legacy on the first short peek"
+        );
+    }
+
+    #[test]
+    fn sniff_client_hello_stalled_magic_prefix_is_protocol_error() {
+        // **Regression test for `CodeRabbit` round 5 on PR #402.**
+        // A client that starts sending the magic (e.g. `RT`)
+        // and then stalls without completing the remaining 2
+        // bytes must NOT fall back to legacy: the prefix bytes
+        // are still queued in the receive buffer, and handing
+        // them to `command_worker` would start the legacy
+        // command stream at `R` (0x52) which isn't any valid
+        // opcode — poisoning every subsequent command. Promote
+        // to `Err` so the client gets dropped.
+        let result = run_sniff_against(|mut client| {
+            client.write_all(&EXTENSION_MAGIC[..2]).unwrap();
+            thread::sleep(HELLO_SNIFF_TIMEOUT * 5);
+            drop(client);
+        });
+        assert!(
+            result.is_err(),
+            "stalled magic prefix must surface as Err (dropping the client) — got \
+             {result:?} which would desync the command stream on legacy fallback"
+        );
+    }
+
+    #[test]
+    fn sniff_client_hello_short_non_magic_prefix_is_legacy_fallback() {
+        // Legacy client whose first TCP segment carries only 1
+        // byte that already disagrees with magic (e.g. 0x01 =
+        // `SetCenterFreq` opcode). The sniff loop must recognize
+        // this as a definite non-match from the short peek and
+        // fall back to legacy immediately — no reason to wait
+        // out the full `HELLO_SNIFF_TIMEOUT` when the first byte
+        // already rules out RTLX.
+        //
+        // Times just the sniff call (not the client-thread join)
+        // to verify the short-circuit. Inlined instead of using
+        // `run_sniff_against` so the client keeps the socket
+        // open past the sniff return — otherwise we can't prove
+        // the sniff exited on the definite-non-match path vs.
+        // on an EOF from the client dropping.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let keep_alive = Arc::new(AtomicBool::new(true));
+        let keep_alive_clone = Arc::clone(&keep_alive);
+        let client_thread = thread::spawn(move || {
+            let mut client = TcpStream::connect(addr).unwrap();
+            client.write_all(&[0x01]).unwrap();
+            client.flush().unwrap();
+            // Hold the socket open so the sniff must decide on
+            // the 1-byte prefix alone, not on EOF.
+            while keep_alive_clone.load(Ordering::Relaxed) {
+                thread::sleep(Duration::from_millis(2));
+            }
+            drop(client);
+        });
+        let (server_stream, _peer) = listener.accept().unwrap();
+        let sniff_start = std::time::Instant::now();
+        let result = sniff_client_hello(&server_stream);
+        let elapsed = sniff_start.elapsed();
+        keep_alive.store(false, Ordering::Relaxed);
+        drop(server_stream);
+        let _ = client_thread.join();
+
+        match result {
+            Ok(None) => {}
+            other => panic!("expected Ok(None) for short non-magic prefix, got {other:?}"),
+        }
+        assert!(
+            elapsed < HELLO_SNIFF_TIMEOUT,
+            "short non-magic prefix should short-circuit within HELLO_SNIFF_TIMEOUT, \
+             but sniff took {elapsed:?} (HELLO_SNIFF_TIMEOUT = {HELLO_SNIFF_TIMEOUT:?})"
         );
     }
 

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -945,11 +945,16 @@ fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHe
                 // fallback) would shift the command reader by
                 // the 1–3 prefix bytes still queued in the
                 // receive buffer — parsing `R` / `RT` / `RTL`
-                // as opcodes corrupts the command stream. Same
-                // reasoning as the post-magic-match failure
-                // modes below; drop the client.
+                // as opcodes corrupts the command stream. Surface
+                // as `InvalidData` (not `TimedOut`) to match the
+                // post-magic-match `read_exact` and body-parse
+                // failure paths below: both are protocol-desync
+                // errors from the host's perspective — the socket
+                // isn't "idle", it sent bytes that commit to the
+                // extended protocol and then stalled. Per
+                // `CodeRabbit` round 6 on PR #402.
                 return Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
+                    std::io::ErrorKind::InvalidData,
                     "RTLX magic prefix observed but full 4-byte magic did not complete \
                      within HELLO_SNIFF_TIMEOUT",
                 ));
@@ -1690,7 +1695,10 @@ mod tests {
 
     #[test]
     fn sniff_client_hello_stalled_magic_prefix_is_protocol_error() {
-        // **Regression test for `CodeRabbit` round 5 on PR #402.**
+        // **Regression test for `CodeRabbit` round 5 on PR #402**
+        // (initial promotion to `Err`) **+ round 6** (pinning
+        // the error kind to `InvalidData`, not `TimedOut`).
+        //
         // A client that starts sending the magic (e.g. `RT`)
         // and then stalls without completing the remaining 2
         // bytes must NOT fall back to legacy: the prefix bytes
@@ -1698,16 +1706,24 @@ mod tests {
         // them to `command_worker` would start the legacy
         // command stream at `R` (0x52) which isn't any valid
         // opcode — poisoning every subsequent command. Promote
-        // to `Err` so the client gets dropped.
+        // to `Err` with `ErrorKind::InvalidData` so it lands in
+        // the same classification bucket as `read_exact`
+        // timeout mid-hello and a malformed body — all three
+        // are protocol-desync errors from the host's POV.
         let result = run_sniff_against(|mut client| {
             client.write_all(&EXTENSION_MAGIC[..2]).unwrap();
             thread::sleep(HELLO_SNIFF_TIMEOUT * 5);
             drop(client);
         });
-        assert!(
-            result.is_err(),
-            "stalled magic prefix must surface as Err (dropping the client) — got \
-             {result:?} which would desync the command stream on legacy fallback"
+        let err = result.expect_err(
+            "stalled magic prefix must surface as Err (dropping the client) — legacy \
+             fallback would desync the command stream",
+        );
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::InvalidData,
+            "stalled RTLX prefix classifies as InvalidData (protocol desync), not \
+             TimedOut (idle-socket semantics) — got {err:?}"
         );
     }
 

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -618,10 +618,17 @@ fn spawn_accept_thread(
                 }
             }
             // Mark stopped AFTER the loop exits so callers polling
-            // `has_stopped()` observe the server is fully done. The
-            // broadcaster thread is joined by `Server::drop` — we
-            // don't wait for it here because `Server` owns that
-            // handle.
+            // `has_stopped()` observe that the accept thread is
+            // gone. **Narrow semantic** — this flag is set before
+            // `join_all_threads()` runs in `stop()` / `Drop`, so
+            // the broadcaster + per-client workers may still be
+            // running (and still holding the device mutex) when
+            // `has_stopped()` first returns true. Callers that
+            // need "dongle is actually free" must wait for
+            // `stop()` / `Drop` to return — the CLI's
+            // `while !has_stopped() ...; drop(server)` pattern
+            // does exactly that. Per `CodeRabbit` round 4 on
+            // PR #402 (comment clarity; no behavior change).
             stopped.store(true, Ordering::SeqCst);
             tracing::debug!("rtl_tcp accept thread exiting");
         })
@@ -1263,6 +1270,43 @@ fn read_full(
 mod tests {
     use super::*;
 
+    // ============================================================
+    // Test fixture constants (CodeRabbit round 4 on PR #402).
+    // Extracted so each test's intent reads at a glance —
+    // `42_001` on its own is noise, `TEST_CLIENT_A_PORT` plus a
+    // bounds docstring is self-documenting.
+    // ============================================================
+
+    /// Loopback peer port for the "client A" side of two-client
+    /// fixtures. Non-privileged, doesn't overlap with anything
+    /// well-known, and disjoint from `TEST_CLIENT_B_PORT`.
+    const TEST_CLIENT_A_PORT: u16 = 42_001;
+    /// Loopback peer port for "client B". Disjoint from
+    /// `TEST_CLIENT_A_PORT` so snapshot assertions can verify
+    /// ordering / identity.
+    const TEST_CLIENT_B_PORT: u16 = 42_002;
+    /// Small per-client channel depth used by tests that don't
+    /// exercise the full/drop path — just needs to fit the few
+    /// chunks a test sends. Anything ≥ the chunk count is fine.
+    const TEST_CLIENT_CHANNEL_DEPTH: usize = 4;
+    /// Synthetic `bytes_sent` value for client A's stats —
+    /// arbitrary small number, just has to differ from B's value
+    /// so the per-client readback assertions prove the right
+    /// entry landed in `connected_clients[0]`.
+    const TEST_CLIENT_A_BYTES: u64 = 100;
+    /// Synthetic `bytes_sent` value for client B. Differs from
+    /// A's by an order of magnitude so a cross-over bug stands out.
+    const TEST_CLIENT_B_BYTES: u64 = 999;
+    /// 2-meter amateur band frequency (145.5 MHz) stamped into
+    /// client A's `current_freq_hz` — stand-in for "non-default
+    /// freq client A commanded".
+    const TEST_CLIENT_A_FREQ_HZ: u32 = 145_500_000;
+    /// WFM broadcast band frequency (100 MHz) stamped into
+    /// client B's `current_freq_hz`. Second distinct sample so
+    /// cross-client bugs show up as the wrong freq under
+    /// `connected_clients[1]`.
+    const TEST_CLIENT_B_FREQ_HZ: u32 = 100_000_000;
+
     #[test]
     fn start_surfaces_port_conflict_as_typed_error() {
         // Hold a port before calling Server::start — the second bind must
@@ -1365,25 +1409,25 @@ mod tests {
 
         let (slot_a, _rx_a) = ClientSlot::new(
             registry.allocate_id(),
-            SocketAddr::from(([127, 0, 0, 1], 42_001)),
+            SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_A_PORT)),
             Codec::None,
-            4,
+            TEST_CLIENT_CHANNEL_DEPTH,
         );
         if let Ok(mut s) = slot_a.stats.lock() {
-            s.bytes_sent = 100;
-            s.current_freq_hz = Some(145_500_000);
+            s.bytes_sent = TEST_CLIENT_A_BYTES;
+            s.current_freq_hz = Some(TEST_CLIENT_A_FREQ_HZ);
         }
         registry.register(slot_a);
 
         let (slot_b, _rx_b) = ClientSlot::new(
             registry.allocate_id(),
-            SocketAddr::from(([127, 0, 0, 1], 42_002)),
+            SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_B_PORT)),
             Codec::Lz4,
-            4,
+            TEST_CLIENT_CHANNEL_DEPTH,
         );
         if let Ok(mut s) = slot_b.stats.lock() {
-            s.bytes_sent = 999;
-            s.current_freq_hz = Some(100_000_000);
+            s.bytes_sent = TEST_CLIENT_B_BYTES;
+            s.current_freq_hz = Some(TEST_CLIENT_B_FREQ_HZ);
         }
         registry.register(slot_b);
 
@@ -1401,12 +1445,12 @@ mod tests {
         assert_eq!(stats.connected_clients.len(), 2);
         assert_eq!(
             stats.connected_clients[0].peer,
-            SocketAddr::from(([127, 0, 0, 1], 42_001))
+            SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_A_PORT))
         );
-        assert_eq!(stats.connected_clients[0].bytes_sent, 100);
+        assert_eq!(stats.connected_clients[0].bytes_sent, TEST_CLIENT_A_BYTES);
         assert_eq!(
             stats.connected_clients[1].peer,
-            SocketAddr::from(([127, 0, 0, 1], 42_002))
+            SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_B_PORT))
         );
         assert_eq!(stats.connected_clients[1].codec, Codec::Lz4);
         assert_eq!(stats.lifetime_accepted, 2);

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -421,12 +421,24 @@ impl Server {
         self.compression
     }
 
-    /// Has the server exited? Set to `true` after the accept thread
-    /// AND broadcaster thread have joined.
+    /// Has the **accept thread** exited?
     ///
-    /// CLI callers poll this alongside their own Ctrl-C handler so the
-    /// process exits when serving actually stops, instead of sleeping
-    /// forever after the dongle is unplugged.
+    /// Narrowly scoped signal, despite the name — flipped by the
+    /// accept thread itself right before it returns (after
+    /// observing the global shutdown flag, typically on dongle
+    /// unplug or a caller-initiated stop). Does **not** imply that
+    /// the broadcaster and per-client worker threads have joined
+    /// or that the RTL-SDR dongle has been released. Full shutdown
+    /// only happens inside [`Self::stop`] or `Drop` (both of which
+    /// join every owned thread via `join_all_threads`).
+    ///
+    /// CLI callers poll this alongside their own Ctrl-C handler so
+    /// the poll loop exits when serving stops on its own (e.g.,
+    /// dongle unplug), then drop the `Server` which blocks until
+    /// every worker has joined and the dongle is actually released.
+    /// Per `CodeRabbit` round 2 on PR #402 (doc clarified; narrow
+    /// semantic preserved to avoid breaking the CLI's
+    /// `has_stopped() → drop(server)` coupling).
     pub fn has_stopped(&self) -> bool {
         self.stopped.load(Ordering::Relaxed)
     }
@@ -1396,7 +1408,7 @@ mod tests {
     }
 
     // ============================================================
-    // sniff_client_hello regression tests (CodeRabbit round 2 on PR #399)
+    // sniff_client_hello regression tests (`CodeRabbit` round 2 on PR #399)
     //
     // The sniff is the only piece of the per-client handshake that
     // can run without a real RTL-SDR dongle, so unit tests live here.
@@ -1492,7 +1504,7 @@ mod tests {
 
     #[test]
     fn sniff_client_hello_partial_hello_is_protocol_error() {
-        // **Regression test for CodeRabbit round 2 on PR #399.**
+        // **Regression test for `CodeRabbit` round 2 on PR #399.**
         // A client that sends the 4-byte `RTLX` magic and then
         // stalls without sending the remaining 4 hello bytes used
         // to fall back to the legacy path — which desynced the

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -35,7 +35,6 @@
 //! semantics and the epic's "one dongle, shared state" model. Role
 //! enforcement (listeners can't tune) lands in #392.
 
-use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -205,45 +204,39 @@ impl Default for InitialDeviceState {
 
 /// Live server statistics for UI consumption.
 ///
-/// **Transitional single-client projection** (#391 commit 2a): still
-/// shaped like the pre-multi-client struct, populated from
-/// [`ClientRegistry::snapshot`] via [`project_to_legacy_stats`]. The
-/// "first connected client" fills the per-session fields; second/third
-/// clients are invisible to this view. Commit 2b replaces this with
-/// a per-client `Vec<ClientInfo>` schema and updates all in-tree
-/// consumers (Linux UI + sdr-ffi + C header) in the same change.
+/// Multi-client shape (#391). Every connected client contributes an
+/// entry to [`Self::connected_clients`]; per-session counters
+/// (bytes_sent, commanded state, etc.) live on each [`ClientInfo`].
+/// Aggregate counters at the top level are cumulative over the
+/// server's lifetime — never reset — so UI consumers can compute
+/// rolling deltas across snapshots without having to sum the
+/// per-client vec.
 ///
-/// UI callers snapshot the struct via `Server::stats()` on a timer
-/// and compute deltas (e.g. data-rate) across consecutive snapshots.
+/// UI callers snapshot the struct via `Server::stats()` on a timer.
+/// Data-rate is the delta in [`Self::total_bytes_sent`] between
+/// consecutive snapshots, divided by the poll interval.
 #[derive(Debug, Clone, Default)]
 pub struct ServerStats {
-    /// Socket address of the first connected client. `None` means no
-    /// clients are connected.
-    pub connected_client: Option<SocketAddr>,
-    /// Wall-clock moment the first client's session began. Paired
-    /// with `connected_client`: both are `Some` or both are `None`.
-    pub connected_since: Option<Instant>,
-    /// Bytes written to the first client's TCP socket for the current
-    /// session. Only reflects one client's traffic in commit 2a — the
-    /// total-across-all-clients rendering ships in 2b.
-    pub bytes_sent: u64,
-    /// Buffer-drop count for the first client. Per-client counter;
-    /// other clients' drops are invisible to this view.
-    pub buffers_dropped: u64,
-    /// Most recent command dispatched for the first client.
-    pub last_command: Option<(CommandOp, Instant)>,
-    /// First client's most recent `SetCenterFreq` request, in Hz.
-    pub current_freq_hz: Option<u32>,
-    /// First client's most recent `SetSampleRate` request, in Hz.
-    pub current_sample_rate_hz: Option<u32>,
-    /// First client's most recent `SetTunerGain` request, in tenths
-    /// of dB.
-    pub current_gain_tenths_db: Option<i32>,
-    /// First client's most recent `SetGainMode` request.
-    pub current_gain_auto: Option<bool>,
-    /// Ring buffer of the first client's recent commands. Bounded at
-    /// [`RECENT_COMMANDS_CAPACITY`].
-    pub recent_commands: VecDeque<(CommandOp, Instant)>,
+    /// Snapshot of every currently-connected client. Includes
+    /// slots that disconnected between the last broadcaster prune
+    /// tick and this snapshot — they render as "just left" for one
+    /// poll cycle before disappearing. Order is oldest-first.
+    pub connected_clients: Vec<crate::broadcaster::ClientInfo>,
+    /// Cumulative bytes fanned out across all clients over the
+    /// server's lifetime. Monotonic — never reset. UI derives the
+    /// rolling data-rate as `(stats[t].total_bytes_sent -
+    /// stats[t-1].total_bytes_sent) / poll_interval`.
+    pub total_bytes_sent: u64,
+    /// Cumulative USB chunks dropped across all clients over the
+    /// server's lifetime. A drop is counted when the broadcaster's
+    /// `try_send` into a client's channel returns `Full` (that
+    /// client's listener stalled). Monotonic — never reset.
+    pub total_buffers_dropped: u64,
+    /// Cumulative count of clients accepted over the server's
+    /// lifetime (including clients that have since disconnected).
+    /// UI renders as "N clients served" / "N sessions since start"
+    /// style load diagnostics.
+    pub lifetime_accepted: u64,
 }
 
 /// Tuner metadata captured at open time, exposed for callers that
@@ -357,14 +350,20 @@ impl Server {
         })
     }
 
-    /// Current server statistics (transitional single-client projection).
+    /// Current server statistics.
     ///
-    /// Projects the [`ClientRegistry`] to the old `ServerStats` shape
-    /// via [`project_to_legacy_stats`] so commit 2a keeps the workspace
-    /// compiling. Commit 2b swaps this for a per-client `Vec<ClientInfo>`
-    /// API and updates every consumer in the same change.
+    /// Snapshots every connected client plus the cumulative
+    /// server-lifetime counters from the registry. Cheap — acquires
+    /// the registry's slot-list lock briefly, per-slot stats mutex
+    /// once each. UI consumers call this on their poll timer (~2 Hz)
+    /// and compute data-rate deltas across consecutive snapshots.
     pub fn stats(&self) -> ServerStats {
-        project_to_legacy_stats(&self.registry)
+        ServerStats {
+            connected_clients: self.registry.snapshot(),
+            total_bytes_sent: self.registry.total_bytes_sent(),
+            total_buffers_dropped: self.registry.total_buffers_dropped(),
+            lifetime_accepted: self.registry.lifetime_accepted(),
+        }
     }
 
     /// The address the server is bound to.
@@ -566,7 +565,10 @@ fn spawn_accept_thread(
 /// The caller (accept thread) moves on to the next accept.
 #[allow(
     clippy::too_many_arguments,
-    reason = "accept-time client setup fans state"
+    clippy::too_many_lines,
+    reason = "accept-time client setup fans state across handshake + registry + \
+              two worker threads; refactoring to a context struct would churn the \
+              accept path without improving clarity"
 )]
 fn spawn_client_workers(
     stream: TcpStream,
@@ -774,40 +776,6 @@ fn set_keepalive(_stream: &TcpStream, _on: bool) -> std::io::Result<()> {
         std::io::ErrorKind::Unsupported,
         "SO_KEEPALIVE not implemented on this platform",
     ))
-}
-
-/// **Transitional**: project the multi-client registry snapshot into
-/// the legacy single-client [`ServerStats`] shape so commit 2a of
-/// #391 can land without breaking downstream consumers. Takes the
-/// oldest-still-connected client as "the client" for every
-/// per-session field, and zeroes everything else when no clients
-/// are connected.
-///
-/// Commit 2b replaces this with a direct `Vec<ClientInfo>` on
-/// `ServerStats` and updates every consumer (Linux UI + FFI).
-fn project_to_legacy_stats(registry: &Arc<ClientRegistry>) -> ServerStats {
-    // `ClientRegistry::snapshot` includes disconnected-but-not-yet-
-    // pruned slots by design (so UI rows survive one poll tick
-    // after a client drops). The legacy projection picks the
-    // first-registered slot regardless — commit 2b introduces a
-    // per-client Vec where disconnected slots render with a "just
-    // left" hint explicitly.
-    let clients = registry.snapshot();
-    let Some(first) = clients.into_iter().next() else {
-        return ServerStats::default();
-    };
-    ServerStats {
-        connected_client: Some(first.peer),
-        connected_since: Some(first.connected_since),
-        bytes_sent: first.bytes_sent,
-        buffers_dropped: first.buffers_dropped,
-        last_command: first.last_command,
-        current_freq_hz: first.current_freq_hz,
-        current_sample_rate_hz: first.current_sample_rate_hz,
-        current_gain_tenths_db: first.current_gain_tenths_db,
-        current_gain_auto: first.current_gain_auto,
-        recent_commands: first.recent_commands,
-    }
 }
 
 /// How long the server waits on a fresh TCP connection for a
@@ -1248,18 +1216,12 @@ mod tests {
     }
 
     #[test]
-    fn server_stats_default_is_not_connected() {
+    fn server_stats_default_is_empty() {
         let stats = ServerStats::default();
-        assert!(stats.connected_client.is_none());
-        assert!(stats.connected_since.is_none());
-        assert_eq!(stats.bytes_sent, 0);
-        assert_eq!(stats.buffers_dropped, 0);
-        assert!(stats.last_command.is_none());
-        assert!(stats.current_freq_hz.is_none());
-        assert!(stats.current_sample_rate_hz.is_none());
-        assert!(stats.current_gain_tenths_db.is_none());
-        assert!(stats.current_gain_auto.is_none());
-        assert!(stats.recent_commands.is_empty());
+        assert!(stats.connected_clients.is_empty());
+        assert_eq!(stats.total_bytes_sent, 0);
+        assert_eq!(stats.total_buffers_dropped, 0);
+        assert_eq!(stats.lifetime_accepted, 0);
     }
 
     #[test]
@@ -1292,27 +1254,14 @@ mod tests {
     }
 
     #[test]
-    fn project_to_legacy_stats_empty_registry_returns_default() {
-        // No clients connected → the legacy-shape projection must
-        // return the same zero-filled struct a fresh
-        // `ServerStats::default()` returns. Guards the UI's
-        // "Waiting for client" rendering: a non-None connected_client
-        // in the projection would be a phantom client.
-        let registry = Arc::new(ClientRegistry::new());
-        let stats = project_to_legacy_stats(&registry);
-        let expected = ServerStats::default();
-        assert_eq!(stats.connected_client, expected.connected_client);
-        assert_eq!(stats.bytes_sent, expected.bytes_sent);
-        assert_eq!(stats.buffers_dropped, expected.buffers_dropped);
-        assert!(stats.recent_commands.is_empty());
-    }
-
-    #[test]
-    fn project_to_legacy_stats_picks_first_registered_client() {
-        // Multiple clients → the projection returns the FIRST (oldest)
-        // registered client's session fields. Second+ clients are
-        // invisible in the legacy shape; commit 2b makes all clients
-        // visible via `Vec<ClientInfo>`.
+    fn server_stats_exposes_all_connected_clients() {
+        // Multi-client shape: `connected_clients` carries one
+        // `ClientInfo` per registered slot. Different from the
+        // pre-#391 single-client projection which only exposed the
+        // first client's session fields. This test pins the
+        // contract that every registered slot is visible to the
+        // UI / FFI — critical for the per-client rendering that
+        // follows in PR B.
         use crate::broadcaster::ClientSlot;
         let registry = Arc::new(ClientRegistry::new());
 
@@ -1340,14 +1289,28 @@ mod tests {
         }
         registry.register(slot_b);
 
-        let stats = project_to_legacy_stats(&registry);
-        // First client's peer + session fields.
+        // Snapshot via the registry directly since we don't have a
+        // real Server here — the same code path `Server::stats`
+        // uses to build its `ServerStats`.
+        let stats = ServerStats {
+            connected_clients: registry.snapshot(),
+            total_bytes_sent: registry.total_bytes_sent(),
+            total_buffers_dropped: registry.total_buffers_dropped(),
+            lifetime_accepted: registry.lifetime_accepted(),
+        };
+
+        assert_eq!(stats.connected_clients.len(), 2);
         assert_eq!(
-            stats.connected_client,
-            Some(SocketAddr::from(([127, 0, 0, 1], 42_001)))
+            stats.connected_clients[0].peer,
+            SocketAddr::from(([127, 0, 0, 1], 42_001))
         );
-        assert_eq!(stats.bytes_sent, 100);
-        assert_eq!(stats.current_freq_hz, Some(145_500_000));
+        assert_eq!(stats.connected_clients[0].bytes_sent, 100);
+        assert_eq!(
+            stats.connected_clients[1].peer,
+            SocketAddr::from(([127, 0, 0, 1], 42_002))
+        );
+        assert_eq!(stats.connected_clients[1].codec, Codec::Lz4);
+        assert_eq!(stats.lifetime_accepted, 2);
     }
 
     // ============================================================

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -237,6 +237,16 @@ pub struct ServerStats {
     /// UI renders as "N clients served" / "N sessions since start"
     /// style load diagnostics.
     pub lifetime_accepted: u64,
+    /// Snapshot of the server's configured initial device state —
+    /// the values `apply_initial_state` set at `Server::start`.
+    /// UI uses these as the fallback when a client hasn't yet
+    /// issued a `SetCenterFreq` / `SetSampleRate` / `SetTunerGain`
+    /// command: `current_*` fields on a `ClientInfo` mean "what
+    /// the client asked for"; unset means "still on the server's
+    /// initial", which is a different rendering than "server's
+    /// baked-in crate defaults". Per CodeRabbit round 1 on
+    /// PR #402.
+    pub initial: InitialDeviceState,
 }
 
 /// Tuner metadata captured at open time, exposed for callers that
@@ -261,6 +271,12 @@ pub struct Server {
     bind: SocketAddr,
     tuner: TunerAdvertiseInfo,
     compression: crate::codec::CodecMask,
+    /// Snapshot of the `InitialDeviceState` that `apply_initial_state`
+    /// actually applied at start. Cloned from `ServerConfig.initial`
+    /// and stashed here so `Server::stats()` can include it without
+    /// re-reading the (mutating) live device state. UI consumers use
+    /// it as the fallback for unset per-client `current_*` fields.
+    initial: InitialDeviceState,
 }
 
 impl Server {
@@ -328,7 +344,7 @@ impl Server {
         let broadcaster_thread =
             spawn_broadcaster_thread(dev_mutex.clone(), registry.clone(), shutdown.clone())?;
 
-        let accept_thread = spawn_accept_thread(
+        let accept_thread = match spawn_accept_thread(
             listener,
             dev_mutex,
             registry.clone(),
@@ -336,7 +352,22 @@ impl Server {
             stopped.clone(),
             per_client_depth,
             config.compression,
-        )?;
+        ) {
+            Ok(h) => h,
+            Err(e) => {
+                // Accept-thread spawn failed AFTER the broadcaster
+                // was already running. Signal global shutdown so
+                // the broadcaster exits its USB read loop, join
+                // it so its `Arc<Mutex<RtlSdrDevice>>` clone
+                // drops, THEN surface the error. Without this the
+                // broadcaster would keep reading USB against a
+                // dongle the caller expects to be released. Per
+                // CodeRabbit round 1 on PR #402.
+                shutdown.store(true, Ordering::SeqCst);
+                let _ = broadcaster_thread.join();
+                return Err(ServerError::Io(e));
+            }
+        };
 
         Ok(Server {
             shutdown,
@@ -347,6 +378,7 @@ impl Server {
             bind: actual_bind,
             tuner,
             compression: config.compression,
+            initial: config.initial,
         })
     }
 
@@ -363,6 +395,7 @@ impl Server {
             total_bytes_sent: self.registry.total_bytes_sent(),
             total_buffers_dropped: self.registry.total_buffers_dropped(),
             lifetime_accepted: self.registry.lifetime_accepted(),
+            initial: self.initial.clone(),
         }
     }
 
@@ -398,36 +431,60 @@ impl Server {
         self.stopped.load(Ordering::Relaxed)
     }
 
-    /// Signal shutdown and wait for both the accept and broadcaster
-    /// threads to exit.
+    /// Signal shutdown and wait for every owned thread to exit —
+    /// accept, broadcaster, and every per-client worker
+    /// (writer + command). Equivalent to dropping the `Server`.
     ///
-    /// Equivalent to dropping the `Server`. Any panic from either
-    /// thread is silently swallowed — if you need to observe panics,
-    /// keep the `JoinHandle` yourself instead of calling `stop()`.
+    /// Joining the per-client workers is **load-bearing**: each
+    /// holds an `Arc<Mutex<RtlSdrDevice>>` clone, and dropping
+    /// `Server` without joining them would let those Arcs outlive
+    /// the reported shutdown — leaving the dongle claimed for the
+    /// next consumer. Per `CodeRabbit` round 1 on PR #402.
+    ///
+    /// Any panic from a worker thread is silently swallowed — if
+    /// you need to observe panics, keep the handle yourself
+    /// instead of routing through `Server`.
     pub fn stop(mut self) {
         self.initiate_shutdown();
+        self.join_all_threads();
+    }
+
+    fn initiate_shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    /// Drain + join every owned thread. Called by both `stop()`
+    /// and `Drop`. The order is:
+    ///   1. accept thread — stop accepting new clients first so the
+    ///      per-client worker set can't grow mid-shutdown.
+    ///   2. per-client workers — their `Arc<Mutex<RtlSdrDevice>>`
+    ///      clones must drop before the broadcaster exits so the
+    ///      last Arc hits zero and the device is released.
+    ///   3. broadcaster thread — exits once the shutdown flag is
+    ///      set; owns its own USB handle clone that's dropped
+    ///      on return.
+    ///
+    /// After this returns, no thread the Server spawned is still
+    /// running, and the device mutex's strong-ref count is
+    /// guaranteed to be zero (the inner `Device` is dropped
+    /// with `dev_mutex` when the `Server` itself is dropped).
+    fn join_all_threads(&mut self) {
         if let Some(h) = self.accept_thread.take() {
+            let _ = h.join();
+        }
+        for h in self.registry.drain_worker_handles() {
             let _ = h.join();
         }
         if let Some(h) = self.broadcaster_thread.take() {
             let _ = h.join();
         }
-    }
-
-    fn initiate_shutdown(&self) {
-        self.shutdown.store(true, Ordering::SeqCst);
     }
 }
 
 impl Drop for Server {
     fn drop(&mut self) {
         self.initiate_shutdown();
-        if let Some(h) = self.accept_thread.take() {
-            let _ = h.join();
-        }
-        if let Some(h) = self.broadcaster_thread.take() {
-            let _ = h.join();
-        }
+        self.join_all_threads();
     }
 }
 
@@ -674,6 +731,7 @@ fn spawn_client_workers(
     let tracked_writer = StatsTrackingWrite {
         inner: writer,
         slot: slot.clone(),
+        registry: registry.clone(),
     };
     let encoded_writer = Encoder::new(codec, tracked_writer);
     let writer_handle = match thread::Builder::new()
@@ -689,12 +747,13 @@ fn spawn_client_workers(
     };
 
     // Spawn the command thread. If it fails, mark the slot
-    // disconnected so the writer exits too — don't leak it.
+    // disconnected so the writer exits too, and join the writer
+    // here so its handle isn't dropped on the floor.
     let command_slot = slot.clone();
     let command_shutdown = shutdown.clone();
     let command_device = device;
     let command_stream = stream;
-    let command_result = thread::Builder::new()
+    let command_handle = match thread::Builder::new()
         .name(format!("rtl_tcp-command-{id}"))
         .spawn(move || {
             command_worker(
@@ -703,13 +762,15 @@ fn spawn_client_workers(
                 command_slot,
                 command_shutdown,
             );
-        });
-    if let Err(e) = command_result {
-        tracing::error!(%peer, %e, "failed to spawn rtl_tcp command thread — tearing down client");
-        slot.mark_disconnected();
-        let _ = writer_handle.join();
-        return;
-    }
+        }) {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!(%peer, %e, "failed to spawn rtl_tcp command thread — tearing down client");
+            slot.mark_disconnected();
+            let _ = writer_handle.join();
+            return;
+        }
+    };
 
     // All three threads (writer, command, broadcaster-observing-this-slot)
     // are now set up. Register the slot so the broadcaster starts
@@ -717,6 +778,14 @@ fn spawn_client_workers(
     // the broadcaster can't find the slot; after register, the
     // broadcaster discovers it on its next tick.
     registry.register(slot);
+
+    // Park both worker handles on the registry so `Server::drop` can
+    // join them during shutdown — without this, the threads'
+    // `Arc<Mutex<RtlSdrDevice>>` clones could outlive
+    // `has_stopped() == true` and leave the dongle claimed for a
+    // follow-up `Server::start`. Per `CodeRabbit` round 1 on PR #402.
+    registry.register_worker_handle(writer_handle);
+    registry.register_worker_handle(command_handle);
 
     // Fire and forget — neither the writer nor the command handle is
     // joined here. Both exit independently when they observe the
@@ -886,25 +955,34 @@ fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHe
 }
 
 /// `Write` adapter sitting between the negotiated `Encoder` and the
-/// raw `TcpStream`. Updates the slot's per-client `bytes_sent` counter
-/// with the on-wire (post-compression) byte count from each
-/// successful write, so the UI's data-rate row reflects actual
-/// bandwidth rather than pre-compression payload size.
+/// raw `TcpStream`. Updates the slot's per-client `bytes_sent`
+/// counter AND the registry's aggregate `total_bytes_sent` with
+/// the on-wire (post-compression) byte count from each successful
+/// write. Counting at this layer (not inside `ClientRegistry::broadcast`)
+/// means the aggregate and per-client counters never diverge and
+/// both reflect bytes that actually reached the socket. Per
+/// CodeRabbit round 1 on PR #402.
 struct StatsTrackingWrite {
     inner: TcpStream,
     slot: Arc<ClientSlot>,
+    registry: Arc<ClientRegistry>,
 }
 
 impl Write for StatsTrackingWrite {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let n = self.inner.write(buf)?;
+        let delta = n as u64;
         // Poisoned mutex only happens if a stats reader panicked
         // while holding the lock — keep streaming and let the
         // stats drift; a crashed UI thread is worse than a dropped
         // counter bump.
         if let Ok(mut s) = self.slot.stats.lock() {
-            s.bytes_sent = s.bytes_sent.saturating_add(n as u64);
+            s.bytes_sent = s.bytes_sent.saturating_add(delta);
         }
+        // Aggregate tracks the sum of every successful on-wire
+        // write. Cheap atomic fetch_add; no lock contention with
+        // other writers or the UI snapshot path.
+        self.registry.record_bytes_sent(delta);
         Ok(n)
     }
 
@@ -1222,6 +1300,9 @@ mod tests {
         assert_eq!(stats.total_bytes_sent, 0);
         assert_eq!(stats.total_buffers_dropped, 0);
         assert_eq!(stats.lifetime_accepted, 0);
+        // Default initial state matches the upstream rtl_tcp defaults.
+        assert_eq!(stats.initial.center_freq_hz, DEFAULT_CENTER_FREQ_HZ);
+        assert_eq!(stats.initial.sample_rate_hz, DEFAULT_SAMPLE_RATE_HZ);
     }
 
     #[test]
@@ -1297,6 +1378,7 @@ mod tests {
             total_bytes_sent: registry.total_bytes_sent(),
             total_buffers_dropped: registry.total_buffers_dropped(),
             lifetime_accepted: registry.lifetime_accepted(),
+            initial: InitialDeviceState::default(),
         };
 
         assert_eq!(stats.connected_clients.len(), 2);

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -217,10 +217,15 @@ impl Default for InitialDeviceState {
 /// consecutive snapshots, divided by the poll interval.
 #[derive(Debug, Clone, Default)]
 pub struct ServerStats {
-    /// Snapshot of every currently-connected client. Includes
-    /// slots that disconnected between the last broadcaster prune
-    /// tick and this snapshot — they render as "just left" for one
-    /// poll cycle before disappearing. Order is oldest-first.
+    /// Live-only snapshot of every currently-connected client.
+    /// Disconnected-but-not-yet-pruned slots are filtered out at
+    /// the registry layer (see `ClientRegistry::snapshot`), so
+    /// this Vec never contains dead sessions — UI and FFI
+    /// consumers can treat every entry as a peer that was
+    /// actively reachable at snapshot time. Order is oldest-first
+    /// by connect time. Per `CodeRabbit` round 2 on PR #402
+    /// (switched to live-only filtering) + round 3 (doc
+    /// alignment with the new contract).
     pub connected_clients: Vec<crate::broadcaster::ClientInfo>,
     /// Cumulative bytes fanned out across all clients over the
     /// server's lifetime. Monotonic — never reset. UI derives the

--- a/crates/sdr-server-rtltcp/tests/multi_client_fanout.rs
+++ b/crates/sdr-server-rtltcp/tests/multi_client_fanout.rs
@@ -55,6 +55,28 @@ const CONSUMER_RECV_TIMEOUT: Duration = Duration::from_millis(50);
 /// a test timeout instead of hanging the suite indefinitely.
 const TEST_WALL_CLOCK_CEILING: Duration = Duration::from_secs(5);
 
+/// Delay between producer broadcasts. Lets consumers get a chance
+/// to drain — without this, the producer burns through its loop
+/// faster than any single-slot channel can consume, defeating the
+/// "fast drain" assertions. Per `CodeRabbit` round 1 on PR #402.
+const PRODUCER_YIELD_DELAY: Duration = Duration::from_millis(1);
+
+/// How long the disconnect-scheduler test waits before marking a
+/// slot disconnected. Short enough that at least one chunk has
+/// broadcast by then, long enough that the producer thread has
+/// actually started its loop (spawn has non-zero cost). 3 ms sits
+/// comfortably above both bounds on any real CI runner.
+const DISCONNECT_DELAY: Duration = Duration::from_millis(3);
+
+/// Test peer ports. Each test uses a disjoint pair so logs
+/// pinpoint which test generated which peer.
+const TEST_PEER_A_PORT: u16 = 10_001;
+const TEST_PEER_B_PORT: u16 = 10_002;
+const TEST_SLOW_PEER_PORT: u16 = 10_100;
+const TEST_FAST_PEER_PORT: u16 = 10_101;
+const TEST_DISCONNECT_A_PORT: u16 = 10_200;
+const TEST_DISCONNECT_B_PORT: u16 = 10_201;
+
 fn test_peer(port: u16) -> SocketAddr {
     SocketAddr::from(([127, 0, 0, 1], port))
 }
@@ -77,12 +99,9 @@ fn spawn_test_producer(registry: Arc<ClientRegistry>) -> (thread::JoinHandle<()>
                 let idx_u32 = u32::try_from(i).expect("chunk count fits u32");
                 chunk[..4].copy_from_slice(&idx_u32.to_be_bytes());
                 registry.broadcast(&chunk);
-                // Yield briefly so consumers get a chance to drain
-                // between broadcasts. Without this the producer
-                // would burn through its full loop faster than any
-                // single-slot channel could drain, defeating the
-                // "fast drain" scenarios.
-                thread::sleep(Duration::from_millis(1));
+                // Yield so consumers get a drain window between
+                // broadcasts — see PRODUCER_YIELD_DELAY's docstring.
+                thread::sleep(PRODUCER_YIELD_DELAY);
             }
             done_setter.store(true, Ordering::SeqCst);
         })
@@ -132,13 +151,13 @@ fn two_clients_receive_identical_byte_streams() {
 
     let (slot_a, rx_a) = ClientSlot::new(
         registry.allocate_id(),
-        test_peer(1),
+        test_peer(TEST_PEER_A_PORT),
         Codec::None,
         TEST_FAST_CHANNEL_DEPTH,
     );
     let (slot_b, rx_b) = ClientSlot::new(
         registry.allocate_id(),
-        test_peer(2),
+        test_peer(TEST_PEER_B_PORT),
         Codec::None,
         TEST_FAST_CHANNEL_DEPTH,
     );
@@ -205,14 +224,14 @@ fn slow_client_drops_do_not_block_fast_client() {
 
     let (slow, _slow_rx) = ClientSlot::new(
         registry.allocate_id(),
-        test_peer(100),
+        test_peer(TEST_SLOW_PEER_PORT),
         Codec::None,
         TEST_SLOW_CHANNEL_DEPTH,
     );
     let slow_id = slow.id;
     let (fast, fast_rx) = ClientSlot::new(
         registry.allocate_id(),
-        test_peer(101),
+        test_peer(TEST_FAST_PEER_PORT),
         Codec::None,
         TEST_FAST_CHANNEL_DEPTH,
     );
@@ -287,13 +306,13 @@ fn disconnected_client_is_skipped_by_broadcaster_fanout() {
     let registry = Arc::new(ClientRegistry::new());
     let (slot_a, rx_a) = ClientSlot::new(
         registry.allocate_id(),
-        test_peer(200),
+        test_peer(TEST_DISCONNECT_A_PORT),
         Codec::None,
         TEST_FAST_CHANNEL_DEPTH,
     );
-    let (slot_b, _rx_b) = ClientSlot::new(
+    let (slot_b, rx_b) = ClientSlot::new(
         registry.allocate_id(),
-        test_peer(201),
+        test_peer(TEST_DISCONNECT_B_PORT),
         Codec::None,
         TEST_FAST_CHANNEL_DEPTH,
     );
@@ -305,15 +324,23 @@ fn disconnected_client_is_skipped_by_broadcaster_fanout() {
     // will have broadcast a few chunks by then; subsequent chunks
     // skip B entirely.
     let disconnector = thread::spawn(move || {
-        thread::sleep(Duration::from_millis(3));
+        thread::sleep(DISCONNECT_DELAY);
         slot_b_handle.mark_disconnected();
     });
 
     let (producer, producer_done) = spawn_test_producer(registry.clone());
-    let done = producer_done.clone();
-    let consumer_a = thread::spawn(move || drain_until_done(&rx_a, &done));
+    let done_a = producer_done.clone();
+    let done_b = producer_done.clone();
+    let consumer_a = thread::spawn(move || drain_until_done(&rx_a, &done_a));
+    // Drain B too so we can prove it received FEWER chunks than A
+    // (the broadcaster actually skipped it post-disconnect). Per
+    // CodeRabbit round 1 on PR #402 — the original test only
+    // checked A, which passes even if B kept receiving every
+    // chunk despite being disconnected.
+    let consumer_b = thread::spawn(move || drain_until_done(&rx_b, &done_b));
 
     let received_a = consumer_a.join().expect("consumer a joined");
+    let received_b = consumer_b.join().expect("consumer b joined");
     producer.join().expect("producer joined");
     disconnector.join().expect("disconnector joined");
 
@@ -324,5 +351,13 @@ fn disconnected_client_is_skipped_by_broadcaster_fanout() {
          (got {}/{})",
         received_a.len(),
         TEST_CHUNK_COUNT
+    );
+    assert!(
+        received_b.len() < received_a.len(),
+        "client B should receive fewer chunks than A (got B={}/{}, A={}) — \
+         if they match, the broadcaster is still sending to disconnected slots",
+        received_b.len(),
+        TEST_CHUNK_COUNT,
+        received_a.len()
     );
 }

--- a/crates/sdr-server-rtltcp/tests/multi_client_fanout.rs
+++ b/crates/sdr-server-rtltcp/tests/multi_client_fanout.rs
@@ -1,0 +1,328 @@
+//! Integration tests for the multi-client fan-out broadcaster
+//! (#391). The real [`Server`] needs a USB-attached RTL-SDR dongle
+//! to start, so these tests drive [`ClientRegistry`] directly — one
+//! producer thread feeding N consumer threads, each draining their
+//! own slot's receiver. Validates the per-client drop isolation
+//! guarantee that's the whole point of the per-client-channel
+//! design: one stalled listener can't block the controller or the
+//! other listeners.
+//!
+//! Kept out of the in-lib unit tests because they spawn threads
+//! and coordinate over mpsc channels with timeouts; putting them in
+//! `tests/` means they run with `cargo test --test
+//! multi_client_fanout` without slowing the inner unit test pass.
+//!
+//! [`Server`]: sdr_server_rtltcp::Server
+//! [`ClientRegistry`]: sdr_server_rtltcp::broadcaster::ClientRegistry
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use sdr_server_rtltcp::broadcaster::{ClientRegistry, ClientSlot};
+use sdr_server_rtltcp::codec::Codec;
+
+/// How many distinct chunks the producer thread fans out in each
+/// test. 32 is small enough for tests to finish quickly, large
+/// enough to exercise per-client ordering under the default
+/// 500-slot channel.
+const TEST_CHUNK_COUNT: usize = 32;
+
+/// Bytes per fanned-out chunk. 64 is plenty to catch any
+/// truncation / offset bug and keeps allocation noise low.
+const TEST_CHUNK_LEN: usize = 64;
+
+/// Per-client channel depth for the "fast both" tests. Generous
+/// enough that neither receiver fills under the test's 32-chunk
+/// load.
+const TEST_FAST_CHANNEL_DEPTH: usize = 64;
+
+/// Per-client channel depth for the "slow client" test. Small so a
+/// client that never reads fills after a few chunks and the
+/// producer starts accounting drops against it.
+const TEST_SLOW_CHANNEL_DEPTH: usize = 4;
+
+/// How long a consumer waits per `recv_timeout` tick before
+/// re-checking whether the producer has finished. Short enough
+/// that test wall-clock stays small, long enough to absorb
+/// scheduling jitter on CI runners.
+const CONSUMER_RECV_TIMEOUT: Duration = Duration::from_millis(50);
+
+/// Wall-clock ceiling on each test. Hard stop so a broken
+/// synchronization bug that would otherwise deadlock surfaces as
+/// a test timeout instead of hanging the suite indefinitely.
+const TEST_WALL_CLOCK_CEILING: Duration = Duration::from_secs(5);
+
+fn test_peer(port: u16) -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], port))
+}
+
+/// Build a producer thread that calls `registry.broadcast(&chunk)`
+/// `TEST_CHUNK_COUNT` times with a deterministic byte pattern per
+/// chunk (`chunk[0..4] = be_bytes(i)`, rest = 0xAB), then signals
+/// done via the returned `AtomicBool`.
+fn spawn_test_producer(registry: Arc<ClientRegistry>) -> (thread::JoinHandle<()>, Arc<AtomicBool>) {
+    let done = Arc::new(AtomicBool::new(false));
+    let done_setter = done.clone();
+    let handle = thread::Builder::new()
+        .name("test-producer".into())
+        .spawn(move || {
+            for i in 0..TEST_CHUNK_COUNT {
+                let mut chunk = vec![0xABu8; TEST_CHUNK_LEN];
+                // Stamp the chunk index into the leading 4 bytes
+                // so consumers can verify ordering. `TEST_CHUNK_COUNT`
+                // fits well inside `u32::MAX` (test-only constant).
+                let idx_u32 = u32::try_from(i).expect("chunk count fits u32");
+                chunk[..4].copy_from_slice(&idx_u32.to_be_bytes());
+                registry.broadcast(&chunk);
+                // Yield briefly so consumers get a chance to drain
+                // between broadcasts. Without this the producer
+                // would burn through its full loop faster than any
+                // single-slot channel could drain, defeating the
+                // "fast drain" scenarios.
+                thread::sleep(Duration::from_millis(1));
+            }
+            done_setter.store(true, Ordering::SeqCst);
+        })
+        .expect("spawn test producer");
+    (handle, done)
+}
+
+/// Drain `rx` until either `TEST_CHUNK_COUNT` chunks have been
+/// received OR `producer_done` is set AND the channel is empty.
+/// Returns the collected chunks in arrival order. Borrows the
+/// receiver so the caller retains ownership for lifecycle
+/// management (e.g. moving into a spawned thread via a closure).
+fn drain_until_done(
+    rx: &std::sync::mpsc::Receiver<Vec<u8>>,
+    producer_done: &Arc<AtomicBool>,
+) -> Vec<Vec<u8>> {
+    let mut received = Vec::with_capacity(TEST_CHUNK_COUNT);
+    let deadline = Instant::now() + TEST_WALL_CLOCK_CEILING;
+    while received.len() < TEST_CHUNK_COUNT && Instant::now() < deadline {
+        match rx.recv_timeout(CONSUMER_RECV_TIMEOUT) {
+            Ok(buf) => received.push(buf),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                if producer_done.load(Ordering::SeqCst) {
+                    // Producer is done; drain remaining backlog
+                    // non-blockingly until empty.
+                    while let Ok(buf) = rx.try_recv() {
+                        received.push(buf);
+                    }
+                    break;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    received
+}
+
+#[test]
+fn two_clients_receive_identical_byte_streams() {
+    // Two clients with generous channel depths. Producer broadcasts
+    // 32 chunks; both consumers drain in parallel. Every chunk
+    // should land in both clients' receive buffers in the same
+    // order — per-client channels mean the broadcaster fans out
+    // identical payloads, and each consumer gets its own Vec
+    // clone.
+    let registry = Arc::new(ClientRegistry::new());
+
+    let (slot_a, rx_a) = ClientSlot::new(
+        registry.allocate_id(),
+        test_peer(1),
+        Codec::None,
+        TEST_FAST_CHANNEL_DEPTH,
+    );
+    let (slot_b, rx_b) = ClientSlot::new(
+        registry.allocate_id(),
+        test_peer(2),
+        Codec::None,
+        TEST_FAST_CHANNEL_DEPTH,
+    );
+    registry.register(slot_a);
+    registry.register(slot_b);
+
+    let (producer, producer_done) = spawn_test_producer(registry.clone());
+
+    // Drain both consumers on separate threads so the test
+    // exercises the concurrent case (both drains happening while
+    // the producer is mid-loop) rather than serializing them.
+    let done_a = producer_done.clone();
+    let done_b = producer_done.clone();
+    let consumer_a = thread::spawn(move || drain_until_done(&rx_a, &done_a));
+    let consumer_b = thread::spawn(move || drain_until_done(&rx_b, &done_b));
+
+    let received_a = consumer_a.join().expect("consumer a joined");
+    let received_b = consumer_b.join().expect("consumer b joined");
+    producer.join().expect("producer joined");
+
+    assert_eq!(
+        received_a.len(),
+        TEST_CHUNK_COUNT,
+        "client A should receive every broadcast chunk (got {}/{})",
+        received_a.len(),
+        TEST_CHUNK_COUNT
+    );
+    assert_eq!(
+        received_b.len(),
+        TEST_CHUNK_COUNT,
+        "client B should receive every broadcast chunk (got {}/{})",
+        received_b.len(),
+        TEST_CHUNK_COUNT
+    );
+    // Byte-for-byte equality across all 32 chunks — proves the
+    // broadcaster clones the same payload to each slot rather
+    // than mutating it for one client.
+    assert_eq!(
+        received_a, received_b,
+        "both clients must see the same ordered byte stream"
+    );
+    // Ordering sanity: chunk i's leading 4 bytes encode `i` as
+    // big-endian u32. If the broadcaster ever reordered or
+    // dropped silently, this index sequence would break.
+    for (i, chunk) in received_a.iter().enumerate() {
+        let index = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        assert_eq!(index as usize, i, "chunk {i} has wrong index tag");
+    }
+}
+
+#[test]
+fn slow_client_drops_do_not_block_fast_client() {
+    // The core per-client isolation guarantee: one client's
+    // never-draining channel fills and starts dropping, but
+    // another client's drain keeps pace and sees every chunk.
+    //
+    // Setup:
+    //   - Slow client with a 4-slot channel, no consumer — the
+    //     broadcaster's `try_send` fills it in the first 4
+    //     chunks, then drops the remaining 28.
+    //   - Fast client with a 64-slot channel + a drain thread —
+    //     sees all 32 chunks in order.
+    let registry = Arc::new(ClientRegistry::new());
+
+    let (slow, _slow_rx) = ClientSlot::new(
+        registry.allocate_id(),
+        test_peer(100),
+        Codec::None,
+        TEST_SLOW_CHANNEL_DEPTH,
+    );
+    let slow_id = slow.id;
+    let (fast, fast_rx) = ClientSlot::new(
+        registry.allocate_id(),
+        test_peer(101),
+        Codec::None,
+        TEST_FAST_CHANNEL_DEPTH,
+    );
+    registry.register(slow);
+    registry.register(fast);
+
+    let (producer, producer_done) = spawn_test_producer(registry.clone());
+    let done_fast = producer_done.clone();
+    let fast_consumer = thread::spawn(move || drain_until_done(&fast_rx, &done_fast));
+
+    let received_fast = fast_consumer.join().expect("fast consumer joined");
+    producer.join().expect("producer joined");
+
+    // Fast client — should see every chunk despite the slow
+    // neighbor's drops.
+    assert_eq!(
+        received_fast.len(),
+        TEST_CHUNK_COUNT,
+        "fast client must receive every chunk regardless of slow neighbor stalling \
+         (got {}/{})",
+        received_fast.len(),
+        TEST_CHUNK_COUNT
+    );
+    for (i, chunk) in received_fast.iter().enumerate() {
+        let index = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        assert_eq!(
+            index as usize, i,
+            "fast client saw chunk {index} out of order at position {i}"
+        );
+    }
+
+    // Slow client — should have accumulated drops. Find its entry
+    // in the registry snapshot and assert a non-zero drop count.
+    let snap = registry.snapshot();
+    let slow_snap = snap
+        .iter()
+        .find(|c| c.id == slow_id)
+        .expect("slow client should still be in the registry");
+    assert!(
+        slow_snap.buffers_dropped > 0,
+        "slow client should have accrued drops (got {})",
+        slow_snap.buffers_dropped
+    );
+    // Aggregate counter matches — broadcaster's
+    // `total_buffers_dropped` should reflect the slow client's
+    // drops.
+    assert_eq!(
+        registry.total_buffers_dropped(),
+        slow_snap.buffers_dropped,
+        "aggregate drop counter should equal the slow client's drops when they're \
+         the only slow path"
+    );
+}
+
+#[test]
+fn disconnected_client_is_skipped_by_broadcaster_fanout() {
+    // A client marked disconnected mid-stream should be skipped on
+    // subsequent broadcasts — the broadcaster's `is_disconnected`
+    // check on each fan-out prevents wasted clone + try_send work,
+    // and the slot gets pruned on the next `prune_disconnected`
+    // sweep.
+    //
+    // Scenario:
+    //   - Two clients; A drains normally, B is marked disconnected
+    //     AFTER the first chunk arrives but BEFORE the producer
+    //     finishes.
+    //   - Expected: A sees all 32 chunks; B sees at most the first
+    //     few (received before disconnection was observed).
+    //   - Aggregate `total_bytes_sent` reflects only A's drain
+    //     + whatever B got before disconnection — not the full
+    //     32 × TEST_CHUNK_LEN × 2 we'd see if both fully received.
+    let registry = Arc::new(ClientRegistry::new());
+    let (slot_a, rx_a) = ClientSlot::new(
+        registry.allocate_id(),
+        test_peer(200),
+        Codec::None,
+        TEST_FAST_CHANNEL_DEPTH,
+    );
+    let (slot_b, _rx_b) = ClientSlot::new(
+        registry.allocate_id(),
+        test_peer(201),
+        Codec::None,
+        TEST_FAST_CHANNEL_DEPTH,
+    );
+    let slot_b_handle = slot_b.clone();
+    registry.register(slot_a);
+    registry.register(slot_b);
+
+    // Schedule B's disconnect a short delay in — the producer
+    // will have broadcast a few chunks by then; subsequent chunks
+    // skip B entirely.
+    let disconnector = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(3));
+        slot_b_handle.mark_disconnected();
+    });
+
+    let (producer, producer_done) = spawn_test_producer(registry.clone());
+    let done = producer_done.clone();
+    let consumer_a = thread::spawn(move || drain_until_done(&rx_a, &done));
+
+    let received_a = consumer_a.join().expect("consumer a joined");
+    producer.join().expect("producer joined");
+    disconnector.join().expect("disconnector joined");
+
+    assert_eq!(
+        received_a.len(),
+        TEST_CHUNK_COUNT,
+        "client A should receive every chunk even while B is disconnecting \
+         (got {}/{})",
+        received_a.len(),
+        TEST_CHUNK_COUNT
+    );
+}

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3414,23 +3414,71 @@ fn render_status_rows(
         |info| format_uptime(info.connected_since.elapsed()),
     ));
 
-    // Data-rate row. Uses the cumulative `total_bytes_sent` counter
-    // (monotonic across the server's lifetime) so the delta here
-    // reflects aggregate traffic across ALL clients. No clamping
-    // needed — monotonic means the delta is always >= 0.
+    // Data-rate row. Uses the cumulative `total_bytes_sent`
+    // counter, which is monotonic within a single Server lifetime.
+    // After a stop+start cycle the counter resets to 0 while
+    // `last_bytes_sent` still holds the previous server's final
+    // value — in that case `current < previous` is the restart
+    // signal: rebase `last_bytes_sent` to the new counter and
+    // report 0 bytes this tick rather than a bogus huge delta or
+    // a long "0.0 kbps" flatline until the new server catches up
+    // past the old final byte count. Per `CodeRabbit` round 2 on
+    // PR #402.
     let current_bytes = stats.total_bytes_sent;
-    let delta = current_bytes.saturating_sub(last_bytes_sent.get());
+    let previous_bytes = last_bytes_sent.get();
+    let delta = if current_bytes < previous_bytes {
+        // Restart detected — the new server has already
+        // accumulated `current_bytes` worth of traffic since its
+        // start, so that's the best available estimate for
+        // "bytes this tick". Reporting 0 or the saturating sub
+        // would flatline the row until the new server exceeds
+        // the old final count. Per `CodeRabbit` round 2 on
+        // PR #402.
+        current_bytes
+    } else {
+        current_bytes - previous_bytes
+    };
     last_bytes_sent.set(current_bytes);
     widgets
         .status_data_rate_row
         .set_subtitle(&format_data_rate(delta, SERVER_STATUS_POLL_INTERVAL));
 
-    // Commanded-state row — first client's state. Once #392's role
-    // gate lands this becomes "the controller's state" and the
-    // listener rows render with a "listening" badge instead.
+    // Commanded-state row — the most-recently-commanding client's
+    // state. Pre-#392 any connected client can send `SetX`
+    // commands, so picking the oldest client would let a later
+    // peer's tune show up as the oldest peer's "stale" state.
+    // `pick_most_recent_commander` resolves this by finding the
+    // client whose `last_command` timestamp is newest (falls back
+    // to the first connected client when nobody has commanded
+    // yet). Post-#392, role-gated dispatch means only the
+    // controller can record a command, so this helper naturally
+    // resolves to the controller. Per `CodeRabbit` round 2 on
+    // PR #402.
+    let commander = pick_most_recent_commander(&stats.connected_clients);
     widgets
         .status_commanded_row
-        .set_subtitle(&format_commanded_state(first, &stats.initial));
+        .set_subtitle(&format_commanded_state(commander, &stats.initial));
+}
+
+/// Select the client whose most recent `last_command` timestamp is
+/// newest. Falls back to the first connected client when nobody
+/// has issued a command yet, and to `None` when no clients are
+/// connected.
+///
+/// Shared between the commanded-state row and the activity-log
+/// renderer so both surfaces track the same "who's actually
+/// driving the dongle" peer. Pre-#392 this matters because any
+/// client can command; post-#392 role-gated dispatch will make
+/// this resolve to the controller every time.
+fn pick_most_recent_commander(
+    clients: &[sdr_server_rtltcp::ClientInfo],
+) -> Option<&sdr_server_rtltcp::ClientInfo> {
+    clients
+        .iter()
+        .filter_map(|c| c.last_command.map(|(_, t)| (c, t)))
+        .max_by_key(|&(_, t)| t)
+        .map(|(c, _)| c)
+        .or_else(|| clients.first())
 }
 
 /// Render a `Duration` as `Nh Nm Ns` / `Nm Ns` / `Ns` depending on
@@ -3535,19 +3583,20 @@ fn format_hz(hz: u32) -> String {
     }
 }
 
-/// Rebuild the activity-log list from the first connected client's
-/// `recent_commands` ring if it has actually changed since the last
-/// render. The "changed?" check uses the ring length + the
+/// Rebuild the activity-log list from the most-recently-commanding
+/// client's `recent_commands` ring if it has actually changed since
+/// the last render. The "changed?" check uses the ring length + the
 /// timestamp of the newest entry so we skip the clear-and-rebuild
 /// on idle ticks — preserves any scroll position the user has in
 /// the `ListBox`.
 ///
-/// Renders the FIRST client's activity log in #391 (PR A). PR B
-/// replaces this with a per-client log tab so each connected
-/// client's commands show under their own row. When #392's role
-/// gate lands, only the controller can issue commands — the
-/// activity log then implicitly means "controller's commands"
-/// regardless of which client that is at any given moment.
+/// Uses [`pick_most_recent_commander`] rather than just the first
+/// connected client because pre-#392 any client can send commands
+/// — the oldest client would shadow a newer peer's activity. Per
+/// `CodeRabbit` round 2 on PR #402. PR B of #391 replaces this with
+/// a per-client log tab so every client's commands show under
+/// their own row; until then, tracking "whoever's driving right
+/// now" is the right single-row compromise.
 fn render_activity_log(
     widgets: &ServerStatusWidgets,
     stats: &sdr_server_rtltcp::ServerStats,
@@ -3555,7 +3604,7 @@ fn render_activity_log(
 ) {
     use crate::sidebar::server_panel::ACTIVITY_LOG_EMPTY_SUBTITLE;
 
-    let Some(first_client) = stats.connected_clients.first() else {
+    let Some(commander) = pick_most_recent_commander(&stats.connected_clients) else {
         // No connected client → clear + show empty subtitle if
         // we're not already in that state. Track the idle cache
         // key as (0, None) so the render skips on subsequent
@@ -3574,7 +3623,7 @@ fn render_activity_log(
         return;
     };
     let ring: &std::collections::VecDeque<(sdr_server_rtltcp::CommandOp, Instant)> =
-        &first_client.recent_commands;
+        &commander.recent_commands;
 
     let newest = ring.back().map(|(_, t)| *t);
     let current_key = (ring.len(), newest);
@@ -5358,7 +5407,7 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
             // mapped any non-Network value to Local, which would
             // silently dispatch a sink swap on a transient or
             // future-added combo entry that this handler doesn't
-            // know about. Per CodeRabbit round 2 on PR #351.
+            // know about. Per `CodeRabbit` round 2 on PR #351.
             let new_type = match row.selected() {
                 sidebar::audio_panel::SINK_TYPE_LOCAL_IDX => sdr_core::AudioSinkType::Local,
                 sidebar::audio_panel::SINK_TYPE_NETWORK_IDX => sdr_core::AudioSinkType::Network,
@@ -6804,6 +6853,39 @@ mod server_panel_format_tests {
         format_uptime,
     };
 
+    // ============================================================
+    // Test fixture constants (`CodeRabbit` round 2 on PR #402).
+    // Names make each scenario's intent obvious at a glance:
+    // "is this testing 145 MHz 2m-band tune or 100 MHz WFM"
+    // reads clearer when the literal has a rationale.
+    // ============================================================
+
+    /// Placeholder peer port for `ClientInfo` fixtures that don't
+    /// exercise the peer address field — any non-privileged port
+    /// works, so pick one well above the well-known range.
+    const FIXTURE_PEER_PORT: u16 = 42_000;
+    /// 2-meter amateur band test frequency (145.5 MHz) — stands in
+    /// for "non-default freq the user commanded" in fallback tests.
+    const FIXTURE_FREQ_2M_HZ: u32 = 145_500_000;
+    /// 100 MHz WFM broadcast band test frequency — second sample
+    /// to catch tests that pass on the 2m fixture by coincidence.
+    const FIXTURE_FREQ_WFM_HZ: u32 = 100_000_000;
+    /// Typical RTL-SDR sample rate (2.4 Msps) — used across tune
+    /// fixtures.
+    const FIXTURE_SAMPLE_RATE_HZ: u32 = 2_400_000;
+    /// Mid-range tuner gain in tenths-of-dB (29.6 dB) — well
+    /// inside the R820T table so "auto vs manual" branches aren't
+    /// ambiguous.
+    const FIXTURE_GAIN_MID_TENTHS: i32 = 296;
+    /// Upper-range tuner gain in tenths-of-dB (49.6 dB) — matches
+    /// the R820T's documented top step so the "manual gain in dB"
+    /// formatter has a realistic ceiling value.
+    const FIXTURE_GAIN_TOP_TENTHS: i32 = 496;
+    /// Low-but-visible manual gain in tenths-of-dB (20 dB) —
+    /// used specifically in the "auto overrides manual" test to
+    /// prove the auto flag wins over any set value.
+    const FIXTURE_GAIN_LOW_TENTHS: i32 = 200;
+
     /// Fresh `InitialDeviceState` matching what `Server::start`
     /// stores when the user takes the upstream-default path. Most
     /// format tests use this; the ones that want to prove
@@ -6824,7 +6906,7 @@ mod server_panel_format_tests {
     ) -> ClientInfo {
         ClientInfo {
             id: 0,
-            peer: SocketAddr::from(([127, 0, 0, 1], 42_000)),
+            peer: SocketAddr::from(([127, 0, 0, 1], FIXTURE_PEER_PORT)),
             connected_since: Instant::now(),
             codec: Codec::None,
             bytes_sent: 0,
@@ -6909,9 +6991,9 @@ mod server_panel_format_tests {
         // client hasn't sent any SetX commands yet.
         // Per `CodeRabbit` round 1 on PR #402.
         let initial = InitialDeviceState {
-            center_freq_hz: 145_500_000,
-            sample_rate_hz: 2_400_000,
-            gain_tenths_db: Some(296),
+            center_freq_hz: FIXTURE_FREQ_2M_HZ,
+            sample_rate_hz: FIXTURE_SAMPLE_RATE_HZ,
+            gain_tenths_db: Some(FIXTURE_GAIN_MID_TENTHS),
             ..InitialDeviceState::default()
         };
         let subtitle = format_commanded_state(Some(&info(None, None, None, None)), &initial);
@@ -6952,7 +7034,12 @@ mod server_panel_format_tests {
         // When the client has sent SetGainMode(auto), "auto" wins
         // regardless of any previous manual gain value OR the
         // server's configured initial gain.
-        let client = info(Some(145_500_000), Some(2_400_000), Some(200), Some(true));
+        let client = info(
+            Some(FIXTURE_FREQ_2M_HZ),
+            Some(FIXTURE_SAMPLE_RATE_HZ),
+            Some(FIXTURE_GAIN_LOW_TENTHS),
+            Some(true),
+        );
         let subtitle = format_commanded_state(Some(&client), &default_initial());
         assert!(subtitle.contains("145.500 MHz"));
         assert!(subtitle.contains("2.400 MHz"));
@@ -6966,7 +7053,12 @@ mod server_panel_format_tests {
     fn format_commanded_state_renders_manual_gain_in_db() {
         // SetTunerGain records tenths-of-dB; the render converts to
         // full dB with one decimal.
-        let client = info(Some(100_000_000), Some(2_400_000), Some(496), Some(false));
+        let client = info(
+            Some(FIXTURE_FREQ_WFM_HZ),
+            Some(FIXTURE_SAMPLE_RATE_HZ),
+            Some(FIXTURE_GAIN_TOP_TENTHS),
+            Some(false),
+        );
         let subtitle = format_commanded_state(Some(&client), &default_initial());
         assert!(
             subtitle.contains("gain 49.6 dB"),

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3360,6 +3360,15 @@ fn connect_server_status_polling(
 /// — strong refs held only for this call's duration — so the poll
 /// closure itself doesn't contribute to the long-running `GObject`
 /// refcount.
+///
+/// Renders the FIRST connected client in the per-session rows
+/// (client peer, uptime, commanded state, activity log). Multi-
+/// client per-client UI rows land in PR B of #391; this commit
+/// just wires the new `Vec<ClientInfo>` shape into the existing
+/// single-client row layout so the server-panel keeps working.
+/// The data-rate row switches to the aggregate
+/// `total_bytes_sent` so operators see the full server throughput
+/// even before PR B's per-client rows arrive.
 fn render_status_rows(
     widgets: &ServerStatusWidgets,
     stats: &sdr_server_rtltcp::ServerStats,
@@ -3369,13 +3378,26 @@ fn render_status_rows(
         STATUS_IDLE_VALUE_SUBTITLE, STATUS_WAITING_FOR_CLIENT_SUBTITLE,
     };
 
-    // Client row + expander subtitle.
-    if let Some(peer) = stats.connected_client {
-        let peer_str = peer.to_string();
-        widgets.status_client_row.set_subtitle(&peer_str);
-        widgets
-            .status_row
-            .set_subtitle(&format!("Connected: {peer_str}"));
+    let first = stats.connected_clients.first();
+    let extra = stats.connected_clients.len().saturating_sub(1);
+
+    // Client row + expander subtitle. When there are N > 1 clients,
+    // append "(+N-1 more)" so the row makes the multi-client state
+    // visible even before PR B's per-client list exists.
+    if let Some(info) = first {
+        let peer_str = info.peer.to_string();
+        let client_subtitle = if extra > 0 {
+            format!("{peer_str} (+{extra} more)")
+        } else {
+            peer_str.clone()
+        };
+        widgets.status_client_row.set_subtitle(&client_subtitle);
+        let expander_subtitle = if stats.connected_clients.len() == 1 {
+            format!("Connected: {peer_str}")
+        } else {
+            format!("{} clients connected", stats.connected_clients.len())
+        };
+        widgets.status_row.set_subtitle(&expander_subtitle);
     } else {
         widgets
             .status_client_row
@@ -3385,31 +3407,30 @@ fn render_status_rows(
             .set_subtitle(STATUS_WAITING_FOR_CLIENT_SUBTITLE);
     }
 
-    // Uptime row.
-    widgets
-        .status_uptime_row
-        .set_subtitle(&stats.connected_since.map_or_else(
-            || STATUS_IDLE_VALUE_SUBTITLE.to_string(),
-            |since| format_uptime(since.elapsed()),
-        ));
+    // Uptime row — first client's uptime. PR B will show one row
+    // per client, each with its own uptime.
+    widgets.status_uptime_row.set_subtitle(&first.map_or_else(
+        || STATUS_IDLE_VALUE_SUBTITLE.to_string(),
+        |info| format_uptime(info.connected_since.elapsed()),
+    ));
 
-    // Data-rate row. Counter reset on disconnect produces a
-    // negative delta in the u64 arithmetic; clamp to 0 so the row
-    // doesn't read a bogus Mbps number on the transient.
-    let current_bytes = stats.bytes_sent;
+    // Data-rate row. Uses the cumulative `total_bytes_sent` counter
+    // (monotonic across the server's lifetime) so the delta here
+    // reflects aggregate traffic across ALL clients. No clamping
+    // needed — monotonic means the delta is always >= 0.
+    let current_bytes = stats.total_bytes_sent;
     let delta = current_bytes.saturating_sub(last_bytes_sent.get());
     last_bytes_sent.set(current_bytes);
     widgets
         .status_data_rate_row
         .set_subtitle(&format_data_rate(delta, SERVER_STATUS_POLL_INTERVAL));
 
-    // Commanded-state row. "Tuned to" means "what the client has
-    // most recently requested." Assembled one piece at a time; an
-    // unset field shows its upstream default stamp from
-    // `InitialDeviceState::default()` rather than blanking out.
+    // Commanded-state row — first client's state. Once #392's role
+    // gate lands this becomes "the controller's state" and the
+    // listener rows render with a "listening" badge instead.
     widgets
         .status_commanded_row
-        .set_subtitle(&format_commanded_state(stats));
+        .set_subtitle(&format_commanded_state(first));
 }
 
 /// Render a `Duration` as `Nh Nm Ns` / `Nm Ns` / `Ns` depending on
@@ -3451,19 +3472,24 @@ fn format_data_rate(bytes: u64, interval: Duration) -> String {
     }
 }
 
-/// Render the "Tuned to" row subtitle. Combines frequency, sample
-/// rate and gain into one line. Unset fields show their upstream
-/// default stamp from `InitialDeviceState::default()` — which is
-/// what the server applied on open — rather than blanking out, so
-/// the row never looks broken during the pre-first-command window.
-fn format_commanded_state(stats: &sdr_server_rtltcp::ServerStats) -> String {
-    let freq_hz = stats
+/// Render the "Tuned to" row subtitle for the first connected
+/// client. Combines frequency, sample rate and gain into one
+/// line. Unset fields show their upstream default stamp from
+/// `InitialDeviceState::default()` — which is what the server
+/// applied on open — rather than blanking out, so the row never
+/// looks broken during the pre-first-command window. `None` input
+/// (no clients connected) renders as the idle placeholder.
+fn format_commanded_state(info: Option<&sdr_server_rtltcp::ClientInfo>) -> String {
+    let Some(info) = info else {
+        return crate::sidebar::server_panel::STATUS_IDLE_VALUE_SUBTITLE.to_string();
+    };
+    let freq_hz = info
         .current_freq_hz
         .unwrap_or(sdr_server_rtltcp::DEFAULT_CENTER_FREQ_HZ);
-    let sample_rate_hz = stats
+    let sample_rate_hz = info
         .current_sample_rate_hz
         .unwrap_or(sdr_server_rtltcp::DEFAULT_SAMPLE_RATE_HZ);
-    let gain_text = match (stats.current_gain_auto, stats.current_gain_tenths_db) {
+    let gain_text = match (info.current_gain_auto, info.current_gain_tenths_db) {
         (Some(true), _) => "auto".to_string(),
         (_, Some(gain_tenths)) => {
             #[allow(clippy::cast_precision_loss, reason = "gain tenths-of-dB, cosmetic")]
@@ -3497,11 +3523,19 @@ fn format_hz(hz: u32) -> String {
     }
 }
 
-/// Rebuild the activity-log list from the `ServerStats` ring if
-/// it has actually changed since the last render. The "changed?"
-/// check uses the ring length + the timestamp of the newest entry
-/// so we skip the clear-and-rebuild on idle ticks — preserves any
-/// scroll position the user has in the `ListBox`.
+/// Rebuild the activity-log list from the first connected client's
+/// `recent_commands` ring if it has actually changed since the last
+/// render. The "changed?" check uses the ring length + the
+/// timestamp of the newest entry so we skip the clear-and-rebuild
+/// on idle ticks — preserves any scroll position the user has in
+/// the `ListBox`.
+///
+/// Renders the FIRST client's activity log in #391 (PR A). PR B
+/// replaces this with a per-client log tab so each connected
+/// client's commands show under their own row. When #392's role
+/// gate lands, only the controller can issue commands — the
+/// activity log then implicitly means "controller's commands"
+/// regardless of which client that is at any given moment.
 fn render_activity_log(
     widgets: &ServerStatusWidgets,
     stats: &sdr_server_rtltcp::ServerStats,
@@ -3509,8 +3543,29 @@ fn render_activity_log(
 ) {
     use crate::sidebar::server_panel::ACTIVITY_LOG_EMPTY_SUBTITLE;
 
-    let newest = stats.recent_commands.back().map(|(_, t)| *t);
-    let current_key = (stats.recent_commands.len(), newest);
+    let Some(first_client) = stats.connected_clients.first() else {
+        // No connected client → clear + show empty subtitle if
+        // we're not already in that state. Track the idle cache
+        // key as (0, None) so the render skips on subsequent
+        // idle ticks.
+        let current_key = (0usize, None::<Instant>);
+        if current_key == last_rendered.get() {
+            return;
+        }
+        last_rendered.set(current_key);
+        while let Some(child) = widgets.activity_log_list.first_child() {
+            widgets.activity_log_list.remove(&child);
+        }
+        widgets
+            .activity_log_row
+            .set_subtitle(ACTIVITY_LOG_EMPTY_SUBTITLE);
+        return;
+    };
+    let ring: &std::collections::VecDeque<(sdr_server_rtltcp::CommandOp, Instant)> =
+        &first_client.recent_commands;
+
+    let newest = ring.back().map(|(_, t)| *t);
+    let current_key = (ring.len(), newest);
     if current_key == last_rendered.get() {
         return;
     }
@@ -3522,7 +3577,7 @@ fn render_activity_log(
         widgets.activity_log_list.remove(&child);
     }
 
-    if stats.recent_commands.is_empty() {
+    if ring.is_empty() {
         widgets
             .activity_log_row
             .set_subtitle(ACTIVITY_LOG_EMPTY_SUBTITLE);
@@ -3531,11 +3586,11 @@ fn render_activity_log(
 
     widgets
         .activity_log_row
-        .set_subtitle(&format!("{} commands", stats.recent_commands.len()));
+        .set_subtitle(&format!("{} commands", ring.len()));
     // Newest first so the user doesn't have to scroll to see the
     // most recent activity.
     let now = Instant::now();
-    for (op, at) in stats.recent_commands.iter().rev() {
+    for (op, at) in ring.iter().rev() {
         let row = adw::ActionRow::builder()
             .title(format!("{op:?}"))
             .subtitle(format_log_age(now.saturating_duration_since(*at)))
@@ -6726,14 +6781,42 @@ mod rtl_tcp_discovery_format_tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod server_panel_format_tests {
-    use std::time::Duration;
+    use std::collections::VecDeque;
+    use std::net::SocketAddr;
+    use std::time::{Duration, Instant};
 
-    use sdr_server_rtltcp::ServerStats;
+    use sdr_server_rtltcp::{ClientInfo, codec::Codec};
 
     use super::{
         SERVER_STATUS_POLL_INTERVAL, format_commanded_state, format_data_rate, format_hz,
         format_uptime,
     };
+
+    /// Build a `ClientInfo` fixture for the `format_commanded_state`
+    /// tests. Defaults to unset per-session fields (`None` on
+    /// `current_freq` / `current_sample_rate` / `current_gain`) so
+    /// each test only overrides the fields it's exercising.
+    fn info(
+        current_freq_hz: Option<u32>,
+        current_sample_rate_hz: Option<u32>,
+        current_gain_tenths_db: Option<i32>,
+        current_gain_auto: Option<bool>,
+    ) -> ClientInfo {
+        ClientInfo {
+            id: 0,
+            peer: SocketAddr::from(([127, 0, 0, 1], 42_000)),
+            connected_since: Instant::now(),
+            codec: Codec::None,
+            bytes_sent: 0,
+            buffers_dropped: 0,
+            last_command: None,
+            current_freq_hz,
+            current_sample_rate_hz,
+            current_gain_tenths_db,
+            current_gain_auto,
+            recent_commands: VecDeque::new(),
+        }
+    }
 
     #[test]
     fn format_uptime_uses_compact_unit_picker() {
@@ -6783,13 +6866,26 @@ mod server_panel_format_tests {
     }
 
     #[test]
+    fn format_commanded_state_no_client_renders_idle_placeholder() {
+        // `None` means no connected client — the row should show
+        // the idle `STATUS_IDLE_VALUE_SUBTITLE` placeholder. Guards
+        // against a phantom row when the server is up but nobody's
+        // connected.
+        let subtitle = format_commanded_state(None);
+        assert_eq!(
+            subtitle,
+            crate::sidebar::server_panel::STATUS_IDLE_VALUE_SUBTITLE
+        );
+    }
+
+    #[test]
     fn format_commanded_state_uses_upstream_defaults_when_client_silent() {
-        // A brand-new session that hasn't sent any commands should
-        // still render a sensible line — we show the upstream
+        // A connected client that hasn't sent any commands yet —
+        // row should still render a sensible line via the upstream
         // rtl_tcp.c defaults (100 MHz @ 2.048 MHz, gain "initial")
-        // rather than blanking the row.
-        let stats = ServerStats::default();
-        let subtitle = format_commanded_state(&stats);
+        // rather than blanking out during the pre-first-command
+        // window.
+        let subtitle = format_commanded_state(Some(&info(None, None, None, None)));
         assert!(
             subtitle.contains("100.000 MHz"),
             "default freq should show: {subtitle}"
@@ -6808,14 +6904,8 @@ mod server_panel_format_tests {
     fn format_commanded_state_renders_client_auto_gain_preference() {
         // When the client has sent SetGainMode(auto), "auto" wins
         // regardless of any previous manual gain value.
-        let stats = ServerStats {
-            current_freq_hz: Some(145_500_000),
-            current_sample_rate_hz: Some(2_400_000),
-            current_gain_tenths_db: Some(200),
-            current_gain_auto: Some(true),
-            ..ServerStats::default()
-        };
-        let subtitle = format_commanded_state(&stats);
+        let client = info(Some(145_500_000), Some(2_400_000), Some(200), Some(true));
+        let subtitle = format_commanded_state(Some(&client));
         assert!(subtitle.contains("145.500 MHz"));
         assert!(subtitle.contains("2.400 MHz"));
         assert!(
@@ -6828,14 +6918,8 @@ mod server_panel_format_tests {
     fn format_commanded_state_renders_manual_gain_in_db() {
         // SetTunerGain records tenths-of-dB; the render converts to
         // full dB with one decimal.
-        let stats = ServerStats {
-            current_freq_hz: Some(100_000_000),
-            current_sample_rate_hz: Some(2_400_000),
-            current_gain_tenths_db: Some(496),
-            current_gain_auto: Some(false),
-            ..ServerStats::default()
-        };
-        let subtitle = format_commanded_state(&stats);
+        let client = info(Some(100_000_000), Some(2_400_000), Some(496), Some(false));
+        let subtitle = format_commanded_state(Some(&client));
         assert!(
             subtitle.contains("gain 49.6 dB"),
             "49.6 dB should render from 496 tenths: {subtitle}"

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3430,7 +3430,7 @@ fn render_status_rows(
     // listener rows render with a "listening" badge instead.
     widgets
         .status_commanded_row
-        .set_subtitle(&format_commanded_state(first));
+        .set_subtitle(&format_commanded_state(first, &stats.initial));
 }
 
 /// Render a `Duration` as `Nh Nm Ns` / `Nm Ns` / `Ns` depending on
@@ -3474,21 +3474,23 @@ fn format_data_rate(bytes: u64, interval: Duration) -> String {
 
 /// Render the "Tuned to" row subtitle for the first connected
 /// client. Combines frequency, sample rate and gain into one
-/// line. Unset fields show their upstream default stamp from
-/// `InitialDeviceState::default()` — which is what the server
-/// applied on open — rather than blanking out, so the row never
-/// looks broken during the pre-first-command window. `None` input
-/// (no clients connected) renders as the idle placeholder.
-fn format_commanded_state(info: Option<&sdr_server_rtltcp::ClientInfo>) -> String {
+/// line. Unset `current_*` fields on the client fall back to the
+/// server's **configured** `initial` state (what the user set up
+/// in the server panel or CLI args), NOT the library's upstream
+/// `rtl_tcp.c` defaults. `None` input (no clients connected)
+/// renders as the idle placeholder. Per `CodeRabbit` round 1 on
+/// PR #402.
+fn format_commanded_state(
+    info: Option<&sdr_server_rtltcp::ClientInfo>,
+    initial: &sdr_server_rtltcp::InitialDeviceState,
+) -> String {
     let Some(info) = info else {
         return crate::sidebar::server_panel::STATUS_IDLE_VALUE_SUBTITLE.to_string();
     };
-    let freq_hz = info
-        .current_freq_hz
-        .unwrap_or(sdr_server_rtltcp::DEFAULT_CENTER_FREQ_HZ);
+    let freq_hz = info.current_freq_hz.unwrap_or(initial.center_freq_hz);
     let sample_rate_hz = info
         .current_sample_rate_hz
-        .unwrap_or(sdr_server_rtltcp::DEFAULT_SAMPLE_RATE_HZ);
+        .unwrap_or(initial.sample_rate_hz);
     let gain_text = match (info.current_gain_auto, info.current_gain_tenths_db) {
         (Some(true), _) => "auto".to_string(),
         (_, Some(gain_tenths)) => {
@@ -3496,7 +3498,17 @@ fn format_commanded_state(info: Option<&sdr_server_rtltcp::ClientInfo>) -> Strin
             let db = f64::from(gain_tenths) / 10.0;
             format!("{db:.1} dB")
         }
-        _ => "initial".to_string(),
+        // Client hasn't sent a gain command yet — show whatever
+        // the server started with. `initial.gain_tenths_db = None`
+        // encodes upstream's "automatic" mode (CLI `-g 0`).
+        _ => match initial.gain_tenths_db {
+            None => "auto".to_string(),
+            Some(gain_tenths) => {
+                #[allow(clippy::cast_precision_loss, reason = "gain tenths-of-dB, cosmetic")]
+                let db = f64::from(gain_tenths) / 10.0;
+                format!("{db:.1} dB")
+            }
+        },
     };
     format!(
         "{} @ {} • gain {}",
@@ -6785,12 +6797,20 @@ mod server_panel_format_tests {
     use std::net::SocketAddr;
     use std::time::{Duration, Instant};
 
-    use sdr_server_rtltcp::{ClientInfo, codec::Codec};
+    use sdr_server_rtltcp::{ClientInfo, InitialDeviceState, codec::Codec};
 
     use super::{
         SERVER_STATUS_POLL_INTERVAL, format_commanded_state, format_data_rate, format_hz,
         format_uptime,
     };
+
+    /// Fresh `InitialDeviceState` matching what `Server::start`
+    /// stores when the user takes the upstream-default path. Most
+    /// format tests use this; the ones that want to prove
+    /// fallback-to-initial override the relevant field.
+    fn default_initial() -> InitialDeviceState {
+        InitialDeviceState::default()
+    }
 
     /// Build a `ClientInfo` fixture for the `format_commanded_state`
     /// tests. Defaults to unset per-session fields (`None` on
@@ -6871,7 +6891,7 @@ mod server_panel_format_tests {
         // the idle `STATUS_IDLE_VALUE_SUBTITLE` placeholder. Guards
         // against a phantom row when the server is up but nobody's
         // connected.
-        let subtitle = format_commanded_state(None);
+        let subtitle = format_commanded_state(None, &default_initial());
         assert_eq!(
             subtitle,
             crate::sidebar::server_panel::STATUS_IDLE_VALUE_SUBTITLE
@@ -6879,38 +6899,66 @@ mod server_panel_format_tests {
     }
 
     #[test]
-    fn format_commanded_state_uses_upstream_defaults_when_client_silent() {
+    fn format_commanded_state_falls_back_to_server_initial_when_client_silent() {
         // A connected client that hasn't sent any commands yet —
-        // row should still render a sensible line via the upstream
-        // rtl_tcp.c defaults (100 MHz @ 2.048 MHz, gain "initial")
-        // rather than blanking out during the pre-first-command
-        // window.
-        let subtitle = format_commanded_state(Some(&info(None, None, None, None)));
+        // row should render the SERVER'S configured `initial`
+        // values (what the user configured at `Server::start`),
+        // not the library's upstream `rtl_tcp.c` defaults. Here
+        // the initial is a non-default 145 MHz / 2.4 Msps / 29.6 dB,
+        // so the subtitle should read those values even though the
+        // client hasn't sent any SetX commands yet.
+        // Per `CodeRabbit` round 1 on PR #402.
+        let initial = InitialDeviceState {
+            center_freq_hz: 145_500_000,
+            sample_rate_hz: 2_400_000,
+            gain_tenths_db: Some(296),
+            ..InitialDeviceState::default()
+        };
+        let subtitle = format_commanded_state(Some(&info(None, None, None, None)), &initial);
         assert!(
-            subtitle.contains("100.000 MHz"),
-            "default freq should show: {subtitle}"
+            subtitle.contains("145.500 MHz"),
+            "server's configured initial freq should show: {subtitle}"
         );
         assert!(
-            subtitle.contains("2.048 MHz"),
-            "default sample rate should show: {subtitle}"
+            subtitle.contains("2.400 MHz"),
+            "server's configured initial sample rate should show: {subtitle}"
         );
         assert!(
-            subtitle.contains("gain initial"),
-            "default gain hint should show: {subtitle}"
+            subtitle.contains("gain 29.6 dB"),
+            "server's configured initial gain should show: {subtitle}"
+        );
+    }
+
+    #[test]
+    fn format_commanded_state_renders_auto_when_initial_gain_is_none() {
+        // `initial.gain_tenths_db = None` encodes upstream's
+        // automatic-gain mode (the CLI's `-g 0` path). With no
+        // client overrides, the gain text should read "auto", not
+        // a literal dB value. Regression for the pre-CR "initial"
+        // placeholder that was meaningless to users.
+        let initial = InitialDeviceState {
+            gain_tenths_db: None,
+            ..InitialDeviceState::default()
+        };
+        let subtitle = format_commanded_state(Some(&info(None, None, None, None)), &initial);
+        assert!(
+            subtitle.contains("gain auto"),
+            "initial gain None should render as auto: {subtitle}"
         );
     }
 
     #[test]
     fn format_commanded_state_renders_client_auto_gain_preference() {
         // When the client has sent SetGainMode(auto), "auto" wins
-        // regardless of any previous manual gain value.
+        // regardless of any previous manual gain value OR the
+        // server's configured initial gain.
         let client = info(Some(145_500_000), Some(2_400_000), Some(200), Some(true));
-        let subtitle = format_commanded_state(Some(&client));
+        let subtitle = format_commanded_state(Some(&client), &default_initial());
         assert!(subtitle.contains("145.500 MHz"));
         assert!(subtitle.contains("2.400 MHz"));
         assert!(
             subtitle.contains("gain auto"),
-            "auto should override manual gain value: {subtitle}"
+            "client auto should override manual gain value: {subtitle}"
         );
     }
 
@@ -6919,7 +6967,7 @@ mod server_panel_format_tests {
         // SetTunerGain records tenths-of-dB; the render converts to
         // full dB with one decimal.
         let client = info(Some(100_000_000), Some(2_400_000), Some(496), Some(false));
-        let subtitle = format_commanded_state(Some(&client));
+        let subtitle = format_commanded_state(Some(&client), &default_initial());
         assert!(
             subtitle.contains("gain 49.6 dB"),
             "49.6 dB should render from 496 tenths: {subtitle}"

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -58,19 +58,18 @@ extern "C" {
 #define SDR_CORE_ABI_VERSION_MAJOR 0
 #define SDR_CORE_ABI_VERSION_MINOR 14
 /*
- * 0.14 (#391 / PR #402) — breaking change to the rtl_tcp server
- * surface. `SdrRtlTcpServerStats` layout changed to aggregate-only
- * counters (per-client session state moved to the new
- * `SdrRtlTcpClientInfo` struct, fetched via
- * `sdr_rtltcp_server_client_list`), and
+ * 0.14 — breaking change to the rtl_tcp server surface.
+ * `SdrRtlTcpServerStats` layout changed to aggregate-only counters
+ * (per-client session state moved to the new `SdrRtlTcpClientInfo`
+ * struct, fetched via `sdr_rtltcp_server_client_list`), and
  * `sdr_rtltcp_server_recent_commands_json` gained a required
  * `client_id` parameter. Older hosts built against 0.13 MUST fail
  * fast on the ABI-version check — the new struct is shorter than
  * the old one, and the new `_recent_commands_json` signature
  * would silently mis-interpret the `out_buf` pointer as a
- * `client_id`. Per `CodeRabbit` round 2 on PR #402: we're pre-1.0
- * so MINOR bumps are breaking by convention on this project;
- * full semver respect starts at MAJOR >= 1.
+ * `client_id`. Pre-1.0 MINOR bumps are breaking by project
+ * convention (see "ABI versioning" block above); full SemVer
+ * applies once MAJOR >= 1.
  */
 
 /*
@@ -814,9 +813,13 @@ typedef struct SdrRtlTcpServerConfig {
  * server-wide cumulative counters + the tuner gain count.
  */
 typedef struct SdrRtlTcpServerStats {
-    /* Number of clients currently connected. Size a follow-up
-     * SdrRtlTcpClientInfo array of this length and call
-     * sdr_rtltcp_server_client_list to read per-client state. */
+    /* Number of clients connected at the moment this snapshot
+     * was taken. `sdr_rtltcp_server_client_list` is a separate
+     * live read, so membership may change between the two calls.
+     * Use this as an initial sizing hint for the client array,
+     * then honor `*out_count` returned by the list call and
+     * retry with a larger buffer if the returned count exceeds
+     * the capacity you passed. */
     uint32_t connected_count;
     /* Cumulative bytes fanned out across all clients over the
      * server's lifetime. Monotonic — never reset. Consumers
@@ -903,7 +906,7 @@ typedef struct SdrRtlTcpClientInfo {
      * worthwhile; use THAT function's `out_required` size-probe
      * path to allocate the JSON buffer — length depends on opcode
      * names and float formatting and isn't a fixed per-entry
-     * byte count. Per `CodeRabbit` round 2 on PR #402. */
+     * byte count. */
     uint32_t recent_commands_count;
 } SdrRtlTcpClientInfo;
 
@@ -963,8 +966,12 @@ bool sdr_rtltcp_server_has_stopped(SdrRtlTcpServer* handle);
  * are truncated; NOT an error. 64 bytes handles any realistic
  * tuner name.
  *
- * For per-client state call `sdr_rtltcp_server_client_list` after
- * reading `out_stats->connected_count`.
+ * For per-client state, use `out_stats->connected_count` as an
+ * initial sizing hint for `sdr_rtltcp_server_client_list`. That
+ * call is a separate live read, so membership may change between
+ * the two — always honor the list call's returned `*out_count`
+ * and retry with a larger buffer if it exceeds the capacity you
+ * passed.
  *
  * Returns `SDR_CORE_OK` on success, `SDR_CORE_ERR_INVALID_ARG`
  * on null out_stats, `SDR_CORE_ERR_INVALID_HANDLE` on null

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,17 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 14
+#define SDR_CORE_ABI_VERSION_MINOR 15
 /*
+ * 0.15 — adds `has_last_command` / `last_command_op` /
+ * `last_command_age_secs` to the tail of `SdrRtlTcpClientInfo`
+ * so FFI hosts can replicate the "most recent commander"
+ * selection the Rust UI does via `pick_most_recent_commander`
+ * without having to poll + parse the JSON ring for every
+ * connected client. Struct layout grows; callers built against
+ * 0.14 MUST fail fast on the ABI-version check (pre-1.0
+ * exact-match rule, see "ABI versioning" block above).
+ *
  * 0.14 — breaking change to the rtl_tcp server surface.
  * `SdrRtlTcpServerStats` layout changed to aggregate-only counters
  * (per-client session state moved to the new `SdrRtlTcpClientInfo`
@@ -908,6 +917,30 @@ typedef struct SdrRtlTcpClientInfo {
      * names and float formatting and isn't a fixed per-entry
      * byte count. */
     uint32_t recent_commands_count;
+    /* true once the client has issued at least one command this
+     * session. Complementary to recent_commands_count:
+     * recent_commands_count > 0 implies has_last_command, but
+     * has_last_command alone means "at least one command
+     * dispatched" without committing to whether the ring has
+     * already evicted earlier entries. last_command_op and
+     * last_command_age_secs are only valid when this is true. */
+    bool     has_last_command;
+    /* Wire byte of the client's most recently dispatched command
+     * — matches the opcodes documented in rtl_tcp.c:315-372
+     * (SetCenterFreq = 0x01, SetSampleRate = 0x02, ...,
+     * SetBiasTee = 0x0e). Valid only when has_last_command ==
+     * true; 0 otherwise. Hosts that want a display label can map
+     * the opcode locally or call
+     * sdr_rtltcp_server_recent_commands_json for the ring. */
+    uint8_t  last_command_op;
+    /* Seconds elapsed since the client's most recent command
+     * was dispatched. Measured at the moment this snapshot was
+     * assembled; increases monotonically between polls. Valid
+     * only when has_last_command == true. Hosts that want to
+     * replicate "most recent commander" selection across the
+     * connected-client list pick the entry with the smallest
+     * last_command_age_secs. */
+    double   last_command_age_secs;
 } SdrRtlTcpClientInfo;
 
 /*

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -933,13 +933,19 @@ typedef struct SdrRtlTcpClientInfo {
      * the opcode locally or call
      * sdr_rtltcp_server_recent_commands_json for the ring. */
     uint8_t  last_command_op;
-    /* Seconds elapsed since the client's most recent command
-     * was dispatched. Measured at the moment this snapshot was
-     * assembled; increases monotonically between polls. Valid
-     * only when has_last_command == true. Hosts that want to
-     * replicate "most recent commander" selection across the
-     * connected-client list pick the entry with the smallest
-     * last_command_age_secs. */
+    /* Seconds elapsed between the client's most recent command
+     * and the moment this snapshot was assembled. A pure
+     * snapshot-time age — NOT a monotonic counter: a fresh
+     * command from the client resets it back near zero on the
+     * next poll, so consumers should not rely on it increasing
+     * between consecutive samples. Intended use: compare recency
+     * *across clients within a single snapshot* — the entry with
+     * the smallest last_command_age_secs is the most recent
+     * commander (mirrors the Rust UI's
+     * pick_most_recent_commander helper). Valid only when
+     * has_last_command == true. All entries in the same
+     * sdr_rtltcp_server_client_list call reference a single
+     * snapshot clock, so the ordering is consistent. */
     double   last_command_age_secs;
 } SdrRtlTcpClientInfo;
 

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -48,7 +48,22 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 13
+#define SDR_CORE_ABI_VERSION_MINOR 14
+/*
+ * 0.14 (#391 / PR #402) — breaking change to the rtl_tcp server
+ * surface. `SdrRtlTcpServerStats` layout changed to aggregate-only
+ * counters (per-client session state moved to the new
+ * `SdrRtlTcpClientInfo` struct, fetched via
+ * `sdr_rtltcp_server_client_list`), and
+ * `sdr_rtltcp_server_recent_commands_json` gained a required
+ * `client_id` parameter. Older hosts built against 0.13 MUST fail
+ * fast on the ABI-version check — the new struct is shorter than
+ * the old one, and the new `_recent_commands_json` signature
+ * would silently mis-interpret the `out_buf` pointer as a
+ * `client_id`. Per `CodeRabbit` round 2 on PR #402: we're pre-1.0
+ * so MINOR bumps are breaking by convention on this project;
+ * full semver respect starts at MAJOR >= 1.
+ */
 
 /*
  * Return the ABI version the library was built with, packed as
@@ -863,9 +878,14 @@ typedef struct SdrRtlTcpClientInfo {
     /* true once the client has issued at least one SetGainMode
      * command. */
     bool     has_current_gain_mode;
-    /* Number of entries in this client's recent-commands ring.
-     * Sizes a follow-up _recent_commands_json(client_id, ...)
-     * buffer. */
+    /* Number of entries in this client's recent-commands ring
+     * (an entry count, not a byte count). Useful for UI hints
+     * ("N commands since connect") and for deciding whether a
+     * follow-up sdr_rtltcp_server_recent_commands_json call is
+     * worthwhile; use THAT function's `out_required` size-probe
+     * path to allocate the JSON buffer — length depends on opcode
+     * names and float formatting and isn't a fixed per-entry
+     * byte count. Per `CodeRabbit` round 2 on PR #402. */
     uint32_t recent_commands_count;
 } SdrRtlTcpClientInfo;
 

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -849,8 +849,16 @@ typedef struct SdrRtlTcpClientInfo {
      * vanilla rtl_tcp), 1 = LZ4. */
     uint8_t  codec;
     /* Bytes written to this client's TCP socket since accept.
-     * Post-compression — sum across all clients equals the
-     * server's on-wire total. */
+     * Post-compression (LZ4 sessions report the
+     * compressed-on-wire count). Covers only this currently-
+     * connected session — SdrRtlTcpServerStats.total_bytes_sent
+     * is a separate server-lifetime aggregate that also carries
+     * contributions from previously-disconnected clients, so the
+     * sum of per-client bytes_sent across the currently-
+     * connected list does NOT equal total_bytes_sent once at
+     * least one disconnect has occurred. Hosts reconciling the
+     * two counters should treat them as complementary, not
+     * overlapping. */
     uint64_t bytes_sent;
     /* Buffer drops this client has accrued (broadcaster saw
      * TrySendError::Full against this client's channel). */

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -780,48 +780,94 @@ typedef struct SdrRtlTcpServerConfig {
 } SdrRtlTcpServerConfig;
 
 /*
- * Scalar server statistics snapshot. String fields
- * (connected-client address, tuner name) are written to
- * caller-allocated buffers by `sdr_rtltcp_server_stats`.
+ * Aggregate server-lifetime statistics.
+ *
+ * Post-#391 the rtl_tcp server is multi-client; per-client
+ * session state (peer address, bytes_sent, commanded frequency,
+ * etc.) lives in SdrRtlTcpClientInfo and is read through
+ * sdr_rtltcp_server_client_list. This struct carries only the
+ * server-wide cumulative counters + the tuner gain count.
  */
 typedef struct SdrRtlTcpServerStats {
-    bool     has_client;
-    double   uptime_secs;              /* 0 when no client connected */
-    uint64_t bytes_sent;
-    uint64_t buffers_dropped;
-    /* Client-issued center-frequency override. 0 before the
-     * connected client has sent SetCenterFreq; resets on
-     * disconnect. Does NOT reflect the server's applied
-     * initial_freq_hz or the live device register — hosts
-     * that want "what the dongle is actually tuned to" should
-     * fall back to SdrRtlTcpServerConfig.initial_freq_hz when
-     * has_client && current_freq_hz == 0. */
-    uint32_t current_freq_hz;
-    /* Client-issued sample-rate override, same semantics as
-     * current_freq_hz above. */
-    uint32_t current_sample_rate_hz;
-    int32_t  current_gain_tenths_db;   /* valid only when has_current_gain_value */
-    bool     current_gain_auto;        /* valid only when has_current_gain_mode */
-    /* `true` once the client sent at least one SetTunerGain
-     * command this session. Tracked separately from the mode
-     * flag below because a client can set one without the
-     * other — without the separate validity bits, a genuine
-     * 0 dB manual gain would be indistinguishable from
-     * "client hasn't set gain yet." */
-    bool     has_current_gain_value;
-    /* `true` once the client sent at least one SetGainMode
-     * command this session. Valid companion to
-     * current_gain_auto — without this flag a `false` value
-     * would be indistinguishable from "client hasn't asked
-     * for a gain mode yet." */
-    bool     has_current_gain_mode;
+    /* Number of clients currently connected. Size a follow-up
+     * SdrRtlTcpClientInfo array of this length and call
+     * sdr_rtltcp_server_client_list to read per-client state. */
+    uint32_t connected_count;
+    /* Cumulative bytes fanned out across all clients over the
+     * server's lifetime. Monotonic — never reset. Consumers
+     * derive data-rate from the delta between consecutive
+     * snapshots divided by the poll interval. */
+    uint64_t total_bytes_sent;
+    /* Cumulative buffer drops across all clients. Monotonic. */
+    uint64_t total_buffers_dropped;
+    /* Cumulative count of clients accepted over the server's
+     * lifetime. Persists across disconnects. */
+    uint64_t lifetime_accepted;
     /* Tuner's advertised discrete gain count (from
      * dongle_info_t). Populated by Server::start during the
      * dongle-open phase — non-zero for the entire server
      * lifetime, including before the first client connects. */
     uint32_t gain_count;
-    uint32_t recent_commands_count;    /* size of the recent-commands ring */
 } SdrRtlTcpServerStats;
+
+/* Fixed-size buffer (bytes) for the "ip:port" peer address in
+ * SdrRtlTcpClientInfo. Sized to fit IPv6 literal forms
+ * ("[ffff:...:ffff]:65535" is 48 bytes incl NUL); 64 rounds up
+ * and leaves room for future annotation suffixes. */
+#define SDR_RTLTCP_CLIENT_PEER_LEN 64
+
+/*
+ * Per-client state snapshot. One entry per connected client,
+ * returned from sdr_rtltcp_server_client_list.
+ */
+typedef struct SdrRtlTcpClientInfo {
+    /* Stable, monotonic identifier assigned at accept time.
+     * Never reused over the server's lifetime — useful for
+     * correlating across polls when the same peer reconnects. */
+    uint64_t id;
+    /* Peer socket address as "ip:port", NUL-terminated.
+     * Always fits within SDR_RTLTCP_CLIENT_PEER_LEN incl NUL. */
+    char     peer_addr[SDR_RTLTCP_CLIENT_PEER_LEN];
+    /* Seconds since this client's handshake completed. */
+    double   uptime_secs;
+    /* Negotiated stream codec wire byte: 0 = None (legacy /
+     * vanilla rtl_tcp), 1 = LZ4. */
+    uint8_t  codec;
+    /* Bytes written to this client's TCP socket since accept.
+     * Post-compression — sum across all clients equals the
+     * server's on-wire total. */
+    uint64_t bytes_sent;
+    /* Buffer drops this client has accrued (broadcaster saw
+     * TrySendError::Full against this client's channel). */
+    uint64_t buffers_dropped;
+    /* Client-issued center-frequency override in Hz. 0 before
+     * the client has sent SetCenterFreq; does NOT reflect the
+     * server's applied initial_freq_hz or the live device
+     * register. */
+    uint32_t current_freq_hz;
+    /* Client-issued sample-rate override, same semantics as
+     * current_freq_hz. */
+    uint32_t current_sample_rate_hz;
+    /* Most recent client-issued tuner-gain request in 0.1 dB.
+     * Valid only when has_current_gain_value == true. */
+    int32_t  current_gain_tenths_db;
+    /* true when the client's last gain-mode request was auto;
+     * false when manual. Valid only when
+     * has_current_gain_mode == true. */
+    bool     current_gain_auto;
+    /* true once the client has issued at least one SetTunerGain
+     * command. Tracked separately from the mode flag because a
+     * client can send SetGainMode(auto) without a preceding
+     * SetTunerGain (and vice versa). */
+    bool     has_current_gain_value;
+    /* true once the client has issued at least one SetGainMode
+     * command. */
+    bool     has_current_gain_mode;
+    /* Number of entries in this client's recent-commands ring.
+     * Sizes a follow-up _recent_commands_json(client_id, ...)
+     * buffer. */
+    uint32_t recent_commands_count;
+} SdrRtlTcpClientInfo;
 
 /*
  * Start an rtl_tcp server. On success writes the handle to
@@ -871,13 +917,16 @@ void sdr_rtltcp_server_stop(SdrRtlTcpServer* handle);
 bool sdr_rtltcp_server_has_stopped(SdrRtlTcpServer* handle);
 
 /*
- * Snapshot the server's live stats.
+ * Snapshot the server's aggregate stats.
  *
- * `out_stats` must be non-null. `out_client_addr` and
- * `out_tuner_name` are optional NUL-terminated string buffers
- * (pass NULL with `*_len = 0` to skip). Strings longer than
- * the buffer are truncated; NOT an error. A 64-byte buffer
- * handles any realistic `"ip:port"` or tuner name.
+ * `out_stats` must be non-null. `out_tuner_name` is an optional
+ * NUL-terminated string buffer (pass NULL with
+ * `tuner_name_len = 0` to skip). Strings longer than the buffer
+ * are truncated; NOT an error. 64 bytes handles any realistic
+ * tuner name.
+ *
+ * For per-client state call `sdr_rtltcp_server_client_list` after
+ * reading `out_stats->connected_count`.
  *
  * Returns `SDR_CORE_OK` on success, `SDR_CORE_ERR_INVALID_ARG`
  * on null out_stats, `SDR_CORE_ERR_INVALID_HANDLE` on null
@@ -887,28 +936,61 @@ bool sdr_rtltcp_server_has_stopped(SdrRtlTcpServer* handle);
 int32_t sdr_rtltcp_server_stats(
     SdrRtlTcpServer*      handle,
     SdrRtlTcpServerStats* out_stats,
-    char*                 out_client_addr,
-    size_t                client_addr_len,
     char*                 out_tuner_name,
     size_t                tuner_name_len
 );
 
 /*
- * Write the recent-commands ring to `out_buf` as a JSON
- * array. Each entry: `{"op": "<name>", "seconds_ago": <f64>}`.
+ * Snapshot every connected client's state into a caller-provided
+ * array.
+ *
+ * `out_count` must be non-null and receives the current
+ * connected-client count. `out_clients` may be null when
+ * `capacity == 0` — use that form to size a buffer before
+ * re-calling. When `capacity > 0` and there are more connected
+ * clients than `capacity`, the first `capacity` entries are
+ * filled and the caller should retry with a bigger buffer.
+ *
+ * Returns `SDR_CORE_OK` on success (including the query-count
+ * path), `SDR_CORE_ERR_INVALID_ARG` on null `out_count` (or null
+ * `out_clients` with non-zero `capacity`),
+ * `SDR_CORE_ERR_INVALID_HANDLE` on null handle,
+ * `SDR_CORE_ERR_NOT_RUNNING` if the server was already stopped.
+ *
+ * Client ordering is stable within a snapshot (oldest-first) but
+ * may shift across snapshots as clients disconnect. Use
+ * `SdrRtlTcpClientInfo::id` for cross-snapshot correlation.
+ */
+int32_t sdr_rtltcp_server_client_list(
+    SdrRtlTcpServer*      handle,
+    SdrRtlTcpClientInfo*  out_clients,
+    size_t                capacity,
+    size_t*               out_count
+);
+
+/*
+ * Write one client's recent-commands ring to `out_buf` as a
+ * JSON array. Each entry: `{"op": "<name>", "seconds_ago": <f64>}`.
  * The entries are ordered oldest-first.
+ *
+ * `client_id` identifies the target client — read it from an
+ * earlier `SdrRtlTcpClientInfo::id` snapshot. A stale id
+ * (client disconnected between snapshots) returns
+ * `SDR_CORE_ERR_INVALID_ARG` with `*out_required = 0`.
  *
  * Returns:
  *   SDR_CORE_OK              — buffer was big enough; filled and NUL-terminated.
- *   SDR_CORE_ERR_INVALID_ARG — buffer too small or null with nonzero len. `*out_required`
- *                              (when non-null) receives the exact size (incl. NUL) the
- *                              caller should allocate and retry. `out_buf` is untouched.
+ *   SDR_CORE_ERR_INVALID_ARG — buffer too small, null with nonzero len, or client_id
+ *                              no longer connected. `*out_required` (when non-null)
+ *                              receives the exact size (incl. NUL) the caller should
+ *                              allocate and retry (or 0 for the stale-id case).
  *   SDR_CORE_ERR_INVALID_HANDLE — null handle.
  *   SDR_CORE_ERR_NOT_RUNNING    — server already stopped.
  *   SDR_CORE_ERR_INTERNAL       — JSON encoding failure (shouldn't reach here).
  */
 int32_t sdr_rtltcp_server_recent_commands_json(
     SdrRtlTcpServer* handle,
+    uint64_t         client_id,
     char*            out_buf,
     size_t           buf_len,
     size_t*          out_required

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -23,13 +23,21 @@
  *     observed the error code.
  *
  * ABI versioning:
- *   - Minor bump = additive (new function, new event variant, new
- *     error code). Old hosts keep working; they just don't see new
- *     things.
- *   - Major bump = breaking (signature change, struct layout, etc.).
- *     Old hosts must fail to start against a newer library.
- *   - Hosts should call `sdr_core_abi_version()` once at startup and
- *     abort cleanly on a major mismatch.
+ *   - While `SDR_CORE_ABI_VERSION_MAJOR == 0` (pre-1.0), BOTH
+ *     major AND minor bumps may be breaking. Hosts must require an
+ *     exact `(major, minor)` match at startup and refuse to run
+ *     against any other combination. This project doesn't yet
+ *     commit to additive-only minors — the rtl_tcp server surface
+ *     was reshaped in 0.14, for example, which would have been
+ *     silent UB against a 0.13 host if MINOR were treated as
+ *     additive.
+ *   - Once `SDR_CORE_ABI_VERSION_MAJOR >= 1` the standard SemVer
+ *     rules apply: MINOR is additive (new functions / event
+ *     variants / error codes; old hosts keep working), MAJOR is
+ *     breaking.
+ *   - Hosts should call `sdr_core_abi_version()` once at startup.
+ *     In pre-1.0 builds, abort on any mismatch; in 1.x+ builds,
+ *     abort only on MAJOR mismatch.
  */
 
 #ifndef SDR_CORE_H
@@ -68,8 +76,10 @@ extern "C" {
 /*
  * Return the ABI version the library was built with, packed as
  * `(major << 16) | minor`. Hosts call this once at startup and
- * abort (or show a "library mismatch" dialog) on a major mismatch
- * against what they were compiled against.
+ * abort (or show a "library mismatch" dialog) on any mismatch.
+ * See the "ABI versioning" block above for the pre-1.0 vs 1.x+
+ * match rules — pre-1.0 requires an exact `(major, minor)` match,
+ * 1.x+ allows MINOR drift but not MAJOR.
  */
 uint32_t sdr_core_abi_version(void);
 

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -951,6 +951,12 @@ int32_t sdr_rtltcp_server_stats(
  * clients than `capacity`, the first `capacity` entries are
  * filled and the caller should retry with a bigger buffer.
  *
+ * The two query-count forms are equivalent: `out_clients == NULL`
+ * with `capacity == 0`, AND `out_clients != NULL` with
+ * `capacity == 0`. Both write the connected-client count to
+ * `*out_count` and fill zero entries. Use whichever is cleanest
+ * at the call site.
+ *
  * Returns `SDR_CORE_OK` on success (including the query-count
  * path), `SDR_CORE_ERR_INVALID_ARG` on null `out_count` (or null
  * `out_clients` with non-zero `capacity`),


### PR DESCRIPTION
First PR of the multi-client epic #390. Replaces the rtl_tcp server's single-client data path with a fan-out broadcaster: one USB reader, N per-client bounded channels, drop-on-full per-client. Breaks the `ServerStats` API cleanly to a per-client `Vec<ClientInfo>` + aggregate counters; updates every in-tree consumer (Linux UI + C ABI + header).

Closes #391.

## Why this is the foundation

Every remaining #390 sub-issue (role gate #392, takeover #393, auth #394, UI layers #395/#396) assumes multi-client infrastructure. Pre-#391 the server explicitly rejected any second connection with TCP FIN. This PR flips the data path — the rest stack cleanly on top.

## Architecture

```
USB reader                     per-client workers
    │
    ▼
broadcaster_worker           for each ClientSlot:
    │                          writer:  slot.rx → encoded TCP socket
    ▼                          command: TCP socket → device mutex
registry.broadcast(chunk)
    │ (holds lock briefly,
    │  clones live Arc<ClientSlot>,
    │  releases lock, then try_send
    │  per slot — drop-on-full per
    │  client only)
    ▼
bounded per-client channels
```

- **`sdr-server-rtltcp::broadcaster`** — new module. `ClientRegistry` + `ClientSlot` + `ClientStats` + `ClientInfo`. Registry holds `Mutex<Vec<Arc<ClientSlot>>>`; `broadcast` snapshots live Arcs under the lock, releases, then fan-outs lock-free. Accept thread can `register` mid-broadcast without blocking.
- **`server.rs` refactor** — deleted `handle_client` + the per-client `data_worker`. Replaced with a single server-lifetime `broadcaster_worker` (one USB reader for the whole server) and per-client `spawn_client_workers` that handshakes + registers + spawns writer + command. No more second-connection reject.
- **`ServerStats` break** — `connected_clients: Vec<ClientInfo>` + aggregate (`total_bytes_sent`, `total_buffers_dropped`, `lifetime_accepted`). No shim. Linux UI + C ABI + header all updated in the same PR (per user guidance: break cleanly, no legacy compat).
- **Device state**: `apply_initial_state` runs once at `Server::start`, never re-applied per-accept. Clients share live state (broadcast-radio semantics). Role-based tune/command gating ships in #392.

## Commits

1. **broadcaster module** — types + registry API + 11 unit tests. Registry methods, drop-on-full, disconnection lifecycle, snapshot contract.
2. **server refactor** — broadcaster thread, per-client workers, accept-loop-registers-N. Uses internal `project_to_legacy_stats` helper to keep the workspace compiling through this commit. Preserves all pre-#391 single-server-side tests.
3. **ServerStats break** — clean API swap. All consumers updated: Linux UI renders per-client list with "(+N more)" suffix and switches data-rate to the aggregate counter; FFI C ABI gets `SdrRtlTcpServerStats` shrunk to aggregates + new `SdrRtlTcpClientInfo` + new `sdr_rtltcp_server_client_list` accessor; `recent_commands_json` takes a `client_id`; C header updated to match.
4. **integration tests** — three concurrent producer-consumer tests: two-clients-identical-streams, slow-client-drops-don't-block-fast, disconnect-mid-stream.

## Follow-ups

- **#401** (filed) — Swift macOS app: align `SdrCoreKit` bindings to the new C struct + accessor. Safe to lag — no Mac release pipeline consumes main.
- **PR B** (to come, same epic) — rich per-client UI rows in the "Share over network" sidebar (one `AdwActionRow` per connected client with bytes/s + codec badge + uptime + per-client activity log). Scope is purely rendering the `Vec<ClientInfo>` well.
- **#392** (role gate) + **#394** (auth) can land in parallel on top of this PR.

## Test plan

- [x] `cargo test --workspace --features whisper-cpu` — 1109 tests pass (broadcaster 11, server-rtltcp 58, ffi 37, ui 155, integration 3, + the rest of the workspace).
- [x] `cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Manual UI smoke (owner): "Share over network" panel starts the server; connecting 1 client shows single-client rendering; connecting 2 clients shows "peer1 (+1 more)" on the client row and "2 clients connected" on the expander.
- [ ] Manual compatibility smoke (owner): connect a vanilla `rtl_tcp` client (GQRX / SDR++) to the server, verify it still works unchanged (no hello, no extension); then connect a second one simultaneously and verify both stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi‑client fan‑out with per‑client queues, registry and per‑client snapshots.
  * Client snapshot API including per‑client recent‑command metadata.

* **Changes**
  * Server stats are now aggregate lifetime counters; per‑client/session details moved to client snapshots.
  * Recent‑commands API requires a client identifier and reports invalid/stale client IDs.
  * UI updated for multiple clients (primary client display, “+N-1” indicator, aggregate data‑rate/uptime, commander selection).

* **Other**
  * Public ABI minor version bumped; client peer length exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->