### PR TITLE
feat: source-panel persistence + transcript channel markers (#552, #517)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1847,15 +1847,12 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
 
         UiToDsp::EnableTranscription(tx) => {
-            if state.scanner.is_enabled() {
-                let cmds = state
-                    .scanner
-                    .handle_event(sdr_scanner::ScannerEvent::SetEnabled(false));
-                apply_scanner_commands(state, dsp_tx, cmds);
-                let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
-                    ScannerMutexReason::ScannerStoppedForTranscription,
-                ));
-            }
+            // Scanner ↔ transcription mutex was REMOVED — the two
+            // are designed to coexist (issue #517 emits per-channel
+            // markers in the transcript log when the scanner hops).
+            // Recording ↔ transcription mutex still applies because
+            // a running WAV writer + concurrent transcription tap
+            // produced inconsistent audio flow in earlier rounds.
             // Recording ↔ transcription leg of the mutex. Both
             // `stop_any_recording` sends cover the UI (it emits
             // `AudioRecordingStopped` / `IqRecordingStopped`), so
@@ -1994,18 +1991,13 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
         }
         // --- Scanner (#317) ---
         UiToDsp::SetScannerEnabled(enabled) => {
-            if enabled {
-                if stop_any_recording(state, dsp_tx) {
-                    let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
-                        ScannerMutexReason::RecordingStoppedForScanner,
-                    ));
-                }
-                if stop_transcription(state) {
-                    let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
-                        ScannerMutexReason::TranscriptionStoppedForScanner,
-                    ));
-                }
+            if enabled && stop_any_recording(state, dsp_tx) {
+                let _ = dsp_tx.send(DspToUi::ScannerMutexStopped(
+                    ScannerMutexReason::RecordingStoppedForScanner,
+                ));
             }
+            // Scanner ↔ transcription mutex was REMOVED — the two
+            // are designed to coexist (issue #517).
             let cmds = state
                 .scanner
                 .handle_event(sdr_scanner::ScannerEvent::SetEnabled(enabled));

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -364,11 +364,26 @@ struct DspState {
     /// `CodeRabbit` round 1 on PR #349.
     audio_tap_phase: usize,
 
-    /// Last known squelch gate state, used to detect open/close edge
-    /// transitions so we only emit one `SquelchOpened` / `SquelchClosed`
-    /// event per transition instead of one per audio chunk. Initialized
-    /// to `false` (matches `IfChain`'s initial closed state).
+    /// Last known squelch gate state, used by the SCANNER edge detector
+    /// to emit one `ScannerEvent::SquelchEdge` per transition instead
+    /// of one per audio chunk. Initialized to `false` (matches
+    /// `IfChain`'s initial closed state). Reset on tune / mode /
+    /// bandwidth boundaries so a fresh open at the new channel always
+    /// emits an Open edge. Per `CodeRabbit` round 1 on PR #558 — the
+    /// scanner ↔ transcription mutex removal exposed that the same
+    /// field used to be reset by `EnableTranscription` /
+    /// `DisableTranscription`, which now perturbs the scanner's edge
+    /// detection. The transcription tap has its own
+    /// `transcription_squelch_was_open` tracker below.
     squelch_was_open: bool,
+
+    /// Last known squelch gate state, used by the TRANSCRIPTION audio
+    /// tap to decide when to emit `TranscriptionInput::SquelchOpened`
+    /// / `SquelchClosed` edge messages. Independent of
+    /// `squelch_was_open` so toggling the transcription tap (which
+    /// resets this tracker) doesn't fire a spurious scanner edge on
+    /// the next block. Per `CodeRabbit` round 1 on PR #558.
+    transcription_squelch_was_open: bool,
 
     /// Last observed CTCSS sustained-gate state, used to emit
     /// `DspToUi::CtcssSustainedChanged` only on edges so the UI
@@ -561,6 +576,7 @@ impl DspState {
             audio_tap_tx: None,
             audio_tap_phase: 0,
             squelch_was_open: false,
+            transcription_squelch_was_open: false,
             ctcss_was_sustained: false,
             voice_squelch_was_open: true,
             audio_frames_written: 0,
@@ -908,6 +924,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                     // from before the mode switch.
                     state.audio_tap_phase = 0;
                     state.squelch_was_open = false;
+                    state.transcription_squelch_was_open = false;
                     // Mode switch rebuilds the AF chain + CTCSS
                     // detector + voice squelch — edge trackers
                     // must match the new closed state.
@@ -1858,22 +1875,29 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             // `AudioRecordingStopped` / `IqRecordingStopped`), so
             // the recording buttons flip off automatically.
             stop_any_recording(state, dsp_tx);
-            // Reset the squelch edge tracker when a new tap is wired up.
-            // Without this, a previous session that ended with squelch open
-            // leaves `squelch_was_open == true`, so the first chunk of the
-            // new session sees `now_open == was_open` and no SquelchOpened
-            // edge is emitted — the offline Auto Break state machine would
-            // stay in Idle and drop the entire current transmission until
-            // the next open/close cycle.
-            state.squelch_was_open = false;
+            // Reset the TRANSCRIPTION-side squelch edge tracker when a
+            // new tap is wired up. Without this, a previous session
+            // that ended with squelch open leaves the tracker `true`,
+            // so the first chunk of the new session sees `now_open ==
+            // was_open` and no SquelchOpened edge is emitted — the
+            // offline Auto Break state machine would stay in Idle and
+            // drop the entire current transmission until the next
+            // open/close cycle. The SCANNER tracker
+            // (`squelch_was_open`) is intentionally NOT reset here:
+            // doing so used to fire a spurious `ScannerEvent::SquelchEdge`
+            // on the next block once the mutex was removed (the two
+            // are now designed to coexist). Per CodeRabbit round 1 on
+            // PR #558.
+            state.transcription_squelch_was_open = false;
             state.transcription_tx = Some(tx);
             tracing::info!("transcription audio tap enabled");
         }
         UiToDsp::DisableTranscription => {
             state.transcription_tx = None;
-            // Mirror the reset on disable so a subsequent EnableTranscription
-            // always starts from a known state.
-            state.squelch_was_open = false;
+            // Mirror the reset on disable so a subsequent
+            // EnableTranscription always starts from a known state.
+            // Scanner tracker is independent and stays intact.
+            state.transcription_squelch_was_open = false;
             tracing::info!("transcription audio tap disabled");
         }
 
@@ -2028,9 +2052,11 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 /// Reset the per-tune engine state that MUST NOT carry over a
 /// frequency / demod / bandwidth change:
 ///
-/// 1. The controller-side squelch-edge tracker
-///    (`state.squelch_was_open`) — so a fresh `SquelchEdge::Open`
-///    at the new channel isn't suppressed by the previous
+/// 1. The controller-side squelch-edge trackers
+///    (`state.squelch_was_open` for the scanner +
+///    `state.transcription_squelch_was_open` for the offline
+///    transcription tap) — so a fresh `SquelchEdge::Open` at
+///    the new channel isn't suppressed by the previous
 ///    channel's trailing open state. Originally added for the
 ///    scanner retune path (PR #372 round 3); the same risk
 ///    applies to every manual tune / mode / bandwidth change.
@@ -2045,9 +2071,10 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
 ///
 /// Call from every UI-origin retune site (`UiToDsp::Tune`,
 /// `SetDemodMode`, `SetBandwidth`) and the scanner retune
-/// path. Cheap — two field writes plus an `if`-guarded reset.
+/// path. Cheap — three field writes plus an `if`-guarded reset.
 fn on_tune_change(state: &mut DspState) {
     state.squelch_was_open = false;
+    state.transcription_squelch_was_open = false;
     state.radio.rearm_auto_squelch();
 }
 
@@ -2082,7 +2109,9 @@ fn stop_transcription(state: &mut DspState) -> bool {
     if state.transcription_tx.take().is_some() {
         // Mirror the reset from the explicit DisableTranscription
         // handler — next EnableTranscription starts fresh.
-        state.squelch_was_open = false;
+        // Scanner tracker stays intact (the two are independent
+        // since the scanner ↔ transcription mutex was removed).
+        state.transcription_squelch_was_open = false;
         true
     } else {
         false
@@ -3046,7 +3075,12 @@ fn process_iq_block(
                         // (Dwelling→Listening, Listening→Hanging) apply to any
                         // mode. This runs outside the transcription gate below so
                         // the scanner sees every transition even when the
-                        // transcription tap is inactive.
+                        // transcription tap is inactive. The scanner tracker
+                        // is advanced IMMEDIATELY on emit so it stays
+                        // independent of the transcription tap's retry-on-Full
+                        // logic below — toggling transcription must not perturb
+                        // scanner edge detection. Per CodeRabbit round 1 on PR
+                        // #558.
                         let now_open = state.radio.if_chain().squelch_open();
                         if now_open != state.squelch_was_open {
                             let scanner_edge = if now_open {
@@ -3057,6 +3091,7 @@ fn process_iq_block(
                             let scan_cmds = state
                                 .scanner
                                 .handle_event(sdr_scanner::ScannerEvent::SquelchEdge(scanner_edge));
+                            state.squelch_was_open = now_open;
                             apply_scanner_commands(state, dsp_tx, scan_cmds);
                         }
 
@@ -3070,15 +3105,16 @@ fn process_iq_block(
                             let mut send_error = false;
                             // True unless we tried to send an edge event and hit
                             // `TrySendError::Full`. Squelch edges are one-shot
-                            // state transitions — if we advance `squelch_was_open`
-                            // without the downstream having received the edge,
-                            // the Auto Break state machine misses the transition
-                            // entirely and gets stuck in Idle/Recording until the
-                            // 30s safety flush fires. Retry on the next block by
-                            // leaving the tracker unchanged.
-                            let mut advance_tracker = true;
+                            // state transitions — if we advance the transcription
+                            // tracker without the downstream having received the
+                            // edge, the Auto Break state machine misses the
+                            // transition entirely and gets stuck in
+                            // Idle/Recording until the 30s safety flush fires.
+                            // Retry on the next block by leaving the tracker
+                            // unchanged.
+                            let mut advance_transcription_tracker = true;
 
-                            if now_open != state.squelch_was_open
+                            if now_open != state.transcription_squelch_was_open
                                 && state.radio.current_mode() == sdr_types::DemodMode::Nfm
                             {
                                 let edge = if now_open {
@@ -3097,7 +3133,7 @@ fn process_iq_block(
                                         // tracker so we retry this edge on the
                                         // next audio block instead of silently
                                         // dropping it.
-                                        advance_tracker = false;
+                                        advance_transcription_tracker = false;
                                         tracing::warn!(
                                             ?now_open,
                                             "transcription channel full; retrying squelch edge next block"
@@ -3105,8 +3141,8 @@ fn process_iq_block(
                                     }
                                 }
                             }
-                            if advance_tracker {
-                                state.squelch_was_open = now_open;
+                            if advance_transcription_tracker {
+                                state.transcription_squelch_was_open = now_open;
                             }
 
                             if !send_error {
@@ -3130,12 +3166,12 @@ fn process_iq_block(
                                     "transcription receiver disconnected, disabling tap"
                                 );
                             }
-                        } else {
-                            // No transcription tap: advance the tracker
-                            // unconditionally so the scanner doesn't see
-                            // the same edge repeatedly on every block.
-                            state.squelch_was_open = now_open;
                         }
+                        // No `else` branch — the scanner block above
+                        // advances `state.squelch_was_open` itself, so
+                        // edge tracking stays correct whether or not
+                        // the transcription tap is wired. Per CodeRabbit
+                        // round 1 on PR #558.
 
                         // Generic audio tap: downsample to 16 kHz mono
                         // and try_send. Pre-volume (like the transcription

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -3145,7 +3145,19 @@ fn process_iq_block(
                                 state.transcription_squelch_was_open = now_open;
                             }
 
-                            if !send_error {
+                            // Skip the sample send while a squelch edge is
+                            // pending retry (i.e. we hit `TrySendError::Full`
+                            // above and chose not to advance the tracker).
+                            // Without this, if the worker drains one slot
+                            // between the failed edge `try_send` and this
+                            // sample `try_send`, audio for the new state
+                            // would arrive BEFORE the missing
+                            // `SquelchOpened` / `SquelchClosed` edge — Auto
+                            // Break would keep buffering the new utterance
+                            // into the previous segment until the edge
+                            // finally lands on the next block. Per
+                            // `CodeRabbit` round 2 on PR #558.
+                            if !send_error && advance_transcription_tracker {
                                 let mut interleaved = Vec::with_capacity(audio_count * 2);
                                 for s in &state.audio_buf[..audio_count] {
                                     interleaved.push(s.l);

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -10,19 +10,22 @@ use sdr_types::{DemodMode, Protocol, RtlTcpConnectionState};
 
 use crate::sink_slot::{AudioSinkType, NetworkSinkStatus};
 
-/// Why the scanner↔recording/transcription mutex fired.
-/// Surfaced to the UI via `DspToUi::ScannerMutexStopped` so the
-/// appropriate toast can be shown.
+/// Why the scanner↔recording mutex fired. Surfaced to the UI
+/// via `DspToUi::ScannerMutexStopped` so the appropriate toast
+/// can be shown.
+///
+/// Scanner ↔ transcription mutex was removed — the two are
+/// designed to coexist as of PR #558 (issue #517 emits
+/// per-channel markers in the transcript log when the scanner
+/// hops). The two surviving variants cover the recording leg,
+/// which still mutexes with both scanner activation and
+/// transcription start.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScannerMutexReason {
     /// Scanner activation stopped a running recording.
     RecordingStoppedForScanner,
-    /// Scanner activation stopped a running transcription.
-    TranscriptionStoppedForScanner,
     /// Recording start stopped an active scanner.
     ScannerStoppedForRecording,
-    /// Transcription start stopped an active scanner.
-    ScannerStoppedForTranscription,
 }
 
 /// Messages sent from the DSP pipeline thread to the UI main loop.
@@ -1017,23 +1020,11 @@ mod tests {
             mutex_rec,
             DspToUi::ScannerMutexStopped(ScannerMutexReason::RecordingStoppedForScanner)
         ));
-        let mutex_trans =
-            DspToUi::ScannerMutexStopped(ScannerMutexReason::TranscriptionStoppedForScanner);
-        assert!(matches!(
-            mutex_trans,
-            DspToUi::ScannerMutexStopped(ScannerMutexReason::TranscriptionStoppedForScanner)
-        ));
         let mutex_scan_rec =
             DspToUi::ScannerMutexStopped(ScannerMutexReason::ScannerStoppedForRecording);
         assert!(matches!(
             mutex_scan_rec,
             DspToUi::ScannerMutexStopped(ScannerMutexReason::ScannerStoppedForRecording)
-        ));
-        let mutex_scan_trans =
-            DspToUi::ScannerMutexStopped(ScannerMutexReason::ScannerStoppedForTranscription);
-        assert!(matches!(
-            mutex_scan_trans,
-            DspToUi::ScannerMutexStopped(ScannerMutexReason::ScannerStoppedForTranscription)
         ));
     }
 

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -85,13 +85,19 @@ pub const SDR_SCANNER_STATE_HANGING: i32 = 4;
 // ============================================================
 
 pub const SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER: i32 = 0;
-// Discriminant 1 was `TRANSCRIPTION_STOPPED_FOR_SCANNER`, removed
-// when the scanner ↔ transcription mutex was deleted (PR #558 /
-// issue #517 — the two are designed to coexist). Slot left
-// unused so existing discriminants keep their numeric values.
+/// Reserved ABI slot. Discriminant 1 was previously
+/// `TRANSCRIPTION_STOPPED_FOR_SCANNER`; removed when the scanner ↔
+/// transcription mutex was deleted (PR #558 / issue #517 — the two
+/// are designed to coexist). Kept as a named reserved constant so
+/// the C ABI in `include/sdr_core.h` keeps its numeric layout and
+/// future discriminants don't accidentally reuse the slot. Per
+/// `CodeRabbit` round 1 on PR #558.
+pub const SDR_SCANNER_MUTEX_RESERVED_1: i32 = 1;
 pub const SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING: i32 = 2;
-// Discriminant 3 was `SCANNER_STOPPED_FOR_TRANSCRIPTION`, also
-// removed by the mutex deletion above.
+/// Reserved ABI slot. Discriminant 3 was previously
+/// `SCANNER_STOPPED_FOR_TRANSCRIPTION`; removed alongside slot 1
+/// above.
+pub const SDR_SCANNER_MUTEX_RESERVED_3: i32 = 3;
 
 // ============================================================
 //  Network sink status discriminants — must match the
@@ -1053,12 +1059,15 @@ mod tests {
     #[test]
     fn scanner_mutex_reason_discriminants_match_header() {
         assert_eq!(SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER, 0);
+        // Discriminants 1 and 3 are reserved ABI slots — the
+        // scanner ↔ transcription mutex variants that used to
+        // live here were removed in PR #558 when the two
+        // subsystems were redesigned to coexist. The slots stay
+        // pinned so future discriminants don't reuse them and
+        // perturb the wire format.
+        assert_eq!(SDR_SCANNER_MUTEX_RESERVED_1, 1);
         assert_eq!(SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING, 2);
-        // Discriminants 1 and 3 (`TRANSCRIPTION_STOPPED_FOR_SCANNER`
-        // and `SCANNER_STOPPED_FOR_TRANSCRIPTION`) were removed
-        // when the scanner ↔ transcription mutex was deleted —
-        // the slots are intentionally left unfilled to keep the
-        // remaining discriminants stable.
+        assert_eq!(SDR_SCANNER_MUTEX_RESERVED_3, 3);
     }
 
     #[test]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -85,9 +85,13 @@ pub const SDR_SCANNER_STATE_HANGING: i32 = 4;
 // ============================================================
 
 pub const SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER: i32 = 0;
-pub const SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER: i32 = 1;
+// Discriminant 1 was `TRANSCRIPTION_STOPPED_FOR_SCANNER`, removed
+// when the scanner ↔ transcription mutex was deleted (PR #558 /
+// issue #517 — the two are designed to coexist). Slot left
+// unused so existing discriminants keep their numeric values.
 pub const SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING: i32 = 2;
-pub const SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION: i32 = 3;
+// Discriminant 3 was `SCANNER_STOPPED_FOR_TRANSCRIPTION`, also
+// removed by the mutex deletion above.
 
 // ============================================================
 //  Network sink status discriminants — must match the
@@ -731,14 +735,8 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
                 ScannerMutexReason::RecordingStoppedForScanner => {
                     SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER
                 }
-                ScannerMutexReason::TranscriptionStoppedForScanner => {
-                    SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER
-                }
                 ScannerMutexReason::ScannerStoppedForRecording => {
                     SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING
-                }
-                ScannerMutexReason::ScannerStoppedForTranscription => {
-                    SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION
                 }
             };
             SdrEvent {
@@ -1055,9 +1053,12 @@ mod tests {
     #[test]
     fn scanner_mutex_reason_discriminants_match_header() {
         assert_eq!(SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER, 0);
-        assert_eq!(SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER, 1);
         assert_eq!(SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING, 2);
-        assert_eq!(SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION, 3);
+        // Discriminants 1 and 3 (`TRANSCRIPTION_STOPPED_FOR_SCANNER`
+        // and `SCANNER_STOPPED_FOR_TRANSCRIPTION`) were removed
+        // when the scanner ↔ transcription mutex was deleted —
+        // the slots are intentionally left unfilled to keep the
+        // remaining discriminants stable.
     }
 
     #[test]
@@ -1199,16 +1200,8 @@ mod tests {
                 SDR_SCANNER_MUTEX_RECORDING_STOPPED_FOR_SCANNER,
             ),
             (
-                ScannerMutexReason::TranscriptionStoppedForScanner,
-                SDR_SCANNER_MUTEX_TRANSCRIPTION_STOPPED_FOR_SCANNER,
-            ),
-            (
                 ScannerMutexReason::ScannerStoppedForRecording,
                 SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_RECORDING,
-            ),
-            (
-                ScannerMutexReason::ScannerStoppedForTranscription,
-                SDR_SCANNER_MUTEX_SCANNER_STOPPED_FOR_TRANSCRIPTION,
             ),
         ];
         for (reason, expected_int) in cases {

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -62,6 +62,44 @@ pub const KEY_SOURCE_RTL_GAIN_DB: &str = "src_rtl_gain_db";
 /// `0` (no correction). Per issue `#551`.
 pub const KEY_SOURCE_RTL_PPM: &str = "src_rtl_ppm";
 
+// ─── Source-panel persistence keys (#552) ───────────────────────────
+// Top-level + frontend + per-source-type config rows that today
+// reset to widget defaults across restart. Mechanical mirror of
+// the `KEY_SOURCE_RTL_*` pattern for tuner-specific settings —
+// each key has a matching `load_*` / `save_*` pair below and a
+// `connect_source_panel` restore-then-wire block in `window.rs`.
+
+/// Currently-selected source type (RTL-SDR / Network / File /
+/// RTL-TCP). Stored as the combo-row index per the `DEVICE_*`
+/// constants (`DEVICE_RTLSDR` / `DEVICE_NETWORK` / etc.).
+/// Default `DEVICE_RTLSDR` (`0`). Per issue `#552`.
+pub const KEY_SOURCE_DEVICE_INDEX: &str = "src_device_index";
+/// Sample rate dropdown index (into `SAMPLE_RATES`). Default
+/// matches the widget's initial selection. Per issue `#552`.
+pub const KEY_SOURCE_SAMPLE_RATE_INDEX: &str = "src_sample_rate_index";
+/// Decimation dropdown index (into `DECIMATION_FACTORS`).
+/// Default `0` (1× / no decimation). Per issue `#552`.
+pub const KEY_SOURCE_DECIMATION_INDEX: &str = "src_decimation_index";
+/// DC blocking toggle on the IQ frontend. Default `true`
+/// matches the widget's initial state. Per issue `#552`.
+pub const KEY_SOURCE_DC_BLOCKING: &str = "src_dc_blocking";
+/// IQ DC correction toggle. Default `false`. Per issue `#552`.
+pub const KEY_SOURCE_IQ_CORRECTION: &str = "src_iq_correction";
+/// IQ swap toggle. Default `false`. Per issue `#552`.
+pub const KEY_SOURCE_IQ_INVERSION: &str = "src_iq_inversion";
+/// Raw-Network source hostname. Default `"localhost"`. Note:
+/// the `rtl_tcp` client maintains its own per-server hostname/port
+/// state via `KEY_RTL_TCP_CLIENT_FAVORITES` — this key is for
+/// the raw IQ-stream Network source only. Per issue `#552`.
+pub const KEY_SOURCE_NETWORK_HOSTNAME: &str = "src_network_hostname";
+/// Raw-Network source port. Default `1234`. Per issue `#552`.
+pub const KEY_SOURCE_NETWORK_PORT: &str = "src_network_port";
+/// Raw-Network protocol dropdown index (into TCP/UDP). Default
+/// `NETWORK_PROTOCOL_TCPCLIENT_IDX`. Per issue `#552`.
+pub const KEY_SOURCE_NETWORK_PROTOCOL_INDEX: &str = "src_network_protocol_index";
+/// File source playback path. Default empty. Per issue `#552`.
+pub const KEY_SOURCE_FILE_PATH: &str = "src_file_path";
+
 /// Device selector index for RTL-SDR.
 pub const DEVICE_RTLSDR: u32 = 0;
 /// Device selector index for Network.
@@ -1189,6 +1227,190 @@ pub fn save_source_rtl_ppm(config: &Arc<ConfigManager>, ppm: i32) {
     });
 }
 
+// ─── #552 source-panel persistence helpers ──────────────────────────
+//
+// All follow the same shape as `load_source_rtl_*` /
+// `save_source_rtl_*`: a tolerant `load` that falls back to a
+// safe default on missing-key or wrong-type, paired with an
+// idempotent `save`. The wiring layer in
+// `window.rs::connect_source_panel` calls each `save_*` from the
+// row's change-notify handler and each `load_*` once at panel
+// build time (restore-before-wire idiom).
+
+/// Load the persisted source-type combo index. Defaults to
+/// [`DEVICE_RTLSDR`].
+#[must_use]
+pub fn load_source_device_index(config: &Arc<ConfigManager>) -> u32 {
+    config.read(|v| {
+        v.get(KEY_SOURCE_DEVICE_INDEX)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(DEVICE_RTLSDR)
+    })
+}
+
+pub fn save_source_device_index(config: &Arc<ConfigManager>, index: u32) {
+    config.write(|v| {
+        v[KEY_SOURCE_DEVICE_INDEX] = serde_json::json!(index);
+    });
+}
+
+/// Load the persisted sample-rate combo index. Defaults to `0`
+/// (the first entry in `SAMPLE_RATES`, matching the widget's
+/// initial selection at panel build time).
+#[must_use]
+pub fn load_source_sample_rate_index(config: &Arc<ConfigManager>) -> u32 {
+    config.read(|v| {
+        v.get(KEY_SOURCE_SAMPLE_RATE_INDEX)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(0)
+    })
+}
+
+pub fn save_source_sample_rate_index(config: &Arc<ConfigManager>, index: u32) {
+    config.write(|v| {
+        v[KEY_SOURCE_SAMPLE_RATE_INDEX] = serde_json::json!(index);
+    });
+}
+
+/// Load the persisted decimation combo index. Defaults to `0`
+/// (1× decimation).
+#[must_use]
+pub fn load_source_decimation_index(config: &Arc<ConfigManager>) -> u32 {
+    config.read(|v| {
+        v.get(KEY_SOURCE_DECIMATION_INDEX)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(0)
+    })
+}
+
+pub fn save_source_decimation_index(config: &Arc<ConfigManager>, index: u32) {
+    config.write(|v| {
+        v[KEY_SOURCE_DECIMATION_INDEX] = serde_json::json!(index);
+    });
+}
+
+/// Load the persisted DC-blocking toggle. Defaults to `true`
+/// (matches the widget's initial state).
+#[must_use]
+pub fn load_source_dc_blocking(config: &Arc<ConfigManager>) -> bool {
+    config.read(|v| {
+        v.get(KEY_SOURCE_DC_BLOCKING)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(true)
+    })
+}
+
+pub fn save_source_dc_blocking(config: &Arc<ConfigManager>, enabled: bool) {
+    config.write(|v| {
+        v[KEY_SOURCE_DC_BLOCKING] = serde_json::json!(enabled);
+    });
+}
+
+/// Load the persisted IQ-correction toggle. Defaults to `false`.
+#[must_use]
+pub fn load_source_iq_correction(config: &Arc<ConfigManager>) -> bool {
+    config.read(|v| {
+        v.get(KEY_SOURCE_IQ_CORRECTION)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    })
+}
+
+pub fn save_source_iq_correction(config: &Arc<ConfigManager>, enabled: bool) {
+    config.write(|v| {
+        v[KEY_SOURCE_IQ_CORRECTION] = serde_json::json!(enabled);
+    });
+}
+
+/// Load the persisted IQ-swap toggle. Defaults to `false`.
+#[must_use]
+pub fn load_source_iq_inversion(config: &Arc<ConfigManager>) -> bool {
+    config.read(|v| {
+        v.get(KEY_SOURCE_IQ_INVERSION)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    })
+}
+
+pub fn save_source_iq_inversion(config: &Arc<ConfigManager>, enabled: bool) {
+    config.write(|v| {
+        v[KEY_SOURCE_IQ_INVERSION] = serde_json::json!(enabled);
+    });
+}
+
+/// Load the persisted raw-Network hostname. Defaults to
+/// `"localhost"` (matches the widget's initial value).
+#[must_use]
+pub fn load_source_network_hostname(config: &Arc<ConfigManager>) -> String {
+    config.read(|v| {
+        v.get(KEY_SOURCE_NETWORK_HOSTNAME)
+            .and_then(serde_json::Value::as_str)
+            .map_or_else(|| "localhost".to_string(), ToString::to_string)
+    })
+}
+
+pub fn save_source_network_hostname(config: &Arc<ConfigManager>, hostname: &str) {
+    config.write(|v| {
+        v[KEY_SOURCE_NETWORK_HOSTNAME] = serde_json::json!(hostname);
+    });
+}
+
+/// Load the persisted raw-Network port. Defaults to `1234`
+/// (matches `DEFAULT_PORT`).
+#[must_use]
+pub fn load_source_network_port(config: &Arc<ConfigManager>) -> u16 {
+    config.read(|v| {
+        v.get(KEY_SOURCE_NETWORK_PORT)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u16::try_from(n).ok())
+            .unwrap_or(1234)
+    })
+}
+
+pub fn save_source_network_port(config: &Arc<ConfigManager>, port: u16) {
+    config.write(|v| {
+        v[KEY_SOURCE_NETWORK_PORT] = serde_json::json!(port);
+    });
+}
+
+/// Load the persisted raw-Network protocol combo index.
+/// Defaults to [`NETWORK_PROTOCOL_TCPCLIENT_IDX`].
+#[must_use]
+pub fn load_source_network_protocol_index(config: &Arc<ConfigManager>) -> u32 {
+    config.read(|v| {
+        v.get(KEY_SOURCE_NETWORK_PROTOCOL_INDEX)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(NETWORK_PROTOCOL_TCPCLIENT_IDX)
+    })
+}
+
+pub fn save_source_network_protocol_index(config: &Arc<ConfigManager>, index: u32) {
+    config.write(|v| {
+        v[KEY_SOURCE_NETWORK_PROTOCOL_INDEX] = serde_json::json!(index);
+    });
+}
+
+/// Load the persisted File-source playback path. Defaults to
+/// the empty string (no file selected).
+#[must_use]
+pub fn load_source_file_path(config: &Arc<ConfigManager>) -> String {
+    config.read(|v| {
+        v.get(KEY_SOURCE_FILE_PATH)
+            .and_then(serde_json::Value::as_str)
+            .map_or_else(String::new, ToString::to_string)
+    })
+}
+
+pub fn save_source_file_path(config: &Arc<ConfigManager>, path: &str) {
+    config.write(|v| {
+        v[KEY_SOURCE_FILE_PATH] = serde_json::json!(path);
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1643,5 +1865,121 @@ mod tests {
         assert_eq!(load_source_rtl_ppm(&config), 50);
         config.write(|v| v[KEY_SOURCE_RTL_PPM] = serde_json::json!("not a number"));
         assert_eq!(load_source_rtl_ppm(&config), 0);
+    }
+
+    // ─── #552 persistence round-trips ─────────────────────────
+
+    #[test]
+    fn source_device_index_round_trip_and_default() {
+        let config = make_config();
+        assert_eq!(load_source_device_index(&config), DEVICE_RTLSDR);
+        save_source_device_index(&config, DEVICE_NETWORK);
+        assert_eq!(load_source_device_index(&config), DEVICE_NETWORK);
+        config.write(|v| v[KEY_SOURCE_DEVICE_INDEX] = serde_json::json!("nope"));
+        assert_eq!(load_source_device_index(&config), DEVICE_RTLSDR);
+    }
+
+    #[test]
+    fn source_sample_rate_index_round_trip_and_default() {
+        let config = make_config();
+        assert_eq!(load_source_sample_rate_index(&config), 0);
+        save_source_sample_rate_index(&config, 3);
+        assert_eq!(load_source_sample_rate_index(&config), 3);
+        config.write(|v| v[KEY_SOURCE_SAMPLE_RATE_INDEX] = serde_json::json!("nope"));
+        assert_eq!(load_source_sample_rate_index(&config), 0);
+    }
+
+    #[test]
+    fn source_decimation_index_round_trip_and_default() {
+        let config = make_config();
+        assert_eq!(load_source_decimation_index(&config), 0);
+        save_source_decimation_index(&config, 2);
+        assert_eq!(load_source_decimation_index(&config), 2);
+        config.write(|v| v[KEY_SOURCE_DECIMATION_INDEX] = serde_json::json!("nope"));
+        assert_eq!(load_source_decimation_index(&config), 0);
+    }
+
+    #[test]
+    fn source_dc_blocking_round_trip_and_default() {
+        let config = make_config();
+        assert!(load_source_dc_blocking(&config));
+        save_source_dc_blocking(&config, false);
+        assert!(!load_source_dc_blocking(&config));
+        save_source_dc_blocking(&config, true);
+        assert!(load_source_dc_blocking(&config));
+        config.write(|v| v[KEY_SOURCE_DC_BLOCKING] = serde_json::json!("nope"));
+        assert!(load_source_dc_blocking(&config));
+    }
+
+    #[test]
+    fn source_iq_correction_round_trip_and_default() {
+        let config = make_config();
+        assert!(!load_source_iq_correction(&config));
+        save_source_iq_correction(&config, true);
+        assert!(load_source_iq_correction(&config));
+        config.write(|v| v[KEY_SOURCE_IQ_CORRECTION] = serde_json::json!("nope"));
+        assert!(!load_source_iq_correction(&config));
+    }
+
+    #[test]
+    fn source_iq_inversion_round_trip_and_default() {
+        let config = make_config();
+        assert!(!load_source_iq_inversion(&config));
+        save_source_iq_inversion(&config, true);
+        assert!(load_source_iq_inversion(&config));
+        config.write(|v| v[KEY_SOURCE_IQ_INVERSION] = serde_json::json!("nope"));
+        assert!(!load_source_iq_inversion(&config));
+    }
+
+    #[test]
+    fn source_network_hostname_round_trip_and_default() {
+        let config = make_config();
+        assert_eq!(load_source_network_hostname(&config), "localhost");
+        save_source_network_hostname(&config, "shack-pi.local");
+        assert_eq!(load_source_network_hostname(&config), "shack-pi.local");
+        config.write(|v| v[KEY_SOURCE_NETWORK_HOSTNAME] = serde_json::json!(42));
+        assert_eq!(load_source_network_hostname(&config), "localhost");
+    }
+
+    #[test]
+    fn source_network_port_round_trip_and_default() {
+        let config = make_config();
+        assert_eq!(load_source_network_port(&config), 1234);
+        save_source_network_port(&config, 8888);
+        assert_eq!(load_source_network_port(&config), 8888);
+        // out-of-range u16 falls back
+        config.write(|v| v[KEY_SOURCE_NETWORK_PORT] = serde_json::json!(70_000));
+        assert_eq!(load_source_network_port(&config), 1234);
+        config.write(|v| v[KEY_SOURCE_NETWORK_PORT] = serde_json::json!("nope"));
+        assert_eq!(load_source_network_port(&config), 1234);
+    }
+
+    #[test]
+    fn source_network_protocol_index_round_trip_and_default() {
+        let config = make_config();
+        assert_eq!(
+            load_source_network_protocol_index(&config),
+            NETWORK_PROTOCOL_TCPCLIENT_IDX
+        );
+        save_source_network_protocol_index(&config, NETWORK_PROTOCOL_UDP_IDX);
+        assert_eq!(
+            load_source_network_protocol_index(&config),
+            NETWORK_PROTOCOL_UDP_IDX
+        );
+        config.write(|v| v[KEY_SOURCE_NETWORK_PROTOCOL_INDEX] = serde_json::json!("nope"));
+        assert_eq!(
+            load_source_network_protocol_index(&config),
+            NETWORK_PROTOCOL_TCPCLIENT_IDX
+        );
+    }
+
+    #[test]
+    fn source_file_path_round_trip_and_default() {
+        let config = make_config();
+        assert_eq!(load_source_file_path(&config), "");
+        save_source_file_path(&config, "/tmp/iq.wav");
+        assert_eq!(load_source_file_path(&config), "/tmp/iq.wav");
+        config.write(|v| v[KEY_SOURCE_FILE_PATH] = serde_json::json!(42));
+        assert_eq!(load_source_file_path(&config), "");
     }
 }

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -8,7 +8,18 @@ use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
 use sdr_config::ConfigManager;
+use sdr_source_rtlsdr::SAMPLE_RATES;
 use sdr_types::RtlTcpConnectionState;
+
+/// Decimation factors available in the source panel dropdown.
+/// Order is load-bearing: the dropdown row uses the slice index
+/// as the persisted combo index, and `DECIMATION_FACTORS[idx]` is
+/// the multiplier sent to the DSP. Lives here (not in `window.rs`)
+/// so the persistence loader [`load_source_decimation_index`] can
+/// bound-check against `DECIMATION_FACTORS.len()` without
+/// `window.rs` having to expose the slice. Per `CodeRabbit`
+/// round 1 on PR #558.
+pub const DECIMATION_FACTORS: &[u32] = &[1, 2, 4, 8, 16];
 
 /// Config key for the persisted list of favorited `rtl_tcp`
 /// servers. Stored as a JSON array of [`FavoriteEntry`] objects,
@@ -437,7 +448,9 @@ pub fn format_rtl_tcp_state(state: &RtlTcpConnectionState) -> String {
 }
 
 /// Default sample rate selector index (2.4 MHz = index 7).
-const DEFAULT_SAMPLE_RATE_INDEX: u32 = 7;
+/// Shared with [`load_source_sample_rate_index`] so the loader's
+/// fallback matches the widget's initial selection.
+pub(crate) const DEFAULT_SAMPLE_RATE_INDEX: u32 = 7;
 
 /// Build RTL-SDR-specific rows: sample rate, gain, AGC, PPM correction.
 fn build_rtlsdr_rows() -> (
@@ -1238,13 +1251,17 @@ pub fn save_source_rtl_ppm(config: &Arc<ConfigManager>, ppm: i32) {
 // build time (restore-before-wire idiom).
 
 /// Load the persisted source-type combo index. Defaults to
-/// [`DEVICE_RTLSDR`].
+/// [`DEVICE_RTLSDR`] when the key is missing, the value isn't a
+/// `u64`, or the parsed index falls outside `0..=DEVICE_RTLTCP`
+/// (e.g. a future build added more source types and the user
+/// rolled back). Per `CodeRabbit` round 1 on PR #558.
 #[must_use]
 pub fn load_source_device_index(config: &Arc<ConfigManager>) -> u32 {
     config.read(|v| {
         v.get(KEY_SOURCE_DEVICE_INDEX)
             .and_then(serde_json::Value::as_u64)
             .and_then(|n| u32::try_from(n).ok())
+            .filter(|&idx| idx <= DEVICE_RTLTCP)
             .unwrap_or(DEVICE_RTLSDR)
     })
 }
@@ -1255,16 +1272,21 @@ pub fn save_source_device_index(config: &Arc<ConfigManager>, index: u32) {
     });
 }
 
-/// Load the persisted sample-rate combo index. Defaults to `0`
-/// (the first entry in `SAMPLE_RATES`, matching the widget's
-/// initial selection at panel build time).
+/// Load the persisted sample-rate combo index. Falls back to
+/// [`DEFAULT_SAMPLE_RATE_INDEX`] (matches the widget's initial
+/// selection at panel build time) when the key is missing, the
+/// value isn't numeric, or the parsed index is out of range
+/// (`>= SAMPLE_RATES.len()`). Per `CodeRabbit` round 1 on PR #558
+/// — the prior literal-`0` fallback would silently downgrade a
+/// fresh install to 250 kHz instead of the intended 2.4 MHz.
 #[must_use]
 pub fn load_source_sample_rate_index(config: &Arc<ConfigManager>) -> u32 {
     config.read(|v| {
         v.get(KEY_SOURCE_SAMPLE_RATE_INDEX)
             .and_then(serde_json::Value::as_u64)
             .and_then(|n| u32::try_from(n).ok())
-            .unwrap_or(0)
+            .filter(|&idx| (idx as usize) < SAMPLE_RATES.len())
+            .unwrap_or(DEFAULT_SAMPLE_RATE_INDEX)
     })
 }
 
@@ -1275,13 +1297,17 @@ pub fn save_source_sample_rate_index(config: &Arc<ConfigManager>, index: u32) {
 }
 
 /// Load the persisted decimation combo index. Defaults to `0`
-/// (1× decimation).
+/// (1× decimation, the widget's initial selection) when the key
+/// is missing, the value isn't numeric, or the parsed index is
+/// out of range (`>= DECIMATION_FACTORS.len()`). Per
+/// `CodeRabbit` round 1 on PR #558.
 #[must_use]
 pub fn load_source_decimation_index(config: &Arc<ConfigManager>) -> u32 {
     config.read(|v| {
         v.get(KEY_SOURCE_DECIMATION_INDEX)
             .and_then(serde_json::Value::as_u64)
             .and_then(|n| u32::try_from(n).ok())
+            .filter(|&idx| (idx as usize) < DECIMATION_FACTORS.len())
             .unwrap_or(0)
     })
 }
@@ -1376,14 +1402,18 @@ pub fn save_source_network_port(config: &Arc<ConfigManager>, port: u16) {
     });
 }
 
-/// Load the persisted raw-Network protocol combo index.
-/// Defaults to [`NETWORK_PROTOCOL_TCPCLIENT_IDX`].
+/// Load the persisted raw-Network protocol combo index. Defaults
+/// to [`NETWORK_PROTOCOL_TCPCLIENT_IDX`] when the key is missing,
+/// the value isn't numeric, or the parsed index falls outside
+/// `0..=NETWORK_PROTOCOL_UDP_IDX`. Per `CodeRabbit` round 1 on
+/// PR #558.
 #[must_use]
 pub fn load_source_network_protocol_index(config: &Arc<ConfigManager>) -> u32 {
     config.read(|v| {
         v.get(KEY_SOURCE_NETWORK_PROTOCOL_INDEX)
             .and_then(serde_json::Value::as_u64)
             .and_then(|n| u32::try_from(n).ok())
+            .filter(|&idx| idx <= NETWORK_PROTOCOL_UDP_IDX)
             .unwrap_or(NETWORK_PROTOCOL_TCPCLIENT_IDX)
     })
 }
@@ -1877,16 +1907,36 @@ mod tests {
         assert_eq!(load_source_device_index(&config), DEVICE_NETWORK);
         config.write(|v| v[KEY_SOURCE_DEVICE_INDEX] = serde_json::json!("nope"));
         assert_eq!(load_source_device_index(&config), DEVICE_RTLSDR);
+        // Out-of-range numeric: a future build that added more
+        // source types and was rolled back must fall back, not
+        // pin the combo to a non-existent index.
+        config.write(|v| v[KEY_SOURCE_DEVICE_INDEX] = serde_json::json!(999));
+        assert_eq!(load_source_device_index(&config), DEVICE_RTLSDR);
     }
 
     #[test]
     fn source_sample_rate_index_round_trip_and_default() {
         let config = make_config();
-        assert_eq!(load_source_sample_rate_index(&config), 0);
+        // Missing key falls back to the panel's actual default
+        // (DEFAULT_SAMPLE_RATE_INDEX = 7 = 2.4 MHz), not 0
+        // (250 kHz). Per CodeRabbit round 1 on PR #558.
+        assert_eq!(
+            load_source_sample_rate_index(&config),
+            DEFAULT_SAMPLE_RATE_INDEX
+        );
         save_source_sample_rate_index(&config, 3);
         assert_eq!(load_source_sample_rate_index(&config), 3);
         config.write(|v| v[KEY_SOURCE_SAMPLE_RATE_INDEX] = serde_json::json!("nope"));
-        assert_eq!(load_source_sample_rate_index(&config), 0);
+        assert_eq!(
+            load_source_sample_rate_index(&config),
+            DEFAULT_SAMPLE_RATE_INDEX
+        );
+        // Out-of-range numeric falls back to default.
+        config.write(|v| v[KEY_SOURCE_SAMPLE_RATE_INDEX] = serde_json::json!(9999));
+        assert_eq!(
+            load_source_sample_rate_index(&config),
+            DEFAULT_SAMPLE_RATE_INDEX
+        );
     }
 
     #[test]
@@ -1896,6 +1946,9 @@ mod tests {
         save_source_decimation_index(&config, 2);
         assert_eq!(load_source_decimation_index(&config), 2);
         config.write(|v| v[KEY_SOURCE_DECIMATION_INDEX] = serde_json::json!("nope"));
+        assert_eq!(load_source_decimation_index(&config), 0);
+        // Out-of-range numeric falls back to 1× decimation.
+        config.write(|v| v[KEY_SOURCE_DECIMATION_INDEX] = serde_json::json!(99));
         assert_eq!(load_source_decimation_index(&config), 0);
     }
 
@@ -1967,6 +2020,12 @@ mod tests {
             NETWORK_PROTOCOL_UDP_IDX
         );
         config.write(|v| v[KEY_SOURCE_NETWORK_PROTOCOL_INDEX] = serde_json::json!("nope"));
+        assert_eq!(
+            load_source_network_protocol_index(&config),
+            NETWORK_PROTOCOL_TCPCLIENT_IDX
+        );
+        // Out-of-range numeric falls back to TCP-client (idx 0).
+        config.write(|v| v[KEY_SOURCE_NETWORK_PROTOCOL_INDEX] = serde_json::json!(42));
         assert_eq!(
             load_source_network_protocol_index(&config),
             NETWORK_PROTOCOL_TCPCLIENT_IDX

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -224,6 +224,53 @@ pub struct TranscriptPanel {
     pub clear_button: gtk4::Button,
 }
 
+/// Append a channel-marker divider line to a transcript
+/// `gtk4::TextView`. Called from the wiring layer's
+/// `DspToUi::ScannerActiveChannelChanged` handler whenever the
+/// scanner switches to a non-idle channel — gives the reader a
+/// navigation anchor so transcribed text from different channels
+/// doesn't bleed together visually. Per issue #517.
+///
+/// Format: `─── HH:MM:SS · {channel_name} ───`. Styled dim +
+/// italic via a lazily-installed `channel_marker` `TextTag` on
+/// the buffer's tag table so it stands apart from regular
+/// transcript rows.
+///
+/// Freestanding rather than a method on `TranscriptPanel` so the
+/// call site in `window.rs::handle_dsp_message` only has to
+/// thread a `&gtk4::TextView` clone (cheap — GTK widgets are
+/// Rc-internal) instead of the whole panel.
+pub fn push_channel_marker(text_view: &gtk4::TextView, channel_name: &str) {
+    let buf = text_view.buffer();
+    let tag_table = buf.tag_table();
+    let tag = tag_table.lookup("channel_marker").unwrap_or_else(|| {
+        let new_tag = gtk4::TextTag::builder()
+            .name("channel_marker")
+            .style(gtk4::pango::Style::Italic)
+            .foreground("#888888")
+            .build();
+        tag_table.add(&new_tag);
+        new_tag
+    });
+
+    let timestamp = chrono::Local::now().format("%H:%M:%S");
+    let marker_text = format!("─── {timestamp} · {channel_name} ───\n");
+
+    let start_offset = buf.end_iter().offset();
+    let mut end_iter = buf.end_iter();
+    buf.insert(&mut end_iter, &marker_text);
+    let start_iter = buf.iter_at_offset(start_offset);
+    let end_iter = buf.end_iter();
+    buf.apply_tag(&tag, &start_iter, &end_iter);
+
+    // Auto-scroll to the bottom so the new marker is visible
+    // even when the user hasn't manually scrolled along. Same
+    // idiom as the regular transcript-text insert.
+    let mark = buf.create_mark(None, &buf.end_iter(), false);
+    text_view.scroll_to_mark(&mark, 0.0, false, 0.0, 0.0);
+    buf.delete_mark(&mark);
+}
+
 /// Specification for a persisted-millisecond `AdwSpinRow`. Used by
 /// [`build_persisted_ms_slider`] to construct the three Auto Break
 /// timing sliders from one code path.

--- a/crates/sdr-ui/src/sidebar/transcript_panel.rs
+++ b/crates/sdr-ui/src/sidebar/transcript_panel.rs
@@ -240,7 +240,18 @@ pub struct TranscriptPanel {
 /// call site in `window.rs::handle_dsp_message` only has to
 /// thread a `&gtk4::TextView` clone (cheap — GTK widgets are
 /// Rc-internal) instead of the whole panel.
-pub fn push_channel_marker(text_view: &gtk4::TextView, channel_name: &str) {
+///
+/// `switched_at` is the wall-clock instant the scanner emitted
+/// `ScannerActiveChannelChanged` — captured at hop time and
+/// passed through here. Render time can lag by seconds when the
+/// transcription backend is busy, so using `chrono::Local::now()`
+/// inside this helper would stamp markers with the wrong time on
+/// busy passes. Per `CodeRabbit` round 1 on PR #558.
+pub fn push_channel_marker(
+    text_view: &gtk4::TextView,
+    switched_at: chrono::DateTime<chrono::Local>,
+    channel_name: &str,
+) {
     let buf = text_view.buffer();
     let tag_table = buf.tag_table();
     let tag = tag_table.lookup("channel_marker").unwrap_or_else(|| {
@@ -253,7 +264,7 @@ pub fn push_channel_marker(text_view: &gtk4::TextView, channel_name: &str) {
         new_tag
     });
 
-    let timestamp = chrono::Local::now().format("%H:%M:%S");
+    let timestamp = switched_at.format("%H:%M:%S");
     let marker_text = format!("─── {timestamp} · {channel_name} ───\n");
 
     let start_offset = buf.end_iter().offset();

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -97,7 +97,7 @@ pub struct AppState {
     /// moving the stored value out, which interferes with the
     /// borrow-and-clone pattern the button handler uses.
     pub scanner_active_key: RefCell<Option<sdr_scanner::ChannelKey>>,
-    /// Channel name buffered for lazy emission of a transcript
+    /// Channel hop buffered for lazy emission of a transcript
     /// channel-marker (#517). Written by the
     /// `DspToUi::ScannerActiveChannelChanged` handler when the
     /// scanner switches to a non-idle channel; consumed by the
@@ -105,12 +105,19 @@ pub struct AppState {
     /// transcribed text arrives. The lazy approach skips marker
     /// emission entirely when (a) transcription is OFF (no
     /// `TranscriptionEvent::Text` ever fires, so the buffered
-    /// name stays unconsumed), and (b) the scanner hops past a
+    /// hop stays unconsumed), and (b) the scanner hops past a
     /// channel without producing any audio (the next channel
-    /// overwrites the buffered name before it's consumed).
+    /// overwrites the buffered hop before it's consumed).
     /// Squashes runs of empty-channel hops to a single marker
     /// at the next channel that actually produces text.
-    pub pending_channel_marker: RefCell<Option<String>>,
+    ///
+    /// Stored as `(switched_at, channel_name)` so the marker
+    /// renders the actual hop time rather than render time —
+    /// otherwise a busy transcription backend with seconds of
+    /// buffered audio would stamp markers with a clock that
+    /// drifts past the real channel switch. Per `CodeRabbit`
+    /// round 1 on PR #558.
+    pub pending_channel_marker: RefCell<Option<(chrono::DateTime<chrono::Local>, String)>>,
     /// Previous `rtl_tcp` connection state discriminant, used to
     /// detect edge transitions into terminal role-denial states
     /// (`ControllerBusy`, `AuthRequired`, `AuthFailed`). The toast
@@ -128,6 +135,19 @@ pub struct AppState {
     /// per-server keyring entry. Empty string when no server is
     /// selected. Per issue #396.
     pub rtl_tcp_active_server: RefCell<String>,
+    /// `true` while `apply_rtl_tcp_connect` (or the matching
+    /// startup hydration in `connect_rtl_tcp_discovery`) is
+    /// programmatically rewriting the shared
+    /// `hostname_row` / `port_row` / `protocol_row` triple to
+    /// point at an RTL-TCP server. The change-notify handlers
+    /// for those rows always dispatch `SetNetworkConfig` (so the
+    /// running session re-points), but they MUST NOT persist the
+    /// values to `KEY_SOURCE_NETWORK_*` while this flag is set —
+    /// the user's independent raw-network selection lives in
+    /// those keys and would otherwise be silently overwritten by
+    /// every RTL-TCP hydration. Per `CodeRabbit` round 1 on PR
+    /// #558.
+    pub rtl_tcp_hydration_in_progress: std::cell::Cell<bool>,
     /// Currently-open NOAA APT viewer window, or `None` when no
     /// viewer is open. Set by the viewer's open path (the
     /// activity-bar / shortcut handler) and cleared by its
@@ -197,6 +217,7 @@ impl AppState {
             // AuthFailed is correctly detected as an edge.
             last_rtl_tcp_state_disc: Cell::new(RTL_TCP_STATE_DISC_DISCONNECTED),
             rtl_tcp_active_server: RefCell::new(String::new()),
+            rtl_tcp_hydration_in_progress: std::cell::Cell::new(false),
             apt_viewer: RefCell::new(None),
             apt_viewer_window: RefCell::new(None),
             lrpt_viewer: RefCell::new(None),

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -97,6 +97,20 @@ pub struct AppState {
     /// moving the stored value out, which interferes with the
     /// borrow-and-clone pattern the button handler uses.
     pub scanner_active_key: RefCell<Option<sdr_scanner::ChannelKey>>,
+    /// Channel name buffered for lazy emission of a transcript
+    /// channel-marker (#517). Written by the
+    /// `DspToUi::ScannerActiveChannelChanged` handler when the
+    /// scanner switches to a non-idle channel; consumed by the
+    /// `TranscriptionEvent::Text` handler when the next
+    /// transcribed text arrives. The lazy approach skips marker
+    /// emission entirely when (a) transcription is OFF (no
+    /// `TranscriptionEvent::Text` ever fires, so the buffered
+    /// name stays unconsumed), and (b) the scanner hops past a
+    /// channel without producing any audio (the next channel
+    /// overwrites the buffered name before it's consumed).
+    /// Squashes runs of empty-channel hops to a single marker
+    /// at the next channel that actually produces text.
+    pub pending_channel_marker: RefCell<Option<String>>,
     /// Previous `rtl_tcp` connection state discriminant, used to
     /// detect edge transitions into terminal role-denial states
     /// (`ControllerBusy`, `AuthRequired`, `AuthFailed`). The toast
@@ -176,6 +190,7 @@ impl AppState {
             suppress_bandwidth_notify: Cell::new(false),
             suppress_demod_notify: Cell::new(false),
             scanner_active_key: RefCell::new(None),
+            pending_channel_marker: RefCell::new(None),
             // Initialize to `RTL_TCP_STATE_DISC_DISCONNECTED` — same
             // as the connection manager's initial state so the first
             // real transition into ControllerBusy / AuthRequired /

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3828,13 +3828,18 @@ fn apply_rtl_tcp_connect(
     };
 
     let already_rtl_tcp = device_row.selected() == DEVICE_RTLTCP;
-    // Guard the programmatic row rewrites so the persistence
-    // handlers don't clobber `KEY_SOURCE_NETWORK_*` (which
-    // belong to the user's independent raw-Network selection)
-    // with the RTL-TCP endpoint. The handlers still dispatch
-    // `SetNetworkConfig` so the running session re-points; only
-    // the disk-write is skipped. Per CodeRabbit round 1 on PR
-    // #558.
+    // Guard the programmatic row rewrites so the per-field
+    // handlers don't clobber `KEY_SOURCE_NETWORK_*` (which belong
+    // to the user's independent raw-Network selection) with the
+    // RTL-TCP endpoint. While the hydration flag is set, the
+    // handlers suppress BOTH the persistence write AND the
+    // per-edit `SetNetworkConfig` dispatch — three sequential row
+    // mutations otherwise fan out to three intermediate
+    // reconnects against a partially-rewritten triple. A single
+    // canonical `SetNetworkConfig` is dispatched further down
+    // (after the flag clears) so the DSP gets the fully-formed
+    // endpoint exactly once. Per `CodeRabbit` rounds 1, 2, and 5
+    // on PR #558.
     state.rtl_tcp_hydration_in_progress.set(true);
     protocol_row.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
     hostname_row.set_text(host);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3227,13 +3227,30 @@ fn connect_rtl_tcp_discovery(
     // `SetNetworkConfig` against the RTL-TCP endpoint on the very
     // first tick. Pinning TCP first keeps the restore both silent
     // to the user and correct end-to-end.
-    if let Some(last) = crate::sidebar::source_panel::load_last_connected(&config_for_discovery) {
+    // Only hydrate the shared host / port / protocol row triple
+    // with the last-connected RTL-TCP server when the persisted
+    // source type is actually RTL-TCP. If the user was last on
+    // raw Network, the values restored by `connect_source_panel`
+    // a moment earlier (KEY_SOURCE_NETWORK_*) are the right ones
+    // to keep visible — overwriting them with an unrelated
+    // RTL-TCP endpoint just because one was once connected would
+    // surprise the user on every restart. Per `CodeRabbit` round
+    // 2 on PR #558.
+    let restored_source_is_rtl_tcp =
+        sidebar::source_panel::load_source_device_index(&config_for_discovery)
+            == sidebar::source_panel::DEVICE_RTLTCP;
+    if restored_source_is_rtl_tcp
+        && let Some(last) = crate::sidebar::source_panel::load_last_connected(&config_for_discovery)
+    {
         // Same guarded-rewrite idiom as `apply_rtl_tcp_connect`:
         // hydrating the last-connected RTL-TCP server must not
         // overwrite `KEY_SOURCE_NETWORK_*` (the raw-Network
         // triple). The persistence handlers for those rows
-        // observe the flag and skip the disk-write. Per
-        // CodeRabbit round 1 on PR #558.
+        // observe the flag and skip the disk-write, AND skip
+        // the `SetNetworkConfig` dispatch so the three row
+        // mutations don't kick three intermediate reconnects
+        // against a partially-rewritten triple. Per `CodeRabbit`
+        // rounds 1 and 2 on PR #558.
         state.rtl_tcp_hydration_in_progress.set(true);
         protocol_row.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
         hostname_row.set_text(&last.host);
@@ -7192,11 +7209,21 @@ fn connect_source_panel(
         } else {
             sdr_types::Protocol::TcpClient
         };
-        state_host.send_dsp(UiToDsp::SetNetworkConfig {
-            hostname,
-            port,
-            protocol,
-        });
+        // Suppress per-edit `SetNetworkConfig` dispatch while a
+        // hydration is rewriting all three rows in sequence. The
+        // sequence would otherwise cause three intermediate
+        // reconnect attempts (one per row), each against a
+        // partially-rewritten triple. `apply_rtl_tcp_connect`
+        // dispatches a single canonical `SetNetworkConfig` after
+        // clearing the flag, so the final state still reaches
+        // the DSP. Per `CodeRabbit` round 2 on PR #558.
+        if !state_host.rtl_tcp_hydration_in_progress.get() {
+            state_host.send_dsp(UiToDsp::SetNetworkConfig {
+                hostname,
+                port,
+                protocol,
+            });
+        }
     });
 
     // Network port
@@ -7227,11 +7254,16 @@ fn connect_source_panel(
         } else {
             sdr_types::Protocol::TcpClient
         };
-        state_port.send_dsp(UiToDsp::SetNetworkConfig {
-            hostname,
-            port,
-            protocol,
-        });
+        // Suppress per-edit dispatch during hydration; see
+        // hostname handler above. Per `CodeRabbit` round 2 on
+        // PR #558.
+        if !state_port.rtl_tcp_hydration_in_progress.get() {
+            state_port.send_dsp(UiToDsp::SetNetworkConfig {
+                hostname,
+                port,
+                protocol,
+            });
+        }
     });
 
     // Network protocol
@@ -7258,11 +7290,16 @@ fn connect_source_panel(
                 NETWORK_PROTOCOL_UDP_IDX => sdr_types::Protocol::Udp,
                 _ => return, // ignore transient indices
             };
-            state_proto.send_dsp(UiToDsp::SetNetworkConfig {
-                hostname,
-                port,
-                protocol,
-            });
+            // Suppress per-edit dispatch during hydration; see
+            // hostname handler above. Per `CodeRabbit` round 2 on
+            // PR #558.
+            if !state_proto.rtl_tcp_hydration_in_progress.get() {
+                state_proto.send_dsp(UiToDsp::SetNetworkConfig {
+                    hostname,
+                    port,
+                    protocol,
+                });
+            }
         });
 
     // Connection-role picker (#396). The selector flips between

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1245,6 +1245,19 @@ fn handle_dsp_message(
             // before the widget sync below so a racing user click
             // during this frame sees the latest key.
             state.scanner_active_key.borrow_mut().clone_from(&key);
+            // Buffer the channel name for lazy marker emission.
+            // The transcription text-event handler will consume
+            // this when the next transcribed line arrives — that
+            // way markers only appear when there's actual audio
+            // to attribute. If the scanner hops past a quiet
+            // channel before any text fires, the next channel's
+            // name overwrites the buffer and the silent channel
+            // never gets a marker. If transcription is off, no
+            // text events fire at all, so the buffered name
+            // simply stays unconsumed (gets overwritten on each
+            // hop) and no markers ever appear in the panel.
+            // Per issue #517 + initial-smoke feedback on PR #558.
+            *state.pending_channel_marker.borrow_mut() = key.as_ref().map(|_| name.clone());
             if key.is_some() {
                 // Update the cached tuning state so downstream
                 // reads (bandwidth notify's status-bar rewrite,
@@ -1397,19 +1410,10 @@ fn handle_dsp_message(
                 sdr_core::messages::ScannerMutexReason::RecordingStoppedForScanner => {
                     "Recording stopped — Scanner activated"
                 }
-                sdr_core::messages::ScannerMutexReason::TranscriptionStoppedForScanner => {
-                    transcription_enable_row.set_active(false);
-                    "Transcription stopped — Scanner activated"
-                }
                 sdr_core::messages::ScannerMutexReason::ScannerStoppedForRecording => {
                     scanner_panel.master_switch.set_state(false);
                     clear_scanner_active_channel_ui(scanner_panel, state);
                     "Scanner stopped — recording started"
-                }
-                sdr_core::messages::ScannerMutexReason::ScannerStoppedForTranscription => {
-                    scanner_panel.master_switch.set_state(false);
-                    clear_scanner_active_channel_ui(scanner_panel, state);
-                    "Scanner stopped — transcription started"
                 }
             };
             if let Some(overlay) = toast_overlay_weak.upgrade() {
@@ -6510,31 +6514,80 @@ fn connect_source_panel(
     // already has RTL-TCP + a high sample rate selected.
     apply_source_bandwidth_advisory();
 
+    // Sample rate selector. Restore-then-wire (#552).
+    {
+        let persisted_idx = sidebar::source_panel::load_source_sample_rate_index(config);
+        if (persisted_idx as usize) < SAMPLE_RATES.len() {
+            panels.source.sample_rate_row.set_selected(persisted_idx);
+            if let Some(&rate) = SAMPLE_RATES.get(persisted_idx as usize) {
+                state.send_dsp(UiToDsp::SetSampleRate(rate));
+            }
+        }
+    }
     let state_sr = Rc::clone(state);
+    let config_sr = std::sync::Arc::clone(config);
     let apply_on_sr = apply_source_bandwidth_advisory.clone();
     panels
         .source
         .sample_rate_row
         .connect_selected_notify(move |row| {
-            let idx = row.selected() as usize;
-            if let Some(&rate) = SAMPLE_RATES.get(idx) {
+            let idx = row.selected();
+            sidebar::source_panel::save_source_sample_rate_index(&config_sr, idx);
+            if let Some(&rate) = SAMPLE_RATES.get(idx as usize) {
                 state_sr.send_dsp(UiToDsp::SetSampleRate(rate));
             }
             apply_on_sr();
         });
+    // Source-type (device) selector. Restore-then-wire (#552).
+    // The restore SETs the row's selected index, which fires
+    // `connect_selected_notify` and thus re-applies the bandwidth
+    // advisory; that's intentional (it wires up the correct
+    // visibility for the persisted source type at startup). The
+    // source-type swap itself is handled by an UPSTREAM
+    // `connect_selected_notify` (around the per-source-type
+    // visibility block); this handler only wires the persistence
+    // save + bandwidth-advisory refresh. The dedicated swap
+    // dispatch lives at the end of `connect_source_panel`.
+    {
+        let persisted_idx = sidebar::source_panel::load_source_device_index(config);
+        // Bound check via `DEVICE_RTLTCP` (the highest valid
+        // index) — fails closed if a stale config carries an
+        // out-of-range value (e.g. a future build added more
+        // source types and the user rolled back).
+        if persisted_idx <= sidebar::source_panel::DEVICE_RTLTCP {
+            panels.source.device_row.set_selected(persisted_idx);
+        }
+    }
+    let config_device = std::sync::Arc::clone(config);
     let apply_on_device = apply_source_bandwidth_advisory;
     panels
         .source
         .device_row
-        .connect_selected_notify(move |_| apply_on_device());
+        .connect_selected_notify(move |row| {
+            sidebar::source_panel::save_source_device_index(&config_device, row.selected());
+            apply_on_device();
+        });
 
-    // DC blocking toggle
+    // DC blocking toggle. Restore-then-wire (#552). Same idiom
+    // as bias-T / gain / PPM: programmatic `set_active` fires
+    // `connect_active_notify`, which would re-save the loaded
+    // value AND re-dispatch `SetDcBlocking` — both cheap, but
+    // the duplicate dispatch in tracing logs is misleading. So
+    // restore first, then wire.
+    {
+        let persisted = sidebar::source_panel::load_source_dc_blocking(config);
+        panels.source.dc_blocking_row.set_active(persisted);
+        state.send_dsp(UiToDsp::SetDcBlocking(persisted));
+    }
     let state_dc_block = Rc::clone(state);
+    let config_dc_block = std::sync::Arc::clone(config);
     panels
         .source
         .dc_blocking_row
         .connect_active_notify(move |row| {
-            state_dc_block.send_dsp(UiToDsp::SetDcBlocking(row.is_active()));
+            let enabled = row.is_active();
+            sidebar::source_panel::save_source_dc_blocking(&config_dc_block, enabled);
+            state_dc_block.send_dsp(UiToDsp::SetDcBlocking(enabled));
         });
 
     // Bias-T toggle (#537). Powers an inline LNA over the
@@ -6569,23 +6622,46 @@ fn connect_source_panel(
             state_bias_tee.send_dsp(UiToDsp::SetBiasTee(enabled));
         });
 
-    // IQ inversion toggle
+    // IQ inversion toggle. Restore-then-wire (#552).
+    {
+        let persisted = sidebar::source_panel::load_source_iq_inversion(config);
+        panels.source.iq_inversion_row.set_active(persisted);
+        state.send_dsp(UiToDsp::SetIqInversion(persisted));
+    }
     let state_iq_inv = Rc::clone(state);
+    let config_iq_inv = std::sync::Arc::clone(config);
     panels
         .source
         .iq_inversion_row
         .connect_active_notify(move |row| {
-            state_iq_inv.send_dsp(UiToDsp::SetIqInversion(row.is_active()));
+            let enabled = row.is_active();
+            sidebar::source_panel::save_source_iq_inversion(&config_iq_inv, enabled);
+            state_iq_inv.send_dsp(UiToDsp::SetIqInversion(enabled));
         });
 
-    // Decimation selector
+    // Decimation selector. Restore-then-wire (#552). The
+    // decimation index also feeds the bandwidth-advisory
+    // recompute via `apply_source_bandwidth_advisory`, so
+    // restoring here BEFORE wiring keeps the advisory pristine
+    // on first launch.
+    {
+        let persisted_idx = sidebar::source_panel::load_source_decimation_index(config);
+        if (persisted_idx as usize) < DECIMATION_FACTORS.len() {
+            panels.source.decimation_row.set_selected(persisted_idx);
+            if let Some(&factor) = DECIMATION_FACTORS.get(persisted_idx as usize) {
+                state.send_dsp(UiToDsp::SetDecimation(factor));
+            }
+        }
+    }
     let state_decim = Rc::clone(state);
+    let config_decim = std::sync::Arc::clone(config);
     panels
         .source
         .decimation_row
         .connect_selected_notify(move |row| {
-            let idx = row.selected() as usize;
-            if let Some(&factor) = DECIMATION_FACTORS.get(idx) {
+            let idx = row.selected();
+            sidebar::source_panel::save_source_decimation_index(&config_decim, idx);
+            if let Some(&factor) = DECIMATION_FACTORS.get(idx as usize) {
                 state_decim.send_dsp(UiToDsp::SetDecimation(factor));
             }
         });
@@ -6874,13 +6950,21 @@ fn connect_source_panel(
         });
     }
 
-    // IQ correction toggle
+    // IQ correction toggle. Restore-then-wire (#552).
+    {
+        let persisted = sidebar::source_panel::load_source_iq_correction(config);
+        panels.source.iq_correction_row.set_active(persisted);
+        state.send_dsp(UiToDsp::SetIqCorrection(persisted));
+    }
     let state_iq_corr = Rc::clone(state);
+    let config_iq_corr = std::sync::Arc::clone(config);
     panels
         .source
         .iq_correction_row
         .connect_active_notify(move |row| {
-            state_iq_corr.send_dsp(UiToDsp::SetIqCorrection(row.is_active()));
+            let enabled = row.is_active();
+            sidebar::source_panel::save_source_iq_correction(&config_iq_corr, enabled);
+            state_iq_corr.send_dsp(UiToDsp::SetIqCorrection(enabled));
         });
 
     // PPM correction. Restore persisted value before wiring
@@ -6971,8 +7055,42 @@ fn connect_source_panel(
             state_source.send_dsp(UiToDsp::SetSourceType(source_type));
         });
 
+    // Raw-Network source config (hostname / port / protocol).
+    // Restore all three widgets atomically BEFORE wiring the
+    // change-notify handlers, then dispatch one
+    // `SetNetworkConfig` with the loaded values so Play picks up
+    // the right destination on first launch. Per #552. (rtl_tcp
+    // client maintains its own per-server hostname/port via the
+    // favorites list — these keys are for the raw IQ-stream
+    // Network source only; on a launch where the user was last
+    // on rtl_tcp the favorites system also restores its own
+    // hostname/port and the two are independent.)
+    {
+        let hostname = sidebar::source_panel::load_source_network_hostname(config);
+        let port = sidebar::source_panel::load_source_network_port(config);
+        let protocol_idx = sidebar::source_panel::load_source_network_protocol_index(config);
+        panels.source.hostname_row.set_text(&hostname);
+        panels.source.port_row.set_value(f64::from(port));
+        if protocol_idx == NETWORK_PROTOCOL_UDP_IDX
+            || protocol_idx == NETWORK_PROTOCOL_TCPCLIENT_IDX
+        {
+            panels.source.protocol_row.set_selected(protocol_idx);
+        }
+        let protocol = if protocol_idx == NETWORK_PROTOCOL_UDP_IDX {
+            sdr_types::Protocol::Udp
+        } else {
+            sdr_types::Protocol::TcpClient
+        };
+        state.send_dsp(UiToDsp::SetNetworkConfig {
+            hostname,
+            port,
+            protocol,
+        });
+    }
+
     // Network hostname — send on every edit so Play always has current value
     let state_host = Rc::clone(state);
+    let config_host = std::sync::Arc::clone(config);
     let port_for_host = panels.source.port_row.clone();
     let proto_for_host = panels.source.protocol_row.clone();
     let hostname_for_host = panels.source.hostname_row.clone();
@@ -6991,6 +7109,7 @@ fn connect_source_panel(
             &auth_key_for_host,
         );
         let hostname = row.text().to_string();
+        sidebar::source_panel::save_source_network_hostname(&config_host, &hostname);
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = port_for_host.value() as u16;
         let protocol = if proto_for_host.selected() == NETWORK_PROTOCOL_UDP_IDX {
@@ -7007,6 +7126,7 @@ fn connect_source_panel(
 
     // Network port
     let state_port = Rc::clone(state);
+    let config_port = std::sync::Arc::clone(config);
     let host_for_port = panels.source.hostname_row.clone();
     let proto_for_port = panels.source.protocol_row.clone();
     let port_row_for_port = panels.source.port_row.clone();
@@ -7021,6 +7141,7 @@ fn connect_source_panel(
         let hostname = host_for_port.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = row.value() as u16;
+        sidebar::source_panel::save_source_network_port(&config_port, port);
         let protocol = if proto_for_port.selected() == NETWORK_PROTOCOL_UDP_IDX {
             sdr_types::Protocol::Udp
         } else {
@@ -7035,6 +7156,7 @@ fn connect_source_panel(
 
     // Network protocol
     let state_proto = Rc::clone(state);
+    let config_proto = std::sync::Arc::clone(config);
     let host_for_proto = panels.source.hostname_row.clone();
     let port_for_proto = panels.source.port_row.clone();
     panels
@@ -7044,7 +7166,9 @@ fn connect_source_panel(
             let hostname = host_for_proto.text().to_string();
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let port = port_for_proto.value() as u16;
-            let protocol = match row.selected() {
+            let selected = row.selected();
+            sidebar::source_panel::save_source_network_protocol_index(&config_proto, selected);
+            let protocol = match selected {
                 NETWORK_PROTOCOL_TCPCLIENT_IDX => sdr_types::Protocol::TcpClient,
                 NETWORK_PROTOCOL_UDP_IDX => sdr_types::Protocol::Udp,
                 _ => return, // ignore transient indices
@@ -7276,11 +7400,21 @@ fn connect_source_panel(
             });
         });
 
-    // File path — send on every edit so Play always has current value
+    // File path — send on every edit so Play always has current
+    // value. Restore-then-wire (#552). Empty saved string is the
+    // default and means "no file selected" — re-set the widget
+    // to empty too so the placeholder stays correct.
+    {
+        let persisted = sidebar::source_panel::load_source_file_path(config);
+        panels.source.file_path_row.set_text(&persisted);
+        state.send_dsp(UiToDsp::SetFilePath(std::path::PathBuf::from(&persisted)));
+    }
     let state_file = Rc::clone(state);
+    let config_file = std::sync::Arc::clone(config);
     panels.source.file_path_row.connect_changed(move |row| {
-        let path = std::path::PathBuf::from(row.text().to_string());
-        state_file.send_dsp(UiToDsp::SetFilePath(path));
+        let text = row.text().to_string();
+        sidebar::source_panel::save_source_file_path(&config_file, &text);
+        state_file.send_dsp(UiToDsp::SetFilePath(std::path::PathBuf::from(text)));
     });
 
     // IQ recording toggle
@@ -10670,6 +10804,11 @@ fn connect_transcript_panel(
                         auto_break_min_segment_row_weak.clone();
                     #[cfg(feature = "sherpa")]
                     let live_line_weak = live_line_weak.clone();
+                    // State handle for the lazy channel-marker
+                    // emission (#517) — the closure consumes
+                    // `state_clone.pending_channel_marker` from
+                    // the `TranscriptionEvent::Text` arm below.
+                    let state_for_marker = Rc::clone(&state_clone);
 
                     glib::timeout_add_local(Duration::from_millis(100), move || {
                         // Upgrade once per tick. If any widget has been
@@ -10759,6 +10898,25 @@ fn connect_transcript_panel(
                                         }
                                     }
                                     TranscriptionEvent::Text { timestamp, text } => {
+                                        // Drain the pending channel-marker
+                                        // (#517) BEFORE inserting the
+                                        // transcribed text — the marker
+                                        // belongs ABOVE the text it
+                                        // precedes. Lazy emission means
+                                        // markers only land when there's
+                                        // actual audio to attribute, so
+                                        // a quiet channel never produces
+                                        // a divider.
+                                        if let Some(channel_name) = state_for_marker
+                                            .pending_channel_marker
+                                            .borrow_mut()
+                                            .take()
+                                        {
+                                            sidebar::transcript_panel::push_channel_marker(
+                                                &tv,
+                                                &channel_name,
+                                            );
+                                        }
                                         let buf = tv.buffer();
                                         let mut end = buf.end_iter();
                                         buf.insert(&mut end, &format!("[{timestamp}] {text}\n"));

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -444,7 +444,18 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     );
 
     // On window close, signal the worker to stop without blocking.
+    // Tracing line + backtrace on entry so we can pinpoint the
+    // cascade when the close was unexpected (a recent user report
+    // had the entire app exit after auto-record LOS — only the
+    // viewer should have closed). Backtrace is `Backtrace::capture`
+    // so it costs nothing unless `RUST_BACKTRACE=1` is set. Per
+    // PR #558 auto-record-close investigation.
     window.connect_close_request(move |_| {
+        let bt = std::backtrace::Backtrace::capture();
+        tracing::info!(
+            backtrace = ?bt,
+            "main window close-request fired",
+        );
         transcription_engine.borrow_mut().shutdown_nonblocking();
         glib::Propagation::Proceed
     });
@@ -7187,12 +7198,28 @@ fn connect_source_panel(
         // `apply_rtl_tcp_connect`'s programmatic writes when
         // those match the cache). Per CodeRabbit round 4 on
         // PR #408.
-        invalidate_rtl_tcp_active_server_on_edit(
-            &state_host,
-            &hostname_for_host,
-            &port_for_host,
-            &auth_key_for_host,
-        );
+        //
+        // Skip the invalidation during RTL-TCP hydration: the
+        // startup hydration in `connect_rtl_tcp_discovery`
+        // rewrites this row from the last-connected RTL-TCP
+        // server (only when the persisted source type is
+        // RTL-TCP), and `apply_rtl_tcp_connect` writes the
+        // cache *after* the row writes — so an unguarded
+        // invalidate would clear the cache the hydration just
+        // restored AND blank the auth row before the auth-row
+        // handler had a chance to push the saved key. The
+        // `apply_rtl_tcp_connect` path handles cache and auth
+        // row deterministically itself; we just need to stay
+        // out of its way here. Per `CodeRabbit` round 3 on PR
+        // #558.
+        if !state_host.rtl_tcp_hydration_in_progress.get() {
+            invalidate_rtl_tcp_active_server_on_edit(
+                &state_host,
+                &hostname_for_host,
+                &port_for_host,
+                &auth_key_for_host,
+            );
+        }
         let hostname = row.text().to_string();
         // Skip the raw-Network disk-write when this change came
         // from an RTL-TCP hydration. The user's independent
@@ -7234,12 +7261,17 @@ fn connect_source_panel(
     let port_row_for_port = panels.source.port_row.clone();
     let auth_key_for_port = panels.source.rtl_tcp_auth_key_row.clone();
     panels.source.port_row.connect_value_notify(move |row| {
-        invalidate_rtl_tcp_active_server_on_edit(
-            &state_port,
-            &host_for_port,
-            &port_row_for_port,
-            &auth_key_for_port,
-        );
+        // Skip the invalidation during RTL-TCP hydration; see
+        // hostname handler above for the rationale. Per
+        // `CodeRabbit` round 3 on PR #558.
+        if !state_port.rtl_tcp_hydration_in_progress.get() {
+            invalidate_rtl_tcp_active_server_on_edit(
+                &state_port,
+                &host_for_port,
+                &port_row_for_port,
+                &auth_key_for_port,
+            );
+        }
         let hostname = host_for_port.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = row.value() as u16;
@@ -7279,17 +7311,22 @@ fn connect_source_panel(
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let port = port_for_proto.value() as u16;
             let selected = row.selected();
-            // Skip the raw-Network disk-write during RTL-TCP
-            // hydration; see hostname handler above. Per
-            // CodeRabbit round 1 on PR #558.
-            if !state_proto.rtl_tcp_hydration_in_progress.get() {
-                sidebar::source_panel::save_source_network_protocol_index(&config_proto, selected);
-            }
+            // Validate the selected index BEFORE persisting so a
+            // transient out-of-range value during widget churn
+            // can't land in config (matches the sample-rate /
+            // device / decimation handlers' early-return pattern).
+            // Per `CodeRabbit` round 3 on PR #558.
             let protocol = match selected {
                 NETWORK_PROTOCOL_TCPCLIENT_IDX => sdr_types::Protocol::TcpClient,
                 NETWORK_PROTOCOL_UDP_IDX => sdr_types::Protocol::Udp,
                 _ => return, // ignore transient indices
             };
+            // Skip the raw-Network disk-write during RTL-TCP
+            // hydration; see hostname handler above. Per
+            // `CodeRabbit` round 1 on PR #558.
+            if !state_proto.rtl_tcp_hydration_in_progress.get() {
+                sidebar::source_panel::save_source_network_protocol_index(&config_proto, selected);
+            }
             // Suppress per-edit dispatch during hydration; see
             // hostname handler above. Per `CodeRabbit` round 2 on
             // PR #558.
@@ -9724,6 +9761,7 @@ fn connect_satellites_panel(
                         .as_ref()
                         .and_then(glib::WeakRef::upgrade)
                 {
+                    tracing::info!("auto-record LOS: closing APT viewer window after PNG save");
                     window.close();
                 }
             }
@@ -9910,6 +9948,9 @@ fn connect_satellites_panel(
                             .as_ref()
                             .and_then(glib::WeakRef::upgrade)
                     {
+                        tracing::info!(
+                            "auto-record LOS: closing LRPT viewer window after PNG save"
+                        );
                         window.close();
                     }
                 });

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3267,6 +3267,20 @@ fn connect_rtl_tcp_discovery(
         hostname_row.set_text(&last.host);
         port_row.set_value(f64::from(last.port));
         state.rtl_tcp_hydration_in_progress.set(false);
+        // Emit the canonical `SetNetworkConfig` for the restored
+        // RTL-TCP endpoint *after* the flag clears, mirroring
+        // `apply_rtl_tcp_connect`'s own post-hydration dispatch.
+        // Without this, the only `SetNetworkConfig` the DSP saw
+        // came from `connect_source_panel`'s raw-Network restore
+        // a moment earlier — so first Play on a persisted
+        // RTL-TCP session would dial the stale raw-Network
+        // endpoint until the user nudged a row by hand. Per
+        // `CodeRabbit` round 4 on PR #558.
+        state.send_dsp(UiToDsp::SetNetworkConfig {
+            hostname: last.host.clone(),
+            port: last.port,
+            protocol: sdr_types::Protocol::TcpClient,
+        });
     }
 
     // Poll the discovery channel from the main thread. Cheap enough

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -50,8 +50,7 @@ use crate::sidebar::display_panel::FFT_SIZES;
 #[cfg(feature = "sherpa")]
 use crate::sidebar::transcript_panel::DISPLAY_MODE_FINAL_IDX;
 
-/// Decimation factors available in the source panel dropdown (must match panel order).
-const DECIMATION_FACTORS: &[u32] = &[1, 2, 4, 8, 16];
+use crate::sidebar::source_panel::DECIMATION_FACTORS;
 
 /// Interval in milliseconds for polling the DSP→UI channel.
 const DSP_POLL_INTERVAL_MS: u64 = 16;
@@ -911,6 +910,13 @@ fn clear_scanner_active_channel_ui(
     state: &AppState,
 ) {
     *state.scanner_active_key.borrow_mut() = None;
+    // Drop any buffered channel-marker hop so the next transcript
+    // text doesn't inherit a divider from a channel that's no
+    // longer active. Reaches every stop path that funnels through
+    // this helper (`ScannerActiveChannelChanged { key: None }`,
+    // `ScannerEmptyRotation`, `ScannerMutexStopped`). Per
+    // CodeRabbit round 1 on PR #558.
+    *state.pending_channel_marker.borrow_mut() = None;
     scanner_panel
         .active_channel_row
         .set_subtitle(sidebar::scanner_panel::ACTIVE_CHANNEL_PLACEHOLDER);
@@ -1245,19 +1251,25 @@ fn handle_dsp_message(
             // before the widget sync below so a racing user click
             // during this frame sees the latest key.
             state.scanner_active_key.borrow_mut().clone_from(&key);
-            // Buffer the channel name for lazy marker emission.
-            // The transcription text-event handler will consume
-            // this when the next transcribed line arrives — that
-            // way markers only appear when there's actual audio
-            // to attribute. If the scanner hops past a quiet
+            // Buffer the channel name + hop time for lazy marker
+            // emission. The transcription text-event handler will
+            // consume this when the next transcribed line arrives
+            // — that way markers only appear when there's actual
+            // audio to attribute. If the scanner hops past a quiet
             // channel before any text fires, the next channel's
             // name overwrites the buffer and the silent channel
             // never gets a marker. If transcription is off, no
-            // text events fire at all, so the buffered name
-            // simply stays unconsumed (gets overwritten on each
-            // hop) and no markers ever appear in the panel.
-            // Per issue #517 + initial-smoke feedback on PR #558.
-            *state.pending_channel_marker.borrow_mut() = key.as_ref().map(|_| name.clone());
+            // text events fire at all, so the buffered hop simply
+            // stays unconsumed (gets overwritten on each hop) and
+            // no markers ever appear in the panel. The hop time
+            // is captured here (`chrono::Local::now()`) — not at
+            // render time — so the marker reflects when the
+            // scanner actually switched, even if the transcription
+            // backend lags by a few seconds. Per issue #517 +
+            // initial-smoke feedback on PR #558 + CodeRabbit
+            // round 1 on PR #558.
+            *state.pending_channel_marker.borrow_mut() =
+                key.as_ref().map(|_| (chrono::Local::now(), name.clone()));
             if key.is_some() {
                 // Update the cached tuning state so downstream
                 // reads (bandwidth notify's status-bar rewrite,
@@ -3216,9 +3228,17 @@ fn connect_rtl_tcp_discovery(
     // first tick. Pinning TCP first keeps the restore both silent
     // to the user and correct end-to-end.
     if let Some(last) = crate::sidebar::source_panel::load_last_connected(&config_for_discovery) {
+        // Same guarded-rewrite idiom as `apply_rtl_tcp_connect`:
+        // hydrating the last-connected RTL-TCP server must not
+        // overwrite `KEY_SOURCE_NETWORK_*` (the raw-Network
+        // triple). The persistence handlers for those rows
+        // observe the flag and skip the disk-write. Per
+        // CodeRabbit round 1 on PR #558.
+        state.rtl_tcp_hydration_in_progress.set(true);
         protocol_row.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
         hostname_row.set_text(&last.host);
         port_row.set_value(f64::from(last.port));
+        state.rtl_tcp_hydration_in_progress.set(false);
     }
 
     // Poll the discovery channel from the main thread. Cheap enough
@@ -3766,9 +3786,18 @@ fn apply_rtl_tcp_connect(
     };
 
     let already_rtl_tcp = device_row.selected() == DEVICE_RTLTCP;
+    // Guard the programmatic row rewrites so the persistence
+    // handlers don't clobber `KEY_SOURCE_NETWORK_*` (which
+    // belong to the user's independent raw-Network selection)
+    // with the RTL-TCP endpoint. The handlers still dispatch
+    // `SetNetworkConfig` so the running session re-points; only
+    // the disk-write is skipped. Per CodeRabbit round 1 on PR
+    // #558.
+    state.rtl_tcp_hydration_in_progress.set(true);
     protocol_row.set_selected(NETWORK_PROTOCOL_TCPCLIENT_IDX);
     hostname_row.set_text(host);
     port_row.set_value(f64::from(port));
+    state.rtl_tcp_hydration_in_progress.set(false);
     // Restore saved per-server state (#396) BEFORE the
     // `SetNetworkConfig` / `SetSourceType` dispatch so the DSP
     // thread's first use of the new endpoint already carries the
@@ -6532,10 +6561,18 @@ fn connect_source_panel(
         .sample_rate_row
         .connect_selected_notify(move |row| {
             let idx = row.selected();
+            // Validate before persisting. GTK can briefly emit
+            // out-of-range values during widget-model churn (e.g.
+            // teardown / rebuild on style changes); persisting
+            // those would corrupt the config file across restart.
+            // Mirror the protocol_row pattern further down: bail
+            // when the index doesn't map to a real sample rate.
+            // Per CodeRabbit round 1 on PR #558.
+            let Some(&rate) = SAMPLE_RATES.get(idx as usize) else {
+                return;
+            };
             sidebar::source_panel::save_source_sample_rate_index(&config_sr, idx);
-            if let Some(&rate) = SAMPLE_RATES.get(idx as usize) {
-                state_sr.send_dsp(UiToDsp::SetSampleRate(rate));
-            }
+            state_sr.send_dsp(UiToDsp::SetSampleRate(rate));
             apply_on_sr();
         });
     // Source-type (device) selector. Restore-then-wire (#552).
@@ -6556,6 +6593,25 @@ fn connect_source_panel(
         // source types and the user rolled back).
         if persisted_idx <= sidebar::source_panel::DEVICE_RTLTCP {
             panels.source.device_row.set_selected(persisted_idx);
+            // Dispatch the restored source type to the DSP so a
+            // saved Network / File / RTL-TCP selection takes
+            // effect at startup. The change-notify handler that
+            // dispatches `SetSourceType` from user clicks is
+            // wired AFTER this restore block runs, and even if it
+            // were wired first, programmatic `set_selected` to a
+            // value that already matches the row's default (0 =
+            // RTL-SDR) wouldn't fire it. Explicit dispatch closes
+            // both gaps. Per CodeRabbit round 1 on PR #558.
+            let source_type = match persisted_idx {
+                sidebar::source_panel::DEVICE_RTLSDR => Some(SourceType::RtlSdr),
+                sidebar::source_panel::DEVICE_NETWORK => Some(SourceType::Network),
+                sidebar::source_panel::DEVICE_FILE => Some(SourceType::File),
+                sidebar::source_panel::DEVICE_RTLTCP => Some(SourceType::RtlTcp),
+                _ => None,
+            };
+            if let Some(source_type) = source_type {
+                state.send_dsp(UiToDsp::SetSourceType(source_type));
+            }
         }
     }
     let config_device = std::sync::Arc::clone(config);
@@ -6564,7 +6620,15 @@ fn connect_source_panel(
         .source
         .device_row
         .connect_selected_notify(move |row| {
-            sidebar::source_panel::save_source_device_index(&config_device, row.selected());
+            let idx = row.selected();
+            // Validate before persisting (same rationale as the
+            // sample-rate row above). `DEVICE_RTLTCP` is the
+            // highest valid index. Per CodeRabbit round 1 on
+            // PR #558.
+            if idx > sidebar::source_panel::DEVICE_RTLTCP {
+                return;
+            }
+            sidebar::source_panel::save_source_device_index(&config_device, idx);
             apply_on_device();
         });
 
@@ -6660,10 +6724,14 @@ fn connect_source_panel(
         .decimation_row
         .connect_selected_notify(move |row| {
             let idx = row.selected();
+            // Validate before persisting (same rationale as the
+            // sample-rate row above). Per CodeRabbit round 1 on
+            // PR #558.
+            let Some(&factor) = DECIMATION_FACTORS.get(idx as usize) else {
+                return;
+            };
             sidebar::source_panel::save_source_decimation_index(&config_decim, idx);
-            if let Some(&factor) = DECIMATION_FACTORS.get(idx as usize) {
-                state_decim.send_dsp(UiToDsp::SetDecimation(factor));
-            }
+            state_decim.send_dsp(UiToDsp::SetDecimation(factor));
         });
 
     // Gain control. Sensitivity is gated by AGC — see the `AGC
@@ -7109,7 +7177,14 @@ fn connect_source_panel(
             &auth_key_for_host,
         );
         let hostname = row.text().to_string();
-        sidebar::source_panel::save_source_network_hostname(&config_host, &hostname);
+        // Skip the raw-Network disk-write when this change came
+        // from an RTL-TCP hydration. The user's independent
+        // raw-Network hostname stays in `KEY_SOURCE_NETWORK_*`
+        // and round-trips across restart on its own. Per
+        // CodeRabbit round 1 on PR #558.
+        if !state_host.rtl_tcp_hydration_in_progress.get() {
+            sidebar::source_panel::save_source_network_hostname(&config_host, &hostname);
+        }
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = port_for_host.value() as u16;
         let protocol = if proto_for_host.selected() == NETWORK_PROTOCOL_UDP_IDX {
@@ -7141,7 +7216,12 @@ fn connect_source_panel(
         let hostname = host_for_port.text().to_string();
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let port = row.value() as u16;
-        sidebar::source_panel::save_source_network_port(&config_port, port);
+        // Skip the raw-Network disk-write during RTL-TCP
+        // hydration; see hostname handler above. Per CodeRabbit
+        // round 1 on PR #558.
+        if !state_port.rtl_tcp_hydration_in_progress.get() {
+            sidebar::source_panel::save_source_network_port(&config_port, port);
+        }
         let protocol = if proto_for_port.selected() == NETWORK_PROTOCOL_UDP_IDX {
             sdr_types::Protocol::Udp
         } else {
@@ -7167,7 +7247,12 @@ fn connect_source_panel(
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let port = port_for_proto.value() as u16;
             let selected = row.selected();
-            sidebar::source_panel::save_source_network_protocol_index(&config_proto, selected);
+            // Skip the raw-Network disk-write during RTL-TCP
+            // hydration; see hostname handler above. Per
+            // CodeRabbit round 1 on PR #558.
+            if !state_proto.rtl_tcp_hydration_in_progress.get() {
+                sidebar::source_panel::save_source_network_protocol_index(&config_proto, selected);
+            }
             let protocol = match selected {
                 NETWORK_PROTOCOL_TCPCLIENT_IDX => sdr_types::Protocol::TcpClient,
                 NETWORK_PROTOCOL_UDP_IDX => sdr_types::Protocol::Udp,
@@ -10772,6 +10857,14 @@ fn connect_transcript_panel(
                         state_clone
                             .send_dsp(crate::messages::UiToDsp::EnableTranscription(audio_tx));
                     }
+                    // Drop any channel-marker buffered while
+                    // transcription was off — the first text
+                    // event after re-enable should attribute to
+                    // the *next* hop, not whichever channel the
+                    // scanner happened to land on during the
+                    // off period. Per CodeRabbit round 1 on PR
+                    // #558.
+                    *state_clone.pending_channel_marker.borrow_mut() = None;
 
                     status_label.set_text("Starting...");
                     status_label.set_visible(true);
@@ -10907,13 +11000,15 @@ fn connect_transcript_panel(
                                         // actual audio to attribute, so
                                         // a quiet channel never produces
                                         // a divider.
-                                        if let Some(channel_name) = state_for_marker
-                                            .pending_channel_marker
-                                            .borrow_mut()
-                                            .take()
+                                        if let Some((switched_at, channel_name)) =
+                                            state_for_marker
+                                                .pending_channel_marker
+                                                .borrow_mut()
+                                                .take()
                                         {
                                             sidebar::transcript_panel::push_channel_marker(
                                                 &tv,
+                                                switched_at,
                                                 &channel_name,
                                             );
                                         }
@@ -11105,6 +11200,11 @@ fn connect_transcript_panel(
                 &auto_break_min_segment_row.downgrade(),
             );
             state_clone.send_dsp(crate::messages::UiToDsp::DisableTranscription);
+            // Drop any pending channel-marker so a stray scanner
+            // hop that landed during the live session doesn't
+            // poison the next enable's first text event. Per
+            // CodeRabbit round 1 on PR #558.
+            *state_clone.pending_channel_marker.borrow_mut() = None;
             engine_clone.borrow_mut().shutdown_nonblocking();
             status_label.set_text("");
             status_label.set_visible(false);


### PR DESCRIPTION
## Summary

Bundles two cross-cutting features so CodeRabbit has a wider surface to diff:

- **#552** — Source-panel persistence for 9 settings (device, sample rate, decimation, DC blocking, IQ correction/inversion, network host/port/protocol, file path)
- **#517** — Lazy channel markers in the transcript pane (only emitted when transcription is on AND there is text to transcribe)
- **Scanner ↔ transcription mutex removal** (smoke discovery — the legacy protective mutex stopped the scanner whenever transcription enabled, and vice versa; the two are designed to coexist now)

Closes #552
Closes #517

## #552 — Source panel persistence

- Adds `KEY_SOURCE_*` config keys + typed `load_source_* / save_source_*` helpers in `source_panel.rs`, each with a round-trip unit test.
- `window.rs` uses the restore-then-wire idiom for every row.
- The network triple (hostname / port / protocol) restores atomically with a single `SetNetworkConfig` dispatch to avoid mid-restore reconnect storms.

## #517 — Channel markers in transcript

- `AppState.pending_channel_marker` buffers the channel name on `ScannerActiveChannelChanged`.
- `transcript_panel::push_channel_marker` is a freestanding helper that inserts an italic gray timestamped divider with a `channel_marker` `TextTag`.
- Marker is emitted **lazily** inside the `TranscriptionEvent::Text` handler — so it only appears when transcription is actually running AND there is text to transcribe. Bare channel changes with transcription off no longer pollute the buffer (smoke regression that came up before this PR).

## Scanner ↔ transcription mutex removal

- The legacy mutex pre-dated the design intent of #517 (scanner + transcription should coexist).
- Removed in both directions — `EnableTranscription` no longer stops the scanner; `SetScannerEnabled` no longer stops transcription.
- Dropped `DspToUi::TranscriptionStoppedForScanner` and `DspToUi::ScannerStoppedForTranscription`; FFI keeps numeric discriminants 1 and 3 as gaps with comments so the wire format stays stable.
- Recording ↔ scanner mutex is **preserved** (recording the same RF tap as the scanner is genuinely incompatible).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check --no-default-features --features sherpa-cpu` (mutex cross-check)
- [x] `cargo fmt --all -- --check`
- [x] Manual GTK4 smoke: source-panel values persist across restart; channel changes during scanner+transcription show italic gray dividers; bare channel changes with transcription off do **not** leave markers; scanner and transcription run together without either stopping the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source panel persists many settings with tolerant, validated restore and safe-save behavior.
  * Transcript view adds timestamped channel markers and buffers them until matching transcript text arrives.

* **Bug Fixes**
  * Scanner and transcription no longer stop each other; related mutex stop reasons removed.
  * Improved squelch-edge handling with retry logic to prevent out-of-order audio/state.

* **Other**
  * RTL‑TCP hydration avoids overwriting user edits; added extra diagnostics/logging for unexpected closes and PNG-save events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->