### PR TITLE
sdr-sat,sdr-ui: catalog polish + per-row tune button (closes #506, #507)

### DIFF
--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -46,6 +46,31 @@ pub struct KnownSatellite {
     /// NORAD catalog number — the canonical satellite identifier.
     /// [`TleCache`] looks up TLEs by this id directly.
     pub norad_id: u32,
+    /// Downlink centre frequency, Hz. Targets the satellite's primary
+    /// imaging signal — APT (137.x MHz) for NOAA, LRPT (137.x MHz) for
+    /// Meteor-M, SSTV (145.8 MHz) for ISS during transmission events.
+    /// Consumed by the Satellites panel's pass-row display and (in
+    /// the upcoming #482b work) by the "tune to this satellite" play
+    /// button.
+    pub downlink_hz: u64,
+    /// Demod mode the receiver should be in for this satellite. NFM
+    /// for everything we ship today: NOAA APT, Meteor LRPT, and ISS
+    /// SSTV all ride wide-FM-style channels and our demod chain
+    /// handles them through the same NFM front-end with a wider
+    /// channel filter. Tracked as a field rather than hardcoded so a
+    /// future amateur-band catalog addition (e.g. AO-92 with FM voice
+    /// vs PSK telemetry) can choose differently without a special
+    /// case in the wiring layer.
+    pub demod_mode: sdr_types::DemodMode,
+    /// Channel bandwidth (Hz) the receiver should use for this
+    /// satellite. APT / LRPT / SSTV all need ~38 kHz of headroom
+    /// past the NFM default 12.5 kHz to capture the full subcarrier
+    /// spectrum without clipping the brighter / darker extremes.
+    /// Same per-satellite philosophy as `demod_mode` — the catalog
+    /// entry is the single source of truth so the play button can
+    /// dispatch a `SetBandwidth` without re-deriving the value from
+    /// signal type.
+    pub bandwidth_hz: u32,
 }
 
 /// Built-in catalog. Order is the order the scheduler UI displays.
@@ -54,32 +79,53 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     KnownSatellite {
         name: "NOAA 15",
         norad_id: 25_338,
+        downlink_hz: 137_620_000,
+        demod_mode: sdr_types::DemodMode::Nfm,
+        bandwidth_hz: 38_000,
     },
     KnownSatellite {
         name: "NOAA 18",
         norad_id: 28_654,
+        downlink_hz: 137_912_500,
+        demod_mode: sdr_types::DemodMode::Nfm,
+        bandwidth_hz: 38_000,
     },
     KnownSatellite {
         name: "NOAA 19",
         norad_id: 33_591,
+        downlink_hz: 137_100_000,
+        demod_mode: sdr_types::DemodMode::Nfm,
+        bandwidth_hz: 38_000,
     },
-    // Meteor-M LRPT — epic #469
+    // Meteor-M LRPT — epic #469. Note: METEOR-M 2 and NOAA 19 share
+    // the 137.100 MHz channel — they're never on simultaneously by
+    // design. The pass scheduler picks whichever is overhead.
     KnownSatellite {
         name: "METEOR-M 2",
         norad_id: 40_069,
+        downlink_hz: 137_100_000,
+        demod_mode: sdr_types::DemodMode::Nfm,
+        bandwidth_hz: 38_000,
     },
     KnownSatellite {
         name: "METEOR-M2 3",
         norad_id: 57_166,
+        downlink_hz: 137_900_000,
+        demod_mode: sdr_types::DemodMode::Nfm,
+        bandwidth_hz: 38_000,
     },
-    KnownSatellite {
-        name: "METEOR-M2 4",
-        norad_id: 61_024,
-    },
-    // ISS SSTV — epic #472
+    // METEOR-M2 4 (NORAD 61024) deliberately omitted — launched 2024,
+    // failed shortly after, no usable TLE on Celestrak (404 from the
+    // GP API). Per #506.
+    // ISS SSTV — epic #472. 145.800 MHz is the primary downlink for
+    // SSTV transmission events and the ARISS voice repeater; both
+    // ride wide-FM and use the same tune-and-listen flow.
     KnownSatellite {
         name: "ISS (ZARYA)",
         norad_id: 25_544,
+        downlink_hz: 145_800_000,
+        demod_mode: sdr_types::DemodMode::Nfm,
+        bandwidth_hz: 38_000,
     },
 ];
 
@@ -109,5 +155,36 @@ mod tests {
         assert!(names.iter().any(|n| n.contains("METEOR")));
         // ISS SSTV
         assert!(names.iter().any(|n| n.contains("ISS")));
+    }
+
+    #[test]
+    fn meteor_m2_4_is_dropped_from_catalog() {
+        // NORAD 61024 (METEOR-M2 4) launched 2024 and failed shortly
+        // after — Celestrak's GP API returns 404 for it. Per #506,
+        // the entry is intentionally absent so refreshes don't
+        // accumulate per-call warn logs for a satellite that will
+        // never produce a pass.
+        assert!(
+            !KNOWN_SATELLITES.iter().any(|s| s.norad_id == 61_024),
+            "METEOR-M2 4 (NORAD 61024) should not be in KNOWN_SATELLITES",
+        );
+    }
+
+    #[test]
+    fn known_satellites_have_imaging_band_downlinks() {
+        // All catalog entries today are weather / imaging / SSTV
+        // satellites that downlink in the 137-148 MHz VHF window.
+        // Pin the range so a future entry with a wildly-wrong freq
+        // (e.g. forgot to convert MHz → Hz, or pasted a different
+        // satellite's value) trips this test rather than reaching
+        // the user as a misconfigured tune button.
+        for s in KNOWN_SATELLITES {
+            assert!(
+                (137_000_000..=148_000_000).contains(&s.downlink_hz),
+                "{} downlink {} Hz is outside the 137-148 MHz VHF imaging band",
+                s.name,
+                s.downlink_hz,
+            );
+        }
     }
 }

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -35,6 +35,24 @@ pub use postal_lookup::{PostalLocation, PostalLookupError, lookup_us_zip};
 pub use sgp4_core::{Satellite, SatelliteError};
 pub use tle_cache::{TleCache, TleCacheError, celestrak_gp_url};
 
+/// Default channel bandwidth (Hz) for every catalog entry. APT,
+/// LRPT, and ISS SSTV all need ~38 kHz of headroom past the NFM
+/// 12.5 kHz default to capture the full subcarrier spectrum without
+/// clipping the brighter / darker extremes. Hoisted to a module
+/// constant so the same number doesn't get pasted into every
+/// catalog row — and so a future re-tune of the default applies
+/// everywhere consistently.
+pub const DEFAULT_SATELLITE_BANDWIDTH_HZ: u32 = 38_000;
+
+/// VHF imaging-band lower bound (Hz). Every catalog satellite's
+/// downlink must land in [`IMAGING_BAND_MIN_HZ`,
+/// [`IMAGING_BAND_MAX_HZ`]] — checked at compile time-ish via the
+/// unit test below. Captures the standard 137 MHz weather-sat band
+/// plus the 145.8 MHz ISS SSTV / amateur-satellite slot.
+pub const IMAGING_BAND_MIN_HZ: u64 = 137_000_000;
+/// VHF imaging-band upper bound (Hz). See [`IMAGING_BAND_MIN_HZ`].
+pub const IMAGING_BAND_MAX_HZ: u64 = 148_000_000;
+
 /// A satellite the user-facing scheduler ships with by default. The list
 /// is intentionally tight — we want passes to "just work" for the most
 /// common LEO weather / ham satellites without making the user paste
@@ -81,21 +99,21 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         norad_id: 25_338,
         downlink_hz: 137_620_000,
         demod_mode: sdr_types::DemodMode::Nfm,
-        bandwidth_hz: 38_000,
+        bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
     },
     KnownSatellite {
         name: "NOAA 18",
         norad_id: 28_654,
         downlink_hz: 137_912_500,
         demod_mode: sdr_types::DemodMode::Nfm,
-        bandwidth_hz: 38_000,
+        bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
     },
     KnownSatellite {
         name: "NOAA 19",
         norad_id: 33_591,
         downlink_hz: 137_100_000,
         demod_mode: sdr_types::DemodMode::Nfm,
-        bandwidth_hz: 38_000,
+        bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
     },
     // Meteor-M LRPT — epic #469. Note: METEOR-M 2 and NOAA 19 share
     // the 137.100 MHz channel — they're never on simultaneously by
@@ -105,14 +123,14 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         norad_id: 40_069,
         downlink_hz: 137_100_000,
         demod_mode: sdr_types::DemodMode::Nfm,
-        bandwidth_hz: 38_000,
+        bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
     },
     KnownSatellite {
         name: "METEOR-M2 3",
         norad_id: 57_166,
         downlink_hz: 137_900_000,
         demod_mode: sdr_types::DemodMode::Nfm,
-        bandwidth_hz: 38_000,
+        bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
     },
     // METEOR-M2 4 (NORAD 61024) deliberately omitted — launched 2024,
     // failed shortly after, no usable TLE on Celestrak (404 from the
@@ -125,7 +143,7 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         norad_id: 25_544,
         downlink_hz: 145_800_000,
         demod_mode: sdr_types::DemodMode::Nfm,
-        bandwidth_hz: 38_000,
+        bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
     },
 ];
 
@@ -180,10 +198,12 @@ mod tests {
         // the user as a misconfigured tune button.
         for s in KNOWN_SATELLITES {
             assert!(
-                (137_000_000..=148_000_000).contains(&s.downlink_hz),
-                "{} downlink {} Hz is outside the 137-148 MHz VHF imaging band",
+                (IMAGING_BAND_MIN_HZ..=IMAGING_BAND_MAX_HZ).contains(&s.downlink_hz),
+                "{} downlink {} Hz is outside the {}-{} Hz VHF imaging band",
                 s.name,
                 s.downlink_hz,
+                IMAGING_BAND_MIN_HZ,
+                IMAGING_BAND_MAX_HZ,
             );
         }
     }

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -531,18 +531,24 @@ pub fn pass_quality_label(peak_elev_deg: f64) -> &'static str {
     }
 }
 
+/// Find the [`KnownSatellite`] entry whose display name matches the
+/// pass's satellite. `None` for off-catalog satellites — shouldn't
+/// happen in practice because the pass list is enumerated against
+/// `KNOWN_SATELLITES`, but the name is the only key carried on
+/// [`Pass`] so the lookup indirection is the natural shape. Shared
+/// by every `*_for_pass` accessor in this module so the predicate
+/// stays in exactly one place.
+#[must_use]
+fn known_satellite_for_pass(pass: &Pass) -> Option<&'static sdr_sat::KnownSatellite> {
+    KNOWN_SATELLITES.iter().find(|s| s.name == pass.satellite)
+}
+
 /// Look up the downlink frequency for a satellite by its display
 /// name. Returns `None` for satellites that aren't in
-/// [`KNOWN_SATELLITES`] (shouldn't happen in practice — the
-/// pass list is enumerated against that catalog — but the name is
-/// the only key carried on the [`Pass`] type, so a lookup
-/// indirection is the natural shape).
+/// [`KNOWN_SATELLITES`].
 #[must_use]
 pub fn downlink_hz_for_pass(pass: &Pass) -> Option<u64> {
-    KNOWN_SATELLITES
-        .iter()
-        .find(|s| s.name == pass.satellite)
-        .map(|s| s.downlink_hz)
+    known_satellite_for_pass(pass).map(|s| s.downlink_hz)
 }
 
 /// The full tuning triple — frequency, demod mode, channel
@@ -553,10 +559,7 @@ pub fn downlink_hz_for_pass(pass: &Pass) -> Option<u64> {
 /// [`downlink_hz_for_pass`].
 #[must_use]
 pub fn tune_target_for_pass(pass: &Pass) -> Option<(u64, sdr_types::DemodMode, u32)> {
-    KNOWN_SATELLITES
-        .iter()
-        .find(|s| s.name == pass.satellite)
-        .map(|s| (s.downlink_hz, s.demod_mode, s.bandwidth_hz))
+    known_satellite_for_pass(pass).map(|s| (s.downlink_hz, s.demod_mode, s.bandwidth_hz))
 }
 
 /// Format a Hz frequency as a fixed-precision MHz string with

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -515,6 +515,18 @@ const QUALITY_WINNER_DEG: f64 = 40.0;
 const QUALITY_GOOD_DEG: f64 = 25.0;
 const QUALITY_MARGINAL_DEG: f64 = 15.0;
 
+/// Hz → MHz conversion factor for the downlink formatter.
+const HZ_PER_MHZ: f64 = 1_000_000.0;
+/// Decimal-place ceiling for the formatted MHz string. Pinned to
+/// 4 to preserve NOAA 18's 137.9125 MHz off-channel offset; any
+/// catalog entry with finer-than-100-Hz precision would lose
+/// digits past this.
+const DOWNLINK_MAX_DECIMALS: usize = 4;
+/// Decimal-place floor for the formatted MHz string. Padded out
+/// to 3 even for round numbers so every panel row lines up
+/// visually ("137.100" not "137.1").
+const DOWNLINK_MIN_DECIMALS: usize = 3;
+
 /// Map a pass's peak elevation to a one-word quality tag for the
 /// pass row's subtitle. Helps the user spot which upcoming pass is
 /// worth setting an alarm for vs. ones to skip past.
@@ -574,19 +586,19 @@ pub fn tune_target_for_pass(pass: &Pass) -> Option<(u64, sdr_types::DemodMode, u
               that ceiling"
 )]
 pub fn format_downlink_mhz(hz: u64) -> String {
-    let mhz = hz as f64 / 1_000_000.0;
-    // Up to 4 decimals (137.9125), then trim trailing zeros so
-    // 137.100 reads as "137.100" and 145.800 as "145.800" but
+    let mhz = hz as f64 / HZ_PER_MHZ;
+    // Up to MAX decimals (4 → 137.9125), then trim trailing zeros
+    // so 137.100 reads as "137.100" and 145.800 as "145.800" but
     // 137.9125 keeps its 4th digit.
-    let raw = format!("{mhz:.4}");
+    let raw = format!("{mhz:.DOWNLINK_MAX_DECIMALS$}");
     let trimmed = raw.trim_end_matches('0');
     let trimmed = trimmed.trim_end_matches('.');
-    // Always show at least 3 decimals so every entry lines up
+    // Always show at least MIN decimals so every entry lines up
     // visually in the panel ("137.100" not "137.1").
     let dot_idx = trimmed.find('.').unwrap_or(trimmed.len());
     let decimals = trimmed.len().saturating_sub(dot_idx + 1);
-    let formatted = if decimals < 3 {
-        format!("{mhz:.3}")
+    let formatted = if decimals < DOWNLINK_MIN_DECIMALS {
+        format!("{mhz:.DOWNLINK_MIN_DECIMALS$}")
     } else {
         trimmed.to_string()
     };
@@ -898,6 +910,29 @@ mod tests {
         let mut pass = synthetic_pass(now, 30);
         pass.satellite = "MYSTERY-SAT".to_string();
         assert_eq!(downlink_hz_for_pass(&pass), None);
+    }
+
+    #[test]
+    fn tune_target_for_pass_returns_full_tuning_triple() {
+        // Pin the (downlink_hz, demod_mode, bandwidth_hz) triple
+        // for a known catalog entry. A future refactor that splits
+        // or reorders the tuple — or that drifts the catalog
+        // values — fails here before reaching the play-button
+        // wiring layer.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_pass(now, 30); // satellite = "NOAA 19"
+        let target = tune_target_for_pass(&pass).expect("NOAA 19 is in catalog");
+        assert_eq!(target.0, 137_100_000);
+        assert_eq!(target.1, sdr_types::DemodMode::Nfm);
+        assert_eq!(target.2, 38_000);
+    }
+
+    #[test]
+    fn tune_target_for_pass_returns_none_for_unknown_satellite() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let mut pass = synthetic_pass(now, 30);
+        pass.satellite = "MYSTERY-SAT".to_string();
+        assert!(tune_target_for_pass(&pass).is_none());
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -859,11 +859,16 @@ mod tests {
     fn format_pass_subtitle_falls_back_when_satellite_not_in_catalog() {
         // A pass for a satellite the panel doesn't know about (user
         // has manually loaded a TLE, future) — subtitle still works,
-        // just without the freq.
+        // just without the freq. The fallback is still
+        // `quality · geometry`, NOT geometry-only — assert all three
+        // invariants so a regression that drops the quality tag in
+        // the off-catalog branch trips here rather than reaching the
+        // user as an inconsistent row.
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let mut pass = synthetic_pass(now, 30);
         pass.satellite = "FAKESAT-7".to_string();
         let subtitle = format_pass_subtitle(&pass);
+        assert!(subtitle.contains("winner"), "subtitle: {subtitle}");
         assert!(subtitle.contains("max el 56"), "subtitle: {subtitle}");
         assert!(!subtitle.contains("MHz"), "subtitle: {subtitle}");
     }

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -502,14 +502,110 @@ fn read_bool_or(config: &Arc<ConfigManager>, key: &str, default: bool) -> bool {
 
 // ─── Helpers used by the wiring layer ─────────────────────────────────
 
+/// Pass-quality boundaries (degrees of peak elevation). Tuned from
+/// real-world receive experience:
+///
+/// * `>= 40°` → "winner" — clean image, clear land/cloud features.
+/// * `>= 25°` → "good" — recognizable image with some noise at edges.
+/// * `>= 15°` → "marginal" — main features survive but noisy.
+/// * else (down to the [`MIN_PASS_ELEVATION_DEG`] floor) → "barely" —
+///   mostly noise, only worth tuning if nothing better is in the
+///   next few hours.
+const QUALITY_WINNER_DEG: f64 = 40.0;
+const QUALITY_GOOD_DEG: f64 = 25.0;
+const QUALITY_MARGINAL_DEG: f64 = 15.0;
+
+/// Map a pass's peak elevation to a one-word quality tag for the
+/// pass row's subtitle. Helps the user spot which upcoming pass is
+/// worth setting an alarm for vs. ones to skip past.
+#[must_use]
+pub fn pass_quality_label(peak_elev_deg: f64) -> &'static str {
+    if peak_elev_deg >= QUALITY_WINNER_DEG {
+        "winner"
+    } else if peak_elev_deg >= QUALITY_GOOD_DEG {
+        "good"
+    } else if peak_elev_deg >= QUALITY_MARGINAL_DEG {
+        "marginal"
+    } else {
+        "barely"
+    }
+}
+
+/// Look up the downlink frequency for a satellite by its display
+/// name. Returns `None` for satellites that aren't in
+/// [`KNOWN_SATELLITES`] (shouldn't happen in practice — the
+/// pass list is enumerated against that catalog — but the name is
+/// the only key carried on the [`Pass`] type, so a lookup
+/// indirection is the natural shape).
+#[must_use]
+pub fn downlink_hz_for_pass(pass: &Pass) -> Option<u64> {
+    KNOWN_SATELLITES
+        .iter()
+        .find(|s| s.name == pass.satellite)
+        .map(|s| s.downlink_hz)
+}
+
+/// The full tuning triple — frequency, demod mode, channel
+/// bandwidth — for a given pass's satellite. Returned as a tuple
+/// to keep the call site simple (the play-button wiring layer
+/// destructures it directly into the three `UiToDsp` setters).
+/// `None` for the same off-catalog reason as
+/// [`downlink_hz_for_pass`].
+#[must_use]
+pub fn tune_target_for_pass(pass: &Pass) -> Option<(u64, sdr_types::DemodMode, u32)> {
+    KNOWN_SATELLITES
+        .iter()
+        .find(|s| s.name == pass.satellite)
+        .map(|s| (s.downlink_hz, s.demod_mode, s.bandwidth_hz))
+}
+
+/// Format a Hz frequency as a fixed-precision MHz string with
+/// trailing zeros trimmed: `137_100_000` → `"137.100 MHz"`,
+/// `137_912_500` → `"137.9125 MHz"`. Three decimals is enough to
+/// disambiguate every NOAA / Meteor / ISS downlink we ship.
+#[must_use]
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "u64 → f64 here only loses precision past ~2^53; our \
+              downlink frequencies are in the 100s of MHz, far below \
+              that ceiling"
+)]
+pub fn format_downlink_mhz(hz: u64) -> String {
+    let mhz = hz as f64 / 1_000_000.0;
+    // Up to 4 decimals (137.9125), then trim trailing zeros so
+    // 137.100 reads as "137.100" and 145.800 as "145.800" but
+    // 137.9125 keeps its 4th digit.
+    let raw = format!("{mhz:.4}");
+    let trimmed = raw.trim_end_matches('0');
+    let trimmed = trimmed.trim_end_matches('.');
+    // Always show at least 3 decimals so every entry lines up
+    // visually in the panel ("137.100" not "137.1").
+    let dot_idx = trimmed.find('.').unwrap_or(trimmed.len());
+    let decimals = trimmed.len().saturating_sub(dot_idx + 1);
+    let formatted = if decimals < 3 {
+        format!("{mhz:.3}")
+    } else {
+        trimmed.to_string()
+    };
+    format!("{formatted} MHz")
+}
+
 /// Description text shown on a pass row alongside its title-line
-/// countdown. Format: `"max el 56°  ·  AOS 245° → LOS 105°"`.
+/// countdown. Format with downlink + quality tag:
+/// `"winner · 137.100 MHz · max el 56° · AOS 245° → LOS 105°"`.
+/// Falls back to the plain geometry-only form if the satellite
+/// isn't in [`KNOWN_SATELLITES`] (no downlink to display).
 #[must_use]
 pub fn format_pass_subtitle(pass: &Pass) -> String {
-    format!(
+    let quality = pass_quality_label(pass.max_elevation_deg);
+    let geometry = format!(
         "max el {:.0}°  ·  AOS {:.0}° → LOS {:.0}°",
         pass.max_elevation_deg, pass.start_az_deg, pass.end_az_deg,
-    )
+    );
+    match downlink_hz_for_pass(pass) {
+        Some(hz) => format!("{quality}  ·  {}  ·  {geometry}", format_downlink_mhz(hz)),
+        None => format!("{quality}  ·  {geometry}"),
+    }
 }
 
 /// Title-line countdown rendering. Examples:
@@ -731,6 +827,74 @@ mod tests {
         assert!(subtitle.contains("max el 56"));
         assert!(subtitle.contains("AOS 245"));
         assert!(subtitle.contains("LOS 105"));
+    }
+
+    #[test]
+    fn format_pass_subtitle_includes_quality_tag_and_downlink() {
+        // NOAA 19 with 56° peak is a "winner" tier pass; downlink
+        // is 137.100 MHz from the catalog.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_pass(now, 30);
+        let subtitle = format_pass_subtitle(&pass);
+        assert!(subtitle.contains("winner"), "subtitle: {subtitle}");
+        assert!(subtitle.contains("137.100 MHz"), "subtitle: {subtitle}");
+    }
+
+    #[test]
+    fn format_pass_subtitle_falls_back_when_satellite_not_in_catalog() {
+        // A pass for a satellite the panel doesn't know about (user
+        // has manually loaded a TLE, future) — subtitle still works,
+        // just without the freq.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let mut pass = synthetic_pass(now, 30);
+        pass.satellite = "FAKESAT-7".to_string();
+        let subtitle = format_pass_subtitle(&pass);
+        assert!(subtitle.contains("max el 56"), "subtitle: {subtitle}");
+        assert!(!subtitle.contains("MHz"), "subtitle: {subtitle}");
+    }
+
+    #[test]
+    fn pass_quality_label_pins_boundary_values() {
+        // Boundary table: the threshold value itself takes the
+        // higher tier (`>=`), one tick below drops to the next.
+        assert_eq!(pass_quality_label(60.0), "winner");
+        assert_eq!(pass_quality_label(40.0), "winner");
+        assert_eq!(pass_quality_label(39.9), "good");
+        assert_eq!(pass_quality_label(25.0), "good");
+        assert_eq!(pass_quality_label(24.9), "marginal");
+        assert_eq!(pass_quality_label(15.0), "marginal");
+        assert_eq!(pass_quality_label(14.9), "barely");
+        assert_eq!(pass_quality_label(5.0), "barely");
+    }
+
+    #[test]
+    fn format_downlink_mhz_renders_three_decimals_minimum() {
+        // 137.100 MHz reads as "137.100", not "137.1" — the panel
+        // wants every entry to line up visually.
+        assert_eq!(format_downlink_mhz(137_100_000), "137.100 MHz");
+        assert_eq!(format_downlink_mhz(145_800_000), "145.800 MHz");
+    }
+
+    #[test]
+    fn format_downlink_mhz_preserves_extra_precision_when_needed() {
+        // NOAA 18 is on 137.9125 MHz exactly — the formatter must
+        // not round to 3 decimals and lose the off-channel offset.
+        assert_eq!(format_downlink_mhz(137_912_500), "137.9125 MHz");
+    }
+
+    #[test]
+    fn downlink_hz_for_pass_finds_catalog_entry() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_pass(now, 30); // satellite = "NOAA 19"
+        assert_eq!(downlink_hz_for_pass(&pass), Some(137_100_000));
+    }
+
+    #[test]
+    fn downlink_hz_for_pass_returns_none_for_unknown_satellite() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let mut pass = synthetic_pass(now, 30);
+        pass.satellite = "MYSTERY-SAT".to_string();
+        assert_eq!(downlink_hz_for_pass(&pass), None);
     }
 
     #[test]

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2710,7 +2710,45 @@ fn connect_sidebar_panels(
     connect_volume_persistence(panels, state, config, volume_button);
     connect_distance_estimator_persistence(panels, config);
     connect_scanner_panel(panels, state, config);
-    connect_satellites_panel(panels, config);
+    // "Tune to satellite" closure used by the Satellites panel's
+    // per-row play buttons. Mirrors the bookmark-recall dance in
+    // `connect_navigation_panel`: forces the scanner off, updates
+    // local `AppState`, sends `Tune` + `SetBandwidth` to the DSP,
+    // and pokes every UI widget that mirrors the radio's tuning
+    // state (spectrum centre line, demod dropdown, bandwidth
+    // SpinRow). The dropdown's `selected-notify` and the spin
+    // row's `value-notify` callbacks then fire `SetDemodMode` /
+    // `SetBandwidth` themselves — that's why we only `send_dsp`
+    // the freq + initial bandwidth here.
+    let tune_to_satellite: Rc<dyn Fn(u64, sdr_types::DemodMode, u32)> = {
+        let state_t = Rc::clone(state);
+        let freq_selector_t = freq_selector.clone();
+        let demod_dropdown_t = demod_dropdown.clone();
+        let spectrum_t = Rc::clone(spectrum_handle);
+        let force_disable_t = Rc::clone(scanner_force_disable);
+        let bandwidth_row_t = panels.radio.bandwidth_row.clone();
+        Rc::new(move |freq_hz, mode, bw_hz| {
+            force_disable_t.trigger("satellite tune");
+            #[allow(
+                clippy::cast_precision_loss,
+                reason = "downlink frequencies sit in the 100s of MHz, far \
+                          below f64's 2^53 mantissa ceiling"
+            )]
+            let freq_f64 = freq_hz as f64;
+            let bw_f64 = f64::from(bw_hz);
+            state_t.center_frequency.set(freq_f64);
+            state_t.demod_mode.set(mode);
+            state_t.send_dsp(UiToDsp::Tune(freq_f64));
+            state_t.send_dsp(UiToDsp::SetBandwidth(bw_f64));
+            freq_selector_t.set_frequency(freq_hz);
+            spectrum_t.set_center_frequency(freq_f64);
+            if let Some(idx) = demod_selector::demod_mode_to_index(mode) {
+                demod_dropdown_t.set_selected(idx);
+            }
+            bandwidth_row_t.set_value(bw_f64);
+        })
+    };
+    connect_satellites_panel(panels, config, &tune_to_satellite);
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
         panels,
@@ -8346,13 +8384,15 @@ fn connect_scanner_panel(
 fn connect_satellites_panel(
     panels: &SidebarPanels,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
+    tune_to_satellite: &Rc<dyn Fn(u64, sdr_types::DemodMode, u32)>,
 ) {
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
     use sidebar::satellites_panel::{
         KEY_STATION_ALT_M, KEY_STATION_LAT_DEG, KEY_STATION_LON_DEG, SatellitesPanelWeak,
-        enumerate_upcoming_passes, format_last_refresh, format_pass_subtitle, format_pass_title,
-        load_auto_record_apt, load_station_alt_m, load_station_lat_deg, load_station_lon_deg,
-        save_auto_record_apt, save_f64, save_tle_last_refresh,
+        enumerate_upcoming_passes, format_downlink_mhz, format_last_refresh, format_pass_subtitle,
+        format_pass_title, load_auto_record_apt, load_station_alt_m, load_station_lat_deg,
+        load_station_lon_deg, save_auto_record_apt, save_f64, save_tle_last_refresh,
+        tune_target_for_pass,
     };
 
     // One pass row + its source `Pass` so the 1 Hz ticker can
@@ -8412,6 +8452,7 @@ fn connect_satellites_panel(
         let cache_recompute = std::sync::Arc::clone(cache);
         let panel_weak_recompute = panel_weak.clone();
         let displayed_recompute = Rc::clone(&displayed);
+        let tune_for_recompute = Rc::clone(tune_to_satellite);
         Rc::new(move || {
             let Some(panel) = panel_weak_recompute.upgrade() else {
                 return;
@@ -8449,6 +8490,35 @@ fn connect_satellites_panel(
                     .title(format_pass_title(&pass, now))
                     .subtitle(format_pass_subtitle(&pass))
                     .build();
+                // Per-row play button — one-click tune to the
+                // satellite's downlink with the right demod / BW.
+                // Skipped when the satellite isn't in the catalog
+                // (impossible in practice but the lookup type is
+                // `Option`, so we fail closed — no button rather
+                // than a button that does nothing).
+                if let Some((freq_hz, mode, bw_hz)) = tune_target_for_pass(&pass) {
+                    let play_btn = gtk4::Button::builder()
+                        .icon_name("media-playback-start-symbolic")
+                        .tooltip_text(format!(
+                            "Tune to {} ({})",
+                            pass.satellite,
+                            format_downlink_mhz(freq_hz),
+                        ))
+                        .valign(gtk4::Align::Center)
+                        .css_classes(["flat"])
+                        .build();
+                    // Tooltips aren't read by screen readers — set
+                    // the accessible label too, matching the
+                    // project rule for icon-only buttons.
+                    let a11y_label = format!("Tune to {} downlink", pass.satellite);
+                    play_btn
+                        .update_property(&[gtk4::accessible::Property::Label(a11y_label.as_str())]);
+                    let tune_for_click = Rc::clone(&tune_for_recompute);
+                    play_btn.connect_clicked(move |_| {
+                        tune_for_click(freq_hz, mode, bw_hz);
+                    });
+                    row.add_suffix(&play_btn);
+                }
                 panel.passes_group.add(&row);
                 new_rows.push(DisplayedPass { row, pass });
             }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2712,14 +2712,17 @@ fn connect_sidebar_panels(
     connect_scanner_panel(panels, state, config);
     // "Tune to satellite" closure used by the Satellites panel's
     // per-row play buttons. Mirrors the bookmark-recall dance in
-    // `connect_navigation_panel`: forces the scanner off, updates
-    // local `AppState`, sends `Tune` + `SetBandwidth` to the DSP,
-    // and pokes every UI widget that mirrors the radio's tuning
-    // state (spectrum centre line, demod dropdown, bandwidth
-    // SpinRow). The dropdown's `selected-notify` and the spin
-    // row's `value-notify` callbacks then fire `SetDemodMode` /
-    // `SetBandwidth` themselves — that's why we only `send_dsp`
-    // the freq + initial bandwidth here.
+    // `connect_navigation_panel` end-to-end: forces the scanner
+    // off, updates local `AppState`, sends `Tune` + `SetBandwidth`
+    // to the DSP, and pokes every UI widget / status indicator
+    // that mirrors the radio's tuning state — spectrum centre
+    // line, demod dropdown, bandwidth SpinRow, status bar
+    // frequency / demod-mode label, and the radio panel's mode-
+    // specific control visibility. The dropdown's
+    // `selected-notify` and the spin row's `value-notify`
+    // callbacks fire `SetDemodMode` / a redundant `SetBandwidth`
+    // themselves — idempotent at the DSP, cheaper than threading
+    // a suppress flag through here.
     let tune_to_satellite: Rc<dyn Fn(u64, sdr_types::DemodMode, u32)> = {
         let state_t = Rc::clone(state);
         let freq_selector_t = freq_selector.clone();
@@ -2727,6 +2730,8 @@ fn connect_sidebar_panels(
         let spectrum_t = Rc::clone(spectrum_handle);
         let force_disable_t = Rc::clone(scanner_force_disable);
         let bandwidth_row_t = panels.radio.bandwidth_row.clone();
+        let radio_panel_t = panels.radio.clone();
+        let status_bar_t = Rc::clone(status_bar);
         Rc::new(move |freq_hz, mode, bw_hz| {
             force_disable_t.trigger("satellite tune");
             #[allow(
@@ -2746,6 +2751,16 @@ fn connect_sidebar_panels(
                 demod_dropdown_t.set_selected(idx);
             }
             bandwidth_row_t.set_value(bw_f64);
+            // Mode-specific control visibility (e.g. squelch /
+            // deemph rows shown only in NFM/WFM) — must be poked
+            // explicitly because the demod-dropdown notify only
+            // covers the dropdown's own state.
+            radio_panel_t.apply_demod_visibility(mode);
+            // Status bar mirrors. Done last so a panic anywhere
+            // upstream doesn't leave the indicator showing an
+            // optimistic value that the DSP never received.
+            status_bar_t.update_frequency(freq_f64);
+            status_bar_t.update_demod(header::demod_mode_label(mode), bw_f64);
         })
     };
     connect_satellites_panel(panels, config, &tune_to_satellite);


### PR DESCRIPTION
## Summary

Three rolled together because they all touch `KnownSatellite` and the Satellites panel rendering:

- **#506** — drops the dead-on-arrival METEOR-M2 4 (NORAD 61024) entry from `KNOWN_SATELLITES`. No more 404 warn-spam every refresh.
- **#507** — `KnownSatellite` gains `downlink_hz` + `demod_mode` + `bandwidth_hz` fields. Pass row subtitles now lead with a quality tag (`winner` / `good` / `marginal` / `barely`) and the downlink frequency:

  > `winner  ·  137.100 MHz  ·  max el 56°  ·  AOS 245° → LOS 105°`

- **Per-row play button** (carved from #482b's scope since it slotted in cleanly here). Click → one-shot tune to the satellite's downlink: `Tune` + `SetBandwidth` to DSP, plus widget syncs (frequency selector, spectrum centre, demod dropdown, bandwidth SpinRow), plus the same scanner-force-disable hook bookmark recall uses.

## Why bundle the play button

Once `KnownSatellite` carried `downlink_hz` + `demod_mode` + `bandwidth_hz`, wiring the play button was ~40 lines of widget code in `recompute()` plus an `Rc<dyn Fn(u64, DemodMode, u32)>` closure in `connect_sidebar_panels` that bundles the tune dance. Holding it for #482b would have meant churning the satellites panel one more time when the same data is already at hand.

The closure is shared infrastructure: the eventual auto-record-on-pass path (#482b) just calls the same `tune_to_satellite` Rc on AOS. No further refactor needed.

## Test plan

- [x] `cargo build --workspace --features whisper-cpu` clean
- [x] `cargo test --workspace --features whisper-cpu` — 67 sdr-sat tests, 24 satellites_panel tests, no failures
- [x] `cargo clippy --workspace --features whisper-cpu --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` clean (transcription not touched but per the dual-build rule)
- [x] Manual smoke: pass list shows quality tags + frequencies; ▶ button on each row tunes correctly; bookmarks + scanner + spectrum unaffected
- [ ] CodeRabbit review

## New tests pinning behaviour

- `sdr-sat`: METEOR-M2 4 absence; every catalog entry's downlink lands in the 137-148 MHz VHF imaging band.
- `sdr-ui::sidebar::satellites_panel`: subtitle includes quality + freq; subtitle falls back gracefully when satellite isn't in catalog; quality-label boundary table (60° / 40° / 39.9° / 25° / 24.9° / 15° / 14.9° / 5°); downlink formatter for both 3-decimal (137.100) and 4-decimal (137.9125) cases; tune-target lookup.

## Related

- Part of epic #468 (NOAA APT)
- Closes #506
- Closes #507
- Reduces #482b scope — the auto-record state machine now has a ready-made `tune_to_satellite` primitive to call at AOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-click satellite tuning buttons that auto-configure receiver frequency, demodulation mode, and bandwidth.
  * Enhanced pass list showing a one-word pass quality label and downlink frequency when available.

* **Data Updates**
  * Catalog populated with tuning parameters for NOAA APT, Meteor LRPT, and ISS SSTV.
  * METEOR‑M2 4 removed from the catalog.

* **Tests**
  * New checks ensure the removed entry remains absent and all catalog downlinks lie within the imaging band.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->