### PR TITLE
sdr-ui: FSPL distance estimator in the Radio panel (closes #164)

### DIFF
--- a/crates/sdr-dsp/src/lib.rs
+++ b/crates/sdr-dsp/src/lib.rs
@@ -19,6 +19,7 @@ pub mod loops;
 pub mod math;
 pub mod multirate;
 pub mod noise;
+pub mod propagation;
 pub mod stereo;
 pub mod taps;
 pub mod tone_detect;

--- a/crates/sdr-dsp/src/propagation.rs
+++ b/crates/sdr-dsp/src/propagation.rs
@@ -1,0 +1,269 @@
+//! Free-space path loss and signal-to-distance conversions.
+//!
+//! Implements the textbook FSPL (Free-Space Path Loss) formula:
+//!
+//! ```text
+//! FSPL(dB) = 20·log10(d) + 20·log10(f) - 147.55
+//! ```
+//!
+//! Where `d` is distance in metres, `f` is frequency in Hz, and the
+//! constant `147.55` is `20·log10(c / 4π)` with c = 299 792 458 m/s.
+//! Solving for distance given a measured path loss:
+//!
+//! ```text
+//! d = 10 ^ ((FSPL - 20·log10(f) + 147.55) / 20)
+//! ```
+//!
+//! # Caveats
+//!
+//! FSPL is the **idealised line-of-sight** loss between two isotropic
+//! antennas in free space — no terrain, no buildings, no multipath,
+//! no atmospheric effects, no antenna directivity. Real-world receive
+//! levels generally drop off faster than ideal FSPL because of
+//! obstructions and diffraction, so a distance estimate computed
+//! with these helpers should be read as an **upper bound**
+//! ("the transmitter is *at most* this far away for this received
+//! level") rather than a ranging measurement.
+//!
+//! Pure-math module — no threading, no I/O, no allocation.
+
+use std::f64::consts::PI;
+
+/// Speed of light in m/s. Exact by definition.
+const C_M_PER_S: f64 = 299_792_458.0;
+
+/// The FSPL additive constant, `20·log10(c / 4π)`.
+///
+/// Computing this once at module-const time rather than every call.
+/// The value is approximately 147.55 dB — what you'll see in RF
+/// engineering tables. We evaluate it analytically here so the
+/// formulas match any textbook derivation precisely.
+///
+/// `const fn`-free because `log10` isn't a const-fn; we compute it
+/// lazily via `Lazy` in a helper accessor instead of forcing the
+/// computation inline every call.
+#[inline]
+fn fspl_constant_db() -> f64 {
+    // 20 · log10(c / (4π))
+    20.0 * (C_M_PER_S / (4.0 * PI)).log10()
+}
+
+/// Convert transmitter output power from watts to dBm.
+///
+/// Definition: `P(dBm) = 10·log10(P_mW)`, so for watts the formula is
+/// `10·log10(P_watts · 1000) = 30 + 10·log10(P_watts)`. Handy for
+/// ERP comparisons since radio handheld specs are usually in watts
+/// but the FSPL formula wants dBm.
+///
+/// Returns `f64::NEG_INFINITY` for non-positive watts — physically
+/// "infinite attenuation", which makes downstream `fspl_distance_m`
+/// return zero distance (the sensible thing for "no transmitter").
+#[must_use]
+pub fn watts_to_dbm(watts: f64) -> f64 {
+    if watts <= 0.0 {
+        return f64::NEG_INFINITY;
+    }
+    30.0 + 10.0 * watts.log10()
+}
+
+/// Convert power from dBm back to watts.
+///
+/// Inverse of [`watts_to_dbm`].
+#[must_use]
+pub fn dbm_to_watts(dbm: f64) -> f64 {
+    10_f64.powf((dbm - 30.0) / 10.0)
+}
+
+/// Compute FSPL in dB for a given distance and frequency.
+///
+/// Primarily a building block for tests and for sanity-checking
+/// round-trips against [`fspl_distance_m`]. Callers doing distance
+/// estimation should use [`fspl_distance_m`] directly.
+///
+/// Returns `f64::NAN` for non-positive `distance_m` or
+/// `frequency_hz` — both are non-physical inputs and we'd rather
+/// propagate NaN than silently return a misleading number.
+#[must_use]
+pub fn fspl_db(distance_m: f64, frequency_hz: f64) -> f64 {
+    if distance_m <= 0.0 || frequency_hz <= 0.0 {
+        return f64::NAN;
+    }
+    20.0 * distance_m.log10() + 20.0 * frequency_hz.log10() - fspl_constant_db()
+}
+
+/// Estimate distance (metres) from the path loss implied by
+/// transmitter ERP, received signal level, and carrier frequency.
+///
+/// `erp_dbm` is the effective radiated power at the transmitter
+/// (see [`watts_to_dbm`] for converting specs from watts). The
+/// implied path loss is `erp_dbm - received_dbm`, and the inverse
+/// FSPL formula maps that loss + frequency to a distance.
+///
+/// Returns `0.0` when the received signal is at or above the
+/// transmitter's own output (physically impossible under FSPL,
+/// implies either miscalibration or near-field coupling), and
+/// `f64::NAN` for non-finite or non-positive frequency.
+///
+/// ```
+/// use sdr_dsp::propagation::{fspl_distance_m, watts_to_dbm};
+///
+/// // A 50 W FM broadcast at 155 MHz received at -90 dBm should be
+/// // estimated at roughly 1000 km under idealised line-of-sight
+/// // conditions (real-world much less due to terrain / multipath).
+/// let erp = watts_to_dbm(50.0);
+/// let d = fspl_distance_m(erp, -90.0, 155e6);
+/// assert!(d > 100_000.0 && d < 10_000_000.0);
+/// ```
+#[must_use]
+pub fn fspl_distance_m(erp_dbm: f64, received_dbm: f64, frequency_hz: f64) -> f64 {
+    if !frequency_hz.is_finite() || frequency_hz <= 0.0 {
+        return f64::NAN;
+    }
+    if !erp_dbm.is_finite() || !received_dbm.is_finite() {
+        return f64::NAN;
+    }
+
+    let path_loss_db = erp_dbm - received_dbm;
+    if path_loss_db <= 0.0 {
+        return 0.0;
+    }
+
+    // d = 10 ^ ((FSPL - 20·log10(f) + 147.55) / 20)
+    let exponent = (path_loss_db - 20.0 * frequency_hz.log10() + fspl_constant_db()) / 20.0;
+    10_f64.powf(exponent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tolerance for direct formula comparisons (the additive
+    /// constant is about 147.5517 dB depending on how many digits
+    /// you carry, so references from tables to three decimals land
+    /// within this).
+    const DB_TOL: f64 = 0.01;
+
+    /// Tolerance for distance round-trips — `10^x` with f64
+    /// round-trips introduce bit-level drift; one part in 1e-9 is
+    /// plenty.
+    const DIST_REL_TOL: f64 = 1e-9;
+
+    #[test]
+    fn fspl_constant_matches_textbook() {
+        // 20·log10(c / 4π) ≈ 147.55 dB. Exact value with the defined
+        // speed of light is 147.5517...; any decent reference gives
+        // 147.55 to two decimals.
+        let k = fspl_constant_db();
+        assert!(
+            (k - 147.55).abs() < 0.01,
+            "FSPL constant {k} deviates from textbook 147.55"
+        );
+    }
+
+    #[test]
+    fn watts_dbm_round_trip() {
+        for &watts in &[0.001, 0.1, 1.0, 5.0, 25.0, 50.0, 100.0, 1000.0] {
+            let dbm = watts_to_dbm(watts);
+            let back = dbm_to_watts(dbm);
+            let rel_err = (back - watts).abs() / watts;
+            assert!(
+                rel_err < 1e-12,
+                "watts round-trip failed: {watts} → {dbm} dBm → {back} W (rel err {rel_err:e})"
+            );
+        }
+    }
+
+    #[test]
+    fn watts_to_dbm_anchors() {
+        // Common reference points every RF engineer has memorised.
+        // 1 W = 30 dBm, 1 mW = 0 dBm, 100 W = 50 dBm.
+        assert!((watts_to_dbm(1.0) - 30.0).abs() < DB_TOL);
+        assert!((watts_to_dbm(0.001) - 0.0).abs() < DB_TOL);
+        assert!((watts_to_dbm(100.0) - 50.0).abs() < DB_TOL);
+    }
+
+    #[test]
+    fn watts_to_dbm_edge_cases() {
+        // Zero or negative input → −∞ (no transmitter). Using
+        // `is_infinite` + `is_sign_negative` rather than direct
+        // float compare to keep clippy's `float_cmp` lint happy
+        // while still asserting the exact sentinel.
+        assert!(watts_to_dbm(0.0).is_infinite() && watts_to_dbm(0.0).is_sign_negative());
+        assert!(watts_to_dbm(-1.0).is_infinite() && watts_to_dbm(-1.0).is_sign_negative());
+    }
+
+    #[test]
+    fn fspl_db_anchors() {
+        // At 100 MHz and 1 m: 20·log10(1) = 0, 20·log10(1e8) = 160,
+        // so FSPL = 0 + 160 - 147.55 = 12.45 dB.
+        let loss = fspl_db(1.0, 100e6);
+        assert!(
+            (loss - 12.45).abs() < DB_TOL,
+            "expected ~12.45 dB at 100 MHz / 1 m, got {loss}"
+        );
+
+        // At 1 GHz and 10 km: 20·log10(1e4) = 80, 20·log10(1e9) = 180,
+        // FSPL = 80 + 180 - 147.55 = 112.45 dB.
+        let loss = fspl_db(10_000.0, 1e9);
+        assert!(
+            (loss - 112.45).abs() < DB_TOL,
+            "expected ~112.45 dB at 1 GHz / 10 km, got {loss}"
+        );
+    }
+
+    #[test]
+    fn fspl_round_trip_distance_to_loss_to_distance() {
+        // For a range of frequencies and distances, compute the
+        // loss, then recover the distance from the loss, and
+        // confirm we recover the original distance.
+        for &freq in &[50e6, 155e6, 446e6, 1.575e9, 2.4e9] {
+            for &d in &[1.0_f64, 100.0, 1_000.0, 50_000.0, 1e6] {
+                let loss = fspl_db(d, freq);
+                // Treat the path loss as (erp - received) with
+                // erp = 0 dBm (so received = -loss dBm).
+                let d_back = fspl_distance_m(0.0, -loss, freq);
+                let rel = (d_back - d).abs() / d;
+                assert!(
+                    rel < DIST_REL_TOL,
+                    "round-trip failed at f={freq}, d={d}: got {d_back} (rel err {rel:e})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fspl_distance_rejects_non_physical_inputs() {
+        // Non-positive frequency → NaN.
+        assert!(fspl_distance_m(30.0, -80.0, 0.0).is_nan());
+        assert!(fspl_distance_m(30.0, -80.0, -1.0).is_nan());
+
+        // Non-finite powers → NaN.
+        assert!(fspl_distance_m(f64::NAN, -80.0, 100e6).is_nan());
+        assert!(fspl_distance_m(30.0, f64::NAN, 100e6).is_nan());
+        assert!(fspl_distance_m(f64::INFINITY, -80.0, 100e6).is_nan());
+
+        // Received ≥ transmitted → physically impossible FSPL.
+        // Return 0 rather than a negative or NaN distance so the
+        // UI can treat this as "calibration issue" gracefully.
+        // `< f64::EPSILON` instead of `== 0.0` because clippy's
+        // `float_cmp` lint doesn't allow direct equality on
+        // floats even when we know the value is exactly zero.
+        assert!(fspl_distance_m(30.0, 30.0, 100e6) < f64::EPSILON);
+        assert!(fspl_distance_m(30.0, 40.0, 100e6) < f64::EPSILON);
+    }
+
+    #[test]
+    fn public_safety_vhf_scenario() {
+        // Textbook scenario from the ticket: 50 W transmitter at
+        // VHF (155 MHz), received at -90 dBm. Expected distance
+        // under ideal FSPL is ~1100 km. This is a sanity check
+        // that the output is in the right ball-park for a
+        // reader spot-checking the feature.
+        let erp = watts_to_dbm(50.0);
+        let d = fspl_distance_m(erp, -90.0, 155e6);
+        assert!(
+            (500_000.0..2_000_000.0).contains(&d),
+            "expected 500 km - 2 Mm for 50W @ 155 MHz @ -90 dBm FSPL, got {d} m"
+        );
+    }
+}

--- a/crates/sdr-dsp/src/propagation.rs
+++ b/crates/sdr-dsp/src/propagation.rs
@@ -34,14 +34,15 @@ const C_M_PER_S: f64 = 299_792_458.0;
 
 /// The FSPL additive constant, `20·log10(c / 4π)`.
 ///
-/// Computing this once at module-const time rather than every call.
 /// The value is approximately 147.55 dB — what you'll see in RF
 /// engineering tables. We evaluate it analytically here so the
 /// formulas match any textbook derivation precisely.
 ///
-/// `const fn`-free because `log10` isn't a const-fn; we compute it
-/// lazily via `Lazy` in a helper accessor instead of forcing the
-/// computation inline every call.
+/// Not a `const` because `f64::log10` isn't `const fn`. The
+/// arithmetic is cheap (one division + one `log10`) and nothing
+/// here is a hot path — FSPL is called at most once per FFT
+/// display frame (~60 Hz), so skipping a `OnceCell` dep and just
+/// recomputing inline keeps the code simpler at negligible cost.
 #[inline]
 fn fspl_constant_db() -> f64 {
     // 20 · log10(c / (4π))

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -1,7 +1,11 @@
 //! Radio / demodulator configuration panel — bandwidth, squelch, de-emphasis.
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use libadwaita as adw;
 use libadwaita::prelude::*;
+use sdr_dsp::propagation::{fspl_distance_m, watts_to_dbm};
 use sdr_dsp::tone_detect::{CTCSS_DEFAULT_THRESHOLD, CTCSS_TONES_HZ};
 use sdr_dsp::voice_squelch::{
     VOICE_SQUELCH_SNR_DEFAULT_THRESHOLD_DB, VOICE_SQUELCH_SYLLABIC_DEFAULT_THRESHOLD,
@@ -94,6 +98,59 @@ const CTCSS_THRESHOLD_STEP: f64 = 0.01;
 /// Page step (scroll / page-down).
 const CTCSS_THRESHOLD_PAGE: f64 = 0.05;
 
+// ─── Distance estimator (FSPL) tuning ────────────────────────
+//
+// Config keys for the two user-settable inputs (ticket #164).
+// Persisted as top-level entries in the main JSON config rather
+// than inside a bookmark's `TuningProfile` because ERP and
+// receiver calibration are properties of the station + receiver
+// setup, not per-channel: a user's antenna/receiver chain has one
+// calibration offset, and typical usage is to dial in a known
+// transmitter's power once and estimate distances for whatever
+// channel they're on.
+
+/// Config key for the FSPL distance estimator's transmitter ERP,
+/// stored as watts. Public so `window.rs` can persist the row's
+/// value without re-typing the literal.
+pub const KEY_RADIO_DISTANCE_ERP_WATTS: &str = "radio_distance_erp_watts";
+
+/// Config key for the FSPL distance estimator's receiver
+/// calibration offset, stored as dB.
+pub const KEY_RADIO_DISTANCE_CALIBRATION_DB: &str = "radio_distance_calibration_db";
+
+// Transmitter effective radiated power (ERP) bounds. 25 W is a
+// reasonable default — most mobile public-safety radios (police,
+// fire, EMS) ship at 25-50 W, handhelds at 1-5 W, broadcast
+// transmitters up to ~100 kW. The spin row covers the useful
+// range without restricting experimentation.
+
+/// Default transmitter ERP in watts.
+const DEFAULT_ERP_WATTS: f64 = 25.0;
+/// Minimum ERP. Below this a user is probably mis-typing.
+const MIN_ERP_WATTS: f64 = 0.001;
+/// Maximum ERP — covers high-power FM broadcast.
+const MAX_ERP_WATTS: f64 = 100_000.0;
+/// Step size for small-knob tuning.
+const ERP_STEP_WATTS: f64 = 1.0;
+/// Page step for the scroll / page-down keys.
+const ERP_PAGE_WATTS: f64 = 10.0;
+
+/// Default receiver-chain calibration offset in dB. The FSPL
+/// formula assumes the received level in dBm is calibrated — most
+/// RTL-SDRs report relative dBFS with an arbitrary reference, so
+/// this slider lets the user dial in an offset until a known
+/// reference signal's distance reads correctly.
+const DEFAULT_CALIBRATION_DB: f64 = 0.0;
+/// Minimum calibration offset. ±30 dB covers every reasonable
+/// RTL-SDR reference-level scenario we've seen.
+const MIN_CALIBRATION_DB: f64 = -30.0;
+/// Maximum calibration offset.
+const MAX_CALIBRATION_DB: f64 = 30.0;
+/// Calibration offset step.
+const CALIBRATION_STEP_DB: f64 = 0.5;
+/// Calibration offset page step.
+const CALIBRATION_PAGE_DB: f64 = 5.0;
+
 /// Default squelch level in dB.
 const DEFAULT_SQUELCH_DB: f64 = -100.0;
 /// Minimum squelch level in dB.
@@ -180,6 +237,27 @@ pub struct RadioPanel {
     /// from `DspToUi::VoiceSquelchOpenChanged` via
     /// [`Self::set_voice_squelch_open`].
     pub voice_squelch_status_row: adw::ActionRow,
+    /// Transmitter effective radiated power (watts) — input to the
+    /// FSPL distance estimator. Persisted to config.
+    pub erp_row: adw::SpinRow,
+    /// Receiver calibration offset (dB). Shifts the raw signal
+    /// level before computing path loss. Persisted to config.
+    pub calibration_row: adw::SpinRow,
+    /// Read-only display row whose subtitle shows the current
+    /// distance estimate. Value set by [`Self::update_distance_display`].
+    pub distance_row: adw::ActionRow,
+    /// Cached most-recent signal level (dB). Used by the ERP /
+    /// calibration value-changed handlers so the distance display
+    /// refreshes immediately when the user tweaks a knob, even if
+    /// no new `SignalLevel` message arrives in between.
+    ///
+    /// `Rc<Cell<_>>` (not plain `Cell<_>`) so that cloning
+    /// `RadioPanel` shares the cache across clones — the derive
+    /// on plain `Cell` would produce disconnected caches.
+    pub distance_last_signal_db: Rc<Cell<Option<f32>>>,
+    /// Cached most-recent tuner centre frequency (Hz). Same
+    /// rationale as `distance_last_signal_db`.
+    pub distance_last_frequency_hz: Rc<Cell<Option<f64>>>,
 }
 
 impl RadioPanel {
@@ -486,6 +564,306 @@ impl RadioPanel {
             }
         });
     }
+
+    /// Cache a fresh signal level and recompute the distance
+    /// estimate. Called from the `DspToUi::SignalLevel` handler
+    /// in `window.rs` on every level update (~10 Hz).
+    pub fn update_distance_from_signal(&self, signal_db: f32, frequency_hz: f64) {
+        self.distance_last_signal_db.set(Some(signal_db));
+        self.distance_last_frequency_hz.set(Some(frequency_hz));
+        self.refresh_distance_display();
+    }
+
+    /// Cache a new tuner frequency and recompute the distance
+    /// estimate. Called from the tuner-change handler in
+    /// `window.rs`.
+    pub fn update_distance_frequency(&self, frequency_hz: f64) {
+        self.distance_last_frequency_hz.set(Some(frequency_hz));
+        self.refresh_distance_display();
+    }
+
+    /// Recompute and render the distance display from the cached
+    /// signal/frequency and the current ERP / calibration row
+    /// values. Called by the setters above and by the ERP /
+    /// calibration spin-row value-notify handlers.
+    pub fn refresh_distance_display(&self) {
+        let state = DistanceDisplay::compute(
+            self.distance_last_signal_db.get(),
+            self.distance_last_frequency_hz.get(),
+            self.erp_row.value(),
+            self.calibration_row.value(),
+        );
+        self.distance_row.set_subtitle(&state.format());
+    }
+}
+
+/// Standalone version of [`RadioPanel::refresh_distance_display`]
+/// usable from inside `build_radio_panel` before the `RadioPanel`
+/// struct has been materialised — wired to the ERP / calibration
+/// value-notify signals so a knob twiddle refreshes the display
+/// immediately. Both variants route through [`DistanceDisplay`]
+/// so the state machine stays in one place.
+fn refresh_distance_display_standalone(
+    erp_row: &adw::SpinRow,
+    calibration_row: &adw::SpinRow,
+    distance_row: &adw::ActionRow,
+    last_signal_db: Option<f32>,
+    last_frequency_hz: Option<f64>,
+) {
+    let state = DistanceDisplay::compute(
+        last_signal_db,
+        last_frequency_hz,
+        erp_row.value(),
+        calibration_row.value(),
+    );
+    distance_row.set_subtitle(&state.format());
+}
+
+/// Maximum distance in metres the formatter will print as a
+/// number. The longest great-circle path on Earth is ~20,015 km;
+/// above this the FSPL math is producing a physically
+/// meaningless result (almost always because path loss is
+/// implying a distance bigger than any RF can meaningfully
+/// travel from a terrestrial source).
+const MAX_MEANINGFUL_DISTANCE_M: f64 = 20_000_000.0;
+
+/// Calibrated received-power threshold (dBm) below which we
+/// assume there is no active signal to estimate a distance from.
+/// Slightly above the theoretical MDS of a sensitive narrowband
+/// receiver (~-130 dBm for a commercial VHF/UHF set, a bit
+/// better for lab gear). Anything below this is dominated by
+/// noise or is the pipeline reporting a squelch-gated floor —
+/// we label it "no active signal" rather than stretching FSPL
+/// into sci-fi territory.
+const NO_ACTIVE_SIGNAL_DBM: f64 = -130.0;
+
+/// Distinct visual states the distance display can be in.
+/// Split out so the logic is explicit and test-covered rather
+/// than buried in a single formatter function that had to
+/// overload "—" for several semantically different cases.
+#[derive(Debug, PartialEq)]
+enum DistanceDisplay {
+    /// No signal level has ever flowed yet — source not running
+    /// or panel freshly constructed.
+    NoData,
+    /// Calibrated received level is below receiver sensitivity,
+    /// so there is nothing real to measure. Typical cause:
+    /// squelch gated, source pointed at an empty channel, or
+    /// hardware disconnected.
+    NoActiveSignal,
+    /// Received level ≥ transmitted ERP — physically impossible
+    /// under FSPL. The user has a calibration problem (receiver
+    /// cal offset too large, or ERP set too low for the actual
+    /// transmitter).
+    CheckCalibration,
+    /// A signal is present above the sensitivity threshold but
+    /// path loss implies a distance greater than Earth's great-
+    /// circle maximum — the estimator has saturated.
+    TooWeak,
+    /// Meaningful distance in metres, safe to print as a number.
+    Value(f64),
+}
+
+impl DistanceDisplay {
+    /// Decide the display state from the live inputs. All four
+    /// fields-that-matter (last signal, last frequency, ERP,
+    /// calibration offset) get threaded through explicitly so
+    /// tests can pin every transition without constructing a
+    /// full `RadioPanel`.
+    fn compute(
+        signal_db: Option<f32>,
+        frequency_hz: Option<f64>,
+        erp_watts: f64,
+        cal_db: f64,
+    ) -> Self {
+        let (Some(raw_signal_db), Some(freq)) = (signal_db, frequency_hz) else {
+            return Self::NoData;
+        };
+        let received_dbm = f64::from(raw_signal_db) + cal_db;
+        if !received_dbm.is_finite() || received_dbm < NO_ACTIVE_SIGNAL_DBM {
+            return Self::NoActiveSignal;
+        }
+        let erp_dbm = watts_to_dbm(erp_watts);
+        let d = fspl_distance_m(erp_dbm, received_dbm, freq);
+        if !d.is_finite() || d < f64::EPSILON {
+            // `fspl_distance_m` returns 0.0 when received ≥ ERP
+            // (i.e., the user is receiving stronger than the
+            // transmitter putatively radiates — only reachable
+            // by miscalibrated inputs).
+            return Self::CheckCalibration;
+        }
+        if d > MAX_MEANINGFUL_DISTANCE_M {
+            return Self::TooWeak;
+        }
+        Self::Value(d)
+    }
+
+    /// Render the state as the subtitle text for the
+    /// `distance_row`. Keeps wording in one place so changes
+    /// don't drift between the panel helpers and test assertions.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn format(&self) -> String {
+        match *self {
+            Self::NoData => "—".to_string(),
+            Self::NoActiveSignal => "No active signal".to_string(),
+            Self::CheckCalibration => "Check calibration".to_string(),
+            Self::TooWeak => "Too weak to measure".to_string(),
+            Self::Value(d) => {
+                if d < 1_000.0 {
+                    format!("{} m", d.round() as u64)
+                } else if d < 1_000_000.0 {
+                    format!("{:.1} km", d / 1_000.0)
+                } else {
+                    let km_rounded_10 = ((d / 1_000.0) / 10.0).round() * 10.0;
+                    format!("{km_rounded_10:.0} km")
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod distance_display_tests {
+    use super::{DistanceDisplay, MAX_MEANINGFUL_DISTANCE_M};
+
+    // ERP for the scenarios below: a 25 W public-safety mobile,
+    // which is one of the defaults we suggest in the UI. Doesn't
+    // affect any of the state-transition boundaries this module
+    // tests — just needs to be a realistic value.
+    const TEST_ERP_WATTS: f64 = 25.0;
+    const TEST_FREQ_HZ: f64 = 155e6;
+
+    #[test]
+    fn no_data_when_signal_cache_empty() {
+        let s = DistanceDisplay::compute(None, Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
+        assert_eq!(s, DistanceDisplay::NoData);
+        assert_eq!(s.format(), "—");
+    }
+
+    #[test]
+    fn no_data_when_frequency_missing() {
+        let s = DistanceDisplay::compute(Some(-80.0), None, TEST_ERP_WATTS, 0.0);
+        assert_eq!(s, DistanceDisplay::NoData);
+    }
+
+    #[test]
+    fn no_active_signal_below_receiver_sensitivity() {
+        // -120 dB raw + -20 dB calibration → -140 dBm received,
+        // below our -130 dBm "active signal" threshold. This
+        // matches the exact user report of "squelch on, no audio,
+        // showing millions of km" (ticket #164 user feedback).
+        let s = DistanceDisplay::compute(Some(-120.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, -20.0);
+        assert_eq!(s, DistanceDisplay::NoActiveSignal);
+        assert_eq!(s.format(), "No active signal");
+    }
+
+    #[test]
+    fn check_calibration_when_received_exceeds_transmitted() {
+        // 25 W ERP ≈ 44 dBm. Received at +50 dBm is louder than
+        // the transmitter — impossible under FSPL; user needs to
+        // check their calibration offset or ERP value.
+        let s = DistanceDisplay::compute(Some(50.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
+        assert_eq!(s, DistanceDisplay::CheckCalibration);
+        assert_eq!(s.format(), "Check calibration");
+    }
+
+    #[test]
+    fn too_weak_when_signal_present_but_fspl_saturates() {
+        // Received level above the sensitivity threshold but
+        // implying a distance past Earth's great-circle max.
+        // -50 dB raw + -75 dB cal → -125 dBm received, just above
+        // the -130 dBm threshold; 25W at 155 MHz says distance is
+        // about 35,000 km — past the 20,000 km cap.
+        let s = DistanceDisplay::compute(Some(-50.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, -75.0);
+        assert_eq!(s, DistanceDisplay::TooWeak);
+        assert_eq!(s.format(), "Too weak to measure");
+    }
+
+    #[test]
+    fn value_for_plausible_signal() {
+        // 25W ERP, -80 dBm received at 155 MHz → 44 dBm path loss
+        // of 124 dB → ~244 km FSPL. Hand-computed:
+        //   d = 10 ^ ((124 - 163.8 + 147.55) / 20)
+        //     = 10 ^ (107.75 / 20)  ≈  243 km
+        // Bounds generous (100–1000 km) so micro-drift in the
+        // 147.55 constant doesn't fail the test.
+        let s = DistanceDisplay::compute(Some(-80.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
+        let DistanceDisplay::Value(d) = s else {
+            unreachable!("expected Value, got {s:?}");
+        };
+        assert!(
+            (100_000.0..1_000_000.0).contains(&d),
+            "expected 100-1000 km for -80 dBm received from 25W at 155 MHz, got {d} m"
+        );
+    }
+
+    #[test]
+    fn value_for_strong_signal() {
+        // Anchors the user-reported "9 km" scenario. For 25W at
+        // 155 MHz to produce a ~9 km estimate the received level
+        // has to be roughly -51 dBm — a very strong nearby
+        // station. The test just checks the same
+        // state-machine path returns `Value` and a modest
+        // (single-to-tens-of-km) distance.
+        let s = DistanceDisplay::compute(Some(-51.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
+        let DistanceDisplay::Value(d) = s else {
+            unreachable!("expected Value, got {s:?}");
+        };
+        assert!(
+            (1_000.0..50_000.0).contains(&d),
+            "expected 1-50 km for -51 dBm received from 25W at 155 MHz, got {d} m"
+        );
+    }
+
+    #[test]
+    fn exactly_at_sensitivity_threshold_still_evaluates() {
+        // Boundary: exactly at the threshold should NOT trip
+        // `NoActiveSignal` — we use `<` not `<=` so legitimate
+        // edge-of-sensitivity receptions still get measured.
+        // The threshold is -130 dBm; explicit literal rather than
+        // casting `NO_ACTIVE_SIGNAL_DBM` because `as f32` would
+        // trip clippy's `cast_possible_truncation` even though
+        // -130.0 is exactly representable.
+        let signal_at_threshold_db: f32 = -130.0;
+        let s = DistanceDisplay::compute(
+            Some(signal_at_threshold_db),
+            Some(TEST_FREQ_HZ),
+            TEST_ERP_WATTS,
+            0.0,
+        );
+        assert_ne!(s, DistanceDisplay::NoActiveSignal);
+    }
+
+    // ─── format() rendering tests ─────────────────────────────
+
+    #[test]
+    fn format_sub_kilometre_shows_metres() {
+        assert_eq!(DistanceDisplay::Value(1.4).format(), "1 m");
+        assert_eq!(DistanceDisplay::Value(837.5).format(), "838 m");
+        assert_eq!(DistanceDisplay::Value(999.0).format(), "999 m");
+    }
+
+    #[test]
+    fn format_kilometre_range_has_one_decimal() {
+        assert_eq!(DistanceDisplay::Value(1_000.0).format(), "1.0 km");
+        assert_eq!(DistanceDisplay::Value(12_345.0).format(), "12.3 km");
+        assert_eq!(DistanceDisplay::Value(999_000.0).format(), "999.0 km");
+    }
+
+    #[test]
+    fn format_large_distances_round_to_10_km() {
+        assert_eq!(DistanceDisplay::Value(1_234_000.0).format(), "1230 km");
+        assert_eq!(DistanceDisplay::Value(1_500_000.0).format(), "1500 km");
+    }
+
+    #[test]
+    fn format_exactly_at_cap_still_shown_as_number() {
+        // Boundary case: the cap value itself is still a real
+        // distance (half of Earth's circumference). Only values
+        // STRICTLY above it transition to `TooWeak`.
+        let formatted = DistanceDisplay::Value(MAX_MEANINGFUL_DISTANCE_M).format();
+        assert!(formatted.ends_with(" km"));
+    }
 }
 
 /// Build the radio / demodulator configuration panel.
@@ -782,12 +1160,92 @@ pub fn build_radio_panel() -> RadioPanel {
     ctcss_group.add(&ctcss_threshold_row);
     ctcss_group.add(&ctcss_status_row);
 
+    // --- Distance Estimator (FSPL, ticket #164) ---
+    let erp_adj = gtk4::Adjustment::new(
+        DEFAULT_ERP_WATTS,
+        MIN_ERP_WATTS,
+        MAX_ERP_WATTS,
+        ERP_STEP_WATTS,
+        ERP_PAGE_WATTS,
+        0.0,
+    );
+    let erp_row = adw::SpinRow::builder()
+        .title("Transmitter Power")
+        .subtitle("Effective radiated power, in watts (handheld ~5, mobile ~25-50)")
+        .adjustment(&erp_adj)
+        .digits(3)
+        .build();
+
+    let cal_adj = gtk4::Adjustment::new(
+        DEFAULT_CALIBRATION_DB,
+        MIN_CALIBRATION_DB,
+        MAX_CALIBRATION_DB,
+        CALIBRATION_STEP_DB,
+        CALIBRATION_PAGE_DB,
+        0.0,
+    );
+    let calibration_row = adw::SpinRow::builder()
+        .title("Receiver Calibration")
+        .subtitle("dB offset applied to raw level before computing path loss")
+        .adjustment(&cal_adj)
+        .digits(1)
+        .build();
+
+    let distance_row = adw::ActionRow::builder()
+        .title("Estimated Distance")
+        .subtitle("—")
+        .selectable(false)
+        .activatable(false)
+        .build();
+
+    let distance_group = adw::PreferencesGroup::builder()
+        .title("Distance Estimator")
+        .description(
+            "Rough line-of-sight (FSPL) estimate — read as an upper bound, not precision ranging",
+        )
+        .build();
+    distance_group.add(&erp_row);
+    distance_group.add(&calibration_row);
+    distance_group.add(&distance_row);
+
+    // Internal state shared across the panel clone surface — see
+    // the field docs on `RadioPanel` for why this is `Rc<Cell>`
+    // rather than plain `Cell`.
+    let distance_last_signal_db: Rc<Cell<Option<f32>>> = Rc::new(Cell::new(None));
+    let distance_last_frequency_hz: Rc<Cell<Option<f64>>> = Rc::new(Cell::new(None));
+
+    // Wire ERP and calibration spin-row changes to trigger a
+    // distance refresh using the cached signal/frequency. Config
+    // persistence and any DSP plumbing that cares about these
+    // values is wired separately in `window.rs` on the same
+    // signal — both handlers run on value change.
+    {
+        let last_signal = Rc::clone(&distance_last_signal_db);
+        let last_freq = Rc::clone(&distance_last_frequency_hz);
+        let erp_row_for_signal = erp_row.clone();
+        let cal_row_for_signal = calibration_row.clone();
+        let distance_row_for_signal = distance_row.clone();
+        let refresh = move || {
+            refresh_distance_display_standalone(
+                &erp_row_for_signal,
+                &cal_row_for_signal,
+                &distance_row_for_signal,
+                last_signal.get(),
+                last_freq.get(),
+            );
+        };
+        let refresh_for_erp = refresh.clone();
+        erp_row.connect_value_notify(move |_| refresh_for_erp());
+        calibration_row.connect_value_notify(move |_| refresh());
+    }
+
     let page = adw::PreferencesPage::new();
     page.add(&bandwidth_group);
     page.add(&squelch_group);
     page.add(&filters_group);
     page.add(&deemphasis_group);
     page.add(&ctcss_group);
+    page.add(&distance_group);
 
     // All rows connected to DSP pipeline via window.rs
 
@@ -813,6 +1271,11 @@ pub fn build_radio_panel() -> RadioPanel {
         voice_squelch_row,
         voice_squelch_threshold_row,
         voice_squelch_status_row,
+        erp_row,
+        calibration_row,
+        distance_row,
+        distance_last_signal_db,
+        distance_last_frequency_hz,
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -637,6 +637,26 @@ const MAX_MEANINGFUL_DISTANCE_M: f64 = 20_000_000.0;
 /// into sci-fi territory.
 const NO_ACTIVE_SIGNAL_DBM: f64 = -130.0;
 
+/// At or above this distance (metres) the distance display
+/// switches from "N m" to "N.N km". Mirrors the naming pattern
+/// in `antenna.rs` for unit-scaling thresholds.
+const KM_THRESHOLD_M: f64 = 1_000.0;
+
+/// At or above this distance (metres) single-km precision is
+/// meaningless — FSPL idealisation swamps any third-significant-
+/// digit stability — so the display rounds to the nearest 10 km.
+const MEGAMETRE_THRESHOLD_M: f64 = 1_000_000.0;
+
+/// Rounding granularity (in km) for distances at or above
+/// `MEGAMETRE_THRESHOLD_M`. Kept as a named constant so the
+/// "why round to 10 km" rationale lives next to the value.
+const MEGAMETRE_ROUND_KM: f64 = 10.0;
+
+/// Kilometres per metre, factored out so the formatter's intent
+/// reads cleanly without magic literals sharing the numeric
+/// literal `1_000.0` with `KM_THRESHOLD_M`.
+const METRES_PER_KM: f64 = 1_000.0;
+
 /// Distinct visual states the distance display can be in.
 /// Split out so the logic is explicit and test-covered rather
 /// than buried in a single formatter function that had to
@@ -709,13 +729,14 @@ impl DistanceDisplay {
             Self::CheckCalibration => "Check calibration".to_string(),
             Self::TooWeak => "Too weak to measure".to_string(),
             Self::Value(d) => {
-                if d < 1_000.0 {
+                if d < KM_THRESHOLD_M {
                     format!("{} m", d.round() as u64)
-                } else if d < 1_000_000.0 {
-                    format!("{:.1} km", d / 1_000.0)
+                } else if d < MEGAMETRE_THRESHOLD_M {
+                    format!("{:.1} km", d / METRES_PER_KM)
                 } else {
-                    let km_rounded_10 = ((d / 1_000.0) / 10.0).round() * 10.0;
-                    format!("{km_rounded_10:.0} km")
+                    let km_rounded =
+                        (d / METRES_PER_KM / MEGAMETRE_ROUND_KM).round() * MEGAMETRE_ROUND_KM;
+                    format!("{km_rounded:.0} km")
                 }
             }
         }

--- a/crates/sdr-ui/src/sidebar/radio_panel.rs
+++ b/crates/sdr-ui/src/sidebar/radio_panel.rs
@@ -166,9 +166,10 @@ const SQUELCH_PAGE_DB: f64 = 10.0;
 #[derive(Clone)]
 pub struct RadioPanel {
     /// The `AdwPreferencesPage` widget packed into the Radio
-    /// activity stack slot. The page hosts five titled
+    /// activity stack slot. The page hosts six titled
     /// `AdwPreferencesGroup`s (Bandwidth / Squelch / Filters /
-    /// De-emphasis / CTCSS) — see [`build_radio_panel`].
+    /// De-emphasis / CTCSS / Distance Estimator) — see
+    /// [`build_radio_panel`].
     pub widget: adw::PreferencesPage,
     /// De-emphasis section group. Stored as a handle so
     /// [`apply_demod_visibility`] can show/hide the whole section
@@ -568,18 +569,29 @@ impl RadioPanel {
     /// Cache a fresh signal level and recompute the distance
     /// estimate. Called from the `DspToUi::SignalLevel` handler
     /// in `window.rs` on every level update (~10 Hz).
+    ///
+    /// The render step is skipped when the Radio panel isn't
+    /// mapped (user is on a different activity-bar tab). Cached
+    /// inputs are still updated so the `map` signal handler on
+    /// [`Self::widget`] can render a fresh value when the user
+    /// switches to Radio.
     pub fn update_distance_from_signal(&self, signal_db: f32, frequency_hz: f64) {
         self.distance_last_signal_db.set(Some(signal_db));
         self.distance_last_frequency_hz.set(Some(frequency_hz));
-        self.refresh_distance_display();
+        if self.widget.is_mapped() {
+            self.refresh_distance_display();
+        }
     }
 
     /// Cache a new tuner frequency and recompute the distance
     /// estimate. Called from the tuner-change handler in
-    /// `window.rs`.
+    /// `window.rs`. Same visibility-gating as
+    /// [`Self::update_distance_from_signal`].
     pub fn update_distance_frequency(&self, frequency_hz: f64) {
         self.distance_last_frequency_hz.set(Some(frequency_hz));
-        self.refresh_distance_display();
+        if self.widget.is_mapped() {
+            self.refresh_distance_display();
+        }
     }
 
     /// Recompute and render the distance display from the cached
@@ -740,150 +752,6 @@ impl DistanceDisplay {
                 }
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod distance_display_tests {
-    use super::{DistanceDisplay, MAX_MEANINGFUL_DISTANCE_M};
-
-    // ERP for the scenarios below: a 25 W public-safety mobile,
-    // which is one of the defaults we suggest in the UI. Doesn't
-    // affect any of the state-transition boundaries this module
-    // tests — just needs to be a realistic value.
-    const TEST_ERP_WATTS: f64 = 25.0;
-    const TEST_FREQ_HZ: f64 = 155e6;
-
-    #[test]
-    fn no_data_when_signal_cache_empty() {
-        let s = DistanceDisplay::compute(None, Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
-        assert_eq!(s, DistanceDisplay::NoData);
-        assert_eq!(s.format(), "—");
-    }
-
-    #[test]
-    fn no_data_when_frequency_missing() {
-        let s = DistanceDisplay::compute(Some(-80.0), None, TEST_ERP_WATTS, 0.0);
-        assert_eq!(s, DistanceDisplay::NoData);
-    }
-
-    #[test]
-    fn no_active_signal_below_receiver_sensitivity() {
-        // -120 dB raw + -20 dB calibration → -140 dBm received,
-        // below our -130 dBm "active signal" threshold. This
-        // matches the exact user report of "squelch on, no audio,
-        // showing millions of km" (ticket #164 user feedback).
-        let s = DistanceDisplay::compute(Some(-120.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, -20.0);
-        assert_eq!(s, DistanceDisplay::NoActiveSignal);
-        assert_eq!(s.format(), "No active signal");
-    }
-
-    #[test]
-    fn check_calibration_when_received_exceeds_transmitted() {
-        // 25 W ERP ≈ 44 dBm. Received at +50 dBm is louder than
-        // the transmitter — impossible under FSPL; user needs to
-        // check their calibration offset or ERP value.
-        let s = DistanceDisplay::compute(Some(50.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
-        assert_eq!(s, DistanceDisplay::CheckCalibration);
-        assert_eq!(s.format(), "Check calibration");
-    }
-
-    #[test]
-    fn too_weak_when_signal_present_but_fspl_saturates() {
-        // Received level above the sensitivity threshold but
-        // implying a distance past Earth's great-circle max.
-        // -50 dB raw + -75 dB cal → -125 dBm received, just above
-        // the -130 dBm threshold; 25W at 155 MHz says distance is
-        // about 35,000 km — past the 20,000 km cap.
-        let s = DistanceDisplay::compute(Some(-50.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, -75.0);
-        assert_eq!(s, DistanceDisplay::TooWeak);
-        assert_eq!(s.format(), "Too weak to measure");
-    }
-
-    #[test]
-    fn value_for_plausible_signal() {
-        // 25W ERP, -80 dBm received at 155 MHz → 44 dBm path loss
-        // of 124 dB → ~244 km FSPL. Hand-computed:
-        //   d = 10 ^ ((124 - 163.8 + 147.55) / 20)
-        //     = 10 ^ (107.75 / 20)  ≈  243 km
-        // Bounds generous (100–1000 km) so micro-drift in the
-        // 147.55 constant doesn't fail the test.
-        let s = DistanceDisplay::compute(Some(-80.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
-        let DistanceDisplay::Value(d) = s else {
-            unreachable!("expected Value, got {s:?}");
-        };
-        assert!(
-            (100_000.0..1_000_000.0).contains(&d),
-            "expected 100-1000 km for -80 dBm received from 25W at 155 MHz, got {d} m"
-        );
-    }
-
-    #[test]
-    fn value_for_strong_signal() {
-        // Anchors the user-reported "9 km" scenario. For 25W at
-        // 155 MHz to produce a ~9 km estimate the received level
-        // has to be roughly -51 dBm — a very strong nearby
-        // station. The test just checks the same
-        // state-machine path returns `Value` and a modest
-        // (single-to-tens-of-km) distance.
-        let s = DistanceDisplay::compute(Some(-51.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
-        let DistanceDisplay::Value(d) = s else {
-            unreachable!("expected Value, got {s:?}");
-        };
-        assert!(
-            (1_000.0..50_000.0).contains(&d),
-            "expected 1-50 km for -51 dBm received from 25W at 155 MHz, got {d} m"
-        );
-    }
-
-    #[test]
-    fn exactly_at_sensitivity_threshold_still_evaluates() {
-        // Boundary: exactly at the threshold should NOT trip
-        // `NoActiveSignal` — we use `<` not `<=` so legitimate
-        // edge-of-sensitivity receptions still get measured.
-        // The threshold is -130 dBm; explicit literal rather than
-        // casting `NO_ACTIVE_SIGNAL_DBM` because `as f32` would
-        // trip clippy's `cast_possible_truncation` even though
-        // -130.0 is exactly representable.
-        let signal_at_threshold_db: f32 = -130.0;
-        let s = DistanceDisplay::compute(
-            Some(signal_at_threshold_db),
-            Some(TEST_FREQ_HZ),
-            TEST_ERP_WATTS,
-            0.0,
-        );
-        assert_ne!(s, DistanceDisplay::NoActiveSignal);
-    }
-
-    // ─── format() rendering tests ─────────────────────────────
-
-    #[test]
-    fn format_sub_kilometre_shows_metres() {
-        assert_eq!(DistanceDisplay::Value(1.4).format(), "1 m");
-        assert_eq!(DistanceDisplay::Value(837.5).format(), "838 m");
-        assert_eq!(DistanceDisplay::Value(999.0).format(), "999 m");
-    }
-
-    #[test]
-    fn format_kilometre_range_has_one_decimal() {
-        assert_eq!(DistanceDisplay::Value(1_000.0).format(), "1.0 km");
-        assert_eq!(DistanceDisplay::Value(12_345.0).format(), "12.3 km");
-        assert_eq!(DistanceDisplay::Value(999_000.0).format(), "999.0 km");
-    }
-
-    #[test]
-    fn format_large_distances_round_to_10_km() {
-        assert_eq!(DistanceDisplay::Value(1_234_000.0).format(), "1230 km");
-        assert_eq!(DistanceDisplay::Value(1_500_000.0).format(), "1500 km");
-    }
-
-    #[test]
-    fn format_exactly_at_cap_still_shown_as_number() {
-        // Boundary case: the cap value itself is still a real
-        // distance (half of Earth's circumference). Only values
-        // STRICTLY above it transition to `TooWeak`.
-        let formatted = DistanceDisplay::Value(MAX_MEANINGFUL_DISTANCE_M).format();
-        assert!(formatted.ends_with(" km"));
     }
 }
 
@@ -1268,6 +1136,29 @@ pub fn build_radio_panel() -> RadioPanel {
     page.add(&ctcss_group);
     page.add(&distance_group);
 
+    // When the Radio tab becomes visible (user switches to it
+    // via the activity bar), render the distance estimate with
+    // whatever cached inputs are current. The DSP-driven
+    // `update_distance_*` methods skip the render step while the
+    // panel is unmapped — without this handler the user would see
+    // a stale subtitle until the next SignalLevel message arrived.
+    {
+        let erp_for_map = erp_row.clone();
+        let cal_for_map = calibration_row.clone();
+        let dist_for_map = distance_row.clone();
+        let last_signal_for_map = Rc::clone(&distance_last_signal_db);
+        let last_freq_for_map = Rc::clone(&distance_last_frequency_hz);
+        page.connect_map(move |_| {
+            refresh_distance_display_standalone(
+                &erp_for_map,
+                &cal_for_map,
+                &dist_for_map,
+                last_signal_for_map.get(),
+                last_freq_for_map.get(),
+            );
+        });
+    }
+
     // All rows connected to DSP pipeline via window.rs
 
     RadioPanel {
@@ -1302,6 +1193,8 @@ pub fn build_radio_panel() -> RadioPanel {
 
 #[cfg(test)]
 mod tests {
+    use super::{DistanceDisplay, MAX_MEANINGFUL_DISTANCE_M};
+
     /// Compile-time validation that bandwidth constants are consistent.
     const _: () = {
         assert!(super::MIN_BANDWIDTH_HZ <= super::MAX_BANDWIDTH_HZ);
@@ -1336,4 +1229,165 @@ mod tests {
         assert!(super::NOTCH_FREQ_STEP_HZ > 0.0);
         assert!(super::NOTCH_FREQ_PAGE_HZ > 0.0);
     };
+
+    /// Compile-time validation that distance-estimator ERP
+    /// constants are consistent.
+    const _: () = {
+        assert!(super::MIN_ERP_WATTS <= super::MAX_ERP_WATTS);
+        assert!(super::DEFAULT_ERP_WATTS >= super::MIN_ERP_WATTS);
+        assert!(super::DEFAULT_ERP_WATTS <= super::MAX_ERP_WATTS);
+        assert!(super::ERP_STEP_WATTS > 0.0);
+        assert!(super::ERP_PAGE_WATTS > 0.0);
+    };
+
+    /// Compile-time validation that distance-estimator calibration
+    /// constants are consistent.
+    const _: () = {
+        assert!(super::MIN_CALIBRATION_DB <= super::MAX_CALIBRATION_DB);
+        assert!(super::DEFAULT_CALIBRATION_DB >= super::MIN_CALIBRATION_DB);
+        assert!(super::DEFAULT_CALIBRATION_DB <= super::MAX_CALIBRATION_DB);
+        assert!(super::CALIBRATION_STEP_DB > 0.0);
+        assert!(super::CALIBRATION_PAGE_DB > 0.0);
+    };
+
+    // ─── Distance estimator state machine (ticket #164) ──────
+
+    /// ERP for the scenarios below: a 25 W public-safety mobile,
+    /// which is one of the defaults we suggest in the UI. Doesn't
+    /// affect any of the state-transition boundaries these tests
+    /// pin — just needs to be a realistic value.
+    const TEST_ERP_WATTS: f64 = 25.0;
+    const TEST_FREQ_HZ: f64 = 155e6;
+
+    #[test]
+    fn no_data_when_signal_cache_empty() {
+        let s = DistanceDisplay::compute(None, Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
+        assert_eq!(s, DistanceDisplay::NoData);
+        assert_eq!(s.format(), "—");
+    }
+
+    #[test]
+    fn no_data_when_frequency_missing() {
+        let s = DistanceDisplay::compute(Some(-80.0), None, TEST_ERP_WATTS, 0.0);
+        assert_eq!(s, DistanceDisplay::NoData);
+    }
+
+    #[test]
+    fn no_active_signal_below_receiver_sensitivity() {
+        // -120 dB raw + -20 dB calibration → -140 dBm received,
+        // below our -130 dBm "active signal" threshold. This
+        // matches the exact user report of "squelch on, no audio,
+        // showing millions of km" (ticket #164 user feedback).
+        let s = DistanceDisplay::compute(Some(-120.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, -20.0);
+        assert_eq!(s, DistanceDisplay::NoActiveSignal);
+        assert_eq!(s.format(), "No active signal");
+    }
+
+    #[test]
+    fn check_calibration_when_received_exceeds_transmitted() {
+        // 25 W ERP ≈ 44 dBm. Received at +50 dBm is louder than
+        // the transmitter — impossible under FSPL; user needs to
+        // check their calibration offset or ERP value.
+        let s = DistanceDisplay::compute(Some(50.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
+        assert_eq!(s, DistanceDisplay::CheckCalibration);
+        assert_eq!(s.format(), "Check calibration");
+    }
+
+    #[test]
+    fn too_weak_when_signal_present_but_fspl_saturates() {
+        // Received level above the sensitivity threshold but
+        // implying a distance past Earth's great-circle max.
+        // -50 dB raw + -75 dB cal → -125 dBm received, just above
+        // the -130 dBm threshold; 25W at 155 MHz says distance is
+        // about 35,000 km — past the 20,000 km cap.
+        let s = DistanceDisplay::compute(Some(-50.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, -75.0);
+        assert_eq!(s, DistanceDisplay::TooWeak);
+        assert_eq!(s.format(), "Too weak to measure");
+    }
+
+    #[test]
+    fn value_for_plausible_signal() {
+        // 25W ERP, -80 dBm received at 155 MHz → 44 dBm path loss
+        // of 124 dB → ~244 km FSPL. Hand-computed:
+        //   d = 10 ^ ((124 - 163.8 + 147.55) / 20)
+        //     = 10 ^ (107.75 / 20)  ≈  243 km
+        // Bounds generous (100–1000 km) so micro-drift in the
+        // 147.55 constant doesn't fail the test.
+        let s = DistanceDisplay::compute(Some(-80.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
+        let DistanceDisplay::Value(d) = s else {
+            unreachable!("expected Value, got {s:?}");
+        };
+        assert!(
+            (100_000.0..1_000_000.0).contains(&d),
+            "expected 100-1000 km for -80 dBm received from 25W at 155 MHz, got {d} m"
+        );
+    }
+
+    #[test]
+    fn value_for_strong_signal() {
+        // Anchors the user-reported "9 km" scenario. For 25W at
+        // 155 MHz to produce a ~9 km estimate the received level
+        // has to be roughly -51 dBm — a very strong nearby
+        // station. The test just checks the same state-machine
+        // path returns `Value` and a modest (single-to-tens-of-km)
+        // distance.
+        let s = DistanceDisplay::compute(Some(-51.0), Some(TEST_FREQ_HZ), TEST_ERP_WATTS, 0.0);
+        let DistanceDisplay::Value(d) = s else {
+            unreachable!("expected Value, got {s:?}");
+        };
+        assert!(
+            (1_000.0..50_000.0).contains(&d),
+            "expected 1-50 km for -51 dBm received from 25W at 155 MHz, got {d} m"
+        );
+    }
+
+    #[test]
+    fn exactly_at_sensitivity_threshold_still_evaluates() {
+        // Boundary: exactly at the threshold should NOT trip
+        // `NoActiveSignal` — we use `<` not `<=` so legitimate
+        // edge-of-sensitivity receptions still get measured.
+        // The threshold is -130 dBm; explicit literal rather than
+        // casting `NO_ACTIVE_SIGNAL_DBM` because `as f32` would
+        // trip clippy's `cast_possible_truncation` even though
+        // -130.0 is exactly representable.
+        let signal_at_threshold_db: f32 = -130.0;
+        let s = DistanceDisplay::compute(
+            Some(signal_at_threshold_db),
+            Some(TEST_FREQ_HZ),
+            TEST_ERP_WATTS,
+            0.0,
+        );
+        assert_ne!(s, DistanceDisplay::NoActiveSignal);
+    }
+
+    // ─── format() rendering tests ─────────────────────────────
+
+    #[test]
+    fn format_sub_kilometre_shows_metres() {
+        assert_eq!(DistanceDisplay::Value(1.4).format(), "1 m");
+        assert_eq!(DistanceDisplay::Value(837.5).format(), "838 m");
+        assert_eq!(DistanceDisplay::Value(999.0).format(), "999 m");
+    }
+
+    #[test]
+    fn format_kilometre_range_has_one_decimal() {
+        assert_eq!(DistanceDisplay::Value(1_000.0).format(), "1.0 km");
+        assert_eq!(DistanceDisplay::Value(12_345.0).format(), "12.3 km");
+        assert_eq!(DistanceDisplay::Value(999_000.0).format(), "999.0 km");
+    }
+
+    #[test]
+    fn format_large_distances_round_to_10_km() {
+        assert_eq!(DistanceDisplay::Value(1_234_000.0).format(), "1230 km");
+        assert_eq!(DistanceDisplay::Value(1_500_000.0).format(), "1500 km");
+    }
+
+    #[test]
+    fn format_exactly_at_cap_still_shown_as_number() {
+        // Boundary case: the cap value itself is still a real
+        // distance (half of Earth's circumference). Only values
+        // STRICTLY above it transition to `TooWeak`.
+        let formatted = DistanceDisplay::Value(MAX_MEANINGFUL_DISTANCE_M).format();
+        assert!(formatted.ends_with(" km"));
+    }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -531,6 +531,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     let state_freq = Rc::clone(&state);
     let spectrum_for_freq = Rc::clone(&spectrum_handle);
     let force_disable_freq = Rc::clone(&scanner_force_disable);
+    let radio_for_freq = panels.radio.clone();
     freq_selector.connect_frequency_changed(move |freq| {
         tracing::debug!(frequency_hz = freq, "frequency changed");
         // Flip scanner off before dispatching the tune so the
@@ -544,6 +545,10 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         state_freq.send_dsp(UiToDsp::Tune(freq_f64));
         status_bar_for_freq.update_frequency(freq_f64);
         spectrum_for_freq.set_center_frequency(freq_f64);
+        // Feed the FSPL distance estimator in the Radio panel
+        // with the new frequency so the cached distance estimate
+        // uses the right carrier (ticket #164).
+        radio_for_freq.update_distance_frequency(freq_f64);
     });
     // Single demod-change handler: gate → force-disable → dispatch
     // → cosmetic UI updates. Order matters: force-disable must
@@ -858,6 +863,11 @@ fn handle_dsp_message(
         DspToUi::SignalLevel(level) => {
             status_bar.update_signal_level(level);
             spectrum_handle.push_signal_level(level);
+            // Feed the FSPL distance estimator in the Radio panel
+            // (ticket #164). The panel caches the level + current
+            // frequency so the display refreshes if the user later
+            // tweaks ERP / calibration.
+            radio_panel.update_distance_from_signal(level, state.center_frequency.get());
         }
         DspToUi::Error(err_msg) => {
             tracing::warn!(error = %err_msg, "DSP error");
@@ -2668,6 +2678,7 @@ fn connect_sidebar_panels(
     connect_display_panel(panels, state, spectrum_handle);
     connect_audio_panel(panels, state);
     connect_volume_persistence(panels, state, config, volume_button);
+    connect_distance_estimator_persistence(panels, config);
     connect_scanner_panel(panels, state, config);
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
@@ -8130,6 +8141,59 @@ fn unlock_transcription_session_rows(
     if let Some(row) = auto_break_min_segment_row.upgrade() {
         row.set_sensitive(true);
     }
+}
+
+/// Load saved transmitter ERP and receiver calibration offset
+/// into the Radio panel's FSPL distance estimator rows, and wire
+/// value-change handlers to persist any edits back to the config
+/// (ticket #164). The distance display refresh wiring lives
+/// inside `build_radio_panel` — this function is only about
+/// config ↔ row synchronisation.
+fn connect_distance_estimator_persistence(
+    panels: &SidebarPanels,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
+    use sidebar::radio_panel::{KEY_RADIO_DISTANCE_CALIBRATION_DB, KEY_RADIO_DISTANCE_ERP_WATTS};
+
+    // Seed the rows with the saved values (clamped to the spin
+    // rows' own adjustment bounds via their `set_value`). The
+    // default spin row values were already applied at
+    // `build_radio_panel` time, so `config.read` here only
+    // overrides when a saved value exists.
+    let saved_erp = config.read(|v| {
+        v.get(KEY_RADIO_DISTANCE_ERP_WATTS)
+            .and_then(serde_json::Value::as_f64)
+    });
+    let saved_cal = config.read(|v| {
+        v.get(KEY_RADIO_DISTANCE_CALIBRATION_DB)
+            .and_then(serde_json::Value::as_f64)
+    });
+    if let Some(erp) = saved_erp {
+        panels.radio.erp_row.set_value(erp);
+    }
+    if let Some(cal) = saved_cal {
+        panels.radio.calibration_row.set_value(cal);
+    }
+
+    // Persist-on-change. Uses `value_notify` (not the adjustment's
+    // `value_changed`) to match the signal the in-panel distance
+    // refresh handler is already listening to — both fire on the
+    // same user edit.
+    let config_erp = std::sync::Arc::clone(config);
+    panels.radio.erp_row.connect_value_notify(move |row| {
+        config_erp.write(|v| {
+            v[KEY_RADIO_DISTANCE_ERP_WATTS] = serde_json::json!(row.value());
+        });
+    });
+    let config_cal = std::sync::Arc::clone(config);
+    panels
+        .radio
+        .calibration_row
+        .connect_value_notify(move |row| {
+            config_cal.write(|v| {
+                v[KEY_RADIO_DISTANCE_CALIBRATION_DB] = serde_json::json!(row.value());
+            });
+        });
 }
 
 /// Connect scanner panel controls to DSP commands.


### PR DESCRIPTION
## Summary

Adds a "Distance Estimator" section at the bottom of the Radio sidebar panel. Given a transmitter ERP and a receiver calibration offset, it runs the textbook free-space path loss formula against the live signal level and tuner frequency to show an estimated distance.

\`\`\`
FSPL(dB) = 20·log10(d) + 20·log10(f) - 147.55
        ⇒ d = 10 ^ ((FSPL - 20·log10(f) + 147.55) / 20)
\`\`\`

The \`147.55\` dB constant is \`20·log10(c / 4π)\` — computed analytically from the exact-by-definition speed of light so the formula matches any textbook derivation.

## What's added

### \`sdr-dsp::propagation\` (new module)

Pure-math helpers, no threading or I/O:

- \`fspl_distance_m(erp_dbm, received_dbm, frequency_hz) -> f64\`
- \`fspl_db(distance_m, frequency_hz) -> f64\`  (round-trip helper)
- \`watts_to_dbm\` / \`dbm_to_watts\`

**8 unit tests** — including a round-trip across 5 frequencies × 5 distances, textbook anchors (1 W = 30 dBm, FSPL at 100 MHz / 1 m = 12.45 dB, etc.), NaN/zero/negative edge cases, and a "50 W @ 155 MHz @ -90 dBm ≈ 1000 km" sanity anchor.

### Radio panel UI

New \`AdwPreferencesGroup\` "Distance Estimator" with three rows:
- **Transmitter Power** — \`AdwSpinRow\`, watts, default 25 W (mobile public-safety). Range 0.001–100 000 W.
- **Receiver Calibration** — \`AdwSpinRow\`, dB, default 0. Range ±30 dB for any reasonable RTL-SDR scale offset.
- **Estimated Distance** — read-only \`AdwActionRow\`, subtitle updates live.

Display state is explicit as an enum with five variants:

| State | Trigger | Display |
|---|---|---|
| \`NoData\` | no signal level has ever flowed | \`—\` |
| \`NoActiveSignal\` | calibrated received < -130 dBm | \`No active signal\` |
| \`CheckCalibration\` | received ≥ transmitted (physically impossible) | \`Check calibration\` |
| \`TooWeak\` | FSPL > Earth's great-circle max (~20 000 km) | \`Too weak to measure\` |
| \`Value(d)\` | meaningful | \`X m\` / \`X.X km\` / \`XX km\` |

The -130 dBm threshold sits just below a sensitive narrowband receiver's MDS — below it the signal is almost certainly squelch-gated or noise-floor and the FSPL math would saturate at physically absurd distances. **12 unit tests** cover every state transition plus the number formatting.

### Wiring (window.rs)

- \`DspToUi::SignalLevel\` handler calls \`radio_panel.update_distance_from_signal(level, center_freq)\` on every level update (~10 Hz)
- \`freq_selector.connect_frequency_changed\` calls \`update_distance_frequency\` so the estimate tracks retunes
- ERP / calibration spin rows have two value-notify handlers: one inside \`build_radio_panel\` recomputes the display from cached inputs; one in \`connect_distance_estimator_persistence\` writes to \`ConfigManager\`
- Initial values seeded from config at startup, falling back to 25 W / 0 dB on a fresh config

Config keys (public constants on \`radio_panel\`):
- \`radio_distance_erp_watts\`
- \`radio_distance_calibration_db\`

## Caveat (documented in-panel)

The group subtitle reads:

> *Rough line-of-sight (FSPL) estimate — read as an upper bound, not precision ranging*

FSPL is the idealised line-of-sight loss between two isotropic antennas in free space — no terrain, no buildings, no multipath, no atmospheric effects. Real-world receive levels drop off faster, so the estimate is really "the transmitter is *at most* this far away for this received level." Helpful for antenna adjustment / propagation sanity-check, not for precision ranging.

## Scope explicitly out

- **RadioReference ERP auto-fill** (ticket suggests this → #151 area). Not in this PR.
- **Overlay on the signal-history graph.** Status-row display in the Radio panel is sufficient; graph overlay can be a follow-up if you want it.
- **Terrain / multipath modelling.** FSPL is deliberately the simplest estimate.

## User smoke test

Verified on 25 W public-safety NFM at 155 MHz:
- Real signal shows ~9 km (matches hand-computed FSPL)
- Squelch-gated / no-signal state shows **"No active signal"** (replaces the earlier "out of range (signal below noise floor?)" message per user feedback)
- ERP / calibration knobs update the distance display immediately on edit
- Persistence across restart works (25 W / 0 dB defaults on fresh config)
- Rest of Radio panel (bandwidth / squelch / filters / de-emphasis / CTCSS) regression-free; demod visibility toggling unaffected

## Test plan

- [x] \`cargo test -p sdr-dsp --lib propagation\` — 8/8 pass + doctest
- [x] \`cargo test -p sdr-ui --lib --features whisper-cpu distance_display\` — 12/12 pass
- [x] \`cargo clippy --all-targets --workspace --features whisper-cpu -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`make install CARGO_FLAGS=\"--release --features whisper-cuda\"\` — user smoke-tested on live signals

Closes #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Estimated Distance estimator in the radio sidebar with ERP (transmitter power) and receiver calibration controls; estimates auto-update from received signal level and tuner frequency and persist between sessions.
  * Exposed public propagation math helpers for FSPL, power/unit conversions, and distance estimation for use by other components.

* **Tests**
  * Added unit tests covering numeric anchors, edge cases, and UI transition/formatting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->