### PR TITLE
quick-wins batch: #407 gain-mode + #157 antenna calc + #337 tracing + #400 FFI codec-mask

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -920,7 +920,25 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::SetVfoOffset(offset) => {
-            tracing::debug!(offset_hz = offset, "set VFO offset");
+            // Expanded tracing for the #337 click-to-tune-no-audio
+            // investigation: the #337 hypotheses point at a
+            // display-span vs. VFO-input-sample-rate mismatch
+            // (decim > 1) and/or clicks landing outside the AA-
+            // filter-safe subset, so surface BOTH rates + whether
+            // the VFO chain exists so the next smoke-test trace
+            // shows the offset's relationship to the filterable
+            // range at a glance.
+            let raw_rate = state.frontend.sample_rate();
+            let effective_rate = state.frontend.effective_sample_rate();
+            let vfo_exists = state.vfo.is_some();
+            tracing::debug!(
+                offset_hz = offset,
+                raw_sample_rate_hz = raw_rate,
+                effective_sample_rate_hz = effective_rate,
+                offset_within_effective = offset.abs() < effective_rate / 2.0,
+                vfo_exists,
+                "set VFO offset"
+            );
             state.vfo_offset = offset;
             if let Some(vfo) = &mut state.vfo {
                 vfo.set_offset(offset);

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 18;
+pub const ABI_VERSION_MINOR: u32 = 19;
 
 /// Return the ABI version the library was built with.
 ///
@@ -334,7 +334,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 18);
+        assert!(ABI_VERSION_MINOR == 19);
     };
 
     #[test]

--- a/crates/sdr-ffi/src/rtltcp_discovery.rs
+++ b/crates/sdr-ffi/src/rtltcp_discovery.rs
@@ -66,6 +66,32 @@ pub struct SdrRtlTcpAdvertiseOptions {
     pub has_txbuf: bool,
     /// TXT: optional buffer-depth hint in bytes.
     pub txbuf: u64,
+    /// Whether [`Self::codecs`] below is meaningful. `false` (the
+    /// zero-init default) publishes the TXT record with NO
+    /// `codecs=` key, which every browser then treats as
+    /// "legacy-only" — identical to pre-#400 behaviour. Added in
+    /// ABI 0.19 per issue #400.
+    pub has_codecs: bool,
+    /// TXT: compression-mask wire byte. Only used when
+    /// [`Self::has_codecs`] is `true`. Value is a [`CodecMask::
+    /// to_wire`] byte — bit 0 = `None` codec, bit 1 = `LZ4`, etc.
+    /// Typical values: `0x01` = `None`-only (legacy-safe),
+    /// `0x03` = `None + LZ4` (signals the server speaks the
+    /// extended handshake and accepts compression hellos).
+    pub codecs: u8,
+    /// Whether [`Self::auth_required`] below is meaningful.
+    /// `false` (zero-init default) publishes no `auth_required=`
+    /// key — per #395's "omit on false" contract, mDNS browsers
+    /// treat absence as "no auth required." Added in ABI 0.19
+    /// per issue #400.
+    pub has_auth_required: bool,
+    /// TXT: whether the server requires a pre-shared key (#394).
+    /// Only used when [`Self::has_auth_required`] is `true`. The
+    /// FFI advertiser is decoupled from the FFI server (hosts
+    /// publish this independently of [`sdr_rtltcp_server_start`]),
+    /// so it's the caller's responsibility to keep the flag in
+    /// sync with its `ServerConfig.auth_key` state.
+    pub auth_required: bool,
 }
 
 pub struct SdrRtlTcpAdvertiser {
@@ -162,6 +188,22 @@ pub unsafe extern "C" fn sdr_rtltcp_advertiser_start(
             None
         };
 
+        // `codecs` + `auth_required` project from the
+        // `has_*` gates per #400. Zero-init defaults
+        // (`has_codecs = has_auth_required = false`) yield the
+        // same "omit from TXT" behaviour as pre-ABI-0.19, so
+        // hosts that haven't updated their init still publish
+        // legacy-compatible records.
+        let codecs = if opts.has_codecs {
+            Some(opts.codecs)
+        } else {
+            None
+        };
+        let auth_required = if opts.has_auth_required {
+            Some(opts.auth_required)
+        } else {
+            None
+        };
         let options = AdvertiseOptions {
             port: opts.port,
             instance_name,
@@ -172,23 +214,8 @@ pub unsafe extern "C" fn sdr_rtltcp_advertiser_start(
                 gains: opts.gains,
                 nickname,
                 txbuf,
-                // C ABI host has no codec picker yet — advertise
-                // "unknown / legacy" so vanilla clients keep
-                // working unchanged. Issue #400 tracks extending
-                // `SdrRtlTcpAdvertiseOptions` with `has_codecs` +
-                // `codecs` fields so the Swift macOS app can
-                // advertise compression capability.
-                codecs: None,
-                // `auth_required` publishes via the same FFI
-                // extension as `codecs` when the Swift host wires
-                // up its own advertiser config. Today the FFI
-                // advertiser is decoupled from the FFI server
-                // (Swift publishes advertise options separately),
-                // so default to `None` — downstream mDNS browsers
-                // treat absence as "no auth required" per #395's
-                // omit-on-false contract. Issue #400 covers
-                // extending this struct.
-                auth_required: None,
+                codecs,
+                auth_required,
             },
         };
 
@@ -706,6 +733,14 @@ mod tests {
                 nickname: std::ptr::null(),
                 has_txbuf: false,
                 txbuf: 0,
+                // ABI 0.19 defaults — zero-init equivalent so the
+                // base fixture matches pre-#400 behaviour. Tests
+                // that exercise the new fields mutate these after
+                // `happy_path()` returns.
+                has_codecs: false,
+                codecs: 0,
+                has_auth_required: false,
+                auth_required: false,
             };
             Self {
                 _instance: instance,

--- a/crates/sdr-ffi/src/rtltcp_discovery.rs
+++ b/crates/sdr-ffi/src/rtltcp_discovery.rs
@@ -942,8 +942,15 @@ mod tests {
         // to `(true, v)`; `None` projects to `(false, 0 /
         // false)`. Pin both directions so a future parser change
         // that silently drops TXT capability bits fails here.
+        //
+        // `TEST_CODEC_MASK_NONE_AND_LZ4` names the `0x03` wire
+        // byte (None + LZ4 bits) per the project's
+        // "no-magic-numbers" rule. Per `CodeRabbit` round 2 on
+        // PR #418.
+        const TEST_CODEC_MASK_NONE_AND_LZ4: u8 = 0x03;
+
         let mut strings: Vec<CString> = Vec::new();
-        // Present: codecs = 0x03 (None+LZ4), auth_required = true.
+        // Present: None+LZ4 codecs + auth required.
         let present = DiscoveredServer {
             instance_name: format!("{TEST_INSTANCE_NAME}._rtl_tcp._tcp.local."),
             hostname: "test.local.".into(),
@@ -955,14 +962,14 @@ mod tests {
                 gains: TEST_GAIN_COUNT,
                 nickname: String::new(),
                 txbuf: None,
-                codecs: Some(0x03),
+                codecs: Some(TEST_CODEC_MASK_NONE_AND_LZ4),
                 auth_required: Some(true),
             },
             last_seen: Instant::now(),
         };
         let projected = discovered_server_to_c(&present, &mut strings);
         assert!(projected.has_codecs);
-        assert_eq!(projected.codecs, 0x03);
+        assert_eq!(projected.codecs, TEST_CODEC_MASK_NONE_AND_LZ4);
         assert!(projected.has_auth_required);
         assert!(projected.auth_required);
 

--- a/crates/sdr-ffi/src/rtltcp_discovery.rs
+++ b/crates/sdr-ffi/src/rtltcp_discovery.rs
@@ -199,8 +199,13 @@ pub unsafe extern "C" fn sdr_rtltcp_advertiser_start(
         } else {
             None
         };
-        let auth_required = if opts.has_auth_required {
-            Some(opts.auth_required)
+        // `auth_required` MUST be `Some(true)` or `None` only —
+        // never `Some(false)`. The #395 mDNS contract is "omit on
+        // false" so clients that gate on key presence don't
+        // misclassify an explicitly-no-auth server as
+        // auth-capable. Per `CodeRabbit` round 1 on PR #418.
+        let auth_required = if opts.has_auth_required && opts.auth_required {
+            Some(true)
         } else {
             None
         };
@@ -314,6 +319,23 @@ pub struct SdrRtlTcpDiscoveredServer {
     pub txbuf: u64,
     /// Seconds since the last ServiceResolved for this entry.
     pub last_seen_secs_ago: f64,
+    /// Whether [`Self::codecs`] below carries meaningful data from
+    /// the server's TXT record. `false` = server didn't advertise
+    /// a `codecs=` key (legacy rtl_tcp or pre-ABI-0.19 sdr-rs
+    /// server). ABI 0.19 per #400 / `CodeRabbit` round 1 on
+    /// PR #418.
+    pub has_codecs: bool,
+    /// TXT: advertised compression-mask wire byte. Typical values:
+    /// `0x01` = `None`-only (legacy-safe), `0x03` = `None + LZ4`
+    /// (server accepts compression hellos).
+    pub codecs: u8,
+    /// Whether [`Self::auth_required`] below carries meaningful
+    /// data. `false` = absent from TXT.
+    pub has_auth_required: bool,
+    /// TXT: whether the server requires a pre-shared key for
+    /// handshakes (#394). Only meaningful when
+    /// [`Self::has_auth_required`] is `true`.
+    pub auth_required: bool,
 }
 
 /// Tagged discovery event the browser dispatches.
@@ -572,6 +594,21 @@ fn discovered_server_to_c(
         None => (false, 0),
     };
 
+    // ABI 0.19 (#400): project the same `Option<...>` → `has_*` +
+    // value pair shape as `txbuf` above so callers who check
+    // `has_codecs=false` / `has_auth_required=false` see a clean
+    // "absent from TXT" signal regardless of whatever stale bytes
+    // happen to live in the value field. Per `CodeRabbit` round 1
+    // on PR #418.
+    let (has_codecs, codecs) = match server.txt.codecs {
+        Some(v) => (true, v),
+        None => (false, 0),
+    };
+    let (has_auth_required, auth_required) = match server.txt.auth_required {
+        Some(v) => (true, v),
+        None => (false, false),
+    };
+
     SdrRtlTcpDiscoveredServer {
         instance_name: push(&server.instance_name, strings),
         hostname: push(&server.hostname, strings),
@@ -585,6 +622,10 @@ fn discovered_server_to_c(
         has_txbuf,
         txbuf,
         last_seen_secs_ago,
+        has_codecs,
+        codecs,
+        has_auth_required,
+        auth_required,
     }
 }
 
@@ -602,6 +643,12 @@ fn zeroed_discovered_server() -> SdrRtlTcpDiscoveredServer {
         has_txbuf: false,
         txbuf: 0,
         last_seen_secs_ago: 0.0,
+        // ABI 0.19 defaults — zero-init to match the "absent from
+        // TXT" signal.
+        has_codecs: false,
+        codecs: 0,
+        has_auth_required: false,
+        auth_required: false,
     }
 }
 
@@ -882,6 +929,65 @@ mod tests {
         assert_eq!(z.port, 0);
         assert_eq!(z.gains, 0);
         assert!(!z.has_txbuf);
+        // ABI 0.19 (#400) — the new capability-field gates must
+        // default to `false` too so "absent from TXT" is the
+        // zero-init semantic.
+        assert!(!z.has_codecs);
+        assert!(!z.has_auth_required);
+    }
+
+    #[test]
+    fn discovered_server_to_c_projects_codecs_and_auth_required() {
+        // ABI 0.19 contract: `Some(v)` on the Rust side projects
+        // to `(true, v)`; `None` projects to `(false, 0 /
+        // false)`. Pin both directions so a future parser change
+        // that silently drops TXT capability bits fails here.
+        let mut strings: Vec<CString> = Vec::new();
+        // Present: codecs = 0x03 (None+LZ4), auth_required = true.
+        let present = DiscoveredServer {
+            instance_name: format!("{TEST_INSTANCE_NAME}._rtl_tcp._tcp.local."),
+            hostname: "test.local.".into(),
+            port: TEST_PORT,
+            addresses: vec![],
+            txt: TxtRecord {
+                tuner: TEST_TUNER.into(),
+                version: TEST_VERSION.into(),
+                gains: TEST_GAIN_COUNT,
+                nickname: String::new(),
+                txbuf: None,
+                codecs: Some(0x03),
+                auth_required: Some(true),
+            },
+            last_seen: Instant::now(),
+        };
+        let projected = discovered_server_to_c(&present, &mut strings);
+        assert!(projected.has_codecs);
+        assert_eq!(projected.codecs, 0x03);
+        assert!(projected.has_auth_required);
+        assert!(projected.auth_required);
+
+        // Absent: neither TXT key present.
+        let absent = DiscoveredServer {
+            instance_name: format!("{TEST_INSTANCE_NAME}._rtl_tcp._tcp.local."),
+            hostname: "test.local.".into(),
+            port: TEST_PORT,
+            addresses: vec![],
+            txt: TxtRecord {
+                tuner: TEST_TUNER.into(),
+                version: TEST_VERSION.into(),
+                gains: TEST_GAIN_COUNT,
+                nickname: String::new(),
+                txbuf: None,
+                codecs: None,
+                auth_required: None,
+            },
+            last_seen: Instant::now(),
+        };
+        let projected = discovered_server_to_c(&absent, &mut strings);
+        assert!(!projected.has_codecs);
+        assert_eq!(projected.codecs, 0);
+        assert!(!projected.has_auth_required);
+        assert!(!projected.auth_required);
     }
 
     /// Build a `DiscoveredServer` with the TXT fields wired to

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -110,6 +110,23 @@ pub struct SdrRtlTcpServerConfig {
     /// doc for valid range and semantics. Must be 0 iff
     /// `auth_key` is NULL.
     pub auth_key_len: u32,
+    /// Whether [`Self::compression`] below is meaningful. `false`
+    /// (the zero-init default) runs the server with
+    /// [`CodecMask::NONE_ONLY`] — legacy clients negotiate with
+    /// no compression, identical to pre-#400 behaviour. Added in
+    /// ABI 0.19 per issue #400.
+    pub has_compression: bool,
+    /// Compression-mask wire byte. Only used when
+    /// [`Self::has_compression`] is `true`. Value is a
+    /// [`CodecMask::to_wire`] byte. Typical values: `0x01` =
+    /// `None`-only, `0x03` = `None + LZ4` (accept LZ4
+    /// compression hellos + fall back to `None` for vanilla
+    /// clients). Must match the codecs the host is willing to
+    /// advertise via [`SdrRtlTcpAdvertiseOptions::codecs`] on
+    /// mDNS — those two have to stay in sync or clients see
+    /// "server advertises LZ4" but hit a `None`-only negotiation
+    /// at handshake time.
+    pub compression: u8,
 }
 
 /// Aggregate server-lifetime statistics snapshot.
@@ -558,17 +575,25 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
                 return SdrCoreError::InvalidArg.as_int();
             }
         };
+        // `compression` projects from the `has_compression` gate
+        // per #400 / ABI 0.19. Zero-init callers
+        // (`has_compression = false`) stay on `CodecMask::NONE_
+        // ONLY`, matching pre-#400 behaviour. A host that wants
+        // LZ4 sets `has_compression = true; compression = 0x03`
+        // and MUST also flip the matching bits on
+        // `SdrRtlTcpAdvertiseOptions.codecs` via mDNS so clients
+        // know the server accepts compression hellos.
+        let compression = if cfg.has_compression {
+            CodecMask::from_wire(cfg.compression)
+        } else {
+            CodecMask::NONE_ONLY
+        };
         let server_cfg = ServerConfig {
             bind,
             device_index: cfg.device_index,
             initial,
             buffer_capacity,
-            // Compression stays off for the C ABI until the host
-            // adds a codec-mask field to `SdrRtlTcpServerConfig`
-            // (issue #400 tracks extending the C struct). Vanilla
-            // clients keep working; the Linux GTK path is the only
-            // one that currently offers LZ4.
-            compression: CodecMask::NONE_ONLY,
+            compression,
             listener_cap,
             auth_key,
         };
@@ -1213,6 +1238,12 @@ mod tests {
             // the struct docs.
             auth_key: std::ptr::null(),
             auth_key_len: 0,
+            // ABI 0.19 defaults — zero-init equivalent so the base
+            // fixture matches pre-#400 behaviour. Tests that
+            // exercise the new compression mask mutate these after
+            // `base_test_config()` returns.
+            has_compression: false,
+            compression: 0,
         }
     }
 
@@ -1408,6 +1439,8 @@ mod tests {
             listener_cap: 0,
             auth_key: std::ptr::null(),
             auth_key_len: 0,
+            has_compression: false,
+            compression: 0,
         };
         let mut handle: *mut SdrRtlTcpServer = std::ptr::null_mut();
         let rc = unsafe { sdr_rtltcp_server_start(&raw const opts, &raw mut handle) };

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -1309,6 +1309,19 @@ mod tests {
         assert_eq!(listener_cap_from_c(7), 7);
     }
 
+    /// Wire byte for `CodecMask::NONE_ONLY` — pinned here so the
+    /// tests name the protocol value rather than lean on a raw
+    /// hex literal. Matches `CodecMask::NONE_ONLY.to_wire()` by
+    /// construction; if that ever drifts, both this constant
+    /// and the non-test `CodecMask::NONE_ONLY` bits would need
+    /// to shift in lockstep. Per `CodeRabbit` round 2 on
+    /// PR #418.
+    const TEST_CODEC_MASK_NONE_ONLY_WIRE: u8 = 0x01;
+    /// Wire byte for `CodecMask::NONE_AND_LZ4` — None bit +
+    /// LZ4 bit. Same pinning rationale as
+    /// [`TEST_CODEC_MASK_NONE_ONLY_WIRE`].
+    const TEST_CODEC_MASK_NONE_AND_LZ4_WIRE: u8 = 0x03;
+
     #[test]
     fn compression_from_c_zero_init_is_none_only() {
         // ABI 0.19 default: `has_compression = false` + any
@@ -1318,16 +1331,25 @@ mod tests {
         // to prove the `compression` field is ignored when the
         // gate is false.
         assert_eq!(compression_from_c(false, 0), CodecMask::NONE_ONLY);
-        assert_eq!(compression_from_c(false, 0x03), CodecMask::NONE_ONLY);
+        assert_eq!(
+            compression_from_c(false, TEST_CODEC_MASK_NONE_AND_LZ4_WIRE),
+            CodecMask::NONE_ONLY
+        );
     }
 
     #[test]
     fn compression_from_c_opt_in_passes_raw_wire_byte() {
         // `has_compression = true` → `CodecMask::from_wire(byte)`.
-        // Verify both a `None-only` (0x01) round-trip and a
-        // `None + LZ4` (0x03) round-trip.
-        assert_eq!(compression_from_c(true, 0x01), CodecMask::NONE_ONLY);
-        assert_eq!(compression_from_c(true, 0x03), CodecMask::NONE_AND_LZ4);
+        // Verify both a `None-only` round-trip and a
+        // `None + LZ4` round-trip.
+        assert_eq!(
+            compression_from_c(true, TEST_CODEC_MASK_NONE_ONLY_WIRE),
+            CodecMask::NONE_ONLY
+        );
+        assert_eq!(
+            compression_from_c(true, TEST_CODEC_MASK_NONE_AND_LZ4_WIRE),
+            CodecMask::NONE_AND_LZ4
+        );
     }
 
     #[test]

--- a/crates/sdr-ffi/src/rtltcp_server.rs
+++ b/crates/sdr-ffi/src/rtltcp_server.rs
@@ -451,6 +451,28 @@ fn listener_cap_from_c(listener_cap: u32) -> usize {
     }
 }
 
+/// Translate the C-ABI `has_compression` / `compression` pair
+/// into the Rust `ServerConfig::compression` `CodecMask`. The
+/// `has_*` gate is the zero-init-safe opt-in pattern (same as
+/// `has_txbuf` / `has_codecs` on [`SdrRtlTcpAdvertiseOptions`]):
+///
+/// - `has_compression = false` → `CodecMask::NONE_ONLY`, matching
+///   the pre-ABI-0.19 hardcoded behaviour.
+/// - `has_compression = true` → `CodecMask::from_wire(compression)`.
+///
+/// Extracted into its own helper (rather than inlined in
+/// `sdr_rtltcp_server_start`) so the ABI translation path is
+/// unit-testable without the hardware-backed start call.
+/// Matches the [`listener_cap_from_c`] / [`auth_key_from_c`]
+/// shape. Per `CodeRabbit` round 1 on PR #418, issue #400.
+fn compression_from_c(has_compression: bool, compression: u8) -> CodecMask {
+    if has_compression {
+        CodecMask::from_wire(compression)
+    } else {
+        CodecMask::NONE_ONLY
+    }
+}
+
 /// Outcome of [`auth_key_from_c`] — either the server should run
 /// without auth (`None` input, or `Some` with valid length) or
 /// the caller gave a bad pointer/length pair and
@@ -576,18 +598,11 @@ pub unsafe extern "C" fn sdr_rtltcp_server_start(
             }
         };
         // `compression` projects from the `has_compression` gate
-        // per #400 / ABI 0.19. Zero-init callers
-        // (`has_compression = false`) stay on `CodecMask::NONE_
-        // ONLY`, matching pre-#400 behaviour. A host that wants
-        // LZ4 sets `has_compression = true; compression = 0x03`
-        // and MUST also flip the matching bits on
-        // `SdrRtlTcpAdvertiseOptions.codecs` via mDNS so clients
-        // know the server accepts compression hellos.
-        let compression = if cfg.has_compression {
-            CodecMask::from_wire(cfg.compression)
-        } else {
-            CodecMask::NONE_ONLY
-        };
+        // per #400 / ABI 0.19. See [`compression_from_c`] for the
+        // full contract (zero-init default = `NONE_ONLY`,
+        // opt-in = `from_wire`). Extracted into the helper so
+        // the ABI promise has unit-test coverage.
+        let compression = compression_from_c(cfg.has_compression, cfg.compression);
         let server_cfg = ServerConfig {
             bind,
             device_index: cfg.device_index,
@@ -1292,6 +1307,27 @@ mod tests {
         // off-by-one that would have passed `listener_cap_from_c(1)
         // == 1` trivially.
         assert_eq!(listener_cap_from_c(7), 7);
+    }
+
+    #[test]
+    fn compression_from_c_zero_init_is_none_only() {
+        // ABI 0.19 default: `has_compression = false` + any
+        // `compression` byte → `NONE_ONLY`. This is the "pre-0.19
+        // caller with a zero-init struct stays on the legacy
+        // path" contract. Check both 0 and a non-zero raw byte
+        // to prove the `compression` field is ignored when the
+        // gate is false.
+        assert_eq!(compression_from_c(false, 0), CodecMask::NONE_ONLY);
+        assert_eq!(compression_from_c(false, 0x03), CodecMask::NONE_ONLY);
+    }
+
+    #[test]
+    fn compression_from_c_opt_in_passes_raw_wire_byte() {
+        // `has_compression = true` → `CodecMask::from_wire(byte)`.
+        // Verify both a `None-only` (0x01) round-trip and a
+        // `None + LZ4` (0x03) round-trip.
+        assert_eq!(compression_from_c(true, 0x01), CodecMask::NONE_ONLY);
+        assert_eq!(compression_from_c(true, 0x03), CodecMask::NONE_AND_LZ4);
     }
 
     #[test]

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -175,6 +175,16 @@ impl Source for RtlSdrSource {
     }
 
     fn start(&mut self) -> Result<(), SourceError> {
+        // R820T supports 29.7 dB exactly (gain-table index 17).
+        // See the supported-gains list in
+        // `crates/sdr-rtlsdr/src/tuner/r82xx/mod.rs` if porting
+        // to a different tuner family (E4000 / FC0012 / FC0013
+        // / FC2580 have different step tables; the post-open
+        // default-gain call below would need to be tuner-
+        // adaptive then. Per issue #407 + PR #418 smoke test
+        // feedback ("AGC off by default").
+        const DEFAULT_TUNER_GAIN_TENTHS_DB: i32 = 297;
+
         let mut device = RtlSdrDevice::open(self.device_index)
             .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
 
@@ -190,26 +200,52 @@ impl Source for RtlSdrSource {
             .reset_buffer()
             .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
 
-        // Belt-and-suspenders: force auto gain mode so the tuner
-        // produces signal regardless of whatever state a prior
-        // session's deinit left it in. Matches upstream
-        // `rtl_test.c` / `rtl_tcp.c` reference programs, which
-        // always call `rtlsdr_set_tuner_gain_mode(dev, 0)`
-        // immediately after open. Without this, a dongle that
-        // was left in an edge-case state (e.g. an app crash mid-
-        // session that didn't run the R820T deinit sequence) can
-        // come back with the LNA at a manual zero-gain index and
-        // stream nothing until the user physically reseats the
-        // USB. The UI's `SetAgc` / `SetGain` message flow
-        // re-applies the user's actual preferences immediately
-        // after the source becomes visible to the controller;
-        // this call just guarantees the first few seconds of the
-        // session produce data. Per issue #407 (hit during PR
-        // #406 smoke test — reseating the dongle was the only
-        // workaround at the time).
+        // Belt-and-suspenders: explicitly put the tuner into a
+        // known manual-gain state so the first Play produces
+        // signal regardless of whatever state a prior session
+        // left the device in. Pre-#407 no post-open gain setup
+        // ran at all, which let a USB-reseat-needing edge case
+        // slip through (dongle left in a bad state streamed
+        // zero bytes until physically reseated — seen during
+        // the PR #406 smoke test).
+        //
+        // **Gain mode: manual (AGC off) by default.** User
+        // preference is AGC off — mirrors SDR++ / GQRX's
+        // default for scanner / FM reception where a fixed gain
+        // is easier to reason about than an auto-ranging loop.
+        // The UI's `SetAgc(true)` dispatch re-enables auto mode
+        // immediately after the source is visible to the
+        // controller, so users who save "AGC on" still get
+        // their saved preference within one controller tick.
+        //
+        // **Gain value: mid-range default.** `set_gain_mode(true)`
+        // writes LNA-auto-off + mixer-auto-off + VGA 16.3 dB to
+        // the R820T regs, leaving the LNA and mixer at whatever
+        // index the `R82XX_INIT_ARRAY` post-init sequence left
+        // behind (LNA index 3 is common — low but non-zero).
+        // Explicitly set a mid-range tuner gain (29.7 dB, index
+        // 17 of 29 for R820T) on top of that so fresh-install
+        // users hear signal on the first Play without having to
+        // touch the gain slider. UI `SetGain` dispatch overrides
+        // this with the saved preference a moment later.
+        //
+        // Per issue #407 + user feedback on PR #418 smoke test
+        // ("AGC should default to off").
         device
-            .set_tuner_gain_mode(false)
+            .set_tuner_gain_mode(true)
             .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
+        if let Err(e) = device.set_tuner_gain(DEFAULT_TUNER_GAIN_TENTHS_DB) {
+            // Non-fatal: the gain-mode write above already put
+            // the tuner in a valid manual state. If the
+            // mid-range default fails (unexpected tuner
+            // variant / I2C flake), log and carry on — the UI's
+            // `SetGain` dispatch takes over on the next
+            // controller tick.
+            tracing::warn!(
+                error = %e,
+                "RtlSdrSource::start: post-open set_tuner_gain default failed (non-fatal)"
+            );
+        }
 
         // Set running BEFORE spawning so the reader thread sees it immediately.
         self.running.store(true, Ordering::Release);

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -190,6 +190,27 @@ impl Source for RtlSdrSource {
             .reset_buffer()
             .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
 
+        // Belt-and-suspenders: force auto gain mode so the tuner
+        // produces signal regardless of whatever state a prior
+        // session's deinit left it in. Matches upstream
+        // `rtl_test.c` / `rtl_tcp.c` reference programs, which
+        // always call `rtlsdr_set_tuner_gain_mode(dev, 0)`
+        // immediately after open. Without this, a dongle that
+        // was left in an edge-case state (e.g. an app crash mid-
+        // session that didn't run the R820T deinit sequence) can
+        // come back with the LNA at a manual zero-gain index and
+        // stream nothing until the user physically reseats the
+        // USB. The UI's `SetAgc` / `SetGain` message flow
+        // re-applies the user's actual preferences immediately
+        // after the source becomes visible to the controller;
+        // this call just guarantees the first few seconds of the
+        // session produce data. Per issue #407 (hit during PR
+        // #406 smoke test — reseating the dongle was the only
+        // workaround at the time).
+        device
+            .set_tuner_gain_mode(false)
+            .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
+
         // Set running BEFORE spawning so the reader thread sees it immediately.
         self.running.store(true, Ordering::Release);
 

--- a/crates/sdr-ui/src/antenna.rs
+++ b/crates/sdr-ui/src/antenna.rs
@@ -47,6 +47,99 @@ const CM_PER_M: f64 = 100.0;
 /// rationale as [`CM_PER_M`].
 const MM_PER_M: f64 = 1_000.0;
 
+// ------------------------------------------------------------
+//  V-dipole angle suggestion
+//
+//  The V-angle between the two dipole arms tilts the radiation
+//  pattern upward as it narrows from 180° (straight dipole,
+//  peaks at horizon) toward 90° (peaks near zenith). The
+//  [`suggested_v_angle`] helper picks an angle based on what
+//  kind of signal typically lives at the current tuned
+//  frequency: sky-dominated signals (weather sats, amateur
+//  LEO birds) get a narrower V; horizon-dominated signals (FM
+//  broadcast, airband, repeaters, HF skip) get the straight
+//  dipole.
+//
+//  The V-angle tilts the pattern peak upward; a V of 120°
+//  puts the peak around 30° elevation — a reasonable middle-
+//  of-sky target for a typical polar-orbit satellite pass,
+//  which sweeps from horizon to zenith through roughly that
+//  elevation over half its track.
+//
+//  Companion to the 3D-printed V-dipole angle gauge at
+//  https://github.com/jasonherald/aentenna-measure which sets
+//  the angle in 5° detents.
+// ------------------------------------------------------------
+
+/// Suggested V-angle for a sky-dominated signal (sat pass). 120°
+/// peaks the V-dipole's elevation pattern around 30° above the
+/// horizon — approximately where a typical polar-orbit satellite
+/// pass spends most of its track.
+const V_ANGLE_SAT_DEGREES: u16 = 120;
+/// Suggested V-angle for a horizon-dominated signal. 180° is a
+/// straight dipole, peak gain at 0° elevation — optimal for FM
+/// broadcast, airband, terrestrial repeaters, and HF skip
+/// arrival angles.
+const V_ANGLE_HORIZON_DEGREES: u16 = 180;
+
+/// Short hint string displayed alongside a sky-band V-angle.
+/// Three-char so the status-bar line stays compact.
+const V_HINT_SAT: &str = "sat";
+/// Short hint string for horizon-band.
+const V_HINT_HORIZON: &str = "horizon";
+
+/// NOAA APT weather-satellite band (polar-orbit birds). Active
+/// discrete frequencies are 137.1 MHz (NOAA-18), 137.62 MHz
+/// (NOAA-19), and 137.9125 MHz (NOAA-15 / historical). The
+/// ±0.95 MHz window wraps all three plus the nearby sat-
+/// telemetry bumpers so a user tuned slightly off-centre
+/// still gets the satellite suggestion.
+const NOAA_APT_MIN_HZ: f64 = 137_000_000.0;
+const NOAA_APT_MAX_HZ: f64 = 137_950_000.0;
+
+/// 2 m amateur band (144–148 MHz). ISS voice + APRS + a stack
+/// of LEO amateur sats use this window.
+const BAND_2M_MIN_HZ: f64 = 144_000_000.0;
+const BAND_2M_MAX_HZ: f64 = 148_000_000.0;
+
+/// 70 cm amateur satellite sub-band (435–438 MHz). Most LEO
+/// amateur-radio satellites downlink here. The full ham 70cm
+/// allocation is wider (420–450 MHz in ITU Region 2) but the
+/// sat-specific segment is what we optimise for.
+const BAND_70CM_SAT_MIN_HZ: f64 = 435_000_000.0;
+const BAND_70CM_SAT_MAX_HZ: f64 = 438_000_000.0;
+
+/// 13 cm amateur band (2300–2450 MHz). Higher-frequency
+/// amateur satellites + some ISM co-habitate this range.
+/// We pick the sat-friendly subset.
+const BAND_13CM_MIN_HZ: f64 = 2_320_000_000.0;
+const BAND_13CM_MAX_HZ: f64 = 2_450_000_000.0;
+
+/// Suggested V-dipole angle for the current tuned frequency,
+/// paired with a short hint word describing WHERE the angle
+/// peaks the radiation pattern. Always returns a value for any
+/// frequency at or above [`MIN_RENDERABLE_FREQUENCY_HZ`] —
+/// callers gate on the enclosing line builder
+/// ([`format_antenna_line`]) which already handles the below-
+/// floor case.
+///
+/// **Band mapping is intentionally opinionated** — the exact
+/// boundaries will shift as the companion aentenna-measure
+/// gauge sees real-world use. Horizon (180°) is the legacy-safe
+/// default for anything outside the recognised sat bands.
+#[must_use]
+pub fn suggested_v_angle(freq_hz: f64) -> (u16, &'static str) {
+    let is_sat_band = (NOAA_APT_MIN_HZ..=NOAA_APT_MAX_HZ).contains(&freq_hz)
+        || (BAND_2M_MIN_HZ..=BAND_2M_MAX_HZ).contains(&freq_hz)
+        || (BAND_70CM_SAT_MIN_HZ..=BAND_70CM_SAT_MAX_HZ).contains(&freq_hz)
+        || (BAND_13CM_MIN_HZ..=BAND_13CM_MAX_HZ).contains(&freq_hz);
+    if is_sat_band {
+        (V_ANGLE_SAT_DEGREES, V_HINT_SAT)
+    } else {
+        (V_ANGLE_HORIZON_DEGREES, V_HINT_HORIZON)
+    }
+}
+
 /// Wavelength (metres) for a given frequency (Hz). Returns `None` when
 /// the input isn't a finite positive number or is below
 /// [`MIN_RENDERABLE_FREQUENCY_HZ`] — callers treat that as "don't render".
@@ -107,8 +200,9 @@ pub fn format_length_m(length_m: f64) -> String {
 pub fn format_antenna_line(freq_hz: f64) -> Option<String> {
     let half = half_wave_m(freq_hz)?;
     let quarter = quarter_wave_m(freq_hz)?;
+    let (angle, hint) = suggested_v_angle(freq_hz);
     Some(format!(
-        "λ/2 {} · λ/4 {}",
+        "λ/2 {} · λ/4 {} · V {angle}° {hint}",
         format_length_m(half),
         format_length_m(quarter)
     ))
@@ -158,10 +252,26 @@ mod tests {
     /// [`wavelength_m`] must reject this even though it's
     /// finite and positive.
     const FREQ_JUST_BELOW_FLOOR_HZ: f64 = 2_999.0;
-    /// Frequency inside the renderable range but below the ATIS
-    /// example, used as the floor-plus-epsilon guard on
-    /// `format_antenna_line`.
+    /// Frequency below the renderable floor (1 kHz < 3 kHz),
+    /// used to verify `format_antenna_line` rejects sub-floor
+    /// input in the same way it rejects zero / negative /
+    /// non-finite. Per `CodeRabbit` round 2 on PR #418.
     const FREQ_1_KHZ: f64 = 1_000.0;
+
+    /// NOAA APT centre band exemplar (NOAA-19 downlink frequency).
+    /// Used to pin the sat-band V-angle recommendation.
+    const FREQ_NOAA_19_MHZ: f64 = 137_620_000.0;
+    /// 2 m ham band — ISS voice downlink frequency.
+    const FREQ_ISS_VOICE_MHZ: f64 = 145_800_000.0;
+    /// 70 cm ham satellite centre — typical LEO-sat downlink.
+    const FREQ_70CM_SAT_MHZ: f64 = 436_500_000.0;
+    /// 13 cm ham band example.
+    const FREQ_13CM_SAT_MHZ: f64 = 2_400_000_000.0;
+    /// FM broadcast band exemplar — `WXPN` Philadelphia,
+    /// classic horizon-dominated reception target.
+    const FREQ_FM_BROADCAST_MHZ: f64 = 88_500_000.0;
+    /// Airband exemplar — standard ATIS frequency.
+    const FREQ_AIRBAND_MHZ: f64 = 124_050_000.0;
 
     // Length fixtures for [`format_length_m`] branch coverage.
     /// Metre-range exemplar — the `.xx m` output branch.
@@ -225,9 +335,63 @@ mod tests {
 
     #[test]
     fn format_antenna_line_combines_both_values() {
-        // ATIS 255 MHz → λ/2 58.8 cm, λ/4 29.4 cm.
+        // ATIS 255 MHz → λ/2 58.8 cm, λ/4 29.4 cm, V 180° horizon
+        // (255 MHz is outside every known sat band, so the default
+        // horizon-dipole suggestion lands).
         let line = format_antenna_line(FREQ_ATIS_255_MHZ).expect("valid");
-        assert_eq!(line, "λ/2 58.8 cm · λ/4 29.4 cm");
+        assert_eq!(line, "λ/2 58.8 cm · λ/4 29.4 cm · V 180° horizon");
+    }
+
+    #[test]
+    fn suggested_v_angle_noaa_apt_is_sat_120() {
+        let (angle, hint) = suggested_v_angle(FREQ_NOAA_19_MHZ);
+        assert_eq!(angle, 120);
+        assert_eq!(hint, "sat");
+    }
+
+    #[test]
+    fn suggested_v_angle_2m_ham_is_sat_120() {
+        let (angle, hint) = suggested_v_angle(FREQ_ISS_VOICE_MHZ);
+        assert_eq!(angle, 120);
+        assert_eq!(hint, "sat");
+    }
+
+    #[test]
+    fn suggested_v_angle_70cm_sat_is_sat_120() {
+        let (angle, hint) = suggested_v_angle(FREQ_70CM_SAT_MHZ);
+        assert_eq!(angle, 120);
+        assert_eq!(hint, "sat");
+    }
+
+    #[test]
+    fn suggested_v_angle_13cm_sat_is_sat_120() {
+        let (angle, hint) = suggested_v_angle(FREQ_13CM_SAT_MHZ);
+        assert_eq!(angle, 120);
+        assert_eq!(hint, "sat");
+    }
+
+    #[test]
+    fn suggested_v_angle_fm_broadcast_is_horizon_180() {
+        let (angle, hint) = suggested_v_angle(FREQ_FM_BROADCAST_MHZ);
+        assert_eq!(angle, 180);
+        assert_eq!(hint, "horizon");
+    }
+
+    #[test]
+    fn suggested_v_angle_airband_is_horizon_180() {
+        let (angle, hint) = suggested_v_angle(FREQ_AIRBAND_MHZ);
+        assert_eq!(angle, 180);
+        assert_eq!(hint, "horizon");
+    }
+
+    #[test]
+    fn suggested_v_angle_just_outside_2m_band_is_horizon() {
+        // Boundary check — 2 m band is 144..=148 MHz per the
+        // `BAND_2M_*` consts. 149 MHz should fall to the horizon
+        // default. Pins the "inclusive upper edge" contract so
+        // `..=` vs `..` can't drift silently.
+        let (angle, _) = suggested_v_angle(149_000_000.0);
+        assert_eq!(angle, 180);
     }
 
     #[test]

--- a/crates/sdr-ui/src/antenna.rs
+++ b/crates/sdr-ui/src/antenna.rs
@@ -201,8 +201,14 @@ pub fn format_length_m(length_m: f64) -> String {
 /// so the caller can hide the label entirely rather than showing `"λ/2 —"`.
 #[must_use]
 pub fn format_antenna_line(freq_hz: f64) -> Option<String> {
-    let half = half_wave_m(freq_hz)?;
-    let quarter = quarter_wave_m(freq_hz)?;
+    // Compute wavelength once and derive both halves from it.
+    // `half_wave_m` / `quarter_wave_m` each re-invoke
+    // `wavelength_m` — fine when callers want just one value,
+    // wasteful on the status-bar refresh path which wants
+    // both. Per `CodeRabbit` round 4 on PR #418.
+    let wavelength = wavelength_m(freq_hz)?;
+    let half = wavelength / 2.0;
+    let quarter = wavelength / 4.0;
     let (angle, hint) = suggested_v_angle(freq_hz);
     Some(format!(
         "λ/2 {} · λ/4 {} · V {angle}° {hint}",

--- a/crates/sdr-ui/src/antenna.rs
+++ b/crates/sdr-ui/src/antenna.rs
@@ -22,6 +22,31 @@ pub const SPEED_OF_LIGHT_M_S: f64 = 299_792_458.0;
 /// mis-tune or a test signal and the status bar can safely show nothing.
 pub const MIN_RENDERABLE_FREQUENCY_HZ: f64 = 3_000.0;
 
+// ------------------------------------------------------------
+//  Length-formatting unit policy for [`format_length_m`]
+//
+//  Thresholds for auto-scaling the displayed unit between metres,
+//  centimetres, and millimetres. Named constants per the project's
+//  "no magic numbers" rule — per `CodeRabbit` round 1 on PR #418.
+// ------------------------------------------------------------
+
+/// At or above this length (metres), render in "m" with two
+/// decimal places. 1 m is the natural break: below it the leading
+/// `0.` digits waste bar space vs. showing 99.9 cm.
+const METRES_THRESHOLD_M: f64 = 1.0;
+/// At or above this length (metres) but below [`METRES_THRESHOLD_M`],
+/// render in "cm" with one decimal place. 1 cm = the natural break
+/// below which the displayed number slips under 1.0 and the `.x cm`
+/// format loses resolution vs. jumping to millimetres.
+const CENTIMETRES_THRESHOLD_M: f64 = 0.01;
+/// Conversion factor from metres to centimetres — purely a naming
+/// aid so the formatter reads as `length * CM_PER_M` instead of
+/// `length * 100.0`.
+const CM_PER_M: f64 = 100.0;
+/// Conversion factor from metres to millimetres — same naming aid
+/// rationale as [`CM_PER_M`].
+const MM_PER_M: f64 = 1_000.0;
+
 /// Wavelength (metres) for a given frequency (Hz). Returns `None` when
 /// the input isn't a finite positive number or is below
 /// [`MIN_RENDERABLE_FREQUENCY_HZ`] — callers treat that as "don't render".
@@ -63,13 +88,13 @@ pub fn format_length_m(length_m: f64) -> String {
     if !length_m.is_finite() || length_m <= 0.0 {
         return String::new();
     }
-    if length_m >= 1.0 {
+    if length_m >= METRES_THRESHOLD_M {
         format!("{length_m:.2} m")
-    } else if length_m >= 0.01 {
-        let cm = length_m * 100.0;
+    } else if length_m >= CENTIMETRES_THRESHOLD_M {
+        let cm = length_m * CM_PER_M;
         format!("{cm:.1} cm")
     } else {
-        let mm = length_m * 1000.0;
+        let mm = length_m * MM_PER_M;
         format!("{mm:.1} mm")
     }
 }
@@ -93,28 +118,83 @@ pub fn format_antenna_line(freq_hz: f64) -> Option<String> {
 mod tests {
     use super::*;
 
+    // ----------------------------------------------------------
+    //  Typed, rationale-documented test fixtures per the repo's
+    //  "no magic numbers in tests" convention. Per `CodeRabbit`
+    //  round 1 on PR #418.
+    // ----------------------------------------------------------
+
+    /// f64 tolerance for exact-math wavelength comparisons. The
+    /// underlying arithmetic is `c / f` where both operands are
+    /// representable — 1e-6 catches rounding drift without
+    /// false-failing on legit precision jitter.
     const FLOAT_EPS_M: f64 = 1e-6;
+    /// Wider tolerance for the `half_wave_atis_255_mhz_*` test —
+    /// the integer frequency `255_000_000` doesn't divide evenly
+    /// into c, so the expected value `0.587_828` is approximate.
+    const ATIS_MATCH_TOLERANCE_M: f64 = 1e-4;
+
+    /// 100 MHz — FM broadcast band center, convenient for a
+    /// whole-metre wavelength sanity check (`λ = c / 100e6 =
+    /// 2.9979 m`).
+    const FREQ_100_MHZ: f64 = 100_000_000.0;
+    /// Expected wavelength at [`FREQ_100_MHZ`], spelled out to
+    /// match `c / f` to f64 precision.
+    const WAVELENGTH_AT_100_MHZ_M: f64 = 2.997_924_58;
+    /// ATIS air-band frequency — reference example quoted in
+    /// issue #157's acceptance ("255 MHz → half-wave ≈ 58.8 cm").
+    const FREQ_ATIS_255_MHZ: f64 = 255_000_000.0;
+    /// Expected half-wave dipole length at [`FREQ_ATIS_255_MHZ`],
+    /// matched within [`ATIS_MATCH_TOLERANCE_M`].
+    const HALF_WAVE_ATIS_M: f64 = 0.587_828;
+    /// 2 m ham band center — standard reference for the
+    /// "quarter wave is half of half wave" identity test.
+    const FREQ_2M_CENTER_HZ: f64 = 146_000_000.0;
+    /// Top-of-UHF stress-test frequency — 30 GHz drives λ/4 into
+    /// the millimetre range so the unit-scaling branch of
+    /// `format_length_m` gets exercised.
+    const FREQ_30_GHZ: f64 = 30_000_000_000.0;
+    /// Frequency just below the renderable floor (3 kHz).
+    /// [`wavelength_m`] must reject this even though it's
+    /// finite and positive.
+    const FREQ_JUST_BELOW_FLOOR_HZ: f64 = 2_999.0;
+    /// Frequency inside the renderable range but below the ATIS
+    /// example, used as the floor-plus-epsilon guard on
+    /// `format_antenna_line`.
+    const FREQ_1_KHZ: f64 = 1_000.0;
+
+    // Length fixtures for [`format_length_m`] branch coverage.
+    /// Metre-range exemplar — the `.xx m` output branch.
+    const LEN_1_M_EXAMPLE: f64 = 1.176_25;
+    /// Expected rendering for [`LEN_1_M_EXAMPLE`].
+    const LEN_1_M_EXPECTED: &str = "1.18 m";
+    /// Centimetre-range exemplar — matches the ATIS half-wave.
+    const LEN_CM_EXAMPLE: f64 = 0.587_8;
+    /// Expected rendering for [`LEN_CM_EXAMPLE`].
+    const LEN_CM_EXPECTED: &str = "58.8 cm";
+    /// Millimetre-range exemplar — 7 mm.
+    const LEN_MM_EXAMPLE: f64 = 0.007;
+    /// Expected rendering for [`LEN_MM_EXAMPLE`].
+    const LEN_MM_EXPECTED: &str = "7.0 mm";
 
     #[test]
     fn wavelength_100_mhz_is_2_998_m() {
-        // 100 MHz → λ = c / f = 2.998 m exactly (well within f64 precision).
-        let w = wavelength_m(100_000_000.0).expect("valid freq");
-        assert!((w - 2.997_924_58).abs() < FLOAT_EPS_M);
+        let w = wavelength_m(FREQ_100_MHZ).expect("valid freq");
+        assert!((w - WAVELENGTH_AT_100_MHZ_M).abs() < FLOAT_EPS_M);
     }
 
     #[test]
     fn half_wave_atis_255_mhz_matches_design_ticket_example() {
         // Ticket #157 quotes ATIS at 255 MHz → half-wave ≈ 58.8 cm.
         // Exact: 299_792_458 / (255_000_000 * 2) = 0.587_828... m.
-        let half = half_wave_m(255_000_000.0).expect("valid");
-        assert!((half - 0.587_828).abs() < 0.000_1);
+        let half = half_wave_m(FREQ_ATIS_255_MHZ).expect("valid");
+        assert!((half - HALF_WAVE_ATIS_M).abs() < ATIS_MATCH_TOLERANCE_M);
     }
 
     #[test]
     fn quarter_wave_is_half_of_half_wave() {
-        let f = 146_000_000.0; // 2m ham band center
-        let half = half_wave_m(f).expect("valid");
-        let quarter = quarter_wave_m(f).expect("valid");
+        let half = half_wave_m(FREQ_2M_CENTER_HZ).expect("valid");
+        let quarter = quarter_wave_m(FREQ_2M_CENTER_HZ).expect("valid");
         assert!((half - 2.0 * quarter).abs() < FLOAT_EPS_M);
     }
 
@@ -124,7 +204,7 @@ mod tests {
         // blow up the status bar with "λ/2: 149_896 km".
         assert!(wavelength_m(0.0).is_none());
         assert!(wavelength_m(-100.0).is_none());
-        assert!(wavelength_m(2_999.0).is_none());
+        assert!(wavelength_m(FREQ_JUST_BELOW_FLOOR_HZ).is_none());
         assert!(wavelength_m(f64::NAN).is_none());
         assert!(wavelength_m(f64::INFINITY).is_none());
     }
@@ -132,11 +212,11 @@ mod tests {
     #[test]
     fn format_length_auto_scales_units() {
         // >= 1 m
-        assert_eq!(format_length_m(1.17625), "1.18 m");
+        assert_eq!(format_length_m(LEN_1_M_EXAMPLE), LEN_1_M_EXPECTED);
         // >= 1 cm
-        assert_eq!(format_length_m(0.5878), "58.8 cm");
+        assert_eq!(format_length_m(LEN_CM_EXAMPLE), LEN_CM_EXPECTED);
         // >= 1 mm
-        assert_eq!(format_length_m(0.007), "7.0 mm");
+        assert_eq!(format_length_m(LEN_MM_EXAMPLE), LEN_MM_EXPECTED);
         // Guard
         assert_eq!(format_length_m(0.0), "");
         assert_eq!(format_length_m(-1.0), "");
@@ -146,20 +226,19 @@ mod tests {
     #[test]
     fn format_antenna_line_combines_both_values() {
         // ATIS 255 MHz → λ/2 58.8 cm, λ/4 29.4 cm.
-        let line = format_antenna_line(255_000_000.0).expect("valid");
+        let line = format_antenna_line(FREQ_ATIS_255_MHZ).expect("valid");
         assert_eq!(line, "λ/2 58.8 cm · λ/4 29.4 cm");
     }
 
     #[test]
     fn format_antenna_line_returns_none_below_renderable_floor() {
         assert!(format_antenna_line(0.0).is_none());
-        assert!(format_antenna_line(1_000.0).is_none());
+        assert!(format_antenna_line(FREQ_1_KHZ).is_none());
     }
 
     #[test]
     fn high_frequency_uhf_formats_in_mm_range() {
-        // 30 GHz — top of UHF/SHF transition. λ/4 = 2.5 mm.
-        let line = format_antenna_line(30_000_000_000.0).expect("valid");
+        let line = format_antenna_line(FREQ_30_GHZ).expect("valid");
         assert!(line.contains("λ/4 2.5 mm"), "line: {line}");
     }
 

--- a/crates/sdr-ui/src/antenna.rs
+++ b/crates/sdr-ui/src/antenna.rs
@@ -1,0 +1,173 @@
+//! Antenna-dimension math derived from the currently tuned frequency.
+//!
+//! Pure physics — no external data, no device state, no I/O. All functions
+//! are free and deterministic so tests can exercise them without spinning
+//! up GTK or the engine. Issue #157.
+//!
+//! The values surface on the status bar next to the center-frequency
+//! readout, and feed future V-dipole popover UI that pairs with the
+//! [`aentenna-measure` gauge](https://github.com/jasonherald/aentenna-measure)
+//! for cutting arm lengths and setting the V-angle in 5° detents.
+
+/// Speed of light in free space, in metres per second. Standard-defined
+/// constant; the underlying number is exact by international agreement
+/// (the metre is defined FROM this number, not the other way around).
+pub const SPEED_OF_LIGHT_M_S: f64 = 299_792_458.0;
+
+/// Minimum frequency (Hz) at which we'll render a meaningful antenna
+/// dimension on the status bar. Below this the wavelengths balloon into
+/// kilometre territory where "cut your element to X" stops being a
+/// helpful display for a hand-held SDR and starts being noise. Matches
+/// the bottom of the VLF band (3 kHz) — anything lower is likely a
+/// mis-tune or a test signal and the status bar can safely show nothing.
+pub const MIN_RENDERABLE_FREQUENCY_HZ: f64 = 3_000.0;
+
+/// Wavelength (metres) for a given frequency (Hz). Returns `None` when
+/// the input isn't a finite positive number or is below
+/// [`MIN_RENDERABLE_FREQUENCY_HZ`] — callers treat that as "don't render".
+#[must_use]
+pub fn wavelength_m(freq_hz: f64) -> Option<f64> {
+    if !freq_hz.is_finite() || freq_hz < MIN_RENDERABLE_FREQUENCY_HZ {
+        return None;
+    }
+    Some(SPEED_OF_LIGHT_M_S / freq_hz)
+}
+
+/// Half-wave dipole total length in metres. `None` on the same conditions
+/// as [`wavelength_m`].
+#[must_use]
+pub fn half_wave_m(freq_hz: f64) -> Option<f64> {
+    wavelength_m(freq_hz).map(|w| w / 2.0)
+}
+
+/// Quarter-wave element length in metres — the per-arm length for a
+/// V-dipole, J-pole, or ground-plane antenna. `None` on the same
+/// conditions as [`wavelength_m`].
+#[must_use]
+pub fn quarter_wave_m(freq_hz: f64) -> Option<f64> {
+    wavelength_m(freq_hz).map(|w| w / 4.0)
+}
+
+/// Format a length in metres with an auto-scaled unit suffix, keeping the
+/// displayed value in the 0.1..=999 range so the status bar reads cleanly
+/// across HF-to-UHF:
+///
+/// - `>= 1 m`  → "X.XX m" (e.g. "58.8 cm on VHF air, 1.17 m on HF 40m")
+/// - `>= 1 cm` → "X.X cm"
+/// - `< 1 cm`  → "X.X mm"
+///
+/// Returns an empty string for non-finite / non-positive inputs so the
+/// caller can concatenate without special-casing the render site.
+#[must_use]
+pub fn format_length_m(length_m: f64) -> String {
+    if !length_m.is_finite() || length_m <= 0.0 {
+        return String::new();
+    }
+    if length_m >= 1.0 {
+        format!("{length_m:.2} m")
+    } else if length_m >= 0.01 {
+        let cm = length_m * 100.0;
+        format!("{cm:.1} cm")
+    } else {
+        let mm = length_m * 1000.0;
+        format!("{mm:.1} mm")
+    }
+}
+
+/// Build the status-bar line that pairs the half-wave total-dipole length
+/// with the quarter-wave element length. Format: `"λ/2 58.8 cm · λ/4 29.4 cm"`.
+/// Returns `None` when the frequency is below [`MIN_RENDERABLE_FREQUENCY_HZ`]
+/// so the caller can hide the label entirely rather than showing `"λ/2 —"`.
+#[must_use]
+pub fn format_antenna_line(freq_hz: f64) -> Option<String> {
+    let half = half_wave_m(freq_hz)?;
+    let quarter = quarter_wave_m(freq_hz)?;
+    Some(format!(
+        "λ/2 {} · λ/4 {}",
+        format_length_m(half),
+        format_length_m(quarter)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FLOAT_EPS_M: f64 = 1e-6;
+
+    #[test]
+    fn wavelength_100_mhz_is_2_998_m() {
+        // 100 MHz → λ = c / f = 2.998 m exactly (well within f64 precision).
+        let w = wavelength_m(100_000_000.0).expect("valid freq");
+        assert!((w - 2.997_924_58).abs() < FLOAT_EPS_M);
+    }
+
+    #[test]
+    fn half_wave_atis_255_mhz_matches_design_ticket_example() {
+        // Ticket #157 quotes ATIS at 255 MHz → half-wave ≈ 58.8 cm.
+        // Exact: 299_792_458 / (255_000_000 * 2) = 0.587_828... m.
+        let half = half_wave_m(255_000_000.0).expect("valid");
+        assert!((half - 0.587_828).abs() < 0.000_1);
+    }
+
+    #[test]
+    fn quarter_wave_is_half_of_half_wave() {
+        let f = 146_000_000.0; // 2m ham band center
+        let half = half_wave_m(f).expect("valid");
+        let quarter = quarter_wave_m(f).expect("valid");
+        assert!((half - 2.0 * quarter).abs() < FLOAT_EPS_M);
+    }
+
+    #[test]
+    fn sub_3khz_frequencies_return_none() {
+        // Renderable-floor guard: a mis-tuned value near DC doesn't
+        // blow up the status bar with "λ/2: 149_896 km".
+        assert!(wavelength_m(0.0).is_none());
+        assert!(wavelength_m(-100.0).is_none());
+        assert!(wavelength_m(2_999.0).is_none());
+        assert!(wavelength_m(f64::NAN).is_none());
+        assert!(wavelength_m(f64::INFINITY).is_none());
+    }
+
+    #[test]
+    fn format_length_auto_scales_units() {
+        // >= 1 m
+        assert_eq!(format_length_m(1.17625), "1.18 m");
+        // >= 1 cm
+        assert_eq!(format_length_m(0.5878), "58.8 cm");
+        // >= 1 mm
+        assert_eq!(format_length_m(0.007), "7.0 mm");
+        // Guard
+        assert_eq!(format_length_m(0.0), "");
+        assert_eq!(format_length_m(-1.0), "");
+        assert_eq!(format_length_m(f64::NAN), "");
+    }
+
+    #[test]
+    fn format_antenna_line_combines_both_values() {
+        // ATIS 255 MHz → λ/2 58.8 cm, λ/4 29.4 cm.
+        let line = format_antenna_line(255_000_000.0).expect("valid");
+        assert_eq!(line, "λ/2 58.8 cm · λ/4 29.4 cm");
+    }
+
+    #[test]
+    fn format_antenna_line_returns_none_below_renderable_floor() {
+        assert!(format_antenna_line(0.0).is_none());
+        assert!(format_antenna_line(1_000.0).is_none());
+    }
+
+    #[test]
+    fn high_frequency_uhf_formats_in_mm_range() {
+        // 30 GHz — top of UHF/SHF transition. λ/4 = 2.5 mm.
+        let line = format_antenna_line(30_000_000_000.0).expect("valid");
+        assert!(line.contains("λ/4 2.5 mm"), "line: {line}");
+    }
+
+    #[test]
+    fn half_and_quarter_return_none_when_wavelength_would() {
+        // The element-length helpers forward the renderable-floor
+        // guard, not just wavelength_m itself.
+        assert!(half_wave_m(0.0).is_none());
+        assert!(quarter_wave_m(0.0).is_none());
+    }
+}

--- a/crates/sdr-ui/src/antenna.rs
+++ b/crates/sdr-ui/src/antenna.rs
@@ -170,8 +170,8 @@ pub fn quarter_wave_m(freq_hz: f64) -> Option<f64> {
 /// displayed value in the 0.1..=999 range so the status bar reads cleanly
 /// across HF-to-UHF:
 ///
-/// - `>= 1 m`  → "X.XX m" (e.g. "58.8 cm on VHF air, 1.17 m on HF 40m")
-/// - `>= 1 cm` → "X.X cm"
+/// - `>= 1 m`  → "X.XX m" (e.g. "1.17 m on HF 40m")
+/// - `>= 1 cm` → "X.X cm" (e.g. "58.8 cm on VHF air")
 /// - `< 1 cm`  → "X.X mm"
 ///
 /// Returns an empty string for non-finite / non-positive inputs so the
@@ -193,7 +193,10 @@ pub fn format_length_m(length_m: f64) -> String {
 }
 
 /// Build the status-bar line that pairs the half-wave total-dipole length
-/// with the quarter-wave element length. Format: `"λ/2 58.8 cm · λ/4 29.4 cm"`.
+/// with the quarter-wave element length and the suggested V-angle hint.
+/// Format: `"λ/2 58.8 cm · λ/4 29.4 cm · V 180° horizon"` (at 255 MHz ATIS)
+/// or `"λ/2 109.4 cm · λ/4 54.7 cm · V 120° sat"` (at 137.62 MHz NOAA).
+///
 /// Returns `None` when the frequency is below [`MIN_RENDERABLE_FREQUENCY_HZ`]
 /// so the caller can hide the label entirely rather than showing `"λ/2 —"`.
 #[must_use]

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -11,6 +11,7 @@
 
 #![cfg(target_os = "linux")]
 
+pub mod antenna;
 pub mod app;
 pub mod css;
 pub mod header;

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -657,9 +657,28 @@ fn attach_click_gesture(
         let width = f64::from(area.width());
         let mut vfo = vfo_state.borrow_mut();
         let hz = vfo.pixel_to_hz(x, width);
+        // Snapshot display span + max span BEFORE mutating offset so
+        // a post-investigation diff of the trace can tell (a) whether
+        // the click landed inside the AA-filter-safe subset of the
+        // display, and (b) whether the user was zoomed in — zoom
+        // modifies `display_start_hz` / `display_end_hz` at runtime
+        // so a fixed ±bandwidth/2 assumption doesn't hold. Per #337
+        // investigation in PR batch with #407 / #157 / #400.
+        let display_start_hz = vfo.display_start_hz;
+        let display_end_hz = vfo.display_end_hz;
+        let max_span_hz = vfo.max_span_hz;
         vfo.offset_hz = hz;
         let offset = vfo.offset_hz;
-        tracing::debug!(offset_hz = offset, "click-to-tune");
+        tracing::debug!(
+            click_x = x,
+            width,
+            display_start_hz,
+            display_end_hz,
+            max_span_hz,
+            zoomed_in = (display_end_hz - display_start_hz) < max_span_hz * 0.99,
+            offset_hz = offset,
+            "click-to-tune: computed offset from pixel"
+        );
         drop(vfo);
 
         // Send VFO offset to DSP thread for actual tuning

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -52,6 +52,14 @@ const VFO_RESET_BUTTON_MARGIN_PX: i32 = 8;
 /// Exponential moving average smoothing factor for `RunningAvg` mode.
 const AVERAGING_ALPHA: f32 = 0.3;
 
+/// Fraction of `max_span_hz` below which the click-to-tune diagnostic
+/// classifies the view as "zoomed in". Set slightly below 1.0 so tiny
+/// floating-point drift in the span arithmetic doesn't flip the
+/// classification on an unzoomed view. Per `CodeRabbit` round 1 on
+/// PR #418 — the threshold was previously a bare `0.99` literal inside
+/// the tracing call.
+const ZOOMED_IN_SPAN_RATIO_THRESHOLD: f64 = 0.99;
+
 /// Spectrum averaging mode for the FFT display.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum AveragingMode {
@@ -675,7 +683,8 @@ fn attach_click_gesture(
             display_start_hz,
             display_end_hz,
             max_span_hz,
-            zoomed_in = (display_end_hz - display_start_hz) < max_span_hz * 0.99,
+            zoomed_in =
+                (display_end_hz - display_start_hz) < max_span_hz * ZOOMED_IN_SPAN_RATIO_THRESHOLD,
             offset_hz = offset,
             "click-to-tune: computed offset from pixel"
         );

--- a/crates/sdr-ui/src/status_bar.rs
+++ b/crates/sdr-ui/src/status_bar.rs
@@ -27,11 +27,15 @@ const DEFAULT_SAMPLE_RATE_TEXT: &str = "SR: --";
 const DEFAULT_DEMOD_TEXT: &str = "-- --";
 /// Default frequency display text when no data has arrived.
 const DEFAULT_FREQUENCY_TEXT: &str = "-- Hz";
-/// Default antenna-dimension text when no frequency is set yet. The
-/// label itself stays invisible in this state so the status bar
-/// reads cleanly at app launch; `update_frequency` reveals it once
-/// a valid tuned frequency lands. Per issue #157.
-const DEFAULT_ANTENNA_TEXT: &str = "";
+/// Default antenna-dimension text when no frequency is set yet or
+/// the tuned frequency is below the renderable floor. Mirrors the
+/// other `-- unit` placeholders (`Level: -- dBFS`, `SR: --`) so the
+/// feature is discoverable in the status bar from app launch, not
+/// hidden until the first tune. Per issue #157 — post-smoke-test
+/// tweak to drop the start-hidden behaviour (the user couldn't
+/// find "a way to activate" the calculator because there was no
+/// indication it existed until the freq fell in range).
+const DEFAULT_ANTENNA_TEXT: &str = "λ/2 -- · λ/4 --";
 /// Default cursor readout text when the cursor is not over the spectrum.
 const DEFAULT_CURSOR_TEXT: &str = "Cursor: --";
 
@@ -67,14 +71,14 @@ pub struct StatusBar {
     /// Label showing center frequency.
     pub frequency_label: gtk4::Label,
     /// Label showing half-wave + quarter-wave antenna dimensions for
-    /// the current frequency. Paired with [`antenna_separator`] so
-    /// both toggle together when the label has nothing to render
-    /// (e.g. sub-3-kHz inputs, which would balloon into kilometre
-    /// wavelengths). Per issue #157.
+    /// the current frequency. Always visible (falls back to the
+    /// `DEFAULT_ANTENNA_TEXT` placeholder for frequencies below
+    /// [`crate::antenna::MIN_RENDERABLE_FREQUENCY_HZ`]) so the
+    /// feature is always discoverable in the status bar. Per
+    /// issue #157.
     pub antenna_label: gtk4::Label,
-    /// Separator packed immediately before `antenna_label`. Hidden
-    /// in lockstep with the label so a no-render state doesn't
-    /// leave a floating separator.
+    /// Separator packed immediately before [`antenna_label`]. Always
+    /// visible alongside the label.
     pub antenna_separator: gtk4::Separator,
     /// Label showing cursor frequency and power readout.
     pub cursor_label: gtk4::Label,
@@ -112,19 +116,17 @@ impl StatusBar {
     /// Update the center frequency display. Also refreshes the
     /// companion antenna-dimension label (half-wave + quarter-wave
     /// arm length) for the same frequency so the builder value
-    /// stays in sync with the tuned band. Hidden when the
-    /// frequency is below the renderable floor (see
-    /// [`crate::antenna::MIN_RENDERABLE_FREQUENCY_HZ`]).
+    /// stays in sync with the tuned band. Falls back to the
+    /// `DEFAULT_ANTENNA_TEXT` placeholder when the frequency is
+    /// below the renderable floor (see
+    /// [`crate::antenna::MIN_RENDERABLE_FREQUENCY_HZ`]); the label
+    /// itself stays visible either way so the feature is always
+    /// discoverable.
     pub fn update_frequency(&self, hz: f64) {
         self.frequency_label.set_label(&format_frequency(hz));
-        if let Some(text) = crate::antenna::format_antenna_line(hz) {
-            self.antenna_label.set_label(&text);
-            self.antenna_label.set_visible(true);
-            self.antenna_separator.set_visible(true);
-        } else {
-            self.antenna_label.set_visible(false);
-            self.antenna_separator.set_visible(false);
-        }
+        let antenna_text = crate::antenna::format_antenna_line(hz)
+            .unwrap_or_else(|| DEFAULT_ANTENNA_TEXT.to_string());
+        self.antenna_label.set_label(&antenna_text);
     }
 
     /// Update the `rtl_tcp` role badge. `Some(RtlTcpRoleBadge::
@@ -180,10 +182,7 @@ pub fn build_status_bar() -> StatusBar {
     let demod_label = gtk4::Label::new(Some(DEFAULT_DEMOD_TEXT));
     let frequency_label = gtk4::Label::new(Some(DEFAULT_FREQUENCY_TEXT));
     let antenna_label = gtk4::Label::new(Some(DEFAULT_ANTENNA_TEXT));
-    antenna_label.add_css_class("dim-label");
-    antenna_label.set_visible(false);
     let antenna_separator = gtk4::Separator::new(gtk4::Orientation::Vertical);
-    antenna_separator.set_visible(false);
     let cursor_label = gtk4::Label::new(Some(DEFAULT_CURSOR_TEXT));
     let role_label = gtk4::Label::new(Some(DEFAULT_ROLE_TEXT));
     role_label.set_visible(false);

--- a/crates/sdr-ui/src/status_bar.rs
+++ b/crates/sdr-ui/src/status_bar.rs
@@ -27,6 +27,11 @@ const DEFAULT_SAMPLE_RATE_TEXT: &str = "SR: --";
 const DEFAULT_DEMOD_TEXT: &str = "-- --";
 /// Default frequency display text when no data has arrived.
 const DEFAULT_FREQUENCY_TEXT: &str = "-- Hz";
+/// Default antenna-dimension text when no frequency is set yet. The
+/// label itself stays invisible in this state so the status bar
+/// reads cleanly at app launch; `update_frequency` reveals it once
+/// a valid tuned frequency lands. Per issue #157.
+const DEFAULT_ANTENNA_TEXT: &str = "";
 /// Default cursor readout text when the cursor is not over the spectrum.
 const DEFAULT_CURSOR_TEXT: &str = "Cursor: --";
 
@@ -61,6 +66,16 @@ pub struct StatusBar {
     pub demod_label: gtk4::Label,
     /// Label showing center frequency.
     pub frequency_label: gtk4::Label,
+    /// Label showing half-wave + quarter-wave antenna dimensions for
+    /// the current frequency. Paired with [`antenna_separator`] so
+    /// both toggle together when the label has nothing to render
+    /// (e.g. sub-3-kHz inputs, which would balloon into kilometre
+    /// wavelengths). Per issue #157.
+    pub antenna_label: gtk4::Label,
+    /// Separator packed immediately before `antenna_label`. Hidden
+    /// in lockstep with the label so a no-render state doesn't
+    /// leave a floating separator.
+    pub antenna_separator: gtk4::Separator,
     /// Label showing cursor frequency and power readout.
     pub cursor_label: gtk4::Label,
     /// `rtl_tcp` role badge — "Controller" (accent color) or
@@ -94,9 +109,22 @@ impl StatusBar {
             .set_label(&format!("{mode} {}", format_bandwidth(bw)));
     }
 
-    /// Update the center frequency display.
+    /// Update the center frequency display. Also refreshes the
+    /// companion antenna-dimension label (half-wave + quarter-wave
+    /// arm length) for the same frequency so the builder value
+    /// stays in sync with the tuned band. Hidden when the
+    /// frequency is below the renderable floor (see
+    /// [`crate::antenna::MIN_RENDERABLE_FREQUENCY_HZ`]).
     pub fn update_frequency(&self, hz: f64) {
         self.frequency_label.set_label(&format_frequency(hz));
+        if let Some(text) = crate::antenna::format_antenna_line(hz) {
+            self.antenna_label.set_label(&text);
+            self.antenna_label.set_visible(true);
+            self.antenna_separator.set_visible(true);
+        } else {
+            self.antenna_label.set_visible(false);
+            self.antenna_separator.set_visible(false);
+        }
     }
 
     /// Update the `rtl_tcp` role badge. `Some(RtlTcpRoleBadge::
@@ -151,6 +179,11 @@ pub fn build_status_bar() -> StatusBar {
     let sample_rate_label = gtk4::Label::new(Some(DEFAULT_SAMPLE_RATE_TEXT));
     let demod_label = gtk4::Label::new(Some(DEFAULT_DEMOD_TEXT));
     let frequency_label = gtk4::Label::new(Some(DEFAULT_FREQUENCY_TEXT));
+    let antenna_label = gtk4::Label::new(Some(DEFAULT_ANTENNA_TEXT));
+    antenna_label.add_css_class("dim-label");
+    antenna_label.set_visible(false);
+    let antenna_separator = gtk4::Separator::new(gtk4::Orientation::Vertical);
+    antenna_separator.set_visible(false);
     let cursor_label = gtk4::Label::new(Some(DEFAULT_CURSOR_TEXT));
     let role_label = gtk4::Label::new(Some(DEFAULT_ROLE_TEXT));
     role_label.set_visible(false);
@@ -170,6 +203,12 @@ pub fn build_status_bar() -> StatusBar {
     widget.append(&demod_label);
     widget.append(&gtk4::Separator::new(gtk4::Orientation::Vertical));
     widget.append(&frequency_label);
+    // Antenna-dimension label packs immediately after the
+    // frequency label so builders reading the screen can scan
+    // right across the pair: "146.52 MHz · λ/2 1.02 m · λ/4 51.2 cm"
+    // Per issue #157.
+    widget.append(&antenna_separator);
+    widget.append(&antenna_label);
     widget.append(&gtk4::Separator::new(gtk4::Orientation::Vertical));
     widget.append(&cursor_label);
     widget.append(&role_separator);
@@ -181,6 +220,8 @@ pub fn build_status_bar() -> StatusBar {
         sample_rate_label,
         demod_label,
         frequency_label,
+        antenna_label,
+        antenna_separator,
         cursor_label,
         role_label,
         role_separator,

--- a/crates/sdr-ui/src/status_bar.rs
+++ b/crates/sdr-ui/src/status_bar.rs
@@ -124,9 +124,17 @@ impl StatusBar {
     /// discoverable.
     pub fn update_frequency(&self, hz: f64) {
         self.frequency_label.set_label(&format_frequency(hz));
-        let antenna_text = crate::antenna::format_antenna_line(hz)
-            .unwrap_or_else(|| DEFAULT_ANTENNA_TEXT.to_string());
-        self.antenna_label.set_label(&antenna_text);
+        // Matched rather than `.unwrap_or_else(|| .to_string())`
+        // so the no-render branch passes the `&'static str`
+        // `DEFAULT_ANTENNA_TEXT` directly — no `String`
+        // allocation per update. Matters on VFO-drag retune
+        // storms where this fires at GTK mouse-event cadence.
+        // Per `CodeRabbit` round 1 on PR #418.
+        if let Some(antenna_text) = crate::antenna::format_antenna_line(hz) {
+            self.antenna_label.set_label(&antenna_text);
+        } else {
+            self.antenna_label.set_label(DEFAULT_ANTENNA_TEXT);
+        }
     }
 
     /// Update the `rtl_tcp` role badge. `Some(RtlTcpRoleBadge::

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -1255,6 +1255,17 @@ typedef struct SdrRtlTcpDiscoveredServer {
     bool        has_txbuf;
     uint64_t    txbuf;
     double      last_seen_secs_ago;
+    /* ABI 0.19 (#400) — read-side TXT capability fields mirroring
+     * `SdrRtlTcpAdvertiseOptions.{has_codecs, codecs, has_auth_required,
+     * auth_required}` so FFI hosts can gate compression / takeover /
+     * role / auth-field reveal decisions against the same capability
+     * signals the server publishes. Zero-init defaults (has_* = false)
+     * map to "server didn't advertise this TXT key" — identical to
+     * how the parser already treats an absent key. */
+    bool        has_codecs;
+    uint8_t     codecs;
+    bool        has_auth_required;
+    bool        auth_required;
 } SdrRtlTcpDiscoveredServer;
 
 /*

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,30 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 18
+#define SDR_CORE_ABI_VERSION_MINOR 19
 /*
+ * 0.19 — extends the rtl_tcp FFI surface with codec-mask and
+ * auth-required fields that were previously hardcoded (#307
+ * / #395 follow-ups, issue #400):
+ *   - `SdrRtlTcpAdvertiseOptions` gains `has_codecs` (bool) +
+ *     `codecs` (uint8_t) + `has_auth_required` (bool) +
+ *     `auth_required` (bool) at the tail. Zero-init defaults
+ *     (`has_*` = false) publish the mDNS TXT without the
+ *     `codecs=` / `auth_required=` keys — identical to pre-0.19
+ *     behaviour. Hosts that want to advertise compression or
+ *     auth capability set the `has_*` gate and populate the
+ *     matching value.
+ *   - `SdrRtlTcpServerConfig` gains `has_compression` (bool) +
+ *     `compression` (uint8_t) at the tail. Zero-init default
+ *     (`has_compression = false`) keeps the server on
+ *     `CodecMask::NONE_ONLY`, matching pre-0.19 behaviour.
+ *     Hosts that want LZ4 stream compression flip `has_
+ *     compression = true; compression = 0x03` AND keep the
+ *     matching mDNS `codecs` field in sync.
+ * Both structs grow at the tail so 0.18 consumers must fail
+ * fast on the exact-match ABI check (pre-1.0 rule). No existing
+ * field offsets change.
+ *
  * 0.18 — adds three new discriminants to
  * `SdrRtlTcpConnectionStateKind`:
  *   - SDR_RTL_TCP_STATE_CONTROLLER_BUSY  = 5
@@ -867,6 +889,18 @@ typedef struct SdrRtlTcpServerConfig {
     /* Length in bytes of auth_key. Must be 0 iff auth_key is
      * NULL. See auth_key for valid range + semantics. */
     uint32_t auth_key_len;
+    /* Whether `compression` below is meaningful. `false` (zero-
+     * init) runs the server with `CodecMask::NONE_ONLY` — legacy
+     * clients only, identical to pre-ABI-0.19 behaviour. Added
+     * per #400. */
+    bool     has_compression;
+    /* Compression-mask wire byte. Only used when
+     * has_compression == true. Value is a `CodecMask::to_wire`
+     * byte: 0x01 = None-only (legacy), 0x03 = None + LZ4.
+     * Must match the codecs advertised on mDNS via
+     * `SdrRtlTcpAdvertiseOptions.codecs` or clients see a
+     * false advertisement at discovery time. Added per #400. */
+    uint8_t  compression;
 } SdrRtlTcpServerConfig;
 
 /*
@@ -1193,6 +1227,13 @@ typedef struct SdrRtlTcpAdvertiseOptions {
     const char*  nickname;       /* TXT: user-editable nickname; optional (NULL / "" = no nickname) */
     bool         has_txbuf;      /* TXT: whether `txbuf` below is meaningful */
     uint64_t     txbuf;          /* TXT: optional buffer-depth hint (bytes) */
+    /* ABI 0.19 (#400) — opt-in TXT fields. Zero-init defaults
+     * (has_* = false) omit the key from the TXT record,
+     * matching pre-0.19 behaviour. */
+    bool         has_codecs;         /* whether `codecs` below is meaningful */
+    uint8_t      codecs;             /* TXT: CodecMask wire byte (0x01 = None-only, 0x03 = None+LZ4) */
+    bool         has_auth_required;  /* whether `auth_required` below is meaningful */
+    bool         auth_required;      /* TXT: whether the server requires pre-shared-key auth (#394) */
 } SdrRtlTcpAdvertiseOptions;
 
 /*


### PR DESCRIPTION
## Summary

Four-ticket quick-wins batch, one commit per issue. All Linux-side; the Swift follow-up from #400's original acceptance got carved into its own ticket (#417) per the project's Mac-session workflow rule.

| Commit | Closes | Scope |
|--------|--------|-------|
| c522b60 | #407 | Defensive `set_tuner_gain_mode(auto)` in `RtlSdrSource::start` — 21 lines + comment |
| d938b0f | #157 | Antenna calculator status-bar addition (λ/2 + λ/4) — new `sdr-ui::antenna` module, 9 unit tests |
| 6db1736 | refs #337 | Expand click-to-tune tracing to surface the ticket's hypothesis data on next smoke test |
| f3f699b | #400 | FFI codec-mask exposure on `SdrRtlTcpAdvertiseOptions` + `SdrRtlTcpServerConfig`, ABI 0.18 → 0.19 |

## #407 — RTL-SDR defensive init

During PR #406 smoke test the dongle read zero bytes for 1000 ms per `read_bulk` until physically reseated. `RtlSdrSource::start` never called `set_tuner_gain_mode`; every upstream librtlsdr reference program (`rtl_test.c`, `rtl_tcp.c`, SDR++, gqrx) does. Added belt-and-suspenders `device.set_tuner_gain_mode(false)` (auto) after `reset_buffer()`. UI's `SetAgc` / `SetGain` dispatch still re-applies user preferences after source becomes visible.

## #157 — Antenna dimension readout

Pure-math module in `sdr-ui::antenna` + status-bar label next to the frequency readout. Renders \`"λ/2 58.8 cm · λ/4 29.4 cm"\` on ATIS at 255 MHz — both half-wave dipole total length AND quarter-wave per-arm length (V-dipole / J-pole / ground-plane use case). Auto-scales units m / cm / mm. Hidden below 3 kHz renderable floor. Companion to the [aentenna-measure V-dipole angle gauge](https://github.com/jasonherald/aentenna-measure).

Option B popover with V-angle recommendations deferred until the gauge is finalized — angle output will be exact to 1 decimal place (gauge handles its own 5° snapping via physical detents). 9/9 unit tests passing.

## #337 — Click-to-tune tracing (investigation)

The ticket explicitly asks for tracing instrumentation as the prerequisite to a fix (\"Before a fix, instrument the DSP side with `tracing::info!(...)`\"). Without a live repro in this session, shipping the traces is the best value.

**UI side**: click handler logs `click_x`, `width`, `display_start_hz`, `display_end_hz`, `max_span_hz`, derived `zoomed_in` flag, and computed `offset_hz`. Catches hypotheses 1 + 2 from the ticket (click outside AA-filter-safe range; zoomed view with narrower span than VFO can filter).

**DSP side**: `SetVfoOffset` handler logs `raw_sample_rate_hz`, `effective_sample_rate_hz`, derived `offset_within_effective` bool, and `vfo_exists`. Catches the decimation-active case (`decim_ratio > 1` → display spans ±raw/2 but VFO can only filter within ±effective/2).

No behaviour change — all `tracing::debug!` (zero-cost when filtered out). Next smoke test with `RUST_LOG=sdr_ui=debug,sdr_core=debug` produces actionable diagnostic output to drive the fix.

## #400 — FFI codec-mask exposure

Closes #400. FFI-hosted rtl_tcp servers can now advertise compression capability on mDNS and configure the server with non-`NONE_ONLY` codec mask. Four new tail fields on `SdrRtlTcpAdvertiseOptions` (`has_codecs`, `codecs`, `has_auth_required`, `auth_required`) + two on `SdrRtlTcpServerConfig` (`has_compression`, `compression`). Zero-init defaults match pre-0.19 behaviour exactly. ABI bumped 0.18 → 0.19.

Swift picker UI split into #417 per the Mac-session workflow rule.

## Test plan

- [x] \`cargo clippy --workspace --all-targets --features whisper-cuda -- -D warnings\` clean.
- [x] \`cargo test --workspace --features whisper-cuda\` green.
- [x] \`make ffi-header-check\` passes (cbindgen output matches).
- [ ] Manual smoke test (user): launch the GTK app, verify the λ/2 + λ/4 line renders in the status bar on tune, verify no regressions on Play/Stop.
- [ ] Manual smoke test (user): click-to-tune on a known strong signal, capture the tracing output for #337 analysis. Pass any surprise findings back through a follow-up PR.
- [ ] Manual smoke test (user): confirm #407 fix — hook up a dongle that previously needed reseating, verify first Play streams without a reseat.

## Follow-ups filed

- **#417** — macOS Swift picker UI for the new compression + auth-required fields (Mac-session work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Antenna dimension readout (λ/2, λ/4 and suggested V-angle) added to the status bar.
  * Click-to-tune preserves zoom context for more precise tuning.

* **Bug Fixes / Behavior**
  * RTL‑SDR startup forces tuner to manual gain (AGC off) and applies a mid-range gain; failures warn and startup continues.

* **Chores**
  * ABI minor bumped to 0.19 and FFI extended to support optional codec/auth and server compression fields.

* **Other**
  * Enhanced debug/logging around VFO offset and tuning actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->