### PR TITLE
sdr-ui: auto-record on NOAA APT pass (closes #482)

### DIFF
--- a/crates/sdr-ui/src/apt_viewer.rs
+++ b/crates/sdr-ui/src/apt_viewer.rs
@@ -503,32 +503,46 @@ pub fn connect_apt_action(
     let parent_provider = Rc::clone(parent_provider);
     let state_for_action = Rc::clone(state);
     action.connect_activate(move |_, _| {
-        if state_for_action.apt_viewer.borrow().is_some() {
-            // Already open — nothing to do. The user can find the
-            // existing window via the OS window switcher.
-            return;
-        }
-        let Some(parent) = parent_provider() else {
-            tracing::warn!("apt-open invoked with no main window available");
-            return;
-        };
-        let (view, window) = open_apt_viewer_window(&parent, "NOAA APT");
-        // Stash a clone in AppState so the DSP→UI handler can find
-        // it. The clone is cheap (every field is `Rc`-shared).
-        *state_for_action.apt_viewer.borrow_mut() = Some(view);
-
-        // Clear the AppState slot when the user closes the window
-        // — otherwise `DspToUi::AptLine` would keep pushing into a
-        // detached widget tree until the next reopen, and the
-        // viewer state would never reset for a second pass.
-        let state_for_close = Rc::clone(&state_for_action);
-        window.connect_close_request(move |_| {
-            *state_for_close.apt_viewer.borrow_mut() = None;
-            glib::Propagation::Proceed
-        });
+        open_apt_viewer_if_needed(&parent_provider, &state_for_action);
     });
     app.add_action(&action);
     app.set_accels_for_action("app.apt-open", &["<Ctrl><Shift>a"]);
+}
+
+/// Open the APT viewer window if it isn't already open, registering
+/// the new view in `state.apt_viewer` and wiring `close-request` to
+/// clear that slot. No-op if a viewer is already open.
+///
+/// Pulled out of `connect_apt_action` so the auto-record-on-pass
+/// path (#482b) can fire the same open flow at AOS without going
+/// through the GIO action system.
+pub fn open_apt_viewer_if_needed(
+    parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,
+    state: &Rc<crate::state::AppState>,
+) {
+    if state.apt_viewer.borrow().is_some() {
+        // Already open — nothing to do. The user can find the
+        // existing window via the OS window switcher.
+        return;
+    }
+    let Some(parent) = parent_provider() else {
+        tracing::warn!("apt-open invoked with no main window available");
+        return;
+    };
+    let (view, window) = open_apt_viewer_window(&parent, "NOAA APT");
+    // Stash a clone in AppState so the DSP→UI handler can find
+    // it. The clone is cheap (every field is `Rc`-shared).
+    *state.apt_viewer.borrow_mut() = Some(view);
+
+    // Clear the AppState slot when the user closes the window
+    // — otherwise `DspToUi::AptLine` would keep pushing into a
+    // detached widget tree until the next reopen, and the viewer
+    // state would never reset for a second pass.
+    let state_for_close = Rc::clone(state);
+    window.connect_close_request(move |_| {
+        *state_for_close.apt_viewer.borrow_mut() = None;
+        glib::Propagation::Proceed
+    });
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -12,6 +12,7 @@ pub mod general_panel;
 pub mod navigation_panel;
 pub mod radio_panel;
 pub mod satellites_panel;
+pub mod satellites_recorder;
 pub mod scanner_panel;
 pub mod server_panel;
 pub mod source_panel;

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -230,6 +230,19 @@ impl AutoRecorder {
             if pass.max_elevation_deg < AUTO_RECORD_MIN_ELEV_DEG {
                 continue;
             }
+            // Skip already-finished passes. A stale displayed-pass
+            // snapshot (or a panel that hasn't recomputed since
+            // the user resumed from suspend) can leave entries in
+            // the list whose `end` is already in the past. Without
+            // this guard the loop below would emit
+            // `StartAutoRecord` for a finished pass — the UI
+            // would briefly retune + open the viewer, then save
+            // an empty PNG on the next tick. Pass list is sorted
+            // by start, so we just `continue` rather than `break`
+            // — there could be a future pass behind a stale one.
+            if pass.end <= now {
+                continue;
+            }
             let secs_to_aos = (pass.start - now).num_seconds();
             if !(0..=AOS_LEAD_SECS).contains(&secs_to_aos) && pass.start > now {
                 // Not yet within the lead-in window. The pass list
@@ -458,6 +471,37 @@ mod tests {
         let actions = r.tick(now, &[pass], true, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn idle_skips_passes_already_past_los() {
+        // Suspend / resume: the laptop sleeps mid-session and wakes
+        // up after a pass has already ended. The displayed-pass
+        // list may still carry the finished entry until the next
+        // recompute fires. The recorder must NOT arm for a
+        // finished pass — otherwise we'd briefly retune + open
+        // the viewer and save an empty PNG on the next tick.
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Pass ended 30 seconds ago.
+        let mut pass = synthetic_noaa19(now, -660, 600, 50.0); // started -660 s ago, ended -60 s ago
+        // Sanity: this pass is in the past from `now`'s perspective.
+        assert!(pass.end < now);
+        let actions = r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        assert!(matches!(r.state(), State::Idle));
+        assert!(actions.is_empty());
+        // Mutating the pass to make peak elevation match the
+        // threshold + extending end past now would arm — pinning
+        // that the only thing keeping us idle was the LOS check.
+        pass.end = now + ChronoDuration::seconds(720);
+        pass.start = now + ChronoDuration::seconds(3);
+        let actions = r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        assert!(matches!(r.state(), State::BeforePass { .. }));
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, Action::StartAutoRecord { .. }))
+        );
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -272,8 +272,19 @@ impl AutoRecorder {
                 mode,
                 bandwidth_hz,
             });
+            // "Starting" reads wrong if we missed the lead window
+            // (laptop wake, recompute lag, etc.) and the pass is
+            // already underway — in that case the user sees the
+            // toast announcing "starting" while the pass clock is
+            // already counting down. `in progress` is the honest
+            // phrasing for that case.
+            let phase = if pass.start <= now {
+                "in progress"
+            } else {
+                "starting"
+            };
             actions.push(Action::Toast {
-                message: format!("{} pass starting — auto-recording", pass.satellite),
+                message: format!("{} pass {phase} — auto-recording", pass.satellite),
                 kind: ToastKind::Info,
             });
             self.state = State::BeforePass {
@@ -445,7 +456,44 @@ mod tests {
         let actions = r.tick(now, &[pass], true, default_tune());
         assert!(matches!(r.state(), State::BeforePass { .. }));
         assert!(matches!(actions[0], Action::StartAutoRecord { .. }));
-        assert!(matches!(actions[1], Action::Toast { .. }));
+        // Pre-AOS arming reports "starting" — the pass hasn't
+        // crossed `pass.start` yet.
+        match &actions[1] {
+            Action::Toast { message, .. } => {
+                assert!(
+                    message.contains("starting"),
+                    "expected starting copy, got: {message}",
+                );
+            }
+            other => panic!("expected Toast, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn idle_arms_for_already_started_pass_uses_in_progress_copy() {
+        // Missed the lead window — the laptop woke from suspend
+        // mid-pass, or the 1 Hz tick stalled long enough that the
+        // displayed-pass entry crosses `pass.start` before
+        // `tick_idle` saw it. Recorder still arms (pass.end is
+        // future, eligibility holds) but the toast must read "in
+        // progress" — saying "starting" when the pass clock is
+        // already running would lie to the user.
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Pass started 30 s ago, ends in 9.5 min — eligible by
+        // every other gate (NOAA, 50° peak, end > now).
+        let pass = synthetic_noaa19(now, -30, 600, 50.0);
+        let actions = r.tick(now, &[pass], true, default_tune());
+        assert!(matches!(r.state(), State::BeforePass { .. }));
+        match &actions[1] {
+            Action::Toast { message, .. } => {
+                assert!(
+                    message.contains("in progress"),
+                    "expected in-progress copy, got: {message}",
+                );
+            }
+            other => panic!("expected Toast, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -102,6 +102,14 @@ pub enum State {
 /// for every cross-boundary handoff. The bandwidth row uses
 /// `f64` internally but we round at the snapshot boundary so
 /// the restore path doesn't have to.
+///
+/// `scanner_running` snapshots the scanner's master-switch
+/// state. The wiring layer's `tune_to_satellite` helper
+/// force-disables the scanner as a manual-tune side effect
+/// (same path bookmark recall takes) — so without restoring
+/// here, an active pre-AOS scan session would be left off
+/// after the pass ends. Mirrors `was_running`'s "return the
+/// user to whatever they had configured" intent.
 #[derive(Debug, Clone, Copy)]
 pub struct SavedTune {
     pub freq_hz: f64,
@@ -109,6 +117,7 @@ pub struct SavedTune {
     pub mode: DemodMode,
     pub bandwidth_hz: u32,
     pub was_running: bool,
+    pub scanner_running: bool,
 }
 
 /// Side effects the wiring layer must perform on each transition.
@@ -423,6 +432,7 @@ mod tests {
             mode: DemodMode::Wfm,
             bandwidth_hz: 200_000,
             was_running: true,
+            scanner_running: false,
         }
     }
 
@@ -573,6 +583,7 @@ mod tests {
             mode: DemodMode::Wfm,
             bandwidth_hz: 200_000,
             was_running: false,
+            scanner_running: true, // pin: pre-AOS scan must come back at LOS
         };
         // Walk all transitions.
         r.tick(now, std::slice::from_ref(&pass), true, saved);
@@ -590,9 +601,12 @@ mod tests {
         assert!(matches!(r.state(), State::Idle));
         // Restore action carries the original saved tune,
         // including the VFO offset (so a user's drag position
-        // survives the auto-record round trip) and the
-        // pre-AOS playback state (so a stopped radio doesn't
-        // silently keep running after LOS).
+        // survives the auto-record round trip), the pre-AOS
+        // playback state (so a stopped radio doesn't silently
+        // keep running after LOS), and the pre-AOS scanner
+        // state (since `tune_a` force-disables the scanner at
+        // AOS, so a previously-running scan would otherwise be
+        // dropped permanently).
         match &actions[0] {
             Action::RestoreTune(t) => {
                 assert_eq!(t.freq_hz, 89_700_000.0);
@@ -600,6 +614,7 @@ mod tests {
                 assert_eq!(t.mode, DemodMode::Wfm);
                 assert_eq!(t.bandwidth_hz, 200_000);
                 assert!(!t.was_running);
+                assert!(t.scanner_running);
             }
             other => panic!("expected RestoreTune, got {other:?}"),
         }

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -84,9 +84,16 @@ pub enum State {
 /// Snapshot of the radio's tune state at the moment the recorder
 /// took over. Stored on the in-flight state so a `Finalizing`
 /// transition can restore it without the caller having to re-snap.
+///
+/// Carries `vfo_offset_hz` separately from `freq_hz` so a user-
+/// dragged VFO position survives the auto-record round trip:
+/// snapshot captures both, restore replays both. Without this,
+/// LOS would re-tune to bare centre frequency and the user would
+/// lose whatever signal they had pinned with a VFO drag pre-AOS.
 #[derive(Debug, Clone, Copy)]
 pub struct SavedTune {
     pub freq_hz: f64,
+    pub vfo_offset_hz: f64,
     pub mode: DemodMode,
     pub bandwidth_hz: f64,
 }
@@ -251,16 +258,20 @@ impl AutoRecorder {
         tuned_at: DateTime<Utc>,
         saved_tune: SavedTune,
     ) -> Vec<Action> {
-        // Defensive: if the pass somehow ended while we were
-        // settling (e.g. a low-elevation pass shorter than the
-        // settle window), skip straight to finalizing.
+        // LOS already arrived (e.g. the 1 Hz driver stalled on a
+        // sleep / suspend cycle, or a very short pass elapsed
+        // entirely inside the settle window). Skip straight to
+        // finalizing AND emit the SavePng — otherwise we'd jump
+        // to Idle on the next tick without ever exporting the
+        // image.
         if pass.end <= now {
+            let png_path = png_path_for(&pass, now);
             self.state = State::Finalizing {
                 pass: pass.clone(),
                 saved_tune,
-                png_path: png_path_for(&pass, now),
+                png_path: png_path.clone(),
             };
-            return Vec::new();
+            return vec![Action::SavePng(png_path)];
         }
         if (now - tuned_at).num_seconds() >= SETTLE_SECS {
             self.state = State::Recording { pass, saved_tune };
@@ -275,24 +286,19 @@ impl AutoRecorder {
         saved_tune: SavedTune,
     ) -> Vec<Action> {
         if pass.end <= now {
+            // Emit `SavePng` only — the success / failure toast
+            // is the wiring layer's responsibility (it knows the
+            // export's actual outcome). Announcing "image saved"
+            // here would lie if the user closed the viewer
+            // mid-pass or `export_png` errored on disk-full /
+            // permissions.
             let png_path = png_path_for(&pass, now);
-            let actions = vec![
-                Action::SavePng(png_path.clone()),
-                Action::Toast {
-                    message: format!(
-                        "{} pass complete — image saved to {}",
-                        pass.satellite,
-                        png_path.display()
-                    ),
-                    kind: ToastKind::Info,
-                },
-            ];
             self.state = State::Finalizing {
                 pass,
                 saved_tune,
-                png_path,
+                png_path: png_path.clone(),
             };
-            return actions;
+            return vec![Action::SavePng(png_path)];
         }
         Vec::new()
     }
@@ -387,6 +393,7 @@ mod tests {
     fn default_tune() -> SavedTune {
         SavedTune {
             freq_hz: 100_000_000.0,
+            vfo_offset_hz: 0.0,
             mode: DemodMode::Wfm,
             bandwidth_hz: 200_000.0,
         }
@@ -486,8 +493,15 @@ mod tests {
         let los_plus_one = pass.end + ChronoDuration::seconds(1);
         let actions = r.tick(los_plus_one, &[pass], true, default_tune());
         assert!(matches!(r.state(), State::Finalizing { .. }));
+        // Only `SavePng` — the success / failure toast is the
+        // wiring layer's responsibility now (it knows the export
+        // outcome). Asserting absence of any Toast keeps the
+        // recorder honest about what it claims.
         assert!(matches!(actions[0], Action::SavePng(_)));
-        assert!(matches!(actions[1], Action::Toast { .. }));
+        assert!(
+            !actions.iter().any(|a| matches!(a, Action::Toast { .. })),
+            "recorder must not announce save success before export — actions: {actions:?}"
+        );
     }
 
     #[test]
@@ -497,6 +511,7 @@ mod tests {
         let pass = synthetic_noaa19(now, 3, 60, 50.0);
         let saved = SavedTune {
             freq_hz: 89_700_000.0,
+            vfo_offset_hz: 25_000.0, // pin a non-zero offset for the round trip
             mode: DemodMode::Wfm,
             bandwidth_hz: 200_000.0,
         };
@@ -514,15 +529,41 @@ mod tests {
         assert!(matches!(r.state(), State::Finalizing { .. }));
         let actions = r.tick(los_plus, &[pass], true, default_tune());
         assert!(matches!(r.state(), State::Idle));
-        // Restore action carries the original saved tune.
+        // Restore action carries the original saved tune,
+        // including the VFO offset (so a user's drag position
+        // survives the auto-record round trip).
         match &actions[0] {
             Action::RestoreTune(t) => {
                 assert_eq!(t.freq_hz, 89_700_000.0);
+                assert_eq!(t.vfo_offset_hz, 25_000.0);
                 assert_eq!(t.mode, DemodMode::Wfm);
                 assert_eq!(t.bandwidth_hz, 200_000.0);
             }
             other => panic!("expected RestoreTune, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn los_during_before_pass_still_emits_save_png() {
+        // Regression: a 1 Hz driver stall (sleep / suspend) can
+        // jump the recorder from BeforePass to Finalizing without
+        // ever entering Recording. The PNG must still be saved —
+        // otherwise the pass completes silently and the user
+        // loses whatever decoder lines did arrive during the
+        // stall window.
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 60, 50.0); // 1 min pass, 3 s lead-in
+        r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        assert!(matches!(r.state(), State::BeforePass { .. }));
+        // Jump to a moment past LOS (simulate stalled driver).
+        let post_los = pass.end + ChronoDuration::seconds(5);
+        let actions = r.tick(post_los, std::slice::from_ref(&pass), true, default_tune());
+        assert!(matches!(r.state(), State::Finalizing { .. }));
+        assert!(
+            actions.iter().any(|a| matches!(a, Action::SavePng(_))),
+            "BeforePass→Finalizing must emit SavePng even when stalled past LOS"
+        );
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -1,0 +1,570 @@
+//! Auto-record-on-pass state machine (epic #468 / ticket #482b).
+//!
+//! Drives the unattended-receive flow for NOAA APT passes:
+//!
+//! ```text
+//! Idle ──(pass arming + auto-record on + quality OK)──▶ BeforePass
+//!                                                          │
+//!         (settle window elapsed)                          ▼
+//!                                                       Recording
+//!                                                          │
+//!         (pass.end ≤ now)                                 ▼
+//!                                                       Finalizing ──▶ Idle
+//! ```
+//!
+//! State transitions are **pure** — `tick` produces a `Vec<Action>`
+//! the caller (`window.rs::connect_satellites_panel`) interprets. No
+//! widget mutation, no DSP commands, no I/O happen inside this
+//! module. That keeps the transition logic unit-testable without a
+//! GTK harness, and lets the caller batch / order side-effects
+//! however it wants.
+//!
+//! The wiring layer drives `tick` from the existing 1 Hz countdown
+//! timer (the same one that updates pass-row titles) so we don't add
+//! a second `GLib` source.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use sdr_sat::Pass;
+use sdr_types::DemodMode;
+
+use crate::sidebar::satellites_panel::tune_target_for_pass;
+
+/// Minimum peak elevation (degrees) for an auto-record-eligible
+/// pass. Below this, APT decode is mostly horizon-grazing noise and
+/// the saved PNG is mostly disk waste. Hardcoded to the
+/// "winners + good" tier (≥ 25°) for V1; will become a user-
+/// selectable combo in #511.
+pub const AUTO_RECORD_MIN_ELEV_DEG: f64 = 25.0;
+
+/// Lead-in before AOS at which the recorder enters `BeforePass` and
+/// fires the auto-tune. Gives the channel filter, demod, and
+/// decoder a few seconds to settle before the satellite crosses
+/// the elevation floor.
+const AOS_LEAD_SECS: i64 = 5;
+
+/// Settle time after the auto-tune before the recorder advances to
+/// `Recording`. Decoder is producing lines during this window, but
+/// they're pre-AOS noise so we don't count them toward the
+/// "actually receiving" status.
+const SETTLE_SECS: i64 = 3;
+
+/// Recorder lifecycle. Each variant carries the data the next
+/// transition needs so the caller doesn't have to thread state
+/// through the call site.
+#[derive(Debug, Clone)]
+pub enum State {
+    /// No active recording. Awaiting the next eligible pass.
+    Idle,
+    /// Auto-tune dispatched; waiting for the channel filter / demod
+    /// / decoder to settle before declaring `Recording`. `tuned_at`
+    /// is the wall-clock time we issued the tune so the settle
+    /// timer can compare against `now`.
+    BeforePass {
+        pass: Pass,
+        tuned_at: DateTime<Utc>,
+        /// Snapshot of the user's tune state captured before we
+        /// took over. Restored at LOS so the user comes back to
+        /// whatever they were listening to.
+        saved_tune: SavedTune,
+    },
+    /// Pass is in progress; APT decoder is producing the live
+    /// image. No per-tick work needed — we just wait for LOS.
+    Recording { pass: Pass, saved_tune: SavedTune },
+    /// Pass ended; PNG export and tune restore are pending. This
+    /// state is single-tick: the next `tick` advances to `Idle`.
+    Finalizing {
+        pass: Pass,
+        saved_tune: SavedTune,
+        png_path: PathBuf,
+    },
+}
+
+/// Snapshot of the radio's tune state at the moment the recorder
+/// took over. Stored on the in-flight state so a `Finalizing`
+/// transition can restore it without the caller having to re-snap.
+#[derive(Debug, Clone, Copy)]
+pub struct SavedTune {
+    pub freq_hz: f64,
+    pub mode: DemodMode,
+    pub bandwidth_hz: f64,
+}
+
+/// Side effects the wiring layer must perform on each transition.
+/// Returned from `tick` so the state machine itself stays pure.
+#[derive(Debug, Clone)]
+pub enum Action {
+    /// Tune the radio to the satellite's downlink and open the APT
+    /// viewer window. Fired on `Idle → BeforePass`.
+    StartAutoRecord {
+        satellite: String,
+        freq_hz: u64,
+        mode: DemodMode,
+        bandwidth_hz: u32,
+    },
+    /// Save the in-flight APT image to `png_path`. Fired on
+    /// `Recording → Finalizing`. Caller is expected to call
+    /// `AptImageView::export_png` against the open viewer.
+    SavePng(PathBuf),
+    /// Restore the radio to the pre-recording tune. Fired on
+    /// `Finalizing → Idle`. Caller dispatches the same triple
+    /// through the same primitive the play button uses.
+    RestoreTune(SavedTune),
+    /// Surface a status message to the user. The wiring layer
+    /// chooses how (toast, status row, log). Two flavours:
+    /// `info` and `warn`.
+    Toast { message: String, kind: ToastKind },
+}
+
+/// Toast severity, matching the existing `AdwToastOverlay` use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToastKind {
+    Info,
+    Warn,
+}
+
+/// The recorder.
+pub struct AutoRecorder {
+    state: State,
+}
+
+impl Default for AutoRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AutoRecorder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { state: State::Idle }
+    }
+
+    /// Snapshot of the current state — exposed so the wiring layer
+    /// can reflect "currently recording {sat}" in the UI.
+    #[must_use]
+    pub fn state(&self) -> &State {
+        &self.state
+    }
+
+    /// Drive the state machine forward. Returns a list of actions
+    /// the caller must execute (tune, save, toast, restore).
+    ///
+    /// `passes` should be the panel's current upcoming-pass list,
+    /// already sorted by `start`. `auto_record_on` reflects the
+    /// panel's switch state (false → recorder is dormant; an
+    /// in-flight pass keeps running to LOS regardless, but no new
+    /// passes will arm).
+    ///
+    /// `now_tune` is the radio's current `(freq_hz, mode,
+    /// bandwidth_hz)`. Captured at AOS as the `saved_tune` for the
+    /// in-flight pass so a later LOS can restore.
+    pub fn tick(
+        &mut self,
+        now: DateTime<Utc>,
+        passes: &[Pass],
+        auto_record_on: bool,
+        now_tune: SavedTune,
+    ) -> Vec<Action> {
+        match self.state.clone() {
+            State::Idle => self.tick_idle(now, passes, auto_record_on, now_tune),
+            State::BeforePass {
+                pass,
+                tuned_at,
+                saved_tune,
+            } => self.tick_before_pass(now, pass, tuned_at, saved_tune),
+            State::Recording { pass, saved_tune } => self.tick_recording(now, pass, saved_tune),
+            State::Finalizing {
+                pass,
+                saved_tune,
+                png_path,
+            } => self.tick_finalizing(pass, saved_tune, png_path),
+        }
+    }
+
+    fn tick_idle(
+        &mut self,
+        now: DateTime<Utc>,
+        passes: &[Pass],
+        auto_record_on: bool,
+        now_tune: SavedTune,
+    ) -> Vec<Action> {
+        if !auto_record_on {
+            return Vec::new();
+        }
+        // Find the soonest eligible upcoming pass. Eligibility:
+        // 1. Satellite is in our catalog (lookup yields tune target).
+        //    LRPT-only satellites are out — the APT decoder won't
+        //    decode their signal even if we tune to it.
+        // 2. Peak elevation meets the quality threshold.
+        // 3. AOS is within `AOS_LEAD_SECS` (start tuning a few
+        //    seconds early so the pipeline is ready at AOS proper).
+        for pass in passes {
+            let Some((freq_hz, mode, bandwidth_hz)) = tune_target_for_pass(pass) else {
+                continue;
+            };
+            if !is_apt_capable(&pass.satellite) {
+                continue;
+            }
+            if pass.max_elevation_deg < AUTO_RECORD_MIN_ELEV_DEG {
+                continue;
+            }
+            let secs_to_aos = (pass.start - now).num_seconds();
+            if !(0..=AOS_LEAD_SECS).contains(&secs_to_aos) && pass.start > now {
+                // Not yet within the lead-in window. The pass list
+                // is sorted by start; once we hit one beyond the
+                // window the rest are too. Break out.
+                if secs_to_aos > AOS_LEAD_SECS {
+                    break;
+                }
+                continue;
+            }
+            // Fall through: pass is in the lead-in window OR has
+            // already started (we missed the lead — start tuning
+            // immediately).
+            let mut actions = Vec::with_capacity(2);
+            actions.push(Action::StartAutoRecord {
+                satellite: pass.satellite.clone(),
+                freq_hz,
+                mode,
+                bandwidth_hz,
+            });
+            actions.push(Action::Toast {
+                message: format!("{} pass starting — auto-recording", pass.satellite),
+                kind: ToastKind::Info,
+            });
+            self.state = State::BeforePass {
+                pass: pass.clone(),
+                tuned_at: now,
+                saved_tune: now_tune,
+            };
+            return actions;
+        }
+        Vec::new()
+    }
+
+    fn tick_before_pass(
+        &mut self,
+        now: DateTime<Utc>,
+        pass: Pass,
+        tuned_at: DateTime<Utc>,
+        saved_tune: SavedTune,
+    ) -> Vec<Action> {
+        // Defensive: if the pass somehow ended while we were
+        // settling (e.g. a low-elevation pass shorter than the
+        // settle window), skip straight to finalizing.
+        if pass.end <= now {
+            self.state = State::Finalizing {
+                pass: pass.clone(),
+                saved_tune,
+                png_path: png_path_for(&pass, now),
+            };
+            return Vec::new();
+        }
+        if (now - tuned_at).num_seconds() >= SETTLE_SECS {
+            self.state = State::Recording { pass, saved_tune };
+        }
+        Vec::new()
+    }
+
+    fn tick_recording(
+        &mut self,
+        now: DateTime<Utc>,
+        pass: Pass,
+        saved_tune: SavedTune,
+    ) -> Vec<Action> {
+        if pass.end <= now {
+            let png_path = png_path_for(&pass, now);
+            let actions = vec![
+                Action::SavePng(png_path.clone()),
+                Action::Toast {
+                    message: format!(
+                        "{} pass complete — image saved to {}",
+                        pass.satellite,
+                        png_path.display()
+                    ),
+                    kind: ToastKind::Info,
+                },
+            ];
+            self.state = State::Finalizing {
+                pass,
+                saved_tune,
+                png_path,
+            };
+            return actions;
+        }
+        Vec::new()
+    }
+
+    fn tick_finalizing(
+        &mut self,
+        _pass: Pass,
+        saved_tune: SavedTune,
+        _png_path: PathBuf,
+    ) -> Vec<Action> {
+        // Single-tick state: SavePng was issued on entry; restore
+        // tune and return to Idle.
+        self.state = State::Idle;
+        vec![Action::RestoreTune(saved_tune)]
+    }
+}
+
+/// Is this satellite something we can actually decode in the APT
+/// viewer? NOAA POES (15 / 18 / 19) carry the analog APT subcarrier
+/// our decoder is built for. METEOR-M / ISS use different
+/// modulations (LRPT / SSTV) and would tune correctly but produce
+/// no decoded image — pointless to auto-record them today. When
+/// LRPT / SSTV decoders ship (epics #469 / #472) this gate will
+/// loosen accordingly.
+#[must_use]
+fn is_apt_capable(satellite_name: &str) -> bool {
+    matches!(satellite_name, "NOAA 15" | "NOAA 18" | "NOAA 19")
+}
+
+/// Build the export path for a satellite + timestamp:
+/// `~/sdr-recordings/apt-NOAA-19-2026-04-25-143015.png`.
+/// Centralised here so the `SavePng` action and the toast message
+/// can't drift on naming.
+#[must_use]
+fn png_path_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
+    let stamp = now
+        .with_timezone(&chrono::Local)
+        .format("%Y-%m-%d-%H%M%S")
+        .to_string();
+    // Sanitize the satellite name for filesystem safety: spaces /
+    // parens / etc become hyphens. We control the name source
+    // (KNOWN_SATELLITES) so a heavy-handed sanitizer is fine.
+    let sat_slug: String = pass
+        .satellite
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    // Collapse runs of `-` so "NOAA 19" → "NOAA-19", not
+    // "NOAA--19", and trim leading/trailing.
+    let sat_slug = sat_slug
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    glib::home_dir()
+        .join("sdr-recordings")
+        .join(format!("apt-{sat_slug}-{stamp}.png"))
+}
+
+// `glib` is referenced via the GTK4 stack but only available on
+// Linux per the workspace gating; the panel itself is Linux-only.
+use gtk4::glib;
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::float_cmp)]
+mod tests {
+    use super::*;
+    use chrono::{Duration as ChronoDuration, TimeZone};
+
+    /// Build a synthetic NOAA 19 pass starting `aos_offset_secs`
+    /// from `now`, lasting `duration_secs`, with the given peak
+    /// elevation. Mirrors the synthetic-pass fixture pattern used
+    /// by the `satellites_panel` tests.
+    fn synthetic_noaa19(
+        now: DateTime<Utc>,
+        aos_offset_secs: i64,
+        duration_secs: i64,
+        peak_elev_deg: f64,
+    ) -> Pass {
+        let start = now + ChronoDuration::seconds(aos_offset_secs);
+        Pass {
+            satellite: "NOAA 19".to_string(),
+            start,
+            end: start + ChronoDuration::seconds(duration_secs),
+            max_elevation_deg: peak_elev_deg,
+            max_el_time: start + ChronoDuration::seconds(duration_secs / 2),
+            start_az_deg: 245.0,
+            end_az_deg: 105.0,
+        }
+    }
+
+    fn default_tune() -> SavedTune {
+        SavedTune {
+            freq_hz: 100_000_000.0,
+            mode: DemodMode::Wfm,
+            bandwidth_hz: 200_000.0,
+        }
+    }
+
+    #[test]
+    fn idle_arms_when_pass_in_lead_window_and_eligible() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Pass starts in 3 s — inside the 5 s lead-in.
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+        let actions = r.tick(now, &[pass], true, default_tune());
+        assert!(matches!(r.state(), State::BeforePass { .. }));
+        assert!(matches!(actions[0], Action::StartAutoRecord { .. }));
+        assert!(matches!(actions[1], Action::Toast { .. }));
+    }
+
+    #[test]
+    fn idle_does_not_arm_when_toggle_off() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+        let actions = r.tick(now, &[pass], false, default_tune());
+        assert!(matches!(r.state(), State::Idle));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn idle_does_not_arm_below_quality_threshold() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // 20° peak — "marginal" tier, below the 25° "good" floor.
+        let pass = synthetic_noaa19(now, 3, 720, 20.0);
+        let actions = r.tick(now, &[pass], true, default_tune());
+        assert!(matches!(r.state(), State::Idle));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn idle_does_not_arm_for_non_apt_satellite() {
+        // METEOR-M is in the catalog but uses LRPT, not APT —
+        // tuning would succeed but the APT decoder would never
+        // produce a meaningful image.
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let mut pass = synthetic_noaa19(now, 3, 720, 50.0);
+        pass.satellite = "METEOR-M 2".to_string();
+        let actions = r.tick(now, &[pass], true, default_tune());
+        assert!(matches!(r.state(), State::Idle));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn idle_skips_passes_outside_lead_window() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Pass starts in 10 min. Way outside the 5 s lead-in.
+        let pass = synthetic_noaa19(now, 600, 720, 50.0);
+        let actions = r.tick(now, &[pass], true, default_tune());
+        assert!(matches!(r.state(), State::Idle));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn before_pass_advances_to_recording_after_settle() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+        // Initial arm.
+        r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        assert!(matches!(r.state(), State::BeforePass { .. }));
+        // Pre-settle tick: still in BeforePass.
+        let later = now + ChronoDuration::seconds(2);
+        r.tick(later, std::slice::from_ref(&pass), true, default_tune());
+        assert!(matches!(r.state(), State::BeforePass { .. }));
+        // Past settle window: advance to Recording.
+        let later = now + ChronoDuration::seconds(SETTLE_SECS);
+        r.tick(later, &[pass], true, default_tune());
+        assert!(matches!(r.state(), State::Recording { .. }));
+    }
+
+    #[test]
+    fn recording_advances_to_finalizing_at_los() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 600, 50.0); // 10 min pass
+        r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            default_tune(),
+        );
+        assert!(matches!(r.state(), State::Recording { .. }));
+        // Tick past LOS.
+        let los_plus_one = pass.end + ChronoDuration::seconds(1);
+        let actions = r.tick(los_plus_one, &[pass], true, default_tune());
+        assert!(matches!(r.state(), State::Finalizing { .. }));
+        assert!(matches!(actions[0], Action::SavePng(_)));
+        assert!(matches!(actions[1], Action::Toast { .. }));
+    }
+
+    #[test]
+    fn finalizing_advances_to_idle_with_restore_action() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 60, 50.0);
+        let saved = SavedTune {
+            freq_hz: 89_700_000.0,
+            mode: DemodMode::Wfm,
+            bandwidth_hz: 200_000.0,
+        };
+        // Walk all transitions.
+        r.tick(now, std::slice::from_ref(&pass), true, saved);
+        let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            default_tune(),
+        );
+        let los_plus = pass.end + ChronoDuration::seconds(1);
+        r.tick(los_plus, std::slice::from_ref(&pass), true, default_tune());
+        assert!(matches!(r.state(), State::Finalizing { .. }));
+        let actions = r.tick(los_plus, &[pass], true, default_tune());
+        assert!(matches!(r.state(), State::Idle));
+        // Restore action carries the original saved tune.
+        match &actions[0] {
+            Action::RestoreTune(t) => {
+                assert_eq!(t.freq_hz, 89_700_000.0);
+                assert_eq!(t.mode, DemodMode::Wfm);
+                assert_eq!(t.bandwidth_hz, 200_000.0);
+            }
+            other => panic!("expected RestoreTune, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn overlapping_pass_does_not_re_arm_while_recording() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass_a = synthetic_noaa19(now, 3, 720, 50.0);
+        // Arm + settle into Recording.
+        r.tick(now, std::slice::from_ref(&pass_a), true, default_tune());
+        let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle,
+            std::slice::from_ref(&pass_a),
+            true,
+            default_tune(),
+        );
+        assert!(matches!(r.state(), State::Recording { .. }));
+        // A second NOAA pass appears in the list (mid-recording).
+        // The recorder should ignore it — Recording stays put.
+        let mut pass_b = synthetic_noaa19(now, 30, 720, 60.0);
+        pass_b.satellite = "NOAA 18".to_string();
+        let actions = r.tick(after_settle, &[pass_a, pass_b], true, default_tune());
+        assert!(matches!(r.state(), State::Recording { .. }));
+        // No StartAutoRecord action emitted.
+        assert!(
+            !actions
+                .iter()
+                .any(|a| matches!(a, Action::StartAutoRecord { .. }))
+        );
+    }
+
+    #[test]
+    fn png_path_includes_satellite_slug_and_timestamp() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 30, 15).unwrap();
+        let pass = synthetic_noaa19(now, 0, 720, 50.0);
+        let path = png_path_for(&pass, now);
+        let s = path.to_string_lossy().to_string();
+        assert!(s.contains("apt-NOAA-19-"));
+        assert!(
+            std::path::Path::new(&s)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("png"))
+        );
+    }
+}

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -90,12 +90,25 @@ pub enum State {
 /// snapshot captures both, restore replays both. Without this,
 /// LOS would re-tune to bare centre frequency and the user would
 /// lose whatever signal they had pinned with a VFO drag pre-AOS.
+///
+/// `was_running` snapshots the source's playback state so the
+/// LOS restore can return to it. If the user had playback off
+/// when auto-record armed (a common "set it and forget it"
+/// scenario), we want to leave them off post-LOS — not silently
+/// keep the radio chewing CPU after the pass ended.
+///
+/// `bandwidth_hz` is `u32` to match `Action::StartAutoRecord`
+/// and `KnownSatellite::bandwidth_hz` — single integral type
+/// for every cross-boundary handoff. The bandwidth row uses
+/// `f64` internally but we round at the snapshot boundary so
+/// the restore path doesn't have to.
 #[derive(Debug, Clone, Copy)]
 pub struct SavedTune {
     pub freq_hz: f64,
     pub vfo_offset_hz: f64,
     pub mode: DemodMode,
-    pub bandwidth_hz: f64,
+    pub bandwidth_hz: u32,
+    pub was_running: bool,
 }
 
 /// Side effects the wiring layer must perform on each transition.
@@ -395,7 +408,8 @@ mod tests {
             freq_hz: 100_000_000.0,
             vfo_offset_hz: 0.0,
             mode: DemodMode::Wfm,
-            bandwidth_hz: 200_000.0,
+            bandwidth_hz: 200_000,
+            was_running: true,
         }
     }
 
@@ -513,7 +527,8 @@ mod tests {
             freq_hz: 89_700_000.0,
             vfo_offset_hz: 25_000.0, // pin a non-zero offset for the round trip
             mode: DemodMode::Wfm,
-            bandwidth_hz: 200_000.0,
+            bandwidth_hz: 200_000,
+            was_running: false,
         };
         // Walk all transitions.
         r.tick(now, std::slice::from_ref(&pass), true, saved);
@@ -531,13 +546,16 @@ mod tests {
         assert!(matches!(r.state(), State::Idle));
         // Restore action carries the original saved tune,
         // including the VFO offset (so a user's drag position
-        // survives the auto-record round trip).
+        // survives the auto-record round trip) and the
+        // pre-AOS playback state (so a stopped radio doesn't
+        // silently keep running after LOS).
         match &actions[0] {
             Action::RestoreTune(t) => {
                 assert_eq!(t.freq_hz, 89_700_000.0);
                 assert_eq!(t.vfo_offset_hz, 25_000.0);
                 assert_eq!(t.mode, DemodMode::Wfm);
-                assert_eq!(t.bandwidth_hz, 200_000.0);
+                assert_eq!(t.bandwidth_hz, 200_000);
+                assert!(!t.was_running);
             }
             other => panic!("expected RestoreTune, got {other:?}"),
         }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8905,6 +8905,19 @@ fn connect_satellites_panel(
                 tracing::info!(
                     "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz",
                 );
+                // If the radio isn't running yet, kick it on so
+                // the AptDecoder actually receives audio. Without
+                // this, auto-record arms at AOS but no `AptLine`s
+                // ever flow — the pass completes with an empty
+                // image. The pre-AOS `was_running == false` is
+                // captured in `SavedTune` so the LOS restore can
+                // stop the radio again, returning to whatever
+                // state the user left it in.
+                if !state_a.is_running.get() {
+                    tracing::info!("auto-record: starting source (was stopped pre-AOS)");
+                    state_a.send_dsp(UiToDsp::Start);
+                    state_a.is_running.set(true);
+                }
                 tune_a(freq_hz, mode, bandwidth_hz);
                 crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
             }
@@ -8943,17 +8956,11 @@ fn connect_satellites_panel(
                 #[allow(
                     clippy::cast_sign_loss,
                     clippy::cast_possible_truncation,
-                    reason = "saved values came from the same widgets we're feeding back; \
-                              both are non-negative and well within u64/u32"
+                    reason = "saved freq came from the same widget we're feeding back; \
+                              non-negative and well within u64"
                 )]
                 let freq_hz = saved.freq_hz as u64;
-                #[allow(
-                    clippy::cast_sign_loss,
-                    clippy::cast_possible_truncation,
-                    reason = "user-set bandwidth is rounded to the nearest Hz on the way back"
-                )]
-                let bandwidth_hz = saved.bandwidth_hz.round() as u32;
-                tune_a(freq_hz, saved.mode, bandwidth_hz);
+                tune_a(freq_hz, saved.mode, saved.bandwidth_hz);
                 // Replay the user's pre-AOS VFO offset so a
                 // dragged-from-centre carrier comes back. The
                 // existing `DspToUi::VfoOffsetChanged` handler
@@ -8961,6 +8968,18 @@ fn connect_satellites_panel(
                 // bar when the DSP echoes the change, so we
                 // don't have to mirror those widgets manually.
                 state_a.send_dsp(UiToDsp::SetVfoOffset(saved.vfo_offset_hz));
+                // If the user had playback off pre-AOS, we
+                // started the radio at AOS to make audio flow —
+                // honour that round trip and stop it now. A user
+                // who explicitly turned playback off during the
+                // pass (rare) loses that intent here, but the
+                // expected case (set-and-forget overnight) gets
+                // the right behaviour.
+                if !saved.was_running {
+                    tracing::info!("auto-record: stopping source (was stopped pre-AOS)");
+                    state_a.send_dsp(UiToDsp::Stop);
+                    state_a.is_running.set(false);
+                }
             }
             RecorderAction::Toast { message, kind } => {
                 if matches!(kind, ToastKind::Warn) {
@@ -9009,11 +9028,23 @@ fn connect_satellites_panel(
                 .map(|e| e.pass.clone())
                 .collect();
             let auto_record_on = panel.auto_record_switch.is_active();
+            // Round f64 SpinRow value to u32 at the snapshot
+            // boundary so SavedTune carries a clean integer for
+            // the eventual restore — no per-restore rounding.
+            #[allow(
+                clippy::cast_sign_loss,
+                clippy::cast_possible_truncation,
+                reason = "user-set bandwidth is non-negative and \
+                          fits in u32 for any realistic SDR channel \
+                          width; the SpinRow's own min is positive"
+            )]
+            let bandwidth_hz_u32 = bandwidth_row_tick.value().round() as u32;
             let now_tune = SavedTune {
                 freq_hz: state_tick.center_frequency.get(),
                 vfo_offset_hz: spectrum_tick.vfo_offset_hz(),
                 mode: state_tick.demod_mode.get(),
-                bandwidth_hz: bandwidth_row_tick.value(),
+                bandwidth_hz: bandwidth_hz_u32,
+                was_running: state_tick.is_running.get(),
             };
             let actions =
                 recorder_tick

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -452,6 +452,25 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         toast_overlay: toast_overlay.downgrade(),
     });
 
+    // Header play/stop button as a set-and-forget hook for any
+    // wiring that needs to start or stop the radio without bypassing
+    // the visible toggle (currently auto-record-on-pass; same idiom
+    // would suit any future "schedule the radio on" feature). Going
+    // through `set_active` reuses the existing
+    // `play_button.connect_toggled` handler — the single place that
+    // updates `state.is_running`, sends `UiToDsp::Start` / `Stop`,
+    // and swaps the icon — so the DSP, `AppState`, and header
+    // button stay aligned. `set_active` is idempotent: GTK only
+    // emits `toggled` on a real state change, so a redundant
+    // `set_playing(true)` while the radio is already running is a
+    // no-op (no duplicate Start dispatch).
+    let set_playing: Rc<dyn Fn(bool)> = {
+        let play_btn = play_button.clone();
+        Rc::new(move |should_play| {
+            play_btn.set_active(should_play);
+        })
+    };
+
     connect_sidebar_panels(
         &panels,
         &state,
@@ -464,6 +483,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         &favorites_handle,
         &scanner_force_disable,
         &volume_button,
+        &set_playing,
     );
 
     // Seed the scanner with the persisted bookmark list on
@@ -2657,6 +2677,7 @@ fn connect_sidebar_panels(
     favorites_header: &FavoritesHeaderHandle,
     scanner_force_disable: &Rc<ScannerForceDisable>,
     volume_button: &gtk4::ScaleButton,
+    set_playing: &Rc<dyn Fn(bool)>,
 ) {
     // Shared "is the rtl_tcp server currently live?" flag. Written by
     // the server panel's start/stop handler, read by the source
@@ -2770,6 +2791,7 @@ fn connect_sidebar_panels(
         toast_overlay,
         spectrum_handle,
         &tune_to_satellite,
+        set_playing,
     );
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
@@ -8410,6 +8432,7 @@ fn connect_satellites_panel(
     toast_overlay: &adw::ToastOverlay,
     spectrum_handle: &Rc<spectrum::SpectrumHandle>,
     tune_to_satellite: &Rc<dyn Fn(u64, sdr_types::DemodMode, u32)>,
+    set_playing: &Rc<dyn Fn(bool)>,
 ) {
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
     use sidebar::satellites_panel::{
@@ -8885,6 +8908,7 @@ fn connect_satellites_panel(
     let interpret_action: Rc<dyn Fn(RecorderAction)> = {
         let state_a = Rc::clone(state);
         let tune_a = Rc::clone(tune_to_satellite);
+        let set_playing_a = Rc::clone(set_playing);
         // Weak ref for the same lifecycle reason as
         // `parent_provider_for_recorder` — strong clone would pin
         // the toast overlay alive past window close.
@@ -8905,21 +8929,29 @@ fn connect_satellites_panel(
                 tracing::info!(
                     "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz",
                 );
-                // If the radio isn't running yet, kick it on so
-                // the AptDecoder actually receives audio. Without
-                // this, auto-record arms at AOS but no `AptLine`s
-                // ever flow — the pass completes with an empty
-                // image. The pre-AOS `was_running == false` is
-                // captured in `SavedTune` so the LOS restore can
-                // stop the radio again, returning to whatever
-                // state the user left it in.
-                if !state_a.is_running.get() {
-                    tracing::info!("auto-record: starting source (was stopped pre-AOS)");
-                    state_a.send_dsp(UiToDsp::Start);
-                    state_a.is_running.set(true);
-                }
+                // Drive Start through the header play button —
+                // its `connect_toggled` handler is the single place
+                // that updates `state.is_running`, dispatches
+                // `UiToDsp::Start`, and swaps the play/stop icon.
+                // `set_active` is a no-op when the radio is
+                // already running, so this is safe to call
+                // unconditionally without a duplicate Start.
+                // The pre-AOS `was_running` flag (captured in
+                // `SavedTune` by the 1 Hz tick before this action
+                // fires) drives the corresponding LOS-side stop.
+                set_playing_a(true);
                 tune_a(freq_hz, mode, bandwidth_hz);
                 crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
+                // Clear the canvas at AOS so a back-to-back pass
+                // (e.g. NOAA 18 → NOAA 19 with overlapping
+                // viewer sessions) starts on a clean image. The
+                // viewer was either just opened above (already
+                // empty) or carried over from a previous pass —
+                // either way, an explicit clear keeps the image
+                // we're about to save scoped to *this* pass.
+                if let Some(view) = state_a.apt_viewer.borrow().as_ref() {
+                    view.clear();
+                }
             }
             RecorderAction::SavePng(path) => {
                 // Toast based on the *actual* export outcome
@@ -8974,11 +9006,12 @@ fn connect_satellites_panel(
                 // who explicitly turned playback off during the
                 // pass (rare) loses that intent here, but the
                 // expected case (set-and-forget overnight) gets
-                // the right behaviour.
+                // the right behaviour. Routed through
+                // `set_playing` (header play button) so the icon,
+                // `state.is_running`, and DSP all move together.
                 if !saved.was_running {
                     tracing::info!("auto-record: stopping source (was stopped pre-AOS)");
-                    state_a.send_dsp(UiToDsp::Stop);
-                    state_a.is_running.set(false);
+                    set_playing_a(false);
                 }
             }
             RecorderAction::Toast { message, kind } => {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2763,7 +2763,14 @@ fn connect_sidebar_panels(
             status_bar_t.update_demod(header::demod_mode_label(mode), bw_f64);
         })
     };
-    connect_satellites_panel(panels, config, state, toast_overlay, &tune_to_satellite);
+    connect_satellites_panel(
+        panels,
+        config,
+        state,
+        toast_overlay,
+        spectrum_handle,
+        &tune_to_satellite,
+    );
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
         panels,
@@ -8401,6 +8408,7 @@ fn connect_satellites_panel(
     config: &std::sync::Arc<sdr_config::ConfigManager>,
     state: &Rc<AppState>,
     toast_overlay: &adw::ToastOverlay,
+    spectrum_handle: &Rc<spectrum::SpectrumHandle>,
     tune_to_satellite: &Rc<dyn Fn(u64, sdr_types::DemodMode, u32)>,
 ) {
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
@@ -8860,13 +8868,16 @@ fn connect_satellites_panel(
     // Parent-window resolver for the auto-open-viewer side effect.
     // Walks up the widget tree from the satellites page; falls
     // back to `None` if the widget has been detached, in which
-    // case the open is silently skipped — matches the
-    // already-open no-op semantics.
+    // case the open is silently skipped. Holds a `WeakRef` so the
+    // 1 Hz timer's `panel_weak.upgrade() == None` exit gate can
+    // actually fire — a strong clone here would keep the panel
+    // widget alive and the timer would never break.
     let parent_provider_for_recorder: Rc<dyn Fn() -> Option<gtk4::Window>> = {
-        let widget = panel.widget.clone();
+        let widget_weak = panel.widget.downgrade();
         Rc::new(move || {
-            widget
-                .root()
+            widget_weak
+                .upgrade()
+                .and_then(|w| w.root())
                 .and_then(|r| r.downcast::<gtk4::Window>().ok())
         })
     };
@@ -8874,8 +8885,16 @@ fn connect_satellites_panel(
     let interpret_action: Rc<dyn Fn(RecorderAction)> = {
         let state_a = Rc::clone(state);
         let tune_a = Rc::clone(tune_to_satellite);
-        let toast_overlay_a = toast_overlay.clone();
+        // Weak ref for the same lifecycle reason as
+        // `parent_provider_for_recorder` — strong clone would pin
+        // the toast overlay alive past window close.
+        let toast_overlay_weak = toast_overlay.downgrade();
         let parent_provider_a = Rc::clone(&parent_provider_for_recorder);
+        let post_toast = move |overlay_weak: &glib::WeakRef<adw::ToastOverlay>, msg: &str| {
+            if let Some(overlay) = overlay_weak.upgrade() {
+                overlay.add_toast(adw::Toast::new(msg));
+            }
+        };
         Rc::new(move |action: RecorderAction| match action {
             RecorderAction::StartAutoRecord {
                 satellite,
@@ -8890,22 +8909,35 @@ fn connect_satellites_panel(
                 crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
             }
             RecorderAction::SavePng(path) => {
-                if let Some(view) = state_a.apt_viewer.borrow().as_ref() {
-                    if let Err(e) = view.export_png(&path) {
-                        tracing::warn!("auto-record PNG export to {path:?} failed: {e}");
-                    } else {
-                        tracing::info!("auto-record PNG saved to {path:?}");
+                // Toast based on the *actual* export outcome
+                // rather than announcing success up front — the
+                // recorder doesn't know whether the user closed
+                // the viewer mid-pass or whether disk write will
+                // succeed.
+                let result_msg = if let Some(view) = state_a.apt_viewer.borrow().as_ref() {
+                    match view.export_png(&path) {
+                        Ok(()) => {
+                            tracing::info!("auto-record PNG saved to {path:?}");
+                            format!("Pass complete — image saved to {}", path.display())
+                        }
+                        Err(e) => {
+                            tracing::warn!("auto-record PNG export to {path:?} failed: {e}");
+                            format!("Pass complete but PNG save failed: {e}")
+                        }
                     }
                 } else {
                     tracing::warn!(
                         "auto-record SavePng but no APT viewer is open (user closed mid-pass)",
                     );
-                }
+                    "Pass complete, but the APT viewer was closed — no image saved".to_string()
+                };
+                post_toast(&toast_overlay_weak, &result_msg);
             }
             RecorderAction::RestoreTune(saved) => {
                 tracing::info!(
-                    "auto-record LOS: restoring tune to {} Hz, BW {} Hz",
+                    "auto-record LOS: restoring tune to {} Hz (offset {} Hz), BW {} Hz",
                     saved.freq_hz,
+                    saved.vfo_offset_hz,
                     saved.bandwidth_hz,
                 );
                 #[allow(
@@ -8922,16 +8954,22 @@ fn connect_satellites_panel(
                 )]
                 let bandwidth_hz = saved.bandwidth_hz.round() as u32;
                 tune_a(freq_hz, saved.mode, bandwidth_hz);
+                // Replay the user's pre-AOS VFO offset so a
+                // dragged-from-centre carrier comes back. The
+                // existing `DspToUi::VfoOffsetChanged` handler
+                // updates the spectrum + freq selector + status
+                // bar when the DSP echoes the change, so we
+                // don't have to mirror those widgets manually.
+                state_a.send_dsp(UiToDsp::SetVfoOffset(saved.vfo_offset_hz));
             }
             RecorderAction::Toast { message, kind } => {
-                let toast = adw::Toast::new(&message);
                 if matches!(kind, ToastKind::Warn) {
                     // No dedicated warn styling on AdwToast; the
                     // message itself carries the severity. Tracing
                     // captures it for the log either way.
                     tracing::warn!("auto-record: {message}");
                 }
-                toast_overlay_a.add_toast(toast);
+                post_toast(&toast_overlay_weak, &message);
             }
         })
     };
@@ -8944,6 +8982,7 @@ fn connect_satellites_panel(
         let interpret_tick = Rc::clone(&interpret_action);
         let state_tick = Rc::clone(state);
         let bandwidth_row_tick = panels.radio.bandwidth_row.clone();
+        let spectrum_tick = Rc::clone(spectrum_handle);
         let _ = glib::timeout_add_local(SATELLITES_COUNTDOWN_TICK, move || {
             let Some(panel) = panel_weak_tick.upgrade() else {
                 return glib::ControlFlow::Break;
@@ -8960,7 +8999,10 @@ fn connect_satellites_panel(
             // Drive the auto-record state machine. Snapshot the
             // pass list (cloned out of the displayed vec to keep
             // the borrow short) and the current tune so the
-            // recorder gets a consistent view.
+            // recorder gets a consistent view. Capture the VFO
+            // offset alongside centre frequency — a user-dragged
+            // carrier position needs to survive the AOS→LOS round
+            // trip.
             let passes_snapshot: Vec<Pass> = displayed_tick
                 .borrow()
                 .iter()
@@ -8969,6 +9011,7 @@ fn connect_satellites_panel(
             let auto_record_on = panel.auto_record_switch.is_active();
             let now_tune = SavedTune {
                 freq_hz: state_tick.center_frequency.get(),
+                vfo_offset_hz: spectrum_tick.vfo_offset_hz(),
                 mode: state_tick.demod_mode.get(),
                 bandwidth_hz: bandwidth_row_tick.value(),
             };

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2763,7 +2763,7 @@ fn connect_sidebar_panels(
             status_bar_t.update_demod(header::demod_mode_label(mode), bw_f64);
         })
     };
-    connect_satellites_panel(panels, config, &tune_to_satellite);
+    connect_satellites_panel(panels, config, state, toast_overlay, &tune_to_satellite);
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
         panels,
@@ -8399,6 +8399,8 @@ fn connect_scanner_panel(
 fn connect_satellites_panel(
     panels: &SidebarPanels,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
+    state: &Rc<AppState>,
+    toast_overlay: &adw::ToastOverlay,
     tune_to_satellite: &Rc<dyn Fn(u64, sdr_types::DemodMode, u32)>,
 ) {
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
@@ -8408,6 +8410,9 @@ fn connect_satellites_panel(
         format_pass_title, load_auto_record_apt, load_station_alt_m, load_station_lat_deg,
         load_station_lon_deg, save_auto_record_apt, save_f64, save_tle_last_refresh,
         tune_target_for_pass,
+    };
+    use sidebar::satellites_recorder::{
+        Action as RecorderAction, AutoRecorder, SavedTune, ToastKind,
     };
 
     // One pass row + its source `Pass` so the 1 Hz ticker can
@@ -8845,14 +8850,104 @@ fn connect_satellites_panel(
     // widget has been dropped (otherwise GLib runs it forever,
     // holding a strong chain into the `displayed` vec and its
     // widgets).
+    // Auto-record-on-pass state machine (#482b). Driven from the
+    // same 1 Hz tick that updates pass-row countdowns — no second
+    // GLib source. The recorder itself is pure (returns
+    // `Vec<RecorderAction>`); the closure below interprets each
+    // action against the live UI / DSP / filesystem.
+    let recorder: Rc<RefCell<AutoRecorder>> = Rc::new(RefCell::new(AutoRecorder::new()));
+
+    // Parent-window resolver for the auto-open-viewer side effect.
+    // Walks up the widget tree from the satellites page; falls
+    // back to `None` if the widget has been detached, in which
+    // case the open is silently skipped — matches the
+    // already-open no-op semantics.
+    let parent_provider_for_recorder: Rc<dyn Fn() -> Option<gtk4::Window>> = {
+        let widget = panel.widget.clone();
+        Rc::new(move || {
+            widget
+                .root()
+                .and_then(|r| r.downcast::<gtk4::Window>().ok())
+        })
+    };
+
+    let interpret_action: Rc<dyn Fn(RecorderAction)> = {
+        let state_a = Rc::clone(state);
+        let tune_a = Rc::clone(tune_to_satellite);
+        let toast_overlay_a = toast_overlay.clone();
+        let parent_provider_a = Rc::clone(&parent_provider_for_recorder);
+        Rc::new(move |action: RecorderAction| match action {
+            RecorderAction::StartAutoRecord {
+                satellite,
+                freq_hz,
+                mode,
+                bandwidth_hz,
+            } => {
+                tracing::info!(
+                    "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz",
+                );
+                tune_a(freq_hz, mode, bandwidth_hz);
+                crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
+            }
+            RecorderAction::SavePng(path) => {
+                if let Some(view) = state_a.apt_viewer.borrow().as_ref() {
+                    if let Err(e) = view.export_png(&path) {
+                        tracing::warn!("auto-record PNG export to {path:?} failed: {e}");
+                    } else {
+                        tracing::info!("auto-record PNG saved to {path:?}");
+                    }
+                } else {
+                    tracing::warn!(
+                        "auto-record SavePng but no APT viewer is open (user closed mid-pass)",
+                    );
+                }
+            }
+            RecorderAction::RestoreTune(saved) => {
+                tracing::info!(
+                    "auto-record LOS: restoring tune to {} Hz, BW {} Hz",
+                    saved.freq_hz,
+                    saved.bandwidth_hz,
+                );
+                #[allow(
+                    clippy::cast_sign_loss,
+                    clippy::cast_possible_truncation,
+                    reason = "saved values came from the same widgets we're feeding back; \
+                              both are non-negative and well within u64/u32"
+                )]
+                let freq_hz = saved.freq_hz as u64;
+                #[allow(
+                    clippy::cast_sign_loss,
+                    clippy::cast_possible_truncation,
+                    reason = "user-set bandwidth is rounded to the nearest Hz on the way back"
+                )]
+                let bandwidth_hz = saved.bandwidth_hz.round() as u32;
+                tune_a(freq_hz, saved.mode, bandwidth_hz);
+            }
+            RecorderAction::Toast { message, kind } => {
+                let toast = adw::Toast::new(&message);
+                if matches!(kind, ToastKind::Warn) {
+                    // No dedicated warn styling on AdwToast; the
+                    // message itself carries the severity. Tracing
+                    // captures it for the log either way.
+                    tracing::warn!("auto-record: {message}");
+                }
+                toast_overlay_a.add_toast(toast);
+            }
+        })
+    };
+
     if cache.is_some() {
         let panel_weak_tick = panel_weak.clone();
         let displayed_tick = Rc::clone(&displayed);
         let recompute_tick = Rc::clone(&recompute);
+        let recorder_tick = Rc::clone(&recorder);
+        let interpret_tick = Rc::clone(&interpret_action);
+        let state_tick = Rc::clone(state);
+        let bandwidth_row_tick = panels.radio.bandwidth_row.clone();
         let _ = glib::timeout_add_local(SATELLITES_COUNTDOWN_TICK, move || {
-            if panel_weak_tick.upgrade().is_none() {
+            let Some(panel) = panel_weak_tick.upgrade() else {
                 return glib::ControlFlow::Break;
-            }
+            };
             let now = chrono::Utc::now();
             let mut needs_recompute = false;
             for entry in displayed_tick.borrow().iter() {
@@ -8861,6 +8956,28 @@ fn connect_satellites_panel(
                     continue;
                 }
                 entry.row.set_title(&format_pass_title(&entry.pass, now));
+            }
+            // Drive the auto-record state machine. Snapshot the
+            // pass list (cloned out of the displayed vec to keep
+            // the borrow short) and the current tune so the
+            // recorder gets a consistent view.
+            let passes_snapshot: Vec<Pass> = displayed_tick
+                .borrow()
+                .iter()
+                .map(|e| e.pass.clone())
+                .collect();
+            let auto_record_on = panel.auto_record_switch.is_active();
+            let now_tune = SavedTune {
+                freq_hz: state_tick.center_frequency.get(),
+                mode: state_tick.demod_mode.get(),
+                bandwidth_hz: bandwidth_row_tick.value(),
+            };
+            let actions =
+                recorder_tick
+                    .borrow_mut()
+                    .tick(now, &passes_snapshot, auto_record_on, now_tune);
+            for action in actions {
+                interpret_tick(action);
             }
             if needs_recompute {
                 recompute_tick();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8914,6 +8914,12 @@ fn connect_satellites_panel(
         // the toast overlay alive past window close.
         let toast_overlay_weak = toast_overlay.downgrade();
         let parent_provider_a = Rc::clone(&parent_provider_for_recorder);
+        // Scanner master switch handle for the LOS-side restore.
+        // Set-active here fires the switch's `connect_active_notify`
+        // handler, which re-dispatches `SetScannerEnabled(true)` and
+        // re-arms the engine — same path the user takes when they
+        // flip the switch by hand.
+        let scanner_switch_a = panels.scanner.master_switch.clone();
         let post_toast = move |overlay_weak: &glib::WeakRef<adw::ToastOverlay>, msg: &str| {
             if let Some(overlay) = overlay_weak.upgrade() {
                 overlay.add_toast(adw::Toast::new(msg));
@@ -8941,6 +8947,19 @@ fn connect_satellites_panel(
                 // fires) drives the corresponding LOS-side stop.
                 set_playing_a(true);
                 tune_a(freq_hz, mode, bandwidth_hz);
+                // Zero the live VFO offset for the auto-record
+                // pass. The user's pre-AOS offset (a manual
+                // VFO drag away from centre) is preserved in
+                // `SavedTune` for the LOS restore, but during
+                // the pass the demod must align *exactly* with
+                // the satellite's downlink — otherwise we'd
+                // demod at `freq_hz + saved_offset` and the
+                // APT subcarrier would land outside the
+                // channel filter. The DSP's
+                // `DspToUi::VfoOffsetChanged` echo updates the
+                // spectrum widget, freq selector, and status
+                // bar; no manual mirror needed.
+                state_a.send_dsp(UiToDsp::SetVfoOffset(0.0));
                 crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
                 // Clear the canvas at AOS so a back-to-back pass
                 // (e.g. NOAA 18 → NOAA 19 with overlapping
@@ -9013,6 +9032,22 @@ fn connect_satellites_panel(
                     tracing::info!("auto-record: stopping source (was stopped pre-AOS)");
                     set_playing_a(false);
                 }
+                // Re-arm the scanner if it was running pre-AOS.
+                // The AOS-side `tune_a` call goes through
+                // `tune_to_satellite`, which fires
+                // `ScannerForceDisable::trigger("satellite tune")`
+                // as a manual-tune side effect — without this
+                // restore, an active pre-AOS scan would be left
+                // permanently off after the pass. Same idiom as
+                // `was_running`: snapshot the user's pre-AOS
+                // state, return them to it. `set_active(true)`
+                // fires the switch's notify handler, which
+                // dispatches `SetScannerEnabled(true)` to the
+                // engine — same path a manual flip takes.
+                if saved.scanner_running && !scanner_switch_a.is_active() {
+                    tracing::info!("auto-record: re-arming scanner (was running pre-AOS)");
+                    scanner_switch_a.set_active(true);
+                }
             }
             RecorderAction::Toast { message, kind } => {
                 if matches!(kind, ToastKind::Warn) {
@@ -9035,6 +9070,14 @@ fn connect_satellites_panel(
         let state_tick = Rc::clone(state);
         let bandwidth_row_tick = panels.radio.bandwidth_row.clone();
         let spectrum_tick = Rc::clone(spectrum_handle);
+        // Scanner master switch — read for the per-tick snapshot so
+        // SavedTune carries scanner state across AOS → LOS, written
+        // by `interpret_action::RestoreTune` to re-arm the scanner
+        // if it was running pre-AOS. Strong clone because the tick
+        // already captures other panel widgets (bandwidth_row);
+        // when the panel is dropped the tick's `panel_weak.upgrade`
+        // returns None and we Break, dropping the chain.
+        let scanner_switch_tick = panels.scanner.master_switch.clone();
         let _ = glib::timeout_add_local(SATELLITES_COUNTDOWN_TICK, move || {
             let Some(panel) = panel_weak_tick.upgrade() else {
                 return glib::ControlFlow::Break;
@@ -9078,6 +9121,7 @@ fn connect_satellites_panel(
                 mode: state_tick.demod_mode.get(),
                 bandwidth_hz: bandwidth_hz_u32,
                 was_running: state_tick.is_running.get(),
+                scanner_running: scanner_switch_tick.is_active(),
             };
             let actions =
                 recorder_tick


### PR DESCRIPTION
## Summary

Closes the second half of **#482** — the unattended-receive path. When the Satellites panel's auto-record toggle is on and a NOAA APT pass crosses the 25° "good" tier, the radio auto-tunes to the satellite's downlink at AOS, opens the APT viewer, decodes the image live, saves a PNG at LOS, and restores the user's prior tune.

## State machine

Pure (returns `Vec<Action>` the wiring layer interprets), single-tick driven from the existing 1 Hz countdown timer — no second `GLib` source:

```
Idle ── pass arming + toggle on + quality OK ──▶ BeforePass
                                                     │
        settle window elapsed                        ▼
                                                  Recording
                                                     │
        pass.end ≤ now                               ▼
                                                  Finalizing ──▶ Idle
```

Lives in `crates/sdr-ui/src/sidebar/satellites_recorder.rs`.

## Wiring (`connect_satellites_panel` in `window.rs`)

The 1 Hz timer snapshots the pass list, the auto-record toggle state, and the current tune; passes them into `recorder.tick`; interprets returned actions:

| Action | Handler |
|---|---|
| `StartAutoRecord` | `tune_to_satellite` closure (same primitive the play button uses) + `open_apt_viewer_if_needed` (extracted from `connect_apt_action` so manual / auto opens share one path — no double-spawn) |
| `SavePng` | `state.apt_viewer.borrow().export_png(path)` |
| `RestoreTune` | `tune_to_satellite` again, with the saved (freq, mode, bw) |
| `Toast` | `AdwToast` on the existing overlay |

## NOAA-only auto-record

`is_apt_capable` matches `NOAA 15 / 18 / 19`. Meteor / ISS would tune correctly but the existing APT decoder can't decode their signals (LRPT / SSTV are different modulations) — pointless to auto-record them today. When the LRPT (epic #469) and SSTV (epic #472) decoders ship, the gate loosens accordingly.

## Quality threshold hardcoded for V1

`AUTO_RECORD_MIN_ELEV_DEG = 25.0` matches the "winners + good" tier from #507's quality tags. The user-selectable combo (#511) will replace this with a config-backed setting in its own PR.

## Test plan

- [x] `cargo build --workspace --features whisper-cpu` clean
- [x] `cargo test --workspace --features whisper-cpu` — 10 new recorder tests pass; 0 regressions
- [x] `cargo clippy --workspace --features whisper-cpu --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` clean
- [x] Manual smoke: panel + play button + ZIP lookup + viewer + ZIP-to-restore-tune still work; auto-record toggle in/out of Idle correctly.
- [ ] Live AOS→LOS smoke on a real NOAA pass (next eligible: NOAA 15 in ~5h at 28° peak per the panel's pass list).
- [ ] CodeRabbit review.

## What's left on epic #468 after this

Just polish, all already filed: **#510** (notifications), **#511** (auto-record threshold combo), **#512** (tray icon / keep-running), **#509** (shared tune helper refactor), **#504** / **#505** (radio panel bugs). All independent now — the APT receive loop is closed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-record NOAA APT passes: arms before AOS, starts at AOS, finalizes at LOS, and saves timestamped PNGs; info toasts indicate “starting” vs “in progress”, failures show warn toasts.

* **User Experience**
  * Satellites panel runs auto-record in background, opens/clears the APT viewer at AOS, and restores prior tuning, playback, and scanner state after recordings; respects elevation/AOS eligibility.

* **Tests**
  * Unit tests cover timing, non-rearming, action outputs, PNG naming, and tune-restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->