### PR TITLE
fix: reset APT/LRPT decoder state between auto-record passes (closes #544)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1856,6 +1856,23 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             // round 1 on PR #543.
         }
 
+        UiToDsp::ResetImagingDecoders => {
+            // Between-pass reset for the auto-record flow when
+            // the source stays open across pass boundaries
+            // (`was_running == true` pre-AOS keeps `set_playing`
+            // engaged at LOS, so the source-stop path doesn't
+            // run and `cleanup`'s reset never fires). Without
+            // this, the LRPT pipeline's internal
+            // `ImageAssembler` retains every previous pass's
+            // pixels (~6 MB per channel per pass) and the APT
+            // decoder's accumulator + ready queue grow
+            // monotonically. Same field reset as `cleanup`,
+            // factored out into `reset_imaging_decoders` so
+            // both call sites stay in lockstep. Per issue #544.
+            tracing::info!("auto-record: imaging decoders reset between passes");
+            reset_imaging_decoders(state);
+        }
+
         UiToDsp::StartIqRecording(path) => {
             tracing::info!(?path, "start IQ recording");
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -2788,43 +2805,57 @@ fn cleanup(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
 
     state.source = None;
 
-    // Hard stream discontinuity — flush APT decoder state so a
-    // subsequent Start can't bleed pre-stop accumulator/ready
-    // lines into the new session and emit a stale first line.
-    // The decoder itself stays allocated so the next Start
-    // doesn't pay re-init cost (filter taps, resampler tables);
-    // we only clear its in-flight buffers via `AptDecoder::reset`.
-    // Cross-mode preservation (NFM → WFM → NFM mid-pass) is a
-    // *soft* discontinuity and intentionally stays untouched —
-    // the user keeps decoding the same pass.
+    // Hard stream discontinuity — flush imaging-decoder state so
+    // a subsequent Start can't bleed pre-stop accumulator / ready
+    // lines / Viterbi traceback / image-assembler pixels into
+    // the new session. Decoders themselves stay allocated so the
+    // next Start doesn't pay re-init cost (filter taps,
+    // resampler tables, FEC tables); only their in-flight
+    // buffers get cleared. Cross-mode preservation (NFM → WFM →
+    // NFM mid-pass) is a *soft* discontinuity and intentionally
+    // stays untouched — the user keeps decoding the same pass.
+    reset_imaging_decoders(state);
+
+    tracing::info!("source closed");
+}
+
+/// Flush APT and LRPT decoder state without dropping the
+/// decoders themselves. Used by both [`cleanup`] (full source
+/// stop) and the [`UiToDsp::ResetImagingDecoders`] handler
+/// (between-pass reset for auto-record sessions where the
+/// source stays open). Per issue #544.
+///
+/// What gets reset:
+/// - `state.apt_decoder` — accumulator + ready queue + sync
+///   tracker via [`sdr_dsp::AptDecoder::reset`]. The filter
+///   taps and resampler tables stay allocated.
+/// - `state.apt_mono_buf` — scratch buffer for the L+R downmix
+///   (cleared, kept allocated).
+/// - `state.apt_init_failed_at_rate` — clear the cached
+///   per-rate init-failure memo so the next session retries
+///   even if a previous attempt failed.
+/// - `state.lrpt_decoder` — Viterbi traceback + ASM sync
+///   window + RS path + image assembler via
+///   [`sdr_radio::LrptDecoder::reset`]. If `reset` fails (the
+///   demod rebuild it does internally is practically
+///   unreachable), drop the decoder so the next tap call lazily
+///   re-initialises.
+/// - `state.lrpt_init_failed` — same rationale as the APT
+///   memo.
+fn reset_imaging_decoders(state: &mut DspState) {
     if let Some(decoder) = state.apt_decoder.as_mut() {
         decoder.reset();
     }
     state.apt_mono_buf.clear();
-    // Clear the failed-init guard so a fresh Start gets a fresh
-    // init attempt — the user may have tweaked the radio audio
-    // rate between sessions, and we don't want a stale failure
-    // memo to silently suppress a now-valid rate.
     state.apt_init_failed_at_rate = None;
 
-    // Same semantics for the LRPT decoder (#469): flush
-    // in-flight Viterbi traceback / sync window / RS path /
-    // image assembler so the next Start paints a clean canvas.
-    // If reset's demod-rebuild fails (practically unreachable;
-    // see `LrptDemod::new`), drop the decoder entirely so the
-    // next tap call lazily re-initialises.
     if let Some(decoder) = state.lrpt_decoder.as_mut()
         && let Err(e) = decoder.reset()
     {
         tracing::warn!("LRPT decoder reset failed; dropping for re-init: {e}");
         state.lrpt_decoder = None;
     }
-    // Clear the failed-init guard so a fresh Start gets a fresh
-    // init attempt. Mirror `apt_init_failed_at_rate` above. Per
-    // `CodeRabbit` round 12 on PR #543.
     state.lrpt_init_failed = false;
-
-    tracing::info!("source closed");
 }
 
 /// Rebuild the IQ frontend with the current sample rate, preserving user settings.

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -419,6 +419,18 @@ pub enum UiToDsp {
     /// `EmptyRotation` (all channels locked) this resumes
     /// rotation automatically.
     UnlockScannerChannel(sdr_scanner::ChannelKey),
+    /// Flush in-flight imaging-decoder state (APT + LRPT) without
+    /// closing the source. The source-stop path (`cleanup`)
+    /// already does this on full Stop, but the auto-record flow
+    /// when `was_running == true` pre-AOS keeps the source open
+    /// across pass boundaries — leaving the LRPT pipeline's
+    /// `ImageAssembler` and the APT decoder's accumulator
+    /// retaining state from pass N when pass N+1 begins. The
+    /// auto-record state machine emits this at the
+    /// `Recording → Finalizing` transition (LOS) so each pass
+    /// starts with clean decoder state regardless of whether the
+    /// source is power-cycled. Per issue #544.
+    ResetImagingDecoders,
 }
 
 #[cfg(test)]
@@ -1055,5 +1067,16 @@ mod tests {
 
         let unlock = UiToDsp::UnlockScannerChannel(key);
         assert!(matches!(unlock, UiToDsp::UnlockScannerChannel(_)));
+    }
+
+    /// Shape regression for `UiToDsp::ResetImagingDecoders`. The
+    /// auto-record state machine's `Recording → Finalizing`
+    /// transition emits this — a rename / removal would fail the
+    /// recorder's wiring at runtime, so pin the variant here. Per
+    /// issue #544.
+    #[test]
+    fn test_reset_imaging_decoders_variant() {
+        let msg = UiToDsp::ResetImagingDecoders;
+        assert!(matches!(msg, UiToDsp::ResetImagingDecoders));
     }
 }

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -276,6 +276,17 @@ pub enum Action {
     /// pass does NOT retroactively start or stop recording.
     /// Wiring layer maps to `UiToDsp::StopAudioRecording`.
     StopAutoAudioRecord,
+    /// Flush in-flight imaging-decoder state between passes.
+    /// Fired alongside [`Action::SavePng`] /
+    /// [`Action::SaveLrptPass`] on the `Recording → Finalizing`
+    /// transition. Without it, when the user was already
+    /// running pre-AOS (`SavedTune.was_running == true`), the
+    /// source stays open across the LOS → AOS boundary and the
+    /// LRPT pipeline's `ImageAssembler` + APT decoder
+    /// accumulator retain pass N's state when pass N+1 begins.
+    /// Wiring layer maps to `UiToDsp::ResetImagingDecoders`.
+    /// Per issue #544.
+    ResetImagingDecoders,
     /// Restore the radio to the pre-recording tune. Fired on
     /// `Finalizing → Idle`. Caller dispatches the same triple
     /// through the same primitive the play button uses.
@@ -609,11 +620,24 @@ impl AutoRecorder {
             // `export_png` errored on disk-full / permissions.
             // `output` was computed at AOS so the path pairs
             // with `audio_path`.
-            let mut actions = Vec::with_capacity(2);
+            //
+            // The reset-decoders action is emitted last so it
+            // runs AFTER the save action's snapshot read of the
+            // shared `LrptImage`. Cleanup-style: drain the data
+            // we want to keep, then flush the rest. If the
+            // user's `was_running == true` pre-AOS the source
+            // stays open across LOS → AOS, so this is the only
+            // hook between passes; if `was_running == false`
+            // the subsequent `set_playing(false)` in
+            // `RestoreTune` will trigger the source-stop path
+            // which resets again — idempotent, so the
+            // double-reset is fine. Per issue #544.
+            let mut actions = Vec::with_capacity(3);
             actions.push(save_action_for(&output));
             if audio_path.is_some() {
                 actions.push(Action::StopAutoAudioRecord);
             }
+            actions.push(Action::ResetImagingDecoders);
             self.state = State::Finalizing {
                 pass,
                 saved_tune,
@@ -1785,5 +1809,116 @@ mod tests {
                 .any(|a| matches!(a, Action::StartAutoAudioRecord(_))),
             "APT pass with audio toggle on must emit StartAutoAudioRecord; got {aos_actions:?}"
         );
+    }
+
+    /// Per #544: LOS must emit `ResetImagingDecoders` so the
+    /// in-flight APT/LRPT decoder state from the just-finished
+    /// pass doesn't bleed into the next one when the source
+    /// stays open across the LOS → AOS boundary. Pinning the
+    /// emit here so the wiring layer's between-pass cleanup
+    /// hook can't go stealth-quiet on a refactor.
+    #[test]
+    fn los_emits_reset_imaging_decoders() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 720, 50.0);
+        r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        let los_plus = pass.end + ChronoDuration::seconds(1);
+        let los_actions = r.tick(los_plus, &[pass], true, false, default_tune());
+        assert!(
+            los_actions
+                .iter()
+                .any(|a| matches!(a, Action::ResetImagingDecoders)),
+            "LOS must emit Action::ResetImagingDecoders; got {los_actions:?}",
+        );
+    }
+
+    /// Per #544: two back-to-back passes must each emit their
+    /// own `ResetImagingDecoders` — the recorder's state machine
+    /// is reusable across passes (`Idle → BeforePass → Recording
+    /// → Finalizing → Idle` is the per-pass cycle). Without a
+    /// reset between them, an overnight unattended setup with
+    /// 4-6 LRPT passes would accrete the pipeline's
+    /// `ImageAssembler` state monotonically.
+    #[test]
+    fn two_back_to_back_passes_each_emit_reset() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+
+        // Pass 1.
+        let pass1 = synthetic_noaa19(now, 3, 720, 50.0);
+        r.tick(
+            now,
+            std::slice::from_ref(&pass1),
+            true,
+            false,
+            default_tune(),
+        );
+        let after_settle_1 = now + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle_1,
+            std::slice::from_ref(&pass1),
+            true,
+            false,
+            default_tune(),
+        );
+        let los_1 = pass1.end + ChronoDuration::seconds(1);
+        let los_1_actions = r.tick(
+            los_1,
+            std::slice::from_ref(&pass1),
+            true,
+            false,
+            default_tune(),
+        );
+        let reset_count_1 = los_1_actions
+            .iter()
+            .filter(|a| matches!(a, Action::ResetImagingDecoders))
+            .count();
+        assert_eq!(reset_count_1, 1, "pass 1 LOS must emit exactly one reset");
+
+        // Settle from Finalizing back to Idle (the next tick after
+        // LOS does Finalizing → Idle and emits RestoreTune).
+        let post_los_1 = los_1 + ChronoDuration::seconds(1);
+        r.tick(post_los_1, &[pass1], true, false, default_tune());
+
+        // Pass 2 — fresh AOS, schedule it after pass 1 completed.
+        let pass2_aos = post_los_1 + ChronoDuration::seconds(60);
+        let pass2 = synthetic_noaa19(pass2_aos, 0, 720, 50.0);
+        r.tick(
+            pass2_aos,
+            std::slice::from_ref(&pass2),
+            true,
+            false,
+            default_tune(),
+        );
+        let after_settle_2 = pass2_aos + ChronoDuration::seconds(SETTLE_SECS + 1);
+        r.tick(
+            after_settle_2,
+            std::slice::from_ref(&pass2),
+            true,
+            false,
+            default_tune(),
+        );
+        let los_2 = pass2.end + ChronoDuration::seconds(1);
+        let los_2_actions = r.tick(los_2, &[pass2], true, false, default_tune());
+        let reset_count_2 = los_2_actions
+            .iter()
+            .filter(|a| matches!(a, Action::ResetImagingDecoders))
+            .count();
+        assert_eq!(reset_count_2, 1, "pass 2 LOS must emit exactly one reset");
     }
 }

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -577,13 +577,13 @@ impl AutoRecorder {
         // finalizing AND emit the protocol-appropriate save —
         // otherwise we'd jump to Idle on the next tick without
         // ever exporting the image. `output` was computed at AOS
-        // so the path pairs with `audio_path`.
+        // so the path pairs with `audio_path`. Same action vec
+        // as the `tick_recording` LOS path — both go through
+        // `los_actions_for` so the BeforePass-stall edge case
+        // gets the same `ResetImagingDecoders` flush. Per
+        // CodeRabbit round 1 on PR #560.
         if pass.end <= now {
-            let mut actions = Vec::with_capacity(2);
-            actions.push(save_action_for(&output));
-            if audio_path.is_some() {
-                actions.push(Action::StopAutoAudioRecord);
-            }
+            let actions = los_actions_for(&output, audio_path.is_some());
             self.state = State::Finalizing {
                 pass: pass.clone(),
                 saved_tune,
@@ -612,32 +612,14 @@ impl AutoRecorder {
         audio_path: Option<PathBuf>,
     ) -> Vec<Action> {
         if pass.end <= now {
-            // Emit the protocol-appropriate save action — the
-            // success / failure toast is the wiring layer's
-            // responsibility (it knows the export's actual
-            // outcome). Announcing "image saved" here would lie
-            // if the user closed the viewer mid-pass or
-            // `export_png` errored on disk-full / permissions.
-            // `output` was computed at AOS so the path pairs
-            // with `audio_path`.
-            //
-            // The reset-decoders action is emitted last so it
-            // runs AFTER the save action's snapshot read of the
-            // shared `LrptImage`. Cleanup-style: drain the data
-            // we want to keep, then flush the rest. If the
-            // user's `was_running == true` pre-AOS the source
-            // stays open across LOS → AOS, so this is the only
-            // hook between passes; if `was_running == false`
-            // the subsequent `set_playing(false)` in
-            // `RestoreTune` will trigger the source-stop path
-            // which resets again — idempotent, so the
-            // double-reset is fine. Per issue #544.
-            let mut actions = Vec::with_capacity(3);
-            actions.push(save_action_for(&output));
-            if audio_path.is_some() {
-                actions.push(Action::StopAutoAudioRecord);
-            }
-            actions.push(Action::ResetImagingDecoders);
+            // Same action vec as the `tick_before_pass` LOS
+            // short-circuit — both paths go through
+            // `los_actions_for` so a stalled BeforePass tick
+            // gets the same `ResetImagingDecoders` flush. The
+            // helper documents the ordering rationale (save →
+            // stop audio → reset decoders) and the idempotency
+            // contract with the source-stop reset.
+            let actions = los_actions_for(&output, audio_path.is_some());
             self.state = State::Finalizing {
                 pass,
                 saved_tune,
@@ -731,6 +713,41 @@ fn save_action_for(output: &PassOutput) -> Action {
         PassOutput::AptPng(p) => Action::SavePng(p.clone()),
         PassOutput::LrptDir(p) => Action::SaveLrptPass(p.clone()),
     }
+}
+
+/// Build the action vec for a `Recording → Finalizing` (or
+/// `BeforePass → Finalizing` short-circuit) LOS transition.
+/// Both paths emit the same actions in the same order:
+///
+/// 1. Protocol-appropriate save (`SavePng` for APT,
+///    `SaveLrptPass` for LRPT) — must run BEFORE the reset so
+///    the export can still snapshot the just-finished pass's
+///    pixels.
+/// 2. `StopAutoAudioRecord` — only when audio was started at
+///    AOS. Toggling the audio switch mid-pass doesn't
+///    retroactively start or stop recording.
+/// 3. `ResetImagingDecoders` — flush the in-flight APT / LRPT
+///    decoder buffers so the next pass starts clean. When
+///    `was_running == true` pre-AOS, this is the only hook
+///    between passes; when `was_running == false`, the
+///    subsequent `RestoreTune` triggers source-stop which
+///    resets again — idempotent. Per issue #544.
+///
+/// Centralising this into one helper guards against the
+/// `tick_before_pass` short-circuit (1 Hz driver stalled, or
+/// pass entirely inside the settle window) silently dropping
+/// the reset action — both call sites stay in lockstep on what
+/// "LOS finalisation" means. Per `CodeRabbit` round 1 on PR
+/// #560.
+#[must_use]
+fn los_actions_for(output: &PassOutput, has_audio: bool) -> Vec<Action> {
+    let mut actions = Vec::with_capacity(3);
+    actions.push(save_action_for(output));
+    if has_audio {
+        actions.push(Action::StopAutoAudioRecord);
+    }
+    actions.push(Action::ResetImagingDecoders);
+    actions
 }
 
 /// Shared filename builder for the per-pass file artifacts —
@@ -1164,6 +1181,47 @@ mod tests {
         assert!(
             actions.iter().any(|a| matches!(a, Action::SavePng(_))),
             "BeforePass→Finalizing must emit SavePng even when stalled past LOS"
+        );
+    }
+
+    /// Regression for the BeforePass-stall LOS edge case
+    /// (`#544` + `CodeRabbit` round 1 on PR #560). The
+    /// `tick_before_pass` short-circuit jumps straight to
+    /// `Finalizing` without entering `Recording` — earlier
+    /// drafts of the #544 fix only added `ResetImagingDecoders`
+    /// to the `tick_recording` LOS path, so a stalled driver
+    /// would skip the reset and leak APT/LRPT state into the
+    /// next pass on exactly the edge case the issue is trying
+    /// to close. Both LOS paths now go through the shared
+    /// `los_actions_for` helper; this test pins that the
+    /// stalled-BeforePass path still emits the reset.
+    #[test]
+    fn los_during_before_pass_still_emits_reset_imaging_decoders() {
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let pass = synthetic_noaa19(now, 3, 60, 50.0);
+        r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        assert!(matches!(r.state(), State::BeforePass { .. }));
+        let post_los = pass.end + ChronoDuration::seconds(5);
+        let actions = r.tick(
+            post_los,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            default_tune(),
+        );
+        assert!(matches!(r.state(), State::Finalizing { .. }));
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, Action::ResetImagingDecoders)),
+            "BeforePass→Finalizing must emit Action::ResetImagingDecoders even when stalled past LOS; got {actions:?}",
         );
     }
 

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -278,14 +278,19 @@ pub enum Action {
     StopAutoAudioRecord,
     /// Flush in-flight imaging-decoder state between passes.
     /// Fired alongside [`Action::SavePng`] /
-    /// [`Action::SaveLrptPass`] on the `Recording → Finalizing`
-    /// transition. Without it, when the user was already
-    /// running pre-AOS (`SavedTune.was_running == true`), the
-    /// source stays open across the LOS → AOS boundary and the
-    /// LRPT pipeline's `ImageAssembler` + APT decoder
-    /// accumulator retain pass N's state when pass N+1 begins.
-    /// Wiring layer maps to `UiToDsp::ResetImagingDecoders`.
-    /// Per issue #544.
+    /// [`Action::SaveLrptPass`] on either LOS transition path —
+    /// the normal `Recording → Finalizing` (end-of-pass) AND
+    /// the `BeforePass → Finalizing` short-circuit (1 Hz driver
+    /// stalled, or pass entirely inside the settle window).
+    /// Both paths build the action vec via `los_actions_for`,
+    /// which guarantees save → optional stop-audio → reset
+    /// ordering. Without it, when the user was already running
+    /// pre-AOS (`SavedTune.was_running == true`), the source
+    /// stays open across the LOS → AOS boundary and the LRPT
+    /// pipeline's `ImageAssembler` + APT decoder accumulator
+    /// retain pass N's state when pass N+1 begins. Wiring
+    /// layer maps to `UiToDsp::ResetImagingDecoders`. Per
+    /// issue #544 + `CodeRabbit` round 1 on PR #560.
     ResetImagingDecoders,
     /// Restore the radio to the pre-recording tune. Fired on
     /// `Finalizing → Idle`. Caller dispatches the same triple
@@ -1217,12 +1222,7 @@ mod tests {
             default_tune(),
         );
         assert!(matches!(r.state(), State::Finalizing { .. }));
-        assert!(
-            actions
-                .iter()
-                .any(|a| matches!(a, Action::ResetImagingDecoders)),
-            "BeforePass→Finalizing must emit Action::ResetImagingDecoders even when stalled past LOS; got {actions:?}",
-        );
+        assert_save_before_reset(&actions, "BeforePass-stall LOS");
     }
 
     #[test]
@@ -1875,6 +1875,31 @@ mod tests {
     /// stays open across the LOS → AOS boundary. Pinning the
     /// emit here so the wiring layer's between-pass cleanup
     /// hook can't go stealth-quiet on a refactor.
+    ///
+    /// Helper for the three LOS-reset tests below: assert the
+    /// LOS contract that save runs BEFORE reset — the save
+    /// action's snapshot read of the shared `LrptImage` would
+    /// otherwise capture an empty buffer instead of the
+    /// just-finished pass. Pure positional assertion, panics
+    /// with a clear message that includes the offending action
+    /// vec. Per `CodeRabbit` round 2 on PR #560.
+    fn assert_save_before_reset(actions: &[Action], label: &str) {
+        let save_idx = actions
+            .iter()
+            .position(|a| matches!(a, Action::SavePng(_) | Action::SaveLrptPass(_)))
+            .unwrap_or_else(|| panic!("{label}: LOS must emit a save action; got {actions:?}"));
+        let reset_idx = actions
+            .iter()
+            .position(|a| matches!(a, Action::ResetImagingDecoders))
+            .unwrap_or_else(|| {
+                panic!("{label}: LOS must emit Action::ResetImagingDecoders; got {actions:?}")
+            });
+        assert!(
+            save_idx < reset_idx,
+            "{label}: save must precede reset; got {actions:?}",
+        );
+    }
+
     #[test]
     fn los_emits_reset_imaging_decoders() {
         let mut r = AutoRecorder::new();
@@ -1897,12 +1922,7 @@ mod tests {
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
         let los_actions = r.tick(los_plus, &[pass], true, false, default_tune());
-        assert!(
-            los_actions
-                .iter()
-                .any(|a| matches!(a, Action::ResetImagingDecoders)),
-            "LOS must emit Action::ResetImagingDecoders; got {los_actions:?}",
-        );
+        assert_save_before_reset(&los_actions, "single-pass LOS");
     }
 
     /// Per #544: two back-to-back passes must each emit their
@@ -1947,6 +1967,7 @@ mod tests {
             .filter(|a| matches!(a, Action::ResetImagingDecoders))
             .count();
         assert_eq!(reset_count_1, 1, "pass 1 LOS must emit exactly one reset");
+        assert_save_before_reset(&los_1_actions, "pass 1 LOS");
 
         // Settle from Finalizing back to Idle (the next tick after
         // LOS does Finalizing → Idle and emits RestoreTune).
@@ -1978,5 +1999,6 @@ mod tests {
             .filter(|a| matches!(a, Action::ResetImagingDecoders))
             .count();
         assert_eq!(reset_count_2, 1, "pass 2 LOS must emit exactly one reset");
+        assert_save_before_reset(&los_2_actions, "pass 2 LOS");
     }
 }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9802,6 +9802,24 @@ fn connect_satellites_panel(
                 tracing::info!("auto-record LOS: closing WAV writer");
                 state_a.send_dsp(UiToDsp::StopAudioRecording);
             }
+            RecorderAction::ResetImagingDecoders => {
+                // Between-pass decoder flush. The state machine
+                // emits this at every `Recording → Finalizing`
+                // transition (LOS), AFTER the save action's
+                // snapshot read of the shared `LrptImage`. When
+                // `was_running == true` pre-AOS this is the only
+                // hook between passes — `RestoreTune` keeps the
+                // source open across LOS → AOS, so the
+                // source-stop reset never fires. When
+                // `was_running == false` the subsequent
+                // `set_playing(false)` in `RestoreTune` triggers
+                // the source-stop path which resets again —
+                // idempotent (`reset_imaging_decoders` only
+                // touches in-flight buffers), so the
+                // double-reset is harmless. Per issue #544.
+                tracing::info!("auto-record LOS: resetting imaging decoders");
+                state_a.send_dsp(UiToDsp::ResetImagingDecoders);
+            }
             RecorderAction::SavePng(path) => {
                 // Toast based on the *actual* export outcome
                 // rather than announcing success up front — the


### PR DESCRIPTION
## Summary

The auto-record flow now flushes APT + LRPT decoder state at every LOS, not just on full source stop. Closes #544.

## Why

Pre-this-PR, decoder reset only happened in `cleanup` (full source stop). That's fine when `was_running == false` pre-AOS — `RestoreTune` at LOS calls `set_playing(false)` and the source-stop path runs. But when the user was already running pre-AOS (e.g. listening to FM with auto-record on, three Meteor passes overnight), the source stays open across LOS → AOS, `cleanup` never fires, and:

- `LrptPipeline`'s internal `ImageAssembler` retains every previous pass's pixels (~6 MB per channel per pass).
- `LrptDecoder::last_pushed_lines` watermark grows monotonically.
- `AptDecoder` accumulator + ready queue keep growing.

Memory grows linearly with pass count. Surfaced in PR #543 review.

## Approach

1. Lift the existing APT + LRPT reset block out of `cleanup` into a `reset_imaging_decoders(state)` helper. Single source of truth — `cleanup` calls it for source-stop, the new handler calls it for between-pass.
2. Add `UiToDsp::ResetImagingDecoders`. Handler is a one-liner over the helper.
3. Add `Action::ResetImagingDecoders` to the recorder's action enum. Emit it at every `Recording → Finalizing` transition (LOS), AFTER the save action so the PNG export still snapshots the just-finished pass.
4. Wire the new action variant in `connect_satellites_panel`'s `interpret_action`.

## Idempotency

When `was_running == false` pre-AOS, the LOS chain fires the reset, then `RestoreTune` calls `set_playing(false)` which triggers the source-stop path which also calls `reset_imaging_decoders`. The second call is a no-op (`AptDecoder::reset` clears already-empty buffers, `LrptDecoder::reset` is similarly stateless on already-flushed input) — the double-reset is harmless.

## Commits

1. `sdr-core: extract reset_imaging_decoders helper + UiToDsp::ResetImagingDecoders` — 7ee47ed. Refactor + new variant + handler + shape-regression test.
2. `sdr-ui: emit ResetImagingDecoders at LOS + wiring + tests` — 308e2d7. Action variant + state-machine emit + window.rs wiring + two new pure-state-machine tests.

## Test plan

- [x] `cargo build --workspace --features whisper-cpu`
- [x] `cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings`
- [x] `cargo test --workspace --features whisper-cpu` — all 31 recorder tests pass including the two new ones (`los_emits_reset_imaging_decoders`, `two_back_to_back_passes_each_emit_reset`)
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` (mutex cross-check)
- [x] `cargo fmt --all -- --check`
- [ ] Manual smoke (deferred to next pass): APT/LRPT pass at LOS — confirm new tracing line `auto-record LOS: resetting imaging decoders` appears; back-to-back passes (start source pre-AOS so `was_running == true`) produce two clean PNGs without pass-1 pixels bleeding into pass-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-record now issues an imaging-decoder reset between passes at loss-of-signal, clearing APT and LRPT decoder buffers while keeping the receiver active for the next pass.
* **Bug Fixes**
  * Unified between-pass and full-stop reset behavior to prevent stale decoder state and ensure consistent cleanup; retains warning-and-drop if LRPT reset fails.
* **Tests**
  * Added regression tests to verify reset is emitted once per pass, preserves save-before-reset ordering, and covers edge-case pass transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->