### PR TITLE
sdr-ui: activity-bar session persistence

### DIFF
--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -129,6 +129,137 @@ pub const RIGHT_ACTIVITIES: &[ActivityBarEntry] = &[
     },
 ];
 
+// ─── Session persistence (#428) ───────────────────────────────
+//
+// Four config keys carry the across-restart activity-bar state.
+// `width_px` is a separate concern that lands with sub-ticket
+// #429 (resize handles). The `expanded.<panel>.<section>` keys
+// the design doc envisaged are moot — the panels shipped with
+// flat `AdwPreferencesGroup`s instead of `AdwExpanderRow`s, so
+// there is no per-section collapse state to remember.
+
+/// Config key for the `name` of the currently selected left
+/// activity. Values must be one of [`LEFT_ACTIVITIES`]`.name`.
+pub const KEY_LEFT_SELECTED: &str = "ui_sidebar_left_selected";
+/// Config key for the left split-view's open/closed state.
+pub const KEY_LEFT_OPEN: &str = "ui_sidebar_left_open";
+/// Config key for the `name` of the currently selected right
+/// activity. Values must be one of [`RIGHT_ACTIVITIES`]`.name`.
+pub const KEY_RIGHT_SELECTED: &str = "ui_sidebar_right_selected";
+/// Config key for the right split-view's open/closed state.
+pub const KEY_RIGHT_OPEN: &str = "ui_sidebar_right_open";
+
+/// Default left selection on a fresh install. Must match an entry
+/// in [`LEFT_ACTIVITIES`].
+pub const DEFAULT_LEFT_SELECTED: &str = "general";
+/// Default left-panel open state on a fresh install.
+pub const DEFAULT_LEFT_OPEN: bool = true;
+/// Default right selection on a fresh install. Must match an
+/// entry in [`RIGHT_ACTIVITIES`].
+pub const DEFAULT_RIGHT_SELECTED: &str = "transcript";
+/// Default right-panel open state on a fresh install — closed,
+/// per the design doc's "Transcript opt-in" note.
+pub const DEFAULT_RIGHT_OPEN: bool = false;
+
+/// Persisted activity-bar state, loaded once at launch by
+/// [`load_session`] and applied before the window is presented.
+/// Every field resolves to a concrete value even on a fresh
+/// install; callers don't see `Option`s.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SidebarSession {
+    /// Stable `name` from [`LEFT_ACTIVITIES`]. Guaranteed valid
+    /// (a stale config naming a removed activity falls back to
+    /// [`DEFAULT_LEFT_SELECTED`]).
+    pub left_selected: &'static str,
+    pub left_open: bool,
+    /// Stable `name` from [`RIGHT_ACTIVITIES`]. Same validity
+    /// guarantee as [`left_selected`](Self::left_selected).
+    pub right_selected: &'static str,
+    pub right_open: bool,
+}
+
+impl Default for SidebarSession {
+    fn default() -> Self {
+        Self {
+            left_selected: DEFAULT_LEFT_SELECTED,
+            left_open: DEFAULT_LEFT_OPEN,
+            right_selected: DEFAULT_RIGHT_SELECTED,
+            right_open: DEFAULT_RIGHT_OPEN,
+        }
+    }
+}
+
+/// Resolve a persisted activity name against the canonical entry
+/// list. Returns the entry's `&'static str` (not the caller's
+/// borrowed config value) so downstream code — notably
+/// `wire_activity_bar_clicks` — can hold it in a
+/// `RefCell<&'static str>` without lifetime headaches. Any stale
+/// or typo'd name falls back to `default`.
+fn pick_entry_name(
+    candidate: Option<&str>,
+    entries: &'static [ActivityBarEntry],
+    default: &'static str,
+) -> &'static str {
+    candidate
+        .and_then(|c| entries.iter().find(|e| e.name == c).map(|e| e.name))
+        .unwrap_or(default)
+}
+
+/// Load the persisted activity-bar session from config, filling
+/// missing or malformed fields with the fresh-install defaults.
+#[must_use]
+pub fn load_session(config: &std::sync::Arc<sdr_config::ConfigManager>) -> SidebarSession {
+    config.read(|v| SidebarSession {
+        left_selected: pick_entry_name(
+            v.get(KEY_LEFT_SELECTED).and_then(serde_json::Value::as_str),
+            LEFT_ACTIVITIES,
+            DEFAULT_LEFT_SELECTED,
+        ),
+        left_open: v
+            .get(KEY_LEFT_OPEN)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(DEFAULT_LEFT_OPEN),
+        right_selected: pick_entry_name(
+            v.get(KEY_RIGHT_SELECTED)
+                .and_then(serde_json::Value::as_str),
+            RIGHT_ACTIVITIES,
+            DEFAULT_RIGHT_SELECTED,
+        ),
+        right_open: v
+            .get(KEY_RIGHT_OPEN)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(DEFAULT_RIGHT_OPEN),
+    })
+}
+
+/// Persist the left-activity selection.
+pub fn save_left_selected(config: &std::sync::Arc<sdr_config::ConfigManager>, name: &str) {
+    config.write(|v| {
+        v[KEY_LEFT_SELECTED] = serde_json::json!(name);
+    });
+}
+
+/// Persist the left panel open/closed state.
+pub fn save_left_open(config: &std::sync::Arc<sdr_config::ConfigManager>, open: bool) {
+    config.write(|v| {
+        v[KEY_LEFT_OPEN] = serde_json::json!(open);
+    });
+}
+
+/// Persist the right-activity selection.
+pub fn save_right_selected(config: &std::sync::Arc<sdr_config::ConfigManager>, name: &str) {
+    config.write(|v| {
+        v[KEY_RIGHT_SELECTED] = serde_json::json!(name);
+    });
+}
+
+/// Persist the right panel open/closed state.
+pub fn save_right_open(config: &std::sync::Arc<sdr_config::ConfigManager>, open: bool) {
+    config.write(|v| {
+        v[KEY_RIGHT_OPEN] = serde_json::json!(open);
+    });
+}
+
 /// Which edge of the window the activity bar sits against. Controls
 /// the CSS class list and the border side.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -298,5 +429,84 @@ mod tests {
                 entry.name
             );
         }
+    }
+
+    // ─── Session persistence ────────────────────────────────
+
+    use std::sync::Arc;
+
+    use sdr_config::ConfigManager;
+
+    fn make_config() -> Arc<ConfigManager> {
+        Arc::new(ConfigManager::in_memory(&serde_json::json!({})))
+    }
+
+    #[test]
+    fn session_defaults_on_fresh_config() {
+        let config = make_config();
+        let loaded = load_session(&config);
+        assert_eq!(loaded, SidebarSession::default());
+    }
+
+    #[test]
+    fn session_default_agrees_with_canonical_activity_list() {
+        // `DEFAULT_LEFT_SELECTED` / `DEFAULT_RIGHT_SELECTED` must
+        // resolve against their respective entry lists — a typo
+        // would silently fall back to the entry's own default
+        // string but then `pick_entry_name` with the stale key
+        // would still work because it matches by name. Pin the
+        // direct presence here to catch the misspelling earlier.
+        assert!(
+            LEFT_ACTIVITIES
+                .iter()
+                .any(|e| e.name == DEFAULT_LEFT_SELECTED),
+            "DEFAULT_LEFT_SELECTED not in LEFT_ACTIVITIES"
+        );
+        assert!(
+            RIGHT_ACTIVITIES
+                .iter()
+                .any(|e| e.name == DEFAULT_RIGHT_SELECTED),
+            "DEFAULT_RIGHT_SELECTED not in RIGHT_ACTIVITIES"
+        );
+    }
+
+    #[test]
+    fn session_round_trips_full_state() {
+        let config = make_config();
+        save_left_selected(&config, "radio");
+        save_left_open(&config, false);
+        save_right_selected(&config, "bookmarks");
+        save_right_open(&config, true);
+        let loaded = load_session(&config);
+        assert_eq!(loaded.left_selected, "radio");
+        assert!(!loaded.left_open);
+        assert_eq!(loaded.right_selected, "bookmarks");
+        assert!(loaded.right_open);
+    }
+
+    #[test]
+    fn session_stale_selection_falls_back_to_default() {
+        // A config left behind by an older build (pre-Share)
+        // might name an activity we removed. Fall back to the
+        // default rather than crash or show a blank stack.
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            KEY_LEFT_SELECTED: "removed-activity",
+            KEY_RIGHT_SELECTED: "also-removed",
+        })));
+        let loaded = load_session(&config);
+        assert_eq!(loaded.left_selected, DEFAULT_LEFT_SELECTED);
+        assert_eq!(loaded.right_selected, DEFAULT_RIGHT_SELECTED);
+    }
+
+    #[test]
+    fn session_malformed_values_fall_back_to_defaults() {
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            KEY_LEFT_SELECTED: 42,
+            KEY_LEFT_OPEN: "not-a-bool",
+            KEY_RIGHT_SELECTED: [1, 2, 3],
+            KEY_RIGHT_OPEN: "nope",
+        })));
+        let loaded = load_session(&config);
+        assert_eq!(loaded, SidebarSession::default());
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -238,21 +238,68 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // CURRENTLY-selected icon toggles the panel while keeping the
     // icon selected (design doc §4.2). `:checked` CSS renders the
     // accent tint via `ToggleButton::active`.
-    if let Some(general_btn) = left_activity_bar.buttons.get("general") {
-        general_btn.set_active(true);
+    //
+    // Seed ordering (closes #428): load the persisted session,
+    // apply to widgets BEFORE wiring the persistence notify
+    // handlers, so the initial `set_active` / `set_visible_child` /
+    // `set_show_sidebar` calls don't write the same value back
+    // through the save path. Matches the "seed-then-wire" pattern
+    // `connect_volume_persistence` uses.
+    let session = sidebar::activity_bar::load_session(config);
+    left_stack.set_visible_child_name(session.left_selected);
+    if let Some(btn) = left_activity_bar.buttons.get(session.left_selected) {
+        btn.set_active(true);
     }
-    wire_activity_bar_clicks(&left_activity_bar, &left_stack, &left_split_view, "general");
+    left_split_view.set_show_sidebar(session.left_open);
+    right_stack.set_visible_child_name(session.right_selected);
+    if session.right_open
+        && let Some(btn) = right_activity_bar.buttons.get(session.right_selected)
+    {
+        btn.set_active(true);
+    }
+    right_split_view.set_show_sidebar(session.right_open);
 
-    // Right bar pre-selection: Transcript is the landing activity
-    // when the right panel first opens. No button starts visually
-    // active because the panel itself starts closed — first click
-    // opens it and flips the matching icon's `active` on.
+    wire_activity_bar_clicks(
+        &left_activity_bar,
+        &left_stack,
+        &left_split_view,
+        session.left_selected,
+    );
     wire_activity_bar_clicks(
         &right_activity_bar,
         &right_stack,
         &right_split_view,
-        "transcript",
+        session.right_selected,
     );
+
+    // Persistence — wire AFTER the seed so the initial sets don't
+    // round-trip back through config. `save_*` writes are cheap
+    // (`ConfigManager` batches); every activity click / panel
+    // open-close writes.
+    for (&name, btn) in &left_activity_bar.buttons {
+        let config_weak = std::sync::Arc::clone(config);
+        btn.connect_toggled(move |b| {
+            if b.is_active() {
+                sidebar::activity_bar::save_left_selected(&config_weak, name);
+            }
+        });
+    }
+    for (&name, btn) in &right_activity_bar.buttons {
+        let config_weak = std::sync::Arc::clone(config);
+        btn.connect_toggled(move |b| {
+            if b.is_active() {
+                sidebar::activity_bar::save_right_selected(&config_weak, name);
+            }
+        });
+    }
+    let config_left_open = std::sync::Arc::clone(config);
+    left_split_view.connect_show_sidebar_notify(move |sv| {
+        sidebar::activity_bar::save_left_open(&config_left_open, sv.shows_sidebar());
+    });
+    let config_right_open = std::sync::Arc::clone(config);
+    right_split_view.connect_show_sidebar_notify(move |sv| {
+        sidebar::activity_bar::save_right_open(&config_right_open, sv.shows_sidebar());
+    });
 
     // Header sidebar toggle ↔ left split view `show-sidebar` sync.
     // Without this, clicking the currently-selected activity icon to
@@ -267,6 +314,9 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
             toggle.set_active(sv.shows_sidebar());
         }
     });
+    // Seed the header sidebar toggle to match the restored left
+    // panel state so F9's "is it open?" check starts accurate.
+    sidebar_toggle.set_active(session.left_open);
 
     let toolbar_view = build_toolbar_view(&header, &layout_root);
     let breakpoint = build_breakpoint(&left_split_view, &right_split_view);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -252,9 +252,14 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     }
     left_split_view.set_show_sidebar(session.left_open);
     right_stack.set_visible_child_name(session.right_selected);
-    if session.right_open
-        && let Some(btn) = right_activity_bar.buttons.get(session.right_selected)
-    {
+    // Seed the right selection as active even when the panel
+    // restores closed. The activity-bar contract (design doc §4.2)
+    // is that an icon stays visually selected through open/close
+    // cycles — the icon is a preview of "which slot opens next".
+    // Without this, `right_stack` + `wire_activity_bar_clicks`
+    // would both treat `session.right_selected` as selected while
+    // the bar shows no active button until the user's first click.
+    if let Some(btn) = right_activity_bar.buttons.get(session.right_selected) {
         btn.set_active(true);
     }
     right_split_view.set_show_sidebar(session.right_open);


### PR DESCRIPTION
Closes #428. Sub-ticket 8/10 of epic #420.

## Summary

Persists activity-bar selection and panel open/closed state across sessions so the app relaunches to the same view the user left it in.

## Config keys

| Key | Type | Default | Notes |
|-----|------|---------|-------|
| `ui_sidebar_left_selected` | string | `"general"` | Must match a `LEFT_ACTIVITIES[*].name` |
| `ui_sidebar_left_open` | bool | `true` | Left panel starts open |
| `ui_sidebar_right_selected` | string | `"transcript"` | Must match a `RIGHT_ACTIVITIES[*].name` |
| `ui_sidebar_right_open` | bool | `false` | Transcript opt-in — right panel starts closed |

## Scope reductions from the original issue

- **`width_px` persistence** — explicitly deferred to #429 (resize handles) by the issue itself. This PR doesn't touch it.
- **`expanded.<panel>.<section>` keys** — moot. The panels shipped with flat `AdwPreferencesGroup`s rather than `AdwExpanderRow`s (per the user preference for the Apple-style section rhythm), so there's no per-section collapse state to persist.
- **Migration from `sidebar.collapsed`** — no-op. The legacy key never existed in the codebase (verified with `grep -rn`); the issue was written speculatively before implementation.

## Key design calls

- **`SidebarSession` struct + `pick_entry_name`** — loaded state is `&'static str` referring to entries in the canonical lists, so downstream code (notably `wire_activity_bar_clicks`) can hold it in a `RefCell<&'static str>` without lifetime gymnastics. Stale / typo'd names fall back to the default.
- **Seed-then-wire ordering** — widgets are set from the loaded session BEFORE handlers are wired, matching the pattern `connect_volume_persistence` established in #424. This means the initial `set_active` / `set_show_sidebar` calls don't round-trip back through the save path. If I'd wired handlers first, every restart would write the loaded value back (idempotent but noisy).
- **Header sidebar toggle seeded** to match the restored left-panel state so F9's toggle starts from the correct direction on launch.

## Tests

Five new unit tests in `sidebar::activity_bar::tests`:

- `session_defaults_on_fresh_config` — empty config yields defaults.
- `session_default_agrees_with_canonical_activity_list` — catches a default-string typo at build time.
- `session_round_trips_full_state` — save then load preserves all four fields.
- `session_stale_selection_falls_back_to_default` — config naming a removed activity falls back cleanly (forward compat for future activity list tweaks).
- `session_malformed_values_fall_back_to_defaults` — wrong JSON types (number, array, string-for-bool) all fall back.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --workspace` — all 10 activity_bar tests pass (5 new).
- [x] `make install CARGO_FLAGS="--release --no-default-features --features sherpa-cuda"` builds + installs.
- [x] Smoke: click Radio → quit → relaunch: Radio still selected.
- [x] Smoke: collapse left panel (F9 or click selected icon again) → quit → relaunch: panel still closed.
- [x] Smoke: open right Bookmarks → quit → relaunch: right panel open showing Bookmarks.
- [x] Smoke: hand-edit config to name a deleted activity → relaunch: falls back to General / Transcript defaults, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar activity selections and panel visibility are now persisted and automatically restored across restarts, including correct restoration of right-panel selection even when the panel is closed.
  * Restoration is robust: malformed or stale saved values fall back to safe defaults to ensure consistent UI state.

* **Tests**
  * Added tests verifying default initialization, round-trip persistence, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->