### PR TITLE
sdr-ui: General panel + Share/Bookmarks activities

### DIFF
--- a/crates/sdr-ui/src/shortcuts.rs
+++ b/crates/sdr-ui/src/shortcuts.rs
@@ -21,7 +21,7 @@ pub fn setup_shortcuts(
     window: &adw::ApplicationWindow,
     play_button: &gtk4::ToggleButton,
     sidebar_toggle: &gtk4::ToggleButton,
-    bookmarks_toggle: &gtk4::ToggleButton,
+    bookmarks_button: &gtk4::Button,
     demod_dropdown: &gtk4::DropDown,
     scanner_switch: &gtk4::Switch,
     left_activity_bar: &ActivityBar,
@@ -82,18 +82,18 @@ pub fn setup_shortcuts(
         controller.add_shortcut(shortcut);
     }
 
-    // Ctrl+B: Toggle bookmarks flyout. Routed through the header
-    // toggle button so the button's visual state stays in sync
-    // with the flyout — same indirection pattern as F9 /
-    // sidebar_toggle above. "B" is the bookmarks mnemonic; F10
-    // was considered but conflicts with the GNOME menu
-    // convention some shell extensions bind.
-    let bookmarks_toggle_weak = bookmarks_toggle.downgrade();
+    // Ctrl+B: Show bookmarks. The header bookmarks button is a
+    // click-navigate `gtk4::Button` that routes through the right
+    // activity bar's Bookmarks icon — `emit_clicked` re-fires the
+    // same path here. "B" is the bookmarks mnemonic; F10 was
+    // considered but conflicts with the GNOME menu convention some
+    // shell extensions bind.
+    let bookmarks_button_weak = bookmarks_button.downgrade();
     let trigger_ctrl_b = gtk4::ShortcutTrigger::parse_string("<Ctrl>b");
     if let Some(trigger) = trigger_ctrl_b {
         let action = gtk4::CallbackAction::new(move |_widget, _args| {
-            if let Some(btn) = bookmarks_toggle_weak.upgrade() {
-                btn.set_active(!btn.is_active());
+            if let Some(btn) = bookmarks_button_weak.upgrade() {
+                btn.emit_clicked();
                 return glib::Propagation::Stop;
             }
             glib::Propagation::Proceed

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -99,20 +99,34 @@ pub const LEFT_ACTIVITIES: &[ActivityBarEntry] = &[
         shortcut_label: "Ctrl+5",
         accelerator: "<Ctrl>5",
     },
+    ActivityBarEntry {
+        name: "share",
+        icon_name: "network-transmit-receive-symbolic",
+        display_name: "Share",
+        shortcut_label: "Ctrl+6",
+        accelerator: "<Ctrl>6",
+    },
 ];
 
-/// Canonical right-activity-bar entries. Single entry today; the
-/// slice-based API future-proofs the pattern for Recordings /
-/// Event log / etc. Consumers derive shortcut registration and help
-/// rows from this — same single-source-of-truth contract as
-/// [`LEFT_ACTIVITIES`].
-pub const RIGHT_ACTIVITIES: &[ActivityBarEntry] = &[ActivityBarEntry {
-    name: "transcript",
-    icon_name: "user-available-symbolic",
-    display_name: "Transcript",
-    shortcut_label: "Ctrl+Shift+1",
-    accelerator: "<Ctrl><Shift>1",
-}];
+/// Canonical right-activity-bar entries — Transcript + Bookmarks.
+/// Consumers derive shortcut registration and help rows from this
+/// single source of truth. Same contract as [`LEFT_ACTIVITIES`].
+pub const RIGHT_ACTIVITIES: &[ActivityBarEntry] = &[
+    ActivityBarEntry {
+        name: "transcript",
+        icon_name: "user-available-symbolic",
+        display_name: "Transcript",
+        shortcut_label: "Ctrl+Shift+1",
+        accelerator: "<Ctrl><Shift>1",
+    },
+    ActivityBarEntry {
+        name: "bookmarks",
+        icon_name: "user-bookmarks-symbolic",
+        display_name: "Bookmarks",
+        shortcut_label: "Ctrl+Shift+2",
+        accelerator: "<Ctrl><Shift>2",
+    },
+];
 
 /// Which edge of the window the activity bar sits against. Controls
 /// the CSS class list and the border side.

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -1,6 +1,7 @@
 //! VS Code-style activity bar — narrow vertical strip of icon toggle
 //! buttons used to switch between panel "activities" (General, Radio,
-//! Audio, Display, Scanner on the left; Transcript on the right).
+//! Audio, Display, Scanner, Share on the left; Transcript, Bookmarks
+//! on the right).
 //!
 //! See `docs/design/sidebar-activity-bar-redesign.md` §2.3 for the
 //! design rationale. This module produces the widget; wiring (stack

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -1,32 +1,34 @@
-//! Right-side bookmarks slide-out panel (#339).
+//! Bookmarks activity panel (#339).
 //!
-//! Complementary to the left sidebar's `NavigationPanel`: the sidebar
-//! keeps the quick-add controls (name entry + Add button) so the user
-//! can stash a bookmark without opening the flyout, while this panel
-//! is the browse / search / manage surface for the full bookmark
-//! list. Toggled from the header bar bookmark icon or `Ctrl+B`.
+//! Complementary to the left sidebar's `NavigationPanel`: the left
+//! side keeps the quick-add controls (name entry + Add button) so
+//! the user can stash a bookmark without leaving the General panel,
+//! while this panel is the browse / search / manage surface for the
+//! full bookmark list. Opened by clicking the 📑 icon in the right
+//! activity bar, via the header bookmark button, or `Ctrl+B`.
 //!
-//! The widget built here is packed into a `gtk4::Revealer` alongside
-//! the transcript revealer in `window.rs::build_split_view`. Slide
-//! transition matches the transcript pattern (200 ms slide from the
-//! right edge of the content area).
+//! The widget built here is an `adw::PreferencesGroup` slotted into
+//! the right activity-bar stack as the `"bookmarks"` child (see
+//! `window.rs::build_layout`). Switching to this activity makes the
+//! right split view's sidebar visible and renders this panel — there
+//! is no separate revealer or slide animation; the activity-bar
+//! wiring owns open/close/switch semantics.
 //!
 //! Owns the bookmark list state: the `Rc<RefCell<Vec<Bookmark>>>`
 //! backing store, active-bookmark highlight, navigate / save
 //! callbacks. `NavigationPanel`'s Add button wires into this state
 //! via shared `Rc` clones — both panels render views of the same
 //! underlying list.
-//!
-//! Commits that land on this file:
-//! - Layout scaffolding (prior commit).
-//! - List + row actions relocated from `NavigationPanel` (prior commit).
-//! - Filter / search row (prior commit).
-//! - Category grouping via `AdwExpanderRow` (prior commit).
-//! - Persist flyout open/closed state across restarts (THIS commit).
 
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
+
+/// Vertical gap between the search entry and the bookmark list in
+/// pixels. `AdwPreferencesGroup` packs its children flush; without
+/// this the two rows sit crowded together. Matches the 12 px rhythm
+/// the other preferences sections use.
+const SEARCH_LIST_GAP_PX: i32 = 12;
 
 use super::navigation_panel::{
     ActiveBookmark, Bookmark, BookmarksMutatedCallback, NavigationCallback, SaveCallback,
@@ -202,11 +204,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         .hscrollbar_policy(gtk4::PolicyType::Never)
         .vscrollbar_policy(gtk4::PolicyType::Automatic)
         .vexpand(true)
-        // Breathing room between the search entry and the list —
-        // `AdwPreferencesGroup` packs its children flush, and a
-        // search row + list row stacked flush look crowded. Same
-        // ~12 px rhythm the other preferences sections have.
-        .margin_top(12)
+        .margin_top(SEARCH_LIST_GAP_PX)
         .build();
     widget.add(&bookmark_scroll);
 

--- a/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
+++ b/crates/sdr-ui/src/sidebar/bookmarks_panel.rs
@@ -26,24 +26,12 @@
 
 use gtk4::prelude::*;
 use libadwaita as adw;
+use libadwaita::prelude::*;
 
 use super::navigation_panel::{
     ActiveBookmark, Bookmark, BookmarksMutatedCallback, NavigationCallback, SaveCallback,
     load_bookmarks, rebuild_bookmark_list,
 };
-
-/// Default width of the bookmarks flyout, in pixels. Wide enough for
-/// a long bookmark nickname + a recall button + a delete affordance
-/// without wrapping. Slightly wider than the transcript revealer
-/// (320 px) because bookmark rows carry more suffix widgets (active
-/// indicator, save button, delete button) than transcript items.
-pub const BOOKMARKS_PANEL_WIDTH_PX: i32 = 360;
-
-/// Config key for whether the bookmarks flyout was open at last
-/// shutdown. Read once on startup to restore the reveal state +
-/// the header toggle button's visual pressed state; written on
-/// every toggle change.
-pub const CONFIG_KEY_FLYOUT_OPEN: &str = "bookmarks_flyout_open";
 
 /// Widget handles + shared state exposed from the bookmarks flyout.
 ///
@@ -59,8 +47,10 @@ pub const CONFIG_KEY_FLYOUT_OPEN: &str = "bookmarks_flyout_open";
 ///   selected. The `connect_navigate` / `connect_save` methods
 ///   register the callbacks the list rows invoke on click.
 pub struct BookmarksPanel {
-    /// Root container for the flyout — packed into the revealer.
-    pub widget: gtk4::Box,
+    /// Root container — an `AdwPreferencesGroup` so the Bookmarks
+    /// activity panel picks up the same title + margin rhythm as
+    /// the other preferences-style panels on the left side.
+    pub widget: adw::PreferencesGroup,
     /// Bookmark list widget. Rebuilt in place on every add /
     /// delete / import via [`rebuild_bookmark_list`].
     pub bookmark_list: gtk4::ListBox,
@@ -185,22 +175,10 @@ impl BookmarksPanel {
 /// with it; this panel just holds a reference.
 #[must_use]
 pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
-    let widget = gtk4::Box::builder()
-        .orientation(gtk4::Orientation::Vertical)
-        .spacing(12)
-        .margin_top(12)
-        .margin_bottom(12)
-        .margin_start(12)
-        .margin_end(12)
-        .width_request(BOOKMARKS_PANEL_WIDTH_PX)
+    let widget = adw::PreferencesGroup::builder()
+        .title("Bookmarks")
+        .description("Saved stations")
         .build();
-
-    let heading = gtk4::Label::builder()
-        .label("Bookmarks")
-        .css_classes(["title-2"])
-        .halign(gtk4::Align::Start)
-        .build();
-    widget.append(&heading);
 
     // Search entry — live-filters the list by updating
     // `filter_text` and rebuilding on every `search-changed`
@@ -212,7 +190,7 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
     let search_entry = gtk4::SearchEntry::builder()
         .placeholder_text("Search bookmarks")
         .build();
-    widget.append(&search_entry);
+    widget.add(&search_entry);
 
     let bookmark_list = gtk4::ListBox::builder()
         .selection_mode(gtk4::SelectionMode::None)
@@ -224,8 +202,13 @@ pub fn build_bookmarks_panel(name_entry: &adw::EntryRow) -> BookmarksPanel {
         .hscrollbar_policy(gtk4::PolicyType::Never)
         .vscrollbar_policy(gtk4::PolicyType::Automatic)
         .vexpand(true)
+        // Breathing room between the search entry and the list —
+        // `AdwPreferencesGroup` packs its children flush, and a
+        // search row + list row stacked flush look crowded. Same
+        // ~12 px rhythm the other preferences sections have.
+        .margin_top(12)
         .build();
-    widget.append(&bookmark_scroll);
+    widget.add(&bookmark_scroll);
 
     let bookmarks = std::rc::Rc::new(std::cell::RefCell::new(load_bookmarks()));
     let on_navigate: std::rc::Rc<std::cell::RefCell<Option<NavigationCallback>>> =

--- a/crates/sdr-ui/src/sidebar/general_panel.rs
+++ b/crates/sdr-ui/src/sidebar/general_panel.rs
@@ -1,0 +1,50 @@
+//! General activity panel — the landing view behind the 🏠 icon.
+//!
+//! Composes the two most-common control groups (band presets +
+//! source) into an `AdwPreferencesPage`. Sections are flat
+//! `AdwPreferencesGroup`s — not `AdwExpanderRow`s. The expander
+//! pattern gave every group a visible left indent from the list-row
+//! inset + another inset from the preferences-group's own margins,
+//! which read cluttered once populated; flat groups match the
+//! GNOME Settings / iOS Settings section idiom cleanly without the
+//! double inset.
+//!
+//! Bookmarks live behind the right-side Bookmarks activity icon —
+//! they're browse/manage controls, not landing-page quick tunes,
+//! and the activity-bar separation keeps the left panel focused on
+//! "configure this radio" rather than mixing in a bookmark
+//! directory. The `rtl_tcp` share-over-network controls have their
+//! own left-side Share activity.
+//!
+//! # Ownership
+//!
+//! `build_general_panel` reparents child widgets borrowed from the
+//! navigation and source panels. GTK auto-unparents on
+//! `PreferencesPage::add`, so callers stop being the parent the
+//! moment this panel is constructed.
+
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use super::navigation_panel::NavigationPanel;
+use super::source_panel::SourcePanel;
+
+/// Assembled General activity panel.
+pub struct GeneralPanel {
+    /// Root widget — `AdwPreferencesPage` so the content scrolls
+    /// vertically inside the left stack child and inherits the
+    /// preferences-page margin/spacing rhythm.
+    pub widget: adw::PreferencesPage,
+}
+
+/// Build the General activity panel by composing pre-existing
+/// preference groups into an `AdwPreferencesPage`.
+///
+/// The borrowed panels stay functional — this function just
+/// reparents their root `AdwPreferencesGroup`s onto the page.
+pub fn build_general_panel(navigation: &NavigationPanel, source: &SourcePanel) -> GeneralPanel {
+    let page = adw::PreferencesPage::new();
+    page.add(&navigation.presets_widget);
+    page.add(&source.widget);
+    GeneralPanel { widget: page }
+}

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -56,9 +56,10 @@ pub struct SidebarPanels {
     /// to break the otherwise-cyclic `on_save → stored closure`
     /// reference chain.
     pub bookmarks: Rc<BookmarksPanel>,
-    /// Share-over-network (`rtl_tcp` server) controls. Hidden by
-    /// default; `window.rs` reveals it when a local RTL-SDR dongle
-    /// is plugged in and not currently the active source.
+    /// Share-over-network (`rtl_tcp` server) controls. Packed as
+    /// the `"share"` child of the left activity stack, so the panel
+    /// is always reachable via the 📡 Share icon; the Start switch
+    /// errors gracefully when no dongle is plugged in.
     pub server: ServerPanel,
     /// Scanner control panel at bottom of left sidebar (Phase 1,
     /// issue #317). Master switch, active-channel / state

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -4,12 +4,11 @@
 
 use std::rc::Rc;
 
-use gtk4::prelude::*;
-
 pub mod activity_bar;
 pub mod audio_panel;
 pub mod bookmarks_panel;
 pub mod display_panel;
+pub mod general_panel;
 pub mod navigation_panel;
 pub mod radio_panel;
 pub mod scanner_panel;
@@ -24,17 +23,13 @@ pub use activity_bar::{
 pub use audio_panel::{AudioPanel, build_audio_panel};
 pub use bookmarks_panel::{BookmarksPanel, build_bookmarks_panel};
 pub use display_panel::{DisplayPanel, build_display_panel};
+pub use general_panel::{GeneralPanel, build_general_panel};
 pub use navigation_panel::{NavigationPanel, build_navigation_panel};
 pub use radio_panel::{RadioPanel, build_radio_panel};
 pub use scanner_panel::{ScannerPanel, build_scanner_panel};
 pub use server_panel::{ServerPanel, build_server_panel};
 pub use source_panel::{SourcePanel, build_source_panel};
 pub use transcript_panel::{TranscriptPanel, build_transcript_panel};
-
-/// Spacing between sidebar preference groups in pixels.
-const SIDEBAR_SPACING: i32 = 12;
-/// Margin around the sidebar content in pixels.
-const SIDEBAR_MARGIN: i32 = 12;
 
 /// All sidebar panels, for DSP bridge wiring.
 pub struct SidebarPanels {
@@ -71,13 +66,13 @@ pub struct SidebarPanels {
     pub scanner: ScannerPanel,
 }
 
-/// Build the complete sidebar `ScrolledWindow` containing all configuration panels.
-///
-/// Returns both the scroll widget (for embedding in the split view) and the
-/// `SidebarPanels` struct (for DSP bridge signal wiring — see issue #92).
-/// The returned `SidebarPanels::bookmarks` is the right-side flyout widget;
-/// `window.rs` packs it into the bookmarks revealer.
-pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
+/// Build every sidebar panel. Activity-bar migration: each panel
+/// widget is packed individually into its matching `GtkStack` child
+/// by `window.rs::build_layout`, so this builder no longer wraps
+/// them in a shared `ScrolledWindow`. The returned `SidebarPanels`
+/// carries the full panel set for both widget placement and DSP
+/// bridge signal wiring (see issue #92).
+pub fn build_panels() -> SidebarPanels {
     let source = build_source_panel();
     let server = build_server_panel();
     let audio = build_audio_panel();
@@ -99,33 +94,7 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
     navigation_panel::connect_preset_to_bookmarks(&navigation, &bookmarks);
     let bookmarks = Rc::new(bookmarks);
 
-    let sidebar_box = gtk4::Box::builder()
-        .orientation(gtk4::Orientation::Vertical)
-        .spacing(SIDEBAR_SPACING)
-        .margin_top(SIDEBAR_MARGIN)
-        .margin_bottom(SIDEBAR_MARGIN)
-        .margin_start(SIDEBAR_MARGIN)
-        .margin_end(SIDEBAR_MARGIN)
-        .build();
-
-    sidebar_box.append(&navigation.presets_widget);
-    sidebar_box.append(&navigation.bookmarks_widget);
-    sidebar_box.append(&source.widget);
-    // Server panel sits directly under Source so the "consume local
-    // dongle" vs "share local dongle" decision is one visual group.
-    // Hidden by default; revealed dynamically by the wiring layer.
-    sidebar_box.append(&server.widget);
-    sidebar_box.append(&audio.widget);
-    sidebar_box.append(&radio.widget);
-    sidebar_box.append(&display.widget);
-    sidebar_box.append(&scanner.widget);
-
-    let scroll = gtk4::ScrolledWindow::builder()
-        .child(&sidebar_box)
-        .hscrollbar_policy(gtk4::PolicyType::Never)
-        .build();
-
-    let panels = SidebarPanels {
+    SidebarPanels {
         source,
         audio,
         radio,
@@ -134,7 +103,5 @@ pub fn build_sidebar() -> (gtk4::ScrolledWindow, SidebarPanels) {
         bookmarks,
         server,
         scanner,
-    };
-
-    (scroll, panels)
+    }
 }

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -1,11 +1,14 @@
 //! Server panel — "Share over network" controls exposing a local
 //! RTL-SDR dongle to remote `rtl_tcp` clients.
 //!
-//! This panel is hidden by default. It becomes visible when a local
-//! RTL-SDR dongle is detected AND it's not currently the active
-//! source — exposing the same dongle over `rtl_tcp` while also
-//! receiving from it locally would cause a USB-device double-open,
-//! so the UI gates the panel on the incompatible state.
+//! Always-visible activity panel: lives behind the 📡 Share icon
+//! on the left activity bar. The legacy hotplug-gated hide/show
+//! behaviour was removed when Share became its own activity — the
+//! user's click on the icon is the explicit opt-in gesture, and
+//! the Start switch still errors gracefully when no local RTL-SDR
+//! is plugged in (an exclusivity-guard toast fires if the local
+//! RTL-SDR is currently the active source, since that would cause
+//! a USB double-open).
 //!
 //! The panel itself only builds widgets; the wire-up (start/stop,
 //! stats polling, activity log) lives in `window.rs` alongside the
@@ -274,9 +277,9 @@ const _: () = {
 /// time and disables them while the server is running so the user
 /// can't mutate config out from under a live session.
 pub struct ServerPanel {
-    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
-    /// Hidden by default — `window.rs` toggles visibility based on
-    /// USB hotplug + active-source state.
+    /// The `AdwPreferencesGroup` widget rendered under the Share
+    /// (📡) activity on the left activity bar. Always visible;
+    /// `window.rs` no longer gates it on hotplug state.
     pub widget: adw::PreferencesGroup,
     /// Master share-over-network switch. On → start Server. Off →
     /// stop Server.

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -653,9 +653,12 @@ fn build_device_defaults_rows() -> DeviceDefaultsRows {
     }
 }
 
-/// Build the server-panel widgets. The panel is hidden by default;
-/// `window.rs` toggles `widget.set_visible(true)` once a local dongle
-/// is detected and the active source is not RTL-SDR.
+/// Build the server-panel widgets. Always visible — the Share
+/// activity icon in the left activity bar is the user's opt-in
+/// gesture, so the panel no longer hides itself based on hotplug
+/// state. When no dongle is plugged in the Start switch errors
+/// gracefully; the panel's presence under its dedicated icon is
+/// the right UX regardless of current dongle availability.
 #[allow(
     clippy::too_many_lines,
     reason = "widget-assembly function — splitting scatters one-time wire-up across many helpers with no readability win"
@@ -664,7 +667,6 @@ pub fn build_server_panel() -> ServerPanel {
     let widget = adw::PreferencesGroup::builder()
         .title("Share over network")
         .description("Expose this machine's RTL-SDR dongle to remote rtl_tcp clients")
-        .visible(false)
         .build();
 
     let share_row = adw::SwitchRow::builder()

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -44,13 +44,6 @@ const DEFAULT_HEIGHT: i32 = 800;
 /// Sidebar collapse breakpoint width in pixels.
 const SIDEBAR_BREAKPOINT_PX: f64 = 800.0;
 
-/// Slide-in/out duration for right-side flyouts (transcript,
-/// bookmarks) in milliseconds. Centralized so the two
-/// revealers stay in lockstep — drifting values would make
-/// one panel feel snappier than the other when the user
-/// toggles between them.
-const RIGHT_FLYOUT_TRANSITION_MS: u32 = 200;
-
 /// FFT sizes — re-exported from display panel (single source of truth).
 use crate::sidebar::display_panel::FFT_SIZES;
 #[cfg(feature = "sherpa")]
@@ -169,12 +162,12 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         left_activity_bar,
         right_activity_bar,
         left_stack,
-        right_stack: _right_stack,
+        right_stack,
         panels,
         spectrum_handle: spectrum_handle_raw,
         status_bar,
         transcript_panel,
-        bookmarks_revealer,
+        general_panel: _general_panel,
     } = build_layout(&state, config);
     let spectrum_handle = Rc::new(spectrum_handle_raw);
     let sidebar_toggle = build_sidebar_toggle(&left_split_view);
@@ -188,57 +181,34 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         favorites_handle,
     ) = build_header_bar(&sidebar_toggle, &state);
 
-    // Bookmarks flyout toggle — packed `pack_end` first so it
-    // ends up LEFT of the transcript toggle in the header's
-    // right cluster. `pack_end` stacks right-to-left, so the
-    // last `pack_end` call sits furthest from the right edge.
-    // Keeping bookmarks near the far edge matches the visual
-    // mapping "click the icon → panel slides in from directly
-    // under it on the right."
-    let bookmarks_toggle = gtk4::ToggleButton::builder()
+    // Header bookmarks shortcut — a plain click-to-navigate button
+    // (not a state toggle). Clicking it routes through the right
+    // activity bar's Bookmarks button, which owns the
+    // show/hide-and-stack-swap logic. Same pattern as `Ctrl+B` —
+    // both go through the activity-bar handler for consistency.
+    let bookmarks_toggle = gtk4::Button::builder()
         .icon_name("user-bookmarks-symbolic")
-        .tooltip_text("Toggle bookmarks panel (Ctrl+B)")
+        .tooltip_text("Show bookmarks (Ctrl+B)")
         .build();
-    // `tooltip_text` alone isn't reliably announced by screen
-    // readers — set the accessible label explicitly, matching
-    // the pattern used for the other icon-only controls in this
-    // file (pinned servers menu, copy server address, etc.).
-    bookmarks_toggle
-        .update_property(&[gtk4::accessible::Property::Label("Toggle bookmarks panel")]);
+    bookmarks_toggle.update_property(&[gtk4::accessible::Property::Label("Show bookmarks")]);
     header.pack_end(&bookmarks_toggle);
 
-    // Restore the flyout open/closed state saved at last shutdown.
-    // Set the toggle's `active` property before wiring the handler
-    // so the initial `set_active` doesn't feed a no-op write back
-    // through `connect_toggled` — `connect_toggled` fires only on
-    // changes, but explicitly wiring the handler after the initial
-    // state is set keeps the "saved state → initial reveal" path
-    // free of config round-trips.
-    let bookmarks_initial_open = config.read(|v| {
-        v.get(sidebar::bookmarks_panel::CONFIG_KEY_FLYOUT_OPEN)
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false)
-    });
-    bookmarks_toggle.set_active(bookmarks_initial_open);
-    bookmarks_revealer.set_reveal_child(bookmarks_initial_open);
-
-    let bookmarks_revealer_clone = bookmarks_revealer.clone();
-    let bookmarks_config = std::sync::Arc::clone(config);
-    bookmarks_toggle.connect_toggled(move |btn| {
-        let open = btn.is_active();
-        bookmarks_revealer_clone.set_reveal_child(open);
-        bookmarks_config.write(|v| {
-            v[sidebar::bookmarks_panel::CONFIG_KEY_FLYOUT_OPEN] = serde_json::json!(open);
-        });
+    let right_bookmarks_btn_weak = right_activity_bar
+        .buttons
+        .get("bookmarks")
+        .map(glib::object::ObjectExt::downgrade);
+    bookmarks_toggle.connect_clicked(move |_| {
+        if let Some(Some(btn)) = right_bookmarks_btn_weak
+            .as_ref()
+            .map(glib::WeakRef::upgrade)
+        {
+            btn.emit_clicked();
+        }
     });
 
-    // Transcript toggle button in header bar — now drives the right
-    // activity bar's transcript button (which in turn toggles the
-    // right split view's show-sidebar). Keeping the header toggle
-    // preserves muscle memory from the pre-activity-bar layout;
-    // future sub-tickets may remove it as activity-bar-first UX
-    // beds in.
-    let transcript_button = gtk4::ToggleButton::builder()
+    // Header transcript shortcut — same click-to-navigate pattern.
+    // Drives the right activity bar's Transcript button.
+    let transcript_button = gtk4::Button::builder()
         .icon_name("document-page-setup-symbolic")
         .tooltip_text("Toggle transcript panel (Ctrl+Shift+1)")
         .build();
@@ -246,30 +216,47 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         .update_property(&[gtk4::accessible::Property::Label("Toggle transcript panel")]);
     header.pack_end(&transcript_button);
 
-    // The right-side transcript is no longer an opaque revealer
-    // that could stack over the bookmarks flyout — it lives in the
-    // right split view's sidebar. Bookmarks still hang off the
-    // content HBox in that split view, so the two right-side panels
-    // no longer compete for the same space and the old mutual-
-    // exclusion handler can be dropped.
+    let right_transcript_btn_weak = right_activity_bar
+        .buttons
+        .get("transcript")
+        .map(glib::object::ObjectExt::downgrade);
+    transcript_button.connect_clicked(move |_| {
+        if let Some(Some(btn)) = right_transcript_btn_weak
+            .as_ref()
+            .map(glib::WeakRef::upgrade)
+        {
+            btn.emit_clicked();
+        }
+    });
 
     // --- Activity-bar wiring ---
     //
-    // Left (multi-button): click on a NEW icon → deselect siblings,
-    // switch stack, open panel. Click on the CURRENTLY-selected
-    // icon → icon stays selected (design doc §4.2), panel toggles.
-    // `:checked` CSS renders the accent tint automatically.
+    // Both bars use `wire_activity_bar_clicks`: click on a NEW icon
+    // swaps the stack child and opens the panel; click on the
+    // CURRENTLY-selected icon toggles the panel while keeping the
+    // icon selected (design doc §4.2). `:checked` CSS renders the
+    // accent tint via `ToggleButton::active`.
     if let Some(general_btn) = left_activity_bar.buttons.get("general") {
         general_btn.set_active(true);
     }
     wire_activity_bar_clicks(&left_activity_bar, &left_stack, &left_split_view, "general");
 
+    // Right bar pre-selection: Transcript is the landing activity
+    // when the right panel first opens. No button starts visually
+    // active because the panel itself starts closed — first click
+    // opens it and flips the matching icon's `active` on.
+    wire_activity_bar_clicks(
+        &right_activity_bar,
+        &right_stack,
+        &right_split_view,
+        "transcript",
+    );
+
     // Header sidebar toggle ↔ left split view `show-sidebar` sync.
     // Without this, clicking the currently-selected activity icon to
     // collapse the panel leaves the header toggle stuck in `active`;
     // the user's next header click then sets `show-sidebar=false`
-    // again (no-op) instead of reopening the panel. Mirrors the same
-    // `connect_show_sidebar_notify` pattern used on the right side.
+    // again (no-op) instead of reopening the panel.
     let sidebar_toggle_weak = sidebar_toggle.downgrade();
     left_split_view.connect_show_sidebar_notify(move |sv| {
         if let Some(toggle) = sidebar_toggle_weak.upgrade()
@@ -278,52 +265,6 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
             toggle.set_active(sv.shows_sidebar());
         }
     });
-
-    // Right (single-button): the transcript toggle, the header
-    // transcript button, and `right_split_view.show-sidebar` form a
-    // tri-state that must stay in sync. Approach: each toggle button
-    // writes its `active` state through to `show-sidebar`; the split
-    // view's `notify::show-sidebar` reflects back into both buttons.
-    // `set_active(x)` on an already-in-state-`x` button is a GTK
-    // no-op (no `toggled` signal), so the two-way propagation is
-    // naturally idempotent.
-    if let Some(right_transcript_btn) = right_activity_bar.buttons.get("transcript") {
-        let right_split_weak = right_split_view.downgrade();
-        right_transcript_btn.connect_toggled(move |btn| {
-            if let Some(sv) = right_split_weak.upgrade() {
-                sv.set_show_sidebar(btn.is_active());
-            }
-        });
-
-        let right_split_weak = right_split_view.downgrade();
-        transcript_button.connect_toggled(move |btn| {
-            if let Some(sv) = right_split_weak.upgrade() {
-                sv.set_show_sidebar(btn.is_active());
-            }
-        });
-
-        let right_btn_weak = right_transcript_btn.downgrade();
-        let header_btn_weak = transcript_button.downgrade();
-        right_split_view.connect_show_sidebar_notify(move |sv| {
-            let visible = sv.shows_sidebar();
-            if let Some(rb) = right_btn_weak.upgrade()
-                && rb.is_active() != visible
-            {
-                rb.set_active(visible);
-            }
-            if let Some(hdr) = header_btn_weak.upgrade()
-                && hdr.is_active() != visible
-            {
-                hdr.set_active(visible);
-            }
-        });
-
-        // Initial alignment — panel is closed at launch, so both
-        // buttons start inactive. Config-driven restoration comes
-        // in sub-ticket #428.
-        right_transcript_btn.set_active(false);
-        transcript_button.set_active(false);
-    }
 
     let toolbar_view = build_toolbar_view(&header, &layout_root);
     let breakpoint = build_breakpoint(&left_split_view, &right_split_view);
@@ -1813,12 +1754,10 @@ struct LayoutHandles {
     spectrum_handle: spectrum::SpectrumHandle,
     status_bar: StatusBar,
     transcript_panel: sidebar::transcript_panel::TranscriptPanel,
-    /// Legacy bookmarks flyout — hangs off the right-split-view
-    /// content box. Retained for this scaffolding PR so the header
-    /// `Ctrl+B` path keeps working; sub-ticket #422 will migrate the
-    /// bookmarks list into the General activity panel and this
-    /// revealer can then be dropped.
-    bookmarks_revealer: gtk4::Revealer,
+    /// General activity panel — landing view. Exposes its expander
+    /// rows so the header bookmarks toggle can open the Bookmarks
+    /// section on focus.
+    general_panel: sidebar::GeneralPanel,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -1826,16 +1765,17 @@ fn build_layout(
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
 ) -> LayoutHandles {
-    // Legacy sidebar — packed into the General activity slot so that
-    // Source / Radio / Audio / Display / Scanner / Navigation
-    // controls stay reachable during the scaffolding-to-real-panel
-    // migration window. Sub-tickets #422-#426 gradually pull each
-    // sub-section out into its own dedicated activity child; the last
-    // migration removes this bridge entirely and the General slot
-    // becomes a band-presets / bookmarks / source preferences page
-    // per the design doc §3.1.
-    let (legacy_sidebar_scroll, panels) = sidebar::build_sidebar();
+    // Sidebar panels — constructed flat; each lives in its own
+    // activity stack child (no shared scroll wrapper anymore).
+    // Sub-ticket #422 lands the General activity's composed panel
+    // (band presets + bookmarks + source + rtl_tcp share); the
+    // remaining four activities host their source panel widget
+    // directly until sub-tickets #423-#426 refactor each into
+    // the expander-row layout.
+    let panels = sidebar::build_panels();
     sidebar::server_panel::connect_server_panel_persistence(&panels.server, config);
+
+    let general_panel = sidebar::build_general_panel(&panels.navigation, &panels.source);
 
     // Spectrum display (FFT + waterfall) + status bar.
     let (spectrum_view, spectrum_handle) = spectrum::build_spectrum_view(state.ui_tx.clone());
@@ -1850,70 +1790,33 @@ fn build_layout(
     content_box.append(&spectrum_view);
     content_box.append(&status_bar.widget);
 
-    // Transcript panel — becomes the only child of the right stack
-    // (the real widget, not a placeholder) because this sub-ticket's
-    // design is that transcription keeps working through the
-    // scaffolding. See PR description for the one-real-panel
-    // rationale (design doc §3.6 end-state).
+    // Transcript panel — the real widget, not a placeholder. Its
+    // root is already an `AdwPreferencesGroup` so it slots straight
+    // into the page wrapper in the right stack, inheriting the same
+    // chrome as every other activity panel.
     let transcript_panel = sidebar::transcript_panel::build_transcript_panel(config);
-    let transcript_scroll = gtk4::ScrolledWindow::builder()
-        .child(&transcript_panel.widget)
-        .hscrollbar_policy(gtk4::PolicyType::Never)
-        .vexpand(true)
-        .margin_top(12)
-        .margin_bottom(12)
-        .margin_start(12)
-        .margin_end(12)
-        .build();
 
-    // Legacy bookmarks flyout — still hosted as a right-side revealer
-    // in the inner split view's content area. Header `bookmarks_toggle`
-    // + `Ctrl+B` still drive this revealer unchanged. Sub-ticket #422
-    // migrates the list into the General activity panel and this
-    // revealer is deleted at that time.
-    let bookmarks_revealer = gtk4::Revealer::builder()
-        .transition_type(gtk4::RevealerTransitionType::SlideLeft)
-        .transition_duration(RIGHT_FLYOUT_TRANSITION_MS)
-        .reveal_child(false)
-        .child(&panels.bookmarks.widget)
-        .hexpand(false)
-        .build();
-
-    let content_inner = gtk4::Box::builder()
-        .orientation(gtk4::Orientation::Horizontal)
-        .build();
-    content_inner.append(&content_box);
-    content_inner.append(&bookmarks_revealer);
-
-    // Left panel stack — General hosts the full legacy sidebar
-    // (preserves all Source / Radio / Audio / Display / Scanner
-    // control reachability during the migration), the other four
-    // activities are placeholder `Label`s until sub-tickets
-    // #422-#426 swap each one for a real panel. The `name` strings
-    // MUST remain stable because they're the config-persistence
-    // keys (§5 of the design doc).
+    // Left panel stack — one real panel widget per activity. General
+    // hosts the composed `GeneralPanel` (band presets + bookmarks +
+    // source + rtl_tcp share as expander rows); Radio / Audio /
+    // Display / Scanner host their existing panel widget wrapped in
+    // a scroll so long pages can scroll internally without resizing
+    // the panel's width (design doc §2.4). Sub-tickets #423-#426
+    // later refactor each of those widgets into the expander-row
+    // layout the General panel demonstrates; the `name` strings MUST
+    // remain stable because they're the config-persistence keys
+    // (§5 of the design doc).
     let left_stack = gtk4::Stack::builder()
         .transition_type(gtk4::StackTransitionType::None)
         .hexpand(true)
         .vexpand(true)
         .build();
-    for entry in sidebar::LEFT_ACTIVITIES {
-        if entry.name == "general" {
-            left_stack.add_named(&legacy_sidebar_scroll, Some(entry.name));
-            continue;
-        }
-        let placeholder = gtk4::Label::builder()
-            .label(format!(
-                "{} — coming in a follow-up sub-ticket",
-                entry.display_name
-            ))
-            .wrap(true)
-            .justify(gtk4::Justification::Center)
-            .hexpand(true)
-            .vexpand(true)
-            .build();
-        left_stack.add_named(&placeholder, Some(entry.name));
-    }
+    left_stack.add_named(&general_panel.widget, Some("general"));
+    left_stack.add_named(&page_from_group(&panels.radio.widget), Some("radio"));
+    left_stack.add_named(&page_from_group(&panels.audio.widget), Some("audio"));
+    left_stack.add_named(&page_from_group(&panels.display.widget), Some("display"));
+    left_stack.add_named(&page_from_widget(&panels.scanner.widget), Some("scanner"));
+    left_stack.add_named(&page_from_group(&panels.server.widget), Some("share"));
 
     // Right panel stack — single child today, hosts the real
     // transcript widget (not a placeholder) so transcription keeps
@@ -1923,44 +1826,49 @@ fn build_layout(
         .hexpand(true)
         .vexpand(true)
         .build();
-    right_stack.add_named(&transcript_scroll, Some("transcript"));
+    right_stack.add_named(
+        &page_from_group(&transcript_panel.widget),
+        Some("transcript"),
+    );
+    right_stack.add_named(
+        &page_from_group(&panels.bookmarks.widget),
+        Some("bookmarks"),
+    );
 
     // Inner (right) split view — sidebar sits on the trailing edge
     // so the right activity bar is the rightmost element on-screen.
-    // `sidebar-width-unit = Px` makes `sidebar_width_fraction`
-    // interpret its argument as literal pixels instead of a fraction
-    // of the split view's allocated width. Without this, the
-    // default-width math lies under nesting: the left split view is
-    // already narrower than the window (activity bars are outside
-    // it), and the right split view is narrower again (it lives in
-    // the left split's content area), so a naive
-    // `LEFT_SIDEBAR_DEFAULT_WIDTH / DEFAULT_WIDTH` fraction resolves
-    // to something smaller than the desired pixel width on every
-    // child. Pixels-first avoids the post-realize callback path and
-    // matches the `min_sidebar_width` / `max_sidebar_width` pixel
-    // units already in use.
+    //
+    // `sidebar_width_fraction` is in `[0, 1]` regardless of
+    // `sidebar-width-unit`; that unit only controls how the
+    // `min`/`max-sidebar-width` pixel values are interpreted. So the
+    // exact 420 px / 320 px default is approximate under nested
+    // splits — the fraction resolves against each split view's
+    // *own* allocated width, not the full window. We accept the
+    // approximation and let `min-sidebar-width` clamp the transcript
+    // panel up to its 360 px floor when the fractional math would
+    // otherwise leave it narrower; hitting the exact pixel target
+    // would require a post-realize callback (sub-ticket #428
+    // session-persistence territory).
     let right_split_view = adw::OverlaySplitView::builder()
         .sidebar_position(gtk4::PackType::End)
         .sidebar(&right_stack)
-        .content(&content_inner)
+        .content(&content_box)
         .show_sidebar(false)
         .min_sidebar_width(RIGHT_SIDEBAR_MIN_WIDTH)
         .max_sidebar_width(RIGHT_SIDEBAR_DEFAULT_WIDTH * 2.0)
-        .sidebar_width_unit(adw::LengthUnit::Px)
-        .sidebar_width_fraction(RIGHT_SIDEBAR_DEFAULT_WIDTH)
+        .sidebar_width_fraction(RIGHT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
 
     // Outer (left) split view — sidebar hosts the left activity
     // stack. Starts open with "general" visible so a fresh launch
-    // lands on the General placeholder instead of an empty frame.
+    // lands on the General panel instead of an empty frame.
     let left_split_view = adw::OverlaySplitView::builder()
         .sidebar(&left_stack)
         .content(&right_split_view)
         .show_sidebar(true)
         .min_sidebar_width(LEFT_SIDEBAR_MIN_WIDTH)
         .max_sidebar_width(LEFT_SIDEBAR_DEFAULT_WIDTH * 2.0)
-        .sidebar_width_unit(adw::LengthUnit::Px)
-        .sidebar_width_fraction(LEFT_SIDEBAR_DEFAULT_WIDTH)
+        .sidebar_width_fraction(LEFT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
     left_stack.set_visible_child_name("general");
 
@@ -1990,8 +1898,31 @@ fn build_layout(
         spectrum_handle,
         status_bar,
         transcript_panel,
-        bookmarks_revealer,
+        general_panel,
     }
+}
+
+/// Wrap an `AdwPreferencesGroup` in its own `AdwPreferencesPage`
+/// so every activity stack child inherits the same margin/spacing
+/// rhythm as the General panel (Apple-style header padding + group
+/// titles). `AdwPreferencesPage` is itself scrollable internally,
+/// so no extra `GtkScrolledWindow` wrapper is needed.
+fn page_from_group(group: &adw::PreferencesGroup) -> adw::PreferencesPage {
+    let page = adw::PreferencesPage::new();
+    page.add(group);
+    page
+}
+
+/// Wrap a non-`PreferencesGroup` widget (scanner's custom `GtkBox`,
+/// transcript's scrolled text view) in an untitled
+/// `AdwPreferencesGroup` hosted on a page — keeps outer chrome
+/// identical to the other stack children.
+fn page_from_widget(child: &impl gtk4::prelude::IsA<gtk4::Widget>) -> adw::PreferencesPage {
+    let page = adw::PreferencesPage::new();
+    let group = adw::PreferencesGroup::new();
+    group.add(child);
+    page.add(&group);
+    page
 }
 
 /// Build the sidebar toggle button bound to the split view.
@@ -4022,49 +3953,25 @@ fn connect_server_panel(
     use std::cell::Cell;
 
     let server_widget_weak = panels.server.widget.downgrade();
-    let device_row = panels.source.device_row.clone();
     let last_seen_count = Rc::new(Cell::new(u32::MAX));
     let running: Rc<RefCell<Option<RunningServer>>> = Rc::new(RefCell::new(None));
 
-    // Pure function: does the combined rule say "show"? A running
-    // server always wins — the user must be able to reach the Stop
-    // switch regardless of hotplug / source-type state.
-    let should_be_visible = |dongle_count: u32, selected: u32, is_running: bool| -> bool {
-        is_running || (dongle_count > 0 && selected != DEVICE_RTLSDR)
-    };
-
-    // Apply visibility, using the cached dongle count. Shared
-    // between the poll tick, the device-row notify handler, and the
-    // start/stop path so all three callers stay in lockstep.
-    let apply_visibility = {
-        let server_widget_weak = server_widget_weak.clone();
-        let device_row = device_row.clone();
-        let last_seen_count = Rc::clone(&last_seen_count);
-        let running = Rc::clone(&running);
-        move || {
-            let Some(widget) = server_widget_weak.upgrade() else {
-                return;
-            };
-            let count = last_seen_count.get();
-            // First invocation before any poll: count is u32::MAX,
-            // which would evaluate true for `> 0`. Treat the
-            // pre-first-tick state as "no dongle yet" so the panel
-            // stays hidden until we actually know — prevents a
-            // flash-of-unwanted-panel during startup.
-            let effective_count = if count == u32::MAX { 0 } else { count };
-            let is_running = running.borrow().is_some();
-            widget.set_visible(should_be_visible(
-                effective_count,
-                device_row.selected(),
-                is_running,
-            ));
-        }
-    };
+    // Visibility hook kept as a no-op callable so the existing
+    // call sites (`connect_share_switch`, `connect_server_status_polling`,
+    // device-row / poll-tick re-apply) stay wired with minimum churn.
+    // The legacy hotplug-driven hide/show behaviour no longer
+    // applies: the Share activity is an opt-in icon on the left
+    // activity bar, so users explicitly request the panel; leaving
+    // it empty when no dongle is plugged in was the old scrolling-
+    // sidebar concern, not a concern here. The `last_seen_count`
+    // tracking remains because it's used by the start-server path
+    // (exclusivity guard vs. the local-RTL-SDR source).
+    let apply_visibility = || {};
 
     // Reapply on source-type change. Cloned because
     // `connect_selected_notify` takes an `Fn(&ComboRow)` and we want
     // the same logic as the poll tick.
-    let apply_on_device_change = apply_visibility.clone();
+    let apply_on_device_change = apply_visibility;
     panels
         .source
         .device_row
@@ -4074,7 +3981,7 @@ fn connect_server_panel(
     // (rather than running the USB probe synchronously during
     // wiring) keeps the window-build path fast and avoids a libusb
     // session init on a thread that may not have one ready.
-    let apply_on_tick = apply_visibility.clone();
+    let apply_on_tick = apply_visibility;
     let poll_widget_weak = server_widget_weak.clone();
     let poll_last_seen_count = Rc::clone(&last_seen_count);
     let _ = glib::timeout_add_local(SERVER_PANEL_HOTPLUG_POLL_INTERVAL, move || {
@@ -4114,7 +4021,7 @@ fn connect_server_panel(
         panels,
         toast_overlay,
         Rc::clone(&running),
-        apply_visibility.clone(),
+        apply_visibility,
         server_running,
     );
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -188,9 +188,10 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // both go through the activity-bar handler for consistency.
     let bookmarks_toggle = gtk4::Button::builder()
         .icon_name("user-bookmarks-symbolic")
-        .tooltip_text("Show bookmarks (Ctrl+B)")
+        .tooltip_text("Toggle bookmarks panel (Ctrl+B)")
         .build();
-    bookmarks_toggle.update_property(&[gtk4::accessible::Property::Label("Show bookmarks")]);
+    bookmarks_toggle
+        .update_property(&[gtk4::accessible::Property::Label("Toggle bookmarks panel")]);
     header.pack_end(&bookmarks_toggle);
 
     let right_bookmarks_btn_weak = right_activity_bar

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1755,9 +1755,11 @@ struct LayoutHandles {
     spectrum_handle: spectrum::SpectrumHandle,
     status_bar: StatusBar,
     transcript_panel: sidebar::transcript_panel::TranscriptPanel,
-    /// General activity panel — landing view. Exposes its expander
-    /// rows so the header bookmarks toggle can open the Bookmarks
-    /// section on focus.
+    /// General activity panel — landing view. Hosts band presets
+    /// and source as flat `AdwPreferencesGroup`s on an
+    /// `AdwPreferencesPage`. Bookmarks live in the right activity
+    /// stack (not here); `rtl_tcp` share controls live in the Share
+    /// left activity (not here).
     general_panel: sidebar::GeneralPanel,
 }
 
@@ -1767,12 +1769,12 @@ fn build_layout(
     config: &std::sync::Arc<sdr_config::ConfigManager>,
 ) -> LayoutHandles {
     // Sidebar panels — constructed flat; each lives in its own
-    // activity stack child (no shared scroll wrapper anymore).
-    // Sub-ticket #422 lands the General activity's composed panel
-    // (band presets + bookmarks + source + rtl_tcp share); the
-    // remaining four activities host their source panel widget
-    // directly until sub-tickets #423-#426 refactor each into
-    // the expander-row layout.
+    // activity stack child (no shared scroll wrapper). The
+    // General activity composes band presets + source into an
+    // `AdwPreferencesPage`; Radio / Audio / Display / Scanner /
+    // Share host their respective panel widgets directly until
+    // sub-tickets #423-#426 refactor each into the expander-row
+    // layout. Bookmarks lives in the right activity stack.
     let panels = sidebar::build_panels();
     sidebar::server_panel::connect_server_panel_persistence(&panels.server, config);
 
@@ -3911,32 +3913,21 @@ fn clear_client_auth_key_from_keyring(
     store.delete(&entry)
 }
 
-/// Wire the server panel end-to-end: visibility gating, the master
-/// share-over-network switch, and its downstream start/stop effects.
-/// Errors surface via the `toast_overlay`, and the switch auto-
-/// reverts to its off state so the UI never lies about whether a
-/// server is actually running.
+/// Wire the server panel end-to-end: the master share-over-network
+/// switch (start/stop + control locking), periodic `Server::stats()`
+/// polling (rendered status rows + auto-stop on `has_stopped()`), and
+/// the bandwidth advisory that toggles on the device-default sample
+/// rate. Errors surface via the `toast_overlay`, and the switch
+/// auto-reverts to its off state on start failure so the UI never
+/// lies about whether a server is actually running.
 ///
-/// Visibility rule:
-/// 1. at least one RTL-SDR dongle is visible on the local USB bus
-///    (`sdr_rtlsdr::get_device_count() > 0`), and
-/// 2. the active source type is **not** RTL-SDR — re-exposing the
-///    same dongle over `rtl_tcp` while a local `RtlSdrSource` is
-///    holding it would cause a USB-device double-open, and
-/// 3. OR the server is already running (keep the panel visible so
-///    the user can reach the Stop switch no matter what).
-///
-/// Visibility is recomputed on three triggers so the panel feels
-/// responsive without polling the world: a low-frequency timer that
-/// handles the USB side (hotplug has no GTK signal we can subscribe
-/// to), a `device_row.connect_selected_notify` handler that fires
-/// on every source-type change, and the share-row start/stop path
-/// itself. A `Cell<u32>` tracks the last-seen device count so we
-/// only pay the widget-state-update cost on an actual edge.
-#[allow(
-    clippy::too_many_lines,
-    reason = "GTK signal-wiring: visibility + start-stop + control-locking all share state via nested closures — splitting scatters the captures"
-)]
+/// The panel itself is always visible — Share is its own activity on
+/// the left activity bar (📡), so the legacy hotplug-gated
+/// hide/show timer, the device-count cache, and the
+/// `device_row.connect_selected_notify` handler that fed it are gone.
+/// The start path still rejects a "local RTL-SDR is the active
+/// source" conflict via an exclusivity toast inside the share-switch
+/// handler — that guard is independent of the removed machinery.
 fn connect_server_panel(
     panels: &SidebarPanels,
     toast_overlay: &adw::ToastOverlay,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1837,6 +1837,12 @@ fn build_layout(
         &page_from_group(&panels.bookmarks.widget),
         Some("bookmarks"),
     );
+    // Explicitly pin the initial visible child so a future
+    // additional right-activity inserted before transcript doesn't
+    // silently shift what the first `Ctrl+Shift+1` press (or the
+    // header transcript button's click) shows. Matches the contract
+    // `wire_activity_bar_clicks(..., "transcript")` relies on below.
+    right_stack.set_visible_child_name("transcript");
 
     // Inner (right) split view — sidebar sits on the trailing edge
     // so the right activity bar is the rightmost element on-screen.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1838,17 +1838,16 @@ fn build_layout(
     // Inner (right) split view — sidebar sits on the trailing edge
     // so the right activity bar is the rightmost element on-screen.
     //
-    // `sidebar_width_fraction` is in `[0, 1]` regardless of
-    // `sidebar-width-unit`; that unit only controls how the
-    // `min`/`max-sidebar-width` pixel values are interpreted. So the
-    // exact 420 px / 320 px default is approximate under nested
-    // splits — the fraction resolves against each split view's
-    // *own* allocated width, not the full window. We accept the
-    // approximation and let `min-sidebar-width` clamp the transcript
-    // panel up to its 360 px floor when the fractional math would
-    // otherwise leave it narrower; hitting the exact pixel target
-    // would require a post-realize callback (sub-ticket #428
-    // session-persistence territory).
+    // `sidebar_width_fraction` is `[0, 1]` regardless of the
+    // `sidebar-width-unit` we set; the unit only changes how
+    // `min`/`max-sidebar-width` are interpreted. Passing a pixel
+    // value as the fraction panics at property-set even with
+    // `unit = Px` (verified on libadwaita 1.9). So the default
+    // here is a fraction; under nested splits its pixel result
+    // is approximate, and `min-sidebar-width` clamps the transcript
+    // panel up to its 360 px floor when the math would otherwise
+    // leave it narrower. Hitting the exact pixel target would
+    // require a post-realize callback (sub-ticket #428 territory).
     let right_split_view = adw::OverlaySplitView::builder()
         .sidebar_position(gtk4::PackType::End)
         .sidebar(&right_stack)
@@ -3048,14 +3047,6 @@ fn connect_rtl_tcp_discovery(
     });
 }
 
-/// Cadence for the USB hotplug poll that drives server-panel
-/// visibility. 3 s is the sweet spot: fast enough that a user
-/// plugging in a dongle sees the panel within the time it takes them
-/// to reach the sidebar with the mouse, slow enough that the
-/// per-tick `rusb::devices()` USB-bus enumerate is invisible in
-/// profile traces.
-const SERVER_PANEL_HOTPLUG_POLL_INTERVAL: Duration = Duration::from_secs(3);
-
 /// Icon name for the un-filled ("not pinned") star on discovery
 /// rows. GNOME Symbolic icon set — `non-starred-symbolic` renders
 /// the outline glyph, which is visually distinct from the filled
@@ -3950,85 +3941,26 @@ fn connect_server_panel(
     toast_overlay: &adw::ToastOverlay,
     server_running: Rc<std::cell::Cell<bool>>,
 ) {
-    use std::cell::Cell;
-
-    let server_widget_weak = panels.server.widget.downgrade();
-    let last_seen_count = Rc::new(Cell::new(u32::MAX));
     let running: Rc<RefCell<Option<RunningServer>>> = Rc::new(RefCell::new(None));
 
-    // Visibility hook kept as a no-op callable so the existing
-    // call sites (`connect_share_switch`, `connect_server_status_polling`,
-    // device-row / poll-tick re-apply) stay wired with minimum churn.
-    // The legacy hotplug-driven hide/show behaviour no longer
-    // applies: the Share activity is an opt-in icon on the left
-    // activity bar, so users explicitly request the panel; leaving
-    // it empty when no dongle is plugged in was the old scrolling-
-    // sidebar concern, not a concern here. The `last_seen_count`
-    // tracking remains because it's used by the start-server path
-    // (exclusivity guard vs. the local-RTL-SDR source).
-    let apply_visibility = || {};
-
-    // Reapply on source-type change. Cloned because
-    // `connect_selected_notify` takes an `Fn(&ComboRow)` and we want
-    // the same logic as the poll tick.
-    let apply_on_device_change = apply_visibility;
-    panels
-        .source
-        .device_row
-        .connect_selected_notify(move |_| apply_on_device_change());
-
-    // Seed `last_seen_count` on the first tick. Using a glib timer
-    // (rather than running the USB probe synchronously during
-    // wiring) keeps the window-build path fast and avoids a libusb
-    // session init on a thread that may not have one ready.
-    let apply_on_tick = apply_visibility;
-    let poll_widget_weak = server_widget_weak.clone();
-    let poll_last_seen_count = Rc::clone(&last_seen_count);
-    let _ = glib::timeout_add_local(SERVER_PANEL_HOTPLUG_POLL_INTERVAL, move || {
-        // If the widget is gone, tear the poller down — nothing to
-        // show, and we don't want to leak `rusb::devices()` calls
-        // past window close.
-        if poll_widget_weak.upgrade().is_none() {
-            return glib::ControlFlow::Break;
-        }
-        // `sdr_rtlsdr::get_device_count()` is a libusb enumerate
-        // (vendor/product-ID filter over `rusb::devices()`). Fast
-        // enough for the UI thread at a 3 s cadence; no syscall
-        // churn worth moving to a worker.
-        let count = sdr_rtlsdr::get_device_count();
-        // First tick ALWAYS flips the cache off `u32::MAX`, so this
-        // branch fires at least once even if the real count is 0 —
-        // that's the "resolve the panel out of its pre-first-tick
-        // hidden state" moment. Subsequent ticks only apply on a
-        // real edge so we don't churn widget state every 3 s.
-        if count != poll_last_seen_count.get() {
-            tracing::debug!(
-                previous = poll_last_seen_count.get(),
-                current = count,
-                "rtl_tcp server panel: local dongle count changed"
-            );
-            poll_last_seen_count.set(count);
-            apply_on_tick();
-        }
-        glib::ControlFlow::Continue
-    });
+    // Share is now an activity on the left activity bar — always
+    // reachable via the 📡 icon. The legacy hotplug-driven
+    // hide/show timer + device-count cache + device-row notify
+    // were removed with that migration; `sdr_rtlsdr::get_device_count`
+    // is no longer polled on the GTK main loop for visibility,
+    // and the start-server path still rejects the "local dongle is
+    // the active source" conflict via its own exclusivity guard.
 
     // Wire the master share-over-network switch. The handler is the
     // authority on server lifecycle — on toggle we either start a
     // new `Server` (+ optional `Advertiser`) and store the handle,
     // or drop the handle so the accept thread tears down.
-    connect_share_switch(
-        panels,
-        toast_overlay,
-        Rc::clone(&running),
-        apply_visibility,
-        server_running,
-    );
+    connect_share_switch(panels, toast_overlay, Rc::clone(&running), server_running);
 
     // Poll `Server::stats()` on a timer, render the status rows,
     // and auto-stop the server if `has_stopped()` becomes true
     // (e.g. USB unplug or accept-thread failure).
-    connect_server_status_polling(panels, Rc::clone(&running), apply_visibility);
+    connect_server_status_polling(panels, Rc::clone(&running));
 
     // Bandwidth advisory — toggled on the device-default sample
     // rate. Unlike the source panel's advisory (which also gates
@@ -4213,7 +4145,6 @@ fn connect_share_switch(
     panels: &SidebarPanels,
     toast_overlay: &adw::ToastOverlay,
     running: Rc<RefCell<Option<RunningServer>>>,
-    apply_visibility: impl Fn() + Clone + 'static,
     server_running: Rc<std::cell::Cell<bool>>,
 ) {
     use std::cell::Cell;
@@ -4416,7 +4347,6 @@ fn connect_share_switch(
             reset_activity_log(&widgets);
             reset_clients_list(&widgets);
         }
-        apply_visibility();
     });
 
     // ====================================================
@@ -4802,7 +4732,6 @@ impl ServerStatusWidgetsWeak {
 fn connect_server_status_polling(
     panels: &SidebarPanels,
     running: Rc<RefCell<Option<RunningServer>>>,
-    apply_visibility: impl Fn() + 'static,
 ) {
     use std::cell::Cell;
 
@@ -4867,7 +4796,6 @@ fn connect_server_status_polling(
             if let Some(share) = share_row_weak.upgrade() {
                 share.set_active(false);
             }
-            apply_visibility();
             return glib::ControlFlow::Continue;
         }
 
@@ -5851,12 +5779,12 @@ fn apply_agc_squelch_mutex(
 /// dongle after app launch sees the slot update to the real
 /// device name within a few seconds without having to restart.
 ///
-/// Shares cadence with `SERVER_PANEL_HOTPLUG_POLL_INTERVAL` as a
-/// deliberate choice — both pollers watch the same libusb bus for
-/// the same vendor/product-filtered device set, so users see
-/// both the source combo and the server panel update on the same
-/// tick. Kept as a separate constant so each poller's sizing can
-/// evolve independently.
+/// Previously shared cadence with a server-panel hotplug poll that
+/// drove panel visibility — that poll was removed when Share became
+/// its own activity icon, but this source-combo poller's 3 s cadence
+/// was tuned for the same reason (user plugs in a dongle, sees the
+/// slot update by the time they reach for the sidebar) so the value
+/// remains a good fit on its own.
 const SOURCE_RTLSDR_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Install a hotplug poller on the source panel that keeps the


### PR DESCRIPTION
Closes #422. Sub-ticket 2/10 of epic #420.

## Summary

Migrates every legacy sidebar section into an activity-bar slot of its own, introduces two new activity icons along the way, and unifies the panel chrome so every activity stack child gets the same Apple-style `AdwPreferencesPage` margins + section titles.

## Layout changes

### Left activity bar — now 6 icons

| # | Icon | Activity | Panel content | Shortcut |
|---|------|----------|---------------|----------|
| 1 | 🏠 | General | Band presets + Source (flat `AdwPreferencesGroup`s, no expander-row wrappers) | `Ctrl+1` |
| 2 | ▶ | Radio | Existing `RadioPanel` widget | `Ctrl+2` |
| 3 | 🎚 | Audio | Existing `AudioPanel` widget | `Ctrl+3` |
| 4 | 📊 | Display | Existing `DisplayPanel` widget | `Ctrl+4` |
| 5 | 🔄 | Scanner | Existing `ScannerPanel` widget | `Ctrl+5` |
| 6 | 📡 | **Share** *(new)* | `rtl_tcp` server-share controls | `Ctrl+6` |

### Right activity bar — now 2 icons

| # | Icon | Activity | Panel content | Shortcut |
|---|------|----------|---------------|----------|
| 1 | 💬 | Transcript | Unchanged | `Ctrl+Shift+1` |
| 2 | 📑 | **Bookmarks** *(new)* | Full bookmark list relocated from the legacy right-side revealer | `Ctrl+Shift+2` |

The canonical `LEFT_ACTIVITIES` / `RIGHT_ACTIVITIES` slices in `sidebar::activity_bar` still drive both shortcut registration and help-dialog rows — the new entries appear everywhere automatically.

## Key design decisions

**Flat `AdwPreferencesGroup`s, no expander rows.** The design doc called for `AdwExpanderRow` wrappers inside General. In practice the expander's list-row inset + the group's own margin stacked to a double-inset effect that read cluttered. Flat groups match the GNOME Settings / iOS Settings section idiom cleanly. If we want collapse back later, it's a CSS/widget upgrade — not baked into the architecture.

**Share is opt-in, not hotplug-gated.** The legacy server panel built with `.visible(false)` and waited for `window.rs` to toggle it visible once a local dongle was hotplugged. With the activity-bar icon as the user's explicit opt-in gesture, the panel is now always reachable; the Start switch errors gracefully when no dongle is present.

**Header bookmarks / transcript buttons converted from `ToggleButton` to `gtk4::Button`.** They no longer track panel state — they're navigation shortcuts. Clicking routes through `emit_clicked` on the matching right-bar activity button, so the `wire_activity_bar_clicks` handler owns all open/close/switch semantics. No more three-way sync juggling between header + activity button + split-view `show-sidebar`.

**Every stack child wrapped in `AdwPreferencesPage`.** Consistent top/side margins + section-title rhythm across General / Radio / Audio / Display / Scanner / Share / Transcript / Bookmarks. Two helpers: `page_from_group` (for panels whose root is already an `AdwPreferencesGroup`, which is every panel except Scanner) and `page_from_widget` (wraps a freeform widget in an untitled group inside a page).

**`BookmarksPanel` root converted to `AdwPreferencesGroup`.** Was a custom `gtk4::Box` with a `title-2` heading label. Now uses `PreferencesGroup::builder().title("Bookmarks").description("Saved stations")` so it matches the other panels' section-title treatment; internal heading label dropped to avoid duplication. Search row + list added via `group.add()`; 12 px top margin on the list so the search entry doesn't sit flush against it.

## Supporting changes

- `sidebar::build_sidebar` (returned `(scroll, panels)`) renamed to `sidebar::build_panels` (returns `panels` only) — the legacy shared scroll has no consumer left. `SIDEBAR_SPACING` / `SIDEBAR_MARGIN` / `RIGHT_FLYOUT_TRANSITION_MS` / `BOOKMARKS_PANEL_WIDTH_PX` / `CONFIG_KEY_FLYOUT_OPEN` all removed (dead).
- `apply_visibility` in `connect_server_panel` neutralized to a no-op — the Share activity owns visibility now.
- `sidebar_width_unit(Px)` experiment reverted; `sidebar-width-fraction` is always `[0, 1]` so we use fractional math + `min-sidebar-width` clamps as the floor. Documented.
- Split-view-value-out-of-range panic at launch fixed (same root cause).
- Layout bouncing during caption streaming + status-bar rendering also fixed: `transcript` `TextView` uses `WrapMode::WordChar` (not `Word`) so long tokens break mid-word instead of demanding width; every status-bar label is `EllipsizeMode::End`.

## Smoke test

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"` builds + installs.
- [x] Launch clean — no panic.
- [x] General panel: Band presets + Source render cleanly, all controls work (device/gain/SR/IQ/decimation/PPM).
- [x] Radio/Audio/Display/Scanner panels: accessed via icons, controls functional.
- [x] Share panel: rtl_tcp controls visible, Start-switch gated by exclusivity rule.
- [x] Bookmarks: full list visible, search filter works, CRUD works, 12 px gap between search and list.
- [x] Transcript: captions still stream, no layout bounce.
- [x] Keyboard: `Ctrl+1..6` left, `Ctrl+Shift+1..2` right, `Ctrl+B` opens Bookmarks via header shortcut button.
- [x] Help dialog (`Ctrl+/`) lists every new activity binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New keyboard shortcuts: Ctrl+6 (Share) and Ctrl+Shift+2 (Bookmarks).

* **Improvements**
  * Bookmarks panel redesigned into a preferences-style layout with improved spacing.
  * Added a General activity panel to surface presets and source controls.
  * Activity bar now exposes Bookmarks as a first-class page alongside Transcript.
  * Server/Share panel visible by default.

* **Behavior Changes**
  * Header bookmark control now forwards clicks to the activity bar for consistent navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->