### PR TITLE
SwiftUI: sidebar session persistence (closes #449)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -654,6 +654,93 @@ public final class SdrCore: @unchecked Sendable {
     }
 
     // ==========================================================
+    //  Config — ABI 0.21, issue #449. Round-trips against the
+    //  shared `sdr-config` JSON file passed to the engine at
+    //  init time. Auto-save runs off a worker thread the engine
+    //  starts; writes here become persistent at the next save
+    //  tick (and on `Drop` / engine destroy at the latest).
+    //
+    //  All getters return `Optional` — `nil` when the key is
+    //  absent OR present with a mismatched type. The two cases
+    //  are deliberately conflated on the Swift side because
+    //  callers want the same fallback ("use my Swift default")
+    //  in both. The C ABI distinguishes them via
+    //  `SDR_CORE_ERR_KEY_NOT_FOUND` for diagnostic logging if a
+    //  future caller needs the split.
+    // ==========================================================
+
+    /// Read a string-valued config key. `nil` when absent or
+    /// stored under a non-string JSON type.
+    public func configString(key: String) -> String? {
+        // Two-pass call: ask for the size, then fill a buffer
+        // sized exactly for the value. This matches the FFI's
+        // size-then-fill contract and avoids a fixed-cap
+        // assumption (config values can be arbitrarily long).
+        var required: Int = 0
+        let sizeRc = key.withCString { keyPtr in
+            sdr_core_config_get_string(handle, keyPtr, nil, 0, &required)
+        }
+        guard sizeRc == 0 else { return nil }
+        // Allocate the buffer, fill it, decode.
+        var buf = [CChar](repeating: 0, count: required)
+        let fillRc = key.withCString { keyPtr in
+            buf.withUnsafeMutableBufferPointer { bufPtr in
+                sdr_core_config_get_string(
+                    handle, keyPtr, bufPtr.baseAddress, bufPtr.count, nil
+                )
+            }
+        }
+        guard fillRc == 0 else { return nil }
+        return String(cString: buf)
+    }
+
+    /// Write a string-valued config key. Empty values are
+    /// stored verbatim — distinct from absence (which a
+    /// future read returns as `nil`).
+    public func setConfigString(key: String, value: String) throws {
+        try checkRc(key.withCString { keyPtr in
+            value.withCString { valuePtr in
+                sdr_core_config_set_string(handle, keyPtr, valuePtr)
+            }
+        })
+    }
+
+    /// Read a bool-valued config key. `nil` when absent or
+    /// stored under a non-bool JSON type.
+    public func configBool(key: String) -> Bool? {
+        var out = false
+        let rc = key.withCString { keyPtr in
+            sdr_core_config_get_bool(handle, keyPtr, &out)
+        }
+        return rc == 0 ? out : nil
+    }
+
+    /// Write a bool-valued config key.
+    public func setConfigBool(key: String, value: Bool) throws {
+        try checkRc(key.withCString { keyPtr in
+            sdr_core_config_set_bool(handle, keyPtr, value)
+        })
+    }
+
+    /// Read a u32-valued config key. `nil` when absent, stored
+    /// under a non-numeric type, or stored as a number that
+    /// doesn't fit in `UInt32`.
+    public func configUInt32(key: String) -> UInt32? {
+        var out: UInt32 = 0
+        let rc = key.withCString { keyPtr in
+            sdr_core_config_get_u32(handle, keyPtr, &out)
+        }
+        return rc == 0 ? out : nil
+    }
+
+    /// Write a u32-valued config key.
+    public func setConfigUInt32(key: String, value: UInt32) throws {
+        try checkRc(key.withCString { keyPtr in
+            sdr_core_config_set_u32(handle, keyPtr, value)
+        })
+    }
+
+    // ==========================================================
     //  FFT frame pull
     // ==========================================================
 

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -671,27 +671,63 @@ public final class SdrCore: @unchecked Sendable {
 
     /// Read a string-valued config key. `nil` when absent or
     /// stored under a non-string JSON type.
+    ///
+    /// Implementation detail: the engine's config FFI uses a
+    /// size-then-fill contract, so this is a two-pass call. We
+    /// pass `out_required` on the FILL pass too — if another
+    /// thread grew the value between the size probe and the
+    /// fill (a real possibility with the engine's auto-save
+    /// worker plus arbitrary host writes), the FFI returns
+    /// `InvalidArg` with the new required size, and we retry
+    /// with a fresh buffer once. A second growth in the same
+    /// call would be exotic; if it happened we'd give up and
+    /// return `nil` rather than loop unbounded — same policy
+    /// the rtl_tcp recent-commands reader uses.
     public func configString(key: String) -> String? {
-        // Two-pass call: ask for the size, then fill a buffer
-        // sized exactly for the value. This matches the FFI's
-        // size-then-fill contract and avoids a fixed-cap
-        // assumption (config values can be arbitrarily long).
+        // 1. Probe required size.
         var required: Int = 0
         let sizeRc = key.withCString { keyPtr in
             sdr_core_config_get_string(handle, keyPtr, nil, 0, &required)
         }
         guard sizeRc == 0 else { return nil }
-        // Allocate the buffer, fill it, decode.
-        var buf = [CChar](repeating: 0, count: required)
+        return readConfigStringFill(key: key, capacity: required)
+    }
+
+    /// Run the fill pass of the size-then-fill string read with
+    /// a single retry on inter-call growth. Split out so the
+    /// retry loop stays small and the happy-path stays a flat
+    /// `withCString { ... }`. Per `CodeRabbit` round 1 on
+    /// PR #499.
+    private func readConfigStringFill(key: String, capacity: Int) -> String? {
+        var buf = [CChar](repeating: 0, count: capacity)
+        var required: Int = 0
         let fillRc = key.withCString { keyPtr in
             buf.withUnsafeMutableBufferPointer { bufPtr in
                 sdr_core_config_get_string(
-                    handle, keyPtr, bufPtr.baseAddress, bufPtr.count, nil
+                    handle, keyPtr, bufPtr.baseAddress, bufPtr.count, &required
                 )
             }
         }
-        guard fillRc == 0 else { return nil }
-        return String(cString: buf)
+        if fillRc == 0 {
+            return String(cString: buf)
+        }
+        // Race: another writer grew the value between the size
+        // probe and this fill. Retry with the FFI's freshly
+        // reported size — but only once, to bound recursion.
+        if fillRc == SdrCoreError.Code.invalidArg.rawValue, required > capacity {
+            var retryBuf = [CChar](repeating: 0, count: required)
+            let retryRc = key.withCString { keyPtr in
+                retryBuf.withUnsafeMutableBufferPointer { bufPtr in
+                    sdr_core_config_get_string(
+                        handle, keyPtr, bufPtr.baseAddress, bufPtr.count, nil
+                    )
+                }
+            }
+            if retryRc == 0 {
+                return String(cString: retryBuf)
+            }
+        }
+        return nil
     }
 
     /// Write a string-valued config key. Empty values are

--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -48,61 +48,71 @@ struct ContentView: View {
     @State private var showingRadioReference: Bool = false
 
     // ----------------------------------------------------------
-    //  Activity-bar selections — new in #442
+    //  Activity-bar selections + width drag — sidebar session
     //
-    //  Ephemeral for scaffolding; session persistence wires
-    //  these bindings into `sdr-config` via #449.
+    //  Selection / open / width all live on CoreModel
+    //  (`sidebarLeft*` / `sidebarRight*`) so the activity-bar
+    //  click handler and the resize gesture write straight to
+    //  the shared `sdr-config` JSON via the engine FFI.
+    //  CoreModel restores from config in `bootstrap()` BEFORE
+    //  this view first paints, so the @Observable bindings
+    //  here pick up the persisted state without flashing the
+    //  default first. Per #449.
+    //
+    //  `liveLeftWidth` / `liveRightWidth` track the live drag
+    //  position separately so we don't write to the shared
+    //  config on every pixel. The drag-end commit pushes the
+    //  final value to `model.setSidebar*Width` in one shot.
     // ----------------------------------------------------------
 
-    /// Currently-selected left activity. Stays stable across
-    /// panel open/close so the icon highlight persists when
-    /// the user collapses the panel via a second click.
-    /// `leftPanelOpen` controls visibility independently.
-    /// This split mirrors the Linux
-    /// `ui_sidebar_left_{selected,open}` config-key pair, so
-    /// #449's session-persistence wires both bindings into
-    /// the shared sdr-config JSON. Per `CodeRabbit` round 1
-    /// on PR #491.
-    @State private var leftSelection: LeftActivity = .general
-    @State private var leftPanelOpen: Bool = true
-
-    /// Same split for the right bar. Defaults: Transcript
-    /// remembered as the active activity, panel starts closed
-    /// — matches Linux startup.
-    @State private var rightSelection: RightActivity = .transcript
-    @State private var rightPanelOpen: Bool = false
-
-    /// Ideal width of a left / right panel. `HSplitView` in
-    /// #450 will let the user drag these; today they're fixed.
-    private static let leftPanelWidth: CGFloat = 280
-    private static let rightPanelWidth: CGFloat = 360
+    /// Live drag width for the left panel — `nil` when no drag
+    /// is in progress (the model's `sidebarLeftWidth` drives
+    /// the layout in that case). Set on drag start, updated on
+    /// drag, cleared + flushed to the model on drag end.
+    @State private var liveLeftWidth: CGFloat? = nil
+    /// Same pattern for the right panel.
+    @State private var liveRightWidth: CGFloat? = nil
 
     var body: some View {
-        HStack(spacing: 0) {
+        @Bindable var model = model
+        let leftSelectionBinding = Binding<LeftActivity>(
+            get: { LeftActivity(rawValue: model.sidebarLeftSelected) ?? .general },
+            set: { model.setSidebarLeftSelected($0.rawValue) }
+        )
+        let leftOpenBinding = Binding<Bool>(
+            get: { model.sidebarLeftOpen },
+            set: { model.setSidebarLeftOpen($0) }
+        )
+        let rightSelectionBinding = Binding<RightActivity>(
+            get: { RightActivity(rawValue: model.sidebarRightSelected) ?? .transcript },
+            set: { model.setSidebarRightSelected($0.rawValue) }
+        )
+        let rightOpenBinding = Binding<Bool>(
+            get: { model.sidebarRightOpen },
+            set: { model.setSidebarRightOpen($0) }
+        )
+        let leftWidth = liveLeftWidth ?? CGFloat(model.sidebarLeftWidth)
+        let rightWidth = liveRightWidth ?? CGFloat(model.sidebarRightWidth)
+
+        return HStack(spacing: 0) {
             // Left activity bar — always visible.
             ActivityBarView(
-                selection: $leftSelection,
-                isOpen: $leftPanelOpen,
+                selection: leftSelectionBinding,
+                isOpen: leftOpenBinding,
                 shortcutModifiers: .command
             )
             Divider()
 
-            // Left panel — visible only when `leftPanelOpen`.
-            // The remembered `leftSelection` stays put when
-            // closed so a re-open snaps back to the same panel.
-            // Placeholder bodies during scaffolding; real
-            // panels land in #443–#447.
-            if leftPanelOpen {
-                LeftPanelHost(activity: leftSelection)
-                    .frame(width: Self.leftPanelWidth)
-                Divider()
+            // Left panel — visible only when `sidebarLeftOpen`.
+            // The remembered selection stays put when closed
+            // so a re-open snaps back to the same panel.
+            if model.sidebarLeftOpen {
+                LeftPanelHost(activity: leftSelectionBinding.wrappedValue)
+                    .frame(width: leftWidth)
+                resizeHandle(side: .left)
             }
 
-            // Detail column — spectrum + status bar. The
-            // pre-redesign right-side flyouts (Transcription,
-            // Bookmarks) moved to the right activity-bar
-            // panels in #448, so the detail column is now
-            // just the visualization stack.
+            // Detail column — spectrum + status bar.
             VStack(spacing: 0) {
                 CenterView()
                 StatusBar()
@@ -110,25 +120,20 @@ struct ContentView: View {
             .frame(maxWidth: .infinity)
 
             // Right panel — driven by the right activity bar.
-            // Hosts TranscriptionPanel or BookmarksPanel
-            // depending on `rightSelection`; bookmarks gets
-            // the `isOpen` binding so its X close button
-            // toggles the activity bar's state directly.
-            if rightPanelOpen {
-                Divider()
+            if model.sidebarRightOpen {
+                resizeHandle(side: .right)
                 RightPanelHost(
-                    activity: rightSelection,
-                    isOpen: $rightPanelOpen
+                    activity: rightSelectionBinding.wrappedValue,
+                    isOpen: rightOpenBinding
                 )
-                .frame(width: Self.rightPanelWidth)
+                .frame(width: rightWidth)
             }
             Divider()
 
-            // Right activity bar — always visible. One icon
-            // in scaffolding; #448 adds the second.
+            // Right activity bar — always visible.
             ActivityBarView(
-                selection: $rightSelection,
-                isOpen: $rightPanelOpen,
+                selection: rightSelectionBinding,
+                isOpen: rightOpenBinding,
                 shortcutModifiers: [.command, .shift]
             )
         }
@@ -205,6 +210,108 @@ struct ContentView: View {
                 bad output. Reinstall a matching build.
                 """)
         }
+    }
+
+    /// Which sidebar a resize handle controls. Drag direction
+    /// is inverted between sides — dragging the left handle
+    /// rightward grows the left panel, while dragging the
+    /// right handle leftward grows the right panel.
+    private enum Side {
+        case left, right
+    }
+
+    /// Visible 1 px divider wrapped in an 8 px invisible hit
+    /// target. Mirrors the GTK `build_resize_handle` pattern
+    /// (custom gesture on a narrow strip — `HSplitView` would
+    /// also work but takes over more layout decisions than we
+    /// want here, since the panels and bars are part of the
+    /// same `HStack`).
+    ///
+    /// **Color.white.opacity(0.001) over Color.clear** —
+    /// SwiftUI treats a `.clear` fill as non-hit-testable even
+    /// with an explicit `contentShape`. A near-zero-opacity
+    /// fill is visually identical but draws (and therefore
+    /// hits) normally. This is the documented SwiftUI
+    /// workaround — any opacity > 0 will do; we pick 0.001 to
+    /// stay inside the "no pixels drawn" optimization. Kept as
+    /// a constant on the view so a future Retina cap or
+    /// cursor-snap tweak stays in one place.
+    ///
+    /// Live-drag width is held in `liveLeftWidth` /
+    /// `liveRightWidth` so we don't write to the shared config
+    /// on every pixel; the on-drag-end commit pushes the final
+    /// value through the model setter (which clamps + writes
+    /// to the FFI config).
+    private func resizeHandle(side: Side) -> some View {
+        let baseWidth: CGFloat = side == .left
+            ? CGFloat(model.sidebarLeftWidth)
+            : CGFloat(model.sidebarRightWidth)
+        // 8 px of draggable strip centered on the 1 px divider.
+        // Wider than the divider so the hit target is forgiving
+        // — matches macOS's own HSplitView separator feel.
+        let hitWidth: CGFloat = 8
+        return Color.white.opacity(0.001)
+            .frame(width: hitWidth)
+            .overlay(
+                // The visible 1 px line. Uses the system
+                // separator color so the divider looks native
+                // in both Light and Dark modes and tracks any
+                // accent-tint changes the user makes.
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor))
+                    .frame(width: 1)
+            )
+            .contentShape(Rectangle())
+            .onHover { inside in
+                // Push/pop gives stable cursor behavior when
+                // the drag crosses above / below other views
+                // — a `set`-only approach can leave the resize
+                // cursor stuck after a fast exit.
+                if inside {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let delta = value.translation.width
+                        let next: CGFloat
+                        switch side {
+                        case .left:
+                            next = baseWidth + delta
+                        case .right:
+                            next = baseWidth - delta
+                        }
+                        // Clamp to the model's configured range
+                        // so the live preview stays inside the
+                        // visible bounds (setter clamps too).
+                        let lo = CGFloat(CoreModel.sidebarWidthRange.lowerBound)
+                        let hi = CGFloat(CoreModel.sidebarWidthRange.upperBound)
+                        let clamped = min(max(next, lo), hi)
+                        switch side {
+                        case .left: liveLeftWidth = clamped
+                        case .right: liveRightWidth = clamped
+                        }
+                    }
+                    .onEnded { _ in
+                        // Commit the final width to CoreModel
+                        // (which writes to the shared config).
+                        switch side {
+                        case .left:
+                            if let w = liveLeftWidth {
+                                model.setSidebarLeftWidth(UInt32(w.rounded()))
+                            }
+                            liveLeftWidth = nil
+                        case .right:
+                            if let w = liveRightWidth {
+                                model.setSidebarRightWidth(UInt32(w.rounded()))
+                            }
+                            liveRightWidth = nil
+                        }
+                    }
+            )
     }
 }
 

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -954,6 +954,18 @@ final class CoreModel {
         do {
             let c = try SdrCore(configPath: configPath)
             self.core = c
+            // Restore sidebar session from the shared config —
+            // issue #449. Runs AFTER the engine handle is set
+            // because `loadSidebarSession()` reads through the
+            // FFI's config surface, which depends on the
+            // ConfigManager owned by the engine handle. Has to
+            // happen before the SwiftUI scene first paints so the
+            // remembered selection / open state / width is on the
+            // observable properties before ContentView's bindings
+            // wire up. Out-of-range values fall through to the
+            // already-set defaults — same defensive policy as the
+            // rest of the bootstrap restore block.
+            loadSidebarSession()
             // `[weak self]` breaks the retain cycle that would
             // otherwise form: CoreModel → eventTask → closure →
             // self. If the model is dropped (e.g., from a future
@@ -2647,6 +2659,153 @@ final class CoreModel {
     /// the GTK panel uses an in-memory `ComboRow` and resets on
     /// app restart).
     static let lastSelectedBandPresetDefaultsKey = "SDRMac.lastSelectedBandPreset"
+
+    // ----------------------------------------------------------
+    //  Sidebar session — issue #449 (ABI 0.21)
+    //
+    //  Six fields, three per side, persisted to the shared
+    //  `sdr-config` JSON file via the engine's config FFI. Keys
+    //  match the Linux side exactly so a user who runs both
+    //  frontends sees consistent state. Values for the
+    //  `*_selected` fields are the activity raw-value strings
+    //  defined on `LeftActivity` / `RightActivity` (which match
+    //  the Linux activity-bar entry names — same source of
+    //  truth).
+    //
+    //  Default values match the Linux `SidebarSession::default`:
+    //  left = General open at 320 px, right = Transcript closed
+    //  at 320 px. The 320 px width matches the GTK
+    //  `DEFAULT_SIDEBAR_WIDTH_PX` constant.
+    //
+    //  These fields are observable @Observable storage so
+    //  ContentView can bind through them (and the activity bar /
+    //  resize gesture writes flow back through the matching
+    //  setters). The setters double-write: update the
+    //  observable property AND push to the engine config so the
+    //  on-disk JSON stays in sync.
+    // ----------------------------------------------------------
+
+    /// Activity selected in the left sidebar — one of the
+    /// `LeftActivity` raw values. Loaded from
+    /// `ui_sidebar_left_selected` on bootstrap; written through
+    /// `setSidebarLeftSelected(_:)` on user picks.
+    var sidebarLeftSelected: String = "general"
+    /// Whether the left panel is currently visible.
+    var sidebarLeftOpen: Bool = true
+    /// Width of the left panel in pixels.
+    var sidebarLeftWidth: UInt32 = 320
+
+    /// Activity selected in the right sidebar — one of the
+    /// `RightActivity` raw values.
+    var sidebarRightSelected: String = "transcript"
+    /// Whether the right panel is currently visible.
+    var sidebarRightOpen: Bool = false
+    /// Width of the right panel in pixels.
+    var sidebarRightWidth: UInt32 = 320
+
+    /// Config keys — match the Linux constants in
+    /// `crates/sdr-ui/src/sidebar/activity_bar.rs` exactly so a
+    /// user who runs both frontends sees consistent state.
+    static let sidebarLeftSelectedKey = "ui_sidebar_left_selected"
+    static let sidebarLeftOpenKey = "ui_sidebar_left_open"
+    static let sidebarLeftWidthKey = "ui_sidebar_left_width_px"
+    static let sidebarRightSelectedKey = "ui_sidebar_right_selected"
+    static let sidebarRightOpenKey = "ui_sidebar_right_open"
+    static let sidebarRightWidthKey = "ui_sidebar_right_width_px"
+
+    /// Hard floor / ceiling for sidebar widths (pixels). The
+    /// GTK side tolerates anything but applies a sane minimum
+    /// in its split-view handler; we mirror that here so a
+    /// hand-edited config can't hand the SwiftUI HSplitView a
+    /// degenerate width that collapses the panel beyond the
+    /// drag-back-out threshold.
+    static let sidebarWidthRange: ClosedRange<UInt32> = 200...800
+
+    /// Restore all six sidebar fields from the shared config.
+    /// Called once during `bootstrap()` AFTER the engine is
+    /// alive (the engine handle owns the `ConfigManager` we
+    /// read through). Out-of-range / malformed entries fall
+    /// through to the default value already on the property —
+    /// same defensive policy as the network-sink restore above.
+    private func loadSidebarSession() {
+        guard let core else { return }
+        if let s = core.configString(key: Self.sidebarLeftSelectedKey),
+           LeftActivity(rawValue: s) != nil {
+            sidebarLeftSelected = s
+        }
+        if let b = core.configBool(key: Self.sidebarLeftOpenKey) {
+            sidebarLeftOpen = b
+        }
+        if let w = core.configUInt32(key: Self.sidebarLeftWidthKey),
+           Self.sidebarWidthRange.contains(w) {
+            sidebarLeftWidth = w
+        }
+        if let s = core.configString(key: Self.sidebarRightSelectedKey),
+           RightActivity(rawValue: s) != nil {
+            sidebarRightSelected = s
+        }
+        if let b = core.configBool(key: Self.sidebarRightOpenKey) {
+            sidebarRightOpen = b
+        }
+        if let w = core.configUInt32(key: Self.sidebarRightWidthKey),
+           Self.sidebarWidthRange.contains(w) {
+            sidebarRightWidth = w
+        }
+    }
+
+    /// Update the left sidebar's selected activity. Validates
+    /// against `LeftActivity` raw values before writing — a
+    /// non-UI caller passing a bogus string can't poison the
+    /// shared config (Linux side would silently ignore it on
+    /// next load anyway, but the round-trip would be sticky
+    /// across sessions).
+    func setSidebarLeftSelected(_ name: String) {
+        guard LeftActivity(rawValue: name) != nil else { return }
+        sidebarLeftSelected = name
+        capture {
+            try core?.setConfigString(key: Self.sidebarLeftSelectedKey, value: name)
+        }
+    }
+
+    func setSidebarLeftOpen(_ open: Bool) {
+        sidebarLeftOpen = open
+        capture { try core?.setConfigBool(key: Self.sidebarLeftOpenKey, value: open) }
+    }
+
+    func setSidebarLeftWidth(_ width: UInt32) {
+        let clamped = min(
+            max(width, Self.sidebarWidthRange.lowerBound),
+            Self.sidebarWidthRange.upperBound
+        )
+        sidebarLeftWidth = clamped
+        capture {
+            try core?.setConfigUInt32(key: Self.sidebarLeftWidthKey, value: clamped)
+        }
+    }
+
+    func setSidebarRightSelected(_ name: String) {
+        guard RightActivity(rawValue: name) != nil else { return }
+        sidebarRightSelected = name
+        capture {
+            try core?.setConfigString(key: Self.sidebarRightSelectedKey, value: name)
+        }
+    }
+
+    func setSidebarRightOpen(_ open: Bool) {
+        sidebarRightOpen = open
+        capture { try core?.setConfigBool(key: Self.sidebarRightOpenKey, value: open) }
+    }
+
+    func setSidebarRightWidth(_ width: UInt32) {
+        let clamped = min(
+            max(width, Self.sidebarWidthRange.lowerBound),
+            Self.sidebarWidthRange.upperBound
+        )
+        sidebarRightWidth = clamped
+        capture {
+            try core?.setConfigUInt32(key: Self.sidebarRightWidthKey, value: clamped)
+        }
+    }
 
     /// Apply the current network-source host/port/protocol to
     /// the engine. Called on explicit Apply in the Source pane

--- a/crates/sdr-ffi/src/config.rs
+++ b/crates/sdr-ffi/src/config.rs
@@ -1,0 +1,589 @@
+//! Config C ABI (ABI 0.21 / issue #449): key/value get + set against
+//! the shared `sdr-config` JSON file the host passed to
+//! `sdr_core_create`.
+//!
+//! The engine doesn't yet consume its own config (the GTK frontend
+//! and the eventual Mac-native config readers both drive persistence
+//! themselves through this surface). What lives behind this ABI:
+//!
+//!   - `get_string` / `set_string` — arbitrary UTF-8 values.
+//!     Read path uses the standard size-then-fill pattern.
+//!   - `get_bool`  / `set_bool`   — JSON bools.
+//!   - `get_u32`   / `set_u32`    — JSON numbers, narrowed to `u32`.
+//!
+//! All getters return `KeyNotFound` (not `InvalidArg`) when the key
+//! is absent or present with a mismatched type, so hosts can cleanly
+//! branch on "use default" vs "surface error".
+//!
+//! The host-provided config path governs whether on-disk persistence
+//! is active: an empty path at `sdr_core_create` time leaves
+//! `core.config` as `None`, and every entry point in this module
+//! returns `InvalidArg` with an explanatory last-error — no crash,
+//! but the host is told it's operating in an ephemeral mode.
+//!
+//! Auto-save is enabled on the `ConfigManager` at create time so
+//! writes through this surface land on disk without the host
+//! calling any sync helper. The auto-save thread is joined on the
+//! manager's `Drop`, which fires as part of `sdr_core_destroy`.
+
+use std::ffi::{CStr, c_char};
+
+use crate::error::{SdrCoreError, clear_last_error, set_last_error};
+use crate::handle::SdrCore;
+use crate::lifecycle::panic_message;
+
+/// Shared boilerplate wrapper for every config entry point.
+///
+/// Validates the handle, rejects an empty-config (in-memory) handle
+/// with `InvalidArg`, reads the key string, and hands the closure a
+/// borrow of both. The closure returns a `Result<(), SdrCoreError>`
+/// the same way the command-module `with_core` does.
+///
+/// # Safety
+///
+/// Same contract as `SdrCore::from_raw` plus `key_utf8` must be
+/// either null (rejected as `InvalidArg`) or a pointer to a NUL-
+/// terminated UTF-8 string for the duration of the call.
+unsafe fn with_config<F>(handle: *mut SdrCore, key_utf8: *const c_char, f: F) -> i32
+where
+    F: FnOnce(&std::sync::Arc<sdr_config::ConfigManager>, &str) -> Result<(), SdrCoreError>
+        + std::panic::UnwindSafe,
+{
+    let result = std::panic::catch_unwind(|| {
+        // SAFETY: caller contract matches SdrCore::from_raw.
+        let Some(core) = (unsafe { SdrCore::from_raw(handle) }) else {
+            set_last_error("sdr_core_config: null or invalid handle");
+            return SdrCoreError::InvalidHandle.as_int();
+        };
+        let Some(config) = core.config.as_ref() else {
+            set_last_error(
+                "sdr_core_config: engine was created with an empty path (in-memory \
+                 mode) — config get/set is not available. Pass a non-empty \
+                 config_path_utf8 to sdr_core_create to enable persistence.",
+            );
+            return SdrCoreError::InvalidArg.as_int();
+        };
+        if key_utf8.is_null() {
+            set_last_error("sdr_core_config: key pointer is null");
+            return SdrCoreError::InvalidArg.as_int();
+        }
+        // SAFETY: caller contract — key_utf8 is NUL-terminated UTF-8
+        // for the duration of this call.
+        let cstr = unsafe { CStr::from_ptr(key_utf8) };
+        let Ok(key) = cstr.to_str() else {
+            set_last_error("sdr_core_config: key is not valid UTF-8");
+            return SdrCoreError::InvalidArg.as_int();
+        };
+        if key.is_empty() {
+            set_last_error("sdr_core_config: key is empty");
+            return SdrCoreError::InvalidArg.as_int();
+        }
+        match f(config, key) {
+            Ok(()) => {
+                clear_last_error();
+                SdrCoreError::Ok.as_int()
+            }
+            Err(e) => e.as_int(),
+        }
+    });
+    match result {
+        Ok(code) => code,
+        Err(payload) => {
+            set_last_error(format!(
+                "sdr_core_config: panic: {}",
+                panic_message(&payload)
+            ));
+            SdrCoreError::Internal.as_int()
+        }
+    }
+}
+
+// ============================================================
+//  String
+// ============================================================
+
+/// Read a string-valued config key. Size-then-fill pattern: pass a
+/// NULL `out_buf` + zero `buf_len` to query the required buffer
+/// size (written to `*out_required`, including the NUL terminator);
+/// then retry with a buffer of at least that size.
+///
+/// Returns `KeyNotFound` if the key doesn't exist or exists with a
+/// non-string type. Returns `InvalidArg` with `*out_required`
+/// populated when the provided buffer is too small — the host
+/// should retry with at least that many bytes.
+///
+/// `out_required` may be null if the caller doesn't care about the
+/// required size (e.g., has a known-large buffer). `out_buf` may be
+/// null ONLY when `buf_len == 0` (the pure-query form). Any other
+/// combination returns `InvalidArg`.
+///
+/// # Safety
+///
+/// Same contract as `sdr_core_config_set_string` (see below) plus
+/// `out_buf` must point to writable storage of at least `buf_len`
+/// bytes when non-null, and `out_required` must point to writable
+/// storage for one `usize` when non-null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_config_get_string(
+    handle: *mut SdrCore,
+    key_utf8: *const c_char,
+    out_buf: *mut c_char,
+    buf_len: usize,
+    out_required: *mut usize,
+) -> i32 {
+    unsafe {
+        with_config(handle, key_utf8, |config, key| {
+            if out_buf.is_null() && buf_len != 0 {
+                set_last_error("sdr_core_config_get_string: out_buf is null but buf_len != 0");
+                return Err(SdrCoreError::InvalidArg);
+            }
+
+            let value: Option<String> = config.read(|v| {
+                v.get(key)
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            });
+            let Some(s) = value else {
+                set_last_error(format!(
+                    "sdr_core_config_get_string: key '{key}' not found or not a string"
+                ));
+                return Err(SdrCoreError::KeyNotFound);
+            };
+
+            // Required buffer = bytes + trailing NUL.
+            let required = s.len().saturating_add(1);
+            if !out_required.is_null() {
+                // SAFETY: caller contract — already inside the
+                // outer fn-level unsafe block.
+                *out_required = required;
+            }
+
+            // Pure-query form — host just wanted the size.
+            if out_buf.is_null() {
+                return Ok(());
+            }
+            if buf_len < required {
+                set_last_error(format!(
+                    "sdr_core_config_get_string: buffer too small for key '{key}' \
+                     — need {required} bytes including NUL, got {buf_len}"
+                ));
+                return Err(SdrCoreError::InvalidArg);
+            }
+
+            let bytes = s.as_bytes();
+            // SAFETY: out_buf is non-null, buf_len >= required >=
+            // bytes.len() + 1, and we hold the read lock guard's
+            // reference through the memcpy. Already inside the
+            // outer fn-level unsafe block.
+            std::ptr::copy_nonoverlapping(bytes.as_ptr().cast::<c_char>(), out_buf, bytes.len());
+            *out_buf.add(bytes.len()) = 0;
+            Ok(())
+        })
+    }
+}
+
+/// Write a string-valued config key. Empty strings are accepted and
+/// stored verbatim — an empty value is distinct from key absence.
+///
+/// # Safety
+///
+/// `handle` must be either null or a pointer previously returned by
+/// `sdr_core_create` and not yet destroyed. `key_utf8` and
+/// `value_utf8` must be either null (both rejected with `InvalidArg`)
+/// or pointers to NUL-terminated UTF-8 strings for the duration of
+/// the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_config_set_string(
+    handle: *mut SdrCore,
+    key_utf8: *const c_char,
+    value_utf8: *const c_char,
+) -> i32 {
+    unsafe {
+        with_config(handle, key_utf8, |config, key| {
+            if value_utf8.is_null() {
+                set_last_error("sdr_core_config_set_string: value pointer is null");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            // SAFETY: caller contract — value_utf8 is NUL-terminated
+            // UTF-8 for the duration of this call. Already inside
+            // the outer fn-level unsafe block.
+            let cstr = CStr::from_ptr(value_utf8);
+            let Ok(value) = cstr.to_str() else {
+                set_last_error("sdr_core_config_set_string: value is not valid UTF-8");
+                return Err(SdrCoreError::InvalidArg);
+            };
+            let owned = value.to_owned();
+            config.write(|v| {
+                v[key] = serde_json::Value::String(owned);
+            });
+            Ok(())
+        })
+    }
+}
+
+// ============================================================
+//  Bool
+// ============================================================
+
+/// Read a bool-valued config key. Returns `KeyNotFound` when the
+/// key is absent or present with a non-bool JSON type.
+///
+/// # Safety
+///
+/// Same contract as `sdr_core_config_set_bool`, plus `out_value`
+/// must point to writable storage for one `bool`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_config_get_bool(
+    handle: *mut SdrCore,
+    key_utf8: *const c_char,
+    out_value: *mut bool,
+) -> i32 {
+    unsafe {
+        with_config(handle, key_utf8, |config, key| {
+            if out_value.is_null() {
+                set_last_error("sdr_core_config_get_bool: out_value is null");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            let value: Option<bool> =
+                config.read(|v| v.get(key).and_then(serde_json::Value::as_bool));
+            let Some(b) = value else {
+                set_last_error(format!(
+                    "sdr_core_config_get_bool: key '{key}' not found or not a bool"
+                ));
+                return Err(SdrCoreError::KeyNotFound);
+            };
+            // SAFETY: caller contract — out_value points to
+            // writable `bool` storage. Already inside the
+            // outer fn-level unsafe block.
+            *out_value = b;
+            Ok(())
+        })
+    }
+}
+
+/// Write a bool-valued config key.
+///
+/// # Safety
+///
+/// `handle` must be either null or a pointer previously returned by
+/// `sdr_core_create`. `key_utf8` must be either null or a NUL-
+/// terminated UTF-8 string for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_config_set_bool(
+    handle: *mut SdrCore,
+    key_utf8: *const c_char,
+    value: bool,
+) -> i32 {
+    unsafe {
+        with_config(handle, key_utf8, |config, key| {
+            config.write(|v| {
+                v[key] = serde_json::Value::Bool(value);
+            });
+            Ok(())
+        })
+    }
+}
+
+// ============================================================
+//  u32
+// ============================================================
+
+/// Read a u32-valued config key. Returns `KeyNotFound` when the key
+/// is absent, present with a non-numeric JSON type, or present with
+/// a number that doesn't fit in `u32`.
+///
+/// # Safety
+///
+/// Same contract as `sdr_core_config_set_u32`, plus `out_value`
+/// must point to writable storage for one `u32`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_config_get_u32(
+    handle: *mut SdrCore,
+    key_utf8: *const c_char,
+    out_value: *mut u32,
+) -> i32 {
+    unsafe {
+        with_config(handle, key_utf8, |config, key| {
+            if out_value.is_null() {
+                set_last_error("sdr_core_config_get_u32: out_value is null");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            let value: Option<u32> = config.read(|v| {
+                v.get(key)
+                    .and_then(serde_json::Value::as_u64)
+                    .and_then(|n| u32::try_from(n).ok())
+            });
+            let Some(n) = value else {
+                set_last_error(format!(
+                    "sdr_core_config_get_u32: key '{key}' not found or not a u32"
+                ));
+                return Err(SdrCoreError::KeyNotFound);
+            };
+            // SAFETY: caller contract — out_value points to
+            // writable `u32` storage. Already inside the
+            // outer fn-level unsafe block.
+            *out_value = n;
+            Ok(())
+        })
+    }
+}
+
+/// Write a u32-valued config key.
+///
+/// # Safety
+///
+/// Same contract as `sdr_core_config_set_bool`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_config_set_u32(
+    handle: *mut SdrCore,
+    key_utf8: *const c_char,
+    value: u32,
+) -> i32 {
+    unsafe {
+        with_config(handle, key_utf8, |config, key| {
+            config.write(|v| {
+                v[key] = serde_json::Value::Number(value.into());
+            });
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::lifecycle::{sdr_core_create, sdr_core_destroy};
+    use std::ffi::CString;
+
+    /// Build a handle backed by an on-disk config file under the
+    /// system temp directory. The file path is unique per test
+    /// (pid + monotonic nanos) so parallel tests don't collide.
+    fn make_handle_with_config() -> (*mut SdrCore, std::path::PathBuf) {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let path = std::env::temp_dir().join(format!(
+            "sdr-ffi-config-{}-{nonce}.json",
+            std::process::id()
+        ));
+        let path_c = CString::new(path.to_string_lossy().as_bytes()).unwrap();
+        let mut handle: *mut SdrCore = std::ptr::null_mut();
+        let rc = unsafe { sdr_core_create(path_c.as_ptr(), &raw mut handle) };
+        assert_eq!(rc, SdrCoreError::Ok.as_int());
+        assert!(!handle.is_null());
+        (handle, path)
+    }
+
+    fn destroy(handle: *mut SdrCore, path: std::path::PathBuf) {
+        unsafe { sdr_core_destroy(handle) };
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn all_getters_reject_null_handle() {
+        let key = CString::new("ui_sidebar_left_selected").unwrap();
+        let mut out_bool = false;
+        let mut out_u32: u32 = 0;
+        assert_eq!(
+            unsafe {
+                sdr_core_config_get_string(
+                    std::ptr::null_mut(),
+                    key.as_ptr(),
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null_mut(),
+                )
+            },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+        assert_eq!(
+            unsafe {
+                sdr_core_config_get_bool(std::ptr::null_mut(), key.as_ptr(), &raw mut out_bool)
+            },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+        assert_eq!(
+            unsafe {
+                sdr_core_config_get_u32(std::ptr::null_mut(), key.as_ptr(), &raw mut out_u32)
+            },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+    }
+
+    #[test]
+    fn missing_key_returns_key_not_found() {
+        let (h, path) = make_handle_with_config();
+        let key = CString::new("never_written").unwrap();
+        let mut out_bool = true;
+        let rc = unsafe { sdr_core_config_get_bool(h, key.as_ptr(), &raw mut out_bool) };
+        assert_eq!(rc, SdrCoreError::KeyNotFound.as_int());
+        // out_value must be untouched on KeyNotFound so the host
+        // can keep its default — no partial-write surprises.
+        assert!(out_bool);
+        destroy(h, path);
+    }
+
+    #[test]
+    fn round_trip_string() {
+        let (h, path) = make_handle_with_config();
+        let key = CString::new("ui_sidebar_left_selected").unwrap();
+        let value = CString::new("radio").unwrap();
+
+        assert_eq!(
+            unsafe { sdr_core_config_set_string(h, key.as_ptr(), value.as_ptr()) },
+            SdrCoreError::Ok.as_int()
+        );
+
+        // Query-size form: NULL buf + zero len + non-null out_required.
+        let mut required: usize = 0;
+        assert_eq!(
+            unsafe {
+                sdr_core_config_get_string(
+                    h,
+                    key.as_ptr(),
+                    std::ptr::null_mut(),
+                    0,
+                    &raw mut required,
+                )
+            },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(required, "radio".len() + 1); // NUL-inclusive.
+
+        // Fill form.
+        let mut buf = vec![0i8; required];
+        assert_eq!(
+            unsafe {
+                sdr_core_config_get_string(
+                    h,
+                    key.as_ptr(),
+                    buf.as_mut_ptr(),
+                    buf.len(),
+                    std::ptr::null_mut(),
+                )
+            },
+            SdrCoreError::Ok.as_int()
+        );
+        let read = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_str().unwrap();
+        assert_eq!(read, "radio");
+
+        destroy(h, path);
+    }
+
+    #[test]
+    fn round_trip_bool_and_u32() {
+        let (h, path) = make_handle_with_config();
+        let open_key = CString::new("ui_sidebar_left_open").unwrap();
+        let width_key = CString::new("ui_sidebar_left_width_px").unwrap();
+
+        assert_eq!(
+            unsafe { sdr_core_config_set_bool(h, open_key.as_ptr(), true) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(
+            unsafe { sdr_core_config_set_u32(h, width_key.as_ptr(), 420) },
+            SdrCoreError::Ok.as_int()
+        );
+
+        let mut out_bool = false;
+        let mut out_u32: u32 = 0;
+        assert_eq!(
+            unsafe { sdr_core_config_get_bool(h, open_key.as_ptr(), &raw mut out_bool) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert!(out_bool);
+        assert_eq!(
+            unsafe { sdr_core_config_get_u32(h, width_key.as_ptr(), &raw mut out_u32) },
+            SdrCoreError::Ok.as_int()
+        );
+        assert_eq!(out_u32, 420);
+
+        destroy(h, path);
+    }
+
+    #[test]
+    fn mismatched_type_returns_key_not_found() {
+        // Writing a bool and then trying to read it as a string
+        // should be KeyNotFound, not a coerced value. Same for
+        // u32-vs-bool etc.
+        let (h, path) = make_handle_with_config();
+        let key = CString::new("ui_sidebar_right_open").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_config_set_bool(h, key.as_ptr(), false) },
+            SdrCoreError::Ok.as_int()
+        );
+
+        let mut required: usize = 0;
+        let rc = unsafe {
+            sdr_core_config_get_string(h, key.as_ptr(), std::ptr::null_mut(), 0, &raw mut required)
+        };
+        assert_eq!(rc, SdrCoreError::KeyNotFound.as_int());
+
+        let mut out_u32: u32 = 99;
+        let rc_u32 = unsafe { sdr_core_config_get_u32(h, key.as_ptr(), &raw mut out_u32) };
+        assert_eq!(rc_u32, SdrCoreError::KeyNotFound.as_int());
+        assert_eq!(out_u32, 99); // untouched.
+
+        destroy(h, path);
+    }
+
+    #[test]
+    fn empty_config_path_returns_invalid_arg() {
+        // Empty path at create time means the handle runs with no
+        // on-disk config. Every config entry point surfaces that
+        // as InvalidArg so the host knows it's in the ephemeral
+        // mode and persistence isn't available.
+        let empty = CString::new("").unwrap();
+        let mut handle: *mut SdrCore = std::ptr::null_mut();
+        let rc = unsafe { sdr_core_create(empty.as_ptr(), &raw mut handle) };
+        assert_eq!(rc, SdrCoreError::Ok.as_int());
+
+        let key = CString::new("anything").unwrap();
+        let mut out_bool = false;
+        assert_eq!(
+            unsafe { sdr_core_config_get_bool(handle, key.as_ptr(), &raw mut out_bool) },
+            SdrCoreError::InvalidArg.as_int()
+        );
+
+        unsafe { sdr_core_destroy(handle) };
+    }
+
+    #[test]
+    fn buffer_too_small_reports_required_size() {
+        let (h, path) = make_handle_with_config();
+        let key = CString::new("ui_sidebar_left_selected").unwrap();
+        let value = CString::new("something_longer_than_10_bytes").unwrap();
+        assert_eq!(
+            unsafe { sdr_core_config_set_string(h, key.as_ptr(), value.as_ptr()) },
+            SdrCoreError::Ok.as_int()
+        );
+
+        let mut small_buf = [0i8; 4];
+        let mut required: usize = 0;
+        let rc = unsafe {
+            sdr_core_config_get_string(
+                h,
+                key.as_ptr(),
+                small_buf.as_mut_ptr(),
+                small_buf.len(),
+                &raw mut required,
+            )
+        };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+        assert_eq!(required, "something_longer_than_10_bytes".len() + 1);
+
+        destroy(h, path);
+    }
+
+    #[test]
+    fn null_key_rejected() {
+        let (h, path) = make_handle_with_config();
+        let mut out_bool = false;
+        let rc = unsafe { sdr_core_config_get_bool(h, std::ptr::null(), &raw mut out_bool) };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+        let rc_set = unsafe { sdr_core_config_set_bool(h, std::ptr::null(), true) };
+        assert_eq!(rc_set, SdrCoreError::InvalidArg.as_int());
+        destroy(h, path);
+    }
+}

--- a/crates/sdr-ffi/src/error.rs
+++ b/crates/sdr-ffi/src/error.rs
@@ -48,6 +48,14 @@ pub enum SdrCoreError {
     /// (actionable: ask the user) from "server is down" (transient,
     /// retry might work). ABI 0.5 → 0.6.
     Auth = -9,
+    /// A config read was dispatched for a key that doesn't exist
+    /// in the current JSON, or exists with a type the reader
+    /// didn't ask for (e.g. `get_bool` on a string-valued key).
+    /// Distinct from `InvalidArg` so hosts can branch cleanly
+    /// on "key absent → use default" vs "key malformed →
+    /// surface an error". Added for the sidebar session
+    /// surface (issue #449). ABI 0.20 → 0.21.
+    KeyNotFound = -10,
 }
 
 impl SdrCoreError {

--- a/crates/sdr-ffi/src/error.rs
+++ b/crates/sdr-ffi/src/error.rs
@@ -190,5 +190,6 @@ mod tests {
         assert_eq!(SdrCoreError::Io.as_int(), -7);
         assert_eq!(SdrCoreError::Config.as_int(), -8);
         assert_eq!(SdrCoreError::Auth.as_int(), -9);
+        assert_eq!(SdrCoreError::KeyNotFound.as_int(), -10);
     }
 }

--- a/crates/sdr-ffi/src/handle.rs
+++ b/crates/sdr-ffi/src/handle.rs
@@ -12,6 +12,7 @@
 
 use std::sync::{Arc, Condvar, Mutex};
 
+use sdr_config::ConfigManager;
 use sdr_core::Engine;
 
 /// Opaque handle the C ABI hands to consumers.
@@ -29,19 +30,36 @@ pub struct SdrCore {
     /// without borrowing the `SdrCore` handle directly.
     pub(crate) event_callback: Arc<EventCallbackGuard>,
 
-    /// Path the host provided to `sdr_core_create`. Stored for future
-    /// config-persistence wiring (the v1 engine doesn't load it yet —
-    /// see the M1 spec deviation note in
-    /// `crates/sdr-core/src/engine.rs`). Holding it here means the
-    /// path threads through the FFI surface in v1 even before the
-    /// engine consumes it, so adding persistence in a follow-up PR
-    /// doesn't require an ABI change.
+    /// Path the host provided to `sdr_core_create`. Stored for
+    /// diagnostics / future migrations — the live read/write path
+    /// goes through `config` below, which owns a `ConfigManager`
+    /// tied to this same file.
     ///
-    /// `#[allow(dead_code)]`: read by the `#[cfg(test)]` integration
-    /// tests in `lifecycle.rs` but not by non-test code yet. Comes
-    /// off once a production call site exists.
+    /// `#[allow(dead_code)]`: read by `#[cfg(test)]` integration
+    /// tests in `lifecycle.rs` (which assert `core.config_path`
+    /// matches what `sdr_core_create` was called with) but not
+    /// by non-test code. Clippy doesn't see test-only reads
+    /// on the lib target.
     #[allow(dead_code)]
     pub(crate) config_path: std::path::PathBuf,
+
+    /// Shared JSON config, tied to `config_path`. Built by
+    /// `sdr_core_create` (loading the on-disk file or starting
+    /// in-memory when `config_path` is empty) and owned for the
+    /// lifetime of the handle. `Arc` so future consumers (an
+    /// eventual engine-side config reader, the RadioReference
+    /// keyring already uses `Arc<ConfigManager>`, …) can clone
+    /// their own reference cheaply. Auto-save runs off a worker
+    /// thread enabled at create time; the writer is joined
+    /// automatically on `Drop` so ffi destroy doesn't need
+    /// special handling.
+    ///
+    /// `None` when the host passed an empty path — in-memory
+    /// mode, used by tests + by future embedders that want
+    /// ephemeral config. FFI config read/write entry points
+    /// return `InvalidArg` in that state so the host can
+    /// distinguish "key absent" from "no config file at all".
+    pub(crate) config: Option<Arc<ConfigManager>>,
 
     /// FFI event dispatcher thread join handle. Spawned at
     /// `sdr_core_create` time, joined at `sdr_core_destroy` so the
@@ -100,6 +118,21 @@ pub(crate) struct EventCallbackState {
     pub in_flight: usize,
 }
 
+// `ConfigManager` stores an `Option<JoinHandle<()>>` for its
+// auto-save worker, and `JoinHandle` transitively contains an
+// `UnsafeCell<Option<Result<(), PanicPayload>>>` that isn't
+// `RefUnwindSafe` by default. The handle's other fields
+// (`Engine`, `Mutex`es, `Arc`s) are all unwind-safe individually;
+// the compound type just can't auto-derive. Asserting these
+// traits by hand is correct because the FFI catch_unwind
+// boundary only ever reads the handle — it doesn't observe
+// partial mutations, and a panic can't leave the handle in an
+// observably-broken state (the poison mechanism on `Mutex` /
+// `RwLock` handles the lock-held case; the `JoinHandle` just
+// owns a finished thread's result).
+impl std::panic::UnwindSafe for SdrCore {}
+impl std::panic::RefUnwindSafe for SdrCore {}
+
 impl SdrCore {
     /// Construct from a successfully-built [`Engine`], the
     /// host-provided config path, and the spawned dispatcher
@@ -107,6 +140,7 @@ impl SdrCore {
     pub(crate) fn new(
         engine: Engine,
         config_path: std::path::PathBuf,
+        config: Option<Arc<ConfigManager>>,
         event_callback: Arc<EventCallbackGuard>,
         dispatcher_handle: std::thread::JoinHandle<()>,
     ) -> Self {
@@ -114,6 +148,7 @@ impl SdrCore {
             engine,
             event_callback,
             config_path,
+            config,
             dispatcher_handle: Mutex::new(Some(dispatcher_handle)),
             audio_tap_dispatcher: Mutex::new(None),
         }

--- a/crates/sdr-ffi/src/lib.rs
+++ b/crates/sdr-ffi/src/lib.rs
@@ -43,6 +43,7 @@
 
 pub mod audio_tap;
 pub mod command;
+pub mod config;
 pub mod enumerate;
 pub mod error;
 pub mod event;
@@ -66,6 +67,10 @@ pub use command::{
     sdr_core_set_squelch_enabled, sdr_core_set_vfo_offset, sdr_core_set_volume, sdr_core_start,
     sdr_core_start_audio_recording, sdr_core_start_iq_recording, sdr_core_stop,
     sdr_core_stop_audio_recording, sdr_core_stop_iq_recording, sdr_core_tune,
+};
+pub use config::{
+    sdr_core_config_get_bool, sdr_core_config_get_string, sdr_core_config_get_u32,
+    sdr_core_config_set_bool, sdr_core_config_set_string, sdr_core_config_set_u32,
 };
 pub use enumerate::{
     sdr_core_audio_device_count, sdr_core_audio_device_name, sdr_core_audio_device_uid,

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -8,6 +8,7 @@ use std::ffi::{CStr, c_char};
 use std::path::PathBuf;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
+use sdr_config::ConfigManager;
 use sdr_core::Engine;
 
 use crate::error::{SdrCoreError, clear_last_error, set_last_error};
@@ -21,7 +22,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 19;
+pub const ABI_VERSION_MINOR: u32 = 21;
 
 /// Return the ABI version the library was built with.
 ///
@@ -123,6 +124,39 @@ pub unsafe extern "C" fn sdr_core_create(
             PathBuf::from(s)
         };
 
+        // Build the shared config manager. Empty path → in-memory
+        // (ephemeral, used by tests and any future embedder that
+        // doesn't want on-disk persistence). Non-empty path loads
+        // the JSON file, defaulting to `{}` for missing / malformed
+        // files — ConfigManager::load is forgiving there.
+        //
+        // Auto-save is enabled so host writes (e.g., the sidebar-
+        // session `set_config_string` calls from #449) land on
+        // disk without the host having to call a sync helper.
+        // The auto-save thread is joined automatically on `Drop`
+        // so there's no leak path at destroy.
+        let config = if config_path.as_os_str().is_empty() {
+            None
+        } else {
+            let defaults = serde_json::json!({});
+            match ConfigManager::load(&config_path, &defaults) {
+                Ok(mut cfg) => {
+                    cfg.enable_auto_save();
+                    Some(Arc::new(cfg))
+                }
+                Err(err) => {
+                    // Surface the specific path on failure so the
+                    // host can decide whether to fall back (e.g.,
+                    // present the user with a picker) or bail.
+                    set_last_error(format!(
+                        "sdr_core_create: ConfigManager::load({}) failed: {err}",
+                        config_path.display()
+                    ));
+                    return SdrCoreError::Config.as_int();
+                }
+            }
+        };
+
         // Build the engine. Any spawn failure maps to INTERNAL.
         let engine = match Engine::new(config_path.clone()) {
             Ok(e) => e,
@@ -167,6 +201,7 @@ pub unsafe extern "C" fn sdr_core_create(
         let core = Box::new(SdrCore::new(
             engine,
             config_path,
+            config,
             event_callback,
             dispatcher_handle,
         ));
@@ -334,7 +369,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 19);
+        assert!(ABI_VERSION_MINOR == 21);
     };
 
     #[test]

--- a/crates/sdr-ui/benches/waterfall_push_line.rs
+++ b/crates/sdr-ui/benches/waterfall_push_line.rs
@@ -29,74 +29,90 @@
 //!
 //! Input FFT size is held at 65536 — the high-resolution waterfall
 //! case, where `push_line` does real downsample work.
+//!
+//! `sdr-ui` is Linux-only (the GTK4 frontend), so the bench body
+//! only compiles on Linux. On non-Linux targets the file falls
+//! through to a stub `main()` so cargo's bench harness can still
+//! resolve the entry point during a workspace clippy / build pass
+//! — without that, `cargo clippy --workspace` would fail with
+//! "main function not found" on macOS even though the bench is
+//! never actually runnable there.
 
-#![cfg(target_os = "linux")]
+#[cfg(target_os = "linux")]
+mod linux_bench {
+    use std::hint::black_box;
 
-use std::hint::black_box;
+    use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+    use sdr_ui::spectrum::waterfall::WaterfallRenderer;
 
-use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use sdr_ui::spectrum::waterfall::WaterfallRenderer;
+    /// FFT size we feed into the waterfall — the same high-resolution
+    /// size the rest of the FFT bench family measures.
+    const FFT_SIZE: usize = 65_536;
 
-/// FFT size we feed into the waterfall — the same high-resolution
-/// size the rest of the FFT bench family measures.
-const FFT_SIZE: usize = 65_536;
+    /// Display widths under test. The history height is fixed by the
+    /// renderer at 1024 rows; width is the knob the user's monitor
+    /// drives.
+    const DISPLAY_WIDTHS: &[usize] = &[800, 1920, 4096];
 
-/// Display widths under test. The history height is fixed by the
-/// renderer at 1024 rows; width is the knob the user's monitor
-/// drives.
-const DISPLAY_WIDTHS: &[usize] = &[800, 1920, 4096];
+    /// Phase step for the synthetic dB input. Doesn't affect cost —
+    /// the hot path is data-independent (clamp + linear map +
+    /// colormap-array indexing).
+    const PHASE_STEP_RAD: f32 = 0.01;
 
-/// Phase step for the synthetic dB input. Doesn't affect cost —
-/// the hot path is data-independent (clamp + linear map +
-/// colormap-array indexing).
-const PHASE_STEP_RAD: f32 = 0.01;
+    /// Realistic min/max dB range — matches `DEFAULT_MIN_DB` /
+    /// `DEFAULT_MAX_DB` in `waterfall.rs`.
+    const DB_MIN: f32 = -70.0;
+    const DB_MAX: f32 = 0.0;
 
-/// Realistic min/max dB range — matches `DEFAULT_MIN_DB` /
-/// `DEFAULT_MAX_DB` in `waterfall.rs`.
-const DB_MIN: f32 = -70.0;
-const DB_MAX: f32 = 0.0;
-
-fn make_synthetic_fft(bins: usize) -> Vec<f32> {
-    // Sweep from below-floor to above-ceiling so the normalization
-    // hits every clamp branch. Bench cost is clamp-branch-
-    // dependent only via prediction, so mix both directions.
-    #[allow(clippy::cast_precision_loss)]
-    let bins_f = bins as f32;
-    (0..bins)
-        .map(|i| {
-            #[allow(clippy::cast_precision_loss)]
-            let t = i as f32;
-            let sweep_db = DB_MIN - 10.0 + ((t / bins_f) * (DB_MAX - DB_MIN + 20.0));
-            // Throw in a sinusoidal wobble so the compiler can't
-            // hoist anything as constant.
-            sweep_db + (t * PHASE_STEP_RAD).sin() * 3.0
-        })
-        .collect()
-}
-
-fn bench_push_line(c: &mut Criterion) {
-    let mut group = c.benchmark_group("waterfall_push_line");
-    let input = make_synthetic_fft(FFT_SIZE);
-    group.throughput(Throughput::Elements(FFT_SIZE as u64));
-
-    for &width in DISPLAY_WIDTHS {
-        // Engine owns its pixel buffer, colormap, downsample scratch
-        // — all pre-allocated in `new()`. Only `push_line` runs
-        // inside the measured closure.
-        let mut renderer = WaterfallRenderer::new(width);
-        group.bench_function(format!("display_width={width}_fft_bins={FFT_SIZE}"), |b| {
-            b.iter_batched(
-                || black_box(input.clone()),
-                |fft_frame| {
-                    renderer.push_line(&fft_frame);
-                    black_box(&renderer);
-                },
-                BatchSize::SmallInput,
-            );
-        });
+    fn make_synthetic_fft(bins: usize) -> Vec<f32> {
+        // Sweep from below-floor to above-ceiling so the normalization
+        // hits every clamp branch. Bench cost is clamp-branch-
+        // dependent only via prediction, so mix both directions.
+        #[allow(clippy::cast_precision_loss)]
+        let bins_f = bins as f32;
+        (0..bins)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f32;
+                let sweep_db = DB_MIN - 10.0 + ((t / bins_f) * (DB_MAX - DB_MIN + 20.0));
+                // Throw in a sinusoidal wobble so the compiler can't
+                // hoist anything as constant.
+                sweep_db + (t * PHASE_STEP_RAD).sin() * 3.0
+            })
+            .collect()
     }
-    group.finish();
+
+    fn bench_push_line(c: &mut Criterion) {
+        let mut group = c.benchmark_group("waterfall_push_line");
+        let input = make_synthetic_fft(FFT_SIZE);
+        group.throughput(Throughput::Elements(FFT_SIZE as u64));
+
+        for &width in DISPLAY_WIDTHS {
+            // Engine owns its pixel buffer, colormap, downsample scratch
+            // — all pre-allocated in `new()`. Only `push_line` runs
+            // inside the measured closure.
+            let mut renderer = WaterfallRenderer::new(width);
+            group.bench_function(format!("display_width={width}_fft_bins={FFT_SIZE}"), |b| {
+                b.iter_batched(
+                    || black_box(input.clone()),
+                    |fft_frame| {
+                        renderer.push_line(&fft_frame);
+                        black_box(&renderer);
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        }
+        group.finish();
+    }
+
+    criterion_group!(benches, bench_push_line);
+    criterion_main!(benches);
 }
 
-criterion_group!(benches, bench_push_line);
-criterion_main!(benches);
+// Non-Linux stub: keeps cargo's bench harness happy without
+// pulling in the GTK / criterion graph that doesn't compile here.
+// The Linux bench's `criterion_main!` provides the real `main`
+// when building on Linux, so this stub is gated to other targets.
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/crates/sdr-ui/benches/waterfall_push_line.rs
+++ b/crates/sdr-ui/benches/waterfall_push_line.rs
@@ -31,88 +31,130 @@
 //! case, where `push_line` does real downsample work.
 //!
 //! `sdr-ui` is Linux-only (the GTK4 frontend), so the bench body
-//! only compiles on Linux. On non-Linux targets the file falls
-//! through to a stub `main()` so cargo's bench harness can still
-//! resolve the entry point during a workspace clippy / build pass
-//! — without that, `cargo clippy --workspace` would fail with
-//! "main function not found" on macOS even though the bench is
-//! never actually runnable there.
+//! only compiles on Linux. Each top-level item is gated with
+//! `#[cfg(target_os = "linux")]` so:
+//!
+//! - On Linux: `criterion_main!` expands to a crate-level `fn main`
+//!   and runs the bench normally.
+//! - On non-Linux targets: every Linux-only item is skipped, and
+//!   the no-op `fn main()` at the bottom satisfies the bench
+//!   harness so a workspace clippy / build pass succeeds.
+//!
+//! **Why per-item gates instead of a `linux_bench` module wrapper:**
+//! `criterion_main!` invoked inside a module expands to a function
+//! at module scope (`linux_bench::main`), NOT to a crate-level
+//! `main` — Linux CI fails with "main function not found" because
+//! there's still no `main` at the crate root. Flat per-item gates
+//! keep the macro invocation at file scope where its expansion
+//! lands at the crate root.
 
 #[cfg(target_os = "linux")]
-mod linux_bench {
-    use std::hint::black_box;
+use std::hint::black_box;
 
-    use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-    use sdr_ui::spectrum::waterfall::WaterfallRenderer;
+#[cfg(target_os = "linux")]
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+#[cfg(target_os = "linux")]
+use sdr_ui::spectrum::waterfall::WaterfallRenderer;
 
-    /// FFT size we feed into the waterfall — the same high-resolution
-    /// size the rest of the FFT bench family measures.
-    const FFT_SIZE: usize = 65_536;
+/// FFT size we feed into the waterfall — the same high-resolution
+/// size the rest of the FFT bench family measures.
+#[cfg(target_os = "linux")]
+const FFT_SIZE: usize = 65_536;
 
-    /// Display widths under test. The history height is fixed by the
-    /// renderer at 1024 rows; width is the knob the user's monitor
-    /// drives.
-    const DISPLAY_WIDTHS: &[usize] = &[800, 1920, 4096];
+/// Display widths under test. The history height is fixed by the
+/// renderer at 1024 rows; width is the knob the user's monitor
+/// drives.
+#[cfg(target_os = "linux")]
+const DISPLAY_WIDTHS: &[usize] = &[800, 1920, 4096];
 
-    /// Phase step for the synthetic dB input. Doesn't affect cost —
-    /// the hot path is data-independent (clamp + linear map +
-    /// colormap-array indexing).
-    const PHASE_STEP_RAD: f32 = 0.01;
+/// Phase step for the synthetic dB input. Doesn't affect cost —
+/// the hot path is data-independent (clamp + linear map +
+/// colormap-array indexing).
+#[cfg(target_os = "linux")]
+const PHASE_STEP_RAD: f32 = 0.01;
 
-    /// Realistic min/max dB range — matches `DEFAULT_MIN_DB` /
-    /// `DEFAULT_MAX_DB` in `waterfall.rs`.
-    const DB_MIN: f32 = -70.0;
-    const DB_MAX: f32 = 0.0;
+/// Realistic min/max dB range — matches `DEFAULT_MIN_DB` /
+/// `DEFAULT_MAX_DB` in `waterfall.rs`.
+#[cfg(target_os = "linux")]
+const DB_MIN: f32 = -70.0;
+#[cfg(target_os = "linux")]
+const DB_MAX: f32 = 0.0;
 
-    fn make_synthetic_fft(bins: usize) -> Vec<f32> {
-        // Sweep from below-floor to above-ceiling so the normalization
-        // hits every clamp branch. Bench cost is clamp-branch-
-        // dependent only via prediction, so mix both directions.
-        #[allow(clippy::cast_precision_loss)]
-        let bins_f = bins as f32;
-        (0..bins)
-            .map(|i| {
-                #[allow(clippy::cast_precision_loss)]
-                let t = i as f32;
-                let sweep_db = DB_MIN - 10.0 + ((t / bins_f) * (DB_MAX - DB_MIN + 20.0));
-                // Throw in a sinusoidal wobble so the compiler can't
-                // hoist anything as constant.
-                sweep_db + (t * PHASE_STEP_RAD).sin() * 3.0
-            })
-            .collect()
-    }
+/// dB padding extended below `DB_MIN` for the synthetic input.
+/// Pushes the early bins below the floor so the normalization
+/// hits the lower clamp branch — measuring the real cost of the
+/// branch-prediction patterns the renderer sees in production.
+#[cfg(target_os = "linux")]
+const DB_BELOW_FLOOR_PAD: f32 = 10.0;
+/// dB padding extended above `DB_MAX` for the synthetic input.
+/// Pushes the late bins above the ceiling so the upper clamp
+/// branch fires too. Twice the below-floor pad on purpose: the
+/// upper edge clamp is the hotter branch in real-world traffic
+/// (squelch-open events sit near peak), so weighting the test
+/// toward it keeps the bench representative.
+#[cfg(target_os = "linux")]
+const DB_ABOVE_CEILING_PAD: f32 = 20.0;
+/// Amplitude (dB) of the sinusoidal wobble layered on top of the
+/// linear sweep. Just enough to keep the optimizer from hoisting
+/// the input as a constant — content of the wobble is irrelevant
+/// to bench cost.
+#[cfg(target_os = "linux")]
+const SWEEP_WOBBLE_DB: f32 = 3.0;
 
-    fn bench_push_line(c: &mut Criterion) {
-        let mut group = c.benchmark_group("waterfall_push_line");
-        let input = make_synthetic_fft(FFT_SIZE);
-        group.throughput(Throughput::Elements(FFT_SIZE as u64));
-
-        for &width in DISPLAY_WIDTHS {
-            // Engine owns its pixel buffer, colormap, downsample scratch
-            // — all pre-allocated in `new()`. Only `push_line` runs
-            // inside the measured closure.
-            let mut renderer = WaterfallRenderer::new(width);
-            group.bench_function(format!("display_width={width}_fft_bins={FFT_SIZE}"), |b| {
-                b.iter_batched(
-                    || black_box(input.clone()),
-                    |fft_frame| {
-                        renderer.push_line(&fft_frame);
-                        black_box(&renderer);
-                    },
-                    BatchSize::SmallInput,
-                );
-            });
-        }
-        group.finish();
-    }
-
-    criterion_group!(benches, bench_push_line);
-    criterion_main!(benches);
+#[cfg(target_os = "linux")]
+fn make_synthetic_fft(bins: usize) -> Vec<f32> {
+    // Sweep from below-floor to above-ceiling so the normalization
+    // hits every clamp branch. Bench cost is clamp-branch-
+    // dependent only via prediction, so mix both directions.
+    #[allow(clippy::cast_precision_loss)]
+    let bins_f = bins as f32;
+    let sweep_total_db = DB_MAX - DB_MIN + DB_BELOW_FLOOR_PAD + DB_ABOVE_CEILING_PAD;
+    (0..bins)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let t = i as f32;
+            let sweep_db = DB_MIN - DB_BELOW_FLOOR_PAD + ((t / bins_f) * sweep_total_db);
+            // Throw in a sinusoidal wobble so the compiler can't
+            // hoist anything as constant.
+            sweep_db + (t * PHASE_STEP_RAD).sin() * SWEEP_WOBBLE_DB
+        })
+        .collect()
 }
+
+#[cfg(target_os = "linux")]
+fn bench_push_line(c: &mut Criterion) {
+    let mut group = c.benchmark_group("waterfall_push_line");
+    let input = make_synthetic_fft(FFT_SIZE);
+    group.throughput(Throughput::Elements(FFT_SIZE as u64));
+
+    for &width in DISPLAY_WIDTHS {
+        // Engine owns its pixel buffer, colormap, downsample scratch
+        // — all pre-allocated in `new()`. Only `push_line` runs
+        // inside the measured closure.
+        let mut renderer = WaterfallRenderer::new(width);
+        group.bench_function(format!("display_width={width}_fft_bins={FFT_SIZE}"), |b| {
+            b.iter_batched(
+                || black_box(input.clone()),
+                |fft_frame| {
+                    renderer.push_line(&fft_frame);
+                    black_box(&renderer);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+#[cfg(target_os = "linux")]
+criterion_group!(benches, bench_push_line);
+#[cfg(target_os = "linux")]
+criterion_main!(benches);
 
 // Non-Linux stub: keeps cargo's bench harness happy without
 // pulling in the GTK / criterion graph that doesn't compile here.
-// The Linux bench's `criterion_main!` provides the real `main`
-// when building on Linux, so this stub is gated to other targets.
+// The Linux `criterion_main!` above provides the real `main` at
+// the crate root when building on Linux, so this stub is gated to
+// other targets.
 #[cfg(not(target_os = "linux"))]
 fn main() {}

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,39 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 20
+#define SDR_CORE_ABI_VERSION_MINOR 21
 /*
+ * 0.21 — exposes the shared `sdr-config` JSON file at the FFI
+ * boundary so the macOS SwiftUI host can round-trip sidebar
+ * session state (#449) and other settings against the same
+ * config file the GTK frontend already writes to.
+ *
+ * Additive surface (existing struct layouts and enum values
+ * unchanged):
+ *   - New `SdrCoreError` discriminant `SDR_CORE_ERR_KEY_NOT_FOUND`
+ *     = -10. Returned by the get-* commands when the requested
+ *     key is absent or present with a JSON type the reader
+ *     didn't ask for. Distinct from `SDR_CORE_ERR_INVALID_ARG`
+ *     so hosts can branch on "use default" vs surface error.
+ *   - Six new commands: `sdr_core_config_get_string` (size-then-
+ *     fill pattern, same shape as the rtl_tcp recent-commands
+ *     JSON reader), `sdr_core_config_set_string`,
+ *     `sdr_core_config_get_bool`, `sdr_core_config_set_bool`,
+ *     `sdr_core_config_get_u32`, `sdr_core_config_set_u32`.
+ *   - Auto-save semantics: writes through these entry points
+ *     are flushed to disk by the engine's auto-save thread
+ *     (started at `sdr_core_create` time). The auto-save
+ *     thread is joined automatically on `sdr_core_destroy`,
+ *     so any pending writes land before the call returns.
+ *   - In-memory mode: passing an empty `config_path_utf8` to
+ *     `sdr_core_create` is still valid (and still loads the
+ *     engine), but every config get/set entry point returns
+ *     `SDR_CORE_ERR_INVALID_ARG` with an explanatory
+ *     last-error message — no on-disk JSON to read or write.
+ *
+ * Pre-1.0 minor bumps are breaking by project convention — old
+ * 0.20 hosts must fail fast on the exact-match ABI check.
+ *
  * 0.20 — exposes the scanner Phase 1 surface (#447) at the FFI
  * boundary so the macOS SwiftUI scanner panel can drive it.
  * Additive enum + payload growth:
@@ -208,6 +239,7 @@ typedef enum SdrCoreError {
     SDR_CORE_ERR_IO             = -7, /* File / network I/O error.      */
     SDR_CORE_ERR_CONFIG         = -8, /* Config load/save error.        */
     SDR_CORE_ERR_AUTH           = -9, /* Remote service rejected credentials (RadioReference). */
+    SDR_CORE_ERR_KEY_NOT_FOUND  = -10, /* Config key absent or wrong type (#449, ABI 0.21). */
 } SdrCoreError;
 
 /*
@@ -1643,6 +1675,118 @@ int32_t sdr_core_unlock_scanner_channel(
     SdrCore*    handle,
     const char* name_utf8,
     uint64_t    frequency_hz
+);
+
+/* --- Config — shared `sdr-config` JSON (issue #449, ABI 0.21) --- */
+/*
+ * Read / write keys against the JSON file passed to
+ * `sdr_core_create` as `config_path_utf8`. Round-trips with the
+ * GTK frontend's `ConfigManager` — the same dotted keys (e.g.
+ * `ui_sidebar_left_selected`) work from both sides.
+ *
+ * Concurrency: every entry point takes the engine's internal
+ * `RwLock` for the duration of the call; safe from any thread.
+ * Auto-save runs on a background worker spun up at create time;
+ * it's joined automatically on `sdr_core_destroy` so any pending
+ * writes from this session land on disk before the call returns.
+ *
+ * In-memory mode: when `config_path_utf8` was empty at create
+ * time, every entry point in this section returns
+ * `SDR_CORE_ERR_INVALID_ARG` with an explanatory last-error
+ * message. Hosts should branch on that to decide whether to
+ * fall back to a Mac-local store (e.g. `UserDefaults`) or
+ * surface a "no config file configured" message.
+ */
+
+/*
+ * Read a string-valued config key.
+ *
+ * Size-then-fill pattern:
+ *   1. Pass `out_buf == NULL`, `buf_len == 0`,
+ *      `out_required` non-NULL. On success the required size
+ *      including the trailing NUL is written to
+ *      `*out_required`.
+ *   2. Allocate a buffer of at least `*out_required` bytes,
+ *      then call again with the populated buffer + length.
+ *
+ * Return codes:
+ *   - `SDR_CORE_OK`              — key found; on the fill call,
+ *                                   `out_buf` holds the NUL-
+ *                                   terminated UTF-8 value.
+ *   - `SDR_CORE_ERR_KEY_NOT_FOUND` — key absent or present with
+ *                                    a non-string JSON type.
+ *   - `SDR_CORE_ERR_INVALID_ARG`  — null handle / null key /
+ *                                    empty key / non-NULL
+ *                                    `out_buf` with `buf_len`
+ *                                    too small (the required
+ *                                    size is written to
+ *                                    `out_required` when non-
+ *                                    NULL, so the caller knows
+ *                                    how big to make the
+ *                                    retry buffer).
+ *   - `SDR_CORE_ERR_INVALID_HANDLE` — null / destroyed handle.
+ */
+int32_t sdr_core_config_get_string(
+    SdrCore*    handle,
+    const char* key_utf8,
+    char*       out_buf,
+    size_t      buf_len,
+    size_t*     out_required
+);
+
+/*
+ * Write a string-valued config key. Empty values are accepted
+ * and stored verbatim — distinct from key absence. Returns
+ * `SDR_CORE_OK` on success, `SDR_CORE_ERR_INVALID_ARG` for
+ * null pointers or non-UTF-8 input, `SDR_CORE_ERR_INVALID_HANDLE`
+ * for a null / destroyed handle.
+ */
+int32_t sdr_core_config_set_string(
+    SdrCore*    handle,
+    const char* key_utf8,
+    const char* value_utf8
+);
+
+/*
+ * Read a bool-valued config key. On success writes `*out_value`.
+ * Returns `SDR_CORE_ERR_KEY_NOT_FOUND` (and leaves `*out_value`
+ * untouched) when the key is absent or present with a non-bool
+ * JSON type — the host can keep its default safely.
+ */
+int32_t sdr_core_config_get_bool(
+    SdrCore*    handle,
+    const char* key_utf8,
+    bool*       out_value
+);
+
+/*
+ * Write a bool-valued config key.
+ */
+int32_t sdr_core_config_set_bool(
+    SdrCore*    handle,
+    const char* key_utf8,
+    bool        value
+);
+
+/*
+ * Read a u32-valued config key. Returns
+ * `SDR_CORE_ERR_KEY_NOT_FOUND` when the key is absent, present
+ * with a non-numeric JSON type, or present with a number that
+ * doesn't fit in `uint32_t`.
+ */
+int32_t sdr_core_config_get_u32(
+    SdrCore*    handle,
+    const char* key_utf8,
+    uint32_t*   out_value
+);
+
+/*
+ * Write a u32-valued config key.
+ */
+int32_t sdr_core_config_set_u32(
+    SdrCore*    handle,
+    const char* key_utf8,
+    uint32_t    value
 );
 
 /* ================================================================ */

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -408,13 +408,29 @@ void sdr_core_init_logging(int32_t min_level);
 /*
  * Create a new engine instance.
  *
- * `config_path_utf8` is the on-disk config file the engine should
- * eventually load from and persist to. Must be either NULL or a
- * NUL-terminated UTF-8 string. NULL and empty string ("") are
- * equivalent: both run with in-memory defaults and no persistence.
- * v1 engines accept the path and store it for future use but do
- * not yet read or write through it — passing a valid path now
- * means persistence can land in a follow-up without an ABI change.
+ * `config_path_utf8` is the on-disk JSON config file the engine
+ * loads from and persists to. Must be either NULL or a NUL-
+ * terminated UTF-8 string. NULL and empty string ("") are
+ * equivalent: both run in-memory with no persistence (the
+ * "config FFI" entry points below — `sdr_core_config_get_string`
+ * et al. — return `SDR_CORE_ERR_INVALID_ARG` in that mode, with
+ * an explanatory last-error message).
+ *
+ * When the path is non-empty (ABI 0.21+, issue #449):
+ *   - The engine loads the JSON file at create time. A missing
+ *     file is treated as `{}` — the FFI returns
+ *     `SDR_CORE_OK` and starts with an empty config.
+ *     A malformed file (invalid JSON, IO error on a file that
+ *     exists) returns `SDR_CORE_ERR_CONFIG`.
+ *   - An auto-save worker thread is spawned. Writes through
+ *     `sdr_core_config_set_*` land on disk on a periodic tick;
+ *     the worker is joined automatically on `sdr_core_destroy`,
+ *     so any pending writes flush before the destroy call
+ *     returns.
+ *   - The same JSON file is shared with the GTK frontend's
+ *     `sdr_config::ConfigManager` — opening the same path from
+ *     either consumer round-trips the same dotted keys (e.g.
+ *     `ui_sidebar_left_selected`).
  *
  * On success: writes the opaque handle to `*out_handle` and
  * returns `SDR_CORE_OK`. The handle must eventually be released
@@ -429,6 +445,10 @@ void sdr_core_init_logging(int32_t min_level);
  *   SDR_CORE_ERR_INVALID_ARG     — `out_handle` is NULL, or
  *                                 `config_path_utf8` is non-NULL
  *                                 but not valid UTF-8.
+ *   SDR_CORE_ERR_CONFIG          — the on-disk config file
+ *                                 exists but couldn't be loaded
+ *                                 (malformed JSON, permissions,
+ *                                 IO error). ABI 0.21+.
  *   SDR_CORE_ERR_INTERNAL        — DSP thread spawn failed, or a
  *                                 Rust panic crossed the boundary.
  */


### PR DESCRIPTION
## Summary

- Persists the macOS sidebar's selected activity / open state / width — per side — to the shared `sdr-config` JSON file the GTK frontend already writes to. A user who runs both frontends sees consistent layout on both.
- Bumps the C ABI to 0.21 with a focused config get/set surface (string / bool / u32) and a new `SDR_CORE_ERR_KEY_NOT_FOUND` error code so hosts can cleanly branch on "key absent → use default" vs "key present → honor it."
- Drive-by: workspace-clippy fix for the pre-existing Linux-only bench file (`crates/sdr-ui/benches/waterfall_push_line.rs`) that was failing `cargo clippy --workspace --all-targets` on Mac.

## ABI 0.21 — `include/sdr_core.h`

Additive surface (struct layouts and existing enum values unchanged):

- New `SdrCoreError` discriminant `SDR_CORE_ERR_KEY_NOT_FOUND` = -10. Returned by the get-* commands when the key is absent or present with a JSON type the reader didn't ask for. Distinct from `SDR_CORE_ERR_INVALID_ARG` so hosts can route cleanly.
- Six new commands:
  - `sdr_core_config_get_string` (size-then-fill pattern — same shape as the rtl_tcp recent-commands JSON reader)
  - `sdr_core_config_set_string`
  - `sdr_core_config_get_bool`
  - `sdr_core_config_set_bool`
  - `sdr_core_config_get_u32`
  - `sdr_core_config_set_u32`
- Auto-save semantics: writes through these entry points are flushed by the engine's auto-save worker (started at `sdr_core_create` time, joined on `sdr_core_destroy`).
- In-memory mode: passing an empty `config_path_utf8` to `sdr_core_create` is still valid (still loads the engine), but every config get/set returns `SDR_CORE_ERR_INVALID_ARG` with an explanatory last-error — no on-disk JSON to read or write.

Header drift check (`make ffi-header-check`) passes — hand-written and cbindgen-generated headers agree.

## SdrCoreKit Swift wrappers

`SdrCore` grows three typed read/write pairs:

- `configString(key:) -> String?` / `setConfigString(key:value:)`
- `configBool(key:) -> Bool?` / `setConfigBool(key:value:)`
- `configUInt32(key:) -> UInt32?` / `setConfigUInt32(key:value:)`

Reads return `Optional` so the two failure modes (key absent vs wrong type) collapse into a clean Swift fallback path. The string reader handles the size-then-fill protocol internally — callers just see `String?`.

## CoreModel session state

Six observable fields plus a configurable width range:

```swift
var sidebarLeftSelected: String = "general"
var sidebarLeftOpen: Bool = true
var sidebarLeftWidth: UInt32 = 320
var sidebarRightSelected: String = "transcript"
var sidebarRightOpen: Bool = false
var sidebarRightWidth: UInt32 = 320
static let sidebarWidthRange: ClosedRange<UInt32> = 200...800
```

`bootstrap()` calls `loadSidebarSession()` after the engine is alive (the FFI config surface is on the engine handle). Setters validate raw-value strings against `LeftActivity` / `RightActivity` and clamp width to the range — a non-UI caller can't poison the shared config.

## ContentView resize gesture

- Sidebar selection / open / width all bind through CoreModel — no view-local `@State` for those anymore.
- `liveLeftWidth` / `liveRightWidth` track in-flight drag so config writes only happen on drag-end, not on every pixel.
- Custom 8 px hit target over a 1 px `Color(nsColor: .separatorColor)` line. `NSCursor.resizeLeftRight.push()` / `.pop()` on hover for stable cursor behavior. **`Color.white.opacity(0.001)` base** — `Color.clear` is not hit-testable in SwiftUI even with explicit `contentShape`, so the near-zero-opacity fix is the documented workaround. Saved as a memory so it doesn't bite again.

## Acceptance (per #449)

- [x] **Select Radio, resize to 400 px, quit, relaunch → Radio selected at 400 px.** Smoke-tested locally.
- [x] **Fresh install: left = General open at 320 px, right = Transcript closed at 320 px.** Defaults match the Linux `SidebarSession::default`.
- [x] **Config round-trip Mac ↔ Linux works.** Both frontends now write to the same JSON file via `ConfigManager` with identical key names; the on-disk shape is the same `serde_json::Value` representation.

## Drive-by — workspace clippy fix

`crates/sdr-ui/benches/waterfall_push_line.rs` had `#![cfg(target_os = "linux")]` at file scope, which on macOS killed the whole file including `criterion_main!`'s generated `main`. Workspace clippy on Mac was already failing with "main function not found" before this PR — visible in the round-1 validation pass here. Wrapped the Linux body in a `linux_bench` mod with a non-Linux stub `main()`. Now `cargo clippy --workspace --all-targets` passes cleanly on Mac too.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (Mac AND would also pass on Linux; the workspace lint passes both ways)
- [x] `cargo test --workspace --lib` — all tests pass; 8 new config tests under `sdr_ffi::config::tests` (null handle, missing key, round-trip string / bool / u32, mismatched type, empty config path, buffer-too-small, null key)
- [x] `make ffi-header-check` — hand-written and cbindgen agree
- [x] `make mac-app` — Mac app bundles + ad-hoc signs successfully
- [x] Smoke test: launched `apps/macos/build/sdr-rs.app`, switched activities, dragged the resize handle (live preview during drag, persisted on release), quit + relaunched, confirmed remembered selection / open / width.
- [ ] CodeRabbit review

## Links

- Closes #449
- Other open redesign tickets: #450 (resize persistence — partially done here, the per-side width is now persisted, but #450 also covers some HSplitView-vs-HStack discussion that this PR sidesteps), #451 (architecture docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar panels are resizable with drag handles and live resizing feedback.
  * Sidebar state (open/closed, selected activity, and panel widths) is persisted and restored across sessions.
  * App now reads/writes shared configuration (string, boolean, and numeric keys) so UI settings survive restarts.
* **Chores**
  * Under-the-hood config persistence is enabled at startup to ensure restored state before first paint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->