### PR TITLE
feat: source-panel direct sampling + offset tuning, transcription warn-flood fix (#538, #539)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -3172,9 +3172,18 @@ fn process_iq_block(
                                         // suppressed-count gets reported
                                         // alongside the next emitted
                                         // warning so the burst magnitude
-                                        // stays observable.
-                                        state.transcription_full_suppressed =
-                                            state.transcription_full_suppressed.saturating_add(1);
+                                        // stays observable. Note: the
+                                        // counter is incremented ONLY on
+                                        // the suppressed path — the event
+                                        // that actually triggers the warn
+                                        // is reported as the warn itself
+                                        // and is not added to
+                                        // `suppressed_in_window`. So
+                                        // `suppressed_in_window=0` means
+                                        // "the warn is firing for the
+                                        // first event in this window;
+                                        // nothing extra was hidden". Per
+                                        // `CodeRabbit` round 1 on PR #559.
                                         if state.transcription_full_warn_at.elapsed()
                                             >= TRANSCRIPTION_FULL_WARN_INTERVAL
                                         {
@@ -3187,6 +3196,10 @@ fn process_iq_block(
                                             state.transcription_full_suppressed = 0;
                                             state.transcription_full_warn_at =
                                                 std::time::Instant::now();
+                                        } else {
+                                            state.transcription_full_suppressed = state
+                                                .transcription_full_suppressed
+                                                .saturating_add(1);
                                         }
                                     }
                                 }

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -54,6 +54,16 @@ const DEFAULT_FFT_SIZE: usize = 2048;
 /// number in either place.
 const DIAG_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Minimum interval between successive
+/// "transcription channel full; retrying squelch edge next block"
+/// warnings. Without throttling, the warning fires on every DSP
+/// block the edge stays pending — at typical block cadence
+/// that's 100+ lines/sec for as long as the worker is decoding,
+/// which buries the rest of the trace log. The suppressed-count
+/// is reported alongside the next emitted warning so the
+/// operator can see the burst magnitude without the line spam.
+const TRANSCRIPTION_FULL_WARN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Default FFT display rate in FPS (matches SDR++ default of 20).
 /// Lower rate reduces Mesa GL driver memory pressure from per-frame
 /// buffer uploads.
@@ -406,6 +416,23 @@ struct DspState {
     /// Next wall-clock deadline for the periodic diagnostic log.
     diag_log_at: std::time::Instant,
 
+    /// Last wall-clock instant we emitted the
+    /// "transcription channel full; retrying squelch edge next
+    /// block" warning. Used to throttle the warning to one per
+    /// `TRANSCRIPTION_FULL_WARN_INTERVAL` window — without this,
+    /// a backed-up worker (sherpa Moonshine inference taking 1–2
+    /// seconds, Whisper taking 5+) would log on every DSP block
+    /// the edge stays pending, drowning the rest of the trace
+    /// log at 100+ lines/sec. Per FYI-flood reported during PR
+    /// for issues #538 / #539.
+    transcription_full_warn_at: std::time::Instant,
+    /// Count of warnings suppressed by the throttle since the
+    /// last emitted warning. Logged alongside the next warn so
+    /// the operator can see how bad the backpressure burst was
+    /// rather than "one per second forever" obscuring the
+    /// magnitude.
+    transcription_full_suppressed: u32,
+
     /// Last observed voice-squelch open state. Mirrors the CTCSS
     /// tracker pattern — we only emit edge events, and the UI
     /// status indicator subscribes to those. The initial value
@@ -582,6 +609,8 @@ impl DspState {
             audio_frames_written: 0,
             iq_samples_read: 0,
             diag_log_at: std::time::Instant::now(),
+            transcription_full_warn_at: std::time::Instant::now(),
+            transcription_full_suppressed: 0,
             last_rtl_tcp_state: RtlTcpConnectionState::Disconnected,
             rtl_tcp_poll_at: std::time::Instant::now(),
             scanner: sdr_scanner::Scanner::new(),
@@ -3134,10 +3163,31 @@ fn process_iq_block(
                                         // next audio block instead of silently
                                         // dropping it.
                                         advance_transcription_tracker = false;
-                                        tracing::warn!(
-                                            ?now_open,
-                                            "transcription channel full; retrying squelch edge next block"
-                                        );
+                                        // Throttle the warning to one per
+                                        // `TRANSCRIPTION_FULL_WARN_INTERVAL`
+                                        // window — a backed-up worker can
+                                        // hold this edge pending for many
+                                        // blocks, and an unthrottled warn
+                                        // floods the trace log. The
+                                        // suppressed-count gets reported
+                                        // alongside the next emitted
+                                        // warning so the burst magnitude
+                                        // stays observable.
+                                        state.transcription_full_suppressed =
+                                            state.transcription_full_suppressed.saturating_add(1);
+                                        if state.transcription_full_warn_at.elapsed()
+                                            >= TRANSCRIPTION_FULL_WARN_INTERVAL
+                                        {
+                                            let suppressed = state.transcription_full_suppressed;
+                                            tracing::warn!(
+                                                ?now_open,
+                                                suppressed_in_window = suppressed,
+                                                "transcription channel full; retrying squelch edge next block"
+                                            );
+                                            state.transcription_full_suppressed = 0;
+                                            state.transcription_full_warn_at =
+                                                std::time::Instant::now();
+                                        }
                                     }
                                 }
                             }

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -444,6 +444,38 @@ impl Source for RtlSdrSource {
         }
         Ok(())
     }
+
+    fn set_direct_sampling(&mut self, mode: i32) -> Result<(), SourceError> {
+        // Routes through `rtlsdr_set_direct_sampling`. Mode 0
+        // disables direct sampling (normal tuner path); 1 selects
+        // the I branch and 2 selects the Q branch — both bypass
+        // the tuner entirely and feed the ADC straight from the
+        // antenna input, which is how RTL-SDR Blog v3+ dongles
+        // tune below 28 MHz (the R820T tuner cuts off there).
+        // Most users want Q branch on a v3 dongle. Per issue
+        // #538.
+        if let Some(device) = &mut self.device {
+            device
+                .set_direct_sampling(mode)
+                .map_err(|e| SourceError::TuneFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn set_offset_tuning(&mut self, enabled: bool) -> Result<(), SourceError> {
+        // Routes through `rtlsdr_set_offset_tuning`. Pushes the
+        // local oscillator off the tuned frequency so the DC
+        // spike that lives at the LO doesn't sit on top of the
+        // signal of interest. Most relevant on E4000 tuners; on
+        // R820T / R820T2 the driver returns Ok but the operation
+        // is a no-op in hardware. Per issue #539.
+        if let Some(device) = &mut self.device {
+            device
+                .set_offset_tuning(enabled)
+                .map_err(|e| SourceError::TuneFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -454,6 +454,22 @@ impl Source for RtlSdrSource {
         // tune below 28 MHz (the R820T tuner cuts off there).
         // Most users want Q branch on a v3 dongle. Per issue
         // #538.
+        //
+        // Defense-in-depth boundary check: the UI handler in
+        // `connect_source_panel` already validates the combo
+        // index against `DIRECT_SAMPLING_MAX_IDX` and the
+        // persistence loader range-clamps before dispatch, but
+        // any future caller (FFI consumer, scripted DSP test,
+        // etc.) could still wire a malformed `mode` here. Reject
+        // out-of-range values with a clear error rather than
+        // forwarding to the driver, which would either silently
+        // misbehave or surface a confusing low-level error. Per
+        // `CodeRabbit` round 1 on PR #559.
+        if !(0..=2).contains(&mode) {
+            return Err(SourceError::TuneFailed(format!(
+                "invalid direct sampling mode: {mode} (expected 0..=2)"
+            )));
+        }
         if let Some(device) = &mut self.device {
             device
                 .set_direct_sampling(mode)
@@ -467,8 +483,15 @@ impl Source for RtlSdrSource {
         // local oscillator off the tuned frequency so the DC
         // spike that lives at the LO doesn't sit on top of the
         // signal of interest. Most relevant on E4000 tuners; on
-        // R820T / R820T2 the driver returns Ok but the operation
-        // is a no-op in hardware. Per issue #539.
+        // R820T / R828D the driver in
+        // `crates/sdr-rtlsdr/src/device/frequency.rs` returns
+        // `InvalidParameter` ("offset tuning not supported for
+        // R82XX tuners"), and the call is also rejected while
+        // direct sampling is enabled. We surface either rejection
+        // as a `TuneFailed` toast rather than crashing — the user
+        // sees a clear "your tuner doesn't support this" message
+        // instead of a no-op. Per issue #539 + `CodeRabbit`
+        // round 1 on PR #559.
         if let Some(device) = &mut self.device {
             device
                 .set_offset_tuning(enabled)

--- a/crates/sdr-transcription/src/backends/sherpa/host.rs
+++ b/crates/sdr-transcription/src/backends/sherpa/host.rs
@@ -16,7 +16,18 @@ use crate::init_event::InitEvent;
 use crate::sherpa_model::{self, SherpaModel};
 
 /// Bounded channel capacity for audio buffers from DSP → backend.
-pub(super) const AUDIO_CHANNEL_CAPACITY: usize = 256;
+///
+/// Sized to absorb a worst-case worker stall — sherpa Moonshine
+/// inference can take 1–2 seconds on a single utterance, and at
+/// typical NFM block cadence that's hundreds of audio chunks
+/// queued behind the worker. The previous `256` slot ceiling
+/// filled inside one decode and surfaced as a flood of
+/// `transcription channel full; retrying squelch edge next
+/// block` warns; `1024` gives enough headroom that a normal
+/// worker pause doesn't spam the log even when the warn is
+/// throttled. Per FYI-flood reported during PR for issues
+/// #538 / #539.
+pub(super) const AUDIO_CHANNEL_CAPACITY: usize = 1024;
 
 /// Polling interval for the audio receive loop when checking for cancellation.
 pub(super) const AUDIO_RECV_TIMEOUT: Duration = Duration::from_millis(100);

--- a/crates/sdr-transcription/src/backends/whisper.rs
+++ b/crates/sdr-transcription/src/backends/whisper.rs
@@ -20,10 +20,18 @@ use crate::vad::VoiceActivityDetector;
 use crate::{denoise, model, resampler};
 
 /// Bounded channel capacity for audio buffers from DSP → backend.
-/// Each buffer is ~1024-4096 stereo samples (~20-80 ms). At 48 kHz with
-/// 5-second inference chunks, we need ~250 buffers to avoid drops during
-/// a single inference pass. 512 gives comfortable headroom.
-const AUDIO_CHANNEL_CAPACITY: usize = 512;
+/// Each buffer is ~1024-4096 stereo samples (~20-80 ms). At
+/// 48 kHz with 5-second inference chunks, we need ~250 buffers
+/// to avoid drops during a single inference pass; whisper
+/// inference can extend to several seconds on slower CPUs and
+/// CUDA-busy systems, and the previous `512` ceiling filled
+/// during long utterances and surfaced as a flood of
+/// `transcription channel full; retrying squelch edge next
+/// block` warns. `2048` gives enough headroom that a normal
+/// worker pause doesn't spam the log even when the warn is
+/// throttled. Per FYI-flood reported during PR for issues
+/// #538 / #539.
+const AUDIO_CHANNEL_CAPACITY: usize = 2048;
 
 /// Seconds of audio per transcription chunk.
 const CHUNK_SECONDS: usize = 5;

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -660,6 +660,67 @@ fn build_common_rows() -> (
     )
 }
 
+/// Apply the per-device visibility policy to every row whose
+/// visibility depends on the selected source type. Single source
+/// of truth for the policy — both [`build_source_panel`]'s
+/// initial render block AND [`connect_device_visibility`]'s
+/// `connect_selected_notify` handler call this so they can never
+/// drift as rows evolve. Per `CodeRabbit` round 1 on PR #559.
+///
+/// Policy:
+/// - **Tune controls** (sample rate, gain, AGC, PPM): visible
+///   for local RTL-SDR USB AND remote `rtl_tcp` — both route
+///   through the `Source` trait's `set_gain` / `set_gain_mode` /
+///   `set_ppm_correction` hooks, and `RtlTcpSource` forwards
+///   them as wire commands.
+/// - **Bias tee, direct sampling, offset tuning**: visible only
+///   for local RTL-SDR USB. The `rtl_tcp` wire protocol exposes
+///   equivalents but this panel doesn't surface them today (the
+///   server-side panel has its own bias-T toggle); the `Source`
+///   trait defaults silently drop these commands on
+///   file/network sources.
+/// - **Hostname / port**: visible for raw-IQ Network AND
+///   `rtl_tcp` — both dial a host:port. **Protocol** (TCP / UDP)
+///   only applies to raw Network — `rtl_tcp` always rides on
+///   TCP.
+/// - **File path**: visible only for File source.
+#[allow(clippy::too_many_arguments)]
+fn apply_source_row_visibility(
+    selected: u32,
+    sample_rate_row: &adw::ComboRow,
+    gain_row: &adw::SpinRow,
+    agc_row: &adw::ComboRow,
+    ppm_row: &adw::SpinRow,
+    bias_tee_row: &adw::SwitchRow,
+    direct_sampling_row: &adw::ComboRow,
+    offset_tuning_row: &adw::SwitchRow,
+    hostname_row: &adw::EntryRow,
+    port_row: &adw::SpinRow,
+    protocol_row: &adw::ComboRow,
+    file_path_row: &adw::EntryRow,
+) {
+    let is_rtlsdr = selected == DEVICE_RTLSDR;
+    let is_network = selected == DEVICE_NETWORK;
+    let is_file = selected == DEVICE_FILE;
+    let is_rtltcp = selected == DEVICE_RTLTCP;
+
+    let tune_controls_visible = is_rtlsdr || is_rtltcp;
+    sample_rate_row.set_visible(tune_controls_visible);
+    gain_row.set_visible(tune_controls_visible);
+    agc_row.set_visible(tune_controls_visible);
+    ppm_row.set_visible(tune_controls_visible);
+
+    bias_tee_row.set_visible(is_rtlsdr);
+    direct_sampling_row.set_visible(is_rtlsdr);
+    offset_tuning_row.set_visible(is_rtlsdr);
+
+    hostname_row.set_visible(is_network || is_rtltcp);
+    port_row.set_visible(is_network || is_rtltcp);
+    protocol_row.set_visible(is_network);
+
+    file_path_row.set_visible(is_file);
+}
+
 /// Wire the device selector to show/hide source-specific rows.
 #[allow(clippy::too_many_arguments)]
 fn connect_device_visibility(
@@ -701,44 +762,20 @@ fn connect_device_visibility(
         file_path_row,
         move |row| {
             let selected = row.selected();
-            let is_rtlsdr = selected == DEVICE_RTLSDR;
-            let is_network = selected == DEVICE_NETWORK;
-            let is_file = selected == DEVICE_FILE;
-            let is_rtltcp = selected == DEVICE_RTLTCP;
-
-            // Tuning controls are meaningful for both the local dongle
-            // AND a remote rtl_tcp server (they route through the
-            // Source trait's set_gain / set_gain_mode / set_ppm_correction
-            // hooks, which RtlTcpSource implements by forwarding wire
-            // commands). Sample-rate row too — UiToDsp::SetSampleRate
-            // goes through Source::set_sample_rate either way.
-            let tune_controls_visible = is_rtlsdr || is_rtltcp;
-            sample_rate_row.set_visible(tune_controls_visible);
-            gain_row.set_visible(tune_controls_visible);
-            agc_row.set_visible(tune_controls_visible);
-            ppm_row.set_visible(tune_controls_visible);
-            // Bias tee is local-RTL-SDR only — see the
-            // initial-visibility block for the same gating
-            // rationale. Per issue #537.
-            bias_tee_row.set_visible(is_rtlsdr);
-            // Direct sampling + offset tuning are local-RTL-SDR-only;
-            // the rtl_tcp wire protocol exposes equivalents but
-            // we don't surface them through this panel today, and
-            // the `Source` trait's defaults silently drop the
-            // command on file/network sources. Per issues #538 /
-            // #539.
-            direct_sampling_row.set_visible(is_rtlsdr);
-            offset_tuning_row.set_visible(is_rtlsdr);
-
-            // Hostname / port entry is shared between raw-IQ Network
-            // and RTL-TCP modes. Protocol (TCP/UDP) only applies to
-            // raw Network — RTL-TCP always rides on TCP.
-            hostname_row.set_visible(is_network || is_rtltcp);
-            port_row.set_visible(is_network || is_rtltcp);
-            protocol_row.set_visible(is_network);
-
-            file_path_row.set_visible(is_file);
-
+            apply_source_row_visibility(
+                selected,
+                &sample_rate_row,
+                &gain_row,
+                &agc_row,
+                &ppm_row,
+                &bias_tee_row,
+                &direct_sampling_row,
+                &offset_tuning_row,
+                &hostname_row,
+                &port_row,
+                &protocol_row,
+                &file_path_row,
+            );
             tracing::debug!(device = selected, "source device changed");
         }
     ));
@@ -897,31 +934,32 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&rtl_tcp_auth_key_row);
     group.add(&bandwidth_advisory_row);
 
-    // Derive initial visibility from the selected device.
+    // Derive initial visibility from the selected device. Funnel
+    // through the same helper the change-notify handler uses so
+    // the policy lives in exactly one place. Per `CodeRabbit`
+    // round 1 on PR #559.
     let selected = device_row.selected();
-    let is_rtlsdr = selected == DEVICE_RTLSDR;
-    let is_network = selected == DEVICE_NETWORK;
-    let is_file = selected == DEVICE_FILE;
+    apply_source_row_visibility(
+        selected,
+        &sample_rate_row,
+        &gain_row,
+        &agc_row,
+        &ppm_row,
+        &bias_tee_row,
+        &direct_sampling_row,
+        &offset_tuning_row,
+        &hostname_row,
+        &port_row,
+        &protocol_row,
+        &file_path_row,
+    );
+    // RTL-TCP-specific rows aren't part of `apply_source_row_
+    // visibility` — they're handled by `connect_rtl_tcp_visibility`
+    // below for change-notify, but the initial render still
+    // needs to seed them. `is_rtltcp` is recomputed locally
+    // because the helper consumes `selected` and doesn't return
+    // the projection.
     let is_rtltcp = selected == DEVICE_RTLTCP;
-    let tune_controls_visible = is_rtlsdr || is_rtltcp;
-    sample_rate_row.set_visible(tune_controls_visible);
-    gain_row.set_visible(tune_controls_visible);
-    agc_row.set_visible(tune_controls_visible);
-    ppm_row.set_visible(tune_controls_visible);
-    // Bias tee is local-RTL-SDR only — the rtl_tcp wire
-    // protocol exposes a bias-T command but the rtl_tcp client
-    // doesn't currently surface it in this panel (the
-    // server-side panel has its own toggle). Keep this row
-    // hidden on RTL-TCP to match. Per issue #537.
-    bias_tee_row.set_visible(is_rtlsdr);
-    // Direct sampling and offset tuning are local-RTL-SDR-only —
-    // same gating rationale as bias tee. Per issues #538 / #539.
-    direct_sampling_row.set_visible(is_rtlsdr);
-    offset_tuning_row.set_visible(is_rtlsdr);
-    hostname_row.set_visible(is_network || is_rtltcp);
-    port_row.set_visible(is_network || is_rtltcp);
-    protocol_row.set_visible(is_network);
-    file_path_row.set_visible(is_file);
     rtl_tcp_discovered_row.set_visible(is_rtltcp);
     rtl_tcp_status_row.set_visible(is_rtltcp);
     rtl_tcp_role_row.set_visible(is_rtltcp);

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -73,6 +73,31 @@ pub const KEY_SOURCE_RTL_GAIN_DB: &str = "src_rtl_gain_db";
 /// `0` (no correction). Per issue `#551`.
 pub const KEY_SOURCE_RTL_PPM: &str = "src_rtl_ppm";
 
+/// Config key for persisted RTL2832 direct-sampling mode.
+/// Stored as the same `i32` mode value the
+/// `rtlsdr_set_direct_sampling` C ABI expects — `0` disables
+/// direct sampling (normal tuner path), `1` selects the I
+/// branch and `2` selects the Q branch (both bypass the tuner
+/// for HF reception). Default `0`. Per issue #538.
+pub const KEY_SOURCE_RTL_DIRECT_SAMPLING_MODE: &str = "src_rtl_direct_sampling";
+
+/// Config key for persisted RTL-SDR offset-tuning toggle.
+/// Default `false` — most users have R820T-family dongles
+/// where the setting is a no-op anyway. Per issue #539.
+pub const KEY_SOURCE_RTL_OFFSET_TUNING: &str = "src_rtl_offset_tuning";
+
+/// Direct-sampling combo indices. Order is load-bearing —
+/// matches the `rtlsdr_set_direct_sampling` mode argument the
+/// driver expects (0/1/2). The combo's user-visible label list
+/// in [`build_rtlsdr_rows`] is built in the same order so the
+/// selected index can be cast straight to the driver mode.
+pub const DIRECT_SAMPLING_DISABLED_IDX: u32 = 0;
+pub const DIRECT_SAMPLING_I_BRANCH_IDX: u32 = 1;
+pub const DIRECT_SAMPLING_Q_BRANCH_IDX: u32 = 2;
+/// Highest valid direct-sampling combo index, used by the
+/// loader to bound-check persisted values.
+pub const DIRECT_SAMPLING_MAX_IDX: u32 = DIRECT_SAMPLING_Q_BRANCH_IDX;
+
 // ─── Source-panel persistence keys (#552) ───────────────────────────
 // Top-level + frontend + per-source-type config rows that today
 // reset to widget defaults across restart. Mechanical mirror of
@@ -328,6 +353,21 @@ pub struct SourcePanel {
     /// share-server panel rather than reusing this row. Per
     /// issue #537.
     pub bias_tee_row: adw::SwitchRow,
+    /// RTL-SDR direct-sampling combo (Disabled / I branch /
+    /// Q branch). Q branch is how RTL-SDR Blog v3+ dongles tune
+    /// below 28 MHz — the R820T tuner cuts off there, but the
+    /// RTL2832 ADC can sample I or Q directly when the tuner is
+    /// bypassed. Visibility-gated to local RTL-SDR USB only in
+    /// this panel (hidden for Network / File / `rtl_tcp`). Per
+    /// issue #538.
+    pub direct_sampling_row: adw::ComboRow,
+    /// RTL-SDR offset-tuning toggle. Pushes the LO away from
+    /// the tuned frequency to dodge the DC spike. Mostly
+    /// relevant on E4000 tuners; on R820T / R820T2 the driver
+    /// returns Ok but the operation is a no-op in hardware.
+    /// Same visibility gate as the rest of the RTL-SDR-specific
+    /// rows. Per issue #539.
+    pub offset_tuning_row: adw::SwitchRow,
     /// Network hostname entry.
     pub hostname_row: adw::EntryRow,
     /// Network port number.
@@ -452,12 +492,15 @@ pub fn format_rtl_tcp_state(state: &RtlTcpConnectionState) -> String {
 /// fallback matches the widget's initial selection.
 pub(crate) const DEFAULT_SAMPLE_RATE_INDEX: u32 = 7;
 
-/// Build RTL-SDR-specific rows: sample rate, gain, AGC, PPM correction.
+/// Build RTL-SDR-specific rows: sample rate, gain, AGC, PPM
+/// correction, bias tee, direct sampling, offset tuning.
 fn build_rtlsdr_rows() -> (
     adw::ComboRow,
     adw::SpinRow,
     adw::ComboRow,
     adw::SpinRow,
+    adw::SwitchRow,
+    adw::ComboRow,
     adw::SwitchRow,
 ) {
     let sample_rate_model = gtk4::StringList::new(&[
@@ -525,7 +568,40 @@ fn build_rtlsdr_rows() -> (
         .active(false)
         .build();
 
-    (sample_rate_row, gain_row, agc_row, ppm_row, bias_tee_row)
+    // Direct sampling — Disabled / I branch / Q branch. Order is
+    // load-bearing: the combo's selected index is cast straight
+    // to the `rtlsdr_set_direct_sampling` `mode` argument
+    // (0/1/2). Disabled is the default — only RTL-SDR Blog v3+
+    // dongles benefit, and only when the user is tuning HF.
+    // Per issue #538.
+    let direct_sampling_model = gtk4::StringList::new(&["Disabled", "I branch", "Q branch"]);
+    let direct_sampling_row = adw::ComboRow::builder()
+        .title("Direct Sampling")
+        .subtitle("Bypass the tuner for HF reception (RTL-SDR Blog v3+)")
+        .model(&direct_sampling_model)
+        .selected(DIRECT_SAMPLING_DISABLED_IDX)
+        .build();
+
+    // Offset tuning — pushes the LO away from the requested
+    // centre frequency to dodge the DC spike that lives at the
+    // LO position. Most relevant on E4000 tuners; effectively a
+    // no-op on R820T/R820T2 (the driver returns Ok but the
+    // hardware doesn't shift). Off by default. Per issue #539.
+    let offset_tuning_row = adw::SwitchRow::builder()
+        .title("Offset Tuning")
+        .subtitle("Shift LO off the tuned freq to avoid the DC spike (E4000 only)")
+        .active(false)
+        .build();
+
+    (
+        sample_rate_row,
+        gain_row,
+        agc_row,
+        ppm_row,
+        bias_tee_row,
+        direct_sampling_row,
+        offset_tuning_row,
+    )
 }
 
 /// Build network-specific rows: hostname, port, protocol.
@@ -593,6 +669,8 @@ fn connect_device_visibility(
     agc_row: &adw::ComboRow,
     ppm_row: &adw::SpinRow,
     bias_tee_row: &adw::SwitchRow,
+    direct_sampling_row: &adw::ComboRow,
+    offset_tuning_row: &adw::SwitchRow,
     hostname_row: &adw::EntryRow,
     port_row: &adw::SpinRow,
     protocol_row: &adw::ComboRow,
@@ -609,6 +687,10 @@ fn connect_device_visibility(
         ppm_row,
         #[weak]
         bias_tee_row,
+        #[weak]
+        direct_sampling_row,
+        #[weak]
+        offset_tuning_row,
         #[weak]
         hostname_row,
         #[weak]
@@ -639,6 +721,14 @@ fn connect_device_visibility(
             // initial-visibility block for the same gating
             // rationale. Per issue #537.
             bias_tee_row.set_visible(is_rtlsdr);
+            // Direct sampling + offset tuning are local-RTL-SDR-only;
+            // the rtl_tcp wire protocol exposes equivalents but
+            // we don't surface them through this panel today, and
+            // the `Source` trait's defaults silently drop the
+            // command on file/network sources. Per issues #538 /
+            // #539.
+            direct_sampling_row.set_visible(is_rtlsdr);
+            offset_tuning_row.set_visible(is_rtlsdr);
 
             // Hostname / port entry is shared between raw-IQ Network
             // and RTL-TCP modes. Protocol (TCP/UDP) only applies to
@@ -684,7 +774,15 @@ pub fn build_source_panel() -> SourcePanel {
         .model(&device_model)
         .build();
 
-    let (sample_rate_row, gain_row, agc_row, ppm_row, bias_tee_row) = build_rtlsdr_rows();
+    let (
+        sample_rate_row,
+        gain_row,
+        agc_row,
+        ppm_row,
+        bias_tee_row,
+        direct_sampling_row,
+        offset_tuning_row,
+    ) = build_rtlsdr_rows();
     let (hostname_row, port_row, protocol_row) = build_network_rows();
     let file_path_row = adw::EntryRow::builder()
         .title("File Path")
@@ -782,6 +880,8 @@ pub fn build_source_panel() -> SourcePanel {
     group.add(&agc_row);
     group.add(&ppm_row);
     group.add(&bias_tee_row);
+    group.add(&direct_sampling_row);
+    group.add(&offset_tuning_row);
     group.add(&hostname_row);
     group.add(&port_row);
     group.add(&protocol_row);
@@ -814,6 +914,10 @@ pub fn build_source_panel() -> SourcePanel {
     // server-side panel has its own toggle). Keep this row
     // hidden on RTL-TCP to match. Per issue #537.
     bias_tee_row.set_visible(is_rtlsdr);
+    // Direct sampling and offset tuning are local-RTL-SDR-only —
+    // same gating rationale as bias tee. Per issues #538 / #539.
+    direct_sampling_row.set_visible(is_rtlsdr);
+    offset_tuning_row.set_visible(is_rtlsdr);
     hostname_row.set_visible(is_network || is_rtltcp);
     port_row.set_visible(is_network || is_rtltcp);
     protocol_row.set_visible(is_network);
@@ -835,6 +939,8 @@ pub fn build_source_panel() -> SourcePanel {
         &agc_row,
         &ppm_row,
         &bias_tee_row,
+        &direct_sampling_row,
+        &offset_tuning_row,
         &hostname_row,
         &port_row,
         &protocol_row,
@@ -859,6 +965,8 @@ pub fn build_source_panel() -> SourcePanel {
         agc_row,
         ppm_row,
         bias_tee_row,
+        direct_sampling_row,
+        offset_tuning_row,
         hostname_row,
         port_row,
         protocol_row,
@@ -1200,6 +1308,54 @@ pub fn load_source_rtl_bias_tee(config: &Arc<ConfigManager>) -> bool {
 pub fn save_source_rtl_bias_tee(config: &Arc<ConfigManager>, enabled: bool) {
     config.write(|v| {
         v[KEY_SOURCE_RTL_BIAS_TEE] = serde_json::json!(enabled);
+    });
+}
+
+/// Load the persisted RTL2832 direct-sampling combo index.
+/// Defaults to [`DIRECT_SAMPLING_DISABLED_IDX`] when the key is
+/// missing, the value isn't numeric, or the parsed value falls
+/// outside the legal range `0..=DIRECT_SAMPLING_MAX_IDX` (e.g.
+/// a future build added more modes and the user rolled back).
+/// Per issue #538.
+#[must_use]
+pub fn load_source_rtl_direct_sampling_mode(config: &Arc<ConfigManager>) -> u32 {
+    config.read(|v| {
+        v.get(KEY_SOURCE_RTL_DIRECT_SAMPLING_MODE)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .filter(|&idx| idx <= DIRECT_SAMPLING_MAX_IDX)
+            .unwrap_or(DIRECT_SAMPLING_DISABLED_IDX)
+    })
+}
+
+/// Persist the direct-sampling combo index. Written on every
+/// `direct_sampling_row.connect_selected_notify` event in
+/// `window.rs::connect_source_panel`. Per issue #538.
+pub fn save_source_rtl_direct_sampling_mode(config: &Arc<ConfigManager>, mode: u32) {
+    config.write(|v| {
+        v[KEY_SOURCE_RTL_DIRECT_SAMPLING_MODE] = serde_json::json!(mode);
+    });
+}
+
+/// Load the persisted offset-tuning toggle. Defaults to `false`
+/// — most R820T-family dongles ignore the setting anyway, and a
+/// false default keeps tuning behavior predictable across
+/// hardware variants. Per issue #539.
+#[must_use]
+pub fn load_source_rtl_offset_tuning(config: &Arc<ConfigManager>) -> bool {
+    config.read(|v| {
+        v.get(KEY_SOURCE_RTL_OFFSET_TUNING)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    })
+}
+
+/// Persist the offset-tuning toggle. Written on every
+/// `offset_tuning_row.connect_active_notify` event in
+/// `window.rs::connect_source_panel`. Per issue #539.
+pub fn save_source_rtl_offset_tuning(config: &Arc<ConfigManager>, enabled: bool) {
+    config.write(|v| {
+        v[KEY_SOURCE_RTL_OFFSET_TUNING] = serde_json::json!(enabled);
     });
 }
 
@@ -1871,6 +2027,54 @@ mod tests {
             v[KEY_SOURCE_RTL_BIAS_TEE] = serde_json::json!("not a bool");
         });
         assert!(!load_source_rtl_bias_tee(&config));
+    }
+
+    /// #538 persistence: direct-sampling combo index.
+    #[test]
+    fn source_rtl_direct_sampling_round_trip_and_default() {
+        let config = make_config();
+        assert_eq!(
+            load_source_rtl_direct_sampling_mode(&config),
+            DIRECT_SAMPLING_DISABLED_IDX
+        );
+        save_source_rtl_direct_sampling_mode(&config, DIRECT_SAMPLING_Q_BRANCH_IDX);
+        assert_eq!(
+            load_source_rtl_direct_sampling_mode(&config),
+            DIRECT_SAMPLING_Q_BRANCH_IDX
+        );
+        save_source_rtl_direct_sampling_mode(&config, DIRECT_SAMPLING_I_BRANCH_IDX);
+        assert_eq!(
+            load_source_rtl_direct_sampling_mode(&config),
+            DIRECT_SAMPLING_I_BRANCH_IDX
+        );
+        // Corrupt value falls back to Disabled.
+        config.write(|v| v[KEY_SOURCE_RTL_DIRECT_SAMPLING_MODE] = serde_json::json!("not a u64"));
+        assert_eq!(
+            load_source_rtl_direct_sampling_mode(&config),
+            DIRECT_SAMPLING_DISABLED_IDX
+        );
+        // Out-of-range numeric falls back to Disabled — covers
+        // a stale config from a future build that added more
+        // direct-sampling modes than this build understands.
+        config.write(|v| v[KEY_SOURCE_RTL_DIRECT_SAMPLING_MODE] = serde_json::json!(99));
+        assert_eq!(
+            load_source_rtl_direct_sampling_mode(&config),
+            DIRECT_SAMPLING_DISABLED_IDX
+        );
+    }
+
+    /// #539 persistence: offset-tuning toggle.
+    #[test]
+    fn source_rtl_offset_tuning_round_trip_and_default() {
+        let config = make_config();
+        assert!(!load_source_rtl_offset_tuning(&config));
+        save_source_rtl_offset_tuning(&config, true);
+        assert!(load_source_rtl_offset_tuning(&config));
+        save_source_rtl_offset_tuning(&config, false);
+        assert!(!load_source_rtl_offset_tuning(&config));
+        // Corrupt value falls back to false.
+        config.write(|v| v[KEY_SOURCE_RTL_OFFSET_TUNING] = serde_json::json!("not a bool"));
+        assert!(!load_source_rtl_offset_tuning(&config));
     }
 
     /// #551 persistence: gain in dB.

--- a/crates/sdr-ui/src/sidebar/source_panel.rs
+++ b/crates/sdr-ui/src/sidebar/source_panel.rs
@@ -82,8 +82,11 @@ pub const KEY_SOURCE_RTL_PPM: &str = "src_rtl_ppm";
 pub const KEY_SOURCE_RTL_DIRECT_SAMPLING_MODE: &str = "src_rtl_direct_sampling";
 
 /// Config key for persisted RTL-SDR offset-tuning toggle.
-/// Default `false` — most users have R820T-family dongles
-/// where the setting is a no-op anyway. Per issue #539.
+/// Default `false` — support varies by tuner/driver (E4000
+/// honors it; R820T/R828D reject with `InvalidParameter`; the
+/// driver also rejects while direct sampling is enabled), so
+/// the default keeps tuning behavior predictable across
+/// hardware variants. Per issue #539.
 pub const KEY_SOURCE_RTL_OFFSET_TUNING: &str = "src_rtl_offset_tuning";
 
 /// Direct-sampling combo indices. Order is load-bearing —
@@ -362,10 +365,14 @@ pub struct SourcePanel {
     /// issue #538.
     pub direct_sampling_row: adw::ComboRow,
     /// RTL-SDR offset-tuning toggle. Pushes the LO away from
-    /// the tuned frequency to dodge the DC spike. Mostly
-    /// relevant on E4000 tuners; on R820T / R820T2 the driver
-    /// returns Ok but the operation is a no-op in hardware.
-    /// Same visibility gate as the rest of the RTL-SDR-specific
+    /// the tuned frequency to dodge the DC spike. Most relevant
+    /// on E4000 tuners; support varies by tuner and driver, and
+    /// unsupported hardware (R820T / R828D) rejects the request
+    /// with `InvalidParameter`. The change-notify handler in
+    /// `connect_source_panel` surfaces driver rejections as a
+    /// `TuneFailed` toast so the user gets a clear "your tuner
+    /// doesn't support this" rather than a silent no-op. Same
+    /// visibility gate as the rest of the RTL-SDR-specific
     /// rows. Per issue #539.
     pub offset_tuning_row: adw::SwitchRow,
     /// Network hostname entry.
@@ -584,12 +591,15 @@ fn build_rtlsdr_rows() -> (
 
     // Offset tuning — pushes the LO away from the requested
     // centre frequency to dodge the DC spike that lives at the
-    // LO position. Most relevant on E4000 tuners; effectively a
-    // no-op on R820T/R820T2 (the driver returns Ok but the
-    // hardware doesn't shift). Off by default. Per issue #539.
+    // LO position. Most relevant on E4000 tuners; support
+    // varies by tuner and driver. R820T/R828D reject the
+    // request with `InvalidParameter` (surfaced as a
+    // `TuneFailed` toast by the wiring in `window.rs`). Off by
+    // default to keep behavior predictable across hardware. Per
+    // issue #539.
     let offset_tuning_row = adw::SwitchRow::builder()
         .title("Offset Tuning")
-        .subtitle("Shift LO off the tuned freq to avoid the DC spike (E4000 only)")
+        .subtitle("Shift LO off the tuned freq to avoid the DC spike")
         .active(false)
         .build();
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -6733,6 +6733,60 @@ fn connect_source_panel(
             state_bias_tee.send_dsp(UiToDsp::SetBiasTee(enabled));
         });
 
+    // Direct sampling combo (#538). Same restore-then-wire idiom
+    // as bias-T above. The persisted value is the combo index
+    // (0/1/2), which is also the `rtlsdr_set_direct_sampling`
+    // mode argument — cast straight to `i32` for the dispatch.
+    {
+        let persisted = sidebar::source_panel::load_source_rtl_direct_sampling_mode(config);
+        if persisted <= sidebar::source_panel::DIRECT_SAMPLING_MAX_IDX {
+            panels.source.direct_sampling_row.set_selected(persisted);
+            #[allow(clippy::cast_possible_wrap, reason = "u32 <= 2 fits in i32 trivially")]
+            state.send_dsp(UiToDsp::SetDirectSampling(persisted as i32));
+        }
+    }
+    let state_direct = Rc::clone(state);
+    let config_direct = std::sync::Arc::clone(config);
+    panels
+        .source
+        .direct_sampling_row
+        .connect_selected_notify(move |row| {
+            let idx = row.selected();
+            // Validate before persisting (mirrors the
+            // protocol_row / sample-rate / device / decimation
+            // early-return-on-invalid pattern). GTK can briefly
+            // emit out-of-range values during widget-model
+            // churn; persisting them would leave the next
+            // restart pinned to a non-existent direct-sampling
+            // mode. Per `CodeRabbit` round 3 on PR #558.
+            if idx > sidebar::source_panel::DIRECT_SAMPLING_MAX_IDX {
+                return;
+            }
+            sidebar::source_panel::save_source_rtl_direct_sampling_mode(&config_direct, idx);
+            #[allow(clippy::cast_possible_wrap, reason = "idx <= 2 fits in i32 trivially")]
+            state_direct.send_dsp(UiToDsp::SetDirectSampling(idx as i32));
+        });
+
+    // Offset tuning toggle (#539). Same restore-then-wire idiom
+    // as bias-T above. The controller bridge
+    // (`UiToDsp::SetOffsetTuning`) was already plumbed; only
+    // wiring is new here.
+    {
+        let persisted = sidebar::source_panel::load_source_rtl_offset_tuning(config);
+        panels.source.offset_tuning_row.set_active(persisted);
+        state.send_dsp(UiToDsp::SetOffsetTuning(persisted));
+    }
+    let state_offset = Rc::clone(state);
+    let config_offset = std::sync::Arc::clone(config);
+    panels
+        .source
+        .offset_tuning_row
+        .connect_active_notify(move |row| {
+            let enabled = row.is_active();
+            sidebar::source_panel::save_source_rtl_offset_tuning(&config_offset, enabled);
+            state_offset.send_dsp(UiToDsp::SetOffsetTuning(enabled));
+        });
+
     // IQ inversion toggle. Restore-then-wire (#552).
     {
         let persisted = sidebar::source_panel::load_source_iq_inversion(config);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -6747,6 +6747,7 @@ fn connect_source_panel(
     }
     let state_direct = Rc::clone(state);
     let config_direct = std::sync::Arc::clone(config);
+    let toast_overlay_direct = toast_overlay.downgrade();
     panels
         .source
         .direct_sampling_row
@@ -6765,6 +6766,23 @@ fn connect_source_panel(
             sidebar::source_panel::save_source_rtl_direct_sampling_mode(&config_direct, idx);
             #[allow(clippy::cast_possible_wrap, reason = "idx <= 2 fits in i32 trivially")]
             state_direct.send_dsp(UiToDsp::SetDirectSampling(idx as i32));
+            // Surface a tune-guidance toast: enabling direct
+            // sampling routes the antenna straight to the ADC,
+            // which silences VHF/UHF (the R820T tuner is now
+            // bypassed); disabling it puts the tuner back in
+            // path, which silences HF. Either direction needs a
+            // manual retune to be useful, and a toast saves the
+            // user from staring at noise wondering why. Per
+            // `CodeRabbit` round 1 on PR #559 / closes #538
+            // objective.
+            if let Some(overlay) = toast_overlay_direct.upgrade() {
+                let msg = if idx == sidebar::source_panel::DIRECT_SAMPLING_DISABLED_IDX {
+                    "Direct Sampling off — retune to VHF/UHF."
+                } else {
+                    "Direct Sampling on — retune to an HF frequency (< 28 MHz)."
+                };
+                overlay.add_toast(adw::Toast::new(msg));
+            }
         });
 
     // Offset tuning toggle (#539). Same restore-then-wire idiom


### PR DESCRIPTION
## Summary

Bundles two source-panel additions plus the transcription-warn flood fix the user surfaced mid-PR.

- **#538 — Direct Sampling combo** (Disabled / I branch / Q branch) on the local source panel. Unlocks HF reception below 28 MHz on RTL-SDR Blog v3+ dongles.
- **#539 — Offset Tuning toggle** on the local source panel. DC-spike workaround for E4000 tuners (no-op on R820T-family).
- **Transcription-warn flood fix.** A backed-up worker (sherpa Moonshine 1–2 s, whisper 5+ s) was producing 100+ "transcription channel full; retrying squelch edge next block" lines per second under load. Throttled to one warn per second with a `suppressed_in_window` count, plus bumped both bounded audio channels (sherpa 256 → 1024, whisper 512 → 2048).

Closes #538.
Closes #539.

## Commits (intentional split for review)

1. `sdr-source-rtlsdr` — implement `set_direct_sampling` + `set_offset_tuning` on the local USB Source. Both methods existed as default no-op stubs on the `Source` trait + already plumbed through controller and source-rebuild replay; the local USB adapter was the only hole.
2. `sdr-ui` — source-panel rows + persistence for direct sampling and offset tuning. New `direct_sampling_row: AdwComboRow` and `offset_tuning_row: AdwSwitchRow` on `SourcePanel`, visibility-gated to `DEVICE_RTLSDR` (mirrors the bias-T pattern). New `KEY_SOURCE_RTL_DIRECT_SAMPLING_MODE` + `KEY_SOURCE_RTL_OFFSET_TUNING` config keys with load/save helpers + round-trip + corrupt-value + out-of-range tests.
3. `sdr-ui` — wire the rows in `connect_source_panel`. Restore-then-wire idiom matching bias-T directly above. Direct-sampling handler validates the index against `DIRECT_SAMPLING_MAX_IDX` BEFORE persisting (mirrors the protocol_row early-return pattern from PR #558 round 3).
4. `sdr-core` — throttle the channel-full warn to one per second, with a `suppressed_in_window=N` count so burst magnitude stays observable. Init `transcription_full_warn_at` to `Instant::now()` in `DspState::new`.
5. `sdr-transcription` — bump bounded audio-channel capacities (sherpa 256 → 1024, whisper 512 → 2048). Memory cost ≈ 4 MB worst-case sherpa, 8 MB whisper — negligible against model size.

## Test plan

- [x] `cargo build --workspace --features whisper-cpu`
- [x] `cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings`
- [x] `cargo test --workspace --features whisper-cpu`
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` (mutex cross-check)
- [x] `cargo fmt --all -- --check`
- [ ] Manual GTK4 smoke (in progress with user):
    - Direct Sampling combo appears under Bias-T, 3 options. Toggle / hide on non-RTL-SDR / persist across restart.
    - Offset Tuning switch appears below Direct Sampling. Toggle / hide on non-RTL-SDR / persist across restart.
    - Confirm transcription-warn flood is gone — at most one per second, with `suppressed_in_window=N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RTL‑SDR direct‑sampling and offset‑tuning controls in the Source panel with startup restore, persisted settings, and toast guidance for manual retuning.
* **Bug Fixes**
  * Throttled transcription-channel warnings; emitted warnings now report how many were suppressed.
  * Increased audio buffer capacities to reduce sender failures during long processing.
* **Reliability**
  * Persistence is tolerant of missing/corrupted values and falls back to safe defaults.
* **Tests**
  * Added round‑trip and corruption/fallback tests for RTL‑SDR persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->