### PR TITLE
rtl_tcp: optional pre-shared-key auth (#394)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1680,12 +1680,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1695,7 +1716,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2080,10 +2110,12 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "lz4_flex",
+ "rand 0.8.6",
  "rusb",
  "sdr-rtlsdr",
  "sdr-rtltcp-discovery",
  "socket2 0.5.10",
+ "subtle",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,21 @@ sherpa-onnx = { git = "https://github.com/jasonherald/sherpa-onnx.git", rev = "6
 dirs-next = "2"
 libc = "0.2"
 
+# Random number generation. Pulled in for the rtl_tcp optional-auth
+# server (#394) key generator — `OsRng` wraps `/dev/urandom` on
+# unix and `BCryptGenRandom` on Windows, which is what we want for
+# a 32-byte pre-shared key (CSPRNG quality, no seed management).
+# Pinned to 0.8.x until we need the 0.9 API rework; 0.8 is still
+# the ecosystem-majority version as of the workspace's 1.95 pin.
+rand = "0.8"
+
+# Constant-time primitives. Used by the rtl_tcp optional-auth
+# server (#394) for the `ConstantTimeEq` compare between the
+# client-provided key and the configured expected key. Rolling
+# a constant-time `memcmp` by hand is easy to get wrong; this
+# crate is the standard Rust answer and has zero runtime deps.
+subtle = "2.5"
+
 # Error handling
 thiserror = "2"
 anyhow = "1"

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 16;
+pub const ABI_VERSION_MINOR: u32 = 17;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 16);
+        assert!(ABI_VERSION_MINOR == 17);
     };
 
     #[test]

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -84,6 +84,32 @@ pub struct SdrRtlTcpServerConfig {
     /// counted — they occupy the controller slot, which is
     /// separate from the listener pool. #392.
     pub listener_cap: u32,
+    /// Pre-shared auth key bytes. `NULL` with `auth_key_len == 0`
+    /// means "auth disabled" — default, matches today's LAN-trust
+    /// model. Non-null pointer + non-zero length enables the
+    /// auth gate: every connecting client must present an
+    /// `AuthKeyMessage` whose bytes match these bytes
+    /// (constant-time compare). The server copies the bytes
+    /// into its owned `Vec<u8>` during
+    /// `sdr_rtltcp_server_start` — the caller's buffer can be
+    /// freed / reused immediately after the call returns.
+    ///
+    /// Length must be in `1..=256`
+    /// ([`sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN`]);
+    /// values outside that range cause `sdr_rtltcp_server_start`
+    /// to return [`SdrCoreError::InvalidArg`] without starting
+    /// the server.
+    ///
+    /// Keys travel as cleartext over TCP — wrap the connection in
+    /// SSH / WireGuard / Tailscale if the threat model demands
+    /// WAN-grade confidentiality. This flag enables LAN isolation
+    /// (keeping IoT devices / shared-network cohabitants from
+    /// seizing the dongle), nothing stronger. #394.
+    pub auth_key: *const u8,
+    /// Length in bytes of [`Self::auth_key`]. See that field's
+    /// doc for valid range and semantics. Must be 0 iff
+    /// `auth_key` is NULL.
+    pub auth_key_len: u32,
 }
 
 /// Aggregate server-lifetime statistics snapshot.
@@ -408,6 +434,63 @@ fn listener_cap_from_c(listener_cap: u32) -> usize {
     }
 }
 
+/// Outcome of [`auth_key_from_c`] — either the server should run
+/// without auth (`None` input, or `Some` with valid length) or
+/// the caller gave a bad pointer/length pair and
+/// `sdr_rtltcp_server_start` should reject with
+/// `SdrCoreError::InvalidArg`. Split out so the translation is
+/// unit-testable without the hardware-backed start path.
+#[derive(Debug, PartialEq, Eq)]
+enum AuthKeyFromC {
+    /// Auth disabled (caller passed NULL pointer + zero length).
+    Disabled,
+    /// Auth enabled with the given bytes. Caller stores this in
+    /// `ServerConfig::auth_key`.
+    Enabled(Vec<u8>),
+    /// Malformed input — non-null pointer with zero length, null
+    /// pointer with non-zero length, or length exceeding
+    /// `MAX_AUTH_KEY_LEN`. `sdr_rtltcp_server_start` surfaces as
+    /// `InvalidArg`.
+    Invalid,
+}
+
+/// Translate the C-ABI `auth_key` + `auth_key_len` pair into a
+/// `ServerConfig::auth_key` value. Rules:
+///
+/// - Both `NULL` and `0`: auth disabled.
+/// - Non-null + `len` in `1..=MAX_AUTH_KEY_LEN`: copy `len`
+///   bytes, enabled.
+/// - Any other combination (null + len > 0, non-null + len = 0,
+///   len > MAX): invalid.
+///
+/// # Safety
+///
+/// `auth_key` must either be NULL or point at `auth_key_len`
+/// readable bytes. Caller's buffer can be freed/reused after
+/// this call returns — bytes are copied into the returned Vec.
+unsafe fn auth_key_from_c(auth_key: *const u8, auth_key_len: u32) -> AuthKeyFromC {
+    use sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN;
+    let len_usize = auth_key_len as usize;
+    if auth_key.is_null() && auth_key_len == 0 {
+        return AuthKeyFromC::Disabled;
+    }
+    if auth_key.is_null() || auth_key_len == 0 {
+        // Exactly one of the pair is zero/null → malformed.
+        return AuthKeyFromC::Invalid;
+    }
+    if len_usize > MAX_AUTH_KEY_LEN {
+        // Over-max length would fail at `AuthKeyMessage::to_bytes`
+        // downstream; catch here so the diagnostic surfaces
+        // cleanly as an InvalidArg rather than a handshake fail.
+        return AuthKeyFromC::Invalid;
+    }
+    // SAFETY: caller contract — pointer is non-null and points
+    // at `len_usize` readable bytes. Copy into a Vec so the
+    // caller's buffer can be freed / reused after this call.
+    let bytes = unsafe { std::slice::from_raw_parts(auth_key, len_usize) }.to_vec();
+    AuthKeyFromC::Enabled(bytes)
+}
+
 // ============================================================
 //  FFI entry points
 // ============================================================
@@ -459,6 +542,22 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
             cfg.buffer_capacity as usize
         };
         let listener_cap = listener_cap_from_c(cfg.listener_cap);
+        // SAFETY: `auth_key` is NULL-or-readable-for-`auth_key_len`
+        // per the struct doc; caller contract extends to us here.
+        let auth_key = match unsafe { auth_key_from_c(cfg.auth_key, cfg.auth_key_len) } {
+            AuthKeyFromC::Disabled => None,
+            AuthKeyFromC::Enabled(bytes) => Some(bytes),
+            AuthKeyFromC::Invalid => {
+                set_last_error(format!(
+                    "sdr_rtltcp_server_start: invalid auth_key / auth_key_len pair \
+                     (auth_key null? = {}, auth_key_len = {}, max = {})",
+                    cfg.auth_key.is_null(),
+                    cfg.auth_key_len,
+                    sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN,
+                ));
+                return SdrCoreError::InvalidArg.as_int();
+            }
+        };
         let server_cfg = ServerConfig {
             bind,
             device_index: cfg.device_index,
@@ -471,9 +570,7 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
             // one that currently offers LZ4.
             compression: CodecMask::NONE_ONLY,
             listener_cap,
-            // Auth (#394) is off for this commit — wiring the
-            // FFI auth_key field lands later on this branch.
-            auth_key: None,
+            auth_key,
         };
         match Server::start(server_cfg) {
             Ok(server) => {
@@ -1103,6 +1200,11 @@ mod tests {
             initial_bias_tee: false,
             initial_direct_sampling: 0,
             listener_cap: 0, // 0 → use DEFAULT_LISTENER_CAP
+            // Auth disabled: NULL pointer + zero length = no
+            // auth gate. Matches the "LAN-trust default" from
+            // the struct docs.
+            auth_key: std::ptr::null(),
+            auth_key_len: 0,
         }
     }
 
@@ -1151,6 +1253,96 @@ mod tests {
         // off-by-one that would have passed `listener_cap_from_c(1)
         // == 1` trivially.
         assert_eq!(listener_cap_from_c(7), 7);
+    }
+
+    #[test]
+    fn auth_key_from_c_null_pointer_zero_length_is_disabled() {
+        // Default C struct (zero-initialized) has NULL + 0 here.
+        // Must map to `Disabled`, not `Invalid` — otherwise
+        // every default-constructed `SdrRtlTcpServerConfig`
+        // would fail to start.
+        // SAFETY: NULL pointer with matching zero length is
+        // valid input to `auth_key_from_c` per its contract.
+        let outcome = unsafe { auth_key_from_c(std::ptr::null(), 0) };
+        assert_eq!(outcome, AuthKeyFromC::Disabled);
+    }
+
+    #[test]
+    fn auth_key_from_c_valid_pointer_and_length_is_enabled() {
+        // Normal enable path: caller's buffer + length.
+        let buf = [0xAAu8, 0xBB, 0xCC, 0xDD];
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "buf.len() is a const 4, fits u32 trivially"
+        )]
+        let len = buf.len() as u32;
+        // SAFETY: `buf.as_ptr()` is valid for `buf.len()` bytes.
+        let outcome = unsafe { auth_key_from_c(buf.as_ptr(), len) };
+        let AuthKeyFromC::Enabled(bytes) = outcome else {
+            unreachable!("expected Enabled variant, got {outcome:?}");
+        };
+        assert_eq!(bytes, buf.to_vec());
+    }
+
+    #[test]
+    fn auth_key_from_c_null_with_nonzero_length_is_invalid() {
+        // Malformed: caller claimed length but gave NULL. Reject
+        // cleanly rather than dereferencing a null pointer.
+        // SAFETY: Invalid input path; pointer is not
+        // dereferenced.
+        let outcome = unsafe { auth_key_from_c(std::ptr::null(), 4) };
+        assert_eq!(outcome, AuthKeyFromC::Invalid);
+    }
+
+    #[test]
+    fn auth_key_from_c_nonnull_with_zero_length_is_invalid() {
+        // Malformed: caller gave a pointer but said length is 0.
+        // Could be an uninitialized field or a bug where the
+        // operator passed a buffer but forgot the length. Reject.
+        let buf = [0xAAu8];
+        // SAFETY: Invalid input path; pointer is not
+        // dereferenced (the length-zero check short-circuits).
+        let outcome = unsafe { auth_key_from_c(buf.as_ptr(), 0) };
+        assert_eq!(outcome, AuthKeyFromC::Invalid);
+    }
+
+    #[test]
+    fn auth_key_from_c_over_max_length_is_invalid() {
+        // Length > MAX_AUTH_KEY_LEN would fail downstream at
+        // AuthKeyMessage serialization. Catch here so the FFI
+        // caller sees InvalidArg instead of a runtime handshake
+        // failure.
+        let buf = vec![0u8; sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN + 1];
+        // SAFETY: `buf.as_ptr()` is valid for `buf.len()` bytes,
+        // but we expect the length-range check to fail before
+        // any deref happens.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "MAX_AUTH_KEY_LEN + 1 = 257 fits u32 trivially"
+        )]
+        let len = buf.len() as u32;
+        let outcome = unsafe { auth_key_from_c(buf.as_ptr(), len) };
+        assert_eq!(outcome, AuthKeyFromC::Invalid);
+    }
+
+    #[test]
+    fn auth_key_from_c_max_length_at_boundary_is_enabled() {
+        // Exactly `MAX_AUTH_KEY_LEN = 256` bytes — the upper
+        // bound. Pins an off-by-one defense: a check spelled
+        // `>` vs `>=` would regress this to `Invalid`.
+        let buf = vec![0xEEu8; sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN];
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "MAX_AUTH_KEY_LEN = 256 fits u32 trivially"
+        )]
+        let len = buf.len() as u32;
+        // SAFETY: Valid buffer of matching length.
+        let outcome = unsafe { auth_key_from_c(buf.as_ptr(), len) };
+        let AuthKeyFromC::Enabled(bytes) = outcome else {
+            unreachable!("expected Enabled at max length, got {outcome:?}");
+        };
+        assert_eq!(bytes.len(), sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN);
+        assert_eq!(bytes[0], 0xEE);
     }
 
     #[test]
@@ -1206,6 +1398,8 @@ mod tests {
             initial_bias_tee: false,
             initial_direct_sampling: 0,
             listener_cap: 0,
+            auth_key: std::ptr::null(),
+            auth_key_len: 0,
         };
         let mut handle: *mut SdrRtlTcpServer = std::ptr::null_mut();
         let rc = unsafe { sdr_rtltcp_server_start(&raw const opts, &raw mut handle) };

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -471,6 +471,9 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
             // one that currently offers LZ4.
             compression: CodecMask::NONE_ONLY,
             listener_cap,
+            // Auth (#394) is off for this commit — wiring the
+            // FFI auth_key field lands later on this branch.
+            auth_key: None,
         };
         match Server::start(server_cfg) {
             Ok(server) => {

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -590,6 +590,14 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
                     ServerError::Device(_)
                     | ServerError::NoDevice
                     | ServerError::BadDeviceIndex { .. } => SdrCoreError::Device.as_int(),
+                    // Config-time rejection (auth_key length out of
+                    // range). Caller supplied an out-of-bounds value
+                    // in `SdrRtlTcpServerConfig`; surface as
+                    // InvalidArg so the FFI code matches the already-
+                    // established "malformed input" error class
+                    // (same code `auth_key_from_c` returns for
+                    // NULL-pointer/length mismatches).
+                    ServerError::InvalidAuthKeyLength { .. } => SdrCoreError::InvalidArg.as_int(),
                 }
             }
         }

--- a/crates/sdr-server-rtltcp/Cargo.toml
+++ b/crates/sdr-server-rtltcp/Cargo.toml
@@ -44,6 +44,12 @@ sdr-rtltcp-discovery = { workspace = true, optional = true }
 # mask at handshake time, which doesn't require the codec trait impls
 # to be absent.
 lz4_flex.workspace = true
+# Optional pre-shared-key auth (#394). `rand::rngs::OsRng` generates
+# the 32-byte server key; `subtle::ConstantTimeEq` compares a
+# client-provided key against the expected value without leaking
+# timing info about where a mismatch occurred.
+rand.workspace = true
+subtle.workspace = true
 
 # Non-unix (Windows, WASI, etc.) keepalive enable for the #393
 # zombie-detection fallback path. `std::net::TcpStream` has no

--- a/crates/sdr-server-rtltcp/src/auth.rs
+++ b/crates/sdr-server-rtltcp/src/auth.rs
@@ -75,6 +75,18 @@ pub fn generate_random_auth_key() -> Vec<u8> {
 /// the return duration is a function of `min(lenA, lenB)` only.
 #[must_use]
 pub fn validate_auth_key(provided: &[u8], expected: &[u8]) -> bool {
+    // Empty keys are rejected at every layer of the auth gate
+    // — wire format, FFI translator, and here. Defense in depth:
+    // if an upstream layer ever regresses and hands us an empty
+    // `expected` (misconfigured `ServerConfig { auth_key:
+    // Some(vec![]) }` constructed by hand, say), this check
+    // makes sure the validator doesn't silently accept every
+    // peer with a matching-empty provided. `ct_eq(empty, empty)`
+    // would otherwise return `true` and defeat the gate. Per
+    // `CodeRabbit` round 1 on PR #405.
+    if provided.is_empty() || expected.is_empty() {
+        return false;
+    }
     // `ConstantTimeEq::ct_eq` returns a `Choice` (wire byte 1 or
     // 0) that we convert to `bool` via `Into::into`. The length-
     // mismatch check is intentionally NOT constant-time — a
@@ -155,29 +167,44 @@ mod tests {
 
     #[test]
     fn validate_auth_key_rejects_empty_vs_empty() {
-        // Empty keys should never be accepted by the server even
-        // if both sides are empty — the wire format rejects
-        // zero-length `AuthKeyMessage`s at parse time, so this
-        // state shouldn't be reachable in practice, but
-        // defense-in-depth: if it is reached, reject.
-        //
-        // Actually — `ct_eq` of two empty slices returns `true`,
-        // which is mathematically consistent but NOT what we
-        // want for an auth gate (empty provided = empty expected
-        // would bypass). We rely on upstream (`AuthKeyMessage`
-        // parse + server config loader) to never pass empty
-        // slices to this function. Documenting the assumption
-        // here so the assumption chain stays explicit.
-        //
-        // If the upstream guard ever breaks, this test would
-        // PASS (because ct_eq of empties is true), not fail —
-        // which is why the real defense is at the wire-format
-        // layer, not here. Leaving the test as documentation.
+        // Defense-in-depth: empty keys are rejected at every
+        // layer of the auth gate. The wire format rejects
+        // zero-length `AuthKeyMessage`s at parse time and the
+        // FFI translator rejects `auth_key_len == 0` with
+        // non-null pointer — but a direct `ServerConfig {
+        // auth_key: Some(vec![]) }` construction could slip a
+        // naked empty Vec through. The validator's own empty
+        // guard means that even in that pathological case, no
+        // peer authenticates. Per `CodeRabbit` round 1 on
+        // PR #405 — the previous test documented the
+        // `ct_eq(empty, empty) == true` invariant as an
+        // assumption-chain note; that's now a real guard.
         let empty_a: Vec<u8> = Vec::new();
         let empty_b: Vec<u8> = Vec::new();
-        // This IS true; the test documents the invariant, not
-        // the surface behavior callers should rely on.
-        assert!(validate_auth_key(&empty_a, &empty_b));
+        assert!(
+            !validate_auth_key(&empty_a, &empty_b),
+            "validator must reject empty-vs-empty (defense in depth)"
+        );
+    }
+
+    #[test]
+    fn validate_auth_key_rejects_empty_provided() {
+        // Client sends zero-length key against a non-empty
+        // expected — should be rejected. Covers the wire-path
+        // regression where a bad parser hands us Vec::new() as
+        // the provided key.
+        let provided: Vec<u8> = Vec::new();
+        let expected = vec![0xAA, 0xBB];
+        assert!(!validate_auth_key(&provided, &expected));
+    }
+
+    #[test]
+    fn validate_auth_key_rejects_empty_expected() {
+        // Server config mistakenly carries an empty key (should
+        // have been caught upstream, but defense in depth).
+        let provided = vec![0xAA, 0xBB];
+        let expected: Vec<u8> = Vec::new();
+        assert!(!validate_auth_key(&provided, &expected));
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/auth.rs
+++ b/crates/sdr-server-rtltcp/src/auth.rs
@@ -1,0 +1,190 @@
+//! Pre-shared-key authentication helpers for the rtl_tcp server
+//! (#394).
+//!
+//! Two responsibilities:
+//!
+//! 1. **Key generation** — [`generate_random_auth_key`] wraps
+//!    [`rand::rngs::OsRng`] to produce a 32-byte key. OS-backed
+//!    CSPRNG (reads from `/dev/urandom` on unix, `BCryptGenRandom`
+//!    on Windows), so no seed management on our side. 32 bytes =
+//!    256 bits of entropy, more than sufficient for the threat
+//!    model the issue specifies (casual LAN interlopers, not
+//!    nation-state actors).
+//!
+//! 2. **Constant-time compare** — [`validate_auth_key`] wraps
+//!    [`subtle::ConstantTimeEq`] so a byte-by-byte mismatch
+//!    doesn't leak timing info about where the keys diverge. A
+//!    naive `==` on `&[u8]` short-circuits at the first
+//!    differing byte, which (on a LAN attacker's scope) is
+//!    visible in the round-trip microseconds — measurable over
+//!    thousands of attempts.
+//!
+//! The server holds the configured key as `Vec<u8>` in
+//! [`crate::server::ServerConfig`]; the client hello follow-up
+//! lands as an [`crate::extension::AuthKeyMessage`]. This module
+//! bridges the two with verification + a helper to produce the
+//! expected key at server-start time.
+
+use rand::RngCore;
+use subtle::ConstantTimeEq;
+
+/// Size in bytes of the server-generated random key. 32 bytes
+/// chosen to match the issue's "URL-safe base64 32-byte" spec —
+/// base64-encoding 32 raw bytes yields ~43 display chars, fits on
+/// one UI line, and provides 256 bits of entropy. User-supplied
+/// keys can be any length in `1..=MAX_AUTH_KEY_LEN`; this is only
+/// the default when the server auto-generates.
+pub const DEFAULT_AUTH_KEY_LEN: usize = 32;
+
+/// Generate a random auth key using the OS CSPRNG. Returns
+/// [`DEFAULT_AUTH_KEY_LEN`] bytes. Intended for:
+///
+/// - Server-start when the operator enables auth for the first
+///   time (and hasn't pasted a pre-existing key from the UI).
+/// - Tests that need a realistic key shape.
+///
+/// OS-CSPRNG means there's no seed state on our side — every
+/// call is independent. `rand::rngs::OsRng` is infallible in
+/// practice on our targets (the `try_fill_bytes` path would only
+/// surface an error on exotic platforms where `/dev/urandom` is
+/// unreadable; we don't support those).
+#[must_use]
+pub fn generate_random_auth_key() -> Vec<u8> {
+    let mut buf = vec![0u8; DEFAULT_AUTH_KEY_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut buf);
+    buf
+}
+
+/// Compare `provided` (client-sent) against `expected` (server's
+/// configured key) in constant time — the compare walks both
+/// slices fully even when they diverge early, so an attacker
+/// can't derive "where the keys differ" from the round-trip
+/// duration.
+///
+/// `false` on length mismatch. `true` only when the slices are
+/// byte-for-byte equal.
+///
+/// # Why constant time
+///
+/// A naive `provided == expected` on `&[u8]` short-circuits at
+/// the first differing byte. On a LAN an attacker with a scope
+/// can measure the round-trip microseconds and derive each
+/// leading byte of the expected key by brute-forcing single-byte
+/// positions in turn — a timing oracle. `ConstantTimeEq` runs
+/// the XOR over every byte regardless of early divergence, so
+/// the return duration is a function of `min(lenA, lenB)` only.
+#[must_use]
+pub fn validate_auth_key(provided: &[u8], expected: &[u8]) -> bool {
+    // `ConstantTimeEq::ct_eq` returns a `Choice` (wire byte 1 or
+    // 0) that we convert to `bool` via `Into::into`. The length-
+    // mismatch check is intentionally NOT constant-time — a
+    // length difference isn't a secret (the wire format
+    // advertises `key_len` in cleartext), and short-circuiting
+    // here avoids the edge case where `ct_eq` panics on
+    // differently-sized slices.
+    if provided.len() != expected.len() {
+        return false;
+    }
+    provided.ct_eq(expected).into()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::extension::MAX_AUTH_KEY_LEN;
+
+    #[test]
+    fn generate_random_auth_key_returns_default_length() {
+        // Length contract — 32 bytes matches the issue's
+        // URL-safe base64 32-byte spec. If a future change
+        // bumps the default, this test is the trip-wire that
+        // forces re-reading the generator's callers (wire-format
+        // `MAX_AUTH_KEY_LEN` still accepts up to 256, so the
+        // increase is safe from that angle, but the display
+        // layer in #395 would need to resize the key field).
+        let key = generate_random_auth_key();
+        assert_eq!(key.len(), DEFAULT_AUTH_KEY_LEN);
+    }
+
+    #[test]
+    fn generate_random_auth_key_fits_wire_bound() {
+        // Every generator output must fit the
+        // `AuthKeyMessage`-imposed upper bound. Otherwise
+        // serialization downstream (`msg.to_bytes()`) would
+        // reject our own server-generated key.
+        let key = generate_random_auth_key();
+        assert!(key.len() <= MAX_AUTH_KEY_LEN);
+        assert!(!key.is_empty(), "generator must not produce empty keys");
+    }
+
+    #[test]
+    fn generate_random_auth_key_entropy_smoke_check() {
+        // Cheap sanity check that the OsRng is actually doing
+        // something — two consecutive calls should produce
+        // different bytes. A broken rand impl (e.g., a stub
+        // returning zeros) would fail this.
+        let a = generate_random_auth_key();
+        let b = generate_random_auth_key();
+        assert_ne!(
+            a, b,
+            "two successive OsRng-based key generations must differ"
+        );
+    }
+
+    #[test]
+    fn validate_auth_key_accepts_matching_keys() {
+        let key = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        assert!(validate_auth_key(&key, &key));
+    }
+
+    #[test]
+    fn validate_auth_key_rejects_mismatch() {
+        let provided = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        let expected = vec![0xAA, 0xBB, 0xCC, 0xDE]; // last byte differs
+        assert!(!validate_auth_key(&provided, &expected));
+    }
+
+    #[test]
+    fn validate_auth_key_rejects_length_mismatch() {
+        let shorter = vec![0xAA, 0xBB];
+        let longer = vec![0xAA, 0xBB, 0xCC];
+        assert!(!validate_auth_key(&shorter, &longer));
+        assert!(!validate_auth_key(&longer, &shorter));
+    }
+
+    #[test]
+    fn validate_auth_key_rejects_empty_vs_empty() {
+        // Empty keys should never be accepted by the server even
+        // if both sides are empty — the wire format rejects
+        // zero-length `AuthKeyMessage`s at parse time, so this
+        // state shouldn't be reachable in practice, but
+        // defense-in-depth: if it is reached, reject.
+        //
+        // Actually — `ct_eq` of two empty slices returns `true`,
+        // which is mathematically consistent but NOT what we
+        // want for an auth gate (empty provided = empty expected
+        // would bypass). We rely on upstream (`AuthKeyMessage`
+        // parse + server config loader) to never pass empty
+        // slices to this function. Documenting the assumption
+        // here so the assumption chain stays explicit.
+        //
+        // If the upstream guard ever breaks, this test would
+        // PASS (because ct_eq of empties is true), not fail —
+        // which is why the real defense is at the wire-format
+        // layer, not here. Leaving the test as documentation.
+        let empty_a: Vec<u8> = Vec::new();
+        let empty_b: Vec<u8> = Vec::new();
+        // This IS true; the test documents the invariant, not
+        // the surface behavior callers should rely on.
+        assert!(validate_auth_key(&empty_a, &empty_b));
+    }
+
+    #[test]
+    fn validate_auth_key_with_generated_key_round_trips() {
+        // End-to-end smoke: generator output + validator should
+        // accept itself.
+        let key = generate_random_auth_key();
+        assert!(validate_auth_key(&key, &key));
+    }
+}

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -116,6 +116,15 @@ fn usage(exit_code: i32) -> ! {
          (default: {DEFAULT_LISTENER_CAP}; the single Control client is \
          separate)"
     );
+    let _ = writeln!(
+        out,
+        "    --auth-key <HEX>  Enable pre-shared-key auth (#394). \
+         HEX is the key bytes as an even-length hex string (e.g. \
+         `openssl rand -hex 32`). Clients must present the same \
+         key at handshake; wrong / missing keys are denied. \
+         Default: disabled. LAN-grade trust model only — wrap in \
+         SSH/WG for real confidentiality."
+    );
     let _ = writeln!(out, "    -h, --help   Show this help");
     std::process::exit(exit_code);
 }
@@ -365,11 +374,43 @@ fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<(ServerConfig, DiscoveryOptio
                 config.listener_cap = v.parse().map_err(|_| ParseError)?;
                 i += 2;
             }
+            "--auth-key" => {
+                let v = args.get(i + 1).ok_or(ParseError)?.as_ref();
+                config.auth_key = Some(parse_auth_key_hex(v)?);
+                i += 2;
+            }
             _ => return Err(ParseError),
         }
     }
 
     Ok((config, discovery))
+}
+
+/// Decode a hex-encoded auth key from the `--auth-key` CLI arg.
+/// Accepts even-length hex (e.g. `0a1b2c...`) and produces the raw
+/// bytes. Rejects odd length, non-hex chars, empty input, or keys
+/// longer than [`sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN`].
+/// Hex chosen over base64 for CLI parsing — one fewer alphabet to
+/// remember, no URL-safety concerns, easy to generate with
+/// `openssl rand -hex 32`. #394.
+fn parse_auth_key_hex(s: &str) -> Result<Vec<u8>, ParseError> {
+    if s.is_empty() || !s.len().is_multiple_of(2) {
+        return Err(ParseError);
+    }
+    let bytes: Result<Vec<u8>, _> = (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+        .collect();
+    let bytes = bytes.map_err(|_| ParseError)?;
+    // Upper bound matches the wire-format `MAX_AUTH_KEY_LEN`. A
+    // CLI-supplied key beyond that would fail at
+    // `AuthKeyMessage::to_bytes` anyway; reject here so the
+    // diagnostic lands as a clean argv-parse error rather than a
+    // runtime handshake failure.
+    if bytes.len() > sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN {
+        return Err(ParseError);
+    }
+    Ok(bytes)
 }
 
 /// Register the running server in mDNS so clients can discover it
@@ -669,6 +710,78 @@ mod tests {
         let args = ["--listener-cap", "25"];
         let (cfg, _disc) = parse_args(&args).unwrap();
         assert_eq!(cfg.listener_cap, 25);
+    }
+
+    #[test]
+    fn parse_args_auth_key_defaults_to_none() {
+        let (cfg, _disc) = parse_args::<&str>(&[]).unwrap();
+        assert!(cfg.auth_key.is_none());
+    }
+
+    #[test]
+    fn parse_args_auth_key_decodes_valid_hex() {
+        // 8-byte key in hex form → 16 hex chars.
+        let args = ["--auth-key", "deadbeef01020304"];
+        let (cfg, _disc) = parse_args(&args).unwrap();
+        assert_eq!(
+            cfg.auth_key,
+            Some(vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04])
+        );
+    }
+
+    #[test]
+    fn parse_args_auth_key_decodes_32_byte_default() {
+        // 32-byte key (the default `generate_random_auth_key`
+        // shape) → 64 hex chars. Pins that the CLI parser
+        // handles the canonical server-generated length, which
+        // is what operators will paste from the UI (once #395
+        // ships) or `openssl rand -hex 32`.
+        let mut hex = String::with_capacity(64);
+        {
+            use std::fmt::Write;
+            for i in 0..32u32 {
+                write!(&mut hex, "{:02x}", (i * 7) % 256).unwrap();
+            }
+        }
+        let args = ["--auth-key", hex.as_str()];
+        let (cfg, _disc) = parse_args(&args).unwrap();
+        let key = cfg.auth_key.unwrap();
+        assert_eq!(key.len(), 32);
+        assert_eq!(key[0], 0x00);
+        assert_eq!(key[1], 0x07);
+        assert_eq!(key[2], 0x0E);
+    }
+
+    #[test]
+    fn parse_args_auth_key_rejects_odd_length_hex() {
+        // Odd-length hex can't round-trip to bytes — reject
+        // at argv-parse time rather than truncating silently.
+        let args = ["--auth-key", "abc"];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_auth_key_rejects_non_hex_chars() {
+        // 'z' isn't a valid hex digit.
+        let args = ["--auth-key", "zzzzzzzz"];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_auth_key_rejects_empty() {
+        let args = ["--auth-key", ""];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_auth_key_rejects_over_max_length() {
+        // MAX_AUTH_KEY_LEN = 256 bytes → 512 hex chars. Anything
+        // beyond that would fail at AuthKeyMessage serialization
+        // downstream; catch here so the error surfaces as a
+        // clean argv-parse fail.
+        let hex: String = "ab".repeat(sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN + 1);
+        let args = ["--auth-key", hex.as_str()];
+        assert!(parse_args(&args).is_err());
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -394,14 +394,40 @@ fn parse_args<S: AsRef<str>>(args: &[S]) -> Result<(ServerConfig, DiscoveryOptio
 /// remember, no URL-safety concerns, easy to generate with
 /// `openssl rand -hex 32`. #394.
 fn parse_auth_key_hex(s: &str) -> Result<Vec<u8>, ParseError> {
-    if s.is_empty() || !s.len().is_multiple_of(2) {
+    /// Number of hex chars per raw byte — two. Pulled out so the
+    /// `chunks_exact` call reads intent-first instead of bare `2`.
+    const HEX_CHARS_PER_BYTE: usize = 2;
+
+    // Reject non-ASCII BEFORE any byte-index slicing. A 4-byte
+    // emoji like "💩" passes `len().is_multiple_of(2)` but
+    // indexing `&s[i..i+2]` on a UTF-8 str would panic at the
+    // non-char-boundary offset. `is_ascii()` fast-paths on the
+    // first non-ASCII byte without a full scan. Per `CodeRabbit`
+    // round 1 on PR #405.
+    if s.is_empty() || !s.is_ascii() || !s.len().is_multiple_of(HEX_CHARS_PER_BYTE) {
         return Err(ParseError);
     }
-    let bytes: Result<Vec<u8>, _> = (0..s.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+    // With ASCII confirmed, the string is also a valid byte
+    // slice — `chunks_exact(2)` walks pairs without str-slicing
+    // boundary concerns. Per-char hex-digit validation keeps
+    // the error surface narrow (same "bad input" signal for
+    // "not hex" and "not ASCII").
+    let bytes: Result<Vec<u8>, ParseError> = s
+        .as_bytes()
+        .chunks_exact(HEX_CHARS_PER_BYTE)
+        .map(|pair| {
+            let hi = char::from(pair[0]).to_digit(16).ok_or(ParseError)?;
+            let lo = char::from(pair[1]).to_digit(16).ok_or(ParseError)?;
+            // `to_digit(16)` only returns 0..=15, so `hi << 4 | lo`
+            // fits in u8. The `as u8` is lossless here.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "to_digit(16) bounds hi and lo to 0..=15"
+            )]
+            Ok(((hi << 4) | lo) as u8)
+        })
         .collect();
-    let bytes = bytes.map_err(|_| ParseError)?;
+    let bytes = bytes?;
     // Upper bound matches the wire-format `MAX_AUTH_KEY_LEN`. A
     // CLI-supplied key beyond that would fail at
     // `AuthKeyMessage::to_bytes` anyway; reject here so the
@@ -765,6 +791,22 @@ mod tests {
         // 'z' isn't a valid hex digit.
         let args = ["--auth-key", "zzzzzzzz"];
         assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_args_auth_key_rejects_non_ascii() {
+        // **Regression test for `CodeRabbit` round 1 on PR #405.**
+        // Non-ASCII input must fail cleanly instead of panicking
+        // on UTF-8 byte-boundary slicing. 4-byte emojis like
+        // "💩" pass `len().is_multiple_of(2)` (`len() == 4`), so
+        // the early-exit length check alone wouldn't catch it;
+        // the `is_ascii()` guard in `parse_auth_key_hex` does.
+        let args = ["--auth-key", "💩"];
+        assert!(parse_args(&args).is_err());
+
+        // Mix of ASCII hex + non-ASCII also rejected.
+        let mixed_args = ["--auth-key", "ab💩cd"];
+        assert!(parse_args(&mixed_args).is_err());
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/error.rs
+++ b/crates/sdr-server-rtltcp/src/error.rs
@@ -28,4 +28,17 @@ pub enum ServerError {
     /// dongles.
     #[error("device index {requested} out of range (found {available})")]
     BadDeviceIndex { requested: u32, available: u32 },
+
+    /// `ServerConfig.auth_key` carries an out-of-range length —
+    /// either zero (which would silently accept any client, per
+    /// `validate_auth_key`'s empty-reject contract) or more than
+    /// [`crate::extension::MAX_AUTH_KEY_LEN`] (which would fail
+    /// at `AuthKeyMessage::to_bytes` every handshake, leaving
+    /// the server started but unusable). `Server::start`
+    /// rejects these up-front so the operator sees one clear
+    /// config error instead of every client failing at
+    /// handshake time. Per `CodeRabbit` round 2 on PR #405.
+    /// #394.
+    #[error("auth_key length {len} is out of range (must be 1..={max})")]
+    InvalidAuthKeyLength { len: usize, max: usize },
 }

--- a/crates/sdr-server-rtltcp/src/extension.rs
+++ b/crates/sdr-server-rtltcp/src/extension.rs
@@ -178,14 +178,23 @@ pub struct ClientHello {
 }
 
 /// Flag bit indicating the client wants to kick the current
-/// controller if the slot is occupied. Reserved for #393.
+/// controller if the slot is occupied. #393.
 pub const FLAG_REQUEST_TAKEOVER: u8 = 1 << 0;
+
+/// Flag bit indicating the client is sending an
+/// [`AuthKeyMessage`] immediately after the hello. Servers that
+/// require auth (#394) parse the key from the hello stream
+/// without waiting for an `AuthRequired` round-trip. Clients
+/// that don't have an auth key leave this clear — the server
+/// will reply with `status=AuthRequired` (for auth-enabled
+/// servers) and the client follows up with the key then.
+pub const FLAG_HAS_AUTH: u8 = 1 << 1;
 
 /// Full [`ClientHello::flags`] value for the "no flags set" case —
 /// the #307 common path, where the client isn't requesting a
-/// takeover and has no other bits to assert. Named constant so
-/// callers don't litter the codebase with bare `0` literals that
-/// silently mean "don't set any flag bit".
+/// takeover, not carrying auth, and has no other bits to assert.
+/// Named constant so callers don't litter the codebase with bare
+/// `0` literals that silently mean "don't set any flag bit".
 pub const CLIENT_HELLO_FLAGS_NONE: u8 = 0;
 
 impl ClientHello {
@@ -235,7 +244,159 @@ impl ClientHello {
     pub fn request_takeover(self) -> bool {
         self.flags & FLAG_REQUEST_TAKEOVER != 0
     }
+
+    /// Convenience: does the caller's flags byte announce that an
+    /// [`AuthKeyMessage`] is being sent immediately after this
+    /// hello? #394.
+    #[must_use]
+    pub fn has_auth(self) -> bool {
+        self.flags & FLAG_HAS_AUTH != 0
+    }
 }
+
+/// 4-byte magic identifying an [`AuthKeyMessage`] on the wire.
+/// Chosen to be distinct from [`EXTENSION_MAGIC`] (`RTLX`) so the
+/// server can unambiguously tell whether an incoming message is
+/// a hello follow-up or stray protocol garbage. First byte is
+/// `'R' = 0x52` (same as RTLX) — doesn't matter here since
+/// auth-key messages are only read AFTER a hello, never on a
+/// fresh connection. #394.
+pub const AUTH_KEY_MAGIC: [u8; 4] = *b"RTKA";
+
+/// Maximum length in bytes of an auth key. The issue spec caps it
+/// at 256 and the wire format uses `u16` BE for the length, so
+/// values beyond this would overflow the signaled size. 32-byte
+/// URL-safe base64 (the server-generated default) encodes to
+/// ~43 chars; 256 leaves plenty of headroom for user-chosen
+/// phrases, while staying small enough that the message fits in
+/// one TCP segment on every path MTU we care about. #394.
+pub const MAX_AUTH_KEY_LEN: usize = 256;
+
+/// Serialized size of the fixed [`AuthKeyMessage`] header prefix
+/// (magic + length field). The total on-wire size is this plus
+/// the key bytes themselves. Named so `sniff_auth_key` can
+/// `read_exact(AUTH_KEY_HEADER_LEN)` without a magic number.
+pub const AUTH_KEY_HEADER_LEN: usize = 4 + 2;
+
+/// Maximum total on-wire size of an [`AuthKeyMessage`] — header
+/// plus a [`MAX_AUTH_KEY_LEN`]-byte key. Buffer size hint for
+/// server-side reads; values beyond this are a protocol error.
+pub const MAX_AUTH_KEY_MESSAGE_LEN: usize = AUTH_KEY_HEADER_LEN + MAX_AUTH_KEY_LEN;
+
+/// Client → server auth-key follow-up. Sent immediately after a
+/// [`ClientHello`] that set the [`FLAG_HAS_AUTH`] bit, or in
+/// response to a [`Status::AuthRequired`] server message. The
+/// server validates the key using a constant-time compare and
+/// either proceeds to the normal role-admission flow (on match)
+/// or closes the connection with [`Status::AuthFailed`] (on
+/// mismatch). #394.
+///
+/// # Wire layout
+///
+/// ```text
+/// off  size    field
+/// 0    4       magic = "RTKA"
+/// 4    2       key_len (u16 BE)  — in range 1..=MAX_AUTH_KEY_LEN
+/// 6    key_len key bytes         — raw, no encoding
+/// ```
+///
+/// Length is big-endian for consistency with
+/// `sdr_server_rtltcp::protocol` (upstream `rtl_tcp.c` uses BE
+/// for the 4-byte param in its 5-byte command frames).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthKeyMessage {
+    /// Raw key bytes. Length is signaled by the on-wire `key_len`
+    /// field; the crate enforces `1..=MAX_AUTH_KEY_LEN` at parse
+    /// time. Not a `String` because auth keys aren't required to
+    /// be valid UTF-8 — the canonical server-generated form is
+    /// URL-safe base64, but user-supplied keys might be hex,
+    /// ASCII passphrases, or arbitrary bytes.
+    pub key: Vec<u8>,
+}
+
+impl AuthKeyMessage {
+    /// Serialize to its `6 + key.len()` byte wire representation.
+    /// Returns `None` when `key.is_empty()` (auth keys must carry
+    /// at least one byte; zero-length keys would be trivially
+    /// matched by the empty-string-matches-empty-string case and
+    /// defeat the auth gate) or `key.len() > MAX_AUTH_KEY_LEN`.
+    #[must_use]
+    pub fn to_bytes(&self) -> Option<Vec<u8>> {
+        if self.key.is_empty() || self.key.len() > MAX_AUTH_KEY_LEN {
+            return None;
+        }
+        let mut out = Vec::with_capacity(AUTH_KEY_HEADER_LEN + self.key.len());
+        out.extend_from_slice(&AUTH_KEY_MAGIC);
+        // `self.key.len() <= MAX_AUTH_KEY_LEN (256) < u16::MAX` so
+        // the `as u16` cast is lossless. Guarded by the bounds
+        // check above.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "key length bounded by MAX_AUTH_KEY_LEN (256)"
+        )]
+        let len = self.key.len() as u16;
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(&self.key);
+        Some(out)
+    }
+
+    /// Parse from a byte slice. Returns `None` on:
+    /// - slice shorter than `AUTH_KEY_HEADER_LEN`
+    /// - bad magic (not `"RTKA"`)
+    /// - `key_len == 0` (empty keys rejected per `to_bytes`)
+    /// - `key_len > MAX_AUTH_KEY_LEN`
+    /// - slice length doesn't match `header + key_len`
+    ///
+    /// The caller is responsible for having read exactly the
+    /// right number of bytes — servers should first `read_exact`
+    /// the 6-byte header to decode `key_len`, then `read_exact`
+    /// that many more bytes.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < AUTH_KEY_HEADER_LEN {
+            return None;
+        }
+        if bytes[..AUTH_KEY_MAGIC.len()] != AUTH_KEY_MAGIC {
+            return None;
+        }
+        let key_len = u16::from_be_bytes([bytes[4], bytes[5]]) as usize;
+        if key_len == 0 || key_len > MAX_AUTH_KEY_LEN {
+            return None;
+        }
+        if bytes.len() != AUTH_KEY_HEADER_LEN + key_len {
+            return None;
+        }
+        Some(Self {
+            key: bytes[AUTH_KEY_HEADER_LEN..].to_vec(),
+        })
+    }
+
+    /// Decode just the `key_len` field from the header bytes.
+    /// Returns `None` on bad magic or out-of-range length.
+    /// Servers call this after `read_exact(6)` to know how many
+    /// more bytes to read before calling [`Self::from_bytes`] on
+    /// the full buffer.
+    #[must_use]
+    pub fn parse_header_len(header: &[u8; AUTH_KEY_HEADER_LEN]) -> Option<u16> {
+        if header[..AUTH_KEY_MAGIC.len()] != AUTH_KEY_MAGIC {
+            return None;
+        }
+        let len = u16::from_be_bytes([header[4], header[5]]);
+        let len_usize = len as usize;
+        if len_usize == 0 || len_usize > MAX_AUTH_KEY_LEN {
+            return None;
+        }
+        Some(len)
+    }
+}
+
+/// How long the server waits for an [`AuthKeyMessage`] follow-up
+/// after sending [`Status::AuthRequired`] to a client that didn't
+/// set [`FLAG_HAS_AUTH`] on its hello. 5 seconds matches the
+/// issue spec and is long enough that a UI-driven "paste the
+/// key" flow can land within the window, but short enough that a
+/// silent-client DOS can't wedge the accept thread. #394.
+pub const AUTH_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Server → client extension response — 8 bytes on the wire,
 /// fixed layout. Written immediately after the legacy
@@ -479,5 +640,161 @@ mod tests {
         // Documented opcodes are 0x01..=0x0E (per rtl_tcp.c); our
         // magic's first byte sits well above that range.
         assert!(EXTENSION_MAGIC[0] > 0x0E);
+    }
+
+    // ============================================================
+    // AuthKeyMessage (#394) wire-format tests.
+    // ============================================================
+
+    #[test]
+    fn auth_key_message_round_trip() {
+        // Minimum viable auth key — a single byte. Exercises the
+        // length-field encoding + the header + key concatenation.
+        let msg = AuthKeyMessage { key: vec![0x42] };
+        let bytes = msg.to_bytes().expect("single-byte key serializes");
+        assert_eq!(bytes.len(), AUTH_KEY_HEADER_LEN + 1);
+        assert_eq!(&bytes[..4], &AUTH_KEY_MAGIC);
+        assert_eq!(&bytes[4..6], &1u16.to_be_bytes());
+        assert_eq!(bytes[6], 0x42);
+        assert_eq!(AuthKeyMessage::from_bytes(&bytes), Some(msg));
+    }
+
+    #[test]
+    fn auth_key_message_round_trip_full_length() {
+        // 256-byte key (the max) — pins that the u16 length field
+        // encodes correctly at the upper bound and `from_bytes`
+        // accepts it. Regression guard against an off-by-one that
+        // rejects exactly-MAX keys.
+        let key: Vec<u8> = (0..MAX_AUTH_KEY_LEN).map(|i| i as u8).collect();
+        let msg = AuthKeyMessage { key: key.clone() };
+        let bytes = msg.to_bytes().expect("max-length key serializes");
+        assert_eq!(bytes.len(), AUTH_KEY_HEADER_LEN + MAX_AUTH_KEY_LEN);
+        let len_field = u16::from_be_bytes([bytes[4], bytes[5]]);
+        assert_eq!(len_field as usize, MAX_AUTH_KEY_LEN);
+        assert_eq!(AuthKeyMessage::from_bytes(&bytes), Some(msg));
+    }
+
+    #[test]
+    fn auth_key_message_empty_key_rejected_on_encode() {
+        // Zero-length key would be trivially matched by an empty
+        // expected key on the server side — defeats the auth gate.
+        // Reject at serialize time.
+        let msg = AuthKeyMessage { key: vec![] };
+        assert!(msg.to_bytes().is_none());
+    }
+
+    #[test]
+    fn auth_key_message_over_max_rejected_on_encode() {
+        // Anything > MAX_AUTH_KEY_LEN can't be expressed in the
+        // u16 length field's valid range (we cap below u16::MAX so
+        // a malicious server can't allocate ~64 KiB per handshake).
+        let msg = AuthKeyMessage {
+            key: vec![0u8; MAX_AUTH_KEY_LEN + 1],
+        };
+        assert!(msg.to_bytes().is_none());
+    }
+
+    #[test]
+    fn auth_key_message_rejects_bad_magic() {
+        let mut bytes = vec![0x00, 0x01, 0x02, 0x03]; // not RTKA
+        bytes.extend_from_slice(&1u16.to_be_bytes());
+        bytes.push(0x42);
+        assert!(AuthKeyMessage::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn auth_key_message_rejects_zero_length() {
+        let mut bytes = AUTH_KEY_MAGIC.to_vec();
+        bytes.extend_from_slice(&0u16.to_be_bytes());
+        // No trailing bytes — slice length matches header but the
+        // length field is 0.
+        assert!(AuthKeyMessage::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn auth_key_message_rejects_length_mismatch() {
+        // Header says 4 bytes but only 2 follow — truncated on
+        // the wire. `from_bytes` requires the full message to
+        // have been read; servers that decode incrementally must
+        // `read_exact(header.key_len)` after parsing the header.
+        let mut bytes = AUTH_KEY_MAGIC.to_vec();
+        bytes.extend_from_slice(&4u16.to_be_bytes());
+        bytes.extend_from_slice(&[0x01, 0x02]);
+        assert!(AuthKeyMessage::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn auth_key_message_parse_header_len_decodes_valid_range() {
+        let mut header = [0u8; AUTH_KEY_HEADER_LEN];
+        header[..4].copy_from_slice(&AUTH_KEY_MAGIC);
+        header[4..6].copy_from_slice(&42u16.to_be_bytes());
+        assert_eq!(AuthKeyMessage::parse_header_len(&header), Some(42));
+    }
+
+    #[test]
+    fn auth_key_message_parse_header_len_rejects_zero_and_overlong() {
+        let mut header = [0u8; AUTH_KEY_HEADER_LEN];
+        header[..4].copy_from_slice(&AUTH_KEY_MAGIC);
+        // Zero length.
+        header[4..6].copy_from_slice(&0u16.to_be_bytes());
+        assert!(AuthKeyMessage::parse_header_len(&header).is_none());
+        // Length exceeds MAX.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "test-only overflow synthesis, caller check is the point"
+        )]
+        let overlong = (MAX_AUTH_KEY_LEN + 1) as u16;
+        header[4..6].copy_from_slice(&overlong.to_be_bytes());
+        assert!(AuthKeyMessage::parse_header_len(&header).is_none());
+    }
+
+    #[test]
+    fn client_hello_has_auth_flag_helper() {
+        let with_auth = ClientHello {
+            codec_mask: CodecMask::NONE_ONLY,
+            role: Role::Control,
+            flags: FLAG_HAS_AUTH,
+            version: PROTOCOL_VERSION,
+        };
+        assert!(with_auth.has_auth());
+        assert!(!with_auth.request_takeover());
+
+        // Flags are additive — takeover + auth together.
+        let both = ClientHello {
+            flags: FLAG_HAS_AUTH | FLAG_REQUEST_TAKEOVER,
+            ..with_auth
+        };
+        assert!(both.has_auth());
+        assert!(both.request_takeover());
+
+        let without_auth = ClientHello {
+            flags: 0,
+            ..with_auth
+        };
+        assert!(!without_auth.has_auth());
+    }
+
+    #[test]
+    fn flag_bits_are_distinct() {
+        // Defense-in-depth: if someone ever adds a third flag bit
+        // and accidentally collides with an existing one, this
+        // test trips. Each bit must be uniquely assigned.
+        assert_eq!(FLAG_REQUEST_TAKEOVER & FLAG_HAS_AUTH, 0);
+        assert_ne!(FLAG_REQUEST_TAKEOVER, 0);
+        assert_ne!(FLAG_HAS_AUTH, 0);
+    }
+
+    #[test]
+    fn auth_key_magic_first_byte_distinct_from_legacy_opcodes() {
+        // `RTKA`'s first byte is 'R' (0x52), same as
+        // EXTENSION_MAGIC. That's fine here because an
+        // AuthKeyMessage is only ever read AFTER a hello, never
+        // as the first bytes on a fresh connection, so there's
+        // no legacy-opcode collision path. Documenting this as
+        // a test so a future refactor that re-reads AUTH_KEY_MAGIC
+        // at connection-start would trip the >0x0E assertion
+        // and the reviewer knows to re-examine the flow.
+        assert_eq!(AUTH_KEY_MAGIC[0], b'R');
+        assert!(AUTH_KEY_MAGIC[0] > 0x0E);
     }
 }

--- a/crates/sdr-server-rtltcp/src/extension.rs
+++ b/crates/sdr-server-rtltcp/src/extension.rs
@@ -73,11 +73,56 @@ pub const CLIENT_HELLO_LEN: usize = 8;
 /// Serialized size of [`ServerExtension`] on the wire.
 pub const SERVER_EXTENSION_LEN: usize = 8;
 
-/// Current protocol schema version for both hello and response.
-/// Bumped only on breaking layout changes — adding codecs or
-/// status codes is additive and doesn't require a version bump
-/// because the over-the-wire bytes keep their positions.
-pub const PROTOCOL_VERSION: u8 = 1;
+/// Protocol schema version **1** — the original (#307) shape.
+/// Callers that only opt into compression or role (#392) / takeover
+/// (#393) emit this version: the features are additive within the
+/// same 8-byte hello layout and pre-auth servers handle them
+/// without knowing about `FLAG_HAS_AUTH` or the
+/// `AuthKeyMessage` follow-up.
+pub const PROTOCOL_VERSION_V1: u8 = 1;
+
+/// Protocol schema version **2** — introduced in #394 for
+/// pre-shared-key auth. Clients that set [`FLAG_HAS_AUTH`] MUST
+/// emit this version so pre-v2 servers reject the hello cleanly
+/// at parse time rather than accepting it and then reading the
+/// queued `AuthKeyMessage` bytes as garbage legacy commands. The
+/// wire layout is byte-for-byte identical to v1; the version
+/// field is the gate, not a different shape. Per `CodeRabbit`
+/// round 1 on PR #405.
+pub const PROTOCOL_VERSION_V2: u8 = 2;
+
+/// Newest protocol schema version this crate emits. Clients that
+/// need the latest features (auth) write this. Clients that don't
+/// — compression-only, takeover-only, or plain — write
+/// [`PROTOCOL_VERSION_V1`] to stay backward-compatible with
+/// older servers. Bumping this is a breaking wire change, so it
+/// happens at well-known sub-issue boundaries.
+pub const PROTOCOL_VERSION: u8 = PROTOCOL_VERSION_V2;
+
+/// Versions this crate accepts on parse paths
+/// ([`ClientHello::from_bytes`], [`ServerExtension::from_bytes`]).
+/// Widens as new versions are introduced so old peers continue to
+/// interoperate with new peers for the feature subset they share.
+/// A v1 client talking to a v2 server sends a v1 hello, server
+/// accepts (this array includes v1), server echoes v1 on the
+/// response. Per `CodeRabbit` round 1 on PR #405.
+pub const SUPPORTED_VERSIONS: &[u8] = &[PROTOCOL_VERSION_V1, PROTOCOL_VERSION_V2];
+
+/// Pick the minimum-viable protocol version for a hello that
+/// carries the given flags. Clients use this helper so they only
+/// bump the version when a feature actually requires it —
+/// compression-only / takeover-only hellos stay v1 (backward-
+/// compat with pre-#394 servers); auth-bearing hellos go v2
+/// (pre-#394 servers reject cleanly at parse time). Per
+/// `CodeRabbit` round 1 on PR #405.
+#[must_use]
+pub fn required_protocol_version(flags: u8) -> u8 {
+    if flags & FLAG_HAS_AUTH != 0 {
+        PROTOCOL_VERSION_V2
+    } else {
+        PROTOCOL_VERSION_V1
+    }
+}
 
 /// Role a client is requesting (or that the server granted).
 /// Reserved values — #307 only ever uses [`Self::Control`]; #392
@@ -211,23 +256,29 @@ impl ClientHello {
     }
 
     /// Parse from its 8-byte wire representation. Returns `None`
-    /// if the magic doesn't match, the schema version doesn't
-    /// match [`PROTOCOL_VERSION`], or the role byte is unknown.
+    /// if the magic doesn't match, the schema version isn't in
+    /// [`SUPPORTED_VERSIONS`], or the role byte is unknown.
     /// Callers surface `None` as a protocol error and drop the
     /// client — letting a peer built for a future wire layout
     /// through would cause silent mis-negotiation rather than a
-    /// clean version break. Per CodeRabbit round 3 on PR #399.
+    /// clean version break.
+    ///
+    /// Version gate widened from the #399-era strict `==
+    /// PROTOCOL_VERSION` check to accept any member of
+    /// `SUPPORTED_VERSIONS`. Ensures pre-#394 clients emitting
+    /// v1 hellos interoperate with this crate's v2-era servers:
+    /// v1 is still a first-class parse result, only the wire
+    /// layout stayed identical and the flag byte's
+    /// `FLAG_HAS_AUTH` is only meaningful when `version ==
+    /// PROTOCOL_VERSION_V2`. Per `CodeRabbit` round 3 on PR #399
+    /// (initial strict gate) + round 1 on PR #405 (widen for
+    /// multi-version support).
     #[must_use]
     pub fn from_bytes(bytes: &[u8; CLIENT_HELLO_LEN]) -> Option<Self> {
         if bytes[..EXTENSION_MAGIC.len()] != EXTENSION_MAGIC {
             return None;
         }
-        // Version gate is strict: peers built against a newer
-        // layout must be rejected, not silently parsed as v1.
-        // If we ever bump PROTOCOL_VERSION we'll add a wider
-        // accept-set here (e.g., `matches!(bytes[7], 1 | 2)`)
-        // once both sides of the upgrade have shipped.
-        if bytes[7] != PROTOCOL_VERSION {
+        if !SUPPORTED_VERSIONS.contains(&bytes[7]) {
             return None;
         }
         let role = Role::from_wire(bytes[5])?;
@@ -434,21 +485,20 @@ impl ServerExtension {
     }
 
     /// Parse from its 8-byte wire representation. Returns `None`
-    /// when the magic doesn't match, the schema version doesn't
-    /// match [`PROTOCOL_VERSION`], or any enum-typed byte is
-    /// unknown. Callers surface `None` as a protocol error and
-    /// drop the connection — a peer built for a future wire
-    /// layout should trigger a clean version break rather than
-    /// silent mis-negotiation as v1. Per CodeRabbit round 3 on
-    /// PR #399.
+    /// when the magic doesn't match, the schema version isn't in
+    /// [`SUPPORTED_VERSIONS`], or any enum-typed byte is unknown.
+    /// Callers surface `None` as a protocol error and drop the
+    /// connection — a peer built for a future wire layout should
+    /// trigger a clean version break rather than silent mis-
+    /// negotiation. Per `CodeRabbit` round 3 on PR #399 (initial
+    /// strict gate) + round 1 on PR #405 (widen for
+    /// multi-version support).
     #[must_use]
     pub fn from_bytes(bytes: &[u8; SERVER_EXTENSION_LEN]) -> Option<Self> {
         if bytes[..EXTENSION_MAGIC.len()] != EXTENSION_MAGIC {
             return None;
         }
-        // Strict version gate — see the matching comment in
-        // `ClientHello::from_bytes`.
-        if bytes[7] != PROTOCOL_VERSION {
+        if !SUPPORTED_VERSIONS.contains(&bytes[7]) {
             return None;
         }
         let codec = Codec::from_wire(bytes[4])?;
@@ -509,18 +559,81 @@ mod tests {
 
     #[test]
     fn client_hello_rejects_unknown_version() {
-        // Regression test for CodeRabbit round 3 on PR #399: a
-        // future peer that bumps the wire layout must be rejected
-        // so we don't silently mis-negotiate it as v1. Otherwise
-        // `PROTOCOL_VERSION` is dead metadata and a clean protocol
-        // break turns into a subtle runtime bug.
+        // Regression test for `CodeRabbit` round 3 on PR #399:
+        // a future peer that bumps the wire layout must be
+        // rejected so we don't silently mis-negotiate it as v1.
+        // Updated for PR #405: supported set is now {v1, v2}, so
+        // the first rejected value is v3. Version byte zero is
+        // also rejected (guards against uninitialized struct
+        // slipping through).
         let mut bytes = [0u8; CLIENT_HELLO_LEN];
         bytes[..4].copy_from_slice(&EXTENSION_MAGIC);
         bytes[4] = CodecMask::NONE_ONLY.to_wire();
         bytes[5] = Role::Control.to_wire();
         bytes[6] = 0;
-        bytes[7] = PROTOCOL_VERSION.wrapping_add(1);
+        // v3 is not in SUPPORTED_VERSIONS → rejected.
+        bytes[7] = PROTOCOL_VERSION_V2 + 1;
         assert!(ClientHello::from_bytes(&bytes).is_none());
+        // v0 is the uninitialized-struct sentinel → rejected.
+        bytes[7] = 0;
+        assert!(ClientHello::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn client_hello_accepts_both_supported_versions() {
+        // **Regression test for `CodeRabbit` round 1 on PR #405.**
+        // The version gate widened from strict `== PROTOCOL_VERSION`
+        // to `SUPPORTED_VERSIONS.contains(..)` so pre-#394 v1
+        // clients can still hand a hello to a post-#394 v2 server
+        // without the server rejecting them. Pins both members
+        // of the supported set.
+        let base = ClientHello {
+            codec_mask: CodecMask::NONE_ONLY,
+            role: Role::Control,
+            flags: CLIENT_HELLO_FLAGS_NONE,
+            version: PROTOCOL_VERSION_V1,
+        };
+        let v1_bytes = base.to_bytes();
+        assert_eq!(
+            ClientHello::from_bytes(&v1_bytes).map(|h| h.version),
+            Some(PROTOCOL_VERSION_V1),
+            "v1 hello must be accepted for pre-#394 client back-compat"
+        );
+
+        let v2 = ClientHello {
+            version: PROTOCOL_VERSION_V2,
+            ..base
+        };
+        let v2_bytes = v2.to_bytes();
+        assert_eq!(
+            ClientHello::from_bytes(&v2_bytes).map(|h| h.version),
+            Some(PROTOCOL_VERSION_V2),
+            "v2 hello must be accepted for #394-aware clients"
+        );
+    }
+
+    #[test]
+    fn required_protocol_version_picks_minimum_viable() {
+        // Helper contract: only bump to v2 when the hello
+        // carries auth. Plain / compression / takeover hellos
+        // stay v1 so pre-#394 servers continue to accept them.
+        assert_eq!(
+            required_protocol_version(CLIENT_HELLO_FLAGS_NONE),
+            PROTOCOL_VERSION_V1
+        );
+        assert_eq!(
+            required_protocol_version(FLAG_REQUEST_TAKEOVER),
+            PROTOCOL_VERSION_V1
+        );
+        assert_eq!(
+            required_protocol_version(FLAG_HAS_AUTH),
+            PROTOCOL_VERSION_V2
+        );
+        assert_eq!(
+            required_protocol_version(FLAG_HAS_AUTH | FLAG_REQUEST_TAKEOVER),
+            PROTOCOL_VERSION_V2,
+            "takeover + auth together still needs v2 (any auth bit forces v2)"
+        );
     }
 
     #[test]
@@ -575,7 +688,8 @@ mod tests {
         bytes[4] = Codec::None.to_wire();
         bytes[5] = Role::Control.to_wire();
         bytes[6] = Status::Ok.to_wire();
-        bytes[7] = PROTOCOL_VERSION.wrapping_add(1);
+        // v3 is outside SUPPORTED_VERSIONS → rejected.
+        bytes[7] = PROTOCOL_VERSION_V2 + 1;
         assert!(ServerExtension::from_bytes(&bytes).is_none());
     }
 

--- a/crates/sdr-server-rtltcp/src/lib.rs
+++ b/crates/sdr-server-rtltcp/src/lib.rs
@@ -33,6 +33,7 @@
 //! #391 as the first step of the #390 multi-client epic; the data
 //! path flip that consumes it ships in the next commit.
 
+pub mod auth;
 pub mod broadcaster;
 pub mod codec;
 pub mod dispatch;

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -820,25 +820,37 @@ fn spawn_client_workers(
     //     Vanilla has no wire field to carry a key, so they can't
     //     participate. Same signal as "server not there" from
     //     the legacy client's POV.
-    //   - Auth required + RTLX + has_auth: read the follow-up
-    //     `AuthKeyMessage` with a bounded timeout, constant-time
-    //     compare against the configured key.
+    //   - Auth required + RTLX + has_auth (eager): read the
+    //     follow-up `AuthKeyMessage` with a bounded timeout,
+    //     constant-time compare against the configured key.
     //     - Match: continue to role admission.
     //     - Mismatch / malformed / timeout / eof: send dongle_info_t
     //       + `ServerExtension(status=AuthFailed)` and close.
-    //   - Auth required + RTLX + !has_auth: send dongle_info_t +
-    //     `ServerExtension(status=AuthRequired)` and close. Client
-    //     must reconnect with `has_auth=true` and the key to
-    //     succeed. (Simpler than an in-connection retry state
-    //     machine; costs one extra TCP handshake per never-
-    //     authed-before client, which is a one-time UX cost per
-    //     saved-profile.)
+    //   - Auth required + RTLX + !has_auth (lazy, per #394 spec):
+    //     send dongle_info_t + `ServerExtension(status=AuthRequired)`
+    //     KEEPING THE SOCKET OPEN, then wait up to
+    //     `AUTH_REPLY_TIMEOUT` for the client to deliver an
+    //     `AuthKeyMessage` on the same connection. On match,
+    //     fall through to role admission; the granted path
+    //     then resends the ServerExtension with the actual role
+    //     status WITHOUT re-emitting dongle_info_t (the client
+    //     would misread it as a second handshake). On mismatch
+    //     / timeout / parse error, send a follow-up
+    //     `ServerExtension(status=AuthFailed)` (extension-only,
+    //     no second dongle_info_t) and close. Per `CodeRabbit`
+    //     round 3 on PR #405.
     //
     // If `has_auth` is set but auth isn't configured, we STILL
     // read the AuthKeyMessage from the stream to keep the
     // post-hello byte position in sync (the client doesn't know
     // our config and sent the key based on its own); we just
     // discard it without validation.
+    //
+    // `dongle_info_sent` threads through the rest of this function
+    // so the lazy path's initial dongle_info_t emission is visible
+    // to role admission (which must skip the duplicate send in
+    // both the granted and denied follow-up branches).
+    let mut dongle_info_sent = false;
     if hello_seen && has_auth {
         // Read the AuthKeyMessage follow-up regardless of whether
         // auth is required — need to consume the bytes either way
@@ -889,17 +901,63 @@ fn spawn_client_workers(
                 return;
             }
         }
-    } else if auth_key.is_some() {
+    } else if let Some(expected) = auth_key.as_deref() {
         // Client didn't set has_auth but the server requires auth.
         if hello_seen {
-            // RTLX client: send the AuthRequired denial so the
-            // client's UI can surface "server requires key" and
-            // prompt for one.
+            // RTLX client — lazy path per #394 spec. Send
+            // dongle_info_t + `ServerExtension(AuthRequired)`
+            // and keep the socket open so a compliant client
+            // can reply with `AuthKeyMessage` on the same
+            // connection. The peer has
+            // `AUTH_REPLY_TIMEOUT` to deliver the key;
+            // `sniff_auth_key_message` enforces the bound with
+            // an absolute deadline. Per `CodeRabbit` round 3
+            // on PR #405.
             tracing::info!(
                 %peer,
-                "rtl_tcp auth required but client didn't send key — denying with AuthRequired"
+                "rtl_tcp auth required but client didn't send key — sending AuthRequired (lazy path)"
             );
             send_denied_response(&stream, peer, &device, Status::AuthRequired, hello_version);
+            dongle_info_sent = true;
+
+            let auth_ok = match sniff_auth_key_message(&stream) {
+                Ok(msg) => {
+                    if crate::auth::validate_auth_key(&msg.key, expected) {
+                        tracing::info!(
+                            %peer,
+                            "rtl_tcp lazy auth key validated"
+                        );
+                        true
+                    } else {
+                        tracing::info!(
+                            %peer,
+                            "rtl_tcp lazy auth key mismatch — denying"
+                        );
+                        false
+                    }
+                }
+                Err(e) => {
+                    tracing::info!(
+                        %peer,
+                        %e,
+                        "rtl_tcp lazy auth follow-up unreadable — denying"
+                    );
+                    false
+                }
+            };
+            if !auth_ok {
+                // dongle_info_t already on the wire — send only
+                // the 8-byte `ServerExtension(AuthFailed)` so
+                // the client doesn't misread a duplicate header
+                // as a second handshake.
+                send_extension_only(&stream, peer, Status::AuthFailed, hello_version);
+                return;
+            }
+            // Match → fall through to role admission. The granted
+            // path below observes `dongle_info_sent = true` and
+            // skips the duplicate header write; any role-denial
+            // (ControllerBusy / ListenerCapReached) similarly
+            // switches to `send_extension_only`.
         } else {
             // Vanilla client: can't authenticate, so there's
             // nothing meaningful to tell them. Bare TCP FIN.
@@ -907,8 +965,8 @@ fn spawn_client_workers(
                 %peer,
                 "rtl_tcp vanilla client denied — auth required"
             );
+            return;
         }
-        return;
     }
 
     // Allocate id + build slot with the requested role + channel.
@@ -956,14 +1014,23 @@ fn spawn_client_workers(
             // signal for their "connection refused" UX and avoids
             // handing them a dongle_info_t they'd interpret as
             // admission.
+            //
+            // If the lazy auth path already emitted dongle_info_t
+            // (#394 round 3 on PR #405), send only the 8-byte
+            // ServerExtension follow-up — a duplicate header
+            // would desync the client's parser.
             if hello_seen {
-                send_denied_response(
-                    &stream,
-                    peer,
-                    &device,
-                    Status::ControllerBusy,
-                    hello_version,
-                );
+                if dongle_info_sent {
+                    send_extension_only(&stream, peer, Status::ControllerBusy, hello_version);
+                } else {
+                    send_denied_response(
+                        &stream,
+                        peer,
+                        &device,
+                        Status::ControllerBusy,
+                        hello_version,
+                    );
+                }
             }
             return;
         }
@@ -985,13 +1052,17 @@ fn spawn_client_workers(
                 "vanilla clients should never land in ListenerCapReached"
             );
             if hello_seen {
-                send_denied_response(
-                    &stream,
-                    peer,
-                    &device,
-                    Status::ListenerCapReached,
-                    hello_version,
-                );
+                if dongle_info_sent {
+                    send_extension_only(&stream, peer, Status::ListenerCapReached, hello_version);
+                } else {
+                    send_denied_response(
+                        &stream,
+                        peer,
+                        &device,
+                        Status::ListenerCapReached,
+                        hello_version,
+                    );
+                }
             }
             return;
         }
@@ -1036,21 +1107,29 @@ fn spawn_client_workers(
     // Send the 12-byte dongle_info_t header (rtl_tcp.c:576-594).
     // Emitted for BOTH granted RTLX and granted vanilla — it's the
     // first thing any rtl_tcp client expects.
-    let header = {
-        let Ok(dev) = device.lock() else {
-            tracing::error!(%peer, "device mutex poisoned, aborting client");
+    //
+    // Lazy-auth (#394) skips this: the header was already emitted
+    // alongside the initial `ServerExtension(AuthRequired)`
+    // challenge, and writing it again would make the client
+    // mis-parse the second dongle_info_t as a second handshake.
+    // Per `CodeRabbit` round 3 on PR #405.
+    if !dongle_info_sent {
+        let header = {
+            let Ok(dev) = device.lock() else {
+                tracing::error!(%peer, "device mutex poisoned, aborting client");
+                registry.unwind_admission(&slot);
+                return;
+            };
+            DongleInfo {
+                tuner: TunerTypeCode::from(dev.tuner_type()),
+                gain_count: dev.tuner_gains().len() as u32,
+            }
+        };
+        if let Err(e) = writer.write_all(&header.to_bytes()) {
+            tracing::warn!(%peer, %e, "failed to send dongle_info_t — client gone");
             registry.unwind_admission(&slot);
             return;
-        };
-        DongleInfo {
-            tuner: TunerTypeCode::from(dev.tuner_type()),
-            gain_count: dev.tuner_gains().len() as u32,
         }
-    };
-    if let Err(e) = writer.write_all(&header.to_bytes()) {
-        tracing::warn!(%peer, %e, "failed to send dongle_info_t — client gone");
-        registry.unwind_admission(&slot);
-        return;
     }
 
     // RTLX clients additionally get the ServerExtension(granted)
@@ -1236,6 +1315,57 @@ fn send_denied_response(
             %peer,
             ?status,
             "failed to send denial ServerExtension — client already gone"
+        );
+    }
+}
+
+/// Emit a follow-up `ServerExtension` (8 bytes) to an RTLX client
+/// that has already received `dongle_info_t` on this connection —
+/// i.e., the lazy #394 auth path sent `dongle_info_t +
+/// ServerExtension(AuthRequired)` as its challenge, and the
+/// outcome of the auth reply (and any downstream role-admission
+/// denial) must now be communicated WITHOUT re-emitting the
+/// header. Writing dongle_info_t twice would make the client's
+/// magic-peek misfire on the second handshake.
+///
+/// Used for `Status::AuthFailed` after a bad / missing lazy auth
+/// reply, and for role-admission denials
+/// (`Status::ControllerBusy`, `Status::ListenerCapReached`)
+/// that land AFTER the lazy path has already emitted
+/// `dongle_info_t`. Write failures downgrade to debug-level
+/// tracing because a refused-handshake peer often tears down the
+/// socket before our follow-up lands — noisy warn! would bury
+/// real signal. Per `CodeRabbit` round 3 on PR #405. #394.
+fn send_extension_only(stream: &TcpStream, peer: SocketAddr, status: Status, hello_version: u8) {
+    let mut writer = match stream.try_clone() {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(
+                %peer,
+                %e,
+                "failed to clone stream for follow-up extension — closing without reply"
+            );
+            return;
+        }
+    };
+    let ext = ServerExtension {
+        // Neutral defaults — the client never proceeds to the IQ
+        // stream on a denial, and the follow-up is an
+        // informational status, not a codec negotiation.
+        codec: Codec::None,
+        granted_role: None,
+        status,
+        // Echo the client's hello version so v1 clients can
+        // parse this follow-up without tripping their strict
+        // version gate. Matches `send_denied_response`'s
+        // version-echo contract.
+        version: hello_version,
+    };
+    if writer.write_all(&ext.to_bytes()).is_err() {
+        tracing::debug!(
+            %peer,
+            ?status,
+            "failed to send follow-up ServerExtension — client already gone"
         );
     }
 }
@@ -2161,6 +2291,18 @@ mod tests {
         let _ = client_thread.join();
     }
 
+    /// Scheduling slack on top of `AUTH_REPLY_TIMEOUT` when
+    /// asserting that a timeout fired inside the budget. Must be
+    /// tight enough that a regression to per-phase timeouts
+    /// (where total elapsed could approach `2 * AUTH_REPLY_TIMEOUT`
+    /// under the header-then-body flow) trips the assertion, but
+    /// generous enough to absorb realistic OS scheduling jitter
+    /// on a loaded CI runner. 500 ms lands comfortably in that
+    /// window — one `AUTH_REPLY_TIMEOUT` (5 s) plus slack stays
+    /// well under the 2× regression threshold. Per `CodeRabbit`
+    /// round 3 on PR #405.
+    const AUTH_TIMEOUT_SLACK: Duration = Duration::from_millis(500);
+
     #[test]
     fn sniff_auth_key_message_times_out_when_client_silent() {
         // Client connects but never sends. Header read blocks
@@ -2190,11 +2332,74 @@ mod tests {
             ),
             "expected WouldBlock/TimedOut for silent client, got {err:?}"
         );
-        // And it actually respected the timeout budget (within
-        // a generous 2x margin for scheduling jitter).
+        // Tight bound: total elapsed must sit inside ONE
+        // `AUTH_REPLY_TIMEOUT` plus scheduling slack, not the
+        // earlier 2× allowance. The loose 2× bound would have
+        // silently accepted a regression to per-phase timeouts
+        // where the header + body phases each reset the budget.
+        // Per `CodeRabbit` round 3 on PR #405.
         assert!(
-            elapsed <= AUTH_REPLY_TIMEOUT * 2,
-            "silent-client read took {elapsed:?}, exceeded 2× AUTH_REPLY_TIMEOUT ({AUTH_REPLY_TIMEOUT:?})"
+            elapsed <= AUTH_REPLY_TIMEOUT + AUTH_TIMEOUT_SLACK,
+            "silent-client read took {elapsed:?}, exceeded AUTH_REPLY_TIMEOUT ({AUTH_REPLY_TIMEOUT:?}) + slack ({AUTH_TIMEOUT_SLACK:?})"
+        );
+        let _ = keep_tx.send(());
+        drop(server_stream);
+        let _ = client_thread.join();
+    }
+
+    #[test]
+    fn sniff_auth_key_message_times_out_when_body_stalls() {
+        // Regression guard for the absolute-deadline contract.
+        // Client sends a valid header but never follows with the
+        // body bytes — this is the path that the old per-phase
+        // timeout silently accepted: the header read returns
+        // quickly (burns ~0 of the budget), then the body read
+        // gets a fresh `AUTH_REPLY_TIMEOUT` window of its own.
+        // With the absolute-deadline implementation the body
+        // read inherits the remaining budget and trips within
+        // `AUTH_REPLY_TIMEOUT` of entry.
+        //
+        // Paired with the silent-client test: together they pin
+        // the "one shared budget across both reads" contract and
+        // defeat any future revert to per-phase timeouts.
+        // Per `CodeRabbit` round 3 on PR #405.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Valid 6-byte header claiming a 32-byte key body. Server
+        // will consume it fast, then block on the absent body.
+        let key_len: u16 = 32;
+        let mut header = [0u8; AUTH_KEY_HEADER_LEN];
+        header[..4].copy_from_slice(&crate::extension::AUTH_KEY_MAGIC);
+        header[4..6].copy_from_slice(&key_len.to_be_bytes());
+
+        let (keep_tx, keep_rx) = std::sync::mpsc::channel::<()>();
+        let client_thread = thread::spawn(move || {
+            let mut client = TcpStream::connect(addr).unwrap();
+            client.write_all(&header).unwrap();
+            client.flush().unwrap();
+            // Hold the socket open WITHOUT sending the body.
+            // Server should trip its absolute deadline and
+            // return. Release after the server's timeout fires.
+            let _ = keep_rx.recv();
+        });
+
+        let (server_stream, _peer) = listener.accept().unwrap();
+        let start = Instant::now();
+        let err = sniff_auth_key_message(&server_stream).unwrap_err();
+        let elapsed = start.elapsed();
+        assert!(
+            matches!(
+                err.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            ),
+            "expected WouldBlock/TimedOut for stalled body, got {err:?}"
+        );
+        // The decisive assertion: elapsed must be within the
+        // single-budget bound. A regression to per-phase
+        // timeouts would push this toward 2× AUTH_REPLY_TIMEOUT.
+        assert!(
+            elapsed <= AUTH_REPLY_TIMEOUT + AUTH_TIMEOUT_SLACK,
+            "stalled-body read took {elapsed:?}, exceeded AUTH_REPLY_TIMEOUT ({AUTH_REPLY_TIMEOUT:?}) + slack ({AUTH_TIMEOUT_SLACK:?}) — absolute-deadline contract regressed"
         );
         let _ = keep_tx.send(());
         drop(server_stream);

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -562,8 +562,32 @@ impl Server {
         if let Some(h) = self.accept_thread.take() {
             let _ = h.join();
         }
-        for h in self.registry.drain_worker_handles() {
-            let _ = h.join();
+        // Loop-drain: setup threads (post-PR #405 round 4) and
+        // the writer/command threads they spawn share the same
+        // registry bucket. A setup thread that's still inside
+        // `spawn_client_workers` when the FIRST drain runs will
+        // register its `writer_handle` + `command_handle` AFTER
+        // the drain returned — those late handles would never
+        // be joined under a single-pass drain, leaving the
+        // writer/command workers alive with their
+        // `Arc<Mutex<RtlSdrDevice>>` clones past the
+        // `has_stopped()` transition. Keep draining until the
+        // bucket stays empty across a full pass. Termination is
+        // guaranteed: the accept thread was joined first so no
+        // new setup threads can spawn; each live setup thread
+        // has a bounded lifetime (≤ `HELLO_SNIFF_TIMEOUT` +
+        // `AUTH_REPLY_TIMEOUT` ≈ 5.1 s) and registers its
+        // writer/command handles before exiting, so after at
+        // most one round of joins + drains the bucket converges
+        // to empty. Per `CodeRabbit` round 5 on PR #405.
+        loop {
+            let handles = self.registry.drain_worker_handles();
+            if handles.is_empty() {
+                break;
+            }
+            for h in handles {
+                let _ = h.join();
+            }
         }
         if let Some(h) = self.broadcaster_thread.take() {
             let _ = h.join();

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -50,7 +50,8 @@ use crate::codec::{Codec, CodecMask, Encoder};
 use crate::dispatch::dispatch;
 use crate::error::ServerError;
 use crate::extension::{
-    CLIENT_HELLO_LEN, ClientHello, EXTENSION_MAGIC, PROTOCOL_VERSION, Role, ServerExtension, Status,
+    AUTH_KEY_HEADER_LEN, AUTH_REPLY_TIMEOUT, AuthKeyMessage, CLIENT_HELLO_LEN, ClientHello,
+    EXTENSION_MAGIC, PROTOCOL_VERSION, Role, ServerExtension, Status,
 };
 use crate::protocol::{COMMAND_LEN, Command, CommandOp, DongleInfo, TunerTypeCode};
 
@@ -405,6 +406,7 @@ impl Server {
             per_client_depth,
             config.compression,
             config.listener_cap,
+            config.auth_key.clone(),
         ) {
             Ok(h) => h,
             Err(e) => {
@@ -633,6 +635,7 @@ fn spawn_accept_thread(
     per_client_buffer_depth: usize,
     compression: CodecMask,
     listener_cap: usize,
+    auth_key: Option<Vec<u8>>,
 ) -> std::io::Result<JoinHandle<()>> {
     listener.set_nonblocking(true)?;
     thread::Builder::new()
@@ -656,6 +659,7 @@ fn spawn_accept_thread(
                             per_client_buffer_depth,
                             compression,
                             listener_cap,
+                            auth_key.clone(),
                         );
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -710,6 +714,7 @@ fn spawn_client_workers(
     per_client_buffer_depth: usize,
     compression_offer: CodecMask,
     listener_cap: usize,
+    auth_key: Option<Vec<u8>>,
 ) {
     // Extended handshake (#307) — sniff the RTLX hello if the
     // client sent one. The outcome drives both codec negotiation
@@ -731,10 +736,11 @@ fn spawn_client_workers(
     //   - `negotiated_codec` is `None` for vanilla (always
     //     uncompressed); `Some(_)` for RTLX clients — the
     //     intersection of their mask and ours
-    let (hello_seen, requested_role, request_takeover, negotiated_codec) =
+    let (hello_seen, requested_role, request_takeover, has_auth, negotiated_codec) =
         if let Some(hello) = &sniff_outcome {
             let codec = compression_offer.pick(hello.codec_mask);
             let takeover = hello.request_takeover();
+            let has_auth = hello.has_auth();
             tracing::info!(
                 %peer,
                 client_mask = hello.codec_mask.to_wire(),
@@ -742,9 +748,10 @@ fn spawn_client_workers(
                 chosen = %codec,
                 requested_role = ?hello.role,
                 request_takeover = takeover,
+                has_auth,
                 "rtl_tcp extended-handshake negotiated"
             );
-            (true, hello.role, takeover, Some(codec))
+            (true, hello.role, takeover, has_auth, Some(codec))
         } else {
             tracing::debug!(
                 %peer,
@@ -755,9 +762,110 @@ fn spawn_client_workers(
             // "request_takeover = false" — the existing Control
             // client (if any) is protected from vanilla-driven
             // displacement. Takeover is an explicit RTLX action.
-            (false, Role::Control, false, None)
+            // Same logic applies to `has_auth`: vanilla clients
+            // never carry an AuthKeyMessage follow-up, so `false`
+            // here routes the auth gate's vanilla+auth-required
+            // path to a bare TCP FIN (they can't authenticate).
+            (false, Role::Control, false, false, None)
         };
     let codec = negotiated_codec.unwrap_or(Codec::None);
+
+    // Auth gate (#394). Runs BEFORE role admission — an
+    // unauthenticated client shouldn't even be evaluated for role
+    // because the wire response would leak server state (role
+    // grants or cap status) to an attacker probing the slot. The
+    // four outcomes:
+    //
+    //   - No auth required: skip entirely, fall through to role
+    //     admission as-is.
+    //   - Auth required + vanilla client: bare TCP FIN, no bytes.
+    //     Vanilla has no wire field to carry a key, so they can't
+    //     participate. Same signal as "server not there" from
+    //     the legacy client's POV.
+    //   - Auth required + RTLX + has_auth: read the follow-up
+    //     `AuthKeyMessage` with a bounded timeout, constant-time
+    //     compare against the configured key.
+    //     - Match: continue to role admission.
+    //     - Mismatch / malformed / timeout / eof: send dongle_info_t
+    //       + `ServerExtension(status=AuthFailed)` and close.
+    //   - Auth required + RTLX + !has_auth: send dongle_info_t +
+    //     `ServerExtension(status=AuthRequired)` and close. Client
+    //     must reconnect with `has_auth=true` and the key to
+    //     succeed. (Simpler than an in-connection retry state
+    //     machine; costs one extra TCP handshake per never-
+    //     authed-before client, which is a one-time UX cost per
+    //     saved-profile.)
+    //
+    // If `has_auth` is set but auth isn't configured, we STILL
+    // read the AuthKeyMessage from the stream to keep the
+    // post-hello byte position in sync (the client doesn't know
+    // our config and sent the key based on its own); we just
+    // discard it without validation.
+    if hello_seen && has_auth {
+        // Read the AuthKeyMessage follow-up regardless of whether
+        // auth is required — need to consume the bytes either way
+        // so the stream position stays correct.
+        let auth_result = sniff_auth_key_message(&stream);
+        match auth_result {
+            Ok(msg) => {
+                if let Some(expected) = auth_key.as_deref() {
+                    if !crate::auth::validate_auth_key(&msg.key, expected) {
+                        tracing::info!(
+                            %peer,
+                            "rtl_tcp auth key mismatch — denying client"
+                        );
+                        send_denied_response(&stream, peer, &device, Status::AuthFailed);
+                        return;
+                    }
+                    tracing::info!(%peer, "rtl_tcp auth key validated");
+                } else {
+                    // Client sent a key to a server that doesn't
+                    // require one — fine, just ignore it. Keeps
+                    // the wire-protocol compat flexible: clients
+                    // can always send has_auth=true without
+                    // knowing the server's config.
+                    tracing::debug!(
+                        %peer,
+                        "rtl_tcp client sent auth key but server doesn't require one — ignored"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::info!(
+                    %peer,
+                    %e,
+                    "rtl_tcp auth key follow-up unreadable — denying client"
+                );
+                if auth_key.is_some() {
+                    send_denied_response(&stream, peer, &device, Status::AuthFailed);
+                }
+                // If auth wasn't required but the client promised
+                // a follow-up (has_auth=true) and didn't deliver,
+                // the stream position is wrong either way — drop.
+                return;
+            }
+        }
+    } else if auth_key.is_some() {
+        // Client didn't set has_auth but the server requires auth.
+        if hello_seen {
+            // RTLX client: send the AuthRequired denial so the
+            // client's UI can surface "server requires key" and
+            // prompt for one.
+            tracing::info!(
+                %peer,
+                "rtl_tcp auth required but client didn't send key — denying with AuthRequired"
+            );
+            send_denied_response(&stream, peer, &device, Status::AuthRequired);
+        } else {
+            // Vanilla client: can't authenticate, so there's
+            // nothing meaningful to tell them. Bare TCP FIN.
+            tracing::info!(
+                %peer,
+                "rtl_tcp vanilla client denied — auth required"
+            );
+        }
+        return;
+    }
 
     // Allocate id + build slot with the requested role + channel.
     // The slot is not yet registered — `register_with_role` below
@@ -1266,6 +1374,52 @@ const HELLO_SNIFF_TIMEOUT: Duration = Duration::from_millis(100);
 /// Per `CodeRabbit` round 2 on PR #399 (initial fix),
 /// round 3 (doc alignment), and round 5 on PR #402
 /// (partial-prefix handling for fragmented RTLX).
+/// Read + parse an [`AuthKeyMessage`] from `stream` within
+/// [`AUTH_REPLY_TIMEOUT`]. Caller is responsible for having
+/// observed `hello.has_auth() == true` on the preceding hello
+/// — this helper assumes the auth message is the next thing on
+/// the wire. Two-phase read: header (6 bytes) then body
+/// (`key_len` bytes). Both phases gated by
+/// `AUTH_REPLY_TIMEOUT`, so a silent client can't wedge the
+/// accept thread. #394.
+fn sniff_auth_key_message(mut stream: &TcpStream) -> std::io::Result<AuthKeyMessage> {
+    stream.set_read_timeout(Some(AUTH_REPLY_TIMEOUT))?;
+    let mut header = [0u8; AUTH_KEY_HEADER_LEN];
+    if let Err(e) = stream.read_exact(&mut header) {
+        // Reset the timeout before propagating so the caller
+        // doesn't carry this temporary setting into the rest of
+        // the flow (if we even got there — but defense-in-depth).
+        let _ = stream.set_read_timeout(None);
+        return Err(e);
+    }
+    let Some(key_len) = AuthKeyMessage::parse_header_len(&header) else {
+        let _ = stream.set_read_timeout(None);
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "auth key message header: bad magic or out-of-range key_len",
+        ));
+    };
+    let mut body = vec![0u8; key_len as usize];
+    let body_result = stream.read_exact(&mut body);
+    let _ = stream.set_read_timeout(None);
+    body_result?;
+    // Reassemble the full wire buffer for AuthKeyMessage::from_bytes.
+    // Passing through the decoder rather than constructing the
+    // struct directly ensures the same validation runs on BOTH
+    // the parse-header-then-body path here and the
+    // full-buffer-in-hand path the tests use — keeps
+    // round-trip invariants honest.
+    let mut full = Vec::with_capacity(AUTH_KEY_HEADER_LEN + body.len());
+    full.extend_from_slice(&header);
+    full.extend_from_slice(&body);
+    AuthKeyMessage::from_bytes(&full).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "auth key message body failed to round-trip through AuthKeyMessage::from_bytes",
+        )
+    })
+}
+
 fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHello>> {
     // Poll cadence for the peek retry loop. Small enough that a
     // fragmented `RTLX` hello whose trailing bytes land within a
@@ -1838,6 +1992,139 @@ mod tests {
 
         drop(server_stream);
         let _ = client.join();
+    }
+
+    // ============================================================
+    // Auth handshake tests (#394).
+    //
+    // The real `spawn_client_workers` needs a live
+    // `Arc<Mutex<RtlSdrDevice>>` which requires a USB dongle —
+    // not something CI has. These tests instead exercise
+    // `sniff_auth_key_message` directly over a loopback TCP
+    // pair, pinning the wire-read contract that the enforcement
+    // flow calls into. Full end-to-end (server + client with
+    // real dongle) lives in the manual smoke test.
+    // ============================================================
+
+    #[test]
+    fn sniff_auth_key_message_reads_and_parses_full_message() {
+        // Happy path: client sends a valid AuthKeyMessage, server
+        // reads + parses. Pins the two-phase read (header then
+        // body) + the wire-format round-trip.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let key_bytes = b"test-key-32-bytes-exactly--abcdef".to_vec();
+        let msg = AuthKeyMessage {
+            key: key_bytes.clone(),
+        };
+        let wire = msg.to_bytes().unwrap();
+        let client_thread = thread::spawn(move || {
+            let mut client = TcpStream::connect(addr).unwrap();
+            client.write_all(&wire).unwrap();
+            // Hold the socket open past the server's read so the
+            // server doesn't see EOF mid-body-read.
+            thread::sleep(Duration::from_millis(50));
+        });
+        let (server_stream, _peer) = listener.accept().unwrap();
+        let parsed = sniff_auth_key_message(&server_stream).unwrap();
+        assert_eq!(parsed.key, key_bytes);
+        drop(server_stream);
+        let _ = client_thread.join();
+    }
+
+    #[test]
+    fn sniff_auth_key_message_rejects_bad_magic() {
+        // Client sends a 6-byte header with non-RTKA magic. The
+        // header parser catches the bad magic via
+        // `parse_header_len → None` and the helper surfaces
+        // InvalidData.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client_thread = thread::spawn(move || {
+            let mut client = TcpStream::connect(addr).unwrap();
+            let mut bad = vec![0x00, 0x01, 0x02, 0x03];
+            bad.extend_from_slice(&1u16.to_be_bytes());
+            bad.push(0xAA);
+            client.write_all(&bad).unwrap();
+            thread::sleep(Duration::from_millis(50));
+        });
+        let (server_stream, _peer) = listener.accept().unwrap();
+        let err = sniff_auth_key_message(&server_stream).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        drop(server_stream);
+        let _ = client_thread.join();
+    }
+
+    #[test]
+    fn sniff_auth_key_message_times_out_when_client_silent() {
+        // Client connects but never sends. Header read blocks
+        // up to AUTH_REPLY_TIMEOUT, then fails. Guards against a
+        // silent-client DOS that would otherwise wedge the
+        // accept thread.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (keep_tx, keep_rx) = std::sync::mpsc::channel::<()>();
+        let client_thread = thread::spawn(move || {
+            let _client = TcpStream::connect(addr).unwrap();
+            // Hold the socket open, don't send anything. Release
+            // after the server's timeout has fired.
+            let _ = keep_rx.recv();
+        });
+        let (server_stream, _peer) = listener.accept().unwrap();
+        let start = Instant::now();
+        let err = sniff_auth_key_message(&server_stream).unwrap_err();
+        let elapsed = start.elapsed();
+        // Error kind is WouldBlock / TimedOut depending on
+        // platform; either is an acceptable "header read timed
+        // out" signal from the OS.
+        assert!(
+            matches!(
+                err.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            ),
+            "expected WouldBlock/TimedOut for silent client, got {err:?}"
+        );
+        // And it actually respected the timeout budget (within
+        // a generous 2x margin for scheduling jitter).
+        assert!(
+            elapsed <= AUTH_REPLY_TIMEOUT * 2,
+            "silent-client read took {elapsed:?}, exceeded 2× AUTH_REPLY_TIMEOUT ({AUTH_REPLY_TIMEOUT:?})"
+        );
+        let _ = keep_tx.send(());
+        drop(server_stream);
+        let _ = client_thread.join();
+    }
+
+    #[test]
+    fn sniff_auth_key_message_handles_fragmented_send() {
+        // Client sends the header in one write and the body in a
+        // separate write (with a short pause). The server's
+        // read_exact waits for the rest — no protocol desync.
+        // Pins the contract that the helper tolerates realistic
+        // TCP segmentation.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let key_bytes: Vec<u8> = (0..64).map(|i| i as u8).collect();
+        let msg = AuthKeyMessage {
+            key: key_bytes.clone(),
+        };
+        let wire = msg.to_bytes().unwrap();
+        let (header_part, body_part) = wire.split_at(AUTH_KEY_HEADER_LEN);
+        let header_vec = header_part.to_vec();
+        let body_vec = body_part.to_vec();
+        let client_thread = thread::spawn(move || {
+            let mut client = TcpStream::connect(addr).unwrap();
+            client.write_all(&header_vec).unwrap();
+            client.flush().unwrap();
+            thread::sleep(Duration::from_millis(20));
+            client.write_all(&body_vec).unwrap();
+            thread::sleep(Duration::from_millis(50));
+        });
+        let (server_stream, _peer) = listener.accept().unwrap();
+        let parsed = sniff_auth_key_message(&server_stream).unwrap();
+        assert_eq!(parsed.key, key_bytes);
+        drop(server_stream);
+        let _ = client_thread.join();
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -171,6 +171,33 @@ pub struct ServerConfig {
     /// so the cap doesn't apply to them. Default:
     /// [`DEFAULT_LISTENER_CAP`]. #392.
     pub listener_cap: usize,
+
+    /// Pre-shared auth key. `None` disables the auth gate entirely
+    /// (default — matches the issue's "LAN-only trust model
+    /// continues to work as today"). When `Some(key)`, the server
+    /// validates every connecting client's [`AuthKeyMessage`]
+    /// against this value using a constant-time compare; clients
+    /// that don't produce a matching key are denied with
+    /// [`Status::AuthFailed`] and the connection is closed. Auth
+    /// runs BEFORE the role / listener-cap gate — an
+    /// unauthenticated client isn't even evaluated for role.
+    ///
+    /// Per-byte threat model: the key travels as cleartext over
+    /// the TCP connection. Fine for casual on-LAN cohabitants
+    /// and IoT-trust-zone separation; NOT suitable for WAN-grade
+    /// security. Deployments that need real confidentiality
+    /// should wrap the socket in SSH / WireGuard / Tailscale
+    /// first and use the PSK as a second layer. See #394 for the
+    /// full threat model discussion.
+    ///
+    /// Key length must be in `1..=crate::extension::MAX_AUTH_KEY_LEN`
+    /// — enforced at [`AuthKeyMessage`] serialization/parse time,
+    /// so a zero-length or oversize value here would fail-fast at
+    /// handshake rather than silently accepting anyone. #394.
+    ///
+    /// [`AuthKeyMessage`]: crate::extension::AuthKeyMessage
+    /// [`Status::AuthFailed`]: crate::extension::Status::AuthFailed
+    pub auth_key: Option<Vec<u8>>,
 }
 
 impl ServerConfig {
@@ -185,6 +212,7 @@ impl ServerConfig {
             buffer_capacity: DEFAULT_BUFFER_CAPACITY,
             compression: crate::codec::CodecMask::NONE_ONLY,
             listener_cap: DEFAULT_LISTENER_CAP,
+            auth_key: None,
         }
     }
 }
@@ -1829,6 +1857,7 @@ mod tests {
             buffer_capacity: 0,
             compression: CodecMask::NONE_ONLY,
             listener_cap: DEFAULT_LISTENER_CAP,
+            auth_key: None,
         };
         match Server::start(config) {
             Err(ServerError::PortInUse(ref addr)) => {

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -340,6 +340,25 @@ impl Server {
     /// thread. Dropping it signals shutdown and waits for both — plus
     /// any currently-connected clients — to exit cleanly.
     pub fn start(config: ServerConfig) -> Result<Self, ServerError> {
+        // Validate `auth_key` BEFORE bind or USB open so a bad
+        // config doesn't leave a half-initialized server + a
+        // claimed dongle. `ServerConfig` is public, so library
+        // callers can construct `Some(vec![])` or an oversize
+        // key directly (bypassing the FFI + wire-format guards).
+        // Catch that here rather than deferring to per-handshake
+        // failures — otherwise the server appears to start fine
+        // but every client gets rejected. Per `CodeRabbit`
+        // round 2 on PR #405.
+        if let Some(key) = &config.auth_key {
+            let max = crate::extension::MAX_AUTH_KEY_LEN;
+            if key.is_empty() || key.len() > max {
+                return Err(ServerError::InvalidAuthKeyLength {
+                    len: key.len(),
+                    max,
+                });
+            }
+        }
+
         // Bind first — surface port-in-use before touching the USB device
         // so we don't leave a dongle claimed after a failed bind.
         let listener = TcpListener::bind(config.bind).map_err(|e| {
@@ -1419,52 +1438,6 @@ const HELLO_SNIFF_TIMEOUT: Duration = Duration::from_millis(100);
 /// Per `CodeRabbit` round 2 on PR #399 (initial fix),
 /// round 3 (doc alignment), and round 5 on PR #402
 /// (partial-prefix handling for fragmented RTLX).
-/// Read + parse an [`AuthKeyMessage`] from `stream` within
-/// [`AUTH_REPLY_TIMEOUT`]. Caller is responsible for having
-/// observed `hello.has_auth() == true` on the preceding hello
-/// — this helper assumes the auth message is the next thing on
-/// the wire. Two-phase read: header (6 bytes) then body
-/// (`key_len` bytes). Both phases gated by
-/// `AUTH_REPLY_TIMEOUT`, so a silent client can't wedge the
-/// accept thread. #394.
-fn sniff_auth_key_message(mut stream: &TcpStream) -> std::io::Result<AuthKeyMessage> {
-    stream.set_read_timeout(Some(AUTH_REPLY_TIMEOUT))?;
-    let mut header = [0u8; AUTH_KEY_HEADER_LEN];
-    if let Err(e) = stream.read_exact(&mut header) {
-        // Reset the timeout before propagating so the caller
-        // doesn't carry this temporary setting into the rest of
-        // the flow (if we even got there — but defense-in-depth).
-        let _ = stream.set_read_timeout(None);
-        return Err(e);
-    }
-    let Some(key_len) = AuthKeyMessage::parse_header_len(&header) else {
-        let _ = stream.set_read_timeout(None);
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "auth key message header: bad magic or out-of-range key_len",
-        ));
-    };
-    let mut body = vec![0u8; key_len as usize];
-    let body_result = stream.read_exact(&mut body);
-    let _ = stream.set_read_timeout(None);
-    body_result?;
-    // Reassemble the full wire buffer for AuthKeyMessage::from_bytes.
-    // Passing through the decoder rather than constructing the
-    // struct directly ensures the same validation runs on BOTH
-    // the parse-header-then-body path here and the
-    // full-buffer-in-hand path the tests use — keeps
-    // round-trip invariants honest.
-    let mut full = Vec::with_capacity(AUTH_KEY_HEADER_LEN + body.len());
-    full.extend_from_slice(&header);
-    full.extend_from_slice(&body);
-    AuthKeyMessage::from_bytes(&full).ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "auth key message body failed to round-trip through AuthKeyMessage::from_bytes",
-        )
-    })
-}
-
 fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHello>> {
     // Poll cadence for the peek retry loop. Small enough that a
     // fragmented `RTLX` hello whose trailing bytes land within a
@@ -1590,6 +1563,88 @@ fn sniff_client_hello(mut stream: &TcpStream) -> std::io::Result<Option<ClientHe
              malformed field)",
             )
         })
+}
+
+/// Read + parse an [`AuthKeyMessage`] from `stream` within an
+/// **absolute** [`AUTH_REPLY_TIMEOUT`] budget. Caller is
+/// responsible for having observed `hello.has_auth() == true`
+/// on the preceding hello — this helper assumes the auth message
+/// is the next thing on the wire. Two-phase read: 6-byte header
+/// (magic + u16 key_len) then `key_len`-byte body.
+///
+/// **Absolute deadline, not per-read timeout.** The budget caps
+/// the whole sniff call, not each `read_exact` syscall
+/// independently. Per-read timeouts reset on every successful
+/// byte, so a slow peer trickling one byte every 4.9 s could
+/// keep both reads inside their individual 5 s windows while
+/// wedging the accept thread indefinitely. The deadline-based
+/// approach bounds total elapsed time — header + body must
+/// complete within `AUTH_REPLY_TIMEOUT` of entry. Per
+/// `CodeRabbit` round 2 on PR #405. #394.
+fn sniff_auth_key_message(mut stream: &TcpStream) -> std::io::Result<AuthKeyMessage> {
+    let deadline = Instant::now() + AUTH_REPLY_TIMEOUT;
+
+    // Header read. `remaining_until` returns the interval from
+    // now to the deadline, or `Duration::ZERO` if the deadline
+    // already passed (which signals TimedOut here too — reading
+    // with a zero timeout is undefined, so we explicitly error).
+    let header_timeout = deadline.saturating_duration_since(Instant::now());
+    if header_timeout.is_zero() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "auth key header read deadline expired before first read",
+        ));
+    }
+    stream.set_read_timeout(Some(header_timeout))?;
+    let mut header = [0u8; AUTH_KEY_HEADER_LEN];
+    if let Err(e) = stream.read_exact(&mut header) {
+        let _ = stream.set_read_timeout(None);
+        return Err(e);
+    }
+
+    // Header parsed OK → decode `key_len` so we know how much
+    // more to read.
+    let Some(key_len) = AuthKeyMessage::parse_header_len(&header) else {
+        let _ = stream.set_read_timeout(None);
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "auth key message header: bad magic or out-of-range key_len",
+        ));
+    };
+
+    // Body read with the remaining (shrinking) budget. If the
+    // header read burned most of the window, the body read gets
+    // whatever's left. A zero-remaining budget short-circuits as
+    // TimedOut before we ever call into `read_exact`.
+    let body_timeout = deadline.saturating_duration_since(Instant::now());
+    if body_timeout.is_zero() {
+        let _ = stream.set_read_timeout(None);
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "auth key body read deadline expired before body read",
+        ));
+    }
+    stream.set_read_timeout(Some(body_timeout))?;
+    let mut body = vec![0u8; key_len as usize];
+    let body_result = stream.read_exact(&mut body);
+    let _ = stream.set_read_timeout(None);
+    body_result?;
+
+    // Reassemble the full wire buffer for
+    // `AuthKeyMessage::from_bytes`. Passing through the decoder
+    // rather than constructing the struct directly ensures the
+    // same validation runs on BOTH the parse-header-then-body
+    // path here and the full-buffer-in-hand path the tests use
+    // — keeps round-trip invariants honest.
+    let mut full = Vec::with_capacity(AUTH_KEY_HEADER_LEN + body.len());
+    full.extend_from_slice(&header);
+    full.extend_from_slice(&body);
+    AuthKeyMessage::from_bytes(&full).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "auth key message body failed to round-trip through AuthKeyMessage::from_bytes",
+        )
+    })
 }
 
 /// `Write` adapter sitting between the negotiated `Encoder` and the
@@ -2205,6 +2260,65 @@ mod tests {
             Ok(_) => panic!("bind should have failed"),
         }
         drop(holder);
+    }
+
+    #[test]
+    fn start_rejects_empty_auth_key_as_config_error() {
+        // **Regression test for `CodeRabbit` round 2 on PR #405.**
+        // `ServerConfig` is public, so a library caller can
+        // construct `Some(vec![])` and bypass every upstream
+        // guard (FFI / CLI / wire format). `Server::start` must
+        // catch this BEFORE bind / USB open so the operator sees
+        // one clear config error instead of every client
+        // failing at handshake.
+        //
+        // Uses port 0 so bind succeeds even if another test is
+        // holding a port — the config validation runs first, so
+        // the bind never actually happens. USB is never touched
+        // either (same early-exit ordering).
+        let config = ServerConfig {
+            bind: SocketAddr::from(([127, 0, 0, 1], 0)),
+            device_index: 0,
+            initial: InitialDeviceState::default(),
+            buffer_capacity: 0,
+            compression: CodecMask::NONE_ONLY,
+            listener_cap: DEFAULT_LISTENER_CAP,
+            auth_key: Some(Vec::new()), // empty — invalid per `validate_auth_key`
+        };
+        match Server::start(config) {
+            Err(ServerError::InvalidAuthKeyLength { len, max }) => {
+                assert_eq!(len, 0);
+                assert_eq!(max, crate::extension::MAX_AUTH_KEY_LEN);
+            }
+            Err(e) => panic!("expected InvalidAuthKeyLength, got {e:?}"),
+            Ok(_) => panic!("empty auth_key must not start a server"),
+        }
+    }
+
+    #[test]
+    fn start_rejects_oversize_auth_key_as_config_error() {
+        // Complement to the empty-key test — keys longer than
+        // `MAX_AUTH_KEY_LEN` (256 bytes) can't be serialized by
+        // `AuthKeyMessage::to_bytes`, so the server would start
+        // but reject every client at handshake. Catch at config
+        // time.
+        let config = ServerConfig {
+            bind: SocketAddr::from(([127, 0, 0, 1], 0)),
+            device_index: 0,
+            initial: InitialDeviceState::default(),
+            buffer_capacity: 0,
+            compression: CodecMask::NONE_ONLY,
+            listener_cap: DEFAULT_LISTENER_CAP,
+            auth_key: Some(vec![0u8; crate::extension::MAX_AUTH_KEY_LEN + 1]),
+        };
+        match Server::start(config) {
+            Err(ServerError::InvalidAuthKeyLength { len, max }) => {
+                assert_eq!(len, crate::extension::MAX_AUTH_KEY_LEN + 1);
+                assert_eq!(max, crate::extension::MAX_AUTH_KEY_LEN);
+            }
+            Err(e) => panic!("expected InvalidAuthKeyLength, got {e:?}"),
+            Ok(_) => panic!("oversize auth_key must not start a server"),
+        }
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -51,7 +51,7 @@ use crate::dispatch::dispatch;
 use crate::error::ServerError;
 use crate::extension::{
     AUTH_KEY_HEADER_LEN, AUTH_REPLY_TIMEOUT, AuthKeyMessage, CLIENT_HELLO_LEN, ClientHello,
-    EXTENSION_MAGIC, PROTOCOL_VERSION, Role, ServerExtension, Status,
+    EXTENSION_MAGIC, PROTOCOL_VERSION_V1, Role, ServerExtension, Status,
 };
 use crate::protocol::{COMMAND_LEN, Command, CommandOp, DongleInfo, TunerTypeCode};
 
@@ -736,7 +736,7 @@ fn spawn_client_workers(
     //   - `negotiated_codec` is `None` for vanilla (always
     //     uncompressed); `Some(_)` for RTLX clients — the
     //     intersection of their mask and ours
-    let (hello_seen, requested_role, request_takeover, has_auth, negotiated_codec) =
+    let (hello_seen, requested_role, request_takeover, has_auth, hello_version, negotiated_codec) =
         if let Some(hello) = &sniff_outcome {
             let codec = compression_offer.pick(hello.codec_mask);
             let takeover = hello.request_takeover();
@@ -749,9 +749,17 @@ fn spawn_client_workers(
                 requested_role = ?hello.role,
                 request_takeover = takeover,
                 has_auth,
+                hello_version = hello.version,
                 "rtl_tcp extended-handshake negotiated"
             );
-            (true, hello.role, takeover, has_auth, Some(codec))
+            (
+                true,
+                hello.role,
+                takeover,
+                has_auth,
+                hello.version,
+                Some(codec),
+            )
         } else {
             tracing::debug!(
                 %peer,
@@ -766,7 +774,18 @@ fn spawn_client_workers(
             // never carry an AuthKeyMessage follow-up, so `false`
             // here routes the auth gate's vanilla+auth-required
             // path to a bare TCP FIN (they can't authenticate).
-            (false, Role::Control, false, false, None)
+            // Vanilla clients never receive a `ServerExtension`
+            // either, so `hello_version` is nominal here — use
+            // `PROTOCOL_VERSION_V1` as a neutral default; it's
+            // never written to the wire on the vanilla path.
+            (
+                false,
+                Role::Control,
+                false,
+                false,
+                PROTOCOL_VERSION_V1,
+                None,
+            )
         };
     let codec = negotiated_codec.unwrap_or(Codec::None);
 
@@ -814,7 +833,13 @@ fn spawn_client_workers(
                             %peer,
                             "rtl_tcp auth key mismatch — denying client"
                         );
-                        send_denied_response(&stream, peer, &device, Status::AuthFailed);
+                        send_denied_response(
+                            &stream,
+                            peer,
+                            &device,
+                            Status::AuthFailed,
+                            hello_version,
+                        );
                         return;
                     }
                     tracing::info!(%peer, "rtl_tcp auth key validated");
@@ -837,7 +862,7 @@ fn spawn_client_workers(
                     "rtl_tcp auth key follow-up unreadable — denying client"
                 );
                 if auth_key.is_some() {
-                    send_denied_response(&stream, peer, &device, Status::AuthFailed);
+                    send_denied_response(&stream, peer, &device, Status::AuthFailed, hello_version);
                 }
                 // If auth wasn't required but the client promised
                 // a follow-up (has_auth=true) and didn't deliver,
@@ -855,7 +880,7 @@ fn spawn_client_workers(
                 %peer,
                 "rtl_tcp auth required but client didn't send key — denying with AuthRequired"
             );
-            send_denied_response(&stream, peer, &device, Status::AuthRequired);
+            send_denied_response(&stream, peer, &device, Status::AuthRequired, hello_version);
         } else {
             // Vanilla client: can't authenticate, so there's
             // nothing meaningful to tell them. Bare TCP FIN.
@@ -913,7 +938,13 @@ fn spawn_client_workers(
             // handing them a dongle_info_t they'd interpret as
             // admission.
             if hello_seen {
-                send_denied_response(&stream, peer, &device, Status::ControllerBusy);
+                send_denied_response(
+                    &stream,
+                    peer,
+                    &device,
+                    Status::ControllerBusy,
+                    hello_version,
+                );
             }
             return;
         }
@@ -935,7 +966,13 @@ fn spawn_client_workers(
                 "vanilla clients should never land in ListenerCapReached"
             );
             if hello_seen {
-                send_denied_response(&stream, peer, &device, Status::ListenerCapReached);
+                send_denied_response(
+                    &stream,
+                    peer,
+                    &device,
+                    Status::ListenerCapReached,
+                    hello_version,
+                );
             }
             return;
         }
@@ -1006,7 +1043,11 @@ fn spawn_client_workers(
             codec,
             granted_role: Some(requested_role),
             status: Status::Ok,
-            version: PROTOCOL_VERSION,
+            // Echo the client's hello version on the response so
+            // v1 clients interoperate with this v2-era server
+            // without hitting the peer-side strict version gate.
+            // Per `CodeRabbit` round 1 on PR #405.
+            version: hello_version,
         };
         if let Err(e) = writer.write_all(&ext.to_bytes()) {
             tracing::warn!(%peer, %e, "failed to send RTLX server extension — client gone");
@@ -1129,6 +1170,7 @@ fn send_denied_response(
     peer: SocketAddr,
     device: &Arc<Mutex<RtlSdrDevice>>,
     status: Status,
+    hello_version: u8,
 ) {
     let Ok(dev) = device.lock() else {
         tracing::warn!(%peer, "device mutex poisoned during denial response");
@@ -1165,7 +1207,10 @@ fn send_denied_response(
         codec: Codec::None,
         granted_role: None,
         status,
-        version: PROTOCOL_VERSION,
+        // Echo the client's hello version so v1 clients can
+        // parse this denial without tripping their strict
+        // version gate. Per `CodeRabbit` round 1 on PR #405.
+        version: hello_version,
     };
     if writer.write_all(&ext.to_bytes()).is_err() {
         tracing::debug!(
@@ -2013,7 +2058,13 @@ mod tests {
         // body) + the wire-format round-trip.
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
-        let key_bytes = b"test-key-32-bytes-exactly--abcdef".to_vec();
+        // Exactly 32 bytes — matches the canonical
+        // `DEFAULT_AUTH_KEY_LEN` used by `generate_random_auth_key`
+        // so the fixture shape tracks production size. The ASCII
+        // label makes test log output readable while keeping the
+        // bytes well within the `1..=MAX_AUTH_KEY_LEN` window.
+        let key_bytes = b"test-key-32-bytes-exactly-abcdef".to_vec();
+        debug_assert_eq!(key_bytes.len(), 32);
         let msg = AuthKeyMessage {
             key: key_bytes.clone(),
         };
@@ -2321,7 +2372,7 @@ mod tests {
         // returns `Ok(Some)` with the parsed struct. Regression
         // guard against a future refactor breaking the common case.
         use crate::codec::CodecMask;
-        use crate::extension::{CLIENT_HELLO_FLAGS_NONE, Role};
+        use crate::extension::{CLIENT_HELLO_FLAGS_NONE, PROTOCOL_VERSION, Role};
         let hello = ClientHello {
             codec_mask: CodecMask::NONE_AND_LZ4,
             role: Role::Control,
@@ -2411,7 +2462,7 @@ mod tests {
         // `EXTENSION_MAGIC`, so a fragmented magic still reaches
         // the full `read_exact` path.
         use crate::codec::CodecMask;
-        use crate::extension::{CLIENT_HELLO_FLAGS_NONE, Role};
+        use crate::extension::{CLIENT_HELLO_FLAGS_NONE, PROTOCOL_VERSION, Role};
         let hello = ClientHello {
             codec_mask: CodecMask::NONE_AND_LZ4,
             role: Role::Control,
@@ -2533,7 +2584,7 @@ mod tests {
         garbled[4] = 0x03; // codec mask (NONE+LZ4)
         garbled[5] = 0x99; // invalid role — from_bytes returns None
         garbled[6] = 0x00; // flags
-        garbled[7] = PROTOCOL_VERSION;
+        garbled[7] = crate::extension::PROTOCOL_VERSION;
         let result = run_sniff_against(move |mut client| {
             client.write_all(&garbled).unwrap();
             thread::sleep(Duration::from_millis(50));

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -192,9 +192,13 @@ pub struct ServerConfig {
     /// full threat model discussion.
     ///
     /// Key length must be in `1..=crate::extension::MAX_AUTH_KEY_LEN`
-    /// — enforced at [`AuthKeyMessage`] serialization/parse time,
-    /// so a zero-length or oversize value here would fail-fast at
-    /// handshake rather than silently accepting anyone. #394.
+    /// (i.e., `1..=256`). [`Server::start`] validates the length
+    /// BEFORE binding the listener or opening the USB device and
+    /// returns [`ServerError::InvalidAuthKeyLength`] immediately
+    /// if the key is empty or oversize, so the operator sees a
+    /// single clear configuration error at startup rather than
+    /// every client failing at handshake time. Per `CodeRabbit`
+    /// round 2 on PR #405. #394.
     ///
     /// [`AuthKeyMessage`]: crate::extension::AuthKeyMessage
     /// [`Status::AuthFailed`]: crate::extension::Status::AuthFailed
@@ -669,17 +673,57 @@ fn spawn_accept_thread(
                             continue;
                         }
                         configure_client_socket(&stream);
-                        spawn_client_workers(
-                            stream,
-                            peer,
-                            device.clone(),
-                            registry.clone(),
-                            shutdown.clone(),
-                            per_client_buffer_depth,
-                            compression,
-                            listener_cap,
-                            auth_key.clone(),
-                        );
+                        // Dispatch the blocking handshake (sniff hello +
+                        // optional auth follow-up + role admission) to a
+                        // short-lived per-connection setup thread. Holding
+                        // it inline would let one stalled RTLX client
+                        // serialize unrelated accepts for up to
+                        // `HELLO_SNIFF_TIMEOUT` (0.1 s) + `AUTH_REPLY_TIMEOUT`
+                        // (5 s) — a slow-peer DOS against the listener
+                        // backlog. Per `CodeRabbit` round 4 on PR #405.
+                        //
+                        // The setup thread runs to natural completion
+                        // regardless of shutdown: it either fails its
+                        // handshake (fast return, no registry entry) or
+                        // progresses to registering writer + command
+                        // handles and exits. We register its `JoinHandle`
+                        // on the same `register_worker_handle` bucket as
+                        // writer/command threads so `Server::drop`
+                        // joins it alongside them — bounded shutdown
+                        // latency of ≤ `HELLO_SNIFF_TIMEOUT` +
+                        // `AUTH_REPLY_TIMEOUT` per in-flight handshake.
+                        let setup_device = device.clone();
+                        let setup_registry = registry.clone();
+                        let setup_shutdown = shutdown.clone();
+                        let setup_auth_key = auth_key.clone();
+                        let setup_registry_for_register = registry.clone();
+                        match thread::Builder::new()
+                            .name(format!("rtl_tcp-setup-{}", peer.port()))
+                            .spawn(move || {
+                                spawn_client_workers(
+                                    stream,
+                                    peer,
+                                    setup_device,
+                                    setup_registry,
+                                    setup_shutdown,
+                                    per_client_buffer_depth,
+                                    compression,
+                                    listener_cap,
+                                    setup_auth_key,
+                                );
+                            }) {
+                            Ok(h) => {
+                                setup_registry_for_register.register_worker_handle(h);
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    %peer,
+                                    %e,
+                                    "failed to spawn rtl_tcp setup thread — dropping client"
+                                );
+                                // `stream` drops here → bare TCP FIN.
+                            }
+                        }
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                         thread::sleep(ACCEPT_POLL_INTERVAL);
@@ -709,14 +753,25 @@ fn spawn_accept_thread(
 
 /// Do the handshake on a freshly-accepted socket, build a
 /// [`ClientSlot`], register it, and spawn this client's writer +
-/// command threads. Fire-and-forget — the accept thread doesn't wait
-/// for this client's workers; lifecycle is observed via the slot's
+/// command threads. Lifecycle is observed via the slot's
 /// disconnection flag.
+///
+/// **Runs on a per-connection setup thread**, not on the accept
+/// thread. The handshake includes two blocking reads —
+/// [`sniff_client_hello`] (bounded by `HELLO_SNIFF_TIMEOUT = 100 ms`)
+/// and, when auth is configured and the client didn't send
+/// `has_auth=true`, [`sniff_auth_key_message`] (bounded by
+/// [`AUTH_REPLY_TIMEOUT`] = 5 s). Holding these on the accept thread
+/// would let one stalled RTLX client serialize unrelated accepts for
+/// up to ~5.1 s and pressure the listener backlog. Per `CodeRabbit`
+/// round 4 on PR #405. #394.
 ///
 /// If the handshake fails at any step (sniff error, socket clone
 /// fails, header write fails, thread spawn fails), the client is
 /// silently dropped — no slot is registered, no stats are updated.
-/// The caller (accept thread) moves on to the next accept.
+/// The setup thread then exits; its `JoinHandle` is already
+/// registered with the `ClientRegistry` so `Server::drop` joins
+/// it alongside the per-client writer / command handles.
 #[allow(
     clippy::too_many_arguments,
     clippy::too_many_lines,

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -47,8 +47,8 @@ use std::time::{Duration, Instant};
 use sdr_pipeline::source_manager::Source;
 use sdr_server_rtltcp::codec::{Codec, CodecMask, Decoder};
 use sdr_server_rtltcp::extension::{
-    CLIENT_HELLO_FLAGS_NONE, ClientHello, EXTENSION_MAGIC, PROTOCOL_VERSION, Role,
-    SERVER_EXTENSION_LEN, ServerExtension, Status,
+    CLIENT_HELLO_FLAGS_NONE, ClientHello, EXTENSION_MAGIC, Role, SERVER_EXTENSION_LEN,
+    ServerExtension, Status,
 };
 use sdr_server_rtltcp::protocol::{Command, CommandOp, DONGLE_INFO_LEN, DongleInfo, TunerTypeCode};
 use sdr_types::{Complex, SourceError};
@@ -872,6 +872,13 @@ struct HandshakeOutcome {
     codec: Codec,
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "connect flow is linear — TCP connect + RTLX handshake + \
+              auth pre-build + dongle_info_t + ServerExtension + state \
+              publish. Splitting would scatter the error-mapping glue \
+              that's the whole point of this function."
+)]
 fn attempt_connect(
     host: &str,
     port: u16,
@@ -946,6 +953,35 @@ fn attempt_connect(
             // to request it. #394.
             flags |= sdr_server_rtltcp::extension::FLAG_HAS_AUTH;
         }
+        // Pre-build AND validate the auth payload BEFORE any
+        // writes hit the socket. Two reasons (`CodeRabbit` round 1
+        // on PR #405):
+        //
+        // 1. An invalid `auth_key` (empty or > `MAX_AUTH_KEY_LEN`)
+        //    caught at `AuthKeyMessage::to_bytes` must surface
+        //    as a config error BEFORE the hello lands on the
+        //    wire. Otherwise we'd send the hello, discover the
+        //    key is bad, and abort — leaving a pre-#394 server
+        //    stuck reading bytes we never sent (or mis-parsing
+        //    the hello as a legacy command prefix).
+        // 2. All-or-nothing semantics — the server either sees
+        //    the full extended handshake (hello + auth) or
+        //    nothing at all. No partial-write state.
+        let auth_payload: Option<Vec<u8>> = if let Some(key) = &config.auth_key {
+            let msg = sdr_server_rtltcp::extension::AuthKeyMessage { key: key.clone() };
+            Some(msg.to_bytes().ok_or_else(|| {
+                SourceError::Protocol(format!(
+                    "RtlTcpConfig.auth_key length {} invalid for AuthKeyMessage (must be \
+                     1..={MAX}; 32-byte URL-safe base64 is the canonical server-\
+                     generated shape)",
+                    key.len(),
+                    MAX = sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN,
+                ))
+            })?)
+        } else {
+            None
+        };
+
         let hello = ClientHello {
             codec_mask: config.compression,
             // sdr-rs clients always request Control on connect;
@@ -954,33 +990,25 @@ fn attempt_connect(
             // opt-in that isn't part of #393's scope.
             role: Role::Control,
             flags,
-            version: PROTOCOL_VERSION,
+            // Pick the MINIMUM viable protocol version for this
+            // hello's feature set. Compression-only / takeover-
+            // only / plain hellos emit v1 (back-compat with
+            // pre-#394 servers that haven't widened their version
+            // gate). Auth-bearing hellos emit v2 so pre-#394
+            // servers reject at parse time instead of accepting
+            // the hello and then mis-reading the queued
+            // `AuthKeyMessage` bytes as legacy commands. Per
+            // `CodeRabbit` round 1 on PR #405.
+            version: sdr_server_rtltcp::extension::required_protocol_version(flags),
         };
         if let Err(e) = (&stream).write_all(&hello.to_bytes()) {
             return Err(SourceError::Io(e));
         }
-
-        // Auth-key follow-up (#394 eager path). When configured,
-        // the AuthKeyMessage lands immediately after the hello
-        // — the server has already seen `FLAG_HAS_AUTH` set and
-        // is in the "read auth follow-up" state. Message format:
-        // 4-byte `RTKA` magic + 2-byte u16 BE length + key bytes.
-        // `AuthKeyMessage::to_bytes` returns `None` on empty or
-        // over-max keys; we surface that as a clear protocol
-        // error since the caller's config is busted — rather
-        // than write nothing and have the server stall on
-        // `read_exact`.
-        if let Some(key) = &config.auth_key {
-            let msg = sdr_server_rtltcp::extension::AuthKeyMessage { key: key.clone() };
-            let wire = msg.to_bytes().ok_or_else(|| {
-                SourceError::Protocol(format!(
-                    "RtlTcpConfig.auth_key length {} invalid for AuthKeyMessage (must be \
-                     1..={MAX}; 32-byte URL-safe base64 is the canonical server-\
-                     generated shape)",
-                    key.len(),
-                    MAX = sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN,
-                ))
-            })?;
+        // Auth follow-up (#394 eager path). Pre-built above so
+        // local validation precedes any socket write; server
+        // reads these bytes in the same receive-buffer position
+        // without a round-trip to request them.
+        if let Some(wire) = auth_payload {
             if let Err(e) = (&stream).write_all(&wire) {
                 return Err(SourceError::Io(e));
             }
@@ -1548,6 +1576,13 @@ impl Source for RtlTcpSource {
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+    // Tests build `ServerExtension` / `ClientHello` values with
+    // explicit `version: PROTOCOL_VERSION`. Lib code itself
+    // picks versions via `required_protocol_version` and no
+    // longer needs the constant at the top of the file; the
+    // test-scope import keeps clippy's `unused_imports` lint
+    // happy on the lib target.
+    use sdr_server_rtltcp::extension::PROTOCOL_VERSION;
     use std::net::TcpListener;
     // `CLIENT_HELLO_LEN` is only consumed by the loopback fixtures
     // in the RTLX handshake tests below — keep it in test scope

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -2489,6 +2489,15 @@ mod tests {
                 .unwrap();
             let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
             sock.read_exact(&mut hello_buf).expect("read hello");
+            // Capture the client-sent version byte (offset 7)
+            // BEFORE forwarding the hello to the test driver.
+            // Compression-only opt-in should produce v1 per
+            // `required_protocol_version(flags)`; echoing this
+            // value in the response means any future regression
+            // that changes the client-side version selection
+            // surfaces here (driver asserts below). Per
+            // `CodeRabbit` round 2 on PR #405.
+            let client_hello_version = hello_buf[7];
             let _ = hello_tx.send(hello_buf);
             // Probe with a short timeout for any additional
             // bytes — expect WouldBlock / TimedOut because the
@@ -2508,7 +2517,13 @@ mod tests {
                 codec: Codec::Lz4,
                 granted_role: Some(Role::Control),
                 status: Status::Ok,
-                version: PROTOCOL_VERSION,
+                // Echo the client's hello version — this is what
+                // a real v2-era server does so v1 clients can
+                // still parse the response under their strict
+                // version gate. Hard-coding `PROTOCOL_VERSION`
+                // here would mask a regression that changes
+                // client-side version selection away from v1.
+                version: client_hello_version,
             };
             sock.write_all(&ext.to_bytes()).unwrap();
             thread::sleep(RTLX_TEST_SERVER_HOLD);
@@ -2534,6 +2549,16 @@ mod tests {
             flags_byte & sdr_server_rtltcp::extension::FLAG_HAS_AUTH,
             0,
             "auth_key = None must clear FLAG_HAS_AUTH bit in the hello"
+        );
+        // Compression-only + no auth + no takeover →
+        // `required_protocol_version(flags) == V1`. Pin the
+        // version byte so a regression that swaps the default
+        // to v2 against pre-#394 servers surfaces here. Per
+        // `CodeRabbit` round 2 on PR #405.
+        assert_eq!(
+            hello[7],
+            sdr_server_rtltcp::extension::PROTOCOL_VERSION_V1,
+            "compression-only hello must emit v1 (compat with pre-#394 servers)"
         );
 
         // Server probe for follow-up bytes. Must time out — no

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -259,6 +259,37 @@ pub struct RtlTcpConfig {
     /// prior controller. Per #393 + `CodeRabbit` round 1 on
     /// PR #404 (doc clarification).
     pub request_takeover: bool,
+
+    /// Pre-shared auth key to send in the extended handshake
+    /// (#394). `None` means "no key" (default); `Some(bytes)`
+    /// activates the eager-auth path: hello's `FLAG_HAS_AUTH`
+    /// bit is set AND the client immediately follows with an
+    /// `AuthKeyMessage` carrying these bytes. Server-side
+    /// behavior:
+    /// - If the server doesn't require auth, the key is
+    ///   discarded server-side (stream-sync only) and the
+    ///   handshake proceeds normally.
+    /// - If the server requires auth and the key matches
+    ///   (constant-time compare), the handshake proceeds.
+    /// - If the server requires auth and the key doesn't match,
+    ///   the server responds with `status=AuthFailed` and
+    ///   closes; the client's manager transitions to `Failed`
+    ///   with a Protocol-kind error so the UI can surface
+    ///   "wrong key" guidance.
+    ///
+    /// **RTLX-only — NOT safe against vanilla servers.** Same
+    /// hazard as [`Self::request_takeover`] — setting this
+    /// triggers a `ClientHello` emission via the
+    /// `extension_enabled` gate below, and vanilla rtl_tcp
+    /// servers misinterpret the 8-byte hello as two 5-byte
+    /// commands. Gate this on the same out-of-band evidence
+    /// that gates `compression` / `request_takeover` (mDNS
+    /// TXT `codecs=3`, or cached server-profile knowledge).
+    ///
+    /// Keys are cleartext over TCP — the threat model is
+    /// casual LAN isolation, not WAN-grade security. See #394
+    /// for the full threat model discussion. #394.
+    pub auth_key: Option<Vec<u8>>,
 }
 
 impl Default for RtlTcpConfig {
@@ -269,6 +300,7 @@ impl Default for RtlTcpConfig {
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
             request_takeover: false,
+            auth_key: None,
         }
     }
 }
@@ -889,18 +921,31 @@ fn attempt_connect(
     // Default `compression = NONE_ONLY && request_takeover =
     // false` → no hello → wire-compatible with every rtl_tcp
     // server on earth. Per #307 / #393.
-    let extension_enabled = config.compression != CodecMask::NONE_ONLY || config.request_takeover;
+    let extension_enabled = config.compression != CodecMask::NONE_ONLY
+        || config.request_takeover
+        || config.auth_key.is_some();
     if extension_enabled {
-        let flags = if config.request_takeover {
-            // Bit 0 of the reserved flags byte is
-            // `FLAG_REQUEST_TAKEOVER`. Setting it tells #392+
-            // servers to kick the existing Control client and
-            // admit us instead (when the slot is busy); servers
-            // without role support ignore the whole hello. #393.
-            sdr_server_rtltcp::extension::FLAG_REQUEST_TAKEOVER
-        } else {
-            CLIENT_HELLO_FLAGS_NONE
-        };
+        // Compose the flags byte. Each bit is independently set
+        // based on config — takeover and auth can co-exist on
+        // the same hello. Servers without role / auth support
+        // ignore the whole hello, but the RTLX-only hazard still
+        // applies (see the field docs for the mDNS `codecs=`
+        // gate).
+        let mut flags = CLIENT_HELLO_FLAGS_NONE;
+        if config.request_takeover {
+            // Bit 0: `FLAG_REQUEST_TAKEOVER`. Tells #392+ servers
+            // to kick the existing Control client (when the slot
+            // is busy) and admit us instead. #393.
+            flags |= sdr_server_rtltcp::extension::FLAG_REQUEST_TAKEOVER;
+        }
+        if config.auth_key.is_some() {
+            // Bit 1: `FLAG_HAS_AUTH`. Announces that an
+            // `AuthKeyMessage` follow-up lands immediately after
+            // this hello. Server reads the follow-up in the
+            // same receive-buffer position without a round-trip
+            // to request it. #394.
+            flags |= sdr_server_rtltcp::extension::FLAG_HAS_AUTH;
+        }
         let hello = ClientHello {
             codec_mask: config.compression,
             // sdr-rs clients always request Control on connect;
@@ -913,6 +958,32 @@ fn attempt_connect(
         };
         if let Err(e) = (&stream).write_all(&hello.to_bytes()) {
             return Err(SourceError::Io(e));
+        }
+
+        // Auth-key follow-up (#394 eager path). When configured,
+        // the AuthKeyMessage lands immediately after the hello
+        // — the server has already seen `FLAG_HAS_AUTH` set and
+        // is in the "read auth follow-up" state. Message format:
+        // 4-byte `RTKA` magic + 2-byte u16 BE length + key bytes.
+        // `AuthKeyMessage::to_bytes` returns `None` on empty or
+        // over-max keys; we surface that as a clear protocol
+        // error since the caller's config is busted — rather
+        // than write nothing and have the server stall on
+        // `read_exact`.
+        if let Some(key) = &config.auth_key {
+            let msg = sdr_server_rtltcp::extension::AuthKeyMessage { key: key.clone() };
+            let wire = msg.to_bytes().ok_or_else(|| {
+                SourceError::Protocol(format!(
+                    "RtlTcpConfig.auth_key length {} invalid for AuthKeyMessage (must be \
+                     1..={MAX}; 32-byte URL-safe base64 is the canonical server-\
+                     generated shape)",
+                    key.len(),
+                    MAX = sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN,
+                ))
+            })?;
+            if let Err(e) = (&stream).write_all(&wire) {
+                return Err(SourceError::Io(e));
+            }
         }
     }
 
@@ -1656,6 +1727,7 @@ mod tests {
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
             request_takeover: false,
+            auth_key: None,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -1922,6 +1994,7 @@ mod tests {
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             compression: CodecMask::NONE_AND_LZ4,
             request_takeover: false,
+            auth_key: None,
         };
         (listener, config)
     }
@@ -2169,6 +2242,7 @@ mod tests {
             // "compression != NONE_ONLY OR request_takeover".
             compression: CodecMask::NONE_ONLY,
             request_takeover: true,
+            auth_key: None,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -2249,6 +2323,7 @@ mod tests {
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             compression: CodecMask::NONE_AND_LZ4,
             request_takeover: false,
+            auth_key: None,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -2264,6 +2339,185 @@ mod tests {
             "request_takeover = false must clear FLAG_REQUEST_TAKEOVER \
              in the hello (got flags byte 0x{flags_byte:02x})"
         );
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_sends_auth_key_when_config_opts_in() {
+        // **Regression test for #394.** When
+        // `RtlTcpConfig::auth_key = Some(key)`, the client must
+        // emit `FLAG_HAS_AUTH` on the hello AND follow with an
+        // `AuthKeyMessage` carrying the configured bytes. Pairs
+        // with the server-side `sniff_auth_key_message` tests in
+        // `sdr_server_rtltcp::server::tests` — this test locks
+        // in the client's end of the same wire contract.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let expected_key = b"the-shared-secret-32-bytes-!!".to_vec();
+        let expected_key_for_server = expected_key.clone();
+
+        let (hello_tx, hello_rx) = std::sync::mpsc::channel::<[u8; CLIENT_HELLO_LEN]>();
+        let (auth_tx, auth_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            sock.set_read_timeout(Some(RTLX_TEST_STATE_DEADLINE))
+                .unwrap();
+            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+            sock.read_exact(&mut hello_buf).expect("read hello");
+            let _ = hello_tx.send(hello_buf);
+            // Read the AuthKeyMessage follow-up: 6-byte header
+            // (RTKA + u16 key_len) then key_len bytes.
+            let mut header = [0u8; sdr_server_rtltcp::extension::AUTH_KEY_HEADER_LEN];
+            sock.read_exact(&mut header).expect("read auth header");
+            let key_len = sdr_server_rtltcp::extension::AuthKeyMessage::parse_header_len(&header)
+                .expect("valid header");
+            let mut body = vec![0u8; key_len as usize];
+            sock.read_exact(&mut body).expect("read auth body");
+            let _ = auth_tx.send(body);
+            // Accept the handshake so the client reaches
+            // Connected.
+            let header_out = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: RTLX_TEST_GAIN_COUNT,
+            }
+            .to_bytes();
+            sock.write_all(&header_out).unwrap();
+            let ext = ServerExtension {
+                codec: Codec::None,
+                granted_role: Some(Role::Control),
+                status: Status::Ok,
+                version: PROTOCOL_VERSION,
+            };
+            sock.write_all(&ext.to_bytes()).unwrap();
+            thread::sleep(RTLX_TEST_SERVER_HOLD);
+            // Consume the server's copy so the test data stays
+            // alive until the thread runs.
+            let _ = expected_key_for_server;
+        });
+
+        let config = RtlTcpConfig {
+            data_read_timeout: RTLX_TEST_DATA_READ_TIMEOUT,
+            max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            // Auth opt-in triggers the hello even without
+            // compression — the `extension_enabled` gate is
+            // `compression != NONE_ONLY OR request_takeover OR
+            // auth_key.is_some()`.
+            compression: CodecMask::NONE_ONLY,
+            request_takeover: false,
+            auth_key: Some(expected_key.clone()),
+        };
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        src.start_manager().unwrap();
+
+        let hello = hello_rx
+            .recv_timeout(RTLX_TEST_STATE_DEADLINE)
+            .expect("server should receive hello within deadline");
+        assert_eq!(&hello[..EXTENSION_MAGIC.len()], &EXTENSION_MAGIC);
+        let flags_byte = hello[6];
+        assert_ne!(
+            flags_byte & sdr_server_rtltcp::extension::FLAG_HAS_AUTH,
+            0,
+            "auth_key = Some(..) must set FLAG_HAS_AUTH bit in the \
+             hello (got flags byte 0x{flags_byte:02x})"
+        );
+        let observed_key = auth_rx
+            .recv_timeout(RTLX_TEST_STATE_DEADLINE)
+            .expect("server should receive auth key within deadline");
+        assert_eq!(
+            observed_key, expected_key,
+            "client must emit the configured key bytes verbatim"
+        );
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_omits_auth_flag_when_no_auth_key_configured() {
+        // Complement to the auth opt-in test: when `auth_key =
+        // None`, the hello's `FLAG_HAS_AUTH` bit must be clear
+        // AND the server must not observe any bytes after the
+        // 8-byte hello (the client sends no AuthKeyMessage).
+        // Protects against a bug that hard-codes the flag or
+        // always emits a key.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (hello_tx, hello_rx) = std::sync::mpsc::channel::<[u8; CLIENT_HELLO_LEN]>();
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel::<std::io::Result<usize>>();
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            sock.set_read_timeout(Some(RTLX_TEST_STATE_DEADLINE))
+                .unwrap();
+            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+            sock.read_exact(&mut hello_buf).expect("read hello");
+            let _ = hello_tx.send(hello_buf);
+            // Probe with a short timeout for any additional
+            // bytes — expect WouldBlock / TimedOut because the
+            // client shouldn't have sent an AuthKeyMessage.
+            sock.set_read_timeout(Some(NO_HELLO_PROBE_TIMEOUT)).unwrap();
+            let mut probe_buf = [0u8; 8];
+            let read_result = sock.read(&mut probe_buf);
+            let _ = probe_tx.send(read_result);
+            sock.set_read_timeout(None).unwrap();
+            let header_out = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: RTLX_TEST_GAIN_COUNT,
+            }
+            .to_bytes();
+            sock.write_all(&header_out).unwrap();
+            let ext = ServerExtension {
+                codec: Codec::Lz4,
+                granted_role: Some(Role::Control),
+                status: Status::Ok,
+                version: PROTOCOL_VERSION,
+            };
+            sock.write_all(&ext.to_bytes()).unwrap();
+            thread::sleep(RTLX_TEST_SERVER_HOLD);
+        });
+
+        // Compression-only opt-in, no auth.
+        let config = RtlTcpConfig {
+            data_read_timeout: RTLX_TEST_DATA_READ_TIMEOUT,
+            max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            compression: CodecMask::NONE_AND_LZ4,
+            request_takeover: false,
+            auth_key: None,
+        };
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        src.start_manager().unwrap();
+
+        let hello = hello_rx
+            .recv_timeout(RTLX_TEST_STATE_DEADLINE)
+            .expect("server should receive hello within deadline");
+        let flags_byte = hello[6];
+        assert_eq!(
+            flags_byte & sdr_server_rtltcp::extension::FLAG_HAS_AUTH,
+            0,
+            "auth_key = None must clear FLAG_HAS_AUTH bit in the hello"
+        );
+
+        // Server probe for follow-up bytes. Must time out — no
+        // AuthKeyMessage means nothing more on the wire before
+        // the server's response.
+        let probe_result = probe_rx
+            .recv_timeout(RTLX_TEST_STATE_DEADLINE)
+            .expect("server probe should resolve within deadline");
+        match probe_result {
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut => {}
+            Ok(0) => {}
+            Ok(n) => panic!(
+                "client with auth_key = None must NOT emit any follow-up bytes, \
+                 but server observed {n} byte(s) after the hello"
+            ),
+            Err(e) => panic!("unexpected server probe error: {e:?}"),
+        }
 
         src.stop_manager();
         let _ = server_thread.join();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3816,6 +3816,11 @@ fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
         buffer_capacity: SERVER_BUFFER_CAPACITY_DEFAULT,
         compression,
         listener_cap: sdr_server_rtltcp::DEFAULT_LISTENER_CAP,
+        // Auth defaults to off (None) — enabling it lives behind
+        // the #395 server UI toggle. #394 ships the wire + server
+        // enforcement plumbing; the UI knob + keyring storage
+        // hooks come in the follow-up sub-issue.
+        auth_key: None,
     }
 }
 

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,19 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 16
+#define SDR_CORE_ABI_VERSION_MINOR 17
 /*
+ * 0.17 — adds `auth_key` (pointer to raw bytes) and
+ * `auth_key_len` (u32) to the tail of `SdrRtlTcpServerConfig`
+ * so FFI hosts can enable pre-shared-key auth (#394) at
+ * server-start time. NULL pointer + zero length means auth
+ * disabled (default); non-null + non-zero length enables the
+ * gate with the provided bytes. Length must be in `1..=256`
+ * (sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN); out-of-
+ * range values are rejected with SDR_CORE_ERR_INVALID_ARG.
+ * Struct layout grows; any 0.16 consumer must fail fast on
+ * the exact-match ABI check (pre-1.0 rule).
+ *
  * 0.16 — TWO struct layouts grow as part of #392 (role gate).
  * Either change alone is ABI-breaking under the pre-1.0 exact-
  * match rule; both land together:
@@ -825,6 +836,21 @@ typedef struct SdrRtlTcpServerConfig {
     bool     initial_bias_tee;
     int32_t  initial_direct_sampling;    /* 0 = off, 1 = I, 2 = Q */
     uint32_t listener_cap;               /* max concurrent Role::Listen clients; 0 = crate default (10); the single Control client is separate */
+    /* Pre-shared auth key bytes (#394). NULL pointer + zero
+     * length = auth disabled (default; LAN-trust model). Non-
+     * null + non-zero length = auth gate active: every
+     * connecting client must present these bytes verbatim in
+     * their `AuthKeyMessage`. Length must be in 1..=256; out-
+     * of-range values are rejected with
+     * SDR_CORE_ERR_INVALID_ARG. Bytes are copied into the
+     * server's owned buffer during `_start` so the caller's
+     * buffer may be freed/reused immediately after the call
+     * returns. LAN-grade trust only — wrap in SSH/WG for
+     * WAN-grade confidentiality. */
+    const uint8_t* auth_key;
+    /* Length in bytes of auth_key. Must be 0 iff auth_key is
+     * NULL. See auth_key for valid range + semantics. */
+    uint32_t auth_key_len;
 } SdrRtlTcpServerConfig;
 
 /*


### PR DESCRIPTION
## Summary

Closes #394 — fourth sub-issue of multi-client epic #390.

Adds an optional pre-shared-key authentication gate to the rtl_tcp server. Disabled by default (LAN-trust model unchanged). When enabled, every connecting client must present a matching `AuthKeyMessage` at handshake — wrong or missing keys are denied and the connection closes. Auth runs BEFORE the #392 role gate (unauthenticated clients aren't even evaluated for role, so the wire response can't leak slot state to an attacker probing without credentials).

## Threat model

**In scope:** casual on-LAN interlopers, shared-living-space cohabitants who see `_rtl_tcp._tcp.local.` on their network, untrusted IoT devices on the same subnet, children's devices that shouldn't be able to seize control mid-session.

**Out of scope:** WAN-grade security. Keys travel cleartext over TCP. Wrap in SSH / WireGuard / Tailscale for real confidentiality. Two layers of defense: transport (SSH/WG) for confidentiality, PSK for opportunistic isolation on trusted LANs.

## Commits

1. **Wire format types** — `FLAG_HAS_AUTH = 1 << 1`, `AuthKeyMessage` (RTKA magic + u16 BE key_len + key bytes), `MAX_AUTH_KEY_LEN = 256`, `AUTH_REPLY_TIMEOUT = 5s`, `ClientHello::has_auth()` helper. 11 round-trip / parse-error tests. Additive — no `PROTOCOL_VERSION` bump (the flag bit + Status variants were reserved in #392).

2. **Auth helpers + `ServerConfig::auth_key: Option<Vec<u8>>`** — new `sdr_server_rtltcp::auth` module with `generate_random_auth_key()` (32 bytes via `OsRng`) and `validate_auth_key()` (constant-time via `subtle::ConstantTimeEq`). New workspace deps: `rand = "0.8"`, `subtle = "2.5"`. 8 unit tests.

3. **Server-side gate in `spawn_client_workers`** — enforces auth before role admission with the four-branch decision matrix:
   - No auth required → skip
   - Auth required + vanilla → bare TCP FIN (vanilla can't carry a key)
   - Auth required + RTLX + has_auth → read `AuthKeyMessage` eagerly, validate, continue on match or deny with `AuthFailed`
   - Auth required + RTLX + !has_auth → emit `AuthRequired` denial + close (client must reconnect with has_auth)
   - No auth required + has_auth → read + discard the key (stream-sync only)
   
   New helper `sniff_auth_key_message(stream)` does the two-phase read (6-byte header then body) with 5s timeout on both phases. 4 loopback-TCP tests cover happy path + bad magic + timeout + fragmented send.

4. **Client-side eager auth** — `RtlTcpConfig::auth_key: Option<Vec<u8>>`. When set, the client flips `FLAG_HAS_AUTH` on the hello AND emits an `AuthKeyMessage` immediately after. Existing `extension_enabled` gate widens to include `|| auth_key.is_some()`. Existing receive-side handling of `Status::AuthRequired` / `Status::AuthFailed` already transitions to `Failed` as Protocol errors (doc comment had explicitly anticipated #394). 2 wire-capture tests verify the flag + follow-up bytes in the opt-in case AND the "no key, nothing follows" complement.

5. **CLI `--auth-key HEX` on sdr-rtl-tcp binary** — hex-encoded key (no base64 alphabet ambiguity, easy to produce with `openssl rand -hex 32`). Rejects empty, odd-length, non-hex, or over-max-length input at argv-parse time. 7 CLI tests.

6. **FFI `SdrRtlTcpServerConfig.auth_key` + `auth_key_len`** — pointer + length pair on the C struct (NULL+0 = disabled). `auth_key_from_c` translation helper with invalid-input rejection (NULL+nonzero, nonzero+zero, over-max) all surface as `SdrCoreError::InvalidArg`. **ABI bump 0.16 → 0.17** (struct grows). 6 pure-function tests + cbindgen drift check clean.

## Wire flow (example)

**Eager path (client has the key, sends it immediately):**
```
client → server: ClientHello { flags: FLAG_HAS_AUTH | ..., ... }
client → server: AuthKeyMessage { key: [..] }
server: validate constant-time. If match:
  server → client: dongle_info_t + ServerExtension { status: Ok, granted_role: Some(Control) }
  [normal IQ stream begins]
server: if mismatch or parse error:
  server → client: dongle_info_t + ServerExtension { status: AuthFailed }
  server: close
```

**Lazy path (client doesn't know server needs auth):**
```
client → server: ClientHello { flags: 0, ... }
server: auth required but has_auth = false:
  server → client: dongle_info_t + ServerExtension { status: AuthRequired }
  server: close
client: manager → Failed(Protocol). UI (future #396) prompts for key, reconnects with has_auth=true + key (eager path).
```

## Test coverage

**Unit tests** (all passing, total 38 new):
- Wire format: 11 (`AuthKeyMessage` round-trip + error paths, flag bit hygiene)
- Auth helpers: 8 (generator + constant-time compare)
- Server enforcement: 4 (`sniff_auth_key_message` happy + bad magic + timeout + fragmented)
- Client-side: 2 (wire-capture of hello + follow-up bytes, both directions)
- CLI: 7 (hex decode matrix)
- FFI translation: 6 (`auth_key_from_c` matrix including the 256-byte boundary)

**Deferred to manual smoke test** (needs real dongle + live auth-enabled server):
- End-to-end: `sdr-rtl-tcp --auth-key <hex>` + client with matching key → connects, bad key → denied, no key → AuthRequired
- Auth-off server + auth-on client → key discarded, connection succeeds

## Smoke-test checklist (Linux, with real RTL-SDR)

When you run the binary:

- [ ] `sdr-rtl-tcp --auth-key $(openssl rand -hex 32)` starts cleanly. Help shows the new flag.
- [ ] sdr-rs client with no key tries to connect → server denies with `AuthRequired`, client shows Failed state.
- [ ] sdr-rs client with wrong key → server denies with `AuthFailed`.
- [ ] sdr-rs client with correct key → connects, streams normally.
- [ ] `sdr-rtl-tcp` without `--auth-key` (auth off) + client that set `auth_key` → server discards the key, connection succeeds.
- [ ] `sdr-rtl-tcp --auth-key <bad-hex>` → argv-parse fails cleanly with a non-zero exit.

## What's NOT in this PR (deferred per issue scope)

- **mDNS TXT `auth_required` advertising** → #395 scope (client UI needs the signal to enable the key field).
- **Server UI**: "Require key" toggle, key display (masked/reveal), regenerate, copy → #395.
- **Client UI**: "Server key" field on connect form, "key required" error toast → #396.
- **Keyring-backed storage** for the server-generated key → UI-driven; lands in #395 alongside the toggle.
- **Base64 encoding** for display → UI presentation layer, #395.

## Remaining multi-client epic #390 sub-issues

- **#395** — server UI (client list + cap + auth toggle + mDNS TXT wiring)
- **#396** — client UI (role picker + takeover button + kicked toast + key field)
- **#397** — FIPS-compliant transport encryption (investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional pre-shared-key authentication for RTL‑TCP: servers can require a client key; clients send an auth payload during handshake. CLI flag to supply a hex auth key; UI/server default remains disabled.

* **Chores**
  * ABI minor version bumped to 0.17.
  * Added secure random key generation and constant-time comparison for auth.

* **Bug Fixes**
  * Early validation and clearer error reporting for malformed or out-of-range auth keys.

* **Tests**
  * Added unit and integration tests for generation, validation, protocol messages, timeouts, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->