### PR TITLE
sdr-dsp: wgpu GPU FFT engine (Stockham autosort), epic #452 phase 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +59,21 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -79,16 +109,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -285,6 +339,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +517,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "earshot"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +618,18 @@ dependencies = [
  "futures-sink",
  "spin",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -738,6 +833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glib"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +893,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +922,40 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -911,7 +1072,28 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -931,6 +1113,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hound"
@@ -1156,7 +1344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1211,6 +1399,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1450,23 @@ dependencies = [
  "security-framework 3.7.0",
  "zeroize",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lazy_static"
@@ -1312,7 +1545,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1366,6 +1599,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1465,6 +1704,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "naga"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1600,7 +1875,34 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
+ "bitflags",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1614,6 +1916,15 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "pango"
@@ -1637,6 +1948,29 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1692,6 +2026,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +2063,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -1747,6 +2108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,7 +2133,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -1786,7 +2153,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -1885,6 +2252,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +2332,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
@@ -1996,6 +2402,12 @@ dependencies = [
  "libc",
  "libusb1-sys",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2168,12 +2580,16 @@ dependencies = [
 name = "sdr-dsp"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "criterion",
+ "pollster",
  "rustfft",
  "sdr-types",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
+ "wgpu",
 ]
 
 [[package]]
@@ -2565,6 +2981,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,10 +3036,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strength_reduce"
@@ -2688,6 +3128,15 @@ name = "target-lexicon"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "thiserror"
@@ -3053,6 +3502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,6 +3597,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3644,173 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
 ]
 
 [[package]]
@@ -3234,10 +3868,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3306,6 +4035,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3434,6 +4172,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,6 +244,15 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 # Zero-copy type casting
 bytemuck = { version = "1", features = ["derive"] }
 
+# GPU compute (epic #452 phase 2+). Used by sdr-dsp for the wgpu-backed
+# FFT engine behind the `FftEngine` trait. We target the default wgpu
+# backend set — Vulkan on Linux, Metal on macOS, DX12 on Windows —
+# which is what the `RTL-SDR` project supports anyway. `pollster`
+# drives wgpu's async surface to completion on the sync `FftEngine::
+# forward` path without pulling in a full async runtime.
+wgpu = "29"
+pollster = "0.4"
+
 # GTK4 / UI
 gtk4 = { version = "0.11", features = ["v4_10"] }
 libadwaita = { version = "0.9", features = ["v1_5"] }

--- a/crates/sdr-dsp/Cargo.toml
+++ b/crates/sdr-dsp/Cargo.toml
@@ -11,6 +11,16 @@ sdr-types.workspace = true
 rustfft.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+# GPU FFT backend (epic #452 phase 2 / #179). Behind the same
+# `FftEngine` trait as `RustFftEngine`. `pollster` drives the async
+# wgpu readback to completion on the sync trait surface.
+wgpu.workspace = true
+pollster.workspace = true
+# bytemuck gets us zero-copy `Complex` ↔ `f32` slice casts for the
+# GPU upload / readback path — the same layout-identity we rely on
+# in the rustfft path, expressed safely.
+bytemuck.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -31,6 +41,14 @@ workspace = true
 
 [[bench]]
 name = "fft"
+harness = false
+
+# GPU companion to the CPU FFT bench (epic #452 phase 2 / #179).
+# Uses the same `FftEngine::forward` surface, same sizes, same
+# `iter_batched` + `black_box` discipline so the numbers are
+# directly comparable against `fft`.
+[[bench]]
+name = "fft_gpu"
 harness = false
 
 [[bench]]

--- a/crates/sdr-dsp/benches/fft_gpu.rs
+++ b/crates/sdr-dsp/benches/fft_gpu.rs
@@ -1,0 +1,129 @@
+//! GPU FFT throughput — `GpuFftEngine` (wgpu + Stockham autosort,
+//! radix-2) at the same three power-of-two sizes as the CPU
+//! baseline in `benches/fft.rs`. Epic #452 phase 2 / #179.
+//!
+//! **Comparison surface.** Identical to `benches/fft.rs`:
+//!
+//! - Same `FftEngine::forward` trait call shape — in-place complex
+//!   f32 forward DFT.
+//! - Same input (sinusoid via `INPUT_PHASE_STEP_RAD`).
+//! - Same `iter_batched` + `SmallInput` + `black_box` discipline
+//!   (CPU bench rationale at `benches/fft.rs`).
+//! - Same pre-allocation discipline: engine is built once outside
+//!   the Criterion closure, only `forward` runs inside. The
+//!   engine already owns all its wgpu state (pipeline, ping-pong
+//!   buffers, bind groups) so this is where the GPU path earns
+//!   back the driver-init cost on every tick.
+//!
+//! **Adapter selection.** Env var `SDR_GPU_ADAPTER` drives which
+//! adapter wgpu picks:
+//!
+//! - unset / `auto` / `high` → `HighPerformance` (default, picks
+//!   discrete GPU on laptops and multi-GPU desktops)
+//! - `low` / `igpu`          → `LowPower` (forces iGPU on hybrid
+//!   setups)
+//! - `fallback` / `software` → forces a software adapter
+//!
+//! Backend override via `SDR_GPU_BACKEND=vulkan|metal|dx12|gl` —
+//! the default is `Backends::all()` which wgpu resolves per-
+//! platform. For the multi-GPU matrix on the dev machine (NVIDIA
+//! 4080 Super, NVIDIA 3090, AMD iGPU), set both vars to pin the
+//! exact adapter per bench run.
+
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use sdr_dsp::fft::FftEngine;
+use sdr_dsp::gpu_fft::{GpuFftEngine, GpuFftOptions};
+use sdr_types::Complex;
+
+/// FFT sizes under test. Mirrors `benches/fft.rs::SIZES` exactly.
+const SIZES: &[usize] = &[2048, 8192, 65_536];
+
+/// Matches `benches/fft.rs::INPUT_PHASE_STEP_RAD`. Data-independent
+/// for both engines — same value keeps the two benches directly
+/// comparable line-for-line.
+const INPUT_PHASE_STEP_RAD: f32 = 0.01;
+
+fn make_input(size: usize) -> Vec<Complex> {
+    (0..size)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let t = i as f32;
+            Complex {
+                re: (t * INPUT_PHASE_STEP_RAD).sin(),
+                im: (t * INPUT_PHASE_STEP_RAD).cos(),
+            }
+        })
+        .collect()
+}
+
+fn gpu_options_from_env() -> GpuFftOptions {
+    let mut opts = GpuFftOptions::default();
+    if let Ok(pref) = std::env::var("SDR_GPU_ADAPTER") {
+        match pref.to_ascii_lowercase().as_str() {
+            "high" | "auto" | "" => {}
+            "low" | "igpu" => opts.power_preference = wgpu::PowerPreference::LowPower,
+            "fallback" | "software" => opts.force_fallback_adapter = true,
+            other => eprintln!("unknown SDR_GPU_ADAPTER={other:?}, using default"),
+        }
+    }
+    if let Ok(backend) = std::env::var("SDR_GPU_BACKEND") {
+        match backend.to_ascii_lowercase().as_str() {
+            "vulkan" | "vk" => opts.backends = wgpu::Backends::VULKAN,
+            "metal" => opts.backends = wgpu::Backends::METAL,
+            "dx12" | "d3d12" => opts.backends = wgpu::Backends::DX12,
+            "gl" | "opengl" | "gles" => opts.backends = wgpu::Backends::GL,
+            other => eprintln!("unknown SDR_GPU_BACKEND={other:?}, using default"),
+        }
+    }
+    opts
+}
+
+fn bench_forward(c: &mut Criterion) {
+    let opts = gpu_options_from_env();
+
+    let mut group = c.benchmark_group("fft_forward_gpu_stockham");
+    for &size in SIZES {
+        group.throughput(Throughput::Elements(size as u64));
+        let input = make_input(size);
+
+        // Construct the engine once. If the GPU is unavailable on
+        // this machine (no adapter / CI runner / driver issue),
+        // log and skip rather than panicking — the CPU bench still
+        // runs and the comparison just won't include this config.
+        let Ok(mut engine) = GpuFftEngine::with_options(size, &opts) else {
+            eprintln!("GPU FFT engine unavailable at size={size}, skipping");
+            continue;
+        };
+
+        // Print the adapter once per size so the bench output
+        // makes it obvious which GPU was measured (the dev machine
+        // has 3 — 4080 Super / 3090 / AMD 780M iGPU — and the
+        // default high-performance pick is not guaranteed to be
+        // stable across driver releases).
+        let summary = engine.adapter_summary();
+        eprintln!(
+            "fft_forward_gpu_stockham/size={size}: adapter = {} ({:?} / {:?}) driver = {}",
+            summary.name, summary.device_type, summary.backend, summary.driver,
+        );
+
+        group.bench_function(format!("size={size}"), |b| {
+            b.iter_batched(
+                // Same `black_box` shape as the CPU bench so LLVM
+                // can't elide the buffer population or hoist
+                // constants into the measured call.
+                || black_box(input.clone()),
+                |mut buf| {
+                    engine.forward(&mut buf).expect("GPU forward FFT");
+                    black_box(&buf);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_forward);
+criterion_main!(benches);

--- a/crates/sdr-dsp/src/gpu_fft.rs
+++ b/crates/sdr-dsp/src/gpu_fft.rs
@@ -1,0 +1,686 @@
+//! wgpu-backed FFT engine — Stockham autosort radix-2 forward DFT,
+//! one pass per compute dispatch (epic #452 phase 2 / #179).
+//!
+//! Lives behind the same [`FftEngine`] trait as [`RustFftEngine`]
+//! so callers can hot-swap CPU↔GPU without touching the signal
+//! path. The host-side scaffolding here owns the device / queue /
+//! pipeline / ping-pong buffers for the engine's lifetime; the
+//! hot path (`forward`) only issues `log2(N)` compute dispatches
+//! plus one readback copy, zero allocations.
+//!
+//! # Algorithm
+//!
+//! Stockham out-of-place radix-2 FFT. Pass `s` (0 ≤ s < log2(N))
+//! combines two size-`2^s` subFFTs into one size-`2^(s+1)` subFFT,
+//! reading from one ping-pong buffer and writing to the other.
+//! No bit-reversal permutation pass — Stockham's "contiguous
+//! output" layout already produces the final natural order after
+//! the last pass. See `gpu_fft.wgsl` for the per-butterfly
+//! arithmetic.
+//!
+//! # Pre-allocation
+//!
+//! Everything is created once in [`GpuFftEngine::with_options`]:
+//!
+//! - `wgpu::Instance`, `wgpu::Adapter`, `wgpu::Device`, `wgpu::Queue`
+//! - Compute pipeline + bind group layout
+//! - Two ping-pong storage buffers (sized `N * 8 bytes`)
+//! - One uniform buffer holding all `log2(N)` `Params` entries at
+//!   `min_uniform_buffer_offset_alignment` stride; written once,
+//!   bound with dynamic offsets per pass
+//! - Two bind groups (ping and pong) with the uniform in both
+//! - One staging download buffer (`MAP_READ | COPY_DST`)
+//!
+//! GPU pipeline state caching is paramount — wgpu device+pipeline
+//! construction is the expensive part (~ms), dispatches are cheap
+//! (~µs). Anything that skips this cache defeats the point of GPU
+//! compute for this workload, which is why the trait is
+//! `&mut self` and every per-FFT allocation is denied.
+//!
+//! # Sync surface over async wgpu
+//!
+//! wgpu 29's `request_adapter` / `request_device` / `map_async`
+//! are all futures. The [`FftEngine`] trait is sync, so we block
+//! via [`pollster`] on the `new`/`with_options` path and poll the
+//! device on the `forward` readback path. The forward path does
+//! *not* spawn an async runtime — `device.poll(PollType::Wait)`
+//! blocks on the calling thread inside wgpu-core's own event loop.
+
+use std::sync::Arc;
+
+use bytemuck::{Pod, Zeroable};
+use sdr_types::{Complex, DspError};
+use tracing::{debug, info};
+
+use crate::fft::FftEngine;
+
+/// WGSL source for the Stockham FFT compute kernel. Compiled into
+/// a single pipeline reused across all passes.
+const SHADER_SRC: &str = include_str!("gpu_fft.wgsl");
+
+/// Workgroup size declared in the shader. Must match
+/// `@workgroup_size(N)` in `gpu_fft.wgsl` — the CPU dispatch math
+/// divides butterfly count by this.
+const SHADER_WORKGROUP_SIZE: u32 = 64;
+
+/// `Params` struct size in WGSL is two `u32`s = 8 bytes, but we
+/// stride entries by the device's
+/// `min_uniform_buffer_offset_alignment` so each dispatch can use
+/// a dynamic offset. 256 covers every GPU we care about (NVIDIA /
+/// AMD discrete and integrated); we query the actual limit at
+/// construction time rather than hard-coding it.
+const PARAMS_SIZE_BYTES: u64 = std::mem::size_of::<ShaderParams>() as u64;
+
+/// Adapter-selection knobs for [`GpuFftEngine::with_options`].
+///
+/// Default = discrete high-performance adapter via the default
+/// backend set (Vulkan on Linux, Metal on macOS, DX12 on Windows).
+/// The bench harness in `benches/fft_gpu.rs` overrides these to
+/// sweep the 4080 Super / 3090 / AMD iGPU matrix.
+#[derive(Debug, Clone)]
+pub struct GpuFftOptions {
+    /// Power-preference hint. `HighPerformance` picks the discrete
+    /// GPU on laptops and multi-GPU desktops; `LowPower` picks
+    /// the iGPU.
+    pub power_preference: wgpu::PowerPreference,
+    /// Which GPU backend(s) the instance is allowed to see. Defaults
+    /// to `Backends::all()` so wgpu picks per-platform defaults;
+    /// narrow to `VULKAN` / `METAL` / `DX12` to test a specific
+    /// driver stack.
+    pub backends: wgpu::Backends,
+    /// If true, force a software ("CPU fallback") adapter. Useful
+    /// as a sanity check — the shader should produce identical
+    /// output on any compliant backend.
+    pub force_fallback_adapter: bool,
+}
+
+impl Default for GpuFftOptions {
+    fn default() -> Self {
+        Self {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            backends: wgpu::Backends::all(),
+            force_fallback_adapter: false,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
+struct ShaderParams {
+    pass_s: u32,
+    size: u32,
+}
+
+/// Adapter / backend summary for a constructed GPU engine, exposed
+/// so the bench harness can print which GPU a given run measured
+/// (the dev machine in epic #452 has 3 GPUs and the "default
+/// high-performance" pick can depend on display vs. render
+/// attachments and driver priority).
+#[derive(Debug, Clone)]
+pub struct AdapterSummary {
+    pub name: String,
+    pub backend: wgpu::Backend,
+    pub device_type: wgpu::DeviceType,
+    pub driver: String,
+}
+
+/// wgpu-backed FFT engine. Implements [`FftEngine`] with identical
+/// semantics to [`RustFftEngine`]: in-place forward complex DFT.
+///
+/// Not `Clone` — each instance owns its own wgpu device and a
+/// sized set of buffers. Sharing across threads is possible via
+/// `Arc<Mutex<GpuFftEngine>>` but each instance is single-threaded
+/// internally.
+#[derive(Debug)]
+pub struct GpuFftEngine {
+    adapter_summary: AdapterSummary,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    pipeline: wgpu::ComputePipeline,
+
+    // Ping-pong storage buffers. Both sized `size * 8 bytes` (size
+    // complex × 2 × f32). `buf_a` also carries `COPY_DST` so we
+    // can upload the input via `queue.write_buffer`.
+    buf_a: wgpu::Buffer,
+    buf_b: wgpu::Buffer,
+
+    // Uniform buffer holding `log2(size)` `ShaderParams` entries at
+    // `params_stride` bytes each. Pre-filled once in `new()` and
+    // addressed via dynamic offsets at dispatch time — so the host
+    // never writes to it on the forward path.
+    params_bg_a: wgpu::BindGroup,
+    params_bg_b: wgpu::BindGroup,
+    params_stride: u32,
+
+    // MAP_READ | COPY_DST staging buffer for device→host readback.
+    staging: wgpu::Buffer,
+
+    size: usize,
+    log2_size: u32,
+    workgroup_count: u32,
+
+    // After `log2_size` ping-pong passes, the final result lives in
+    // `buf_a` iff `log2_size` is even (last pass reads from the
+    // buffer flipped-to-pong-side, writes back to A).
+    output_in_buf_a: bool,
+}
+
+impl GpuFftEngine {
+    /// Create a new GPU FFT engine for the given size with default
+    /// adapter options (discrete high-performance adapter).
+    ///
+    /// # Errors
+    ///
+    /// - [`DspError::InvalidParameter`] if `size` is not a power
+    ///   of two ≥ 2.
+    /// - [`DspError::GpuUnavailable`] if no compatible adapter /
+    ///   device can be acquired. Callers that want the CPU
+    ///   engine as a fallback should catch this and construct
+    ///   [`RustFftEngine`] instead.
+    pub fn new(size: usize) -> Result<Self, DspError> {
+        Self::with_options(size, &GpuFftOptions::default())
+    }
+
+    /// Create a new GPU FFT engine with explicit adapter options.
+    /// Used by the bench harness to pin a specific adapter when
+    /// sweeping a multi-GPU matrix.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`GpuFftEngine::new`].
+    pub fn with_options(size: usize, opts: &GpuFftOptions) -> Result<Self, DspError> {
+        if size < 2 || !size.is_power_of_two() {
+            return Err(DspError::InvalidParameter(format!(
+                "GPU FFT size must be a power of two ≥ 2, got {size}"
+            )));
+        }
+        pollster::block_on(Self::build_async(size, opts))
+    }
+
+    /// Adapter / backend / driver string for the underlying wgpu
+    /// adapter. Captured once at engine construction so downstream
+    /// (benches, telemetry) never has to go re-query wgpu itself.
+    #[must_use]
+    pub fn adapter_summary(&self) -> &AdapterSummary {
+        &self.adapter_summary
+    }
+
+    /// Create the wgpu instance, pick an adapter per `opts`, and
+    /// request a device + queue. Split out of `build_async` to
+    /// keep that function under the `too_many_lines` clippy bar.
+    async fn acquire_device(
+        opts: &GpuFftOptions,
+    ) -> Result<(Arc<wgpu::Device>, Arc<wgpu::Queue>, AdapterSummary), DspError> {
+        let mut instance_desc = wgpu::InstanceDescriptor::new_without_display_handle();
+        instance_desc.backends = opts.backends;
+        let instance = wgpu::Instance::new(instance_desc);
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: opts.power_preference,
+                force_fallback_adapter: opts.force_fallback_adapter,
+                compatible_surface: None,
+            })
+            .await
+            .map_err(|e| DspError::GpuUnavailable(format!("request_adapter failed: {e}")))?;
+
+        let info = adapter.get_info();
+        let summary = AdapterSummary {
+            name: info.name.clone(),
+            backend: info.backend,
+            device_type: info.device_type,
+            driver: info.driver.clone(),
+        };
+        info!(
+            target: "sdr_dsp::gpu_fft",
+            backend = ?summary.backend,
+            device = %summary.name,
+            device_type = ?summary.device_type,
+            driver = %summary.driver,
+            "selected GPU FFT adapter"
+        );
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("sdr-dsp GPU FFT device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| DspError::GpuUnavailable(format!("request_device failed: {e}")))?;
+        Ok((Arc::new(device), Arc::new(queue), summary))
+    }
+
+    /// Pre-fill the per-pass uniforms. Stride is the device's
+    /// reported `min_uniform_buffer_offset_alignment`, which is
+    /// 256 on almost every GPU. Each entry is only 8 bytes so we
+    /// zero-pad the remainder of each stride.
+    ///
+    /// The `try_from` cascades can't actually fail for any shape
+    /// the caller could construct — FFT sizes are validated at
+    /// power-of-two above and `min_uniform_buffer_offset_alignment`
+    /// is always a small u32 — but going through fallible casts
+    /// keeps clippy's pedantic cast lint happy and documents the
+    /// narrowing explicitly.
+    fn build_params_buffer(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        size: usize,
+        log2_size: u32,
+    ) -> Result<(wgpu::Buffer, u32), DspError> {
+        let params_size_u32 = u32::try_from(PARAMS_SIZE_BYTES)
+            .map_err(|_| DspError::InvalidParameter("ShaderParams size exceeds u32".into()))?;
+        let params_stride = device
+            .limits()
+            .min_uniform_buffer_offset_alignment
+            .max(params_size_u32);
+        let size_u32 = u32::try_from(size)
+            .map_err(|_| DspError::InvalidParameter(format!("FFT size {size} exceeds u32")))?;
+        let params_buf_bytes = u64::from(params_stride) * u64::from(log2_size);
+        let params_buf_bytes_usize = usize::try_from(params_buf_bytes).map_err(|_| {
+            DspError::InvalidParameter(format!(
+                "uniform buffer size {params_buf_bytes} exceeds usize"
+            ))
+        })?;
+
+        let mut params_bytes = vec![0_u8; params_buf_bytes_usize];
+        for s in 0..log2_size {
+            let params = ShaderParams {
+                pass_s: s,
+                size: size_u32,
+            };
+            let start = (s * params_stride) as usize;
+            let end = start + std::mem::size_of::<ShaderParams>();
+            params_bytes[start..end].copy_from_slice(bytemuck::bytes_of(&params));
+        }
+        let params_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("sdr-dsp GPU FFT params"),
+            size: params_buf_bytes,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&params_buf, 0, &params_bytes);
+
+        Ok((params_buf, params_stride))
+    }
+
+    /// Build the single compute pipeline + its bind group layout.
+    /// The pipeline is reused across every pass.
+    fn build_pipeline(device: &wgpu::Device) -> (wgpu::ComputePipeline, wgpu::BindGroupLayout) {
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("sdr-dsp GPU FFT bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: wgpu::BufferSize::new(PARAMS_SIZE_BYTES),
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("sdr-dsp GPU FFT shader"),
+            source: wgpu::ShaderSource::Wgsl(SHADER_SRC.into()),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("sdr-dsp GPU FFT pipeline layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("sdr-dsp GPU FFT pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            cache: None,
+        });
+
+        (pipeline, bind_group_layout)
+    }
+
+    async fn build_async(size: usize, opts: &GpuFftOptions) -> Result<Self, DspError> {
+        let (device, queue, adapter_summary) = Self::acquire_device(opts).await?;
+
+        // Buffer sizing. Each complex point is two f32s = 8 bytes.
+        let buffer_bytes = (size as u64)
+            .checked_mul(std::mem::size_of::<Complex>() as u64)
+            .ok_or_else(|| {
+                DspError::InvalidParameter(format!("FFT size {size} overflows buffer bytes"))
+            })?;
+
+        let buf_a = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("sdr-dsp GPU FFT buf_a"),
+            size: buffer_bytes,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let buf_b = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("sdr-dsp GPU FFT buf_b"),
+            size: buffer_bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("sdr-dsp GPU FFT staging"),
+            size: buffer_bytes,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let log2_size = size.trailing_zeros();
+        let (params_buf, params_stride) =
+            Self::build_params_buffer(&device, &queue, size, log2_size)?;
+        let (pipeline, bind_group_layout) = Self::build_pipeline(&device);
+
+        // Two bind groups — alternating which ping-pong buffer is
+        // read-only (src) vs read-write (dst). Both share the same
+        // dynamic-offset uniform binding.
+        let make_bg = |label: &str, src: &wgpu::Buffer, dst: &wgpu::Buffer| -> wgpu::BindGroup {
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some(label),
+                layout: &bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &params_buf,
+                            offset: 0,
+                            size: wgpu::BufferSize::new(PARAMS_SIZE_BYTES),
+                        }),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: src.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: dst.as_entire_binding(),
+                    },
+                ],
+            })
+        };
+        let params_bg_a = make_bg("sdr-dsp GPU FFT bg (read A, write B)", &buf_a, &buf_b);
+        let params_bg_b = make_bg("sdr-dsp GPU FFT bg (read B, write A)", &buf_b, &buf_a);
+
+        let butterflies_per_pass = size / 2;
+        let workgroup_count = u32::try_from(
+            butterflies_per_pass.div_ceil(SHADER_WORKGROUP_SIZE as usize),
+        )
+        .map_err(|_| {
+            DspError::InvalidParameter(format!(
+                "FFT size {size} produces too many workgroups for u32 dispatch"
+            ))
+        })?;
+
+        // Last pass is `log2_size - 1` (0-indexed). After an even
+        // number of total passes, result is back in `buf_a`
+        // (pass 0 A→B, pass 1 B→A, pass 2 A→B, ...).
+        let output_in_buf_a = log2_size.is_multiple_of(2);
+
+        debug!(
+            target: "sdr_dsp::gpu_fft",
+            size = size,
+            log2_size = log2_size,
+            buffer_bytes = buffer_bytes,
+            params_stride = params_stride,
+            workgroup_count = workgroup_count,
+            output_in_buf_a = output_in_buf_a,
+            "GPU FFT engine ready"
+        );
+
+        Ok(Self {
+            adapter_summary,
+            device,
+            queue,
+            pipeline,
+            buf_a,
+            buf_b,
+            params_bg_a,
+            params_bg_b,
+            params_stride,
+            staging,
+            size,
+            log2_size,
+            workgroup_count,
+            output_in_buf_a,
+        })
+    }
+}
+
+impl FftEngine for GpuFftEngine {
+    fn forward(&mut self, buf: &mut [Complex]) -> Result<(), DspError> {
+        if buf.len() != self.size {
+            return Err(DspError::BufferTooSmall {
+                need: self.size,
+                got: buf.len(),
+            });
+        }
+
+        // 1. Upload input into buf_a.
+        self.queue
+            .write_buffer(&self.buf_a, 0, bytemuck::cast_slice(buf));
+
+        // 2. Encode log2(N) compute dispatches, alternating bind
+        //    groups so the ping-pong reads/writes flow correctly.
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("sdr-dsp GPU FFT encoder"),
+            });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("sdr-dsp GPU FFT compute pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            for s in 0..self.log2_size {
+                let bg = if s % 2 == 0 {
+                    &self.params_bg_a
+                } else {
+                    &self.params_bg_b
+                };
+                let dynamic_offset = s * self.params_stride;
+                pass.set_bind_group(0, bg, &[dynamic_offset]);
+                pass.dispatch_workgroups(self.workgroup_count, 1, 1);
+            }
+        }
+
+        // 3. Copy final buffer to staging for readback.
+        let final_buf = if self.output_in_buf_a {
+            &self.buf_a
+        } else {
+            &self.buf_b
+        };
+        let buffer_bytes = (self.size * std::mem::size_of::<Complex>()) as u64;
+        encoder.copy_buffer_to_buffer(final_buf, 0, &self.staging, 0, buffer_bytes);
+
+        self.queue.submit(std::iter::once(encoder.finish()));
+
+        // 4. Map staging synchronously (blocks the calling thread
+        //    via device.poll(Wait) inside wgpu-core).
+        let slice = self.staging.slice(..);
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        slice.map_async(wgpu::MapMode::Read, move |res| {
+            // Ignore send errors — the receiver side always drains
+            // exactly once on the same thread, so the channel
+            // can't be closed before we post.
+            let _ = tx.send(res);
+        });
+        self.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .map_err(|e| DspError::GpuUnavailable(format!("device poll failed: {e}")))?;
+        rx.recv()
+            .map_err(|e| DspError::GpuUnavailable(format!("staging map channel: {e}")))?
+            .map_err(|e| DspError::GpuUnavailable(format!("staging map failed: {e}")))?;
+
+        // 5. Copy mapped bytes into the caller's buffer.
+        let data = slice.get_mapped_range();
+        let as_complex: &[Complex] = bytemuck::cast_slice(&data);
+        buf.copy_from_slice(as_complex);
+        drop(data);
+        self.staging.unmap();
+
+        Ok(())
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fft::RustFftEngine;
+
+    /// Max allowed normalized L2 error between GPU and CPU spectra:
+    ///
+    ///     sum((gpu - cpu)^2) / sum(cpu^2)  <  PARITY_REL_L2_TOL
+    ///
+    /// A single-scalar comparison averages out the per-bin f32
+    /// rounding noise that diverges between rustfft (scalar SIMD)
+    /// and the GPU (vendor-specific cos/sin polynomial + possibly
+    /// contracted FMAs). Per-bin absolute tolerance is a trap at
+    /// high FFT sizes — bin magnitudes scale with √N so any fixed
+    /// threshold either accepts nonsense at 65536 or rejects real
+    /// parity at 2048. The relative L2 form is scale-invariant.
+    ///
+    /// 1e-4 is tight enough to catch an algorithmic bug (off-by-one
+    /// in pass indexing, wrong twiddle sign, bit-reversal mistake)
+    /// and loose enough to tolerate FMA / polynomial-sin/cos
+    /// divergence across backends.
+    const PARITY_REL_L2_TOL: f32 = 1e-4;
+
+    fn rand_like(n: usize, seed: f32) -> Vec<Complex> {
+        (0..n)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f32;
+                // A mix of two sinusoids keeps every bin non-trivial
+                // — energy scattered across the spectrum instead of
+                // a single bright peak.
+                Complex {
+                    re: (t * 0.011 + seed).sin() + 0.5 * (t * 0.073).cos(),
+                    im: (t * 0.019 + seed).cos() - 0.3 * (t * 0.041).sin(),
+                }
+            })
+            .collect()
+    }
+
+    fn try_gpu_engine(size: usize) -> Option<GpuFftEngine> {
+        match GpuFftEngine::new(size) {
+            Ok(engine) => Some(engine),
+            Err(DspError::GpuUnavailable(msg)) => {
+                eprintln!("skipping GPU parity test at size={size}: {msg}");
+                None
+            }
+            // Any non-"GPU missing" construction failure is a real
+            // bug. `unreachable!` keeps clippy's `panic` lint
+            // quiet and also documents that the only non-
+            // `GpuUnavailable` errors that can get here would
+            // indicate a regression in parameter validation.
+            Err(e) => unreachable!("unexpected GPU FFT construction error at size={size}: {e}"),
+        }
+    }
+
+    fn assert_parity(size: usize) {
+        let Some(mut gpu) = try_gpu_engine(size) else {
+            return;
+        };
+        let mut cpu = RustFftEngine::new(size).expect("CPU FFT");
+
+        let input = rand_like(size, 1.5);
+        let mut gpu_buf = input.clone();
+        let mut cpu_buf = input;
+
+        gpu.forward(&mut gpu_buf).expect("GPU forward");
+        cpu.forward(&mut cpu_buf).expect("CPU forward");
+
+        // Normalized L2 error — see PARITY_REL_L2_TOL rationale.
+        let mut err_sq = 0.0_f64;
+        let mut ref_sq = 0.0_f64;
+        for (g, c) in gpu_buf.iter().zip(cpu_buf.iter()) {
+            let dr = f64::from(g.re - c.re);
+            let di = f64::from(g.im - c.im);
+            err_sq += dr * dr + di * di;
+            let cr = f64::from(c.re);
+            let ci = f64::from(c.im);
+            ref_sq += cr * cr + ci * ci;
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let rel = (err_sq / ref_sq.max(f64::MIN_POSITIVE)) as f32;
+        assert!(
+            rel < PARITY_REL_L2_TOL,
+            "size={size} relative L2 error {rel:.3e} exceeds tolerance {PARITY_REL_L2_TOL:.0e}"
+        );
+    }
+
+    #[test]
+    fn parity_2048() {
+        assert_parity(2048);
+    }
+
+    #[test]
+    fn parity_8192() {
+        assert_parity(8192);
+    }
+
+    #[test]
+    fn parity_65536() {
+        assert_parity(65_536);
+    }
+
+    #[test]
+    fn rejects_non_power_of_two() {
+        // 1000 isn't a power of two, should fail param validation
+        // before even touching the GPU — so this test is safe on
+        // CI runners without a GPU.
+        let err = GpuFftEngine::new(1000).expect_err("must reject");
+        assert!(
+            matches!(err, DspError::InvalidParameter(_)),
+            "expected InvalidParameter, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_size_one() {
+        let err = GpuFftEngine::new(1).expect_err("must reject");
+        assert!(
+            matches!(err, DspError::InvalidParameter(_)),
+            "expected InvalidParameter, got {err:?}"
+        );
+    }
+}

--- a/crates/sdr-dsp/src/gpu_fft.wgsl
+++ b/crates/sdr-dsp/src/gpu_fft.wgsl
@@ -1,0 +1,92 @@
+// Stockham autosort radix-2 forward FFT, one pass per dispatch.
+//
+// Epic #452 / #179. See `gpu_fft.rs` for the host-side scaffolding
+// and algorithm notes. This shader is intentionally minimal:
+// every per-pass detail (which pass index, total size) comes in
+// via the `Params` uniform so the host can reuse the same pipeline
+// for all `log2(N)` passes.
+//
+// Why Stockham (not in-place Cooley-Tukey): the in-place variant
+// needs an explicit bit-reversal permutation, which is ugly to
+// parallelize on GPU. Stockham ping-pongs between two buffers
+// and writes the combined subFFT contiguously on each pass, so
+// the output of pass `s` is already in "natural" ordering for
+// pass `s+1` to consume. No permutation pass, no scatter/gather.
+//
+// Pass `s` (0 ≤ s < log2(N)) takes `src` in "stride-N/2" layout
+// and writes `dst` in "contiguous subFFT of size 2^(s+1)" layout:
+//
+//   L = 2^(s+1)            // size of output subFFTs after this pass
+//   m = L / 2 = 2^s        // size of input subFFTs before this pass
+//   j = bfly >> s          // which group of paired subFFTs
+//   k = bfly & (m - 1)     // position within one butterfly group
+//
+//   a = src[j*m + k]
+//   b = src[j*m + k + N/2]
+//   W = exp(-2πi * k / L)                 (forward DFT twiddle)
+//   dst[j*L + k]     = a + W*b
+//   dst[j*L + k + m] = a - W*b
+//
+// Total butterflies per pass = N/2 (one per workitem).
+
+struct Params {
+    // Which pass of the `log2(N)` sequence this dispatch runs.
+    pass_s: u32,
+    // Total number of complex points (power of two).
+    size: u32,
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read>       src: array<vec2<f32>>;
+@group(0) @binding(2) var<storage, read_write> dst: array<vec2<f32>>;
+
+fn complex_mul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
+    // (a.re + i*a.im) * (b.re + i*b.im) expanded.
+    return vec2<f32>(
+        a.x * b.x - a.y * b.y,
+        a.x * b.y + a.y * b.x,
+    );
+}
+
+// 64 threads/workgroup — the common sweet-spot for compute
+// shaders that have to run well on NVIDIA (warp = 32, 2 warps),
+// AMD RDNA (wavefront = 32), AMD GCN (wavefront = 64), and Intel
+// iGPUs. No dependence on subgroup size.
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let bfly = gid.x;
+    let half_n = params.size >> 1u;
+    if (bfly >= half_n) {
+        return;
+    }
+
+    let m: u32 = 1u << params.pass_s;     // == 2^s
+    let l: u32 = m << 1u;                 // == 2^(s+1)
+    let mask_m: u32 = m - 1u;             // == 2^s - 1 (zero when m == 1)
+
+    // Split the flat butterfly index into (group, within-group).
+    let j: u32 = bfly >> params.pass_s;
+    let k: u32 = bfly & mask_m;
+
+    // Stockham invariant: src reads always stride by N/2,
+    // regardless of pass. Only dst writes change their stride
+    // (by `m`, which doubles each pass).
+    let src_lo = j * m + k;
+    let src_hi = src_lo + half_n;
+    let a = src[src_lo];
+    let b = src[src_hi];
+
+    // Forward-DFT twiddle: W_L^k = exp(-2πi * k / L).
+    // Using `radians = -2π·k / L` keeps the angle math in f32;
+    // the cos/sin lookup is a single pair of hardware fast-math
+    // calls on every GPU architecture we care about.
+    let two_pi: f32 = 6.283185307179586;
+    let angle: f32 = -two_pi * f32(k) / f32(l);
+    let tw = vec2<f32>(cos(angle), sin(angle));
+    let wb = complex_mul(tw, b);
+
+    let dst_lo = j * l + k;
+    let dst_hi = dst_lo + m;
+    dst[dst_lo] = a + wb;
+    dst[dst_hi] = a - wb;
+}

--- a/crates/sdr-dsp/src/lib.rs
+++ b/crates/sdr-dsp/src/lib.rs
@@ -14,6 +14,7 @@ pub mod decim_taps;
 pub mod demod;
 pub mod fft;
 pub mod filter;
+pub mod gpu_fft;
 pub mod loops;
 pub mod math;
 pub mod multirate;

--- a/crates/sdr-types/src/error.rs
+++ b/crates/sdr-types/src/error.rs
@@ -5,6 +5,13 @@ pub enum DspError {
     InvalidParameter(String),
     #[error("buffer too small: need {need}, got {got}")]
     BufferTooSmall { need: usize, got: usize },
+    /// GPU-backed DSP path failed to initialise or run. Covers "no
+    /// compatible adapter", "device request failed", "shader
+    /// compile rejected by driver", and mid-transform mapping
+    /// failures. Carries a human-readable message so the caller
+    /// can log it or fall back to a CPU engine.
+    #[error("gpu unavailable: {0}")]
+    GpuUnavailable(String),
 }
 
 /// Errors from pipeline/streaming operations.


### PR DESCRIPTION
## Summary

Phase 2 of epic #452 / ticket #179. Lands the wgpu-backed FFT engine behind the same \`FftEngine\` trait as \`RustFftEngine\`, plus a companion Criterion bench that mirrors \`benches/fft.rs\` for direct comparison.

**Algorithm:** Stockham autosort radix-2, out-of-place, one compute dispatch per pass. \`log2(N)\` dispatches per transform, ping-pong between two storage buffers. No bit-reversal permutation pass — Stockham's contiguous-output layout produces natural ordering after the last pass.

**Pre-allocation discipline:** everything (device, queue, pipeline, both ping-pong buffers, staging download buffer, both bind groups, and the full per-pass uniform array) is created in \`GpuFftEngine::with_options\`. \`forward()\` does upload → N dispatches → blocking readback with zero allocations.

## Public surface

- \`sdr_dsp::gpu_fft::GpuFftEngine\` (impl \`FftEngine\`)
- \`sdr_dsp::gpu_fft::GpuFftOptions\` — \`{ power_preference, backends, force_fallback_adapter }\`
- \`sdr_dsp::gpu_fft::AdapterSummary\` — read-only telemetry so the bench can print which GPU ran
- \`sdr_types::DspError::GpuUnavailable(String)\` — new variant covering any GPU init or mid-transform failure

## Phase-2 numbers

Median, release build, dev machine, Linux + Vulkan:

| size  | CPU (rustfft) | GPU 4080S | GPU AMD 780M iGPU |
|-------|---------------|-----------|-------------------|
| 2048  | **3.54 µs**   | 83.70 µs  | 130.14 µs         |
| 8192  | **11.84 µs**  | 117.88 µs | 157.47 µs         |
| 65536 | **143.47 µs** | 373.46 µs | 445.19 µs         |

**GPU loses at every size on every adapter measured.** Root cause is dispatch submission overhead: Stockham = log2(N) sequential compute dispatches × ~10-20 µs driver scheduling per dispatch. At 65536 points we spend ~200 µs of pure overhead, exceeding the ~126 µs CPU compute budget before any actual work happens.

The trend is unambiguous, though — each doubling of N halves the GPU's relative disadvantage. Projecting: GPU would match CPU around N=131K-262K and win above N=524K, but those sizes aren't in the SDR workload.

**Phase 2b escalation** is the single-dispatch variant using subgroup primitives (wgpu \`SUBGROUP\` feature gate), which collapses the log2(N) dispatches into one and should eliminate the overhead ceiling. Left as a follow-up ticket once this infrastructure lands — that's what this PR delivers.

## Why still land this

- The GPU engine is **numerically correct** — all 5 parity tests pass at 2048 / 8192 / 65536 via scale-invariant relative-L2 error comparison against \`RustFftEngine\`
- The bench harness **mirrors CPU one-for-one** so #181 (GPU FIR) and #180 (GPU waterfall) get a template for their own comparison benches
- \`DspError::GpuUnavailable\` unblocks the other sub-tickets too
- The "trail" of how we got to a shipping GPU path lives in git history, not a separate doc

**Does NOT wire into \`IqFrontend\` runtime** — runtime engine selection is a follow-up once Phase 2b shows a real speedup. At current numbers, shipping this as the default would be a regression.

## Deps

- New workspace deps: \`wgpu=29\`, \`pollster=0.4\`
- \`bytemuck\` + \`tracing\` pulled into \`sdr-dsp\`'s main dep set (both already workspace-level)

## Adapter selection

For the multi-GPU matrix on the dev machine (4080 Super / 3090 / 780M iGPU):

\`\`\`
cargo bench -p sdr-dsp --bench fft_gpu                          # default high-perf (picks 4080S)
SDR_GPU_ADAPTER=low cargo bench -p sdr-dsp --bench fft_gpu      # picks 780M iGPU
SDR_GPU_ADAPTER=fallback cargo bench -p sdr-dsp --bench fft_gpu # software fallback
SDR_GPU_BACKEND=vulkan cargo bench -p sdr-dsp --bench fft_gpu   # force Vulkan
\`\`\`

3090-specific selection needs an enumerate-by-name path that's not in this PR (both discrete cards are \`HighPerformance\`, and wgpu picks whichever the driver lists first). Filed as follow-up for Phase 2b.

## Test plan

- [x] \`cargo test -p sdr-dsp --lib gpu_fft\` — 5/5 parity tests pass on 4080S
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo bench -p sdr-dsp --bench fft_gpu\` — runs end-to-end, captures numbers above
- [x] \`SDR_GPU_ADAPTER=low cargo bench -p sdr-dsp --bench fft_gpu\` — runs on AMD iGPU

Refs #452. Does not close #179 — the ticket is open until Phase 2b lands a shipping speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU-accelerated Fast Fourier Transform (FFT) computation support added to the signal processing engine
  * GPU adapter selection configurable through environment variables for backend and power preference settings
  * New benchmarking tools for measuring and comparing GPU FFT performance across different input sizes
  * Improved error messaging for GPU unavailability scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->