### PR TITLE
SwiftUI: activity-bar scaffolding (closes #442)

### DIFF
--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -75,15 +75,23 @@ struct ContentView: View {
     //  these bindings into `sdr-config` via #449.
     // ----------------------------------------------------------
 
-    /// Which left panel is currently open, or `nil` when
-    /// collapsed. Defaults to `.general` matching the Linux
-    /// startup behavior.
-    @State private var leftSelection: LeftActivity? = .general
+    /// Currently-selected left activity. Stays stable across
+    /// panel open/close so the icon highlight persists when
+    /// the user collapses the panel via a second click.
+    /// `leftPanelOpen` controls visibility independently.
+    /// This split mirrors the Linux
+    /// `ui_sidebar_left_{selected,open}` config-key pair, so
+    /// #449's session-persistence wires both bindings into
+    /// the shared sdr-config JSON. Per `CodeRabbit` round 1
+    /// on PR #491.
+    @State private var leftSelection: LeftActivity = .general
+    @State private var leftPanelOpen: Bool = true
 
-    /// Which right panel is currently open, or `nil` when
-    /// collapsed. Defaults to `nil` — the right bar is there
-    /// but starts closed, matching Linux.
-    @State private var rightSelection: RightActivity? = nil
+    /// Same split for the right bar. Defaults: Transcript
+    /// remembered as the active activity, panel starts closed
+    /// — matches Linux startup.
+    @State private var rightSelection: RightActivity = .transcript
+    @State private var rightPanelOpen: Bool = false
 
     /// Ideal width of a left / right panel. `HSplitView` in
     /// #450 will let the user drag these; today they're fixed.
@@ -95,14 +103,17 @@ struct ContentView: View {
             // Left activity bar — always visible.
             ActivityBarView(
                 selection: $leftSelection,
+                isOpen: $leftPanelOpen,
                 shortcutModifiers: .command
             )
             Divider()
 
-            // Left panel — only when an activity is selected.
+            // Left panel — visible only when `leftPanelOpen`.
+            // The remembered `leftSelection` stays put when
+            // closed so a re-open snaps back to the same panel.
             // Placeholder bodies during scaffolding; real
             // panels land in #443–#447.
-            if let leftSelection {
+            if leftPanelOpen {
                 LeftPanelHost(activity: leftSelection)
                     .frame(width: Self.leftPanelWidth)
                 Divider()
@@ -143,7 +154,7 @@ struct ContentView: View {
             // Right panel — placeholder during scaffolding.
             // The existing flyouts above still live inside the
             // detail column; #448 unifies these surfaces.
-            if let rightSelection {
+            if rightPanelOpen {
                 Divider()
                 RightPanelHost(activity: rightSelection)
                     .frame(width: Self.rightPanelWidth)
@@ -154,6 +165,7 @@ struct ContentView: View {
             // in scaffolding; #448 adds the second.
             ActivityBarView(
                 selection: $rightSelection,
+                isOpen: $rightPanelOpen,
                 shortcutModifiers: [.command, .shift]
             )
         }

--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -1,11 +1,23 @@
 //
-// ContentView.swift — top-level layout.
+// ContentView.swift — top-level layout with activity-bar
+// sidebar redesign (epic #441, sub-ticket #442).
 //
-// `NavigationSplitView` gives us the macOS-native sidebar pattern
-// (collapsible via the toolbar button for free). Sidebar holds
-// the Source/Radio/Display accordion; the detail column holds the
-// spectrum/waterfall + status bar, with the header toolbar
-// attached via `.toolbar`.
+// Layout mirrors the GTK VS Code-style activity-bar pattern:
+//
+//   ┌─────────────────────────────────────────────────────────┐
+//   │ [L] │ [L panel] │ spectrum + status + [old flyouts] │ [R panel] │ [R] │
+//   └─────────────────────────────────────────────────────────┘
+//      ↑       ↑                 ↑                      ↑        ↑
+//    left   optional          detail column          optional  right
+//   activity left panel       (existing content)     right     activity
+//    bar      (per-selection)                        panel      bar
+//
+// Scaffolding phase (this ticket): all left/right panels are
+// `ComingSoonPanel` placeholders pointing at the follow-up
+// sub-tickets that port their real content (#443–#447, #448).
+// The old flyouts (Transcription, Bookmarks) and the RR sheet
+// stay toolbar-driven — #448 consolidates the right side,
+// which may remove or relocate the existing flyouts.
 
 import AppKit
 import SwiftUI
@@ -13,6 +25,13 @@ import SwiftUI
 struct ContentView: View {
     @Environment(CoreModel.self) private var model
     @Environment(\.scenePhase) private var scenePhase
+
+    // ----------------------------------------------------------
+    //  Pre-redesign toolbar-driven surfaces — preserved as-is
+    //  during scaffolding. #448 may relocate the right flyouts
+    //  into the activity-bar-driven `rightSelection` panel.
+    // ----------------------------------------------------------
+
     /// Sheet state lives up here (not inside the toolbar)
     /// because the subview-wrapped version of the RR button
     /// didn't render in the toolbar — inlining the button in
@@ -49,11 +68,52 @@ struct ContentView: View {
     /// 200 ms `Revealer.transition_duration`.
     static let rightFlyoutTransitionSeconds: Double = 0.2
 
+    // ----------------------------------------------------------
+    //  Activity-bar selections — new in #442
+    //
+    //  Ephemeral for scaffolding; session persistence wires
+    //  these bindings into `sdr-config` via #449.
+    // ----------------------------------------------------------
+
+    /// Which left panel is currently open, or `nil` when
+    /// collapsed. Defaults to `.general` matching the Linux
+    /// startup behavior.
+    @State private var leftSelection: LeftActivity? = .general
+
+    /// Which right panel is currently open, or `nil` when
+    /// collapsed. Defaults to `nil` — the right bar is there
+    /// but starts closed, matching Linux.
+    @State private var rightSelection: RightActivity? = nil
+
+    /// Ideal width of a left / right panel. `HSplitView` in
+    /// #450 will let the user drag these; today they're fixed.
+    private static let leftPanelWidth: CGFloat = 280
+    private static let rightPanelWidth: CGFloat = 360
+
     var body: some View {
-        NavigationSplitView {
-            SidebarView()
-                .navigationSplitViewColumnWidth(min: 240, ideal: 280)
-        } detail: {
+        HStack(spacing: 0) {
+            // Left activity bar — always visible.
+            ActivityBarView(
+                selection: $leftSelection,
+                shortcutModifiers: .command
+            )
+            Divider()
+
+            // Left panel — only when an activity is selected.
+            // Placeholder bodies during scaffolding; real
+            // panels land in #443–#447.
+            if let leftSelection {
+                LeftPanelHost(activity: leftSelection)
+                    .frame(width: Self.leftPanelWidth)
+                Divider()
+            }
+
+            // Detail column — unchanged from the pre-redesign
+            // app. Spectrum + status bar live here, and the
+            // existing right flyouts (Transcription, Bookmarks)
+            // still slide in from the right edge of this
+            // column. #448 will reconcile that with the new
+            // right activity bar.
             HStack(spacing: 0) {
                 VStack(spacing: 0) {
                     CenterView()
@@ -70,15 +130,31 @@ struct ContentView: View {
                         .transition(.move(edge: .trailing))
                 }
             }
-            // Match GTK's Revealer SlideLeft animation. Shared
-            // duration constant so both flyouts stay in lockstep.
+            .frame(maxWidth: .infinity)
             .animation(
-                .easeInOut(duration: ContentView.rightFlyoutTransitionSeconds),
+                .easeInOut(duration: Self.rightFlyoutTransitionSeconds),
                 value: showingTranscription
             )
             .animation(
-                .easeInOut(duration: ContentView.rightFlyoutTransitionSeconds),
+                .easeInOut(duration: Self.rightFlyoutTransitionSeconds),
                 value: showingBookmarks
+            )
+
+            // Right panel — placeholder during scaffolding.
+            // The existing flyouts above still live inside the
+            // detail column; #448 unifies these surfaces.
+            if let rightSelection {
+                Divider()
+                RightPanelHost(activity: rightSelection)
+                    .frame(width: Self.rightPanelWidth)
+            }
+            Divider()
+
+            // Right activity bar — always visible. One icon
+            // in scaffolding; #448 adds the second.
+            ActivityBarView(
+                selection: $rightSelection,
+                shortcutModifiers: [.command, .shift]
             )
         }
         .toolbar {
@@ -165,29 +241,6 @@ struct ContentView: View {
                 bad output. Reinstall a matching build.
                 """)
         }
-    }
-}
-
-/// Accordion sidebar: three sections, each collapsible. SwiftUI's
-/// `Form` + `Section` inside a `List` gives the native "sidebar
-/// panels" look without custom drawing.
-struct SidebarView: View {
-    var body: some View {
-        Form {
-            SourceSection()
-            RadioSection()
-            DisplaySection()
-            RecordingSection()
-            BookmarksSection()
-            // `RtlTcpServerSection` is visible only when a
-            // local RTL-SDR dongle is detected — the section
-            // itself is always included in the form, but the
-            // body collapses to a single "no dongle" caption
-            // otherwise so it doesn't clutter the sidebar on a
-            // network/file source setup.
-            RtlTcpServerSection()
-        }
-        .formStyle(.grouped)
     }
 }
 

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
@@ -46,10 +46,14 @@ struct ActivityBarView<Activity: ActivityEntry>: View {
     /// for the right — matches the Linux accelerator scheme.
     let shortcutModifiers: EventModifiers
 
-    /// Static column width. Matches the GTK 48 px icon strip —
-    /// wide enough for a 24 pt SF Symbol + comfortable padding,
-    /// narrow enough that it doesn't steal space from the
-    /// panels it flanks.
+    /// Static column width — 44 pt. Wide enough for an 18 pt
+    /// SF Symbol in a 36×32 hit-target plus comfortable
+    /// padding, narrow enough that it doesn't steal space
+    /// from the panels it flanks. (The GTK side sizes its
+    /// activity-bar via Adwaita CSS rather than an explicit
+    /// constant, so there's no Linux number to mirror — the
+    /// 44 pt value is tuned for the macOS look directly.)
+    /// Per `CodeRabbit` round 4 on PR #491.
     static var columnWidth: CGFloat { 44 }
 
     var body: some View {

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
@@ -23,10 +23,21 @@
 import SwiftUI
 
 struct ActivityBarView<Activity: ActivityEntry>: View {
-    /// Selected activity for this column, or `nil` when the
-    /// panel is closed. Binding so parent view owns the state;
-    /// session persistence wires into this same binding in #449.
-    @Binding var selection: Activity?
+    /// Which activity is currently "selected" in this column.
+    /// Stays stable across open/close — tapping the same icon
+    /// twice flips `isOpen` but leaves `selection` alone, so
+    /// the icon keeps its active highlight even when the panel
+    /// is hidden. This split maps 1:1 onto the Linux
+    /// `ui_sidebar_{left,right}_selected` config key for
+    /// session persistence in #449. Per `CodeRabbit` round 1
+    /// on PR #491.
+    @Binding var selection: Activity
+
+    /// Whether the panel next to this bar is currently
+    /// visible. Independent of `selection` — closing the
+    /// panel doesn't clear which activity was selected.
+    /// Maps onto Linux `ui_sidebar_{left,right}_open`.
+    @Binding var isOpen: Bool
 
     /// Modifier set applied to each activity's shortcut.
     /// `.command` for the left column, `[.command, .shift]`
@@ -45,8 +56,9 @@ struct ActivityBarView<Activity: ActivityEntry>: View {
                 ActivityBarButton(
                     activity: activity,
                     isSelected: selection == activity,
+                    isPanelOpen: selection == activity && isOpen,
                     shortcutModifiers: shortcutModifiers,
-                    onTap: { toggle(activity) }
+                    onTap: { tap(activity) }
                 )
             }
             Spacer(minLength: 0)
@@ -56,17 +68,22 @@ struct ActivityBarView<Activity: ActivityEntry>: View {
         .background(Color(nsColor: .underPageBackgroundColor))
     }
 
-    /// Select `activity`, or clear the selection if `activity`
-    /// was already selected. Mirrors the Linux "same-button
-    /// toggles panel while keeping the icon selected" intent
-    /// — on Mac the icon visual selection simply falls out of
-    /// the `selection == activity` read below, so no separate
-    /// "icon pressed but panel closed" state is needed.
-    private func toggle(_ activity: Activity) {
+    /// Click-handler semantics — matches the GTK
+    /// `wire_activity_bar_clicks` comment in
+    /// `sdr-ui/src/window.rs`:
+    ///
+    /// - Tapping the **currently-selected** icon toggles the
+    ///   panel open/closed. Selection stays put so the icon
+    ///   remains visually active.
+    /// - Tapping a **different** icon switches selection AND
+    ///   opens the panel (matching Linux "different-button
+    ///   swaps stack + opens panel").
+    private func tap(_ activity: Activity) {
         if selection == activity {
-            selection = nil
+            isOpen.toggle()
         } else {
             selection = activity
+            isOpen = true
         }
     }
 }
@@ -76,7 +93,17 @@ struct ActivityBarView<Activity: ActivityEntry>: View {
 /// visual treatment live in one place.
 private struct ActivityBarButton<Activity: ActivityEntry>: View {
     let activity: Activity
+    /// `true` when this is the column's currently-selected
+    /// activity. Persists across open/close so the icon stays
+    /// visually highlighted even when the panel is closed —
+    /// matches the Linux activity-bar contract.
     let isSelected: Bool
+    /// `true` only when this activity is selected AND its
+    /// panel is open. Drives the `.isSelected` accessibility
+    /// trait so VoiceOver announces "selected" only for the
+    /// active panel, not for a remembered-but-collapsed
+    /// selection.
+    let isPanelOpen: Bool
     let shortcutModifiers: EventModifiers
     let onTap: () -> Void
 
@@ -97,6 +124,12 @@ private struct ActivityBarButton<Activity: ActivityEntry>: View {
         .keyboardShortcut(shortcutKey, modifiers: shortcutModifiers)
         .help(helpText)
         .accessibilityLabel(helpText)
+        // Surface the active state to VoiceOver. The visual
+        // highlight (tint + background) tells sighted users
+        // which panel is active; the `.isSelected` trait
+        // tells screen readers the same thing. Per `CodeRabbit`
+        // round 1 on PR #491.
+        .accessibilityAddTraits(isPanelOpen ? .isSelected : [])
     }
 
     /// Key equivalent for the 1..9 shortcut mapping. Out-of-range

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
@@ -8,12 +8,14 @@
 // the left column (6 entries, `⌘1..6`) and the right column
 // (1 entry in scaffolding — `⌘⇧1` — grows to 2 after #448).
 //
-// Click semantics:
-// - Click an unselected icon → selects that activity, opens
-//   its panel.
-// - Click the currently-selected icon → clears selection,
-//   closes the panel. (Icon stays visible; just the panel
-//   slides away.)
+// Click semantics (mirrors the GTK
+// `wire_activity_bar_clicks` doc in `sdr-ui/src/window.rs`):
+//
+// - Click an unselected icon → selects that activity AND
+//   opens its panel.
+// - Click the currently-selected icon → toggles the panel
+//   open / closed; selection stays put so the icon keeps
+//   its highlight even when the panel is collapsed.
 //
 // Keyboard shortcut semantics match the Linux accelerators:
 // the index (1..N) binds to a `KeyEquivalent` of "1".."N" with
@@ -121,7 +123,11 @@ private struct ActivityBarButton<Activity: ActivityEntry>: View {
                 .foregroundStyle(isSelected ? Color.accentColor : .primary)
         }
         .buttonStyle(.plain)
-        .keyboardShortcut(shortcutKey, modifiers: shortcutModifiers)
+        // Pass the shortcut as an optional `KeyboardShortcut?`
+        // so an out-of-range `shortcutIndex` (>9) registers no
+        // shortcut at all rather than silently binding the Tab
+        // key. Per `CodeRabbit` round 2 on PR #491.
+        .keyboardShortcut(keyboardShortcut)
         .help(helpText)
         .accessibilityLabel(helpText)
         // Surface the active state to VoiceOver. The visual
@@ -132,23 +138,32 @@ private struct ActivityBarButton<Activity: ActivityEntry>: View {
         .accessibilityAddTraits(isPanelOpen ? .isSelected : [])
     }
 
-    /// Key equivalent for the 1..9 shortcut mapping. Out-of-range
-    /// indices degrade to no shortcut rather than crash — the
-    /// enums above all stay within 1..9, but belt-and-suspenders
-    /// in case a future activity is added past 9.
-    private var shortcutKey: KeyEquivalent {
+    /// `KeyboardShortcut?` for this button. Returns `nil` when
+    /// `shortcutIndex` falls outside `1...9`, which causes
+    /// `.keyboardShortcut(_:)` to register no shortcut at all
+    /// (the optional API form is the documented "no shortcut"
+    /// path; passing a real `KeyEquivalent` like `.tab` as a
+    /// fallback would actually bind the Tab key, which is the
+    /// trap CodeRabbit caught).
+    ///
+    /// All current activity enums stay within 1...9, so this
+    /// branch is a defensive guard for a future enum that adds
+    /// a 10th entry without expanding the digit table.
+    private var keyboardShortcut: KeyboardShortcut? {
+        let key: KeyEquivalent
         switch activity.shortcutIndex {
-        case 1: return "1"
-        case 2: return "2"
-        case 3: return "3"
-        case 4: return "4"
-        case 5: return "5"
-        case 6: return "6"
-        case 7: return "7"
-        case 8: return "8"
-        case 9: return "9"
-        default: return .tab  // unreachable under current enums
+        case 1: key = "1"
+        case 2: key = "2"
+        case 3: key = "3"
+        case 4: key = "4"
+        case 5: key = "5"
+        case 6: key = "6"
+        case 7: key = "7"
+        case 8: key = "8"
+        case 9: key = "9"
+        default: return nil
         }
+        return KeyboardShortcut(key, modifiers: shortcutModifiers)
     }
 
     private var helpText: String {

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
@@ -1,0 +1,139 @@
+//
+// ActivityBarView.swift — narrow icon-only column that selects
+// which panel is visible next to it. Mirrors the GTK
+// `build_activity_bar` widget from
+// `crates/sdr-ui/src/sidebar/activity_bar.rs`.
+//
+// Generic over `ActivityEntry` so the same view renders both
+// the left column (6 entries, `⌘1..6`) and the right column
+// (1 entry in scaffolding — `⌘⇧1` — grows to 2 after #448).
+//
+// Click semantics:
+// - Click an unselected icon → selects that activity, opens
+//   its panel.
+// - Click the currently-selected icon → clears selection,
+//   closes the panel. (Icon stays visible; just the panel
+//   slides away.)
+//
+// Keyboard shortcut semantics match the Linux accelerators:
+// the index (1..N) binds to a `KeyEquivalent` of "1".."N" with
+// the supplied modifier set (`.command` for left, `.command
+// + .shift` for right).
+
+import SwiftUI
+
+struct ActivityBarView<Activity: ActivityEntry>: View {
+    /// Selected activity for this column, or `nil` when the
+    /// panel is closed. Binding so parent view owns the state;
+    /// session persistence wires into this same binding in #449.
+    @Binding var selection: Activity?
+
+    /// Modifier set applied to each activity's shortcut.
+    /// `.command` for the left column, `[.command, .shift]`
+    /// for the right — matches the Linux accelerator scheme.
+    let shortcutModifiers: EventModifiers
+
+    /// Static column width. Matches the GTK 48 px icon strip —
+    /// wide enough for a 24 pt SF Symbol + comfortable padding,
+    /// narrow enough that it doesn't steal space from the
+    /// panels it flanks.
+    static var columnWidth: CGFloat { 44 }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ForEach(Array(Activity.allCases), id: \.self) { activity in
+                ActivityBarButton(
+                    activity: activity,
+                    isSelected: selection == activity,
+                    shortcutModifiers: shortcutModifiers,
+                    onTap: { toggle(activity) }
+                )
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 6)
+        .frame(width: Self.columnWidth)
+        .background(Color(nsColor: .underPageBackgroundColor))
+    }
+
+    /// Select `activity`, or clear the selection if `activity`
+    /// was already selected. Mirrors the Linux "same-button
+    /// toggles panel while keeping the icon selected" intent
+    /// — on Mac the icon visual selection simply falls out of
+    /// the `selection == activity` read below, so no separate
+    /// "icon pressed but panel closed" state is needed.
+    private func toggle(_ activity: Activity) {
+        if selection == activity {
+            selection = nil
+        } else {
+            selection = activity
+        }
+    }
+}
+
+/// Single icon-only button in the activity bar. Extracted so
+/// the `.keyboardShortcut` modifier and the selection-state
+/// visual treatment live in one place.
+private struct ActivityBarButton<Activity: ActivityEntry>: View {
+    let activity: Activity
+    let isSelected: Bool
+    let shortcutModifiers: EventModifiers
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Image(systemName: activity.systemImage)
+                .font(.system(size: 18, weight: .regular))
+                .frame(width: 36, height: 32)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isSelected
+                              ? Color.accentColor.opacity(0.22)
+                              : Color.clear)
+                )
+                .foregroundStyle(isSelected ? Color.accentColor : .primary)
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(shortcutKey, modifiers: shortcutModifiers)
+        .help(helpText)
+        .accessibilityLabel(helpText)
+    }
+
+    /// Key equivalent for the 1..9 shortcut mapping. Out-of-range
+    /// indices degrade to no shortcut rather than crash — the
+    /// enums above all stay within 1..9, but belt-and-suspenders
+    /// in case a future activity is added past 9.
+    private var shortcutKey: KeyEquivalent {
+        switch activity.shortcutIndex {
+        case 1: return "1"
+        case 2: return "2"
+        case 3: return "3"
+        case 4: return "4"
+        case 5: return "5"
+        case 6: return "6"
+        case 7: return "7"
+        case 8: return "8"
+        case 9: return "9"
+        default: return .tab  // unreachable under current enums
+        }
+    }
+
+    private var helpText: String {
+        // Build the shortcut string Mac-style: ⌘1 / ⌘⇧1.
+        let shortcut = formatShortcut(
+            index: activity.shortcutIndex,
+            modifiers: shortcutModifiers
+        )
+        return "\(activity.label) (\(shortcut))"
+    }
+
+    private func formatShortcut(index: Int, modifiers: EventModifiers) -> String {
+        var s = ""
+        if modifiers.contains(.control) { s += "⌃" }
+        if modifiers.contains(.option)  { s += "⌥" }
+        if modifiers.contains(.shift)   { s += "⇧" }
+        if modifiers.contains(.command) { s += "⌘" }
+        s += "\(index)"
+        return s
+    }
+}

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift
@@ -166,8 +166,15 @@ private struct ActivityBarButton<Activity: ActivityEntry>: View {
         return KeyboardShortcut(key, modifiers: shortcutModifiers)
     }
 
+    /// Tooltip + accessibility label. Falls back to just the
+    /// activity label when `keyboardShortcut` is `nil`, so an
+    /// out-of-range `shortcutIndex` doesn't show a phantom
+    /// `⌘10` glyph that wouldn't actually fire. Per
+    /// `CodeRabbit` round 3 on PR #491.
     private var helpText: String {
-        // Build the shortcut string Mac-style: ⌘1 / ⌘⇧1.
+        guard keyboardShortcut != nil else {
+            return activity.label
+        }
         let shortcut = formatShortcut(
             index: activity.shortcutIndex,
             modifiers: shortcutModifiers

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityEntry.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityEntry.swift
@@ -1,0 +1,136 @@
+//
+// ActivityEntry.swift — canonical slices for the sidebar activity
+// bars on macOS, mirroring the Linux `LEFT_ACTIVITIES` /
+// `RIGHT_ACTIVITIES` slices in
+// `crates/sdr-ui/src/sidebar/activity_bar.rs`.
+//
+// Each case's `rawValue` is the persistence key that session
+// storage (#449) will consume from the shared `sdr-config`
+// JSON — lowercase kebab-case, matching the Linux `name:`
+// field exactly. Do not rename without also renaming the
+// Linux constants; both frontends read the same file and a
+// schema mismatch would wipe the user's sidebar layout on
+// cross-frontend launch.
+//
+// Per epic #441 and sub-ticket #442.
+
+import SwiftUI
+
+/// Protocol shared by `LeftActivity` and `RightActivity` so
+/// `ActivityBarView` can render either column with the same
+/// code.
+protocol ActivityEntry: Hashable, Identifiable, CaseIterable {
+    /// Short human-readable label; used as tooltip + accessibility
+    /// label on the icon button and as the header of the
+    /// corresponding panel.
+    var label: String { get }
+
+    /// SF Symbol name for the icon-only activity-bar button.
+    /// Chosen to approximate the Linux `icon_name` Symbolic
+    /// icon (Adwaita glyphs → SF Symbols is approximate by
+    /// necessity; the names below are judgment calls).
+    var systemImage: String { get }
+
+    /// 1-based number key for the keyboard shortcut. Left
+    /// activities use `⌘1..6`; right activities use `⌘⇧1..2`.
+    /// `ActivityBarView` reads this to wire `.keyboardShortcut`.
+    var shortcutIndex: Int { get }
+
+    /// Lowercase kebab-case persistence key. Stored as-is in
+    /// the shared config JSON that the Linux side also reads.
+    /// Same string as `rawValue` below — this accessor exists
+    /// so `ActivityBarView` can log / debug without coupling
+    /// to the raw-value semantic.
+    var persistenceName: String { get }
+}
+
+// Default for Int-free `id` on String-raw enums — Swift can't
+// synthesize both automatically when the protocol also demands
+// `CaseIterable`.
+extension ActivityEntry where Self: RawRepresentable, RawValue == String {
+    var id: String { rawValue }
+    var persistenceName: String { rawValue }
+}
+
+/// Left activity bar — six slots, ordered identically to
+/// `LEFT_ACTIVITIES` in `activity_bar.rs`. Reordering would
+/// drift the `⌘1..6` shortcuts between frontends.
+enum LeftActivity: String, CaseIterable, Identifiable, ActivityEntry {
+    case general
+    case radio
+    case audio
+    case display
+    case scanner
+    case share
+
+    var label: String {
+        switch self {
+        case .general: return "General"
+        case .radio:   return "Radio"
+        case .audio:   return "Audio"
+        case .display: return "Display"
+        case .scanner: return "Scanner"
+        case .share:   return "Share"
+        }
+    }
+
+    /// SF Symbol picks approximating the Linux Adwaita icons:
+    /// - general → `slider.horizontal.3` (parity settings)
+    /// - radio → `antenna.radiowaves.left.and.right`
+    /// - audio → `speaker.wave.2`
+    /// - display → `waveform`
+    /// - scanner → `dot.radiowaves.forward`
+    /// - share → `network` (`network-transmit-receive-symbolic`)
+    var systemImage: String {
+        switch self {
+        case .general: return "slider.horizontal.3"
+        case .radio:   return "antenna.radiowaves.left.and.right"
+        case .audio:   return "speaker.wave.2"
+        case .display: return "waveform"
+        case .scanner: return "dot.radiowaves.forward"
+        case .share:   return "network"
+        }
+    }
+
+    var shortcutIndex: Int {
+        switch self {
+        case .general: return 1
+        case .radio:   return 2
+        case .audio:   return 3
+        case .display: return 4
+        case .scanner: return 5
+        case .share:   return 6
+        }
+    }
+}
+
+/// Right activity bar — transcript slot only in scaffolding;
+/// bookmarks lands in `#448` (Right activity bar + Transcript)
+/// when the existing toolbar-toggled `BookmarksPanel` flyout
+/// migrates to the activity-bar pattern.
+///
+/// Kept as a separate enum from `LeftActivity` so the compiler
+/// enforces that a left selection can't accidentally be used
+/// in the right-bar binding (the two columns have different
+/// shortcut-modifier sets and different default widths).
+enum RightActivity: String, CaseIterable, Identifiable, ActivityEntry {
+    case transcript
+
+    var label: String {
+        switch self {
+        case .transcript: return "Transcript"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .transcript: return "text.bubble"
+        }
+    }
+
+    var shortcutIndex: Int {
+        switch self {
+        case .transcript: return 1
+        }
+    }
+}

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityPanelHost.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityPanelHost.swift
@@ -1,0 +1,104 @@
+//
+// ActivityPanelHost.swift — renders the panel body for the
+// currently-selected activity. Scaffolding only: every slot
+// shows a `ComingSoonPanel` placeholder with the activity's
+// label + icon + a pointer to the sub-ticket that will fill
+// it in.
+//
+// Subsequent sub-tickets (#443–#447, #448) replace each
+// placeholder's branch with the real panel view.
+//
+// Per epic #441 and sub-ticket #442.
+
+import SwiftUI
+
+/// Left panel host — switches on `LeftActivity` to pick which
+/// view renders as the currently-selected left panel.
+struct LeftPanelHost: View {
+    let activity: LeftActivity
+
+    var body: some View {
+        switch activity {
+        case .general:
+            ComingSoonPanel(
+                activity: activity,
+                followUpTicket: "#443 — General panel (band + source)"
+            )
+        case .radio:
+            ComingSoonPanel(
+                activity: activity,
+                followUpTicket: "#444 — Radio panel"
+            )
+        case .audio:
+            ComingSoonPanel(
+                activity: activity,
+                followUpTicket: "#445 — Audio panel + volume persistence"
+            )
+        case .display:
+            ComingSoonPanel(
+                activity: activity,
+                followUpTicket: "#446 — Display panel"
+            )
+        case .scanner:
+            ComingSoonPanel(
+                activity: activity,
+                followUpTicket: "#447 — Scanner panel"
+            )
+        case .share:
+            // Share = rtl_tcp server + client + discovery. The
+            // existing RtlTcpServerSection / SourceSection
+            // rtl_tcp arm fills this slot once #447/#443 port
+            // their content.
+            ComingSoonPanel(
+                activity: activity,
+                followUpTicket: "#443/#447 — rtl_tcp share (server + client)"
+            )
+        }
+    }
+}
+
+/// Right panel host — one activity during scaffolding
+/// (`#442`); Bookmarks lands in `#448`.
+struct RightPanelHost: View {
+    let activity: RightActivity
+
+    var body: some View {
+        switch activity {
+        case .transcript:
+            ComingSoonPanel(
+                activity: activity,
+                followUpTicket: "#448 — Transcript + right activity bar"
+            )
+        }
+    }
+}
+
+/// Placeholder body for any activity slot whose real content
+/// hasn't been ported yet. Shows the activity's icon + label
+/// prominently plus a small pointer to the sub-ticket that
+/// will fill it in, so anyone running the intermediate build
+/// knows what's missing and why.
+private struct ComingSoonPanel<Activity: ActivityEntry>: View {
+    let activity: Activity
+    let followUpTicket: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: activity.systemImage)
+                .font(.system(size: 48, weight: .light))
+                .foregroundStyle(.secondary)
+            Text(activity.label)
+                .font(.title2)
+                .fontWeight(.medium)
+            Text("Coming in \(followUpTicket).")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+}

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityPanelHost.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityPanelHost.swift
@@ -20,10 +20,26 @@ struct LeftPanelHost: View {
     var body: some View {
         switch activity {
         case .general:
-            ComingSoonPanel(
-                activity: activity,
-                followUpTicket: "#443 — General panel (band + source)"
-            )
+            // Scaffolding compromise per `CodeRabbit` round 2
+            // on PR #491: the legacy sidebar Form (Source +
+            // Radio + Display + Recording + Bookmarks +
+            // RtlTcpServer sections) hangs off the General
+            // slot during scaffolding so the user retains
+            // access to every existing control. Subsequent
+            // sub-tickets carve sections OUT of this Form
+            // and into their dedicated activity panels:
+            //
+            //  #443 → Source moves out (General panel proper)
+            //  #444 → Radio moves out
+            //  #445 → Audio (Recording) moves out
+            //  #446 → Display moves out
+            //  #447 → Scanner panel
+            //
+            // After all five land, this case will only carry
+            // the band presets + the trimmed Source content.
+            // Mirrors the Linux scaffolding decision in
+            // `crates/sdr-ui/src/window.rs`.
+            LegacySidebarPanel()
         case .radio:
             ComingSoonPanel(
                 activity: activity,
@@ -70,6 +86,37 @@ struct RightPanelHost: View {
                 followUpTicket: "#448 — Transcript + right activity bar"
             )
         }
+    }
+}
+
+/// Scaffolding-only stand-in for the General slot — keeps the
+/// pre-redesign sidebar Form (with every existing section)
+/// reachable while subsequent sub-tickets carve sections out
+/// into dedicated activity panels. Verbatim copy of the
+/// pre-#442 `SidebarView` body so the user loses nothing
+/// during the redesign transition.
+///
+/// Each carve-out sub-ticket (#443–#447) deletes the
+/// corresponding `*Section()` line from this body and stands
+/// up the matching panel in `LeftPanelHost`. When all five
+/// have landed, this struct can be deleted entirely.
+struct LegacySidebarPanel: View {
+    var body: some View {
+        Form {
+            SourceSection()
+            RadioSection()
+            DisplaySection()
+            RecordingSection()
+            BookmarksSection()
+            // `RtlTcpServerSection` is visible only when a
+            // local RTL-SDR dongle is detected — the section
+            // itself is always included in the form, but the
+            // body collapses to a single "no dongle" caption
+            // otherwise so it doesn't clutter the sidebar on
+            // a network/file source setup.
+            RtlTcpServerSection()
+        }
+        .formStyle(.grouped)
     }
 }
 


### PR DESCRIPTION
First of ten sub-tickets under epic #441 (macOS activity-bar sidebar redesign, mirroring the GTK work from #420 / PRs #431–#440). Lays the layout frame; real panel content lands in #443–#447 (left) and #448 (right).

## What's in

**New files** under `apps/macos/SDRMac/Views/ActivityBar/`:

- **`ActivityEntry.swift`** — \`LeftActivity\` (6 cases, \`⌘1..6\`) and \`RightActivity\` (1 case in scaffolding, \`⌘⇧1\`). \`rawValue\` keys match the Linux \`LEFT_ACTIVITIES\` / \`RIGHT_ACTIVITIES\` \`name\` fields in \`crates/sdr-ui/src/sidebar/activity_bar.rs\` so #449's session-persistence layer can consume the same \`sdr-config\` JSON the GTK app writes.
- **`ActivityBarView.swift`** — generic over \`ActivityEntry\`. Renders a 44pt icon-only column with click-to-toggle selection, keyboard shortcuts, and an accent-tinted background on the active icon.
- **`ActivityPanelHost.swift`** — \`LeftPanelHost\` / \`RightPanelHost\` switch on selection. All seven slots are \`ComingSoonPanel\` placeholders today, each pointing at its follow-up sub-ticket.

**`ContentView.swift`** rewired from \`NavigationSplitView\` into an \`HStack\`:

\`\`\`
[L bar] │ [L panel?] │ detail column │ [R panel?] │ [R bar]
\`\`\`

Detail column preserves the existing spectrum + status + Transcription / Bookmarks flyouts unchanged. #448 consolidates the right-side surfaces when the real Transcript panel ports into the activity bar.

## What's deliberately preserved (no regression)

- Header toolbar (Play/Stop, frequency entry, demod picker, Transcription / Bookmarks / RadioReference buttons)
- RadioReference sheet + ABI-mismatch modal
- \`scenePhase\` hooks (RR credentials refresh, USB hotplug fallback probe)
- Mutual-exclusivity + UserDefaults persistence for the existing right flyouts

## Acceptance (per #442)

- [x] App launches; both activity bars render (6 left + 1 right).
- [x] Clicking an icon changes the panel to its placeholder.
- [x] \`⌘1..6\` and \`⌘⇧1\` keyboard shortcuts work.
- [x] No regressions in spectrum / waterfall / status rendering.

## Non-goals

- Real panel content — placeholders only (#443–#447, #448).
- Session persistence — #449.
- Resize persistence / draggable dividers — #450.
- \`HSplitView\` adoption — #450.

## Follow-ups in the redesign chain

Run order from the plan we built up: **#442 (this)** → #443 → #444 → #486 (FSPL into Radio) → #488 (VFO reset into Radio) → #445 → #446 → #487 (antenna calc, status-bar) → #447 → #490 (bookmark scan/priority) → #417 (rtl_tcp codec picker, after #401) → #448 → #449 → #450 → #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned macOS UI with always-visible left and right activity bars, independent selection and open/closed state per side.
  * Added activity panel hosts with temporary "Coming Soon" panels for not-yet-implemented activities.
  * Numeric keyboard shortcuts (1–9) for activity buttons; shortcut hints shown in help text.

* **Accessibility**
  * Improved accessibility labels and selection traits for activity buttons.

* **Bug Fixes / UX**
  * Refined flyout animation timing for smoother panel transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->