### PR TITLE
sdr-ui: sectioned Audio panel + volume persistence

### DIFF
--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -1,5 +1,5 @@
-//! Audio output configuration panel — device, sink type, network
-//! sink config, and recording toggle.
+//! Audio output configuration panel — device, volume, network sink
+//! config, and recording toggle.
 
 use libadwaita as adw;
 use libadwaita::prelude::*;
@@ -16,6 +16,22 @@ pub const SINK_TYPE_NETWORK_IDX: u32 = 1;
 /// must match the model strings in `build_audio_panel`.
 pub const NETWORK_SINK_PROTOCOL_TCP_IDX: u32 = 0;
 pub const NETWORK_SINK_PROTOCOL_UDP_IDX: u32 = 1;
+
+/// Volume slider range — the header `GtkScaleButton` is 0.0..=1.0
+/// with a 0.05 step; the panel's spin row is the percentage
+/// equivalent (0..=100 step 1) so both feel natural to users.
+/// `window.rs` converts between the two via simple ×100 / ÷100.
+pub const VOLUME_PERCENT_MIN: f64 = 0.0;
+pub const VOLUME_PERCENT_MAX: f64 = 100.0;
+pub const VOLUME_PERCENT_STEP: f64 = 1.0;
+pub const VOLUME_PERCENT_PAGE: f64 = 10.0;
+
+/// Config key for persisted volume. Stored as a `f64` in
+/// `[0.0, 1.0]` (header `GtkScaleButton` domain) so the on-disk
+/// value is the same shape the DSP sees via `UiToDsp::SetVolume`.
+/// Restored at startup by `window::connect_volume_persistence`
+/// (closes #419).
+pub const KEY_AUDIO_VOLUME: &str = "audio_volume";
 
 // Defaults are owned by `sdr_core::sink_slot` so the engine
 // initializer and the panel always agree. Re-exported here as
@@ -43,18 +59,32 @@ pub fn protocol_from_combo_idx(idx: u32) -> Protocol {
 
 /// Audio output configuration panel with references to interactive rows.
 pub struct AudioPanel {
-    /// The `AdwPreferencesGroup` widget to pack into the sidebar.
-    pub widget: adw::PreferencesGroup,
+    /// The `AdwPreferencesPage` widget packed into the Audio
+    /// activity stack slot. Hosts four titled `AdwPreferencesGroup`s
+    /// (Output / Volume / Network sink / Recording) — see
+    /// [`build_audio_panel`].
+    pub widget: adw::PreferencesPage,
+    /// Network-sink section group. Stored as a handle so
+    /// `window::connect_audio_panel` can toggle the entire
+    /// section's visibility when the user flips between the local
+    /// and network sink types, rather than hiding four rows
+    /// individually.
+    pub network_sink_group: adw::PreferencesGroup,
     /// Audio device selector.
     pub device_row: adw::ComboRow,
     /// Sink type selector (Audio, Network).
     pub sink_type_row: adw::ComboRow,
     /// Node names corresponding to device dropdown indices (for routing).
     pub device_node_names: Vec<String>,
+    /// Volume slider — 0..=100 percent. Kept in two-way sync with
+    /// the header `GtkScaleButton` (which uses 0.0..=1.0); both
+    /// dispatch `UiToDsp::SetVolume` and persist to config on
+    /// change. Closes #419.
+    pub volume_row: adw::SpinRow,
     /// Toggle to start/stop audio recording.
     pub record_audio_row: adw::SwitchRow,
-    /// Hostname / IP for the network audio sink. Hidden unless
-    /// `Network` is the active sink type.
+    /// Hostname / IP for the network audio sink. Visible only
+    /// when the Network sink type is selected.
     pub network_host_row: adw::EntryRow,
     /// Port for the network audio sink (1..=65535).
     pub network_port_row: adw::SpinRow,
@@ -70,15 +100,16 @@ pub struct AudioPanel {
 ///
 /// Queries `PipeWire` for available audio output sinks and populates
 /// the device selector dropdown. The network config rows are built
-/// up front (so the sidebar layout doesn't shift when the user
-/// toggles between sink types) but `set_visible(false)` until
-/// `Network` is the active sink type.
+/// up front and packed into their own titled section group so the
+/// outer layout doesn't shift when the user toggles between sink
+/// types — `window::connect_audio_panel` hides the whole group via
+/// [`AudioPanel::network_sink_group`] when the Local sink is active.
+///
+/// Lays out as an `AdwPreferencesPage` with four titled sections
+/// matching the activity-bar redesign's Apple-style rhythm (design
+/// doc §3.3). Flat groups, no `AdwExpanderRow` wrappers — same call
+/// as the General / Radio panels.
 pub fn build_audio_panel() -> AudioPanel {
-    let group = adw::PreferencesGroup::builder()
-        .title("Audio")
-        .description("Output configuration")
-        .build();
-
     // Query PipeWire for available audio sinks
     let sinks = sdr_sink_audio::list_audio_sinks();
     let display_names: Vec<&str> = sinks.iter().map(|s| s.display_name.as_str()).collect();
@@ -95,13 +126,26 @@ pub fn build_audio_panel() -> AudioPanel {
         .model(&sink_model)
         .build();
 
-    // Network config rows — built unconditionally so the
-    // visibility toggle in `connect_audio_panel` is a cheap
-    // `set_visible` rather than a structural insert/remove.
+    // --- Volume (new, closes #419) ---
+    let volume_adj = gtk4::Adjustment::new(
+        VOLUME_PERCENT_MAX,
+        VOLUME_PERCENT_MIN,
+        VOLUME_PERCENT_MAX,
+        VOLUME_PERCENT_STEP,
+        VOLUME_PERCENT_PAGE,
+        0.0,
+    );
+    let volume_row = adw::SpinRow::builder()
+        .title("Volume")
+        .subtitle("%")
+        .adjustment(&volume_adj)
+        .digits(0)
+        .build();
+
+    // --- Network sink config ---
     let network_host_row = adw::EntryRow::builder()
         .title("Network host")
         .text(NETWORK_SINK_DEFAULT_HOST)
-        .visible(false)
         .build();
 
     let port_adjustment = gtk4::Adjustment::new(
@@ -115,20 +159,17 @@ pub fn build_audio_panel() -> AudioPanel {
     let network_port_row = adw::SpinRow::builder()
         .title("Port")
         .adjustment(&port_adjustment)
-        .visible(false)
         .build();
 
     let protocol_model = gtk4::StringList::new(&["TCP (server)", "UDP"]);
     let network_protocol_row = adw::ComboRow::builder()
         .title("Protocol")
         .model(&protocol_model)
-        .visible(false)
         .build();
 
     let network_status_row = adw::ActionRow::builder()
         .title("Network sink")
         .subtitle("Inactive")
-        .visible(false)
         .build();
 
     let record_audio_row = adw::SwitchRow::builder()
@@ -136,19 +177,49 @@ pub fn build_audio_panel() -> AudioPanel {
         .subtitle("48 kHz stereo WAV")
         .build();
 
-    group.add(&device_row);
-    group.add(&sink_type_row);
-    group.add(&network_host_row);
-    group.add(&network_port_row);
-    group.add(&network_protocol_row);
-    group.add(&network_status_row);
-    group.add(&record_audio_row);
+    // --- Sectioned preferences page ---
+    let output_group = adw::PreferencesGroup::builder()
+        .title("Output")
+        .description("Where audio plays")
+        .build();
+    output_group.add(&device_row);
+    output_group.add(&sink_type_row);
+
+    let volume_group = adw::PreferencesGroup::builder()
+        .title("Volume")
+        .description("Playback level — mirrors the header slider")
+        .build();
+    volume_group.add(&volume_row);
+
+    let network_sink_group = adw::PreferencesGroup::builder()
+        .title("Network sink")
+        .description("Stream audio to another host over TCP or UDP")
+        .visible(false)
+        .build();
+    network_sink_group.add(&network_host_row);
+    network_sink_group.add(&network_port_row);
+    network_sink_group.add(&network_protocol_row);
+    network_sink_group.add(&network_status_row);
+
+    let recording_group = adw::PreferencesGroup::builder()
+        .title("Recording")
+        .description("Save demodulated audio to disk")
+        .build();
+    recording_group.add(&record_audio_row);
+
+    let page = adw::PreferencesPage::new();
+    page.add(&output_group);
+    page.add(&volume_group);
+    page.add(&network_sink_group);
+    page.add(&recording_group);
 
     AudioPanel {
-        widget: group,
+        widget: page,
+        network_sink_group,
         device_row,
         sink_type_row,
         device_node_names: node_names,
+        volume_row,
         record_audio_row,
         network_host_row,
         network_port_row,

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -85,9 +85,16 @@ pub struct AudioPanel {
     /// Node names corresponding to device dropdown indices (for routing).
     pub device_node_names: Vec<String>,
     /// Volume slider — 0..=100 percent. Kept in two-way sync with
-    /// the header `GtkScaleButton` (which uses 0.0..=1.0); both
-    /// dispatch `UiToDsp::SetVolume` and persist to config on
-    /// change. Closes #419.
+    /// the header `GtkScaleButton` (which uses 0.0..=1.0). The
+    /// header button is the **single source of truth** — only its
+    /// `value_changed` handler dispatches `UiToDsp::SetVolume` and
+    /// writes `KEY_AUDIO_VOLUME`. This row is mirror-only: its
+    /// `value_notify` handler forwards edits into the button via
+    /// `set_value`, and the button's handler does the real work.
+    /// Programmatic restores (e.g. bookmark recall) must also go
+    /// through the button, never call `send_dsp(SetVolume(..))`
+    /// directly — see `connect_volume_persistence` in `window.rs`.
+    /// Closes #419.
     pub volume_row: adw::SpinRow,
     /// Toggle to start/stop audio recording.
     pub record_audio_row: adw::SwitchRow,

--- a/crates/sdr-ui/src/sidebar/audio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/audio_panel.rs
@@ -26,6 +26,14 @@ pub const VOLUME_PERCENT_MAX: f64 = 100.0;
 pub const VOLUME_PERCENT_STEP: f64 = 1.0;
 pub const VOLUME_PERCENT_PAGE: f64 = 10.0;
 
+/// Valid TCP / UDP port range for the network sink port spin row.
+pub const PORT_MIN: f64 = 1.0;
+pub const PORT_MAX: f64 = 65535.0;
+/// Keyboard increment / scroll-wheel step for the port spin row.
+pub const PORT_STEP: f64 = 1.0;
+/// Page-up / page-down step for the port spin row.
+pub const PORT_PAGE: f64 = 100.0;
+
 /// Config key for persisted volume. Stored as a `f64` in
 /// `[0.0, 1.0]` (header `GtkScaleButton` domain) so the on-disk
 /// value is the same shape the DSP sees via `UiToDsp::SetVolume`.
@@ -150,10 +158,10 @@ pub fn build_audio_panel() -> AudioPanel {
 
     let port_adjustment = gtk4::Adjustment::new(
         f64::from(NETWORK_SINK_DEFAULT_PORT),
-        1.0,
-        65535.0,
-        1.0,
-        100.0,
+        PORT_MIN,
+        PORT_MAX,
+        PORT_STEP,
+        PORT_PAGE,
         0.0,
     );
     let network_port_row = adw::SpinRow::builder()

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2040,6 +2040,11 @@ fn build_header_bar(
     // `build_window` after `connect_audio_panel` runs, so the
     // persistence + audio-panel mirror rely on the full handle set.
     volume_button.set_tooltip_text(Some("Volume"));
+    // Explicit accessibility label — tooltip text alone isn't
+    // announced reliably by screen readers for icon-only header
+    // controls (same idiom as the bookmarks / transcript / pinned-
+    // servers buttons).
+    volume_button.update_property(&[gtk4::accessible::Property::Label("Volume")]);
 
     // App menu
     let menu_button = build_menu_button();
@@ -2365,6 +2370,7 @@ fn connect_sidebar_panels(
         status_bar,
         spectrum_handle,
         scanner_force_disable,
+        volume_button,
     );
 
     // Mutation-triggered scanner re-projection. Fires on scan
@@ -7109,6 +7115,7 @@ fn restore_bookmark_profile(
     radio: &sidebar::RadioPanel,
     gain_row: &adw::SpinRow,
     agc_row: &adw::ComboRow,
+    volume_button: &gtk4::ScaleButton,
 ) {
     if let Some(sq_en) = bookmark.squelch_enabled {
         state.send_dsp(UiToDsp::SetSquelchEnabled(sq_en));
@@ -7161,7 +7168,19 @@ fn restore_bookmark_profile(
         gain_row.set_value(gain);
     }
     if let Some(vol) = bookmark.volume {
-        state.send_dsp(UiToDsp::SetVolume(vol));
+        // Route through the header `ScaleButton` so the restored
+        // level flows through the single source of truth
+        // `connect_volume_persistence` established: the button's
+        // `value_changed` handler dispatches `SetVolume`, writes
+        // `KEY_AUDIO_VOLUME`, and mirrors into the audio panel's
+        // `volume_row`. Calling `send_dsp(SetVolume(vol))` directly
+        // here would leave the button + audio row + persisted key
+        // showing stale state until the next user edit flicked
+        // them back. `set_value` fires the handler only if the new
+        // value differs from the current one — same idempotency
+        // story as the gain row above.
+        #[allow(clippy::cast_lossless)]
+        volume_button.set_value(vol as f64);
     }
     if let Some(de_idx) = bookmark.deemphasis {
         let deemp = match de_idx {
@@ -7242,6 +7261,7 @@ fn connect_navigation_panel(
     status_bar: &Rc<StatusBar>,
     spectrum_handle: &Rc<spectrum::SpectrumHandle>,
     scanner_force_disable: &Rc<ScannerForceDisable>,
+    volume_button: &gtk4::ScaleButton,
 ) {
     // Navigation callback: restore full tuning profile from bookmark.
     let state_nav = Rc::clone(state);
@@ -7253,6 +7273,7 @@ fn connect_navigation_panel(
     let source_nav_gain = panels.source.gain_row.clone();
     let source_nav_agc = panels.source.agc_row.clone();
     let force_disable_nav = Rc::clone(scanner_force_disable);
+    let volume_button_nav = volume_button.clone();
 
     panels.bookmarks.connect_navigate(move |bookmark| {
         // Both bookmark recall AND band-preset selection come in
@@ -7297,6 +7318,7 @@ fn connect_navigation_panel(
             &radio_nav,
             &source_nav_gain,
             &source_nav_agc,
+            &volume_button_nav,
         );
 
         // Update mode-specific control visibility for the restored mode.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -7549,11 +7549,21 @@ const VOLUME_SYNC_EPSILON: f64 = 0.005;
 /// button's handler do the real work. That keeps one handler owning
 /// dispatch + persist, and the mirror path stays idempotent.
 ///
-/// Startup ordering: wire the handlers first, THEN seed
-/// `volume_button.set_value(saved)`. That ensures the initial
-/// `value_changed` fires with the saved level so the DSP starts at
-/// the restored volume and the user doesn't hear a 1-frame blast at
-/// the build-time default (spec req for #424).
+/// Startup ordering (load-bearing):
+///   1. Seed both widgets with the saved volume (no handlers yet,
+///      so no dispatch or cascade).
+///   2. Explicit `state.send_dsp(UiToDsp::SetVolume(saved))` —
+///      guarantees the DSP starts at the restored level regardless
+///      of `ScaleButton::set_value` being a no-op on same-value
+///      (closes #424's "no 1-frame blast while config loads"
+///      requirement).
+///   3. Wire the handlers.
+///
+/// Any other code path that mutates volume (bookmark recall,
+/// preferences restore, etc.) must go through
+/// `volume_button.set_value(vol)` so this handler runs — direct
+/// `send_dsp(SetVolume(..))` would leave the button / row / config
+/// showing stale state until the user's next edit.
 fn connect_volume_persistence(
     panels: &SidebarPanels,
     state: &Rc<AppState>,
@@ -7571,7 +7581,10 @@ fn connect_volume_persistence(
     // "user change" — no handlers fire, no duplicate dispatch,
     // no mirror-path cascade. Dispatch is done explicitly below.
     volume_button.set_value(saved_volume);
-    panels.audio.volume_row.set_value(saved_volume * 100.0);
+    panels
+        .audio
+        .volume_row
+        .set_value(saved_volume * sidebar::audio_panel::VOLUME_PERCENT_MAX);
 
     // Guaranteed initial dispatch to the DSP so audio starts at
     // the restored level regardless of how `ScaleButton::set_value`
@@ -7592,8 +7605,10 @@ fn connect_volume_persistence(
             v[sidebar::audio_panel::KEY_AUDIO_VOLUME] = serde_json::json!(value);
         });
         if let Some(row) = volume_row_weak.upgrade() {
-            let target_pct = value * 100.0;
-            if (row.value() - target_pct).abs() > VOLUME_SYNC_EPSILON * 100.0 {
+            let target_pct = value * sidebar::audio_panel::VOLUME_PERCENT_MAX;
+            if (row.value() - target_pct).abs()
+                > VOLUME_SYNC_EPSILON * sidebar::audio_panel::VOLUME_PERCENT_MAX
+            {
                 row.set_value(target_pct);
             }
         }
@@ -7605,7 +7620,7 @@ fn connect_volume_persistence(
     // loop when the two widgets are already in sync.
     let volume_button_weak = volume_button.downgrade();
     panels.audio.volume_row.connect_value_notify(move |row| {
-        let value = (row.value() / 100.0).clamp(0.0, 1.0);
+        let value = (row.value() / sidebar::audio_panel::VOLUME_PERCENT_MAX).clamp(0.0, 1.0);
         if let Some(btn) = volume_button_weak.upgrade()
             && (btn.value() - value).abs() > VOLUME_SYNC_EPSILON
         {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -178,6 +178,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         freq_selector,
         screenshot_button,
         rr_button,
+        volume_button,
         favorites_handle,
     ) = build_header_bar(&sidebar_toggle, &state);
 
@@ -359,6 +360,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         config,
         &favorites_handle,
         &scanner_force_disable,
+        &volume_button,
     );
 
     // Seed the scanner with the persisted bookmark list on
@@ -1816,7 +1818,7 @@ fn build_layout(
         .build();
     left_stack.add_named(&general_panel.widget, Some("general"));
     left_stack.add_named(&panels.radio.widget, Some("radio"));
-    left_stack.add_named(&page_from_group(&panels.audio.widget), Some("audio"));
+    left_stack.add_named(&panels.audio.widget, Some("audio"));
     left_stack.add_named(&page_from_group(&panels.display.widget), Some("display"));
     left_stack.add_named(&page_from_widget(&panels.scanner.widget), Some("scanner"));
     left_stack.add_named(&page_from_group(&panels.server.widget), Some("share"));
@@ -1985,6 +1987,7 @@ fn build_header_bar(
     header::frequency_selector::FrequencySelector,
     gtk4::Button,
     gtk4::Button,
+    gtk4::ScaleButton,
     FavoritesHeaderHandle,
 ) {
     // Play/stop button
@@ -2033,13 +2036,10 @@ fn build_header_bar(
             "audio-volume-high-symbolic",
         ],
     );
-    volume_button.set_value(1.0);
+    // Initial value + `connect_value_changed` handler are wired in
+    // `build_window` after `connect_audio_panel` runs, so the
+    // persistence + audio-panel mirror rely on the full handle set.
     volume_button.set_tooltip_text(Some("Volume"));
-    let state_vol = Rc::clone(state);
-    volume_button.connect_value_changed(move |_btn, value| {
-        #[allow(clippy::cast_possible_truncation)]
-        state_vol.send_dsp(UiToDsp::SetVolume(value as f32));
-    });
 
     // App menu
     let menu_button = build_menu_button();
@@ -2083,6 +2083,7 @@ fn build_header_bar(
         freq_selector,
         screenshot_button,
         rr_button,
+        volume_button,
         favorites_handle,
     )
 }
@@ -2302,6 +2303,7 @@ fn connect_sidebar_panels(
     config: &std::sync::Arc<sdr_config::ConfigManager>,
     favorites_header: &FavoritesHeaderHandle,
     scanner_force_disable: &Rc<ScannerForceDisable>,
+    volume_button: &gtk4::ScaleButton,
 ) {
     // Shared "is the rtl_tcp server currently live?" flag. Written by
     // the server panel's start/stop handler, read by the source
@@ -2352,6 +2354,7 @@ fn connect_sidebar_panels(
     connect_radio_panel(panels, state, scanner_force_disable);
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
+    connect_volume_persistence(panels, state, config, volume_button);
     connect_scanner_panel(panels, state, config);
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
@@ -7502,6 +7505,93 @@ fn connect_navigation_panel(
     });
 }
 
+/// Epsilon (in fractional volume units, i.e. `[0.0, 1.0]`) below
+/// which the mirrored volume widgets are considered "already at the
+/// target" and the sync side skips its `set_value` call. Prevents
+/// floating-point round-trip artefacts from causing a trivial
+/// mirror loop between the header `GtkScaleButton` (0.0..=1.0 step
+/// 0.05) and the audio panel `AdwSpinRow` (0..=100 step 1 →
+/// 0.01-per-step when scaled). A half-step worth of slack sits
+/// comfortably below the smallest user-perceptible change.
+const VOLUME_SYNC_EPSILON: f64 = 0.005;
+
+/// Wire volume persistence (closes #419) and two-way sync between
+/// the header `GtkScaleButton` and the audio panel's
+/// `volume_row` `AdwSpinRow`.
+///
+/// The header button is the single source of truth: its
+/// `connect_value_changed` handler is the ONLY path that dispatches
+/// `UiToDsp::SetVolume` and writes to the config. The audio-panel
+/// row drives the button via `set_value` — its own
+/// `connect_value_notify` just mirrors into the button and lets the
+/// button's handler do the real work. That keeps one handler owning
+/// dispatch + persist, and the mirror path stays idempotent.
+///
+/// Startup ordering: wire the handlers first, THEN seed
+/// `volume_button.set_value(saved)`. That ensures the initial
+/// `value_changed` fires with the saved level so the DSP starts at
+/// the restored volume and the user doesn't hear a 1-frame blast at
+/// the build-time default (spec req for #424).
+fn connect_volume_persistence(
+    panels: &SidebarPanels,
+    state: &Rc<AppState>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+    volume_button: &gtk4::ScaleButton,
+) {
+    let saved_volume = config.read(|v| {
+        v.get(sidebar::audio_panel::KEY_AUDIO_VOLUME)
+            .and_then(serde_json::Value::as_f64)
+            .map_or(1.0, |f| f.clamp(0.0, 1.0))
+    });
+
+    // Seed both widgets BEFORE wiring handlers. Setting values
+    // first means the initial state isn't observed as a
+    // "user change" — no handlers fire, no duplicate dispatch,
+    // no mirror-path cascade. Dispatch is done explicitly below.
+    volume_button.set_value(saved_volume);
+    panels.audio.volume_row.set_value(saved_volume * 100.0);
+
+    // Guaranteed initial dispatch to the DSP so audio starts at
+    // the restored level regardless of how `ScaleButton::set_value`
+    // interacts with its default (closes #424's "no 1-frame blast
+    // while config loads" requirement).
+    #[allow(clippy::cast_possible_truncation)]
+    state.send_dsp(UiToDsp::SetVolume(saved_volume as f32));
+
+    // Button is the single source of truth: its handler owns
+    // dispatch + persist + mirror-to-row.
+    let state_vol = Rc::clone(state);
+    let config_vol = std::sync::Arc::clone(config);
+    let volume_row_weak = panels.audio.volume_row.downgrade();
+    volume_button.connect_value_changed(move |_btn, value| {
+        #[allow(clippy::cast_possible_truncation)]
+        state_vol.send_dsp(UiToDsp::SetVolume(value as f32));
+        config_vol.write(|v| {
+            v[sidebar::audio_panel::KEY_AUDIO_VOLUME] = serde_json::json!(value);
+        });
+        if let Some(row) = volume_row_weak.upgrade() {
+            let target_pct = value * 100.0;
+            if (row.value() - target_pct).abs() > VOLUME_SYNC_EPSILON * 100.0 {
+                row.set_value(target_pct);
+            }
+        }
+    });
+
+    // Audio panel row is mirror-only. Drives the button, which
+    // runs the dispatch + config write. The idempotency check
+    // breaks the `btn.set_value → row.set_value → btn.set_value`
+    // loop when the two widgets are already in sync.
+    let volume_button_weak = volume_button.downgrade();
+    panels.audio.volume_row.connect_value_notify(move |row| {
+        let value = (row.value() / 100.0).clamp(0.0, 1.0);
+        if let Some(btn) = volume_button_weak.upgrade()
+            && (btn.value() - value).abs() > VOLUME_SYNC_EPSILON
+        {
+            btn.set_value(value);
+        }
+    });
+}
+
 /// Connect audio panel controls to DSP commands.
 fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
     // Audio device selector — routes PipeWire output to the selected sink
@@ -7519,10 +7609,7 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
     // network config rows so the sidebar layout reflects the
     // active mode. Per issue #247.
     let state_sink_type = Rc::clone(state);
-    let host_row = panels.audio.network_host_row.clone();
-    let port_row = panels.audio.network_port_row.clone();
-    let proto_row = panels.audio.network_protocol_row.clone();
-    let status_row = panels.audio.network_status_row.clone();
+    let network_group = panels.audio.network_sink_group.clone();
     panels
         .audio
         .sink_type_row
@@ -7545,10 +7632,10 @@ fn connect_audio_panel(panels: &SidebarPanels, state: &Rc<AppState>) {
                 }
             };
             let network_visible = matches!(new_type, sdr_core::AudioSinkType::Network);
-            host_row.set_visible(network_visible);
-            port_row.set_visible(network_visible);
-            proto_row.set_visible(network_visible);
-            status_row.set_visible(network_visible);
+            // Toggle the whole Network-sink section instead of its
+            // four rows individually — same pattern as the Radio
+            // panel's De-emphasis / CTCSS group-level hides.
+            network_group.set_visible(network_visible);
             state_sink_type.send_dsp(UiToDsp::SetAudioSinkType(new_type));
         });
 


### PR DESCRIPTION
Closes #424. Closes #419. Sub-ticket 4/10 of epic #420.

## Summary

Splits the Audio panel into the four titled `AdwPreferencesPage` sections called for by the activity-bar redesign and fixes the volume-persistence bug in the same pass (the Audio panel is the natural home for the fix; doing both at once avoids a second touch of the same widgets).

## Sections

| Title | Description | Contents |
|-------|-------------|----------|
| **Output** | Where audio plays | Device combo + Sink-type combo (Audio / Network) |
| **Volume** | Playback level — mirrors the header slider | Percent spin row, two-way synced with the header `GtkScaleButton` |
| **Network sink** | Stream audio to another host over TCP or UDP | Host / port / protocol / status rows |
| **Recording** | Save demodulated audio to disk | Record Audio switch |

Network-sink visibility now flips at the **group level** when the user toggles between Local and Network sink types (same pattern as Radio's De-emphasis / CTCSS group-level hides) — cleaner than showing a titled group with four hidden rows.

## Volume persistence (#419)

- New config key `audio_volume` in `sidebar::audio_panel`, stored as a `f64` in `[0.0, 1.0]` (same domain the header `GtkScaleButton` uses, same domain the DSP sees via `UiToDsp::SetVolume`).
- New `connect_volume_persistence` helper:
  - Reads saved volume from config.
  - Header button is the **single source of truth** — its `connect_value_changed` owns dispatch + persist + mirror-to-row.
  - Audio-panel row is mirror-only; its `connect_value_notify` drives the button via `set_value` and the button's handler does the real work. Idempotency epsilon (`VOLUME_SYNC_EPSILON = 0.005`) breaks the btn→row→btn→… loop.
- **Startup ordering** (closes #424's "no 1-frame blast while config loads" requirement):
  1. Seed both widgets before wiring handlers — no handlers connected ⇒ no cascade.
  2. Explicit `state.send_dsp(UiToDsp::SetVolume(saved))` — guarantees DSP starts at restored level regardless of GTK's `set_value`-is-no-op-on-same-value behaviour (e.g. saved = 0.0 matches the `ScaleButton` default).
  3. Wire handlers.

## Supporting changes

- `build_header_bar` return tuple now includes `volume_button` so the persistence helper in `connect_sidebar_panels` can reach it; `connect_sidebar_panels` signature gains `volume_button: &gtk4::ScaleButton`.
- `AudioPanel.widget` changed from `adw::PreferencesGroup` to `adw::PreferencesPage`; the `window.rs` call site drops its `page_from_group` wrap.
- `AudioPanel` gains `network_sink_group` + `volume_row` fields.
- Device combo picks up PipeWire sinks on launch (unchanged from before).

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"` builds + installs, clean launch (no panic).
- [ ] Click **Audio** icon → 4 titled sections render with consistent chrome.
- [ ] Flip Sink Type: Local hides the whole Network-sink section; Network reveals it.
- [ ] Volume persistence (#419): set header volume to 30 %, quit, relaunch → both controls restore to 30 %, no 1-frame blast at 100 %.
- [ ] Drag audio-panel volume row → header button follows in real time (and vice versa).
- [ ] Network audio sink still works end-to-end (host / port / protocol / status).
- [ ] Recording toggle still writes WAV to disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Volume control exposed as a 0–100% spin/slider, persisted and synchronized with the header control.
  * Audio settings reorganized into a preferences page with sections: Output, Volume, Network Sink, Recording.
  * Network sink section toggles visibility as a whole; network port controls have refined ranges/steps.

* **Bug Fixes**
  * Restored/bookmarked volume now follows the same persisted sync path to avoid duplicate dispatches and feedback loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->