### PR TITLE
rtl_tcp: role gate + listener cap (#392)

### DIFF
--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 15;
+pub const ABI_VERSION_MINOR: u32 = 16;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 15);
+        assert!(ABI_VERSION_MINOR == 16);
     };
 
     #[test]

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -78,6 +78,12 @@ pub struct SdrRtlTcpServerConfig {
     /// Direct-sampling mode: 0 = off, 1 = I, 2 = Q. Rejected
     /// outside this range by `sdr_rtltcp_server_start`.
     pub initial_direct_sampling: i32,
+    /// Maximum concurrent `Role::Listen` clients. 0 = use
+    /// [`sdr_server_rtltcp::DEFAULT_LISTENER_CAP`] (10). Vanilla
+    /// `rtl_tcp` clients and the single Control client are NOT
+    /// counted — they occupy the controller slot, which is
+    /// separate from the listener pool. #392.
+    pub listener_cap: u32,
 }
 
 /// Aggregate server-lifetime statistics snapshot.
@@ -435,6 +441,11 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
         } else {
             cfg.buffer_capacity as usize
         };
+        let listener_cap = if cfg.listener_cap == 0 {
+            sdr_server_rtltcp::DEFAULT_LISTENER_CAP
+        } else {
+            cfg.listener_cap as usize
+        };
         let server_cfg = ServerConfig {
             bind,
             device_index: cfg.device_index,
@@ -446,6 +457,7 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
             // clients keep working; the Linux GTK path is the only
             // one that currently offers LZ4.
             compression: CodecMask::NONE_ONLY,
+            listener_cap,
         };
         match Server::start(server_cfg) {
             Ok(server) => {
@@ -1074,6 +1086,7 @@ mod tests {
             initial_ppm: 0,
             initial_bias_tee: false,
             initial_direct_sampling: 0,
+            listener_cap: 0, // 0 → use DEFAULT_LISTENER_CAP
         }
     }
 
@@ -1154,6 +1167,7 @@ mod tests {
             initial_ppm: 0,
             initial_bias_tee: false,
             initial_direct_sampling: 0,
+            listener_cap: 0,
         };
         let mut handle: *mut SdrRtlTcpServer = std::ptr::null_mut();
         let rc = unsafe { sdr_rtltcp_server_start(&raw const opts, &raw mut handle) };

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -391,6 +391,23 @@ fn bind_socket_addr(bind: i32, port: u16) -> Result<SocketAddr, SdrCoreError> {
     }
 }
 
+/// Translate the C-ABI `listener_cap` field into the Rust
+/// `ServerConfig::listener_cap`. Zero means "use the crate
+/// default" per the header docs — the `0 → DEFAULT_LISTENER_CAP`
+/// rule is the public contract, so pulling it out of
+/// `sdr_rtltcp_server_start` makes it unit-testable without the
+/// hardware-backed start path. Non-zero values passthrough as
+/// `u32 → usize` (widening cast, always lossless on 32- and
+/// 64-bit targets we build for). Per `CodeRabbit` round 2 on
+/// PR #403.
+fn listener_cap_from_c(listener_cap: u32) -> usize {
+    if listener_cap == 0 {
+        sdr_server_rtltcp::DEFAULT_LISTENER_CAP
+    } else {
+        listener_cap as usize
+    }
+}
+
 // ============================================================
 //  FFI entry points
 // ============================================================
@@ -441,11 +458,7 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
         } else {
             cfg.buffer_capacity as usize
         };
-        let listener_cap = if cfg.listener_cap == 0 {
-            sdr_server_rtltcp::DEFAULT_LISTENER_CAP
-        } else {
-            cfg.listener_cap as usize
-        };
+        let listener_cap = listener_cap_from_c(cfg.listener_cap);
         let server_cfg = ServerConfig {
             bind,
             device_index: cfg.device_index,
@@ -1113,6 +1126,28 @@ mod tests {
     fn bind_socket_addr_zero_port_uses_default() {
         let addr = bind_socket_addr(SDR_BIND_LOOPBACK, 0).unwrap();
         assert_eq!(addr.port(), DEFAULT_PORT);
+    }
+
+    #[test]
+    fn listener_cap_from_c_zero_uses_default() {
+        // Contract: `SdrRtlTcpServerConfig::listener_cap == 0` is
+        // the "use the crate default" sentinel. Extracted helper
+        // lets this rule be verified without the hardware-backed
+        // `sdr_rtltcp_server_start` path. Per `CodeRabbit` round 2
+        // on PR #403.
+        assert_eq!(
+            listener_cap_from_c(0),
+            sdr_server_rtltcp::DEFAULT_LISTENER_CAP
+        );
+    }
+
+    #[test]
+    fn listener_cap_from_c_nonzero_is_preserved() {
+        // Non-zero values widen from u32 to usize without
+        // modification. Picking a mid-range value rules out an
+        // off-by-one that would have passed `listener_cap_from_c(1)
+        // == 1` trivially.
+        assert_eq!(listener_cap_from_c(7), 7);
     }
 
     #[test]

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -229,6 +229,16 @@ pub struct SdrRtlTcpClientInfo {
     /// `pick_most_recent_commander`). Valid only when
     /// `has_last_command == true`.
     pub last_command_age_secs: f64,
+    /// Role the server granted to this client: `0 = Control` (can
+    /// tune / change gain / etc.), `1 = Listen` (receives the IQ
+    /// stream; server drops any commands they send). Matches
+    /// `sdr_server_rtltcp::extension::Role::to_wire`. Hosts that
+    /// want to render a "Controller" / "Listener" badge in the
+    /// client list read this byte directly; the `Role::Control`
+    /// value is the default for vanilla `rtl_tcp` clients that
+    /// don't speak the RTLX extension (they always land in the
+    /// Control slot when it's free, never as listeners). #392.
+    pub role: u8,
 }
 
 impl Default for SdrRtlTcpClientInfo {
@@ -250,6 +260,7 @@ impl Default for SdrRtlTcpClientInfo {
             has_last_command: false,
             last_command_op: 0,
             last_command_age_secs: 0.0,
+            role: 0, // Role::Control wire byte
         }
     }
 }
@@ -878,6 +889,7 @@ fn client_info_to_c(info: &ClientInfo, snapshot_at: std::time::Instant) -> SdrRt
         has_last_command,
         last_command_op,
         last_command_age_secs,
+        role: info.role.to_wire(),
     };
     // Write peer_addr into the inline byte array, truncating at
     // `len - 1` to leave room for a NUL. Cast via &mut raw ptr
@@ -1241,6 +1253,7 @@ mod tests {
             peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_GAIN_PEER_PORT)),
             connected_since: std::time::Instant::now(),
             codec: Codec::Lz4,
+            role: sdr_server_rtltcp::extension::Role::Control,
             bytes_sent: TEST_CLIENT_BYTES_SENT,
             buffers_dropped: TEST_CLIENT_BUFFERS_DROPPED,
             last_command: None,
@@ -1341,6 +1354,7 @@ mod tests {
             peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_GAIN_PEER_PORT)),
             connected_since: std::time::Instant::now(),
             codec: Codec::None,
+            role: sdr_server_rtltcp::extension::Role::Control,
             bytes_sent: 0,
             buffers_dropped: 0,
             // `SetBiasTee` (0x0e) chosen because it's the highest
@@ -1389,6 +1403,7 @@ mod tests {
             peer: SocketAddr::from((TEST_CLIENT_PEER_IP, TEST_CLIENT_PEER_PORT)),
             connected_since: std::time::Instant::now(),
             codec: Codec::None,
+            role: sdr_server_rtltcp::extension::Role::Control,
             bytes_sent: 0,
             buffers_dropped: 0,
             last_command: None,
@@ -1452,6 +1467,7 @@ mod tests {
             peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_JSON_PEER_PORT)),
             connected_since: std::time::Instant::now(),
             codec: Codec::None,
+            role: sdr_server_rtltcp::extension::Role::Control,
             bytes_sent: 0,
             buffers_dropped: 0,
             last_command: None,

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -266,7 +266,7 @@ impl Default for SdrRtlTcpClientInfo {
             has_last_command: false,
             last_command_op: 0,
             last_command_age_secs: 0.0,
-            role: 0, // Role::Control wire byte
+            role: sdr_server_rtltcp::extension::Role::Control.to_wire(),
         }
     }
 }

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -1285,6 +1285,14 @@ mod tests {
         assert_eq!(c.id, TEST_CLIENT_ID);
         assert_eq!(c.bytes_sent, TEST_CLIENT_BYTES_SENT);
         assert_eq!(c.codec, 1); // LZ4 wire value
+        // Role projection: Control → 0 wire byte. Pins the #392
+        // FFI contract per `CodeRabbit` round 1 on PR #403 — a
+        // regression in `client_info_to_c` that drops the role
+        // field would otherwise slip through without detection.
+        assert_eq!(
+            c.role,
+            sdr_server_rtltcp::extension::Role::Control.to_wire()
+        );
         // `last_command` fixture is `None` for the whole test;
         // the projection must surface that as `has_last_command
         // == false` with the op / age fields defaulted to zero
@@ -1385,6 +1393,11 @@ mod tests {
         assert!(c.has_last_command);
         assert_eq!(c.last_command_op, CommandOp::SetBiasTee as u8);
         assert_eq!(c.last_command_op, 0x0e, "opcode wire byte");
+        // Role projection (round 1 on PR #403): Control → 0.
+        assert_eq!(
+            c.role,
+            sdr_server_rtltcp::extension::Role::Control.to_wire()
+        );
         #[allow(
             clippy::cast_precision_loss,
             reason = "seconds count fits in f64 mantissa"
@@ -1439,6 +1452,40 @@ mod tests {
             .expect("NUL terminator");
         let peer_str = std::str::from_utf8(&peer_bytes[..nul_pos]).unwrap();
         assert_eq!(peer_str, "192.168.1.100:1234");
+        // Role projection (round 1 on PR #403): Control → 0.
+        assert_eq!(
+            c.role,
+            sdr_server_rtltcp::extension::Role::Control.to_wire()
+        );
+    }
+
+    #[test]
+    fn client_info_to_c_projects_listen_role() {
+        // **Regression test for `CodeRabbit` round 1 on PR #403.**
+        // The existing projection tests all use `Role::Control`
+        // (the default for vanilla clients), so a bug that hard-
+        // coded `role: 0` in `client_info_to_c` would pass
+        // every test in this module. Flip a fixture to
+        // `Role::Listen` and verify the wire byte flips to 1.
+        use sdr_server_rtltcp::codec::Codec;
+        let info = ClientInfo {
+            id: TEST_CLIENT_ID,
+            peer: SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_GAIN_PEER_PORT)),
+            connected_since: std::time::Instant::now(),
+            codec: Codec::None,
+            role: sdr_server_rtltcp::extension::Role::Listen,
+            bytes_sent: 0,
+            buffers_dropped: 0,
+            last_command: None,
+            current_freq_hz: None,
+            current_sample_rate_hz: None,
+            current_gain_tenths_db: None,
+            current_gain_auto: None,
+            recent_commands: std::collections::VecDeque::new(),
+        };
+        let c = client_info_to_c(&info, std::time::Instant::now());
+        assert_eq!(c.role, sdr_server_rtltcp::extension::Role::Listen.to_wire());
+        assert_eq!(c.role, 1, "Listen wire byte");
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 
 use sdr_rtltcp_discovery::{AdvertiseOptions, Advertiser, TxtRecord, local_hostname};
 use sdr_server_rtltcp::server::{DEFAULT_SAMPLE_RATE_HZ, Server, ServerConfig};
-use sdr_server_rtltcp::{DEFAULT_BUFFER_CAPACITY, DEFAULT_PORT};
+use sdr_server_rtltcp::{DEFAULT_BUFFER_CAPACITY, DEFAULT_LISTENER_CAP, DEFAULT_PORT};
 
 /// How often `main` polls the shutdown / server-stopped flags. Below
 /// any user-perceptible latency; costs a few syscalls per second while
@@ -109,6 +109,12 @@ fn usage(exit_code: i32) -> ! {
     let _ = writeln!(
         out,
         "    --no-announce  Skip mDNS advertisement (default: advertise)"
+    );
+    let _ = writeln!(
+        out,
+        "    --listener-cap <N>  Max concurrent Role::Listen clients \
+         (default: {DEFAULT_LISTENER_CAP}; the single Control client is \
+         separate)"
     );
     let _ = writeln!(out, "    -h, --help   Show this help");
     std::process::exit(exit_code);
@@ -353,6 +359,11 @@ fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<(ServerConfig, DiscoveryOptio
             "--no-announce" => {
                 discovery.announce = false;
                 i += 1;
+            }
+            "--listener-cap" => {
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
+                config.listener_cap = v.parse().map_err(|_| ParseError)?;
+                i += 2;
             }
             _ => return Err(ParseError),
         }
@@ -641,6 +652,32 @@ mod tests {
         assert_eq!(cfg.buffer_capacity, 250);
         assert!(cfg.initial.bias_tee);
         assert_eq!(cfg.initial.direct_sampling, 2);
+    }
+
+    #[test]
+    fn parse_args_listener_cap_defaults_to_crate_default() {
+        // No `--listener-cap` flag → `ServerConfig::default_loopback`
+        // value, which is [`DEFAULT_LISTENER_CAP`]. Pins the contract
+        // that omitting the flag doesn't silently zero the cap.
+        let (cfg, _disc) = parse_args::<&str>(&[]).unwrap();
+        assert_eq!(cfg.listener_cap, DEFAULT_LISTENER_CAP);
+    }
+
+    #[test]
+    fn parse_args_listener_cap_override() {
+        // Explicit `--listener-cap N` overrides the default.
+        let args = ["--listener-cap", "25"];
+        let (cfg, _disc) = parse_args(&args).unwrap();
+        assert_eq!(cfg.listener_cap, 25);
+    }
+
+    #[test]
+    fn parse_args_listener_cap_rejects_non_numeric() {
+        // Non-u32 argument surfaces as `ParseError` — users get a
+        // clean "bad args" exit code instead of a silent fallback
+        // that would confuse "why is my cap still 10?"
+        let args = ["--listener-cap", "lots"];
+        assert!(parse_args(&args).is_err());
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -280,7 +280,8 @@ pub enum RoleDecision {
     /// `ServerExtension { granted_role: None, status: ControllerBusy }`
     /// to RTLX clients (vanilla clients get TCP FIN without a
     /// header so they see "connection refused"-equivalent), then
-    /// closes.
+    /// closes. **Transient** — clients treat this as retryable via
+    /// their connect/backoff loop.
     ControllerBusy,
     /// Client requested `Role::Listen` but `listener_cap` live
     /// listeners are already registered. Caller emits
@@ -288,6 +289,16 @@ pub enum RoleDecision {
     /// and closes. Vanilla clients never land here — they're
     /// always Control-or-denied.
     ListenerCapReached,
+    /// Registry's slots mutex is poisoned — a prior operation
+    /// panicked mid-update and the server is in a broken state.
+    /// Distinct from [`Self::ControllerBusy`] because the client
+    /// retry loop treats ControllerBusy as a transient "try again
+    /// in a second" hint; poison is a terminal server fault that
+    /// deserves a clean close + server-side log. Callers drop the
+    /// client with no wire response (no admission state to
+    /// narrate, and the server-side log captures the diagnostic).
+    /// Per `CodeRabbit` round 1 on PR #403. #392.
+    RegistryPoisoned,
 }
 
 /// Public snapshot of a client's state, returned by
@@ -445,13 +456,13 @@ impl ClientRegistry {
         // as `prune_disconnected` and `snapshot`, so the decision
         // sees a consistent live-set view.
         let Ok(mut guard) = self.slots.lock() else {
-            // Poisoned — safest fallback is to deny. A poisoned
-            // slot mutex means some earlier operation panicked
-            // mid-update; admitting a new client on top of that
-            // broken state invites cascading failures. The client
-            // gets ControllerBusy (caller decides how to frame
-            // the denial to the peer).
-            return RoleDecision::ControllerBusy;
+            // Poisoned — a prior operation panicked mid-update
+            // and the slot list is in a broken state. Surface as
+            // `RegistryPoisoned` rather than `ControllerBusy` so
+            // clients that retry transient denials don't thrash
+            // against a terminally-broken server. Per `CodeRabbit`
+            // round 1 on PR #403.
+            return RoleDecision::RegistryPoisoned;
         };
         match slot.role {
             Role::Control => {
@@ -475,6 +486,55 @@ impl ClientRegistry {
         self.lifetime_accepted.fetch_add(1, Ordering::Relaxed);
         guard.push(slot);
         RoleDecision::Granted
+    }
+
+    /// Undo a prior [`Self::register_with_role`] `Granted` outcome
+    /// after post-admission setup fails (header write fails, worker
+    /// spawn fails, etc.). Marks the slot disconnected so the
+    /// broadcaster stops fanning to it immediately, removes it
+    /// from the slot list, and decrements
+    /// [`Self::lifetime_accepted`] so sessions that never served a
+    /// byte don't inflate the "accepted clients" counter. Returns
+    /// `true` iff the slot was found and removed.
+    ///
+    /// Idempotent — safe to call even if the slot was already
+    /// pruned by [`Self::prune_disconnected`] or removed by a
+    /// concurrent rollback. The slot-list mutex serializes the
+    /// remove, and the decrement is tied 1:1 to the original
+    /// `register_with_role` increment via the `removed` guard, so
+    /// double-calls can't underflow the counter.
+    ///
+    /// Per `CodeRabbit` round 1 on PR #403.
+    pub fn unwind_admission(&self, slot: &Arc<ClientSlot>) -> bool {
+        // Flag the slot first so any in-flight broadcaster tick
+        // skips it before we even take the slots lock. This
+        // shrinks the fan-out window between the setup failure
+        // and the slot-list remove below to at most one
+        // broadcaster tick.
+        slot.mark_disconnected();
+        let Ok(mut guard) = self.slots.lock() else {
+            // Poisoned — the rollback target is inaccessible, but
+            // the server is in a terminal state anyway (see
+            // `RoleDecision::RegistryPoisoned`). Log + return
+            // `false` so callers can't double-count the failure.
+            tracing::warn!(
+                slot_id = slot.id,
+                "unwind_admission: registry slots mutex poisoned"
+            );
+            return false;
+        };
+        let before = guard.len();
+        guard.retain(|s| s.id != slot.id);
+        let removed = guard.len() < before;
+        if removed {
+            // `lifetime_accepted` was `fetch_add(1)`-bumped during
+            // `register_with_role`, so the corresponding
+            // `fetch_sub(1)` cancels it out exactly. No underflow
+            // risk because the `removed` guard ties the decrement
+            // to the prior increment 1:1.
+            self.lifetime_accepted.fetch_sub(1, Ordering::Relaxed);
+        }
+        removed
     }
 
     /// Park a per-client worker `JoinHandle` for later join.
@@ -1114,6 +1174,49 @@ mod tests {
     /// enough to hit the cap quickly without inflating the fixture.
     const TEST_LISTENER_CAP: usize = 2;
 
+    // ------------------------------------------------------------
+    // Named peer ports for the role-gate tests. Each test uses a
+    // disjoint 20_0XX / 20_1XX etc. block so log output points
+    // directly at the test that emitted the peer. Extracted per
+    // `CodeRabbit` round 1 on PR #403 — raw `20_001` / `20_010`
+    // literals aren't grep-friendly and drift naming conventions
+    // away from the rest of this module's `TEST_*_PORT` pattern.
+    // ------------------------------------------------------------
+
+    /// Single-Control happy path: port for the first (and only)
+    /// admitted client.
+    const ROLE_TEST_SINGLE_CTRL_PORT: u16 = 20_001;
+    /// `denies_second_control_as_controller_busy`: first Control
+    /// client (admitted) and second (denied).
+    const ROLE_TEST_BUSY_FIRST_CTRL_PORT: u16 = 20_010;
+    const ROLE_TEST_BUSY_SECOND_CTRL_PORT: u16 = 20_011;
+    /// `grants_second_control_after_first_disconnects`: original
+    /// Control then the takeover-via-disconnect successor.
+    const ROLE_TEST_DISCONNECT_FIRST_CTRL_PORT: u16 = 20_020;
+    const ROLE_TEST_DISCONNECT_SECOND_CTRL_PORT: u16 = 20_021;
+    /// `admits_listeners_up_to_cap`: Control base port + offset
+    /// per listener. The listener loop adds `i` to the base, so
+    /// the reserved block is `20_031..20_031 + TEST_LISTENER_CAP`.
+    const ROLE_TEST_ADMIT_CTRL_PORT: u16 = 20_030;
+    const ROLE_TEST_ADMIT_LISTENER_BASE_PORT: u16 = 20_031;
+    /// `denies_listen_past_cap`: listener-fill block + the
+    /// overflow peer that gets denied.
+    const ROLE_TEST_CAP_LISTENER_BASE_PORT: u16 = 20_040;
+    const ROLE_TEST_CAP_OVERFLOW_PORT: u16 = 20_049;
+    /// `counts_only_live_listeners_for_cap`: listener-fill block,
+    /// first overflow attempt that should be denied, and the
+    /// replacement that succeeds after a slot is freed.
+    const ROLE_TEST_LIVE_LISTENER_BASE_PORT: u16 = 20_050;
+    const ROLE_TEST_LIVE_DENIED_PORT: u16 = 20_058;
+    const ROLE_TEST_LIVE_REPLACEMENT_PORT: u16 = 20_059;
+
+    /// Convenience: compute the Nth listener port in a test that
+    /// stamps a contiguous block starting at `base`.
+    fn listener_port(base: u16, offset: usize) -> u16 {
+        base.checked_add(u16::try_from(offset).expect("offset fits u16"))
+            .expect("listener port fits u16")
+    }
+
     /// Build a slot with the requested role for the decision
     /// tests. Channel depth doesn't matter (nothing broadcasts
     /// here); `TEST_CHANNEL_DEPTH_SMALL` keeps allocation cheap.
@@ -1134,7 +1237,7 @@ mod tests {
         // slot lands in the registry and `lifetime_accepted`
         // bumps.
         let reg = ClientRegistry::new();
-        let slot = role_test_slot(&reg, 20_001, Role::Control);
+        let slot = role_test_slot(&reg, ROLE_TEST_SINGLE_CTRL_PORT, Role::Control);
         assert_eq!(
             reg.register_with_role(slot, TEST_LISTENER_CAP),
             RoleDecision::Granted
@@ -1149,12 +1252,12 @@ mod tests {
         // live and gets ControllerBusy without consuming a
         // lifetime_accepted slot (denials don't count).
         let reg = ClientRegistry::new();
-        let first = role_test_slot(&reg, 20_010, Role::Control);
+        let first = role_test_slot(&reg, ROLE_TEST_BUSY_FIRST_CTRL_PORT, Role::Control);
         assert_eq!(
             reg.register_with_role(first, TEST_LISTENER_CAP),
             RoleDecision::Granted
         );
-        let second = role_test_slot(&reg, 20_011, Role::Control);
+        let second = role_test_slot(&reg, ROLE_TEST_BUSY_SECOND_CTRL_PORT, Role::Control);
         assert_eq!(
             reg.register_with_role(second, TEST_LISTENER_CAP),
             RoleDecision::ControllerBusy
@@ -1174,13 +1277,13 @@ mod tests {
         // flow — we shouldn't require them to wait ~2.5s for
         // prune_disconnected to run.
         let reg = ClientRegistry::new();
-        let first = role_test_slot(&reg, 20_020, Role::Control);
+        let first = role_test_slot(&reg, ROLE_TEST_DISCONNECT_FIRST_CTRL_PORT, Role::Control);
         assert_eq!(
             reg.register_with_role(first.clone(), TEST_LISTENER_CAP),
             RoleDecision::Granted
         );
         first.mark_disconnected();
-        let second = role_test_slot(&reg, 20_021, Role::Control);
+        let second = role_test_slot(&reg, ROLE_TEST_DISCONNECT_SECOND_CTRL_PORT, Role::Control);
         assert_eq!(
             reg.register_with_role(second, TEST_LISTENER_CAP),
             RoleDecision::Granted
@@ -1194,13 +1297,17 @@ mod tests {
         // live simultaneously. Shape: Control doesn't contribute
         // to the listener count.
         let reg = ClientRegistry::new();
-        let ctrl = role_test_slot(&reg, 20_030, Role::Control);
+        let ctrl = role_test_slot(&reg, ROLE_TEST_ADMIT_CTRL_PORT, Role::Control);
         assert_eq!(
             reg.register_with_role(ctrl, TEST_LISTENER_CAP),
             RoleDecision::Granted
         );
         for i in 0..TEST_LISTENER_CAP {
-            let listener = role_test_slot(&reg, 20_031 + i as u16, Role::Listen);
+            let listener = role_test_slot(
+                &reg,
+                listener_port(ROLE_TEST_ADMIT_LISTENER_BASE_PORT, i),
+                Role::Listen,
+            );
             assert_eq!(
                 reg.register_with_role(listener, TEST_LISTENER_CAP),
                 RoleDecision::Granted,
@@ -1215,13 +1322,17 @@ mod tests {
         // Fill the cap, then attempt one more → ListenerCapReached.
         let reg = ClientRegistry::new();
         for i in 0..TEST_LISTENER_CAP {
-            let listener = role_test_slot(&reg, 20_040 + i as u16, Role::Listen);
+            let listener = role_test_slot(
+                &reg,
+                listener_port(ROLE_TEST_CAP_LISTENER_BASE_PORT, i),
+                Role::Listen,
+            );
             assert_eq!(
                 reg.register_with_role(listener, TEST_LISTENER_CAP),
                 RoleDecision::Granted
             );
         }
-        let overflow = role_test_slot(&reg, 20_049, Role::Listen);
+        let overflow = role_test_slot(&reg, ROLE_TEST_CAP_OVERFLOW_PORT, Role::Listen);
         assert_eq!(
             reg.register_with_role(overflow, TEST_LISTENER_CAP),
             RoleDecision::ListenerCapReached
@@ -1233,6 +1344,58 @@ mod tests {
     }
 
     #[test]
+    fn unwind_admission_removes_slot_and_decrements_counter() {
+        // **Regression guard for `CodeRabbit` round 1 on PR #403.**
+        // Post-register setup failures (try_clone, header write,
+        // worker spawn) must roll back the admission so
+        // `lifetime_accepted` doesn't inflate with sessions that
+        // never served a byte. Contract:
+        //   - slot is removed from the registry
+        //   - `lifetime_accepted` decrements 1:1 with the prior
+        //     register_with_role bump
+        //   - slot's `disconnected` flag is set (broadcaster
+        //     stops fanning immediately, before the slot-list
+        //     remove takes effect)
+        //   - double-call is idempotent (returns false the
+        //     second time; counter doesn't underflow)
+        let reg = ClientRegistry::new();
+        let slot = role_test_slot(&reg, ROLE_TEST_SINGLE_CTRL_PORT, Role::Control);
+        assert_eq!(
+            reg.register_with_role(slot.clone(), TEST_LISTENER_CAP),
+            RoleDecision::Granted
+        );
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.lifetime_accepted(), 1);
+
+        assert!(
+            reg.unwind_admission(&slot),
+            "first unwind should find the slot"
+        );
+        assert_eq!(reg.len(), 0, "unwound slot must not remain in the registry");
+        assert_eq!(
+            reg.lifetime_accepted(),
+            0,
+            "unwind should cancel the register_with_role bump"
+        );
+        assert!(
+            slot.is_disconnected(),
+            "unwind marks the slot dead so the broadcaster stops fanning"
+        );
+
+        // Second call: slot is gone → returns false, counter
+        // stays at zero (no underflow).
+        assert!(
+            !reg.unwind_admission(&slot),
+            "second unwind returns false because the slot is already gone"
+        );
+        assert_eq!(
+            reg.lifetime_accepted(),
+            0,
+            "double-unwind must not underflow lifetime_accepted"
+        );
+    }
+
+    #[test]
     fn register_with_role_counts_only_live_listeners_for_cap() {
         // A disconnected Listener frees a listener slot
         // immediately (same reasoning as the Control disconnect
@@ -1241,7 +1404,11 @@ mod tests {
         let reg = ClientRegistry::new();
         let mut listeners = Vec::new();
         for i in 0..TEST_LISTENER_CAP {
-            let listener = role_test_slot(&reg, 20_050 + i as u16, Role::Listen);
+            let listener = role_test_slot(
+                &reg,
+                listener_port(ROLE_TEST_LIVE_LISTENER_BASE_PORT, i),
+                Role::Listen,
+            );
             assert_eq!(
                 reg.register_with_role(listener.clone(), TEST_LISTENER_CAP),
                 RoleDecision::Granted
@@ -1249,14 +1416,14 @@ mod tests {
             listeners.push(listener);
         }
         // Cap is full — verify.
-        let denied = role_test_slot(&reg, 20_058, Role::Listen);
+        let denied = role_test_slot(&reg, ROLE_TEST_LIVE_DENIED_PORT, Role::Listen);
         assert_eq!(
             reg.register_with_role(denied, TEST_LISTENER_CAP),
             RoleDecision::ListenerCapReached
         );
         // Flip one listener to disconnected and retry.
         listeners[0].mark_disconnected();
-        let replacement = role_test_slot(&reg, 20_059, Role::Listen);
+        let replacement = role_test_slot(&reg, ROLE_TEST_LIVE_REPLACEMENT_PORT, Role::Listen);
         assert_eq!(
             reg.register_with_role(replacement, TEST_LISTENER_CAP),
             RoleDecision::Granted

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -66,6 +66,7 @@ use std::thread::JoinHandle;
 use std::time::Instant;
 
 use crate::codec::Codec;
+use crate::extension::Role;
 use crate::protocol::CommandOp;
 
 /// Default per-client bounded-channel capacity measured in 256 KiB USB
@@ -168,6 +169,16 @@ pub struct ClientSlot {
     /// lifetime — if the client wants to change codec they must
     /// reconnect.
     pub codec: Codec,
+    /// Role granted by the server during handshake. `Control` =
+    /// commands dispatched to the device; `Listen` = commands
+    /// dropped server-side (the command worker observes this and
+    /// logs + skips the dispatch). Immutable for the slot's
+    /// lifetime — if the client wants to change role they must
+    /// reconnect (or, once #393 lands, send a takeover request).
+    /// Vanilla `rtl_tcp` clients (no RTLX hello) always land here
+    /// as `Control`; they have no way to request `Listen` and the
+    /// server only admits them when the Control slot is free. #392.
+    pub role: Role,
     /// Write half of this client's bounded channel. The broadcaster
     /// calls [`SyncSender::try_send`] to push USB chunks; the
     /// client's writer thread owns the matching `Receiver` and
@@ -188,11 +199,14 @@ pub struct ClientSlot {
 impl ClientSlot {
     /// Construct a slot with a freshly-created bounded channel.
     /// Returns both the slot (ready to register) and the `Receiver`
-    /// that the writer thread consumes.
+    /// that the writer thread consumes. `role` is the server's
+    /// grant (not the client's request — the server may deny the
+    /// request, in which case no slot is built at all). #392.
     pub fn new(
         id: ClientId,
         peer: SocketAddr,
         codec: Codec,
+        role: Role,
         channel_depth: usize,
     ) -> (Arc<Self>, Receiver<Vec<u8>>) {
         let (tx, rx) = sync_channel::<Vec<u8>>(channel_depth);
@@ -201,6 +215,7 @@ impl ClientSlot {
             peer,
             connected_since: Instant::now(),
             codec,
+            role,
             tx,
             stats: Mutex::new(ClientStats::default()),
             disconnected: AtomicBool::new(false),
@@ -237,6 +252,7 @@ impl ClientSlot {
             peer: self.peer,
             connected_since: self.connected_since,
             codec: self.codec,
+            role: self.role,
             bytes_sent: stats_clone.bytes_sent,
             buffers_dropped: stats_clone.buffers_dropped,
             last_command: stats_clone.last_command,
@@ -259,6 +275,11 @@ pub struct ClientInfo {
     pub peer: SocketAddr,
     pub connected_since: Instant,
     pub codec: Codec,
+    /// Role the server granted to this client (`Control` dispatches
+    /// commands to the device; `Listen` drops them at the command
+    /// worker). Stats consumers render this as "Controller" /
+    /// "Listener" in the client list. #392.
+    pub role: Role,
     pub bytes_sent: u64,
     pub buffers_dropped: u64,
     pub last_command: Option<(CommandOp, Instant)>,
@@ -647,6 +668,7 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_GENERIC_A),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         reg.register(slot);
@@ -657,6 +679,7 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_GENERIC_B),
             Codec::Lz4,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         reg.register(slot2);
@@ -671,6 +694,7 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_FIRST),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         reg.register(slot);
@@ -692,12 +716,14 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_FIRST),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         let (s2, rx2) = ClientSlot::new(
             reg.allocate_id(),
             test_peer(TEST_PORT_SECOND),
             Codec::Lz4,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         reg.register(s1);
@@ -736,6 +762,7 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_FIRST),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH,
         );
         // Fast client with generous room — shouldn't drop anything.
@@ -743,6 +770,7 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_SECOND),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_GENEROUS,
         );
         let slow_id = slow.id;
@@ -777,6 +805,7 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_FIRST),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         reg.register(slot.clone());
@@ -796,6 +825,7 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_FIRST),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         reg.register(slot.clone());
@@ -820,12 +850,14 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_FIRST),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         let (dead, _dead_rx) = ClientSlot::new(
             reg.allocate_id(),
             test_peer(TEST_PORT_SECOND),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         dead.mark_disconnected();
@@ -845,6 +877,7 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_SNAPSHOT),
             Codec::Lz4,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         let slot_id = slot.id;
@@ -944,12 +977,14 @@ mod tests {
             reg.allocate_id(),
             test_peer(TEST_PORT_FIRST),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         let (dead, _dead_rx) = ClientSlot::new(
             reg.allocate_id(),
             test_peer(TEST_PORT_SECOND),
             Codec::None,
+            Role::Control,
             TEST_CHANNEL_DEPTH_STANDARD,
         );
         reg.register(live);

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -265,6 +265,31 @@ impl ClientSlot {
     }
 }
 
+/// Outcome of [`ClientRegistry::register_with_role`] — whether the
+/// slot was admitted, and if not, why. The caller maps these onto
+/// the wire-level `ServerExtension` response: `Granted` →
+/// `status=Ok, granted_role=Some(requested)`; denial variants →
+/// `status=<matching>, granted_role=None` (0xFF sentinel). #392.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoleDecision {
+    /// Slot registered. Caller proceeds with the handshake response
+    /// and spawns the per-client writer + command workers.
+    Granted,
+    /// Client requested `Role::Control` but another live slot is
+    /// already holding it. Caller emits
+    /// `ServerExtension { granted_role: None, status: ControllerBusy }`
+    /// to RTLX clients (vanilla clients get TCP FIN without a
+    /// header so they see "connection refused"-equivalent), then
+    /// closes.
+    ControllerBusy,
+    /// Client requested `Role::Listen` but `listener_cap` live
+    /// listeners are already registered. Caller emits
+    /// `ServerExtension { granted_role: None, status: ListenerCapReached }`
+    /// and closes. Vanilla clients never land here — they're
+    /// always Control-or-denied.
+    ListenerCapReached,
+}
+
 /// Public snapshot of a client's state, returned by
 /// [`ClientRegistry::snapshot`] and embedded in `ServerStats`. Flat
 /// (not an `Arc`) so stats consumers can clone it freely without
@@ -372,11 +397,84 @@ impl ClientRegistry {
     /// have been allocated via [`Self::allocate_id`]; the registry
     /// doesn't enforce this but stats consumers expect ids to be
     /// monotonic and unique.
+    ///
+    /// **No role/cap check** — admits unconditionally. Production
+    /// callers (`spawn_client_workers`) use
+    /// [`Self::register_with_role`] instead so the role gate and
+    /// listener cap enforcement happen atomically under the same
+    /// lock that would otherwise let two concurrent accepts both
+    /// claim Control. `register()` stays as the test-facing
+    /// convenience for fixtures that don't exercise the role
+    /// path.
     pub fn register(&self, slot: Arc<ClientSlot>) {
         self.lifetime_accepted.fetch_add(1, Ordering::Relaxed);
         if let Ok(mut guard) = self.slots.lock() {
             guard.push(slot);
         }
+    }
+
+    /// Admit a slot if the server's role gate and listener cap
+    /// permit it. Returns the outcome so the caller can respond to
+    /// the client appropriately (Granted → continue the handshake,
+    /// denied → send a denial `ServerExtension` + close). The
+    /// slot's role (decided at construction time from the client's
+    /// hello, or defaulted to `Control` for vanilla clients) drives
+    /// the decision:
+    ///
+    /// - `Role::Control` — granted iff no other live slot currently
+    ///   has role Control. Denying with `ControllerBusy` because
+    ///   the Control slot is exclusive (one commander at a time).
+    /// - `Role::Listen` — granted iff the count of live `Listen`
+    ///   slots is strictly less than `listener_cap`. Denying with
+    ///   `ListenerCapReached`.
+    ///
+    /// "Live" means not flagged disconnected — the broadcaster's
+    /// periodic `prune_disconnected` sweep evicts dead slots, but
+    /// between sweeps a slot can already be marked disconnected.
+    /// Using the flag for the check means a dropping-Control
+    /// client frees the slot immediately on their worker
+    /// disconnecting, without waiting for the next prune tick.
+    ///
+    /// `lifetime_accepted` is bumped only on `Granted` — the
+    /// counter tracks real admissions, not denied-handshake
+    /// attempts. #392.
+    pub fn register_with_role(&self, slot: Arc<ClientSlot>, listener_cap: usize) -> RoleDecision {
+        // Lock the slot list first so the decision + push land
+        // atomically — two concurrent Control requests can't both
+        // observe "slot free" and both push. Same lock discipline
+        // as `prune_disconnected` and `snapshot`, so the decision
+        // sees a consistent live-set view.
+        let Ok(mut guard) = self.slots.lock() else {
+            // Poisoned — safest fallback is to deny. A poisoned
+            // slot mutex means some earlier operation panicked
+            // mid-update; admitting a new client on top of that
+            // broken state invites cascading failures. The client
+            // gets ControllerBusy (caller decides how to frame
+            // the denial to the peer).
+            return RoleDecision::ControllerBusy;
+        };
+        match slot.role {
+            Role::Control => {
+                let has_live_controller = guard
+                    .iter()
+                    .any(|s| s.role == Role::Control && !s.is_disconnected());
+                if has_live_controller {
+                    return RoleDecision::ControllerBusy;
+                }
+            }
+            Role::Listen => {
+                let live_listeners = guard
+                    .iter()
+                    .filter(|s| s.role == Role::Listen && !s.is_disconnected())
+                    .count();
+                if live_listeners >= listener_cap {
+                    return RoleDecision::ListenerCapReached;
+                }
+            }
+        }
+        self.lifetime_accepted.fetch_add(1, Ordering::Relaxed);
+        guard.push(slot);
+        RoleDecision::Granted
     }
 
     /// Park a per-client worker `JoinHandle` for later join.
@@ -999,5 +1097,169 @@ mod tests {
         reg.prune_disconnected();
         assert_eq!(reg.len(), 1);
         assert_eq!(reg.snapshot().len(), 1);
+    }
+
+    // ============================================================
+    // register_with_role decision matrix (#392)
+    //
+    // These cover the atomic role-gate contract at the registry
+    // level — `spawn_client_workers` is the sole production caller
+    // and threads the decision directly into the `ServerExtension`
+    // response block, so pinning the decision semantics here is
+    // the durable guard against future regressions in either the
+    // role gate or the listener cap.
+    // ============================================================
+
+    /// Test listener cap shared across the role-gate tests. Small
+    /// enough to hit the cap quickly without inflating the fixture.
+    const TEST_LISTENER_CAP: usize = 2;
+
+    /// Build a slot with the requested role for the decision
+    /// tests. Channel depth doesn't matter (nothing broadcasts
+    /// here); `TEST_CHANNEL_DEPTH_SMALL` keeps allocation cheap.
+    fn role_test_slot(reg: &ClientRegistry, port: u16, role: Role) -> Arc<ClientSlot> {
+        let (slot, _rx) = ClientSlot::new(
+            reg.allocate_id(),
+            test_peer(port),
+            Codec::None,
+            role,
+            TEST_CHANNEL_DEPTH_SMALL,
+        );
+        slot
+    }
+
+    #[test]
+    fn register_with_role_grants_first_control_client() {
+        // No prior clients → a Control request fits. Verify the
+        // slot lands in the registry and `lifetime_accepted`
+        // bumps.
+        let reg = ClientRegistry::new();
+        let slot = role_test_slot(&reg, 20_001, Role::Control);
+        assert_eq!(
+            reg.register_with_role(slot, TEST_LISTENER_CAP),
+            RoleDecision::Granted
+        );
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.lifetime_accepted(), 1);
+    }
+
+    #[test]
+    fn register_with_role_denies_second_control_as_controller_busy() {
+        // First Control grants; second Control sees the first
+        // live and gets ControllerBusy without consuming a
+        // lifetime_accepted slot (denials don't count).
+        let reg = ClientRegistry::new();
+        let first = role_test_slot(&reg, 20_010, Role::Control);
+        assert_eq!(
+            reg.register_with_role(first, TEST_LISTENER_CAP),
+            RoleDecision::Granted
+        );
+        let second = role_test_slot(&reg, 20_011, Role::Control);
+        assert_eq!(
+            reg.register_with_role(second, TEST_LISTENER_CAP),
+            RoleDecision::ControllerBusy
+        );
+        // Registry still only has the first — denial must not
+        // push.
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.lifetime_accepted(), 1);
+    }
+
+    #[test]
+    fn register_with_role_grants_second_control_after_first_disconnects() {
+        // Contract: the "live" check treats disconnected slots as
+        // absent (so a freshly-dropping Control client opens the
+        // slot before the next prune tick lands). This matters
+        // for the natural "user 1 disconnects, user 2 reconnects"
+        // flow — we shouldn't require them to wait ~2.5s for
+        // prune_disconnected to run.
+        let reg = ClientRegistry::new();
+        let first = role_test_slot(&reg, 20_020, Role::Control);
+        assert_eq!(
+            reg.register_with_role(first.clone(), TEST_LISTENER_CAP),
+            RoleDecision::Granted
+        );
+        first.mark_disconnected();
+        let second = role_test_slot(&reg, 20_021, Role::Control);
+        assert_eq!(
+            reg.register_with_role(second, TEST_LISTENER_CAP),
+            RoleDecision::Granted
+        );
+        assert_eq!(reg.lifetime_accepted(), 2);
+    }
+
+    #[test]
+    fn register_with_role_admits_listeners_up_to_cap() {
+        // Coexistence test: one Control + up-to-cap Listeners all
+        // live simultaneously. Shape: Control doesn't contribute
+        // to the listener count.
+        let reg = ClientRegistry::new();
+        let ctrl = role_test_slot(&reg, 20_030, Role::Control);
+        assert_eq!(
+            reg.register_with_role(ctrl, TEST_LISTENER_CAP),
+            RoleDecision::Granted
+        );
+        for i in 0..TEST_LISTENER_CAP {
+            let listener = role_test_slot(&reg, 20_031 + i as u16, Role::Listen);
+            assert_eq!(
+                reg.register_with_role(listener, TEST_LISTENER_CAP),
+                RoleDecision::Granted,
+                "listener {i} should fit under cap {TEST_LISTENER_CAP}"
+            );
+        }
+        assert_eq!(reg.len(), 1 + TEST_LISTENER_CAP);
+    }
+
+    #[test]
+    fn register_with_role_denies_listen_past_cap() {
+        // Fill the cap, then attempt one more → ListenerCapReached.
+        let reg = ClientRegistry::new();
+        for i in 0..TEST_LISTENER_CAP {
+            let listener = role_test_slot(&reg, 20_040 + i as u16, Role::Listen);
+            assert_eq!(
+                reg.register_with_role(listener, TEST_LISTENER_CAP),
+                RoleDecision::Granted
+            );
+        }
+        let overflow = role_test_slot(&reg, 20_049, Role::Listen);
+        assert_eq!(
+            reg.register_with_role(overflow, TEST_LISTENER_CAP),
+            RoleDecision::ListenerCapReached
+        );
+        // Denial must not push into slots.
+        assert_eq!(reg.len(), TEST_LISTENER_CAP);
+        // Denials don't count toward lifetime_accepted.
+        assert_eq!(reg.lifetime_accepted() as usize, TEST_LISTENER_CAP);
+    }
+
+    #[test]
+    fn register_with_role_counts_only_live_listeners_for_cap() {
+        // A disconnected Listener frees a listener slot
+        // immediately (same reasoning as the Control disconnect
+        // test above). Fills cap, flips one to disconnected,
+        // verifies the next Listen fits.
+        let reg = ClientRegistry::new();
+        let mut listeners = Vec::new();
+        for i in 0..TEST_LISTENER_CAP {
+            let listener = role_test_slot(&reg, 20_050 + i as u16, Role::Listen);
+            assert_eq!(
+                reg.register_with_role(listener.clone(), TEST_LISTENER_CAP),
+                RoleDecision::Granted
+            );
+            listeners.push(listener);
+        }
+        // Cap is full — verify.
+        let denied = role_test_slot(&reg, 20_058, Role::Listen);
+        assert_eq!(
+            reg.register_with_role(denied, TEST_LISTENER_CAP),
+            RoleDecision::ListenerCapReached
+        );
+        // Flip one listener to disconnected and retry.
+        listeners[0].mark_disconnected();
+        let replacement = role_test_slot(&reg, 20_059, Role::Listen);
+        assert_eq!(
+            reg.register_with_role(replacement, TEST_LISTENER_CAP),
+            RoleDecision::Granted
+        );
     }
 }

--- a/crates/sdr-server-rtltcp/src/extension.rs
+++ b/crates/sdr-server-rtltcp/src/extension.rs
@@ -43,7 +43,8 @@
 //! 4    1     codec             chosen codec scalar (#307)
 //! 5    1     granted_role      0=control, 1=listen, 255=denied (reserved for #392)
 //! 6    1     status            0=ok, 1=controller_busy, 2=auth_required,
-//!                               3=auth_failed (reserved for #392/#394)
+//!                               3=auth_failed, 4=listener_cap_reached
+//!                               (0/1/4 used by #392, 2/3 reserved for #394)
 //! 7    1     version           response schema version, currently 1
 //! ```
 //!
@@ -110,22 +111,30 @@ impl Role {
     }
 }
 
-/// Status code in the server's response block. Reserved —
-/// #307 only ever emits [`Self::Ok`]; #392 and #394 use the other
-/// variants when roles / auth are active.
+/// Status code in the server's response block. Variants 0, 1, 4
+/// are live with #392 (role gate + listener cap); 2 and 3 are
+/// reserved for #394 (auth) and will be emitted by a future
+/// handshake layer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Status {
     /// Negotiation succeeded. Client proceeds to the IQ stream.
     Ok = 0,
     /// Controller slot is busy and the client didn't request
-    /// takeover. Reserved for #392.
+    /// takeover. #392.
     ControllerBusy = 1,
     /// Server requires an auth key and the client didn't provide
     /// one. Reserved for #394.
     AuthRequired = 2,
     /// Client-provided auth key didn't match. Reserved for #394.
     AuthFailed = 3,
+    /// Server's listener slot count (`ServerConfig::listener_cap`)
+    /// is already fully allocated; the client asked for
+    /// `Role::Listen` and there's no room. #392. Additive wire
+    /// code — new variants don't version-bump as long as the
+    /// `PROTOCOL_VERSION` gate catches peers reading layouts
+    /// they don't understand.
+    ListenerCapReached = 4,
 }
 
 impl Status {
@@ -139,6 +148,7 @@ impl Status {
             1 => Some(Self::ControllerBusy),
             2 => Some(Self::AuthRequired),
             3 => Some(Self::AuthFailed),
+            4 => Some(Self::ListenerCapReached),
             _ => None,
         }
     }
@@ -406,6 +416,41 @@ mod tests {
         bytes[6] = Status::Ok.to_wire();
         bytes[7] = PROTOCOL_VERSION.wrapping_add(1);
         assert!(ServerExtension::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn server_extension_listener_cap_reached_round_trips() {
+        // #392 path: server denies a Listen request because the
+        // cap is already filled. Encoded with `granted_role =
+        // denied (0xFF)` + `status = ListenerCapReached (4)`.
+        // Additive status code — no PROTOCOL_VERSION bump needed
+        // because the schema gate already catches peers that
+        // read a value they don't know.
+        let ext = ServerExtension {
+            codec: Codec::None,
+            granted_role: None,
+            status: Status::ListenerCapReached,
+            version: PROTOCOL_VERSION,
+        };
+        let bytes = ext.to_bytes();
+        assert_eq!(bytes[5], GRANTED_ROLE_DENIED);
+        assert_eq!(bytes[6], 4);
+        assert_eq!(ServerExtension::from_bytes(&bytes), Some(ext));
+    }
+
+    #[test]
+    fn status_from_wire_covers_all_documented_variants() {
+        // Pin the 0/1/2/3/4 → enum mapping. A future addition
+        // that reshuffles the discriminants would break over-the-
+        // wire compat with already-shipped clients; this test is
+        // the trip-wire.
+        assert_eq!(Status::from_wire(0), Some(Status::Ok));
+        assert_eq!(Status::from_wire(1), Some(Status::ControllerBusy));
+        assert_eq!(Status::from_wire(2), Some(Status::AuthRequired));
+        assert_eq!(Status::from_wire(3), Some(Status::AuthFailed));
+        assert_eq!(Status::from_wire(4), Some(Status::ListenerCapReached));
+        assert_eq!(Status::from_wire(5), None);
+        assert_eq!(Status::from_wire(255), None);
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -48,6 +48,6 @@ pub use protocol::{
     TunerTypeCode,
 };
 pub use server::{
-    DEFAULT_BUFFER_CAPACITY, DEFAULT_CENTER_FREQ_HZ, DEFAULT_SAMPLE_RATE_HZ, InitialDeviceState,
-    READ_BUFFER_LEN, Server, ServerConfig, ServerStats, TunerAdvertiseInfo,
+    DEFAULT_BUFFER_CAPACITY, DEFAULT_CENTER_FREQ_HZ, DEFAULT_LISTENER_CAP, DEFAULT_SAMPLE_RATE_HZ,
+    InitialDeviceState, READ_BUFFER_LEN, Server, ServerConfig, ServerStats, TunerAdvertiseInfo,
 };

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -783,6 +783,22 @@ fn spawn_client_workers(
             }
             return;
         }
+        RoleDecision::RegistryPoisoned => {
+            // Terminal server fault — the slot list mutex was
+            // poisoned by an earlier panic mid-update. Don't
+            // write anything to the peer: RTLX clients treat
+            // `ControllerBusy` as transient and retry, so
+            // sending that (or any other denial) would invite a
+            // reconnect storm against a terminally broken
+            // server. Bare TCP FIN is the cleanest signal. Per
+            // `CodeRabbit` round 1 on PR #403.
+            tracing::error!(
+                %peer,
+                ?requested_role,
+                "rtl_tcp registry slots mutex poisoned — closing client without reply"
+            );
+            return;
+        }
     }
 
     // Granted path — slot is now in the registry. The broadcaster
@@ -799,7 +815,7 @@ fn spawn_client_workers(
                 %e,
                 "failed to clone client stream for writer — tearing down client"
             );
-            slot.mark_disconnected();
+            registry.unwind_admission(&slot);
             return;
         }
     };
@@ -811,7 +827,7 @@ fn spawn_client_workers(
     let header = {
         let Ok(dev) = device.lock() else {
             tracing::error!(%peer, "device mutex poisoned, aborting client");
-            slot.mark_disconnected();
+            registry.unwind_admission(&slot);
             return;
         };
         DongleInfo {
@@ -821,7 +837,7 @@ fn spawn_client_workers(
     };
     if let Err(e) = writer.write_all(&header.to_bytes()) {
         tracing::warn!(%peer, %e, "failed to send dongle_info_t — client gone");
-        slot.mark_disconnected();
+        registry.unwind_admission(&slot);
         return;
     }
 
@@ -838,7 +854,7 @@ fn spawn_client_workers(
         };
         if let Err(e) = writer.write_all(&ext.to_bytes()) {
             tracing::warn!(%peer, %e, "failed to send RTLX server extension — client gone");
-            slot.mark_disconnected();
+            registry.unwind_admission(&slot);
             return;
         }
     }
@@ -853,14 +869,17 @@ fn spawn_client_workers(
             %e,
             "set_write_timeout on data channel failed; tearing down client"
         );
-        slot.mark_disconnected();
+        registry.unwind_admission(&slot);
         return;
     }
 
     // Spawn writer + command threads. Pre-#392 spawn-before-register
     // ordering is inverted here (register happens during the
-    // decision above) so `mark_disconnected` on any spawn failure
-    // takes the already-registered slot out of fan-out.
+    // decision above) so every failure path from this point on
+    // must call `registry.unwind_admission(&slot)` — that marks
+    // the slot disconnected AND rolls back the admission so
+    // `lifetime_accepted` stays tied to sessions that actually
+    // began serving. Per `CodeRabbit` round 1 on PR #403.
     let writer_slot = slot.clone();
     let writer_shutdown = shutdown.clone();
     let tracked_writer = StatsTrackingWrite {
@@ -881,14 +900,14 @@ fn spawn_client_workers(
                 %e,
                 "failed to spawn rtl_tcp writer thread — tearing down client"
             );
-            slot.mark_disconnected();
+            registry.unwind_admission(&slot);
             return;
         }
     };
 
-    // Spawn the command thread. If it fails, mark the slot
-    // disconnected so the writer exits too, and join the writer
-    // here so its handle isn't dropped on the floor.
+    // Spawn the command thread. If it fails, unwind the admission
+    // (also marks the slot disconnected so the writer exits) and
+    // join the writer here so its handle isn't dropped on the floor.
     let command_slot = slot.clone();
     let command_shutdown = shutdown.clone();
     let command_device = device;
@@ -910,7 +929,7 @@ fn spawn_client_workers(
                 %e,
                 "failed to spawn rtl_tcp command thread — tearing down client"
             );
-            slot.mark_disconnected();
+            registry.unwind_admission(&slot);
             let _ = writer_handle.join();
             return;
         }

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -45,7 +45,7 @@ use std::time::{Duration, Instant};
 
 use sdr_rtlsdr::device::RtlSdrDevice;
 
-use crate::broadcaster::{ClientRegistry, ClientSlot};
+use crate::broadcaster::{ClientRegistry, ClientSlot, RoleDecision};
 use crate::codec::{Codec, CodecMask, Encoder};
 use crate::dispatch::dispatch;
 use crate::error::ServerError;
@@ -376,6 +376,7 @@ impl Server {
             stopped.clone(),
             per_client_depth,
             config.compression,
+            config.listener_cap,
         ) {
             Ok(h) => h,
             Err(e) => {
@@ -603,6 +604,7 @@ fn spawn_accept_thread(
     stopped: Arc<AtomicBool>,
     per_client_buffer_depth: usize,
     compression: CodecMask,
+    listener_cap: usize,
 ) -> std::io::Result<JoinHandle<()>> {
     listener.set_nonblocking(true)?;
     thread::Builder::new()
@@ -625,6 +627,7 @@ fn spawn_accept_thread(
                             shutdown.clone(),
                             per_client_buffer_depth,
                             compression,
+                            listener_cap,
                         );
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -678,39 +681,137 @@ fn spawn_client_workers(
     shutdown: Arc<AtomicBool>,
     per_client_buffer_depth: usize,
     compression_offer: CodecMask,
+    listener_cap: usize,
 ) {
-    // Extended handshake (#307). Must run BEFORE we write the legacy
-    // `dongle_info_t` — if the client sent an `"RTLX"` hello, the
-    // server response block must be emitted immediately after the
-    // legacy header, all in one atomic stretch, so the client's peek
-    // for the `"RTLX"` magic lands on our bytes and not on IQ samples
-    // a racing broadcaster may have queued.
-    let negotiated_codec = match sniff_client_hello(&stream) {
-        Ok(Some(hello)) => {
-            let codec = compression_offer.pick(hello.codec_mask);
-            tracing::info!(
-                %peer,
-                client_mask = hello.codec_mask.to_wire(),
-                server_mask = compression_offer.to_wire(),
-                chosen = %codec,
-                "rtl_tcp extended-handshake negotiated"
-            );
-            Some(codec)
-        }
-        Ok(None) => {
-            tracing::debug!(%peer, "rtl_tcp no extended-handshake hello — legacy client path");
-            None
-        }
+    // Extended handshake (#307) — sniff the RTLX hello if the
+    // client sent one. The outcome drives both codec negotiation
+    // and the role request that feeds the #392 admission gate.
+    let sniff_outcome = match sniff_client_hello(&stream) {
+        Ok(h) => h,
         Err(e) => {
             tracing::warn!(%peer, %e, "rtl_tcp handshake sniff failed — dropping client");
             return;
         }
     };
+    // Split the sniff result into the fields we actually act on:
+    //   - `hello_seen` gates ServerExtension emission (vanilla
+    //     clients don't expect it; writing one would corrupt their
+    //     stream)
+    //   - `requested_role` is what the client asked for; vanilla
+    //     clients implicitly request `Control` since they have no
+    //     way to ask for Listen (no hello = no role byte)
+    //   - `negotiated_codec` is `None` for vanilla (always
+    //     uncompressed); `Some(_)` for RTLX clients — the
+    //     intersection of their mask and ours
+    let (hello_seen, requested_role, negotiated_codec) = if let Some(hello) = &sniff_outcome {
+        let codec = compression_offer.pick(hello.codec_mask);
+        tracing::info!(
+            %peer,
+            client_mask = hello.codec_mask.to_wire(),
+            server_mask = compression_offer.to_wire(),
+            chosen = %codec,
+            requested_role = ?hello.role,
+            "rtl_tcp extended-handshake negotiated"
+        );
+        (true, hello.role, Some(codec))
+    } else {
+        tracing::debug!(
+            %peer,
+            "rtl_tcp no extended-handshake hello — legacy client path (implicit Role::Control)"
+        );
+        (false, Role::Control, None)
+    };
+    let codec = negotiated_codec.unwrap_or(Codec::None);
+
+    // Allocate id + build slot with the requested role + channel.
+    // The slot is not yet registered — `register_with_role` below
+    // takes the slots mutex and checks the role/cap atomically
+    // before admitting.
+    let id = registry.allocate_id();
+    let (slot, rx) = ClientSlot::new(id, peer, codec, requested_role, per_client_buffer_depth);
+
+    // Atomic #392 admission. On `Granted` the slot is now in the
+    // registry and the broadcaster can find it on its next tick;
+    // on denial the slot is never pushed and drops on scope exit.
+    let decision = registry.register_with_role(slot.clone(), listener_cap);
+    match decision {
+        RoleDecision::Granted => {
+            tracing::info!(
+                %peer,
+                client_id = id,
+                ?requested_role,
+                ?codec,
+                "rtl_tcp client admitted"
+            );
+        }
+        RoleDecision::ControllerBusy => {
+            tracing::info!(
+                %peer,
+                ?requested_role,
+                "rtl_tcp Control slot busy — denying client"
+            );
+            // RTLX clients get the full denial response so their UI
+            // can show "controller busy" rather than a bare EOF.
+            // Vanilla clients get TCP FIN with no bytes — cleanest
+            // signal for their "connection refused" UX and avoids
+            // handing them a dongle_info_t they'd interpret as
+            // admission.
+            if hello_seen {
+                send_denied_response(&stream, peer, &device, Status::ControllerBusy);
+            }
+            return;
+        }
+        RoleDecision::ListenerCapReached => {
+            tracing::info!(
+                %peer,
+                ?requested_role,
+                cap = listener_cap,
+                "rtl_tcp listener cap reached — denying client"
+            );
+            // Vanilla clients never land here — they always request
+            // (implicit) Control, which routes through the
+            // ControllerBusy path above. Defensive debug_assert
+            // catches any future regression that breaks that
+            // invariant; runtime behavior stays safe (TCP FIN
+            // only) even if the assert fires.
+            debug_assert!(
+                hello_seen,
+                "vanilla clients should never land in ListenerCapReached"
+            );
+            if hello_seen {
+                send_denied_response(&stream, peer, &device, Status::ListenerCapReached);
+            }
+            return;
+        }
+    }
+
+    // Granted path — slot is now in the registry. The broadcaster
+    // can begin fan-out as soon as its next tick runs; any chunks
+    // that arrive before the writer thread spawns queue in the
+    // bounded channel and get recorded as per-client `buffers_dropped`
+    // if the channel fills first. Worker spawn is microseconds
+    // away so the drop risk is negligible in practice.
+    let writer_stream = match stream.try_clone() {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!(
+                %peer,
+                %e,
+                "failed to clone client stream for writer — tearing down client"
+            );
+            slot.mark_disconnected();
+            return;
+        }
+    };
+    let mut writer = writer_stream;
 
     // Send the 12-byte dongle_info_t header (rtl_tcp.c:576-594).
+    // Emitted for BOTH granted RTLX and granted vanilla — it's the
+    // first thing any rtl_tcp client expects.
     let header = {
         let Ok(dev) = device.lock() else {
             tracing::error!(%peer, "device mutex poisoned, aborting client");
+            slot.mark_disconnected();
             return;
         };
         DongleInfo {
@@ -718,35 +819,26 @@ fn spawn_client_workers(
             gain_count: dev.tuner_gains().len() as u32,
         }
     };
-    let header_bytes = header.to_bytes();
-    let writer_stream = match stream.try_clone() {
-        Ok(w) => w,
-        Err(e) => {
-            tracing::error!(%peer, %e, "failed to clone client stream for writer — dropping client");
-            return;
-        }
-    };
-    let mut writer = writer_stream;
-    if let Err(e) = writer.write_all(&header_bytes) {
+    if let Err(e) = writer.write_all(&header.to_bytes()) {
         tracing::warn!(%peer, %e, "failed to send dongle_info_t — client gone");
+        slot.mark_disconnected();
         return;
     }
 
-    // Emit the `ServerExtension` block immediately after
-    // `dongle_info_t` when we negotiated the extended protocol. Must
-    // land before any IQ data or the client's magic-peek will read
-    // random samples instead.
-    if let Some(codec) = negotiated_codec {
+    // RTLX clients additionally get the ServerExtension(granted)
+    // block. Must land immediately after dongle_info_t so the
+    // client's magic-peek lands on our bytes and not on IQ samples
+    // a racing broadcaster may have queued.
+    if hello_seen {
         let ext = ServerExtension {
             codec,
-            // #391 is still single-controller; role always reports
-            // Control until #392 plugs in the actual role gate.
-            granted_role: Some(Role::Control),
+            granted_role: Some(requested_role),
             status: Status::Ok,
             version: PROTOCOL_VERSION,
         };
         if let Err(e) = writer.write_all(&ext.to_bytes()) {
             tracing::warn!(%peer, %e, "failed to send RTLX server extension — client gone");
+            slot.mark_disconnected();
             return;
         }
     }
@@ -756,23 +848,19 @@ fn spawn_client_workers(
     // stream's `write()`, which in turn enforces `SO_SNDTIMEO`.
     // Setting after-wrap would lose visibility into the inner stream.
     if let Err(e) = writer.set_write_timeout(Some(WRITER_RECV_TIMEOUT)) {
-        tracing::warn!(%peer, %e, "set_write_timeout on data channel failed; dropping client");
+        tracing::warn!(
+            %peer,
+            %e,
+            "set_write_timeout on data channel failed; tearing down client"
+        );
+        slot.mark_disconnected();
         return;
     }
 
-    // Build the slot, allocating a fresh id + per-client channel.
-    let id = registry.allocate_id();
-    let codec = negotiated_codec.unwrap_or(Codec::None);
-    // Role grant defaults to `Control` for this commit — #392's
-    // next commit adds the atomic role/cap decision and feeds the
-    // actual granted role here. Leaving `Control` preserves
-    // pre-#392 single-client behavior while the field is wired up.
-    let (slot, rx) = ClientSlot::new(id, peer, codec, Role::Control, per_client_buffer_depth);
-
-    // Spawn the writer first so that by the time we register, the
-    // receiver end of the slot's channel is already being drained.
-    // If spawn fails, bail without registering — no half-registered
-    // clients to clean up.
+    // Spawn writer + command threads. Pre-#392 spawn-before-register
+    // ordering is inverted here (register happens during the
+    // decision above) so `mark_disconnected` on any spawn failure
+    // takes the already-registered slot out of fan-out.
     let writer_slot = slot.clone();
     let writer_shutdown = shutdown.clone();
     let tracked_writer = StatsTrackingWrite {
@@ -788,7 +876,12 @@ fn spawn_client_workers(
         }) {
         Ok(h) => h,
         Err(e) => {
-            tracing::error!(%peer, %e, "failed to spawn rtl_tcp writer thread — dropping client");
+            tracing::error!(
+                %peer,
+                %e,
+                "failed to spawn rtl_tcp writer thread — tearing down client"
+            );
+            slot.mark_disconnected();
             return;
         }
     };
@@ -812,19 +905,16 @@ fn spawn_client_workers(
         }) {
         Ok(h) => h,
         Err(e) => {
-            tracing::error!(%peer, %e, "failed to spawn rtl_tcp command thread — tearing down client");
+            tracing::error!(
+                %peer,
+                %e,
+                "failed to spawn rtl_tcp command thread — tearing down client"
+            );
             slot.mark_disconnected();
             let _ = writer_handle.join();
             return;
         }
     };
-
-    // All three threads (writer, command, broadcaster-observing-this-slot)
-    // are now set up. Register the slot so the broadcaster starts
-    // fanning out to it. Registration order matters: before register,
-    // the broadcaster can't find the slot; after register, the
-    // broadcaster discovers it on its next tick.
-    registry.register(slot);
 
     // Park both worker handles on the registry so `Server::drop`
     // can join any still running at shutdown — without this, the
@@ -843,6 +933,72 @@ fn spawn_client_workers(
     // joined here. Both exit independently when they observe the
     // shutdown flag or the slot's disconnection flag. The slot itself
     // is retained by the registry until it's pruned.
+}
+
+/// Emit a dongle_info_t + denial `ServerExtension` to an RTLX
+/// client whose admission the role gate refused, then let the
+/// stream drop out of scope so the TCP FIN reaches the peer. Only
+/// called for RTLX clients — vanilla peers get a bare TCP close
+/// (no bytes) because they'd mis-parse any response we wrote. The
+/// dongle_info_t block comes first because the RTLX client
+/// protocol expects it at the head of the stream regardless of
+/// whether the handshake was accepted; the ServerExtension
+/// follows with `granted_role = None` (0xFF wire sentinel) and
+/// the caller-supplied `status` (ControllerBusy or
+/// ListenerCapReached). Write failures downgrade to debug-level
+/// tracing because a refused-handshake peer often tears down the
+/// socket before our response lands — noisy warn! would bury
+/// real signal. #392.
+fn send_denied_response(
+    stream: &TcpStream,
+    peer: SocketAddr,
+    device: &Arc<Mutex<RtlSdrDevice>>,
+    status: Status,
+) {
+    let Ok(dev) = device.lock() else {
+        tracing::warn!(%peer, "device mutex poisoned during denial response");
+        return;
+    };
+    let header = DongleInfo {
+        tuner: TunerTypeCode::from(dev.tuner_type()),
+        gain_count: dev.tuner_gains().len() as u32,
+    };
+    drop(dev);
+    let mut writer = match stream.try_clone() {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(
+                %peer,
+                %e,
+                "failed to clone stream for denial response — closing without reply"
+            );
+            return;
+        }
+    };
+    if writer.write_all(&header.to_bytes()).is_err() {
+        tracing::debug!(
+            %peer,
+            ?status,
+            "failed to send dongle_info_t during denial — client already gone"
+        );
+        return;
+    }
+    let ext = ServerExtension {
+        // Codec choice is moot on denial — the client never
+        // proceeds to the IQ stream. `Codec::None` is the neutral
+        // choice: no allocation, always valid on the wire.
+        codec: Codec::None,
+        granted_role: None,
+        status,
+        version: PROTOCOL_VERSION,
+    };
+    if writer.write_all(&ext.to_bytes()).is_err() {
+        tracing::debug!(
+            %peer,
+            ?status,
+            "failed to send denial ServerExtension — client already gone"
+        );
+    }
 }
 
 fn configure_client_socket(stream: &TcpStream) {
@@ -1202,6 +1358,23 @@ fn command_worker(
             );
             continue;
         };
+        // Role gate (#392). Listener clients may send commands —
+        // the protocol doesn't stop them — but the server drops
+        // them server-side without touching the device. No reply
+        // is sent (keeps the wire protocol identical for Control
+        // and Listen); the listener's UI simply observes that its
+        // tune / gain commands have no effect, which matches the
+        // "passive observer" contract they signed up for by
+        // requesting Role::Listen.
+        if slot.role == Role::Listen {
+            tracing::debug!(
+                client_id = slot.id,
+                op = ?cmd.op,
+                param = cmd.param,
+                "rtl_tcp listener client attempted command — dropped"
+            );
+            continue;
+        }
         let Ok(mut dev) = device.lock() else {
             // Same rationale as the broadcaster: a poisoned device
             // mutex is unrecoverable, and silently dropping commands

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -744,7 +744,11 @@ fn spawn_client_workers(
     // Build the slot, allocating a fresh id + per-client channel.
     let id = registry.allocate_id();
     let codec = negotiated_codec.unwrap_or(Codec::None);
-    let (slot, rx) = ClientSlot::new(id, peer, codec, per_client_buffer_depth);
+    // Role grant defaults to `Control` for this commit — #392's
+    // next commit adds the atomic role/cap decision and feeds the
+    // actual granted role here. Leaving `Control` preserves
+    // pre-#392 single-client behavior while the field is wired up.
+    let (slot, rx) = ClientSlot::new(id, peer, codec, Role::Control, per_client_buffer_depth);
 
     // Spawn the writer first so that by the time we register, the
     // receiver end of the slot's channel is already being drained.
@@ -1490,6 +1494,7 @@ mod tests {
             registry.allocate_id(),
             SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_A_PORT)),
             Codec::None,
+            Role::Control,
             TEST_CLIENT_CHANNEL_DEPTH,
         );
         if let Ok(mut s) = slot_a.stats.lock() {
@@ -1502,6 +1507,7 @@ mod tests {
             registry.allocate_id(),
             SocketAddr::from(([127, 0, 0, 1], TEST_CLIENT_B_PORT)),
             Codec::Lz4,
+            Role::Control,
             TEST_CLIENT_CHANNEL_DEPTH,
         );
         if let Ok(mut s) = slot_b.stats.lock() {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -106,6 +106,13 @@ const USB_READ_TIMEOUT: Duration = Duration::from_secs(1);
 /// lock + retain work happen per chunk.
 const BROADCASTER_PRUNE_EVERY_N_TICKS: u32 = 256;
 
+/// Default cap on concurrent `Role::Listen` clients. Vanilla / Control
+/// clients are counted separately (they allocate the single controller
+/// slot). 10 is a generous default — real deployments pushing past this
+/// are either relay/broadcast scenarios where the UI gives the user an
+/// explicit "max listeners" knob, or a test setup. Per #390 decisions.
+pub const DEFAULT_LISTENER_CAP: usize = 10;
+
 /// Default sample rate in Hz. Matches upstream `rtl_tcp.c:DEFAULT_SAMPLE_RATE_HZ`.
 ///
 /// Exposed so the CLI can share the same constant instead of hard-coding
@@ -153,6 +160,17 @@ pub struct ServerConfig {
     /// [`CodecMask::NONE_ONLY`] — compression is opt-in per-
     /// server so existing deployments behave identically.
     pub compression: crate::codec::CodecMask,
+
+    /// Maximum concurrent `Role::Listen` clients. The Control client
+    /// is separate (always exactly one when occupied), so the total
+    /// live-client ceiling is `listener_cap + 1`. When the cap is
+    /// already filled, an RTLX client requesting `Role::Listen`
+    /// receives `granted_role=denied, status=ListenerCapReached` and
+    /// the connection is closed. Vanilla `rtl_tcp` clients never
+    /// enter the listener path — they're always Control-or-denied —
+    /// so the cap doesn't apply to them. Default:
+    /// [`DEFAULT_LISTENER_CAP`]. #392.
+    pub listener_cap: usize,
 }
 
 impl ServerConfig {
@@ -166,6 +184,7 @@ impl ServerConfig {
             initial: InitialDeviceState::default(),
             buffer_capacity: DEFAULT_BUFFER_CAPACITY,
             compression: crate::codec::CodecMask::NONE_ONLY,
+            listener_cap: DEFAULT_LISTENER_CAP,
         }
     }
 }
@@ -1406,6 +1425,7 @@ mod tests {
             initial: InitialDeviceState::default(),
             buffer_capacity: 0,
             compression: CodecMask::NONE_ONLY,
+            listener_cap: DEFAULT_LISTENER_CAP,
         };
         match Server::start(config) {
             Err(ServerError::PortInUse(ref addr)) => {

--- a/crates/sdr-server-rtltcp/tests/multi_client_fanout.rs
+++ b/crates/sdr-server-rtltcp/tests/multi_client_fanout.rs
@@ -157,11 +157,17 @@ fn two_clients_receive_identical_byte_streams() {
         Role::Control,
         TEST_FAST_CHANNEL_DEPTH,
     );
+    // Client B is a listener — pins the post-#392 contract that
+    // fan-out reaches Role::Listen slots identically to Control.
+    // If broadcast ever starts skipping listeners (e.g., a
+    // misplaced `slot.role == Role::Control` filter in the fanout
+    // path), this test flips to failure. Per `CodeRabbit` round 1
+    // on PR #403.
     let (slot_b, rx_b) = ClientSlot::new(
         registry.allocate_id(),
         test_peer(TEST_PEER_B_PORT),
         Codec::None,
-        Role::Control,
+        Role::Listen,
         TEST_FAST_CHANNEL_DEPTH,
     );
     registry.register(slot_a);
@@ -225,11 +231,16 @@ fn slow_client_drops_do_not_block_fast_client() {
     //     sees all 32 chunks in order.
     let registry = Arc::new(ClientRegistry::new());
 
+    // Slow client is the listener — proves a stalled listener
+    // doesn't block the controller's fan-out. This is the
+    // realistic production shape: the Control client is an
+    // active host and the slow neighbor is a passive listener
+    // with a full channel.
     let (slow, _slow_rx) = ClientSlot::new(
         registry.allocate_id(),
         test_peer(TEST_SLOW_PEER_PORT),
         Codec::None,
-        Role::Control,
+        Role::Listen,
         TEST_SLOW_CHANNEL_DEPTH,
     );
     let slow_id = slow.id;
@@ -316,11 +327,14 @@ fn disconnected_client_is_skipped_by_broadcaster_fanout() {
         Role::Control,
         TEST_FAST_CHANNEL_DEPTH,
     );
+    // Slot B is a listener — pins the post-#392 contract that
+    // mid-stream disconnect skip-on-fanout applies identically
+    // regardless of role.
     let (slot_b, rx_b) = ClientSlot::new(
         registry.allocate_id(),
         test_peer(TEST_DISCONNECT_B_PORT),
         Codec::None,
-        Role::Control,
+        Role::Listen,
         TEST_FAST_CHANNEL_DEPTH,
     );
     let slot_b_handle = slot_b.clone();

--- a/crates/sdr-server-rtltcp/tests/multi_client_fanout.rs
+++ b/crates/sdr-server-rtltcp/tests/multi_client_fanout.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, Instant};
 
 use sdr_server_rtltcp::broadcaster::{ClientRegistry, ClientSlot};
 use sdr_server_rtltcp::codec::Codec;
+use sdr_server_rtltcp::extension::Role;
 
 /// How many distinct chunks the producer thread fans out in each
 /// test. 32 is small enough for tests to finish quickly, large
@@ -153,12 +154,14 @@ fn two_clients_receive_identical_byte_streams() {
         registry.allocate_id(),
         test_peer(TEST_PEER_A_PORT),
         Codec::None,
+        Role::Control,
         TEST_FAST_CHANNEL_DEPTH,
     );
     let (slot_b, rx_b) = ClientSlot::new(
         registry.allocate_id(),
         test_peer(TEST_PEER_B_PORT),
         Codec::None,
+        Role::Control,
         TEST_FAST_CHANNEL_DEPTH,
     );
     registry.register(slot_a);
@@ -226,6 +229,7 @@ fn slow_client_drops_do_not_block_fast_client() {
         registry.allocate_id(),
         test_peer(TEST_SLOW_PEER_PORT),
         Codec::None,
+        Role::Control,
         TEST_SLOW_CHANNEL_DEPTH,
     );
     let slow_id = slow.id;
@@ -233,6 +237,7 @@ fn slow_client_drops_do_not_block_fast_client() {
         registry.allocate_id(),
         test_peer(TEST_FAST_PEER_PORT),
         Codec::None,
+        Role::Control,
         TEST_FAST_CHANNEL_DEPTH,
     );
     registry.register(slow);
@@ -308,12 +313,14 @@ fn disconnected_client_is_skipped_by_broadcaster_fanout() {
         registry.allocate_id(),
         test_peer(TEST_DISCONNECT_A_PORT),
         Codec::None,
+        Role::Control,
         TEST_FAST_CHANNEL_DEPTH,
     );
     let (slot_b, rx_b) = ClientSlot::new(
         registry.allocate_id(),
         test_peer(TEST_DISCONNECT_B_PORT),
         Codec::None,
+        Role::Control,
         TEST_FAST_CHANNEL_DEPTH,
     );
     let slot_b_handle = slot_b.clone();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3815,6 +3815,7 @@ fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
         },
         buffer_capacity: SERVER_BUFFER_CAPACITY_DEFAULT,
         compression,
+        listener_cap: sdr_server_rtltcp::DEFAULT_LISTENER_CAP,
     }
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -6909,6 +6909,7 @@ mod server_panel_format_tests {
             peer: SocketAddr::from(([127, 0, 0, 1], FIXTURE_PEER_PORT)),
             connected_since: Instant::now(),
             codec: Codec::None,
+            role: sdr_server_rtltcp::extension::Role::Control,
             bytes_sent: 0,
             buffers_dropped: 0,
             last_command: None,

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,15 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 15
+#define SDR_CORE_ABI_VERSION_MINOR 16
 /*
+ * 0.16 — adds `role` (u8 wire byte: 0=Control, 1=Listen) at the
+ * tail of `SdrRtlTcpClientInfo` so FFI hosts can render a
+ * "Controller" / "Listener" badge per-client without parsing
+ * the RTLX wire format themselves. Struct layout grows; any 0.15
+ * consumer must fail fast on the exact-match ABI check (see
+ * "ABI versioning" block above). Part of #392 (role gate).
+ *
  * 0.15 — adds `has_last_command` / `last_command_op` /
  * `last_command_age_secs` to the tail of `SdrRtlTcpClientInfo`
  * so FFI hosts can replicate the "most recent commander"
@@ -947,6 +954,15 @@ typedef struct SdrRtlTcpClientInfo {
      * sdr_rtltcp_server_client_list call reference a single
      * snapshot clock, so the ordering is consistent. */
     double   last_command_age_secs;
+    /* Role the server granted to this client: 0 = Control (can
+     * tune / change gain / etc.), 1 = Listen (receives the IQ
+     * stream; server drops any commands they send). Matches the
+     * Role enum wire byte in sdr_server_rtltcp::extension.
+     * Hosts render this as "Controller" / "Listener" in the
+     * client list. Vanilla rtl_tcp clients that don't speak the
+     * RTLX extension always land here as Control — the server
+     * only admits them when the Control slot is free. #392. */
+    uint8_t  role;
 } SdrRtlTcpClientInfo;
 
 /*

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -58,12 +58,18 @@ extern "C" {
 #define SDR_CORE_ABI_VERSION_MAJOR 0
 #define SDR_CORE_ABI_VERSION_MINOR 16
 /*
- * 0.16 — adds `role` (u8 wire byte: 0=Control, 1=Listen) at the
- * tail of `SdrRtlTcpClientInfo` so FFI hosts can render a
- * "Controller" / "Listener" badge per-client without parsing
- * the RTLX wire format themselves. Struct layout grows; any 0.15
- * consumer must fail fast on the exact-match ABI check (see
- * "ABI versioning" block above). Part of #392 (role gate).
+ * 0.16 — TWO struct layouts grow as part of #392 (role gate).
+ * Either change alone is ABI-breaking under the pre-1.0 exact-
+ * match rule; both land together:
+ *   - `SdrRtlTcpClientInfo.role` (uint8_t, 0=Control 1=Listen)
+ *     appended at the tail so hosts can render a "Controller" /
+ *     "Listener" badge per-client without parsing the RTLX wire
+ *     format themselves.
+ *   - `SdrRtlTcpServerConfig.listener_cap` (uint32_t, 0 = use
+ *     crate default of 10) appended at the tail so hosts can
+ *     size the Listen pool at server-start time.
+ * Any 0.15 consumer must fail fast on the exact-match ABI check
+ * (see "ABI versioning" block above).
  *
  * 0.15 — adds `has_last_command` / `last_command_op` /
  * `last_command_age_secs` to the tail of `SdrRtlTcpClientInfo`

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -805,6 +805,7 @@ typedef enum SdrBindAddress {
  * `initial_gain_tenths_db == 0` means "auto" (no manual gain).
  * `initial_direct_sampling` must be one of 0 / 1 / 2.
  * `port == 0` falls back to the crate default port (1234).
+ * `listener_cap == 0` uses the crate default (10).
  */
 typedef struct SdrRtlTcpServerConfig {
     int32_t  bind_address;               /* SdrBindAddress */
@@ -817,6 +818,7 @@ typedef struct SdrRtlTcpServerConfig {
     int32_t  initial_ppm;                /* frequency correction (ppm) */
     bool     initial_bias_tee;
     int32_t  initial_direct_sampling;    /* 0 = off, 1 = I, 2 = Q */
+    uint32_t listener_cap;               /* max concurrent Role::Listen clients; 0 = crate default (10); the single Control client is separate */
 } SdrRtlTcpServerConfig;
 
 /*


### PR DESCRIPTION
## Summary

Closes #392 — second sub-issue of multi-client epic #390.

Implements role-based access for the rtl_tcp server: only the single `Role::Control` client can drive dongle state (tune / gain / etc.); `Role::Listen` clients receive the IQ stream but their commands are dropped server-side. Listener count is capped (default 10, configurable via `--listener-cap N` or FFI `SdrRtlTcpServerConfig.listener_cap`). Vanilla `rtl_tcp` clients (SDR++, Gqrx, SDRangel, CubicSDR, etc.) remain first-class — they're admitted as Control when the slot is free, denied with TCP FIN when it's taken.

## Commits

1. **`rtl_tcp: add Status::ListenerCapReached variant`** — additive wire status code 4 on `ServerExtension`. No PROTOCOL_VERSION bump per the round-3 rule on #399 (schema gate catches unknown values at parse time). Round-trip + exhaustive `from_wire` tests.
2. **`rtl_tcp: thread Role through ClientSlot + ClientInfo + FFI`** — plumbing only. `ClientSlot.role: Role` immutable field; projected through `ClientInfo` and `SdrRtlTcpClientInfo`. **ABI bump 0.15 → 0.16** (struct layout grew). `make ffi-header-check` clean.
3. **`rtl_tcp: atomic role gate + listener cap on ClientRegistry`** — `register_with_role(slot, cap) -> RoleDecision` holds the `slots` mutex across the role/cap check + push so two concurrent accepts can't both claim Control. Disconnected slots count as absent (Control / cap frees immediately on client drop, without waiting for the ~2.5s prune sweep). `ServerConfig.listener_cap: usize` + `DEFAULT_LISTENER_CAP = 10`. FFI field + C header matching docs.
4. **`rtl_tcp: wire role-aware admission into accept path + gate command worker`** — `spawn_client_workers` replaced; role-aware decision happens before any wire writes. RTLX denials get full `dongle_info_t + ServerExtension(denied)` (their UI can render "controller busy"); vanilla denials get bare TCP FIN (cleanest for "connection refused" UX). `command_worker` drops Listen-client commands with `tracing::debug!` + `continue`.
5. **`rtl_tcp: sdr-rtl-tcp CLI flag --listener-cap`** — `--listener-cap N` argument + help text; 3 parse tests.

## Decision matrix

| Client | Control slot | Listener cap | Outcome |
|---|---|---|---|
| Vanilla | free | — | Grant Control, commands dispatch |
| Vanilla | taken | — | TCP close (no bytes) |
| RTLX asking Control | free | — | Grant, `ServerExtension(role=Control, status=Ok)` |
| RTLX asking Control | taken | — | Deny, `ServerExtension(role=None, status=ControllerBusy)` + close |
| RTLX asking Listen | — | under cap | Grant, `ServerExtension(role=Listen, status=Ok)`, commands dropped |
| RTLX asking Listen | — | at cap | Deny, `ServerExtension(role=None, status=ListenerCapReached)` + close |

## Test coverage

**Unit tests** (all passing):
- `Status::from_wire_covers_all_documented_variants` — trip-wire against future discriminant reshuffles
- `server_extension_listener_cap_reached_round_trips` — wire encoding for the new variant
- `register_with_role_grants_first_control_client` — happy path
- `register_with_role_denies_second_control_as_controller_busy` — exclusivity
- `register_with_role_grants_second_control_after_first_disconnects` — disconnect frees the slot before the next prune tick
- `register_with_role_admits_listeners_up_to_cap` — Control + cap listeners coexist
- `register_with_role_denies_listen_past_cap` — cap boundary
- `register_with_role_counts_only_live_listeners_for_cap` — disconnected listener frees a slot
- `parse_args_listener_cap_defaults_to_crate_default` — CLI
- `parse_args_listener_cap_override` — CLI
- `parse_args_listener_cap_rejects_non_numeric` — CLI

**Deferred to manual smoke test** (requires real RTL-SDR hardware):
- Full TCP accept path: vanilla client + RTLX Control + RTLX Listen concurrent clients, verify commands from the controller alone drive the device. `Server::start` requires a USB-attached dongle, so end-to-end integration tests don't run in CI (same constraint as #391's `multi_client_fanout.rs` which also drives the `ClientRegistry` directly).

## Smoke-test checklist (Linux, with real RTL-SDR)

When you run the binary:

- [ ] `sdr-rtl-tcp --listener-cap 2` starts cleanly; help output shows the new flag
- [ ] First client (SDR++ or `rtl_tcp` client) connects → gets Control, can tune / change gain
- [ ] Second client (vanilla) tries to connect while first still up → connection refused (TCP FIN without data)
- [ ] Our GTK app connects with `role=Listen` while Control is held → receives IQ stream, client-side tune commands silently no-op server-side
- [ ] Third listener attempt with cap=2 already filled → RTLX client shows ListenerCapReached denial
- [ ] First Control client disconnects → second client can reconnect as Control without delay (disconnect-frees-slot contract)
- [ ] Stats panel shows role per client (Controller / Listener badges once #395 lands — for now, `cargo test` confirms the field propagates through FFI)

## Wire-format note

Bytes 5 (`granted_role`) / 6 (`status`) / 7 (`version`) of the 8-byte `ServerExtension` were already reserved by #307, so this PR ships **no wire-format version bump** — only additive `status = 4` (`ListenerCapReached`). The PROTOCOL_VERSION gate catches peers that read unknown status values at parse time.

## Remaining multi-client epic #390 sub-issues

- **#393** — takeover handshake (explicit kick of existing controller)
- **#394** — optional auth key
- **#395** — server UI (client list + cap + auth toggle)
- **#396** — client UI (role picker, takeover button, kicked toast)
- **#397** — FIPS-compliant transport encryption (investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable listener capacity via a new CLI option to limit concurrent RTL‑TCP listeners.
  * Role-based client admission distinguishing Control vs Listen; Listen admission enforces the listener cap.
  * Server emits explicit denial responses and a new status when capacity or role constraints block a connection.

* **Public API / UI**
  * Default listener cap is exported and configurable from the server panel.

* **Chores**
  * Bumped C ABI minor version to 0.16.

* **Tests**
  * Expanded unit and integration tests covering role admission, listener cap behavior, and denial/status round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->