### PR TITLE
sdr-lrpt: stage 4 image assembly + Meteor JPEG (epic #469 task 5a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +603,15 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "field-offset"
@@ -1395,6 +1410,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1789,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "naga"
 version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2121,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2239,12 @@ dependencies = [
  "tempfile",
  "unarray",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -2722,6 +2779,7 @@ name = "sdr-lrpt"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "image",
  "proptest",
  "sdr-types",
  "thiserror 2.0.18",
@@ -2744,6 +2802,7 @@ name = "sdr-radio"
 version = "0.1.0"
 dependencies = [
  "sdr-dsp",
+ "sdr-lrpt",
  "sdr-pipeline",
  "sdr-types",
  "serde",

--- a/crates/sdr-lrpt/Cargo.toml
+++ b/crates/sdr-lrpt/Cargo.toml
@@ -10,6 +10,10 @@ repository.workspace = true
 sdr-types.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+# PNG export for the per-channel + composite outputs. Local dep
+# rather than workspace because no other crate uses it yet; hoist
+# to workspace.dependencies if a second consumer arrives.
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/sdr-lrpt/src/image/composite.rs
+++ b/crates/sdr-lrpt/src/image/composite.rs
@@ -1,0 +1,267 @@
+//! Per-channel scan-line buffer + RGB composite renderer.
+//!
+//! Meteor LRPT can transmit up to 6 AVHRR imaging channels per
+//! pass. Each channel arrives as a stream of decoded 8×8 pixel
+//! blocks (one per Meteor JPEG MCU); we stitch the blocks into a
+//! 2D image per channel, indexed by APID (channel ID).
+//!
+//! The RGB compositor takes three channel selections and
+//! produces a false-color image — what the user sees in the
+//! live viewer.
+
+use std::collections::HashMap;
+
+use super::jpeg::{Block8x8, MCU_SIDE};
+
+/// MCUs per Meteor LRPT scan line. Per medet's `mcu_per_line`.
+pub const MCUS_PER_LINE: usize = 196;
+
+/// Width of one Meteor scan line in pixels.
+/// (= [`MCUS_PER_LINE`] × [`MCU_SIDE`] = 196 × 8 = 1568 px.)
+pub const IMAGE_WIDTH: usize = MCUS_PER_LINE * MCU_SIDE;
+
+/// One channel's accumulated grayscale image.
+#[derive(Clone, Debug, Default)]
+pub struct ChannelBuffer {
+    /// Row-major 8-bit pixel data. Length = `lines * IMAGE_WIDTH`.
+    pub pixels: Vec<u8>,
+    /// Number of complete scan lines accumulated so far.
+    pub lines: usize,
+}
+
+impl ChannelBuffer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one full scan line ([`IMAGE_WIDTH`] pixels). Pads
+    /// with zero if the input is short, truncates if too long.
+    /// Used by callers that have a complete scanline ready.
+    pub fn push_line(&mut self, line: &[u8]) {
+        let mut padded = vec![0_u8; IMAGE_WIDTH];
+        let n = line.len().min(IMAGE_WIDTH);
+        padded[..n].copy_from_slice(&line[..n]);
+        self.pixels.extend_from_slice(&padded);
+        self.lines += 1;
+    }
+
+    /// Place one decoded 8×8 MCU at line index `mcu_row` and
+    /// column index `mcu_col` (0-indexed in MCUs, not pixels).
+    /// Auto-grows the underlying buffer to hold up to row
+    /// `mcu_row + 1` of MCUs (= `(mcu_row + 1) * MCU_SIDE` lines
+    /// of pixels).
+    ///
+    /// This is the per-MCU placement entry point used by the
+    /// LRPT pipeline as JPEG decoding emits blocks.
+    pub fn place_mcu(&mut self, mcu_row: usize, mcu_col: usize, block: &Block8x8) {
+        let needed_lines = (mcu_row + 1) * MCU_SIDE;
+        if needed_lines > self.lines {
+            let new_pixels = (needed_lines - self.lines) * IMAGE_WIDTH;
+            self.pixels.extend(std::iter::repeat_n(0_u8, new_pixels));
+            self.lines = needed_lines;
+        }
+        if mcu_col >= MCUS_PER_LINE {
+            return; // out of bounds — silently drop
+        }
+        let px_top = mcu_row * MCU_SIDE;
+        let px_left = mcu_col * MCU_SIDE;
+        for (dy, row) in block.iter().enumerate() {
+            let dst_y = px_top + dy;
+            let dst_off = dst_y * IMAGE_WIDTH + px_left;
+            self.pixels[dst_off..dst_off + MCU_SIDE].copy_from_slice(row);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.pixels.clear();
+        self.lines = 0;
+    }
+}
+
+/// Multi-channel image accumulator. Maps APID → channel buffer.
+///
+/// Uses the Meteor APID-as-channel-key convention: APID 64 / 65
+/// / 66 / 67 / 68 / 69 are the AVHRR channels (the actual
+/// channel set transmitted on a given pass varies; only the
+/// active ones populate).
+pub struct ImageAssembler {
+    channels: HashMap<u16, ChannelBuffer>,
+}
+
+impl Default for ImageAssembler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageAssembler {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            channels: HashMap::new(),
+        }
+    }
+
+    /// Push one decoded 8×8 MCU for `apid` at the given MCU row
+    /// + column. Creates the channel buffer on first sight.
+    pub fn place_mcu(&mut self, apid: u16, mcu_row: usize, mcu_col: usize, block: &Block8x8) {
+        self.channels
+            .entry(apid)
+            .or_default()
+            .place_mcu(mcu_row, mcu_col, block);
+    }
+
+    /// Push one full scan line for `apid` (used by callers that
+    /// already have a row buffered, e.g. APT-style consumers).
+    pub fn push_line(&mut self, apid: u16, line: &[u8]) {
+        self.channels.entry(apid).or_default().push_line(line);
+    }
+
+    /// Iterate channels by APID in unspecified order.
+    pub fn channels(&self) -> impl Iterator<Item = (&u16, &ChannelBuffer)> {
+        self.channels.iter()
+    }
+
+    /// Borrow the buffer for `apid`.
+    #[must_use]
+    pub fn channel(&self, apid: u16) -> Option<&ChannelBuffer> {
+        self.channels.get(&apid)
+    }
+
+    /// Build an RGB composite from three channels. Returns
+    /// `(width, height, RGB bytes)` or `None` if any of the
+    /// three channels is missing or empty.
+    ///
+    /// Composite height is `min(r.lines, g.lines, b.lines)` — we
+    /// stop at the shortest channel so every output row has
+    /// data from all three.
+    #[must_use]
+    pub fn composite_rgb(
+        &self,
+        r_apid: u16,
+        g_apid: u16,
+        b_apid: u16,
+    ) -> Option<(usize, usize, Vec<u8>)> {
+        let r = self.channels.get(&r_apid)?;
+        let g = self.channels.get(&g_apid)?;
+        let b = self.channels.get(&b_apid)?;
+        if r.lines == 0 || g.lines == 0 || b.lines == 0 {
+            return None;
+        }
+        let height = r.lines.min(g.lines).min(b.lines);
+        let mut rgb = Vec::with_capacity(IMAGE_WIDTH * height * 3);
+        for row in 0..height {
+            for col in 0..IMAGE_WIDTH {
+                let idx = row * IMAGE_WIDTH + col;
+                rgb.push(r.pixels[idx]);
+                rgb.push(g.pixels[idx]);
+                rgb.push(b.pixels[idx]);
+            }
+        }
+        Some((IMAGE_WIDTH, height, rgb))
+    }
+
+    pub fn clear(&mut self) {
+        self.channels.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fill_block(value: u8) -> Block8x8 {
+        [[value; MCU_SIDE]; MCU_SIDE]
+    }
+
+    #[test]
+    fn channel_buffer_pads_short_lines() {
+        let mut cb = ChannelBuffer::new();
+        cb.push_line(&[1, 2, 3]);
+        assert_eq!(cb.lines, 1);
+        assert_eq!(cb.pixels.len(), IMAGE_WIDTH);
+        assert_eq!(&cb.pixels[..3], &[1, 2, 3]);
+        assert_eq!(cb.pixels[3], 0, "should be padded with 0");
+    }
+
+    #[test]
+    fn channel_buffer_truncates_long_lines() {
+        let mut cb = ChannelBuffer::new();
+        let huge = vec![5_u8; IMAGE_WIDTH * 2];
+        cb.push_line(&huge);
+        assert_eq!(cb.pixels.len(), IMAGE_WIDTH);
+    }
+
+    #[test]
+    fn place_mcu_grows_buffer_and_places_block() {
+        let mut cb = ChannelBuffer::new();
+        // Place a block at MCU row 2, col 3.
+        let block = fill_block(42);
+        cb.place_mcu(2, 3, &block);
+        // Buffer should now have (2+1)*8 = 24 lines.
+        assert_eq!(cb.lines, 24);
+        assert_eq!(cb.pixels.len(), 24 * IMAGE_WIDTH);
+        // Every pixel inside the placed block should be 42.
+        let px_top = 2 * MCU_SIDE;
+        let px_left = 3 * MCU_SIDE;
+        for dy in 0..MCU_SIDE {
+            for dx in 0..MCU_SIDE {
+                let idx = (px_top + dy) * IMAGE_WIDTH + (px_left + dx);
+                assert_eq!(cb.pixels[idx], 42, "block pixel ({dy}, {dx}) wrong");
+            }
+        }
+        // A pixel outside the block should still be 0.
+        assert_eq!(cb.pixels[0], 0);
+    }
+
+    #[test]
+    fn place_mcu_skips_out_of_bounds_columns() {
+        let mut cb = ChannelBuffer::new();
+        let block = fill_block(99);
+        // MCUS_PER_LINE = 196; col 200 is past the line.
+        cb.place_mcu(0, 200, &block);
+        // Buffer grew but the block wasn't placed.
+        assert_eq!(cb.lines, MCU_SIDE);
+        assert!(cb.pixels.iter().all(|&p| p == 0), "no pixel should be 99");
+    }
+
+    #[test]
+    fn assembler_routes_mcus_by_apid() {
+        let mut a = ImageAssembler::new();
+        a.place_mcu(64, 0, 0, &fill_block(11));
+        a.place_mcu(65, 0, 0, &fill_block(22));
+        let ch64 = a.channel(64).expect("channel 64");
+        let ch65 = a.channel(65).expect("channel 65");
+        assert_eq!(ch64.pixels[0], 11);
+        assert_eq!(ch65.pixels[0], 22);
+    }
+
+    #[test]
+    fn composite_requires_all_three_channels() {
+        let mut a = ImageAssembler::new();
+        a.push_line(64, &vec![100; IMAGE_WIDTH]);
+        a.push_line(65, &vec![150; IMAGE_WIDTH]);
+        // No channel 66.
+        assert!(a.composite_rgb(64, 65, 66).is_none());
+        a.push_line(66, &vec![200; IMAGE_WIDTH]);
+        let (w, h, rgb) = a.composite_rgb(64, 65, 66).expect("composite");
+        assert_eq!(w, IMAGE_WIDTH);
+        assert_eq!(h, 1);
+        // First pixel: (R, G, B) = (100, 150, 200).
+        assert_eq!(&rgb[..3], &[100, 150, 200]);
+    }
+
+    #[test]
+    fn composite_truncates_to_shortest_channel() {
+        let mut a = ImageAssembler::new();
+        a.push_line(64, &vec![1; IMAGE_WIDTH]);
+        a.push_line(64, &vec![2; IMAGE_WIDTH]);
+        a.push_line(65, &vec![3; IMAGE_WIDTH]);
+        a.push_line(66, &vec![4; IMAGE_WIDTH]);
+        a.push_line(66, &vec![5; IMAGE_WIDTH]);
+        // R has 2 lines, G has 1, B has 2 → composite height = 1.
+        let (_, h, _) = a.composite_rgb(64, 65, 66).expect("composite");
+        assert_eq!(h, 1);
+    }
+}

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -321,17 +321,31 @@ fn map_range(cat: u8, value: u16) -> i32 {
 
 /// Peek the next `n` bits from `bytes` starting at `bit_offset`,
 /// MSB-first. Returns the bits right-aligned in a u16.
+///
+/// Zero-pads any portion of the window that runs off the end of
+/// `bytes` rather than erroring — `decode_mcu` always asks for a
+/// full 16-bit window into the LUT, but the actual Huffman code
+/// inside that window may be much shorter (a final EOB can be a
+/// 4-bit code at the very end of the payload). Erroring on a
+/// partial peek would reject those valid trailing codes.
+/// `EndOfStream` is reserved for [`fetch_n_bits`] — the actual
+/// consume operation that asks for bits we don't have.
 fn peek_n_bits(bytes: &[u8], bit_offset: usize, n: usize) -> Result<u16, JpegError> {
     debug_assert!(n <= 16);
+    let total_bits = bytes.len() * 8;
+    if bit_offset >= total_bits {
+        return Err(JpegError::EndOfStream);
+    }
     let mut result: u32 = 0;
     for i in 0..n {
         let bit_pos = bit_offset + i;
-        let byte_idx = bit_pos / 8;
-        if byte_idx >= bytes.len() {
-            return Err(JpegError::EndOfStream);
-        }
-        let bit_in_byte = 7 - (bit_pos % 8);
-        let bit = (bytes[byte_idx] >> bit_in_byte) & 1;
+        let bit = if bit_pos < total_bits {
+            let byte_idx = bit_pos / 8;
+            let bit_in_byte = 7 - (bit_pos % 8);
+            (bytes[byte_idx] >> bit_in_byte) & 1
+        } else {
+            0
+        };
         result = (result << 1) | u32::from(bit);
     }
     // Left-pad to 16 bits so callers can index a 65k LUT
@@ -666,5 +680,204 @@ mod tests {
         dec.last_dc = 42.0;
         dec.reset_dc();
         assert_eq!(dec.last_dc, 0.0);
+    }
+
+    /// Quality byte that selects the upper branch of `fill_dqt`'s
+    /// piecewise function (`f = 5000 / qf`, valid range 20 < q < 50).
+    const QUALITY_UPPER_BRANCH: u8 = 30;
+    /// Quality byte that selects the lower branch (`f = 200 - 2 * qf`).
+    /// 60 sits comfortably inside `qf >= 50`.
+    const QUALITY_LOWER_BRANCH: u8 = 60;
+    /// Quality byte that drives `f` very small so the per-slot
+    /// `max(1.0)` clamp actually fires — exercises the "minimum 1"
+    /// guard that prevents divide-by-zero downstream.
+    const QUALITY_MAX: u8 = 100;
+    /// Expected level-shift output for an all-zero DCT block:
+    /// IDCT(0) = 0, then `+128` level shift. Pin this so a future
+    /// refactor that drops the level shift fails a test.
+    const LEVEL_SHIFT_OFFSET: u8 = 128;
+
+    #[test]
+    fn peek_n_bits_zero_pads_partial_window_at_end_of_stream() {
+        // CR round 1: peek into a 16-bit LUT must succeed even
+        // when fewer than 16 bits remain. Construct a 1-byte
+        // payload (8 bits available) and ask for 16 bits at
+        // offset 0 — the high 8 bits should be the byte's
+        // contents and the low 8 bits should be zero-padded.
+        let bytes = [0xA5_u8]; // 1010 0101
+        let peeked = peek_n_bits(&bytes, 0, 16).expect("partial peek must succeed");
+        assert_eq!(
+            peeked, 0xA500,
+            "high 8 bits = byte, low 8 bits zero-padded; got {peeked:#06x}"
+        );
+    }
+
+    #[test]
+    fn peek_n_bits_returns_eof_when_offset_past_end() {
+        // Reserved-EOF case: when bit_offset itself is past the
+        // available bits, peek must return EndOfStream so the
+        // decoder can break the AC loop instead of looping
+        // forever on a zero-padded code.
+        let bytes = [0xA5_u8];
+        // 8 bits available, ask for 16 starting at bit 8 — that's
+        // exactly at the boundary. Peeking from bit 8 should EOF
+        // because 8 >= total_bits (= 8).
+        let result = peek_n_bits(&bytes, 8, 16);
+        assert!(
+            matches!(result, Err(JpegError::EndOfStream)),
+            "got {result:?}"
+        );
+    }
+
+    #[test]
+    fn fetch_n_bits_advances_offset_and_returns_eof_past_end() {
+        // Fetch is the actual consume operation — it MUST
+        // surface EOF when the requested bits run past the
+        // available payload, since the decoder relies on that
+        // signal to abort mid-MCU.
+        let bytes = [0xFF_u8];
+        let mut ofs = 4_usize;
+        let four = fetch_n_bits(&bytes, &mut ofs, 4).expect("4 bits available");
+        assert_eq!(four, 0b1111);
+        assert_eq!(ofs, 8);
+        // Now ask for one more bit — the byte is exhausted.
+        let result = fetch_n_bits(&bytes, &mut ofs, 1);
+        assert!(
+            matches!(result, Err(JpegError::EndOfStream)),
+            "got {result:?}"
+        );
+    }
+
+    #[test]
+    fn lookup_dc_returns_negative_for_invalid_window() {
+        // The DC table covers categories 0-11, all of which
+        // start with a 1-bit prefix that lookup_dc handles. The
+        // only unmapped windows are those whose top 7 bits are
+        // 0b1111111 followed by a non-canonical continuation —
+        // those should return -1 so decode_mcu can surface
+        // BadDcCode.
+        let invalid = 0xFFFE_u16; // top 7 bits all 1 + non-canonical
+        assert_eq!(lookup_dc(invalid), -1);
+    }
+
+    #[test]
+    fn lookup_dc_decodes_each_known_category() {
+        // Walk the DC code table — code "00" + cat-specific
+        // suffixes — and verify each maps to the right category.
+        // (Bits beyond the code length don't matter; the helper
+        // only inspects the prefix.)
+        assert_eq!(lookup_dc(0b00 << 14), 0); // cat 0: code 00
+        assert_eq!(lookup_dc(0b010 << 13), 1); // cat 1: code 010
+        assert_eq!(lookup_dc(0b011 << 13), 2);
+        assert_eq!(lookup_dc(0b100 << 13), 3);
+        assert_eq!(lookup_dc(0b101 << 13), 4);
+        assert_eq!(lookup_dc(0b110 << 13), 5);
+        assert_eq!(lookup_dc(0b1110 << 12), 6); // cat 6: code 1110
+        assert_eq!(lookup_dc(0b11110 << 11), 7);
+        assert_eq!(lookup_dc(0b11_1110 << 10), 8);
+        assert_eq!(lookup_dc(0b111_1110 << 9), 9);
+        assert_eq!(lookup_dc(0b1111_1110 << 8), 10);
+        assert_eq!(lookup_dc(0b1_1111_1110 << 7), 11);
+    }
+
+    #[test]
+    fn fill_dqt_branches_on_quality_band() {
+        // Coverage gate: exercise both arms of the piecewise
+        // `f` formula. Different quality bands give different
+        // dqt magnitudes — pin "different" rather than exact
+        // values so QUANT_TEMPLATE refactors don't break this.
+        let lo = fill_dqt(QUALITY_UPPER_BRANCH);
+        let hi = fill_dqt(QUALITY_LOWER_BRANCH);
+        assert_ne!(lo, hi, "different quality bands must produce different dqt");
+        // Both must satisfy the `max(1.0)` floor.
+        assert!(lo.iter().all(|&v| v >= 1));
+        assert!(hi.iter().all(|&v| v >= 1));
+        // Highest quality should produce dqt ≈ 0 in the formula
+        // but the floor saturates everything to 1.
+        let max = fill_dqt(QUALITY_MAX);
+        assert!(
+            max.iter().all(|&v| v == 1),
+            "max-quality dqt must be all 1s"
+        );
+    }
+
+    #[test]
+    fn decode_mcu_minimal_stream_produces_uniform_block() {
+        // End-to-end smoke test of `decode_mcu`'s success path —
+        // the only path that exercises zigzag-unscramble + IDCT +
+        // level-shift in one call. Largely uncovered by the
+        // construction-only tests above.
+        //
+        // Bitstream: DC code "00" (cat 0, delta=0) then AC EOB
+        // code "1010" (run=0, size=0). Total 6 bits, packed
+        // MSB-first into one byte. Trailing zero bits don't
+        // matter — decode_mcu hits EOB and stops.
+        //   bits:  0 0 1 0 1 0 _ _
+        //          ────── ─────── ──
+        //           DC      EOB    pad
+        //   byte:  0b0010_1000 = 0x28
+        //
+        // Result: zdct = [0; 64] → IDCT zeros → +128 level shift
+        // → every pixel = 128.
+        let bytes = [0x28_u8];
+        let mut decoder = JpegDecoder::new();
+        let mut bit_offset = 0_usize;
+        let block = decoder
+            .decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH)
+            .expect("minimal MCU should decode");
+        assert_eq!(bit_offset, 6, "consumed exactly 6 bits");
+        for (y, row) in block.iter().enumerate() {
+            for (x, &p) in row.iter().enumerate() {
+                assert_eq!(
+                    p, LEVEL_SHIFT_OFFSET,
+                    "pixel ({y}, {x}) should be {LEVEL_SHIFT_OFFSET} after level shift"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn decode_mcu_dc_predictor_carries_across_calls() {
+        // The DC predictor accumulates across consecutive MCUs
+        // in the same packet (decoder.last_dc), then `reset_dc`
+        // zeros it between packets. Verify that the second
+        // identical "delta=0" MCU stream produces the same
+        // pixels as the first — the predictor stays at 0 because
+        // both deltas are 0.
+        let bytes = [0x28_u8]; // same minimal stream
+        let mut decoder = JpegDecoder::new();
+        let mut bit_offset = 0_usize;
+        let block_a = decoder
+            .decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH)
+            .expect("first MCU");
+        bit_offset = 0;
+        let block_b = decoder
+            .decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH)
+            .expect("second MCU");
+        assert_eq!(block_a, block_b, "DC=0 streams must match exactly");
+        // Now write a non-zero DC and confirm reset clears the
+        // predictor for the third call.
+        decoder.last_dc = 42.0;
+        decoder.reset_dc();
+        bit_offset = 0;
+        let block_c = decoder
+            .decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH)
+            .expect("post-reset MCU");
+        assert_eq!(
+            block_c, block_a,
+            "post-reset MCU must match the from-zero baseline"
+        );
+    }
+
+    #[test]
+    fn decode_mcu_eos_on_empty_input() {
+        // Zero-length payload: the very first peek should EOF.
+        let mut decoder = JpegDecoder::new();
+        let mut bit_offset = 0_usize;
+        let result = decoder.decode_mcu(&[], &mut bit_offset, QUALITY_LOWER_BRANCH);
+        assert!(
+            matches!(result, Err(JpegError::EndOfStream)),
+            "got {result:?}"
+        );
     }
 }

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -56,9 +56,9 @@ const ZIGZAG: [u8; 64] = [
 ];
 
 /// Per-category bit-offset for the standard JPEG DC Huffman
-/// table. Index = DC category (0-11); value = total Huffman code
-/// length in bits (length includes the variable-length suffix
-/// for category > 0).
+/// table. Index = DC category (0-11); value = Huffman code
+/// length in bits (code only; the variable-length value suffix
+/// of `cat` bits is fetched separately by `decode_mcu`).
 const DC_CAT_BIT_LEN: [u8; 12] = [2, 3, 3, 3, 3, 3, 4, 5, 6, 7, 8, 9];
 
 /// Standard JPEG AC Huffman table preamble + symbols. First 16
@@ -220,9 +220,7 @@ impl JpegDecoder {
             *bit_offset += ac.len as usize;
             // EOB marker: run=0 size=0.
             if ac.run == 0 && ac.size == 0 {
-                for slot in zdct.iter_mut().take(64).skip(k) {
-                    *slot = 0.0;
-                }
+                zdct[k..].fill(0.0);
                 break;
             }
             // Pre-validate that the AC symbol won't run past

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -225,16 +225,32 @@ impl JpegDecoder {
                 }
                 break;
             }
+            // Pre-validate that the AC symbol won't run past
+            // coefficient 63 BEFORE writing any zeros or fetching
+            // any value bits. Without this, an AC symbol whose
+            // run + value would land on k > 63 used to break the
+            // loop mid-symbol, leaving `bit_offset` part-way
+            // through the value bits and desyncing the next MCU.
+            // Per CR round 3.
+            //
+            // `needed` slots:
+            //   size > 0          : run zeros + 1 coefficient
+            //   run == 15, size 0 : ZRL writes 16 zeros total
+            //   anything else with size == 0 is invalid AC code
+            let needed = if ac.size > 0 {
+                usize::from(ac.run) + 1
+            } else if ac.run == 15 {
+                16
+            } else {
+                return Err(JpegError::BadAcCode);
+            };
+            if k + needed > MCU_SAMPLES {
+                return Err(JpegError::BadAcCode);
+            }
             // Skip `run` zeros then place the next coefficient.
             for _ in 0..ac.run {
-                if k >= 64 {
-                    break;
-                }
                 zdct[k] = 0.0;
                 k += 1;
-            }
-            if k >= 64 {
-                break;
             }
             if ac.size > 0 {
                 let n = fetch_n_bits(bytes, bit_offset, ac.size as usize)?;
@@ -245,10 +261,10 @@ impl JpegDecoder {
                 let coeff = map_range(ac.size, n) as f32;
                 zdct[k] = coeff;
                 k += 1;
-            } else if ac.run == 15 {
-                // ZRL: 16 zeros + no value (run=15 case writes
-                // one extra zero on top of the run we already
-                // wrote above).
+            } else {
+                // ZRL — guaranteed by the `needed` branch above
+                // (run == 15, size == 0). Writes one extra zero
+                // on top of the 15 the run loop already wrote.
                 zdct[k] = 0.0;
                 k += 1;
             }
@@ -886,6 +902,53 @@ mod tests {
         assert!(
             matches!(result, Err(JpegError::EndOfStream)),
             "got {result:?}"
+        );
+    }
+
+    #[test]
+    fn decode_mcu_rejects_ac_run_past_coefficient_63() {
+        // CR round 3: an AC symbol whose run + value would land
+        // past coefficient 63 must be rejected as a malformed
+        // code rather than silently breaking the AC loop and
+        // leaving bit_offset mid-symbol.
+        //
+        // Trigger: DC=0 (cat 0, code "00", 2 bits) then 4 × ZRL.
+        // Each ZRL writes 16 zeros — after 3 ZRLs k = 1 + 48 = 49,
+        // and the 4th ZRL needs 16 more slots which would land at
+        // k = 65, tripping the `k + needed > MCU_SAMPLES` guard.
+        //
+        // ZRL's actual code value depends on the AC table walk
+        // order, so look it up rather than hardcoding the bits.
+        let decoder = JpegDecoder::new();
+        let zrl = decoder
+            .ac_table
+            .iter()
+            .find(|e| e.run == 15 && e.size == 0)
+            .expect("ZRL must exist in AC table");
+
+        // Pack DC "00" (2 zero bits — already in the bit
+        // accumulator) + 4 × ZRL code, MSB-first.
+        let mut bits: u64 = 0;
+        let mut nbits: u32 = 2;
+        for _ in 0..4 {
+            bits = (bits << zrl.len) | u64::from(zrl.code);
+            nbits += u32::from(zrl.len);
+        }
+        let pad = (8 - (nbits % 8)) % 8;
+        bits <<= pad;
+        let total_bytes = (nbits + pad) as usize / 8;
+        let mut bytes = vec![0_u8; total_bytes];
+        for i in (0..total_bytes).rev() {
+            bytes[i] = (bits & 0xFF) as u8;
+            bits >>= 8;
+        }
+
+        let mut dec = JpegDecoder::new();
+        let mut bit_offset = 0_usize;
+        let result = dec.decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH);
+        assert!(
+            matches!(result, Err(JpegError::BadAcCode)),
+            "4x ZRL overshoots coefficient 63; expected BadAcCode, got {result:?}"
         );
     }
 }

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -110,6 +110,11 @@ pub struct JpegDecoder {
     /// 16-bit-window → DC category. -1 = no match.
     dc_lookup: Box<[i16; 65536]>,
     ac_table: Vec<AcEntry>,
+    /// Precomputed 8×8 cosine table for the IDCT inner loop.
+    /// Hoisted from a global `OnceLock` to a per-decoder field
+    /// (per CR round 2) so the hot path doesn't pay the
+    /// `OnceLock::get_or_init` atomic load per IDCT call.
+    cosine: [[f32; 8]; 8],
     /// Running DC predictor (across MCUs in the same packet).
     last_dc: f32,
 }
@@ -143,6 +148,7 @@ impl JpegDecoder {
             ac_lookup,
             dc_lookup,
             ac_table,
+            cosine: build_cosine_table(),
             last_dc: 0.0,
         }
     }
@@ -256,7 +262,7 @@ impl JpegDecoder {
 
         // Step 4: inverse DCT.
         let mut img = [0_f32; MCU_SAMPLES];
-        idct_8x8(&dct, &mut img);
+        idct_8x8(&dct, &mut img, &self.cosine);
 
         // Step 5: level-shift + clamp + pack into 8×8 block.
         let mut block: Block8x8 = [[0_u8; MCU_SIDE]; MCU_SIDE];
@@ -507,8 +513,11 @@ fn build_ac_table() -> Vec<AcEntry> {
 /// Inverse 8×8 DCT (naive O(N⁴) — adequate at Meteor's
 /// ~400 IDCTs/second budget). Direct port of medet's
 /// `flt_idct_8x8`.
-fn idct_8x8(input: &[f32; MCU_SAMPLES], output: &mut [f32; MCU_SAMPLES]) {
-    let cosine = cosine_table();
+///
+/// `cosine` is the precomputed 8×8 cosine table; the caller
+/// owns it (typically a [`JpegDecoder`] field) so this hot
+/// function doesn't pay a per-call atomic load.
+fn idct_8x8(input: &[f32; MCU_SAMPLES], output: &mut [f32; MCU_SAMPLES], cosine: &[[f32; 8]; 8]) {
     let alpha = alpha_table();
     for y in 0..MCU_SIDE {
         for x in 0..MCU_SIDE {
@@ -527,25 +536,22 @@ fn idct_8x8(input: &[f32; MCU_SAMPLES], output: &mut [f32; MCU_SAMPLES]) {
     }
 }
 
-/// Precomputed 8×8 cosine table.
-fn cosine_table() -> [[f32; 8]; 8] {
-    // Computed once and stuffed inline; runtime cost is the
-    // first `cosine_table()` call (which initializes the static
-    // via std::sync::OnceLock under the hood).
-    static TABLE: std::sync::OnceLock<[[f32; 8]; 8]> = std::sync::OnceLock::new();
-    *TABLE.get_or_init(|| {
-        let mut t = [[0.0_f32; 8]; 8];
-        #[allow(
-            clippy::cast_precision_loss,
-            reason = "loop indices 0..8 fit exactly in f32"
-        )]
-        for (y, row) in t.iter_mut().enumerate() {
-            for (x, slot) in row.iter_mut().enumerate() {
-                *slot = (PI / 16.0 * (2.0 * y as f32 + 1.0) * x as f32).cos();
-            }
+/// Build the 8×8 cosine table used by [`idct_8x8`]. Called
+/// once per [`JpegDecoder::new`]; the result is stored in the
+/// decoder so the IDCT inner loop can read it without any
+/// synchronization.
+fn build_cosine_table() -> [[f32; 8]; 8] {
+    let mut t = [[0.0_f32; 8]; 8];
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "loop indices 0..8 fit exactly in f32"
+    )]
+    for (y, row) in t.iter_mut().enumerate() {
+        for (x, slot) in row.iter_mut().enumerate() {
+            *slot = (PI / 16.0 * (2.0 * y as f32 + 1.0) * x as f32).cos();
         }
-        t
-    })
+    }
+    t
 }
 
 /// Precomputed alpha vector — `alpha[0] = 1/√2`, rest = 1.
@@ -621,7 +627,8 @@ mod tests {
     fn idct_zero_block_returns_zero() {
         let zeros = [0_f32; MCU_SAMPLES];
         let mut out = [0_f32; MCU_SAMPLES];
-        idct_8x8(&zeros, &mut out);
+        let cosine = build_cosine_table();
+        idct_8x8(&zeros, &mut out, &cosine);
         for &v in &out {
             assert!(v.abs() < 1e-5, "IDCT of zeros should be zero, got {v}");
         }
@@ -635,7 +642,8 @@ mod tests {
         let mut input = [0_f32; MCU_SAMPLES];
         input[0] = 800.0;
         let mut out = [0_f32; MCU_SAMPLES];
-        idct_8x8(&input, &mut out);
+        let cosine = build_cosine_table();
+        idct_8x8(&input, &mut out, &cosine);
         let expected = 800.0 / 8.0;
         for &v in &out {
             assert!(

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -214,6 +214,14 @@ impl JpegDecoder {
             reason = "guarded by the dc_cat_signed < 0 branch above; DC category ∈ [0, 11] always fits in u8"
         )]
         let dc_cat = dc_cat_signed as u8;
+        // The LUT can match a code via zero-padded peek bits; only
+        // advance bit_offset if those bits actually exist. Per CR
+        // round 7.
+        ensure_n_bits_available(
+            bytes,
+            *bit_offset,
+            usize::from(DC_CAT_BIT_LEN[dc_cat as usize]),
+        )?;
         *bit_offset += DC_CAT_BIT_LEN[dc_cat as usize] as usize;
         let dc_value_bits = if dc_cat > 0 {
             fetch_n_bits(bytes, bit_offset, dc_cat as usize)?
@@ -241,6 +249,9 @@ impl JpegDecoder {
                 reason = "guarded by the ac_idx_signed < 0 branch above"
             )]
             let ac = self.ac_table[ac_idx_signed as usize];
+            // Same zero-padded-peek hazard as DC above: only
+            // advance if the matched code's bits actually exist.
+            ensure_n_bits_available(bytes, *bit_offset, usize::from(ac.len))?;
             *bit_offset += ac.len as usize;
             // EOB marker: run=0 size=0.
             if ac.run == 0 && ac.size == 0 {
@@ -403,6 +414,20 @@ fn peek_n_bits(bytes: &[u8], bit_offset: usize, n: usize) -> Result<u16, JpegErr
     )]
     let padded = (result << (HUFF_LOOKAHEAD_BITS - n)) as u16;
     Ok(padded)
+}
+
+/// Verify that `n` bits are actually present in `bytes` starting at
+/// `bit_offset`. Used to gate Huffman-code consumption AFTER the
+/// LUT lookup has matched, because [`peek_n_bits`] zero-pads short
+/// windows — without this guard a payload tail of `101` could be
+/// accepted as the 4-bit AC EOB code (`1010`) and `bit_offset` would
+/// advance past the end of the stream. Per CR round 7.
+fn ensure_n_bits_available(bytes: &[u8], bit_offset: usize, n: usize) -> Result<(), JpegError> {
+    let total_bits = bytes.len() * 8;
+    match bit_offset.checked_add(n) {
+        Some(end) if end <= total_bits => Ok(()),
+        _ => Err(JpegError::EndOfStream),
+    }
 }
 
 /// Fetch the next `n` bits from `bytes`, advancing `bit_offset`.
@@ -978,6 +1003,73 @@ mod tests {
         assert!(
             matches!(result, Err(JpegError::BadAcCode)),
             "4x ZRL overshoots coefficient 63; expected BadAcCode, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn ensure_n_bits_available_validates_bounds() {
+        // Direct test of the helper's contract: returns Ok when
+        // `bit_offset + n` is in bounds, EndOfStream otherwise,
+        // including the checked_add overflow path.
+        let bytes = [0xFF_u8; 2]; // 16 bits
+        assert!(ensure_n_bits_available(&bytes, 0, 16).is_ok());
+        assert!(ensure_n_bits_available(&bytes, 8, 8).is_ok());
+        assert!(matches!(
+            ensure_n_bits_available(&bytes, 8, 9),
+            Err(JpegError::EndOfStream)
+        ));
+        assert!(matches!(
+            ensure_n_bits_available(&bytes, usize::MAX, 1),
+            Err(JpegError::EndOfStream)
+        ));
+    }
+
+    #[test]
+    fn decode_mcu_rejects_truncated_dc_code() {
+        // CR round 7: peek_n_bits zero-pads short windows so a
+        // truncated tail can spuriously match a Huffman LUT
+        // entry. The AFTER-match availability check must catch
+        // that and return EndOfStream rather than advance
+        // bit_offset past the end of the payload.
+        //
+        // Trigger: empty payload with bit_offset already past
+        // the start. peek returns EndOfStream directly here.
+        // For the matched-code-but-not-enough-bits path, build
+        // a 1-byte payload whose last 4 bits look like a valid
+        // DC code prefix but where there isn't room for the
+        // category's value suffix.
+        //
+        // DC cat 6 has code 0b1110 (4 bits) + 6 value bits
+        // (10 bits total). Pack DC "1110" left-aligned in one
+        // byte = 0b1110_0000 = 0xE0. After matching cat 6, the
+        // pre-CR code would advance bit_offset by 4 then try to
+        // fetch 6 value bits — but only 4 bits remain in the
+        // payload after the code, so fetch_n_bits would EOF
+        // anyway. The new pre-advance guard makes the failure
+        // mode crisper: ensure_n_bits_available catches the
+        // missing code bits BEFORE advancing.
+        //
+        // To exercise the ensure_n_bits_available branch
+        // specifically, construct a payload where the LUT
+        // matches via padding bits. 1-byte payload `0b1110_0000`
+        // peeked at bit_offset=4 sees only 4 valid bits
+        // (`0000`) followed by 12 zero pads — the all-zeros
+        // window matches DC cat 0 (code "00"). With cat 0
+        // requiring 2 code bits and only 4 actual bits left
+        // (bit_offset=4 in an 8-bit payload), the pre-advance
+        // guard accepts the 2-bit consumption. To force the
+        // failure, peek at bit_offset=7: only 1 valid bit
+        // remains, but the LUT will still match cat 0 (the
+        // all-zero window). The pre-advance guard rejects
+        // because 7 + 2 = 9 > 8.
+        let bytes = [0xE0_u8]; // 8 valid bits
+        let mut decoder = JpegDecoder::new();
+        let mut bit_offset = 7_usize;
+        let dqt = fill_dqt(QUALITY_LOWER_BRANCH);
+        let result = decoder.decode_mcu(&bytes, &mut bit_offset, &dqt);
+        assert!(
+            matches!(result, Err(JpegError::EndOfStream)),
+            "matched DC cat 0 (2 bits) at bit_offset=7 of 8-bit payload must EOF, got {result:?}"
         );
     }
 }

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -37,6 +37,12 @@ pub const MCU_SAMPLES: usize = MCU_SIDE * MCU_SIDE; // 64
 /// Pixel values in a decoded 8×8 MCU.
 pub type Block8x8 = [[u8; MCU_SIDE]; MCU_SIDE];
 
+/// Per-packet quantization table — one `u16` per zigzag slot.
+/// Built once per image packet by [`fill_dqt`] and threaded into
+/// every [`JpegDecoder::decode_mcu`] call so the hot loop doesn't
+/// recompute it 14 times per packet.
+pub type Dqt = [u16; MCU_SAMPLES];
+
 /// Standard JPEG luminance quantization template (see JPEG ISO/
 /// IEC 10918-1 Annex K). Meteor scales this per-packet by a
 /// quality byte; `fill_dqt` does the scaling.
@@ -54,6 +60,18 @@ const ZIGZAG: [u8; 64] = [
     18, 24, 31, 40, 44, 53, 10, 19, 23, 32, 39, 45, 52, 54, 20, 22, 33, 38, 46, 51, 55, 60, 21, 34,
     37, 47, 50, 56, 59, 61, 35, 36, 48, 49, 57, 58, 62, 63,
 ];
+
+/// Bit-window width for Huffman code lookup. The decoder peeks
+/// this many bits, indexes a flat LUT keyed by the window, and
+/// reads back the Huffman entry — turning a per-symbol bit-by-bit
+/// walk into a single load. 16 bits is the maximum standard JPEG
+/// Huffman code length, so any valid code fits inside one window.
+const HUFF_LOOKAHEAD_BITS: usize = 16;
+
+/// Number of entries in each Huffman LUT (`2 ^ HUFF_LOOKAHEAD_BITS`
+/// = 65536). Each entry is an `i16` storing either the table
+/// index for a matched code or `-1` for "no match".
+const HUFF_LUT_SIZE: usize = 1 << HUFF_LOOKAHEAD_BITS;
 
 /// Per-category bit-offset for the standard JPEG DC Huffman
 /// table. Index = DC category (0-11); value = Huffman code
@@ -105,10 +123,10 @@ pub enum JpegError {
 /// lookup tables (built once at construction); per-MCU state is
 /// the running DC predictor.
 pub struct JpegDecoder {
-    /// 16-bit-window → AC table index. -1 = no match.
-    ac_lookup: Box<[i16; 65536]>,
-    /// 16-bit-window → DC category. -1 = no match.
-    dc_lookup: Box<[i16; 65536]>,
+    /// `HUFF_LOOKAHEAD_BITS`-window → AC table index. -1 = no match.
+    ac_lookup: Box<[i16; HUFF_LUT_SIZE]>,
+    /// `HUFF_LOOKAHEAD_BITS`-window → DC category. -1 = no match.
+    dc_lookup: Box<[i16; HUFF_LUT_SIZE]>,
     ac_table: Vec<AcEntry>,
     /// Precomputed 8×8 cosine table for the IDCT inner loop.
     /// Hoisted from a global `OnceLock` to a per-decoder field
@@ -129,16 +147,21 @@ impl JpegDecoder {
     #[must_use]
     #[allow(
         clippy::large_stack_arrays,
-        reason = "two 65536-entry i16 LUTs are heap-allocated via Box::new — the stack pressure is the boxed initializer, not the final storage; smaller LUTs would defeat the O(1) Huffman lookup"
+        reason = "two HUFF_LUT_SIZE-entry i16 LUTs are heap-allocated via Box::new — the stack pressure is the boxed initializer, not the final storage; smaller LUTs would defeat the O(1) Huffman lookup"
     )]
     pub fn new() -> Self {
         let ac_table = build_ac_table();
-        let mut ac_lookup = Box::new([-1_i16; 65536]);
-        let mut dc_lookup = Box::new([-1_i16; 65536]);
-        for w in 0_u32..65536 {
+        let mut ac_lookup = Box::new([-1_i16; HUFF_LUT_SIZE]);
+        let mut dc_lookup = Box::new([-1_i16; HUFF_LUT_SIZE]);
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "HUFF_LUT_SIZE = 2^16 = 65536 fits exactly in u32"
+        )]
+        let lut_size_u32 = HUFF_LUT_SIZE as u32;
+        for w in 0_u32..lut_size_u32 {
             #[allow(
                 clippy::cast_possible_truncation,
-                reason = "loop bound 0..65536 fits in u16"
+                reason = "loop bound 0..HUFF_LUT_SIZE = 2^16 fits in u16"
             )]
             let w16 = w as u16;
             ac_lookup[w as usize] = lookup_ac(w16, &ac_table);
@@ -159,9 +182,11 @@ impl JpegDecoder {
         self.last_dc = 0.0;
     }
 
-    /// Decode one 8×8 MCU from the bit stream `bytes`. `quality`
-    /// is the per-packet quantization-table scaling byte (Meteor
-    /// transmits this in the image-packet payload header).
+    /// Decode one 8×8 MCU from the bit stream `bytes`. `dqt` is
+    /// the per-packet quantization table — caller computes it
+    /// once per packet via [`fill_dqt`] and passes the same
+    /// reference to every MCU in the packet so the dequant
+    /// step doesn't recompute it 14 times in the inner loop.
     /// Returns the decoded pixel block on success.
     ///
     /// # Errors
@@ -173,13 +198,12 @@ impl JpegDecoder {
         &mut self,
         bytes: &[u8],
         bit_offset: &mut usize,
-        quality: u8,
+        dqt: &Dqt,
     ) -> Result<Block8x8, JpegError> {
-        let dqt = fill_dqt(quality);
         let mut zdct = [0_f32; MCU_SAMPLES];
 
         // Step 1: DC delta.
-        let dc_window = peek_n_bits(bytes, *bit_offset, 16)?;
+        let dc_window = peek_n_bits(bytes, *bit_offset, HUFF_LOOKAHEAD_BITS)?;
         let dc_cat_signed = self.dc_lookup[dc_window as usize];
         if dc_cat_signed < 0 {
             return Err(JpegError::BadDcCode);
@@ -207,7 +231,7 @@ impl JpegDecoder {
         // Step 2: AC run-length pairs until end-of-block.
         let mut k: usize = 1;
         while k < 64 {
-            let ac_window = peek_n_bits(bytes, *bit_offset, 16)?;
+            let ac_window = peek_n_bits(bytes, *bit_offset, HUFF_LOOKAHEAD_BITS)?;
             let ac_idx_signed = self.ac_lookup[ac_window as usize];
             if ac_idx_signed < 0 {
                 return Err(JpegError::BadAcCode);
@@ -297,15 +321,17 @@ impl JpegDecoder {
 }
 
 /// Per-packet quantization table — derived from the standard
-/// template scaled by the packet's quality byte.
-fn fill_dqt(q: u8) -> [u16; 64] {
+/// template scaled by the packet's quality byte. Public so the
+/// LRPT pipeline can compute it once per packet and pass the
+/// same `Dqt` to every MCU in that packet.
+pub fn fill_dqt(q: u8) -> Dqt {
     let qf = f32::from(q);
     let f = if qf > 20.0 && qf < 50.0 {
         5000.0 / qf
     } else {
         200.0 - 2.0 * qf
     };
-    let mut dqt = [0_u16; 64];
+    let mut dqt: Dqt = [0_u16; MCU_SAMPLES];
     for (i, slot) in dqt.iter_mut().enumerate() {
         let scaled = (f * f32::from(QUANT_TEMPLATE[i]) / 100.0).round();
         #[allow(
@@ -351,7 +377,7 @@ fn map_range(cat: u8, value: u16) -> i32 {
 /// `EndOfStream` is reserved for [`fetch_n_bits`] — the actual
 /// consume operation that asks for bits we don't have.
 fn peek_n_bits(bytes: &[u8], bit_offset: usize, n: usize) -> Result<u16, JpegError> {
-    debug_assert!(n <= 16);
+    debug_assert!(n <= HUFF_LOOKAHEAD_BITS);
     let total_bits = bytes.len() * 8;
     if bit_offset >= total_bits {
         return Err(JpegError::EndOfStream);
@@ -368,20 +394,20 @@ fn peek_n_bits(bytes: &[u8], bit_offset: usize, n: usize) -> Result<u16, JpegErr
         };
         result = (result << 1) | u32::from(bit);
     }
-    // Left-pad to 16 bits so callers can index a 65k LUT
-    // directly off the value (matches medet's bio_peek_n_bits
-    // convention).
+    // Left-pad to HUFF_LOOKAHEAD_BITS so callers can index the
+    // HUFF_LUT_SIZE-entry LUT directly off the value (matches
+    // medet's bio_peek_n_bits convention).
     #[allow(
         clippy::cast_possible_truncation,
-        reason = "result < 2^n ≤ 2^16, fits in u16 after the shift below"
+        reason = "result < 2^n ≤ 2^HUFF_LOOKAHEAD_BITS, fits in u16 after the shift below"
     )]
-    let padded = (result << (16 - n)) as u16;
+    let padded = (result << (HUFF_LOOKAHEAD_BITS - n)) as u16;
     Ok(padded)
 }
 
 /// Fetch the next `n` bits from `bytes`, advancing `bit_offset`.
 fn fetch_n_bits(bytes: &[u8], bit_offset: &mut usize, n: usize) -> Result<u16, JpegError> {
-    debug_assert!(n <= 16);
+    debug_assert!(n <= HUFF_LOOKAHEAD_BITS);
     let mut result: u16 = 0;
     for _ in 0..n {
         let byte_idx = *bit_offset / 8;
@@ -437,9 +463,10 @@ fn lookup_dc(w: u16) -> i16 {
 fn lookup_ac(w: u16, table: &[AcEntry]) -> i16 {
     for (i, e) in table.iter().enumerate() {
         // Right-shift to align `w` with the entry's code length,
-        // then mask to the entry's bit width. Mask uses u32
-        // so e.len = 16 doesn't overflow `1_u16 << 16`.
-        let shifted = u32::from(w) >> (16 - e.len);
+        // then mask to the entry's bit width. Mask uses u32 so
+        // e.len = HUFF_LOOKAHEAD_BITS doesn't overflow
+        // `1_u16 << HUFF_LOOKAHEAD_BITS`.
+        let shifted = u32::from(w) >> (HUFF_LOOKAHEAD_BITS - usize::from(e.len));
         let mask = (1_u32 << e.len) - 1;
         if (shifted & mask) == u32::from(e.code) {
             #[allow(
@@ -458,13 +485,13 @@ fn lookup_ac(w: u16, table: &[AcEntry]) -> i16 {
 /// values arrays. Direct port of medet's `default_huffman_table`.
 #[allow(
     clippy::large_stack_arrays,
-    reason = "the 65536-entry slot table is the canonical (length, position) addressing space matching medet's port; called once per JpegDecoder construction"
+    reason = "the HUFF_LUT_SIZE-entry slot table is the canonical (length, position) addressing space matching medet's port; called once per JpegDecoder construction"
 )]
 fn build_ac_table() -> Vec<AcEntry> {
     let bits = &T_AC_0[0..16];
     let values = &T_AC_0[16..];
     // Distribute symbols into per-length slots.
-    let mut v = vec![0_u8; 65536];
+    let mut v = vec![0_u8; HUFF_LUT_SIZE];
     let mut p = 0_usize;
     for k in 1..=16 {
         for i in 0..bits[k - 1] as usize {
@@ -844,8 +871,9 @@ mod tests {
         let bytes = [0x28_u8];
         let mut decoder = JpegDecoder::new();
         let mut bit_offset = 0_usize;
+        let dqt = fill_dqt(QUALITY_LOWER_BRANCH);
         let block = decoder
-            .decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH)
+            .decode_mcu(&bytes, &mut bit_offset, &dqt)
             .expect("minimal MCU should decode");
         assert_eq!(bit_offset, 6, "consumed exactly 6 bits");
         for (y, row) in block.iter().enumerate() {
@@ -869,12 +897,13 @@ mod tests {
         let bytes = [0x28_u8]; // same minimal stream
         let mut decoder = JpegDecoder::new();
         let mut bit_offset = 0_usize;
+        let dqt = fill_dqt(QUALITY_LOWER_BRANCH);
         let block_a = decoder
-            .decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH)
+            .decode_mcu(&bytes, &mut bit_offset, &dqt)
             .expect("first MCU");
         bit_offset = 0;
         let block_b = decoder
-            .decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH)
+            .decode_mcu(&bytes, &mut bit_offset, &dqt)
             .expect("second MCU");
         assert_eq!(block_a, block_b, "DC=0 streams must match exactly");
         // Now write a non-zero DC and confirm reset clears the
@@ -883,7 +912,7 @@ mod tests {
         decoder.reset_dc();
         bit_offset = 0;
         let block_c = decoder
-            .decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH)
+            .decode_mcu(&bytes, &mut bit_offset, &dqt)
             .expect("post-reset MCU");
         assert_eq!(
             block_c, block_a,
@@ -896,7 +925,8 @@ mod tests {
         // Zero-length payload: the very first peek should EOF.
         let mut decoder = JpegDecoder::new();
         let mut bit_offset = 0_usize;
-        let result = decoder.decode_mcu(&[], &mut bit_offset, QUALITY_LOWER_BRANCH);
+        let dqt = fill_dqt(QUALITY_LOWER_BRANCH);
+        let result = decoder.decode_mcu(&[], &mut bit_offset, &dqt);
         assert!(
             matches!(result, Err(JpegError::EndOfStream)),
             "got {result:?}"
@@ -943,7 +973,8 @@ mod tests {
 
         let mut dec = JpegDecoder::new();
         let mut bit_offset = 0_usize;
-        let result = dec.decode_mcu(&bytes, &mut bit_offset, QUALITY_LOWER_BRANCH);
+        let dqt = fill_dqt(QUALITY_LOWER_BRANCH);
+        let result = dec.decode_mcu(&bytes, &mut bit_offset, &dqt);
         assert!(
             matches!(result, Err(JpegError::BadAcCode)),
             "4x ZRL overshoots coefficient 63; expected BadAcCode, got {result:?}"

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -313,7 +313,7 @@ fn fill_dqt(q: u8) -> [u16; 64] {
         #[allow(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
-            reason = "max value is QUANT_TEMPLATE max (121) × max f (≈10) = 1210, fits in u16"
+            reason = "max scaled value is QUANT_TEMPLATE max (121) × max f (≈238 from 5000/qf at qf≈21) / 100 ≈ 288, fits in u16"
         )]
         let raw = scaled.max(1.0) as u16;
         *slot = raw;

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -200,10 +200,19 @@ impl JpegDecoder {
         bit_offset: &mut usize,
         dqt: &Dqt,
     ) -> Result<Block8x8, JpegError> {
+        // Per CR round 8: decode through local shadow state
+        // (`next_offset` for bit_offset, `next_dc` for self.last_dc)
+        // and only commit the shadows back to the caller-visible
+        // fields once the MCU has fully decoded. On any
+        // intermediate Err the caller's `bit_offset` and the
+        // decoder's `last_dc` stay at their pre-call values, so
+        // the public streaming API is transactional.
+        let mut next_offset = *bit_offset;
+        let mut next_dc = self.last_dc;
         let mut zdct = [0_f32; MCU_SAMPLES];
 
         // Step 1: DC delta.
-        let dc_window = peek_n_bits(bytes, *bit_offset, HUFF_LOOKAHEAD_BITS)?;
+        let dc_window = peek_n_bits(bytes, next_offset, HUFF_LOOKAHEAD_BITS)?;
         let dc_cat_signed = self.dc_lookup[dc_window as usize];
         if dc_cat_signed < 0 {
             return Err(JpegError::BadDcCode);
@@ -215,16 +224,15 @@ impl JpegDecoder {
         )]
         let dc_cat = dc_cat_signed as u8;
         // The LUT can match a code via zero-padded peek bits; only
-        // advance bit_offset if those bits actually exist. Per CR
-        // round 7.
+        // advance if those bits actually exist. Per CR round 7.
         ensure_n_bits_available(
             bytes,
-            *bit_offset,
+            next_offset,
             usize::from(DC_CAT_BIT_LEN[dc_cat as usize]),
         )?;
-        *bit_offset += DC_CAT_BIT_LEN[dc_cat as usize] as usize;
+        next_offset += DC_CAT_BIT_LEN[dc_cat as usize] as usize;
         let dc_value_bits = if dc_cat > 0 {
-            fetch_n_bits(bytes, bit_offset, dc_cat as usize)?
+            fetch_n_bits(bytes, &mut next_offset, dc_cat as usize)?
         } else {
             0
         };
@@ -233,13 +241,13 @@ impl JpegDecoder {
             reason = "DC delta is bounded by ±2^11 (category ≤ 11), well within f32 mantissa"
         )]
         let dc_delta = map_range(dc_cat, dc_value_bits) as f32;
-        zdct[0] = dc_delta + self.last_dc;
-        self.last_dc = zdct[0];
+        next_dc += dc_delta;
+        zdct[0] = next_dc;
 
         // Step 2: AC run-length pairs until end-of-block.
         let mut k: usize = 1;
         while k < 64 {
-            let ac_window = peek_n_bits(bytes, *bit_offset, HUFF_LOOKAHEAD_BITS)?;
+            let ac_window = peek_n_bits(bytes, next_offset, HUFF_LOOKAHEAD_BITS)?;
             let ac_idx_signed = self.ac_lookup[ac_window as usize];
             if ac_idx_signed < 0 {
                 return Err(JpegError::BadAcCode);
@@ -251,8 +259,8 @@ impl JpegDecoder {
             let ac = self.ac_table[ac_idx_signed as usize];
             // Same zero-padded-peek hazard as DC above: only
             // advance if the matched code's bits actually exist.
-            ensure_n_bits_available(bytes, *bit_offset, usize::from(ac.len))?;
-            *bit_offset += ac.len as usize;
+            ensure_n_bits_available(bytes, next_offset, usize::from(ac.len))?;
+            next_offset += ac.len as usize;
             // EOB marker: run=0 size=0.
             if ac.run == 0 && ac.size == 0 {
                 zdct[k..].fill(0.0);
@@ -286,7 +294,7 @@ impl JpegDecoder {
                 k += 1;
             }
             if ac.size > 0 {
-                let n = fetch_n_bits(bytes, bit_offset, ac.size as usize)?;
+                let n = fetch_n_bits(bytes, &mut next_offset, ac.size as usize)?;
                 #[allow(
                     clippy::cast_precision_loss,
                     reason = "AC coefficient is bounded by ±2^10 (size ≤ 10 in practice), within f32 mantissa"
@@ -327,9 +335,37 @@ impl JpegDecoder {
                 block[y][x] = clamped;
             }
         }
+        // Commit shadow state — the MCU has decoded fully without
+        // any intermediate Err. Per CR round 8: leaving these
+        // commits to the very end keeps `decode_mcu` transactional
+        // (caller's bit_offset and decoder's last_dc stay at the
+        // pre-call values on any error path above).
+        *bit_offset = next_offset;
+        self.last_dc = next_dc;
         Ok(block)
     }
 }
+
+/// Lower bound (exclusive) of the Meteor JPEG quality band that
+/// uses the `5000 / qf` scaling rule. Below or at this threshold
+/// the linear `200 - 2 * qf` rule applies instead.
+const QUALITY_HYPERBOLIC_MIN: f32 = 20.0;
+/// Upper bound (exclusive) of the same hyperbolic band. At or
+/// above this quality the linear rule takes over again.
+const QUALITY_HYPERBOLIC_MAX: f32 = 50.0;
+/// Numerator of the hyperbolic quality rule: `f = HYP_NUM / qf`
+/// for qf ∈ (`QUALITY_HYPERBOLIC_MIN`, `QUALITY_HYPERBOLIC_MAX`).
+const QUALITY_HYPERBOLIC_NUM: f32 = 5000.0;
+/// Constant term of the linear quality rule: `f = LIN_BASE - LIN_SLOPE * qf`.
+const QUALITY_LINEAR_BASE: f32 = 200.0;
+/// Slope of the linear quality rule.
+const QUALITY_LINEAR_SLOPE: f32 = 2.0;
+/// Divisor that scales `f * QUANT_TEMPLATE[i]` back into the JPEG
+/// quantization range. Lifted directly from medet's `met_jpg.pas`.
+const QUALITY_TEMPLATE_DIVISOR: f32 = 100.0;
+/// Floor applied per-slot — JPEG dequantization divides by
+/// `dqt[i]`, so a zero would blow up the IDCT input.
+const QUALITY_MIN_DQT: f32 = 1.0;
 
 /// Per-packet quantization table — derived from the standard
 /// template scaled by the packet's quality byte. Public so the
@@ -337,20 +373,20 @@ impl JpegDecoder {
 /// same `Dqt` to every MCU in that packet.
 pub fn fill_dqt(q: u8) -> Dqt {
     let qf = f32::from(q);
-    let f = if qf > 20.0 && qf < 50.0 {
-        5000.0 / qf
+    let f = if qf > QUALITY_HYPERBOLIC_MIN && qf < QUALITY_HYPERBOLIC_MAX {
+        QUALITY_HYPERBOLIC_NUM / qf
     } else {
-        200.0 - 2.0 * qf
+        QUALITY_LINEAR_BASE - QUALITY_LINEAR_SLOPE * qf
     };
     let mut dqt: Dqt = [0_u16; MCU_SAMPLES];
     for (i, slot) in dqt.iter_mut().enumerate() {
-        let scaled = (f * f32::from(QUANT_TEMPLATE[i]) / 100.0).round();
+        let scaled = (f * f32::from(QUANT_TEMPLATE[i]) / QUALITY_TEMPLATE_DIVISOR).round();
         #[allow(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
             reason = "max scaled value is QUANT_TEMPLATE max (121) × max f (≈238 from 5000/qf at qf≈21) / 100 ≈ 288, fits in u16"
         )]
-        let raw = scaled.max(1.0) as u16;
+        let raw = scaled.max(QUALITY_MIN_DQT) as u16;
         *slot = raw;
     }
     dqt
@@ -1070,6 +1106,39 @@ mod tests {
         assert!(
             matches!(result, Err(JpegError::EndOfStream)),
             "matched DC cat 0 (2 bits) at bit_offset=7 of 8-bit payload must EOF, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn decode_mcu_is_transactional_on_error() {
+        // CR round 8: on any intermediate Err, the caller's
+        // bit_offset and the decoder's last_dc must stay at
+        // their pre-call values. Otherwise a streaming caller
+        // is left with a poisoned predictor / half-advanced
+        // offset that desyncs the next MCU.
+        //
+        // Trigger: bit_offset=7 in an 8-bit payload (same as
+        // the truncated-DC test above) — `ensure_n_bits_available`
+        // returns EndOfStream AFTER the LUT match. Confirm
+        // both bit_offset and last_dc are unchanged after
+        // the call returns Err.
+        // Pre-set last_dc to a non-zero sentinel so an
+        // accidental commit-on-error would clobber it visibly.
+        const PRE_DC: f32 = 99.0;
+        let bytes = [0xE0_u8];
+        let mut decoder = JpegDecoder::new();
+        decoder.last_dc = PRE_DC;
+        let mut bit_offset = 7_usize;
+        let dqt = fill_dqt(QUALITY_LOWER_BRANCH);
+        let result = decoder.decode_mcu(&bytes, &mut bit_offset, &dqt);
+        assert!(matches!(result, Err(JpegError::EndOfStream)));
+        assert_eq!(
+            bit_offset, 7,
+            "caller's bit_offset must not advance on error"
+        );
+        assert_eq!(
+            decoder.last_dc, PRE_DC,
+            "decoder's last_dc must not change on error"
         );
     }
 }

--- a/crates/sdr-lrpt/src/image/jpeg.rs
+++ b/crates/sdr-lrpt/src/image/jpeg.rs
@@ -1,0 +1,670 @@
+//! Meteor reduced-JPEG decoder.
+//!
+//! Decodes the JPEG-compressed scan-line groups carried in
+//! Meteor LRPT image packets. Meteor uses a *reduced* JPEG: the
+//! standard JPEG AC Huffman table, the standard zigzag pattern,
+//! and the standard quantization template — but no per-frame
+//! tables on the wire. The receiver must hardcode all three.
+//!
+//! Output: one [`Block8x8`] per call to [`JpegDecoder::decode_mcu`],
+//! representing one 8×8 MCU (minimum coded unit) of the AVHRR
+//! scan-line group.
+//!
+//! Pipeline math (per medet's `met_jpg.pas`):
+//! 1. Huffman-decode DC delta, reconstruct DC coefficient
+//! 2. Huffman-decode AC run-length pairs until end-of-block
+//! 3. Zigzag-unscramble the 64 coefficients
+//! 4. Dequantize: `coeffs[i] *= dqt[i]` (dqt scaled per packet
+//!    quality byte)
+//! 5. Inverse DCT (8×8 naive O(N²) — adequate at Meteor's
+//!    ~400 IDCTs/second budget)
+//! 6. Level-shift +128 + clamp to 0-255
+//!
+//! References (read-only):
+//! - `original/medet/met_jpg.pas`
+//! - `original/medet/dct.pas`
+//! - `original/medet/huffman.pas`
+//! - `original/MeteorDemod/decoder/protocol/lrpt/msumr/image.cpp`
+
+use std::f32::consts::{FRAC_1_SQRT_2, PI};
+
+/// Side length of one MCU in pixels.
+pub const MCU_SIDE: usize = 8;
+
+/// Total samples per MCU.
+pub const MCU_SAMPLES: usize = MCU_SIDE * MCU_SIDE; // 64
+
+/// Pixel values in a decoded 8×8 MCU.
+pub type Block8x8 = [[u8; MCU_SIDE]; MCU_SIDE];
+
+/// Standard JPEG luminance quantization template (see JPEG ISO/
+/// IEC 10918-1 Annex K). Meteor scales this per-packet by a
+/// quality byte; `fill_dqt` does the scaling.
+const QUANT_TEMPLATE: [u8; 64] = [
+    16, 11, 10, 16, 24, 40, 51, 61, 12, 12, 14, 19, 26, 58, 60, 55, 14, 13, 16, 24, 40, 57, 69, 56,
+    14, 17, 22, 29, 51, 87, 80, 62, 18, 22, 37, 56, 68, 109, 103, 77, 24, 35, 55, 64, 81, 104, 113,
+    92, 49, 64, 78, 87, 103, 121, 120, 101, 72, 92, 95, 98, 112, 100, 103, 99,
+];
+
+/// Standard JPEG zigzag pattern (Annex F.1.1.5). Maps a 64-entry
+/// run-length-decoded coefficient array back to its 8×8 spatial
+/// position.
+const ZIGZAG: [u8; 64] = [
+    0, 1, 5, 6, 14, 15, 27, 28, 2, 4, 7, 13, 16, 26, 29, 42, 3, 8, 12, 17, 25, 30, 41, 43, 9, 11,
+    18, 24, 31, 40, 44, 53, 10, 19, 23, 32, 39, 45, 52, 54, 20, 22, 33, 38, 46, 51, 55, 60, 21, 34,
+    37, 47, 50, 56, 59, 61, 35, 36, 48, 49, 57, 58, 62, 63,
+];
+
+/// Per-category bit-offset for the standard JPEG DC Huffman
+/// table. Index = DC category (0-11); value = total Huffman code
+/// length in bits (length includes the variable-length suffix
+/// for category > 0).
+const DC_CAT_BIT_LEN: [u8; 12] = [2, 3, 3, 3, 3, 3, 4, 5, 6, 7, 8, 9];
+
+/// Standard JPEG AC Huffman table preamble + symbols. First 16
+/// bytes = "BITS" array (number of codes of each length 1..=16);
+/// remaining bytes = symbol table. Verbatim from JPEG spec /
+/// medet's `t_ac_0`.
+const T_AC_0: [u8; 16 + 162] = [
+    0, 2, 1, 3, 3, 2, 4, 3, 5, 5, 4, 4, 0, 0, 1, 125, 1, 2, 3, 0, 4, 17, 5, 18, 33, 49, 65, 6, 19,
+    81, 97, 7, 34, 113, 20, 50, 129, 145, 161, 8, 35, 66, 177, 193, 21, 82, 209, 240, 36, 51, 98,
+    114, 130, 9, 10, 22, 23, 24, 25, 26, 37, 38, 39, 40, 41, 42, 52, 53, 54, 55, 56, 57, 58, 67,
+    68, 69, 70, 71, 72, 73, 74, 83, 84, 85, 86, 87, 88, 89, 90, 99, 100, 101, 102, 103, 104, 105,
+    106, 115, 116, 117, 118, 119, 120, 121, 122, 131, 132, 133, 134, 135, 136, 137, 138, 146, 147,
+    148, 149, 150, 151, 152, 153, 154, 162, 163, 164, 165, 166, 167, 168, 169, 170, 178, 179, 180,
+    181, 182, 183, 184, 185, 186, 194, 195, 196, 197, 198, 199, 200, 201, 202, 210, 211, 212, 213,
+    214, 215, 216, 217, 218, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 241, 242, 243, 244,
+    245, 246, 247, 248, 249, 250,
+];
+
+/// Decoded AC table entry (post-table-build).
+#[derive(Debug, Clone, Copy, Default)]
+struct AcEntry {
+    /// Run length of zero coefficients before this AC value.
+    run: u8,
+    /// Bit-size of the AC value's variable-length suffix.
+    size: u8,
+    /// Total Huffman-code length for this entry (bits).
+    len: u8,
+    /// Huffman code value, right-aligned.
+    code: u16,
+}
+
+/// Decode error.
+#[derive(Debug, thiserror::Error)]
+pub enum JpegError {
+    #[error("invalid DC Huffman code")]
+    BadDcCode,
+    #[error("invalid AC Huffman code")]
+    BadAcCode,
+    #[error("ran out of bits mid-MCU")]
+    EndOfStream,
+}
+
+/// Streaming Meteor JPEG decoder. Holds the precomputed AC / DC
+/// lookup tables (built once at construction); per-MCU state is
+/// the running DC predictor.
+pub struct JpegDecoder {
+    /// 16-bit-window → AC table index. -1 = no match.
+    ac_lookup: Box<[i16; 65536]>,
+    /// 16-bit-window → DC category. -1 = no match.
+    dc_lookup: Box<[i16; 65536]>,
+    ac_table: Vec<AcEntry>,
+    /// Running DC predictor (across MCUs in the same packet).
+    last_dc: f32,
+}
+
+impl Default for JpegDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JpegDecoder {
+    #[must_use]
+    #[allow(
+        clippy::large_stack_arrays,
+        reason = "two 65536-entry i16 LUTs are heap-allocated via Box::new — the stack pressure is the boxed initializer, not the final storage; smaller LUTs would defeat the O(1) Huffman lookup"
+    )]
+    pub fn new() -> Self {
+        let ac_table = build_ac_table();
+        let mut ac_lookup = Box::new([-1_i16; 65536]);
+        let mut dc_lookup = Box::new([-1_i16; 65536]);
+        for w in 0_u32..65536 {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "loop bound 0..65536 fits in u16"
+            )]
+            let w16 = w as u16;
+            ac_lookup[w as usize] = lookup_ac(w16, &ac_table);
+            dc_lookup[w as usize] = lookup_dc(w16);
+        }
+        Self {
+            ac_lookup,
+            dc_lookup,
+            ac_table,
+            last_dc: 0.0,
+        }
+    }
+
+    /// Reset the DC predictor (call at the start of a new
+    /// per-channel packet group).
+    pub fn reset_dc(&mut self) {
+        self.last_dc = 0.0;
+    }
+
+    /// Decode one 8×8 MCU from the bit stream `bytes`. `quality`
+    /// is the per-packet quantization-table scaling byte (Meteor
+    /// transmits this in the image-packet payload header).
+    /// Returns the decoded pixel block on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JpegError::BadDcCode`] / [`BadAcCode`] when the
+    /// Huffman lookup misses, or [`EndOfStream`] when the bit
+    /// stream runs out mid-decode.
+    pub fn decode_mcu(
+        &mut self,
+        bytes: &[u8],
+        bit_offset: &mut usize,
+        quality: u8,
+    ) -> Result<Block8x8, JpegError> {
+        let dqt = fill_dqt(quality);
+        let mut zdct = [0_f32; MCU_SAMPLES];
+
+        // Step 1: DC delta.
+        let dc_window = peek_n_bits(bytes, *bit_offset, 16)?;
+        let dc_cat_signed = self.dc_lookup[dc_window as usize];
+        if dc_cat_signed < 0 {
+            return Err(JpegError::BadDcCode);
+        }
+        #[allow(
+            clippy::cast_sign_loss,
+            clippy::cast_possible_truncation,
+            reason = "guarded by the dc_cat_signed < 0 branch above; DC category ∈ [0, 11] always fits in u8"
+        )]
+        let dc_cat = dc_cat_signed as u8;
+        *bit_offset += DC_CAT_BIT_LEN[dc_cat as usize] as usize;
+        let dc_value_bits = if dc_cat > 0 {
+            fetch_n_bits(bytes, bit_offset, dc_cat as usize)?
+        } else {
+            0
+        };
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "DC delta is bounded by ±2^11 (category ≤ 11), well within f32 mantissa"
+        )]
+        let dc_delta = map_range(dc_cat, dc_value_bits) as f32;
+        zdct[0] = dc_delta + self.last_dc;
+        self.last_dc = zdct[0];
+
+        // Step 2: AC run-length pairs until end-of-block.
+        let mut k: usize = 1;
+        while k < 64 {
+            let ac_window = peek_n_bits(bytes, *bit_offset, 16)?;
+            let ac_idx_signed = self.ac_lookup[ac_window as usize];
+            if ac_idx_signed < 0 {
+                return Err(JpegError::BadAcCode);
+            }
+            #[allow(
+                clippy::cast_sign_loss,
+                reason = "guarded by the ac_idx_signed < 0 branch above"
+            )]
+            let ac = self.ac_table[ac_idx_signed as usize];
+            *bit_offset += ac.len as usize;
+            // EOB marker: run=0 size=0.
+            if ac.run == 0 && ac.size == 0 {
+                for slot in zdct.iter_mut().take(64).skip(k) {
+                    *slot = 0.0;
+                }
+                break;
+            }
+            // Skip `run` zeros then place the next coefficient.
+            for _ in 0..ac.run {
+                if k >= 64 {
+                    break;
+                }
+                zdct[k] = 0.0;
+                k += 1;
+            }
+            if k >= 64 {
+                break;
+            }
+            if ac.size > 0 {
+                let n = fetch_n_bits(bytes, bit_offset, ac.size as usize)?;
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "AC coefficient is bounded by ±2^10 (size ≤ 10 in practice), within f32 mantissa"
+                )]
+                let coeff = map_range(ac.size, n) as f32;
+                zdct[k] = coeff;
+                k += 1;
+            } else if ac.run == 15 {
+                // ZRL: 16 zeros + no value (run=15 case writes
+                // one extra zero on top of the run we already
+                // wrote above).
+                zdct[k] = 0.0;
+                k += 1;
+            }
+        }
+
+        // Step 3: zigzag-unscramble + dequantize (single pass).
+        let mut dct = [0_f32; MCU_SAMPLES];
+        for i in 0..MCU_SAMPLES {
+            dct[i] = zdct[ZIGZAG[i] as usize] * f32::from(dqt[i]);
+        }
+
+        // Step 4: inverse DCT.
+        let mut img = [0_f32; MCU_SAMPLES];
+        idct_8x8(&dct, &mut img);
+
+        // Step 5: level-shift + clamp + pack into 8×8 block.
+        let mut block: Block8x8 = [[0_u8; MCU_SIDE]; MCU_SIDE];
+        for y in 0..MCU_SIDE {
+            for x in 0..MCU_SIDE {
+                let v = img[y * MCU_SIDE + x] + 128.0;
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_sign_loss,
+                    reason = "clamp to [0, 255] before cast keeps the conversion lossless"
+                )]
+                let clamped = v.clamp(0.0, 255.0) as u8;
+                block[y][x] = clamped;
+            }
+        }
+        Ok(block)
+    }
+}
+
+/// Per-packet quantization table — derived from the standard
+/// template scaled by the packet's quality byte.
+fn fill_dqt(q: u8) -> [u16; 64] {
+    let qf = f32::from(q);
+    let f = if qf > 20.0 && qf < 50.0 {
+        5000.0 / qf
+    } else {
+        200.0 - 2.0 * qf
+    };
+    let mut dqt = [0_u16; 64];
+    for (i, slot) in dqt.iter_mut().enumerate() {
+        let scaled = (f * f32::from(QUANT_TEMPLATE[i]) / 100.0).round();
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "max value is QUANT_TEMPLATE max (121) × max f (≈10) = 1210, fits in u16"
+        )]
+        let raw = scaled.max(1.0) as u16;
+        *slot = raw;
+    }
+    dqt
+}
+
+/// JPEG `EXTEND` operation — convert variable-length bit pattern
+/// to signed integer (Annex F.1.2.1.1).
+fn map_range(cat: u8, value: u16) -> i32 {
+    if cat == 0 {
+        return 0;
+    }
+    let max_val = (1_u32 << cat) - 1;
+    let sign_bit = 1_u32 << (cat - 1);
+    if (u32::from(value) & sign_bit) != 0 {
+        i32::from(value)
+    } else {
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "max_val = 2^cat - 1 with cat ≤ 11, well within i32 range"
+        )]
+        let signed = max_val as i32;
+        i32::from(value) - signed
+    }
+}
+
+/// Peek the next `n` bits from `bytes` starting at `bit_offset`,
+/// MSB-first. Returns the bits right-aligned in a u16.
+fn peek_n_bits(bytes: &[u8], bit_offset: usize, n: usize) -> Result<u16, JpegError> {
+    debug_assert!(n <= 16);
+    let mut result: u32 = 0;
+    for i in 0..n {
+        let bit_pos = bit_offset + i;
+        let byte_idx = bit_pos / 8;
+        if byte_idx >= bytes.len() {
+            return Err(JpegError::EndOfStream);
+        }
+        let bit_in_byte = 7 - (bit_pos % 8);
+        let bit = (bytes[byte_idx] >> bit_in_byte) & 1;
+        result = (result << 1) | u32::from(bit);
+    }
+    // Left-pad to 16 bits so callers can index a 65k LUT
+    // directly off the value (matches medet's bio_peek_n_bits
+    // convention).
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "result < 2^n ≤ 2^16, fits in u16 after the shift below"
+    )]
+    let padded = (result << (16 - n)) as u16;
+    Ok(padded)
+}
+
+/// Fetch the next `n` bits from `bytes`, advancing `bit_offset`.
+fn fetch_n_bits(bytes: &[u8], bit_offset: &mut usize, n: usize) -> Result<u16, JpegError> {
+    debug_assert!(n <= 16);
+    let mut result: u16 = 0;
+    for _ in 0..n {
+        let byte_idx = *bit_offset / 8;
+        if byte_idx >= bytes.len() {
+            return Err(JpegError::EndOfStream);
+        }
+        let bit_in_byte = 7 - (*bit_offset % 8);
+        let bit = (bytes[byte_idx] >> bit_in_byte) & 1;
+        result = (result << 1) | u16::from(bit);
+        *bit_offset += 1;
+    }
+    Ok(result)
+}
+
+/// DC Huffman lookup (matches medet's `get_dc_real`).
+fn lookup_dc(w: u16) -> i16 {
+    // Decision tree over the high bits of `w`.
+    if w >> 14 == 0 {
+        return 0;
+    }
+    match w >> 13 {
+        2 => return 1,
+        3 => return 2,
+        4 => return 3,
+        5 => return 4,
+        6 => return 5,
+        _ => {}
+    }
+    if w >> 12 == 0x00E {
+        return 6;
+    }
+    if w >> 11 == 0x01E {
+        return 7;
+    }
+    if w >> 10 == 0x03E {
+        return 8;
+    }
+    if w >> 9 == 0x07E {
+        return 9;
+    }
+    if w >> 8 == 0x0FE {
+        return 10;
+    }
+    if w >> 7 == 0x1FE {
+        return 11;
+    }
+    -1
+}
+
+/// AC Huffman lookup — match `w` against the precomputed
+/// `ac_table` linearly (slow real lookup; cached into a 65k LUT
+/// at construction time).
+fn lookup_ac(w: u16, table: &[AcEntry]) -> i16 {
+    for (i, e) in table.iter().enumerate() {
+        // Right-shift to align `w` with the entry's code length,
+        // then mask to the entry's bit width. Mask uses u32
+        // so e.len = 16 doesn't overflow `1_u16 << 16`.
+        let shifted = u32::from(w) >> (16 - e.len);
+        let mask = (1_u32 << e.len) - 1;
+        if (shifted & mask) == u32::from(e.code) {
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_possible_wrap,
+                reason = "ac table size ≤ 256 fits in i16"
+            )]
+            let idx = i as i16;
+            return idx;
+        }
+    }
+    -1
+}
+
+/// Build the AC Huffman table from the canonical JPEG bits +
+/// values arrays. Direct port of medet's `default_huffman_table`.
+#[allow(
+    clippy::large_stack_arrays,
+    reason = "the 65536-entry slot table is the canonical (length, position) addressing space matching medet's port; called once per JpegDecoder construction"
+)]
+fn build_ac_table() -> Vec<AcEntry> {
+    let bits = &T_AC_0[0..16];
+    let values = &T_AC_0[16..];
+    // Distribute symbols into per-length slots.
+    let mut v = vec![0_u8; 65536];
+    let mut p = 0_usize;
+    for k in 1..=16 {
+        for i in 0..bits[k - 1] as usize {
+            v[(k << 8) + i] = values[p];
+            p += 1;
+        }
+    }
+    // Compute min/max code per length.
+    let mut min_code = [0_u16; 17];
+    let mut maj_code = [0_u16; 17];
+    let mut code = 0_u16;
+    for k in 1..=16 {
+        min_code[k] = code;
+        for _ in 1..=bits[k - 1] {
+            code = code.wrapping_add(1);
+        }
+        maj_code[k] = code.saturating_sub(u16::from(code != 0));
+        code = code.wrapping_mul(2);
+        if bits[k - 1] == 0 {
+            min_code[k] = 0xFFFF;
+            maj_code[k] = 0;
+        }
+    }
+    // Walk the (length, code) space and emit one AcEntry per
+    // valid Huffman code. Iteration counter is u32 because
+    // (1 << 16) doesn't fit in u16; AcEntry.code stays u16.
+    let mut table = Vec::with_capacity(256);
+    for k in 1..=16 {
+        let min_val = u32::from(min_code[k]);
+        let max_val = u32::from(maj_code[k]);
+        for i in 0_u32..(1_u32 << k) {
+            if i <= max_val && i >= min_val {
+                let size_val = v[(k << 8) + (i - min_val) as usize];
+                let run = size_val >> 4;
+                let size = size_val & 0xF;
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "k ∈ [1, 16] fits in u8; i < 1<<16 fits in u16"
+                )]
+                let len = k as u8;
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "i < 2^16 = 65536, fits in u16"
+                )]
+                let code = i as u16;
+                table.push(AcEntry {
+                    run,
+                    size,
+                    len,
+                    code,
+                });
+            }
+        }
+    }
+    table
+}
+
+// ─── DCT ────────────────────────────────────────────────────────
+
+/// Inverse 8×8 DCT (naive O(N⁴) — adequate at Meteor's
+/// ~400 IDCTs/second budget). Direct port of medet's
+/// `flt_idct_8x8`.
+fn idct_8x8(input: &[f32; MCU_SAMPLES], output: &mut [f32; MCU_SAMPLES]) {
+    let cosine = cosine_table();
+    let alpha = alpha_table();
+    for y in 0..MCU_SIDE {
+        for x in 0..MCU_SIDE {
+            let mut s = 0_f32;
+            for u in 0..MCU_SIDE {
+                let cxu = alpha[u] * cosine[x][u];
+                // Inner sum unrolled per medet's optimization.
+                let mut inner = 0_f32;
+                for v in 0..MCU_SIDE {
+                    inner += input[v * MCU_SIDE + u] * alpha[v] * cosine[y][v];
+                }
+                s += cxu * inner;
+            }
+            output[y * MCU_SIDE + x] = s / 4.0;
+        }
+    }
+}
+
+/// Precomputed 8×8 cosine table.
+fn cosine_table() -> [[f32; 8]; 8] {
+    // Computed once and stuffed inline; runtime cost is the
+    // first `cosine_table()` call (which initializes the static
+    // via std::sync::OnceLock under the hood).
+    static TABLE: std::sync::OnceLock<[[f32; 8]; 8]> = std::sync::OnceLock::new();
+    *TABLE.get_or_init(|| {
+        let mut t = [[0.0_f32; 8]; 8];
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "loop indices 0..8 fit exactly in f32"
+        )]
+        for (y, row) in t.iter_mut().enumerate() {
+            for (x, slot) in row.iter_mut().enumerate() {
+                *slot = (PI / 16.0 * (2.0 * y as f32 + 1.0) * x as f32).cos();
+            }
+        }
+        t
+    })
+}
+
+/// Precomputed alpha vector — `alpha[0] = 1/√2`, rest = 1.
+fn alpha_table() -> [f32; 8] {
+    [FRAC_1_SQRT_2, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::float_cmp,
+    clippy::unwrap_used
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quant_template_starts_with_documented_value() {
+        assert_eq!(QUANT_TEMPLATE[0], 16);
+        assert_eq!(QUANT_TEMPLATE[63], 99);
+    }
+
+    #[test]
+    fn zigzag_is_a_permutation_of_0_to_63() {
+        let mut seen = [false; 64];
+        for &v in &ZIGZAG {
+            assert!(!seen[v as usize], "duplicate ZIGZAG entry {v}");
+            seen[v as usize] = true;
+        }
+        assert!(seen.iter().all(|&s| s));
+    }
+
+    #[test]
+    fn fill_dqt_clamps_to_minimum_one() {
+        // Quality value that produces tiny coefficients. The
+        // minimum of 1 prevents divide-by-zero downstream.
+        let dqt = fill_dqt(100);
+        for &v in &dqt {
+            assert!(v >= 1, "dqt entry {v} below minimum");
+        }
+    }
+
+    #[test]
+    fn map_range_decodes_jpeg_extend() {
+        // JPEG Annex F.1.2.1.1 Table F.1: cat=0 → 0; cat=N
+        // values in [0, 2^(N-1)-1] are negative.
+        assert_eq!(map_range(0, 0), 0);
+        // cat=1: 0 → -1, 1 → 1
+        assert_eq!(map_range(1, 0), -1);
+        assert_eq!(map_range(1, 1), 1);
+        // cat=3: max_val=7. Values 0-3 negative, 4-7 positive.
+        assert_eq!(map_range(3, 0), -7);
+        assert_eq!(map_range(3, 4), 4);
+        assert_eq!(map_range(3, 7), 7);
+    }
+
+    #[test]
+    fn peek_and_fetch_round_trip() {
+        // Bit stream: [0b1010_1010, 0b1100_0011]
+        let bytes = [0xAA, 0xC3];
+        let mut ofs = 0_usize;
+        // peek then fetch for 4 bits — should match high nibble.
+        let peeked = peek_n_bits(&bytes, ofs, 4).unwrap();
+        // peek returns value left-aligned in u16, so 0b1010 << 12.
+        assert_eq!(peeked, 0b1010 << 12);
+        let fetched = fetch_n_bits(&bytes, &mut ofs, 4).unwrap();
+        assert_eq!(fetched, 0b1010);
+        assert_eq!(ofs, 4);
+    }
+
+    #[test]
+    fn idct_zero_block_returns_zero() {
+        let zeros = [0_f32; MCU_SAMPLES];
+        let mut out = [0_f32; MCU_SAMPLES];
+        idct_8x8(&zeros, &mut out);
+        for &v in &out {
+            assert!(v.abs() < 1e-5, "IDCT of zeros should be zero, got {v}");
+        }
+    }
+
+    #[test]
+    fn idct_dc_only_block_is_uniform() {
+        // A pure DC coefficient (cat=0 position) should produce a
+        // uniform 8×8 block with value DC × alpha_0² / 4 = DC / 8
+        // (since alpha_0 = 1/√2, alpha_0² = 1/2, then /4).
+        let mut input = [0_f32; MCU_SAMPLES];
+        input[0] = 800.0;
+        let mut out = [0_f32; MCU_SAMPLES];
+        idct_8x8(&input, &mut out);
+        let expected = 800.0 / 8.0;
+        for &v in &out {
+            assert!(
+                (v - expected).abs() < 1e-3,
+                "DC-only IDCT not uniform: got {v}, expected {expected}",
+            );
+        }
+    }
+
+    #[test]
+    fn ac_table_has_expected_canonical_jpeg_entries() {
+        // The table is built by walking (length, code) in
+        // increasing order. JPEG Annex K Table K.5 ordering:
+        //   - length 2: 2 codes (symbols 1, 2 → run/size pairs
+        //     (0,1) and (0,2))
+        //   - length 3: 1 code (symbol 3 → (0,3))
+        //   - length 4: 3 codes (symbols 0, 4, 17 → EOB (0,0),
+        //     (0,4), (1,1))
+        // We pin the first entry + the EOB position so a future
+        // table-build refactor can't silently scramble the order.
+        let table = build_ac_table();
+        assert!(!table.is_empty(), "ac_table must be non-empty");
+        let first = &table[0];
+        assert_eq!((first.run, first.size, first.len), (0, 1, 2));
+        // EOB lives at index 3 (after 2 length-2 + 1 length-3
+        // entries). Symbol value 0 → (run=0, size=0).
+        let eob = &table[3];
+        assert_eq!((eob.run, eob.size, eob.len), (0, 0, 4));
+    }
+
+    #[test]
+    fn decoder_constructible() {
+        let dec = JpegDecoder::new();
+        // Pin that tables are populated.
+        assert!(!dec.ac_table.is_empty());
+        assert_eq!(dec.last_dc, 0.0);
+    }
+
+    #[test]
+    fn decoder_resets_dc() {
+        let mut dec = JpegDecoder::new();
+        dec.last_dc = 42.0;
+        dec.reset_dc();
+        assert_eq!(dec.last_dc, 0.0);
+    }
+}

--- a/crates/sdr-lrpt/src/image/mod.rs
+++ b/crates/sdr-lrpt/src/image/mod.rs
@@ -12,4 +12,4 @@ pub mod png_export;
 
 pub use composite::{ChannelBuffer, IMAGE_WIDTH, ImageAssembler, MCUS_PER_LINE};
 pub use jpeg::{Block8x8, JpegDecoder, JpegError, MCU_SAMPLES, MCU_SIDE};
-pub use png_export::{save_channel, save_composite};
+pub use png_export::{PngExportError, save_channel, save_composite};

--- a/crates/sdr-lrpt/src/image/mod.rs
+++ b/crates/sdr-lrpt/src/image/mod.rs
@@ -1,0 +1,15 @@
+//! Image-assembly + PNG export for Meteor LRPT.
+//!
+//! Stage 4 of the receive pipeline. Consumes [`super::ccsds::ImagePacket`]s
+//! from the framing layer, decodes them as Meteor reduced-JPEG
+//! ([`jpeg::JpegDecoder`]), accumulates per-channel scan-line
+//! buffers ([`composite::ImageAssembler`]), and exposes PNG export
+//! ([`png_export::save_channel`] / [`png_export::save_composite`]).
+
+pub mod composite;
+pub mod jpeg;
+pub mod png_export;
+
+pub use composite::{ChannelBuffer, IMAGE_WIDTH, ImageAssembler, MCUS_PER_LINE};
+pub use jpeg::{Block8x8, JpegDecoder, JpegError, MCU_SAMPLES, MCU_SIDE};
+pub use png_export::{save_channel, save_composite};

--- a/crates/sdr-lrpt/src/image/mod.rs
+++ b/crates/sdr-lrpt/src/image/mod.rs
@@ -11,5 +11,5 @@ pub mod jpeg;
 pub mod png_export;
 
 pub use composite::{ChannelBuffer, IMAGE_WIDTH, ImageAssembler, MCUS_PER_LINE};
-pub use jpeg::{Block8x8, JpegDecoder, JpegError, MCU_SAMPLES, MCU_SIDE};
+pub use jpeg::{Block8x8, Dqt, JpegDecoder, JpegError, MCU_SAMPLES, MCU_SIDE, fill_dqt};
 pub use png_export::{PngExportError, save_channel, save_composite};

--- a/crates/sdr-lrpt/src/image/png_export.rs
+++ b/crates/sdr-lrpt/src/image/png_export.rs
@@ -1,0 +1,103 @@
+//! PNG export for assembled LRPT imagery.
+//!
+//! Thin layer over the [`image`] crate. Two entry points:
+//! per-channel grayscale PNG via [`save_channel`], and
+//! multi-channel false-color RGB composite via [`save_composite`].
+
+use std::path::Path;
+
+use super::composite::{ChannelBuffer, IMAGE_WIDTH, ImageAssembler};
+
+/// Save one channel's accumulated image to a grayscale PNG.
+///
+/// # Errors
+///
+/// Returns an error string if the channel is empty, the buffer
+/// dimensions don't match the expected `lines × IMAGE_WIDTH`
+/// shape, or the PNG write itself fails.
+pub fn save_channel(path: &Path, channel: &ChannelBuffer) -> Result<(), String> {
+    if channel.lines == 0 {
+        return Err("channel has no scan lines".into());
+    }
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "image dimensions are bounded by Meteor's 1568 px width and pass-length lines"
+    )]
+    let width_u32 = IMAGE_WIDTH as u32;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "ditto — pass-length lines fit in u32"
+    )]
+    let height_u32 = channel.lines as u32;
+    let img = image::GrayImage::from_raw(width_u32, height_u32, channel.pixels.clone())
+        .ok_or_else(|| "buffer size mismatch".to_string())?;
+    img.save(path).map_err(|e| format!("png save: {e}"))
+}
+
+/// Save the RGB composite to a PNG.
+///
+/// # Errors
+///
+/// Returns an error string if any of the three channels are
+/// missing or empty, the buffer dimensions don't match, or the
+/// PNG write fails.
+pub fn save_composite(
+    path: &Path,
+    assembler: &ImageAssembler,
+    r_apid: u16,
+    g_apid: u16,
+    b_apid: u16,
+) -> Result<(), String> {
+    let (w, h, rgb) = assembler
+        .composite_rgb(r_apid, g_apid, b_apid)
+        .ok_or_else(|| "composite unavailable: missing or empty channels".to_string())?;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "image dimensions are bounded by Meteor's 1568 px width and pass-length lines"
+    )]
+    let img = image::RgbImage::from_raw(w as u32, h as u32, rgb)
+        .ok_or_else(|| "composite buffer size mismatch".to_string())?;
+    img.save(path).map_err(|e| format!("png save: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_channel_writes_png_signature() {
+        let mut cb = ChannelBuffer::new();
+        for _ in 0..10 {
+            cb.push_line(&vec![128_u8; IMAGE_WIDTH]);
+        }
+        let tmp = std::env::temp_dir().join("test_lrpt_save_channel.png");
+        save_channel(&tmp, &cb).expect("save");
+        let bytes = std::fs::read(&tmp).expect("read back");
+        // PNG file signature: 89 50 4E 47 ('\x89PNG').
+        assert_eq!(&bytes[..4], &[0x89, b'P', b'N', b'G']);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn save_channel_rejects_empty_buffer() {
+        let cb = ChannelBuffer::new();
+        let tmp = std::env::temp_dir().join("test_lrpt_empty.png");
+        let result = save_channel(&tmp, &cb);
+        assert!(result.is_err(), "empty buffer must fail to save");
+    }
+
+    #[test]
+    fn save_composite_writes_png_signature() {
+        let mut a = ImageAssembler::new();
+        for _ in 0..5 {
+            a.push_line(64, &vec![100; IMAGE_WIDTH]);
+            a.push_line(65, &vec![150; IMAGE_WIDTH]);
+            a.push_line(66, &vec![200; IMAGE_WIDTH]);
+        }
+        let tmp = std::env::temp_dir().join("test_lrpt_save_composite.png");
+        save_composite(&tmp, &a, 64, 65, 66).expect("save");
+        let bytes = std::fs::read(&tmp).expect("read back");
+        assert_eq!(&bytes[..4], &[0x89, b'P', b'N', b'G']);
+        let _ = std::fs::remove_file(&tmp);
+    }
+}

--- a/crates/sdr-lrpt/src/image/png_export.rs
+++ b/crates/sdr-lrpt/src/image/png_export.rs
@@ -8,16 +8,50 @@ use std::path::Path;
 
 use super::composite::{ChannelBuffer, IMAGE_WIDTH, ImageAssembler};
 
+/// Errors from PNG export. Typed (not `String`) so callers can
+/// pattern-match each kind — useful for the live-viewer UI to
+/// surface "no signal yet" (`EmptyChannel`) differently from
+/// "disk write failed" (`Save`).
+#[derive(Debug, thiserror::Error)]
+pub enum PngExportError {
+    /// The requested channel buffer is empty (no scan lines).
+    /// Common during the first second of a new pass before any
+    /// VCDU has been decoded.
+    #[error("channel has no scan lines")]
+    EmptyChannel,
+    /// One or more of the requested composite channels is missing
+    /// from the assembler or has zero scan lines. Surfaced when
+    /// the user picks an RGB triple before all three channels
+    /// have any data.
+    #[error("composite unavailable: missing or empty channels")]
+    CompositeUnavailable,
+    /// The pixel buffer's length doesn't match the requested
+    /// `width × height` (or `width × height × 3` for RGB).
+    /// Indicates an internal bug — should never surface to a
+    /// user.
+    #[error("buffer size mismatch")]
+    BufferSizeMismatch,
+    /// The underlying [`image::ImageError`] from the encoder /
+    /// filesystem write. Source preserved so callers can dig
+    /// into the wrapped I/O or format error.
+    #[error("png save: {0}")]
+    Save(#[from] image::ImageError),
+}
+
 /// Save one channel's accumulated image to a grayscale PNG.
 ///
 /// # Errors
 ///
-/// Returns an error string if the channel is empty, the buffer
-/// dimensions don't match the expected `lines × IMAGE_WIDTH`
-/// shape, or the PNG write itself fails.
-pub fn save_channel(path: &Path, channel: &ChannelBuffer) -> Result<(), String> {
+/// - [`PngExportError::EmptyChannel`] if the channel has no
+///   scan lines yet.
+/// - [`PngExportError::BufferSizeMismatch`] if the channel's
+///   internal pixel buffer length doesn't match
+///   `lines × IMAGE_WIDTH` (internal bug).
+/// - [`PngExportError::Save`] wrapping the underlying
+///   [`image::ImageError`] from the PNG encoder or filesystem.
+pub fn save_channel(path: &Path, channel: &ChannelBuffer) -> Result<(), PngExportError> {
     if channel.lines == 0 {
-        return Err("channel has no scan lines".into());
+        return Err(PngExportError::EmptyChannel);
     }
     #[allow(
         clippy::cast_possible_truncation,
@@ -30,44 +64,70 @@ pub fn save_channel(path: &Path, channel: &ChannelBuffer) -> Result<(), String> 
     )]
     let height_u32 = channel.lines as u32;
     let img = image::GrayImage::from_raw(width_u32, height_u32, channel.pixels.clone())
-        .ok_or_else(|| "buffer size mismatch".to_string())?;
-    img.save(path).map_err(|e| format!("png save: {e}"))
+        .ok_or(PngExportError::BufferSizeMismatch)?;
+    img.save(path)?;
+    Ok(())
 }
 
 /// Save the RGB composite to a PNG.
 ///
 /// # Errors
 ///
-/// Returns an error string if any of the three channels are
-/// missing or empty, the buffer dimensions don't match, or the
-/// PNG write fails.
+/// - [`PngExportError::CompositeUnavailable`] if any of the
+///   three requested channels is missing from the assembler or
+///   has zero scan lines.
+/// - [`PngExportError::BufferSizeMismatch`] if the composite
+///   buffer length doesn't match the expected
+///   `width × height × 3` (internal bug).
+/// - [`PngExportError::Save`] wrapping the underlying
+///   [`image::ImageError`] from the PNG encoder or filesystem.
 pub fn save_composite(
     path: &Path,
     assembler: &ImageAssembler,
     r_apid: u16,
     g_apid: u16,
     b_apid: u16,
-) -> Result<(), String> {
+) -> Result<(), PngExportError> {
     let (w, h, rgb) = assembler
         .composite_rgb(r_apid, g_apid, b_apid)
-        .ok_or_else(|| "composite unavailable: missing or empty channels".to_string())?;
+        .ok_or(PngExportError::CompositeUnavailable)?;
     #[allow(
         clippy::cast_possible_truncation,
         reason = "image dimensions are bounded by Meteor's 1568 px width and pass-length lines"
     )]
     let img = image::RgbImage::from_raw(w as u32, h as u32, rgb)
-        .ok_or_else(|| "composite buffer size mismatch".to_string())?;
-    img.save(path).map_err(|e| format!("png save: {e}"))
+        .ok_or(PngExportError::BufferSizeMismatch)?;
+    img.save(path)?;
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// APID used in the round-trip save tests. Matches the
+    /// AVHRR convention (64 = first channel) used elsewhere in
+    /// the test suite.
+    const APID_R: u16 = 64;
+    const APID_G: u16 = 65;
+    const APID_B: u16 = 66;
+
+    /// Number of scan lines pushed in the round-trip tests.
+    /// Small enough to keep the test fast; large enough that the
+    /// PNG actually has multi-row content to verify against.
+    const TEST_N_LINES: usize = 5;
+
+    /// Per-channel grayscale fill values for the composite test.
+    /// Distinct values so a regression that mismatched channel
+    /// ordering would fail the byte-equality check.
+    const FILL_R: u8 = 100;
+    const FILL_G: u8 = 150;
+    const FILL_B: u8 = 200;
+
     #[test]
     fn save_channel_writes_png_signature() {
         let mut cb = ChannelBuffer::new();
-        for _ in 0..10 {
+        for _ in 0..TEST_N_LINES {
             cb.push_line(&vec![128_u8; IMAGE_WIDTH]);
         }
         let tmp = std::env::temp_dir().join("test_lrpt_save_channel.png");
@@ -83,21 +143,81 @@ mod tests {
         let cb = ChannelBuffer::new();
         let tmp = std::env::temp_dir().join("test_lrpt_empty.png");
         let result = save_channel(&tmp, &cb);
-        assert!(result.is_err(), "empty buffer must fail to save");
+        assert!(
+            matches!(result, Err(PngExportError::EmptyChannel)),
+            "empty buffer must return EmptyChannel, got {result:?}"
+        );
     }
 
     #[test]
     fn save_composite_writes_png_signature() {
         let mut a = ImageAssembler::new();
-        for _ in 0..5 {
-            a.push_line(64, &vec![100; IMAGE_WIDTH]);
-            a.push_line(65, &vec![150; IMAGE_WIDTH]);
-            a.push_line(66, &vec![200; IMAGE_WIDTH]);
+        for _ in 0..TEST_N_LINES {
+            a.push_line(APID_R, &vec![FILL_R; IMAGE_WIDTH]);
+            a.push_line(APID_G, &vec![FILL_G; IMAGE_WIDTH]);
+            a.push_line(APID_B, &vec![FILL_B; IMAGE_WIDTH]);
         }
         let tmp = std::env::temp_dir().join("test_lrpt_save_composite.png");
-        save_composite(&tmp, &a, 64, 65, 66).expect("save");
+        save_composite(&tmp, &a, APID_R, APID_G, APID_B).expect("save");
         let bytes = std::fs::read(&tmp).expect("read back");
         assert_eq!(&bytes[..4], &[0x89, b'P', b'N', b'G']);
         let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn save_composite_rejects_missing_channel() {
+        // Only push two of the three requested channels — the
+        // composite call should surface CompositeUnavailable
+        // (not a panic, not a generic IO error). This is the UI
+        // path's "user picked RGB before all three channels had
+        // data" case.
+        let mut a = ImageAssembler::new();
+        a.push_line(APID_R, &vec![FILL_R; IMAGE_WIDTH]);
+        a.push_line(APID_G, &vec![FILL_G; IMAGE_WIDTH]);
+        let tmp = std::env::temp_dir().join("test_lrpt_missing_channel.png");
+        let result = save_composite(&tmp, &a, APID_R, APID_G, APID_B);
+        assert!(
+            matches!(result, Err(PngExportError::CompositeUnavailable)),
+            "missing channel must return CompositeUnavailable, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn save_channel_propagates_io_failure_as_save_variant() {
+        // Path inside a non-existent directory tree without
+        // create_dir_all — the underlying image crate surfaces
+        // an io error. We just want to confirm it lands in the
+        // Save variant (preserving the source) and not in any
+        // other branch.
+        let mut cb = ChannelBuffer::new();
+        cb.push_line(&vec![1_u8; IMAGE_WIDTH]);
+        let bad_path = std::path::PathBuf::from(
+            "/nonexistent-directory-for-lrpt-png-save-test/should-fail.png",
+        );
+        let result = save_channel(&bad_path, &cb);
+        assert!(
+            matches!(result, Err(PngExportError::Save(_))),
+            "io failure must land in Save variant, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn error_display_strings_are_human_readable() {
+        // CR pattern: error variants have stable, descriptive
+        // messages. Pin the strings so a future refactor that
+        // accidentally swaps them in the `#[error(...)]` attrs
+        // fails a test rather than silently rewording the UI.
+        assert_eq!(
+            format!("{}", PngExportError::EmptyChannel),
+            "channel has no scan lines"
+        );
+        assert_eq!(
+            format!("{}", PngExportError::CompositeUnavailable),
+            "composite unavailable: missing or empty channels"
+        );
+        assert_eq!(
+            format!("{}", PngExportError::BufferSizeMismatch),
+            "buffer size mismatch"
+        );
     }
 }

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -195,11 +195,19 @@ impl LrptPipeline {
             let mcu_col = (mcu_id + m) as usize;
             // mcu_id is a single payload byte (0-255) and m is
             // 0..14, so mcu_col can reach 268 — past the 196
-            // MCUS_PER_LINE bound. ImageAssembler::place_mcu
-            // silently drops out-of-bounds columns, but it's
-            // worth a trace because it indicates a corrupt
-            // packet header (post-RS miscorrection or upstream
-            // demux desync).
+            // MCUS_PER_LINE bound. Skip the place_mcu call
+            // entirely on out-of-range columns: place_mcu's
+            // internal guard would drop the block, but only
+            // AFTER growing the channel buffer's row count
+            // (composite.rs: needed_lines extension runs before
+            // the column check), so a corrupt mcu_id would
+            // permanently inflate channel height with blank
+            // rows. Per CR round 3.
+            //
+            // Trace surfaces the corruption so it's visible in
+            // debug logs without breaking real-time flow.
+            // Causes upstream: post-RS miscorrection of the
+            // packet header byte, or demux desync.
             if mcu_col >= MCUS_PER_LINE {
                 tracing::trace!(
                     "out-of-range mcu_col {mcu_col} (max {max}) on APID {apid} packet {pkt}",
@@ -207,6 +215,7 @@ impl LrptPipeline {
                     apid = packet.apid,
                     pkt = packet.sequence_count,
                 );
+                continue;
             }
             self.assembler
                 .place_mcu(packet.apid, mcu_row, mcu_col, &block);
@@ -495,6 +504,34 @@ mod tests {
         assert!(
             p.decoders.is_empty(),
             "all-zero VCDU yields no image packets"
+        );
+    }
+
+    #[test]
+    fn consume_packet_skips_place_mcu_on_out_of_range_column() {
+        // CR round 3: when mcu_id pushes mcu_col past the
+        // MCUS_PER_LINE bound (e.g. corrupt packet header
+        // post-RS miscorrection), the place_mcu call must be
+        // skipped entirely — not just have its block silently
+        // dropped after the channel buffer's row count was
+        // already grown. Otherwise corrupt packets would
+        // permanently inflate channel height with blank rows.
+        //
+        // mcu_id = 200 + the loop's m ∈ 0..14 → mcu_col ranges
+        // from 200 to 213, all past MCUS_PER_LINE = 196.
+        let mut p = LrptPipeline::new();
+        let mut pkt = synthetic_image_packet(64, 100);
+        pkt.payload[0] = 200; // overwrite the mcu_id byte
+        p.consume_packet(&pkt);
+        // Channel state was created (we passed the early
+        // returns), and the JPEG decode loop ran successfully
+        // for all 14 MCUs — but every placement was skipped
+        // because the columns were out of range. The assembler
+        // must NOT have inflated the channel buffer.
+        assert!(p.decoders.contains_key(&64));
+        assert!(
+            p.assembler.channel(64).is_none(),
+            "out-of-range columns must skip place_mcu entirely",
         );
     }
 }

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -23,3 +23,218 @@
 
 pub mod ccsds;
 pub mod fec;
+pub mod image;
+
+use crate::ccsds::{Demux, ImagePacket};
+use crate::image::{ImageAssembler, JpegDecoder};
+
+/// MCUs encoded per Meteor LRPT image packet. Per medet's
+/// `mcu_per_packet`. Drives the per-packet decode loop and the
+/// row-group denominator below.
+const MCUS_PER_PACKET: u16 = 14;
+
+/// Packets per Meteor LRPT scan-line group (3 imaging channels ×
+/// 14 packets each + 1 onboard-time packet = 43). Used as the
+/// row-index denominator: `mcu_row = (pkt - first_pkt) / 43`.
+/// Per medet's `progress_image`.
+const PACKETS_PER_ROW_GROUP: i32 = 43;
+
+/// Modulus for the 14-bit CCSDS packet sequence counter.
+/// `2^14 = 16384` — the counter wraps back to 0 after this value,
+/// so anchor counts are walked back by this amount on detection
+/// of a non-monotonic step.
+const SEQUENCE_COUNT_MODULUS: i32 = 1 << 14;
+
+/// Image-packet payload header length in bytes: 1 byte MCU id +
+/// 2 bytes `scan_hdr` + 2 bytes `seg_hdr` + 1 byte quality.
+/// JPEG-coded MCU stream begins immediately after.
+const IMAGE_PACKET_HEADER_LEN: usize = 6;
+
+/// APID of the on-board-time / housekeeping packet. Carries no
+/// MCU stream; dropped on entry to `consume_packet`.
+const APID_ONBOARD_TIME: u16 = 70;
+
+/// Per-channel JPEG-decode + image-assembly state. The DC
+/// predictor is per-channel because CCSDS MCU streams are
+/// independent across APIDs.
+struct ChannelDecoder {
+    jpeg: JpegDecoder,
+    /// First packet count we saw on this channel — anchors the
+    /// per-MCU row index calculation. Per medet's `progress_image`.
+    first_pkt: Option<i32>,
+    last_pkt: Option<i32>,
+}
+
+impl ChannelDecoder {
+    fn new() -> Self {
+        Self {
+            jpeg: JpegDecoder::new(),
+            first_pkt: None,
+            last_pkt: None,
+        }
+    }
+}
+
+/// Top-level LRPT decoder pipeline. Consumes whole VCDUs (post-RS
+/// 892-byte buffers from the FEC stage) and accumulates imagery
+/// into the per-channel image assembler.
+///
+/// Caller pulls images out via [`Self::assembler`] (live snapshot)
+/// or saves PNGs at LOS via [`crate::image::save_channel`] /
+/// [`crate::image::save_composite`].
+pub struct LrptPipeline {
+    demux: Demux,
+    decoders: std::collections::HashMap<u16, ChannelDecoder>,
+    assembler: ImageAssembler,
+}
+
+impl Default for LrptPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LrptPipeline {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            demux: Demux::new(),
+            decoders: std::collections::HashMap::new(),
+            assembler: ImageAssembler::new(),
+        }
+    }
+
+    /// Push one [`VCDU_TOTAL_LEN`]-byte VCDU. Drives demux →
+    /// per-channel JPEG decode → image-assembler placement.
+    pub fn push_vcdu(&mut self, vcdu_bytes: &[u8]) {
+        for packet in self.demux.push(vcdu_bytes) {
+            self.consume_packet(&packet);
+        }
+    }
+
+    /// Decode one image packet: parse the per-MCU header bytes,
+    /// run the JPEG decoder for each MCU in the packet, and
+    /// place each decoded block in the channel buffer.
+    ///
+    /// Per medet's `mj_dec_mcus` layout: image packet payload
+    /// starts with 6 metadata bytes (MCU id, scan headers,
+    /// quality byte) followed by the JPEG-coded MCU stream.
+    fn consume_packet(&mut self, packet: &ImagePacket) {
+        if packet.apid == APID_ONBOARD_TIME {
+            return;
+        }
+        if packet.payload.len() < IMAGE_PACKET_HEADER_LEN {
+            return;
+        }
+        let mcu_id = u16::from(packet.payload[0]);
+        // bytes 1-2 = scan_hdr, bytes 3-4 = seg_hdr (unused
+        // here; medet only displays them in debug logs).
+        let quality = packet.payload[5];
+        let jpeg_bytes = &packet.payload[IMAGE_PACKET_HEADER_LEN..];
+
+        let decoder = self
+            .decoders
+            .entry(packet.apid)
+            .or_insert_with(ChannelDecoder::new);
+
+        // Anchor the row-index calculation on first sight of
+        // this channel (per medet `progress_image`). Different
+        // APIDs start their packet counter at different offsets
+        // within a row group; subtract the channel-specific
+        // offset so all channels align to row 0.
+        let pkt = i32::from(packet.sequence_count);
+        if decoder.first_pkt.is_none() {
+            let offset = match packet.apid {
+                65 => i32::from(MCUS_PER_PACKET),
+                66 | 68 => i32::from(2 * MCUS_PER_PACKET),
+                _ => 0,
+            };
+            decoder.first_pkt = Some(pkt - offset);
+            decoder.last_pkt = Some(pkt);
+        }
+        // 14-bit sequence count wraps at SEQUENCE_COUNT_MODULUS.
+        // If the new pkt is less than the previous one (allowing
+        // for jitter), assume a wrap.
+        if let (Some(last), Some(first)) = (decoder.last_pkt, decoder.first_pkt)
+            && pkt < last
+        {
+            decoder.first_pkt = Some(first - SEQUENCE_COUNT_MODULUS);
+        }
+        decoder.last_pkt = Some(pkt);
+
+        let Some(first) = decoder.first_pkt else {
+            return;
+        };
+        let row_pkt = (pkt - first).max(0);
+        #[allow(
+            clippy::cast_sign_loss,
+            reason = "row_pkt is non-negative after the .max(0)"
+        )]
+        let mcu_row = (row_pkt / PACKETS_PER_ROW_GROUP) as usize;
+
+        // Reset DC predictor per packet — Meteor packets are
+        // independently coded.
+        decoder.jpeg.reset_dc();
+        let mut bit_offset = 0_usize;
+        for m in 0..MCUS_PER_PACKET {
+            let Ok(block) = decoder
+                .jpeg
+                .decode_mcu(jpeg_bytes, &mut bit_offset, quality)
+            else {
+                tracing::trace!(
+                    "JPEG decode failed at MCU {m} of APID {apid} packet {pkt}",
+                    apid = packet.apid,
+                    pkt = packet.sequence_count,
+                );
+                break;
+            };
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "mcu_id + m is bounded by mcu_per_line = 196"
+            )]
+            let mcu_col = (mcu_id + m) as usize;
+            self.assembler
+                .place_mcu(packet.apid, mcu_row, mcu_col, &block);
+        }
+    }
+
+    /// Borrow the image assembler — used by the live viewer to
+    /// pull updated scan lines, and at LOS to save PNGs.
+    #[must_use]
+    pub fn assembler(&self) -> &ImageAssembler {
+        &self.assembler
+    }
+
+    /// Reset the pipeline (clear all state). Called between
+    /// passes when the recorder fires `RestoreTune`.
+    pub fn reset(&mut self) {
+        self.demux = Demux::new();
+        self.decoders.clear();
+        self.assembler.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccsds::VCDU_TOTAL_LEN;
+
+    #[test]
+    fn pipeline_constructible_and_resets() {
+        let mut p = LrptPipeline::new();
+        assert!(p.assembler.channels().next().is_none());
+        // Push some bytes (all zeros — empty version, no
+        // imagery emerges) and confirm reset clears state.
+        p.push_vcdu(&vec![0_u8; VCDU_TOTAL_LEN]);
+        p.reset();
+        assert!(p.assembler.channels().next().is_none());
+    }
+
+    #[test]
+    fn empty_vcdu_doesnt_crash() {
+        let mut p = LrptPipeline::new();
+        // Wrong-length input — demux silently drops.
+        p.push_vcdu(&[0_u8; 100]);
+        assert!(p.assembler.channels().next().is_none());
+    }
+}

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -26,7 +26,7 @@ pub mod fec;
 pub mod image;
 
 use crate::ccsds::{Demux, ImagePacket};
-use crate::image::{ImageAssembler, JpegDecoder, MCUS_PER_LINE};
+use crate::image::{ImageAssembler, JpegDecoder, MCUS_PER_LINE, fill_dqt};
 
 /// MCUs encoded per Meteor LRPT image packet. Per medet's
 /// `mcu_per_packet`. Drives the per-packet decode loop and the
@@ -173,14 +173,16 @@ impl LrptPipeline {
         let mcu_row = (row_pkt / PACKETS_PER_ROW_GROUP) as usize;
 
         // Reset DC predictor per packet — Meteor packets are
-        // independently coded.
+        // independently coded. Compute DQT once for the packet
+        // (it depends only on the per-packet quality byte) and
+        // pass the same reference into every per-MCU decode so
+        // the inner loop doesn't recompute it 14 times. Per CR
+        // round 6.
         decoder.jpeg.reset_dc();
+        let dqt = fill_dqt(quality);
         let mut bit_offset = 0_usize;
         for m in 0..MCUS_PER_PACKET {
-            let Ok(block) = decoder
-                .jpeg
-                .decode_mcu(jpeg_bytes, &mut bit_offset, quality)
-            else {
+            let Ok(block) = decoder.jpeg.decode_mcu(jpeg_bytes, &mut bit_offset, &dqt) else {
                 tracing::trace!(
                     "JPEG decode failed at MCU {m} of APID {apid} packet {pkt}",
                     apid = packet.apid,

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -45,6 +45,17 @@ const PACKETS_PER_ROW_GROUP: i32 = 43;
 /// of a non-monotonic step.
 const SEQUENCE_COUNT_MODULUS: i32 = 1 << 14;
 
+/// Minimum backward delta that distinguishes a real
+/// `SEQUENCE_COUNT_MODULUS` wraparound from a small reordering
+/// or a corrupted sequence-count byte. Set to half the modulus:
+/// any backward step ≥ 8192 must be a wrap (the next packet
+/// can't legitimately be that far behind), while a smaller
+/// reversal is more likely a glitch the wrap fix would massively
+/// over-correct. Per CR round 7 — the prior unconditional
+/// `pkt < last` walked `first_pkt` back 16384 on any reversal,
+/// shifting later MCU placements hundreds of rows.
+const WRAP_MIN_BACKWARD_DELTA: i32 = SEQUENCE_COUNT_MODULUS / 2;
+
 /// Image-packet payload header length in bytes: 1 byte MCU id +
 /// 2 bytes `scan_hdr` + 2 bytes `seg_hdr` + 1 byte quality.
 /// JPEG-coded MCU stream begins immediately after.
@@ -153,12 +164,25 @@ impl LrptPipeline {
             decoder.last_pkt = Some(pkt);
         }
         // 14-bit sequence count wraps at SEQUENCE_COUNT_MODULUS.
-        // If the new pkt is less than the previous one (allowing
-        // for jitter), assume a wrap.
+        // Only treat large backward steps (≥ half the modulus)
+        // as a wrap — a small reversal is more likely a corrupted
+        // sequence-count byte (post-RS miscorrection or demux
+        // desync), and the prior unconditional wrap fix would
+        // shift first_pkt back 16384 in those cases, jumping
+        // future MCU placements by hundreds of rows. Per CR
+        // round 7. Smaller reversals are trace-logged for
+        // visibility but do not move first_pkt.
         if let (Some(last), Some(first)) = (decoder.last_pkt, decoder.first_pkt)
             && pkt < last
         {
-            decoder.first_pkt = Some(first - SEQUENCE_COUNT_MODULUS);
+            if last - pkt >= WRAP_MIN_BACKWARD_DELTA {
+                decoder.first_pkt = Some(first - SEQUENCE_COUNT_MODULUS);
+            } else {
+                tracing::trace!(
+                    "non-wrap sequence-count reversal on APID {apid}: last={last} pkt={pkt}",
+                    apid = packet.apid,
+                );
+            }
         }
         decoder.last_pkt = Some(pkt);
 
@@ -405,10 +429,12 @@ mod tests {
     #[test]
     fn consume_packet_handles_sequence_count_wraparound() {
         // The 14-bit sequence counter wraps at SEQUENCE_COUNT_MODULUS
-        // (16384). When we observe a sequence_count strictly less
-        // than the previous one, walk first_pkt back by one
-        // modulus so the row-index calc keeps producing
-        // monotonically increasing rows across the wrap boundary.
+        // (16384). When we observe a backward step ≥ half the
+        // modulus, walk first_pkt back by one modulus so the
+        // row-index calc keeps producing monotonically increasing
+        // rows across the wrap boundary. (Smaller backward steps
+        // are treated as corruption — see
+        // `consume_packet_ignores_small_sequence_count_reversal`.)
         let mut p = LrptPipeline::new();
         // Establish anchor at a high sequence count near the
         // wrap boundary. SEQUENCE_COUNT_MODULUS - 4 = 16380,
@@ -507,6 +533,40 @@ mod tests {
             p.decoders.is_empty(),
             "all-zero VCDU yields no image packets"
         );
+    }
+
+    #[test]
+    fn consume_packet_ignores_small_sequence_count_reversal() {
+        // CR round 7: a small backward step in sequence_count is
+        // more likely a corrupted header (post-RS miscorrection,
+        // upstream demux desync) than a real wrap. The prior
+        // unconditional `pkt < last` would walk first_pkt back
+        // 16384 in those cases, jumping later MCU placements by
+        // hundreds of rows. The fixed gate requires the backward
+        // delta to be at least WRAP_MIN_BACKWARD_DELTA
+        // (= SEQUENCE_COUNT_MODULUS / 2 = 8192) before treating
+        // it as a wrap.
+        //
+        // Push pkt=100, then pkt=99 (one step back, NOT a wrap).
+        // first_pkt must NOT be moved by SEQUENCE_COUNT_MODULUS.
+        let mut p = LrptPipeline::new();
+        let pkt_a = synthetic_image_packet(64, 100);
+        p.consume_packet(&pkt_a);
+        let first_before = p
+            .decoders
+            .get(&64)
+            .expect("apid 64 channel created")
+            .first_pkt
+            .expect("first_pkt set on initial packet");
+        let pkt_b = synthetic_image_packet(64, 99);
+        p.consume_packet(&pkt_b);
+        let dec = p.decoders.get(&64).expect("apid 64 still present");
+        assert_eq!(
+            dec.first_pkt,
+            Some(first_before),
+            "1-step reversal must NOT trigger wrap correction"
+        );
+        assert_eq!(dec.last_pkt, Some(99));
     }
 
     #[test]

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -189,10 +189,24 @@ impl LrptPipeline {
         let Some(first) = decoder.first_pkt else {
             return;
         };
-        let row_pkt = (pkt - first).max(0);
+        let row_pkt = pkt - first;
+        // Per CR round 8: drop pre-anchor packets entirely
+        // instead of clamping them to row 0. The previous
+        // `.max(0)` would silently snap a corrupted-but-not-
+        // wrap reversal (caught by WRAP_MIN_BACKWARD_DELTA
+        // above) onto the first image row, overwriting real
+        // data. Trace-log the drop so the corruption stays
+        // visible during debug runs.
+        if row_pkt < 0 {
+            tracing::trace!(
+                "dropping pre-anchor packet on APID {apid}: first={first} pkt={pkt}",
+                apid = packet.apid,
+            );
+            return;
+        }
         #[allow(
             clippy::cast_sign_loss,
-            reason = "row_pkt is non-negative after the .max(0)"
+            reason = "row_pkt is non-negative after the row_pkt < 0 early return above"
         )]
         let mcu_row = (row_pkt / PACKETS_PER_ROW_GROUP) as usize;
 
@@ -567,6 +581,41 @@ mod tests {
             "1-step reversal must NOT trigger wrap correction"
         );
         assert_eq!(dec.last_pkt, Some(99));
+    }
+
+    #[test]
+    fn consume_packet_drops_pre_anchor_packet() {
+        // CR round 8: a packet whose pkt < first_pkt (after
+        // wrap handling) used to be silently snapped to row 0
+        // by `.max(0)`, overwriting real first-row data. The
+        // fix returns early instead.
+        //
+        // Anchor APID 65 (whose offset = -14 from the first
+        // sequence_count). With initial pkt = 100, first_pkt
+        // becomes 86. Then push pkt = 80 — small backward
+        // step (≤ WRAP_MIN_BACKWARD_DELTA), so the wrap fix
+        // does NOT move first_pkt; row_pkt = 80 - 86 = -6,
+        // which would have clamped to 0 before the fix.
+        //
+        // First push lands at row 0 (writes assembler data).
+        // Second push must NOT add more pixels — the drop
+        // happens before `place_mcu` is called.
+        let mut p = LrptPipeline::new();
+        let pkt_a = synthetic_image_packet(65, 100);
+        p.consume_packet(&pkt_a);
+        let pixels_after_first = p.assembler.channel(65).map_or(0, |c| c.pixels.len());
+        assert!(
+            pixels_after_first > 0,
+            "first packet must populate assembler",
+        );
+
+        let pkt_b = synthetic_image_packet(65, 80);
+        p.consume_packet(&pkt_b);
+        let pixels_after_second = p.assembler.channel(65).map_or(0, |c| c.pixels.len());
+        assert_eq!(
+            pixels_after_second, pixels_after_first,
+            "pre-anchor packet must be dropped, not overwrite row 0",
+        );
     }
 
     #[test]

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -237,4 +237,249 @@ mod tests {
         p.push_vcdu(&[0_u8; 100]);
         assert!(p.assembler.channels().next().is_none());
     }
+
+    // ─── consume_packet path tests ──────────────────────────────
+    //
+    // The full IQ→VCDU FEC chain isn't wired into LrptPipeline
+    // yet (deferred to a follow-up PR), so we exercise
+    // `consume_packet` directly with hand-built `ImagePacket`s.
+    // These tests pin the per-channel anchoring math (medet's
+    // `progress_image` rules), the 14-bit sequence-count
+    // wraparound, the APID 70 timestamp drop, and the short-
+    // payload guard — none of which the demux-driven
+    // `pipeline_constructible_and_resets` test reaches with its
+    // all-zeros input.
+
+    /// Quality byte that selects the lower branch of `fill_dqt`.
+    /// 60 sits comfortably inside `qf >= 50`.
+    const TEST_QUALITY: u8 = 60;
+    /// Per-MCU header length the `consume_packet` path expects:
+    /// 1 byte `mcu_id` + 2 bytes `scan_hdr` + 2 bytes `seg_hdr`
+    /// + 1 byte quality.
+    const HEADER_LEN: usize = IMAGE_PACKET_HEADER_LEN;
+    /// VCID for the AVHRR imaging stream — propagated through
+    /// the demux. `consume_packet` doesn't actually inspect it
+    /// (decisions are by APID), but the struct requires the
+    /// field.
+    const TEST_VCID: u8 = 5;
+    /// Bit pattern for one minimal-MCU encoded as a back-to-back
+    /// 6-bit code stream.
+    /// Every 4 MCUs (= 24 bits = 3 bytes) cycle through this
+    /// pattern; with 14 MCUs we get 3 full cycles + a 2-byte
+    /// tail. See [`MCU_TAIL_2B`] for the partial-cycle remainder.
+    const MCU_PATTERN_3B: [u8; 3] = [0x28, 0xA2, 0x8A];
+    /// Trailing 2 bytes after 3 full [`MCU_PATTERN_3B`] cycles —
+    /// encodes MCUs 13 + 14, with the last 4 bits zero-padded.
+    const MCU_TAIL_2B: [u8; 2] = [0x28, 0xA0];
+    /// Number of full [`MCU_PATTERN_3B`] cycles in the
+    /// 14-MCU synthetic packet payload.
+    const MCU_PATTERN_CYCLES: usize = 3;
+    /// Total post-header bytes the synthetic packet appends.
+    /// Pinned so a future change to the 14-MCU layout fails
+    /// `synthetic_image_packet`'s `debug_assert_eq!`.
+    const SYNTHETIC_TAIL_LEN: usize = MCU_PATTERN_CYCLES * 3 + 2;
+
+    /// Build an [`ImagePacket`] whose payload is a valid header +
+    /// 14 minimal-MCU bitstreams stitched together. The decoder
+    /// loop will succeed on every MCU and place 14 blocks into
+    /// the assembler.
+    fn synthetic_image_packet(apid: u16, sequence_count: u16) -> ImagePacket {
+        let mut payload = vec![0_u8; HEADER_LEN];
+        payload[0] = 0; // mcu_id starts at column 0
+        payload[5] = TEST_QUALITY; // per-packet quality byte
+        // Append 14 minimal MCUs back-to-back as one bit stream.
+        // Each MCU is 6 bits (DC code "00" = cat 0, delta=0;
+        // then AC EOB code "1010"). 14 × 6 = 84 bits = 10 full
+        // bytes + 4 trailing pad bits. See MCU_PATTERN_3B for
+        // the cycle derivation.
+        for _ in 0..MCU_PATTERN_CYCLES {
+            payload.extend_from_slice(&MCU_PATTERN_3B);
+        }
+        payload.extend_from_slice(&MCU_TAIL_2B);
+        debug_assert_eq!(payload.len() - HEADER_LEN, SYNTHETIC_TAIL_LEN);
+        ImagePacket {
+            vcid: TEST_VCID,
+            apid,
+            sequence_count,
+            payload,
+        }
+    }
+
+    #[test]
+    fn consume_packet_drops_apid_70_timestamp() {
+        // APID 70 carries the on-board timestamp packet, not
+        // imagery. consume_packet must drop it before any
+        // channel state is touched.
+        let mut p = LrptPipeline::new();
+        let pkt = synthetic_image_packet(APID_ONBOARD_TIME, 0);
+        p.consume_packet(&pkt);
+        assert!(p.assembler.channels().next().is_none());
+        assert!(
+            p.decoders.is_empty(),
+            "no channel state allocated for apid 70"
+        );
+    }
+
+    #[test]
+    fn consume_packet_drops_short_payload() {
+        // Payload too short to even hold the 6-byte header —
+        // must early-return without touching any state.
+        let mut p = LrptPipeline::new();
+        let pkt = ImagePacket {
+            vcid: TEST_VCID,
+            apid: 64,
+            sequence_count: 100,
+            payload: vec![0_u8; HEADER_LEN - 1],
+        };
+        p.consume_packet(&pkt);
+        assert!(p.assembler.channels().next().is_none());
+    }
+
+    #[test]
+    fn consume_packet_anchors_apid_64_at_zero_offset() {
+        // APID 64 is the "first" channel; medet anchors it with
+        // offset = 0, so first_pkt = sequence_count.
+        let mut p = LrptPipeline::new();
+        let pkt = synthetic_image_packet(64, 100);
+        p.consume_packet(&pkt);
+        let dec = p.decoders.get(&64).expect("apid 64 channel created");
+        assert_eq!(dec.first_pkt, Some(100), "no offset for apid 64");
+        assert_eq!(dec.last_pkt, Some(100));
+    }
+
+    #[test]
+    fn consume_packet_anchors_apid_65_with_minus_14_offset() {
+        // medet's per-channel anchoring: APID 65 = -14 (one
+        // packet group of MCUS_PER_PACKET).
+        let mut p = LrptPipeline::new();
+        let pkt = synthetic_image_packet(65, 100);
+        p.consume_packet(&pkt);
+        let dec = p.decoders.get(&65).expect("apid 65 channel created");
+        assert_eq!(dec.first_pkt, Some(100 - i32::from(MCUS_PER_PACKET)));
+    }
+
+    #[test]
+    fn consume_packet_anchors_apid_66_with_minus_28_offset() {
+        // medet's per-channel anchoring: APID 66 / 68 = -28
+        // (two MCUS_PER_PACKET groups). Pin both APIDs so a
+        // future per-APID rewrite that breaks 68 doesn't slip
+        // through.
+        let mut p = LrptPipeline::new();
+        let pkt66 = synthetic_image_packet(66, 200);
+        p.consume_packet(&pkt66);
+        let dec66 = p.decoders.get(&66).expect("apid 66 channel created");
+        assert_eq!(dec66.first_pkt, Some(200 - 2 * i32::from(MCUS_PER_PACKET)));
+
+        let pkt68 = synthetic_image_packet(68, 300);
+        p.consume_packet(&pkt68);
+        let dec68 = p.decoders.get(&68).expect("apid 68 channel created");
+        assert_eq!(dec68.first_pkt, Some(300 - 2 * i32::from(MCUS_PER_PACKET)));
+    }
+
+    #[test]
+    fn consume_packet_handles_sequence_count_wraparound() {
+        // The 14-bit sequence counter wraps at SEQUENCE_COUNT_MODULUS
+        // (16384). When we observe a sequence_count strictly less
+        // than the previous one, walk first_pkt back by one
+        // modulus so the row-index calc keeps producing
+        // monotonically increasing rows across the wrap boundary.
+        let mut p = LrptPipeline::new();
+        // Establish anchor at a high sequence count near the
+        // wrap boundary. SEQUENCE_COUNT_MODULUS - 4 = 16380,
+        // well within u16 range.
+        #[allow(
+            clippy::cast_sign_loss,
+            clippy::cast_possible_truncation,
+            reason = "SEQUENCE_COUNT_MODULUS = 16384 fits in u16; -4 stays positive"
+        )]
+        let near = (SEQUENCE_COUNT_MODULUS - 4) as u16;
+        let near_wrap = synthetic_image_packet(64, near);
+        p.consume_packet(&near_wrap);
+        let first_before = p
+            .decoders
+            .get(&64)
+            .expect("apid 64 channel created")
+            .first_pkt
+            .expect("first_pkt set on initial packet");
+        // Push a second packet whose sequence_count has wrapped.
+        let after_wrap = synthetic_image_packet(64, 2);
+        p.consume_packet(&after_wrap);
+        let dec = p.decoders.get(&64).expect("apid 64 still present");
+        assert_eq!(
+            dec.first_pkt,
+            Some(first_before - SEQUENCE_COUNT_MODULUS),
+            "first_pkt must walk back by one modulus on wrap"
+        );
+        assert_eq!(dec.last_pkt, Some(2));
+    }
+
+    #[test]
+    fn consume_packet_decodes_mcus_into_assembler() {
+        // End-to-end smoke test: a synthetic packet with a
+        // valid header + 14 minimal MCUs decodes successfully
+        // and writes 14 MCUs (= one packet's worth of one row)
+        // into the assembler under the packet's APID.
+        let mut p = LrptPipeline::new();
+        let pkt = synthetic_image_packet(64, 100);
+        p.consume_packet(&pkt);
+        // The assembler now has channel 64 with at least one
+        // row's worth of pixels (8 lines × IMAGE_WIDTH).
+        let ch = p.assembler.channel(64).expect("channel 64 populated");
+        assert!(
+            ch.lines >= 8,
+            "at least 8 lines should be present, got {}",
+            ch.lines
+        );
+        // Every placed MCU is a uniform 128-valued block (the
+        // minimal-stream output). The first 14 MCUs occupy
+        // columns 0..14 of row 0; verify a sample pixel inside
+        // the first MCU.
+        assert_eq!(
+            ch.pixels[0], 128,
+            "first MCU pixel should be level-shifted 128"
+        );
+    }
+
+    #[test]
+    fn consume_packet_breaks_loop_on_jpeg_error() {
+        // Header is valid but the MCU bitstream is empty —
+        // first decode_mcu call returns EndOfStream, which
+        // triggers the `else` branch and breaks the loop.
+        // No MCUs land in the assembler.
+        let mut p = LrptPipeline::new();
+        let pkt = ImagePacket {
+            vcid: TEST_VCID,
+            apid: 64,
+            sequence_count: 100,
+            payload: {
+                let mut payload = vec![0_u8; HEADER_LEN];
+                payload[5] = TEST_QUALITY;
+                payload
+            },
+        };
+        p.consume_packet(&pkt);
+        // Channel state was created (we passed the early
+        // returns) but the assembler has no actual MCU pixels —
+        // place_mcu was never called.
+        assert!(p.decoders.contains_key(&64));
+        assert!(
+            p.assembler.channel(64).is_none(),
+            "no pixels on JPEG decode failure"
+        );
+    }
+
+    #[test]
+    fn push_vcdu_drives_demux_into_consume_packet() {
+        // The exposed entry point. We don't have a synthetic
+        // VCDU helper at this layer (that lives in ccsds), so
+        // just confirm that pushing the all-zero VCDU (which
+        // the demux silently drops because APID is 0 / IDLE)
+        // doesn't allocate channel state.
+        let mut p = LrptPipeline::new();
+        p.push_vcdu(&vec![0_u8; VCDU_TOTAL_LEN]);
+        assert!(
+            p.decoders.is_empty(),
+            "all-zero VCDU yields no image packets"
+        );
+    }
 }

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -26,7 +26,7 @@ pub mod fec;
 pub mod image;
 
 use crate::ccsds::{Demux, ImagePacket};
-use crate::image::{ImageAssembler, JpegDecoder};
+use crate::image::{ImageAssembler, JpegDecoder, MCUS_PER_LINE};
 
 /// MCUs encoded per Meteor LRPT image packet. Per medet's
 /// `mcu_per_packet`. Drives the per-packet decode loop and the
@@ -190,9 +190,24 @@ impl LrptPipeline {
             };
             #[allow(
                 clippy::cast_possible_truncation,
-                reason = "mcu_id + m is bounded by mcu_per_line = 196"
+                reason = "mcu_id + m fits in usize on every supported target"
             )]
             let mcu_col = (mcu_id + m) as usize;
+            // mcu_id is a single payload byte (0-255) and m is
+            // 0..14, so mcu_col can reach 268 — past the 196
+            // MCUS_PER_LINE bound. ImageAssembler::place_mcu
+            // silently drops out-of-bounds columns, but it's
+            // worth a trace because it indicates a corrupt
+            // packet header (post-RS miscorrection or upstream
+            // demux desync).
+            if mcu_col >= MCUS_PER_LINE {
+                tracing::trace!(
+                    "out-of-range mcu_col {mcu_col} (max {max}) on APID {apid} packet {pkt}",
+                    max = MCUS_PER_LINE - 1,
+                    apid = packet.apid,
+                    pkt = packet.sequence_count,
+                );
+            }
             self.assembler
                 .place_mcu(packet.apid, mcu_row, mcu_col, &block);
         }

--- a/crates/sdr-radio/Cargo.toml
+++ b/crates/sdr-radio/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 sdr-types.workspace = true
 sdr-dsp.workspace = true
+sdr-lrpt.workspace = true
 sdr-pipeline.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -9,6 +9,7 @@ pub mod apt_image;
 pub mod apt_telemetry;
 pub mod demod;
 pub mod if_chain;
+pub mod lrpt_image;
 
 use sdr_dsp::filter::{DEEMPHASIS_TAU_EU, DEEMPHASIS_TAU_US};
 use sdr_dsp::multirate::RationalResampler;

--- a/crates/sdr-radio/src/lrpt_image.rs
+++ b/crates/sdr-radio/src/lrpt_image.rs
@@ -1,0 +1,172 @@
+//! Live Meteor LRPT image handle — sdr-radio surface over the
+//! `sdr-lrpt::ImageAssembler`.
+//!
+//! Sits one stage downstream of [`sdr_lrpt::LrptPipeline`]: the
+//! pipeline accumulates per-channel scan lines as VCDUs arrive,
+//! and this wrapper exposes that accumulation to other threads
+//! (the live viewer in `sdr-ui`, the LOS PNG saver) through an
+//! `Arc<Mutex<...>>`.
+//!
+//! Pure handle — no decoding, no threading control. Clone the
+//! handle to share the underlying assembler across threads;
+//! every clone reads / writes the same buffer.
+//!
+//! ```text
+//!     LrptPipeline ──[VCDU → MCU placement]──▶  ImageAssembler
+//!                                                  ▲
+//!                                                  │ (Arc<Mutex<>>)
+//!                                                  │
+//!                                              LrptImage
+//!                                              │      │
+//!                                              ▼      ▼
+//!                                  live viewer    LOS PNG export
+//! ```
+//!
+//! One [`LrptImage`] corresponds to **one satellite pass**.
+//! Starting a fresh pass = constructing a fresh handle (or
+//! calling [`LrptImage::clear`]); finalizing = stopping the
+//! decoder feed and using the existing snapshot for export.
+
+use sdr_lrpt::image::{ChannelBuffer, ImageAssembler};
+use std::sync::{Arc, Mutex};
+
+/// Cloneable handle over a shared [`ImageAssembler`]. All clones
+/// read and write the same underlying buffer.
+#[derive(Clone)]
+pub struct LrptImage {
+    inner: Arc<Mutex<ImageAssembler>>,
+}
+
+impl Default for LrptImage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LrptImage {
+    /// Start a fresh pass with an empty assembler.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ImageAssembler::new())),
+        }
+    }
+
+    /// Push a complete scan line for `apid`. Used by callers
+    /// that already have a row buffered.
+    pub fn push_line(&self, apid: u16, line: &[u8]) {
+        if let Ok(mut a) = self.inner.lock() {
+            a.push_line(apid, line);
+        }
+    }
+
+    /// Snapshot of channel `apid` as it stands right now, or
+    /// `None` if the channel hasn't received any data yet.
+    /// Returns a clone — the caller doesn't hold the lock during
+    /// long renders.
+    #[must_use]
+    pub fn snapshot_channel(&self, apid: u16) -> Option<ChannelBuffer> {
+        let a = self.inner.lock().ok()?;
+        a.channel(apid).cloned()
+    }
+
+    /// All channel APIDs the assembler has seen at least one
+    /// MCU / line for, in unspecified order.
+    #[must_use]
+    pub fn channel_apids(&self) -> Vec<u16> {
+        let Ok(a) = self.inner.lock() else {
+            return Vec::new();
+        };
+        a.channels().map(|(&apid, _)| apid).collect()
+    }
+
+    /// Borrow the assembler under lock for save / composite ops
+    /// at LOS. Caller is expected to keep the closure short —
+    /// other threads block on the mutex while it runs.
+    pub fn with_assembler<R>(&self, f: impl FnOnce(&ImageAssembler) -> R) -> Option<R> {
+        let a = self.inner.lock().ok()?;
+        Some(f(&a))
+    }
+
+    /// Clear all accumulated channels — call between passes.
+    pub fn clear(&self) {
+        if let Ok(mut a) = self.inner.lock() {
+            a.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sdr_lrpt::image::IMAGE_WIDTH;
+
+    /// APID used in single-channel persistence checks. Any value
+    /// in the AVHRR range works (64–69); 64 is the conventional
+    /// "first channel" used elsewhere in the test suite.
+    const APID_TEST: u16 = 64;
+
+    /// Marker pixel value pushed in `push_then_snapshot_round_trip`.
+    /// Distinct from 0 (empty buffer fill) and 0xFF (saturation)
+    /// so a regression that returned a default-constructed buffer
+    /// would fail loudly instead of silently matching.
+    const TEST_PIXEL: u8 = 42;
+
+    #[test]
+    fn push_then_snapshot_round_trip() {
+        let img = LrptImage::new();
+        img.push_line(APID_TEST, &vec![TEST_PIXEL; IMAGE_WIDTH]);
+        let snap = img.snapshot_channel(APID_TEST).expect("channel present");
+        assert_eq!(snap.lines, 1);
+        assert_eq!(snap.pixels[0], TEST_PIXEL);
+    }
+
+    #[test]
+    fn snapshot_unknown_channel_returns_none() {
+        let img = LrptImage::new();
+        assert!(img.snapshot_channel(APID_TEST).is_none());
+    }
+
+    #[test]
+    fn channel_apids_lists_pushed_channels() {
+        let img = LrptImage::new();
+        img.push_line(64, &vec![1; IMAGE_WIDTH]);
+        img.push_line(65, &vec![2; IMAGE_WIDTH]);
+        let mut apids = img.channel_apids();
+        apids.sort_unstable();
+        assert_eq!(apids, vec![64, 65]);
+    }
+
+    #[test]
+    fn clear_drops_all_channels() {
+        let img = LrptImage::new();
+        img.push_line(APID_TEST, &vec![TEST_PIXEL; IMAGE_WIDTH]);
+        img.clear();
+        assert!(img.snapshot_channel(APID_TEST).is_none());
+        assert!(img.channel_apids().is_empty());
+    }
+
+    #[test]
+    fn handle_clones_share_assembler() {
+        // Both clones must observe the same underlying buffer —
+        // that's the whole point of the Arc<Mutex<...>> handle.
+        // A regression that accidentally cloned the inner state
+        // (e.g. by deriving Clone on a non-Arc inner type) would
+        // surface as the second handle reading None.
+        let a = LrptImage::new();
+        let b = a.clone();
+        a.push_line(APID_TEST, &vec![TEST_PIXEL; IMAGE_WIDTH]);
+        let snap = b.snapshot_channel(APID_TEST).expect("clone sees write");
+        assert_eq!(snap.pixels[0], TEST_PIXEL);
+    }
+
+    #[test]
+    fn with_assembler_runs_closure_under_lock() {
+        let img = LrptImage::new();
+        img.push_line(APID_TEST, &vec![TEST_PIXEL; IMAGE_WIDTH]);
+        let lines = img
+            .with_assembler(|a| a.channel(APID_TEST).map(|c| c.lines))
+            .expect("lock acquired");
+        assert_eq!(lines, Some(1));
+    }
+}

--- a/crates/sdr-radio/src/lrpt_image.rs
+++ b/crates/sdr-radio/src/lrpt_image.rs
@@ -28,7 +28,7 @@
 //! decoder feed and using the existing snapshot for export.
 
 use sdr_lrpt::image::{ChannelBuffer, ImageAssembler};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 /// Cloneable handle over a shared [`ImageAssembler`]. All clones
 /// read and write the same underlying buffer.
@@ -43,6 +43,26 @@ impl Default for LrptImage {
     }
 }
 
+/// Acquire the assembler lock, recovering from a poisoned mutex
+/// by logging a warning and returning the inner guard via
+/// [`PoisonError::into_inner`].
+///
+/// Poisoning here means a previous decoder thread panicked while
+/// holding the lock — the in-flight VCDU placement may have left
+/// the buffer mid-mutation, but `ImageAssembler` operations are
+/// individually atomic (they don't span across calls), so the
+/// next read/write still observes consistent per-channel state.
+/// Silently swallowing the lock as the previous code did meant
+/// a single panic anywhere in the decoder would permanently mute
+/// the live viewer; recovering keeps the pipeline alive at the
+/// cost of one warn log.
+fn lock_or_recover(inner: &Mutex<ImageAssembler>) -> MutexGuard<'_, ImageAssembler> {
+    inner.lock().unwrap_or_else(|e: PoisonError<_>| {
+        tracing::warn!("LrptImage mutex poisoned, recovering — a decoder thread panicked");
+        e.into_inner()
+    })
+}
+
 impl LrptImage {
     /// Start a fresh pass with an empty assembler.
     #[must_use]
@@ -55,9 +75,8 @@ impl LrptImage {
     /// Push a complete scan line for `apid`. Used by callers
     /// that already have a row buffered.
     pub fn push_line(&self, apid: u16, line: &[u8]) {
-        if let Ok(mut a) = self.inner.lock() {
-            a.push_line(apid, line);
-        }
+        let mut a = lock_or_recover(&self.inner);
+        a.push_line(apid, line);
     }
 
     /// Snapshot of channel `apid` as it stands right now, or
@@ -66,7 +85,7 @@ impl LrptImage {
     /// long renders.
     #[must_use]
     pub fn snapshot_channel(&self, apid: u16) -> Option<ChannelBuffer> {
-        let a = self.inner.lock().ok()?;
+        let a = lock_or_recover(&self.inner);
         a.channel(apid).cloned()
     }
 
@@ -74,25 +93,22 @@ impl LrptImage {
     /// MCU / line for, in unspecified order.
     #[must_use]
     pub fn channel_apids(&self) -> Vec<u16> {
-        let Ok(a) = self.inner.lock() else {
-            return Vec::new();
-        };
+        let a = lock_or_recover(&self.inner);
         a.channels().map(|(&apid, _)| apid).collect()
     }
 
     /// Borrow the assembler under lock for save / composite ops
     /// at LOS. Caller is expected to keep the closure short —
     /// other threads block on the mutex while it runs.
-    pub fn with_assembler<R>(&self, f: impl FnOnce(&ImageAssembler) -> R) -> Option<R> {
-        let a = self.inner.lock().ok()?;
-        Some(f(&a))
+    pub fn with_assembler<R>(&self, f: impl FnOnce(&ImageAssembler) -> R) -> R {
+        let a = lock_or_recover(&self.inner);
+        f(&a)
     }
 
     /// Clear all accumulated channels — call between passes.
     pub fn clear(&self) {
-        if let Ok(mut a) = self.inner.lock() {
-            a.clear();
-        }
+        let mut a = lock_or_recover(&self.inner);
+        a.clear();
     }
 }
 
@@ -101,16 +117,26 @@ mod tests {
     use super::*;
     use sdr_lrpt::image::IMAGE_WIDTH;
 
-    /// APID used in single-channel persistence checks. Any value
-    /// in the AVHRR range works (64–69); 64 is the conventional
-    /// "first channel" used elsewhere in the test suite.
+    /// Primary APID used in single-channel persistence checks.
+    /// Any value in the AVHRR range works (64–69); 64 is the
+    /// conventional "first channel" used elsewhere in the test
+    /// suite.
     const APID_TEST: u16 = 64;
+    /// Secondary APID for multi-channel listing checks. Distinct
+    /// from `APID_TEST` so the sort-and-compare assertion in
+    /// `channel_apids_lists_pushed_channels` actually exercises
+    /// the multi-channel path.
+    const APID_TEST_2: u16 = 65;
 
     /// Marker pixel value pushed in `push_then_snapshot_round_trip`.
     /// Distinct from 0 (empty buffer fill) and 0xFF (saturation)
     /// so a regression that returned a default-constructed buffer
     /// would fail loudly instead of silently matching.
     const TEST_PIXEL: u8 = 42;
+    /// Marker pixel for the second channel in the listing test.
+    /// Distinct from `TEST_PIXEL` so a swapped-channel bug would
+    /// surface in any future per-channel content assertion.
+    const TEST_PIXEL_2: u8 = 99;
 
     #[test]
     fn push_then_snapshot_round_trip() {
@@ -130,11 +156,11 @@ mod tests {
     #[test]
     fn channel_apids_lists_pushed_channels() {
         let img = LrptImage::new();
-        img.push_line(64, &vec![1; IMAGE_WIDTH]);
-        img.push_line(65, &vec![2; IMAGE_WIDTH]);
+        img.push_line(APID_TEST, &vec![TEST_PIXEL; IMAGE_WIDTH]);
+        img.push_line(APID_TEST_2, &vec![TEST_PIXEL_2; IMAGE_WIDTH]);
         let mut apids = img.channel_apids();
         apids.sort_unstable();
-        assert_eq!(apids, vec![64, 65]);
+        assert_eq!(apids, vec![APID_TEST, APID_TEST_2]);
     }
 
     #[test]
@@ -164,9 +190,64 @@ mod tests {
     fn with_assembler_runs_closure_under_lock() {
         let img = LrptImage::new();
         img.push_line(APID_TEST, &vec![TEST_PIXEL; IMAGE_WIDTH]);
-        let lines = img
-            .with_assembler(|a| a.channel(APID_TEST).map(|c| c.lines))
-            .expect("lock acquired");
+        let lines = img.with_assembler(|a| a.channel(APID_TEST).map(|c| c.lines));
         assert_eq!(lines, Some(1));
+    }
+
+    #[test]
+    #[allow(
+        clippy::panic,
+        reason = "test deliberately panics on a worker thread to poison the mutex; the panic is the test fixture"
+    )]
+    fn recovers_from_poisoned_mutex() {
+        // Per CR round 1: a panic on a decoder thread used to
+        // permanently mute the live viewer because every
+        // subsequent `inner.lock()` would return Err and the
+        // silent-swallow code path skipped the operation. With
+        // poison recovery, the next push/snapshot still works —
+        // we just emit a warn log.
+        use std::sync::Arc;
+        use std::thread;
+
+        let img = LrptImage::new();
+        img.push_line(APID_TEST, &vec![TEST_PIXEL; IMAGE_WIDTH]);
+
+        // Poison the mutex: spawn a thread that locks then
+        // panics. The Arc/Mutex we share with `img` will be
+        // marked poisoned when the thread unwinds.
+        let inner = Arc::clone(&img.inner);
+        let _ = thread::spawn(move || {
+            let _guard = inner.lock().expect("first lock");
+            panic!("intentional panic to poison the mutex");
+        })
+        .join();
+        assert!(
+            img.inner.is_poisoned(),
+            "test setup: mutex must be poisoned"
+        );
+
+        // The pre-poison line must still be readable, AND new
+        // writes must still land. Both routes go through
+        // `lock_or_recover`.
+        let snap = img
+            .snapshot_channel(APID_TEST)
+            .expect("snapshot post-poison");
+        assert_eq!(snap.pixels[0], TEST_PIXEL);
+        img.push_line(APID_TEST_2, &vec![TEST_PIXEL_2; IMAGE_WIDTH]);
+        let snap2 = img
+            .snapshot_channel(APID_TEST_2)
+            .expect("write post-poison");
+        assert_eq!(snap2.pixels[0], TEST_PIXEL_2);
+
+        // channel_apids and clear must also recover, not return
+        // empty / no-op.
+        let mut apids = img.channel_apids();
+        apids.sort_unstable();
+        assert_eq!(apids, vec![APID_TEST, APID_TEST_2]);
+        img.clear();
+        assert!(
+            img.channel_apids().is_empty(),
+            "clear must work post-poison"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Stage 4 of the Meteor LRPT receive chain — Meteor reduced-JPEG decoder, per-channel image assembly, RGB compositor, PNG export, and the sdr-radio Arc<Mutex> handle the future live viewer will read snapshots from.

\`LrptPipeline\` ties it together: takes whole 892-byte VCDUs (output of the existing CCSDS demux from PR #530), runs each emitted image packet through the per-channel JPEG decoder, and places decoded MCUs into the assembler at the medet-anchored row index.

The IQ→VCDU FEC chain wiring (Viterbi-bytes → bit-aligned ASM sync → derand → CCSDS depth-4 RS de-interleave) and the \`sdr-lrpt-replay\` CLI are deferred to a follow-up — that chain is a meaty bit-level state machine + interleaving module that warrants its own review surface.

## What's in here

- \`crates/sdr-lrpt/src/image/jpeg.rs\` — Meteor reduced-JPEG decoder. Standard quant template + AC Huffman, hardcoded DC Huffman per medet's \`mj_dec_mcus\`. Per-packet quality byte → DQT scaling, per-MCU zigzag → IDCT → level-shift → 8×8 \`Block8x8\`.
- \`crates/sdr-lrpt/src/image/composite.rs\` — \`ChannelBuffer\` (per-APID auto-growing scan-line accumulator with 8×8 MCU placement) + \`ImageAssembler\` (\`HashMap<u16, ChannelBuffer>\`) + 3-channel RGB compositor.
- \`crates/sdr-lrpt/src/image/png_export.rs\` — \`save_channel\` (grayscale per channel) + \`save_composite\` (RGB triple) over the \`image\` crate.
- \`crates/sdr-lrpt/src/lib.rs\` — \`LrptPipeline\` ties demux → JPEG decoder → assembler. Per-channel anchor handling for the 14-bit sequence-count wraparound and medet's APID-65/66/68 row alignment.
- \`crates/sdr-radio/src/lrpt_image.rs\` — \`LrptImage\` Arc<Mutex<ImageAssembler>> handle that mirrors \`apt_image\`'s pattern. Cloneable, snapshot-on-demand, no decoder thread blocking on UI render.

Reference: \`original/medet/met_jpg.pas\`, \`original/medet/dct.pas\`, \`original/MeteorDemod/decoder/protocol/lrpt/msumr/image.cpp\`.

## Test plan

- [x] \`cargo test -p sdr-lrpt -p sdr-radio\` — 66 tests pass (60 in sdr-lrpt, 6 new in sdr-radio::lrpt_image)
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] Self-reviewed against the CR-pattern checklist before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full LRPT image pipeline: reduced-JPEG decoding, per-channel scanline buffering, RGB composition, and PNG export; public pipeline API and thread-safe live image handle with snapshot/clear and poisoned-lock recovery

* **Tests**
  * Extensive unit tests covering decoding, assembly, export, concurrency, and recovery from poisoned locks

* **Chores**
  * Enabled PNG export support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->