### PR TITLE
docs: Meteor-M LRPT design spec + implementation plan (epic #469)

### DIFF
--- a/docs/superpowers/plans/2026-04-25-meteor-lrpt-implementation.md
+++ b/docs/superpowers/plans/2026-04-25-meteor-lrpt-implementation.md
@@ -1,0 +1,5560 @@
+# Meteor-M LRPT Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the 4-stage Meteor-M LRPT pure-Rust receive pipeline (QPSK demod → Viterbi+RS FEC → CCSDS framing → Meteor-JPEG image assembly) end-to-end, plus auto-record generalization, viewer, and docs walkthrough — closes epic #469.
+
+**Architecture:** Stage 1 (DSP) lives in `sdr-dsp::lrpt`. Stages 2–4 (FEC + CCSDS + image) live in a new `sdr-lrpt` crate. The viewer is a fresh `sdr-ui::lrpt_viewer.rs`. Auto-record dispatches via a new catalog-driven `ImagingProtocol` enum in `sdr-sat`. See [`docs/superpowers/specs/2026-04-25-meteor-lrpt-design.md`](../specs/2026-04-25-meteor-lrpt-design.md) for the full design rationale, reference-codebase mapping, and out-of-scope deferrals (epic #520).
+
+**Tech Stack:** Rust 2024 edition, `num-complex` for IQ math, `proptest` for FEC property tests, `cargo-llvm-cov` for coverage gating, `criterion` for per-stage benches. New runtime crate dependencies: `image` (PNG export). Reference codebases (read-only, not linked): `original/SDRPlusPlus/decoder_modules/meteor_demodulator/` (stage 1), plus `medet`, `meteordemod`, SatDump for stages 2–4 (cloned on demand into `original/`, gitignored).
+
+---
+
+## Task overview
+
+| Task | PR scope | Crate(s) | Closes |
+|---|---|---|---|
+| 1 | Stage 1: QPSK demod (Costas + RRC + Gardner + slicer) | `sdr-dsp::lrpt` | — |
+| 2 | Stage 2a: Viterbi K=7 rate-1/2 + frame sync + derand | `sdr-lrpt::fec` (partial) | — |
+| 3 | Stage 2b: Reed-Solomon (255, 223) CCSDS dual-basis | `sdr-lrpt::fec` (complete) | — |
+| 4 | Stage 3: CCSDS VCDU/CADU/M_PDU framing | `sdr-lrpt::ccsds` | — |
+| 5 | Stage 4: Meteor-JPEG decoder + image assembly + CLI replay | `sdr-lrpt::image`, `sdr-radio::lrpt_image` | — |
+| 6 | Auto-record generalization (`ImagingProtocol` enum + dispatch) | `sdr-sat`, `sdr-ui` | #514 |
+| 7 | E2E LRPT integration (viewer + driver + catalog flip) | `sdr-ui`, `sdr-radio`, `sdr-sat` | — |
+| 8 | Docs walkthrough + `CLAUDE.md` + `README.md` updates | docs only | #469 |
+
+**Branch convention:** one feature branch per task, `feature/lrpt-stage-{1..7}` and `feature/lrpt-docs` for task 8. Each task is a single PR reviewed by CodeRabbit; per the user's workflow memory, wait for CR review and reply before opening the next PR.
+
+---
+
+## Task 1: Stage 1 — QPSK demod
+
+**Branch:** `feature/lrpt-stage-1`
+**Files:**
+- Create: `crates/sdr-dsp/src/lrpt/mod.rs`
+- Create: `crates/sdr-dsp/src/lrpt/costas.rs`
+- Create: `crates/sdr-dsp/src/lrpt/rrc_filter.rs`
+- Create: `crates/sdr-dsp/src/lrpt/timing.rs`
+- Create: `crates/sdr-dsp/src/lrpt/slicer.rs`
+- Create: `crates/sdr-dsp/benches/lrpt_demod.rs`
+- Modify: `crates/sdr-dsp/src/lib.rs` (add `pub mod lrpt;`)
+- Modify: `crates/sdr-dsp/Cargo.toml` (add `[[bench]]` entry, `criterion` dev-dependency)
+- Modify: `.github/workflows/ci.yml` (add `cargo-llvm-cov` job — coverage gate is wired here even though it'll only check `sdr-lrpt` once that crate exists in Task 2; setting up the CI plumbing is cheaper as a sub-task here than its own PR)
+- Reference: `original/SDRPlusPlus/decoder_modules/meteor_demodulator/src/{meteor_costas.h,meteor_demod.h}`
+
+**Pre-task setup:**
+
+- [ ] **Step 0a: Branch + clone reference**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feature/lrpt-stage-1
+# meteor_demod is the closer-to-our-needs reference even though
+# the spec says we port from SDR++; SDR++'s meteor_demodulator
+# IS the source of truth, but cross-checking against meteor_demod
+# (the standalone C tool) is useful for validating filter coefficients.
+test -d original/meteor_demod || git clone --depth 1 https://github.com/dbdexter-dev/meteor_demod.git original/meteor_demod
+```
+
+- [ ] **Step 0b: Verify reference files are readable**
+
+```bash
+ls original/SDRPlusPlus/decoder_modules/meteor_demodulator/src/
+ls original/meteor_demod/dsp/
+```
+
+Expected: both directories list source files. If either is missing, halt and re-clone — every subsequent step references these.
+
+### Module 1.1: `costas.rs` — QPSK Costas loop
+
+The Costas loop recovers the carrier phase from a QPSK signal where the carrier itself is suppressed. Implementation pattern: store running phase + frequency offset, multiply incoming I/Q by `e^(-j·phase)` to derotate, compute phase error from the rotated samples, drive a 2nd-order PI loop filter. Reference: `meteor_costas.h` (~50 lines, the cleanest tight implementation) and `meteor_demod/dsp/pll.c`.
+
+- [ ] **Step 1.1.1: Write the failing test** at `crates/sdr-dsp/src/lrpt/costas.rs` (file initially absent — test goes in the same file under `#[cfg(test)] mod tests`):
+
+```rust
+//! QPSK Costas loop for Meteor-M LRPT carrier recovery.
+//!
+//! Ported from SDR++'s `meteor_costas.h`. Locks onto the suppressed
+//! QPSK carrier by computing phase error from the rotated samples
+//! and driving a 2nd-order PI loop filter (alpha + beta gains).
+//!
+//! Reference (read-only): original/SDRPlusPlus/decoder_modules/
+//!                        meteor_demodulator/src/meteor_costas.h
+
+use num_complex::Complex32;
+
+/// QPSK Costas loop. Single-instance, single-threaded — caller
+/// hands in IQ samples and gets back de-rotated samples plus the
+/// instantaneous frequency-error estimate (useful for telemetry).
+#[derive(Debug)]
+pub struct Costas {
+    phase: f32,
+    freq: f32,
+    alpha: f32,
+    beta: f32,
+}
+
+impl Costas {
+    /// `loop_bw_hz` is the loop bandwidth at the symbol rate
+    /// (Meteor's working value: ~50 Hz from the SDR++ port).
+    /// `sample_rate_hz` is the working sample rate (typically
+    /// 2 × symbol rate after RRC matched filtering).
+    #[must_use]
+    pub fn new(loop_bw_hz: f32, sample_rate_hz: f32) -> Self {
+        let damping = 0.707_f32;
+        let theta = loop_bw_hz / sample_rate_hz;
+        let denom = 1.0 + 2.0 * damping * theta + theta * theta;
+        let alpha = 4.0 * damping * theta / denom;
+        let beta = 4.0 * theta * theta / denom;
+        Self { phase: 0.0, freq: 0.0, alpha, beta }
+    }
+
+    /// De-rotate one IQ sample. Returns the rotated sample.
+    pub fn process(&mut self, sample: Complex32) -> Complex32 {
+        let nco = Complex32::from_polar(1.0, -self.phase);
+        let out = sample * nco;
+        // QPSK phase error: hard-decision quadrant gradient.
+        let err = out.re.signum() * out.im - out.im.signum() * out.re;
+        self.freq += self.beta * err;
+        self.phase += self.freq + self.alpha * err;
+        // Wrap phase into [-π, π].
+        while self.phase > std::f32::consts::PI {
+            self.phase -= 2.0 * std::f32::consts::PI;
+        }
+        while self.phase < -std::f32::consts::PI {
+            self.phase += 2.0 * std::f32::consts::PI;
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locks_onto_clean_qpsk_constellation() {
+        // Synthesize a clean QPSK signal at zero frequency offset:
+        // four constellation points (±1, ±1)/sqrt(2). After Costas
+        // settles, the rotated output should be on or near these
+        // constellation points.
+        let symbols = [
+            Complex32::new(0.707, 0.707),
+            Complex32::new(-0.707, 0.707),
+            Complex32::new(0.707, -0.707),
+            Complex32::new(-0.707, -0.707),
+        ];
+        let mut costas = Costas::new(50.0, 144_000.0);
+        let mut last_out = Complex32::new(0.0, 0.0);
+        // Enough iterations to settle (loop bw is 50 Hz at 144 ksps,
+        // settling time ~3 / loop_bw = ~60 ms = ~8640 samples).
+        for i in 0..10_000 {
+            let s = symbols[i % 4];
+            last_out = costas.process(s);
+        }
+        // After lock the magnitude should still be ~1 (de-rotation
+        // preserves magnitude) and the constellation point should
+        // be one of the four QPSK points.
+        let mag = (last_out.re * last_out.re + last_out.im * last_out.im).sqrt();
+        assert!(
+            (mag - 1.0).abs() < 0.01,
+            "post-lock magnitude {mag} is not unity; Costas isn't preserving sample magnitude",
+        );
+    }
+
+    #[test]
+    fn corrects_small_frequency_offset() {
+        // Inject 100 Hz of carrier offset at 144 ksps. The Costas
+        // loop should track and de-rotate it to a stationary
+        // constellation.
+        let offset_hz = 100.0_f32;
+        let fs = 144_000.0_f32;
+        let mut costas = Costas::new(50.0, fs);
+        let mut output_phases: Vec<f32> = Vec::new();
+        let symbol = Complex32::new(0.707, 0.707);
+        for i in 0..20_000 {
+            let phase = 2.0 * std::f32::consts::PI * offset_hz * (i as f32) / fs;
+            let rotator = Complex32::from_polar(1.0, phase);
+            let s = symbol * rotator;
+            let out = costas.process(s);
+            if i > 15_000 {
+                output_phases.push(out.im.atan2(out.re));
+            }
+        }
+        // Post-settle, the output phase variance should be small —
+        // the loop is tracking the offset.
+        let mean: f32 = output_phases.iter().sum::<f32>() / output_phases.len() as f32;
+        let var: f32 = output_phases
+            .iter()
+            .map(|p| (p - mean).powi(2))
+            .sum::<f32>()
+            / output_phases.len() as f32;
+        assert!(
+            var < 0.01,
+            "post-lock phase variance {var} is too high; Costas isn't tracking 100 Hz offset",
+        );
+    }
+}
+```
+
+- [ ] **Step 1.1.2: Add `num-complex` to `sdr-dsp/Cargo.toml`** (workspace dep should already exist; if not, `[workspace.dependencies] num-complex = "0.4"` then `num-complex = { workspace = true }` in the crate).
+
+```bash
+grep "num-complex" Cargo.toml crates/sdr-dsp/Cargo.toml
+# If absent: add to [workspace.dependencies] in root Cargo.toml,
+# then add `num-complex = { workspace = true }` under [dependencies]
+# in crates/sdr-dsp/Cargo.toml.
+```
+
+- [ ] **Step 1.1.3: Add `pub mod lrpt;` to `crates/sdr-dsp/src/lib.rs`**
+
+```rust
+// In crates/sdr-dsp/src/lib.rs, alongside `pub mod apt;`:
+pub mod lrpt;
+```
+
+- [ ] **Step 1.1.4: Create `crates/sdr-dsp/src/lrpt/mod.rs`** (re-exports placeholder):
+
+```rust
+//! Meteor-M LRPT QPSK demodulator.
+//!
+//! Pipeline: AGC → RRC matched filter → Costas loop → Gardner
+//! symbol-timing recovery → hard slicer → soft symbols (i8 ±127).
+//!
+//! Reference: original/SDRPlusPlus/decoder_modules/meteor_demodulator/
+
+pub mod costas;
+pub mod rrc_filter;
+pub mod slicer;
+pub mod timing;
+
+pub use costas::Costas;
+pub use rrc_filter::RrcFilter;
+pub use slicer::slice_soft;
+pub use timing::Gardner;
+```
+
+The four sub-module files don't exist yet — they'll be created as we work through 1.2/1.3/1.4. For this commit only `costas.rs` is real; the others are placeholder stubs:
+
+- [ ] **Step 1.1.5: Create stubs for the other three modules** so `mod.rs` compiles:
+
+```rust
+// crates/sdr-dsp/src/lrpt/rrc_filter.rs
+//! Root-raised-cosine matched filter — stub, implemented in 1.2.
+pub struct RrcFilter;
+```
+
+```rust
+// crates/sdr-dsp/src/lrpt/timing.rs
+//! Gardner symbol-timing recovery — stub, implemented in 1.3.
+pub struct Gardner;
+```
+
+```rust
+// crates/sdr-dsp/src/lrpt/slicer.rs
+//! Hard slicer → soft symbols — stub, implemented in 1.4.
+#[must_use]
+pub fn slice_soft(_sample: num_complex::Complex32) -> [i8; 2] {
+    [0, 0]
+}
+```
+
+- [ ] **Step 1.1.6: Run the Costas tests, expect PASS**
+
+```bash
+cargo test -p sdr-dsp --features sdr-ui/whisper sidebar=false 2>/dev/null || \
+cargo test -p sdr-dsp lrpt::costas
+```
+
+Expected: `2 passed; 0 failed`. If `locks_onto_clean_qpsk_constellation` fails, recompute alpha/beta against the formula in `meteor_costas.h` line ~30. If `corrects_small_frequency_offset` fails, the wrap-phase logic is inverted.
+
+- [ ] **Step 1.1.7: Commit**
+
+```bash
+git add crates/sdr-dsp/src/lib.rs crates/sdr-dsp/src/lrpt/
+git commit -m "$(cat <<'EOF'
+sdr-dsp: scaffold lrpt module with QPSK Costas loop
+
+First piece of epic #469's stage 1 (LRPT QPSK demod). Costas loop
+is the carrier-recovery PI controller — derotates samples + drives
+a 2nd-order loop filter with damping=0.707, alpha/beta computed
+from the loop bandwidth (50 Hz at 144 ksps for Meteor).
+
+Ports the algorithm from SDR++'s meteor_demodulator/src/meteor_costas.h.
+Two unit tests: clean-constellation lock, 100 Hz offset tracking.
+The other three module files (rrc_filter/timing/slicer) are stubs
+to keep the module tree compiling; they ship next in 1.2-1.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 1.2: `rrc_filter.rs` — Root-raised-cosine matched filter
+
+RRC is the matched filter for the QPSK signal — its impulse response is the time-domain RRC pulse with rolloff β=0.6 and span 31 symbols. Reference: `meteor_demod/dsp/filter.c` (the standalone C version is cleanest), or SDR++'s `dsp/filter` framework.
+
+- [ ] **Step 1.2.1: Replace the stub at `crates/sdr-dsp/src/lrpt/rrc_filter.rs`**
+
+```rust
+//! Root-raised-cosine matched filter for Meteor LRPT QPSK.
+//!
+//! Coefficients computed from the standard RRC formula:
+//!   h(t) = (1/T) · [sin(π·t·(1-β)/T) + 4β·t·cos(π·t·(1+β)/T)/T]
+//!         / (π·t·(1 - (4βt/T)²) / T)
+//! at β = 0.6, span 31 symbols, 2 samples per symbol = 63 taps.
+//!
+//! Reference: original/meteor_demod/dsp/filter.c (filter_rrc_init).
+
+use num_complex::Complex32;
+
+/// Number of taps. Span 31 symbols × 2 samples/symbol + 1 = 63.
+pub const NUM_TAPS: usize = 63;
+
+/// Symbol-rate rolloff factor for Meteor LRPT (β).
+pub const ROLLOFF: f32 = 0.6;
+
+/// Root-raised-cosine FIR matched filter. Single-channel, complex
+/// in/out (the QPSK signal is complex baseband).
+pub struct RrcFilter {
+    taps: [f32; NUM_TAPS],
+    history: [Complex32; NUM_TAPS],
+    write_idx: usize,
+}
+
+impl RrcFilter {
+    /// Build the RRC filter at `samples_per_symbol` (typically 2 for
+    /// the standard 2 sps QPSK chain).
+    #[must_use]
+    pub fn new(samples_per_symbol: usize) -> Self {
+        let mut taps = [0.0_f32; NUM_TAPS];
+        let span = 31_i32; // symbols
+        let mid = NUM_TAPS as i32 / 2;
+        for i in 0..NUM_TAPS as i32 {
+            let t = (i - mid) as f32 / samples_per_symbol as f32;
+            taps[i as usize] = rrc_impulse(t, ROLLOFF);
+        }
+        // Normalize to unity DC gain (sum of taps = 1).
+        let sum: f32 = taps.iter().sum();
+        if sum.abs() > 1e-6 {
+            for tap in &mut taps {
+                *tap /= sum;
+            }
+        }
+        Self {
+            taps,
+            history: [Complex32::new(0.0, 0.0); NUM_TAPS],
+            write_idx: 0,
+        }
+    }
+
+    /// Process one complex sample. Returns the filtered sample.
+    pub fn process(&mut self, x: Complex32) -> Complex32 {
+        self.history[self.write_idx] = x;
+        self.write_idx = (self.write_idx + 1) % NUM_TAPS;
+        let mut acc = Complex32::new(0.0, 0.0);
+        for i in 0..NUM_TAPS {
+            let idx = (self.write_idx + i) % NUM_TAPS;
+            acc += self.history[idx] * self.taps[NUM_TAPS - 1 - i];
+        }
+        acc
+    }
+}
+
+/// Continuous-time RRC impulse response. Handles the t=0 and
+/// t = ±T/(4β) singularities by L'Hopital expansion (which the
+/// C reference also does).
+fn rrc_impulse(t: f32, beta: f32) -> f32 {
+    use std::f32::consts::PI;
+    if t.abs() < 1e-6 {
+        return 1.0 - beta + 4.0 * beta / PI;
+    }
+    let denom_singular = (4.0 * beta * t).powi(2);
+    if (denom_singular - 1.0).abs() < 1e-6 {
+        let s = (PI / (4.0 * beta)).sin();
+        let c = (PI / (4.0 * beta)).cos();
+        return (beta / 2.0_f32.sqrt()) * ((1.0 + 2.0 / PI) * s + (1.0 - 2.0 / PI) * c);
+    }
+    let num = (PI * t * (1.0 - beta)).sin() + 4.0 * beta * t * (PI * t * (1.0 + beta)).cos();
+    let den = PI * t * (1.0 - denom_singular);
+    num / den
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rrc_taps_are_symmetric() {
+        let f = RrcFilter::new(2);
+        for i in 0..(NUM_TAPS / 2) {
+            let a = f.taps[i];
+            let b = f.taps[NUM_TAPS - 1 - i];
+            assert!(
+                (a - b).abs() < 1e-5,
+                "RRC taps must be symmetric: tap[{i}]={a}, tap[{}]={b}",
+                NUM_TAPS - 1 - i,
+            );
+        }
+    }
+
+    #[test]
+    fn rrc_passes_dc_with_unity_gain() {
+        let mut f = RrcFilter::new(2);
+        // Push 200 samples of constant DC. Output magnitude
+        // should approach 1 after the filter settles (NUM_TAPS
+        // samples).
+        let mut last = Complex32::new(0.0, 0.0);
+        for _ in 0..200 {
+            last = f.process(Complex32::new(1.0, 0.0));
+        }
+        assert!(
+            (last.re - 1.0).abs() < 1e-3,
+            "DC response should be unity, got {}",
+            last.re,
+        );
+        assert!(last.im.abs() < 1e-3, "DC response imag should be 0");
+    }
+
+    #[test]
+    fn rrc_attenuates_above_band() {
+        // Drive the filter with a sinusoid at the symbol rate
+        // (Nyquist for 2 sps). With β=0.6 the cutoff is at
+        // (1+β)/2 of the symbol rate from baseband, so a tone at
+        // the symbol rate sits beyond the rolloff region and
+        // should be heavily attenuated.
+        let mut f = RrcFilter::new(2);
+        let mut max_after_settle = 0.0_f32;
+        for n in 0..400 {
+            let phase = std::f32::consts::PI * n as f32; // alternating ±1
+            let s = Complex32::new(phase.cos(), 0.0);
+            let out = f.process(s);
+            if n > NUM_TAPS {
+                max_after_settle = max_after_settle.max(out.re.abs());
+            }
+        }
+        assert!(
+            max_after_settle < 0.2,
+            "RRC should attenuate symbol-rate tone, got peak {max_after_settle}",
+        );
+    }
+}
+```
+
+- [ ] **Step 1.2.2: Run the RRC tests**
+
+```bash
+cargo test -p sdr-dsp lrpt::rrc_filter
+```
+
+Expected: `3 passed; 0 failed`. If symmetric fails, the loop bound is off-by-one. If DC unity fails, the normalization step is missing. If attenuation fails, β is swapped or the formula has a sign error.
+
+- [ ] **Step 1.2.3: Commit**
+
+```bash
+git add crates/sdr-dsp/src/lrpt/rrc_filter.rs
+git commit -m "$(cat <<'EOF'
+sdr-dsp::lrpt: root-raised-cosine matched filter
+
+63-tap symmetric FIR with rolloff β=0.6, normalized to unity DC
+gain. Direct-form FIR with circular history buffer (NUM_TAPS=63
+matches Meteor LRPT's standard 31-symbol span at 2 samples/symbol).
+
+Three tests pin: tap symmetry, unity DC pass-through, attenuation
+of an at-symbol-rate tone (the matched filter's intended job).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 1.3: `timing.rs` — Gardner symbol-timing recovery
+
+Gardner is a non-data-aided symbol-timing recovery algorithm. It produces a timing-error estimate from three consecutive samples (mid + late + early) and drives a fractional resampler. Reference: `meteor_demod/dsp/timing.c` (~100 lines, very direct).
+
+- [ ] **Step 1.3.1: Replace the stub at `crates/sdr-dsp/src/lrpt/timing.rs`**
+
+```rust
+//! Gardner symbol-timing recovery for Meteor LRPT QPSK.
+//!
+//! Non-data-aided timing recovery — uses three consecutive
+//! oversampled samples (early / mid / late) to compute a
+//! timing-error estimate, drives a 2nd-order loop filter, and
+//! produces one decimated output sample per recovered symbol.
+//!
+//! Reference: original/meteor_demod/dsp/timing.c
+
+use num_complex::Complex32;
+
+/// Gardner timing recovery. Single-channel, takes 2 samples per
+/// symbol in (the standard rate post-RRC) and emits 1 symbol per
+/// recovered timing-tick.
+pub struct Gardner {
+    mu: f32,            // fractional offset, [0, 1)
+    omega: f32,         // current symbol period in samples
+    omega_mid: f32,     // nominal symbol period (= 2.0 for 2 sps)
+    omega_lim: f32,     // ± fractional drift limit (typ. 0.005)
+    gain_mu: f32,       // tracking gain on µ
+    gain_omega: f32,    // tracking gain on ω
+    last: Complex32,    // previous output sample
+    mid: Complex32,     // mid-point sample
+    pending: Vec<Complex32>,   // input buffer awaiting consumption
+}
+
+impl Gardner {
+    /// `samples_per_symbol` is the input rate (typically 2.0).
+    /// `gain` is the loop bandwidth — Meteor's working value is 0.005.
+    #[must_use]
+    pub fn new(samples_per_symbol: f32, gain: f32) -> Self {
+        Self {
+            mu: 0.0,
+            omega: samples_per_symbol,
+            omega_mid: samples_per_symbol,
+            omega_lim: 0.005,
+            gain_mu: gain,
+            gain_omega: 0.25 * gain * gain,
+            last: Complex32::new(0.0, 0.0),
+            mid: Complex32::new(0.0, 0.0),
+            pending: Vec::with_capacity(8),
+        }
+    }
+
+    /// Push one input sample. May produce 0 or 1 output symbols
+    /// depending on where the timing tick lands; returns the
+    /// recovered symbol if a tick fired.
+    pub fn process(&mut self, x: Complex32) -> Option<Complex32> {
+        self.pending.push(x);
+        if self.pending.len() < 3 {
+            return None;
+        }
+        // Linear interpolation between adjacent input samples
+        // for the fractional advance — Meteor doesn't need a
+        // higher-order interpolator at 2 sps.
+        let early = self.pending[0];
+        let mid_in = self.pending[1];
+        let late = self.pending[2];
+        let interp = mid_in * (1.0 - self.mu) + late * self.mu;
+        // Gardner error: Im(conj(mid) · (late - early)) for QPSK.
+        let diff = late - early;
+        let err = self.mid.conj() * diff;
+        let err_scalar = err.im;
+        // 2nd-order loop filter on omega + mu.
+        self.omega += self.gain_omega * err_scalar;
+        self.omega = self
+            .omega
+            .clamp(self.omega_mid - self.omega_lim, self.omega_mid + self.omega_lim);
+        self.mu += self.omega + self.gain_mu * err_scalar;
+        let consume = self.mu.floor() as usize;
+        self.mu -= consume as f32;
+        // Drop consumed samples + emit the recovered symbol.
+        if consume + 1 <= self.pending.len() {
+            self.pending.drain(0..consume);
+        } else {
+            self.pending.clear();
+        }
+        self.mid = mid_in;
+        self.last = interp;
+        Some(interp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovers_symbol_rate_from_2sps_input() {
+        // Synthesize 2 sps QPSK with no timing jitter — every
+        // other input sample is the symbol, alternating with a
+        // (zero) sample between. Gardner should converge to
+        // emitting one output per pair.
+        let mut g = Gardner::new(2.0, 0.005);
+        let mut emitted = 0usize;
+        for n in 0..2000 {
+            let on_symbol = n % 2 == 0;
+            let s = if on_symbol {
+                Complex32::new(0.707, 0.707)
+            } else {
+                Complex32::new(0.0, 0.0)
+            };
+            if g.process(s).is_some() {
+                emitted += 1;
+            }
+        }
+        // 2000 inputs at 2 sps → expect ~1000 emitted symbols.
+        // Tolerance accounts for the loop's initial settling.
+        assert!(
+            emitted > 900 && emitted < 1100,
+            "expected ~1000 emitted, got {emitted}",
+        );
+    }
+}
+```
+
+- [ ] **Step 1.3.2: Run the timing tests**
+
+```bash
+cargo test -p sdr-dsp lrpt::timing
+```
+
+Expected: `1 passed`. If emitted count is wildly off (e.g. 0 or > 1500), the µ accumulator is broken — re-check that `consume = mu.floor()` is being subtracted from `mu`.
+
+- [ ] **Step 1.3.3: Commit**
+
+```bash
+git add crates/sdr-dsp/src/lrpt/timing.rs
+git commit -m "$(cat <<'EOF'
+sdr-dsp::lrpt: Gardner symbol-timing recovery
+
+Non-data-aided timing recovery driven by the Gardner error
+estimator (Im(conj(mid) · (late - early)) for QPSK). 2nd-order
+loop filter on the symbol-period (omega) and fractional-offset
+(mu) accumulators with omega clamped to ±0.005 of nominal.
+Linear interpolation is sufficient at 2 sps; higher-order
+isn't needed for Meteor's signal characteristics.
+
+Ported from meteor_demod/dsp/timing.c. Test pins the recovery
+rate at ~1 symbol per 2 input samples.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 1.4: `slicer.rs` — Hard slice → soft symbols
+
+The slicer takes recovered constellation points and produces signed-byte soft symbols (i8 ±127). This is what feeds into the FEC stage.
+
+- [ ] **Step 1.4.1: Replace the stub at `crates/sdr-dsp/src/lrpt/slicer.rs`**
+
+```rust
+//! QPSK hard slicer → soft i8 symbol pairs for FEC input.
+//!
+//! Each QPSK symbol carries 2 bits, mapped from sign of (I, Q).
+//! The Viterbi decoder downstream wants soft information rather
+//! than hard bits — we produce signed bytes scaled to ±127, with
+//! magnitude proportional to constellation-point distance from
+//! the decision boundary.
+
+use num_complex::Complex32;
+
+/// Slice one recovered QPSK symbol to two soft i8 bits. Output
+/// `[i_bit, q_bit]` order matches CCSDS 131.0-B-3 convention.
+#[must_use]
+pub fn slice_soft(sample: Complex32) -> [i8; 2] {
+    [scale(sample.re), scale(sample.im)]
+}
+
+/// Scale an axis component to i8 range. Saturates beyond ±127.
+fn scale(x: f32) -> i8 {
+    let scaled = (x * 127.0).round();
+    scaled.clamp(-127.0, 127.0) as i8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_qpsk_constellation_to_signed_bytes() {
+        // Standard QPSK constellation, normalized to unit
+        // magnitude. After scaling, each axis should land near
+        // ±90 (= round(0.707 * 127)).
+        let cases = [
+            (Complex32::new(0.707, 0.707), 90, 90),
+            (Complex32::new(-0.707, 0.707), -90, 90),
+            (Complex32::new(0.707, -0.707), 90, -90),
+            (Complex32::new(-0.707, -0.707), -90, -90),
+        ];
+        for (sample, expected_i, expected_q) in cases {
+            let [i, q] = slice_soft(sample);
+            assert!(
+                (i32::from(i) - expected_i).abs() <= 1,
+                "I: expected ~{expected_i}, got {i}",
+            );
+            assert!(
+                (i32::from(q) - expected_q).abs() <= 1,
+                "Q: expected ~{expected_q}, got {q}",
+            );
+        }
+    }
+
+    #[test]
+    fn saturates_beyond_unit_magnitude() {
+        let huge = Complex32::new(5.0, -5.0);
+        assert_eq!(slice_soft(huge), [127, -127]);
+    }
+}
+```
+
+- [ ] **Step 1.4.2: Run the slicer tests**
+
+```bash
+cargo test -p sdr-dsp lrpt::slicer
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 1.4.3: Commit**
+
+```bash
+git add crates/sdr-dsp/src/lrpt/slicer.rs
+git commit -m "$(cat <<'EOF'
+sdr-dsp::lrpt: QPSK soft slicer
+
+Maps recovered QPSK constellation points to signed-byte soft
+symbols (i8 ±127, magnitude proportional to distance from the
+decision boundary). The Viterbi decoder downstream consumes
+these directly. Saturating clamp prevents overflow on outliers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 1.5: Top-level `LrptDemod` chain
+
+- [ ] **Step 1.5.1: Replace `crates/sdr-dsp/src/lrpt/mod.rs`** with the chained processor:
+
+```rust
+//! Meteor-M LRPT QPSK demodulator.
+//!
+//! Pipeline: RRC matched filter (no AGC in v1 — RRC normalization handles unity gain)
+//! → Costas loop → Gardner symbol-timing → hard slicer →
+//! soft symbols (i8 ±127).
+//!
+//! The pipeline is single-channel, single-threaded. Caller pushes
+//! complex baseband samples at the working sample rate (typically
+//! 2 × symbol rate = 144 ksps for Meteor) and pulls soft i8 symbol
+//! pairs out as the chain produces them.
+//!
+//! Reference: original/SDRPlusPlus/decoder_modules/meteor_demodulator/
+
+use num_complex::Complex32;
+
+pub mod costas;
+pub mod rrc_filter;
+pub mod slicer;
+pub mod timing;
+
+pub use costas::Costas;
+pub use rrc_filter::RrcFilter;
+pub use slicer::slice_soft;
+pub use timing::Gardner;
+
+/// Meteor LRPT symbol rate (symbols per second).
+pub const SYMBOL_RATE_HZ: f32 = 72_000.0;
+
+/// Working sample rate for the demod chain. 2 samples per
+/// symbol is the standard QPSK convention post-RRC.
+pub const SAMPLE_RATE_HZ: f32 = SYMBOL_RATE_HZ * 2.0;
+
+/// Costas loop bandwidth (Hz at the working sample rate).
+/// Tuned per `meteor_costas.h` — wider locks faster but tracks
+/// less cleanly post-lock; this value matches SDR++.
+pub const COSTAS_LOOP_BW_HZ: f32 = 50.0;
+
+/// Gardner gain coefficient. Tuned per `meteor_demod`.
+pub const GARDNER_GAIN: f32 = 0.005;
+
+/// Top-level LRPT demodulator chain.
+pub struct LrptDemod {
+    rrc: RrcFilter,
+    costas: Costas,
+    gardner: Gardner,
+}
+
+impl Default for LrptDemod {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LrptDemod {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            rrc: RrcFilter::new(2),
+            costas: Costas::new(COSTAS_LOOP_BW_HZ, SAMPLE_RATE_HZ),
+            gardner: Gardner::new(2.0, GARDNER_GAIN),
+        }
+    }
+
+    /// Push one complex baseband sample. Returns up to one
+    /// soft-symbol pair (`[i, q]`) when the timing recovery
+    /// fires a symbol tick.
+    pub fn process(&mut self, x: Complex32) -> Option<[i8; 2]> {
+        let filtered = self.rrc.process(x);
+        let derotated = self.costas.process(filtered);
+        self.gardner.process(derotated).map(slice_soft)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_produces_soft_symbols_from_synthetic_qpsk() {
+        // Synthesize ~1000 QPSK symbols at 2 sps (no impairments).
+        // Pipeline should converge and emit signed i8 pairs.
+        let mut demod = LrptDemod::new();
+        let symbols = [
+            Complex32::new(0.707, 0.707),
+            Complex32::new(-0.707, 0.707),
+            Complex32::new(0.707, -0.707),
+            Complex32::new(-0.707, -0.707),
+        ];
+        let mut emitted = 0usize;
+        for n in 0..4000 {
+            let sym = symbols[(n / 2) % 4];
+            // Insert zero between each symbol to mimic 2 sps.
+            let s = if n % 2 == 0 { sym } else { Complex32::new(0.0, 0.0) };
+            if demod.process(s).is_some() {
+                emitted += 1;
+            }
+        }
+        // 4000 inputs at 2 sps → expect ~2000 emitted; the chain
+        // takes ~NUM_TAPS samples to settle, so anything near
+        // half is correct.
+        assert!(
+            emitted > 1500,
+            "pipeline should emit ~2000 soft symbols, got {emitted}",
+        );
+    }
+}
+```
+
+- [ ] **Step 1.5.2: Run all `sdr-dsp::lrpt` tests**
+
+```bash
+cargo test -p sdr-dsp lrpt
+```
+
+Expected: `7 passed; 0 failed` (2 Costas + 3 RRC + 1 timing + 2 slicer = 8, but mod.rs adds 1 → 9 total; OK if the count differs by a few, what matters is no failures).
+
+### Module 1.6: Criterion bench
+
+- [ ] **Step 1.6.1: Add `[[bench]]` and `criterion` dev-dep to `crates/sdr-dsp/Cargo.toml`**
+
+```toml
+# Add under [dev-dependencies]:
+criterion = { version = "0.5", features = ["html_reports"] }
+
+# Add at the bottom of the file:
+[[bench]]
+name = "lrpt_demod"
+harness = false
+```
+
+- [ ] **Step 1.6.2: Create `crates/sdr-dsp/benches/lrpt_demod.rs`**
+
+```rust
+use criterion::{Criterion, criterion_group, criterion_main, black_box};
+use num_complex::Complex32;
+use sdr_dsp::lrpt::LrptDemod;
+
+fn bench_demod(c: &mut Criterion) {
+    let symbols = [
+        Complex32::new(0.707, 0.707),
+        Complex32::new(-0.707, 0.707),
+        Complex32::new(0.707, -0.707),
+        Complex32::new(-0.707, -0.707),
+    ];
+    // 1 second of input at 144 ksps = 144_000 complex samples.
+    let buf: Vec<Complex32> = (0..144_000)
+        .map(|n| if n % 2 == 0 { symbols[(n / 2) % 4] } else { Complex32::new(0.0, 0.0) })
+        .collect();
+
+    c.bench_function("lrpt_demod_1s_144ksps", |b| {
+        b.iter(|| {
+            let mut demod = LrptDemod::new();
+            let mut emitted = 0_u32;
+            for s in &buf {
+                if demod.process(black_box(*s)).is_some() {
+                    emitted += 1;
+                }
+            }
+            black_box(emitted);
+        });
+    });
+}
+
+criterion_group!(benches, bench_demod);
+criterion_main!(benches);
+```
+
+- [ ] **Step 1.6.3: Run the bench (informational, not a test)**
+
+```bash
+cargo bench -p sdr-dsp --bench lrpt_demod
+```
+
+Expected: throughput report (will be roughly 5–20 ms for 1 second of input on a modern CPU). The number itself is not asserted; it's the per-stage performance floor we'll regression against later.
+
+### Module 1.7: CI coverage gate setup
+
+- [ ] **Step 1.7.1: Modify `.github/workflows/ci.yml`** to add a coverage job. Locate the existing `clippy` or `test` job and add a new sibling job:
+
+```yaml
+  coverage:
+    name: Coverage gate (sdr-lrpt)
+    runs-on: ubuntu-latest
+    if: false  # disabled until sdr-lrpt exists (Task 2)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage
+        run: |
+          cargo llvm-cov --package sdr-lrpt --fail-under-lines 90 --fail-under-regions 90
+```
+
+The job is gated `if: false` for now — Task 2's first commit flips it to `if: true` once `sdr-lrpt` exists.
+
+- [ ] **Step 1.7.2: Commit**
+
+```bash
+git add crates/sdr-dsp/Cargo.toml crates/sdr-dsp/src/lrpt/mod.rs crates/sdr-dsp/benches/lrpt_demod.rs .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+sdr-dsp::lrpt: top-level LrptDemod chain + criterion bench
+
+Wires Costas + RRC + Gardner + slicer into a single LrptDemod
+processor with `process(Complex32) -> Option<[i8; 2]>` interface.
+Constants for symbol rate (72 ksps), sample rate (144 ksps,
+= 2 × symbol rate), Costas loop bandwidth (50 Hz), and Gardner
+gain (0.005) match the SDR++ reference implementation.
+
+Bench at crates/sdr-dsp/benches/lrpt_demod.rs measures end-to-end
+demod throughput on 1 second of synthetic QPSK input — establishes
+the perf floor for regression detection.
+
+CI coverage gate scaffold added in workflow YAML, gated `if: false`
+until Task 2 introduces the sdr-lrpt crate.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Final Task 1 verification
+
+- [ ] **Step 1.8.1: Run full sdr-dsp test suite + lints**
+
+```bash
+cargo test -p sdr-dsp
+cargo clippy -p sdr-dsp --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all tests pass, no clippy warnings, format clean.
+
+- [ ] **Step 1.8.2: Push branch + open PR**
+
+```bash
+git push -u origin feature/lrpt-stage-1
+gh pr create --base main --title "sdr-dsp::lrpt: stage 1 QPSK demod (epic #469)" --body "$(cat <<'EOF'
+## Summary
+
+Stage 1 of epic #469 (Meteor-M LRPT receive). Pure-Rust port of SDR++'s `meteor_demodulator` — QPSK Costas loop + RRC matched filter (β=0.6) + Gardner symbol-timing recovery + hard slicer producing soft i8 symbol pairs.
+
+Lives under \`sdr-dsp::lrpt\` matching the existing \`sdr-dsp::apt\` precedent. No user-visible change yet; the soft-symbol stream feeds the FEC stage in Task 2.
+
+## What's in
+- \`costas.rs\` — QPSK Costas loop (carrier recovery)
+- \`rrc_filter.rs\` — root-raised-cosine matched filter (63 taps, β=0.6)
+- \`timing.rs\` — Gardner symbol-timing recovery
+- \`slicer.rs\` — hard slice → soft i8 symbols
+- \`mod.rs\` — \`LrptDemod\` chain
+- \`benches/lrpt_demod.rs\` — criterion bench, perf floor for regression detection
+- \`.github/workflows/ci.yml\` — coverage-gate job scaffold (gated \`if: false\` until \`sdr-lrpt\` exists in Task 2)
+
+## Test plan
+- [ ] cargo test -p sdr-dsp lrpt — 9 unit tests pass
+- [ ] cargo clippy -p sdr-dsp --all-targets -- -D warnings clean
+- [ ] cargo bench -p sdr-dsp --bench lrpt_demod runs and reports throughput
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 1.8.3: Wait for CodeRabbit review** per `feedback_coderabbit_workflow` memory. Address every comment + reply per `feedback_reply_to_coderabbit`. Run pre-commit CR-pattern self-review on each follow-up commit.
+
+
+
+## Task 2: Stage 2a — Viterbi + frame sync + derandomizer
+
+**Branch:** `feature/lrpt-stage-2a-viterbi`
+**Files:**
+- Create: `crates/sdr-lrpt/Cargo.toml`
+- Create: `crates/sdr-lrpt/src/lib.rs`
+- Create: `crates/sdr-lrpt/src/fec/mod.rs`
+- Create: `crates/sdr-lrpt/src/fec/viterbi.rs`
+- Create: `crates/sdr-lrpt/src/fec/sync.rs`
+- Create: `crates/sdr-lrpt/src/fec/derand.rs`
+- Create: `crates/sdr-lrpt/tests/fixtures/ccsds_131_viterbi_vectors.txt`
+- Create: `crates/sdr-lrpt/benches/fec.rs`
+- Modify: `Cargo.toml` (add `crates/sdr-lrpt` to workspace `members`)
+- Modify: `.github/workflows/ci.yml` (flip coverage-gate `if: false` → `if: true`)
+- Reference: `original/medet/viterbi.c`, `original/medet/correlator.c`
+
+**Pre-task setup:**
+
+- [ ] **Step 0a: Branch + clone medet reference**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feature/lrpt-stage-2a-viterbi
+test -d original/medet || git clone --depth 1 https://github.com/artlav/meteor_decoder.git original/medet
+ls original/medet/
+```
+
+Expected: `viterbi.c`, `correlator.c`, `rs.c`, etc. listed. If the upstream repo has moved, fall back to a fork (search `github.com` for `met_jpg.c` and clone the result).
+
+### Module 2.1: Crate skeleton
+
+- [ ] **Step 2.1.1: Create `crates/sdr-lrpt/Cargo.toml`**
+
+```toml
+[package]
+name = "sdr-lrpt"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+sdr-types = { path = "../sdr-types" }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+proptest = "1"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[lints]
+workspace = true
+
+[[bench]]
+name = "fec"
+harness = false
+```
+
+- [ ] **Step 2.1.2: Create `crates/sdr-lrpt/src/lib.rs`** as the crate root:
+
+```rust
+//! Meteor-M LRPT post-demod decoder.
+//!
+//! Stages 2-4 of the LRPT receive pipeline (epic #469):
+//! - [`fec`] — Viterbi rate-1/2 + frame sync + de-randomize +
+//!   Reed-Solomon (255, 223) per CCSDS Blue Books 131.0-B-3 +
+//!   101.0-B-3.
+//! - [`ccsds`] — VCDU / CADU / M_PDU framing and demux (ships in
+//!   Task 4).
+//! - [`image`] — Meteor reduced-JPEG decoder + per-channel image
+//!   buffer (ships in Task 5).
+//!
+//! Pure data crate — no DSP (those live in [`sdr_dsp::lrpt`]),
+//! no GTK (UI lives in [`sdr_ui`]). Each layer's public surface is
+//! a small struct with a `process()` method matching the
+//! project-wide DSP convention; internals stay private.
+//!
+//! Reference codebases (read-only, not linked):
+//! `original/medet/`, `original/meteordemod/`, `original/SatDump/`.
+
+#![forbid(unsafe_code)]
+
+pub mod fec;
+```
+
+- [ ] **Step 2.1.3: Create `crates/sdr-lrpt/src/fec/mod.rs`** as the FEC module root:
+
+```rust
+//! FEC chain for Meteor-M LRPT.
+//!
+//! ```text
+//! soft i8 ──▶ Viterbi ──▶ Sync ──▶ Derand ──▶ Reed-Solomon ──▶ frames
+//! ```
+//!
+//! Each layer is a streaming `process(input, output) -> usize`
+//! producing or consuming variable-length output. Buffers are
+//! caller-allocated. No async, no threading, no I/O.
+
+pub mod derand;
+pub mod sync;
+pub mod viterbi;
+
+pub use derand::Derandomizer;
+pub use sync::SyncCorrelator;
+pub use viterbi::ViterbiDecoder;
+```
+
+- [ ] **Step 2.1.4: Add `crates/sdr-lrpt` to workspace** in `/data/source/rtl-sdr/Cargo.toml`:
+
+```toml
+# under [workspace] members, alphabetical placement after sdr-ffi:
+"crates/sdr-lrpt",
+```
+
+- [ ] **Step 2.1.5: Verify workspace build**
+
+```bash
+cargo build -p sdr-lrpt
+```
+
+Expected: `Compiling sdr-lrpt v0.1.0 ... Finished`. If it fails on missing modules, ensure all four files in `src/fec/` exist (they're stubbed in the next sub-tasks).
+
+- [ ] **Step 2.1.6: Stub the three FEC sub-modules** so the crate compiles:
+
+```rust
+// crates/sdr-lrpt/src/fec/viterbi.rs
+//! Rate-1/2 K=7 Viterbi decoder — implemented in 2.2.
+pub struct ViterbiDecoder;
+```
+
+```rust
+// crates/sdr-lrpt/src/fec/sync.rs
+//! 32-bit ASM frame-sync correlator — implemented in 2.3.
+pub struct SyncCorrelator;
+```
+
+```rust
+// crates/sdr-lrpt/src/fec/derand.rs
+//! CCSDS PN-sequence de-randomizer — implemented in 2.4.
+pub struct Derandomizer;
+```
+
+- [ ] **Step 2.1.7: Commit the scaffold**
+
+```bash
+git add Cargo.toml crates/sdr-lrpt/
+git commit -m "$(cat <<'EOF'
+sdr-lrpt: new crate scaffold for LRPT post-demod decoder
+
+Empty crate with fec/ccsds/image module structure mapped out.
+Stubs for Viterbi, sync correlator, and derandomizer keep the
+module tree compiling while subsequent commits port each layer.
+
+Workspace member added; depends on sdr-types only (no DSP, no GTK).
+proptest and criterion as dev-deps for property tests + benches.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 2.2: Viterbi rate-1/2 K=7 decoder
+
+CCSDS standard convolutional code: K=7, rate 1/2, generators G1=0o171, G2=0o133. Decode complexity: 64 trellis states, traceback length conventionally 32 × K = ~200 input bits. Reference: `medet/viterbi.c` (~250 lines, the cleanest reference).
+
+- [ ] **Step 2.2.1: Replace the `viterbi.rs` stub with the test harness first**
+
+```rust
+//! Rate-1/2 K=7 Viterbi decoder.
+//!
+//! CCSDS 131.0-B-3 convolutional code:
+//! - Constraint length K = 7 (64 trellis states)
+//! - Generators: G1 = 0o171, G2 = 0o133 (octal)
+//! - Soft-decision input: i8 ±127 (Viterbi metric is Euclidean)
+//! - Output: 1 hard bit per pair of input soft symbols
+//!
+//! Reference: original/medet/viterbi.c
+
+use std::collections::VecDeque;
+
+/// Generator polynomial 1 (octal 171 = binary 1111001).
+pub const G1: u8 = 0o171;
+/// Generator polynomial 2 (octal 133 = binary 1011011).
+pub const G2: u8 = 0o133;
+/// Constraint length.
+pub const K: usize = 7;
+/// Number of trellis states.
+pub const NUM_STATES: usize = 1 << (K - 1);
+/// Traceback depth in trellis steps. 5 × K is the conventional
+/// safe minimum; 32 × K is overkill-safe for noisy input.
+pub const TRACEBACK_DEPTH: usize = 32 * K;
+
+/// Streaming Viterbi decoder. Caller pushes pairs of soft symbols
+/// (`[i8; 2]` per encoded bit), decoder emits decoded bits as the
+/// traceback completes.
+pub struct ViterbiDecoder {
+    metrics: [i32; NUM_STATES],
+    history: VecDeque<[u8; NUM_STATES]>, // per-step parent-state record
+}
+
+impl Default for ViterbiDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ViterbiDecoder {
+    #[must_use]
+    pub fn new() -> Self {
+        let mut metrics = [i32::MIN / 2; NUM_STATES];
+        metrics[0] = 0; // start in state 0 by CCSDS convention
+        Self {
+            metrics,
+            history: VecDeque::with_capacity(TRACEBACK_DEPTH + 1),
+        }
+    }
+
+    /// Push one pair of soft symbols (one encoded bit's worth).
+    /// Returns `Some(bit)` when traceback emits a decoded bit
+    /// (after the first `TRACEBACK_DEPTH` pushes).
+    pub fn step(&mut self, soft: [i8; 2]) -> Option<u8> {
+        let mut new_metrics = [i32::MIN / 2; NUM_STATES];
+        let mut parents = [0_u8; NUM_STATES];
+        for state in 0..NUM_STATES {
+            for input_bit in 0..2_u8 {
+                // Output bits the encoder would produce going from
+                // `state` after seeing `input_bit`.
+                let prev = (state >> 1) | ((input_bit as usize) << (K - 2));
+                let g1_out = parity_8(prev as u8 & G1);
+                let g2_out = parity_8(prev as u8 & G2);
+                // Branch metric: correlation with soft input. Higher
+                // = better. Soft i8 ranges ±127.
+                let metric_g1 = if g1_out == 0 {
+                    i32::from(soft[0])
+                } else {
+                    -i32::from(soft[0])
+                };
+                let metric_g2 = if g2_out == 0 {
+                    i32::from(soft[1])
+                } else {
+                    -i32::from(soft[1])
+                };
+                let candidate = self.metrics[prev] + metric_g1 + metric_g2;
+                if candidate > new_metrics[state] {
+                    new_metrics[state] = candidate;
+                    parents[state] = prev as u8;
+                }
+            }
+        }
+        self.metrics = new_metrics;
+        self.history.push_back(parents);
+        // Renormalize to prevent overflow — subtract min from all.
+        let min = *self.metrics.iter().min().unwrap_or(&0);
+        for m in &mut self.metrics {
+            *m -= min;
+        }
+        if self.history.len() > TRACEBACK_DEPTH {
+            // Trace back from best current state through history.
+            let best = self
+                .metrics
+                .iter()
+                .enumerate()
+                .max_by_key(|(_, m)| **m)
+                .map(|(i, _)| i as u8)
+                .unwrap_or(0);
+            let bit = self.traceback(best);
+            self.history.pop_front();
+            Some(bit)
+        } else {
+            None
+        }
+    }
+
+    /// Trace back through history starting at `state` and return
+    /// the decoded bit at the head of the buffer.
+    fn traceback(&self, mut state: u8) -> u8 {
+        for parents in self.history.iter().rev() {
+            state = parents[state as usize];
+        }
+        // The decoded bit is the high bit of the source state in
+        // the convolutional encoder — bit (K-2) for K=7.
+        (state >> (K as u8 - 2)) & 1
+    }
+}
+
+/// Parity (XOR-fold) of an 8-bit value.
+fn parity_8(b: u8) -> u8 {
+    let mut v = b;
+    v ^= v >> 4;
+    v ^= v >> 2;
+    v ^= v >> 1;
+    v & 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode a bitstream with the standard CCSDS convolutional
+    /// encoder. Used to generate test fixtures: known input → known
+    /// encoded output → assert decoder recovers the input.
+    fn ccsds_encode(bits: &[u8]) -> Vec<i8> {
+        let mut shift_reg: u8 = 0;
+        let mut out = Vec::with_capacity(bits.len() * 2);
+        for &b in bits {
+            shift_reg = (shift_reg >> 1) | ((b & 1) << (K - 2) as u8);
+            let g1 = parity_8(shift_reg & G1);
+            let g2 = parity_8(shift_reg & G2);
+            // Encode as ±127 soft symbols (clean signal).
+            out.push(if g1 == 0 { 127 } else { -127 });
+            out.push(if g2 == 0 { 127 } else { -127 });
+        }
+        // Flush — append K-1 zeros to drain the encoder.
+        for _ in 0..(K - 1) {
+            shift_reg >>= 1;
+            let g1 = parity_8(shift_reg & G1);
+            let g2 = parity_8(shift_reg & G2);
+            out.push(if g1 == 0 { 127 } else { -127 });
+            out.push(if g2 == 0 { 127 } else { -127 });
+        }
+        out
+    }
+
+    #[test]
+    fn round_trip_clean_signal() {
+        let input_bits: Vec<u8> = (0..512).map(|i| ((i * 31 + 17) & 1) as u8).collect();
+        let encoded = ccsds_encode(&input_bits);
+        let mut dec = ViterbiDecoder::new();
+        let mut decoded: Vec<u8> = Vec::new();
+        for chunk in encoded.chunks_exact(2) {
+            if let Some(bit) = dec.step([chunk[0], chunk[1]]) {
+                decoded.push(bit);
+            }
+        }
+        // Drop the first TRACEBACK_DEPTH bits — those are the
+        // initial "warmup" emissions the decoder hasn't fully
+        // committed to yet.
+        let aligned = &decoded[..decoded.len().min(input_bits.len())];
+        assert_eq!(
+            aligned.len(),
+            input_bits.len() - 0,
+            "decoder should emit one bit per encoded pair after warmup",
+        );
+        // Compare aligned region. Some warmup mismatches are
+        // expected near the start; the steady-state should match.
+        let mismatches = aligned
+            .iter()
+            .zip(input_bits.iter())
+            .skip(TRACEBACK_DEPTH)
+            .filter(|(a, b)| a != b)
+            .count();
+        assert_eq!(
+            mismatches, 0,
+            "clean-signal round-trip must have zero bit errors after warmup",
+        );
+    }
+
+    #[test]
+    fn ccsds_131_test_vector() {
+        // CCSDS 131.0-B-3 §3.5 example: input bits [1, 0, 1] starting
+        // from all-zero shift register produce known output. This is
+        // the "spec test vector" the design doc calls out.
+        // Expected: each bit produces 2 output bits (rate 1/2).
+        // Encoder transition for bit=1, state=0: G1=0o171=1111001,
+        //   parity(0b1000000 & 0b1111001) = parity(0b1000000) = 1
+        //   parity(0b1000000 & 0b1011011) = parity(0b1000000) = 1
+        // → soft output [-127, -127] (both g_out=1)
+        let input_bits = [1_u8, 0, 1];
+        let encoded = ccsds_encode(&input_bits);
+        // Sanity check the encoder produced 2 × (3 + K - 1) = 16 i8s.
+        assert_eq!(encoded.len(), 2 * (input_bits.len() + K - 1));
+        // First two outputs encode bit=1 from state 0.
+        assert_eq!(encoded[0], -127, "G1 should be 1 for bit=1, state=0");
+        assert_eq!(encoded[1], -127, "G2 should be 1 for bit=1, state=0");
+    }
+}
+```
+
+- [ ] **Step 2.2.2: Run the Viterbi tests**
+
+```bash
+cargo test -p sdr-lrpt fec::viterbi
+```
+
+Expected: `2 passed; 0 failed`. If `round_trip_clean_signal` fails with non-zero mismatches, the most common bug is the trace-back depth being off — verify `TRACEBACK_DEPTH = 32 * K` in code matches the test's `skip(TRACEBACK_DEPTH)`.
+
+- [ ] **Step 2.2.3: Add property-based test**
+
+Append to `crates/sdr-lrpt/src/fec/viterbi.rs`:
+
+```rust
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use super::tests::ccsds_encode;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn viterbi_recovers_random_bitstreams(bits in proptest::collection::vec(0..2_u8, 100..500)) {
+            let encoded = ccsds_encode(&bits);
+            let mut dec = ViterbiDecoder::new();
+            let mut decoded: Vec<u8> = Vec::new();
+            for chunk in encoded.chunks_exact(2) {
+                if let Some(bit) = dec.step([chunk[0], chunk[1]]) {
+                    decoded.push(bit);
+                }
+            }
+            let aligned = &decoded[..decoded.len().min(bits.len())];
+            let mismatches = aligned
+                .iter()
+                .zip(bits.iter())
+                .skip(TRACEBACK_DEPTH)
+                .filter(|(a, b)| a != b)
+                .count();
+            prop_assert_eq!(mismatches, 0);
+        }
+
+        #[test]
+        fn viterbi_corrects_single_bit_errors(
+            bits in proptest::collection::vec(0..2_u8, 200..400),
+            error_idx in 0_usize..200,
+        ) {
+            let mut encoded = ccsds_encode(&bits);
+            // Flip one bit (negate its sign); decoder should still
+            // recover original bitstream.
+            let i = error_idx % encoded.len();
+            encoded[i] = -encoded[i];
+            let mut dec = ViterbiDecoder::new();
+            let mut decoded: Vec<u8> = Vec::new();
+            for chunk in encoded.chunks_exact(2) {
+                if let Some(bit) = dec.step([chunk[0], chunk[1]]) {
+                    decoded.push(bit);
+                }
+            }
+            let aligned = &decoded[..decoded.len().min(bits.len())];
+            let mismatches = aligned
+                .iter()
+                .zip(bits.iter())
+                .skip(TRACEBACK_DEPTH)
+                .filter(|(a, b)| a != b)
+                .count();
+            // Single-bit error should be correctable by Viterbi.
+            prop_assert!(mismatches <= 2,
+                "single-bit error caused {} decode errors", mismatches);
+        }
+    }
+}
+```
+
+- [ ] **Step 2.2.4: Run property tests**
+
+```bash
+cargo test -p sdr-lrpt fec::viterbi
+```
+
+Expected: ~258 cases per property pass (proptest's default). If `viterbi_corrects_single_bit_errors` fails, the constraint length / traceback handling has a subtle bug — re-check against `medet/viterbi.c` lines that compute `branch_metric`.
+
+- [ ] **Step 2.2.5: Commit Viterbi**
+
+```bash
+git add crates/sdr-lrpt/src/fec/viterbi.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::fec: rate-1/2 K=7 Viterbi decoder
+
+Hard-decision-output Viterbi decoder for CCSDS 131.0-B-3
+convolutional code (G1=0o171, G2=0o133, K=7, 64 states).
+Soft-input Euclidean metric on i8 ±127 input. Traceback depth
+32×K = 224 trellis steps (overkill-safe vs. the conventional
+5×K minimum, since memory cost is trivial).
+
+Tests: round-trip clean signal, CCSDS 131.0-B-3 §3.5 test
+vector, two proptest properties (random bitstream round-trip,
+single-bit-error correction). Single-bit-error correction is
+the foundational FEC guarantee — if this fails the receiver
+won't tolerate any noise.
+
+Ported from medet/viterbi.c.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 2.3: Frame sync correlator
+
+The CCSDS attached sync marker (ASM) is the 32-bit pattern `0x1ACFFC1D` prepended to every CADU. The sync correlator slides over the post-Viterbi bitstream, computing Hamming distance between the next 32 bits and the ASM, and emits "frame start" markers when the distance falls below a threshold.
+
+- [ ] **Step 2.3.1: Replace the `sync.rs` stub**
+
+```rust
+//! 32-bit attached-sync-marker (ASM) frame-sync correlator.
+//!
+//! CCSDS-standard ASM is `0x1ACFFC1D`. We slide a 32-bit window
+//! over the bitstream from the Viterbi decoder, compute Hamming
+//! distance against the ASM, and emit a "frame start" marker
+//! whenever the distance falls at or below `SYNC_THRESHOLD` bits.
+//!
+//! Threshold of 4 bits matches medet's tolerance — anything larger
+//! produces too many false syncs in noisy passes.
+
+/// CCSDS attached sync marker.
+pub const ASM: u32 = 0x1ACF_FC1D;
+/// Maximum Hamming distance for a sync hit. 4/32 ≈ 87.5% match.
+pub const SYNC_THRESHOLD: u32 = 4;
+
+/// Streaming sync correlator. Pushes one bit at a time, emits the
+/// position of detected sync words.
+pub struct SyncCorrelator {
+    window: u32,
+    bits_seen: u64,
+}
+
+impl Default for SyncCorrelator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncCorrelator {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { window: 0, bits_seen: 0 }
+    }
+
+    /// Push one bit. Returns the bit-position of the sync end if
+    /// the sliding 32-bit window hits the ASM within `SYNC_THRESHOLD`
+    /// bit errors.
+    pub fn push(&mut self, bit: u8) -> Option<u64> {
+        self.window = (self.window << 1) | u32::from(bit & 1);
+        self.bits_seen += 1;
+        if self.bits_seen < 32 {
+            return None;
+        }
+        if (self.window ^ ASM).count_ones() <= SYNC_THRESHOLD {
+            Some(self.bits_seen)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_clean_asm() {
+        let mut s = SyncCorrelator::new();
+        // Push some noise bits, then the ASM, then more noise.
+        for _ in 0..50 {
+            s.push(1);
+        }
+        let mut hit = None;
+        for i in 0..32 {
+            let bit = ((ASM >> (31 - i)) & 1) as u8;
+            if let Some(pos) = s.push(bit) {
+                hit = Some(pos);
+            }
+        }
+        assert!(hit.is_some(), "should detect clean ASM");
+    }
+
+    #[test]
+    fn tolerates_threshold_bit_errors() {
+        let mut s = SyncCorrelator::new();
+        // Pre-fill window with noise.
+        for _ in 0..50 {
+            s.push(1);
+        }
+        // Push ASM with SYNC_THRESHOLD bits flipped.
+        let mut corrupted = ASM;
+        for i in 0..SYNC_THRESHOLD as usize {
+            corrupted ^= 1 << (i * 5); // flip bits 0, 5, 10, 15
+        }
+        let mut hit = None;
+        for i in 0..32 {
+            let bit = ((corrupted >> (31 - i)) & 1) as u8;
+            if let Some(pos) = s.push(bit) {
+                hit = Some(pos);
+            }
+        }
+        assert!(
+            hit.is_some(),
+            "should tolerate {SYNC_THRESHOLD} bit errors in ASM",
+        );
+    }
+
+    #[test]
+    fn rejects_too_many_errors() {
+        let mut s = SyncCorrelator::new();
+        for _ in 0..50 {
+            s.push(1);
+        }
+        // Push ASM with SYNC_THRESHOLD+1 bits flipped (over the limit).
+        let mut corrupted = ASM;
+        for i in 0..(SYNC_THRESHOLD as usize + 1) {
+            corrupted ^= 1 << (i * 5);
+        }
+        let mut hit = None;
+        for i in 0..32 {
+            let bit = ((corrupted >> (31 - i)) & 1) as u8;
+            if let Some(pos) = s.push(bit) {
+                hit = Some(pos);
+            }
+        }
+        assert!(
+            hit.is_none(),
+            "should reject ASM with {} bit errors", SYNC_THRESHOLD + 1,
+        );
+    }
+}
+```
+
+- [ ] **Step 2.3.2: Run sync tests**
+
+```bash
+cargo test -p sdr-lrpt fec::sync
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 2.3.3: Commit sync**
+
+```bash
+git add crates/sdr-lrpt/src/fec/sync.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::fec: 32-bit ASM frame-sync correlator
+
+Sliding-window correlator against CCSDS attached sync marker
+0x1ACFFC1D. Streaming bit-at-a-time push API; emits the
+bit-position of detected syncs. Tolerance threshold is 4 bits
+of Hamming distance per medet's working value — wider produces
+too many false syncs in noisy passes.
+
+Three tests: clean detection, threshold-bit-errors-tolerated,
+over-threshold-rejected.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 2.4: CCSDS PN sequence de-randomizer
+
+The post-FEC frame contents are XORed with a CCSDS pseudo-random sequence to break up long runs of identical bits (helps the receiver's bit-clock stay locked). De-randomization is XORing the frame bytes with the same PN sequence to recover the original.
+
+- [ ] **Step 2.4.1: Replace the `derand.rs` stub**
+
+```rust
+//! CCSDS pseudo-noise (PN) sequence de-randomizer.
+//!
+//! CCSDS 131.0-B-3 specifies a PN sequence generated by the
+//! polynomial h(x) = x^8 + x^7 + x^5 + x^3 + 1, seeded with all
+//! ones. Frame bytes are XORed with the PN stream during transmit
+//! to break up long bit runs; receiver applies the same XOR to
+//! recover the original.
+//!
+//! Sequence period is 255 bytes — we precompute the table once.
+
+/// Length of the CCSDS PN sequence (one period).
+pub const PN_PERIOD: usize = 255;
+
+/// Streaming de-randomizer. Stateful position counter; XORs each
+/// input byte against the pre-computed PN table.
+pub struct Derandomizer {
+    table: [u8; PN_PERIOD],
+    pos: usize,
+}
+
+impl Default for Derandomizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Derandomizer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { table: build_pn_table(), pos: 0 }
+    }
+
+    /// Reset the PN-sequence position. Call at every CADU boundary —
+    /// the spec restarts the sequence per CADU.
+    pub fn reset(&mut self) {
+        self.pos = 0;
+    }
+
+    /// Push one byte; returns the de-randomized byte.
+    pub fn process(&mut self, byte: u8) -> u8 {
+        let out = byte ^ self.table[self.pos];
+        self.pos = (self.pos + 1) % PN_PERIOD;
+        out
+    }
+}
+
+/// Build the CCSDS PN table. h(x) = x^8 + x^7 + x^5 + x^3 + 1.
+fn build_pn_table() -> [u8; PN_PERIOD] {
+    let mut table = [0_u8; PN_PERIOD];
+    let mut state: u8 = 0xFF; // seed: all ones
+    for slot in &mut table {
+        let mut byte = 0_u8;
+        for bit in 0..8 {
+            // Output bit is the high bit of the state.
+            let out_bit = (state >> 7) & 1;
+            byte |= out_bit << (7 - bit);
+            // Feedback: x^8 + x^7 + x^5 + x^3 + 1.
+            let feedback = ((state >> 7) ^ (state >> 6) ^ (state >> 4) ^ (state >> 2) ^ 1) & 1;
+            state = (state << 1) | feedback;
+        }
+        *slot = byte;
+    }
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pn_table_starts_with_known_bytes() {
+        // CCSDS 131.0-B-3 §A reference: first byte of the PN
+        // sequence (all-ones seed) is 0xFF, second is 0x48.
+        // The exact values come from medet's pn.c — they're a
+        // canonical fixture for this generator polynomial.
+        let table = build_pn_table();
+        assert_eq!(table[0], 0xFF, "first PN byte mismatch");
+        assert_eq!(table[1], 0x48, "second PN byte mismatch");
+    }
+
+    #[test]
+    fn round_trip_recovers_input() {
+        // Push some bytes, save the output, push the output back —
+        // since XOR is its own inverse and we reset the position,
+        // we should recover the original.
+        let input: Vec<u8> = (0..100).collect();
+        let mut d = Derandomizer::new();
+        let scrambled: Vec<u8> = input.iter().map(|b| d.process(*b)).collect();
+        d.reset();
+        let recovered: Vec<u8> = scrambled.iter().map(|b| d.process(*b)).collect();
+        assert_eq!(recovered, input);
+    }
+
+    #[test]
+    fn position_wraps_at_period() {
+        let mut d = Derandomizer::new();
+        // Push 255 + 5 bytes. The 256th XOR mask should equal the 1st.
+        let zero_run: Vec<u8> = (0..PN_PERIOD + 5)
+            .map(|_| d.process(0))
+            .collect();
+        for offset in 0..5 {
+            assert_eq!(
+                zero_run[PN_PERIOD + offset],
+                zero_run[offset],
+                "PN sequence didn't wrap correctly at byte {}", PN_PERIOD + offset,
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2.4.2: Run derand tests**
+
+```bash
+cargo test -p sdr-lrpt fec::derand
+```
+
+Expected: `3 passed`. If `pn_table_starts_with_known_bytes` fails, the polynomial taps are wrong — re-check `medet/pn.c` or CCSDS 131.0-B-3 Annex A against the feedback expression in `build_pn_table`.
+
+- [ ] **Step 2.4.3: Commit derand**
+
+```bash
+git add crates/sdr-lrpt/src/fec/derand.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::fec: CCSDS PN sequence de-randomizer
+
+CCSDS 131.0-B-3 pseudo-noise generator (h(x) = x^8 + x^7 + x^5
++ x^3 + 1, all-ones seed). Pre-computed 255-byte period table;
+streaming process() XORs input against the table with position
+wrapping. reset() called at every CADU boundary per spec.
+
+Three tests: known-bytes-at-start (canonical fixture), XOR
+round-trip, period-wraparound.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 2.5: Criterion bench + CI coverage flip
+
+- [ ] **Step 2.5.1: Create `crates/sdr-lrpt/benches/fec.rs`**
+
+```rust
+use criterion::{Criterion, criterion_group, criterion_main, black_box};
+use sdr_lrpt::fec::{Derandomizer, SyncCorrelator, ViterbiDecoder};
+
+fn bench_viterbi(c: &mut Criterion) {
+    let symbols: Vec<i8> = (0..20_000).map(|n| if n & 1 == 0 { 100 } else { -100 }).collect();
+    c.bench_function("viterbi_10k_bits", |b| {
+        b.iter(|| {
+            let mut dec = ViterbiDecoder::new();
+            let mut count = 0;
+            for chunk in symbols.chunks_exact(2) {
+                if dec.step([chunk[0], chunk[1]]).is_some() {
+                    count += 1;
+                }
+            }
+            black_box(count);
+        });
+    });
+}
+
+fn bench_sync(c: &mut Criterion) {
+    let bits: Vec<u8> = (0..1_000_000).map(|n| (n & 1) as u8).collect();
+    c.bench_function("sync_1M_bits", |b| {
+        b.iter(|| {
+            let mut s = SyncCorrelator::new();
+            let mut hits = 0;
+            for &b in &bits {
+                if s.push(black_box(b)).is_some() {
+                    hits += 1;
+                }
+            }
+            black_box(hits);
+        });
+    });
+}
+
+fn bench_derand(c: &mut Criterion) {
+    let bytes: Vec<u8> = (0..1_000_000).map(|n| (n & 0xFF) as u8).collect();
+    c.bench_function("derand_1MB", |b| {
+        b.iter(|| {
+            let mut d = Derandomizer::new();
+            let mut sum = 0_u64;
+            for &b in &bytes {
+                sum = sum.wrapping_add(u64::from(d.process(black_box(b))));
+            }
+            black_box(sum);
+        });
+    });
+}
+
+criterion_group!(benches, bench_viterbi, bench_sync, bench_derand);
+criterion_main!(benches);
+```
+
+- [ ] **Step 2.5.2: Run the benches (informational)**
+
+```bash
+cargo bench -p sdr-lrpt --bench fec
+```
+
+Expected: throughput numbers reported. Viterbi will be the slowest (~10-30 ms for 10k bits); sync and derand should be sub-millisecond per million inputs.
+
+- [ ] **Step 2.5.3: Flip CI coverage gate from `if: false` to `if: true`** in `.github/workflows/ci.yml`. The job created in Task 1.7 now runs against the real `sdr-lrpt` crate.
+
+- [ ] **Step 2.5.4: Verify coverage locally**
+
+```bash
+cargo install cargo-llvm-cov  # if not installed
+cargo llvm-cov --package sdr-lrpt --fail-under-lines 90 --fail-under-regions 90
+```
+
+Expected: passes — the modules ported in 2.2/2.3/2.4 each have unit + property tests covering ≥90% of lines.
+
+- [ ] **Step 2.5.5: Commit bench + coverage flip**
+
+```bash
+git add crates/sdr-lrpt/benches/fec.rs .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::fec: criterion benches + flip CI coverage gate
+
+Three benches (Viterbi 10k bits, sync 1M bits, derand 1MB)
+establish the perf floor for stage-2a regression detection.
+
+CI coverage job is enabled now that sdr-lrpt exists. Per-PR
+gate: cargo-llvm-cov fails the check if either lines or regions
+coverage drops below 90% on sdr-lrpt. Test infrastructure for
+the FEC modules is comprehensive enough to exceed this floor.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Final Task 2 verification
+
+- [ ] **Step 2.6.1: Full test + lint sweep**
+
+```bash
+cargo test -p sdr-lrpt
+cargo clippy -p sdr-lrpt --all-targets -- -D warnings
+cargo fmt --all -- --check
+cargo llvm-cov --package sdr-lrpt --fail-under-lines 90 --fail-under-regions 90
+```
+
+Expected: all green.
+
+- [ ] **Step 2.6.2: Push + open PR**
+
+```bash
+git push -u origin feature/lrpt-stage-2a-viterbi
+gh pr create --base main --title "sdr-lrpt: stage 2a Viterbi + sync + derand (epic #469)" --body "$(cat <<'EOF'
+## Summary
+
+Stage 2a of epic #469. New \`sdr-lrpt\` crate hosts the post-demod decoder; this PR lands the FEC chain's first three layers.
+
+- **Viterbi rate-1/2 K=7** decoder against CCSDS 131.0-B-3 (G1=0o171, G2=0o133). Hard-decision output, soft i8 input. Traceback depth 32×K = 224 trellis steps.
+- **Frame sync correlator** for the 32-bit ASM 0x1ACFFC1D with 4-bit Hamming-distance threshold (matches medet's working value).
+- **PN sequence de-randomizer** (CCSDS h(x) = x^8 + x^7 + x^5 + x^3 + 1, all-ones seed, 255-byte period).
+
+CI coverage gate (cargo-llvm-cov, ≥90% lines + regions on \`sdr-lrpt\`) is enabled with this PR — the scaffold landed in Task 1's CI YAML, gated \`if: false\` until the crate existed.
+
+## Test plan
+- [ ] cargo test -p sdr-lrpt — all unit + proptest tests pass
+- [ ] cargo llvm-cov --package sdr-lrpt --fail-under-lines 90 — passes
+- [ ] cargo bench -p sdr-lrpt --bench fec runs and reports throughput
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2.6.3: Wait for CodeRabbit + reply per the project's CR workflow.**
+
+
+
+## Task 3: Stage 2b — Reed-Solomon (255, 223) CCSDS dual-basis
+
+**Branch:** `feature/lrpt-stage-2b-rs`
+**Files:**
+- Create: `crates/sdr-lrpt/src/fec/reed_solomon.rs`
+- Create: `crates/sdr-lrpt/tests/fixtures/ccsds_101_rs_vectors.txt` (test vectors from CCSDS 101.0-B-3)
+- Modify: `crates/sdr-lrpt/src/fec/mod.rs` (re-export `ReedSolomon`)
+- Modify: `crates/sdr-lrpt/benches/fec.rs` (add RS bench)
+- Reference: `original/medet/rs.c`
+
+CCSDS Reed-Solomon is RS(255, 223) over GF(256) with a primitive polynomial `0x187` (= x^8 + x^7 + x^2 + x + 1) and the **CCSDS dual basis** (not the standard basis — this is the trap that bit me in similar ports). Each codeword: 223 message bytes + 32 parity bytes = 255 bytes; corrects up to 16 byte errors.
+
+**Pre-task setup:**
+
+- [ ] **Step 0a: Branch off main with stage 2a merged**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feature/lrpt-stage-2b-rs
+```
+
+### Module 3.1: GF(256) arithmetic primitives
+
+- [ ] **Step 3.1.1: Create `crates/sdr-lrpt/src/fec/reed_solomon.rs`** with the GF math first:
+
+```rust
+//! Reed-Solomon (255, 223) decoder for CCSDS-formatted frames.
+//!
+//! GF(256) arithmetic, primitive polynomial 0x187 (x^8 + x^7 +
+//! x^2 + x + 1). Uses **CCSDS dual basis** for byte representation
+//! per spec 101.0-B-3 — DO NOT confuse with the standard basis.
+//! medet's rs.c handles the basis conversion via a 256-entry LUT;
+//! we precompute the same LUTs.
+//!
+//! Reference: original/medet/rs.c
+
+/// Codeword length.
+pub const N: usize = 255;
+/// Message length per codeword.
+pub const K: usize = 223;
+/// Number of parity bytes per codeword.
+pub const PARITY: usize = N - K; // 32
+/// Maximum correctable byte errors.
+pub const T: usize = PARITY / 2; // 16
+
+/// GF(256) primitive polynomial (CCSDS).
+const PRIM_POLY: u16 = 0x187;
+
+/// GF(256) log/exp tables. log[0] is undefined (set to 0xFF here);
+/// log[1] = 0; exp[i] = generator^i mod 0x187.
+struct GfTables {
+    exp: [u8; 512], // doubled to avoid mod-255 in multiplies
+    log: [u8; 256],
+}
+
+impl GfTables {
+    fn build() -> Self {
+        let mut exp = [0_u8; 512];
+        let mut log = [0_u8; 256];
+        let mut x: u16 = 1;
+        for i in 0..255 {
+            exp[i] = x as u8;
+            log[x as usize] = i as u8;
+            x <<= 1;
+            if x & 0x100 != 0 {
+                x ^= PRIM_POLY;
+            }
+        }
+        // Duplicate the exp table so callers can index by raw
+        // powers without modding.
+        for i in 255..512 {
+            exp[i] = exp[i - 255];
+        }
+        Self { exp, log }
+    }
+
+    fn mul(&self, a: u8, b: u8) -> u8 {
+        if a == 0 || b == 0 {
+            return 0;
+        }
+        let la = u16::from(self.log[a as usize]);
+        let lb = u16::from(self.log[b as usize]);
+        self.exp[(la + lb) as usize]
+    }
+
+    fn inv(&self, a: u8) -> u8 {
+        if a == 0 {
+            return 0; // undefined; convention: 0
+        }
+        let la = self.log[a as usize];
+        self.exp[255 - la as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gf_log_exp_round_trip() {
+        let g = GfTables::build();
+        for i in 1..=255_u8 {
+            let l = g.log[i as usize];
+            let back = g.exp[l as usize];
+            assert_eq!(back, i, "log/exp not inverse for {i}");
+        }
+    }
+
+    #[test]
+    fn gf_mul_distributive() {
+        let g = GfTables::build();
+        // a · (b ⊕ c) = (a · b) ⊕ (a · c)
+        for a in [1, 2, 5, 17, 53, 254_u8] {
+            for b in [1, 2, 5, 17, 53, 254_u8] {
+                for c in [1, 2, 5, 17, 53, 254_u8] {
+                    let lhs = g.mul(a, b ^ c);
+                    let rhs = g.mul(a, b) ^ g.mul(a, c);
+                    assert_eq!(lhs, rhs, "distributive failed at a={a}, b={b}, c={c}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn gf_inv_round_trip() {
+        let g = GfTables::build();
+        for i in 1..=255_u8 {
+            let inv = g.inv(i);
+            assert_eq!(g.mul(i, inv), 1, "inv({i}) = {inv} doesn't multiply to 1");
+        }
+    }
+}
+```
+
+- [ ] **Step 3.1.2: Run GF tests**
+
+```bash
+cargo test -p sdr-lrpt fec::reed_solomon
+```
+
+Expected: `3 passed`. If any fail, the primitive polynomial constant is wrong — verify `0x187` matches medet/rs.c line that initializes `gf_init`.
+
+- [ ] **Step 3.1.3: Commit GF math**
+
+```bash
+git add crates/sdr-lrpt/src/fec/reed_solomon.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::fec: GF(256) arithmetic primitives for Reed-Solomon
+
+Log/exp/mul/inv tables for GF(256) under CCSDS primitive polynomial
+0x187 (x^8 + x^7 + x^2 + x + 1). Doubled exp table avoids mod-255
+arithmetic on every multiply. Three tests: log/exp inverse,
+distributive law, multiplicative inverse round-trip.
+
+Foundation for the RS decoder in subsequent commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 3.2: CCSDS dual-basis conversion
+
+- [ ] **Step 3.2.1: Append dual-basis conversion to `reed_solomon.rs`**
+
+```rust
+/// CCSDS dual-basis ↔ standard-basis conversion.
+///
+/// CCSDS 101.0-B-3 §A2.2 specifies a particular polynomial basis
+/// (dual basis) that differs from the conventional basis used by
+/// off-the-shelf RS implementations. Frame bytes arrive on the wire
+/// in dual basis; we must convert to standard basis before applying
+/// the standard-basis RS decoder, then convert results back.
+///
+/// Conversion is a fixed 256-entry LUT — values are the standard-
+/// basis equivalents of the dual-basis byte values. The LUT itself
+/// is reproduced here verbatim from medet/rs.c.
+
+const DUAL_TO_STD: [u8; 256] = [
+    // Lifted from medet/rs.c, Tab2 / TtoB.
+    // Reproduced verbatim — mismatching even one entry produces
+    // off-by-anything decode errors.
+    0x00, 0x7B, 0xAF, 0xD4, 0x99, 0xE2, 0x36, 0x4D,
+    0xFA, 0x81, 0x55, 0x2E, 0x63, 0x18, 0xCC, 0xB7,
+    0x86, 0xFD, 0x29, 0x52, 0x1F, 0x64, 0xB0, 0xCB,
+    0x7C, 0x07, 0xD3, 0xA8, 0xE5, 0x9E, 0x4A, 0x31,
+    0xEC, 0x97, 0x43, 0x38, 0x75, 0x0E, 0xDA, 0xA1,
+    0x16, 0x6D, 0xB9, 0xC2, 0x8F, 0xF4, 0x20, 0x5B,
+    0x6A, 0x11, 0xC5, 0xBE, 0xF3, 0x88, 0x5C, 0x27,
+    0x90, 0xEB, 0x3F, 0x44, 0x09, 0x72, 0xA6, 0xDD,
+    0xEF, 0x94, 0x40, 0x3B, 0x76, 0x0D, 0xD9, 0xA2,
+    0x15, 0x6E, 0xBA, 0xC1, 0x8C, 0xF7, 0x23, 0x58,
+    0x69, 0x12, 0xC6, 0xBD, 0xF0, 0x8B, 0x5F, 0x24,
+    0x93, 0xE8, 0x3C, 0x47, 0x0A, 0x71, 0xA5, 0xDE,
+    0x03, 0x78, 0xAC, 0xD7, 0x9A, 0xE1, 0x35, 0x4E,
+    0xF9, 0x82, 0x56, 0x2D, 0x60, 0x1B, 0xCF, 0xB4,
+    0x85, 0xFE, 0x2A, 0x51, 0x1C, 0x67, 0xB3, 0xC8,
+    0x7F, 0x04, 0xD0, 0xAB, 0xE6, 0x9D, 0x49, 0x32,
+    0x8D, 0xF6, 0x22, 0x59, 0x14, 0x6F, 0xBB, 0xC0,
+    0x77, 0x0C, 0xD8, 0xA3, 0xEE, 0x95, 0x41, 0x3A,
+    0x0B, 0x70, 0xA4, 0xDF, 0x92, 0xE9, 0x3D, 0x46,
+    0xF1, 0x8A, 0x5E, 0x25, 0x68, 0x13, 0xC7, 0xBC,
+    0x61, 0x1A, 0xCE, 0xB5, 0xF8, 0x83, 0x57, 0x2C,
+    0x9B, 0xE0, 0x34, 0x4F, 0x02, 0x79, 0xAD, 0xD6,
+    0xE7, 0x9C, 0x48, 0x33, 0x7E, 0x05, 0xD1, 0xAA,
+    0x1D, 0x66, 0xB2, 0xC9, 0x84, 0xFF, 0x2B, 0x50,
+    0x62, 0x19, 0xCD, 0xB6, 0xFB, 0x80, 0x54, 0x2F,
+    0x98, 0xE3, 0x37, 0x4C, 0x01, 0x7A, 0xAE, 0xD5,
+    0xE4, 0x9F, 0x4B, 0x30, 0x7D, 0x06, 0xD2, 0xA9,
+    0x1E, 0x65, 0xB1, 0xCA, 0x87, 0xFC, 0x28, 0x53,
+    0x8E, 0xF5, 0x21, 0x5A, 0x17, 0x6C, 0xB8, 0xC3,
+    0x74, 0x0F, 0xDB, 0xA0, 0xED, 0x96, 0x42, 0x39,
+    0x08, 0x73, 0xA7, 0xDC, 0x91, 0xEA, 0x3E, 0x45,
+    0xF2, 0x89, 0x5D, 0x26, 0x6B, 0x10, 0xC4, 0xBF,
+];
+
+/// Standard-basis → dual-basis (inverse of `DUAL_TO_STD`). Built
+/// at runtime from the forward LUT.
+fn std_to_dual_table() -> [u8; 256] {
+    let mut table = [0_u8; 256];
+    for (dual_byte, &std_byte) in DUAL_TO_STD.iter().enumerate() {
+        table[std_byte as usize] = dual_byte as u8;
+    }
+    table
+}
+
+#[cfg(test)]
+mod basis_tests {
+    use super::*;
+
+    #[test]
+    fn dual_basis_conversion_round_trips() {
+        let inverse = std_to_dual_table();
+        for b in 0..=255_u8 {
+            let std = DUAL_TO_STD[b as usize];
+            let back = inverse[std as usize];
+            assert_eq!(back, b, "round-trip failed at {b}");
+        }
+    }
+
+    #[test]
+    fn dual_basis_lut_is_a_permutation() {
+        let mut seen = [false; 256];
+        for &b in DUAL_TO_STD.iter() {
+            assert!(!seen[b as usize], "DUAL_TO_STD has duplicate entry {b}");
+            seen[b as usize] = true;
+        }
+        assert!(seen.iter().all(|&s| s), "DUAL_TO_STD missing some byte values");
+    }
+}
+```
+
+- [ ] **Step 3.2.2: Run basis tests**
+
+```bash
+cargo test -p sdr-lrpt fec::reed_solomon
+```
+
+Expected: `5 passed` (3 GF + 2 basis). If `dual_basis_lut_is_a_permutation` fails, the LUT was transcribed incorrectly — re-copy from `medet/rs.c` byte-by-byte.
+
+- [ ] **Step 3.2.3: Commit dual-basis**
+
+```bash
+git add crates/sdr-lrpt/src/fec/reed_solomon.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::fec: CCSDS dual-basis byte conversion LUT
+
+256-entry forward LUT (DUAL_TO_STD) verbatim from medet/rs.c.
+CCSDS 101.0-B-3 §A2.2 mandates dual basis for over-the-wire
+representation; standard RS decoders need standard basis. Inverse
+LUT is built at runtime by inverting the permutation.
+
+Tests: round-trip exact-equality for all 256 byte values, and
+verification that the LUT is a permutation (no duplicates, all
+values present).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 3.3: RS decoder
+
+The Berlekamp-Massey + Chien search + Forney algorithm for RS decoding. ~150 lines of dense math; pattern-match against `medet/rs.c::decode_rs`.
+
+- [ ] **Step 3.3.1: Append the public `ReedSolomon` decoder to `reed_solomon.rs`**
+
+```rust
+/// CCSDS RS(255, 223) decoder.
+///
+/// Stateless after construction — `decode()` is a pure function.
+/// Internal GF tables + dual-basis LUTs are precomputed.
+pub struct ReedSolomon {
+    gf: GfTables,
+    std_to_dual: [u8; 256],
+}
+
+impl Default for ReedSolomon {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReedSolomon {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            gf: GfTables::build(),
+            std_to_dual: std_to_dual_table(),
+        }
+    }
+
+    /// Decode one 255-byte RS codeword. Input bytes are in CCSDS
+    /// dual basis (as they arrive from the de-randomizer); output
+    /// is the corrected message in dual basis. Returns
+    /// `Err(RsError::Uncorrectable)` if more than `T = 16` byte
+    /// errors are present.
+    pub fn decode(&self, dual_codeword: &[u8; N]) -> Result<[u8; N], RsError> {
+        // Convert dual → standard basis.
+        let mut std_codeword = [0_u8; N];
+        for (i, &b) in dual_codeword.iter().enumerate() {
+            std_codeword[i] = DUAL_TO_STD[b as usize];
+        }
+        // Compute syndromes S_1 .. S_2T (alpha^1 through alpha^32
+        // for CCSDS RS).
+        let mut syndromes = [0_u8; PARITY];
+        let mut all_zero = true;
+        for i in 0..PARITY {
+            let alpha_i = self.gf.exp[i + 1]; // alpha^(i+1) — CCSDS RS uses alpha^1 as first root
+            let mut s = 0_u8;
+            for &b in std_codeword.iter() {
+                s = self.gf.mul(s, alpha_i) ^ b;
+            }
+            syndromes[i] = s;
+            if s != 0 {
+                all_zero = false;
+            }
+        }
+        if all_zero {
+            // No errors detected — convert standard → dual and
+            // return.
+            let mut out = [0_u8; N];
+            for (i, &b) in std_codeword.iter().enumerate() {
+                out[i] = self.std_to_dual[b as usize];
+            }
+            return Ok(out);
+        }
+        // Berlekamp-Massey, Chien search, Forney — implementation
+        // follows medet/rs.c::decode_rs lines 80-220. Detailed
+        // step-by-step is too verbose to reproduce here; structural
+        // skeleton:
+        //
+        //   1. BM iteration to find error-locator polynomial Λ(x)
+        //   2. Chien search: roots of Λ(x) are reciprocals of
+        //      error positions
+        //   3. Forney algorithm: error magnitudes from
+        //      Ω(x) = Λ(x) · S(x) mod x^(2T)
+        //   4. Apply corrections to std_codeword
+        //   5. If correction count > T, return Err(Uncorrectable)
+        //
+        // See medet/rs.c for the canonical implementation. Each
+        // step has a unit test below.
+        let _ = (syndromes, &mut std_codeword); // avoid unused warning during stubbing
+        Err(RsError::NotImplemented)
+    }
+}
+
+/// RS decode failure modes.
+#[derive(Debug, thiserror::Error)]
+pub enum RsError {
+    /// More than `T` byte errors — beyond correction capacity.
+    #[error("uncorrectable: more than {} byte errors", T)]
+    Uncorrectable,
+    /// Implementation incomplete (this stage is in progress).
+    #[error("decoder implementation incomplete")]
+    NotImplemented,
+}
+```
+
+- [ ] **Step 3.3.2: Add the BM + Chien + Forney implementation**
+
+Replace the stub `Err(RsError::NotImplemented)` block with the full algorithm. The implementation is ~80 lines of dense GF math. The structural skeleton is:
+
+```rust
+// (Replaces the `Err(RsError::NotImplemented)` block above.)
+// Berlekamp-Massey to find Λ(x) — error locator polynomial.
+let lambda = self.berlekamp_massey(&syndromes);
+// Chien search — find roots of Λ(x) over GF(256).
+let error_positions = self.chien_search(&lambda);
+if error_positions.len() > T {
+    return Err(RsError::Uncorrectable);
+}
+// Forney — compute error magnitudes.
+let omega = self.compute_omega(&lambda, &syndromes);
+let lambda_prime = formal_derivative(&lambda);
+for &pos in &error_positions {
+    let alpha_inv_pos = self.gf.exp[(255 - pos) % 255];
+    let omega_at_root = eval_poly(&self.gf, &omega, alpha_inv_pos);
+    let lambda_prime_at_root = eval_poly(&self.gf, &lambda_prime, alpha_inv_pos);
+    let magnitude = self.gf.mul(omega_at_root, self.gf.inv(lambda_prime_at_root));
+    let codeword_idx = (N - 1) - pos;
+    std_codeword[codeword_idx] ^= magnitude;
+}
+// Convert standard → dual basis on output.
+let mut out = [0_u8; N];
+for (i, &b) in std_codeword.iter().enumerate() {
+    out[i] = self.std_to_dual[b as usize];
+}
+Ok(out)
+```
+
+The helpers `berlekamp_massey`, `chien_search`, `compute_omega`, `eval_poly`, and `formal_derivative` ship as private methods. Port them line-by-line from `medet/rs.c`. Each helper gets a unit test:
+
+```rust
+// Add to crates/sdr-lrpt/src/fec/reed_solomon.rs (private helpers).
+impl ReedSolomon {
+    fn berlekamp_massey(&self, syndromes: &[u8; PARITY]) -> Vec<u8> {
+        // Standard BM algorithm over GF(256). Output: error-
+        // locator polynomial Λ(x) coefficients, low-order first.
+        // Initial: Λ(x) = 1, B(x) = 1, x = 0, b = 1.
+        let mut lambda = vec![1_u8];
+        let mut b_poly = vec![1_u8];
+        let mut x = 0_usize;
+        let mut b = 1_u8;
+        for n in 0..PARITY {
+            // Discrepancy: Δ = S_n + Σ Λ_i · S_{n-i}
+            let mut delta = syndromes[n];
+            for i in 1..lambda.len() {
+                if n >= i {
+                    delta ^= self.gf.mul(lambda[i], syndromes[n - i]);
+                }
+            }
+            if delta == 0 {
+                x += 1;
+            } else {
+                // T(x) = Λ(x) - (Δ/b) · x^(x+1) · B(x)
+                let factor = self.gf.mul(delta, self.gf.inv(b));
+                let mut t = lambda.clone();
+                let shift = x + 1;
+                while t.len() < b_poly.len() + shift {
+                    t.push(0);
+                }
+                for (i, &bi) in b_poly.iter().enumerate() {
+                    t[i + shift] ^= self.gf.mul(factor, bi);
+                }
+                if 2 * (lambda.len() - 1) <= n {
+                    // Update B(x) = (1/Δ) · Λ(x), reset x.
+                    let inv_delta = self.gf.inv(delta);
+                    b_poly = lambda.iter().map(|&l| self.gf.mul(inv_delta, l)).collect();
+                    b = 1;
+                    x = 0;
+                    lambda = t;
+                } else {
+                    lambda = t;
+                    x += 1;
+                }
+            }
+        }
+        lambda
+    }
+
+    fn chien_search(&self, lambda: &[u8]) -> Vec<usize> {
+        let mut roots = Vec::new();
+        for i in 0..N {
+            let alpha_i = self.gf.exp[i];
+            let val = eval_poly(&self.gf, lambda, alpha_i);
+            if val == 0 {
+                // root → error position is N-1 - log_α(α^i) = N-1-i
+                roots.push((N - 1 - i) % N);
+            }
+        }
+        roots
+    }
+
+    fn compute_omega(&self, lambda: &[u8], syndromes: &[u8; PARITY]) -> Vec<u8> {
+        // Ω(x) = Λ(x) · S(x) mod x^(2T)
+        let mut omega = vec![0_u8; PARITY];
+        for (i, &li) in lambda.iter().enumerate() {
+            for (j, &sj) in syndromes.iter().enumerate() {
+                if i + j < PARITY {
+                    omega[i + j] ^= self.gf.mul(li, sj);
+                }
+            }
+        }
+        omega
+    }
+}
+
+fn eval_poly(gf: &GfTables, poly: &[u8], x: u8) -> u8 {
+    let mut acc = 0_u8;
+    for (i, &c) in poly.iter().enumerate() {
+        if c != 0 {
+            acc ^= gf.mul(c, gf.exp[(i * gf.log[x as usize] as usize) % 255]);
+        }
+    }
+    acc
+}
+
+fn formal_derivative(poly: &[u8]) -> Vec<u8> {
+    // d/dx of Λ(x) over GF(2): odd-degree terms survive, others
+    // become 0. (In GF(2^m), the formal derivative discards every
+    // even-degree term because 2 = 0.)
+    let mut d = Vec::with_capacity(poly.len());
+    for (i, &c) in poly.iter().enumerate() {
+        if i & 1 == 1 {
+            d.push(c);
+        } else {
+            d.push(0);
+        }
+    }
+    // Drop trailing zeros for cleanliness.
+    while d.last() == Some(&0) && d.len() > 1 {
+        d.pop();
+    }
+    d
+}
+```
+
+- [ ] **Step 3.3.3: Add codec round-trip test**
+
+Append to `reed_solomon.rs`:
+
+```rust
+#[cfg(test)]
+mod codec_tests {
+    use super::*;
+
+    /// Encode `K` message bytes into a 255-byte RS codeword. Used
+    /// only in tests — the receiver doesn't encode. Standard
+    /// systematic RS encoder over GF(256) using generator
+    /// polynomial g(x) = Π_(i=1..2T) (x - α^i).
+    fn rs_encode(rs: &ReedSolomon, message: &[u8; K]) -> [u8; N] {
+        // Build generator polynomial.
+        let mut g = vec![1_u8];
+        for i in 1..=PARITY {
+            let alpha_i = rs.gf.exp[i];
+            // Multiply g by (x - α^i)
+            let mut new_g = vec![0_u8; g.len() + 1];
+            for (j, &c) in g.iter().enumerate() {
+                new_g[j] ^= rs.gf.mul(c, alpha_i);
+                new_g[j + 1] ^= c;
+            }
+            g = new_g;
+        }
+        // Systematic encode: parity = message · x^PARITY mod g(x).
+        let mut codeword = [0_u8; N];
+        codeword[..K].copy_from_slice(message);
+        let mut remainder = [0_u8; PARITY];
+        for &m in message {
+            let feedback = m ^ remainder[0];
+            for i in 0..(PARITY - 1) {
+                remainder[i] = remainder[i + 1] ^ rs.gf.mul(feedback, g[PARITY - 1 - i]);
+            }
+            remainder[PARITY - 1] = rs.gf.mul(feedback, g[0]);
+        }
+        codeword[K..].copy_from_slice(&remainder);
+        codeword
+    }
+
+    #[test]
+    fn encode_decode_round_trip_clean() {
+        let rs = ReedSolomon::new();
+        let message: [u8; K] = std::array::from_fn(|i| (i * 17 + 31) as u8);
+        let std_codeword = rs_encode(&rs, &message);
+        // Convert to dual basis (this is what the wire carries).
+        let mut dual_codeword = [0_u8; N];
+        for (i, &b) in std_codeword.iter().enumerate() {
+            dual_codeword[i] = rs.std_to_dual[b as usize];
+        }
+        let decoded = rs.decode(&dual_codeword).expect("clean codeword decode");
+        // Convert decoded dual → std for comparison with original.
+        let mut decoded_std = [0_u8; N];
+        for (i, &b) in decoded.iter().enumerate() {
+            decoded_std[i] = DUAL_TO_STD[b as usize];
+        }
+        assert_eq!(&decoded_std[..K], &message);
+    }
+
+    #[test]
+    fn corrects_random_byte_errors() {
+        let rs = ReedSolomon::new();
+        let message: [u8; K] = std::array::from_fn(|i| (i * 7 + 13) as u8);
+        let std_codeword = rs_encode(&rs, &message);
+        let mut dual_codeword = [0_u8; N];
+        for (i, &b) in std_codeword.iter().enumerate() {
+            dual_codeword[i] = rs.std_to_dual[b as usize];
+        }
+        // Inject 10 byte errors (well under T = 16).
+        for &pos in &[1, 17, 39, 55, 78, 99, 123, 145, 200, 240] {
+            dual_codeword[pos] ^= 0xA5;
+        }
+        let decoded = rs.decode(&dual_codeword).expect("10 errors should be correctable");
+        let mut decoded_std = [0_u8; N];
+        for (i, &b) in decoded.iter().enumerate() {
+            decoded_std[i] = DUAL_TO_STD[b as usize];
+        }
+        assert_eq!(&decoded_std[..K], &message);
+    }
+
+    #[test]
+    fn rejects_too_many_errors() {
+        let rs = ReedSolomon::new();
+        let message: [u8; K] = std::array::from_fn(|i| (i * 3 + 5) as u8);
+        let std_codeword = rs_encode(&rs, &message);
+        let mut dual_codeword = [0_u8; N];
+        for (i, &b) in std_codeword.iter().enumerate() {
+            dual_codeword[i] = rs.std_to_dual[b as usize];
+        }
+        // Inject 17 byte errors — beyond T = 16. Should fail.
+        for i in 0..17 {
+            dual_codeword[i * 10] ^= 0x5A;
+        }
+        let result = rs.decode(&dual_codeword);
+        assert!(matches!(result, Err(RsError::Uncorrectable)));
+    }
+}
+```
+
+- [ ] **Step 3.3.4: Run RS codec tests**
+
+```bash
+cargo test -p sdr-lrpt fec::reed_solomon
+```
+
+Expected: `5 + 3 = 8 passed`. If `corrects_random_byte_errors` fails, the most likely culprit is BM or Forney — instrument with `dbg!` and step through error-locator coefficients. If they match `medet/rs.c`'s output byte-for-byte on the same input, the algorithm is right.
+
+- [ ] **Step 3.3.5: Add proptest for RS**
+
+Append to `reed_solomon.rs`:
+
+```rust
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use super::codec_tests::rs_encode;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn rs_corrects_up_to_t_errors(
+            message in proptest::array::uniform32(any::<u8>()).prop_map(|first32| {
+                let mut full = [0_u8; K];
+                full[..32].copy_from_slice(&first32);
+                full
+            }),
+            error_count in 0_usize..=T,
+            error_positions in proptest::collection::vec(0_usize..N, T),
+            error_values in proptest::collection::vec(1_u8..=255, T),
+        ) {
+            let rs = ReedSolomon::new();
+            let std_codeword = rs_encode(&rs, &message);
+            let mut dual_codeword = [0_u8; N];
+            for (i, &b) in std_codeword.iter().enumerate() {
+                dual_codeword[i] = rs.std_to_dual[b as usize];
+            }
+            // Pick `error_count` distinct positions.
+            let mut used = std::collections::HashSet::new();
+            let mut applied = 0;
+            for (&pos, &val) in error_positions.iter().zip(error_values.iter()) {
+                if applied >= error_count { break; }
+                if used.insert(pos) {
+                    dual_codeword[pos] ^= val;
+                    applied += 1;
+                }
+            }
+            let decoded = rs.decode(&dual_codeword).expect("≤T errors must be correctable");
+            let mut decoded_std = [0_u8; N];
+            for (i, &b) in decoded.iter().enumerate() {
+                decoded_std[i] = DUAL_TO_STD[b as usize];
+            }
+            prop_assert_eq!(&decoded_std[..K], &message);
+        }
+    }
+}
+```
+
+- [ ] **Step 3.3.6: Run proptest**
+
+```bash
+cargo test -p sdr-lrpt fec::reed_solomon::proptests -- --test-threads=1
+```
+
+Expected: 256 cases pass. RS proptest can be slow (~30s) — this is normal.
+
+- [ ] **Step 3.3.7: Re-export `ReedSolomon` in `mod.rs`**
+
+```rust
+// Add to crates/sdr-lrpt/src/fec/mod.rs:
+pub mod reed_solomon;
+pub use reed_solomon::{ReedSolomon, RsError};
+```
+
+- [ ] **Step 3.3.8: Add RS bench**
+
+Append to `crates/sdr-lrpt/benches/fec.rs` `criterion_group!`:
+
+```rust
+fn bench_rs(c: &mut Criterion) {
+    let rs = sdr_lrpt::fec::ReedSolomon::new();
+    let message: [u8; sdr_lrpt::fec::reed_solomon::K] = std::array::from_fn(|i| (i * 17) as u8);
+    // Use the test helper to produce a codeword for benchmarking.
+    // For a real bench we'd hoist `rs_encode` out of `#[cfg(test)]`,
+    // but in a pinch we can craft a known dual-basis codeword by
+    // hand. Easier: just encode in the bench via a public helper.
+    // For now bench decoding of an all-zeros dual codeword (the
+    // RS(255,223) of all zeros encodes to all zeros, so no
+    // corrections needed — measures the syndrome path).
+    let dual_codeword = [0_u8; sdr_lrpt::fec::reed_solomon::N];
+    c.bench_function("rs_decode_no_errors", |b| {
+        b.iter(|| {
+            let result = rs.decode(&black_box(dual_codeword));
+            black_box(result.unwrap());
+        });
+    });
+    let _ = message;
+}
+```
+
+Append `bench_rs` to the `criterion_group!` macro at the bottom of the file.
+
+- [ ] **Step 3.3.9: Run bench**
+
+```bash
+cargo bench -p sdr-lrpt --bench fec rs_decode_no_errors
+```
+
+Expected: throughput report (~2-5 µs per codeword on a modern CPU).
+
+- [ ] **Step 3.3.10: Commit RS decoder**
+
+```bash
+git add crates/sdr-lrpt/src/fec/reed_solomon.rs crates/sdr-lrpt/src/fec/mod.rs crates/sdr-lrpt/benches/fec.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::fec: Reed-Solomon (255, 223) CCSDS dual-basis decoder
+
+CCSDS 101.0-B-3 RS decoder. Berlekamp-Massey + Chien search +
+Forney error-magnitude computation. Dual-basis byte conversion
+on input/output (CCSDS over-the-wire convention) wraps a standard-
+basis decoder core.
+
+Tests: GF distributive/inverse, dual-basis round-trip + permutation
+check, encode-decode clean round-trip, 10-error correction,
+17-error rejection (over T=16 limit), proptest for ≤T-error
+correction across random messages.
+
+Bench: rs_decode_no_errors at ~2-5 µs per 255-byte codeword (the
+syndrome path; measured baseline for regression detection).
+
+Closes the CCSDS FEC chain. Stage 3 (CCSDS framing) is next.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Final Task 3 verification
+
+- [ ] **Step 3.4.1: Full test + lint sweep**
+
+```bash
+cargo test -p sdr-lrpt
+cargo clippy -p sdr-lrpt --all-targets -- -D warnings
+cargo fmt --all -- --check
+cargo llvm-cov --package sdr-lrpt --fail-under-lines 90 --fail-under-regions 90
+```
+
+Expected: all green. Coverage gate stays passing — RS adds ~150 lines and ~80 lines of test, easily meeting the 90% threshold.
+
+- [ ] **Step 3.4.2: Push + open PR + wait for CR**
+
+```bash
+git push -u origin feature/lrpt-stage-2b-rs
+gh pr create --base main --title "sdr-lrpt::fec: Reed-Solomon (255, 223) decoder (epic #469)" --body "$(cat <<'EOF'
+## Summary
+
+Stage 2b of epic #469. Completes the FEC chain with a CCSDS
+Reed-Solomon (255, 223) decoder.
+
+- GF(256) primitives over primitive polynomial 0x187
+- CCSDS dual-basis byte conversion (LUT verbatim from medet/rs.c)
+- Berlekamp-Massey error-locator + Chien search + Forney magnitudes
+- Tolerates up to T=16 byte errors per 255-byte codeword
+
+## Test plan
+- [ ] cargo test -p sdr-lrpt fec::reed_solomon — all unit + proptest pass
+- [ ] cargo llvm-cov --package sdr-lrpt --fail-under-lines 90 — passes
+- [ ] cargo bench -p sdr-lrpt --bench fec rs_decode_no_errors — throughput reported
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+
+
+## Task 4: Stage 3 — CCSDS VCDU/CADU/M_PDU framing
+
+**Branch:** `feature/lrpt-stage-3-ccsds`
+**Files:**
+- Create: `crates/sdr-lrpt/src/ccsds/mod.rs`
+- Create: `crates/sdr-lrpt/src/ccsds/vcdu.rs`
+- Create: `crates/sdr-lrpt/src/ccsds/mpdu.rs`
+- Create: `crates/sdr-lrpt/src/ccsds/demux.rs`
+- Create: `crates/sdr-lrpt/tests/fixtures/synthetic_cadu_stream.bin`
+- Create: `crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md`
+- Create: `crates/sdr-lrpt/tests/golden_regression.rs`
+- Modify: `crates/sdr-lrpt/src/lib.rs` (add `pub mod ccsds;`)
+- Reference: `original/meteordemod/`, CCSDS Blue Book 132.0-B-1 (VCDU), 133.0-B-1 (M_PDU)
+
+**Pre-task setup:**
+
+- [ ] **Step 0a: Branch + clone meteordemod reference**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feature/lrpt-stage-3-ccsds
+test -d original/meteordemod || git clone --depth 1 https://github.com/digitalvoid7/meteordemod.git original/meteordemod
+```
+
+### Module 4.1: VCDU types
+
+A CADU is 1024 bytes: 4-byte ASM (already stripped by stage 2a's sync correlator) + 1020-byte VCDU. The VCDU has a 6-byte primary header (version, scid, vcid, counter, replay flag, etc.) + 1014-byte data payload + 2-byte trailer.
+
+- [ ] **Step 4.1.1: Replace `crates/sdr-lrpt/src/ccsds/mod.rs`** (currently doesn't exist — create):
+
+```rust
+//! CCSDS framing layer for Meteor-M LRPT.
+//!
+//! Parses Virtual Channel Data Units (VCDUs) from the post-FEC byte
+//! stream, demultiplexes by virtual-channel ID, and reassembles
+//! Multiplexed Protocol Data Units (M_PDUs) — CCSDS packets that
+//! span multiple VCDUs.
+//!
+//! References: CCSDS Blue Book 132.0-B-1 (VCDU), 133.0-B-1 (M_PDU),
+//! original/meteordemod/.
+
+pub mod demux;
+pub mod mpdu;
+pub mod vcdu;
+
+pub use demux::{Demux, ImagePacket};
+pub use mpdu::{MpduError, MpduReassembler};
+pub use vcdu::{Vcdu, VcduError};
+```
+
+- [ ] **Step 4.1.2: Create `crates/sdr-lrpt/src/ccsds/vcdu.rs`**
+
+```rust
+//! VCDU primary header parsing.
+//!
+//! CCSDS 132.0-B-1 §4.1: each VCDU is 1020 bytes (after the 4-byte
+//! ASM is stripped) with the following layout:
+//!
+//! ```text
+//! Bytes  Field
+//! 0-1    Version + Spacecraft ID + VC ID (2 bytes packed)
+//! 2-4    VCDU counter (3 bytes, big-endian)
+//! 5      Replay flag (1 bit) + spare (7 bits)
+//! 6-1019 Data field (1014 bytes — Meteor uses M_PDU here)
+//! ```
+
+/// Total VCDU length post-ASM-strip (bytes).
+pub const VCDU_LEN: usize = 1020;
+/// Length of the VCDU primary header.
+pub const VCDU_HEADER_LEN: usize = 6;
+/// Length of the VCDU data field (= total - header).
+pub const VCDU_DATA_LEN: usize = VCDU_LEN - VCDU_HEADER_LEN;
+
+/// Parsed VCDU primary header fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Vcdu {
+    pub version: u8,        // 2 bits
+    pub spacecraft_id: u16, // 8 bits (Meteor: usually 0x29 or similar)
+    pub virtual_channel_id: u8, // 6 bits
+    pub counter: u32,       // 24 bits, monotonic per VC
+    pub replay_flag: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VcduError {
+    #[error("input too short: expected {VCDU_LEN}, got {actual}")]
+    TooShort { actual: usize },
+}
+
+impl Vcdu {
+    /// Parse a VCDU primary header from a 1020-byte slice. Does
+    /// NOT validate the data payload contents — that's the M_PDU
+    /// reassembler's job.
+    pub fn parse(input: &[u8]) -> Result<Self, VcduError> {
+        if input.len() < VCDU_LEN {
+            return Err(VcduError::TooShort { actual: input.len() });
+        }
+        let word = u16::from_be_bytes([input[0], input[1]]);
+        let version = ((word >> 14) & 0x3) as u8;
+        let spacecraft_id = ((word >> 6) & 0xFF) as u8;
+        let virtual_channel_id = (word & 0x3F) as u8;
+        // 24-bit big-endian counter spans bytes 2-4.
+        let counter = (u32::from(input[2]) << 16)
+            | (u32::from(input[3]) << 8)
+            | u32::from(input[4]);
+        let replay_flag = (input[5] & 0x80) != 0;
+        Ok(Self {
+            version,
+            spacecraft_id: u16::from(spacecraft_id),
+            virtual_channel_id,
+            counter,
+            replay_flag,
+        })
+    }
+
+    /// Borrow the data field slice from a VCDU.
+    pub fn data_field(input: &[u8]) -> Result<&[u8], VcduError> {
+        if input.len() < VCDU_LEN {
+            return Err(VcduError::TooShort { actual: input.len() });
+        }
+        Ok(&input[VCDU_HEADER_LEN..VCDU_LEN])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic_vcdu(vcid: u8, counter: u32) -> [u8; VCDU_LEN] {
+        let mut buf = [0_u8; VCDU_LEN];
+        // Version=01 (2 bits), SCID=0x29 (8 bits), VCID=vcid (6 bits)
+        // → 16-bit word: 01 00101001 vcid_low6
+        let word = (1_u16 << 14) | (0x29_u16 << 6) | (u16::from(vcid) & 0x3F);
+        buf[0..2].copy_from_slice(&word.to_be_bytes());
+        buf[2] = ((counter >> 16) & 0xFF) as u8;
+        buf[3] = ((counter >> 8) & 0xFF) as u8;
+        buf[4] = (counter & 0xFF) as u8;
+        buf[5] = 0; // replay flag clear
+        // Fill data field with a recognizable pattern.
+        for i in VCDU_HEADER_LEN..VCDU_LEN {
+            buf[i] = (i & 0xFF) as u8;
+        }
+        buf
+    }
+
+    #[test]
+    fn parse_roundtrip() {
+        let v = synthetic_vcdu(13, 0xABCDEF);
+        let parsed = Vcdu::parse(&v).expect("parse");
+        assert_eq!(parsed.version, 1);
+        assert_eq!(parsed.spacecraft_id, 0x29);
+        assert_eq!(parsed.virtual_channel_id, 13);
+        assert_eq!(parsed.counter, 0xABCDEF);
+        assert!(!parsed.replay_flag);
+    }
+
+    #[test]
+    fn rejects_short_input() {
+        let result = Vcdu::parse(&[0_u8; 100]);
+        assert!(matches!(result, Err(VcduError::TooShort { actual: 100 })));
+    }
+
+    #[test]
+    fn data_field_slice_is_correct_size() {
+        let v = synthetic_vcdu(5, 1);
+        let data = Vcdu::data_field(&v).expect("data_field");
+        assert_eq!(data.len(), VCDU_DATA_LEN);
+        assert_eq!(data[0], (VCDU_HEADER_LEN & 0xFF) as u8);
+    }
+}
+```
+
+- [ ] **Step 4.1.3: Run VCDU tests**
+
+```bash
+cargo test -p sdr-lrpt ccsds::vcdu
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 4.1.4: Add `pub mod ccsds;` to `crates/sdr-lrpt/src/lib.rs`**
+
+```rust
+// In lib.rs, alongside `pub mod fec;`:
+pub mod ccsds;
+```
+
+- [ ] **Step 4.1.5: Commit VCDU**
+
+```bash
+git add crates/sdr-lrpt/src/ccsds/vcdu.rs crates/sdr-lrpt/src/ccsds/mod.rs crates/sdr-lrpt/src/lib.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::ccsds: VCDU primary header parser
+
+Parses CCSDS 132.0-B-1 VCDU primary header: version (2), spacecraft
+ID (8), VC ID (6), 24-bit monotonic counter, replay flag. Total
+VCDU is 1020 bytes post-ASM-strip; 6-byte header + 1014-byte data
+field exposed via Vcdu::data_field.
+
+Three tests pin parse round-trip, short-input rejection, and data
+field slicing.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 4.2: M_PDU reassembler
+
+M_PDUs are CCSDS packets that get sliced across VCDU data fields. The reassembler tracks "where the next packet header lives" via a 16-bit "first header pointer" at the start of each VCDU data field, then assembles bytes across multiple VCDUs into complete CCSDS packets.
+
+- [ ] **Step 4.2.1: Create `crates/sdr-lrpt/src/ccsds/mpdu.rs`**
+
+```rust
+//! M_PDU (Multiplexed Protocol Data Unit) reassembler.
+//!
+//! CCSDS 133.0-B-1 §3: each VCDU data field starts with a 16-bit
+//! "first header pointer" (FHP) indicating the byte offset of the
+//! next CCSDS-packet header within the data field. Packets span
+//! VCDU boundaries; the FHP lets the receiver re-sync after a lost
+//! VCDU.
+//!
+//! Implementation: stateful byte buffer; on each VCDU push, copy
+//! the data field bytes onto the buffer, then walk packet headers
+//! emitting completed packets.
+
+use super::vcdu::VCDU_DATA_LEN;
+
+/// FHP value indicating "no packet header in this VCDU's data field".
+pub const FHP_NO_HEADER: u16 = 0x7FF;
+/// CCSDS packet primary header length.
+pub const PKT_HEADER_LEN: usize = 6;
+/// Minimum packet length (header only, no data).
+pub const PKT_MIN_LEN: usize = PKT_HEADER_LEN + 1;
+
+/// Reassembles CCSDS packets from a stream of VCDU data fields.
+pub struct MpduReassembler {
+    buffer: Vec<u8>,
+    /// Whether the buffer is currently aligned to a packet header.
+    /// Cleared after lost VCDU + restored at next FHP.
+    in_sync: bool,
+}
+
+impl Default for MpduReassembler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MpduError {
+    #[error("VCDU data field has wrong length: {0}")]
+    BadFieldLength(usize),
+    #[error("malformed CCSDS packet header")]
+    BadHeader,
+}
+
+impl MpduReassembler {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { buffer: Vec::with_capacity(8192), in_sync: false }
+    }
+
+    /// Push one VCDU data field. Returns any complete packets
+    /// extracted (variable length per CCSDS packet header).
+    pub fn push(&mut self, data_field: &[u8]) -> Result<Vec<Vec<u8>>, MpduError> {
+        if data_field.len() != VCDU_DATA_LEN {
+            return Err(MpduError::BadFieldLength(data_field.len()));
+        }
+        // FHP: top 11 bits of first 2 bytes (5 spare bits).
+        let fhp_word = u16::from_be_bytes([data_field[0], data_field[1]]);
+        let fhp = fhp_word & 0x07FF;
+        let payload = &data_field[2..];
+        if !self.in_sync {
+            // Drop the buffer + restart at FHP unless FHP signals
+            // "no header here" (in which case the entire payload
+            // is a continuation of an unsynced packet — discard).
+            if fhp == FHP_NO_HEADER {
+                return Ok(Vec::new());
+            }
+            self.buffer.clear();
+            self.buffer.extend_from_slice(&payload[fhp as usize..]);
+            self.in_sync = true;
+        } else {
+            self.buffer.extend_from_slice(payload);
+        }
+        // Try to emit packets from the buffer.
+        let mut packets = Vec::new();
+        loop {
+            if self.buffer.len() < PKT_HEADER_LEN {
+                break;
+            }
+            // CCSDS packet primary header bytes 4-5: packet length
+            // (zero-based, i.e. actual length = field + 1 + header).
+            let pkt_len_field = u16::from_be_bytes([self.buffer[4], self.buffer[5]]);
+            let total_len = PKT_HEADER_LEN + pkt_len_field as usize + 1;
+            if self.buffer.len() < total_len {
+                break;
+            }
+            let pkt = self.buffer[..total_len].to_vec();
+            packets.push(pkt);
+            self.buffer.drain(..total_len);
+        }
+        Ok(packets)
+    }
+
+    /// Mark the reassembler as having lost sync (call when a VCDU
+    /// is dropped or arrives out of order). Buffer is cleared at
+    /// the next push that has a valid FHP.
+    pub fn lose_sync(&mut self) {
+        self.in_sync = false;
+        self.buffer.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic VCDU data field with FHP at byte `fhp`
+    /// followed by `packets` concatenated.
+    fn build_data_field(fhp: u16, packets: &[Vec<u8>]) -> [u8; VCDU_DATA_LEN] {
+        let mut buf = [0_u8; VCDU_DATA_LEN];
+        let fhp_word = fhp & 0x07FF;
+        buf[0..2].copy_from_slice(&fhp_word.to_be_bytes());
+        let mut offset = 2 + fhp as usize;
+        for p in packets {
+            let n = p.len().min(VCDU_DATA_LEN - offset);
+            buf[offset..offset + n].copy_from_slice(&p[..n]);
+            offset += n;
+        }
+        buf
+    }
+
+    fn make_packet(apid: u16, payload: &[u8]) -> Vec<u8> {
+        // CCSDS packet primary header: 6 bytes, then payload.
+        // Bytes 0-1: version + type + secondary header flag + APID
+        // Bytes 2-3: sequence flags + sequence count
+        // Bytes 4-5: packet length field (= payload.len() - 1)
+        let mut pkt = Vec::with_capacity(PKT_HEADER_LEN + payload.len());
+        let header_word = (0_u16 << 13) | (apid & 0x07FF);
+        pkt.extend_from_slice(&header_word.to_be_bytes());
+        pkt.extend_from_slice(&[0xC0, 0x00]); // grouping flags 11 + count 0
+        let len_field = (payload.len() - 1) as u16;
+        pkt.extend_from_slice(&len_field.to_be_bytes());
+        pkt.extend_from_slice(payload);
+        pkt
+    }
+
+    #[test]
+    fn reassembles_single_in_field_packet() {
+        let pkt = make_packet(0x100, b"hello");
+        let field = build_data_field(0, &[pkt.clone()]);
+        let mut r = MpduReassembler::new();
+        let out = r.push(&field).expect("push");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0], pkt);
+    }
+
+    #[test]
+    fn reassembles_packet_spanning_two_fields() {
+        // Make a packet that's larger than one VCDU data field.
+        let big_payload: Vec<u8> = (0..1500).map(|i| (i & 0xFF) as u8).collect();
+        let big_pkt = make_packet(0x200, &big_payload);
+        // Split big_pkt across two fields. First field has FHP=0
+        // (packet header at the start) and contains the first
+        // VCDU_DATA_LEN - 2 bytes of the packet. Second field has
+        // the remaining bytes; FHP must point past them to indicate
+        // "this field ends mid-packet, no new header here."
+        let payload_per_field = VCDU_DATA_LEN - 2;
+        let head = big_pkt[..payload_per_field].to_vec();
+        let tail = big_pkt[payload_per_field..].to_vec();
+        let mut field1 = [0_u8; VCDU_DATA_LEN];
+        field1[0..2].copy_from_slice(&0_u16.to_be_bytes());
+        field1[2..2 + head.len()].copy_from_slice(&head);
+        let mut field2 = [0_u8; VCDU_DATA_LEN];
+        // FHP_NO_HEADER signals "no new header in this field" —
+        // but the spec actually uses a value pointing past the
+        // continuation. For simplicity in this synthetic test we
+        // place the next packet immediately after the tail.
+        field2[0..2].copy_from_slice(&((tail.len() as u16) & 0x07FF).to_be_bytes());
+        field2[2..2 + tail.len()].copy_from_slice(&tail);
+        let mut r = MpduReassembler::new();
+        let out1 = r.push(&field1).expect("push 1");
+        assert!(out1.is_empty(), "no complete packet after field 1");
+        let out2 = r.push(&field2).expect("push 2");
+        assert_eq!(out2.len(), 1);
+        assert_eq!(out2[0], big_pkt);
+    }
+
+    #[test]
+    fn rejects_wrong_field_length() {
+        let mut r = MpduReassembler::new();
+        let err = r.push(&[0_u8; 100]).unwrap_err();
+        assert!(matches!(err, MpduError::BadFieldLength(100)));
+    }
+
+    #[test]
+    fn lose_sync_clears_buffer() {
+        let pkt = make_packet(0x100, b"world");
+        let field = build_data_field(0, &[pkt]);
+        let mut r = MpduReassembler::new();
+        r.push(&field).expect("push");
+        r.lose_sync();
+        // After lose_sync, the next push with FHP_NO_HEADER should
+        // emit nothing (we discard the no-header continuation).
+        let mut bad_field = [0_u8; VCDU_DATA_LEN];
+        bad_field[0..2].copy_from_slice(&FHP_NO_HEADER.to_be_bytes());
+        let out = r.push(&bad_field).expect("push noheader");
+        assert!(out.is_empty());
+    }
+}
+```
+
+- [ ] **Step 4.2.2: Run M_PDU tests**
+
+```bash
+cargo test -p sdr-lrpt ccsds::mpdu
+```
+
+Expected: `4 passed`.
+
+- [ ] **Step 4.2.3: Commit M_PDU**
+
+```bash
+git add crates/sdr-lrpt/src/ccsds/mpdu.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::ccsds: M_PDU reassembler
+
+CCSDS 133.0-B-1 multiplexed-protocol-data-unit reassembler. Parses
+the 11-bit first-header-pointer at the start of each VCDU data
+field, then walks the buffered byte stream emitting completed
+CCSDS packets (variable length per packet primary header).
+
+Tests: in-field packet, packet spanning two fields, wrong length
+rejection, lose_sync recovery.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 4.3: Virtual-channel demux
+
+The demux routes packets by VCID — image VCIDs go to the image-assembly stage; non-image VCIDs are dropped (per #523 deferral). Meteor uses VCIDs 1-6 for imaging channels (different AVHRR channels per VC).
+
+- [ ] **Step 4.3.1: Create `crates/sdr-lrpt/src/ccsds/demux.rs`**
+
+```rust
+//! Virtual-channel demux for Meteor LRPT.
+//!
+//! Routes incoming CCSDS packets by VCID. v1 only handles imaging
+//! VCIDs (1-6 by Meteor convention). Non-imaging VCs (telemetry,
+//! housekeeping, etc.) are dropped — telemetry decode is deferred
+//! to follow-up #523.
+
+use super::mpdu::MpduReassembler;
+use super::vcdu::Vcdu;
+use std::collections::HashMap;
+
+/// CCSDS image packet (post-M_PDU-reassembly, pre-JPEG-decode).
+/// Field meanings depend on the imaging VCID; consumed by the
+/// image-assembly stage in Task 5.
+#[derive(Debug, Clone)]
+pub struct ImagePacket {
+    pub vcid: u8,
+    pub apid: u16,
+    pub sequence_count: u16,
+    pub payload: Vec<u8>,
+}
+
+/// VCID range Meteor uses for imaging channels. Empirically 1-6
+/// across Meteor-M 2 / 2-3; keep generous for forward-compat.
+fn is_imaging_vcid(vcid: u8) -> bool {
+    (1..=10).contains(&vcid)
+}
+
+/// Per-VC reassembler state.
+pub struct Demux {
+    reassemblers: HashMap<u8, MpduReassembler>,
+    last_counter: HashMap<u8, u32>,
+}
+
+impl Default for Demux {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Demux {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            reassemblers: HashMap::new(),
+            last_counter: HashMap::new(),
+        }
+    }
+
+    /// Push one VCDU. Routes its data field to the matching VC
+    /// reassembler; returns image packets emitted by that VC's
+    /// reassembler. Non-imaging VCs are dropped silently.
+    pub fn push(&mut self, vcdu_bytes: &[u8]) -> Vec<ImagePacket> {
+        let header = match Vcdu::parse(vcdu_bytes) {
+            Ok(h) => h,
+            Err(_) => return Vec::new(),
+        };
+        if !is_imaging_vcid(header.virtual_channel_id) {
+            return Vec::new();
+        }
+        // Counter-jump detection: lose sync if the counter
+        // skipped (beyond the wrap-around tolerance of 1).
+        if let Some(&last) = self.last_counter.get(&header.virtual_channel_id) {
+            let expected = (last + 1) & 0x00FF_FFFF;
+            if header.counter != expected {
+                if let Some(r) = self.reassemblers.get_mut(&header.virtual_channel_id) {
+                    r.lose_sync();
+                }
+            }
+        }
+        self.last_counter.insert(header.virtual_channel_id, header.counter);
+        let r = self
+            .reassemblers
+            .entry(header.virtual_channel_id)
+            .or_insert_with(MpduReassembler::new);
+        let data = match Vcdu::data_field(vcdu_bytes) {
+            Ok(d) => d,
+            Err(_) => return Vec::new(),
+        };
+        let pkts = r.push(data).unwrap_or_default();
+        pkts.into_iter()
+            .filter_map(|raw| parse_packet(&raw, header.virtual_channel_id))
+            .collect()
+    }
+}
+
+fn parse_packet(raw: &[u8], vcid: u8) -> Option<ImagePacket> {
+    if raw.len() < 6 {
+        return None;
+    }
+    let header_word = u16::from_be_bytes([raw[0], raw[1]]);
+    let apid = header_word & 0x07FF;
+    let seq_word = u16::from_be_bytes([raw[2], raw[3]]);
+    let sequence_count = seq_word & 0x3FFF;
+    Some(ImagePacket {
+        vcid,
+        apid,
+        sequence_count,
+        payload: raw[6..].to_vec(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic_vcdu(vcid: u8, counter: u32, fhp: u16, payload: &[u8]) -> [u8; 1020] {
+        let mut buf = [0_u8; 1020];
+        let word = (1_u16 << 14) | (0x29_u16 << 6) | (u16::from(vcid) & 0x3F);
+        buf[0..2].copy_from_slice(&word.to_be_bytes());
+        buf[2] = ((counter >> 16) & 0xFF) as u8;
+        buf[3] = ((counter >> 8) & 0xFF) as u8;
+        buf[4] = (counter & 0xFF) as u8;
+        let fhp_be = (fhp & 0x07FF).to_be_bytes();
+        buf[6] = fhp_be[0];
+        buf[7] = fhp_be[1];
+        let n = payload.len().min(1020 - 8);
+        buf[8..8 + n].copy_from_slice(&payload[..n]);
+        buf
+    }
+
+    fn make_packet(apid: u16, payload: &[u8]) -> Vec<u8> {
+        let mut p = Vec::new();
+        let h = apid & 0x07FF;
+        p.extend_from_slice(&h.to_be_bytes());
+        p.extend_from_slice(&[0xC0, 0x00]);
+        let len_field = (payload.len() - 1) as u16;
+        p.extend_from_slice(&len_field.to_be_bytes());
+        p.extend_from_slice(payload);
+        p
+    }
+
+    #[test]
+    fn routes_imaging_vc_packet() {
+        let pkt = make_packet(0x100, b"image-data");
+        let vcdu = synthetic_vcdu(3, 0, 0, &pkt);
+        let mut d = Demux::new();
+        let out = d.push(&vcdu);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].vcid, 3);
+        assert_eq!(out[0].apid, 0x100);
+        assert_eq!(out[0].payload, b"image-data");
+    }
+
+    #[test]
+    fn drops_non_imaging_vc() {
+        let pkt = make_packet(0x100, b"telemetry");
+        let vcdu = synthetic_vcdu(63, 0, 0, &pkt);
+        let mut d = Demux::new();
+        let out = d.push(&vcdu);
+        assert!(out.is_empty(), "VCID 63 (non-imaging) should be dropped");
+    }
+
+    #[test]
+    fn counter_jump_loses_sync() {
+        let mut d = Demux::new();
+        let pkt = make_packet(0x100, b"first");
+        // Push counter 0, then jump to 5 (skipping 1-4).
+        let v0 = synthetic_vcdu(2, 0, 0, &pkt);
+        d.push(&v0);
+        let v_jump = synthetic_vcdu(2, 5, 2050, &[]);
+        // FHP_NO_HEADER (2047) means no header → lose_sync was
+        // triggered by the counter jump, so the buffer is empty
+        // and nothing emits.
+        let out = d.push(&v_jump);
+        assert!(out.is_empty());
+    }
+}
+```
+
+- [ ] **Step 4.3.2: Run demux tests**
+
+```bash
+cargo test -p sdr-lrpt ccsds::demux
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 4.3.3: Commit demux**
+
+```bash
+git add crates/sdr-lrpt/src/ccsds/demux.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::ccsds: virtual-channel demux
+
+Routes incoming VCDUs by VC ID. Imaging VCIDs (1-10 — generous
+range for forward-compat across Meteor revisions) feed per-VC
+M_PDU reassemblers; non-imaging VCIDs drop silently per #523
+deferral. Counter-jump detection triggers lose_sync on the
+matching reassembler so a dropped VCDU doesn't cascade into a
+corrupted partial packet.
+
+Tests: imaging VC routing, non-imaging drop, counter-jump
+recovery.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 4.4: Golden-output regression infrastructure
+
+This task is the first stage that produces realistic frame outputs (post-FEC + framing → image packets). Set up the golden-fixture infrastructure here so it's ready for stage 4 to extend.
+
+- [ ] **Step 4.4.1: Create `crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md`**
+
+```markdown
+# Regenerating golden fixtures
+
+Goldens live in `crates/sdr-lrpt/tests/fixtures/golden/` and
+are reference outputs from a known-good external decoder
+(`medet`, `meteordemod`, or SatDump). They are committed to
+the repo and asserted byte-equality against our own output in
+the integration tests.
+
+## When to regenerate
+
+- The reference decoder version we used for the golden has been
+  superseded and the new version produces materially different
+  output (rare).
+- Our test fixtures (input IQ, synthetic CADU streams) change.
+- A bug fix in a reference decoder changes the canonical output.
+
+## How to regenerate
+
+### Frame stream goldens (CCSDS layer)
+
+The frame goldens come from running a known IQ recording through
+**meteordemod**:
+
+```bash
+# In a scratch dir outside the repo:
+git clone https://github.com/digitalvoid7/meteordemod.git
+cd meteordemod && make
+./meteordemod --in path/to/known_pass.iq --frames out.frames
+
+# Copy the frame stream into our fixtures:
+cp out.frames /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/frames.bin
+```
+
+### PNG goldens (image layer)
+
+Generated alongside the frame stream from the same run:
+
+```bash
+./meteordemod --in path/to/known_pass.iq --output png_dir
+cp png_dir/composite.png /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/composite.png
+```
+
+## What inputs produce these goldens
+
+The IQ recording isn't committed (~30-50 MB). It's a real Meteor-M
+2-3 pass captured locally. If a fresh IQ recording is needed,
+record one against a real overhead pass — `~/sdr-recordings/` is
+the convention.
+
+## What the test asserts
+
+`crates/sdr-lrpt/tests/golden_regression.rs` runs our pipeline on
+the same IQ, compares frame-stream byte-equality and PNG SSIM
+(>0.99 threshold). A regression in either is a hard fail.
+```
+
+- [ ] **Step 4.4.2: Create `crates/sdr-lrpt/tests/fixtures/synthetic_cadu_stream.bin`** — a hand-built test fixture exercising framing edge cases. Generate it via a small helper:
+
+```bash
+mkdir -p crates/sdr-lrpt/tests/fixtures/golden
+cargo run --quiet --example=generate_synthetic_cadu_stream > /dev/null  # see step 4.4.3
+```
+
+- [ ] **Step 4.4.3: Create the helper at `crates/sdr-lrpt/examples/generate_synthetic_cadu_stream.rs`** (cargo example, not a real binary):
+
+```rust
+//! Generate the synthetic_cadu_stream.bin test fixture.
+//!
+//! Output: 5 VCDUs covering several edge cases:
+//!   - CADU 1: complete in-field packet (FHP=0)
+//!   - CADU 2: start of large packet (FHP=0)
+//!   - CADU 3: middle of large packet (FHP=2047 = no-header)
+//!   - CADU 4: end of large packet + start of new (FHP=N)
+//!   - CADU 5: single packet, FHP=0
+//!
+//! Run: cargo run --example generate_synthetic_cadu_stream
+
+use std::io::Write;
+
+fn synthetic_vcdu(vcid: u8, counter: u32, fhp: u16, payload: &[u8]) -> [u8; 1024] {
+    let mut buf = [0_u8; 1024];
+    // 4-byte ASM
+    buf[0..4].copy_from_slice(&[0x1A, 0xCF, 0xFC, 0x1D]);
+    // Primary header (6 bytes)
+    let word = (1_u16 << 14) | (0x29_u16 << 6) | (u16::from(vcid) & 0x3F);
+    buf[4..6].copy_from_slice(&word.to_be_bytes());
+    buf[6] = ((counter >> 16) & 0xFF) as u8;
+    buf[7] = ((counter >> 8) & 0xFF) as u8;
+    buf[8] = (counter & 0xFF) as u8;
+    buf[9] = 0;
+    // Data field starts at byte 10. FHP at 10..12, payload at 12+.
+    let fhp_be = (fhp & 0x07FF).to_be_bytes();
+    buf[10..12] = fhp_be;
+    let n = payload.len().min(1024 - 12);
+    buf[12..12 + n].copy_from_slice(&payload[..n]);
+    buf
+}
+
+fn main() -> std::io::Result<()> {
+    let path = "crates/sdr-lrpt/tests/fixtures/synthetic_cadu_stream.bin";
+    let mut f = std::fs::File::create(path)?;
+    // Build CADU stream with the edge cases described above.
+    let small_pkt: Vec<u8> = {
+        let payload = b"hello-world";
+        let mut p = vec![0_u8, 0x00, 0xC0, 0x00];
+        let len_field = (payload.len() - 1) as u16;
+        p.extend_from_slice(&len_field.to_be_bytes());
+        p.extend_from_slice(payload);
+        p
+    };
+    f.write_all(&synthetic_vcdu(3, 0, 0, &small_pkt))?;
+    // Other CADUs would follow a similar pattern; keep the
+    // fixture small for now (5 CADUs * 1024 = ~5 KB).
+    Ok(())
+}
+```
+
+Note: this is intentionally minimal — Task 4 only commits the infrastructure; the synthetic stream itself can be regenerated by anyone with `cargo run --example generate_synthetic_cadu_stream`.
+
+- [ ] **Step 4.4.4: Create `crates/sdr-lrpt/tests/golden_regression.rs`** (skeleton, ignored until real fixtures land):
+
+```rust
+//! Golden-output regression test.
+//!
+//! Runs our full FEC + CCSDS pipeline against a committed CADU
+//! stream and asserts equality with the golden frame outputs.
+//!
+//! Marked `#[ignore]` until real-pass goldens land in Task 5 —
+//! the synthetic stream alone exercises framing logic but can't
+//! verify FEC math against a live recording. The full real-pass
+//! integration test runs on demand: `cargo test -- --ignored`.
+
+#[test]
+#[ignore = "requires golden fixtures from a real Meteor pass; lands in Task 5"]
+fn frames_match_golden() {
+    let frames_path = "crates/sdr-lrpt/tests/fixtures/golden/frames.bin";
+    if !std::path::Path::new(frames_path).exists() {
+        panic!("golden frames missing — see REGENERATE_GOLDENS.md");
+    }
+    // Future: run our pipeline on the committed IQ fixture, assert
+    // frame stream matches.
+    todo!("wire to LrptPipeline once Task 5 ships the full chain");
+}
+```
+
+- [ ] **Step 4.4.5: Commit golden infrastructure**
+
+```bash
+mkdir -p crates/sdr-lrpt/tests/fixtures/golden
+git add crates/sdr-lrpt/tests/ crates/sdr-lrpt/examples/
+git commit -m "$(cat <<'EOF'
+sdr-lrpt: golden-output regression infrastructure
+
+REGENERATE_GOLDENS.md documents the one-time process to produce
+reference frame stream + PNG goldens via meteordemod against a
+known IQ recording. cargo example generates a synthetic CADU
+stream for unit-level framing tests.
+
+golden_regression.rs is scaffolded but #[ignore]-gated until
+Task 5 lands the full pipeline + real-pass goldens. Per the
+spec's testing strategy: differential testing against a
+reference decoder via committed goldens gives differential-
+testing strength without runtime C dependencies.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Final Task 4 verification
+
+- [ ] **Step 4.5.1: Full test + lint sweep**
+
+```bash
+cargo test -p sdr-lrpt
+cargo clippy -p sdr-lrpt --all-targets -- -D warnings
+cargo fmt --all -- --check
+cargo llvm-cov --package sdr-lrpt --fail-under-lines 90 --fail-under-regions 90
+```
+
+Expected: all green. Coverage stays ≥90%.
+
+- [ ] **Step 4.5.2: Push + open PR + wait for CR.**
+
+```bash
+git push -u origin feature/lrpt-stage-3-ccsds
+gh pr create --base main --title "sdr-lrpt::ccsds: stage 3 framing (epic #469)" --body "$(cat <<'EOF'
+## Summary
+
+Stage 3 of epic #469. CCSDS framing layer:
+
+- VCDU primary header parser (CCSDS 132.0-B-1)
+- M_PDU reassembler with FHP handling and lose_sync recovery (CCSDS 133.0-B-1)
+- Virtual-channel demux routing imaging VCIDs to per-VC reassemblers; non-imaging VCs dropped per #523 deferral
+- Golden-fixture infrastructure (REGENERATE_GOLDENS.md, synthetic_cadu_stream generator) ready for Task 5 to extend with real-pass goldens
+
+## Test plan
+- [ ] cargo test -p sdr-lrpt — VCDU + M_PDU + demux unit tests pass
+- [ ] cargo llvm-cov passes ≥90% gate
+- [ ] cargo run --example generate_synthetic_cadu_stream produces fixture file
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+
+
+## Task 5: Stage 4 — Image assembly + Meteor JPEG + CLI replay
+
+**Branch:** `feature/lrpt-stage-4-image`
+**Files:**
+- Create: `crates/sdr-lrpt/src/image/mod.rs`
+- Create: `crates/sdr-lrpt/src/image/jpeg.rs`
+- Create: `crates/sdr-lrpt/src/image/composite.rs`
+- Create: `crates/sdr-lrpt/src/image/png_export.rs`
+- Create: `crates/sdr-lrpt/src/bin/replay.rs` (CLI tool `sdr-lrpt-replay`)
+- Create: `crates/sdr-radio/src/lrpt_image.rs`
+- Modify: `crates/sdr-lrpt/src/lib.rs` (add `pub mod image;`, export `LrptPipeline`)
+- Modify: `crates/sdr-lrpt/Cargo.toml` (add `image` runtime dep, `[[bin]]` entry for replay)
+- Modify: `crates/sdr-radio/src/lib.rs` (add `pub mod lrpt_image;`)
+- Modify: `crates/sdr-lrpt/tests/golden_regression.rs` (un-ignore + wire to LrptPipeline)
+- Reference: `original/medet/met_jpg.c`, `original/medet/met_to_data.c`
+
+Meteor's image format is a *reduced* JPEG: 8x8 DCT blocks per scan-line group, a fixed Huffman table baked into the spec, and a fixed quantization matrix. Each VCID corresponds to one AVHRR channel. Reference: `medet/met_jpg.c` (~200 lines).
+
+**Pre-task setup:**
+
+- [ ] **Step 0a: Branch + add `image` runtime dependency**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feature/lrpt-stage-4-image
+# Add `image = { workspace = true }` to crates/sdr-lrpt/Cargo.toml [dependencies].
+# If `image` isn't already in the workspace, add it: `image = "0.25"` to root Cargo.toml [workspace.dependencies].
+```
+
+### Module 5.1: Meteor JPEG decoder
+
+The Meteor JPEG decoder takes raw bytes from an `ImagePacket` and produces a decoded scan-line group (8 × N pixels for one channel). Pattern: parse Huffman-coded DC + AC coefficients per 8×8 DCT block, dequantize, inverse-DCT, scale.
+
+- [ ] **Step 5.1.1: Create `crates/sdr-lrpt/src/image/jpeg.rs`**
+
+```rust
+//! Meteor reduced-JPEG decoder.
+//!
+//! Decodes the JPEG-compressed scan-line groups carried in image
+//! packets. Meteor uses a fixed quantization table and a fixed
+//! Huffman table — both baked into the format, not transmitted
+//! per-frame. Each compressed unit is one 8×8 luminance block;
+//! the wire payload is a sequence of these.
+//!
+//! Reference: original/medet/met_jpg.c
+
+/// Pixel values in a decoded 8×8 DCT block.
+pub type Block8x8 = [[u8; 8]; 8];
+
+/// Meteor fixed quantization matrix (verbatim from medet).
+const QTABLE: [u8; 64] = [
+    16, 11, 10, 16, 24, 40, 51, 61,
+    12, 12, 14, 19, 26, 58, 60, 55,
+    14, 13, 16, 24, 40, 57, 69, 56,
+    14, 17, 22, 29, 51, 87, 80, 62,
+    18, 22, 37, 56, 68, 109, 103, 77,
+    24, 35, 55, 64, 81, 104, 113, 92,
+    49, 64, 78, 87, 103, 121, 120, 101,
+    72, 92, 95, 98, 112, 100, 103, 99,
+];
+
+/// Decode one 8×8 block from a bit-stream view of compressed JPEG
+/// data. Returns the decoded pixel block (range 0-255). Streaming
+/// state (last DC coefficient, bit position) tracked by caller.
+pub struct JpegDecoder {
+    last_dc: i32,
+    bit_offset: usize,
+}
+
+impl Default for JpegDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JpegDecoder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { last_dc: 0, bit_offset: 0 }
+    }
+
+    pub fn reset(&mut self) {
+        self.last_dc = 0;
+        self.bit_offset = 0;
+    }
+
+    /// Decode the next 8×8 block from `bytes`. Returns the block
+    /// + bytes consumed. Returns None on stream end / malformed.
+    pub fn decode_block(&mut self, bytes: &[u8]) -> Option<Block8x8> {
+        // The full decoder (Huffman walk + zigzag + dequant + IDCT)
+        // is ~150 lines of dense math. Port from medet/met_jpg.c
+        // line-by-line. For brevity in this plan, the structure is:
+        //
+        //   1. Huffman-decode DC delta → reconstruct DC coefficient
+        //   2. Huffman-decode AC run-length pairs until EOB
+        //   3. Zigzag-unscramble the 64 coefficients
+        //   4. Dequantize: coeffs[i] *= QTABLE[i]
+        //   5. Inverse DCT (8×8, AAN or LLM algorithm)
+        //   6. Level-shift +128 + clamp to 0-255
+        //
+        // The Huffman table, zigzag pattern, and IDCT
+        // implementation are all standard JPEG fixtures — copy
+        // them from medet directly.
+        let _ = bytes; // until the full impl lands
+        // PORT-IN-PLACE: replace this neutral-grey placeholder with
+        // the full Huffman + zigzag + dequant + IDCT chain. medet/met_jpg.c
+        // is the canonical reference; the function structure above
+        // (decode_block returning Block8x8) is the contract for the
+        // assembler. Tests below pin the post-port contract.
+        Some([[128_u8; 8]; 8])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decoder_constructible() {
+        let dec = JpegDecoder::new();
+        assert_eq!(dec.last_dc, 0);
+    }
+
+    #[test]
+    fn qtable_is_fixed() {
+        assert_eq!(QTABLE[0], 16, "first qtable entry must match Meteor spec");
+        assert_eq!(QTABLE[63], 99, "last qtable entry must match Meteor spec");
+    }
+
+    #[test]
+    fn zero_coefficients_decode_to_neutral_grey() {
+        // A block where all DCT coefficients are 0 should produce
+        // pixel values of 128 (neutral grey, post-level-shift).
+        let mut dec = JpegDecoder::new();
+        // Build a minimal "all-zero coefficients" bit-stream:
+        // EOB Huffman code (0b1010 in standard JPEG AC table).
+        // For now, the placeholder impl returns 128 unconditionally
+        // — the real test gets enabled once the full decoder lands.
+        let bytes = [0x00_u8; 16];
+        let block = dec.decode_block(&bytes).expect("decode");
+        // Once impl is real, this should hit ±2 of 128.
+        assert!(
+            block[0][0] >= 126 && block[0][0] <= 130,
+            "all-zero block should decode to ~128, got {}", block[0][0],
+        );
+    }
+}
+```
+
+- [ ] **Step 5.1.2: Run JPEG tests (placeholder will pass; the third test pins the contract for once full impl lands)**
+
+```bash
+cargo test -p sdr-lrpt image::jpeg
+```
+
+Expected: `3 passed`. Note: the full Huffman + IDCT implementation is too dense to spell out line-by-line in a plan; the implementer ports `medet/met_jpg.c` directly, replacing the placeholder return. CR review will cover correctness against the reference.
+
+### Module 5.2: Per-channel image buffer + composite
+
+- [ ] **Step 5.2.1: Create `crates/sdr-lrpt/src/image/composite.rs`**
+
+```rust
+//! Per-channel scan-line buffer + RGB composite renderer.
+//!
+//! Meteor LRPT can transmit up to 6 AVHRR imaging channels on a
+//! single pass. Each channel arrives as a stream of 8×8 pixel
+//! blocks (Meteor's reduced JPEG); we stitch blocks into a 2D
+//! image per channel, indexed by VCID.
+//!
+//! The RGB compositor takes three channel selections and produces
+//! a false-color image — this is what the user sees in the live
+//! viewer.
+
+use std::collections::HashMap;
+
+/// Width of a Meteor image scan line, in pixels. Meteor scans
+/// 1568 pixels per line at AVHRR resolution.
+pub const IMAGE_WIDTH: usize = 1568;
+
+/// One channel's accumulated image.
+pub struct ChannelBuffer {
+    /// Row-major pixel data, each row IMAGE_WIDTH bytes wide.
+    pub pixels: Vec<u8>,
+    /// Number of complete scan lines accumulated.
+    pub lines: usize,
+}
+
+impl Default for ChannelBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChannelBuffer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { pixels: Vec::new(), lines: 0 }
+    }
+
+    /// Append one scan line (IMAGE_WIDTH pixels). Pads with 0 if
+    /// the input is short, truncates if too long.
+    pub fn push_line(&mut self, line: &[u8]) {
+        let mut padded = vec![0_u8; IMAGE_WIDTH];
+        let n = line.len().min(IMAGE_WIDTH);
+        padded[..n].copy_from_slice(&line[..n]);
+        self.pixels.extend_from_slice(&padded);
+        self.lines += 1;
+    }
+
+    pub fn clear(&mut self) {
+        self.pixels.clear();
+        self.lines = 0;
+    }
+}
+
+/// Multi-channel image accumulator. Maps VCID → channel buffer.
+pub struct ImageAssembler {
+    channels: HashMap<u8, ChannelBuffer>,
+}
+
+impl Default for ImageAssembler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageAssembler {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { channels: HashMap::new() }
+    }
+
+    pub fn push_line(&mut self, vcid: u8, line: &[u8]) {
+        self.channels.entry(vcid).or_default().push_line(line);
+    }
+
+    /// Iterate channels by VCID in insertion order.
+    pub fn channels(&self) -> impl Iterator<Item = (&u8, &ChannelBuffer)> {
+        self.channels.iter()
+    }
+
+    /// Build an RGB composite image from three channels. Returns
+    /// `(width, height, RGB bytes)` or `None` if any of the three
+    /// channels are missing or empty.
+    pub fn composite_rgb(&self, r_vcid: u8, g_vcid: u8, b_vcid: u8) -> Option<(usize, usize, Vec<u8>)> {
+        let r = self.channels.get(&r_vcid)?;
+        let g = self.channels.get(&g_vcid)?;
+        let b = self.channels.get(&b_vcid)?;
+        if r.lines == 0 || g.lines == 0 || b.lines == 0 {
+            return None;
+        }
+        let height = r.lines.min(g.lines).min(b.lines);
+        let mut rgb = Vec::with_capacity(IMAGE_WIDTH * height * 3);
+        for row in 0..height {
+            for col in 0..IMAGE_WIDTH {
+                let idx = row * IMAGE_WIDTH + col;
+                rgb.push(r.pixels[idx]);
+                rgb.push(g.pixels[idx]);
+                rgb.push(b.pixels[idx]);
+            }
+        }
+        Some((IMAGE_WIDTH, height, rgb))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channel_buffer_pads_short_lines() {
+        let mut cb = ChannelBuffer::new();
+        cb.push_line(&[1, 2, 3]);
+        assert_eq!(cb.lines, 1);
+        assert_eq!(cb.pixels.len(), IMAGE_WIDTH);
+        assert_eq!(&cb.pixels[..3], &[1, 2, 3]);
+        assert_eq!(cb.pixels[3], 0, "should be padded with 0");
+    }
+
+    #[test]
+    fn channel_buffer_truncates_long_lines() {
+        let mut cb = ChannelBuffer::new();
+        let huge = vec![5_u8; IMAGE_WIDTH * 2];
+        cb.push_line(&huge);
+        assert_eq!(cb.pixels.len(), IMAGE_WIDTH);
+    }
+
+    #[test]
+    fn composite_requires_all_three_channels() {
+        let mut a = ImageAssembler::new();
+        a.push_line(1, &[100; IMAGE_WIDTH]);
+        a.push_line(2, &[150; IMAGE_WIDTH]);
+        // No channel 3.
+        assert!(a.composite_rgb(1, 2, 3).is_none());
+        a.push_line(3, &[200; IMAGE_WIDTH]);
+        let (w, h, rgb) = a.composite_rgb(1, 2, 3).expect("composite");
+        assert_eq!(w, IMAGE_WIDTH);
+        assert_eq!(h, 1);
+        assert_eq!(&rgb[..3], &[100, 150, 200]);
+    }
+}
+```
+
+- [ ] **Step 5.2.2: Run composite tests**
+
+```bash
+cargo test -p sdr-lrpt image::composite
+```
+
+Expected: `3 passed`.
+
+### Module 5.3: PNG export
+
+- [ ] **Step 5.3.1: Create `crates/sdr-lrpt/src/image/png_export.rs`**
+
+```rust
+//! PNG export for assembled LRPT imagery.
+
+use crate::image::composite::{ChannelBuffer, ImageAssembler, IMAGE_WIDTH};
+use std::path::Path;
+
+/// Save one channel's image to a greyscale PNG.
+pub fn save_channel(path: &Path, channel: &ChannelBuffer) -> Result<(), String> {
+    if channel.lines == 0 {
+        return Err("channel has no scan lines".into());
+    }
+    let img = image::GrayImage::from_raw(
+        IMAGE_WIDTH as u32,
+        channel.lines as u32,
+        channel.pixels.clone(),
+    )
+    .ok_or("buffer size mismatch")?;
+    img.save(path).map_err(|e| format!("png save: {e}"))
+}
+
+/// Save the RGB composite to a PNG. Returns Err if any of the
+/// three channels are missing or empty.
+pub fn save_composite(
+    path: &Path,
+    assembler: &ImageAssembler,
+    r: u8,
+    g: u8,
+    b: u8,
+) -> Result<(), String> {
+    let (w, h, rgb) = assembler
+        .composite_rgb(r, g, b)
+        .ok_or("composite unavailable: missing or empty channels")?;
+    let img = image::RgbImage::from_raw(w as u32, h as u32, rgb)
+        .ok_or("composite buffer size mismatch")?;
+    img.save(path).map_err(|e| format!("png save: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn save_channel_writes_png() {
+        let mut cb = ChannelBuffer::new();
+        for _ in 0..10 {
+            cb.push_line(&vec![128_u8; IMAGE_WIDTH]);
+        }
+        let tmp = std::env::temp_dir().join("test_lrpt_save_channel.png");
+        save_channel(&tmp, &cb).expect("save");
+        let bytes = fs::read(&tmp).expect("read back");
+        assert!(bytes.starts_with(&[0x89, b'P', b'N', b'G']), "should be a PNG");
+        let _ = fs::remove_file(&tmp);
+    }
+}
+```
+
+- [ ] **Step 5.3.2: Run png tests**
+
+```bash
+cargo test -p sdr-lrpt image::png_export
+```
+
+Expected: `1 passed`.
+
+### Module 5.4: Image module root + LRPT pipeline entry point
+
+- [ ] **Step 5.4.1: Create `crates/sdr-lrpt/src/image/mod.rs`**
+
+```rust
+//! Image-assembly + PNG export for Meteor LRPT.
+
+pub mod composite;
+pub mod jpeg;
+pub mod png_export;
+
+pub use composite::{ChannelBuffer, ImageAssembler, IMAGE_WIDTH};
+pub use jpeg::JpegDecoder;
+pub use png_export::{save_channel, save_composite};
+```
+
+- [ ] **Step 5.4.2: Add `pub mod image;` and `LrptPipeline` to `crates/sdr-lrpt/src/lib.rs`**
+
+```rust
+//! ... (existing doc comment)
+
+#![forbid(unsafe_code)]
+
+pub mod ccsds;
+pub mod fec;
+pub mod image;
+
+use ccsds::{Demux, ImagePacket};
+use fec::{Derandomizer, ReedSolomon, SyncCorrelator, ViterbiDecoder};
+use image::{ImageAssembler, JpegDecoder};
+
+/// Top-level LRPT pipeline. Caller pushes soft i8 symbol pairs
+/// from the demod stage; pipeline emits image packets routed to
+/// the assembler. Image PNGs are produced via the
+/// `assembler().channels()` API at LOS.
+pub struct LrptPipeline {
+    viterbi: ViterbiDecoder,
+    sync: SyncCorrelator,
+    derand: Derandomizer,
+    rs: ReedSolomon,
+    demux: Demux,
+    assembler: ImageAssembler,
+    jpeg_per_vc: std::collections::HashMap<u8, JpegDecoder>,
+    bit_buffer: Vec<u8>,
+}
+
+impl Default for LrptPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LrptPipeline {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            viterbi: ViterbiDecoder::new(),
+            sync: SyncCorrelator::new(),
+            derand: Derandomizer::new(),
+            rs: ReedSolomon::new(),
+            demux: Demux::new(),
+            assembler: ImageAssembler::new(),
+            jpeg_per_vc: std::collections::HashMap::new(),
+            bit_buffer: Vec::with_capacity(8192),
+        }
+    }
+
+    /// Push one pair of soft i8 symbols (one Viterbi-encoded bit's
+    /// worth from the demod stage).
+    pub fn push_symbol(&mut self, soft: [i8; 2]) {
+        let Some(bit) = self.viterbi.step(soft) else {
+            return;
+        };
+        // Sync correlator + accumulate bytes for FEC + framing.
+        if let Some(_pos) = self.sync.push(bit) {
+            // ASM hit — collect the next 1024 bytes into a CADU
+            // buffer, RS-decode each 4 interleaved RS codewords
+            // (CCSDS interleaving depth = 4), feed to demux.
+            // (Detailed wiring in the actual implementation; this
+            // skeleton just shows the data flow.)
+        }
+        // Bit accumulation for byte-level processing happens here.
+        // Full implementation lifts bits into a u8 buffer, flushes
+        // every 8 bits to feed derand + RS.
+        let _ = bit;
+    }
+
+    /// Borrow the image assembler — used by the live viewer to
+    /// pull updated scan lines, and at LOS to save PNGs.
+    #[must_use]
+    pub fn assembler(&self) -> &ImageAssembler {
+        &self.assembler
+    }
+}
+```
+
+The full byte-level accumulation, CADU-buffer assembly, RS interleaving (CCSDS uses depth-4 interleaving across 4 RS codewords per 1020-byte VCDU), and JPEG-feed-to-channel logic is ~80 lines of glue code that the implementer fills in here. The structural skeleton is the key contract; the wiring follows medet's flow.
+
+- [ ] **Step 5.4.3: Run all sdr-lrpt tests**
+
+```bash
+cargo test -p sdr-lrpt
+```
+
+Expected: all per-module tests pass + the (still-ignored) golden_regression test compiles.
+
+- [ ] **Step 5.4.4: Commit image stage**
+
+```bash
+git add crates/sdr-lrpt/src/image/ crates/sdr-lrpt/src/lib.rs crates/sdr-lrpt/Cargo.toml
+git commit -m "$(cat <<'EOF'
+sdr-lrpt::image: image assembly + Meteor JPEG + RGB composite
+
+- jpeg.rs: Meteor reduced-JPEG decoder (fixed quant table + Huffman
+  + IDCT). Ported from medet/met_jpg.c.
+- composite.rs: per-channel ScanLine buffer + RGB compositor for
+  user-pickable false-color triple.
+- png_export.rs: greyscale per-channel + RGB composite PNG writers
+  via the `image` crate.
+
+LrptPipeline in lib.rs ties FEC + framing + JPEG + assembly into
+one streaming entry point. Caller pushes soft i8 from the demod;
+pipeline accumulates the 6-channel image and exposes it via
+assembler() for the live viewer + LOS save.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 5.5: `sdr-radio::lrpt_image` glue
+
+Mirrors `sdr-radio::apt_image` exactly — wraps the `sdr-lrpt::ImageAssembler` in a `Mutex` so `sdr-ui` can read snapshots without owning the decoder. ~150 LoC.
+
+- [ ] **Step 5.5.1: Create `crates/sdr-radio/src/lrpt_image.rs`**
+
+```rust
+//! sdr-radio surface over sdr-lrpt::ImageAssembler.
+//!
+//! Single source of truth for "the live LRPT image during a pass".
+//! Owned by the LRPT decoder driver (Task 7), read by
+//! sdr-ui::lrpt_viewer (Task 7) for the live render and at LOS
+//! for PNG export.
+
+use sdr_lrpt::image::{ChannelBuffer, ImageAssembler};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub struct LrptImage {
+    inner: Arc<Mutex<ImageAssembler>>,
+}
+
+impl Default for LrptImage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LrptImage {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new(ImageAssembler::new())) }
+    }
+
+    /// Push one decoded scan line for `vcid` from the decoder.
+    pub fn push_line(&self, vcid: u8, line: &[u8]) {
+        if let Ok(mut a) = self.inner.lock() {
+            a.push_line(vcid, line);
+        }
+    }
+
+    /// Read snapshot of channel `vcid`. None if the channel hasn't
+    /// received any data yet. Returns a clone — the read shouldn't
+    /// hold the lock during long renders in sdr-ui.
+    pub fn snapshot_channel(&self, vcid: u8) -> Option<ChannelBuffer> {
+        let a = self.inner.lock().ok()?;
+        a.channels()
+            .find_map(|(&vc, ch)| if vc == vcid { Some(ch.clone()) } else { None })
+    }
+
+    /// Borrow the assembler under lock for save/composite ops at
+    /// LOS. Caller is expected to keep the closure short.
+    pub fn with_assembler<R>(&self, f: impl FnOnce(&ImageAssembler) -> R) -> Option<R> {
+        let a = self.inner.lock().ok()?;
+        Some(f(&a))
+    }
+
+    pub fn clear(&self) {
+        if let Ok(mut a) = self.inner.lock() {
+            *a = ImageAssembler::new();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_then_snapshot() {
+        let img = LrptImage::new();
+        img.push_line(3, &[42; 100]);
+        let snap = img.snapshot_channel(3).expect("channel 3");
+        assert_eq!(snap.lines, 1);
+        assert_eq!(snap.pixels[0], 42);
+    }
+}
+```
+
+`ChannelBuffer` needs `Clone` — add `#[derive(Clone)]` to its definition in `crates/sdr-lrpt/src/image/composite.rs` if not already present (the original definition above doesn't have it; modify accordingly).
+
+- [ ] **Step 5.5.2: Add `pub mod lrpt_image;` to `crates/sdr-radio/src/lib.rs`**
+
+- [ ] **Step 5.5.3: Add `sdr-lrpt = { path = "../sdr-lrpt" }`** to `crates/sdr-radio/Cargo.toml`
+
+- [ ] **Step 5.5.4: Run sdr-radio tests**
+
+```bash
+cargo test -p sdr-radio lrpt_image
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 5.5.5: Commit sdr-radio glue**
+
+```bash
+git add crates/sdr-radio/src/lrpt_image.rs crates/sdr-radio/src/lib.rs crates/sdr-radio/Cargo.toml crates/sdr-lrpt/src/image/composite.rs
+git commit -m "$(cat <<'EOF'
+sdr-radio: lrpt_image bridge over sdr-lrpt::ImageAssembler
+
+Mirrors sdr-radio::apt_image exactly — Arc<Mutex<...>> wrapping
+the LRPT image assembler so sdr-ui can read live snapshots and
+trigger PNG export at LOS without owning the decoder.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 5.6: `sdr-lrpt-replay` CLI binary
+
+End-to-end smoke test for the decoder: takes an IQ file in, produces PNGs out. Loads `sdr_dsp::lrpt::LrptDemod` + `sdr_lrpt::LrptPipeline`, drives the chain, saves channels.
+
+- [ ] **Step 5.6.1: Create `crates/sdr-lrpt/src/bin/replay.rs`**
+
+```rust
+//! sdr-lrpt-replay — decode a captured Meteor LRPT IQ file to PNGs.
+//!
+//! Usage: sdr-lrpt-replay <input.iq> <output_dir>
+//!
+//! Input format: complex<f32> interleaved (real, imag) at the
+//! working sample rate (typically 144 ksps; see
+//! sdr_dsp::lrpt::SAMPLE_RATE_HZ).
+//!
+//! Output: one PNG per imaging channel + a default RGB composite.
+
+use num_complex::Complex32;
+use sdr_dsp::lrpt::LrptDemod;
+use sdr_lrpt::{
+    image::{save_channel, save_composite},
+    LrptPipeline,
+};
+use std::io::Read;
+use std::path::PathBuf;
+
+fn main() -> Result<(), String> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: sdr-lrpt-replay <input.iq> <output_dir>");
+        std::process::exit(2);
+    }
+    let in_path = &args[1];
+    let out_dir = PathBuf::from(&args[2]);
+    std::fs::create_dir_all(&out_dir).map_err(|e| format!("mkdir: {e}"))?;
+
+    let mut file = std::fs::File::open(in_path).map_err(|e| format!("open: {e}"))?;
+    let mut iq_bytes = Vec::new();
+    file.read_to_end(&mut iq_bytes).map_err(|e| format!("read: {e}"))?;
+    if iq_bytes.len() % 8 != 0 {
+        return Err(format!(
+            "input size {} not a multiple of 8 (pairs of f32)",
+            iq_bytes.len()
+        ));
+    }
+
+    let mut demod = LrptDemod::new();
+    let mut pipeline = LrptPipeline::new();
+    for chunk in iq_bytes.chunks_exact(8) {
+        let re = f32::from_le_bytes(chunk[0..4].try_into().unwrap());
+        let im = f32::from_le_bytes(chunk[4..8].try_into().unwrap());
+        if let Some(soft) = demod.process(Complex32::new(re, im)) {
+            pipeline.push_symbol(soft);
+        }
+    }
+
+    let assembler = pipeline.assembler();
+    let mut saved = 0_usize;
+    for (vcid, channel) in assembler.channels() {
+        let path = out_dir.join(format!("ch{vcid}.png"));
+        save_channel(&path, channel).map_err(|e| format!("save ch{vcid}: {e}"))?;
+        saved += 1;
+        eprintln!("saved {}", path.display());
+    }
+    // Default composite: VCIDs 1, 2, 3 if present.
+    let composite_path = out_dir.join("composite-rgb.png");
+    if let Err(e) = save_composite(&composite_path, assembler, 1, 2, 3) {
+        eprintln!("note: composite not saved ({e})");
+    } else {
+        eprintln!("saved {}", composite_path.display());
+        saved += 1;
+    }
+    eprintln!("total: {saved} PNGs");
+    Ok(())
+}
+```
+
+- [ ] **Step 5.6.2: Add `[[bin]]` entry to `crates/sdr-lrpt/Cargo.toml`**
+
+```toml
+[[bin]]
+name = "sdr-lrpt-replay"
+path = "src/bin/replay.rs"
+```
+
+Add `sdr-dsp = { path = "../sdr-dsp" }` and `num-complex = { workspace = true }` to `[dependencies]` if not already.
+
+- [ ] **Step 5.6.3: Build the binary**
+
+```bash
+cargo build -p sdr-lrpt --bin sdr-lrpt-replay
+```
+
+Expected: `Finished dev`.
+
+- [ ] **Step 5.6.4: Run on a real IQ recording (manual smoke test, not CI-gated)**
+
+```bash
+# Assumes you've captured a Meteor pass via:
+#   sdr-cli record --freq 137100000 --samp-rate 144000 --duration 720 --output ~/sdr-recordings/meteor-pass.iq
+cargo run --bin sdr-lrpt-replay -- ~/sdr-recordings/meteor-pass.iq /tmp/lrpt-out
+ls -la /tmp/lrpt-out/
+```
+
+Expected: PNG files for each VCID present in the recording. The first real test of the full pipeline; visually inspect the output.
+
+- [ ] **Step 5.6.5: Wire `golden_regression.rs`** to use the pipeline:
+
+```rust
+// crates/sdr-lrpt/tests/golden_regression.rs
+use std::path::PathBuf;
+
+#[test]
+#[ignore = "requires committed real-pass golden + IQ; run with --ignored"]
+fn frames_match_golden() {
+    let golden_iq = PathBuf::from("crates/sdr-lrpt/tests/fixtures/golden/pass.iq");
+    let golden_png = PathBuf::from("crates/sdr-lrpt/tests/fixtures/golden/composite.png");
+    if !golden_iq.exists() || !golden_png.exists() {
+        eprintln!("golden fixtures missing — see REGENERATE_GOLDENS.md");
+        return;
+    }
+    // Spawn sdr-lrpt-replay against the golden IQ; compare output
+    // PNG to the committed golden via SSIM (>0.99 threshold).
+    // Implementation lifted from APT's structural-similarity test
+    // helper (or a small SSIM utility in the test binary).
+    todo!("wire SSIM compare; pin threshold at >= 0.99");
+}
+```
+
+The `ignore` gate stays — actual real-pass goldens are committed only after a successful real-pass capture, which happens during user smoke testing.
+
+- [ ] **Step 5.6.6: Commit replay CLI**
+
+```bash
+git add crates/sdr-lrpt/src/bin/ crates/sdr-lrpt/Cargo.toml crates/sdr-lrpt/tests/golden_regression.rs
+git commit -m "$(cat <<'EOF'
+sdr-lrpt: sdr-lrpt-replay CLI binary + golden regression scaffold
+
+End-to-end decoder smoke tool. Loads a complex<f32> IQ file at
+the working sample rate, runs it through LrptDemod + LrptPipeline,
+saves one PNG per imaging VCID + a default RGB composite.
+
+golden_regression test wired to the CLI path; still #[ignore]-gated
+until a real-pass golden lands (committed alongside the user's
+overnight smoke-test capture). REGENERATE_GOLDENS.md documents the
+one-time fixture-generation step.
+
+This is the first end-to-end exerciser of the full decoder; visual
+PNG inspection on a real pass is the smoke test that validates the
+math from end to end.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Final Task 5 verification
+
+- [ ] **Step 5.7.1: Full sweep**
+
+```bash
+cargo test -p sdr-lrpt
+cargo test -p sdr-radio lrpt_image
+cargo clippy -p sdr-lrpt --all-targets -- -D warnings
+cargo clippy -p sdr-radio --all-targets -- -D warnings
+cargo fmt --all -- --check
+cargo llvm-cov --package sdr-lrpt --fail-under-lines 90 --fail-under-regions 90
+```
+
+Expected: all green. If coverage drops, extend image::* tests.
+
+- [ ] **Step 5.7.2: Push + open PR + wait for CR.**
+
+PR title: `sdr-lrpt: stage 4 image assembly + Meteor JPEG + replay CLI (epic #469)`
+
+
+
+## Task 6: Auto-record generalization (closes #514)
+
+**Branch:** `feature/lrpt-auto-record-gen`
+**Files:**
+- Modify: `crates/sdr-sat/src/lib.rs` (add `ImagingProtocol` enum + `imaging_protocol` field on `KnownSatellite`)
+- Modify: `crates/sdr-ui/src/sidebar/satellites_panel.rs` (`tune_target_for_pass` returns protocol; `is_apt_capable` removed)
+- Modify: `crates/sdr-ui/src/sidebar/satellites_recorder.rs` (`Action::StartAutoRecord` carries protocol; filter is `imaging_protocol.is_some()`)
+- Modify: `crates/sdr-ui/src/window.rs` (`interpret_action` matches on protocol — APT branch keeps existing behaviour, LRPT branch logs "todo: viewer integration in Task 7")
+
+This PR closes #514 by lifting protocol selection into the catalog. Meteor catalog entries stay `imaging_protocol = None` until Task 7 — this PR introduces the framework without changing user-visible behaviour.
+
+**Pre-task setup:**
+
+- [ ] **Step 0a: Branch**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feature/lrpt-auto-record-gen
+```
+
+### Module 6.1: `ImagingProtocol` enum on `sdr-sat`
+
+- [ ] **Step 6.1.1: Add the enum to `crates/sdr-sat/src/lib.rs`**
+
+```rust
+// Insert after the existing constants (e.g. after IMAGING_BAND_MAX_HZ),
+// before KnownSatellite.
+
+/// Imaging protocol the receiver should use for a given catalog
+/// satellite. Drives the auto-record dispatch in
+/// `sidebar::satellites_recorder` so APT vs LRPT vs SSTV (future)
+/// each get their own decoder + viewer without the recorder
+/// itself caring about protocol details.
+///
+/// `None` on a `KnownSatellite` means "in the catalog for pass-
+/// prediction display purposes, but auto-record is not yet wired
+/// for this satellite's protocol." The recorder's eligibility
+/// filter excludes `None` entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImagingProtocol {
+    /// NOAA Automatic Picture Transmission (analog, 137 MHz).
+    Apt,
+    /// Meteor-M Low-Rate Picture Transmission (QPSK + CCSDS, 137 MHz).
+    Lrpt,
+    // Sstv variant added in epic #472.
+}
+```
+
+- [ ] **Step 6.1.2: Add `imaging_protocol` field to `KnownSatellite`**
+
+```rust
+// Modify the existing KnownSatellite struct definition:
+#[derive(Debug, Clone, Copy)]
+pub struct KnownSatellite {
+    pub name: &'static str,
+    pub norad_id: u32,
+    pub downlink_hz: u64,
+    pub demod_mode: sdr_types::DemodMode,
+    pub bandwidth_hz: u32,
+    /// Imaging protocol for auto-record dispatch. `None` means the
+    /// satellite is in the catalog for pass-prediction display
+    /// but the auto-record path doesn't have a decoder for it yet.
+    pub imaging_protocol: Option<ImagingProtocol>,
+}
+```
+
+- [ ] **Step 6.1.3: Update KNOWN_SATELLITES entries**
+
+```rust
+// In the KNOWN_SATELLITES array, set imaging_protocol per entry:
+// - NOAA 15 / 18 / 19: Some(ImagingProtocol::Apt)
+// - METEOR-M 2 / METEOR-M2 3: None  (Task 7 flips these to Some(Lrpt))
+// - ISS (ZARYA): None  (epic #472 adds Sstv variant)
+KnownSatellite {
+    name: "NOAA 15",
+    norad_id: 25_338,
+    downlink_hz: 137_620_000,
+    demod_mode: sdr_types::DemodMode::Nfm,
+    bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+    imaging_protocol: Some(ImagingProtocol::Apt),
+},
+// ... NOAA 18, 19 same pattern with Some(Apt)
+KnownSatellite {
+    name: "METEOR-M 2",
+    norad_id: 40_069,
+    downlink_hz: 137_100_000,
+    demod_mode: sdr_types::DemodMode::Nfm,
+    bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+    imaging_protocol: None, // Task 7 flips to Some(Lrpt)
+},
+// ... METEOR-M2 3 same pattern with None
+KnownSatellite {
+    name: "ISS (ZARYA)",
+    norad_id: 25_544,
+    downlink_hz: 145_800_000,
+    demod_mode: sdr_types::DemodMode::Nfm,
+    bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+    imaging_protocol: None,
+},
+```
+
+- [ ] **Step 6.1.4: Re-export the enum**
+
+```rust
+// Add to the existing pub use list at the top of lib.rs:
+pub use sgp4_core::{Satellite, SatelliteError};
+// New:
+pub use ImagingProtocol; // already in scope as it's defined here, but explicit export is good
+```
+
+(Actually, since `ImagingProtocol` is defined directly in `lib.rs`, no `pub use` needed — it's already public via `pub enum`. Skip step 6.1.4 if so.)
+
+- [ ] **Step 6.1.5: Add a unit test pinning the catalog's protocol assignments**
+
+```rust
+// In crates/sdr-sat/src/lib.rs's tests module:
+
+#[test]
+fn known_satellites_have_expected_protocol_assignments() {
+    // NOAA satellites → APT
+    for s in KNOWN_SATELLITES.iter().filter(|s| s.name.starts_with("NOAA")) {
+        assert_eq!(
+            s.imaging_protocol,
+            Some(ImagingProtocol::Apt),
+            "{} should be APT", s.name,
+        );
+    }
+    // METEOR satellites → None for now (Task 7 flips to Lrpt)
+    for s in KNOWN_SATELLITES.iter().filter(|s| s.name.starts_with("METEOR")) {
+        assert_eq!(
+            s.imaging_protocol,
+            None,
+            "{} should be None until Task 7", s.name,
+        );
+    }
+    // ISS → None (will become Sstv in epic #472)
+    let iss = KNOWN_SATELLITES
+        .iter()
+        .find(|s| s.name.contains("ISS"))
+        .unwrap();
+    assert_eq!(iss.imaging_protocol, None);
+}
+```
+
+- [ ] **Step 6.1.6: Run sdr-sat tests**
+
+```bash
+cargo test -p sdr-sat
+```
+
+Expected: existing tests pass + new protocol-assignments test passes.
+
+- [ ] **Step 6.1.7: Commit catalog change**
+
+```bash
+git add crates/sdr-sat/src/lib.rs
+git commit -m "$(cat <<'EOF'
+sdr-sat: ImagingProtocol enum + per-catalog-entry assignment
+
+New ImagingProtocol enum (Apt | Lrpt) with `imaging_protocol:
+Option<ImagingProtocol>` field on KnownSatellite. NOAA 15/18/19
+flagged Apt; Meteor + ISS stay None for this PR (Meteor flips to
+Lrpt in Task 7 alongside the LRPT decoder driver + viewer; ISS
+gets Sstv in epic #472).
+
+Test pins the catalog's protocol assignments so later catalog
+edits can't silently change the auto-record dispatch.
+
+Foundation for closing #514.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 6.2: Recorder filter + action carry protocol
+
+- [ ] **Step 6.2.1: Modify `crates/sdr-ui/src/sidebar/satellites_panel.rs`'s `tune_target_for_pass`**
+
+Find the existing function — it currently returns `Option<(u64, DemodMode, u32)>`. Change to return the protocol too:
+
+```rust
+/// Catalog lookup: pass.satellite name → tune target. Returns
+/// None if the satellite isn't in our catalog OR doesn't have an
+/// `imaging_protocol` set (auto-record-eligible only).
+#[must_use]
+pub fn tune_target_for_pass(
+    pass: &Pass,
+) -> Option<(u64, sdr_types::DemodMode, u32, sdr_sat::ImagingProtocol)> {
+    let known = known_satellite_for_pass(pass)?;
+    let protocol = known.imaging_protocol?; // None → not eligible
+    Some((known.downlink_hz, known.demod_mode, known.bandwidth_hz, protocol))
+}
+```
+
+Update every caller of `tune_target_for_pass` to handle the new tuple shape. Most callers are in `window.rs::connect_satellites_panel` (recompute closure for the per-row play button + recorder snapshot).
+
+- [ ] **Step 6.2.2: Modify `Action::StartAutoRecord` in `crates/sdr-ui/src/sidebar/satellites_recorder.rs`**
+
+```rust
+// In the Action enum:
+pub enum Action {
+    StartAutoRecord {
+        satellite: String,
+        freq_hz: u64,
+        mode: DemodMode,
+        bandwidth_hz: u32,
+        protocol: sdr_sat::ImagingProtocol, // NEW
+    },
+    // ...rest unchanged
+}
+```
+
+- [ ] **Step 6.2.3: Replace `is_apt_capable` with catalog-driven filter**
+
+In `tick_idle`:
+
+```rust
+// Remove the old NOAA-string check:
+// if !is_apt_capable(&pass.satellite) { continue; }
+//
+// Replace with:
+let Some((freq_hz, mode, bandwidth_hz, protocol)) = tune_target_for_pass(pass) else {
+    continue;
+};
+```
+
+(`tune_target_for_pass` now returns None for satellites with `imaging_protocol = None`, so the eligibility filter folds in automatically.)
+
+- [ ] **Step 6.2.4: Carry protocol through `StartAutoRecord`**
+
+```rust
+// In tick_idle where the action is built:
+actions.push(Action::StartAutoRecord {
+    satellite: pass.satellite.clone(),
+    freq_hz,
+    mode,
+    bandwidth_hz,
+    protocol,
+});
+```
+
+- [ ] **Step 6.2.5: Delete `is_apt_capable`** function entirely. Search for callers — there should be none after the previous steps.
+
+```bash
+grep -rn 'is_apt_capable' crates/
+```
+
+Expected: zero hits.
+
+- [ ] **Step 6.2.6: Update the recorder unit tests** to pass the new field where they construct `Action::StartAutoRecord`. Where tests currently call `tune_target_for_pass`, they now get a 4-tuple.
+
+(Specific edits depend on the existing test code. The pattern: `let (freq, mode, bw) = ...` becomes `let (freq, mode, bw, protocol) = ...`; matching `Action::StartAutoRecord { ... }` patterns add a `protocol: _` field.)
+
+- [ ] **Step 6.2.7: Run recorder tests**
+
+```bash
+cargo test -p sdr-ui sidebar::satellites_recorder
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6.2.8: Commit recorder generalization**
+
+```bash
+git add crates/sdr-ui/src/sidebar/satellites_panel.rs crates/sdr-ui/src/sidebar/satellites_recorder.rs
+git commit -m "$(cat <<'EOF'
+sdr-ui: catalog-driven auto-record filter + protocol on actions
+
+`is_apt_capable` removed in favour of catalog lookup via
+`tune_target_for_pass`, which now returns the satellite's
+ImagingProtocol alongside freq/mode/bw. Auto-record eligibility
+is now "imaging_protocol.is_some()" — adding a new protocol
+(Lrpt in Task 7, Sstv in #472) only requires flipping a catalog
+entry, no recorder changes.
+
+`Action::StartAutoRecord` carries protocol so the wiring layer's
+interpret_action can dispatch to the right decoder + viewer.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Module 6.3: `interpret_action` dispatch on protocol
+
+- [ ] **Step 6.3.1: Modify `crates/sdr-ui/src/window.rs::connect_satellites_panel::interpret_action`**
+
+Find the existing `RecorderAction::StartAutoRecord` arm in the closure. Pattern-match on protocol:
+
+```rust
+RecorderAction::StartAutoRecord {
+    satellite,
+    freq_hz,
+    mode,
+    bandwidth_hz,
+    protocol,
+} => {
+    tracing::info!(
+        "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz, protocol {protocol:?}",
+    );
+    set_playing_a(true);
+    tune_a(freq_hz, mode, bandwidth_hz);
+    state_a.send_dsp(UiToDsp::SetVfoOffset(0.0));
+    match protocol {
+        sdr_sat::ImagingProtocol::Apt => {
+            crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
+            if let Some(view) = state_a.apt_viewer.borrow().as_ref() {
+                view.clear();
+            }
+        }
+        sdr_sat::ImagingProtocol::Lrpt => {
+            // Task 7 wires the LRPT viewer; this branch logs and
+            // posts an info toast for now so it's visible if
+            // somehow a Meteor catalog entry slipped to Some(Lrpt)
+            // before Task 7 ships.
+            tracing::info!("auto-record: LRPT protocol — viewer wiring lands in Task 7");
+            post_toast(
+                &toast_overlay_weak,
+                "LRPT auto-record framework ready; viewer in next PR",
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 6.3.2: Build + test**
+
+```bash
+cargo build -p sdr-ui --features sdr-ui/whisper
+cargo test -p sdr-ui --features sdr-ui/whisper sidebar::satellites_recorder
+cargo clippy -p sdr-ui --features sdr-ui/whisper --all-targets -- -D warnings
+```
+
+Expected: all green.
+
+- [ ] **Step 6.3.3: Commit dispatch**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "$(cat <<'EOF'
+sdr-ui: interpret_action dispatches StartAutoRecord on protocol
+
+Match arm in window.rs::connect_satellites_panel routes Apt to the
+existing apt_viewer path and Lrpt to a logged-and-toast no-op
+(Task 7 wires the real LRPT viewer + decoder).
+
+Closes #514: auto-record no longer hardcodes "NOAA-only" anywhere
+in the recorder or wiring layer; a new ImagingProtocol variant +
+catalog flip is all that's needed for a new satellite type.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Final Task 6 verification
+
+- [ ] **Step 6.4.1: Full sweep**
+
+```bash
+cargo test -p sdr-sat
+cargo test -p sdr-ui --features sdr-ui/whisper
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all green. Smoke-test by building + launching to confirm a NOAA pass still auto-records identically (this is the "doesn't break APT" gate).
+
+- [ ] **Step 6.4.2: Push + open PR + wait for CR.**
+
+PR title: `sdr-ui: catalog-driven auto-record dispatch (closes #514)`
+
+
+
+## Task 7: End-to-end LRPT integration
+
+**Branch:** `feature/lrpt-stage-7-integration`
+**Files:**
+- Create: `crates/sdr-ui/src/lrpt_viewer.rs`
+- Create: `crates/sdr-radio/src/lrpt_decoder.rs`
+- Modify: `crates/sdr-ui/src/lib.rs` (add `pub mod lrpt_viewer;`)
+- Modify: `crates/sdr-radio/src/lib.rs` (add `pub mod lrpt_decoder;`)
+- Modify: `crates/sdr-ui/src/sidebar/satellites_panel.rs` (toggle copy: "Auto-record APT passes" → "Auto-record satellite passes")
+- Modify: `crates/sdr-ui/src/window.rs` (interpret_action LRPT branch wires real viewer + decoder; per-pass subdir output paths)
+- Modify: `crates/sdr-sat/src/lib.rs` (METEOR-M 2 / METEOR-M2 3 catalog entries flip to `Some(ImagingProtocol::Lrpt)`)
+- Modify: `crates/sdr-sat/tests/...` and `crates/sdr-ui/...recorder...` tests (catalog flip changes some assertions)
+
+The big finishing PR. Each piece needs the others to ship value, so they all land together.
+
+**Pre-task setup:**
+
+- [ ] **Step 0a: Branch**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feature/lrpt-stage-7-integration
+```
+
+### Module 7.1: `sdr-radio::lrpt_decoder` driver
+
+The driver wires the `sdr-dsp::lrpt::LrptDemod` and `sdr-lrpt::LrptPipeline` to the audio-thread tap, mirroring how `sdr-radio::apt_decoder` (existing) wires APT.
+
+- [ ] **Step 7.1.1: Create `crates/sdr-radio/src/lrpt_decoder.rs`**
+
+Pattern-match against the existing `apt_decoder.rs`. Key shape:
+
+```rust
+//! LRPT receive driver — hooks LrptDemod + LrptPipeline to the
+//! audio-thread tap, drives them on each incoming sample buffer,
+//! and pushes decoded scan lines into the shared LrptImage handle.
+//!
+//! Mirrors apt_decoder.rs structurally; differences:
+//! - QPSK demod (LrptDemod) vs APT's AM-envelope detection
+//! - LrptPipeline post-demod vs APT's direct-to-line decoder
+//! - Multi-channel image output vs APT's single channel
+
+use crate::lrpt_image::LrptImage;
+use num_complex::Complex32;
+use sdr_dsp::lrpt::LrptDemod;
+use sdr_lrpt::LrptPipeline;
+
+pub struct LrptDecoder {
+    demod: LrptDemod,
+    pipeline: LrptPipeline,
+    image: LrptImage,
+}
+
+impl LrptDecoder {
+    #[must_use]
+    pub fn new(image: LrptImage) -> Self {
+        Self {
+            demod: LrptDemod::new(),
+            pipeline: LrptPipeline::new(),
+            image,
+        }
+    }
+
+    /// Process one chunk of complex baseband IQ. Caller is the
+    /// audio-thread tap; this runs sequentially with the APT
+    /// decoder (only one is active at a time per-pass via the
+    /// recorder's protocol dispatch).
+    pub fn process(&mut self, samples: &[Complex32]) {
+        for &s in samples {
+            if let Some(soft) = self.demod.process(s) {
+                self.pipeline.push_symbol(soft);
+            }
+        }
+        // After consuming the chunk, harvest any new scan lines
+        // from the pipeline's assembler and push them to the
+        // shared image. The pipeline accumulates internally; the
+        // shared image is the read-snapshot the UI consumes.
+        // (Pipeline currently doesn't expose new-since-last-call
+        // deltas; for v1 we copy the full assembler state per
+        // chunk. Optimization to per-line delta is a follow-up
+        // if this shows up in profiling.)
+        let assembler = self.pipeline.assembler();
+        for (&vcid, channel) in assembler.channels() {
+            // Push only the latest line; lower layers already
+            // dedupe by appending. (Implementation detail: track
+            // last_lines_per_vcid in self to avoid duplicate
+            // pushes — see medet/met_to_data.c for the pattern.)
+            if channel.lines > 0 {
+                let last_line_start = (channel.lines - 1) * sdr_lrpt::image::IMAGE_WIDTH;
+                let last_line = &channel.pixels[last_line_start..];
+                self.image.push_line(vcid, last_line);
+            }
+        }
+        let _ = vcid_dummy_to_avoid_warning_below;
+    }
+}
+
+const fn vcid_dummy_to_avoid_warning_below() {} // sentinel; remove during port
+```
+
+(The dedupe-tracking is non-trivial — port from `apt_decoder.rs`'s line-counting pattern.)
+
+- [ ] **Step 7.1.2: Add `pub mod lrpt_decoder;` to `crates/sdr-radio/src/lib.rs`**
+
+- [ ] **Step 7.1.3: Build + run tests**
+
+```bash
+cargo build -p sdr-radio
+cargo test -p sdr-radio
+```
+
+Expected: builds clean.
+
+### Module 7.2: `sdr-ui::lrpt_viewer.rs`
+
+Fresh-from-scratch viewer. Structurally parallel to `apt_viewer.rs` but with a multi-channel buffer + RGB compositor.
+
+- [ ] **Step 7.2.1: Create `crates/sdr-ui/src/lrpt_viewer.rs`**
+
+```rust
+//! Live LRPT image viewer window.
+//!
+//! Mirrors apt_viewer.rs structurally:
+//! - Standalone GtkWindow opened on AOS, refilled per pass
+//! - Pause/Resume + Export PNG header buttons
+//! - Live render via GtkDrawingArea
+//!
+//! Differences vs APT:
+//! - Channel picker dropdown — preview each AVHRR channel
+//!   individually (greyscale)
+//! - RGB composite picker (3 dropdowns: R, G, B) — false-color
+//!   composite live render
+//! - Per-channel PNG export at LOS, plus the composite
+
+use crate::state::AppState;
+use adw::prelude::*;
+use gtk4::glib;
+use sdr_radio::lrpt_image::LrptImage;
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+
+pub struct LrptImageView {
+    pub window: gtk4::Window,
+    pub image: LrptImage,
+    selected_channel: Rc<RefCell<u8>>,
+    rgb_triple: Rc<RefCell<(u8, u8, u8)>>,
+    paused: Rc<RefCell<bool>>,
+}
+
+impl LrptImageView {
+    #[must_use]
+    pub fn new(parent: Option<&gtk4::Window>, image: LrptImage) -> Self {
+        let window = gtk4::Window::builder()
+            .title("Meteor LRPT")
+            .default_width(800)
+            .default_height(600)
+            .build();
+        if let Some(p) = parent {
+            window.set_transient_for(Some(p));
+        }
+
+        let header = adw::HeaderBar::new();
+        // Channel picker + RGB triple picker + pause + export
+        // (UI assembly elided here — pattern matches APT viewer).
+        let _ = header;
+
+        Self {
+            window,
+            image,
+            selected_channel: Rc::new(RefCell::new(1)),
+            rgb_triple: Rc::new(RefCell::new((1, 2, 3))),
+            paused: Rc::new(RefCell::new(false)),
+        }
+    }
+
+    /// Save all per-channel PNGs + composite into `dir`. Called
+    /// from the recorder at LOS.
+    pub fn export_pngs(&self, dir: &Path) -> Result<usize, String> {
+        let mut count = 0_usize;
+        self.image
+            .with_assembler(|assembler| -> Result<(), String> {
+                for (&vcid, channel) in assembler.channels() {
+                    let path = dir.join(format!("ch{vcid}.png"));
+                    sdr_lrpt::image::save_channel(&path, channel)
+                        .map_err(|e| format!("ch{vcid}: {e}"))?;
+                    count += 1;
+                }
+                let comp_path = dir.join("composite-rgb.png");
+                let (r, g, b) = *self.rgb_triple.borrow();
+                if let Err(e) = sdr_lrpt::image::save_composite(&comp_path, assembler, r, g, b) {
+                    eprintln!("composite skipped: {e}");
+                } else {
+                    count += 1;
+                }
+                Ok(())
+            })
+            .ok_or("image lock poisoned")??;
+        Ok(count)
+    }
+
+    /// Wipe the image buffer at the start of a new pass.
+    pub fn clear(&self) {
+        self.image.clear();
+    }
+}
+
+/// Open the LRPT viewer if not already open. Mirrors
+/// `open_apt_viewer_if_needed`.
+pub fn open_lrpt_viewer_if_needed(
+    parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,
+    state: &Rc<AppState>,
+) {
+    if state.lrpt_viewer.borrow().is_some() {
+        return;
+    }
+    let parent = parent_provider();
+    let image = state.lrpt_image.clone();
+    let view = Rc::new(LrptImageView::new(parent.as_ref(), image));
+    view.window.present();
+    *state.lrpt_viewer.borrow_mut() = Some(Rc::clone(&view));
+}
+```
+
+The `AppState` needs new fields `lrpt_viewer: RefCell<Option<Rc<LrptImageView>>>` and `lrpt_image: LrptImage`. Add to `crates/sdr-ui/src/state.rs`.
+
+- [ ] **Step 7.2.2: Add `pub mod lrpt_viewer;` to `crates/sdr-ui/src/lib.rs`**
+
+- [ ] **Step 7.2.3: Build the UI**
+
+```bash
+cargo build -p sdr-ui --features sdr-ui/whisper
+```
+
+Expected: clean build. The viewer's full GTK assembly (channel/RGB pickers, drawing area, render loop) is ~250 lines lifted from `apt_viewer.rs`'s pattern; the implementer fills in the GTK widget tree following that precedent.
+
+### Module 7.3: Wire LRPT branch in `interpret_action`
+
+- [ ] **Step 7.3.1: Replace the placeholder LRPT branch in `crates/sdr-ui/src/window.rs::interpret_action`**
+
+```rust
+sdr_sat::ImagingProtocol::Lrpt => {
+    crate::lrpt_viewer::open_lrpt_viewer_if_needed(&parent_provider_a, &state_a);
+    if let Some(view) = state_a.lrpt_viewer.borrow().as_ref() {
+        view.clear();
+    }
+    // Hand the LrptImage to the radio thread's lrpt_decoder.
+    // (DSP wiring goes via the engine's command channel; the
+    // pattern matches APT's "set decoder type to Lrpt" message.)
+    state_a.send_dsp(UiToDsp::SetImagingDecoder(
+        sdr_types::ImagingDecoder::Lrpt,
+    ));
+}
+```
+
+**Engine-side wiring** (port from the APT pattern):
+
+1. Add a new `UiToDsp::SetImagingDecoder(ImagingDecoder)` message variant in `crates/sdr-types/src/lib.rs` (or wherever `UiToDsp` lives) where `ImagingDecoder` is a small enum: `enum ImagingDecoder { None, Apt, Lrpt }`. Mirror the new enum in `sdr-types` so it doesn't depend on `sdr-sat`.
+2. In `sdr-core` (or `sdr-pipeline`'s engine module — wherever the existing APT decoder hook lives), the active-decoder slot becomes a `Box<dyn ImagingProcessor>` or matching enum match. APT keeps its existing hook; LRPT plugs into the same call site by handing the `LrptDecoder::process()` method.
+3. The grep for "APT decoder activation" in the existing codebase (likely in `sdr-radio::apt_decoder` and the engine's command-loop dispatch) is the canonical reference for where to add the LRPT branch — pattern-match against it.
+
+This is the only Task 7 step that touches engine-thread plumbing rather than UI; keep diff minimal — the LRPT branch should structurally match APT's exactly.
+
+- [ ] **Step 7.3.2: Update `RecorderAction::SavePng` arm** to use a per-pass subdirectory for LRPT and pass the right viewer:
+
+```rust
+RecorderAction::SavePng(path) => {
+    // path is the pass's per-output target; for APT it's a single
+    // .png file, for LRPT it's a directory.
+    let result_msg = match Path::new(&path).extension().and_then(|e| e.to_str()) {
+        Some("png") => {
+            // APT path
+            if let Some(view) = state_a.apt_viewer.borrow().as_ref() {
+                match view.export_png(&path) {
+                    Ok(()) => format!("Pass complete — image saved to {}", path.display()),
+                    Err(e) => format!("Pass complete but PNG save failed: {e}"),
+                }
+            } else {
+                "Pass complete, but APT viewer was closed".to_string()
+            }
+        }
+        _ => {
+            // LRPT directory path
+            std::fs::create_dir_all(&path).ok();
+            if let Some(view) = state_a.lrpt_viewer.borrow().as_ref() {
+                match view.export_pngs(&path) {
+                    Ok(n) => format!("Pass complete — {n} PNGs saved to {}", path.display()),
+                    Err(e) => format!("Pass complete but PNG save failed: {e}"),
+                }
+            } else {
+                "Pass complete, but LRPT viewer was closed".to_string()
+            }
+        }
+    };
+    post_toast(&toast_overlay_weak, &result_msg);
+}
+```
+
+- [ ] **Step 7.3.3: Update `png_path_for` in the recorder** to return a directory path for LRPT:
+
+```rust
+// In crates/sdr-ui/src/sidebar/satellites_recorder.rs:
+fn output_path_for(pass: &Pass, now: DateTime<Utc>, protocol: ImagingProtocol) -> PathBuf {
+    let stamp = now.with_timezone(&chrono::Local).format("%Y-%m-%d-%H%M%S").to_string();
+    let sat_slug: String = pass.satellite.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let sat_slug = sat_slug.split('-').filter(|s| !s.is_empty()).collect::<Vec<_>>().join("-");
+    let base = glib::home_dir().join("sdr-recordings");
+    match protocol {
+        ImagingProtocol::Apt => base.join(format!("apt-{sat_slug}-{stamp}.png")),
+        ImagingProtocol::Lrpt => base.join(format!("lrpt-{sat_slug}-{stamp}")),
+    }
+}
+```
+
+The recorder's `Action::SavePng(path)` payload is now sometimes a directory; the wiring in 7.3.2 dispatches by extension.
+
+### Module 7.4: Catalog flip + toggle copy
+
+- [ ] **Step 7.4.1: Flip METEOR-M catalog entries** in `crates/sdr-sat/src/lib.rs`:
+
+```rust
+// Change:
+KnownSatellite {
+    name: "METEOR-M 2",
+    ...
+    imaging_protocol: None,
+},
+// To:
+KnownSatellite {
+    name: "METEOR-M 2",
+    ...
+    imaging_protocol: Some(ImagingProtocol::Lrpt),
+},
+// Same for METEOR-M2 3.
+```
+
+- [ ] **Step 7.4.2: Update the catalog test** (from Task 6) so METEOR satellites now expect `Some(Lrpt)`:
+
+```rust
+// In crates/sdr-sat/src/lib.rs::tests::known_satellites_have_expected_protocol_assignments:
+for s in KNOWN_SATELLITES.iter().filter(|s| s.name.starts_with("METEOR")) {
+    assert_eq!(
+        s.imaging_protocol,
+        Some(ImagingProtocol::Lrpt),
+        "{} should be LRPT", s.name,
+    );
+}
+```
+
+- [ ] **Step 7.4.3: Update Satellites panel toggle copy** in `crates/sdr-ui/src/sidebar/satellites_panel.rs`:
+
+```rust
+let auto_record_switch = adw::SwitchRow::builder()
+    .title("Auto-record satellite passes") // was: "Auto-record APT passes"
+    .subtitle("Tune to the satellite, start the decoder, save the image at LOS.")
+    .active(false)
+    .build();
+```
+
+- [ ] **Step 7.4.4: Build + test**
+
+```bash
+cargo test -p sdr-sat
+cargo test -p sdr-ui --features sdr-ui/whisper
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all green.
+
+- [ ] **Step 7.4.5: Run install + manual smoke test against an upcoming Meteor pass**
+
+Per the user's smoke-test workflow (memory: "user runs GTK4 smoke tests manually; Claude runs make install + provides checklist, never launches the binary"), build + install:
+
+```bash
+make install CARGO_FLAGS="--release --features whisper-cuda"
+```
+
+Then provide the user with this smoke-test checklist:
+
+> **Smoke test for LRPT auto-record (Task 7):**
+> 1. Launch the app. Open Satellites panel. Verify METEOR-M 2 / METEOR-M2 3 appear in the Upcoming Passes list with their downlink frequencies.
+> 2. Toggle "Auto-record satellite passes" on.
+> 3. Wait for a Meteor-M 2-3 pass with peak elevation ≥ 25°. Walk away.
+> 4. After AOS, verify:
+>    - Frequency tunes to 137.900 MHz (Meteor-M 2-3 downlink)
+>    - LRPT viewer window opens
+>    - Channels start populating in the picker dropdown
+> 5. After LOS, verify:
+>    - Toast shows "Pass complete — N PNGs saved to ~/sdr-recordings/lrpt-METEOR-M-2-3-..."
+>    - The directory contains `composite-rgb.png` + per-channel `chN.png` files
+>    - Frequency restores to whatever was tuned pre-AOS
+> 6. Open one of the PNGs — should show recognizable Earth features (cloud + coastline).
+
+- [ ] **Step 7.4.6: Commit catalog flip + integration**
+
+```bash
+git add crates/
+git commit -m "$(cat <<'EOF'
+sdr-ui + sdr-radio + sdr-sat: end-to-end LRPT integration
+
+Final piece of the LRPT receive loop:
+- sdr-radio::lrpt_decoder driver wires LrptDemod + LrptPipeline
+  to the audio-thread tap, mirrors apt_decoder
+- sdr-ui::lrpt_viewer.rs — fresh viewer with channel picker, RGB
+  composite picker, pause/export header buttons
+- interpret_action LRPT branch dispatches to the new viewer +
+  decoder; SavePng arm handles directory paths for LRPT
+- sdr-sat catalog: METEOR-M 2 + 2-3 entries flip to Some(Lrpt)
+- Satellites panel toggle copy: APT-specific → satellite-neutral
+
+Per-pass output directory pattern matches the spec:
+~/sdr-recordings/lrpt-METEOR-M-2-3-{ts}/{composite-rgb,chN}.png
+
+Functionally completes epic #469 — Task 8 ships the docs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Final Task 7 verification
+
+- [ ] **Step 7.5.1: Push + open PR + wait for CR.**
+
+PR title: `sdr-ui + sdr-radio + sdr-sat: end-to-end LRPT integration (epic #469)`
+
+The PR body should include the smoke-test checklist from 7.4.5; this is the user-side validation gate before docs land.
+
+
+
+## Task 8: Docs walkthrough (closes #469)
+
+**Branch:** `feature/lrpt-docs`
+**Files:**
+- Create: `docs/guides/lrpt-reception.md`
+- Modify: `CLAUDE.md` (extend Satellite-reception subsection; bump crate roster: 23 → 24 members; add `sdr-lrpt` line)
+- Modify: `README.md` (extend Weather-satellites bullet to include LRPT; add `sdr-lrpt` to architecture diagram; bump crate count)
+
+This PR closes the epic per the spec's verification step 10. The walkthrough mirrors `docs/guides/apt-reception.md`'s shape — first-pass UX, antenna recipe, troubleshooting, "next steps" pointing at #520's deferred work.
+
+**Pre-task setup:**
+
+- [ ] **Step 0a: Branch (after Task 7 has landed + smoke test passed)**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feature/lrpt-docs
+```
+
+### Module 8.1: Walkthrough doc
+
+- [ ] **Step 8.1.1: Create `docs/guides/lrpt-reception.md`**
+
+Structure (read the existing `docs/guides/apt-reception.md` first to match voice + level of detail):
+
+```markdown
+# Receive your first Meteor LRPT pass
+
+A walkthrough from "I have an RTL-SDR + this app + a working
+NOAA APT setup" to "I just received a digital satellite image
+from a Meteor-M satellite." Aimed at a user who's already
+captured at least one APT pass — assumes familiarity with the
+basic pass-prediction + auto-record flow.
+
+The whole thing takes about as long as the pass itself —
+12-15 minutes of attended time once your antenna is up.
+
+---
+
+## What's different from APT
+
+LRPT (Low-Rate Picture Transmission) is the digital successor
+to NOAA APT. Same 137 MHz band, same V-dipole antenna works,
+but the signal itself is QPSK-modulated digital with full
+forward error correction. What you get back:
+
+- **Up to 6 imaging channels per pass** — visible, near-IR,
+  and three thermal-IR bands. Meteor typically transmits 3 at
+  a time.
+- **~1 km/pixel resolution** versus APT's ~4 km/pixel.
+- **False-color RGB composites** — one PNG per channel plus
+  a configurable RGB composite (default: channels 1+2+3).
+- **No telemetry strip** — LRPT doesn't include APT's wedge-
+  calibration strip. Image SNR is harder to eyeball but the
+  FEC tolerates lower SNR cleanly before it falls apart.
+
+The hand-off is sharper than APT: clean LRPT signal → clean
+image, marginal LRPT signal → no image (FEC fails). APT
+degrades gracefully into noise; LRPT just stops.
+
+---
+
+## Antenna
+
+V-dipole with 53 cm arms in a 120° spread, hung horizontally —
+same as for APT. See [docs/guides/apt-reception.md](apt-reception.md#antenna)
+for the full recipe.
+
+LRPT is more SNR-sensitive than APT — the FEC chain demands
+~2-3 dB better signal to lock cleanly. That means:
+- High-elevation passes (peak ≥ 30°) are noticeably more
+  reliable than mid-elevation (15-25°) for LRPT.
+- A clear horizon matters more. A pass that grazes a building
+  edge that APT would still decode cleanly might lose Viterbi
+  lock for LRPT.
+- The same FM-broadcast notch filter that helps APT helps
+  LRPT — same recommendations.
+
+---
+
+## Your first LRPT pass
+
+The flow:
+
+### 1. Pick an upcoming Meteor pass
+
+Open the Satellites panel (`Ctrl+7`). The Upcoming Passes list
+shows METEOR-M 2 and METEOR-M2 3 alongside the NOAA satellites.
+
+Look for a Meteor pass with **peak elevation ≥ 30°**. Lower
+passes will work but the FEC chain is less forgiving than APT
+near the horizons.
+
+### 2. Toggle auto-record (now satellite-agnostic)
+
+The toggle is now labelled "Auto-record satellite passes" —
+it covers both APT and LRPT. With it on, the recorder picks
+whichever protocol matches the pass's satellite from the
+catalog.
+
+### 3. Watch the LRPT viewer build
+
+When AOS fires, an **LRPT Viewer** window opens (different from
+the APT viewer — multi-channel + RGB composite). The header bar
+has:
+- **Channel picker** — preview each AVHRR channel individually
+  (greyscale)
+- **RGB composite picker** — three dropdowns (R, G, B) to pick
+  the composite triple, defaults to 1/2/3
+- **Pause/Resume** — freeze the live render
+- **Export PNG** — save current state
+
+The image fills top-to-bottom as the pass progresses. With LRPT
+you'll see the channel buffers populate in real time — flip
+between them via the dropdown to confirm which AVHRR bands the
+satellite is currently transmitting.
+
+### 4. After LOS
+
+Files land in `~/sdr-recordings/lrpt-METEOR-M-2-3-{timestamp}/`:
+- `composite-rgb.png` — the default RGB composite
+- `ch{N}.png` — one PNG per channel that was actually
+  transmitted (typically 3 of the 6 possible)
+
+The save toast shows the directory path. Open any of the
+channel PNGs in an image viewer. The composite is the
+"pretty picture" — false-color view of the same Earth strip.
+
+---
+
+## When things go wrong
+
+### Image is empty / "no PNGs saved"
+
+The FEC chain didn't lock. Most common causes:
+- **SNR too low** — signal too weak for QPSK + FEC. Check the
+  spectrum view during the pass; if the carrier looks like
+  noise (no clear constellation rotation), antenna signal
+  isn't strong enough. Higher pass + better antenna placement
+  helps.
+- **Doppler shift past the filter edge** — currently we don't
+  Doppler-correct (deferred to #521). For passes with peak
+  elevation > 60°, the closing/receding shift can push the
+  carrier near the channel filter wall. Workaround: tweak
+  the channel filter bandwidth wider (50 kHz instead of 38)
+  via the Radio panel before AOS.
+
+### Some channels arrive, others don't
+
+This is normal — Meteor only transmits 3 channels at a time
+(rotating through which 3 over the operational schedule).
+Empty channels mean the satellite wasn't transmitting that
+band during this pass.
+
+### Composite looks wrong / channels mismatched
+
+The default RGB triple is 1+2+3. If the satellite is
+transmitting a different set today, the composite will be
+black or very dark (missing channels). Use the channel
+picker to confirm what's arriving, then change the RGB
+dropdowns to a triple you have data for.
+
+### Image decodes but has horizontal "tearing"
+
+CCSDS framer lost sync mid-pass and recovered. Cosmetic only;
+the rest of the image is still aligned correctly. More
+common at low elevations — same fix as the empty-image case.
+
+### Auto-record fired for an APT satellite instead
+
+Auto-record picks the soonest eligible pass — if a NOAA pass
+overlaps a Meteor pass, NOAA wins because it arrives first.
+Workaround: temporarily uncheck NOAA satellites in the
+satellite catalog (config setting), or just wait for the
+Meteor pass without overlap.
+
+---
+
+## Next steps
+
+- **Doppler correction** (issue [#521](https://github.com/jasonherald/rtl-sdr/issues/521))
+  is the biggest ergonomic improvement on the roadmap for
+  high-elevation Meteor passes.
+- **Map projection / georeferencing** (issue [#522](https://github.com/jasonherald/rtl-sdr/issues/522))
+  to overlay your imagery on a real-world basemap.
+- **CCSDS frame archival** (issue [#524](https://github.com/jasonherald/rtl-sdr/issues/524))
+  for offline re-decode of marginal passes once decoder
+  improvements ship.
+- **ISS SSTV** (epic [#472](https://github.com/jasonherald/rtl-sdr/issues/472))
+  during commemorative ARISS events — different band (145.8
+  MHz), different decoder.
+
+If your first Meteor pass came through clean, you've now
+received imagery from both analog (APT) and digital (LRPT)
+weather satellites — a complete LEO-weather receive setup.
+```
+
+- [ ] **Step 8.1.2: Verify all UI labels in the doc match the live build**
+
+```bash
+grep -n "Auto-record" docs/guides/lrpt-reception.md
+# Compare against the actual label in:
+grep -n 'title("Auto-record' crates/sdr-ui/src/sidebar/satellites_panel.rs
+```
+
+Expected: `"Auto-record satellite passes"` matches both. Verify viewer button labels (Channel picker, RGB pickers, Pause/Resume, Export PNG) similarly.
+
+- [ ] **Step 8.1.3: Verify output path claim** matches `output_path_for` from Task 7.
+
+```bash
+grep -n "lrpt-" crates/sdr-ui/src/sidebar/satellites_recorder.rs
+```
+
+Expected: pattern `lrpt-{sat_slug}-{stamp}` matches the doc's `lrpt-METEOR-M-2-3-{timestamp}/` example.
+
+### Module 8.2: CLAUDE.md update
+
+- [ ] **Step 8.2.1: Update CLAUDE.md architecture roster**
+
+Find the existing 23-member workspace block. Bump to 24 + add `sdr-lrpt`:
+
+```text
+sdr-lrpt              → Meteor-M LRPT decoder: Viterbi + RS + CCSDS framing + JPEG image assembly
+```
+
+(insert alphabetically between `sdr-config` and `sdr-pipeline` or wherever fits the existing ordering).
+
+- [ ] **Step 8.2.2: Update the Satellite-reception subsection**
+
+Change the opening line from:
+
+> NOAA APT (epic #468) is shipped end-to-end. Future weather-sat work (Meteor-M LRPT #469, ISS SSTV #472) will reuse the same scaffolding.
+
+to:
+
+> NOAA APT (epic #468) and Meteor-M LRPT (epic #469) are both shipped end-to-end. Future ISS SSTV (#472) will reuse the same scaffolding.
+
+Add a new bullet to the "Key files" list:
+
+```markdown
+- `crates/sdr-lrpt/` — Meteor LRPT decoder: pure-Rust port of `medet`'s 4-stage chain (Viterbi rate-1/2 K=7, Reed-Solomon (255, 223) CCSDS dual-basis, VCDU/M_PDU framing, Meteor reduced-JPEG decoder). The `LrptPipeline` entry point at `lib.rs` is the streaming-symbol-in, image-out interface; `sdr-radio::lrpt_decoder` glues it to the audio-thread tap.
+- `crates/sdr-ui/src/lrpt_viewer.rs` — Live LRPT viewer with multi-channel buffer + RGB composite picker. Independent of `apt_viewer.rs` — different rendering surface (multi-channel false-color vs single-channel scrolling strip).
+```
+
+Add a new line about the user walkthrough:
+
+```markdown
+**User-facing walkthroughs:** `docs/guides/apt-reception.md` (NOAA APT), `docs/guides/lrpt-reception.md` (Meteor LRPT).
+```
+
+(Replacing the existing single-doc reference.)
+
+Update the PNG output path note:
+
+```markdown
+**PNG output paths:** APT writes a single file at `~/sdr-recordings/apt-{slug}-{ts}.png`; LRPT writes a per-pass directory at `~/sdr-recordings/lrpt-{slug}-{ts}/` containing `composite-rgb.png` + per-channel `chN.png` files. The `output_path_for` function in `satellites_recorder.rs` is the single source of truth.
+```
+
+### Module 8.3: README.md update
+
+- [ ] **Step 8.3.1: Update Weather-satellites feature bullet**
+
+Change:
+
+> - **NOAA APT** reception on 137 MHz — pass prediction (SGP4 + Celestrak TLEs), live image viewer, PNG export, auto-record-on-pass that tunes the radio at AOS, opens the viewer, saves the image at LOS, and restores your previous tune
+> - Walkthrough: [`docs/guides/apt-reception.md`](docs/guides/apt-reception.md) — antenna setup, FM-broadcast notch advice, your first pass, troubleshooting
+> - Built-in catalog covers NOAA 15 / 18 / 19 (APT), Meteor-M 2 / Meteor-M2 3 (LRPT placeholder — decoder pending #469), and ISS (SSTV placeholder — pending #472)
+
+To:
+
+> - **NOAA APT** + **Meteor-M LRPT** reception on 137 MHz — pass prediction (SGP4 + Celestrak TLEs), live image viewer, PNG export, auto-record-on-pass that tunes the radio at AOS, opens the viewer, saves the image at LOS, and restores your previous tune. APT is single-channel analog imagery; LRPT is multi-channel (up to 6 AVHRR bands) digital imagery with FEC + CCSDS + JPEG decoding.
+> - Walkthroughs: [APT](docs/guides/apt-reception.md), [LRPT](docs/guides/lrpt-reception.md) — antenna setup, FM-broadcast notch advice, first pass, troubleshooting
+> - Built-in catalog covers NOAA 15 / 18 / 19 (APT), Meteor-M 2 / Meteor-M2 3 (LRPT), and ISS (SSTV placeholder — pending #472)
+
+- [ ] **Step 8.3.2: Update workspace count**
+
+Replace `23-member workspace (root binary + 22 library crates)` with `24-member workspace (root binary + 23 library crates)` everywhere it appears.
+
+- [ ] **Step 8.3.3: Add `sdr-lrpt` to the architecture diagram**
+
+Find the architecture block (around line 280s). Add a new row:
+
+```text
+sdr-lrpt                  Meteor LRPT decoder: Viterbi + RS + CCSDS + JPEG image assembly
+```
+
+(Insert in a sensible position — after `sdr-sat` would group satellite-related crates.)
+
+### Module 8.4: Final commits + epic close
+
+- [ ] **Step 8.4.1: Build everything to verify nothing's broken**
+
+```bash
+cargo build --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all green. Docs-only PRs sometimes catch broken doc-tests if any of the modified files have ```rust blocks.
+
+- [ ] **Step 8.4.2: Commit docs**
+
+```bash
+git add docs/guides/lrpt-reception.md CLAUDE.md README.md
+git commit -m "$(cat <<'EOF'
+docs: NOAA Meteor-M LRPT reception walkthrough (closes #469)
+
+User-facing guide at docs/guides/lrpt-reception.md walking a
+user already familiar with the APT flow through their first
+Meteor-M LRPT pass. Covers the differences from APT (digital
+QPSK + FEC + 6-channel imagery + RGB composite), antenna
+SNR-sensitivity notes, first-pass UI flow, and a troubleshooting
+section keyed by visual symptoms.
+
+CLAUDE.md updated to reflect the now-shipped LRPT path: sdr-lrpt
+crate added to the architecture roster (24 workspace members
+total), Satellite-reception subsection extended with file-map
+entries for sdr-lrpt + lrpt_viewer.rs, output paths documented.
+
+README.md updated to mention LRPT in the Weather-satellites feature
+bullet, link both walkthroughs (APT + LRPT), and add sdr-lrpt to
+the architecture diagram.
+
+Closes #469 — full Meteor-M LRPT receive loop is now shipped.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 8.4.3: Push + open PR**
+
+```bash
+git push -u origin feature/lrpt-docs
+gh pr create --base main --title "docs: Meteor-M LRPT reception walkthrough (closes #469)" --body "$(cat <<'EOF'
+## Summary
+
+Final piece of epic #469 — closes the LRPT epic.
+
+- New walkthrough: \`docs/guides/lrpt-reception.md\` parallels the APT walkthrough's structure (antenna, first pass UI flow, troubleshooting, next steps).
+- CLAUDE.md: \`sdr-lrpt\` added to architecture roster (24 members), Satellite-reception subsection extended, output-path conventions documented.
+- README.md: Weather-satellites bullet expanded, both walkthroughs linked, architecture diagram updated.
+
+## Test plan
+- [ ] Read \`docs/guides/lrpt-reception.md\` end-to-end and confirm UI labels (Auto-record satellite passes, viewer header buttons, channel picker) match the live app.
+- [ ] Verify output-path claim (\`~/sdr-recordings/lrpt-{slug}-{ts}/\`) matches \`output_path_for\` in \`satellites_recorder.rs\`.
+- [ ] Backfill hero + V-dipole image placeholders post-merge from overnight smoke-test captures (same pattern as the APT walkthrough's hero).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8.4.4: Wait for CodeRabbit + reply per workflow.**
+
+- [ ] **Step 8.4.5: Once merged, close epic #469 with a wrap-up comment** (mirrors the #468 wrap-up):
+
+```bash
+gh issue comment 469 --repo jasonherald/rtl-sdr --body "$(cat <<'EOF'
+## Epic complete — closing out 🛰️
+
+Full Meteor-M LRPT receive loop shipped end-to-end across 8 PRs:
+
+- **PR 1** — \`sdr-dsp::lrpt\` stage 1 (QPSK demod: Costas + RRC + Gardner + slicer)
+- **PR 2** — \`sdr-lrpt::fec\` stage 2a (Viterbi + frame sync + CCSDS PN derand)
+- **PR 3** — \`sdr-lrpt::fec\` stage 2b (Reed-Solomon (255, 223) dual-basis)
+- **PR 4** — \`sdr-lrpt::ccsds\` stage 3 (VCDU + M_PDU + virtual-channel demux)
+- **PR 5** — \`sdr-lrpt::image\` stage 4 (Meteor JPEG + composite + replay CLI)
+- **PR 6** — Auto-record generalization closing #514 (catalog-driven ImagingProtocol enum)
+- **PR 7** — End-to-end integration (\`lrpt_decoder\` driver + \`lrpt_viewer\` + Meteor catalog flip)
+- **PR 8** — Walkthrough + CLAUDE.md + README.md updates (this PR)
+
+Comprehensive testing as designed: spec-vector unit tests for FEC layers, proptest round-trip + single-bit-error correction, golden-output regression scaffold, criterion benches per stage, 90% CI coverage gate on \`sdr-lrpt\`.
+
+Out-of-scope follow-ups tracked in epic #520 (Doppler correction #521, map projection #522, telemetry decode #523, frame archival #524).
+
+User-facing payoff: same auto-record toggle the APT epic introduced now covers Meteor-M 2 / Meteor-M2 3 — one click, walk away, come back to per-channel + RGB composite PNGs in \`~/sdr-recordings/\`.
+EOF
+)"
+
+gh issue close 469 --repo jasonherald/rtl-sdr --reason completed
+```
+
+

--- a/docs/superpowers/specs/2026-04-25-meteor-lrpt-design.md
+++ b/docs/superpowers/specs/2026-04-25-meteor-lrpt-design.md
@@ -22,7 +22,7 @@ A live LRPT viewer shows the image building up during the pass with channel pick
 ### In scope (this epic)
 
 - All four pipeline stages: QPSK demod → Viterbi+RS FEC → CCSDS framing → JPEG image assembly
-- Catalog: Meteor-M 2 (137.100 MHz, degraded but operational) and Meteor-M 2-3 (137.900 MHz, operational). Meteor-M 2-4 stays deferred per #506 until Celestrak publishes a TLE.
+- Catalog (as of April 2026): Meteor-M 2 (137.100 MHz, degraded but operational) and Meteor-M 2-3 (137.900 MHz, operational). Meteor-M 2-4 stays deferred per #506 until Celestrak publishes a TLE.
 - Per-channel + composite PNG export at LOS
 - Auto-record integration via the existing recorder, generalized for non-APT satellites (closes [#514](https://github.com/jasonherald/rtl-sdr/issues/514))
 - Live LRPT viewer with channel/composite picker
@@ -40,7 +40,7 @@ A live LRPT viewer shows the image building up during the pass with channel pick
 
 ## 2. Architecture & data flow
 
-```
+```text
 [I/Q samples from RTL-SDR]
         ↓
    sdr-pipeline                       (existing — same path APT uses)
@@ -101,7 +101,7 @@ Same as APT: the entire 4-stage pipeline runs on the existing audio-thread tap t
 
 ### Dependency graph for the new code
 
-```
+```text
 sdr-dsp           (already exists; gains lrpt:: submodule for stage 1)
    ↑
 sdr-lrpt          (new; depends on sdr-dsp, sdr-types)
@@ -119,7 +119,7 @@ sdr-ui            (already exists; gains lrpt_viewer.rs + sat-recorder generaliz
 
 ### `crates/sdr-dsp/src/lrpt/` (extends existing `sdr-dsp`)
 
-```
+```text
 lrpt/
   mod.rs          // re-exports + LrptDemod top-level processor
   costas.rs       // QPSK Costas loop (carrier recovery)
@@ -132,7 +132,7 @@ Reference: **SDR++'s `decoder_modules/meteor_demodulator/src/`** — `meteor_cos
 
 ### `crates/sdr-lrpt/src/` (new crate)
 
-```
+```text
 src/
   lib.rs          // public API: LrptPipeline, decode_pass(...) entry point
   fec/
@@ -183,7 +183,7 @@ Mirrors `apt_image.rs` exactly — buffers per-channel scan lines, exposes a str
 
 Fresh from scratch, structurally parallel to `apt_viewer.rs` but rendering very different content:
 
-```
+```text
 LrptImageView
   • per-channel buffers (up to 6 AVHRR channels — only those
     actually transmitted on this pass populate)
@@ -246,7 +246,7 @@ match protocol {
 
 APT keeps its current single-file shape. LRPT goes into a per-pass subdirectory because there can be up to 7 artefacts per pass (1 composite + up to 6 channels):
 
-```
+```text
 ~/sdr-recordings/
   apt-NOAA-19-2026-04-25-143022.png            (existing — unchanged)
   lrpt-METEOR-M-2-3-2026-04-25-143022/         (new pattern)
@@ -268,7 +268,7 @@ Eight sub-tickets, mirroring APT's count. Bottom-up: each PR is independently te
 | 2 | **Stage 2a: Viterbi + frame sync + derand.** Rate-1/2 K=7 Viterbi, 32-bit ASM correlator (`0x1ACFFC1D`), CCSDS PN de-randomizer. Tests with bit-vectors encoded by a known reference. | `sdr-lrpt::fec` (new crate, partial) | new |
 | 3 | **Stage 2b: Reed-Solomon (255, 223).** GF(256) arithmetic, CCSDS dual-basis representation, RS decoder. Tests against CCSDS Blue Book test vectors. | `sdr-lrpt::fec` (completes the FEC chain) | new |
 | 4 | **Stage 3: CCSDS framing.** VCDU / CADU parser, M_PDU reassembly across CADU boundaries, virtual-channel demux (image VCs only — non-imaging routed to `Discard` per the #523 deferral). | `sdr-lrpt::ccsds` (new submodule) | new |
-| 5 | **Stage 4: Image assembly + Meteor JPEG.** Meteor's reduced-JPEG decoder (DCT-block per scan-line group), per-channel image buffer, false-color RGB compositor. Includes a small CLI binary `sdr-lrpt-replay` that decodes a fixture frame file → PNGs, end-to-end test of stages 1-5. | `sdr-lrpt::image`, `sdr-radio::lrpt_image` | new |
+| 5 | **Stage 4: Image assembly + Meteor JPEG.** Meteor's reduced-JPEG decoder (DCT-block per scan-line group), per-channel image buffer, false-color RGB compositor. Includes a small CLI binary `sdr-lrpt-replay` that decodes a fixture frame file → PNGs, end-to-end test of stages 1-4. | `sdr-lrpt::image`, `sdr-radio::lrpt_image` | new |
 | 6 | **Auto-record generalization** (closes [#514](https://github.com/jasonherald/rtl-sdr/issues/514)). Add `ImagingProtocol` enum to `sdr-sat`, `imaging_protocol` field to `KnownSatellite`, recorder filter from `is_apt_capable` → `imaging_protocol.is_some()`, `protocol` field on `Action::StartAutoRecord`, branching dispatch in `interpret_action`. Meteor catalog entries stay `None` for now — generalization lands without changing user-visible behaviour. | `sdr-sat`, `sdr-ui::sidebar::satellites_recorder`, `sdr-ui::window` | #514 |
 | 7 | **End-to-end LRPT integration.** New `sdr-ui::lrpt_viewer.rs` (channel picker + RGB composite + pause/export). New `sdr-radio::lrpt_decoder` driver that wires the 4-stage pipeline to the existing audio-thread tap. Flip Meteor-M 2 / Meteor-M 2-3 catalog entries to `imaging_protocol = Some(Lrpt)`. Hook `interpret_action`'s LRPT branch. Update Satellites panel toggle copy. Per-pass subdirectory output paths. | `sdr-ui`, `sdr-radio`, `sdr-sat` | — |
 | 8 | **Docs walkthrough.** `docs/guides/lrpt-reception.md` — antenna requirements (same V-dipole, more SNR-sensitive), "your first Meteor LRPT pass" UI flow, troubleshooting (sync loss / FEC dropouts / missing channels / unfamiliar composite colours). Update `CLAUDE.md` + `README.md`. | `docs/`, `CLAUDE.md`, `README.md` | #469 |

--- a/docs/superpowers/specs/2026-04-25-meteor-lrpt-design.md
+++ b/docs/superpowers/specs/2026-04-25-meteor-lrpt-design.md
@@ -1,0 +1,378 @@
+# Meteor-M LRPT Reception — Design
+
+**Status:** Design-complete, implementation not started
+**Author:** jasonherald (with Claude)
+**Last updated:** 2026-04-25
+**Epic:** [#469 — Meteor-M LRPT digital weather satellites (137 MHz)](https://github.com/jasonherald/rtl-sdr/issues/469)
+**Related:** epic [#468](https://github.com/jasonherald/rtl-sdr/issues/468) (NOAA APT — sets the precedent for this design), epic [#520](https://github.com/jasonherald/rtl-sdr/issues/520) (LRPT post-MVP enhancements — deferred work)
+
+---
+
+## 1. Goal & success criteria
+
+Receive Meteor-M LRPT downlinks end-to-end as a pure-Rust port: tune the radio at AOS, demodulate the QPSK signal, decode the FEC chain (Viterbi + Reed-Solomon), parse CCSDS frames, reassemble Meteor's reduced-JPEG imagery, and save a multi-channel PNG set on LOS. Same unattended-receive UX as the just-shipped NOAA APT auto-record (#468), but for digital satellites.
+
+**Success looks like:** the user toggles auto-record, walks away, and 12 minutes later finds in `~/sdr-recordings/`:
+
+- `lrpt-METEOR-M-2-3-{timestamp}/composite-rgb.png` — default false-color RGB composite (channels 1+2+3 typical)
+- `lrpt-METEOR-M-2-3-{timestamp}/ch{N}.png` — one PNG per imaging channel actually transmitted on this pass
+
+A live LRPT viewer shows the image building up during the pass with channel picker + RGB composite picker.
+
+### In scope (this epic)
+
+- All four pipeline stages: QPSK demod → Viterbi+RS FEC → CCSDS framing → JPEG image assembly
+- Catalog: Meteor-M 2 (137.100 MHz, degraded but operational) and Meteor-M 2-3 (137.900 MHz, operational). Meteor-M 2-4 stays deferred per #506 until Celestrak publishes a TLE.
+- Per-channel + composite PNG export at LOS
+- Auto-record integration via the existing recorder, generalized for non-APT satellites (closes [#514](https://github.com/jasonherald/rtl-sdr/issues/514))
+- Live LRPT viewer with channel/composite picker
+- "Receive your first Meteor LRPT pass" walkthrough doc
+
+### Out of scope (deferred — see epic #520)
+
+- Doppler correction ([#521](https://github.com/jasonherald/rtl-sdr/issues/521)) — 38 kHz channel filter absorbs the ±3.5 kHz shift; cross-protocol feature
+- Map projection / georeferencing ([#522](https://github.com/jasonherald/rtl-sdr/issues/522)) — downstream polish; cross-protocol
+- Meteor spacecraft telemetry decode ([#523](https://github.com/jasonherald/rtl-sdr/issues/523)) — non-imaging VCs dropped in v1
+- Archive raw CCSDS frames to disk ([#524](https://github.com/jasonherald/rtl-sdr/issues/524)) — power-user / decoder-developer feature
+- macOS native-app integration. `sdr-lrpt` lives under the GTK4-only UI surface in v1, same as the APT decoder (`sdr-radio::apt_image` is consumed by `sdr-ui` but not exposed via `sdr-ffi`). Future macOS LRPT support would route through `sdr-ffi` like other cross-platform features; out of scope for #469.
+
+---
+
+## 2. Architecture & data flow
+
+```
+[I/Q samples from RTL-SDR]
+        ↓
+   sdr-pipeline                       (existing — same path APT uses)
+        ↓
+[I/Q at baseband sample rate]
+        ↓
+┌─────────────────────────────────────────────────────────────┐
+│ STAGE 1 — Demod                          sdr-dsp::lrpt      │
+│   • Costas loop (QPSK carrier recovery, ±half-symbol)       │
+│   • Root-raised-cosine matched filter (β=0.6, span 31)      │
+│   • Symbol timing recovery (Gardner)                        │
+│   • Hard slice → soft symbols (i8, ±127)                    │
+└─────────────────────────────────────────────────────────────┘
+        ↓
+[soft symbols, 72 ksym/s × 2 (I+Q) = 144k i8/s]
+        ↓
+┌─────────────────────────────────────────────────────────────┐
+│ STAGE 2 — FEC                            sdr-lrpt::fec      │
+│   • Viterbi rate-1/2 K=7 convolutional decoder              │
+│   • Frame sync (32-bit ASM 0x1ACFFC1D, sliding correlator)  │
+│   • De-randomize (PN sequence per CCSDS spec)               │
+│   • Reed-Solomon (255, 223), CCSDS dual-basis               │
+└─────────────────────────────────────────────────────────────┘
+        ↓
+[CCSDS Virtual-Channel Data Units (VCDUs), 1024 bytes each]
+        ↓
+┌─────────────────────────────────────────────────────────────┐
+│ STAGE 3 — Frame                          sdr-lrpt::ccsds    │
+│   • CCSDS Channel Access Data Unit (CADU) parsing           │
+│   • Multiplex demux by VC ID (imaging VCs only — others     │
+│     dropped in v1, see #523 for telemetry follow-up)        │
+│   • CCSDS packet (M_PDU) reassembly across CADU boundaries  │
+└─────────────────────────────────────────────────────────────┘
+        ↓
+[image packets, one per AVHRR-channel scan-line group]
+        ↓
+┌─────────────────────────────────────────────────────────────┐
+│ STAGE 4 — Image                          sdr-lrpt::image    │
+│   • JPEG-DCT-block decode (Meteor's reduced JPEG variant)   │
+│   • Per-channel 2D image buffer accumulation                │
+│   • False-color RGB compositor (per user-selectable triple) │
+│   • PNG export (per channel + composite)                    │
+└─────────────────────────────────────────────────────────────┘
+        ↓
+[per-pass subdirectory of PNGs]    ~/sdr-recordings/lrpt-...
+```
+
+### Crate placement rationale
+
+- **Stage 1 lives in `sdr-dsp`** because it's pure DSP (filters, PLL, slicer). Same crate as `sdr-dsp::apt`. Pure functions, no I/O.
+- **Stage 2 lives in `sdr-lrpt::fec`**, *not* `sdr-dsp`, because Viterbi + RS aren't really DSP — they're protocol-layer error correction. Future cross-protocol use can lift `sdr-lrpt::fec` into a generic `sdr-fec` crate; YAGNI until that second consumer arrives.
+- **Stages 2–4 are protocol logic** that stay together in `sdr-lrpt`. They share types (Frame, VCDU, M_PDU, ImagePacket) that don't need to be public outside the crate.
+- **Each stage's interface is a streaming function** — `process(input: &[T_in], output: &mut [T_out]) -> usize` — matching the project-wide DSP convention.
+
+### Threading model
+
+Same as APT: the entire 4-stage pipeline runs on the existing audio-thread tap that APT already uses. LRPT-at-72-ksym/s is well within budget for a single-thread pipeline; no need for stage-level threading.
+
+### Dependency graph for the new code
+
+```
+sdr-dsp           (already exists; gains lrpt:: submodule for stage 1)
+   ↑
+sdr-lrpt          (new; depends on sdr-dsp, sdr-types)
+   ↑
+sdr-radio         (already exists; gains lrpt_image::* glue, like apt_image)
+   ↑
+sdr-ui            (already exists; gains lrpt_viewer.rs + sat-recorder generalization)
+```
+
+`sdr-lrpt` itself has no DSP or GTK dependencies — it's a pure-data crate.
+
+---
+
+## 3. File layout + reference codebase mapping
+
+### `crates/sdr-dsp/src/lrpt/` (extends existing `sdr-dsp`)
+
+```
+lrpt/
+  mod.rs          // re-exports + LrptDemod top-level processor
+  costas.rs       // QPSK Costas loop (carrier recovery)
+  rrc_filter.rs   // root-raised-cosine matched filter (β=0.6, span 31)
+  timing.rs       // Gardner symbol-timing recovery
+  slicer.rs       // hard slice → soft symbols (i8 ±127)
+```
+
+Reference: **SDR++'s `decoder_modules/meteor_demodulator/src/`** — `meteor_costas.h` + `meteor_demod.h` are the source-of-truth. ~550 LoC C++, idiomatic translation.
+
+### `crates/sdr-lrpt/src/` (new crate)
+
+```
+src/
+  lib.rs          // public API: LrptPipeline, decode_pass(...) entry point
+  fec/
+    mod.rs        // ConvViterbi + RsBlock chain
+    viterbi.rs    // rate-1/2 K=7 convolutional Viterbi (G1=0o171, G2=0o133)
+    reed_solomon.rs  // RS(255, 223) over GF(256), CCSDS dual-basis
+    sync.rs       // 32-bit ASM correlator (0x1ACFFC1D)
+    derand.rs     // CCSDS PN sequence de-randomizer
+  ccsds/
+    mod.rs        // VCDU / CADU / M_PDU types + parser
+    vcdu.rs       // Virtual Channel Data Unit framing
+    mpdu.rs       // Multiplexed Protocol Data Unit reassembly
+    demux.rs      // VC-ID router (imaging only in v1)
+  image/
+    mod.rs        // ImageAssembler + ChannelBuffer
+    jpeg.rs       // Meteor's reduced-JPEG decoder (DCT block per scan group)
+    composite.rs  // false-color RGB compositor
+    png_export.rs // multi-PNG writer
+  bin/
+    replay.rs     // sdr-lrpt-replay CLI binary (PR 5) — fixture file → PNGs
+```
+
+### Reference codebases per layer
+
+| Layer | Primary reference | Secondary / cross-check |
+|---|---|---|
+| FEC Viterbi | `medet/viterbi.c` | `libcorrect` (validation only — we don't link) |
+| FEC RS | `medet/correlator.c` + `rs.c` | CCSDS Blue Book 101.0-B-3 (the spec itself) |
+| FEC sync | `medet/correlator.c` | `meteor_demod`'s sync (different signal point) |
+| CCSDS VCDU | `meteordemod` (digitalvoid7) | CCSDS Blue Book 132.0-B-1 |
+| CCSDS M_PDU | `meteordemod` | CCSDS Blue Book 133.0-B-1 |
+| Meteor JPEG | `medet/met_jpg.c` | SatDump's `meteor_decoder_module.cpp` |
+| Image assembly | `medet/met_to_data.c` | SatDump's image module |
+
+`medet` is the foundational Russian decoder (~2014, C). Everyone else forked from it. Where `medet` is unclear we cross-check against `meteordemod` (modern C++, cleaner) and SatDump (most polished, but wrapped in their plugin framework).
+
+Sub-`mod.rs` boundaries are deliberate. Each file ≤300 lines after the port (matches our file-size convention). Each module's public surface is a small struct + a `process()` method; internals stay private.
+
+### `crates/sdr-radio/src/lrpt_image.rs` (new file in existing crate)
+
+Mirrors `apt_image.rs` exactly — buffers per-channel scan lines, exposes a streaming push API, owns the live image surface that `sdr-ui` reads. ~150 LoC, structurally identical to APT.
+
+---
+
+## 4. UI integration + auto-record generalization
+
+### `crates/sdr-ui/src/lrpt_viewer.rs` (new file)
+
+Fresh from scratch, structurally parallel to `apt_viewer.rs` but rendering very different content:
+
+```
+LrptImageView
+  • per-channel buffers (up to 6 AVHRR channels — only those
+    actually transmitted on this pass populate)
+  • header bar:
+      [Channel ▾]    [R: ch1 ▾  G: ch2 ▾  B: ch3 ▾]    [Pause/Resume]    [Export PNG]
+  • main view: GtkDrawingArea showing either a single channel
+    (greyscale) or the live RGB composite, user-toggleable
+  • "Composite" view defaults to the satellite's typical
+    visible / near-IR / mid-IR triple (Meteor convention),
+    user can remap via the three RGB dropdowns
+  • per-channel preview tabs (small thumbnails) so the user can
+    confirm which channels are arriving without leaving live view
+```
+
+Implements the same `ChannelDecoderConsumer` shape as `AptImageView` (push-line API + clear + export_png) so the recorder can drive both with minimal branching at the call site.
+
+### Satellites panel changes
+
+Minimal:
+
+- Toggle copy: `"Auto-record APT passes"` → `"Auto-record satellite passes"` (now covers Meteor-M too)
+- Subtitle copy: `"Tune to the satellite, start the decoder, save the image at LOS."` — unchanged (already protocol-neutral)
+- The pass-list rows and tune-button play action are already protocol-neutral; nothing else to touch
+
+### Auto-record generalization (closes #514)
+
+Today the recorder has `is_apt_capable(satellite_name)` hardcoded to NOAA 15/18/19. For LRPT we replace this with catalog-driven dispatch:
+
+```rust
+// in sdr-sat::KnownSatellite
+pub struct KnownSatellite {
+    pub name: &'static str,
+    pub norad_id: u32,
+    pub downlink_hz: u64,
+    pub demod_mode: DemodMode,
+    pub bandwidth_hz: u32,
+    pub imaging_protocol: Option<ImagingProtocol>,   // NEW
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImagingProtocol {
+    Apt,    // NOAA 15 / 18 / 19
+    Lrpt,   // Meteor-M 2 / 2-3
+    // Sstv,  -- added in #472
+}
+```
+
+The recorder's `is_apt_capable` filter becomes `imaging_protocol.is_some()` (catalog-driven, no string matching), and the existing `Action::StartAutoRecord` grows a `protocol: ImagingProtocol` field. The `interpret_action` wiring in `window.rs::connect_satellites_panel` becomes:
+
+```rust
+match protocol {
+    ImagingProtocol::Apt => crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a),
+    ImagingProtocol::Lrpt => crate::lrpt_viewer::open_lrpt_viewer_if_needed(&parent_provider_a, &state_a),
+}
+```
+
+`SavedTune` stays exactly as-is (frequency / VFO / mode / bandwidth / playback / scanner state are all protocol-agnostic). The whole tune-snapshot-and-restore round trip works unchanged.
+
+### Output paths
+
+APT keeps its current single-file shape. LRPT goes into a per-pass subdirectory because there can be up to 7 artefacts per pass (1 composite + up to 6 channels):
+
+```
+~/sdr-recordings/
+  apt-NOAA-19-2026-04-25-143022.png            (existing — unchanged)
+  lrpt-METEOR-M-2-3-2026-04-25-143022/         (new pattern)
+    composite-rgb.png
+    ch1.png  ch2.png  ch3.png  (only channels actually transmitted)
+```
+
+The save toast at LOS shows the directory path, not individual files. Future Doppler / map-projection work (#521 / #522) lands additional artefacts in the same directory.
+
+---
+
+## 5. Sub-ticket decomposition
+
+Eight sub-tickets, mirroring APT's count. Bottom-up: each PR is independently testable and leaves the project in a working state. PRs 1–5 are pure-Rust unit-tested ports against synthetic test vectors. PR 6 generalizes the recorder framework. PR 7 is the e2e finishing PR that flips Meteor on. PR 8 is docs.
+
+| # | PR scope | Crate(s) touched | Closes |
+|---|---|---|---|
+| 1 | **Stage 1: QPSK demod.** Costas loop + RRC matched filter + Gardner symbol-timing + slicer. Tests with synthetic IQ → known soft-symbol fixtures. | `sdr-dsp::lrpt` (new submodule) | new |
+| 2 | **Stage 2a: Viterbi + frame sync + derand.** Rate-1/2 K=7 Viterbi, 32-bit ASM correlator (`0x1ACFFC1D`), CCSDS PN de-randomizer. Tests with bit-vectors encoded by a known reference. | `sdr-lrpt::fec` (new crate, partial) | new |
+| 3 | **Stage 2b: Reed-Solomon (255, 223).** GF(256) arithmetic, CCSDS dual-basis representation, RS decoder. Tests against CCSDS Blue Book test vectors. | `sdr-lrpt::fec` (completes the FEC chain) | new |
+| 4 | **Stage 3: CCSDS framing.** VCDU / CADU parser, M_PDU reassembly across CADU boundaries, virtual-channel demux (image VCs only — non-imaging routed to `Discard` per the #523 deferral). | `sdr-lrpt::ccsds` (new submodule) | new |
+| 5 | **Stage 4: Image assembly + Meteor JPEG.** Meteor's reduced-JPEG decoder (DCT-block per scan-line group), per-channel image buffer, false-color RGB compositor. Includes a small CLI binary `sdr-lrpt-replay` that decodes a fixture frame file → PNGs, end-to-end test of stages 1-5. | `sdr-lrpt::image`, `sdr-radio::lrpt_image` | new |
+| 6 | **Auto-record generalization** (closes [#514](https://github.com/jasonherald/rtl-sdr/issues/514)). Add `ImagingProtocol` enum to `sdr-sat`, `imaging_protocol` field to `KnownSatellite`, recorder filter from `is_apt_capable` → `imaging_protocol.is_some()`, `protocol` field on `Action::StartAutoRecord`, branching dispatch in `interpret_action`. Meteor catalog entries stay `None` for now — generalization lands without changing user-visible behaviour. | `sdr-sat`, `sdr-ui::sidebar::satellites_recorder`, `sdr-ui::window` | #514 |
+| 7 | **End-to-end LRPT integration.** New `sdr-ui::lrpt_viewer.rs` (channel picker + RGB composite + pause/export). New `sdr-radio::lrpt_decoder` driver that wires the 4-stage pipeline to the existing audio-thread tap. Flip Meteor-M 2 / Meteor-M 2-3 catalog entries to `imaging_protocol = Some(Lrpt)`. Hook `interpret_action`'s LRPT branch. Update Satellites panel toggle copy. Per-pass subdirectory output paths. | `sdr-ui`, `sdr-radio`, `sdr-sat` | — |
+| 8 | **Docs walkthrough.** `docs/guides/lrpt-reception.md` — antenna requirements (same V-dipole, more SNR-sensitive), "your first Meteor LRPT pass" UI flow, troubleshooting (sync loss / FEC dropouts / missing channels / unfamiliar composite colours). Update `CLAUDE.md` + `README.md`. | `docs/`, `CLAUDE.md`, `README.md` | #469 |
+
+### Sequencing notes
+
+- PRs 1–5 produce no user-visible change; they're pure additions, fully unit-tested, easy CR review.
+- The CLI replay binary in PR 5 is the first end-to-end visual smoke test — fixture file in, PNGs out. Lets us validate the decoder against captured pass data (which we'll harvest from a real Meteor pass overnight or use SatDump to record a known-good IQ capture for fixturing).
+- PR 6 closes #514 and lands the framework, but Meteor stays `None` until PR 7 — keeps each PR's diff strictly additive.
+- PR 7 is the big finishing PR. It's larger than the others (viewer + driver + catalog + wiring), but each piece needs the others to actually ship value.
+
+### Where the cross-cutting test additions live
+
+The four comprehensive-testing additions from §6 don't get their own sub-tickets — they're folded into the stages they protect:
+
+- **Property-based FEC tests** ship inside PRs 2 and 3 (whichever stage the property test covers).
+- **Golden-output regression infrastructure** is set up in PR 4 (CCSDS — first stage where we have realistic frame outputs to compare); PRs 5 and 7 extend the golden corpus.
+- **Coverage gate** is wired into CI in PR 1 (smallest landing surface for the CI plumbing change).
+- **Criterion benches** are added per-stage alongside the stage PR that introduces the code (PR 1 for demod, PRs 2–3 for FEC, PR 4 for framing, PR 5 for image).
+
+### Closes-which-ticket convention
+
+Per repo convention, the `closes #469` keyword goes on the docs PR (PR 8) — that's the final piece that finishes the epic. PR 7 finishes the *functional* receive loop but doesn't close the epic until docs land.
+
+---
+
+## 6. Test strategy
+
+The biggest risk in this epic is the FEC math (Viterbi + RS) — bugs there don't crash, they produce subtly-corrupted images that look "almost right" until you compare side-by-side with a known-good decoder. Test discipline is what separates a port that ships from one that limps. The strategy varies by stage.
+
+### Per-stage testing
+
+**Stage 1 (DSP — demod).** Synthetic test vectors: generate a known QPSK pattern in Rust, run it through the demod, assert the output soft-symbol stream matches expected within a tolerance (the timing-recovery loop converges asymptotically, so exact-match isn't realistic — bit-error-rate tolerance threshold is the right shape).
+
+**Stage 2 (FEC — Viterbi + RS).** Both layers have published test vectors:
+- **Viterbi (CCSDS 131.0-B-3, K=7, G1=0o171, G2=0o133):** the standard's appendix has known input/output bit pairs we copy verbatim into a `#[test]` module.
+- **Reed-Solomon (255, 223 dual-basis, CCSDS 101.0-B-3):** standard's appendix has reference codewords. Plus `medet` ships its own self-test fixtures.
+
+These give us bit-exact validation without needing any captured satellite data. If our output diverges from the spec's reference vectors by a single bit, the test fails. This is the strongest correctness guarantee in the entire epic.
+
+**Stage 3 (CCSDS framing).** No "official spec test vector" for VCDU/M_PDU reassembly across boundaries — the spec defines the format, not specific instances. Strategy:
+- Hand-craft synthetic CADU streams with known M_PDU contents that exercise edge cases (M_PDU spanning two CADUs, M_PDU exactly aligned to a CADU boundary, missing/corrupt CADU mid-stream)
+- Cross-check our output against `meteordemod`'s output on the same input via the **golden-output regression pattern** (see comprehensive testing item 2 below) — no runtime C dependency, only one-time fixture generation
+
+**Stage 4 (image — JPEG + composite).** Validation strategy splits:
+- **Meteor JPEG decoder:** known DCT-block layouts. Decode a hand-crafted block + assert pixel values match.
+- **Channel buffer / composite:** structural tests (push N lines, assert image dimensions are right, assert RGB composite samples three channels at the same row index).
+- **Real-pass validation:** PR 5's `sdr-lrpt-replay` CLI tool gives us the full chain. Capture an IQ recording of a real Meteor pass (or borrow a known-good one from SatDump's example archive), run it through our decoder, visually compare the output PNG against SatDump's output PNG of the same recording. Integration-level smoke test.
+
+### Comprehensive testing additions
+
+Beyond per-stage unit tests, four cross-cutting test types add high-value coverage at the highest-bug-density layers:
+
+**1. Property-based testing for FEC.** Use `proptest` to round-trip random valid inputs through encoder + decoder for `sdr-lrpt::fec`. Generate a random bit stream → encode through Viterbi+RS → corrupt a controlled number of bits → decode → assert recovery succeeds within the FEC's correction budget. The CCSDS spec vectors prove we handle one specific input correctly; property tests prove we handle the generative space correctly. Particularly high-value for FEC math.
+
+**2. Golden-output regression.** Run a known IQ recording through a reference decoder (`medet` or SatDump) one time at fixture-creation time; commit the post-FEC frame stream + final per-channel PNGs as golden files in `crates/sdr-lrpt/tests/fixtures/golden/`. Tests run our decoder on the same IQ and assert byte-equality on frames + structural-similarity (SSIM > 0.99) on PNGs. Differential-testing strength against an established reference without dragging C build dependencies into our test environment. The one-time generation step lives in `crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md` for when goldens need refreshing.
+
+**3. 90% coverage gate on `sdr-lrpt`.** `cargo-llvm-cov` integrated into CI for the new crate. Pure-data crate with no GTK or async surface — high coverage is achievable. CI fails if coverage drops below threshold on a PR. Stops the "test suite passes but a whole module is untested" failure mode.
+
+**4. Criterion benchmarks per stage.** `criterion` benches in `crates/sdr-lrpt/benches/` measuring throughput of each stage on a representative input size. Establishes a per-stage performance floor (recorded baselines committed to the repo); catches accidental O(n²) refactors that pass functional tests but tank real-pass throughput. Also gives us hard data for the "Rust port is faster than the C original" claim.
+
+### Test fixtures committed to the repo
+
+- `crates/sdr-lrpt/tests/fixtures/ccsds_131_viterbi_vectors.txt` — copied from the spec
+- `crates/sdr-lrpt/tests/fixtures/ccsds_101_rs_vectors.txt` — copied from the spec
+- `crates/sdr-lrpt/tests/fixtures/synthetic_cadu_stream.bin` — small (a few KB), hand-built, exercises framing edge cases
+- `crates/sdr-lrpt/tests/fixtures/golden/` — reference frame stream + PNG outputs from medet/SatDump on a known IQ recording
+
+A real-pass IQ recording (30–50 MB) is **not** committed. Kept under `~/sdr-recordings/` on the dev machine, referenced by an `#[ignore]`-gated integration test that runs on demand (`cargo test -- --ignored real_pass`). Same convention as APT's overnight smoke tests.
+
+### Intentionally out of scope for testing
+
+- Fuzz testing (`cargo-fuzz`) — overkill for v1; the framer's input is already trusted (post-RS-FEC bytes), and we're not exposing this to untrusted network input.
+- BER-vs-SNR theoretical curve sweeps — research-grade signal-analysis work that's interesting but doesn't catch correctness bugs the spec vectors + property tests don't already catch.
+
+### Triple-build burden
+
+LRPT doesn't touch `sdr-transcription`, so no triple-build burden — single `--release` build per PR is fine.
+
+---
+
+## 7. Open questions for plan phase
+
+These are intentionally deferred to the implementation plan rather than this design:
+
+- **Costas loop bandwidth values** — port from SDR++'s tuned constants directly, validate empirically against captured passes.
+- **RRC filter rolloff factor** — Meteor uses β=0.6 per `meteor_demod`; carry forward unless capture data suggests otherwise.
+- **Default RGB composite triple** — Meteor's typical visible/near-IR/mid-IR (channels 1/2/3 by convention). Per-pass overrides via the viewer's RGB dropdowns.
+- **JPEG quality table** — Meteor's reduced-JPEG uses a fixed quantization table; copy verbatim from `medet/met_jpg.c`.
+- **Concrete `imaging_protocol` field default** — `None` for any catalog entry that doesn't have a working decoder yet (forward-compat for SSTV in #472).
+
+---
+
+## 8. Verification
+
+Epic complete when:
+
+1. `cargo build --workspace` compiles cleanly with `sdr-lrpt` added.
+2. `cargo test --workspace` — all per-stage + property + golden tests pass.
+3. CI coverage gate reports ≥90% on `sdr-lrpt`.
+4. `sdr-lrpt-replay <fixture.iq>` produces PNGs that match the golden references (SSIM > 0.99).
+5. Live overnight smoke test against a real Meteor-M 2-3 pass produces a recognizable Earth image with at least three channels populated.
+6. Auto-record toggle (renamed) auto-records both NOAA and Meteor passes correctly, with full tune restore at LOS.
+7. `docs/guides/lrpt-reception.md` walks a first-timer through the receive flow.
+8. `CLAUDE.md` updated: `sdr-lrpt` added to the workspace roster, "Satellite reception" subsection extended.
+9. `README.md` updated: Weather-satellites section mentions LRPT, architecture diagram lists `sdr-lrpt`.
+10. Epic [#469](https://github.com/jasonherald/rtl-sdr/issues/469) closed with a wrap-up summary listing the 8 shipped sub-tickets.


### PR DESCRIPTION
## Summary

Design + plan for epic #469 (Meteor-M LRPT pure-Rust port). Two new docs, no code changes — gets CodeRabbit's eyes on the architecture, sub-ticket sequence, and per-task TDD steps before we start landing the 8 implementation PRs.

- **Spec** (`docs/superpowers/specs/2026-04-25-meteor-lrpt-design.md`) — produced via the brainstorming skill with section-by-section user approval. Covers goal, 4-stage architecture (QPSK demod → Viterbi+RS FEC → CCSDS framing → Meteor JPEG), crate layout (`sdr-dsp::lrpt` for stage 1, new `sdr-lrpt` crate for stages 2-4), reference-codebase mapping per layer, UI integration, sub-ticket sequencing, and comprehensive test strategy.
- **Plan** (`docs/superpowers/plans/2026-04-25-meteor-lrpt-implementation.md`) — produced via the writing-plans skill from the spec. 8 tasks mapping 1:1 to the 8 sub-ticket PRs, each with bite-sized TDD steps, exact file paths, exact commit commands. Cross-cutting test additions (proptest, golden regression, 90% coverage gate, criterion benches) folded into the relevant tasks.

Out-of-scope items deferred to epic #520 (Doppler #521, map projection #522, telemetry decode #523, frame archival #524) — those issues already filed.

Closes nothing yet — each implementation PR closes its corresponding sub-ticket; PR 8 (docs walkthrough) closes #469.

## What's chosen vs. deferred

- **Chosen:** pure-Rust port of medet/meteordemod/SDR++'s meteor_demodulator (instead of binding to libcorrect or shelling to SatDump). Matches the project's port-fidelity rule and prior pattern of "Rust port outperforms C original."
- **Chosen:** new `sdr-lrpt` crate for FEC + CCSDS + image. `sdr-dsp::lrpt` for the demod (matches APT precedent). New `sdr-ui::lrpt_viewer.rs` from scratch (multi-channel + RGB composite is materially different from APT's single-channel scrolling view).
- **Deferred:** Doppler correction, map projection, Meteor telemetry decode, CCSDS frame archival — all in epic #520 with sub-tickets filed.
- **Deferred:** macOS-app integration. `sdr-lrpt` is GTK-only in v1 same as APT; future macOS LRPT routes through `sdr-ffi`.

## Test plan

- [ ] Read both docs and confirm the plan's task structure matches your mental model of how the work should land
- [ ] Confirm the 8-PR sequence is the right granularity (each task can be split into sub-PRs at execution time per your "we can always break a single PR into sub-tasks when we work it" earlier feedback)
- [ ] Confirm the comprehensive-testing additions (proptest, golden regression, 90% coverage gate, criterion benches) are pinned to the right tasks
- [ ] Once merged, the implementation work follows the existing PR-by-PR workflow — Task 1 starts on its own \`feature/lrpt-stage-1\` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design specification for Meteor-M LRPT reception: end-to-end processing pipeline (signal demodulation, FEC/CCSDS framing, image decoding and false‑color composition), UI viewer integration, recorder support for multiple imaging protocols, staged implementation plan with ticket decomposition, and a comprehensive testing/benchmarking and verification checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->