### PR TITLE
sdr-sat,sdr-ui: satellites scheduler UI + ZIP/elevation lookup (closes #481)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,6 +2714,7 @@ dependencies = [
  "reqwest",
  "sdr-types",
  "serde",
+ "serde_json",
  "sgp4",
  "thiserror 2.0.18",
  "tracing",
@@ -2856,6 +2857,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "cairo-rs",
+ "chrono",
  "criterion",
  "gtk4",
  "libadwaita",
@@ -2867,6 +2869,7 @@ dependencies = [
  "sdr-radioreference",
  "sdr-rtlsdr",
  "sdr-rtltcp-discovery",
+ "sdr-sat",
  "sdr-scanner",
  "sdr-server-rtltcp",
  "sdr-sink-audio",

--- a/crates/sdr-sat/Cargo.toml
+++ b/crates/sdr-sat/Cargo.toml
@@ -13,6 +13,7 @@ chrono.workspace = true
 reqwest.workspace = true
 dirs-next.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/sdr-sat/src/elevation.rs
+++ b/crates/sdr-sat/src/elevation.rs
@@ -1,0 +1,210 @@
+//! Lat/lon → ground elevation lookup.
+//!
+//! Sister helper to [`crate::postal_lookup`]: once we know a ground
+//! station's latitude/longitude (typed in by hand or resolved from a
+//! ZIP code), this module fills in the altitude field. Pass prediction
+//! is barely sensitive to station altitude — a NOAA at ~850 km doesn't
+//! notice a 100 m height difference — but populating the field anyway
+//! makes the panel feel "complete" after a ZIP lookup. Surprising the
+//! user with a bare 0 m sea-level altitude when they're at 600 m in
+//! Boulder is the kind of thing that erodes trust.
+//!
+//! We hit the public, no-auth Open-Elevation endpoint
+//! (`api.open-elevation.com/api/v1/lookup?locations=lat,lon`). World
+//! coverage, 30 m SRTM-derived dataset, JSON. Like the rest of
+//! sdr-sat's HTTP plumbing, the call is **blocking** and meant to be
+//! invoked from a worker thread.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Default timeout for the Open-Elevation round trip. Generous —
+/// the upstream is community-run and occasionally slow under load.
+/// We'd rather wait 15 s once than spuriously fail a UX nicety.
+pub const DEFAULT_LOOKUP_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Cached HTTP client — built on first call so consecutive lookups
+/// reuse the TLS session. Same `OnceLock` pattern as the postal
+/// lookup module and the TLE cache; same rationale.
+static CLIENT: OnceLock<reqwest::blocking::Client> = OnceLock::new();
+
+/// Errors from an elevation lookup.
+#[derive(Debug, thiserror::Error)]
+pub enum ElevationLookupError {
+    /// Caller passed a lat/lon that's outside the valid WGS84 range.
+    /// Caught client-side rather than burning a request on something
+    /// the upstream would reject anyway.
+    #[error("invalid coordinates: lat={lat_deg}, lon={lon_deg}")]
+    InvalidCoords {
+        /// Latitude that failed the range check.
+        lat_deg: f64,
+        /// Longitude that failed the range check.
+        lon_deg: f64,
+    },
+    /// Upstream returned a non-2xx status, the request timed out, or
+    /// reqwest itself failed to send.
+    #[error("elevation lookup HTTP error: {0}")]
+    Http(String),
+    /// Body wasn't JSON or didn't have the fields we expected.
+    #[error("elevation lookup parse error: {0}")]
+    Parse(String),
+    /// JSON parsed but no result records — Open-Elevation returns
+    /// `{"results":[]}` when its dataset has no coverage at the
+    /// requested point (rare but observed near polar regions).
+    #[error("no elevation data available for the requested point")]
+    NoData,
+}
+
+/// Look up ground elevation in metres at `(lat_deg, lon_deg)`.
+///
+/// # Errors
+///
+/// See [`ElevationLookupError`]. Notable cases:
+///
+/// * [`ElevationLookupError::InvalidCoords`] — coordinates out of
+///   range. No HTTP request is made.
+/// * [`ElevationLookupError::NoData`] — point isn't covered by the
+///   upstream dataset (rare; mostly polar/oceanic gaps).
+pub fn lookup_elevation_m(lat_deg: f64, lon_deg: f64) -> Result<f64, ElevationLookupError> {
+    if !is_valid_coords(lat_deg, lon_deg) {
+        return Err(ElevationLookupError::InvalidCoords { lat_deg, lon_deg });
+    }
+
+    // `{:.6}` is plenty: 0.000001° is ~11 cm at the equator — far
+    // below the dataset's 30 m grid resolution. Locks the URL down
+    // to a deterministic shape for caching/debugging.
+    let url =
+        format!("https://api.open-elevation.com/api/v1/lookup?locations={lat_deg:.6},{lon_deg:.6}");
+    let client = client()?;
+    let body = client
+        .get(&url)
+        .send()
+        .map_err(|e| ElevationLookupError::Http(format!("GET {url}: {e}")))?
+        .error_for_status()
+        .map_err(|e| ElevationLookupError::Http(format!("HTTP status: {e}")))?
+        .text()
+        .map_err(|e| ElevationLookupError::Http(format!("response body: {e}")))?;
+
+    parse_response(&body)
+}
+
+/// WGS84 valid-range check — applied before we burn a request on a
+/// nonsense coordinate (a misclick that put the `SpinRow` at lat=999
+/// shouldn't reach the network).
+fn is_valid_coords(lat_deg: f64, lon_deg: f64) -> bool {
+    lat_deg.is_finite()
+        && lon_deg.is_finite()
+        && (-90.0..=90.0).contains(&lat_deg)
+        && (-180.0..=180.0).contains(&lon_deg)
+}
+
+fn client() -> Result<reqwest::blocking::Client, ElevationLookupError> {
+    if let Some(c) = CLIENT.get() {
+        return Ok(c.clone());
+    }
+    let new_client = reqwest::blocking::Client::builder()
+        .timeout(DEFAULT_LOOKUP_TIMEOUT)
+        .user_agent(concat!("sdr-rs/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| ElevationLookupError::Http(format!("client build: {e}")))?;
+    let _ = CLIENT.set(new_client.clone());
+    Ok(CLIENT.get().cloned().unwrap_or(new_client))
+}
+
+/// Pull the first result's elevation out of an Open-Elevation
+/// response. Free function so the hermetic JSON tests below pin the
+/// parsing rules without touching the network.
+fn parse_response(body: &str) -> Result<f64, ElevationLookupError> {
+    let value: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| ElevationLookupError::Parse(format!("not JSON: {e}")))?;
+    let results = value
+        .get("results")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| ElevationLookupError::Parse("missing `results` array".to_string()))?;
+    let first = results.first().ok_or(ElevationLookupError::NoData)?;
+    first
+        .get("elevation")
+        .and_then(serde_json::Value::as_f64)
+        .ok_or_else(|| ElevationLookupError::Parse("missing/non-numeric elevation".to_string()))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_valid_coords_accepts_in_range() {
+        assert!(is_valid_coords(0.0, 0.0));
+        assert!(is_valid_coords(90.0, 180.0));
+        assert!(is_valid_coords(-90.0, -180.0));
+        assert!(is_valid_coords(37.1548, -80.4184));
+    }
+
+    #[test]
+    fn is_valid_coords_rejects_out_of_range() {
+        assert!(!is_valid_coords(91.0, 0.0));
+        assert!(!is_valid_coords(0.0, 181.0));
+        assert!(!is_valid_coords(-91.0, 0.0));
+    }
+
+    #[test]
+    fn is_valid_coords_rejects_non_finite() {
+        assert!(!is_valid_coords(f64::NAN, 0.0));
+        assert!(!is_valid_coords(0.0, f64::INFINITY));
+    }
+
+    #[test]
+    fn lookup_rejects_invalid_coords_without_calling_network() {
+        // No mock client — validator short-circuits before HTTP.
+        // Test would hang or fail noisily if it actually tried to send.
+        let err = lookup_elevation_m(91.0, 0.0).unwrap_err();
+        assert!(matches!(err, ElevationLookupError::InvalidCoords { .. }));
+    }
+
+    #[test]
+    fn parse_response_extracts_first_elevation() {
+        // Real Open-Elevation body for (37.1548, -80.4184) — pasted
+        // verbatim so a schema regression breaks the test.
+        let body = r#"{"results":[{"latitude":37.1548,"longitude":-80.4184,"elevation":647.0}]}"#;
+        let elev = parse_response(body).unwrap();
+        assert_eq!(elev, 647.0);
+    }
+
+    #[test]
+    fn parse_response_handles_integer_elevation() {
+        // Some upstream responses serialise elevation as a JSON
+        // integer (`647` not `647.0`). `as_f64` accepts both.
+        let body = r#"{"results":[{"latitude":37.0,"longitude":-80.0,"elevation":647}]}"#;
+        let elev = parse_response(body).unwrap();
+        assert_eq!(elev, 647.0);
+    }
+
+    #[test]
+    fn parse_response_returns_no_data_for_empty_results() {
+        let err = parse_response(r#"{"results":[]}"#).unwrap_err();
+        assert!(matches!(err, ElevationLookupError::NoData));
+    }
+
+    #[test]
+    fn parse_response_surfaces_parse_error_for_garbage() {
+        let err = parse_response("<html>oops</html>").unwrap_err();
+        assert!(matches!(err, ElevationLookupError::Parse(_)));
+    }
+
+    #[test]
+    fn parse_response_surfaces_parse_error_for_missing_elevation() {
+        // Right top-level shape, but the result record is missing
+        // elevation. Surface as Parse rather than silently
+        // returning 0.0 — better an error than a wrong altitude.
+        let body = r#"{"results":[{"latitude":37.0,"longitude":-80.0}]}"#;
+        let err = parse_response(body).unwrap_err();
+        assert!(matches!(err, ElevationLookupError::Parse(_)));
+    }
+
+    #[test]
+    fn parse_response_surfaces_parse_error_for_missing_results_array() {
+        let err = parse_response(r#"{"foo":"bar"}"#).unwrap_err();
+        assert!(matches!(err, ElevationLookupError::Parse(_)));
+    }
+}

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -23,12 +23,17 @@
 //! Hard-coded NORAD IDs for the satellites we ship with are in
 //! [`KNOWN_SATELLITES`] so callers don't need to look them up.
 
+pub mod elevation;
 pub mod passes;
+pub mod postal_lookup;
 pub mod sgp4_core;
 pub mod tle_cache;
 
+pub use elevation::{ElevationLookupError, lookup_elevation_m};
+pub use passes::{GroundStation, Pass, Track, track, upcoming_passes};
+pub use postal_lookup::{PostalLocation, PostalLookupError, lookup_us_zip};
 pub use sgp4_core::{Satellite, SatelliteError};
-pub use tle_cache::TleSource;
+pub use tle_cache::{TleCache, TleCacheError, celestrak_gp_url};
 
 /// A satellite the user-facing scheduler ships with by default. The list
 /// is intentionally tight — we want passes to "just work" for the most
@@ -36,14 +41,11 @@ pub use tle_cache::TleSource;
 /// TLEs by hand.
 #[derive(Debug, Clone, Copy)]
 pub struct KnownSatellite {
-    /// Display name, matches the Celestrak TLE name field exactly. Used
-    /// for the `Browse...` filter that pulls the TLE pair out of the
-    /// downloaded text file.
+    /// Display name, matches the Celestrak TLE name field exactly.
     pub name: &'static str,
     /// NORAD catalog number — the canonical satellite identifier.
+    /// [`TleCache`] looks up TLEs by this id directly.
     pub norad_id: u32,
-    /// Which Celestrak source file the TLE lives in.
-    pub source: TleSource,
 }
 
 /// Built-in catalog. Order is the order the scheduler UI displays.
@@ -52,39 +54,32 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     KnownSatellite {
         name: "NOAA 15",
         norad_id: 25_338,
-        source: TleSource::Noaa,
     },
     KnownSatellite {
         name: "NOAA 18",
         norad_id: 28_654,
-        source: TleSource::Noaa,
     },
     KnownSatellite {
         name: "NOAA 19",
         norad_id: 33_591,
-        source: TleSource::Noaa,
     },
     // Meteor-M LRPT — epic #469
     KnownSatellite {
         name: "METEOR-M 2",
         norad_id: 40_069,
-        source: TleSource::Weather,
     },
     KnownSatellite {
         name: "METEOR-M2 3",
         norad_id: 57_166,
-        source: TleSource::Weather,
     },
     KnownSatellite {
         name: "METEOR-M2 4",
         norad_id: 61_024,
-        source: TleSource::Weather,
     },
     // ISS SSTV — epic #472
     KnownSatellite {
         name: "ISS (ZARYA)",
         norad_id: 25_544,
-        source: TleSource::Stations,
     },
 ];
 

--- a/crates/sdr-sat/src/postal_lookup.rs
+++ b/crates/sdr-sat/src/postal_lookup.rs
@@ -1,0 +1,272 @@
+//! US-ZIP-code → ground-station coordinates lookup.
+//!
+//! The satellites scheduler needs a latitude/longitude for the user's
+//! ground station. Asking them to type one in by hand is fiddly; asking
+//! the OS for a "current location" is a rabbit hole (`GeoClue2` needs a
+//! flatpak/snap allowlist to work for most users, Windows location
+//! services are coarse, and we'd be cross-platform on day one). A ZIP
+//! code is something everyone has memorised, gives lat/lon accurate to
+//! ~1 km — way better than IP geolocation — and dodges per-platform
+//! permission UIs entirely.
+//!
+//! We hit the public, no-auth Zippopotam.us endpoint. It serves a flat
+//! JSON document keyed by country + postal code; the US dataset is
+//! complete and well-maintained. International ZIP support is
+//! intentionally out of scope here — non-US users can type lat/lon by
+//! hand. (A `country_code` parameter could be threaded through later
+//! without changing the [`PostalLocation`] return type.)
+//!
+//! Like [`crate::tle_cache::TleCache::tle_text`], the HTTP fetch is
+//! **blocking**. The scheduler UI calls this from a worker thread via
+//! `gio::spawn_blocking`.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Default timeout for the Zippopotam.us round trip. Generous enough
+/// that a sluggish coffee-shop link still resolves, short enough that
+/// a network outage doesn't block the worker thread for a minute.
+pub const DEFAULT_LOOKUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Cached HTTP client — built on first call so consecutive lookups
+/// reuse the same TLS session + connection pool. `OnceLock` mirrors
+/// the [`crate::tle_cache::TleCache`] client cache; same rationale.
+static CLIENT: OnceLock<reqwest::blocking::Client> = OnceLock::new();
+
+/// Resolved ground-station location from a postal-code lookup.
+#[derive(Debug, Clone)]
+pub struct PostalLocation {
+    /// Latitude in decimal degrees, north-positive.
+    pub lat_deg: f64,
+    /// Longitude in decimal degrees, east-positive.
+    pub lon_deg: f64,
+    /// Place name from the upstream record — typically the largest
+    /// settlement in the postal code. Shown back to the user in a
+    /// status row so they can sanity-check the lookup.
+    pub place: String,
+    /// State / region abbreviation when available (e.g. `"VA"`).
+    /// Empty string if upstream omitted it.
+    pub region: String,
+}
+
+/// Errors from a postal-code lookup.
+#[derive(Debug, thiserror::Error)]
+pub enum PostalLookupError {
+    /// Empty / non-numeric / wrong-length input. Caught client-side
+    /// rather than burning a request on something Zippopotam.us would
+    /// 404 anyway.
+    #[error("invalid US ZIP code: {0:?} (expected 5 digits)")]
+    InvalidZip(String),
+    /// Upstream returned a non-2xx status, the request timed out, or
+    /// reqwest itself failed to send.
+    #[error("postal lookup HTTP error: {0}")]
+    Http(String),
+    /// Body wasn't JSON or didn't have the fields we expected.
+    /// Zippopotam.us returns `{}` for ZIPs it doesn't know — the empty
+    /// `places` array surfaces here as `NotFound`.
+    #[error("postal lookup parse error: {0}")]
+    Parse(String),
+    /// JSON parsed but no place records — ZIP simply isn't in the
+    /// upstream dataset.
+    #[error("ZIP {0} not found in postal database")]
+    NotFound(String),
+}
+
+/// Look up the centroid of a US ZIP code. Trims surrounding whitespace
+/// and validates "5 digits" before making the network call.
+///
+/// # Errors
+///
+/// See [`PostalLookupError`]. Notable cases:
+///
+/// * [`PostalLookupError::InvalidZip`] — caller passed something that
+///   isn't a 5-digit ZIP. No HTTP request is made.
+/// * [`PostalLookupError::NotFound`] — ZIP isn't in Zippopotam.us's
+///   dataset (typo, brand-new ZIP, military APO, etc.).
+pub fn lookup_us_zip(zip: &str) -> Result<PostalLocation, PostalLookupError> {
+    let zip = zip.trim();
+    if !is_us_zip(zip) {
+        return Err(PostalLookupError::InvalidZip(zip.to_string()));
+    }
+
+    let url = format!("https://api.zippopotam.us/us/{zip}");
+    let client = client()?;
+    let body = client
+        .get(&url)
+        .send()
+        .map_err(|e| PostalLookupError::Http(format!("GET {url}: {e}")))?
+        .error_for_status()
+        .map_err(|e| PostalLookupError::Http(format!("HTTP status: {e}")))?
+        .text()
+        .map_err(|e| PostalLookupError::Http(format!("response body: {e}")))?;
+
+    parse_response(zip, &body)
+}
+
+/// Five ASCII digits — Zippopotam.us only matches whole ZIPs and
+/// rejects anything else, so we filter aggressively up front.
+fn is_us_zip(zip: &str) -> bool {
+    zip.len() == 5 && zip.chars().all(|c| c.is_ascii_digit())
+}
+
+fn client() -> Result<reqwest::blocking::Client, PostalLookupError> {
+    if let Some(c) = CLIENT.get() {
+        return Ok(c.clone());
+    }
+    let new_client = reqwest::blocking::Client::builder()
+        .timeout(DEFAULT_LOOKUP_TIMEOUT)
+        .user_agent(concat!("sdr-rs/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| PostalLookupError::Http(format!("client build: {e}")))?;
+    let _ = CLIENT.set(new_client.clone());
+    Ok(CLIENT.get().cloned().unwrap_or(new_client))
+}
+
+/// Pull `(lat, lon, place, state)` out of a Zippopotam.us US response.
+/// Pulled out as a free function so the hermetic JSON tests below can
+/// pin the parsing rules without touching the network.
+fn parse_response(zip: &str, body: &str) -> Result<PostalLocation, PostalLookupError> {
+    let value: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| PostalLookupError::Parse(format!("not JSON: {e}")))?;
+    let places = value
+        .get("places")
+        .and_then(serde_json::Value::as_array)
+        .filter(|p| !p.is_empty())
+        .ok_or_else(|| PostalLookupError::NotFound(zip.to_string()))?;
+    let first = &places[0];
+    // Upstream serialises lat/lon as JSON strings, not numbers — parse
+    // through `str::parse` so a future schema flip to numeric values
+    // would still need explicit handling rather than silently breaking.
+    let lat_deg = first
+        .get("latitude")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| s.parse::<f64>().ok())
+        .ok_or_else(|| PostalLookupError::Parse("missing/non-numeric latitude".to_string()))?;
+    let lon_deg = first
+        .get("longitude")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| s.parse::<f64>().ok())
+        .ok_or_else(|| PostalLookupError::Parse("missing/non-numeric longitude".to_string()))?;
+    let place = first
+        .get("place name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let region = first
+        .get("state abbreviation")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    Ok(PostalLocation {
+        lat_deg,
+        lon_deg,
+        place,
+        region,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_us_zip_accepts_five_digits() {
+        assert!(is_us_zip("24068"));
+        assert!(is_us_zip("00501")); // smallest real ZIP
+    }
+
+    #[test]
+    fn is_us_zip_rejects_wrong_lengths() {
+        assert!(!is_us_zip(""));
+        assert!(!is_us_zip("1234"));
+        assert!(!is_us_zip("123456"));
+    }
+
+    #[test]
+    fn is_us_zip_rejects_non_digits() {
+        assert!(!is_us_zip("ABCDE"));
+        assert!(!is_us_zip("1234A"));
+        assert!(!is_us_zip("1 234")); // space
+        assert!(!is_us_zip("12-34")); // hyphen
+    }
+
+    #[test]
+    fn lookup_rejects_invalid_zip_without_calling_network() {
+        // No mock client needed — the validator short-circuits before
+        // any HTTP call. The test would hang or fail noisily if it
+        // actually tried to send.
+        let err = lookup_us_zip("not a zip").unwrap_err();
+        assert!(matches!(err, PostalLookupError::InvalidZip(_)));
+    }
+
+    #[test]
+    fn parse_response_extracts_lat_lon_place_state() {
+        // Real Zippopotam.us body for ZIP 24068 (Christiansburg, VA),
+        // pasted verbatim so we catch field-name regressions if upstream
+        // changes the schema.
+        let body = r#"{
+            "country": "United States",
+            "country abbreviation": "US",
+            "post code": "24068",
+            "places": [{
+                "place name": "Christiansburg",
+                "longitude": "-80.4184",
+                "latitude": "37.1548",
+                "state": "Virginia",
+                "state abbreviation": "VA"
+            }]
+        }"#;
+        let loc = parse_response("24068", body).unwrap();
+        assert!((loc.lat_deg - 37.1548).abs() < 0.0001);
+        assert!((loc.lon_deg - -80.4184).abs() < 0.0001);
+        assert_eq!(loc.place, "Christiansburg");
+        assert_eq!(loc.region, "VA");
+    }
+
+    #[test]
+    fn parse_response_returns_not_found_for_empty_object() {
+        // What Zippopotam.us returns when a ZIP isn't in its dataset.
+        // Distinguish from a `Parse` error so the UI can show a
+        // user-actionable "ZIP not found" instead of a generic
+        // "lookup failed" toast.
+        let err = parse_response("99999", "{}").unwrap_err();
+        assert!(matches!(err, PostalLookupError::NotFound(_)));
+    }
+
+    #[test]
+    fn parse_response_returns_not_found_for_empty_places_array() {
+        // Defensive case: server replies with the right shape but
+        // empty `places`. Should still surface as NotFound.
+        let body = r#"{"post code":"99999","places":[]}"#;
+        let err = parse_response("99999", body).unwrap_err();
+        assert!(matches!(err, PostalLookupError::NotFound(_)));
+    }
+
+    #[test]
+    fn parse_response_surfaces_parse_error_for_garbage() {
+        let err = parse_response("24068", "<html>oops</html>").unwrap_err();
+        assert!(matches!(err, PostalLookupError::Parse(_)));
+    }
+
+    #[test]
+    fn parse_response_surfaces_parse_error_for_missing_fields() {
+        // Right top-level shape, but the place record is missing
+        // latitude/longitude. We require both — better to error than
+        // hand back lat=0 (Atlantic Ocean).
+        let body = r#"{"post code":"24068","places":[{"place name":"X"}]}"#;
+        let err = parse_response("24068", body).unwrap_err();
+        assert!(matches!(err, PostalLookupError::Parse(_)));
+    }
+
+    #[test]
+    fn lookup_trims_surrounding_whitespace() {
+        // User pastes a ZIP with a trailing space — the validator
+        // sees the trimmed form and rejects only on actual length /
+        // digit failures.
+        let err = lookup_us_zip("  abcde  ").unwrap_err();
+        // Whitespace is trimmed first, then validation runs. The
+        // remaining content "abcde" is non-digits, so InvalidZip.
+        assert!(matches!(err, PostalLookupError::InvalidZip(_)));
+    }
+}

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -206,12 +206,81 @@ impl TleCache {
     /// cached entry — the user gets *something* rather than a blank
     /// scheduler. On no-cache + no-network, returns the fetch error.
     ///
+    /// **GTK callers — beware:** the freshness check can trigger a
+    /// blocking HTTP fetch. For UI-thread paths (e.g. recomputing the
+    /// pass list after a lat/lon edit) prefer
+    /// [`TleCache::cached_tle_for`], which is read-only and never
+    /// touches the network.
+    ///
     /// # Errors
     ///
     /// Surfaces [`TleCacheError`] for network, I/O, or lookup failures.
     pub fn tle_for(&self, norad_id: u32) -> Result<(String, String), TleCacheError> {
         let text = self.tle_text(norad_id)?;
         parse_tle_text(&text, norad_id).ok_or(TleCacheError::NotFound { norad_id })
+    }
+
+    /// Cache-only lookup. Reads whatever's on disk, validates the
+    /// content, and returns the matching TLE pair. **Never** makes a
+    /// network call, regardless of cache freshness — staleness is the
+    /// caller's problem (the satellites panel reschedules an explicit
+    /// refresh button click for that).
+    ///
+    /// Used by the UI's pass-recompute path so a lat/lon/alt edit
+    /// can't accidentally block the GTK main loop on synchronous HTTP
+    /// + cache writes.
+    ///
+    /// # Errors
+    ///
+    /// * [`TleCacheError::NotFound`] — cache file missing, unreadable,
+    ///   structurally invalid, or doesn't contain `norad_id`.
+    /// * [`TleCacheError::Io`] — file system read failure (other than
+    ///   not-found / non-UTF-8, both of which are demoted to `NotFound`
+    ///   so the caller doesn't see a fatal Io for a routine miss).
+    pub fn cached_tle_for(&self, norad_id: u32) -> Result<(String, String), TleCacheError> {
+        let path = self.cache_path(norad_id);
+        let cached = read_file(&path)?.ok_or(TleCacheError::NotFound { norad_id })?;
+        if !has_any_tle_pair(&cached) {
+            return Err(TleCacheError::NotFound { norad_id });
+        }
+        parse_tle_text(&cached, norad_id).ok_or(TleCacheError::NotFound { norad_id })
+    }
+
+    /// Forced network fetch. Bypasses the freshness check and the
+    /// stale-cache fallback — used by the manual "Refresh" button so
+    /// a click always means "do the network round-trip" and the
+    /// timestamp can only advance on a real success.
+    ///
+    /// On success, the response is validated and written to the cache
+    /// just like the slow path of [`TleCache::tle_text`].
+    ///
+    /// # Errors
+    ///
+    /// * [`TleCacheError::Fetch`] — network failure, non-2xx status,
+    ///   or upstream returned a body that isn't a valid TLE (HTML
+    ///   error page, captive portal, etc.). The cache is **not**
+    ///   updated and the on-disk copy (stale or otherwise) is left
+    ///   untouched.
+    /// * [`TleCacheError::Io`] — only if writing the freshly-fetched
+    ///   body to disk failed; the in-memory body is still returned.
+    pub fn force_refresh(&self, norad_id: u32) -> Result<String, TleCacheError> {
+        let text = self.fetch(norad_id).and_then(|text| {
+            if has_any_tle_pair(&text) {
+                Ok(text)
+            } else {
+                Err(TleCacheError::Fetch(
+                    "response body did not contain any valid TLE pair (captive portal? HTML error page?)"
+                        .to_string(),
+                ))
+            }
+        })?;
+        let path = self.cache_path(norad_id);
+        if let Err(e) = self.write_cache(&path, &text) {
+            tracing::warn!(
+                "TLE cache write for NORAD {norad_id} failed ({e}); returning fresh in-memory copy",
+            );
+        }
+        Ok(text)
     }
 
     /// Get the raw TLE text for one satellite, refreshing on disk if
@@ -852,6 +921,139 @@ SOMETHING
         let cache = TleCache::with_dir(dir);
         let err = cache.tle_for(99_999).unwrap_err();
         assert!(matches!(err, TleCacheError::NotFound { norad_id: 99_999 }));
+    }
+
+    #[test]
+    fn cached_tle_for_does_not_call_network_on_miss() {
+        // The whole point of `cached_tle_for`: a UI-thread caller
+        // can ask "what TLE do we have on disk?" without risking a
+        // synchronous HTTP fetch. Drop a canned-fail fetcher in to
+        // pin that — a network call here would surface as Fetch
+        // error, but cache_only should never hit that path.
+        let dir = unique_temp_dir("cached-only-miss");
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache = TleCache::with_dir(dir).with_fetcher(always_fail_fetcher());
+        // No file present.
+        let err = cache.cached_tle_for(33_591).unwrap_err();
+        assert!(
+            matches!(err, TleCacheError::NotFound { norad_id: 33_591 }),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn cached_tle_for_returns_pair_when_file_is_present() {
+        let dir = unique_temp_dir("cached-only-hit");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("5.tle");
+        std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
+        let cache = TleCache::with_dir(dir).with_fetcher(always_fail_fetcher());
+        let (l1, l2) = cache.cached_tle_for(5).unwrap();
+        assert!(l1.starts_with("1 00005"));
+        assert!(l2.starts_with("2 00005"));
+    }
+
+    #[test]
+    fn cached_tle_for_never_invokes_the_fetcher_even_when_stale() {
+        // The contract for `cached_tle_for`: zero network calls,
+        // regardless of cache freshness. Pin it by counting fetcher
+        // invocations — that's the actual UI-thread invariant we
+        // care about. (`tle_text` falls back to stale cache on
+        // fetch failure, so its return value can't differentiate
+        // "fetched and failed" from "served stale", which is why we
+        // count fetcher calls instead.)
+        use std::sync::Arc as StdArc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let dir = unique_temp_dir("cached-only-stale");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("5.tle");
+        std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
+        // Sleep one tick + use a 1-ns refresh window so the file
+        // looks "stale" to anyone who'd consult freshness.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let calls = StdArc::new(AtomicU32::new(0));
+        let calls_for_fetcher = StdArc::clone(&calls);
+        let cache = TleCache::with_dir(dir)
+            .with_refresh_max_age(std::time::Duration::from_nanos(1))
+            .with_fetcher(move |_| {
+                calls_for_fetcher.fetch_add(1, Ordering::Relaxed);
+                Err(TleCacheError::Fetch("test: fetcher disabled".to_string()))
+            });
+        // Even with a stale cache file, `cached_tle_for` returns
+        // the on-disk copy and never calls the fetcher.
+        let (l1, _l2) = cache.cached_tle_for(5).unwrap();
+        assert!(l1.starts_with("1 00005"));
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            0,
+            "cached_tle_for invoked the fetcher",
+        );
+    }
+
+    #[test]
+    fn cached_tle_for_returns_not_found_for_corrupted_body() {
+        // Validation gate applies on the read path too — a stray
+        // HTML response (or a manual `echo` into the cache) must
+        // surface as NotFound rather than be served as garbage.
+        let dir = unique_temp_dir("cached-only-corrupt");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("5.tle");
+        std::fs::write(&path, "<html>not a TLE</html>\n").unwrap();
+        let cache = TleCache::with_dir(dir).with_fetcher(always_fail_fetcher());
+        let err = cache.cached_tle_for(5).unwrap_err();
+        assert!(matches!(err, TleCacheError::NotFound { norad_id: 5 }));
+    }
+
+    #[test]
+    fn force_refresh_always_calls_fetcher_even_when_cache_is_fresh() {
+        // The whole point of `force_refresh`: a manual Refresh click
+        // must trigger a real network call so the timestamp is
+        // meaningful, even if the cache happens to be fresh.
+        // Inject a fetcher that records call counts and verify
+        // it fires.
+        use std::sync::Arc as StdArc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let dir = unique_temp_dir("force-refresh");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Pre-populate the cache with a fresh, valid file.
+        let path = dir.join("5.tle");
+        std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
+        let calls = StdArc::new(AtomicU32::new(0));
+        let calls_for_fetcher = StdArc::clone(&calls);
+        let cache = TleCache::with_dir(dir).with_fetcher(move |_| {
+            calls_for_fetcher.fetch_add(1, Ordering::Relaxed);
+            Ok(SAMPLE_TLE_3LINE.to_string())
+        });
+        // Sanity: tle_text would NOT call the fetcher because the
+        // cache is fresh.
+        let _ = cache.tle_text(5).unwrap();
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            0,
+            "tle_text spuriously fetched"
+        );
+        // force_refresh must always fetch.
+        let _ = cache.force_refresh(5).unwrap();
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        // And again — every call hits the network.
+        let _ = cache.force_refresh(5).unwrap();
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn force_refresh_does_not_fall_back_to_stale_cache_on_failure() {
+        // The "Last refreshed" timestamp must mean a real refresh
+        // succeeded — so a network failure with a stale-but-valid
+        // cache file present must still surface as Err. Otherwise
+        // a click on Refresh while offline could march the
+        // timestamp forward without any new data.
+        let dir = unique_temp_dir("force-refresh-no-fallback");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("5.tle");
+        std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
+        let cache = TleCache::with_dir(dir).with_fetcher(always_fail_fetcher());
+        let err = cache.force_refresh(5).unwrap_err();
+        assert!(matches!(err, TleCacheError::Fetch(_)));
     }
 
     #[test]

--- a/crates/sdr-sat/src/tle_cache.rs
+++ b/crates/sdr-sat/src/tle_cache.rs
@@ -1,18 +1,35 @@
 //! Celestrak TLE fetch + on-disk cache.
 //!
-//! Pulls satellite TLE files from
-//! `https://celestrak.org/NORAD/elements/{slug}.txt` and stores them
-//! under `~/.cache/sdr-rs/tle/`. Daily refresh: callers ask for a TLE
-//! by NORAD id, the cache returns it from disk if the file is fresher
-//! than [`DEFAULT_REFRESH_MAX_AGE`] (24 hours); otherwise it tries to
-//! re-download. If re-download fails (offline, Celestrak down, etc.)
-//! it falls back to whatever stale copy the cache already has so the
-//! UI degrades gracefully rather than going dark.
+//! Pulls satellite TLEs from Celestrak's stable per-catalog endpoint
+//!
+//! ```text
+//! https://celestrak.org/NORAD/elements/gp.php?CATNR={id}&FORMAT=tle
+//! ```
+//!
+//! and stores them under `~/.cache/sdr-rs/tle/{id}.tle`. Daily refresh:
+//! callers ask for a TLE by NORAD id, the cache returns it from disk if
+//! the file is fresher than [`DEFAULT_REFRESH_MAX_AGE`] (24 hours);
+//! otherwise it tries to re-download. If re-download fails (offline,
+//! Celestrak down, etc.) it falls back to whatever stale copy the cache
+//! already has so the UI degrades gracefully rather than going dark.
 //!
 //! The HTTP fetch is **blocking** by design — the rest of the
 //! workspace is blocking-only, and TLE fetches are once-a-day so the
 //! caller is expected to invoke this from a worker thread (the
 //! scheduler UI's "refresh TLEs" button, for example).
+//!
+//! ## Why per-NORAD instead of group files
+//!
+//! Earlier versions of this cache fetched whole group files
+//! (`noaa.txt`, `weather.txt`, `stations.txt`) keyed by a `TleSource`
+//! enum. Celestrak deprecated those URLs in 2024-2025: `noaa.txt`
+//! returns 404 outright, the `noaa` group is gone from the GP API,
+//! and the surviving `.txt` paths only redirect to the new `gp.php`
+//! form. NOAA 15/18/19 (the APT-capable POES) aren't grouped under
+//! any current GROUP slug — only `gp.php?CATNR=…` reliably returns
+//! them. Per-NORAD fetches dodge the group-churn problem entirely
+//! and let the catalog in [`crate::KNOWN_SATELLITES`] grow without
+//! someone having to figure out which group each satellite lives in.
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -36,34 +53,12 @@ pub const DEFAULT_REFRESH_MAX_AGE: StdDuration = StdDuration::from_hours(24);
 /// thread doesn't lock up if Celestrak is hung.
 pub const DEFAULT_FETCH_TIMEOUT: StdDuration = StdDuration::from_secs(15);
 
-/// Which Celestrak source file a TLE belongs to. Each maps directly to
-/// a `https://celestrak.org/NORAD/elements/{slug}.txt` URL.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TleSource {
-    /// `noaa.txt` — NOAA POES satellites (15/18/19) for APT.
-    Noaa,
-    /// `weather.txt` — Meteor-M and other weather sats for LRPT.
-    Weather,
-    /// `stations.txt` — ISS and crewed-vehicle TLEs for SSTV.
-    Stations,
-}
-
-impl TleSource {
-    /// Celestrak filename slug — the bit between `/elements/` and `.txt`.
-    #[must_use]
-    pub const fn slug(self) -> &'static str {
-        match self {
-            Self::Noaa => "noaa",
-            Self::Weather => "weather",
-            Self::Stations => "stations",
-        }
-    }
-
-    /// Full Celestrak URL for the file backing this source.
-    #[must_use]
-    pub fn url(self) -> String {
-        format!("https://celestrak.org/NORAD/elements/{}.txt", self.slug())
-    }
+/// Build the Celestrak GP URL for a single NORAD catalog number. Public
+/// so [`TleCache::with_fetcher`] callers (custom HTTP stacks) can mirror
+/// the production URL shape without re-deriving it.
+#[must_use]
+pub fn celestrak_gp_url(norad_id: u32) -> String {
+    format!("https://celestrak.org/NORAD/elements/gp.php?CATNR={norad_id}&FORMAT=tle")
 }
 
 /// Errors from cache lookup or HTTP fetch.
@@ -89,27 +84,25 @@ pub enum TleCacheError {
         #[source]
         source: std::io::Error,
     },
-    /// Looked up a NORAD id that wasn't present in the source's text.
-    /// Usually means the satellite was decommissioned and dropped from
-    /// the upstream file.
-    #[error("NORAD id {norad_id} not found in {tle_source:?} TLE source")]
+    /// Cache file existed and parsed but didn't contain a TLE pair
+    /// matching `norad_id`. Almost always the cached body got truncated
+    /// or corrupted — the canonical path on a successful fetch is for
+    /// the per-NORAD response to contain exactly the requested entry,
+    /// so a `NotFound` after a clean fetch means upstream returned
+    /// something other than the asked-for satellite.
+    #[error("NORAD id {norad_id} not found in cached TLE response")]
     NotFound {
         /// NORAD id requested.
         norad_id: u32,
-        /// Source the lookup ran against. Renamed from `source` because
-        /// thiserror auto-treats a field literally called `source` as
-        /// an `Error::source()` shim and demands the type implement
-        /// `std::error::Error`.
-        tle_source: TleSource,
     },
 }
 
 /// Custom fetcher used by [`TleCache::with_fetcher`]. Receives the
-/// requested source and returns the raw TLE text or a fetch-style
+/// requested NORAD id and returns the raw TLE text or a fetch-style
 /// error. Useful for unit tests that need hermetic refetch-path
 /// behaviour, and for users who want to plug in a non-reqwest HTTP
 /// stack (proxy-aware client, custom auth, etc.).
-pub type Fetcher = dyn Fn(TleSource) -> Result<String, TleCacheError> + Send + Sync;
+pub type Fetcher = dyn Fn(u32) -> Result<String, TleCacheError> + Send + Sync;
 
 /// Filesystem-backed cache of Celestrak TLE files.
 pub struct TleCache {
@@ -176,7 +169,7 @@ impl TleCache {
     #[must_use]
     pub fn with_fetcher<F>(mut self, fetcher: F) -> Self
     where
-        F: Fn(TleSource) -> Result<String, TleCacheError> + Send + Sync + 'static,
+        F: Fn(u32) -> Result<String, TleCacheError> + Send + Sync + 'static,
     {
         self.fetcher = Some(Box::new(fetcher));
         self
@@ -198,14 +191,16 @@ impl TleCache {
         self
     }
 
-    /// Path on disk where this source's TLE file is cached.
+    /// Path on disk where this NORAD id's TLE is cached. Filename uses
+    /// a `.tle` extension so a glance at `~/.cache/sdr-rs/tle/` makes
+    /// it obvious what's there even if the satellite catalog grows.
     #[must_use]
-    pub fn cache_path(&self, source: TleSource) -> PathBuf {
-        self.cache_dir.join(format!("{}.txt", source.slug()))
+    pub fn cache_path(&self, norad_id: u32) -> PathBuf {
+        self.cache_dir.join(format!("{norad_id}.tle"))
     }
 
-    /// Look up the TLE pair for `norad_id` in the given source,
-    /// refreshing the cache file from Celestrak if it's stale.
+    /// Look up the TLE pair for `norad_id`, refreshing from Celestrak
+    /// if the cache file is stale (or missing).
     ///
     /// On a fetch failure with a stale-but-present cache, returns the
     /// cached entry — the user gets *something* rather than a blank
@@ -214,31 +209,24 @@ impl TleCache {
     /// # Errors
     ///
     /// Surfaces [`TleCacheError`] for network, I/O, or lookup failures.
-    pub fn tle_for(
-        &self,
-        norad_id: u32,
-        source: TleSource,
-    ) -> Result<(String, String), TleCacheError> {
-        let text = self.tle_text(source)?;
-        parse_tle_text(&text, norad_id).ok_or(TleCacheError::NotFound {
-            norad_id,
-            tle_source: source,
-        })
+    pub fn tle_for(&self, norad_id: u32) -> Result<(String, String), TleCacheError> {
+        let text = self.tle_text(norad_id)?;
+        parse_tle_text(&text, norad_id).ok_or(TleCacheError::NotFound { norad_id })
     }
 
-    /// Get the raw TLE-file text for a source, refreshing on disk if
+    /// Get the raw TLE text for one satellite, refreshing on disk if
     /// the cached copy is stale (or missing).
     ///
     /// # Errors
     ///
     /// See [`TleCache::tle_for`].
-    pub fn tle_text(&self, source: TleSource) -> Result<String, TleCacheError> {
-        let path = self.cache_path(source);
+    pub fn tle_text(&self, norad_id: u32) -> Result<String, TleCacheError> {
+        let path = self.cache_path(norad_id);
 
         // Fast path: cache file is fresh, readable, AND structurally
         // a TLE file. Mtime + read alone aren't enough — older builds
-        // or a manual `echo > cache.txt` could have left HTML or
-        // garbage at this path, and we'd otherwise keep serving it
+        // or a manual `echo $whatever > cache.txt` could have left HTML
+        // or garbage at this path, and we'd otherwise keep serving it
         // until the file ages out (and `tle_for` would surface a
         // misleading `NotFound` even when upstream is healthy). If a
         // TOCTOU race steals the file between mtime check and read,
@@ -250,17 +238,14 @@ impl TleCache {
             if has_any_tle_pair(&cached) {
                 return Ok(cached);
             }
-            tracing::warn!(
-                "ignoring corrupted fresh TLE cache for {:?}; refetching",
-                source,
-            );
+            tracing::warn!("ignoring corrupted fresh TLE cache for NORAD {norad_id}; refetching");
         }
 
         // Slow path: fetch from upstream, validate, write to disk.
         // If the fetch (or validation) fails, fall back to whatever
         // stale copy still happens to exist *and validates*. If even
         // that's gone or corrupted, surface the original fetch error.
-        let fetch_result = self.fetch(source).and_then(|text| {
+        let fetch_result = self.fetch(norad_id).and_then(|text| {
             if has_any_tle_pair(&text) {
                 Ok(text)
             } else {
@@ -277,8 +262,7 @@ impl TleCache {
                 // network-fresh TLE data. Log and move on.
                 if let Err(e) = self.write_cache(&path, &text) {
                     tracing::warn!(
-                        "TLE cache write for {:?} failed ({e}); returning fresh in-memory copy",
-                        source,
+                        "TLE cache write for NORAD {norad_id} failed ({e}); returning fresh in-memory copy",
                     );
                 }
                 Ok(text)
@@ -288,8 +272,7 @@ impl TleCache {
                     && has_any_tle_pair(&cached)
                 {
                     tracing::warn!(
-                        "TLE fetch for {:?} failed ({fetch_err}); using stale cache",
-                        source,
+                        "TLE fetch for NORAD {norad_id} failed ({fetch_err}); using stale cache",
                     );
                     return Ok(cached);
                 }
@@ -298,17 +281,17 @@ impl TleCache {
         }
     }
 
-    /// Blocking HTTP fetch of one source file. Reuses the cached
+    /// Blocking HTTP fetch of one satellite's TLE. Reuses the cached
     /// reqwest client across calls for connection + TLS-session pooling.
     /// If [`TleCache::with_fetcher`] supplied an override, that closure
     /// runs instead — letting tests stay hermetic and users plug in
     /// custom HTTP stacks.
-    fn fetch(&self, source: TleSource) -> Result<String, TleCacheError> {
+    fn fetch(&self, norad_id: u32) -> Result<String, TleCacheError> {
         if let Some(override_fetcher) = &self.fetcher {
-            return override_fetcher(source);
+            return override_fetcher(norad_id);
         }
         let client = self.client()?;
-        let url = source.url();
+        let url = celestrak_gp_url(norad_id);
         let response = client
             .get(&url)
             .send()
@@ -568,17 +551,16 @@ NOAA 19
 ";
 
     #[test]
-    fn slug_for_each_source_matches_celestrak_filename() {
-        assert_eq!(TleSource::Noaa.slug(), "noaa");
-        assert_eq!(TleSource::Weather.slug(), "weather");
-        assert_eq!(TleSource::Stations.slug(), "stations");
-    }
-
-    #[test]
-    fn url_points_to_celestrak_https() {
-        let url = TleSource::Noaa.url();
-        assert!(url.starts_with("https://celestrak.org/NORAD/elements/"));
-        assert!(url.ends_with("noaa.txt"));
+    fn celestrak_gp_url_uses_stable_per_catnr_endpoint() {
+        // Pin the URL shape — we deliberately do NOT use the legacy
+        // `noaa.txt` / `weather.txt` group files (Celestrak deprecated
+        // them in 2024-2025) or the redirector at `redirect.php`.
+        // Per-CATNR is the documented stable interface.
+        let url = celestrak_gp_url(25_338);
+        assert_eq!(
+            url,
+            "https://celestrak.org/NORAD/elements/gp.php?CATNR=25338&FORMAT=tle"
+        );
     }
 
     #[test]
@@ -707,9 +689,15 @@ SOMETHING
     /// Canned fetcher for hermetic refetch-path tests: always returns
     /// a `Fetch` error so we exercise the "fetch failed, fall back to
     /// stale" branch without touching the network.
-    fn always_fail_fetcher() -> impl Fn(TleSource) -> Result<String, TleCacheError> + Send + Sync {
+    fn always_fail_fetcher() -> impl Fn(u32) -> Result<String, TleCacheError> + Send + Sync {
         |_| Err(TleCacheError::Fetch("test: fetcher disabled".to_string()))
     }
+
+    /// NORAD id used as the fixture key across the cache tests below.
+    /// Matches NOAA 19 — meaningful in case a test file actually leaks
+    /// to disk during debugging, but every test injects a custom
+    /// fetcher / cache dir so no real network call is ever made.
+    const TEST_NORAD: u32 = 33_591;
 
     #[test]
     fn cache_does_not_trust_html_blob_in_fresh_cache_file() {
@@ -726,11 +714,11 @@ SOMETHING
         let dir = unique_temp_dir("html-blob");
         std::fs::create_dir_all(&dir).unwrap();
         let cache = TleCache::with_dir(dir.clone()).with_fetcher(always_fail_fetcher());
-        let path = cache.cache_path(TleSource::Noaa);
+        let path = cache.cache_path(TEST_NORAD);
         let html = "<html><head><title>503</title></head><body>oops</body></html>\n";
         std::fs::write(&path, html).unwrap();
 
-        match cache.tle_text(TleSource::Noaa) {
+        match cache.tle_text(TEST_NORAD) {
             Err(TleCacheError::Fetch(_)) => {}
             Ok(text) => {
                 panic!("cache returned the HTML blob verbatim — corruption was trusted: {text:?}")
@@ -749,11 +737,11 @@ SOMETHING
         let dir = unique_temp_dir("non-utf8");
         std::fs::create_dir_all(&dir).unwrap();
         let cache = TleCache::with_dir(dir.clone()).with_fetcher(always_fail_fetcher());
-        let path = cache.cache_path(TleSource::Noaa);
+        let path = cache.cache_path(TEST_NORAD);
         // 0xFF 0xFE 0x80 0x81 0x82 are invalid as UTF-8 lead bytes.
         std::fs::write(&path, [0xFF_u8, 0xFE, 0x80, 0x81, 0x82]).unwrap();
 
-        match cache.tle_text(TleSource::Noaa) {
+        match cache.tle_text(TEST_NORAD) {
             Err(TleCacheError::Fetch(_)) => {}
             Err(TleCacheError::Io { ref source, .. })
                 if source.kind() == std::io::ErrorKind::InvalidData =>
@@ -777,13 +765,13 @@ SOMETHING
         let dir = unique_temp_dir("toctou");
         std::fs::create_dir_all(&dir).unwrap();
         let cache = TleCache::with_dir(dir.clone()).with_fetcher(always_fail_fetcher());
-        let path = cache.cache_path(TleSource::Noaa);
+        let path = cache.cache_path(TEST_NORAD);
         std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
         // Sanity: fresh-cache fast path works (doesn't go through fetch).
-        assert!(cache.tle_text(TleSource::Noaa).is_ok());
+        assert!(cache.tle_text(TEST_NORAD).is_ok());
         // Race: delete the file before the next call.
         std::fs::remove_file(&path).unwrap();
-        match cache.tle_text(TleSource::Noaa) {
+        match cache.tle_text(TEST_NORAD) {
             Err(TleCacheError::Fetch(_)) => {} // expected: fell through to (failing) fetch
             Err(other @ TleCacheError::Io { .. }) => {
                 panic!("TOCTOU race should fall through to fetch, got Io error: {other:?}")
@@ -802,18 +790,39 @@ SOMETHING
         std::fs::create_dir_all(&dir).unwrap();
         let cache = TleCache::with_dir(dir).with_fetcher(|_| Ok(SAMPLE_TLE_3LINE.to_string()));
         // No file present → goes through the fetch path.
-        let text = cache.tle_text(TleSource::Noaa).unwrap();
+        let text = cache.tle_text(TEST_NORAD).unwrap();
         assert!(text.contains("VANGUARD 1"));
+    }
+
+    #[test]
+    fn cache_fetcher_receives_requested_norad_id() {
+        // The fetcher closure must see the actual NORAD id the caller
+        // asked for — otherwise a custom HTTP stack couldn't build the
+        // right `gp.php?CATNR=…` query. Round-trip an `AtomicU32` so
+        // the test pins the contract regardless of how many times
+        // the fetcher is called.
+        use std::sync::Arc as StdArc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let dir = unique_temp_dir("fetcher-id");
+        std::fs::create_dir_all(&dir).unwrap();
+        let last_seen = StdArc::new(AtomicU32::new(0));
+        let last_seen_clone = StdArc::clone(&last_seen);
+        let cache = TleCache::with_dir(dir).with_fetcher(move |id| {
+            last_seen_clone.store(id, Ordering::Relaxed);
+            Ok(SAMPLE_TLE_3LINE.to_string())
+        });
+        let _ = cache.tle_text(33_591).unwrap();
+        assert_eq!(last_seen.load(Ordering::Relaxed), 33_591);
     }
 
     #[test]
     fn cache_returns_text_when_file_is_fresh() {
         let dir = unique_temp_dir("fresh");
         std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("noaa.txt");
+        let path = dir.join(format!("{TEST_NORAD}.tle"));
         std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
         let cache = TleCache::with_dir(dir.clone());
-        let text = cache.tle_text(TleSource::Noaa).unwrap();
+        let text = cache.tle_text(TEST_NORAD).unwrap();
         assert!(text.contains("VANGUARD 1"));
     }
 
@@ -821,29 +830,28 @@ SOMETHING
     fn cache_returns_tle_pair_when_file_is_fresh() {
         let dir = unique_temp_dir("pair");
         std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("noaa.txt");
+        // Per-NORAD cache: the fixture body needs to contain NORAD 5
+        // and the cache file must be at the path keyed by 5.
+        let path = dir.join("5.tle");
         std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
         let cache = TleCache::with_dir(dir);
-        let (l1, l2) = cache.tle_for(5, TleSource::Noaa).unwrap();
+        let (l1, l2) = cache.tle_for(5).unwrap();
         assert!(l1.starts_with("1 00005"));
         assert!(l2.starts_with("2 00005"));
     }
 
     #[test]
     fn cache_returns_not_found_when_norad_id_missing_from_fresh_file() {
+        // Per-NORAD cache file at id 99999 that contains a different
+        // satellite's entries — should surface as NotFound, not as
+        // a successful match.
         let dir = unique_temp_dir("missing-id");
         std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("noaa.txt");
+        let path = dir.join("99999.tle");
         std::fs::write(&path, SAMPLE_TLE_3LINE).unwrap();
         let cache = TleCache::with_dir(dir);
-        let err = cache.tle_for(99_999, TleSource::Noaa).unwrap_err();
-        assert!(matches!(
-            err,
-            TleCacheError::NotFound {
-                norad_id: 99_999,
-                tle_source: TleSource::Noaa,
-            }
-        ));
+        let err = cache.tle_for(99_999).unwrap_err();
+        assert!(matches!(err, TleCacheError::NotFound { norad_id: 99_999 }));
     }
 
     #[test]
@@ -888,12 +896,12 @@ SOMETHING
         let dir = unique_temp_dir("atomic-write");
         std::fs::create_dir_all(&dir).unwrap();
         let cache = TleCache::with_dir(dir.clone());
-        let path = cache.cache_path(TleSource::Noaa);
+        let path = cache.cache_path(TEST_NORAD);
         cache.write_cache(&path, "hello cache").unwrap();
         let contents = std::fs::read_to_string(&path).unwrap();
         assert_eq!(contents, "hello cache");
         // No leftover tempfiles in the cache directory.
-        // Tempfiles look like `noaa.tmp.12345.0` — `Path::extension()`
+        // Tempfiles look like `33591.tmp.12345.0` — `Path::extension()`
         // returns the *last* segment (`"0"`), not `"tmp"`, so we have
         // to scan the filename string for the `.tmp.` infix instead.
         let leftover_tmp_count = std::fs::read_dir(&dir)

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -44,6 +44,13 @@ sdr-pipeline.workspace = true
 sdr-config.workspace = true
 sdr-radio.workspace = true
 sdr-rtlsdr.workspace = true
+# Satellite pass predictor — used by the Satellites scheduler panel
+# to enumerate upcoming overhead passes and refresh TLEs from
+# Celestrak via the cache's blocking fetcher.
+sdr-sat.workspace = true
+# Pass times rendered as `DateTime<Utc>` and formatted with
+# `Local` for user-facing display.
+chrono.workspace = true
 sdr-source-rtlsdr.workspace = true
 # Scanner state machine — UI references `ScannerState` to map
 # phase enum variants to human-readable labels and builds

--- a/crates/sdr-ui/src/sidebar/activity_bar.rs
+++ b/crates/sdr-ui/src/sidebar/activity_bar.rs
@@ -157,6 +157,19 @@ pub const LEFT_ACTIVITIES: &[ActivityBarEntry] = &[
         shortcut_label: "Ctrl+6",
         accelerator: "<Ctrl>6",
     },
+    ActivityBarEntry {
+        name: "satellites",
+        // `find-location-symbolic` reads as "where things are" —
+        // a fit for pass prediction (we predict *where* a satellite
+        // will be when). GNOME doesn't ship a dedicated satellite
+        // icon, and `network-wireless-symbolic` (the ticket's
+        // alternative) overlaps too closely with our existing
+        // wireless/signal icons elsewhere in the bar.
+        icon_name: "find-location-symbolic",
+        display_name: "Satellites",
+        shortcut_label: "Ctrl+7",
+        accelerator: "<Ctrl>7",
+    },
 ];
 
 /// Canonical right-activity-bar entries — Transcript + Bookmarks.

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -11,6 +11,7 @@ pub mod display_panel;
 pub mod general_panel;
 pub mod navigation_panel;
 pub mod radio_panel;
+pub mod satellites_panel;
 pub mod scanner_panel;
 pub mod server_panel;
 pub mod source_panel;
@@ -26,6 +27,7 @@ pub use display_panel::{DisplayPanel, build_display_panel};
 pub use general_panel::{GeneralPanel, build_general_panel};
 pub use navigation_panel::{NavigationPanel, build_navigation_panel};
 pub use radio_panel::{RadioPanel, build_radio_panel};
+pub use satellites_panel::{SatellitesPanel, build_satellites_panel};
 pub use scanner_panel::{ScannerPanel, build_scanner_panel};
 pub use server_panel::{ServerPanel, build_server_panel};
 pub use source_panel::{SourcePanel, build_source_panel};
@@ -65,6 +67,11 @@ pub struct SidebarPanels {
     /// issue #317). Master switch, active-channel / state
     /// display, lockout button, default dwell/hang sliders.
     pub scanner: ScannerPanel,
+    /// Satellites scheduler — ground station settings, TLE refresh
+    /// status, upcoming passes, auto-record toggle. Drives the
+    /// "Satellites" left activity (#481), with the auto-record
+    /// switch driving #482's APT-on-pass wiring.
+    pub satellites: SatellitesPanel,
 }
 
 /// Build every sidebar panel. Activity-bar migration: each panel
@@ -81,6 +88,7 @@ pub fn build_panels() -> SidebarPanels {
     let display = build_display_panel();
     let navigation = build_navigation_panel();
     let scanner = build_scanner_panel();
+    let satellites = build_satellites_panel();
     // Flyout is built after navigation because it borrows the
     // left-sidebar `name_entry` — its row actions (recall,
     // delete-of-active) sync the entry field.
@@ -104,5 +112,6 @@ pub fn build_panels() -> SidebarPanels {
         bookmarks,
         server,
         scanner,
+        satellites,
     }
 }

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -1,0 +1,649 @@
+//! Satellite pass scheduler panel — ground station settings, TLE
+//! refresh status, upcoming-passes list, auto-record toggle.
+//!
+//! Pure view module: this file builds the widgets and exposes them
+//! through [`SatellitesPanel`]. Signal-handler wiring (persisting
+//! station coordinates on edit, kicking off TLE refreshes on a
+//! worker thread, the 1 Hz countdown timer, recomputing the pass
+//! list when ground station or TLEs change) lives in
+//! `window.rs::connect_satellites_panel` — same separation as
+//! `scanner_panel`.
+//!
+//! ## Layout
+//!
+//! Three flat `AdwPreferencesGroup`s on a single
+//! `AdwPreferencesPage` (no `AdwExpanderRow`s — see CLAUDE.md
+//! "Sidebar architecture" for the rationale):
+//!
+//! 1. **Ground Station** — latitude / longitude / altitude
+//!    `AdwSpinRow`s plus a "ZIP code" entry that resolves to a
+//!    centroid via [`sdr_sat::lookup_us_zip`]. First-run defaults
+//!    to the geographic centre of the contiguous US so passes show
+//!    up immediately and the user can tweak (or paste a ZIP) from
+//!    a sensible starting point. ZIP lookup is US-only by design;
+//!    international users enter lat/lon by hand.
+//! 2. **TLE Data** — last-refreshed timestamp + a refresh button
+//!    that re-downloads each entry in [`KNOWN_SATELLITES`] via
+//!    Celestrak's per-NORAD `gp.php?CATNR=…` endpoint, through
+//!    [`sdr_sat::TleCache`]. The button uses an `AdwSpinner` to
+//!    show progress; refresh runs on a worker thread so the UI
+//!    stays responsive.
+//! 3. **Recording** — auto-record `AdwSwitchRow` (drives #482's
+//!    auto-record-on-pass wiring once it lands).
+//! 4. **Upcoming Passes** — one `AdwActionRow` per pass; titles
+//!    carry "Sat name — countdown", subtitles carry max elevation
+//!    plus start/end direction. Empty state shows a placeholder
+//!    row pointing the user at the Refresh button.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use sdr_config::ConfigManager;
+use sdr_sat::{
+    GroundStation, KNOWN_SATELLITES, Pass, Satellite, TleCache, TleCacheError, upcoming_passes,
+};
+
+// ─── First-run defaults ────────────────────────────────────────────────
+
+/// Geographic center of the contiguous US (≈ Lebanon, Kansas).
+/// First-run default so passes appear immediately and the user
+/// adjusts from a known-OK starting point rather than (0, 0) ocean.
+pub const DEFAULT_STATION_LAT_DEG: f64 = 39.8283;
+/// Geographic center of the contiguous US — longitude.
+pub const DEFAULT_STATION_LON_DEG: f64 = -98.5795;
+/// Default altitude — sea level. Most users are within a few hundred
+/// metres of this; pass timings are mostly insensitive to altitude
+/// at LEO ranges.
+pub const DEFAULT_STATION_ALT_M: f64 = 0.0;
+
+// ─── SpinRow bounds ────────────────────────────────────────────────────
+
+/// Latitude range, degrees north (negative = south).
+pub const LAT_MIN_DEG: f64 = -90.0;
+pub const LAT_MAX_DEG: f64 = 90.0;
+/// Longitude range, degrees east (negative = west).
+pub const LON_MIN_DEG: f64 = -180.0;
+pub const LON_MAX_DEG: f64 = 180.0;
+/// Altitude range, metres above the WGS84 ellipsoid. Lower bound
+/// covers the Dead Sea (-430 m); upper bound covers Mt Everest
+/// (8849 m). Anything outside this range is almost certainly user
+/// error or a flying-receiver scenario we'll address separately.
+pub const ALT_MIN_M: f64 = -500.0;
+pub const ALT_MAX_M: f64 = 9000.0;
+
+/// Step / increment values for the `SpinRow`s. Lat/lon use 0.0001°
+/// (~11 m at the equator) which is plenty of precision for pass
+/// prediction; altitude is in whole metres.
+const LATLON_STEP_DEG: f64 = 0.0001;
+const ALT_STEP_M: f64 = 1.0;
+const LATLON_DIGITS: u32 = 4;
+const ALT_DIGITS: u32 = 0;
+
+// ─── Pass enumeration tunables ─────────────────────────────────────────
+
+/// How many upcoming passes the panel surfaces by default. Six fits
+/// comfortably in the activity-bar panel without scrolling, and
+/// covers ~12 hours of LEO activity at most stations (NOAA + Meteor
+/// are 4-6 passes/day each visible above the horizon).
+pub const DEFAULT_PASS_DISPLAY_COUNT: usize = 6;
+
+/// Minimum peak elevation (degrees) for a pass to appear in the
+/// list. Below ~5° the signal usually has too much horizon
+/// attenuation to decode anything useful; we filter here so the
+/// list reads as "things you can actually catch".
+pub const MIN_PASS_ELEVATION_DEG: f64 = 5.0;
+
+/// Forward window for pass enumeration. 24 h gives the user plenty
+/// of advance planning info; cheap to compute (a few hundred
+/// elevation evaluations per satellite per call).
+pub const PASS_LOOKAHEAD_HOURS: i64 = 24;
+
+// ─── Config keys ───────────────────────────────────────────────────────
+
+/// Persisted latitude (degrees, north-positive).
+pub const KEY_STATION_LAT_DEG: &str = "sat_station_lat_deg";
+/// Persisted longitude (degrees, east-positive).
+pub const KEY_STATION_LON_DEG: &str = "sat_station_lon_deg";
+/// Persisted altitude (metres above WGS84 ellipsoid).
+pub const KEY_STATION_ALT_M: &str = "sat_station_alt_m";
+/// Persisted RFC3339 timestamp of the last successful TLE refresh.
+pub const KEY_TLE_LAST_REFRESH: &str = "sat_tle_last_refresh";
+/// Persisted "auto-record APT passes" toggle.
+pub const KEY_AUTO_RECORD_APT: &str = "sat_auto_record_apt";
+
+// ─── Panel ─────────────────────────────────────────────────────────────
+
+/// Widgets composing the Satellites scheduler panel. `Clone` is
+/// derived so `connect_satellites_panel` can hand pieces to
+/// closures without lifetime acrobatics — every field is a `GObject`
+/// wrapper, so clone is a cheap refcount bump.
+#[derive(Clone)]
+pub struct SatellitesPanel {
+    /// Root widget — `AdwPreferencesPage` packed into the
+    /// "satellites" `GtkStack` child.
+    pub widget: adw::PreferencesPage,
+
+    // Ground station group --------------------------------------------------
+    /// Latitude in decimal degrees (`LAT_MIN_DEG..=LAT_MAX_DEG`).
+    pub lat_row: adw::SpinRow,
+    /// Longitude in decimal degrees (`LON_MIN_DEG..=LON_MAX_DEG`).
+    pub lon_row: adw::SpinRow,
+    /// Altitude in metres above the WGS84 ellipsoid.
+    pub alt_row: adw::SpinRow,
+    /// US ZIP code entry. The built-in apply button (Enter / click)
+    /// fires `apply` and `connect_satellites_panel` runs the lookup,
+    /// updating `lat_row` and `lon_row`. Result text lands in
+    /// [`zip_status_row`](Self::zip_status_row) — `AdwEntryRow` has
+    /// no subtitle slot of its own.
+    pub zip_row: adw::EntryRow,
+    /// Spinner shown next to the apply button while a lookup is in
+    /// flight. Toggled by `connect_satellites_panel`.
+    pub zip_spinner: gtk4::Spinner,
+    /// Status / feedback row for ZIP lookups. Hidden on first launch;
+    /// `connect_satellites_panel` reveals it on the first lookup
+    /// attempt and rewrites the title with success ("Resolved:
+    /// Christiansburg, VA") or failure ("ZIP 99999 not found in
+    /// postal database") text.
+    pub zip_status_row: adw::ActionRow,
+
+    // TLE status group ------------------------------------------------------
+    /// Action row carrying the "last refreshed" timestamp in its
+    /// subtitle. Updated by `connect_satellites_panel` when a
+    /// refresh completes.
+    pub last_refresh_row: adw::ActionRow,
+    /// Refresh button packed as a suffix on `last_refresh_row`.
+    /// Click handler in `connect_satellites_panel` spawns a
+    /// blocking TLE fetch on a worker thread.
+    pub refresh_button: gtk4::Button,
+    /// Spinner shown next to the refresh button while a fetch is
+    /// in flight. Sibling to the button rather than wrapping it so
+    /// the button stays clickable visually after the fetch ends.
+    pub refresh_spinner: gtk4::Spinner,
+
+    // Recording group -------------------------------------------------------
+    /// Auto-record toggle — drives #482's "open APT viewer +
+    /// start decoding when a NOAA pass starts" wiring.
+    pub auto_record_switch: adw::SwitchRow,
+
+    // Next passes group -----------------------------------------------------
+    /// The preferences group hosting the dynamically-built pass
+    /// rows. `connect_satellites_panel` adds / removes
+    /// `AdwActionRow`s from this group as the pass list is
+    /// recomputed.
+    pub passes_group: adw::PreferencesGroup,
+    /// Empty-state row shown before any TLE refresh has succeeded
+    /// or when no passes meet the elevation threshold in the
+    /// lookahead window. Removed from the group when real pass
+    /// rows are added; re-added when the list goes empty.
+    pub passes_status_row: adw::ActionRow,
+}
+
+/// Build the Satellites scheduler panel widgets with first-run
+/// defaults. Persisted values are restored later by
+/// `window.rs::connect_satellites_panel` *before* it wires the
+/// change-notify handlers, matching the scanner-panel pattern
+/// (avoids spurious save-on-restore feedback during window
+/// construction).
+#[must_use]
+pub fn build_satellites_panel() -> SatellitesPanel {
+    let page = adw::PreferencesPage::new();
+
+    // ─── Ground station ────────────────────────────────────────
+    let station_group = adw::PreferencesGroup::builder()
+        .title("Ground Station")
+        .description("Used to compute pass times for your location.")
+        .build();
+
+    let lat_row = adw::SpinRow::with_range(LAT_MIN_DEG, LAT_MAX_DEG, LATLON_STEP_DEG);
+    lat_row.set_title("Latitude");
+    lat_row.set_subtitle("Degrees north (negative = south)");
+    lat_row.set_digits(LATLON_DIGITS);
+    lat_row.set_value(DEFAULT_STATION_LAT_DEG);
+    station_group.add(&lat_row);
+
+    let lon_row = adw::SpinRow::with_range(LON_MIN_DEG, LON_MAX_DEG, LATLON_STEP_DEG);
+    lon_row.set_title("Longitude");
+    lon_row.set_subtitle("Degrees east (negative = west)");
+    lon_row.set_digits(LATLON_DIGITS);
+    lon_row.set_value(DEFAULT_STATION_LON_DEG);
+    station_group.add(&lon_row);
+
+    let alt_row = adw::SpinRow::with_range(ALT_MIN_M, ALT_MAX_M, ALT_STEP_M);
+    alt_row.set_title("Altitude");
+    alt_row.set_subtitle("Metres above WGS84 ellipsoid (≈ sea level)");
+    alt_row.set_digits(ALT_DIGITS);
+    alt_row.set_value(DEFAULT_STATION_ALT_M);
+    station_group.add(&alt_row);
+
+    // ZIP-code shortcut: the apply button (Enter / click) fires the
+    // `apply` signal that `connect_satellites_panel` listens on. The
+    // wiring layer runs the network lookup off-thread and writes
+    // back to `lat_row`/`lon_row` on success.
+    let zip_row = adw::EntryRow::builder()
+        .title("US ZIP code")
+        .show_apply_button(true)
+        .input_purpose(gtk4::InputPurpose::Digits)
+        .build();
+    let zip_spinner = gtk4::Spinner::builder().visible(false).build();
+    zip_row.add_suffix(&zip_spinner);
+    station_group.add(&zip_row);
+
+    let zip_status_row = adw::ActionRow::builder().visible(false).build();
+    station_group.add(&zip_status_row);
+
+    page.add(&station_group);
+
+    // ─── TLE Data ──────────────────────────────────────────────
+    let tle_group = adw::PreferencesGroup::builder()
+        .title("TLE Data")
+        .description("Two-line element sets fetched from celestrak.org.")
+        .build();
+
+    let last_refresh_row = adw::ActionRow::builder()
+        .title("Last refreshed")
+        .subtitle("Never")
+        .build();
+
+    let refresh_spinner = gtk4::Spinner::builder().visible(false).build();
+
+    let refresh_button = gtk4::Button::builder()
+        .icon_name("view-refresh-symbolic")
+        .tooltip_text("Re-download TLE data from celestrak.org")
+        .valign(gtk4::Align::Center)
+        .css_classes(["flat"])
+        .build();
+    // Tooltips aren't read by screen readers — set the accessible
+    // label too, matching the project rule for icon-only buttons.
+    refresh_button.update_property(&[gtk4::accessible::Property::Label("Refresh TLE data")]);
+
+    let refresh_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
+    refresh_box.append(&refresh_spinner);
+    refresh_box.append(&refresh_button);
+    last_refresh_row.add_suffix(&refresh_box);
+
+    tle_group.add(&last_refresh_row);
+    page.add(&tle_group);
+
+    // ─── Recording ─────────────────────────────────────────────
+    let recording_group = adw::PreferencesGroup::builder()
+        .title("Recording")
+        .description("Pick what happens when a pass becomes active.")
+        .build();
+
+    let auto_record_switch = adw::SwitchRow::builder()
+        .title("Auto-record APT passes")
+        .subtitle("Tune to the satellite, start the decoder, save the image at LOS.")
+        .active(false)
+        .build();
+    recording_group.add(&auto_record_switch);
+    page.add(&recording_group);
+
+    // ─── Upcoming Passes ──────────────────────────────────────
+    let passes_group = adw::PreferencesGroup::builder()
+        .title("Upcoming Passes")
+        .description(format!(
+            "Next {DEFAULT_PASS_DISPLAY_COUNT} passes above \
+             {MIN_PASS_ELEVATION_DEG:.0}° in the coming {PASS_LOOKAHEAD_HOURS} h."
+        ))
+        .build();
+
+    let passes_status_row = adw::ActionRow::builder()
+        .title("No passes yet")
+        .subtitle("Click ↻ to fetch fresh TLE data, or adjust your ground station above.")
+        .build();
+    passes_group.add(&passes_status_row);
+    page.add(&passes_group);
+
+    SatellitesPanel {
+        widget: page,
+        lat_row,
+        lon_row,
+        alt_row,
+        zip_row,
+        zip_spinner,
+        zip_status_row,
+        last_refresh_row,
+        refresh_button,
+        refresh_spinner,
+        auto_record_switch,
+        passes_group,
+        passes_status_row,
+    }
+}
+
+// ─── Config readers / writers used by the wiring layer ───────────────
+
+/// Read the persisted ground station latitude, or fall back to
+/// [`DEFAULT_STATION_LAT_DEG`].
+#[must_use]
+pub fn load_station_lat_deg(config: &Arc<ConfigManager>) -> f64 {
+    read_f64_or(config, KEY_STATION_LAT_DEG, DEFAULT_STATION_LAT_DEG)
+}
+
+/// Read the persisted ground station longitude, or fall back to
+/// [`DEFAULT_STATION_LON_DEG`].
+#[must_use]
+pub fn load_station_lon_deg(config: &Arc<ConfigManager>) -> f64 {
+    read_f64_or(config, KEY_STATION_LON_DEG, DEFAULT_STATION_LON_DEG)
+}
+
+/// Read the persisted ground station altitude, or fall back to
+/// [`DEFAULT_STATION_ALT_M`].
+#[must_use]
+pub fn load_station_alt_m(config: &Arc<ConfigManager>) -> f64 {
+    read_f64_or(config, KEY_STATION_ALT_M, DEFAULT_STATION_ALT_M)
+}
+
+/// Read the persisted "auto-record APT passes" toggle state.
+/// Defaults to `false` (opt-in).
+#[must_use]
+pub fn load_auto_record_apt(config: &Arc<ConfigManager>) -> bool {
+    read_bool_or(config, KEY_AUTO_RECORD_APT, false)
+}
+
+/// Persist `value` under `key`. Single helper for the three
+/// lat/lon/alt `SpinRow` change-notify handlers.
+pub fn save_f64(config: &Arc<ConfigManager>, key: &str, value: f64) {
+    config.write(|v| {
+        v[key] = serde_json::json!(value);
+    });
+}
+
+/// Persist `value` under [`KEY_AUTO_RECORD_APT`].
+pub fn save_auto_record_apt(config: &Arc<ConfigManager>, value: bool) {
+    config.write(|v| {
+        v[KEY_AUTO_RECORD_APT] = serde_json::json!(value);
+    });
+}
+
+/// Persist a fresh "last refreshed" RFC3339 timestamp under
+/// [`KEY_TLE_LAST_REFRESH`].
+pub fn save_tle_last_refresh(config: &Arc<ConfigManager>, when: DateTime<Utc>) {
+    config.write(|v| {
+        v[KEY_TLE_LAST_REFRESH] = serde_json::json!(when.to_rfc3339());
+    });
+}
+
+fn read_f64_or(config: &Arc<ConfigManager>, key: &str, default: f64) -> f64 {
+    config.read(|v| {
+        v.get(key)
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(default)
+    })
+}
+
+fn read_bool_or(config: &Arc<ConfigManager>, key: &str, default: bool) -> bool {
+    config.read(|v| {
+        v.get(key)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(default)
+    })
+}
+
+// ─── Helpers used by the wiring layer ─────────────────────────────────
+
+/// Description text shown on a pass row alongside its title-line
+/// countdown. Format: `"max el 56°  ·  AOS 245° → LOS 105°"`.
+#[must_use]
+pub fn format_pass_subtitle(pass: &Pass) -> String {
+    format!(
+        "max el {:.0}°  ·  AOS {:.0}° → LOS {:.0}°",
+        pass.max_elevation_deg, pass.start_az_deg, pass.end_az_deg,
+    )
+}
+
+/// Title-line countdown rendering. Examples:
+///
+/// * `"NOAA 19 — in 1h 12m"`
+/// * `"NOAA 19 — in 4 min"`
+/// * `"NOAA 19 — starting now"`
+/// * `"NOAA 19 — in progress (3 min in)"`
+/// * `"NOAA 19 — ended"` (only seen briefly between recomputes)
+#[must_use]
+pub fn format_pass_title(pass: &Pass, now: DateTime<Utc>) -> String {
+    let to_start = pass.start - now;
+    let to_end = pass.end - now;
+    let secs = to_start.num_seconds();
+    let label = if secs > 3_600 {
+        let h = secs / 3_600;
+        let m = (secs % 3_600) / 60;
+        format!("in {h}h {m:02}m")
+    } else if secs > 60 {
+        format!("in {} min", secs / 60)
+    } else if secs > 0 {
+        "starting now".to_string()
+    } else if to_end.num_seconds() > 0 {
+        format!("in progress ({} min in)", -secs / 60)
+    } else {
+        "ended".to_string()
+    };
+    format!("{} — {}", pass.satellite, label)
+}
+
+/// Enumerate the next [`DEFAULT_PASS_DISPLAY_COUNT`] visible passes
+/// across every entry in [`KNOWN_SATELLITES`], sorted by start
+/// time.
+///
+/// Errors looking up a TLE for a particular satellite (not yet
+/// fetched, decommissioned, etc.) are logged and silently skipped
+/// — the rest of the list still renders. Returns an empty `Vec`
+/// when no satellites have usable TLEs (e.g. before the first
+/// successful refresh).
+#[must_use]
+pub fn enumerate_upcoming_passes(
+    cache: &TleCache,
+    station: &GroundStation,
+    from: DateTime<Utc>,
+) -> Vec<Pass> {
+    let to = from + ChronoDuration::hours(PASS_LOOKAHEAD_HOURS);
+    let mut passes = Vec::new();
+    for known in KNOWN_SATELLITES {
+        match cache.tle_for(known.norad_id) {
+            Ok((line1, line2)) => match Satellite::from_tle(known.name, &line1, &line2) {
+                Ok(sat) => {
+                    let mut found =
+                        upcoming_passes(station, &sat, from, to, MIN_PASS_ELEVATION_DEG);
+                    passes.append(&mut found);
+                }
+                Err(e) => log_satellite_skip(known.name, &e.to_string()),
+            },
+            Err(TleCacheError::NotFound { .. }) => {
+                // Common case before the first refresh — quiet log.
+                tracing::debug!(
+                    "no cached TLE for {} (NORAD {}); refresh to enable",
+                    known.name,
+                    known.norad_id,
+                );
+            }
+            Err(e) => log_satellite_skip(known.name, &e.to_string()),
+        }
+    }
+    passes.sort_by_key(|p| p.start);
+    passes.truncate(DEFAULT_PASS_DISPLAY_COUNT);
+    passes
+}
+
+fn log_satellite_skip(name: &str, why: &str) {
+    tracing::warn!("skipping satellite {name} in pass list: {why}");
+}
+
+/// Format the "last refreshed" timestamp for the action row's
+/// subtitle. Shows "Never" if no refresh has been recorded; shows
+/// the local-timezone wall-clock time otherwise so it reads
+/// naturally to the user.
+#[must_use]
+pub fn format_last_refresh(config: &Arc<ConfigManager>) -> String {
+    let raw = config.read(|v| {
+        v.get(KEY_TLE_LAST_REFRESH)
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+    });
+    match raw {
+        None => "Never".to_string(),
+        Some(rfc3339) => match chrono::DateTime::parse_from_rfc3339(&rfc3339) {
+            Ok(dt) => dt
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M %Z")
+                .to_string(),
+            Err(_) => rfc3339, // Show the raw stamp on parse failure
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn defaults_lie_inside_spinrow_bounds() {
+        // Belt-and-braces: if someone tweaks DEFAULT_STATION_*
+        // without updating the bounds, the SpinRow would clamp
+        // the seeded value silently. Pin the invariant.
+        assert!((LAT_MIN_DEG..=LAT_MAX_DEG).contains(&DEFAULT_STATION_LAT_DEG));
+        assert!((LON_MIN_DEG..=LON_MAX_DEG).contains(&DEFAULT_STATION_LON_DEG));
+        assert!((ALT_MIN_M..=ALT_MAX_M).contains(&DEFAULT_STATION_ALT_M));
+    }
+
+    #[test]
+    fn read_f64_or_returns_default_for_missing_key() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({})));
+        assert_eq!(read_f64_or(&cfg, "missing_key", 42.5), 42.5);
+    }
+
+    #[test]
+    fn read_f64_or_returns_default_for_wrong_type() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            "wrong_type": "not a float",
+        })));
+        assert_eq!(read_f64_or(&cfg, "wrong_type", 42.5), 42.5);
+    }
+
+    #[test]
+    fn read_f64_or_returns_persisted_value() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            "stored": 12.34,
+        })));
+        assert_eq!(read_f64_or(&cfg, "stored", 99.0), 12.34);
+    }
+
+    #[test]
+    fn read_bool_or_returns_persisted_value() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            "auto": true,
+        })));
+        assert!(read_bool_or(&cfg, "auto", false));
+    }
+
+    #[test]
+    fn format_last_refresh_says_never_when_unset() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({})));
+        assert_eq!(format_last_refresh(&cfg), "Never");
+    }
+
+    #[test]
+    fn format_last_refresh_renders_rfc3339_in_local_time() {
+        // 2024-06-15T18:30:00Z is unambiguous; we don't pin the
+        // local-formatted string (it depends on the test
+        // runner's TZ) but assert the formatter doesn't return
+        // the raw RFC3339 string OR "Never".
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            "sat_tle_last_refresh": "2024-06-15T18:30:00Z",
+        })));
+        let formatted = format_last_refresh(&cfg);
+        assert_ne!(formatted, "Never");
+        assert!(
+            !formatted.contains('T'),
+            "RFC3339 'T' separator leaked into user-facing format: {formatted}"
+        );
+    }
+
+    #[test]
+    fn format_last_refresh_falls_back_to_raw_on_parse_error() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            "sat_tle_last_refresh": "garbage timestamp",
+        })));
+        assert_eq!(format_last_refresh(&cfg), "garbage timestamp");
+    }
+
+    fn synthetic_pass(now: DateTime<Utc>, offset_min: i64) -> Pass {
+        let start = now + ChronoDuration::minutes(offset_min);
+        Pass {
+            satellite: "NOAA 19".to_string(),
+            start,
+            end: start + ChronoDuration::minutes(12),
+            max_elevation_deg: 56.0,
+            max_el_time: start + ChronoDuration::minutes(6),
+            start_az_deg: 245.0,
+            end_az_deg: 105.0,
+        }
+    }
+
+    #[test]
+    fn format_pass_subtitle_shows_elevation_and_azimuths() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_pass(now, 30);
+        let subtitle = format_pass_subtitle(&pass);
+        assert!(subtitle.contains("max el 56"));
+        assert!(subtitle.contains("AOS 245"));
+        assert!(subtitle.contains("LOS 105"));
+    }
+
+    #[test]
+    fn format_pass_title_uses_h_m_for_far_passes() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_pass(now, 75); // 1 h 15 min away
+        let title = format_pass_title(&pass, now);
+        assert_eq!(title, "NOAA 19 — in 1h 15m");
+    }
+
+    #[test]
+    fn format_pass_title_uses_minutes_for_near_passes() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_pass(now, 12); // 12 min away
+        assert_eq!(format_pass_title(&pass, now), "NOAA 19 — in 12 min");
+    }
+
+    #[test]
+    fn format_pass_title_says_starting_now_inside_one_minute() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Pass starts in 30 seconds.
+        let pass = Pass {
+            satellite: "NOAA 19".to_string(),
+            start: now + ChronoDuration::seconds(30),
+            end: now + ChronoDuration::minutes(12),
+            max_elevation_deg: 50.0,
+            max_el_time: now + ChronoDuration::minutes(5),
+            start_az_deg: 0.0,
+            end_az_deg: 0.0,
+        };
+        assert_eq!(format_pass_title(&pass, now), "NOAA 19 — starting now");
+    }
+
+    #[test]
+    fn format_pass_title_says_in_progress_for_active_passes() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Started 3 minutes ago, ends in 9.
+        let pass = synthetic_pass(now, -3);
+        let title = format_pass_title(&pass, now);
+        assert!(
+            title.contains("in progress"),
+            "expected 'in progress', got {title:?}"
+        );
+        assert!(
+            title.contains("3 min in"),
+            "expected '3 min in', got {title:?}"
+        );
+    }
+
+    #[test]
+    fn format_pass_title_says_ended_after_los() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Pass ended 30 minutes ago.
+        let pass = synthetic_pass(now, -42);
+        assert_eq!(format_pass_title(&pass, now), "NOAA 19 — ended");
+    }
+}

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -145,16 +145,15 @@ pub struct SatellitesPanel {
     /// fires `apply` and `connect_satellites_panel` runs the lookup,
     /// updating `lat_row` and `lon_row`. Result text lands in
     /// [`zip_status_row`](Self::zip_status_row) — `AdwEntryRow` has
-    /// no subtitle slot of its own.
+    /// no subtitle slot of its own. No custom spinner suffix on
+    /// purpose — it conflicts with the built-in apply button.
     pub zip_row: adw::EntryRow,
-    /// Spinner shown next to the apply button while a lookup is in
-    /// flight. Toggled by `connect_satellites_panel`.
-    pub zip_spinner: gtk4::Spinner,
-    /// Status / feedback row for ZIP lookups. Hidden on first launch;
-    /// `connect_satellites_panel` reveals it on the first lookup
-    /// attempt and rewrites the title with success ("Resolved:
-    /// Christiansburg, VA") or failure ("ZIP 99999 not found in
-    /// postal database") text.
+    /// Status / feedback row for ZIP lookups. Always visible — the
+    /// initial title is a hint ("Type a US ZIP code and press ↵")
+    /// that gets rewritten by `connect_satellites_panel` on each
+    /// lookup attempt: "Looking up…" while in flight, then
+    /// "Resolved: Christiansburg, VA (647 m)" or the error text
+    /// from `PostalLookupError::Display` on failure.
     pub zip_status_row: adw::ActionRow,
 
     // TLE status group ------------------------------------------------------
@@ -218,8 +217,6 @@ pub struct SatellitesPanelWeak {
     pub alt_row: glib::WeakRef<adw::SpinRow>,
     /// Weak ref to [`SatellitesPanel::zip_row`].
     pub zip_row: glib::WeakRef<adw::EntryRow>,
-    /// Weak ref to [`SatellitesPanel::zip_spinner`].
-    pub zip_spinner: glib::WeakRef<gtk4::Spinner>,
     /// Weak ref to [`SatellitesPanel::zip_status_row`].
     pub zip_status_row: glib::WeakRef<adw::ActionRow>,
     /// Weak ref to [`SatellitesPanel::last_refresh_row`].
@@ -249,7 +246,6 @@ impl SatellitesPanel {
             lon_row: self.lon_row.downgrade(),
             alt_row: self.alt_row.downgrade(),
             zip_row: self.zip_row.downgrade(),
-            zip_spinner: self.zip_spinner.downgrade(),
             zip_status_row: self.zip_status_row.downgrade(),
             last_refresh_row: self.last_refresh_row.downgrade(),
             refresh_button: self.refresh_button.downgrade(),
@@ -276,7 +272,6 @@ impl SatellitesPanelWeak {
             lon_row: self.lon_row.upgrade()?,
             alt_row: self.alt_row.upgrade()?,
             zip_row: self.zip_row.upgrade()?,
-            zip_spinner: self.zip_spinner.upgrade()?,
             zip_status_row: self.zip_status_row.upgrade()?,
             last_refresh_row: self.last_refresh_row.upgrade()?,
             refresh_button: self.refresh_button.upgrade()?,
@@ -329,16 +324,32 @@ pub fn build_satellites_panel() -> SatellitesPanel {
     // `apply` signal that `connect_satellites_panel` listens on. The
     // wiring layer runs the network lookup off-thread and writes
     // back to `lat_row`/`lon_row` on success.
+    //
+    // Deliberately NO custom suffix widget: AdwEntryRow's built-in
+    // apply button lives in the suffix slot, and an earlier attempt
+    // to pack a `gtk4::Spinner` next to it broke the apply button —
+    // the user's Enter / click stopped firing the `apply` signal,
+    // presumably because the layout pushed the apply button out of
+    // its normal position. The status row below carries
+    // "Looking up…" / "Resolved: …" text instead, which is plenty
+    // of feedback for a sub-second lookup.
     let zip_row = adw::EntryRow::builder()
         .title("US ZIP code")
         .show_apply_button(true)
         .input_purpose(gtk4::InputPurpose::Digits)
         .build();
-    let zip_spinner = gtk4::Spinner::builder().visible(false).build();
-    zip_row.add_suffix(&zip_spinner);
     station_group.add(&zip_row);
 
-    let zip_status_row = adw::ActionRow::builder().visible(false).build();
+    // Always visible — toggling `visible(false) → set_visible(true)`
+    // on rows packed into an `AdwPreferencesGroup` doesn't always
+    // surface the row reliably (the group's internal listbox caches
+    // child measurements at construction). Always-visible with a
+    // hint title is also better UX: the user sees the affordance
+    // without having to attempt a lookup first.
+    let zip_status_row = adw::ActionRow::builder()
+        .title("Type a US ZIP code and press ↵")
+        .css_classes(["dim-label"])
+        .build();
     station_group.add(&zip_status_row);
 
     page.add(&station_group);
@@ -410,7 +421,6 @@ pub fn build_satellites_panel() -> SatellitesPanel {
         lon_row,
         alt_row,
         zip_row,
-        zip_spinner,
         zip_status_row,
         last_refresh_row,
         refresh_button,
@@ -557,7 +567,13 @@ pub fn enumerate_upcoming_passes(
     let to = from + ChronoDuration::hours(PASS_LOOKAHEAD_HOURS);
     let mut passes = Vec::new();
     for known in KNOWN_SATELLITES {
-        match cache.tle_for(known.norad_id) {
+        // `cached_tle_for` (NOT `tle_for`) — this loop runs on the
+        // GTK main thread on every lat/lon/alt edit, and `tle_for`
+        // can trigger a synchronous HTTP fetch on cache miss /
+        // staleness. A network call here would freeze the panel
+        // mid-edit. The user explicitly refreshes via the button,
+        // which uses `force_refresh` off-thread instead.
+        match cache.cached_tle_for(known.norad_id) {
             Ok((line1, line2)) => match Satellite::from_tle(known.name, &line1, &line2) {
                 Ok(sat) => {
                     let mut found =
@@ -664,17 +680,25 @@ mod tests {
     #[test]
     fn format_last_refresh_renders_rfc3339_in_local_time() {
         // 2024-06-15T18:30:00Z is unambiguous; we don't pin the
-        // local-formatted string (it depends on the test
-        // runner's TZ) but assert the formatter doesn't return
-        // the raw RFC3339 string OR "Never".
+        // local-formatted string (it depends on the test runner's
+        // TZ). Pin two timezone-independent invariants instead:
+        //
+        //   1. The output isn't the literal "Never" placeholder.
+        //   2. The output isn't the raw RFC3339 string — i.e. byte
+        //      10 is the date-vs-time separator, and the formatter
+        //      uses a space (`%Y-%m-%d %H:%M %Z`) where RFC3339
+        //      uses `T`. Checking *that specific position* avoids
+        //      false negatives from timezone abbreviations like
+        //      `UTC` / `EDT` / `PDT` that happen to contain a `T`.
         let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
             "sat_tle_last_refresh": "2024-06-15T18:30:00Z",
         })));
         let formatted = format_last_refresh(&cfg);
         assert_ne!(formatted, "Never");
-        assert!(
-            !formatted.contains('T'),
-            "RFC3339 'T' separator leaked into user-facing format: {formatted}"
+        assert_eq!(
+            formatted.chars().nth(10),
+            Some(' '),
+            "expected a space at position 10 (date/time separator); got: {formatted}",
         );
     }
 

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -38,6 +38,8 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use gtk4::glib;
+use gtk4::prelude::ObjectExt;
 use libadwaita as adw;
 use libadwaita::prelude::*;
 use sdr_config::ConfigManager;
@@ -99,6 +101,13 @@ pub const MIN_PASS_ELEVATION_DEG: f64 = 5.0;
 /// of advance planning info; cheap to compute (a few hundred
 /// elevation evaluations per satellite per call).
 pub const PASS_LOOKAHEAD_HOURS: i64 = 24;
+
+/// Seconds per minute / hour, named so the countdown formatter in
+/// [`format_pass_title`] reads as logic rather than as a wall of
+/// `60`s and `3_600`s. Per project convention (CLAUDE.md "DSP
+/// conventions"): name magic numbers.
+const SECS_PER_MINUTE: i64 = 60;
+const SECS_PER_HOUR: i64 = 60 * SECS_PER_MINUTE;
 
 // ─── Config keys ───────────────────────────────────────────────────────
 
@@ -178,6 +187,105 @@ pub struct SatellitesPanel {
     /// lookahead window. Removed from the group when real pass
     /// rows are added; re-added when the list goes empty.
     pub passes_status_row: adw::ActionRow,
+}
+
+/// Weak counterpart of [`SatellitesPanel`] — every field is a
+/// `glib::WeakRef`, so capturing one of these in a long-lived
+/// closure (signal handler, `GLib` timer, async task) does NOT pin
+/// the panel widgets alive.
+///
+/// **Why this exists:** the strong [`SatellitesPanel`] is `Clone`,
+/// which made it tempting to capture clones inside closures stored
+/// on the panel's own widgets — but doing so creates a refcount
+/// cycle (widget → handler → closure → cloned panel → widget). The
+/// cycle blocks teardown forever, including the 1 Hz countdown
+/// timer's `WeakRef::upgrade` exit check (the upgrade keeps
+/// returning `Some` because the panel can't drop). Using these
+/// weak refs in every closure breaks the cycle and lets the panel
+/// drop cleanly when the window closes.
+///
+/// `Clone` is derived so the same weak handle can be cheaply
+/// cloned into multiple closures.
+#[derive(Clone)]
+pub struct SatellitesPanelWeak {
+    /// Weak ref to [`SatellitesPanel::widget`].
+    pub widget: glib::WeakRef<adw::PreferencesPage>,
+    /// Weak ref to [`SatellitesPanel::lat_row`].
+    pub lat_row: glib::WeakRef<adw::SpinRow>,
+    /// Weak ref to [`SatellitesPanel::lon_row`].
+    pub lon_row: glib::WeakRef<adw::SpinRow>,
+    /// Weak ref to [`SatellitesPanel::alt_row`].
+    pub alt_row: glib::WeakRef<adw::SpinRow>,
+    /// Weak ref to [`SatellitesPanel::zip_row`].
+    pub zip_row: glib::WeakRef<adw::EntryRow>,
+    /// Weak ref to [`SatellitesPanel::zip_spinner`].
+    pub zip_spinner: glib::WeakRef<gtk4::Spinner>,
+    /// Weak ref to [`SatellitesPanel::zip_status_row`].
+    pub zip_status_row: glib::WeakRef<adw::ActionRow>,
+    /// Weak ref to [`SatellitesPanel::last_refresh_row`].
+    pub last_refresh_row: glib::WeakRef<adw::ActionRow>,
+    /// Weak ref to [`SatellitesPanel::refresh_button`].
+    pub refresh_button: glib::WeakRef<gtk4::Button>,
+    /// Weak ref to [`SatellitesPanel::refresh_spinner`].
+    pub refresh_spinner: glib::WeakRef<gtk4::Spinner>,
+    /// Weak ref to [`SatellitesPanel::auto_record_switch`].
+    pub auto_record_switch: glib::WeakRef<adw::SwitchRow>,
+    /// Weak ref to [`SatellitesPanel::passes_group`].
+    pub passes_group: glib::WeakRef<adw::PreferencesGroup>,
+    /// Weak ref to [`SatellitesPanel::passes_status_row`].
+    pub passes_status_row: glib::WeakRef<adw::ActionRow>,
+}
+
+impl SatellitesPanel {
+    /// Build a [`SatellitesPanelWeak`] suitable for capture in
+    /// long-lived closures. See the type-level doc on
+    /// `SatellitesPanelWeak` for why we use this everywhere instead
+    /// of `Clone`.
+    #[must_use]
+    pub fn downgrade(&self) -> SatellitesPanelWeak {
+        SatellitesPanelWeak {
+            widget: self.widget.downgrade(),
+            lat_row: self.lat_row.downgrade(),
+            lon_row: self.lon_row.downgrade(),
+            alt_row: self.alt_row.downgrade(),
+            zip_row: self.zip_row.downgrade(),
+            zip_spinner: self.zip_spinner.downgrade(),
+            zip_status_row: self.zip_status_row.downgrade(),
+            last_refresh_row: self.last_refresh_row.downgrade(),
+            refresh_button: self.refresh_button.downgrade(),
+            refresh_spinner: self.refresh_spinner.downgrade(),
+            auto_record_switch: self.auto_record_switch.downgrade(),
+            passes_group: self.passes_group.downgrade(),
+            passes_status_row: self.passes_status_row.downgrade(),
+        }
+    }
+}
+
+impl SatellitesPanelWeak {
+    /// Atomic upgrade — returns `Some(SatellitesPanel)` only if
+    /// every widget is still alive. Returns `None` the moment
+    /// any single field's underlying `GObject` has been dropped, so
+    /// callers can short-circuit cleanly with a single `let-else`
+    /// rather than threading partial-upgrade error handling
+    /// through every closure body.
+    #[must_use]
+    pub fn upgrade(&self) -> Option<SatellitesPanel> {
+        Some(SatellitesPanel {
+            widget: self.widget.upgrade()?,
+            lat_row: self.lat_row.upgrade()?,
+            lon_row: self.lon_row.upgrade()?,
+            alt_row: self.alt_row.upgrade()?,
+            zip_row: self.zip_row.upgrade()?,
+            zip_spinner: self.zip_spinner.upgrade()?,
+            zip_status_row: self.zip_status_row.upgrade()?,
+            last_refresh_row: self.last_refresh_row.upgrade()?,
+            refresh_button: self.refresh_button.upgrade()?,
+            refresh_spinner: self.refresh_spinner.upgrade()?,
+            auto_record_switch: self.auto_record_switch.upgrade()?,
+            passes_group: self.passes_group.upgrade()?,
+            passes_status_row: self.passes_status_row.upgrade()?,
+        })
+    }
 }
 
 /// Build the Satellites scheduler panel widgets with first-run
@@ -406,16 +514,25 @@ pub fn format_pass_title(pass: &Pass, now: DateTime<Utc>) -> String {
     let to_start = pass.start - now;
     let to_end = pass.end - now;
     let secs = to_start.num_seconds();
-    let label = if secs > 3_600 {
-        let h = secs / 3_600;
-        let m = (secs % 3_600) / 60;
+    // Boundary conventions:
+    // * `>= SECS_PER_HOUR` means a pass exactly 60 min away reads
+    //   "in 1h 00m", not "in 60 min".
+    // * `>= SECS_PER_MINUTE` means a pass exactly 60 s away reads
+    //   "in 1 min", not "starting now".
+    // * In the "in progress" branch, floor-div would render the
+    //   first minute of an active pass as "0 min in"; clamp to 1
+    //   so the user never sees a zero count for a running pass.
+    let label = if secs >= SECS_PER_HOUR {
+        let h = secs / SECS_PER_HOUR;
+        let m = (secs % SECS_PER_HOUR) / SECS_PER_MINUTE;
         format!("in {h}h {m:02}m")
-    } else if secs > 60 {
-        format!("in {} min", secs / 60)
+    } else if secs >= SECS_PER_MINUTE {
+        format!("in {} min", secs / SECS_PER_MINUTE)
     } else if secs > 0 {
         "starting now".to_string()
     } else if to_end.num_seconds() > 0 {
-        format!("in progress ({} min in)", -secs / 60)
+        let mins_in = ((-secs) / SECS_PER_MINUTE).max(1);
+        format!("in progress ({mins_in} min in)")
     } else {
         "ended".to_string()
     };
@@ -645,5 +762,47 @@ mod tests {
         // Pass ended 30 minutes ago.
         let pass = synthetic_pass(now, -42);
         assert_eq!(format_pass_title(&pass, now), "NOAA 19 — ended");
+    }
+
+    #[test]
+    fn format_pass_title_at_exact_one_hour_uses_h_m_format() {
+        // Boundary: a pass starting in exactly 60 min should read
+        // "in 1h 00m", not "in 60 min". The strict `>` version of
+        // this code surfaced the latter — fixed via `>=`.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_pass(now, 60);
+        assert_eq!(format_pass_title(&pass, now), "NOAA 19 — in 1h 00m");
+    }
+
+    #[test]
+    fn format_pass_title_at_exact_one_minute_says_one_min() {
+        // Boundary: a pass starting in exactly 60 s should read
+        // "in 1 min", not "starting now". `>=` fixes this.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_pass(now, 1);
+        assert_eq!(format_pass_title(&pass, now), "NOAA 19 — in 1 min");
+    }
+
+    #[test]
+    fn format_pass_title_clamps_in_progress_min_to_at_least_one() {
+        // First 60 seconds of an active pass: floor-div would say
+        // "0 min in", which reads like the pass hasn't started.
+        // Clamp to a minimum of 1 so the user always sees a real
+        // count.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Pass started 30 seconds ago, ends in 12 minutes.
+        let pass = Pass {
+            satellite: "NOAA 19".to_string(),
+            start: now - ChronoDuration::seconds(30),
+            end: now + ChronoDuration::minutes(12),
+            max_elevation_deg: 45.0,
+            max_el_time: now + ChronoDuration::minutes(5),
+            start_az_deg: 0.0,
+            end_az_deg: 0.0,
+        };
+        assert_eq!(
+            format_pass_title(&pass, now),
+            "NOAA 19 — in progress (1 min in)"
+        );
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8320,10 +8320,10 @@ fn connect_satellites_panel(
 ) {
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
     use sidebar::satellites_panel::{
-        KEY_STATION_ALT_M, KEY_STATION_LAT_DEG, KEY_STATION_LON_DEG, enumerate_upcoming_passes,
-        format_last_refresh, format_pass_subtitle, format_pass_title, load_auto_record_apt,
-        load_station_alt_m, load_station_lat_deg, load_station_lon_deg, save_auto_record_apt,
-        save_f64, save_tle_last_refresh,
+        KEY_STATION_ALT_M, KEY_STATION_LAT_DEG, KEY_STATION_LON_DEG, SatellitesPanelWeak,
+        enumerate_upcoming_passes, format_last_refresh, format_pass_subtitle, format_pass_title,
+        load_auto_record_apt, load_station_alt_m, load_station_lat_deg, load_station_lon_deg,
+        save_auto_record_apt, save_f64, save_tle_last_refresh,
     };
 
     // One pass row + its source `Pass` so the 1 Hz ticker can
@@ -8333,7 +8333,14 @@ fn connect_satellites_panel(
         pass: Pass,
     }
 
-    let panel = panels.satellites.clone();
+    // Borrow the panel for synchronous setup, then capture only
+    // weak refs in long-lived closures. Cloning the strong panel
+    // into a closure stored on its own widget creates a refcount
+    // cycle (widget → handler → closure → cloned panel → widget)
+    // that prevents teardown — see `SatellitesPanelWeak`'s doc for
+    // the full chain.
+    let panel = &panels.satellites;
+    let panel_weak: SatellitesPanelWeak = panel.downgrade();
 
     // Restore persisted values BEFORE wiring change-notify handlers,
     // matching the scanner-panel pattern: `set_value` on a SpinRow
@@ -8349,20 +8356,21 @@ fn connect_satellites_panel(
         .last_refresh_row
         .set_subtitle(&format_last_refresh(config));
 
-    // `Arc<TleCache>` so the refresh button can hand a clone to
-    // `gio::spawn_blocking` (Send required). If the platform has no
-    // cache directory, leave the panel showing its empty state and
-    // disable the refresh button — the status row already explains
-    // that there are no passes yet.
-    let cache = match TleCache::new() {
-        Ok(c) => std::sync::Arc::new(c),
+    // `Option<Arc<TleCache>>`. `None` means the platform refused us
+    // a cache directory (rare; sandboxed minimal environments).
+    // Disable TLE-specific UI but keep ground-station persistence,
+    // ZIP lookup, and the auto-record toggle wired — those don't
+    // depend on TLEs and shouldn't go inert just because the cache
+    // is gone.
+    let cache: Option<std::sync::Arc<TleCache>> = match TleCache::new() {
+        Ok(c) => Some(std::sync::Arc::new(c)),
         Err(e) => {
             tracing::warn!("Satellites panel: TLE cache unavailable — {e}");
             panel.refresh_button.set_sensitive(false);
             panel
                 .last_refresh_row
                 .set_subtitle("Cache directory unavailable");
-            return;
+            None
         }
     };
 
@@ -8374,53 +8382,63 @@ fn connect_satellites_panel(
     // `build_satellites_panel` adds the row.
     let status_attached: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(true));
 
-    let cache_recompute = std::sync::Arc::clone(&cache);
-    let panel_recompute = panel.clone();
-    let displayed_recompute = Rc::clone(&displayed);
-    let status_recompute = Rc::clone(&status_attached);
-    let recompute: Rc<dyn Fn()> = Rc::new(move || {
-        // Tear down whatever is currently in the passes group so we
-        // can rebuild from a clean slate.
-        if status_recompute.get() {
-            panel_recompute
-                .passes_group
-                .remove(&panel_recompute.passes_status_row);
-            status_recompute.set(false);
-        }
-        for entry in displayed_recompute.borrow_mut().drain(..) {
-            panel_recompute.passes_group.remove(&entry.row);
-        }
+    // `recompute` is built unconditionally — when the cache is
+    // unavailable it's a no-op so the lat/lon/alt notify handlers
+    // can call it without branching. When the cache is available
+    // it does the real pass-enumeration + row-rebuild work.
+    let recompute: Rc<dyn Fn()> = if let Some(cache) = cache.as_ref() {
+        let cache_recompute = std::sync::Arc::clone(cache);
+        let panel_weak_recompute = panel_weak.clone();
+        let displayed_recompute = Rc::clone(&displayed);
+        let status_recompute = Rc::clone(&status_attached);
+        Rc::new(move || {
+            let Some(panel) = panel_weak_recompute.upgrade() else {
+                return;
+            };
+            // Tear down whatever is currently in the passes group so we
+            // can rebuild from a clean slate.
+            if status_recompute.get() {
+                panel.passes_group.remove(&panel.passes_status_row);
+                status_recompute.set(false);
+            }
+            for entry in displayed_recompute.borrow_mut().drain(..) {
+                panel.passes_group.remove(&entry.row);
+            }
 
-        let station = GroundStation::new(
-            panel_recompute.lat_row.value(),
-            panel_recompute.lon_row.value(),
-            panel_recompute.alt_row.value(),
-        );
-        let now = chrono::Utc::now();
-        let passes = enumerate_upcoming_passes(&cache_recompute, &station, now);
+            let station = GroundStation::new(
+                panel.lat_row.value(),
+                panel.lon_row.value(),
+                panel.alt_row.value(),
+            );
+            let now = chrono::Utc::now();
+            let passes = enumerate_upcoming_passes(&cache_recompute, &station, now);
 
-        if passes.is_empty() {
-            panel_recompute
-                .passes_group
-                .add(&panel_recompute.passes_status_row);
-            status_recompute.set(true);
-            return;
-        }
+            if passes.is_empty() {
+                panel.passes_group.add(&panel.passes_status_row);
+                status_recompute.set(true);
+                return;
+            }
 
-        let mut new_rows = Vec::with_capacity(passes.len());
-        for pass in passes {
-            let row = adw::ActionRow::builder()
-                .title(format_pass_title(&pass, now))
-                .subtitle(format_pass_subtitle(&pass))
-                .build();
-            panel_recompute.passes_group.add(&row);
-            new_rows.push(DisplayedPass { row, pass });
-        }
-        *displayed_recompute.borrow_mut() = new_rows;
-    });
+            let mut new_rows = Vec::with_capacity(passes.len());
+            for pass in passes {
+                let row = adw::ActionRow::builder()
+                    .title(format_pass_title(&pass, now))
+                    .subtitle(format_pass_subtitle(&pass))
+                    .build();
+                panel.passes_group.add(&row);
+                new_rows.push(DisplayedPass { row, pass });
+            }
+            *displayed_recompute.borrow_mut() = new_rows;
+        })
+    } else {
+        // No cache → no enumeration. Lat/lon/alt notify handlers
+        // still call this on every change; making it a no-op
+        // keeps the call sites branch-free.
+        Rc::new(|| {})
+    };
 
     // Initial paint — show passes immediately if we already have
-    // cached TLEs from a prior session.
+    // cached TLEs from a prior session. (No-op if cache is None.)
     recompute();
 
     // Lat / lon / alt — persist on change and re-run pass
@@ -8461,23 +8479,28 @@ fn connect_satellites_panel(
         });
     }
 
-    // Refresh button — re-download all three Celestrak TLE files
-    // on a worker thread, update the timestamp row, and rebuild
-    // the pass list. Same `spawn_future_local` + `spawn_blocking`
-    // pattern as the RadioReference search button.
-    {
-        let cache_refresh = std::sync::Arc::clone(&cache);
+    // Refresh button — re-download every known satellite's TLE on
+    // a worker thread, update the timestamp row, and rebuild the
+    // pass list. Same `spawn_future_local` + `spawn_blocking`
+    // pattern as the RadioReference search button. Wired only
+    // when the cache is available; otherwise the button was
+    // already disabled above.
+    if let Some(cache_outer) = cache.as_ref() {
+        let cache_refresh = std::sync::Arc::clone(cache_outer);
         let config_refresh = std::sync::Arc::clone(config);
-        let panel_refresh = panel.clone();
+        let panel_weak_refresh = panel_weak.clone();
         let recompute_refresh = Rc::clone(&recompute);
         panel.refresh_button.connect_clicked(move |_| {
-            panel_refresh.refresh_spinner.set_visible(true);
-            panel_refresh.refresh_spinner.start();
-            panel_refresh.refresh_button.set_sensitive(false);
+            let Some(panel) = panel_weak_refresh.upgrade() else {
+                return;
+            };
+            panel.refresh_spinner.set_visible(true);
+            panel.refresh_spinner.start();
+            panel.refresh_button.set_sensitive(false);
 
             let cache_task = std::sync::Arc::clone(&cache_refresh);
             let config_done = std::sync::Arc::clone(&config_refresh);
-            let panel_done = panel_refresh.clone();
+            let panel_weak_done = panel_weak_refresh.clone();
             let recompute_done = Rc::clone(&recompute_refresh);
 
             glib::spawn_future_local(async move {
@@ -8520,28 +8543,31 @@ fn connect_satellites_panel(
                 })
                 .await;
 
-                panel_done.refresh_spinner.stop();
-                panel_done.refresh_spinner.set_visible(false);
-                panel_done.refresh_button.set_sensitive(true);
+                let Some(panel) = panel_weak_done.upgrade() else {
+                    return;
+                };
+                panel.refresh_spinner.stop();
+                panel.refresh_spinner.set_visible(false);
+                panel.refresh_button.set_sensitive(true);
 
                 match result {
                     Ok(Ok(())) => {
                         let now = chrono::Utc::now();
                         save_tle_last_refresh(&config_done, now);
-                        panel_done
+                        panel
                             .last_refresh_row
                             .set_subtitle(&format_last_refresh(&config_done));
                         recompute_done();
                     }
                     Ok(Err(e)) => {
                         tracing::warn!("TLE refresh failed: {e}");
-                        panel_done
+                        panel
                             .last_refresh_row
                             .set_subtitle(&format!("Refresh failed: {e}"));
                     }
                     Err(_) => {
                         tracing::warn!("TLE refresh task panicked");
-                        panel_done
+                        panel
                             .last_refresh_row
                             .set_subtitle("Refresh failed: background task panicked");
                     }
@@ -8558,18 +8584,22 @@ fn connect_satellites_panel(
     // so we don't have to repeat that work here. Result text goes
     // to `zip_status_row` (AdwEntryRow has no subtitle slot of
     // its own) so the user can see what came back without leaving
-    // the panel.
+    // the panel. Wired regardless of TLE cache availability — the
+    // ZIP lookup is independent.
     {
-        let panel_zip = panel.clone();
+        let panel_weak_zip = panel_weak.clone();
         panel.zip_row.connect_apply(move |entry| {
+            let Some(panel) = panel_weak_zip.upgrade() else {
+                return;
+            };
             let zip = entry.text().to_string();
-            panel_zip.zip_spinner.set_visible(true);
-            panel_zip.zip_spinner.start();
+            panel.zip_spinner.set_visible(true);
+            panel.zip_spinner.start();
             entry.set_sensitive(false);
-            panel_zip.zip_status_row.set_title("Looking up…");
-            panel_zip.zip_status_row.set_visible(true);
+            panel.zip_status_row.set_title("Looking up…");
+            panel.zip_status_row.set_visible(true);
 
-            let panel_done = panel_zip.clone();
+            let panel_weak_done = panel_weak_zip.clone();
             let zip_for_task = zip.clone();
             glib::spawn_future_local(async move {
                 // Chain the two lookups on the worker thread so the
@@ -8600,9 +8630,12 @@ fn connect_satellites_panel(
                 })
                 .await;
 
-                panel_done.zip_spinner.stop();
-                panel_done.zip_spinner.set_visible(false);
-                panel_done.zip_row.set_sensitive(true);
+                let Some(panel) = panel_weak_done.upgrade() else {
+                    return;
+                };
+                panel.zip_spinner.stop();
+                panel.zip_spinner.set_visible(false);
+                panel.zip_row.set_sensitive(true);
 
                 match result {
                     Ok(Ok((loc, elevation))) => {
@@ -8611,8 +8644,8 @@ fn connect_satellites_panel(
                         // value and triggers `recompute`. Three
                         // recomputes back-to-back is fine —
                         // sub-millisecond each.
-                        panel_done.lat_row.set_value(loc.lat_deg);
-                        panel_done.lon_row.set_value(loc.lon_deg);
+                        panel.lat_row.set_value(loc.lat_deg);
+                        panel.lon_row.set_value(loc.lon_deg);
                         let where_text = if loc.region.is_empty() {
                             loc.place
                         } else {
@@ -8620,7 +8653,7 @@ fn connect_satellites_panel(
                         };
                         let status = match elevation {
                             Some(alt_m) => {
-                                panel_done.alt_row.set_value(alt_m);
+                                panel.alt_row.set_value(alt_m);
                                 format!("Resolved: {where_text} ({alt_m:.0} m)")
                             }
                             None => {
@@ -8631,15 +8664,15 @@ fn connect_satellites_panel(
                                 format!("Resolved: {where_text} (altitude unchanged)")
                             }
                         };
-                        panel_done.zip_status_row.set_title(&status);
+                        panel.zip_status_row.set_title(&status);
                     }
                     Ok(Err(e)) => {
                         tracing::warn!("ZIP lookup for {zip:?} failed: {e}");
-                        panel_done.zip_status_row.set_title(&e.to_string());
+                        panel.zip_status_row.set_title(&e.to_string());
                     }
                     Err(_) => {
                         tracing::warn!("ZIP lookup task panicked");
-                        panel_done
+                        panel
                             .zip_status_row
                             .set_title("Lookup failed: background task panicked");
                     }
@@ -8648,31 +8681,36 @@ fn connect_satellites_panel(
         });
     }
 
-    // 1 Hz countdown ticker. WeakRef to the passes group so the
-    // source returns `ControlFlow::Break` once the window is
-    // destroyed (otherwise GLib runs it forever, holding a strong
-    // chain into the `displayed` vec and its widgets).
-    let group_weak = panel.passes_group.downgrade();
-    let displayed_tick = Rc::clone(&displayed);
-    let recompute_tick = Rc::clone(&recompute);
-    let _ = glib::timeout_add_local(Duration::from_secs(1), move || {
-        if group_weak.upgrade().is_none() {
-            return glib::ControlFlow::Break;
-        }
-        let now = chrono::Utc::now();
-        let mut needs_recompute = false;
-        for entry in displayed_tick.borrow().iter() {
-            if entry.pass.end <= now {
-                needs_recompute = true;
-                continue;
+    // 1 Hz countdown ticker. Only scheduled when the cache is
+    // available — without it `displayed` stays empty forever and
+    // the timer would tick uselessly. Captures the panel weakly
+    // so the source returns `ControlFlow::Break` once any panel
+    // widget has been dropped (otherwise GLib runs it forever,
+    // holding a strong chain into the `displayed` vec and its
+    // widgets).
+    if cache.is_some() {
+        let panel_weak_tick = panel_weak.clone();
+        let displayed_tick = Rc::clone(&displayed);
+        let recompute_tick = Rc::clone(&recompute);
+        let _ = glib::timeout_add_local(Duration::from_secs(1), move || {
+            if panel_weak_tick.upgrade().is_none() {
+                return glib::ControlFlow::Break;
             }
-            entry.row.set_title(&format_pass_title(&entry.pass, now));
-        }
-        if needs_recompute {
-            recompute_tick();
-        }
-        glib::ControlFlow::Continue
-    });
+            let now = chrono::Utc::now();
+            let mut needs_recompute = false;
+            for entry in displayed_tick.borrow().iter() {
+                if entry.pass.end <= now {
+                    needs_recompute = true;
+                    continue;
+                }
+                entry.row.set_title(&format_pass_title(&entry.pass, now));
+            }
+            if needs_recompute {
+                recompute_tick();
+            }
+            glib::ControlFlow::Continue
+        });
+    }
 }
 
 /// Connect transcript panel controls to DSP commands.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1930,6 +1930,7 @@ fn build_layout(
     left_stack.add_named(&panels.display.widget, Some("display"));
     left_stack.add_named(&panels.scanner.widget, Some("scanner"));
     left_stack.add_named(&page_from_group(&panels.server.widget), Some("share"));
+    left_stack.add_named(&panels.satellites.widget, Some("satellites"));
 
     // Right panel stack — single child today, hosts the real
     // transcript widget (not a placeholder) so transcription keeps
@@ -2680,6 +2681,7 @@ fn connect_sidebar_panels(
     connect_volume_persistence(panels, state, config, volume_button);
     connect_distance_estimator_persistence(panels, config);
     connect_scanner_panel(panels, state, config);
+    connect_satellites_panel(panels, config);
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
         panels,
@@ -8290,6 +8292,386 @@ fn connect_scanner_panel(
             return;
         };
         state_lockout.send_dsp(UiToDsp::LockoutScannerChannel(key));
+    });
+}
+
+/// Wire the Satellites scheduler panel to its config-persistence
+/// layer, the [`sdr_sat::TleCache`], and a 1 Hz countdown timer.
+///
+/// Two pieces of shared state plumb the handlers together:
+///
+/// * `displayed: Rc<RefCell<Vec<DisplayedPass>>>` — the list of
+///   pass rows currently in `passes_group`. Walked by the 1 Hz
+///   ticker (to update title-line countdowns) and rebuilt by
+///   `recompute` whenever lat/lon/alt changes or a TLE refresh
+///   completes.
+/// * `cache: Arc<TleCache>` — `Arc` (not `Rc`) because the
+///   refresh button hands a clone to `gio::spawn_blocking`, which
+///   requires `Send`. `TleCache` is `Send + Sync`.
+///
+/// The 1 Hz timer holds a `glib::WeakRef<adw::PreferencesGroup>`
+/// to the passes group so it returns `ControlFlow::Break` once
+/// the window is destroyed; same lifecycle pattern as the DSP
+/// poll loop.
+#[allow(clippy::too_many_lines)]
+fn connect_satellites_panel(
+    panels: &SidebarPanels,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
+    use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
+    use sidebar::satellites_panel::{
+        KEY_STATION_ALT_M, KEY_STATION_LAT_DEG, KEY_STATION_LON_DEG, enumerate_upcoming_passes,
+        format_last_refresh, format_pass_subtitle, format_pass_title, load_auto_record_apt,
+        load_station_alt_m, load_station_lat_deg, load_station_lon_deg, save_auto_record_apt,
+        save_f64, save_tle_last_refresh,
+    };
+
+    // One pass row + its source `Pass` so the 1 Hz ticker can
+    // refresh the title without re-running pass enumeration.
+    struct DisplayedPass {
+        row: adw::ActionRow,
+        pass: Pass,
+    }
+
+    let panel = panels.satellites.clone();
+
+    // Restore persisted values BEFORE wiring change-notify handlers,
+    // matching the scanner-panel pattern: `set_value` on a SpinRow
+    // fires `value-changed`, so wiring first would trigger spurious
+    // saves + recomputes during window construction.
+    panel.lat_row.set_value(load_station_lat_deg(config));
+    panel.lon_row.set_value(load_station_lon_deg(config));
+    panel.alt_row.set_value(load_station_alt_m(config));
+    panel
+        .auto_record_switch
+        .set_active(load_auto_record_apt(config));
+    panel
+        .last_refresh_row
+        .set_subtitle(&format_last_refresh(config));
+
+    // `Arc<TleCache>` so the refresh button can hand a clone to
+    // `gio::spawn_blocking` (Send required). If the platform has no
+    // cache directory, leave the panel showing its empty state and
+    // disable the refresh button — the status row already explains
+    // that there are no passes yet.
+    let cache = match TleCache::new() {
+        Ok(c) => std::sync::Arc::new(c),
+        Err(e) => {
+            tracing::warn!("Satellites panel: TLE cache unavailable — {e}");
+            panel.refresh_button.set_sensitive(false);
+            panel
+                .last_refresh_row
+                .set_subtitle("Cache directory unavailable");
+            return;
+        }
+    };
+
+    let displayed: Rc<RefCell<Vec<DisplayedPass>>> = Rc::new(RefCell::new(Vec::new()));
+    // `passes_status_row` is the empty-state placeholder built by
+    // `build_satellites_panel`. We attach / detach it manually here
+    // (no "is this row in the group?" query on AdwPreferencesGroup)
+    // and track membership via this flag — `true` initially because
+    // `build_satellites_panel` adds the row.
+    let status_attached: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(true));
+
+    let cache_recompute = std::sync::Arc::clone(&cache);
+    let panel_recompute = panel.clone();
+    let displayed_recompute = Rc::clone(&displayed);
+    let status_recompute = Rc::clone(&status_attached);
+    let recompute: Rc<dyn Fn()> = Rc::new(move || {
+        // Tear down whatever is currently in the passes group so we
+        // can rebuild from a clean slate.
+        if status_recompute.get() {
+            panel_recompute
+                .passes_group
+                .remove(&panel_recompute.passes_status_row);
+            status_recompute.set(false);
+        }
+        for entry in displayed_recompute.borrow_mut().drain(..) {
+            panel_recompute.passes_group.remove(&entry.row);
+        }
+
+        let station = GroundStation::new(
+            panel_recompute.lat_row.value(),
+            panel_recompute.lon_row.value(),
+            panel_recompute.alt_row.value(),
+        );
+        let now = chrono::Utc::now();
+        let passes = enumerate_upcoming_passes(&cache_recompute, &station, now);
+
+        if passes.is_empty() {
+            panel_recompute
+                .passes_group
+                .add(&panel_recompute.passes_status_row);
+            status_recompute.set(true);
+            return;
+        }
+
+        let mut new_rows = Vec::with_capacity(passes.len());
+        for pass in passes {
+            let row = adw::ActionRow::builder()
+                .title(format_pass_title(&pass, now))
+                .subtitle(format_pass_subtitle(&pass))
+                .build();
+            panel_recompute.passes_group.add(&row);
+            new_rows.push(DisplayedPass { row, pass });
+        }
+        *displayed_recompute.borrow_mut() = new_rows;
+    });
+
+    // Initial paint — show passes immediately if we already have
+    // cached TLEs from a prior session.
+    recompute();
+
+    // Lat / lon / alt — persist on change and re-run pass
+    // enumeration. Cheap: a single SGP4 sweep across ~7
+    // satellites takes well under a millisecond.
+    {
+        let config_lat = std::sync::Arc::clone(config);
+        let recompute_lat = Rc::clone(&recompute);
+        panel.lat_row.connect_value_notify(move |row| {
+            save_f64(&config_lat, KEY_STATION_LAT_DEG, row.value());
+            recompute_lat();
+        });
+    }
+    {
+        let config_lon = std::sync::Arc::clone(config);
+        let recompute_lon = Rc::clone(&recompute);
+        panel.lon_row.connect_value_notify(move |row| {
+            save_f64(&config_lon, KEY_STATION_LON_DEG, row.value());
+            recompute_lon();
+        });
+    }
+    {
+        let config_alt = std::sync::Arc::clone(config);
+        let recompute_alt = Rc::clone(&recompute);
+        panel.alt_row.connect_value_notify(move |row| {
+            save_f64(&config_alt, KEY_STATION_ALT_M, row.value());
+            recompute_alt();
+        });
+    }
+
+    // Auto-record toggle — persist only. The actual "tune the
+    // radio + start APT decoding when a NOAA pass starts" wiring
+    // lands in #482 and reads from the same config key.
+    {
+        let config_auto = std::sync::Arc::clone(config);
+        panel.auto_record_switch.connect_active_notify(move |sw| {
+            save_auto_record_apt(&config_auto, sw.is_active());
+        });
+    }
+
+    // Refresh button — re-download all three Celestrak TLE files
+    // on a worker thread, update the timestamp row, and rebuild
+    // the pass list. Same `spawn_future_local` + `spawn_blocking`
+    // pattern as the RadioReference search button.
+    {
+        let cache_refresh = std::sync::Arc::clone(&cache);
+        let config_refresh = std::sync::Arc::clone(config);
+        let panel_refresh = panel.clone();
+        let recompute_refresh = Rc::clone(&recompute);
+        panel.refresh_button.connect_clicked(move |_| {
+            panel_refresh.refresh_spinner.set_visible(true);
+            panel_refresh.refresh_spinner.start();
+            panel_refresh.refresh_button.set_sensitive(false);
+
+            let cache_task = std::sync::Arc::clone(&cache_refresh);
+            let config_done = std::sync::Arc::clone(&config_refresh);
+            let panel_done = panel_refresh.clone();
+            let recompute_done = Rc::clone(&recompute_refresh);
+
+            glib::spawn_future_local(async move {
+                let result = gio::spawn_blocking(move || {
+                    // Walk every known satellite. `tle_text` writes
+                    // the freshened entry to disk and returns the body
+                    // — we discard the body, the on-disk cache is what
+                    // subsequent `tle_for` lookups read. A failure on
+                    // any one satellite is logged and skipped so a
+                    // single decommissioned/rate-limited entry can't
+                    // break the whole refresh: the user gets the rest.
+                    let mut last_err: Option<sdr_sat::TleCacheError> = None;
+                    let mut succeeded = 0usize;
+                    for known in KNOWN_SATELLITES {
+                        match cache_task.tle_text(known.norad_id) {
+                            Ok(_) => succeeded += 1,
+                            Err(e) => {
+                                tracing::warn!(
+                                    "TLE refresh for {} (NORAD {}) failed: {e}",
+                                    known.name,
+                                    known.norad_id,
+                                );
+                                last_err = Some(e);
+                            }
+                        }
+                    }
+                    if succeeded == 0 {
+                        // Every fetch failed — surface the last error so
+                        // the UI can show it. (If at least one
+                        // succeeded, treat the refresh as "done" so
+                        // the user sees the timestamp tick forward.)
+                        Err(last_err.unwrap_or_else(|| {
+                            sdr_sat::TleCacheError::Fetch(
+                                "refresh produced no successful fetches".to_string(),
+                            )
+                        }))
+                    } else {
+                        Ok(())
+                    }
+                })
+                .await;
+
+                panel_done.refresh_spinner.stop();
+                panel_done.refresh_spinner.set_visible(false);
+                panel_done.refresh_button.set_sensitive(true);
+
+                match result {
+                    Ok(Ok(())) => {
+                        let now = chrono::Utc::now();
+                        save_tle_last_refresh(&config_done, now);
+                        panel_done
+                            .last_refresh_row
+                            .set_subtitle(&format_last_refresh(&config_done));
+                        recompute_done();
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!("TLE refresh failed: {e}");
+                        panel_done
+                            .last_refresh_row
+                            .set_subtitle(&format!("Refresh failed: {e}"));
+                    }
+                    Err(_) => {
+                        tracing::warn!("TLE refresh task panicked");
+                        panel_done
+                            .last_refresh_row
+                            .set_subtitle("Refresh failed: background task panicked");
+                    }
+                }
+            });
+        });
+    }
+
+    // ZIP code → lat/lon shortcut. The apply button is built in by
+    // AdwEntryRow; clicking it (or pressing Enter on a non-empty
+    // entry) emits `apply`. Run the lookup on a worker thread, then
+    // write the resolved coords back to `lat_row` / `lon_row` —
+    // their existing `value-notify` handlers persist + recompute,
+    // so we don't have to repeat that work here. Result text goes
+    // to `zip_status_row` (AdwEntryRow has no subtitle slot of
+    // its own) so the user can see what came back without leaving
+    // the panel.
+    {
+        let panel_zip = panel.clone();
+        panel.zip_row.connect_apply(move |entry| {
+            let zip = entry.text().to_string();
+            panel_zip.zip_spinner.set_visible(true);
+            panel_zip.zip_spinner.start();
+            entry.set_sensitive(false);
+            panel_zip.zip_status_row.set_title("Looking up…");
+            panel_zip.zip_status_row.set_visible(true);
+
+            let panel_done = panel_zip.clone();
+            let zip_for_task = zip.clone();
+            glib::spawn_future_local(async move {
+                // Chain the two lookups on the worker thread so the
+                // UI side just gets one result. ZIP failure is fatal
+                // for this run; elevation failure is logged and
+                // demoted to `Ok(_, None)` — altitude is best-effort
+                // since it barely matters for pass prediction
+                // anyway, and we'd rather populate lat/lon than
+                // leave the user staring at an error toast.
+                let result = gio::spawn_blocking(move || -> Result<
+                    (sdr_sat::PostalLocation, Option<f64>),
+                    sdr_sat::PostalLookupError,
+                > {
+                    let loc = sdr_sat::lookup_us_zip(&zip_for_task)?;
+                    let elevation = match sdr_sat::lookup_elevation_m(loc.lat_deg, loc.lon_deg)
+                    {
+                        Ok(m) => Some(m),
+                        Err(e) => {
+                            tracing::warn!(
+                                "elevation lookup at ({lat:.4}, {lon:.4}) failed: {e}",
+                                lat = loc.lat_deg,
+                                lon = loc.lon_deg,
+                            );
+                            None
+                        }
+                    };
+                    Ok((loc, elevation))
+                })
+                .await;
+
+                panel_done.zip_spinner.stop();
+                panel_done.zip_spinner.set_visible(false);
+                panel_done.zip_row.set_sensitive(true);
+
+                match result {
+                    Ok(Ok((loc, elevation))) => {
+                        // Order matters slightly: setting lat/lon/alt
+                        // fires `value-notify`, which persists the
+                        // value and triggers `recompute`. Three
+                        // recomputes back-to-back is fine —
+                        // sub-millisecond each.
+                        panel_done.lat_row.set_value(loc.lat_deg);
+                        panel_done.lon_row.set_value(loc.lon_deg);
+                        let where_text = if loc.region.is_empty() {
+                            loc.place
+                        } else {
+                            format!("{place}, {region}", place = loc.place, region = loc.region)
+                        };
+                        let status = match elevation {
+                            Some(alt_m) => {
+                                panel_done.alt_row.set_value(alt_m);
+                                format!("Resolved: {where_text} ({alt_m:.0} m)")
+                            }
+                            None => {
+                                // Leave altitude alone — the warn
+                                // log captured the real reason; show
+                                // a short hint so the user notices
+                                // altitude wasn't updated.
+                                format!("Resolved: {where_text} (altitude unchanged)")
+                            }
+                        };
+                        panel_done.zip_status_row.set_title(&status);
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!("ZIP lookup for {zip:?} failed: {e}");
+                        panel_done.zip_status_row.set_title(&e.to_string());
+                    }
+                    Err(_) => {
+                        tracing::warn!("ZIP lookup task panicked");
+                        panel_done
+                            .zip_status_row
+                            .set_title("Lookup failed: background task panicked");
+                    }
+                }
+            });
+        });
+    }
+
+    // 1 Hz countdown ticker. WeakRef to the passes group so the
+    // source returns `ControlFlow::Break` once the window is
+    // destroyed (otherwise GLib runs it forever, holding a strong
+    // chain into the `displayed` vec and its widgets).
+    let group_weak = panel.passes_group.downgrade();
+    let displayed_tick = Rc::clone(&displayed);
+    let recompute_tick = Rc::clone(&recompute);
+    let _ = glib::timeout_add_local(Duration::from_secs(1), move || {
+        if group_weak.upgrade().is_none() {
+            return glib::ControlFlow::Break;
+        }
+        let now = chrono::Utc::now();
+        let mut needs_recompute = false;
+        for entry in displayed_tick.borrow().iter() {
+            if entry.pass.end <= now {
+                needs_recompute = true;
+                continue;
+            }
+            entry.row.set_title(&format_pass_title(&entry.pass, now));
+        }
+        if needs_recompute {
+            recompute_tick();
+        }
+        glib::ControlFlow::Continue
     });
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -58,6 +58,13 @@ const DSP_POLL_INTERVAL_MS: u64 = 16;
 /// Toast display time (seconds) for scanner "force-disable" notices.
 const SCANNER_TOAST_TIMEOUT_SECS: u32 = 3;
 
+/// Cadence of the Satellites panel's countdown ticker — 1 line/sec
+/// is the smallest interval that produces a visible change in the
+/// pass-row title (which renders to 1-minute granularity for far
+/// passes and to seconds only inside the "starting now" window).
+/// Smaller would burn cycles for no visible benefit.
+const SATELLITES_COUNTDOWN_TICK: Duration = Duration::from_secs(1);
+
 /// Shared "kill the scanner on a manual tune" hook. Built once in
 /// `build_window` and cloned into every manual-change handler
 /// (frequency selector, demod dropdown, bandwidth row, bookmark
@@ -8599,8 +8606,13 @@ fn connect_satellites_panel(
                 let Some(panel) = panel_weak_zip.upgrade() else {
                     return;
                 };
-                let zip = entry.text().to_string();
-                if zip.trim().is_empty() {
+                // Trim once, here, so the trimmed value is what
+                // flows through the lookup. `lookup_us_zip` does its
+                // own trim internally too, but a paste of "  24068 "
+                // showing up as `length=8` in the debug log reads
+                // worse than `length=5`.
+                let zip = entry.text().trim().to_string();
+                if zip.is_empty() {
                     // Empty entry — nothing to do; treat as a no-op so a
                     // stray Enter doesn't reset the status row.
                     return;
@@ -8722,7 +8734,7 @@ fn connect_satellites_panel(
         let panel_weak_tick = panel_weak.clone();
         let displayed_tick = Rc::clone(&displayed);
         let recompute_tick = Rc::clone(&recompute);
-        let _ = glib::timeout_add_local(Duration::from_secs(1), move || {
+        let _ = glib::timeout_add_local(SATELLITES_COUNTDOWN_TICK, move || {
             if panel_weak_tick.upgrade().is_none() {
                 return glib::ControlFlow::Break;
             }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8634,20 +8634,27 @@ fn connect_satellites_panel(
                     // anyway, and we'd rather populate lat/lon than
                     // leave the user staring at an error toast.
                     let result = gio::spawn_blocking(move || -> Result<
-                    (sdr_sat::PostalLocation, Option<f64>),
+                    (sdr_sat::PostalLocation, Result<f64, String>),
                     sdr_sat::PostalLookupError,
                 > {
                     let loc = sdr_sat::lookup_us_zip(&zip_for_task)?;
+                    // Elevation lookup is best-effort — a failure here
+                    // shouldn't fail the whole flow, but we DO want
+                    // the provider error to reach the UI so the user
+                    // can see why altitude didn't update. Pass it
+                    // back as `Err(String)` (cheap to send across
+                    // thread, decoupled from `ElevationLookupError`'s
+                    // type, and the log already scrubbed lat/lon).
                     let elevation = match sdr_sat::lookup_elevation_m(loc.lat_deg, loc.lon_deg)
                     {
-                        Ok(m) => Some(m),
+                        Ok(m) => Ok(m),
                         Err(e) => {
                             // Don't include lat/lon in the log — that's user
-                            // location data, and the failure path is already
-                            // surfaced inline in the status row. Provider
-                            // error message alone is enough for debugging.
+                            // location data. The error message itself is
+                            // safe (it's the upstream HTTP error / parse
+                            // error / dataset-coverage error).
                             tracing::warn!("elevation lookup failed: {e}");
-                            None
+                            Err(e.to_string())
                         }
                     };
                     Ok((loc, elevation))
@@ -8675,16 +8682,17 @@ fn connect_satellites_panel(
                                 format!("{place}, {region}", place = loc.place, region = loc.region)
                             };
                             let status = match elevation {
-                                Some(alt_m) => {
+                                Ok(alt_m) => {
                                     panel.alt_row.set_value(alt_m);
                                     format!("Resolved: {where_text} ({alt_m:.0} m)")
                                 }
-                                None => {
-                                    // Leave altitude alone — the warn
-                                    // log captured the real reason; show
-                                    // a short hint so the user notices
-                                    // altitude wasn't updated.
-                                    format!("Resolved: {where_text} (altitude unchanged)")
+                                Err(e) => {
+                                    // Leave altitude alone but
+                                    // surface the provider error
+                                    // so the user knows what to
+                                    // try next (e.g. retry on a
+                                    // bad network).
+                                    format!("Resolved: {where_text} (altitude unchanged: {e})")
                                 }
                             };
                             panel.zip_status_row.set_title(&status);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8375,13 +8375,6 @@ fn connect_satellites_panel(
     };
 
     let displayed: Rc<RefCell<Vec<DisplayedPass>>> = Rc::new(RefCell::new(Vec::new()));
-    // `passes_status_row` is the empty-state placeholder built by
-    // `build_satellites_panel`. We attach / detach it manually here
-    // (no "is this row in the group?" query on AdwPreferencesGroup)
-    // and track membership via this flag — `true` initially because
-    // `build_satellites_panel` adds the row.
-    let status_attached: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(true));
-
     // `recompute` is built unconditionally — when the cache is
     // unavailable it's a no-op so the lat/lon/alt notify handlers
     // can call it without branching. When the cache is available
@@ -8390,21 +8383,23 @@ fn connect_satellites_panel(
         let cache_recompute = std::sync::Arc::clone(cache);
         let panel_weak_recompute = panel_weak.clone();
         let displayed_recompute = Rc::clone(&displayed);
-        let status_recompute = Rc::clone(&status_attached);
         Rc::new(move || {
             let Some(panel) = panel_weak_recompute.upgrade() else {
                 return;
             };
-            // Tear down whatever is currently in the passes group so we
-            // can rebuild from a clean slate.
-            if status_recompute.get() {
-                panel.passes_group.remove(&panel.passes_status_row);
-                status_recompute.set(false);
-            }
+            // Drop the previous pass rows — these are throwaway,
+            // built fresh per recompute.
             for entry in displayed_recompute.borrow_mut().drain(..) {
                 panel.passes_group.remove(&entry.row);
             }
-
+            // `passes_status_row` is the always-present empty-state
+            // placeholder. We toggle its *visibility* rather than
+            // detach + reattach. Once a widget is unparented, its
+            // last strong ref lives only on the SatellitesPanel
+            // struct — and that struct is dropped when
+            // `build_window` returns. Toggling visibility keeps the
+            // row parented (and therefore alive) for the lifetime
+            // of the window.
             let station = GroundStation::new(
                 panel.lat_row.value(),
                 panel.lon_row.value(),
@@ -8414,11 +8409,11 @@ fn connect_satellites_panel(
             let passes = enumerate_upcoming_passes(&cache_recompute, &station, now);
 
             if passes.is_empty() {
-                panel.passes_group.add(&panel.passes_status_row);
-                status_recompute.set(true);
+                panel.passes_status_row.set_visible(true);
                 return;
             }
 
+            panel.passes_status_row.set_visible(false);
             let mut new_rows = Vec::with_capacity(passes.len());
             for pass in passes {
                 let row = adw::ActionRow::builder()
@@ -8505,17 +8500,20 @@ fn connect_satellites_panel(
 
             glib::spawn_future_local(async move {
                 let result = gio::spawn_blocking(move || {
-                    // Walk every known satellite. `tle_text` writes
-                    // the freshened entry to disk and returns the body
-                    // — we discard the body, the on-disk cache is what
-                    // subsequent `tle_for` lookups read. A failure on
-                    // any one satellite is logged and skipped so a
-                    // single decommissioned/rate-limited entry can't
-                    // break the whole refresh: the user gets the rest.
+                    // `force_refresh` — NOT `tle_text` — because the
+                    // user clicked Refresh and a fresh-cache fast-path
+                    // would let us mark "Last refreshed: now" without
+                    // any actual network fetch. `force_refresh` always
+                    // hits the network and never falls back to a stale
+                    // cache, so a successful return means a real round
+                    // trip happened. A per-satellite failure is logged
+                    // and skipped so a single decommissioned /
+                    // rate-limited entry can't break the whole
+                    // refresh: the user still gets the rest.
                     let mut last_err: Option<sdr_sat::TleCacheError> = None;
                     let mut succeeded = 0usize;
                     for known in KNOWN_SATELLITES {
-                        match cache_task.tle_text(known.norad_id) {
+                        match cache_task.force_refresh(known.norad_id) {
                             Ok(_) => succeeded += 1,
                             Err(e) => {
                                 tracing::warn!(
@@ -8576,40 +8574,54 @@ fn connect_satellites_panel(
         });
     }
 
-    // ZIP code → lat/lon shortcut. The apply button is built in by
-    // AdwEntryRow; clicking it (or pressing Enter on a non-empty
-    // entry) emits `apply`. Run the lookup on a worker thread, then
-    // write the resolved coords back to `lat_row` / `lon_row` —
-    // their existing `value-notify` handlers persist + recompute,
-    // so we don't have to repeat that work here. Result text goes
-    // to `zip_status_row` (AdwEntryRow has no subtitle slot of
-    // its own) so the user can see what came back without leaving
-    // the panel. Wired regardless of TLE cache availability — the
-    // ZIP lookup is independent.
+    // ZIP code → lat/lon shortcut. We wire BOTH `apply` (apply
+    // button click / Enter when apply-button is sensitive) and
+    // `entry_activated` (Enter, unconditional), then dedupe by an
+    // "in-flight" flag — `apply` won't fire if AdwEntryRow's
+    // internal "has the text been edited?" tracking is in a state
+    // where the apply button is insensitive, but `entry_activated`
+    // fires on Enter regardless. Belt-and-braces is cheaper than
+    // chasing libadwaita's internal sensitivity rules.
+    //
+    // Result text goes to `zip_status_row` (AdwEntryRow has no
+    // subtitle slot of its own). Wired regardless of TLE cache
+    // availability — the ZIP lookup is independent.
     {
-        let panel_weak_zip = panel_weak.clone();
-        panel.zip_row.connect_apply(move |entry| {
-            let Some(panel) = panel_weak_zip.upgrade() else {
-                return;
-            };
-            let zip = entry.text().to_string();
-            panel.zip_spinner.set_visible(true);
-            panel.zip_spinner.start();
-            entry.set_sensitive(false);
-            panel.zip_status_row.set_title("Looking up…");
-            panel.zip_status_row.set_visible(true);
+        let in_flight: Rc<std::cell::Cell<bool>> = Rc::new(std::cell::Cell::new(false));
+        let run_lookup: Rc<dyn Fn(adw::EntryRow)> = {
+            let panel_weak_zip = panel_weak.clone();
+            let in_flight_run = Rc::clone(&in_flight);
+            Rc::new(move |entry: adw::EntryRow| {
+                if in_flight_run.get() {
+                    tracing::debug!("Satellites: ZIP lookup ignored — already in flight");
+                    return;
+                }
+                let Some(panel) = panel_weak_zip.upgrade() else {
+                    return;
+                };
+                let zip = entry.text().to_string();
+                if zip.trim().is_empty() {
+                    // Empty entry — nothing to do; treat as a no-op so a
+                    // stray Enter doesn't reset the status row.
+                    return;
+                }
+                in_flight_run.set(true);
+                tracing::debug!("Satellites: ZIP lookup triggered (length={})", zip.len());
+                entry.set_sensitive(false);
+                panel.zip_status_row.set_title("Looking up…");
 
-            let panel_weak_done = panel_weak_zip.clone();
-            let zip_for_task = zip.clone();
-            glib::spawn_future_local(async move {
-                // Chain the two lookups on the worker thread so the
-                // UI side just gets one result. ZIP failure is fatal
-                // for this run; elevation failure is logged and
-                // demoted to `Ok(_, None)` — altitude is best-effort
-                // since it barely matters for pass prediction
-                // anyway, and we'd rather populate lat/lon than
-                // leave the user staring at an error toast.
-                let result = gio::spawn_blocking(move || -> Result<
+                let panel_weak_done = panel_weak_zip.clone();
+                let in_flight_done = Rc::clone(&in_flight_run);
+                let zip_for_task = zip.clone();
+                glib::spawn_future_local(async move {
+                    // Chain the two lookups on the worker thread so the
+                    // UI side just gets one result. ZIP failure is fatal
+                    // for this run; elevation failure is logged and
+                    // demoted to `Ok(_, None)` — altitude is best-effort
+                    // since it barely matters for pass prediction
+                    // anyway, and we'd rather populate lat/lon than
+                    // leave the user staring at an error toast.
+                    let result = gio::spawn_blocking(move || -> Result<
                     (sdr_sat::PostalLocation, Option<f64>),
                     sdr_sat::PostalLookupError,
                 > {
@@ -8618,11 +8630,11 @@ fn connect_satellites_panel(
                     {
                         Ok(m) => Some(m),
                         Err(e) => {
-                            tracing::warn!(
-                                "elevation lookup at ({lat:.4}, {lon:.4}) failed: {e}",
-                                lat = loc.lat_deg,
-                                lon = loc.lon_deg,
-                            );
+                            // Don't include lat/lon in the log — that's user
+                            // location data, and the failure path is already
+                            // surfaced inline in the status row. Provider
+                            // error message alone is enough for debugging.
+                            tracing::warn!("elevation lookup failed: {e}");
                             None
                         }
                     };
@@ -8630,55 +8642,73 @@ fn connect_satellites_panel(
                 })
                 .await;
 
-                let Some(panel) = panel_weak_done.upgrade() else {
-                    return;
-                };
-                panel.zip_spinner.stop();
-                panel.zip_spinner.set_visible(false);
-                panel.zip_row.set_sensitive(true);
+                    in_flight_done.set(false);
+                    let Some(panel) = panel_weak_done.upgrade() else {
+                        return;
+                    };
+                    panel.zip_row.set_sensitive(true);
 
-                match result {
-                    Ok(Ok((loc, elevation))) => {
-                        // Order matters slightly: setting lat/lon/alt
-                        // fires `value-notify`, which persists the
-                        // value and triggers `recompute`. Three
-                        // recomputes back-to-back is fine —
-                        // sub-millisecond each.
-                        panel.lat_row.set_value(loc.lat_deg);
-                        panel.lon_row.set_value(loc.lon_deg);
-                        let where_text = if loc.region.is_empty() {
-                            loc.place
-                        } else {
-                            format!("{place}, {region}", place = loc.place, region = loc.region)
-                        };
-                        let status = match elevation {
-                            Some(alt_m) => {
-                                panel.alt_row.set_value(alt_m);
-                                format!("Resolved: {where_text} ({alt_m:.0} m)")
-                            }
-                            None => {
-                                // Leave altitude alone — the warn
-                                // log captured the real reason; show
-                                // a short hint so the user notices
-                                // altitude wasn't updated.
-                                format!("Resolved: {where_text} (altitude unchanged)")
-                            }
-                        };
-                        panel.zip_status_row.set_title(&status);
+                    match result {
+                        Ok(Ok((loc, elevation))) => {
+                            // Order matters slightly: setting lat/lon/alt
+                            // fires `value-notify`, which persists the
+                            // value and triggers `recompute`. Three
+                            // recomputes back-to-back is fine —
+                            // sub-millisecond each.
+                            panel.lat_row.set_value(loc.lat_deg);
+                            panel.lon_row.set_value(loc.lon_deg);
+                            let where_text = if loc.region.is_empty() {
+                                loc.place
+                            } else {
+                                format!("{place}, {region}", place = loc.place, region = loc.region)
+                            };
+                            let status = match elevation {
+                                Some(alt_m) => {
+                                    panel.alt_row.set_value(alt_m);
+                                    format!("Resolved: {where_text} ({alt_m:.0} m)")
+                                }
+                                None => {
+                                    // Leave altitude alone — the warn
+                                    // log captured the real reason; show
+                                    // a short hint so the user notices
+                                    // altitude wasn't updated.
+                                    format!("Resolved: {where_text} (altitude unchanged)")
+                                }
+                            };
+                            panel.zip_status_row.set_title(&status);
+                        }
+                        Ok(Err(e)) => {
+                            // Don't include the ZIP in the log — user
+                            // location data, already surfaced inline in
+                            // the status row. Provider error alone is
+                            // enough.
+                            tracing::warn!("ZIP lookup failed: {e}");
+                            panel.zip_status_row.set_title(&e.to_string());
+                        }
+                        Err(_) => {
+                            tracing::warn!("ZIP lookup task panicked");
+                            panel
+                                .zip_status_row
+                                .set_title("Lookup failed: background task panicked");
+                        }
                     }
-                    Ok(Err(e)) => {
-                        tracing::warn!("ZIP lookup for {zip:?} failed: {e}");
-                        panel.zip_status_row.set_title(&e.to_string());
-                    }
-                    Err(_) => {
-                        tracing::warn!("ZIP lookup task panicked");
-                        panel
-                            .zip_status_row
-                            .set_title("Lookup failed: background task panicked");
-                    }
-                }
-            });
-        });
+                });
+            })
+        };
+        // Wire both signal paths to the same closure: `apply` for
+        // the apply button click (when libadwaita has flagged the
+        // text as edited), `entry-activated` for raw Enter keys
+        // (always fires, regardless of edit state).
+        {
+            let run = Rc::clone(&run_lookup);
+            panel.zip_row.connect_apply(move |entry| run(entry.clone()));
+        }
+        {
+            let run = Rc::clone(&run_lookup);
+            panel
+                .zip_row
+                .connect_entry_activated(move |entry| run(entry.clone()));
+        }
     }
 
     // 1 Hz countdown ticker. Only scheduled when the cache is


### PR DESCRIPTION
## Summary

- Adds the **Satellites** left-sidebar activity (Ctrl+7) with a four-group panel: Ground Station / TLE Data / Recording / Upcoming Passes. 1 Hz countdown ticker keeps each pass row's title in sync ("NOAA 19 — in 12 min" → "starting now" → "in progress (3 min in)").
- **Refactors `sdr-sat::TleCache` to per-NORAD fetches.** Celestrak deprecated the per-group `.txt` URLs (`noaa.txt` is now 404; `noaa` group slug is gone from the GP API; NOAA 15/18/19 aren't in any current group). New endpoint is `gp.php?CATNR={id}&FORMAT=tle`. Cache files become `~/.cache/sdr-rs/tle/{norad_id}.tle`. Validation gate, atomic-rename writes, fetcher injection for tests, and stale-cache fallback all carry over.
- **Two small blocking-HTTP helpers in `sdr-sat`:** `lookup_us_zip` (Zippopotam.us → lat/lon) and `lookup_elevation_m` (Open-Elevation → altitude). The panel chains them on a single worker hop so a US ZIP fills in lat/lon/alt in one click.

## Why ZIP instead of OS location services

GeoClue2 needs the app to be in `/etc/geoclue/geoclue.conf`'s allowlist (typically only flatpak/snap apps) — would fail silently for cargo-installed users. ZIP lookup gives ~1 km accuracy (vs IP geolocation's ~50 km), works without platform-specific permission UIs, and ports cleanly to the planned mac/Windows front-ends. US-only by design for V1; international users enter coords by hand.

## Why per-NORAD instead of group files

Per-NORAD dodges the group-churn problem entirely and lets `KNOWN_SATELLITES` grow without anyone having to figure out which Celestrak group each satellite lives in.

## Test plan

- [x] `cargo build --workspace --features whisper-cpu` clean
- [x] `cargo test --workspace --features whisper-cpu` — 59 sdr-sat tests pass (incl. 14 new postal/elevation tests + new URL-shape pin)
- [x] `cargo clippy --workspace --features whisper-cpu --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` clean (transcription not touched but per the dual-build rule)
- [x] Manual smoke (live NOAA 19 pass): activity bar entry + Ctrl+7 toggles correctly; ZIP lookup populates lat/lon/alt with real ground elevation; TLE refresh produces 7 `{norad_id}.tle` files in cache dir; upcoming passes recompute on lat/lon edit; 1 Hz countdown updates rows in place.
- [ ] CodeRabbit review

## Related

- Part of epic #468 (NOAA APT)
- Closes #481
- Unblocks #482 — the auto-record-on-pass UX, which now has a clearer scope including the decoder-wiring precursor (audio → `AptDecoder` → `AptImage` → viewer). Updated #482 body to reflect that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Satellites sidebar panel (Ctrl+7) for ground‑station setup and pass scheduling.
  * ZIP-to-location lookup and automatic ground‑altitude lookup for station inputs with status feedback.
  * Per‑satellite TLE caching with manual refresh, “Last refreshed” status, and graceful UI when cache is unavailable.
  * Real‑time pass enumeration and 1 Hz countdown updates, auto‑record APT toggle, and persisted station/TLE settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->