### PR TITLE
sdr-ui: auto-record audio-chain safety net (closes #555, #556)

### DIFF
--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -27,6 +27,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use sdr_sat::Pass;
+use sdr_radio::af_chain::CtcssMode;
 use sdr_types::DemodMode;
 
 use crate::sidebar::satellites_panel::tune_target_for_pass;
@@ -170,6 +171,35 @@ pub enum State {
 /// here, an active pre-AOS scan session would be left off
 /// after the pass ends. Mirrors `was_running`'s "return the
 /// user to whatever they had configured" intent.
+///
+/// The audio-chain snapshot fields (`squelch_enabled`,
+/// `squelch_db`, `ctcss_mode`, `fm_if_nr_enabled`) capture
+/// the user's pre-AOS state for IF/AF settings that must be
+/// **force-disabled during a satellite pass** because they're
+/// destructive to data-bearing FM modulation:
+///
+/// - **Squelch / CTCSS** (#555): gate audio when SNR / tone
+///   thresholds aren't met. APT image quality depends on
+///   getting EVERY scan line; gating low-SNR rows to silence
+///   produces black-streaked or fully-black PNGs.
+/// - **FM IF NR** (#556): frequency-domain peak-bin filter
+///   that zeros all FFT bins except the dominant one. Kills
+///   the FM sidebands where the APT 2.4 kHz subcarrier and
+///   ISS SSTV tone modulation live.
+///
+/// Wiring layer flips the corresponding widgets to disabled
+/// at AOS (firing the existing change-notify dispatch chain)
+/// and back to the saved values at LOS. User-visible — same
+/// pattern as `scanner_running`.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "snapshot of tune + audio-chain state for the auto-record AOS→LOS \
+              round trip — the bool fields each correspond to a distinct user \
+              widget that has to be restored after the pass; collapsing them \
+              into a sub-struct (e.g. `SavedAudioChain`) would obscure the \
+              one-field-per-restored-widget mapping that makes the wiring \
+              layer's restore loop trivially auditable"
+)]
 #[derive(Debug, Clone, Copy)]
 pub struct SavedTune {
     pub freq_hz: f64,
@@ -178,6 +208,21 @@ pub struct SavedTune {
     pub bandwidth_hz: u32,
     pub was_running: bool,
     pub scanner_running: bool,
+    /// Pre-AOS squelch master-switch state. Forced OFF at AOS,
+    /// restored at LOS. Per #555.
+    pub squelch_enabled: bool,
+    /// Pre-AOS squelch threshold (dBFS). Restored verbatim at
+    /// LOS — leaving it untouched during the pass would be
+    /// fine on its own (squelch is disabled), but persisting
+    /// the user's preferred level avoids a silent reset on a
+    /// "force-disable + force-defaults" approach.
+    pub squelch_db: f32,
+    /// Pre-AOS CTCSS mode (Off / Tone(hz)). Forced to Off at
+    /// AOS, restored at LOS. Per #555.
+    pub ctcss_mode: CtcssMode,
+    /// Pre-AOS FM IF NR toggle. Forced OFF at AOS, restored at
+    /// LOS. Per #556.
+    pub fm_if_nr_enabled: bool,
 }
 
 /// Side effects the wiring layer must perform on each transition.
@@ -750,6 +795,10 @@ mod tests {
             bandwidth_hz: 200_000,
             was_running: true,
             scanner_running: false,
+            squelch_enabled: false,
+            squelch_db: -50.0,
+            ctcss_mode: CtcssMode::Off,
+            fm_if_nr_enabled: false,
         }
     }
 
@@ -977,6 +1026,11 @@ mod tests {
             bandwidth_hz: 200_000,
             was_running: false,
             scanner_running: true, // pin: pre-AOS scan must come back at LOS
+            // pin: pre-AOS audio-chain settings must come back at LOS
+            squelch_enabled: true,
+            squelch_db: -42.5,
+            ctcss_mode: CtcssMode::Tone(100.0),
+            fm_if_nr_enabled: true,
         };
         // Walk all transitions.
         r.tick(now, std::slice::from_ref(&pass), true, false, saved);
@@ -1015,6 +1069,13 @@ mod tests {
                 assert_eq!(t.bandwidth_hz, 200_000);
                 assert!(!t.was_running);
                 assert!(t.scanner_running);
+                // Audio-chain pre-AOS state survives round-trip
+                // (#555 / #556): squelch enable + level, CTCSS
+                // mode, and FM IF NR all come back.
+                assert!(t.squelch_enabled);
+                assert!((t.squelch_db - (-42.5)).abs() < f32::EPSILON);
+                assert!(matches!(t.ctcss_mode, CtcssMode::Tone(hz) if (hz - 100.0).abs() < f32::EPSILON));
+                assert!(t.fm_if_nr_enabled);
             }
             other => panic!("expected RestoreTune, got {other:?}"),
         }

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -26,8 +26,8 @@
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
-use sdr_sat::Pass;
 use sdr_radio::af_chain::CtcssMode;
+use sdr_sat::Pass;
 use sdr_types::DemodMode;
 
 use crate::sidebar::satellites_panel::tune_target_for_pass;
@@ -1016,20 +1016,32 @@ mod tests {
 
     #[test]
     fn finalizing_advances_to_idle_with_restore_action() {
+        // Scoped typed constants for the round-trip pins. Each
+        // value is intentionally distinct from the recorder's
+        // defaults / the `default_tune` fixture so a regression
+        // that resets a field would fail loudly. Declared before
+        // any statements per clippy's `items_after_statements`.
+        // Per CR round 1 on PR #557.
+        const SAVED_FREQ_HZ: f64 = 89_700_000.0;
+        const SAVED_VFO_OFFSET_HZ: f64 = 25_000.0;
+        const SAVED_BANDWIDTH_HZ: u32 = 200_000;
+        const SAVED_SQUELCH_DB: f32 = -42.5;
+        const SAVED_CTCSS_TONE_HZ: f32 = 100.0;
+
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 60, 50.0);
         let saved = SavedTune {
-            freq_hz: 89_700_000.0,
-            vfo_offset_hz: 25_000.0, // pin a non-zero offset for the round trip
+            freq_hz: SAVED_FREQ_HZ,
+            vfo_offset_hz: SAVED_VFO_OFFSET_HZ, // pin a non-zero offset for the round trip
             mode: DemodMode::Wfm,
-            bandwidth_hz: 200_000,
+            bandwidth_hz: SAVED_BANDWIDTH_HZ,
             was_running: false,
             scanner_running: true, // pin: pre-AOS scan must come back at LOS
             // pin: pre-AOS audio-chain settings must come back at LOS
             squelch_enabled: true,
-            squelch_db: -42.5,
-            ctcss_mode: CtcssMode::Tone(100.0),
+            squelch_db: SAVED_SQUELCH_DB,
+            ctcss_mode: CtcssMode::Tone(SAVED_CTCSS_TONE_HZ),
             fm_if_nr_enabled: true,
         };
         // Walk all transitions.
@@ -1063,18 +1075,20 @@ mod tests {
         // dropped permanently).
         match &actions[0] {
             Action::RestoreTune(t) => {
-                assert_eq!(t.freq_hz, 89_700_000.0);
-                assert_eq!(t.vfo_offset_hz, 25_000.0);
+                assert_eq!(t.freq_hz, SAVED_FREQ_HZ);
+                assert_eq!(t.vfo_offset_hz, SAVED_VFO_OFFSET_HZ);
                 assert_eq!(t.mode, DemodMode::Wfm);
-                assert_eq!(t.bandwidth_hz, 200_000);
+                assert_eq!(t.bandwidth_hz, SAVED_BANDWIDTH_HZ);
                 assert!(!t.was_running);
                 assert!(t.scanner_running);
                 // Audio-chain pre-AOS state survives round-trip
                 // (#555 / #556): squelch enable + level, CTCSS
                 // mode, and FM IF NR all come back.
                 assert!(t.squelch_enabled);
-                assert!((t.squelch_db - (-42.5)).abs() < f32::EPSILON);
-                assert!(matches!(t.ctcss_mode, CtcssMode::Tone(hz) if (hz - 100.0).abs() < f32::EPSILON));
+                assert!((t.squelch_db - SAVED_SQUELCH_DB).abs() < f32::EPSILON);
+                assert!(
+                    matches!(t.ctcss_mode, CtcssMode::Tone(hz) if (hz - SAVED_CTCSS_TONE_HZ).abs() < f32::EPSILON)
+                );
                 assert!(t.fm_if_nr_enabled);
             }
             other => panic!("expected RestoreTune, got {other:?}"),

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -173,7 +173,8 @@ pub enum State {
 /// user to whatever they had configured" intent.
 ///
 /// The audio-chain snapshot fields (`squelch_enabled`,
-/// `squelch_db`, `ctcss_mode`, `fm_if_nr_enabled`) capture
+/// `auto_squelch_enabled`, `squelch_db`, `ctcss_mode`,
+/// `fm_if_nr_enabled`) capture
 /// the user's pre-AOS state for IF/AF settings that must be
 /// **force-disabled during a satellite pass** because they're
 /// destructive to data-bearing FM modulation:
@@ -1031,7 +1032,10 @@ mod tests {
         // Per CR round 1 on PR #557.
         const SAVED_FREQ_HZ: f64 = 89_700_000.0;
         const SAVED_VFO_OFFSET_HZ: f64 = 25_000.0;
-        const SAVED_BANDWIDTH_HZ: u32 = 200_000;
+        // Distinct from `default_tune()`'s 200_000 so a
+        // regression that resets bandwidth to the fixture
+        // default fails loudly. Per CR round 3 on PR #557.
+        const SAVED_BANDWIDTH_HZ: u32 = 180_000;
         const SAVED_SQUELCH_DB: f32 = -42.5;
         const SAVED_CTCSS_TONE_HZ: f32 = 100.0;
 

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -211,6 +211,12 @@ pub struct SavedTune {
     /// Pre-AOS squelch master-switch state. Forced OFF at AOS,
     /// restored at LOS. Per #555.
     pub squelch_enabled: bool,
+    /// Pre-AOS auto-squelch toggle. Auto-squelch tracks the
+    /// noise floor and gates audio dynamically — same audio-
+    /// gating bug class as manual squelch, just adaptive.
+    /// Forced OFF at AOS, restored at LOS. Per CR round 2 on
+    /// PR #557.
+    pub auto_squelch_enabled: bool,
     /// Pre-AOS squelch threshold (dBFS). Restored verbatim at
     /// LOS — leaving it untouched during the pass would be
     /// fine on its own (squelch is disabled), but persisting
@@ -796,6 +802,7 @@ mod tests {
             was_running: true,
             scanner_running: false,
             squelch_enabled: false,
+            auto_squelch_enabled: false,
             squelch_db: -50.0,
             ctcss_mode: CtcssMode::Off,
             fm_if_nr_enabled: false,
@@ -1040,6 +1047,7 @@ mod tests {
             scanner_running: true, // pin: pre-AOS scan must come back at LOS
             // pin: pre-AOS audio-chain settings must come back at LOS
             squelch_enabled: true,
+            auto_squelch_enabled: true,
             squelch_db: SAVED_SQUELCH_DB,
             ctcss_mode: CtcssMode::Tone(SAVED_CTCSS_TONE_HZ),
             fm_if_nr_enabled: true,
@@ -1082,9 +1090,10 @@ mod tests {
                 assert!(!t.was_running);
                 assert!(t.scanner_running);
                 // Audio-chain pre-AOS state survives round-trip
-                // (#555 / #556): squelch enable + level, CTCSS
-                // mode, and FM IF NR all come back.
+                // (#555 / #556): squelch enable + auto-squelch +
+                // level, CTCSS mode, and FM IF NR all come back.
                 assert!(t.squelch_enabled);
+                assert!(t.auto_squelch_enabled);
                 assert!((t.squelch_db - SAVED_SQUELCH_DB).abs() < f32::EPSILON);
                 assert!(
                     matches!(t.ctcss_mode, CtcssMode::Tone(hz) if (hz - SAVED_CTCSS_TONE_HZ).abs() < f32::EPSILON)

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -13,6 +13,7 @@ use libadwaita::prelude::*;
 use sdr_core::Engine;
 use sdr_pipeline::iq_frontend::FftWindow;
 use sdr_radio::DeemphasisMode;
+use sdr_radio::af_chain::CtcssMode;
 use sdr_rtltcp_discovery::{
     AdvertiseOptions, Advertiser, Browser, DiscoveredServer, DiscoveryEvent, TxtRecord,
     local_hostname,
@@ -9290,8 +9291,11 @@ fn connect_satellites_panel(
                     if squelch_enabled_row_a.is_active() {
                         squelch_enabled_row_a.set_active(false);
                     }
-                    if ctcss_row_a.selected() != 0 {
-                        ctcss_row_a.set_selected(0);
+                    let off_idx = sidebar::radio_panel::RadioPanel::ctcss_index_from_mode(
+                        CtcssMode::Off,
+                    );
+                    if ctcss_row_a.selected() != off_idx {
+                        ctcss_row_a.set_selected(off_idx);
                     }
                     if fm_if_nr_row_a.is_active() {
                         fm_if_nr_row_a.set_active(false);
@@ -9299,6 +9303,18 @@ fn connect_satellites_panel(
                 };
                 match protocol {
                     sdr_sat::ImagingProtocol::Apt => {
+                        // **Order is load-bearing.** Force the
+                        // audio chain off BEFORE start/tune so
+                        // the very first samples through the
+                        // freshly-tuned demod aren't gated by a
+                        // stale squelch / CTCSS / FM-IF-NR
+                        // setting. Otherwise low-SNR AOS rows
+                        // race against the change-notify chain
+                        // dispatching the SetX messages and the
+                        // first few scan lines could be silenced
+                        // before the demod even sees them. Per
+                        // CR round 1 on PR #557.
+                        force_audio_chain_off();
                         // Drive Start through the header play
                         // button — its `connect_toggled` handler
                         // is the single place that updates
@@ -9314,7 +9330,6 @@ fn connect_satellites_panel(
                         // the corresponding LOS-side stop.
                         set_playing_a(true);
                         tune_a(freq_hz, mode, bandwidth_hz);
-                        force_audio_chain_off();
                         // Zero the live VFO offset for the
                         // auto-record pass. The user's pre-AOS
                         // offset (a manual VFO drag away from
@@ -9376,13 +9391,19 @@ fn connect_satellites_panel(
                         if let Some(view) = state_a.lrpt_viewer.borrow().as_ref() {
                             view.clear();
                         }
+                        // Force audio chain off BEFORE start/tune
+                        // so the freshly-tuned demod isn't gated
+                        // by a stale squelch / CTCSS / FM-IF-NR
+                        // setting. Per CR round 1 on PR #557 —
+                        // see APT arm above for the full
+                        // rationale.
+                        force_audio_chain_off();
                         // Now safe to start playback + retune;
                         // any decoded rows from this point
                         // forward land in the cleared image.
                         set_playing_a(true);
                         tune_a(freq_hz, mode, bandwidth_hz);
                         state_a.dispatch_vfo_offset(0.0);
-                        force_audio_chain_off();
                     }
                 }
             }
@@ -9669,27 +9690,20 @@ fn connect_satellites_panel(
                     tracing::info!("auto-record: stopping source (was stopped pre-AOS)");
                     set_playing_a(false);
                 }
-                // Re-arm the scanner if it was running pre-AOS.
-                // The AOS-side `tune_a` call goes through
-                // `tune_to_satellite`, which fires
-                // `ScannerForceDisable::trigger("satellite tune")`
-                // as a manual-tune side effect — without this
-                // restore, an active pre-AOS scan would be left
-                // permanently off after the pass. Same idiom as
-                // `was_running`: snapshot the user's pre-AOS
-                // state, return them to it. `set_active(true)`
-                // fires the switch's notify handler, which
-                // dispatches `SetScannerEnabled(true)` to the
-                // engine — same path a manual flip takes.
-                if saved.scanner_running && !scanner_switch_a.is_active() {
-                    tracing::info!("auto-record: re-arming scanner (was running pre-AOS)");
-                    scanner_switch_a.set_active(true);
-                }
-                // Restore the pre-AOS audio-chain settings via the
-                // same `set_*`-fires-notify pattern. Per #555 / #556.
-                // Squelch level is restored unconditionally
-                // (cheap, idempotent on equal value); the toggles
-                // are guarded against no-op writes for cleaner
+                // **Order is load-bearing.** Restore the audio-
+                // chain settings BEFORE re-arming the scanner.
+                // A scanner that wakes back up while the audio
+                // chain is still in its forced-off pass state
+                // would briefly run with wrong squelch / CTCSS /
+                // FM-IF-NR — wasting the first dwell or two on
+                // un-gated noise. Per CR round 1 on PR #557.
+                //
+                // Same `set_*`-fires-notify pattern the rest of
+                // this handler uses (and that the AOS-side
+                // `force_audio_chain_off` mirrors). Squelch
+                // level is restored unconditionally (cheap,
+                // idempotent on equal value); the toggles are
+                // guarded against no-op writes for cleaner
                 // tracing logs.
                 #[allow(
                     clippy::cast_possible_truncation,
@@ -9709,6 +9723,22 @@ fn connect_satellites_panel(
                 }
                 if saved.fm_if_nr_enabled != fm_if_nr_row_a.is_active() {
                     fm_if_nr_row_a.set_active(saved.fm_if_nr_enabled);
+                }
+                // Re-arm the scanner if it was running pre-AOS.
+                // The AOS-side `tune_a` call goes through
+                // `tune_to_satellite`, which fires
+                // `ScannerForceDisable::trigger("satellite tune")`
+                // as a manual-tune side effect — without this
+                // restore, an active pre-AOS scan would be left
+                // permanently off after the pass. Same idiom as
+                // `was_running`: snapshot the user's pre-AOS
+                // state, return them to it. `set_active(true)`
+                // fires the switch's notify handler, which
+                // dispatches `SetScannerEnabled(true)` to the
+                // engine — same path a manual flip takes.
+                if saved.scanner_running && !scanner_switch_a.is_active() {
+                    tracing::info!("auto-record: re-arming scanner (was running pre-AOS)");
+                    scanner_switch_a.set_active(true);
                 }
             }
             RecorderAction::Toast { message, kind } => {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9234,6 +9234,13 @@ fn connect_satellites_panel(
         // re-arms the engine — same path the user takes when they
         // flip the switch by hand.
         let scanner_switch_a = panels.scanner.master_switch.clone();
+        // Audio-chain widgets — force-disabled at AOS, restored at
+        // LOS via the same `set_*` notify chain that any user flip
+        // takes. Per #555 (squelch + CTCSS) and #556 (FM IF NR).
+        let squelch_enabled_row_a = panels.radio.squelch_enabled_row.clone();
+        let squelch_level_row_a = panels.radio.squelch_level_row.clone();
+        let ctcss_row_a = panels.radio.ctcss_row.clone();
+        let fm_if_nr_row_a = panels.radio.fm_if_nr_row.clone();
         let post_toast = move |overlay_weak: &glib::WeakRef<adw::ToastOverlay>, msg: &str| {
             if let Some(overlay) = overlay_weak.upgrade() {
                 overlay.add_toast(adw::Toast::new(msg));
@@ -9264,6 +9271,32 @@ fn connect_satellites_panel(
                 // the LRPT viewer, the user's tune state must
                 // NOT be hijacked just to land in a no-op
                 // branch.
+                // Audio-chain force-off helper. Flips the three
+                // user-visible widgets to disabled; each one's
+                // `connect_*_notify` handler then dispatches the
+                // corresponding `UiToDsp::Set*` message — same
+                // path a manual flip takes. Per #555 (squelch +
+                // CTCSS) / #556 (FM IF NR). Idempotent: a
+                // `set_active(false)` on an already-false switch
+                // is a no-op (no notify fired, no redundant
+                // dispatch).
+                //
+                // Called inside each protocol arm rather than
+                // before the match so an unsupported protocol
+                // doesn't hijack the user's audio chain (mirrors
+                // the AOS side-effect-isolation rule from CR
+                // round 1 on PR #541).
+                let force_audio_chain_off = || {
+                    if squelch_enabled_row_a.is_active() {
+                        squelch_enabled_row_a.set_active(false);
+                    }
+                    if ctcss_row_a.selected() != 0 {
+                        ctcss_row_a.set_selected(0);
+                    }
+                    if fm_if_nr_row_a.is_active() {
+                        fm_if_nr_row_a.set_active(false);
+                    }
+                };
                 match protocol {
                     sdr_sat::ImagingProtocol::Apt => {
                         // Drive Start through the header play
@@ -9281,6 +9314,7 @@ fn connect_satellites_panel(
                         // the corresponding LOS-side stop.
                         set_playing_a(true);
                         tune_a(freq_hz, mode, bandwidth_hz);
+                        force_audio_chain_off();
                         // Zero the live VFO offset for the
                         // auto-record pass. The user's pre-AOS
                         // offset (a manual VFO drag away from
@@ -9348,6 +9382,7 @@ fn connect_satellites_panel(
                         set_playing_a(true);
                         tune_a(freq_hz, mode, bandwidth_hz);
                         state_a.dispatch_vfo_offset(0.0);
+                        force_audio_chain_off();
                     }
                 }
             }
@@ -9650,6 +9685,31 @@ fn connect_satellites_panel(
                     tracing::info!("auto-record: re-arming scanner (was running pre-AOS)");
                     scanner_switch_a.set_active(true);
                 }
+                // Restore the pre-AOS audio-chain settings via the
+                // same `set_*`-fires-notify pattern. Per #555 / #556.
+                // Squelch level is restored unconditionally
+                // (cheap, idempotent on equal value); the toggles
+                // are guarded against no-op writes for cleaner
+                // tracing logs.
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "saved.squelch_db came from the same SpinRow we're \
+                              feeding back into; round-trip preserves precision \
+                              well within the row's range"
+                )]
+                let squelch_db_f64 = f64::from(saved.squelch_db);
+                squelch_level_row_a.set_value(squelch_db_f64);
+                if saved.squelch_enabled != squelch_enabled_row_a.is_active() {
+                    squelch_enabled_row_a.set_active(saved.squelch_enabled);
+                }
+                let saved_ctcss_idx =
+                    sidebar::radio_panel::RadioPanel::ctcss_index_from_mode(saved.ctcss_mode);
+                if ctcss_row_a.selected() != saved_ctcss_idx {
+                    ctcss_row_a.set_selected(saved_ctcss_idx);
+                }
+                if saved.fm_if_nr_enabled != fm_if_nr_row_a.is_active() {
+                    fm_if_nr_row_a.set_active(saved.fm_if_nr_enabled);
+                }
             }
             RecorderAction::Toast { message, kind } => {
                 if matches!(kind, ToastKind::Warn) {
@@ -9680,6 +9740,15 @@ fn connect_satellites_panel(
         // when the panel is dropped the tick's `panel_weak.upgrade`
         // returns None and we Break, dropping the chain.
         let scanner_switch_tick = panels.scanner.master_switch.clone();
+        // Audio-chain widgets snapshotted into SavedTune so the
+        // pre-AOS state can be restored at LOS. AOS force-disables
+        // these because they're destructive to data-bearing FM
+        // signals (squelch / CTCSS gate audio; FM IF NR zeros the
+        // sidebands the APT subcarrier lives in). Per #555 / #556.
+        let squelch_enabled_row_tick = panels.radio.squelch_enabled_row.clone();
+        let squelch_level_row_tick = panels.radio.squelch_level_row.clone();
+        let ctcss_row_tick = panels.radio.ctcss_row.clone();
+        let fm_if_nr_row_tick = panels.radio.fm_if_nr_row.clone();
         let _ = glib::timeout_add_local(SATELLITES_COUNTDOWN_TICK, move || {
             let Some(panel) = panel_weak_tick.upgrade() else {
                 return glib::ControlFlow::Break;
@@ -9723,6 +9792,12 @@ fn connect_satellites_panel(
                           width; the SpinRow's own min is positive"
             )]
             let bandwidth_hz_u32 = bandwidth_row_tick.value().round() as u32;
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "squelch SpinRow value is in dBFS, bounded by the row's \
+                          configured min/max (well within f32 range)"
+            )]
+            let squelch_db_f32 = squelch_level_row_tick.value() as f32;
             let now_tune = SavedTune {
                 freq_hz: state_tick.center_frequency.get(),
                 vfo_offset_hz: spectrum_tick.vfo_offset_hz(),
@@ -9730,6 +9805,12 @@ fn connect_satellites_panel(
                 bandwidth_hz: bandwidth_hz_u32,
                 was_running: state_tick.is_running.get(),
                 scanner_running: scanner_switch_tick.is_active(),
+                squelch_enabled: squelch_enabled_row_tick.is_active(),
+                squelch_db: squelch_db_f32,
+                ctcss_mode: sidebar::radio_panel::RadioPanel::ctcss_mode_from_index(
+                    ctcss_row_tick.selected(),
+                ),
+                fm_if_nr_enabled: fm_if_nr_row_tick.is_active(),
             };
             let actions = recorder_tick.borrow_mut().tick(
                 now,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9291,9 +9291,8 @@ fn connect_satellites_panel(
                     if squelch_enabled_row_a.is_active() {
                         squelch_enabled_row_a.set_active(false);
                     }
-                    let off_idx = sidebar::radio_panel::RadioPanel::ctcss_index_from_mode(
-                        CtcssMode::Off,
-                    );
+                    let off_idx =
+                        sidebar::radio_panel::RadioPanel::ctcss_index_from_mode(CtcssMode::Off);
                     if ctcss_row_a.selected() != off_idx {
                         ctcss_row_a.set_selected(off_idx);
                     }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9239,6 +9239,7 @@ fn connect_satellites_panel(
         // LOS via the same `set_*` notify chain that any user flip
         // takes. Per #555 (squelch + CTCSS) and #556 (FM IF NR).
         let squelch_enabled_row_a = panels.radio.squelch_enabled_row.clone();
+        let auto_squelch_row_a = panels.radio.auto_squelch_row.clone();
         let squelch_level_row_a = panels.radio.squelch_level_row.clone();
         let ctcss_row_a = panels.radio.ctcss_row.clone();
         let fm_if_nr_row_a = panels.radio.fm_if_nr_row.clone();
@@ -9290,6 +9291,9 @@ fn connect_satellites_panel(
                 let force_audio_chain_off = || {
                     if squelch_enabled_row_a.is_active() {
                         squelch_enabled_row_a.set_active(false);
+                    }
+                    if auto_squelch_row_a.is_active() {
+                        auto_squelch_row_a.set_active(false);
                     }
                     let off_idx =
                         sidebar::radio_panel::RadioPanel::ctcss_index_from_mode(CtcssMode::Off);
@@ -9715,6 +9719,9 @@ fn connect_satellites_panel(
                 if saved.squelch_enabled != squelch_enabled_row_a.is_active() {
                     squelch_enabled_row_a.set_active(saved.squelch_enabled);
                 }
+                if saved.auto_squelch_enabled != auto_squelch_row_a.is_active() {
+                    auto_squelch_row_a.set_active(saved.auto_squelch_enabled);
+                }
                 let saved_ctcss_idx =
                     sidebar::radio_panel::RadioPanel::ctcss_index_from_mode(saved.ctcss_mode);
                 if ctcss_row_a.selected() != saved_ctcss_idx {
@@ -9775,6 +9782,7 @@ fn connect_satellites_panel(
         // signals (squelch / CTCSS gate audio; FM IF NR zeros the
         // sidebands the APT subcarrier lives in). Per #555 / #556.
         let squelch_enabled_row_tick = panels.radio.squelch_enabled_row.clone();
+        let auto_squelch_row_tick = panels.radio.auto_squelch_row.clone();
         let squelch_level_row_tick = panels.radio.squelch_level_row.clone();
         let ctcss_row_tick = panels.radio.ctcss_row.clone();
         let fm_if_nr_row_tick = panels.radio.fm_if_nr_row.clone();
@@ -9835,6 +9843,7 @@ fn connect_satellites_panel(
                 was_running: state_tick.is_running.get(),
                 scanner_running: scanner_switch_tick.is_active(),
                 squelch_enabled: squelch_enabled_row_tick.is_active(),
+                auto_squelch_enabled: auto_squelch_row_tick.is_active(),
                 squelch_db: squelch_db_f32,
                 ctcss_mode: sidebar::radio_panel::RadioPanel::ctcss_mode_from_index(
                     ctcss_row_tick.selected(),


### PR DESCRIPTION
## Summary

Force-disable destructive IF/AF chain settings at AOS, restore pre-AOS values at LOS. Two issues, one PR — same bug class, same files, same `SavedTune` round-trip pattern.

**Settings now snapshot/force-off/restore:**
- **Squelch** (enable + level) — gates audio when below threshold; black-streaked APT
- **CTCSS** mode — gates audio when tone not detected; same problem
- **FM IF NR** — frequency-domain peak-bin filter that zeros FM sidebands; kills the APT 2.4 kHz subcarrier + ISS SSTV tone modulation

The squelch one was the bug we live-tested during PR #554's overnight run — Doppler tracked perfectly but the captured PNG was mostly black because squelch gated low-SNR scan lines to silence.

## Architecture

Pattern mirrors the existing `scanner_running` snapshot/restore (PR #513) and the `vfo_offset_hz` snapshot/restore that's already in `SavedTune`:

1. **1 Hz tick** captures four new widget values into `SavedTune`.
2. **AOS** (`StartAutoRecord`) flips the widgets to safe values via `force_audio_chain_off()`. Widget change-notify handlers dispatch the corresponding `UiToDsp::Set*` messages — same path a manual flip takes.
3. **LOS** (`RestoreTune`) restores via `set_active` / `set_selected` / `set_value` — same idiom.

`force_audio_chain_off` lives inside each protocol arm (APT / LRPT) rather than before the match, per CR round 1 on PR #541's rule that AOS side effects must not hijack tune state for unsupported protocols.

## Tests

- Existing `finalizing_advances_to_idle_with_restore_action` test extended to pin the round-trip for all four new fields.
- `default_tune` fixture extended with safe-default values so all other state-machine tests compile unchanged.

## Test plan

- [x] \`cargo build --workspace --features sdr-ui/whisper-cpu\`
- [x] \`cargo clippy --workspace --features sdr-ui/whisper-cpu --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --features sdr-ui/whisper-cpu\` (round-trip test passes)
- [x] \`cargo check --workspace --no-default-features --features sdr-ui/sherpa-cpu\`
- [x] \`cargo fmt --all -- --check\`
- [ ] Live smoke (deferred — will report after next NOAA pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Satellite pass recording now snapshots and restores audio-chain controls (squelch on/off and level, auto-squelch, CTCSS mode/tone, FM IF noise reduction) so audio settings round-trip across pass start/finish.
  * During acquisition, audio controls are temporarily forced to a safe off state and then reliably re-applied after the pass.

* **Tests**
  * Unit tests strengthened to validate precise round-trip preservation of all audio-chain settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->