### PR TITLE
sdr-sat: SGP4 satellite pass predictor + TLE cache (closes #480)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1234,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2669,6 +2705,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdr-sat"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dirs-next",
+ "reqwest",
+ "sdr-types",
+ "serde",
+ "sgp4",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "sdr-scanner"
 version = "0.1.0"
 dependencies = [
@@ -2932,6 +2982,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sgp4"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9467b9a7be8485ed8be0f336d399c8f32c0fcd60686e7dd2ed3dab75c9a73eb3"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ members = [
     "crates/sdr-radio",
     "crates/sdr-config",
     "crates/sdr-radioreference",
+    "crates/sdr-sat",
     "crates/sdr-transcription",
     "crates/sdr-core",
     "crates/sdr-ffi",
@@ -142,6 +143,7 @@ sdr-sink-network = { path = "crates/sdr-sink-network" }
 sdr-radio = { path = "crates/sdr-radio" }
 sdr-config = { path = "crates/sdr-config" }
 sdr-radioreference = { path = "crates/sdr-radioreference" }
+sdr-sat = { path = "crates/sdr-sat" }
 sdr-transcription = { path = "crates/sdr-transcription" }
 sdr-core = { path = "crates/sdr-core" }
 sdr-ffi = { path = "crates/sdr-ffi" }
@@ -184,6 +186,14 @@ sherpa-onnx = { git = "https://github.com/jasonherald/sherpa-onnx.git", rev = "6
 # System directories / libc
 dirs-next = "2"
 libc = "0.2"
+
+# Satellite tracking (sdr-sat). The `sgp4` crate is the de-facto
+# pure-Rust port of Vallado's SGP4/SDP4 (matches the reference C++
+# implementation, ships the AIAA test vectors). chrono gives us
+# `DateTime<Utc>` for human-friendly pass times — APT scheduling is
+# inherently a "render this in the user's timezone" feature.
+sgp4 = "2.3"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 
 # Random number generation. Pulled in for the rtl_tcp optional-auth
 # server (#394) key generator — `OsRng` wraps `/dev/urandom` on

--- a/crates/sdr-sat/Cargo.toml
+++ b/crates/sdr-sat/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sdr-sat"
+version = "0.1.0"
+description = "Satellite pass prediction (SGP4) and TLE cache for LEO weather / ham satellites"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+sdr-types.workspace = true
+sgp4.workspace = true
+chrono.workspace = true
+reqwest.workspace = true
+dirs-next.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -1,0 +1,118 @@
+//! Satellite pass prediction service.
+//!
+//! Foundation crate for any feature that needs to know "where is
+//! satellite X right now" or "when does satellite X next come overhead":
+//! NOAA APT (epic #468), Meteor-M LRPT (#469), ISS SSTV (#472), and
+//! whatever comes after.
+//!
+//! The crate is split into three layers:
+//!
+//! * [`sgp4_core`] — pure SGP4/SDP4 propagation. No I/O, no time-of-day
+//!   queries, no allocator surprises in the hot path. Wraps the
+//!   well-tested [`sgp4`] crate from crates.io and adds the geometry
+//!   helpers we actually need (ECI → ECEF → station-frame az/el/range).
+//! * [`passes`] — pass enumeration and real-time tracking. Pure
+//!   functions over [`GroundStation`] + [`Satellite`] + time. Doppler
+//!   shift is exposed via real-time tracking only — pass enumeration
+//!   doesn't need it.
+//! * [`tle_cache`] — fetches TLEs from Celestrak once a day and caches
+//!   them under `~/.cache/sdr-rs/tle/`. Blocking reqwest call meant to
+//!   be invoked from a worker thread; the rest of the crate has zero
+//!   network awareness.
+//!
+//! Hard-coded NORAD IDs for the satellites we ship with are in
+//! [`KNOWN_SATELLITES`] so callers don't need to look them up.
+
+pub mod passes;
+pub mod sgp4_core;
+pub mod tle_cache;
+
+pub use sgp4_core::{Satellite, SatelliteError};
+pub use tle_cache::TleSource;
+
+/// A satellite the user-facing scheduler ships with by default. The list
+/// is intentionally tight — we want passes to "just work" for the most
+/// common LEO weather / ham satellites without making the user paste
+/// TLEs by hand.
+#[derive(Debug, Clone, Copy)]
+pub struct KnownSatellite {
+    /// Display name, matches the Celestrak TLE name field exactly. Used
+    /// for the `Browse...` filter that pulls the TLE pair out of the
+    /// downloaded text file.
+    pub name: &'static str,
+    /// NORAD catalog number — the canonical satellite identifier.
+    pub norad_id: u32,
+    /// Which Celestrak source file the TLE lives in.
+    pub source: TleSource,
+}
+
+/// Built-in catalog. Order is the order the scheduler UI displays.
+pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
+    // NOAA APT — epic #468
+    KnownSatellite {
+        name: "NOAA 15",
+        norad_id: 25_338,
+        source: TleSource::Noaa,
+    },
+    KnownSatellite {
+        name: "NOAA 18",
+        norad_id: 28_654,
+        source: TleSource::Noaa,
+    },
+    KnownSatellite {
+        name: "NOAA 19",
+        norad_id: 33_591,
+        source: TleSource::Noaa,
+    },
+    // Meteor-M LRPT — epic #469
+    KnownSatellite {
+        name: "METEOR-M 2",
+        norad_id: 40_069,
+        source: TleSource::Weather,
+    },
+    KnownSatellite {
+        name: "METEOR-M2 3",
+        norad_id: 57_166,
+        source: TleSource::Weather,
+    },
+    KnownSatellite {
+        name: "METEOR-M2 4",
+        norad_id: 61_024,
+        source: TleSource::Weather,
+    },
+    // ISS SSTV — epic #472
+    KnownSatellite {
+        name: "ISS (ZARYA)",
+        norad_id: 25_544,
+        source: TleSource::Stations,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_satellites_have_unique_norad_ids() {
+        let mut ids: Vec<u32> = KNOWN_SATELLITES.iter().map(|s| s.norad_id).collect();
+        ids.sort_unstable();
+        let before = ids.len();
+        ids.dedup();
+        assert_eq!(
+            ids.len(),
+            before,
+            "two entries in KNOWN_SATELLITES share a NORAD id",
+        );
+    }
+
+    #[test]
+    fn known_satellites_cover_all_three_epics() {
+        let names: Vec<&str> = KNOWN_SATELLITES.iter().map(|s| s.name).collect();
+        // NOAA APT
+        assert!(names.iter().any(|n| n.contains("NOAA")));
+        // Meteor-M LRPT
+        assert!(names.iter().any(|n| n.contains("METEOR")));
+        // ISS SSTV
+        assert!(names.iter().any(|n| n.contains("ISS")));
+    }
+}

--- a/crates/sdr-sat/src/passes.rs
+++ b/crates/sdr-sat/src/passes.rs
@@ -1,0 +1,491 @@
+//! Satellite pass enumeration + real-time tracking.
+//!
+//! Built on top of [`crate::sgp4_core`]: given a [`GroundStation`] and a
+//! parsed [`Satellite`], produce
+//!
+//! * [`Track`] — current az/el/range/range-rate at one specific UTC
+//!   instant. The Doppler shift comes out of `track().doppler_shift_hz`
+//!   for whatever carrier frequency the caller cares about (137 MHz
+//!   for APT, 145.8 for ISS-SSTV, 137.1 for Meteor LRPT, etc.).
+//! * [`Pass`] — start/end/max-elevation summary of one overhead
+//!   transit. [`upcoming_passes`] enumerates all passes in a time
+//!   window above a caller-specified minimum elevation.
+//!
+//! The pass enumerator is deliberately simple: coarse 1-minute
+//! elevation scan to find horizon crossings, bisection to refine each
+//! crossing to ~1-second precision, fine scan inside the pass to
+//! locate maximum elevation. This is plenty accurate for an APT pass
+//! scheduler — pass timings drift by tens of seconds on a fresh TLE
+//! anyway, and SGP4 itself is only good to a few km in position.
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::sgp4_core::{
+    EARTH_ROTATION_RAD_PER_SEC, Satellite, SatelliteError, ecef_to_enu, eci_to_ecef,
+    geodetic_to_ecef, gmst_rad,
+};
+
+/// Speed of light, km/s. Defined exactly by the SI metre.
+const SPEED_OF_LIGHT_KM_S: f64 = 299_792.458;
+
+/// Coarse step for the initial pass scan. One minute is comfortably
+/// finer than the shortest LEO horizon-to-horizon transit (a low-pass
+/// of ISS at high latitude can be ~6 minutes; APT at NOAA altitude is
+/// 12–16 minutes), so we won't miss a pass entirely. Refinement uses
+/// bisection to pin the start/end timestamps down to seconds.
+const COARSE_STEP: Duration = Duration::seconds(60);
+
+/// Step inside a detected pass for locating the elevation peak.
+const FINE_STEP: Duration = Duration::seconds(10);
+
+/// Bisection precision for horizon-crossing refinement.
+const REFINE_PRECISION: Duration = Duration::seconds(1);
+
+/// Maximum bisection iterations — bounded so a degenerate input (e.g.
+/// satellite near horizon almost the whole window) can't loop forever.
+const MAX_REFINE_ITERATIONS: usize = 20;
+
+/// A receiver site on the ground — what the satellite is overhead of.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GroundStation {
+    /// Latitude in degrees, positive north (`-90.0..=90.0`).
+    pub lat_deg: f64,
+    /// Longitude in degrees, positive east (`-180.0..=180.0`).
+    pub lon_deg: f64,
+    /// Altitude above the WGS84 ellipsoid, in metres. Sea level is `0.0`.
+    pub alt_m: f64,
+}
+
+impl GroundStation {
+    /// Convenience constructor.
+    #[must_use]
+    pub const fn new(lat_deg: f64, lon_deg: f64, alt_m: f64) -> Self {
+        Self {
+            lat_deg,
+            lon_deg,
+            alt_m,
+        }
+    }
+
+    /// Station position in ECEF (km).
+    #[must_use]
+    pub fn ecef_km(&self) -> [f64; 3] {
+        geodetic_to_ecef(self.lat_deg, self.lon_deg, self.alt_m)
+    }
+}
+
+/// Snapshot of where the satellite is *right now* relative to the
+/// station — what a tracker would feed to a rotor or an antenna-pattern
+/// hint. Doppler shift is exposed as a method so the caller can ask
+/// for it at the actual carrier frequency for whatever downlink they
+/// care about.
+#[derive(Debug, Clone, Copy)]
+pub struct Track {
+    /// Compass bearing, degrees clockwise from true north
+    /// (`0.0..360.0`).
+    pub azimuth_deg: f64,
+    /// Elevation above local horizontal, degrees (`-90.0..=90.0`).
+    /// Negative means below the horizon — won't be in a [`Pass`] but
+    /// `track()` will report it for satellites that aren't overhead.
+    pub elevation_deg: f64,
+    /// Slant range from station to satellite, km.
+    pub range_km: f64,
+    /// Range rate in km/s. Positive = moving away from station,
+    /// negative = approaching. Multiply through `doppler_shift_hz`
+    /// for the carrier-frequency shift seen at the station.
+    pub range_rate_km_s: f64,
+    /// UTC instant the track was evaluated at.
+    pub when: DateTime<Utc>,
+}
+
+impl Track {
+    /// Doppler frequency shift the station observes at carrier
+    /// `frequency_hz`. Positive shift = received frequency higher than
+    /// transmitted (satellite approaching); the formula is
+    /// `Δf = -f₀ · ṙ / c`.
+    #[must_use]
+    pub fn doppler_shift_hz(&self, frequency_hz: f64) -> f64 {
+        -frequency_hz * self.range_rate_km_s / SPEED_OF_LIGHT_KM_S
+    }
+}
+
+/// Summary of one overhead pass — what the scheduler UI displays.
+#[derive(Debug, Clone)]
+pub struct Pass {
+    /// Display name copied from the [`Satellite`] used for enumeration,
+    /// so the result is self-describing once moved out of the call site.
+    pub satellite: String,
+    /// AOS (Acquisition Of Signal) — the moment the satellite first
+    /// crosses above the requested minimum elevation.
+    pub start: DateTime<Utc>,
+    /// LOS (Loss Of Signal) — when the satellite drops back below the
+    /// minimum elevation.
+    pub end: DateTime<Utc>,
+    /// Peak elevation reached during the pass (degrees).
+    pub max_elevation_deg: f64,
+    /// UTC instant the elevation peak occurs at.
+    pub max_el_time: DateTime<Utc>,
+    /// Azimuth at AOS (degrees clockwise from true north).
+    pub start_az_deg: f64,
+    /// Azimuth at LOS (degrees clockwise from true north).
+    pub end_az_deg: f64,
+}
+
+/// Compute the satellite's current az/el/range/Doppler relative to the
+/// ground station.
+///
+/// # Errors
+///
+/// Propagates [`SatelliteError`] from the underlying SGP4 propagator.
+pub fn track(
+    station: &GroundStation,
+    satellite: &Satellite,
+    when: DateTime<Utc>,
+) -> Result<Track, SatelliteError> {
+    let sat_eci = satellite.propagate(when)?;
+    let sat_ecef = eci_to_ecef(sat_eci.position_km, when);
+    let station_ecef = station.ecef_km();
+    let relative_ecef = sub(sat_ecef, station_ecef);
+    let enu = ecef_to_enu(relative_ecef, station.lat_deg, station.lon_deg);
+
+    let range_km = norm(enu);
+    // Azimuth: 0 = North, 90 = East, range [0, 360).
+    let az_rad = enu[0].atan2(enu[1]);
+    let azimuth_deg = az_rad.to_degrees().rem_euclid(360.0);
+    // Elevation: positive above horizon.
+    let elevation_deg = if range_km > 0.0 {
+        (enu[2] / range_km).asin().to_degrees()
+    } else {
+        90.0
+    };
+
+    // Range rate: compute in ECI to avoid the rotating-frame Coriolis
+    // bookkeeping. Station velocity in ECI is ω × r_station_eci.
+    let g = gmst_rad(when);
+    let (sin_g, cos_g) = g.sin_cos();
+    // Inverse of eci_to_ecef: rotate ECEF back into ECI.
+    let station_eci = [
+        cos_g * station_ecef[0] - sin_g * station_ecef[1],
+        sin_g * station_ecef[0] + cos_g * station_ecef[1],
+        station_ecef[2],
+    ];
+    let omega = EARTH_ROTATION_RAD_PER_SEC;
+    // ω × r where ω = (0, 0, omega): result is (-omega·y, omega·x, 0).
+    let station_vel_eci = [-omega * station_eci[1], omega * station_eci[0], 0.0];
+    let range_vec_eci = sub(sat_eci.position_km, station_eci);
+    let rel_vel_eci = sub(sat_eci.velocity_km_s, station_vel_eci);
+    let range_rate_km_s = dot(range_vec_eci, rel_vel_eci) / norm(range_vec_eci);
+
+    Ok(Track {
+        azimuth_deg,
+        elevation_deg,
+        range_km,
+        range_rate_km_s,
+        when,
+    })
+}
+
+/// Enumerate all overhead passes of `satellite` from `from` to `to`
+/// (inclusive of `from`, exclusive of `to`) with peak elevation at
+/// or above `min_elevation_deg`.
+///
+/// Passes that are already in progress at `from` are still returned —
+/// their `start` is whatever moment the satellite first cleared
+/// `min_elevation_deg` *within* the window. Symmetrically, passes that
+/// haven't fully ended by `to` are returned with `end == to`.
+pub fn upcoming_passes(
+    station: &GroundStation,
+    satellite: &Satellite,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+    min_elevation_deg: f64,
+) -> Vec<Pass> {
+    if to <= from {
+        return Vec::new();
+    }
+
+    let mut passes = Vec::new();
+    let mut t = from;
+    let mut prev_el = elevation_at(station, satellite, t);
+    let mut pass_open: Option<DateTime<Utc>> = if prev_el >= min_elevation_deg {
+        // Window starts mid-pass — clamp the start to the window edge.
+        Some(from)
+    } else {
+        None
+    };
+
+    while t < to {
+        let next_t = (t + COARSE_STEP).min(to);
+        let next_el = elevation_at(station, satellite, next_t);
+
+        match (
+            pass_open,
+            prev_el >= min_elevation_deg,
+            next_el >= min_elevation_deg,
+        ) {
+            // Rising edge: refine the boundary.
+            (None, false, true) => {
+                let start = refine_crossing(station, satellite, t, next_t, min_elevation_deg);
+                pass_open = Some(start);
+            }
+            // Setting edge: refine, build the Pass, push.
+            (Some(open_at), true, false) => {
+                let end = refine_crossing(station, satellite, t, next_t, min_elevation_deg);
+                if let Some(p) = build_pass(station, satellite, open_at, end) {
+                    passes.push(p);
+                }
+                pass_open = None;
+            }
+            _ => {}
+        }
+
+        prev_el = next_el;
+        t = next_t;
+    }
+
+    // Pass still open at `to` — emit it with end clamped.
+    if let Some(open_at) = pass_open
+        && let Some(p) = build_pass(station, satellite, open_at, to)
+    {
+        passes.push(p);
+    }
+
+    passes
+}
+
+// ─── Internals ────────────────────────────────────────────────────────
+
+fn elevation_at(station: &GroundStation, satellite: &Satellite, when: DateTime<Utc>) -> f64 {
+    track(station, satellite, when).map_or(f64::NEG_INFINITY, |t| t.elevation_deg)
+}
+
+/// Bisect between `lo` (below threshold) and `hi` (above threshold) to
+/// find the moment elevation crosses `threshold_deg`, to within
+/// [`REFINE_PRECISION`]. Returns `hi` if bisection bottoms out before
+/// the precision target.
+fn refine_crossing(
+    station: &GroundStation,
+    satellite: &Satellite,
+    lo: DateTime<Utc>,
+    hi: DateTime<Utc>,
+    threshold_deg: f64,
+) -> DateTime<Utc> {
+    let mut lo = lo;
+    let mut hi = hi;
+    for _ in 0..MAX_REFINE_ITERATIONS {
+        if hi - lo <= REFINE_PRECISION {
+            return hi;
+        }
+        let mid = lo + (hi - lo) / 2;
+        if elevation_at(station, satellite, mid) >= threshold_deg {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+    }
+    hi
+}
+
+/// Walk a fine grid between `start` and `end`, find the maximum
+/// elevation, and pull the AOS/LOS azimuths. Returns `None` only if
+/// SGP4 propagation fails at *both* AOS and LOS — `elevation_at`
+/// handles transient propagation failures gracefully so this is rare.
+fn build_pass(
+    station: &GroundStation,
+    satellite: &Satellite,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> Option<Pass> {
+    let aos = track(station, satellite, start).ok()?;
+    let los = track(station, satellite, end).ok()?;
+
+    let mut max_el = aos.elevation_deg.max(los.elevation_deg);
+    let mut max_t = if aos.elevation_deg >= los.elevation_deg {
+        start
+    } else {
+        end
+    };
+    let mut t = start + FINE_STEP;
+    while t < end {
+        let el = elevation_at(station, satellite, t);
+        if el > max_el {
+            max_el = el;
+            max_t = t;
+        }
+        t += FINE_STEP;
+    }
+
+    Some(Pass {
+        satellite: satellite.name().to_string(),
+        start,
+        end,
+        max_elevation_deg: max_el,
+        max_el_time: max_t,
+        start_az_deg: aos.azimuth_deg,
+        end_az_deg: los.azimuth_deg,
+    })
+}
+
+#[inline]
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+#[inline]
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+fn norm(v: [f64; 3]) -> f64 {
+    dot(v, v).sqrt()
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    /// Vallado TC0 reference TLE — same as in [`crate::sgp4_core`] tests.
+    /// Vanguard 1, NORAD 5, epoch 2000-06-27 18:50:19 UTC. Ships in
+    /// every SGP4 implementation as a sanity-check vector.
+    const TEST_TLE_NAME: &str = "VANGUARD 1";
+    const TEST_TLE_LINE1: &str =
+        "1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753";
+    const TEST_TLE_LINE2: &str =
+        "2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667";
+
+    /// Mid-latitude US station — pinned so pass-count tests are
+    /// reproducible. (40°N 74°W is roughly Princeton, NJ.)
+    const TEST_STATION_LAT: f64 = 40.0;
+    const TEST_STATION_LON: f64 = -74.0;
+    const TEST_STATION_ALT_M: f64 = 50.0;
+
+    /// 5° minimum elevation — the standard "useful pass" cutoff for
+    /// LEO weather work; below 5° the signal usually has too much
+    /// horizon attenuation to decode anything.
+    const TEST_MIN_ELEVATION_DEG: f64 = 5.0;
+
+    fn test_satellite() -> Satellite {
+        Satellite::from_tle(TEST_TLE_NAME, TEST_TLE_LINE1, TEST_TLE_LINE2).unwrap()
+    }
+
+    fn test_station() -> GroundStation {
+        GroundStation::new(TEST_STATION_LAT, TEST_STATION_LON, TEST_STATION_ALT_M)
+    }
+
+    #[test]
+    fn track_at_epoch_returns_finite_values() {
+        let sat = test_satellite();
+        let station = test_station();
+        let t = track(&station, &sat, sat.epoch()).unwrap();
+        assert!(t.azimuth_deg.is_finite() && (0.0..360.0).contains(&t.azimuth_deg));
+        assert!(t.elevation_deg.is_finite() && (-90.0..=90.0).contains(&t.elevation_deg));
+        assert!(t.range_km.is_finite() && t.range_km > 0.0);
+        assert!(t.range_rate_km_s.is_finite());
+    }
+
+    #[test]
+    fn doppler_shift_sign_matches_range_rate() {
+        // Construct a Track by hand to test the formula in isolation —
+        // doesn't depend on SGP4 details.
+        let approaching = Track {
+            azimuth_deg: 0.0,
+            elevation_deg: 30.0,
+            range_km: 1_000.0,
+            range_rate_km_s: -5.0, // moving toward station
+            when: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        };
+        let receding = Track {
+            range_rate_km_s: 5.0, // moving away
+            ..approaching
+        };
+        let f = 137.5e6; // APT carrier
+        let shift_in = approaching.doppler_shift_hz(f);
+        let shift_out = receding.doppler_shift_hz(f);
+        assert!(shift_in > 0.0, "approaching = blueshift, got {shift_in}");
+        assert!(shift_out < 0.0, "receding = redshift, got {shift_out}");
+        // Magnitudes should match.
+        assert!((shift_in + shift_out).abs() < 1e-6);
+    }
+
+    #[test]
+    fn upcoming_passes_finds_passes_in_a_one_day_window() {
+        // For a TLE epoch + 1-day window, expect at least a few passes —
+        // any LEO satellite has 12–15 orbits/day, of which several are
+        // visible from a fixed station.
+        let sat = test_satellite();
+        let station = test_station();
+        let from = sat.epoch();
+        let to = from + Duration::days(1);
+        let passes = upcoming_passes(&station, &sat, from, to, TEST_MIN_ELEVATION_DEG);
+        assert!(!passes.is_empty(), "expected ≥ 1 pass in 24 h");
+        // Vanguard 1 has 10.82 orbits/day; ~1/3 of those will be
+        // visible above 5° from a single mid-lat station, so 1–6
+        // passes is the realistic window.
+        assert!(
+            passes.len() <= 8,
+            "implausibly many passes ({}) — coarse-step bug?",
+            passes.len(),
+        );
+    }
+
+    #[test]
+    fn each_pass_is_self_consistent() {
+        let sat = test_satellite();
+        let station = test_station();
+        let from = sat.epoch();
+        let to = from + Duration::days(1);
+        let passes = upcoming_passes(&station, &sat, from, to, TEST_MIN_ELEVATION_DEG);
+        for p in &passes {
+            // Time ordering.
+            assert!(p.start < p.end, "pass {p:?}: start ≥ end");
+            assert!(
+                p.start <= p.max_el_time && p.max_el_time <= p.end,
+                "pass {p:?}: max_el_time outside [start, end]",
+            );
+            // Elevation plausibility.
+            assert!(
+                (TEST_MIN_ELEVATION_DEG..=90.0).contains(&p.max_elevation_deg),
+                "pass {p:?}: max_elevation out of [min, 90°]",
+            );
+            // Azimuths in valid range.
+            assert!((0.0..360.0).contains(&p.start_az_deg));
+            assert!((0.0..360.0).contains(&p.end_az_deg));
+            // Pass duration sanity: at least 30 seconds, less than the
+            // satellite's orbital half-period. Round-orbit LEO sats
+            // give 5–15 min passes; Vanguard 1's eccentricity (~0.19)
+            // produces apogee dwells that can run 30–60 min — both
+            // are physically valid. Tightening this would just chase
+            // SGP4's eccentric-orbit edge cases. The 90-minute ceiling
+            // catches genuine "off-by-orbit-period" bugs without
+            // being orbit-shape-specific.
+            let duration = p.end - p.start;
+            assert!(
+                duration > Duration::seconds(30) && duration < Duration::minutes(90),
+                "pass {p:?}: implausible duration {duration:?}",
+            );
+            // Satellite name round-trips.
+            assert_eq!(p.satellite, TEST_TLE_NAME);
+        }
+    }
+
+    #[test]
+    fn upcoming_passes_returns_empty_for_zero_window() {
+        let sat = test_satellite();
+        let station = test_station();
+        let t = sat.epoch();
+        assert!(upcoming_passes(&station, &sat, t, t, TEST_MIN_ELEVATION_DEG).is_empty());
+        assert!(
+            upcoming_passes(
+                &station,
+                &sat,
+                t,
+                t - Duration::seconds(1),
+                TEST_MIN_ELEVATION_DEG
+            )
+            .is_empty()
+        );
+    }
+}

--- a/crates/sdr-sat/src/sgp4_core.rs
+++ b/crates/sdr-sat/src/sgp4_core.rs
@@ -1,0 +1,433 @@
+//! Pure SGP4 propagation — TLE parsing, position/velocity propagation,
+//! and the geometric helpers needed to go from the propagator's TEME
+//! frame to topocentric az/el/range.
+//!
+//! No I/O, no clock queries, no allocations on the hot path. Wraps the
+//! [`sgp4`] crate from crates.io (Vallado's reference implementation;
+//! ships the AIAA test vectors and matches the canonical C++ port to
+//! sub-metre accuracy).
+
+use chrono::{DateTime, TimeZone, Utc};
+
+// `TimeZone` is used by `Utc.from_utc_datetime` below.
+
+/// Errors from TLE parsing or SGP4 propagation.
+#[derive(Debug, thiserror::Error)]
+pub enum SatelliteError {
+    /// The TLE strings couldn't be parsed by the underlying SGP4 crate.
+    #[error("invalid TLE for {name}: {message}")]
+    InvalidTle {
+        /// Name from the TLE's "0 NAME" line (or whatever the caller
+        /// passed) so the message says *which* TLE failed.
+        name: String,
+        /// Stringified SGP4 parse error.
+        message: String,
+    },
+    /// SGP4 propagation produced a non-physical result. This usually
+    /// means the requested time is decades from the TLE's epoch — TLEs
+    /// drift, propagation past ~2 weeks is unreliable, past ~1 year is
+    /// nonsense.
+    #[error("propagation failed for {name} at {when}: {message}")]
+    Propagation {
+        /// Satellite name for context.
+        name: String,
+        /// Time we tried to propagate to.
+        when: DateTime<Utc>,
+        /// Stringified SGP4 propagation error.
+        message: String,
+    },
+}
+
+/// One satellite's parsed TLE plus the SGP4 propagator built from it.
+///
+/// Construct via [`Satellite::from_tle`]; thereafter call
+/// [`Satellite::propagate`] for any UTC time you need a position at.
+/// The struct is `Clone` so it can be passed across thread boundaries
+/// without lifetime gymnastics — propagating is a few hundred
+/// floating-point ops, not worth Arc-wrapping.
+#[derive(Debug, Clone)]
+pub struct Satellite {
+    name: String,
+    constants: sgp4::Constants,
+    /// UTC moment the TLE's elements describe — used to translate any
+    /// future propagation time into "minutes since epoch", which is
+    /// what the SGP4 propagator wants.
+    epoch: DateTime<Utc>,
+}
+
+impl Satellite {
+    /// Parse a two-line element set into a propagator.
+    ///
+    /// `name` is the satellite display name (e.g. `"NOAA 19"`). `line1`
+    /// and `line2` are the two TLE lines exactly as they appear in
+    /// Celestrak files; trailing newlines are tolerated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SatelliteError::InvalidTle`] if either line fails the
+    /// SGP4 crate's parser (bad checksum, malformed numeric fields,
+    /// missing whitespace at the wrong column, etc.).
+    pub fn from_tle(name: &str, line1: &str, line2: &str) -> Result<Self, SatelliteError> {
+        let elements = sgp4::Elements::from_tle(
+            Some(name.to_string()),
+            line1.trim_end_matches(['\r', '\n']).as_bytes(),
+            line2.trim_end_matches(['\r', '\n']).as_bytes(),
+        )
+        .map_err(|e| SatelliteError::InvalidTle {
+            name: name.to_string(),
+            message: format!("{e}"),
+        })?;
+        let constants =
+            sgp4::Constants::from_elements(&elements).map_err(|e| SatelliteError::InvalidTle {
+                name: name.to_string(),
+                message: format!("{e}"),
+            })?;
+        // The sgp4 crate parses the TLE epoch into a chrono NaiveDateTime
+        // for us — wrap it as UTC.
+        let epoch = Utc.from_utc_datetime(&elements.datetime);
+        Ok(Self {
+            name: name.to_string(),
+            constants,
+            epoch,
+        })
+    }
+
+    /// Display name as supplied to [`Satellite::from_tle`].
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// UTC instant the underlying TLE's elements were valid at.
+    /// Propagation accuracy degrades the further you get from this —
+    /// keep it within ~2 weeks for sub-km accuracy.
+    #[must_use]
+    pub fn epoch(&self) -> DateTime<Utc> {
+        self.epoch
+    }
+
+    /// Propagate the orbit to `when` and return the satellite's
+    /// position + velocity in the **TEME** frame (treated as ECI for
+    /// our purposes — the ~tens-of-arcseconds difference is negligible
+    /// vs SGP4's ~km-level error budget).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SatelliteError::Propagation`] if the SGP4 propagator
+    /// fails — usually because `when` is far enough from the epoch
+    /// that the orbital elements no longer describe physical motion.
+    pub fn propagate(&self, when: DateTime<Utc>) -> Result<EciState, SatelliteError> {
+        let dt = when - self.epoch;
+        // SGP4 wants minutes since epoch as f64. `num_microseconds`
+        // is the most precise integer span chrono will give us; over
+        // very long propagations (decades) it can return None — we
+        // surface that as a propagation error since SGP4 is unreliable
+        // way before then anyway.
+        let dt_minutes = match dt.num_microseconds() {
+            Some(us) => {
+                #[allow(clippy::cast_precision_loss)]
+                let us_f = us as f64;
+                us_f / 60_000_000.0
+            }
+            None => {
+                return Err(SatelliteError::Propagation {
+                    name: self.name.clone(),
+                    when,
+                    message: "time delta exceeds f64 microsecond range".to_string(),
+                });
+            }
+        };
+        let prediction = self
+            .constants
+            .propagate(sgp4::MinutesSinceEpoch(dt_minutes))
+            .map_err(|e| SatelliteError::Propagation {
+                name: self.name.clone(),
+                when,
+                message: format!("{e}"),
+            })?;
+        Ok(EciState {
+            position_km: prediction.position,
+            velocity_km_s: prediction.velocity,
+            when,
+        })
+    }
+}
+
+/// Position + velocity from a single SGP4 propagation, in the
+/// TEME-≈-ECI frame. Position is km, velocity is km/s.
+#[derive(Debug, Clone, Copy)]
+pub struct EciState {
+    /// Position vector \[x, y, z\] in km.
+    pub position_km: [f64; 3],
+    /// Velocity vector \[vx, vy, vz\] in km/s.
+    pub velocity_km_s: [f64; 3],
+    /// UTC instant the propagation was evaluated at.
+    pub when: DateTime<Utc>,
+}
+
+// ─── Earth model + frame conversions ──────────────────────────────────
+
+/// WGS84 semi-major axis in km. The reference ellipsoid every modern
+/// geodesy stack uses; matches Celestrak / NORAD / USNO conventions.
+pub const EARTH_RADIUS_KM: f64 = 6_378.137;
+/// WGS84 flattening, dimensionless.
+pub const EARTH_FLATTENING: f64 = 1.0 / 298.257_223_563;
+/// Earth's sidereal rotation rate in rad/s (IERS conventions).
+pub const EARTH_ROTATION_RAD_PER_SEC: f64 = 7.292_115_146_706_979e-5;
+
+/// Greenwich Mean Sidereal Time at the given UTC instant, in radians,
+/// reduced to `[0, 2π)`.
+///
+/// Uses the standard low-order polynomial (Vallado, "Fundamentals of
+/// Astrodynamics and Applications", 4th ed., eq. 3-45). Accuracy is
+/// well under 1 arcsec for any time in the 20th–21st centuries — way
+/// more than SGP4 itself needs.
+#[must_use]
+pub fn gmst_rad(when: DateTime<Utc>) -> f64 {
+    // Julian Date (UT1, but for our purposes UT1≈UTC to within a second
+    // — UT1-UTC is bounded to |0.9 s| by leap-second insertion and
+    // SGP4 doesn't care).
+    let jd = julian_date_utc(when);
+    let t = (jd - 2_451_545.0) / 36_525.0;
+    // Vallado eq. 3-45 — GMST in seconds.
+    let gmst_seconds =
+        67_310.548_41 + (876_600.0 * 3_600.0 + 8_640_184.812_866) * t + 0.093_104 * t * t
+            - 6.2e-6 * t.powi(3);
+    let gmst_rad = (gmst_seconds % 86_400.0) / 86_400.0 * std::f64::consts::TAU;
+    // Reduce to [0, 2π). `rem_euclid` handles negative values that
+    // small-time offsets near J2000 can produce.
+    gmst_rad.rem_euclid(std::f64::consts::TAU)
+}
+
+/// Rotate an ECI vector to ECEF by negating the GMST rotation about Z.
+#[must_use]
+pub fn eci_to_ecef(eci: [f64; 3], when: DateTime<Utc>) -> [f64; 3] {
+    let g = gmst_rad(when);
+    let (sin_g, cos_g) = g.sin_cos();
+    [
+        cos_g * eci[0] + sin_g * eci[1],
+        -sin_g * eci[0] + cos_g * eci[1],
+        eci[2],
+    ]
+}
+
+/// Convert geodetic lat/lon/alt (degrees, degrees, metres) to ECEF
+/// position (km), using the WGS84 ellipsoid.
+#[must_use]
+#[allow(clippy::similar_names)] // lat_deg / lon_deg / alt are intentional
+pub fn geodetic_to_ecef(lat_deg: f64, lon_deg: f64, altitude_m: f64) -> [f64; 3] {
+    let lat = lat_deg.to_radians();
+    let lon = lon_deg.to_radians();
+    let altitude_km = altitude_m / 1_000.0;
+    let e2 = 2.0 * EARTH_FLATTENING - EARTH_FLATTENING * EARTH_FLATTENING;
+    let n = EARTH_RADIUS_KM / (1.0 - e2 * lat.sin().powi(2)).sqrt();
+    let (sin_lat, cos_lat) = lat.sin_cos();
+    let (sin_lon, cos_lon) = lon.sin_cos();
+    [
+        (n + altitude_km) * cos_lat * cos_lon,
+        (n + altitude_km) * cos_lat * sin_lon,
+        (n * (1.0 - e2) + altitude_km) * sin_lat,
+    ]
+}
+
+/// Rotate an ECEF vector relative to a station at `(lat, lon)` into
+/// the station's topocentric ENU (East / North / Up) frame.
+#[must_use]
+pub fn ecef_to_enu(ecef: [f64; 3], lat_deg: f64, lon_deg: f64) -> [f64; 3] {
+    let lat = lat_deg.to_radians();
+    let lon = lon_deg.to_radians();
+    let (sin_lat, cos_lat) = lat.sin_cos();
+    let (sin_lon, cos_lon) = lon.sin_cos();
+    [
+        // East
+        -sin_lon * ecef[0] + cos_lon * ecef[1],
+        // North
+        -sin_lat * cos_lon * ecef[0] - sin_lat * sin_lon * ecef[1] + cos_lat * ecef[2],
+        // Up
+        cos_lat * cos_lon * ecef[0] + cos_lat * sin_lon * ecef[1] + sin_lat * ecef[2],
+    ]
+}
+
+/// Julian Date for a UTC chrono `DateTime`. Uses the standard
+/// Gregorian-calendar formula (Vallado eq. 3-13).
+#[allow(clippy::similar_names)]
+fn julian_date_utc(when: DateTime<Utc>) -> f64 {
+    use chrono::Datelike;
+    use chrono::Timelike;
+    let mut year_i = when.year();
+    let mut month_i = i32::try_from(when.month()).unwrap_or(0);
+    let day_i = i32::try_from(when.day()).unwrap_or(0);
+    if month_i <= 2 {
+        year_i -= 1;
+        month_i += 12;
+    }
+    let year_f = f64::from(year_i);
+    let month_f = f64::from(month_i);
+    let day_f = f64::from(day_i);
+    let century = (year_f / 100.0).floor();
+    let leap_correction = 2.0 - century + (century / 4.0).floor();
+    let jd_at_midnight = (365.25 * (year_f + 4716.0)).floor()
+        + (30.6001 * (month_f + 1.0)).floor()
+        + day_f
+        + leap_correction
+        - 1524.5;
+    let day_fraction = (f64::from(when.num_seconds_from_midnight())
+        + f64::from(when.nanosecond()) / 1e9)
+        / 86_400.0;
+    jd_at_midnight + day_fraction
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// Vallado's TC0 reference TLE (Vanguard 1, NORAD 5, epoch 2000-06-27)
+    /// — the canonical SGP4 verification test case from
+    /// "Revisiting Spacetrack Report #3" (AIAA 2006-6753). Pinned here
+    /// so the tests don't depend on network state and the line-checksum
+    /// digits are guaranteed correct.
+    const TEST_TLE_NAME: &str = "VANGUARD 1";
+    const TEST_TLE_LINE1: &str =
+        "1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753";
+    const TEST_TLE_LINE2: &str =
+        "2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667";
+
+    #[test]
+    fn satellite_from_tle_parses_and_round_trips_name() {
+        let sat = Satellite::from_tle(TEST_TLE_NAME, TEST_TLE_LINE1, TEST_TLE_LINE2).unwrap();
+        assert_eq!(sat.name(), TEST_TLE_NAME);
+    }
+
+    #[test]
+    fn satellite_from_tle_rejects_garbage() {
+        let result = Satellite::from_tle("BAD", "not a tle line", "either");
+        assert!(matches!(result, Err(SatelliteError::InvalidTle { .. })));
+    }
+
+    #[test]
+    fn satellite_propagate_at_epoch_returns_finite_state() {
+        let sat = Satellite::from_tle(TEST_TLE_NAME, TEST_TLE_LINE1, TEST_TLE_LINE2).unwrap();
+        let state = sat.propagate(sat.epoch()).unwrap();
+        let r = (state.position_km[0].powi(2)
+            + state.position_km[1].powi(2)
+            + state.position_km[2].powi(2))
+        .sqrt();
+        // Vanguard 1's orbit varies from ~7000 km perigee to ~10000 km
+        // apogee (eccentricity 0.186 around a ~8600 km semi-major axis).
+        // Either way the radius is bounded comfortably in this range.
+        assert!(
+            (5_000.0..15_000.0).contains(&r),
+            "satellite radius at epoch out of range: {r:.1} km",
+        );
+        let v = (state.velocity_km_s[0].powi(2)
+            + state.velocity_km_s[1].powi(2)
+            + state.velocity_km_s[2].powi(2))
+        .sqrt();
+        // vis-viva for this orbit gives velocities in the 4–10 km/s range.
+        assert!(
+            (3.0..12.0).contains(&v),
+            "satellite speed at epoch out of range: {v:.3} km/s",
+        );
+    }
+
+    #[test]
+    fn satellite_propagate_an_hour_later_moves() {
+        let sat = Satellite::from_tle(TEST_TLE_NAME, TEST_TLE_LINE1, TEST_TLE_LINE2).unwrap();
+        let s0 = sat.propagate(sat.epoch()).unwrap();
+        let s1 = sat
+            .propagate(sat.epoch() + chrono::Duration::hours(1))
+            .unwrap();
+        // 1 hour into the orbit (~half a revolution at this period) the
+        // satellite must have moved a long way from where it started.
+        let dx = s1.position_km[0] - s0.position_km[0];
+        let dy = s1.position_km[1] - s0.position_km[1];
+        let dz = s1.position_km[2] - s0.position_km[2];
+        let displacement = (dx * dx + dy * dy + dz * dz).sqrt();
+        assert!(
+            displacement > 1_000.0,
+            "expected > 1000 km displacement in 1 h, got {displacement:.1} km",
+        );
+    }
+
+    #[test]
+    fn gmst_at_j2000_matches_known_value() {
+        // GMST at J2000 (2000-01-01 12:00:00 UTC) is 18h 41m 50.5s
+        // sidereal time, which is 280.46° ≈ 4.8949612... rad.
+        let j2000 = Utc.with_ymd_and_hms(2000, 1, 1, 12, 0, 0).unwrap();
+        let g = gmst_rad(j2000);
+        let expected = 4.894_961_212_735_793;
+        assert!(
+            (g - expected).abs() < 1e-3,
+            "GMST(J2000) expected ≈ {expected:.6}, got {g:.6}",
+        );
+    }
+
+    #[test]
+    fn gmst_advances_by_one_sidereal_day_per_24h() {
+        let t0 = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let t1 = t0 + chrono::Duration::hours(24);
+        let g0 = gmst_rad(t0);
+        let g1 = gmst_rad(t1);
+        // After 24 solar hours, sidereal time advances by 24h × (366.25/365.25)
+        // ≈ 24h 03m 56s — i.e. ~0.0172 rad past a full revolution.
+        let mut diff = g1 - g0;
+        diff = diff.rem_euclid(std::f64::consts::TAU);
+        // Expected sidereal advance modulo 2π is ≈ 0.01721 rad.
+        assert!(
+            (0.015..0.020).contains(&diff),
+            "24h sidereal advance expected ≈ 0.0172 rad, got {diff:.5}",
+        );
+    }
+
+    #[test]
+    fn geodetic_to_ecef_at_equator_prime_meridian() {
+        // (0°, 0°, 0 m) should land at (a, 0, 0).
+        let p = geodetic_to_ecef(0.0, 0.0, 0.0);
+        assert!((p[0] - EARTH_RADIUS_KM).abs() < 1e-6);
+        assert!(p[1].abs() < 1e-6);
+        assert!(p[2].abs() < 1e-6);
+    }
+
+    #[test]
+    fn geodetic_to_ecef_at_north_pole() {
+        // North pole at sea level: x=y=0, z = polar radius
+        // = a * (1 - f) ≈ 6356.752 km.
+        let p = geodetic_to_ecef(90.0, 0.0, 0.0);
+        let polar_radius = EARTH_RADIUS_KM * (1.0 - EARTH_FLATTENING);
+        assert!(p[0].abs() < 1e-6);
+        assert!(p[1].abs() < 1e-6);
+        assert!(
+            (p[2] - polar_radius).abs() < 1e-3,
+            "polar z expected {polar_radius:.6}, got {:.6}",
+            p[2],
+        );
+    }
+
+    #[test]
+    fn ecef_to_enu_zenith_at_station() {
+        // A point straight up from the station should have ENU
+        // = (0, 0, +up). On an oblate ellipsoid, "up" is the surface
+        // *normal* — not the geocentric radial — so we have to displace
+        // along the geodetic-up unit vector, not along station_ecef.
+        let lat: f64 = 40.0;
+        let lon: f64 = -75.0;
+        let lat_rad = lat.to_radians();
+        let lon_rad = lon.to_radians();
+        let up_unit = [
+            lat_rad.cos() * lon_rad.cos(),
+            lat_rad.cos() * lon_rad.sin(),
+            lat_rad.sin(),
+        ];
+        let relative = [100.0 * up_unit[0], 100.0 * up_unit[1], 100.0 * up_unit[2]];
+        let enu = ecef_to_enu(relative, lat, lon);
+        // East and North components should be tiny, Up ≈ 100 km.
+        assert!(enu[0].abs() < 1e-9, "east bias: {}", enu[0]);
+        assert!(enu[1].abs() < 1e-9, "north bias: {}", enu[1]);
+        assert!(
+            (enu[2] - 100.0).abs() < 1e-9,
+            "up expected 100 km, got {}",
+            enu[2],
+        );
+    }
+}

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -16,7 +16,14 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration as StdDuration, SystemTime};
+
+/// Process-wide monotonic counter for unique tempfile names. Combined
+/// with the process pid below it gives every concurrent write its own
+/// path, so even two threads of the same process can't trample each
+/// other's in-flight cache replacement.
+static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(0);
 
 /// Default cache freshness window. TLEs from Celestrak are updated
 /// every few hours but propagation accuracy stays well within SGP4's
@@ -192,10 +199,22 @@ impl TleCache {
         let stale = is_stale(&path, self.refresh_max_age);
 
         if stale {
-            // Try a refresh. If it succeeds, write to disk and return
-            // the new text; if it fails but a stale cache exists, use
-            // that; otherwise propagate the fetch error.
-            match self.fetch(source) {
+            // Try a refresh. If it succeeds AND the body actually
+            // looks like a TLE file, write to disk and return the new
+            // text. If it fails (or returns something that ISN'T a
+            // TLE — captive portal, HTML 5xx page, proxy error), fall
+            // back to whatever stale copy the cache has.
+            let fetch_result = self.fetch(source).and_then(|text| {
+                if has_any_tle_pair(&text) {
+                    Ok(text)
+                } else {
+                    Err(TleCacheError::Fetch(
+                        "response body did not contain any valid TLE pair (captive portal? HTML error page?)"
+                            .to_string(),
+                    ))
+                }
+            });
+            match fetch_result {
                 Ok(text) => {
                     // Best-effort cache write — a failed write
                     // (read-only fs, disk full, permissions) shouldn't
@@ -296,12 +315,14 @@ impl TleCache {
                 source: e,
             })?;
         }
-        // Per-process tempfile so two concurrent processes hitting the
-        // same cache dir don't trample each other's in-flight write.
-        // Two threads in the same process are still racy on the tmp
-        // file, but our once-a-day refresh cadence makes that
-        // essentially impossible to hit in practice.
-        let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+        // Per-call tempfile name: pid + a process-wide atomic counter.
+        // pid disambiguates between concurrent processes hitting the
+        // same cache dir, the counter disambiguates between concurrent
+        // threads of the same process. Either way, every in-flight
+        // write owns its own tempfile path, so no thread can rename
+        // a half-written file out from under another.
+        let tmp_id = NEXT_TMP_ID.fetch_add(1, Ordering::Relaxed);
+        let tmp = path.with_extension(format!("tmp.{}.{tmp_id}", std::process::id()));
         std::fs::write(&tmp, text).map_err(|e| TleCacheError::Io {
             path: tmp.clone(),
             source: e,
@@ -401,6 +422,44 @@ pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
         i += 1;
     }
     None
+}
+
+/// Does `text` contain at least one structurally-consistent TLE pair?
+/// Used as a sanity check on fetched bodies before they replace the
+/// cache: a captive portal, proxy error page, or HTML maintenance
+/// response from upstream would otherwise poison the on-disk cache
+/// and break the offline fallback.
+///
+/// "Structurally consistent" means: a `1 NNNNN ...` line followed
+/// (with any number of intervening blank lines stripped) by a
+/// `2 NNNNN ...` line where both lines parse a NORAD id and the ids
+/// match. Doesn't validate checksums or any orbital fields — those
+/// would catch more, but the cheap structural check is enough to
+/// reject HTML responses (no `1 ` prefix at the right offset).
+#[must_use]
+#[allow(clippy::similar_names)] // line1/line2 names match TLE-spec terminology
+pub fn has_any_tle_pair(text: &str) -> bool {
+    let lines: Vec<&str> = text
+        .lines()
+        .map(str::trim_end)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    let mut i = 0_usize;
+    while i + 1 < lines.len() {
+        let line1 = lines[i];
+        let line2 = lines[i + 1];
+        if line1.starts_with("1 ")
+            && line2.starts_with("2 ")
+            && let (Some(id1), Some(id2)) =
+                (norad_id_from_tle_line(line1), norad_id_from_tle_line(line2))
+            && id1 == id2
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
 }
 
 /// 0-indexed start of the NORAD catalog number field in TLE line 1
@@ -631,6 +690,39 @@ SOMETHING
     }
 
     #[test]
+    fn has_any_tle_pair_accepts_real_tle_text() {
+        assert!(has_any_tle_pair(SAMPLE_TLE_3LINE));
+        assert!(has_any_tle_pair(SAMPLE_TLE_2LINE));
+    }
+
+    #[test]
+    fn has_any_tle_pair_rejects_html_error_pages() {
+        // What a captive portal / proxy 5xx looks like in practice.
+        let html = "\
+<html><head><title>503 Service Unavailable</title></head>
+<body><h1>Service Unavailable</h1>
+<p>The server is temporarily unable to service your request.</p>
+</body></html>
+";
+        assert!(!has_any_tle_pair(html));
+    }
+
+    #[test]
+    fn has_any_tle_pair_rejects_truncated_or_garbage_text() {
+        assert!(!has_any_tle_pair(""));
+        assert!(!has_any_tle_pair("just some random non-TLE text\n"));
+        // Has a `1 NNNNN` line but no matching `2 NNNNN` line — half a
+        // pair only, must not pass.
+        assert!(!has_any_tle_pair(
+            "1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753\n"
+        ));
+        // Mismatched-id pair — line1 NORAD 5, line2 NORAD 25544.
+        assert!(!has_any_tle_pair(
+            "1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753\n2 25544  51.6442 211.4001 0001234  92.7501 270.5089 15.49538275234276\n"
+        ));
+    }
+
+    #[test]
     fn write_cache_atomic_rename_lands_file_at_final_path() {
         // Sanity test for the atomic-rename path: write some text,
         // verify the final cache file exists and contains exactly the
@@ -644,15 +736,17 @@ SOMETHING
         let contents = std::fs::read_to_string(&path).unwrap();
         assert_eq!(contents, "hello cache");
         // No leftover tempfiles in the cache directory.
+        // Tempfiles look like `noaa.tmp.12345.0` — `Path::extension()`
+        // returns the *last* segment (`"0"`), not `"tmp"`, so we have
+        // to scan the filename string for the `.tmp.` infix instead.
         let leftover_tmp_count = std::fs::read_dir(&dir)
             .unwrap()
             .filter_map(Result::ok)
             .filter(|entry| {
                 entry
-                    .path()
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .is_some_and(|ext| ext.starts_with("tmp"))
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.contains(".tmp."))
             })
             .count();
         assert_eq!(leftover_tmp_count, 0);

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -1,0 +1,470 @@
+//! Celestrak TLE fetch + on-disk cache.
+//!
+//! Pulls satellite TLE files from
+//! `https://celestrak.org/NORAD/elements/{slug}.txt` and stores them
+//! under `~/.cache/sdr-rs/tle/`. Daily refresh: callers ask for a TLE
+//! by NORAD id, the cache returns it from disk if the file is fresher
+//! than [`DEFAULT_REFRESH_MAX_AGE`] (24 hours); otherwise it tries to
+//! re-download. If re-download fails (offline, Celestrak down, etc.)
+//! it falls back to whatever stale copy the cache already has so the
+//! UI degrades gracefully rather than going dark.
+//!
+//! The HTTP fetch is **blocking** by design — the rest of the
+//! workspace is blocking-only, and TLE fetches are once-a-day so the
+//! caller is expected to invoke this from a worker thread (the
+//! scheduler UI's "refresh TLEs" button, for example).
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration as StdDuration, SystemTime};
+
+/// Default cache freshness window. TLEs from Celestrak are updated
+/// every few hours but propagation accuracy stays well within SGP4's
+/// km-level error budget for at least a few days. 24 hours strikes a
+/// reasonable balance between hit rate and bandwidth.
+pub const DEFAULT_REFRESH_MAX_AGE: StdDuration = StdDuration::from_hours(24);
+
+/// Default fetch timeout for blocking reqwest calls — long enough that
+/// a sluggish network won't fail spuriously, short enough that the UI
+/// thread doesn't lock up if Celestrak is hung.
+pub const DEFAULT_FETCH_TIMEOUT: StdDuration = StdDuration::from_secs(15);
+
+/// Which Celestrak source file a TLE belongs to. Each maps directly to
+/// a `https://celestrak.org/NORAD/elements/{slug}.txt` URL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TleSource {
+    /// `noaa.txt` — NOAA POES satellites (15/18/19) for APT.
+    Noaa,
+    /// `weather.txt` — Meteor-M and other weather sats for LRPT.
+    Weather,
+    /// `stations.txt` — ISS and crewed-vehicle TLEs for SSTV.
+    Stations,
+}
+
+impl TleSource {
+    /// Celestrak filename slug — the bit between `/elements/` and `.txt`.
+    #[must_use]
+    pub const fn slug(self) -> &'static str {
+        match self {
+            Self::Noaa => "noaa",
+            Self::Weather => "weather",
+            Self::Stations => "stations",
+        }
+    }
+
+    /// Full Celestrak URL for the file backing this source.
+    #[must_use]
+    pub fn url(self) -> String {
+        format!("https://celestrak.org/NORAD/elements/{}.txt", self.slug())
+    }
+}
+
+/// Errors from cache lookup or HTTP fetch.
+#[derive(Debug, thiserror::Error)]
+pub enum TleCacheError {
+    /// `dirs_next::cache_dir` returned `None` — the platform doesn't
+    /// expose a user cache dir (rare on Linux/macOS, possible in
+    /// minimal sandbox environments).
+    #[error("no cache directory available on this platform")]
+    NoCacheDir,
+    /// Celestrak returned a non-2xx status, the request timed out, or
+    /// reqwest itself failed to send.
+    #[error("TLE fetch failed: {0}")]
+    Fetch(String),
+    /// Local I/O error reading or writing the cache file.
+    #[error("cache I/O error at {path:?}: {source}")]
+    Io {
+        /// Path that triggered the error.
+        path: PathBuf,
+        /// Underlying I/O error. (`source` field name is intentional
+        /// here — `std::io::Error` does implement `Error`, so
+        /// thiserror's `Error::source()` shim works as expected.)
+        #[source]
+        source: std::io::Error,
+    },
+    /// Looked up a NORAD id that wasn't present in the source's text.
+    /// Usually means the satellite was decommissioned and dropped from
+    /// the upstream file.
+    #[error("NORAD id {norad_id} not found in {tle_source:?} TLE source")]
+    NotFound {
+        /// NORAD id requested.
+        norad_id: u32,
+        /// Source the lookup ran against. Renamed from `source` because
+        /// thiserror auto-treats a field literally called `source` as
+        /// an `Error::source()` shim and demands the type implement
+        /// `std::error::Error`.
+        tle_source: TleSource,
+    },
+}
+
+/// Filesystem-backed cache of Celestrak TLE files.
+pub struct TleCache {
+    cache_dir: PathBuf,
+    refresh_max_age: StdDuration,
+    fetch_timeout: StdDuration,
+}
+
+impl TleCache {
+    /// Create a cache rooted at the platform's standard user-cache
+    /// directory (`~/.cache/sdr-rs/tle/` on Linux).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TleCacheError::NoCacheDir`] if the platform doesn't
+    /// expose a cache dir.
+    pub fn new() -> Result<Self, TleCacheError> {
+        let base = dirs_next::cache_dir().ok_or(TleCacheError::NoCacheDir)?;
+        Ok(Self::with_dir(base.join("sdr-rs").join("tle")))
+    }
+
+    /// Create a cache rooted at an arbitrary directory. Useful for
+    /// tests or for users who want to share a cache between
+    /// installations.
+    #[must_use]
+    pub fn with_dir(cache_dir: PathBuf) -> Self {
+        Self {
+            cache_dir,
+            refresh_max_age: DEFAULT_REFRESH_MAX_AGE,
+            fetch_timeout: DEFAULT_FETCH_TIMEOUT,
+        }
+    }
+
+    /// Override the cache freshness window. Values shorter than ~1 hour
+    /// will hammer Celestrak unnecessarily; longer than ~7 days will
+    /// degrade SGP4 accuracy as TLEs get stale.
+    #[must_use]
+    pub const fn with_refresh_max_age(mut self, max_age: StdDuration) -> Self {
+        self.refresh_max_age = max_age;
+        self
+    }
+
+    /// Override the per-fetch HTTP timeout.
+    #[must_use]
+    pub const fn with_fetch_timeout(mut self, timeout: StdDuration) -> Self {
+        self.fetch_timeout = timeout;
+        self
+    }
+
+    /// Path on disk where this source's TLE file is cached.
+    #[must_use]
+    pub fn cache_path(&self, source: TleSource) -> PathBuf {
+        self.cache_dir.join(format!("{}.txt", source.slug()))
+    }
+
+    /// Look up the TLE pair for `norad_id` in the given source,
+    /// refreshing the cache file from Celestrak if it's stale.
+    ///
+    /// On a fetch failure with a stale-but-present cache, returns the
+    /// cached entry — the user gets *something* rather than a blank
+    /// scheduler. On no-cache + no-network, returns the fetch error.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces [`TleCacheError`] for network, I/O, or lookup failures.
+    pub fn tle_for(
+        &self,
+        norad_id: u32,
+        source: TleSource,
+    ) -> Result<(String, String), TleCacheError> {
+        let text = self.tle_text(source)?;
+        parse_tle_text(&text, norad_id).ok_or(TleCacheError::NotFound {
+            norad_id,
+            tle_source: source,
+        })
+    }
+
+    /// Get the raw TLE-file text for a source, refreshing on disk if
+    /// the cached copy is stale (or missing).
+    ///
+    /// # Errors
+    ///
+    /// See [`TleCache::tle_for`].
+    pub fn tle_text(&self, source: TleSource) -> Result<String, TleCacheError> {
+        let path = self.cache_path(source);
+        let stale = is_stale(&path, self.refresh_max_age);
+
+        if stale {
+            // Try a refresh. If it succeeds, write to disk and return
+            // the new text; if it fails but a stale cache exists, use
+            // that; otherwise propagate the fetch error.
+            match self.fetch(source) {
+                Ok(text) => {
+                    self.write_cache(&path, &text)?;
+                    return Ok(text);
+                }
+                Err(fetch_err) => {
+                    if let Some(cached) = read_file(&path)? {
+                        tracing::warn!(
+                            "TLE fetch for {:?} failed ({fetch_err}); using stale cache",
+                            source,
+                        );
+                        return Ok(cached);
+                    }
+                    return Err(fetch_err);
+                }
+            }
+        }
+
+        // Cache is fresh — read from disk.
+        read_file(&path)?.ok_or_else(|| TleCacheError::Io {
+            path,
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "fresh cache file disappeared between mtime check and read",
+            ),
+        })
+    }
+
+    /// Blocking HTTP fetch of one source file.
+    fn fetch(&self, source: TleSource) -> Result<String, TleCacheError> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(self.fetch_timeout)
+            .user_agent(concat!("sdr-rs/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .map_err(|e| TleCacheError::Fetch(format!("client build: {e}")))?;
+        let url = source.url();
+        let response = client
+            .get(&url)
+            .send()
+            .map_err(|e| TleCacheError::Fetch(format!("GET {url}: {e}")))?;
+        let response = response
+            .error_for_status()
+            .map_err(|e| TleCacheError::Fetch(format!("HTTP status: {e}")))?;
+        response
+            .text()
+            .map_err(|e| TleCacheError::Fetch(format!("response body: {e}")))
+    }
+
+    #[allow(clippy::unused_self)] // kept on impl for symmetry with other cache methods
+    fn write_cache(&self, path: &Path, text: &str) -> Result<(), TleCacheError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| TleCacheError::Io {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+        std::fs::write(path, text).map_err(|e| TleCacheError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        })
+    }
+}
+
+fn read_file(path: &Path) -> Result<Option<String>, TleCacheError> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Ok(Some(text)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(TleCacheError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        }),
+    }
+}
+
+fn is_stale(path: &Path, max_age: StdDuration) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return true; // missing = stale
+    };
+    let Ok(modified) = meta.modified() else {
+        return true; // can't read mtime → assume stale
+    };
+    SystemTime::now()
+        .duration_since(modified)
+        .map_or(true, |age| age > max_age)
+}
+
+/// Find the `(line1, line2)` TLE pair for `norad_id` in a Celestrak
+/// formatted text file. Accepts both 2-line entries (TLE-only) and
+/// 3-line entries (name + TLE), as Celestrak emits the 3-line variant
+/// for the named-satellite endpoints we use.
+#[must_use]
+pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
+    let mut iter = text
+        .lines()
+        .map(str::trim_end)
+        .filter(|l| !l.is_empty())
+        .peekable();
+
+    while iter.peek().is_some() {
+        // A TLE entry is either:
+        //   3 lines: NAME / "1 ..." / "2 ..."
+        //   2 lines: "1 ..." / "2 ..."
+        let first = iter.next()?;
+        let (line1, line2) = if first.starts_with("1 ") {
+            (first.to_string(), iter.next()?.to_string())
+        } else {
+            // First was a name; next two are the TLE.
+            let l1 = iter.next()?;
+            let l2 = iter.next()?;
+            (l1.to_string(), l2.to_string())
+        };
+        if let Some(parsed) = norad_id_from_line1(&line1)
+            && parsed == norad_id
+        {
+            return Some((line1, line2));
+        }
+    }
+    None
+}
+
+/// Extract the NORAD catalog number from columns 3..=7 of a TLE
+/// line 1 (`"1 NNNNNX ..."`). Returns `None` for malformed lines —
+/// the caller skips and keeps scanning.
+fn norad_id_from_line1(line: &str) -> Option<u32> {
+    if line.len() < 7 {
+        return None;
+    }
+    line[2..7].trim().parse::<u32>().ok()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// Three real TLE entries (Vanguard 1, ISS, NOAA 19) with valid
+    /// checksums, in 3-line Celestrak format, ready to be parsed.
+    const SAMPLE_TLE_3LINE: &str = "\
+VANGUARD 1
+1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753
+2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667
+ISS (ZARYA)
+1 25544U 98067A   20194.88670927  .00002728  00000-0  61021-4 0  9994
+2 25544  51.6442 211.4001 0001234  92.7501 270.5089 15.49538275234276
+NOAA 19
+1 33591U 09005A   24001.50000000  .00000050  00000-0  50000-4 0  9994
+2 33591  99.0000 100.0000 0010000  90.0000 270.0000 14.10000000123456
+";
+
+    /// Same three TLEs but in 2-line format (no name line) — Celestrak
+    /// also serves this variant from some endpoints. Parser must
+    /// handle both.
+    const SAMPLE_TLE_2LINE: &str = "\
+1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753
+2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667
+1 25544U 98067A   20194.88670927  .00002728  00000-0  61021-4 0  9994
+2 25544  51.6442 211.4001 0001234  92.7501 270.5089 15.49538275234276
+";
+
+    #[test]
+    fn slug_for_each_source_matches_celestrak_filename() {
+        assert_eq!(TleSource::Noaa.slug(), "noaa");
+        assert_eq!(TleSource::Weather.slug(), "weather");
+        assert_eq!(TleSource::Stations.slug(), "stations");
+    }
+
+    #[test]
+    fn url_points_to_celestrak_https() {
+        let url = TleSource::Noaa.url();
+        assert!(url.starts_with("https://celestrak.org/NORAD/elements/"));
+        assert!(url.ends_with("noaa.txt"));
+    }
+
+    #[test]
+    fn parse_three_line_format_finds_each_satellite() {
+        let (l1, l2) = parse_tle_text(SAMPLE_TLE_3LINE, 5).unwrap();
+        assert!(l1.starts_with("1 00005"));
+        assert!(l2.starts_with("2 00005"));
+
+        let (l1, _) = parse_tle_text(SAMPLE_TLE_3LINE, 25_544).unwrap();
+        assert!(l1.starts_with("1 25544"));
+
+        let (l1, _) = parse_tle_text(SAMPLE_TLE_3LINE, 33_591).unwrap();
+        assert!(l1.starts_with("1 33591"));
+    }
+
+    #[test]
+    fn parse_two_line_format_also_works() {
+        let (l1, _) = parse_tle_text(SAMPLE_TLE_2LINE, 5).unwrap();
+        assert!(l1.starts_with("1 00005"));
+        let (l1, _) = parse_tle_text(SAMPLE_TLE_2LINE, 25_544).unwrap();
+        assert!(l1.starts_with("1 25544"));
+    }
+
+    #[test]
+    fn parse_returns_none_for_unknown_norad_id() {
+        assert!(parse_tle_text(SAMPLE_TLE_3LINE, 99_999).is_none());
+        // Empty input.
+        assert!(parse_tle_text("", 5).is_none());
+        // Garbage.
+        assert!(parse_tle_text("not a tle file at all", 5).is_none());
+    }
+
+    #[test]
+    fn parse_handles_blank_lines_and_crlf() {
+        let with_noise = concat!(
+            "\n",
+            "\n",
+            "VANGUARD 1\r\n",
+            "1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753\r\n",
+            "2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667\r\n",
+            "\n",
+        );
+        let (l1, _) = parse_tle_text(with_noise, 5).unwrap();
+        assert!(l1.starts_with("1 00005"));
+    }
+
+    #[test]
+    fn cache_returns_text_when_file_is_fresh() {
+        let dir = unique_temp_dir("fresh");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("noaa.txt");
+        std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
+        let cache = TleCache::with_dir(dir.clone());
+        let text = cache.tle_text(TleSource::Noaa).unwrap();
+        assert!(text.contains("VANGUARD 1"));
+    }
+
+    #[test]
+    fn cache_returns_tle_pair_when_file_is_fresh() {
+        let dir = unique_temp_dir("pair");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("noaa.txt");
+        std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
+        let cache = TleCache::with_dir(dir);
+        let (l1, l2) = cache.tle_for(5, TleSource::Noaa).unwrap();
+        assert!(l1.starts_with("1 00005"));
+        assert!(l2.starts_with("2 00005"));
+    }
+
+    #[test]
+    fn cache_returns_not_found_when_norad_id_missing_from_fresh_file() {
+        let dir = unique_temp_dir("missing-id");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("noaa.txt");
+        std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
+        let cache = TleCache::with_dir(dir);
+        let err = cache.tle_for(99_999, TleSource::Noaa).unwrap_err();
+        assert!(matches!(
+            err,
+            TleCacheError::NotFound {
+                norad_id: 99_999,
+                tle_source: TleSource::Noaa,
+            }
+        ));
+    }
+
+    #[test]
+    fn is_stale_returns_true_for_missing_file() {
+        let dir = unique_temp_dir("missing-mtime");
+        let path = dir.join("does-not-exist.txt");
+        assert!(is_stale(&path, DEFAULT_REFRESH_MAX_AGE));
+    }
+
+    #[test]
+    fn is_stale_returns_false_for_fresh_file() {
+        let dir = unique_temp_dir("fresh-mtime");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("a.txt");
+        std::fs::write(&path, "hi").unwrap();
+        assert!(!is_stale(&path, DEFAULT_REFRESH_MAX_AGE));
+    }
+
+    /// Per-test scratch dir under the system temp prefix. Avoids
+    /// pulling in `tempfile` for one-off unit tests.
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        std::env::temp_dir().join(format!("sdr-sat-test-{tag}-{nanos}"))
+    }
+}

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -196,59 +196,56 @@ impl TleCache {
     /// See [`TleCache::tle_for`].
     pub fn tle_text(&self, source: TleSource) -> Result<String, TleCacheError> {
         let path = self.cache_path(source);
-        let stale = is_stale(&path, self.refresh_max_age);
 
-        if stale {
-            // Try a refresh. If it succeeds AND the body actually
-            // looks like a TLE file, write to disk and return the new
-            // text. If it fails (or returns something that ISN'T a
-            // TLE — captive portal, HTML 5xx page, proxy error), fall
-            // back to whatever stale copy the cache has.
-            let fetch_result = self.fetch(source).and_then(|text| {
-                if has_any_tle_pair(&text) {
-                    Ok(text)
-                } else {
-                    Err(TleCacheError::Fetch(
-                        "response body did not contain any valid TLE pair (captive portal? HTML error page?)"
-                            .to_string(),
-                    ))
-                }
-            });
-            match fetch_result {
-                Ok(text) => {
-                    // Best-effort cache write — a failed write
-                    // (read-only fs, disk full, permissions) shouldn't
-                    // throw away network-fresh TLE data. Log and move
-                    // on; the next call will just refetch.
-                    if let Err(e) = self.write_cache(&path, &text) {
-                        tracing::warn!(
-                            "TLE cache write for {:?} failed ({e}); returning fresh in-memory copy",
-                            source,
-                        );
-                    }
-                    return Ok(text);
-                }
-                Err(fetch_err) => {
-                    if let Some(cached) = read_file(&path)? {
-                        tracing::warn!(
-                            "TLE fetch for {:?} failed ({fetch_err}); using stale cache",
-                            source,
-                        );
-                        return Ok(cached);
-                    }
-                    return Err(fetch_err);
-                }
-            }
+        // Fast path: cache file is fresh AND still readable. If a TOCTOU
+        // race steals the file between the mtime check and the read
+        // (concurrent process, cache cleaner like tmpfiles.d, manual
+        // `rm`), fall through to the refetch path rather than turning
+        // a survivable transient into a hard error.
+        if !is_stale(&path, self.refresh_max_age)
+            && let Some(cached) = read_file(&path)?
+        {
+            return Ok(cached);
         }
 
-        // Cache is fresh — read from disk.
-        read_file(&path)?.ok_or_else(|| TleCacheError::Io {
-            path,
-            source: std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "fresh cache file disappeared between mtime check and read",
-            ),
-        })
+        // Slow path: fetch from upstream, validate, write to disk.
+        // If the fetch (or validation) fails, fall back to whatever
+        // stale copy still happens to exist. If even that's gone,
+        // surface the original fetch error.
+        let fetch_result = self.fetch(source).and_then(|text| {
+            if has_any_tle_pair(&text) {
+                Ok(text)
+            } else {
+                Err(TleCacheError::Fetch(
+                    "response body did not contain any valid TLE pair (captive portal? HTML error page?)"
+                        .to_string(),
+                ))
+            }
+        });
+        match fetch_result {
+            Ok(text) => {
+                // Best-effort cache write — a failed write (read-only
+                // fs, disk full, permissions) shouldn't throw away
+                // network-fresh TLE data. Log and move on.
+                if let Err(e) = self.write_cache(&path, &text) {
+                    tracing::warn!(
+                        "TLE cache write for {:?} failed ({e}); returning fresh in-memory copy",
+                        source,
+                    );
+                }
+                Ok(text)
+            }
+            Err(fetch_err) => {
+                if let Some(cached) = read_file(&path)? {
+                    tracing::warn!(
+                        "TLE fetch for {:?} failed ({fetch_err}); using stale cache",
+                        source,
+                    );
+                    return Ok(cached);
+                }
+                Err(fetch_err)
+            }
+        }
     }
 
     /// Blocking HTTP fetch of one source file. Reuses the cached
@@ -377,7 +374,7 @@ fn is_stale(path: &Path, max_age: StdDuration) -> bool {
 /// implementation was vulnerable to that case).
 #[must_use]
 #[allow(clippy::similar_names)] // line1/line2 names match TLE-spec terminology
-pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
+pub(crate) fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
     let lines = tle_lines(text);
     let last = lines.len().saturating_sub(1);
     for i in 0..last {
@@ -401,7 +398,7 @@ pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
 /// check is enough to reject HTML responses (no `1 ` prefix at the
 /// right offset, no NORAD id at the right column, mismatched ids).
 #[must_use]
-pub fn has_any_tle_pair(text: &str) -> bool {
+pub(crate) fn has_any_tle_pair(text: &str) -> bool {
     let lines = tle_lines(text);
     let last = lines.len().saturating_sub(1);
     (0..last).any(|i| pair_matches(lines[i], lines[i + 1], None))
@@ -471,7 +468,7 @@ fn norad_id_from_tle_line(line: &str) -> Option<u32> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
 
@@ -634,6 +631,49 @@ SOMETHING
         );
         let (l1, _) = parse_tle_text(with_noise, 5).unwrap();
         assert!(l1.starts_with("1 00005"));
+    }
+
+    #[test]
+    fn cache_falls_through_to_fetch_when_fresh_file_disappears() {
+        // TOCTOU window: cache file passes the mtime freshness check,
+        // then gets deleted (concurrent process, cache cleaner,
+        // manual rm) before the read. tle_text() must NOT raise a
+        // hard `Io(NotFound)` — it must fall through to the refetch
+        // path so the race becomes a recoverable network condition,
+        // not a file-not-found bug.
+        //
+        // Acceptable outcomes:
+        //   * Ok(text) — refetch reached upstream and won (CI has
+        //     network, etc.). Contract still satisfied.
+        //   * Err(Fetch(_)) — refetch couldn't reach upstream and
+        //     there's no stale to fall back on (we just deleted it).
+        //     Expected on offline runners.
+        // Forbidden outcome:
+        //   * Err(Io(_)) — means the disappeared file became a hard
+        //     error instead of falling through to fetch. That's the
+        //     bug this test exists to catch.
+        //
+        // Aggressive fetch timeout (100 ms) so the offline path
+        // doesn't slow tests down — networked CI runners take longer
+        // than that to round-trip celestrak.org so they'll usually
+        // hit the Fetch-err branch too, but either branch is fine.
+        let dir = unique_temp_dir("toctou");
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache =
+            TleCache::with_dir(dir.clone()).with_fetch_timeout(StdDuration::from_millis(100));
+        let path = cache.cache_path(TleSource::Noaa);
+        std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
+        // Sanity: fresh-cache fast path works as expected.
+        assert!(cache.tle_text(TleSource::Noaa).is_ok());
+        // Race: delete the file before the next call.
+        std::fs::remove_file(&path).unwrap();
+        match cache.tle_text(TleSource::Noaa) {
+            Ok(_) | Err(TleCacheError::Fetch(_)) => {} // both acceptable
+            Err(other @ TleCacheError::Io { .. }) => {
+                panic!("TOCTOU race should fall through to fetch, got Io error: {other:?}")
+            }
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -197,7 +197,16 @@ impl TleCache {
             // that; otherwise propagate the fetch error.
             match self.fetch(source) {
                 Ok(text) => {
-                    self.write_cache(&path, &text)?;
+                    // Best-effort cache write — a failed write
+                    // (read-only fs, disk full, permissions) shouldn't
+                    // throw away network-fresh TLE data. Log and move
+                    // on; the next call will just refetch.
+                    if let Err(e) = self.write_cache(&path, &text) {
+                        tracing::warn!(
+                            "TLE cache write for {:?} failed ({e}); returning fresh in-memory copy",
+                            source,
+                        );
+                    }
                     return Ok(text);
                 }
                 Err(fetch_err) => {
@@ -314,41 +323,53 @@ fn is_stale(path: &Path, max_age: StdDuration) -> bool {
 /// formatted text file. Accepts both 2-line entries (TLE-only) and
 /// 3-line entries (name + TLE), as Celestrak emits the 3-line variant
 /// for the named-satellite endpoints we use.
+///
+/// Uses a sliding-window scan rather than a "consume in groups of 3"
+/// loop so that a malformed entry can't accidentally swallow the next
+/// satellite's `1 ...` line as its `line2` and lose that satellite.
+/// Each window position checks "is this a valid TLE pair?" and slides
+/// by exactly one line otherwise — worst-case `O(n)` and resyncs
+/// cleanly across any cache corruption.
 #[must_use]
+#[allow(clippy::similar_names)] // line1/line2 names match TLE-spec terminology
 pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
-    let mut iter = text
+    let lines: Vec<&str> = text
         .lines()
         .map(str::trim_end)
         .filter(|l| !l.is_empty())
-        .peekable();
+        .collect();
 
-    while iter.peek().is_some() {
-        // A TLE entry is either:
-        //   3 lines: NAME / "1 ..." / "2 ..."
-        //   2 lines: "1 ..." / "2 ..."
-        let first = iter.next()?;
-        let (line1, line2) = if first.starts_with("1 ") {
-            (first.to_string(), iter.next()?.to_string())
+    let mut i = 0_usize;
+    while i < lines.len() {
+        // At each window position, decide where line1/line2 would be:
+        //   * starts with "1 "  → 2-line entry: (lines[i], lines[i+1])
+        //   * otherwise (name)  → 3-line entry: (lines[i+1], lines[i+2])
+        let (line1, line2) = if lines[i].starts_with("1 ") {
+            match lines.get(i + 1) {
+                Some(l2) => (lines[i], *l2),
+                None => break,
+            }
         } else {
-            // First was a name; next two are the TLE.
-            let l1 = iter.next()?;
-            let l2 = iter.next()?;
-            (l1.to_string(), l2.to_string())
+            match (lines.get(i + 1), lines.get(i + 2)) {
+                (Some(l1), Some(l2)) => (*l1, *l2),
+                _ => break,
+            }
         };
-        // Validate the TLE shape before checking the NORAD id —
-        // garbage input (truncated download, HTML error page in the
-        // cache) can produce a "line1" that looks like one but a
-        // "line2" that's actually the next satellite's name. Skip and
-        // resync on the next iteration rather than handing a bogus
-        // pair to SGP4.
-        if !line1.starts_with("1 ") || !line2.starts_with("2 ") {
-            continue;
-        }
-        if let Some(parsed) = norad_id_from_line1(&line1)
+
+        if line1.starts_with("1 ")
+            && line2.starts_with("2 ")
+            && let Some(parsed) = norad_id_from_line1(line1)
             && parsed == norad_id
         {
-            return Some((line1, line2));
+            return Some((line1.to_string(), line2.to_string()));
         }
+
+        // Slide by exactly one line. Even if this window saw a
+        // malformed pair that ate "the next entry's line 1" as its
+        // line2, the next window starts at lines[i+1] which is that
+        // very line 1 — so we re-evaluate it as a fresh entry start
+        // rather than skipping it.
+        i += 1;
     }
     None
 }
@@ -483,6 +504,28 @@ NEXT NAME LINE NOT A TLE
         // The resync test: after skipping the bad pair, the parser
         // must still find the well-formed entry that follows.
         let (l1, l2) = parse_tle_text(bad_pair_then_good, 5).unwrap();
+        assert!(l1.starts_with("1 00005"));
+        assert!(l2.starts_with("2 00005"));
+    }
+
+    #[test]
+    fn parse_resyncs_when_malformed_entry_swallows_next_line1() {
+        // Adversarial corruption: a "name" line followed by *two*
+        // valid line-1s back to back, then a valid line 2 for the
+        // second of them. The first entry is malformed (`1 11111…`
+        // pretends to be a line 1 but its partner is the *next*
+        // satellite's line 1 instead of a "2 ..." line). The
+        // sliding-window parser must NOT lose the good `(1 00005…,
+        // 2 00005…)` pair, even though my earlier consume-in-3s
+        // implementation would have eaten line 1 of NORAD 5 as
+        // line 2 of NORAD 11111 and then run off the end.
+        let bad_swallows_next = "\
+SOMETHING
+1 11111U 99001A   24000.00000000  .00000000  00000-0  10000-3 0  9990
+1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753
+2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667
+";
+        let (l1, l2) = parse_tle_text(bad_swallows_next, 5).unwrap();
         assert!(l1.starts_with("1 00005"));
         assert!(l2.starts_with("2 00005"));
     }

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -335,6 +335,15 @@ pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
             let l2 = iter.next()?;
             (l1.to_string(), l2.to_string())
         };
+        // Validate the TLE shape before checking the NORAD id —
+        // garbage input (truncated download, HTML error page in the
+        // cache) can produce a "line1" that looks like one but a
+        // "line2" that's actually the next satellite's name. Skip and
+        // resync on the next iteration rather than handing a bogus
+        // pair to SGP4.
+        if !line1.starts_with("1 ") || !line2.starts_with("2 ") {
+            continue;
+        }
         if let Some(parsed) = norad_id_from_line1(&line1)
             && parsed == norad_id
         {
@@ -349,20 +358,19 @@ pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
 const TLE_NORAD_START: usize = 2;
 /// 0-indexed exclusive end of the NORAD field (column 7 inclusive).
 const TLE_NORAD_END: usize = 7;
-/// Minimum length a TLE line 1 must have for the NORAD field to fit.
-const TLE_LINE1_MIN_LEN: usize = TLE_NORAD_END;
 
 /// Extract the NORAD catalog number from columns 3..=7 of a TLE
 /// line 1 (`"1 NNNNNX ..."`). Returns `None` for malformed lines —
 /// the caller skips and keeps scanning.
+///
+/// Uses `str::get` rather than direct slicing so a corrupted cache
+/// file with multi-byte UTF-8 at the parsed byte offsets returns
+/// `None` instead of panicking. (Real Celestrak content is ASCII;
+/// a stray non-ASCII byte usually means the response was an HTML
+/// error page that landed in the cache by accident.)
 fn norad_id_from_line1(line: &str) -> Option<u32> {
-    if line.len() < TLE_LINE1_MIN_LEN {
-        return None;
-    }
-    line[TLE_NORAD_START..TLE_NORAD_END]
-        .trim()
-        .parse::<u32>()
-        .ok()
+    let field = line.get(TLE_NORAD_START..TLE_NORAD_END)?;
+    field.trim().parse::<u32>().ok()
 }
 
 #[cfg(test)]
@@ -436,6 +444,47 @@ NOAA 19
         assert!(parse_tle_text("", 5).is_none());
         // Garbage.
         assert!(parse_tle_text("not a tle file at all", 5).is_none());
+    }
+
+    #[test]
+    fn parse_does_not_panic_on_multibyte_utf8_in_norad_field() {
+        // A 6-byte string whose first 7 *bytes* happen to span a
+        // 3-byte UTF-8 char boundary at byte 2 — direct slicing would
+        // panic; `str::get` returns None and the parser keeps walking.
+        let weird = "1 \u{1F4A9}99U garbage";
+        // norad_id_from_line1 must not panic, must not classify.
+        assert_eq!(norad_id_from_line1(weird), None);
+        // Whole-document parse with the bad line buried inside also
+        // must not panic and must skip it cleanly.
+        let mixed = format!(
+            "{weird}\n2 00099 ignore\nVANGUARD 1\n1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753\n2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667\n",
+        );
+        let (l1, _) = parse_tle_text(&mixed, 5).unwrap();
+        assert!(l1.starts_with("1 00005"));
+    }
+
+    #[test]
+    fn parse_skips_pair_when_line2_is_not_a_real_tle_line() {
+        // line2 doesn't start with "2 " — a corrupted file or a name
+        // that accidentally landed where a TLE pair was expected.
+        // Parser must skip and keep scanning rather than emit a bogus
+        // (line1, garbage_line2) pair that would misfire downstream.
+        let bad_pair_then_good = "\
+NAME ONE
+1 11111U 99001A   24000.00000000  .00000000  00000-0  10000-3 0  9990
+NEXT NAME LINE NOT A TLE
+1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753
+2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667
+";
+        // Asking for NORAD 11111 (the misformatted entry) must NOT
+        // succeed even though its line1 is valid — the partner line
+        // isn't a TLE line.
+        assert!(parse_tle_text(bad_pair_then_good, 11_111).is_none());
+        // The resync test: after skipping the bad pair, the parser
+        // must still find the well-formed entry that follows.
+        let (l1, l2) = parse_tle_text(bad_pair_then_good, 5).unwrap();
+        assert!(l1.starts_with("1 00005"));
+        assert!(l2.starts_with("2 00005"));
     }
 
     #[test]

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -104,6 +104,13 @@ pub enum TleCacheError {
     },
 }
 
+/// Custom fetcher used by [`TleCache::with_fetcher`]. Receives the
+/// requested source and returns the raw TLE text or a fetch-style
+/// error. Useful for unit tests that need hermetic refetch-path
+/// behaviour, and for users who want to plug in a non-reqwest HTTP
+/// stack (proxy-aware client, custom auth, etc.).
+pub type Fetcher = dyn Fn(TleSource) -> Result<String, TleCacheError> + Send + Sync;
+
 /// Filesystem-backed cache of Celestrak TLE files.
 pub struct TleCache {
     cache_dir: PathBuf,
@@ -116,6 +123,12 @@ pub struct TleCache {
     /// caller, free improvement if a future flow asks for several
     /// sources in a row.
     client: OnceLock<reqwest::blocking::Client>,
+    /// Optional fetcher override. When `Some`, [`TleCache::fetch`]
+    /// short-circuits to this closure instead of building / using the
+    /// reqwest client. Tests use this to make the refetch-path
+    /// regression tests hermetic — no live HTTP, no DNS, no flakiness
+    /// from celestrak.org being slow on a particular CI run.
+    fetcher: Option<Box<Fetcher>>,
 }
 
 impl TleCache {
@@ -141,7 +154,32 @@ impl TleCache {
             refresh_max_age: DEFAULT_REFRESH_MAX_AGE,
             fetch_timeout: DEFAULT_FETCH_TIMEOUT,
             client: OnceLock::new(),
+            fetcher: None,
         }
+    }
+
+    /// Override the network fetcher with a custom closure. Production
+    /// callers normally don't need this — the default reqwest-based
+    /// fetcher Just Works against celestrak.org. Two real uses:
+    ///
+    /// * **Tests** that exercise the refetch path can inject a canned
+    ///   response so the unit suite stays hermetic (no live HTTP,
+    ///   no DNS, no flaky CI from upstream slowness).
+    /// * **Custom HTTP stacks** — a corporate proxy that needs auth,
+    ///   a SOCKS tunnel, etc. Build the request through whatever
+    ///   client is appropriate and hand the body string back.
+    ///
+    /// The closure is called once per refetch attempt; its return
+    /// value goes through the same `has_any_tle_pair` validation as
+    /// the default fetcher, so a closure that returns garbage still
+    /// gets rejected before poisoning the cache.
+    #[must_use]
+    pub fn with_fetcher<F>(mut self, fetcher: F) -> Self
+    where
+        F: Fn(TleSource) -> Result<String, TleCacheError> + Send + Sync + 'static,
+    {
+        self.fetcher = Some(Box::new(fetcher));
+        self
     }
 
     /// Override the cache freshness window. Values shorter than ~1 hour
@@ -262,7 +300,13 @@ impl TleCache {
 
     /// Blocking HTTP fetch of one source file. Reuses the cached
     /// reqwest client across calls for connection + TLS-session pooling.
+    /// If [`TleCache::with_fetcher`] supplied an override, that closure
+    /// runs instead — letting tests stay hermetic and users plug in
+    /// custom HTTP stacks.
     fn fetch(&self, source: TleSource) -> Result<String, TleCacheError> {
+        if let Some(override_fetcher) = &self.fetcher {
+            return override_fetcher(source);
+        }
         let client = self.client()?;
         let url = source.url();
         let response = client
@@ -660,6 +704,13 @@ SOMETHING
         assert!(l1.starts_with("1 00005"));
     }
 
+    /// Canned fetcher for hermetic refetch-path tests: always returns
+    /// a `Fetch` error so we exercise the "fetch failed, fall back to
+    /// stale" branch without touching the network.
+    fn always_fail_fetcher() -> impl Fn(TleSource) -> Result<String, TleCacheError> + Send + Sync {
+        |_| Err(TleCacheError::Fetch("test: fetcher disabled".to_string()))
+    }
+
     #[test]
     fn cache_does_not_trust_html_blob_in_fresh_cache_file() {
         // Pre-validation-gate versions (or a manual
@@ -669,26 +720,21 @@ SOMETHING
         // serves garbage until the file ages out and `tle_for`
         // returns a misleading `NotFound`. The cache must validate
         // the content and treat invalid bodies as a miss → refetch.
-        //
-        // Acceptable outcomes (same logic as the TOCTOU test):
-        //   * Ok(text) — refetch succeeded (online runner)
-        //   * Err(Fetch(_)) — refetch failed, no valid stale to fall
-        //     back on. Either is fine — what matters is we did NOT
-        //     return the HTML blob.
+        // With a canned-fail fetcher, the only valid outcome is
+        // `Fetch(_)` — the test would have proved nothing if it
+        // accepted whatever the live network happened to return.
         let dir = unique_temp_dir("html-blob");
         std::fs::create_dir_all(&dir).unwrap();
-        let cache =
-            TleCache::with_dir(dir.clone()).with_fetch_timeout(StdDuration::from_millis(100));
+        let cache = TleCache::with_dir(dir.clone()).with_fetcher(always_fail_fetcher());
         let path = cache.cache_path(TleSource::Noaa);
         let html = "<html><head><title>503</title></head><body>oops</body></html>\n";
         std::fs::write(&path, html).unwrap();
 
         match cache.tle_text(TleSource::Noaa) {
-            Ok(text) => assert!(
-                !text.contains("<html>"),
-                "cache returned the HTML blob verbatim — corruption was trusted",
-            ),
             Err(TleCacheError::Fetch(_)) => {}
+            Ok(text) => {
+                panic!("cache returned the HTML blob verbatim — corruption was trusted: {text:?}")
+            }
             Err(other) => panic!("unexpected error variant: {other:?}"),
         }
     }
@@ -699,23 +745,22 @@ SOMETHING
         // gzip decompression got skipped, or some other tool wrote
         // bytes there) shows up to `read_to_string` as
         // `ErrorKind::InvalidData`. Should self-heal as a miss, NOT
-        // surface as a hard `Io` error, so the next call refetches
-        // cleanly.
+        // surface as a hard `Io` error.
         let dir = unique_temp_dir("non-utf8");
         std::fs::create_dir_all(&dir).unwrap();
-        let cache =
-            TleCache::with_dir(dir.clone()).with_fetch_timeout(StdDuration::from_millis(100));
+        let cache = TleCache::with_dir(dir.clone()).with_fetcher(always_fail_fetcher());
         let path = cache.cache_path(TleSource::Noaa);
-        // 0x80 0x81 0x82 etc. are invalid as UTF-8 lead bytes.
+        // 0xFF 0xFE 0x80 0x81 0x82 are invalid as UTF-8 lead bytes.
         std::fs::write(&path, [0xFF_u8, 0xFE, 0x80, 0x81, 0x82]).unwrap();
 
         match cache.tle_text(TleSource::Noaa) {
-            Ok(_) | Err(TleCacheError::Fetch(_)) => {}
+            Err(TleCacheError::Fetch(_)) => {}
             Err(TleCacheError::Io { ref source, .. })
                 if source.kind() == std::io::ErrorKind::InvalidData =>
             {
                 panic!("non-UTF-8 cache file should self-heal as a miss, not surface as Io error")
             }
+            Ok(text) => panic!("unexpected Ok with binary cache: {text:?}"),
             Err(other) => panic!("unexpected error variant: {other:?}"),
         }
     }
@@ -727,40 +772,38 @@ SOMETHING
         // manual rm) before the read. tle_text() must NOT raise a
         // hard `Io(NotFound)` — it must fall through to the refetch
         // path so the race becomes a recoverable network condition,
-        // not a file-not-found bug.
-        //
-        // Acceptable outcomes:
-        //   * Ok(text) — refetch reached upstream and won (CI has
-        //     network, etc.). Contract still satisfied.
-        //   * Err(Fetch(_)) — refetch couldn't reach upstream and
-        //     there's no stale to fall back on (we just deleted it).
-        //     Expected on offline runners.
-        // Forbidden outcome:
-        //   * Err(Io(_)) — means the disappeared file became a hard
-        //     error instead of falling through to fetch. That's the
-        //     bug this test exists to catch.
-        //
-        // Aggressive fetch timeout (100 ms) so the offline path
-        // doesn't slow tests down — networked CI runners take longer
-        // than that to round-trip celestrak.org so they'll usually
-        // hit the Fetch-err branch too, but either branch is fine.
+        // not a file-not-found bug. Canned-fail fetcher pins the
+        // expected outcome to `Fetch(_)` exactly.
         let dir = unique_temp_dir("toctou");
         std::fs::create_dir_all(&dir).unwrap();
-        let cache =
-            TleCache::with_dir(dir.clone()).with_fetch_timeout(StdDuration::from_millis(100));
+        let cache = TleCache::with_dir(dir.clone()).with_fetcher(always_fail_fetcher());
         let path = cache.cache_path(TleSource::Noaa);
         std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
-        // Sanity: fresh-cache fast path works as expected.
+        // Sanity: fresh-cache fast path works (doesn't go through fetch).
         assert!(cache.tle_text(TleSource::Noaa).is_ok());
         // Race: delete the file before the next call.
         std::fs::remove_file(&path).unwrap();
         match cache.tle_text(TleSource::Noaa) {
-            Ok(_) | Err(TleCacheError::Fetch(_)) => {} // both acceptable
+            Err(TleCacheError::Fetch(_)) => {} // expected: fell through to (failing) fetch
             Err(other @ TleCacheError::Io { .. }) => {
                 panic!("TOCTOU race should fall through to fetch, got Io error: {other:?}")
             }
+            Ok(text) => panic!("unexpected Ok with deleted cache + failing fetcher: {text:?}"),
             Err(other) => panic!("unexpected error variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn cache_uses_injected_fetcher_when_set() {
+        // Round-trip the fetcher injection itself: a stale cache
+        // path with a canned-OK fetcher should return the canned
+        // text, NOT make a network call.
+        let dir = unique_temp_dir("inject");
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache = TleCache::with_dir(dir).with_fetcher(|_| Ok(SAMPLE_TLE_3LINE.to_string()));
+        // No file present → goes through the fetch path.
+        let text = cache.tle_text(TleSource::Noaa).unwrap();
+        assert!(text.contains("VANGUARD 1"));
     }
 
     #[test]

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -197,21 +197,31 @@ impl TleCache {
     pub fn tle_text(&self, source: TleSource) -> Result<String, TleCacheError> {
         let path = self.cache_path(source);
 
-        // Fast path: cache file is fresh AND still readable. If a TOCTOU
-        // race steals the file between the mtime check and the read
-        // (concurrent process, cache cleaner like tmpfiles.d, manual
-        // `rm`), fall through to the refetch path rather than turning
-        // a survivable transient into a hard error.
+        // Fast path: cache file is fresh, readable, AND structurally
+        // a TLE file. Mtime + read alone aren't enough — older builds
+        // or a manual `echo > cache.txt` could have left HTML or
+        // garbage at this path, and we'd otherwise keep serving it
+        // until the file ages out (and `tle_for` would surface a
+        // misleading `NotFound` even when upstream is healthy). If a
+        // TOCTOU race steals the file between mtime check and read,
+        // or the cached content fails validation, fall through to
+        // the refetch path so the cache self-heals.
         if !is_stale(&path, self.refresh_max_age)
             && let Some(cached) = read_file(&path)?
         {
-            return Ok(cached);
+            if has_any_tle_pair(&cached) {
+                return Ok(cached);
+            }
+            tracing::warn!(
+                "ignoring corrupted fresh TLE cache for {:?}; refetching",
+                source,
+            );
         }
 
         // Slow path: fetch from upstream, validate, write to disk.
         // If the fetch (or validation) fails, fall back to whatever
-        // stale copy still happens to exist. If even that's gone,
-        // surface the original fetch error.
+        // stale copy still happens to exist *and validates*. If even
+        // that's gone or corrupted, surface the original fetch error.
         let fetch_result = self.fetch(source).and_then(|text| {
             if has_any_tle_pair(&text) {
                 Ok(text)
@@ -236,7 +246,9 @@ impl TleCache {
                 Ok(text)
             }
             Err(fetch_err) => {
-                if let Some(cached) = read_file(&path)? {
+                if let Some(cached) = read_file(&path)?
+                    && has_any_tle_pair(&cached)
+                {
                     tracing::warn!(
                         "TLE fetch for {:?} failed ({fetch_err}); using stale cache",
                         source,
@@ -336,10 +348,25 @@ impl TleCache {
     }
 }
 
+/// Read a UTF-8 file or return `None` for "not present-ish".
+///
+/// `NotFound` and `InvalidData` (non-UTF-8 contents — e.g. a corrupt
+/// or binary cache file from another tool) are both treated as a
+/// cache miss. `tle_text` falls through to the refetch path on miss,
+/// so the cache self-heals immediately on the next successful fetch
+/// rather than blocking the user until the mtime ages the bad file
+/// out. Other I/O errors (permissions, mid-read failures) propagate.
 fn read_file(path: &Path) -> Result<Option<String>, TleCacheError> {
     match std::fs::read_to_string(path) {
         Ok(text) => Ok(Some(text)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::InvalidData
+            ) =>
+        {
+            Ok(None)
+        }
         Err(e) => Err(TleCacheError::Io {
             path: path.to_path_buf(),
             source: e,
@@ -631,6 +658,66 @@ SOMETHING
         );
         let (l1, _) = parse_tle_text(with_noise, 5).unwrap();
         assert!(l1.starts_with("1 00005"));
+    }
+
+    #[test]
+    fn cache_does_not_trust_html_blob_in_fresh_cache_file() {
+        // Pre-validation-gate versions (or a manual
+        // `echo $whatever > cache.txt`) could have left HTML or
+        // arbitrary text in the cache path. Mtime says it's fresh,
+        // read says it's UTF-8 — but if we trust it, every call
+        // serves garbage until the file ages out and `tle_for`
+        // returns a misleading `NotFound`. The cache must validate
+        // the content and treat invalid bodies as a miss → refetch.
+        //
+        // Acceptable outcomes (same logic as the TOCTOU test):
+        //   * Ok(text) — refetch succeeded (online runner)
+        //   * Err(Fetch(_)) — refetch failed, no valid stale to fall
+        //     back on. Either is fine — what matters is we did NOT
+        //     return the HTML blob.
+        let dir = unique_temp_dir("html-blob");
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache =
+            TleCache::with_dir(dir.clone()).with_fetch_timeout(StdDuration::from_millis(100));
+        let path = cache.cache_path(TleSource::Noaa);
+        let html = "<html><head><title>503</title></head><body>oops</body></html>\n";
+        std::fs::write(&path, html).unwrap();
+
+        match cache.tle_text(TleSource::Noaa) {
+            Ok(text) => assert!(
+                !text.contains("<html>"),
+                "cache returned the HTML blob verbatim — corruption was trusted",
+            ),
+            Err(TleCacheError::Fetch(_)) => {}
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cache_treats_non_utf8_cache_file_as_a_miss() {
+        // A binary blob in the cache (say, a partial download where
+        // gzip decompression got skipped, or some other tool wrote
+        // bytes there) shows up to `read_to_string` as
+        // `ErrorKind::InvalidData`. Should self-heal as a miss, NOT
+        // surface as a hard `Io` error, so the next call refetches
+        // cleanly.
+        let dir = unique_temp_dir("non-utf8");
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache =
+            TleCache::with_dir(dir.clone()).with_fetch_timeout(StdDuration::from_millis(100));
+        let path = cache.cache_path(TleSource::Noaa);
+        // 0x80 0x81 0x82 etc. are invalid as UTF-8 lead bytes.
+        std::fs::write(&path, [0xFF_u8, 0xFE, 0x80, 0x81, 0x82]).unwrap();
+
+        match cache.tle_text(TleSource::Noaa) {
+            Ok(_) | Err(TleCacheError::Fetch(_)) => {}
+            Err(TleCacheError::Io { ref source, .. })
+                if source.kind() == std::io::ErrorKind::InvalidData =>
+            {
+                panic!("non-UTF-8 cache file should self-heal as a miss, not surface as Io error")
+            }
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -367,59 +367,24 @@ fn is_stale(path: &Path, max_age: StdDuration) -> bool {
 /// 3-line entries (name + TLE), as Celestrak emits the 3-line variant
 /// for the named-satellite endpoints we use.
 ///
-/// Uses a sliding-window scan rather than a "consume in groups of 3"
-/// loop so that a malformed entry can't accidentally swallow the next
-/// satellite's `1 ...` line as its `line2` and lose that satellite.
-/// Each window position checks "is this a valid TLE pair?" and slides
-/// by exactly one line otherwise — worst-case `O(n)` and resyncs
-/// cleanly across any cache corruption.
+/// Uses a sliding-window scan over consecutive non-empty line pairs.
+/// 3-line entries are handled implicitly: when the window sits on a
+/// name + `1 …` pair, [`pair_matches`] rejects it (line 1 doesn't
+/// start with `"1 "`); next iteration the window sits on `1 …` /
+/// `2 …`, which matches. Worst-case `O(n)` and resyncs cleanly across
+/// any cache corruption — even an entry whose "line 2" is actually
+/// the next satellite's "line 1" (the previous consume-in-3s
+/// implementation was vulnerable to that case).
 #[must_use]
 #[allow(clippy::similar_names)] // line1/line2 names match TLE-spec terminology
 pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
-    let lines: Vec<&str> = text
-        .lines()
-        .map(str::trim_end)
-        .filter(|l| !l.is_empty())
-        .collect();
-
-    let mut i = 0_usize;
-    while i < lines.len() {
-        // At each window position, decide where line1/line2 would be:
-        //   * starts with "1 "  → 2-line entry: (lines[i], lines[i+1])
-        //   * otherwise (name)  → 3-line entry: (lines[i+1], lines[i+2])
-        let (line1, line2) = if lines[i].starts_with("1 ") {
-            match lines.get(i + 1) {
-                Some(l2) => (lines[i], *l2),
-                None => break,
-            }
-        } else {
-            match (lines.get(i + 1), lines.get(i + 2)) {
-                (Some(l1), Some(l2)) => (*l1, *l2),
-                _ => break,
-            }
-        };
-
-        // Cross-check: both TLE lines have the NORAD catalog number at
-        // the same column, and a sane file always pairs them. A
-        // corrupted cache could splice line 1 of one satellite with
-        // line 2 of another (both look "valid" individually) — refuse
-        // to return such a Frankenstein pair.
-        if line1.starts_with("1 ")
-            && line2.starts_with("2 ")
-            && let (Some(line1_id), Some(line2_id)) =
-                (norad_id_from_tle_line(line1), norad_id_from_tle_line(line2))
-            && line1_id == norad_id
-            && line2_id == norad_id
-        {
+    let lines = tle_lines(text);
+    let last = lines.len().saturating_sub(1);
+    for i in 0..last {
+        let (line1, line2) = (lines[i], lines[i + 1]);
+        if pair_matches(line1, line2, Some(norad_id)) {
             return Some((line1.to_string(), line2.to_string()));
         }
-
-        // Slide by exactly one line. Even if this window saw a
-        // malformed pair that ate "the next entry's line 1" as its
-        // line2, the next window starts at lines[i+1] which is that
-        // very line 1 — so we re-evaluate it as a fresh entry start
-        // rather than skipping it.
-        i += 1;
     }
     None
 }
@@ -430,36 +395,58 @@ pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
 /// response from upstream would otherwise poison the on-disk cache
 /// and break the offline fallback.
 ///
-/// "Structurally consistent" means: a `1 NNNNN ...` line followed
-/// (with any number of intervening blank lines stripped) by a
-/// `2 NNNNN ...` line where both lines parse a NORAD id and the ids
-/// match. Doesn't validate checksums or any orbital fields — those
-/// would catch more, but the cheap structural check is enough to
-/// reject HTML responses (no `1 ` prefix at the right offset).
+/// "Structurally consistent" means [`pair_matches`] accepts at least
+/// one pair of consecutive non-empty lines without an id constraint.
+/// Doesn't validate checksums or orbital fields — the cheap structural
+/// check is enough to reject HTML responses (no `1 ` prefix at the
+/// right offset, no NORAD id at the right column, mismatched ids).
 #[must_use]
-#[allow(clippy::similar_names)] // line1/line2 names match TLE-spec terminology
 pub fn has_any_tle_pair(text: &str) -> bool {
-    let lines: Vec<&str> = text
-        .lines()
+    let lines = tle_lines(text);
+    let last = lines.len().saturating_sub(1);
+    (0..last).any(|i| pair_matches(lines[i], lines[i + 1], None))
+}
+
+/// Collect the non-empty, right-trimmed lines of `text` into a `Vec`.
+/// Shared between [`parse_tle_text`] and [`has_any_tle_pair`] so the
+/// preprocessing stays identical (CRLF tolerance, blank-line skipping)
+/// no matter which entry point the caller used.
+fn tle_lines(text: &str) -> Vec<&str> {
+    text.lines()
         .map(str::trim_end)
         .filter(|l| !l.is_empty())
-        .collect();
+        .collect()
+}
 
-    let mut i = 0_usize;
-    while i + 1 < lines.len() {
-        let line1 = lines[i];
-        let line2 = lines[i + 1];
-        if line1.starts_with("1 ")
-            && line2.starts_with("2 ")
-            && let (Some(id1), Some(id2)) =
-                (norad_id_from_tle_line(line1), norad_id_from_tle_line(line2))
-            && id1 == id2
-        {
-            return true;
-        }
-        i += 1;
+/// Is `(line1, line2)` a structurally-valid TLE pair, optionally
+/// matching `expected` NORAD id?
+///
+/// Required for any "yes":
+///
+/// * `line1` starts with `"1 "` (canonical TLE line-1 prefix);
+/// * `line2` starts with `"2 "`;
+/// * both lines parse a NORAD id from the catalog field
+///   (columns 3..=7);
+/// * the two ids agree — a corrupted cache could splice line 1 of
+///   sat A with line 2 of sat B and they'd pass the prefix checks
+///   individually; the cross-check catches the Frankenstein case;
+/// * if `expected` is `Some(id)`, the parsed id equals `id`.
+#[allow(clippy::similar_names)] // line1/line2 names match TLE-spec terminology
+fn pair_matches(line1: &str, line2: &str, expected: Option<u32>) -> bool {
+    if !line1.starts_with("1 ") || !line2.starts_with("2 ") {
+        return false;
     }
-    false
+    let (Some(id1), Some(id2)) = (norad_id_from_tle_line(line1), norad_id_from_tle_line(line2))
+    else {
+        return false;
+    };
+    if id1 != id2 {
+        return false;
+    }
+    match expected {
+        Some(target) => id1 == target,
+        None => true,
+    }
 }
 
 /// 0-indexed start of the NORAD catalog number field in TLE line 1

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -15,6 +15,7 @@
 //! scheduler UI's "refresh TLEs" button, for example).
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{Duration as StdDuration, SystemTime};
 
 /// Default cache freshness window. TLEs from Celestrak are updated
@@ -101,6 +102,13 @@ pub struct TleCache {
     cache_dir: PathBuf,
     refresh_max_age: StdDuration,
     fetch_timeout: StdDuration,
+    /// HTTP client built lazily on first fetch so builder methods like
+    /// [`TleCache::with_fetch_timeout`] still get a chance to apply
+    /// before we lock in the configuration. Reused across fetches for
+    /// connection / TLS-session pooling — small win for a once-a-day
+    /// caller, free improvement if a future flow asks for several
+    /// sources in a row.
+    client: OnceLock<reqwest::blocking::Client>,
 }
 
 impl TleCache {
@@ -125,6 +133,7 @@ impl TleCache {
             cache_dir,
             refresh_max_age: DEFAULT_REFRESH_MAX_AGE,
             fetch_timeout: DEFAULT_FETCH_TIMEOUT,
+            client: OnceLock::new(),
         }
     }
 
@@ -214,13 +223,10 @@ impl TleCache {
         })
     }
 
-    /// Blocking HTTP fetch of one source file.
+    /// Blocking HTTP fetch of one source file. Reuses the cached
+    /// reqwest client across calls for connection + TLS-session pooling.
     fn fetch(&self, source: TleSource) -> Result<String, TleCacheError> {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(self.fetch_timeout)
-            .user_agent(concat!("sdr-rs/", env!("CARGO_PKG_VERSION")))
-            .build()
-            .map_err(|e| TleCacheError::Fetch(format!("client build: {e}")))?;
+        let client = self.client()?;
         let url = source.url();
         let response = client
             .get(&url)
@@ -232,6 +238,29 @@ impl TleCache {
         response
             .text()
             .map_err(|e| TleCacheError::Fetch(format!("response body: {e}")))
+    }
+
+    /// Get-or-build the cached HTTP client. First call builds it from
+    /// the current `fetch_timeout`; subsequent calls reuse the same
+    /// instance. Builder methods that change the timeout *after* the
+    /// first fetch don't take effect — by design, since reqwest's
+    /// timeout is baked into the client at build time.
+    fn client(&self) -> Result<&reqwest::blocking::Client, TleCacheError> {
+        if let Some(c) = self.client.get() {
+            return Ok(c);
+        }
+        let new_client = reqwest::blocking::Client::builder()
+            .timeout(self.fetch_timeout)
+            .user_agent(concat!("sdr-rs/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .map_err(|e| TleCacheError::Fetch(format!("client build: {e}")))?;
+        // If another thread won the race we just drop our local copy;
+        // either way, `get` after `set` returns the canonical client.
+        let _ = self.client.set(new_client);
+        Ok(self
+            .client
+            .get()
+            .expect("client::set succeeded or another thread won the race"))
     }
 
     #[allow(clippy::unused_self)] // kept on impl for symmetry with other cache methods

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -927,10 +927,20 @@ SOMETHING
 
     /// Per-test scratch dir under the system temp prefix. Avoids
     /// pulling in `tempfile` for one-off unit tests.
+    /// Process-wide test-only counter so two parallel tests with the
+    /// same `tag` can't land on the same scratch path. `SystemTime`
+    /// alone isn't enough — `cargo test` defaults to running tests
+    /// concurrently within a single process, and on coarse-resolution
+    /// clocks (e.g. CI runners with a 1 ms tick) two threads can read
+    /// the same `nanos` value.
+    static NEXT_TEST_TMP_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
     fn unique_temp_dir(tag: &str) -> PathBuf {
         let nanos = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .map_or(0, |d| d.as_nanos());
-        std::env::temp_dir().join(format!("sdr-sat-test-{tag}-{nanos}"))
+        let counter = NEXT_TEST_TMP_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let pid = std::process::id();
+        std::env::temp_dir().join(format!("sdr-sat-test-{tag}-{pid}-{nanos}-{counter}"))
     }
 }

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -242,25 +242,34 @@ impl TleCache {
 
     /// Get-or-build the cached HTTP client. First call builds it from
     /// the current `fetch_timeout`; subsequent calls reuse the same
-    /// instance. Builder methods that change the timeout *after* the
-    /// first fetch don't take effect — by design, since reqwest's
-    /// timeout is baked into the client at build time.
-    fn client(&self) -> Result<&reqwest::blocking::Client, TleCacheError> {
+    /// underlying connection pool (`reqwest::blocking::Client` is
+    /// internally `Arc`-counted, so clones are cheap atomic
+    /// increments — no realloc, no new TLS sessions). Builder methods
+    /// that change the timeout *after* the first fetch don't take
+    /// effect, since reqwest bakes the timeout into the client at
+    /// build time.
+    ///
+    /// `OnceLock::get_or_try_init` would be the idiomatic single-call
+    /// version of this dance, but that's still nightly as of Rust
+    /// 1.95 (`once_cell_try`). Until it stabilises, the manual
+    /// get-or-build-and-clone pattern below avoids both the panic
+    /// path of `.expect` and the dep on the external `once_cell`
+    /// crate.
+    fn client(&self) -> Result<reqwest::blocking::Client, TleCacheError> {
         if let Some(c) = self.client.get() {
-            return Ok(c);
+            return Ok(c.clone());
         }
         let new_client = reqwest::blocking::Client::builder()
             .timeout(self.fetch_timeout)
             .user_agent(concat!("sdr-rs/", env!("CARGO_PKG_VERSION")))
             .build()
             .map_err(|e| TleCacheError::Fetch(format!("client build: {e}")))?;
-        // If another thread won the race we just drop our local copy;
-        // either way, `get` after `set` returns the canonical client.
-        let _ = self.client.set(new_client);
-        Ok(self
-            .client
-            .get()
-            .expect("client::set succeeded or another thread won the race"))
+        // Race-free publish: if another thread won, their client is
+        // canonical and ours gets dropped. Either way `get` should
+        // return Some afterwards; if for some impossible reason it
+        // doesn't, fall back to our local copy rather than panicking.
+        let _ = self.client.set(new_client.clone());
+        Ok(self.client.get().cloned().unwrap_or(new_client))
     }
 
     #[allow(clippy::unused_self)] // kept on impl for symmetry with other cache methods
@@ -335,14 +344,25 @@ pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
     None
 }
 
+/// 0-indexed start of the NORAD catalog number field in TLE line 1
+/// (column 3 in 1-indexed TLE-spec terms).
+const TLE_NORAD_START: usize = 2;
+/// 0-indexed exclusive end of the NORAD field (column 7 inclusive).
+const TLE_NORAD_END: usize = 7;
+/// Minimum length a TLE line 1 must have for the NORAD field to fit.
+const TLE_LINE1_MIN_LEN: usize = TLE_NORAD_END;
+
 /// Extract the NORAD catalog number from columns 3..=7 of a TLE
 /// line 1 (`"1 NNNNNX ..."`). Returns `None` for malformed lines —
 /// the caller skips and keeps scanning.
 fn norad_id_from_line1(line: &str) -> Option<u32> {
-    if line.len() < 7 {
+    if line.len() < TLE_LINE1_MIN_LEN {
         return None;
     }
-    line[2..7].trim().parse::<u32>().ok()
+    line[TLE_NORAD_START..TLE_NORAD_END]
+        .trim()
+        .parse::<u32>()
+        .ok()
 }
 
 #[cfg(test)]

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -281,6 +281,13 @@ impl TleCache {
         Ok(self.client.get().cloned().unwrap_or(new_client))
     }
 
+    /// Write `text` to `path` atomically via the standard
+    /// "write-to-tempfile-then-rename" dance. A power loss / SIGKILL /
+    /// OOM-kill mid-write leaves either the previous stale cache
+    /// intact (rename never happened) or the new fresh content
+    /// (rename succeeded), never a truncated file. Same-directory
+    /// tempfile so the rename stays on the same filesystem and the
+    /// kernel's `rename(2)` atomicity guarantee applies.
     #[allow(clippy::unused_self)] // kept on impl for symmetry with other cache methods
     fn write_cache(&self, path: &Path, text: &str) -> Result<(), TleCacheError> {
         if let Some(parent) = path.parent() {
@@ -289,9 +296,24 @@ impl TleCache {
                 source: e,
             })?;
         }
-        std::fs::write(path, text).map_err(|e| TleCacheError::Io {
-            path: path.to_path_buf(),
+        // Per-process tempfile so two concurrent processes hitting the
+        // same cache dir don't trample each other's in-flight write.
+        // Two threads in the same process are still racy on the tmp
+        // file, but our once-a-day refresh cadence makes that
+        // essentially impossible to hit in practice.
+        let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+        std::fs::write(&tmp, text).map_err(|e| TleCacheError::Io {
+            path: tmp.clone(),
             source: e,
+        })?;
+        std::fs::rename(&tmp, path).map_err(|e| {
+            // Best-effort cleanup of the orphaned tempfile so we don't
+            // leak it on every failed rename.
+            let _ = std::fs::remove_file(&tmp);
+            TleCacheError::Io {
+                path: path.to_path_buf(),
+                source: e,
+            }
         })
     }
 }
@@ -356,10 +378,17 @@ pub fn parse_tle_text(text: &str, norad_id: u32) -> Option<(String, String)> {
             }
         };
 
+        // Cross-check: both TLE lines have the NORAD catalog number at
+        // the same column, and a sane file always pairs them. A
+        // corrupted cache could splice line 1 of one satellite with
+        // line 2 of another (both look "valid" individually) — refuse
+        // to return such a Frankenstein pair.
         if line1.starts_with("1 ")
             && line2.starts_with("2 ")
-            && let Some(parsed) = norad_id_from_line1(line1)
-            && parsed == norad_id
+            && let (Some(line1_id), Some(line2_id)) =
+                (norad_id_from_tle_line(line1), norad_id_from_tle_line(line2))
+            && line1_id == norad_id
+            && line2_id == norad_id
         {
             return Some((line1.to_string(), line2.to_string()));
         }
@@ -380,16 +409,17 @@ const TLE_NORAD_START: usize = 2;
 /// 0-indexed exclusive end of the NORAD field (column 7 inclusive).
 const TLE_NORAD_END: usize = 7;
 
-/// Extract the NORAD catalog number from columns 3..=7 of a TLE
-/// line 1 (`"1 NNNNNX ..."`). Returns `None` for malformed lines —
-/// the caller skips and keeps scanning.
+/// Extract the NORAD catalog number from columns 3..=7 of a TLE line.
+/// Works on both line 1 (`"1 NNNNNX ..."`) and line 2 (`"2 NNNNN ..."`)
+/// — the catalog field sits at the same byte offsets in both. Returns
+/// `None` for malformed lines — the caller skips and keeps scanning.
 ///
 /// Uses `str::get` rather than direct slicing so a corrupted cache
 /// file with multi-byte UTF-8 at the parsed byte offsets returns
 /// `None` instead of panicking. (Real Celestrak content is ASCII;
 /// a stray non-ASCII byte usually means the response was an HTML
 /// error page that landed in the cache by accident.)
-fn norad_id_from_line1(line: &str) -> Option<u32> {
+fn norad_id_from_tle_line(line: &str) -> Option<u32> {
     let field = line.get(TLE_NORAD_START..TLE_NORAD_END)?;
     field.trim().parse::<u32>().ok()
 }
@@ -473,8 +503,8 @@ NOAA 19
         // 3-byte UTF-8 char boundary at byte 2 — direct slicing would
         // panic; `str::get` returns None and the parser keeps walking.
         let weird = "1 \u{1F4A9}99U garbage";
-        // norad_id_from_line1 must not panic, must not classify.
-        assert_eq!(norad_id_from_line1(weird), None);
+        // norad_id_from_tle_line must not panic, must not classify.
+        assert_eq!(norad_id_from_tle_line(weird), None);
         // Whole-document parse with the bad line buried inside also
         // must not panic and must skip it cleanly.
         let mixed = format!(
@@ -506,6 +536,22 @@ NEXT NAME LINE NOT A TLE
         let (l1, l2) = parse_tle_text(bad_pair_then_good, 5).unwrap();
         assert!(l1.starts_with("1 00005"));
         assert!(l2.starts_with("2 00005"));
+    }
+
+    #[test]
+    fn parse_rejects_pair_with_mismatched_norad_ids() {
+        // line1 of NORAD 5 spliced with line2 from a different
+        // satellite (NORAD 25544). Both lines individually look like
+        // valid TLE format, but the NORAD ids disagree — the parser
+        // must reject rather than hand back a Frankenstein pair that
+        // would propagate as garbage in SGP4.
+        let mismatched_pair = "\
+VANGUARD 1
+1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753
+2 25544  51.6442 211.4001 0001234  92.7501 270.5089 15.49538275234276
+";
+        assert!(parse_tle_text(mismatched_pair, 5).is_none());
+        assert!(parse_tle_text(mismatched_pair, 25_544).is_none());
     }
 
     #[test]
@@ -582,6 +628,34 @@ SOMETHING
                 tle_source: TleSource::Noaa,
             }
         ));
+    }
+
+    #[test]
+    fn write_cache_atomic_rename_lands_file_at_final_path() {
+        // Sanity test for the atomic-rename path: write some text,
+        // verify the final cache file exists and contains exactly the
+        // text we wrote, and verify no leftover ".tmp.*" siblings
+        // were left behind in the cache directory.
+        let dir = unique_temp_dir("atomic-write");
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache = TleCache::with_dir(dir.clone());
+        let path = cache.cache_path(TleSource::Noaa);
+        cache.write_cache(&path, "hello cache").unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "hello cache");
+        // No leftover tempfiles in the cache directory.
+        let leftover_tmp_count = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .path()
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| ext.starts_with("tmp"))
+            })
+            .count();
+        assert_eq!(leftover_tmp_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Foundation crate for any feature that needs to know "where is satellite X right now" or "when does X come overhead next" — used by the NOAA APT epic (#468), Meteor-M LRPT (#469), and ISS SSTV (#472). Design discussion in conversation history; PR matches what was agreed.

## Three layers

* **`sgp4_core`** — pure SGP4/SDP4 propagation. Wraps `sgp4` v2.4 (Vallado's reference impl) plus the geometry helpers we need: ECI→ECEF via GMST, WGS84 geodetic→ECEF, ECEF→ENU. No I/O, no clock queries, no allocations.
* **`passes`** — pass enumeration + real-time tracking. Pure functions over \`GroundStation\` + \`Satellite\` + time. Coarse 1-min elevation scan + bisection refinement to ~1 sec precision + fine scan for the elevation peak. \`track()\` returns az/el/range/range-rate; \`Track::doppler_shift_hz(f0)\` computes the per-call Doppler so APT (137.5 MHz) / Meteor (137.1) / ISS-SSTV (145.8) all share the same plumbing.
* **`tle_cache`** — blocking reqwest fetch of \`noaa.txt\` / \`weather.txt\` / \`stations.txt\` from celestrak.org, cached at \`~/.cache/sdr-rs/tle/\`. Daily refresh (mtime-based). On fetch failure with stale cache present, returns the stale copy + a warning rather than going dark.

## Built-in catalog

\`KNOWN_SATELLITES\` ships with NOAA 15/18/19 (APT), Meteor-M 2 / 2-3 / 2-4 (LRPT), and ISS (SSTV). Order matches the scheduler UI display order #481 will use.

## Workspace deps

Adds \`sgp4 = "2.3"\` and \`chrono = "0.4"\` (with \`serde\` feature for future scheduler state persistence). \`reqwest\` (blocking) and \`dirs-next\` were already there.

## Test plan

- [x] **27 unit tests pass.** sgp4_core (9), passes (5), tle_cache (8), lib (2), and 3 negative-path covers split across modules.
- [x] All propagation tests use **Vallado's TC0 reference TLE** (Vanguard 1, NORAD 5, epoch 2000-06-27) — the canonical SGP4 verification vector from AIAA 2006-6753. Pinned in source so tests don't depend on current Celestrak state.
- [x] Self-consistency tests on every emitted pass: \`start < max_el_time < end\`, \`max_el ∈ [min, 90°]\`, azimuths in \`[0, 360)\`, duration sanity bounds.
- [x] Cache tests use per-test scratch dirs under \`std::env::temp_dir()\` — no \`tempfile\` dep needed, no live network.
- [x] \`cargo test -p sdr-sat\` — 27 passed.
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`cargo build --workspace\` clean.

## What's not in this PR

- **#481** — scheduler UI (this PR is the data layer).
- **#482** — auto-record on overhead pass (needs the controller-side wiring).
- Real-time tracker UI / rotator output — out of epic scope.

## Async vs blocking

Per the brainstorm: blocking reqwest from a worker thread, no tokio. We agreed to revisit if practice shows it needs async — the API surface (sync \`tle_for\` / \`track\` / \`upcoming_passes\`) doesn't bake in a choice that's hard to change later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Satellite pass prediction: real-time tracking, rise/set refinement, max-elevation detection, azimuth/elevation/range and Doppler shift
  * SGP4-based propagation with geodetic/frame conversions for precise positioning
  * Automated TLE management: multi-catalog fetching, on-disk caching with atomic updates, configurable refresh and stale-file fallback
  * Built-in satellite catalog covering NOAA APT, Meteor‑M, and ISS

* **Tests**
  * Unit tests for propagation, pass detection, TLE parsing, caching and failure modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->