### PR TITLE
Meteor-M LRPT end-to-end live integration (closes #469)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,6 +3004,7 @@ dependencies = [
  "sdr-config",
  "sdr-core",
  "sdr-dsp",
+ "sdr-lrpt",
  "sdr-pipeline",
  "sdr-radio",
  "sdr-radioreference",

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -22,6 +22,7 @@ use sdr_dsp::apt::{AptDecoder, AptLine, READY_QUEUE_CAP};
 use sdr_dsp::channel::RxVfo;
 use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
 use sdr_pipeline::source_manager::Source;
+use sdr_radio::lrpt_decoder::LrptDecoder;
 
 use crate::sink_slot::{
     AudioSinkSlot, AudioSinkType, DEFAULT_NETWORK_SINK_HOST, DEFAULT_NETWORK_SINK_PORT,
@@ -432,6 +433,22 @@ struct DspState {
     /// reset so a fresh source restart always gets one fresh
     /// init attempt.
     apt_init_failed_at_rate: Option<u32>,
+    /// Meteor-M LRPT decoder driver. Lazy-init when the demod
+    /// mode first switches to `DemodMode::Lrpt`; teardown in
+    /// `cleanup` (per-source-stop). The driver owns
+    /// `LrptDemod` + `LrptPipeline` + the per-APID line-
+    /// watermark map; the shared `LrptImage` handle is wired
+    /// in from the UI side via `UiToDsp::SetLrptImage` so the
+    /// live viewer reads from the same buffer this driver
+    /// pushes lines into. Per epic #469 task 7.
+    lrpt_decoder: Option<LrptDecoder>,
+    /// Shared image handle the LRPT decoder pushes scan lines
+    /// into. `None` until the UI side wires it via
+    /// `UiToDsp::SetLrptImage`; in that case the controller
+    /// simply doesn't run the LRPT tap (auto-record will set
+    /// it at AOS, manual LRPT-mode use without a viewer is a
+    /// silent-but-harmless state).
+    lrpt_image: Option<sdr_radio::lrpt_image::LrptImage>,
 }
 
 impl DspState {
@@ -508,6 +525,8 @@ impl DspState {
             apt_mono_buf: Vec::new(),
             apt_lines_buf: Vec::new(),
             apt_init_failed_at_rate: None,
+            lrpt_decoder: None,
+            lrpt_image: None,
         })
     }
 }
@@ -585,6 +604,54 @@ fn apt_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_co
             tracing::warn!("APT decode failed: {e}");
         }
     }
+}
+
+/// Meteor-M LRPT decode tap — IQ counterpart of [`apt_decode_tap`].
+/// Lazy-initialises the decoder against the shared
+/// `LrptImage` handle the wiring layer set via
+/// `UiToDsp::SetLrptImage`, then streams the post-VFO IQ slice
+/// (`radio_input` — already at 144 ksps thanks to the
+/// `DemodMode::Lrpt` IF rate) through the full LRPT chain
+/// (QPSK demod, FEC, image assembler). Emitted scan lines
+/// land in the shared `LrptImage` for the live viewer to read.
+///
+/// Only runs when (a) `current_mode == DemodMode::Lrpt` and (b)
+/// the wiring layer has handed us a `LrptImage` handle. Without
+/// the handle, the tap is silent — manual LRPT-mode use without
+/// a viewer harmlessly produces no output. Per epic #469 task 7.
+///
+/// Takes the decoder + image references directly (rather than
+/// `&mut DspState`) so the call site can hold a live borrow of
+/// `radio_input` — which itself points into a separate state
+/// field (`vfo_buf` or `processed_buf`) — without violating
+/// borrow-disjointness.
+fn lrpt_decode_tap(
+    decoder_slot: &mut Option<LrptDecoder>,
+    image: Option<&sdr_radio::lrpt_image::LrptImage>,
+    radio_input: &[Complex],
+) {
+    let Some(image) = image else {
+        return;
+    };
+    if decoder_slot.is_none() {
+        match LrptDecoder::new(image.clone()) {
+            Ok(decoder) => {
+                tracing::info!(
+                    "LRPT decoder initialised at {} Hz IF rate",
+                    sdr_dsp::lrpt::SAMPLE_RATE_HZ
+                );
+                *decoder_slot = Some(decoder);
+            }
+            Err(e) => {
+                tracing::warn!("LRPT decoder init failed: {e}");
+                return;
+            }
+        }
+    }
+    let Some(decoder) = decoder_slot.as_mut() else {
+        return;
+    };
+    decoder.process(radio_input);
 }
 
 /// Handle a single UI command.
@@ -1612,6 +1679,25 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             let _ = dsp_tx.send(DspToUi::AudioRecordingStopped);
         }
 
+        UiToDsp::SetLrptImage(image) => {
+            tracing::info!("LRPT image handle attached — decoder tap will push lines");
+            state.lrpt_image = Some(image);
+            // Drop any existing decoder so the next tap call
+            // lazy-rebuilds against the new image handle.
+            // Otherwise scan lines would keep flowing into the
+            // *previous* pass's image.
+            state.lrpt_decoder = None;
+        }
+
+        UiToDsp::ClearLrptImage => {
+            tracing::info!("LRPT image handle cleared — decoder tap is silent");
+            state.lrpt_image = None;
+            // Drop the decoder too — without an image there's
+            // nowhere for harvested lines to land, and we want
+            // a fresh pipeline on the next attach anyway.
+            state.lrpt_decoder = None;
+        }
+
         UiToDsp::StartIqRecording(path) => {
             tracing::info!(?path, "start IQ recording");
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -2397,6 +2483,19 @@ fn cleanup(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
     // memo to silently suppress a now-valid rate.
     state.apt_init_failed_at_rate = None;
 
+    // Same semantics for the LRPT decoder (#469): flush
+    // in-flight Viterbi traceback / sync window / RS path /
+    // image assembler so the next Start paints a clean canvas.
+    // If reset's demod-rebuild fails (practically unreachable;
+    // see `LrptDemod::new`), drop the decoder entirely so the
+    // next tap call lazily re-initialises.
+    if let Some(decoder) = state.lrpt_decoder.as_mut()
+        && let Err(e) = decoder.reset()
+    {
+        tracing::warn!("LRPT decoder reset failed; dropping for re-init: {e}");
+        state.lrpt_decoder = None;
+    }
+
     tracing::info!("source closed");
 }
 
@@ -2597,6 +2696,23 @@ fn process_iq_block(
                     // No VFO configured — pass frontend output directly (fallback).
                     &state.processed_buf[..processed_count]
                 };
+
+                // Meteor-M LRPT decode tap (#469). Only runs in
+                // LRPT mode — the demod is a silent passthrough
+                // sized so `radio_input` is at the LRPT working
+                // sample rate (144 ksps), which is exactly what
+                // the QPSK demod + FEC chain expects. Tapped
+                // BEFORE `radio.process` so we read the IQ
+                // before the passthrough discards it; harvested
+                // scan lines flow into the shared `LrptImage`
+                // the live viewer reads from.
+                if state.radio.current_mode() == sdr_types::DemodMode::Lrpt {
+                    lrpt_decode_tap(
+                        &mut state.lrpt_decoder,
+                        state.lrpt_image.as_ref(),
+                        radio_input,
+                    );
+                }
 
                 // Process through radio module for audio output.
                 let max_out = state.radio.max_output_samples(radio_input.len());

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1692,10 +1692,17 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         UiToDsp::ClearLrptImage => {
             tracing::info!("LRPT image handle cleared — decoder tap is silent");
             state.lrpt_image = None;
-            // Drop the decoder too — without an image there's
-            // nowhere for harvested lines to land, and we want
-            // a fresh pipeline on the next attach anyway.
-            state.lrpt_decoder = None;
+            // Decoder state stays alive — the tap is already
+            // disabled because `lrpt_image` is None, and
+            // teardown / reset belong to the source-stop
+            // cleanup path. Mirrors the APT decoder, which
+            // also keeps its state across stop-listening /
+            // resume-listening cycles so resumed listening
+            // doesn't pay re-init cost. The `messages.rs`
+            // doc-comment for `ClearLrptImage` codifies this
+            // contract; an earlier draft contradicted it by
+            // dropping the decoder here. Per CodeRabbit
+            // round 1 on PR #543.
         }
 
         UiToDsp::StartIqRecording(path) => {

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -449,6 +449,15 @@ struct DspState {
     /// it at AOS, manual LRPT-mode use without a viewer is a
     /// silent-but-harmless state).
     lrpt_image: Option<sdr_radio::lrpt_image::LrptImage>,
+    /// One-shot guard: set to `true` when `LrptDecoder::new`
+    /// fails, so subsequent `lrpt_decode_tap` calls return
+    /// early instead of retrying init (and warn-logging) on
+    /// every IQ chunk. Cleared in `cleanup` so a fresh `Start`
+    /// gets a fresh attempt. Mirrors `apt_init_failed_at_rate`
+    /// — without this, a sustained init failure would spam the
+    /// log at the IQ block rate (~100 Hz) until source-stop.
+    /// Per `CodeRabbit` round 12 on PR #543.
+    lrpt_init_failed: bool,
 }
 
 impl DspState {
@@ -527,6 +536,7 @@ impl DspState {
             apt_init_failed_at_rate: None,
             lrpt_decoder: None,
             lrpt_image: None,
+            lrpt_init_failed: false,
         })
     }
 }
@@ -629,10 +639,19 @@ fn lrpt_decode_tap(
     decoder_slot: &mut Option<LrptDecoder>,
     image: Option<&sdr_radio::lrpt_image::LrptImage>,
     radio_input: &[Complex],
+    init_failed: &mut bool,
 ) {
     let Some(image) = image else {
         return;
     };
+    // One-shot guard: a previous init attempt failed. Skip
+    // until source-stop cleanup clears the flag, otherwise
+    // we'd warn-log on every IQ chunk (~100 Hz). Per
+    // `CodeRabbit` round 12 on PR #543 — mirrors the
+    // `apt_init_failed_at_rate` guard on the APT side.
+    if *init_failed {
+        return;
+    }
     if decoder_slot.is_none() {
         match LrptDecoder::new(image.clone()) {
             Ok(decoder) => {
@@ -644,6 +663,7 @@ fn lrpt_decode_tap(
             }
             Err(e) => {
                 tracing::warn!("LRPT decoder init failed: {e}");
+                *init_failed = true;
                 return;
             }
         }
@@ -2508,6 +2528,10 @@ fn cleanup(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
         tracing::warn!("LRPT decoder reset failed; dropping for re-init: {e}");
         state.lrpt_decoder = None;
     }
+    // Clear the failed-init guard so a fresh Start gets a fresh
+    // init attempt. Mirror `apt_init_failed_at_rate` above. Per
+    // `CodeRabbit` round 12 on PR #543.
+    state.lrpt_init_failed = false;
 
     tracing::info!("source closed");
 }
@@ -2724,6 +2748,7 @@ fn process_iq_block(
                         &mut state.lrpt_decoder,
                         state.lrpt_image.as_ref(),
                         radio_input,
+                        &mut state.lrpt_init_failed,
                     );
                 }
 

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1682,11 +1682,17 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         UiToDsp::SetLrptImage(image) => {
             tracing::info!("LRPT image handle attached — decoder tap will push lines");
             state.lrpt_image = Some(image);
-            // Drop any existing decoder so the next tap call
-            // lazy-rebuilds against the new image handle.
-            // Otherwise scan lines would keep flowing into the
-            // *previous* pass's image.
-            state.lrpt_decoder = None;
+            // Decoder state intentionally NOT dropped here.
+            // `AppState::lrpt_image` is a long-lived singleton
+            // — every `SetLrptImage` carries the same handle —
+            // so reattach is logically a no-op for the decoder.
+            // Earlier draft dropped it defensively, but that
+            // turned the round-11 (`CodeRabbit` PR #543)
+            // defensive re-send in `open_lrpt_viewer_if_needed`
+            // into a mid-pass decoder reset that lost Viterbi /
+            // sync state on every viewer reuse. Decoder
+            // lifecycle stays owned by source-stop cleanup —
+            // same contract `ClearLrptImage` codifies (round 1).
         }
 
         UiToDsp::ClearLrptImage => {

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -348,6 +348,22 @@ pub enum UiToDsp {
     StartIqRecording(std::path::PathBuf),
     /// Stop IQ recording and finalize the WAV file.
     StopIqRecording,
+    /// Hand the DSP thread a clone of the shared
+    /// `sdr_radio::lrpt_image::LrptImage` handle the live LRPT
+    /// viewer reads from. Sent by the wiring layer at AOS for
+    /// LRPT auto-record passes (or whenever the user opens the
+    /// LRPT viewer manually). The DSP thread stores the handle
+    /// and pushes decoded scan lines into it whenever the LRPT
+    /// decoder tap runs (`current_mode` == `DemodMode::Lrpt`).
+    /// Per epic #469 task 7.
+    SetLrptImage(sdr_radio::lrpt_image::LrptImage),
+    /// Drop the shared LRPT image handle. Sent at LOS / when
+    /// the live viewer closes — stops the LRPT decoder from
+    /// pushing further lines (next AOS will re-set with a fresh
+    /// handle). Decoder state itself stays alive until the
+    /// next source-stop, mirroring the APT decoder's
+    /// "decoder kept across mode toggles" behavior.
+    ClearLrptImage,
     /// Start sending audio to the transcription engine.
     EnableTranscription(std::sync::mpsc::SyncSender<sdr_transcription::TranscriptionInput>),
     /// Stop sending audio to the transcription engine.

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -826,6 +826,19 @@ mod tests {
         let iq_stop = UiToDsp::StopIqRecording;
         assert!(matches!(iq_stop, UiToDsp::StopIqRecording));
 
+        // LRPT image-handle attach / detach (epic #469 task 7)
+        // — pin the variant shape so a future change to the
+        // `LrptImage` payload type or a rename of `ClearLrptImage`
+        // fails this regression net rather than silently
+        // breaking the controller's `lrpt_decode_tap` plumbing.
+        // Per CodeRabbit round 1 on PR #543.
+        let lrpt_image = sdr_radio::lrpt_image::LrptImage::new();
+        let set_lrpt = UiToDsp::SetLrptImage(lrpt_image);
+        assert!(matches!(set_lrpt, UiToDsp::SetLrptImage(_)));
+
+        let clear_lrpt = UiToDsp::ClearLrptImage;
+        assert!(matches!(clear_lrpt, UiToDsp::ClearLrptImage));
+
         let (tx, _rx) = std::sync::mpsc::sync_channel::<sdr_transcription::TranscriptionInput>(1);
         let enable = UiToDsp::EnableTranscription(tx);
         assert!(matches!(enable, UiToDsp::EnableTranscription(_)));

--- a/crates/sdr-radio/src/demod/lrpt.rs
+++ b/crates/sdr-radio/src/demod/lrpt.rs
@@ -1,0 +1,192 @@
+//! Meteor-M LRPT receive "demodulator" — at this layer it's a
+//! passthrough that produces silent stereo audio. The actual QPSK
+//! demod + FEC chain lives in `sdr_dsp::lrpt::LrptDemod` +
+//! `sdr_lrpt::LrptPipeline`, driven by the controller's LRPT tap
+//! against the post-VFO IQ buffer (which is at this mode's IF
+//! rate of 144 ksps — the LRPT working rate per
+//! `sdr_dsp::lrpt::SAMPLE_RATE_HZ`).
+//!
+//! Why a passthrough demod here at all:
+//!
+//! 1. The `RadioModule` is the single source of truth for
+//!    "current IF sample rate". Adding `DemodMode::Lrpt` as a
+//!    real demod variant lets the existing VFO + IF-chain
+//!    plumbing (resample to `if_sample_rate`, pin the channel
+//!    bandwidth at 144 kHz) just work — no bypass plumbing in
+//!    the controller, no parallel path that has to track
+//!    sample-rate changes.
+//! 2. The LRPT tap reads `radio_input` (the post-VFO IQ slice
+//!    fed to `RadioModule::process`) BEFORE this passthrough
+//!    runs. So `radio_input` is already at 144 ksps thanks to
+//!    the VFO; the QPSK demod gets the right rate; the
+//!    "demod" here just produces zero audio because there is
+//!    no listenable signal mid-pass — the imagery is the
+//!    artifact.
+//! 3. Squelch / NB / FM-IF-NR / deemphasis / high-pass /
+//!    voice-squelch are all disabled (`*_allowed: false`)
+//!    because none of them apply to a QPSK signal — applying
+//!    them would risk shaping the IQ before the LRPT tap reads
+//!    it (which would corrupt the carrier).
+
+use sdr_types::{Complex, DspError, Stereo};
+
+use super::{DemodConfig, Demodulator, VfoReference};
+
+/// LRPT working sample rate (Hz). Matches
+/// `sdr_dsp::lrpt::SAMPLE_RATE_HZ` exactly — pinned here as a
+/// `f64` so it slots into the `DemodConfig` numeric type without
+/// an extra cast at every read site. A `const_assert!` below
+/// catches drift if the DSP-layer constant ever changes.
+const LRPT_IF_SAMPLE_RATE: f64 = 144_000.0;
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+const _: () = assert!(LRPT_IF_SAMPLE_RATE as u32 == sdr_dsp::lrpt::SAMPLE_RATE_HZ as u32);
+
+/// AF (audio) sample rate produced by the passthrough. Matches
+/// the IF rate so the AF chain doesn't resample (and the silent
+/// audio buffer doesn't grow).
+const LRPT_AF_SAMPLE_RATE: f64 = LRPT_IF_SAMPLE_RATE;
+
+/// Default channel bandwidth for LRPT (Hz). Wider than NFM's
+/// 38 kHz default so the QPSK sidebands aren't clipped by the
+/// VFO's channel filter. Pinned at the IF rate; the bandwidth
+/// row is locked because LRPT is a fixed-symbol-rate signal.
+const LRPT_DEFAULT_BANDWIDTH: f64 = LRPT_IF_SAMPLE_RATE;
+
+/// LRPT passthrough demodulator. Produces silent stereo audio;
+/// the actual decoding happens in the controller's LRPT tap
+/// against the post-VFO IQ buffer.
+pub struct LrptDemodulator {
+    config: DemodConfig,
+}
+
+impl LrptDemodulator {
+    /// Create a new LRPT passthrough demodulator.
+    #[must_use]
+    pub fn new() -> Self {
+        let config = DemodConfig {
+            if_sample_rate: LRPT_IF_SAMPLE_RATE,
+            af_sample_rate: LRPT_AF_SAMPLE_RATE,
+            default_bandwidth: LRPT_DEFAULT_BANDWIDTH,
+            min_bandwidth: LRPT_DEFAULT_BANDWIDTH,
+            max_bandwidth: LRPT_DEFAULT_BANDWIDTH,
+            bandwidth_locked: true,
+            default_snap_interval: 0.0,
+            vfo_reference: VfoReference::Center,
+            deemp_allowed: false,
+            post_proc_enabled: false,
+            default_deemp_tau: 0.0,
+            fm_if_nr_allowed: false,
+            nb_allowed: false,
+            high_pass_allowed: false,
+            squelch_allowed: false,
+        };
+        Self { config }
+    }
+}
+
+impl Default for LrptDemodulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Demodulator for LrptDemodulator {
+    fn process(&mut self, input: &[Complex], output: &mut [Stereo]) -> Result<usize, DspError> {
+        // Silent output. The IQ at `input` was already harvested
+        // by the controller's LRPT tap before this demod ran;
+        // the AF chain downstream just gets zeros (which the
+        // sink writes as silence). Length matches input so the
+        // controller's `audio_count` accounting stays consistent
+        // with non-LRPT modes.
+        if output.len() < input.len() {
+            return Err(DspError::BufferTooSmall {
+                need: input.len(),
+                got: output.len(),
+            });
+        }
+        for slot in output.iter_mut().take(input.len()) {
+            *slot = Stereo::default();
+        }
+        Ok(input.len())
+    }
+
+    fn set_bandwidth(&mut self, _bw: f64) {
+        // Bandwidth is locked in LRPT mode (fixed-symbol-rate signal).
+    }
+
+    fn config(&self) -> &DemodConfig {
+        &self.config
+    }
+
+    fn name(&self) -> &'static str {
+        "LRPT"
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lrpt_config_matches_dsp_constant() {
+        let demod = LrptDemodulator::new();
+        let cfg = demod.config();
+        assert!((cfg.if_sample_rate - 144_000.0).abs() < f64::EPSILON);
+        assert!((cfg.af_sample_rate - cfg.if_sample_rate).abs() < f64::EPSILON);
+        assert!(cfg.bandwidth_locked);
+        assert!(!cfg.post_proc_enabled);
+        // None of the voice-mode features apply to a QPSK signal —
+        // make sure the config gates them off so a future "enable
+        // squelch on every demod" refactor can't accidentally
+        // shape the IQ before the LRPT tap reads it.
+        assert!(!cfg.fm_if_nr_allowed);
+        assert!(!cfg.nb_allowed);
+        assert!(!cfg.high_pass_allowed);
+        assert!(!cfg.squelch_allowed);
+        assert!(!cfg.deemp_allowed);
+    }
+
+    #[test]
+    fn test_lrpt_produces_silent_stereo() {
+        let mut demod = LrptDemodulator::new();
+        let input = [
+            Complex::new(0.5, -0.3),
+            Complex::new(-1.0, 0.7),
+            Complex::new(0.0, 0.0),
+        ];
+        let mut output = [Stereo::default(); 3];
+        let count = demod.process(&input, &mut output).unwrap();
+        assert_eq!(count, 3);
+        // All output is silent — the LRPT tap consumes the IQ
+        // upstream; the AF chain has nothing to emit.
+        for s in &output {
+            assert_eq!(s.l, 0.0);
+            assert_eq!(s.r, 0.0);
+        }
+    }
+
+    #[test]
+    fn test_lrpt_rejects_undersized_output() {
+        let mut demod = LrptDemodulator::new();
+        let input = [Complex::new(1.0, 0.0); 4];
+        let mut output = [Stereo::default(); 2];
+        let err = demod.process(&input, &mut output);
+        assert!(matches!(
+            err,
+            Err(DspError::BufferTooSmall { need: 4, got: 2 })
+        ));
+    }
+
+    #[test]
+    fn test_lrpt_set_bandwidth_is_no_op() {
+        // Locked-bandwidth contract: set_bandwidth doesn't error
+        // (so callers don't have to special-case LRPT) but
+        // doesn't change anything either.
+        let mut demod = LrptDemodulator::new();
+        let before = demod.config().default_bandwidth;
+        demod.set_bandwidth(38_000.0);
+        let after = demod.config().default_bandwidth;
+        assert_eq!(before, after);
+    }
+}

--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -7,6 +7,7 @@
 mod am;
 mod cw;
 mod dsb;
+mod lrpt;
 mod lsb;
 mod nfm;
 mod raw;
@@ -48,6 +49,7 @@ pub(crate) fn process_with_agc_to_stereo(
 pub use am::AmDemodulator;
 pub use cw::CwDemodulator;
 pub use dsb::DsbDemodulator;
+pub use lrpt::LrptDemodulator;
 pub use lsb::LsbDemodulator;
 pub use nfm::NfmDemodulator;
 pub use raw::RawDemodulator;
@@ -146,6 +148,7 @@ pub fn create_demodulator(
         DemodMode::Dsb => Ok(Box::new(DsbDemodulator::new()?)),
         DemodMode::Cw => Ok(Box::new(CwDemodulator::new()?)),
         DemodMode::Raw => Ok(Box::new(RawDemodulator::new())),
+        DemodMode::Lrpt => Ok(Box::new(LrptDemodulator::new())),
     }
 }
 
@@ -185,6 +188,7 @@ mod tests {
             DemodMode::Dsb,
             DemodMode::Cw,
             DemodMode::Raw,
+            DemodMode::Lrpt,
         ];
         for mode in modes {
             let demod = create_demodulator(mode);
@@ -203,6 +207,7 @@ mod tests {
             DemodMode::Dsb,
             DemodMode::Cw,
             DemodMode::Raw,
+            DemodMode::Lrpt,
         ];
         for mode in modes {
             let demod = create_demodulator(mode).unwrap();

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -9,6 +9,7 @@ pub mod apt_image;
 pub mod apt_telemetry;
 pub mod demod;
 pub mod if_chain;
+pub mod lrpt_decoder;
 pub mod lrpt_image;
 
 use sdr_dsp::filter::{DEEMPHASIS_TAU_EU, DEEMPHASIS_TAU_US};

--- a/crates/sdr-radio/src/lrpt_decoder.rs
+++ b/crates/sdr-radio/src/lrpt_decoder.rs
@@ -104,6 +104,11 @@ impl LrptDecoder {
             if channel.lines <= already {
                 continue;
             }
+            // Track lines actually pushed so that if the bounds
+            // guard below trips, the watermark doesn't jump past
+            // un-pushed rows and permanently drop them. Per
+            // CodeRabbit round 1 on PR #543.
+            let mut pushed = already;
             for line_idx in already..channel.lines {
                 let start = line_idx * IMAGE_WIDTH;
                 let end = start + IMAGE_WIDTH;
@@ -119,8 +124,9 @@ impl LrptDecoder {
                     break;
                 }
                 self.image.push_line(apid, &channel.pixels[start..end]);
+                pushed = line_idx + 1;
             }
-            self.last_pushed_lines.insert(apid, channel.lines);
+            self.last_pushed_lines.insert(apid, pushed);
         }
     }
 

--- a/crates/sdr-radio/src/lrpt_decoder.rs
+++ b/crates/sdr-radio/src/lrpt_decoder.rs
@@ -1,0 +1,219 @@
+//! Meteor-M LRPT receive driver — bridges the post-VFO IQ buffer
+//! to the QPSK demod + FEC chain + image assembler, and pushes
+//! newly-decoded scan lines into the shared [`LrptImage`] handle
+//! the live viewer reads from.
+//!
+//! Mirrors the role of `sdr_core::controller::apt_decode_tap` for
+//! LRPT — except APT runs on demodulated audio (post-FM, mono
+//! downmix) while LRPT runs on the IQ that would have been fed
+//! to the FM demod. The controller's
+//! [`DemodMode::Lrpt`](sdr_types::DemodMode::Lrpt) branch reads
+//! `radio_input` (IQ at 144 ksps thanks to the VFO + LRPT demod's
+//! IF rate) and drives this decoder before
+//! `RadioModule::process` runs (the LRPT mode's "demod" is a
+//! silent passthrough).
+//!
+//! Lifecycle:
+//!
+//! - **Construction** — Caller passes the shared [`LrptImage`].
+//!   `LrptDecoder::new` sets up the demod + pipeline + the
+//!   per-APID line-watermark map.
+//! - **Per chunk** — [`Self::process`] streams IQ through
+//!   `LrptDemod::process` → `LrptPipeline::push_symbol`. After
+//!   consuming the chunk, walks each channel in the pipeline's
+//!   assembler and pushes any newly-appended scan lines to the
+//!   shared [`LrptImage`]. The `last_pushed_lines: APID → count`
+//!   map tracks what's already been forwarded so the same line
+//!   never gets pushed twice.
+//! - **Between passes** — Caller drops + reconstructs (or calls
+//!   [`Self::reset`]) so the pipeline's internal state and the
+//!   line-watermark map all flush cleanly. Same idiom the
+//!   APT decoder uses.
+
+use std::collections::HashMap;
+
+use sdr_dsp::lrpt::LrptDemod;
+use sdr_lrpt::LrptPipeline;
+use sdr_lrpt::image::IMAGE_WIDTH;
+use sdr_types::{Complex, DspError};
+
+use crate::lrpt_image::LrptImage;
+
+/// Driver that ties IQ in to per-channel scan lines out.
+pub struct LrptDecoder {
+    demod: LrptDemod,
+    pipeline: LrptPipeline,
+    image: LrptImage,
+    /// Per-APID watermark — the last `channel.lines` count we
+    /// pushed into the shared `LrptImage`. Indexed by APID
+    /// (16-bit) since that's the identifier the demux stamps
+    /// onto each [`sdr_lrpt::ccsds::ImagePacket`]. New lines
+    /// (`channel.lines > watermark`) get pushed and the
+    /// watermark advances.
+    last_pushed_lines: HashMap<u16, usize>,
+}
+
+impl LrptDecoder {
+    /// Build a fresh decoder around the given shared image.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if the underlying
+    /// [`LrptDemod`] constructor rejects its parameters
+    /// (practically unreachable — see that constructor's docs).
+    pub fn new(image: LrptImage) -> Result<Self, DspError> {
+        Ok(Self {
+            demod: LrptDemod::new()?,
+            pipeline: LrptPipeline::new(),
+            image,
+            last_pushed_lines: HashMap::new(),
+        })
+    }
+
+    /// Stream one chunk of post-VFO IQ samples through the
+    /// chain. Each input sample feeds the QPSK demod; emitted
+    /// soft-symbol pairs feed the FEC chain (Viterbi → ASM
+    /// sync → derand → RS → demux → JPEG decode → image
+    /// assembly). After the loop, harvest any new scan lines
+    /// from the pipeline's internal assembler and forward them
+    /// to the shared [`LrptImage`] for the live viewer to read.
+    ///
+    /// `samples` is at the LRPT working sample rate
+    /// ([`sdr_dsp::lrpt::SAMPLE_RATE_HZ`] = 144 ksps); the
+    /// caller is responsible for the VFO + IF-chain plumbing
+    /// that delivers IQ at that rate.
+    pub fn process(&mut self, samples: &[Complex]) {
+        for &sample in samples {
+            if let Some(soft) = self.demod.process(sample) {
+                self.pipeline.push_symbol(soft);
+            }
+        }
+        self.harvest_new_lines();
+    }
+
+    /// Walk the pipeline's assembler and push every line that's
+    /// new since the last harvest into the shared
+    /// [`LrptImage`]. Tracks per-APID watermarks so the same
+    /// line is never pushed twice — `push_line` in the shared
+    /// image is append-only, so a duplicate would show up as a
+    /// repeated row in the rendered viewer.
+    fn harvest_new_lines(&mut self) {
+        let assembler = self.pipeline.assembler();
+        for (&apid, channel) in assembler.channels() {
+            let already = self.last_pushed_lines.get(&apid).copied().unwrap_or(0);
+            if channel.lines <= already {
+                continue;
+            }
+            for line_idx in already..channel.lines {
+                let start = line_idx * IMAGE_WIDTH;
+                let end = start + IMAGE_WIDTH;
+                // Defensive bounds check — `place_mcu` always
+                // grows pixels by full-line increments, so this
+                // is structurally guaranteed; the explicit guard
+                // protects against a future refactor of the
+                // composite buffer that drops the invariant.
+                if end > channel.pixels.len() {
+                    tracing::warn!(
+                        "LrptDecoder: channel {apid} pixel buffer shorter than `lines * IMAGE_WIDTH`; skipping line {line_idx}",
+                    );
+                    break;
+                }
+                self.image.push_line(apid, &channel.pixels[start..end]);
+            }
+            self.last_pushed_lines.insert(apid, channel.lines);
+        }
+    }
+
+    /// Flush all chain state. Called between passes so the
+    /// next pass starts on a clean Viterbi traceback / sync
+    /// window / RS path. The shared image is also cleared so
+    /// the next pass paints onto a fresh canvas; the watermark
+    /// map resets so the harvest loop forwards every line of
+    /// the new pass.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError` if the demod re-construction fails
+    /// (see [`LrptDemod::new`]).
+    pub fn reset(&mut self) -> Result<(), DspError> {
+        self.demod = LrptDemod::new()?;
+        self.pipeline.reset();
+        self.image.clear();
+        self.last_pushed_lines.clear();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use sdr_lrpt::image::IMAGE_WIDTH;
+
+    /// APID used in the harvest test. AVHRR convention: 64 is
+    /// the conventional "channel 0" — same value the rest of
+    /// the test suite uses for single-channel cases.
+    const APID_TEST: u16 = 64;
+
+    #[test]
+    fn lrpt_decoder_constructible() {
+        let image = LrptImage::new();
+        let _decoder = LrptDecoder::new(image).expect("LrptDemod must construct");
+    }
+
+    #[test]
+    fn process_zero_iq_does_not_crash_or_push_lines() {
+        // Zero IQ produces no symbol locks → no VCDUs → no
+        // image lines. The decoder should run cleanly and the
+        // shared image should stay empty.
+        let image = LrptImage::new();
+        let mut decoder = LrptDecoder::new(image.clone()).unwrap();
+        let zeros = vec![Complex::default(); 1_000];
+        decoder.process(&zeros);
+        assert!(image.snapshot_channel(APID_TEST).is_none());
+    }
+
+    #[test]
+    fn harvest_pushes_only_new_lines() {
+        // Drive the harvest path directly by hand-feeding the
+        // pipeline's assembler via an internal route the test
+        // can simulate: place a synthetic line into the
+        // pipeline's assembler, run harvest, confirm it lands
+        // in the shared image.
+        //
+        // We can't easily synthesize a CADU here (that's what
+        // the FecChain / golden-fixture tests cover), so we
+        // exercise the harvest watermark logic in isolation
+        // via `pipeline.push_vcdu(empty)` — the existing
+        // pipeline tests confirm that path stays a no-op for
+        // garbage input. Instead, we validate the watermark
+        // ledger directly: an LrptDecoder constructed against
+        // an empty pipeline harvests nothing on the first
+        // call.
+        let image = LrptImage::new();
+        let mut decoder = LrptDecoder::new(image.clone()).unwrap();
+        // Empty pipeline → empty assembler → harvest is a no-op.
+        decoder.harvest_new_lines();
+        assert!(decoder.last_pushed_lines.is_empty());
+        assert!(image.snapshot_channel(APID_TEST).is_none());
+    }
+
+    #[test]
+    fn reset_clears_state_and_image() {
+        // Pre-populate the shared image with a line so we can
+        // verify reset() clears it.
+        let image = LrptImage::new();
+        image.push_line(APID_TEST, &vec![42_u8; IMAGE_WIDTH]);
+        assert!(image.snapshot_channel(APID_TEST).is_some());
+        let mut decoder = LrptDecoder::new(image.clone()).unwrap();
+        decoder.last_pushed_lines.insert(APID_TEST, 7);
+        decoder.reset().expect("reset must succeed");
+        assert!(decoder.last_pushed_lines.is_empty());
+        // Reset clears the shared image too — between-pass
+        // invariant: the next pass paints on a clean canvas.
+        assert!(
+            image.snapshot_channel(APID_TEST).is_none(),
+            "reset must clear the shared image",
+        );
+    }
+}

--- a/crates/sdr-radio/src/lrpt_image.rs
+++ b/crates/sdr-radio/src/lrpt_image.rs
@@ -43,6 +43,20 @@ impl Default for LrptImage {
     }
 }
 
+// Manual `Debug` so callers can put `LrptImage` in derived-`Debug`
+// enums (e.g. `UiToDsp::SetLrptImage`) without forcing
+// `ImageAssembler` to expose its internals through derived
+// `Debug`. The handle is opaque from the outside — the only
+// observable identity is its existence — so a placeholder print
+// is faithful and avoids accidentally locking the mutex from a
+// `Debug` formatter (which would otherwise let a panic'd holder
+// poison logging too).
+impl std::fmt::Debug for LrptImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LrptImage").finish_non_exhaustive()
+    }
+}
+
 /// Acquire the assembler lock, recovering from a poisoned mutex
 /// by logging a warning and returning the inner guard via
 /// [`PoisonError::into_inner`].

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -94,14 +94,15 @@ pub struct KnownSatellite {
     /// the upcoming #482b work) by the "tune to this satellite" play
     /// button.
     pub downlink_hz: u64,
-    /// Demod mode the receiver should be in for this satellite. NFM
-    /// for everything we ship today: NOAA APT, Meteor LRPT, and ISS
-    /// SSTV all ride wide-FM-style channels and our demod chain
-    /// handles them through the same NFM front-end with a wider
-    /// channel filter. Tracked as a field rather than hardcoded so a
-    /// future amateur-band catalog addition (e.g. AO-92 with FM voice
-    /// vs PSK telemetry) can choose differently without a special
-    /// case in the wiring layer.
+    /// Demod mode the receiver should be in for this satellite.
+    /// NFM for NOAA APT and ISS (wide-FM-style audio channels);
+    /// LRPT for Meteor-M (the controller's `lrpt_decode_tap`
+    /// drives the QPSK demod + FEC chain off the post-VFO IQ
+    /// at 144 ksps, and the LRPT mode's silent-passthrough demod
+    /// makes that the IF rate). Tracked as a field rather than
+    /// hardcoded so a future amateur-band catalog addition
+    /// (e.g. AO-92 with FM voice vs PSK telemetry) can choose
+    /// differently without a special case in the wiring layer.
     pub demod_mode: sdr_types::DemodMode,
     /// Channel bandwidth (Hz) the receiver should use for this
     /// satellite. APT / LRPT / SSTV all need ~38 kHz of headroom
@@ -153,24 +154,35 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     // Meteor-M LRPT — epic #469. Note: METEOR-M 2 and NOAA 19 share
     // the 137.100 MHz channel — they're never on simultaneously by
     // design. The pass scheduler picks whichever is overhead.
-    // `imaging_protocol: None` keeps these out of the auto-record
-    // flow until Task 7 wires the live LRPT viewer; user can still
-    // see upcoming passes in the panel.
+    // `imaging_protocol: Some(Lrpt)` enrolls these in the
+    // auto-record flow per epic #469 task 7. The recorder
+    // constructor's `supported_protocols` set now includes
+    // `Lrpt`, the wiring layer's `interpret_action` opens the
+    // LRPT viewer + signals the DSP to attach the decoder, and
+    // the LOS save walks every decoded APID into a per-pass
+    // directory.
     KnownSatellite {
         name: "METEOR-M 2",
         norad_id: 40_069,
         downlink_hz: 137_100_000,
-        demod_mode: sdr_types::DemodMode::Nfm,
+        // LRPT mode runs the IF chain at 144 ksps and feeds the
+        // post-VFO IQ straight into the QPSK demod + FEC chain
+        // via the controller's `lrpt_decode_tap` (epic #469
+        // task 7.3). NFM would smear the QPSK constellation.
+        demod_mode: sdr_types::DemodMode::Lrpt,
+        // `set_bandwidth` is a no-op in LRPT mode (the demod's
+        // channel filter is locked at the IF rate); we keep the
+        // shared default for consistency with other entries.
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
-        imaging_protocol: None,
+        imaging_protocol: Some(ImagingProtocol::Lrpt),
     },
     KnownSatellite {
         name: "METEOR-M2 3",
         norad_id: 57_166,
         downlink_hz: 137_900_000,
-        demod_mode: sdr_types::DemodMode::Nfm,
+        demod_mode: sdr_types::DemodMode::Lrpt,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
-        imaging_protocol: None,
+        imaging_protocol: Some(ImagingProtocol::Lrpt),
     },
     // METEOR-M2 4 (NORAD 61024) deliberately omitted — launched 2024,
     // failed shortly after, no usable TLE on Celestrak (404 from the
@@ -272,16 +284,22 @@ mod tests {
                 s.name,
             );
         }
-        // METEOR satellites → None for this PR. Task 7 of epic
-        // #469 flips them to Some(Lrpt) once the live LRPT
-        // viewer + decoder driver are wired.
-        for s in KNOWN_SATELLITES
+        // METEOR satellites → Lrpt (epic #469 task 7). Both
+        // METEOR-M 2 and METEOR-M2 3 ship with Some(Lrpt) once
+        // the live LRPT viewer + decoder driver are wired.
+        let meteors: Vec<&KnownSatellite> = KNOWN_SATELLITES
             .iter()
             .filter(|s| s.name.starts_with("METEOR"))
-        {
+            .collect();
+        assert!(
+            !meteors.is_empty(),
+            "catalog regression: no METEOR entries found",
+        );
+        for s in meteors {
             assert_eq!(
-                s.imaging_protocol, None,
-                "{} should be None until Task 7 of epic #469",
+                s.imaging_protocol,
+                Some(ImagingProtocol::Lrpt),
+                "{} should be Lrpt (Meteor LRPT shipped in epic #469 task 7)",
                 s.name,
             );
         }

--- a/crates/sdr-types/src/enums.rs
+++ b/crates/sdr-types/src/enums.rs
@@ -17,6 +17,14 @@ pub enum DemodMode {
     Cw,
     /// Raw IQ passthrough.
     Raw,
+    /// Meteor-M LRPT receive mode. Like `Raw` but the
+    /// `RadioModule` runs at 144 ksps IF rate (the LRPT working
+    /// rate per `sdr_dsp::lrpt::SAMPLE_RATE_HZ`) so the post-VFO
+    /// IQ is fed straight into the QPSK demod + FEC chain by
+    /// the controller's LRPT tap. Audio output is silent stereo
+    /// — there's no listenable signal mid-pass; the imagery is
+    /// the artifact. Per epic #469 Task 7.
+    Lrpt,
 }
 
 /// Network IQ sample format — matches SDR++ `SampleType` enum.

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -43,6 +43,10 @@ sdr-dsp.workspace = true
 sdr-pipeline.workspace = true
 sdr-config.workspace = true
 sdr-radio.workspace = true
+# LRPT image-assembler types (`IMAGE_WIDTH`, `ChannelBuffer`) used
+# by the live LRPT viewer to decode the shared `LrptImage`
+# handle's per-APID scan-line buffers.
+sdr-lrpt.workspace = true
 sdr-rtlsdr.workspace = true
 # Satellite pass predictor — used by the Satellites scheduler panel
 # to enumerate upcoming overhead passes and refresh TLEs from

--- a/crates/sdr-ui/src/header/demod_selector.rs
+++ b/crates/sdr-ui/src/header/demod_selector.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use sdr_types::DemodMode;
 
 /// Display labels for each demodulation mode, in dropdown order.
-const DEMOD_LABELS: &[&str] = &["WFM", "NFM", "AM", "USB", "LSB", "DSB", "CW", "RAW"];
+const DEMOD_LABELS: &[&str] = &["WFM", "NFM", "AM", "USB", "LSB", "DSB", "CW", "RAW", "LRPT"];
 
 /// Number of available demod modes.
 #[allow(clippy::cast_possible_truncation)]
@@ -22,6 +22,7 @@ const DEMOD_MODES: &[DemodMode] = &[
     DemodMode::Dsb,
     DemodMode::Cw,
     DemodMode::Raw,
+    DemodMode::Lrpt,
 ];
 
 /// Default demod mode index (WFM = 0).
@@ -123,5 +124,6 @@ mod tests {
         assert_eq!(demod_mode_label(DemodMode::Dsb), "DSB");
         assert_eq!(demod_mode_label(DemodMode::Cw), "CW");
         assert_eq!(demod_mode_label(DemodMode::Raw), "RAW");
+        assert_eq!(demod_mode_label(DemodMode::Lrpt), "LRPT");
     }
 }

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -16,6 +16,7 @@ pub mod app;
 pub mod apt_viewer;
 pub mod css;
 pub mod header;
+pub mod lrpt_viewer;
 pub mod notify;
 pub mod preferences;
 pub mod radioreference;

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -458,13 +458,25 @@ impl LrptImageRenderer {
 /// Pixel-buffer length mismatch (`pixels.len() != width * height`)
 /// is reported as a stringified error rather than silently
 /// truncating.
-#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub fn write_greyscale_png(
     path: &Path,
     pixels: &[u8],
     width: usize,
     height: usize,
 ) -> Result<(), String> {
+    // Validate dimensions fit Cairo's `i32` API up front. The
+    // earlier draft `as i32`-cast both, which silently wraps for
+    // any usize > i32::MAX (2.1 G) into a negative or bogus
+    // surface request. Practically unreachable for LRPT
+    // (IMAGE_WIDTH = 1568, MAX_LINES = 8192) but
+    // `write_greyscale_png` is a `pub` library function and the
+    // `#[allow(cast_possible_wrap)]` would have hidden the
+    // wrap, not prevented it. Per `CodeRabbit` round 9 on PR
+    // #543.
+    let width_i32 = i32::try_from(width)
+        .map_err(|_| format!("greyscale PNG: width {width} exceeds i32::MAX"))?;
+    let height_i32 = i32::try_from(height)
+        .map_err(|_| format!("greyscale PNG: height {height} exceeds i32::MAX"))?;
     let expected = width
         .checked_mul(height)
         .ok_or_else(|| format!("greyscale PNG: width*height overflow ({width} × {height})"))?;
@@ -484,9 +496,8 @@ pub fn write_greyscale_png(
         std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
     }
 
-    let mut surface =
-        cairo::ImageSurface::create(cairo::Format::ARgb32, width as i32, height as i32)
-            .map_err(|e| format!("export surface: {e}"))?;
+    let mut surface = cairo::ImageSurface::create(cairo::Format::ARgb32, width_i32, height_i32)
+        .map_err(|e| format!("export surface: {e}"))?;
     {
         let stride =
             usize::try_from(surface.stride()).map_err(|e| format!("invalid stride: {e}"))?;
@@ -678,6 +689,17 @@ impl LrptImageView {
                 // side, plus `PushOutcome::consumed()` for the
                 // renderer-side failure case. Per `CodeRabbit`
                 // rounds 2 + 3 on PR #543.
+                // Track whether ANY row actually painted this
+                // pass. `Capped` / `InvalidLine` advance the
+                // watermark (so the row is "consumed" — see
+                // `PushOutcome::consumed`) but don't change the
+                // visible canvas, and `TransientFailure` doesn't
+                // even advance. Without this distinction, a
+                // channel parked at MAX_LINES would queue a redraw
+                // every 250 ms tick forever — wasted GPU work
+                // for an unchanged image. Per `CodeRabbit` round
+                // 9 on PR #543.
+                let mut painted_any = false;
                 let mut pushed = already;
                 for line_idx in already..channel.lines {
                     let start = line_idx * IMAGE_WIDTH;
@@ -700,10 +722,15 @@ impl LrptImageView {
                         // tick will pick up where we left off.
                         break;
                     }
+                    if matches!(outcome, PushOutcome::Pushed) {
+                        painted_any = true;
+                    }
                     pushed = line_idx + 1;
                 }
                 last_seen.insert(apid, pushed);
-                any_new = true;
+                if painted_any {
+                    any_new = true;
+                }
             }
         });
         drop(renderer);

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -745,15 +745,34 @@ fn build_channel_dropdown(view: &LrptImageView) -> gtk4::DropDown {
         move || {
             let mut current = view_for_tick.known_apids();
             current.sort_unstable();
-            if *dropdown_apids.borrow() == current {
+            // Cheap sync check: bail out only if BOTH the APID
+            // list AND the dropdown's selected channel still
+            // match the renderer's active APID. The selected-
+            // sync arm guards against an external caller
+            // (`SaveLrptPass` walks active_apid through every
+            // channel; future programmatic API users) changing
+            // `view.active_apid()` without changing the list,
+            // which the previous list-only fast-path would have
+            // ignored — leaving the dropdown stuck on the wrong
+            // channel until the next list change. Per
+            // `CodeRabbit` round 6 on PR #543.
+            let active = view_for_tick.active_apid();
+            let apids_unchanged = *dropdown_apids.borrow() == current;
+            #[allow(clippy::cast_possible_truncation)]
+            let selected_apid = {
+                let apids = dropdown_apids.borrow();
+                apids.get(dropdown_clone.selected() as usize).copied()
+            };
+            if apids_unchanged && selected_apid == active {
                 return glib::ControlFlow::Continue;
             }
-            let active = view_for_tick.active_apid();
-            model.splice(0, model.n_items(), &[]);
-            for &apid in &current {
-                model.append(&format!("APID {apid}"));
+            if !apids_unchanged {
+                model.splice(0, model.n_items(), &[]);
+                for &apid in &current {
+                    model.append(&format!("APID {apid}"));
+                }
+                dropdown_apids.borrow_mut().clone_from(&current);
             }
-            dropdown_apids.borrow_mut().clone_from(&current);
             dropdown_clone.set_sensitive(!current.is_empty());
             if let Some(active) = active {
                 if let Some(pos) = current.iter().position(|&a| a == active) {
@@ -838,6 +857,17 @@ pub fn open_lrpt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
         let Some(window_for_export) = window_for_export.upgrade() else {
             return;
         };
+        // Drain pending rows BEFORE deriving the export path —
+        // `drain_new_lines` may auto-select the first decoded
+        // APID (the renderer's `push_line` does so on first
+        // push to any channel), and we want the filename to
+        // reflect that resolved channel rather than the
+        // pre-drain `None` (which would land at
+        // `lrpt-unknown-...png`). `LrptImageView::export_png`
+        // also drains internally, but by that point we'd have
+        // already baked the stale APID into the path. Per
+        // `CodeRabbit` round 6 on PR #543.
+        export_view.drain_new_lines();
         let path = default_export_path(export_view.active_apid());
         let toast = match export_view.export_png(&path) {
             Ok(()) => adw::Toast::builder()

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -1132,6 +1132,16 @@ pub fn open_lrpt_viewer_if_needed(
     state: &Rc<crate::state::AppState>,
 ) {
     if state.lrpt_viewer.borrow().is_some() {
+        // Defensive re-attach: if a future code path ever
+        // detaches the DSP-side image (today nothing sends
+        // `ClearLrptImage`, but a future refactor might), the
+        // existing-viewer fast-path would silently leave the
+        // tap muted. Re-sending `SetLrptImage` is idempotent
+        // — the controller's handler no longer drops the
+        // decoder on attach (round 11 paired change), so
+        // mid-pass decoder state survives the round-trip. Per
+        // `CodeRabbit` round 11 on PR #543.
+        state.send_dsp(UiToDsp::SetLrptImage(state.lrpt_image.clone()));
         return;
     }
     let Some(parent) = parent_provider() else {

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -672,67 +672,100 @@ impl LrptImageView {
     /// the DSP thread on the lock for any longer than the
     /// strict copy time.
     pub fn drain_new_lines(&self) {
+        // Two-phase to keep the shared `LrptImage` mutex hold
+        // bounded. Phase 1 (under lock): walk the assembler and
+        // copy out the new rows per APID into owned `Vec<u8>`s.
+        // Phase 2 (lock released): hand the rows to the renderer,
+        // which may lazy-alloc a ~51 MB Cairo surface and acquire
+        // its surface-data lock — neither operation is fast
+        // enough to hold the assembler mutex across, since that
+        // would stall the DSP-thread writer behind it. Per
+        // `CodeRabbit` round 12 on PR #543.
+        struct PendingChannel {
+            apid: u16,
+            already: usize,
+            rows: Vec<Vec<u8>>,
+        }
+
+        // Phase 1 — under shared-image lock.
+        let pending: Vec<PendingChannel> = {
+            let last_seen = self.last_seen_lines.borrow();
+            let mut acc: Vec<PendingChannel> = Vec::new();
+            self.image.with_assembler(|a| {
+                for (&apid, channel) in a.channels() {
+                    let already = last_seen.get(&apid).copied().unwrap_or(0);
+                    if channel.lines <= already {
+                        continue;
+                    }
+                    let mut rows = Vec::with_capacity(channel.lines - already);
+                    for line_idx in already..channel.lines {
+                        let start = line_idx * IMAGE_WIDTH;
+                        let end = start + IMAGE_WIDTH;
+                        if end > channel.pixels.len() {
+                            // Defensive — see lrpt_decoder::harvest_new_lines
+                            // for the parallel guard. Structurally
+                            // unreachable; the warn protects against
+                            // a future refactor of the assembler
+                            // buffer.
+                            tracing::warn!(
+                                "LRPT view: channel {apid} pixel buffer shorter than expected; skipping line {line_idx}",
+                            );
+                            break;
+                        }
+                        rows.push(channel.pixels[start..end].to_vec());
+                    }
+                    acc.push(PendingChannel {
+                        apid,
+                        already,
+                        rows,
+                    });
+                }
+            });
+            acc
+        };
+
+        // Phase 2 — outside the shared-image lock.
         let mut any_new = false;
         let mut last_seen = self.last_seen_lines.borrow_mut();
         let mut renderer = self.renderer.borrow_mut();
-        self.image.with_assembler(|a| {
-            for (&apid, channel) in a.channels() {
-                let already = last_seen.get(&apid).copied().unwrap_or(0);
-                if channel.lines <= already {
-                    continue;
+        for p in pending {
+            // Track lines actually consumed so the watermark
+            // doesn't advance past either the bounds-guard
+            // skip path OR a transient renderer failure
+            // (surface alloc / stride / lock). Same shape as
+            // `lrpt_decoder::harvest_new_lines` on the DSP
+            // side, plus `PushOutcome::consumed()` for the
+            // renderer-side failure case. Per `CodeRabbit`
+            // rounds 2 + 3 on PR #543.
+            //
+            // `painted_any` only flips on `PushOutcome::Pushed`.
+            // `Capped` / `InvalidLine` advance the watermark (so
+            // the row is "consumed" — see `PushOutcome::consumed`)
+            // but don't change the visible canvas, and
+            // `TransientFailure` doesn't even advance. Without
+            // this distinction, a channel parked at MAX_LINES
+            // would queue a redraw every 250 ms tick forever —
+            // wasted GPU work for an unchanged image. Per
+            // `CodeRabbit` round 9 on PR #543.
+            let mut painted_any = false;
+            let mut pushed = p.already;
+            for (offset, row) in p.rows.iter().enumerate() {
+                let outcome = renderer.push_line(p.apid, row);
+                if !outcome.consumed() {
+                    // Transient failure — leave this row in the
+                    // source so the next poll retries.
+                    break;
                 }
-                // Track lines actually consumed so the watermark
-                // doesn't advance past either the bounds-guard
-                // skip path OR a transient renderer failure
-                // (surface alloc / stride / lock). Same shape as
-                // `lrpt_decoder::harvest_new_lines` on the DSP
-                // side, plus `PushOutcome::consumed()` for the
-                // renderer-side failure case. Per `CodeRabbit`
-                // rounds 2 + 3 on PR #543.
-                // Track whether ANY row actually painted this
-                // pass. `Capped` / `InvalidLine` advance the
-                // watermark (so the row is "consumed" — see
-                // `PushOutcome::consumed`) but don't change the
-                // visible canvas, and `TransientFailure` doesn't
-                // even advance. Without this distinction, a
-                // channel parked at MAX_LINES would queue a redraw
-                // every 250 ms tick forever — wasted GPU work
-                // for an unchanged image. Per `CodeRabbit` round
-                // 9 on PR #543.
-                let mut painted_any = false;
-                let mut pushed = already;
-                for line_idx in already..channel.lines {
-                    let start = line_idx * IMAGE_WIDTH;
-                    let end = start + IMAGE_WIDTH;
-                    if end > channel.pixels.len() {
-                        // Defensive — see lrpt_decoder::harvest_new_lines
-                        // for the parallel guard. Structurally
-                        // unreachable; the warn protects against a
-                        // future refactor of the assembler buffer.
-                        tracing::warn!(
-                            "LRPT view: channel {apid} pixel buffer shorter than expected; skipping line {line_idx}",
-                        );
-                        break;
-                    }
-                    let outcome = renderer.push_line(apid, &channel.pixels[start..end]);
-                    if !outcome.consumed() {
-                        // Transient failure — leave this row in
-                        // the source so the next poll retries.
-                        // Don't break the outer loop; the next
-                        // tick will pick up where we left off.
-                        break;
-                    }
-                    if matches!(outcome, PushOutcome::Pushed) {
-                        painted_any = true;
-                    }
-                    pushed = line_idx + 1;
+                if matches!(outcome, PushOutcome::Pushed) {
+                    painted_any = true;
                 }
-                last_seen.insert(apid, pushed);
-                if painted_any {
-                    any_new = true;
-                }
+                pushed = p.already + offset + 1;
             }
-        });
+            last_seen.insert(p.apid, pushed);
+            if painted_any {
+                any_new = true;
+            }
+        }
         drop(renderer);
         drop(last_seen);
 

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -87,18 +87,20 @@ const BYTES_PER_PIXEL: usize = 4;
 
 /// Default size for the viewer window. A typical Meteor MSU-MR
 /// pass produces ~3600 lines × 1568 px (portrait, ~1:2 aspect)
-/// at full duration, so the image will scroll vertically inside
-/// the window for most of the pass. The default 900 × 600
-/// landscape footprint is chosen for ergonomics rather than
-/// aspect match: it sits comfortably alongside the main radio
-/// window on a typical 1080p+ desktop, fills well during the
-/// early-pass phase when the image is still short and wide, and
-/// the user can resize freely once they see how the pass is
-/// developing. (Pre-round-2 the comment claimed "wider than
-/// tall because typical pass heights are ~600 lines" — that
-/// assumption was based on the old 1024-line cap and stopped
-/// holding once `MAX_LINES` bumped to 8192.) Per `CodeRabbit`
-/// round 14 on PR #543.
+/// at full duration. There's no scroll path — `DrawingArea`
+/// sits directly under `ToolbarView` and `LrptImageRenderer::render`
+/// scales the full image to fit the available area, preserving
+/// aspect — so the visible pixels per scan-line drop as the
+/// image grows tall. The default 900 × 600 landscape footprint
+/// is chosen for ergonomics rather than aspect match: it sits
+/// comfortably alongside the main radio window on a typical
+/// 1080p+ desktop, fills well during the early-pass phase when
+/// the image is still short and wide, and the user can resize
+/// freely once they see how the pass is developing. (Pre-round-2
+/// the comment claimed "wider than tall because typical pass
+/// heights are ~600 lines" — that assumption was based on the
+/// old 1024-line cap and stopped holding once `MAX_LINES`
+/// bumped to 8192.) Per `CodeRabbit` rounds 14 + 15 on PR #543.
 const VIEWER_WINDOW_WIDTH: i32 = 900;
 const VIEWER_WINDOW_HEIGHT: i32 = 600;
 
@@ -832,21 +834,27 @@ impl LrptImageView {
     /// Drains any pending rows from the shared `LrptImage`
     /// into the renderer first, so the export captures the tail
     /// of the pass even if it arrived after the most recent
-    /// poll tick. Without this, the LOS `SaveLrptPass` flow —
-    /// which exports immediately on receipt of the LOS action,
-    /// not on the next 250 ms poll — would systematically miss
-    /// the last fraction-of-a-second of decoded data. Per
-    /// `CodeRabbit` round 1 on PR #543.
+    /// poll tick. Without this, an immediate-export flow would
+    /// systematically miss the last fraction-of-a-second of
+    /// decoded data. Per `CodeRabbit` round 1 on PR #543.
     ///
-    /// **Caller is responsible for off-main-thread dispatch.**
-    /// This function performs Cairo PNG encoding + filesystem
-    /// I/O synchronously and will freeze the GTK main loop on
-    /// large images. Use [`Self::snapshot_active_channel`] +
-    /// [`write_greyscale_png`] inside `gio::spawn_blocking` for
-    /// the GTK click-handler path. The recorder LOS handler in
-    /// `window.rs` already does this; the manual Export PNG
-    /// button in [`open_lrpt_viewer_window`] does too. Per
-    /// `CodeRabbit` rounds 7 + 8 + 10 on PR #543.
+    /// **Main-thread only.** `drain_new_lines` invokes
+    /// `DrawingArea::queue_draw`, which GTK4 requires on the
+    /// main thread, so this method cannot be moved to
+    /// `gio::spawn_blocking` directly. It also performs
+    /// synchronous Cairo PNG encoding + filesystem I/O — large
+    /// images (~50 MB cap) will freeze the GTK main loop while
+    /// it runs. For the GTK click-handler / LOS-save path, use
+    /// [`Self::snapshot_active_channel`] on the main thread
+    /// (cheap mutex-clone, also drains rows + queues the redraw)
+    /// followed by [`write_greyscale_png`] inside
+    /// `gio::spawn_blocking` — that's how the manual Export PNG
+    /// button in [`open_lrpt_viewer_window`] and the recorder's
+    /// `RecorderAction::SaveLrptPass` handler in `window.rs`
+    /// dispatch heavy exports today. Kept as a convenience for
+    /// any future caller that genuinely wants the synchronous
+    /// path (small test exports, scripted batch flows). Per
+    /// `CodeRabbit` round 15 on PR #543.
     ///
     /// # Errors
     ///

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -164,7 +164,7 @@ struct ChannelSurface {
 
 impl ChannelSurface {
     /// Allocate a fresh full-pass-sized surface for one APID.
-    /// Returns `None` if Cairo can't allocate the (~6 MB) ARGB32
+    /// Returns `None` if Cairo can't allocate the (~51 MB) ARGB32
     /// surface — practically unreachable on any desktop machine,
     /// but the library-crate "no panic" rule still applies.
     /// Per `CodeRabbit` round 1 on PR #543: the earlier draft
@@ -328,7 +328,7 @@ impl LrptImageRenderer {
     }
 
     /// Drop all per-channel surfaces. The `HashMap` allocation
-    /// itself is preserved, but each ~6 MB surface is freed —
+    /// itself is preserved, but each ~51 MB surface is freed —
     /// callers (between-pass cleanup) typically rebuild from
     /// scratch as new channels reappear.
     pub fn clear(&mut self) {
@@ -555,7 +555,7 @@ pub struct LrptImageView {
     /// drain tick) and by `open_lrpt_viewer_window` (the
     /// channel-dropdown refresh tick). [`Self::shutdown`]
     /// removes them all so the closures' `Rc` chains drop and
-    /// the view + ~6 MB-per-channel surfaces don't leak past
+    /// the view + ~51 MB-per-channel surfaces don't leak past
     /// the window's close-request. Per `CodeRabbit` round 1 on
     /// PR #543.
     timeout_ids: Rc<RefCell<Vec<glib::SourceId>>>,
@@ -618,7 +618,7 @@ impl LrptImageView {
     /// Cancel every registered `glib` source. Called on the
     /// viewer window's `close-request` so the timeout closures
     /// drop their `Rc` clones of the view's inner state — without
-    /// this, the view + ~6 MB-per-channel surfaces stay alive in
+    /// this, the view + ~51 MB-per-channel surfaces stay alive in
     /// the main context until the application exits. Safe to
     /// call more than once (subsequent calls are no-ops because
     /// the `Vec` is drained).
@@ -789,12 +789,42 @@ impl LrptImageView {
     /// the last fraction-of-a-second of decoded data. Per
     /// `CodeRabbit` round 1 on PR #543.
     ///
+    /// **Caller is responsible for off-main-thread dispatch.**
+    /// This function performs Cairo PNG encoding + filesystem
+    /// I/O synchronously and will freeze the GTK main loop on
+    /// large images. Use [`Self::snapshot_active_channel`] +
+    /// [`write_greyscale_png`] inside `gio::spawn_blocking` for
+    /// the GTK click-handler path. The recorder LOS handler in
+    /// `window.rs` already does this; the manual Export PNG
+    /// button in [`open_lrpt_viewer_window`] does too. Per
+    /// `CodeRabbit` rounds 7 + 8 + 10 on PR #543.
+    ///
     /// # Errors
     ///
     /// Propagates any error from the underlying renderer.
     pub fn export_png(&self, path: &Path) -> Result<(), String> {
         self.drain_new_lines();
         self.renderer.borrow().export_png(path)
+    }
+
+    /// Snapshot the currently-active channel's pixel data into
+    /// an owned `(apid, ChannelBuffer)` pair. Used by the
+    /// manual Export PNG button to hand the heavy encoding work
+    /// to `gio::spawn_blocking` without holding `Rc`-shared
+    /// renderer state across the future. Drains pending rows
+    /// from the shared `LrptImage` first so the snapshot
+    /// captures the tail of the pass.
+    ///
+    /// Returns `None` if no APID is currently selected, or if
+    /// the active APID has no decoded rows in the shared image.
+    pub fn snapshot_active_channel(&self) -> Option<(u16, sdr_lrpt::image::ChannelBuffer)> {
+        self.drain_new_lines();
+        let apid = self.renderer.borrow().active_apid()?;
+        let snap = self.image.snapshot_channel(apid)?;
+        if snap.lines == 0 {
+            return None;
+        }
+        Some((apid, snap))
     }
 }
 
@@ -833,7 +863,7 @@ fn build_channel_dropdown(view: &LrptImageView) -> gtk4::DropDown {
     // a faster cadence would burn CPU on idle string compares).
     // Register the source on the view so `LrptImageView::shutdown`
     // can cancel it when the window closes; otherwise the closure's
-    // `view.clone()` would keep the view + ~6 MB-per-channel
+    // `view.clone()` would keep the view + ~51 MB-per-channel
     // surfaces alive forever.
     //
     // **Borrow scoping:** GTK4's `gtk4::DropDown::set_selected`
@@ -963,30 +993,62 @@ pub fn open_lrpt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
     let export_view = view.clone();
     let window_for_export = window.downgrade();
     export_btn.connect_clicked(move |_| {
-        let Some(window_for_export) = window_for_export.upgrade() else {
+        let Some(window_now) = window_for_export.upgrade() else {
             return;
         };
-        // Drain pending rows BEFORE deriving the export path —
-        // `drain_new_lines` may auto-select the first decoded
-        // APID (the renderer's `push_line` does so on first
-        // push to any channel), and we want the filename to
-        // reflect that resolved channel rather than the
-        // pre-drain `None` (which would land at
-        // `lrpt-unknown-...png`). `LrptImageView::export_png`
-        // also drains internally, but by that point we'd have
-        // already baked the stale APID into the path. Per
-        // `CodeRabbit` round 6 on PR #543.
-        export_view.drain_new_lines();
-        let path = default_export_path(export_view.active_apid());
-        let toast = match export_view.export_png(&path) {
-            Ok(()) => adw::Toast::builder()
-                .title(format!("Saved {}", path.display()))
-                .build(),
-            Err(e) => adw::Toast::builder()
-                .title(format!("PNG export failed: {e}"))
-                .build(),
+        // Snapshot the active channel's pixels on the GTK main
+        // thread (drains pending rows + clones the per-channel
+        // Vec<u8> under a brief mutex hold, then off-main-thread
+        // does the heavy PNG encoding + filesystem I/O via
+        // `gio::spawn_blocking`. Same pattern the LOS
+        // `SaveLrptPass` handler uses; before this round, the
+        // manual Export PNG button froze the GTK main loop on
+        // any large channel because Cairo PNG encoding is
+        // O(width × n_lines) and not negligible at the
+        // ≤8192-line cap. Per `CodeRabbit` round 10 on PR #543.
+        let Some((apid, snap)) = export_view.snapshot_active_channel() else {
+            // Either no APID is selected, or the active channel
+            // has no decoded rows yet. Surface as a clear toast
+            // rather than an opaque "no active channel" error.
+            show_toast_in(
+                &window_now,
+                adw::Toast::builder()
+                    .title("No LRPT channel data to export yet")
+                    .build(),
+            );
+            return;
         };
-        show_toast_in(&window_for_export, toast);
+        // Filename is derived AFTER the snapshot so the resolved
+        // APID lands in it (see CodeRabbit round 6 on PR #543).
+        let path = default_export_path(Some(apid));
+        let window_weak = window_now.downgrade();
+        glib::spawn_future_local(async move {
+            let path_for_msg = path.clone();
+            let result = gio::spawn_blocking(move || {
+                write_greyscale_png(&path, &snap.pixels, IMAGE_WIDTH, snap.lines)
+            })
+            .await;
+            let toast = match result {
+                Ok(Ok(())) => adw::Toast::builder()
+                    .title(format!("Saved {}", path_for_msg.display()))
+                    .build(),
+                Ok(Err(e)) => adw::Toast::builder()
+                    .title(format!("PNG export failed: {e}"))
+                    .build(),
+                Err(e) => {
+                    // Worker thread panicked. `Box<dyn Any>`
+                    // doesn't implement Display — log via Debug,
+                    // surface a generic message.
+                    tracing::warn!("manual LRPT export worker panicked: {e:?}");
+                    adw::Toast::builder()
+                        .title("PNG export worker panicked")
+                        .build()
+                }
+            };
+            if let Some(window) = window_weak.upgrade() {
+                show_toast_in(&window, toast);
+            }
+        });
     });
     header.pack_end(&export_btn);
 
@@ -1085,7 +1147,7 @@ pub fn open_lrpt_viewer_if_needed(
     window.connect_close_request(move |_| {
         // Cancel the view's drain + dropdown-refresh timeouts
         // BEFORE we drop the AppState slot; otherwise their
-        // closures' `Rc<view>` clones keep the view + ~6 MB-
+        // closures' `Rc<view>` clones keep the view + ~51 MB-
         // per-channel surfaces alive until the application
         // exits. Per `CodeRabbit` round 1 on PR #543.
         if let Some(view) = state_for_close.lrpt_viewer.borrow().as_ref() {

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -93,6 +93,13 @@ const VIEWER_WINDOW_HEIGHT: i32 = 600;
 /// content here, just discrete row appends.
 const POLL_INTERVAL_MS: u32 = 250;
 
+/// Refresh interval for the channel-dropdown population tick.
+/// Channel discovery on Meteor is rare (a handful of APIDs per
+/// pass, all surfaced within the first minute), so 1 Hz is
+/// plenty — anything faster would burn CPU on idle string
+/// compares. Per `CodeRabbit` round 5 on PR #543.
+const DROPDOWN_REFRESH_INTERVAL_MS: u32 = 1_000;
+
 /// What [`LrptImageRenderer::push_line`] did with the row.
 /// Drives the caller's per-APID watermark: rows that were
 /// committed (or permanently dropped because they're either
@@ -572,7 +579,6 @@ impl LrptImageView {
     /// the DSP thread on the lock for any longer than the
     /// strict copy time.
     pub fn drain_new_lines(&self) {
-        let mut new_apids: Vec<u16> = Vec::new();
         let mut any_new = false;
         let mut last_seen = self.last_seen_lines.borrow_mut();
         let mut renderer = self.renderer.borrow_mut();
@@ -582,7 +588,6 @@ impl LrptImageView {
                 if channel.lines <= already {
                     continue;
                 }
-                let known = renderer.channels.contains_key(&apid);
                 // Track lines actually consumed so the watermark
                 // doesn't advance past either the bounds-guard
                 // skip path OR a transient renderer failure
@@ -616,9 +621,6 @@ impl LrptImageView {
                     pushed = line_idx + 1;
                 }
                 last_seen.insert(apid, pushed);
-                if !known {
-                    new_apids.push(apid);
-                }
                 any_new = true;
             }
         });
@@ -738,33 +740,36 @@ fn build_channel_dropdown(view: &LrptImageView) -> gtk4::DropDown {
     // held during the `set_selected` calls.
     let view_for_tick = view.clone();
     let dropdown_clone = dropdown.clone();
-    let refresh_id = glib::timeout_add_local(std::time::Duration::from_secs(1), move || {
-        let mut current = view_for_tick.known_apids();
-        current.sort_unstable();
-        if *dropdown_apids.borrow() == current {
-            return glib::ControlFlow::Continue;
-        }
-        let active = view_for_tick.active_apid();
-        model.splice(0, model.n_items(), &[]);
-        for &apid in &current {
-            model.append(&format!("APID {apid}"));
-        }
-        dropdown_apids.borrow_mut().clone_from(&current);
-        dropdown_clone.set_sensitive(!current.is_empty());
-        if let Some(active) = active {
-            if let Some(pos) = current.iter().position(|&a| a == active) {
-                #[allow(clippy::cast_possible_truncation)]
-                dropdown_clone.set_selected(pos as u32);
+    let refresh_id = glib::timeout_add_local(
+        std::time::Duration::from_millis(u64::from(DROPDOWN_REFRESH_INTERVAL_MS)),
+        move || {
+            let mut current = view_for_tick.known_apids();
+            current.sort_unstable();
+            if *dropdown_apids.borrow() == current {
+                return glib::ControlFlow::Continue;
             }
-        } else if !current.is_empty() {
-            // No previous selection — pick the first APID
-            // (sorted) so the user sees something the moment
-            // data arrives. The `selected_notify` handler above
-            // will route the choice into the renderer.
-            dropdown_clone.set_selected(0);
-        }
-        glib::ControlFlow::Continue
-    });
+            let active = view_for_tick.active_apid();
+            model.splice(0, model.n_items(), &[]);
+            for &apid in &current {
+                model.append(&format!("APID {apid}"));
+            }
+            dropdown_apids.borrow_mut().clone_from(&current);
+            dropdown_clone.set_sensitive(!current.is_empty());
+            if let Some(active) = active {
+                if let Some(pos) = current.iter().position(|&a| a == active) {
+                    #[allow(clippy::cast_possible_truncation)]
+                    dropdown_clone.set_selected(pos as u32);
+                }
+            } else if !current.is_empty() {
+                // No previous selection — pick the first APID
+                // (sorted) so the user sees something the moment
+                // data arrives. The `selected_notify` handler above
+                // will route the choice into the renderer.
+                dropdown_clone.set_selected(0);
+            }
+            glib::ControlFlow::Continue
+        },
+    );
     view.register_source(refresh_id);
 
     dropdown

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -85,6 +85,42 @@ const VIEWER_WINDOW_HEIGHT: i32 = 600;
 /// content here, just discrete row appends.
 const POLL_INTERVAL_MS: u32 = 250;
 
+/// What [`LrptImageRenderer::push_line`] did with the row.
+/// Drives the caller's per-APID watermark: rows that were
+/// committed (or permanently dropped because they're either
+/// malformed or past the channel's [`MAX_LINES`] cap) advance the
+/// watermark; transient renderer failures leave the row in the
+/// source so the next poll can retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushOutcome {
+    /// Row was written into the per-APID Cairo surface.
+    Pushed,
+    /// Channel already at [`MAX_LINES`] — row intentionally
+    /// dropped. Caller should advance its watermark; further
+    /// data for this channel will keep hitting the cap no
+    /// matter how many retries.
+    Capped,
+    /// Caller bug — pixel slice didn't match [`IMAGE_WIDTH`].
+    /// Caller should advance its watermark; the data is
+    /// malformed at the source and retrying won't help.
+    InvalidLine,
+    /// Transient renderer-side failure (surface allocation,
+    /// stride conversion, or surface-data lock). Caller should
+    /// NOT advance its watermark — the next poll might succeed
+    /// (alloc relief, lock contention clearing).
+    TransientFailure,
+}
+
+impl PushOutcome {
+    /// `true` when the caller should advance its watermark past
+    /// this row. `false` means "leave it in the source for the
+    /// next poll to retry" — used only for [`Self::TransientFailure`].
+    #[must_use]
+    pub fn consumed(self) -> bool {
+        !matches!(self, Self::TransientFailure)
+    }
+}
+
 /// Pure Cairo renderer for a multi-channel LRPT image buffer.
 ///
 /// Owns one persistent ARGB32 [`cairo::ImageSurface`] per APID,
@@ -191,25 +227,33 @@ impl LrptImageRenderer {
     /// surface for `apid`, lazy-allocating the surface on the
     /// first push for that APID. Greyscale values go into the
     /// surface's backing data as ARGB32 (B/G/R/A — Cairo's
-    /// little-endian layout, alpha = `0xFF`). No-op once
-    /// [`MAX_LINES`] is reached for that channel.
+    /// little-endian layout, alpha = `0xFF`).
     ///
-    /// If `pixels.len()` doesn't equal [`IMAGE_WIDTH`], the line
-    /// is dropped with a warning — caller bug; this can't be
-    /// recovered from at the renderer layer.
-    pub fn push_line(&mut self, apid: u16, pixels: &[u8]) {
+    /// Returns a [`PushOutcome`] that callers (specifically
+    /// [`LrptImageView::drain_new_lines`]) inspect to decide
+    /// whether to advance their per-APID watermark. Pushed and
+    /// permanently-dropped rows (cap reached, malformed input)
+    /// advance the watermark; transient renderer failures
+    /// (surface alloc, stride conversion, surface-data lock)
+    /// leave the row in the source so the next poll can retry.
+    /// Per `CodeRabbit` round 3 on PR #543.
+    pub fn push_line(&mut self, apid: u16, pixels: &[u8]) -> PushOutcome {
         if pixels.len() != IMAGE_WIDTH {
             tracing::warn!(
                 "LRPT renderer: ignoring line for APID {apid} with {} pixels (expected {IMAGE_WIDTH})",
                 pixels.len(),
             );
-            return;
+            // Caller bug. Watermark should still advance —
+            // retrying with the same malformed input will only
+            // reproduce the same warn forever.
+            return PushOutcome::InvalidLine;
         }
         // Lazy alloc; `ChannelSurface::new` returns `None` if
-        // Cairo can't acquire the ~6 MB ARGB32 surface. Drop
-        // the line with a warn rather than panicking — the
-        // viewer keeps working for any already-allocated
-        // channels and the next line will retry.
+        // Cairo can't acquire the ~MAX-LINES-sized ARGB32
+        // surface. Drop the line with a warn rather than
+        // panicking — and report the failure as transient so
+        // the next poll retries (alloc may succeed later under
+        // memory pressure relief).
         let entry = match self.channels.entry(apid) {
             std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
             std::collections::hash_map::Entry::Vacant(e) => {
@@ -217,19 +261,22 @@ impl LrptImageRenderer {
                     tracing::warn!(
                         "LRPT renderer: surface alloc failed for APID {apid}; dropping line",
                     );
-                    return;
+                    return PushOutcome::TransientFailure;
                 };
                 e.insert(surface)
             }
         };
         if entry.n_lines >= MAX_LINES {
-            return;
+            // Surface full — advance watermark anyway. Further
+            // data for this channel will keep hitting the cap
+            // no matter how many times we retry.
+            return PushOutcome::Capped;
         }
         let stride = match usize::try_from(entry.surface.stride()) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!("LRPT renderer: invalid surface stride: {e}");
-                return;
+                return PushOutcome::TransientFailure;
             }
         };
         let row_offset = entry.n_lines * stride;
@@ -237,7 +284,7 @@ impl LrptImageRenderer {
             Ok(d) => d,
             Err(e) => {
                 tracing::warn!("LRPT renderer: surface data lock failed: {e}");
-                return;
+                return PushOutcome::TransientFailure;
             }
         };
         for (i, &g) in pixels.iter().enumerate() {
@@ -256,6 +303,7 @@ impl LrptImageRenderer {
         if self.active.is_none() {
             self.active = Some(apid);
         }
+        PushOutcome::Pushed
     }
 
     /// Drop all per-channel surfaces. The `HashMap` allocation
@@ -527,11 +575,14 @@ impl LrptImageView {
                     continue;
                 }
                 let known = renderer.channels.contains_key(&apid);
-                // Track lines actually pushed so the bounds-guard
-                // skip path can't permanently strand un-copied
-                // rows. Same fix as `lrpt_decoder::harvest_new_lines`
-                // — the parallel watermark on the DSP side. Per
-                // `CodeRabbit` round 2 on PR #543.
+                // Track lines actually consumed so the watermark
+                // doesn't advance past either the bounds-guard
+                // skip path OR a transient renderer failure
+                // (surface alloc / stride / lock). Same shape as
+                // `lrpt_decoder::harvest_new_lines` on the DSP
+                // side, plus `PushOutcome::consumed()` for the
+                // renderer-side failure case. Per `CodeRabbit`
+                // rounds 2 + 3 on PR #543.
                 let mut pushed = already;
                 for line_idx in already..channel.lines {
                     let start = line_idx * IMAGE_WIDTH;
@@ -546,7 +597,14 @@ impl LrptImageView {
                         );
                         break;
                     }
-                    renderer.push_line(apid, &channel.pixels[start..end]);
+                    let outcome = renderer.push_line(apid, &channel.pixels[start..end]);
+                    if !outcome.consumed() {
+                        // Transient failure — leave this row in
+                        // the source so the next poll retries.
+                        // Don't break the outer loop; the next
+                        // tick will pick up where we left off.
+                        break;
+                    }
                     pushed = line_idx + 1;
                 }
                 last_seen.insert(apid, pushed);
@@ -658,13 +716,24 @@ fn build_channel_dropdown(view: &LrptImageView) -> gtk4::DropDown {
     // can cancel it when the window closes; otherwise the closure's
     // `view.clone()` would keep the view + ~6 MB-per-channel
     // surfaces alive forever.
+    //
+    // **Borrow scoping:** GTK4's `gtk4::DropDown::set_selected`
+    // emits `notify::selected` SYNCHRONOUSLY inside the setter,
+    // which means the `connect_selected_notify` handler above
+    // re-enters this same `dropdown_apids` `RefCell` to look
+    // up the APID for the new index. If we held a `borrow_mut()`
+    // across `set_selected(...)`, that re-entrance would panic
+    // with "already borrowed". Per `CodeRabbit` round 3 on PR
+    // #543. The borrows below are kept tight: an immutable
+    // `borrow()` for the equality compare, a fresh
+    // `borrow_mut()` for the `clone_from`, and zero borrows
+    // held during the `set_selected` calls.
     let view_for_tick = view.clone();
     let dropdown_clone = dropdown.clone();
     let refresh_id = glib::timeout_add_local(std::time::Duration::from_secs(1), move || {
         let mut current = view_for_tick.known_apids();
         current.sort_unstable();
-        let mut existing = dropdown_apids.borrow_mut();
-        if *existing == current {
+        if *dropdown_apids.borrow() == current {
             return glib::ControlFlow::Continue;
         }
         let active = view_for_tick.active_apid();
@@ -672,7 +741,7 @@ fn build_channel_dropdown(view: &LrptImageView) -> gtk4::DropDown {
         for &apid in &current {
             model.append(&format!("APID {apid}"));
         }
-        (*existing).clone_from(&current);
+        dropdown_apids.borrow_mut().clone_from(&current);
         dropdown_clone.set_sensitive(!current.is_empty());
         if let Some(active) = active {
             if let Some(pos) = current.iter().position(|&a| a == active) {
@@ -934,11 +1003,19 @@ mod tests {
     fn push_line_caps_at_max_lines_per_channel() {
         let mut r = LrptImageRenderer::new();
         for _ in 0..MAX_LINES {
-            r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+            assert_eq!(
+                r.push_line(APID_TEST, &synth_line(TEST_PIXEL)),
+                PushOutcome::Pushed,
+            );
         }
         assert_eq!(r.n_lines(APID_TEST), MAX_LINES);
-        // One more push past the cap is a no-op.
-        r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        // One more push past the cap reports `Capped` — caller's
+        // watermark should still advance (further pushes won't
+        // succeed no matter how many retries).
+        assert_eq!(
+            r.push_line(APID_TEST, &synth_line(TEST_PIXEL)),
+            PushOutcome::Capped,
+        );
         assert_eq!(r.n_lines(APID_TEST), MAX_LINES);
     }
 
@@ -946,10 +1023,25 @@ mod tests {
     fn push_line_with_wrong_width_is_dropped() {
         let mut r = LrptImageRenderer::new();
         // IMAGE_WIDTH is 1568; deliberately pass a short slice.
-        r.push_line(APID_TEST, &[TEST_PIXEL; 16]);
+        assert_eq!(
+            r.push_line(APID_TEST, &[TEST_PIXEL; 16]),
+            PushOutcome::InvalidLine,
+        );
         // No surface allocated, no line counted.
         assert_eq!(r.n_lines(APID_TEST), 0);
         assert!(r.known_apids().is_empty());
+    }
+
+    #[test]
+    fn push_outcome_consumed_pins_watermark_semantics() {
+        // Pin the contract `LrptImageView::drain_new_lines`
+        // depends on: only `TransientFailure` leaves the row
+        // in the source for retry. Per `CodeRabbit` round 3
+        // on PR #543.
+        assert!(PushOutcome::Pushed.consumed());
+        assert!(PushOutcome::Capped.consumed());
+        assert!(PushOutcome::InvalidLine.consumed());
+        assert!(!PushOutcome::TransientFailure.consumed());
     }
 
     #[test]

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -1,0 +1,955 @@
+//! Live Meteor-M LRPT image viewer + PNG export.
+//!
+//! LRPT counterpart to [`crate::apt_viewer`]. Displays the
+//! per-APID scan-line buffers from a shared
+//! [`sdr_radio::lrpt_image::LrptImage`] as they accumulate during
+//! a satellite pass. Width is fixed at the LRPT scan width
+//! ([`IMAGE_WIDTH`] = 1568 px); height grows downward as new
+//! lines arrive from the FEC chain.
+//!
+//! Three pieces:
+//!
+//! * [`LrptImageRenderer`] — pure Cairo renderer. Owns a
+//!   `HashMap<APID, ChannelSurface>` of ARGB32 surfaces, each
+//!   sized for a full pass. Knows how to paint the active
+//!   channel into a cairo context with auto-fit + aspect
+//!   preservation. No GTK dependency, fully unit-testable.
+//! * [`LrptImageView`] — GTK widget wrapping a renderer plus a
+//!   poll timer that drains new scan lines from the shared
+//!   [`sdr_radio::lrpt_image::LrptImage`] handle. Cloneable
+//!   (all state is `Rc`-shared) so closures on toolbar buttons
+//!   can hold their own handle. Polling — rather than
+//!   message-pushing as APT does — matches LRPT's
+//!   `Arc<Mutex<ImageAssembler>>` data-sharing model: the DSP
+//!   thread mutates the shared buffer, the UI reads it.
+//! * [`open_lrpt_viewer_window`] — opens the view in a
+//!   non-modal transient window. Header bar carries a channel
+//!   selector, Pause / Resume, and Export PNG.
+//!
+//! [`connect_lrpt_action`] wires the `app.lrpt-open` action
+//! (`Ctrl+Shift+L`). Activating it opens a viewer window and
+//! registers the shared `LrptImage` handle with the DSP
+//! controller via `UiToDsp::SetLrptImage`. Closing the window
+//! sends `UiToDsp::ClearLrptImage` so the decoder tap goes
+//! silent until the user reopens.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use gtk4::prelude::*;
+use gtk4::{cairo, gio, glib};
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use sdr_lrpt::image::IMAGE_WIDTH;
+use sdr_radio::lrpt_image::LrptImage;
+
+use crate::messages::UiToDsp;
+
+/// Maximum lines we'll keep per channel. A Meteor-M LRPT pass
+/// runs ~10 min and AVHRR-on-Meteor scan lines arrive at
+/// roughly 1 Hz, so ~600 lines is a typical full pass; 1024
+/// gives comfortable headroom for the longest plausible
+/// high-elevation pass without ever growing the surface at
+/// runtime.
+pub const MAX_LINES: usize = 1_024;
+
+/// Background colour painted before any LRPT data is received
+/// (and behind the image when the widget is wider than the
+/// image's aspect). Near-black so the eventual greyscale image
+/// stands out, matching the APT viewer's palette.
+const BACKGROUND_RGB: [f64; 3] = [0.05, 0.05, 0.06];
+
+/// Default size for the viewer window. Wider than tall because
+/// LRPT scan width (1568 px) is greater than typical pass
+/// heights (~600 lines) — landscape layout fills better.
+const VIEWER_WINDOW_WIDTH: i32 = 900;
+const VIEWER_WINDOW_HEIGHT: i32 = 600;
+
+/// Poll interval the view uses to drain new scan lines from
+/// the shared `LrptImage` and queue redraws. 250 ms (4 Hz) is
+/// faster than the satellite's ~1 Hz line cadence so users see
+/// data the moment it lands, without burning CPU on a tight
+/// loop. 60 FPS would be wasteful — there's no smooth-motion
+/// content here, just discrete row appends.
+const POLL_INTERVAL_MS: u32 = 250;
+
+/// Pure Cairo renderer for a multi-channel LRPT image buffer.
+///
+/// Owns one persistent ARGB32 [`cairo::ImageSurface`] per APID,
+/// each sized [`IMAGE_WIDTH`] × [`MAX_LINES`] and lazily
+/// allocated on the first `push_line(apid, …)` for that APID.
+/// Surfaces are kept across pushes so [`Self::render`] can paint
+/// the latest state without copying — same alloc-free hot-path
+/// guarantee the APT renderer offers.
+pub struct LrptImageRenderer {
+    channels: HashMap<u16, ChannelSurface>,
+    /// APID currently selected for display. `None` if the user
+    /// hasn't picked a channel yet (or the renderer is empty).
+    active: Option<u16>,
+}
+
+struct ChannelSurface {
+    surface: cairo::ImageSurface,
+    n_lines: usize,
+}
+
+impl ChannelSurface {
+    /// Allocate a fresh full-pass-sized surface for one APID.
+    /// Mirrors [`crate::apt_viewer::AptImageRenderer::new`]'s
+    /// expectation that a desktop machine can spare ~6 MB at
+    /// startup; the alternative would be a fallible API the
+    /// rest of the renderer would have to plumb errors through
+    /// for a for-all-practical-purposes-infallible alloc.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn new() -> Self {
+        let surface = cairo::ImageSurface::create(
+            cairo::Format::ARgb32,
+            IMAGE_WIDTH as i32,
+            MAX_LINES as i32,
+        )
+        .expect("LRPT renderer: ARGB32 surface allocation (~6 MB) failed at startup");
+        Self {
+            surface,
+            n_lines: 0,
+        }
+    }
+}
+
+impl Default for LrptImageRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LrptImageRenderer {
+    /// Build an empty renderer. No channels are allocated until
+    /// the first `push_line` call for each APID.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            channels: HashMap::new(),
+            active: None,
+        }
+    }
+
+    /// All APIDs the renderer has seen at least one line for,
+    /// in unspecified order. Used by the GTK widget to populate
+    /// its channel dropdown.
+    pub fn known_apids(&self) -> Vec<u16> {
+        self.channels.keys().copied().collect()
+    }
+
+    /// APID currently selected for display, if any.
+    #[must_use]
+    pub fn active_apid(&self) -> Option<u16> {
+        self.active
+    }
+
+    /// Set which APID's channel is shown. A no-op (returns
+    /// `false`) if the renderer has never received a line for
+    /// that APID — without a backing surface there's nothing to
+    /// paint, and silently switching to a missing channel would
+    /// leave the user staring at a blank canvas with no
+    /// feedback.
+    pub fn set_active_apid(&mut self, apid: u16) -> bool {
+        if self.channels.contains_key(&apid) {
+            self.active = Some(apid);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Number of scan lines buffered for `apid`, or 0 if unknown.
+    #[must_use]
+    pub fn n_lines(&self, apid: u16) -> usize {
+        self.channels.get(&apid).map_or(0, |c| c.n_lines)
+    }
+
+    /// `true` when no APID has any scan line yet.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.channels.values().all(|c| c.n_lines == 0)
+    }
+
+    /// Append one scan line of width [`IMAGE_WIDTH`] to the
+    /// surface for `apid`, lazy-allocating the surface on the
+    /// first push for that APID. Greyscale values go into the
+    /// surface's backing data as ARGB32 (B/G/R/A — Cairo's
+    /// little-endian layout, alpha = `0xFF`). No-op once
+    /// [`MAX_LINES`] is reached for that channel.
+    ///
+    /// If `pixels.len()` doesn't equal [`IMAGE_WIDTH`], the line
+    /// is dropped with a warning — caller bug; this can't be
+    /// recovered from at the renderer layer.
+    pub fn push_line(&mut self, apid: u16, pixels: &[u8]) {
+        if pixels.len() != IMAGE_WIDTH {
+            tracing::warn!(
+                "LRPT renderer: ignoring line for APID {apid} with {} pixels (expected {IMAGE_WIDTH})",
+                pixels.len(),
+            );
+            return;
+        }
+        let entry = self
+            .channels
+            .entry(apid)
+            .or_insert_with(ChannelSurface::new);
+        if entry.n_lines >= MAX_LINES {
+            return;
+        }
+        let stride = match usize::try_from(entry.surface.stride()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("LRPT renderer: invalid surface stride: {e}");
+                return;
+            }
+        };
+        let row_offset = entry.n_lines * stride;
+        let mut data = match entry.surface.data() {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!("LRPT renderer: surface data lock failed: {e}");
+                return;
+            }
+        };
+        for (i, &g) in pixels.iter().enumerate() {
+            let pixel_offset = row_offset + i * 4;
+            data[pixel_offset] = g;
+            data[pixel_offset + 1] = g;
+            data[pixel_offset + 2] = g;
+            data[pixel_offset + 3] = 0xFF;
+        }
+        // `data` guard drops here, flushing the surface for cairo.
+        drop(data);
+        entry.n_lines += 1;
+        // First-ever push for any channel — auto-select it so
+        // the user sees something the moment data starts
+        // flowing, without having to discover the dropdown.
+        if self.active.is_none() {
+            self.active = Some(apid);
+        }
+    }
+
+    /// Drop all per-channel surfaces. The `HashMap` allocation
+    /// itself is preserved, but each ~6 MB surface is freed —
+    /// callers (between-pass cleanup) typically rebuild from
+    /// scratch as new channels reappear.
+    pub fn clear(&mut self) {
+        self.channels.clear();
+        self.active = None;
+    }
+
+    /// Paint the active channel's image into `cr`, scaled to fit
+    /// `(width, height)` while preserving the
+    /// `IMAGE_WIDTH : n_lines` aspect. Centred horizontally,
+    /// top-aligned vertically.
+    ///
+    /// Returns `Ok(())` and paints just the background when no
+    /// channel is active or the active channel has no lines —
+    /// callers don't need to special-case the empty state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stringified Cairo error on paint failure.
+    /// Callers usually log and continue — drawing failures
+    /// shouldn't kill the UI.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn render(&self, cr: &cairo::Context, width: i32, height: i32) -> Result<(), String> {
+        cr.set_source_rgb(BACKGROUND_RGB[0], BACKGROUND_RGB[1], BACKGROUND_RGB[2]);
+        cr.paint().map_err(|e| format!("background paint: {e}"))?;
+
+        let Some(apid) = self.active else {
+            return Ok(());
+        };
+        let Some(channel) = self.channels.get(&apid) else {
+            return Ok(());
+        };
+        if channel.n_lines == 0 || width <= 0 || height <= 0 {
+            return Ok(());
+        }
+
+        let img_w = IMAGE_WIDTH as f64;
+        let img_h = channel.n_lines as f64;
+        let scale = (f64::from(width) / img_w).min(f64::from(height) / img_h);
+        let off_x = (f64::from(width) - img_w * scale) / 2.0;
+
+        cr.save().map_err(|e| format!("save: {e}"))?;
+        cr.translate(off_x, 0.0);
+        cr.scale(scale, scale);
+        cr.set_source_surface(&channel.surface, 0.0, 0.0)
+            .map_err(|e| format!("set_source_surface: {e}"))?;
+        cr.rectangle(0.0, 0.0, img_w, img_h);
+        cr.fill().map_err(|e| format!("image fill: {e}"))?;
+        cr.restore().map_err(|e| format!("restore: {e}"))?;
+        Ok(())
+    }
+
+    /// Save the active channel's image to a PNG file. Builds a
+    /// one-shot tightly-sized export surface
+    /// (`IMAGE_WIDTH × n_lines`) so the file doesn't carry
+    /// padding rows past the real data.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stringified error if no channel is active /
+    /// has data, or from filesystem creation, surface
+    /// construction, paint operations, or Cairo's PNG encoder.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    pub fn export_png(&self, path: &Path) -> Result<(), String> {
+        let Some(apid) = self.active else {
+            return Err("no LRPT channel selected for export".to_string());
+        };
+        let Some(channel) = self.channels.get(&apid) else {
+            return Err(format!("LRPT channel APID {apid} has no data to export"));
+        };
+        if channel.n_lines == 0 {
+            return Err(format!("LRPT channel APID {apid} has no data to export"));
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+        }
+
+        let export_surface = cairo::ImageSurface::create(
+            cairo::Format::ARgb32,
+            IMAGE_WIDTH as i32,
+            channel.n_lines as i32,
+        )
+        .map_err(|e| format!("export surface: {e}"))?;
+        let cr =
+            cairo::Context::new(&export_surface).map_err(|e| format!("export context: {e}"))?;
+        cr.set_source_surface(&channel.surface, 0.0, 0.0)
+            .map_err(|e| format!("export set_source_surface: {e}"))?;
+        // IMAGE_WIDTH and n_lines are well under f64's mantissa
+        // — bounded by MAX_LINES — so no real precision loss.
+        #[allow(clippy::cast_precision_loss)]
+        cr.rectangle(0.0, 0.0, IMAGE_WIDTH as f64, channel.n_lines as f64);
+        cr.fill().map_err(|e| format!("export fill: {e}"))?;
+        drop(cr);
+
+        let mut file = std::fs::File::create(path).map_err(|e| format!("file: {e}"))?;
+        export_surface
+            .write_to_png(&mut file)
+            .map_err(|e| format!("png: {e}"))?;
+        tracing::info!(
+            ?path,
+            apid,
+            lines = channel.n_lines,
+            "LRPT image exported to PNG"
+        );
+        Ok(())
+    }
+}
+
+// ─── GTK widget ────────────────────────────────────────────────────────
+
+/// Live Meteor LRPT image viewer widget.
+///
+/// Holds a `DrawingArea`, a renderer, the shared
+/// [`LrptImage`] handle the DSP thread is writing to, and a
+/// poll-tick `glib` source. The poll tick drains any new scan
+/// lines from the shared image into the renderer and queues a
+/// redraw.
+///
+/// `Clone` is derived (existing pattern) so toolbar callbacks
+/// and the channel dropdown can hold their own handles. Every
+/// field is internally `Rc`-shared, so cloning is a refcount
+/// bump.
+#[derive(Clone)]
+pub struct LrptImageView {
+    drawing_area: gtk4::DrawingArea,
+    renderer: Rc<RefCell<LrptImageRenderer>>,
+    image: LrptImage,
+    paused: Rc<Cell<bool>>,
+    /// Per-APID watermark: how many lines have already been
+    /// pulled from the shared image into the renderer. Mirrors
+    /// the watermark map in the DSP-side `LrptDecoder` — both
+    /// sides need it so the same line isn't pushed twice (and
+    /// so the viewer's poll tick is O(new lines), not O(total
+    /// lines)).
+    last_seen_lines: Rc<RefCell<HashMap<u16, usize>>>,
+}
+
+impl LrptImageView {
+    /// Build a view bound to the given shared image. Spawns a
+    /// poll tick on the GTK main context that drains new lines
+    /// every [`POLL_INTERVAL_MS`].
+    #[must_use]
+    pub fn new(image: LrptImage) -> Self {
+        let renderer = Rc::new(RefCell::new(LrptImageRenderer::new()));
+        let paused = Rc::new(Cell::new(false));
+        let last_seen_lines: Rc<RefCell<HashMap<u16, usize>>> =
+            Rc::new(RefCell::new(HashMap::new()));
+
+        let drawing_area = gtk4::DrawingArea::builder()
+            .hexpand(true)
+            .vexpand(true)
+            .build();
+        let renderer_for_draw = Rc::clone(&renderer);
+        drawing_area.set_draw_func(move |_area, cr, w, h| {
+            if let Err(e) = renderer_for_draw.borrow().render(cr, w, h) {
+                tracing::warn!("LRPT render failed: {e}");
+            }
+        });
+
+        let view = Self {
+            drawing_area,
+            renderer,
+            image,
+            paused,
+            last_seen_lines,
+        };
+
+        // Poll tick: drain new lines + queue redraw on change.
+        let view_for_tick = view.clone();
+        glib::timeout_add_local(
+            std::time::Duration::from_millis(u64::from(POLL_INTERVAL_MS)),
+            move || {
+                view_for_tick.drain_new_lines();
+                glib::ControlFlow::Continue
+            },
+        );
+
+        view
+    }
+
+    /// The underlying `GtkDrawingArea`. Pack into a layout
+    /// container, wrap in a `ScrolledWindow`, etc.
+    #[must_use]
+    pub fn drawing_area(&self) -> &gtk4::DrawingArea {
+        &self.drawing_area
+    }
+
+    /// All APIDs the renderer has seen at least one line for.
+    /// Wraps the renderer's `known_apids` for callers that hold
+    /// only a `LrptImageView` (the dropdown updater).
+    #[must_use]
+    pub fn known_apids(&self) -> Vec<u16> {
+        self.renderer.borrow().known_apids()
+    }
+
+    /// Switch which APID's channel is displayed. Returns `false`
+    /// (no-op) if the renderer has never seen a line for that
+    /// APID — see [`LrptImageRenderer::set_active_apid`] for
+    /// rationale. Queues a redraw on success.
+    pub fn set_active_apid(&self, apid: u16) -> bool {
+        let ok = self.renderer.borrow_mut().set_active_apid(apid);
+        if ok {
+            self.drawing_area.queue_draw();
+        }
+        ok
+    }
+
+    /// Currently-displayed APID, if any.
+    #[must_use]
+    pub fn active_apid(&self) -> Option<u16> {
+        self.renderer.borrow().active_apid()
+    }
+
+    /// Pull every scan line that's new since the last call out
+    /// of the shared [`LrptImage`] and into the per-APID
+    /// renderer surfaces. Queues a single redraw if anything
+    /// changed and the view isn't paused.
+    ///
+    /// `with_assembler` holds the shared mutex while the line
+    /// copy runs, so we keep the closure minimal — just memcpy
+    /// the row slices, no rendering work — to avoid blocking
+    /// the DSP thread on the lock for any longer than the
+    /// strict copy time.
+    pub fn drain_new_lines(&self) {
+        let mut new_apids: Vec<u16> = Vec::new();
+        let mut any_new = false;
+        let mut last_seen = self.last_seen_lines.borrow_mut();
+        let mut renderer = self.renderer.borrow_mut();
+        self.image.with_assembler(|a| {
+            for (&apid, channel) in a.channels() {
+                let already = last_seen.get(&apid).copied().unwrap_or(0);
+                if channel.lines <= already {
+                    continue;
+                }
+                let known = renderer.channels.contains_key(&apid);
+                for line_idx in already..channel.lines {
+                    let start = line_idx * IMAGE_WIDTH;
+                    let end = start + IMAGE_WIDTH;
+                    if end > channel.pixels.len() {
+                        // Defensive — see lrpt_decoder::harvest_new_lines
+                        // for the parallel guard. Structurally
+                        // unreachable; the warn protects against a
+                        // future refactor of the assembler buffer.
+                        tracing::warn!(
+                            "LRPT view: channel {apid} pixel buffer shorter than expected; skipping line {line_idx}",
+                        );
+                        break;
+                    }
+                    renderer.push_line(apid, &channel.pixels[start..end]);
+                }
+                last_seen.insert(apid, channel.lines);
+                if !known {
+                    new_apids.push(apid);
+                }
+                any_new = true;
+            }
+        });
+        drop(renderer);
+        drop(last_seen);
+
+        if any_new && !self.paused.get() {
+            self.drawing_area.queue_draw();
+        }
+    }
+
+    /// Clear all buffered lines and reset the watermark map.
+    /// Between-pass cleanup; the next pass starts on a clean
+    /// canvas.
+    pub fn clear(&self) {
+        self.renderer.borrow_mut().clear();
+        self.last_seen_lines.borrow_mut().clear();
+        self.drawing_area.queue_draw();
+    }
+
+    /// Toggle pause / resume. Pausing freezes the visible
+    /// canvas; new lines pulled while paused still accumulate
+    /// in the renderer (so nothing is lost) and become visible
+    /// on resume via a forced single redraw.
+    pub fn set_paused(&self, paused: bool) {
+        let was_paused = self.paused.replace(paused);
+        if was_paused && !paused {
+            self.drawing_area.queue_draw();
+        }
+    }
+
+    /// `true` if the view is currently paused.
+    #[must_use]
+    pub fn is_paused(&self) -> bool {
+        self.paused.get()
+    }
+
+    /// Save the active channel's image to a PNG. Same error
+    /// semantics as [`LrptImageRenderer::export_png`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the underlying renderer.
+    pub fn export_png(&self, path: &Path) -> Result<(), String> {
+        self.renderer.borrow().export_png(path)
+    }
+}
+
+// ─── Non-modal viewer window ───────────────────────────────────────────
+
+/// Build the dynamic channel-picker dropdown for the viewer
+/// header. APIDs aren't known at open time, so the dropdown
+/// starts dimmed-but-visible and a 1 Hz `glib` timer rebuilds
+/// its model whenever new APIDs appear in `view`. A parallel
+/// `Vec<u16>` lets us decode the dropdown's numeric `selected`
+/// index back into an APID without parsing the display string.
+fn build_channel_dropdown(view: &LrptImageView) -> gtk4::DropDown {
+    let model = gtk4::StringList::new(&[]);
+    let dropdown = gtk4::DropDown::builder()
+        .model(&model)
+        .tooltip_text("Which AVHRR channel (APID) to display")
+        .sensitive(false)
+        .build();
+    dropdown.update_property(&[gtk4::accessible::Property::Label("LRPT channel selector")]);
+    let dropdown_apids: Rc<RefCell<Vec<u16>>> = Rc::new(RefCell::new(Vec::new()));
+
+    // Selection → renderer.
+    {
+        let view = view.clone();
+        let dropdown_apids = Rc::clone(&dropdown_apids);
+        dropdown.connect_selected_notify(move |dd| {
+            let idx = dd.selected() as usize;
+            let apids = dropdown_apids.borrow();
+            if let Some(&apid) = apids.get(idx) {
+                let _ = view.set_active_apid(apid);
+            }
+        });
+    }
+
+    // Refresh tick — runs at 1 Hz (channel discovery is rare;
+    // a faster cadence would burn CPU on idle string compares).
+    let view = view.clone();
+    let dropdown_clone = dropdown.clone();
+    glib::timeout_add_local(std::time::Duration::from_secs(1), move || {
+        let mut current = view.known_apids();
+        current.sort_unstable();
+        let mut existing = dropdown_apids.borrow_mut();
+        if *existing == current {
+            return glib::ControlFlow::Continue;
+        }
+        let active = view.active_apid();
+        model.splice(0, model.n_items(), &[]);
+        for &apid in &current {
+            model.append(&format!("APID {apid}"));
+        }
+        (*existing).clone_from(&current);
+        dropdown_clone.set_sensitive(!current.is_empty());
+        if let Some(active) = active {
+            if let Some(pos) = current.iter().position(|&a| a == active) {
+                #[allow(clippy::cast_possible_truncation)]
+                dropdown_clone.set_selected(pos as u32);
+            }
+        } else if !current.is_empty() {
+            // No previous selection — pick the first APID
+            // (sorted) so the user sees something the moment
+            // data arrives. The `selected_notify` handler above
+            // will route the choice into the renderer.
+            dropdown_clone.set_selected(0);
+        }
+        glib::ControlFlow::Continue
+    });
+
+    dropdown
+}
+
+/// Build the Pause / Resume toggle for the viewer header.
+/// Pull-out so [`open_lrpt_viewer_window`] stays under the
+/// 100-line clippy threshold.
+fn build_pause_button(view: &LrptImageView) -> gtk4::ToggleButton {
+    let btn = gtk4::ToggleButton::builder()
+        .icon_name("media-playback-pause-symbolic")
+        .tooltip_text("Pause / resume the live image update")
+        .build();
+    btn.update_property(&[gtk4::accessible::Property::Label(
+        "Pause or resume live image update",
+    )]);
+    let view = view.clone();
+    btn.connect_toggled(move |b| {
+        view.set_paused(b.is_active());
+    });
+    btn
+}
+
+/// Open the LRPT viewer in a non-modal transient window. The
+/// window holds a header bar with a channel dropdown,
+/// Pause / Resume, and Export PNG, plus the drawing-area
+/// canvas underneath.
+///
+/// Non-modal so the user can keep tuning, recording, or
+/// otherwise interacting with the main radio window while the
+/// LRPT image builds up alongside.
+pub fn open_lrpt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
+    parent: &W,
+    title: &str,
+    image: LrptImage,
+) -> (LrptImageView, adw::Window) {
+    let view = LrptImageView::new(image);
+
+    let window = adw::Window::builder()
+        .title(title)
+        .default_width(VIEWER_WINDOW_WIDTH)
+        .default_height(VIEWER_WINDOW_HEIGHT)
+        .transient_for(parent)
+        .modal(false)
+        .build();
+
+    let header = adw::HeaderBar::new();
+
+    let channel_dropdown = build_channel_dropdown(&view);
+    header.pack_start(&channel_dropdown);
+
+    let pause_btn = build_pause_button(&view);
+    header.pack_start(&pause_btn);
+
+    // ── Export PNG ────────────────────────────────────────
+    let export_btn = gtk4::Button::builder()
+        .icon_name("document-save-symbolic")
+        .tooltip_text("Export the current LRPT channel image to PNG")
+        .build();
+    export_btn.update_property(&[gtk4::accessible::Property::Label(
+        "Export LRPT channel image to PNG",
+    )]);
+    let export_view = view.clone();
+    let window_for_export = window.downgrade();
+    export_btn.connect_clicked(move |_| {
+        let Some(window_for_export) = window_for_export.upgrade() else {
+            return;
+        };
+        let path = default_export_path(export_view.active_apid());
+        let toast = match export_view.export_png(&path) {
+            Ok(()) => adw::Toast::builder()
+                .title(format!("Saved {}", path.display()))
+                .build(),
+            Err(e) => adw::Toast::builder()
+                .title(format!("PNG export failed: {e}"))
+                .build(),
+        };
+        show_toast_in(&window_for_export, toast);
+    });
+    header.pack_end(&export_btn);
+
+    let toolbar = adw::ToolbarView::new();
+    toolbar.add_top_bar(&header);
+    toolbar.set_content(Some(view.drawing_area()));
+
+    let toast_overlay = adw::ToastOverlay::new();
+    toast_overlay.set_child(Some(&toolbar));
+
+    window.set_content(Some(&toast_overlay));
+    window.present();
+
+    (view, window)
+}
+
+/// Default path the Export PNG button writes to:
+/// `~/sdr-recordings/lrpt-{apid}-YYYY-MM-DD-HHMMSS.png`.
+fn default_export_path(apid: Option<u16>) -> PathBuf {
+    let timestamp = glib::DateTime::now_local()
+        .and_then(|dt| dt.format("%Y-%m-%d-%H%M%S"))
+        .map_or_else(|_| "unknown".to_string(), |s| s.to_string());
+    let apid_part = apid.map_or_else(|| "unknown".to_string(), |a| format!("apid{a}"));
+    glib::home_dir()
+        .join("sdr-recordings")
+        .join(format!("lrpt-{apid_part}-{timestamp}.png"))
+}
+
+/// Walk the window content tree looking for a [`adw::ToastOverlay`]
+/// to display `toast` in. Falls through silently if the layout
+/// changes — toasts are best-effort feedback, not load-bearing UI.
+fn show_toast_in<W: gtk4::prelude::IsA<gtk4::Window>>(window: &W, toast: adw::Toast) {
+    if let Some(child) = window.as_ref().child()
+        && let Some(overlay) = child.downcast_ref::<adw::ToastOverlay>()
+    {
+        overlay.add_toast(toast);
+    }
+}
+
+// ─── Live viewer action ────────────────────────────────────────────────
+
+/// Wire the `app.lrpt-open` action onto `app`. Activating it
+/// (via the app menu, the `Ctrl+Shift+L` accelerator, or future
+/// activity-bar entry) opens a non-modal LRPT viewer window
+/// and informs the DSP controller about the shared image
+/// handle so the LRPT decoder tap starts pushing scan lines
+/// into it. Closing the window clears both the `AppState` slot
+/// and the DSP-side handle.
+pub fn connect_lrpt_action(
+    app: &adw::Application,
+    parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,
+    state: &Rc<crate::state::AppState>,
+) {
+    let action = gio::SimpleAction::new("lrpt-open", None);
+    let parent_provider = Rc::clone(parent_provider);
+    let state_for_action = Rc::clone(state);
+    action.connect_activate(move |_, _| {
+        open_lrpt_viewer_if_needed(&parent_provider, &state_for_action);
+    });
+    app.add_action(&action);
+    app.set_accels_for_action("app.lrpt-open", &["<Ctrl><Shift>l"]);
+}
+
+/// Open the LRPT viewer window if it isn't already open.
+/// Registers the new view in `state.lrpt_viewer`, hands the
+/// shared image to the DSP thread, and wires `close-request`
+/// to tear both down.
+///
+/// Pulled out of [`connect_lrpt_action`] so the auto-record
+/// path (Task 7.5) can fire the same open flow at AOS without
+/// going through the GIO action system. Mirrors the APT
+/// viewer's [`crate::apt_viewer::open_apt_viewer_if_needed`].
+pub fn open_lrpt_viewer_if_needed(
+    parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,
+    state: &Rc<crate::state::AppState>,
+) {
+    if state.lrpt_viewer.borrow().is_some() {
+        return;
+    }
+    let Some(parent) = parent_provider() else {
+        tracing::warn!("lrpt-open invoked with no main window available");
+        return;
+    };
+    let image = state.lrpt_image.clone();
+    let (view, window) = open_lrpt_viewer_window(&parent, "Meteor-M LRPT", image.clone());
+    *state.lrpt_viewer.borrow_mut() = Some(view);
+    state.send_dsp(UiToDsp::SetLrptImage(image));
+
+    let state_for_close = Rc::clone(state);
+    window.connect_close_request(move |_| {
+        *state_for_close.lrpt_viewer.borrow_mut() = None;
+        state_for_close.send_dsp(UiToDsp::ClearLrptImage);
+        glib::Propagation::Proceed
+    });
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// APID used in renderer tests. AVHRR convention: 64 = ch1.
+    /// Same value the rest of the LRPT test suite uses for
+    /// single-channel cases.
+    const APID_TEST: u16 = 64;
+    /// Secondary APID for multi-channel checks.
+    const APID_TEST_2: u16 = 65;
+    /// Pixel marker — distinct from 0/0xFF so a regression that
+    /// returned a default-allocated surface would fail loudly.
+    const TEST_PIXEL: u8 = 0x42;
+    const TEST_PIXEL_2: u8 = 0xC0;
+
+    fn synth_line(value: u8) -> Vec<u8> {
+        vec![value; IMAGE_WIDTH]
+    }
+
+    #[test]
+    fn renderer_starts_empty_with_no_active_channel() {
+        let r = LrptImageRenderer::new();
+        assert!(r.is_empty());
+        assert!(r.active_apid().is_none());
+        assert!(r.known_apids().is_empty());
+    }
+
+    #[test]
+    fn push_line_lazily_allocates_surface_per_apid() {
+        let mut r = LrptImageRenderer::new();
+        r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        assert_eq!(r.n_lines(APID_TEST), 1);
+        // The other APID has never been pushed — n_lines returns 0
+        // and the channel doesn't exist yet.
+        assert_eq!(r.n_lines(APID_TEST_2), 0);
+        assert_eq!(r.known_apids(), vec![APID_TEST]);
+    }
+
+    #[test]
+    fn first_push_auto_selects_that_apid() {
+        let mut r = LrptImageRenderer::new();
+        r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        // The user shouldn't have to manually pick a channel
+        // before any data is visible — pushing the first line
+        // for any APID auto-selects it.
+        assert_eq!(r.active_apid(), Some(APID_TEST));
+    }
+
+    #[test]
+    fn subsequent_push_for_different_apid_doesnt_steal_active() {
+        // First-push auto-select shouldn't keep firing — the
+        // user's pick (or the initial pick) stays sticky as
+        // additional channels appear.
+        let mut r = LrptImageRenderer::new();
+        r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        r.push_line(APID_TEST_2, &synth_line(TEST_PIXEL_2));
+        assert_eq!(r.active_apid(), Some(APID_TEST));
+    }
+
+    #[test]
+    fn push_line_caps_at_max_lines_per_channel() {
+        let mut r = LrptImageRenderer::new();
+        for _ in 0..MAX_LINES {
+            r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        }
+        assert_eq!(r.n_lines(APID_TEST), MAX_LINES);
+        // One more push past the cap is a no-op.
+        r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        assert_eq!(r.n_lines(APID_TEST), MAX_LINES);
+    }
+
+    #[test]
+    fn push_line_with_wrong_width_is_dropped() {
+        let mut r = LrptImageRenderer::new();
+        // IMAGE_WIDTH is 1568; deliberately pass a short slice.
+        r.push_line(APID_TEST, &[TEST_PIXEL; 16]);
+        // No surface allocated, no line counted.
+        assert_eq!(r.n_lines(APID_TEST), 0);
+        assert!(r.known_apids().is_empty());
+    }
+
+    #[test]
+    fn set_active_apid_only_succeeds_for_known_channels() {
+        let mut r = LrptImageRenderer::new();
+        r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        // Existing APID — switch succeeds.
+        assert!(r.set_active_apid(APID_TEST));
+        assert_eq!(r.active_apid(), Some(APID_TEST));
+        // Unknown APID — switch refused, active stays put.
+        assert!(!r.set_active_apid(APID_TEST_2));
+        assert_eq!(r.active_apid(), Some(APID_TEST));
+    }
+
+    #[test]
+    fn clear_drops_all_channels_and_active_selection() {
+        let mut r = LrptImageRenderer::new();
+        r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        r.push_line(APID_TEST_2, &synth_line(TEST_PIXEL_2));
+        r.clear();
+        assert!(r.is_empty());
+        assert!(r.active_apid().is_none());
+        assert!(r.known_apids().is_empty());
+    }
+
+    #[test]
+    fn pixel_layout_is_argb32_with_grayscale_in_bgr_channels() {
+        // Same invariant as the APT renderer test: Cairo's
+        // ARGB32 little-endian layout = B, G, R, A. Every
+        // channel of the input greyscale value goes into all
+        // three colour bytes; alpha is opaque.
+        let mut r = LrptImageRenderer::new();
+        let mut line = vec![0_u8; IMAGE_WIDTH];
+        line[0] = 0x80;
+        line[1] = 0xC0;
+        r.push_line(APID_TEST, &line);
+        let surface = &mut r.channels.get_mut(&APID_TEST).unwrap().surface;
+        let data = surface.data().unwrap();
+        assert_eq!(&data[0..4], &[0x80, 0x80, 0x80, 0xFF]);
+        assert_eq!(&data[4..8], &[0xC0, 0xC0, 0xC0, 0xFF]);
+    }
+
+    #[test]
+    fn export_png_refuses_when_no_active_channel() {
+        let r = LrptImageRenderer::new();
+        let path = std::env::temp_dir().join("lrpt-test-no-active-should-not-be-written.png");
+        let result = r.export_png(&path);
+        assert!(result.is_err());
+        assert!(!path.exists(), "no file should be created on empty export");
+    }
+
+    #[test]
+    fn export_png_refuses_when_active_channel_has_no_data() {
+        // Force-set active to an APID we never pushed to (via
+        // the test-only path: renderer's HashMap entry exists
+        // because we push one line then... wait, no — we need
+        // a way to test "active set, but channel empty". Push
+        // then clear partway: clear() drops active too, so
+        // that's not it. Instead use the renderer's contract:
+        // set_active_apid can't succeed for an unknown channel
+        // either, so the only reachable "active set, n_lines==0"
+        // case is "freshly pushed once, then..." — actually
+        // n_lines becomes 1 the moment we push. So the first
+        // branch (no active) is the only reachable empty error.
+        // We test the second branch by directly mutating the
+        // channel's n_lines back to 0 via the test-only access
+        // below.
+        let mut r = LrptImageRenderer::new();
+        r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        r.channels.get_mut(&APID_TEST).unwrap().n_lines = 0;
+        let path = std::env::temp_dir().join("lrpt-test-empty-channel-should-not-be-written.png");
+        let result = r.export_png(&path);
+        assert!(result.is_err());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn export_png_round_trips_to_a_real_file() {
+        use std::io::Read;
+        let mut r = LrptImageRenderer::new();
+        for _ in 0..16 {
+            r.push_line(APID_TEST, &synth_line(TEST_PIXEL));
+        }
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let path = std::env::temp_dir().join(format!("sdr-ui-lrpt-test-{nanos}.png"));
+        r.export_png(&path).unwrap();
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert!(metadata.len() > 0, "PNG file shouldn't be empty");
+        let mut header = [0_u8; 8];
+        let mut f = std::fs::File::open(&path).unwrap();
+        f.read_exact(&mut header).unwrap();
+        assert_eq!(
+            &header, b"\x89PNG\r\n\x1a\n",
+            "exported file isn't a valid PNG (header mismatch)",
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -743,7 +743,24 @@ impl LrptImageView {
         };
 
         // Phase 2 — outside the shared-image lock.
-        let mut any_new = false;
+        //
+        // Only the renderer's currently-active APID is painted
+        // by `LrptImageRenderer::render`, so the redraw should
+        // fire ONLY when that channel got a row this tick.
+        // Hidden APIDs that just gained rows are off-screen —
+        // their data lands in the per-channel surface but isn't
+        // visible until the user picks them in the dropdown,
+        // and the dropdown's own selected_notify handler will
+        // queue a redraw when that happens. Per `CodeRabbit`
+        // round 16 on PR #543.
+        //
+        // The auto-select transition (active was None, first
+        // ever push promotes it to Some(apid)) is covered by
+        // the per-channel comparison below: after `push_line`
+        // the renderer's `active_apid()` matches `p.apid`, so
+        // the same `painted_any && active == Some(p.apid)` gate
+        // catches the auto-select case naturally.
+        let mut visible_dirty = false;
         let mut last_seen = self.last_seen_lines.borrow_mut();
         let mut renderer = self.renderer.borrow_mut();
         for p in pending {
@@ -780,14 +797,14 @@ impl LrptImageView {
                 pushed = p.already + offset + 1;
             }
             last_seen.insert(p.apid, pushed);
-            if painted_any {
-                any_new = true;
+            if painted_any && renderer.active_apid() == Some(p.apid) {
+                visible_dirty = true;
             }
         }
         drop(renderer);
         drop(last_seen);
 
-        if any_new && !self.paused.get() {
+        if visible_dirty && !self.paused.get() {
             self.drawing_area.queue_draw();
         }
     }
@@ -844,17 +861,30 @@ impl LrptImageView {
     /// `gio::spawn_blocking` directly. It also performs
     /// synchronous Cairo PNG encoding + filesystem I/O — large
     /// images (~50 MB cap) will freeze the GTK main loop while
-    /// it runs. For the GTK click-handler / LOS-save path, use
-    /// [`Self::snapshot_active_channel`] on the main thread
-    /// (cheap mutex-clone, also drains rows + queues the redraw)
-    /// followed by [`write_greyscale_png`] inside
-    /// `gio::spawn_blocking` — that's how the manual Export PNG
-    /// button in [`open_lrpt_viewer_window`] and the recorder's
-    /// `RecorderAction::SaveLrptPass` handler in `window.rs`
-    /// dispatch heavy exports today. Kept as a convenience for
-    /// any future caller that genuinely wants the synchronous
-    /// path (small test exports, scripted batch flows). Per
-    /// `CodeRabbit` round 15 on PR #543.
+    /// it runs.
+    ///
+    /// For off-main-thread use the production paths take two
+    /// different routes:
+    ///
+    /// - The manual Export PNG button in
+    ///   [`open_lrpt_viewer_window`] calls
+    ///   [`Self::snapshot_active_channel`] on the main thread
+    ///   (cheap mutex-clone, also drains rows + queues the
+    ///   redraw), then writes the PNG inside
+    ///   `gio::spawn_blocking` via [`write_greyscale_png`].
+    /// - The recorder's `RecorderAction::SaveLrptPass` handler
+    ///   in `window.rs` snapshots per-APID `ChannelBuffer`s
+    ///   directly from `AppState::lrpt_image` (it doesn't go
+    ///   through the viewer at all — the LOS save needs to
+    ///   work even when the user has closed the window
+    ///   mid-pass), then writes one PNG per channel inside
+    ///   `gio::spawn_blocking` via the same
+    ///   [`write_greyscale_png`].
+    ///
+    /// Kept as a convenience for any future caller that
+    /// genuinely wants the synchronous main-thread path (small
+    /// test exports, scripted batch flows). Per `CodeRabbit`
+    /// rounds 15 + 16 on PR #543.
     ///
     /// # Errors
     ///

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -702,7 +702,17 @@ impl LrptImageView {
         struct PendingChannel {
             apid: u16,
             already: usize,
-            rows: Vec<Vec<u8>>,
+            /// Flat tail of the channel's pixel buffer — every
+            /// row from `already` to `min(channel.lines,
+            /// available_lines)` packed contiguously, ready for
+            /// `chunks_exact(IMAGE_WIDTH)` in phase 2. One heap
+            /// alloc per APID per drain instead of one per row;
+            /// matters on viewer reopen mid-pass when there can
+            /// be thousands of unseen rows for a single APID
+            /// and the per-row alloc would churn the allocator
+            /// at 4 Hz under the shared-image mutex. Per
+            /// `CodeRabbit` round 17 on PR #543.
+            pixels: Vec<u8>,
         }
 
         // Phase 1 — under shared-image lock.
@@ -715,27 +725,29 @@ impl LrptImageView {
                     if channel.lines <= already {
                         continue;
                     }
-                    let mut rows = Vec::with_capacity(channel.lines - already);
-                    for line_idx in already..channel.lines {
-                        let start = line_idx * IMAGE_WIDTH;
-                        let end = start + IMAGE_WIDTH;
-                        if end > channel.pixels.len() {
-                            // Defensive — see lrpt_decoder::harvest_new_lines
-                            // for the parallel guard. Structurally
-                            // unreachable; the warn protects against
-                            // a future refactor of the assembler
-                            // buffer.
-                            tracing::warn!(
-                                "LRPT view: channel {apid} pixel buffer shorter than expected; skipping line {line_idx}",
-                            );
-                            break;
-                        }
-                        rows.push(channel.pixels[start..end].to_vec());
+                    // Defensive — see lrpt_decoder::harvest_new_lines
+                    // for the parallel guard. Structurally
+                    // unreachable; the warn protects against
+                    // a future refactor of the assembler buffer
+                    // that drops the "pixels grows by full-line
+                    // increments" invariant.
+                    let available_lines = channel.pixels.len() / IMAGE_WIDTH;
+                    if available_lines < channel.lines {
+                        tracing::warn!(
+                            "LRPT view: channel {apid} pixel buffer shorter than expected; truncating at line {available_lines} (claimed lines = {})",
+                            channel.lines,
+                        );
                     }
+                    let end_line = channel.lines.min(available_lines);
+                    if end_line <= already {
+                        continue;
+                    }
+                    let start = already * IMAGE_WIDTH;
+                    let end = end_line * IMAGE_WIDTH;
                     acc.push(PendingChannel {
                         apid,
                         already,
-                        rows,
+                        pixels: channel.pixels[start..end].to_vec(),
                     });
                 }
             });
@@ -784,7 +796,10 @@ impl LrptImageView {
             // `CodeRabbit` round 9 on PR #543.
             let mut painted_any = false;
             let mut pushed = p.already;
-            for (offset, row) in p.rows.iter().enumerate() {
+            // `chunks_exact` views the flat tail buffer as
+            // per-row slices without further allocation. Per
+            // `CodeRabbit` round 17 on PR #543.
+            for (offset, row) in p.pixels.chunks_exact(IMAGE_WIDTH).enumerate() {
                 let outcome = renderer.push_line(p.apid, row);
                 if !outcome.consumed() {
                     // Transient failure — leave this row in the

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -48,13 +48,22 @@ use sdr_radio::lrpt_image::LrptImage;
 
 use crate::messages::UiToDsp;
 
-/// Maximum lines we'll keep per channel. A Meteor-M LRPT pass
-/// runs ~10 min and AVHRR-on-Meteor scan lines arrive at
-/// roughly 1 Hz, so ~600 lines is a typical full pass; 1024
-/// gives comfortable headroom for the longest plausible
-/// high-elevation pass without ever growing the surface at
-/// runtime.
-pub const MAX_LINES: usize = 1_024;
+/// Maximum lines we'll keep per channel. The MSU-MR scanner on
+/// Meteor-M produces AVHRR-style imagery at ~6 scan lines per
+/// second per channel; a long high-elevation pass (~15 min above
+/// horizon) is therefore ~5400 lines, and a typical 10-min pass
+/// is ~3600. 8192 gives ~2× headroom for the longest plausible
+/// pass without ever growing the surface at runtime — the
+/// previous 1024 cap clipped roughly the last 80 % of even a
+/// nominal pass. Per `CodeRabbit` round 2 on PR #543.
+///
+/// Memory cost is lazy: the per-APID Cairo surface only
+/// allocates when that channel first receives a line. At the
+/// cap, one channel is `IMAGE_WIDTH × MAX_LINES × 4 B` ≈ 51 MB.
+/// A typical pass with three active AVHRR channels therefore
+/// peaks around 150 MB, which matches the rest of the SDR
+/// pipeline's working-set budget.
+pub const MAX_LINES: usize = 8_192;
 
 /// Background colour painted before any LRPT data is received
 /// (and behind the image when the widget is wider than the
@@ -518,6 +527,12 @@ impl LrptImageView {
                     continue;
                 }
                 let known = renderer.channels.contains_key(&apid);
+                // Track lines actually pushed so the bounds-guard
+                // skip path can't permanently strand un-copied
+                // rows. Same fix as `lrpt_decoder::harvest_new_lines`
+                // — the parallel watermark on the DSP side. Per
+                // `CodeRabbit` round 2 on PR #543.
+                let mut pushed = already;
                 for line_idx in already..channel.lines {
                     let start = line_idx * IMAGE_WIDTH;
                     let end = start + IMAGE_WIDTH;
@@ -532,8 +547,9 @@ impl LrptImageView {
                         break;
                     }
                     renderer.push_line(apid, &channel.pixels[start..end]);
+                    pushed = line_idx + 1;
                 }
-                last_seen.insert(apid, channel.lines);
+                last_seen.insert(apid, pushed);
                 if !known {
                     new_apids.push(apid);
                 }

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -431,6 +431,82 @@ impl LrptImageRenderer {
     }
 }
 
+// ─── Standalone PNG writer ─────────────────────────────────────────────
+
+/// Write a tightly-sized PNG of greyscale `pixels` (one byte per
+/// pixel, row-major, length `width * height`) to `path`.
+///
+/// Builds a one-shot ARGB32 surface — same Cairo path
+/// `LrptImageRenderer::export_png` uses, but reading from a raw
+/// pixel slice rather than a cached per-channel surface. Pulled
+/// out as a free function so the LOS `SaveLrptPass` handler in
+/// `window.rs` can write per-channel PNGs straight from
+/// `state.lrpt_image` without going through a viewer renderer
+/// — the recorder needs to save imagery whether or not the user
+/// has the live viewer open. Per `CodeRabbit` round 7 on PR #543.
+///
+/// # Errors
+///
+/// Returns a stringified error from filesystem creation, surface
+/// construction, the surface-data lock, or Cairo's PNG encoder.
+/// Pixel-buffer length mismatch (`pixels.len() != width * height`)
+/// is reported as a stringified error rather than silently
+/// truncating.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+pub fn write_greyscale_png(
+    path: &Path,
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+) -> Result<(), String> {
+    let expected = width
+        .checked_mul(height)
+        .ok_or_else(|| format!("greyscale PNG: width*height overflow ({width} × {height})"))?;
+    if pixels.len() != expected {
+        return Err(format!(
+            "greyscale PNG: pixel buffer length {} doesn't match width*height ({}*{} = {})",
+            pixels.len(),
+            width,
+            height,
+            expected,
+        ));
+    }
+    if width == 0 || height == 0 {
+        return Err("greyscale PNG: zero-sized image".to_string());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+    }
+
+    let mut surface =
+        cairo::ImageSurface::create(cairo::Format::ARgb32, width as i32, height as i32)
+            .map_err(|e| format!("export surface: {e}"))?;
+    {
+        let stride =
+            usize::try_from(surface.stride()).map_err(|e| format!("invalid stride: {e}"))?;
+        let mut data = surface
+            .data()
+            .map_err(|e| format!("surface data lock: {e}"))?;
+        for row in 0..height {
+            let row_offset = row * stride;
+            let pixel_row_offset = row * width;
+            for col in 0..width {
+                let g = pixels[pixel_row_offset + col];
+                let pixel_offset = row_offset + col * BYTES_PER_PIXEL;
+                data[pixel_offset] = g;
+                data[pixel_offset + 1] = g;
+                data[pixel_offset + 2] = g;
+                data[pixel_offset + 3] = 0xFF;
+            }
+        }
+    }
+    let mut file = std::fs::File::create(path).map_err(|e| format!("file: {e}"))?;
+    surface
+        .write_to_png(&mut file)
+        .map_err(|e| format!("png: {e}"))?;
+    Ok(())
+}
+
 // ─── GTK widget ────────────────────────────────────────────────────────
 
 /// Live Meteor LRPT image viewer widget.
@@ -977,7 +1053,21 @@ pub fn open_lrpt_viewer_if_needed(
             view.shutdown();
         }
         *state_for_close.lrpt_viewer.borrow_mut() = None;
-        state_for_close.send_dsp(UiToDsp::ClearLrptImage);
+        // Deliberately NOT sending `UiToDsp::ClearLrptImage`
+        // here — the DSP-side decoder + shared image stay
+        // attached so the DSP keeps decoding into the shared
+        // image regardless of viewer presence. Closing the
+        // viewer mid-pass used to drop all subsequent rows
+        // and break the LOS `SaveLrptPass` save (the recorder
+        // would post "no image saved" even though decoding
+        // was still feasible). Now the recorder reads the
+        // shared image directly at LOS, so viewer close is
+        // purely a UI teardown. The decoder remains gated by
+        // `current_mode == Lrpt` and the source-stop cleanup
+        // path, so closing the viewer in manual LRPT mode
+        // doesn't burn CPU forever — switching demod or
+        // stopping the source still tears it down. Per
+        // `CodeRabbit` round 7 on PR #543.
         glib::Propagation::Proceed
     });
 }
@@ -1183,5 +1273,49 @@ mod tests {
             "exported file isn't a valid PNG (header mismatch)",
         );
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn write_greyscale_png_round_trips_to_a_real_file() {
+        // Pin the new free-function path used by the LOS
+        // `SaveLrptPass` handler in `window.rs`. Per
+        // `CodeRabbit` round 7 on PR #543.
+        use std::io::Read;
+        const W: usize = 32;
+        const H: usize = 8;
+        let pixels: Vec<u8> = (0..W * H)
+            .map(|i| u8::try_from(i & 0xff).unwrap_or(0))
+            .collect();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let path = std::env::temp_dir().join(format!("sdr-ui-lrpt-bare-{nanos}.png"));
+        write_greyscale_png(&path, &pixels, W, H).unwrap();
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert!(metadata.len() > 0);
+        let mut header = [0_u8; 8];
+        let mut f = std::fs::File::open(&path).unwrap();
+        f.read_exact(&mut header).unwrap();
+        assert_eq!(&header, b"\x89PNG\r\n\x1a\n");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn write_greyscale_png_rejects_size_mismatch() {
+        let path = std::env::temp_dir().join("sdr-ui-lrpt-bare-mismatch.png");
+        let result = write_greyscale_png(&path, &[0_u8; 10], 4, 4);
+        assert!(result.is_err());
+        assert!(
+            !path.exists(),
+            "no file should be written on size-mismatch error"
+        );
+    }
+
+    #[test]
+    fn write_greyscale_png_rejects_zero_size() {
+        let path = std::env::temp_dir().join("sdr-ui-lrpt-bare-zero.png");
+        let result = write_greyscale_png(&path, &[], 0, 0);
+        assert!(result.is_err());
+        assert!(!path.exists());
     }
 }

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -30,8 +30,14 @@
 //! (`Ctrl+Shift+L`). Activating it opens a viewer window and
 //! registers the shared `LrptImage` handle with the DSP
 //! controller via `UiToDsp::SetLrptImage`. Closing the window
-//! sends `UiToDsp::ClearLrptImage` so the decoder tap goes
-//! silent until the user reopens.
+//! is **purely a UI teardown** — the DSP capture stays running
+//! and the shared image keeps accumulating decoded rows so the
+//! recorder's LOS save still produces a per-pass directory.
+//! The decoder is gated by `current_mode == Lrpt` and the
+//! source-stop cleanup path (an explicit detach via
+//! `UiToDsp::ClearLrptImage` is reserved as future API surface
+//! and never sent today). Per `CodeRabbit` rounds 7 + 8 on PR
+//! #543.
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -1000,8 +1006,12 @@ fn show_toast_in<W: gtk4::prelude::IsA<gtk4::Window>>(window: &W, toast: adw::To
 /// activity-bar entry) opens a non-modal LRPT viewer window
 /// and informs the DSP controller about the shared image
 /// handle so the LRPT decoder tap starts pushing scan lines
-/// into it. Closing the window clears both the `AppState` slot
-/// and the DSP-side handle.
+/// into it. Closing the window clears the `AppState` slot
+/// (the GTK widget tree drops with the window) but leaves the
+/// DSP-side decoder + shared image attached so an in-flight
+/// auto-record pass keeps capturing — see the close-request
+/// comment in [`open_lrpt_viewer_if_needed`] and the
+/// module-level docs above for the lifecycle rationale.
 pub fn connect_lrpt_action(
     app: &adw::Application,
     parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,
@@ -1020,7 +1030,9 @@ pub fn connect_lrpt_action(
 /// Open the LRPT viewer window if it isn't already open.
 /// Registers the new view in `state.lrpt_viewer`, hands the
 /// shared image to the DSP thread, and wires `close-request`
-/// to tear both down.
+/// to cancel the view's `glib` timers + drop the `AppState` slot.
+/// The DSP capture (decoder + shared image) intentionally
+/// outlives the window — see the close-request body for why.
 ///
 /// Pulled out of [`connect_lrpt_action`] so the auto-record
 /// path (Task 7.5) can fire the same open flow at AOS without

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -71,6 +71,14 @@ pub const MAX_LINES: usize = 8_192;
 /// stands out, matching the APT viewer's palette.
 const BACKGROUND_RGB: [f64; 3] = [0.05, 0.05, 0.06];
 
+/// Bytes per pixel for Cairo's ARGB32 surface format —
+/// `B`, `G`, `R`, `A` in little-endian byte order. Pulled out
+/// of the hot-path pixel-copy loop in
+/// [`LrptImageRenderer::push_line`] so a future format change
+/// (e.g. RGB24 for the LRPT RGB-composite mode) is a one-line
+/// edit. Per `CodeRabbit` round 4 on PR #543.
+const BYTES_PER_PIXEL: usize = 4;
+
 /// Default size for the viewer window. Wider than tall because
 /// LRPT scan width (1568 px) is greater than typical pass
 /// heights (~600 lines) — landscape layout fills better.
@@ -288,7 +296,7 @@ impl LrptImageRenderer {
             }
         };
         for (i, &g) in pixels.iter().enumerate() {
-            let pixel_offset = row_offset + i * 4;
+            let pixel_offset = row_offset + i * BYTES_PER_PIXEL;
             data[pixel_offset] = g;
             data[pixel_offset + 1] = g;
             data[pixel_offset + 2] = g;

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -98,23 +98,26 @@ struct ChannelSurface {
 
 impl ChannelSurface {
     /// Allocate a fresh full-pass-sized surface for one APID.
-    /// Mirrors [`crate::apt_viewer::AptImageRenderer::new`]'s
-    /// expectation that a desktop machine can spare ~6 MB at
-    /// startup; the alternative would be a fallible API the
-    /// rest of the renderer would have to plumb errors through
-    /// for a for-all-practical-purposes-infallible alloc.
+    /// Returns `None` if Cairo can't allocate the (~6 MB) ARGB32
+    /// surface — practically unreachable on any desktop machine,
+    /// but the library-crate "no panic" rule still applies.
+    /// Per `CodeRabbit` round 1 on PR #543: the earlier draft
+    /// panicked via `.expect()` even though `sdr-ui` is a
+    /// library crate. Callers (`LrptImageRenderer::push_line`)
+    /// degrade gracefully — log a warning and drop the line
+    /// rather than killing the GTK main loop.
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    fn new() -> Self {
+    fn new() -> Option<Self> {
         let surface = cairo::ImageSurface::create(
             cairo::Format::ARgb32,
             IMAGE_WIDTH as i32,
             MAX_LINES as i32,
         )
-        .expect("LRPT renderer: ARGB32 surface allocation (~6 MB) failed at startup");
-        Self {
+        .ok()?;
+        Some(Self {
             surface,
             n_lines: 0,
-        }
+        })
     }
 }
 
@@ -193,10 +196,23 @@ impl LrptImageRenderer {
             );
             return;
         }
-        let entry = self
-            .channels
-            .entry(apid)
-            .or_insert_with(ChannelSurface::new);
+        // Lazy alloc; `ChannelSurface::new` returns `None` if
+        // Cairo can't acquire the ~6 MB ARGB32 surface. Drop
+        // the line with a warn rather than panicking — the
+        // viewer keeps working for any already-allocated
+        // channels and the next line will retry.
+        let entry = match self.channels.entry(apid) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(e) => {
+                let Some(surface) = ChannelSurface::new() else {
+                    tracing::warn!(
+                        "LRPT renderer: surface alloc failed for APID {apid}; dropping line",
+                    );
+                    return;
+                };
+                e.insert(surface)
+            }
+        };
         if entry.n_lines >= MAX_LINES {
             return;
         }
@@ -370,6 +386,14 @@ pub struct LrptImageView {
     /// so the viewer's poll tick is O(new lines), not O(total
     /// lines)).
     last_seen_lines: Rc<RefCell<HashMap<u16, usize>>>,
+    /// `glib` source IDs of timeouts spawned by the view (the
+    /// drain tick) and by `open_lrpt_viewer_window` (the
+    /// channel-dropdown refresh tick). [`Self::shutdown`]
+    /// removes them all so the closures' `Rc` chains drop and
+    /// the view + ~6 MB-per-channel surfaces don't leak past
+    /// the window's close-request. Per `CodeRabbit` round 1 on
+    /// PR #543.
+    timeout_ids: Rc<RefCell<Vec<glib::SourceId>>>,
 }
 
 impl LrptImageView {
@@ -382,6 +406,7 @@ impl LrptImageView {
         let paused = Rc::new(Cell::new(false));
         let last_seen_lines: Rc<RefCell<HashMap<u16, usize>>> =
             Rc::new(RefCell::new(HashMap::new()));
+        let timeout_ids: Rc<RefCell<Vec<glib::SourceId>>> = Rc::new(RefCell::new(Vec::new()));
 
         let drawing_area = gtk4::DrawingArea::builder()
             .hexpand(true)
@@ -400,19 +425,42 @@ impl LrptImageView {
             image,
             paused,
             last_seen_lines,
+            timeout_ids,
         };
 
         // Poll tick: drain new lines + queue redraw on change.
         let view_for_tick = view.clone();
-        glib::timeout_add_local(
+        let drain_id = glib::timeout_add_local(
             std::time::Duration::from_millis(u64::from(POLL_INTERVAL_MS)),
             move || {
                 view_for_tick.drain_new_lines();
                 glib::ControlFlow::Continue
             },
         );
+        view.timeout_ids.borrow_mut().push(drain_id);
 
         view
+    }
+
+    /// Register an external `glib` source (e.g. the
+    /// channel-dropdown refresh tick spawned by
+    /// [`open_lrpt_viewer_window`]) so it gets cleaned up by
+    /// [`Self::shutdown`] alongside the internal drain tick.
+    pub fn register_source(&self, id: glib::SourceId) {
+        self.timeout_ids.borrow_mut().push(id);
+    }
+
+    /// Cancel every registered `glib` source. Called on the
+    /// viewer window's `close-request` so the timeout closures
+    /// drop their `Rc` clones of the view's inner state — without
+    /// this, the view + ~6 MB-per-channel surfaces stay alive in
+    /// the main context until the application exits. Safe to
+    /// call more than once (subsequent calls are no-ops because
+    /// the `Vec` is drained).
+    pub fn shutdown(&self) {
+        for id in std::mem::take(&mut *self.timeout_ids.borrow_mut()) {
+            id.remove();
+        }
     }
 
     /// The underlying `GtkDrawingArea`. Pack into a layout
@@ -500,10 +548,20 @@ impl LrptImageView {
         }
     }
 
-    /// Clear all buffered lines and reset the watermark map.
+    /// Clear all buffered lines and reset the watermark map,
+    /// AND clear the backing shared `LrptImage` so the next
+    /// drain tick can't replay any rows that were still in the
+    /// shared assembler at the time of the clear. Without that,
+    /// reopening the viewer mid-pass — or starting a new pass
+    /// while the wiring layer hasn't yet cleared the shared
+    /// image itself — would repopulate the canvas with the
+    /// previous pass's pixels and contaminate later exports.
+    /// Per `CodeRabbit` round 1 on PR #543.
+    ///
     /// Between-pass cleanup; the next pass starts on a clean
-    /// canvas.
+    /// canvas. Idempotent — calling twice is harmless.
     pub fn clear(&self) {
+        self.image.clear();
         self.renderer.borrow_mut().clear();
         self.last_seen_lines.borrow_mut().clear();
         self.drawing_area.queue_draw();
@@ -529,10 +587,20 @@ impl LrptImageView {
     /// Save the active channel's image to a PNG. Same error
     /// semantics as [`LrptImageRenderer::export_png`].
     ///
+    /// Drains any pending rows from the shared `LrptImage`
+    /// into the renderer first, so the export captures the tail
+    /// of the pass even if it arrived after the most recent
+    /// poll tick. Without this, the LOS `SaveLrptPass` flow —
+    /// which exports immediately on receipt of the LOS action,
+    /// not on the next 250 ms poll — would systematically miss
+    /// the last fraction-of-a-second of decoded data. Per
+    /// `CodeRabbit` round 1 on PR #543.
+    ///
     /// # Errors
     ///
     /// Propagates any error from the underlying renderer.
     pub fn export_png(&self, path: &Path) -> Result<(), String> {
+        self.drain_new_lines();
         self.renderer.borrow().export_png(path)
     }
 }
@@ -570,16 +638,20 @@ fn build_channel_dropdown(view: &LrptImageView) -> gtk4::DropDown {
 
     // Refresh tick — runs at 1 Hz (channel discovery is rare;
     // a faster cadence would burn CPU on idle string compares).
-    let view = view.clone();
+    // Register the source on the view so `LrptImageView::shutdown`
+    // can cancel it when the window closes; otherwise the closure's
+    // `view.clone()` would keep the view + ~6 MB-per-channel
+    // surfaces alive forever.
+    let view_for_tick = view.clone();
     let dropdown_clone = dropdown.clone();
-    glib::timeout_add_local(std::time::Duration::from_secs(1), move || {
-        let mut current = view.known_apids();
+    let refresh_id = glib::timeout_add_local(std::time::Duration::from_secs(1), move || {
+        let mut current = view_for_tick.known_apids();
         current.sort_unstable();
         let mut existing = dropdown_apids.borrow_mut();
         if *existing == current {
             return glib::ControlFlow::Continue;
         }
-        let active = view.active_apid();
+        let active = view_for_tick.active_apid();
         model.splice(0, model.n_items(), &[]);
         for &apid in &current {
             model.append(&format!("APID {apid}"));
@@ -600,6 +672,7 @@ fn build_channel_dropdown(view: &LrptImageView) -> gtk4::DropDown {
         }
         glib::ControlFlow::Continue
     });
+    view.register_source(refresh_id);
 
     dropdown
 }
@@ -767,6 +840,14 @@ pub fn open_lrpt_viewer_if_needed(
 
     let state_for_close = Rc::clone(state);
     window.connect_close_request(move |_| {
+        // Cancel the view's drain + dropdown-refresh timeouts
+        // BEFORE we drop the AppState slot; otherwise their
+        // closures' `Rc<view>` clones keep the view + ~6 MB-
+        // per-channel surfaces alive until the application
+        // exits. Per `CodeRabbit` round 1 on PR #543.
+        if let Some(view) = state_for_close.lrpt_viewer.borrow().as_ref() {
+            view.shutdown();
+        }
         *state_for_close.lrpt_viewer.borrow_mut() = None;
         state_for_close.send_dsp(UiToDsp::ClearLrptImage);
         glib::Propagation::Proceed

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -85,18 +85,34 @@ const BACKGROUND_RGB: [f64; 3] = [0.05, 0.05, 0.06];
 /// edit. Per `CodeRabbit` round 4 on PR #543.
 const BYTES_PER_PIXEL: usize = 4;
 
-/// Default size for the viewer window. Wider than tall because
-/// LRPT scan width (1568 px) is greater than typical pass
-/// heights (~600 lines) — landscape layout fills better.
+/// Default size for the viewer window. A typical Meteor MSU-MR
+/// pass produces ~3600 lines × 1568 px (portrait, ~1:2 aspect)
+/// at full duration, so the image will scroll vertically inside
+/// the window for most of the pass. The default 900 × 600
+/// landscape footprint is chosen for ergonomics rather than
+/// aspect match: it sits comfortably alongside the main radio
+/// window on a typical 1080p+ desktop, fills well during the
+/// early-pass phase when the image is still short and wide, and
+/// the user can resize freely once they see how the pass is
+/// developing. (Pre-round-2 the comment claimed "wider than
+/// tall because typical pass heights are ~600 lines" — that
+/// assumption was based on the old 1024-line cap and stopped
+/// holding once `MAX_LINES` bumped to 8192.) Per `CodeRabbit`
+/// round 14 on PR #543.
 const VIEWER_WINDOW_WIDTH: i32 = 900;
 const VIEWER_WINDOW_HEIGHT: i32 = 600;
 
 /// Poll interval the view uses to drain new scan lines from
-/// the shared `LrptImage` and queue redraws. 250 ms (4 Hz) is
-/// faster than the satellite's ~1 Hz line cadence so users see
-/// data the moment it lands, without burning CPU on a tight
-/// loop. 60 FPS would be wasteful — there's no smooth-motion
-/// content here, just discrete row appends.
+/// the shared `LrptImage` and queue redraws. MSU-MR produces
+/// ~6 scan lines per second per channel; 250 ms (4 Hz) keeps
+/// the viewer one tick behind the line arrival rate at most,
+/// which feels responsive without burning CPU on a tight
+/// loop. A faster cadence wouldn't pay off — multiple lines
+/// land per tick anyway and `drain_new_lines` already batches
+/// them. 60 FPS would be wasteful: there's no smooth-motion
+/// content here, just discrete row appends. Per `CodeRabbit`
+/// round 14 on PR #543 (refreshed from the older "~1 Hz" copy
+/// that predated the round-2 MSU-MR rate research).
 const POLL_INTERVAL_MS: u32 = 250;
 
 /// Refresh interval for the channel-dropdown population tick.

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -1099,11 +1099,24 @@ pub fn open_lrpt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
 }
 
 /// Default path the Export PNG button writes to:
-/// `~/sdr-recordings/lrpt-{apid}-YYYY-MM-DD-HHMMSS.png`.
+/// `~/sdr-recordings/lrpt-{apid}-YYYY-MM-DD-HHMMSS-uuuuuu.png`.
+///
+/// The microsecond suffix prevents collisions when the user
+/// rapid-fires the export button on the same channel within the
+/// same second — without it, the second export silently
+/// overwrote the first via `File::create`'s truncate semantics.
+/// Per `CodeRabbit` round 13 on PR #543.
 fn default_export_path(apid: Option<u16>) -> PathBuf {
     let timestamp = glib::DateTime::now_local()
-        .and_then(|dt| dt.format("%Y-%m-%d-%H%M%S"))
-        .map_or_else(|_| "unknown".to_string(), |s| s.to_string());
+        .as_ref()
+        .ok()
+        .and_then(|dt| {
+            let stamp = dt.format("%Y-%m-%d-%H%M%S").ok()?;
+            // glib's `microsecond()` is 0..=999_999, zero-padded
+            // to 6 digits keeps lexical-sort matching wall-clock.
+            Some(format!("{stamp}-{usec:06}", usec = dt.microsecond()))
+        })
+        .unwrap_or_else(|| "unknown".to_string());
     let apid_part = apid.map_or_else(|| "unknown".to_string(), |a| format!("apid{a}"));
     glib::home_dir()
         .join("sdr-recordings")
@@ -1175,6 +1188,21 @@ pub fn open_lrpt_viewer_if_needed(
         // mid-pass decoder state survives the round-trip. Per
         // `CodeRabbit` round 11 on PR #543.
         state.send_dsp(UiToDsp::SetLrptImage(state.lrpt_image.clone()));
+        // Raise the existing window so `Ctrl+Shift+L` actually
+        // surfaces a buried / minimised viewer instead of being
+        // a silent no-op. Weak-ref upgrade fails closed: if the
+        // window is gone but the AppState slot wasn't cleared
+        // yet (close-request race), we just skip — the slot
+        // will clear momentarily anyway. Per `CodeRabbit`
+        // round 13 on PR #543.
+        if let Some(window) = state
+            .lrpt_viewer_window
+            .borrow()
+            .as_ref()
+            .and_then(glib::WeakRef::upgrade)
+        {
+            window.present();
+        }
         return;
     }
     let Some(parent) = parent_provider() else {
@@ -1184,6 +1212,7 @@ pub fn open_lrpt_viewer_if_needed(
     let image = state.lrpt_image.clone();
     let (view, window) = open_lrpt_viewer_window(&parent, "Meteor-M LRPT", image.clone());
     *state.lrpt_viewer.borrow_mut() = Some(view);
+    *state.lrpt_viewer_window.borrow_mut() = Some(window.downgrade());
     state.send_dsp(UiToDsp::SetLrptImage(image));
 
     let state_for_close = Rc::clone(state);
@@ -1197,6 +1226,7 @@ pub fn open_lrpt_viewer_if_needed(
             view.shutdown();
         }
         *state_for_close.lrpt_viewer.borrow_mut() = None;
+        *state_for_close.lrpt_viewer_window.borrow_mut() = None;
         // Deliberately NOT sending `UiToDsp::ClearLrptImage`
         // here — the DSP-side decoder + shared image stay
         // attached so the DSP keeps decoding into the shared

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -322,6 +322,7 @@ pub fn demod_mode_to_string(mode: DemodMode) -> String {
         DemodMode::Dsb => "DSB",
         DemodMode::Cw => "CW",
         DemodMode::Raw => "RAW",
+        DemodMode::Lrpt => "LRPT",
     }
     .to_string()
 }

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -343,6 +343,12 @@ fn string_to_demod_mode(s: &str) -> DemodMode {
         "DSB" => DemodMode::Dsb,
         "CW" => DemodMode::Cw,
         "RAW" => DemodMode::Raw,
+        // Per CodeRabbit round 1 on PR #543: this arm was
+        // missing, so a Meteor bookmark saved as "LRPT" parsed
+        // back as `Nfm` on next load — silently demoting the
+        // user's catalog-driven LRPT tune. Mirrors the
+        // serializer's `DemodMode::Lrpt => "LRPT"`.
+        "LRPT" => DemodMode::Lrpt,
         // "NFM" and any unrecognized string default to NFM.
         _ => DemodMode::Nfm,
     }
@@ -1149,11 +1155,15 @@ mod tests {
             DemodMode::Dsb,
             DemodMode::Cw,
             DemodMode::Raw,
+            // Per CodeRabbit round 1 on PR #543 — pin Lrpt
+            // bidirectionally so a future variant addition
+            // can't silently demote LRPT bookmarks back to NFM.
+            DemodMode::Lrpt,
         ];
         for mode in modes {
             let s = demod_mode_to_string(mode);
             let back = string_to_demod_mode(&s);
-            assert_eq!(mode, back);
+            assert_eq!(mode, back, "roundtrip failed for {mode:?}");
         }
     }
 

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -411,8 +411,8 @@ pub fn build_satellites_panel() -> SatellitesPanel {
         .build();
 
     let auto_record_switch = adw::SwitchRow::builder()
-        .title("Auto-record APT passes")
-        .subtitle("Tune to the satellite, start the decoder, save the image at LOS.")
+        .title("Auto-record satellite passes")
+        .subtitle("Tune to the satellite, start the decoder, save the imagery at LOS. Works for NOAA APT and Meteor-M LRPT.")
         .active(false)
         .build();
     recording_group.add(&auto_record_switch);
@@ -422,9 +422,15 @@ pub fn build_satellites_panel() -> SatellitesPanel {
     // AOS so a mid-pass toggle can't leave a half-stopped writer.
     // Per #533. Also depends on #532 (pre-volume WAV writer) to
     // capture usable audio when speakers are muted.
+    //
+    // LRPT passes ignore this toggle even when it's on — the
+    // demod is silent (the imagery is the artifact) so a 10-min
+    // pass would write ~170 MB of stereo silence for no value.
+    // The recorder enforces this in `tick_idle`. Per epic #469
+    // task 7.4.
     let auto_record_audio_switch = adw::SwitchRow::builder()
         .title("Also save audio (.wav)")
-        .subtitle("Capture demodulated audio alongside the image. Pairs with the PNG by filename.")
+        .subtitle("Capture demodulated audio alongside the image. Pairs with the PNG by filename. APT only — LRPT passes are silent.")
         .active(false)
         .build();
     recording_group.add(&auto_record_audio_switch);
@@ -1004,18 +1010,21 @@ mod tests {
     }
 
     #[test]
-    fn tune_target_for_pass_returns_none_protocol_for_meteor() {
-        // Meteor passes are in the catalog (so the play button +
-        // upcoming-passes display work) but `imaging_protocol`
-        // is None until Task 7 of epic #469. Recorder filters on
-        // this; play button does not.
+    fn tune_target_for_pass_returns_lrpt_protocol_for_meteor() {
+        // Per epic #469 task 7, METEOR-M 2 / METEOR-M2 3 are now
+        // flagged `Some(ImagingProtocol::Lrpt)` in the catalog so
+        // the recorder enrolls them in the auto-record flow. The
+        // play button still uses the same `tune_target_for_pass`
+        // path; the protocol field is only consumed by the
+        // recorder, so this test pins the catalog→LRPT routing.
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let mut pass = synthetic_pass(now, 30);
         pass.satellite = "METEOR-M 2".to_string();
         let target = tune_target_for_pass(&pass).expect("METEOR-M 2 is in catalog");
         assert_eq!(
-            target.3, None,
-            "Meteor protocol stays None until Task 7 wires the LRPT viewer"
+            target.3,
+            Some(sdr_sat::ImagingProtocol::Lrpt),
+            "Meteor protocol must be Lrpt after epic #469 task 7",
         );
     }
 

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -50,6 +50,38 @@ const AOS_LEAD_SECS: i64 = 5;
 /// "actually receiving" status.
 const SETTLE_SECS: i64 = 3;
 
+/// Where the per-pass imagery should land. Computed at AOS by
+/// branching on [`sdr_sat::ImagingProtocol`] and stored on the
+/// in-flight state so the LOS-side save uses the same path.
+///
+/// APT writes a single PNG; LRPT writes one PNG per AVHRR
+/// channel (APID) into a directory, since LRPT is multispectral
+/// and a single file can't represent all the data the user
+/// actually wants to keep. Per epic #469 task 7.4.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PassOutput {
+    /// Single PNG file (NOAA APT). Wiring layer dispatches via
+    /// [`Action::SavePng`].
+    AptPng(PathBuf),
+    /// Directory holding one PNG per APID (Meteor-M LRPT).
+    /// Wiring layer dispatches via [`Action::SaveLrptPass`] —
+    /// the directory is created lazily by the wiring layer's
+    /// per-channel save loop.
+    LrptDir(PathBuf),
+}
+
+impl PassOutput {
+    /// Stable per-protocol discriminant for tests and logs.
+    /// Avoids matching on `Debug`-formatted strings.
+    #[must_use]
+    pub fn protocol(&self) -> sdr_sat::ImagingProtocol {
+        match self {
+            Self::AptPng(_) => sdr_sat::ImagingProtocol::Apt,
+            Self::LrptDir(_) => sdr_sat::ImagingProtocol::Lrpt,
+        }
+    }
+}
+
 /// Recorder lifecycle. Each variant carries the data the next
 /// transition needs so the caller doesn't have to thread state
 /// through the call site.
@@ -68,37 +100,41 @@ pub enum State {
         /// took over. Restored at LOS so the user comes back to
         /// whatever they were listening to.
         saved_tune: SavedTune,
-        /// PNG export path computed at AOS using the AOS
+        /// Per-pass imagery target computed at AOS using the AOS
         /// timestamp. Stored on state so the LOS-side
-        /// `Action::SavePng` uses the same timestamp as
-        /// `audio_path` — without this the filenames would
-        /// differ by exactly the pass duration (CR round 1
-        /// on PR #534).
-        png_path: PathBuf,
+        /// `Action::SavePng` / `Action::SaveLrptPass` uses the
+        /// same timestamp as `audio_path` — without this the
+        /// filenames would differ by exactly the pass duration
+        /// (CR round 1 on PR #534).
+        output: PassOutput,
         /// Audio recording path the wiring layer was asked to
         /// open at AOS. `Some(path)` means we'll fire
         /// [`Action::StopAutoAudioRecord`] at LOS to close it
-        /// cleanly. `None` means the audio toggle was off when
-        /// AOS fired and there's no in-flight recording. The
+        /// cleanly. `None` means audio recording is off for this
+        /// pass — either the user toggle was off at AOS, or the
+        /// pass is LRPT (whose audio path is silent stereo and
+        /// wastes ~170 MB per 10-min pass for no benefit). The
         /// captured value persists across the AOS toggle so a
         /// user flipping it mid-pass can't leave a half-stopped
         /// writer.
         audio_path: Option<PathBuf>,
     },
-    /// Pass is in progress; APT decoder is producing the live
-    /// image. No per-tick work needed — we just wait for LOS.
+    /// Pass is in progress; the protocol-specific decoder is
+    /// producing live image data. No per-tick work needed — we
+    /// just wait for LOS.
     Recording {
         pass: Pass,
         saved_tune: SavedTune,
-        png_path: PathBuf,
+        output: PassOutput,
         audio_path: Option<PathBuf>,
     },
-    /// Pass ended; PNG export and tune restore are pending. This
-    /// state is single-tick: the next `tick` advances to `Idle`.
+    /// Pass ended; image export and tune restore are pending.
+    /// This state is single-tick: the next `tick` advances to
+    /// `Idle`.
     Finalizing {
         pass: Pass,
         saved_tune: SavedTune,
-        png_path: PathBuf,
+        output: PassOutput,
         audio_path: Option<PathBuf>,
     },
 }
@@ -166,9 +202,19 @@ pub enum Action {
     /// to `UiToDsp::StartAudioRecording(path)`. Per #533.
     StartAutoAudioRecord(PathBuf),
     /// Save the in-flight APT image to `png_path`. Fired on
-    /// `Recording → Finalizing`. Caller is expected to call
-    /// `AptImageView::export_png` against the open viewer.
+    /// `Recording → Finalizing` for APT passes. Caller is
+    /// expected to call `AptImageView::export_png` against the
+    /// open viewer.
     SavePng(PathBuf),
+    /// Save the in-flight LRPT pass into the given directory.
+    /// Fired on `Recording → Finalizing` for LRPT passes.
+    /// Caller walks every APID known to `LrptImageView` and
+    /// writes one PNG per channel into the directory (creating
+    /// it if needed). Per epic #469 task 7.4. Distinct from
+    /// `SavePng` so the wiring layer's per-protocol export
+    /// strategy is statically separated — no path-meaning
+    /// overload.
+    SaveLrptPass(PathBuf),
     /// Stop the in-flight WAV writer opened by
     /// [`Action::StartAutoAudioRecord`]. Fired alongside
     /// [`Action::SavePng`] on LOS, but only when audio recording
@@ -220,14 +266,17 @@ impl Default for AutoRecorder {
 }
 
 impl AutoRecorder {
-    /// Build a recorder that arms only on
-    /// [`sdr_sat::ImagingProtocol::Apt`]. Today's only fully-
-    /// wired auto-record path. Task 7 of epic #469 will swap
-    /// callers to [`Self::with_supported_protocols`] passing
-    /// `[Apt, Lrpt]`.
+    /// Build a recorder that arms on every imaging protocol the
+    /// wiring layer has fully wired in `interpret_action`
+    /// (decoder tap, viewer open, LOS save). As of epic #469
+    /// task 7 that's `[Apt, Lrpt]`; ISS SSTV adds `Sstv` once
+    /// epic #472 ships.
     #[must_use]
     pub fn new() -> Self {
-        Self::with_supported_protocols(&[sdr_sat::ImagingProtocol::Apt])
+        Self::with_supported_protocols(&[
+            sdr_sat::ImagingProtocol::Apt,
+            sdr_sat::ImagingProtocol::Lrpt,
+        ])
     }
 
     /// Build a recorder that arms only on the given imaging
@@ -294,21 +343,21 @@ impl AutoRecorder {
                 pass,
                 tuned_at,
                 saved_tune,
-                png_path,
+                output,
                 audio_path,
-            } => self.tick_before_pass(now, pass, tuned_at, saved_tune, png_path, audio_path),
+            } => self.tick_before_pass(now, pass, tuned_at, saved_tune, output, audio_path),
             State::Recording {
                 pass,
                 saved_tune,
-                png_path,
+                output,
                 audio_path,
-            } => self.tick_recording(now, pass, saved_tune, png_path, audio_path),
+            } => self.tick_recording(now, pass, saved_tune, output, audio_path),
             State::Finalizing {
                 pass,
                 saved_tune,
-                png_path,
+                output,
                 audio_path,
-            } => self.tick_finalizing(pass, saved_tune, png_path, audio_path),
+            } => self.tick_finalizing(pass, saved_tune, output, audio_path),
         }
     }
 
@@ -384,13 +433,29 @@ impl AutoRecorder {
             // already started (we missed the lead — start tuning
             // immediately).
             //
-            // Both filenames use the AOS timestamp so PNG and
-            // WAV pair by string match. CR round 1 on PR #534
-            // caught the prior bug: png_path_for was called at
-            // LOS while audio_path_for was called at AOS, so a
-            // 10-min pass produced filenames 10 min apart.
-            let png_path = png_path_for(pass, now);
-            let audio_path = audio_record_on.then(|| audio_path_for(pass, now));
+            // Imagery and audio paths use the same AOS timestamp
+            // so the artifacts pair by string match. CR round 1
+            // on PR #534 caught the prior bug: png_path_for was
+            // called at LOS while audio_path_for was called at
+            // AOS, so a 10-min pass produced filenames 10 min
+            // apart.
+            //
+            // Per epic #469 task 7.4, the imagery target depends
+            // on the protocol: APT writes a single PNG; LRPT
+            // writes a directory of per-channel PNGs.
+            let output = match protocol {
+                sdr_sat::ImagingProtocol::Apt => PassOutput::AptPng(png_path_for(pass, now)),
+                sdr_sat::ImagingProtocol::Lrpt => PassOutput::LrptDir(lrpt_dir_for(pass, now)),
+            };
+            // Audio recording is suppressed for LRPT regardless
+            // of the user toggle: the LRPT demod is a silent
+            // passthrough (the imagery is the artifact), and
+            // recording 10+ minutes of stereo silence at 144 kHz
+            // would burn ~170 MB per pass for no value. The
+            // toggle still applies to APT — voice/audio capture
+            // is genuinely useful there.
+            let want_audio = audio_record_on && protocol != sdr_sat::ImagingProtocol::Lrpt;
+            let audio_path = want_audio.then(|| audio_path_for(pass, now));
             let mut actions = Vec::with_capacity(3);
             actions.push(Action::StartAutoRecord {
                 satellite: pass.satellite.clone(),
@@ -421,7 +486,7 @@ impl AutoRecorder {
                 pass: pass.clone(),
                 tuned_at: now,
                 saved_tune: now_tune,
-                png_path,
+                output,
                 audio_path,
             };
             return actions;
@@ -435,26 +500,26 @@ impl AutoRecorder {
         pass: Pass,
         tuned_at: DateTime<Utc>,
         saved_tune: SavedTune,
-        png_path: PathBuf,
+        output: PassOutput,
         audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         // LOS already arrived (e.g. the 1 Hz driver stalled on a
         // sleep / suspend cycle, or a very short pass elapsed
         // entirely inside the settle window). Skip straight to
-        // finalizing AND emit the SavePng — otherwise we'd jump
-        // to Idle on the next tick without ever exporting the
-        // image. `png_path` was computed at AOS so the filename
-        // pairs with `audio_path`.
+        // finalizing AND emit the protocol-appropriate save —
+        // otherwise we'd jump to Idle on the next tick without
+        // ever exporting the image. `output` was computed at AOS
+        // so the path pairs with `audio_path`.
         if pass.end <= now {
             let mut actions = Vec::with_capacity(2);
-            actions.push(Action::SavePng(png_path.clone()));
+            actions.push(save_action_for(&output));
             if audio_path.is_some() {
                 actions.push(Action::StopAutoAudioRecord);
             }
             self.state = State::Finalizing {
                 pass: pass.clone(),
                 saved_tune,
-                png_path,
+                output,
                 audio_path,
             };
             return actions;
@@ -463,7 +528,7 @@ impl AutoRecorder {
             self.state = State::Recording {
                 pass,
                 saved_tune,
-                png_path,
+                output,
                 audio_path,
             };
         }
@@ -475,26 +540,27 @@ impl AutoRecorder {
         now: DateTime<Utc>,
         pass: Pass,
         saved_tune: SavedTune,
-        png_path: PathBuf,
+        output: PassOutput,
         audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         if pass.end <= now {
-            // Emit `SavePng` only — the success / failure toast
-            // is the wiring layer's responsibility (it knows the
-            // export's actual outcome). Announcing "image saved"
-            // here would lie if the user closed the viewer
-            // mid-pass or `export_png` errored on disk-full /
-            // permissions. `png_path` was computed at AOS so
-            // the filename pairs with `audio_path`.
+            // Emit the protocol-appropriate save action — the
+            // success / failure toast is the wiring layer's
+            // responsibility (it knows the export's actual
+            // outcome). Announcing "image saved" here would lie
+            // if the user closed the viewer mid-pass or
+            // `export_png` errored on disk-full / permissions.
+            // `output` was computed at AOS so the path pairs
+            // with `audio_path`.
             let mut actions = Vec::with_capacity(2);
-            actions.push(Action::SavePng(png_path.clone()));
+            actions.push(save_action_for(&output));
             if audio_path.is_some() {
                 actions.push(Action::StopAutoAudioRecord);
             }
             self.state = State::Finalizing {
                 pass,
                 saved_tune,
-                png_path,
+                output,
                 audio_path,
             };
             return actions;
@@ -506,7 +572,7 @@ impl AutoRecorder {
         &mut self,
         _pass: Pass,
         saved_tune: SavedTune,
-        _png_path: PathBuf,
+        _output: PassOutput,
         _audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         // Single-tick state: SavePng was issued on entry; restore
@@ -542,13 +608,26 @@ impl AutoRecorder {
 // `window.rs::interpret_action`, (d) update `new()` to include
 // the new protocol in the default supported set.
 
-/// Build the export path for a satellite + timestamp:
+/// Build the export path for an APT pass:
 /// `~/sdr-recordings/apt-NOAA-19-2026-04-25-143015.png`.
 /// Centralised here so the `SavePng` action and the toast message
 /// can't drift on naming.
 #[must_use]
 fn png_path_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
     pass_recording_path(pass, now, "apt", "png")
+}
+
+/// Build the export directory for an LRPT pass:
+/// `~/sdr-recordings/lrpt-METEOR-M2-3-2026-04-25-143015`.
+///
+/// The wiring layer creates the directory lazily and writes one
+/// PNG per APID inside it (e.g. `apid64.png`, `apid65.png`).
+/// LRPT is multispectral — a single file can't capture every
+/// channel — so the per-pass artifact is a directory rather
+/// than a file. Per epic #469 task 7.4.
+#[must_use]
+fn lrpt_dir_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
+    pass_recording_dir(pass, now, "lrpt")
 }
 
 /// Build the audio-recording path for a satellite + timestamp:
@@ -560,32 +639,70 @@ fn audio_path_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
     pass_recording_path(pass, now, "audio", "wav")
 }
 
-/// Shared filename builder for the per-pass artifacts — the PNG
-/// (`png_path_for`) and the WAV (`audio_path_for`) both go through
-/// here so a future filename-format tweak only touches one place.
+/// Project a [`PassOutput`] to the matching save action. Lives
+/// here (and not as `impl PassOutput`) because [`Action`] is a
+/// recorder concept and we want the variant→action mapping
+/// localised to the state-machine module — anyone touching the
+/// dispatch reads it next to the variant emission.
+#[must_use]
+fn save_action_for(output: &PassOutput) -> Action {
+    match output {
+        PassOutput::AptPng(p) => Action::SavePng(p.clone()),
+        PassOutput::LrptDir(p) => Action::SaveLrptPass(p.clone()),
+    }
+}
+
+/// Shared filename builder for the per-pass file artifacts —
+/// the APT PNG (`png_path_for`) and the WAV (`audio_path_for`)
+/// both go through here so a future filename-format tweak only
+/// touches one place.
 fn pass_recording_path(pass: &Pass, now: DateTime<Utc>, prefix: &str, extension: &str) -> PathBuf {
-    let stamp = now
-        .with_timezone(&chrono::Local)
-        .format("%Y-%m-%d-%H%M%S")
-        .to_string();
-    // Sanitize the satellite name for filesystem safety: spaces /
-    // parens / etc become hyphens. We control the name source
-    // (KNOWN_SATELLITES) so a heavy-handed sanitizer is fine.
-    let sat_slug: String = pass
+    glib::home_dir().join("sdr-recordings").join(format!(
+        "{prefix}-{sat}-{stamp}.{extension}",
+        sat = pass_satellite_slug(pass),
+        stamp = pass_timestamp(now),
+    ))
+}
+
+/// Shared directory builder for per-pass directory artifacts —
+/// the LRPT pass directory (`lrpt_dir_for`) goes through here.
+/// Same satellite-slug + timestamp logic as the file builder
+/// minus the extension. Pulled out as a sibling rather than a
+/// special case in `pass_recording_path` so the call sites stay
+/// readable and the "no extension" axis isn't smuggled through
+/// an empty-string parameter.
+fn pass_recording_dir(pass: &Pass, now: DateTime<Utc>, prefix: &str) -> PathBuf {
+    glib::home_dir().join("sdr-recordings").join(format!(
+        "{prefix}-{sat}-{stamp}",
+        sat = pass_satellite_slug(pass),
+        stamp = pass_timestamp(now),
+    ))
+}
+
+/// Filesystem-safe slug for a pass's satellite name: spaces /
+/// parens / etc become hyphens, and runs of hyphens collapse so
+/// "NOAA 19" → "NOAA-19" (not "NOAA--19"). We control the name
+/// source ([`sdr_sat::KNOWN_SATELLITES`]) so a heavy-handed
+/// sanitizer is fine.
+fn pass_satellite_slug(pass: &Pass) -> String {
+    let raw: String = pass
         .satellite
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect();
-    // Collapse runs of `-` so "NOAA 19" → "NOAA-19", not
-    // "NOAA--19", and trim leading/trailing.
-    let sat_slug = sat_slug
-        .split('-')
+    raw.split('-')
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
-        .join("-");
-    glib::home_dir()
-        .join("sdr-recordings")
-        .join(format!("{prefix}-{sat_slug}-{stamp}.{extension}"))
+        .join("-")
+}
+
+/// AOS timestamp formatted in the user's local timezone, used
+/// in every per-pass artifact name so the PNG / directory / WAV
+/// triplet pair by string match.
+fn pass_timestamp(now: DateTime<Utc>) -> String {
+    now.with_timezone(&chrono::Local)
+        .format("%Y-%m-%d-%H%M%S")
+        .to_string()
 }
 
 // `glib` is referenced via the GTK4 stack but only available on
@@ -702,14 +819,22 @@ mod tests {
     }
 
     #[test]
-    fn idle_does_not_arm_for_non_apt_satellite() {
-        // METEOR-M is in the catalog but uses LRPT, not APT —
-        // tuning would succeed but the APT decoder would never
-        // produce a meaningful image.
+    fn idle_does_not_arm_for_unflagged_satellite() {
+        // ISS is in the catalog but `imaging_protocol: None`
+        // (SSTV decoder + viewer ship in epic #472). The
+        // recorder must skip it — tuning would succeed but no
+        // decoder would produce imagery, and the LOS-side save
+        // would emit an action with no backing data.
+        //
+        // Pre-task-7 of epic #469 this test used Meteor as the
+        // unflagged-protocol fixture; once Meteor flipped to
+        // `Some(Lrpt)` we needed a different unflagged catalog
+        // entry. ISS is the canonical "in the catalog for
+        // pass display, no auto-record yet" case.
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let mut pass = synthetic_noaa19(now, 3, 720, 50.0);
-        pass.satellite = "METEOR-M 2".to_string();
+        pass.satellite = "ISS (ZARYA)".to_string();
         let actions = r.tick(now, &[pass], true, false, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
@@ -1347,5 +1472,224 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_meteor_m2(now, 0, 600, 50.0);
         assert_eq!(pass.satellite, "METEOR-M 2");
+    }
+
+    // ─── Per-pass output paths (epic #469 task 7.4) ──────────
+
+    #[test]
+    fn lrpt_dir_includes_satellite_slug_and_no_extension() {
+        // LRPT's per-pass artifact is a directory, not a file —
+        // pin the slug + stamp + lack-of-extension contract so
+        // a future filename refactor doesn't accidentally
+        // reintroduce a `.png` suffix that would conflict with
+        // the per-channel files written inside the directory.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 30, 15).unwrap();
+        let pass = synthetic_meteor_m2(now, 0, 720, 50.0);
+        let dir = lrpt_dir_for(&pass, now);
+        let s = dir.to_string_lossy().to_string();
+        assert!(s.contains("lrpt-METEOR-M-2-"), "got {s}");
+        assert!(
+            dir.extension().is_none(),
+            "LRPT pass artifact must be a directory, not a file: {dir:?}"
+        );
+    }
+
+    #[test]
+    fn lrpt_dir_pairs_with_audio_path_on_same_timestamp() {
+        // If the user has the audio toggle on, a future scenario
+        // (hypothetically — see suppression test below) the WAV
+        // and the LRPT directory must share a timestamp so a
+        // post-pass viewer can pair them by string match. Same
+        // contract `audio_path_pairs_with_png_path_on_same_timestamp`
+        // enforces for APT.
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 30, 15).unwrap();
+        let pass = synthetic_meteor_m2(now, 0, 720, 50.0);
+        let dir = lrpt_dir_for(&pass, now);
+        let audio = audio_path_for(&pass, now);
+        let dir_name = dir.file_name().unwrap().to_string_lossy().to_string();
+        let audio_stem = audio.file_stem().unwrap().to_string_lossy().to_string();
+        let dir_tail = dir_name.strip_prefix("lrpt-").unwrap();
+        let audio_tail = audio_stem.strip_prefix("audio-").unwrap();
+        assert_eq!(dir_tail, audio_tail, "slug+timestamp must match");
+        assert_eq!(dir.parent(), audio.parent());
+    }
+
+    #[test]
+    fn pass_output_protocol_dispatch_matches_variant() {
+        // The `protocol()` discriminant mirrors the variant
+        // 1:1 — pin it so a future variant addition without
+        // updating `protocol()` fails this test loudly instead
+        // of silently dispatching to the wrong save action.
+        let apt = PassOutput::AptPng(PathBuf::from("/tmp/apt.png"));
+        let lrpt = PassOutput::LrptDir(PathBuf::from("/tmp/lrpt-dir"));
+        assert_eq!(apt.protocol(), sdr_sat::ImagingProtocol::Apt);
+        assert_eq!(lrpt.protocol(), sdr_sat::ImagingProtocol::Lrpt);
+    }
+
+    #[test]
+    fn save_action_for_apt_emits_save_png() {
+        let action = save_action_for(&PassOutput::AptPng(PathBuf::from("/tmp/apt.png")));
+        assert!(matches!(action, Action::SavePng(_)));
+    }
+
+    #[test]
+    fn save_action_for_lrpt_emits_save_lrpt_pass() {
+        let action = save_action_for(&PassOutput::LrptDir(PathBuf::from("/tmp/lrpt-dir")));
+        assert!(matches!(action, Action::SaveLrptPass(_)));
+    }
+
+    /// LRPT recorder configured with both Apt + Lrpt support so
+    /// the Meteor pass actually arms. The default constructor
+    /// only supports `[Apt]` today (Task 7.5 flips it to
+    /// `[Apt, Lrpt]`); these tests need the wider set to
+    /// exercise the LRPT path.
+    fn lrpt_recorder() -> AutoRecorder {
+        AutoRecorder::with_supported_protocols(&[
+            sdr_sat::ImagingProtocol::Apt,
+            sdr_sat::ImagingProtocol::Lrpt,
+        ])
+    }
+
+    #[test]
+    fn lrpt_pass_at_aos_emits_save_lrpt_pass_at_los() {
+        // End-to-end: Meteor pass through AOS → settle → LOS
+        // dispatches `Action::SaveLrptPass` (NOT `Action::SavePng`)
+        // because the per-pass artifact is a directory of
+        // per-channel PNGs.
+        //
+        // Lock the wiring contract so a future refactor that
+        // accidentally routes the LRPT path through the APT
+        // save action fails this test instead of the user's
+        // disk (the directory path would land where the APT
+        // save handler expects a file).
+        let mut r = lrpt_recorder();
+        let now_aos = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_meteor_m2(now_aos, 3, 600, 50.0);
+
+        // AOS — arm the recorder.
+        let aos_actions = r.tick(
+            now_aos,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        // CR-bait check: the LRPT arm must dispatch the
+        // protocol on Action::StartAutoRecord so the wiring
+        // layer can route to the LRPT viewer/decoder.
+        assert!(aos_actions.iter().any(|a| matches!(
+            a,
+            Action::StartAutoRecord {
+                protocol: sdr_sat::ImagingProtocol::Lrpt,
+                ..
+            }
+        )));
+
+        // Advance through settle to Recording, then to LOS.
+        let after_settle = now_aos + ChronoDuration::seconds(SETTLE_SECS + 1);
+        let _ = r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        assert!(matches!(r.state(), State::Recording { .. }));
+
+        let after_los = pass.end + ChronoDuration::seconds(1);
+        let los_actions = r.tick(
+            after_los,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        assert!(
+            los_actions
+                .iter()
+                .any(|a| matches!(a, Action::SaveLrptPass(_))),
+            "LRPT LOS must emit SaveLrptPass, got {los_actions:?}"
+        );
+        assert!(
+            !los_actions.iter().any(|a| matches!(a, Action::SavePng(_))),
+            "LRPT LOS must NOT emit SavePng (that's APT-only), got {los_actions:?}"
+        );
+    }
+
+    #[test]
+    fn lrpt_pass_suppresses_audio_recording_even_when_toggle_on() {
+        // LRPT's demod is a silent passthrough — recording 10+
+        // minutes of stereo silence at 144 kHz wastes ~170 MB
+        // per pass for no value. The recorder must suppress
+        // audio for LRPT regardless of the user's "also save
+        // audio" toggle. The toggle still applies to APT —
+        // voice/audio capture is genuinely useful there.
+        let mut r = lrpt_recorder();
+        let now_aos = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_meteor_m2(now_aos, 3, 600, 50.0);
+
+        // Toggle ON, but Meteor pass should still skip the
+        // StartAutoAudioRecord emission.
+        let aos_actions = r.tick(
+            now_aos,
+            std::slice::from_ref(&pass),
+            true,
+            true, // audio_record_on
+            default_tune(),
+        );
+        assert!(
+            !aos_actions
+                .iter()
+                .any(|a| matches!(a, Action::StartAutoAudioRecord(_))),
+            "LRPT pass must NOT start audio recording even with toggle on; got {aos_actions:?}"
+        );
+
+        // Drive to LOS — must also skip StopAutoAudioRecord
+        // (no recording was started, so stopping would be a
+        // no-op disguised as a real action).
+        let after_settle = now_aos + ChronoDuration::seconds(SETTLE_SECS + 1);
+        let _ = r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        let after_los = pass.end + ChronoDuration::seconds(1);
+        let los_actions = r.tick(
+            after_los,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        assert!(
+            !los_actions
+                .iter()
+                .any(|a| matches!(a, Action::StopAutoAudioRecord)),
+            "LRPT LOS must NOT emit StopAutoAudioRecord (no recording was started); got {los_actions:?}"
+        );
+    }
+
+    #[test]
+    fn apt_pass_still_records_audio_with_toggle_on() {
+        // Inverse of the LRPT suppression — make sure the LRPT
+        // gate didn't accidentally mute APT audio recording.
+        let mut r = lrpt_recorder();
+        let now_aos = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now_aos, 3, 600, 50.0);
+        let aos_actions = r.tick(
+            now_aos,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            default_tune(),
+        );
+        assert!(
+            aos_actions
+                .iter()
+                .any(|a| matches!(a, Action::StartAutoAudioRecord(_))),
+            "APT pass with audio toggle on must emit StartAutoAudioRecord; got {aos_actions:?}"
+        );
     }
 }

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -117,6 +117,15 @@ pub struct AppState {
     /// when no viewer is open. Same lifecycle pattern as
     /// `apt_viewer` above. Per epic #469 task 7.
     pub lrpt_viewer: RefCell<Option<crate::lrpt_viewer::LrptImageView>>,
+    /// Weak handle to the open LRPT viewer window so the
+    /// `app.lrpt-open` action can `present()` (raise) an
+    /// already-open-but-buried viewer instead of being a
+    /// silent no-op. Cleared by the viewer's `close-request`
+    /// alongside `lrpt_viewer`. Weak rather than strong so the
+    /// `AppState` slot doesn't keep the window alive past its
+    /// natural lifetime (the GTK toplevel registry owns the
+    /// strong ref). Per `CodeRabbit` round 13 on PR #543.
+    pub lrpt_viewer_window: RefCell<Option<gtk4::glib::WeakRef<libadwaita::Window>>>,
     /// Long-lived shared image handle for the LRPT decoder /
     /// viewer. Allocated once per process — every pass reuses
     /// the same handle so the open viewer's poll tick keeps
@@ -148,6 +157,7 @@ impl AppState {
             rtl_tcp_active_server: RefCell::new(String::new()),
             apt_viewer: RefCell::new(None),
             lrpt_viewer: RefCell::new(None),
+            lrpt_viewer_window: RefCell::new(None),
             lrpt_image: sdr_radio::lrpt_image::LrptImage::new(),
         })
     }

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -113,6 +113,18 @@ pub struct AppState {
     /// `close-request` fires, not when the `GObject`'s last strong
     /// ref happens to drop.
     pub apt_viewer: RefCell<Option<crate::apt_viewer::AptImageView>>,
+    /// Currently-open Meteor-M LRPT viewer window, or `None`
+    /// when no viewer is open. Same lifecycle pattern as
+    /// `apt_viewer` above. Per epic #469 task 7.
+    pub lrpt_viewer: RefCell<Option<crate::lrpt_viewer::LrptImageView>>,
+    /// Long-lived shared image handle for the LRPT decoder /
+    /// viewer. Allocated once per process — every pass reuses
+    /// the same handle so the open viewer's poll tick keeps
+    /// reading from the same `Arc<Mutex<…>>` even as the DSP
+    /// thread tears down + re-inits the per-pass decoder.
+    /// Cleared between passes via `LrptImage::clear` rather
+    /// than reconstructed.
+    pub lrpt_image: sdr_radio::lrpt_image::LrptImage,
 }
 
 impl AppState {
@@ -135,6 +147,8 @@ impl AppState {
             last_rtl_tcp_state_disc: Cell::new(RTL_TCP_STATE_DISC_DISCONNECTED),
             rtl_tcp_active_server: RefCell::new(String::new()),
             apt_viewer: RefCell::new(None),
+            lrpt_viewer: RefCell::new(None),
+            lrpt_image: sdr_radio::lrpt_image::LrptImage::new(),
         })
     }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9023,46 +9023,43 @@ fn connect_satellites_panel(
                         }
                     }
                     sdr_sat::ImagingProtocol::Lrpt => {
-                        // Same shape as the APT branch above —
-                        // start playback, tune, zero the VFO,
-                        // open the protocol's live viewer, and
-                        // clear the canvas so back-to-back passes
-                        // start fresh.
+                        // **Order is load-bearing.** Reset the
+                        // shared image AND the viewer canvas
+                        // BEFORE starting playback / retuning
+                        // so the freshly-tuned LRPT decoder
+                        // can't push pass-1 leftover rows (or
+                        // race the clear and erase the first
+                        // few rows of the new pass). Per
+                        // CodeRabbit round 8 on PR #543.
                         //
-                        // The LRPT viewer's open path also sends
-                        // `UiToDsp::SetLrptImage(handle)` to the
-                        // DSP thread, which lazy-inits the LRPT
-                        // decoder against that handle on the next
-                        // `lrpt_decode_tap` call. Catalog's
+                        // The viewer is opened first so the
+                        // `view.clear()` call below can target
+                        // it — the open path also sends
+                        // `UiToDsp::SetLrptImage(handle)` to
+                        // the DSP thread, which lazy-inits the
+                        // decoder against the (now-cleared)
+                        // shared image. Catalog's
                         // `demod_mode: Lrpt` lines up the
                         // controller's IF rate (144 ksps) with
                         // the QPSK demod's expected sample rate
-                        // — without that, `radio_input` would be
-                        // at the wrong rate and the demod's
+                        // — without that, `radio_input` would
+                        // be at the wrong rate and the demod's
                         // resampler would sit at the wrong
                         // setpoint. Per epic #469 task 7.
-                        set_playing_a(true);
-                        tune_a(freq_hz, mode, bandwidth_hz);
-                        state_a.send_dsp(UiToDsp::SetVfoOffset(0.0));
                         crate::lrpt_viewer::open_lrpt_viewer_if_needed(
                             &parent_provider_a,
                             &state_a,
                         );
-                        // Reset the shared image so the new pass
-                        // paints onto a clean canvas. The
-                        // `LrptDecoder::reset()` between-pass
-                        // hook in the controller flushes its own
-                        // per-APID watermark + pipeline state —
-                        // here we wipe the assembler buffer so
-                        // the *next* pass's first scan line
-                        // doesn't show up below leftover rows
-                        // from a previous pass that the user
-                        // might still have buffered in the
-                        // viewer.
                         state_a.lrpt_image.clear();
                         if let Some(view) = state_a.lrpt_viewer.borrow().as_ref() {
                             view.clear();
                         }
+                        // Now safe to start playback + retune;
+                        // any decoded rows from this point
+                        // forward land in the cleared image.
+                        set_playing_a(true);
+                        tune_a(freq_hz, mode, bandwidth_hz);
+                        state_a.send_dsp(UiToDsp::SetVfoOffset(0.0));
                     }
                 }
             }
@@ -9115,85 +9112,121 @@ fn connect_satellites_panel(
                 // against viewer close: the decoder runs as long
                 // as the demod mode is `Lrpt`, and the captured
                 // imagery survives any number of viewer cycles.
-                let mut sorted = state_a.lrpt_image.channel_apids();
-                sorted.sort_unstable();
-                let result_msg = if sorted.is_empty() {
-                    tracing::warn!(
-                        "auto-record SaveLrptPass but no APIDs were decoded — pass produced no imagery",
-                    );
-                    format!(
-                        "Pass complete, but no LRPT channels decoded — nothing saved to {}",
-                        dir.display()
-                    )
-                } else if let Err(e) = std::fs::create_dir_all(&dir) {
-                    // Per-pass directory created up front so a
-                    // disk-full / permissions failure surfaces as
-                    // a single observable error rather than `N`
-                    // per-channel warnings. Per CodeRabbit
-                    // round 1 on PR #543.
-                    tracing::warn!(
-                        "auto-record SaveLrptPass: failed to create directory {dir:?}: {e}",
-                    );
-                    format!("Pass complete but couldn't create {}: {e}", dir.display())
-                } else {
-                    let mut saved = 0_usize;
-                    let mut errors: Vec<String> = Vec::new();
-                    for apid in sorted {
-                        let Some(snap) = state_a.lrpt_image.snapshot_channel(apid) else {
-                            // Disappeared between channel_apids
-                            // and snapshot_channel — racy with a
-                            // future clear; treat as empty.
-                            continue;
-                        };
-                        if snap.lines == 0 {
-                            continue;
-                        }
-                        let path = dir.join(format!("apid{apid}.png"));
-                        match crate::lrpt_viewer::write_greyscale_png(
-                            &path,
-                            &snap.pixels,
-                            sdr_lrpt::image::IMAGE_WIDTH,
-                            snap.lines,
-                        ) {
-                            Ok(()) => {
-                                tracing::info!(
-                                    ?path,
-                                    apid,
-                                    lines = snap.lines,
-                                    "auto-record LRPT channel saved",
-                                );
-                                saved += 1;
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "auto-record LRPT export for APID {apid} to {path:?} failed: {e}",
-                                );
-                                errors.push(format!("APID {apid}: {e}"));
-                            }
-                        }
-                    }
-                    if saved == 0 && errors.is_empty() {
-                        // Every channel had `lines == 0` — pass
-                        // saw APID metadata but no actual pixel
-                        // data (very-low-elevation noise pass).
-                        format!(
-                            "Pass complete, but every LRPT channel was empty — nothing saved to {}",
-                            dir.display()
-                        )
-                    } else if errors.is_empty() {
-                        format!(
-                            "Pass complete — {saved} LRPT channel(s) saved to {}",
-                            dir.display()
-                        )
-                    } else {
-                        format!(
-                            "Pass complete — {saved} channel(s) saved, {} failed: {}",
-                            errors.len(),
-                            errors.join("; ")
-                        )
-                    }
+                // Snapshot every non-empty APID's pixel buffer
+                // on the main thread (cheap — `snapshot_channel`
+                // clones the per-channel `Vec<u8>` under a brief
+                // mutex hold), then move the encoding + file
+                // I/O off to a worker via `gio::spawn_blocking`.
+                // PNG encoding for a full multi-channel pass is
+                // multiple MB per APID and can take seconds; doing
+                // it inline on the 1 Hz countdown tick would
+                // freeze the UI right when the auto-record toast
+                // and tune-restore should be landing. Per
+                // CodeRabbit round 8 on PR #543. Established
+                // pattern in this file (TLE refresh @ 8678,
+                // bookmark import @ 8805).
+                let snapshots: Vec<(u16, sdr_lrpt::image::ChannelBuffer)> = {
+                    let mut sorted = state_a.lrpt_image.channel_apids();
+                    sorted.sort_unstable();
+                    sorted
+                        .into_iter()
+                        .filter_map(|apid| {
+                            state_a
+                                .lrpt_image
+                                .snapshot_channel(apid)
+                                .filter(|s| s.lines > 0)
+                                .map(|s| (apid, s))
+                        })
+                        .collect()
                 };
-                post_toast(&toast_overlay_weak, &result_msg);
+                let toast_overlay_weak_for_save = toast_overlay_weak.clone();
+                glib::spawn_future_local(async move {
+                    let dir_for_msg = dir.clone();
+                    let result_msg = gio::spawn_blocking(move || {
+                        if snapshots.is_empty() {
+                            tracing::warn!(
+                                "auto-record SaveLrptPass but no APIDs were decoded — pass produced no imagery",
+                            );
+                            return format!(
+                                "Pass complete, but no LRPT channels decoded — nothing saved to {}",
+                                dir.display()
+                            );
+                        }
+                        if let Err(e) = std::fs::create_dir_all(&dir) {
+                            // Per-pass directory created up
+                            // front so a disk-full / permissions
+                            // failure surfaces as a single
+                            // observable error rather than `N`
+                            // per-channel warnings. Per
+                            // CodeRabbit round 1 on PR #543.
+                            tracing::warn!(
+                                "auto-record SaveLrptPass: failed to create directory {dir:?}: {e}",
+                            );
+                            return format!(
+                                "Pass complete but couldn't create {}: {e}",
+                                dir.display()
+                            );
+                        }
+                        let mut saved = 0_usize;
+                        let mut errors: Vec<String> = Vec::new();
+                        for (apid, snap) in snapshots {
+                            let path = dir.join(format!("apid{apid}.png"));
+                            match crate::lrpt_viewer::write_greyscale_png(
+                                &path,
+                                &snap.pixels,
+                                sdr_lrpt::image::IMAGE_WIDTH,
+                                snap.lines,
+                            ) {
+                                Ok(()) => {
+                                    tracing::info!(
+                                        ?path,
+                                        apid,
+                                        lines = snap.lines,
+                                        "auto-record LRPT channel saved",
+                                    );
+                                    saved += 1;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "auto-record LRPT export for APID {apid} to {path:?} failed: {e}",
+                                    );
+                                    errors.push(format!("APID {apid}: {e}"));
+                                }
+                            }
+                        }
+                        if errors.is_empty() {
+                            format!(
+                                "Pass complete — {saved} LRPT channel(s) saved to {}",
+                                dir.display()
+                            )
+                        } else {
+                            format!(
+                                "Pass complete — {saved} channel(s) saved, {} failed: {}",
+                                errors.len(),
+                                errors.join("; ")
+                            )
+                        }
+                    })
+                    .await
+                    .unwrap_or_else(|e| {
+                        // `gio::spawn_blocking`'s join error is a
+                        // panic payload (`Box<dyn Any + Send>`),
+                        // which doesn't implement `Display`.
+                        // Format via `Debug` on the worker side
+                        // and just report a generic message to
+                        // the user — a panicking PNG encoder is
+                        // a logic bug, not something the user
+                        // can act on.
+                        tracing::warn!(
+                            "auto-record SaveLrptPass: worker thread panicked: {e:?}",
+                        );
+                        format!(
+                            "Pass complete but PNG worker panicked (target was {})",
+                            dir_for_msg.display()
+                        )
+                    });
+                    post_toast(&toast_overlay_weak_for_save, &result_msg);
+                });
             }
             RecorderAction::RestoreTune(saved) => {
                 tracing::info!(

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -386,6 +386,12 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         let parent_provider: Rc<dyn Fn() -> Option<gtk4::Window>> =
             Rc::new(move || app_for_provider.windows().into_iter().next());
         crate::apt_viewer::connect_apt_action(app, &parent_provider, &state);
+        // Same wiring for the LRPT viewer (`Ctrl+Shift+L` /
+        // `app.lrpt-open`). Sharing the parent_provider closure
+        // would be possible but each `connect_*_action` clones
+        // it internally — passing twice keeps the call sites
+        // symmetric. Per epic #469 task 7.5.
+        crate::lrpt_viewer::connect_lrpt_action(app, &parent_provider, &state);
     }
 
     // Set initial status bar values and mode-specific control visibility.
@@ -9017,39 +9023,46 @@ fn connect_satellites_panel(
                         }
                     }
                     sdr_sat::ImagingProtocol::Lrpt => {
-                        // **Should be unreachable** — the
-                        // `AutoRecorder` constructor in this
-                        // module passes
-                        // `supported_protocols = [Apt]`, so the
-                        // recorder's `tick_idle` filter rejects
-                        // any catalog entry flagged
-                        // `Some(Lrpt)` before reaching the
-                        // wiring layer. Per CR round 2 on PR
-                        // #541.
+                        // Same shape as the APT branch above —
+                        // start playback, tune, zero the VFO,
+                        // open the protocol's live viewer, and
+                        // clear the canvas so back-to-back passes
+                        // start fresh.
                         //
-                        // Kept as defense-in-depth: if a future
-                        // refactor breaks the recorder gate
-                        // (e.g. someone passes a wider supported
-                        // set without wiring the viewer), this
-                        // branch makes the failure visible
-                        // (error log + user-facing toast) and
-                        // fails closed (no playback / tune /
-                        // VFO mutation).
-                        //
-                        // Task 7 of epic #469 replaces this
-                        // entire branch with the LRPT viewer-
-                        // open + decoder-tap wiring (and the
-                        // recorder constructor flips to
-                        // `[Apt, Lrpt]`).
-                        tracing::error!(
-                            "auto-record fired for LRPT satellite {satellite} but the recorder gate should have prevented this — please file a bug",
+                        // The LRPT viewer's open path also sends
+                        // `UiToDsp::SetLrptImage(handle)` to the
+                        // DSP thread, which lazy-inits the LRPT
+                        // decoder against that handle on the next
+                        // `lrpt_decode_tap` call. Catalog's
+                        // `demod_mode: Lrpt` lines up the
+                        // controller's IF rate (144 ksps) with
+                        // the QPSK demod's expected sample rate
+                        // — without that, `radio_input` would be
+                        // at the wrong rate and the demod's
+                        // resampler would sit at the wrong
+                        // setpoint. Per epic #469 task 7.
+                        set_playing_a(true);
+                        tune_a(freq_hz, mode, bandwidth_hz);
+                        state_a.send_dsp(UiToDsp::SetVfoOffset(0.0));
+                        crate::lrpt_viewer::open_lrpt_viewer_if_needed(
+                            &parent_provider_a,
+                            &state_a,
                         );
-                        post_toast(
-                            &toast_overlay_weak,
-                            &format!(
-                                "{satellite}: LRPT auto-record arrived early — viewer ships in epic #469 Task 7"
-                            ),
-                        );
+                        // Reset the shared image so the new pass
+                        // paints onto a clean canvas. The
+                        // `LrptDecoder::reset()` between-pass
+                        // hook in the controller flushes its own
+                        // per-APID watermark + pipeline state —
+                        // here we wipe the assembler buffer so
+                        // the *next* pass's first scan line
+                        // doesn't show up below leftover rows
+                        // from a previous pass that the user
+                        // might still have buffered in the
+                        // viewer.
+                        state_a.lrpt_image.clear();
+                        if let Some(view) = state_a.lrpt_viewer.borrow().as_ref() {
+                            view.clear();
+                        }
                     }
                 }
             }
@@ -9083,6 +9096,85 @@ fn connect_satellites_panel(
                         "auto-record SavePng but no APT viewer is open (user closed mid-pass)",
                     );
                     "Pass complete, but the APT viewer was closed — no image saved".to_string()
+                };
+                post_toast(&toast_overlay_weak, &result_msg);
+            }
+            RecorderAction::SaveLrptPass(dir) => {
+                // Walk every APID known to the LRPT viewer and
+                // write one PNG per channel into the per-pass
+                // directory (creating it lazily). Toast reports
+                // the count actually written — closed viewer or
+                // an empty pass collapses to a clear message
+                // rather than a silent success. Per epic #469
+                // task 7.4. The full per-channel save loop lives
+                // here (not on `LrptImageView`) because the
+                // viewer's PNG export only knows about the
+                // currently-active channel; the per-pass
+                // artifact wants every channel.
+                let result_msg = if let Some(view) = state_a.lrpt_viewer.borrow().as_ref() {
+                    let apids = view.known_apids();
+                    if apids.is_empty() {
+                        tracing::warn!(
+                            "auto-record SaveLrptPass but no APIDs were decoded — pass produced no imagery",
+                        );
+                        format!(
+                            "Pass complete, but no LRPT channels decoded — nothing saved to {}",
+                            dir.display()
+                        )
+                    } else {
+                        // Save the currently-active channel last
+                        // so the viewer comes out of the loop
+                        // pointing at whatever the user had open
+                        // — the temporary set_active_apid below
+                        // is the only way to get the per-channel
+                        // export path through the existing
+                        // `export_png` API without adding a
+                        // by-APID variant.
+                        let user_active = view.active_apid();
+                        let mut saved = 0_usize;
+                        let mut errors: Vec<String> = Vec::new();
+                        let mut sorted = apids;
+                        sorted.sort_unstable();
+                        for apid in sorted {
+                            if !view.set_active_apid(apid) {
+                                continue;
+                            }
+                            let path = dir.join(format!("apid{apid}.png"));
+                            match view.export_png(&path) {
+                                Ok(()) => {
+                                    tracing::info!(?path, apid, "auto-record LRPT channel saved");
+                                    saved += 1;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "auto-record LRPT export for APID {apid} to {path:?} failed: {e}",
+                                    );
+                                    errors.push(format!("APID {apid}: {e}"));
+                                }
+                            }
+                        }
+                        // Restore the user's selection.
+                        if let Some(apid) = user_active {
+                            view.set_active_apid(apid);
+                        }
+                        if errors.is_empty() {
+                            format!(
+                                "Pass complete — {saved} LRPT channel(s) saved to {}",
+                                dir.display()
+                            )
+                        } else {
+                            format!(
+                                "Pass complete — {saved} channel(s) saved, {} failed: {}",
+                                errors.len(),
+                                errors.join("; ")
+                            )
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        "auto-record SaveLrptPass but no LRPT viewer is open (user closed mid-pass)",
+                    );
+                    "Pass complete, but the LRPT viewer was closed — no image saved".to_string()
                 };
                 post_toast(&toast_overlay_weak, &result_msg);
             }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9121,6 +9121,23 @@ fn connect_satellites_panel(
                             "Pass complete, but no LRPT channels decoded — nothing saved to {}",
                             dir.display()
                         )
+                    } else if let Err(e) = std::fs::create_dir_all(&dir) {
+                        // The recorder hands us a path that
+                        // doesn't exist yet — `LrptImageRenderer::export_png`
+                        // creates the *parent* lazily, but for
+                        // an LRPT pass each export's parent is
+                        // the same directory, so creating it
+                        // up front avoids the chance of a race
+                        // (the per-APID files all create the
+                        // same parent on first use). Also gives
+                        // us a single observable failure point
+                        // for "disk full / permissions" rather
+                        // than `N` toasts. Per CodeRabbit
+                        // round 1 on PR #543.
+                        tracing::warn!(
+                            "auto-record SaveLrptPass: failed to create directory {dir:?}: {e}",
+                        );
+                        format!("Pass complete but couldn't create {}: {e}", dir.display())
                     } else {
                         // Save the currently-active channel last
                         // so the viewer comes out of the loop

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9100,98 +9100,98 @@ fn connect_satellites_panel(
                 post_toast(&toast_overlay_weak, &result_msg);
             }
             RecorderAction::SaveLrptPass(dir) => {
-                // Walk every APID known to the LRPT viewer and
-                // write one PNG per channel into the per-pass
-                // directory (creating it lazily). Toast reports
-                // the count actually written — closed viewer or
-                // an empty pass collapses to a clear message
-                // rather than a silent success. Per epic #469
-                // task 7.4. The full per-channel save loop lives
-                // here (not on `LrptImageView`) because the
-                // viewer's PNG export only knows about the
-                // currently-active channel; the per-pass
-                // artifact wants every channel.
-                let result_msg = if let Some(view) = state_a.lrpt_viewer.borrow().as_ref() {
-                    let apids = view.known_apids();
-                    if apids.is_empty() {
-                        tracing::warn!(
-                            "auto-record SaveLrptPass but no APIDs were decoded — pass produced no imagery",
-                        );
-                        format!(
-                            "Pass complete, but no LRPT channels decoded — nothing saved to {}",
-                            dir.display()
-                        )
-                    } else if let Err(e) = std::fs::create_dir_all(&dir) {
-                        // The recorder hands us a path that
-                        // doesn't exist yet — `LrptImageRenderer::export_png`
-                        // creates the *parent* lazily, but for
-                        // an LRPT pass each export's parent is
-                        // the same directory, so creating it
-                        // up front avoids the chance of a race
-                        // (the per-APID files all create the
-                        // same parent on first use). Also gives
-                        // us a single observable failure point
-                        // for "disk full / permissions" rather
-                        // than `N` toasts. Per CodeRabbit
-                        // round 1 on PR #543.
-                        tracing::warn!(
-                            "auto-record SaveLrptPass: failed to create directory {dir:?}: {e}",
-                        );
-                        format!("Pass complete but couldn't create {}: {e}", dir.display())
-                    } else {
-                        // Save the currently-active channel last
-                        // so the viewer comes out of the loop
-                        // pointing at whatever the user had open
-                        // — the temporary set_active_apid below
-                        // is the only way to get the per-channel
-                        // export path through the existing
-                        // `export_png` API without adding a
-                        // by-APID variant.
-                        let user_active = view.active_apid();
-                        let mut saved = 0_usize;
-                        let mut errors: Vec<String> = Vec::new();
-                        let mut sorted = apids;
-                        sorted.sort_unstable();
-                        for apid in sorted {
-                            if !view.set_active_apid(apid) {
-                                continue;
-                            }
-                            let path = dir.join(format!("apid{apid}.png"));
-                            match view.export_png(&path) {
-                                Ok(()) => {
-                                    tracing::info!(?path, apid, "auto-record LRPT channel saved");
-                                    saved += 1;
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        "auto-record LRPT export for APID {apid} to {path:?} failed: {e}",
-                                    );
-                                    errors.push(format!("APID {apid}: {e}"));
-                                }
-                            }
+                // Walk every APID present in the SHARED `LrptImage`
+                // (the DSP-side decoder's destination — the source
+                // of truth) and write one PNG per channel into the
+                // per-pass directory (creating it lazily). Decoupled
+                // from the live viewer in `CodeRabbit` round 7 on
+                // PR #543: the previous implementation went through
+                // `state.lrpt_viewer` and produced "no image saved"
+                // toasts whenever the user dismissed the live
+                // window mid-pass — even though the DSP had been
+                // happily decoding into the shared image the
+                // whole time. Reading directly from
+                // `state.lrpt_image` makes the LOS save robust
+                // against viewer close: the decoder runs as long
+                // as the demod mode is `Lrpt`, and the captured
+                // imagery survives any number of viewer cycles.
+                let mut sorted = state_a.lrpt_image.channel_apids();
+                sorted.sort_unstable();
+                let result_msg = if sorted.is_empty() {
+                    tracing::warn!(
+                        "auto-record SaveLrptPass but no APIDs were decoded — pass produced no imagery",
+                    );
+                    format!(
+                        "Pass complete, but no LRPT channels decoded — nothing saved to {}",
+                        dir.display()
+                    )
+                } else if let Err(e) = std::fs::create_dir_all(&dir) {
+                    // Per-pass directory created up front so a
+                    // disk-full / permissions failure surfaces as
+                    // a single observable error rather than `N`
+                    // per-channel warnings. Per CodeRabbit
+                    // round 1 on PR #543.
+                    tracing::warn!(
+                        "auto-record SaveLrptPass: failed to create directory {dir:?}: {e}",
+                    );
+                    format!("Pass complete but couldn't create {}: {e}", dir.display())
+                } else {
+                    let mut saved = 0_usize;
+                    let mut errors: Vec<String> = Vec::new();
+                    for apid in sorted {
+                        let Some(snap) = state_a.lrpt_image.snapshot_channel(apid) else {
+                            // Disappeared between channel_apids
+                            // and snapshot_channel — racy with a
+                            // future clear; treat as empty.
+                            continue;
+                        };
+                        if snap.lines == 0 {
+                            continue;
                         }
-                        // Restore the user's selection.
-                        if let Some(apid) = user_active {
-                            view.set_active_apid(apid);
-                        }
-                        if errors.is_empty() {
-                            format!(
-                                "Pass complete — {saved} LRPT channel(s) saved to {}",
-                                dir.display()
-                            )
-                        } else {
-                            format!(
-                                "Pass complete — {saved} channel(s) saved, {} failed: {}",
-                                errors.len(),
-                                errors.join("; ")
-                            )
+                        let path = dir.join(format!("apid{apid}.png"));
+                        match crate::lrpt_viewer::write_greyscale_png(
+                            &path,
+                            &snap.pixels,
+                            sdr_lrpt::image::IMAGE_WIDTH,
+                            snap.lines,
+                        ) {
+                            Ok(()) => {
+                                tracing::info!(
+                                    ?path,
+                                    apid,
+                                    lines = snap.lines,
+                                    "auto-record LRPT channel saved",
+                                );
+                                saved += 1;
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "auto-record LRPT export for APID {apid} to {path:?} failed: {e}",
+                                );
+                                errors.push(format!("APID {apid}: {e}"));
+                            }
                         }
                     }
-                } else {
-                    tracing::warn!(
-                        "auto-record SaveLrptPass but no LRPT viewer is open (user closed mid-pass)",
-                    );
-                    "Pass complete, but the LRPT viewer was closed — no image saved".to_string()
+                    if saved == 0 && errors.is_empty() {
+                        // Every channel had `lines == 0` — pass
+                        // saw APID metadata but no actual pixel
+                        // data (very-low-elevation noise pass).
+                        format!(
+                            "Pass complete, but every LRPT channel was empty — nothing saved to {}",
+                            dir.display()
+                        )
+                    } else if errors.is_empty() {
+                        format!(
+                            "Pass complete — {saved} LRPT channel(s) saved to {}",
+                            dir.display()
+                        )
+                    } else {
+                        format!(
+                            "Pass complete — {saved} channel(s) saved, {} failed: {}",
+                            errors.len(),
+                            errors.join("; ")
+                        )
+                    }
                 };
                 post_toast(&toast_overlay_weak, &result_msg);
             }


### PR DESCRIPTION
## Summary

Final task in epic #469 — wires the Meteor-M LRPT decoder all the way from RF to disk:

- **DSP path**: `DemodMode::Lrpt` is a silent passthrough that pins the IF rate to 144 ksps. The controller's `lrpt_decode_tap` reads `radio_input` before `radio.process` and drives `LrptDecoder` (QPSK demod + FEC chain + image assembler) against the shared `LrptImage` handle.
- **Live viewer**: `LrptImageView` polls the shared image at 4 Hz, paints per-APID Cairo surfaces, exposes a dynamic channel dropdown (auto-populated as APIDs appear), pause/resume, and per-channel PNG export. `Ctrl+Shift+L` / `app.lrpt-open` opens the viewer manually; auto-record opens it at AOS.
- **Auto-record**: Catalog `METEOR-M 2` / `METEOR-M2 3` flipped to `Some(ImagingProtocol::Lrpt)` + `DemodMode::Lrpt`. The recorder's `PassOutput` enum routes APT to a single PNG and LRPT to a per-pass directory of per-channel PNGs (one per AVHRR APID). Audio recording is suppressed for LRPT regardless of toggle (silent demod = ~170 MB of stereo silence per 10-min pass).
- **Toggle copy** updated to "Auto-record satellite passes" with an LRPT silence note on the audio sub-toggle. Follow-up #542 will revisit whether to remove the audio sub-toggle once usage data lands.

19 files changed, +2156 / -144. New modules: `sdr-radio::demod::lrpt`, `sdr-radio::lrpt_decoder`, `sdr-ui::lrpt_viewer`.

## Test plan

- [x] `cargo test --workspace --features sdr-ui/whisper-cpu` — zero failures (all 50+ new unit tests pass alongside the existing suite)
- [x] `cargo clippy --workspace --features sdr-ui/whisper-cpu --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace --no-default-features --features sdr-ui/sherpa-cpu` — clean (transcription-mutex sibling verified)
- [x] `make install CARGO_FLAGS=\"--features sdr-ui/whisper-cpu\"` — clean
- [ ] Manual smoke: tune to 137.1 MHz with the demod selector set to LRPT during a real Meteor pass — viewer populates with APIDs, image builds line-by-line, Pause/Export PNG land files
- [ ] Manual smoke: enable auto-record + wait for a Meteor pass overhead — at AOS the viewer opens automatically; at LOS a per-channel directory `~/sdr-recordings/lrpt-METEOR-M-2-…/apid64.png …` lands and a toast reports "N LRPT channel(s) saved"; tune is restored
- [ ] No APT regression: NOAA pass still produces a single PNG and a paired WAV when the audio toggle is on
- [ ] LRPT audio suppression: even with "Also save audio" on, no WAV is written for the Meteor pass
- [ ] Mid-pass close-and-reopen of the LRPT viewer: decoder lazy re-inits cleanly on the next reopen, image starts fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectable LRPT demodulation mode for Meteor‑M reception
  * Integrated LRPT decoding pipeline with persistent decoder, lazy init/failure guard, and shared live image buffer
  * Live LRPT viewer: multi‑channel display, pause/drain, snapshot and greyscale PNG export, singleton window, open/close action
  * Recorder support for LRPT passes (protocol‑aware save action, LRPT output directory, background export)

* **Updates**
  * Catalog entries, UI labels, selector and serialization updated for LRPT
  * LRPT passes are silent; audio recording suppressed for LRPT
  * Improved debug formatting and expanded unit tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->