### PR TITLE
sdr-ui: typed ViewerError + bias-T toggle (closes #545, #537)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -696,7 +696,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             state.audio_frames_written = 0;
             state.iq_samples_read = 0;
             state.diag_log_at = std::time::Instant::now();
-            match open_source(state) {
+            match open_source(state, dsp_tx) {
                 Ok(()) => {
                     // Start the audio sink -- if it fails, log but continue
                     // so the spectrum display still works. Discriminate the
@@ -1420,7 +1420,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             }
             // Restart with the new source type if was playing
             if was_running {
-                match open_source(state) {
+                match open_source(state, dsp_tx) {
                     Ok(()) => {
                         // Clear the audio-sink offline latch on
                         // a successful restart, same as the
@@ -2367,7 +2367,7 @@ fn rebuild_rtl_tcp_source(
 }
 
 /// Open the active IQ source and configure it for streaming.
-fn open_source(state: &mut DspState) -> Result<(), String> {
+fn open_source(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) -> Result<(), String> {
     let mut source: Box<dyn Source> = match state.source_type {
         SourceType::RtlSdr => Box::new(RtlSdrSource::new(DEVICE_INDEX)),
         SourceType::Network => Box::new(sdr_source_network::NetworkSource::new(
@@ -2459,9 +2459,11 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
     // gated on `bias_tee_enabled` being `true`) so an explicit
     // `false` also wins over any stale GPIO state from a prior
     // app. No-op for non-RTL-SDR sources, so we gate on
-    // `SourceType::RtlSdr`. Warn-and-continue on failure —
-    // bias-T is non-critical and the source is otherwise
-    // streaming. Per CR on PR #550.
+    // `SourceType::RtlSdr`. Warn-and-continue on failure, AND
+    // surface a non-fatal toast so the user isn't left with a
+    // switch that silently lies about hardware state — mirrors
+    // the live `UiToDsp::SetBiasTee` handler's error path.
+    // Per CR round 2 on PR #550.
     if state.source_type == SourceType::RtlSdr
         && let Err(e) = source.set_bias_tee(state.bias_tee_enabled)
     {
@@ -2470,6 +2472,10 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
             enabled = state.bias_tee_enabled,
             "re-applying persisted bias-T on source open failed"
         );
+        let _ = dsp_tx.send(DspToUi::Error(format!(
+            "Bias tee {} failed: {e}",
+            if state.bias_tee_enabled { "on" } else { "off" }
+        )));
     }
 
     // Sync sample rate from the source (file sources have fixed rates).

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -301,6 +301,14 @@ struct DspState {
     /// and to the newly-opened source when the source is rebuilt
     /// from a path or source-type change. Per issue #236.
     file_looping: bool,
+    /// RTL-SDR USB bias-T (5 V on coax) toggle. Persisted in
+    /// state so a `SetBiasTee` dispatched while no source is
+    /// open isn't silently dropped — `open_source` re-applies
+    /// the value to the freshly-built RTL-SDR source. Without
+    /// this, first-play after restart would always start with
+    /// bias-T off regardless of the persisted UI switch.
+    /// Per CR round 1 on PR #550.
+    bias_tee_enabled: bool,
 
     // Pre-allocated buffers
     iq_buf: Vec<Complex>,
@@ -510,6 +518,7 @@ impl DspState {
             rtl_tcp_auth_key: None,
             file_path: std::path::PathBuf::new(),
             file_looping: false,
+            bias_tee_enabled: false,
             iq_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             processed_buf: vec![Complex::default(); IQ_PAIRS_PER_READ],
             fft_buf: vec![0.0; DEFAULT_FFT_SIZE],
@@ -1548,6 +1557,10 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 
         UiToDsp::SetBiasTee(enabled) => {
             tracing::debug!(enabled, "set bias tee");
+            // Persist FIRST so a dispatch with no live source
+            // (e.g. startup before the user hits Play) survives
+            // until `open_source` runs. Per CR on PR #550.
+            state.bias_tee_enabled = enabled;
             if let Some(source) = &mut state.source
                 && let Err(e) = source.set_bias_tee(enabled)
             {
@@ -2435,6 +2448,29 @@ fn open_source(state: &mut DspState) -> Result<(), String> {
     }
 
     source.start().map_err(|e| e.to_string())?;
+
+    // Re-apply persisted bias-T to the freshly-opened RTL-SDR
+    // source. The `SetBiasTee` handler stores the value in
+    // state but only forwards to the live source — without
+    // this, a user who toggled bias-T while no source was
+    // open (or whose persisted-true value was dispatched at
+    // startup before Play) would land here with the dongle's
+    // GPIO still in its power-on default. Always apply (not
+    // gated on `bias_tee_enabled` being `true`) so an explicit
+    // `false` also wins over any stale GPIO state from a prior
+    // app. No-op for non-RTL-SDR sources, so we gate on
+    // `SourceType::RtlSdr`. Warn-and-continue on failure —
+    // bias-T is non-critical and the source is otherwise
+    // streaming. Per CR on PR #550.
+    if state.source_type == SourceType::RtlSdr
+        && let Err(e) = source.set_bias_tee(state.bias_tee_enabled)
+    {
+        tracing::warn!(
+            error = %e,
+            enabled = state.bias_tee_enabled,
+            "re-applying persisted bias-T on source open failed"
+        );
+    }
 
     // Sync sample rate from the source (file sources have fixed rates).
     state.sample_rate = source.sample_rate();

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -427,6 +427,23 @@ impl Source for RtlSdrSource {
         }
         Ok(())
     }
+
+    fn set_bias_tee(&mut self, enabled: bool) -> Result<(), SourceError> {
+        // Routes through `rtlsdr_set_bias_tee` (GPIO 0). Older
+        // V3-clone dongles lack the bias-T circuit entirely; the
+        // driver returns Err on those — surfaced as a
+        // `TuneFailed` toast rather than crashing. Per issue
+        // #537. The Source-trait default is a silent no-op so
+        // every other source type (file, network) ignores the
+        // command — only the live RTL-SDR USB path actually
+        // toggles hardware.
+        if let Some(device) = &mut self.device {
+            device
+                .set_bias_tee(enabled)
+                .map_err(|e| SourceError::TuneFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/sdr-ui/src/apt_viewer.rs
+++ b/crates/sdr-ui/src/apt_viewer.rs
@@ -38,6 +38,8 @@ use libadwaita::prelude::*;
 
 use sdr_dsp::apt::LINE_PIXELS;
 
+use crate::viewer::ViewerError;
+
 /// Maximum lines we'll keep in the renderer. NOAA APT bounds a pass
 /// at ~1800 lines (15 min × 2 lines/sec); 2048 leaves headroom for
 /// the longest plausible high-elevation pass without ever growing
@@ -178,13 +180,25 @@ impl AptImageRenderer {
     ///
     /// # Errors
     ///
-    /// Returns a stringified Cairo error on paint failure. Callers
-    /// usually log and continue — drawing failures shouldn't kill
-    /// the UI.
+    /// # Errors
+    ///
+    /// Returns [`ViewerError::Cairo`] if any of the Cairo
+    /// operations (`paint`, `save`, `restore`,
+    /// `set_source_surface`, `fill`) fail. Callers usually log
+    /// and continue — drawing failures shouldn't kill the UI.
+    /// Per issue #545 (was `Result<(), String>` before).
     #[allow(clippy::cast_precision_loss)]
-    pub fn render(&self, cr: &cairo::Context, width: i32, height: i32) -> Result<(), String> {
+    pub fn render(
+        &self,
+        cr: &cairo::Context,
+        width: i32,
+        height: i32,
+    ) -> Result<(), ViewerError> {
         cr.set_source_rgb(BACKGROUND_RGB[0], BACKGROUND_RGB[1], BACKGROUND_RGB[2]);
-        cr.paint().map_err(|e| format!("background paint: {e}"))?;
+        cr.paint().map_err(|e| ViewerError::Cairo {
+            op: "background paint",
+            source: e,
+        })?;
 
         if self.n_lines == 0 || width <= 0 || height <= 0 {
             return Ok(());
@@ -195,18 +209,30 @@ impl AptImageRenderer {
         let scale = (f64::from(width) / img_w).min(f64::from(height) / img_h);
         let off_x = (f64::from(width) - img_w * scale) / 2.0;
 
-        cr.save().map_err(|e| format!("save: {e}"))?;
+        cr.save().map_err(|e| ViewerError::Cairo {
+            op: "save",
+            source: e,
+        })?;
         cr.translate(off_x, 0.0);
         cr.scale(scale, scale);
         cr.set_source_surface(&self.surface, 0.0, 0.0)
-            .map_err(|e| format!("set_source_surface: {e}"))?;
+            .map_err(|e| ViewerError::Cairo {
+                op: "set_source_surface",
+                source: e,
+            })?;
         // Rectangle + fill clips the paint to the populated rows;
         // rows past n_lines stay alpha-0 in the surface and would
         // paint as nothing under `paint()` anyway, but clipping
         // here also bounds the layout area cleanly.
         cr.rectangle(0.0, 0.0, img_w, img_h);
-        cr.fill().map_err(|e| format!("image fill: {e}"))?;
-        cr.restore().map_err(|e| format!("restore: {e}"))?;
+        cr.fill().map_err(|e| ViewerError::Cairo {
+            op: "image fill",
+            source: e,
+        })?;
+        cr.restore().map_err(|e| ViewerError::Cairo {
+            op: "restore",
+            source: e,
+        })?;
         Ok(())
     }
 
@@ -220,16 +246,21 @@ impl AptImageRenderer {
     ///
     /// # Errors
     ///
-    /// Returns a stringified error from filesystem creation,
-    /// surface construction, paint operations, or Cairo's PNG
-    /// encoder.
+    /// Returns [`ViewerError::EmptyChannel`] (with `apid: None`
+    /// — APT has no APIDs) when there's nothing to export, or a
+    /// `Cairo` / `Io` / `PngEncode` variant on the failing step.
+    /// Per issue #545 (was `Result<(), String>` before).
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    pub fn export_png(&self, path: &Path) -> Result<(), String> {
+    pub fn export_png(&self, path: &Path) -> Result<(), ViewerError> {
         if self.n_lines == 0 {
-            return Err("no APT image data to export".to_string());
+            return Err(ViewerError::EmptyChannel { apid: None });
         }
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+            std::fs::create_dir_all(parent).map_err(|e| ViewerError::Io {
+                op: "create_dir_all",
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
         }
 
         let export_surface = cairo::ImageSurface::create(
@@ -237,22 +268,35 @@ impl AptImageRenderer {
             LINE_PIXELS as i32,
             self.n_lines as i32,
         )
-        .map_err(|e| format!("export surface: {e}"))?;
-        let cr =
-            cairo::Context::new(&export_surface).map_err(|e| format!("export context: {e}"))?;
+        .map_err(|e| ViewerError::Cairo {
+            op: "export surface",
+            source: e,
+        })?;
+        let cr = cairo::Context::new(&export_surface).map_err(|e| ViewerError::Cairo {
+            op: "export context",
+            source: e,
+        })?;
         cr.set_source_surface(&self.surface, 0.0, 0.0)
-            .map_err(|e| format!("export set_source_surface: {e}"))?;
+            .map_err(|e| ViewerError::Cairo {
+                op: "export set_source_surface",
+                source: e,
+            })?;
         // LINE_PIXELS / n_lines are both bounded by MAX_LINES — well
         // under f64's 52-bit mantissa, no real precision loss.
         #[allow(clippy::cast_precision_loss)]
         cr.rectangle(0.0, 0.0, LINE_PIXELS as f64, self.n_lines as f64);
-        cr.fill().map_err(|e| format!("export fill: {e}"))?;
+        cr.fill().map_err(|e| ViewerError::Cairo {
+            op: "export fill",
+            source: e,
+        })?;
         drop(cr);
 
-        let mut file = std::fs::File::create(path).map_err(|e| format!("file: {e}"))?;
-        export_surface
-            .write_to_png(&mut file)
-            .map_err(|e| format!("png: {e}"))?;
+        let mut file = std::fs::File::create(path).map_err(|e| ViewerError::Io {
+            op: "file create",
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+        export_surface.write_to_png(&mut file)?;
         tracing::info!(?path, lines = self.n_lines, "APT image exported to PNG");
         Ok(())
     }
@@ -360,8 +404,10 @@ impl AptImageView {
     ///
     /// # Errors
     ///
-    /// Propagates any error from the underlying renderer.
-    pub fn export_png(&self, path: &Path) -> Result<(), String> {
+    /// Propagates any [`ViewerError`] from the underlying
+    /// renderer (per issue #545 — was `Result<(), String>`
+    /// before).
+    pub fn export_png(&self, path: &Path) -> Result<(), ViewerError> {
         self.renderer.borrow().export_png(path)
     }
 

--- a/crates/sdr-ui/src/apt_viewer.rs
+++ b/crates/sdr-ui/src/apt_viewer.rs
@@ -180,20 +180,13 @@ impl AptImageRenderer {
     ///
     /// # Errors
     ///
-    /// # Errors
-    ///
     /// Returns [`ViewerError::Cairo`] if any of the Cairo
     /// operations (`paint`, `save`, `restore`,
     /// `set_source_surface`, `fill`) fail. Callers usually log
     /// and continue — drawing failures shouldn't kill the UI.
     /// Per issue #545 (was `Result<(), String>` before).
     #[allow(clippy::cast_precision_loss)]
-    pub fn render(
-        &self,
-        cr: &cairo::Context,
-        width: i32,
-        height: i32,
-    ) -> Result<(), ViewerError> {
+    pub fn render(&self, cr: &cairo::Context, width: i32, height: i32) -> Result<(), ViewerError> {
         cr.set_source_rgb(BACKGROUND_RGB[0], BACKGROUND_RGB[1], BACKGROUND_RGB[2]);
         cr.paint().map_err(|e| ViewerError::Cairo {
             op: "background paint",

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -26,6 +26,7 @@ pub mod spectrum;
 pub mod state;
 pub mod status_bar;
 pub mod ui_helpers;
+pub mod viewer;
 pub mod window;
 
 // Re-exports from sdr-core for backward compat with internal modules.

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -372,12 +372,7 @@ impl LrptImageRenderer {
     /// usually log and continue — drawing failures shouldn't
     /// kill the UI. Per issue #545.
     #[allow(clippy::cast_precision_loss)]
-    pub fn render(
-        &self,
-        cr: &cairo::Context,
-        width: i32,
-        height: i32,
-    ) -> Result<(), ViewerError> {
+    pub fn render(&self, cr: &cairo::Context, width: i32, height: i32) -> Result<(), ViewerError> {
         cr.set_source_rgb(BACKGROUND_RGB[0], BACKGROUND_RGB[1], BACKGROUND_RGB[2]);
         cr.paint().map_err(|e| ViewerError::Cairo {
             op: "background paint",

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -366,8 +366,6 @@ impl LrptImageRenderer {
     ///
     /// # Errors
     ///
-    /// # Errors
-    ///
     /// Returns [`ViewerError::Cairo`] on paint failure. Callers
     /// usually log and continue — drawing failures shouldn't
     /// kill the UI. Per issue #545.

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -538,6 +538,14 @@ pub fn write_greyscale_png(
         dim: "height",
         value: height,
     })?;
+    // Zero-size guard runs BEFORE buffer-shape validation so a
+    // call like `write_greyscale_png(path, &[1], 0, 1)` reports
+    // the dedicated `ZeroSized` discriminant rather than masking
+    // it as a generic `InvalidBuffer`. Callers (and the user-
+    // facing toast) match on these distinctly. Per CR on PR #550.
+    if width == 0 || height == 0 {
+        return Err(ViewerError::ZeroSized);
+    }
     let expected = width
         .checked_mul(height)
         .ok_or(ViewerError::DimensionTooLarge {
@@ -552,9 +560,6 @@ pub fn write_greyscale_png(
             height,
             expected,
         )));
-    }
-    if width == 0 || height == 0 {
-        return Err(ViewerError::ZeroSized);
     }
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| ViewerError::Io {
@@ -1613,6 +1618,18 @@ mod tests {
         let path = std::env::temp_dir().join("sdr-ui-lrpt-bare-zero.png");
         let result = write_greyscale_png(&path, &[], 0, 0);
         assert!(result.is_err());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn write_greyscale_png_zero_dim_with_pixels_reports_zero_sized() {
+        // Pin the CR-requested ordering: a zero-dim call with a
+        // non-empty pixel buffer must surface as `ZeroSized`, not
+        // mask as the generic `InvalidBuffer` length-mismatch.
+        // Per CR on PR #550.
+        let path = std::env::temp_dir().join("sdr-ui-lrpt-bare-zero-dim-pixels.png");
+        let result = write_greyscale_png(&path, &[1_u8], 0, 1);
+        assert!(matches!(result, Err(crate::viewer::ViewerError::ZeroSized)));
         assert!(!path.exists());
     }
 }

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -53,6 +53,7 @@ use sdr_lrpt::image::IMAGE_WIDTH;
 use sdr_radio::lrpt_image::LrptImage;
 
 use crate::messages::UiToDsp;
+use crate::viewer::ViewerError;
 
 /// Maximum lines we'll keep per channel. The MSU-MR scanner on
 /// Meteor-M produces AVHRR-style imagery at ~6 scan lines per
@@ -365,13 +366,23 @@ impl LrptImageRenderer {
     ///
     /// # Errors
     ///
-    /// Returns a stringified Cairo error on paint failure.
-    /// Callers usually log and continue — drawing failures
-    /// shouldn't kill the UI.
+    /// # Errors
+    ///
+    /// Returns [`ViewerError::Cairo`] on paint failure. Callers
+    /// usually log and continue — drawing failures shouldn't
+    /// kill the UI. Per issue #545.
     #[allow(clippy::cast_precision_loss)]
-    pub fn render(&self, cr: &cairo::Context, width: i32, height: i32) -> Result<(), String> {
+    pub fn render(
+        &self,
+        cr: &cairo::Context,
+        width: i32,
+        height: i32,
+    ) -> Result<(), ViewerError> {
         cr.set_source_rgb(BACKGROUND_RGB[0], BACKGROUND_RGB[1], BACKGROUND_RGB[2]);
-        cr.paint().map_err(|e| format!("background paint: {e}"))?;
+        cr.paint().map_err(|e| ViewerError::Cairo {
+            op: "background paint",
+            source: e,
+        })?;
 
         let Some(apid) = self.active else {
             return Ok(());
@@ -388,14 +399,26 @@ impl LrptImageRenderer {
         let scale = (f64::from(width) / img_w).min(f64::from(height) / img_h);
         let off_x = (f64::from(width) - img_w * scale) / 2.0;
 
-        cr.save().map_err(|e| format!("save: {e}"))?;
+        cr.save().map_err(|e| ViewerError::Cairo {
+            op: "save",
+            source: e,
+        })?;
         cr.translate(off_x, 0.0);
         cr.scale(scale, scale);
         cr.set_source_surface(&channel.surface, 0.0, 0.0)
-            .map_err(|e| format!("set_source_surface: {e}"))?;
+            .map_err(|e| ViewerError::Cairo {
+                op: "set_source_surface",
+                source: e,
+            })?;
         cr.rectangle(0.0, 0.0, img_w, img_h);
-        cr.fill().map_err(|e| format!("image fill: {e}"))?;
-        cr.restore().map_err(|e| format!("restore: {e}"))?;
+        cr.fill().map_err(|e| ViewerError::Cairo {
+            op: "image fill",
+            source: e,
+        })?;
+        cr.restore().map_err(|e| ViewerError::Cairo {
+            op: "restore",
+            source: e,
+        })?;
         Ok(())
     }
 
@@ -406,22 +429,27 @@ impl LrptImageRenderer {
     ///
     /// # Errors
     ///
-    /// Returns a stringified error if no channel is active /
-    /// has data, or from filesystem creation, surface
-    /// construction, paint operations, or Cairo's PNG encoder.
+    /// Returns [`ViewerError::NoActiveChannel`] when no APID is
+    /// selected, [`ViewerError::EmptyChannel`] when the active
+    /// channel has no decoded rows yet, or `Cairo` / `Io` /
+    /// `PngEncode` on the failing step. Per issue #545.
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    pub fn export_png(&self, path: &Path) -> Result<(), String> {
+    pub fn export_png(&self, path: &Path) -> Result<(), ViewerError> {
         let Some(apid) = self.active else {
-            return Err("no LRPT channel selected for export".to_string());
+            return Err(ViewerError::NoActiveChannel);
         };
         let Some(channel) = self.channels.get(&apid) else {
-            return Err(format!("LRPT channel APID {apid} has no data to export"));
+            return Err(ViewerError::EmptyChannel { apid: Some(apid) });
         };
         if channel.n_lines == 0 {
-            return Err(format!("LRPT channel APID {apid} has no data to export"));
+            return Err(ViewerError::EmptyChannel { apid: Some(apid) });
         }
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+            std::fs::create_dir_all(parent).map_err(|e| ViewerError::Io {
+                op: "create_dir_all",
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
         }
 
         let export_surface = cairo::ImageSurface::create(
@@ -429,22 +457,35 @@ impl LrptImageRenderer {
             IMAGE_WIDTH as i32,
             channel.n_lines as i32,
         )
-        .map_err(|e| format!("export surface: {e}"))?;
-        let cr =
-            cairo::Context::new(&export_surface).map_err(|e| format!("export context: {e}"))?;
+        .map_err(|e| ViewerError::Cairo {
+            op: "export surface",
+            source: e,
+        })?;
+        let cr = cairo::Context::new(&export_surface).map_err(|e| ViewerError::Cairo {
+            op: "export context",
+            source: e,
+        })?;
         cr.set_source_surface(&channel.surface, 0.0, 0.0)
-            .map_err(|e| format!("export set_source_surface: {e}"))?;
+            .map_err(|e| ViewerError::Cairo {
+                op: "export set_source_surface",
+                source: e,
+            })?;
         // IMAGE_WIDTH and n_lines are well under f64's mantissa
         // — bounded by MAX_LINES — so no real precision loss.
         #[allow(clippy::cast_precision_loss)]
         cr.rectangle(0.0, 0.0, IMAGE_WIDTH as f64, channel.n_lines as f64);
-        cr.fill().map_err(|e| format!("export fill: {e}"))?;
+        cr.fill().map_err(|e| ViewerError::Cairo {
+            op: "export fill",
+            source: e,
+        })?;
         drop(cr);
 
-        let mut file = std::fs::File::create(path).map_err(|e| format!("file: {e}"))?;
-        export_surface
-            .write_to_png(&mut file)
-            .map_err(|e| format!("png: {e}"))?;
+        let mut file = std::fs::File::create(path).map_err(|e| ViewerError::Io {
+            op: "file create",
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+        export_surface.write_to_png(&mut file)?;
         tracing::info!(
             ?path,
             apid,
@@ -471,17 +512,20 @@ impl LrptImageRenderer {
 ///
 /// # Errors
 ///
-/// Returns a stringified error from filesystem creation, surface
-/// construction, the surface-data lock, or Cairo's PNG encoder.
-/// Pixel-buffer length mismatch (`pixels.len() != width * height`)
-/// is reported as a stringified error rather than silently
-/// truncating.
+/// Returns a [`ViewerError`] variant identifying the failing
+/// step: `DimensionTooLarge` if `width` or `height` exceeds
+/// `i32::MAX` (Cairo's API limit), `InvalidBuffer` if
+/// `pixels.len()` doesn't match `width * height`, `ZeroSized`
+/// if either dimension is 0, and `Io` / `Cairo` /
+/// `SurfaceDataLock` / `InvalidStride` / `PngEncode` for the
+/// downstream Cairo and filesystem failures. Per issue #545
+/// (was `Result<(), String>` before).
 pub fn write_greyscale_png(
     path: &Path,
     pixels: &[u8],
     width: usize,
     height: usize,
-) -> Result<(), String> {
+) -> Result<(), ViewerError> {
     // Validate dimensions fit Cairo's `i32` API up front. The
     // earlier draft `as i32`-cast both, which silently wraps for
     // any usize > i32::MAX (2.1 G) into a negative or bogus
@@ -491,37 +535,48 @@ pub fn write_greyscale_png(
     // `#[allow(cast_possible_wrap)]` would have hidden the
     // wrap, not prevented it. Per `CodeRabbit` round 9 on PR
     // #543.
-    let width_i32 = i32::try_from(width)
-        .map_err(|_| format!("greyscale PNG: width {width} exceeds i32::MAX"))?;
-    let height_i32 = i32::try_from(height)
-        .map_err(|_| format!("greyscale PNG: height {height} exceeds i32::MAX"))?;
+    let width_i32 = i32::try_from(width).map_err(|_| ViewerError::DimensionTooLarge {
+        dim: "width",
+        value: width,
+    })?;
+    let height_i32 = i32::try_from(height).map_err(|_| ViewerError::DimensionTooLarge {
+        dim: "height",
+        value: height,
+    })?;
     let expected = width
         .checked_mul(height)
-        .ok_or_else(|| format!("greyscale PNG: width*height overflow ({width} × {height})"))?;
+        .ok_or(ViewerError::DimensionTooLarge {
+            dim: "width × height",
+            value: usize::MAX,
+        })?;
     if pixels.len() != expected {
-        return Err(format!(
-            "greyscale PNG: pixel buffer length {} doesn't match width*height ({}*{} = {})",
+        return Err(ViewerError::InvalidBuffer(format!(
+            "greyscale PNG pixel buffer length {} doesn't match width*height ({}*{} = {})",
             pixels.len(),
             width,
             height,
             expected,
-        ));
+        )));
     }
     if width == 0 || height == 0 {
-        return Err("greyscale PNG: zero-sized image".to_string());
+        return Err(ViewerError::ZeroSized);
     }
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+        std::fs::create_dir_all(parent).map_err(|e| ViewerError::Io {
+            op: "create_dir_all",
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
     }
 
     let mut surface = cairo::ImageSurface::create(cairo::Format::ARgb32, width_i32, height_i32)
-        .map_err(|e| format!("export surface: {e}"))?;
+        .map_err(|e| ViewerError::Cairo {
+            op: "export surface",
+            source: e,
+        })?;
     {
-        let stride =
-            usize::try_from(surface.stride()).map_err(|e| format!("invalid stride: {e}"))?;
-        let mut data = surface
-            .data()
-            .map_err(|e| format!("surface data lock: {e}"))?;
+        let stride = usize::try_from(surface.stride())?;
+        let mut data = surface.data()?;
         for row in 0..height {
             let row_offset = row * stride;
             let pixel_row_offset = row * width;
@@ -535,10 +590,12 @@ pub fn write_greyscale_png(
             }
         }
     }
-    let mut file = std::fs::File::create(path).map_err(|e| format!("file: {e}"))?;
-    surface
-        .write_to_png(&mut file)
-        .map_err(|e| format!("png: {e}"))?;
+    let mut file = std::fs::File::create(path).map_err(|e| ViewerError::Io {
+        op: "file create",
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    surface.write_to_png(&mut file)?;
     Ok(())
 }
 
@@ -903,8 +960,10 @@ impl LrptImageView {
     ///
     /// # Errors
     ///
-    /// Propagates any error from the underlying renderer.
-    pub fn export_png(&self, path: &Path) -> Result<(), String> {
+    /// Propagates any [`ViewerError`] from the underlying
+    /// renderer (per issue #545 — was `Result<(), String>`
+    /// before).
+    pub fn export_png(&self, path: &Path) -> Result<(), ViewerError> {
         self.drain_new_lines();
         self.renderer.borrow().export_png(path)
     }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -263,8 +263,10 @@ pub struct SourcePanel {
     /// RTL-SDR bias tee toggle. Powers an inline LNA over the
     /// coax (V3+ dongles only — older clones lack the circuit
     /// and the driver returns Err on those, surfaced as a
-    /// toast). Visibility-gated to RTL-SDR USB (and `rtl_tcp`
-    /// when the user has remote-bias-T toggle wired). Per
+    /// toast). Visibility-gated to local RTL-SDR USB only in
+    /// this panel (hidden for Network / File / `rtl_tcp`).
+    /// `rtl_tcp` has its own remote-bias-T default in the
+    /// share-server panel rather than reusing this row. Per
     /// issue #537.
     pub bias_tee_row: adw::SwitchRow,
     /// Network hostname entry.

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -44,6 +44,14 @@ pub const KEY_AGC_TYPE: &str = "rtl_sdr_agc_type";
 /// don't lose their AGC setting on first launch.
 pub const KEY_LEGACY_AGC_ENABLED: &str = "rtl_sdr_agc_enabled";
 
+/// Config key for the persisted bias-T toggle. Powers an
+/// inline LNA over the dongle's coax connector — only
+/// meaningful on RTL-SDR hardware that has the bias-T circuit
+/// (V3+; older clones don't). Default `false` so users without
+/// powered antennas don't accidentally feed 5 V into a passive
+/// LNA. Per issue #537.
+pub const KEY_SOURCE_RTL_BIAS_TEE: &str = "src_rtl_bias_tee";
+
 /// Device selector index for RTL-SDR.
 pub const DEVICE_RTLSDR: u32 = 0;
 /// Device selector index for Network.
@@ -252,6 +260,13 @@ pub struct SourcePanel {
     pub agc_row: adw::ComboRow,
     /// RTL-SDR PPM frequency correction.
     pub ppm_row: adw::SpinRow,
+    /// RTL-SDR bias tee toggle. Powers an inline LNA over the
+    /// coax (V3+ dongles only — older clones lack the circuit
+    /// and the driver returns Err on those, surfaced as a
+    /// toast). Visibility-gated to RTL-SDR USB (and `rtl_tcp`
+    /// when the user has remote-bias-T toggle wired). Per
+    /// issue #537.
+    pub bias_tee_row: adw::SwitchRow,
     /// Network hostname entry.
     pub hostname_row: adw::EntryRow,
     /// Network port number.
@@ -375,7 +390,13 @@ pub fn format_rtl_tcp_state(state: &RtlTcpConnectionState) -> String {
 const DEFAULT_SAMPLE_RATE_INDEX: u32 = 7;
 
 /// Build RTL-SDR-specific rows: sample rate, gain, AGC, PPM correction.
-fn build_rtlsdr_rows() -> (adw::ComboRow, adw::SpinRow, adw::ComboRow, adw::SpinRow) {
+fn build_rtlsdr_rows() -> (
+    adw::ComboRow,
+    adw::SpinRow,
+    adw::ComboRow,
+    adw::SpinRow,
+    adw::SwitchRow,
+) {
     let sample_rate_model = gtk4::StringList::new(&[
         "250 kHz",
         "1.024 MHz",
@@ -431,7 +452,17 @@ fn build_rtlsdr_rows() -> (adw::ComboRow, adw::SpinRow, adw::ComboRow, adw::Spin
         .digits(0)
         .build();
 
-    (sample_rate_row, gain_row, agc_row, ppm_row)
+    // Bias tee — powers an inline LNA over the coax. Off by
+    // default so users without powered antennas don't drive
+    // unexpected current into a passive antenna's centre
+    // conductor. Per issue #537.
+    let bias_tee_row = adw::SwitchRow::builder()
+        .title("Bias-T")
+        .subtitle("Power an inline LNA over the antenna coax")
+        .active(false)
+        .build();
+
+    (sample_rate_row, gain_row, agc_row, ppm_row, bias_tee_row)
 }
 
 /// Build network-specific rows: hostname, port, protocol.
@@ -498,6 +529,7 @@ fn connect_device_visibility(
     gain_row: &adw::SpinRow,
     agc_row: &adw::ComboRow,
     ppm_row: &adw::SpinRow,
+    bias_tee_row: &adw::SwitchRow,
     hostname_row: &adw::EntryRow,
     port_row: &adw::SpinRow,
     protocol_row: &adw::ComboRow,
@@ -512,6 +544,8 @@ fn connect_device_visibility(
         agc_row,
         #[weak]
         ppm_row,
+        #[weak]
+        bias_tee_row,
         #[weak]
         hostname_row,
         #[weak]
@@ -538,6 +572,10 @@ fn connect_device_visibility(
             gain_row.set_visible(tune_controls_visible);
             agc_row.set_visible(tune_controls_visible);
             ppm_row.set_visible(tune_controls_visible);
+            // Bias tee is local-RTL-SDR only — see the
+            // initial-visibility block for the same gating
+            // rationale. Per issue #537.
+            bias_tee_row.set_visible(is_rtlsdr);
 
             // Hostname / port entry is shared between raw-IQ Network
             // and RTL-TCP modes. Protocol (TCP/UDP) only applies to
@@ -583,7 +621,7 @@ pub fn build_source_panel() -> SourcePanel {
         .model(&device_model)
         .build();
 
-    let (sample_rate_row, gain_row, agc_row, ppm_row) = build_rtlsdr_rows();
+    let (sample_rate_row, gain_row, agc_row, ppm_row, bias_tee_row) = build_rtlsdr_rows();
     let (hostname_row, port_row, protocol_row) = build_network_rows();
     let file_path_row = adw::EntryRow::builder()
         .title("File Path")
@@ -680,6 +718,7 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&gain_row);
     group.add(&agc_row);
     group.add(&ppm_row);
+    group.add(&bias_tee_row);
     group.add(&hostname_row);
     group.add(&port_row);
     group.add(&protocol_row);
@@ -706,6 +745,12 @@ pub fn build_source_panel() -> SourcePanel {
     gain_row.set_visible(tune_controls_visible);
     agc_row.set_visible(tune_controls_visible);
     ppm_row.set_visible(tune_controls_visible);
+    // Bias tee is local-RTL-SDR only — the rtl_tcp wire
+    // protocol exposes a bias-T command but the rtl_tcp client
+    // doesn't currently surface it in this panel (the
+    // server-side panel has its own toggle). Keep this row
+    // hidden on RTL-TCP to match. Per issue #537.
+    bias_tee_row.set_visible(is_rtlsdr);
     hostname_row.set_visible(is_network || is_rtltcp);
     port_row.set_visible(is_network || is_rtltcp);
     protocol_row.set_visible(is_network);
@@ -726,6 +771,7 @@ pub fn build_source_panel() -> SourcePanel {
         &gain_row,
         &agc_row,
         &ppm_row,
+        &bias_tee_row,
         &hostname_row,
         &port_row,
         &protocol_row,
@@ -749,6 +795,7 @@ pub fn build_source_panel() -> SourcePanel {
         gain_row,
         agc_row,
         ppm_row,
+        bias_tee_row,
         hostname_row,
         port_row,
         protocol_row,
@@ -1069,6 +1116,27 @@ pub fn load_agc_type(config: &Arc<ConfigManager>) -> AgcType {
 pub fn save_agc_type(config: &Arc<ConfigManager>, agc_type: AgcType) {
     config.write(|v| {
         v[KEY_AGC_TYPE] = serde_json::to_value(agc_type).unwrap_or(serde_json::Value::Null);
+    });
+}
+
+/// Load the persisted bias-T toggle. Defaults to `false` —
+/// users without powered antennas should never have 5 V on
+/// the coax accidentally on first launch. Per issue #537.
+#[must_use]
+pub fn load_source_rtl_bias_tee(config: &Arc<ConfigManager>) -> bool {
+    config.read(|v| {
+        v.get(KEY_SOURCE_RTL_BIAS_TEE)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    })
+}
+
+/// Persist the bias-T toggle. Written on every
+/// `bias_tee_row.connect_active_notify` event in
+/// `window.rs::connect_source_panel`. Per issue #537.
+pub fn save_source_rtl_bias_tee(config: &Arc<ConfigManager>, enabled: bool) {
+    config.write(|v| {
+        v[KEY_SOURCE_RTL_BIAS_TEE] = serde_json::json!(enabled);
     });
 }
 
@@ -1468,5 +1536,39 @@ mod tests {
         // `u32::MAX` is the `gtk4::INVALID_LIST_POSITION`
         // sentinel; make sure we don't panic or coerce.
         assert_eq!(agc_type_from_selected(u32::MAX), None);
+    }
+
+    // --- Bias-T persistence tests (#537) ---
+
+    /// Fresh config (no key present) defaults to `false`.
+    /// "Safe by default" — a user without a powered antenna
+    /// shouldn't get 5 V on the coax on first launch.
+    #[test]
+    fn load_source_rtl_bias_tee_defaults_to_off() {
+        let config = make_config();
+        assert!(!load_source_rtl_bias_tee(&config));
+    }
+
+    /// Round-trip: write `true`, read back `true`.
+    #[test]
+    fn save_and_load_source_rtl_bias_tee_round_trip() {
+        let config = make_config();
+        save_source_rtl_bias_tee(&config, true);
+        assert!(load_source_rtl_bias_tee(&config));
+        save_source_rtl_bias_tee(&config, false);
+        assert!(!load_source_rtl_bias_tee(&config));
+    }
+
+    /// Corrupt value (wrong JSON type) falls back to default
+    /// rather than panicking. Mirrors the
+    /// `load_agc_type_tolerates_corrupt_new_key` resilience
+    /// pattern.
+    #[test]
+    fn load_source_rtl_bias_tee_tolerates_non_bool() {
+        let config = make_config();
+        config.write(|v| {
+            v[KEY_SOURCE_RTL_BIAS_TEE] = serde_json::json!("not a bool");
+        });
+        assert!(!load_source_rtl_bias_tee(&config));
     }
 }

--- a/crates/sdr-ui/src/viewer.rs
+++ b/crates/sdr-ui/src/viewer.rs
@@ -40,7 +40,13 @@ use std::path::PathBuf;
 /// Errors returned by the APT and LRPT image viewers' renderer
 /// and PNG-export paths. Constructed at the failing call site
 /// so the `Display` output identifies which step failed.
+///
+/// Marked `#[non_exhaustive]` because the module docs explicitly
+/// say new variants land here as either viewer needs them — a
+/// future addition would otherwise break exhaustive matches in
+/// downstream callers. Per CR on PR #550.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ViewerError {
     /// A Cairo drawing or surface operation failed. `op` names
     /// the failing call (`"paint"`, `"save"`, `"restore"`,
@@ -168,21 +174,20 @@ mod tests {
 
     #[test]
     fn cairo_error_display_includes_op_identifier() {
-        // We can't easily synthesise a real `cairo::Error` in a
-        // unit test (the variants are open-ended), but we can
-        // pin the message format by checking that the `op` field
-        // surfaces as part of any future `Display` output. This
-        // test serves as a contract-pin via the `Debug` impl,
-        // which is good enough for the format-stability
-        // assertion.
-        let dbg = format!(
-            "{:?}",
+        // Pins the user-facing `Display` contract — the `op`
+        // identifier must surface in the `#[error(...)]` string
+        // so toasts and log lines name the failing call site.
+        // `Debug` is too lenient (always prints field names
+        // verbatim) and would mask a future `#[error(...)]`
+        // regression. Per CR on PR #550.
+        let msg = format!(
+            "{}",
             ViewerError::Cairo {
                 op: "test paint",
                 source: cairo::Error::NoMemory,
             }
         );
-        assert!(dbg.contains("test paint"));
+        assert!(msg.contains("test paint"), "got {msg}");
     }
 
     #[test]

--- a/crates/sdr-ui/src/viewer.rs
+++ b/crates/sdr-ui/src/viewer.rs
@@ -175,10 +175,13 @@ mod tests {
         // test serves as a contract-pin via the `Debug` impl,
         // which is good enough for the format-stability
         // assertion.
-        let dbg = format!("{:?}", ViewerError::Cairo {
-            op: "test paint",
-            source: cairo::Error::NoMemory,
-        });
+        let dbg = format!(
+            "{:?}",
+            ViewerError::Cairo {
+                op: "test paint",
+                source: cairo::Error::NoMemory,
+            }
+        );
         assert!(dbg.contains("test paint"));
     }
 

--- a/crates/sdr-ui/src/viewer.rs
+++ b/crates/sdr-ui/src/viewer.rs
@@ -1,0 +1,201 @@
+//! Shared error type for the live image viewers (NOAA APT
+//! [`crate::apt_viewer`] and Meteor-M LRPT [`crate::lrpt_viewer`]).
+//!
+//! Both viewers hit the same Cairo + filesystem error categories
+//! when rendering and writing PNGs — this module collects the
+//! discriminants in one place so callers can match on `Cairo` /
+//! `Io` / `EmptyChannel` etc. without parsing strings.
+//!
+//! ## Why one shared type instead of per-viewer
+//!
+//! Pre-existing `Result<_, String>` returns (closed by issue
+//! [#545](https://github.com/jasonherald/rtl-sdr/issues/545))
+//! erased source context — callers couldn't distinguish a
+//! transient Cairo failure from a missing-channel domain
+//! condition without substring matching. CR's PR #543 review
+//! flagged the project guideline that library crates use
+//! `thiserror`. The two viewers' error sets overlap completely
+//! (both use Cairo, both write PNGs, both have empty / missing
+//! domain conditions), so a single `ViewerError` keeps the
+//! conversion cheap and avoids duplication. New variants land
+//! here when either viewer needs them.
+//!
+//! ## How to construct a Cairo error
+//!
+//! Cairo's `cairo::Error` is the common case — many ops can
+//! return it (`paint`, `save`, `restore`, `set_source_surface`,
+//! `fill`, `ImageSurface::create`, `Context::new`, …).
+//! Identify the failing op as a `&'static str` so the
+//! `Display` output points the reader at the call site:
+//!
+//! ```ignore
+//! cr.paint().map_err(|e| ViewerError::Cairo {
+//!     op: "background paint",
+//!     source: e,
+//! })?;
+//! ```
+
+use std::path::PathBuf;
+
+/// Errors returned by the APT and LRPT image viewers' renderer
+/// and PNG-export paths. Constructed at the failing call site
+/// so the `Display` output identifies which step failed.
+#[derive(Debug, thiserror::Error)]
+pub enum ViewerError {
+    /// A Cairo drawing or surface operation failed. `op` names
+    /// the failing call (`"paint"`, `"save"`, `"restore"`,
+    /// `"set_source_surface"`, `"fill"`, `"export surface"`,
+    /// `"export context"`, etc.) so callers and the user-facing
+    /// toast can both show the failure site without parsing
+    /// stringly-typed messages.
+    #[error("Cairo {op} failed: {source}")]
+    Cairo {
+        /// Identifier of the failing Cairo operation.
+        op: &'static str,
+        /// Underlying Cairo error.
+        #[source]
+        source: cairo::Error,
+    },
+
+    /// PNG encoder failure — Cairo's [`cairo::IoError`] from
+    /// `surface.write_to_png(...)`. Distinct from
+    /// [`Self::Io`] because Cairo's PNG IO has its own error
+    /// type that wraps both Cairo state errors and `std::io`
+    /// errors internally.
+    #[error("PNG encoder failed: {0}")]
+    PngEncode(#[from] cairo::IoError),
+
+    /// Filesystem operation failed — `std::fs::File::create`
+    /// or `std::fs::create_dir_all`. `op` identifies which.
+    /// Includes the failing path so the user-facing toast can
+    /// show what the export was targeting.
+    #[error("filesystem {op} failed for {path:?}: {source}")]
+    Io {
+        /// Identifier of the failing filesystem operation
+        /// (`"create_dir_all"`, `"file create"`, ...).
+        op: &'static str,
+        /// Path the failing operation was acting on.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Cairo refused to lend the surface's backing data
+    /// (`ImageSurface::data()` returned `BorrowError`). Rare
+    /// in practice — usually means another borrow is live;
+    /// reported separately so the failure mode is greppable.
+    #[error("Cairo surface-data lock failed: {0}")]
+    SurfaceDataLock(#[from] cairo::BorrowError),
+
+    /// Surface stride couldn't be converted to `usize`. Cairo
+    /// returns an `i32` stride; structurally it should always
+    /// be non-negative for ARGB32 surfaces but the conversion
+    /// is fallible so we surface the failure rather than
+    /// `as`-cast.
+    #[error("invalid surface stride: {0}")]
+    InvalidStride(#[from] std::num::TryFromIntError),
+
+    /// Caller-supplied pixel buffer doesn't match the declared
+    /// `width × height`. Carries a description rather than the
+    /// raw mismatched lengths because the formatting varies by
+    /// caller (greyscale tiles, ARGB32 surfaces, etc.).
+    #[error("invalid pixel buffer: {0}")]
+    InvalidBuffer(String),
+
+    /// Export requested but the renderer has no active channel
+    /// selected (e.g. the LRPT viewer dropdown hasn't picked
+    /// one yet). Distinct from [`Self::EmptyChannel`] —
+    /// nothing to even point at.
+    #[error("no active channel selected for export")]
+    NoActiveChannel,
+
+    /// Active channel exists but has no decoded scan lines
+    /// yet. `apid` is `Some` for LRPT (per-APID error message),
+    /// `None` for APT (single-image protocol). The custom
+    /// `Display` formatting elides the parenthetical when
+    /// `apid` is `None`.
+    #[error(
+        "active channel has no data to export{}",
+        apid.map(|a| format!(" (APID {a})")).unwrap_or_default()
+    )]
+    EmptyChannel {
+        /// CCSDS APID (the per-channel identifier) for LRPT
+        /// exports; `None` for APT (single-image protocol with
+        /// no APID concept).
+        apid: Option<u16>,
+    },
+
+    /// Export dimension exceeds Cairo's `i32` API limit.
+    /// `dim` identifies which axis (`"width"`, `"height"`,
+    /// `"width × height"` for the multiply-overflow case).
+    #[error("export dimension {dim} = {value} exceeds i32::MAX")]
+    DimensionTooLarge {
+        /// Axis identifier.
+        dim: &'static str,
+        /// The over-large value.
+        value: usize,
+    },
+
+    /// Caller passed a zero-sized export (width or height = 0).
+    /// Reported separately because Cairo's zero-size error is
+    /// distinct from a generic `InvalidBuffer` mismatch and is
+    /// easy to match on for the "nothing to export yet" UX.
+    #[error("export size is zero (width × height = 0)")]
+    ZeroSized,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_channel_with_apid_renders_apid_in_message() {
+        let err = ViewerError::EmptyChannel { apid: Some(64) };
+        let msg = format!("{err}");
+        assert!(msg.contains("APID 64"), "got {msg}");
+        assert!(msg.contains("no data to export"), "got {msg}");
+    }
+
+    #[test]
+    fn empty_channel_without_apid_skips_parenthetical() {
+        let err = ViewerError::EmptyChannel { apid: None };
+        let msg = format!("{err}");
+        assert!(!msg.contains("APID"), "got {msg}");
+        assert!(msg.contains("no data to export"), "got {msg}");
+    }
+
+    #[test]
+    fn cairo_error_display_includes_op_identifier() {
+        // We can't easily synthesise a real `cairo::Error` in a
+        // unit test (the variants are open-ended), but we can
+        // pin the message format by checking that the `op` field
+        // surfaces as part of any future `Display` output. This
+        // test serves as a contract-pin via the `Debug` impl,
+        // which is good enough for the format-stability
+        // assertion.
+        let dbg = format!("{:?}", ViewerError::Cairo {
+            op: "test paint",
+            source: cairo::Error::NoMemory,
+        });
+        assert!(dbg.contains("test paint"));
+    }
+
+    #[test]
+    fn no_active_channel_message_is_stable() {
+        let err = ViewerError::NoActiveChannel;
+        assert_eq!(format!("{err}"), "no active channel selected for export");
+    }
+
+    #[test]
+    fn dimension_too_large_includes_axis_and_value() {
+        let err = ViewerError::DimensionTooLarge {
+            dim: "width",
+            value: 3_000_000_000,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("width"));
+        assert!(msg.contains("3000000000"));
+    }
+}

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -6512,6 +6512,38 @@ fn connect_source_panel(
             state_dc_block.send_dsp(UiToDsp::SetDcBlocking(row.is_active()));
         });
 
+    // Bias-T toggle (#537). Powers an inline LNA over the
+    // RTL-SDR's coax. The startup restore must run BEFORE
+    // wiring the change-notify handler — same idiom as the
+    // satellites-panel auto-record toggle: a programmatic
+    // `set_active` fires `connect_active_notify`, which would
+    // otherwise re-save the just-loaded value (cheap) AND
+    // dispatch a redundant `SetBiasTee` (also cheap, but
+    // misleading in tracing logs).
+    {
+        let persisted = sidebar::source_panel::load_source_rtl_bias_tee(config);
+        panels.source.bias_tee_row.set_active(persisted);
+        // Dispatch the persisted value once at startup so the
+        // dongle's GPIO matches the UI from the first source
+        // open, not just after the user toggles. The
+        // controller's source slot may be `None` here (no
+        // source open yet); the SetBiasTee handler is a no-op
+        // in that case, and the value re-applies via the
+        // `set_active`-triggered notify the next time around.
+        // Cheap to send either way.
+        state.send_dsp(UiToDsp::SetBiasTee(persisted));
+    }
+    let state_bias_tee = Rc::clone(state);
+    let config_bias_tee = std::sync::Arc::clone(config);
+    panels
+        .source
+        .bias_tee_row
+        .connect_active_notify(move |row| {
+            let enabled = row.is_active();
+            sidebar::source_panel::save_source_rtl_bias_tee(&config_bias_tee, enabled);
+            state_bias_tee.send_dsp(UiToDsp::SetBiasTee(enabled));
+        });
+
     // IQ inversion toggle
     let state_iq_inv = Rc::clone(state);
     panels

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -6526,11 +6526,11 @@ fn connect_source_panel(
         // Dispatch the persisted value once at startup so the
         // dongle's GPIO matches the UI from the first source
         // open, not just after the user toggles. The
-        // controller's source slot may be `None` here (no
-        // source open yet); the SetBiasTee handler is a no-op
-        // in that case, and the value re-applies via the
-        // `set_active`-triggered notify the next time around.
-        // Cheap to send either way.
+        // `SetBiasTee` handler stores the value in `DspState`
+        // up-front, and `open_source` re-applies it to the
+        // freshly-opened RTL-SDR source — so this dispatch
+        // works regardless of whether a source is open at
+        // startup. Per CR on PR #550.
         state.send_dsp(UiToDsp::SetBiasTee(persisted));
     }
     let state_bias_tee = Rc::clone(state);


### PR DESCRIPTION
## Summary

Two follow-ups bundled into one PR (multiple commits, scoped per issue):

- **#545** — Replace `Result<_, String>` returns in `apt_viewer` and `lrpt_viewer` with a shared `ViewerError` enum (`thiserror`). Brings the live-image viewers in line with the project guideline that library crates use typed errors. Variants cover Cairo failures (with `op` identifier), PNG encode, filesystem ops (with path), surface-data lock, stride conversion, invalid buffer, no-active-channel, empty-channel (with optional APID for LRPT), oversized export dims, and zero-sized export.
- **#537** — Bias-T (5V on antenna) toggle in the local RTL-SDR source panel. `AdwSwitchRow` under "DC blocking", visibility-gated to RTL-SDR (hidden for rtl_tcp / Network / File), persisted across restarts, dispatched via `UiToDsp::SetBiasTee` to the controller and through `Source::set_bias_tee` to the dongle.

## Commits

1. `sdr-ui: typed ViewerError for APT + LRPT viewers (closes #545)`
2. `sdr-source-rtlsdr,sdr-ui: bias-T toggle in local source panel (closes #537)`
3. `sdr-ui: rustfmt fixups on viewer + lrpt_viewer`

## Test plan

- [x] `cargo build --workspace --features sdr-ui/whisper-cpu`
- [x] `cargo clippy --workspace --features sdr-ui/whisper-cpu --all-targets -- -D warnings`
- [x] `cargo test --workspace --features sdr-ui/whisper-cpu` (3 new bias-T persistence tests + 5 new ViewerError display tests pass)
- [x] `cargo check --workspace --no-default-features --features sdr-ui/sherpa-cpu`
- [x] `cargo fmt --all -- --check`
- [x] Smoke test: APT and LRPT Export PNG still work; bias-T row appears for RTL-SDR only, hides for rtl_tcp/Network/File, persists across restart, dispatches without errors when toggled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Bias‑T (inline LNA) toggle for RTL‑SDR sources with persistent setting, restored on startup, and applied to hardware when enabled/changed.

* **Bug Fixes**
  * Bias‑T state is now reliably retained and applied even if no source was active when the setting was changed.

* **Refactor / Improvements**
  * Live image viewers and PNG export now surface clearer, structured error messages and stronger validation for more reliable exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->