### PR TITLE
sdr-core,sdr-ui: pre-volume WAV writer + auto-record audio toggle

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -2816,15 +2816,17 @@ fn process_iq_block(
                             }
                         }
 
-                        // Apply volume with perceptual (power-law) scaling.
-                        // Quadratic curve maps the linear slider to perceived loudness.
-                        let vol = state.volume * state.volume;
-                        for s in &mut state.audio_buf[..audio_count] {
-                            s.l *= vol;
-                            s.r *= vol;
-                        }
-
-                        // Write to audio recording file (post-volume).
+                        // Write to audio recording file BEFORE the
+                        // volume scale (closes #532). The recorder is
+                        // a diagnostic artifact — it should capture
+                        // what the demodulator produced, not what the
+                        // speaker played. A muted overnight pass used
+                        // to fill 200+ MB of disk with all-zero
+                        // samples; the user only discovered the bug
+                        // when they tried to replay the WAV. Now the
+                        // recording is independent of the volume knob,
+                        // matching the APT decoder tap (line ~2632)
+                        // which is also pre-volume.
                         if let Some(writer) = &mut state.audio_writer
                             && let Err(e) = writer.write_stereo(&state.audio_buf[..audio_count])
                         {
@@ -2833,6 +2835,14 @@ fn process_iq_block(
                             let _ = dsp_tx
                                 .send(DspToUi::Error("Audio recording write failed".to_string()));
                             let _ = dsp_tx.send(DspToUi::AudioRecordingStopped);
+                        }
+
+                        // Apply volume with perceptual (power-law) scaling.
+                        // Quadratic curve maps the linear slider to perceived loudness.
+                        let vol = state.volume * state.volume;
+                        for s in &mut state.audio_buf[..audio_count] {
+                            s.l *= vol;
+                            s.r *= vol;
                         }
 
                         // Scanner mute: fill the audio buffer with

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -121,6 +121,10 @@ pub const KEY_STATION_ALT_M: &str = "sat_station_alt_m";
 pub const KEY_TLE_LAST_REFRESH: &str = "sat_tle_last_refresh";
 /// Persisted "auto-record APT passes" toggle.
 pub const KEY_AUTO_RECORD_APT: &str = "sat_auto_record_apt";
+/// Persisted "also save audio (.wav) on auto-record" toggle.
+/// Pairs with [`KEY_AUTO_RECORD_APT`] — only meaningful when
+/// auto-record is on. Default: `false` (opt-in). Per #533.
+pub const KEY_AUTO_RECORD_AUDIO: &str = "sat_auto_record_audio";
 
 // ─── Panel ─────────────────────────────────────────────────────────────
 
@@ -174,6 +178,13 @@ pub struct SatellitesPanel {
     /// Auto-record toggle — drives #482's "open APT viewer +
     /// start decoding when a NOAA pass starts" wiring.
     pub auto_record_switch: adw::SwitchRow,
+    /// "Also save audio (.wav)" toggle — when on AND
+    /// `auto_record_switch` is on, the recorder fires
+    /// `Action::StartAutoAudioRecord` at AOS and
+    /// `Action::StopAutoAudioRecord` at LOS so the pass's
+    /// demodulated audio lands in `~/sdr-recordings/audio-{slug}-
+    /// {timestamp}.wav` paired with the PNG. Per #533.
+    pub auto_record_audio_switch: adw::SwitchRow,
 
     // Next passes group -----------------------------------------------------
     /// The preferences group hosting the dynamically-built pass
@@ -227,6 +238,8 @@ pub struct SatellitesPanelWeak {
     pub refresh_spinner: glib::WeakRef<gtk4::Spinner>,
     /// Weak ref to [`SatellitesPanel::auto_record_switch`].
     pub auto_record_switch: glib::WeakRef<adw::SwitchRow>,
+    /// Weak ref to [`SatellitesPanel::auto_record_audio_switch`].
+    pub auto_record_audio_switch: glib::WeakRef<adw::SwitchRow>,
     /// Weak ref to [`SatellitesPanel::passes_group`].
     pub passes_group: glib::WeakRef<adw::PreferencesGroup>,
     /// Weak ref to [`SatellitesPanel::passes_status_row`].
@@ -251,6 +264,7 @@ impl SatellitesPanel {
             refresh_button: self.refresh_button.downgrade(),
             refresh_spinner: self.refresh_spinner.downgrade(),
             auto_record_switch: self.auto_record_switch.downgrade(),
+            auto_record_audio_switch: self.auto_record_audio_switch.downgrade(),
             passes_group: self.passes_group.downgrade(),
             passes_status_row: self.passes_status_row.downgrade(),
         }
@@ -277,6 +291,7 @@ impl SatellitesPanelWeak {
             refresh_button: self.refresh_button.upgrade()?,
             refresh_spinner: self.refresh_spinner.upgrade()?,
             auto_record_switch: self.auto_record_switch.upgrade()?,
+            auto_record_audio_switch: self.auto_record_audio_switch.upgrade()?,
             passes_group: self.passes_group.upgrade()?,
             passes_status_row: self.passes_status_row.upgrade()?,
         })
@@ -290,6 +305,10 @@ impl SatellitesPanelWeak {
 /// (avoids spurious save-on-restore feedback during window
 /// construction).
 #[must_use]
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear panel layout — ground-station group, TLE group, recording group (now with two switches per #533), and passes group are easier to follow as one block than artificially split into helpers"
+)]
 pub fn build_satellites_panel() -> SatellitesPanel {
     let page = adw::PreferencesPage::new();
 
@@ -397,6 +416,18 @@ pub fn build_satellites_panel() -> SatellitesPanel {
         .active(false)
         .build();
     recording_group.add(&auto_record_switch);
+
+    // Pairs with auto-record. Only takes effect when both this
+    // and `auto_record_switch` are on; sampled exclusively at
+    // AOS so a mid-pass toggle can't leave a half-stopped writer.
+    // Per #533. Also depends on #532 (pre-volume WAV writer) to
+    // capture usable audio when speakers are muted.
+    let auto_record_audio_switch = adw::SwitchRow::builder()
+        .title("Also save audio (.wav)")
+        .subtitle("Capture demodulated audio alongside the image. Pairs with the PNG by filename.")
+        .active(false)
+        .build();
+    recording_group.add(&auto_record_audio_switch);
     page.add(&recording_group);
 
     // ─── Upcoming Passes ──────────────────────────────────────
@@ -426,6 +457,7 @@ pub fn build_satellites_panel() -> SatellitesPanel {
         refresh_button,
         refresh_spinner,
         auto_record_switch,
+        auto_record_audio_switch,
         passes_group,
         passes_status_row,
     }
@@ -461,6 +493,13 @@ pub fn load_auto_record_apt(config: &Arc<ConfigManager>) -> bool {
     read_bool_or(config, KEY_AUTO_RECORD_APT, false)
 }
 
+/// Read the persisted "also save audio" toggle. Defaults to
+/// `false` (opt-in). Per #533.
+#[must_use]
+pub fn load_auto_record_audio(config: &Arc<ConfigManager>) -> bool {
+    read_bool_or(config, KEY_AUTO_RECORD_AUDIO, false)
+}
+
 /// Persist `value` under `key`. Single helper for the three
 /// lat/lon/alt `SpinRow` change-notify handlers.
 pub fn save_f64(config: &Arc<ConfigManager>, key: &str, value: f64) {
@@ -473,6 +512,13 @@ pub fn save_f64(config: &Arc<ConfigManager>, key: &str, value: f64) {
 pub fn save_auto_record_apt(config: &Arc<ConfigManager>, value: bool) {
     config.write(|v| {
         v[KEY_AUTO_RECORD_APT] = serde_json::json!(value);
+    });
+}
+
+/// Persist `value` under [`KEY_AUTO_RECORD_AUDIO`].
+pub fn save_auto_record_audio(config: &Arc<ConfigManager>, value: bool) {
+    config.write(|v| {
+        v[KEY_AUTO_RECORD_AUDIO] = serde_json::json!(value);
     });
 }
 

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -68,6 +68,13 @@ pub enum State {
         /// took over. Restored at LOS so the user comes back to
         /// whatever they were listening to.
         saved_tune: SavedTune,
+        /// PNG export path computed at AOS using the AOS
+        /// timestamp. Stored on state so the LOS-side
+        /// `Action::SavePng` uses the same timestamp as
+        /// `audio_path` — without this the filenames would
+        /// differ by exactly the pass duration (CR round 1
+        /// on PR #534).
+        png_path: PathBuf,
         /// Audio recording path the wiring layer was asked to
         /// open at AOS. `Some(path)` means we'll fire
         /// [`Action::StopAutoAudioRecord`] at LOS to close it
@@ -83,6 +90,7 @@ pub enum State {
     Recording {
         pass: Pass,
         saved_tune: SavedTune,
+        png_path: PathBuf,
         audio_path: Option<PathBuf>,
     },
     /// Pass ended; PNG export and tune restore are pending. This
@@ -236,13 +244,15 @@ impl AutoRecorder {
                 pass,
                 tuned_at,
                 saved_tune,
+                png_path,
                 audio_path,
-            } => self.tick_before_pass(now, pass, tuned_at, saved_tune, audio_path),
+            } => self.tick_before_pass(now, pass, tuned_at, saved_tune, png_path, audio_path),
             State::Recording {
                 pass,
                 saved_tune,
+                png_path,
                 audio_path,
-            } => self.tick_recording(now, pass, saved_tune, audio_path),
+            } => self.tick_recording(now, pass, saved_tune, png_path, audio_path),
             State::Finalizing {
                 pass,
                 saved_tune,
@@ -306,6 +316,13 @@ impl AutoRecorder {
             // Fall through: pass is in the lead-in window OR has
             // already started (we missed the lead — start tuning
             // immediately).
+            //
+            // Both filenames use the AOS timestamp so PNG and
+            // WAV pair by string match. CR round 1 on PR #534
+            // caught the prior bug: png_path_for was called at
+            // LOS while audio_path_for was called at AOS, so a
+            // 10-min pass produced filenames 10 min apart.
+            let png_path = png_path_for(pass, now);
             let audio_path = audio_record_on.then(|| audio_path_for(pass, now));
             let mut actions = Vec::with_capacity(3);
             actions.push(Action::StartAutoRecord {
@@ -336,6 +353,7 @@ impl AutoRecorder {
                 pass: pass.clone(),
                 tuned_at: now,
                 saved_tune: now_tune,
+                png_path,
                 audio_path,
             };
             return actions;
@@ -349,6 +367,7 @@ impl AutoRecorder {
         pass: Pass,
         tuned_at: DateTime<Utc>,
         saved_tune: SavedTune,
+        png_path: PathBuf,
         audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         // LOS already arrived (e.g. the 1 Hz driver stalled on a
@@ -356,9 +375,9 @@ impl AutoRecorder {
         // entirely inside the settle window). Skip straight to
         // finalizing AND emit the SavePng — otherwise we'd jump
         // to Idle on the next tick without ever exporting the
-        // image.
+        // image. `png_path` was computed at AOS so the filename
+        // pairs with `audio_path`.
         if pass.end <= now {
-            let png_path = png_path_for(&pass, now);
             let mut actions = Vec::with_capacity(2);
             actions.push(Action::SavePng(png_path.clone()));
             if audio_path.is_some() {
@@ -376,6 +395,7 @@ impl AutoRecorder {
             self.state = State::Recording {
                 pass,
                 saved_tune,
+                png_path,
                 audio_path,
             };
         }
@@ -387,6 +407,7 @@ impl AutoRecorder {
         now: DateTime<Utc>,
         pass: Pass,
         saved_tune: SavedTune,
+        png_path: PathBuf,
         audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         if pass.end <= now {
@@ -395,8 +416,8 @@ impl AutoRecorder {
             // export's actual outcome). Announcing "image saved"
             // here would lie if the user closed the viewer
             // mid-pass or `export_png` errored on disk-full /
-            // permissions.
-            let png_path = png_path_for(&pass, now);
+            // permissions. `png_path` was computed at AOS so
+            // the filename pairs with `audio_path`.
             let mut actions = Vec::with_capacity(2);
             actions.push(Action::SavePng(png_path.clone()));
             if audio_path.is_some() {
@@ -873,29 +894,112 @@ mod tests {
     }
 
     #[test]
-    fn audio_path_pairs_with_png_path() {
-        // PNG and WAV must share the same satellite slug + local
-        // timestamp so a post-pass file picker can pair them by
-        // filename match. Per #533. Locking both paths together
-        // here also serves as a regression test against a future
-        // refactor that splits the timestamp between the two.
+    fn audio_path_pairs_with_png_path_on_same_timestamp() {
+        // Helper-function level pairing: with the same timestamp
+        // input, PNG and WAV stems differ only in the "apt-" /
+        // "audio-" prefix and the extension. This is the
+        // contract `pass_recording_path` is supposed to enforce.
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 30, 15).unwrap();
         let pass = synthetic_noaa19(now, 0, 720, 50.0);
         let png = png_path_for(&pass, now);
         let audio = audio_path_for(&pass, now);
         let png_stem = png.file_stem().unwrap().to_string_lossy().to_string();
         let audio_stem = audio.file_stem().unwrap().to_string_lossy().to_string();
-        // Strip the prefix differences ("apt-" vs "audio-") and
-        // confirm the rest (slug + timestamp) matches verbatim.
         let png_tail = png_stem.strip_prefix("apt-").unwrap();
         let audio_tail = audio_stem.strip_prefix("audio-").unwrap();
         assert_eq!(png_tail, audio_tail, "slug+timestamp must match");
-        // Extension differs, parent dir matches.
         assert_eq!(png.parent(), audio.parent());
         assert!(
             audio
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("wav"))
+        );
+    }
+
+    #[test]
+    fn audio_and_png_paths_share_aos_timestamp_across_pass_duration() {
+        // CR round 1 on PR #534 caught the production bug the
+        // previous unit test missed: png_path_for was called at
+        // LOS while audio_path_for was called at AOS, so a
+        // typical 10-15 minute pass produced filenames that
+        // differed by the entire pass duration — breaking the
+        // "pair by filename match" contract.
+        //
+        // Drive the state machine through a real AOS → settle →
+        // LOS transition, capturing the audio path the recorder
+        // emitted at AOS and the png path it emitted at LOS,
+        // then assert their timestamp tails match. Without the
+        // pre-compute-png-at-AOS fix this test fails by exactly
+        // the pass duration.
+        let mut r = AutoRecorder::new();
+        let now_aos = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        // Pass starts in 3 s (inside the 5 s lead-in window),
+        // lasts 720 s — large enough that an LOS-timestamped
+        // png_path would be obviously wrong vs the AOS-
+        // timestamped audio_path (12-minute delta).
+        let pass = synthetic_noaa19(now_aos, 3, 720, 50.0);
+
+        // AOS — capture the audio path the recorder asked for.
+        let aos_actions = r.tick(
+            now_aos,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        let audio_path = aos_actions
+            .iter()
+            .find_map(|a| match a {
+                Action::StartAutoAudioRecord(p) => Some(p.clone()),
+                _ => None,
+            })
+            .expect("StartAutoAudioRecord at AOS");
+
+        // Settle, then LOS at a wall-clock time clearly after
+        // AOS. If png_path were re-computed at LOS, this delta
+        // would surface as a different timestamp in the PNG
+        // filename.
+        let after_settle = now_aos + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        let los_plus = pass.end + ChronoDuration::seconds(1);
+        let los_actions = r.tick(
+            los_plus,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        let png_path = los_actions
+            .iter()
+            .find_map(|a| match a {
+                Action::SavePng(p) => Some(p.clone()),
+                _ => None,
+            })
+            .expect("SavePng at LOS");
+
+        // The defining assertion: the timestamp tail of the PNG
+        // matches the timestamp tail of the WAV. Strip the
+        // "apt-NOAA-19-" / "audio-NOAA-19-" prefix and compare
+        // verbatim.
+        let png_stem = png_path.file_stem().unwrap().to_string_lossy().to_string();
+        let audio_stem = audio_path
+            .file_stem()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let png_ts = png_stem.strip_prefix("apt-NOAA-19-").unwrap();
+        let audio_ts = audio_stem.strip_prefix("audio-NOAA-19-").unwrap();
+        assert_eq!(
+            png_ts, audio_ts,
+            "PNG and WAV must share the AOS timestamp (regression: \
+             pre-fix produced png={png_ts} vs audio={audio_ts}, \
+             differing by the pass duration)",
         );
     }
 

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -68,16 +68,30 @@ pub enum State {
         /// took over. Restored at LOS so the user comes back to
         /// whatever they were listening to.
         saved_tune: SavedTune,
+        /// Audio recording path the wiring layer was asked to
+        /// open at AOS. `Some(path)` means we'll fire
+        /// [`Action::StopAutoAudioRecord`] at LOS to close it
+        /// cleanly. `None` means the audio toggle was off when
+        /// AOS fired and there's no in-flight recording. The
+        /// captured value persists across the AOS toggle so a
+        /// user flipping it mid-pass can't leave a half-stopped
+        /// writer.
+        audio_path: Option<PathBuf>,
     },
     /// Pass is in progress; APT decoder is producing the live
     /// image. No per-tick work needed — we just wait for LOS.
-    Recording { pass: Pass, saved_tune: SavedTune },
+    Recording {
+        pass: Pass,
+        saved_tune: SavedTune,
+        audio_path: Option<PathBuf>,
+    },
     /// Pass ended; PNG export and tune restore are pending. This
     /// state is single-tick: the next `tick` advances to `Idle`.
     Finalizing {
         pass: Pass,
         saved_tune: SavedTune,
         png_path: PathBuf,
+        audio_path: Option<PathBuf>,
     },
 }
 
@@ -132,10 +146,23 @@ pub enum Action {
         mode: DemodMode,
         bandwidth_hz: u32,
     },
+    /// Open a WAV writer at `audio_path` to capture the
+    /// demodulated audio for the duration of the pass. Fired
+    /// alongside [`Action::StartAutoRecord`] only when the user
+    /// has the "also save audio" toggle on. Wiring layer maps
+    /// to `UiToDsp::StartAudioRecording(path)`. Per #533.
+    StartAutoAudioRecord(PathBuf),
     /// Save the in-flight APT image to `png_path`. Fired on
     /// `Recording → Finalizing`. Caller is expected to call
     /// `AptImageView::export_png` against the open viewer.
     SavePng(PathBuf),
+    /// Stop the in-flight WAV writer opened by
+    /// [`Action::StartAutoAudioRecord`]. Fired alongside
+    /// [`Action::SavePng`] on LOS, but only when audio recording
+    /// was actually started at AOS — flipping the toggle mid-
+    /// pass does NOT retroactively start or stop recording.
+    /// Wiring layer maps to `UiToDsp::StopAudioRecording`.
+    StopAutoAudioRecord,
     /// Restore the radio to the pre-recording tune. Fired on
     /// `Finalizing → Idle`. Caller dispatches the same triple
     /// through the same primitive the play button uses.
@@ -186,6 +213,12 @@ impl AutoRecorder {
     /// in-flight pass keeps running to LOS regardless, but no new
     /// passes will arm).
     ///
+    /// `audio_record_on` reflects the "also save audio" toggle.
+    /// Sampled exclusively at AOS — flipping it mid-pass does NOT
+    /// retroactively start or stop a recording (avoids leaving a
+    /// half-stopped writer behind, and matches the `auto_record_on`
+    /// "in-flight pass keeps running" semantics).
+    ///
     /// `now_tune` is the radio's current `(freq_hz, mode,
     /// bandwidth_hz)`. Captured at AOS as the `saved_tune` for the
     /// in-flight pass so a later LOS can restore.
@@ -194,21 +227,28 @@ impl AutoRecorder {
         now: DateTime<Utc>,
         passes: &[Pass],
         auto_record_on: bool,
+        audio_record_on: bool,
         now_tune: SavedTune,
     ) -> Vec<Action> {
         match self.state.clone() {
-            State::Idle => self.tick_idle(now, passes, auto_record_on, now_tune),
+            State::Idle => self.tick_idle(now, passes, auto_record_on, audio_record_on, now_tune),
             State::BeforePass {
                 pass,
                 tuned_at,
                 saved_tune,
-            } => self.tick_before_pass(now, pass, tuned_at, saved_tune),
-            State::Recording { pass, saved_tune } => self.tick_recording(now, pass, saved_tune),
+                audio_path,
+            } => self.tick_before_pass(now, pass, tuned_at, saved_tune, audio_path),
+            State::Recording {
+                pass,
+                saved_tune,
+                audio_path,
+            } => self.tick_recording(now, pass, saved_tune, audio_path),
             State::Finalizing {
                 pass,
                 saved_tune,
                 png_path,
-            } => self.tick_finalizing(pass, saved_tune, png_path),
+                audio_path,
+            } => self.tick_finalizing(pass, saved_tune, png_path, audio_path),
         }
     }
 
@@ -217,6 +257,7 @@ impl AutoRecorder {
         now: DateTime<Utc>,
         passes: &[Pass],
         auto_record_on: bool,
+        audio_record_on: bool,
         now_tune: SavedTune,
     ) -> Vec<Action> {
         if !auto_record_on {
@@ -265,13 +306,17 @@ impl AutoRecorder {
             // Fall through: pass is in the lead-in window OR has
             // already started (we missed the lead — start tuning
             // immediately).
-            let mut actions = Vec::with_capacity(2);
+            let audio_path = audio_record_on.then(|| audio_path_for(pass, now));
+            let mut actions = Vec::with_capacity(3);
             actions.push(Action::StartAutoRecord {
                 satellite: pass.satellite.clone(),
                 freq_hz,
                 mode,
                 bandwidth_hz,
             });
+            if let Some(path) = &audio_path {
+                actions.push(Action::StartAutoAudioRecord(path.clone()));
+            }
             // "Starting" reads wrong if we missed the lead window
             // (laptop wake, recompute lag, etc.) and the pass is
             // already underway — in that case the user sees the
@@ -291,6 +336,7 @@ impl AutoRecorder {
                 pass: pass.clone(),
                 tuned_at: now,
                 saved_tune: now_tune,
+                audio_path,
             };
             return actions;
         }
@@ -303,6 +349,7 @@ impl AutoRecorder {
         pass: Pass,
         tuned_at: DateTime<Utc>,
         saved_tune: SavedTune,
+        audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         // LOS already arrived (e.g. the 1 Hz driver stalled on a
         // sleep / suspend cycle, or a very short pass elapsed
@@ -312,15 +359,25 @@ impl AutoRecorder {
         // image.
         if pass.end <= now {
             let png_path = png_path_for(&pass, now);
+            let mut actions = Vec::with_capacity(2);
+            actions.push(Action::SavePng(png_path.clone()));
+            if audio_path.is_some() {
+                actions.push(Action::StopAutoAudioRecord);
+            }
             self.state = State::Finalizing {
                 pass: pass.clone(),
                 saved_tune,
-                png_path: png_path.clone(),
+                png_path,
+                audio_path,
             };
-            return vec![Action::SavePng(png_path)];
+            return actions;
         }
         if (now - tuned_at).num_seconds() >= SETTLE_SECS {
-            self.state = State::Recording { pass, saved_tune };
+            self.state = State::Recording {
+                pass,
+                saved_tune,
+                audio_path,
+            };
         }
         Vec::new()
     }
@@ -330,6 +387,7 @@ impl AutoRecorder {
         now: DateTime<Utc>,
         pass: Pass,
         saved_tune: SavedTune,
+        audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         if pass.end <= now {
             // Emit `SavePng` only — the success / failure toast
@@ -339,12 +397,18 @@ impl AutoRecorder {
             // mid-pass or `export_png` errored on disk-full /
             // permissions.
             let png_path = png_path_for(&pass, now);
+            let mut actions = Vec::with_capacity(2);
+            actions.push(Action::SavePng(png_path.clone()));
+            if audio_path.is_some() {
+                actions.push(Action::StopAutoAudioRecord);
+            }
             self.state = State::Finalizing {
                 pass,
                 saved_tune,
-                png_path: png_path.clone(),
+                png_path,
+                audio_path,
             };
-            return vec![Action::SavePng(png_path)];
+            return actions;
         }
         Vec::new()
     }
@@ -354,6 +418,7 @@ impl AutoRecorder {
         _pass: Pass,
         saved_tune: SavedTune,
         _png_path: PathBuf,
+        _audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         // Single-tick state: SavePng was issued on entry; restore
         // tune and return to Idle.
@@ -380,6 +445,22 @@ fn is_apt_capable(satellite_name: &str) -> bool {
 /// can't drift on naming.
 #[must_use]
 fn png_path_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
+    pass_recording_path(pass, now, "apt", "png")
+}
+
+/// Build the audio-recording path for a satellite + timestamp:
+/// `~/sdr-recordings/audio-NOAA-19-2026-04-25-143015.wav`.
+/// Pairs with [`png_path_for`] — same sat slug + timestamp so a
+/// post-pass viewer can pair PNG with WAV by filename match.
+#[must_use]
+fn audio_path_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
+    pass_recording_path(pass, now, "audio", "wav")
+}
+
+/// Shared filename builder for the per-pass artifacts — the PNG
+/// (`png_path_for`) and the WAV (`audio_path_for`) both go through
+/// here so a future filename-format tweak only touches one place.
+fn pass_recording_path(pass: &Pass, now: DateTime<Utc>, prefix: &str, extension: &str) -> PathBuf {
     let stamp = now
         .with_timezone(&chrono::Local)
         .format("%Y-%m-%d-%H%M%S")
@@ -401,7 +482,7 @@ fn png_path_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
         .join("-");
     glib::home_dir()
         .join("sdr-recordings")
-        .join(format!("apt-{sat_slug}-{stamp}.png"))
+        .join(format!("{prefix}-{sat_slug}-{stamp}.{extension}"))
 }
 
 // `glib` is referenced via the GTK4 stack but only available on
@@ -453,7 +534,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // Pass starts in 3 s — inside the 5 s lead-in.
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, default_tune());
+        let actions = r.tick(now, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::BeforePass { .. }));
         assert!(matches!(actions[0], Action::StartAutoRecord { .. }));
         // Pre-AOS arming reports "starting" — the pass hasn't
@@ -483,7 +564,7 @@ mod tests {
         // Pass started 30 s ago, ends in 9.5 min — eligible by
         // every other gate (NOAA, 50° peak, end > now).
         let pass = synthetic_noaa19(now, -30, 600, 50.0);
-        let actions = r.tick(now, &[pass], true, default_tune());
+        let actions = r.tick(now, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::BeforePass { .. }));
         match &actions[1] {
             Action::Toast { message, .. } => {
@@ -501,7 +582,7 @@ mod tests {
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], false, default_tune());
+        let actions = r.tick(now, &[pass], false, false, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -512,7 +593,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // 20° peak — "marginal" tier, below the 25° "good" floor.
         let pass = synthetic_noaa19(now, 3, 720, 20.0);
-        let actions = r.tick(now, &[pass], true, default_tune());
+        let actions = r.tick(now, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -526,7 +607,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let mut pass = synthetic_noaa19(now, 3, 720, 50.0);
         pass.satellite = "METEOR-M 2".to_string();
-        let actions = r.tick(now, &[pass], true, default_tune());
+        let actions = r.tick(now, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -545,7 +626,13 @@ mod tests {
         let mut pass = synthetic_noaa19(now, -660, 600, 50.0); // started -660 s ago, ended -60 s ago
         // Sanity: this pass is in the past from `now`'s perspective.
         assert!(pass.end < now);
-        let actions = r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        let actions = r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
         // Mutating the pass to make peak elevation match the
@@ -553,7 +640,13 @@ mod tests {
         // that the only thing keeping us idle was the LOS check.
         pass.end = now + ChronoDuration::seconds(720);
         pass.start = now + ChronoDuration::seconds(3);
-        let actions = r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        let actions = r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::BeforePass { .. }));
         assert!(
             actions
@@ -568,7 +661,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // Pass starts in 10 min. Way outside the 5 s lead-in.
         let pass = synthetic_noaa19(now, 600, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, default_tune());
+        let actions = r.tick(now, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -579,15 +672,27 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
         // Initial arm.
-        r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::BeforePass { .. }));
         // Pre-settle tick: still in BeforePass.
         let later = now + ChronoDuration::seconds(2);
-        r.tick(later, std::slice::from_ref(&pass), true, default_tune());
+        r.tick(
+            later,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::BeforePass { .. }));
         // Past settle window: advance to Recording.
         let later = now + ChronoDuration::seconds(SETTLE_SECS);
-        r.tick(later, &[pass], true, default_tune());
+        r.tick(later, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::Recording { .. }));
     }
 
@@ -596,18 +701,25 @@ mod tests {
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 600, 50.0); // 10 min pass
-        r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
         r.tick(
             after_settle,
             std::slice::from_ref(&pass),
             true,
+            false,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
         // Tick past LOS.
         let los_plus_one = pass.end + ChronoDuration::seconds(1);
-        let actions = r.tick(los_plus_one, &[pass], true, default_tune());
+        let actions = r.tick(los_plus_one, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::Finalizing { .. }));
         // Only `SavePng` — the success / failure toast is the
         // wiring layer's responsibility now (it knows the export
@@ -634,18 +746,25 @@ mod tests {
             scanner_running: true, // pin: pre-AOS scan must come back at LOS
         };
         // Walk all transitions.
-        r.tick(now, std::slice::from_ref(&pass), true, saved);
+        r.tick(now, std::slice::from_ref(&pass), true, false, saved);
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
         r.tick(
             after_settle,
             std::slice::from_ref(&pass),
             true,
+            false,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
-        r.tick(los_plus, std::slice::from_ref(&pass), true, default_tune());
+        r.tick(
+            los_plus,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Finalizing { .. }));
-        let actions = r.tick(los_plus, &[pass], true, default_tune());
+        let actions = r.tick(los_plus, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::Idle));
         // Restore action carries the original saved tune,
         // including the VFO offset (so a user's drag position
@@ -679,11 +798,23 @@ mod tests {
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 60, 50.0); // 1 min pass, 3 s lead-in
-        r.tick(now, std::slice::from_ref(&pass), true, default_tune());
+        r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::BeforePass { .. }));
         // Jump to a moment past LOS (simulate stalled driver).
         let post_los = pass.end + ChronoDuration::seconds(5);
-        let actions = r.tick(post_los, std::slice::from_ref(&pass), true, default_tune());
+        let actions = r.tick(
+            post_los,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Finalizing { .. }));
         assert!(
             actions.iter().any(|a| matches!(a, Action::SavePng(_))),
@@ -697,12 +828,19 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass_a = synthetic_noaa19(now, 3, 720, 50.0);
         // Arm + settle into Recording.
-        r.tick(now, std::slice::from_ref(&pass_a), true, default_tune());
+        r.tick(
+            now,
+            std::slice::from_ref(&pass_a),
+            true,
+            false,
+            default_tune(),
+        );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
         r.tick(
             after_settle,
             std::slice::from_ref(&pass_a),
             true,
+            false,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
@@ -710,7 +848,7 @@ mod tests {
         // The recorder should ignore it — Recording stays put.
         let mut pass_b = synthetic_noaa19(now, 30, 720, 60.0);
         pass_b.satellite = "NOAA 18".to_string();
-        let actions = r.tick(after_settle, &[pass_a, pass_b], true, default_tune());
+        let actions = r.tick(after_settle, &[pass_a, pass_b], true, false, default_tune());
         assert!(matches!(r.state(), State::Recording { .. }));
         // No StartAutoRecord action emitted.
         assert!(
@@ -731,6 +869,129 @@ mod tests {
             std::path::Path::new(&s)
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("png"))
+        );
+    }
+
+    #[test]
+    fn audio_path_pairs_with_png_path() {
+        // PNG and WAV must share the same satellite slug + local
+        // timestamp so a post-pass file picker can pair them by
+        // filename match. Per #533. Locking both paths together
+        // here also serves as a regression test against a future
+        // refactor that splits the timestamp between the two.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 30, 15).unwrap();
+        let pass = synthetic_noaa19(now, 0, 720, 50.0);
+        let png = png_path_for(&pass, now);
+        let audio = audio_path_for(&pass, now);
+        let png_stem = png.file_stem().unwrap().to_string_lossy().to_string();
+        let audio_stem = audio.file_stem().unwrap().to_string_lossy().to_string();
+        // Strip the prefix differences ("apt-" vs "audio-") and
+        // confirm the rest (slug + timestamp) matches verbatim.
+        let png_tail = png_stem.strip_prefix("apt-").unwrap();
+        let audio_tail = audio_stem.strip_prefix("audio-").unwrap();
+        assert_eq!(png_tail, audio_tail, "slug+timestamp must match");
+        // Extension differs, parent dir matches.
+        assert_eq!(png.parent(), audio.parent());
+        assert!(
+            audio
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("wav"))
+        );
+    }
+
+    #[test]
+    fn audio_toggle_off_does_not_emit_audio_actions() {
+        // Per #533: with the audio toggle off at AOS, the recorder
+        // must NOT emit StartAutoAudioRecord at AOS or
+        // StopAutoAudioRecord at LOS. PNG path is unaffected.
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+        // AOS with audio_record_on = false.
+        let aos_actions = r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        assert!(
+            aos_actions
+                .iter()
+                .any(|a| matches!(a, Action::StartAutoRecord { .. }))
+        );
+        assert!(
+            !aos_actions
+                .iter()
+                .any(|a| matches!(a, Action::StartAutoAudioRecord(_))),
+            "audio toggle off → no StartAutoAudioRecord",
+        );
+        // Settle + LOS — audio toggle flipped on mid-pass should
+        // NOT retroactively emit StartAutoAudioRecord, and there
+        // must be no StopAutoAudioRecord at LOS either (because
+        // we never started one).
+        let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        let los_plus = pass.end + ChronoDuration::seconds(1);
+        let los_actions = r.tick(los_plus, &[pass], true, true, default_tune());
+        assert!(los_actions.iter().any(|a| matches!(a, Action::SavePng(_))));
+        assert!(
+            !los_actions
+                .iter()
+                .any(|a| matches!(a, Action::StopAutoAudioRecord)),
+            "no audio recording was started → no StopAutoAudioRecord",
+        );
+    }
+
+    #[test]
+    fn audio_toggle_on_emits_paired_start_and_stop() {
+        // Per #533: audio_record_on at AOS emits
+        // StartAutoAudioRecord(path) alongside StartAutoRecord;
+        // LOS emits StopAutoAudioRecord alongside SavePng.
+        // The audio path must share the satellite slug with the
+        // PNG path the LOS emits.
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+        let aos_actions = r.tick(now, std::slice::from_ref(&pass), true, true, default_tune());
+        let audio_path = aos_actions.iter().find_map(|a| match a {
+            Action::StartAutoAudioRecord(p) => Some(p.clone()),
+            _ => None,
+        });
+        let audio_path = audio_path.expect("audio toggle on must emit StartAutoAudioRecord");
+        assert!(
+            audio_path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("audio-NOAA-19-")
+        );
+        // Settle then LOS — flipping the audio toggle off mid-
+        // pass should NOT cancel the in-flight stop. The stop
+        // fires at LOS unconditionally based on the captured
+        // audio_path.
+        let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        let los_plus = pass.end + ChronoDuration::seconds(1);
+        let los_actions = r.tick(los_plus, &[pass], true, false, default_tune());
+        assert!(los_actions.iter().any(|a| matches!(a, Action::SavePng(_))));
+        assert!(
+            los_actions
+                .iter()
+                .any(|a| matches!(a, Action::StopAutoAudioRecord)),
+            "in-flight audio recording must stop at LOS even after toggle flip",
         );
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8438,9 +8438,9 @@ fn connect_satellites_panel(
     use sidebar::satellites_panel::{
         KEY_STATION_ALT_M, KEY_STATION_LAT_DEG, KEY_STATION_LON_DEG, SatellitesPanelWeak,
         enumerate_upcoming_passes, format_downlink_mhz, format_last_refresh, format_pass_subtitle,
-        format_pass_title, load_auto_record_apt, load_station_alt_m, load_station_lat_deg,
-        load_station_lon_deg, save_auto_record_apt, save_f64, save_tle_last_refresh,
-        tune_target_for_pass,
+        format_pass_title, load_auto_record_apt, load_auto_record_audio, load_station_alt_m,
+        load_station_lat_deg, load_station_lon_deg, save_auto_record_apt, save_auto_record_audio,
+        save_f64, save_tle_last_refresh, tune_target_for_pass,
     };
     use sidebar::satellites_recorder::{
         Action as RecorderAction, AutoRecorder, SavedTune, ToastKind,
@@ -8472,6 +8472,9 @@ fn connect_satellites_panel(
     panel
         .auto_record_switch
         .set_active(load_auto_record_apt(config));
+    panel
+        .auto_record_audio_switch
+        .set_active(load_auto_record_audio(config));
     panel
         .last_refresh_row
         .set_subtitle(&format_last_refresh(config));
@@ -8622,6 +8625,18 @@ fn connect_satellites_panel(
         panel.auto_record_switch.connect_active_notify(move |sw| {
             save_auto_record_apt(&config_auto, sw.is_active());
         });
+    }
+
+    // "Also save audio" toggle — persist only. The recorder's
+    // 1 Hz tick samples this switch's `is_active()` at AOS.
+    // Per #533.
+    {
+        let config_audio = std::sync::Arc::clone(config);
+        panel
+            .auto_record_audio_switch
+            .connect_active_notify(move |sw| {
+                save_auto_record_audio(&config_audio, sw.is_active());
+            });
     }
 
     // Refresh button — re-download every known satellite's TLE on
@@ -8972,6 +8987,14 @@ fn connect_satellites_panel(
                     view.clear();
                 }
             }
+            RecorderAction::StartAutoAudioRecord(path) => {
+                tracing::info!("auto-record AOS: opening WAV writer at {path:?}");
+                state_a.send_dsp(UiToDsp::StartAudioRecording(path));
+            }
+            RecorderAction::StopAutoAudioRecord => {
+                tracing::info!("auto-record LOS: closing WAV writer");
+                state_a.send_dsp(UiToDsp::StopAudioRecording);
+            }
             RecorderAction::SavePng(path) => {
                 // Toast based on the *actual* export outcome
                 // rather than announcing success up front — the
@@ -9104,6 +9127,12 @@ fn connect_satellites_panel(
                 .map(|e| e.pass.clone())
                 .collect();
             let auto_record_on = panel.auto_record_switch.is_active();
+            // Per #533: the "also save audio" toggle is sampled
+            // exclusively at AOS by the state machine; flipping
+            // it mid-pass does NOT retroactively start or stop
+            // recording (matches `auto_record_on`'s
+            // "in-flight pass keeps running" semantics).
+            let audio_record_on = panel.auto_record_audio_switch.is_active();
             // Round f64 SpinRow value to u32 at the snapshot
             // boundary so SavedTune carries a clean integer for
             // the eventual restore — no per-restore rounding.
@@ -9123,10 +9152,13 @@ fn connect_satellites_panel(
                 was_running: state_tick.is_running.get(),
                 scanner_running: scanner_switch_tick.is_active(),
             };
-            let actions =
-                recorder_tick
-                    .borrow_mut()
-                    .tick(now, &passes_snapshot, auto_record_on, now_tune);
+            let actions = recorder_tick.borrow_mut().tick(
+                now,
+                &passes_snapshot,
+                auto_record_on,
+                audio_record_on,
+                now_tune,
+            );
             for action in actions {
                 interpret_tick(action);
             }


### PR DESCRIPTION
## Summary

Two paired fixes for the unattended overnight auto-record diagnostic flow:

- **#532**: WAV writer was post-volume → muted overnight passes wrote 200 MB of silence. Moved pre-volume so the recording captures what the demodulator produced, not what the speaker played.
- **#533**: New \"Also save audio (.wav)\" toggle in the Satellites panel. When on, AOS opens a WAV writer at \`~/sdr-recordings/audio-{slug}-{stamp}.wav\` paired with the existing PNG; LOS closes it cleanly. Toggle is sampled at AOS — flipping mid-pass doesn't leave a half-stopped writer.

Bundled because #533 alone would produce silent WAVs without #532. Together they enable paired (PNG, WAV) per pass for offline replay against future decoder revisions.

## What's in here

- \`crates/sdr-core/src/controller.rs\` — WAV write moved before the volume scaling loop.
- \`crates/sdr-ui/src/sidebar/satellites_panel.rs\` — second SwitchRow + KEY_AUTO_RECORD_AUDIO + load/save helpers.
- \`crates/sdr-ui/src/sidebar/satellites_recorder.rs\` — \`audio_record_on: bool\` plumbed through \`tick()\`; each in-flight state carries \`Option<PathBuf>\` for the audio artifact path. Two new actions: \`StartAutoAudioRecord(PathBuf)\` and \`StopAutoAudioRecord\`. New \`audio_path_for\` helper sharing slug+timestamp with PNG via a common \`pass_recording_path\`.
- \`crates/sdr-ui/src/window.rs\` — wire the new switch (load at startup, persist on change), thread \`audio_record_on\` into \`recorder.tick()\`, dispatch the two new Action variants to \`UiToDsp::StartAudioRecording\` / \`StopAudioRecording\`.

## Test plan

- [x] \`cargo test --workspace --features whisper-cpu\` — all green; 16 recorder tests (was 13, +3 new for audio path)
- [x] \`cargo clippy --all-targets --features whisper-cpu -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`make install CARGO_FLAGS=\"--release --features whisper-cuda\"\` — built clean
- [ ] Manual smoke: enable both toggles, mute volume, let an overnight pass run; verify saved WAV is non-silent (peak/rms > 0) and PNG+WAV filenames pair.

Closes #532, #533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent "Also save audio (.wav)" toggle to the Satellites panel so users can enable automatic WAV capture per pass.

* **Changes**
  * Recording now captures audio earlier in the pipeline (before volume scaling), preserving the recorded waveform independent of playback scaling.
  * PNG and WAV filenames are now generated together so images and audio share matching timestamps.

* **Tests**
  * Updated tests to ensure PNG/WAV pairing and correct behavior when toggling audio mid-pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->