### PR TITLE
sdr-dsp: CPU baseline benchmark harness for GPU-accel epic #452

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "annotate-snippets"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +73,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -160,6 +166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +213,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +249,31 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -283,6 +347,46 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dbus"
@@ -800,6 +904,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +925,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hound"
@@ -1052,6 +1173,26 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1467,6 +1608,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pango"
@@ -1941,6 +2088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2168,7 @@ dependencies = [
 name = "sdr-dsp"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "rustfft",
  "sdr-types",
  "serde",
@@ -2592,6 +2749,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +3053,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,6 +3217,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,6 +249,13 @@ gtk4 = { version = "0.11", features = ["v4_10"] }
 libadwaita = { version = "0.9", features = ["v1_5"] }
 cairo-rs = { version = "0.22", features = ["png"] }
 
+# Benchmarking. `default-features = false` drops the `rayon`-backed
+# HTML reporting; we only need the `cargo bench` harness support, which
+# `cargo_bench_support` turns on. Keeping the pin workspace-wide so the
+# GPU-acceleration sub-tickets (#179-#182) pick up the same version as
+# the CPU baseline harness in sdr-dsp.
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
 [workspace.lints.rust]
 unsafe_code = "deny"
 

--- a/crates/sdr-dsp/Cargo.toml
+++ b/crates/sdr-dsp/Cargo.toml
@@ -14,6 +14,33 @@ thiserror.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+# Benchmark harness for the GPU-acceleration epic (#452).
+# Phase-1 baseline suite measures the CPU implementations of FFT,
+# FIR filtering, waterfall colormap lookup, and energy detection so
+# every subsequent GPU sub-ticket has a fixed comparison surface.
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 
 [lints]
 workspace = true
+
+# ─── Benchmarks (epic #452 phase 1) ──────────────────────────
+# `harness = false` tells cargo to skip the default libtest harness
+# so Criterion's own entrypoint (`criterion_group!` + `criterion_main!`)
+# takes over. Missing this is the usual "why does `cargo bench` do
+# nothing useful" trap.
+
+[[bench]]
+name = "fft"
+harness = false
+
+[[bench]]
+name = "fir"
+harness = false
+
+[[bench]]
+name = "colormap"
+harness = false
+
+[[bench]]
+name = "detection"
+harness = false

--- a/crates/sdr-dsp/Cargo.toml
+++ b/crates/sdr-dsp/Cargo.toml
@@ -18,7 +18,7 @@ serde_json.workspace = true
 # Phase-1 baseline suite measures the CPU implementations of FFT,
 # FIR filtering, waterfall colormap lookup, and energy detection so
 # every subsequent GPU sub-ticket has a fixed comparison surface.
-criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+criterion.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdr-dsp/benches/colormap.rs
+++ b/crates/sdr-dsp/benches/colormap.rs
@@ -16,6 +16,8 @@
 //! allocated once outside the closure; only the normalize +
 //! lookup + write loop runs inside.
 
+use std::hint::black_box;
+
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 
 /// Typical waterfall width at high FFT resolution — matches
@@ -115,9 +117,13 @@ fn bench_colormap(c: &mut Criterion) {
     group.bench_function(format!("bins={BINS}"), |b| {
         let mut output = vec![[0_u8; 4]; BINS];
         b.iter_batched(
-            || db_line.clone(),
+            // `black_box` on setup + after the lookup forces LLVM
+            // to treat the RGBA write-back as observable, so the
+            // clamp-normalize-index-write chain can't be elided.
+            || black_box(db_line.clone()),
             |line| {
                 apply_colormap(&line, &palette, &mut output);
+                black_box(&output);
             },
             BatchSize::SmallInput,
         );

--- a/crates/sdr-dsp/benches/colormap.rs
+++ b/crates/sdr-dsp/benches/colormap.rs
@@ -33,6 +33,21 @@ const PALETTE_ENTRIES: usize = 256;
 const DB_FLOOR: f32 = -70.0;
 const DB_CEILING: f32 = 0.0;
 
+/// Max channel byte value (fully-lit red / fully-opaque alpha).
+const PALETTE_CHANNEL_MAX: u8 = 255;
+/// Divisor applied to the blue channel so the synthetic ramp
+/// produces three non-identical colour curves (otherwise the
+/// compiler could theoretically fold the `[u8; 4]` build down).
+const PALETTE_BLUE_DIVISOR: u8 = 2;
+
+/// Low end of the synthetic dB sweep — below `DB_FLOOR` so the
+/// clamp's saturate-low branch actually fires on some bins.
+const SWEEP_DB_FLOOR: f32 = -90.0;
+/// Span of the sweep. Paired with `SWEEP_DB_FLOOR = -90.0` this
+/// takes the ramp up to +5 dB, above `DB_CEILING = 0.0`, so the
+/// saturate-high branch also fires.
+const SWEEP_DB_RANGE: f32 = 95.0;
+
 /// Build a synthetic 256-entry palette. The real picker uses
 /// Turbo / Viridis / Plasma / Inferno; the lookup cost is
 /// identical regardless of the palette's colour ramp, so a
@@ -43,7 +58,12 @@ fn synthetic_palette() -> Vec<[u8; 4]> {
         .map(|i| {
             #[allow(clippy::cast_possible_truncation)]
             let byte = i as u8;
-            [byte, 255 - byte, byte / 2, 255]
+            [
+                byte,
+                PALETTE_CHANNEL_MAX - byte,
+                byte / PALETTE_BLUE_DIVISOR,
+                PALETTE_CHANNEL_MAX,
+            ]
         })
         .collect()
 }
@@ -57,10 +77,11 @@ fn synthetic_db_line(bins: usize) -> Vec<f32> {
         .map(|i| {
             #[allow(clippy::cast_precision_loss)]
             let x = i as f32 / bins as f32;
-            // Sweep from -90 to +5 dB linearly — covers the
-            // saturate-low and saturate-high branches of the
+            // Sweep from `SWEEP_DB_FLOOR` to
+            // `SWEEP_DB_FLOOR + SWEEP_DB_RANGE` linearly — covers
+            // the saturate-low and saturate-high branches of the
             // clamp plus the linear-interior hot path.
-            -90.0 + x * 95.0
+            SWEEP_DB_FLOOR + x * SWEEP_DB_RANGE
         })
         .collect()
 }

--- a/crates/sdr-dsp/benches/colormap.rs
+++ b/crates/sdr-dsp/benches/colormap.rs
@@ -1,0 +1,108 @@
+//! Baseline waterfall colormap throughput — the CPU path
+//! equivalent of "normalize a dB line to 0..1 and look up the
+//! palette" that runs once per FFT frame (epic #452 phase 1 /
+//! #180 phase 3a).
+//!
+//! **Scope caveat.** The production colormap lives in
+//! `crates/sdr-ui/src/spectrum/colormap.rs` (not in `sdr-dsp`)
+//! because it's a render-side concern. Duplicating the 256-entry
+//! palette generation + lookup here inline keeps the baseline
+//! self-contained without pulling `sdr-ui` into `sdr-dsp`'s dev
+//! graph. The GPU phase (#180) compares against a CPU path with
+//! the same shape, not against this exact code — the measurement
+//! surface is "one f32 → one [u8; 4] per bin".
+//!
+//! **Measurement discipline.** Palette + input dB vector
+//! allocated once outside the closure; only the normalize +
+//! lookup + write loop runs inside.
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+
+/// Typical waterfall width at high FFT resolution — matches
+/// the #180 spec's 65536-bin case.
+const BINS: usize = 65_536;
+
+/// Palette resolution — 256 entries is the standard 1-D texture
+/// size every colormap picker in the app uses.
+const PALETTE_ENTRIES: usize = 256;
+
+/// dB range the picker normalizes into. Matches the
+/// `min_db`/`max_db` clamp the spectrum view ships with today
+/// (`display_panel.rs` → `DEFAULT_MIN_DB = -70.0`,
+/// `DEFAULT_MAX_DB = 0.0`).
+const DB_FLOOR: f32 = -70.0;
+const DB_CEILING: f32 = 0.0;
+
+/// Build a synthetic 256-entry palette. The real picker uses
+/// Turbo / Viridis / Plasma / Inferno; the lookup cost is
+/// identical regardless of the palette's colour ramp, so a
+/// synthetic gradient keeps the benchmark independent of the
+/// `sdr-ui` crate.
+fn synthetic_palette() -> Vec<[u8; 4]> {
+    (0..PALETTE_ENTRIES)
+        .map(|i| {
+            #[allow(clippy::cast_possible_truncation)]
+            let byte = i as u8;
+            [byte, 255 - byte, byte / 2, 255]
+        })
+        .collect()
+}
+
+/// Fill a vector with a plausible FFT power-in-dB line. Real
+/// input has more structure (carrier + noise floor); this
+/// produces equivalent per-bin work without depending on the
+/// FFT path.
+fn synthetic_db_line(bins: usize) -> Vec<f32> {
+    (0..bins)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let x = i as f32 / bins as f32;
+            // Sweep from -90 to +5 dB linearly — covers the
+            // saturate-low and saturate-high branches of the
+            // clamp plus the linear-interior hot path.
+            -90.0 + x * 95.0
+        })
+        .collect()
+}
+
+/// The actual hot path: for each bin, clamp into
+/// `[DB_FLOOR, DB_CEILING]`, normalize to `[0, 1]`, index the
+/// palette, write the RGBA pixel. Mirrors the CPU code in
+/// `sdr-ui::spectrum::waterfall::push_line` closely enough that
+/// the GPU ticket has a fair comparison surface.
+#[inline]
+fn apply_colormap(db_line: &[f32], palette: &[[u8; 4]], out: &mut [[u8; 4]]) {
+    debug_assert_eq!(db_line.len(), out.len());
+    let range = DB_CEILING - DB_FLOOR;
+    #[allow(clippy::cast_precision_loss)]
+    let scale = (palette.len() - 1) as f32;
+    for (src, dst) in db_line.iter().zip(out.iter_mut()) {
+        let clamped = src.clamp(DB_FLOOR, DB_CEILING);
+        let norm = (clamped - DB_FLOOR) / range;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let idx = (norm * scale).round() as usize;
+        *dst = palette[idx.min(palette.len() - 1)];
+    }
+}
+
+fn bench_colormap(c: &mut Criterion) {
+    let palette = synthetic_palette();
+    let db_line = synthetic_db_line(BINS);
+
+    let mut group = c.benchmark_group("colormap_lookup_cpu");
+    group.throughput(Throughput::Elements(BINS as u64));
+    group.bench_function(format!("bins={BINS}"), |b| {
+        let mut output = vec![[0_u8; 4]; BINS];
+        b.iter_batched(
+            || db_line.clone(),
+            |line| {
+                apply_colormap(&line, &palette, &mut output);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_colormap);
+criterion_main!(benches);

--- a/crates/sdr-dsp/benches/detection.rs
+++ b/crates/sdr-dsp/benches/detection.rs
@@ -1,0 +1,108 @@
+//! Baseline energy-detection throughput — sweep a full FFT
+//! spectrum looking for bins whose power clears the noise-floor
+//! threshold (epic #452 phase 1 / #182 phase 3b).
+//!
+//! **Why this shape.** #182's "automatic signal identification,
+//! band activity monitoring, smart squelch" features all start
+//! from a fundamental building block: "given N dB bins, return
+//! the set of bins whose power exceeds a relative threshold above
+//! the estimated noise floor." That's the operation this bench
+//! measures. Everything fancier (feature extraction, pattern
+//! matching) is downstream of it.
+//!
+//! **Algorithm.** Two passes in one call:
+//!
+//! 1. Estimate noise floor as the median-ish of the bottom
+//!    quartile (cheap approximation — real impls use more
+//!    sophisticated estimators but the per-bin cost is
+//!    similar).
+//! 2. Scan every bin; count bins exceeding `floor + threshold_db`.
+//!
+//! The scan's output is a count rather than a `Vec<usize>` of
+//! hit indices because allocating a vec inside a tight loop
+//! defeats the "measure pure compute" discipline. A real impl
+//! would write hits into a pre-allocated output buffer — the
+//! GPU path will need one too.
+//!
+//! **Measurement discipline.** Input vec + output scratch
+//! allocated once outside the closure; the hot path is purely
+//! compute + one bool-ish write per bin.
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+
+const BINS: usize = 65_536;
+
+/// How many dB above the noise floor a bin must sit before it
+/// counts as a detection. Picked to match a realistic "busy
+/// channel" SNR threshold — this number only affects how many
+/// hits the bench reports, not the cost per bin.
+const THRESHOLD_DB: f32 = 10.0;
+
+/// Fraction of bins used to estimate the noise floor. Bottom
+/// 25 % is a common heuristic — quiet enough to be noise-only
+/// on a sparsely-occupied spectrum, big enough to smooth out
+/// single-bin glitches.
+const NOISE_FLOOR_QUANTILE_BINS: usize = BINS / 4;
+
+fn synthetic_db_line(bins: usize) -> Vec<f32> {
+    // Noise floor around -80 dB + a few narrow-band "signals"
+    // punched in at known offsets. Gives the bench a
+    // realistic mix of detection hits + non-hits so branch
+    // predictors see a realistic hit-rate (~1 %).
+    let mut v = vec![-80.0_f32; bins];
+    for (i, x) in v.iter_mut().enumerate() {
+        #[allow(clippy::cast_precision_loss)]
+        let t = i as f32;
+        // Broadband noise variance.
+        *x += (t * 0.05).sin() * 3.0;
+        // Sparse "signals" every ~100 bins.
+        if i % 100 == 0 {
+            *x = -40.0;
+        }
+    }
+    v
+}
+
+/// Cheap quartile-based noise-floor estimator.
+///
+/// Sorts a working copy of the bin powers — O(n log n) on the
+/// full spectrum. A streaming / running-min-quantile impl would
+/// be faster in steady state; this bench measures the fair
+/// worst-case starting point so the GPU ticket sees the
+/// generous comparison surface.
+fn estimate_noise_floor(db_line: &[f32], scratch: &mut Vec<f32>) -> f32 {
+    scratch.clear();
+    scratch.extend_from_slice(db_line);
+    scratch.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    scratch[NOISE_FLOOR_QUANTILE_BINS / 2]
+}
+
+/// Count bins exceeding `floor + THRESHOLD_DB`. Output is just
+/// the count — see module doc for why.
+#[inline]
+fn count_detections(db_line: &[f32], floor: f32) -> usize {
+    let cutoff = floor + THRESHOLD_DB;
+    db_line.iter().filter(|&&x| x > cutoff).count()
+}
+
+fn bench_energy_detect(c: &mut Criterion) {
+    let db_line = synthetic_db_line(BINS);
+    let mut sort_scratch = Vec::with_capacity(BINS);
+
+    let mut group = c.benchmark_group("energy_detect_cpu");
+    group.throughput(Throughput::Elements(BINS as u64));
+    group.bench_function(format!("bins={BINS}"), |b| {
+        b.iter_batched(
+            || db_line.clone(),
+            |line| {
+                let floor = estimate_noise_floor(&line, &mut sort_scratch);
+                let _hits = count_detections(&line, floor);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_energy_detect);
+criterion_main!(benches);

--- a/crates/sdr-dsp/benches/detection.rs
+++ b/crates/sdr-dsp/benches/detection.rs
@@ -44,20 +44,42 @@ const THRESHOLD_DB: f32 = 10.0;
 /// single-bin glitches.
 const NOISE_FLOOR_QUANTILE_BINS: usize = BINS / 4;
 
+/// Base noise floor of the synthetic fixture, in dB. Sets where
+/// the estimator should land so the detection threshold has a
+/// sensible reference point.
+const SYNTH_BASE_NOISE_DB: f32 = -80.0;
+/// Radians-per-bin phase advance of the synthetic noise wobble.
+/// Bench cost is data-independent so the exact value only has to
+/// produce a varying (not constant) offset so the compiler can't
+/// fold the add.
+const SYNTH_WOBBLE_STEP_RAD: f32 = 0.05;
+/// Peak dB amplitude of the synthetic noise wobble on top of
+/// `SYNTH_BASE_NOISE_DB`.
+const SYNTH_WOBBLE_AMPLITUDE_DB: f32 = 3.0;
+/// Spacing between the synthetic "signals" punched into the
+/// noise line. 100-bin spacing on a 65 536-bin line gives ~1 %
+/// detection hit rate — matches a moderately busy spectrum and
+/// keeps the branch predictor honest.
+const SYNTH_SIGNAL_EVERY_BINS: usize = 100;
+/// dB level of the synthetic "signals". Picked well above
+/// `SYNTH_BASE_NOISE_DB + THRESHOLD_DB` so every planted signal
+/// counts as a detection hit.
+const SYNTH_SIGNAL_LEVEL_DB: f32 = -40.0;
+
 fn synthetic_db_line(bins: usize) -> Vec<f32> {
     // Noise floor around -80 dB + a few narrow-band "signals"
     // punched in at known offsets. Gives the bench a
     // realistic mix of detection hits + non-hits so branch
     // predictors see a realistic hit-rate (~1 %).
-    let mut v = vec![-80.0_f32; bins];
+    let mut v = vec![SYNTH_BASE_NOISE_DB; bins];
     for (i, x) in v.iter_mut().enumerate() {
         #[allow(clippy::cast_precision_loss)]
         let t = i as f32;
         // Broadband noise variance.
-        *x += (t * 0.05).sin() * 3.0;
-        // Sparse "signals" every ~100 bins.
-        if i % 100 == 0 {
-            *x = -40.0;
+        *x += (t * SYNTH_WOBBLE_STEP_RAD).sin() * SYNTH_WOBBLE_AMPLITUDE_DB;
+        // Sparse "signals" every ~SYNTH_SIGNAL_EVERY_BINS bins.
+        if i % SYNTH_SIGNAL_EVERY_BINS == 0 {
+            *x = SYNTH_SIGNAL_LEVEL_DB;
         }
     }
     v

--- a/crates/sdr-dsp/benches/detection.rs
+++ b/crates/sdr-dsp/benches/detection.rs
@@ -28,6 +28,8 @@
 //! allocated once outside the closure; the hot path is purely
 //! compute + one bool-ish write per bin.
 
+use std::hint::black_box;
+
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 
 const BINS: usize = 65_536;
@@ -115,10 +117,15 @@ fn bench_energy_detect(c: &mut Criterion) {
     group.throughput(Throughput::Elements(BINS as u64));
     group.bench_function(format!("bins={BINS}"), |b| {
         b.iter_batched(
-            || db_line.clone(),
+            // `black_box` on the input + on the returned hit count
+            // prevents LLVM from constant-folding the sort or
+            // eliding the threshold scan once it sees the result
+            // is dropped.
+            || black_box(db_line.clone()),
             |line| {
                 let floor = estimate_noise_floor(&line, &mut sort_scratch);
-                let _hits = count_detections(&line, floor);
+                let hits = count_detections(&line, floor);
+                black_box(hits);
             },
             BatchSize::SmallInput,
         );

--- a/crates/sdr-dsp/benches/fft.rs
+++ b/crates/sdr-dsp/benches/fft.rs
@@ -18,6 +18,8 @@
 //! designed for exactly this pattern: the setup closure clones
 //! the input, the routine closure consumes it.
 
+use std::hint::black_box;
+
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use sdr_dsp::fft::{FftEngine, RustFftEngine};
 use sdr_types::Complex;
@@ -64,9 +66,16 @@ fn bench_forward(c: &mut Criterion) {
         let mut engine = RustFftEngine::new(size).expect("valid FFT size");
         group.bench_function(format!("size={size}"), |b| {
             b.iter_batched(
-                || input.clone(),
+                // `black_box` on the setup return value forces LLVM
+                // to treat the cloned buffer as "could be anything",
+                // so it can't hoist constants out of the FFT call.
+                || black_box(input.clone()),
                 |mut buf| {
                     engine.forward(&mut buf).expect("forward FFT in-place");
+                    // And `black_box(&buf)` after the call forces
+                    // the frequency-domain result to be observed,
+                    // so the write-back can't be elided.
+                    black_box(&buf);
                 },
                 BatchSize::SmallInput,
             );

--- a/crates/sdr-dsp/benches/fft.rs
+++ b/crates/sdr-dsp/benches/fft.rs
@@ -28,6 +28,12 @@ use sdr_types::Complex;
 /// SIMD.
 const SIZES: &[usize] = &[2048, 8192, 65536];
 
+/// Radians-per-sample advance for the synthetic input sinusoid.
+/// `rustfft`'s butterfly cost is independent of sample values, so
+/// the exact step doesn't matter — it's here only so the bench
+/// fixture is documented and reproducible across machines.
+const INPUT_PHASE_STEP_RAD: f32 = 0.01;
+
 fn make_input(size: usize) -> Vec<Complex> {
     // Deterministic, non-zero samples — a real FFT would see
     // bursty energy from a live IQ stream, but the cost of
@@ -39,8 +45,8 @@ fn make_input(size: usize) -> Vec<Complex> {
             #[allow(clippy::cast_precision_loss)]
             let t = i as f32;
             Complex {
-                re: (t * 0.01).sin(),
-                im: (t * 0.01).cos(),
+                re: (t * INPUT_PHASE_STEP_RAD).sin(),
+                im: (t * INPUT_PHASE_STEP_RAD).cos(),
             }
         })
         .collect()

--- a/crates/sdr-dsp/benches/fft.rs
+++ b/crates/sdr-dsp/benches/fft.rs
@@ -1,0 +1,73 @@
+//! Baseline FFT throughput — `RustFftEngine` at the three
+//! power-of-two sizes the GPU path is expected to compare against
+//! (epic #452 phase 1 / #179 phase 2).
+//!
+//! **Measurement discipline.** The engine + its planner-allocated
+//! scratch buffers are constructed once outside the `iter_batched`
+//! closure; the closure itself only runs the in-place forward FFT.
+//! This mirrors the pre-allocation discipline the GPU harness
+//! MUST follow (wgpu device, pipeline, bind groups, staging
+//! buffers all amortized at construction) so the two sides can be
+//! compared without one of them paying a setup tax on every tick.
+//!
+//! The input buffer is deliberately re-seeded from a fresh copy
+//! every iteration — `RustFftEngine::forward` is in-place, so if
+//! we didn't reset the input the second iteration onward would be
+//! running a transform on the previous iteration's frequency-
+//! domain data. Criterion's `iter_batched` with `SmallInput` is
+//! designed for exactly this pattern: the setup closure clones
+//! the input, the routine closure consumes it.
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use sdr_dsp::fft::{FftEngine, RustFftEngine};
+use sdr_types::Complex;
+
+/// FFT sizes under test. 2048 and 8192 are typical waterfall-rate
+/// sizes; 65536 is the top-end wide-spectrum size where GPU
+/// parallelism has the best shot at beating `rustfft`'s scalar
+/// SIMD.
+const SIZES: &[usize] = &[2048, 8192, 65536];
+
+fn make_input(size: usize) -> Vec<Complex> {
+    // Deterministic, non-zero samples — a real FFT would see
+    // bursty energy from a live IQ stream, but the cost of
+    // `rustfft` is independent of the data values (it's all
+    // multiply-adds on the butterfly structure). Using a simple
+    // sinusoid keeps the numbers reproducible across machines.
+    (0..size)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let t = i as f32;
+            Complex {
+                re: (t * 0.01).sin(),
+                im: (t * 0.01).cos(),
+            }
+        })
+        .collect()
+}
+
+fn bench_forward(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fft_forward_rustfft");
+    for &size in SIZES {
+        // Measure throughput in complex samples per second so the
+        // output reads as "complex samples/sec" across sizes —
+        // easy to eyeball scaling and to compare against the GPU
+        // harness later.
+        group.throughput(Throughput::Elements(size as u64));
+        let input = make_input(size);
+        let mut engine = RustFftEngine::new(size).expect("valid FFT size");
+        group.bench_function(format!("size={size}"), |b| {
+            b.iter_batched(
+                || input.clone(),
+                |mut buf| {
+                    engine.forward(&mut buf).expect("forward FFT in-place");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_forward);
+criterion_main!(benches);

--- a/crates/sdr-dsp/benches/fir.rs
+++ b/crates/sdr-dsp/benches/fir.rs
@@ -42,14 +42,25 @@ const AUDIO_SAMPLE_RATE_HZ: f64 = 48_000.0;
 const AUDIO_CUTOFF_HZ: f64 = 5_000.0;
 const AUDIO_TRANSITION_HZ: f64 = 500.0;
 
+/// Radians-per-sample advance for the synthetic IQ fixture. The
+/// FIR hot path is data-independent (multiply-add over a fixed
+/// tap set), so the exact step only has to be small enough that
+/// the generated samples stay in-range — the bench cost is
+/// identical either way.
+const COMPLEX_INPUT_PHASE_STEP_RAD: f32 = 0.001;
+/// Same idea for the real-valued audio fixture, at an order of
+/// magnitude faster because 4800 samples is a much shorter span
+/// than the 16384-sample IQ buffer.
+const REAL_INPUT_PHASE_STEP_RAD: f32 = 0.01;
+
 fn make_complex_input(n: usize) -> Vec<Complex> {
     (0..n)
         .map(|i| {
             #[allow(clippy::cast_precision_loss)]
             let t = i as f32;
             Complex {
-                re: (t * 0.001).sin(),
-                im: (t * 0.001).cos(),
+                re: (t * COMPLEX_INPUT_PHASE_STEP_RAD).sin(),
+                im: (t * COMPLEX_INPUT_PHASE_STEP_RAD).cos(),
             }
         })
         .collect()
@@ -60,7 +71,7 @@ fn make_real_input(n: usize) -> Vec<f32> {
         .map(|i| {
             #[allow(clippy::cast_precision_loss)]
             let t = i as f32;
-            (t * 0.01).sin()
+            (t * REAL_INPUT_PHASE_STEP_RAD).sin()
         })
         .collect()
 }

--- a/crates/sdr-dsp/benches/fir.rs
+++ b/crates/sdr-dsp/benches/fir.rs
@@ -23,6 +23,8 @@
 //!   shape where small-buffer GPU almost certainly loses —
 //!   #181 calls this out.
 
+use std::hint::black_box;
+
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use sdr_dsp::filter::{ComplexFirFilter, FirFilter};
 use sdr_dsp::taps::low_pass;
@@ -98,11 +100,15 @@ fn bench_channel_filter(c: &mut Criterion) {
         |b| {
             let mut output = vec![Complex::default(); CHANNEL_IQ_BUFFER_SAMPLES];
             b.iter_batched(
-                || input.clone(),
+                // `black_box` on setup + after `process` keeps LLVM
+                // from hoisting constants through the taps or
+                // eliding the filtered write-back.
+                || black_box(input.clone()),
                 |buf| {
                     filter
                         .process(&buf, &mut output)
                         .expect("output sized to input");
+                    black_box(&output);
                 },
                 BatchSize::SmallInput,
             );
@@ -133,11 +139,12 @@ fn bench_audio_lpf(c: &mut Criterion) {
         |b| {
             let mut output = vec![0.0_f32; AUDIO_BUFFER_SAMPLES];
             b.iter_batched(
-                || input.clone(),
+                || black_box(input.clone()),
                 |buf| {
                     filter
                         .process_f32(&buf, &mut output)
                         .expect("output sized to input");
+                    black_box(&output);
                 },
                 BatchSize::SmallInput,
             );

--- a/crates/sdr-dsp/benches/fir.rs
+++ b/crates/sdr-dsp/benches/fir.rs
@@ -1,0 +1,139 @@
+//! Baseline FIR filter throughput — the two shapes real-time DSP
+//! hits most: a channel filter on the 2.4 Msps complex IQ stream
+//! and an audio LPF on the 48 kHz real output (epic #452 phase 1
+//! / #181 phase 4).
+//!
+//! **Measurement discipline.** Filter + tap buffers allocated
+//! once outside the iteration closure. Input buffer is cloned
+//! per-iteration via `iter_batched` because `process` reads
+//! input + writes output — reusing the same input cross-
+//! iteration would be fine correctness-wise but risks the
+//! compiler hoisting constants in a way that muddies the
+//! comparison with a GPU path that'll see fresh samples every
+//! tick.
+//!
+//! Why these two cases specifically:
+//!
+//! - **Channel filter**: complex-valued, ~256 taps, buffer
+//!   sized to a realistic DSP tick (16384 samples ≈ 6.8 ms at
+//!   2.4 Msps). Large enough to be non-trivial, small enough
+//!   that the GPU transfer overhead realistically competes.
+//! - **Audio LPF**: real-valued f32, ~128 taps, 48 kHz buffer
+//!   sized to one render tick (4800 samples = 100 ms). The
+//!   shape where small-buffer GPU almost certainly loses —
+//!   #181 calls this out.
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use sdr_dsp::filter::{ComplexFirFilter, FirFilter};
+use sdr_dsp::taps::low_pass;
+use sdr_types::Complex;
+
+/// Channel filter: complex IQ, 2.4 Msps context, ~256 taps
+/// (10 kHz transition width at 2.4 Msps via Nuttall window).
+const CHANNEL_IQ_BUFFER_SAMPLES: usize = 16_384;
+const CHANNEL_SAMPLE_RATE_HZ: f64 = 2_400_000.0;
+const CHANNEL_CUTOFF_HZ: f64 = 100_000.0;
+const CHANNEL_TRANSITION_HZ: f64 = 20_000.0;
+
+/// Audio LPF: real f32, 48 kHz context, ~128 taps
+/// (500 Hz transition at 48 kHz — typical post-demod brick wall).
+const AUDIO_BUFFER_SAMPLES: usize = 4_800;
+const AUDIO_SAMPLE_RATE_HZ: f64 = 48_000.0;
+const AUDIO_CUTOFF_HZ: f64 = 5_000.0;
+const AUDIO_TRANSITION_HZ: f64 = 500.0;
+
+fn make_complex_input(n: usize) -> Vec<Complex> {
+    (0..n)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let t = i as f32;
+            Complex {
+                re: (t * 0.001).sin(),
+                im: (t * 0.001).cos(),
+            }
+        })
+        .collect()
+}
+
+fn make_real_input(n: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let t = i as f32;
+            (t * 0.01).sin()
+        })
+        .collect()
+}
+
+fn bench_channel_filter(c: &mut Criterion) {
+    let taps = low_pass(
+        CHANNEL_CUTOFF_HZ,
+        CHANNEL_TRANSITION_HZ,
+        CHANNEL_SAMPLE_RATE_HZ,
+        /* odd_tap_count */ false,
+    )
+    .expect("valid lowpass taps");
+    let mut filter = ComplexFirFilter::new(taps).expect("non-empty taps");
+    let input = make_complex_input(CHANNEL_IQ_BUFFER_SAMPLES);
+
+    let mut group = c.benchmark_group("fir_channel_complex");
+    group.throughput(Throughput::Elements(CHANNEL_IQ_BUFFER_SAMPLES as u64));
+    group.bench_function(
+        format!(
+            "taps={}_samples={}",
+            filter.tap_count(),
+            CHANNEL_IQ_BUFFER_SAMPLES
+        ),
+        |b| {
+            let mut output = vec![Complex::default(); CHANNEL_IQ_BUFFER_SAMPLES];
+            b.iter_batched(
+                || input.clone(),
+                |buf| {
+                    filter
+                        .process(&buf, &mut output)
+                        .expect("output sized to input");
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.finish();
+}
+
+fn bench_audio_lpf(c: &mut Criterion) {
+    let taps = low_pass(
+        AUDIO_CUTOFF_HZ,
+        AUDIO_TRANSITION_HZ,
+        AUDIO_SAMPLE_RATE_HZ,
+        /* odd_tap_count */ false,
+    )
+    .expect("valid lowpass taps");
+    let mut filter = FirFilter::new(taps).expect("non-empty taps");
+    let input = make_real_input(AUDIO_BUFFER_SAMPLES);
+
+    let mut group = c.benchmark_group("fir_audio_real");
+    group.throughput(Throughput::Elements(AUDIO_BUFFER_SAMPLES as u64));
+    group.bench_function(
+        format!(
+            "taps={}_samples={}",
+            filter.tap_count(),
+            AUDIO_BUFFER_SAMPLES
+        ),
+        |b| {
+            let mut output = vec![0.0_f32; AUDIO_BUFFER_SAMPLES];
+            b.iter_batched(
+                || input.clone(),
+                |buf| {
+                    filter
+                        .process_f32(&buf, &mut output)
+                        .expect("output sized to input");
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.finish();
+}
+
+criterion_group!(benches, bench_channel_filter, bench_audio_lpf);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Phase 1 of epic #452 (GPU acceleration). Adds Criterion as a dev-dep in `sdr-dsp` plus four baseline benches covering the exact CPU paths the GPU sub-tickets (#179-#182) need to beat.

All four benches follow the same measurement discipline the GPU harness will have to match: engines/filters/scratch buffers pre-allocated once **outside** the `iter_batched` closure, only the compute call inside. Input cloned per-iteration via `iter_batched` with `SmallInput` to avoid measuring `Vec::clone` in the hot path.

Pre-allocation discipline is non-negotiable for the GPU sub-tickets — GPU buffer allocation dominates at these block sizes. Baking it into the CPU baselines keeps the comparison one-for-one.

## Baseline numbers (GTK dev machine, release build)

| Operation | Shape | Median | Throughput |
|---|---|---|---|
| \`RustFftEngine::forward\` | 2048 pts | 2.77 µs | 740 Melem/s |
| \`RustFftEngine::forward\` | 8192 pts | 11.98 µs | 684 Melem/s |
| \`RustFftEngine::forward\` | 65536 pts | 125.81 µs | 521 Melem/s |
| \`ComplexFirFilter::process\` | 1200 taps × 16384 IQ | 12.96 ms | 1.26 Melem/s |
| \`FirFilter::process_f32\` | 960 taps × 4800 f32 | 3.00 ms | 1.60 Melem/s |
| Colormap lookup | 65536 bins | 224.61 µs | 292 Melem/s |
| Energy detection | 65536 bins | 794.56 µs | 82 Melem/s |

Full analysis (which phases look tight, which look like real opportunities, which are likely to lose standalone) posted on epic #452.

## Files

- \`crates/sdr-dsp/Cargo.toml\` — Criterion dev-dep, 4 \`[[bench]]\` entries with \`harness = false\`
- \`crates/sdr-dsp/benches/fft.rs\` — \`RustFftEngine::forward\` at 2048/8192/65536
- \`crates/sdr-dsp/benches/fir.rs\` — \`ComplexFirFilter\` (channel filter) + \`FirFilter::process_f32\` (audio LPF)
- \`crates/sdr-dsp/benches/colormap.rs\` — self-contained 65536-bin dB→RGBA lookup
- \`crates/sdr-dsp/benches/detection.rs\` — sort-based noise floor + threshold scan (generous CPU baseline; phase 3b will also need a streaming-quantile comparison)

## Test plan

- [x] \`cargo bench -p sdr-dsp --bench fft\`
- [x] \`cargo bench -p sdr-dsp --bench fir\`
- [x] \`cargo bench -p sdr-dsp --bench colormap\`
- [x] \`cargo bench -p sdr-dsp --bench detection\`
- [x] \`cargo build --workspace\` still green (no production code changed)
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\`

Refs #452. Does not close any sub-ticket — Phase 2 (#179 GPU FFT) is the next branch and will reference these numbers directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Criterion benchmarking to the workspace and pinned a consistent Criterion version for reproducible benches.
  * Introduced benchmark suites measuring FFT, FIR filter, colormap lookup, and signal-detection performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->