### PR TITLE
docs: sidebar architecture + activity-bar contributor guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,32 @@ make lint                        # All of the above + cargo deny + cargo audit
 - All crates use `[lints] workspace = true`
 - `unsafe_code` is denied workspace-wide
 
+### Sidebar architecture
+
+The GTK4 UI uses a VS Code-style activity-bar pattern (epic #420): a narrow icon strip on each window edge switches a `GtkStack` of panels between "activities". Left bar hosts General / Radio / Audio / Display / Scanner / Share; right bar hosts Transcript / Bookmarks. See `docs/design/sidebar-activity-bar-redesign.md` for the full rationale.
+
+**Key files:**
+
+- `crates/sdr-ui/src/sidebar/activity_bar.rs` — the `ActivityBarEntry` struct, the canonical `LEFT_ACTIVITIES` / `RIGHT_ACTIVITIES` slices (single source of truth for icon + shortcut + display name + config-persistence name), `build_activity_bar` widget builder, and `SidebarSession` persistence.
+- `crates/sdr-ui/src/window.rs::build_layout` — nests two `AdwOverlaySplitView`s inside a horizontal `GtkBox` alongside the two activity bars.
+- `crates/sdr-ui/src/window.rs::wire_activity_bar_clicks` — the click-handler semantics: different-button swaps stack + opens panel; same-button toggles panel while keeping the icon selected.
+- `crates/sdr-ui/src/window.rs::build_resize_handle` — custom `GtkGestureDrag` on an invisible 6 px strip at each panel's inner edge, because `AdwOverlaySplitView` has no built-in draggable divider in libadwaita 1.9.
+
+**Adding a new activity:**
+
+1. Append an `ActivityBarEntry` to `LEFT_ACTIVITIES` or `RIGHT_ACTIVITIES` in `activity_bar.rs`. Keep existing entries' order + names stable — they're config keys. Shortcut accelerator uses `<Ctrl>N` / `<Ctrl><Shift>N` per side.
+2. In `window.rs::build_layout`, add a stack child under the new name: `left_stack.add_named(&panel_widget, Some("your-name"))` (or `right_stack`).
+3. Keyboard shortcut registration and help-dialog rows auto-derive from the slice — no wiring changes needed.
+4. If the activity hosts a new panel with its own DSP controls, add a `connect_your_panel(panels, state)` call in `connect_sidebar_panels` matching the pattern of existing panels.
+
+**Panel layout convention:**
+
+Every activity panel is an `AdwPreferencesPage` of flat `AdwPreferencesGroup`s with `title` + short plain-English `description`. We deliberately avoid `AdwExpanderRow` — the expander-row inset stacked on top of the group's own inset read cluttered (verified across General / Radio / Audio / Display / Scanner). "Expanded by default, collapsible" became "always visible, scrollable" and the app looks cleaner for it.
+
+**Session persistence:**
+
+Four config keys per side live in `activity_bar.rs`: `ui_sidebar_{left,right}_{selected,open,width_px}`. Load at launch via `load_session(config)`, apply before wiring handlers (seed-then-wire prevents the initial `set_active` / `set_show_sidebar` calls from writing back). On change, persist via `save_*` helpers. Pixel widths are converted to `AdwOverlaySplitView`'s `[0, 1]` fraction via `apply_sidebar_width`'s one-shot `notify::width` handler once the split view has its first real allocation.
+
 ## C++ Reference
 
 Original SDR++ source is in `original/SDRPlusPlus/` (gitignored).

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -23,6 +23,56 @@
 //! screen readers, so it cannot substitute. This mirrors the idiom
 //! used by other icon-only controls in this crate (bookmarks toggle,
 //! pinned-servers menu, etc.).
+//!
+//! # Example — adding a new activity
+//!
+//! The canonical `LEFT_ACTIVITIES` / `RIGHT_ACTIVITIES` slices drive
+//! the entire activity-bar surface: the widget itself, keyboard
+//! shortcut registration, help-dialog Navigation rows, and config
+//! persistence. Adding an activity is almost entirely a data edit.
+//!
+//! To add (say) a "Recordings" activity on the right side:
+//!
+//! ```ignore
+//! // 1. In this file, append to RIGHT_ACTIVITIES:
+//! pub const RIGHT_ACTIVITIES: &[ActivityBarEntry] = &[
+//!     ActivityBarEntry {
+//!         name: "transcript", // existing
+//!         // ...
+//!     },
+//!     ActivityBarEntry {
+//!         name: "bookmarks", // existing
+//!         // ...
+//!     },
+//!     ActivityBarEntry {
+//!         name: "recordings",
+//!         icon_name: "media-record-symbolic",
+//!         display_name: "Recordings",
+//!         shortcut_label: "Ctrl+Shift+3",
+//!         accelerator: "<Ctrl><Shift>3",
+//!     },
+//! ];
+//!
+//! // 2. In window.rs::build_layout, add the stack child under the
+//! //    new `name`. The panel widget should be an
+//! //    `AdwPreferencesPage` for chrome consistency; use flat
+//! //    `AdwPreferencesGroup`s with title + description for each
+//! //    section (no `AdwExpanderRow`).
+//! right_stack.add_named(&recordings_panel.widget, Some("recordings"));
+//! ```
+//!
+//! That's it for the bar. `Ctrl+Shift+3` registration, the
+//! help-dialog row, activity-bar click-handler state machine, and
+//! session persistence (`ui_sidebar_right_selected`) all derive from
+//! the entry automatically. Keep existing entries' `name` strings
+//! stable — they're config keys.
+//!
+//! If the new activity hosts DSP-connected controls, add a
+//! `connect_recordings_panel(panels, state)` call in
+//! `connect_sidebar_panels` following the existing panel patterns.
+//! See `CLAUDE.md` → "Sidebar architecture" for the broader
+//! contributor guide and `docs/design/sidebar-activity-bar-redesign.md`
+//! for the design rationale.
 
 use std::collections::HashMap;
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -278,7 +278,7 @@ The `sdr-rtlsdr` crate replaces C `librtlsdr` entirely. Uses `rusb` for USB comm
 | FFT plot (ImGui drawlist) | `GtkGLArea` shared with waterfall |
 | VFO overlay rectangles | Custom drawing on GL area overlay |
 | Frequency selector digits | Custom `GtkWidget` subclass with scroll-per-digit |
-| Side menu accordion | `AdwPreferencesGroup` in `AdwFlap` sidebar |
+| Side menu accordion | Activity-bar pattern — nested `AdwOverlaySplitView`s switching `GtkStack` panels by icon click (see `CLAUDE.md` → "Sidebar architecture") |
 | Source/sink combo | `AdwComboRow` |
 | Gain slider | `GtkScale` or `AdwSpinRow` |
 | Play/Stop button | `GtkToggleButton` with media icons |


### PR DESCRIPTION
Closes #430. **Final sub-ticket of epic #420** 🎉

## Summary

Documents the activity-bar pattern for future contributors so the next person adding a sidebar panel doesn't have to reverse-engineer it from `window.rs`.

## Three touches

### `CLAUDE.md` — new "Sidebar architecture" H3 section

Under Key Conventions. Covers:

- The layout (activity bars + nested `AdwOverlaySplitView`s + `GtkStack`).
- Key file locations: `activity_bar.rs`, `window.rs::build_layout`, `wire_activity_bar_clicks`, `build_resize_handle`.
- **How to add a new activity** (data edit + one `stack.add_named` call).
- **Panel layout convention**: flat `AdwPreferencesGroup` with `title` + short plain-English `description`, no `AdwExpanderRow`, and the rationale (expander + group inset stacked to a cluttered double-indent).
- **Session persistence**: the four config keys per side, the seed-then-wire pattern, and the one-shot `notify::width` post-allocation conversion for pixel-stored widths.

Cross-links the design doc.

### `docs/PROJECT.md` — stale row updated

The widget-mapping table had one stale entry:

> Side menu accordion | `AdwPreferencesGroup` in `AdwFlap` sidebar

Updated to describe the activity-bar pattern and point at the CLAUDE.md guide.

### `activity_bar.rs` — module rustdoc example

New "Example — adding a new activity" section with a Recordings-on-the-right hypothetical. Shows the minimal surface area: one `ActivityBarEntry` edit in `RIGHT_ACTIVITIES`, one `stack.add_named` call in `build_layout`. Shortcut registration, help-dialog rows, click-handler state machine, and session persistence all derive automatically.

## Scope reductions from the original issue body

- **No `AdwExpanderRow` guidance** — we dropped expanders entirely in favor of flat `AdwPreferencesGroup` sections (per user preference, across #422–#426 panel migrations). The CLAUDE.md convention reflects the shipped reality.
- **No `ui.sidebar.<side>.expanded.<panel>.<section>` keys** — moot for the same reason: no expanders = nothing collapsible to persist. Documented config keys are the four pairs that actually exist: `{left,right}_{selected,open,width_px}`.

## Test plan

- [x] `cargo doc --workspace --no-deps` builds clean — pre-existing `redundant_explicit_links` warnings in `bookmarks_panel` are unchanged by this PR.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `CLAUDE.md` renders the new H3 section correctly as Markdown.
- [x] Rustdoc module page for `sidebar::activity_bar` shows the new "Example — adding a new activity" block with the code snippet fenced as `ignore` (it references types that exist, so users can adapt it; but it intentionally isn't a compiled doctest because the example spans multiple files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation of the activity-bar sidebar design pattern, covering implementation approach, procedures for extending with new activity options, session persistence mechanisms, and configuration guidelines.
  * Updated project architecture documentation to reflect the redesigned activity-bar sidebar with icon-driven panel navigation and automatic session state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->