### PR TITLE
sdr-core,sdr-ui: live APT decoder wiring (part of #482)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -423,6 +423,15 @@ struct DspState {
     /// `AptDecoder` docs); the decoder won't emit more than this in
     /// a single call.
     apt_lines_buf: Vec<AptLine>,
+    /// Most recent audio sample rate that `AptDecoder::new` rejected
+    /// (or `None` if every prior init succeeded / hasn't been tried).
+    /// Guards against the audio-block hot loop retrying — and
+    /// log-spamming — on a rate the decoder will never accept (e.g.
+    /// a future audio-rate change to something below the 4800 Hz
+    /// Nyquist floor). Cleared in `cleanup` alongside the decoder
+    /// reset so a fresh source restart always gets one fresh
+    /// init attempt.
+    apt_init_failed_at_rate: Option<u32>,
 }
 
 impl DspState {
@@ -498,6 +507,7 @@ impl DspState {
             apt_decoder: None,
             apt_mono_buf: Vec::new(),
             apt_lines_buf: Vec::new(),
+            apt_init_failed_at_rate: None,
         })
     }
 }
@@ -516,10 +526,18 @@ fn apt_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_co
     if state.apt_decoder.is_none() {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let rate_hz = state.radio.audio_sample_rate() as u32;
+        // Guard against retry-spamming the warn log on a rate the
+        // decoder will reject. If we've already tried this exact
+        // rate and it failed, silently bail until either the rate
+        // changes (next-block check) or `cleanup` clears the cache.
+        if state.apt_init_failed_at_rate == Some(rate_hz) {
+            return;
+        }
         match AptDecoder::new(rate_hz) {
             Ok(decoder) => {
                 tracing::info!("APT decoder initialised at {rate_hz} Hz");
                 state.apt_decoder = Some(decoder);
+                state.apt_init_failed_at_rate = None;
                 // Size the output slice to the decoder's documented
                 // per-call emission cap so a single `process` call
                 // can never need to flush.
@@ -529,6 +547,7 @@ fn apt_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_co
             }
             Err(e) => {
                 tracing::warn!("APT decoder init failed at {rate_hz} Hz: {e}");
+                state.apt_init_failed_at_rate = Some(rate_hz);
                 return;
             }
         }
@@ -2366,6 +2385,11 @@ fn cleanup(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
         decoder.reset();
     }
     state.apt_mono_buf.clear();
+    // Clear the failed-init guard so a fresh Start gets a fresh
+    // init attempt — the user may have tweaked the radio audio
+    // rate between sessions, and we don't want a stale failure
+    // memo to silently suppress a now-valid rate.
+    state.apt_init_failed_at_rate = None;
 
     tracing::info!("source closed");
 }

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -571,8 +571,14 @@ fn apt_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_co
 
     match decoder.process(&state.apt_mono_buf, &mut state.apt_lines_buf) {
         Ok(produced) => {
-            for line in state.apt_lines_buf.iter().take(produced) {
-                let _ = dsp_tx.send(DspToUi::AptLine(Box::new(line.clone())));
+            // `mem::take` lifts each emitted line out by swapping in
+            // `AptLine::default()` — moves ownership without the
+            // ~2 KB clone. The next `process` call overwrites the
+            // (now-default) slot regardless, so leaving an empty
+            // line behind is harmless.
+            for slot in state.apt_lines_buf.iter_mut().take(produced) {
+                let line = std::mem::take(slot);
+                let _ = dsp_tx.send(DspToUi::AptLine(Box::new(line)));
             }
         }
         Err(e) => {

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -541,11 +541,14 @@ fn apt_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_co
     // equivalent to taking either channel for FM-demodulated
     // audio (both channels carry the same baseband signal once
     // any stereo pilot is filtered out by the channel filter).
+    // `extend` over a `map` iterator is exact-size, so `Vec`'s
+    // internal reserve is precise — no manual `reserve` needed.
     state.apt_mono_buf.clear();
-    state.apt_mono_buf.reserve(audio_count);
-    for s in &state.audio_buf[..audio_count] {
-        state.apt_mono_buf.push((s.l + s.r) * 0.5);
-    }
+    state.apt_mono_buf.extend(
+        state.audio_buf[..audio_count]
+            .iter()
+            .map(|s| (s.l + s.r) * 0.5),
+    );
 
     match decoder.process(&state.apt_mono_buf, &mut state.apt_lines_buf) {
         Ok(produced) => {

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -2349,6 +2349,21 @@ fn cleanup(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
     }
 
     state.source = None;
+
+    // Hard stream discontinuity — flush APT decoder state so a
+    // subsequent Start can't bleed pre-stop accumulator/ready
+    // lines into the new session and emit a stale first line.
+    // The decoder itself stays allocated so the next Start
+    // doesn't pay re-init cost (filter taps, resampler tables);
+    // we only clear its in-flight buffers via `AptDecoder::reset`.
+    // Cross-mode preservation (NFM → WFM → NFM mid-pass) is a
+    // *soft* discontinuity and intentionally stays untouched —
+    // the user keeps decoding the same pass.
+    if let Some(decoder) = state.apt_decoder.as_mut() {
+        decoder.reset();
+    }
+    state.apt_mono_buf.clear();
+
     tracing::info!("source closed");
 }
 

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -18,6 +18,7 @@
 use std::sync::mpsc;
 use std::time::Duration;
 
+use sdr_dsp::apt::{AptDecoder, AptLine};
 use sdr_dsp::channel::RxVfo;
 use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
 use sdr_pipeline::source_manager::Source;
@@ -401,6 +402,27 @@ struct DspState {
     /// runs (squelch edges still fire → scanner state machine
     /// stays live).
     scanner_muted: bool,
+
+    /// NOAA APT decoder, lazily constructed on first use. Fed
+    /// from the post-`radio.process` audio path when the active
+    /// demod mode is NFM (the only mode the APT 2400 Hz subcarrier
+    /// rides through cleanly). Audio output rate is 48 kHz which
+    /// is well above the decoder's 4800 Hz Nyquist floor.
+    ///
+    /// `None` means "not yet built" — built once, kept across
+    /// demod-mode toggles so re-entering NFM during a pass picks
+    /// up where it left off rather than restarting decoder state.
+    /// Per epic #468 / ticket #482.
+    apt_decoder: Option<AptDecoder>,
+    /// Pre-allocated mono downmix buffer for the APT decoder
+    /// input. Reused across DSP blocks; resized in place each
+    /// call so we don't alloc inside the hot loop.
+    apt_mono_buf: Vec<f32>,
+    /// Pre-allocated output buffer for `AptDecoder::process`. Sized
+    /// to match the decoder's internal queue cap (8 lines per the
+    /// `AptDecoder` docs); the decoder won't emit more than this in
+    /// a single call.
+    apt_lines_buf: Vec<AptLine>,
 }
 
 impl DspState {
@@ -473,7 +495,64 @@ impl DspState {
             scanner: sdr_scanner::Scanner::new(),
             scanner_channels: Vec::new(),
             scanner_muted: false,
+            apt_decoder: None,
+            apt_mono_buf: Vec::new(),
+            apt_lines_buf: Vec::new(),
         })
+    }
+}
+
+/// NOAA APT decode tap. Lazy-initialises the decoder at the
+/// `RadioModule`'s current audio sample rate, downmixes the post-
+/// `radio.process` stereo audio block to mono, runs the decoder,
+/// and emits any newly-produced lines through the DSP→UI channel
+/// as `DspToUi::AptLine`.
+///
+/// Per epic #468 / ticket #482. Caller must ensure
+/// `audio_count > 0` and the active demod is NFM.
+fn apt_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_count: usize) {
+    // Lazy-init. Audio rate comes from `RadioModule::audio_sample_rate`
+    // (typically 48 kHz, well above the decoder's 4800 Hz floor).
+    if state.apt_decoder.is_none() {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let rate_hz = state.radio.audio_sample_rate() as u32;
+        match AptDecoder::new(rate_hz) {
+            Ok(decoder) => {
+                tracing::info!("APT decoder initialised at {rate_hz} Hz");
+                state.apt_decoder = Some(decoder);
+                // 8 lines of headroom — `AptDecoder` caps its
+                // internal queue at this many per-call.
+                state.apt_lines_buf.resize(8, AptLine::default());
+            }
+            Err(e) => {
+                tracing::warn!("APT decoder init failed at {rate_hz} Hz: {e}");
+                return;
+            }
+        }
+    }
+    let Some(decoder) = state.apt_decoder.as_mut() else {
+        return;
+    };
+
+    // Mono downmix. APT is mono by spec — averaging L+R is
+    // equivalent to taking either channel for FM-demodulated
+    // audio (both channels carry the same baseband signal once
+    // any stereo pilot is filtered out by the channel filter).
+    state.apt_mono_buf.clear();
+    state.apt_mono_buf.reserve(audio_count);
+    for s in &state.audio_buf[..audio_count] {
+        state.apt_mono_buf.push((s.l + s.r) * 0.5);
+    }
+
+    match decoder.process(&state.apt_mono_buf, &mut state.apt_lines_buf) {
+        Ok(produced) => {
+            for line in state.apt_lines_buf.iter().take(produced) {
+                let _ = dsp_tx.send(DspToUi::AptLine(Box::new(line.clone())));
+            }
+        }
+        Err(e) => {
+            tracing::warn!("APT decode failed: {e}");
+        }
     }
 }
 
@@ -2483,6 +2562,23 @@ fn process_iq_block(
                             let rms = (sum_sq / (2.0 * audio_count as f32)).sqrt();
                             let level_db = 20.0 * rms.max(f32::MIN_POSITIVE).log10();
                             let _ = dsp_tx.send(DspToUi::SignalLevel(level_db));
+                        }
+
+                        // NOAA APT decode tap (#482). Only runs in
+                        // NFM mode — the APT 2400 Hz subcarrier rides
+                        // on a Wide-FM-style demod with a narrow
+                        // (~38 kHz) channel filter, which the user's
+                        // NFM mode is set up for. WFM's deemphasis
+                        // would smear the subcarrier; AM/SSB don't
+                        // demodulate it at all. Pre-volume audio
+                        // (this point) so the volume knob doesn't
+                        // affect decode quality. Worker is the DSP
+                        // thread — `AptDecoder` is internally
+                        // single-threaded which fits perfectly.
+                        if audio_count > 0
+                            && state.radio.current_mode() == sdr_types::DemodMode::Nfm
+                        {
+                            apt_decode_tap(state, dsp_tx, audio_count);
                         }
 
                         // Emit CTCSS sustained-gate edges for the UI

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -18,7 +18,7 @@
 use std::sync::mpsc;
 use std::time::Duration;
 
-use sdr_dsp::apt::{AptDecoder, AptLine};
+use sdr_dsp::apt::{AptDecoder, AptLine, READY_QUEUE_CAP};
 use sdr_dsp::channel::RxVfo;
 use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
 use sdr_pipeline::source_manager::Source;
@@ -520,9 +520,12 @@ fn apt_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_co
             Ok(decoder) => {
                 tracing::info!("APT decoder initialised at {rate_hz} Hz");
                 state.apt_decoder = Some(decoder);
-                // 8 lines of headroom — `AptDecoder` caps its
-                // internal queue at this many per-call.
-                state.apt_lines_buf.resize(8, AptLine::default());
+                // Size the output slice to the decoder's documented
+                // per-call emission cap so a single `process` call
+                // can never need to flush.
+                state
+                    .apt_lines_buf
+                    .resize(READY_QUEUE_CAP, AptLine::default());
             }
             Err(e) => {
                 tracing::warn!("APT decoder init failed at {rate_hz} Hz: {e}");

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -1,5 +1,6 @@
 //! Message types for communication between the DSP thread and the UI thread.
 
+use sdr_dsp::apt::AptLine;
 use sdr_dsp::voice_squelch::VoiceSquelchMode;
 use sdr_radio::{DeemphasisMode, af_chain::CtcssMode};
 use sdr_types::{DemodMode, Protocol, RtlTcpConnectionState};
@@ -140,6 +141,20 @@ pub enum DspToUi {
     /// via the mutex. UI shows a toast describing the
     /// transition.
     ScannerMutexStopped(ScannerMutexReason),
+
+    // --- APT decoder (#482) ---
+    /// One decoded NOAA APT image line. Emitted from the DSP
+    /// thread when the live FM-demodulated audio path's `AptDecoder`
+    /// produces a new line. The UI handler routes it to the open
+    /// `AptImageView` (no-op if the viewer isn't open).
+    ///
+    /// Cadence: ~2 lines/sec during a NOAA APT pass (the spec's
+    /// fixed line rate). Boxed because `AptLine` is ~2 KB while
+    /// every other variant is tiny — boxing keeps the enum's
+    /// stack size in line with the rest, which matters for the
+    /// `mpsc::Receiver::try_recv()` hot path that copies the
+    /// returned `DspToUi` value once per drain.
+    AptLine(Box<AptLine>),
 }
 
 /// Available source types for IQ input.

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -1,7 +1,10 @@
 //! Message types for communication between the DSP thread and the UI thread.
 
-use sdr_dsp::apt::AptLine;
 use sdr_dsp::voice_squelch::VoiceSquelchMode;
+// Re-export so downstream crates that match on the `DspToUi::AptLine`
+// variant (e.g. `sdr-ffi` for its FFI-drop regression test) can
+// reach the payload type without taking a direct `sdr-dsp` dep.
+pub use sdr_dsp::apt::AptLine;
 use sdr_radio::{DeemphasisMode, af_chain::CtcssMode};
 use sdr_types::{DemodMode, Protocol, RtlTcpConnectionState};
 
@@ -496,6 +499,29 @@ mod tests {
         assert!(matches!(open, DspToUi::VoiceSquelchOpenChanged(true)));
         let closed = DspToUi::VoiceSquelchOpenChanged(false);
         assert!(matches!(closed, DspToUi::VoiceSquelchOpenChanged(false)));
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn apt_line_message_round_trips_boxed_payload() {
+        // Pins the wire shape: `AptLine` carries a `Box<AptLine>`,
+        // not a bare `AptLine`. A future refactor that swaps to an
+        // unboxed payload (or adds a tuple field, or splits the
+        // line into `(pixels, sync_quality)`, etc.) trips this test
+        // before it can silently bloat the enum's stack size.
+        let payload = AptLine {
+            sync_quality: 0.75,
+            input_sample_index: 12_345,
+            ..AptLine::default()
+        };
+        let msg = DspToUi::AptLine(Box::new(payload));
+        match msg {
+            DspToUi::AptLine(boxed) => {
+                assert!((boxed.sync_quality - 0.75).abs() < f32::EPSILON);
+                assert_eq!(boxed.input_sample_index, 12_345);
+            }
+            other => panic!("expected AptLine, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/sdr-dsp/src/apt.rs
+++ b/crates/sdr-dsp/src/apt.rs
@@ -490,7 +490,12 @@ const MIN_ACCUMULATOR_FOR_DECODE: usize = SAMPLES_PER_LINE * 2;
 /// between calls — at 2 lines/sec, 8 lines = 4 s of slack. Lines past
 /// the cap stay buffered as raw envelope samples in `accumulator` (which
 /// has its own cap); only after both fill does anything get dropped.
-const READY_QUEUE_CAP: usize = 8;
+///
+/// Public so callers that pre-allocate an output slice for
+/// [`AptDecoder::process`] can size it to the decoder's internal
+/// emission cap without duplicating the literal — see the controller
+/// crate's `apt_decode_tap` for an example.
+pub const READY_QUEUE_CAP: usize = 8;
 
 /// Maximum input audio samples processed through the resample → envelope
 /// stages in one pass. Keeps `resample_scratch`, `envelope_scratch`, and

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -1222,6 +1222,25 @@ mod tests {
     }
 
     #[test]
+    fn translate_apt_line_is_dropped_at_ffi_boundary() {
+        // `DspToUi::AptLine` is intentionally dropped by the FFI
+        // translation layer — the macOS frontend's APT viewer is a
+        // separate ticket, and forwarding 2 KB-per-line image data
+        // through a C ABI without a host consumer would be wasted
+        // work. Pin that policy with a regression test: a future
+        // change that exposes APT lines through the FFI (or
+        // accidentally lets the variant fall through to the
+        // catch-all panic arm) trips this assert before it can
+        // reach the Mac side. Per CodeRabbit on PR #503.
+        let line = sdr_core::messages::AptLine::default();
+        let msg = DspToUi::AptLine(Box::new(line));
+        assert!(
+            translate_event(&msg).is_none(),
+            "AptLine must not translate to a wire event yet",
+        );
+    }
+
+    #[test]
     fn rtl_tcp_state_discriminants_match_header() {
         assert_eq!(SDR_RTL_TCP_STATE_DISCONNECTED, 0);
         assert_eq!(SDR_RTL_TCP_STATE_CONNECTING, 1);

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -754,7 +754,12 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         | DspToUi::BandwidthChanged(_)
         | DspToUi::VfoOffsetChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
-        | DspToUi::VoiceSquelchOpenChanged(_) => return None,
+        | DspToUi::VoiceSquelchOpenChanged(_)
+        // APT lines (#482) aren't surfaced through the FFI layer
+        // yet — the macOS frontend will gain a native APT viewer
+        // through its own ticket. Drop them here so the Linux UI
+        // side can keep emitting without a Mac-side build break.
+        | DspToUi::AptLine(_) => return None,
     };
 
     Some((event, owned_cstring, owned_vec))

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -641,6 +641,17 @@ impl RadioModule {
         self.mode
     }
 
+    /// Get the audio output sample rate (Hz). Stable across mode
+    /// switches — the AF chain resamples each demod's native rate
+    /// to this single output rate. Used by downstream consumers
+    /// that need to know the sample rate of `process()`'s output
+    /// buffer (e.g. the NOAA APT decoder tap, which expects an
+    /// input rate strictly greater than 4800 Hz).
+    #[must_use]
+    pub fn audio_sample_rate(&self) -> f64 {
+        self.audio_sample_rate
+    }
+
     /// Get the current demodulator's configuration.
     pub fn demod_config(&self) -> &DemodConfig {
         self.demod.config()

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -6,9 +6,7 @@ use gtk4::glib;
 use gtk4::prelude::*;
 use libadwaita as adw;
 
-use std::rc::Rc;
-
-use crate::{apt_viewer, css, window};
+use crate::{css, window};
 
 /// Application ID for the SDR-RS application.
 const APP_ID: &str = "com.sdr.rs";
@@ -78,17 +76,9 @@ pub fn build_app() -> adw::Application {
             return;
         }
         window::build_window(app, &config);
-
-        // Temporary demo wiring for #483 — Ctrl+Shift+A opens an APT
-        // viewer window with a synthetic gradient pass running at the
-        // real 2 lines/sec cadence. Lets us visually smoke-test the
-        // viewer + non-modal window plumbing without a live overhead
-        // pass. Replaced by #482 (auto-record on overhead pass) once
-        // the radio path knows when to open the viewer for real.
-        let app_for_provider = app.clone();
-        let parent_provider: Rc<dyn Fn() -> Option<gtk4::Window>> =
-            Rc::new(move || app_for_provider.windows().into_iter().next());
-        apt_viewer::connect_demo_action(app, &parent_provider);
+        // Note: the `app.apt-open` action is wired inside
+        // `build_window` (it needs `&Rc<AppState>` for the line
+        // router), not here.
     });
 
     app

--- a/crates/sdr-ui/src/apt_viewer.rs
+++ b/crates/sdr-ui/src/apt_viewer.rs
@@ -19,10 +19,13 @@
 //!   transient window so the main radio window stays interactive
 //!   during a pass. Header bar carries Pause / Resume + Export PNG.
 //!
-//! `connect_demo_action` wires a temporary `app.apt-demo` action
-//! that pumps a synthetic gradient pass through a freshly-opened
-//! window — useful for visual smoke-testing tonight, replaced by
-//! the real radio-side wiring in #482 (auto-record on overhead pass).
+//! [`connect_apt_action`] wires the `app.apt-open` action
+//! (`Ctrl+Shift+A`). Activating it opens a viewer window and
+//! registers it with [`crate::state::AppState::apt_viewer`] so the
+//! `DspToUi::AptLine` handler in `window.rs` can route real,
+//! live-decoded APT lines into it. Closing the window clears the
+//! `AppState` slot — subsequent decoder lines are then dropped
+//! silently until the user reopens.
 
 use std::cell::{Cell, RefCell};
 use std::path::{Path, PathBuf};
@@ -54,17 +57,6 @@ const BACKGROUND_RGB: [f64; 3] = [0.05, 0.05, 0.06];
 /// most desktop resolutions without the user having to resize.
 const VIEWER_WINDOW_WIDTH: i32 = 800;
 const VIEWER_WINDOW_HEIGHT: i32 = 600;
-
-/// Cadence of the synthetic demo pass — 500 ms = 2 lines/sec, which
-/// is the actual NOAA APT line rate. Real pass wiring (#482) drops
-/// the demo entirely.
-const DEMO_TICK: std::time::Duration = std::time::Duration::from_millis(500);
-
-/// Number of lines pumped before the demo timer breaks. 240 ticks at
-/// 2 Hz = 2 minutes — long enough to verify auto-fit + scrolling +
-/// pause + export, short enough that the demo doesn't run forever
-/// even if the window is left open.
-const DEMO_MAX_LINES: u32 = 240;
 
 /// Pure Cairo renderer for an APT scan-line buffer.
 ///
@@ -275,6 +267,11 @@ impl AptImageRenderer {
 /// toolbar callbacks can hold their own handle without lifetime
 /// dance. Push new lines in via [`AptImageView::push_line`]; the
 /// widget queues a redraw automatically (unless paused).
+/// Handle for an open APT viewer. `Clone` is derived (existing
+/// pattern) so the wiring layer can stash a copy in
+/// [`crate::state::AppState`] for the `DspToUi::AptLine` handler
+/// to push lines into — every field is already `Rc`-shared
+/// internally, so cloning is a refcount bump.
 #[derive(Clone)]
 pub struct AptImageView {
     drawing_area: gtk4::DrawingArea,
@@ -389,7 +386,7 @@ impl AptImageView {
 pub fn open_apt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
     parent: &W,
     title: &str,
-) -> AptImageView {
+) -> (AptImageView, adw::Window) {
     let view = AptImageView::new();
 
     let window = adw::Window::builder()
@@ -457,7 +454,7 @@ pub fn open_apt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
     window.set_content(Some(&toast_overlay));
     window.present();
 
-    view
+    (view, window)
 }
 
 /// Default path the Export PNG button writes to:
@@ -482,99 +479,56 @@ fn show_toast_in<W: gtk4::prelude::IsA<gtk4::Window>>(window: &W, toast: adw::To
     }
 }
 
-// ─── Demo action (smoke-test wiring) ───────────────────────────────────
+// ─── Live viewer action ─────────────────────────────────────────────────
 
-/// Wire the temporary `app.apt-demo` action onto `app`. Activating
-/// it opens an APT viewer window and pumps a synthetic gradient
-/// pass into it at the real APT cadence (2 lines / sec). Useful for
-/// visual smoke-testing the renderer + window plumbing tonight; the
-/// real radio-side wiring lands in #482 (auto-record on overhead
-/// pass) and this action goes away.
-pub fn connect_demo_action(
+/// Wire the `app.apt-open` action onto `app`. Activating it (via the
+/// app menu, the `Ctrl+Shift+A` accelerator, or future activity-bar
+/// entry) opens a non-modal APT viewer window. The window is fed
+/// real `AptLine`s from the DSP-thread decoder via
+/// `state.apt_viewer` — the [`crate::messages::DspToUi::AptLine`]
+/// handler in `window.rs` looks up the active view there and pushes
+/// pixel rows into it.
+///
+/// If the viewer is already open, activating the action again is a
+/// no-op (we don't try to refocus or re-create — the existing window
+/// is already on screen and accepting lines). Closing the window
+/// clears `state.apt_viewer` so the decoder's lines are dropped
+/// silently until the user reopens.
+pub fn connect_apt_action(
     app: &adw::Application,
     parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,
+    state: &Rc<crate::state::AppState>,
 ) {
-    let action = gio::SimpleAction::new("apt-demo", None);
+    let action = gio::SimpleAction::new("apt-open", None);
     let parent_provider = Rc::clone(parent_provider);
-    action.connect_activate(glib::clone!(
-        #[strong]
-        parent_provider,
-        move |_, _| {
-            let Some(parent) = parent_provider() else {
-                tracing::warn!("apt-demo invoked with no main window available");
-                return;
-            };
-            spawn_demo_pass(&parent);
+    let state_for_action = Rc::clone(state);
+    action.connect_activate(move |_, _| {
+        if state_for_action.apt_viewer.borrow().is_some() {
+            // Already open — nothing to do. The user can find the
+            // existing window via the OS window switcher.
+            return;
         }
-    ));
-    app.add_action(&action);
-    app.set_accels_for_action("app.apt-demo", &["<Ctrl><Shift>a"]);
-}
-
-/// Open a viewer window and start a [`DEMO_TICK`] timeout that pumps
-/// one synthetic line into it per tick (matching real APT cadence).
-/// Each line is a 2080-pixel left-to-right grayscale gradient with a
-/// row-dependent vertical fade — easy to eyeball as "yep, lines are
-/// arriving in order, the renderer is fitting correctly, the image
-/// is building downward".
-///
-/// The timer holds a `WeakRef` to the underlying `DrawingArea` and
-/// `Weak` references to the renderer / pause state. If the user
-/// closes the viewer window before the demo completes, the next
-/// tick fails to upgrade the weak refs and breaks out cleanly —
-/// no work pumped into a destroyed widget, no lingering ~17 MB
-/// pixel buffer kept alive by the closure for the rest of the
-/// 2-minute schedule.
-fn spawn_demo_pass<W: gtk4::prelude::IsA<gtk4::Window>>(parent: &W) {
-    let view = open_apt_viewer_window(parent, "NOAA APT — Demo Pass (synthetic)");
-
-    // Weak refs to widget + state. Drop the strong `view` immediately
-    // so the timer doesn't keep the window's DrawingArea alive past
-    // the user closing the window.
-    let drawing_area_weak = view.drawing_area.downgrade();
-    let renderer_weak = Rc::downgrade(&view.renderer);
-    let paused_weak = Rc::downgrade(&view.paused);
-    drop(view);
-
-    let row = Rc::new(Cell::new(0_u32));
-    glib::timeout_add_local(DEMO_TICK, move || {
-        // Window gone → nothing left to draw into, exit the timer.
-        let Some(drawing_area) = drawing_area_weak.upgrade() else {
-            return glib::ControlFlow::Break;
+        let Some(parent) = parent_provider() else {
+            tracing::warn!("apt-open invoked with no main window available");
+            return;
         };
-        let Some(renderer) = renderer_weak.upgrade() else {
-            return glib::ControlFlow::Break;
-        };
-        let Some(paused) = paused_weak.upgrade() else {
-            return glib::ControlFlow::Break;
-        };
+        let (view, window) = open_apt_viewer_window(&parent, "NOAA APT");
+        // Stash a clone in AppState so the DSP→UI handler can find
+        // it. The clone is cheap (every field is `Rc`-shared).
+        *state_for_action.apt_viewer.borrow_mut() = Some(view);
 
-        if !paused.get() {
-            let mut pixels = [0_u8; LINE_PIXELS];
-            let r = row.get();
-            // Left-to-right horizontal gradient + a vertical fade so
-            // each row is visibly different from the last — enough
-            // variation that any rendering bug (off-by-one, wrong
-            // stride, scale direction wrong) shows up obviously.
-            #[allow(clippy::cast_possible_truncation)]
-            for (i, p) in pixels.iter_mut().enumerate() {
-                let h = (i * 255 / LINE_PIXELS) as u32;
-                let v = (r.wrapping_mul(7)) % 200; // slow-cycling brightness offset
-                *p = (((h + v) % 256) & 0xff) as u8;
-            }
-            renderer.borrow_mut().push_line(&pixels);
-            drawing_area.queue_draw();
-            row.set(r.wrapping_add(1));
-        }
-
-        // Cap the demo at DEMO_MAX_LINES so it doesn't run forever
-        // even if the user leaves the window open.
-        if row.get() >= DEMO_MAX_LINES {
-            glib::ControlFlow::Break
-        } else {
-            glib::ControlFlow::Continue
-        }
+        // Clear the AppState slot when the user closes the window
+        // — otherwise `DspToUi::AptLine` would keep pushing into a
+        // detached widget tree until the next reopen, and the
+        // viewer state would never reset for a second pass.
+        let state_for_close = Rc::clone(&state_for_action);
+        window.connect_close_request(move |_| {
+            *state_for_close.apt_viewer.borrow_mut() = None;
+            glib::Propagation::Proceed
+        });
     });
+    app.add_action(&action);
+    app.set_accels_for_action("app.apt-open", &["<Ctrl><Shift>a"]);
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -98,6 +98,21 @@ pub struct AppState {
     /// per-server keyring entry. Empty string when no server is
     /// selected. Per issue #396.
     pub rtl_tcp_active_server: RefCell<String>,
+    /// Currently-open NOAA APT viewer window, or `None` when no
+    /// viewer is open. Set by the viewer's open path (the
+    /// activity-bar / shortcut handler) and cleared by its
+    /// `close-request` signal. The `DspToUi::AptLine` handler in
+    /// `handle_dsp_message` routes incoming lines here — when
+    /// `None`, the lines are dropped (the decoder runs anyway, but
+    /// nothing is displayed). Per epic #468 / ticket #482.
+    ///
+    /// `RefCell<Option<AptImageView>>` rather than
+    /// `RefCell<Option<glib::WeakRef<…>>>` because `AptImageView`
+    /// is internally `Rc`-shared already, and we want the line
+    /// router to fail closed (drop the line) when the viewer's
+    /// `close-request` fires, not when the `GObject`'s last strong
+    /// ref happens to drop.
+    pub apt_viewer: RefCell<Option<crate::apt_viewer::AptImageView>>,
 }
 
 impl AppState {
@@ -119,6 +134,7 @@ impl AppState {
             // AuthFailed is correctly detected as an edge.
             last_rtl_tcp_state_disc: Cell::new(RTL_TCP_STATE_DISC_DISCONNECTED),
             rtl_tcp_active_server: RefCell::new(String::new()),
+            apt_viewer: RefCell::new(None),
         })
     }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -377,6 +377,17 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
 
     window.add_breakpoint(breakpoint);
 
+    // Wire `app.apt-open` (Ctrl+Shift+A) — opens the live APT
+    // viewer window. Done here rather than in `app.rs::activate`
+    // because the action's line-routing handler reads
+    // `state.apt_viewer`, and `state` is owned by this window.
+    {
+        let app_for_provider = app.clone();
+        let parent_provider: Rc<dyn Fn() -> Option<gtk4::Window>> =
+            Rc::new(move || app_for_provider.windows().into_iter().next());
+        crate::apt_viewer::connect_apt_action(app, &parent_provider, &state);
+    }
+
     // Set initial status bar values and mode-specific control visibility.
     if let Some(mode) = demod_selector::index_to_demod_mode(demod_dropdown.selected()) {
         let label = header::demod_mode_label(mode);
@@ -1251,6 +1262,17 @@ fn handle_dsp_message(
             // but relying on that ordering across four stop
             // sites was brittle.
             clear_scanner_active_channel_ui(scanner_panel, state);
+        }
+        DspToUi::AptLine(line) => {
+            // Route the freshly-decoded APT line into the open
+            // viewer, if any. When no viewer is open we silently
+            // drop — the decoder always runs (it's cheap) so the
+            // user can open the viewer mid-pass and start seeing
+            // lines from that moment on, rather than having to
+            // pre-arm before AOS.
+            if let Some(view) = state.apt_viewer.borrow().as_ref() {
+                view.push_line(&line.pixels);
+            }
         }
         DspToUi::ScannerMutexStopped(reason) => {
             tracing::info!(?reason, "scanner mutex stopped");


### PR DESCRIPTION
## Summary

Connects the existing APT pieces — `sdr_dsp::apt::AptDecoder` (PR #492), `sdr_radio::apt_image` (PR #494), `sdr_ui::apt_viewer` (PR #501) — so a real NOAA APT pass produces a real image instead of the synthetic gradient that's stood in since the viewer shipped. This is the first chunk of #482; the auto-record-on-pass UX is the second chunk and ships separately.

- **DSP tap** in `sdr-core::controller::apt_decode_tap` runs only in NFM mode, pre-volume, with mono downmix and zero per-block allocation. Lazy-init'd `AptDecoder` at the radio's audio sample rate (typically 48 kHz, well above the decoder's 4800 Hz Nyquist floor).
- **`DspToUi::AptLine(Box<AptLine>)`** message variant. Boxed because `AptLine` is ~2 KB while every other variant is small — boxing keeps the enum's stack size sensible.
- **`AppState::apt_viewer`** is the routing slot. `handle_dsp_message::AptLine` looks up the active view there and pushes pixel rows in (no-op when no viewer is open — decoder always runs, lines just drop).
- **`app.apt-open` action** replaces the temporary `app.apt-demo`. Same `Ctrl+Shift+A` shortcut, but now opens a real-feed viewer and registers it with `AppState`. Window's `close-request` clears the slot. Synthetic gradient + `DEMO_TICK` / `DEMO_MAX_LINES` constants deleted.

## What this leaves for #482b

- Auto-record-on-pass UX — watch the Satellites panel's upcoming passes, auto-tune at AOS, save PNG at LOS.
- Per-row "tune to this satellite" play button on each upcoming-pass row (manual companion to the auto-record primitive).

## Manual smoke test

- [x] `Ctrl+Shift+A` opens the viewer titled "NOAA APT" (no longer "Demo Pass (synthetic)").
- [x] Tuning to a NOAA APT freq (137.100 / 137.620 / 137.9125 MHz) in NFM with ~38 kHz BW renders real lines into the viewer at 2 lines/sec — confirmed during testing: even off-pass, decoder static is rendering, which proves the audio→decoder→viewer path is end-to-end live.
- [ ] Real overhead pass produces a recognizable image (waiting on a clear pass to fully verify; ground-station calibration / dongle PPM are likely confounders unrelated to this PR).
- [ ] CodeRabbit review.

## Build verification

- [x] `cargo build --workspace --features whisper-cpu` clean
- [x] `cargo test --workspace --features whisper-cpu` no failures
- [x] `cargo clippy --workspace --features whisper-cpu --all-targets -- -D warnings` clean (`AptLine` boxing fixes the `large_enum_variant` warning)
- [x] `cargo fmt --all --check` clean
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` clean (per dual-build rule, even though transcription not touched)

## Related

- Part of epic #468 (NOAA APT)
- Part of #482 (decoder wiring + auto-record on pass) — #482b will close the issue
- Builds on #481 (Satellites scheduler UI) which provides the pass schedule that #482b will consume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent NOAA APT viewer action opens a non‑modal window to display live decoded satellite image lines.

* **Bug Fixes / Behavior**
  * Removed demo placeholder; viewer open/close now controls whether decoded lines are shown or dropped.
  * Decoder resets on stream discontinuity to avoid stale lines.
  * Decoding failures are logged and do not produce output or cross the external event boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->