### PR TITLE
SwiftUI: per-side sidebar ranges + double-click reset (closes #450)

### DIFF
--- a/apps/macos/SDRMac/ContentView.swift
+++ b/apps/macos/SDRMac/ContentView.swift
@@ -246,6 +246,13 @@ struct ContentView: View {
         let baseWidth: CGFloat = side == .left
             ? CGFloat(model.sidebarLeftWidth)
             : CGFloat(model.sidebarRightWidth)
+        // Per-side clamp range — left 220..=640, right 360..=840
+        // per the spec for #450. The model's setters clamp to
+        // these too; doing it during the drag also keeps the
+        // live preview inside the visible bounds.
+        let range: ClosedRange<Int> = side == .left
+            ? CoreModel.sidebarLeftWidthRange
+            : CoreModel.sidebarRightWidthRange
         // 8 px of draggable strip centered on the 1 px divider.
         // Wider than the divider so the hit target is forgiving
         // — matches macOS's own HSplitView separator feel.
@@ -273,8 +280,22 @@ struct ContentView: View {
                     NSCursor.pop()
                 }
             }
+            // Double-click → reset to the side's default width.
+            // Per the spec for #450. The tap gesture has higher
+            // priority than the drag so a fast double-click
+            // doesn't get interpreted as a zero-distance drag.
+            .onTapGesture(count: 2) {
+                switch side {
+                case .left:
+                    liveLeftWidth = nil
+                    model.setSidebarLeftWidth(CoreModel.sidebarLeftDefaultWidth)
+                case .right:
+                    liveRightWidth = nil
+                    model.setSidebarRightWidth(CoreModel.sidebarRightDefaultWidth)
+                }
+            }
             .gesture(
-                DragGesture(minimumDistance: 0)
+                DragGesture(minimumDistance: 1)
                     .onChanged { value in
                         let delta = value.translation.width
                         let next: CGFloat
@@ -284,11 +305,8 @@ struct ContentView: View {
                         case .right:
                             next = baseWidth - delta
                         }
-                        // Clamp to the model's configured range
-                        // so the live preview stays inside the
-                        // visible bounds (setter clamps too).
-                        let lo = CGFloat(CoreModel.sidebarWidthRange.lowerBound)
-                        let hi = CGFloat(CoreModel.sidebarWidthRange.upperBound)
+                        let lo = CGFloat(range.lowerBound)
+                        let hi = CGFloat(range.upperBound)
                         let clamped = min(max(next, lo), hi)
                         switch side {
                         case .left: liveLeftWidth = clamped

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -2672,10 +2672,13 @@ final class CoreModel {
     //  the Linux activity-bar entry names — same source of
     //  truth).
     //
-    //  Default values match the Linux `SidebarSession::default`:
-    //  left = General open at 320 px, right = Transcript closed
-    //  at 320 px. The 320 px width matches the GTK
-    //  `DEFAULT_SIDEBAR_WIDTH_PX` constant.
+    //  Default values per the spec for #450 and the Linux
+    //  `SidebarSession::default`: left = General, open, 320 px;
+    //  right = Transcript, closed, 420 px. The right default is
+    //  wider than the left because the right side hosts content-
+    //  heavy panels (Transcript / Bookmarks) that read better
+    //  with extra room — same rationale captured on the per-side
+    //  range constants below.
     //
     //  These fields are observable @Observable storage so
     //  ContentView can bind through them (and the activity bar /

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -2721,25 +2721,43 @@ final class CoreModel {
     static let sidebarRightOpenKey = "ui_sidebar_right_open"
     static let sidebarRightWidthKey = "ui_sidebar_right_width_px"
 
-    /// Per-side clamp ranges + defaults, matching the spec for
-    /// #450. Different floors and ceilings on each side reflect
-    /// what the panels need to render usefully — left holds a
-    /// `Form` with grouped sections (220 px is the minimum that
-    /// keeps the labels readable), right holds Transcript /
-    /// Bookmarks list views (360 px is the minimum that keeps
-    /// timestamps + content side-by-side without truncation).
-    /// Upper ceilings prevent a single panel from monopolising
-    /// the window.
+    /// Allowed clamp range for the left sidebar's width (px).
+    /// 220 px is the minimum that keeps the panel's `Form`
+    /// section labels readable; 640 px stops a single panel
+    /// from monopolising the window. Matches the Linux
+    /// `LEFT_PANEL_MIN_PX` / `_MAX_PX` constants in
+    /// `crates/sdr-ui/src/sidebar/activity_bar.rs`. Used by
+    /// `setSidebarLeftWidth(_:)` for runtime clamps and by
+    /// the `loadSidebarSession()` restore for validating
+    /// persisted values.
     ///
-    /// Ranges live as `Int` rather than `UInt32` because both
+    /// Stored as `Int` rather than `UInt32` because both
     /// AppKit (`NSSplitView` constraints) and SwiftUI's
     /// `.frame(minWidth:maxWidth:)` modifier take `CGFloat`,
     /// and the conversion path is simpler from `Int`. The
-    /// model still stores width as `UInt32` because the
+    /// model still persists width as `UInt32` because the
     /// shared `sdr-config` file uses unsigned ints there.
     static let sidebarLeftWidthRange: ClosedRange<Int> = 220...640
+
+    /// Allowed clamp range for the right sidebar's width (px).
+    /// 360 px is the minimum that keeps Transcript /
+    /// Bookmarks list rows from truncating timestamps+content;
+    /// 840 px is the upper ceiling. Same Linux-parity
+    /// rationale as `sidebarLeftWidthRange`.
     static let sidebarRightWidthRange: ClosedRange<Int> = 360...840
+
+    /// Default width applied on a fresh install, on a
+    /// double-click reset of the left handle, and as the seed
+    /// value for the `sidebarLeftWidth` observable property.
+    /// Matches the Linux `DEFAULT_SIDEBAR_WIDTH_PX` constant.
     static let sidebarLeftDefaultWidth: UInt32 = 320
+
+    /// Default width applied on a fresh install, on a
+    /// double-click reset of the right handle, and as the seed
+    /// value for the `sidebarRightWidth` observable property.
+    /// Wider than the left default because the right side
+    /// hosts content-heavy panels (Transcript / Bookmarks)
+    /// that read better with extra room.
     static let sidebarRightDefaultWidth: UInt32 = 420
 
     /// Restore all six sidebar fields from the shared config.

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -2692,16 +2692,21 @@ final class CoreModel {
     var sidebarLeftSelected: String = "general"
     /// Whether the left panel is currently visible.
     var sidebarLeftOpen: Bool = true
-    /// Width of the left panel in pixels.
-    var sidebarLeftWidth: UInt32 = 320
+    /// Width of the left panel in pixels. Default matches the
+    /// Linux `DEFAULT_SIDEBAR_WIDTH_PX` constant; the per-side
+    /// clamp range below is the spec's floor/ceiling pair.
+    var sidebarLeftWidth: UInt32 = sidebarLeftDefaultWidth
 
     /// Activity selected in the right sidebar — one of the
     /// `RightActivity` raw values.
     var sidebarRightSelected: String = "transcript"
     /// Whether the right panel is currently visible.
     var sidebarRightOpen: Bool = false
-    /// Width of the right panel in pixels.
-    var sidebarRightWidth: UInt32 = 320
+    /// Width of the right panel in pixels. Default is wider than
+    /// the left because the right side hosts content-heavy
+    /// panels (Transcript / Bookmarks) that read better with
+    /// extra room.
+    var sidebarRightWidth: UInt32 = sidebarRightDefaultWidth
 
     /// Config keys — match the Linux constants in
     /// `crates/sdr-ui/src/sidebar/activity_bar.rs` exactly so a
@@ -2713,13 +2718,26 @@ final class CoreModel {
     static let sidebarRightOpenKey = "ui_sidebar_right_open"
     static let sidebarRightWidthKey = "ui_sidebar_right_width_px"
 
-    /// Hard floor / ceiling for sidebar widths (pixels). The
-    /// GTK side tolerates anything but applies a sane minimum
-    /// in its split-view handler; we mirror that here so a
-    /// hand-edited config can't hand the SwiftUI HSplitView a
-    /// degenerate width that collapses the panel beyond the
-    /// drag-back-out threshold.
-    static let sidebarWidthRange: ClosedRange<UInt32> = 200...800
+    /// Per-side clamp ranges + defaults, matching the spec for
+    /// #450. Different floors and ceilings on each side reflect
+    /// what the panels need to render usefully — left holds a
+    /// `Form` with grouped sections (220 px is the minimum that
+    /// keeps the labels readable), right holds Transcript /
+    /// Bookmarks list views (360 px is the minimum that keeps
+    /// timestamps + content side-by-side without truncation).
+    /// Upper ceilings prevent a single panel from monopolising
+    /// the window.
+    ///
+    /// Ranges live as `Int` rather than `UInt32` because both
+    /// AppKit (`NSSplitView` constraints) and SwiftUI's
+    /// `.frame(minWidth:maxWidth:)` modifier take `CGFloat`,
+    /// and the conversion path is simpler from `Int`. The
+    /// model still stores width as `UInt32` because the
+    /// shared `sdr-config` file uses unsigned ints there.
+    static let sidebarLeftWidthRange: ClosedRange<Int> = 220...640
+    static let sidebarRightWidthRange: ClosedRange<Int> = 360...840
+    static let sidebarLeftDefaultWidth: UInt32 = 320
+    static let sidebarRightDefaultWidth: UInt32 = 420
 
     /// Restore all six sidebar fields from the shared config.
     /// Called once during `bootstrap()` AFTER the engine is
@@ -2737,7 +2755,7 @@ final class CoreModel {
             sidebarLeftOpen = b
         }
         if let w = core.configUInt32(key: Self.sidebarLeftWidthKey),
-           Self.sidebarWidthRange.contains(w) {
+           Self.sidebarLeftWidthRange.contains(Int(w)) {
             sidebarLeftWidth = w
         }
         if let s = core.configString(key: Self.sidebarRightSelectedKey),
@@ -2748,7 +2766,7 @@ final class CoreModel {
             sidebarRightOpen = b
         }
         if let w = core.configUInt32(key: Self.sidebarRightWidthKey),
-           Self.sidebarWidthRange.contains(w) {
+           Self.sidebarRightWidthRange.contains(Int(w)) {
             sidebarRightWidth = w
         }
     }
@@ -2773,10 +2791,9 @@ final class CoreModel {
     }
 
     func setSidebarLeftWidth(_ width: UInt32) {
-        let clamped = min(
-            max(width, Self.sidebarWidthRange.lowerBound),
-            Self.sidebarWidthRange.upperBound
-        )
+        let lo = UInt32(Self.sidebarLeftWidthRange.lowerBound)
+        let hi = UInt32(Self.sidebarLeftWidthRange.upperBound)
+        let clamped = min(max(width, lo), hi)
         sidebarLeftWidth = clamped
         capture {
             try core?.setConfigUInt32(key: Self.sidebarLeftWidthKey, value: clamped)
@@ -2797,10 +2814,9 @@ final class CoreModel {
     }
 
     func setSidebarRightWidth(_ width: UInt32) {
-        let clamped = min(
-            max(width, Self.sidebarWidthRange.lowerBound),
-            Self.sidebarWidthRange.upperBound
-        )
+        let lo = UInt32(Self.sidebarRightWidthRange.lowerBound)
+        let hi = UInt32(Self.sidebarRightWidthRange.upperBound)
+        let clamped = min(max(width, lo), hi)
         sidebarRightWidth = clamped
         capture {
             try core?.setConfigUInt32(key: Self.sidebarRightWidthKey, value: clamped)


### PR DESCRIPTION
## Summary

- Per-side sidebar clamp ranges — left 220..=640, right 360..=840 — matching the GTK constants the spec calls out for #450.
- Double-click the resize handle to snap that side to its default width (320 px left, 420 px right).
- Drag-end persistence + Mac↔Linux config round-trip already in place from #449; the custom drag handle from that PR carries the new constraints + tap recognizer.

## Spec acceptance (#450)

| | |
|---|---|
| Hover inner panel edge → col-resize cursor | ✓ `NSCursor.resizeLeftRight.push()` on `.onHover` |
| Drag → panel resizes, spectrum rescales live | ✓ `liveLeftWidth` / `liveRightWidth` track in-flight drag |
| Drag past min/max → clamps | ✓ Per-side clamp during drag + clamp again in the model setter |
| Release → config persists | ✓ `.onEnded` writes through `setSidebar*Width` → FFI config |
| Double-click divider → snaps to default | ✓ `.onTapGesture(count: 2)` calls the setter with the side's default |
| Mac ↔ Linux round-trip of width keys | ✓ Already shared via `ui_sidebar_*_width_px` (from #449) |

## Approach choice

The spec recommended `HSplitView` (or `NSSplitView`) for native dividers + cursor; this PR keeps the custom 8 px hit-target divider that landed in #499. Reasoning:

I burned several iterations during this PR's prep trying the "Apple-blessed" `NSSplitViewController` + `NSSplitViewItem` pattern via `NSViewControllerRepresentable`. Each fix uncovered another layout pathology:

1. `viewDidLoad` doesn't run until `controller.view` is first accessed → first `updateNSViewController` finds host controllers nil → every pane silently stays on `EmptyView()`.
2. `sizeThatFits(_:nsViewController:context:)` returning the proposal collapses to 0×0 on first paint (proposal width is `.unspecified` until parent finalizes).
3. Without `preferredThicknessFraction` on each item, NSSplitView's first-paint distribution gives the side panes their `maximumThickness` (640 + 840 = 1480 px), pushing the center to negative width and erasing the spectrum.

After several rounds of "fix one, hit another," the user (correctly) called it: cut losses, ship the working pure-SwiftUI version. The custom-handle approach covers every spec acceptance criterion, has native cursor + drag feel, persists correctly, and round-trips with Linux. Lessons saved as a memory so a future me doesn't reach for `NSSplitViewController` again here.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --lib` — all tests pass
- [x] `make mac-app` — Mac app bundles successfully
- [x] Smoke tests:
  - Hover left/right divider → resize cursor appears
  - Drag left to 250 → respects 220 min, doesn't shrink past
  - Drag left to 700 → clamps at 640
  - Drag right to 320 → respects 360 min
  - Drag right to 900 → clamps at 840
  - Release at any width → quit + relaunch shows the same width
  - Double-click left handle → snaps to 320 px
  - Double-click right handle → snaps to 420 px
  - Open the panels via activity-bar icons or ⌘1–6 / ⌘⇧1–2 → content renders, drag still works
- [ ] CodeRabbit review

## Links

- Closes #450
- Builds on #449's session persistence (the `ui_sidebar_*_width_px` keys + the model setters already exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-click a sidebar resize handle to reset that side to its default width.

* **Improvements**
  * Left and right sidebars now resize independently with separate clamp ranges.
  * Saved sidebar sizes are validated and restored per side, avoiding invalid values.
  * Drag behavior refined to reduce accidental drags during quick interactions, improving resize reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->