### PR TITLE
sidebar activity-bar scaffolding + Parakeet v3 test pins

### DIFF
--- a/crates/sdr-transcription/src/sherpa_model.rs
+++ b/crates/sdr-transcription/src/sherpa_model.rs
@@ -824,6 +824,46 @@ mod tests {
     }
 
     #[test]
+    fn parakeet_v3_filename_and_label_match_upstream() {
+        // Upstream k2-fsa release filename + display label pin —
+        // deliberate literal test rather than deriving from the enum,
+        // so a future edit that accidentally changes either one fails
+        // here rather than silently breaking every user's download or
+        // their persisted UI selection. Mirrors the Whisper-side
+        // `large_v3_turbo_filename_matches_upstream` pattern.
+        assert_eq!(
+            SherpaModel::ParakeetTdt06bV3En.archive_filename(),
+            "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2"
+        );
+        assert_eq!(
+            SherpaModel::ParakeetTdt06bV3En.label(),
+            "Parakeet TDT 0.6b v3 (English)"
+        );
+        assert!(
+            SherpaModel::ParakeetTdt06bV3En
+                .archive_url()
+                .ends_with("sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2"),
+            "archive_url must resolve to the canonical upstream filename"
+        );
+    }
+
+    #[test]
+    fn all_models_preserves_legacy_indices() {
+        // Persistence contract: `ALL` is append-only. The UI stores
+        // the user's model choice as an index into this slice, so
+        // reordering or inserting mid-list would silently change
+        // existing users' selections on next launch. Pinning the
+        // leading indices here catches any accidental reordering.
+        // Mirrors the Whisper-side `all_models_preserves_legacy_indices`
+        // pattern.
+        let models = SherpaModel::ALL;
+        assert_eq!(models[0], SherpaModel::StreamingZipformerEn);
+        assert_eq!(models[1], SherpaModel::MoonshineTinyEn);
+        assert_eq!(models[2], SherpaModel::MoonshineBaseEn);
+        assert_eq!(models[3], SherpaModel::ParakeetTdt06bV3En);
+    }
+
+    #[test]
     fn silero_vad_path_is_under_sherpa_models_dir() {
         let path = silero_vad_path();
         assert!(path.ends_with("silero-vad/silero_vad.onnx"));

--- a/crates/sdr-ui/src/css.rs
+++ b/crates/sdr-ui/src/css.rs
@@ -62,34 +62,40 @@ const APP_CSS: &str = r#"
     background: transparent;
 }
 
-/* Activity bar — narrow strip of icon toggle buttons against window edge */
+/* Activity bar — narrow strip of icon toggle buttons against window
+ * edge. Visually a natural extension of the header bar: no chrome
+ * on buttons, icons sit on transparent background, subtle hover tint,
+ * and a thin accent strip + tint on the currently-selected icon.
+ */
 .activity-bar {
-    background-color: alpha(@theme_bg_color, 0.95);
-    border-right: 1px solid alpha(@borders, 0.4);
-    padding: 6px 2px;
+    background-color: transparent;
+    padding: 4px 0;
 }
 
-.activity-bar button {
-    min-width: 40px;
-    min-height: 40px;
-    padding: 8px;
-    border-radius: 4px;
-    margin: 2px 0;
+.activity-bar button.activity-bar-button {
+    min-width: 32px;
+    min-height: 32px;
+    padding: 4px;
+    margin: 2px 4px;
+    border-radius: 6px;
+    background: none;
+    border: none;
+    box-shadow: none;
+    color: alpha(@window_fg_color, 0.7);
 }
 
-.activity-bar button.accent {
-    border-left: 2px solid @accent_color;
+.activity-bar button.activity-bar-button:hover {
+    background-color: alpha(@window_fg_color, 0.08);
+    color: @window_fg_color;
 }
 
-/* Right activity bar — mirror the border to the left edge */
-.activity-bar-right {
-    border-left: 1px solid alpha(@borders, 0.4);
-    border-right: none;
+.activity-bar button.activity-bar-button:checked {
+    background-color: alpha(@accent_color, 0.15);
+    color: @accent_color;
 }
 
-.activity-bar-right button.accent {
-    border-left: none;
-    border-right: 2px solid @accent_color;
+.activity-bar button.activity-bar-button:checked:hover {
+    background-color: alpha(@accent_color, 0.2);
 }
 "#;
 

--- a/crates/sdr-ui/src/css.rs
+++ b/crates/sdr-ui/src/css.rs
@@ -61,6 +61,36 @@ const APP_CSS: &str = r#"
     border: none;
     background: transparent;
 }
+
+/* Activity bar — narrow strip of icon toggle buttons against window edge */
+.activity-bar {
+    background-color: alpha(@theme_bg_color, 0.95);
+    border-right: 1px solid alpha(@borders, 0.4);
+    padding: 6px 2px;
+}
+
+.activity-bar button {
+    min-width: 40px;
+    min-height: 40px;
+    padding: 8px;
+    border-radius: 4px;
+    margin: 2px 0;
+}
+
+.activity-bar button.accent {
+    border-left: 2px solid @accent_color;
+}
+
+/* Right activity bar — mirror the border to the left edge */
+.activity-bar-right {
+    border-left: 1px solid alpha(@borders, 0.4);
+    border-right: none;
+}
+
+.activity-bar-right button.accent {
+    border-left: none;
+    border-right: 2px solid @accent_color;
+}
 "#;
 
 /// Load the application CSS into the default display's style context.

--- a/crates/sdr-ui/src/shortcuts.rs
+++ b/crates/sdr-ui/src/shortcuts.rs
@@ -6,11 +6,7 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::header::demod_selector::DEMOD_MODE_COUNT;
-use crate::sidebar::ActivityBar;
-
-/// Ordered list of left-activity stable names used by `Ctrl+1`..`Ctrl+5`.
-/// Must match the `ActivityBarEntry::name` values in `window.rs`.
-const LEFT_ACTIVITY_SHORTCUT_NAMES: &[&str] = &["general", "radio", "audio", "display", "scanner"];
+use crate::sidebar::{ActivityBar, ActivityBarEntry, LEFT_ACTIVITIES, RIGHT_ACTIVITIES};
 
 /// Set up keyboard shortcuts on the application window.
 ///
@@ -128,26 +124,47 @@ pub fn setup_shortcuts(
         controller.add_shortcut(shortcut);
     }
 
-    // Ctrl+1..Ctrl+5: Select left activity by index. `emit_clicked`
-    // runs the activity bar's click handler, which handles the
-    // different-button-vs-same-button logic (swap stack or toggle
-    // panel). Going through the button keeps the visual `.accent`
-    // state and the logical selection in lockstep — same indirection
-    // pattern as the F9 sidebar toggle above.
-    for (index, name) in LEFT_ACTIVITY_SHORTCUT_NAMES.iter().enumerate() {
-        let Some(btn) = left_activity_bar.buttons.get(*name) else {
+    // Activity-bar keyboard bindings — iterate the canonical entry
+    // lists (single source of truth in `sidebar::activity_bar`) so a
+    // rename/reorder/new-entry in one place automatically propagates
+    // to both the GTK binding registration and the help-dialog
+    // catalog. `emit_clicked` routes through the activity bar's
+    // click handler, which manages selection vs. panel-toggle
+    // semantics and keeps `:checked` in lockstep with the logical
+    // selection.
+    register_activity_shortcuts(&controller, LEFT_ACTIVITIES, left_activity_bar);
+    register_activity_shortcuts(&controller, RIGHT_ACTIVITIES, right_activity_bar);
+
+    window.add_controller(controller);
+}
+
+/// Register `Ctrl+N` / `Ctrl+Shift+N` bindings for every entry in an
+/// activity list. Each binding fires `emit_clicked` on the matching
+/// `ToggleButton` so the press runs through the same click handler
+/// as a real click (preserving the selection-vs-toggle semantic).
+fn register_activity_shortcuts(
+    controller: &gtk4::ShortcutController,
+    entries: &[ActivityBarEntry],
+    bar: &ActivityBar,
+) {
+    for entry in entries {
+        let Some(btn) = bar.buttons.get(entry.name) else {
             tracing::warn!(
-                "Ctrl+{} shortcut has no matching activity button ({})",
-                index + 1,
-                name
+                "activity shortcut {} has no matching button ({})",
+                entry.accelerator,
+                entry.name
+            );
+            continue;
+        };
+        let Some(trigger) = gtk4::ShortcutTrigger::parse_string(entry.accelerator) else {
+            tracing::warn!(
+                "activity accelerator {} for {} failed to parse",
+                entry.accelerator,
+                entry.name
             );
             continue;
         };
         let btn_weak = btn.downgrade();
-        let trigger_str = format!("<Ctrl>{}", index + 1);
-        let Some(trigger) = gtk4::ShortcutTrigger::parse_string(&trigger_str) else {
-            continue;
-        };
         let action = gtk4::CallbackAction::new(move |_widget, _args| {
             if let Some(btn) = btn_weak.upgrade() {
                 btn.emit_clicked();
@@ -157,55 +174,72 @@ pub fn setup_shortcuts(
         });
         controller.add_shortcut(gtk4::Shortcut::new(Some(trigger), Some(action)));
     }
-
-    // Ctrl+Shift+1: Toggle right transcript panel. Single icon today;
-    // future additions extend this block with `<Ctrl><Shift>2` etc.
-    if let Some(transcript_btn) = right_activity_bar.buttons.get("transcript") {
-        let btn_weak = transcript_btn.downgrade();
-        if let Some(trigger) = gtk4::ShortcutTrigger::parse_string("<Ctrl><Shift>1") {
-            let action = gtk4::CallbackAction::new(move |_widget, _args| {
-                if let Some(btn) = btn_weak.upgrade() {
-                    btn.emit_clicked();
-                    return glib::Propagation::Stop;
-                }
-                glib::Propagation::Proceed
-            });
-            controller.add_shortcut(gtk4::Shortcut::new(Some(trigger), Some(action)));
-        }
-    }
-
-    window.add_controller(controller);
 }
 
-/// Shortcut catalog — single source of truth for the help dialog.
-const SHORTCUT_CATALOG: &[(&str, &[(&str, &str)])] = &[
-    (
-        "Playback",
-        &[("Space", "Play / Stop"), ("M", "Cycle demod mode")],
-    ),
-    (
-        "Navigation",
-        &[
-            ("F9", "Toggle left panel"),
-            ("Ctrl+1", "General panel"),
-            ("Ctrl+2", "Radio panel"),
-            ("Ctrl+3", "Audio panel"),
-            ("Ctrl+4", "Display panel"),
-            ("Ctrl+5", "Scanner panel"),
-            ("Ctrl+Shift+1", "Toggle transcript panel"),
-            ("Ctrl+B", "Toggle bookmarks panel"),
-            ("F8", "Toggle scanner"),
-        ],
-    ),
-    (
-        "Application",
-        &[
-            ("Ctrl+/", "Keyboard shortcuts"),
-            ("Ctrl+Q", "Quit"),
-            ("F1", "About"),
-        ],
-    ),
+/// Playback shortcuts — stable, no activity-bar dependency.
+const PLAYBACK_SHORTCUTS: &[(&str, &str)] = &[("Space", "Play / Stop"), ("M", "Cycle demod mode")];
+
+/// Static navigation shortcuts that don't come from the activity
+/// lists — F9/F8/Ctrl+B. Activity-bar `Ctrl+N`/`Ctrl+Shift+N`
+/// bindings are spliced in by [`shortcut_catalog`] so the dialog
+/// always reflects the canonical entry lists in
+/// `sidebar::activity_bar`.
+const NAV_STATIC_SHORTCUTS: &[(&str, &str)] = &[
+    ("F9", "Toggle left panel"),
+    ("Ctrl+B", "Toggle bookmarks panel"),
+    ("F8", "Toggle scanner"),
 ];
+
+/// Application-level shortcuts — stable.
+const APPLICATION_SHORTCUTS: &[(&str, &str)] = &[
+    ("Ctrl+/", "Keyboard shortcuts"),
+    ("Ctrl+Q", "Quit"),
+    ("F1", "About"),
+];
+
+/// Build the shortcut catalog shown in the help dialog. Navigation
+/// entries are derived from [`LEFT_ACTIVITIES`] / [`RIGHT_ACTIVITIES`]
+/// so renaming / reordering / adding an activity in
+/// `sidebar::activity_bar` updates the dialog automatically without
+/// requiring a separate table edit here.
+fn shortcut_catalog() -> Vec<(&'static str, Vec<(String, String)>)> {
+    let playback = PLAYBACK_SHORTCUTS
+        .iter()
+        .map(|(k, d)| ((*k).to_string(), (*d).to_string()))
+        .collect::<Vec<_>>();
+
+    let mut navigation: Vec<(String, String)> = Vec::new();
+    navigation.push((
+        NAV_STATIC_SHORTCUTS[0].0.to_string(),
+        NAV_STATIC_SHORTCUTS[0].1.to_string(),
+    ));
+    for entry in LEFT_ACTIVITIES {
+        navigation.push((
+            entry.shortcut_label.to_string(),
+            format!("{} panel", entry.display_name),
+        ));
+    }
+    for entry in RIGHT_ACTIVITIES {
+        navigation.push((
+            entry.shortcut_label.to_string(),
+            format!("Toggle {} panel", entry.display_name.to_lowercase()),
+        ));
+    }
+    for (key, desc) in &NAV_STATIC_SHORTCUTS[1..] {
+        navigation.push(((*key).to_string(), (*desc).to_string()));
+    }
+
+    let application = APPLICATION_SHORTCUTS
+        .iter()
+        .map(|(k, d)| ((*k).to_string(), (*d).to_string()))
+        .collect::<Vec<_>>();
+
+    vec![
+        ("Playback", playback),
+        ("Navigation", navigation),
+        ("Application", application),
+    ]
+}
 
 /// Dialog layout constants.
 const DIALOG_CONTENT_WIDTH: i32 = 400;
@@ -225,9 +259,9 @@ pub fn show_shortcuts_dialog(parent: &impl gtk4::prelude::IsA<gtk4::Widget>) {
         .margin_end(DIALOG_MARGIN_SIDE)
         .build();
 
-    for (group_name, entries) in SHORTCUT_CATALOG {
+    for (group_name, entries) in shortcut_catalog() {
         let group_label = gtk4::Label::builder()
-            .label(*group_name)
+            .label(group_name)
             .css_classes(["heading"])
             .halign(gtk4::Align::Start)
             .build();
@@ -238,10 +272,10 @@ pub fn show_shortcuts_dialog(parent: &impl gtk4::prelude::IsA<gtk4::Widget>) {
             .css_classes(["boxed-list"])
             .build();
 
-        for (key, description) in *entries {
-            let row = adw::ActionRow::builder().title(*description).build();
+        for (key, description) in entries {
+            let row = adw::ActionRow::builder().title(&description).build();
             let key_label = gtk4::Label::builder()
-                .label(*key)
+                .label(&key)
                 .css_classes(["dim-label"])
                 .build();
             row.add_suffix(&key_label);

--- a/crates/sdr-ui/src/shortcuts.rs
+++ b/crates/sdr-ui/src/shortcuts.rs
@@ -6,11 +6,21 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::header::demod_selector::DEMOD_MODE_COUNT;
+use crate::sidebar::ActivityBar;
+
+/// Ordered list of left-activity stable names used by `Ctrl+1`..`Ctrl+5`.
+/// Must match the `ActivityBarEntry::name` values in `window.rs`.
+const LEFT_ACTIVITY_SHORTCUT_NAMES: &[&str] = &["general", "radio", "audio", "display", "scanner"];
 
 /// Set up keyboard shortcuts on the application window.
 ///
 /// Registers shortcuts for play/stop toggle, demod cycling, sidebar toggle,
 /// and attaches a help overlay for `Ctrl+?`.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "single window-wide shortcut setup — callers already bundle their widgets; the registrations are parallel not chainable"
+)]
 pub fn setup_shortcuts(
     window: &adw::ApplicationWindow,
     play_button: &gtk4::ToggleButton,
@@ -18,6 +28,8 @@ pub fn setup_shortcuts(
     bookmarks_toggle: &gtk4::ToggleButton,
     demod_dropdown: &gtk4::DropDown,
     scanner_switch: &gtk4::Switch,
+    left_activity_bar: &ActivityBar,
+    right_activity_bar: &ActivityBar,
 ) {
     let controller = gtk4::ShortcutController::new();
     controller.set_scope(gtk4::ShortcutScope::Managed);
@@ -116,6 +128,52 @@ pub fn setup_shortcuts(
         controller.add_shortcut(shortcut);
     }
 
+    // Ctrl+1..Ctrl+5: Select left activity by index. `emit_clicked`
+    // runs the activity bar's click handler, which handles the
+    // different-button-vs-same-button logic (swap stack or toggle
+    // panel). Going through the button keeps the visual `.accent`
+    // state and the logical selection in lockstep — same indirection
+    // pattern as the F9 sidebar toggle above.
+    for (index, name) in LEFT_ACTIVITY_SHORTCUT_NAMES.iter().enumerate() {
+        let Some(btn) = left_activity_bar.buttons.get(*name) else {
+            tracing::warn!(
+                "Ctrl+{} shortcut has no matching activity button ({})",
+                index + 1,
+                name
+            );
+            continue;
+        };
+        let btn_weak = btn.downgrade();
+        let trigger_str = format!("<Ctrl>{}", index + 1);
+        let Some(trigger) = gtk4::ShortcutTrigger::parse_string(&trigger_str) else {
+            continue;
+        };
+        let action = gtk4::CallbackAction::new(move |_widget, _args| {
+            if let Some(btn) = btn_weak.upgrade() {
+                btn.emit_clicked();
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        controller.add_shortcut(gtk4::Shortcut::new(Some(trigger), Some(action)));
+    }
+
+    // Ctrl+Shift+1: Toggle right transcript panel. Single icon today;
+    // future additions extend this block with `<Ctrl><Shift>2` etc.
+    if let Some(transcript_btn) = right_activity_bar.buttons.get("transcript") {
+        let btn_weak = transcript_btn.downgrade();
+        if let Some(trigger) = gtk4::ShortcutTrigger::parse_string("<Ctrl><Shift>1") {
+            let action = gtk4::CallbackAction::new(move |_widget, _args| {
+                if let Some(btn) = btn_weak.upgrade() {
+                    btn.emit_clicked();
+                    return glib::Propagation::Stop;
+                }
+                glib::Propagation::Proceed
+            });
+            controller.add_shortcut(gtk4::Shortcut::new(Some(trigger), Some(action)));
+        }
+    }
+
     window.add_controller(controller);
 }
 
@@ -128,7 +186,13 @@ const SHORTCUT_CATALOG: &[(&str, &[(&str, &str)])] = &[
     (
         "Navigation",
         &[
-            ("F9", "Toggle sidebar"),
+            ("F9", "Toggle left panel"),
+            ("Ctrl+1", "General panel"),
+            ("Ctrl+2", "Radio panel"),
+            ("Ctrl+3", "Audio panel"),
+            ("Ctrl+4", "Display panel"),
+            ("Ctrl+5", "Scanner panel"),
+            ("Ctrl+Shift+1", "Toggle transcript panel"),
             ("Ctrl+B", "Toggle bookmarks panel"),
             ("F8", "Toggle scanner"),
         ],

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -67,9 +67,13 @@ pub struct ActivityBar {
 
 /// Build an activity bar for one window edge.
 ///
-/// Entries are packed top-down in the given order; the first entry
-/// starts `active` so a panel is always selected on launch. Callers
-/// persist and restore `active` state themselves (sub-ticket #428).
+/// Every button is flat (no chrome), sized to match libadwaita
+/// header-bar buttons so the activity bar reads as a natural window-
+/// edge extension rather than an inset toolbar. Initial `active` and
+/// `.accent` state are the caller's responsibility — left bars
+/// typically start with the first entry selected (a panel is always
+/// visible); the right bar starts with no entry selected (panel
+/// closed by default).
 pub fn build_activity_bar(entries: &[ActivityBarEntry], side: ActivityBarSide) -> ActivityBar {
     let widget = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
@@ -84,23 +88,16 @@ pub fn build_activity_bar(entries: &[ActivityBarEntry], side: ActivityBarSide) -
 
     let mut buttons = HashMap::with_capacity(entries.len());
 
-    for (index, entry) in entries.iter().enumerate() {
+    for entry in entries {
         let btn = gtk4::ToggleButton::builder()
             .icon_name(entry.icon_name)
             .tooltip_text(format!("{} ({})", entry.display_name, entry.shortcut_label))
-            .active(index == 0)
+            .css_classes(["flat", "activity-bar-button"])
             .build();
 
         // Explicit accessibility label — tooltip text is not reliably
         // announced by screen readers (see module docs §Accessibility).
         btn.update_property(&[gtk4::accessible::Property::Label(entry.display_name)]);
-
-        // The first entry starts as the selected activity; give it
-        // the `.accent` class so its selected-strip matches the
-        // click-handler's later toggling.
-        if index == 0 {
-            btn.add_css_class("accent");
-        }
 
         widget.append(&btn);
         buttons.insert(entry.name, btn);

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -27,8 +27,13 @@ use std::collections::HashMap;
 
 use gtk4::prelude::*;
 
-/// One entry in an activity bar.
-#[derive(Clone, Copy)]
+/// One entry in an activity bar. Used as the single source of truth
+/// for the activity's identity, icon, accessible/tooltip label, and
+/// keyboard shortcut — any consumer that needs one piece of this
+/// metadata derives the rest from the entry so the activity bar,
+/// keyboard-shortcut registration, help dialog, and (future) config
+/// persistence never drift out of sync.
+#[derive(Clone, Copy, Debug)]
 pub struct ActivityBarEntry {
     /// Stable identifier used as the `GtkStack` child name and config
     /// key (e.g. `"general"`, `"transcript"`). Lowercase, kebab-case
@@ -39,11 +44,75 @@ pub struct ActivityBarEntry {
     /// Human-readable activity name (e.g. `"General"`). Used as the
     /// accessible label and the tooltip prefix.
     pub display_name: &'static str,
-    /// Keyboard-shortcut label shown in the tooltip (e.g. `"Ctrl+1"`).
-    /// Does not bind the shortcut — the caller does that via
-    /// `GtkShortcutController`; this is display-only.
+    /// Keyboard-shortcut label shown in the tooltip and help dialog
+    /// (e.g. `"Ctrl+1"`). Human-readable sibling of [`accelerator`].
+    ///
+    /// [`accelerator`]: Self::accelerator
     pub shortcut_label: &'static str,
+    /// `GtkShortcutTrigger::parse_string` input for this entry's
+    /// keyboard binding (e.g. `"<Ctrl>1"`, `"<Ctrl><Shift>1"`). The
+    /// machine-readable sibling of [`shortcut_label`].
+    ///
+    /// [`shortcut_label`]: Self::shortcut_label
+    pub accelerator: &'static str,
 }
+
+/// Canonical left-activity-bar entries — sub-tickets #422–#426 swap
+/// the `name` entries' stack children for real panels, but the
+/// order, names, icons, and keyboard bindings defined here are the
+/// single source of truth. `shortcuts.rs` iterates this slice to
+/// register `Ctrl+N` bindings AND to generate the help-dialog
+/// Navigation rows; changing an entry here propagates to both.
+pub const LEFT_ACTIVITIES: &[ActivityBarEntry] = &[
+    ActivityBarEntry {
+        name: "general",
+        icon_name: "go-home-symbolic",
+        display_name: "General",
+        shortcut_label: "Ctrl+1",
+        accelerator: "<Ctrl>1",
+    },
+    ActivityBarEntry {
+        name: "radio",
+        icon_name: "audio-input-microphone-symbolic",
+        display_name: "Radio",
+        shortcut_label: "Ctrl+2",
+        accelerator: "<Ctrl>2",
+    },
+    ActivityBarEntry {
+        name: "audio",
+        icon_name: "audio-speakers-symbolic",
+        display_name: "Audio",
+        shortcut_label: "Ctrl+3",
+        accelerator: "<Ctrl>3",
+    },
+    ActivityBarEntry {
+        name: "display",
+        icon_name: "video-display-symbolic",
+        display_name: "Display",
+        shortcut_label: "Ctrl+4",
+        accelerator: "<Ctrl>4",
+    },
+    ActivityBarEntry {
+        name: "scanner",
+        icon_name: "media-seek-forward-symbolic",
+        display_name: "Scanner",
+        shortcut_label: "Ctrl+5",
+        accelerator: "<Ctrl>5",
+    },
+];
+
+/// Canonical right-activity-bar entries. Single entry today; the
+/// slice-based API future-proofs the pattern for Recordings /
+/// Event log / etc. Consumers derive shortcut registration and help
+/// rows from this — same single-source-of-truth contract as
+/// [`LEFT_ACTIVITIES`].
+pub const RIGHT_ACTIVITIES: &[ActivityBarEntry] = &[ActivityBarEntry {
+    name: "transcript",
+    icon_name: "user-available-symbolic",
+    display_name: "Transcript",
+    shortcut_label: "Ctrl+Shift+1",
+    accelerator: "<Ctrl><Shift>1",
+}];
 
 /// Which edge of the window the activity bar sits against. Controls
 /// the CSS class list and the border side.
@@ -109,28 +178,110 @@ pub fn build_activity_bar(entries: &[ActivityBarEntry], side: ActivityBarSide) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+
+    /// Every activity entry's invariants the consumers rely on:
+    /// `name`/`display_name`/`icon_name`/`accelerator` all non-empty,
+    /// `shortcut_label` non-empty, and each field reasonably formed.
+    fn assert_entry_well_formed(entry: &ActivityBarEntry) {
+        assert!(!entry.name.is_empty(), "name empty: {entry:?}");
+        assert!(
+            entry.name == entry.name.to_lowercase(),
+            "name must be lowercase: {}",
+            entry.name
+        );
+        assert!(
+            !entry.icon_name.is_empty(),
+            "icon_name empty for {}",
+            entry.name
+        );
+        assert!(
+            !entry.display_name.is_empty(),
+            "display_name empty for {}",
+            entry.name
+        );
+        assert!(
+            !entry.shortcut_label.is_empty(),
+            "shortcut_label empty for {}",
+            entry.name
+        );
+        assert!(
+            !entry.accelerator.is_empty(),
+            "accelerator empty for {}",
+            entry.name
+        );
+    }
+
+    /// Stack-child names are used as config-persistence keys
+    /// (design doc §5) and as visible-child identifiers in
+    /// `GtkStack`; duplicates would silently collapse stack
+    /// children and corrupt saved expansion state on the next
+    /// launch.
+    fn assert_names_unique(entries: &[ActivityBarEntry]) {
+        let mut seen: HashSet<&'static str> = HashSet::new();
+        for entry in entries {
+            assert!(
+                seen.insert(entry.name),
+                "duplicate name in activity list: {}",
+                entry.name
+            );
+        }
+    }
+
+    /// `accelerator` and `shortcut_label` are parallel — if one
+    /// gets renamed without the other, the tooltip and the
+    /// registered binding drift. Enforce a loose contract: both
+    /// reference the same modifier + key set.
+    fn assert_accelerator_matches_label(entry: &ActivityBarEntry) {
+        for fragment in ["Ctrl", "Shift", "Alt"] {
+            let label_mentions = entry.shortcut_label.contains(fragment);
+            let accelerator_mentions = entry
+                .accelerator
+                .to_ascii_lowercase()
+                .contains(&fragment.to_ascii_lowercase());
+            assert_eq!(
+                label_mentions, accelerator_mentions,
+                "shortcut_label ({}) and accelerator ({}) disagree on {fragment}",
+                entry.shortcut_label, entry.accelerator,
+            );
+        }
+    }
 
     #[test]
-    fn entries_preserve_order_and_count() {
-        let entries = &[
-            ActivityBarEntry {
-                name: "general",
-                icon_name: "go-home-symbolic",
-                display_name: "General",
-                shortcut_label: "Ctrl+1",
-            },
-            ActivityBarEntry {
-                name: "radio",
-                icon_name: "audio-input-microphone-symbolic",
-                display_name: "Radio",
-                shortcut_label: "Ctrl+2",
-            },
-        ];
-        // `gtk4::init` is required before constructing widgets; skip
-        // the widget build here and just exercise the entry-shape
-        // invariant the builder relies on.
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0].name, "general");
-        assert_eq!(entries[1].shortcut_label, "Ctrl+2");
+    fn left_activities_are_well_formed() {
+        assert!(!LEFT_ACTIVITIES.is_empty());
+        for entry in LEFT_ACTIVITIES {
+            assert_entry_well_formed(entry);
+            assert_accelerator_matches_label(entry);
+        }
+        assert_names_unique(LEFT_ACTIVITIES);
+    }
+
+    #[test]
+    fn right_activities_are_well_formed() {
+        assert!(!RIGHT_ACTIVITIES.is_empty());
+        for entry in RIGHT_ACTIVITIES {
+            assert_entry_well_formed(entry);
+            assert_accelerator_matches_label(entry);
+        }
+        assert_names_unique(RIGHT_ACTIVITIES);
+    }
+
+    #[test]
+    fn activity_names_do_not_collide_across_bars() {
+        // Left/right stacks are independent, but config-persistence
+        // keys (`ui.sidebar.<side>.expanded[<name>][...]`) are
+        // namespaced by side. Names colliding across bars would
+        // still be technically safe but makes key collisions easy
+        // to mistake for an error in code review — keep the two
+        // sets disjoint as a belt-and-braces contract.
+        let mut combined: HashSet<&'static str> = HashSet::new();
+        for entry in LEFT_ACTIVITIES.iter().chain(RIGHT_ACTIVITIES.iter()) {
+            assert!(
+                combined.insert(entry.name),
+                "activity name collides across bars: {}",
+                entry.name
+            );
+        }
     }
 }

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -1,0 +1,139 @@
+//! VS Code-style activity bar — narrow vertical strip of icon toggle
+//! buttons used to switch between panel "activities" (General, Radio,
+//! Audio, Display, Scanner on the left; Transcript on the right).
+//!
+//! See `docs/design/sidebar-activity-bar-redesign.md` §2.3 for the
+//! design rationale. This module produces the widget; wiring (stack
+//! child swaps, split-view show-sidebar toggle, keyboard shortcuts)
+//! lives in `window.rs` so the activity bar stays independent of
+//! which panels the app actually hosts.
+//!
+//! # Mutual exclusion
+//!
+//! `GtkToggleButton::set_group` is intentionally NOT used. That API
+//! enforces radio-group semantics, which prevents the "click-selected-
+//! icon-to-collapse-panel" behavior the design calls for. Callers
+//! manage mutual exclusion manually in their click handlers.
+//!
+//! # Accessibility
+//!
+//! Every icon-only button sets an explicit `GtkAccessible` label via
+//! `update_property`. Tooltip text alone is not announced reliably by
+//! screen readers, so it cannot substitute. This mirrors the idiom
+//! used by other icon-only controls in this crate (bookmarks toggle,
+//! pinned-servers menu, etc.).
+
+use std::collections::HashMap;
+
+use gtk4::prelude::*;
+
+/// One entry in an activity bar.
+#[derive(Clone, Copy)]
+pub struct ActivityBarEntry {
+    /// Stable identifier used as the `GtkStack` child name and config
+    /// key (e.g. `"general"`, `"transcript"`). Lowercase, kebab-case
+    /// if multi-word; stable across versions.
+    pub name: &'static str,
+    /// GNOME symbolic icon name (e.g. `"go-home-symbolic"`).
+    pub icon_name: &'static str,
+    /// Human-readable activity name (e.g. `"General"`). Used as the
+    /// accessible label and the tooltip prefix.
+    pub display_name: &'static str,
+    /// Keyboard-shortcut label shown in the tooltip (e.g. `"Ctrl+1"`).
+    /// Does not bind the shortcut — the caller does that via
+    /// `GtkShortcutController`; this is display-only.
+    pub shortcut_label: &'static str,
+}
+
+/// Which edge of the window the activity bar sits against. Controls
+/// the CSS class list and the border side.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActivityBarSide {
+    Left,
+    Right,
+}
+
+/// An assembled activity bar — the widget for packing and the set of
+/// toggle buttons keyed by `ActivityBarEntry::name` for click-handler
+/// wiring.
+pub struct ActivityBar {
+    /// Vertical `GtkBox` with the `.activity-bar` CSS class applied.
+    /// Pack this into the window's main horizontal container.
+    pub widget: gtk4::Box,
+    /// Map from entry `name` → `ToggleButton`. Callers iterate this
+    /// to attach click handlers and keyboard-shortcut targets.
+    pub buttons: HashMap<&'static str, gtk4::ToggleButton>,
+}
+
+/// Build an activity bar for one window edge.
+///
+/// Entries are packed top-down in the given order; the first entry
+/// starts `active` so a panel is always selected on launch. Callers
+/// persist and restore `active` state themselves (sub-ticket #428).
+pub fn build_activity_bar(entries: &[ActivityBarEntry], side: ActivityBarSide) -> ActivityBar {
+    let widget = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(0)
+        .css_classes(match side {
+            ActivityBarSide::Left => vec!["activity-bar".to_string()],
+            ActivityBarSide::Right => {
+                vec!["activity-bar".to_string(), "activity-bar-right".to_string()]
+            }
+        })
+        .build();
+
+    let mut buttons = HashMap::with_capacity(entries.len());
+
+    for (index, entry) in entries.iter().enumerate() {
+        let btn = gtk4::ToggleButton::builder()
+            .icon_name(entry.icon_name)
+            .tooltip_text(format!("{} ({})", entry.display_name, entry.shortcut_label))
+            .active(index == 0)
+            .build();
+
+        // Explicit accessibility label — tooltip text is not reliably
+        // announced by screen readers (see module docs §Accessibility).
+        btn.update_property(&[gtk4::accessible::Property::Label(entry.display_name)]);
+
+        // The first entry starts as the selected activity; give it
+        // the `.accent` class so its selected-strip matches the
+        // click-handler's later toggling.
+        if index == 0 {
+            btn.add_css_class("accent");
+        }
+
+        widget.append(&btn);
+        buttons.insert(entry.name, btn);
+    }
+
+    ActivityBar { widget, buttons }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entries_preserve_order_and_count() {
+        let entries = &[
+            ActivityBarEntry {
+                name: "general",
+                icon_name: "go-home-symbolic",
+                display_name: "General",
+                shortcut_label: "Ctrl+1",
+            },
+            ActivityBarEntry {
+                name: "radio",
+                icon_name: "audio-input-microphone-symbolic",
+                display_name: "Radio",
+                shortcut_label: "Ctrl+2",
+            },
+        ];
+        // `gtk4::init` is required before constructing widgets; skip
+        // the widget build here and just exercise the entry-shape
+        // invariant the builder relies on.
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "general");
+        assert_eq!(entries[1].shortcut_label, "Ctrl+2");
+    }
+}

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -17,7 +17,10 @@ pub mod server_panel;
 pub mod source_panel;
 pub mod transcript_panel;
 
-pub use activity_bar::{ActivityBar, ActivityBarEntry, ActivityBarSide, build_activity_bar};
+pub use activity_bar::{
+    ActivityBar, ActivityBarEntry, ActivityBarSide, LEFT_ACTIVITIES, RIGHT_ACTIVITIES,
+    build_activity_bar,
+};
 pub use audio_panel::{AudioPanel, build_audio_panel};
 pub use bookmarks_panel::{BookmarksPanel, build_bookmarks_panel};
 pub use display_panel::{DisplayPanel, build_display_panel};

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use gtk4::prelude::*;
 
+pub mod activity_bar;
 pub mod audio_panel;
 pub mod bookmarks_panel;
 pub mod display_panel;
@@ -16,6 +17,7 @@ pub mod server_panel;
 pub mod source_panel;
 pub mod transcript_panel;
 
+pub use activity_bar::{ActivityBar, ActivityBarEntry, ActivityBarSide, build_activity_bar};
 pub use audio_panel::{AudioPanel, build_audio_panel};
 pub use bookmarks_panel::{BookmarksPanel, build_bookmarks_panel};
 pub use display_panel::{DisplayPanel, build_display_panel};

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -866,10 +866,17 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
         .margin_top(4)
         .build();
 
+    // `WordChar` wraps on word boundaries OR mid-word when a single
+    // token is wider than the panel — critical for monospace-rendered
+    // transcription output, where a long contiguous token (non-Latin
+    // script, URLs, technical jargon) with plain `Word` wrapping
+    // grows the `TextView`'s natural width, propagates up through the
+    // scrolled window, and fights the sidebar `min-sidebar-width`.
+    // That fight reads as layout "bouncing" while captions stream in.
     let text_view = gtk4::TextView::builder()
         .editable(false)
         .cursor_visible(false)
-        .wrap_mode(gtk4::WrapMode::Word)
+        .wrap_mode(gtk4::WrapMode::WordChar)
         .monospace(true)
         .top_margin(8)
         .bottom_margin(8)
@@ -879,6 +886,12 @@ pub fn build_transcript_panel(config: &Arc<ConfigManager>) -> TranscriptPanel {
 
     let scroll = gtk4::ScrolledWindow::builder()
         .child(&text_view)
+        // `hscrollbar_policy=Never` keeps the horizontal scrollbar
+        // from appearing as a secondary symptom of the above —
+        // with `WordChar` wrapping it's never needed, and an
+        // `Automatic` policy would briefly flash the scrollbar
+        // while content was still renegotiating width.
+        .hscrollbar_policy(gtk4::PolicyType::Never)
         .min_content_height(150)
         .vexpand(true)
         .css_classes(["card"])

--- a/crates/sdr-ui/src/status_bar.rs
+++ b/crates/sdr-ui/src/status_bar.rs
@@ -185,14 +185,32 @@ impl StatusBar {
 
 /// Build the status bar widget with initial placeholder labels.
 pub fn build_status_bar() -> StatusBar {
-    let signal_level_label = gtk4::Label::new(Some(DEFAULT_LEVEL_TEXT));
-    let sample_rate_label = gtk4::Label::new(Some(DEFAULT_SAMPLE_RATE_TEXT));
-    let demod_label = gtk4::Label::new(Some(DEFAULT_DEMOD_TEXT));
-    let frequency_label = gtk4::Label::new(Some(DEFAULT_FREQUENCY_TEXT));
-    let antenna_label = gtk4::Label::new(Some(DEFAULT_ANTENNA_TEXT));
+    // Ellipsize every label so a crowded status bar (long frequency
+    // + long antenna readout + live cursor readout + role badge)
+    // can shrink gracefully below its natural width when the
+    // sidebars pinch content-area room. Without this, the status
+    // bar demands its full natural width from its parent, which
+    // with both sidebars open leaves the content area in a
+    // renegotiation loop with the split view — the visible symptom
+    // is a few-pixel layout "bounce" every time a label updates.
+    // `EllipsizeMode::End` puts "…" at the end of the trimmed text;
+    // combined with not setting `max_width_chars`, GTK picks the
+    // widest fit per frame and shrinks only when needed.
+    let make_label = |text: &str| -> gtk4::Label {
+        let label = gtk4::Label::new(Some(text));
+        label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+        label.set_xalign(0.0);
+        label
+    };
+
+    let signal_level_label = make_label(DEFAULT_LEVEL_TEXT);
+    let sample_rate_label = make_label(DEFAULT_SAMPLE_RATE_TEXT);
+    let demod_label = make_label(DEFAULT_DEMOD_TEXT);
+    let frequency_label = make_label(DEFAULT_FREQUENCY_TEXT);
+    let antenna_label = make_label(DEFAULT_ANTENNA_TEXT);
     let antenna_separator = gtk4::Separator::new(gtk4::Orientation::Vertical);
-    let cursor_label = gtk4::Label::new(Some(DEFAULT_CURSOR_TEXT));
-    let role_label = gtk4::Label::new(Some(DEFAULT_ROLE_TEXT));
+    let cursor_label = make_label(DEFAULT_CURSOR_TEXT);
+    let role_label = make_label(DEFAULT_ROLE_TEXT);
     role_label.set_visible(false);
     let role_separator = gtk4::Separator::new(gtk4::Orientation::Vertical);
     role_separator.set_visible(false);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1927,6 +1927,18 @@ fn build_layout(
 
     // Inner (right) split view — sidebar sits on the trailing edge
     // so the right activity bar is the rightmost element on-screen.
+    // `sidebar-width-unit = Px` makes `sidebar_width_fraction`
+    // interpret its argument as literal pixels instead of a fraction
+    // of the split view's allocated width. Without this, the
+    // default-width math lies under nesting: the left split view is
+    // already narrower than the window (activity bars are outside
+    // it), and the right split view is narrower again (it lives in
+    // the left split's content area), so a naive
+    // `LEFT_SIDEBAR_DEFAULT_WIDTH / DEFAULT_WIDTH` fraction resolves
+    // to something smaller than the desired pixel width on every
+    // child. Pixels-first avoids the post-realize callback path and
+    // matches the `min_sidebar_width` / `max_sidebar_width` pixel
+    // units already in use.
     let right_split_view = adw::OverlaySplitView::builder()
         .sidebar_position(gtk4::PackType::End)
         .sidebar(&right_stack)
@@ -1934,7 +1946,8 @@ fn build_layout(
         .show_sidebar(false)
         .min_sidebar_width(RIGHT_SIDEBAR_MIN_WIDTH)
         .max_sidebar_width(RIGHT_SIDEBAR_DEFAULT_WIDTH * 2.0)
-        .sidebar_width_fraction(RIGHT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
+        .sidebar_width_unit(adw::LengthUnit::Px)
+        .sidebar_width_fraction(RIGHT_SIDEBAR_DEFAULT_WIDTH)
         .build();
 
     // Outer (left) split view — sidebar hosts the left activity
@@ -1946,7 +1959,8 @@ fn build_layout(
         .show_sidebar(true)
         .min_sidebar_width(LEFT_SIDEBAR_MIN_WIDTH)
         .max_sidebar_width(LEFT_SIDEBAR_DEFAULT_WIDTH * 2.0)
-        .sidebar_width_fraction(LEFT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
+        .sidebar_width_unit(adw::LengthUnit::Px)
+        .sidebar_width_fraction(LEFT_SIDEBAR_DEFAULT_WIDTH)
         .build();
     left_stack.set_visible_child_name("general");
 
@@ -6051,7 +6065,12 @@ fn connect_source_panel(
             ) else {
                 return;
             };
-            let is_network_path = device_row.selected() == DEVICE_RTLTCP;
+            // Raw Network (TCP/UDP IQ) has the same wire-bandwidth
+            // cost profile as rtl_tcp — a high-sample-rate pull
+            // across the network will saturate a 100 Mbit link
+            // either way. The advisory applies equally to both
+            // network-backed source types.
+            let is_network_path = matches!(device_row.selected(), DEVICE_NETWORK | DEVICE_RTLTCP);
             // Bounds-check the sample-rate index: transient
             // out-of-range values from widget-model churn would
             // otherwise satisfy the `>= threshold` compare and

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -169,7 +169,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         left_activity_bar,
         right_activity_bar,
         left_stack,
-        right_stack,
+        right_stack: _right_stack,
         panels,
         spectrum_handle: spectrum_handle_raw,
         status_bar,
@@ -256,53 +256,59 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
 
     // --- Activity-bar wiring ---
     //
-    // Click on a NEW left icon → deselect other buttons, switch
-    // stack, ensure left panel is open.
-    // Click on the CURRENTLY-selected left icon → keep icon
-    // selected (design doc §4.2) and toggle panel open/closed.
-    // Accent CSS class tracks the `active` state via a `toggled`
-    // handler per button so screen-reader and visual states stay
-    // in lockstep.
+    // Left (multi-button): click on a NEW icon → deselect siblings,
+    // switch stack, open panel. Click on the CURRENTLY-selected
+    // icon → icon stays selected (design doc §4.2), panel toggles.
+    // `:checked` CSS renders the accent tint automatically.
+    if let Some(general_btn) = left_activity_bar.buttons.get("general") {
+        general_btn.set_active(true);
+    }
     wire_activity_bar_clicks(&left_activity_bar, &left_stack, &left_split_view, "general");
-    wire_activity_bar_clicks(
-        &right_activity_bar,
-        &right_stack,
-        &right_split_view,
-        "transcript",
-    );
 
-    // Header transcript button ↔ right activity bar transcript
-    // toggle — two-way sync so clicking either one drives the
-    // same panel. `set_active(x)` on an already-in-state-`x` toggle
-    // is a no-op (GTK suppresses `toggled`), so the mutual calls
-    // don't infinite-loop.
+    // Right (single-button): the transcript toggle, the header
+    // transcript button, and `right_split_view.show-sidebar` form a
+    // tri-state that must stay in sync. Approach: each toggle button
+    // writes its `active` state through to `show-sidebar`; the split
+    // view's `notify::show-sidebar` reflects back into both buttons.
+    // `set_active(x)` on an already-in-state-`x` button is a GTK
+    // no-op (no `toggled` signal), so the two-way propagation is
+    // naturally idempotent.
     if let Some(right_transcript_btn) = right_activity_bar.buttons.get("transcript") {
-        let right_btn_weak = right_transcript_btn.downgrade();
-        transcript_button.connect_toggled(move |btn| {
-            if let Some(right) = right_btn_weak.upgrade()
-                && right.is_active() != btn.is_active()
-            {
-                right.set_active(btn.is_active());
-                right.emit_clicked();
-            }
-        });
-        // Initial state: right panel starts closed, so the header
-        // toggle starts inactive. Restore-from-config happens in
-        // sub-ticket #428.
-        transcript_button.set_active(right_transcript_btn.is_active());
-
-        let header_btn_weak = transcript_button.downgrade();
         let right_split_weak = right_split_view.downgrade();
         right_transcript_btn.connect_toggled(move |btn| {
-            if let Some(hdr) = header_btn_weak.upgrade()
-                && hdr.is_active() != btn.is_active()
-            {
-                hdr.set_active(btn.is_active());
-            }
             if let Some(sv) = right_split_weak.upgrade() {
                 sv.set_show_sidebar(btn.is_active());
             }
         });
+
+        let right_split_weak = right_split_view.downgrade();
+        transcript_button.connect_toggled(move |btn| {
+            if let Some(sv) = right_split_weak.upgrade() {
+                sv.set_show_sidebar(btn.is_active());
+            }
+        });
+
+        let right_btn_weak = right_transcript_btn.downgrade();
+        let header_btn_weak = transcript_button.downgrade();
+        right_split_view.connect_show_sidebar_notify(move |sv| {
+            let visible = sv.shows_sidebar();
+            if let Some(rb) = right_btn_weak.upgrade()
+                && rb.is_active() != visible
+            {
+                rb.set_active(visible);
+            }
+            if let Some(hdr) = header_btn_weak.upgrade()
+                && hdr.is_active() != visible
+            {
+                hdr.set_active(visible);
+            }
+        });
+
+        // Initial alignment — panel is closed at launch, so both
+        // buttons start inactive. Config-driven restoration comes
+        // in sub-ticket #428.
+        right_transcript_btn.set_active(false);
+        transcript_button.set_active(false);
     }
 
     let toolbar_view = build_toolbar_view(&header, &layout_root);
@@ -1798,13 +1804,20 @@ const RIGHT_ACTIVITY_ENTRIES: &[sidebar::ActivityBarEntry] = &[sidebar::Activity
     shortcut_label: "Ctrl+Shift+1",
 }];
 
-/// Minimum side-panel width in pixels — narrower than this makes
+/// Minimum left-panel width in pixels — narrower than this makes
 /// `AdwPreferencesGroup` content wrap awkwardly (design doc §4.4).
-const SIDEBAR_MIN_WIDTH: f64 = 220.0;
+const LEFT_SIDEBAR_MIN_WIDTH: f64 = 220.0;
+/// Minimum right-panel width. The transcript panel's controls
+/// (model combo, VAD slider, auto-break sliders) need more breathing
+/// room than a preferences row — below this they stack awkwardly
+/// and the transcript text view loses usable line width.
+const RIGHT_SIDEBAR_MIN_WIDTH: f64 = 360.0;
 /// Default left-panel width — matches today's sidebar width.
 const LEFT_SIDEBAR_DEFAULT_WIDTH: f64 = 320.0;
-/// Default right-panel width — matches today's transcript flyout width.
-const RIGHT_SIDEBAR_DEFAULT_WIDTH: f64 = 360.0;
+/// Default right-panel width — gives the transcript panel room for
+/// its wider controls without the user having to resize on every
+/// launch.
+const RIGHT_SIDEBAR_DEFAULT_WIDTH: f64 = 420.0;
 
 /// Handles returned by [`build_layout`] for downstream wiring. Bundled
 /// into a struct rather than a tuple because the return list grew past
@@ -1954,7 +1967,7 @@ fn build_layout(
         .sidebar(&right_stack)
         .content(&content_inner)
         .show_sidebar(false)
-        .min_sidebar_width(SIDEBAR_MIN_WIDTH)
+        .min_sidebar_width(RIGHT_SIDEBAR_MIN_WIDTH)
         .max_sidebar_width(RIGHT_SIDEBAR_DEFAULT_WIDTH * 2.0)
         .sidebar_width_fraction(RIGHT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
@@ -1966,7 +1979,7 @@ fn build_layout(
         .sidebar(&left_stack)
         .content(&right_split_view)
         .show_sidebar(true)
-        .min_sidebar_width(SIDEBAR_MIN_WIDTH)
+        .min_sidebar_width(LEFT_SIDEBAR_MIN_WIDTH)
         .max_sidebar_width(LEFT_SIDEBAR_DEFAULT_WIDTH * 2.0)
         .sidebar_width_fraction(LEFT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
@@ -2265,23 +2278,28 @@ fn build_toolbar_view(header: &adw::HeaderBar, content: &gtk4::Box) -> adw::Tool
     toolbar_view
 }
 
-/// Wire click handlers on every button of an activity bar so that:
+/// Wire click handlers on every button of a multi-activity bar so:
 ///
-/// - Clicking a *different* button swaps the stack's visible child,
-///   moves the `.accent` CSS class to the new button, and forces the
-///   split view's sidebar open.
+/// - Clicking a *different* button swaps the stack's visible child
+///   and forces the split view's sidebar open.
 /// - Clicking the *currently-selected* button keeps that button
 ///   visually selected (design doc §4.2 — the user's mental model is
 ///   "I'm still in Radio, I just closed the panel for a second") and
 ///   toggles the split view's sidebar show/hide.
 ///
-/// `initial_selected` is the `name` that starts selected on launch.
-/// It must match the stack's initial visible child and the button
-/// that `build_activity_bar` initialised with the `.accent` class
-/// (the first entry in the list passed to that function).
+/// `initial_selected` must match the stack's initial visible child
+/// and the button the caller pre-activated via `set_active(true)`.
+///
+/// The `:checked` CSS pseudo-class (driven by `ToggleButton::active`)
+/// renders the accent tint — no manual CSS class juggling needed.
 ///
 /// Mutual exclusion is enforced manually rather than via
 /// `ToggleButton::set_group`; see `sidebar::activity_bar` module docs.
+///
+/// Only suitable for bars with more than one entry. Single-button
+/// bars (like the right transcript bar today) wire `active` directly
+/// to `show_sidebar` — there's no "select vs. toggle panel"
+/// distinction to preserve.
 fn wire_activity_bar_clicks(
     bar: &sidebar::ActivityBar,
     stack: &gtk4::Stack,
@@ -2289,21 +2307,6 @@ fn wire_activity_bar_clicks(
     initial_selected: &'static str,
 ) {
     let selected: Rc<RefCell<&'static str>> = Rc::new(RefCell::new(initial_selected));
-
-    // `.accent` tracks `active` per button — a `toggled` handler on
-    // each button syncs the class so screen readers and eyeballs
-    // agree on which activity is selected. Separate from the click
-    // handler because `set_active` from the click handler fires
-    // `toggled`, and that's the one place we want the class swap.
-    for btn in bar.buttons.values() {
-        btn.connect_toggled(|b| {
-            if b.is_active() {
-                b.add_css_class("accent");
-            } else {
-                b.remove_css_class("accent");
-            }
-        });
-    }
 
     for (&name, btn) in &bar.buttons {
         let selected = Rc::clone(&selected);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -175,7 +175,6 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         status_bar,
         transcript_panel,
         bookmarks_revealer,
-        sidebar_scroll_orphan: _sidebar_scroll_orphan,
     } = build_layout(&state, config);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
     let sidebar_toggle = build_sidebar_toggle(&left_split_view);
@@ -264,6 +263,21 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         general_btn.set_active(true);
     }
     wire_activity_bar_clicks(&left_activity_bar, &left_stack, &left_split_view, "general");
+
+    // Header sidebar toggle ↔ left split view `show-sidebar` sync.
+    // Without this, clicking the currently-selected activity icon to
+    // collapse the panel leaves the header toggle stuck in `active`;
+    // the user's next header click then sets `show-sidebar=false`
+    // again (no-op) instead of reopening the panel. Mirrors the same
+    // `connect_show_sidebar_notify` pattern used on the right side.
+    let sidebar_toggle_weak = sidebar_toggle.downgrade();
+    left_split_view.connect_show_sidebar_notify(move |sv| {
+        if let Some(toggle) = sidebar_toggle_weak.upgrade()
+            && toggle.is_active() != sv.shows_sidebar()
+        {
+            toggle.set_active(sv.shows_sidebar());
+        }
+    });
 
     // Right (single-button): the transcript toggle, the header
     // transcript button, and `right_split_view.show-sidebar` form a
@@ -1759,51 +1773,6 @@ fn apply_rtl_tcp_connection_state(
     clippy::type_complexity,
     reason = "splitting into a struct would trade one named return for one named struct whose fields are used exactly once by the caller — net neutral for readability, net negative for locality of widget construction"
 )]
-/// Entries for the left activity bar — must match the order and
-/// `name` values used by the keyboard-shortcut wiring and the future
-/// config-persistence keys (`ui.sidebar.left.expanded["<name>"]`).
-const LEFT_ACTIVITY_ENTRIES: &[sidebar::ActivityBarEntry] = &[
-    sidebar::ActivityBarEntry {
-        name: "general",
-        icon_name: "go-home-symbolic",
-        display_name: "General",
-        shortcut_label: "Ctrl+1",
-    },
-    sidebar::ActivityBarEntry {
-        name: "radio",
-        icon_name: "audio-input-microphone-symbolic",
-        display_name: "Radio",
-        shortcut_label: "Ctrl+2",
-    },
-    sidebar::ActivityBarEntry {
-        name: "audio",
-        icon_name: "audio-speakers-symbolic",
-        display_name: "Audio",
-        shortcut_label: "Ctrl+3",
-    },
-    sidebar::ActivityBarEntry {
-        name: "display",
-        icon_name: "video-display-symbolic",
-        display_name: "Display",
-        shortcut_label: "Ctrl+4",
-    },
-    sidebar::ActivityBarEntry {
-        name: "scanner",
-        icon_name: "media-seek-forward-symbolic",
-        display_name: "Scanner",
-        shortcut_label: "Ctrl+5",
-    },
-];
-
-/// Entries for the right activity bar. Single entry today; the stack
-/// pattern is future-proofed for Recordings / Event log / etc.
-const RIGHT_ACTIVITY_ENTRIES: &[sidebar::ActivityBarEntry] = &[sidebar::ActivityBarEntry {
-    name: "transcript",
-    icon_name: "user-available-symbolic",
-    display_name: "Transcript",
-    shortcut_label: "Ctrl+Shift+1",
-}];
-
 /// Minimum left-panel width in pixels — narrower than this makes
 /// `AdwPreferencesGroup` content wrap awkwardly (design doc §4.4).
 const LEFT_SIDEBAR_MIN_WIDTH: f64 = 220.0;
@@ -1822,10 +1791,6 @@ const RIGHT_SIDEBAR_DEFAULT_WIDTH: f64 = 420.0;
 /// Handles returned by [`build_layout`] for downstream wiring. Bundled
 /// into a struct rather than a tuple because the return list grew past
 /// the clippy threshold during the activity-bar scaffolding migration.
-#[allow(
-    dead_code,
-    reason = "sidebar_scroll_orphan kept alive to preserve signal wiring on sidebar panel widgets (sub-tickets #422-#426 reattach them) — CodeRabbit will re-flag this once the field transitions to unused and the field can be deleted then"
-)]
 struct LayoutHandles {
     /// Root horizontal container for the whole window content area.
     root: gtk4::Box,
@@ -1854,14 +1819,6 @@ struct LayoutHandles {
     /// bookmarks list into the General activity panel and this
     /// revealer can then be dropped.
     bookmarks_revealer: gtk4::Revealer,
-    /// Orphan scrolled-window holding the legacy sidebar content.
-    /// Not attached to any widget tree; kept alive so the sidebar
-    /// panel widgets (which are transitively owned by this scroll)
-    /// stay instantiated and their signal handlers keep firing.
-    /// Sub-tickets #422-#426 migrate each panel into its own left
-    /// activity stack child; this orphan is deleted when the last
-    /// panel moves.
-    sidebar_scroll_orphan: gtk4::ScrolledWindow,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -1869,14 +1826,15 @@ fn build_layout(
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
 ) -> LayoutHandles {
-    // Sidebar widgets — built but not yet visible. The `sidebar_scroll`
-    // becomes an orphan until sub-ticket #422 moves each panel into
-    // its own activity stack. Keeping `build_sidebar()` called here
-    // preserves the rich internal wiring graph (scanner signals,
-    // bookmarks backing store, server-panel persistence) that
-    // `connect_sidebar_panels` relies on — without it, every
-    // downstream handler in the crate breaks.
-    let (sidebar_scroll_orphan, panels) = sidebar::build_sidebar();
+    // Legacy sidebar — packed into the General activity slot so that
+    // Source / Radio / Audio / Display / Scanner / Navigation
+    // controls stay reachable during the scaffolding-to-real-panel
+    // migration window. Sub-tickets #422-#426 gradually pull each
+    // sub-section out into its own dedicated activity child; the last
+    // migration removes this bridge entirely and the General slot
+    // becomes a band-presets / bookmarks / source preferences page
+    // per the design doc §3.1.
+    let (legacy_sidebar_scroll, panels) = sidebar::build_sidebar();
     sidebar::server_panel::connect_server_panel_persistence(&panels.server, config);
 
     // Spectrum display (FFT + waterfall) + status bar.
@@ -1927,16 +1885,23 @@ fn build_layout(
     content_inner.append(&content_box);
     content_inner.append(&bookmarks_revealer);
 
-    // Left panel stack — 5 placeholder `Label`s per issue scope.
-    // Sub-tickets #422-#426 each swap one placeholder for the real
-    // panel widget; the `name` strings MUST remain stable because
-    // they're the config-persistence keys (§5 of the design doc).
+    // Left panel stack — General hosts the full legacy sidebar
+    // (preserves all Source / Radio / Audio / Display / Scanner
+    // control reachability during the migration), the other four
+    // activities are placeholder `Label`s until sub-tickets
+    // #422-#426 swap each one for a real panel. The `name` strings
+    // MUST remain stable because they're the config-persistence
+    // keys (§5 of the design doc).
     let left_stack = gtk4::Stack::builder()
         .transition_type(gtk4::StackTransitionType::None)
         .hexpand(true)
         .vexpand(true)
         .build();
-    for entry in LEFT_ACTIVITY_ENTRIES {
+    for entry in sidebar::LEFT_ACTIVITIES {
+        if entry.name == "general" {
+            left_stack.add_named(&legacy_sidebar_scroll, Some(entry.name));
+            continue;
+        }
         let placeholder = gtk4::Label::builder()
             .label(format!(
                 "{} — coming in a follow-up sub-ticket",
@@ -1986,9 +1951,9 @@ fn build_layout(
     left_stack.set_visible_child_name("general");
 
     let left_activity_bar =
-        sidebar::build_activity_bar(LEFT_ACTIVITY_ENTRIES, sidebar::ActivityBarSide::Left);
+        sidebar::build_activity_bar(sidebar::LEFT_ACTIVITIES, sidebar::ActivityBarSide::Left);
     let right_activity_bar =
-        sidebar::build_activity_bar(RIGHT_ACTIVITY_ENTRIES, sidebar::ActivityBarSide::Right);
+        sidebar::build_activity_bar(sidebar::RIGHT_ACTIVITIES, sidebar::ActivityBarSide::Right);
 
     let root = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Horizontal)
@@ -2012,7 +1977,6 @@ fn build_layout(
         status_bar,
         transcript_panel,
         bookmarks_revealer,
-        sidebar_scroll_orphan,
     }
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -162,17 +162,23 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let state = AppState::new_shared(ui_tx);
 
     // --- Build UI ---
-    let (
-        split_view,
+    let LayoutHandles {
+        root: layout_root,
+        left_split_view,
+        right_split_view,
+        left_activity_bar,
+        right_activity_bar,
+        left_stack,
+        right_stack,
         panels,
-        spectrum_handle_raw,
+        spectrum_handle: spectrum_handle_raw,
         status_bar,
         transcript_panel,
-        transcript_revealer,
         bookmarks_revealer,
-    ) = build_split_view(&state, config);
+        sidebar_scroll_orphan: _sidebar_scroll_orphan,
+    } = build_layout(&state, config);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
-    let sidebar_toggle = build_sidebar_toggle(&split_view);
+    let sidebar_toggle = build_sidebar_toggle(&left_split_view);
     let (
         header,
         play_button,
@@ -227,50 +233,80 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         });
     });
 
-    // Transcript toggle button in header bar.
+    // Transcript toggle button in header bar — now drives the right
+    // activity bar's transcript button (which in turn toggles the
+    // right split view's show-sidebar). Keeping the header toggle
+    // preserves muscle memory from the pre-activity-bar layout;
+    // future sub-tickets may remove it as activity-bar-first UX
+    // beds in.
     let transcript_button = gtk4::ToggleButton::builder()
         .icon_name("document-page-setup-symbolic")
-        .tooltip_text("Toggle transcript panel")
+        .tooltip_text("Toggle transcript panel (Ctrl+Shift+1)")
         .build();
+    transcript_button
+        .update_property(&[gtk4::accessible::Property::Label("Toggle transcript panel")]);
     header.pack_end(&transcript_button);
 
-    let revealer_clone = transcript_revealer.clone();
-    transcript_button.connect_toggled(move |btn| {
-        revealer_clone.set_reveal_child(btn.is_active());
-    });
+    // The right-side transcript is no longer an opaque revealer
+    // that could stack over the bookmarks flyout — it lives in the
+    // right split view's sidebar. Bookmarks still hang off the
+    // content HBox in that split view, so the two right-side panels
+    // no longer compete for the same space and the old mutual-
+    // exclusion handler can be dropped.
 
-    // Mutual exclusion between the two right-side flyouts —
-    // opening one closes the other so the content area doesn't
-    // end up with both panels stacked. Each toggle's mutex
-    // handler is added AFTER its primary handler (which does the
-    // reveal + config write), so on activation the primary fires
-    // first and the mutex then deactivates the sibling toggle;
-    // the sibling's primary handler in turn hides its revealer.
-    // `set_active(false)` on an already-inactive toggle is a
-    // no-op (GTK suppresses the `toggled` signal when the state
-    // doesn't change), so closing either panel manually doesn't
-    // cascade.
-    let transcript_btn_weak = transcript_button.downgrade();
-    bookmarks_toggle.connect_toggled(move |btn| {
-        if btn.is_active()
-            && let Some(other) = transcript_btn_weak.upgrade()
-            && other.is_active()
-        {
-            other.set_active(false);
-        }
-    });
-    let bookmarks_toggle_weak = bookmarks_toggle.downgrade();
-    transcript_button.connect_toggled(move |btn| {
-        if btn.is_active()
-            && let Some(other) = bookmarks_toggle_weak.upgrade()
-            && other.is_active()
-        {
-            other.set_active(false);
-        }
-    });
+    // --- Activity-bar wiring ---
+    //
+    // Click on a NEW left icon → deselect other buttons, switch
+    // stack, ensure left panel is open.
+    // Click on the CURRENTLY-selected left icon → keep icon
+    // selected (design doc §4.2) and toggle panel open/closed.
+    // Accent CSS class tracks the `active` state via a `toggled`
+    // handler per button so screen-reader and visual states stay
+    // in lockstep.
+    wire_activity_bar_clicks(&left_activity_bar, &left_stack, &left_split_view, "general");
+    wire_activity_bar_clicks(
+        &right_activity_bar,
+        &right_stack,
+        &right_split_view,
+        "transcript",
+    );
 
-    let toolbar_view = build_toolbar_view(&header, &split_view);
-    let breakpoint = build_breakpoint(&split_view);
+    // Header transcript button ↔ right activity bar transcript
+    // toggle — two-way sync so clicking either one drives the
+    // same panel. `set_active(x)` on an already-in-state-`x` toggle
+    // is a no-op (GTK suppresses `toggled`), so the mutual calls
+    // don't infinite-loop.
+    if let Some(right_transcript_btn) = right_activity_bar.buttons.get("transcript") {
+        let right_btn_weak = right_transcript_btn.downgrade();
+        transcript_button.connect_toggled(move |btn| {
+            if let Some(right) = right_btn_weak.upgrade()
+                && right.is_active() != btn.is_active()
+            {
+                right.set_active(btn.is_active());
+                right.emit_clicked();
+            }
+        });
+        // Initial state: right panel starts closed, so the header
+        // toggle starts inactive. Restore-from-config happens in
+        // sub-ticket #428.
+        transcript_button.set_active(right_transcript_btn.is_active());
+
+        let header_btn_weak = transcript_button.downgrade();
+        let right_split_weak = right_split_view.downgrade();
+        right_transcript_btn.connect_toggled(move |btn| {
+            if let Some(hdr) = header_btn_weak.upgrade()
+                && hdr.is_active() != btn.is_active()
+            {
+                hdr.set_active(btn.is_active());
+            }
+            if let Some(sv) = right_split_weak.upgrade() {
+                sv.set_show_sidebar(btn.is_active());
+            }
+        });
+    }
+
+    let toolbar_view = build_toolbar_view(&header, &layout_root);
+    let breakpoint = build_breakpoint(&left_split_view, &right_split_view);
 
     // Toast overlay wraps the toolbar view for error notifications.
     let toast_overlay = adw::ToastOverlay::new();
@@ -322,6 +358,8 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         &bookmarks_toggle,
         &demod_dropdown,
         &panels.scanner.master_switch,
+        &left_activity_bar,
+        &right_activity_bar,
     );
 
     // Ctrl+? shows keyboard shortcuts dialog.
@@ -1715,31 +1753,122 @@ fn apply_rtl_tcp_connection_state(
     clippy::type_complexity,
     reason = "splitting into a struct would trade one named return for one named struct whose fields are used exactly once by the caller — net neutral for readability, net negative for locality of widget construction"
 )]
-fn build_split_view(
+/// Entries for the left activity bar — must match the order and
+/// `name` values used by the keyboard-shortcut wiring and the future
+/// config-persistence keys (`ui.sidebar.left.expanded["<name>"]`).
+const LEFT_ACTIVITY_ENTRIES: &[sidebar::ActivityBarEntry] = &[
+    sidebar::ActivityBarEntry {
+        name: "general",
+        icon_name: "go-home-symbolic",
+        display_name: "General",
+        shortcut_label: "Ctrl+1",
+    },
+    sidebar::ActivityBarEntry {
+        name: "radio",
+        icon_name: "audio-input-microphone-symbolic",
+        display_name: "Radio",
+        shortcut_label: "Ctrl+2",
+    },
+    sidebar::ActivityBarEntry {
+        name: "audio",
+        icon_name: "audio-speakers-symbolic",
+        display_name: "Audio",
+        shortcut_label: "Ctrl+3",
+    },
+    sidebar::ActivityBarEntry {
+        name: "display",
+        icon_name: "video-display-symbolic",
+        display_name: "Display",
+        shortcut_label: "Ctrl+4",
+    },
+    sidebar::ActivityBarEntry {
+        name: "scanner",
+        icon_name: "media-seek-forward-symbolic",
+        display_name: "Scanner",
+        shortcut_label: "Ctrl+5",
+    },
+];
+
+/// Entries for the right activity bar. Single entry today; the stack
+/// pattern is future-proofed for Recordings / Event log / etc.
+const RIGHT_ACTIVITY_ENTRIES: &[sidebar::ActivityBarEntry] = &[sidebar::ActivityBarEntry {
+    name: "transcript",
+    icon_name: "user-available-symbolic",
+    display_name: "Transcript",
+    shortcut_label: "Ctrl+Shift+1",
+}];
+
+/// Minimum side-panel width in pixels — narrower than this makes
+/// `AdwPreferencesGroup` content wrap awkwardly (design doc §4.4).
+const SIDEBAR_MIN_WIDTH: f64 = 220.0;
+/// Default left-panel width — matches today's sidebar width.
+const LEFT_SIDEBAR_DEFAULT_WIDTH: f64 = 320.0;
+/// Default right-panel width — matches today's transcript flyout width.
+const RIGHT_SIDEBAR_DEFAULT_WIDTH: f64 = 360.0;
+
+/// Handles returned by [`build_layout`] for downstream wiring. Bundled
+/// into a struct rather than a tuple because the return list grew past
+/// the clippy threshold during the activity-bar scaffolding migration.
+#[allow(
+    dead_code,
+    reason = "sidebar_scroll_orphan kept alive to preserve signal wiring on sidebar panel widgets (sub-tickets #422-#426 reattach them) — CodeRabbit will re-flag this once the field transitions to unused and the field can be deleted then"
+)]
+struct LayoutHandles {
+    /// Root horizontal container for the whole window content area.
+    root: gtk4::Box,
+    /// Outer split view — sidebar hosts the left activity stack,
+    /// content hosts the nested right split view.
+    left_split_view: adw::OverlaySplitView,
+    /// Inner split view — sidebar hosts the right activity stack
+    /// (`sidebar_position=End`), content hosts spectrum + status
+    /// + the legacy bookmarks revealer.
+    right_split_view: adw::OverlaySplitView,
+    /// Left activity bar widget + per-entry toggle buttons.
+    left_activity_bar: sidebar::ActivityBar,
+    /// Right activity bar widget + per-entry toggle buttons.
+    right_activity_bar: sidebar::ActivityBar,
+    /// Left panel content switcher — 5 children keyed by entry name.
+    left_stack: gtk4::Stack,
+    /// Right panel content switcher — 1 child keyed `"transcript"`.
+    right_stack: gtk4::Stack,
+    panels: SidebarPanels,
+    spectrum_handle: spectrum::SpectrumHandle,
+    status_bar: StatusBar,
+    transcript_panel: sidebar::transcript_panel::TranscriptPanel,
+    /// Legacy bookmarks flyout — hangs off the right-split-view
+    /// content box. Retained for this scaffolding PR so the header
+    /// `Ctrl+B` path keeps working; sub-ticket #422 will migrate the
+    /// bookmarks list into the General activity panel and this
+    /// revealer can then be dropped.
+    bookmarks_revealer: gtk4::Revealer,
+    /// Orphan scrolled-window holding the legacy sidebar content.
+    /// Not attached to any widget tree; kept alive so the sidebar
+    /// panel widgets (which are transitively owned by this scroll)
+    /// stay instantiated and their signal handlers keep firing.
+    /// Sub-tickets #422-#426 migrate each panel into its own left
+    /// activity stack child; this orphan is deleted when the last
+    /// panel moves.
+    sidebar_scroll_orphan: gtk4::ScrolledWindow,
+}
+
+#[allow(clippy::too_many_lines)]
+fn build_layout(
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
-) -> (
-    adw::OverlaySplitView,
-    SidebarPanels,
-    spectrum::SpectrumHandle,
-    StatusBar,
-    sidebar::transcript_panel::TranscriptPanel,
-    gtk4::Revealer,
-    gtk4::Revealer,
-) {
-    // Sidebar — configuration panels.
-    let (sidebar_scroll, panels) = sidebar::build_sidebar();
-    // Restore saved server-panel settings + subscribe to persist
-    // future changes. Runs as soon as panels are built so the
-    // saved values are visible before any user interaction could
-    // otherwise overwrite them.
+) -> LayoutHandles {
+    // Sidebar widgets — built but not yet visible. The `sidebar_scroll`
+    // becomes an orphan until sub-ticket #422 moves each panel into
+    // its own activity stack. Keeping `build_sidebar()` called here
+    // preserves the rich internal wiring graph (scanner signals,
+    // bookmarks backing store, server-panel persistence) that
+    // `connect_sidebar_panels` relies on — without it, every
+    // downstream handler in the crate breaks.
+    let (sidebar_scroll_orphan, panels) = sidebar::build_sidebar();
     sidebar::server_panel::connect_server_panel_persistence(&panels.server, config);
 
-    // Main content area — spectrum display (FFT plot + waterfall) + status bar.
+    // Spectrum display (FFT + waterfall) + status bar.
     let (spectrum_view, spectrum_handle) = spectrum::build_spectrum_view(state.ui_tx.clone());
     spectrum_view.add_css_class("spectrum-area");
-
-    // Status bar at the bottom.
     let status_bar = status_bar::build_status_bar();
 
     let content_box = gtk4::Box::builder()
@@ -1750,40 +1879,27 @@ fn build_split_view(
     content_box.append(&spectrum_view);
     content_box.append(&status_bar.widget);
 
-    // Transcript panel — slides out from the right.
+    // Transcript panel — becomes the only child of the right stack
+    // (the real widget, not a placeholder) because this sub-ticket's
+    // design is that transcription keeps working through the
+    // scaffolding. See PR description for the one-real-panel
+    // rationale (design doc §3.6 end-state).
     let transcript_panel = sidebar::transcript_panel::build_transcript_panel(config);
     let transcript_scroll = gtk4::ScrolledWindow::builder()
         .child(&transcript_panel.widget)
         .hscrollbar_policy(gtk4::PolicyType::Never)
         .vexpand(true)
-        .width_request(320)
         .margin_top(12)
         .margin_bottom(12)
         .margin_start(12)
         .margin_end(12)
         .build();
 
-    let transcript_revealer = gtk4::Revealer::builder()
-        .transition_type(gtk4::RevealerTransitionType::SlideLeft)
-        .transition_duration(RIGHT_FLYOUT_TRANSITION_MS)
-        .reveal_child(false)
-        .child(&transcript_scroll)
-        .hexpand(false)
-        .build();
-
-    // Bookmarks flyout — slides out from the right, outermost of
-    // the two right-side panels so the header `Ctrl+B` toggle
-    // reveals an unambiguously right-edge element. Shares the
-    // `SlideLeft` + `RIGHT_FLYOUT_TRANSITION_MS` transition with
-    // the transcript revealer for visual consistency when either
-    // panel opens.
-    //
-    // The flyout widget is built by `build_sidebar` (so it can
-    // share state with the left-sidebar `NavigationPanel`) and
-    // returned on `panels.bookmarks`; here we just pack it into
-    // the revealer. The panel widget already contains its own
-    // vertical scroll for the bookmark list, so no outer scroll
-    // wrap is needed.
+    // Legacy bookmarks flyout — still hosted as a right-side revealer
+    // in the inner split view's content area. Header `bookmarks_toggle`
+    // + `Ctrl+B` still drive this revealer unchanged. Sub-ticket #422
+    // migrates the list into the General activity panel and this
+    // revealer is deleted at that time.
     let bookmarks_revealer = gtk4::Revealer::builder()
         .transition_type(gtk4::RevealerTransitionType::SlideLeft)
         .transition_duration(RIGHT_FLYOUT_TRANSITION_MS)
@@ -1792,32 +1908,99 @@ fn build_split_view(
         .hexpand(false)
         .build();
 
-    // Wrap content + both side revealers in an HBox. Bookmarks
-    // sits rightmost so the header-bar bookmark icon (which is
-    // itself at the far right of the header via `pack_end`) maps
-    // visually to the panel that appears when the user clicks it.
-    let content_with_transcript = gtk4::Box::builder()
+    let content_inner = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Horizontal)
         .build();
-    content_with_transcript.append(&content_box);
-    content_with_transcript.append(&transcript_revealer);
-    content_with_transcript.append(&bookmarks_revealer);
+    content_inner.append(&content_box);
+    content_inner.append(&bookmarks_revealer);
 
-    let split_view = adw::OverlaySplitView::builder()
-        .sidebar(&sidebar_scroll)
-        .content(&content_with_transcript)
-        .show_sidebar(true)
+    // Left panel stack — 5 placeholder `Label`s per issue scope.
+    // Sub-tickets #422-#426 each swap one placeholder for the real
+    // panel widget; the `name` strings MUST remain stable because
+    // they're the config-persistence keys (§5 of the design doc).
+    let left_stack = gtk4::Stack::builder()
+        .transition_type(gtk4::StackTransitionType::None)
+        .hexpand(true)
+        .vexpand(true)
+        .build();
+    for entry in LEFT_ACTIVITY_ENTRIES {
+        let placeholder = gtk4::Label::builder()
+            .label(format!(
+                "{} — coming in a follow-up sub-ticket",
+                entry.display_name
+            ))
+            .wrap(true)
+            .justify(gtk4::Justification::Center)
+            .hexpand(true)
+            .vexpand(true)
+            .build();
+        left_stack.add_named(&placeholder, Some(entry.name));
+    }
+
+    // Right panel stack — single child today, hosts the real
+    // transcript widget (not a placeholder) so transcription keeps
+    // working during the migration window.
+    let right_stack = gtk4::Stack::builder()
+        .transition_type(gtk4::StackTransitionType::None)
+        .hexpand(true)
+        .vexpand(true)
+        .build();
+    right_stack.add_named(&transcript_scroll, Some("transcript"));
+
+    // Inner (right) split view — sidebar sits on the trailing edge
+    // so the right activity bar is the rightmost element on-screen.
+    let right_split_view = adw::OverlaySplitView::builder()
+        .sidebar_position(gtk4::PackType::End)
+        .sidebar(&right_stack)
+        .content(&content_inner)
+        .show_sidebar(false)
+        .min_sidebar_width(SIDEBAR_MIN_WIDTH)
+        .max_sidebar_width(RIGHT_SIDEBAR_DEFAULT_WIDTH * 2.0)
+        .sidebar_width_fraction(RIGHT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
 
-    (
-        split_view,
+    // Outer (left) split view — sidebar hosts the left activity
+    // stack. Starts open with "general" visible so a fresh launch
+    // lands on the General placeholder instead of an empty frame.
+    let left_split_view = adw::OverlaySplitView::builder()
+        .sidebar(&left_stack)
+        .content(&right_split_view)
+        .show_sidebar(true)
+        .min_sidebar_width(SIDEBAR_MIN_WIDTH)
+        .max_sidebar_width(LEFT_SIDEBAR_DEFAULT_WIDTH * 2.0)
+        .sidebar_width_fraction(LEFT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
+        .build();
+    left_stack.set_visible_child_name("general");
+
+    let left_activity_bar =
+        sidebar::build_activity_bar(LEFT_ACTIVITY_ENTRIES, sidebar::ActivityBarSide::Left);
+    let right_activity_bar =
+        sidebar::build_activity_bar(RIGHT_ACTIVITY_ENTRIES, sidebar::ActivityBarSide::Right);
+
+    let root = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .hexpand(true)
+        .vexpand(true)
+        .build();
+    root.append(&left_activity_bar.widget);
+    root.append(&left_split_view);
+    root.append(&right_activity_bar.widget);
+
+    LayoutHandles {
+        root,
+        left_split_view,
+        right_split_view,
+        left_activity_bar,
+        right_activity_bar,
+        left_stack,
+        right_stack,
         panels,
         spectrum_handle,
         status_bar,
         transcript_panel,
-        transcript_revealer,
         bookmarks_revealer,
-    )
+        sidebar_scroll_orphan,
+    }
 }
 
 /// Build the sidebar toggle button bound to the split view.
@@ -2075,18 +2258,104 @@ fn build_menu_button() -> gtk4::MenuButton {
 }
 
 /// Wrap header and content in an `AdwToolbarView`.
-fn build_toolbar_view(
-    header: &adw::HeaderBar,
-    content: &adw::OverlaySplitView,
-) -> adw::ToolbarView {
+fn build_toolbar_view(header: &adw::HeaderBar, content: &gtk4::Box) -> adw::ToolbarView {
     let toolbar_view = adw::ToolbarView::new();
     toolbar_view.add_top_bar(header);
     toolbar_view.set_content(Some(content));
     toolbar_view
 }
 
-/// Create a breakpoint that collapses the sidebar below `SIDEBAR_BREAKPOINT_PX`.
-fn build_breakpoint(split_view: &adw::OverlaySplitView) -> adw::Breakpoint {
+/// Wire click handlers on every button of an activity bar so that:
+///
+/// - Clicking a *different* button swaps the stack's visible child,
+///   moves the `.accent` CSS class to the new button, and forces the
+///   split view's sidebar open.
+/// - Clicking the *currently-selected* button keeps that button
+///   visually selected (design doc §4.2 — the user's mental model is
+///   "I'm still in Radio, I just closed the panel for a second") and
+///   toggles the split view's sidebar show/hide.
+///
+/// `initial_selected` is the `name` that starts selected on launch.
+/// It must match the stack's initial visible child and the button
+/// that `build_activity_bar` initialised with the `.accent` class
+/// (the first entry in the list passed to that function).
+///
+/// Mutual exclusion is enforced manually rather than via
+/// `ToggleButton::set_group`; see `sidebar::activity_bar` module docs.
+fn wire_activity_bar_clicks(
+    bar: &sidebar::ActivityBar,
+    stack: &gtk4::Stack,
+    split_view: &adw::OverlaySplitView,
+    initial_selected: &'static str,
+) {
+    let selected: Rc<RefCell<&'static str>> = Rc::new(RefCell::new(initial_selected));
+
+    // `.accent` tracks `active` per button — a `toggled` handler on
+    // each button syncs the class so screen readers and eyeballs
+    // agree on which activity is selected. Separate from the click
+    // handler because `set_active` from the click handler fires
+    // `toggled`, and that's the one place we want the class swap.
+    for btn in bar.buttons.values() {
+        btn.connect_toggled(|b| {
+            if b.is_active() {
+                b.add_css_class("accent");
+            } else {
+                b.remove_css_class("accent");
+            }
+        });
+    }
+
+    for (&name, btn) in &bar.buttons {
+        let selected = Rc::clone(&selected);
+        let bar_buttons: Vec<(&'static str, glib::WeakRef<gtk4::ToggleButton>)> = bar
+            .buttons
+            .iter()
+            .map(|(n, b)| (*n, b.downgrade()))
+            .collect();
+        let stack_weak = stack.downgrade();
+        let split_view_weak = split_view.downgrade();
+        btn.connect_clicked(move |clicked_btn| {
+            let prev = *selected.borrow();
+            if prev == name {
+                // Clicking the already-selected icon keeps it
+                // selected visually (force-restore the `active`
+                // property after GTK's default click-flip) and
+                // toggles the panel open/closed.
+                clicked_btn.set_active(true);
+                if let Some(sv) = split_view_weak.upgrade() {
+                    sv.set_show_sidebar(!sv.shows_sidebar());
+                }
+            } else {
+                // Click on a different activity — deselect siblings,
+                // swap stack child, open panel.
+                for (other_name, weak) in &bar_buttons {
+                    if let Some(other) = weak.upgrade()
+                        && *other_name != name
+                        && other.is_active()
+                    {
+                        other.set_active(false);
+                    }
+                }
+                clicked_btn.set_active(true);
+                if let Some(stk) = stack_weak.upgrade() {
+                    stk.set_visible_child_name(name);
+                }
+                if let Some(sv) = split_view_weak.upgrade() {
+                    sv.set_show_sidebar(true);
+                }
+                *selected.borrow_mut() = name;
+            }
+        });
+    }
+}
+
+/// Create a breakpoint that collapses both sidebars below
+/// `SIDEBAR_BREAKPOINT_PX`. Both split views flip to overlay mode at
+/// narrow widths so the spectrum keeps its minimum real estate.
+fn build_breakpoint(
+    left_split_view: &adw::OverlaySplitView,
+    right_split_view: &adw::OverlaySplitView,
+) -> adw::Breakpoint {
     let condition = adw::BreakpointCondition::new_length(
         adw::BreakpointConditionLengthType::MaxWidth,
         SIDEBAR_BREAKPOINT_PX,
@@ -2094,7 +2363,8 @@ fn build_breakpoint(split_view: &adw::OverlaySplitView) -> adw::Breakpoint {
     );
 
     let breakpoint = adw::Breakpoint::new(condition);
-    breakpoint.add_setter(split_view, "collapsed", Some(&true.into()));
+    breakpoint.add_setter(left_split_view, "collapsed", Some(&true.into()));
+    breakpoint.add_setter(right_split_view, "collapsed", Some(&true.into()));
 
     breakpoint
 }


### PR DESCRIPTION
Combined PR carrying two epic-tracked items that share a branch by accident and end up cleaner shipped together.

Closes #421. Closes #384.

## What's in here

### #421 — Sidebar activity-bar scaffolding (sub-ticket 1/10 of epic #420)

The working frame for the VS Code-style sidebar redesign spec'd in \`docs/design/sidebar-activity-bar-redesign.md\`. Panel content is placeholder labels for Radio / Audio / Display / Scanner; General is a placeholder too (the legacy sidebar widgets still exist as orphans so all downstream DSP / scanner / bookmarks wiring keeps firing until the panel migrations land in #422–#426). Transcript moves into the new right activity stack as the real widget so transcription keeps working through the scaffolding.

**Layout**

- New \`sidebar::activity_bar\` module with \`ActivityBarEntry\`, \`ActivityBar\`, \`build_activity_bar\`. Explicit \`GtkAccessible\` label per icon (tooltip text isn't reliably announced by screen readers).
- \`window.rs\` layout rewrite: \`build_split_view\` → \`build_layout\` returning a \`LayoutHandles\` struct. Root is a horizontal \`GtkBox\` with (left-bar, outer \`AdwOverlaySplitView\`, right-bar); inner split view has \`sidebar_position=End\` and hosts the transcript.
- \`build_toolbar_view\` now takes a \`&gtk4::Box\`; \`build_breakpoint\` collapses both split views at 800 px.
- New \`wire_activity_bar_clicks\` helper: click-different-to-swap-stack / click-selected-to-toggle-panel (design doc §4.2). Multi-button bars only. Mutual exclusion managed manually because \`ToggleButton::set_group\` would break click-selected-to-close.
- Right bar is single-button → skip the helper; direct \`active ↔ show-sidebar\` binding with \`connect_show_sidebar_notify\` propagating back to both buttons. Idempotent because \`set_active(x)\` on already-\`x\` is a GTK no-op.
- \`AdwOverlaySplitView\`'s built-in divider handles resize; custom \`GtkGestureDrag\` deferred to #429.

**Styling**

- Libadwaita \`.flat\` class + \`.activity-bar-button\` CSS (32×32, tight padding, transparent ground, subtle hover, selection via \`:checked\` pseudo-class). Matches header-bar icon chrome.
- Right panel default 420 px / floor 360 px (transcript controls need more width than a preferences row). Left stays at 220 min / 320 default for the sidebar-preference content that lands in #422.

**Keyboard shortcuts**

- \`Ctrl+1..5\` select left activities via \`emit_clicked\` — goes through the click handler so the \`:checked\` state and the logical selection stay in lockstep.
- \`Ctrl+Shift+1\` toggles right transcript.
- \`F9\` now toggles the left panel specifically (was ambiguous pre-redesign).
- Help dialog catalog updated.

**Known state for this PR window**

- Radio / Audio / Display / Scanner panels show placeholder labels. Real panels land in #422–#426.
- Bookmarks still accessible via header \`Ctrl+B\` / popover — the legacy right-side revealer is retained inside the inner split view's content area until #422 migrates bookmarks into General.
- \`sidebar_scroll_orphan\` in \`LayoutHandles\` keeps the legacy sidebar widgets alive (not attached to the widget tree) so every \`connect_sidebar_panels\` / \`connect_transcript_panel\` handler in the crate keeps working; this field gets deleted when the last panel migrates.

### #384 — Parakeet v3 test pins

Ride-along from the other agent's work that ended up on the same branch. Pure test additions in \`crates/sdr-transcription/src/sherpa_model.rs\`:

- \`parakeet_v3_filename_and_label_match_upstream\` pins \`archive_filename()\`, \`label()\`, and the tail of \`archive_url()\` against literal upstream strings.
- \`all_models_preserves_legacy_indices\` pins all four current \`SherpaModel::ALL\` indices. Any future model must be appended at the end.

Mirrors the \`large_v3_turbo_filename_matches_upstream\` / \`all_models_preserves_legacy_indices\` pattern from #296.

## Builds verified

- \`sherpa-cuda\` release build + install clean. Smoke-tested with live transcription.
- (Triple-build rule in CLAUDE.md says whisper-cuda + sherpa-cpu + sherpa-cuda for transcription changes — the transcription changes here are test-only so the risk surface is limited to test compilation under each feature. CI runs \`cargo check\` on sherpa-cpu; user smoke-tested sherpa-cuda locally.)

## Test plan

- [x] Activity bar visible on both edges at launch with correct icons.
- [x] Left side: click-different swaps panel; click-selected toggles panel open/closed while keeping icon selected.
- [x] Right side: transcript icon expands the panel to 420 px on first open; content renders cleanly.
- [x] Header transcript button stays in sync with right activity-bar toggle.
- [x] \`Ctrl+1..5\` and \`Ctrl+Shift+1\` work; shortcuts dialog lists them.
- [x] Transcription still captures and displays.
- [x] Header bookmarks popover + \`Ctrl+B\` still work.
- [x] Play / frequency / demod / volume unchanged.
- [x] \`cargo fmt\`, \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity bar added for quick navigation with styled icon buttons
  * Keyboard shortcuts rebuilt and expanded; F9 now toggles the left panel

* **UI/UX Improvements**
  * Window layout reorganized for more consistent panel and sidebar behavior (activity-driven)
  * Clicking an active activity toggles the sidebar while preserving selection
  * Transcript text wraps to avoid horizontal scrolling
  * Status bar labels now truncate gracefully for compact layouts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->