### PR TITLE
fix: offset-tuning replay toasts + scanner-locked click/drag (closes #564, #563)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -2542,10 +2542,26 @@ fn rtl_sdr_replay_persisted_settings(
         let _ = dsp_tx.send(DspToUi::Error(format!("Direct sampling failed: {e}")));
     }
 
-    if let Err(e) = source.set_offset_tuning(state.offset_tuning_enabled) {
+    // Only replay an *enabled* offset-tuning state. The
+    // librtlsdr R820T-family branch returns `InvalidParameter`
+    // for every `set_offset_tuning` call regardless of the
+    // value — even setting it to `false`, which is already the
+    // driver default. Replaying `false` on every source open
+    // therefore generated a spurious "Offset tuning failed"
+    // toast for the vast majority of users (R820T2 / R828D
+    // dongles) at every Play / source-type switch / source-
+    // restart, even when they never enabled the toggle.
+    // Replaying `true` still goes through — that's the actual
+    // hardware-state restore path that matters for E4000
+    // tuners. The user-driven toggle (the `SetOffsetTuning`
+    // handler at line ~1693) keeps surfacing errors so an
+    // explicit user action gets explicit feedback. Per issue
+    // #564.
+    if state.offset_tuning_enabled
+        && let Err(e) = source.set_offset_tuning(true)
+    {
         tracing::warn!(
             error = %e,
-            enabled = state.offset_tuning_enabled,
             "re-applying persisted offset-tuning on source open failed"
         );
         let _ = dsp_tx.send(DspToUi::Error(format!("Offset tuning failed: {e}")));

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -32,6 +32,19 @@ type CursorCallback = Rc<RefCell<Option<Box<dyn Fn(f64, f32)>>>>;
 /// user click-to-tunes or drags the VFO to a new frequency offset.
 type VfoOffsetCallback = Rc<RefCell<Option<Box<dyn Fn(f64)>>>>;
 
+/// Scanner-mode click-to-tune callback — invoked with the
+/// **absolute** frequency (in Hz) under the click when the
+/// scanner-axis lock is engaged. The wiring layer registers a
+/// callback that force-disables the scanner (via
+/// `ScannerForceDisable::trigger`, which flips the master
+/// switch and tears down the lock) and dispatches a manual
+/// tune. Distinct from `VfoOffsetCallback` because the
+/// dispatch shape is different — `UiToDsp::Tune(absolute)`,
+/// not `UiToDsp::SetVfoOffset(relative)` — and because the
+/// scanner-disable side-effect needs widget access that
+/// `attach_click_gesture` doesn't have. Per issue #563.
+type LockedClickCallback = Rc<RefCell<Option<Box<dyn Fn(f64)>>>>;
+
 /// Number of FFT bins for the display (used for initial buffer sizing).
 const FFT_SIZE: usize = 2048;
 
@@ -114,6 +127,12 @@ pub struct SpectrumHandle {
     /// (click-to-tune or drag). Used by `window.rs` to update the frequency
     /// display and status bar.
     vfo_offset_callback: VfoOffsetCallback,
+    /// Callback invoked on click in scanner-locked mode, with the
+    /// absolute frequency under the click. Lets the wiring layer
+    /// force-disable the scanner and tune absolutely without
+    /// `attach_click_gesture` needing direct access to
+    /// `ScannerForceDisable`. Per issue #563.
+    locked_click_callback: LockedClickCallback,
     /// Full (unzoomed) FFT bandwidth in Hz, set by `set_display_bandwidth()`.
     /// Used by the FFT plot and waterfall renderers for zoom mapping.
     full_bandwidth: Rc<Cell<f64>>,
@@ -546,6 +565,21 @@ impl SpectrumHandle {
     pub fn connect_vfo_offset_changed<F: Fn(f64) + 'static>(&self, f: F) {
         *self.vfo_offset_callback.borrow_mut() = Some(Box::new(f));
     }
+
+    /// Register a callback invoked on click in scanner-locked
+    /// mode, with the **absolute** frequency (Hz) under the
+    /// click. The wiring layer registers a callback that
+    /// force-disables the scanner (which tears down the lock
+    /// via the master switch's `connect_active_notify`) and
+    /// dispatches `UiToDsp::Tune(absolute)` plus the usual
+    /// frequency-display + spectrum-centre + status-bar
+    /// updates. Without this, click in scanner mode would
+    /// dispatch a centre-relative VFO offset against a
+    /// wandering active-channel centre — semantically broken.
+    /// Per issue #563.
+    pub fn connect_locked_click_to_tune<F: Fn(f64) + 'static>(&self, f: F) {
+        *self.locked_click_callback.borrow_mut() = Some(Box::new(f));
+    }
 }
 
 /// Height in pixels for the collapsible signal history area.
@@ -570,6 +604,7 @@ pub fn build_spectrum_view(
     let fill_enabled: Rc<Cell<bool>> = Rc::new(Cell::new(true));
     let cursor_callback: CursorCallback = Rc::new(RefCell::new(None));
     let vfo_offset_callback: VfoOffsetCallback = Rc::new(RefCell::new(None));
+    let locked_click_callback: LockedClickCallback = Rc::new(RefCell::new(None));
     let full_bandwidth: Rc<Cell<f64>> = Rc::new(Cell::new(0.0));
     let center_freq: Rc<Cell<f64>> = Rc::new(Cell::new(100_000_000.0)); // default 100 MHz
     let scanner_axis_lock: Rc<RefCell<Option<ScannerAxisLock>>> = Rc::new(RefCell::new(None));
@@ -619,8 +654,16 @@ pub fn build_spectrum_view(
         &vfo_state,
         dsp_tx.clone(),
         &vfo_offset_callback,
+        &scanner_axis_lock,
+        &locked_click_callback,
     );
-    attach_drag_gesture(&waterfall_area, &vfo_state, dsp_tx, &vfo_offset_callback);
+    attach_drag_gesture(
+        &waterfall_area,
+        &vfo_state,
+        dsp_tx,
+        &vfo_offset_callback,
+        &scanner_axis_lock,
+    );
     attach_scroll_gesture(&waterfall_area, &vfo_state);
 
     // Also attach scroll-to-zoom on the FFT area for convenience.
@@ -704,6 +747,7 @@ pub fn build_spectrum_view(
         avg_buffer: Rc::new(RefCell::new(Vec::new())),
         cursor_callback,
         vfo_offset_callback,
+        locked_click_callback,
         full_bandwidth,
         center_freq,
         scanner_axis_lock,
@@ -945,22 +989,60 @@ fn build_signal_history_area(
 /// Attach a click-to-tune gesture to a `DrawingArea`.
 ///
 /// Single-clicking sets the VFO center to the clicked frequency.
+#[allow(clippy::too_many_arguments)]
 fn attach_click_gesture(
     area: &gtk4::DrawingArea,
     vfo_state: &Rc<RefCell<VfoState>>,
     dsp_tx: std::sync::mpsc::Sender<UiToDsp>,
     vfo_offset_callback: &VfoOffsetCallback,
+    scanner_axis_lock: &Rc<RefCell<Option<ScannerAxisLock>>>,
+    locked_click_callback: &LockedClickCallback,
 ) {
     let click = gtk4::GestureClick::new();
 
     let vfo_state = Rc::clone(vfo_state);
     let area_weak = area.downgrade();
     let offset_cb = Rc::clone(vfo_offset_callback);
+    let click_lock = Rc::clone(scanner_axis_lock);
+    let locked_click_cb = Rc::clone(locked_click_callback);
     click.connect_pressed(move |_gesture, _n_press, x, _y| {
         let Some(area) = area_weak.upgrade() else {
             return;
         };
         let width = f64::from(area.width());
+
+        // Scanner-locked path: the X axis represents an
+        // absolute multi-channel range, not a centre-relative
+        // VFO. A click here means "I see something interesting,
+        // jump to it" — which only makes sense after force-
+        // disabling the scanner so the radio actually parks on
+        // the chosen frequency. The wiring layer's callback
+        // handles both: flips the master switch off (which
+        // tears down the lock via `connect_active_notify`)
+        // and dispatches `UiToDsp::Tune(absolute_freq)`. Skip
+        // the regular SetVfoOffset path entirely — it'd dispatch
+        // a centre-relative offset against a wandering active-
+        // channel centre, which is meaningless. Per issue #563.
+        let lock_snapshot = *click_lock.borrow();
+        if let Some(lock) = lock_snapshot {
+            if width <= 0.0 {
+                return;
+            }
+            let frac = (x / width).clamp(0.0, 1.0);
+            let abs_freq_hz = lock.min_hz + frac * (lock.max_hz - lock.min_hz);
+            tracing::debug!(
+                click_x = x,
+                width,
+                abs_freq_hz,
+                "scanner-locked click-to-tune: dispatching absolute tune"
+            );
+            if let Some(cb) = locked_click_cb.borrow().as_ref() {
+                cb(abs_freq_hz);
+            }
+            area.queue_draw();
+            return;
+        }
+
         let mut vfo = vfo_state.borrow_mut();
         let hz = vfo.pixel_to_hz(x, width);
         // Snapshot display span + max span BEFORE mutating offset so
@@ -1005,12 +1087,13 @@ fn attach_click_gesture(
 }
 
 /// Attach a drag gesture for VFO center movement and bandwidth handle adjustment.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
 fn attach_drag_gesture(
     area: &gtk4::DrawingArea,
     vfo_state: &Rc<RefCell<VfoState>>,
     dsp_tx: std::sync::mpsc::Sender<UiToDsp>,
     vfo_offset_callback: &VfoOffsetCallback,
+    scanner_axis_lock: &Rc<RefCell<Option<ScannerAxisLock>>>,
 ) {
     let drag = gtk4::GestureDrag::new();
 
@@ -1023,10 +1106,24 @@ fn attach_drag_gesture(
     let start_offset = Rc::clone(&drag_start_offset_hz);
     let start_bw = Rc::clone(&drag_start_bw_hz);
     let area_weak_begin = area.downgrade();
+    let drag_lock = Rc::clone(scanner_axis_lock);
     drag.connect_drag_begin(move |_gesture, x, _y| {
         let Some(area) = area_weak_begin.upgrade() else {
             return;
         };
+        // Suppress drag entirely while the scanner-axis lock
+        // is engaged. Drag-VFO and drag-bandwidth are inherently
+        // single-channel operations; the wide multi-channel
+        // axis has no compatible meaning. The user can still
+        // click-to-tune (see `attach_click_gesture`'s lock-aware
+        // path), which force-disables the scanner before
+        // tuning. Per issue #563.
+        if drag_lock.borrow().is_some() {
+            let mut vfo = vfo_begin.borrow_mut();
+            vfo.dragging = false;
+            vfo.bw_dragging = None;
+            return;
+        }
         let width = f64::from(area.width());
         let mut vfo = vfo_begin.borrow_mut();
         let hit = vfo.hit_test(x, width);

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -1160,10 +1160,26 @@ fn attach_drag_gesture(
     let area_weak_update = area.downgrade();
     let dsp_tx_update = dsp_tx.clone();
     let offset_cb = Rc::clone(vfo_offset_callback);
+    let drag_lock_update = Rc::clone(scanner_axis_lock);
     drag.connect_drag_update(move |_gesture, offset_x, _offset_y| {
         let Some(area) = area_weak_update.upgrade() else {
             return;
         };
+        // Re-check the lock at every update tick. If the
+        // scanner engaged mid-gesture (e.g. a Doppler retune
+        // hit at the same moment the user started dragging),
+        // bail and clear the local drag flags so subsequent
+        // updates also short-circuit. Without this, a drag
+        // begun before the lock engaged would keep emitting
+        // `SetVfoOffset` / `SetBandwidth` against a wide
+        // multi-channel axis where the math is meaningless.
+        // Per `CodeRabbit` round 1 on PR #565.
+        if drag_lock_update.borrow().is_some() {
+            let mut vfo = vfo_update.borrow_mut();
+            vfo.dragging = false;
+            vfo.bw_dragging = None;
+            return;
+        }
         let width = f64::from(area.width());
         let mut vfo = vfo_update.borrow_mut();
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -632,6 +632,38 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
         status_bar_for_vfo.update_frequency(tuned);
     });
 
+    // Scanner-locked click-to-tune (#563). When the scanner-axis
+    // lock is engaged and the user clicks the spectrum, the
+    // gesture handler calls this callback with the absolute
+    // frequency under the click. We force-disable the scanner
+    // (which tears down the lock via the master switch's
+    // `connect_active_notify`), then dispatch a normal manual
+    // tune — same end shape as the freq-selector path below.
+    // Force-disable runs FIRST so the engine sees
+    // `SetScannerEnabled(false)` before the `Tune`, and the
+    // subsequent retune lands on an Idle scanner.
+    let status_bar_for_locked_click = Rc::clone(&status_bar_demod);
+    let state_for_locked_click = Rc::clone(&state);
+    let spectrum_for_locked_click = Rc::clone(&spectrum_handle);
+    let freq_selector_for_locked_click = freq_selector.clone();
+    let force_disable_for_locked_click = Rc::clone(&scanner_force_disable);
+    let radio_for_locked_click = panels.radio.clone();
+    spectrum_handle.connect_locked_click_to_tune(move |freq_hz| {
+        tracing::debug!(
+            freq_hz,
+            "scanner-locked click-to-tune: force-disable + tune"
+        );
+        force_disable_for_locked_click.trigger("scanner spectrum click");
+        state_for_locked_click.center_frequency.set(freq_hz);
+        state_for_locked_click.send_dsp(UiToDsp::Tune(freq_hz));
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let freq_u64 = freq_hz.max(0.0) as u64;
+        freq_selector_for_locked_click.set_frequency(freq_u64);
+        status_bar_for_locked_click.update_frequency(freq_hz);
+        spectrum_for_locked_click.set_center_frequency(freq_hz);
+        radio_for_locked_click.update_distance_frequency(freq_hz);
+    });
+
     let status_bar_for_freq = Rc::clone(&status_bar_demod);
     let state_freq = Rc::clone(&state);
     let spectrum_for_freq = Rc::clone(&spectrum_handle);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -6989,10 +6989,22 @@ fn connect_source_panel(
     // as bias-T above. The controller bridge
     // (`UiToDsp::SetOffsetTuning`) was already plumbed; only
     // wiring is new here.
+    //
+    // Only DISPATCH the persisted value when it's `true`. The
+    // librtlsdr R820T-family branch returns `InvalidParameter`
+    // for every `set_offset_tuning` call regardless of value —
+    // dispatching `false` at startup (the default for users
+    // who've never touched the toggle) generates a spurious
+    // "Offset tuning failed" toast on the vast majority of
+    // dongles. The driver default already matches `false`, so
+    // skipping the dispatch is semantically a no-op. Per issue
+    // #564.
     {
         let persisted = sidebar::source_panel::load_source_rtl_offset_tuning(config);
         panels.source.offset_tuning_row.set_active(persisted);
-        state.send_dsp(UiToDsp::SetOffsetTuning(persisted));
+        if persisted {
+            state.send_dsp(UiToDsp::SetOffsetTuning(true));
+        }
     }
     let state_offset = Rc::clone(state);
     let config_offset = std::sync::Arc::clone(config);

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -109,6 +109,47 @@ impl ScannerForceDisable {
     }
 }
 
+/// Apply a manual tune originated by user UI interaction —
+/// shared between the freq-selector `connect_frequency_changed`
+/// handler and the scanner-locked spectrum click callback. Both
+/// follow the same five-step recipe:
+///
+/// 1. Force-disable the scanner so the engine sees
+///    `SetScannerEnabled(false)` BEFORE the `Tune` lands —
+///    avoids racing a scanner retune with the manual tune.
+/// 2. Update the cached center frequency in `AppState`.
+/// 3. Dispatch `UiToDsp::Tune` to the engine.
+/// 4. Sync the status bar's frequency readout.
+/// 5. Sync the spectrum widget's centre + the Radio panel's
+///    FSPL distance estimator (#164).
+///
+/// Per-caller specifics that DON'T fit the helper:
+/// - The freq-selector widget itself: scanner-locked click
+///   needs to push the new value INTO it (the click came from
+///   the spectrum); freq-selector handler skips that step (the
+///   value originated there).
+/// - Bookmark recall: also restores demod mode + bandwidth +
+///   tuning profile, which is a different shape and stays
+///   inline in `connect_navigation_panel`.
+///
+/// Per `CodeRabbit` round 1 on PR #565.
+fn apply_manual_tune(
+    freq_hz: f64,
+    reason: &str,
+    state: &Rc<AppState>,
+    force_disable: &ScannerForceDisable,
+    status_bar: &Rc<StatusBar>,
+    spectrum_handle: &Rc<spectrum::SpectrumHandle>,
+    radio_panel: &sidebar::radio_panel::RadioPanel,
+) {
+    force_disable.trigger(reason);
+    state.center_frequency.set(freq_hz);
+    state.send_dsp(UiToDsp::Tune(freq_hz));
+    status_bar.update_frequency(freq_hz);
+    spectrum_handle.set_center_frequency(freq_hz);
+    radio_panel.update_distance_frequency(freq_hz);
+}
+
 /// Build and present the main application window.
 #[allow(clippy::too_many_lines)]
 pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::ConfigManager>) {
@@ -638,12 +679,15 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // frequency under the click. We force-disable the scanner
     // (which tears down the lock via the master switch's
     // `connect_active_notify`), then dispatch a normal manual
-    // tune — same end shape as the freq-selector path below.
-    // Force-disable runs FIRST so the engine sees
-    // `SetScannerEnabled(false)` before the `Tune`, and the
-    // subsequent retune lands on an Idle scanner.
-    let status_bar_for_locked_click = Rc::clone(&status_bar_demod);
+    // tune via the shared `apply_manual_tune` helper — same
+    // end shape as the freq-selector path below. Locked-click
+    // additionally syncs the freq-selector widget (the click
+    // came from the spectrum, not the selector, so the
+    // selector display needs catching up); the freq-selector
+    // handler skips that step because the value originated
+    // there. Per `CodeRabbit` round 1 on PR #565.
     let state_for_locked_click = Rc::clone(&state);
+    let status_bar_for_locked_click = Rc::clone(&status_bar_demod);
     let spectrum_for_locked_click = Rc::clone(&spectrum_handle);
     let freq_selector_for_locked_click = freq_selector.clone();
     let force_disable_for_locked_click = Rc::clone(&scanner_force_disable);
@@ -653,39 +697,45 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
             freq_hz,
             "scanner-locked click-to-tune: force-disable + tune"
         );
-        force_disable_for_locked_click.trigger("scanner spectrum click");
-        state_for_locked_click.center_frequency.set(freq_hz);
-        state_for_locked_click.send_dsp(UiToDsp::Tune(freq_hz));
+        apply_manual_tune(
+            freq_hz,
+            "scanner spectrum click",
+            &state_for_locked_click,
+            &force_disable_for_locked_click,
+            &status_bar_for_locked_click,
+            &spectrum_for_locked_click,
+            &radio_for_locked_click,
+        );
+        // The click originated on the spectrum — the freq
+        // selector widget didn't move, so push the new value
+        // into it manually. (The freq-selector handler skips
+        // this step because the value came FROM the selector.)
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let freq_u64 = freq_hz.max(0.0) as u64;
         freq_selector_for_locked_click.set_frequency(freq_u64);
-        status_bar_for_locked_click.update_frequency(freq_hz);
-        spectrum_for_locked_click.set_center_frequency(freq_hz);
-        radio_for_locked_click.update_distance_frequency(freq_hz);
     });
 
-    let status_bar_for_freq = Rc::clone(&status_bar_demod);
     let state_freq = Rc::clone(&state);
+    let status_bar_for_freq = Rc::clone(&status_bar_demod);
     let spectrum_for_freq = Rc::clone(&spectrum_handle);
     let force_disable_freq = Rc::clone(&scanner_force_disable);
     let radio_for_freq = panels.radio.clone();
     freq_selector.connect_frequency_changed(move |freq| {
         tracing::debug!(frequency_hz = freq, "frequency changed");
-        // Flip scanner off before dispatching the tune so the
-        // engine receives the `SetScannerEnabled(false)` first —
-        // the subsequent `Tune` then lands on an Idle scanner and
-        // doesn't race a retune command.
-        force_disable_freq.trigger("manual tune");
         #[allow(clippy::cast_precision_loss)]
         let freq_f64 = freq as f64;
-        state_freq.center_frequency.set(freq_f64);
-        state_freq.send_dsp(UiToDsp::Tune(freq_f64));
-        status_bar_for_freq.update_frequency(freq_f64);
-        spectrum_for_freq.set_center_frequency(freq_f64);
-        // Feed the FSPL distance estimator in the Radio panel
-        // with the new frequency so the cached distance estimate
-        // uses the right carrier (ticket #164).
-        radio_for_freq.update_distance_frequency(freq_f64);
+        apply_manual_tune(
+            freq_f64,
+            "manual tune",
+            &state_freq,
+            &force_disable_freq,
+            &status_bar_for_freq,
+            &spectrum_for_freq,
+            &radio_for_freq,
+        );
+        // No `freq_selector.set_frequency` here — the value
+        // ORIGINATED in the selector, calling set on it would
+        // be a no-op at best and a feedback loop at worst.
     });
     // Single demod-change handler: gate → force-disable → dispatch
     // → cosmetic UI updates. Order matters: force-disable must


### PR DESCRIPTION
## Summary

Two follow-ups from PR #562 smoke testing, bundled per usual cross-cutting-review preference:

- **#564** — Offset-tuning replay no longer spams "Offset tuning failed" toasts on R820T-family tuners (the vast majority of dongles).
- **#563** — Spectrum click + drag interaction math is now scanner-axis-lock-aware: click force-disables the scanner and tunes to the absolute frequency under the click; drag is suppressed while locked.

Closes #564.
Closes #563.

## #564 — Offset-tuning false-replay toasts

The librtlsdr R820T / R820T2 / R828D branch returns `InvalidParameter` for every `rtlsdr_set_offset_tuning` call regardless of value — even setting it to `false`, which is already the driver's default state. Two replay sites unconditionally drove `set_offset_tuning(state)`:

- Startup dispatch (`window.rs::connect_source_panel`).
- Source-rebuild replay (`controller.rs::set_active_source`, fires on every Play / source-type change / source-restart).

Each `false` replay generated a toast for users who never enabled the toggle. Both sites now skip the call when requesting `false`. The driver default already matches; the call has no semantic effect anyway. Replaying `true` still goes through (real hardware-state restore for E4000 tuners). The user-driven toggle handler keeps surfacing errors — explicit user actions still get explicit feedback.

Bias-T deliberately keeps unconditional replay because its `false` call genuinely flips a GPIO low (needed when switching from powered to passive antennas).

## #563 — Scanner-locked click + drag

Round-1 of PR #562 fixed the cursor readout to be lock-aware but deferred click + drag.

**Click in scanner mode (option 1 from the issue):** force-disable scanner + tune to absolute frequency under the click. Mirrors the existing freq-selector + bookmark-recall manual-tune flow:

```
ScannerForceDisable::trigger("scanner spectrum click")
  → master_switch.set_active(false)
  → connect_active_notify fires
    → SetScannerEnabled(false) to DSP
    → spectrum exit_scanner_mode
    → Display panel status row hides
UiToDsp::Tune(absolute_freq)
freq_selector.set_frequency(...)
status_bar.update_frequency(...)
spectrum.set_center_frequency(...)
radio_panel.update_distance_frequency(...)
```

**Drag in scanner mode:** suppressed entirely. Drag-VFO and drag-bandwidth are inherently single-channel operations; the wide multi-channel axis has no compatible meaning. User can click-to-tune (which force-disables) and then drag normally afterward.

### Architecture

- New `LockedClickCallback` callback type on `SpectrumHandle` + `connect_locked_click_to_tune` registration method. Spectrum-side gesture handlers don't have direct access to `ScannerForceDisable` (window.rs-private struct), so the wiring layer registers a callback that performs both the force-disable and the tune.
- `attach_click_gesture` consults `scanner_axis_lock`. When engaged, computes absolute frequency from `lock.min_hz + frac * span` and invokes the registered callback. Skips the existing `SetVfoOffset` dispatch (centre-relative against a wandering active-channel centre — semantically broken).
- `attach_drag_gesture` consults the same lock at `connect_drag_begin` and short-circuits when engaged.

## Test plan

- [x] `cargo build --workspace --features whisper-cpu`
- [x] `cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings`
- [x] `cargo test --workspace --features whisper-cpu`
- [x] `cargo check --workspace --no-default-features --features sherpa-cpu` (mutex cross-check)
- [x] `cargo fmt --all -- --check`
- [x] **Manual smoke (in progress on user's R820T):**
  - Cold launch, click Play, switch source types: no spurious "Offset tuning failed" toast.
  - User explicit toggle of Offset Tuning ON: toast still fires (explicit-action feedback preserved).
  - Click in scanner mode → scanner flips off, radio tunes to clicked freq, lock disengages cleanly.
  - Drag in scanner mode → suppressed (no VFO movement / bandwidth-handle drag).
  - Click + drag with scanner OFF: existing VFO behavior preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click-to-tune now works when the scanner axis is locked; manual tuning flow unified for consistent UI updates (status, spectrum center, frequency selector).
  * Drag gestures are suppressed while scanner lock is active to avoid accidental tuning.

* **Bug Fixes**
  * Prevents spurious "Offset tuning failed" errors by only restoring offset-tuning when the persisted toggle is enabled.
  * Frequency selector updates avoid feedback-loop/no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->