### PR TITLE
SwiftUI: scanner panel + ABI 0.20 backfill (closes #447)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "sdr-radioreference",
  "sdr-rtlsdr",
  "sdr-rtltcp-discovery",
+ "sdr-scanner",
  "sdr-server-rtltcp",
  "sdr-sink-audio",
  "sdr-types",

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -616,6 +616,44 @@ public final class SdrCore: @unchecked Sendable {
     }
 
     // ==========================================================
+    //  Scanner — ABI 0.20, issue #447. Master enable + per-
+    //  channel session lockout / unlock. Channel-list projection
+    //  follows in #490 when the macOS bookmark layer grows the
+    //  `scan_enabled` / `priority` fields the Linux side already
+    //  has.
+    // ==========================================================
+
+    /// Master scanner enable / disable. Tripping this on with no
+    /// projected channels leaves the engine in `.idle` (visible
+    /// via the `scannerStateChanged` event); the host doesn't
+    /// need to special-case empty rotation.
+    public func setScannerEnabled(_ enabled: Bool) throws {
+        try checkRc(sdr_core_set_scanner_enabled(handle, enabled))
+    }
+
+    /// Lock out a channel for the rest of the scanner session.
+    ///
+    /// `name` + `frequencyHz` together form the scanner's channel
+    /// identity — they must match the channel's identity at
+    /// projection time exactly. Lockouts persist until the
+    /// channel is unlocked (`unlockScannerChannel`), the scanner
+    /// is disabled, or the engine is destroyed.
+    public func lockoutScannerChannel(name: String, frequencyHz: UInt64) throws {
+        try checkRc(name.withCString {
+            sdr_core_lockout_scanner_channel(handle, $0, frequencyHz)
+        })
+    }
+
+    /// Clear a session lockout previously installed by
+    /// `lockoutScannerChannel`. No-op if the channel wasn't
+    /// locked out.
+    public func unlockScannerChannel(name: String, frequencyHz: UInt64) throws {
+        try checkRc(name.withCString {
+            sdr_core_unlock_scanner_channel(handle, $0, frequencyHz)
+        })
+    }
+
+    // ==========================================================
     //  FFT frame pull
     // ==========================================================
 

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
@@ -200,6 +200,76 @@ public enum NetworkSinkStatus: Sendable, Equatable {
     case error(message: String)
 }
 
+/// Scanner phase surfaced via the `scannerStateChanged` engine
+/// event. Mirrors `sdr_scanner::ScannerState` on the Rust side.
+/// Matches `SdrScannerState` in the C header. Per issue #447.
+public enum ScannerState: Int32, Sendable, CaseIterable, Codable {
+    /// Scanner off, or on with no channels enabled.
+    case idle      = 0
+    /// Retune in flight; audio muted, waiting for settle.
+    case retuning  = 1
+    /// Settled on the channel; audio still muted; waiting for
+    /// a squelch-open event within the dwell window.
+    case dwelling  = 2
+    /// Squelch open post-settle, audio flowing.
+    case listening = 3
+    /// Squelch closed, hang countdown before advancing.
+    case hanging   = 4
+
+    /// Single-word label for the scanner panel's State row.
+    /// Matches the GTK panel's vocabulary so the wording stays
+    /// consistent across frontends.
+    public var label: String {
+        switch self {
+        case .idle:      return "Off"
+        case .retuning:  return "Retuning…"
+        case .dwelling:  return "Listening…"
+        case .listening: return "Listening"
+        case .hanging:   return "Hang…"
+        }
+    }
+}
+
+/// Why the scanner ↔ recording / transcription mutex fired.
+/// Surfaced via the `scannerMutexStopped` engine event. Mirrors
+/// `sdr_core::messages::ScannerMutexReason`. Matches
+/// `SdrScannerMutexReason` in the C header. Per issue #447.
+public enum ScannerMutexReason: Int32, Sendable, CaseIterable {
+    /// Scanner activation stopped a running recording.
+    case recordingStoppedForScanner     = 0
+    /// Scanner activation stopped a running transcription.
+    case transcriptionStoppedForScanner = 1
+    /// Recording start stopped an active scanner.
+    case scannerStoppedForRecording     = 2
+    /// Transcription start stopped an active scanner.
+    case scannerStoppedForTranscription = 3
+
+    /// Toast copy describing the transition. The wording mirrors
+    /// the GTK frontend's strings so cross-platform docs and
+    /// support material stay in sync.
+    public var toastMessage: String {
+        switch self {
+        case .recordingStoppedForScanner:
+            return "Recording stopped — scanner started."
+        case .transcriptionStoppedForScanner:
+            return "Transcription stopped — scanner started."
+        case .scannerStoppedForRecording:
+            return "Scanner stopped — recording started."
+        case .scannerStoppedForTranscription:
+            return "Scanner stopped — transcription started."
+        }
+    }
+}
+
+/// Identity of the scanner's currently-latched channel surfaced
+/// via the `scannerActiveChannelChanged` engine event. The
+/// scanner emits a `nil` payload when it returns to idle and a
+/// non-nil one each time it latches on a new channel.
+public struct ScannerActiveChannel: Sendable, Equatable {
+    public let name: String
+    public let frequencyHz: UInt64
+}
+
 /// FFT window function. Matches `SdrFftWindow` in the C header.
 ///
 /// Only three variants because that's what

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -43,6 +43,10 @@ private let kIqRecordingStarted    = Int32(SDR_EVT_IQ_RECORDING_STARTED.rawValue
 private let kIqRecordingStopped    = Int32(SDR_EVT_IQ_RECORDING_STOPPED.rawValue)
 private let kNetworkSinkStatus     = Int32(SDR_EVT_NETWORK_SINK_STATUS.rawValue)
 private let kRtlTcpConnectionState = Int32(SDR_EVT_RTL_TCP_CONNECTION_STATE.rawValue)
+private let kScannerStateChanged          = Int32(SDR_EVT_SCANNER_STATE_CHANGED.rawValue)
+private let kScannerActiveChannelChanged  = Int32(SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED.rawValue)
+private let kScannerEmptyRotation         = Int32(SDR_EVT_SCANNER_EMPTY_ROTATION.rawValue)
+private let kScannerMutexStopped          = Int32(SDR_EVT_SCANNER_MUTEX_STOPPED.rawValue)
 
 /// High-level event from the engine.
 ///
@@ -110,6 +114,26 @@ public enum SdrCoreEvent: Sendable, Equatable {
     /// (connect / disconnect / retry countdown tick) so hosts
     /// can drive a live status row. Per issue #325.
     case rtlTcpConnectionState(RtlTcpConnectionState)
+
+    /// Scanner phase transition — host updates the State row in
+    /// the scanner panel. Per issue #447 (ABI 0.20).
+    case scannerStateChanged(ScannerState)
+
+    /// Scanner latched on a new channel (`channel` non-nil) or
+    /// returned to idle (`channel == nil`). Host updates the
+    /// Channel row's subtitle. Per issue #447 (ABI 0.20).
+    case scannerActiveChannelChanged(ScannerActiveChannel?)
+
+    /// Rotation exhausted because all channels are absent or
+    /// locked out. Host can show a brief toast before the panel
+    /// readout resets. Per issue #447 (ABI 0.20).
+    case scannerEmptyRotation
+
+    /// The scanner ↔ recording / transcription mutex fired —
+    /// either the scanner stopped one of those (or vice versa).
+    /// Host shows a toast describing the transition. Per issue
+    /// #447 (ABI 0.20).
+    case scannerMutexStopped(ScannerMutexReason)
 
     /// Translate a C `SdrEvent` into a Swift value.
     ///
@@ -219,6 +243,48 @@ public enum SdrCoreEvent: Sendable, Equatable {
                 // silently, matches the outer `default` policy.
                 return nil
             }
+
+        case kScannerStateChanged:
+            let raw = payload.scanner_state.state
+            guard let state = ScannerState(rawValue: raw) else {
+                // Unknown phase — future ABI extension. Drop
+                // silently rather than mapping to a fallback,
+                // since the host's State-row label would lie.
+                return nil
+            }
+            return .scannerStateChanged(state)
+
+        case kScannerActiveChannelChanged:
+            let active = payload.scanner_active_channel
+            guard let cstr = active.name_utf8 else {
+                // Idle sentinel — scanner cleared the latched
+                // channel. Host clears its readout.
+                return .scannerActiveChannelChanged(nil)
+            }
+            let name = String(cString: cstr)
+            // The Rust side promises non-empty strings on
+            // latched events. An empty name with a non-null
+            // pointer would still be malformed; drop it rather
+            // than leaving the host's readout in an
+            // ambiguous "named with nothing" state.
+            guard !name.isEmpty else { return nil }
+            return .scannerActiveChannelChanged(
+                ScannerActiveChannel(name: name, frequencyHz: active.frequency_hz)
+            )
+
+        case kScannerEmptyRotation:
+            return .scannerEmptyRotation
+
+        case kScannerMutexStopped:
+            let raw = payload.scanner_mutex_stopped.reason
+            guard let reason = ScannerMutexReason(rawValue: raw) else {
+                // Unknown reason — drop silently. A future ABI
+                // extension would land in a known direction; a
+                // pop-a-toast-with-nothing-to-say payload helps
+                // no one.
+                return nil
+            }
+            return .scannerMutexStopped(reason)
 
         case kNetworkSinkStatus:
             let status = payload.network_sink_status

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpDiscovery.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpDiscovery.swift
@@ -83,6 +83,17 @@ public final class SdrRtlTcpAdvertiser: @unchecked Sendable {
                 options.tuner.withCString { tunerPtr in
                     options.version.withCString { versionPtr in
                         options.nickname.withCString { nicknamePtr -> Int32 in
+                            // ABI 0.19 (#400) appended four
+                            // opt-in TXT fields at the tail:
+                            // `has_codecs` / `codecs` /
+                            // `has_auth_required` /
+                            // `auth_required`. Mac-side UI for
+                            // any of these (compression toggle,
+                            // auth-required badge) follows in
+                            // #496; until then the wrapper
+                            // publishes neither key, matching
+                            // pre-0.19 advertisement behaviour
+                            // exactly.
                             var opts = SdrRtlTcpAdvertiseOptions(
                                 port: options.port,
                                 instance_name: instancePtr,
@@ -92,7 +103,11 @@ public final class SdrRtlTcpAdvertiser: @unchecked Sendable {
                                 gains: options.gains,
                                 nickname: nicknamePtr,
                                 has_txbuf: options.txbufBytes != nil,
-                                txbuf: options.txbufBytes ?? 0
+                                txbuf: options.txbufBytes ?? 0,
+                                has_codecs: false,
+                                codecs: 0,
+                                has_auth_required: false,
+                                auth_required: false
                             )
                             return withUnsafePointer(to: &opts) { optsPtr in
                                 sdr_rtltcp_advertiser_start(optsPtr, &rawHandle)

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpServer.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpServer.swift
@@ -118,6 +118,20 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
         }
 
         fileprivate func toC() -> SdrRtlTcpServerConfig {
+            // ABI 0.16 (#392 / `listener_cap`), 0.17 (#394 /
+            // `auth_key` + `auth_key_len`), and 0.19 (#400 /
+            // `has_compression` + `compression`) appended fields
+            // at the tail. The Mac side hasn't surfaced auth /
+            // listener-cap / compression UI yet, so we pass the
+            // documented zero-init defaults that preserve pre-
+            // ABI-0.16 behaviour:
+            //   - listener_cap = 0     → crate default (10)
+            //   - auth_key = NULL,
+            //     auth_key_len = 0     → auth disabled (LAN trust)
+            //   - has_compression = false → CodecMask::NONE_ONLY
+            // When the Mac UI grows controls for any of these,
+            // promote the matching field to a typed Swift
+            // property and forward it from `Config`.
             SdrRtlTcpServerConfig(
                 bind_address: bindAddress.rawValue,
                 port: port,
@@ -128,51 +142,47 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
                 initial_gain_tenths_db: initialGainTenthsDb,
                 initial_ppm: initialPpm,
                 initial_bias_tee: initialBiasTee,
-                initial_direct_sampling: initialDirectSampling.rawValue
+                initial_direct_sampling: initialDirectSampling.rawValue,
+                listener_cap: 0,
+                auth_key: nil,
+                auth_key_len: 0,
+                has_compression: false,
+                compression: 0
             )
         }
     }
 
-    /// Snapshot of server stats. Maps `SdrRtlTcpServerStats` +
-    /// the two string outputs into one value for Swift callers.
+    /// Snapshot of server-wide stats. Maps the post-#391
+    /// (multi-client) `SdrRtlTcpServerStats` shape — aggregates
+    /// only — plus the tuner-name string output into one value.
+    ///
+    /// **Per-client state lives elsewhere now.** Pre-#391 this
+    /// struct carried `hasClient` / `connectedClientAddr` /
+    /// `currentFreqHz` etc. for the single connected client.
+    /// The engine became multi-client in #391; that detail
+    /// moved into `SdrRtlTcpClientInfo` rows fetched through
+    /// `sdr_rtltcp_server_client_list`. The Mac SwiftUI surface
+    /// for that list (per-client rows in the panel + the
+    /// `clientList()` Swift wrapper) lands in #496 — until
+    /// then the panel renders aggregates only.
     public struct Stats: Sendable, Equatable {
-        public var hasClient: Bool
-        public var connectedClientAddr: String
-        public var uptimeSecs: Double
-        public var bytesSent: UInt64
-        public var buffersDropped: UInt64
-        public var currentFreqHz: UInt32
-        public var currentSampleRateHz: UInt32
-        public var currentGainTenthsDb: Int32
-        public var currentGainAuto: Bool
-        /// `true` once the client has issued at least one
-        /// `SetTunerGain` command this session. Tracked
-        /// independently from the mode flag below so hosts can
-        /// distinguish "genuine 0 dB manual gain" from "client
-        /// hasn't asked yet." Per `CodeRabbit` round 7 on
-        /// PR #360.
-        public var hasCurrentGainValue: Bool
-        /// `true` once the client has issued at least one
-        /// `SetGainMode` command this session. Companion to
-        /// `currentGainAuto` — without this flag a `false`
-        /// reading would be indistinguishable from "no mode
-        /// requested yet."
-        public var hasCurrentGainMode: Bool
+        /// Number of clients connected at the moment of the
+        /// snapshot. Membership may change between this read
+        /// and a follow-up `clientList()` call (#496).
+        public var connectedCount: UInt32
+        /// Cumulative bytes fanned out across all clients over
+        /// the server's lifetime. Monotonic.
+        public var totalBytesSent: UInt64
+        /// Cumulative buffer drops across all clients. Monotonic.
+        public var totalBuffersDropped: UInt64
+        /// Cumulative count of clients accepted over the
+        /// server's lifetime. Persists across disconnects.
+        public var lifetimeAccepted: UInt64
+        /// Tuner family name reported by the dongle. Non-empty
+        /// for the entire server lifetime once `start` succeeded.
         public var tunerName: String
+        /// Number of discrete gain steps the tuner advertises.
         public var gainCount: UInt32
-        public var recentCommandsCount: UInt32
-    }
-
-    /// One row of the recent-commands ring — the JSON schema
-    /// the FFI produces.
-    public struct RecentCommand: Sendable, Equatable, Decodable {
-        public let op: String
-        public let secondsAgo: Double
-
-        enum CodingKeys: String, CodingKey {
-            case op
-            case secondsAgo = "seconds_ago"
-        }
     }
 
     // ----------------------------------------------------------
@@ -223,111 +233,49 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
     //  Snapshots
     // ----------------------------------------------------------
 
-    /// Capacity for the client-addr / tuner-name buffers
-    /// handed to `sdr_rtltcp_server_stats`. 64 bytes comfortably
-    /// fits any IPv6 + port string and any RTL-SDR tuner name.
-    private static let statsStringBufferLen = 64
+    /// Capacity for the tuner-name buffer handed to
+    /// `sdr_rtltcp_server_stats`. 64 bytes comfortably fits any
+    /// RTL-SDR tuner family name. The pre-#391 single-client
+    /// peer-address output buffer is gone — peer addresses live
+    /// on per-client `SdrRtlTcpClientInfo` rows now (#496).
+    private static let statsTunerNameBufferLen = 64
 
-    /// Capture a stats snapshot. Throws `SdrCoreError` on a
-    /// stopped server or other FFI error.
+    /// Capture a server-wide stats snapshot. Throws
+    /// `SdrCoreError` on a stopped server or other FFI error.
     ///
     /// The full FFI call runs inside the handle-box lock so a
-    /// concurrent `stop()` can't free the pointer mid-call. Per
-    /// `CodeRabbit` round 1 on PR #360.
+    /// concurrent `stop()` can't free the pointer mid-call —
+    /// same pattern as the engine's own handle wrappers.
+    ///
+    /// Per-client state (peer address, current tuning, recent
+    /// commands) is no longer in this snapshot — fetch it via
+    /// the upcoming `clientList()` / per-client recent-commands
+    /// surface (#496).
     public func stats() throws -> Stats {
         let result: Stats? = try handleBox.withHandle { handle -> Stats in
             var cStats = SdrRtlTcpServerStats()
-            var clientBuf = [CChar](repeating: 0, count: Self.statsStringBufferLen)
-            var tunerBuf = [CChar](repeating: 0, count: Self.statsStringBufferLen)
-            let rc = clientBuf.withUnsafeMutableBufferPointer { clientPtr in
-                tunerBuf.withUnsafeMutableBufferPointer { tunerPtr in
-                    sdr_rtltcp_server_stats(
-                        handle,
-                        &cStats,
-                        clientPtr.baseAddress,
-                        clientPtr.count,
-                        tunerPtr.baseAddress,
-                        tunerPtr.count
-                    )
-                }
+            var tunerBuf = [CChar](repeating: 0, count: Self.statsTunerNameBufferLen)
+            let rc = tunerBuf.withUnsafeMutableBufferPointer { tunerPtr in
+                sdr_rtltcp_server_stats(
+                    handle,
+                    &cStats,
+                    tunerPtr.baseAddress,
+                    tunerPtr.count
+                )
             }
             try checkRc(rc)
             return Stats(
-                hasClient: cStats.has_client,
-                connectedClientAddr: cStringToSwiftString(clientBuf),
-                uptimeSecs: cStats.uptime_secs,
-                bytesSent: cStats.bytes_sent,
-                buffersDropped: cStats.buffers_dropped,
-                currentFreqHz: cStats.current_freq_hz,
-                currentSampleRateHz: cStats.current_sample_rate_hz,
-                currentGainTenthsDb: cStats.current_gain_tenths_db,
-                currentGainAuto: cStats.current_gain_auto,
-                hasCurrentGainValue: cStats.has_current_gain_value,
-                hasCurrentGainMode: cStats.has_current_gain_mode,
+                connectedCount: cStats.connected_count,
+                totalBytesSent: cStats.total_bytes_sent,
+                totalBuffersDropped: cStats.total_buffers_dropped,
+                lifetimeAccepted: cStats.lifetime_accepted,
                 tunerName: cStringToSwiftString(tunerBuf),
-                gainCount: cStats.gain_count,
-                recentCommandsCount: cStats.recent_commands_count
+                gainCount: cStats.gain_count
             )
         }
         guard let stats = result else {
             throw SdrCoreError(code: .notRunning, message: "server already stopped")
         }
         return stats
-    }
-
-    /// Fetch the recent-commands ring as decoded rows. Calls
-    /// through `sdr_rtltcp_server_recent_commands_json` with a
-    /// start-4 KiB buffer and retries if the server reports it
-    /// needs more. Decode failures (bad UTF-8, malformed JSON)
-    /// propagate as `SdrCoreError` — an empty array is a valid
-    /// "no commands" result and shouldn't mask a real
-    /// serialization bug. Per `CodeRabbit` round 1 on PR #360.
-    public func recentCommands() throws -> [RecentCommand] {
-        let result: [RecentCommand]? = try handleBox.withHandle { handle -> [RecentCommand] in
-            var capacity = 4096
-            while true {
-                var buf = [CChar](repeating: 0, count: capacity)
-                var required: Int = 0
-                let rc = buf.withUnsafeMutableBufferPointer { ptr in
-                    sdr_rtltcp_server_recent_commands_json(
-                        handle, ptr.baseAddress, ptr.count, &required
-                    )
-                }
-                // OK (0): buffer was big enough — parse + return.
-                if rc == 0 {
-                    let json = cStringToSwiftString(buf)
-                    guard let data = json.data(using: .utf8) else {
-                        throw SdrCoreError(
-                            code: .internal,
-                            message: "recent-commands JSON is not valid UTF-8"
-                        )
-                    }
-                    do {
-                        return try JSONDecoder().decode([RecentCommand].self, from: data)
-                    } catch {
-                        throw SdrCoreError(
-                            code: .internal,
-                            message: "recent-commands JSON decode failed: \(error)"
-                        )
-                    }
-                }
-                // Too-small-buffer contract: `InvalidArg` with
-                // `required > buf_len`. Any other combination is
-                // a real failure and propagates.
-                if rc == SdrCoreError.Code.invalidArg.rawValue && required > capacity {
-                    // Retry with the server's reported required
-                    // size + a little slack so a race that
-                    // appends a command between calls doesn't
-                    // loop twice.
-                    capacity = required + 128
-                    continue
-                }
-                try checkRc(rc)
-            }
-        }
-        guard let commands = result else {
-            throw SdrCoreError(code: .notRunning, message: "server already stopped")
-        }
-        return commands
     }
 }

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -274,6 +274,53 @@ final class CoreModel {
     var notchFrequencyHz: Float = 1_000
 
     // ==========================================================
+    //  Scanner — issue #447 (ABI 0.20)
+    //
+    //  All four fields are engine-driven: the Mac side issues
+    //  `setScannerEnabled(_:)` and reads back the resulting
+    //  state via the `scannerStateChanged` /
+    //  `scannerActiveChannelChanged` event arms. We don't flip
+    //  these locally — the engine is authoritative.
+    //
+    //  Bookmark → `ScannerChannel` projection isn't wired yet;
+    //  flipping `scannerEnabled` true with no channels leaves
+    //  `scannerState == .idle`. Tracked under #490 (per-bookmark
+    //  scan/priority) — the panel footer surfaces the gap.
+    //
+    //  `scannerDefaultDwellMs` / `scannerDefaultHangMs` ARE
+    //  stored on this model (not engine-side) — they're "default
+    //  fallbacks the host folds into each `ScannerChannel` at
+    //  projection time", same pattern the Linux side uses.
+    //  Persisted via `UserDefaults` at write time.
+    // ==========================================================
+
+    /// Scanner master switch. Set via `setScannerEnabled(_:)`;
+    /// the engine echoes the resulting phase via
+    /// `scannerStateChanged` (which lands in `scannerState`).
+    var scannerEnabled: Bool = false
+
+    /// Scanner phase as last reported by the engine. Drives the
+    /// panel's State row and the lockout button's visibility
+    /// (button shows only when `scannerActiveChannel != nil`).
+    var scannerState: ScannerState = .idle
+
+    /// Channel the scanner is currently latched on, or `nil` when
+    /// idle. Drives the Channel row's subtitle and the lockout
+    /// button's identity (passed to
+    /// `lockoutScannerChannel(name:frequencyHz:)`).
+    var scannerActiveChannel: ScannerActiveChannel? = nil
+
+    /// Default per-channel settle time in ms. The host folds
+    /// this into each projected `ScannerChannel`'s `dwell_ms`
+    /// when the bookmark doesn't carry an override. Range
+    /// matches the Linux side (`DWELL_MIN_MS`..`DWELL_MAX_MS`).
+    var scannerDefaultDwellMs: Int = 100
+
+    /// Default per-channel hang time in ms. Same projection-time
+    /// fallback contract as `scannerDefaultDwellMs`.
+    var scannerDefaultHangMs: Int = 2_000
+
+    // ==========================================================
     //  Audio
     // ==========================================================
 
@@ -369,12 +416,17 @@ final class CoreModel {
     }
 
     /// Most-recent poll snapshot of server stats. `nil` while
-    /// the server isn't running.
+    /// the server isn't running. Aggregates only — per-client
+    /// state moved to the multi-client surface in #391 and
+    /// lands on the Mac side in #496.
     var rtlTcpServerStats: SdrRtlTcpServer.Stats? = nil
 
-    /// Last ~50 commands the client issued, newest first. Fed
-    /// by the poll task that also refreshes `rtlTcpServerStats`.
-    var rtlTcpRecentCommands: [SdrRtlTcpServer.RecentCommand] = []
+    // The pre-#391 single-client `rtlTcpRecentCommands` ring
+    // is gone — recent-commands tracking is per-client now and
+    // requires the multi-client list surface (#496) to map a
+    // client id back to its commands. The panel renders the
+    // server-wide aggregates `connectedCount` / `lifetimeAccepted`
+    // / `totalBytesSent` / `totalBuffersDropped` instead.
 
     /// Last error surfaced from a rtl_tcp server start or poll
     /// attempt. Cleared on successful start; mirrors into a
@@ -814,6 +866,23 @@ final class CoreModel {
             networkSinkProtocol = NetworkProtocol(rawValue: raw) ?? .tcpServer
         }
 
+        // Restore scanner timing defaults — issue #447.
+        // Out-of-range values are silently ignored (the Rust side
+        // also clamps); same defensive pattern as the network
+        // sink port restore above.
+        if UserDefaults.standard.object(forKey: Self.scannerDefaultDwellMsDefaultsKey) != nil {
+            let stored = UserDefaults.standard.integer(forKey: Self.scannerDefaultDwellMsDefaultsKey)
+            if (50...500).contains(stored) {
+                scannerDefaultDwellMs = stored
+            }
+        }
+        if UserDefaults.standard.object(forKey: Self.scannerDefaultHangMsDefaultsKey) != nil {
+            let stored = UserDefaults.standard.integer(forKey: Self.scannerDefaultHangMsDefaultsKey)
+            if (500...5_000).contains(stored) {
+                scannerDefaultHangMs = stored
+            }
+        }
+
         // Seed the RadioReference credentials flag from the
         // keyring so the sidebar panel / settings pane render
         // correctly on first paint without waiting for a user
@@ -1039,6 +1108,43 @@ final class CoreModel {
             // disconnect / retry buttons gate on it. Per issue
             // #326.
             rtlTcpConnectionState = state
+        case .scannerStateChanged(let state):
+            // Engine is authoritative for the scanner phase —
+            // its state machine fires this on every Idle/Retuning
+            // /Dwelling/Listening/Hanging transition. The panel
+            // reads `scannerState` directly to render the State
+            // row.
+            scannerState = state
+            // Idle is the engine's "rotation parked" sentinel.
+            // The active channel readout could still be lying in
+            // the previous latched value if `scannerEnabled` was
+            // toggled off without the engine emitting a
+            // matching null active-channel event first; clear
+            // proactively so the panel doesn't keep showing a
+            // stale Channel row while State says Off.
+            if state == .idle {
+                scannerActiveChannel = nil
+            }
+        case .scannerActiveChannelChanged(let channel):
+            // `nil` means "scanner returned to idle / no latched
+            // channel" — the panel's Channel row resets to its
+            // placeholder. Non-nil carries the bookmark name +
+            // frequency the lockout button targets.
+            scannerActiveChannel = channel
+        case .scannerEmptyRotation:
+            // All projected channels are absent or locked out —
+            // the engine has exhausted its rotation. Currently a
+            // no-op on this side; a follow-up could surface a
+            // toast. The panel's State row reads `.idle` either
+            // way once the engine settles.
+            break
+        case .scannerMutexStopped(let reason):
+            // The scanner ↔ recording / transcription mutex
+            // fired. Currently a no-op: the panel state will
+            // reflect the actual outcome via the next
+            // `scannerStateChanged` / recording-event pair. A
+            // follow-up could surface `reason.toastMessage` here.
+            _ = reason
         @unknown default:
             // Surface new engine event variants during
             // development. SdrCoreEvent is a non-frozen enum
@@ -1527,6 +1633,68 @@ final class CoreModel {
     }
 
     // ----------------------------------------------------------
+    //  Scanner — issue #447 (ABI 0.20)
+    // ----------------------------------------------------------
+
+    /// Toggle the scanner master switch. Optimistic — we flip
+    /// `scannerEnabled` immediately so the UI doesn't lag, but
+    /// the engine's `scannerStateChanged` reply is authoritative
+    /// for the resulting phase (`scannerState`). Until #490
+    /// lands the per-bookmark `scan_enabled` projection,
+    /// flipping this on with no scan-enabled bookmarks leaves
+    /// the engine in `.idle` (no rotation to drive), and the
+    /// panel's State row reflects that.
+    func setScannerEnabled(_ on: Bool) {
+        scannerEnabled = on
+        capture { try core?.setScannerEnabled(on) }
+    }
+
+    /// Lock out the channel currently latched (if any) for the
+    /// rest of the scanner session. No-op when the scanner
+    /// isn't latched on a channel. The engine's lockout set is
+    /// session-scoped — disabling the scanner clears it.
+    func lockoutCurrentScannerChannel() {
+        guard let channel = scannerActiveChannel else { return }
+        capture {
+            try core?.lockoutScannerChannel(
+                name: channel.name,
+                frequencyHz: channel.frequencyHz
+            )
+        }
+    }
+
+    /// Update the default settle time per-channel (ms). The
+    /// host applies this at projection time; engine doesn't
+    /// store a separate "default" — it sees a fully-resolved
+    /// `dwell_ms` on each `ScannerChannel`. Persisted via
+    /// `UserDefaults` so the choice survives relaunches.
+    func setScannerDefaultDwellMs(_ ms: Int) {
+        scannerDefaultDwellMs = ms
+        UserDefaults.standard.set(ms, forKey: Self.scannerDefaultDwellMsDefaultsKey)
+    }
+
+    /// Update the default hang time per-channel (ms). Same
+    /// projection-time fallback contract as the dwell setter.
+    func setScannerDefaultHangMs(_ ms: Int) {
+        scannerDefaultHangMs = ms
+        UserDefaults.standard.set(ms, forKey: Self.scannerDefaultHangMsDefaultsKey)
+    }
+
+    /// `UserDefaults` key for the scanner default-dwell (ms).
+    /// Mirrors the Linux config key
+    /// (`crates/sdr-ui/src/sidebar/scanner_panel.rs`'s
+    /// `CONFIG_KEY_DEFAULT_DWELL_MS`); we don't share storage
+    /// with the GTK side yet (separate `UserDefaults` /
+    /// `sdr-config`) but the key name stays identical so a
+    /// future shared-config layer can round-trip without
+    /// renaming.
+    static let scannerDefaultDwellMsDefaultsKey = "scanner_default_dwell_ms"
+
+    /// `UserDefaults` key for the scanner default-hang (ms).
+    /// Same name-parity rationale as the dwell key.
+    static let scannerDefaultHangMsDefaultsKey = "scanner_default_hang_ms"
+
+    // ----------------------------------------------------------
     //  Source (advanced) — #246
     // ----------------------------------------------------------
 
@@ -1861,7 +2029,6 @@ final class CoreModel {
         // Per `CodeRabbit` round 7 on PR #362.
         rtlTcpServerStopping = true
         rtlTcpServerStats = nil
-        rtlTcpRecentCommands = []
 
         let prior = rtlTcpServerLifecycleTask
         let task = Task { [weak self] in
@@ -1936,7 +2103,6 @@ final class CoreModel {
         // is released. Per `CodeRabbit` round 7 on PR #362.
         rtlTcpServerStopping = false
         rtlTcpServerStats = nil
-        rtlTcpRecentCommands = []
         advertiser?.stop()
         server?.stop()
     }
@@ -1976,25 +2142,29 @@ final class CoreModel {
         )
     }
 
-    /// Background poller that refreshes `rtlTcpServerStats` +
-    /// `rtlTcpRecentCommands` on a one-second tick. Runs on
-    /// the main actor (the whole `CoreModel` is `@MainActor`)
-    /// which matches what `@Observable` needs for writes.
+    /// Background poller that refreshes `rtlTcpServerStats`
+    /// on a one-second tick. Runs on the main actor (the whole
+    /// `CoreModel` is `@MainActor`) which matches what
+    /// `@Observable` needs for writes.
+    ///
+    /// The pre-#391 per-client `rtlTcpRecentCommands` refresh
+    /// is gone — recent-commands tracking is per-client now and
+    /// returns under a separate poll keyed by `client.id` once
+    /// the multi-client surface lands (#496).
     private func startRtlTcpPoller() {
         rtlTcpPollTask = Task { [weak self] in
             // Tick cadence slow enough to be negligible on the
-            // main thread, fast enough that "uptime" and data-
-            // rate look live. 1 Hz is the GTK panel's tick too.
+            // main thread, fast enough that aggregate counters
+            // look live. 1 Hz is the GTK panel's tick too.
             let tickNanos: UInt64 = 1_000_000_000
             // Poll-then-sleep ordering so `rtlTcpServerStats`
-            // and `rtlTcpRecentCommands` populate immediately on
-            // server start rather than after a full tick of nil.
-            // Per `CodeRabbit` round 4 on PR #362.
+            // populates immediately on server start rather than
+            // after a full tick of nil. Per `CodeRabbit` round 4
+            // on PR #362.
             while !Task.isCancelled {
                 guard let self, let server = self.rtlTcpServer else { return }
                 do {
                     self.rtlTcpServerStats = try server.stats()
-                    self.rtlTcpRecentCommands = try server.recentCommands()
                 } catch {
                     // Server has gone away (stopped externally,
                     // USB unplug, panic caught by the FFI). Tear

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -869,16 +869,19 @@ final class CoreModel {
         // Restore scanner timing defaults — issue #447.
         // Out-of-range values are silently ignored (the Rust side
         // also clamps); same defensive pattern as the network
-        // sink port restore above.
+        // sink port restore above. The setters clamp at write
+        // time so a poisoned defaults entry can only show up
+        // here on first restore — subsequent writes go through
+        // `setScannerDefault{Dwell,Hang}Ms` which clamp.
         if UserDefaults.standard.object(forKey: Self.scannerDefaultDwellMsDefaultsKey) != nil {
             let stored = UserDefaults.standard.integer(forKey: Self.scannerDefaultDwellMsDefaultsKey)
-            if (50...500).contains(stored) {
+            if Self.scannerDwellMsRange.contains(stored) {
                 scannerDefaultDwellMs = stored
             }
         }
         if UserDefaults.standard.object(forKey: Self.scannerDefaultHangMsDefaultsKey) != nil {
             let stored = UserDefaults.standard.integer(forKey: Self.scannerDefaultHangMsDefaultsKey)
-            if (500...5_000).contains(stored) {
+            if Self.scannerHangMsRange.contains(stored) {
                 scannerDefaultHangMs = stored
             }
         }
@@ -1132,19 +1135,46 @@ final class CoreModel {
             // frequency the lockout button targets.
             scannerActiveChannel = channel
         case .scannerEmptyRotation:
-            // All projected channels are absent or locked out —
-            // the engine has exhausted its rotation. Currently a
-            // no-op on this side; a follow-up could surface a
-            // toast. The panel's State row reads `.idle` either
-            // way once the engine settles.
-            break
+            // All projected channels are absent or locked out
+            // — engine has exhausted its rotation. Surface the
+            // exhausted state immediately rather than waiting
+            // for the next `scannerStateChanged(.idle)` event:
+            // the engine doesn't always emit one (a rotation
+            // that can't find a non-locked channel may settle
+            // straight back to dwelling, then re-emit empty on
+            // the next sweep). Snap state + clear the active
+            // readout so the panel reflects "no rotation
+            // possible right now" without lag.
+            scannerState = .idle
+            scannerActiveChannel = nil
         case .scannerMutexStopped(let reason):
             // The scanner ↔ recording / transcription mutex
-            // fired. Currently a no-op: the panel state will
-            // reflect the actual outcome via the next
-            // `scannerStateChanged` / recording-event pair. A
-            // follow-up could surface `reason.toastMessage` here.
-            _ = reason
+            // fired. Two of the four reasons mean the scanner
+            // itself was stopped (ScannerStoppedFor* directions)
+            // — flip `scannerEnabled` false locally so the
+            // panel's master toggle reflects engine truth
+            // immediately. The other two reasons mean the
+            // scanner stopped recording / transcription; the
+            // matching recording-state event arms handle their
+            // own UI sync, so the scanner panel doesn't need
+            // extra work for those directions.
+            //
+            // Toast surfacing for any of the four directions
+            // is a follow-up — we have `reason.toastMessage`
+            // ready, but routing it through a notifications
+            // surface lands separately.
+            switch reason {
+            case .scannerStoppedForRecording, .scannerStoppedForTranscription:
+                scannerEnabled = false
+                scannerState = .idle
+                scannerActiveChannel = nil
+            case .recordingStoppedForScanner, .transcriptionStoppedForScanner:
+                // Inverse direction — the recording / transcription
+                // side stopped, scanner is now running. The
+                // scanner-state event arm above handles the
+                // panel sync; nothing extra here.
+                break
+            }
         @unknown default:
             // Surface new engine event variants during
             // development. SdrCoreEvent is a non-frozen enum
@@ -1663,21 +1693,43 @@ final class CoreModel {
         }
     }
 
+    /// Allowed range for the default-dwell setting (ms). Mirrors
+    /// the Linux `DWELL_MIN_MS` / `DWELL_MAX_MS` constants; kept
+    /// model-side because the SwiftUI Stepper enforces the same
+    /// bounds AND a non-UI caller (scripted defaults edit, future
+    /// AppleScript / shortcut, test code) can write through the
+    /// setter directly.
+    static let scannerDwellMsRange: ClosedRange<Int> = 50...500
+    /// Allowed range for the default-hang setting (ms). Mirrors
+    /// the Linux `HANG_MIN_MS` / `HANG_MAX_MS` constants.
+    static let scannerHangMsRange: ClosedRange<Int> = 500...5_000
+
     /// Update the default settle time per-channel (ms). The
     /// host applies this at projection time; engine doesn't
     /// store a separate "default" — it sees a fully-resolved
     /// `dwell_ms` on each `ScannerChannel`. Persisted via
     /// `UserDefaults` so the choice survives relaunches.
+    ///
+    /// Out-of-range values are clamped at the boundary so a
+    /// non-UI caller can't poison persistent state with a value
+    /// that's silently dropped on next launch (bootstrap also
+    /// validates the range when reading back). Per `CodeRabbit`
+    /// round 1 on PR #497.
     func setScannerDefaultDwellMs(_ ms: Int) {
-        scannerDefaultDwellMs = ms
-        UserDefaults.standard.set(ms, forKey: Self.scannerDefaultDwellMsDefaultsKey)
+        let range = Self.scannerDwellMsRange
+        let clamped = min(max(ms, range.lowerBound), range.upperBound)
+        scannerDefaultDwellMs = clamped
+        UserDefaults.standard.set(clamped, forKey: Self.scannerDefaultDwellMsDefaultsKey)
     }
 
     /// Update the default hang time per-channel (ms). Same
-    /// projection-time fallback contract as the dwell setter.
+    /// projection-time fallback contract — and same clamp
+    /// rationale — as the dwell setter.
     func setScannerDefaultHangMs(_ ms: Int) {
-        scannerDefaultHangMs = ms
-        UserDefaults.standard.set(ms, forKey: Self.scannerDefaultHangMsDefaultsKey)
+        let range = Self.scannerHangMsRange
+        let clamped = min(max(ms, range.lowerBound), range.upperBound)
+        scannerDefaultHangMs = clamped
+        UserDefaults.standard.set(clamped, forKey: Self.scannerDefaultHangMsDefaultsKey)
     }
 
     /// `UserDefaults` key for the scanner default-dwell (ms).

--- a/apps/macos/SDRMac/Views/ActivityBar/ActivityPanelHost.swift
+++ b/apps/macos/SDRMac/Views/ActivityBar/ActivityPanelHost.swift
@@ -45,16 +45,13 @@ struct LeftPanelHost: View {
             // Appearance.
             DisplayPanelView()
         case .scanner:
-            // #447 deferred: the Mac CoreModel doesn't expose
-            // any scanner state yet (the engine's `sdr-scanner`
-            // crate has no FFI surface — the C ABI still
-            // needs the matching commands + events). Until
-            // that lands, clicking Scanner shows a clear
-            // placeholder.
-            ComingSoonPanel(
-                activity: activity,
-                followUpTicket: "#447 — Scanner panel (blocked on FFI surface)"
-            )
+            // #447 — Scanner / Active / Timing sections.
+            // Master switch flips engine state today; the
+            // bookmark→ScannerChannel projection that gives the
+            // scanner channels to rotate through follows in #490
+            // (per-bookmark scan opt-in). The panel's Scanner
+            // section footer documents that gap.
+            ScannerPanelView()
         case .share:
             // Share = rtl_tcp server (and eventually client +
             // discovery). The existing server panel slots in

--- a/apps/macos/SDRMac/Views/Panels/ScannerPanelView.swift
+++ b/apps/macos/SDRMac/Views/Panels/ScannerPanelView.swift
@@ -77,11 +77,18 @@ private struct ActiveChannelSection: View {
             // frequency. Idle: em-dash placeholder. Subtitle
             // wraps to multiple lines naturally — no
             // `.lineLimit(1)` so long names stay readable.
+            //
+            // `.textSelection(.enabled)` matches the pattern used
+            // across the other Mac panels (TranscriptionPanel,
+            // SourceSection, SettingsView) — long bookmark names
+            // like "KY State Police District 7 Dispatch" are
+            // selectable for paste into a search / log.
             LabeledContent("Channel") {
                 Text(channelLabel)
                     .font(.callout)
                     .foregroundStyle(model.scannerActiveChannel == nil ? .secondary : .primary)
                     .multilineTextAlignment(.trailing)
+                    .textSelection(.enabled)
             }
 
             // State row — tracks the engine's `ScannerState`
@@ -140,7 +147,7 @@ private struct TimingSection: View {
                         get: { model.scannerDefaultDwellMs },
                         set: { model.setScannerDefaultDwellMs($0) }
                     ),
-                    in: 50...500,
+                    in: CoreModel.scannerDwellMsRange,
                     step: 10
                 ) {
                     Text("\(model.scannerDefaultDwellMs) ms")
@@ -155,7 +162,7 @@ private struct TimingSection: View {
                         get: { model.scannerDefaultHangMs },
                         set: { model.setScannerDefaultHangMs($0) }
                     ),
-                    in: 500...5_000,
+                    in: CoreModel.scannerHangMsRange,
                     step: 100
                 ) {
                     Text("\(model.scannerDefaultHangMs) ms")

--- a/apps/macos/SDRMac/Views/Panels/ScannerPanelView.swift
+++ b/apps/macos/SDRMac/Views/Panels/ScannerPanelView.swift
@@ -1,0 +1,174 @@
+//
+// ScannerPanelView.swift — Scanner activity panel (closes #447).
+//
+// Three flat Sections matching the GTK
+// `crates/sdr-ui/src/sidebar/scanner_panel.rs` layout:
+//
+//   - Scanner   — master enable toggle
+//   - Active    — Channel / State rows + lockout button (button
+//                 only visible when latched)
+//   - Timing    — default dwell + default hang
+//
+// The Channel / State row text wraps multi-line by default —
+// SwiftUI `Text` doesn't truncate without an explicit
+// `.lineLimit(1)`, which we deliberately don't apply. Long
+// bookmark names like "KY State Police District 7 Dispatch"
+// stay fully readable in the sidebar.
+//
+// Bookmark → `ScannerChannel` projection isn't wired yet — the
+// Mac `Bookmark` model doesn't carry `scan_enabled` /
+// `priority` fields the Linux side has. Until #490 lands that,
+// flipping the master switch leaves the engine in `.idle` (no
+// rotation to drive); the Scanner section's footer documents
+// the gap so the panel reads honestly during the carve-out.
+
+import SwiftUI
+import SdrCoreKit
+
+struct ScannerPanelView: View {
+    var body: some View {
+        Form {
+            ScannerMasterSection()
+            ActiveChannelSection()
+            TimingSection()
+        }
+        .formStyle(.grouped)
+    }
+}
+
+// ============================================================
+//  Scanner master switch
+// ============================================================
+
+private struct ScannerMasterSection: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        Section {
+            Toggle("Scanner", isOn: Binding(
+                get: { model.scannerEnabled },
+                set: { model.setScannerEnabled($0) }
+            ))
+        } header: {
+            Text("Scanner")
+        } footer: {
+            // Honest footer: the master switch is wired, but
+            // there are no scan-enabled bookmarks to rotate
+            // through until per-bookmark scan opt-in lands
+            // (#490). The toggle still flips engine state
+            // (visible via the Active section's State row); it
+            // just stays in Off until #490 ships.
+            Text("Sweep through bookmarked frequencies. Per-bookmark scan opt-in lands in a follow-up — until then the rotation list is empty and the scanner stays Off.")
+                .font(.caption)
+        }
+    }
+}
+
+// ============================================================
+//  Active — current channel / state / lockout
+// ============================================================
+
+private struct ActiveChannelSection: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        Section {
+            // Channel row. Latched: bookmark name + formatted
+            // frequency. Idle: em-dash placeholder. Subtitle
+            // wraps to multiple lines naturally — no
+            // `.lineLimit(1)` so long names stay readable.
+            LabeledContent("Channel") {
+                Text(channelLabel)
+                    .font(.callout)
+                    .foregroundStyle(model.scannerActiveChannel == nil ? .secondary : .primary)
+                    .multilineTextAlignment(.trailing)
+            }
+
+            // State row — tracks the engine's `ScannerState`
+            // phase enum (Off / Retuning / Listening / Hang).
+            LabeledContent("State") {
+                Text(model.scannerState.label)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Lockout button — only visible when the scanner
+            // has a channel latched. The button alone in an
+            // always-visible row would leave a dangling labeled
+            // strip when the scanner goes idle; the GTK panel
+            // hides the whole row for the same reason.
+            if model.scannerActiveChannel != nil {
+                Button(role: .destructive) {
+                    model.lockoutCurrentScannerChannel()
+                } label: {
+                    Label("Lockout this channel", systemImage: "nosign")
+                }
+            }
+        } header: {
+            Text("Active")
+        } footer: {
+            Text("Current channel and detector state. Lockout skips the active channel for the rest of the scanner session.")
+                .font(.caption)
+        }
+    }
+
+    /// Render the Channel row's right-side label. Latched:
+    /// `"<bookmark name> — <freq MHz>"` to match the GTK
+    /// panel's vocabulary. Idle: em-dash placeholder, same
+    /// glyph the Linux side uses.
+    private var channelLabel: String {
+        guard let channel = model.scannerActiveChannel else {
+            return "—"
+        }
+        let mhz = Double(channel.frequencyHz) / 1_000_000.0
+        return String(format: "%@ — %.4f MHz", channel.name, mhz)
+    }
+}
+
+// ============================================================
+//  Timing — default dwell / hang
+// ============================================================
+
+private struct TimingSection: View {
+    @Environment(CoreModel.self) private var model
+
+    var body: some View {
+        Section {
+            LabeledContent("Default dwell") {
+                Stepper(
+                    value: Binding(
+                        get: { model.scannerDefaultDwellMs },
+                        set: { model.setScannerDefaultDwellMs($0) }
+                    ),
+                    in: 50...500,
+                    step: 10
+                ) {
+                    Text("\(model.scannerDefaultDwellMs) ms")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+            LabeledContent("Default hang") {
+                Stepper(
+                    value: Binding(
+                        get: { model.scannerDefaultHangMs },
+                        set: { model.setScannerDefaultHangMs($0) }
+                    ),
+                    in: 500...5_000,
+                    step: 100
+                ) {
+                    Text("\(model.scannerDefaultHangMs) ms")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+        } header: {
+            Text("Timing")
+        } footer: {
+            Text("How long the scanner lingers on each channel. Dwell is the settle window after retune; hang is the linger time after squelch closes before advancing.")
+                .font(.caption)
+        }
+    }
+}

--- a/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
+++ b/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
@@ -25,9 +25,10 @@ private let rtlSdrSampleRates: [UInt32] = [
     3_200_000,
 ]
 
-/// Max lines to render in the activity log — the Rust side's
-/// `recent_commands` ring is bounded at 50 too.
-private let activityLogMaxRows = 50
+// Pre-#391 the panel rendered a per-client recent-commands
+// activity log capped at 50 rows; the multi-client list
+// surface that replaces it lands in #496. Until then the
+// status section below shows server-wide aggregates only.
 
 struct RtlTcpServerSection: View {
     @Environment(CoreModel.self) private var model
@@ -157,9 +158,11 @@ struct RtlTcpServerSection: View {
 
         if model.rtlTcpServerRunning {
             statusRows
-            DisclosureGroup("Activity log") {
-                activityLog
-            }
+            // Per-client activity log is gone for now — the
+            // server's recent-commands ring is per-client (post-
+            // #391) and re-surfacing it requires the multi-
+            // client list path landing on the Mac side. Tracked
+            // in #496.
         }
     }
 
@@ -273,16 +276,27 @@ struct RtlTcpServerSection: View {
     //  Status + activity log
     // ----------------------------------------------------------
 
+    /// Server-wide status rows. Aggregates only — per-client
+    /// detail (peer address, current freq/rate/gain, recent
+    /// commands) requires the multi-client list surface that
+    /// follows in #496. Until then the panel reports the count
+    /// of connected clients plus lifetime totals; clicking an
+    /// individual client to see its tuning state is the
+    /// follow-up.
     @ViewBuilder
     private var statusRows: some View {
         let stats = model.rtlTcpServerStats
-        LabeledContent("Status") {
-            if let stats, stats.hasClient {
-                Text(stats.connectedClientAddr)
-                    .foregroundStyle(.green)
-                    .textSelection(.enabled)
+        LabeledContent("Clients") {
+            if let stats {
+                if stats.connectedCount == 0 {
+                    Text("Waiting for client")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("\(stats.connectedCount) connected")
+                        .foregroundStyle(.green)
+                }
             } else {
-                Text("Waiting for client")
+                Text("—")
                     .foregroundStyle(.secondary)
             }
         }
@@ -295,78 +309,20 @@ struct RtlTcpServerSection: View {
                 )
                 .foregroundStyle(.secondary)
             }
-            LabeledContent("Uptime") {
-                Text(formatUptime(stats.uptimeSecs))
+            LabeledContent("Lifetime accepted") {
+                Text("\(stats.lifetimeAccepted)")
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
-            LabeledContent("Data rate") {
-                Text(formatRate(bytesSent: stats.bytesSent, uptimeSecs: stats.uptimeSecs))
+            LabeledContent("Total bytes sent") {
+                Text(formatBytes(stats.totalBytesSent))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
-            if stats.currentFreqHz > 0 {
-                LabeledContent("Client freq") {
-                    Text(
-                        "\(Double(stats.currentFreqHz) / 1_000_000.0, specifier: "%.3f") MHz"
-                    )
-                    .monospacedDigit()
-                    .foregroundStyle(.secondary)
-                }
-            }
-            if stats.currentSampleRateHz > 0 {
-                LabeledContent("Client rate") {
-                    Text(
-                        "\(Double(stats.currentSampleRateHz) / 1_000_000.0, specifier: "%.3f") Msps"
-                    )
-                    .monospacedDigit()
-                    .foregroundStyle(.secondary)
-                }
-            }
-            if stats.hasCurrentGainMode {
-                LabeledContent("Client gain mode") {
-                    Text(stats.currentGainAuto ? "Auto" : "Manual")
-                        .foregroundStyle(.secondary)
-                }
-            }
-            if stats.hasCurrentGainValue {
-                LabeledContent("Client gain") {
-                    Text(
-                        "\(Double(stats.currentGainTenthsDb) / 10.0, specifier: "%.1f") dB"
-                    )
-                    .monospacedDigit()
-                    .foregroundStyle(.secondary)
-                }
-            }
-            if stats.buffersDropped > 0 {
-                LabeledContent("Dropped") {
-                    Text("\(stats.buffersDropped) buffer(s)")
+            if stats.totalBuffersDropped > 0 {
+                LabeledContent("Dropped (lifetime)") {
+                    Text("\(stats.totalBuffersDropped) buffer(s)")
                         .foregroundStyle(.orange)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var activityLog: some View {
-        if model.rtlTcpRecentCommands.isEmpty {
-            Text("No commands yet.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        } else {
-            // Newest-first. The Rust ring is oldest-first;
-            // reversing on render keeps the controller cheap.
-            ForEach(
-                Array(model.rtlTcpRecentCommands.reversed().prefix(activityLogMaxRows).enumerated()),
-                id: \.offset
-            ) { _, cmd in
-                HStack {
-                    Text(cmd.op)
-                        .font(.caption.monospaced())
-                    Spacer()
-                    Text("\(cmd.secondsAgo, specifier: "%.1f")s ago")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                 }
             }
         }
@@ -385,22 +341,23 @@ struct RtlTcpServerSection: View {
         model.isRunning && model.sourceType == .rtlSdr
     }
 
-    /// Render seconds-since-connect as `HH:MM:SS`.
-    private func formatUptime(_ secs: Double) -> String {
-        guard secs > 0, secs.isFinite else { return "—" }
-        let whole = Int(secs)
-        let h = whole / 3600
-        let m = (whole % 3600) / 60
-        let s = whole % 60
-        return String(format: "%02d:%02d:%02d", h, m, s)
-    }
-
-    /// Average stream rate in Mbps. Session-cumulative — real
-    /// rolling rate (delta over a short window) is a follow-up
-    /// if the average turns out to be misleading.
-    private func formatRate(bytesSent: UInt64, uptimeSecs: Double) -> String {
-        guard uptimeSecs > 0.25 else { return "—" }
-        let mbps = Double(bytesSent) * 8.0 / uptimeSecs / 1_000_000.0
-        return String(format: "%.2f Mbps", mbps)
+    /// Format a byte count as KiB / MiB / GiB. The lifetime
+    /// total grows fast at typical RTL-SDR rates (~16 Mbps for
+    /// 2 Msps × 8 bits) so a plain "bytes" label gets unreadable
+    /// in minutes.
+    private func formatBytes(_ bytes: UInt64) -> String {
+        let kib: UInt64 = 1_024
+        let mib: UInt64 = kib * 1_024
+        let gib: UInt64 = mib * 1_024
+        if bytes >= gib {
+            return String(format: "%.2f GiB", Double(bytes) / Double(gib))
+        }
+        if bytes >= mib {
+            return String(format: "%.2f MiB", Double(bytes) / Double(mib))
+        }
+        if bytes >= kib {
+            return String(format: "%.2f KiB", Double(bytes) / Double(kib))
+        }
+        return "\(bytes) B"
     }
 }

--- a/crates/sdr-ffi/Cargo.toml
+++ b/crates/sdr-ffi/Cargo.toml
@@ -31,6 +31,11 @@ sdr-types.workspace = true
 # by a future sdr-core refactor that drops the transitive edge.
 sdr-pipeline.workspace = true
 sdr-radio.workspace = true
+# Scanner state types (`ScannerState`, `ChannelKey`, `ScannerChannel`)
+# referenced at the FFI boundary by the scanner command + event
+# surface (#447). Pulled in transitively via sdr-core anyway; same
+# explicit-dep rationale as sdr-pipeline / sdr-radio above.
+sdr-scanner.workspace = true
 # Direct dep on sdr-rtlsdr for the device-enumeration functions
 # (`sdr_core_device_count` / `sdr_core_device_name` in the C ABI).
 # These are static (no handle required), so they don't fit the

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -2478,4 +2478,104 @@ mod tests {
         }
         destroy(h);
     }
+
+    // ------------------------------------------------------
+    //  Scanner — ABI 0.20, issue #447
+    // ------------------------------------------------------
+
+    #[test]
+    fn scanner_commands_reject_null_handle() {
+        // Matches the `all_commands_reject_null_handle` pattern
+        // above — pins the null-handle guard on all three
+        // new entry points so a refactor of `with_core`
+        // can't silently drop it for one arm. Per `CodeRabbit`
+        // round 1 on PR #497.
+        assert_eq!(
+            unsafe { sdr_core_set_scanner_enabled(std::ptr::null_mut(), true) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+        let name = CString::new("Test").unwrap();
+        assert_eq!(
+            unsafe {
+                sdr_core_lockout_scanner_channel(std::ptr::null_mut(), name.as_ptr(), 162_550_000)
+            },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+        assert_eq!(
+            unsafe {
+                sdr_core_unlock_scanner_channel(std::ptr::null_mut(), name.as_ptr(), 162_550_000)
+            },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+    }
+
+    #[test]
+    fn scanner_lockout_rejects_null_name() {
+        // The lockout / unlock commands need a NUL-terminated
+        // UTF-8 name to build the `ChannelKey`. Null pointer
+        // is a caller bug; surface it as InvalidArg instead
+        // of dereferencing.
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_lockout_scanner_channel(h, std::ptr::null(), 162_550_000) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_unlock_scanner_channel(h, std::ptr::null(), 162_550_000) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn scanner_lockout_rejects_invalid_utf8_name() {
+        // `CStr::to_str` refuses non-UTF-8 bytes; the command
+        // returns InvalidArg rather than taking the bytes
+        // lossily. A lossy coerce would let a host write a
+        // ChannelKey name that would never match the
+        // projection-time name the scanner holds.
+        let h = make_handle();
+        // Lone 0xFF — invalid start byte for any UTF-8
+        // codepoint. NUL-terminated so `CStr::from_ptr`
+        // finds the end of string.
+        let bad: [u8; 2] = [0xFF, 0x00];
+        let bad_ptr = bad.as_ptr().cast::<c_char>();
+        assert_eq!(
+            unsafe { sdr_core_lockout_scanner_channel(h, bad_ptr, 162_550_000) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_unlock_scanner_channel(h, bad_ptr, 162_550_000) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn scanner_commands_happy_path_return_ok() {
+        // Engine accepts the scanner command regardless of
+        // whether any channels are projected — the state
+        // machine just stays in Idle. Confirms dispatch
+        // round-trips and the name-copy path works for a
+        // normal UTF-8 string.
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_set_scanner_enabled(h, true) },
+            SdrCoreError::Ok.as_int()
+        );
+        let name = CString::new("NOAA Weather").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_lockout_scanner_channel(h, name.as_ptr(), 162_550_000) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_unlock_scanner_channel(h, name.as_ptr(), 162_550_000) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_set_scanner_enabled(h, false) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
 }

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -1210,27 +1210,6 @@ pub unsafe extern "C" fn sdr_core_set_fft_rate(handle: *mut SdrCore, fps: f64) -
 // without observable effect; the SwiftUI panel documents this
 // in its footer.
 
-/// Helper: read a borrowed `*const c_char` channel name into a
-/// validated `String` for `LockoutScannerChannel` /
-/// `UnlockScannerChannel` dispatch. Rejects null pointers and
-/// non-UTF-8 input with `SdrCoreError::InvalidArg`. Empty
-/// strings are accepted — the engine treats them as a real
-/// (if unusual) channel name.
-fn read_channel_name(name_utf8: *const c_char, fn_label: &str) -> Result<String, SdrCoreError> {
-    if name_utf8.is_null() {
-        set_last_error(format!("{fn_label}: name pointer is null"));
-        return Err(SdrCoreError::InvalidArg);
-    }
-    // SAFETY: caller contract — name_utf8 is a NUL-terminated
-    // C string for the duration of this call.
-    let cstr = unsafe { CStr::from_ptr(name_utf8) };
-    let Ok(s) = cstr.to_str() else {
-        set_last_error(format!("{fn_label}: name is not valid UTF-8"));
-        return Err(SdrCoreError::InvalidArg);
-    };
-    Ok(s.to_owned())
-}
-
 /// Master scanner enable / disable. Routes to
 /// `UiToDsp::SetScannerEnabled`. Tripping this on with no
 /// projected channels leaves the engine in `Idle` (visible
@@ -1267,7 +1246,9 @@ pub unsafe extern "C" fn sdr_core_lockout_scanner_channel(
 ) -> i32 {
     unsafe {
         with_core(handle, |core| {
-            let name = read_channel_name(name_utf8, "sdr_core_lockout_scanner_channel")?;
+            // Reuse the shared string-in helper so null / non-UTF-8
+            // error semantics match every other command path.
+            let name = cstr_to_string("sdr_core_lockout_scanner_channel", name_utf8)?;
             send(
                 core,
                 UiToDsp::LockoutScannerChannel(sdr_scanner::ChannelKey { name, frequency_hz }),
@@ -1291,7 +1272,7 @@ pub unsafe extern "C" fn sdr_core_unlock_scanner_channel(
 ) -> i32 {
     unsafe {
         with_core(handle, |core| {
-            let name = read_channel_name(name_utf8, "sdr_core_unlock_scanner_channel")?;
+            let name = cstr_to_string("sdr_core_unlock_scanner_channel", name_utf8)?;
             send(
                 core,
                 UiToDsp::UnlockScannerChannel(sdr_scanner::ChannelKey { name, frequency_hz }),
@@ -2483,6 +2464,14 @@ mod tests {
     //  Scanner — ABI 0.20, issue #447
     // ------------------------------------------------------
 
+    /// Fixture frequency reused across all four scanner
+    /// command tests. 162.550 MHz is the NOAA Weather Radio
+    /// canonical frequency — a realistic NFM channel rather
+    /// than a round number, so a naive default-0 in either
+    /// side of the lockout path would be obvious in logs.
+    /// Per `CodeRabbit` round 2 on PR #497.
+    const TEST_SCANNER_FREQ_HZ: u64 = 162_550_000;
+
     #[test]
     fn scanner_commands_reject_null_handle() {
         // Matches the `all_commands_reject_null_handle` pattern
@@ -2497,13 +2486,21 @@ mod tests {
         let name = CString::new("Test").unwrap();
         assert_eq!(
             unsafe {
-                sdr_core_lockout_scanner_channel(std::ptr::null_mut(), name.as_ptr(), 162_550_000)
+                sdr_core_lockout_scanner_channel(
+                    std::ptr::null_mut(),
+                    name.as_ptr(),
+                    TEST_SCANNER_FREQ_HZ,
+                )
             },
             SdrCoreError::InvalidHandle.as_int()
         );
         assert_eq!(
             unsafe {
-                sdr_core_unlock_scanner_channel(std::ptr::null_mut(), name.as_ptr(), 162_550_000)
+                sdr_core_unlock_scanner_channel(
+                    std::ptr::null_mut(),
+                    name.as_ptr(),
+                    TEST_SCANNER_FREQ_HZ,
+                )
             },
             SdrCoreError::InvalidHandle.as_int()
         );
@@ -2517,11 +2514,11 @@ mod tests {
         // of dereferencing.
         let h = make_handle();
         assert_eq!(
-            unsafe { sdr_core_lockout_scanner_channel(h, std::ptr::null(), 162_550_000) },
+            unsafe { sdr_core_lockout_scanner_channel(h, std::ptr::null(), TEST_SCANNER_FREQ_HZ) },
             SdrCoreError::InvalidArg.as_int()
         );
         assert_eq!(
-            unsafe { sdr_core_unlock_scanner_channel(h, std::ptr::null(), 162_550_000) },
+            unsafe { sdr_core_unlock_scanner_channel(h, std::ptr::null(), TEST_SCANNER_FREQ_HZ) },
             SdrCoreError::InvalidArg.as_int()
         );
         destroy(h);
@@ -2541,11 +2538,11 @@ mod tests {
         let bad: [u8; 2] = [0xFF, 0x00];
         let bad_ptr = bad.as_ptr().cast::<c_char>();
         assert_eq!(
-            unsafe { sdr_core_lockout_scanner_channel(h, bad_ptr, 162_550_000) },
+            unsafe { sdr_core_lockout_scanner_channel(h, bad_ptr, TEST_SCANNER_FREQ_HZ) },
             SdrCoreError::InvalidArg.as_int()
         );
         assert_eq!(
-            unsafe { sdr_core_unlock_scanner_channel(h, bad_ptr, 162_550_000) },
+            unsafe { sdr_core_unlock_scanner_channel(h, bad_ptr, TEST_SCANNER_FREQ_HZ) },
             SdrCoreError::InvalidArg.as_int()
         );
         destroy(h);
@@ -2565,11 +2562,11 @@ mod tests {
         );
         let name = CString::new("NOAA Weather").unwrap();
         assert_eq!(
-            unsafe { sdr_core_lockout_scanner_channel(h, name.as_ptr(), 162_550_000) },
+            unsafe { sdr_core_lockout_scanner_channel(h, name.as_ptr(), TEST_SCANNER_FREQ_HZ) },
             SdrCoreError::Ok.as_int()
         );
         assert_eq!(
-            unsafe { sdr_core_unlock_scanner_channel(h, name.as_ptr(), 162_550_000) },
+            unsafe { sdr_core_unlock_scanner_channel(h, name.as_ptr(), TEST_SCANNER_FREQ_HZ) },
             SdrCoreError::Ok.as_int()
         );
         assert_eq!(

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -1197,6 +1197,109 @@ pub unsafe extern "C" fn sdr_core_set_fft_rate(handle: *mut SdrCore, fps: f64) -
     }
 }
 
+// ============================================================
+//  Scanner — #447 / ABI 0.20
+// ============================================================
+//
+// Master enable + per-channel session lockout / unlock. The
+// channel-list projection (`UpdateScannerChannels`) is NOT
+// exposed here yet — that follows when the macOS bookmark
+// layer grows the `scan_enabled` / `priority` fields the Linux
+// `Bookmark` already has (#490). Until then, the scanner has
+// no channels to rotate through and the master switch flips
+// without observable effect; the SwiftUI panel documents this
+// in its footer.
+
+/// Helper: read a borrowed `*const c_char` channel name into a
+/// validated `String` for `LockoutScannerChannel` /
+/// `UnlockScannerChannel` dispatch. Rejects null pointers and
+/// non-UTF-8 input with `SdrCoreError::InvalidArg`. Empty
+/// strings are accepted — the engine treats them as a real
+/// (if unusual) channel name.
+fn read_channel_name(name_utf8: *const c_char, fn_label: &str) -> Result<String, SdrCoreError> {
+    if name_utf8.is_null() {
+        set_last_error(format!("{fn_label}: name pointer is null"));
+        return Err(SdrCoreError::InvalidArg);
+    }
+    // SAFETY: caller contract — name_utf8 is a NUL-terminated
+    // C string for the duration of this call.
+    let cstr = unsafe { CStr::from_ptr(name_utf8) };
+    let Ok(s) = cstr.to_str() else {
+        set_last_error(format!("{fn_label}: name is not valid UTF-8"));
+        return Err(SdrCoreError::InvalidArg);
+    };
+    Ok(s.to_owned())
+}
+
+/// Master scanner enable / disable. Routes to
+/// `UiToDsp::SetScannerEnabled`. Tripping this on with no
+/// projected channels leaves the engine in `Idle` (visible
+/// via `SDR_EVT_SCANNER_STATE_CHANGED`); the host doesn't
+/// need to special-case it. Per #447 (ABI 0.20).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_set_scanner_enabled(handle: *mut SdrCore, enabled: bool) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            send(core, UiToDsp::SetScannerEnabled(enabled))
+        })
+    }
+}
+
+/// Lock out the channel identified by `(name, frequency_hz)`
+/// for the rest of the scanner session. Routes to
+/// `UiToDsp::LockoutScannerChannel`.
+///
+/// `name_utf8` is a NUL-terminated UTF-8 string borrowed for
+/// the duration of the call (the scanner state machine clones
+/// the name into its `HashSet<ChannelKey>`). Per #447 (ABI 0.20).
+///
+/// # Safety
+///
+/// `handle` must be either null or a pointer previously
+/// returned by `sdr_core_create` and not yet destroyed.
+/// `name_utf8` must be either null or a valid pointer to a
+/// NUL-terminated UTF-8 string for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_lockout_scanner_channel(
+    handle: *mut SdrCore,
+    name_utf8: *const c_char,
+    frequency_hz: u64,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let name = read_channel_name(name_utf8, "sdr_core_lockout_scanner_channel")?;
+            send(
+                core,
+                UiToDsp::LockoutScannerChannel(sdr_scanner::ChannelKey { name, frequency_hz }),
+            )
+        })
+    }
+}
+
+/// Clear a session lockout for `(name, frequency_hz)`. Routes
+/// to `UiToDsp::UnlockScannerChannel`. No-op if the channel
+/// wasn't locked out. Per #447 (ABI 0.20).
+///
+/// # Safety
+///
+/// Same contract as `sdr_core_lockout_scanner_channel`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_unlock_scanner_channel(
+    handle: *mut SdrCore,
+    name_utf8: *const c_char,
+    frequency_hz: u64,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            let name = read_channel_name(name_utf8, "sdr_core_unlock_scanner_channel")?;
+            send(
+                core,
+                UiToDsp::UnlockScannerChannel(sdr_scanner::ChannelKey { name, frequency_hz }),
+            )
+        })
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -1150,19 +1150,40 @@ mod tests {
     }
 
     #[test]
-    fn translate_scanner_mutex_stopped_for_recording() {
+    fn translate_scanner_mutex_stopped_maps_all_reasons() {
+        // Pin every `ScannerMutexReason` arm individually — the
+        // host-side toast routing branches on the wire integer
+        // directly, so a silent remap (e.g., a refactor that
+        // reorders the Rust enum) breaks every C ABI consumer
+        // without failing any Rust-level type check. Per
+        // `CodeRabbit` round 1 on PR #497.
         use sdr_core::messages::ScannerMutexReason;
-        let (event, owned_cstring, _) = translate_event(&DspToUi::ScannerMutexStopped(
-            ScannerMutexReason::ScannerStoppedForRecording,
-        ))
-        .expect("ScannerMutexStopped should translate");
-        assert_eq!(event.kind, SDR_EVT_SCANNER_MUTEX_STOPPED);
-        let payload = unsafe { event.payload.scanner_mutex_stopped };
-        assert_eq!(
-            payload.reason,
-            SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING
-        );
-        assert!(owned_cstring.is_none());
+        let cases = [
+            (
+                ScannerMutexReason::RecordingStoppedForScanner,
+                SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER,
+            ),
+            (
+                ScannerMutexReason::TranscriptionStoppedForScanner,
+                SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER,
+            ),
+            (
+                ScannerMutexReason::ScannerStoppedForRecording,
+                SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING,
+            ),
+            (
+                ScannerMutexReason::ScannerStoppedForTranscription,
+                SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION,
+            ),
+        ];
+        for (reason, expected_int) in cases {
+            let (event, owned_cstring, _) = translate_event(&DspToUi::ScannerMutexStopped(reason))
+                .expect("ScannerMutexStopped should translate");
+            assert_eq!(event.kind, SDR_EVT_SCANNER_MUTEX_STOPPED);
+            let payload = unsafe { event.payload.scanner_mutex_stopped };
+            assert_eq!(payload.reason, expected_int);
+            assert!(owned_cstring.is_none());
+        }
     }
 
     #[test]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -284,6 +284,12 @@ pub struct SdrEventScannerMutexStopped {
 /// | `SDR_EVT_AUDIO_RECORDING_STOPPED` | none                         |
 /// | `SDR_EVT_IQ_RECORDING_STARTED`    | `iq_recording.path_utf8`     |
 /// | `SDR_EVT_IQ_RECORDING_STOPPED`    | none                         |
+/// | `SDR_EVT_NETWORK_SINK_STATUS`     | `network_sink_status.{kind,utf8,protocol}` |
+/// | `SDR_EVT_RTL_TCP_CONNECTION_STATE`| `rtl_tcp_connection_state.{kind,utf8,attempt,retry_in_secs,gain_count}` |
+/// | `SDR_EVT_SCANNER_STATE_CHANGED`   | `scanner_state.state`        |
+/// | `SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED` | `scanner_active_channel.{name_utf8,frequency_hz}` |
+/// | `SDR_EVT_SCANNER_EMPTY_ROTATION`  | none                         |
+/// | `SDR_EVT_SCANNER_MUTEX_STOPPED`   | `scanner_mutex_stopped.reason` |
 ///
 /// `_placeholder` exists so `SOURCE_STOPPED` events (which carry
 /// no payload) can still construct the struct with a meaningful
@@ -1061,6 +1067,30 @@ mod tests {
         assert!(owned_cstring.is_none());
     }
 
+    /// Fixture name for the latched-channel scanner tests. NOAA
+    /// Weather Radio is a canonical NFM channel with a recognisable
+    /// string, making debug output easy to read. Per `CodeRabbit`
+    /// round 2 on PR #497.
+    const TEST_SCANNER_NAME: &str = "NOAA Weather";
+    /// Fixture frequency paired with `TEST_SCANNER_NAME` — 162.550
+    /// MHz is the NOAA Weather Radio canonical channel. Same
+    /// constant appears in the command-side tests under the same
+    /// name, but keep them crate-private-per-test-module so a
+    /// future refactor that splits the modules doesn't collide.
+    const TEST_SCANNER_FREQ_HZ: u64 = 162_550_000;
+    /// Fixture bandwidth the active-channel event carries in the
+    /// flattened `bandwidth` field. NFM default — the FFI layer
+    /// doesn't read this field, so the exact value is only
+    /// meaningful as a recognisable placeholder in debug dumps.
+    const TEST_SCANNER_BANDWIDTH_HZ: f64 = 12_500.0;
+    /// Interior-NUL fixture for the sanitization test. The
+    /// dispatcher's `replace('\0', '?')` call should turn this
+    /// into "Weather?Channel" before it reaches the callback.
+    const TEST_SCANNER_NAME_WITH_INTERIOR_NUL: &str = "Weather\0Channel";
+    /// Expected output after the dispatcher sanitizes the
+    /// interior NUL in `TEST_SCANNER_NAME_WITH_INTERIOR_NUL`.
+    const TEST_SCANNER_NAME_SANITIZED: &str = "Weather?Channel";
+
     /// Build a synthetic `DspToUi::ScannerActiveChannelChanged`
     /// for the FFI translation tests. The flattened `freq_hz` /
     /// `name` fields are populated by the controller-side helper
@@ -1076,7 +1106,7 @@ mod tests {
             key,
             freq_hz,
             demod_mode: sdr_types::DemodMode::Nfm,
-            bandwidth: 12_500.0,
+            bandwidth: TEST_SCANNER_BANDWIDTH_HZ,
             name: latched_name.unwrap_or("").to_string(),
             ctcss: None,
             voice_squelch: None,
@@ -1086,19 +1116,19 @@ mod tests {
     #[test]
     fn translate_scanner_active_channel_latched_carries_name_and_frequency() {
         let (event, owned_cstring, _) = translate_event(&scanner_active_channel_event(
-            Some("NOAA Weather"),
-            162_550_000,
+            Some(TEST_SCANNER_NAME),
+            TEST_SCANNER_FREQ_HZ,
         ))
         .expect("ScannerActiveChannelChanged should translate");
         assert_eq!(event.kind, SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED);
         let payload = unsafe { event.payload.scanner_active_channel };
         assert!(!payload.name_utf8.is_null());
-        assert_eq!(payload.frequency_hz, 162_550_000);
+        assert_eq!(payload.frequency_hz, TEST_SCANNER_FREQ_HZ);
         // Name lives in the owned CString — pointer must still
         // resolve to the original bytes via the standard
         // round-trip through CStr.
         let as_cstr = unsafe { std::ffi::CStr::from_ptr(payload.name_utf8) };
-        assert_eq!(as_cstr.to_str().unwrap(), "NOAA Weather");
+        assert_eq!(as_cstr.to_str().unwrap(), TEST_SCANNER_NAME);
         assert!(owned_cstring.is_some());
     }
 
@@ -1132,13 +1162,13 @@ mod tests {
         // `name_utf8` dangling. Same lifetime contract as the
         // other translate_*-pattern tests.
         let (event, _owned_cstring, _) = translate_event(&scanner_active_channel_event(
-            Some("Weather\0Channel"),
-            162_550_000,
+            Some(TEST_SCANNER_NAME_WITH_INTERIOR_NUL),
+            TEST_SCANNER_FREQ_HZ,
         ))
         .expect("sanitized ScannerActiveChannelChanged should translate");
         let payload = unsafe { event.payload.scanner_active_channel };
         let as_cstr = unsafe { std::ffi::CStr::from_ptr(payload.name_utf8) };
-        assert_eq!(as_cstr.to_str().unwrap(), "Weather?Channel");
+        assert_eq!(as_cstr.to_str().unwrap(), TEST_SCANNER_NAME_SANITIZED);
     }
 
     #[test]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -59,6 +59,35 @@ pub const SDR_EVT_IQ_RECORDING_STARTED: i32 = 10;
 pub const SDR_EVT_IQ_RECORDING_STOPPED: i32 = 11;
 pub const SDR_EVT_NETWORK_SINK_STATUS: i32 = 12;
 pub const SDR_EVT_RTL_TCP_CONNECTION_STATE: i32 = 13;
+pub const SDR_EVT_SCANNER_STATE_CHANGED: i32 = 14;
+pub const SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED: i32 = 15;
+pub const SDR_EVT_SCANNER_EMPTY_ROTATION: i32 = 16;
+pub const SDR_EVT_SCANNER_MUTEX_STOPPED: i32 = 17;
+
+// ============================================================
+//  Scanner phase discriminants — must match `SdrScannerState`
+//  in `include/sdr_core.h`. Numeric values mirror the variant
+//  order of `sdr_scanner::ScannerState`. Never reorder or
+//  renumber.
+// ============================================================
+
+pub const SDR_SCANNER_STATE_IDLE: i32 = 0;
+pub const SDR_SCANNER_STATE_RETUNING: i32 = 1;
+pub const SDR_SCANNER_STATE_DWELLING: i32 = 2;
+pub const SDR_SCANNER_STATE_LISTENING: i32 = 3;
+pub const SDR_SCANNER_STATE_HANGING: i32 = 4;
+
+// ============================================================
+//  Scanner mutex-stop reasons — must match
+//  `SdrScannerMutexReason` in `include/sdr_core.h`. Mirrors
+//  the variant order of `sdr_core::messages::ScannerMutexReason`.
+//  Never reorder or renumber.
+// ============================================================
+
+pub const SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER: i32 = 0;
+pub const SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER: i32 = 1;
+pub const SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING: i32 = 2;
+pub const SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION: i32 = 3;
 
 // ============================================================
 //  Network sink status discriminants — must match the
@@ -201,6 +230,43 @@ pub struct SdrEventNetworkSinkStatus {
     pub protocol: i32,
 }
 
+/// Payload for `SDR_EVT_SCANNER_STATE_CHANGED`. `state` is one
+/// of the `SDR_SCANNER_STATE_*` discriminants. Per #447 (ABI 0.20).
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SdrEventScannerStateChanged {
+    pub state: i32,
+}
+
+/// Payload for `SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED`. The
+/// scanner emits this on every channel latch (squelch open on
+/// the new channel) AND on every release back to Idle. When the
+/// scanner is idle (no latched channel), `name_utf8` is NULL and
+/// `frequency_hz` is 0 — the host clears its "active channel"
+/// readout. When latched, `name_utf8` is the bookmark name the
+/// host originally projected via `UpdateScannerChannels` and
+/// `frequency_hz` is the matching `ChannelKey::frequency_hz`.
+///
+/// `name_utf8` is a borrowed pointer into dispatcher-owned
+/// storage; valid only for the duration of the callback. Per
+/// #447 (ABI 0.20).
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SdrEventScannerActiveChannelChanged {
+    pub name_utf8: *const c_char,
+    pub frequency_hz: u64,
+}
+
+/// Payload for `SDR_EVT_SCANNER_MUTEX_STOPPED`. `reason` is one
+/// of the `SDR_SCANNER_MUTEX_*` discriminants — describes which
+/// side of the scanner ↔ recording / transcription mutex fired.
+/// Per #447 (ABI 0.20).
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SdrEventScannerMutexStopped {
+    pub reason: i32,
+}
+
 /// C-layout tagged union of event payloads. Which field is valid
 /// is determined by the `kind` discriminant on the enclosing
 /// `SdrEvent`:
@@ -235,6 +301,9 @@ pub union SdrEventPayload {
     pub iq_recording: SdrEventIqRecording,
     pub network_sink_status: SdrEventNetworkSinkStatus,
     pub rtl_tcp_connection_state: SdrEventRtlTcpConnectionState,
+    pub scanner_state: SdrEventScannerStateChanged,
+    pub scanner_active_channel: SdrEventScannerActiveChannelChanged,
+    pub scanner_mutex_stopped: SdrEventScannerMutexStopped,
     /// Placeholder for kinds that carry no payload (e.g.,
     /// `SDR_EVT_SOURCE_STOPPED`). Accessing this field is always
     /// valid as a zero-byte read.
@@ -514,13 +583,11 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         //     (#336 / #341). Linux-only for now; macOS SwiftUI
         //     gets them when the equivalent VFO overlay +
         //     reset affordances land on that side.
-        //   - `ScannerActiveChannelChanged`, `ScannerStateChanged`,
-        //     `ScannerEmptyRotation`, `ScannerMutexStopped` are the
-        //     scanner Phase 1 UI events (#317). Intentionally
-        //     withheld from ABI v1; the Mac-side scanner ticket
-        //     (tracked separately) will add them when the SwiftUI
-        //     scanner panel is designed — likely as a group at
-        //     the next minor bump.
+        //
+        // Scanner Phase 1 UI events (`ScannerActiveChannelChanged`,
+        // `ScannerStateChanged`, `ScannerEmptyRotation`,
+        // `ScannerMutexStopped`) landed at the FFI boundary in ABI
+        // 0.20 (#447) — see the dedicated arms above.
         //
         // Adding any of these to the ABI is additive (new
         // `SDR_EVT_*` discriminant + new payload struct or reuse
@@ -599,16 +666,89 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
             }
         }
 
+        DspToUi::ScannerStateChanged(state) => {
+            use sdr_scanner::ScannerState;
+            let state_int = match state {
+                ScannerState::Idle => SDR_SCANNER_STATE_IDLE,
+                ScannerState::Retuning => SDR_SCANNER_STATE_RETUNING,
+                ScannerState::Dwelling => SDR_SCANNER_STATE_DWELLING,
+                ScannerState::Listening => SDR_SCANNER_STATE_LISTENING,
+                ScannerState::Hanging => SDR_SCANNER_STATE_HANGING,
+            };
+            SdrEvent {
+                kind: SDR_EVT_SCANNER_STATE_CHANGED,
+                payload: SdrEventPayload {
+                    scanner_state: SdrEventScannerStateChanged { state: state_int },
+                },
+            }
+        }
+
+        DspToUi::ScannerActiveChannelChanged { key, .. } => {
+            // `mode_override` is intentionally NOT exposed at the
+            // FFI boundary — the host already chose the demod
+            // mode when it projected the bookmark into a
+            // `ScannerChannel`, and the scanner's retune already
+            // applied it. The UI just needs the channel identity
+            // for its "active channel" readout.
+            let (name_ptr, frequency_hz, name_cstr) = match key {
+                Some(k) => {
+                    let sanitized = k.name.replace('\0', "?");
+                    let Ok(cstr) = CString::new(sanitized) else {
+                        // Unreachable: replace stripped NULs.
+                        return None;
+                    };
+                    let ptr = cstr.as_ptr();
+                    (ptr, k.frequency_hz, Some(cstr))
+                }
+                None => (std::ptr::null(), 0_u64, None),
+            };
+            owned_cstring = name_cstr;
+            SdrEvent {
+                kind: SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED,
+                payload: SdrEventPayload {
+                    scanner_active_channel: SdrEventScannerActiveChannelChanged {
+                        name_utf8: name_ptr,
+                        frequency_hz,
+                    },
+                },
+            }
+        }
+
+        DspToUi::ScannerEmptyRotation => SdrEvent {
+            kind: SDR_EVT_SCANNER_EMPTY_ROTATION,
+            payload: SdrEventPayload { _placeholder: 0 },
+        },
+
+        DspToUi::ScannerMutexStopped(reason) => {
+            use sdr_core::messages::ScannerMutexReason;
+            let reason_int = match reason {
+                ScannerMutexReason::RecordingStoppedForScanner => {
+                    SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER
+                }
+                ScannerMutexReason::TranscriptionStoppedForScanner => {
+                    SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER
+                }
+                ScannerMutexReason::ScannerStoppedForRecording => {
+                    SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING
+                }
+                ScannerMutexReason::ScannerStoppedForTranscription => {
+                    SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION
+                }
+            };
+            SdrEvent {
+                kind: SDR_EVT_SCANNER_MUTEX_STOPPED,
+                payload: SdrEventPayload {
+                    scanner_mutex_stopped: SdrEventScannerMutexStopped { reason: reason_int },
+                },
+            }
+        }
+
         DspToUi::FftData(_)
         | DspToUi::DemodModeChanged(_)
         | DspToUi::BandwidthChanged(_)
         | DspToUi::VfoOffsetChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
-        | DspToUi::VoiceSquelchOpenChanged(_)
-        | DspToUi::ScannerActiveChannelChanged { .. }
-        | DspToUi::ScannerStateChanged(_)
-        | DspToUi::ScannerEmptyRotation
-        | DspToUi::ScannerMutexStopped(_) => return None,
+        | DspToUi::VoiceSquelchOpenChanged(_) => return None,
     };
 
     Some((event, owned_cstring, owned_vec))
@@ -883,6 +1023,146 @@ mod tests {
         assert_eq!(SDR_EVT_IQ_RECORDING_STOPPED, 11);
         assert_eq!(SDR_EVT_NETWORK_SINK_STATUS, 12);
         assert_eq!(SDR_EVT_RTL_TCP_CONNECTION_STATE, 13);
+        assert_eq!(SDR_EVT_SCANNER_STATE_CHANGED, 14);
+        assert_eq!(SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED, 15);
+        assert_eq!(SDR_EVT_SCANNER_EMPTY_ROTATION, 16);
+        assert_eq!(SDR_EVT_SCANNER_MUTEX_STOPPED, 17);
+    }
+
+    #[test]
+    fn scanner_state_discriminants_match_header() {
+        // The host-side scanner state readout reads these wire
+        // integers directly, so any renumber breaks every C ABI
+        // consumer without failing a Rust-level type check.
+        assert_eq!(SDR_SCANNER_STATE_IDLE, 0);
+        assert_eq!(SDR_SCANNER_STATE_RETUNING, 1);
+        assert_eq!(SDR_SCANNER_STATE_DWELLING, 2);
+        assert_eq!(SDR_SCANNER_STATE_LISTENING, 3);
+        assert_eq!(SDR_SCANNER_STATE_HANGING, 4);
+    }
+
+    #[test]
+    fn scanner_mutex_reason_discriminants_match_header() {
+        assert_eq!(SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER, 0);
+        assert_eq!(SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER, 1);
+        assert_eq!(SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING, 2);
+        assert_eq!(SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION, 3);
+    }
+
+    #[test]
+    fn translate_scanner_state_changed_listening() {
+        let (event, owned_cstring, _) = translate_event(&DspToUi::ScannerStateChanged(
+            sdr_scanner::ScannerState::Listening,
+        ))
+        .expect("ScannerStateChanged should translate");
+        assert_eq!(event.kind, SDR_EVT_SCANNER_STATE_CHANGED);
+        let payload = unsafe { event.payload.scanner_state };
+        assert_eq!(payload.state, SDR_SCANNER_STATE_LISTENING);
+        assert!(owned_cstring.is_none());
+    }
+
+    /// Build a synthetic `DspToUi::ScannerActiveChannelChanged`
+    /// for the FFI translation tests. The flattened `freq_hz` /
+    /// `name` fields are populated by the controller-side helper
+    /// in lockstep with the `key`, so the test fixture mirrors
+    /// that contract — passing the same string for `name` and
+    /// `key.name`. Other fields are filler the FFI doesn't read.
+    fn scanner_active_channel_event(latched_name: Option<&str>, freq_hz: u64) -> DspToUi {
+        let key = latched_name.map(|name| sdr_scanner::ChannelKey {
+            name: name.to_string(),
+            frequency_hz: freq_hz,
+        });
+        DspToUi::ScannerActiveChannelChanged {
+            key,
+            freq_hz,
+            demod_mode: sdr_types::DemodMode::Nfm,
+            bandwidth: 12_500.0,
+            name: latched_name.unwrap_or("").to_string(),
+            ctcss: None,
+            voice_squelch: None,
+        }
+    }
+
+    #[test]
+    fn translate_scanner_active_channel_latched_carries_name_and_frequency() {
+        let (event, owned_cstring, _) = translate_event(&scanner_active_channel_event(
+            Some("NOAA Weather"),
+            162_550_000,
+        ))
+        .expect("ScannerActiveChannelChanged should translate");
+        assert_eq!(event.kind, SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED);
+        let payload = unsafe { event.payload.scanner_active_channel };
+        assert!(!payload.name_utf8.is_null());
+        assert_eq!(payload.frequency_hz, 162_550_000);
+        // Name lives in the owned CString — pointer must still
+        // resolve to the original bytes via the standard
+        // round-trip through CStr.
+        let as_cstr = unsafe { std::ffi::CStr::from_ptr(payload.name_utf8) };
+        assert_eq!(as_cstr.to_str().unwrap(), "NOAA Weather");
+        assert!(owned_cstring.is_some());
+    }
+
+    #[test]
+    fn translate_scanner_active_channel_idle_has_null_name_and_zero_freq() {
+        let (event, owned_cstring, _) = translate_event(&scanner_active_channel_event(None, 0))
+            .expect("idle ScannerActiveChannelChanged should translate");
+        assert_eq!(event.kind, SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED);
+        let payload = unsafe { event.payload.scanner_active_channel };
+        // Idle sentinel: the host clears its "active channel"
+        // readout when it sees (null, 0).
+        assert!(payload.name_utf8.is_null());
+        assert_eq!(payload.frequency_hz, 0);
+        assert!(owned_cstring.is_none());
+    }
+
+    #[test]
+    fn translate_scanner_active_channel_sanitizes_interior_nul_in_name() {
+        // NUL inside the channel name would normally break the
+        // CString conversion; we replace it with '?' rather than
+        // dropping the event (same policy as DeviceInfo /
+        // endpoint strings). A channel name really shouldn't
+        // contain a NUL, but if a host projects one accidentally
+        // we'd rather surface a mangled name than silently drop
+        // the latch event.
+        //
+        // **Bind the owned CString return** — `_owned` rather
+        // than `_` keeps the storage alive for the
+        // `CStr::from_ptr` call below. A bare `_` drops it
+        // immediately at the end of the let binding, leaving
+        // `name_utf8` dangling. Same lifetime contract as the
+        // other translate_*-pattern tests.
+        let (event, _owned_cstring, _) = translate_event(&scanner_active_channel_event(
+            Some("Weather\0Channel"),
+            162_550_000,
+        ))
+        .expect("sanitized ScannerActiveChannelChanged should translate");
+        let payload = unsafe { event.payload.scanner_active_channel };
+        let as_cstr = unsafe { std::ffi::CStr::from_ptr(payload.name_utf8) };
+        assert_eq!(as_cstr.to_str().unwrap(), "Weather?Channel");
+    }
+
+    #[test]
+    fn translate_scanner_empty_rotation() {
+        let (event, owned_cstring, _) = translate_event(&DspToUi::ScannerEmptyRotation)
+            .expect("ScannerEmptyRotation should translate");
+        assert_eq!(event.kind, SDR_EVT_SCANNER_EMPTY_ROTATION);
+        assert!(owned_cstring.is_none());
+    }
+
+    #[test]
+    fn translate_scanner_mutex_stopped_for_recording() {
+        use sdr_core::messages::ScannerMutexReason;
+        let (event, owned_cstring, _) = translate_event(&DspToUi::ScannerMutexStopped(
+            ScannerMutexReason::ScannerStoppedForRecording,
+        ))
+        .expect("ScannerMutexStopped should translate");
+        assert_eq!(event.kind, SDR_EVT_SCANNER_MUTEX_STOPPED);
+        let payload = unsafe { event.payload.scanner_mutex_stopped };
+        assert_eq!(
+            payload.reason,
+            SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING
+        );
+        assert!(owned_cstring.is_none());
     }
 
     #[test]

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -1635,10 +1635,20 @@ const TCP_KEEPALIVE_IDLE_SECS: u32 = 60;
 /// `TCP_KEEPINTVL`. 10 s gives the zombie three chances to reply
 /// across a ~30 s window — enough to ride out a brief network
 /// hiccup without blowing the detection deadline. Per #393.
+///
+/// Linux-only: macOS exposes only `TCP_KEEPALIVE` (the seconds-
+/// until-first-probe knob); per-probe interval and retry count
+/// are kernel-wide sysctls there. The constant is gated to the
+/// platform that can actually set it so non-Linux targets don't
+/// drag a dead-code warning forward.
+#[cfg(target_os = "linux")]
 const TCP_KEEPALIVE_INTERVAL_SECS: u32 = 10;
 /// How many unanswered probes before the kernel drops the socket.
 /// `TCP_KEEPCNT`. 3 keeps the total dead-peer detection window at
 /// roughly 90 s (idle 60 s + 3 × 10 s probes). Per #393.
+///
+/// Linux-only — same rationale as `TCP_KEEPALIVE_INTERVAL_SECS`.
+#[cfg(target_os = "linux")]
 const TCP_KEEPALIVE_RETRIES: u32 = 3;
 
 fn configure_client_socket(stream: &TcpStream) {

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,37 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 19
+#define SDR_CORE_ABI_VERSION_MINOR 20
 /*
+ * 0.20 — exposes the scanner Phase 1 surface (#447) at the FFI
+ * boundary so the macOS SwiftUI scanner panel can drive it.
+ * Additive enum + payload growth:
+ *   - `SdrEventKind` gains four discriminants:
+ *     `SDR_EVT_SCANNER_STATE_CHANGED`        = 14
+ *     `SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED` = 15
+ *     `SDR_EVT_SCANNER_EMPTY_ROTATION`       = 16
+ *     `SDR_EVT_SCANNER_MUTEX_STOPPED`        = 17
+ *   - New helper enums `SdrScannerState` (Idle / Retuning /
+ *     Dwelling / Listening / Hanging) and `SdrScannerMutexReason`
+ *     for the corresponding payload `state` / `reason` fields.
+ *   - New payload structs `SdrEventScannerStateChanged`,
+ *     `SdrEventScannerActiveChannelChanged`,
+ *     `SdrEventScannerMutexStopped` appended to `SdrEventPayload`
+ *     as new union members (existing field offsets unchanged).
+ *   - Three new commands: `sdr_core_set_scanner_enabled`,
+ *     `sdr_core_lockout_scanner_channel`,
+ *     `sdr_core_unlock_scanner_channel`.
+ * The bookmark-list projection (`UpdateScannerChannels`) is NOT
+ * exposed in 0.20 — that follows when the macOS bookmark layer
+ * grows the `scan_enabled` / `priority` fields the Linux side
+ * already has (#490). Until then, the scanner has no channels
+ * to rotate through and the master switch flips without
+ * observable effect; the SwiftUI panel documents this in its
+ * footer.
+ *
+ * Pre-1.0 minor bumps are breaking by project convention — old
+ * 0.19 hosts must fail fast on the exact-match ABI check.
+ *
  * 0.19 — extends the rtl_tcp FFI surface with codec-mask and
  * auth-required fields that were previously hardcoded (#307
  * / #395 follow-ups, issue #400):
@@ -1573,6 +1602,49 @@ int32_t sdr_core_set_fft_size(SdrCore* handle, size_t n);
 int32_t sdr_core_set_fft_window(SdrCore* handle, int32_t window);
 int32_t sdr_core_set_fft_rate(SdrCore* handle, double fps);
 
+/* --- Scanner (issue #447, ABI 0.20) ------------------------------ */
+
+/*
+ * Master scanner enable / disable. Maps to
+ * `UiToDsp::SetScannerEnabled` on the Rust side. Tripping this on
+ * with no projected channels leaves the engine in
+ * `SDR_SCANNER_STATE_IDLE` (visible via the SCANNER_STATE_CHANGED
+ * event); the host doesn't need to special-case empty rotation.
+ */
+int32_t sdr_core_set_scanner_enabled(SdrCore* handle, bool enabled);
+
+/*
+ * Lock out a channel for the rest of the scanner session.
+ *
+ * `name_utf8` + `frequency_hz` together form the scanner's
+ * `ChannelKey` — they must match the channel's identity at
+ * projection time exactly. The scanner clones the name into its
+ * `HashSet<ChannelKey>`, so the borrowed string is only read for
+ * the duration of the call.
+ *
+ * Lockouts persist until the channel is unlocked (see
+ * `sdr_core_unlock_scanner_channel`), the scanner is disabled,
+ * or the engine is destroyed. Returns `SDR_CORE_ERR_INVALID_ARG`
+ * if `name_utf8` is null or not valid UTF-8.
+ */
+int32_t sdr_core_lockout_scanner_channel(
+    SdrCore*    handle,
+    const char* name_utf8,
+    uint64_t    frequency_hz
+);
+
+/*
+ * Clear a session lockout previously installed by
+ * `sdr_core_lockout_scanner_channel`. No-op if the channel
+ * wasn't locked out. Same `(name_utf8, frequency_hz)` identity
+ * contract as the lockout call.
+ */
+int32_t sdr_core_unlock_scanner_channel(
+    SdrCore*    handle,
+    const char* name_utf8,
+    uint64_t    frequency_hz
+);
+
 /* ================================================================ */
 /*  Events                                                          */
 /* ================================================================ */
@@ -1625,7 +1697,43 @@ typedef enum SdrEventKind {
     SDR_EVT_IQ_RECORDING_STOPPED    = 11,
     SDR_EVT_NETWORK_SINK_STATUS     = 12, /* ABI 0.9 — issue #247 */
     SDR_EVT_RTL_TCP_CONNECTION_STATE = 13, /* ABI 0.11 — issue #325 */
+    SDR_EVT_SCANNER_STATE_CHANGED         = 14, /* ABI 0.20 — issue #447 */
+    SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED = 15, /* ABI 0.20 — issue #447 */
+    SDR_EVT_SCANNER_EMPTY_ROTATION        = 16, /* ABI 0.20 — issue #447 */
+    SDR_EVT_SCANNER_MUTEX_STOPPED         = 17, /* ABI 0.20 — issue #447 */
 } SdrEventKind;
+
+/* Scanner phase. Discriminant for the `state` field of
+ * `SdrEventScannerStateChanged` below. Mirrors the variant order
+ * of the engine-side `sdr_scanner::ScannerState`. Stable — never
+ * reorder. ABI 0.20.
+ */
+typedef enum SdrScannerState {
+    /* Scanner off, or on with no channels enabled. */
+    SDR_SCANNER_STATE_IDLE      = 0,
+    /* Retune in flight; audio muted, waiting for settle. */
+    SDR_SCANNER_STATE_RETUNING  = 1,
+    /* Settled on the channel; audio still muted; waiting for
+     * a squelch-open event within the dwell window. */
+    SDR_SCANNER_STATE_DWELLING  = 2,
+    /* Squelch open post-settle, audio flowing. */
+    SDR_SCANNER_STATE_LISTENING = 3,
+    /* Squelch closed, hang countdown before advancing. */
+    SDR_SCANNER_STATE_HANGING   = 4,
+} SdrScannerState;
+
+/* Why the scanner ↔ recording / transcription mutex fired.
+ * Discriminant for the `reason` field of
+ * `SdrEventScannerMutexStopped` below. Mirrors
+ * `sdr_core::messages::ScannerMutexReason`. Stable — never
+ * reorder. ABI 0.20.
+ */
+typedef enum SdrScannerMutexReason {
+    SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER     = 0,
+    SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER = 1,
+    SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING     = 2,
+    SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION = 3,
+} SdrScannerMutexReason;
 
 /* Discriminants for the `kind` field of
  * `SdrEventRtlTcpConnectionState` below. Stable — never reorder.
@@ -1755,6 +1863,44 @@ typedef struct SdrEventRtlTcpConnectionState {
 } SdrEventRtlTcpConnectionState;
 
 /*
+ * Payload for SDR_EVT_SCANNER_STATE_CHANGED. `state` is one of the
+ * `SDR_SCANNER_STATE_*` discriminants. ABI 0.20, per #447.
+ */
+typedef struct SdrEventScannerStateChanged {
+    int32_t state;
+} SdrEventScannerStateChanged;
+
+/*
+ * Payload for SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED. The scanner
+ * fires this on every channel latch (squelch open on the new
+ * channel) and on every release back to Idle.
+ *
+ * | scanner state         | name_utf8     | frequency_hz |
+ * |-----------------------|---------------|--------------|
+ * | active (latched)      | bookmark name | channel Hz   |
+ * | idle (no channel)     | NULL          | 0            |
+ *
+ * `name_utf8` is borrowed from dispatcher-owned storage; valid
+ * only for the duration of the callback. ABI 0.20, per #447.
+ */
+typedef struct SdrEventScannerActiveChannelChanged {
+    const char* name_utf8;
+    uint64_t    frequency_hz;
+} SdrEventScannerActiveChannelChanged;
+
+/*
+ * Payload for SDR_EVT_SCANNER_MUTEX_STOPPED. `reason` is one of
+ * the `SDR_SCANNER_MUTEX_*` discriminants — describes which side
+ * of the scanner ↔ recording / transcription mutex fired. ABI
+ * 0.20, per #447.
+ *
+ * SDR_EVT_SCANNER_EMPTY_ROTATION carries no payload.
+ */
+typedef struct SdrEventScannerMutexStopped {
+    int32_t reason;
+} SdrEventScannerMutexStopped;
+
+/*
  * Tagged union of all event payloads. Which union field is valid
  * is determined by the `kind` discriminant on the enclosing
  * SdrEvent (see the table below).
@@ -1774,6 +1920,10 @@ typedef struct SdrEventRtlTcpConnectionState {
  * SDR_EVT_IQ_RECORDING_STOPPED        none (all-zero payload)
  * SDR_EVT_NETWORK_SINK_STATUS         network_sink_status.{kind,utf8,protocol}
  * SDR_EVT_RTL_TCP_CONNECTION_STATE    rtl_tcp_connection_state.{kind,utf8,attempt,retry_in_secs,gain_count}
+ * SDR_EVT_SCANNER_STATE_CHANGED          scanner_state.state
+ * SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED scanner_active_channel.{name_utf8,frequency_hz}
+ * SDR_EVT_SCANNER_EMPTY_ROTATION         none (all-zero payload)
+ * SDR_EVT_SCANNER_MUTEX_STOPPED          scanner_mutex_stopped.reason
  */
 typedef union SdrEventPayload {
     double sample_rate_hz;
@@ -1786,6 +1936,9 @@ typedef union SdrEventPayload {
     SdrEventIqRecording       iq_recording;
     SdrEventNetworkSinkStatus      network_sink_status;
     SdrEventRtlTcpConnectionState  rtl_tcp_connection_state;
+    SdrEventScannerStateChanged          scanner_state;
+    SdrEventScannerActiveChannelChanged  scanner_active_channel;
+    SdrEventScannerMutexStopped          scanner_mutex_stopped;
     /* Placeholder so kinds with no payload (e.g., SOURCE_STOPPED)
      * have a well-defined zeroed payload representation. */
     uint64_t _placeholder;


### PR DESCRIPTION
## Summary

- Lands the macOS scanner activity panel (#447) — three sections (Scanner / Active / Timing) mirroring the GTK reference.
- Bumps the C ABI to 0.20: exposes the scanner Phase 1 surface (commands + four events + helper enums) that was deliberately withheld from earlier minor bumps.
- Backfills `SdrRtlTcpServer` / `SdrRtlTcpDiscovery` Swift wrappers for ABI 0.14–0.19 multi-client refactor — the Mac side hadn't caught up to those Linux changes and the build was red on `main`. Per-client detail (rows / recent-commands ring) moves to #496.

## Scanner panel

Mirrors `crates/sdr-ui/src/sidebar/scanner_panel.rs`:
- **Scanner** — master enable toggle.
- **Active** — Channel row (latched bookmark name + freq, em-dash placeholder when idle), State row (Off / Retuning / Listening / Hang), Lockout button visible only while latched.
- **Timing** — default dwell (50–500 ms) and default hang (500–5 000 ms) steppers, persisted via `UserDefaults` under the same key names as the Linux side for future cross-frontend config alignment.

Bookmark → `ScannerChannel` projection lands in #490. Until then, flipping the master switch leaves the engine in `.idle` — the panel's footer documents the gap. Same carve-out pattern used for the CTCSS placeholder in the Radio panel.

## ABI 0.20 — `include/sdr_core.h`

New surface (additive — pre-1.0 minor bumps are still breaking by project convention, but field offsets don't shift):
- `SdrEventKind` gains `SDR_EVT_SCANNER_STATE_CHANGED` / `_ACTIVE_CHANNEL_CHANGED` / `_EMPTY_ROTATION` / `_MUTEX_STOPPED` (14–17).
- `SdrScannerState` enum (`IDLE`/`RETUNING`/`DWELLING`/`LISTENING`/`HANGING`) and `SdrScannerMutexReason` enum.
- Payload structs `SdrEventScannerStateChanged`, `SdrEventScannerActiveChannelChanged` (NULL name + zero freq = idle sentinel), `SdrEventScannerMutexStopped`. Added as new union members.
- Three commands: `sdr_core_set_scanner_enabled`, `sdr_core_lockout_scanner_channel`, `sdr_core_unlock_scanner_channel`. The bookmark-list projection (`UpdateScannerChannels`) is **not** exposed in 0.20 — that follows when the Mac bookmark layer grows the `scan_enabled` / `priority` fields the Linux `Bookmark` already has (#490).

Header drift check (`make ffi-header-check`) passes — hand-written and cbindgen-generated headers agree.

## rtl_tcp wrapper backfill

The Linux side reworked the rtl_tcp server to multi-client (#391 / ABI 0.14) and added subsequent feature fields through 0.19. Swift wrappers had drifted; the Mac build was failing at compile/link before this PR. Minimum-honest fix:
- `SdrRtlTcpServer.Stats` collapsed to server-wide aggregates (`connectedCount`, `totalBytesSent`, `totalBuffersDropped`, `lifetimeAccepted`, `tunerName`, `gainCount`).
- `recentCommands()` removed — recent-commands ring is per-client now and requires `clientList()` (the multi-client surface) to map an id back to its commands. Tracked in #496.
- `Config.toC()` and `AdvertiseOptions` pass zero-init defaults for new tail fields (`listener_cap` / `auth_key` / `auth_key_len` / `has_compression` / `compression`, `has_codecs` / `codecs` / `has_auth_required` / `auth_required`) — preserves pre-ABI-0.16 server / pre-ABI-0.19 advertise behaviour exactly.
- `RtlTcpServerSection` panel reads aggregates; per-client activity log gone for now.

Full multi-client port (per-client `ClientInfo` rows, per-client recent-commands disclosure, auth / listener-cap / compression UI) lands in **#496**.

## Drive-by

`TCP_KEEPALIVE_INTERVAL_SECS` / `TCP_KEEPALIVE_RETRIES` in `crates/sdr-server-rtltcp/src/server.rs` are now `#[cfg(target_os = "linux")]` — they were dead-code on macOS (Linux-only `TCP_KEEPINTVL` / `TCP_KEEPCNT` setters reference them; mac uses only the single `TCP_KEEPALIVE` knob). Cleared the warning before opening this PR.

## Test plan

- [x] `make ffi-header-check` — hand-written / cbindgen agree on the FFI surface
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p sdr-ffi --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p sdr-server-rtltcp --all-targets -- -D warnings` — clean
- [x] `cargo test -p sdr-ffi` — 178 passed (8 new scanner translate / discriminant tests)
- [x] `cargo build --workspace --release` — clean, no warnings
- [x] `make mac-app` — Mac app bundles + ad-hoc signs successfully
- [x] Smoke test: launched `apps/macos/build/sdr-rs.app`, clicked the Scanner activity icon, confirmed three sections render, master switch toggles, State row reads "Off" with no channels, dwell/hang steppers work + persist across relaunch
- [x] Other panels still work (General / Radio / Audio / Display / Share)
- [x] rtl_tcp Share panel still functions — Status section now shows aggregates instead of single-client detail
- [ ] CodeRabbit review

## Links

- Closes #447
- Multi-client rtl_tcp port follow-up: #496
- Bookmark scan-enable opt-in (the data path that gives the scanner channels): #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scanner master toggle, per-channel lockout/unlock, and adjustable dwell/hang timing in the UI
  * New Scanner panel showing state, active channel, and a “Lockout this channel” action

* **Changes**
  * RTL‑TCP server view simplified: per-client activity log removed; replaced with server‑wide aggregate stats (connected count, lifetime bytes/drops)

* **Other**
  * Engine-driven scanner events now surface to the UI (state, active channel, empty rotation, mutex stop)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->