### PR TITLE
rtl_tcp client UI: role picker, take-control toast, auth key, role badge (#396)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "sdr-radio",
  "sdr-rtlsdr",
  "sdr-scanner",
+ "sdr-server-rtltcp",
  "sdr-sink-audio",
  "sdr-sink-network",
  "sdr-source-file",

--- a/crates/sdr-core/Cargo.toml
+++ b/crates/sdr-core/Cargo.toml
@@ -30,6 +30,14 @@ sdr-scanner.workspace = true
 sdr-rtlsdr.workspace = true
 sdr-source-rtlsdr.workspace = true
 sdr-source-network.workspace = true
+# `sdr-server-rtltcp` is pulled in for its
+# `extension::Role` enum, used by the `UiToDsp::SetRtlTcpClientConfig`
+# message added in #396. The role is already in the dependency
+# graph transitively (via `sdr-source-network`), but naming it
+# directly here lets us reference the type without going through
+# the source-client's re-export chain and keeps the controller's
+# type imports flat. Per #396.
+sdr-server-rtltcp.workspace = true
 sdr-source-file.workspace = true
 sdr-sink-network.workspace = true
 thiserror.workspace = true

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1620,6 +1620,68 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 }
             }
         }
+        UiToDsp::RetryRtlTcpWithTakeover => {
+            // One-shot Take-control reconnect per #396. Rebuild
+            // the `rtl_tcp` source with `request_takeover = true`
+            // on the hello, then stop + start to trigger the
+            // handshake. The flag is not persisted on `DspState`
+            // — the source is destroyed + recreated with
+            // `request_takeover = false` on the NEXT open_source
+            // (scheduled when the user hits Play after Stop, a
+            // fresh source-type switch, etc.). Keeping takeover
+            // "one-shot per action" matches the #393 spec:
+            // takeover is an explicit user decision, not a
+            // persistent preference.
+            if state.source_type != SourceType::RtlTcp {
+                tracing::debug!(
+                    active = ?state.source_type,
+                    "RetryRtlTcpWithTakeover ignored — active source is not RtlTcp"
+                );
+                return;
+            }
+            // Stop the current source first (if any) so its
+            // connection manager thread exits cleanly before we
+            // open a fresh source with the takeover flag.
+            // `source` drops at the end of the if-let — the
+            // manager thread joins on Drop, so the next
+            // open_source sees a quiescent slot.
+            if let Some(mut source) = state.source.take()
+                && let Err(e) = source.stop()
+            {
+                tracing::warn!(error = %e, "rtl_tcp stop before takeover-retry failed");
+            }
+            // Build a one-shot config with takeover + the
+            // user's current role / auth choices. `Default`
+            // covers timeouts + compression; `requested_role`
+            // and `auth_key` come from the SetRtlTcpClientConfig
+            // state carried across the retry. After this
+            // source's lifetime ends, a fresh open_source will
+            // build without `request_takeover`.
+            let rtl_tcp_config = sdr_source_network::rtl_tcp::RtlTcpConfig {
+                requested_role: state.rtl_tcp_requested_role,
+                auth_key: state.rtl_tcp_auth_key.clone(),
+                request_takeover: true,
+                ..Default::default()
+            };
+            let mut source: Box<dyn sdr_pipeline::source_manager::Source> =
+                Box::new(sdr_source_network::RtlTcpSource::with_config(
+                    &state.network_host,
+                    state.network_port,
+                    rtl_tcp_config,
+                ));
+            if let Err(e) = source.set_sample_rate(state.configured_sample_rate) {
+                tracing::warn!(error = %e, "takeover-retry set_sample_rate failed");
+            }
+            if let Err(e) = source.tune(state.center_freq) {
+                tracing::warn!(error = %e, "takeover-retry tune failed");
+            }
+            if let Err(e) = source.start() {
+                tracing::warn!(error = %e, "rtl_tcp takeover-retry start failed");
+                let _ = dsp_tx.send(DspToUi::Error(format!("Take control failed: {e}")));
+                return;
+            }
+            state.source = Some(source);
+        }
         // --- Scanner (#317) ---
         UiToDsp::SetScannerEnabled(enabled) => {
             if enabled {

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1599,10 +1599,26 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             let _ = dsp_tx.send(DspToUi::SourceStopped);
         }
         UiToDsp::RetryRtlTcpNow => {
-            // Same source-type gate as Disconnect. "Retry now"
-            // implements as stop+start so the current backoff
-            // sleep is short-circuited; the existing start_manager
-            // path tears up a fresh connection from Connecting.
+            // "Retry now" REBUILDS the `RtlTcpSource` from the
+            // latest `DspState` (role + auth_key) instead of just
+            // stopping + starting the existing instance. Rebuild
+            // is required because the role / auth-key config is
+            // baked into `RtlTcpSource` at construction via
+            // `with_config(...)`; a subsequent `start()` on the
+            // same instance replays its original `ClientHello`,
+            // which means a newly-entered key or flipped role
+            // from the UI would never land on the wire until the
+            // user forced a full source tear-down (Stop + Play,
+            // source-type switch). After an `AuthRequired` /
+            // `AuthFailed` / `ControllerBusy` denial those retry
+            // semantics are explicitly user-driven, so the
+            // rebuild is the correct behavior.
+            //
+            // The sticky-command replay cache (gain, AGC, PPM,
+            // bias tee, direct sampling, etc.) is carried across
+            // the rebuild via the Source-trait snapshot hooks so
+            // the reconnect lands with the pre-retry device state.
+            // Per `CodeRabbit` round 3 on PR #408.
             if state.source_type != SourceType::RtlTcp {
                 tracing::debug!(
                     active = ?state.source_type,
@@ -1610,25 +1626,20 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 );
                 return;
             }
-            if let Some(source) = state.source.as_mut() {
-                if let Err(e) = source.stop() {
-                    tracing::warn!(error = %e, "rtl_tcp stop before retry failed");
-                }
-                if let Err(e) = source.start() {
-                    tracing::warn!(error = %e, "rtl_tcp restart failed");
-                    let _ = dsp_tx.send(DspToUi::Error(format!("Retry failed: {e}")));
-                }
+            if state.source.is_none() {
+                tracing::debug!("RetryRtlTcpNow ignored — no live source (was disconnected)");
+                return;
             }
+            rebuild_rtl_tcp_source(state, dsp_tx, /* request_takeover */ false);
         }
         UiToDsp::RetryRtlTcpWithTakeover => {
-            // One-shot Take-control reconnect per #396. Rebuild
-            // the `rtl_tcp` source with `request_takeover = true`
-            // on the hello, then stop + start to trigger the
-            // handshake. The flag is not persisted on `DspState`
-            // — the source is destroyed + recreated with
-            // `request_takeover = false` on the NEXT open_source
-            // (scheduled when the user hits Play after Stop, a
-            // fresh source-type switch, etc.). Keeping takeover
+            // One-shot Take-control reconnect per #396. Same
+            // rebuild machinery as `RetryRtlTcpNow`, but with
+            // `request_takeover = true` set on the rebuilt
+            // config's `ClientHello`. The flag doesn't persist on
+            // `DspState` — the next non-takeover retry or a
+            // fresh `open_source` (Play after Stop, source-type
+            // switch) rebuilds without it. Keeping takeover
             // "one-shot per action" matches the #393 spec:
             // takeover is an explicit user decision, not a
             // persistent preference.
@@ -1639,7 +1650,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 );
                 return;
             }
-            // Also gate on a live source. After DisconnectRtlTcp
+            // Gate on a live source. After `DisconnectRtlTcp`
             // the source is gone (`state.source = None`) but
             // `state.source_type` remains `RtlTcp`, so a stale
             // "Take control" toast action could otherwise
@@ -1653,48 +1664,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 );
                 return;
             }
-            // Stop the current source first so its connection
-            // manager thread exits cleanly before we open a
-            // fresh source with the takeover flag. `source`
-            // drops at the end of the if-let — the manager
-            // thread joins on Drop, so the next open_source
-            // sees a quiescent slot.
-            if let Some(mut source) = state.source.take()
-                && let Err(e) = source.stop()
-            {
-                tracing::warn!(error = %e, "rtl_tcp stop before takeover-retry failed");
-            }
-            // Build a one-shot config with takeover + the
-            // user's current role / auth choices. `Default`
-            // covers timeouts + compression; `requested_role`
-            // and `auth_key` come from the SetRtlTcpClientConfig
-            // state carried across the retry. After this
-            // source's lifetime ends, a fresh open_source will
-            // build without `request_takeover`.
-            let rtl_tcp_config = sdr_source_network::rtl_tcp::RtlTcpConfig {
-                requested_role: state.rtl_tcp_requested_role,
-                auth_key: state.rtl_tcp_auth_key.clone(),
-                request_takeover: true,
-                ..Default::default()
-            };
-            let mut source: Box<dyn sdr_pipeline::source_manager::Source> =
-                Box::new(sdr_source_network::RtlTcpSource::with_config(
-                    &state.network_host,
-                    state.network_port,
-                    rtl_tcp_config,
-                ));
-            if let Err(e) = source.set_sample_rate(state.configured_sample_rate) {
-                tracing::warn!(error = %e, "takeover-retry set_sample_rate failed");
-            }
-            if let Err(e) = source.tune(state.center_freq) {
-                tracing::warn!(error = %e, "takeover-retry tune failed");
-            }
-            if let Err(e) = source.start() {
-                tracing::warn!(error = %e, "rtl_tcp takeover-retry start failed");
-                let _ = dsp_tx.send(DspToUi::Error(format!("Take control failed: {e}")));
-                return;
-            }
-            state.source = Some(source);
+            rebuild_rtl_tcp_source(state, dsp_tx, /* request_takeover */ true);
         }
         // --- Scanner (#317) ---
         UiToDsp::SetScannerEnabled(enabled) => {
@@ -2020,6 +1990,120 @@ fn emit_scanner_active_channel(
         },
     };
     let _ = dsp_tx.send(msg);
+}
+
+/// Destroy the current `RtlTcpSource` and construct a fresh one
+/// with the latest role / `auth_key` config from `DspState`, then
+/// start it. Used by both `RetryRtlTcpNow` (ordinary manual
+/// retry after an `AuthRequired` / `AuthFailed` / `ControllerBusy`
+/// denial) and `RetryRtlTcpWithTakeover` (the #393 "Take
+/// control" one-shot).
+///
+/// **Why rebuild instead of stop+start the existing source:** the
+/// `ClientHello` is built at `with_config(...)` time from the
+/// `RtlTcpConfig` passed to the constructor. Calling `start()` on
+/// the same instance replays its original hello — a newly entered
+/// auth key or a flipped role would never land on the wire until
+/// a full source tear-down (Stop + Play, source-type switch).
+/// Rebuilding picks up the current `state.rtl_tcp_requested_role`
+/// and `state.rtl_tcp_auth_key` for the next hello, which is the
+/// behavior the UI expects after any denial arm.
+///
+/// **Sticky-command cache:** the previous source's replay
+/// snapshot (gain, AGC, PPM, bias tee, direct sampling, etc.) is
+/// captured via `Source::rtl_tcp_sticky_snapshot()` and restored
+/// onto the new instance BEFORE `start()` so the reconnect's
+/// `replay_sticky_commands` emits the same setters the old
+/// session had. Without this, a takeover / auth-retry rebuild
+/// would reset device state to defaults (gain = 0, AGC off, PPM
+/// = 0, ...) and the user would lose their tuning setup.
+///
+/// `request_takeover` is the one bit of per-call config not read
+/// from `DspState` — we keep takeover as an explicit one-shot
+/// parameter so the next non-takeover retry or `open_source` call
+/// cleanly starts without the flag.
+///
+/// Caller must have already ensured `state.source_type ==
+/// RtlTcp` and `state.source.is_some()`. Per `CodeRabbit` round
+/// 3 on PR #408.
+fn rebuild_rtl_tcp_source(
+    state: &mut DspState,
+    dsp_tx: &std::sync::mpsc::Sender<DspToUi>,
+    request_takeover: bool,
+) {
+    let error_prefix = if request_takeover {
+        "Take control failed"
+    } else {
+        "Retry failed"
+    };
+    // Snapshot the replay cache + drop the old source. The
+    // Source-trait hook returns `None` for non-RtlTcp sources —
+    // can't happen here given the caller's `source_type` gate,
+    // but `unwrap_or_default()` keeps this defensive.
+    let sticky_snapshot = state
+        .source
+        .as_ref()
+        .and_then(|s| s.rtl_tcp_sticky_snapshot())
+        .unwrap_or_default();
+    if let Some(mut source) = state.source.take()
+        && let Err(e) = source.stop()
+    {
+        tracing::warn!(
+            error = %e,
+            request_takeover,
+            "rtl_tcp stop before rebuild failed"
+        );
+    }
+    // Build the fresh config from the latest DspState.
+    // `Default` covers timeouts + compression; role and auth
+    // come from state, and `request_takeover` is the caller's
+    // one-shot choice.
+    let rtl_tcp_config = sdr_source_network::rtl_tcp::RtlTcpConfig {
+        requested_role: state.rtl_tcp_requested_role,
+        auth_key: state.rtl_tcp_auth_key.clone(),
+        request_takeover,
+        ..Default::default()
+    };
+    let mut source: Box<dyn Source> = Box::new(sdr_source_network::RtlTcpSource::with_config(
+        &state.network_host,
+        state.network_port,
+        rtl_tcp_config,
+    ));
+    // Restore sticky cache BEFORE `start()` so the manager
+    // thread's `replay_sticky_commands` call on the freshly-
+    // opened stream already sees the pre-rebuild values.
+    source.rtl_tcp_restore_sticky_snapshot(&sticky_snapshot);
+    // Reapply sample rate + tune on the new instance — these
+    // are derived from `DspState`, not the snapshot, because
+    // they can change between the snapshot and the restart
+    // (e.g., a user sample-rate switch while the old source
+    // was in `AuthRequired`). Both calls also update the
+    // sticky cache on the new source, which is fine — any
+    // subsequent reconnect replays the fresher value.
+    if let Err(e) = source.set_sample_rate(state.configured_sample_rate) {
+        tracing::warn!(
+            error = %e,
+            request_takeover,
+            "rtl_tcp rebuild set_sample_rate failed"
+        );
+    }
+    if let Err(e) = source.tune(state.center_freq) {
+        tracing::warn!(
+            error = %e,
+            request_takeover,
+            "rtl_tcp rebuild tune failed"
+        );
+    }
+    if let Err(e) = source.start() {
+        tracing::warn!(
+            error = %e,
+            request_takeover,
+            "rtl_tcp rebuild start failed"
+        );
+        let _ = dsp_tx.send(DspToUi::Error(format!("{error_prefix}: {e}")));
+        return;
+    }
+    state.source = Some(source);
 }
 
 /// Open the active IQ source and configure it for streaming.

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1639,12 +1639,26 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 );
                 return;
             }
-            // Stop the current source first (if any) so its
-            // connection manager thread exits cleanly before we
-            // open a fresh source with the takeover flag.
-            // `source` drops at the end of the if-let — the
-            // manager thread joins on Drop, so the next
-            // open_source sees a quiescent slot.
+            // Also gate on a live source. After DisconnectRtlTcp
+            // the source is gone (`state.source = None`) but
+            // `state.source_type` remains `RtlTcp`, so a stale
+            // "Take control" toast action could otherwise
+            // recreate + start a fresh source here — breaking
+            // the disconnect contract (reopen path after an
+            // explicit disconnect is Play/Start, not a retry
+            // command). Mirrors the `RetryRtlTcpNow` gate above.
+            if state.source.is_none() {
+                tracing::debug!(
+                    "RetryRtlTcpWithTakeover ignored — no live source (was disconnected)"
+                );
+                return;
+            }
+            // Stop the current source first so its connection
+            // manager thread exits cleanly before we open a
+            // fresh source with the takeover flag. `source`
+            // drops at the end of the if-let — the manager
+            // thread joins on Drop, so the next open_source
+            // sees a quiescent slot.
             if let Some(mut source) = state.source.take()
                 && let Err(e) = source.stop()
             {

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -282,6 +282,16 @@ struct DspState {
     network_host: String,
     network_port: u16,
     network_protocol: sdr_types::Protocol,
+    /// Role the `rtl_tcp` client requests in its `ClientHello`.
+    /// Default `Role::Control` matches the pre-#392 single-
+    /// client flow every legacy client assumes; UI flips this
+    /// to `Role::Listen` when the user picks the Listen option
+    /// in the connection-role combo row. Per #396.
+    rtl_tcp_requested_role: sdr_server_rtltcp::extension::Role,
+    /// Pre-shared key (#394) to send eagerly on `rtl_tcp`
+    /// connect. `None` disables the auth gate; `Some(bytes)`
+    /// activates the eager-auth path. Per #396.
+    rtl_tcp_auth_key: Option<Vec<u8>>,
     file_path: std::path::PathBuf,
     /// Loop-on-EOF flag for the file playback source. Default
     /// `false` (stop at EOF). Updated by `UiToDsp::SetFileLooping`
@@ -439,6 +449,8 @@ impl DspState {
             network_host: "127.0.0.1".to_string(),
             network_port: 1234,
             network_protocol: sdr_types::Protocol::TcpClient,
+            rtl_tcp_requested_role: sdr_server_rtltcp::extension::Role::Control,
+            rtl_tcp_auth_key: None,
             file_path: std::path::PathBuf::new(),
             file_looping: false,
             iq_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
@@ -1276,6 +1288,27 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             state.network_protocol = protocol;
         }
 
+        UiToDsp::SetRtlTcpClientConfig {
+            requested_role,
+            auth_key,
+        } => {
+            // Role-only updates log the role; auth-key updates
+            // log the has/not-has state, not the bytes.
+            tracing::debug!(
+                ?requested_role,
+                auth_key_set = auth_key.is_some(),
+                "set rtl_tcp client config"
+            );
+            state.rtl_tcp_requested_role = requested_role;
+            state.rtl_tcp_auth_key = auth_key;
+            // Takes effect on the NEXT connect. An already-
+            // running rtl_tcp session keeps its admitted role
+            // until it disconnects — changing role mid-stream
+            // would require the server to re-admit the client,
+            // which the wire protocol doesn't support (the
+            // role byte is part of the hello). Per issue #396.
+        }
+
         UiToDsp::SetFilePath(path) => {
             tracing::debug!(?path, "set file path");
             state.file_path = path;
@@ -1936,12 +1969,27 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
         // server, handshakes the 12-byte RTL0 header, and routes
         // future tune / gain / PPM messages through the 5-byte
         // command channel. Reuses the `network_host` + `network_port`
-        // config fields since the connection shape is the same (no
-        // separate RtlTcpConfig state field needed).
-        SourceType::RtlTcp => Box::new(sdr_source_network::RtlTcpSource::new(
-            &state.network_host,
-            state.network_port,
-        )),
+        // config fields for address, but also threads the #396
+        // `requested_role` + `auth_key` fields from state into an
+        // `RtlTcpConfig` so the hello carries the user's choices.
+        // Non-default role / auth opt-ins are RTLX-only — safe
+        // against any server advertising `codecs=3`; unsafe against
+        // vanilla rtl_tcp servers (which mis-parse the 8-byte hello
+        // as two 5-byte commands). The source panel's discovery
+        // gating is responsible for refusing those opt-ins against
+        // legacy-only servers. Per #396.
+        SourceType::RtlTcp => {
+            let rtl_tcp_config = sdr_source_network::rtl_tcp::RtlTcpConfig {
+                requested_role: state.rtl_tcp_requested_role,
+                auth_key: state.rtl_tcp_auth_key.clone(),
+                ..Default::default()
+            };
+            Box::new(sdr_source_network::RtlTcpSource::with_config(
+                &state.network_host,
+                state.network_port,
+                rtl_tcp_config,
+            ))
+        }
     };
 
     if let Err(e) = source.set_sample_rate(state.configured_sample_rate) {

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -2048,12 +2048,32 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
         // config fields for address, but also threads the #396
         // `requested_role` + `auth_key` fields from state into an
         // `RtlTcpConfig` so the hello carries the user's choices.
-        // Non-default role / auth opt-ins are RTLX-only — safe
-        // against any server advertising `codecs=3`; unsafe against
-        // vanilla rtl_tcp servers (which mis-parse the 8-byte hello
-        // as two 5-byte commands). The source panel's discovery
-        // gating is responsible for refusing those opt-ins against
-        // legacy-only servers. Per #396.
+        //
+        // **Capability signals, in narrow scope:**
+        // - `codecs=3` in the mDNS TXT record says "this server
+        //   parses `ClientHello`, so a hello won't be mis-framed as
+        //   two 5-byte commands." That makes `compression`,
+        //   `request_takeover`, and `requested_role` opt-ins wire-
+        //   safe on this server. It does **NOT** prove the server
+        //   supports auth — auth uses the v2 protocol path, which
+        //   `codecs=3` doesn't speak to.
+        // - Auth capability is a separate signal: the #394 servers
+        //   advertise `auth_required` (present in the mDNS TXT
+        //   record and persisted on `FavoriteEntry`) AND accept
+        //   hellos with `PROTOCOL_VERSION_V2`. Eager-auth hellos
+        //   therefore require v2 — `required_protocol_version(flags)`
+        //   in `sdr-source-network` picks the minimum viable version
+        //   from the flag set, returning v2 when `FLAG_HAS_AUTH` is
+        //   set. Sending an auth-bearing hello to a `codecs=3`-only
+        //   server that doesn't understand v2 will bounce at the
+        //   server's version gate.
+        //
+        // The source panel's discovery gating is responsible for
+        // refusing role / compression / takeover opt-ins against
+        // legacy-only (non-`codecs=3`) servers, and for only
+        // offering the auth field on servers that advertise
+        // `auth_required`. Per #396 / `CodeRabbit` round 2 on
+        // PR #408.
         SourceType::RtlTcp => {
             let rtl_tcp_config = sdr_source_network::rtl_tcp::RtlTcpConfig {
                 requested_role: state.rtl_tcp_requested_role,

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -507,6 +507,7 @@ mod tests {
             tuner_name: "R820T".into(),
             gain_count: 29,
             codec: "None".into(),
+            granted_role: Some(true),
         });
         assert!(matches!(
             connected,
@@ -826,6 +827,30 @@ mod tests {
         assert!(matches!(disc, UiToDsp::DisconnectRtlTcp));
         let retry = UiToDsp::RetryRtlTcpNow;
         assert!(matches!(retry, UiToDsp::RetryRtlTcpNow));
+
+        // RTL-TCP role + auth-key config (issue #396). Constructed
+        // with a non-default Listen role and a plausible 32-byte
+        // key so the shape regression fires on either a field
+        // rename / retyping OR the re-export path going stale. The
+        // matching `SetRtlTcpClientConfig` handler is load-bearing
+        // for the role picker and per-server keyring flows.
+        let cfg = UiToDsp::SetRtlTcpClientConfig {
+            requested_role: sdr_server_rtltcp::extension::Role::Listen,
+            auth_key: Some(vec![0xAB; 32]),
+        };
+        assert!(matches!(
+            cfg,
+            UiToDsp::SetRtlTcpClientConfig {
+                requested_role: sdr_server_rtltcp::extension::Role::Listen,
+                auth_key: Some(ref bytes),
+            } if bytes.len() == 32 && bytes.iter().all(|&b| b == 0xAB)
+        ));
+
+        // `RetryRtlTcpWithTakeover` is a unit variant today, but
+        // the pattern match fails loudly if that changes (e.g.
+        // a future refactor adds a scoped-reason payload).
+        let takeover = UiToDsp::RetryRtlTcpWithTakeover;
+        assert!(matches!(takeover, UiToDsp::RetryRtlTcpWithTakeover));
     }
 
     #[test]

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -267,6 +267,25 @@ pub enum UiToDsp {
         port: u16,
         protocol: sdr_types::Protocol,
     },
+    /// Configure `rtl_tcp` client role + auth key. Takes effect
+    /// on the NEXT connect (already-open sessions keep their
+    /// admitted role until they disconnect). `requested_role`
+    /// drives the `ClientHello.role` byte; `auth_key` activates
+    /// the eager-auth path (#394) when `Some`. Both fields are
+    /// independent — a caller can change just the role
+    /// (Control ↔ Listen) or just rotate the key. Per issue
+    /// #396.
+    SetRtlTcpClientConfig {
+        /// Role to request in the next connect. `Role::Control`
+        /// is the default / back-compat path; `Role::Listen`
+        /// opts into the #392 concurrent-listener flow.
+        requested_role: sdr_server_rtltcp::extension::Role,
+        /// Pre-shared key (#394) to send eagerly with the hello.
+        /// `None` disables the auth gate (no key on the wire);
+        /// `Some(bytes)` sets `FLAG_HAS_AUTH` and emits an
+        /// `AuthKeyMessage` follow-up.
+        auth_key: Option<Vec<u8>>,
+    },
     /// Set the file path for file source playback.
     SetFilePath(std::path::PathBuf),
     /// Toggle loop-on-EOF for the file playback source. `true`

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -358,6 +358,15 @@ pub enum UiToDsp {
     /// wait for the current exponential-backoff delay to expire.
     /// No-op when the active source is not `RtlTcp`.
     RetryRtlTcpNow,
+    /// One-shot "Take control" reconnect (#393 takeover handshake).
+    /// Sets `FLAG_REQUEST_TAKEOVER` on the NEXT `ClientHello`
+    /// and triggers an immediate reconnect; the bit auto-clears
+    /// after that single attempt so subsequent reconnects (e.g.,
+    /// transport-level retries) don't keep displacing whoever
+    /// just got admitted. Surfaced by the UI when the user
+    /// clicks "Take control" on the `ControllerBusy` toast. No-op
+    /// when the active source is not `RtlTcp`. Per issue #396.
+    RetryRtlTcpWithTakeover,
     // --- Scanner (#317) ---
     /// Master scanner on/off toggle.
     SetScannerEnabled(bool),

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -892,6 +892,64 @@ mod tests {
         assert_eq!(SDR_RTL_TCP_STATE_CONNECTED, 2);
         assert_eq!(SDR_RTL_TCP_STATE_RETRYING, 3);
         assert_eq!(SDR_RTL_TCP_STATE_FAILED, 4);
+        // ABI 0.18 role-denial states (#396) — the host-side
+        // toast routing reads these wire integers directly,
+        // so any accidental renumber breaks every client of
+        // the C ABI without failing any Rust-level type check.
+        assert_eq!(SDR_RTL_TCP_STATE_CONTROLLER_BUSY, 5);
+        assert_eq!(SDR_RTL_TCP_STATE_AUTH_REQUIRED, 6);
+        assert_eq!(SDR_RTL_TCP_STATE_AUTH_FAILED, 7);
+    }
+
+    #[test]
+    fn translate_rtl_tcp_connection_state_controller_busy() {
+        use sdr_types::RtlTcpConnectionState;
+        let (event, owned_cstring, _) = translate_event(&DspToUi::RtlTcpConnectionState(
+            RtlTcpConnectionState::ControllerBusy,
+        ))
+        .expect("ControllerBusy event should translate");
+        let payload = unsafe { event.payload.rtl_tcp_connection_state };
+        assert_eq!(payload.kind, SDR_RTL_TCP_STATE_CONTROLLER_BUSY);
+        // Role-denial states are payload-less — no tuner
+        // string, no counters. Host UIs dispatch on `kind`
+        // alone and look up localized copy on their side.
+        assert!(payload.utf8.is_null());
+        assert_eq!(payload.attempt, 0);
+        assert!(payload.retry_in_secs.abs() < f64::EPSILON);
+        assert_eq!(payload.gain_count, 0);
+        assert!(owned_cstring.is_none());
+    }
+
+    #[test]
+    fn translate_rtl_tcp_connection_state_auth_required() {
+        use sdr_types::RtlTcpConnectionState;
+        let (event, owned_cstring, _) = translate_event(&DspToUi::RtlTcpConnectionState(
+            RtlTcpConnectionState::AuthRequired,
+        ))
+        .expect("AuthRequired event should translate");
+        let payload = unsafe { event.payload.rtl_tcp_connection_state };
+        assert_eq!(payload.kind, SDR_RTL_TCP_STATE_AUTH_REQUIRED);
+        assert!(payload.utf8.is_null());
+        assert_eq!(payload.attempt, 0);
+        assert!(payload.retry_in_secs.abs() < f64::EPSILON);
+        assert_eq!(payload.gain_count, 0);
+        assert!(owned_cstring.is_none());
+    }
+
+    #[test]
+    fn translate_rtl_tcp_connection_state_auth_failed() {
+        use sdr_types::RtlTcpConnectionState;
+        let (event, owned_cstring, _) = translate_event(&DspToUi::RtlTcpConnectionState(
+            RtlTcpConnectionState::AuthFailed,
+        ))
+        .expect("AuthFailed event should translate");
+        let payload = unsafe { event.payload.rtl_tcp_connection_state };
+        assert_eq!(payload.kind, SDR_RTL_TCP_STATE_AUTH_FAILED);
+        assert!(payload.utf8.is_null());
+        assert_eq!(payload.attempt, 0);
+        assert!(payload.retry_in_secs.abs() < f64::EPSILON);
+        assert_eq!(payload.gain_count, 0);
+        assert!(owned_cstring.is_none());
     }
 
     #[test]
@@ -923,6 +981,7 @@ mod tests {
                 tuner_name: "R820T".to_string(),
                 gain_count: 29,
                 codec: "None".to_string(),
+                granted_role: Some(true),
             },
         ))
         .expect("Connected event should translate");

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -92,6 +92,21 @@ pub const SDR_RTL_TCP_STATE_CONNECTING: i32 = 1;
 pub const SDR_RTL_TCP_STATE_CONNECTED: i32 = 2;
 pub const SDR_RTL_TCP_STATE_RETRYING: i32 = 3;
 pub const SDR_RTL_TCP_STATE_FAILED: i32 = 4;
+/// Server has an existing Control client and denied this
+/// attempt with `Status::ControllerBusy`. Host UIs should
+/// offer the user "Take control" / "Connect as Listener"
+/// actions rather than retry silently. No-auto-retry —
+/// the client does not attempt another connect while this
+/// state is active. ABI 0.18, per #396.
+pub const SDR_RTL_TCP_STATE_CONTROLLER_BUSY: i32 = 5;
+/// Server requires a pre-shared key (#394) and the client
+/// didn't send one. Host UIs should prompt the user for a
+/// key and reconnect. No-auto-retry. ABI 0.18, per #396.
+pub const SDR_RTL_TCP_STATE_AUTH_REQUIRED: i32 = 6;
+/// Server required a key and the client's attempt was
+/// rejected (`Status::AuthFailed`). Host UIs should re-
+/// prompt for a key. No-auto-retry. ABI 0.18, per #396.
+pub const SDR_RTL_TCP_STATE_AUTH_FAILED: i32 = 7;
 
 // ============================================================
 //  SdrEvent tagged union — `#[repr(C)]` layout matching the
@@ -549,6 +564,21 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
                         return None;
                     };
                     (SDR_RTL_TCP_STATE_FAILED, Some(cstr), 0, 0.0, 0)
+                }
+                // Role-denial terminal states (#396). Payload
+                // shape matches Disconnected/Connecting: no
+                // message string, zero counters. The kind
+                // discriminant is enough for the host to pick
+                // the right toast copy ("Controller busy" /
+                // "Server requires a key" / "Key rejected").
+                RtlTcpConnectionState::ControllerBusy => {
+                    (SDR_RTL_TCP_STATE_CONTROLLER_BUSY, None, 0, 0.0, 0)
+                }
+                RtlTcpConnectionState::AuthRequired => {
+                    (SDR_RTL_TCP_STATE_AUTH_REQUIRED, None, 0, 0.0, 0)
+                }
+                RtlTcpConnectionState::AuthFailed => {
+                    (SDR_RTL_TCP_STATE_AUTH_FAILED, None, 0, 0.0, 0)
                 }
             };
             let utf8 = message_cstr

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 17;
+pub const ABI_VERSION_MINOR: u32 = 18;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 17);
+        assert!(ABI_VERSION_MINOR == 18);
     };
 
     #[test]

--- a/crates/sdr-pipeline/src/source_manager.rs
+++ b/crates/sdr-pipeline/src/source_manager.rs
@@ -122,6 +122,66 @@ pub trait Source: Send {
     fn set_looping(&mut self, _looping: bool) -> Result<(), SourceError> {
         Ok(())
     }
+
+    // ----------------------------------------------------------
+    //  RTL-TCP sticky-command replay snapshot (#396 round 3)
+    //
+    //  `RtlTcpSource` accumulates the latest value for each wire
+    //  command (gain, AGC, PPM, bias tee, direct sampling, etc.)
+    //  in its `SharedState` so reconnects replay those settings
+    //  onto the fresh stream and the server's view matches the
+    //  UI's. A controller-driven source REBUILD (manual retry
+    //  after an auth or takeover flow) destroys the old source
+    //  and constructs a new one — without these two hooks, the
+    //  new source starts with a blank replay cache and the user
+    //  loses gain / AGC / PPM / etc. until they touch each
+    //  control. These methods let the controller shuttle the
+    //  cache across the rebuild boundary without downcasting to
+    //  the concrete RtlTcpSource type. Default no-op so other
+    //  source impls ignore them entirely.
+    // ----------------------------------------------------------
+
+    /// Snapshot the RTL-TCP sticky-command replay cache. `None`
+    /// for every source except `RtlTcpSource`.
+    fn rtl_tcp_sticky_snapshot(&self) -> Option<RtlTcpStickySnapshot> {
+        None
+    }
+
+    /// Restore a previously-captured sticky-command replay cache
+    /// before `start()`. No-op for every source except
+    /// `RtlTcpSource`; the RTL-TCP impl seeds its internal
+    /// atomics so the next reconnect replays the saved values.
+    fn rtl_tcp_restore_sticky_snapshot(&mut self, _snapshot: &RtlTcpStickySnapshot) {}
+}
+
+/// Snapshot of `RtlTcpSource`'s sticky-command replay cache,
+/// plain `u32` fields so it can live in `sdr-pipeline` without
+/// forcing a dep on `sdr-source-network`. The atomics inside
+/// `SharedState` use `u32` bit representations throughout, so
+/// passing raw values through is semantically identical to
+/// copying the atomics themselves. Order + set must mirror
+/// `SharedState`'s sticky fields — dropping one here silently
+/// drops it across a rebuild.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RtlTcpStickySnapshot {
+    /// `replay_mask` bit-per-op sentinel — bit `i` set means op
+    /// `0x01 + i` has had at least one value recorded, and the
+    /// reconnect path should resend it.
+    pub replay_mask: u32,
+    pub last_center_freq_hz: u32,
+    pub last_sample_rate_hz: u32,
+    pub last_gain_mode: u32,
+    pub last_tuner_gain: u32,
+    pub last_ppm: u32,
+    pub last_agc_mode: u32,
+    pub last_direct_sampling: u32,
+    pub last_offset_tuning: u32,
+    pub last_bias_tee: u32,
+    pub last_gain_by_index: u32,
+    pub last_testmode: u32,
+    pub last_if_gain: u32,
+    pub last_rtl_xtal: u32,
+    pub last_tuner_xtal: u32,
 }
 
 /// Manages available IQ sources and the active source lifecycle.

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -138,10 +138,22 @@ pub enum ConnectionState {
     /// Handshake complete, handler streaming I/Q. `codec` reflects
     /// the negotiated stream codec from the extended `"RTLX"`
     /// handshake (#307); legacy / uncompressed paths land on
-    /// `Codec::None`.
+    /// `Codec::None`. `granted_role` carries the server's
+    /// `ServerExtension.granted_role` decision (#392): `Some(Role)`
+    /// when the server is RTLX-capable and admitted us into a
+    /// specific slot, `None` when we didn't send a hello (legacy
+    /// path) or the server is a pre-#392 RTLX server that doesn't
+    /// yet advertise the field. The UI shows the role badge only
+    /// when this is `Some` — a legacy server's role is unknown
+    /// territory, and guessing "Controller" there would mis-label
+    /// the connection on pre-#392 RTLX servers that still hand
+    /// every accepted client a Control-equivalent slot without
+    /// saying so on the wire. Per #396 / CodeRabbit round 1 on
+    /// PR #408.
     Connected {
         tuner: TunerInfo,
         codec: Codec,
+        granted_role: Option<sdr_server_rtltcp::extension::Role>,
     },
     /// Connection dropped, backoff pending. Transport-level errors
     /// (TCP connect refused, EOF, stall) stay in this state — the
@@ -172,13 +184,30 @@ impl From<&ConnectionState> for sdr_types::RtlTcpConnectionState {
         match value {
             ConnectionState::Disconnected => Self::Disconnected,
             ConnectionState::Connecting => Self::Connecting,
-            ConnectionState::Connected { tuner, codec } => Self::Connected {
+            ConnectionState::Connected {
+                tuner,
+                codec,
+                granted_role,
+            } => Self::Connected {
                 // `TunerTypeCode`'s `Debug` renders the upstream
                 // tuner name ("R820T", "E4000", etc.) directly —
                 // what the UI wants for the status row subtitle.
                 tuner_name: format!("{:?}", tuner.tuner),
                 gain_count: tuner.gain_count,
                 codec: codec.label().to_string(),
+                // Project the server-granted role to `Option<bool>`
+                // at the crate boundary so `sdr_types` doesn't have
+                // to depend on `sdr-server-rtltcp`'s wire `Role`
+                // enum: `true` = Controller, `false` = Listener,
+                // `None` = unknown (legacy handshake or pre-#392
+                // RTLX server). The UI uses this to decide whether
+                // to show the role badge at all — per CodeRabbit
+                // round 1 on PR #408, the previous `Option<bool>`
+                // derived from the user's requested role could
+                // mis-label a session the server actually admitted
+                // differently.
+                granted_role: granted_role
+                    .map(|r| r == sdr_server_rtltcp::extension::Role::Control),
             },
             ConnectionState::Retrying { attempt, next_at } => Self::Retrying {
                 attempt: *attempt,
@@ -938,6 +967,15 @@ fn read_server_extension(stream: &TcpStream) -> std::io::Result<ServerExtension>
 /// TCP socket (still plain `TcpStream`; the caller wraps it in a
 /// [`Decoder`] for reads). `codec` tells the caller which
 /// decoder to use for the IQ stream.
+///
+/// `ServerExtension.granted_role` isn't carried here — it's
+/// already published inside `attempt_connect` on the
+/// `ConnectionState::Connected` state transition, which is the
+/// single consumer the UI needs. Threading it through the
+/// outcome struct too would require the manager's data-pump
+/// branch to also read and forward it, which it has no use for
+/// (no mid-stream role changes exist in the wire protocol).
+/// Per CodeRabbit round 1 on PR #408.
 struct HandshakeOutcome {
     stream: TcpStream,
     codec: Codec,
@@ -1129,6 +1167,13 @@ fn attempt_connect(
     // silently falling back would let a server that picked LZ4
     // stream compressed bytes into our IQ decoder. Per CodeRabbit
     // round 1 on PR #399.
+    // Track the server's `granted_role` so it can flow through
+    // to `ConnectionState::Connected`. `None` on the legacy path
+    // (we never read the extension block) OR on an extended
+    // server that predates #392 and leaves the field unset —
+    // the UI treats both as "unknown" and hides the role badge.
+    // Per CodeRabbit round 1 on PR #408.
+    let mut granted_role: Option<sdr_server_rtltcp::extension::Role> = None;
     let codec = if extension_enabled {
         match read_server_extension(&stream) {
             Ok(ext) => {
@@ -1178,8 +1223,10 @@ fn attempt_connect(
                 tracing::info!(
                     codec = %ext.codec,
                     status = ext.status.to_wire(),
+                    granted_role = ?ext.granted_role,
                     "rtl_tcp extended-handshake accepted by server"
                 );
+                granted_role = ext.granted_role;
                 ext.codec
             }
             Err(e) => {
@@ -1201,7 +1248,14 @@ fn attempt_connect(
     if let Ok(mut slot) = shared.tuner.lock() {
         *slot = Some(tuner);
     }
-    set_state(shared, ConnectionState::Connected { tuner, codec });
+    set_state(
+        shared,
+        ConnectionState::Connected {
+            tuner,
+            codec,
+            granted_role,
+        },
+    );
 
     // Publish a clone of the stream for the command sender. Install a
     // write timeout on the clone so `send_command`'s blocking
@@ -2818,9 +2872,29 @@ mod tests {
                 .unwrap();
             let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
             sock.read_exact(&mut hello_buf).expect("read hello");
+            // Pin the role-only hello to protocol v1 — this
+            // gate path has non-default role but zero flags, so
+            // `required_protocol_version(flags)` (used by the
+            // client hello-builder) returns v1. A regression
+            // that silently promoted this hello to v2 would
+            // lock out pre-#394 servers without surfacing a
+            // test failure unless the version byte is checked
+            // explicitly. Per CodeRabbit round 1 on PR #408.
+            let client_hello_version = hello_buf[7];
+            assert_eq!(
+                client_hello_version,
+                sdr_server_rtltcp::extension::PROTOCOL_VERSION_V1,
+                "role-only hello must stay on v1 for backward compatibility \
+                 (got 0x{:02x})",
+                client_hello_version,
+            );
             let _ = hello_tx.send(hello_buf);
             // Accept the handshake with Listen granted so the
-            // client reaches Connected.
+            // client reaches Connected. Echo the client-chosen
+            // protocol version back rather than the compile-time
+            // `PROTOCOL_VERSION` so a future bump of `PROTOCOL_
+            // VERSION` doesn't mask a regression where the role-
+            // only hello regresses to a newer version.
             let header = DongleInfo {
                 tuner: TunerTypeCode::R820t,
                 gain_count: RTLX_TEST_GAIN_COUNT,
@@ -2831,7 +2905,7 @@ mod tests {
                 codec: Codec::None,
                 granted_role: Some(Role::Listen),
                 status: Status::Ok,
-                version: PROTOCOL_VERSION,
+                version: client_hello_version,
             };
             sock.write_all(&ext.to_bytes()).unwrap();
             thread::sleep(RTLX_TEST_SERVER_HOLD);

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -139,16 +139,24 @@ pub enum ConnectionState {
     /// the negotiated stream codec from the extended `"RTLX"`
     /// handshake (#307); legacy / uncompressed paths land on
     /// `Codec::None`.
-    Connected { tuner: TunerInfo, codec: Codec },
+    Connected {
+        tuner: TunerInfo,
+        codec: Codec,
+    },
     /// Connection dropped, backoff pending. Transport-level errors
     /// (TCP connect refused, EOF, stall) stay in this state — the
     /// manager retries forever with exponential backoff up to the
     /// 30 s cap.
-    Retrying { attempt: u32, next_at: Instant },
+    Retrying {
+        attempt: u32,
+        next_at: Instant,
+    },
     /// Terminal failure — only entered for a protocol-level error
     /// (e.g., server sent a non-RTL0 header). Transport failures
     /// never reach this state; they remain in `Retrying`.
-    Failed { reason: String },
+    Failed {
+        reason: String,
+    },
     /// Terminal role-denial states surfaced by the #392/#394
     /// extended handshake. Per #396, the connection manager
     /// stops retrying and waits for the UI to offer the user an

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -148,7 +148,7 @@ pub enum ConnectionState {
     /// territory, and guessing "Controller" there would mis-label
     /// the connection on pre-#392 RTLX servers that still hand
     /// every accepted client a Control-equivalent slot without
-    /// saying so on the wire. Per #396 / CodeRabbit round 1 on
+    /// saying so on the wire. Per #396 / `CodeRabbit` round 1 on
     /// PR #408.
     Connected {
         tuner: TunerInfo,
@@ -975,7 +975,7 @@ fn read_server_extension(stream: &TcpStream) -> std::io::Result<ServerExtension>
 /// outcome struct too would require the manager's data-pump
 /// branch to also read and forward it, which it has no use for
 /// (no mid-stream role changes exist in the wire protocol).
-/// Per CodeRabbit round 1 on PR #408.
+/// Per `CodeRabbit` round 1 on PR #408.
 struct HandshakeOutcome {
     stream: TcpStream,
     codec: Codec,
@@ -2885,8 +2885,7 @@ mod tests {
                 client_hello_version,
                 sdr_server_rtltcp::extension::PROTOCOL_VERSION_V1,
                 "role-only hello must stay on v1 for backward compatibility \
-                 (got 0x{:02x})",
-                client_hello_version,
+                 (got 0x{client_hello_version:02x})",
             );
             let _ = hello_tx.send(hello_buf);
             // Accept the handshake with Listen granted so the
@@ -2944,6 +2943,40 @@ mod tests {
         // Flags byte (offset 6) must be zero — we didn't opt
         // into takeover or auth, just role.
         assert_eq!(hello[6], 0);
+
+        // Lock in the state-side contract: after the handshake
+        // completes, `ConnectionState::Connected.granted_role`
+        // must carry `Some(Role::Listen)` — the value the server
+        // wrote into `ServerExtension.granted_role` above. A
+        // regression in `attempt_connect` that drops the
+        // extension's `granted_role` on the floor would still
+        // pass the wire-byte assertions but would break the
+        // status-bar badge provenance (it would read `None` and
+        // hide the badge even when the server explicitly
+        // admitted us as a Listener). Poll with a bounded
+        // deadline since the state transition is driven by the
+        // manager thread. Per `CodeRabbit` round 2 on PR #408.
+        let deadline = Instant::now() + RTLX_TEST_STATE_DEADLINE;
+        let mut reached_connected_with_listen = false;
+        while Instant::now() < deadline {
+            if matches!(
+                src.connection_state(),
+                ConnectionState::Connected {
+                    granted_role: Some(Role::Listen),
+                    ..
+                }
+            ) {
+                reached_connected_with_listen = true;
+                break;
+            }
+            thread::sleep(RTLX_TEST_POLL_INTERVAL);
+        }
+        assert!(
+            reached_connected_with_listen,
+            "Connected state should retain the server-granted Listen role \
+             (final observed state: {:?})",
+            src.connection_state()
+        );
 
         src.stop_manager();
         let _ = server_thread.join();

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -149,6 +149,14 @@ pub enum ConnectionState {
     /// (e.g., server sent a non-RTL0 header). Transport failures
     /// never reach this state; they remain in `Retrying`.
     Failed { reason: String },
+    /// Terminal role-denial states surfaced by the #392/#394
+    /// extended handshake. Per #396, the connection manager
+    /// stops retrying and waits for the UI to offer the user an
+    /// explicit recovery action (take-control, re-enter key, or
+    /// give up).
+    ControllerBusy,
+    AuthRequired,
+    AuthFailed,
 }
 
 impl From<&ConnectionState> for sdr_types::RtlTcpConnectionState {
@@ -177,6 +185,9 @@ impl From<&ConnectionState> for sdr_types::RtlTcpConnectionState {
             ConnectionState::Failed { reason } => Self::Failed {
                 reason: reason.clone(),
             },
+            ConnectionState::ControllerBusy => Self::ControllerBusy,
+            ConnectionState::AuthRequired => Self::AuthRequired,
+            ConnectionState::AuthFailed => Self::AuthFailed,
         }
     }
 }
@@ -799,26 +810,51 @@ fn connection_manager(host: String, port: u16, shared: Arc<SharedState>, config:
             }
             Err(e) => {
                 tracing::warn!(%e, host = %host, port, attempt, "rtl_tcp connect failed");
-                if let SourceError::Protocol(_) = e {
-                    // Non-recoverable: server isn't speaking
-                    // rtl_tcp, or the extended handshake was
-                    // rejected for a reason that won't clear on
-                    // retry (auth required/failed, parse error).
-                    set_state(
-                        &shared,
-                        ConnectionState::Failed {
-                            reason: format!("{e}"),
-                        },
-                    );
-                    return;
+                // Route each terminal error-kind to its
+                // dedicated `ConnectionState` variant so the UI
+                // can offer specific recovery actions (take-
+                // control, enter key, re-prompt) instead of a
+                // generic "Failed" with opaque reason string.
+                // Pre-#396 AuthRequired/AuthFailed folded into
+                // `Failed { reason: "protocol error: ..." }` and
+                // `ControllerBusy` auto-retried via
+                // `TemporarilyUnavailable`. Per #396, each gets
+                // its own terminal state.
+                match e {
+                    SourceError::ControllerBusy => {
+                        set_state(&shared, ConnectionState::ControllerBusy);
+                        return;
+                    }
+                    SourceError::AuthRequired => {
+                        set_state(&shared, ConnectionState::AuthRequired);
+                        return;
+                    }
+                    SourceError::AuthFailed => {
+                        set_state(&shared, ConnectionState::AuthFailed);
+                        return;
+                    }
+                    SourceError::Protocol(_) => {
+                        // Non-recoverable: server isn't speaking
+                        // rtl_tcp, or the extended handshake was
+                        // rejected for a reason we don't have a
+                        // dedicated state for (ListenerCapReached,
+                        // parse errors, future status codes).
+                        set_state(
+                            &shared,
+                            ConnectionState::Failed {
+                                reason: format!("{e}"),
+                            },
+                        );
+                        return;
+                    }
+                    // `TemporarilyUnavailable` (transient network
+                    // conditions the caller wants us to back off
+                    // and retry on — NOT role denials, which are
+                    // now their own variants above) and every
+                    // other `SourceError` variant fall through to
+                    // the backoff loop below.
+                    _ => {}
                 }
-                // `TemporarilyUnavailable` (e.g. server responded
-                // with `ControllerBusy`) and every other
-                // `SourceError` variant fall through to the
-                // backoff loop below. The condition is expected
-                // to clear on its own — retrying with the normal
-                // schedule is the right behavior. Per CodeRabbit
-                // round 7 on PR #399.
             }
         }
 
@@ -1089,34 +1125,47 @@ fn attempt_connect(
         match read_server_extension(&stream) {
             Ok(ext) => {
                 // A non-OK status means the server parsed our hello
-                // but rejected the session. Two flavors:
+                // but rejected the session. Each flavor needs a
+                // distinct error variant so the connection manager
+                // can route to the right `RtlTcpConnectionState`
+                // without string-parsing the reason:
                 //
-                // - `ControllerBusy` (#392): another client owns the
-                //   control slot right now. This is **transient** —
-                //   that client will eventually disconnect, so we
-                //   return `SourceError::TemporarilyUnavailable` and
-                //   let the connection manager retry on the normal
-                //   backoff schedule. Per CodeRabbit round 7 on
-                //   PR #399.
-                // - `AuthRequired` / `AuthFailed` (#394) and any
-                //   future non-OK status: terminal. The user must
-                //   take action (set the right auth key) before
-                //   retries have any chance of succeeding, so we
-                //   surface `SourceError::Protocol` and the manager
-                //   transitions to `Failed`.
-                if ext.status == Status::ControllerBusy {
-                    return Err(SourceError::TemporarilyUnavailable(format!(
-                        "rtl_tcp server controller busy: status={:?} (wire={})",
-                        ext.status,
-                        ext.status.to_wire()
-                    )));
-                }
-                if ext.status != Status::Ok {
-                    return Err(SourceError::Protocol(format!(
-                        "rtl_tcp extension rejected by server: status={:?} (wire={})",
-                        ext.status,
-                        ext.status.to_wire()
-                    )));
+                // - `ControllerBusy` (#392) → `SourceError::ControllerBusy`.
+                //   User must decide: retry with `request_takeover`
+                //   or switch to `Role::Listen`. No auto-retry; the
+                //   UI surfaces a toast with action buttons.
+                //   Pre-#396 this folded into `TemporarilyUnavailable`
+                //   with silent auto-retry, which hid the decision
+                //   point. Per #396.
+                // - `AuthRequired` (#394) → `SourceError::AuthRequired`.
+                //   User must enter a key. No auto-retry.
+                // - `AuthFailed` (#394) → `SourceError::AuthFailed`.
+                //   User must enter the RIGHT key. No auto-retry.
+                // - Anything else → `SourceError::Protocol` (generic
+                //   terminal). Covers future status codes we haven't
+                //   seen yet, plus `ListenerCapReached` (which the
+                //   UI can treat similarly to ControllerBusy at the
+                //   toast level, but surfacing as generic Protocol
+                //   is acceptable until a dedicated #396 follow-up
+                //   fleshes out listener-cap UX).
+                match ext.status {
+                    Status::Ok => {}
+                    Status::ControllerBusy => {
+                        return Err(SourceError::ControllerBusy);
+                    }
+                    Status::AuthRequired => {
+                        return Err(SourceError::AuthRequired);
+                    }
+                    Status::AuthFailed => {
+                        return Err(SourceError::AuthFailed);
+                    }
+                    other @ Status::ListenerCapReached => {
+                        return Err(SourceError::Protocol(format!(
+                            "rtl_tcp extension rejected by server: status={:?} (wire={})",
+                            other,
+                            other.to_wire()
+                        )));
+                    }
                 }
                 tracing::info!(
                     codec = %ext.codec,
@@ -2163,8 +2212,16 @@ mod tests {
         // transient — the other controller will eventually
         // disconnect and we should retry. `AuthFailed` is the
         // right terminal substitute: a wrong key will not start
-        // working on retry, so the manager must transition to
-        // `Failed` and stop looping.
+        // working on retry, so the manager must transition to a
+        // terminal state and stop looping.
+        //
+        // **Updated for #396:** `AuthFailed` now routes to the
+        // dedicated `ConnectionState::AuthFailed` variant (not
+        // generic `Failed`) so the UI can surface a specific
+        // "Key rejected" toast + re-prompt path instead of an
+        // opaque error string. The terminal-ness contract is
+        // unchanged — the manager still stops the retry loop on
+        // `AuthFailed`.
         //
         // The test also guards the delayed-tuner-publish ordering:
         // `tuner_info()` must stay `None` because the handshake
@@ -2189,17 +2246,17 @@ mod tests {
         src.start_manager().unwrap();
 
         let deadline = Instant::now() + RTLX_TEST_STATE_DEADLINE;
-        let mut reached_failed = false;
+        let mut reached_terminal = false;
         while Instant::now() < deadline {
-            if matches!(src.connection_state(), ConnectionState::Failed { .. }) {
-                reached_failed = true;
+            if matches!(src.connection_state(), ConnectionState::AuthFailed) {
+                reached_terminal = true;
                 break;
             }
             thread::sleep(RTLX_TEST_POLL_INTERVAL);
         }
         assert!(
-            reached_failed,
-            "client should transition to Failed on `AuthFailed` ServerExtension status"
+            reached_terminal,
+            "client should transition to AuthFailed on `AuthFailed` ServerExtension status (per #396)"
         );
         assert!(
             src.tuner_info().is_none(),
@@ -2211,26 +2268,39 @@ mod tests {
     }
 
     #[test]
-    fn rtlx_handshake_controller_busy_is_transient_not_terminal() {
-        // Regression test for CodeRabbit round 7 on PR #399.
-        // `ControllerBusy` means another client currently owns the
-        // control slot (#392). That condition resolves on its own
-        // when the other client disconnects, so the rtl_tcp source
-        // must NOT transition to `Failed` — the connection manager
-        // should keep cycling through the backoff + reconnect path.
+    fn rtlx_handshake_controller_busy_routes_to_dedicated_state() {
+        // Regression test for #396. `ControllerBusy` means
+        // another client currently owns the control slot (#392).
+        // Pre-#396 this routed to `TemporarilyUnavailable` and
+        // the connection manager auto-retried silently via
+        // backoff. Per #396 the connection manager now routes
+        // it to the dedicated `ConnectionState::ControllerBusy`
+        // variant and STOPS the retry loop — the UI needs to
+        // surface the busy state to the user so they can pick
+        // Take-control or Connect-as-Listener instead of
+        // waiting for the other controller to drop.
         //
-        // We assert two things:
-        //   1. State never reaches `Failed` within the observation
-        //      window (CR #17 regression guard).
-        //   2. `tuner_info()` stays `None` (the delayed-publish
-        //      ordering holds regardless of status).
+        // Historical rename: the CR-round-7-on-PR-#399 rule
+        // ("ControllerBusy must not route to Failed") still
+        // holds — `ControllerBusy` is its OWN terminal state,
+        // not `Failed`. The UX contract changed; the naming
+        // discipline for generic-error terminal = `Failed` did
+        // not.
+        //
+        // We assert:
+        //   1. State reaches `ConnectionState::ControllerBusy`
+        //      within the observation window (the new #396
+        //      routing).
+        //   2. `tuner_info()` stays `None` — the handshake
+        //      never reached `Connected`.
         let (listener, config) = rtlx_test_listener_and_config();
         let addr = listener.local_addr().unwrap();
 
         let server_thread = thread::spawn(move || {
-            // Accept a single connection and reject it. The client
-            // will then loop; subsequent accepts would require an
-            // accept loop we don't need for this assertion.
+            // Accept a single connection and reject it. Because
+            // ControllerBusy is now terminal, the client will
+            // NOT retry and we don't need a multi-accept loop
+            // here.
             let ext = ServerExtension {
                 codec: Codec::None,
                 granted_role: None,
@@ -2245,23 +2315,30 @@ mod tests {
 
         src.start_manager().unwrap();
 
-        // Poll for the entire window. If `Failed` shows up at any
-        // point, that's the round-7 regression (ControllerBusy
-        // being treated as terminal).
         let deadline = Instant::now() + RTLX_TEST_STATE_DEADLINE;
+        let mut reached_controller_busy = false;
         while Instant::now() < deadline {
-            if matches!(src.connection_state(), ConnectionState::Failed { .. }) {
-                panic!(
-                    "ControllerBusy must not route to Failed — the server condition \
-                     is transient and the manager should keep retrying. \
-                     Observed state: Failed."
-                );
+            if matches!(src.connection_state(), ConnectionState::ControllerBusy) {
+                reached_controller_busy = true;
+                break;
             }
+            // The `Failed` path would be a regression — Failed
+            // is for generic protocol errors only, not role
+            // denials.
+            assert!(
+                !matches!(src.connection_state(), ConnectionState::Failed { .. }),
+                "ControllerBusy must route to its dedicated state, not generic Failed"
+            );
             thread::sleep(RTLX_TEST_POLL_INTERVAL);
         }
         assert!(
+            reached_controller_busy,
+            "client should transition to ControllerBusy on `ControllerBusy` \
+             ServerExtension status (per #396)"
+        );
+        assert!(
             src.tuner_info().is_none(),
-            "tuner_info must stay None across transient busy retries"
+            "tuner_info must stay None when the handshake is rejected"
         );
 
         src.stop_manager();

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -1719,6 +1719,100 @@ impl Source for RtlTcpSource {
     fn set_gain_by_index(&mut self, index: u32) -> Result<(), SourceError> {
         RtlTcpSource::set_gain_by_index(self, index)
     }
+
+    // ----------------------------------------------------------
+    //  Sticky-command replay snapshot (#396 round 3)
+    //
+    //  Controller-driven rebuilds (manual retry after an auth
+    //  flow, takeover retry) destroy the old `RtlTcpSource` and
+    //  construct a fresh one. Without these two hooks, the new
+    //  source starts with zeroed replay atomics — gain / AGC /
+    //  PPM / bias tee / direct sampling / etc. would default
+    //  back to zero on the first reconnect, stripping the user's
+    //  session state. Snapshot + restore copies the `u32` values
+    //  across the boundary so the fresh manager thread's
+    //  `replay_sticky_commands` call emits the same `SetX`
+    //  commands the old one would have.
+    // ----------------------------------------------------------
+    fn rtl_tcp_sticky_snapshot(
+        &self,
+    ) -> Option<sdr_pipeline::source_manager::RtlTcpStickySnapshot> {
+        Some(sdr_pipeline::source_manager::RtlTcpStickySnapshot {
+            replay_mask: self.shared.replay_mask.load(Ordering::Relaxed),
+            last_center_freq_hz: self.shared.last_center_freq_hz.load(Ordering::Relaxed),
+            last_sample_rate_hz: self.shared.last_sample_rate_hz.load(Ordering::Relaxed),
+            last_gain_mode: self.shared.last_gain_mode.load(Ordering::Relaxed),
+            last_tuner_gain: self.shared.last_tuner_gain.load(Ordering::Relaxed),
+            last_ppm: self.shared.last_ppm.load(Ordering::Relaxed),
+            last_agc_mode: self.shared.last_agc_mode.load(Ordering::Relaxed),
+            last_direct_sampling: self.shared.last_direct_sampling.load(Ordering::Relaxed),
+            last_offset_tuning: self.shared.last_offset_tuning.load(Ordering::Relaxed),
+            last_bias_tee: self.shared.last_bias_tee.load(Ordering::Relaxed),
+            last_gain_by_index: self.shared.last_gain_by_index.load(Ordering::Relaxed),
+            last_testmode: self.shared.last_testmode.load(Ordering::Relaxed),
+            last_if_gain: self.shared.last_if_gain.load(Ordering::Relaxed),
+            last_rtl_xtal: self.shared.last_rtl_xtal.load(Ordering::Relaxed),
+            last_tuner_xtal: self.shared.last_tuner_xtal.load(Ordering::Relaxed),
+        })
+    }
+
+    fn rtl_tcp_restore_sticky_snapshot(
+        &mut self,
+        snapshot: &sdr_pipeline::source_manager::RtlTcpStickySnapshot,
+    ) {
+        // Order mirrors `SharedState::new`'s initialization so a
+        // future field addition here is forced through the same
+        // review as the atomics themselves.
+        self.shared
+            .last_center_freq_hz
+            .store(snapshot.last_center_freq_hz, Ordering::Relaxed);
+        self.shared
+            .last_sample_rate_hz
+            .store(snapshot.last_sample_rate_hz, Ordering::Relaxed);
+        self.shared
+            .last_gain_mode
+            .store(snapshot.last_gain_mode, Ordering::Relaxed);
+        self.shared
+            .last_tuner_gain
+            .store(snapshot.last_tuner_gain, Ordering::Relaxed);
+        self.shared
+            .last_ppm
+            .store(snapshot.last_ppm, Ordering::Relaxed);
+        self.shared
+            .last_agc_mode
+            .store(snapshot.last_agc_mode, Ordering::Relaxed);
+        self.shared
+            .last_direct_sampling
+            .store(snapshot.last_direct_sampling, Ordering::Relaxed);
+        self.shared
+            .last_offset_tuning
+            .store(snapshot.last_offset_tuning, Ordering::Relaxed);
+        self.shared
+            .last_bias_tee
+            .store(snapshot.last_bias_tee, Ordering::Relaxed);
+        self.shared
+            .last_gain_by_index
+            .store(snapshot.last_gain_by_index, Ordering::Relaxed);
+        self.shared
+            .last_testmode
+            .store(snapshot.last_testmode, Ordering::Relaxed);
+        self.shared
+            .last_if_gain
+            .store(snapshot.last_if_gain, Ordering::Relaxed);
+        self.shared
+            .last_rtl_xtal
+            .store(snapshot.last_rtl_xtal, Ordering::Relaxed);
+        self.shared
+            .last_tuner_xtal
+            .store(snapshot.last_tuner_xtal, Ordering::Relaxed);
+        // `replay_mask` last so a partially-restored snapshot
+        // (e.g. a panic mid-write — shouldn't happen with simple
+        // atomics but belt-and-braces) doesn't leave the
+        // reconnect path replaying fresh zeros.
+        self.shared
+            .replay_mask
+            .store(snapshot.replay_mask, Ordering::Relaxed);
+    }
 }
 
 #[cfg(test)]
@@ -2396,6 +2490,70 @@ mod tests {
         assert!(
             reached_controller_busy,
             "client should transition to ControllerBusy on `ControllerBusy` \
+             ServerExtension status (per #396)"
+        );
+        assert!(
+            src.tuner_info().is_none(),
+            "tuner_info must stay None when the handshake is rejected"
+        );
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_auth_required_routes_to_dedicated_state() {
+        // Regression test for #396. `AuthRequired` means the
+        // server demands a pre-shared key (#394) and the client
+        // didn't include one in the hello. Pre-#396 the
+        // connection manager folded this into `Protocol` and
+        // landed in `Failed` with a generic reason; per #396 it
+        // now routes to the dedicated `ConnectionState::
+        // AuthRequired` variant so the UI can reveal + focus
+        // the Server key entry row instead of showing an opaque
+        // error toast. Terminal — no auto-retry while the UI
+        // waits for the user to enter a key.
+        //
+        // Complements the existing `AuthFailed` /
+        // `ControllerBusy` regression tests, which pin the same
+        // contract for the other two role-denial statuses. Per
+        // `CodeRabbit` round 3 on PR #408.
+        let (listener, config) = rtlx_test_listener_and_config();
+        let addr = listener.local_addr().unwrap();
+
+        let server_thread = thread::spawn(move || {
+            let ext = ServerExtension {
+                codec: Codec::None,
+                granted_role: None,
+                status: Status::AuthRequired,
+                version: PROTOCOL_VERSION,
+            };
+            rtlx_test_serve_one(&listener, ext);
+        });
+
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        assert!(src.tuner_info().is_none());
+
+        src.start_manager().unwrap();
+
+        let deadline = Instant::now() + RTLX_TEST_STATE_DEADLINE;
+        let mut reached_auth_required = false;
+        while Instant::now() < deadline {
+            if matches!(src.connection_state(), ConnectionState::AuthRequired) {
+                reached_auth_required = true;
+                break;
+            }
+            // `Failed` would be a regression back to the pre-#396
+            // routing — the dedicated variant is the whole point.
+            assert!(
+                !matches!(src.connection_state(), ConnectionState::Failed { .. }),
+                "AuthRequired must route to its dedicated state, not generic Failed"
+            );
+            thread::sleep(RTLX_TEST_POLL_INTERVAL);
+        }
+        assert!(
+            reached_auth_required,
+            "client should transition to AuthRequired on `AuthRequired` \
              ServerExtension status (per #396)"
         );
         assert!(

--- a/crates/sdr-source-network/src/rtl_tcp.rs
+++ b/crates/sdr-source-network/src/rtl_tcp.rs
@@ -46,9 +46,11 @@ use std::time::{Duration, Instant};
 
 use sdr_pipeline::source_manager::Source;
 use sdr_server_rtltcp::codec::{Codec, CodecMask, Decoder};
+#[cfg(test)]
+use sdr_server_rtltcp::extension::Role;
 use sdr_server_rtltcp::extension::{
-    CLIENT_HELLO_FLAGS_NONE, ClientHello, EXTENSION_MAGIC, Role, SERVER_EXTENSION_LEN,
-    ServerExtension, Status,
+    CLIENT_HELLO_FLAGS_NONE, ClientHello, EXTENSION_MAGIC, SERVER_EXTENSION_LEN, ServerExtension,
+    Status,
 };
 use sdr_server_rtltcp::protocol::{Command, CommandOp, DONGLE_INFO_LEN, DongleInfo, TunerTypeCode};
 use sdr_types::{Complex, SourceError};
@@ -290,6 +292,27 @@ pub struct RtlTcpConfig {
     /// casual LAN isolation, not WAN-grade security. See #394
     /// for the full threat model discussion. #394.
     pub auth_key: Option<Vec<u8>>,
+
+    /// Role the client requests in its `ClientHello`. Default
+    /// [`Role::Control`] matches the pre-#392 single-client
+    /// behavior every legacy `rtl_tcp` client assumes. The UI
+    /// lets users opt into [`Role::Listen`] for concurrent
+    /// read-only access to a server that already has a
+    /// controller. Per issue #396.
+    ///
+    /// **RTLX-only when non-default.** `Role::Listen` implies
+    /// the server is #392-aware (has the role gate); vanilla
+    /// `rtl_tcp` servers ignore the role byte entirely and
+    /// every client is implicitly Control. The
+    /// `extension_enabled` gate below already trips when the
+    /// hello needs to carry any non-default flag, and the same
+    /// mDNS TXT `codecs=3` out-of-band evidence that gates
+    /// compression / takeover / auth also gates this field.
+    /// `Role::Control` is the back-compat default for vanilla
+    /// servers; setting `Role::Listen` against a vanilla
+    /// server corrupts the 5-byte command framing (same hazard
+    /// as `compression` / `request_takeover` / `auth_key`).
+    pub requested_role: sdr_server_rtltcp::extension::Role,
 }
 
 impl Default for RtlTcpConfig {
@@ -301,6 +324,10 @@ impl Default for RtlTcpConfig {
             compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
             request_takeover: false,
             auth_key: None,
+            // `Role::Control` matches the pre-#392 single-client
+            // behavior every legacy `rtl_tcp` client assumes — no
+            // wire change from the default path.
+            requested_role: sdr_server_rtltcp::extension::Role::Control,
         }
     }
 }
@@ -928,9 +955,16 @@ fn attempt_connect(
     // Default `compression = NONE_ONLY && request_takeover =
     // false` → no hello → wire-compatible with every rtl_tcp
     // server on earth. Per #307 / #393.
+    // Hello needed when ANY field carries non-default state:
+    // compression opt-in, takeover opt-in, auth, or role
+    // (Listen != Control default). Per #396, a `Role::Listen`
+    // request also has to surface on the wire, so widen the
+    // gate here — same RTLX-only hazard as the other fields,
+    // same mDNS `codecs=3` out-of-band evidence requirement.
     let extension_enabled = config.compression != CodecMask::NONE_ONLY
         || config.request_takeover
-        || config.auth_key.is_some();
+        || config.auth_key.is_some()
+        || config.requested_role != sdr_server_rtltcp::extension::Role::Control;
     if extension_enabled {
         // Compose the flags byte. Each bit is independently set
         // based on config — takeover and auth can co-exist on
@@ -984,11 +1018,15 @@ fn attempt_connect(
 
         let hello = ClientHello {
             codec_mask: config.compression,
-            // sdr-rs clients always request Control on connect;
-            // Listen clients don't emerge from this codepath —
-            // they'd flow through a future client-side Listen
-            // opt-in that isn't part of #393's scope.
-            role: Role::Control,
+            // Threaded from `RtlTcpConfig.requested_role` — the
+            // UI's Connection-role picker (#396) feeds this
+            // directly. Default `Role::Control` matches the
+            // pre-#392 single-client behavior every legacy
+            // `rtl_tcp` client assumes; opting into
+            // `Role::Listen` needs the out-of-band evidence
+            // that the server is #392-aware (mDNS TXT
+            // `codecs=3` or saved-profile knowledge).
+            role: config.requested_role,
             flags,
             // Pick the MINIMUM viable protocol version for this
             // hello's feature set. Compression-only / takeover-
@@ -1763,6 +1801,7 @@ mod tests {
             compression: sdr_server_rtltcp::codec::CodecMask::NONE_ONLY,
             request_takeover: false,
             auth_key: None,
+            requested_role: Role::Control,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -2030,6 +2069,7 @@ mod tests {
             compression: CodecMask::NONE_AND_LZ4,
             request_takeover: false,
             auth_key: None,
+            requested_role: Role::Control,
         };
         (listener, config)
     }
@@ -2278,6 +2318,7 @@ mod tests {
             compression: CodecMask::NONE_ONLY,
             request_takeover: true,
             auth_key: None,
+            requested_role: Role::Control,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -2359,6 +2400,7 @@ mod tests {
             compression: CodecMask::NONE_AND_LZ4,
             request_takeover: false,
             auth_key: None,
+            requested_role: Role::Control,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -2443,6 +2485,7 @@ mod tests {
             compression: CodecMask::NONE_ONLY,
             request_takeover: false,
             auth_key: Some(expected_key.clone()),
+            requested_role: Role::Control,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -2537,6 +2580,7 @@ mod tests {
             compression: CodecMask::NONE_AND_LZ4,
             request_takeover: false,
             auth_key: None,
+            requested_role: Role::Control,
         };
         let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
         src.start_manager().unwrap();
@@ -2666,6 +2710,106 @@ mod tests {
 
         src.stop_manager();
         let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_sends_listen_role_when_config_opts_in() {
+        // **Regression test for #396.** When
+        // `RtlTcpConfig::requested_role = Role::Listen`, the
+        // `extension_enabled` gate must widen to emit a hello
+        // (even with compression=NONE_ONLY + takeover=false +
+        // auth_key=None) AND the role byte in the hello must be
+        // `Role::Listen`. Server-side admission logic for the
+        // Listen path is pinned by the role-matrix tests in
+        // `broadcaster::tests::register_with_role_*`; this test
+        // locks in the client's end of the same wire contract.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (hello_tx, hello_rx) = std::sync::mpsc::channel::<[u8; CLIENT_HELLO_LEN]>();
+        let server_thread = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            sock.set_read_timeout(Some(RTLX_TEST_STATE_DEADLINE))
+                .unwrap();
+            let mut hello_buf = [0u8; CLIENT_HELLO_LEN];
+            sock.read_exact(&mut hello_buf).expect("read hello");
+            let _ = hello_tx.send(hello_buf);
+            // Accept the handshake with Listen granted so the
+            // client reaches Connected.
+            let header = DongleInfo {
+                tuner: TunerTypeCode::R820t,
+                gain_count: RTLX_TEST_GAIN_COUNT,
+            }
+            .to_bytes();
+            sock.write_all(&header).unwrap();
+            let ext = ServerExtension {
+                codec: Codec::None,
+                granted_role: Some(Role::Listen),
+                status: Status::Ok,
+                version: PROTOCOL_VERSION,
+            };
+            sock.write_all(&ext.to_bytes()).unwrap();
+            thread::sleep(RTLX_TEST_SERVER_HOLD);
+        });
+
+        let config = RtlTcpConfig {
+            data_read_timeout: RTLX_TEST_DATA_READ_TIMEOUT,
+            max_consecutive_timeouts: 2,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            // Only role is non-default; every other gate field
+            // stays at the vanilla-safe default. This pins the
+            // "role opt-in alone trips the hello" contract so a
+            // future refactor of `extension_enabled` can't
+            // silently drop the role from the gate list.
+            compression: CodecMask::NONE_ONLY,
+            request_takeover: false,
+            auth_key: None,
+            requested_role: Role::Listen,
+        };
+        let mut src = RtlTcpSource::with_config(&addr.ip().to_string(), addr.port(), config);
+        src.start_manager().unwrap();
+
+        let hello = hello_rx
+            .recv_timeout(RTLX_TEST_STATE_DEADLINE)
+            .expect("server should receive hello within deadline");
+        // Magic bytes first — sanity-check we read a hello, not
+        // command framing.
+        assert_eq!(&hello[..EXTENSION_MAGIC.len()], &EXTENSION_MAGIC);
+        // Role byte (offset 5) must be `Role::Listen`.
+        assert_eq!(
+            hello[5],
+            Role::Listen as u8,
+            "Listen opt-in must encode Role::Listen at byte offset 5 (got 0x{:02x})",
+            hello[5],
+        );
+        // Flags byte (offset 6) must be zero — we didn't opt
+        // into takeover or auth, just role.
+        assert_eq!(hello[6], 0);
+
+        src.stop_manager();
+        let _ = server_thread.join();
+    }
+
+    #[test]
+    fn rtlx_handshake_emits_control_role_by_default() {
+        // Complement to the Listen test above: the TRUE default
+        // path (fields all at `Default`) sends no hello at all,
+        // matching `rtl_tcp_default_config_sends_no_hello_to_vanilla_server`.
+        // The DEFAULT *role* is `Role::Control`, but the default
+        // config gate (`extension_enabled = false` because
+        // compression / takeover / auth / role are all default)
+        // means no hello is emitted on the wire.
+        //
+        // This test pins the "role defaults to Control" struct
+        // contract via `Default::default()` so a future typo or
+        // accidental swap (e.g. flipping the default to Listen)
+        // would trip here immediately.
+        let config = RtlTcpConfig::default();
+        assert_eq!(
+            config.requested_role,
+            Role::Control,
+            "Default for `requested_role` must be `Control` — legacy-safe behavior"
+        );
     }
 
     #[test]

--- a/crates/sdr-types/src/error.rs
+++ b/crates/sdr-types/src/error.rs
@@ -60,6 +60,32 @@ pub enum SourceError {
     /// can route terminal vs. retry-worthy rejections correctly.
     #[error("temporarily unavailable: {0}")]
     TemporarilyUnavailable(String),
+
+    /// Server denied the connect with `Status::ControllerBusy`
+    /// (#392) and the user needs to explicitly decide what to
+    /// do next — either connect as Listener, force a takeover,
+    /// or give up. Treated as terminal by the connection
+    /// manager (no auto-retry) per #396; the UI surfaces
+    /// the choice via a toast with "Take control" / "Connect
+    /// as Listener" action buttons. Distinct from
+    /// `TemporarilyUnavailable` (which auto-retries) because
+    /// a user-facing decision is needed. Per #396.
+    #[error("controller slot is occupied")]
+    ControllerBusy,
+
+    /// Server requires a pre-shared key (#394) and the client
+    /// didn't send one. Terminal from the connection manager's
+    /// perspective (no auto-retry); the UI re-prompts for a
+    /// key and triggers a fresh connect. Per #396.
+    #[error("server requires an authentication key")]
+    AuthRequired,
+
+    /// Server required a key and the client's attempt was
+    /// rejected (`Status::AuthFailed`). Terminal from the
+    /// connection manager's perspective; the UI re-prompts
+    /// with "Key rejected" copy. Per #396.
+    #[error("authentication key rejected")]
+    AuthFailed,
 }
 
 /// Errors from sink modules.

--- a/crates/sdr-types/src/error.rs
+++ b/crates/sdr-types/src/error.rs
@@ -47,17 +47,33 @@ pub enum SourceError {
     /// Treated as **terminal** by the `rtl_tcp` client's connection manager:
     /// the backoff loop exits and the state transitions to
     /// `ConnectionState::Failed`. Use this for errors that won't be fixed
-    /// by retrying (bad server, wrong protocol version, auth rejection).
+    /// by retrying and that don't have a dedicated variant below (bad
+    /// server, wrong protocol version, unexpected handshake status codes
+    /// like `Status::ListenerCapReached`, LZ4 mid-stream decode failure).
+    ///
+    /// **Not** for role-denial errors (pre-#396 those folded in here with
+    /// a `"not an rtl_tcp server: ..."` or similar reason string — now
+    /// routed to [`Self::ControllerBusy`] / [`Self::AuthRequired`] /
+    /// [`Self::AuthFailed`] so the connection manager can publish a
+    /// distinct [`crate::RtlTcpConnectionState`] variant and the UI
+    /// can offer a specific recovery action instead of a generic
+    /// "Failed — \<reason\>" toast).
     #[error("protocol error: {0}")]
     Protocol(String),
-    /// Transient, retryable failure from a network source — e.g. the
-    /// `rtl_tcp` server's extended handshake returned `ControllerBusy`
-    /// because another client is currently controlling the dongle.
-    /// The condition is expected to resolve without user action once
-    /// the other client disconnects, so the connection manager keeps
-    /// retrying on the normal backoff schedule rather than
-    /// transitioning to `Failed`. Distinct from `Protocol` so callers
-    /// can route terminal vs. retry-worthy rejections correctly.
+    /// Transient, retryable failure from a network source. Used for
+    /// conditions the connection manager expects to resolve without
+    /// user action — currently none of the `rtl_tcp` extended
+    /// handshake status codes. The backoff loop keeps retrying on
+    /// the normal schedule rather than transitioning to a terminal
+    /// state.
+    ///
+    /// **Not** for `Status::ControllerBusy`: pre-#396 this variant
+    /// wrapped busy rejections with silent auto-retry, which hid the
+    /// decision point (Take control? / Connect as Listener? / give
+    /// up?) from the user. Per #396, `ControllerBusy` now routes to
+    /// the dedicated [`Self::ControllerBusy`] variant (terminal,
+    /// no auto-retry) so the UI can surface the choice explicitly
+    /// via a toast.
     #[error("temporarily unavailable: {0}")]
     TemporarilyUnavailable(String),
 
@@ -68,22 +84,29 @@ pub enum SourceError {
     /// manager (no auto-retry) per #396; the UI surfaces
     /// the choice via a toast with "Take control" / "Connect
     /// as Listener" action buttons. Distinct from
-    /// `TemporarilyUnavailable` (which auto-retries) because
-    /// a user-facing decision is needed. Per #396.
+    /// [`Self::TemporarilyUnavailable`] (which auto-retries)
+    /// because a user-facing decision is needed. Per #396.
     #[error("controller slot is occupied")]
     ControllerBusy,
 
     /// Server requires a pre-shared key (#394) and the client
     /// didn't send one. Terminal from the connection manager's
     /// perspective (no auto-retry); the UI re-prompts for a
-    /// key and triggers a fresh connect. Per #396.
+    /// key and triggers a fresh connect. Distinct from
+    /// [`Self::Protocol`] (which is where this folded pre-#396,
+    /// as `"protocol error: server requires auth"`) so the UI
+    /// can reveal / focus the Server-key entry row instead of
+    /// showing a generic failure toast. Per #396.
     #[error("server requires an authentication key")]
     AuthRequired,
 
     /// Server required a key and the client's attempt was
     /// rejected (`Status::AuthFailed`). Terminal from the
     /// connection manager's perspective; the UI re-prompts
-    /// with "Key rejected" copy. Per #396.
+    /// with "Key rejected" copy. Distinct from
+    /// [`Self::AuthRequired`] (which means the client never
+    /// sent a key) so the toast can tell "never tried" vs
+    /// "wrong key" apart. Per #396.
     #[error("authentication key rejected")]
     AuthFailed,
 }

--- a/crates/sdr-types/src/rtl_tcp_connection_state.rs
+++ b/crates/sdr-types/src/rtl_tcp_connection_state.rs
@@ -57,7 +57,7 @@ pub enum RtlTcpConnectionState {
         /// Listener, `None` = unknown (we never sent a hello, or
         /// the server is a pre-#392 RTLX build that doesn't yet
         /// write the field). UIs render the role badge only when
-        /// this is `Some` — per CodeRabbit round 1 on PR #408,
+        /// this is `Some` — per `CodeRabbit` round 1 on PR #408,
         /// a legacy / pre-#392 server's actual slot is unknowable
         /// from the client side, and guessing "Controller" there
         /// could mis-label the session. Issue #396.

--- a/crates/sdr-types/src/rtl_tcp_connection_state.rs
+++ b/crates/sdr-types/src/rtl_tcp_connection_state.rs
@@ -76,6 +76,34 @@ pub enum RtlTcpConnectionState {
         /// underlying error type's `Display` should produce this.
         reason: String,
     },
+
+    /// Server has an existing Control client and the user's
+    /// connect attempt was denied with `Status::ControllerBusy`.
+    /// The UI surfaces this distinctly (not as generic
+    /// `Retrying` or `Failed`) so it can offer a "Take control"
+    /// / "Connect as Listener" choice instead of silently
+    /// retrying in the background. Pre-#396 this folded into
+    /// `TemporarilyUnavailable` with an auto-retry loop — that
+    /// hid the busy state from the user and prevented the
+    /// explicit role-choice UX the issue calls for. Per #396.
+    ControllerBusy,
+
+    /// Server requires a pre-shared key (#394) and the client
+    /// didn't send one. UI surfaces this by revealing / focusing
+    /// the Server key field so the user can enter the key and
+    /// reconnect. Distinct from `AuthFailed` (which means the
+    /// client DID send a key but the server rejected it) so the
+    /// UI can tell "never tried" vs "wrong key" apart in the
+    /// toast copy. Terminal — the connection manager does not
+    /// auto-retry while an auth prompt is pending. Per #396.
+    AuthRequired,
+
+    /// Server required a key and the client's attempt was
+    /// rejected (`Status::AuthFailed`). UI surfaces "Key
+    /// rejected. Check with the server owner." and re-focuses
+    /// the Server key field. Terminal — same no-retry treatment
+    /// as `AuthRequired`. Per #396.
+    AuthFailed,
 }
 
 impl RtlTcpConnectionState {
@@ -92,6 +120,21 @@ impl RtlTcpConnectionState {
     /// treatment.
     pub fn is_in_progress(&self) -> bool {
         matches!(self, Self::Connecting | Self::Retrying { .. })
+    }
+
+    /// True for terminal states that require explicit user
+    /// interaction before another connect attempt. `Failed` +
+    /// the three role-denial variants (`ControllerBusy`,
+    /// `AuthRequired`, `AuthFailed`) all halt the auto-retry
+    /// loop. UI uses this to distinguish "keep showing the
+    /// spinner, server will come back" (`Retrying`) from
+    /// "the user has to pick / type / click something"
+    /// (this group). Per #396.
+    pub fn needs_user_action(&self) -> bool {
+        matches!(
+            self,
+            Self::Failed { .. } | Self::ControllerBusy | Self::AuthRequired | Self::AuthFailed
+        )
     }
 }
 

--- a/crates/sdr-types/src/rtl_tcp_connection_state.rs
+++ b/crates/sdr-types/src/rtl_tcp_connection_state.rs
@@ -50,6 +50,18 @@ pub enum RtlTcpConnectionState {
         /// uncompressed-by-choice paths both land on `"None"`.
         /// Issue #307.
         codec: String,
+        /// Server's `ServerExtension.granted_role` decision from
+        /// the #392 extended handshake, projected to `Option<bool>`
+        /// so this type doesn't pull in `sdr-server-rtltcp`'s wire
+        /// `Role` enum: `Some(true)` = Controller, `Some(false)` =
+        /// Listener, `None` = unknown (we never sent a hello, or
+        /// the server is a pre-#392 RTLX build that doesn't yet
+        /// write the field). UIs render the role badge only when
+        /// this is `Some` — per CodeRabbit round 1 on PR #408,
+        /// a legacy / pre-#392 server's actual slot is unknowable
+        /// from the client side, and guessing "Controller" there
+        /// could mis-label the session. Issue #396.
+        granted_role: Option<bool>,
     },
 
     /// Transport-level error (connect refused, EOF, stall). The
@@ -151,6 +163,7 @@ mod tests {
                 tuner_name: "R820T".into(),
                 gain_count: 29,
                 codec: "None".into(),
+                granted_role: Some(true),
             }
             .is_connected()
         );
@@ -178,6 +191,7 @@ mod tests {
                 tuner_name: "R820T".into(),
                 gain_count: 29,
                 codec: "None".into(),
+                granted_role: Some(true),
             }
             .is_in_progress()
         );
@@ -189,5 +203,45 @@ mod tests {
             .is_in_progress()
         );
         assert!(!RtlTcpConnectionState::Failed { reason: "x".into() }.is_in_progress());
+    }
+
+    #[test]
+    fn needs_user_action_matches_terminal_user_action_states() {
+        // Terminal states that gate the auto-retry loop and
+        // demand an explicit click / type / pick from the user.
+        // Added alongside the #396 client UI so the helper
+        // cleanly replaces an ad-hoc pattern match at every
+        // call site. Pre-#396 only `Failed` needed this
+        // treatment; `ControllerBusy` / `AuthRequired` /
+        // `AuthFailed` are new terminal variants that must
+        // also return `true`.
+        assert!(RtlTcpConnectionState::Failed { reason: "x".into() }.needs_user_action());
+        assert!(RtlTcpConnectionState::ControllerBusy.needs_user_action());
+        assert!(RtlTcpConnectionState::AuthRequired.needs_user_action());
+        assert!(RtlTcpConnectionState::AuthFailed.needs_user_action());
+
+        // Non-terminal states — the connection manager is
+        // either waiting to start, already streaming, or
+        // auto-retrying on its own backoff schedule. The UI
+        // should show a spinner / status icon, not a recovery
+        // affordance.
+        assert!(!RtlTcpConnectionState::Disconnected.needs_user_action());
+        assert!(!RtlTcpConnectionState::Connecting.needs_user_action());
+        assert!(
+            !RtlTcpConnectionState::Connected {
+                tuner_name: "R820T".into(),
+                gain_count: 29,
+                codec: "None".into(),
+                granted_role: Some(true),
+            }
+            .needs_user_action()
+        );
+        assert!(
+            !RtlTcpConnectionState::Retrying {
+                attempt: 1,
+                retry_in: Duration::from_secs(1),
+            }
+            .needs_user_action()
+        );
     }
 }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -156,6 +156,18 @@ pub fn probe_rtlsdr_device_label() -> String {
 /// empty-after-disconnect paths render identical text.
 pub const RTL_TCP_STATUS_DISCONNECTED_SUBTITLE: &str = "Disconnected";
 
+/// Combo-row index for `Role::Control` on `rtl_tcp_role_row`.
+/// Load-bearing — must match the `StringList` order built in
+/// `build_source_panel`. Per issue #396.
+pub const RTL_TCP_ROLE_CONTROL_IDX: u32 = 0;
+/// Combo-row index for `Role::Listen` on `rtl_tcp_role_row`.
+pub const RTL_TCP_ROLE_LISTEN_IDX: u32 = 1;
+
+/// Config key for the persisted last-used connection role.
+/// Stored as a `"control"` / `"listen"` string via
+/// `FavoriteRole`'s serde representation. Per issue #396.
+pub const KEY_RTL_TCP_CLIENT_LAST_ROLE: &str = "rtl_tcp_client_last_role";
+
 /// Sample-rate selector index at which we start showing the
 /// "high bandwidth" advisory caption. Index 7 = 2.4 MHz, which
 /// at 8-bit I/Q pairs wire-format works out to ~38 Mbps — over
@@ -285,6 +297,20 @@ pub struct SourcePanel {
     /// indicates we're between attempts (Retrying / Failed /
     /// Disconnected).
     pub rtl_tcp_retry_button: gtk4::Button,
+    /// "Connection role" picker (Control / Listen) shown only
+    /// when the RTL-TCP source type is selected. Wire-level
+    /// default is Control (#392 back-compat); Listen opts into
+    /// concurrent read-only access to a server that already has
+    /// a controller. Per issue #396.
+    pub rtl_tcp_role_row: adw::ComboRow,
+    /// "Server key" password entry shown when the RTL-TCP source
+    /// is selected AND the active server either advertises
+    /// `auth_required=true` via mDNS TXT or has a saved key in
+    /// the keyring. Per issue #396. The key bytes themselves
+    /// are persisted to the OS keyring (not this widget's
+    /// value), so the `EntryRow` is cleared on source-type change
+    /// to avoid leaking the value into widget-tree dumps.
+    pub rtl_tcp_auth_key_row: adw::PasswordEntryRow,
 
     /// Advisory caption shown when the selected sample rate is at
     /// or above `HIGH_BANDWIDTH_SAMPLE_RATE_IDX` AND the source
@@ -609,6 +635,30 @@ pub fn build_source_panel() -> SourcePanel {
     rtl_tcp_status_row.add_suffix(&rtl_tcp_disconnect_button);
     rtl_tcp_status_row.add_suffix(&rtl_tcp_retry_button);
 
+    // Connection-role picker (#396). AdwComboRow with two
+    // entries: "Control" (index 0) and "Listen" (index 1).
+    // Default Control matches the pre-#392 single-client flow
+    // every legacy rtl_tcp client / server assumes.
+    let rtl_tcp_role_model = gtk4::StringList::new(&["Control", "Listen"]);
+    let rtl_tcp_role_row = adw::ComboRow::builder()
+        .title("Connection role")
+        .subtitle("Control drives tuning; Listen receives IQ read-only")
+        .model(&rtl_tcp_role_model)
+        .selected(RTL_TCP_ROLE_CONTROL_IDX)
+        .visible(false)
+        .build();
+
+    // Server key entry (#394 + #396). Password-purpose entry
+    // row — masked by default, revealable via AdwPasswordEntryRow's
+    // built-in "peek" button. Kept separate from the main hostname
+    // / port block so the user sees it only when a key is
+    // actually needed (server advertises auth_required=true OR
+    // there's a saved key for the active host:port).
+    let rtl_tcp_auth_key_row = adw::PasswordEntryRow::builder()
+        .title("Server key")
+        .visible(false)
+        .build();
+
     // Bandwidth advisory row — hidden by default. Visibility is
     // toggled by the sample-rate and device-type notify handlers
     // in window.rs. Title + subtitle copy come from shared consts
@@ -637,6 +687,8 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&record_iq_row);
     group.add(&rtl_tcp_discovered_row);
     group.add(&rtl_tcp_status_row);
+    group.add(&rtl_tcp_role_row);
+    group.add(&rtl_tcp_auth_key_row);
     group.add(&bandwidth_advisory_row);
 
     // Derive initial visibility from the selected device.
@@ -656,6 +708,13 @@ pub fn build_source_panel() -> SourcePanel {
     file_path_row.set_visible(is_file);
     rtl_tcp_discovered_row.set_visible(is_rtltcp);
     rtl_tcp_status_row.set_visible(is_rtltcp);
+    rtl_tcp_role_row.set_visible(is_rtltcp);
+    // Auth key row stays hidden until a specific signal
+    // (mDNS TXT auth_required=true OR saved key exists for the
+    // active host:port). Starting hidden avoids prompting users
+    // on servers that don't require auth. The wiring in
+    // window.rs flips visibility via the discovery / last-
+    // connected load paths.
 
     connect_device_visibility(
         &device_row,
@@ -668,7 +727,13 @@ pub fn build_source_panel() -> SourcePanel {
         &protocol_row,
         &file_path_row,
     );
-    connect_rtl_tcp_visibility(&device_row, &rtl_tcp_discovered_row, &rtl_tcp_status_row);
+    connect_rtl_tcp_visibility(
+        &device_row,
+        &rtl_tcp_discovered_row,
+        &rtl_tcp_status_row,
+        &rtl_tcp_role_row,
+        &rtl_tcp_auth_key_row,
+    );
 
     // Controls connected to DSP pipeline via window.rs
 
@@ -694,6 +759,8 @@ pub fn build_source_panel() -> SourcePanel {
         rtl_tcp_status_row,
         rtl_tcp_disconnect_button,
         rtl_tcp_retry_button,
+        rtl_tcp_role_row,
+        rtl_tcp_auth_key_row,
         bandwidth_advisory_row,
     }
 }
@@ -705,16 +772,34 @@ fn connect_rtl_tcp_visibility(
     device_row: &adw::ComboRow,
     rtl_tcp_discovered_row: &adw::ExpanderRow,
     rtl_tcp_status_row: &adw::ActionRow,
+    rtl_tcp_role_row: &adw::ComboRow,
+    rtl_tcp_auth_key_row: &adw::PasswordEntryRow,
 ) {
     device_row.connect_selected_notify(glib::clone!(
         #[weak]
         rtl_tcp_discovered_row,
         #[weak]
         rtl_tcp_status_row,
+        #[weak]
+        rtl_tcp_role_row,
+        #[weak]
+        rtl_tcp_auth_key_row,
         move |row| {
             let is_rtltcp = row.selected() == DEVICE_RTLTCP;
             rtl_tcp_discovered_row.set_visible(is_rtltcp);
             rtl_tcp_status_row.set_visible(is_rtltcp);
+            rtl_tcp_role_row.set_visible(is_rtltcp);
+            // Auth key row stays hidden until the discovery /
+            // last-connected layer in window.rs flips it on via
+            // the `auth_required` hint or a saved-key lookup.
+            // Flipping to a non-RTLX source type always hides
+            // it AND clears the entry so the value doesn't
+            // linger in the widget tree for other source types
+            // that don't use it. Per #396.
+            if !is_rtltcp {
+                rtl_tcp_auth_key_row.set_visible(false);
+                rtl_tcp_auth_key_row.set_text("");
+            }
         }
     ));
 }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -331,6 +331,10 @@ pub fn format_rtl_tcp_state(state: &RtlTcpConnectionState) -> String {
             tuner_name,
             gain_count,
             codec,
+            // The subtitle copy intentionally omits the role —
+            // the status-bar badge carries it. Per CodeRabbit
+            // round 1 on PR #408.
+            granted_role: _,
         } => {
             // Only surface the codec when it's actually compressing —
             // the common "None" case (every legacy server, plus our
@@ -1143,6 +1147,7 @@ mod tests {
                 tuner_name: "R820T".into(),
                 gain_count: 29,
                 codec: "None".into(),
+                granted_role: Some(true),
             }),
             "Connected — R820T (29 gains)"
         );
@@ -1155,6 +1160,7 @@ mod tests {
                 tuner_name: "R820T".into(),
                 gain_count: 29,
                 codec: "LZ4".into(),
+                granted_role: Some(true),
             }),
             "Connected — R820T (29 gains, LZ4)"
         );
@@ -1192,6 +1198,23 @@ mod tests {
                 reason: "bad handshake".into(),
             }),
             "Failed — bad handshake"
+        );
+        // Role-denial states (#396) get their own short
+        // subtitles — no reason string needed because the
+        // variant itself IS the reason. Lock in each copy
+        // against accidental drift; a typo here would ship
+        // to users without CI catching it otherwise.
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::ControllerBusy),
+            "Controller slot is occupied",
+        );
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::AuthRequired),
+            "Server requires a key",
+        );
+        assert_eq!(
+            format_rtl_tcp_state(&RtlTcpConnectionState::AuthFailed),
+            "Key rejected",
         );
     }
 
@@ -1271,6 +1294,15 @@ mod tests {
         assert!(loaded[0].tuner_name.is_none());
         assert!(loaded[0].gain_count.is_none());
         assert!(loaded[0].last_seen_unix.is_none());
+        // Role + auth-required fields are #396 additions and
+        // must also default to `None` for legacy bare-string
+        // entries — the connect path treats `None` as
+        // "unknown, default to Control / don't pre-reveal the
+        // auth row." A regression that silently wrote `Some`
+        // defaults here would change the UX for every
+        // pre-#396 favorite on the first launch after upgrade.
+        assert!(loaded[0].requested_role.is_none());
+        assert!(loaded[0].auth_required.is_none());
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -330,6 +330,14 @@ pub fn format_rtl_tcp_state(state: &RtlTcpConnectionState) -> String {
             format!("Retrying in {secs} s (attempt {attempt})")
         }
         RtlTcpConnectionState::Failed { reason } => format!("Failed — {reason}"),
+        // Role-denial terminal states (#396). These show short
+        // actionable subtitles so the user knows WHY the
+        // connection didn't advance — the full toast UX with
+        // "Take control" / "Connect as Listener" buttons lives
+        // in `window.rs`.
+        RtlTcpConnectionState::ControllerBusy => "Controller slot is occupied".to_string(),
+        RtlTcpConnectionState::AuthRequired => "Server requires a key".to_string(),
+        RtlTcpConnectionState::AuthFailed => "Key rejected".to_string(),
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -773,6 +773,61 @@ pub struct FavoriteEntry {
     /// `ServerAnnounced` event for this `key`. `None` when we
     /// haven't seen the server this session.
     pub last_seen_unix: Option<u64>,
+    /// Last-used role against this server: `"control"` or
+    /// `"listen"`. Stored as a string (via
+    /// `serde(rename_all = "snake_case")` on the enum) rather
+    /// than the raw enum so the JSON is human-readable and a
+    /// future enum-variant rename doesn't silently break
+    /// deserialization. `None` until the user explicitly picks
+    /// a role for this server; the connect path defaults to
+    /// Control when `None`. Per issue #396.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_role: Option<FavoriteRole>,
+    /// Whether the most recent mDNS TXT for this server
+    /// advertised `auth_required=true`. Pre-populated from
+    /// discovery events so the UI can reveal the Server key
+    /// field BEFORE the user clicks Connect (saves a round
+    /// trip through the `AuthRequired` error path). `None`
+    /// means "unknown" — either we've never seen a TXT, or the
+    /// record didn't carry the field (older server, non-sdr-rs
+    /// server). Per issue #396.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_required: Option<bool>,
+}
+
+/// Favorite-entry serialized form of a client's preferred role
+/// for a given server. `snake_case` so the JSON surface reads
+/// as `"control"` / `"listen"` — easier to hand-edit and
+/// more forgiving across future enum changes. Per #396.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FavoriteRole {
+    Control,
+    Listen,
+}
+
+impl FavoriteRole {
+    /// Translate to the wire-level `sdr_server_rtltcp::extension::Role`
+    /// the client hello will carry. Kept as a separate crate
+    /// boundary so `FavoriteEntry` doesn't force a dep on
+    /// `sdr-server-rtltcp` at every call site that reads a
+    /// serialized favorite.
+    pub fn as_wire_role(self) -> sdr_server_rtltcp::extension::Role {
+        match self {
+            Self::Control => sdr_server_rtltcp::extension::Role::Control,
+            Self::Listen => sdr_server_rtltcp::extension::Role::Listen,
+        }
+    }
+
+    /// Inverse: build a `FavoriteRole` from a wire-level
+    /// `Role`. Used when persisting a newly-chosen role back to
+    /// the favorite entry after a successful connect.
+    pub fn from_wire_role(role: sdr_server_rtltcp::extension::Role) -> Self {
+        match role {
+            sdr_server_rtltcp::extension::Role::Control => Self::Control,
+            sdr_server_rtltcp::extension::Role::Listen => Self::Listen,
+        }
+    }
 }
 
 /// Load the persisted favorites list. Returns an empty `Vec` on
@@ -809,13 +864,20 @@ pub fn load_favorites(config: &Arc<ConfigManager>) -> Vec<FavoriteEntry> {
                     // Legacy bare-string entry. Build a stub
                     // FavoriteEntry so the slide-out still has
                     // something to render while the user waits
-                    // for the server to re-announce.
+                    // for the server to re-announce. Role and
+                    // auth-required default to `None` — the
+                    // connect path treats both as "unknown"
+                    // (role defaults to Control, auth_required
+                    // is decided by the server on first
+                    // connect).
                     Some(FavoriteEntry {
                         key: s.to_string(),
                         nickname: s.to_string(),
                         tuner_name: None,
                         gain_count: None,
                         last_seen_unix: None,
+                        requested_role: None,
+                        auth_required: None,
                     })
                 } else {
                     // Corrupt object entry — hand-edited JSON or a
@@ -1066,6 +1128,8 @@ mod tests {
                 tuner_name: Some("R820T".into()),
                 gain_count: Some(29),
                 last_seen_unix: Some(TEST_LAST_SEEN_UNIX),
+                requested_role: Some(FavoriteRole::Listen),
+                auth_required: Some(true),
             },
             FavoriteEntry {
                 key: "attic-pi.local.:1234".into(),
@@ -1073,6 +1137,8 @@ mod tests {
                 tuner_name: None,
                 gain_count: None,
                 last_seen_unix: None,
+                requested_role: None,
+                auth_required: None,
             },
         ];
         save_favorites(&config, &favs);
@@ -1083,11 +1149,18 @@ mod tests {
         assert_eq!(loaded[0].tuner_name.as_deref(), Some("R820T"));
         assert_eq!(loaded[0].gain_count, Some(29));
         assert_eq!(loaded[0].last_seen_unix, Some(TEST_LAST_SEEN_UNIX));
+        // Role + auth_required round-trip on the opt-in side.
+        // Per #396: the JSON surface carries these through the
+        // serde `snake_case` rename and skip-if-none attributes.
+        assert_eq!(loaded[0].requested_role, Some(FavoriteRole::Listen));
+        assert_eq!(loaded[0].auth_required, Some(true));
         // Second entry has every optional field None → must
         // round-trip as None, NOT as missing / default values.
         assert!(loaded[1].tuner_name.is_none());
         assert!(loaded[1].gain_count.is_none());
         assert!(loaded[1].last_seen_unix.is_none());
+        assert!(loaded[1].requested_role.is_none());
+        assert!(loaded[1].auth_required.is_none());
     }
 
     #[test]

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -11,6 +11,37 @@ use crate::messages::UiToDsp;
 /// Default center frequency in Hz (100 MHz — FM broadcast band).
 const DEFAULT_CENTER_FREQUENCY_HZ: f64 = 100_000_000.0;
 
+// Discriminant constants for `last_rtl_tcp_state_disc`. Matches
+// the variant ordering of `sdr_types::RtlTcpConnectionState` —
+// not a wire contract (we never serialize these), just a stable
+// `u8` representation so `Cell::set` works across the enum's
+// non-Copy variants. Per #396.
+pub const RTL_TCP_STATE_DISC_DISCONNECTED: u8 = 0;
+pub const RTL_TCP_STATE_DISC_CONNECTING: u8 = 1;
+pub const RTL_TCP_STATE_DISC_CONNECTED: u8 = 2;
+pub const RTL_TCP_STATE_DISC_RETRYING: u8 = 3;
+pub const RTL_TCP_STATE_DISC_FAILED: u8 = 4;
+pub const RTL_TCP_STATE_DISC_CONTROLLER_BUSY: u8 = 5;
+pub const RTL_TCP_STATE_DISC_AUTH_REQUIRED: u8 = 6;
+pub const RTL_TCP_STATE_DISC_AUTH_FAILED: u8 = 7;
+
+/// Project an `RtlTcpConnectionState` to its `u8` discriminant
+/// for use in the edge-detection path. Kept as a free function
+/// so callers don't have to reach into the enum's internal
+/// representation. Per #396.
+pub fn rtl_tcp_state_discriminant(state: &sdr_types::RtlTcpConnectionState) -> u8 {
+    match state {
+        sdr_types::RtlTcpConnectionState::Disconnected => RTL_TCP_STATE_DISC_DISCONNECTED,
+        sdr_types::RtlTcpConnectionState::Connecting => RTL_TCP_STATE_DISC_CONNECTING,
+        sdr_types::RtlTcpConnectionState::Connected { .. } => RTL_TCP_STATE_DISC_CONNECTED,
+        sdr_types::RtlTcpConnectionState::Retrying { .. } => RTL_TCP_STATE_DISC_RETRYING,
+        sdr_types::RtlTcpConnectionState::Failed { .. } => RTL_TCP_STATE_DISC_FAILED,
+        sdr_types::RtlTcpConnectionState::ControllerBusy => RTL_TCP_STATE_DISC_CONTROLLER_BUSY,
+        sdr_types::RtlTcpConnectionState::AuthRequired => RTL_TCP_STATE_DISC_AUTH_REQUIRED,
+        sdr_types::RtlTcpConnectionState::AuthFailed => RTL_TCP_STATE_DISC_AUTH_FAILED,
+    }
+}
+
 /// Shared application state, designed for single-threaded GTK main loop access.
 ///
 /// Wrap in `Rc<AppState>` and clone into GTK closures.
@@ -50,6 +81,23 @@ pub struct AppState {
     /// moving the stored value out, which interferes with the
     /// borrow-and-clone pattern the button handler uses.
     pub scanner_active_key: RefCell<Option<sdr_scanner::ChannelKey>>,
+    /// Previous `rtl_tcp` connection state discriminant, used to
+    /// detect edge transitions into terminal role-denial states
+    /// (`ControllerBusy`, `AuthRequired`, `AuthFailed`). The toast
+    /// UX only wants to fire ONCE per entry into each state, not
+    /// on every poll tick that re-publishes the same state. `u8`
+    /// discriminant instead of the full enum so `Cell::set` works
+    /// (the full enum carries `String` fields that defeat Copy).
+    /// Per issue #396.
+    pub last_rtl_tcp_state_disc: Cell<u8>,
+    /// Host:port string for the currently-selected `rtl_tcp`
+    /// server, kept in lockstep with the UI's `hostname_row` +
+    /// `port_row`. Captured on every successful `AuthRequired` /
+    /// `AuthFailed` transition so a subsequent successful
+    /// `Connected` can save the user-entered key to the right
+    /// per-server keyring entry. Empty string when no server is
+    /// selected. Per issue #396.
+    pub rtl_tcp_active_server: RefCell<String>,
 }
 
 impl AppState {
@@ -65,6 +113,12 @@ impl AppState {
             suppress_bandwidth_notify: Cell::new(false),
             suppress_demod_notify: Cell::new(false),
             scanner_active_key: RefCell::new(None),
+            // Initialize to `RTL_TCP_STATE_DISC_DISCONNECTED` — same
+            // as the connection manager's initial state so the first
+            // real transition into ControllerBusy / AuthRequired /
+            // AuthFailed is correctly detected as an edge.
+            last_rtl_tcp_state_disc: Cell::new(RTL_TCP_STATE_DISC_DISCONNECTED),
+            rtl_tcp_active_server: RefCell::new(String::new()),
         })
     }
 

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -167,4 +167,58 @@ mod tests {
         // Should not panic — just logs a warning.
         state.send_dsp(UiToDsp::Stop);
     }
+
+    #[test]
+    fn rtl_tcp_state_discriminant_covers_all_variants() {
+        // Lock-in test so a future `RtlTcpConnectionState`
+        // variant reorder doesn't silently desync the
+        // `RTL_TCP_STATE_DISC_*` u8 constants used by the
+        // toast edge-detection path. The constants are
+        // `Cell<u8>`-friendly projections of the enum's
+        // variant ordering and must match 1:1. Per
+        // CodeRabbit round 1 on PR #408.
+        use std::time::Duration;
+        assert_eq!(
+            rtl_tcp_state_discriminant(&sdr_types::RtlTcpConnectionState::Disconnected),
+            RTL_TCP_STATE_DISC_DISCONNECTED
+        );
+        assert_eq!(
+            rtl_tcp_state_discriminant(&sdr_types::RtlTcpConnectionState::Connecting),
+            RTL_TCP_STATE_DISC_CONNECTING
+        );
+        assert_eq!(
+            rtl_tcp_state_discriminant(&sdr_types::RtlTcpConnectionState::Connected {
+                tuner_name: "R820T".into(),
+                gain_count: 29,
+                codec: "None".into(),
+                granted_role: Some(true),
+            }),
+            RTL_TCP_STATE_DISC_CONNECTED
+        );
+        assert_eq!(
+            rtl_tcp_state_discriminant(&sdr_types::RtlTcpConnectionState::Retrying {
+                attempt: 1,
+                retry_in: Duration::from_secs(1),
+            }),
+            RTL_TCP_STATE_DISC_RETRYING
+        );
+        assert_eq!(
+            rtl_tcp_state_discriminant(&sdr_types::RtlTcpConnectionState::Failed {
+                reason: "x".into(),
+            }),
+            RTL_TCP_STATE_DISC_FAILED
+        );
+        assert_eq!(
+            rtl_tcp_state_discriminant(&sdr_types::RtlTcpConnectionState::ControllerBusy),
+            RTL_TCP_STATE_DISC_CONTROLLER_BUSY
+        );
+        assert_eq!(
+            rtl_tcp_state_discriminant(&sdr_types::RtlTcpConnectionState::AuthRequired),
+            RTL_TCP_STATE_DISC_AUTH_REQUIRED
+        );
+        assert_eq!(
+            rtl_tcp_state_discriminant(&sdr_types::RtlTcpConnectionState::AuthFailed),
+            RTL_TCP_STATE_DISC_AUTH_FAILED
+        );
+    }
 }

--- a/crates/sdr-ui/src/status_bar.rs
+++ b/crates/sdr-ui/src/status_bar.rs
@@ -16,6 +16,11 @@ const SPS_PER_KSPS: f64 = 1_000.0;
 
 /// Default signal level display text when no data has arrived.
 const DEFAULT_LEVEL_TEXT: &str = "Level: -- dBFS";
+/// Default role badge text when no `rtl_tcp` session is active.
+/// The label itself stays invisible in this state so it doesn't
+/// clutter the bar for users on local RTL-SDR / File / Network
+/// sources. Per issue #396.
+const DEFAULT_ROLE_TEXT: &str = "";
 /// Default sample rate display text when no data has arrived.
 const DEFAULT_SAMPLE_RATE_TEXT: &str = "SR: --";
 /// Default demod display text when no data has arrived.
@@ -39,6 +44,16 @@ pub struct StatusBar {
     pub frequency_label: gtk4::Label,
     /// Label showing cursor frequency and power readout.
     pub cursor_label: gtk4::Label,
+    /// `rtl_tcp` role badge — "Controller" (accent color) or
+    /// "Listener" (dim) when connected to an `rtl_tcp` server.
+    /// Hidden when the source isn't `rtl_tcp` or when the
+    /// connection isn't in `Connected` state. Per issue #396.
+    pub role_label: gtk4::Label,
+    /// Separator widget packed immediately before `role_label`.
+    /// Kept as a field so visibility can be toggled in lockstep
+    /// with the label (hiding the label alone leaves a stray
+    /// separator on the right edge).
+    pub role_separator: gtk4::Separator,
 }
 
 impl StatusBar {
@@ -65,6 +80,33 @@ impl StatusBar {
         self.frequency_label.set_label(&format_frequency(hz));
     }
 
+    /// Update the `rtl_tcp` role badge. `Some(is_control)`
+    /// shows "Controller" (accent CSS) when `true` or
+    /// "Listener" (dim CSS) when `false`; `None` hides the
+    /// badge + its separator entirely. Per issue #396.
+    pub fn update_role(&self, role: Option<bool>) {
+        match role {
+            Some(true) => {
+                self.role_label.set_label("Controller");
+                self.role_label.remove_css_class("dim-label");
+                self.role_label.add_css_class("accent");
+                self.role_label.set_visible(true);
+                self.role_separator.set_visible(true);
+            }
+            Some(false) => {
+                self.role_label.set_label("Listener");
+                self.role_label.remove_css_class("accent");
+                self.role_label.add_css_class("dim-label");
+                self.role_label.set_visible(true);
+                self.role_separator.set_visible(true);
+            }
+            None => {
+                self.role_label.set_visible(false);
+                self.role_separator.set_visible(false);
+            }
+        }
+    }
+
     /// Update the cursor readout with frequency and power at the mouse position.
     ///
     /// When `power_db` is `f32::NEG_INFINITY`, the cursor has left the area
@@ -88,6 +130,10 @@ pub fn build_status_bar() -> StatusBar {
     let demod_label = gtk4::Label::new(Some(DEFAULT_DEMOD_TEXT));
     let frequency_label = gtk4::Label::new(Some(DEFAULT_FREQUENCY_TEXT));
     let cursor_label = gtk4::Label::new(Some(DEFAULT_CURSOR_TEXT));
+    let role_label = gtk4::Label::new(Some(DEFAULT_ROLE_TEXT));
+    role_label.set_visible(false);
+    let role_separator = gtk4::Separator::new(gtk4::Orientation::Vertical);
+    role_separator.set_visible(false);
 
     let widget = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Horizontal)
@@ -104,6 +150,8 @@ pub fn build_status_bar() -> StatusBar {
     widget.append(&frequency_label);
     widget.append(&gtk4::Separator::new(gtk4::Orientation::Vertical));
     widget.append(&cursor_label);
+    widget.append(&role_separator);
+    widget.append(&role_label);
 
     StatusBar {
         widget,
@@ -112,6 +160,8 @@ pub fn build_status_bar() -> StatusBar {
         demod_label,
         frequency_label,
         cursor_label,
+        role_label,
+        role_separator,
     }
 }
 

--- a/crates/sdr-ui/src/status_bar.rs
+++ b/crates/sdr-ui/src/status_bar.rs
@@ -37,7 +37,7 @@ const DEFAULT_CURSOR_TEXT: &str = "Cursor: --";
 /// caller whether the bool came from the user's requested role
 /// or the server's admission decision, so a UI that passed a
 /// requested role here would mis-label sessions where the server
-/// admitted a different role than asked. Per CodeRabbit round 1
+/// admitted a different role than asked. Per `CodeRabbit` round 1
 /// on PR #408, callers must now name the slot explicitly. Per
 /// issue #396.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,7 +105,7 @@ impl StatusBar {
     /// CSS; `None` hides the badge + its separator entirely.
     /// Callers must pass the server's admitted role (not the
     /// user's requested role) — see [`RtlTcpRoleBadge`]. Per
-    /// issue #396 / CodeRabbit round 1 on PR #408.
+    /// issue #396 / `CodeRabbit` round 1 on PR #408.
     pub fn update_role(&self, role: Option<RtlTcpRoleBadge>) {
         match role {
             Some(RtlTcpRoleBadge::Controller) => {

--- a/crates/sdr-ui/src/status_bar.rs
+++ b/crates/sdr-ui/src/status_bar.rs
@@ -30,6 +30,25 @@ const DEFAULT_FREQUENCY_TEXT: &str = "-- Hz";
 /// Default cursor readout text when the cursor is not over the spectrum.
 const DEFAULT_CURSOR_TEXT: &str = "Cursor: --";
 
+/// Role badge state rendered by the status bar when connected
+/// to an `rtl_tcp` server. Variants carry role provenance
+/// explicitly — the API that previously took an `Option<bool>`
+/// (`true` = Controller, `false` = Listener) couldn't tell the
+/// caller whether the bool came from the user's requested role
+/// or the server's admission decision, so a UI that passed a
+/// requested role here would mis-label sessions where the server
+/// admitted a different role than asked. Per CodeRabbit round 1
+/// on PR #408, callers must now name the slot explicitly. Per
+/// issue #396.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RtlTcpRoleBadge {
+    /// Server admitted us as the Controller client — accent
+    /// styling in the status bar.
+    Controller,
+    /// Server admitted us as a Listener — dim styling.
+    Listener,
+}
+
 /// Bottom status bar showing live metrics.
 pub struct StatusBar {
     /// The container widget to pack into the window.
@@ -80,20 +99,23 @@ impl StatusBar {
         self.frequency_label.set_label(&format_frequency(hz));
     }
 
-    /// Update the `rtl_tcp` role badge. `Some(is_control)`
-    /// shows "Controller" (accent CSS) when `true` or
-    /// "Listener" (dim CSS) when `false`; `None` hides the
-    /// badge + its separator entirely. Per issue #396.
-    pub fn update_role(&self, role: Option<bool>) {
+    /// Update the `rtl_tcp` role badge. `Some(RtlTcpRoleBadge::
+    /// Controller)` shows "Controller" with accent CSS; `Some(
+    /// RtlTcpRoleBadge::Listener)` shows "Listener" with dim
+    /// CSS; `None` hides the badge + its separator entirely.
+    /// Callers must pass the server's admitted role (not the
+    /// user's requested role) — see [`RtlTcpRoleBadge`]. Per
+    /// issue #396 / CodeRabbit round 1 on PR #408.
+    pub fn update_role(&self, role: Option<RtlTcpRoleBadge>) {
         match role {
-            Some(true) => {
+            Some(RtlTcpRoleBadge::Controller) => {
                 self.role_label.set_label("Controller");
                 self.role_label.remove_css_class("dim-label");
                 self.role_label.add_css_class("accent");
                 self.role_label.set_visible(true);
                 self.role_separator.set_visible(true);
             }
-            Some(false) => {
+            Some(RtlTcpRoleBadge::Listener) => {
                 self.role_label.set_label("Listener");
                 self.role_label.remove_css_class("accent");
                 self.role_label.add_css_class("dim-label");

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1311,14 +1311,36 @@ fn handle_rtl_tcp_state_toast(
 
         RtlTcpConnectionState::AuthFailed => {
             record_active_rtl_tcp_server(app_state, hostname_row_weak, port_row_weak);
+            // Clear the saved per-server key from the keyring
+            // too — not just the widget. Pre-CodeRabbit round 2
+            // on PR #408 only `row.set_text("")` was called, so
+            // the keyring entry survived the rejection and the
+            // next discovery / favorites / Play-restart path
+            // would auto-load the same rejected bytes into the
+            // row via `apply_rtl_tcp_connect` / the startup
+            // restore, silently bouncing the user straight back
+            // into `AuthFailed`. Now we delete the saved key
+            // whenever the server explicitly rejects it; the
+            // user has to re-enter (or paste the new) key on
+            // the next attempt, which is the only recovery path
+            // from a rotated server key anyway. Per issue #396.
+            let active = app_state.rtl_tcp_active_server.borrow().clone();
+            if let Some((host, port_str)) = active.rsplit_once(':')
+                && let Ok(port) = port_str.parse::<u16>()
+                && let Err(e) = clear_client_auth_key_from_keyring(host, port)
+            {
+                tracing::warn!(
+                    server = %active,
+                    %e,
+                    "rtl_tcp: client auth key keyring clear on AuthFailed failed (non-fatal)"
+                );
+            }
             if let Some(row) = auth_key_row_weak.upgrade() {
                 row.set_visible(true);
                 row.grab_focus();
                 // Clear the entered value so the user doesn't
                 // re-submit the same wrong key by reflex on the
-                // next Retry. The saved-key keyring entry (if
-                // any) stays untouched — the user can clear it
-                // explicitly via the keyring UI.
+                // next Retry.
                 row.set_text("");
             }
             if let Some(overlay) = toast_overlay_weak.upgrade() {
@@ -1377,11 +1399,29 @@ fn handle_rtl_tcp_state_toast(
 /// the just-entered key to the right per-server keyring entry.
 /// Empty on upgrade failure — the save path skips when the
 /// cached identity is empty. Per #396.
+///
+/// **Cache-preserving fallback** (per `CodeRabbit` round 2 on
+/// PR #408): if `app_state.rtl_tcp_active_server` is already
+/// non-empty, this is a no-op. `apply_rtl_tcp_connect` writes
+/// the stable advertised `hostname:port` (same form as
+/// `favorite_key(server)`) directly into the cache at
+/// connect-setup time, so every downstream per-server lookup
+/// (keyring load/save/clear, favorite match) keys off the same
+/// identity. Reading `hostname_row.text()` here would overwrite
+/// the stable id with whatever the DSP is dialing — for
+/// discovery connects that can be a resolved IPv4/IPv6 literal,
+/// splitting "shack-pi.local.:1234" (favorites) from
+/// "192.168.1.17:1234" (keyring) and breaking round-trip. The
+/// widget-read fallback only runs in the manually-typed Play
+/// path where `apply_rtl_tcp_connect` never ran.
 fn record_active_rtl_tcp_server(
     app_state: &Rc<AppState>,
     hostname_row_weak: &glib::WeakRef<adw::EntryRow>,
     port_row_weak: &glib::WeakRef<adw::SpinRow>,
 ) {
+    if !app_state.rtl_tcp_active_server.borrow().is_empty() {
+        return;
+    }
     let Some(host_row) = hostname_row_weak.upgrade() else {
         return;
     };
@@ -2694,6 +2734,11 @@ fn apply_rtl_tcp_connect(
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
 ) {
+    use crate::sidebar::source_panel::{
+        FavoriteRole, KEY_RTL_TCP_CLIENT_LAST_ROLE, RTL_TCP_ROLE_CONTROL_IDX,
+        RTL_TCP_ROLE_LISTEN_IDX, load_favorites,
+    };
+
     let already_rtl_tcp = device_row.selected() == DEVICE_RTLTCP;
     protocol_row.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
     hostname_row.set_text(host);
@@ -2729,11 +2774,29 @@ fn apply_rtl_tcp_connect(
     // favorited AND never connected to; the picker stays on
     // Control and the row stays hidden, matching pre-#408
     // behavior.
-    use crate::sidebar::source_panel::{
-        FavoriteRole, KEY_RTL_TCP_CLIENT_LAST_ROLE, RTL_TCP_ROLE_CONTROL_IDX,
-        RTL_TCP_ROLE_LISTEN_IDX, load_favorites,
-    };
+    // Stable-id rule (per CodeRabbit round 2 on PR #408): all
+    // per-server state — keyring entries, favorite matches,
+    // `app_state.rtl_tcp_active_server` — keys off the
+    // *advertised* `hostname:port`, the same form
+    // `favorite_key(server)` produces on mDNS announce. The
+    // `host` param threaded into this helper already is that
+    // stable value (discovery + favorites both pass the
+    // advertised hostname, not a resolved IP), so we build the
+    // key from it directly rather than reading it back from
+    // `hostname_row.text()` — the row carries the dial target
+    // the DSP actually connects to, which could be a resolved
+    // IP or an IPv6 literal and would split identity between
+    // "favorite shack-pi.local.:1234" and "resolved
+    // 192.168.1.17:1234". Cache it on `AppState` so the
+    // subsequent auth-flow helpers (`save_current_auth_key_for_
+    // active_server`, the keyring-clear on `AuthFailed`, the
+    // role-picker's per-favorite update) use this same stable
+    // id without re-reading the widget.
     let server_key = format!("{host}:{port}");
+    state
+        .rtl_tcp_active_server
+        .borrow_mut()
+        .clone_from(&server_key);
     let favorite_entry = load_favorites(config)
         .into_iter()
         .find(|f| f.key == server_key);
@@ -2753,25 +2816,37 @@ fn apply_rtl_tcp_connect(
         };
         role_row.set_selected(idx);
     }
-    // Reveal Server-key row if the favorite advertised
-    // `auth_required = true`. We leave it alone when `None` —
-    // an unknown auth stance means "don't nag the user now,
-    // the AuthRequired handshake arm will reveal it if
-    // needed." `Some(false)` also leaves it alone (row stays
-    // hidden for explicitly-no-auth servers).
-    if matches!(
+    // Auth-row state is driven by two inputs:
+    // - `auth_required = Some(true)` on the favorite → the
+    //   server advertises a required key, so reveal the row so
+    //   the user can enter one (or see a saved one below) BEFORE
+    //   the first connect lands — saves the
+    //   `AuthRequired` bounce.
+    // - A saved key in the per-server keyring → pre-fill the
+    //   hex representation so a pre-configured auth connect
+    //   succeeds in a single `Connecting → Connected` hop.
+    //
+    // Pre-CodeRabbit round 2 on PR #408 each of these was a
+    // positive-only mutation: on the "no auth / no saved key"
+    // path the row kept whatever visibility and text the
+    // previous server left behind, so switching from
+    // auth-required server A to no-auth server B would leak
+    // A's revealed row + pre-filled key bytes into B — the
+    // next connect would dispatch `SetRtlTcpClientConfig` with
+    // A's key bound to B's endpoint. Now we rewrite both fields
+    // deterministically: `set_visible(should_reveal)` and
+    // `set_text(saved_hex_or_empty)` fire on every call.
+    let has_auth_required = matches!(
         favorite_entry.as_ref().and_then(|f| f.auth_required),
         Some(true)
-    ) {
-        auth_key_row.set_visible(true);
-    }
-    // Pre-fill the saved client key (hex) if we have one for
-    // this server. `load_client_auth_key_from_keyring` returns
-    // raw bytes; re-hex them for the row (the row always
-    // displays hex, matching what `openssl rand -hex 32`
-    // produces and what the server UI's Copy button writes).
-    if let Some(bytes) = load_client_auth_key_from_keyring(host, port) {
+    );
+    let saved_key_bytes = load_client_auth_key_from_keyring(host, port);
+    let should_reveal = has_auth_required || saved_key_bytes.is_some();
+    auth_key_row.set_visible(should_reveal);
+    if let Some(bytes) = saved_key_bytes {
         auth_key_row.set_text(&crate::sidebar::server_panel::auth_key_to_hex(&bytes));
+    } else {
+        auth_key_row.set_text("");
     }
     // Dispatch a fresh `SetRtlTcpClientConfig` so the DSP
     // thread has the restored role + key in place before the
@@ -2780,8 +2855,11 @@ fn apply_rtl_tcp_connect(
     // last-known values (possibly stale from a prior server)
     // and the first connect could land with the wrong role or
     // a dead auth key from another session.
+    // Transient out-of-range ComboRow indices fall back to
+    // Control — the legacy-safe default. Collapsed with the
+    // explicit Control arm since both produce the same
+    // `FavoriteRole::Control`.
     let requested_role = match role_row.selected() {
-        RTL_TCP_ROLE_CONTROL_IDX => FavoriteRole::Control,
         RTL_TCP_ROLE_LISTEN_IDX => FavoriteRole::Listen,
         _ => FavoriteRole::Control,
     }
@@ -2916,13 +2994,13 @@ struct FavoriteRowContext {
     /// Role picker — `apply_rtl_tcp_connect` needs it so the
     /// per-server `requested_role` can be restored before
     /// the new endpoint's first connect dispatch. Per
-    /// CodeRabbit round 1 on PR #408.
+    /// `CodeRabbit` round 1 on PR #408.
     role_row: glib::WeakRef<adw::ComboRow>,
     /// Auth-key row — `apply_rtl_tcp_connect` reveals it
     /// when the favorite advertises `auth_required` and
     /// pre-fills any saved key from the keyring so a
     /// pre-configured auth connect lands in a single
-    /// `Connecting → Connected` hop. Per CodeRabbit round 1
+    /// `Connecting → Connected` hop. Per `CodeRabbit` round 1
     /// on PR #408.
     auth_key_row: glib::WeakRef<adw::PasswordEntryRow>,
     expander_weak: glib::WeakRef<adw::ExpanderRow>,
@@ -3383,7 +3461,6 @@ fn save_client_auth_key_to_keyring(
 /// every reconnect attempt). Missing-entry is treated as
 /// success — the goal is "there is no saved key after this
 /// call," which a missing entry already satisfies. Per #396.
-#[allow(dead_code)]
 fn clear_client_auth_key_from_keyring(
     host: &str,
     port: u16,
@@ -5688,38 +5765,71 @@ fn connect_source_panel(
         );
     }
 
-    // Restore the rtl_tcp client's last-used role (#396). Stored
-    // as a `FavoriteRole` serde-tagged string under
-    // `KEY_RTL_TCP_CLIENT_LAST_ROLE`. Missing / corrupt config
-    // → default Control (legacy-safe). We also seed the DSP
-    // state with the persisted role so the next Play against an
-    // rtl_tcp source picks it up even if the user never touched
-    // the combo this session.
+    // Restore the rtl_tcp client's last-used role + auth key
+    // (#396). Role resolution uses the standard two-tier
+    // lookup: per-favorite `requested_role` first (if the
+    // LastConnectedServer matches a favorite entry), falling
+    // back to the global `KEY_RTL_TCP_CLIENT_LAST_ROLE` default,
+    // and finally to `Control` (legacy-safe). The auth key is
+    // loaded directly from the per-server keyring using the
+    // LastConnectedServer's `host:port`. Pre-CodeRabbit round 2
+    // on PR #408 this path hard-set `auth_key: None` and
+    // ignored per-favorite role, so pressing Play right after
+    // launch against a previously-auth-configured server would
+    // drop the saved key and force a redundant `AuthRequired`
+    // bounce before reconnecting. With the keyring preload the
+    // DSP carries the right bytes from the first Play.
     {
         use crate::sidebar::source_panel::{
             FavoriteRole, KEY_RTL_TCP_CLIENT_LAST_ROLE, RTL_TCP_ROLE_CONTROL_IDX,
-            RTL_TCP_ROLE_LISTEN_IDX,
+            RTL_TCP_ROLE_LISTEN_IDX, load_favorites, load_last_connected,
         };
-        let persisted_role: FavoriteRole = config.read(|v| {
-            v.get(KEY_RTL_TCP_CLIENT_LAST_ROLE)
-                .and_then(|val| serde_json::from_value(val.clone()).ok())
-                .unwrap_or(FavoriteRole::Control)
+        let last_connected = load_last_connected(config);
+        let favorite_entry = last_connected.as_ref().and_then(|srv| {
+            let key = format!("{}:{}", srv.host, srv.port);
+            load_favorites(config).into_iter().find(|f| f.key == key)
         });
+        let persisted_role: FavoriteRole = favorite_entry
+            .as_ref()
+            .and_then(|f| f.requested_role)
+            .or_else(|| {
+                config.read(|v| {
+                    v.get(KEY_RTL_TCP_CLIENT_LAST_ROLE)
+                        .and_then(|val| serde_json::from_value(val.clone()).ok())
+                })
+            })
+            .unwrap_or(FavoriteRole::Control);
         let idx = match persisted_role {
             FavoriteRole::Control => RTL_TCP_ROLE_CONTROL_IDX,
             FavoriteRole::Listen => RTL_TCP_ROLE_LISTEN_IDX,
         };
         panels.source.rtl_tcp_role_row.set_selected(idx);
-        // Seed the DSP with the restored role so a Play before
-        // the user touches the combo picks up the right value.
-        // The auth-key restore lives in the per-server flow
-        // (wired in the follow-up discovery / last-connected
-        // handlers) — here we pass `None` as a safe default;
-        // the per-server load will overlay real bytes before
-        // Connect time when applicable.
+        // Load the saved per-server auth key for the last-
+        // connected endpoint, if any. Also cache that server's
+        // stable id on `AppState` so the first post-Play
+        // `AuthRequired` / `AuthFailed` / `Connected` arm
+        // already has it and the keyring save / clear paths
+        // target the right entry without waiting on the first
+        // `apply_rtl_tcp_connect` call.
+        let mut auth_key: Option<Vec<u8>> = None;
+        if let Some(srv) = last_connected.as_ref() {
+            *state.rtl_tcp_active_server.borrow_mut() = format!("{}:{}", srv.host, srv.port);
+            auth_key = load_client_auth_key_from_keyring(&srv.host, srv.port);
+            // Also reveal + prefill the auth-key row when we
+            // have a saved key, mirroring `apply_rtl_tcp_connect`
+            // so the user can see the pre-loaded value
+            // immediately.
+            if let Some(bytes) = auth_key.as_ref() {
+                panels.source.rtl_tcp_auth_key_row.set_visible(true);
+                panels
+                    .source
+                    .rtl_tcp_auth_key_row
+                    .set_text(&crate::sidebar::server_panel::auth_key_to_hex(bytes));
+            }
+        }
         state.send_dsp(UiToDsp::SetRtlTcpClientConfig {
             requested_role: persisted_role.as_wire_role(),
-            auth_key: None,
+            auth_key,
         });
     }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -596,6 +596,20 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let rtl_tcp_auth_key_row_weak = panels.source.rtl_tcp_auth_key_row.downgrade();
     let rtl_tcp_hostname_row_weak = panels.source.hostname_row.downgrade();
     let rtl_tcp_port_row_weak = panels.source.port_row.downgrade();
+    // Weak refs to the two persistent ControllerBusy toasts, so
+    // clicking either action dismisses BOTH (pre-`CodeRabbit`
+    // round 11 on PR #408 only the clicked toast dismissed and
+    // the sibling stale-action could later rebuild the source
+    // against a healthy session), and so a transition away from
+    // ControllerBusy (e.g. the controller slot freed up and we
+    // reached `Connected` directly) sweeps the live pair. `Rc<
+    // RefCell<Vec<..>>>` lives at the DSP-poll closure scope so
+    // it persists across ticks but drops with the timeout
+    // source. `glib::WeakRef` inside the Vec so a dropped toast
+    // doesn't keep a strong reference — the vec is just a
+    // "remember to dismiss these on state change" ledger.
+    let pending_controller_busy_toasts: Rc<RefCell<Vec<glib::WeakRef<adw::Toast>>>> =
+        Rc::new(RefCell::new(Vec::new()));
     // Network audio sink status row — same weak-ref pattern as
     // the rtl_tcp status row above so a window close can't keep
     // the row alive past its useful life. Per issue #247.
@@ -663,6 +677,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                         &rtl_tcp_auth_key_row_weak,
                         &rtl_tcp_hostname_row_weak,
                         &rtl_tcp_port_row_weak,
+                        &pending_controller_busy_toasts,
                         &network_sink_status_row_weak,
                         &transcription_enable_for_dsp,
                         #[cfg(feature = "sherpa")]
@@ -736,6 +751,7 @@ fn handle_dsp_message(
     rtl_tcp_auth_key_row_weak: &glib::WeakRef<adw::PasswordEntryRow>,
     rtl_tcp_hostname_row_weak: &glib::WeakRef<adw::EntryRow>,
     rtl_tcp_port_row_weak: &glib::WeakRef<adw::SpinRow>,
+    pending_controller_busy_toasts: &Rc<RefCell<Vec<glib::WeakRef<adw::Toast>>>>,
     network_sink_status_row_weak: &glib::WeakRef<adw::ActionRow>,
     transcription_enable_row: &adw::SwitchRow,
     #[cfg(feature = "sherpa")] auto_break_row: &adw::SwitchRow,
@@ -963,6 +979,7 @@ fn handle_dsp_message(
                     rtl_tcp_auth_key_row_weak,
                     rtl_tcp_hostname_row_weak,
                     rtl_tcp_port_row_weak,
+                    pending_controller_busy_toasts,
                 );
             }
             // Status-bar role badge (#396) — show the role the
@@ -1200,6 +1217,22 @@ fn apply_network_sink_status(row: &adw::ActionRow, status: &sdr_core::NetworkSin
 /// immediately following an auth-required transition (to save
 /// the user-entered key to the per-server keyring).
 ///
+/// `adw::Toast::set_timeout(0)` keeps a toast on screen until
+/// the user dismisses it or an explicit `dismiss()` fires. Used
+/// for the two `ControllerBusy` action toasts — the stakes are
+/// high enough (the user has to actively choose between Take-
+/// control, Listener, or abandoning the connect) that a
+/// time-limited toast would feel like silent retry behavior.
+/// Per `CodeRabbit` round 12 on PR #408.
+const TOAST_TIMEOUT_PERSISTENT: u32 = 0;
+
+/// Short toast timeout in seconds for transient-acknowledgement
+/// notices — the `AuthRequired` / `AuthFailed` copy that
+/// complements a revealed key-entry row. Long enough to read, short
+/// enough to clear without user interaction once the user has
+/// moved on to typing. Per `CodeRabbit` round 12 on PR #408.
+const TOAST_TIMEOUT_SHORT_SECS: u32 = 5;
+
 /// Called only from the edge-detection path in
 /// `handle_dsp_message`; the caller already verified
 /// `prev_disc != now_disc` and stored the new discriminant.
@@ -1216,6 +1249,10 @@ fn apply_network_sink_status(row: &adw::ActionRow, status: &sdr_core::NetworkSin
               AuthFailed are type variants — enum paths would make the prose \
               unreadable; backticks on each would overwhelm the paragraph"
 )]
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear arm-by-arm toast + row + state handling for all 8 rtl_tcp connection-state variants; splitting would scatter the shared setup (pending-toasts sweep, edge-log) and obscure the 1:1 mapping from variant to UX gesture"
+)]
 fn handle_rtl_tcp_state_toast(
     state_val: &sdr_types::RtlTcpConnectionState,
     prev_disc: u8,
@@ -1225,13 +1262,35 @@ fn handle_rtl_tcp_state_toast(
     auth_key_row_weak: &glib::WeakRef<adw::PasswordEntryRow>,
     hostname_row_weak: &glib::WeakRef<adw::EntryRow>,
     port_row_weak: &glib::WeakRef<adw::SpinRow>,
+    pending_controller_busy_toasts: &Rc<RefCell<Vec<glib::WeakRef<adw::Toast>>>>,
 ) {
     use sdr_types::RtlTcpConnectionState;
 
     use crate::state::{
         RTL_TCP_STATE_DISC_AUTH_FAILED, RTL_TCP_STATE_DISC_AUTH_REQUIRED,
-        RTL_TCP_STATE_DISC_CONNECTING,
+        RTL_TCP_STATE_DISC_CONNECTING, RTL_TCP_STATE_DISC_CONTROLLER_BUSY,
     };
+
+    // Sweep any still-live ControllerBusy toasts on any
+    // transition that isn't re-entering ControllerBusy. Pre-
+    // `CodeRabbit` round 11 on PR #408 each ControllerBusy
+    // toast's button handler only dismissed itself, so a stale
+    // "Take control" / "Connect as Listener" action sat visible
+    // after the server went away (Connected directly, Disconnect,
+    // Failed, etc.) and could later rebuild the source
+    // unexpectedly against a healthy session. The
+    // `timeout(0)` persistence is intentional — we WANT these to
+    // stick around until the user interacts OR the state
+    // resolves itself — but "the state resolved itself" needs
+    // its own cleanup pass.
+    if !matches!(state_val, RtlTcpConnectionState::ControllerBusy) {
+        let mut pending = pending_controller_busy_toasts.borrow_mut();
+        for weak in pending.drain(..) {
+            if let Some(toast) = weak.upgrade() {
+                toast.dismiss();
+            }
+        }
+    }
 
     match state_val {
         RtlTcpConnectionState::ControllerBusy => {
@@ -1245,21 +1304,57 @@ fn handle_rtl_tcp_state_toast(
             let Some(overlay) = toast_overlay_weak.upgrade() else {
                 return;
             };
+            // Before creating the new pair, sweep any still-
+            // live toasts from a prior `ControllerBusy` entry
+            // (e.g. the user hit `Retry` without clicking either
+            // action, and the server is still busy on the
+            // rebound). Otherwise the overlay would stack two
+            // pairs, and dismissing one pair via the cross-
+            // dismiss helpers below would leave the other pair
+            // orphaned. Per `CodeRabbit` round 11 on PR #408.
+            {
+                let mut pending = pending_controller_busy_toasts.borrow_mut();
+                for weak in pending.drain(..) {
+                    if let Some(toast) = weak.upgrade() {
+                        toast.dismiss();
+                    }
+                }
+            }
+
             let toast = adw::Toast::builder()
                 .title("Controller slot is occupied on this server.")
-                .timeout(0)
+                .timeout(TOAST_TIMEOUT_PERSISTENT)
                 .build();
+            let listen_toast = adw::Toast::builder()
+                .title("Or connect as Listener (read-only).")
+                .timeout(TOAST_TIMEOUT_PERSISTENT)
+                .build();
+            // Cross-dismiss: clicking either action dismisses
+            // BOTH toasts, so a stale sibling action can't fire
+            // later against a session that's already resolved.
+            // `WeakRef` rather than strong clones — the toasts
+            // hand out their own strong refs to the overlay
+            // internally, and we only need to reach the sibling
+            // when it's still live.
+            let toast_weak = toast.downgrade();
+            let listen_toast_weak = listen_toast.downgrade();
+
             // Track the two action buttons as separate signals.
             // AdwToast supports a single primary action via
             // `set_button_label` + `connect_button_clicked`; the
             // "Take control" action lands there, and the
-            // "Connect as Listener" option lives in the toast
-            // body copy so users still see both choices.
+            // "Connect as Listener" option lives in the
+            // sibling toast below so users still see both
+            // choices.
             toast.set_button_label(Some("Take control"));
             let state_for_takeover = Rc::clone(app_state);
+            let listen_weak_for_takeover = listen_toast_weak.clone();
             toast.connect_button_clicked(move |t| {
                 state_for_takeover.send_dsp(UiToDsp::RetryRtlTcpWithTakeover);
                 t.dismiss();
+                if let Some(sibling) = listen_weak_for_takeover.upgrade() {
+                    sibling.dismiss();
+                }
             });
             overlay.add_toast(toast);
 
@@ -1267,13 +1362,10 @@ fn handle_rtl_tcp_state_toast(
             // separate toasts beats a single one because AdwToast
             // exposes only one action button — splitting the two
             // paths keeps both discoverable.
-            let listen_toast = adw::Toast::builder()
-                .title("Or connect as Listener (read-only).")
-                .timeout(0)
-                .build();
             listen_toast.set_button_label(Some("Connect as Listener"));
             let state_for_listen = Rc::clone(app_state);
             let role_row_for_listen = role_row_weak.clone();
+            let toast_weak_for_listen = toast_weak.clone();
             listen_toast.connect_button_clicked(move |t| {
                 if let Some(role_row) = role_row_for_listen.upgrade() {
                     // Flipping the combo to Listen fires its
@@ -1285,8 +1377,21 @@ fn handle_rtl_tcp_state_toast(
                 }
                 state_for_listen.send_dsp(UiToDsp::RetryRtlTcpNow);
                 t.dismiss();
+                if let Some(sibling) = toast_weak_for_listen.upgrade() {
+                    sibling.dismiss();
+                }
             });
             overlay.add_toast(listen_toast);
+
+            // Record the pair so the non-ControllerBusy state
+            // transition at the top of this function can sweep
+            // them if the server resolves itself without user
+            // interaction.
+            {
+                let mut pending = pending_controller_busy_toasts.borrow_mut();
+                pending.push(toast_weak);
+                pending.push(listen_toast_weak);
+            }
         }
 
         RtlTcpConnectionState::AuthRequired => {
@@ -1303,7 +1408,7 @@ fn handle_rtl_tcp_state_toast(
             if let Some(overlay) = toast_overlay_weak.upgrade() {
                 let toast = adw::Toast::builder()
                     .title("Server requires an authentication key.")
-                    .timeout(5)
+                    .timeout(TOAST_TIMEOUT_SHORT_SECS)
                     .build();
                 overlay.add_toast(toast);
             }
@@ -1346,7 +1451,7 @@ fn handle_rtl_tcp_state_toast(
             if let Some(overlay) = toast_overlay_weak.upgrade() {
                 let toast = adw::Toast::builder()
                     .title("Key rejected. Check with the server owner.")
-                    .timeout(5)
+                    .timeout(TOAST_TIMEOUT_SHORT_SECS)
                     .build();
                 overlay.add_toast(toast);
             }
@@ -1355,26 +1460,39 @@ fn handle_rtl_tcp_state_toast(
         RtlTcpConnectionState::Connected { .. } => {
             // Save the user-entered key to the per-server
             // keyring so subsequent reconnects auto-use it.
-            // Fires on the edge from either `AuthRequired` /
-            // `AuthFailed` (user typed a key in response to a
-            // denial) OR `Connecting` (user had auth configured
-            // up front — server advertised `auth_required` via
-            // mDNS, key was entered before the first connect,
-            // and the handshake succeeded in a single
-            // `Connecting → Connected` hop without ever
-            // surfacing an auth-denial state). Pre-CodeRabbit
-            // round 1 on PR #408 the Connecting case was
-            // missed, so up-front keys never hit the keyring
-            // and the user had to re-type them on every
+            // Fires on the edge from any of:
+            //
+            // - `AuthRequired` / `AuthFailed` — user typed a
+            //   key in response to a denial toast;
+            // - `Connecting` — user had auth configured up
+            //   front (server advertised `auth_required` via
+            //   mDNS, key was entered before the first
+            //   connect, and the handshake succeeded in a
+            //   single `Connecting → Connected` hop);
+            // - `ControllerBusy` — user entered a key before
+            //   the first connect, server denied with
+            //   `ControllerBusy`, and the user's subsequent
+            //   Take-control / Listener retry (via
+            //   `RetryRtlTcpWithTakeover` or `RetryRtlTcpNow`)
+            //   succeeded. Added per `CodeRabbit` round 12 on
+            //   PR #408 — without this branch an auth-required
+            //   server that's also busy on the first attempt
+            //   would accept the key on the takeover reconnect
+            //   but never persist it to the keyring.
+            //
+            // Pre-round-1 on PR #408 only the auth-denial arms
+            // triggered the save, so up-front keys never hit the
+            // keyring and the user had to re-type them on every
             // reconnect. `save_current_auth_key_for_active_
             // server` is a no-op when the key row is empty, so
-            // this is safe to trigger on every Connecting→
-            // Connected edge even if the server doesn't require
-            // auth. Call `record_active_rtl_tcp_server` first
-            // so the save-path sees the right `host:port` even
-            // when the user never hit an auth-denial arm
-            // (which is what previously set the cache).
+            // this is safe to trigger on every qualifying edge
+            // even if the server doesn't require auth. Call
+            // `record_active_rtl_tcp_server` first so the save-
+            // path sees the right `host:port` even when the
+            // user never hit an auth-denial arm (which is what
+            // previously set the cache).
             if prev_disc == RTL_TCP_STATE_DISC_CONNECTING
+                || prev_disc == RTL_TCP_STATE_DISC_CONTROLLER_BUSY
                 || prev_disc == RTL_TCP_STATE_DISC_AUTH_REQUIRED
                 || prev_disc == RTL_TCP_STATE_DISC_AUTH_FAILED
             {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1436,6 +1436,58 @@ fn record_active_rtl_tcp_server(
     }
 }
 
+/// Invalidate the cached active `rtl_tcp` server identity when
+/// the hostname / port widgets no longer match it. Called from
+/// the `hostname_row.connect_changed` + `port_row.connect_value_
+/// notify` handlers so a manual edit retargets per-server state
+/// (keyring lookups, favorite matches, `rtl_tcp_active_server`)
+/// to the newly-typed endpoint.
+///
+/// Without this, after the startup `LastConnectedServer` restore
+/// or an `apply_rtl_tcp_connect` seeded the cache, typing a
+/// different host or port in the source row would leave the
+/// cache pointing at the old server — the first subsequent
+/// `AuthFailed` / `Connected` arm would then
+/// clear/save the key under the WRONG server. Per
+/// `CodeRabbit` round 4 on PR #408.
+///
+/// **Comparison guard:** the cache is cleared only when its
+/// current value differs from the widget-derived key. That
+/// keeps `apply_rtl_tcp_connect`'s own `hostname_row.set_text` /
+/// `port_row.set_value` writes (which fire these same handlers)
+/// from spuriously clobbering the stable id the caller just
+/// wrote. During a caller-driven server switch the cache IS
+/// stale at the widget-write moment (old server id, new widget
+/// text), so this invalidation fires correctly there too —
+/// `apply_rtl_tcp_connect` overwrites the empty cache right
+/// afterwards with the new stable id.
+///
+/// Also clears the auth-key row (visibility + text) so the
+/// old server's key bytes can't leak onto a different endpoint.
+/// The row's `connect_changed` handler re-dispatches
+/// `SetRtlTcpClientConfig { auth_key: None, .. }` so DSP state
+/// tracks the invalidation in lockstep with the UI.
+fn invalidate_rtl_tcp_active_server_on_edit(
+    app_state: &Rc<AppState>,
+    hostname_row: &adw::EntryRow,
+    port_row: &adw::SpinRow,
+    auth_key_row: &adw::PasswordEntryRow,
+) {
+    let hostname = hostname_row.text().to_string();
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let port = port_row.value() as u16;
+    let current_key = format!("{hostname}:{port}");
+    let should_clear = {
+        let cached = app_state.rtl_tcp_active_server.borrow();
+        !cached.is_empty() && *cached != current_key
+    };
+    if should_clear {
+        app_state.rtl_tcp_active_server.borrow_mut().clear();
+        auth_key_row.set_visible(false);
+        auth_key_row.set_text("");
+    }
+}
+
 /// Save the current Server-key-row text to the keyring under
 /// the active `rtl_tcp` server's `host:port`. Called on a
 /// successful Connected following AuthRequired / AuthFailed.
@@ -5936,7 +5988,21 @@ fn connect_source_panel(
     let state_host = Rc::clone(state);
     let port_for_host = panels.source.port_row.clone();
     let proto_for_host = panels.source.protocol_row.clone();
+    let hostname_for_host = panels.source.hostname_row.clone();
+    let auth_key_for_host = panels.source.rtl_tcp_auth_key_row.clone();
     panels.source.hostname_row.connect_changed(move |row| {
+        // Invalidate the cached `rtl_tcp_active_server` when
+        // the widget no longer matches the cached stable id
+        // (typically a manual edit; harmless no-op for
+        // `apply_rtl_tcp_connect`'s programmatic writes when
+        // those match the cache). Per CodeRabbit round 4 on
+        // PR #408.
+        invalidate_rtl_tcp_active_server_on_edit(
+            &state_host,
+            &hostname_for_host,
+            &port_for_host,
+            &auth_key_for_host,
+        );
         let hostname = row.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = port_for_host.value() as u16;
@@ -5956,7 +6022,15 @@ fn connect_source_panel(
     let state_port = Rc::clone(state);
     let host_for_port = panels.source.hostname_row.clone();
     let proto_for_port = panels.source.protocol_row.clone();
+    let port_row_for_port = panels.source.port_row.clone();
+    let auth_key_for_port = panels.source.rtl_tcp_auth_key_row.clone();
     panels.source.port_row.connect_value_notify(move |row| {
+        invalidate_rtl_tcp_active_server_on_edit(
+            &state_port,
+            &host_for_port,
+            &port_row_for_port,
+            &auth_key_for_port,
+        );
         let hostname = host_for_port.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = row.value() as u16;

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1150,9 +1150,9 @@ fn apply_rtl_tcp_connection_state(
     );
     // "Retry now" is only meaningful when there's an active source
     // to short-circuit out of its backoff wait — Retrying (most
-    // common) or Failed (the terminal protocol-error path where the
-    // source is still registered but not advancing). After an
-    // explicit Disconnect the controller drops `state.source`, and
+    // common) or any of the four terminal states (Failed +
+    // role-denials added in #396). After an explicit Disconnect
+    // the controller drops `state.source`, and
     // `UiToDsp::RetryRtlTcpNow` is a no-op (it checks
     // `state.source.as_mut()` → None → early return). Leaving the
     // button visibly enabled in that state misleads the user into
@@ -1161,7 +1161,7 @@ fn apply_rtl_tcp_connection_state(
     let can_retry_now = matches!(
         state,
         RtlTcpConnectionState::Retrying { .. } | RtlTcpConnectionState::Failed { .. }
-    );
+    ) || state.needs_user_action();
     disconnect_button.set_sensitive(is_active);
     retry_button.set_sensitive(can_retry_now);
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2395,10 +2395,31 @@ fn connect_rtl_tcp_discovery(
                     } else {
                         server.txt.nickname.clone()
                     };
-                    let host = server
-                        .addresses
-                        .first()
-                        .map_or_else(|| server.hostname.clone(), ToString::to_string);
+                    // Identity host — the advertised mDNS
+                    // hostname, matching `favorite_key(&server)`.
+                    // `apply_rtl_tcp_connect` uses its `host`
+                    // argument as the stable id for
+                    // `rtl_tcp_active_server`, keyring lookups,
+                    // favorite matches, and
+                    // `LastConnectedServer`. Pre-`CodeRabbit`
+                    // round 6 on PR #408 this preferred
+                    // `server.addresses.first()` (a resolved
+                    // IPv4/IPv6 literal when mDNS had resolved
+                    // one), which split per-server state
+                    // between `shack-pi.local.:1234` (what
+                    // favorites store) and `192.168.1.17:1234`
+                    // (what the discovery connect path
+                    // persisted) — role / auth round-tripping
+                    // through discovery + favorites + startup
+                    // restore broke silently. The DSP's actual
+                    // dial path (`RtlTcpSource::with_config` →
+                    // `(host, port).to_socket_addrs()`) resolves
+                    // the hostname at connect time, so keeping
+                    // identity on the advertised name is
+                    // strictly better: stable across IP
+                    // changes AND correct by the
+                    // favorite-key contract.
+                    let host = server.hostname.clone();
                     // Age is effectively 0 here — `server.last_seen` was
                     // stamped by the browser thread a few ms ago —
                     // `format_age` will render "just now". Subsequent
@@ -2474,6 +2495,22 @@ fn connect_rtl_tcp_discovery(
                     };
                     let star_tuner_name = Some(server.txt.tuner.clone());
                     let star_gain_count = Some(server.txt.gains);
+                    // Capture the announce-derived auth flag so
+                    // a fresh star persists it alongside the
+                    // rest of the metadata. Pre-`CodeRabbit`
+                    // round 6 on PR #408 this was hard-set to
+                    // `None` at star time, which meant a newly-
+                    // starred auth-required server looked
+                    // "unknown" until the next mDNS refresh —
+                    // `apply_rtl_tcp_connect` + the startup
+                    // restore wouldn't reveal the key row
+                    // ahead of the first `AuthRequired` bounce.
+                    // The discovery-refresh path below already
+                    // writes `server.txt.auth_required` on re-
+                    // announce; this keeps the two entry points
+                    // consistent so freshly-starred favorites
+                    // carry the same hint as refreshed ones.
+                    let star_auth_required = server.txt.auth_required;
                     let star_favorites = Rc::clone(&favorites);
                     let star_config = std::sync::Arc::clone(&config_for_discovery);
                     let star_expander_weak = expander_weak.clone();
@@ -2513,12 +2550,18 @@ fn connect_rtl_tcp_discovery(
                                         last_seen_unix: Some(
                                             sidebar::source_panel::now_unix_seconds(),
                                         ),
-                                        // Fresh star — no role preference yet;
-                                        // auth_required hint comes from the
-                                        // discovery-refresh path below on a
-                                        // future mDNS announce. Per #396.
+                                        // Fresh star — no role preference
+                                        // yet; `auth_required` is captured
+                                        // from the current mDNS announce's
+                                        // TXT record above so
+                                        // `apply_rtl_tcp_connect` + the
+                                        // startup restore can pre-reveal
+                                        // the key row immediately, without
+                                        // waiting on a mDNS re-announce.
+                                        // Per `CodeRabbit` round 6 on
+                                        // PR #408 and issue #396.
                                         requested_role: None,
-                                        auth_required: None,
+                                        auth_required: star_auth_required,
                                     },
                                 );
                             } else {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -6252,10 +6252,37 @@ fn connect_source_panel(
                 _ => FavoriteRole::Control,
             };
             let text = row.text().to_string();
+            // Malformed hex must NOT collapse to `auth_key: None`.
+            // Pre-`CodeRabbit` round 7 on PR #408 a bad paste fell
+            // into the `auth_key_from_hex(..) -> None` branch and
+            // silently cleared DSP auth state — the next Retry /
+            // Play would then dispatch an unauthenticated connect,
+            // bounce through `AuthRequired`, and the user had to
+            // fix the text before realizing the previous saved key
+            // had been clobbered. Three cases now:
+            //
+            // - Empty text: intentional clear. Drop the error
+            //   class, dispatch `auth_key: None`.
+            // - Valid hex: parsed bytes. Drop the error class,
+            //   dispatch `Some(bytes)`.
+            // - Malformed non-empty text: add the libadwaita
+            //   `error` CSS class so the row reads as invalid,
+            //   and RETURN without dispatching — keeping the
+            //   last-good DSP auth state intact until the user
+            //   either fixes the text or clears the field.
+            //
+            // `auth_key_from_hex` treats empty as `None` too, but
+            // we handle the empty branch explicitly above so the
+            // malformed case is cleanly separable.
             let auth_key: Option<Vec<u8>> = if text.is_empty() {
+                row.remove_css_class("error");
                 None
+            } else if let Some(bytes) = crate::sidebar::server_panel::auth_key_from_hex(&text) {
+                row.remove_css_class("error");
+                Some(bytes)
             } else {
-                crate::sidebar::server_panel::auth_key_from_hex(&text)
+                row.add_css_class("error");
+                return;
             };
             state_auth.send_dsp(UiToDsp::SetRtlTcpClientConfig {
                 requested_role: fav_role.as_wire_role(),

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2831,6 +2831,105 @@ fn ensure_server_auth_key() -> Vec<u8> {
     fresh
 }
 
+/// Keyring-entry prefix for per-server **client** auth keys. The
+/// full entry name is `{prefix}-{host}:{port}` — per-server
+/// so the user can save distinct keys for distinct servers on
+/// the LAN (different owners, different rotation schedules).
+/// Kept distinct from `KEYRING_KEY_AUTH_KEY` (which stores the
+/// local server's own key, single entry) so neither surface
+/// ever reads the other's bytes by accident. Per issue #396.
+const KEYRING_KEY_CLIENT_AUTH_KEY_PREFIX: &str = "rtl_tcp-client-auth-key-";
+
+/// Build the keyring entry name for a client-side saved key
+/// keyed by the server's `host:port` identity. Matches the
+/// identity `FavoriteEntry.key` uses, so the keyring entry
+/// survives server rename / nickname change. Per issue #396.
+fn client_auth_key_entry_name(host: &str, port: u16) -> String {
+    format!("{KEYRING_KEY_CLIENT_AUTH_KEY_PREFIX}{host}:{port}")
+}
+
+/// Load the saved auth key for the given `rtl_tcp` server, if
+/// the user previously connected successfully with a key
+/// against this `host:port`. Returns `None` for missing /
+/// corrupt / keyring-unavailable cases — callers treat that
+/// as "ask the user for a key" rather than silently connecting
+/// without one. Per issue #396.
+#[allow(
+    dead_code,
+    reason = "wired up in the #396 commit that adds the Server key entry row"
+)]
+fn load_client_auth_key_from_keyring(host: &str, port: u16) -> Option<Vec<u8>> {
+    use sdr_config::KeyringStore;
+
+    use crate::sidebar::server_panel::{KEYRING_SERVICE, auth_key_from_hex};
+
+    let entry = client_auth_key_entry_name(host, port);
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    match store.get(&entry) {
+        Ok(Some(hex)) => {
+            let Some(bytes) = auth_key_from_hex(&hex) else {
+                tracing::warn!(
+                    entry = %entry,
+                    "rtl_tcp client auth key in keyring is malformed hex; treating as missing"
+                );
+                return None;
+            };
+            Some(bytes)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!(%e, entry = %entry, "rtl_tcp client auth key keyring read failed");
+            None
+        }
+    }
+}
+
+/// Save a successfully-used client auth key for the given
+/// server to the OS keyring. Called AFTER a successful
+/// auth-required connect so the user doesn't have to re-enter
+/// the key on subsequent reconnects to the same server. A
+/// keyring write failure is non-fatal — the current session
+/// still works; the next launch will just prompt for the key
+/// again. Per issue #396.
+#[allow(
+    dead_code,
+    reason = "wired up in the #396 commit that adds the Server key entry row"
+)]
+fn save_client_auth_key_to_keyring(
+    host: &str,
+    port: u16,
+    bytes: &[u8],
+) -> Result<(), sdr_config::keyring_store::KeyringError> {
+    use sdr_config::KeyringStore;
+
+    use crate::sidebar::server_panel::{KEYRING_SERVICE, auth_key_to_hex};
+
+    let entry = client_auth_key_entry_name(host, port);
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    store.set(&entry, &auth_key_to_hex(bytes))
+}
+
+/// Delete a saved client auth key for the given server. Called
+/// from the UI when the user explicitly clears the key (e.g.
+/// the server regenerated on the other end and the old key no
+/// longer works; clearing avoids auto-sending the dead key on
+/// every reconnect attempt). Missing-entry is treated as
+/// success — the goal is "there is no saved key after this
+/// call," which a missing entry already satisfies. Per #396.
+#[allow(dead_code)]
+fn clear_client_auth_key_from_keyring(
+    host: &str,
+    port: u16,
+) -> Result<(), sdr_config::keyring_store::KeyringError> {
+    use sdr_config::KeyringStore;
+
+    use crate::sidebar::server_panel::KEYRING_SERVICE;
+
+    let entry = client_auth_key_entry_name(host, port);
+    let store = KeyringStore::new(KEYRING_SERVICE);
+    store.delete(&entry)
+}
+
 /// Wire the server panel end-to-end: visibility gating, the master
 /// share-over-network switch, and its downstream start/stop effects.
 /// Errors surface via the `toast_overlay`, and the switch auto-

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -965,6 +965,23 @@ fn handle_dsp_message(
                     rtl_tcp_port_row_weak,
                 );
             }
+            // Status-bar role badge (#396) — flip on Connected
+            // based on the user's most recently-requested role;
+            // hide on every non-Connected state. Server
+            // admission is always "grant as requested" (#392
+            // has no downgrade path), so the requested role
+            // the UI holds mirrors what the server admitted.
+            let role_badge = match &conn_state {
+                sdr_types::RtlTcpConnectionState::Connected { .. } => {
+                    let selected = rtl_tcp_role_row_weak.upgrade().map_or(
+                        crate::sidebar::source_panel::RTL_TCP_ROLE_CONTROL_IDX,
+                        |row| row.selected(),
+                    );
+                    Some(selected == crate::sidebar::source_panel::RTL_TCP_ROLE_CONTROL_IDX)
+                }
+                _ => None,
+            };
+            status_bar.update_role(role_badge);
         }
         DspToUi::NetworkSinkStatus(status) => {
             tracing::debug!(?status, "network sink status");

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2005,15 +2005,41 @@ fn connect_sidebar_panels(
     // closures.
     let server_running: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
 
+    // Shared favorites map — key (stable hostname:port) → rich
+    // `FavoriteEntry` record. Loaded once here and handed to
+    // both `connect_source_panel` (role picker mutates
+    // `requested_role` per-server) and `connect_rtl_tcp_discovery`
+    // (re-announce path refreshes metadata). Pre-`CodeRabbit`
+    // round 8 on PR #408 each function built its own view: the
+    // role picker read + wrote the on-disk JSON via
+    // `load_favorites`/`save_favorites` while discovery held a
+    // separate in-memory HashMap. A subsequent `ServerAnnounced`
+    // would preserve the stale in-memory role from the map and
+    // clobber the user's just-saved selection on next re-
+    // announce. Hoisting the map here makes both paths mutate
+    // the SAME `Rc<RefCell<..>>` so persistence stays
+    // consistent. `Rc<RefCell<HashMap>>` mirrors the
+    // `displayed_rows` pattern — single-threaded GTK main loop,
+    // no lock contention.
+    let favorites: Rc<
+        RefCell<std::collections::HashMap<String, sidebar::source_panel::FavoriteEntry>>,
+    > = Rc::new(RefCell::new(
+        crate::sidebar::source_panel::load_favorites(config)
+            .into_iter()
+            .map(|entry| (entry.key.clone(), entry))
+            .collect(),
+    ));
+
     connect_source_panel(
         panels,
         state,
         toast_overlay,
         Rc::clone(&server_running),
         config,
+        &favorites,
     );
     connect_source_rtlsdr_probe(panels);
-    connect_rtl_tcp_discovery(panels, state, config, favorites_header);
+    connect_rtl_tcp_discovery(panels, state, config, favorites_header, &favorites);
     connect_server_panel(panels, toast_overlay, server_running);
     connect_radio_panel(panels, state, scanner_force_disable);
     connect_display_panel(panels, state, spectrum_handle);
@@ -2079,6 +2105,9 @@ fn connect_rtl_tcp_discovery(
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
     favorites_header: &FavoritesHeaderHandle,
+    favorites: &Rc<
+        RefCell<std::collections::HashMap<String, sidebar::source_panel::FavoriteEntry>>,
+    >,
 ) {
     use std::collections::HashMap;
     use std::time::Instant;
@@ -2201,21 +2230,19 @@ fn connect_rtl_tcp_discovery(
     let config_for_discovery = std::sync::Arc::clone(config);
 
     // Favorites map — key (stable hostname:port) → rich
-    // `FavoriteEntry` record. Loaded once on startup, mutated by
-    // star-toggle handlers and re-announce metadata refresh,
-    // persisted after each change via `save_favorites`.
-    // `Rc<RefCell<HashMap>>` mirrors the `displayed_rows` pattern
-    // — single-threaded GTK main loop, no lock contention. Keyed
-    // by the same `favorite_key(server)` that the reorder / pin-
-    // to-top path uses so lookups stay consistent.
-    let favorites: Rc<
-        RefCell<std::collections::HashMap<String, sidebar::source_panel::FavoriteEntry>>,
-    > = Rc::new(RefCell::new(
-        crate::sidebar::source_panel::load_favorites(&config_for_discovery)
-            .into_iter()
-            .map(|entry| (entry.key.clone(), entry))
-            .collect(),
-    ));
+    // `FavoriteEntry` record. Created by the parent
+    // `connect_sidebar_panels` so the role-picker handler in
+    // `connect_source_panel` can mutate the SAME map this
+    // function's re-announce path reads. Per CodeRabbit round 8
+    // on PR #408: pre-fix the role-picker reloaded favorites
+    // from disk, mutated a local `Vec`, and saved — a
+    // later `ServerAnnounced` would preserve the stale
+    // in-memory role from this map and clobber the just-saved
+    // selection on next disk flush. Sharing keeps both paths
+    // honest. The clone we hold here is a cheap `Rc::clone`; the
+    // parent retains the original so the Arc-count stays > 0
+    // for the lifetime of both handlers.
+    let favorites = Rc::clone(favorites);
 
     // Weak refs to the favorites popover's contents. The star-
     // toggle closure (attached to each row's `ToggleButton`) and
@@ -5625,6 +5652,9 @@ fn connect_source_panel(
     toast_overlay: &adw::ToastOverlay,
     server_running: Rc<std::cell::Cell<bool>>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
+    favorites: &Rc<
+        RefCell<std::collections::HashMap<String, sidebar::source_panel::FavoriteEntry>>,
+    >,
 ) {
     // Sample rate selector + bandwidth advisory re-render.
     // The advisory visibility depends on BOTH the sample-rate
@@ -6158,13 +6188,14 @@ fn connect_source_panel(
     let config_for_role = std::sync::Arc::clone(config);
     let hostname_for_role = panels.source.hostname_row.clone();
     let port_for_role = panels.source.port_row.clone();
+    let favorites_for_role = Rc::clone(favorites);
     panels
         .source
         .rtl_tcp_role_row
         .connect_selected_notify(move |row| {
             use crate::sidebar::source_panel::{
                 FavoriteRole, KEY_RTL_TCP_CLIENT_LAST_ROLE, RTL_TCP_ROLE_CONTROL_IDX,
-                RTL_TCP_ROLE_LISTEN_IDX, load_favorites, save_favorites,
+                RTL_TCP_ROLE_LISTEN_IDX, save_favorites,
             };
             let fav_role = match row.selected() {
                 RTL_TCP_ROLE_CONTROL_IDX => FavoriteRole::Control,
@@ -6172,16 +6203,35 @@ fn connect_source_panel(
                 _ => return, // transient out-of-range indices
             };
             let requested_role = fav_role.as_wire_role();
+            // Re-parsing the auth-key row here has the same
+            // malformed-vs-empty distinction as
+            // `rtl_tcp_auth_key_row.connect_changed` (round 7):
+            // an `auth_key_from_hex(..) -> None` on NON-empty
+            // text means "invalid hex, preserve last-good DSP
+            // auth" — NOT "clear". Pre-`CodeRabbit` round 8 on
+            // PR #408 this handler collapsed both cases to
+            // `auth_key: None`, so flipping the role while the
+            // key field held a bad paste silently clobbered
+            // DSP's saved auth. `Option<Option<..>>` gates the
+            // dispatch: outer `Some` means "push to DSP",
+            // outer `None` means "skip dispatch, keep last-good"
+            // — role persistence below still runs either way so
+            // the picker's user intent is recorded, and the
+            // `auth_key_row`'s own handler will catch up DSP
+            // with the current role + fixed/cleared text on
+            // the next edit.
             let key_text = auth_key_for_role.text().to_string();
-            let auth_key: Option<Vec<u8>> = if key_text.is_empty() {
-                None
+            let dispatch_auth: Option<Option<Vec<u8>>> = if key_text.is_empty() {
+                Some(None)
             } else {
-                crate::sidebar::server_panel::auth_key_from_hex(&key_text)
+                crate::sidebar::server_panel::auth_key_from_hex(&key_text).map(Some)
             };
-            state_role.send_dsp(UiToDsp::SetRtlTcpClientConfig {
-                requested_role,
-                auth_key,
-            });
+            if let Some(auth_key) = dispatch_auth {
+                state_role.send_dsp(UiToDsp::SetRtlTcpClientConfig {
+                    requested_role,
+                    auth_key,
+                });
+            }
             // Tier 1: global default — always written so a fresh
             // server ("never favorited, never configured") picks
             // this up as the picker seed.
@@ -6190,10 +6240,19 @@ fn connect_source_panel(
                     serde_json::to_value(fav_role).unwrap_or(serde_json::Value::Null);
             });
             // Tier 2: per-favorite override. Compute the current
-            // `host:port` key; if it matches a favorite, update
-            // that favorite's `requested_role` and persist. No-op
-            // when the server isn't favorited (the global default
-            // above covers it).
+            // `host:port` key; if it matches a favorite in the
+            // SHARED in-memory map (the one
+            // `connect_rtl_tcp_discovery`'s re-announce path
+            // also reads + mutates), update that entry's
+            // `requested_role` and persist. Pre-`CodeRabbit`
+            // round 8 on PR #408 this handler called
+            // `load_favorites` on every fire and saved a fresh
+            // `Vec`, which diverged from the discovery path's
+            // in-memory map — a subsequent `ServerAnnounced`
+            // would preserve the stale in-memory role and
+            // clobber the just-saved selection on its own
+            // `save_favorites` call. Mutating the shared map
+            // keeps both paths honest.
             let host = hostname_for_role.text().to_string();
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let port = port_for_role.value() as u16;
@@ -6201,17 +6260,21 @@ fn connect_source_panel(
                 return;
             }
             let server_key = format!("{host}:{port}");
-            let mut favorites = load_favorites(&config_for_role);
-            let mut dirty = false;
-            for fav in &mut favorites {
-                if fav.key == server_key && fav.requested_role != Some(fav_role) {
+            let dirty = {
+                let mut favorites = favorites_for_role.borrow_mut();
+                if let Some(fav) = favorites.get_mut(&server_key)
+                    && fav.requested_role != Some(fav_role)
+                {
                     fav.requested_role = Some(fav_role);
-                    dirty = true;
-                    break;
+                    true
+                } else {
+                    false
                 }
-            }
+            };
             if dirty {
-                save_favorites(&config_for_role, &favorites);
+                let snapshot: Vec<sidebar::source_panel::FavoriteEntry> =
+                    favorites_for_role.borrow().values().cloned().collect();
+                save_favorites(&config_for_role, &snapshot);
             }
         });
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2086,6 +2086,12 @@ fn connect_rtl_tcp_discovery(
                                         last_seen_unix: Some(
                                             sidebar::source_panel::now_unix_seconds(),
                                         ),
+                                        // Fresh star — no role preference yet;
+                                        // auth_required hint comes from the
+                                        // discovery-refresh path below on a
+                                        // future mDNS announce. Per #396.
+                                        requested_role: None,
+                                        auth_required: None,
                                     },
                                 );
                             } else {
@@ -2183,6 +2189,14 @@ fn connect_rtl_tcp_discovery(
                             } else {
                                 server.txt.nickname.clone()
                             };
+                            // Preserve any saved `requested_role`
+                            // from the previous favorites entry (the
+                            // user's last pick sticks across
+                            // re-announces); refresh the
+                            // `auth_required` hint from the incoming
+                            // TXT so the UI reveals the key field
+                            // BEFORE the user clicks Connect. Per #396.
+                            let preserved_role = favs.get(&fav_key).and_then(|f| f.requested_role);
                             favs.insert(
                                 fav_key.clone(),
                                 sidebar::source_panel::FavoriteEntry {
@@ -2191,6 +2205,8 @@ fn connect_rtl_tcp_discovery(
                                     tuner_name: Some(server.txt.tuner.clone()),
                                     gain_count: Some(server.txt.gains),
                                     last_seen_unix: Some(sidebar::source_panel::now_unix_seconds()),
+                                    requested_role: preserved_role,
+                                    auth_required: server.txt.auth_required,
                                 },
                             );
                             let snapshot: Vec<sidebar::source_panel::FavoriteEntry> =
@@ -7417,6 +7433,8 @@ mod favorite_sort_tests {
             tuner_name: None,
             gain_count: None,
             last_seen_unix: None,
+            requested_role: None,
+            auth_required: None,
         }
     }
 
@@ -7492,6 +7510,8 @@ mod favorite_subtitle_format_tests {
             tuner_name: tuner.map(str::to_string),
             gain_count: gains,
             last_seen_unix: last_seen,
+            requested_role: None,
+            auth_required: None,
         }
     }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -5875,20 +5875,39 @@ fn connect_source_panel(
         // already has it and the keyring save / clear paths
         // target the right entry without waiting on the first
         // `apply_rtl_tcp_connect` call.
+        //
+        // Auth-row visibility + text is resolved deterministically
+        // using the same two-input rule as `apply_rtl_tcp_connect`
+        // (per `CodeRabbit` round 5 on PR #408): reveal the row
+        // when EITHER the favorite advertises `auth_required ==
+        // Some(true)` (server requires a key; user should see the
+        // field up-front even on a fresh session with no saved
+        // key) OR a saved key exists in the keyring (we want to
+        // show the pre-loaded value so the user knows the
+        // session will auto-auth). Set text from the saved key,
+        // or clear when none — so a prior-session auth-required
+        // server whose key the user later cleared doesn't leak
+        // stale text into the field on the next launch.
         let mut auth_key: Option<Vec<u8>> = None;
         if let Some(srv) = last_connected.as_ref() {
             *state.rtl_tcp_active_server.borrow_mut() = format!("{}:{}", srv.host, srv.port);
             auth_key = load_client_auth_key_from_keyring(&srv.host, srv.port);
-            // Also reveal + prefill the auth-key row when we
-            // have a saved key, mirroring `apply_rtl_tcp_connect`
-            // so the user can see the pre-loaded value
-            // immediately.
+            let has_auth_required = matches!(
+                favorite_entry.as_ref().and_then(|f| f.auth_required),
+                Some(true)
+            );
+            let should_reveal = has_auth_required || auth_key.is_some();
+            panels
+                .source
+                .rtl_tcp_auth_key_row
+                .set_visible(should_reveal);
             if let Some(bytes) = auth_key.as_ref() {
-                panels.source.rtl_tcp_auth_key_row.set_visible(true);
                 panels
                     .source
                     .rtl_tcp_auth_key_row
                     .set_text(&crate::sidebar::server_panel::auth_key_to_hex(bytes));
+            } else {
+                panels.source.rtl_tcp_auth_key_row.set_text("");
             }
         }
         state.send_dsp(UiToDsp::SetRtlTcpClientConfig {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2943,13 +2943,24 @@ fn apply_rtl_tcp_connect(
                     .and_then(|rv| serde_json::from_value::<FavoriteRole>(rv.clone()).ok())
             })
         });
-    if let Some(fav_role) = favorite_role {
-        let idx = match fav_role {
-            FavoriteRole::Control => RTL_TCP_ROLE_CONTROL_IDX,
-            FavoriteRole::Listen => RTL_TCP_ROLE_LISTEN_IDX,
-        };
-        role_row.set_selected(idx);
-    }
+    // Always set the role explicitly — never leave the combo
+    // showing whatever a prior favorite-restore put there. Pre-
+    // `CodeRabbit` round 9 on PR #408 this was `if let Some(
+    // fav_role) = favorite_role { ... }`, so a fresh server
+    // with no per-favorite role and no global
+    // `KEY_RTL_TCP_CLIENT_LAST_ROLE` would silently inherit
+    // whatever `Listen` a previous favorite had set — meaning
+    // the first connect against a never-seen server could
+    // accidentally request Listener instead of the legacy-safe
+    // Control default. `unwrap_or(Control)` forces the picker
+    // to the right default every time `apply_rtl_tcp_connect`
+    // runs.
+    let resolved_role = favorite_role.unwrap_or(FavoriteRole::Control);
+    let idx = match resolved_role {
+        FavoriteRole::Control => RTL_TCP_ROLE_CONTROL_IDX,
+        FavoriteRole::Listen => RTL_TCP_ROLE_LISTEN_IDX,
+    };
+    role_row.set_selected(idx);
     // Auth-row state is driven by two inputs:
     // - `auth_required = Some(true)` on the favorite → the
     //   server advertises a required key, so reveal the row so
@@ -6183,12 +6194,37 @@ fn connect_source_panel(
     //   save_favorites so the next connect from this favorite
     //   restores the right picker state without touching other
     //   servers.
+    // Shared "last-good auth bytes" cache between the auth-key
+    // handler (primary writer) and the role-picker handler
+    // (reader). Populated whenever the auth row parses as empty
+    // (`None`, intentional clear) or valid hex (`Some(bytes)`);
+    // NOT updated on malformed hex. The role handler uses this
+    // snapshot when the live auth text is unparseable so it can
+    // still propagate the new role to DSP with a coherent
+    // auth_key value — without this, flipping role while the
+    // key field held a bad paste would skip the whole
+    // `SetRtlTcpClientConfig` dispatch and leave DSP on the
+    // previous role. Per `CodeRabbit` round 9 on PR #408.
+    //
+    // `Rc<RefCell<Option<Vec<u8>>>>` on GTK's single-threaded
+    // main loop — no lock contention. The outer `Option`
+    // differentiates "never parsed" (fresh session, never had a
+    // valid auth value) from "intentionally cleared" (user typed
+    // empty): both dispatch `auth_key: None` so the distinction
+    // only affects the role-handler's fallback path, where
+    // "never parsed" means "just forward the current text's
+    // parse result (which will itself be None for empty and
+    // therefore match)" — see the role-handler below for the
+    // exact semantics.
+    let last_good_auth_key: Rc<RefCell<Option<Vec<u8>>>> = Rc::new(RefCell::new(None));
+
     let state_role = Rc::clone(state);
     let auth_key_for_role = panels.source.rtl_tcp_auth_key_row.clone();
     let config_for_role = std::sync::Arc::clone(config);
     let hostname_for_role = panels.source.hostname_row.clone();
     let port_for_role = panels.source.port_row.clone();
     let favorites_for_role = Rc::clone(favorites);
+    let last_good_for_role = Rc::clone(&last_good_auth_key);
     panels
         .source
         .rtl_tcp_role_row
@@ -6203,35 +6239,32 @@ fn connect_source_panel(
                 _ => return, // transient out-of-range indices
             };
             let requested_role = fav_role.as_wire_role();
-            // Re-parsing the auth-key row here has the same
-            // malformed-vs-empty distinction as
-            // `rtl_tcp_auth_key_row.connect_changed` (round 7):
-            // an `auth_key_from_hex(..) -> None` on NON-empty
-            // text means "invalid hex, preserve last-good DSP
-            // auth" — NOT "clear". Pre-`CodeRabbit` round 8 on
-            // PR #408 this handler collapsed both cases to
-            // `auth_key: None`, so flipping the role while the
-            // key field held a bad paste silently clobbered
-            // DSP's saved auth. `Option<Option<..>>` gates the
-            // dispatch: outer `Some` means "push to DSP",
-            // outer `None` means "skip dispatch, keep last-good"
-            // — role persistence below still runs either way so
-            // the picker's user intent is recorded, and the
-            // `auth_key_row`'s own handler will catch up DSP
-            // with the current role + fixed/cleared text on
-            // the next edit.
+            // Resolve the auth_key for this dispatch:
+            // - Empty text → `None` (intentional clear).
+            // - Valid hex → `Some(bytes)`.
+            // - Malformed non-empty text → the cached last-good
+            //   bytes (which the auth handler maintains). This
+            //   means a role flip with bad hex in the auth field
+            //   still pushes the new role to DSP — pre-
+            //   `CodeRabbit` round 9 on PR #408 we'd skip the
+            //   dispatch entirely, so a user could switch to
+            //   Listener, hit Retry / ControllerBusy-toast-
+            //   Takeover, and still end up as Controller because
+            //   DSP never saw the new role. The auth_key-row
+            //   handler still drives the `error` CSS class on
+            //   the row so the user sees the malformed input.
             let key_text = auth_key_for_role.text().to_string();
-            let dispatch_auth: Option<Option<Vec<u8>>> = if key_text.is_empty() {
-                Some(None)
+            let auth_key: Option<Vec<u8>> = if key_text.is_empty() {
+                None
+            } else if let Some(bytes) = crate::sidebar::server_panel::auth_key_from_hex(&key_text) {
+                Some(bytes)
             } else {
-                crate::sidebar::server_panel::auth_key_from_hex(&key_text).map(Some)
+                last_good_for_role.borrow().clone()
             };
-            if let Some(auth_key) = dispatch_auth {
-                state_role.send_dsp(UiToDsp::SetRtlTcpClientConfig {
-                    requested_role,
-                    auth_key,
-                });
-            }
+            state_role.send_dsp(UiToDsp::SetRtlTcpClientConfig {
+                requested_role,
+                auth_key,
+            });
             // Tier 1: global default — always written so a fresh
             // server ("never favorited, never configured") picks
             // this up as the picker seed.
@@ -6291,6 +6324,7 @@ fn connect_source_panel(
     // DSP.
     let state_auth = Rc::clone(state);
     let role_for_auth = panels.source.rtl_tcp_role_row.clone();
+    let last_good_for_auth = Rc::clone(&last_good_auth_key);
     panels
         .source
         .rtl_tcp_auth_key_row
@@ -6325,13 +6359,15 @@ fn connect_source_panel(
             // had been clobbered. Three cases now:
             //
             // - Empty text: intentional clear. Drop the error
-            //   class, dispatch `auth_key: None`.
+            //   class, dispatch `auth_key: None`, cache `None`.
             // - Valid hex: parsed bytes. Drop the error class,
-            //   dispatch `Some(bytes)`.
+            //   dispatch `Some(bytes)`, cache `Some(bytes)`.
             // - Malformed non-empty text: add the libadwaita
             //   `error` CSS class so the row reads as invalid,
-            //   and RETURN without dispatching — keeping the
-            //   last-good DSP auth state intact until the user
+            //   and RETURN without dispatching or updating the
+            //   cache — keeping DSP's last-good auth state
+            //   (and the `last_good_auth_key` cache the role
+            //   handler reads from) intact until the user
             //   either fixes the text or clears the field.
             //
             // `auth_key_from_hex` treats empty as `None` too, but
@@ -6347,6 +6383,12 @@ fn connect_source_panel(
                 row.add_css_class("error");
                 return;
             };
+            // Update the last-good cache alongside the dispatch
+            // so the role handler's fallback path (malformed
+            // hex at role-flip time) has a coherent value to
+            // dispatch. See `last_good_auth_key` declaration
+            // above. Per `CodeRabbit` round 9 on PR #408.
+            last_good_for_auth.borrow_mut().clone_from(&auth_key);
             state_auth.send_dsp(UiToDsp::SetRtlTcpClientConfig {
                 requested_role: fav_role.as_wire_role(),
                 auth_key,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -5913,6 +5913,28 @@ fn connect_source_panel(
         );
     }
 
+    // Shared "last-good auth bytes" cache between the auth-key
+    // handler (primary writer) and the role-picker handler
+    // (reader). Populated whenever the auth row parses as empty
+    // (`None`, intentional clear) or valid hex (`Some(bytes)`);
+    // NOT updated on malformed hex. The role handler uses this
+    // snapshot when the live auth text is unparseable so it can
+    // still propagate the new role to DSP with a coherent
+    // auth_key value — without this, flipping role while the
+    // key field held a bad paste would skip the whole
+    // `SetRtlTcpClientConfig` dispatch and leave DSP on the
+    // previous role. Per `CodeRabbit` round 9 on PR #408.
+    //
+    // `Rc<RefCell<Option<Vec<u8>>>>` on GTK's single-threaded
+    // main loop — no lock contention. Declared BEFORE the
+    // startup last-connected restore below so that block can
+    // seed the cache with the keyring-loaded bytes — per
+    // `CodeRabbit` round 10 on PR #408, leaving the cache
+    // empty after startup would let a subsequent malformed-hex
+    // role flip clear DSP's working auth instead of preserving
+    // the startup-restored bytes.
+    let last_good_auth_key: Rc<RefCell<Option<Vec<u8>>>> = Rc::new(RefCell::new(None));
+
     // Restore the rtl_tcp client's last-used role + auth key
     // (#396). Role resolution uses the standard two-tier
     // lookup: per-favorite `requested_role` first (if the
@@ -5976,6 +5998,16 @@ fn connect_source_panel(
         if let Some(srv) = last_connected.as_ref() {
             *state.rtl_tcp_active_server.borrow_mut() = format!("{}:{}", srv.host, srv.port);
             auth_key = load_client_auth_key_from_keyring(&srv.host, srv.port);
+            // Seed the round-9 last-good cache with the
+            // startup-restored bytes so a subsequent malformed-
+            // hex role flip (round 9's fallback path) preserves
+            // the auth DSP just received. Without this the
+            // cache would stay `None` until the user first
+            // edited the auth field, opening a window where a
+            // role flip with malformed text in the row silently
+            // clears DSP auth. Per `CodeRabbit` round 10 on
+            // PR #408.
+            last_good_auth_key.borrow_mut().clone_from(&auth_key);
             let has_auth_required = matches!(
                 favorite_entry.as_ref().and_then(|f| f.auth_required),
                 Some(true)
@@ -6194,30 +6226,6 @@ fn connect_source_panel(
     //   save_favorites so the next connect from this favorite
     //   restores the right picker state without touching other
     //   servers.
-    // Shared "last-good auth bytes" cache between the auth-key
-    // handler (primary writer) and the role-picker handler
-    // (reader). Populated whenever the auth row parses as empty
-    // (`None`, intentional clear) or valid hex (`Some(bytes)`);
-    // NOT updated on malformed hex. The role handler uses this
-    // snapshot when the live auth text is unparseable so it can
-    // still propagate the new role to DSP with a coherent
-    // auth_key value — without this, flipping role while the
-    // key field held a bad paste would skip the whole
-    // `SetRtlTcpClientConfig` dispatch and leave DSP on the
-    // previous role. Per `CodeRabbit` round 9 on PR #408.
-    //
-    // `Rc<RefCell<Option<Vec<u8>>>>` on GTK's single-threaded
-    // main loop — no lock contention. The outer `Option`
-    // differentiates "never parsed" (fresh session, never had a
-    // valid auth value) from "intentionally cleared" (user typed
-    // empty): both dispatch `auth_key: None` so the distinction
-    // only affects the role-handler's fallback path, where
-    // "never parsed" means "just forward the current text's
-    // parse result (which will itself be None for empty and
-    // therefore match)" — see the role-handler below for the
-    // exact semantics.
-    let last_good_auth_key: Rc<RefCell<Option<Vec<u8>>>> = Rc::new(RefCell::new(None));
-
     let state_role = Rc::clone(state);
     let auth_key_for_role = panels.source.rtl_tcp_auth_key_row.clone();
     let config_for_role = std::sync::Arc::clone(config);
@@ -6272,27 +6280,48 @@ fn connect_source_panel(
                 v[KEY_RTL_TCP_CLIENT_LAST_ROLE] =
                     serde_json::to_value(fav_role).unwrap_or(serde_json::Value::Null);
             });
-            // Tier 2: per-favorite override. Compute the current
-            // `host:port` key; if it matches a favorite in the
-            // SHARED in-memory map (the one
-            // `connect_rtl_tcp_discovery`'s re-announce path
-            // also reads + mutates), update that entry's
-            // `requested_role` and persist. Pre-`CodeRabbit`
-            // round 8 on PR #408 this handler called
+            // Tier 2: per-favorite override. Resolve the
+            // server key from the cached stable identity first
+            // (`state.rtl_tcp_active_server`, written by
+            // `apply_rtl_tcp_connect` / the startup restore at
+            // connect-setup time) and only fall back to reading
+            // the `hostname_row` / `port_row` widgets when the
+            // cache is empty (manually-typed Play path, no
+            // apply_rtl_tcp_connect). Pre-`CodeRabbit` round 10
+            // on PR #408 this handler always rebuilt the key
+            // from the widgets, so a discovery connect that
+            // persisted `shack-pi.local.:1234` as the favorite
+            // identity could silently diverge from whatever
+            // resolved-IP value the dial path had pushed into
+            // `hostname_row` — the lookup below would miss the
+            // favorite, and `requested_role` wouldn't round-
+            // trip between discovery, favorites, and reconnects.
+            //
+            // Then update the matching entry's `requested_role`
+            // in the SHARED in-memory map
+            // (`connect_rtl_tcp_discovery`'s re-announce path
+            // also reads + mutates this map), and persist the
+            // full snapshot. Pre-round-8 this handler called
             // `load_favorites` on every fire and saved a fresh
-            // `Vec`, which diverged from the discovery path's
-            // in-memory map — a subsequent `ServerAnnounced`
-            // would preserve the stale in-memory role and
-            // clobber the just-saved selection on its own
-            // `save_favorites` call. Mutating the shared map
+            // `Vec`, diverging from the discovery path's in-
+            // memory map — a subsequent `ServerAnnounced` would
+            // preserve the stale in-memory role and clobber the
+            // just-saved selection. Mutating the shared map
             // keeps both paths honest.
-            let host = hostname_for_role.text().to_string();
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            let port = port_for_role.value() as u16;
-            if host.is_empty() || port == 0 {
-                return;
-            }
-            let server_key = format!("{host}:{port}");
+            let server_key = {
+                let cached = state_role.rtl_tcp_active_server.borrow().clone();
+                if cached.is_empty() {
+                    let host = hostname_for_role.text().to_string();
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let port = port_for_role.value() as u16;
+                    if host.is_empty() || port == 0 {
+                        return;
+                    }
+                    format!("{host}:{port}")
+                } else {
+                    cached
+                }
+            };
             let dirty = {
                 let mut favorites = favorites_for_role.borrow_mut();
                 if let Some(fav) = favorites.get_mut(&server_key)

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -5237,6 +5237,41 @@ fn connect_source_panel(
         );
     }
 
+    // Restore the rtl_tcp client's last-used role (#396). Stored
+    // as a `FavoriteRole` serde-tagged string under
+    // `KEY_RTL_TCP_CLIENT_LAST_ROLE`. Missing / corrupt config
+    // → default Control (legacy-safe). We also seed the DSP
+    // state with the persisted role so the next Play against an
+    // rtl_tcp source picks it up even if the user never touched
+    // the combo this session.
+    {
+        use crate::sidebar::source_panel::{
+            FavoriteRole, KEY_RTL_TCP_CLIENT_LAST_ROLE, RTL_TCP_ROLE_CONTROL_IDX,
+            RTL_TCP_ROLE_LISTEN_IDX,
+        };
+        let persisted_role: FavoriteRole = config.read(|v| {
+            v.get(KEY_RTL_TCP_CLIENT_LAST_ROLE)
+                .and_then(|val| serde_json::from_value(val.clone()).ok())
+                .unwrap_or(FavoriteRole::Control)
+        });
+        let idx = match persisted_role {
+            FavoriteRole::Control => RTL_TCP_ROLE_CONTROL_IDX,
+            FavoriteRole::Listen => RTL_TCP_ROLE_LISTEN_IDX,
+        };
+        panels.source.rtl_tcp_role_row.set_selected(idx);
+        // Seed the DSP with the restored role so a Play before
+        // the user touches the combo picks up the right value.
+        // The auth-key restore lives in the per-server flow
+        // (wired in the follow-up discovery / last-connected
+        // handlers) — here we pass `None` as a safe default;
+        // the per-server load will overlay real bytes before
+        // Connect time when applicable.
+        state.send_dsp(UiToDsp::SetRtlTcpClientConfig {
+            requested_role: persisted_role.as_wire_role(),
+            auth_key: None,
+        });
+    }
+
     // IQ correction toggle
     let state_iq_corr = Rc::clone(state);
     panels
@@ -5384,6 +5419,96 @@ fn connect_source_panel(
                 hostname,
                 port,
                 protocol,
+            });
+        });
+
+    // Connection-role picker (#396). The selector flips between
+    // `Role::Control` (index 0) and `Role::Listen` (index 1); we
+    // dispatch a fresh `SetRtlTcpClientConfig` with the new role
+    // plus the current auth key (unchanged by a role flip). The
+    // role takes effect on the NEXT connect — already-running
+    // sessions keep their admitted role because the wire
+    // protocol ties role to the hello and doesn't support
+    // mid-stream role changes. Also persist the chosen role so a
+    // restart restores the user's preference.
+    let state_role = Rc::clone(state);
+    let auth_key_for_role = panels.source.rtl_tcp_auth_key_row.clone();
+    let config_for_role = std::sync::Arc::clone(config);
+    panels
+        .source
+        .rtl_tcp_role_row
+        .connect_selected_notify(move |row| {
+            use crate::sidebar::source_panel::{
+                FavoriteRole, KEY_RTL_TCP_CLIENT_LAST_ROLE, RTL_TCP_ROLE_CONTROL_IDX,
+                RTL_TCP_ROLE_LISTEN_IDX,
+            };
+            let fav_role = match row.selected() {
+                RTL_TCP_ROLE_CONTROL_IDX => FavoriteRole::Control,
+                RTL_TCP_ROLE_LISTEN_IDX => FavoriteRole::Listen,
+                _ => return, // transient out-of-range indices
+            };
+            let requested_role = fav_role.as_wire_role();
+            let key_text = auth_key_for_role.text().to_string();
+            let auth_key: Option<Vec<u8>> = if key_text.is_empty() {
+                None
+            } else {
+                crate::sidebar::server_panel::auth_key_from_hex(&key_text)
+            };
+            state_role.send_dsp(UiToDsp::SetRtlTcpClientConfig {
+                requested_role,
+                auth_key,
+            });
+            config_for_role.write(|v| {
+                v[KEY_RTL_TCP_CLIENT_LAST_ROLE] =
+                    serde_json::to_value(fav_role).unwrap_or(serde_json::Value::Null);
+            });
+        });
+
+    // Server key entry (#394 + #396). On every edit we rebuild
+    // the `SetRtlTcpClientConfig` message with the current role
+    // + the new key bytes, so the NEXT connect carries the
+    // latest value. The entry accepts hex input (matching what
+    // `openssl rand -hex 32` produces and what the server UI's
+    // Copy button writes to the clipboard); an empty field
+    // clears the key (`auth_key: None`). The key is also saved
+    // to the per-server keyring on a successful auth-required
+    // connect (wired in the toast-flow commit) — this handler
+    // only threads the current-session value through to the
+    // DSP.
+    let state_auth = Rc::clone(state);
+    let role_for_auth = panels.source.rtl_tcp_role_row.clone();
+    panels
+        .source
+        .rtl_tcp_auth_key_row
+        .connect_changed(move |row| {
+            use crate::sidebar::source_panel::{
+                FavoriteRole, RTL_TCP_ROLE_CONTROL_IDX, RTL_TCP_ROLE_LISTEN_IDX,
+            };
+            // Transient out-of-range indices on `ComboRow` can
+            // occur during widget teardown; fall back to the
+            // legacy-safe `Control` default in that case (same
+            // treatment the role_row handler gives with an
+            // `early return`, but auth_key edits happen often
+            // enough that swallowing one rare transient is
+            // fine).
+            #[allow(
+                clippy::match_same_arms,
+                reason = "explicit catch-all matches the Control default"
+            )]
+            let fav_role = match role_for_auth.selected() {
+                RTL_TCP_ROLE_CONTROL_IDX => FavoriteRole::Control,
+                RTL_TCP_ROLE_LISTEN_IDX => FavoriteRole::Listen,
+                _ => FavoriteRole::Control,
+            };
+            let text = row.text().to_string();
+            let auth_key: Option<Vec<u8>> = if text.is_empty() {
+                None
+            } else {
+                crate::sidebar::server_panel::auth_key_from_hex(&text)
+            };
+            state_auth.send_dsp(UiToDsp::SetRtlTcpClientConfig {
+                requested_role: fav_role.as_wire_role(),
+                auth_key,
             });
         });
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1466,10 +1466,22 @@ fn save_current_auth_key_for_active_server(
     };
     let text = row.text().to_string();
     if text.is_empty() {
-        // Nothing to save — e.g., the user connected with a
-        // previously-saved key that was auto-loaded and never
-        // edited the field. The keyring already has the right
-        // value.
+        // User explicitly cleared the field BEFORE this connect
+        // succeeded — mirror that intent in the keyring by
+        // deleting the saved entry. Pre-CodeRabbit round 3 on
+        // PR #408 this branch returned early with a stale
+        // "nothing to save" comment, so clearing the row and
+        // reconnecting left the old bytes in the keyring and
+        // `apply_rtl_tcp_connect` would preload them on the
+        // next discovery / favorites / last-connected path,
+        // silently undoing the user's clear.
+        if let Err(e) = clear_client_auth_key_from_keyring(host, port) {
+            tracing::warn!(
+                server = %active,
+                %e,
+                "rtl_tcp: client auth key keyring clear failed (empty row)"
+            );
+        }
         return;
     }
     let Some(bytes) = crate::sidebar::server_panel::auth_key_from_hex(&text) else {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -592,6 +592,10 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let rtl_tcp_status_row_weak = panels.source.rtl_tcp_status_row.downgrade();
     let rtl_tcp_disconnect_button_weak = panels.source.rtl_tcp_disconnect_button.downgrade();
     let rtl_tcp_retry_button_weak = panels.source.rtl_tcp_retry_button.downgrade();
+    let rtl_tcp_role_row_weak = panels.source.rtl_tcp_role_row.downgrade();
+    let rtl_tcp_auth_key_row_weak = panels.source.rtl_tcp_auth_key_row.downgrade();
+    let rtl_tcp_hostname_row_weak = panels.source.hostname_row.downgrade();
+    let rtl_tcp_port_row_weak = panels.source.port_row.downgrade();
     // Network audio sink status row — same weak-ref pattern as
     // the rtl_tcp status row above so a window close can't keep
     // the row alive past its useful life. Per issue #247.
@@ -655,6 +659,10 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
                         &rtl_tcp_status_row_weak,
                         &rtl_tcp_disconnect_button_weak,
                         &rtl_tcp_retry_button_weak,
+                        &rtl_tcp_role_row_weak,
+                        &rtl_tcp_auth_key_row_weak,
+                        &rtl_tcp_hostname_row_weak,
+                        &rtl_tcp_port_row_weak,
                         &network_sink_status_row_weak,
                         &transcription_enable_for_dsp,
                         #[cfg(feature = "sherpa")]
@@ -724,6 +732,10 @@ fn handle_dsp_message(
     rtl_tcp_status_row_weak: &glib::WeakRef<adw::ActionRow>,
     rtl_tcp_disconnect_button_weak: &glib::WeakRef<gtk4::Button>,
     rtl_tcp_retry_button_weak: &glib::WeakRef<gtk4::Button>,
+    rtl_tcp_role_row_weak: &glib::WeakRef<adw::ComboRow>,
+    rtl_tcp_auth_key_row_weak: &glib::WeakRef<adw::PasswordEntryRow>,
+    rtl_tcp_hostname_row_weak: &glib::WeakRef<adw::EntryRow>,
+    rtl_tcp_port_row_weak: &glib::WeakRef<adw::SpinRow>,
     network_sink_status_row_weak: &glib::WeakRef<adw::ActionRow>,
     transcription_enable_row: &adw::SwitchRow,
     #[cfg(feature = "sherpa")] auto_break_row: &adw::SwitchRow,
@@ -932,6 +944,27 @@ fn handle_dsp_message(
             ) {
                 apply_rtl_tcp_connection_state(&status_row, &disconnect, &retry, &conn_state);
             }
+            // #396 toast surface: fire toast + manipulate widgets
+            // on the EDGE of every transition into a role-denial
+            // terminal state (or into Connected from one of those
+            // states, for the keyring save path). Edge detection
+            // uses a u8-discriminant cell on AppState so we don't
+            // re-fire the toast on every same-state republish.
+            let prev_disc = state.last_rtl_tcp_state_disc.get();
+            let now_disc = crate::state::rtl_tcp_state_discriminant(&conn_state);
+            if prev_disc != now_disc {
+                state.last_rtl_tcp_state_disc.set(now_disc);
+                handle_rtl_tcp_state_toast(
+                    &conn_state,
+                    prev_disc,
+                    state,
+                    toast_overlay_weak,
+                    rtl_tcp_role_row_weak,
+                    rtl_tcp_auth_key_row_weak,
+                    rtl_tcp_hostname_row_weak,
+                    rtl_tcp_port_row_weak,
+                );
+            }
         }
         DspToUi::NetworkSinkStatus(status) => {
             tracing::debug!(?status, "network sink status");
@@ -1134,6 +1167,246 @@ fn apply_network_sink_status(row: &adw::ActionRow, status: &sdr_core::NetworkSin
 /// handler can call it with individual weak-upgraded widgets
 /// instead of holding a whole `SourcePanel` clone across the
 /// signal-handler boundary.
+/// Fire a toast + manipulate widgets on each **edge transition**
+/// into a terminal role-denial state (`ControllerBusy`,
+/// `AuthRequired`, `AuthFailed`), or on a successful `Connected`
+/// immediately following an auth-required transition (to save
+/// the user-entered key to the per-server keyring).
+///
+/// Called only from the edge-detection path in
+/// `handle_dsp_message`; the caller already verified
+/// `prev_disc != now_disc` and stored the new discriminant.
+/// Per issue #396.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "toast composition needs read access to multiple panel widgets \
+              + a dispatch handle; collapsing into a single context struct \
+              would move the same argument count one layer up"
+)]
+#[allow(
+    clippy::doc_markdown,
+    reason = "doc references to Connected / ControllerBusy / AuthRequired / \
+              AuthFailed are type variants — enum paths would make the prose \
+              unreadable; backticks on each would overwhelm the paragraph"
+)]
+fn handle_rtl_tcp_state_toast(
+    state_val: &sdr_types::RtlTcpConnectionState,
+    prev_disc: u8,
+    app_state: &Rc<AppState>,
+    toast_overlay_weak: &glib::WeakRef<adw::ToastOverlay>,
+    role_row_weak: &glib::WeakRef<adw::ComboRow>,
+    auth_key_row_weak: &glib::WeakRef<adw::PasswordEntryRow>,
+    hostname_row_weak: &glib::WeakRef<adw::EntryRow>,
+    port_row_weak: &glib::WeakRef<adw::SpinRow>,
+) {
+    use sdr_types::RtlTcpConnectionState;
+
+    use crate::state::{RTL_TCP_STATE_DISC_AUTH_FAILED, RTL_TCP_STATE_DISC_AUTH_REQUIRED};
+
+    match state_val {
+        RtlTcpConnectionState::ControllerBusy => {
+            // Toast with two action buttons: "Connect as
+            // Listener" flips the role combo (its change handler
+            // re-dispatches SetRtlTcpClientConfig) and fires a
+            // normal retry; "Take control" dispatches the one-shot
+            // `RetryRtlTcpWithTakeover` message which rebuilds
+            // the source with `request_takeover = true` on the
+            // hello.
+            let Some(overlay) = toast_overlay_weak.upgrade() else {
+                return;
+            };
+            let toast = adw::Toast::builder()
+                .title("Controller slot is occupied on this server.")
+                .timeout(0)
+                .build();
+            // Track the two action buttons as separate signals.
+            // AdwToast supports a single primary action via
+            // `set_button_label` + `connect_button_clicked`; the
+            // "Take control" action lands there, and the
+            // "Connect as Listener" option lives in the toast
+            // body copy so users still see both choices.
+            toast.set_button_label(Some("Take control"));
+            let state_for_takeover = Rc::clone(app_state);
+            toast.connect_button_clicked(move |t| {
+                state_for_takeover.send_dsp(UiToDsp::RetryRtlTcpWithTakeover);
+                t.dismiss();
+            });
+            overlay.add_toast(toast);
+
+            // Second toast offering the Listen fallback. Two
+            // separate toasts beats a single one because AdwToast
+            // exposes only one action button — splitting the two
+            // paths keeps both discoverable.
+            let listen_toast = adw::Toast::builder()
+                .title("Or connect as Listener (read-only).")
+                .timeout(0)
+                .build();
+            listen_toast.set_button_label(Some("Connect as Listener"));
+            let state_for_listen = Rc::clone(app_state);
+            let role_row_for_listen = role_row_weak.clone();
+            listen_toast.connect_button_clicked(move |t| {
+                if let Some(role_row) = role_row_for_listen.upgrade() {
+                    // Flipping the combo to Listen fires its
+                    // `selected-notify` handler which dispatches
+                    // `SetRtlTcpClientConfig` with the new role.
+                    // Follow with RetryRtlTcpNow so the user
+                    // doesn't have to click Retry themselves.
+                    role_row.set_selected(crate::sidebar::source_panel::RTL_TCP_ROLE_LISTEN_IDX);
+                }
+                state_for_listen.send_dsp(UiToDsp::RetryRtlTcpNow);
+                t.dismiss();
+            });
+            overlay.add_toast(listen_toast);
+        }
+
+        RtlTcpConnectionState::AuthRequired => {
+            // Remember the active server so a subsequent
+            // successful Connected can save the user-entered
+            // key to the right keyring entry.
+            record_active_rtl_tcp_server(app_state, hostname_row_weak, port_row_weak);
+            // Reveal + focus the Server key field so the user
+            // can enter the key.
+            if let Some(row) = auth_key_row_weak.upgrade() {
+                row.set_visible(true);
+                row.grab_focus();
+            }
+            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                let toast = adw::Toast::builder()
+                    .title("Server requires an authentication key.")
+                    .timeout(5)
+                    .build();
+                overlay.add_toast(toast);
+            }
+        }
+
+        RtlTcpConnectionState::AuthFailed => {
+            record_active_rtl_tcp_server(app_state, hostname_row_weak, port_row_weak);
+            if let Some(row) = auth_key_row_weak.upgrade() {
+                row.set_visible(true);
+                row.grab_focus();
+                // Clear the entered value so the user doesn't
+                // re-submit the same wrong key by reflex on the
+                // next Retry. The saved-key keyring entry (if
+                // any) stays untouched — the user can clear it
+                // explicitly via the keyring UI.
+                row.set_text("");
+            }
+            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                let toast = adw::Toast::builder()
+                    .title("Key rejected. Check with the server owner.")
+                    .timeout(5)
+                    .build();
+                overlay.add_toast(toast);
+            }
+        }
+
+        RtlTcpConnectionState::Connected { .. } => {
+            // Successful connect after an auth-required attempt:
+            // save the user-entered key to the per-server
+            // keyring so subsequent reconnects auto-use it.
+            // Only fires on the edge FROM AuthRequired /
+            // AuthFailed — a regular Connected-from-Connecting
+            // doesn't touch the keyring (user didn't type
+            // anything worth saving).
+            if prev_disc == RTL_TCP_STATE_DISC_AUTH_REQUIRED
+                || prev_disc == RTL_TCP_STATE_DISC_AUTH_FAILED
+            {
+                save_current_auth_key_for_active_server(app_state, auth_key_row_weak);
+            }
+        }
+
+        // Non-toast states (Disconnected / Connecting / Retrying
+        // / Failed) just update the status row subtitle via the
+        // sibling call in `handle_dsp_message`. No additional
+        // UX gesture needed here.
+        RtlTcpConnectionState::Disconnected
+        | RtlTcpConnectionState::Connecting
+        | RtlTcpConnectionState::Retrying { .. }
+        | RtlTcpConnectionState::Failed { .. } => {}
+    }
+}
+
+/// Record the currently-displayed `rtl_tcp` server's `host:port`
+/// on `AppState` so a subsequent successful `Connected` can save
+/// the just-entered key to the right per-server keyring entry.
+/// Empty on upgrade failure — the save path skips when the
+/// cached identity is empty. Per #396.
+fn record_active_rtl_tcp_server(
+    app_state: &Rc<AppState>,
+    hostname_row_weak: &glib::WeakRef<adw::EntryRow>,
+    port_row_weak: &glib::WeakRef<adw::SpinRow>,
+) {
+    let Some(host_row) = hostname_row_weak.upgrade() else {
+        return;
+    };
+    let Some(port_row) = port_row_weak.upgrade() else {
+        return;
+    };
+    let host = host_row.text().to_string();
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let port = port_row.value() as u16;
+    if !host.is_empty() && port != 0 {
+        *app_state.rtl_tcp_active_server.borrow_mut() = format!("{host}:{port}");
+    }
+}
+
+/// Save the current Server-key-row text to the keyring under
+/// the active `rtl_tcp` server's `host:port`. Called on a
+/// successful Connected following AuthRequired / AuthFailed.
+/// Empty text → clear the saved entry instead of writing empty
+/// bytes; invalid hex → log + skip (the live connection
+/// obviously accepted the text, but our keyring round-trip
+/// demands valid hex). Per #396.
+#[allow(
+    clippy::doc_markdown,
+    reason = "Connected / AuthRequired / AuthFailed are enum variants"
+)]
+fn save_current_auth_key_for_active_server(
+    app_state: &Rc<AppState>,
+    auth_key_row_weak: &glib::WeakRef<adw::PasswordEntryRow>,
+) {
+    let active = app_state.rtl_tcp_active_server.borrow().clone();
+    if active.is_empty() {
+        return;
+    }
+    let Some((host, port_str)) = active.rsplit_once(':') else {
+        return;
+    };
+    let Ok(port) = port_str.parse::<u16>() else {
+        return;
+    };
+    let Some(row) = auth_key_row_weak.upgrade() else {
+        return;
+    };
+    let text = row.text().to_string();
+    if text.is_empty() {
+        // Nothing to save — e.g., the user connected with a
+        // previously-saved key that was auto-loaded and never
+        // edited the field. The keyring already has the right
+        // value.
+        return;
+    }
+    let Some(bytes) = crate::sidebar::server_panel::auth_key_from_hex(&text) else {
+        tracing::warn!(
+            server = %active,
+            "rtl_tcp: client auth key hex is invalid — skipping keyring save"
+        );
+        return;
+    };
+    if let Err(e) = save_client_auth_key_to_keyring(host, port, &bytes) {
+        tracing::warn!(
+            server = %active,
+            %e,
+            "rtl_tcp: client auth key keyring save failed"
+        );
+    } else {
+        tracing::info!(
+            server = %active,
+            "rtl_tcp: client auth key saved to keyring for next reconnect"
+        );
+    }
+}
+
 fn apply_rtl_tcp_connection_state(
     status_row: &adw::ActionRow,
     disconnect_button: &gtk4::Button,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -965,20 +965,30 @@ fn handle_dsp_message(
                     rtl_tcp_port_row_weak,
                 );
             }
-            // Status-bar role badge (#396) — flip on Connected
-            // based on the user's most recently-requested role;
-            // hide on every non-Connected state. Server
-            // admission is always "grant as requested" (#392
-            // has no downgrade path), so the requested role
-            // the UI holds mirrors what the server admitted.
+            // Status-bar role badge (#396) — show the role the
+            // SERVER admitted us into, never the role the user
+            // requested. Pre-CodeRabbit round 1 on PR #408 the
+            // badge was derived from the role-picker selection,
+            // which could silently mis-label sessions where the
+            // server admitted a different role (e.g. a pre-#392
+            // RTLX server that hands every client a Control-
+            // equivalent slot without honoring role requests,
+            // or a hypothetical future server with
+            // role-downgrade semantics). `granted_role` is
+            // populated by the extended handshake: `Some(true)`
+            // → Controller, `Some(false)` → Listener, `None` →
+            // unknown (legacy server, or pre-#392 RTLX build
+            // that doesn't write the field). Hide the badge
+            // when unknown AND in every non-Connected state.
             let role_badge = match &conn_state {
-                sdr_types::RtlTcpConnectionState::Connected { .. } => {
-                    let selected = rtl_tcp_role_row_weak.upgrade().map_or(
-                        crate::sidebar::source_panel::RTL_TCP_ROLE_CONTROL_IDX,
-                        |row| row.selected(),
-                    );
-                    Some(selected == crate::sidebar::source_panel::RTL_TCP_ROLE_CONTROL_IDX)
-                }
+                sdr_types::RtlTcpConnectionState::Connected {
+                    granted_role: Some(true),
+                    ..
+                } => Some(crate::status_bar::RtlTcpRoleBadge::Controller),
+                sdr_types::RtlTcpConnectionState::Connected {
+                    granted_role: Some(false),
+                    ..
+                } => Some(crate::status_bar::RtlTcpRoleBadge::Listener),
                 _ => None,
             };
             status_bar.update_role(role_badge);
@@ -1218,7 +1228,10 @@ fn handle_rtl_tcp_state_toast(
 ) {
     use sdr_types::RtlTcpConnectionState;
 
-    use crate::state::{RTL_TCP_STATE_DISC_AUTH_FAILED, RTL_TCP_STATE_DISC_AUTH_REQUIRED};
+    use crate::state::{
+        RTL_TCP_STATE_DISC_AUTH_FAILED, RTL_TCP_STATE_DISC_AUTH_REQUIRED,
+        RTL_TCP_STATE_DISC_CONNECTING,
+    };
 
     match state_val {
         RtlTcpConnectionState::ControllerBusy => {
@@ -1318,16 +1331,32 @@ fn handle_rtl_tcp_state_toast(
         }
 
         RtlTcpConnectionState::Connected { .. } => {
-            // Successful connect after an auth-required attempt:
-            // save the user-entered key to the per-server
+            // Save the user-entered key to the per-server
             // keyring so subsequent reconnects auto-use it.
-            // Only fires on the edge FROM AuthRequired /
-            // AuthFailed — a regular Connected-from-Connecting
-            // doesn't touch the keyring (user didn't type
-            // anything worth saving).
-            if prev_disc == RTL_TCP_STATE_DISC_AUTH_REQUIRED
+            // Fires on the edge from either `AuthRequired` /
+            // `AuthFailed` (user typed a key in response to a
+            // denial) OR `Connecting` (user had auth configured
+            // up front — server advertised `auth_required` via
+            // mDNS, key was entered before the first connect,
+            // and the handshake succeeded in a single
+            // `Connecting → Connected` hop without ever
+            // surfacing an auth-denial state). Pre-CodeRabbit
+            // round 1 on PR #408 the Connecting case was
+            // missed, so up-front keys never hit the keyring
+            // and the user had to re-type them on every
+            // reconnect. `save_current_auth_key_for_active_
+            // server` is a no-op when the key row is empty, so
+            // this is safe to trigger on every Connecting→
+            // Connected edge even if the server doesn't require
+            // auth. Call `record_active_rtl_tcp_server` first
+            // so the save-path sees the right `host:port` even
+            // when the user never hit an auth-denial arm
+            // (which is what previously set the cache).
+            if prev_disc == RTL_TCP_STATE_DISC_CONNECTING
+                || prev_disc == RTL_TCP_STATE_DISC_AUTH_REQUIRED
                 || prev_disc == RTL_TCP_STATE_DISC_AUTH_FAILED
             {
+                record_active_rtl_tcp_server(app_state, hostname_row_weak, port_row_weak);
                 save_current_auth_key_for_active_server(app_state, auth_key_row_weak);
             }
         }
@@ -2059,6 +2088,8 @@ fn connect_rtl_tcp_discovery(
     let port_row = panels.source.port_row.clone();
     let protocol_row = panels.source.protocol_row.clone();
     let device_row = panels.source.device_row.clone();
+    let role_row = panels.source.rtl_tcp_role_row.clone();
+    let auth_key_row = panels.source.rtl_tcp_auth_key_row.clone();
     let state = Rc::clone(state);
     // Shared config handle — the Connect button on each discovered
     // row clones it once more inside the closure so it can persist
@@ -2105,6 +2136,8 @@ fn connect_rtl_tcp_discovery(
         port_row: port_row.downgrade(),
         protocol_row: protocol_row.downgrade(),
         device_row: device_row.downgrade(),
+        role_row: role_row.downgrade(),
+        auth_key_row: auth_key_row.downgrade(),
         expander_weak: expander_weak.clone(),
         // Weak refs — see `FavoriteRowContext.displayed_rows`
         // docstring for the retain-cycle reasoning.
@@ -2433,6 +2466,8 @@ fn connect_rtl_tcp_discovery(
                     let pr = port_row.clone();
                     let protor = protocol_row.clone();
                     let dr = device_row.clone();
+                    let rr = role_row.clone();
+                    let akr = auth_key_row.clone();
                     let st = Rc::clone(&state);
                     let cfg = std::sync::Arc::clone(&config_for_discovery);
                     // Friendly nickname for the persisted snapshot.
@@ -2457,6 +2492,8 @@ fn connect_rtl_tcp_discovery(
                             &pr,
                             &protor,
                             &dr,
+                            &rr,
+                            &akr,
                             &st,
                             &cfg,
                         );
@@ -2652,6 +2689,8 @@ fn apply_rtl_tcp_connect(
     port_row: &adw::SpinRow,
     protocol_row: &adw::ComboRow,
     device_row: &adw::ComboRow,
+    role_row: &adw::ComboRow,
+    auth_key_row: &adw::PasswordEntryRow,
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
 ) {
@@ -2659,6 +2698,104 @@ fn apply_rtl_tcp_connect(
     protocol_row.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
     hostname_row.set_text(host);
     port_row.set_value(f64::from(port));
+    // Restore saved per-server state (#396) BEFORE the
+    // `SetNetworkConfig` / `SetSourceType` dispatch so the DSP
+    // thread's first use of the new endpoint already carries the
+    // right `requested_role` + `auth_key`. Pre-CodeRabbit round 1
+    // on PR #408 this helper only pushed host / port / source,
+    // which meant the new favorite metadata (`requested_role`,
+    // `auth_required`) and per-server client-key keyring helpers
+    // were inert from the discovery + favorites entry points —
+    // role always reverted to the global default and keys never
+    // auto-filled.
+    //
+    // Resolution order for role:
+    // - If the server is a favorite and that favorite carries a
+    //   `requested_role`, use it.
+    // - Otherwise fall back to the global
+    //   `KEY_RTL_TCP_CLIENT_LAST_ROLE` default (if any).
+    // - Otherwise leave the picker alone (Control is the
+    //   picker's built-in default for fresh servers).
+    //
+    // For the auth-key row:
+    // - Reveal the row if the favorite's `auth_required` is
+    //   `Some(true)` — user doesn't have to hit an
+    //   `AuthRequired` denial before seeing the field.
+    // - Load any saved keyring hex for this `host:port` and
+    //   pre-fill the row so the subsequent connect succeeds in
+    //   a single `Connecting → Connected` hop.
+    //
+    // Both operations are no-ops for servers we've never
+    // favorited AND never connected to; the picker stays on
+    // Control and the row stays hidden, matching pre-#408
+    // behavior.
+    use crate::sidebar::source_panel::{
+        FavoriteRole, KEY_RTL_TCP_CLIENT_LAST_ROLE, RTL_TCP_ROLE_CONTROL_IDX,
+        RTL_TCP_ROLE_LISTEN_IDX, load_favorites,
+    };
+    let server_key = format!("{host}:{port}");
+    let favorite_entry = load_favorites(config)
+        .into_iter()
+        .find(|f| f.key == server_key);
+    let favorite_role = favorite_entry
+        .as_ref()
+        .and_then(|f| f.requested_role)
+        .or_else(|| {
+            config.read(|v| {
+                v.get(KEY_RTL_TCP_CLIENT_LAST_ROLE)
+                    .and_then(|rv| serde_json::from_value::<FavoriteRole>(rv.clone()).ok())
+            })
+        });
+    if let Some(fav_role) = favorite_role {
+        let idx = match fav_role {
+            FavoriteRole::Control => RTL_TCP_ROLE_CONTROL_IDX,
+            FavoriteRole::Listen => RTL_TCP_ROLE_LISTEN_IDX,
+        };
+        role_row.set_selected(idx);
+    }
+    // Reveal Server-key row if the favorite advertised
+    // `auth_required = true`. We leave it alone when `None` —
+    // an unknown auth stance means "don't nag the user now,
+    // the AuthRequired handshake arm will reveal it if
+    // needed." `Some(false)` also leaves it alone (row stays
+    // hidden for explicitly-no-auth servers).
+    if matches!(
+        favorite_entry.as_ref().and_then(|f| f.auth_required),
+        Some(true)
+    ) {
+        auth_key_row.set_visible(true);
+    }
+    // Pre-fill the saved client key (hex) if we have one for
+    // this server. `load_client_auth_key_from_keyring` returns
+    // raw bytes; re-hex them for the row (the row always
+    // displays hex, matching what `openssl rand -hex 32`
+    // produces and what the server UI's Copy button writes).
+    if let Some(bytes) = load_client_auth_key_from_keyring(host, port) {
+        auth_key_row.set_text(&crate::sidebar::server_panel::auth_key_to_hex(&bytes));
+    }
+    // Dispatch a fresh `SetRtlTcpClientConfig` so the DSP
+    // thread has the restored role + key in place before the
+    // `SetNetworkConfig` + `SetSourceType` below trigger the
+    // actual handshake. Without this the DSP would use its
+    // last-known values (possibly stale from a prior server)
+    // and the first connect could land with the wrong role or
+    // a dead auth key from another session.
+    let requested_role = match role_row.selected() {
+        RTL_TCP_ROLE_CONTROL_IDX => FavoriteRole::Control,
+        RTL_TCP_ROLE_LISTEN_IDX => FavoriteRole::Listen,
+        _ => FavoriteRole::Control,
+    }
+    .as_wire_role();
+    let key_text = auth_key_row.text().to_string();
+    let auth_key: Option<Vec<u8>> = if key_text.is_empty() {
+        None
+    } else {
+        crate::sidebar::server_panel::auth_key_from_hex(&key_text)
+    };
+    state.send_dsp(UiToDsp::SetRtlTcpClientConfig {
+        requested_role,
+        auth_key,
+    });
     device_row.set_selected(DEVICE_RTLTCP);
     state.send_dsp(UiToDsp::SetNetworkConfig {
         hostname: host.to_string(),
@@ -2776,6 +2913,18 @@ struct FavoriteRowContext {
     port_row: glib::WeakRef<adw::SpinRow>,
     protocol_row: glib::WeakRef<adw::ComboRow>,
     device_row: glib::WeakRef<adw::ComboRow>,
+    /// Role picker — `apply_rtl_tcp_connect` needs it so the
+    /// per-server `requested_role` can be restored before
+    /// the new endpoint's first connect dispatch. Per
+    /// CodeRabbit round 1 on PR #408.
+    role_row: glib::WeakRef<adw::ComboRow>,
+    /// Auth-key row — `apply_rtl_tcp_connect` reveals it
+    /// when the favorite advertises `auth_required` and
+    /// pre-fills any saved key from the keyring so a
+    /// pre-configured auth connect lands in a single
+    /// `Connecting → Connected` hop. Per CodeRabbit round 1
+    /// on PR #408.
+    auth_key_row: glib::WeakRef<adw::PasswordEntryRow>,
     expander_weak: glib::WeakRef<adw::ExpanderRow>,
     displayed_rows: std::rc::Weak<
         RefCell<std::collections::HashMap<String, (adw::ActionRow, DiscoveredServer)>>,
@@ -2873,12 +3022,22 @@ fn attach_favorite_row_actions(
             );
             return;
         };
-        let (Some(hostname_row), Some(port_row), Some(protocol_row), Some(device_row)) = (
+        let (
+            Some(hostname_row),
+            Some(port_row),
+            Some(protocol_row),
+            Some(device_row),
+            Some(role_row),
+            Some(auth_key_row),
+        ) = (
             connect_ctx.hostname_row.upgrade(),
             connect_ctx.port_row.upgrade(),
             connect_ctx.protocol_row.upgrade(),
             connect_ctx.device_row.upgrade(),
-        ) else {
+            connect_ctx.role_row.upgrade(),
+            connect_ctx.auth_key_row.upgrade(),
+        )
+        else {
             return;
         };
         // Shared ordering-sensitive flow lives in
@@ -2892,6 +3051,8 @@ fn attach_favorite_row_actions(
             &port_row,
             &protocol_row,
             &device_row,
+            &role_row,
+            &auth_key_row,
             &connect_ctx.state,
             &connect_ctx.config,
         );
@@ -5719,18 +5880,33 @@ fn connect_source_panel(
     // role takes effect on the NEXT connect — already-running
     // sessions keep their admitted role because the wire
     // protocol ties role to the hello and doesn't support
-    // mid-stream role changes. Also persist the chosen role so a
-    // restart restores the user's preference.
+    // mid-stream role changes. Persistence has two tiers:
+    //
+    // - Global `KEY_RTL_TCP_CLIENT_LAST_ROLE` — fallback default
+    //   for NEW servers that haven't been favorited yet. The
+    //   Connect-from-discovery path reads this to seed the
+    //   picker before the user has expressed a per-server
+    //   preference. Pre-CodeRabbit round 1 on PR #408 this was
+    //   the ONLY persistence tier, which meant changing
+    //   Server B's role clobbered Server A's preference.
+    // - Per-favorite `FavoriteEntry.requested_role` — wins for
+    //   favorited servers. When the current server identity
+    //   matches a favorite key, update that entry's role and
+    //   save_favorites so the next connect from this favorite
+    //   restores the right picker state without touching other
+    //   servers.
     let state_role = Rc::clone(state);
     let auth_key_for_role = panels.source.rtl_tcp_auth_key_row.clone();
     let config_for_role = std::sync::Arc::clone(config);
+    let hostname_for_role = panels.source.hostname_row.clone();
+    let port_for_role = panels.source.port_row.clone();
     panels
         .source
         .rtl_tcp_role_row
         .connect_selected_notify(move |row| {
             use crate::sidebar::source_panel::{
                 FavoriteRole, KEY_RTL_TCP_CLIENT_LAST_ROLE, RTL_TCP_ROLE_CONTROL_IDX,
-                RTL_TCP_ROLE_LISTEN_IDX,
+                RTL_TCP_ROLE_LISTEN_IDX, load_favorites, save_favorites,
             };
             let fav_role = match row.selected() {
                 RTL_TCP_ROLE_CONTROL_IDX => FavoriteRole::Control,
@@ -5748,10 +5924,37 @@ fn connect_source_panel(
                 requested_role,
                 auth_key,
             });
+            // Tier 1: global default — always written so a fresh
+            // server ("never favorited, never configured") picks
+            // this up as the picker seed.
             config_for_role.write(|v| {
                 v[KEY_RTL_TCP_CLIENT_LAST_ROLE] =
                     serde_json::to_value(fav_role).unwrap_or(serde_json::Value::Null);
             });
+            // Tier 2: per-favorite override. Compute the current
+            // `host:port` key; if it matches a favorite, update
+            // that favorite's `requested_role` and persist. No-op
+            // when the server isn't favorited (the global default
+            // above covers it).
+            let host = hostname_for_role.text().to_string();
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let port = port_for_role.value() as u16;
+            if host.is_empty() || port == 0 {
+                return;
+            }
+            let server_key = format!("{host}:{port}");
+            let mut favorites = load_favorites(&config_for_role);
+            let mut dirty = false;
+            for fav in &mut favorites {
+                if fav.key == server_key && fav.requested_role != Some(fav_role) {
+                    fav.requested_role = Some(fav_role);
+                    dirty = true;
+                    break;
+                }
+            }
+            if dirty {
+                save_favorites(&config_for_role, &favorites);
+            }
         });
 
     // Server key entry (#394 + #396). On every edit we rebuild

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,24 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 17
+#define SDR_CORE_ABI_VERSION_MINOR 18
 /*
+ * 0.18 — adds three new discriminants to
+ * `SdrRtlTcpConnectionStateKind`:
+ *   - SDR_RTL_TCP_STATE_CONTROLLER_BUSY  = 5
+ *   - SDR_RTL_TCP_STATE_AUTH_REQUIRED    = 6
+ *   - SDR_RTL_TCP_STATE_AUTH_FAILED      = 7
+ * These are terminal role-denial states surfaced by the
+ * client after #396's connection-manager rework: the
+ * manager no longer auto-retries on these conditions (user
+ * must pick a role / enter a key / click reconnect). Host
+ * UIs should branch on the new discriminants to show the
+ * appropriate toast + action buttons instead of the generic
+ * FAILED handler. Discriminant additions are
+ * ABI-incompatible for hosts that switch on the enum
+ * without a default arm, so the minor bump forces the
+ * exact-match pre-1.0 ABI check to fail on 0.17 consumers.
+ *
  * 0.17 — adds `auth_key` (pointer to raw bytes) and
  * `auth_key_len` (u32) to the tail of `SdrRtlTcpServerConfig`
  * so FFI hosts can enable pre-shared-key auth (#394) at
@@ -1563,11 +1579,20 @@ typedef enum SdrEventKind {
  * `SdrEventRtlTcpConnectionState` below. Stable — never reorder.
  */
 typedef enum SdrRtlTcpConnectionStateKind {
-    SDR_RTL_TCP_STATE_DISCONNECTED = 0,
-    SDR_RTL_TCP_STATE_CONNECTING   = 1,
-    SDR_RTL_TCP_STATE_CONNECTED    = 2,
-    SDR_RTL_TCP_STATE_RETRYING     = 3,
-    SDR_RTL_TCP_STATE_FAILED       = 4,
+    SDR_RTL_TCP_STATE_DISCONNECTED     = 0,
+    SDR_RTL_TCP_STATE_CONNECTING       = 1,
+    SDR_RTL_TCP_STATE_CONNECTED        = 2,
+    SDR_RTL_TCP_STATE_RETRYING         = 3,
+    SDR_RTL_TCP_STATE_FAILED           = 4,
+    /* Role-denial terminal states (ABI 0.18, per #396). Hosts
+     * should surface these distinctly from the generic FAILED
+     * path — the client does not auto-retry while any of these
+     * states is active; the user must pick a role / enter a key
+     * / click a reconnect button.
+     */
+    SDR_RTL_TCP_STATE_CONTROLLER_BUSY  = 5,
+    SDR_RTL_TCP_STATE_AUTH_REQUIRED    = 6,
+    SDR_RTL_TCP_STATE_AUTH_FAILED      = 7,
 } SdrRtlTcpConnectionStateKind;
 
 /* Discriminants for the `kind` field of `SdrEventNetworkSinkStatus`
@@ -1662,9 +1687,12 @@ typedef struct SdrEventNetworkSinkStatus {
  * | SDR_RTL_TCP_STATE_CONNECTED       | tuner name     | 0       | 0.0           | gain steps |
  * | SDR_RTL_TCP_STATE_RETRYING        | NULL           | attempt | seconds       | 0          |
  * | SDR_RTL_TCP_STATE_FAILED          | reason         | 0       | 0.0           | 0          |
+ * | SDR_RTL_TCP_STATE_CONTROLLER_BUSY | NULL           | 0       | 0.0           | 0          |
+ * | SDR_RTL_TCP_STATE_AUTH_REQUIRED   | NULL           | 0       | 0.0           | 0          |
+ * | SDR_RTL_TCP_STATE_AUTH_FAILED     | NULL           | 0       | 0.0           | 0          |
  *
  * `utf8` is borrowed from dispatcher-owned storage; valid only
- * for the duration of the callback. Per issue #325.
+ * for the duration of the callback. Per issue #325 + #396.
  */
 typedef struct SdrEventRtlTcpConnectionState {
     int32_t     kind;


### PR DESCRIPTION
## Summary

Closes #396 — sixth sub-issue of multi-client epic #390. Wires the client-side UI for the features shipped across #391-#395: role picker (Control / Listen), Server key entry with keyring auto-save, distinct toast flows for the three role-denial server responses, and a status-bar role badge.

8 implementation commits. No wire/protocol changes — the backend surface was already there from PRs #402-#406. ABI bump 0.17 → 0.18 for three new `SdrRtlTcpConnectionStateKind` discriminants.

## Commits

1. **`8880464`** — `RtlTcpConfig.requested_role` field; wire through to `ClientHello.role` byte; `extension_enabled` gate widens to include `requested_role != Control` so Listen opt-in alone trips the hello. 2 new tests.
2. **`e8d584d`** — 3 new terminal variants on `RtlTcpConnectionState` (`ControllerBusy` / `AuthRequired` / `AuthFailed`); `needs_user_action()` helper; short actionable subtitles in `format_rtl_tcp_state`; retry-button sensitivity widened. ABI bump 0.17 → 0.18 with matching `SDR_RTL_TCP_STATE_*` discriminants in `sdr_core.h`.
3. **`d5e61e5`** — 3 new `SourceError` variants (`ControllerBusy`/`AuthRequired`/`AuthFailed`); connection manager routes each to the matching terminal state without retrying; matching wire → state mapping in `read_server_extension`. Tests renamed to pin the new routing; `rtlx_handshake_controller_busy_routes_to_dedicated_state` replaces the old `_is_transient_not_terminal` test.
4. **`70b7d57`** — per-server client keyring helpers: `rtl_tcp-client-auth-key-{host}:{port}` entries, load/save/clear functions with lenient `None`-on-corrupt semantics.
5. **`5f0e18e`** — `FavoriteEntry.requested_role: Option<FavoriteRole>` + `auth_required: Option<bool>` fields. New `FavoriteRole` enum with `snake_case` serde + wire-role converter helpers. Round-trip test extended.
6. **`744e163`** — Role picker combo + Server key `AdwPasswordEntryRow` in the source panel. New `UiToDsp::SetRtlTcpClientConfig { requested_role, auth_key }` message; controller threads both into `RtlTcpSource::with_config` in `open_source`. Persists last-used role to `rtl_tcp_client_last_role` config; keyring handles the per-server key bytes.
7. **`66a3d30`** — toast flows. `handle_rtl_tcp_state_toast` helper fires on EDGE transitions only (via `AppState.last_rtl_tcp_state_disc: Cell<u8>`). `ControllerBusy` → two toasts ("Take control" + "Connect as Listener"); `AuthRequired`/`AuthFailed` → reveal + focus key entry with distinct copy; `Connected` from auth-required edge → auto-save key to per-server keyring. New `UiToDsp::RetryRtlTcpWithTakeover` for the one-shot takeover path.
8. **`d084e5e`** — status-bar role badge: "Controller" (accent CSS) / "Listener" (dim-label CSS), hidden on non-Connected states. Matches PR #406's server-side role badges visually.

## Design

**Terminal vs. transient.** ControllerBusy used to route via `SourceError::TemporarilyUnavailable` with silent auto-retry — that hid the decision point. Per #396, it's now a dedicated terminal state so the UI gets to offer the user explicit "Take control" / "Listen" actions instead of grinding backoff in the background.

**Per-server keyring keys** matching the `FavoriteEntry.key` identity (`host:port`) so a server rename / nickname change doesn't invalidate saved keys. Shares the `sdr-rs` keyring service with RadioReference creds and the local server's own key; prefix `rtl_tcp-client-auth-key-` keeps the entries distinguishable.

**Single-source pending key.** `ensure_server_auth_key()` / `load_client_auth_key_from_keyring()` are called once per flow; the result lives on `AppState` / `current_auth_key` and is threaded into `build_server_config_from_panel` as a parameter. No second keyring read on the Play path so a transient keyring hiccup can't desync UI-displayed bytes from what `Server::start` receives.

**Error-gated UI mutation.** The toast handler updates UI state (visibility, focus, subtitles) AFTER confirming the state transition; invalid hex or empty-entry cases skip the save path with a warn log rather than advancing the UI into an inconsistent state.

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean (verified)
- [ ] `cargo test --workspace` — 48 test groups, all green (verified)
- [ ] `make install CARGO_FLAGS="--release --features whisper-cuda"` — built + installed
- [ ] Connect to a free server as Control → status row reads "Connected", status bar badge shows "Controller" (accent)
- [ ] Switch role to Listen → reconnect → status bar badge flips to "Listener" (dim)
- [ ] Connect while another client holds Control → ControllerBusy toast appears with "Take control" button → clicking takes over → old client gets kicked
- [ ] Same scenario, click "Connect as Listener" instead → combo flips to Listen, reconnect succeeds with Listener admission
- [ ] Connect to an auth-required server without a saved key → AuthRequired toast + key field reveals + focuses → enter key → reconnect → key saved to keyring → next session's reconnect auto-uses it
- [ ] Connect with a stale saved key → AuthFailed toast + field clears → enter new key → reconnect succeeds → keyring updates
- [ ] Regenerate the server's key (via #395 server UI) while a client has it saved → client's next reconnect hits AuthFailed → user re-enters → keyring updates to new key

## Remaining epic #390 sub-issues

- **#397** — FIPS-compliant transport encryption (investigation)

## Deferred

- **Kicked toast** when the user's Control session gets displaced by another client's takeover. Requires tracking granted role across the Connected → Retrying transition AND distinguishing user-initiated stops from server-side drops. Follow-up commit during CR review if called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RTL‑TCP role selector (Control/Listen), status‑bar role badge, hidden per‑server auth‑key entry with keyring save/load/clear
  * UI commands to set per‑server RTL‑TCP role/auth (applies on next connect) and one‑shot “Retry with takeover” reconnect
  * Sticky snapshot/restore to preserve tuning and replayed command state across reconnects

* **Improvements**
  * Server‑admitted role propagation and granted‑role display logic; new terminal states with explicit subtitles/toasts for ControllerBusy, AuthRequired, AuthFailed
  * Favorites now persist role/auth info (with legacy upgrade) and prefill on connect; retry enablement respects user‑action needs

* **Chores**
  * FFI/ABI minor version bumped; new RTL‑TCP state discriminants added

* **Tests**
  * Added/updated coverage for new states, messages, favorites serde, keyring, and snapshot/restore
<!-- end of auto-generated comment: release notes by coderabbit.ai -->