### PR TITLE
sdr-sat,sdr-ui: catalog-driven auto-record dispatch via ImagingProtocol (closes #514)

### DIFF
--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -53,6 +53,29 @@ pub const IMAGING_BAND_MIN_HZ: u64 = 137_000_000;
 /// VHF imaging-band upper bound (Hz). See [`IMAGING_BAND_MIN_HZ`].
 pub const IMAGING_BAND_MAX_HZ: u64 = 148_000_000;
 
+/// Imaging protocol the receiver should use for a given catalog
+/// satellite. Drives the auto-record dispatch in
+/// `sidebar::satellites_recorder` so APT vs LRPT vs SSTV (future)
+/// each get their own decoder + viewer without the recorder
+/// itself caring about protocol details.
+///
+/// `None` on a [`KnownSatellite::imaging_protocol`] means "in the
+/// catalog for pass-prediction display purposes, but auto-record
+/// is not yet wired for this satellite's protocol." The recorder's
+/// eligibility filter excludes those entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImagingProtocol {
+    /// NOAA Automatic Picture Transmission (analog FM with 2.4 kHz
+    /// AM subcarrier on 137 MHz). Decoded by `sdr_dsp::apt::AptDecoder`
+    /// + assembled by `sdr_radio::apt_image::AptImage`.
+    Apt,
+    /// Meteor-M Low-Rate Picture Transmission (QPSK + CCSDS framing
+    /// on 137 MHz). Decoded by `sdr_dsp::lrpt::LrptDemod` +
+    /// `sdr_lrpt::LrptPipeline`. Wiring lands in Task 7 (epic #469).
+    Lrpt,
+    // Sstv variant added in epic #472 for ISS SSTV reception.
+}
+
 /// A satellite the user-facing scheduler ships with by default. The list
 /// is intentionally tight — we want passes to "just work" for the most
 /// common LEO weather / ham satellites without making the user paste
@@ -89,6 +112,15 @@ pub struct KnownSatellite {
     /// dispatch a `SetBandwidth` without re-deriving the value from
     /// signal type.
     pub bandwidth_hz: u32,
+    /// Imaging protocol for auto-record dispatch. `None` means the
+    /// satellite is in the catalog for pass-prediction display
+    /// (so the user sees upcoming passes and can manually tune)
+    /// but the auto-record path doesn't have a decoder + viewer
+    /// for it yet. NOAA APT shipped in epic #468; Meteor LRPT
+    /// flips from `None` to `Some(Lrpt)` in Task 7 of epic #469
+    /// alongside the live LRPT viewer; ISS SSTV gets `Some(Sstv)`
+    /// in epic #472.
+    pub imaging_protocol: Option<ImagingProtocol>,
 }
 
 /// Built-in catalog. Order is the order the scheduler UI displays.
@@ -100,6 +132,7 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         downlink_hz: 137_620_000,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+        imaging_protocol: Some(ImagingProtocol::Apt),
     },
     KnownSatellite {
         name: "NOAA 18",
@@ -107,6 +140,7 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         downlink_hz: 137_912_500,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+        imaging_protocol: Some(ImagingProtocol::Apt),
     },
     KnownSatellite {
         name: "NOAA 19",
@@ -114,16 +148,21 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         downlink_hz: 137_100_000,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+        imaging_protocol: Some(ImagingProtocol::Apt),
     },
     // Meteor-M LRPT — epic #469. Note: METEOR-M 2 and NOAA 19 share
     // the 137.100 MHz channel — they're never on simultaneously by
     // design. The pass scheduler picks whichever is overhead.
+    // `imaging_protocol: None` keeps these out of the auto-record
+    // flow until Task 7 wires the live LRPT viewer; user can still
+    // see upcoming passes in the panel.
     KnownSatellite {
         name: "METEOR-M 2",
         norad_id: 40_069,
         downlink_hz: 137_100_000,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+        imaging_protocol: None,
     },
     KnownSatellite {
         name: "METEOR-M2 3",
@@ -131,6 +170,7 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         downlink_hz: 137_900_000,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+        imaging_protocol: None,
     },
     // METEOR-M2 4 (NORAD 61024) deliberately omitted — launched 2024,
     // failed shortly after, no usable TLE on Celestrak (404 from the
@@ -138,12 +178,15 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     // ISS SSTV — epic #472. 145.800 MHz is the primary downlink for
     // SSTV transmission events and the ARISS voice repeater; both
     // ride wide-FM and use the same tune-and-listen flow.
+    // `imaging_protocol: None` until epic #472 ships the SSTV
+    // decoder + viewer.
     KnownSatellite {
         name: "ISS (ZARYA)",
         norad_id: 25_544,
         downlink_hz: 145_800_000,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
+        imaging_protocol: None,
     },
 ];
 
@@ -206,5 +249,50 @@ mod tests {
                 IMAGING_BAND_MAX_HZ,
             );
         }
+    }
+
+    #[test]
+    fn known_satellites_have_expected_protocol_assignments() {
+        // Pin the catalog's protocol assignments so a future
+        // catalog edit can't silently change the auto-record
+        // dispatch. The recorder's eligibility filter keys on
+        // `imaging_protocol.is_some()`, so flipping a satellite
+        // from None → Some (or vice versa) IS a behavior change
+        // that should fail this test.
+        //
+        // NOAA satellites → Apt (shipped in epic #468 / PR #513).
+        for s in KNOWN_SATELLITES
+            .iter()
+            .filter(|s| s.name.starts_with("NOAA"))
+        {
+            assert_eq!(
+                s.imaging_protocol,
+                Some(ImagingProtocol::Apt),
+                "{} should be APT (NOAA APT shipped in epic #468)",
+                s.name,
+            );
+        }
+        // METEOR satellites → None for this PR. Task 7 of epic
+        // #469 flips them to Some(Lrpt) once the live LRPT
+        // viewer + decoder driver are wired.
+        for s in KNOWN_SATELLITES
+            .iter()
+            .filter(|s| s.name.starts_with("METEOR"))
+        {
+            assert_eq!(
+                s.imaging_protocol, None,
+                "{} should be None until Task 7 of epic #469",
+                s.name,
+            );
+        }
+        // ISS → None. Becomes Some(Sstv) in epic #472.
+        let iss = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.name.contains("ISS"))
+            .expect("ISS in catalog");
+        assert_eq!(
+            iss.imaging_protocol, None,
+            "ISS should be None until epic #472"
+        );
     }
 }

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -609,15 +609,39 @@ pub fn downlink_hz_for_pass(pass: &Pass) -> Option<u64> {
     known_satellite_for_pass(pass).map(|s| s.downlink_hz)
 }
 
-/// The full tuning triple — frequency, demod mode, channel
-/// bandwidth — for a given pass's satellite. Returned as a tuple
-/// to keep the call site simple (the play-button wiring layer
-/// destructures it directly into the three `UiToDsp` setters).
-/// `None` for the same off-catalog reason as
+/// The full tuning quadruple — frequency, demod mode, channel
+/// bandwidth, imaging protocol — for a given pass's satellite.
+/// Returned as a tuple to keep the call site simple (the
+/// play-button wiring layer destructures it directly into the
+/// three `UiToDsp` setters; the recorder filters on the
+/// fourth element).
+///
+/// The fourth element is `Option<ImagingProtocol>` so the play
+/// button stays available on every catalog satellite (manual
+/// tune is a user-initiated action). The recorder, in contrast,
+/// only fires on satellites whose protocol is `Some(_)` — that
+/// gate replaces the prior hardcoded `is_apt_capable` filter.
+///
+/// Returns `None` only when the pass's satellite isn't in
+/// [`KNOWN_SATELLITES`] at all (off-catalog), same condition as
 /// [`downlink_hz_for_pass`].
 #[must_use]
-pub fn tune_target_for_pass(pass: &Pass) -> Option<(u64, sdr_types::DemodMode, u32)> {
-    known_satellite_for_pass(pass).map(|s| (s.downlink_hz, s.demod_mode, s.bandwidth_hz))
+pub fn tune_target_for_pass(
+    pass: &Pass,
+) -> Option<(
+    u64,
+    sdr_types::DemodMode,
+    u32,
+    Option<sdr_sat::ImagingProtocol>,
+)> {
+    known_satellite_for_pass(pass).map(|s| {
+        (
+            s.downlink_hz,
+            s.demod_mode,
+            s.bandwidth_hz,
+            s.imaging_protocol,
+        )
+    })
 }
 
 /// Format a Hz frequency as a fixed-precision MHz string with
@@ -964,18 +988,35 @@ mod tests {
     }
 
     #[test]
-    fn tune_target_for_pass_returns_full_tuning_triple() {
-        // Pin the (downlink_hz, demod_mode, bandwidth_hz) triple
-        // for a known catalog entry. A future refactor that splits
-        // or reorders the tuple — or that drifts the catalog
-        // values — fails here before reaching the play-button
-        // wiring layer.
+    fn tune_target_for_pass_returns_full_tuning_quadruple() {
+        // Pin the (downlink_hz, demod_mode, bandwidth_hz,
+        // imaging_protocol) quadruple for a known catalog entry.
+        // A future refactor that splits or reorders the tuple —
+        // or that drifts the catalog values — fails here before
+        // reaching the play-button wiring layer or the recorder.
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_pass(now, 30); // satellite = "NOAA 19"
         let target = tune_target_for_pass(&pass).expect("NOAA 19 is in catalog");
         assert_eq!(target.0, 137_100_000);
         assert_eq!(target.1, sdr_types::DemodMode::Nfm);
         assert_eq!(target.2, 38_000);
+        assert_eq!(target.3, Some(sdr_sat::ImagingProtocol::Apt));
+    }
+
+    #[test]
+    fn tune_target_for_pass_returns_none_protocol_for_meteor() {
+        // Meteor passes are in the catalog (so the play button +
+        // upcoming-passes display work) but `imaging_protocol`
+        // is None until Task 7 of epic #469. Recorder filters on
+        // this; play button does not.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let mut pass = synthetic_pass(now, 30);
+        pass.satellite = "METEOR-M 2".to_string();
+        let target = tune_target_for_pass(&pass).expect("METEOR-M 2 is in catalog");
+        assert_eq!(
+            target.3, None,
+            "Meteor protocol stays None until Task 7 wires the LRPT viewer"
+        );
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -238,8 +238,17 @@ impl AutoRecorder {
     /// skipped — the state machine stays in `Idle` rather than
     /// transitioning to `BeforePass`, so no AOS-side actions
     /// fire and no LOS cleanup fires either.
+    ///
+    /// **Crate-private** so external callers can only use
+    /// [`Self::new`], which encodes today's "fully wired"
+    /// reality (`[Apt]`). Per CR round 2 on PR #541: exposing
+    /// the variadic builder publicly would let the wiring
+    /// layer opt into protocols whose LOS flow isn't actually
+    /// safe yet. When Task 7 of epic #469 finishes the LRPT
+    /// wiring, flip `new()` to default to `[Apt, Lrpt]` rather
+    /// than re-exporting this builder.
     #[must_use]
-    pub fn with_supported_protocols(supported: &[sdr_sat::ImagingProtocol]) -> Self {
+    fn with_supported_protocols(supported: &[sdr_sat::ImagingProtocol]) -> Self {
         Self {
             state: State::Idle,
             supported_protocols: supported.to_vec(),
@@ -507,10 +516,31 @@ impl AutoRecorder {
     }
 }
 
-// `is_apt_capable` removed in PR closing #514 — replaced by the
-// catalog-driven `imaging_protocol.is_some()` filter in
-// `tick_idle`. Adding a new protocol now only requires flipping
-// `imaging_protocol` on the `KnownSatellite` entry.
+// `is_apt_capable` removed in PR closing #514. Replaced by a
+// two-layer eligibility gate in `tick_idle`:
+//
+// 1. The catalog-driven `imaging_protocol.is_some()` check —
+//    keeps non-imaging satellites (Meteor / ISS today) out of
+//    the auto-record flow while still letting them surface in
+//    the upcoming-passes list and respond to the play button.
+//    Source of truth: [`sdr_sat::KnownSatellite::imaging_protocol`].
+//
+// 2. The `self.supported_protocols.contains(&protocol)` check —
+//    deny-by-default safety net keyed on what the wiring layer
+//    can actually handle in `interpret_action`. Without this,
+//    a catalog entry flipped to `Some(Lrpt)` ahead of Task 7
+//    wiring would still transition the state machine through
+//    `BeforePass → Recording → Finalizing`, so the LOS-side
+//    `SavePng` (no-op) and `RestoreTune` (clobbers user state)
+//    would fire even though the AOS side fail-closed. Per CR
+//    round 2 on PR #541. Source of truth: the
+//    `AutoRecorder::new()` constructor in this file.
+//
+// Adding a new protocol means: (a) add the variant to
+// `sdr_sat::ImagingProtocol`, (b) flip the relevant
+// `KnownSatellite::imaging_protocol`, (c) add a `match` arm in
+// `window.rs::interpret_action`, (d) update `new()` to include
+// the new protocol in the default supported set.
 
 /// Build the export path for a satellite + timestamp:
 /// `~/sdr-recordings/apt-NOAA-19-2026-04-25-143015.png`.
@@ -1282,16 +1312,30 @@ mod tests {
         // default), an APT-flagged catalog entry arms the
         // recorder as expected. Pins the negative-test contract
         // above by showing the gate is the only thing stopping
-        // the unsupported case.
+        // the unsupported case. Per CR round 2 on PR #541:
+        // assert the dispatched payload's `protocol` field
+        // explicitly so a future regression that ships
+        // `StartAutoRecord` with the wrong protocol (e.g. an
+        // off-by-one indexing into the catalog) fails here.
         let mut r = AutoRecorder::with_supported_protocols(&[sdr_sat::ImagingProtocol::Apt]);
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
         let actions = r.tick(now, &[pass], true, false, default_tune());
-        assert!(
-            actions
-                .iter()
-                .any(|a| matches!(a, Action::StartAutoRecord { .. })),
-            "supported protocol must arm the recorder",
+        let dispatched = actions.iter().find_map(|a| match a {
+            Action::StartAutoRecord {
+                satellite,
+                protocol,
+                ..
+            } => Some((satellite.clone(), *protocol)),
+            _ => None,
+        });
+        let (satellite, protocol) =
+            dispatched.expect("supported protocol must emit StartAutoRecord");
+        assert_eq!(satellite, "NOAA 19");
+        assert_eq!(
+            protocol,
+            sdr_sat::ImagingProtocol::Apt,
+            "dispatched protocol must match the catalog entry's flag",
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
     }

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -194,8 +194,23 @@ pub enum ToastKind {
 }
 
 /// The recorder.
+///
+/// Carries the set of imaging protocols the wiring layer has
+/// fully wired (decoder + viewer + LOS save). Catalog entries
+/// whose protocol isn't in this set are skipped at AOS — the
+/// state machine never transitions to `BeforePass`, so the LOS-
+/// side `SavePng` / `RestoreTune` actions never fire either.
+///
+/// This is the primary defense against "catalog flipped to
+/// `Some(Lrpt)` ahead of Task 7 wiring": without this gate, an
+/// unsupported protocol would arm the recorder, the wiring
+/// layer's `interpret_action` would fail-closed at AOS, but
+/// `RestoreTune` at LOS would still clobber any user retunes
+/// during the pass and `SavePng` would post a confusing
+/// "viewer was closed" toast. Per CR round 2 on PR #541.
 pub struct AutoRecorder {
     state: State,
+    supported_protocols: Vec<sdr_sat::ImagingProtocol>,
 }
 
 impl Default for AutoRecorder {
@@ -205,9 +220,30 @@ impl Default for AutoRecorder {
 }
 
 impl AutoRecorder {
+    /// Build a recorder that arms only on
+    /// [`sdr_sat::ImagingProtocol::Apt`]. Today's only fully-
+    /// wired auto-record path. Task 7 of epic #469 will swap
+    /// callers to [`Self::with_supported_protocols`] passing
+    /// `[Apt, Lrpt]`.
     #[must_use]
     pub fn new() -> Self {
-        Self { state: State::Idle }
+        Self::with_supported_protocols(&[sdr_sat::ImagingProtocol::Apt])
+    }
+
+    /// Build a recorder that arms only on the given imaging
+    /// protocols. The slice is the set of protocols the wiring
+    /// layer has fully wired in `interpret_action` (decoder
+    /// tap, viewer open, LOS save). Catalog entries whose
+    /// `imaging_protocol` falls outside this set are silently
+    /// skipped — the state machine stays in `Idle` rather than
+    /// transitioning to `BeforePass`, so no AOS-side actions
+    /// fire and no LOS cleanup fires either.
+    #[must_use]
+    pub fn with_supported_protocols(supported: &[sdr_sat::ImagingProtocol]) -> Self {
+        Self {
+            state: State::Idle,
+            supported_protocols: supported.to_vec(),
+        }
     }
 
     /// Snapshot of the current state — exposed so the wiring layer
@@ -288,14 +324,27 @@ impl AutoRecorder {
         //    until Task 7 of #469; ISS SSTV until #472). Per
         //    #514 — replaced the old hardcoded `is_apt_capable`
         //    NOAA-name check.
-        // 3. Peak elevation meets the quality threshold.
-        // 4. AOS is within `AOS_LEAD_SECS` (start tuning a few
+        // 3. Protocol is in `self.supported_protocols`. Per CR
+        //    round 2 on PR #541: even if a catalog entry is
+        //    flipped to `Some(Lrpt)` ahead of the wiring layer
+        //    actually supporting it, the state machine refuses
+        //    to arm. Without this gate, the recorder would
+        //    transition to `BeforePass`, the wiring layer's
+        //    fail-closed AOS branch would no-op, but the
+        //    LOS-side `SavePng` + `RestoreTune` actions would
+        //    still fire — clobbering any user retunes during
+        //    the pass.
+        // 4. Peak elevation meets the quality threshold.
+        // 5. AOS is within `AOS_LEAD_SECS` (start tuning a few
         //    seconds early so the pipeline is ready at AOS proper).
         for pass in passes {
             let Some((freq_hz, mode, bandwidth_hz, Some(protocol))) = tune_target_for_pass(pass)
             else {
                 continue;
             };
+            if !self.supported_protocols.contains(&protocol) {
+                continue;
+            }
             if pass.max_elevation_deg < AUTO_RECORD_MIN_ELEV_DEG {
                 continue;
             }
@@ -1100,5 +1149,159 @@ mod tests {
                 .any(|a| matches!(a, Action::StopAutoAudioRecord)),
             "in-flight audio recording must stop at LOS even after toggle flip",
         );
+    }
+
+    /// Build a synthetic METEOR-M 2 pass. Used by the
+    /// supported-protocols-gate tests below — the catalog flags
+    /// METEOR-M 2 with `imaging_protocol: None` today, but
+    /// these tests need to simulate "what happens if a future
+    /// edit flips it to `Some(Lrpt)` before the wiring layer
+    /// supports it." The recorder gate is what saves us in
+    /// that scenario.
+    fn synthetic_meteor_m2(
+        now: DateTime<Utc>,
+        aos_offset_secs: i64,
+        duration_secs: i64,
+        peak_elev_deg: f64,
+    ) -> Pass {
+        let start = now + ChronoDuration::seconds(aos_offset_secs);
+        Pass {
+            satellite: "METEOR-M 2".to_string(),
+            start,
+            end: start + ChronoDuration::seconds(duration_secs),
+            max_elevation_deg: peak_elev_deg,
+            max_el_time: start + ChronoDuration::seconds(duration_secs / 2),
+            start_az_deg: 245.0,
+            end_az_deg: 105.0,
+        }
+    }
+
+    #[test]
+    fn unsupported_protocol_does_not_arm_recorder() {
+        // CR round 2 on PR #541: a catalog entry with a protocol
+        // outside `supported_protocols` must NOT arm the recorder
+        // — `tick_idle` keeps the state at `Idle` rather than
+        // transitioning to `BeforePass`. This is the primary
+        // defense against "Meteor catalog flipped to Some(Lrpt)
+        // ahead of Task 7 wiring": without this gate, the
+        // wiring layer's fail-closed AOS branch would no-op,
+        // but the LOS-side `SavePng` + `RestoreTune` would
+        // still fire and clobber the user's mid-pass state.
+        //
+        // Simulate the bad-future scenario by using a recorder
+        // configured for `Apt` only, then feeding it a synthetic
+        // pass for a satellite the catalog flags as a different
+        // protocol (METEOR-M 2 with — once Task 7 ships —
+        // `Some(Lrpt)`). Even after we monkeypatch the catalog
+        // entry to advertise Lrpt, the recorder must refuse to
+        // arm.
+        //
+        // The recorder consults the catalog directly via
+        // `tune_target_for_pass`, so monkeypatching the catalog
+        // isn't possible from a test. Instead use the inverse
+        // construction: build a recorder that supports NOTHING
+        // (`with_supported_protocols(&[])`), then feed it an
+        // APT-flagged NOAA pass. Same code path — the
+        // protocol-gate `continue` fires either way.
+        let mut r = AutoRecorder::with_supported_protocols(&[]);
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+        let actions = r.tick(now, &[pass], true, false, default_tune());
+        // No actions of any kind — no StartAutoRecord, no Toast,
+        // no transition.
+        assert!(
+            actions.is_empty(),
+            "unsupported protocol must not arm the recorder; got {actions:?}"
+        );
+        assert!(
+            matches!(r.state(), State::Idle),
+            "state must stay Idle, not transition to BeforePass"
+        );
+    }
+
+    #[test]
+    fn unsupported_protocol_blocks_full_pass_lifecycle() {
+        // Drives the recorder through the entire would-be pass
+        // lifecycle (AOS → settle → LOS) on an unsupported
+        // protocol and asserts NO actions ever fire — most
+        // importantly, no LOS-side `SavePng` or `RestoreTune`
+        // (which would clobber the user's mid-pass state).
+        let mut r = AutoRecorder::with_supported_protocols(&[]);
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+
+        // AOS: gated out, no actions, state stays Idle.
+        let aos = r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        assert!(aos.is_empty());
+        assert!(matches!(r.state(), State::Idle));
+
+        // Settle window — still no transition.
+        let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
+        let mid = r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        assert!(mid.is_empty());
+        assert!(matches!(r.state(), State::Idle));
+
+        // LOS — most important: NO SavePng / RestoreTune fire.
+        // Without the supported-protocols gate, `BeforePass →
+        // Recording → Finalizing` would have transitioned by
+        // now and we'd see those cleanup actions here.
+        let los_plus = pass.end + ChronoDuration::seconds(1);
+        let los = r.tick(
+            los_plus,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        assert!(
+            !los.iter().any(|a| matches!(a, Action::SavePng(_))),
+            "no SavePng on unsupported-protocol LOS",
+        );
+        assert!(
+            !los.iter().any(|a| matches!(a, Action::RestoreTune(_))),
+            "no RestoreTune on unsupported-protocol LOS — the user's mid-pass state must not be clobbered",
+        );
+        assert!(matches!(r.state(), State::Idle));
+    }
+
+    #[test]
+    fn supported_protocol_arms_recorder_normally() {
+        // Sanity: with `supported_protocols = [Apt]` (the
+        // default), an APT-flagged catalog entry arms the
+        // recorder as expected. Pins the negative-test contract
+        // above by showing the gate is the only thing stopping
+        // the unsupported case.
+        let mut r = AutoRecorder::with_supported_protocols(&[sdr_sat::ImagingProtocol::Apt]);
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+        let actions = r.tick(now, &[pass], true, false, default_tune());
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, Action::StartAutoRecord { .. })),
+            "supported protocol must arm the recorder",
+        );
+        assert!(matches!(r.state(), State::BeforePass { .. }));
+    }
+
+    #[test]
+    fn meteor_synthetic_pass_helper_works() {
+        // Sanity for the helper itself — pins the satellite
+        // name our gate tests rely on.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_meteor_m2(now, 0, 600, 50.0);
+        assert_eq!(pass.satellite, "METEOR-M 2");
     }
 }

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -146,13 +146,18 @@ pub struct SavedTune {
 /// Returned from `tick` so the state machine itself stays pure.
 #[derive(Debug, Clone)]
 pub enum Action {
-    /// Tune the radio to the satellite's downlink and open the APT
-    /// viewer window. Fired on `Idle → BeforePass`.
+    /// Tune the radio to the satellite's downlink and open the
+    /// protocol-appropriate live viewer. Fired on `Idle →
+    /// BeforePass`. The wiring layer's `interpret_action`
+    /// matches on `protocol` to dispatch to the right decoder /
+    /// viewer (APT today, LRPT in Task 7 of epic #469, SSTV in
+    /// epic #472). Per #514.
     StartAutoRecord {
         satellite: String,
         freq_hz: u64,
         mode: DemodMode,
         bandwidth_hz: u32,
+        protocol: sdr_sat::ImagingProtocol,
     },
     /// Open a WAV writer at `audio_path` to capture the
     /// demodulated audio for the duration of the pass. Fired
@@ -274,19 +279,23 @@ impl AutoRecorder {
             return Vec::new();
         }
         // Find the soonest eligible upcoming pass. Eligibility:
-        // 1. Satellite is in our catalog (lookup yields tune target).
-        //    LRPT-only satellites are out — the APT decoder won't
-        //    decode their signal even if we tune to it.
-        // 2. Peak elevation meets the quality threshold.
-        // 3. AOS is within `AOS_LEAD_SECS` (start tuning a few
+        // 1. Satellite is in our catalog (lookup yields tune
+        //    target).
+        // 2. Catalog entry has `imaging_protocol = Some(_)`. None
+        //    means the satellite is in the catalog for pass-
+        //    prediction display only — auto-record doesn't have
+        //    a decoder + viewer wired for it yet (Meteor LRPT
+        //    until Task 7 of #469; ISS SSTV until #472). Per
+        //    #514 — replaced the old hardcoded `is_apt_capable`
+        //    NOAA-name check.
+        // 3. Peak elevation meets the quality threshold.
+        // 4. AOS is within `AOS_LEAD_SECS` (start tuning a few
         //    seconds early so the pipeline is ready at AOS proper).
         for pass in passes {
-            let Some((freq_hz, mode, bandwidth_hz)) = tune_target_for_pass(pass) else {
+            let Some((freq_hz, mode, bandwidth_hz, Some(protocol))) = tune_target_for_pass(pass)
+            else {
                 continue;
             };
-            if !is_apt_capable(&pass.satellite) {
-                continue;
-            }
             if pass.max_elevation_deg < AUTO_RECORD_MIN_ELEV_DEG {
                 continue;
             }
@@ -330,6 +339,7 @@ impl AutoRecorder {
                 freq_hz,
                 mode,
                 bandwidth_hz,
+                protocol,
             });
             if let Some(path) = &audio_path {
                 actions.push(Action::StartAutoAudioRecord(path.clone()));
@@ -448,17 +458,10 @@ impl AutoRecorder {
     }
 }
 
-/// Is this satellite something we can actually decode in the APT
-/// viewer? NOAA POES (15 / 18 / 19) carry the analog APT subcarrier
-/// our decoder is built for. METEOR-M / ISS use different
-/// modulations (LRPT / SSTV) and would tune correctly but produce
-/// no decoded image — pointless to auto-record them today. When
-/// LRPT / SSTV decoders ship (epics #469 / #472) this gate will
-/// loosen accordingly.
-#[must_use]
-fn is_apt_capable(satellite_name: &str) -> bool {
-    matches!(satellite_name, "NOAA 15" | "NOAA 18" | "NOAA 19")
-}
+// `is_apt_capable` removed in PR closing #514 — replaced by the
+// catalog-driven `imaging_protocol.is_some()` filter in
+// `tick_idle`. Adding a new protocol now only requires flipping
+// `imaging_protocol` on the `KnownSatellite` entry.
 
 /// Build the export path for a satellite + timestamp:
 /// `~/sdr-recordings/apt-NOAA-19-2026-04-25-143015.png`.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9017,21 +9017,32 @@ fn connect_satellites_panel(
                         }
                     }
                     sdr_sat::ImagingProtocol::Lrpt => {
-                        // Task 7 of epic #469 wires the LRPT
-                        // live viewer + decoder driver. This
-                        // branch is reachable today only if a
-                        // catalog entry is flipped to
-                        // `Some(Lrpt)` ahead of that wiring.
-                        // Fail closed: log + toast WITHOUT
-                        // touching playback / tune / VFO state
-                        // so the user's pre-AOS tune survives
-                        // intact. Task 7 will replace this with
-                        // actual viewer-open + decoder-tap
-                        // wiring (which will then run the same
-                        // set_playing / tune / VFO sequence as
-                        // the APT arm above).
-                        tracing::warn!(
-                            "auto-record fired for LRPT satellite {satellite} but the LRPT viewer is not yet wired (Task 7 of epic #469); leaving radio state untouched",
+                        // **Should be unreachable** — the
+                        // `AutoRecorder` constructor in this
+                        // module passes
+                        // `supported_protocols = [Apt]`, so the
+                        // recorder's `tick_idle` filter rejects
+                        // any catalog entry flagged
+                        // `Some(Lrpt)` before reaching the
+                        // wiring layer. Per CR round 2 on PR
+                        // #541.
+                        //
+                        // Kept as defense-in-depth: if a future
+                        // refactor breaks the recorder gate
+                        // (e.g. someone passes a wider supported
+                        // set without wiring the viewer), this
+                        // branch makes the failure visible
+                        // (error log + user-facing toast) and
+                        // fails closed (no playback / tune /
+                        // VFO mutation).
+                        //
+                        // Task 7 of epic #469 replaces this
+                        // entire branch with the LRPT viewer-
+                        // open + decoder-tap wiring (and the
+                        // recorder constructor flips to
+                        // `[Apt, Lrpt]`).
+                        tracing::error!(
+                            "auto-record fired for LRPT satellite {satellite} but the recorder gate should have prevented this — please file a bug",
                         );
                         post_toast(
                             &toast_overlay_weak,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8956,37 +8956,53 @@ fn connect_satellites_panel(
                 tracing::info!(
                     "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz, protocol {protocol:?}",
                 );
-                // Drive Start through the header play button —
-                // its `connect_toggled` handler is the single place
-                // that updates `state.is_running`, dispatches
-                // `UiToDsp::Start`, and swaps the play/stop icon.
-                // `set_active` is a no-op when the radio is
-                // already running, so this is safe to call
-                // unconditionally without a duplicate Start.
-                // The pre-AOS `was_running` flag (captured in
-                // `SavedTune` by the 1 Hz tick before this action
-                // fires) drives the corresponding LOS-side stop.
-                set_playing_a(true);
-                tune_a(freq_hz, mode, bandwidth_hz);
-                // Zero the live VFO offset for the auto-record
-                // pass. The user's pre-AOS offset (a manual
-                // VFO drag away from centre) is preserved in
-                // `SavedTune` for the LOS restore, but during
-                // the pass the demod must align *exactly* with
-                // the satellite's downlink — otherwise we'd
-                // demod at `freq_hz + saved_offset` and the
-                // APT subcarrier would land outside the
-                // channel filter. The DSP's
-                // `DspToUi::VfoOffsetChanged` echo updates the
-                // spectrum widget, freq selector, and status
-                // bar; no manual mirror needed.
-                state_a.send_dsp(UiToDsp::SetVfoOffset(0.0));
                 // Per-protocol viewer dispatch. Adding a new
                 // protocol means adding a match arm here +
                 // flipping `imaging_protocol` on the catalog
                 // entry — no recorder change needed. Per #514.
+                //
+                // **Fail closed on unsupported protocols.** All
+                // AOS side effects (set_playing, tune, zero VFO,
+                // open viewer) live INSIDE each arm rather than
+                // unconditionally before the match. Per CR
+                // round 1 on PR #541: if a catalog entry is
+                // flipped to `Some(Lrpt)` ahead of Task 7 wiring
+                // the LRPT viewer, the user's tune state must
+                // NOT be hijacked just to land in a no-op
+                // branch.
                 match protocol {
                     sdr_sat::ImagingProtocol::Apt => {
+                        // Drive Start through the header play
+                        // button — its `connect_toggled` handler
+                        // is the single place that updates
+                        // `state.is_running`, dispatches
+                        // `UiToDsp::Start`, and swaps the
+                        // play/stop icon. `set_active` is a
+                        // no-op when the radio is already
+                        // running, so this is safe to call
+                        // unconditionally without a duplicate
+                        // Start. The pre-AOS `was_running` flag
+                        // (captured in `SavedTune` by the 1 Hz
+                        // tick before this action fires) drives
+                        // the corresponding LOS-side stop.
+                        set_playing_a(true);
+                        tune_a(freq_hz, mode, bandwidth_hz);
+                        // Zero the live VFO offset for the
+                        // auto-record pass. The user's pre-AOS
+                        // offset (a manual VFO drag away from
+                        // centre) is preserved in `SavedTune`
+                        // for the LOS restore, but during the
+                        // pass the demod must align *exactly*
+                        // with the satellite's downlink —
+                        // otherwise we'd demod at `freq_hz +
+                        // saved_offset` and the APT subcarrier
+                        // would land outside the channel
+                        // filter. The DSP's
+                        // `DspToUi::VfoOffsetChanged` echo
+                        // updates the spectrum widget, freq
+                        // selector, and status bar; no manual
+                        // mirror needed.
+                        state_a.send_dsp(UiToDsp::SetVfoOffset(0.0));
                         crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
                         // Clear the canvas at AOS so a back-to-back
                         // pass (e.g. NOAA 18 → NOAA 19 with
@@ -9001,14 +9017,21 @@ fn connect_satellites_panel(
                         }
                     }
                     sdr_sat::ImagingProtocol::Lrpt => {
-                        // Task 7 of epic #469 wires the LRPT live
-                        // viewer + decoder driver. This branch is
-                        // reachable today only if a catalog entry
-                        // is flipped to `Some(Lrpt)` ahead of that
-                        // wiring — log + toast so it's visible
-                        // rather than silently no-op.
+                        // Task 7 of epic #469 wires the LRPT
+                        // live viewer + decoder driver. This
+                        // branch is reachable today only if a
+                        // catalog entry is flipped to
+                        // `Some(Lrpt)` ahead of that wiring.
+                        // Fail closed: log + toast WITHOUT
+                        // touching playback / tune / VFO state
+                        // so the user's pre-AOS tune survives
+                        // intact. Task 7 will replace this with
+                        // actual viewer-open + decoder-tap
+                        // wiring (which will then run the same
+                        // set_playing / tune / VFO sequence as
+                        // the APT arm above).
                         tracing::warn!(
-                            "auto-record fired for LRPT satellite {satellite} but the LRPT viewer is not yet wired (Task 7 of epic #469)",
+                            "auto-record fired for LRPT satellite {satellite} but the LRPT viewer is not yet wired (Task 7 of epic #469); leaving radio state untouched",
                         );
                         post_toast(
                             &toast_overlay_weak,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8550,7 +8550,12 @@ fn connect_satellites_panel(
                 // (impossible in practice but the lookup type is
                 // `Option`, so we fail closed — no button rather
                 // than a button that does nothing).
-                if let Some((freq_hz, mode, bw_hz)) = tune_target_for_pass(&pass) {
+                // Per-row play button: ignore the 4th element
+                // (`Option<ImagingProtocol>`) — manual tune is a
+                // user-initiated action and works on any catalog
+                // entry. Only the auto-record path filters on
+                // `Some(protocol)`.
+                if let Some((freq_hz, mode, bw_hz, _protocol)) = tune_target_for_pass(&pass) {
                     let play_btn = gtk4::Button::builder()
                         .icon_name("media-playback-start-symbolic")
                         .tooltip_text(format!(
@@ -8946,9 +8951,10 @@ fn connect_satellites_panel(
                 freq_hz,
                 mode,
                 bandwidth_hz,
+                protocol,
             } => {
                 tracing::info!(
-                    "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz",
+                    "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz, protocol {protocol:?}",
                 );
                 // Drive Start through the header play button —
                 // its `connect_toggled` handler is the single place
@@ -8975,16 +8981,42 @@ fn connect_satellites_panel(
                 // spectrum widget, freq selector, and status
                 // bar; no manual mirror needed.
                 state_a.send_dsp(UiToDsp::SetVfoOffset(0.0));
-                crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
-                // Clear the canvas at AOS so a back-to-back pass
-                // (e.g. NOAA 18 → NOAA 19 with overlapping
-                // viewer sessions) starts on a clean image. The
-                // viewer was either just opened above (already
-                // empty) or carried over from a previous pass —
-                // either way, an explicit clear keeps the image
-                // we're about to save scoped to *this* pass.
-                if let Some(view) = state_a.apt_viewer.borrow().as_ref() {
-                    view.clear();
+                // Per-protocol viewer dispatch. Adding a new
+                // protocol means adding a match arm here +
+                // flipping `imaging_protocol` on the catalog
+                // entry — no recorder change needed. Per #514.
+                match protocol {
+                    sdr_sat::ImagingProtocol::Apt => {
+                        crate::apt_viewer::open_apt_viewer_if_needed(&parent_provider_a, &state_a);
+                        // Clear the canvas at AOS so a back-to-back
+                        // pass (e.g. NOAA 18 → NOAA 19 with
+                        // overlapping viewer sessions) starts on a
+                        // clean image. The viewer was either just
+                        // opened above (already empty) or carried
+                        // over from a previous pass — either way,
+                        // an explicit clear keeps the image we're
+                        // about to save scoped to *this* pass.
+                        if let Some(view) = state_a.apt_viewer.borrow().as_ref() {
+                            view.clear();
+                        }
+                    }
+                    sdr_sat::ImagingProtocol::Lrpt => {
+                        // Task 7 of epic #469 wires the LRPT live
+                        // viewer + decoder driver. This branch is
+                        // reachable today only if a catalog entry
+                        // is flipped to `Some(Lrpt)` ahead of that
+                        // wiring — log + toast so it's visible
+                        // rather than silently no-op.
+                        tracing::warn!(
+                            "auto-record fired for LRPT satellite {satellite} but the LRPT viewer is not yet wired (Task 7 of epic #469)",
+                        );
+                        post_toast(
+                            &toast_overlay_weak,
+                            &format!(
+                                "{satellite}: LRPT auto-record arrived early — viewer ships in epic #469 Task 7"
+                            ),
+                        );
+                    }
                 }
             }
             RecorderAction::StartAutoAudioRecord(path) => {


### PR DESCRIPTION
## Summary

Generalizes the auto-record path so adding a new protocol (LRPT in Task 7 of epic #469, SSTV in #472) becomes one catalog flip + one match-arm in \`interpret_action\` — no recorder change required.

User-visible behavior is **unchanged** by this PR. APT continues to auto-record exactly as before; Meteor / ISS stay non-eligible until Task 7 / #472.

## What's in here

- **\`crates/sdr-sat/src/lib.rs\`**: new \`ImagingProtocol\` enum + \`imaging_protocol: Option<ImagingProtocol>\` field on \`KnownSatellite\`. NOAA → \`Some(Apt)\`, Meteor + ISS → \`None\`. Test pins assignments.
- **\`crates/sdr-ui/src/sidebar/satellites_panel.rs\`**: \`tune_target_for_pass\` now returns the protocol as \`Option<ImagingProtocol>\` (4th tuple element). The recorder filters via \`Some(_)\`; the per-row play button ignores it (manual tune still works on every catalog satellite).
- **\`crates/sdr-ui/src/sidebar/satellites_recorder.rs\`**: \`Action::StartAutoRecord\` carries \`protocol\`. Eligibility check is now \`let Some((..., Some(protocol))) = ...\` — folds the catalog filter into the lookup. \`is_apt_capable\` deleted (zero callers).
- **\`crates/sdr-ui/src/window.rs\`**: \`interpret_action::StartAutoRecord\` matches on \`protocol\`. APT keeps existing viewer-open + clear; LRPT branch logs warn + posts toast (only reachable if a catalog entry is flipped to \`Some(Lrpt)\` ahead of Task 7).

## One deviation from the plan

The plan's \`tune_target_for_pass\` short-circuits via \`?\` on \`imaging_protocol\` — would silently hide the per-row play button on Meteor / ISS rows for the duration of the Task 6 → Task 7 window. Kept the protocol as \`Option<_>\` instead so manual tuning stays available on every catalog satellite. Recorder still filters correctly via \`let Some(protocol) = ...\`.

## Test plan

- [x] \`cargo test --workspace --features whisper-cpu\` — all green
- [x] \`cargo clippy --all-targets --features whisper-cpu -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`grep -rn 'is_apt_capable' crates/\` — only doc-comment references; zero live callers
- [x] sdr-sat: 68 tests pass (was 67, +1 protocol-assignments test)
- [x] sdr-ui satellites: 44 pass

## What's still ahead in the LRPT epic

- **Task 7**: end-to-end live integration — wire \`LrptPipeline::push_symbol\` into the live IQ tap (mirror the APT decoder tap), build the LRPT live viewer in \`sdr-ui\` (mirror \`apt_viewer.rs\`), flip Meteor catalog entries to \`Some(Lrpt)\`. The warn-toast branch added here is the safety net while that wiring lands.
- **Task 8**: docs walkthrough closing #469.

Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog now records a per-satellite imaging protocol; UI uses it to drive auto-record behavior.

* **Improvements**
  * Auto-record eligibility is catalog-driven instead of hardcoded.
  * Manual play/tune remains unaffected; unsupported protocols show a user-facing warning and do not hijack playback.

* **Tests**
  * Tests added to lock protocol assignments and validate recorder gating and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->