### PR TITLE
rtl_tcp server UI: clients list, listener cap, auth toggle (#395)

### DIFF
--- a/crates/sdr-ffi/src/rtltcp_discovery.rs
+++ b/crates/sdr-ffi/src/rtltcp_discovery.rs
@@ -179,6 +179,16 @@ pub unsafe extern "C" fn sdr_rtltcp_advertiser_start(
                 // `codecs` fields so the Swift macOS app can
                 // advertise compression capability.
                 codecs: None,
+                // `auth_required` publishes via the same FFI
+                // extension as `codecs` when the Swift host wires
+                // up its own advertiser config. Today the FFI
+                // advertiser is decoupled from the FFI server
+                // (Swift publishes advertise options separately),
+                // so default to `None` — downstream mDNS browsers
+                // treat absence as "no auth required" per #395's
+                // omit-on-false contract. Issue #400 covers
+                // extending this struct.
+                auth_required: None,
             },
         };
 
@@ -861,6 +871,7 @@ mod tests {
                 },
                 txbuf,
                 codecs: None,
+                auth_required: None,
             },
             last_seen: Instant::now(),
         }

--- a/crates/sdr-rtltcp-discovery/src/lib.rs
+++ b/crates/sdr-rtltcp-discovery/src/lib.rs
@@ -150,6 +150,7 @@ mod tests {
                 nickname: "integration-test-nick".into(),
                 txbuf: None,
                 codecs: None,
+                auth_required: None,
             },
         })
         .expect("announce");

--- a/crates/sdr-rtltcp-discovery/src/txt.rs
+++ b/crates/sdr-rtltcp-discovery/src/txt.rs
@@ -47,6 +47,19 @@ pub struct TxtRecord {
     /// independent of the server crate; the caller converts to /
     /// from `CodecMask` at the boundary.
     pub codecs: Option<u8>,
+
+    /// Whether the server requires pre-shared-key auth (#394).
+    /// `Some(true)` → serialized as `auth_required=true` so clients
+    /// can prompt for a key BEFORE dispatching connect. `None` or
+    /// `Some(false)` → key omitted entirely; clients treat absence
+    /// as "auth not required" (matches the #394 "LAN-only trust
+    /// model continues to work as today" default). Kept as an
+    /// `Option<bool>` rather than `bool` so "unknown" (older
+    /// advertiser didn't publish the field) is distinguishable
+    /// from "explicitly off" at the parser level — both are safe
+    /// to treat as no-auth, but logging can note the difference
+    /// for troubleshooting. Per #395.
+    pub auth_required: Option<bool>,
 }
 
 impl TxtRecord {
@@ -71,6 +84,13 @@ impl TxtRecord {
         }
         if let Some(c) = self.codecs {
             insert_checked(&mut m, "codecs", &c.to_string())?;
+        }
+        // Only emit `auth_required` when explicitly true. `None` and
+        // `Some(false)` both leave the key off the wire — clients
+        // default to "no auth required" on absence, which matches
+        // the pre-#394 deployment behavior. Per #395.
+        if self.auth_required == Some(true) {
+            insert_checked(&mut m, "auth_required", "true")?;
         }
         let total: usize = m.iter().map(|(k, v)| k.len() + v.len() + 2).sum();
         if total > Self::MAX_TOTAL_BYTES {
@@ -98,6 +118,7 @@ impl TxtRecord {
         let mut nickname = String::new();
         let mut txbuf: Option<usize> = None;
         let mut codecs: Option<u8> = None;
+        let mut auth_required: Option<bool> = None;
         for (k, v) in properties {
             match k.as_ref() {
                 "tuner" => tuner = v.as_ref().to_string(),
@@ -106,6 +127,16 @@ impl TxtRecord {
                 "nickname" => nickname = v.as_ref().to_string(),
                 "txbuf" => txbuf = v.as_ref().parse().ok(),
                 "codecs" => codecs = v.as_ref().parse().ok(),
+                // Parse any of the common truthy spellings as `true`.
+                // Anything else (including the literal string "false")
+                // becomes `Some(false)` so the parser round-trips
+                // explicit-false in case a future server wants to
+                // publish it. Absence stays `None`.
+                "auth_required" => {
+                    let raw = v.as_ref();
+                    auth_required =
+                        Some(matches!(raw.to_ascii_lowercase().as_str(), "true" | "1" | "yes"));
+                }
                 _ => {
                     tracing::trace!(
                         key = %k.as_ref(),
@@ -121,6 +152,7 @@ impl TxtRecord {
             nickname,
             txbuf,
             codecs,
+            auth_required,
         }
     }
 }
@@ -163,6 +195,7 @@ mod tests {
             // avoided referencing the server crate here to keep the
             // discovery crate's test independent.
             codecs: Some(0b11),
+            auth_required: None,
         }
     }
 
@@ -208,6 +241,76 @@ mod tests {
         assert_eq!(r.nickname, "");
         assert_eq!(r.txbuf, None);
         assert_eq!(r.codecs, None);
+        assert_eq!(r.auth_required, None);
+    }
+
+    #[test]
+    fn to_properties_emits_auth_required_only_when_true() {
+        // Matches the #395 contract: only `Some(true)` lands on the
+        // wire. `None` and `Some(false)` both omit the key so clients
+        // default to "no auth" on absence (the pre-#394 deployment
+        // behavior).
+        let mut r = sample();
+        r.auth_required = Some(true);
+        let props = r.to_properties().unwrap();
+        assert_eq!(
+            props.get("auth_required").map(String::as_str),
+            Some("true")
+        );
+
+        r.auth_required = Some(false);
+        let props = r.to_properties().unwrap();
+        assert!(!props.contains_key("auth_required"));
+
+        r.auth_required = None;
+        let props = r.to_properties().unwrap();
+        assert!(!props.contains_key("auth_required"));
+    }
+
+    #[test]
+    fn from_properties_parses_auth_required_truthy_spellings() {
+        // Server implementations in other languages may pick
+        // slightly different truthy spellings. Accept "true", "1",
+        // and "yes" (case-insensitive) as `Some(true)`; anything
+        // else becomes `Some(false)` (explicit-false surface for
+        // round-trip of a future `Some(false)` publisher).
+        for raw in ["true", "True", "TRUE", "1", "yes", "YES"] {
+            let r = TxtRecord::from_properties([("auth_required", raw)]);
+            assert_eq!(r.auth_required, Some(true), "failed to parse {raw:?}");
+        }
+        for raw in ["false", "0", "no", "off", "garbage"] {
+            let r = TxtRecord::from_properties([("auth_required", raw)]);
+            assert_eq!(r.auth_required, Some(false), "failed to parse {raw:?}");
+        }
+    }
+
+    #[test]
+    fn auth_required_round_trips_through_wire() {
+        // Pin the emit + parse contract together: a `Some(true)`
+        // record round-trips through `to_properties` →
+        // `from_properties` with value preserved. `None` round-trips
+        // as `None`. `Some(false)` intentionally DOES NOT round-trip
+        // — it serializes as absence, which parses back as `None`.
+        // Document this explicitly so a future refactor that adds
+        // `auth_required=false` emission doesn't silently break the
+        // "absence == unknown, no auth" contract clients rely on.
+        let mut r = sample();
+        r.auth_required = Some(true);
+        let props = r.to_properties().unwrap();
+        let back = TxtRecord::from_properties(props.iter().map(|(k, v)| (k.clone(), v.clone())));
+        assert_eq!(back.auth_required, Some(true));
+
+        r.auth_required = None;
+        let props = r.to_properties().unwrap();
+        let back = TxtRecord::from_properties(props.iter().map(|(k, v)| (k.clone(), v.clone())));
+        assert_eq!(back.auth_required, None);
+
+        r.auth_required = Some(false);
+        let props = r.to_properties().unwrap();
+        let back = TxtRecord::from_properties(props.iter().map(|(k, v)| (k.clone(), v.clone())));
+        // Some(false) → omitted → None on the way back. Intentional;
+        // asserted here so the asymmetry stays documented.
+        assert_eq!(back.auth_required, None);
     }
 
     #[test]

--- a/crates/sdr-rtltcp-discovery/src/txt.rs
+++ b/crates/sdr-rtltcp-discovery/src/txt.rs
@@ -134,8 +134,10 @@ impl TxtRecord {
                 // publish it. Absence stays `None`.
                 "auth_required" => {
                     let raw = v.as_ref();
-                    auth_required =
-                        Some(matches!(raw.to_ascii_lowercase().as_str(), "true" | "1" | "yes"));
+                    auth_required = Some(matches!(
+                        raw.to_ascii_lowercase().as_str(),
+                        "true" | "1" | "yes"
+                    ));
                 }
                 _ => {
                     tracing::trace!(
@@ -253,10 +255,7 @@ mod tests {
         let mut r = sample();
         r.auth_required = Some(true);
         let props = r.to_properties().unwrap();
-        assert_eq!(
-            props.get("auth_required").map(String::as_str),
-            Some("true")
-        );
+        assert_eq!(props.get("auth_required").map(String::as_str), Some("true"));
 
         r.auth_required = Some(false);
         let props = r.to_properties().unwrap();

--- a/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
+++ b/crates/sdr-server-rtltcp/src/bin/sdr-rtl-tcp.rs
@@ -465,6 +465,15 @@ fn announce_over_mdns(
         // so compression-capable clients can decide up-front
         // whether to send an extended hello. #307.
         codecs: Some(server.compression().to_wire()),
+        // CLI surfaces auth via `--auth-key HEX`; advertise
+        // `auth_required=true` iff the server has a key configured
+        // so mDNS browsers can prompt for a key before connecting.
+        // Read from the server (not the raw args) because
+        // `Server::set_auth_key` could in principle flip the state
+        // between the construction here and a future live-update
+        // call; `Server::auth_required()` is the single source of
+        // truth. #394 + #395.
+        auth_required: server.auth_required().then_some(true),
     };
     Advertiser::announce(AdvertiseOptions {
         port: server.bind_address().port(),

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -527,6 +527,18 @@ impl Server {
         self.listener_cap.load(Ordering::Relaxed)
     }
 
+    /// Whether the server currently requires auth. Returns `true`
+    /// iff [`Server::set_auth_key`] has been called with `Some(_)`
+    /// (or the starting `ServerConfig.auth_key` was `Some`). Does
+    /// not leak the key itself — useful for stamping the mDNS TXT
+    /// `auth_required=true` field without handing the caller the
+    /// raw key bytes. Returns `false` on a poisoned mutex because
+    /// an unknown auth state should default to the safer "advertise
+    /// no auth" so clients don't falsely prompt for a key. Per #395.
+    pub fn auth_required(&self) -> bool {
+        self.auth_key.lock().is_ok_and(|g| g.is_some())
+    }
+
     /// Current server statistics.
     ///
     /// Snapshots every connected client plus the cumulative

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -342,6 +342,16 @@ pub struct Server {
     /// mid-handshake `set_auth_key` never splits a single client's
     /// eager-vs-lazy gate across two keys. Per #395.
     auth_key: Arc<Mutex<Option<Vec<u8>>>>,
+    /// Cached "auth is required" flag used by [`Server::auth_required`]
+    /// when the `auth_key` mutex is poisoned. Without this, a poisoned
+    /// mutex would silently advertise "no auth" via mDNS (discovery
+    /// clients would stop prompting for a key) while the handshake
+    /// path and [`Server::set_auth_key`] still treat the poison as
+    /// fatal. The atomic is updated inside [`Server::set_auth_key`]
+    /// on every successful mutation (AFTER the mutex write succeeds)
+    /// and initialized from `ServerConfig.auth_key.is_some()` at
+    /// construction. Per `CodeRabbit` round 1 on PR #406.
+    auth_required_cache: Arc<AtomicBool>,
     /// Snapshot of the `InitialDeviceState` that `apply_initial_state`
     /// actually applied at start. Cloned from `ServerConfig.initial`
     /// and stashed here so `Server::stats()` can include it without
@@ -427,6 +437,10 @@ impl Server {
         // value. Per issue #395: "change takes effect on next accept".
         let listener_cap = Arc::new(AtomicUsize::new(config.listener_cap));
         let auth_key = Arc::new(Mutex::new(config.auth_key.clone()));
+        // Seed the auth-required cache from the starting config.
+        // Kept in lockstep with `auth_key` updates by `set_auth_key`.
+        // Per `CodeRabbit` round 1 on PR #406.
+        let auth_required_cache = Arc::new(AtomicBool::new(config.auth_key.is_some()));
 
         // Broadcaster runs for the server's lifetime regardless of
         // connected-client count. Starting it BEFORE the accept thread
@@ -473,6 +487,7 @@ impl Server {
             compression: config.compression,
             listener_cap,
             auth_key,
+            auth_required_cache,
             initial: config.initial,
         })
     }
@@ -516,7 +531,18 @@ impl Server {
                 "auth_key mutex poisoned — server is in a broken state",
             ))
         })?;
+        let will_be_required = key.is_some();
         *guard = key;
+        // Drop the lock BEFORE the cache store so the cache write
+        // is never ordered-after a still-held mutex observer.
+        drop(guard);
+        // Update the poison-survival cache. Readers of
+        // `auth_required()` fall back to this value when the mutex
+        // is poisoned, so the cache must reflect the latest
+        // successful state change. Per `CodeRabbit` round 1 on
+        // PR #406.
+        self.auth_required_cache
+            .store(will_be_required, Ordering::Relaxed);
         Ok(())
     }
 
@@ -532,11 +558,25 @@ impl Server {
     /// (or the starting `ServerConfig.auth_key` was `Some`). Does
     /// not leak the key itself — useful for stamping the mDNS TXT
     /// `auth_required=true` field without handing the caller the
-    /// raw key bytes. Returns `false` on a poisoned mutex because
-    /// an unknown auth state should default to the safer "advertise
-    /// no auth" so clients don't falsely prompt for a key. Per #395.
+    /// raw key bytes.
+    ///
+    /// Falls back to `auth_required_cache` on a poisoned mutex.
+    /// The handshake path and `set_auth_key` treat poisoning as
+    /// fatal; downgrading the mDNS advertisement to "no auth" in
+    /// the same scenario would make discovery clients stop
+    /// prompting for a key exactly when the server is broken. The
+    /// cache holds the last-known good value so the TXT stays
+    /// honest even after the mutex is unusable. Per `CodeRabbit`
+    /// round 1 on PR #406.
     pub fn auth_required(&self) -> bool {
-        self.auth_key.lock().is_ok_and(|g| g.is_some())
+        if let Ok(g) = self.auth_key.lock() {
+            g.is_some()
+        } else {
+            tracing::warn!(
+                "auth_key mutex poisoned — auth_required() falling back to cached value"
+            );
+            self.auth_required_cache.load(Ordering::Relaxed)
+        }
     }
 
     /// Current server statistics.

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -37,7 +37,7 @@
 
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -328,6 +328,20 @@ pub struct Server {
     bind: SocketAddr,
     tuner: TunerAdvertiseInfo,
     compression: crate::codec::CodecMask,
+    /// Listener cap shared with the accept thread via [`AtomicUsize`]
+    /// so the UI can live-update it via [`Server::set_listener_cap`]
+    /// without restarting the server. Accept path does a
+    /// `Relaxed` load on each admission decision; the atomic's cost
+    /// is negligible relative to the `TcpListener::accept` syscall.
+    /// Per #395.
+    listener_cap: Arc<AtomicUsize>,
+    /// Auth key shared with the accept thread via `Mutex` so the UI
+    /// can live-update it via [`Server::set_auth_key`] without
+    /// restarting the server. The handshake path snapshots the value
+    /// once per connection (cloning the `Option<Vec<u8>>`) so a
+    /// mid-handshake `set_auth_key` never splits a single client's
+    /// eager-vs-lazy gate across two keys. Per #395.
+    auth_key: Arc<Mutex<Option<Vec<u8>>>>,
     /// Snapshot of the `InitialDeviceState` that `apply_initial_state`
     /// actually applied at start. Cloned from `ServerConfig.initial`
     /// and stashed here so `Server::stats()` can include it without
@@ -353,15 +367,7 @@ impl Server {
         // failures — otherwise the server appears to start fine
         // but every client gets rejected. Per `CodeRabbit`
         // round 2 on PR #405.
-        if let Some(key) = &config.auth_key {
-            let max = crate::extension::MAX_AUTH_KEY_LEN;
-            if key.is_empty() || key.len() > max {
-                return Err(ServerError::InvalidAuthKeyLength {
-                    len: key.len(),
-                    max,
-                });
-            }
-        }
+        validate_auth_key_length(config.auth_key.as_deref())?;
 
         // Bind first — surface port-in-use before touching the USB device
         // so we don't leave a dongle claimed after a failed bind.
@@ -413,6 +419,15 @@ impl Server {
             config.buffer_capacity
         };
 
+        // Wrap `listener_cap` and `auth_key` in shared atomics so the
+        // UI can live-update them via `Server::set_listener_cap` /
+        // `Server::set_auth_key` without restarting the server. The
+        // accept thread holds `Arc` clones and re-reads on every
+        // admission so the next-accept-after-change sees the new
+        // value. Per issue #395: "change takes effect on next accept".
+        let listener_cap = Arc::new(AtomicUsize::new(config.listener_cap));
+        let auth_key = Arc::new(Mutex::new(config.auth_key.clone()));
+
         // Broadcaster runs for the server's lifetime regardless of
         // connected-client count. Starting it BEFORE the accept thread
         // means the first client that connects already has a live
@@ -428,8 +443,8 @@ impl Server {
             stopped.clone(),
             per_client_depth,
             config.compression,
-            config.listener_cap,
-            config.auth_key.clone(),
+            listener_cap.clone(),
+            auth_key.clone(),
         ) {
             Ok(h) => h,
             Err(e) => {
@@ -456,8 +471,60 @@ impl Server {
             bind: actual_bind,
             tuner,
             compression: config.compression,
+            listener_cap,
+            auth_key,
             initial: config.initial,
         })
+    }
+
+    /// Replace the listener cap while the server is running. Takes
+    /// effect on the **next accept** — already-connected listeners
+    /// are never kicked, even when the new cap is lower than the
+    /// currently-connected count (surprise disconnection is rude;
+    /// per issue #395). Cheap — single `Relaxed` atomic store. The
+    /// accept thread reads via `Relaxed` load on each admission.
+    pub fn set_listener_cap(&self, cap: usize) {
+        self.listener_cap.store(cap, Ordering::Relaxed);
+    }
+
+    /// Replace the auth key while the server is running. Takes
+    /// effect on the **next accept** — already-authenticated clients
+    /// keep their sessions (auth runs once per handshake, not
+    /// per-message). Useful for the #395 "Regenerate" button: the
+    /// old key stops working for future reconnects without
+    /// disturbing anyone currently streaming.
+    ///
+    /// Validates length up-front (same rule as [`Server::start`]):
+    /// `Some(key)` must have `1..=MAX_AUTH_KEY_LEN` bytes. Rejects
+    /// empty / oversize inputs with [`ServerError::InvalidAuthKeyLength`]
+    /// — the live-update surface cannot silently accept a config
+    /// value that `Server::start` itself would have refused.
+    ///
+    /// `None` disables the auth gate entirely (matches the
+    /// "Require key" switch flipping off in the #395 UI).
+    ///
+    /// Poisoned mutex surfaces as
+    /// [`ServerError::Io(ErrorKind::Other)`] — the only way the
+    /// mutex gets poisoned is if a prior auth-gate panic left it
+    /// locked, which should be unreachable in practice; the server
+    /// is effectively broken at that point and the UI should
+    /// surface the error so the operator can restart it.
+    pub fn set_auth_key(&self, key: Option<Vec<u8>>) -> Result<(), ServerError> {
+        validate_auth_key_length(key.as_deref())?;
+        let mut guard = self.auth_key.lock().map_err(|_| {
+            ServerError::Io(std::io::Error::other(
+                "auth_key mutex poisoned — server is in a broken state",
+            ))
+        })?;
+        *guard = key;
+        Ok(())
+    }
+
+    /// Current listener cap. Reflects the most recent
+    /// [`Server::set_listener_cap`] call, or the starting
+    /// `ServerConfig.listener_cap` if never changed.
+    pub fn listener_cap(&self) -> usize {
+        self.listener_cap.load(Ordering::Relaxed)
     }
 
     /// Current server statistics.
@@ -602,6 +669,27 @@ impl Drop for Server {
     }
 }
 
+/// Shared validation for `ServerConfig.auth_key` /
+/// `Server::set_auth_key` inputs: `None` is always fine; `Some(key)`
+/// must have `1..=MAX_AUTH_KEY_LEN` bytes. Empty or oversize Vecs
+/// return [`ServerError::InvalidAuthKeyLength`] with the out-of-range
+/// len so the caller's error message can name the exact failure.
+/// Centralized here so `Server::start` and `Server::set_auth_key`
+/// enforce the same contract — the live-update path cannot silently
+/// accept inputs that the construction path would refuse. Per #395.
+fn validate_auth_key_length(key: Option<&[u8]>) -> Result<(), ServerError> {
+    if let Some(bytes) = key {
+        let max = crate::extension::MAX_AUTH_KEY_LEN;
+        if bytes.is_empty() || bytes.len() > max {
+            return Err(ServerError::InvalidAuthKeyLength {
+                len: bytes.len(),
+                max,
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Apply the user's initial settings to the freshly-opened device.
 ///
 /// Mirrors the setup block in rtl_tcp.c:490-520. Called once at
@@ -681,8 +769,8 @@ fn spawn_accept_thread(
     stopped: Arc<AtomicBool>,
     per_client_buffer_depth: usize,
     compression: CodecMask,
-    listener_cap: usize,
-    auth_key: Option<Vec<u8>>,
+    listener_cap: Arc<AtomicUsize>,
+    auth_key: Arc<Mutex<Option<Vec<u8>>>>,
 ) -> std::io::Result<JoinHandle<()>> {
     listener.set_nonblocking(true)?;
     thread::Builder::new()
@@ -719,6 +807,17 @@ fn spawn_accept_thread(
                         let setup_device = device.clone();
                         let setup_registry = registry.clone();
                         let setup_shutdown = shutdown.clone();
+                        // Snapshot the live listener cap + auth key
+                        // Arcs into this accept's setup thread. Both
+                        // are `Arc` clones (cheap), so a mid-handshake
+                        // `set_*` call is visible to future accepts
+                        // but does not split the current client's
+                        // gate across two values (the setup thread
+                        // reads the cap once at role-admission, and
+                        // snapshots the auth key once at the top of
+                        // `spawn_client_workers`). Per issue #395
+                        // live-update design.
+                        let setup_listener_cap = listener_cap.clone();
                         let setup_auth_key = auth_key.clone();
                         let setup_registry_for_register = registry.clone();
                         match thread::Builder::new()
@@ -732,7 +831,7 @@ fn spawn_accept_thread(
                                     setup_shutdown,
                                     per_client_buffer_depth,
                                     compression,
-                                    listener_cap,
+                                    setup_listener_cap,
                                     setup_auth_key,
                                 );
                             }) {
@@ -811,9 +910,27 @@ fn spawn_client_workers(
     shutdown: Arc<AtomicBool>,
     per_client_buffer_depth: usize,
     compression_offer: CodecMask,
-    listener_cap: usize,
-    auth_key: Option<Vec<u8>>,
+    listener_cap: Arc<AtomicUsize>,
+    auth_key: Arc<Mutex<Option<Vec<u8>>>>,
 ) {
+    // Snapshot the live-update auth key once at the top of the
+    // handshake. Reading the `Arc<Mutex>` on every gate branch
+    // would risk a mid-handshake `Server::set_auth_key` call
+    // splitting the client's eager path (key bytes already on
+    // the wire against the old expected value) vs the lazy-gate
+    // follow-up (validated against the new value). Snapshot
+    // semantics keep each connection bound to a single key view.
+    // Per issue #395 live-update design.
+    let auth_key: Option<Vec<u8>> = if let Ok(guard) = auth_key.lock() {
+        guard.clone()
+    } else {
+        tracing::error!(
+            %peer,
+            "auth_key mutex poisoned during handshake — dropping client"
+        );
+        return;
+    };
+
     // Extended handshake (#307) — sniff the RTLX hello if the
     // client sent one. The outcome drives both codec negotiation
     // and the role request that feeds the #392 admission gate.
@@ -1061,7 +1178,12 @@ fn spawn_client_workers(
     // slot is never pushed and drops on scope exit. Takeover also
     // marks the displaced controller disconnected under the same
     // lock so its writer / command threads exit cleanly.
-    let decision = registry.register_with_role(slot.clone(), listener_cap, request_takeover);
+    //
+    // Read the listener cap from the live-update Arc ONCE here so
+    // a mid-decision `Server::set_listener_cap` call doesn't split
+    // the "is there room?" check across two values. Per issue #395.
+    let cap = listener_cap.load(Ordering::Relaxed);
+    let decision = registry.register_with_role(slot.clone(), cap, request_takeover);
     match decision {
         RoleDecision::Granted => {
             tracing::info!(
@@ -1117,7 +1239,7 @@ fn spawn_client_workers(
             tracing::info!(
                 %peer,
                 ?requested_role,
-                cap = listener_cap,
+                cap = cap,
                 "rtl_tcp listener cap reached — denying client"
             );
             // Vanilla clients never land here — they always request
@@ -2602,6 +2724,57 @@ mod tests {
             }
             Err(e) => panic!("expected InvalidAuthKeyLength, got {e:?}"),
             Ok(_) => panic!("oversize auth_key must not start a server"),
+        }
+    }
+
+    #[test]
+    fn validate_auth_key_length_accepts_none() {
+        // None disables the auth gate entirely — always valid.
+        // Per the #395 live-update shared-validation contract.
+        validate_auth_key_length(None).unwrap();
+    }
+
+    #[test]
+    fn validate_auth_key_length_accepts_boundary_sizes() {
+        // 1 byte = minimum non-empty key, `MAX_AUTH_KEY_LEN` = 256 =
+        // maximum that the wire format (`AuthKeyMessage::to_bytes`)
+        // can serialize. Both boundaries must pass — the `1..=max`
+        // range is inclusive on both ends.
+        validate_auth_key_length(Some(&[0u8; 1])).unwrap();
+        validate_auth_key_length(Some(&[0u8; crate::extension::MAX_AUTH_KEY_LEN])).unwrap();
+    }
+
+    #[test]
+    fn validate_auth_key_length_rejects_empty() {
+        // `Some(vec![])` bypasses every upstream guard (FFI, CLI,
+        // wire-format) but would silently match an `expected` of
+        // the same length at handshake time. `validate_auth_key`
+        // already guards the match, but defense-in-depth: catch
+        // at construction / set time too. Pinned separately from
+        // `Server::start` + `Server::set_auth_key` so the helper's
+        // contract is a first-class regression surface independent
+        // of the callers.
+        match validate_auth_key_length(Some(&[])) {
+            Err(ServerError::InvalidAuthKeyLength { len, max }) => {
+                assert_eq!(len, 0);
+                assert_eq!(max, crate::extension::MAX_AUTH_KEY_LEN);
+            }
+            other => panic!("expected InvalidAuthKeyLength, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_auth_key_length_rejects_oversize() {
+        // `MAX_AUTH_KEY_LEN + 1` = smallest oversize. Serialization
+        // via `AuthKeyMessage::to_bytes` would fail every handshake;
+        // catch at config time.
+        let oversize = vec![0u8; crate::extension::MAX_AUTH_KEY_LEN + 1];
+        match validate_auth_key_length(Some(&oversize)) {
+            Err(ServerError::InvalidAuthKeyLength { len, max }) => {
+                assert_eq!(len, crate::extension::MAX_AUTH_KEY_LEN + 1);
+                assert_eq!(max, crate::extension::MAX_AUTH_KEY_LEN);
+            }
+            other => panic!("expected InvalidAuthKeyLength, got {other:?}"),
         }
     }
 

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -47,6 +47,11 @@ const KEY_SERVER_DEFAULT_DIRECT_SAMPLING: &str = "rtl_tcp_server_default_direct_
 /// index so a future addition (e.g. Zstd) doesn't invalidate old
 /// configs — unknown indices fall back to `Off` on restore.
 const KEY_SERVER_COMPRESSION_IDX: &str = "rtl_tcp_server_compression_idx";
+/// Config key for the persisted listener cap (max `Role::Listen`
+/// clients). See [`MIN_LISTENER_CAP`] / [`MAX_LISTENER_CAP`] for
+/// the allowed range and [`sdr_server_rtltcp::DEFAULT_LISTENER_CAP`]
+/// for the default. Per issue #395.
+const KEY_SERVER_LISTENER_CAP: &str = "rtl_tcp_server_listener_cap";
 
 /// Default TCP port for `rtl_tcp`. Matches upstream `rtl_tcp.c` and
 /// every ecosystem client's default. Changing it means users have to
@@ -63,6 +68,22 @@ pub const MAX_SERVER_PORT: f64 = 65_535.0;
 const SERVER_PORT_STEP: f64 = 1.0;
 /// Spin-row page step (`PgUp` / `PgDn`) for the port field.
 const SERVER_PORT_PAGE: f64 = 100.0;
+
+/// Minimum listener-cap value. 0 is legal — it means
+/// "control-only; no listeners allowed" (the user explicitly
+/// blocks any `Role::Listen` client). Per issue #395.
+pub const MIN_LISTENER_CAP: f64 = 0.0;
+/// Maximum listener-cap value the UI lets the user pick. 32 is the
+/// soft cap from issue #395 — above that a single dongle's IQ
+/// bandwidth starts showing measurable fan-out overhead, and the
+/// `ClientSlot` / `ClientRegistry` structs aren't optimized for
+/// hundreds of live clients either. Backend accepts larger values
+/// via direct library calls; the UI just doesn't expose them.
+pub const MAX_LISTENER_CAP: f64 = 32.0;
+/// Spin-row per-click step for the listener-cap row.
+const LISTENER_CAP_STEP: f64 = 1.0;
+/// Spin-row page step (`PgUp` / `PgDn`) for the listener-cap row.
+const LISTENER_CAP_PAGE: f64 = 5.0;
 
 /// Bind-address selector index: loopback-only (127.0.0.1). The
 /// default — limits exposure to clients running on the same machine
@@ -200,6 +221,13 @@ pub struct ServerPanel {
     /// clients and our own `NONE_ONLY` clients still get uncompressed
     /// via the mutual-codec intersection. See #307.
     pub compression_row: adw::ComboRow,
+    /// Listener cap — maximum concurrent `Role::Listen` clients.
+    /// 0 = "control only — no listeners allowed". Changes take
+    /// effect on the next accept via
+    /// [`sdr_server_rtltcp::Server::set_listener_cap`]; existing
+    /// listeners are never kicked when the cap is lowered
+    /// (surprise disconnection is rude, per #395).
+    pub listener_cap_row: adw::SpinRow,
     /// Collapsible group of device-defaults (freq / sample rate /
     /// gain / PPM / bias tee / direct sampling) applied on server
     /// start. Clients override these live via the `rtl_tcp` command
@@ -535,6 +563,37 @@ pub fn build_server_panel() -> ServerPanel {
         .selected(COMPRESSION_OFF_IDX)
         .build();
 
+    // Listener cap — per #395. Default pulled from the backend's
+    // `DEFAULT_LISTENER_CAP` so a UI-backend drift would surface as
+    // a test / build failure rather than a quiet divergence. The
+    // `usize` → `f64` cast is lossless on every realistic value
+    // (cap is always < 32, and f64 is exact for integers up to
+    // `2^53`), but clippy's `cast_precision_loss` lint fires on
+    // any `usize as f64` conversion regardless — allow inline
+    // with a reason rather than adding a workspace-wide exception.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "listener cap is bounded << 2^53, f64 represents it exactly"
+    )]
+    let default_cap = sdr_server_rtltcp::DEFAULT_LISTENER_CAP as f64;
+    let listener_cap_adj = gtk4::Adjustment::new(
+        default_cap,
+        MIN_LISTENER_CAP,
+        MAX_LISTENER_CAP,
+        LISTENER_CAP_STEP,
+        LISTENER_CAP_PAGE,
+        0.0,
+    );
+    let listener_cap_row = adw::SpinRow::builder()
+        .title("Listener cap")
+        .subtitle(
+            "Max simultaneous Listen clients — 0 disables listeners, change applies on next client",
+        )
+        .adjustment(&listener_cap_adj)
+        .numeric(true)
+        .snap_to_ticks(true)
+        .build();
+
     let device_defaults_row = adw::ExpanderRow::builder()
         .title("Device defaults")
         .subtitle("Applied when the server opens the dongle — clients override live")
@@ -585,6 +644,7 @@ pub fn build_server_panel() -> ServerPanel {
     widget.add(&bind_row);
     widget.add(&advertise_row);
     widget.add(&compression_row);
+    widget.add(&listener_cap_row);
     widget.add(&device_defaults_row);
     widget.add(&status_row);
     widget.add(&activity_log_row);
@@ -598,6 +658,7 @@ pub fn build_server_panel() -> ServerPanel {
         bind_row,
         advertise_row,
         compression_row,
+        listener_cap_row,
         device_defaults_row,
         center_freq_row,
         sample_rate_row,
@@ -737,6 +798,19 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
             // a corrupt config can't silently enable compression.
             panel.compression_row.set_selected(idx_u32);
         }
+        if let Some(cap) = v
+            .get(KEY_SERVER_LISTENER_CAP)
+            .and_then(serde_json::Value::as_u64)
+        {
+            // Clamp to the UI's advertised range on restore. An
+            // out-of-range stored value would have been saved by
+            // some other client talking to the same config file
+            // (e.g. `sdr-rtl-tcp --listener-cap 999`); the widget
+            // still needs to be a valid spin-row value so pin it
+            // into [MIN_LISTENER_CAP, MAX_LISTENER_CAP]. Per #395.
+            let clamped = (cap as f64).clamp(MIN_LISTENER_CAP, MAX_LISTENER_CAP);
+            panel.listener_cap_row.set_value(clamped);
+        }
     });
 
     // ---- Phase 2: subscribe ----
@@ -853,5 +927,22 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
                 v[KEY_SERVER_COMPRESSION_IDX] = serde_json::json!(selected);
             });
         }
+    });
+    // Listener cap spin row. Persist on every change so the next
+    // session restores the same cap. Applying the new value to a
+    // running server (`Server::set_listener_cap`) is wired
+    // separately in `window.rs` where the live `Server` handle
+    // lives. Per #395.
+    let cfg_cap = Arc::clone(config);
+    panel.listener_cap_row.connect_value_notify(move |row| {
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "spin row bounded to [MIN_LISTENER_CAP, MAX_LISTENER_CAP] at the widget level"
+        )]
+        let cap = row.value() as u64;
+        cfg_cap.write(|v| {
+            v[KEY_SERVER_LISTENER_CAP] = serde_json::json!(cap);
+        });
     });
 }

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -125,13 +125,27 @@ pub fn auth_key_to_hex(bytes: &[u8]) -> String {
 }
 
 /// Decode a lowercase-hex auth-key string back into raw bytes.
-/// Strict validation: rejects odd-length, non-ASCII, and non-hex
-/// input. Returns `None` for any malformed input; callers treat
-/// that as "keyring value is corrupt, regenerate on next
-/// toggle-on". Per issue #395.
+/// Strict validation: rejects odd-length, non-ASCII, non-hex
+/// input, AND decoded lengths outside
+/// `1..=sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN`. Returns
+/// `None` for any malformed input; callers treat that as "keyring
+/// value is corrupt, regenerate on next toggle-on" rather than
+/// letting an oversize payload reach `Server::start` and fail
+/// every client at handshake. Per issue #395 + `CodeRabbit`
+/// round 1 on PR #406.
 pub fn auth_key_from_hex(s: &str) -> Option<Vec<u8>> {
     const HEX_CHARS_PER_BYTE: usize = 2;
-    if s.is_empty() || !s.is_ascii() || !s.len().is_multiple_of(HEX_CHARS_PER_BYTE) {
+    /// Hex-encoded cap matching the backend's byte cap — two
+    /// hex chars per byte. A hex string longer than this cannot
+    /// decode to a valid auth key, so reject before we bother
+    /// allocating.
+    const MAX_HEX_CHARS: usize =
+        sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN * HEX_CHARS_PER_BYTE;
+    if s.is_empty()
+        || !s.is_ascii()
+        || !s.len().is_multiple_of(HEX_CHARS_PER_BYTE)
+        || s.len() > MAX_HEX_CHARS
+    {
         return None;
     }
     let mut out = Vec::with_capacity(s.len() / HEX_CHARS_PER_BYTE);
@@ -770,18 +784,29 @@ pub fn build_server_panel() -> ServerPanel {
         .valign(gtk4::Align::Center)
         .css_classes(["flat"])
         .build();
+    // Icon-only buttons need an explicit accessible label —
+    // screen readers read the label, not the tooltip. The reveal
+    // button's label flips in `window.rs` alongside icon_name when
+    // toggled. Matches the established pattern in this crate
+    // (source_panel, navigation_panel, radio_panel). Per
+    // `CodeRabbit` round 1 on PR #406.
+    auth_key_reveal_button.update_property(&[gtk4::accessible::Property::Label("Reveal key")]);
     let auth_key_copy_button = gtk4::Button::builder()
         .icon_name("edit-copy-symbolic")
         .tooltip_text("Copy key to clipboard")
         .valign(gtk4::Align::Center)
         .css_classes(["flat"])
         .build();
+    auth_key_copy_button
+        .update_property(&[gtk4::accessible::Property::Label("Copy key to clipboard")]);
     let auth_key_regenerate_button = gtk4::Button::builder()
         .icon_name("view-refresh-symbolic")
         .tooltip_text("Regenerate key — old key stops working for future reconnects")
         .valign(gtk4::Align::Center)
         .css_classes(["flat"])
         .build();
+    auth_key_regenerate_button
+        .update_property(&[gtk4::accessible::Property::Label("Regenerate key")]);
     auth_key_row.add_suffix(&auth_key_reveal_button);
     auth_key_row.add_suffix(&auth_key_copy_button);
     auth_key_row.add_suffix(&auth_key_regenerate_button);
@@ -1206,6 +1231,28 @@ mod tests {
         assert!(auth_key_from_hex("abc").is_none(), "odd length");
         assert!(auth_key_from_hex("xyz0").is_none(), "non-hex chars");
         assert!(auth_key_from_hex("💩💩").is_none(), "non-ASCII emoji");
+    }
+
+    #[test]
+    fn auth_key_from_hex_rejects_oversize_decoded_length() {
+        // Hex string encoding more than `MAX_AUTH_KEY_LEN`
+        // bytes must be rejected up-front so a corrupt
+        // keyring entry surfaces as "regenerate" rather than
+        // reaching `Server::start` and failing every client
+        // at handshake. Per `CodeRabbit` round 1 on PR #406.
+        let max_bytes = sdr_server_rtltcp::extension::MAX_AUTH_KEY_LEN;
+        // Exactly at cap: must decode.
+        let at_cap = "a".repeat(max_bytes * 2);
+        assert!(
+            auth_key_from_hex(&at_cap).is_some(),
+            "max-length hex must decode"
+        );
+        // One byte over cap: must reject.
+        let over_cap = "a".repeat((max_bytes + 1) * 2);
+        assert!(
+            auth_key_from_hex(&over_cap).is_none(),
+            "oversize hex must be rejected"
+        );
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -370,6 +370,18 @@ pub struct ServerPanel {
     /// expander so the stats poller can rebuild it on updates
     /// without walking the expander's `AdwActionRow` children.
     pub activity_log_list: gtk4::ListBox,
+    /// Collapsible "Connected clients" expander listing every
+    /// connected client with role badge, duration, and drop
+    /// counter. Sibling to `status_row` (which still shows
+    /// aggregate "most-recent commander" + data rate state).
+    /// Hidden while the server isn't running. Per issue #395.
+    pub clients_row: adw::ExpanderRow,
+    /// `ListBox` child of `clients_row`, one row per connected
+    /// client. Rebuilt from scratch on each stats-poll tick when
+    /// the client-id set has changed. Held separately from the
+    /// expander so the poller doesn't have to walk the expander's
+    /// children. Per issue #395.
+    pub clients_list: gtk4::ListBox,
     /// Advisory caption shown when the device-default sample rate
     /// is at or above the "high bandwidth" threshold. Shared copy
     /// with the source panel's same-named row so the user sees a
@@ -398,6 +410,18 @@ pub const ACTIVITY_LOG_EMPTY_SUBTITLE: &str = "No commands received yet";
 /// without dominating it; the expander is collapsed by default so
 /// users opt in to seeing the log at all.
 const ACTIVITY_LOG_MAX_HEIGHT_PX: i32 = 240;
+
+/// Subtitle shown on the `clients_row` expander header when no
+/// clients are connected. Doubles as the placeholder text inside
+/// the list itself. Per issue #395.
+pub const CLIENTS_LIST_EMPTY_SUBTITLE: &str = "No clients connected";
+
+/// Max height the connected-clients `ScrolledWindow` grows
+/// before scrolling kicks in. Same tuning rationale as
+/// `ACTIVITY_LOG_MAX_HEIGHT_PX`: fits inside the sidebar without
+/// dominating it even when the listener cap is at max (32
+/// clients × ~45 px per row ≈ 1,440 px uncapped; we cap at 240).
+const CLIENTS_LIST_MAX_HEIGHT_PX: i32 = 240;
 
 /// Aggregated status rows rendered under the "Server status"
 /// expander. Grouped so the builder stays readable and the
@@ -439,6 +463,33 @@ fn build_activity_log_row() -> (adw::ExpanderRow, gtk4::ListBox) {
     // Wrap the scroll in an ActionRow so the expander's layout
     // machinery (which expects rows) renders it correctly. Empty
     // title/subtitle pushes the scroll widget into the row body.
+    let wrapper = adw::ActionRow::builder().activatable(false).build();
+    wrapper.add_prefix(&scroll);
+    row.add_row(&wrapper);
+    (row, list)
+}
+
+/// Build the "Connected clients" expander + its inner `ListBox`.
+/// Mirrors `build_activity_log_row`'s scroll-wrapping pattern
+/// so a server with a dozen listeners doesn't balloon the
+/// sidebar height. Per issue #395.
+fn build_clients_row() -> (adw::ExpanderRow, gtk4::ListBox) {
+    let row = adw::ExpanderRow::builder()
+        .title("Connected clients")
+        .subtitle(CLIENTS_LIST_EMPTY_SUBTITLE)
+        .expanded(true)
+        .visible(false)
+        .build();
+    let list = gtk4::ListBox::builder()
+        .selection_mode(gtk4::SelectionMode::None)
+        .css_classes(["boxed-list"])
+        .build();
+    let scroll = gtk4::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .propagate_natural_height(true)
+        .max_content_height(CLIENTS_LIST_MAX_HEIGHT_PX)
+        .child(&list)
+        .build();
     let wrapper = adw::ActionRow::builder().activatable(false).build();
     wrapper.add_prefix(&scroll);
     row.add_row(&wrapper);
@@ -766,6 +817,7 @@ pub fn build_server_panel() -> ServerPanel {
     } = build_status_rows();
 
     let (activity_log_row, activity_log_list) = build_activity_log_row();
+    let (clients_row, clients_list) = build_clients_row();
 
     // Bandwidth advisory — hidden initially. Visibility is toggled
     // on sample-rate changes via the wiring in window.rs, mirroring
@@ -790,6 +842,7 @@ pub fn build_server_panel() -> ServerPanel {
     widget.add(&auth_key_row);
     widget.add(&device_defaults_row);
     widget.add(&status_row);
+    widget.add(&clients_row);
     widget.add(&activity_log_row);
     widget.add(&bandwidth_advisory_row);
 
@@ -822,6 +875,8 @@ pub fn build_server_panel() -> ServerPanel {
         status_stop_button,
         activity_log_row,
         activity_log_list,
+        clients_row,
+        clients_list,
         bandwidth_advisory_row,
     }
 }
@@ -1132,7 +1187,8 @@ mod tests {
         let hex = auth_key_to_hex(&bytes);
         assert_eq!(hex.len(), bytes.len() * 2);
         assert!(
-            hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            hex.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
             "encoder must emit lowercase hex only"
         );
         let back = auth_key_from_hex(&hex).expect("round-trip decode must succeed");

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -52,6 +52,23 @@ const KEY_SERVER_COMPRESSION_IDX: &str = "rtl_tcp_server_compression_idx";
 /// the allowed range and [`sdr_server_rtltcp::DEFAULT_LISTENER_CAP`]
 /// for the default. Per issue #395.
 const KEY_SERVER_LISTENER_CAP: &str = "rtl_tcp_server_listener_cap";
+/// Config key for the "Require key" switch state (bool). The key
+/// bytes themselves live in the OS keyring under
+/// [`KEYRING_KEY_AUTH_KEY`] — `sdr_config` is plaintext JSON,
+/// which is the wrong place for secret bytes. Per issue #395.
+const KEY_SERVER_REQUIRE_AUTH: &str = "rtl_tcp_server_require_auth";
+
+/// Keyring service name for all `sdr-rs` secrets. Matches the value
+/// used in `preferences::accounts_page` so both `RadioReference`
+/// and `rtl_tcp` auth-key entries show up under the same service
+/// heading in `seahorse` / `Keychain Access`.
+pub const KEYRING_SERVICE: &str = "sdr-rs";
+/// Keyring entry name holding the `rtl_tcp` pre-shared auth key.
+/// Stored as a lowercase-hex string so it round-trips through
+/// keyring's `String` API without custom base64/UTF-8 coercion
+/// — `rand::OsRng`-backed keys are arbitrary bytes, not text.
+/// Per issue #395.
+pub const KEYRING_KEY_AUTH_KEY: &str = "rtl_tcp-server-auth-key";
 
 /// Default TCP port for `rtl_tcp`. Matches upstream `rtl_tcp.c` and
 /// every ecosystem client's default. Changing it means users have to
@@ -84,6 +101,52 @@ pub const MAX_LISTENER_CAP: f64 = 32.0;
 const LISTENER_CAP_STEP: f64 = 1.0;
 /// Spin-row page step (`PgUp` / `PgDn`) for the listener-cap row.
 const LISTENER_CAP_PAGE: f64 = 5.0;
+
+/// Subtitle shown on `auth_key_row` when the key is masked
+/// (default state). Fixed-length run of bullet chars — doesn't
+/// leak key length and renders at the same width as a plausible
+/// revealed value so the row height doesn't jump when the user
+/// toggles reveal. Per issue #395.
+pub const AUTH_KEY_MASKED_PLACEHOLDER: &str = "••••••••••••••••••••••••••••••••";
+
+/// Encode an auth-key byte slice as lowercase hex for keyring
+/// storage and clipboard copy. Pre-sized allocation (two hex
+/// chars per input byte) keeps the hot "toggle reveal" UI path
+/// allocation-free after the initial key load. Per issue #395.
+pub fn auth_key_to_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // write! on String is infallible; _ lets us ignore the
+        // Result without burdening callers with unwrap_or_else.
+        let _ = write!(&mut s, "{b:02x}");
+    }
+    s
+}
+
+/// Decode a lowercase-hex auth-key string back into raw bytes.
+/// Strict validation: rejects odd-length, non-ASCII, and non-hex
+/// input. Returns `None` for any malformed input; callers treat
+/// that as "keyring value is corrupt, regenerate on next
+/// toggle-on". Per issue #395.
+pub fn auth_key_from_hex(s: &str) -> Option<Vec<u8>> {
+    const HEX_CHARS_PER_BYTE: usize = 2;
+    if s.is_empty() || !s.is_ascii() || !s.len().is_multiple_of(HEX_CHARS_PER_BYTE) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(s.len() / HEX_CHARS_PER_BYTE);
+    for chunk in s.as_bytes().chunks_exact(HEX_CHARS_PER_BYTE) {
+        let hi = char::from(chunk[0]).to_digit(16)?;
+        let lo = char::from(chunk[1]).to_digit(16)?;
+        // `hi` and `lo` are each 0..=15 (validated by `to_digit(16)`),
+        // so `(hi << 4) | lo` fits in u8 with the top 24 bits zero —
+        // `u8::try_from` is infallible here but keeps clippy's
+        // `cast_possible_truncation` quiet.
+        let byte = u8::try_from((hi << 4) | lo).ok()?;
+        out.push(byte);
+    }
+    Some(out)
+}
 
 /// Bind-address selector index: loopback-only (127.0.0.1). The
 /// default — limits exposure to clients running on the same machine
@@ -228,6 +291,36 @@ pub struct ServerPanel {
     /// listeners are never kicked when the cap is lowered
     /// (surprise disconnection is rude, per #395).
     pub listener_cap_row: adw::SpinRow,
+    /// "Require key" master switch. When on, the server generates
+    /// (or reloads) a 32-byte pre-shared key and enforces it on
+    /// every connecting client via the #394 auth gate. When off,
+    /// the server reverts to the pre-#394 open-LAN posture. The
+    /// keyring entry persists across toggle-off/on cycles so
+    /// flipping back doesn't regenerate the key. Per issue #395.
+    pub auth_require_row: adw::SwitchRow,
+    /// Auth-key display row — hidden when `auth_require_row` is
+    /// off. When on, shows the current key in either masked
+    /// (default) or revealed form. Three suffix buttons: reveal
+    /// toggle, copy-to-clipboard, regenerate. Wiring lives in
+    /// `window.rs` where the running `Server` handle is available
+    /// for live `set_auth_key` calls. Per issue #395.
+    pub auth_key_row: adw::ActionRow,
+    /// Reveal/hide toggle. Icon flips between
+    /// `view-conceal-symbolic` (currently visible → click to hide)
+    /// and `view-reveal-symbolic` (currently masked → click to
+    /// reveal). Caller tracks the on/off state.
+    pub auth_key_reveal_button: gtk4::Button,
+    /// Copy-to-clipboard button. Always copies the FULL hex key
+    /// regardless of whether the display is revealed — users
+    /// typically click Copy without clicking Reveal first.
+    pub auth_key_copy_button: gtk4::Button,
+    /// Regenerate button. Replaces the stored key with a new
+    /// `sdr_server_rtltcp::auth::generate_random_auth_key()`
+    /// result, saves to keyring, and calls
+    /// `Server::set_auth_key` on the running server so the old
+    /// key stops working for future reconnects without kicking
+    /// already-authenticated clients.
+    pub auth_key_regenerate_button: gtk4::Button,
     /// Collapsible group of device-defaults (freq / sample rate /
     /// gain / PPM / bias tee / direct sampling) applied on server
     /// start. Clients override these live via the `rtl_tcp` command
@@ -594,6 +687,54 @@ pub fn build_server_panel() -> ServerPanel {
         .snap_to_ticks(true)
         .build();
 
+    // Auth-key controls (#394/#395). Three widgets: master
+    // "Require key" switch, a key-display row that only shows
+    // when auth is on, and three suffix buttons for
+    // reveal / copy / regenerate. State (current key bytes,
+    // currently-revealed flag) lives in `window.rs` where the
+    // running `Server` + keyring store are accessible.
+    let auth_require_row = adw::SwitchRow::builder()
+        .title("Require key")
+        .subtitle("Clients must present a pre-shared key to connect — LAN-grade only, not WAN-safe")
+        .active(false)
+        .build();
+
+    // Auth-key display row — hidden until `auth_require_row` is
+    // on. `subtitle_selectable(true)` lets users triple-click the
+    // revealed key to copy it without using the Copy button.
+    let auth_key_row = adw::ActionRow::builder()
+        .title("Key")
+        .subtitle(AUTH_KEY_MASKED_PLACEHOLDER)
+        .subtitle_selectable(true)
+        .visible(false)
+        .build();
+
+    // Reveal-toggle button. Icon starts as `view-reveal-symbolic`
+    // (masked → click to reveal); window.rs flips it to
+    // `view-conceal-symbolic` when the subtitle shows the real
+    // key. `.flat()` keeps it visually aligned with the row.
+    let auth_key_reveal_button = gtk4::Button::builder()
+        .icon_name("view-reveal-symbolic")
+        .tooltip_text("Reveal key")
+        .valign(gtk4::Align::Center)
+        .css_classes(["flat"])
+        .build();
+    let auth_key_copy_button = gtk4::Button::builder()
+        .icon_name("edit-copy-symbolic")
+        .tooltip_text("Copy key to clipboard")
+        .valign(gtk4::Align::Center)
+        .css_classes(["flat"])
+        .build();
+    let auth_key_regenerate_button = gtk4::Button::builder()
+        .icon_name("view-refresh-symbolic")
+        .tooltip_text("Regenerate key — old key stops working for future reconnects")
+        .valign(gtk4::Align::Center)
+        .css_classes(["flat"])
+        .build();
+    auth_key_row.add_suffix(&auth_key_reveal_button);
+    auth_key_row.add_suffix(&auth_key_copy_button);
+    auth_key_row.add_suffix(&auth_key_regenerate_button);
+
     let device_defaults_row = adw::ExpanderRow::builder()
         .title("Device defaults")
         .subtitle("Applied when the server opens the dongle — clients override live")
@@ -645,6 +786,8 @@ pub fn build_server_panel() -> ServerPanel {
     widget.add(&advertise_row);
     widget.add(&compression_row);
     widget.add(&listener_cap_row);
+    widget.add(&auth_require_row);
+    widget.add(&auth_key_row);
     widget.add(&device_defaults_row);
     widget.add(&status_row);
     widget.add(&activity_log_row);
@@ -659,6 +802,11 @@ pub fn build_server_panel() -> ServerPanel {
         advertise_row,
         compression_row,
         listener_cap_row,
+        auth_require_row,
+        auth_key_row,
+        auth_key_reveal_button,
+        auth_key_copy_button,
+        auth_key_regenerate_button,
         device_defaults_row,
         center_freq_row,
         sample_rate_row,
@@ -811,6 +959,19 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
             let clamped = (cap as f64).clamp(MIN_LISTENER_CAP, MAX_LISTENER_CAP);
             panel.listener_cap_row.set_value(clamped);
         }
+        if let Some(require) = v
+            .get(KEY_SERVER_REQUIRE_AUTH)
+            .and_then(serde_json::Value::as_bool)
+        {
+            // Restore the "Require key" toggle state. The key
+            // itself lives in the OS keyring; window.rs loads /
+            // creates it on toggle-on. Just restore the bool
+            // here so the widget reflects the user's last
+            // choice; window.rs's connect-active handler
+            // kicks off the keyring/server wiring if it was on.
+            // Per #395.
+            panel.auth_require_row.set_active(require);
+        }
     });
 
     // ---- Phase 2: subscribe ----
@@ -945,4 +1106,56 @@ pub fn connect_server_panel_persistence(panel: &ServerPanel, config: &Arc<Config
             v[KEY_SERVER_LISTENER_CAP] = serde_json::json!(cap);
         });
     });
+    // "Require key" switch — persist the bool to sdr_config. The
+    // key bytes themselves live in the OS keyring, managed by
+    // window.rs. Per #395.
+    let cfg_auth = Arc::clone(config);
+    panel.auth_require_row.connect_active_notify(move |row| {
+        cfg_auth.write(|v| {
+            v[KEY_SERVER_REQUIRE_AUTH] = serde_json::json!(row.is_active());
+        });
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{auth_key_from_hex, auth_key_to_hex};
+
+    #[test]
+    fn auth_key_to_hex_round_trips_through_from_hex() {
+        // Every byte value 0..=255 must round-trip through
+        // hex encode / decode without loss. Pins the
+        // keyring-persistence contract — a key stored today
+        // comes back as the exact same bytes on the next
+        // launch.
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        let hex = auth_key_to_hex(&bytes);
+        assert_eq!(hex.len(), bytes.len() * 2);
+        assert!(
+            hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "encoder must emit lowercase hex only"
+        );
+        let back = auth_key_from_hex(&hex).expect("round-trip decode must succeed");
+        assert_eq!(back, bytes);
+    }
+
+    #[test]
+    fn auth_key_from_hex_rejects_malformed_input() {
+        // Empty, odd-length, and non-hex characters all
+        // surface as `None` so the keyring reader can fall
+        // back to regenerate without panicking. Non-ASCII
+        // (the PR #405 regression vector) must also fail
+        // cleanly rather than panicking on boundary slicing.
+        assert!(auth_key_from_hex("").is_none());
+        assert!(auth_key_from_hex("abc").is_none(), "odd length");
+        assert!(auth_key_from_hex("xyz0").is_none(), "non-hex chars");
+        assert!(auth_key_from_hex("💩💩").is_none(), "non-ASCII emoji");
+    }
+
+    #[test]
+    fn auth_key_to_hex_empty_input_produces_empty_string() {
+        // Edge case — empty slice is legal input (no key set);
+        // encoder must produce an empty string, not panic.
+        assert_eq!(auth_key_to_hex(&[]), "");
+    }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3865,6 +3865,14 @@ fn build_advertiser(
             // Vanilla mDNS consumers (non-sdr-rs clients that
             // don't know this key) just ignore it. #307.
             codecs: Some(server.compression().to_wire()),
+            // Advertise `auth_required=true` when the running
+            // server has a key configured so clients can prompt
+            // for a key BEFORE dispatching connect. Read from
+            // `Server::auth_required()` (not the UI's auth-toggle
+            // state) because a future live-update via
+            // `Server::set_auth_key` is the single source of truth.
+            // #394 + #395.
+            auth_required: server.auth_required().then_some(true),
         },
     };
     Advertiser::announce(opts)
@@ -6754,6 +6762,7 @@ mod rtl_tcp_discovery_format_tests {
                 nickname: "weather".into(),
                 txbuf: None,
                 codecs: None,
+                auth_required: None,
             },
             last_seen: Instant::now(),
         }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3744,11 +3744,19 @@ fn connect_server_status_polling(
     // is cheap but clearing the ListBox resets any user scroll
     // position, so we short-circuit on unchanged ticks.
     let last_activity_key: Rc<Cell<(usize, Option<Instant>)>> = Rc::new(Cell::new((0, None)));
-    // Clients-list diff key: hash of the connected `ClientId` set.
-    // Same rationale as `last_activity_key` — rebuilding the
-    // ListBox every tick would wipe user scroll position + flash
-    // the hover highlight off each 500 ms tick. Per issue #395.
-    let last_clients_key: Rc<Cell<u64>> = Rc::new(Cell::new(0));
+    // Clients-list diff key. Hashes `(id, peer, role, drops,
+    // elapsed_secs)` per client so a stable connected set with
+    // ticking uptime / incrementing drop counters still triggers
+    // a rebuild — the previous id-set-only hash froze row
+    // subtitles once the set stabilized, so a 10-minute session
+    // would show "0s" uptime forever. `Option<u64>` so the
+    // stop/start reset path can invalidate the cache by setting
+    // `None`; without that, an "empty set → empty set" transition
+    // across stop/start would short-circuit the first post-start
+    // render and leave the expander blank (the placeholder row
+    // was removed by `reset_clients_list`). Per `CodeRabbit`
+    // round 2 on PR #406.
+    let last_clients_key: Rc<Cell<Option<u64>>> = Rc::new(Cell::new(None));
 
     // Separate subscription on the Stop button. Flipping the switch
     // off is the single canonical stop path — pointing the button
@@ -4123,27 +4131,60 @@ fn render_activity_log(
 fn render_clients_list(
     widgets: &ServerStatusWidgets,
     stats: &sdr_server_rtltcp::ServerStats,
-    last_rendered: &Rc<std::cell::Cell<u64>>,
+    last_rendered: &Rc<std::cell::Cell<Option<u64>>>,
 ) {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
     use crate::sidebar::server_panel::CLIENTS_LIST_EMPTY_SUBTITLE;
 
-    // Compute a diff key that only changes on accept / disconnect.
-    // `ClientId` is monotonic and never reused, so the sorted-id
-    // tuple uniquely identifies the connected set. Tracking just
-    // a hash keeps the cell small (u64 vs. Vec<ClientId>).
-    let mut ids: Vec<sdr_server_rtltcp::ClientId> =
-        stats.connected_clients.iter().map(|c| c.id).collect();
-    ids.sort_unstable();
+    // Compute a diff key that bumps on *any* rendered-field
+    // change — not just accept / disconnect. Including peer,
+    // role, drops, and (rounded-seconds) uptime in the hash
+    // means a stable connected set with ticking uptime or
+    // incrementing drops still triggers rebuilds. The previous
+    // id-set-only key froze row subtitles once the client set
+    // stabilized. Per `CodeRabbit` round 2 on PR #406.
+    //
+    // Rebuild cost is ~N widget builds at 2 Hz (N ≤ 32 at the
+    // listener cap); trivial vs. the USB / DSP hot path.
+    let now = Instant::now();
+    let mut key_fields: Vec<(sdr_server_rtltcp::ClientId, String, u8, u64, u64)> = stats
+        .connected_clients
+        .iter()
+        .map(|c| {
+            let role_disc = match c.role {
+                sdr_server_rtltcp::extension::Role::Control => 0u8,
+                sdr_server_rtltcp::extension::Role::Listen => 1u8,
+            };
+            let elapsed_secs = now.saturating_duration_since(c.connected_since).as_secs();
+            (
+                c.id,
+                c.peer.to_string(),
+                role_disc,
+                c.buffers_dropped,
+                elapsed_secs,
+            )
+        })
+        .collect();
+    key_fields.sort_unstable_by_key(|(id, _, _, _, _)| *id);
     let mut hasher = DefaultHasher::new();
-    ids.hash(&mut hasher);
+    key_fields.hash(&mut hasher);
     let current_key = hasher.finish();
-    if current_key == last_rendered.get() {
+
+    // Invalidate the cache when the ListBox has been cleared
+    // externally (by `reset_clients_list` on server stop). Without
+    // this, an "empty set → empty set" transition across stop/start
+    // would match the prior hash and short-circuit the first-tick
+    // render, leaving the expander visually blank. The empty
+    // state's placeholder row is a single child, so
+    // `first_child().is_none()` distinguishes the reset state from
+    // the rendered-empty state. Per `CodeRabbit` round 2 on PR #406.
+    let list_was_reset = widgets.clients_list.first_child().is_none();
+    if !list_was_reset && last_rendered.get() == Some(current_key) {
         return;
     }
-    last_rendered.set(current_key);
+    last_rendered.set(Some(current_key));
 
     // Clear the ListBox. GTK4 ListBox has no mass-remove.
     while let Some(child) = widgets.clients_list.first_child() {
@@ -4184,7 +4225,11 @@ fn render_clients_list(
         sdr_server_rtltcp::extension::Role::Listen => 1u8,
     });
 
-    let now = Instant::now();
+    // Reuse the `now` captured for the diff-key hash so the
+    // displayed duration and the hashed `elapsed_secs` are
+    // sampled from the same instant — avoids a split where
+    // the hash matches but the render shows a one-tick-newer
+    // duration (or vice-versa).
     for info in ordered {
         let (role_label, role_css) = match info.role {
             sdr_server_rtltcp::extension::Role::Control => ("Controller", "accent"),

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2768,6 +2768,69 @@ struct RunningServer {
     advertiser: Option<Advertiser>,
 }
 
+/// Read the `rtl_tcp` server auth key from the OS keyring, if
+/// present. Returns `Some(bytes)` for a well-formed hex-encoded
+/// entry, `None` for a missing key, keyring unavailable, empty
+/// entry, or corrupt hex. Corrupt entries are logged at `warn`
+/// so operators can diagnose without the UI silently regenerating
+/// over their paste. Per issue #395.
+fn load_server_auth_key_from_keyring() -> Option<Vec<u8>> {
+    use sdr_config::KeyringStore;
+
+    use crate::sidebar::server_panel::{KEYRING_KEY_AUTH_KEY, KEYRING_SERVICE, auth_key_from_hex};
+
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    match store.get(KEYRING_KEY_AUTH_KEY) {
+        Ok(Some(hex)) => {
+            let Some(bytes) = auth_key_from_hex(&hex) else {
+                tracing::warn!(
+                    "rtl_tcp server auth key in keyring is malformed hex; regenerating on next toggle-on"
+                );
+                return None;
+            };
+            Some(bytes)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!(%e, "rtl_tcp server auth key keyring read failed");
+            None
+        }
+    }
+}
+
+/// Write the `rtl_tcp` server auth key to the OS keyring as
+/// lowercase hex. Returns the underlying keyring error so
+/// callers can surface it via toast — the caller is responsible
+/// for deciding UX fallback (e.g. revert the toggle, show a
+/// banner). Per issue #395.
+fn save_server_auth_key_to_keyring(
+    bytes: &[u8],
+) -> Result<(), sdr_config::keyring_store::KeyringError> {
+    use sdr_config::KeyringStore;
+
+    use crate::sidebar::server_panel::{KEYRING_KEY_AUTH_KEY, KEYRING_SERVICE, auth_key_to_hex};
+
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    store.set(KEYRING_KEY_AUTH_KEY, &auth_key_to_hex(bytes))
+}
+
+/// Load the persisted server auth key, generating + saving a
+/// fresh one when the keyring is either empty or corrupt. The
+/// caller gets the fresh bytes regardless — a write failure
+/// leaves the key in memory so the current session works, and
+/// the next session's toggle-on retries the save path. Per
+/// issue #395.
+fn ensure_server_auth_key() -> Vec<u8> {
+    if let Some(existing) = load_server_auth_key_from_keyring() {
+        return existing;
+    }
+    let fresh = sdr_server_rtltcp::auth::generate_random_auth_key();
+    if let Err(e) = save_server_auth_key_to_keyring(&fresh) {
+        tracing::warn!(%e, "rtl_tcp server auth key keyring write failed — in-memory only");
+    }
+    fresh
+}
+
 /// Wire the server panel end-to-end: visibility gating, the master
 /// share-over-network switch, and its downstream start/stop effects.
 /// Errors surface via the `toast_overlay`, and the switch auto-
@@ -2959,6 +3022,7 @@ struct ServerSwitchWidgetsWeak {
     advertise_row: glib::WeakRef<adw::SwitchRow>,
     compression_row: glib::WeakRef<adw::ComboRow>,
     listener_cap_row: glib::WeakRef<adw::SpinRow>,
+    auth_require_row: glib::WeakRef<adw::SwitchRow>,
     device_defaults_row: glib::WeakRef<adw::ExpanderRow>,
     center_freq_row: glib::WeakRef<adw::SpinRow>,
     sample_rate_row: glib::WeakRef<adw::ComboRow>,
@@ -2988,6 +3052,7 @@ struct ServerSwitchWidgets {
     advertise_row: adw::SwitchRow,
     compression_row: adw::ComboRow,
     listener_cap_row: adw::SpinRow,
+    auth_require_row: adw::SwitchRow,
     device_defaults_row: adw::ExpanderRow,
     center_freq_row: adw::SpinRow,
     sample_rate_row: adw::ComboRow,
@@ -3015,6 +3080,7 @@ impl ServerSwitchWidgetsWeak {
             advertise_row: s.advertise_row.downgrade(),
             compression_row: s.compression_row.downgrade(),
             listener_cap_row: s.listener_cap_row.downgrade(),
+            auth_require_row: s.auth_require_row.downgrade(),
             device_defaults_row: s.device_defaults_row.downgrade(),
             center_freq_row: s.center_freq_row.downgrade(),
             sample_rate_row: s.sample_rate_row.downgrade(),
@@ -3043,6 +3109,7 @@ impl ServerSwitchWidgetsWeak {
             advertise_row: self.advertise_row.upgrade()?,
             compression_row: self.compression_row.upgrade()?,
             listener_cap_row: self.listener_cap_row.upgrade()?,
+            auth_require_row: self.auth_require_row.upgrade()?,
             device_defaults_row: self.device_defaults_row.upgrade()?,
             center_freq_row: self.center_freq_row.upgrade()?,
             sample_rate_row: self.sample_rate_row.upgrade()?,
@@ -3062,6 +3129,13 @@ impl ServerSwitchWidgetsWeak {
     }
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "share switch orchestrates server start/stop plus listener-cap + \
+              auth-key live-update signals; splitting it would scatter the \
+              `running` and `toast_overlay` Rc clones across multiple helpers \
+              without improving clarity"
+)]
 fn connect_share_switch(
     panels: &SidebarPanels,
     toast_overlay: &adw::ToastOverlay,
@@ -3092,6 +3166,44 @@ fn connect_share_switch(
     // share the same `RefCell`; neither holds a borrow past its
     // own tick. Per #395.
     let running_for_cap = Rc::clone(&running);
+    // Additional `running` clones for the auth-related closures
+    // (toggle, reveal, copy, regenerate). Same rationale — clone
+    // before the share_row handler consumes the outer `running`.
+    let running_for_auth_toggle = Rc::clone(&running);
+    let running_for_auth_regen = Rc::clone(&running);
+
+    // Clone the toast-overlay weak ref for every auth-side
+    // closure that surfaces errors (toggle-on/off, copy,
+    // regenerate). Same move-before-share_row problem: the
+    // share_row closure below consumes the outer
+    // `toast_overlay_weak`.
+    let toast_overlay_for_auth_toggle = toast_overlay_weak.clone();
+    let toast_overlay_for_copy = toast_overlay_weak.clone();
+    let toast_overlay_for_regen = toast_overlay_weak.clone();
+
+    // Shared state for the auth-key display row. `current_key`
+    // holds the active key bytes while the server is running
+    // with auth enabled; `None` when auth is off. `key_revealed`
+    // tracks whether the subtitle currently shows the full hex
+    // or the masked placeholder — the user toggles this via the
+    // reveal button. Both are `Rc<...>` so the four closures
+    // (toggle, reveal, copy, regenerate) share the same state
+    // without borrow conflicts. Per issue #395.
+    let current_auth_key: Rc<RefCell<Option<Vec<u8>>>> = Rc::new(RefCell::new(None));
+    let auth_key_revealed: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
+
+    // If auth was restored as ON from config, eagerly load the
+    // key from the keyring so the key row reflects real state
+    // before the user interacts with anything. The server isn't
+    // running yet (that requires the share_row flip), so no
+    // `set_auth_key` call here — just UI state.
+    if panels.server.auth_require_row.is_active() {
+        let key = ensure_server_auth_key();
+        *current_auth_key.borrow_mut() = Some(key);
+        panels.server.auth_key_row.set_visible(true);
+        // Leave subtitle as the masked placeholder (widget
+        // default) — user clicks Reveal to see the real value.
+    }
 
     panels.server.share_row.connect_active_notify(move |row| {
         if reentry_guard.get() {
@@ -3203,6 +3315,174 @@ fn connect_share_switch(
         }
         apply_visibility();
     });
+
+    // ====================================================
+    // Auth controls (#394/#395) — toggle + reveal + copy +
+    // regenerate. All four closures share `current_auth_key`
+    // and `auth_key_revealed` via `Rc` + the running-server
+    // handle via `running_for_auth_{toggle,regen}`.
+    // ====================================================
+
+    // Master "Require key" toggle.
+    // ON: load-or-generate key from keyring, call
+    //     Server::set_auth_key(Some(bytes)) if running, show
+    //     the key row with masked subtitle.
+    // OFF: call Server::set_auth_key(None) if running, hide
+    //      the key row, drop in-memory bytes. Keyring entry
+    //      is PRESERVED per #395 ("flipping back doesn't
+    //      regenerate").
+    let key_row_for_toggle = panels.server.auth_key_row.downgrade();
+    let reveal_button_for_toggle = panels.server.auth_key_reveal_button.downgrade();
+    let current_key_for_toggle = Rc::clone(&current_auth_key);
+    let revealed_for_toggle = Rc::clone(&auth_key_revealed);
+    panels
+        .server
+        .auth_require_row
+        .connect_active_notify(move |row| {
+            let Some(key_row) = key_row_for_toggle.upgrade() else {
+                return;
+            };
+            if row.is_active() {
+                let key = ensure_server_auth_key();
+                if let Ok(handle) = running_for_auth_toggle.try_borrow()
+                    && let Some(handle) = handle.as_ref()
+                    && let Err(e) = handle.server.set_auth_key(Some(key.clone()))
+                {
+                    tracing::warn!(%e, "Server::set_auth_key failed on toggle-on");
+                    if let Some(overlay) = toast_overlay_for_auth_toggle.upgrade() {
+                        overlay.add_toast(adw::Toast::new(&format!(
+                            "Couldn't enable auth on the running server: {e}"
+                        )));
+                    }
+                }
+                *current_key_for_toggle.borrow_mut() = Some(key);
+                key_row.set_visible(true);
+                // Reset to masked state on every toggle-on so the
+                // key row doesn't surface a previously-revealed
+                // value across sessions.
+                revealed_for_toggle.set(false);
+                key_row.set_subtitle(crate::sidebar::server_panel::AUTH_KEY_MASKED_PLACEHOLDER);
+                if let Some(rb) = reveal_button_for_toggle.upgrade() {
+                    rb.set_icon_name("view-reveal-symbolic");
+                    rb.set_tooltip_text(Some("Reveal key"));
+                }
+            } else {
+                if let Ok(handle) = running_for_auth_toggle.try_borrow()
+                    && let Some(handle) = handle.as_ref()
+                    && let Err(e) = handle.server.set_auth_key(None)
+                {
+                    tracing::warn!(%e, "Server::set_auth_key(None) failed on toggle-off");
+                }
+                *current_key_for_toggle.borrow_mut() = None;
+                key_row.set_visible(false);
+                // Zero the revealed flag too so a next toggle-on
+                // starts masked regardless of the prior reveal
+                // state.
+                revealed_for_toggle.set(false);
+            }
+        });
+
+    // Reveal / conceal button — flips the subtitle between the
+    // masked placeholder and the full hex-encoded key. Pure UI
+    // state; doesn't touch keyring or server.
+    let key_row_for_reveal = panels.server.auth_key_row.downgrade();
+    let current_key_for_reveal = Rc::clone(&current_auth_key);
+    let revealed_for_reveal = Rc::clone(&auth_key_revealed);
+    panels
+        .server
+        .auth_key_reveal_button
+        .connect_clicked(move |btn| {
+            let Some(key_row) = key_row_for_reveal.upgrade() else {
+                return;
+            };
+            let Ok(key_opt) = current_key_for_reveal.try_borrow() else {
+                return;
+            };
+            let Some(bytes) = key_opt.as_ref() else {
+                return;
+            };
+            let now_revealed = !revealed_for_reveal.get();
+            revealed_for_reveal.set(now_revealed);
+            if now_revealed {
+                key_row.set_subtitle(&crate::sidebar::server_panel::auth_key_to_hex(bytes));
+                btn.set_icon_name("view-conceal-symbolic");
+                btn.set_tooltip_text(Some("Hide key"));
+            } else {
+                key_row.set_subtitle(crate::sidebar::server_panel::AUTH_KEY_MASKED_PLACEHOLDER);
+                btn.set_icon_name("view-reveal-symbolic");
+                btn.set_tooltip_text(Some("Reveal key"));
+            }
+        });
+
+    // Copy button — always copies the FULL hex key regardless of
+    // reveal state. Users typically click Copy without clicking
+    // Reveal first.
+    let current_key_for_copy = Rc::clone(&current_auth_key);
+    panels
+        .server
+        .auth_key_copy_button
+        .connect_clicked(move |btn| {
+            let Ok(key_opt) = current_key_for_copy.try_borrow() else {
+                return;
+            };
+            let Some(bytes) = key_opt.as_ref() else {
+                return;
+            };
+            let hex = crate::sidebar::server_panel::auth_key_to_hex(bytes);
+            // Grab the display's clipboard via the button's widget
+            // ancestry. `clipboard()` on a widget returns the
+            // primary clipboard for the display it's attached to.
+            let clipboard = btn.clipboard();
+            clipboard.set_text(&hex);
+            if let Some(overlay) = toast_overlay_for_copy.upgrade() {
+                overlay.add_toast(adw::Toast::new("Key copied to clipboard"));
+            }
+        });
+
+    // Regenerate button — generates a fresh 32-byte key,
+    // overwrites the keyring entry, updates the live server
+    // (if running) via set_auth_key, and updates the display
+    // row subtitle (preserving the current revealed state so
+    // the user can verify the new value immediately).
+    let key_row_for_regen = panels.server.auth_key_row.downgrade();
+    let current_key_for_regen = Rc::clone(&current_auth_key);
+    let revealed_for_regen = Rc::clone(&auth_key_revealed);
+    panels
+        .server
+        .auth_key_regenerate_button
+        .connect_clicked(move |_btn| {
+            let Some(key_row) = key_row_for_regen.upgrade() else {
+                return;
+            };
+            let fresh = sdr_server_rtltcp::auth::generate_random_auth_key();
+            if let Err(e) = save_server_auth_key_to_keyring(&fresh) {
+                tracing::warn!(%e, "rtl_tcp auth-key regenerate keyring write failed");
+                if let Some(overlay) = toast_overlay_for_regen.upgrade() {
+                    overlay.add_toast(adw::Toast::new(&format!(
+                        "Couldn't save new key to keyring: {e}"
+                    )));
+                }
+                // Continue anyway — the in-memory key is still
+                // applied so the current session gets the new
+                // value; the next launch will find the old key
+                // until the save path succeeds.
+            }
+            if let Ok(handle) = running_for_auth_regen.try_borrow()
+                && let Some(handle) = handle.as_ref()
+                && let Err(e) = handle.server.set_auth_key(Some(fresh.clone()))
+            {
+                tracing::warn!(%e, "Server::set_auth_key failed on regenerate");
+            }
+            *current_key_for_regen.borrow_mut() = Some(fresh.clone());
+            if revealed_for_regen.get() {
+                key_row.set_subtitle(&crate::sidebar::server_panel::auth_key_to_hex(&fresh));
+            } else {
+                key_row.set_subtitle(crate::sidebar::server_panel::AUTH_KEY_MASKED_PLACEHOLDER);
+            }
+            if let Some(overlay) = toast_overlay_for_regen.upgrade() {
+                overlay.add_toast(adw::Toast::new("New key generated"));
+            }
+        });
 
     // Listener-cap live-apply. Changes on the spin row take effect
     // on the next client accept without restarting the server. The
@@ -3860,11 +4140,17 @@ fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
         // truth at server-start time. Later live-update calls flow
         // through `Server::set_listener_cap` directly. Per #395.
         listener_cap: panel.listener_cap_row.value() as usize,
-        // Auth defaults to off (None) — enabling it lives behind
-        // the #395 server UI toggle. #394 ships the wire + server
-        // enforcement plumbing; the UI knob + keyring storage
-        // hooks come in the follow-up sub-issue.
-        auth_key: None,
+        // Auth key pulled from the OS keyring when the "Require
+        // key" toggle is on; `None` otherwise. `ensure_server_auth_key`
+        // generates + saves a 32-byte CSPRNG key on first enable
+        // and reloads the same bytes on subsequent server
+        // restarts (keyring value survives toggle-off/on cycles).
+        // Per #395.
+        auth_key: if panel.auth_require_row.is_active() {
+            Some(ensure_server_auth_key())
+        } else {
+            None
+        },
     }
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3037,6 +3037,8 @@ struct ServerSwitchWidgetsWeak {
     status_commanded_row: glib::WeakRef<adw::ActionRow>,
     activity_log_row: glib::WeakRef<adw::ExpanderRow>,
     activity_log_list: glib::WeakRef<gtk4::ListBox>,
+    clients_row: glib::WeakRef<adw::ExpanderRow>,
+    clients_list: glib::WeakRef<gtk4::ListBox>,
     source_device_row: glib::WeakRef<adw::ComboRow>,
 }
 
@@ -3067,6 +3069,8 @@ struct ServerSwitchWidgets {
     status_commanded_row: adw::ActionRow,
     activity_log_row: adw::ExpanderRow,
     activity_log_list: gtk4::ListBox,
+    clients_row: adw::ExpanderRow,
+    clients_list: gtk4::ListBox,
     source_device_row: adw::ComboRow,
 }
 
@@ -3095,6 +3099,8 @@ impl ServerSwitchWidgetsWeak {
             status_commanded_row: s.status_commanded_row.downgrade(),
             activity_log_row: s.activity_log_row.downgrade(),
             activity_log_list: s.activity_log_list.downgrade(),
+            clients_row: s.clients_row.downgrade(),
+            clients_list: s.clients_list.downgrade(),
             source_device_row: panels.source.device_row.downgrade(),
         }
     }
@@ -3124,6 +3130,8 @@ impl ServerSwitchWidgetsWeak {
             status_commanded_row: self.status_commanded_row.upgrade()?,
             activity_log_row: self.activity_log_row.upgrade()?,
             activity_log_list: self.activity_log_list.upgrade()?,
+            clients_row: self.clients_row.upgrade()?,
+            clients_list: self.clients_list.upgrade()?,
             source_device_row: self.source_device_row.upgrade()?,
         })
     }
@@ -3266,6 +3274,7 @@ fn connect_share_switch(
                     set_controls_locked(&widgets, true);
                     widgets.status_row.set_visible(true);
                     widgets.activity_log_row.set_visible(true);
+                    widgets.clients_row.set_visible(true);
                     *running.borrow_mut() = Some(RunningServer { server, advertiser });
                     // Flip the shared "server is live" flag AFTER
                     // the handle is stored so the source-panel
@@ -3310,8 +3319,10 @@ fn connect_share_switch(
             set_controls_locked(&widgets, false);
             widgets.status_row.set_visible(false);
             widgets.activity_log_row.set_visible(false);
+            widgets.clients_row.set_visible(false);
             reset_status_rows(&widgets);
             reset_activity_log(&widgets);
+            reset_clients_list(&widgets);
         }
         apply_visibility();
     });
@@ -3549,10 +3560,12 @@ struct ServerStatusWidgetsWeak {
     status_commanded_row: glib::WeakRef<adw::ActionRow>,
     activity_log_row: glib::WeakRef<adw::ExpanderRow>,
     activity_log_list: glib::WeakRef<gtk4::ListBox>,
+    clients_row: glib::WeakRef<adw::ExpanderRow>,
+    clients_list: glib::WeakRef<gtk4::ListBox>,
 }
 
 /// Snapshot of upgraded strong references held for the duration of
-/// a single poll tick. All seven widgets upgrade together or we
+/// a single poll tick. All nine widgets upgrade together or we
 /// `Break` the timer — render functions then read these fields
 /// directly without needing their own weak-ref fallbacks.
 struct ServerStatusWidgets {
@@ -3563,6 +3576,8 @@ struct ServerStatusWidgets {
     status_commanded_row: adw::ActionRow,
     activity_log_row: adw::ExpanderRow,
     activity_log_list: gtk4::ListBox,
+    clients_row: adw::ExpanderRow,
+    clients_list: gtk4::ListBox,
 }
 
 impl ServerStatusWidgetsWeak {
@@ -3575,11 +3590,13 @@ impl ServerStatusWidgetsWeak {
             status_commanded_row: panel.status_commanded_row.downgrade(),
             activity_log_row: panel.activity_log_row.downgrade(),
             activity_log_list: panel.activity_log_list.downgrade(),
+            clients_row: panel.clients_row.downgrade(),
+            clients_list: panel.clients_list.downgrade(),
         }
     }
 
-    /// Upgrade all seven weak refs atomically. Returns `None` if
-    /// any one widget has been destroyed — the caller breaks its
+    /// Upgrade every weak ref atomically. Returns `None` if any
+    /// one widget has been destroyed — the caller breaks its
     /// timer instead of rendering against a partially-dead panel.
     fn upgrade(&self) -> Option<ServerStatusWidgets> {
         Some(ServerStatusWidgets {
@@ -3590,6 +3607,8 @@ impl ServerStatusWidgetsWeak {
             status_commanded_row: self.status_commanded_row.upgrade()?,
             activity_log_row: self.activity_log_row.upgrade()?,
             activity_log_list: self.activity_log_list.upgrade()?,
+            clients_row: self.clients_row.upgrade()?,
+            clients_list: self.clients_list.upgrade()?,
         })
     }
 }
@@ -3623,6 +3642,11 @@ fn connect_server_status_polling(
     // is cheap but clearing the ListBox resets any user scroll
     // position, so we short-circuit on unchanged ticks.
     let last_activity_key: Rc<Cell<(usize, Option<Instant>)>> = Rc::new(Cell::new((0, None)));
+    // Clients-list diff key: hash of the connected `ClientId` set.
+    // Same rationale as `last_activity_key` — rebuilding the
+    // ListBox every tick would wipe user scroll position + flash
+    // the hover highlight off each 500 ms tick. Per issue #395.
+    let last_clients_key: Rc<Cell<u64>> = Rc::new(Cell::new(0));
 
     // Separate subscription on the Stop button. Flipping the switch
     // off is the single canonical stop path — pointing the button
@@ -3670,6 +3694,7 @@ fn connect_server_status_polling(
 
         render_status_rows(&widgets, &stats, &last_bytes_sent);
         render_activity_log(&widgets, &stats, &last_activity_key);
+        render_clients_list(&widgets, &stats, &last_clients_key);
         glib::ControlFlow::Continue
     });
 }
@@ -3981,6 +4006,112 @@ fn render_activity_log(
     }
 }
 
+/// Render the "Connected clients" list — one row per client
+/// with peer, role badge, duration, and drops counter. Empty
+/// state: single "No clients connected" placeholder row plus
+/// matching expander subtitle. Rebuilds only when the
+/// `ClientId` set changes (i.e. a client joined or left) so
+/// user scroll position + hover highlight survive the 500 ms
+/// poll cadence. The per-client field churn (duration bumps,
+/// drop-count increments) IS NOT diffed here — we'd have to
+/// index rows by id to patch them in place, which is more
+/// complexity than the row-per-client design needs. Callers
+/// who want a running clock on each row should watch
+/// individual slots via a dedicated widget. Per issue #395.
+fn render_clients_list(
+    widgets: &ServerStatusWidgets,
+    stats: &sdr_server_rtltcp::ServerStats,
+    last_rendered: &Rc<std::cell::Cell<u64>>,
+) {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    use crate::sidebar::server_panel::CLIENTS_LIST_EMPTY_SUBTITLE;
+
+    // Compute a diff key that only changes on accept / disconnect.
+    // `ClientId` is monotonic and never reused, so the sorted-id
+    // tuple uniquely identifies the connected set. Tracking just
+    // a hash keeps the cell small (u64 vs. Vec<ClientId>).
+    let mut ids: Vec<sdr_server_rtltcp::ClientId> =
+        stats.connected_clients.iter().map(|c| c.id).collect();
+    ids.sort_unstable();
+    let mut hasher = DefaultHasher::new();
+    ids.hash(&mut hasher);
+    let current_key = hasher.finish();
+    if current_key == last_rendered.get() {
+        return;
+    }
+    last_rendered.set(current_key);
+
+    // Clear the ListBox. GTK4 ListBox has no mass-remove.
+    while let Some(child) = widgets.clients_list.first_child() {
+        widgets.clients_list.remove(&child);
+    }
+
+    if stats.connected_clients.is_empty() {
+        widgets
+            .clients_row
+            .set_subtitle(CLIENTS_LIST_EMPTY_SUBTITLE);
+        let empty_row = adw::ActionRow::builder()
+            .title(CLIENTS_LIST_EMPTY_SUBTITLE)
+            .activatable(false)
+            .css_classes(["dim-label"])
+            .build();
+        widgets.clients_list.append(&empty_row);
+        return;
+    }
+
+    // Expander subtitle shows the count so a collapsed expander
+    // still communicates whether the server has activity.
+    let count = stats.connected_clients.len();
+    widgets.clients_row.set_subtitle(&if count == 1 {
+        "1 client".to_string()
+    } else {
+        format!("{count} clients")
+    });
+
+    // Build per-client rows. Controller first (if any) so the
+    // accent-colored row sits at the top; listeners render below
+    // in the order the registry has them (acceptance order, per
+    // `ClientRegistry`). Order isn't a hard contract — if a
+    // future registry reorders for its own reasons, this just
+    // changes visual order.
+    let mut ordered: Vec<&sdr_server_rtltcp::ClientInfo> = stats.connected_clients.iter().collect();
+    ordered.sort_by_key(|c| match c.role {
+        sdr_server_rtltcp::extension::Role::Control => 0u8,
+        sdr_server_rtltcp::extension::Role::Listen => 1u8,
+    });
+
+    let now = Instant::now();
+    for info in ordered {
+        let (role_label, role_css) = match info.role {
+            sdr_server_rtltcp::extension::Role::Control => ("Controller", "accent"),
+            sdr_server_rtltcp::extension::Role::Listen => ("Listener", "dim-label"),
+        };
+        let duration = format_uptime(now.saturating_duration_since(info.connected_since));
+        let subtitle = if info.buffers_dropped > 0 {
+            format!(
+                "{role_label} · {duration} · {drops} drops",
+                drops = info.buffers_dropped
+            )
+        } else {
+            format!("{role_label} · {duration}")
+        };
+        let row = adw::ActionRow::builder()
+            .title(info.peer.to_string())
+            .subtitle(&subtitle)
+            .activatable(false)
+            .build();
+        // Prefix badge: a colored dot (accent for Control, dim
+        // for Listen). Small and unobtrusive but enough to
+        // distinguish the controller at a glance in a dense list.
+        let badge = gtk4::Image::from_icon_name("media-record-symbolic");
+        badge.add_css_class(role_css);
+        row.add_prefix(&badge);
+        widgets.clients_list.append(&row);
+    }
+}
+
 /// Reset activity-log list + subtitle on stop. Without this the
 /// list would persist after the server stopped — misleading users
 /// into thinking the log reflects a currently-running session.
@@ -3992,6 +4123,17 @@ fn reset_activity_log(panel: &ServerSwitchWidgets) {
     panel
         .activity_log_row
         .set_subtitle(ACTIVITY_LOG_EMPTY_SUBTITLE);
+}
+
+/// Reset the connected-clients list to its empty state. Called on
+/// server stop so the next start doesn't surface stale client rows
+/// before the first poll tick repopulates. Per issue #395.
+fn reset_clients_list(panel: &ServerSwitchWidgets) {
+    use crate::sidebar::server_panel::CLIENTS_LIST_EMPTY_SUBTITLE;
+    while let Some(child) = panel.clients_list.first_child() {
+        panel.clients_list.remove(&child);
+    }
+    panel.clients_row.set_subtitle(CLIENTS_LIST_EMPTY_SUBTITLE);
 }
 
 /// Render an elapsed duration as a compact "age" string for the

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3529,23 +3529,28 @@ fn connect_share_switch(
         });
 
     // Regenerate button — generates a fresh 32-byte key,
-    // overwrites the keyring entry, updates the live server
-    // (if running) via set_auth_key, and updates the display
-    // row subtitle (preserving the current revealed state so
-    // the user can verify the new value immediately).
+    // applies it to the live server, persists to keyring, and
+    // updates the display row subtitle (preserving the current
+    // revealed state so the user can verify the new value
+    // immediately).
     //
-    // UI ↔ server parity (per `CodeRabbit` round 1 on PR #406):
-    // if `Server::set_auth_key` returns `Err`, DO NOT advance
-    // the UI to the new key — the server is still holding the
-    // old key, and showing the user a "new key generated"
-    // message that clients can't actually use with the server
-    // would be a lie. Toast the error, log it, leave
-    // `current_auth_key` + the displayed subtitle on the old
-    // value. The keyring write failure is tolerable (in-memory
-    // recovery next launch); the server write failure is not.
+    // Order of operations (per `CodeRabbit` round 2 on PR #406):
+    // 1. Apply to the running server via
+    //    `apply_live_auth_change` — shared with the toggle path.
+    //    On failure (mutex poisoned, borrow race), toast + return
+    //    BEFORE touching keyring or UI.
+    // 2. Persist to keyring. Failure here is non-fatal (the
+    //    in-memory key still works this session; next launch
+    //    would read the OLD keyring value, which now forces the
+    //    user to click Regenerate again — better than the old
+    //    order where a keyring success + server failure would
+    //    leave next-launch using a key the server never
+    //    accepted).
+    // 3. UI mutation (`current_auth_key`, subtitle, toast).
     //
-    // Regenerate keeps `auth_required = true` so the mDNS TXT
-    // doesn't change — no advertiser refresh needed.
+    // Regenerate keeps `auth_required = true`, so the mDNS TXT
+    // doesn't change — `apply_live_auth_change` skips the
+    // advertiser rebuild when passed `widgets = None`.
     let key_row_for_regen = panels.server.auth_key_row.downgrade();
     let current_key_for_regen = Rc::clone(&current_auth_key);
     let revealed_for_regen = Rc::clone(&auth_key_revealed);
@@ -3557,6 +3562,24 @@ fn connect_share_switch(
                 return;
             };
             let fresh = sdr_server_rtltcp::auth::generate_random_auth_key();
+
+            // Step 1: live server apply. `widgets = None` because
+            // regenerate doesn't flip `auth_required`, so no
+            // advertiser rebuild is needed.
+            if !apply_live_auth_change(
+                &running_for_auth_regen,
+                Some(fresh.clone()),
+                None,
+                &toast_overlay_for_regen,
+            ) {
+                return;
+            }
+
+            // Step 2: persist to keyring. Failure is tolerable —
+            // current in-memory key still works this session; the
+            // user can click Regenerate again later when the
+            // keyring recovers. Toast so they know, but don't
+            // roll back the server (it already accepted the key).
             if let Err(e) = save_server_auth_key_to_keyring(&fresh) {
                 tracing::warn!(%e, "rtl_tcp auth-key regenerate keyring write failed");
                 if let Some(overlay) = toast_overlay_for_regen.upgrade() {
@@ -3564,28 +3587,10 @@ fn connect_share_switch(
                         "Couldn't save new key to keyring: {e}"
                     )));
                 }
-                // Continue anyway — the in-memory key is still
-                // applied below so the current session gets the
-                // new value; the next launch will find the old
-                // key until the save path succeeds.
             }
-            // Server-side apply. On error, don't advance the UI
-            // state — toast and return so the displayed key
-            // still matches what the server accepts.
-            if let Ok(handle) = running_for_auth_regen.try_borrow()
-                && let Some(handle) = handle.as_ref()
-                && let Err(e) = handle.server.set_auth_key(Some(fresh.clone()))
-            {
-                tracing::warn!(%e, "Server::set_auth_key failed on regenerate");
-                if let Some(overlay) = toast_overlay_for_regen.upgrade() {
-                    overlay.add_toast(adw::Toast::new(&format!(
-                        "Couldn't apply new key to the running server: {e}"
-                    )));
-                }
-                return;
-            }
-            // All server-side gates passed (or server wasn't
-            // running) — commit the UI update.
+
+            // Step 3: UI mutation after server + persistence
+            // settled.
             *current_key_for_regen.borrow_mut() = Some(fresh.clone());
             if revealed_for_regen.get() {
                 key_row.set_subtitle(&crate::sidebar::server_panel::auth_key_to_hex(&fresh));
@@ -4119,15 +4124,24 @@ fn render_activity_log(
 /// Render the "Connected clients" list — one row per client
 /// with peer, role badge, duration, and drops counter. Empty
 /// state: single "No clients connected" placeholder row plus
-/// matching expander subtitle. Rebuilds only when the
-/// `ClientId` set changes (i.e. a client joined or left) so
-/// user scroll position + hover highlight survive the 500 ms
-/// poll cadence. The per-client field churn (duration bumps,
-/// drop-count increments) IS NOT diffed here — we'd have to
-/// index rows by id to patch them in place, which is more
-/// complexity than the row-per-client design needs. Callers
-/// who want a running clock on each row should watch
-/// individual slots via a dedicated widget. Per issue #395.
+/// matching expander subtitle.
+///
+/// **Rebuild trigger.** Hashes `(id, peer, role, drops,
+/// elapsed_secs)` for every connected client; rebuilds when
+/// the hash changes. That covers both accept/disconnect
+/// transitions AND per-row field churn (ticking uptime,
+/// incrementing drop counters), so the displayed subtitles
+/// stay live throughout a session. Scroll / hover state is
+/// preserved on unchanged ticks. Per issue #395 +
+/// `CodeRabbit` round 2 on PR #406.
+///
+/// **Stop/start invalidation.** On server stop
+/// `reset_clients_list` empties the `ListBox` but can't reach
+/// the cache cell across function boundaries; instead,
+/// `render_clients_list` treats `first_child().is_none()` as
+/// "reset has run, force rebuild" so an empty→empty session
+/// transition still repaints the placeholder. Per `CodeRabbit`
+/// round 2 on PR #406.
 fn render_clients_list(
     widgets: &ServerStatusWidgets,
     stats: &sdr_server_rtltcp::ServerStats,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3015,6 +3015,7 @@ fn connect_server_panel(
 ///
 /// `source_device_row` is a sidebar neighbour (not in `ServerPanel`)
 /// and comes along for the exclusivity guard read.
+#[derive(Clone)]
 struct ServerSwitchWidgetsWeak {
     nickname_row: glib::WeakRef<adw::EntryRow>,
     port_row: glib::WeakRef<adw::SpinRow>,
@@ -3213,6 +3214,28 @@ fn connect_share_switch(
         // default) — user clicks Reveal to see the real value.
     }
 
+    // Clone `current_auth_key` for the share_row closure before
+    // it consumes local state. The closure reads the cell at
+    // server-start time to thread the key into
+    // `build_server_config_from_panel` without a second
+    // `ensure_server_auth_key()` call. Per `CodeRabbit` round 1
+    // on PR #406.
+    let current_key_for_share = Rc::clone(&current_auth_key);
+
+    // Widget-weak clones threaded into the auth toggle + regenerate
+    // closures so they can rebuild the mDNS advertiser when auth
+    // state changes. Without this, discovery clients keep seeing
+    // stale `auth_required` TXT until the next server restart.
+    // Per `CodeRabbit` round 1 on PR #406.
+    let widgets_weak_for_auth_toggle = widgets_weak.clone();
+
+    // Reentry guard for the auth-toggle handler. When the server
+    // reports a failed `set_auth_key`, the handler reverts the
+    // switch — but `set_active()` fires `connect_active_notify`
+    // again, which would re-run the handler and double-toast.
+    // Mirrors `reentry_guard` on the share_row.
+    let auth_toggle_reentry_guard: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
+
     panels.server.share_row.connect_active_notify(move |row| {
         if reentry_guard.get() {
             return;
@@ -3241,8 +3264,13 @@ fn connect_share_switch(
             }
             // Build a ServerConfig from current panel state. Widget
             // readers run on the main thread — safe to block-read
-            // the rows synchronously.
-            let config = build_server_config_from_panel(&widgets);
+            // the rows synchronously. The pending auth key is
+            // read from `current_key_for_share` so a Reveal-and-Copy
+            // operation before Play uses the same bytes
+            // `Server::start` receives. Per `CodeRabbit` round 1
+            // on PR #406.
+            let pending_auth_key = current_key_for_share.borrow().clone();
+            let config = build_server_config_from_panel(&widgets, pending_auth_key);
             match Server::start(config) {
                 Ok(server) => {
                     // If advertising is on, build the TXT record
@@ -3335,37 +3363,69 @@ fn connect_share_switch(
     // ====================================================
 
     // Master "Require key" toggle.
-    // ON: load-or-generate key from keyring, call
-    //     Server::set_auth_key(Some(bytes)) if running, show
-    //     the key row with masked subtitle.
-    // OFF: call Server::set_auth_key(None) if running, hide
-    //      the key row, drop in-memory bytes. Keyring entry
-    //      is PRESERVED per #395 ("flipping back doesn't
-    //      regenerate").
+    //
+    // Order of operations (per `CodeRabbit` round 1 on PR #406):
+    // 1. Apply the change to the running server FIRST.
+    // 2. Refresh the mDNS advertiser so discovery TXT reflects
+    //    the new `auth_required` flag.
+    // 3. Only mutate UI state (current_auth_key, row visibility,
+    //    subtitle, reveal button) after steps 1 and 2 succeeded.
+    //
+    // On any failure: revert the switch to its pre-toggle state
+    // via `auth_toggle_reentry_guard` so UI ↔ server parity is
+    // preserved. Discovery clients never see "auth advertised"
+    // while the server is unauthed, or vice versa.
+    //
+    // When the server isn't running, steps 1+2 are no-ops and UI
+    // mutation always proceeds — toggling auth with the switch
+    // off is a config-only change and the next Start path
+    // honors it via the pending-key plumbing.
     let key_row_for_toggle = panels.server.auth_key_row.downgrade();
     let reveal_button_for_toggle = panels.server.auth_key_reveal_button.downgrade();
     let current_key_for_toggle = Rc::clone(&current_auth_key);
     let revealed_for_toggle = Rc::clone(&auth_key_revealed);
+    let auth_toggle_guard_for_handler = Rc::clone(&auth_toggle_reentry_guard);
     panels
         .server
         .auth_require_row
         .connect_active_notify(move |row| {
+            if auth_toggle_guard_for_handler.get() {
+                // Re-entered from our own `set_active` revert
+                // path — let the signal settle without running
+                // the handler again.
+                return;
+            }
             let Some(key_row) = key_row_for_toggle.upgrade() else {
                 return;
             };
+            let widgets = widgets_weak_for_auth_toggle.upgrade();
+
             if row.is_active() {
+                // Pending key is the single source of truth for
+                // both the server and any subsequent Reveal /
+                // Copy. Generate / load once, reuse everywhere.
                 let key = ensure_server_auth_key();
-                if let Ok(handle) = running_for_auth_toggle.try_borrow()
-                    && let Some(handle) = handle.as_ref()
-                    && let Err(e) = handle.server.set_auth_key(Some(key.clone()))
-                {
-                    tracing::warn!(%e, "Server::set_auth_key failed on toggle-on");
-                    if let Some(overlay) = toast_overlay_for_auth_toggle.upgrade() {
-                        overlay.add_toast(adw::Toast::new(&format!(
-                            "Couldn't enable auth on the running server: {e}"
-                        )));
-                    }
+
+                // Step 1+2: apply to live server + refresh mDNS.
+                let server_result = apply_live_auth_change(
+                    &running_for_auth_toggle,
+                    Some(key.clone()),
+                    widgets.as_ref(),
+                    &toast_overlay_for_auth_toggle,
+                );
+
+                if !server_result {
+                    // Revert the switch. UI stays on the pre-
+                    // toggle state; the user can click again
+                    // after resolving the server issue.
+                    auth_toggle_guard_for_handler.set(true);
+                    row.set_active(false);
+                    auth_toggle_guard_for_handler.set(false);
+                    return;
                 }
+
+                // Step 3: UI mutation AFTER successful server
+                // change.
                 *current_key_for_toggle.borrow_mut() = Some(key);
                 key_row.set_visible(true);
                 // Reset to masked state on every toggle-on so the
@@ -3376,14 +3436,26 @@ fn connect_share_switch(
                 if let Some(rb) = reveal_button_for_toggle.upgrade() {
                     rb.set_icon_name("view-reveal-symbolic");
                     rb.set_tooltip_text(Some("Reveal key"));
+                    rb.update_property(&[gtk4::accessible::Property::Label("Reveal key")]);
                 }
             } else {
-                if let Ok(handle) = running_for_auth_toggle.try_borrow()
-                    && let Some(handle) = handle.as_ref()
-                    && let Err(e) = handle.server.set_auth_key(None)
-                {
-                    tracing::warn!(%e, "Server::set_auth_key(None) failed on toggle-off");
+                // Same structure for toggle-off. Server call
+                // first; on failure revert the switch so the UI
+                // stays honest about the running auth state.
+                let server_result = apply_live_auth_change(
+                    &running_for_auth_toggle,
+                    None,
+                    widgets.as_ref(),
+                    &toast_overlay_for_auth_toggle,
+                );
+
+                if !server_result {
+                    auth_toggle_guard_for_handler.set(true);
+                    row.set_active(true);
+                    auth_toggle_guard_for_handler.set(false);
+                    return;
                 }
+
                 *current_key_for_toggle.borrow_mut() = None;
                 key_row.set_visible(false);
                 // Zero the revealed flag too so a next toggle-on
@@ -3418,10 +3490,16 @@ fn connect_share_switch(
                 key_row.set_subtitle(&crate::sidebar::server_panel::auth_key_to_hex(bytes));
                 btn.set_icon_name("view-conceal-symbolic");
                 btn.set_tooltip_text(Some("Hide key"));
+                // Flip the accessible label alongside the icon /
+                // tooltip so screen readers announce the current
+                // action rather than the stale build-time label.
+                // Per `CodeRabbit` round 1 on PR #406.
+                btn.update_property(&[gtk4::accessible::Property::Label("Hide key")]);
             } else {
                 key_row.set_subtitle(crate::sidebar::server_panel::AUTH_KEY_MASKED_PLACEHOLDER);
                 btn.set_icon_name("view-reveal-symbolic");
                 btn.set_tooltip_text(Some("Reveal key"));
+                btn.update_property(&[gtk4::accessible::Property::Label("Reveal key")]);
             }
         });
 
@@ -3455,6 +3533,19 @@ fn connect_share_switch(
     // (if running) via set_auth_key, and updates the display
     // row subtitle (preserving the current revealed state so
     // the user can verify the new value immediately).
+    //
+    // UI ↔ server parity (per `CodeRabbit` round 1 on PR #406):
+    // if `Server::set_auth_key` returns `Err`, DO NOT advance
+    // the UI to the new key — the server is still holding the
+    // old key, and showing the user a "new key generated"
+    // message that clients can't actually use with the server
+    // would be a lie. Toast the error, log it, leave
+    // `current_auth_key` + the displayed subtitle on the old
+    // value. The keyring write failure is tolerable (in-memory
+    // recovery next launch); the server write failure is not.
+    //
+    // Regenerate keeps `auth_required = true` so the mDNS TXT
+    // doesn't change — no advertiser refresh needed.
     let key_row_for_regen = panels.server.auth_key_row.downgrade();
     let current_key_for_regen = Rc::clone(&current_auth_key);
     let revealed_for_regen = Rc::clone(&auth_key_revealed);
@@ -3474,16 +3565,27 @@ fn connect_share_switch(
                     )));
                 }
                 // Continue anyway — the in-memory key is still
-                // applied so the current session gets the new
-                // value; the next launch will find the old key
-                // until the save path succeeds.
+                // applied below so the current session gets the
+                // new value; the next launch will find the old
+                // key until the save path succeeds.
             }
+            // Server-side apply. On error, don't advance the UI
+            // state — toast and return so the displayed key
+            // still matches what the server accepts.
             if let Ok(handle) = running_for_auth_regen.try_borrow()
                 && let Some(handle) = handle.as_ref()
                 && let Err(e) = handle.server.set_auth_key(Some(fresh.clone()))
             {
                 tracing::warn!(%e, "Server::set_auth_key failed on regenerate");
+                if let Some(overlay) = toast_overlay_for_regen.upgrade() {
+                    overlay.add_toast(adw::Toast::new(&format!(
+                        "Couldn't apply new key to the running server: {e}"
+                    )));
+                }
+                return;
             }
+            // All server-side gates passed (or server wasn't
+            // running) — commit the UI update.
             *current_key_for_regen.borrow_mut() = Some(fresh.clone());
             if revealed_for_regen.get() {
                 key_row.set_subtitle(&crate::sidebar::server_panel::auth_key_to_hex(&fresh));
@@ -4201,7 +4303,21 @@ const SERVER_BUFFER_CAPACITY_DEFAULT: usize = 0;
     clippy::cast_sign_loss,
     reason = "spin-row values are bounded to u16/u32 ranges at the widget level"
 )]
-fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
+/// Build a `ServerConfig` from the panel's current widget state.
+///
+/// **`auth_key` parameter policy**: caller passes the pending
+/// key already loaded into the panel's `current_auth_key` cell.
+/// This is NOT re-derived inside the function via
+/// `ensure_server_auth_key()` — doing so would risk a second
+/// generate-and-save call with a different random value if the
+/// keyring is unavailable between the UI-seed moment and the
+/// server-start moment. Single source of truth: the key shown
+/// by the Reveal button is exactly what `Server::start`
+/// receives. Per `CodeRabbit` round 1 on PR #406.
+fn build_server_config_from_panel(
+    panel: &ServerSwitchWidgets,
+    pending_auth_key: Option<Vec<u8>>,
+) -> ServerConfig {
     use std::net::SocketAddr;
 
     use crate::sidebar::server_panel::{BIND_ALL_INTERFACES_IDX, BIND_LOOPBACK_IDX};
@@ -4282,14 +4398,15 @@ fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
         // truth at server-start time. Later live-update calls flow
         // through `Server::set_listener_cap` directly. Per #395.
         listener_cap: panel.listener_cap_row.value() as usize,
-        // Auth key pulled from the OS keyring when the "Require
-        // key" toggle is on; `None` otherwise. `ensure_server_auth_key`
-        // generates + saves a 32-byte CSPRNG key on first enable
-        // and reloads the same bytes on subsequent server
-        // restarts (keyring value survives toggle-off/on cycles).
-        // Per #395.
+        // Auth key plumbed from the caller. The panel's
+        // `auth_require_row.is_active()` still dictates whether
+        // auth is on — caller passes `Some(key)` only when the
+        // toggle is active. Caller has already validated the
+        // key length via `ensure_server_auth_key()`; `Server::start`
+        // re-validates defensively before bind. Per `CodeRabbit`
+        // round 1 on PR #406.
         auth_key: if panel.auth_require_row.is_active() {
-            Some(ensure_server_auth_key())
+            pending_auth_key
         } else {
             None
         },
@@ -4348,6 +4465,110 @@ fn build_advertiser(
         },
     };
     Advertiser::announce(opts)
+}
+
+/// Apply an auth-key change to the running server and refresh
+/// the mDNS advertiser atomically. Returns `true` iff the
+/// server actually holds the new state; `false` means the
+/// caller must revert the UI so it stays in sync.
+///
+/// **Success cases:**
+/// - No server is running (`running` cell contains `None`): no
+///   server-side change to apply; caller can proceed with UI.
+/// - Server is running and `set_auth_key(new)` returns `Ok`.
+///   The advertiser is then rebuilt via
+///   `refresh_advertiser_for_auth_change` so the TXT record
+///   reflects the new `auth_required` state.
+///
+/// **Failure cases:**
+/// - `try_borrow_mut` on the running-server cell fails (another
+///   handler holds a mutable borrow — rare, mid-click race).
+///   Caller reverts the switch; next click usually wins.
+/// - `set_auth_key` returns `Err` (e.g., mutex poisoned). The
+///   toast surfaces the error and the caller reverts UI state.
+///
+/// Does NOT touch UI state — caller owns the UI mutation gate.
+/// Per `CodeRabbit` round 1 on PR #406.
+fn apply_live_auth_change(
+    running: &Rc<RefCell<Option<RunningServer>>>,
+    new_key: Option<Vec<u8>>,
+    widgets: Option<&ServerSwitchWidgets>,
+    toast_overlay: &glib::WeakRef<adw::ToastOverlay>,
+) -> bool {
+    let Ok(mut handle_cell) = running.try_borrow_mut() else {
+        tracing::warn!("auth change skipped — running-server cell busy");
+        return false;
+    };
+    let Some(handle) = handle_cell.as_mut() else {
+        // Server not running — UI-only change is always fine.
+        return true;
+    };
+    if let Err(e) = handle.server.set_auth_key(new_key) {
+        tracing::warn!(%e, "Server::set_auth_key failed on live auth change");
+        if let Some(overlay) = toast_overlay.upgrade() {
+            overlay.add_toast(adw::Toast::new(&format!(
+                "Couldn't update auth on the running server: {e}"
+            )));
+        }
+        return false;
+    }
+    // mDNS TXT refresh. Only meaningful when we have widget refs
+    // (caller upgraded `widgets_weak` before the call).
+    if let Some(widgets) = widgets {
+        refresh_advertiser_for_auth_change(handle, widgets, toast_overlay);
+    }
+    true
+}
+
+/// Tear down and rebuild the running server's mDNS advertiser so
+/// its TXT record reflects the current `Server::auth_required()`
+/// state. Called after every successful live auth toggle so
+/// discovery clients see the new `auth_required=true|absent`
+/// flag without waiting for a server restart.
+///
+/// **No-op when:**
+/// - No server is running (`handle` is `None`).
+/// - The user has advertising turned off (`advertise_row`
+///   inactive). Honors the user's choice — we don't bring
+///   advertising back online just because auth flipped.
+///
+/// **Error path:** `build_advertiser` failures log + toast
+/// (same pattern as the initial server-start advertise failure).
+/// The server itself keeps running without a fresh TXT; worst
+/// case, clients see stale auth metadata until the server is
+/// restarted. Never panics, never leaves a half-registered
+/// advertiser in place. Per `CodeRabbit` round 1 on PR #406.
+fn refresh_advertiser_for_auth_change(
+    handle: &mut RunningServer,
+    widgets: &ServerSwitchWidgets,
+    toast_overlay: &glib::WeakRef<adw::ToastOverlay>,
+) {
+    if !widgets.advertise_row.is_active() {
+        // User turned advertising off — don't sneak it back on.
+        return;
+    }
+    // Drop the old advertiser FIRST so its Drop-based unregister
+    // fires before we re-announce under the same instance name.
+    // mdns-sd allows back-to-back registers with the same name
+    // but cleanly bracketed unregister/register avoids a window
+    // where duplicate records briefly coexist on the LAN.
+    drop(handle.advertiser.take());
+    match build_advertiser(&handle.server, &widgets.nickname_row.text()) {
+        Ok(adv) => {
+            handle.advertiser = Some(adv);
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "mDNS advertiser rebuild after auth toggle failed; TXT auth_required will be stale until next start"
+            );
+            if let Some(overlay) = toast_overlay.upgrade() {
+                overlay.add_toast(adw::Toast::new(&format!(
+                    "Couldn't refresh mDNS advertisement after auth toggle: {e}"
+                )));
+            }
+        }
+    }
 }
 
 /// Lock or unlock the server-config rows. Called with `true` on

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2958,6 +2958,7 @@ struct ServerSwitchWidgetsWeak {
     bind_row: glib::WeakRef<adw::ComboRow>,
     advertise_row: glib::WeakRef<adw::SwitchRow>,
     compression_row: glib::WeakRef<adw::ComboRow>,
+    listener_cap_row: glib::WeakRef<adw::SpinRow>,
     device_defaults_row: glib::WeakRef<adw::ExpanderRow>,
     center_freq_row: glib::WeakRef<adw::SpinRow>,
     sample_rate_row: glib::WeakRef<adw::ComboRow>,
@@ -2986,6 +2987,7 @@ struct ServerSwitchWidgets {
     bind_row: adw::ComboRow,
     advertise_row: adw::SwitchRow,
     compression_row: adw::ComboRow,
+    listener_cap_row: adw::SpinRow,
     device_defaults_row: adw::ExpanderRow,
     center_freq_row: adw::SpinRow,
     sample_rate_row: adw::ComboRow,
@@ -3012,6 +3014,7 @@ impl ServerSwitchWidgetsWeak {
             bind_row: s.bind_row.downgrade(),
             advertise_row: s.advertise_row.downgrade(),
             compression_row: s.compression_row.downgrade(),
+            listener_cap_row: s.listener_cap_row.downgrade(),
             device_defaults_row: s.device_defaults_row.downgrade(),
             center_freq_row: s.center_freq_row.downgrade(),
             sample_rate_row: s.sample_rate_row.downgrade(),
@@ -3039,6 +3042,7 @@ impl ServerSwitchWidgetsWeak {
             bind_row: self.bind_row.upgrade()?,
             advertise_row: self.advertise_row.upgrade()?,
             compression_row: self.compression_row.upgrade()?,
+            listener_cap_row: self.listener_cap_row.upgrade()?,
             device_defaults_row: self.device_defaults_row.upgrade()?,
             center_freq_row: self.center_freq_row.upgrade()?,
             sample_rate_row: self.sample_rate_row.upgrade()?,
@@ -3081,6 +3085,13 @@ fn connect_share_switch(
     // self-cycle with the `connect_active_notify` subscription.
     // Upgraded per-callback so strong refs live for one tick only.
     let widgets_weak = ServerSwitchWidgetsWeak::from_panels(panels);
+
+    // Clone the `running` handle for the listener-cap live-apply
+    // closure BEFORE the `share_row` active-notify handler
+    // below consumes the outer `running` by move. Both closures
+    // share the same `RefCell`; neither holds a borrow past its
+    // own tick. Per #395.
+    let running_for_cap = Rc::clone(&running);
 
     panels.server.share_row.connect_active_notify(move |row| {
         if reentry_guard.get() {
@@ -3191,6 +3202,35 @@ fn connect_share_switch(
             reset_activity_log(&widgets);
         }
         apply_visibility();
+    });
+
+    // Listener-cap live-apply. Changes on the spin row take effect
+    // on the next client accept without restarting the server. The
+    // row also persists to sdr_config via a separate signal
+    // attached inside `server_panel.rs`; this handler only cares
+    // about the running-server case. Per issue #395.
+    panels.server.listener_cap_row.connect_value_notify(move |row| {
+        let Ok(handle) = running_for_cap.try_borrow() else {
+            // Another handler is holding the `RunningServer` borrow
+            // (e.g. the share_row active-notify flipping server
+            // start/stop). Skip this tick — the spin row's new
+            // value is already persisted via the server_panel
+            // signal, and the next accept after start will pick
+            // it up through `build_server_config_from_panel`.
+            return;
+        };
+        let Some(handle) = handle.as_ref() else {
+            // Server not running — the spin row edit is already
+            // persisted; nothing to apply live.
+            return;
+        };
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "spin row bounded to [MIN_LISTENER_CAP, MAX_LISTENER_CAP] at the widget level"
+        )]
+        let cap = row.value() as usize;
+        handle.server.set_listener_cap(cap);
     });
 }
 
@@ -3815,7 +3855,11 @@ fn build_server_config_from_panel(panel: &ServerSwitchWidgets) -> ServerConfig {
         },
         buffer_capacity: SERVER_BUFFER_CAPACITY_DEFAULT,
         compression,
-        listener_cap: sdr_server_rtltcp::DEFAULT_LISTENER_CAP,
+        // Listener cap pulled from the panel's live widget value so
+        // the spin row's current position is the single source of
+        // truth at server-start time. Later live-update calls flow
+        // through `Server::set_listener_cap` directly. Per #395.
+        listener_cap: panel.listener_cap_row.value() as usize,
         // Auth defaults to off (None) — enabling it lives behind
         // the #395 server UI toggle. #394 ships the wire + server
         // enforcement plumbing; the UI knob + keyring storage


### PR DESCRIPTION
## Summary

Closes #395 — fifth sub-issue of multi-client epic #390. Adds the server-side UI for the features shipped across #391-#394: live listener cap knob, pre-shared-key auth toggle with keyring storage, and a connected-clients list with per-client role badges, duration, and drop counters. Five implementation commits, no wire/protocol changes (all backend surface was already there from PRs #402-#405).

Behind the scenes, the server crate grows a minimal live-update API (`Server::set_listener_cap` / `set_auth_key`) so UI edits take effect on the next accept without restarting (and kicking all connected clients). The mDNS `TxtRecord` gains an `auth_required` field so discovery clients can prompt for a key BEFORE dispatching connect.

## Commits

1. **`a6f41c7`** — `Server::set_listener_cap(n)` + `set_auth_key(key)` backed by `Arc<AtomicUsize>` / `Arc<Mutex<Option<Vec<u8>>>>`. Shared `validate_auth_key_length` helper so the live-update surface cannot accept inputs `Server::start` would refuse. Accept + handshake paths snapshot their respective values once per connection. 4 new unit tests for the validator.
2. **`837853c`** — `TxtRecord.auth_required: Option<bool>`. `Some(true)` emits `auth_required=true`; everything else omits. Parser accepts `true` / `1` / `yes` case-insensitively. CLI and GTK advertisers wired via new `Server::auth_required()` accessor. 4 new tests.
3. **`690af0e`** — Listener cap `AdwSpinRow`, range [0, 32], default 10. Config persistence + live-apply on change. Intentionally NOT in `set_controls_locked` so the user can tune the cap without restarting.
4. **`c707ca0`** — "Require key" `AdwSwitchRow` + `auth_key_row` with masked/reveal subtitle, Copy, Regenerate. Keyring storage via `KEYRING_KEY_AUTH_KEY` as lowercase hex. `ensure_server_auth_key()` load-or-generate. 3 new tests for the hex helpers (round-trip, malformed rejection incl. non-ASCII emoji, empty-input edge case).
5. **`bfaa415`** — "Connected clients" expander with per-client `AdwActionRow`: peer title, `{role} · {duration} · {drops}` subtitle, colored dot prefix (accent for Controller, dim for Listener). Diff by sorted `ClientId` hash so the ListBox rebuilds only on accept/disconnect (user scroll / hover state survive poll cadence).

## Live-update design

Listener cap and auth key are both specified as live-updatable on a running server (issue says "change takes effect on next accept"). New `Server` methods:
- `set_listener_cap(n: usize)` — `Relaxed` store, accept thread reads per admission
- `set_auth_key(key: Option<Vec<u8>>) -> Result<(), ServerError>` — validates length, then mutex-stored, handshake snapshots once per connection
- `set_auth_key` uses the same `validate_auth_key_length` helper as `Server::start` so construction and live-update enforce identical `None | 1..=256` rule.

`spawn_client_workers` snapshots `auth_key` **once** at entry so a mid-handshake `set_auth_key` can't split an eager client's key bytes (written against the old value) from the server's validation (running against the new value). Each handshake is bound to a single key view.

## Test plan

- [ ] `make install CARGO_FLAGS="--release --features whisper-cuda"` — build clean (verified locally)
- [ ] Panel visibility: starts hidden, appears when non-RTLSDR source is selected with a dongle plugged in
- [ ] Listener cap: spin up/down; setting 0 + connecting a listener → server denies with `ListenerCapReached`
- [ ] Listener cap live: with a listener already connected, drop the cap to 0 → listener stays, next listener gets denied
- [ ] Auth toggle on: key row appears with masked subtitle
- [ ] Auth reveal button: flips subtitle between masked and 64-char hex; icon flips
- [ ] Auth copy: clipboard contains the full hex; toast confirms
- [ ] Auth regenerate: subtitle updates; old key fails on the next reconnect (test with `sdr-rtl-tcp --auth-key <old-hex>`); toast confirms
- [ ] Auth toggle off: key row hides; keyring entry preserved (toggle back on reloads same key)
- [ ] Connected clients list: connect one controller + one listener with a vanilla client (e.g. `nc localhost 1234`) and our client → both rows render with correct role badge and duration
- [ ] Clients list empty state: "No clients connected" row when no one connected
- [ ] Server restart across session: toggle auth off → stop → start → toggle auth back on → same keyring key surfaces
- [ ] mDNS TXT: with auth on, another instance's discovery picker should show "auth_required" in the entry (future #396 UI will surface this; today, grep `avahi-browse -r _rtl_tcp._tcp` for `auth_required=true`)

## Remaining epic #390 sub-issues

- **#396** — client UI (role picker + takeover button + kicked toast + auth key field) — next PR
- **#397** — FIPS-compliant transport encryption (investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server auth key management: reveal, copy, regenerate with OS keyring-backed persistence and graceful fallback.
  * Live-adjustable listener capacity with immediate application.
  * Connected clients list in server panel with per-client details.
  * Discovery now advertises whether authentication is required and updates live.

* **Quality / Tests**
  * Unit and integration tests updated to validate TXT record handling, auth-key import/export rules, and live-update behavior.

* **Validation**
  * Strict lowercase-hex validation for auth-key import/export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->