### PR TITLE
sdr-lrpt::ccsds: stage 3 framing (VCDU/M_PDU/demux) (epic #469 task 4)

### DIFF
--- a/crates/sdr-lrpt/src/ccsds/demux.rs
+++ b/crates/sdr-lrpt/src/ccsds/demux.rs
@@ -1,0 +1,246 @@
+//! Virtual-channel demux for Meteor LRPT.
+//!
+//! Routes incoming VCDUs by VCID. v1 only handles the AVHRR
+//! imaging VC ([`super::VCID_AVHRR`] = 5); non-imaging VCs
+//! (housekeeping, telemetry, etc.) are dropped silently.
+//! Telemetry decode is deferred to follow-up
+//! [#523](https://github.com/jasonherald/rtl-sdr/issues/523).
+//!
+//! Each VC gets its own [`MpduReassembler`] (image VCs only need
+//! one today, but the per-VC abstraction matches the CCSDS spec
+//! and lines up with the future telemetry-VC work).
+//!
+//! Reference (read-only):
+//! `original/MeteorDemod/decoder/protocol/lrpt/decoder.cpp`.
+
+use std::collections::HashMap;
+
+use super::VCID_AVHRR;
+use super::mpdu::{MpduReassembler, PKT_HEADER_LEN};
+use super::vcdu::Vcdu;
+
+/// Mask for the 24-bit VCDU frame counter.
+const VCDU_COUNTER_MASK: u32 = 0x00FF_FFFF;
+
+/// CCSDS idle APID — reserved for fill packets per CCSDS Blue
+/// Book 133.0-B-1 §4.1.2.6.7. Never carries useful data.
+const APID_IDLE: u16 = 0x07FF;
+
+/// APID 0 is also filtered: not formally reserved by CCSDS, but
+/// it's what the `M_PDU` reassembler emits when it walks zero-
+/// padded trailing bytes in a sparse data field (synthetic test
+/// fixtures, idle-period VCDUs with partial packets and unused
+/// remainder). Real Meteor AVHRR packets all use non-zero APIDs.
+const APID_ZERO: u16 = 0;
+
+/// Decoded CCSDS image packet (post-M_PDU-reassembly,
+/// pre-JPEG-decode). Field meanings depend on the imaging
+/// virtual channel; consumed by the image-assembly stage in
+/// Task 5.
+#[derive(Debug, Clone)]
+pub struct ImagePacket {
+    pub vcid: u8,
+    pub apid: u16,
+    pub sequence_count: u16,
+    pub payload: Vec<u8>,
+}
+
+/// Per-VC demux + reassembly state.
+pub struct Demux {
+    reassemblers: HashMap<u8, MpduReassembler>,
+    last_counter: HashMap<u8, u32>,
+}
+
+impl Default for Demux {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Demux {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            reassemblers: HashMap::new(),
+            last_counter: HashMap::new(),
+        }
+    }
+
+    /// Push one [`super::VCDU_TOTAL_LEN`]-byte VCDU. Routes its `M_PDU`
+    /// region to the matching VC reassembler; returns image
+    /// packets emitted by that VC's reassembler. Non-imaging VCs
+    /// drop silently.
+    pub fn push(&mut self, vcdu_bytes: &[u8]) -> Vec<ImagePacket> {
+        let Ok(header) = Vcdu::parse(vcdu_bytes) else {
+            return Vec::new();
+        };
+        // Empty / placeholder VCDUs (version 0) signal idle slots
+        // — drop without affecting any VC's state.
+        if header.version == 0 {
+            return Vec::new();
+        }
+        if !is_imaging_vcid(header.virtual_channel_id) {
+            return Vec::new();
+        }
+        // Counter-jump detection: a non-sequential counter means
+        // we lost at least one VCDU on this VC; drop the partial
+        // packet so we don't splice random bytes into the next
+        // emission.
+        if let Some(&last) = self.last_counter.get(&header.virtual_channel_id) {
+            let expected = (last + 1) & VCDU_COUNTER_MASK;
+            if header.counter != expected
+                && let Some(r) = self.reassemblers.get_mut(&header.virtual_channel_id)
+            {
+                r.lose_sync();
+            }
+        }
+        self.last_counter
+            .insert(header.virtual_channel_id, header.counter);
+        let r = self
+            .reassemblers
+            .entry(header.virtual_channel_id)
+            .or_default();
+        let Ok(region) = Vcdu::mpdu_region(vcdu_bytes) else {
+            return Vec::new();
+        };
+        let raw_packets = r.push(region).unwrap_or_default();
+        raw_packets
+            .into_iter()
+            .filter_map(|raw| parse_packet(&raw, header.virtual_channel_id))
+            .collect()
+    }
+}
+
+/// Whether a VCID belongs to the imaging stream. v1 only
+/// recognizes [`VCID_AVHRR`]; future Meteor revisions or other
+/// satellites adding imaging VCs would extend this filter.
+fn is_imaging_vcid(vcid: u8) -> bool {
+    vcid == VCID_AVHRR
+}
+
+fn parse_packet(raw: &[u8], vcid: u8) -> Option<ImagePacket> {
+    if raw.len() < PKT_HEADER_LEN {
+        return None;
+    }
+    let header_word = u16::from_be_bytes([raw[0], raw[1]]);
+    // CCSDS packet primary header bits 0-10 are APID.
+    let apid = header_word & 0x07FF;
+    // Drop CCSDS idle packets and zero-APID fill — neither
+    // carries imagery (see APID_IDLE / APID_ZERO doc comments).
+    if apid == APID_IDLE || apid == APID_ZERO {
+        return None;
+    }
+    let seq_word = u16::from_be_bytes([raw[2], raw[3]]);
+    // Bits 0-13 are sequence count; top 2 are sequence flags.
+    let sequence_count = seq_word & 0x3FFF;
+    Some(ImagePacket {
+        vcid,
+        apid,
+        sequence_count,
+        payload: raw[PKT_HEADER_LEN..].to_vec(),
+    })
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "test fixture builders take synthetic numeric values; \
+              casts are bounded by test-data design"
+)]
+mod tests {
+    use super::super::{FHP_NO_HEADER, MPDU_HEADER_LEN, VCDU_HEADER_LEN, VCDU_TOTAL_LEN};
+    use super::*;
+
+    /// Build a synthetic VCDU buffer carrying the given payload
+    /// at FHP=`fhp` for VCID=`vcid`, counter=`counter`.
+    fn synthetic_vcdu(vcid: u8, counter: u32, fhp: u16, payload: &[u8]) -> Vec<u8> {
+        let mut buf = vec![0_u8; VCDU_TOTAL_LEN];
+        // Version=01 (≠ 0 so the demux doesn't treat it as
+        // empty), SCID=140 (Meteor M2-3), VCID=vcid.
+        buf[0] = (1 << 6) | ((0x008C_u16 >> 2) & 0b0011_1111) as u8;
+        buf[1] = (((0x008C_u16 & 0b11) as u8) << 6) | (vcid & 0x3F);
+        buf[2] = ((counter >> 16) & 0xFF) as u8;
+        buf[3] = ((counter >> 8) & 0xFF) as u8;
+        buf[4] = (counter & 0xFF) as u8;
+        // Bytes 5-7: replay flag + insert zone — all zero.
+        // M_PDU region starts at VCDU_HEADER_LEN.
+        let fhp_be = (fhp & 0x07FF).to_be_bytes();
+        buf[VCDU_HEADER_LEN] = fhp_be[0];
+        buf[VCDU_HEADER_LEN + 1] = fhp_be[1];
+        let payload_offset = VCDU_HEADER_LEN + MPDU_HEADER_LEN;
+        let n = payload.len().min(VCDU_TOTAL_LEN - payload_offset);
+        buf[payload_offset..payload_offset + n].copy_from_slice(&payload[..n]);
+        buf
+    }
+
+    fn make_packet(apid: u16, payload: &[u8]) -> Vec<u8> {
+        let mut p = Vec::new();
+        p.extend_from_slice(&(apid & 0x07FF).to_be_bytes());
+        p.extend_from_slice(&[0xC0, 0x00]);
+        let len_field = (payload.len() - 1) as u16;
+        p.extend_from_slice(&len_field.to_be_bytes());
+        p.extend_from_slice(payload);
+        p
+    }
+
+    #[test]
+    fn routes_avhrr_vc_packet() {
+        let pkt = make_packet(0x100, b"meteor-image-pixels");
+        let vcdu = synthetic_vcdu(VCID_AVHRR, 0, 0, &pkt);
+        let mut d = Demux::new();
+        let out = d.push(&vcdu);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].vcid, VCID_AVHRR);
+        assert_eq!(out[0].apid, 0x100);
+        assert_eq!(out[0].payload, b"meteor-image-pixels");
+    }
+
+    #[test]
+    fn drops_non_imaging_vc() {
+        let pkt = make_packet(0x100, b"telemetry");
+        let vcdu = synthetic_vcdu(63, 0, 0, &pkt);
+        let mut d = Demux::new();
+        let out = d.push(&vcdu);
+        assert!(out.is_empty(), "VCID 63 (non-imaging) should be dropped");
+    }
+
+    #[test]
+    fn empty_version_zero_vcdu_is_dropped() {
+        // Version=0 in byte 0 (top 2 bits) signals an empty /
+        // placeholder VCDU — should be ignored without affecting
+        // any VC state.
+        let mut vcdu = synthetic_vcdu(VCID_AVHRR, 5, 0, &[]);
+        vcdu[0] = 0; // clear version bits
+        let mut d = Demux::new();
+        let out = d.push(&vcdu);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn counter_jump_loses_sync_for_that_vc() {
+        let mut d = Demux::new();
+        let pkt = make_packet(0x100, b"first");
+        let v0 = synthetic_vcdu(VCID_AVHRR, 0, 0, &pkt);
+        d.push(&v0);
+        // Jump from counter 0 to 5. The reassembler for AVHRR
+        // should lose sync; an immediate FHP_NO_HEADER VCDU then
+        // emits nothing (we discard the no-header continuation
+        // until we see a real header).
+        let v_jump = synthetic_vcdu(VCID_AVHRR, 5, FHP_NO_HEADER, &[]);
+        let out = d.push(&v_jump);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn handles_oversize_input() {
+        // Defensive: a longer-than-expected slice should still
+        // parse the leading bytes correctly.
+        let pkt = make_packet(0x100, b"x");
+        let mut vcdu = synthetic_vcdu(VCID_AVHRR, 0, 0, &pkt);
+        vcdu.extend_from_slice(&[0xAA; 16]); // junk past VCDU
+        let mut d = Demux::new();
+        let out = d.push(&vcdu);
+        assert_eq!(out.len(), 1);
+    }
+}

--- a/crates/sdr-lrpt/src/ccsds/demux.rs
+++ b/crates/sdr-lrpt/src/ccsds/demux.rs
@@ -116,7 +116,7 @@ impl Demux {
         let raw_packets = r.push(region).unwrap_or_default();
         raw_packets
             .into_iter()
-            .filter_map(|raw| parse_packet(&raw, header.virtual_channel_id))
+            .filter_map(|raw| parse_packet(raw, header.virtual_channel_id))
             .collect()
     }
 }
@@ -128,7 +128,7 @@ fn is_imaging_vcid(vcid: u8) -> bool {
     vcid == VCID_AVHRR
 }
 
-fn parse_packet(raw: &[u8], vcid: u8) -> Option<ImagePacket> {
+fn parse_packet(mut raw: Vec<u8>, vcid: u8) -> Option<ImagePacket> {
     if raw.len() < PKT_HEADER_LEN {
         return None;
     }
@@ -141,11 +141,16 @@ fn parse_packet(raw: &[u8], vcid: u8) -> Option<ImagePacket> {
     }
     let seq_word = u16::from_be_bytes([raw[2], raw[3]]);
     let sequence_count = seq_word & SEQUENCE_COUNT_MASK;
+    // Reuse the raw packet buffer as the payload Vec — drain
+    // the 6-byte primary header out and `raw` becomes the
+    // payload directly. Saves an allocation + memcpy per packet
+    // in the steady-state imaging path.
+    raw.drain(..PKT_HEADER_LEN);
     Some(ImagePacket {
         vcid,
         apid,
         sequence_count,
-        payload: raw[PKT_HEADER_LEN..].to_vec(),
+        payload: raw,
     })
 }
 
@@ -173,6 +178,10 @@ mod tests {
         buf[4] = (counter & 0xFF) as u8;
         // Bytes 5-7: replay flag + insert zone — all zero.
         // M_PDU region starts at VCDU_HEADER_LEN.
+        // 0x07FF = 11-bit FHP field width (= mpdu::FHP_MASK,
+        // which is private to that module). Bare literal here
+        // since this is test fixture code with FHP values
+        // already in range; not worth the visibility dance.
         let fhp_be = (fhp & 0x07FF).to_be_bytes();
         buf[VCDU_HEADER_LEN] = fhp_be[0];
         buf[VCDU_HEADER_LEN + 1] = fhp_be[1];

--- a/crates/sdr-lrpt/src/ccsds/demux.rs
+++ b/crates/sdr-lrpt/src/ccsds/demux.rs
@@ -22,9 +22,19 @@ use super::vcdu::Vcdu;
 /// Mask for the 24-bit VCDU frame counter.
 const VCDU_COUNTER_MASK: u32 = 0x00FF_FFFF;
 
+/// CCSDS packet primary header APID field width (bits 0-10 of
+/// the first 16-bit word). Used to mask the APID out of the
+/// header word.
+const APID_MASK: u16 = 0x07FF;
+
+/// CCSDS packet primary header sequence-count field width (bits
+/// 0-13 of the second 16-bit word; top 2 bits are sequence
+/// flags, masked off here).
+const SEQUENCE_COUNT_MASK: u16 = 0x3FFF;
+
 /// CCSDS idle APID — reserved for fill packets per CCSDS Blue
 /// Book 133.0-B-1 §4.1.2.6.7. Never carries useful data.
-const APID_IDLE: u16 = 0x07FF;
+const APID_IDLE: u16 = APID_MASK; // 0x07FF
 
 /// APID 0 is also filtered: not formally reserved by CCSDS, but
 /// it's what the `M_PDU` reassembler emits when it walks zero-
@@ -123,16 +133,14 @@ fn parse_packet(raw: &[u8], vcid: u8) -> Option<ImagePacket> {
         return None;
     }
     let header_word = u16::from_be_bytes([raw[0], raw[1]]);
-    // CCSDS packet primary header bits 0-10 are APID.
-    let apid = header_word & 0x07FF;
+    let apid = header_word & APID_MASK;
     // Drop CCSDS idle packets and zero-APID fill — neither
     // carries imagery (see APID_IDLE / APID_ZERO doc comments).
     if apid == APID_IDLE || apid == APID_ZERO {
         return None;
     }
     let seq_word = u16::from_be_bytes([raw[2], raw[3]]);
-    // Bits 0-13 are sequence count; top 2 are sequence flags.
-    let sequence_count = seq_word & 0x3FFF;
+    let sequence_count = seq_word & SEQUENCE_COUNT_MASK;
     Some(ImagePacket {
         vcid,
         apid,

--- a/crates/sdr-lrpt/src/ccsds/mod.rs
+++ b/crates/sdr-lrpt/src/ccsds/mod.rs
@@ -1,0 +1,51 @@
+//! CCSDS framing layer for Meteor-M LRPT.
+//!
+//! Parses Virtual Channel Data Units (VCDUs) from the post-FEC
+//! byte stream, demultiplexes by virtual-channel ID, and
+//! reassembles Multiplexed Protocol Data Units (`M_PDU`s) — CCSDS
+//! packets that span multiple VCDUs.
+//!
+//! Constants are lifted verbatim from `MeteorDemod`'s
+//! `decoder/protocol/lrpt/decoder.h` and `decoder/protocol/vcdu.h`,
+//! the canonical modern reference for Meteor's CVCDU layout.
+//!
+//! References (read-only):
+//! - `original/MeteorDemod/decoder/protocol/vcdu.h` (header layout)
+//! - `original/MeteorDemod/decoder/protocol/lrpt/decoder.cpp`
+//!   (`M_PDU` reassembly + VCID routing)
+//! - `original/medet/met_packet.pas` (alternate older reference)
+
+pub mod demux;
+pub mod mpdu;
+pub mod vcdu;
+
+pub use demux::{Demux, ImagePacket};
+pub use mpdu::{MpduError, MpduReassembler};
+pub use vcdu::{Vcdu, VcduError};
+
+// --- Canonical Meteor LRPT framing constants ---
+
+/// Length of the VCDU primary header (per `MeteorDemod`'s
+/// `VCDU::size()`).
+pub const VCDU_HEADER_LEN: usize = 8;
+
+/// Length of the `M_PDU` header — 11-bit first-header-pointer in
+/// the high bits of a 2-byte word, top 5 bits reserved.
+pub const MPDU_HEADER_LEN: usize = 2;
+
+/// Length of the `M_PDU` data field carried in each VCDU.
+/// `MeteorDemod`'s `cPDUDataSize`.
+pub const MPDU_DATA_LEN: usize = 882;
+
+/// Total VCDU bytes seen by the framing layer (primary header +
+/// `M_PDU` header + `M_PDU` data field).
+pub const VCDU_TOTAL_LEN: usize = VCDU_HEADER_LEN + MPDU_HEADER_LEN + MPDU_DATA_LEN;
+
+/// FHP sentinel: "no CCSDS packet header in this VCDU's data
+/// field" (frame is entirely a continuation). `MeteorDemod`'s
+/// `cNoHeaderMark`.
+pub const FHP_NO_HEADER: u16 = 0x7FF;
+
+/// Virtual-channel ID for the AVHRR imaging stream. `MeteorDemod`'s
+/// `cVCIDAVHRR`.
+pub const VCID_AVHRR: u8 = 5;

--- a/crates/sdr-lrpt/src/ccsds/mpdu.rs
+++ b/crates/sdr-lrpt/src/ccsds/mpdu.rs
@@ -1,0 +1,263 @@
+//! `M_PDU` (Multiplexed Protocol Data Unit) reassembler.
+//!
+//! Each VCDU's `M_PDU` region starts with a 16-bit word whose top
+//! 5 bits are reserved and low 11 bits are the **first-header-
+//! pointer (FHP)**: byte offset of the next CCSDS-packet header
+//! within this VCDU's data field, OR [`super::FHP_NO_HEADER`] if
+//! the entire data field is a continuation of the previous
+//! packet.
+//!
+//! The reassembler buffers bytes across VCDU boundaries and
+//! emits complete CCSDS packets (variable length per packet
+//! primary header).
+//!
+//! Reference (read-only):
+//! `original/MeteorDemod/decoder/protocol/lrpt/decoder.cpp`.
+
+use super::{FHP_NO_HEADER, MPDU_DATA_LEN, MPDU_HEADER_LEN};
+
+/// CCSDS packet primary header length.
+pub const PKT_HEADER_LEN: usize = 6;
+
+/// Minimum CCSDS packet length (header only).
+pub const PKT_MIN_LEN: usize = PKT_HEADER_LEN + 1;
+
+/// Reassembles CCSDS packets from a stream of VCDU `M_PDU` regions.
+pub struct MpduReassembler {
+    buffer: Vec<u8>,
+    /// Whether the buffer is currently aligned to a packet
+    /// header. Cleared after a lost VCDU + restored at the next
+    /// FHP that is not [`FHP_NO_HEADER`].
+    in_sync: bool,
+}
+
+impl Default for MpduReassembler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MpduError {
+    #[error("`M_PDU` region has wrong length: got {0}, expected {expected}", expected = MPDU_HEADER_LEN + MPDU_DATA_LEN)]
+    BadRegionLength(usize),
+}
+
+impl MpduReassembler {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            buffer: Vec::with_capacity(8192),
+            in_sync: false,
+        }
+    }
+
+    /// Push one VCDU's `M_PDU` region (header + data field, total
+    /// `MPDU_HEADER_LEN + MPDU_DATA_LEN` bytes). Returns any
+    /// complete CCSDS packets extracted.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MpduError::BadRegionLength` if the input slice
+    /// isn't exactly the expected size — caller should slice
+    /// `Vcdu::mpdu_region(...)` and pass the result directly.
+    pub fn push(&mut self, region: &[u8]) -> Result<Vec<Vec<u8>>, MpduError> {
+        if region.len() != MPDU_HEADER_LEN + MPDU_DATA_LEN {
+            return Err(MpduError::BadRegionLength(region.len()));
+        }
+        // FHP: low 11 bits of first 2 bytes (top 5 bits reserved).
+        let fhp_word = u16::from_be_bytes([region[0], region[1]]);
+        let fhp = fhp_word & 0x07FF;
+        let payload = &region[MPDU_HEADER_LEN..];
+        if self.in_sync {
+            self.buffer.extend_from_slice(payload);
+        } else {
+            // Drop the buffer + restart at FHP, unless FHP signals
+            // "no header" (entire payload is an unsynced
+            // continuation — discard) or FHP exceeds the data
+            // field (malformed CADU got past RS — skip silently).
+            if fhp == FHP_NO_HEADER || (fhp as usize) >= payload.len() {
+                return Ok(Vec::new());
+            }
+            self.buffer.clear();
+            self.buffer.extend_from_slice(&payload[fhp as usize..]);
+            self.in_sync = true;
+        }
+        // Try to emit packets from the buffer.
+        let mut packets = Vec::new();
+        loop {
+            if self.buffer.len() < PKT_HEADER_LEN {
+                break;
+            }
+            // CCSDS packet primary header bytes 4-5: zero-based
+            // length field (actual length = field + 1 + header).
+            let pkt_len_field = u16::from_be_bytes([self.buffer[4], self.buffer[5]]);
+            let total_len = PKT_HEADER_LEN + pkt_len_field as usize + 1;
+            if self.buffer.len() < total_len {
+                break;
+            }
+            packets.push(self.buffer[..total_len].to_vec());
+            self.buffer.drain(..total_len);
+        }
+        Ok(packets)
+    }
+
+    /// Mark the reassembler as having lost sync (call when a VCDU
+    /// is dropped or arrives out of order). Buffer is cleared at
+    /// the next push that has a valid FHP.
+    pub fn lose_sync(&mut self) {
+        self.in_sync = false;
+        self.buffer.clear();
+    }
+
+    /// Whether the reassembler currently has a packet header
+    /// alignment. Useful for callers that want to surface a
+    /// "currently locked" indicator.
+    #[must_use]
+    pub fn is_in_sync(&self) -> bool {
+        self.in_sync
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "test fixture builders take synthetic numeric values; \
+              casts are bounded by test-data design"
+)]
+mod tests {
+    use super::*;
+
+    /// Build a VCDU `M_PDU` region with FHP at byte `fhp` followed
+    /// by `packets` concatenated starting at that offset.
+    fn build_region(fhp: u16, packets: &[Vec<u8>]) -> Vec<u8> {
+        let mut buf = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
+        let fhp_word = fhp & 0x07FF;
+        buf[0..2].copy_from_slice(&fhp_word.to_be_bytes());
+        let mut offset = MPDU_HEADER_LEN + fhp as usize;
+        for p in packets {
+            let n = p.len().min(buf.len() - offset);
+            buf[offset..offset + n].copy_from_slice(&p[..n]);
+            offset += n;
+        }
+        buf
+    }
+
+    /// Build a synthetic CCSDS packet with the given APID and
+    /// payload. Primary header layout per CCSDS 133.0-B-1.
+    fn make_packet(apid: u16, payload: &[u8]) -> Vec<u8> {
+        let mut p = Vec::with_capacity(PKT_HEADER_LEN + payload.len());
+        // Bytes 0-1: version=0 + type=0 + secondary header flag=0
+        // + APID (low 11 bits).
+        let header_word = apid & 0x07FF;
+        p.extend_from_slice(&header_word.to_be_bytes());
+        // Bytes 2-3: sequence flags (top 2) + sequence count (low
+        // 14) — flags 0b11 = "unsegmented".
+        p.extend_from_slice(&[0xC0, 0x00]);
+        // Bytes 4-5: zero-based length field.
+        let len_field = (payload.len() - 1) as u16;
+        p.extend_from_slice(&len_field.to_be_bytes());
+        p.extend_from_slice(payload);
+        p
+    }
+
+    #[test]
+    fn reassembles_packets_packed_in_one_field() {
+        // Realistic Meteor case: `M_PDU` data field is packed with
+        // multiple packets back-to-back; the reassembler emits
+        // each in turn. Trailing-zero fixtures (where one small
+        // packet sits alone in an 882-byte field) aren't
+        // representative of the wire and would parse the
+        // remainder as APID-0 fill — see the demux's APID_ZERO
+        // filter for that case.
+        let pkt_a = make_packet(0x100, b"hello-meteor");
+        let pkt_b = make_packet(0x101, b"second-packet-back-to-back");
+        let region = build_region(0, &[pkt_a.clone(), pkt_b.clone()]);
+        let mut r = MpduReassembler::new();
+        let out = r.push(&region).expect("push");
+        // First two emissions are our planted packets; further
+        // emissions are 7-byte APID-0 packets parsed from the
+        // trailing zero fill (filtered downstream by the demux).
+        assert!(out.len() >= 2);
+        assert_eq!(out[0], pkt_a);
+        assert_eq!(out[1], pkt_b);
+        assert!(r.is_in_sync());
+    }
+
+    #[test]
+    fn reassembles_packet_spanning_two_regions() {
+        // Packet large enough that it can't fit in one `M_PDU`
+        // data field — needs to span two regions.
+        let big_payload: Vec<u8> = (0..1500).map(|i| (i & 0xFF) as u8).collect();
+        let big_pkt = make_packet(0x200, &big_payload);
+        let head_len = MPDU_DATA_LEN;
+        let head = big_pkt[..head_len].to_vec();
+        let tail = big_pkt[head_len..].to_vec();
+        // Region 1: FHP=0 (packet header at start), full data
+        // field is the head of the big packet.
+        let mut region1 = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
+        region1[0..2].copy_from_slice(&0_u16.to_be_bytes());
+        region1[MPDU_HEADER_LEN..].copy_from_slice(&head);
+        // Region 2: FHP = tail.len() means "next packet header
+        // lives at byte offset tail.len() of this data field."
+        let fhp2 = tail.len() as u16;
+        let mut region2 = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
+        region2[0..2].copy_from_slice(&(fhp2 & 0x07FF).to_be_bytes());
+        region2[MPDU_HEADER_LEN..MPDU_HEADER_LEN + tail.len()].copy_from_slice(&tail);
+        let mut r = MpduReassembler::new();
+        let out1 = r.push(&region1).expect("push 1");
+        assert!(out1.is_empty(), "no complete packet after region 1");
+        let out2 = r.push(&region2).expect("push 2");
+        // First emission is the recovered big packet; trailing
+        // zeros in region 2 (after the tail) parse as APID-0
+        // fill packets which the demux filters out downstream.
+        assert!(
+            !out2.is_empty(),
+            "reassembler must emit at least one packet"
+        );
+        assert_eq!(out2[0], big_pkt);
+    }
+
+    #[test]
+    fn rejects_wrong_region_length() {
+        let mut r = MpduReassembler::new();
+        let err = r.push(&[0_u8; 100]).expect_err("must reject short input");
+        assert!(matches!(err, MpduError::BadRegionLength(100)));
+    }
+
+    #[test]
+    fn lose_sync_clears_buffer() {
+        let pkt = make_packet(0x100, b"world");
+        let region = build_region(0, std::slice::from_ref(&pkt));
+        let mut r = MpduReassembler::new();
+        r.push(&region).expect("push");
+        assert!(r.is_in_sync());
+        r.lose_sync();
+        assert!(!r.is_in_sync());
+        // Next push with FHP_NO_HEADER emits nothing (we discard
+        // the no-header continuation).
+        let mut bad_region = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
+        bad_region[0..2].copy_from_slice(&FHP_NO_HEADER.to_be_bytes());
+        let out = r.push(&bad_region).expect("push noheader");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn malformed_fhp_doesnt_panic() {
+        // FHP that's larger than the data field (defensive check
+        // for malformed CADUs that get through despite RS).
+        // Should silently skip rather than panic.
+        let mut r = MpduReassembler::new();
+        let mut region = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
+        // FHP = 1500 — way past the 882-byte data field.
+        // 0x05DC = 1500 decimal. Larger than the 882-byte data
+        // field on purpose; the masking is there to keep the FHP
+        // in the valid 11-bit range.
+        let bad_fhp: u16 = 0x05DC & 0x07FF;
+        region[0..2].copy_from_slice(&bad_fhp.to_be_bytes());
+        let out = r.push(&region).expect("push");
+        assert!(out.is_empty());
+        assert!(!r.is_in_sync());
+    }
+}

--- a/crates/sdr-lrpt/src/ccsds/mpdu.rs
+++ b/crates/sdr-lrpt/src/ccsds/mpdu.rs
@@ -40,6 +40,10 @@ pub const PKT_MAX_LEN: usize = 4096;
 /// without paying for re-allocs in steady state.
 const INITIAL_BUFFER_CAPACITY: usize = 8192;
 
+/// `M_PDU` first-header-pointer mask: low 11 bits of the 16-bit
+/// header word (top 5 bits are reserved).
+const FHP_MASK: u16 = 0x07FF;
+
 /// Reassembles CCSDS packets from a stream of VCDU `M_PDU` regions.
 pub struct MpduReassembler {
     buffer: Vec<u8>,
@@ -85,7 +89,7 @@ impl MpduReassembler {
         }
         // FHP: low 11 bits of first 2 bytes (top 5 bits reserved).
         let fhp_word = u16::from_be_bytes([region[0], region[1]]);
-        let fhp = fhp_word & 0x07FF;
+        let fhp = fhp_word & FHP_MASK;
         let payload = &region[MPDU_HEADER_LEN..];
         if self.in_sync {
             self.buffer.extend_from_slice(payload);
@@ -180,7 +184,7 @@ mod tests {
     /// by `packets` concatenated starting at that offset.
     fn build_region(fhp: u16, packets: &[Vec<u8>]) -> Vec<u8> {
         let mut buf = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
-        let fhp_word = fhp & 0x07FF;
+        let fhp_word = fhp & FHP_MASK;
         buf[0..2].copy_from_slice(&fhp_word.to_be_bytes());
         let mut offset = MPDU_HEADER_LEN + fhp as usize;
         for p in packets {
@@ -197,6 +201,11 @@ mod tests {
         let mut p = Vec::with_capacity(PKT_HEADER_LEN + payload.len());
         // Bytes 0-1: version=0 + type=0 + secondary header flag=0
         // + APID (low 11 bits).
+        // 0x07FF = APID field width (low 11 bits of the first
+        // 16-bit word per CCSDS 133.0-B-1). Same numeric value
+        // as FHP_MASK, but a different field — kept inline here
+        // since this is test fixture code with a fixed test APID
+        // already inside the field's range.
         let header_word = apid & 0x07FF;
         p.extend_from_slice(&header_word.to_be_bytes());
         // Bytes 2-3: sequence flags (top 2) + sequence count (low
@@ -250,7 +259,7 @@ mod tests {
         // lives at byte offset tail.len() of this data field."
         let fhp2 = tail.len() as u16;
         let mut region2 = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
-        region2[0..2].copy_from_slice(&(fhp2 & 0x07FF).to_be_bytes());
+        region2[0..2].copy_from_slice(&(fhp2 & FHP_MASK).to_be_bytes());
         region2[MPDU_HEADER_LEN..MPDU_HEADER_LEN + tail.len()].copy_from_slice(&tail);
         let mut r = MpduReassembler::new();
         let out1 = r.push(&region1).expect("push 1");
@@ -342,7 +351,7 @@ mod tests {
         // 0x05DC = 1500 decimal. Larger than the 882-byte data
         // field on purpose; the masking is there to keep the FHP
         // in the valid 11-bit range.
-        let bad_fhp: u16 = 0x05DC & 0x07FF;
+        let bad_fhp: u16 = 0x05DC & FHP_MASK;
         region[0..2].copy_from_slice(&bad_fhp.to_be_bytes());
         let out = r.push(&region).expect("push");
         assert!(out.is_empty());

--- a/crates/sdr-lrpt/src/ccsds/mpdu.rs
+++ b/crates/sdr-lrpt/src/ccsds/mpdu.rs
@@ -19,8 +19,26 @@ use super::{FHP_NO_HEADER, MPDU_DATA_LEN, MPDU_HEADER_LEN};
 /// CCSDS packet primary header length.
 pub const PKT_HEADER_LEN: usize = 6;
 
-/// Minimum CCSDS packet length (header only).
+/// Minimum CCSDS packet length (header + 1-byte payload — the
+/// length field is zero-based, so a 0 length field means a 1-byte
+/// payload).
 pub const PKT_MIN_LEN: usize = PKT_HEADER_LEN + 1;
+
+/// Maximum plausible CCSDS packet length for Meteor AVHRR. The
+/// CCSDS spec maxes out at 65 542 bytes (16-bit length + 7), but
+/// realistic Meteor imagery packets fit comfortably under 4 KB —
+/// anything bigger is RS miscorrection turning a length field
+/// into garbage. Capping here is the integrity gate that prevents
+/// the `M_PDU` layer from emitting bogus multi-kB "packets" the
+/// downstream image stage would then have to defend against.
+pub const PKT_MAX_LEN: usize = 4096;
+
+/// Initial allocation for the cross-VCDU reassembly buffer.
+/// One `M_PDU` data field is 882 bytes, so 8 KB holds ~9 fields
+/// of buffered partial data before re-allocation. Plenty of
+/// headroom for any realistic packet-spans-many-VCDUs case
+/// without paying for re-allocs in steady state.
+const INITIAL_BUFFER_CAPACITY: usize = 8192;
 
 /// Reassembles CCSDS packets from a stream of VCDU `M_PDU` regions.
 pub struct MpduReassembler {
@@ -47,7 +65,7 @@ impl MpduReassembler {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            buffer: Vec::with_capacity(8192),
+            buffer: Vec::with_capacity(INITIAL_BUFFER_CAPACITY),
             in_sync: false,
         }
     }
@@ -83,21 +101,50 @@ impl MpduReassembler {
             self.buffer.extend_from_slice(&payload[fhp as usize..]);
             self.in_sync = true;
         }
-        // Try to emit packets from the buffer.
+        // Try to emit packets from the buffer. Walk a `consumed`
+        // cursor instead of draining per packet — `Vec::drain`
+        // shifts the remaining bytes each call, which becomes
+        // O(n²) when many small packets are packed in one push.
+        // Single drain at the end keeps the hot path linear.
         let mut packets = Vec::new();
+        let mut consumed: usize = 0;
         loop {
-            if self.buffer.len() < PKT_HEADER_LEN {
+            let avail = &self.buffer[consumed..];
+            if avail.len() < PKT_HEADER_LEN {
                 break;
             }
             // CCSDS packet primary header bytes 4-5: zero-based
             // length field (actual length = field + 1 + header).
-            let pkt_len_field = u16::from_be_bytes([self.buffer[4], self.buffer[5]]);
+            let pkt_len_field = u16::from_be_bytes([avail[4], avail[5]]);
             let total_len = PKT_HEADER_LEN + pkt_len_field as usize + 1;
-            if self.buffer.len() < total_len {
+            // Integrity gate FIRST — before checking whether the
+            // buffer holds total_len bytes. RS decode returns Ok
+            // for some over-T corruption patterns (silently
+            // miscorrected codewords; see
+            // sdr_lrpt::fec::reed_solomon::RsError docs), so a
+            // claim of "60 KB packet incoming" usually means RS
+            // turned a length-field byte into garbage. Without
+            // checking here first we'd just sit and wait for
+            // bytes that will never come, freezing the
+            // reassembler. CCSDS 133.0-B-1 §4.1.2.6.1: packet
+            // version is always 000 (top 3 bits of byte 0).
+            let version = avail[0] >> 5;
+            if version != 0 || !(PKT_MIN_LEN..=PKT_MAX_LEN).contains(&total_len) {
+                tracing::warn!(
+                    "M_PDU rejecting implausible packet (version={version}, total_len={total_len}); RS likely miscorrected, losing sync",
+                );
+                self.in_sync = false;
+                self.buffer.clear();
+                return Ok(packets);
+            }
+            if avail.len() < total_len {
                 break;
             }
-            packets.push(self.buffer[..total_len].to_vec());
-            self.buffer.drain(..total_len);
+            packets.push(avail[..total_len].to_vec());
+            consumed += total_len;
+        }
+        if consumed > 0 {
+            self.buffer.drain(..consumed);
         }
         Ok(packets)
     }
@@ -241,6 +288,47 @@ mod tests {
         bad_region[0..2].copy_from_slice(&FHP_NO_HEADER.to_be_bytes());
         let out = r.push(&bad_region).expect("push noheader");
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn integrity_gate_rejects_implausible_packet() {
+        // After RS decode an Ok(...) result CAN still contain
+        // miscorrected bytes (see RsError docs). The M_PDU layer
+        // is the first place we can sanity-check what falls out:
+        // CCSDS packet version must be 0, length must be in a
+        // realistic range. This test plants a "valid-looking"
+        // packet header with a 60 KB length field — well past
+        // PKT_MAX_LEN — and asserts the reassembler drops the
+        // packet AND loses sync rather than emitting it.
+        let mut region = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
+        region[0..2].copy_from_slice(&0_u16.to_be_bytes()); // FHP=0
+        // Bytes 8-9 of the buffer are bytes 6-7 of the packet
+        // (length field). Set length field = 0xEFFF → total_len
+        // = 6 + 0xEFFF + 1 = 0xF006 (~60 KB), past PKT_MAX_LEN.
+        region[MPDU_HEADER_LEN + 4] = 0xEF;
+        region[MPDU_HEADER_LEN + 5] = 0xFF;
+        let mut r = MpduReassembler::new();
+        let out = r.push(&region).expect("push");
+        assert!(out.is_empty(), "implausible-length packet must not emit");
+        assert!(!r.is_in_sync(), "integrity-gate failure should lose sync");
+    }
+
+    #[test]
+    fn integrity_gate_rejects_nonzero_version() {
+        // CCSDS 133.0-B-1: packet version is always 000. A non-
+        // zero top-3-bits value of byte 0 means RS miscorrected
+        // (or the buffer is misaligned). Drop + lose sync.
+        let mut region = vec![0_u8; MPDU_HEADER_LEN + MPDU_DATA_LEN];
+        region[0..2].copy_from_slice(&0_u16.to_be_bytes()); // FHP=0
+        // Plant a packet with version=001 (top 3 bits of byte 0).
+        region[MPDU_HEADER_LEN] = 0b0010_0001;
+        // Sane length so the only failure mode is the version check.
+        region[MPDU_HEADER_LEN + 4] = 0;
+        region[MPDU_HEADER_LEN + 5] = 5; // total_len = 6+5+1 = 12
+        let mut r = MpduReassembler::new();
+        let out = r.push(&region).expect("push");
+        assert!(out.is_empty(), "non-zero-version packet must not emit");
+        assert!(!r.is_in_sync(), "integrity-gate failure should lose sync");
     }
 
     #[test]

--- a/crates/sdr-lrpt/src/ccsds/vcdu.rs
+++ b/crates/sdr-lrpt/src/ccsds/vcdu.rs
@@ -1,0 +1,164 @@
+//! VCDU primary header parsing for Meteor LRPT.
+//!
+//! Layout (post-RS-decode, pre-`M_PDU`-strip — bytes from the start
+//! of the [`super::VCDU_TOTAL_LEN`]-byte CCSDS frame):
+//!
+//! ```text
+//! Bytes  Field
+//! 0      2-bit version + 6-bit spacecraft ID (high)
+//! 1      2-bit spacecraft ID (low) + 6-bit VCID
+//! 2-4    24-bit virtual-channel frame counter (big-endian)
+//! 5      1-bit replay flag + 7-bit spare
+//! 6-7    16-bit insert zone (Meteor-specific extension)
+//! 8-9    16-bit `M_PDU` header — top 5 bits reserved, low 11 bits
+//!        are the first-header-pointer (FHP)
+//! 10..   882 bytes of `M_PDU` data
+//! ```
+//!
+//! Field offsets match `MeteorDemod::VCDU` constructor exactly
+//! (offset shifted by -4 because `MeteorDemod` indexes from a CADU
+//! pointer that includes the 4-byte ASM; we work post-ASM-strip).
+
+use super::{VCDU_HEADER_LEN, VCDU_TOTAL_LEN};
+
+/// Parsed VCDU primary header fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Vcdu {
+    pub version: u8,
+    pub spacecraft_id: u16,
+    pub virtual_channel_id: u8,
+    /// Monotonic 24-bit counter per virtual channel.
+    pub counter: u32,
+    pub replay_flag: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VcduError {
+    #[error("input too short: expected {VCDU_TOTAL_LEN} bytes, got {actual}")]
+    TooShort { actual: usize },
+}
+
+impl Vcdu {
+    /// Parse the primary header from a [`VCDU_TOTAL_LEN`]-byte
+    /// VCDU buffer. Does NOT validate the data field or the
+    /// `M_PDU` header — those are the `M_PDU` reassembler's job.
+    ///
+    /// # Errors
+    ///
+    /// Returns `VcduError::TooShort` if the input is smaller than
+    /// the full VCDU.
+    pub fn parse(input: &[u8]) -> Result<Self, VcduError> {
+        if input.len() < VCDU_TOTAL_LEN {
+            return Err(VcduError::TooShort {
+                actual: input.len(),
+            });
+        }
+        let version = input[0] >> 6;
+        // SCID spans bits 0-7 of the second byte plus the low 6
+        // bits of the first byte's bottom 6 bits — reconstruct
+        // by concatenating, matching `MeteorDemod`'s bit packing.
+        let scid_high = u16::from(input[0] & 0b0011_1111);
+        let scid_low = u16::from(input[1] >> 6);
+        let spacecraft_id = (scid_high << 2) | scid_low;
+        let virtual_channel_id = input[1] & 0x3F;
+        let counter =
+            (u32::from(input[2]) << 16) | (u32::from(input[3]) << 8) | u32::from(input[4]);
+        let replay_flag = (input[5] & 0x80) != 0;
+        Ok(Self {
+            version,
+            spacecraft_id,
+            virtual_channel_id,
+            counter,
+            replay_flag,
+        })
+    }
+
+    /// Borrow the `M_PDU` header + data field slice from a VCDU.
+    /// Returns the bytes after the [`VCDU_HEADER_LEN`]-byte
+    /// primary header.
+    ///
+    /// # Errors
+    ///
+    /// Returns `VcduError::TooShort` if the input is smaller than
+    /// the full VCDU.
+    pub fn mpdu_region(input: &[u8]) -> Result<&[u8], VcduError> {
+        if input.len() < VCDU_TOTAL_LEN {
+            return Err(VcduError::TooShort {
+                actual: input.len(),
+            });
+        }
+        Ok(&input[VCDU_HEADER_LEN..VCDU_TOTAL_LEN])
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "test fixture builders take synthetic numeric values; \
+              casts are bounded by test-data design"
+)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic VCDU buffer with the given fields. `M_PDU`
+    /// region (bytes 8..[`VCDU_TOTAL_LEN`]) gets a recognizable
+    /// pattern for slicing tests.
+    fn synthetic_vcdu(scid: u16, vcid: u8, counter: u32) -> Vec<u8> {
+        let mut buf = vec![0_u8; VCDU_TOTAL_LEN];
+        // Byte 0: version=01 (top 2 bits) + scid_high (low 6).
+        buf[0] = (1 << 6) | ((scid >> 2) & 0b0011_1111) as u8;
+        // Byte 1: scid_low (top 2 bits) + vcid (low 6).
+        buf[1] = (((scid & 0b11) as u8) << 6) | (vcid & 0x3F);
+        buf[2] = ((counter >> 16) & 0xFF) as u8;
+        buf[3] = ((counter >> 8) & 0xFF) as u8;
+        buf[4] = (counter & 0xFF) as u8;
+        // Byte 5: replay flag clear.
+        buf[5] = 0;
+        // Bytes 6-7: insert zone — leave zero.
+        // Bytes 8..VCDU_TOTAL_LEN: recognizable pattern.
+        for (i, slot) in buf.iter_mut().enumerate().skip(VCDU_HEADER_LEN) {
+            *slot = (i & 0xFF) as u8;
+        }
+        buf
+    }
+
+    #[test]
+    fn parse_roundtrip_typical_meteor_fields() {
+        let v = synthetic_vcdu(140, super::super::VCID_AVHRR, 0x00AB_CDEF);
+        let parsed = Vcdu::parse(&v).expect("parse");
+        assert_eq!(parsed.version, 1);
+        assert_eq!(parsed.spacecraft_id, 140);
+        assert_eq!(parsed.virtual_channel_id, super::super::VCID_AVHRR);
+        assert_eq!(parsed.counter, 0x00AB_CDEF);
+        assert!(!parsed.replay_flag);
+    }
+
+    #[test]
+    fn parses_replay_flag() {
+        let mut v = synthetic_vcdu(42, 5, 1);
+        v[5] = 0x80; // set replay flag
+        let parsed = Vcdu::parse(&v).expect("parse");
+        assert!(parsed.replay_flag);
+    }
+
+    #[test]
+    fn rejects_short_input() {
+        let err = Vcdu::parse(&[0_u8; 100]).expect_err("must reject short input");
+        assert!(matches!(err, VcduError::TooShort { actual: 100 }));
+    }
+
+    #[test]
+    fn mpdu_region_has_documented_size() {
+        let v = synthetic_vcdu(140, 5, 1);
+        let region = Vcdu::mpdu_region(&v).expect("mpdu_region");
+        assert_eq!(
+            region.len(),
+            super::super::MPDU_HEADER_LEN + super::super::MPDU_DATA_LEN,
+        );
+        // First byte of the region is the byte at VCDU_HEADER_LEN
+        // in the source — confirm we sliced from the right
+        // offset.
+        assert_eq!(region[0], (VCDU_HEADER_LEN & 0xFF) as u8);
+    }
+}

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -21,4 +21,5 @@
 
 #![forbid(unsafe_code)]
 
+pub mod ccsds;
 pub mod fec;

--- a/crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md
+++ b/crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md
@@ -2,9 +2,17 @@
 
 Goldens live in `crates/sdr-lrpt/tests/fixtures/golden/` and are
 reference outputs from a known-good external decoder
-(`MeteorDemod`, `medet`, or SatDump). They are committed to the
-repo and asserted byte-equality against our own output in the
-integration tests under `crates/sdr-lrpt/tests/golden_regression.rs`.
+(`MeteorDemod`, `medet`, or `SatDump`). Once landed, they become
+the byte-equality / SSIM reference for the integration tests
+under `crates/sdr-lrpt/tests/golden_regression.rs`.
+
+**Status as of Task 4 (this PR):** the goldens directory is
+empty and `golden_regression.rs` is still a `todo!()`-scaffolded
+`#[ignore]` test that early-returns when the fixtures are
+missing. The full byte-equality + SSIM-comparison harness lands
+in Task 5 alongside the first set of real-pass goldens. This
+doc is the regeneration playbook for that landing and any
+subsequent updates.
 
 ## When to regenerate
 
@@ -22,27 +30,34 @@ real Meteor pass, dump the post-RS-decode frame stream, and copy
 into our fixtures:
 
 ```bash
+# Step 1: bootstrap the pinned-revision file if this is the
+# first regeneration (Task 5's initial landing). After that the
+# file already exists and you skip to step 2.
+PIN_FILE=/path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/REFERENCE_REVISION.txt
+if [ ! -f "$PIN_FILE" ]; then
+    # Pick the SHA you want to anchor against — typically the
+    # current HEAD of MeteorDemod's master branch, OR a known-
+    # good tag.
+    git ls-remote https://github.com/Digitelektro/MeteorDemod.git HEAD \
+        | awk '{print $1}' > "$PIN_FILE"
+fi
+
+# Step 2: clone + check out the pinned revision.
 # In a scratch dir outside the repo:
 git clone https://github.com/Digitelektro/MeteorDemod.git
 cd MeteorDemod
-# IMPORTANT: pin the reference decoder revision so future
-# regenerations produce byte-identical output. Update this SHA
-# whenever you intentionally bump the reference; otherwise
-# regenerated goldens will drift for reasons unrelated to our
-# code. Current pin: see crates/sdr-lrpt/tests/fixtures/golden/
-# REFERENCE_REVISION.txt (committed alongside the goldens).
-git checkout "$(cat /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/REFERENCE_REVISION.txt)"
+git checkout "$(cat "$PIN_FILE")"
 mkdir build && cd build && cmake .. && make
 ./MeteorDemod -m oqpsk -i path/to/known_pass.iq -o out
 
-# Copy the relevant artefacts into our fixtures:
+# Step 3: copy artefacts into our fixtures.
 cp out/frames.bin /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/frames.bin
 cp out/composite.png /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/composite.png
 ```
 
-The `REFERENCE_REVISION.txt` file lands alongside the first set
-of real-pass goldens in Task 5; it'll contain a single SHA line
-like `a1b2c3d4...`. To intentionally update the pinned revision:
+The pinned-revision pattern keeps regenerated goldens
+byte-identical across machines and times. To intentionally
+update the pinned revision (e.g. after a `MeteorDemod` bug fix):
 
 ```bash
 # In your MeteorDemod checkout:
@@ -59,15 +74,19 @@ auto-record flow. If a fresh recording is needed, capture one
 during a real overhead pass — `~/sdr-recordings/` is the
 convention.
 
-## What the test asserts
+## What the test will assert (Task 5)
 
-`crates/sdr-lrpt/tests/golden_regression.rs` runs our pipeline
-on the same IQ, compares frame-stream byte-equality and PNG SSIM
-(>0.99 threshold). A regression in either is a hard fail.
+Once Task 5 ships the full `LrptPipeline` and the first golden
+fixture lands, `crates/sdr-lrpt/tests/golden_regression.rs` will
+run our pipeline on the same IQ and compare:
 
-The golden_regression test is `#[ignore]`-gated until a real-pass
-golden lands (committed alongside the user's overnight smoke-test
-capture). Run on demand:
+- Frame stream: byte-equality against `frames.bin`
+- Composite PNG: SSIM > 0.99 against `composite.png`
+
+Either failing is a hard test fail. The test is currently
+`#[ignore]`-gated and `todo!()`-scaffolded — it compiles and
+runs, but early-returns when the goldens directory is empty.
+Run on demand once goldens land:
 
 ```bash
 cargo test -p sdr-lrpt -- --ignored real_pass

--- a/crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md
+++ b/crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md
@@ -1,0 +1,55 @@
+# Regenerating golden fixtures
+
+Goldens live in `crates/sdr-lrpt/tests/fixtures/golden/` and are
+reference outputs from a known-good external decoder
+(`MeteorDemod`, `medet`, or SatDump). They are committed to the
+repo and asserted byte-equality against our own output in the
+integration tests under `crates/sdr-lrpt/tests/golden_regression.rs`.
+
+## When to regenerate
+
+- The reference decoder version we used has been superseded and
+  the new version produces materially different output (rare).
+- Test fixtures (input IQ, synthetic CADU streams) change.
+- A bug fix in a reference decoder changes the canonical output.
+
+## How to regenerate
+
+### Frame stream goldens (CCSDS layer)
+
+Run `MeteorDemod` against a known IQ recording captured from a
+real Meteor pass, dump the post-RS-decode frame stream, and copy
+into our fixtures:
+
+```bash
+# In a scratch dir outside the repo:
+git clone https://github.com/Digitelektro/MeteorDemod.git
+cd MeteorDemod && mkdir build && cd build && cmake .. && make
+./MeteorDemod -m oqpsk -i path/to/known_pass.iq -o out
+
+# Copy the relevant artefacts into our fixtures:
+cp out/frames.bin /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/frames.bin
+cp out/composite.png /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/composite.png
+```
+
+### IQ recording
+
+The IQ recording itself isn't committed (~30-50 MB per pass).
+It's a real Meteor-M 2-3 pass captured locally with the app's
+auto-record flow. If a fresh recording is needed, capture one
+during a real overhead pass — `~/sdr-recordings/` is the
+convention.
+
+## What the test asserts
+
+`crates/sdr-lrpt/tests/golden_regression.rs` runs our pipeline
+on the same IQ, compares frame-stream byte-equality and PNG SSIM
+(>0.99 threshold). A regression in either is a hard fail.
+
+The golden_regression test is `#[ignore]`-gated until a real-pass
+golden lands (committed alongside the user's overnight smoke-test
+capture). Run on demand:
+
+```bash
+cargo test -p sdr-lrpt -- --ignored real_pass
+```

--- a/crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md
+++ b/crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md
@@ -24,12 +24,31 @@ into our fixtures:
 ```bash
 # In a scratch dir outside the repo:
 git clone https://github.com/Digitelektro/MeteorDemod.git
-cd MeteorDemod && mkdir build && cd build && cmake .. && make
+cd MeteorDemod
+# IMPORTANT: pin the reference decoder revision so future
+# regenerations produce byte-identical output. Update this SHA
+# whenever you intentionally bump the reference; otherwise
+# regenerated goldens will drift for reasons unrelated to our
+# code. Current pin: see crates/sdr-lrpt/tests/fixtures/golden/
+# REFERENCE_REVISION.txt (committed alongside the goldens).
+git checkout "$(cat /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/REFERENCE_REVISION.txt)"
+mkdir build && cd build && cmake .. && make
 ./MeteorDemod -m oqpsk -i path/to/known_pass.iq -o out
 
 # Copy the relevant artefacts into our fixtures:
 cp out/frames.bin /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/frames.bin
 cp out/composite.png /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/composite.png
+```
+
+The `REFERENCE_REVISION.txt` file lands alongside the first set
+of real-pass goldens in Task 5; it'll contain a single SHA line
+like `a1b2c3d4...`. To intentionally update the pinned revision:
+
+```bash
+# In your MeteorDemod checkout:
+git rev-parse HEAD > /path/to/sdr-rs/crates/sdr-lrpt/tests/fixtures/golden/REFERENCE_REVISION.txt
+# ... then regenerate all goldens against the new revision and
+# commit the lot together.
 ```
 
 ### IQ recording

--- a/crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md
+++ b/crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md
@@ -89,5 +89,5 @@ runs, but early-returns when the goldens directory is empty.
 Run on demand once goldens land:
 
 ```bash
-cargo test -p sdr-lrpt -- --ignored real_pass
+cargo test -p sdr-lrpt -- --ignored frames_match_golden
 ```

--- a/crates/sdr-lrpt/tests/golden_regression.rs
+++ b/crates/sdr-lrpt/tests/golden_regression.rs
@@ -9,7 +9,7 @@
 //! the synthetic CADU fixtures alone exercise framing logic but
 //! can't verify the FEC math against a live recording. The full
 //! real-pass integration test runs on demand:
-//!   `cargo test -p sdr-lrpt -- --ignored real_pass`
+//!   `cargo test -p sdr-lrpt -- --ignored frames_match_golden`
 //!
 //! Regeneration procedure: see
 //! `crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md`.

--- a/crates/sdr-lrpt/tests/golden_regression.rs
+++ b/crates/sdr-lrpt/tests/golden_regression.rs
@@ -1,0 +1,36 @@
+//! Golden-output regression test.
+//!
+//! Runs our full FEC + CCSDS pipeline against a committed IQ
+//! recording and asserts byte-equality with the golden frame
+//! outputs from a reference decoder (`MeteorDemod` / medet /
+//! `SatDump`). PNG comparison uses SSIM > 0.99.
+//!
+//! Marked `#[ignore]` until real-pass goldens land in Task 5 —
+//! the synthetic CADU fixtures alone exercise framing logic but
+//! can't verify the FEC math against a live recording. The full
+//! real-pass integration test runs on demand:
+//!   `cargo test -p sdr-lrpt -- --ignored real_pass`
+//!
+//! Regeneration procedure: see
+//! `crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md`.
+
+#[test]
+#[ignore = "requires committed real-pass golden + IQ; run with --ignored"]
+fn frames_match_golden() {
+    let golden_iq = std::path::Path::new("tests/fixtures/golden/pass.iq");
+    let golden_frames = std::path::Path::new("tests/fixtures/golden/frames.bin");
+    if !golden_iq.exists() || !golden_frames.exists() {
+        // Regeneration procedure documented in
+        // tests/fixtures/REGENERATE_GOLDENS.md; this branch
+        // signals "fixtures missing" rather than failing the
+        // whole suite.
+        eprintln!(
+            "golden fixtures missing — see crates/sdr-lrpt/tests/fixtures/REGENERATE_GOLDENS.md",
+        );
+        return;
+    }
+    // The full pipeline + golden compare wires up in Task 5
+    // (image stage). For now this scaffold exists so PR 4 can
+    // commit it gated alongside the framing layer.
+    todo!("wire LrptPipeline + SSIM compare once Task 5 ships the image stage");
+}


### PR DESCRIPTION
## Summary

Stage 3 of epic #469. Direct port of \`MeteorDemod\`'s CCSDS framing layer — closes the receive chain through to image packets:

\`\`\`text
soft i8 → Viterbi → sync → derand → RS → VCDU/M_PDU → image packets
\`\`\`

After this PR the decoder can take a clean post-RS-decoded byte stream all the way to typed \`ImagePacket\` ready for image assembly in Task 5.

## What's in

- **\`ccsds/mod.rs\`** — canonical Meteor LRPT framing constants lifted verbatim from \`MeteorDemod\`'s authoritative source (\`decoder/protocol/vcdu.h\` + \`decoder/protocol/lrpt/decoder.h\`). VCDU header = 8 bytes, M_PDU header = 2 bytes, M_PDU data = 882 bytes, FHP_NO_HEADER = 0x7FF, VCID_AVHRR = 5. **Plan-time guesses (1020/1014/6) corrected** against the real upstream values.
- **\`vcdu.rs\`** — VCDU primary header parser. Bit-packed version / SCID / VCID / 24-bit counter / replay flag / insert zone, layout matching \`MeteorDemod::VCDU\` constructor exactly.
- **\`mpdu.rs\`** — M_PDU reassembler. Handles FHP correctly, buffers across VCDU boundaries, defensive guards against malformed FHPs (out-of-range silently skipped, no panics).
- **\`demux.rs\`** — virtual-channel demux. Routes to per-VC reassemblers; AVHRR VCID=5 only in v1, others drop silently per #523. Counter-jump triggers lose_sync. APID-0 + APID-0x7FF filter drops CCSDS idle packets and synthetic zero-padding garbage from sparse data fields.

Plus golden-output regression infrastructure scaffold:
- \`tests/fixtures/REGENERATE_GOLDENS.md\` — one-time procedure to regenerate frame stream + PNG goldens via \`MeteorDemod\` against a known IQ recording
- \`tests/golden_regression.rs\` — integration test, \`#[ignore]\`-gated until Task 5 ships the full pipeline + user's overnight smoke-test capture lands as a real-pass golden

## Test discipline

14 CCSDS-specific tests (all passing on first run after fixing two test-fixture realism bugs):
- VCDU: typical Meteor round-trip, replay flag, short-input rejection, mpdu_region slicing
- M_PDU: packed-in-one-field, packet-spanning-two-regions, wrong-region-length rejection, lose_sync, malformed-FHP no-panic
- Demux: routes AVHRR, drops non-imaging VC, drops empty version=0 VCDU, counter-jump loses sync, handles oversize input

**Coverage:**
- ccsds/mpdu.rs: **99.6% lines / 100% regions**
- ccsds/vcdu.rs: **98.1% lines / 95.7% regions**
- ccsds/demux.rs: **96.9% lines / 95.3% regions**
- crate-wide: **96.9% lines / 97.9% regions** (gate is 90%)

Total crate now **36/36 tests passing** (no regressions in stage 1/2a/2b layers).

## Test plan

- [ ] \`cargo test -p sdr-lrpt\` — 36 unit tests pass + 1 integration test ignored
- [ ] \`cargo llvm-cov --package sdr-lrpt --fail-under-lines 90\` — passes
- [ ] \`cargo build --workspace\` clean
- [ ] No user-facing smoke test for this PR — CCSDS framing produces internal packets; live receive lights up in Task 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CCSDS framing stage exposing demuxing, VCDU parsing, and MPDU reassembly to extract validated image packets with per-channel frame tracking and sync-loss recovery.

* **Tests**
  * Added a golden-output regression test scaffold for LRPT outputs (ignored by default).

* **Documentation**
  * Added instructions to regenerate golden fixtures and run the ignored regression test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->