### PR TITLE
sdr-ui: sidebar resize handles

### DIFF
--- a/crates/sdr-ui/src/css.rs
+++ b/crates/sdr-ui/src/css.rs
@@ -97,6 +97,22 @@ const APP_CSS: &str = r#"
 .activity-bar button.activity-bar-button:checked:hover {
     background-color: alpha(@accent_color, 0.2);
 }
+
+/* Sidebar resize handle — a thin strip at the sidebar's inner
+ * edge that carries the drag gesture + col-resize cursor. The
+ * strip is transparent by default (invisible to eye) and tints
+ * subtly on hover so the user discovers the affordance when
+ * their cursor enters the region. Matches the restrained visual
+ * treatment of the activity bar — no chrome unless the user
+ * reaches for it.
+ */
+.sidebar-resize-handle {
+    background: transparent;
+}
+
+.sidebar-resize-handle:hover {
+    background-color: alpha(@accent_color, 0.2);
+}
 "#;
 
 /// Load the application CSS into the default display's style context.

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -143,11 +143,20 @@ pub const RIGHT_ACTIVITIES: &[ActivityBarEntry] = &[
 pub const KEY_LEFT_SELECTED: &str = "ui_sidebar_left_selected";
 /// Config key for the left split-view's open/closed state.
 pub const KEY_LEFT_OPEN: &str = "ui_sidebar_left_open";
+/// Config key for the left panel's pixel width (persisted on
+/// resize drag-end). The saved value is stored as pixels per the
+/// user-facing contract in #429; `window.rs` converts back to an
+/// `AdwOverlaySplitView` fraction once the split view has a real
+/// allocation.
+pub const KEY_LEFT_WIDTH_PX: &str = "ui_sidebar_left_width_px";
 /// Config key for the `name` of the currently selected right
 /// activity. Values must be one of [`RIGHT_ACTIVITIES`]`.name`.
 pub const KEY_RIGHT_SELECTED: &str = "ui_sidebar_right_selected";
 /// Config key for the right split-view's open/closed state.
 pub const KEY_RIGHT_OPEN: &str = "ui_sidebar_right_open";
+/// Config key for the right panel's pixel width. Same conversion
+/// contract as [`KEY_LEFT_WIDTH_PX`].
+pub const KEY_RIGHT_WIDTH_PX: &str = "ui_sidebar_right_width_px";
 
 /// Default left selection on a fresh install. Must match an entry
 /// in [`LEFT_ACTIVITIES`].
@@ -163,8 +172,12 @@ pub const DEFAULT_RIGHT_OPEN: bool = false;
 
 /// Persisted activity-bar state, loaded once at launch by
 /// [`load_session`] and applied before the window is presented.
-/// Every field resolves to a concrete value even on a fresh
-/// install; callers don't see `Option`s.
+/// Selection + open state resolve to concrete values even on a
+/// fresh install; width fields stay `Option`-wrapped because the
+/// builder-time default (a fraction of the split view's allocated
+/// width) is a good answer in the absence of a user preference,
+/// and forcing a pixel value at build time would require knowing
+/// the split view's allocation before it exists.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SidebarSession {
     /// Stable `name` from [`LEFT_ACTIVITIES`]. Guaranteed valid
@@ -172,10 +185,19 @@ pub struct SidebarSession {
     /// [`DEFAULT_LEFT_SELECTED`]).
     pub left_selected: &'static str,
     pub left_open: bool,
+    /// Persisted left panel width in pixels. `None` on fresh
+    /// install; `window.rs` applies the value after the left
+    /// split view's first allocation (fractions are the only
+    /// knob `AdwOverlaySplitView` exposes, and those need
+    /// allocation width to convert from pixels).
+    pub left_width_px: Option<u32>,
     /// Stable `name` from [`RIGHT_ACTIVITIES`]. Same validity
     /// guarantee as [`left_selected`](Self::left_selected).
     pub right_selected: &'static str,
     pub right_open: bool,
+    /// Persisted right panel width in pixels. Same semantics as
+    /// [`left_width_px`](Self::left_width_px).
+    pub right_width_px: Option<u32>,
 }
 
 impl Default for SidebarSession {
@@ -183,8 +205,10 @@ impl Default for SidebarSession {
         Self {
             left_selected: DEFAULT_LEFT_SELECTED,
             left_open: DEFAULT_LEFT_OPEN,
+            left_width_px: None,
             right_selected: DEFAULT_RIGHT_SELECTED,
             right_open: DEFAULT_RIGHT_OPEN,
+            right_width_px: None,
         }
     }
 }
@@ -205,6 +229,16 @@ fn pick_entry_name(
         .unwrap_or(default)
 }
 
+/// Load a persisted pixel width, narrowing JSON `u64` → `u32`
+/// and silently falling back to `None` if the value is missing,
+/// malformed, or overflows.
+fn read_optional_width_px(value: &serde_json::Value, key: &str) -> Option<u32> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u32::try_from(n).ok())
+}
+
 /// Load the persisted activity-bar session from config, filling
 /// missing or malformed fields with the fresh-install defaults.
 #[must_use]
@@ -219,6 +253,7 @@ pub fn load_session(config: &std::sync::Arc<sdr_config::ConfigManager>) -> Sideb
             .get(KEY_LEFT_OPEN)
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(DEFAULT_LEFT_OPEN),
+        left_width_px: read_optional_width_px(v, KEY_LEFT_WIDTH_PX),
         right_selected: pick_entry_name(
             v.get(KEY_RIGHT_SELECTED)
                 .and_then(serde_json::Value::as_str),
@@ -229,6 +264,7 @@ pub fn load_session(config: &std::sync::Arc<sdr_config::ConfigManager>) -> Sideb
             .get(KEY_RIGHT_OPEN)
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(DEFAULT_RIGHT_OPEN),
+        right_width_px: read_optional_width_px(v, KEY_RIGHT_WIDTH_PX),
     })
 }
 
@@ -236,6 +272,20 @@ pub fn load_session(config: &std::sync::Arc<sdr_config::ConfigManager>) -> Sideb
 pub fn save_left_selected(config: &std::sync::Arc<sdr_config::ConfigManager>, name: &str) {
     config.write(|v| {
         v[KEY_LEFT_SELECTED] = serde_json::json!(name);
+    });
+}
+
+/// Persist the left panel's pixel width.
+pub fn save_left_width_px(config: &std::sync::Arc<sdr_config::ConfigManager>, px: u32) {
+    config.write(|v| {
+        v[KEY_LEFT_WIDTH_PX] = serde_json::json!(px);
+    });
+}
+
+/// Persist the right panel's pixel width.
+pub fn save_right_width_px(config: &std::sync::Arc<sdr_config::ConfigManager>, px: u32) {
+    config.write(|v| {
+        v[KEY_RIGHT_WIDTH_PX] = serde_json::json!(px);
     });
 }
 
@@ -475,13 +525,43 @@ mod tests {
         let config = make_config();
         save_left_selected(&config, "radio");
         save_left_open(&config, false);
+        save_left_width_px(&config, 400);
         save_right_selected(&config, "bookmarks");
         save_right_open(&config, true);
+        save_right_width_px(&config, 500);
         let loaded = load_session(&config);
         assert_eq!(loaded.left_selected, "radio");
         assert!(!loaded.left_open);
+        assert_eq!(loaded.left_width_px, Some(400));
         assert_eq!(loaded.right_selected, "bookmarks");
         assert!(loaded.right_open);
+        assert_eq!(loaded.right_width_px, Some(500));
+    }
+
+    #[test]
+    fn session_missing_widths_resolve_to_none() {
+        // Fresh install (or a pre-#429 config with no width keys)
+        // loads with `None` so the builder-time fractional default
+        // stands and no post-realize callback runs.
+        let config = make_config();
+        save_left_selected(&config, "general");
+        let loaded = load_session(&config);
+        assert_eq!(loaded.left_width_px, None);
+        assert_eq!(loaded.right_width_px, None);
+    }
+
+    #[test]
+    fn session_malformed_widths_resolve_to_none() {
+        // A hand-edited or upgrade-corrupted config shouldn't
+        // crash — `u64` that can't narrow to `u32`, wrong JSON
+        // types all become `None`.
+        let config = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            KEY_LEFT_WIDTH_PX: "not-a-number",
+            KEY_RIGHT_WIDTH_PX: u64::from(u32::MAX) + 1,
+        })));
+        let loaded = load_session(&config);
+        assert_eq!(loaded.left_width_px, None);
+        assert_eq!(loaded.right_width_px, None);
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -275,18 +275,21 @@ pub fn save_left_selected(config: &std::sync::Arc<sdr_config::ConfigManager>, na
     });
 }
 
+/// Shared writer used by both sidebar width persistors.
+fn save_width_px(config: &std::sync::Arc<sdr_config::ConfigManager>, key: &str, px: u32) {
+    config.write(|v| {
+        v[key] = serde_json::json!(px);
+    });
+}
+
 /// Persist the left panel's pixel width.
 pub fn save_left_width_px(config: &std::sync::Arc<sdr_config::ConfigManager>, px: u32) {
-    config.write(|v| {
-        v[KEY_LEFT_WIDTH_PX] = serde_json::json!(px);
-    });
+    save_width_px(config, KEY_LEFT_WIDTH_PX, px);
 }
 
 /// Persist the right panel's pixel width.
 pub fn save_right_width_px(config: &std::sync::Arc<sdr_config::ConfigManager>, px: u32) {
-    config.write(|v| {
-        v[KEY_RIGHT_WIDTH_PX] = serde_json::json!(px);
-    });
+    save_width_px(config, KEY_RIGHT_WIDTH_PX, px);
 }
 
 /// Persist the left panel open/closed state.
@@ -522,20 +525,27 @@ mod tests {
 
     #[test]
     fn session_round_trips_full_state() {
+        // Arbitrary in-range widths picked for the test — named
+        // so the save/assert pairs stay in lockstep and the
+        // intent reads as "a round-trip preserves the literal",
+        // not "420 magic bytes somewhere".
+        const TEST_LEFT_WIDTH_PX: u32 = 400;
+        const TEST_RIGHT_WIDTH_PX: u32 = 500;
+
         let config = make_config();
         save_left_selected(&config, "radio");
         save_left_open(&config, false);
-        save_left_width_px(&config, 400);
+        save_left_width_px(&config, TEST_LEFT_WIDTH_PX);
         save_right_selected(&config, "bookmarks");
         save_right_open(&config, true);
-        save_right_width_px(&config, 500);
+        save_right_width_px(&config, TEST_RIGHT_WIDTH_PX);
         let loaded = load_session(&config);
         assert_eq!(loaded.left_selected, "radio");
         assert!(!loaded.left_open);
-        assert_eq!(loaded.left_width_px, Some(400));
+        assert_eq!(loaded.left_width_px, Some(TEST_LEFT_WIDTH_PX));
         assert_eq!(loaded.right_selected, "bookmarks");
         assert!(loaded.right_open);
-        assert_eq!(loaded.right_width_px, Some(500));
+        assert_eq!(loaded.right_width_px, Some(TEST_RIGHT_WIDTH_PX));
     }
 
     #[test]

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -264,6 +264,16 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     }
     right_split_view.set_show_sidebar(session.right_open);
 
+    // Restore saved pixel widths via a one-shot `notify::width`
+    // handler — `sidebar_width_fraction` needs the split view's
+    // live allocation to convert pixels → fraction, and the
+    // allocation isn't settled until the widget has mapped. The
+    // `applied` cell flips after the first non-zero width is seen
+    // so subsequent width changes (window resize) leave the
+    // sidebar's fraction alone.
+    apply_saved_sidebar_width(&left_split_view, session.left_width_px);
+    apply_saved_sidebar_width(&right_split_view, session.right_width_px);
+
     wire_activity_bar_clicks(
         &left_activity_bar,
         &left_stack,
@@ -1912,11 +1922,10 @@ fn build_layout(
     // here is a fraction; under nested splits its pixel result
     // is approximate, and `min-sidebar-width` clamps the transcript
     // panel up to its 360 px floor when the math would otherwise
-    // leave it narrower. Hitting the exact pixel target would
-    // require a post-realize callback (sub-ticket #428 territory).
+    // leave it narrower. User-driven resize + persistence come from
+    // the drag handle wired below (#429).
     let right_split_view = adw::OverlaySplitView::builder()
         .sidebar_position(gtk4::PackType::End)
-        .sidebar(&right_stack)
         .content(&content_box)
         .show_sidebar(false)
         .min_sidebar_width(RIGHT_SIDEBAR_MIN_WIDTH)
@@ -1924,17 +1933,64 @@ fn build_layout(
         .sidebar_width_fraction(RIGHT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
 
+    // Compose the right sidebar with its resize handle on the
+    // leading edge (the boundary with the content area). Dragging
+    // the handle LEFT widens the sidebar; drag-end persists the
+    // new pixel width; double-click resets to the default.
+    let config_right_resize = std::sync::Arc::clone(config);
+    let save_right_width: std::rc::Rc<dyn Fn(u32)> = std::rc::Rc::new(move |px| {
+        sidebar::activity_bar::save_right_width_px(&config_right_resize, px);
+    });
+    let right_handle = build_resize_handle(
+        &right_split_view,
+        ResizeDirection::LeftGrowsSidebar,
+        RIGHT_SIDEBAR_MIN_WIDTH,
+        RIGHT_SIDEBAR_DEFAULT_WIDTH * 2.0,
+        RIGHT_SIDEBAR_DEFAULT_WIDTH,
+        &save_right_width,
+    );
+    let right_sidebar_wrap = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .hexpand(true)
+        .vexpand(true)
+        .build();
+    right_sidebar_wrap.append(&right_handle);
+    right_sidebar_wrap.append(&right_stack);
+    right_split_view.set_sidebar(Some(&right_sidebar_wrap));
+
     // Outer (left) split view — sidebar hosts the left activity
     // stack. Starts open with "general" visible so a fresh launch
     // lands on the General panel instead of an empty frame.
     let left_split_view = adw::OverlaySplitView::builder()
-        .sidebar(&left_stack)
         .content(&right_split_view)
         .show_sidebar(true)
         .min_sidebar_width(LEFT_SIDEBAR_MIN_WIDTH)
         .max_sidebar_width(LEFT_SIDEBAR_DEFAULT_WIDTH * 2.0)
         .sidebar_width_fraction(LEFT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
+
+    // Compose the left sidebar with its resize handle on the
+    // trailing edge. Dragging the handle RIGHT widens the sidebar.
+    let config_left_resize = std::sync::Arc::clone(config);
+    let save_left_width: std::rc::Rc<dyn Fn(u32)> = std::rc::Rc::new(move |px| {
+        sidebar::activity_bar::save_left_width_px(&config_left_resize, px);
+    });
+    let left_handle = build_resize_handle(
+        &left_split_view,
+        ResizeDirection::RightGrowsSidebar,
+        LEFT_SIDEBAR_MIN_WIDTH,
+        LEFT_SIDEBAR_DEFAULT_WIDTH * 2.0,
+        LEFT_SIDEBAR_DEFAULT_WIDTH,
+        &save_left_width,
+    );
+    let left_sidebar_wrap = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .hexpand(true)
+        .vexpand(true)
+        .build();
+    left_sidebar_wrap.append(&left_stack);
+    left_sidebar_wrap.append(&left_handle);
+    left_split_view.set_sidebar(Some(&left_sidebar_wrap));
     left_stack.set_visible_child_name("general");
 
     let left_activity_bar =
@@ -1976,6 +2032,157 @@ fn page_from_group(group: &adw::PreferencesGroup) -> adw::PreferencesPage {
     let page = adw::PreferencesPage::new();
     page.add(group);
     page
+}
+
+/// Apply a saved pixel width to an `AdwOverlaySplitView` sidebar
+/// after the split view has a real allocation. A single
+/// `notify::width` handler fires once the first non-zero width
+/// lands, converts the saved pixels into the `[0, 1]` fraction
+/// the widget accepts, applies it, and then the handler is
+/// effectively inert for the rest of the window's lifetime
+/// (`applied` flag). `None` skips everything — the builder-time
+/// fractional default stands.
+fn apply_saved_sidebar_width(split_view: &adw::OverlaySplitView, saved_px: Option<u32>) {
+    let Some(px) = saved_px else {
+        return;
+    };
+    let applied: std::rc::Rc<std::cell::Cell<bool>> = std::rc::Rc::new(std::cell::Cell::new(false));
+    split_view.connect_notify_local(Some("width"), move |sv, _| {
+        if applied.get() {
+            return;
+        }
+        let sv_w = f64::from(sv.width());
+        if sv_w <= 0.0 {
+            return;
+        }
+        let fraction = (f64::from(px) / sv_w).clamp(0.01, 0.99);
+        sv.set_sidebar_width_fraction(fraction);
+        applied.set(true);
+    });
+}
+
+/// Width of the invisible drag strip at a sidebar's inner edge
+/// (design doc §4.4 calls for "thin (4–6 px)"). 6 px gives the
+/// user a forgiving hit target without stealing pixels from the
+/// panel content.
+const RESIZE_HANDLE_WIDTH_PX: i32 = 6;
+
+/// Which direction of drag grows the sidebar. The LEFT split
+/// view's sidebar sits on the leading edge — dragging the handle
+/// right pushes the sidebar-content boundary right and widens the
+/// sidebar. The RIGHT split view's sidebar sits on the trailing
+/// edge (`sidebar_position=End`) — the handle is on its leading
+/// edge, and dragging LEFT widens the sidebar.
+#[derive(Clone, Copy, Debug)]
+enum ResizeDirection {
+    /// Positive `offset_x` widens the sidebar (left split view).
+    RightGrowsSidebar,
+    /// Negative `offset_x` widens the sidebar (right split view).
+    LeftGrowsSidebar,
+}
+
+/// Build an invisible drag-handle widget sized to
+/// [`RESIZE_HANDLE_WIDTH_PX`] and wire it to resize an
+/// `AdwOverlaySplitView` sidebar. Live-resizes during drag,
+/// persists the final width on drag-end via `save_width_px`,
+/// and resets to `default_px` on a left-button double-click
+/// (standard GTK paned-divider pattern).
+///
+/// `AdwOverlaySplitView` only exposes `sidebar-width-fraction`
+/// (range `[0, 1]`); pixel min/max/default are converted to the
+/// fraction against the split view's live allocation every time
+/// the gesture fires, so the clamp reacts correctly to window
+/// resizes.
+fn build_resize_handle(
+    split_view: &adw::OverlaySplitView,
+    direction: ResizeDirection,
+    min_px: f64,
+    max_px: f64,
+    default_px: f64,
+    save_width_px: &std::rc::Rc<dyn Fn(u32)>,
+) -> gtk4::Box {
+    let handle = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .width_request(RESIZE_HANDLE_WIDTH_PX)
+        .css_classes(["sidebar-resize-handle"])
+        .build();
+    if let Some(cursor) = gtk4::gdk::Cursor::from_name("col-resize", None) {
+        handle.set_cursor(Some(&cursor));
+    }
+
+    // Captured at drag-begin so every `drag-update` computes the
+    // new width from the stable starting fraction rather than
+    // integrating floating-point deltas. Without this the gesture
+    // would drift 1–2 px per drag cycle.
+    let start_fraction: std::rc::Rc<std::cell::Cell<f64>> =
+        std::rc::Rc::new(std::cell::Cell::new(0.0));
+
+    let drag_gesture = gtk4::GestureDrag::new();
+
+    let split_view_begin = split_view.clone();
+    let start_fraction_begin = std::rc::Rc::clone(&start_fraction);
+    drag_gesture.connect_drag_begin(move |_, _, _| {
+        start_fraction_begin.set(split_view_begin.sidebar_width_fraction());
+    });
+
+    let split_view_update = split_view.clone();
+    let start_fraction_update = std::rc::Rc::clone(&start_fraction);
+    drag_gesture.connect_drag_update(move |_, offset_x, _| {
+        let sv_w = f64::from(split_view_update.width());
+        if sv_w <= 0.0 {
+            return;
+        }
+        let start_px = start_fraction_update.get() * sv_w;
+        let signed_offset = match direction {
+            ResizeDirection::RightGrowsSidebar => offset_x,
+            ResizeDirection::LeftGrowsSidebar => -offset_x,
+        };
+        let new_px = (start_px + signed_offset).clamp(min_px, max_px);
+        // Fraction pspec is `[0, 1]`; guard against 0 which the
+        // widget treats as "collapsed" at the animator level.
+        let new_fraction = (new_px / sv_w).clamp(0.01, 0.99);
+        split_view_update.set_sidebar_width_fraction(new_fraction);
+    });
+
+    let split_view_end = split_view.clone();
+    let save_end = std::rc::Rc::clone(save_width_px);
+    drag_gesture.connect_drag_end(move |_, _, _| {
+        let sv_w = f64::from(split_view_end.width());
+        if sv_w <= 0.0 {
+            return;
+        }
+        let final_px = split_view_end.sidebar_width_fraction() * sv_w;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let px = final_px.round().max(0.0) as u32;
+        save_end(px);
+    });
+    handle.add_controller(drag_gesture);
+
+    // Double-click = reset to default width. Matches the GTK paned-
+    // divider convention users expect ("I messed up my drag, take
+    // me back"). A single click does nothing — the drag gesture
+    // already handles press/release.
+    let click_gesture = gtk4::GestureClick::new();
+    click_gesture.set_button(gtk4::gdk::BUTTON_PRIMARY);
+    let split_view_click = split_view.clone();
+    let save_click = std::rc::Rc::clone(save_width_px);
+    click_gesture.connect_released(move |_, n_press, _, _| {
+        if n_press != 2 {
+            return;
+        }
+        let sv_w = f64::from(split_view_click.width());
+        if sv_w <= 0.0 {
+            return;
+        }
+        let fraction = (default_px / sv_w).clamp(0.01, 0.99);
+        split_view_click.set_sidebar_width_fraction(fraction);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let px = default_px.round().max(0.0) as u32;
+        save_click(px);
+    });
+    handle.add_controller(click_gesture);
+
+    handle
 }
 
 /// Build the sidebar toggle button bound to the split view.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -271,8 +271,28 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // `applied` cell flips after the first non-zero width is seen
     // so subsequent width changes (window resize) leave the
     // sidebar's fraction alone.
-    apply_saved_sidebar_width(&left_split_view, session.left_width_px);
-    apply_saved_sidebar_width(&right_split_view, session.right_width_px);
+    //
+    // Fresh sessions (`width_px == None`) route the builder-time
+    // default through the same post-allocation conversion so the
+    // advertised default actually lands: the builder fraction was
+    // derived from `DEFAULT_WIDTH = 1200`, but the right split
+    // view's parent is the left split view's content area (already
+    // narrower by the left sidebar's slice), so the fraction
+    // evaluates against a smaller width and the resulting pixel
+    // value undershoots the target. Routing defaults through
+    // `apply_sidebar_width` with the allocated width fixes that.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    apply_sidebar_width(
+        &left_split_view,
+        session.left_width_px,
+        LEFT_SIDEBAR_DEFAULT_WIDTH as u32,
+    );
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    apply_sidebar_width(
+        &right_split_view,
+        session.right_width_px,
+        RIGHT_SIDEBAR_DEFAULT_WIDTH as u32,
+    );
 
     wire_activity_bar_clicks(
         &left_activity_bar,
@@ -1797,6 +1817,19 @@ const LEFT_SIDEBAR_DEFAULT_WIDTH: f64 = 320.0;
 /// launch.
 const RIGHT_SIDEBAR_DEFAULT_WIDTH: f64 = 420.0;
 
+/// How much wider than its default a sidebar may be dragged. 2× the
+/// default feels natural — "a little bigger" and "a lot bigger"
+/// without letting the panel overrun the spectrum.
+const SIDEBAR_MAX_WIDTH_MULTIPLIER: f64 = 2.0;
+/// Minimum `sidebar-width-fraction` we write. Guards against the
+/// `AdwOverlaySplitView` pspec's rejection of exactly 0 and the
+/// animator's visual collapse at very small values.
+const SIDEBAR_FRACTION_MIN: f64 = 0.01;
+/// Maximum `sidebar-width-fraction` — symmetric sibling of
+/// [`SIDEBAR_FRACTION_MIN`]. Prevents the content area from being
+/// squeezed to zero even if a pixel clamp miscomputes.
+const SIDEBAR_FRACTION_MAX: f64 = 0.99;
+
 /// Handles returned by [`build_layout`] for downstream wiring. Bundled
 /// into a struct rather than a tuple because the return list grew past
 /// the clippy threshold during the activity-bar scaffolding migration.
@@ -1929,7 +1962,7 @@ fn build_layout(
         .content(&content_box)
         .show_sidebar(false)
         .min_sidebar_width(RIGHT_SIDEBAR_MIN_WIDTH)
-        .max_sidebar_width(RIGHT_SIDEBAR_DEFAULT_WIDTH * 2.0)
+        .max_sidebar_width(RIGHT_SIDEBAR_DEFAULT_WIDTH * SIDEBAR_MAX_WIDTH_MULTIPLIER)
         .sidebar_width_fraction(RIGHT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
 
@@ -1945,7 +1978,7 @@ fn build_layout(
         &right_split_view,
         ResizeDirection::LeftGrowsSidebar,
         RIGHT_SIDEBAR_MIN_WIDTH,
-        RIGHT_SIDEBAR_DEFAULT_WIDTH * 2.0,
+        RIGHT_SIDEBAR_DEFAULT_WIDTH * SIDEBAR_MAX_WIDTH_MULTIPLIER,
         RIGHT_SIDEBAR_DEFAULT_WIDTH,
         &save_right_width,
     );
@@ -1965,7 +1998,7 @@ fn build_layout(
         .content(&right_split_view)
         .show_sidebar(true)
         .min_sidebar_width(LEFT_SIDEBAR_MIN_WIDTH)
-        .max_sidebar_width(LEFT_SIDEBAR_DEFAULT_WIDTH * 2.0)
+        .max_sidebar_width(LEFT_SIDEBAR_DEFAULT_WIDTH * SIDEBAR_MAX_WIDTH_MULTIPLIER)
         .sidebar_width_fraction(LEFT_SIDEBAR_DEFAULT_WIDTH / f64::from(DEFAULT_WIDTH))
         .build();
 
@@ -1979,7 +2012,7 @@ fn build_layout(
         &left_split_view,
         ResizeDirection::RightGrowsSidebar,
         LEFT_SIDEBAR_MIN_WIDTH,
-        LEFT_SIDEBAR_DEFAULT_WIDTH * 2.0,
+        LEFT_SIDEBAR_DEFAULT_WIDTH * SIDEBAR_MAX_WIDTH_MULTIPLIER,
         LEFT_SIDEBAR_DEFAULT_WIDTH,
         &save_left_width,
     );
@@ -2034,18 +2067,23 @@ fn page_from_group(group: &adw::PreferencesGroup) -> adw::PreferencesPage {
     page
 }
 
-/// Apply a saved pixel width to an `AdwOverlaySplitView` sidebar
-/// after the split view has a real allocation. A single
-/// `notify::width` handler fires once the first non-zero width
-/// lands, converts the saved pixels into the `[0, 1]` fraction
-/// the widget accepts, applies it, and then the handler is
-/// effectively inert for the rest of the window's lifetime
-/// (`applied` flag). `None` skips everything — the builder-time
-/// fractional default stands.
-fn apply_saved_sidebar_width(split_view: &adw::OverlaySplitView, saved_px: Option<u32>) {
-    let Some(px) = saved_px else {
-        return;
-    };
+/// Apply a pixel width to an `AdwOverlaySplitView` sidebar after
+/// the split view has a real allocation. A single `notify::width`
+/// handler fires once the first non-zero width lands, converts
+/// the target pixels into the `[0, 1]` fraction the widget
+/// accepts, applies it, and then disarms (`applied` flag) so
+/// subsequent width notifications (window resize) leave the
+/// sidebar's fractional preference alone.
+///
+/// `saved_px == Some(px)` uses the persisted value; `None` falls
+/// back to `default_px`. Both cases go through the same
+/// post-allocation conversion so the advertised pixel default
+/// actually lands — builder-time fractions are derived from
+/// `DEFAULT_WIDTH` and evaluate against the split view's
+/// narrower-than-window allocation, so without this the fresh-
+/// session defaults under-shoot their targets.
+fn apply_sidebar_width(split_view: &adw::OverlaySplitView, saved_px: Option<u32>, default_px: u32) {
+    let target_px = saved_px.unwrap_or(default_px);
     let applied: std::rc::Rc<std::cell::Cell<bool>> = std::rc::Rc::new(std::cell::Cell::new(false));
     split_view.connect_notify_local(Some("width"), move |sv, _| {
         if applied.get() {
@@ -2055,7 +2093,8 @@ fn apply_saved_sidebar_width(split_view: &adw::OverlaySplitView, saved_px: Optio
         if sv_w <= 0.0 {
             return;
         }
-        let fraction = (f64::from(px) / sv_w).clamp(0.01, 0.99);
+        let fraction =
+            (f64::from(target_px) / sv_w).clamp(SIDEBAR_FRACTION_MIN, SIDEBAR_FRACTION_MAX);
         sv.set_sidebar_width_fraction(fraction);
         applied.set(true);
     });
@@ -2117,18 +2156,31 @@ fn build_resize_handle(
     let start_fraction: std::rc::Rc<std::cell::Cell<f64>> =
         std::rc::Rc::new(std::cell::Cell::new(0.0));
 
+    // Gesture closures capture `split_view` via `WeakRef` to
+    // break an otherwise-real retain cycle: `split_view` owns
+    // `sidebar`, `sidebar` owns `handle`, `handle` owns the
+    // gesture controllers, the controllers own their closures,
+    // and a strong `split_view.clone()` inside the closures would
+    // close the loop and leak the whole sidebar subtree on window
+    // teardown. Matches the `glib::WeakRef` idiom used elsewhere
+    // in this file (scanner force-disable, RTL-TCP handlers).
     let drag_gesture = gtk4::GestureDrag::new();
 
-    let split_view_begin = split_view.clone();
+    let split_view_weak = split_view.downgrade();
     let start_fraction_begin = std::rc::Rc::clone(&start_fraction);
     drag_gesture.connect_drag_begin(move |_, _, _| {
-        start_fraction_begin.set(split_view_begin.sidebar_width_fraction());
+        if let Some(sv) = split_view_weak.upgrade() {
+            start_fraction_begin.set(sv.sidebar_width_fraction());
+        }
     });
 
-    let split_view_update = split_view.clone();
+    let split_view_weak = split_view.downgrade();
     let start_fraction_update = std::rc::Rc::clone(&start_fraction);
     drag_gesture.connect_drag_update(move |_, offset_x, _| {
-        let sv_w = f64::from(split_view_update.width());
+        let Some(sv) = split_view_weak.upgrade() else {
+            return;
+        };
+        let sv_w = f64::from(sv.width());
         if sv_w <= 0.0 {
             return;
         }
@@ -2140,18 +2192,21 @@ fn build_resize_handle(
         let new_px = (start_px + signed_offset).clamp(min_px, max_px);
         // Fraction pspec is `[0, 1]`; guard against 0 which the
         // widget treats as "collapsed" at the animator level.
-        let new_fraction = (new_px / sv_w).clamp(0.01, 0.99);
-        split_view_update.set_sidebar_width_fraction(new_fraction);
+        let new_fraction = (new_px / sv_w).clamp(SIDEBAR_FRACTION_MIN, SIDEBAR_FRACTION_MAX);
+        sv.set_sidebar_width_fraction(new_fraction);
     });
 
-    let split_view_end = split_view.clone();
+    let split_view_weak = split_view.downgrade();
     let save_end = std::rc::Rc::clone(save_width_px);
     drag_gesture.connect_drag_end(move |_, _, _| {
-        let sv_w = f64::from(split_view_end.width());
+        let Some(sv) = split_view_weak.upgrade() else {
+            return;
+        };
+        let sv_w = f64::from(sv.width());
         if sv_w <= 0.0 {
             return;
         }
-        let final_px = split_view_end.sidebar_width_fraction() * sv_w;
+        let final_px = sv.sidebar_width_fraction() * sv_w;
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let px = final_px.round().max(0.0) as u32;
         save_end(px);
@@ -2164,18 +2219,21 @@ fn build_resize_handle(
     // already handles press/release.
     let click_gesture = gtk4::GestureClick::new();
     click_gesture.set_button(gtk4::gdk::BUTTON_PRIMARY);
-    let split_view_click = split_view.clone();
+    let split_view_weak = split_view.downgrade();
     let save_click = std::rc::Rc::clone(save_width_px);
     click_gesture.connect_released(move |_, n_press, _, _| {
         if n_press != 2 {
             return;
         }
-        let sv_w = f64::from(split_view_click.width());
+        let Some(sv) = split_view_weak.upgrade() else {
+            return;
+        };
+        let sv_w = f64::from(sv.width());
         if sv_w <= 0.0 {
             return;
         }
-        let fraction = (default_px / sv_w).clamp(0.01, 0.99);
-        split_view_click.set_sidebar_width_fraction(fraction);
+        let fraction = (default_px / sv_w).clamp(SIDEBAR_FRACTION_MIN, SIDEBAR_FRACTION_MAX);
+        sv.set_sidebar_width_fraction(fraction);
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let px = default_px.round().max(0.0) as u32;
         save_click(px);


### PR DESCRIPTION
Closes #429. Sub-ticket 9/10 of epic #420.

## Summary

Adds user-draggable resize handles on both sidebar inner edges with live-resize during drag, width-on-drag-end persistence, double-click-to-reset, and `col-resize` cursor on hover. Matches the design doc §2.4 spec to the letter.

## The "built-in divider?" decision (#421 deferred this)

`AdwOverlaySplitView` in libadwaita 1.9 doesn't ship a user-draggable divider. Its user-facing knobs are `show-sidebar` (bool) and `sidebar-width-fraction` (programmatic, `[0, 1]`). The `enable-hide-gesture` / `enable-show-gesture` properties are swipe-on-narrow (mobile-style), not edge-drag-to-resize. So this PR takes the "custom `GtkGestureDrag` on a thin invisible region" fallback the issue explicitly names.

## Layout + cursor

- Each sidebar is now wrapped in a `GtkBox` holding `[stack, handle]` (left) or `[handle, stack]` (right, `sidebar_position=End`).
- Handle = 6 px `GtkBox` with the new `.sidebar-resize-handle` CSS class.
- Cursor = `col-resize` on hover via `set_cursor`.
- Hover tints with a subtle accent wash so the affordance is discoverable without drawing a visible stripe at rest — matches the restrained visual treatment of the activity bar.

## Gesture wiring (`build_resize_handle` helper)

- `GtkGestureDrag`:
  - `drag-begin` captures the start fraction (prevents the floating-point drift that integrating per-update deltas would cause).
  - `drag-update` computes `new_px = start_px ± offset_x` (sign flips for the right handle, whose drag-left widens), clamps to `[min_px, max_px]`, converts to fraction via the split view's live allocation, and calls `set_sidebar_width_fraction`. Fraction is bounded `[0.01, 0.99]` as a safety rail against the pspec.
  - `drag-end` writes the final pixel width to config.
- `GtkGestureClick` (primary button, 2 presses) resets to the panel's default width + persists.

## Persistence

- New keys on `SidebarSession`: `ui_sidebar_left_width_px` / `ui_sidebar_right_width_px` (both `u32`). Stored as pixels per the issue's user-facing contract; applied as fractions at load because that's the only knob `AdwOverlaySplitView` exposes.
- `save_left_width_px` / `save_right_width_px` helpers in `sidebar::activity_bar`.
- Load path: `SidebarSession.{left,right}_width_px: Option<u32>`, `None` on fresh install.
- `apply_saved_sidebar_width(split_view, saved_px)` wires a one-shot `notify::width` handler that fires once the first non-zero allocation lands, converts `px / allocated_w` → fraction, applies it, and disarms (`Rc<Cell<bool>>` flag) so subsequent window resizes leave the user's fractional preference alone.

## Clamps

- Left: min 220 px, max 640 px (2× default).
- Right: min 360 px, max 840 px (2× default, leaves the transcript panel breathing room per #424).
- Defaults: 320 px left / 420 px right (unchanged from earlier work).

## Tests

2 new cases in `sidebar::activity_bar::tests`:

- `session_missing_widths_resolve_to_none` — fresh install or pre-#429 config has no width keys → `None`, builder-time fractional default stands.
- `session_malformed_widths_resolve_to_none` — hand-edited or corrupted values (wrong JSON type, `u64` overflow) → `None`, no crash.

Existing `session_round_trips_full_state` extended to save + load both width fields. Total session tests: 7. All green.

## Smoke

- [x] Hover inner edge of left panel → cursor turns to `col-resize`, strip tints.
- [x] Drag right → panel widens live, spectrum narrows.
- [x] Drag past max (640 px) / below min (220 px) → clamps.
- [x] Release → config persists.
- [x] Double-click → snaps back to default, persists.
- [x] Same for right panel (mirror-image).
- [x] Relaunch → both panels restore their saved widths via the one-shot post-realize callback.
- [x] Window resize after load → panels keep their fractional share, don't re-snap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar panels are now resizable with an interactive drag handle; widths persist across sessions and are restored on load
  * Double-click the resize handle to reset a panel to its default width

* **Style**
  * Resize handle is transparent by default and shows a subtle tint on hover
<!-- end of auto-generated comment: release notes by coderabbit.ai -->