### PR TITLE
feat: scanner-mode X-axis pin (closes #516)

### DIFF
--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -72,6 +72,13 @@ pub struct DisplayPanel {
     pub averaging_row: adw::ComboRow,
     /// Theme selector (System / Dark / Light).
     pub theme_row: adw::ComboRow,
+    /// Read-only status row showing the current scanner-mode
+    /// X-axis lock range. Hidden when the scanner is disabled;
+    /// updated by the wiring layer's
+    /// `SetScannerEnabled` / `ScannerActiveChannelChanged` /
+    /// scanner-stop handlers as the lock engages, the active
+    /// channel changes, or the lock disengages. Per issue #516.
+    pub scanner_axis_row: adw::ActionRow,
 }
 
 /// Build the display settings panel.
@@ -223,10 +230,27 @@ pub fn build_display_panel() -> DisplayPanel {
         .build();
     appearance_group.add(&theme_row);
 
+    // Scanner-mode read-only status row. Subtitle is set by the
+    // wiring layer when the scanner-axis lock engages /
+    // updates / disengages — empty subtitle when scanner is off.
+    // Visibility is also wiring-layer-driven (hidden when off,
+    // shown when locked) so users not running the scanner don't
+    // see a confusing always-empty row. Per issue #516.
+    let scanner_axis_row = adw::ActionRow::builder()
+        .title("Scanner axis")
+        .visible(false)
+        .build();
+    let scanner_group = adw::PreferencesGroup::builder()
+        .title("Scanner")
+        .description("X-axis range when the scanner is active")
+        .build();
+    scanner_group.add(&scanner_axis_row);
+
     let page = adw::PreferencesPage::new();
     page.add(&fft_group);
     page.add(&waterfall_group);
     page.add(&levels_group);
+    page.add(&scanner_group);
     page.add(&appearance_group);
 
     // FFT size and window function connected via window.rs
@@ -242,6 +266,7 @@ pub fn build_display_panel() -> DisplayPanel {
         fill_mode_row,
         averaging_row,
         theme_row,
+        scanner_axis_row,
     }
 }
 

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -446,9 +446,23 @@ pub fn scanner_channel_envelope(channels: &[sdr_scanner::ScannerChannel]) -> Opt
     let mut min = f64::INFINITY;
     let mut max = f64::NEG_INFINITY;
     for ch in channels {
-        let half_bw = ch.bandwidth / 2.0;
+        // Skip malformed channels (NaN / Inf / non-positive
+        // bandwidth) so a single bad bookmark can't poison the
+        // envelope math and silently drop the lock.
+        // `f64::min` / `f64::max` propagate NaN per IEEE 754,
+        // so even one NaN bandwidth would taint `min`/`max`
+        // and make the final `max > min` check fail (returning
+        // `None` for an otherwise-valid channel set). Per
+        // `CodeRabbit` round 1 on PR #562.
+        if !ch.bandwidth.is_finite() || ch.bandwidth <= 0.0 {
+            continue;
+        }
         #[allow(clippy::cast_precision_loss)]
         let center = ch.key.frequency_hz as f64;
+        if !center.is_finite() {
+            continue;
+        }
+        let half_bw = ch.bandwidth / 2.0;
         min = min.min(center - half_bw);
         max = max.max(center + half_bw);
     }

--- a/crates/sdr-ui/src/sidebar/navigation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/navigation_panel.rs
@@ -431,6 +431,30 @@ pub fn project_scanner_channels(
         .collect()
 }
 
+/// Compute the (min, max) frequency envelope of a scanner channel
+/// list — the lower edge of the lowest-frequency channel's
+/// passband to the upper edge of the highest-frequency channel's
+/// passband, both in absolute Hz. Used by the scanner-axis-lock
+/// (#516) to pin the spectrum/waterfall X axis to the full range
+/// the scanner sweeps across.
+///
+/// Returns `None` if the channel list is empty (scanner has no
+/// channels selected, so there's no meaningful range to lock).
+/// Per issue #516.
+#[must_use]
+pub fn scanner_channel_envelope(channels: &[sdr_scanner::ScannerChannel]) -> Option<(f64, f64)> {
+    let mut min = f64::INFINITY;
+    let mut max = f64::NEG_INFINITY;
+    for ch in channels {
+        let half_bw = ch.bandwidth / 2.0;
+        #[allow(clippy::cast_precision_loss)]
+        let center = ch.key.frequency_hz as f64;
+        min = min.min(center - half_bw);
+        max = max.max(center + half_bw);
+    }
+    if max > min { Some((min, max)) } else { None }
+}
+
 /// Convenience: read the persisted default dwell/hang from config,
 /// project the bookmark list into scanner channels, and dispatch
 /// `UiToDsp::UpdateScannerChannels` so the running scanner picks up
@@ -1451,5 +1475,74 @@ mod tests {
         // Demod mode is parsed from the string form on the bookmark.
         assert_eq!(ch.demod_mode, DemodMode::Nfm);
         assert!((ch.bandwidth - 12_500.0).abs() < f64::EPSILON);
+    }
+
+    /// Per #516: envelope of an empty channel list is `None`.
+    #[test]
+    fn scanner_channel_envelope_empty_returns_none() {
+        let channels: Vec<sdr_scanner::ScannerChannel> = Vec::new();
+        assert_eq!(scanner_channel_envelope(&channels), None);
+    }
+
+    /// Per #516: single channel returns
+    /// `(centre - bw/2, centre + bw/2)`.
+    #[test]
+    fn scanner_channel_envelope_single_channel() {
+        let channels = vec![sdr_scanner::ScannerChannel {
+            key: sdr_scanner::ChannelKey {
+                name: "WX".to_string(),
+                frequency_hz: 162_550_000,
+            },
+            demod_mode: DemodMode::Nfm,
+            bandwidth: 12_500.0,
+            ctcss: None,
+            voice_squelch: None,
+            priority: 0,
+            dwell_ms: 1_000,
+            hang_ms: 3_000,
+        }];
+        let env = scanner_channel_envelope(&channels);
+        assert_eq!(env, Some((162_543_750.0, 162_556_250.0)));
+    }
+
+    /// Per #516: multiple channels span lowest-edge to
+    /// highest-edge across the union of all passbands. Channels
+    /// with different bandwidths are handled correctly — the
+    /// envelope must reach the actual edge of the WIDEST
+    /// channel at each end, not just the centres.
+    #[test]
+    fn scanner_channel_envelope_multi_channel_uses_edges() {
+        let channels = vec![
+            sdr_scanner::ScannerChannel {
+                key: sdr_scanner::ChannelKey {
+                    name: "Lower (NFM)".to_string(),
+                    frequency_hz: 146_000_000,
+                },
+                demod_mode: DemodMode::Nfm,
+                bandwidth: 12_500.0,
+                ctcss: None,
+                voice_squelch: None,
+                priority: 0,
+                dwell_ms: 1_000,
+                hang_ms: 3_000,
+            },
+            sdr_scanner::ScannerChannel {
+                key: sdr_scanner::ChannelKey {
+                    name: "Upper (WFM)".to_string(),
+                    frequency_hz: 155_000_000,
+                },
+                demod_mode: DemodMode::Wfm,
+                bandwidth: 200_000.0,
+                ctcss: None,
+                voice_squelch: None,
+                priority: 0,
+                dwell_ms: 1_000,
+                hang_ms: 3_000,
+            },
+        ];
+        let env = scanner_channel_envelope(&channels);
+        // Lower edge: 146M - 6250 = 145.99375M
+        // Upper edge: 155M + 100k = 155.100M
+        assert_eq!(env, Some((145_993_750.0, 155_100_000.0)));
     }
 }

--- a/crates/sdr-ui/src/spectrum/fft_plot.rs
+++ b/crates/sdr-ui/src/spectrum/fft_plot.rs
@@ -13,8 +13,12 @@ use super::frequency_axis;
 /// Highlight-band overlay color for the active scanner channel
 /// (when scanner-axis lock is engaged). Faint accent blue so
 /// the band reads as a "this is what we're sampling" affordance
-/// without obscuring the trace beneath it. Per issue #516.
-const SCANNER_HIGHLIGHT_COLOR: [f64; 4] = [0.3, 0.7, 1.0, 0.18];
+/// without obscuring the trace beneath it. `pub(super)` so
+/// the waterfall draw closure in `mod.rs` can paint a matching
+/// band — visual continuity between the FFT plot and waterfall
+/// panels matters here. Per issue #516 + `CodeRabbit` round 3
+/// on PR #562.
+pub(super) const SCANNER_HIGHLIGHT_COLOR: [f64; 4] = [0.3, 0.7, 1.0, 0.18];
 
 /// Maximum bins for display rendering.
 /// FFT data wider than this is max-pooled down before drawing.

--- a/crates/sdr-ui/src/spectrum/fft_plot.rs
+++ b/crates/sdr-ui/src/spectrum/fft_plot.rs
@@ -7,7 +7,14 @@
 
 use gtk4::cairo;
 
+use super::ScannerAxisLock;
 use super::frequency_axis;
+
+/// Highlight-band overlay color for the active scanner channel
+/// (when scanner-axis lock is engaged). Faint accent blue so
+/// the band reads as a "this is what we're sampling" affordance
+/// without obscuring the trace beneath it. Per issue #516.
+const SCANNER_HIGHLIGHT_COLOR: [f64; 4] = [0.3, 0.7, 1.0, 0.18];
 
 /// Maximum bins for display rendering.
 /// FFT data wider than this is max-pooled down before drawing.
@@ -84,6 +91,52 @@ impl Default for FftPlotRenderer {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Map an FFT bin index to a pixel X within a wide locked
+/// X axis. Pure projection helper extracted for unit testing —
+/// the rendering call sites in [`FftPlotRenderer::render_locked`]
+/// and the waterfall sparse-fill use the same math, and
+/// projection drift between them would manifest as a
+/// half-pixel-misaligned highlight band that's hard to spot
+/// visually. Per issue #516.
+///
+/// # Arguments
+///
+/// * `bin_index` — FFT bin number, 0..n_bins-1. After fftshift,
+///   bin 0 is the most negative offset from the active channel
+///   centre and bin n_bins-1 is the most positive.
+/// * `n_bins` — total bin count in the FFT frame.
+/// * `full_bw_hz` — span of the FFT (effective sample rate
+///   after decimation). Bin 0 maps to `-full_bw/2` relative to
+///   the active channel; bin n_bins-1 maps to `+full_bw/2`.
+/// * `active_channel_hz` — absolute centre frequency of the
+///   channel the scanner is sampling.
+/// * `axis_min_hz`, `axis_max_hz` — the locked X axis bounds.
+/// * `w` — pixel width of the drawing area.
+///
+/// Returns the pixel X coordinate (may fall outside `0..w` if
+/// the bin's absolute frequency is outside the locked range —
+/// caller is responsible for clipping).
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub(super) fn bin_to_locked_x(
+    bin_index: usize,
+    n_bins: usize,
+    full_bw_hz: f64,
+    active_channel_hz: f64,
+    axis_min_hz: f64,
+    axis_max_hz: f64,
+    w: f64,
+) -> f64 {
+    let n = (n_bins.saturating_sub(1)).max(1) as f64;
+    let bin_freq_relative = -full_bw_hz / 2.0 + (bin_index as f64 / n) * full_bw_hz;
+    let bin_freq_abs = active_channel_hz + bin_freq_relative;
+    let span = axis_max_hz - axis_min_hz;
+    if span <= 0.0 {
+        return 0.0;
+    }
+    w * (bin_freq_abs - axis_min_hz) / span
 }
 
 impl FftPlotRenderer {
@@ -195,6 +248,177 @@ impl FftPlotRenderer {
         let _ = cr.stroke();
 
         // Return the downsample buffer to self for reuse next frame.
+        let _ = display_data;
+        self.downsample_buf = ds_buf;
+    }
+
+    /// Render the FFT plot with the scanner X-axis lock engaged.
+    ///
+    /// Sibling of [`Self::render`] for scanner mode. Same Cairo
+    /// commands (background → grid → trace → fill → stroke)
+    /// but the projection math uses absolute frequencies
+    /// against the locked range instead of center-relative
+    /// offsets. The narrow FFT bins land in the active
+    /// channel's slice of the wide canvas; the rest of the X
+    /// axis stays at the background colour (no trace), which
+    /// gives the issue #516's "active channel's slice has
+    /// signal, the rest is empty" appearance.
+    ///
+    /// Renders a faint highlight band over the active channel's
+    /// bandwidth so the user can read "this is what we're
+    /// sampling right now" at a glance — same role the existing
+    /// VFO overlay plays in the unlocked case.
+    ///
+    /// # Arguments
+    ///
+    /// * `cr`, `fft_data`, `width`, `height`, `min_db`, `max_db`,
+    ///   `fill_enabled` — same as [`Self::render`].
+    /// * `full_bandwidth` — span of the FFT frame (post-
+    ///   decimation effective sample rate). Used to map bins to
+    ///   relative offsets from the active channel's centre.
+    /// * `lock` — current scanner-axis lock state. The render
+    ///   uses `lock.min_hz`/`lock.max_hz` for the X axis,
+    ///   `lock.active_channel_hz`/`bw_hz` for the trace
+    ///   placement and the highlight band.
+    ///
+    /// Per issue #516.
+    #[allow(clippy::cast_precision_loss, clippy::too_many_arguments)]
+    pub fn render_locked(
+        &mut self,
+        cr: &cairo::Context,
+        fft_data: &[f32],
+        width: i32,
+        height: i32,
+        min_db: f32,
+        max_db: f32,
+        fill_enabled: bool,
+        full_bandwidth: f64,
+        lock: &ScannerAxisLock,
+    ) {
+        if width <= 0 || height <= 0 {
+            return;
+        }
+        let db_range = max_db - min_db;
+        if db_range <= 0.0 {
+            return;
+        }
+        let w = f64::from(width);
+        let h = f64::from(height);
+
+        // Background.
+        cr.set_source_rgba(
+            BACKGROUND_COLOR[0],
+            BACKGROUND_COLOR[1],
+            BACKGROUND_COLOR[2],
+            BACKGROUND_COLOR[3],
+        );
+        let _ = cr.paint();
+
+        // Grid + labels span the locked range absolutely. We
+        // pass `display_start_hz = 0` and `display_end_hz =
+        // span` plus `center_freq_hz = lock.min_hz` to
+        // `draw_grid` — the existing helper computes
+        // `abs_start = center + display_start = lock.min_hz`
+        // and `abs_end = center + display_end = lock.max_hz`,
+        // which is exactly what we want.
+        let span = lock.max_hz - lock.min_hz;
+        Self::draw_grid(cr, w, h, min_db, max_db, 0.0, span, lock.min_hz);
+
+        // Active-channel highlight band — drawn BEFORE the
+        // trace so the trace renders on top. Skip when no
+        // channel is active yet (lock engaged but first retune
+        // hasn't completed) — empty grid only.
+        if let (Some(active_hz), Some(active_bw)) =
+            (lock.active_channel_hz, lock.active_channel_bw_hz)
+            && span > 0.0
+        {
+            let band_min_x = w * (active_hz - active_bw / 2.0 - lock.min_hz) / span;
+            let band_max_x = w * (active_hz + active_bw / 2.0 - lock.min_hz) / span;
+            let band_w = (band_max_x - band_min_x).max(1.0);
+            cr.set_source_rgba(
+                SCANNER_HIGHLIGHT_COLOR[0],
+                SCANNER_HIGHLIGHT_COLOR[1],
+                SCANNER_HIGHLIGHT_COLOR[2],
+                SCANNER_HIGHLIGHT_COLOR[3],
+            );
+            cr.rectangle(band_min_x, 0.0, band_w, h);
+            let _ = cr.fill();
+        }
+
+        // Trace — only renders if we know which channel is
+        // active. Bins project to absolute X via
+        // `bin_to_locked_x`.
+        let Some(active_hz) = lock.active_channel_hz else {
+            return;
+        };
+        if fft_data.is_empty() {
+            return;
+        }
+
+        let mut ds_buf = std::mem::take(&mut self.downsample_buf);
+        let display_data = downsample_fft(fft_data, &mut ds_buf);
+
+        let db_range_f64 = f64::from(db_range);
+        let min_db_f64 = f64::from(min_db);
+        let bin_count = display_data.len();
+        for (i, &db) in display_data.iter().enumerate() {
+            let x = bin_to_locked_x(
+                i,
+                bin_count,
+                full_bandwidth,
+                active_hz,
+                lock.min_hz,
+                lock.max_hz,
+                w,
+            );
+            let y = h * (1.0 - ((f64::from(db) - min_db_f64) / db_range_f64).clamp(0.0, 1.0));
+            if i == 0 {
+                cr.move_to(x, y);
+            } else {
+                cr.line_to(x, y);
+            }
+        }
+
+        if fill_enabled {
+            // Close the fill polygon along the bottom of the
+            // active channel's slice — NOT the full canvas
+            // width, otherwise the fill would extend across the
+            // entire locked range (visually overstating where
+            // we're sampling).
+            let last_x = bin_to_locked_x(
+                bin_count - 1,
+                bin_count,
+                full_bandwidth,
+                active_hz,
+                lock.min_hz,
+                lock.max_hz,
+                w,
+            );
+            let first_x = bin_to_locked_x(
+                0,
+                bin_count,
+                full_bandwidth,
+                active_hz,
+                lock.min_hz,
+                lock.max_hz,
+                w,
+            );
+            cr.line_to(last_x, h);
+            cr.line_to(first_x, h);
+            cr.close_path();
+            cr.set_source_rgba(FILL_COLOR[0], FILL_COLOR[1], FILL_COLOR[2], FILL_COLOR[3]);
+            let _ = cr.fill_preserve();
+        }
+
+        cr.set_source_rgba(
+            TRACE_COLOR[0],
+            TRACE_COLOR[1],
+            TRACE_COLOR[2],
+            TRACE_COLOR[3],
+        );
+        cr.set_line_width(1.0);
+        let _ = cr.stroke();
+
         let _ = display_data;
         self.downsample_buf = ds_buf;
     }
@@ -333,5 +557,123 @@ impl FftPlotRenderer {
                 cr.line_to(x, y);
             }
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    /// Reference scenario: scanner channels span 144–148 MHz
+    /// (4 MHz wide), active channel sits at 146 MHz with a
+    /// 250 kHz FFT. The active centre should land at exactly
+    /// the middle of an 800 px-wide canvas (50% in, 400 px).
+    #[test]
+    fn bin_to_locked_x_centres_active_channel() {
+        let n_bins = 1024;
+        let full_bw = 250_000.0;
+        let active_hz = 146_000_000.0;
+        let axis_min = 144_000_000.0;
+        let axis_max = 148_000_000.0;
+        let w = 800.0;
+
+        // The mid-bin (n_bins/2) corresponds to bin_freq_relative = 0,
+        // i.e. exactly at active_channel_hz. For odd offsets the
+        // bin numbering means the closest "centre bin" is
+        // n_bins/2; check that one.
+        let mid_bin = n_bins / 2;
+        let x = bin_to_locked_x(mid_bin, n_bins, full_bw, active_hz, axis_min, axis_max, w);
+        // Expected: w * (146M - 144M) / (148M - 144M) = w * 0.5 = 400.0
+        // Mid-bin is one bin above true centre because of the
+        // (i / (n-1)) projection — small offset, well within
+        // 1 px on an 800 px canvas.
+        assert!((x - 400.0).abs() < 1.0, "expected ~400.0, got {x}");
+    }
+
+    /// Endpoint behaviour: bin 0 must land at the leading edge
+    /// of the active channel's slice (active - bw/2), and the
+    /// final bin must land at the trailing edge (active + bw/2).
+    #[test]
+    fn bin_to_locked_x_endpoints_align_with_channel_edges() {
+        let n_bins = 1024;
+        let full_bw = 250_000.0;
+        let active_hz = 146_000_000.0;
+        let axis_min = 144_000_000.0;
+        let axis_max = 148_000_000.0;
+        let w = 800.0;
+
+        // bin 0 → active - bw/2 = 145.875 MHz → x = 800 * (145.875M - 144M) / 4M = 375.0
+        let x_first = bin_to_locked_x(0, n_bins, full_bw, active_hz, axis_min, axis_max, w);
+        assert!(
+            (x_first - 375.0).abs() < 0.1,
+            "expected ~375.0 for bin 0, got {x_first}",
+        );
+
+        // bin n-1 → active + bw/2 = 146.125 MHz → x = 800 * (146.125M - 144M) / 4M = 425.0
+        let x_last = bin_to_locked_x(
+            n_bins - 1,
+            n_bins,
+            full_bw,
+            active_hz,
+            axis_min,
+            axis_max,
+            w,
+        );
+        assert!(
+            (x_last - 425.0).abs() < 0.1,
+            "expected ~425.0 for last bin, got {x_last}",
+        );
+    }
+
+    /// Active channel near the lower edge of the locked range.
+    /// Verifies the active slice can land at the leading edge
+    /// of the canvas (left side) without going negative.
+    #[test]
+    fn bin_to_locked_x_handles_active_at_lower_edge() {
+        let n_bins = 1024;
+        let full_bw = 250_000.0;
+        let active_hz = 144_125_000.0; // active - bw/2 = axis_min
+        let axis_min = 144_000_000.0;
+        let axis_max = 148_000_000.0;
+        let w = 800.0;
+
+        let x_first = bin_to_locked_x(0, n_bins, full_bw, active_hz, axis_min, axis_max, w);
+        assert!(x_first.abs() < 0.1, "expected ~0.0, got {x_first}");
+    }
+
+    /// Degenerate input: zero-width axis. Helper must not divide
+    /// by zero; returning 0.0 is fine because the caller's
+    /// drawing code clips degenerate dimensions anyway.
+    #[test]
+    fn bin_to_locked_x_zero_span_returns_zero() {
+        let x = bin_to_locked_x(
+            100,
+            1024,
+            250_000.0,
+            146_000_000.0,
+            146_000_000.0,
+            146_000_000.0,
+            800.0,
+        );
+        assert_eq!(x, 0.0);
+    }
+
+    /// Single-bin input: avoid div-by-zero on `(n-1)` in the
+    /// projection. Returns the expected first-bin position
+    /// (active - bw/2).
+    #[test]
+    fn bin_to_locked_x_single_bin_does_not_panic() {
+        let x = bin_to_locked_x(
+            0,
+            1,
+            250_000.0,
+            146_000_000.0,
+            144_000_000.0,
+            148_000_000.0,
+            800.0,
+        );
+        // active - bw/2 = 145.875 MHz → x = 800 * (145.875M - 144M) / 4M = 375.0
+        assert!((x - 375.0).abs() < 0.1, "expected ~375.0, got {x}");
     }
 }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 use gtk4::glib;
 use gtk4::prelude::*;
 
-use fft_plot::FftPlotRenderer;
+use fft_plot::{FftPlotRenderer, SCANNER_HIGHLIGHT_COLOR};
 use signal_history::SignalHistoryRenderer;
 use vfo_overlay::{BwHandle, HitZone, VfoOverlayRenderer, VfoState};
 use waterfall::WaterfallRenderer;
@@ -865,10 +865,39 @@ fn build_waterfall_area(
             // don't apply to a multi-channel range. Per issue
             // #516.
             let lock = *scanner_axis_lock.borrow();
-            if lock.is_some() {
+            if let Some(lock) = lock {
                 let bw = full_bandwidth.get();
                 let half = bw / 2.0;
                 s.renderer.render(cr, width, height, -half, half, bw);
+                // Scanner-axis active-channel highlight band —
+                // mirrors the FFT plot's `render_locked` band
+                // so the user has a continuous visual anchor
+                // for "where is the scanner sampling right
+                // now?" across both panels. Drawn AFTER the
+                // texture blit so it overlays the data; spans
+                // the full height for visibility while the
+                // historical rows scroll past underneath. Per
+                // `CodeRabbit` round 3 on PR #562.
+                if let (Some(active_hz), Some(active_bw)) =
+                    (lock.active_channel_hz, lock.active_channel_bw_hz)
+                {
+                    let span = lock.max_hz - lock.min_hz;
+                    if span > 0.0 {
+                        let w = f64::from(width);
+                        let h = f64::from(height);
+                        let band_min_x = w * (active_hz - active_bw / 2.0 - lock.min_hz) / span;
+                        let band_max_x = w * (active_hz + active_bw / 2.0 - lock.min_hz) / span;
+                        let band_w = (band_max_x - band_min_x).max(1.0);
+                        cr.set_source_rgba(
+                            SCANNER_HIGHLIGHT_COLOR[0],
+                            SCANNER_HIGHLIGHT_COLOR[1],
+                            SCANNER_HIGHLIGHT_COLOR[2],
+                            SCANNER_HIGHLIGHT_COLOR[3],
+                        );
+                        cr.rectangle(band_min_x, 0.0, band_w, h);
+                        let _ = cr.fill();
+                    }
+                }
                 return;
             }
 

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -544,6 +544,7 @@ pub fn build_spectrum_view(
         &cursor_callback,
         &full_bandwidth,
         &center_freq,
+        &scanner_axis_lock,
     );
     let waterfall_area = build_waterfall_area(
         Rc::clone(&waterfall_state),
@@ -664,6 +665,7 @@ fn build_fft_area(
     cursor_callback: &CursorCallback,
     full_bandwidth: &Rc<Cell<f64>>,
     center_freq: &Rc<Cell<f64>>,
+    scanner_axis_lock: &Rc<RefCell<Option<ScannerAxisLock>>>,
 ) -> gtk4::DrawingArea {
     let area = gtk4::DrawingArea::builder()
         .hexpand(true)
@@ -677,8 +679,33 @@ fn build_fft_area(
     let vfo_render = Rc::clone(vfo_state);
     let full_bw_render = Rc::clone(full_bandwidth);
     let center_freq_render = Rc::clone(center_freq);
+    let scanner_lock_render = Rc::clone(scanner_axis_lock);
     area.set_draw_func(move |_area, cr, width, height| {
         if let Some(s) = state.borrow_mut().as_mut() {
+            // Scanner-axis lock takes precedence: when the
+            // scanner is engaged, X axis is pinned to the
+            // channel envelope and the narrow FFT data lands
+            // in the active channel's slice. The VFO overlay
+            // is suppressed in scanner mode — its meaning
+            // (drag-to-tune within the current channel)
+            // doesn't apply when the X axis represents a wide
+            // multi-channel range. Per issue #516.
+            let lock = *scanner_lock_render.borrow();
+            if let Some(lock) = lock {
+                s.renderer.render_locked(
+                    cr,
+                    &s.current_data,
+                    width,
+                    height,
+                    min_db_render.get(),
+                    max_db_render.get(),
+                    fill_render.get(),
+                    full_bw_render.get(),
+                    &lock,
+                );
+                return;
+            }
+
             let vfo = vfo_render.borrow();
             s.renderer.render(
                 cr,

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -248,7 +248,18 @@ impl SpectrumHandle {
             if target_width != s.renderer.texture_width() {
                 s.renderer.resize(data.len());
             }
-            s.renderer.push_line(data);
+            // Scanner-axis lock takes precedence: project narrow
+            // bins into the active channel's pixel slice with
+            // dark-grey fill of unsampled regions, so historical
+            // rows render as a sparse spatial picture of every
+            // channel the scanner has touched. Per issue #516.
+            let lock = *self.scanner_axis_lock.borrow();
+            if let Some(lock) = lock {
+                s.renderer
+                    .push_line_locked(data, self.full_bandwidth.get(), &lock);
+            } else {
+                s.renderer.push_line(data);
+            }
         }
         self.waterfall_area.queue_draw();
     }
@@ -550,6 +561,7 @@ pub fn build_spectrum_view(
         Rc::clone(&waterfall_state),
         Rc::clone(&vfo_state),
         Rc::clone(&full_bandwidth),
+        Rc::clone(&scanner_axis_lock),
     );
     let signal_history_area =
         build_signal_history_area(Rc::clone(&signal_history_state), &min_db, &max_db);
@@ -775,6 +787,7 @@ fn build_waterfall_area(
     state: Rc<RefCell<Option<WaterfallState>>>,
     vfo_state: Rc<RefCell<VfoState>>,
     full_bandwidth: Rc<Cell<f64>>,
+    scanner_axis_lock: Rc<RefCell<Option<ScannerAxisLock>>>,
 ) -> gtk4::DrawingArea {
     let area = gtk4::DrawingArea::builder()
         .hexpand(true)
@@ -783,6 +796,21 @@ fn build_waterfall_area(
 
     area.set_draw_func(move |_area, cr, width, height| {
         if let Some(s) = state.borrow().as_ref() {
+            // Scanner-axis lock: pixels are pre-projected to
+            // the wide locked range at push time, so the
+            // renderer just needs a no-zoom call (display
+            // matches full surface 1:1). VFO overlay is
+            // suppressed because its drag-to-tune semantics
+            // don't apply to a multi-channel range. Per issue
+            // #516.
+            let lock = *scanner_axis_lock.borrow();
+            if lock.is_some() {
+                let bw = full_bandwidth.get();
+                let half = bw / 2.0;
+                s.renderer.render(cr, width, height, -half, half, bw);
+                return;
+            }
+
             let vfo = vfo_state.borrow();
             s.renderer.render(
                 cr,

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -367,6 +367,20 @@ impl SpectrumHandle {
             min_hz < max_hz,
             "enter_scanner_mode: min ({min_hz}) must be < max ({max_hz})",
         );
+        // Release-build guard: invalid bounds (non-finite or
+        // inverted) would silently produce broken projections
+        // (division by zero / negative span / NaN-poisoned
+        // pixels) where `debug_assert!` is compiled out. Log
+        // and bail instead of engaging the lock with garbage.
+        // Per `CodeRabbit` round 1 on PR #562.
+        if !min_hz.is_finite() || !max_hz.is_finite() || min_hz >= max_hz {
+            tracing::warn!(
+                min_hz,
+                max_hz,
+                "enter_scanner_mode: ignoring invalid lock bounds",
+            );
+            return;
+        }
         *self.scanner_axis_lock.borrow_mut() = Some(ScannerAxisLock {
             min_hz,
             max_hz,
@@ -389,11 +403,44 @@ impl SpectrumHandle {
     /// `enter_scanner_mode` first, but a stray
     /// `ScannerActiveChannelChanged` arriving after
     /// `exit_scanner_mode` (e.g. mid-shutdown) shouldn't cause
-    /// the lock to mysteriously re-engage. Per issue #516.
+    /// the lock to mysteriously re-engage. Also rejects
+    /// non-finite frequency / bandwidth and non-positive
+    /// bandwidth — invalid values would silently produce
+    /// broken projections in release builds where
+    /// `debug_assert!` is compiled out. Per issue #516 +
+    /// `CodeRabbit` round 1 on PR #562.
     pub fn set_scanner_active_channel(&self, freq_hz: f64, bw_hz: f64) {
+        if !freq_hz.is_finite() || !bw_hz.is_finite() || bw_hz <= 0.0 {
+            tracing::trace!(
+                freq_hz,
+                bw_hz,
+                "set_scanner_active_channel: ignoring invalid channel context",
+            );
+            return;
+        }
         if let Some(lock) = self.scanner_axis_lock.borrow_mut().as_mut() {
             lock.active_channel_hz = Some(freq_hz);
             lock.active_channel_bw_hz = Some(bw_hz);
+            self.fft_area.queue_draw();
+            self.waterfall_area.queue_draw();
+        }
+    }
+
+    /// Clear the active-channel context within an engaged
+    /// scanner-axis lock — keeps the wide X axis pinned but
+    /// drops the highlight band and the narrow-data
+    /// projection. The wiring layer calls this on
+    /// `ScannerActiveChannelChanged { key: None }` (scanner
+    /// went idle without disengaging the lock — e.g. between
+    /// rotations, or after the rotation drained but before the
+    /// engine flips back to Idle). Without this, the previous
+    /// channel's highlight + projection stays rendered until
+    /// the next hop or scanner exit. Per `CodeRabbit` round 1
+    /// on PR #562.
+    pub fn clear_scanner_active_channel(&self) {
+        if let Some(lock) = self.scanner_axis_lock.borrow_mut().as_mut() {
+            lock.active_channel_hz = None;
+            lock.active_channel_bw_hz = None;
             self.fft_area.queue_draw();
             self.waterfall_area.queue_draw();
         }
@@ -743,6 +790,7 @@ fn build_fft_area(
     let cursor_min = Rc::clone(min_db);
     let cursor_max = Rc::clone(max_db);
     let cursor_cb = Rc::clone(cursor_callback);
+    let cursor_lock = Rc::clone(scanner_axis_lock);
     let area_weak_motion = area.downgrade();
     motion.connect_motion(move |_ctrl, x, y| {
         let Some(area) = area_weak_motion.upgrade() else {
@@ -754,9 +802,22 @@ fn build_fft_area(
             return;
         }
 
-        let vfo = cursor_vfo.borrow();
-        let freq_hz = vfo.pixel_to_hz(x, width);
-        drop(vfo);
+        // Pixel → frequency in lock-aware fashion. In scanner
+        // mode the X axis spans `[lock.min_hz, lock.max_hz]`
+        // absolutely; out of mode it's center-relative via the
+        // VFO's `pixel_to_hz`. Without this branch the cursor
+        // readout shows wildly wrong frequencies in scanner
+        // mode (it'd report values relative to the wandering
+        // active-channel centre instead of the wide locked
+        // range). Per `CodeRabbit` round 1 on PR #562.
+        let lock = *cursor_lock.borrow();
+        let freq_hz = if let Some(lock) = lock {
+            let frac = (x / width).clamp(0.0, 1.0);
+            lock.min_hz + frac * (lock.max_hz - lock.min_hz)
+        } else {
+            let vfo = cursor_vfo.borrow();
+            vfo.pixel_to_hz(x, width)
+        };
 
         let lo = cursor_min.get();
         let hi = cursor_max.get();

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -119,6 +119,18 @@ pub struct SpectrumHandle {
     full_bandwidth: Rc<Cell<f64>>,
     /// Tuner center frequency in Hz (for absolute frequency labels).
     center_freq: Rc<Cell<f64>>,
+    /// Scanner-mode X-axis lock. `Some` while the scanner is
+    /// active — pins the spectrum + waterfall to a wide band
+    /// covering all scanner channels' downlink frequencies, so
+    /// retunes between channels don't recentre the X axis on
+    /// every hop. The narrow FFT data the dongle actually
+    /// produces gets projected into the active channel's slice
+    /// of the wide range; unsampled bands render as dark grey
+    /// noise floor instead of being skipped. Active channel is
+    /// highlighted with a vertical band so the user can read
+    /// "where in the band is the scanner picking things up?"
+    /// at a glance. Per issue #516.
+    scanner_axis_lock: Rc<RefCell<Option<ScannerAxisLock>>>,
     /// Floating "Reset VFO" button overlaid on the top-right of
     /// the spectrum area. Visibility is driven by window.rs:
     /// visible when bandwidth ≠ mode default OR vfo offset ≠ 0.
@@ -126,6 +138,46 @@ pub struct SpectrumHandle {
     /// `AppState` to compute the mode's default bandwidth).
     /// Per issue #341.
     pub vfo_reset_button: gtk4::Button,
+}
+
+/// Snapshot of the scanner X-axis lock — what frequency range
+/// the spectrum / waterfall is pinned to, and which channel is
+/// currently being sampled (if any).
+///
+/// Lifecycle:
+/// 1. `enter_scanner_mode(min, max)` — wiring layer pushes the
+///    union of all scanner-channel downlink frequencies. The
+///    lock is `Some` from this point until `exit_scanner_mode`,
+///    so the X axis stays pinned even while the scanner is
+///    between channels.
+/// 2. `set_scanner_active_channel(freq, bw)` — wiring layer
+///    pushes the current active-channel context on every
+///    `ScannerActiveChannelChanged` event. Drives the
+///    highlight-band overlay and the FFT data projection.
+/// 3. `exit_scanner_mode()` — wiring layer clears the lock when
+///    the scanner is disabled / hits empty rotation / a manual
+///    tune supersedes it. The X axis reverts to the normal
+///    "current channel ± half BW" view.
+///
+/// Per issue #516.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScannerAxisLock {
+    /// Lower bound of the locked X axis, absolute Hz.
+    pub min_hz: f64,
+    /// Upper bound of the locked X axis, absolute Hz.
+    pub max_hz: f64,
+    /// Centre frequency of the channel the scanner is currently
+    /// sampling, absolute Hz. `None` between
+    /// `enter_scanner_mode` and the first
+    /// `set_scanner_active_channel` call (e.g. the first retune
+    /// hasn't completed yet).
+    pub active_channel_hz: Option<f64>,
+    /// Channel filter bandwidth of the active channel, in Hz.
+    /// Used to size the highlight band and project the narrow
+    /// FFT bins into the correct slice of the wide range.
+    /// Always paired with `active_channel_hz` — both `Some` or
+    /// both `None`.
+    pub active_channel_bw_hz: Option<f64>,
 }
 
 impl SpectrumHandle {
@@ -287,6 +339,76 @@ impl SpectrumHandle {
         self.waterfall_area.queue_draw();
     }
 
+    /// Engage the scanner X-axis lock. The wiring layer calls
+    /// this on `UiToDsp::SetScannerEnabled(true)` with the
+    /// (min, max) envelope of all scanner-channel downlink
+    /// frequencies. From this point until `exit_scanner_mode`,
+    /// the spectrum + waterfall stay pinned to that range —
+    /// retunes between channels no longer recentre the X axis.
+    ///
+    /// Initial state: `active_channel_*` is `None` until the
+    /// first `set_scanner_active_channel` call. The renderer
+    /// should treat that gap as "scanner mode is on but no
+    /// channel is currently being sampled" — wide axis with
+    /// no highlight band yet. Per issue #516.
+    pub fn enter_scanner_mode(&self, min_hz: f64, max_hz: f64) {
+        debug_assert!(
+            min_hz < max_hz,
+            "enter_scanner_mode: min ({min_hz}) must be < max ({max_hz})",
+        );
+        *self.scanner_axis_lock.borrow_mut() = Some(ScannerAxisLock {
+            min_hz,
+            max_hz,
+            active_channel_hz: None,
+            active_channel_bw_hz: None,
+        });
+        self.fft_area.queue_draw();
+        self.waterfall_area.queue_draw();
+    }
+
+    /// Update the active-channel context within an engaged
+    /// scanner-axis lock. The wiring layer calls this on every
+    /// `DspToUi::ScannerActiveChannelChanged` event with the
+    /// channel's centre frequency and bandwidth. Drives the
+    /// highlight-band overlay and the FFT/waterfall projection
+    /// of narrow data into the wide range.
+    ///
+    /// No-op when the lock is not engaged — the wiring layer
+    /// guards against race ordering by always calling
+    /// `enter_scanner_mode` first, but a stray
+    /// `ScannerActiveChannelChanged` arriving after
+    /// `exit_scanner_mode` (e.g. mid-shutdown) shouldn't cause
+    /// the lock to mysteriously re-engage. Per issue #516.
+    pub fn set_scanner_active_channel(&self, freq_hz: f64, bw_hz: f64) {
+        if let Some(lock) = self.scanner_axis_lock.borrow_mut().as_mut() {
+            lock.active_channel_hz = Some(freq_hz);
+            lock.active_channel_bw_hz = Some(bw_hz);
+            self.fft_area.queue_draw();
+            self.waterfall_area.queue_draw();
+        }
+    }
+
+    /// Disengage the scanner X-axis lock. Wiring layer calls
+    /// this on `UiToDsp::SetScannerEnabled(false)`, scanner
+    /// empty rotation, or any user manual tune that supersedes
+    /// the scanner. The X axis reverts to the normal "current
+    /// channel ± half BW" view on the next render. Per issue
+    /// #516.
+    pub fn exit_scanner_mode(&self) {
+        *self.scanner_axis_lock.borrow_mut() = None;
+        self.fft_area.queue_draw();
+        self.waterfall_area.queue_draw();
+    }
+
+    /// Read-only accessor for the current lock state. Used by
+    /// the Display panel's status row to render the locked
+    /// range, and by tests to assert state-machine transitions.
+    /// Per issue #516.
+    #[must_use]
+    pub fn scanner_axis_lock(&self) -> Option<ScannerAxisLock> {
+        *self.scanner_axis_lock.borrow()
+    }
+
     /// Programmatically update the VFO overlay's offset-from-center.
     ///
     /// Called from the `DspToUi::VfoOffsetChanged` handler so DSP-
@@ -392,6 +514,7 @@ pub fn build_spectrum_view(
     let vfo_offset_callback: VfoOffsetCallback = Rc::new(RefCell::new(None));
     let full_bandwidth: Rc<Cell<f64>> = Rc::new(Cell::new(0.0));
     let center_freq: Rc<Cell<f64>> = Rc::new(Cell::new(100_000_000.0)); // default 100 MHz
+    let scanner_axis_lock: Rc<RefCell<Option<ScannerAxisLock>>> = Rc::new(RefCell::new(None));
 
     // Initialize renderer state eagerly (no GL context needed).
     *fft_state.borrow_mut() = Some(FftPlotState {
@@ -523,6 +646,7 @@ pub fn build_spectrum_view(
         vfo_offset_callback,
         full_bandwidth,
         center_freq,
+        scanner_axis_lock,
         vfo_reset_button,
     };
 

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -14,7 +14,9 @@
 
 use gtk4::cairo;
 
+use super::ScannerAxisLock;
 use super::colormap;
+use super::fft_plot::bin_to_locked_x;
 
 /// Number of history lines stored in the display buffer.
 const HISTORY_LINES: usize = 1024;
@@ -187,6 +189,91 @@ impl WaterfallRenderer {
             self.pixel_buf[idx + 1] = color[1]; // G
             self.pixel_buf[idx + 2] = color[2]; // R
             self.pixel_buf[idx + 3] = color[3]; // A
+        }
+    }
+
+    /// Push a new FFT line under the scanner X-axis lock. Sibling
+    /// of [`Self::push_line`]. The narrow FFT data lands in the
+    /// active channel's pixel slice of the wider locked range;
+    /// the rest of the row gets `colormap[0]` (the "no signal"
+    /// floor colour, dark grey) so historical rows render as a
+    /// sparse spatial picture of the channels the scanner has
+    /// touched. Per issue #516.
+    ///
+    /// Behaviour notes:
+    /// - When `lock.active_channel_hz` is `None` (scanner mode
+    ///   engaged but no channel currently sampled), the entire
+    ///   row gets `colormap[0]`. This still advances the ring
+    ///   buffer so historical rows scroll downward at the
+    ///   normal cadence even during retunes between channels.
+    /// - Bins falling outside `[lock.min_hz, lock.max_hz]` are
+    ///   silently dropped — happens when the FFT span exceeds
+    ///   the locked range (rare; LF/HF dongles with the
+    ///   scanner band entirely fitting inside one FFT frame).
+    /// - Per-pixel max-pool: when multiple bins map to the
+    ///   same pixel (channel narrower than the FFT), the
+    ///   loudest bin wins. Same trade-off as `downsample_to`
+    ///   for the unlocked path — preserves peaks.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    pub fn push_line_locked(&mut self, fft_data: &[f32], full_bw_hz: f64, lock: &ScannerAxisLock) {
+        let db_range = self.max_db - self.min_db;
+        if !db_range.is_finite() || db_range <= 0.0 {
+            return;
+        }
+
+        // Step 1 — fill the row with the dark-grey "no signal"
+        // floor. We always do this even when active is None so
+        // the ring buffer gets fresh content (rather than a
+        // stale row from N rotations ago) on every push.
+        self.row_buffer.fill(0);
+
+        // Step 2 — when a channel is active, project narrow
+        // bins into the active slice's pixels.
+        if let Some(active_hz) = lock.active_channel_hz {
+            let n_bins = fft_data.len();
+            let w = self.display_width as f64;
+            for (i, &db) in fft_data.iter().enumerate() {
+                let x = bin_to_locked_x(
+                    i,
+                    n_bins,
+                    full_bw_hz,
+                    active_hz,
+                    lock.min_hz,
+                    lock.max_hz,
+                    w,
+                );
+                if !x.is_finite() || x < 0.0 || x >= w {
+                    continue;
+                }
+                let pixel_idx = x as usize;
+                let normalized = ((db - self.min_db) / db_range).clamp(0.0, 1.0);
+                let val = (normalized * 255.0).round() as u8;
+                // Per-pixel max-pool: narrow channels squeeze
+                // many bins per pixel, and we want the loudest
+                // to win. Same rationale as `downsample_to` for
+                // the unlocked path. Per issue #516.
+                if val > self.row_buffer[pixel_idx] {
+                    self.row_buffer[pixel_idx] = val;
+                }
+            }
+        }
+
+        // Step 3 — advance the ring + write pixels. Identical
+        // to the unlocked tail-end of `push_line`.
+        self.top_row = (self.top_row + HISTORY_LINES - 1) % HISTORY_LINES;
+        let row_bytes = self.display_width * 4;
+        let row_start = self.top_row * row_bytes;
+        for (i, &val) in self.row_buffer.iter().enumerate() {
+            let color = self.colormap_bgra[val as usize];
+            let idx = row_start + i * 4;
+            self.pixel_buf[idx] = color[0];
+            self.pixel_buf[idx + 1] = color[1];
+            self.pixel_buf[idx + 2] = color[2];
+            self.pixel_buf[idx + 3] = color[3];
         }
     }
 
@@ -747,6 +834,87 @@ mod tests {
                 linear_pixel(&linear, WIDTH_SMALL, visual_row, 0),
                 floor,
                 "display row {visual_row} must be the DB_LOW line"
+            );
+        }
+    }
+
+    /// Per #516: scanner-axis sparse fill. With a 4 MHz locked
+    /// range and a 250 kHz FFT centred at 146 MHz, only the
+    /// pixel slice corresponding to `[145.875, 146.125] MHz`
+    /// should carry signal-coloured pixels; the rest of the row
+    /// must read `colormap[0]` ("no signal" floor).
+    #[test]
+    fn push_line_locked_writes_only_active_slice() {
+        const WIDTH: usize = 1024;
+        let mut r = WaterfallRenderer::new(WIDTH);
+        r.set_db_range(DEFAULT_MIN_DB, DEFAULT_MAX_DB);
+        let floor = r.colormap_bgra[0];
+        let saturation = r.colormap_bgra[255];
+
+        // 250 kHz FFT, all bins at saturation. Channel sits in
+        // the middle of a 4 MHz scanner range.
+        let fft = vec![0.0_f32; 256]; // 0 dB == DEFAULT_MAX_DB == sat
+        let lock = ScannerAxisLock {
+            min_hz: 144_000_000.0,
+            max_hz: 148_000_000.0,
+            active_channel_hz: Some(146_000_000.0),
+            active_channel_bw_hz: Some(25_000.0),
+        };
+        r.push_line_locked(&fft, 250_000.0, &lock);
+
+        let linear = r.linearized_pixel_buf();
+        // Active channel + FFT span maps to absolute frequency
+        // [145.875M, 146.125M]. Within the [144M, 148M] range
+        // and 1024 px width, the FFT's first bin lands at
+        // pixel 480 and the last bin lands at pixel 544
+        // (inclusive — `bin_to_locked_x` puts bin N-1 at
+        // exactly active + bw/2, which yields `x = 544.0` for
+        // these inputs). Outside `[480, 544]`, every pixel
+        // must be `colormap[0]`.
+        for px in 0..WIDTH {
+            let bgra = linear_pixel(&linear, WIDTH, 0, px);
+            if (480..=544).contains(&px) {
+                assert_eq!(
+                    bgra, saturation,
+                    "px {px} (inside active slice) must carry signal colour"
+                );
+            } else {
+                assert_eq!(
+                    bgra, floor,
+                    "px {px} (outside active slice) must carry colormap[0]"
+                );
+            }
+        }
+    }
+
+    /// Per #516: when the scanner has engaged but no channel is
+    /// active yet (between `enter_scanner_mode` and the first
+    /// `set_scanner_active_channel`), the push must still
+    /// advance the ring and produce a uniform `colormap[0]` row
+    /// — historical rows scroll downward at the normal cadence,
+    /// just dark.
+    #[test]
+    fn push_line_locked_with_no_active_channel_fills_dark() {
+        const WIDTH: usize = 1024;
+        let mut r = WaterfallRenderer::new(WIDTH);
+        r.set_db_range(DEFAULT_MIN_DB, DEFAULT_MAX_DB);
+        let floor = r.colormap_bgra[0];
+
+        let fft = vec![0.0_f32; 256];
+        let lock = ScannerAxisLock {
+            min_hz: 144_000_000.0,
+            max_hz: 148_000_000.0,
+            active_channel_hz: None,
+            active_channel_bw_hz: None,
+        };
+        r.push_line_locked(&fft, 250_000.0, &lock);
+
+        let linear = r.linearized_pixel_buf();
+        for px in 0..WIDTH {
+            assert_eq!(
+                linear_pixel(&linear, WIDTH, 0, px),
+                floor,
+                "px {px}: with no active channel, the entire row must be colormap[0]",
             );
         }
     }

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -246,10 +246,18 @@ impl WaterfallRenderer {
                     lock.max_hz,
                     w,
                 );
-                if !x.is_finite() || x < 0.0 || x >= w {
+                // Allow `x == w` so a bin landing exactly on
+                // the upper-bound pixel (boundary-aligned
+                // inputs — last bin maps to `active + bw/2`,
+                // which can equal `axis_max_hz` when the
+                // active channel sits at the upper envelope
+                // edge) still renders. Clamp via `min(w-1)` so
+                // the cast below is in-range. Per `CodeRabbit`
+                // round 1 on PR #562.
+                if !x.is_finite() || x < 0.0 || x > w {
                     continue;
                 }
-                let pixel_idx = x as usize;
+                let pixel_idx = x.min(w - 1.0) as usize;
                 let normalized = ((db - self.min_db) / db_range).clamp(0.0, 1.0);
                 let val = (normalized * 255.0).round() as u8;
                 // Per-pixel max-pool: narrow channels squeeze

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -231,6 +231,19 @@ impl WaterfallRenderer {
         // stale row from N rotations ago) on every push.
         self.row_buffer.fill(0);
 
+        // Zero-width guard. `new(0)` / `resize(0)` produce a
+        // renderer with `display_width == 0`; the projection
+        // below would underflow `w - 1.0` to negative and cast
+        // to a huge `usize`, panicking on the
+        // `self.row_buffer[pixel_idx]` index. Skip the projection
+        // and the pixel-row write — but DO advance the ring so
+        // historical rows still scroll downward at the normal
+        // cadence. Per `CodeRabbit` round 2 on PR #562.
+        if self.display_width == 0 {
+            self.top_row = (self.top_row + HISTORY_LINES - 1) % HISTORY_LINES;
+            return;
+        }
+
         // Step 2 — when a channel is active, project narrow
         // bins into the active slice's pixels.
         if let Some(active_hz) = lock.active_channel_hz {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -916,6 +916,29 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
 /// engine sending a separate `ActiveChannelChanged { key: None }`
 /// event in the same tick — which it does today, but relying on
 /// that ordering across four sites was brittle.
+/// Sync the Display panel's read-only "Scanner axis" status row
+/// to match the current scanner-axis-lock state. Called from
+/// every site that engages / disengages the lock — the master
+/// switch handler in `connect_scanner_panel`, plus the DSP
+/// scanner-stop fan-out (`ScannerEmptyRotation`,
+/// `ScannerMutexStopped`) so the row tracks the actual lock
+/// state instead of just the master switch position. Per issue
+/// #516.
+fn update_scanner_axis_status_row(row: &adw::ActionRow, range_hz: Option<(f64, f64)>) {
+    if let Some((min_hz, max_hz)) = range_hz {
+        let subtitle = format!(
+            "{} – {}",
+            spectrum::frequency_axis::format_frequency(min_hz),
+            spectrum::frequency_axis::format_frequency(max_hz),
+        );
+        row.set_subtitle(&subtitle);
+        row.set_visible(true);
+    } else {
+        row.set_subtitle("");
+        row.set_visible(false);
+    }
+}
+
 fn clear_scanner_active_channel_ui(
     scanner_panel: &sidebar::scanner_panel::ScannerPanel,
     state: &AppState,
@@ -1292,6 +1315,13 @@ fn handle_dsp_message(
                 let freq_f64 = freq_hz as f64;
                 state.center_frequency.set(freq_f64);
                 state.demod_mode.set(demod_mode);
+                // Push the active-channel context to the
+                // scanner-axis lock — drives the highlight
+                // band over the channel's bandwidth and the
+                // narrow-FFT projection into the locked X
+                // axis. No-op when the lock isn't engaged.
+                // Per issue #516.
+                spectrum_handle.set_scanner_active_channel(freq_f64, bandwidth);
 
                 scanner_panel.active_channel_row.set_subtitle(&format!(
                     "{} — {}",
@@ -2903,7 +2933,7 @@ fn connect_sidebar_panels(
     connect_audio_panel(panels, state);
     connect_volume_persistence(panels, state, config, volume_button);
     connect_distance_estimator_persistence(panels, config);
-    connect_scanner_panel(panels, state, config);
+    connect_scanner_panel(panels, state, config, spectrum_handle);
     // "Tune to satellite" closure used by the Satellites panel's
     // per-row play buttons. Mirrors the bookmark-recall dance in
     // `connect_navigation_panel` end-to-end: forces the scanner
@@ -8982,6 +9012,7 @@ fn connect_scanner_panel(
     panels: &SidebarPanels,
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
+    spectrum_handle: &Rc<spectrum::SpectrumHandle>,
 ) {
     let scanner = &panels.scanner;
 
@@ -8998,9 +9029,55 @@ fn connect_scanner_panel(
     //     dispatch is idempotent at the engine — it's cheaper to
     //     pay one extra message per event than to add a suppress
     //     flag for every DSP-origin sync site.
+    // Master switch dispatches `SetScannerEnabled` AND drives
+    // the spectrum's scanner-axis lock. On enable, compute the
+    // (min, max) envelope of all scanner-flagged bookmarks and
+    // push it to the spectrum so the X axis pins to that range
+    // until the scanner stops. On disable, clear the lock so
+    // the spectrum reverts to "current channel ± half BW".
+    // The display panel's status row mirrors the lock state via
+    // the `update_scanner_axis_status_row` helper. Per issue
+    // #516.
     let state_switch = Rc::clone(state);
+    let bookmarks_for_switch = Rc::clone(&panels.bookmarks);
+    let config_for_switch = std::sync::Arc::clone(config);
+    let spectrum_for_switch = Rc::clone(spectrum_handle);
+    let display_axis_row = panels.display.scanner_axis_row.clone();
     scanner.master_switch.connect_active_notify(move |sw| {
-        state_switch.send_dsp(UiToDsp::SetScannerEnabled(sw.is_active()));
+        let enabled = sw.is_active();
+        state_switch.send_dsp(UiToDsp::SetScannerEnabled(enabled));
+        if enabled {
+            // Project the live bookmark list through the
+            // shared scanner-channel projector so the envelope
+            // tracks the same default-dwell/hang resolution
+            // the engine sees.
+            let default_dwell_ms =
+                sidebar::scanner_panel::load_default_dwell_ms(&config_for_switch);
+            let default_hang_ms = sidebar::scanner_panel::load_default_hang_ms(&config_for_switch);
+            let channels = sidebar::navigation_panel::project_scanner_channels(
+                &bookmarks_for_switch.bookmarks.borrow(),
+                default_dwell_ms,
+                default_hang_ms,
+            );
+            if let Some((min_hz, max_hz)) =
+                sidebar::navigation_panel::scanner_channel_envelope(&channels)
+            {
+                spectrum_for_switch.enter_scanner_mode(min_hz, max_hz);
+                update_scanner_axis_status_row(&display_axis_row, Some((min_hz, max_hz)));
+            } else {
+                // No scan-enabled channels — leave the lock
+                // disengaged. Status row stays hidden so the
+                // user gets the standard "scanner is off"
+                // appearance. The engine itself will handle
+                // the empty channel set via its existing
+                // empty-rotation path.
+                spectrum_for_switch.exit_scanner_mode();
+                update_scanner_axis_status_row(&display_axis_row, None);
+            }
+        } else {
+            spectrum_for_switch.exit_scanner_mode();
+            update_scanner_axis_status_row(&display_axis_row, None);
+        }
     });
 
     // Restore persisted slider values BEFORE wiring the notify

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -902,20 +902,6 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     window.present();
 }
 
-/// Clear the scanner's active-channel UI surfaces back to the
-/// idle look: empty cache, placeholder label, hidden lockout
-/// button. Shared between the four events that mean "scanner
-/// isn't parked on a channel anymore":
-///   - `ScannerActiveChannelChanged { key: None }` (explicit
-///     idle edge)
-///   - `ScannerEmptyRotation` (rotation exhausted)
-///   - `ScannerMutexStopped::ScannerStoppedFor{Recording,Transcription}`
-///     (mutex fired)
-///
-/// Without the helper, those stop paths would depend on the
-/// engine sending a separate `ActiveChannelChanged { key: None }`
-/// event in the same tick — which it does today, but relying on
-/// that ordering across four sites was brittle.
 /// Recompute the scanner X-axis envelope from the live
 /// bookmark list and refresh the spectrum's lock + Display
 /// panel status row. Called from both the scanner master-
@@ -953,8 +939,32 @@ fn refresh_scanner_axis_lock(
             .scanner_axis_lock()
             .and_then(|lock| lock.active_channel_hz.zip(lock.active_channel_bw_hz));
         spectrum_handle.enter_scanner_mode(min_hz, max_hz);
+        // Reapply only if the prior active channel still exists
+        // in the refreshed scanner set. If the user just
+        // disabled or deleted the bookmark that was the active
+        // channel, reinstating its highlight would resurrect a
+        // channel that's no longer being sampled — the
+        // highlight would linger until the next DSP hop event
+        // arrived. Match by exact (frequency, bandwidth) tuple
+        // — same fields the prior tuple was sourced from, so
+        // float equality is safe (identical bit patterns
+        // round-trip through the SpectrumHandle store). Per
+        // `CodeRabbit` round 4 on PR #562.
         if let Some((freq_hz, bw_hz)) = prior_active {
-            spectrum_handle.set_scanner_active_channel(freq_hz, bw_hz);
+            #[allow(clippy::cast_precision_loss)]
+            let still_present = channels.iter().any(|ch| {
+                let center = ch.key.frequency_hz as f64;
+                (center - freq_hz).abs() < f64::EPSILON
+                    && (ch.bandwidth - bw_hz).abs() < f64::EPSILON
+            });
+            if still_present {
+                spectrum_handle.set_scanner_active_channel(freq_hz, bw_hz);
+            }
+            // Else: leave `active_channel_*` cleared by
+            // `enter_scanner_mode` above. The next
+            // `ScannerActiveChannelChanged` event from the DSP
+            // engine will fill it in, matching the "scanner on,
+            // no active channel" state.
         }
         update_scanner_axis_status_row(status_row, Some((min_hz, max_hz)));
     } else {
@@ -986,6 +996,20 @@ fn update_scanner_axis_status_row(row: &adw::ActionRow, range_hz: Option<(f64, f
     }
 }
 
+/// Clear the scanner's active-channel UI surfaces back to the
+/// idle look: empty cache, placeholder label, hidden lockout
+/// button. Shared between the four events that mean "scanner
+/// isn't parked on a channel anymore":
+///   - `ScannerActiveChannelChanged { key: None }` (explicit
+///     idle edge)
+///   - `ScannerEmptyRotation` (rotation exhausted)
+///   - `ScannerMutexStopped::ScannerStoppedFor{Recording,Transcription}`
+///     (mutex fired)
+///
+/// Without the helper, those stop paths would depend on the
+/// engine sending a separate `ActiveChannelChanged { key: None }`
+/// event in the same tick — which it does today, but relying on
+/// that ordering across four sites was brittle.
 fn clear_scanner_active_channel_ui(
     scanner_panel: &sidebar::scanner_panel::ScannerPanel,
     state: &AppState,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -902,6 +902,35 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     window.present();
 }
 
+/// Outcome of a [`refresh_scanner_axis_lock`] call. Lets the
+/// bookmark-mutation caller (which has access to the scanner
+/// sidebar widgets) keep `state.scanner_active_key`,
+/// `active_channel_row`, and `lockout_row` in sync when a
+/// refresh drops the previously-active channel from the
+/// rotation — otherwise the sidebar would still show the old
+/// channel name (and the lockout button stays visible) until
+/// the next `ScannerActiveChannelChanged` event arrived. The
+/// master-switch caller ignores the return because it engages
+/// the lock from a clean slate (no prior active to drop). Per
+/// `CodeRabbit` round 5 on PR #562.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScannerAxisRefreshOutcome {
+    /// Lock state didn't change in a way the sidebar cares
+    /// about: either the prior active channel still exists in
+    /// the new set (highlight reinstated), or there was no
+    /// prior active to begin with, or the lock was disengaged
+    /// because the channel set went empty.
+    Unchanged,
+    /// The prior active channel is no longer in the refreshed
+    /// scanner set (user disabled `scan_enabled` on it or
+    /// deleted the bookmark mid-scan). Caller should clear the
+    /// scanner-sidebar surfaces via
+    /// `clear_scanner_active_channel_ui` so the displayed
+    /// channel name + lockout-row visibility match the actual
+    /// "scanner on, no active channel" state.
+    ActiveChannelDropped,
+}
+
 /// Recompute the scanner X-axis envelope from the live
 /// bookmark list and refresh the spectrum's lock + Display
 /// panel status row. Called from both the scanner master-
@@ -912,12 +941,16 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
 /// second call site, scan-list edits silently let the lock
 /// stay pinned to a stale range until the user flips the
 /// master switch off-and-on. Per #516 smoke feedback.
+///
+/// Returns [`ScannerAxisRefreshOutcome::ActiveChannelDropped`]
+/// when the previously-active channel got removed from the new
+/// scanner set (so the caller can clear its sidebar surfaces).
 fn refresh_scanner_axis_lock(
     bookmarks: &[sidebar::navigation_panel::Bookmark],
     config: &std::sync::Arc<sdr_config::ConfigManager>,
     spectrum_handle: &spectrum::SpectrumHandle,
     status_row: &adw::ActionRow,
-) {
+) -> ScannerAxisRefreshOutcome {
     let default_dwell_ms = sidebar::scanner_panel::load_default_dwell_ms(config);
     let default_hang_ms = sidebar::scanner_panel::load_default_hang_ms(config);
     let channels = sidebar::navigation_panel::project_scanner_channels(
@@ -950,7 +983,7 @@ fn refresh_scanner_axis_lock(
         // float equality is safe (identical bit patterns
         // round-trip through the SpectrumHandle store). Per
         // `CodeRabbit` round 4 on PR #562.
-        if let Some((freq_hz, bw_hz)) = prior_active {
+        let outcome = if let Some((freq_hz, bw_hz)) = prior_active {
             #[allow(clippy::cast_precision_loss)]
             let still_present = channels.iter().any(|ch| {
                 let center = ch.key.frequency_hz as f64;
@@ -959,17 +992,33 @@ fn refresh_scanner_axis_lock(
             });
             if still_present {
                 spectrum_handle.set_scanner_active_channel(freq_hz, bw_hz);
+                ScannerAxisRefreshOutcome::Unchanged
+            } else {
+                // Leave `active_channel_*` cleared by
+                // `enter_scanner_mode` above (matches the
+                // "scanner on, no active channel" state) AND
+                // tell the caller the active was dropped, so
+                // the sidebar widgets get cleared in the same
+                // tick instead of waiting for the next DSP
+                // `ScannerActiveChannelChanged` event.
+                ScannerAxisRefreshOutcome::ActiveChannelDropped
             }
-            // Else: leave `active_channel_*` cleared by
-            // `enter_scanner_mode` above. The next
-            // `ScannerActiveChannelChanged` event from the DSP
-            // engine will fill it in, matching the "scanner on,
-            // no active channel" state.
-        }
+        } else {
+            ScannerAxisRefreshOutcome::Unchanged
+        };
         update_scanner_axis_status_row(status_row, Some((min_hz, max_hz)));
+        outcome
     } else {
+        // No channels left in the scanner set. The lock
+        // disengages, so the sidebar's active-channel surfaces
+        // also belong cleared — but `clear_scanner_active_channel_ui`
+        // already runs on the engine-side `ScannerEmptyRotation`
+        // event that this code path implies. Reporting
+        // `Unchanged` here keeps the bookmark-mutation
+        // callback from double-clearing.
         spectrum_handle.exit_scanner_mode();
         update_scanner_axis_status_row(status_row, None);
+        ScannerAxisRefreshOutcome::Unchanged
     }
 }
 
@@ -3120,6 +3169,7 @@ fn connect_sidebar_panels(
     let state_for_mutated = Rc::clone(state);
     let config_for_mutated = std::sync::Arc::clone(config);
     let scanner_switch_for_mutated = panels.scanner.master_switch.clone();
+    let scanner_panel_for_mutated = panels.scanner.clone();
     let spectrum_for_mutated = Rc::clone(spectrum_handle);
     let display_axis_row_for_mutated = panels.display.scanner_axis_row.clone();
     panels.bookmarks.connect_mutated(move || {
@@ -3138,12 +3188,24 @@ fn connect_sidebar_panels(
         // — the lock is already disengaged. Per issue #516
         // smoke feedback.
         if scanner_switch_for_mutated.is_active() {
-            refresh_scanner_axis_lock(
+            let outcome = refresh_scanner_axis_lock(
                 &bookmarks.bookmarks.borrow(),
                 &config_for_mutated,
                 &spectrum_for_mutated,
                 &display_axis_row_for_mutated,
             );
+            // If the helper dropped the previously-active
+            // channel (user disabled `scan_enabled` on the
+            // active bookmark or deleted it), clear the
+            // scanner-sidebar surfaces so the displayed
+            // channel name + lockout-row visibility match.
+            // Without this, the spectrum highlight clears
+            // immediately but the sidebar stays stale until
+            // the next `ScannerActiveChannelChanged` event.
+            // Per `CodeRabbit` round 5 on PR #562.
+            if outcome == ScannerAxisRefreshOutcome::ActiveChannelDropped {
+                clear_scanner_active_channel_ui(&scanner_panel_for_mutated, &state_for_mutated);
+            }
         }
     });
 }
@@ -9166,9 +9228,12 @@ fn connect_scanner_panel(
             // mid-scan scan-flag toggles + adds/deletes pick up
             // on the next master-switch flip. The same helper
             // also fires from the bookmark mutation callback to
-            // refresh while the scanner is already running. Per
-            // issue #516.
-            refresh_scanner_axis_lock(
+            // refresh while the scanner is already running.
+            // Outcome is irrelevant here: this enable path
+            // engages the lock from a clean slate (no prior
+            // active to drop), so `ActiveChannelDropped` can't
+            // fire. Per issue #516.
+            let _ = refresh_scanner_axis_lock(
                 &bookmarks_for_switch.bookmarks.borrow(),
                 &config_for_switch,
                 &spectrum_for_switch,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1480,12 +1480,19 @@ fn handle_dsp_message(
                 ));
             }
             // Engine is already back to Idle — drop the master
-            // switch to match. `set_state` propagates to `active`
-            // and fires `notify::active`, which the master switch's
-            // `connect_active_notify` handler dispatches as a
-            // redundant `SetScannerEnabled(false)` — idempotent on
-            // the engine side (scanner's already Idle), so no harm.
-            scanner_panel.master_switch.set_state(false);
+            // switch to match. Use `set_active(false)` (NOT
+            // `set_state(false)`): per GtkSwitch semantics,
+            // `set_state` only fires `notify::state` and leaves
+            // `active` decoupled, so the master switch's
+            // `connect_active_notify` handler — which now also
+            // tears down the scanner-axis lock + Display panel
+            // status row (#516) — wouldn't run. `set_active`
+            // updates both properties and fires `notify::active`,
+            // dispatching a redundant `SetScannerEnabled(false)`
+            // (idempotent at the engine — scanner's already
+            // Idle) AND triggering the lock teardown. Per
+            // `CodeRabbit` round 3 on PR #562.
+            scanner_panel.master_switch.set_active(false);
             // Clear the active-channel surfaces locally rather
             // than waiting for a separate `ActiveChannelChanged
             // { key: None }` event — the engine sends it today,
@@ -1518,7 +1525,13 @@ fn handle_dsp_message(
                     "Recording stopped — Scanner activated"
                 }
                 sdr_core::messages::ScannerMutexReason::ScannerStoppedForRecording => {
-                    scanner_panel.master_switch.set_state(false);
+                    // `set_active(false)` (NOT `set_state(false)`)
+                    // so `connect_active_notify` fires and tears
+                    // down the scanner-axis lock + status row.
+                    // See `ScannerEmptyRotation` for the full
+                    // rationale. Per `CodeRabbit` round 3 on
+                    // PR #562.
+                    scanner_panel.master_switch.set_active(false);
                     clear_scanner_active_channel_ui(scanner_panel, state);
                     "Scanner stopped — recording started"
                 }
@@ -9094,12 +9107,19 @@ fn connect_scanner_panel(
     //   - `ScannerForceDisable::trigger` calls `set_active(false)`
     //     on the same switch for manual-tune force-disable.
     //   - DSP-origin widget syncs (ScannerEmptyRotation,
-    //     ScannerMutexStopped::ScannerStopped*) call `set_state`,
-    //     which also propagates to active and fires notify::active.
+    //     ScannerMutexStopped::ScannerStopped*) call
+    //     `set_active(false)` so notify::active fires here.
+    //     `set_state(false)` would NOT trigger this handler —
+    //     per GtkSwitch semantics, `state` and `active` are
+    //     separate properties; `set_state` fires only
+    //     notify::state. The previous comment claimed
+    //     otherwise; corrected per `CodeRabbit` round 3 on PR
+    //     #562 once the post-stop scanner-axis-lock teardown
+    //     started depending on this handler running.
     //     The resulting redundant `SetScannerEnabled(false)`
-    //     dispatch is idempotent at the engine — it's cheaper to
-    //     pay one extra message per event than to add a suppress
-    //     flag for every DSP-origin sync site.
+    //     dispatch is idempotent at the engine — it's cheaper
+    //     to pay one extra message per event than to add a
+    //     suppress flag for every DSP-origin sync site.
     // Master switch dispatches `SetScannerEnabled` AND drives
     // the spectrum's scanner-axis lock. On enable, compute the
     // (min, max) envelope of all scanner-flagged bookmarks and

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -940,7 +940,22 @@ fn refresh_scanner_axis_lock(
         default_hang_ms,
     );
     if let Some((min_hz, max_hz)) = sidebar::navigation_panel::scanner_channel_envelope(&channels) {
+        // Snapshot the active-channel context BEFORE
+        // `enter_scanner_mode` resets it to `None`. Without
+        // this, a mid-scan bookmark mutation (the user toggles
+        // a `scan_enabled` flag while a channel is being
+        // sampled) would briefly clear the FFT highlight band
+        // and waterfall projection until the next
+        // `ScannerActiveChannelChanged` event arrived — a
+        // visually jarring blink during live editing. Per
+        // `CodeRabbit` round 2 on PR #562.
+        let prior_active = spectrum_handle
+            .scanner_axis_lock()
+            .and_then(|lock| lock.active_channel_hz.zip(lock.active_channel_bw_hz));
         spectrum_handle.enter_scanner_mode(min_hz, max_hz);
+        if let Some((freq_hz, bw_hz)) = prior_active {
+            spectrum_handle.set_scanner_active_channel(freq_hz, bw_hz);
+        }
         update_scanner_axis_status_row(status_row, Some((min_hz, max_hz)));
     } else {
         spectrum_handle.exit_scanner_mode();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -916,6 +916,38 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
 /// engine sending a separate `ActiveChannelChanged { key: None }`
 /// event in the same tick — which it does today, but relying on
 /// that ordering across four sites was brittle.
+/// Recompute the scanner X-axis envelope from the live
+/// bookmark list and refresh the spectrum's lock + Display
+/// panel status row. Called from both the scanner master-
+/// switch handler (when the user flips it on) AND the bookmark
+/// mutation callback (when the user toggles `scan_enabled` /
+/// deletes / adds a bookmark mid-scan, which can shift the
+/// envelope without the master switch moving). Without the
+/// second call site, scan-list edits silently let the lock
+/// stay pinned to a stale range until the user flips the
+/// master switch off-and-on. Per #516 smoke feedback.
+fn refresh_scanner_axis_lock(
+    bookmarks: &[sidebar::navigation_panel::Bookmark],
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+    spectrum_handle: &spectrum::SpectrumHandle,
+    status_row: &adw::ActionRow,
+) {
+    let default_dwell_ms = sidebar::scanner_panel::load_default_dwell_ms(config);
+    let default_hang_ms = sidebar::scanner_panel::load_default_hang_ms(config);
+    let channels = sidebar::navigation_panel::project_scanner_channels(
+        bookmarks,
+        default_dwell_ms,
+        default_hang_ms,
+    );
+    if let Some((min_hz, max_hz)) = sidebar::navigation_panel::scanner_channel_envelope(&channels) {
+        spectrum_handle.enter_scanner_mode(min_hz, max_hz);
+        update_scanner_axis_status_row(status_row, Some((min_hz, max_hz)));
+    } else {
+        spectrum_handle.exit_scanner_mode();
+        update_scanner_axis_status_row(status_row, None);
+    }
+}
+
 /// Sync the Display panel's read-only "Scanner axis" status row
 /// to match the current scanner-axis-lock state. Called from
 /// every site that engages / disengages the lock — the master
@@ -2867,7 +2899,7 @@ fn build_breakpoint(
 }
 
 /// Connect all sidebar panel controls to dispatch `UiToDsp` commands.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn connect_sidebar_panels(
     panels: &SidebarPanels,
     state: &Rc<AppState>,
@@ -3028,6 +3060,9 @@ fn connect_sidebar_panels(
     let bookmarks_weak = Rc::downgrade(&panels.bookmarks);
     let state_for_mutated = Rc::clone(state);
     let config_for_mutated = std::sync::Arc::clone(config);
+    let scanner_switch_for_mutated = panels.scanner.master_switch.clone();
+    let spectrum_for_mutated = Rc::clone(spectrum_handle);
+    let display_axis_row_for_mutated = panels.display.scanner_axis_row.clone();
     panels.bookmarks.connect_mutated(move || {
         let Some(bookmarks) = bookmarks_weak.upgrade() else {
             return;
@@ -3037,6 +3072,20 @@ fn connect_sidebar_panels(
             &state_for_mutated,
             &config_for_mutated,
         );
+        // Mid-scan scan-flag toggle / add / delete: recompute
+        // the X-axis envelope while the lock is engaged so the
+        // axis tracks the new range without requiring a master-
+        // switch off-and-on. No-op when the scanner isn't on
+        // — the lock is already disengaged. Per issue #516
+        // smoke feedback.
+        if scanner_switch_for_mutated.is_active() {
+            refresh_scanner_axis_lock(
+                &bookmarks.bookmarks.borrow(),
+                &config_for_mutated,
+                &spectrum_for_mutated,
+                &display_axis_row_for_mutated,
+            );
+        }
     });
 }
 
@@ -9047,33 +9096,18 @@ fn connect_scanner_panel(
         let enabled = sw.is_active();
         state_switch.send_dsp(UiToDsp::SetScannerEnabled(enabled));
         if enabled {
-            // Project the live bookmark list through the
-            // shared scanner-channel projector so the envelope
-            // tracks the same default-dwell/hang resolution
-            // the engine sees.
-            let default_dwell_ms =
-                sidebar::scanner_panel::load_default_dwell_ms(&config_for_switch);
-            let default_hang_ms = sidebar::scanner_panel::load_default_hang_ms(&config_for_switch);
-            let channels = sidebar::navigation_panel::project_scanner_channels(
+            // Compute envelope from the LIVE bookmark list so
+            // mid-scan scan-flag toggles + adds/deletes pick up
+            // on the next master-switch flip. The same helper
+            // also fires from the bookmark mutation callback to
+            // refresh while the scanner is already running. Per
+            // issue #516.
+            refresh_scanner_axis_lock(
                 &bookmarks_for_switch.bookmarks.borrow(),
-                default_dwell_ms,
-                default_hang_ms,
+                &config_for_switch,
+                &spectrum_for_switch,
+                &display_axis_row,
             );
-            if let Some((min_hz, max_hz)) =
-                sidebar::navigation_panel::scanner_channel_envelope(&channels)
-            {
-                spectrum_for_switch.enter_scanner_mode(min_hz, max_hz);
-                update_scanner_axis_status_row(&display_axis_row, Some((min_hz, max_hz)));
-            } else {
-                // No scan-enabled channels — leave the lock
-                // disengaged. Status row stays hidden so the
-                // user gets the standard "scanner is off"
-                // appearance. The engine itself will handle
-                // the empty channel set via its existing
-                // empty-rotation path.
-                spectrum_for_switch.exit_scanner_mode();
-                update_scanner_axis_status_row(&display_axis_row, None);
-            }
         } else {
             spectrum_for_switch.exit_scanner_mode();
             update_scanner_axis_status_row(&display_axis_row, None);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1437,6 +1437,13 @@ fn handle_dsp_message(
 
                 scanner_panel.lockout_row.set_visible(true);
             } else {
+                // Scanner went idle but lock stays engaged
+                // (between rotations or before engine flips
+                // back to Idle). Drop the active-channel
+                // context so the highlight band + narrow-data
+                // projection clear; wide axis stays pinned.
+                // Per `CodeRabbit` round 1 on PR #562.
+                spectrum_handle.clear_scanner_active_channel();
                 clear_scanner_active_channel_ui(scanner_panel, state);
             }
         }


### PR DESCRIPTION
## Summary

Pin the spectrum + waterfall X axis to the union of all scanner-channel passbands while the scanner is engaged. Retunes between channels no longer recentre the X axis — instead each channel's narrow FFT data lands in its slice of the wide range, the rest of the row gets the colormap's "no signal" floor, and the active channel is highlighted with a faint vertical band. The Display panel's "Scanner axis" status row mirrors the locked range.

Closes #516.

## Behaviour

| State | X axis | Waterfall fill | Active highlight |
|---|---|---|---|
| Scanner off | Current channel ± half BW (existing) | Bins fill row, tail at colormap[0] | none |
| Scanner on, no active channel yet | Locked envelope | Entire row at colormap[0] | none (band hidden) |
| Scanner on, channel active | Locked envelope | Active slice has signal, rest at colormap[0] | Faint vertical band over channel BW |

## Commits (intentional split for review)

1. **State + lifecycle methods** — `ScannerAxisLock` struct + `Rc<RefCell<Option<...>>>` field on `SpectrumHandle`, plus `enter_scanner_mode` / `set_scanner_active_channel` / `exit_scanner_mode`. State-only, no rendering changes.
2. **FFT plot rendering** — `FftPlotRenderer::render_locked` sibling of `render`. Grid spans locked range absolutely; trace bins project via new `bin_to_locked_x` pure helper (5 unit tests pinning projection math); active-channel highlight band drawn before trace.
3. **Waterfall sparse-fill** — `WaterfallRenderer::push_line_locked` fills entire row with `colormap[0]` then projects narrow bins into the active channel's pixel slice with per-pixel max-pool. 2 unit tests pinning slice-only fill + no-active-channel fallback.
4. **Wiring + Display panel status row** — `connect_active_notify` on the master switch + `ScannerActiveChannelChanged` handler drive the lock lifecycle. New `Scanner` group on the Display panel with a read-only "Scanner axis" `AdwActionRow`. New pure helper `scanner_channel_envelope(channels) -> Option<(f64, f64)>` (3 unit tests).
5. **Smoke fix: refresh on bookmark mutations** — extract `refresh_scanner_axis_lock` helper, call from both the master-switch handler and the bookmark mutation callback. Toggling a bookmark's `scan_enabled` flag mid-scan now updates the lock immediately instead of requiring an off-then-on cycle.

## UX choices (locked during scoping)

- **Dark grey fill** for unsampled waterfall regions (option b from the design conversation: `colormap[0]` floor, distinguishable from actually-quiet bands).
- **Wiring layer computes envelope** from `state.scanner_channels` + bookmarks; `SpectrumHandle` just renders.
- **Lock engages immediately** on `SetScannerEnabled(true)` — wide axis communicates "scanner mode" before the first retune.
- **Vertical band** for active-channel highlight (consistency with existing VFO overlay).
- **User-overridable range deferred** to a follow-up issue if real usage shows the auto envelope is bad UX.

## Test plan

- [x] `cargo build --workspace --features whisper-cpu`
- [x] `cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings`
- [x] `cargo test --workspace --features whisper-cpu` — 10 new unit tests pass (5 projection, 2 waterfall sparse-fill, 3 envelope)
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` (mutex cross-check)
- [x] `cargo fmt --all -- --check`
- [x] **Manual smoke (user)**: master switch on/off rescales axis correctly; mid-scan scan-flag toggles update lock immediately without master-switch cycling. UX is clean for typical VHF/UHF scanner ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only "Scanner axis" status row in settings (hidden until scanner mode) showing locked X-axis range.
  * Spectrum view: locked-axis rendering during scanner sessions, active-channel highlight, and cursor mapped to absolute frequencies.
  * Waterfall: renders into the locked span and highlights active-channel content.
  * Scanner span auto-syncs from bookmarks and live DSP active-channel events.

* **Tests**
  * Added unit tests for envelope calculation, bin→pixel projection, and locked-waterfall rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->