### PR TITLE
feat: APT viewer Clear button (closes #515)

### DIFF
--- a/crates/sdr-ui/src/apt_viewer.rs
+++ b/crates/sdr-ui/src/apt_viewer.rs
@@ -454,6 +454,26 @@ pub fn open_apt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
     });
     header.pack_start(&pause_btn);
 
+    // Clear button — wipes the buffered scan lines and queues a
+    // redraw. Useful when (a) the user just exported a pass and
+    // wants a clean canvas before the next AOS, or (b) a static-
+    // noise patch from a non-pass test filled the surface and
+    // they want a fresh start before the next real signal
+    // arrives. Without this, the only recourse is closing the
+    // viewer window and waiting for the next AOS to re-open it.
+    // The `AptImageView::clear` primitive already exists; this
+    // just wires it to a control. Per issue #515.
+    let clear_btn = gtk4::Button::builder()
+        .icon_name("edit-clear-all-symbolic")
+        .tooltip_text("Clear the image buffer and start fresh")
+        .build();
+    clear_btn.update_property(&[gtk4::accessible::Property::Label("Clear APT image buffer")]);
+    let clear_view = view.clone();
+    clear_btn.connect_clicked(move |_| {
+        clear_view.clear();
+    });
+    header.pack_start(&clear_btn);
+
     let export_btn = gtk4::Button::builder()
         .icon_name("document-save-symbolic")
         .tooltip_text("Export the current APT image to PNG")


### PR DESCRIPTION
## Summary

Adds a Clear button to the APT viewer's header bar between the existing Pause and Export PNG buttons. Wires the existing `AptImageView::clear` primitive to a control so users no longer have to close + reopen the viewer to reset the canvas.

Closes #515.

## Why

`AptImageView::clear` already existed — wipes the surface, resets `n_lines = 0`, queues a redraw — but had no UI control bound to it. The only way to start a fresh canvas was closing the viewer window and reopening on the next AOS, which loses the auto-attach to `state.apt_viewer` until the next `app.apt-open` activation.

Use cases:
- User just exported a pass and wants a clean canvas before the next AOS.
- A static-noise patch from a non-pass test filled the surface and they want a fresh start before the real signal arrives.

## Approach

22 lines, one button add in `crates/sdr-ui/src/apt_viewer.rs`:

```rust
let clear_btn = gtk4::Button::builder()
    .icon_name("edit-clear-all-symbolic")
    .tooltip_text("Clear the image buffer and start fresh")
    .build();
clear_btn.update_property(&[gtk4::accessible::Property::Label("Clear APT image buffer")]);
let clear_view = view.clone();
clear_btn.connect_clicked(move |_| {
    clear_view.clear();
});
header.pack_start(&clear_btn);
```

`pack_start` order is now: Pause → Clear → (Export PNG `pack_end`). Same `view.clone()` pattern as the Pause and Export handlers — `AptImageView` is `Rc`-internal so the clones are cheap.

## Test plan

- [x] `cargo build --workspace --features whisper-cpu`
- [x] `cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings`
- [x] `cargo test --workspace --features whisper-cpu`
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` (mutex cross-check)
- [x] `cargo fmt --all -- --check`
- [ ] Manual smoke: open APT viewer (`Ctrl+Shift+A`); push synthetic data via demo button or wait for a pass; click Clear → image goes blank, `n_lines` resets, next pushed line draws at the top.

## Note: split from #516

Originally bundled with #516 (scanner spectrum/waterfall X-axis pin). Splitting because #516 turned out to be substantially more work — touches the FFT plot + waterfall renderers (1090 lines), needs a new axis-lock abstraction distinct from the existing `center_freq` cell, and has UX choices around the waterfall fill rule that benefit from focused review. #516 will land as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Clear APT image buffer" button to the APT viewer header, enabling users to reset the display and start with a blank canvas without closing and reopening the viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->