### PR TITLE
rtl_tcp: takeover handshake + TCP keepalive tuning (#393)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1277,7 +1277,7 @@ dependencies = [
  "log",
  "mio",
  "socket-pktinfo",
- "socket2",
+ "socket2 0.6.3",
 ]
 
 [[package]]
@@ -1621,7 +1621,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1658,7 +1658,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2083,6 +2083,7 @@ dependencies = [
  "rusb",
  "sdr-rtlsdr",
  "sdr-rtltcp-discovery",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
@@ -2386,8 +2387,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.6.3",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2572,7 +2583,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "windows-sys 0.61.2",
 ]
 

--- a/crates/sdr-server-rtltcp/Cargo.toml
+++ b/crates/sdr-server-rtltcp/Cargo.toml
@@ -22,10 +22,13 @@ mdns-advertise = ["dep:sdr-rtltcp-discovery"]
 sdr-rtlsdr.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-# Needed for `SO_KEEPALIVE` via setsockopt — std::net::TcpStream exposes
-# `set_nodelay` and friends but not keepalive. Rather than pull in socket2
-# just for one call, we use the same libc/allow(unsafe_code) pattern used
-# elsewhere in the workspace (e.g. crates/sdr-transcription/src/util.rs).
+# On unix targets we use `libc::setsockopt` directly — lets us tune
+# `TCP_KEEPIDLE` / `TCP_KEEPINTVL` / `TCP_KEEPCNT` (Linux-specific)
+# without pulling in socket2 for the whole workspace. The
+# non-unix fallback below uses socket2 because std::net::TcpStream
+# has no keepalive setter and raw winsock ioctls via windows-sys
+# would be a larger dep footprint than socket2's abstraction
+# for the same result (#393 CR round 1).
 libc.workspace = true
 rusb.workspace = true
 # Binary only — enables `-s info` style env-filter logging for the CLI.
@@ -41,6 +44,15 @@ sdr-rtltcp-discovery = { workspace = true, optional = true }
 # mask at handshake time, which doesn't require the codec trait impls
 # to be absent.
 lz4_flex.workspace = true
+
+# Non-unix (Windows, WASI, etc.) keepalive enable for the #393
+# zombie-detection fallback path. `std::net::TcpStream` has no
+# keepalive setter; unix paths use `libc::setsockopt` directly, so
+# this only wires up socket2 on platforms we'd otherwise leave with
+# `Err(Unsupported)`. Scoped to `cfg(not(unix))` so the dep doesn't
+# affect the primary Linux/macOS builds.
+[target.'cfg(not(unix))'.dependencies]
+socket2 = "0.5"
 
 [lints]
 workspace = true

--- a/crates/sdr-server-rtltcp/src/broadcaster.rs
+++ b/crates/sdr-server-rtltcp/src/broadcaster.rs
@@ -267,21 +267,40 @@ impl ClientSlot {
 
 /// Outcome of [`ClientRegistry::register_with_role`] — whether the
 /// slot was admitted, and if not, why. The caller maps these onto
-/// the wire-level `ServerExtension` response: `Granted` →
-/// `status=Ok, granted_role=Some(requested)`; denial variants →
-/// `status=<matching>, granted_role=None` (0xFF sentinel). #392.
+/// the wire-level `ServerExtension` response: `Granted` /
+/// `GrantedViaTakeover` → `status=Ok, granted_role=Some(requested)`;
+/// denial variants → `status=<matching>, granted_role=None`
+/// (0xFF sentinel). #392 / #393.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoleDecision {
     /// Slot registered. Caller proceeds with the handshake response
     /// and spawns the per-client writer + command workers.
     Granted,
+    /// Slot registered AFTER displacing the prior Control client —
+    /// i.e., the takeover path (#393). The prior controller's
+    /// slot is marked disconnected by `register_with_role` under
+    /// the same lock, so its writer / command threads observe the
+    /// flag on their next tick and exit with a clean TCP FIN. The
+    /// caller treats this identically to [`Self::Granted`] on the
+    /// wire (both send `ServerExtension { status: Ok, granted_role:
+    /// Some(Control) }`) — the `displaced_id` is carried only for
+    /// server-side logging and UI activity-log correlation.
+    GrantedViaTakeover {
+        /// `ClientId` of the Control slot that was displaced.
+        /// Captured from the slot snapshot taken under the admission
+        /// lock so log output points at the exact predecessor.
+        displaced_id: ClientId,
+    },
     /// Client requested `Role::Control` but another live slot is
-    /// already holding it. Caller emits
+    /// already holding it **and** the client did not set the
+    /// takeover flag. Caller emits
     /// `ServerExtension { granted_role: None, status: ControllerBusy }`
     /// to RTLX clients (vanilla clients get TCP FIN without a
     /// header so they see "connection refused"-equivalent), then
     /// closes. **Transient** — clients treat this as retryable via
-    /// their connect/backoff loop.
+    /// their connect/backoff loop, or prompt the user to click
+    /// "Take control" which re-sends the hello with the takeover
+    /// flag set.
     ControllerBusy,
     /// Client requested `Role::Listen` but `listener_cap` live
     /// listeners are already registered. Caller emits
@@ -426,18 +445,26 @@ impl ClientRegistry {
 
     /// Admit a slot if the server's role gate and listener cap
     /// permit it. Returns the outcome so the caller can respond to
-    /// the client appropriately (Granted → continue the handshake,
-    /// denied → send a denial `ServerExtension` + close). The
-    /// slot's role (decided at construction time from the client's
-    /// hello, or defaulted to `Control` for vanilla clients) drives
-    /// the decision:
+    /// the client appropriately (Granted / GrantedViaTakeover →
+    /// continue the handshake, denied → send a denial
+    /// `ServerExtension` + close). The slot's role (decided at
+    /// construction time from the client's hello, or defaulted to
+    /// `Control` for vanilla clients) drives the decision:
     ///
     /// - `Role::Control` — granted iff no other live slot currently
-    ///   has role Control. Denying with `ControllerBusy` because
-    ///   the Control slot is exclusive (one commander at a time).
+    ///   has role Control. When the slot IS taken:
+    ///   - `request_takeover == false` → [`RoleDecision::ControllerBusy`].
+    ///   - `request_takeover == true` → the prior controller's slot
+    ///     is marked disconnected (its writer + command threads
+    ///     observe the flag on their next tick and exit with a
+    ///     clean TCP FIN) and the new slot is admitted; returns
+    ///     [`RoleDecision::GrantedViaTakeover`] carrying the
+    ///     displaced client's id for server-side logging. #393.
     /// - `Role::Listen` — granted iff the count of live `Listen`
     ///   slots is strictly less than `listener_cap`. Denying with
-    ///   `ListenerCapReached`.
+    ///   `ListenerCapReached`. `request_takeover` is ignored for
+    ///   Listen requests: takeover only makes sense against the
+    ///   single exclusive Control slot.
     ///
     /// "Live" means not flagged disconnected — the broadcaster's
     /// periodic `prune_disconnected` sweep evicts dead slots, but
@@ -446,14 +473,25 @@ impl ClientRegistry {
     /// client frees the slot immediately on their worker
     /// disconnecting, without waiting for the next prune tick.
     ///
-    /// `lifetime_accepted` is bumped only on `Granted` — the
-    /// counter tracks real admissions, not denied-handshake
-    /// attempts. #392.
-    pub fn register_with_role(&self, slot: Arc<ClientSlot>, listener_cap: usize) -> RoleDecision {
-        // Lock the slot list first so the decision + push land
-        // atomically — two concurrent Control requests can't both
-        // observe "slot free" and both push. Same lock discipline
-        // as `prune_disconnected` and `snapshot`, so the decision
+    /// `lifetime_accepted` is bumped only on admission (Granted or
+    /// GrantedViaTakeover) — the counter tracks real admissions,
+    /// not denied-handshake attempts. The takeover's displaced
+    /// controller is NOT subtracted from `lifetime_accepted`: it
+    /// was a real admission that happened to end via kick instead
+    /// of clean disconnect. #392 / #393.
+    pub fn register_with_role(
+        &self,
+        slot: Arc<ClientSlot>,
+        listener_cap: usize,
+        request_takeover: bool,
+    ) -> RoleDecision {
+        // Lock the slot list first so the decision + push (and
+        // the takeover-path mark_disconnected) land atomically —
+        // two concurrent Control requests can't both observe
+        // "slot free" and both push, and a takeover request
+        // can't race with another admission that would displace
+        // someone else's slot. Same lock discipline as
+        // `prune_disconnected` and `snapshot`, so the decision
         // sees a consistent live-set view.
         let Ok(mut guard) = self.slots.lock() else {
             // Poisoned — a prior operation panicked mid-update
@@ -464,13 +502,30 @@ impl ClientRegistry {
             // round 1 on PR #403.
             return RoleDecision::RegistryPoisoned;
         };
+        let mut displaced_id: Option<ClientId> = None;
         match slot.role {
             Role::Control => {
-                let has_live_controller = guard
+                // Find the live controller (if any) so we can
+                // either deny or displace.
+                let existing_controller = guard
                     .iter()
-                    .any(|s| s.role == Role::Control && !s.is_disconnected());
-                if has_live_controller {
-                    return RoleDecision::ControllerBusy;
+                    .find(|s| s.role == Role::Control && !s.is_disconnected())
+                    .cloned();
+                if let Some(prev) = existing_controller {
+                    if !request_takeover {
+                        return RoleDecision::ControllerBusy;
+                    }
+                    // Takeover path: mark the prior controller
+                    // disconnected so its workers exit on their
+                    // next tick. The slot stays in the registry
+                    // until the next `prune_disconnected` sweep or
+                    // an explicit `unwind_admission` — keeping it
+                    // around keeps its per-client stats visible in
+                    // the next UI poll so operators can see
+                    // "client 7 was kicked by client 12" in the
+                    // activity log. #393.
+                    prev.mark_disconnected();
+                    displaced_id = Some(prev.id);
                 }
             }
             Role::Listen => {
@@ -485,7 +540,10 @@ impl ClientRegistry {
         }
         self.lifetime_accepted.fetch_add(1, Ordering::Relaxed);
         guard.push(slot);
-        RoleDecision::Granted
+        match displaced_id {
+            Some(displaced_id) => RoleDecision::GrantedViaTakeover { displaced_id },
+            None => RoleDecision::Granted,
+        }
     }
 
     /// Undo a prior [`Self::register_with_role`] `Granted` outcome
@@ -1239,7 +1297,7 @@ mod tests {
         let reg = ClientRegistry::new();
         let slot = role_test_slot(&reg, ROLE_TEST_SINGLE_CTRL_PORT, Role::Control);
         assert_eq!(
-            reg.register_with_role(slot, TEST_LISTENER_CAP),
+            reg.register_with_role(slot, TEST_LISTENER_CAP, false),
             RoleDecision::Granted
         );
         assert_eq!(reg.len(), 1);
@@ -1254,12 +1312,12 @@ mod tests {
         let reg = ClientRegistry::new();
         let first = role_test_slot(&reg, ROLE_TEST_BUSY_FIRST_CTRL_PORT, Role::Control);
         assert_eq!(
-            reg.register_with_role(first, TEST_LISTENER_CAP),
+            reg.register_with_role(first, TEST_LISTENER_CAP, false),
             RoleDecision::Granted
         );
         let second = role_test_slot(&reg, ROLE_TEST_BUSY_SECOND_CTRL_PORT, Role::Control);
         assert_eq!(
-            reg.register_with_role(second, TEST_LISTENER_CAP),
+            reg.register_with_role(second, TEST_LISTENER_CAP, false),
             RoleDecision::ControllerBusy
         );
         // Registry still only has the first — denial must not
@@ -1279,13 +1337,13 @@ mod tests {
         let reg = ClientRegistry::new();
         let first = role_test_slot(&reg, ROLE_TEST_DISCONNECT_FIRST_CTRL_PORT, Role::Control);
         assert_eq!(
-            reg.register_with_role(first.clone(), TEST_LISTENER_CAP),
+            reg.register_with_role(first.clone(), TEST_LISTENER_CAP, false),
             RoleDecision::Granted
         );
         first.mark_disconnected();
         let second = role_test_slot(&reg, ROLE_TEST_DISCONNECT_SECOND_CTRL_PORT, Role::Control);
         assert_eq!(
-            reg.register_with_role(second, TEST_LISTENER_CAP),
+            reg.register_with_role(second, TEST_LISTENER_CAP, false),
             RoleDecision::Granted
         );
         assert_eq!(reg.lifetime_accepted(), 2);
@@ -1299,7 +1357,7 @@ mod tests {
         let reg = ClientRegistry::new();
         let ctrl = role_test_slot(&reg, ROLE_TEST_ADMIT_CTRL_PORT, Role::Control);
         assert_eq!(
-            reg.register_with_role(ctrl, TEST_LISTENER_CAP),
+            reg.register_with_role(ctrl, TEST_LISTENER_CAP, false),
             RoleDecision::Granted
         );
         for i in 0..TEST_LISTENER_CAP {
@@ -1309,7 +1367,7 @@ mod tests {
                 Role::Listen,
             );
             assert_eq!(
-                reg.register_with_role(listener, TEST_LISTENER_CAP),
+                reg.register_with_role(listener, TEST_LISTENER_CAP, false),
                 RoleDecision::Granted,
                 "listener {i} should fit under cap {TEST_LISTENER_CAP}"
             );
@@ -1328,13 +1386,13 @@ mod tests {
                 Role::Listen,
             );
             assert_eq!(
-                reg.register_with_role(listener, TEST_LISTENER_CAP),
+                reg.register_with_role(listener, TEST_LISTENER_CAP, false),
                 RoleDecision::Granted
             );
         }
         let overflow = role_test_slot(&reg, ROLE_TEST_CAP_OVERFLOW_PORT, Role::Listen);
         assert_eq!(
-            reg.register_with_role(overflow, TEST_LISTENER_CAP),
+            reg.register_with_role(overflow, TEST_LISTENER_CAP, false),
             RoleDecision::ListenerCapReached
         );
         // Denial must not push into slots.
@@ -1361,7 +1419,7 @@ mod tests {
         let reg = ClientRegistry::new();
         let slot = role_test_slot(&reg, ROLE_TEST_SINGLE_CTRL_PORT, Role::Control);
         assert_eq!(
-            reg.register_with_role(slot.clone(), TEST_LISTENER_CAP),
+            reg.register_with_role(slot.clone(), TEST_LISTENER_CAP, false),
             RoleDecision::Granted
         );
         assert_eq!(reg.len(), 1);
@@ -1395,6 +1453,163 @@ mod tests {
         );
     }
 
+    // ------------------------------------------------------------
+    // Takeover handshake tests (#393).
+    //
+    // Shape: `register_with_role(slot, cap, request_takeover)`.
+    // When the Control slot is busy and the new client sets
+    // `request_takeover = true`, the existing controller is
+    // marked disconnected + the new client is admitted as Control.
+    // Vanilla clients never exercise the takeover path (they
+    // can't set the flag); RTLX clients request it explicitly via
+    // `ClientHello::flags` bit 0.
+    // ------------------------------------------------------------
+
+    /// `takeover` peer ports — each test uses a disjoint block so
+    /// log output points at the specific test that stamped the
+    /// peer.
+    const TAKEOVER_TEST_ORIG_CTRL_PORT: u16 = 20_100;
+    const TAKEOVER_TEST_NEW_CTRL_PORT: u16 = 20_101;
+    const TAKEOVER_TEST_NO_CONFLICT_PORT: u16 = 20_110;
+    const TAKEOVER_TEST_DENIED_ORIG_PORT: u16 = 20_120;
+    const TAKEOVER_TEST_DENIED_NEW_PORT: u16 = 20_121;
+    const TAKEOVER_TEST_LISTENER_PORT: u16 = 20_130;
+    const TAKEOVER_TEST_LISTENER_TAKEOVER_CTRL_PORT: u16 = 20_131;
+
+    #[test]
+    fn register_with_role_takeover_displaces_existing_controller() {
+        // **Regression test for #393.** Core takeover contract:
+        // Control client A is live, client B requests Control
+        // with `request_takeover = true`. Expected:
+        //   - B is admitted (GrantedViaTakeover carries A's id)
+        //   - A is marked disconnected (the broadcaster stops
+        //     fanning to it, writer/command workers exit on their
+        //     next tick with a clean TCP FIN)
+        //   - `lifetime_accepted` reflects both admissions (A's
+        //     kick doesn't decrement; it was a real session)
+        let reg = ClientRegistry::new();
+        let slot_a = role_test_slot(&reg, TAKEOVER_TEST_ORIG_CTRL_PORT, Role::Control);
+        let a_id = slot_a.id;
+        assert_eq!(
+            reg.register_with_role(slot_a.clone(), TEST_LISTENER_CAP, false),
+            RoleDecision::Granted
+        );
+
+        let slot_b = role_test_slot(&reg, TAKEOVER_TEST_NEW_CTRL_PORT, Role::Control);
+        let b_id = slot_b.id;
+        assert_eq!(
+            reg.register_with_role(slot_b.clone(), TEST_LISTENER_CAP, true),
+            RoleDecision::GrantedViaTakeover { displaced_id: a_id }
+        );
+
+        // A is still in the registry (stats visible to UI) but
+        // flagged disconnected.
+        assert!(
+            slot_a.is_disconnected(),
+            "displaced controller should be marked disconnected"
+        );
+        // B is live and holds the Control slot from the registry's
+        // point of view.
+        assert!(
+            !slot_b.is_disconnected(),
+            "new controller should be alive after takeover"
+        );
+        // Two admissions in lifetime_accepted — A's kick doesn't
+        // subtract, it was a real session.
+        assert_eq!(reg.lifetime_accepted(), 2);
+        // The live-snapshot reflects only the new controller.
+        let snapshot = reg.snapshot();
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].id, b_id);
+        assert_eq!(snapshot[0].role, Role::Control);
+    }
+
+    #[test]
+    fn register_with_role_takeover_is_noop_when_slot_is_free() {
+        // Pure takeover flag with no existing controller → just
+        // `Granted` (no displacement metadata). The flag is
+        // harmless in the no-conflict case; it's the "please kick
+        // whoever's there" hint, not a hard requirement that
+        // someone BE there.
+        let reg = ClientRegistry::new();
+        let slot = role_test_slot(&reg, TAKEOVER_TEST_NO_CONFLICT_PORT, Role::Control);
+        assert_eq!(
+            reg.register_with_role(slot, TEST_LISTENER_CAP, true),
+            RoleDecision::Granted,
+            "takeover flag with no conflict must resolve to plain Granted"
+        );
+        assert_eq!(reg.lifetime_accepted(), 1);
+    }
+
+    #[test]
+    fn register_with_role_takeover_false_still_denies_busy_controller() {
+        // Regression guard: the #392 ControllerBusy semantics
+        // must stay intact when `request_takeover = false`. A
+        // Control client whose hello has the takeover flag
+        // clear gets denied exactly as before — the #393 branch
+        // only activates on an explicit `true` request.
+        let reg = ClientRegistry::new();
+        let slot_a = role_test_slot(&reg, TAKEOVER_TEST_DENIED_ORIG_PORT, Role::Control);
+        assert_eq!(
+            reg.register_with_role(slot_a.clone(), TEST_LISTENER_CAP, false),
+            RoleDecision::Granted
+        );
+        let slot_b = role_test_slot(&reg, TAKEOVER_TEST_DENIED_NEW_PORT, Role::Control);
+        assert_eq!(
+            reg.register_with_role(slot_b, TEST_LISTENER_CAP, false),
+            RoleDecision::ControllerBusy
+        );
+        // A stays alive — no unintended displacement when the
+        // takeover flag is clear.
+        assert!(!slot_a.is_disconnected());
+        // Denial doesn't bump lifetime_accepted.
+        assert_eq!(reg.lifetime_accepted(), 1);
+    }
+
+    #[test]
+    fn register_with_role_takeover_leaves_listeners_alone() {
+        // Integration: listener + Control(A), then B takes over
+        // from A. Listener must stay connected through the
+        // takeover — the fan-out contract says listeners are
+        // isolated from controller churn. Without this, a
+        // takeover event would drop listeners too, turning every
+        // "kick the zombie controller" action into a reconnect
+        // storm across every passive viewer.
+        let reg = ClientRegistry::new();
+        let listener = role_test_slot(&reg, TAKEOVER_TEST_LISTENER_PORT, Role::Listen);
+        assert_eq!(
+            reg.register_with_role(listener.clone(), TEST_LISTENER_CAP, false),
+            RoleDecision::Granted
+        );
+        let ctrl_a = role_test_slot(&reg, TAKEOVER_TEST_ORIG_CTRL_PORT, Role::Control);
+        let a_id = ctrl_a.id;
+        assert_eq!(
+            reg.register_with_role(ctrl_a.clone(), TEST_LISTENER_CAP, false),
+            RoleDecision::Granted
+        );
+        let ctrl_b = role_test_slot(
+            &reg,
+            TAKEOVER_TEST_LISTENER_TAKEOVER_CTRL_PORT,
+            Role::Control,
+        );
+        assert_eq!(
+            reg.register_with_role(ctrl_b, TEST_LISTENER_CAP, true),
+            RoleDecision::GrantedViaTakeover { displaced_id: a_id }
+        );
+        // Listener survived unscathed.
+        assert!(
+            !listener.is_disconnected(),
+            "takeover must not mark listeners disconnected"
+        );
+        // Old Control was displaced.
+        assert!(ctrl_a.is_disconnected());
+        // Live snapshot has the listener + the new controller
+        // (two live slots; A is pruned out of the live view by
+        // the is_disconnected filter).
+        let snapshot = reg.snapshot();
+        assert_eq!(snapshot.len(), 2);
+    }
+
     #[test]
     fn register_with_role_counts_only_live_listeners_for_cap() {
         // A disconnected Listener frees a listener slot
@@ -1410,7 +1625,7 @@ mod tests {
                 Role::Listen,
             );
             assert_eq!(
-                reg.register_with_role(listener.clone(), TEST_LISTENER_CAP),
+                reg.register_with_role(listener.clone(), TEST_LISTENER_CAP, false),
                 RoleDecision::Granted
             );
             listeners.push(listener);
@@ -1418,14 +1633,14 @@ mod tests {
         // Cap is full — verify.
         let denied = role_test_slot(&reg, ROLE_TEST_LIVE_DENIED_PORT, Role::Listen);
         assert_eq!(
-            reg.register_with_role(denied, TEST_LISTENER_CAP),
+            reg.register_with_role(denied, TEST_LISTENER_CAP, false),
             RoleDecision::ListenerCapReached
         );
         // Flip one listener to disconnected and retry.
         listeners[0].mark_disconnected();
         let replacement = role_test_slot(&reg, ROLE_TEST_LIVE_REPLACEMENT_PORT, Role::Listen);
         assert_eq!(
-            reg.register_with_role(replacement, TEST_LISTENER_CAP),
+            reg.register_with_role(replacement, TEST_LISTENER_CAP, false),
             RoleDecision::Granted
         );
     }

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -703,24 +703,32 @@ fn spawn_client_workers(
     //   - `negotiated_codec` is `None` for vanilla (always
     //     uncompressed); `Some(_)` for RTLX clients — the
     //     intersection of their mask and ours
-    let (hello_seen, requested_role, negotiated_codec) = if let Some(hello) = &sniff_outcome {
-        let codec = compression_offer.pick(hello.codec_mask);
-        tracing::info!(
-            %peer,
-            client_mask = hello.codec_mask.to_wire(),
-            server_mask = compression_offer.to_wire(),
-            chosen = %codec,
-            requested_role = ?hello.role,
-            "rtl_tcp extended-handshake negotiated"
-        );
-        (true, hello.role, Some(codec))
-    } else {
-        tracing::debug!(
-            %peer,
-            "rtl_tcp no extended-handshake hello — legacy client path (implicit Role::Control)"
-        );
-        (false, Role::Control, None)
-    };
+    let (hello_seen, requested_role, request_takeover, negotiated_codec) =
+        if let Some(hello) = &sniff_outcome {
+            let codec = compression_offer.pick(hello.codec_mask);
+            let takeover = hello.request_takeover();
+            tracing::info!(
+                %peer,
+                client_mask = hello.codec_mask.to_wire(),
+                server_mask = compression_offer.to_wire(),
+                chosen = %codec,
+                requested_role = ?hello.role,
+                request_takeover = takeover,
+                "rtl_tcp extended-handshake negotiated"
+            );
+            (true, hello.role, takeover, Some(codec))
+        } else {
+            tracing::debug!(
+                %peer,
+                "rtl_tcp no extended-handshake hello — legacy client path (implicit Role::Control)"
+            );
+            // Vanilla clients have no way to set the takeover
+            // flag, so the admission gate treats them as
+            // "request_takeover = false" — the existing Control
+            // client (if any) is protected from vanilla-driven
+            // displacement. Takeover is an explicit RTLX action.
+            (false, Role::Control, false, None)
+        };
     let codec = negotiated_codec.unwrap_or(Codec::None);
 
     // Allocate id + build slot with the requested role + channel.
@@ -730,10 +738,13 @@ fn spawn_client_workers(
     let id = registry.allocate_id();
     let (slot, rx) = ClientSlot::new(id, peer, codec, requested_role, per_client_buffer_depth);
 
-    // Atomic #392 admission. On `Granted` the slot is now in the
-    // registry and the broadcaster can find it on its next tick;
-    // on denial the slot is never pushed and drops on scope exit.
-    let decision = registry.register_with_role(slot.clone(), listener_cap);
+    // Atomic #392 admission + #393 takeover decision. On `Granted`
+    // or `GrantedViaTakeover` the slot is now in the registry and
+    // the broadcaster can find it on its next tick; on denial the
+    // slot is never pushed and drops on scope exit. Takeover also
+    // marks the displaced controller disconnected under the same
+    // lock so its writer / command threads exit cleanly.
+    let decision = registry.register_with_role(slot.clone(), listener_cap, request_takeover);
     match decision {
         RoleDecision::Granted => {
             tracing::info!(
@@ -742,6 +753,15 @@ fn spawn_client_workers(
                 ?requested_role,
                 ?codec,
                 "rtl_tcp client admitted"
+            );
+        }
+        RoleDecision::GrantedViaTakeover { displaced_id } => {
+            tracing::info!(
+                %peer,
+                client_id = id,
+                displaced_client_id = displaced_id,
+                ?codec,
+                "rtl_tcp client admitted via takeover — prior Control client kicked"
             );
         }
         RoleDecision::ControllerBusy => {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -1020,13 +1020,34 @@ fn send_denied_response(
     }
 }
 
+/// Seconds of socket idleness before the first TCP keepalive probe
+/// goes out. `TCP_KEEPIDLE` (Linux) / `TCP_KEEPALIVE` (macOS). Kernel
+/// default is 7200 s (2 hours) on most systems — unusable for
+/// detecting a zombie controller before the user's patience runs
+/// out. 60 s is the upstream `tcp(7)` recommended minimum for
+/// interactive sessions and matches the #393 budget for zombie
+/// detection (60 + 10 × 3 = 90 s worst case). Per #393.
+const TCP_KEEPALIVE_IDLE_SECS: u32 = 60;
+/// Seconds between probes once the first one has been sent.
+/// `TCP_KEEPINTVL`. 10 s gives the zombie three chances to reply
+/// across a ~30 s window — enough to ride out a brief network
+/// hiccup without blowing the detection deadline. Per #393.
+const TCP_KEEPALIVE_INTERVAL_SECS: u32 = 10;
+/// How many unanswered probes before the kernel drops the socket.
+/// `TCP_KEEPCNT`. 3 keeps the total dead-peer detection window at
+/// roughly 90 s (idle 60 s + 3 × 10 s probes). Per #393.
+const TCP_KEEPALIVE_RETRIES: u32 = 3;
+
 fn configure_client_socket(stream: &TcpStream) {
-    // Keep TCP alive so dead clients (laptop lid closed, wifi dropped) stop
-    // wedging the server rather than trickling forever into the void.
-    // Per-platform keepalive tuning lives in std behind raw setsockopt; we
-    // enable the default which at least lets the kernel eventually notice.
-    if let Err(e) = set_keepalive(stream, true) {
-        tracing::warn!(%e, "SO_KEEPALIVE not applied (non-fatal)");
+    // Enable SO_KEEPALIVE and tune the probe schedule so a zombie
+    // controller (laptop-lid-closed, wifi-dropped) is detected
+    // within ~90 s instead of the kernel default (~2 h on Linux).
+    // Takeover (#393) relies on this for "stale slot eventually
+    // gets pruned without user intervention"; the takeover handshake
+    // itself is the *explicit* path, but keepalive is the fallback
+    // that prevents permanent lockout when neither side sends FIN.
+    if let Err(e) = set_keepalive_tuned(stream) {
+        tracing::warn!(%e, "SO_KEEPALIVE tuning not applied (non-fatal)");
     }
     // Disable Nagle — commands are 5 bytes and we want snappy tuning.
     if let Err(e) = stream.set_nodelay(true) {
@@ -1034,35 +1055,81 @@ fn configure_client_socket(stream: &TcpStream) {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[allow(unsafe_code)]
-fn set_keepalive(stream: &TcpStream, on: bool) -> std::io::Result<()> {
+fn set_keepalive_tuned(stream: &TcpStream) -> std::io::Result<()> {
     use std::os::unix::io::AsRawFd;
     let fd = stream.as_raw_fd();
-    let value: libc::c_int = libc::c_int::from(on);
-    // SAFETY: `fd` is a valid open socket for the duration of this call
-    // (we borrow `stream` by reference). `value` is a stack-local
-    // `c_int` passed as a pointer along with the matching size — this
-    // is the documented shape of `setsockopt(_, SOL_SOCKET,
-    // SO_KEEPALIVE, ...)` on every POSIX target.
-    let ret = unsafe {
-        libc::setsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_KEEPALIVE,
-            std::ptr::addr_of!(value).cast(),
-            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        )
-    };
-    if ret == 0 {
-        Ok(())
-    } else {
-        Err(std::io::Error::last_os_error())
-    }
+
+    // Enable SO_KEEPALIVE first — the per-tunable options below
+    // are no-ops without it.
+    let on: libc::c_int = 1;
+    set_sockopt_int(fd, libc::SOL_SOCKET, libc::SO_KEEPALIVE, on)?;
+
+    // Idle time before first probe (seconds).
+    set_sockopt_int(
+        fd,
+        libc::IPPROTO_TCP,
+        libc::TCP_KEEPIDLE,
+        TCP_KEEPALIVE_IDLE_SECS as libc::c_int,
+    )?;
+    // Interval between subsequent probes.
+    set_sockopt_int(
+        fd,
+        libc::IPPROTO_TCP,
+        libc::TCP_KEEPINTVL,
+        TCP_KEEPALIVE_INTERVAL_SECS as libc::c_int,
+    )?;
+    // Probe count before declaring the peer dead.
+    set_sockopt_int(
+        fd,
+        libc::IPPROTO_TCP,
+        libc::TCP_KEEPCNT,
+        TCP_KEEPALIVE_RETRIES as libc::c_int,
+    )?;
+    Ok(())
+}
+
+#[cfg(all(unix, target_os = "macos"))]
+#[allow(unsafe_code)]
+fn set_keepalive_tuned(stream: &TcpStream) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let fd = stream.as_raw_fd();
+
+    let on: libc::c_int = 1;
+    set_sockopt_int(fd, libc::SOL_SOCKET, libc::SO_KEEPALIVE, on)?;
+
+    // macOS exposes only `TCP_KEEPALIVE` (seconds-until-first-probe,
+    // analogous to Linux's `TCP_KEEPIDLE`). The per-probe interval
+    // and count use system-level defaults (`sysctl
+    // net.inet.tcp.keepintvl` / `keepcnt`), typically 75 s × 8 =
+    // ~10 minute detection. Good enough for takeover — the zombie
+    // detection path is the fallback; the explicit takeover
+    // handshake is the normal case.
+    set_sockopt_int(
+        fd,
+        libc::IPPROTO_TCP,
+        libc::TCP_KEEPALIVE,
+        TCP_KEEPALIVE_IDLE_SECS as libc::c_int,
+    )?;
+    Ok(())
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+#[allow(unsafe_code)]
+fn set_keepalive_tuned(stream: &TcpStream) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let fd = stream.as_raw_fd();
+    // Other unix targets (FreeBSD, etc.) — enable keepalive with
+    // system defaults. The per-target `TCP_KEEPIDLE` constant names
+    // vary; dedicated handling for those targets can be added here
+    // when we actually ship on them.
+    let on: libc::c_int = 1;
+    set_sockopt_int(fd, libc::SOL_SOCKET, libc::SO_KEEPALIVE, on)
 }
 
 #[cfg(not(unix))]
-fn set_keepalive(_stream: &TcpStream, _on: bool) -> std::io::Result<()> {
+fn set_keepalive_tuned(_stream: &TcpStream) -> std::io::Result<()> {
     // Non-unix has no implementation yet. Return Unsupported so the
     // warn path in `configure_client_socket` fires and the log makes
     // the missing keepalive visible — silently returning Ok would
@@ -1072,6 +1139,39 @@ fn set_keepalive(_stream: &TcpStream, _on: bool) -> std::io::Result<()> {
         std::io::ErrorKind::Unsupported,
         "SO_KEEPALIVE not implemented on this platform",
     ))
+}
+
+/// Tiny `setsockopt(fd, level, name, &value)` wrapper for integer
+/// options. Extracted so each keepalive tunable is a one-liner
+/// instead of five lines of repeated FFI boilerplate. Only used
+/// on unix targets.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn set_sockopt_int(
+    fd: libc::c_int,
+    level: libc::c_int,
+    name: libc::c_int,
+    value: libc::c_int,
+) -> std::io::Result<()> {
+    // SAFETY: `fd` is a valid open socket borrowed from the
+    // caller's `&TcpStream` for the duration of this call.
+    // `value` is a stack-local `c_int`; we pass its address plus
+    // the matching size, which is the documented calling
+    // convention for `setsockopt`'s integer options.
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            name,
+            std::ptr::addr_of!(value).cast(),
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
 }
 
 /// How long the server waits on a fresh TCP connection for a
@@ -1600,6 +1700,94 @@ mod tests {
     /// cross-client bugs show up as the wrong freq under
     /// `connected_clients[1]`.
     const TEST_CLIENT_B_FREQ_HZ: u32 = 100_000_000;
+
+    /// Test helper: `getsockopt(fd, level, name)` for integer
+    /// options. Panics on failure with the OS errno so test
+    /// diagnostics point at the real problem instead of a bare
+    /// "assertion failed". Linux-only because the only caller is
+    /// the keepalive readback test below and those constant
+    /// names are Linux-specific.
+    #[cfg(target_os = "linux")]
+    #[allow(unsafe_code)]
+    fn get_sockopt_int(fd: libc::c_int, level: libc::c_int, name: libc::c_int) -> libc::c_int {
+        let mut value: libc::c_int = 0;
+        let mut len: libc::socklen_t = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+        // SAFETY: `fd` is a valid open socket for the call's
+        // duration (test-side caller holds the accepted
+        // TcpStream). `value` and `len` live on the stack; their
+        // pointers are valid for the `getsockopt` call.
+        let ret = unsafe {
+            libc::getsockopt(
+                fd,
+                level,
+                name,
+                std::ptr::addr_of_mut!(value).cast(),
+                std::ptr::addr_of_mut!(len),
+            )
+        };
+        assert_eq!(
+            ret,
+            0,
+            "getsockopt(level={level}, name={name}) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        value
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn configure_client_socket_applies_tuned_keepalive_on_linux() {
+        // **Regression test for #393.** Verifies that the
+        // TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT constants
+        // actually land on the socket — not just that setsockopt
+        // returned zero. Calls getsockopt after
+        // `configure_client_socket` and asserts the kernel-side
+        // values match our per-file constants.
+        //
+        // Linux-only because the platform constants differ
+        // (macOS has only `TCP_KEEPALIVE`, FreeBSD has different
+        // names). Other targets are exercised via the Unsupported
+        // fallback path in `set_keepalive_tuned`.
+        use std::os::unix::io::AsRawFd;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = thread::spawn(move || {
+            let s = TcpStream::connect(addr).unwrap();
+            // Hold the client side alive long enough for the
+            // server half to run getsockopt. Drops at thread
+            // exit, which cleans up the socket pair.
+            thread::sleep(Duration::from_millis(100));
+            drop(s);
+        });
+        let (server_stream, _peer) = listener.accept().unwrap();
+        configure_client_socket(&server_stream);
+
+        let fd = server_stream.as_raw_fd();
+        assert_ne!(
+            get_sockopt_int(fd, libc::SOL_SOCKET, libc::SO_KEEPALIVE),
+            0,
+            "SO_KEEPALIVE should be enabled after configure_client_socket"
+        );
+        assert_eq!(
+            get_sockopt_int(fd, libc::IPPROTO_TCP, libc::TCP_KEEPIDLE) as u32,
+            TCP_KEEPALIVE_IDLE_SECS,
+            "TCP_KEEPIDLE should match the tuned constant"
+        );
+        assert_eq!(
+            get_sockopt_int(fd, libc::IPPROTO_TCP, libc::TCP_KEEPINTVL) as u32,
+            TCP_KEEPALIVE_INTERVAL_SECS,
+            "TCP_KEEPINTVL should match the tuned constant"
+        );
+        assert_eq!(
+            get_sockopt_int(fd, libc::IPPROTO_TCP, libc::TCP_KEEPCNT) as u32,
+            TCP_KEEPALIVE_RETRIES,
+            "TCP_KEEPCNT should match the tuned constant"
+        );
+
+        drop(server_stream);
+        let _ = client.join();
+    }
 
     #[test]
     fn start_surfaces_port_conflict_as_typed_error() {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -1149,16 +1149,19 @@ fn set_keepalive_tuned(stream: &TcpStream) -> std::io::Result<()> {
 }
 
 #[cfg(not(unix))]
-fn set_keepalive_tuned(_stream: &TcpStream) -> std::io::Result<()> {
-    // Non-unix has no implementation yet. Return Unsupported so the
-    // warn path in `configure_client_socket` fires and the log makes
-    // the missing keepalive visible — silently returning Ok would
-    // leave operators thinking dead-peer detection is active when it
-    // isn't.
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "SO_KEEPALIVE not implemented on this platform",
-    ))
+fn set_keepalive_tuned(stream: &TcpStream) -> std::io::Result<()> {
+    // Non-unix targets (Windows, WASI, etc.) enable keepalive with
+    // system defaults via socket2 — std::net::TcpStream exposes no
+    // keepalive setter, and our primary tunables
+    // (`TCP_KEEPIDLE` / `TCP_KEEPINTVL` / `TCP_KEEPCNT`) are
+    // Linux-specific. Using `SockRef::from(&stream)` lets us flip
+    // `SO_KEEPALIVE` without taking ownership of the TcpStream.
+    // The kernel's default probe timings apply (~2 h first probe
+    // on Windows), so the #393 zombie-detection fallback is slower
+    // than on Linux but still runs. Per `CodeRabbit` round 1 on
+    // PR #404. #393.
+    let sock = socket2::SockRef::from(stream);
+    sock.set_keepalive(true)
 }
 
 /// Tiny `setsockopt(fd, level, name, &value)` wrapper for integer

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -233,21 +233,31 @@ pub struct RtlTcpConfig {
     /// client if the slot is occupied, and admit us instead.
     /// Defaults to `false`.
     ///
-    /// The normal UI flow that flips this to `true`: user tries
-    /// to connect as Controller, server denies with
-    /// `status=ControllerBusy`, client shows a "Take control?"
-    /// prompt, user confirms, client reconnects with
-    /// `request_takeover = true`. sdr-rs servers with role
-    /// support (#392+) honor this and displace the prior
-    /// controller; servers without (vanilla `rtl_tcp`) ignore
-    /// the whole extended hello anyway, so setting this in
-    /// combination with `compression = NONE_ONLY` still stays
-    /// wire-compatible with vanilla — the `extension_enabled`
-    /// gate below sends a hello if EITHER compression is
-    /// requested OR takeover is, so opting into takeover
-    /// against a known-vanilla server would send a hello it
-    /// doesn't understand (same mDNS `codecs=3` signal gates
-    /// both opt-ins). #393.
+    /// **RTLX-only — NOT safe against vanilla servers.** Setting
+    /// this to `true` triggers a `ClientHello` on the wire (the
+    /// `extension_enabled` gate below sends a hello if EITHER
+    /// `compression != NONE_ONLY` OR `request_takeover == true`).
+    /// Vanilla `rtl_tcp` servers misinterpret the 8-byte hello as
+    /// two 5-byte commands straddling the framing boundary, which
+    /// can cause garbage dispatches — exactly the hazard the
+    /// [`Self::compression`] doc already describes.
+    ///
+    /// Callers must gate this opt-in on the same out-of-band
+    /// evidence that gates `compression`: the server's mDNS TXT
+    /// record (`codecs=3` = RTLX-capable; absent / `codecs=1` =
+    /// legacy-only, keep this `false`). The UI / client-side
+    /// discovery layer is responsible for refusing to expose the
+    /// takeover action against legacy-only servers, just as it
+    /// already refuses to advertise compression for them.
+    ///
+    /// Normal UI flow when it IS safe: user tries to connect as
+    /// Controller, server denies with `status=ControllerBusy`,
+    /// client shows a "Take control?" prompt (only if the server
+    /// advertised RTLX via mDNS), user confirms, client
+    /// reconnects with `request_takeover = true`. sdr-rs servers
+    /// with role support (#392+) honor the flag and displace the
+    /// prior controller. Per #393 + `CodeRabbit` round 1 on
+    /// PR #404 (doc clarification).
     pub request_takeover: bool,
 }
 

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -227,6 +227,28 @@ pub struct RtlTcpConfig {
     /// safe to send a hello; an absent or `codecs=1` value means
     /// legacy-only and we should leave this at `NONE_ONLY`.
     pub compression: sdr_server_rtltcp::codec::CodecMask,
+
+    /// Request the `FLAG_REQUEST_TAKEOVER` bit in the extended
+    /// handshake — asks the server to kick its existing Control
+    /// client if the slot is occupied, and admit us instead.
+    /// Defaults to `false`.
+    ///
+    /// The normal UI flow that flips this to `true`: user tries
+    /// to connect as Controller, server denies with
+    /// `status=ControllerBusy`, client shows a "Take control?"
+    /// prompt, user confirms, client reconnects with
+    /// `request_takeover = true`. sdr-rs servers with role
+    /// support (#392+) honor this and displace the prior
+    /// controller; servers without (vanilla `rtl_tcp`) ignore
+    /// the whole extended hello anyway, so setting this in
+    /// combination with `compression = NONE_ONLY` still stays
+    /// wire-compatible with vanilla — the `extension_enabled`
+    /// gate below sends a hello if EITHER compression is
+    /// requested OR takeover is, so opting into takeover
+    /// against a known-vanilla server would send a hello it
+    /// doesn't understand (same mDNS `codecs=3` signal gates
+    /// both opt-ins). #393.
+    pub request_takeover: bool,
 }
 
 impl Default for RtlTcpConfig {
@@ -236,6 +258,7 @@ impl Default for RtlTcpConfig {
             max_consecutive_timeouts: DEFAULT_MAX_CONSECUTIVE_TIMEOUTS,
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
+            request_takeover: false,
         }
     }
 }
@@ -839,25 +862,43 @@ fn attempt_connect(
         tracing::warn!(%e, "SO_KEEPALIVE not applied (non-fatal)");
     }
 
-    // Send the extended-protocol `ClientHello` only if the caller
-    // opted into compression. A hello sent to a vanilla
-    // `rtl_tcp` server straddles its 5-byte command-read
-    // framing (hello is 8 bytes = 1.6 commands) and can cause
-    // garbage dispatches, so we only send it when we have
-    // out-of-band evidence the server speaks the extension
-    // (e.g., mDNS TXT `codecs=3` or an explicit per-server
-    // profile setting — see the `RtlTcpConfig.compression`
-    // doc for the full signal). Default `compression = NONE_ONLY`
-    // → no hello → wire-compatible with every rtl_tcp server on
-    // earth. Per #307.
-    let extension_enabled = config.compression != CodecMask::NONE_ONLY;
+    // Send the extended-protocol `ClientHello` if the caller
+    // opted into either compression (#307) or takeover (#393) —
+    // both are RTLX features that require the server to parse
+    // the hello. A hello sent to a vanilla `rtl_tcp` server
+    // straddles its 5-byte command-read framing (hello is 8
+    // bytes = 1.6 commands) and can cause garbage dispatches,
+    // so we only send it when we have out-of-band evidence the
+    // server speaks the extension (e.g., mDNS TXT `codecs=3` or
+    // an explicit per-server profile setting — see the
+    // `RtlTcpConfig.compression` doc for the full signal). The
+    // same signal gates takeover: if the user clicks "Take
+    // control" against a server whose mDNS record says legacy-
+    // only, the UI should gray out the option or toast the user,
+    // because sending a hello there corrupts the legacy stream.
+    // Default `compression = NONE_ONLY && request_takeover =
+    // false` → no hello → wire-compatible with every rtl_tcp
+    // server on earth. Per #307 / #393.
+    let extension_enabled = config.compression != CodecMask::NONE_ONLY || config.request_takeover;
     if extension_enabled {
+        let flags = if config.request_takeover {
+            // Bit 0 of the reserved flags byte is
+            // `FLAG_REQUEST_TAKEOVER`. Setting it tells #392+
+            // servers to kick the existing Control client and
+            // admit us instead (when the slot is busy); servers
+            // without role support ignore the whole hello. #393.
+            sdr_server_rtltcp::extension::FLAG_REQUEST_TAKEOVER
+        } else {
+            CLIENT_HELLO_FLAGS_NONE
+        };
         let hello = ClientHello {
             codec_mask: config.compression,
-            // #307 is single-client on the server side; role and
-            // flags are reserved for #390's multi-client follow-ups.
+            // sdr-rs clients always request Control on connect;
+            // Listen clients don't emerge from this codepath —
+            // they'd flow through a future client-side Listen
+            // opt-in that isn't part of #393's scope.
             role: Role::Control,
-            flags: CLIENT_HELLO_FLAGS_NONE,
+            flags,
             version: PROTOCOL_VERSION,
         };
         if let Err(e) = (&stream).write_all(&hello.to_bytes()) {
@@ -1604,6 +1645,7 @@ mod tests {
             max_consecutive_timeouts: 2,
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
+            request_takeover: false,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -1856,6 +1898,7 @@ mod tests {
             max_consecutive_timeouts: 2,
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             compression: CodecMask::NONE_AND_LZ4,
+            request_takeover: false,
         };
         (listener, config)
     }
@@ -2048,6 +2091,145 @@ mod tests {
         assert!(
             src.tuner_info().is_none(),
             "tuner_info must stay None across transient busy retries"
+        );
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_sends_takeover_flag_when_config_opts_in() {
+        // **Regression test for #393.** When
+        // `RtlTcpConfig::request_takeover = true`, the outgoing
+        // `ClientHello.flags` byte must set bit 0
+        // (`FLAG_REQUEST_TAKEOVER`). Captures the hello off the
+        // wire server-side and asserts the bit is set. Pairs
+        // with the server-side takeover matrix tests in
+        // `broadcaster::tests::register_with_role_takeover_*`
+        // (which exercise the server's reaction); this test
+        // locks in the client's end of the same wire contract.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (hello_tx, hello_rx) = std::sync::mpsc::channel::<[u8; CLIENT_HELLO_LEN]>();
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            sock.set_read_timeout(Some(RTLX_TEST_STATE_DEADLINE))
+                .unwrap();
+            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+            sock.read_exact(&mut hello_buf).expect("read hello");
+            let _ = hello_tx.send(hello_buf);
+            // Accept the handshake so the client reaches
+            // Connected and doesn't loop the accept socket.
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: RTLX_TEST_GAIN_COUNT,
+            }
+            .to_bytes();
+            sock.write_all(&header).unwrap();
+            let ext = ServerExtension {
+                codec: Codec::None,
+                granted_role: Some(Role::Control),
+                status: Status::Ok,
+                version: PROTOCOL_VERSION,
+            };
+            sock.write_all(&ext.to_bytes()).unwrap();
+            thread::sleep(RTLX_TEST_SERVER_HOLD);
+        });
+
+        let config = RtlTcpConfig {
+            data_read_timeout: RTLX_TEST_DATA_READ_TIMEOUT,
+            max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            // Takeover opt-in also enables the hello even when
+            // compression is off — the extension_enabled gate is
+            // "compression != NONE_ONLY OR request_takeover".
+            compression: CodecMask::NONE_ONLY,
+            request_takeover: true,
+        };
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        src.start_manager().unwrap();
+
+        let hello = hello_rx
+            .recv_timeout(RTLX_TEST_STATE_DEADLINE)
+            .expect("server should receive hello within deadline");
+        // Magic bytes first — sanity-check we read the hello,
+        // not IQ garbage or something else.
+        assert_eq!(&hello[..EXTENSION_MAGIC.len()], &EXTENSION_MAGIC);
+        // Flags byte (offset 6) must have bit 0 set.
+        let flags_byte = hello[6];
+        assert_ne!(
+            flags_byte & sdr_server_rtltcp::extension::FLAG_REQUEST_TAKEOVER,
+            0,
+            "request_takeover = true must set FLAG_REQUEST_TAKEOVER bit \
+             in the hello (got flags byte 0x{flags_byte:02x})"
+        );
+        // And the takeover flag opens the hello path even when
+        // compression stayed at NONE_ONLY — the codec_mask on
+        // the wire reflects the caller's mask verbatim.
+        assert_eq!(hello[4], CodecMask::NONE_ONLY.to_wire());
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_omits_takeover_flag_by_default() {
+        // Complement to the takeover-flag test: when
+        // `request_takeover` is left at its default (`false`),
+        // the hello flags byte must NOT have the bit set.
+        // Protects against a bug where `FLAG_REQUEST_TAKEOVER`
+        // gets hard-coded anywhere in the client emission path.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (hello_tx, hello_rx) = std::sync::mpsc::channel::<[u8; CLIENT_HELLO_LEN]>();
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            sock.set_read_timeout(Some(RTLX_TEST_STATE_DEADLINE))
+                .unwrap();
+            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+            sock.read_exact(&mut hello_buf).expect("read hello");
+            let _ = hello_tx.send(hello_buf);
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: RTLX_TEST_GAIN_COUNT,
+            }
+            .to_bytes();
+            sock.write_all(&header).unwrap();
+            let ext = ServerExtension {
+                codec: Codec::Lz4,
+                granted_role: Some(Role::Control),
+                status: Status::Ok,
+                version: PROTOCOL_VERSION,
+            };
+            sock.write_all(&ext.to_bytes()).unwrap();
+            thread::sleep(RTLX_TEST_SERVER_HOLD);
+        });
+
+        // Compression opts into the extended handshake (it must,
+        // otherwise no hello is sent and this test is vacuous).
+        // `request_takeover` stays at its default `false`.
+        let config = RtlTcpConfig {
+            data_read_timeout: RTLX_TEST_DATA_READ_TIMEOUT,
+            max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            compression: CodecMask::NONE_AND_LZ4,
+            request_takeover: false,
+        };
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        src.start_manager().unwrap();
+
+        let hello = hello_rx
+            .recv_timeout(RTLX_TEST_STATE_DEADLINE)
+            .expect("server should receive hello within deadline");
+        assert_eq!(&hello[..EXTENSION_MAGIC.len()], &EXTENSION_MAGIC);
+        let flags_byte = hello[6];
+        assert_eq!(
+            flags_byte & sdr_server_rtltcp::extension::FLAG_REQUEST_TAKEOVER,
+            0,
+            "request_takeover = false must clear FLAG_REQUEST_TAKEOVER \
+             in the hello (got flags byte 0x{flags_byte:02x})"
         );
 
         src.stop_manager();

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -1898,6 +1898,19 @@ mod tests {
     /// enough to catch brief state visits without pegging a core.
     const RTLX_TEST_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
+    /// Slice large enough to catch any stray prefix the default
+    /// client might emit against a vanilla-shape server — 4 bytes
+    /// would be the EXTENSION_MAGIC prefix, 8 would be a full
+    /// `ClientHello`. 16 bytes comfortably covers either
+    /// regression. Used by
+    /// `rtl_tcp_default_config_sends_no_hello_to_vanilla_server`.
+    const NO_HELLO_PROBE_LEN: usize = 16;
+    /// Read timeout for the "did the client send anything?" probe.
+    /// Short enough to keep the test fast, long enough that a
+    /// real client-side hello emission would fall well within
+    /// this window.
+    const NO_HELLO_PROBE_TIMEOUT: Duration = Duration::from_millis(200);
+
     /// Shared fixture setup: listener on loopback + config that
     /// opts into the extended handshake. Keeps the three RTLX
     /// handshake tests aligned on compression mask + timeouts.
@@ -2184,12 +2197,21 @@ mod tests {
     }
 
     #[test]
-    fn rtlx_handshake_omits_takeover_flag_by_default() {
-        // Complement to the takeover-flag test: when
-        // `request_takeover` is left at its default (`false`),
-        // the hello flags byte must NOT have the bit set.
-        // Protects against a bug where `FLAG_REQUEST_TAKEOVER`
-        // gets hard-coded anywhere in the client emission path.
+    fn rtlx_handshake_clears_takeover_flag_when_only_compression_opts_in() {
+        // **Regression test for #393 + CodeRabbit round 2 on PR #404.**
+        // Pins the RTLX-hello-path contract: when compression
+        // triggers the hello (the `extension_enabled` gate) but
+        // `request_takeover` stays at its default `false`, the
+        // flags byte on the wire must NOT have
+        // `FLAG_REQUEST_TAKEOVER` set. Protects against a bug
+        // where the bit gets hard-coded anywhere in the client
+        // emission path.
+        //
+        // The complementary "true default path sends no hello at
+        // all" case is covered by
+        // `rtl_tcp_default_config_sends_no_hello_to_vanilla_server`
+        // below — that test pins NONE_ONLY + request_takeover =
+        // false → no hello, which is the legacy-safe default.
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
 
@@ -2217,9 +2239,10 @@ mod tests {
             thread::sleep(RTLX_TEST_SERVER_HOLD);
         });
 
-        // Compression opts into the extended handshake (it must,
-        // otherwise no hello is sent and this test is vacuous).
-        // `request_takeover` stays at its default `false`.
+        // Compression opts into the extended handshake (required
+        // for this path — without it, `extension_enabled = false`
+        // and no hello is sent). `request_takeover` at its
+        // default `false`.
         let config = RtlTcpConfig {
             data_read_timeout: RTLX_TEST_DATA_READ_TIMEOUT,
             max_consecutive_timeouts: 2,
@@ -2241,6 +2264,91 @@ mod tests {
             "request_takeover = false must clear FLAG_REQUEST_TAKEOVER \
              in the hello (got flags byte 0x{flags_byte:02x})"
         );
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtl_tcp_default_config_sends_no_hello_to_vanilla_server() {
+        // **Regression test for `CodeRabbit` round 2 on PR #404.**
+        // The true default path (no compression opt-in, no
+        // takeover opt-in) MUST NOT send a `ClientHello` — that's
+        // the legacy-safe contract that keeps the client
+        // wire-compatible with every vanilla rtl_tcp server
+        // (GQRX, SDR++, CubicSDR, upstream rtl_tcp, etc.). An
+        // unexpected 8-byte hello would straddle their 5-byte
+        // command framing and cause garbage dispatches.
+        //
+        // Test server: accept, briefly try to read from the
+        // client with a short timeout, assert the read times out
+        // (no bytes received) — proves the client sent nothing
+        // before expecting the server's `dongle_info_t`. Then
+        // send the legacy `dongle_info_t` to let the client's
+        // manager settle into Connected cleanly.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel::<std::io::Result<usize>>();
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            sock.set_read_timeout(Some(NO_HELLO_PROBE_TIMEOUT))
+                .expect("set_read_timeout");
+            // Try to read. If the client sent nothing (the
+            // correct behavior), this returns WouldBlock /
+            // TimedOut after the probe window. Any bytes
+            // received mean the client incorrectly emitted
+            // something before waiting for dongle_info_t.
+            let mut probe_buf = [0u8; NO_HELLO_PROBE_LEN];
+            let read_result = sock.read(&mut probe_buf);
+            let _ = probe_tx.send(read_result);
+            // Clear the probe timeout before the legacy send so
+            // the client's `set_read_timeout` on its side
+            // doesn't interact with ours.
+            sock.set_read_timeout(None).expect("clear timeout");
+            // Complete the legacy handshake so the client
+            // settles into Connected.
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: RTLX_TEST_GAIN_COUNT,
+            }
+            .to_bytes();
+            let _ = sock.write_all(&header);
+            thread::sleep(RTLX_TEST_SERVER_HOLD);
+        });
+
+        // True default: NONE_ONLY compression + request_takeover
+        // default (false) → `extension_enabled = false` → no
+        // hello on the wire.
+        let config = RtlTcpConfig::default();
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        src.start_manager().unwrap();
+
+        let probe_result = probe_rx
+            .recv_timeout(RTLX_TEST_STATE_DEADLINE)
+            .expect("server probe should resolve within deadline");
+        match probe_result {
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                // Expected outcome: the client sent nothing, so
+                // the server's short-timeout read times out.
+                // Legacy-safe contract holds.
+            }
+            Ok(0) => {
+                // Also acceptable: clean EOF before any bytes
+                // (e.g., the manager tore down before proceeding
+                // to the legacy read). Still proves no hello was
+                // emitted.
+            }
+            Ok(n) => panic!(
+                "default config must not send a hello before dongle_info_t, \
+                 but the server observed {n} byte(s) from the client before \
+                 writing its own response"
+            ),
+            Err(e) => panic!("unexpected server probe error (not the benign timeout/EOF): {e:?}"),
+        }
 
         src.stop_manager();
         let _ = server_thread.join();


### PR DESCRIPTION
## Summary

Closes #393 — third sub-issue of multi-client epic #390.

Implements the takeover handshake: a new Control client can set `ClientHello.flags` bit 0 (`FLAG_REQUEST_TAKEOVER`, already reserved on the wire from #307/#392) to ask the server to kick the existing Control client and admit it instead. Prevents permanent lockout when a controller zombies (laptop lid closed, process crashed without FIN). Also tunes TCP keepalive so the fallback "wait for the kernel to notice" path detects a dead controller within ~90s instead of the Linux default ~2 hours.

## Commits

1. **`rtl_tcp: tune TCP keepalive for ~90s zombie detection`** — Linux `TCP_KEEPIDLE=60s` + `TCP_KEEPINTVL=10s` + `TCP_KEEPCNT=3`, macOS `TCP_KEEPALIVE=60s` (only knob exposed on macOS — per-probe interval + count use system defaults, ~10 min detection). Regression test `configure_client_socket_applies_tuned_keepalive_on_linux` uses `getsockopt` to verify the constants land on the kernel socket.

2. **`rtl_tcp: takeover handshake on ClientRegistry`** — new `RoleDecision::GrantedViaTakeover { displaced_id }` variant + `register_with_role(slot, cap, request_takeover: bool)` signature. When `Role::Control` + live controller + `request_takeover = true`: prior controller's slot is `mark_disconnected()`-ed under the admission lock, new slot is admitted, returns `GrantedViaTakeover`. Writer + command workers on the displaced slot observe the flag on their next tick and exit with a clean TCP FIN (~500 ms worst case with current timeouts — acceptable for a user-driven "Take control" click). `spawn_client_workers` reads `hello.request_takeover()` and threads it through; the granted-path match adds an extra arm that logs the displaced id alongside the new client id.

3. **`rtl_tcp client: RtlTcpConfig::request_takeover opt-in`** — client-side config flag that sets the `FLAG_REQUEST_TAKEOVER` bit in the outgoing hello. `extension_enabled` gate updated to `compression != NONE_ONLY || request_takeover` so takeover opt-in triggers a hello even when compression stays at `NONE_ONLY`. Existing `RtlTcpConfig` construction sites updated.

## Decision matrix (server-side, `register_with_role`)

| Requested | Slot state | `request_takeover` | Outcome |
|---|---|---|---|
| Control | free | either | `Granted` |
| Control | busy | false | `ControllerBusy` (#392 unchanged) |
| Control | busy | true | `GrantedViaTakeover { displaced_id }` — prior controller kicked |
| Listen | under cap | either (ignored) | `Granted` |
| Listen | at cap | either (ignored) | `ListenerCapReached` |

Vanilla clients always request `Control` with `request_takeover = false` (they can't set the flag) — the existing Control client is protected from vanilla-driven displacement.

## Test coverage

**Unit tests** (all passing):
- `configure_client_socket_applies_tuned_keepalive_on_linux` — `getsockopt` readback confirms all 4 keepalive values land on the kernel socket.
- `register_with_role_takeover_displaces_existing_controller` — core contract: A admitted, B takes over, A flagged disconnected, `GrantedViaTakeover { displaced_id: a_id }`, `lifetime_accepted == 2` (kick doesn't decrement).
- `register_with_role_takeover_is_noop_when_slot_is_free` — flag with no conflict → plain `Granted`.
- `register_with_role_takeover_false_still_denies_busy_controller` — #392 `ControllerBusy` semantics preserved when flag is clear.
- `register_with_role_takeover_leaves_listeners_alone` — listener survives a Control takeover unscathed (covers acceptance criterion #6).
- `rtlx_handshake_sends_takeover_flag_when_config_opts_in` — client-side: takeover opt-in sets the wire flag byte bit 0.
- `rtlx_handshake_omits_takeover_flag_by_default` — complement: `request_takeover = false` clears the bit.

**Deferred to manual smoke test** (requires real RTL-SDR hardware):
- End-to-end: controller A connects via GTK app, controller B connects from another machine with `request_takeover = true`, verify A's session tears down cleanly and B becomes controller. `Server::start` requires a USB-attached dongle, so end-to-end accept-path tests don't run in CI.

## UI integration flow (future #396 scope)

The client-side plumbing is ready; the UI prompt is #396:

1. User clicks Connect as Controller.
2. Server denies with `status=ControllerBusy`.
3. Client UI shows "Take control?" prompt with the current peer's ID/address (from the registry's connected_clients list, via the stats panel).
4. User confirms → client reconnects with `request_takeover = true`.
5. Server emits `GrantedViaTakeover` + admits.
6. Displaced controller sees TCP FIN; their UI goes to `Disconnected`.

## "Kicked" reason delivery

Per the issue's discussion: **Option A (bare TCP FIN)**. Client UI infers "kicked" from the timing of the disconnect relative to a local takeover attempt. No new wire message format needed. Revisit later if users find the ambiguity annoying.

## Remaining multi-client epic #390 sub-issues

- **#394** — optional auth key (server-generated, client-required when enabled)
- **#395** — server UI (client list + cap + auth toggle — also where per-client activity log surfaces the `displaced_id` from this PR)
- **#396** — client UI (role picker, takeover button, kicked-toast — the UI end of this PR's wire work)
- **#397** — FIPS-compliant transport encryption (investigation)

## Smoke-test checklist (Linux, with real RTL-SDR)

When you run the binary:

- [ ] `sdr-rs` connects normally as the Control client.
- [ ] Second instance of `sdr-rs` on another machine tries to connect → server denies with ControllerBusy (existing #392 behavior).
- [ ] In the second instance, click "Take control" (or manually set `request_takeover = true` in the config and reconnect) → server admits, first instance sees its stream drop cleanly.
- [ ] Close laptop lid on the first instance (or `kill -9` the process without letting it FIN) → within ~90s, `sdr-rtl-tcp` logs show the slot pruned via TCP keepalive, and a new Control connection succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controllers can optionally request to take over an active controller; takeover is opt-in and disabled by default. Clients can advertise takeover intent during handshake.
  * Improved TCP keepalive tuning for more stable connections across platforms.

* **Bug Fixes**
  * Admission counting and displacement behavior corrected; listeners remain unaffected during control takeovers.

* **Tests**
  * Added and updated tests for takeover flag handling, displacement, busy denial, and keepalive settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->