### PR TITLE
fix: radio panel bandwidth ↔ VFO + per-mode range (#504, #505)

### DIFF
--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -171,6 +171,41 @@ pub fn default_bandwidth_for_mode(mode: sdr_types::DemodMode) -> Result<f64, Dsp
     Ok(create_demodulator(mode)?.config().default_bandwidth)
 }
 
+/// Maximum bandwidth (Hz) the demodulator will accept for the
+/// given mode. UI uses this to clamp the Radio panel's
+/// bandwidth `SpinRow` to the active demod's actual range —
+/// without it the `SpinRow` allows up to a global cap (250 kHz)
+/// while NFM / AM / SSB / CW silently reject anything past
+/// their own per-mode max, producing the audio-stutter symptom
+/// in issue #505 (channel filter widens, demod's audio LPF
+/// stays at the previous value, demod processes IQ wildly out
+/// of its design assumptions).
+///
+/// Same caveats as [`default_bandwidth_for_mode`] — constructs
+/// a throwaway demodulator each call to read its config; cheap
+/// enough for UI use on demod-mode changes.
+///
+/// # Errors
+///
+/// Returns `DspError` if demod construction fails. Same
+/// "shouldn't happen for any current variant" guarantee as
+/// `default_bandwidth_for_mode`. Per issue #505.
+pub fn max_bandwidth_for_mode(mode: sdr_types::DemodMode) -> Result<f64, DspError> {
+    Ok(create_demodulator(mode)?.config().max_bandwidth)
+}
+
+/// Minimum bandwidth (Hz) the demodulator will accept for the
+/// given mode. Companion to [`max_bandwidth_for_mode`] for
+/// the same reason — see #505. Especially important for CW
+/// (50 Hz min vs the panel's previous 100 Hz floor).
+///
+/// # Errors
+///
+/// See [`max_bandwidth_for_mode`].
+pub fn min_bandwidth_for_mode(mode: sdr_types::DemodMode) -> Result<f64, DspError> {
+    Ok(create_demodulator(mode)?.config().min_bandwidth)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -224,5 +259,52 @@ mod tests {
             );
             assert!(!demod.name().is_empty(), "{mode:?} name must not be empty");
         }
+    }
+
+    #[test]
+    fn min_max_bandwidth_for_mode_match_demod_config() {
+        // Pin the helpers' contract: they MUST return the same
+        // min/max as `DemodConfig` for every mode. The UI uses
+        // them to clamp the Radio panel SpinRow's allowed range
+        // (issue #505); a divergence here would let the row
+        // accept values the demod silently rejects.
+        let modes = [
+            DemodMode::Wfm,
+            DemodMode::Nfm,
+            DemodMode::Am,
+            DemodMode::Usb,
+            DemodMode::Lsb,
+            DemodMode::Dsb,
+            DemodMode::Cw,
+            DemodMode::Raw,
+            DemodMode::Lrpt,
+        ];
+        for mode in modes {
+            let demod = create_demodulator(mode).unwrap();
+            let cfg = demod.config();
+            let min = min_bandwidth_for_mode(mode).unwrap();
+            let max = max_bandwidth_for_mode(mode).unwrap();
+            assert!(
+                (min - cfg.min_bandwidth).abs() < f64::EPSILON,
+                "{mode:?}: min_bandwidth_for_mode {min} != DemodConfig {}",
+                cfg.min_bandwidth,
+            );
+            assert!(
+                (max - cfg.max_bandwidth).abs() < f64::EPSILON,
+                "{mode:?}: max_bandwidth_for_mode {max} != DemodConfig {}",
+                cfg.max_bandwidth,
+            );
+        }
+    }
+
+    #[test]
+    fn min_bandwidth_for_mode_pins_known_values() {
+        // Specific values from the issue triage on #505 — if any
+        // of these change, that's a UX-affecting bandwidth
+        // boundary shift and the panel range calc needs revisit.
+        assert!((max_bandwidth_for_mode(DemodMode::Nfm).unwrap() - 50_000.0).abs() < f64::EPSILON);
+        assert!((max_bandwidth_for_mode(DemodMode::Wfm).unwrap() - 250_000.0).abs() < f64::EPSILON);
+        assert!((max_bandwidth_for_mode(DemodMode::Cw).unwrap() - 500.0).abs() < f64::EPSILON);
+        assert!((min_bandwidth_for_mode(DemodMode::Cw).unwrap() - 50.0).abs() < f64::EPSILON);
     }
 }

--- a/crates/sdr-radio/src/demod/mod.rs
+++ b/crates/sdr-radio/src/demod/mod.rs
@@ -299,12 +299,30 @@ mod tests {
 
     #[test]
     fn min_bandwidth_for_mode_pins_known_values() {
-        // Specific values from the issue triage on #505 — if any
-        // of these change, that's a UX-affecting bandwidth
-        // boundary shift and the panel range calc needs revisit.
-        assert!((max_bandwidth_for_mode(DemodMode::Nfm).unwrap() - 50_000.0).abs() < f64::EPSILON);
-        assert!((max_bandwidth_for_mode(DemodMode::Wfm).unwrap() - 250_000.0).abs() < f64::EPSILON);
-        assert!((max_bandwidth_for_mode(DemodMode::Cw).unwrap() - 500.0).abs() < f64::EPSILON);
-        assert!((min_bandwidth_for_mode(DemodMode::Cw).unwrap() - 50.0).abs() < f64::EPSILON);
+        // Per-mode bandwidth boundaries the panel range calc
+        // relies on. Named constants rather than inline literals
+        // so a future boundary shift is auditable in diffs. Per
+        // `CodeRabbit` round 1 on PR #548.
+        const EXPECTED_NFM_MAX_BW_HZ: f64 = 50_000.0;
+        const EXPECTED_WFM_MAX_BW_HZ: f64 = 250_000.0;
+        const EXPECTED_CW_MAX_BW_HZ: f64 = 500.0;
+        const EXPECTED_CW_MIN_BW_HZ: f64 = 50.0;
+
+        assert!(
+            (max_bandwidth_for_mode(DemodMode::Nfm).unwrap() - EXPECTED_NFM_MAX_BW_HZ).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (max_bandwidth_for_mode(DemodMode::Wfm).unwrap() - EXPECTED_WFM_MAX_BW_HZ).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (max_bandwidth_for_mode(DemodMode::Cw).unwrap() - EXPECTED_CW_MAX_BW_HZ).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (min_bandwidth_for_mode(DemodMode::Cw).unwrap() - EXPECTED_CW_MIN_BW_HZ).abs()
+                < f64::EPSILON
+        );
     }
 }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -313,11 +313,20 @@ impl SpectrumHandle {
     /// during the gesture, so this method isn't on their hot
     /// path — it exists for the panel-side and DSP-echo
     /// reflection paths. Per issue #504.
+    ///
+    /// **No clamping here.** The drag path uses
+    /// [`vfo_overlay::VfoState::clamp_bandwidth`] which enforces
+    /// a global `[500 Hz, 250 kHz]` envelope — appropriate as a
+    /// safety net for unbounded user drag input, but wrong for
+    /// values arriving via DSP echo. Those values have already
+    /// been clamped to the active demod's actual `[min, max]`
+    /// (CW: `[50, 500]`, NFM: `[1k, 50k]`, etc.) by the demod's
+    /// own `set_bandwidth`. Re-clamping to the global envelope
+    /// here would push CW's 50 Hz bandwidth back up to 500 Hz,
+    /// desyncing the visible width from the actual filter. Per
+    /// `CodeRabbit` round 1 on PR #548.
     pub fn set_vfo_bandwidth(&self, bandwidth_hz: f64) {
-        let mut vfo = self.vfo_state.borrow_mut();
-        vfo.bandwidth_hz = bandwidth_hz;
-        vfo.clamp_bandwidth();
-        drop(vfo);
+        self.vfo_state.borrow_mut().bandwidth_hz = bandwidth_hz;
         self.fft_area.queue_draw();
         self.waterfall_area.queue_draw();
     }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -302,6 +302,26 @@ impl SpectrumHandle {
         self.waterfall_area.queue_draw();
     }
 
+    /// Programmatically set the VFO's visible channel-filter
+    /// width. Called from `DspToUi::BandwidthChanged` so a
+    /// bandwidth change originating outside the spectrum (Radio
+    /// panel `AdwSpinRow`, reset button, mode switch, scanner
+    /// retune) updates the visible VFO rectangle on the
+    /// waterfall, not just the panel's numeric readout.
+    ///
+    /// VFO drag handles update `vfo_state.bandwidth_hz` inline
+    /// during the gesture, so this method isn't on their hot
+    /// path — it exists for the panel-side and DSP-echo
+    /// reflection paths. Per issue #504.
+    pub fn set_vfo_bandwidth(&self, bandwidth_hz: f64) {
+        let mut vfo = self.vfo_state.borrow_mut();
+        vfo.bandwidth_hz = bandwidth_hz;
+        vfo.clamp_bandwidth();
+        drop(vfo);
+        self.fft_area.queue_draw();
+        self.waterfall_area.queue_draw();
+    }
+
     /// Current VFO offset (Hz from tuner center). Used by the
     /// reset-affordance visibility logic so the floating button
     /// can decide whether the VFO is in a non-default state

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -413,9 +413,6 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // Set initial status bar values and mode-specific control visibility.
     if let Some(mode) = demod_selector::index_to_demod_mode(demod_dropdown.selected()) {
         let label = header::demod_mode_label(mode);
-        let bw = panels.radio.bandwidth_row.value();
-        status_bar.update_demod(label, bw);
-
         panels.radio.apply_demod_visibility(mode);
         // Seed the bandwidth row's allowed range to the initial
         // demod (WFM by default — 50 kHz to 250 kHz). Without
@@ -423,7 +420,14 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         // [100 Hz, 250 kHz] envelope until the user changes
         // mode for the first time, letting them dial out-of-range
         // values that the demod silently rejects (issue #505).
-        update_bandwidth_row_range_for_mode(&panels.radio, mode);
+        update_bandwidth_row_range_for_mode(&panels.radio, &state, mode);
+        // Status-bar bandwidth read AFTER the clamp so a saved
+        // out-of-range value (e.g. an older config restoring an
+        // 80 kHz NFM bandwidth) shows the corrected value rather
+        // than the stale pre-clamp one. Per `CodeRabbit` round 1
+        // on PR #548 (outside-diff item).
+        let bw = panels.radio.bandwidth_row.value();
+        status_bar.update_demod(label, bw);
     }
     #[allow(clippy::cast_precision_loss)]
     status_bar.update_frequency(freq_selector.frequency() as f64);
@@ -1071,10 +1075,10 @@ fn handle_dsp_message(
             update_vfo_reset_button_visibility(radio_panel, spectrum_handle, state);
             // Retune the bandwidth row's allowed range to the
             // new mode's [min, max] so the user can't dial a
-            // value the demod will silently reject. Also clamps
-            // the current value into the new range — see issue
-            // #505 for why this matters.
-            update_bandwidth_row_range_for_mode(radio_panel, new_mode);
+            // value the demod will silently reject. Helper
+            // self-suppresses around its auto-clamp — see issue
+            // #505 + CR round 1 on PR #548 for why.
+            update_bandwidth_row_range_for_mode(radio_panel, state, new_mode);
         }
         DspToUi::BandwidthChanged(bw) => {
             // DSP-confirmed bandwidth change. Update BOTH the
@@ -1264,7 +1268,13 @@ fn handle_dsp_message(
                 // previous mode's range would be silently
                 // clamped here and the displayed value would
                 // drift from the actually-applied filter (#505).
-                update_bandwidth_row_range_for_mode(radio_panel, demod_mode);
+                // The helper self-suppresses around its own
+                // auto-clamp, so we don't need to wrap that call
+                // in the suppress flag — only the explicit
+                // `set_value` for the scanner-supplied bandwidth
+                // below needs suppression. Per `CodeRabbit`
+                // round 1 on PR #548.
+                update_bandwidth_row_range_for_mode(radio_panel, state, demod_mode);
                 state.suppress_bandwidth_notify.set(true);
                 radio_panel.bandwidth_row.set_value(bandwidth);
                 state.suppress_bandwidth_notify.set(false);
@@ -7252,14 +7262,27 @@ fn update_bandwidth_reset_sensitivity(radio: &sidebar::radio_panel::RadioPanel, 
 /// Also clamps the row's current value into the new range —
 /// without that, switching from WFM at 200 kHz to NFM would
 /// leave the displayed 200 kHz reading stale until the user
-/// manually adjusts. Setting the value here triggers the
-/// `connect_value_notify` handler, which dispatches a
-/// `SetBandwidth` to the controller. That's the right
-/// behaviour: the controller's `SetBandwidth` handler also
-/// calls `set_bandwidth` on the radio module, which would
-/// otherwise still hold the stale 200 kHz internally.
+/// manually adjusts.
+///
+/// **Self-suppresses `value-notify` around the auto-clamp
+/// `set_value`.** Without that suppression, the clamp would
+/// route through the spin-row's `connect_value_notify` handler
+/// — which is the MANUAL-bandwidth-change path. That path
+/// fires `force_disable.trigger("manual bandwidth change")`,
+/// which would stop the scanner mid-retune (the scanner-driven
+/// mode-change path calls this helper before its own
+/// `set_value`), and dispatch a redundant `SetBandwidth`
+/// command. Per `CodeRabbit` round 1 on PR #548. The clamp is
+/// programmatic (the UI snapping to a mode change), not user
+/// input, so no manual-side effects should fire.
+///
+/// The DSP doesn't need to be told about the clamp — the
+/// caller is responsible for sending its own `SetBandwidth`
+/// (or, in the DSP-echo case, the controller already changed
+/// the bandwidth as part of the mode change).
 fn update_bandwidth_row_range_for_mode(
     radio: &sidebar::radio_panel::RadioPanel,
+    state: &AppState,
     mode: sdr_types::DemodMode,
 ) {
     let Ok(min_bw) = sdr_radio::demod::min_bandwidth_for_mode(mode) else {
@@ -7280,10 +7303,21 @@ fn update_bandwidth_row_range_for_mode(
     adj.set_lower(min_bw);
     adj.set_upper(max_bw);
     let current = radio.bandwidth_row.value();
-    if current < min_bw {
-        radio.bandwidth_row.set_value(min_bw);
+    let target = if current < min_bw {
+        Some(min_bw)
     } else if current > max_bw {
-        radio.bandwidth_row.set_value(max_bw);
+        Some(max_bw)
+    } else {
+        None
+    };
+    if let Some(new_value) = target {
+        // Suppress only around the actual `set_value` — keep
+        // the suppress window as narrow as possible so a
+        // genuinely-user-driven `value-notify` racing the GTK
+        // main loop can't accidentally get swallowed.
+        state.suppress_bandwidth_notify.set(true);
+        radio.bandwidth_row.set_value(new_value);
+        state.suppress_bandwidth_notify.set(false);
     }
 }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -401,6 +401,13 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         status_bar.update_demod(label, bw);
 
         panels.radio.apply_demod_visibility(mode);
+        // Seed the bandwidth row's allowed range to the initial
+        // demod (WFM by default — 50 kHz to 250 kHz). Without
+        // this, the row's adjustment carries the panel-level
+        // [100 Hz, 250 kHz] envelope until the user changes
+        // mode for the first time, letting them dial out-of-range
+        // values that the demod silently rejects (issue #505).
+        update_bandwidth_row_range_for_mode(&panels.radio, mode);
     }
     #[allow(clippy::cast_precision_loss)]
     status_bar.update_frequency(freq_selector.frequency() as f64);
@@ -1046,23 +1053,43 @@ fn handle_dsp_message(
             // default. Per issue #341.
             update_bandwidth_reset_sensitivity(radio_panel, state);
             update_vfo_reset_button_visibility(radio_panel, spectrum_handle, state);
+            // Retune the bandwidth row's allowed range to the
+            // new mode's [min, max] so the user can't dial a
+            // value the demod will silently reject. Also clamps
+            // the current value into the new range — see issue
+            // #505 for why this matters.
+            update_bandwidth_row_range_for_mode(radio_panel, new_mode);
         }
         DspToUi::BandwidthChanged(bw) => {
-            // DSP-originated bandwidth change (typically a VFO drag
-            // on the spectrum). Reflect it in the Radio panel's
-            // spin row so the numeric readout stays in lockstep
-            // with the active filter width.
+            // DSP-confirmed bandwidth change. Update BOTH the
+            // Radio panel's spin row AND the spectrum's visible
+            // VFO width so they stay in lockstep with the active
+            // filter regardless of where the change originated:
             //
-            // Set the suppress flag around the `set_value` call so
-            // the spin's `connect_value_notify` handler knows this
-            // update is DSP-originated and doesn't dispatch a
-            // redundant `UiToDsp::SetBandwidth` back to the
-            // controller. Restored after the set_value returns so
+            // - VFO drag on the spectrum: the drag handler
+            //   already mutated `vfo_state.bandwidth_hz` inline
+            //   for instant visual feedback, so the
+            //   `set_vfo_bandwidth` below is a redundant
+            //   confirm. Cheap.
+            // - Radio panel `AdwSpinRow` / reset button /
+            //   scanner retune / mode switch: those paths only
+            //   sent the `SetBandwidth` command. Without the
+            //   spectrum update here, the visible VFO width
+            //   stays at whatever the previous drag put it at
+            //   — which was issue #504.
+            //
+            // Set the `suppress_bandwidth_notify` flag around
+            // the spin row's `set_value` so its
+            // `connect_value_notify` handler knows this update
+            // is DSP-originated and doesn't dispatch a redundant
+            // `UiToDsp::SetBandwidth` back to the controller.
+            // Restored after the set_value returns so
             // user-originated edits from the next event loop tick
             // are dispatched normally.
             state.suppress_bandwidth_notify.set(true);
             radio_panel.bandwidth_row.set_value(bw);
             state.suppress_bandwidth_notify.set(false);
+            spectrum_handle.set_vfo_bandwidth(bw);
         }
         DspToUi::VfoOffsetChanged(offset) => {
             // DSP-originated VFO offset change — typically a
@@ -1215,6 +1242,13 @@ fn handle_dsp_message(
                 // the radio panel reflects the scanner's channel
                 // instead of the previous mode's row set.
                 radio_panel.apply_demod_visibility(demod_mode);
+                // Retune the bandwidth row's range to the new
+                // mode BEFORE the set_value below — otherwise a
+                // scanner channel with bandwidth outside the
+                // previous mode's range would be silently
+                // clamped here and the displayed value would
+                // drift from the actually-applied filter (#505).
+                update_bandwidth_row_range_for_mode(radio_panel, demod_mode);
                 state.suppress_bandwidth_notify.set(true);
                 radio_panel.bandwidth_row.set_value(bandwidth);
                 state.suppress_bandwidth_notify.set(false);
@@ -7130,6 +7164,55 @@ fn update_bandwidth_reset_sensitivity(radio: &sidebar::radio_panel::RadioPanel, 
     let current = radio.bandwidth_row.value();
     let at_default = (current - default).abs() < BANDWIDTH_RESET_TOLERANCE_HZ;
     radio.bandwidth_reset_button.set_sensitive(!at_default);
+}
+
+/// Retune the bandwidth `AdwSpinRow`'s allowed range to the
+/// active demod's `[min_bandwidth, max_bandwidth]`. Called
+/// whenever the demod mode changes so the row can't accept
+/// values the demod will silently reject — that mismatch was
+/// the root cause of issue #505 (audio stutter at panel-
+/// bandwidth > per-mode max). The panel-level constants
+/// `MIN_BANDWIDTH_HZ` / `MAX_BANDWIDTH_HZ` set the absolute
+/// envelope the row can ever cover (covers WFM's full
+/// 1-250 kHz range); this helper narrows it to the active
+/// mode's actual range on every demod change.
+///
+/// Also clamps the row's current value into the new range —
+/// without that, switching from WFM at 200 kHz to NFM would
+/// leave the displayed 200 kHz reading stale until the user
+/// manually adjusts. Setting the value here triggers the
+/// `connect_value_notify` handler, which dispatches a
+/// `SetBandwidth` to the controller. That's the right
+/// behaviour: the controller's `SetBandwidth` handler also
+/// calls `set_bandwidth` on the radio module, which would
+/// otherwise still hold the stale 200 kHz internally.
+fn update_bandwidth_row_range_for_mode(
+    radio: &sidebar::radio_panel::RadioPanel,
+    mode: sdr_types::DemodMode,
+) {
+    let Ok(min_bw) = sdr_radio::demod::min_bandwidth_for_mode(mode) else {
+        tracing::warn!(
+            ?mode,
+            "min_bandwidth_for_mode failed — leaving bandwidth row range unchanged"
+        );
+        return;
+    };
+    let Ok(max_bw) = sdr_radio::demod::max_bandwidth_for_mode(mode) else {
+        tracing::warn!(
+            ?mode,
+            "max_bandwidth_for_mode failed — leaving bandwidth row range unchanged"
+        );
+        return;
+    };
+    let adj = radio.bandwidth_row.adjustment();
+    adj.set_lower(min_bw);
+    adj.set_upper(max_bw);
+    let current = radio.bandwidth_row.value();
+    if current < min_bw {
+        radio.bandwidth_row.set_value(min_bw);
+    } else if current > max_bw {
+        radio.bandwidth_row.set_value(max_bw);
+    }
 }
 
 /// Tolerance (Hz) for the "VFO offset is at 0" comparison in


### PR DESCRIPTION
## Summary

Two related radio-panel bandwidth bugs.

### #504 — Panel bandwidth row didn't propagate to spectrum's VFO width

The DSP→UI path correctly echoed `BandwidthChanged` to the panel SpinRow, but the spectrum's `VfoState.bandwidth_hz` was only mutated on user drag, never on DSP-confirmed changes. Result: panel SpinRow edits applied to the audio filter but the visible VFO rectangle on the waterfall stayed put.

Fix: new `SpectrumHandle::set_vfo_bandwidth(bandwidth_hz)` method, called from the `DspToUi::BandwidthChanged` handler so all bandwidth-change origins (panel edit, reset button, scanner retune, mode switch, VFO drag) keep both displays in lockstep.

### #505 — Audio stuttered when bandwidth > per-mode max

Root cause: the panel's `AdwSpinRow` allowed up to 250 kHz globally, but each demod's `set_bandwidth` clamped to its own per-mode max (NFM: 50 kHz, AM: 15 kHz, USB/LSB: 12 kHz, CW: 500 Hz). Out-of-range values landed at the VFO channel filter (which accepted them) but were silently rejected by the demod's audio LPF — leaving the demod processing IQ wildly outside its design assumptions.

Fix:
- New `min_bandwidth_for_mode` + `max_bandwidth_for_mode` helpers in `sdr-radio::demod` mirror the existing `default_bandwidth_for_mode`.
- New `update_bandwidth_row_range_for_mode` in `window.rs` retunes the SpinRow's `Adjustment` lower/upper to match the active demod, clamping the current value into the new range. Called from initial setup, `DemodModeChanged`, and the scanner retune path (BEFORE `set_value` so out-of-range scanner channels clamp honestly).

## Test plan

- [x] `cargo test --workspace --features sdr-ui/whisper-cpu` — zero failures (2 new unit tests pin the helper contract + specific values from #505's triage)
- [x] `cargo clippy --workspace --features sdr-ui/whisper-cpu --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace --no-default-features --features sdr-ui/sherpa-cpu` — clean
- [ ] Manual #504: edit Radio panel bandwidth, watch the VFO width on the waterfall — should now move with the panel.
- [ ] Manual #505: switch demods (WFM/NFM/AM/SSB/CW), confirm the bandwidth SpinRow's allowed range updates per mode (no more dialing 200 kHz in NFM).
- [ ] Manual: scanner retune to a channel with non-default bandwidth — confirm panel range + value land consistently with the new mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bandwidth limits now adjust automatically when switching demodulation modes
  * Spectrum VFO overlay updates in real time when bandwidth changes
  * Radio panel numeric control and spectrum view remain synchronized for all bandwidth updates

* **Tests**
  * Added tests covering per‑mode bandwidth boundaries and pinned expected values for common modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->