### PR TITLE
sdr-lrpt: stage 2c FEC chain wiring + replay CLI (epic #469 task 5b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,12 +2778,15 @@ dependencies = [
 name = "sdr-lrpt"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "criterion",
  "image",
  "proptest",
+ "sdr-dsp",
  "sdr-types",
  "thiserror 2.0.18",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/sdr-lrpt/Cargo.toml
+++ b/crates/sdr-lrpt/Cargo.toml
@@ -7,9 +7,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+sdr-dsp.workspace = true
 sdr-types.workspace = true
+bytemuck.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+# Replay binary only — gate behind `[[bin]]` if this gets
+# heavyweight, but the env-filter feature keeps it lean.
+tracing-subscriber.workspace = true
 # PNG export for the per-channel + composite outputs. Local dep
 # rather than workspace because no other crate uses it yet; hoist
 # to workspace.dependencies if a second consumer arrives.
@@ -27,3 +32,10 @@ workspace = true
 [[bench]]
 name = "fec"
 harness = false
+
+# End-to-end IQ → image replay binary. Takes a captured IQ file
+# (complex<f32> interleaved at sdr_dsp::lrpt::SAMPLE_RATE_HZ),
+# drives the full LrptPipeline, and saves per-channel PNGs.
+[[bin]]
+name = "sdr-lrpt-replay"
+path = "src/bin/replay.rs"

--- a/crates/sdr-lrpt/src/bin/replay.rs
+++ b/crates/sdr-lrpt/src/bin/replay.rs
@@ -1,0 +1,136 @@
+//! `sdr-lrpt-replay` — decode a captured Meteor LRPT IQ file
+//! to per-channel PNGs.
+//!
+//! ```text
+//!   sdr-lrpt-replay <input.iq> <output_dir>
+//! ```
+//!
+//! Input format: complex<f32> interleaved (real, imag) at the
+//! Meteor LRPT working sample rate
+//! ([`sdr_dsp::lrpt::SAMPLE_RATE_HZ`] = 144 ksps). Bytes are
+//! `bytemuck::cast_slice`d straight into [`Complex`] pairs — no
+//! per-sample copy. Files captured by `sdr-cli record` at
+//! 144 ksps land in this format already.
+//!
+//! Output: one grayscale PNG per APID present in the recording
+//! (`<output_dir>/ch<apid>.png`) plus a default RGB composite
+//! (`<output_dir>/composite-rgb.png`) using APIDs 64/65/66 if
+//! all three are present.
+//!
+//! End-to-end smoke test for the full LRPT chain: IQ → QPSK
+//! demod ([`LrptDemod`]) → FEC chain ([`FecChain`] inside
+//! [`LrptPipeline::push_symbol`]) → CCSDS demux → JPEG decode
+//! → image assembly → PNG. A single binary that exercises
+//! every stage of epic #469.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use sdr_dsp::lrpt::LrptDemod;
+use sdr_lrpt::{
+    LrptPipeline,
+    image::{save_channel, save_composite},
+};
+use sdr_types::Complex;
+
+/// Bytes per IQ sample on disk: two f32s (real + imag).
+const IQ_SAMPLE_BYTES: usize = 8;
+
+/// Default RGB composite channel triple. Per the Meteor APID
+/// convention: 64 = blue (visible), 65 = green (visible-IR),
+/// 66 = red (near-IR). Composite written only when all three
+/// channels populated.
+const COMPOSITE_R_APID: u16 = 66;
+const COMPOSITE_G_APID: u16 = 65;
+const COMPOSITE_B_APID: u16 = 64;
+
+fn main() -> ExitCode {
+    // Initialise tracing so the chain's `tracing::trace!` /
+    // `tracing::warn!` lines surface during a replay run when
+    // RUST_LOG is set.
+    tracing_subscriber::fmt::try_init().ok();
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: sdr-lrpt-replay <input.iq> <output_dir>");
+        eprintln!();
+        eprintln!("input.iq:    interleaved complex<f32> @ 144 ksps");
+        eprintln!("output_dir:  one ch<APID>.png written per detected channel");
+        return ExitCode::from(2);
+    }
+    match run(&args[1], &PathBuf::from(&args[2])) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(in_path: &str, out_dir: &PathBuf) -> Result<(), String> {
+    std::fs::create_dir_all(out_dir).map_err(|e| format!("mkdir {}: {e}", out_dir.display()))?;
+
+    let iq_bytes = std::fs::read(in_path).map_err(|e| format!("read {in_path}: {e}"))?;
+    if iq_bytes.len() % IQ_SAMPLE_BYTES != 0 {
+        return Err(format!(
+            "input size {} is not a multiple of {IQ_SAMPLE_BYTES} (one complex<f32> = {IQ_SAMPLE_BYTES} bytes)",
+            iq_bytes.len(),
+        ));
+    }
+    let n_samples = iq_bytes.len() / IQ_SAMPLE_BYTES;
+    let samples: &[Complex] = bytemuck::cast_slice(&iq_bytes);
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "n_samples is bounded by file size; even hours-long captures stay below f64's 52-bit mantissa"
+    )]
+    let duration_s = n_samples as f64 / 144_000.0;
+    eprintln!("input: {n_samples} samples ({duration_s:.1} s @ 144 ksps)");
+
+    let mut demod = LrptDemod::new().map_err(|e| format!("LrptDemod::new: {e}"))?;
+    let mut pipeline = LrptPipeline::new();
+    let mut symbol_count = 0_u64;
+    for &sample in samples {
+        if let Some(soft) = demod.process(sample) {
+            pipeline.push_symbol(soft);
+            symbol_count += 1;
+        }
+    }
+    eprintln!("processed: {symbol_count} symbol pairs from {n_samples} IQ samples");
+
+    let assembler = pipeline.assembler();
+    let mut saved = 0_usize;
+    let mut apids: Vec<u16> = assembler.channels().map(|(&apid, _)| apid).collect();
+    apids.sort_unstable();
+    for apid in &apids {
+        let channel = assembler.channel(*apid).expect("listed apid must exist");
+        let path = out_dir.join(format!("ch{apid}.png"));
+        match save_channel(&path, channel) {
+            Ok(()) => {
+                eprintln!("saved {} ({}× lines)", path.display(), channel.lines);
+                saved += 1;
+            }
+            Err(e) => eprintln!("note: ch{apid} not saved ({e})"),
+        }
+    }
+    let composite_path = out_dir.join("composite-rgb.png");
+    match save_composite(
+        &composite_path,
+        assembler,
+        COMPOSITE_R_APID,
+        COMPOSITE_G_APID,
+        COMPOSITE_B_APID,
+    ) {
+        Ok(()) => {
+            eprintln!("saved {}", composite_path.display());
+            saved += 1;
+        }
+        Err(e) => eprintln!(
+            "note: composite-rgb (APIDs {COMPOSITE_R_APID}/{COMPOSITE_G_APID}/{COMPOSITE_B_APID}) not saved ({e})"
+        ),
+    }
+    eprintln!("total: {saved} PNGs in {}", out_dir.display());
+    if saved == 0 {
+        return Err("no PNGs written — likely no usable signal in the input IQ".into());
+    }
+    Ok(())
+}

--- a/crates/sdr-lrpt/src/bin/replay.rs
+++ b/crates/sdr-lrpt/src/bin/replay.rs
@@ -7,8 +7,9 @@
 //!
 //! Input format: complex<f32> interleaved (real, imag) at the
 //! Meteor LRPT working sample rate
-//! ([`sdr_dsp::lrpt::SAMPLE_RATE_HZ`] = 144 ksps). Bytes are
-//! `bytemuck::cast_slice`d straight into [`Complex`] pairs — no
+//! ([`sdr_dsp::lrpt::SAMPLE_RATE_HZ`] = 144 ksps). The file is
+//! streamed in fixed-size chunks via `BufReader`; each chunk is
+//! `bytemuck::cast_slice`d into [`Complex`] pairs in place — no
 //! per-sample copy. Files captured by `sdr-cli record` at
 //! 144 ksps land in this format already.
 //!
@@ -23,6 +24,8 @@
 //! → image assembly → PNG. A single binary that exercises
 //! every stage of epic #469.
 
+use std::fs::File;
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -35,6 +38,25 @@ use sdr_types::Complex;
 
 /// Bytes per IQ sample on disk: two f32s (real + imag).
 const IQ_SAMPLE_BYTES: usize = 8;
+
+/// CLI argv length: `sdr-lrpt-replay <input.iq> <output_dir>`
+/// = 3 elements (program name + 2 positional args).
+const EXPECTED_ARGC: usize = 3;
+
+/// Exit code for usage errors (missing args). Convention follows
+/// BSD `sysexits.h`: 64 = `EX_USAGE`. We use 2 here for parity
+/// with `getopts`-style tools (Python argparse, GNU getopt).
+const USAGE_EXIT_CODE: u8 = 2;
+
+/// Streaming chunk size for the IQ file reader. 64 KiB = 8192
+/// IQ samples per chunk: small enough to keep peak memory flat
+/// regardless of capture length (a 2-hour pass is ~8 GiB on
+/// disk; whole-file slurp would OOM), large enough to amortize
+/// syscall + bytemuck-cast overhead. Multiple of
+/// `IQ_SAMPLE_BYTES` so chunks split exactly on sample
+/// boundaries — no in-flight partial sample to carry over.
+const STREAM_CHUNK_BYTES: usize = 64 * 1024;
+const _: () = assert!(STREAM_CHUNK_BYTES.is_multiple_of(IQ_SAMPLE_BYTES));
 
 /// Default RGB composite channel triple. Per the Meteor APID
 /// convention: 64 = blue (visible), 65 = green (visible-IR),
@@ -51,12 +73,12 @@ fn main() -> ExitCode {
     tracing_subscriber::fmt::try_init().ok();
 
     let args: Vec<String> = std::env::args().collect();
-    if args.len() != 3 {
+    if args.len() != EXPECTED_ARGC {
         eprintln!("usage: sdr-lrpt-replay <input.iq> <output_dir>");
         eprintln!();
-        eprintln!("input.iq:    interleaved complex<f32> @ 144 ksps");
+        eprintln!("input.iq:    interleaved complex<f32> @ {SAMPLE_RATE_HZ} Hz");
         eprintln!("output_dir:  one ch<APID>.png written per detected channel");
-        return ExitCode::from(2);
+        return ExitCode::from(USAGE_EXIT_CODE);
     }
     match run(&args[1], &PathBuf::from(&args[2])) {
         Ok(()) => ExitCode::SUCCESS,
@@ -70,39 +92,68 @@ fn main() -> ExitCode {
 fn run(in_path: &str, out_dir: &Path) -> Result<(), String> {
     std::fs::create_dir_all(out_dir).map_err(|e| format!("mkdir {}: {e}", out_dir.display()))?;
 
-    let iq_bytes = std::fs::read(in_path).map_err(|e| format!("read {in_path}: {e}"))?;
-    if iq_bytes.len() % IQ_SAMPLE_BYTES != 0 {
-        return Err(format!(
-            "input size {} is not a multiple of {IQ_SAMPLE_BYTES} (one complex<f32> = {IQ_SAMPLE_BYTES} bytes)",
-            iq_bytes.len(),
-        ));
-    }
-    let n_samples = iq_bytes.len() / IQ_SAMPLE_BYTES;
-    let samples: &[Complex] = bytemuck::cast_slice(&iq_bytes);
-    #[allow(
-        clippy::cast_precision_loss,
-        reason = "n_samples is bounded by file size; even hours-long captures stay below f64's 52-bit mantissa"
-    )]
-    let duration_s = n_samples as f64 / f64::from(SAMPLE_RATE_HZ);
-    eprintln!("input: {n_samples} samples ({duration_s:.1} s @ {SAMPLE_RATE_HZ} Hz)");
+    let file = File::open(in_path).map_err(|e| format!("open {in_path}: {e}"))?;
+    let mut reader = BufReader::new(file);
 
     let mut demod = LrptDemod::new().map_err(|e| format!("LrptDemod::new: {e}"))?;
     let mut pipeline = LrptPipeline::new();
+    let mut buf = vec![0_u8; STREAM_CHUNK_BYTES];
+    let mut total_samples = 0_u64;
     let mut symbol_count = 0_u64;
-    for &sample in samples {
-        if let Some(soft) = demod.process(sample) {
-            pipeline.push_symbol(soft);
-            symbol_count += 1;
+    loop {
+        // Read up to STREAM_CHUNK_BYTES. Chunks at end-of-file
+        // may be short; only multiples of IQ_SAMPLE_BYTES are
+        // processed and the trailing partial sample (if any)
+        // gets reported as an alignment error after the loop.
+        let n = reader
+            .read(&mut buf)
+            .map_err(|e| format!("read {in_path}: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        let aligned = n - (n % IQ_SAMPLE_BYTES);
+        let samples: &[Complex] = bytemuck::cast_slice(&buf[..aligned]);
+        for &sample in samples {
+            if let Some(soft) = demod.process(sample) {
+                pipeline.push_symbol(soft);
+                symbol_count += 1;
+            }
+        }
+        total_samples += (aligned / IQ_SAMPLE_BYTES) as u64;
+        // If the read was short AND alignment trimmed bytes off,
+        // the file's last partial sample is invalid.
+        if n != STREAM_CHUNK_BYTES && n != aligned {
+            return Err(format!(
+                "input {in_path} has {n_partial} trailing bytes that don't form a complete sample (need a multiple of {IQ_SAMPLE_BYTES})",
+                n_partial = n - aligned,
+            ));
         }
     }
-    eprintln!("processed: {symbol_count} symbol pairs from {n_samples} IQ samples");
+
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "total_samples is bounded by file size; even hours-long captures stay below f64's 52-bit mantissa"
+    )]
+    let duration_s = total_samples as f64 / f64::from(SAMPLE_RATE_HZ);
+    eprintln!("input: {total_samples} samples ({duration_s:.1} s @ {SAMPLE_RATE_HZ} Hz)");
+    eprintln!("processed: {symbol_count} symbol pairs from {total_samples} IQ samples");
 
     let assembler = pipeline.assembler();
     let mut saved = 0_usize;
     let mut apids: Vec<u16> = assembler.channels().map(|(&apid, _)| apid).collect();
     apids.sort_unstable();
     for apid in &apids {
-        let channel = assembler.channel(*apid).expect("listed apid must exist");
+        // Defensive lookup: the assembler's channel set could
+        // theoretically change between the `apids` enumeration
+        // and this read in a future refactor that adds another
+        // path mutating it. Today there's only one writer (the
+        // single-threaded loop above), but skipping silently is
+        // cheap and keeps the binary robust against future
+        // changes. Per CR round 2 on PR #540.
+        let Some(channel) = assembler.channel(*apid) else {
+            tracing::warn!("APID {apid} disappeared during export; skipping");
+            continue;
+        };
         let path = out_dir.join(format!("ch{apid}.png"));
         match save_channel(&path, channel) {
             Ok(()) => {

--- a/crates/sdr-lrpt/src/bin/replay.rs
+++ b/crates/sdr-lrpt/src/bin/replay.rs
@@ -23,10 +23,10 @@
 //! → image assembly → PNG. A single binary that exercises
 //! every stage of epic #469.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use sdr_dsp::lrpt::LrptDemod;
+use sdr_dsp::lrpt::{LrptDemod, SAMPLE_RATE_HZ};
 use sdr_lrpt::{
     LrptPipeline,
     image::{save_channel, save_composite},
@@ -67,7 +67,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(in_path: &str, out_dir: &PathBuf) -> Result<(), String> {
+fn run(in_path: &str, out_dir: &Path) -> Result<(), String> {
     std::fs::create_dir_all(out_dir).map_err(|e| format!("mkdir {}: {e}", out_dir.display()))?;
 
     let iq_bytes = std::fs::read(in_path).map_err(|e| format!("read {in_path}: {e}"))?;
@@ -83,8 +83,8 @@ fn run(in_path: &str, out_dir: &PathBuf) -> Result<(), String> {
         clippy::cast_precision_loss,
         reason = "n_samples is bounded by file size; even hours-long captures stay below f64's 52-bit mantissa"
     )]
-    let duration_s = n_samples as f64 / 144_000.0;
-    eprintln!("input: {n_samples} samples ({duration_s:.1} s @ 144 ksps)");
+    let duration_s = n_samples as f64 / f64::from(SAMPLE_RATE_HZ);
+    eprintln!("input: {n_samples} samples ({duration_s:.1} s @ {SAMPLE_RATE_HZ} Hz)");
 
     let mut demod = LrptDemod::new().map_err(|e| format!("LrptDemod::new: {e}"))?;
     let mut pipeline = LrptPipeline::new();

--- a/crates/sdr-lrpt/src/fec/chain.rs
+++ b/crates/sdr-lrpt/src/fec/chain.rs
@@ -1,0 +1,320 @@
+//! End-to-end FEC chain — soft i8 symbol pairs in, decoded VCDU
+//! bytes out.
+//!
+//! Stitches the per-stage primitives ([`ViterbiDecoder`],
+//! [`SyncCorrelator`], [`Derandomizer`], [`ReedSolomon`]) into a
+//! single streaming state machine matching medet's `try_frame`
+//! flow:
+//!
+//! ```text
+//!   soft i8 pair ─▶ Viterbi ─bit▶ Sync correlator ─bit▶ {hunting | capturing}
+//!                                                                   │
+//!                          ASM hit                                  │
+//!                                                                   ▼
+//!                                                       1020-byte CADU buffer
+//!                                                                   │
+//!                                                                   ▼
+//!                                          derandomize  → de-interleave (×4)
+//!                                                                   │
+//!                                                                   ▼
+//!                                       RS-decode each codeword (255 → 223 bytes)
+//!                                                                   │
+//!                                                                   ▼
+//!                                          re-interleave → 892-byte VCDU
+//! ```
+//!
+//! Layered like this so [`LrptPipeline::push_symbol`] can be a
+//! thin wrapper that drives the chain and feeds emitted VCDUs
+//! into the existing demux + image stages, while the chain
+//! itself stays unit-testable on synthetic byte streams.
+
+use crate::fec::{Derandomizer, ReedSolomon, SyncCorrelator, ViterbiDecoder};
+
+/// Bytes captured per CADU after the ASM. Per CCSDS §10:
+/// 1024-byte CADU = 4-byte ASM + 1020-byte payload. The ASM is
+/// already consumed by the [`SyncCorrelator`] so the payload
+/// length is what we capture.
+const CADU_PAYLOAD_LEN: usize = 1020;
+
+/// CCSDS RS interleaving depth for Meteor LRPT. Each 1020-byte
+/// CADU payload is 4 byte-byte-interleaved Reed-Solomon
+/// codewords. Per medet's `ecc_deinterleave(... n=4)`.
+const RS_INTERLEAVE: usize = 4;
+
+/// Reed-Solomon codeword length (bytes). 4 × 255 = 1020 = full
+/// CADU payload.
+const RS_CODEWORD_LEN: usize = 255;
+
+/// Reed-Solomon message length (bytes). 4 × 223 = 892 = VCDU
+/// length.
+const RS_MESSAGE_LEN: usize = 223;
+
+/// Output VCDU length in bytes — the value the
+/// [`super::super::ccsds::Demux`] expects per VCDU.
+const VCDU_LEN: usize = RS_INTERLEAVE * RS_MESSAGE_LEN; // 892
+
+/// Per-bit chain state. Hunting until ASM, then capturing 1020
+/// bytes worth of CADU payload.
+#[derive(Debug)]
+enum State {
+    /// Looking for the ASM in the post-Viterbi bit stream.
+    Hunting,
+    /// ASM matched; capturing the next [`CADU_PAYLOAD_LEN`]
+    /// bytes of payload, packing 8 bits at a time. `partial` /
+    /// `partial_count` accumulate the in-flight byte; `bytes`
+    /// holds the completed bytes.
+    Capturing {
+        bytes: Vec<u8>,
+        partial: u8,
+        partial_count: u8,
+    },
+}
+
+/// Streaming FEC chain — push one soft i8 symbol pair per call,
+/// receive a decoded VCDU when one becomes available.
+pub struct FecChain {
+    viterbi: ViterbiDecoder,
+    sync: SyncCorrelator,
+    derand: Derandomizer,
+    rs: ReedSolomon,
+    state: State,
+}
+
+impl Default for FecChain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FecChain {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            viterbi: ViterbiDecoder::new(),
+            sync: SyncCorrelator::new(),
+            derand: Derandomizer::new(),
+            rs: ReedSolomon::new(),
+            state: State::Hunting,
+        }
+    }
+
+    /// Push one soft i8 symbol pair (one Viterbi-encoded bit's
+    /// worth from the demod). Returns `Some(VCDU bytes)` on the
+    /// call that completes a successful CADU decode; otherwise
+    /// `None`. Failed RS decodes are silently dropped — the
+    /// chain returns to hunting for the next ASM.
+    pub fn push_symbol(&mut self, soft: [i8; 2]) -> Option<Vec<u8>> {
+        let bit = self.viterbi.step(soft)?;
+        self.process_bit(bit)
+    }
+
+    /// Reset the entire chain to a fresh state. Called between
+    /// passes. Per-stage internals (Viterbi traceback, sync
+    /// window, derand position) all flush; in-flight CADU
+    /// capture is dropped.
+    pub fn reset(&mut self) {
+        self.viterbi = ViterbiDecoder::new();
+        self.sync = SyncCorrelator::new();
+        self.derand.reset();
+        self.state = State::Hunting;
+    }
+
+    fn process_bit(&mut self, bit: u8) -> Option<Vec<u8>> {
+        match &mut self.state {
+            State::Hunting => {
+                if self.sync.push(bit).is_some() {
+                    self.state = State::Capturing {
+                        bytes: Vec::with_capacity(CADU_PAYLOAD_LEN),
+                        partial: 0,
+                        partial_count: 0,
+                    };
+                }
+                None
+            }
+            State::Capturing {
+                bytes,
+                partial,
+                partial_count,
+            } => {
+                *partial = (*partial << 1) | (bit & 1);
+                *partial_count += 1;
+                if *partial_count == 8 {
+                    bytes.push(*partial);
+                    *partial = 0;
+                    *partial_count = 0;
+                }
+                if bytes.len() == CADU_PAYLOAD_LEN {
+                    let cadu = std::mem::take(bytes);
+                    self.state = State::Hunting;
+                    return self.decode_cadu(cadu);
+                }
+                None
+            }
+        }
+    }
+
+    /// Decode one captured CADU payload: derandomize, de-interleave
+    /// the 4 Reed-Solomon codewords, decode each, re-interleave the
+    /// corrected message portions into a 892-byte VCDU. Returns
+    /// `None` if any of the 4 codewords fails to decode (matches
+    /// medet's all-or-nothing acceptance per `try_frame`).
+    fn decode_cadu(&mut self, mut cadu: Vec<u8>) -> Option<Vec<u8>> {
+        debug_assert_eq!(cadu.len(), CADU_PAYLOAD_LEN);
+        // Step 1: derandomize. PN sequence restarts at every
+        // CADU boundary per spec; reset before consuming.
+        self.derand.reset();
+        for byte in &mut cadu {
+            *byte = self.derand.process(*byte);
+        }
+        // Step 2 + 3 + 4: per RS interleave column, extract one
+        // codeword, decode, write the corrected message bytes
+        // back into the VCDU at the same interleave column.
+        let mut vcdu = vec![0_u8; VCDU_LEN];
+        for col in 0..RS_INTERLEAVE {
+            let mut codeword = [0_u8; RS_CODEWORD_LEN];
+            for i in 0..RS_CODEWORD_LEN {
+                codeword[i] = cadu[i * RS_INTERLEAVE + col];
+            }
+            let (corrected, _errors) = self.rs.decode(&codeword).ok()?;
+            for i in 0..RS_MESSAGE_LEN {
+                vcdu[i * RS_INTERLEAVE + col] = corrected[i];
+            }
+        }
+        Some(vcdu)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Total bits in a CADU including the 32-bit ASM. Used by
+    /// the tests below to size the synthetic bit streams.
+    const CADU_TOTAL_BITS: usize = 32 + CADU_PAYLOAD_LEN * 8;
+
+    #[test]
+    fn fec_chain_constructible_and_resets() {
+        let mut c = FecChain::new();
+        assert!(matches!(c.state, State::Hunting));
+        c.reset();
+        assert!(matches!(c.state, State::Hunting));
+    }
+
+    #[test]
+    fn fec_chain_returns_none_during_warmup() {
+        // Viterbi needs TRACEBACK_DEPTH symbol pairs before it
+        // emits its first bit. Until then, push_symbol must
+        // return None on every call.
+        let mut c = FecChain::new();
+        for _ in 0..10 {
+            let result = c.push_symbol([0, 0]);
+            assert!(result.is_none());
+        }
+    }
+
+    /// Pump a full clean ASM bit pattern through the chain's
+    /// `process_bit` (skipping Viterbi). After ASM the next
+    /// 1020 bytes are zeros (which derand will XOR to PN, then
+    /// RS will fail on because zeros aren't a valid codeword).
+    /// We're not testing the VCDU contents — just that the
+    /// state machine cleanly transitions Hunting → Capturing
+    /// → Hunting without a panic.
+    #[test]
+    fn process_bit_state_machine_transitions_after_asm() {
+        let mut c = FecChain::new();
+        // Push the ASM bits one at a time, MSB-first.
+        let asm = crate::fec::ASM;
+        for i in 0..32 {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "ASM is u32; shift index 0..32 is safe"
+            )]
+            let bit = ((asm >> (31 - i)) & 1) as u8;
+            let _ = c.process_bit(bit);
+        }
+        // After ASM the chain must be capturing.
+        assert!(matches!(c.state, State::Capturing { .. }));
+        // Push 1020 × 8 zero bits to fill the CADU buffer.
+        for _ in 0..(CADU_PAYLOAD_LEN * 8) {
+            let _ = c.process_bit(0);
+        }
+        // CADU complete → decode_cadu attempted → returned to
+        // Hunting (whether RS succeeded or not).
+        assert!(matches!(c.state, State::Hunting));
+    }
+
+    #[test]
+    fn decode_cadu_returns_none_on_invalid_codeword() {
+        // Hand-construct a CADU payload that's all zeros. After
+        // derand it becomes the PN sequence, which is not a
+        // valid RS codeword — every column should fail to decode
+        // and the chain should return None.
+        let mut c = FecChain::new();
+        let cadu = vec![0_u8; CADU_PAYLOAD_LEN];
+        assert!(c.decode_cadu(cadu).is_none());
+    }
+
+    #[test]
+    fn decode_cadu_round_trips_clean_rs_encoded_data() {
+        // Build a synthetic CADU from scratch:
+        //   1. Pick 892 bytes of "VCDU" content
+        //   2. De-interleave (split into 4 × 223-byte messages)
+        //   3. RS-encode each message → 4 × 255-byte codewords
+        //   4. Interleave into a 1020-byte CADU payload
+        //   5. Apply derand (XOR with PN) so when the chain's
+        //      derand undoes it, we recover the encoded form
+        //
+        // Then push that synthetic CADU through `decode_cadu`
+        // and assert we recover the original 892-byte VCDU.
+        let rs = ReedSolomon::new();
+        // Distinct, non-uniform VCDU content so any byte-order
+        // bug surfaces visibly.
+        let mut original_vcdu = vec![0_u8; VCDU_LEN];
+        for (i, b) in original_vcdu.iter_mut().enumerate() {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "modulo 256 fits in u8 by definition"
+            )]
+            let byte = ((i * 7 + 11) % 256) as u8;
+            *b = byte;
+        }
+        // De-interleave VCDU into 4 message buffers.
+        let mut messages = [[0_u8; RS_MESSAGE_LEN]; RS_INTERLEAVE];
+        for col in 0..RS_INTERLEAVE {
+            for i in 0..RS_MESSAGE_LEN {
+                messages[col][i] = original_vcdu[i * RS_INTERLEAVE + col];
+            }
+        }
+        // RS-encode each message.
+        let codewords: Vec<[u8; RS_CODEWORD_LEN]> = messages.iter().map(|m| rs.encode(m)).collect();
+        // Interleave back into 1020-byte CADU payload.
+        let mut cadu_payload = vec![0_u8; CADU_PAYLOAD_LEN];
+        for col in 0..RS_INTERLEAVE {
+            for i in 0..RS_CODEWORD_LEN {
+                cadu_payload[i * RS_INTERLEAVE + col] = codewords[col][i];
+            }
+        }
+        // Apply derand (XOR with PN) so the chain's derand
+        // (which XORs again with PN) recovers `cadu_payload`.
+        let mut derand = Derandomizer::new();
+        derand.reset();
+        for byte in &mut cadu_payload {
+            *byte = derand.process(*byte);
+        }
+        // Now feed into the chain's decode path and confirm we
+        // get the original VCDU back.
+        let mut c = FecChain::new();
+        let recovered = c
+            .decode_cadu(cadu_payload)
+            .expect("clean RS-encoded CADU must decode");
+        assert_eq!(recovered, original_vcdu);
+    }
+
+    #[test]
+    fn cadu_total_bits_matches_protocol_constant() {
+        // 1024-byte CADU = 32-bit ASM + 1020 bytes payload =
+        // 32 + 8160 = 8192 bits. Pin so a future constant tweak
+        // that breaks the protocol layout fails loudly.
+        assert_eq!(CADU_TOTAL_BITS, 8192);
+    }
+}

--- a/crates/sdr-lrpt/src/fec/mod.rs
+++ b/crates/sdr-lrpt/src/fec/mod.rs
@@ -11,11 +11,13 @@
 //! This PR (Task 2) ships [`ViterbiDecoder`], [`SyncCorrelator`],
 //! and [`Derandomizer`]. Reed-Solomon lands in Task 3.
 
+pub mod chain;
 pub mod derand;
 pub mod reed_solomon;
 pub mod sync;
 pub mod viterbi;
 
+pub use chain::FecChain;
 pub use derand::Derandomizer;
 pub use reed_solomon::{K as RS_K, N as RS_N, ReedSolomon, RsError, T as RS_T};
 pub use sync::{ASM, ASM_BITS, SYNC_THRESHOLD, SyncCorrelator};

--- a/crates/sdr-lrpt/src/lib.rs
+++ b/crates/sdr-lrpt/src/lib.rs
@@ -26,6 +26,7 @@ pub mod fec;
 pub mod image;
 
 use crate::ccsds::{Demux, ImagePacket};
+use crate::fec::FecChain;
 use crate::image::{ImageAssembler, JpegDecoder, MCUS_PER_LINE, fill_dqt};
 
 /// MCUs encoded per Meteor LRPT image packet. Per medet's
@@ -94,6 +95,7 @@ impl ChannelDecoder {
 /// or saves PNGs at LOS via [`crate::image::save_channel`] /
 /// [`crate::image::save_composite`].
 pub struct LrptPipeline {
+    fec: FecChain,
     demux: Demux,
     decoders: std::collections::HashMap<u16, ChannelDecoder>,
     assembler: ImageAssembler,
@@ -109,14 +111,30 @@ impl LrptPipeline {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            fec: FecChain::new(),
             demux: Demux::new(),
             decoders: std::collections::HashMap::new(),
             assembler: ImageAssembler::new(),
         }
     }
 
+    /// Push one soft-symbol pair from the QPSK demod through the
+    /// full FEC chain. When the chain emits a complete VCDU
+    /// (Viterbi → ASM sync → derand → RS-decode), it's
+    /// immediately routed through demux + image assembly.
+    /// Caller-friendly: one call per demod output, no buffering
+    /// required at the call site.
+    pub fn push_symbol(&mut self, soft: [i8; 2]) {
+        if let Some(vcdu) = self.fec.push_symbol(soft) {
+            self.push_vcdu(&vcdu);
+        }
+    }
+
     /// Push one [`VCDU_TOTAL_LEN`]-byte VCDU. Drives demux →
     /// per-channel JPEG decode → image-assembler placement.
+    /// Public so the [`crate::fec::FecChain`] CLI replay path
+    /// (and tests with synthetic VCDUs) can skip the FEC stage
+    /// entirely.
     pub fn push_vcdu(&mut self, vcdu_bytes: &[u8]) {
         for packet in self.demux.push(vcdu_bytes) {
             self.consume_packet(&packet);
@@ -272,6 +290,7 @@ impl LrptPipeline {
     /// Reset the pipeline (clear all state). Called between
     /// passes when the recorder fires `RestoreTune`.
     pub fn reset(&mut self) {
+        self.fec.reset();
         self.demux = Demux::new();
         self.decoders.clear();
         self.assembler.clear();


### PR DESCRIPTION
## Summary

End-to-end wiring of the post-demod FEC layers, plus the \`sdr-lrpt-replay\` CLI smoke test. With this PR, soft i8 symbol pairs from \`sdr_dsp::lrpt::LrptDemod\` flow through the full chain — Viterbi → ASM sync → CADU capture → derand → CCSDS depth-4 RS de-interleave → 892-byte VCDU emit → existing image-assembly pipeline — and out as PNGs.

This is the chunk I deferred from PR #531 / Task 5; it completes the ingestion path so the LRPT crate can decode IQ end-to-end.

## What's in here

- **\`crates/sdr-lrpt/src/fec/chain.rs\` (new)** — \`FecChain\` struct: streaming bit-level state machine matching medet's \`try_frame\` flow (\`original/medet/met_to_data.pas:115\`). Hunting → ASM hit → Capturing 1020 bytes → derand + RS-decode + emit VCDU → back to Hunting. All-or-nothing acceptance (all 4 RS codewords must succeed) matching medet's \`try_frame\` return logic.
- **\`crates/sdr-lrpt/src/lib.rs\`** — \`LrptPipeline\` gains a \`FecChain\` field and a \`push_symbol(soft: [i8; 2])\` entry point. Emitted VCDUs route into existing \`push_vcdu\` so demux + JPEG decode + image assembly all reuse the previously-shipped path.
- **\`crates/sdr-lrpt/src/bin/replay.rs\` (new)** — \`sdr-lrpt-replay\` CLI binary: \`<input.iq> <output_dir>\` → per-channel PNGs + default RGB composite. Uses \`bytemuck::cast_slice\` to read IQ pairs zero-copy.

## Test plan

- [x] \`cargo test -p sdr-lrpt\` — 94 pass (was 88), 6 new FecChain tests including a defining round-trip that proves the encode-deinterleave-decode-reinterleave math.
- [x] \`cargo clippy --all-targets --features whisper-cpu -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo llvm-cov --package sdr-lrpt --summary-only\` — 93.71% region / 93.43% line (above 90% gate). FecChain itself at 94.66% / 97.10%.
- [x] Smoke test the binary on synthetic zero IQ: chain runs end-to-end without crashing, correctly emits "no usable signal" when no CADUs land.
- [ ] Manual smoke on a real captured Meteor IQ file (when available) — not blocking this PR; that's part of Task 7's live integration work.

## What's still ahead in the LRPT epic

- **Task 6**: auto-record generalization — add LRPT entries to the satellite catalog with their own demod/bandwidth, reuse the existing auto-record state machine for them.
- **Task 7**: end-to-end live integration — wire \`push_symbol\` into the live IQ tap, build the LRPT live viewer in \`sdr-ui\`, mirror the APT viewer's Pause / Export buttons.
- **Task 8**: docs walkthrough closing #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an sdr-lrpt-replay CLI to decode LRPT IQ captures into per-channel PNGs and a composite RGB image, with runtime logging and summary output.
  * Integrated FEC processing into the decoding pipeline to improve reliability and increase successful image recovery.
* **Tests**
  * Added unit tests validating FEC state transitions, warmup, error handling, and encode/decode round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->