### PR TITLE
feat: per-satellite pre-pass notify subscriptions (#510)

### DIFF
--- a/crates/sdr-ui/src/notify.rs
+++ b/crates/sdr-ui/src/notify.rs
@@ -1,17 +1,40 @@
 //! Desktop notification helper via `GNotification`.
 //!
-//! Uses GTK's `gio::Notification` API which integrates with the running
-//! `GtkApplication` and supports click-to-open actions.
+//! Uses GTK's `gio::Notification` API which on Linux maps directly
+//! onto the freedesktop `org.freedesktop.Notifications` D-Bus
+//! interface — same path `notify-send` (and `nwg-notifications` on
+//! the receiving side) speaks. We get urgency hints, action buttons,
+//! and click-to-open via the standard spec without any zbus / dbus
+//! plumbing of our own.
+//!
+//! Two flavors of notification:
+//!
+//! * [`send`] — plain "summary + body + optional click-to-open"
+//!   used by the existing one-off pings (PNG export success/failure,
+//!   etc.).
+//! * [`send_pass_alert`] — richer pre-pass alert used by #510. Sets
+//!   High priority (so notification daemons that honor it surface
+//!   the popup over an idle desktop), adds a "Tune" button bound to
+//!   the `app.tune-satellite` action with the NORAD id as target,
+//!   and falls back gracefully if no `GApplication` is running.
 
 use gtk4::gio;
 use gtk4::glib;
 use gtk4::prelude::*;
+use sdr_sat::Pass;
+
+/// `GApplication` action name fired when the user clicks the "Tune"
+/// button on a pre-pass alert. Target type is `u32` (NORAD id);
+/// the handler — registered in `window.rs::connect_satellites_panel`
+/// — looks the satellite up in [`sdr_sat::KNOWN_SATELLITES`] for
+/// downlink frequency / demod mode / channel bandwidth.
+pub const TUNE_SATELLITE_ACTION: &str = "tune-satellite";
 
 /// Send a desktop notification. If `open_path` is provided, clicking the
 /// notification opens the file with the default application.
 pub fn send(summary: &str, body: &str, open_path: Option<&std::path::Path>) {
     let Some(app) = gio::Application::default() else {
-        tracing::debug!("no default GApplication — skipping notification");
+        tracing::debug!("no default `GApplication` — skipping notification");
         return;
     };
 
@@ -26,9 +49,57 @@ pub fn send(summary: &str, body: &str, open_path: Option<&std::path::Path>) {
     app.send_notification(Some("sdr-rs-notify"), &notification);
 }
 
+/// Fire a pre-pass alert for a watched satellite. Per #510.
+///
+/// The notification includes:
+///
+/// * Title: `"NOAA 19 — overhead in 5 min"`.
+/// * Body: peak elevation + AOS/LOS azimuths (multi-line).
+/// * Priority: `High` — picked over `Urgent` because pass alerts
+///   are timely but not life-critical; `Urgent` (which maps to
+///   urgency=2 / "critical" on the freedesktop bus) is reserved
+///   for actual emergencies and many daemons keep critical popups
+///   on screen until manually dismissed.
+/// * A "Tune" action button that invokes `app.tune-satellite`
+///   with the NORAD id as a `u32` target value. The handler is
+///   registered separately in `window.rs::connect_satellites_panel`.
+///
+/// `lead_min` is the lead time in minutes the user configured —
+/// passed in rather than recomputed from `pass.start - now` so the
+/// title matches what the scheduler decided when it crossed the
+/// threshold.
+pub fn send_pass_alert(pass: &Pass, norad_id: u32, lead_min: u32) {
+    let Some(app) = gio::Application::default() else {
+        tracing::debug!("no default `GApplication` — skipping pass alert");
+        return;
+    };
+    let summary = format!("{} — overhead in {} min", pass.satellite, lead_min);
+    let body = format!(
+        "Peak elevation {:.0}°  ·  AOS {:.0}° → LOS {:.0}°",
+        pass.max_elevation_deg, pass.start_az_deg, pass.end_az_deg,
+    );
+    let notification = gio::Notification::new(&summary);
+    notification.set_body(Some(&body));
+    notification.set_priority(gio::NotificationPriority::High);
+    notification.add_button_with_target_value(
+        "Tune",
+        &format!("app.{TUNE_SATELLITE_ACTION}"),
+        Some(&norad_id.to_variant()),
+    );
+    // Notification id keyed by `(norad, pass_start)` so a redelivery
+    // of the same pass (e.g. user reconnects to the bus) replaces
+    // rather than stacks. Different passes / different sats get
+    // distinct ids and surface as separate notifications.
+    let id = format!("sdr-rs-pass-{norad_id}-{}", pass.start.timestamp());
+    app.send_notification(Some(&id), &notification);
+}
+
 /// Register the `app.open-uri` action on the application.
 ///
 /// Call once during startup so notification click actions work.
+/// The companion `app.tune-satellite` action is registered later
+/// in `window.rs::connect_satellites_panel` because it needs
+/// access to the per-window `tune_to_satellite` closure.
 pub fn register_actions(app: &impl IsA<gio::ActionMap>) {
     let open_action = gio::SimpleAction::new("open-uri", Some(glib::VariantTy::STRING));
     open_action.connect_activate(|_, param| {

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -11,6 +11,7 @@ pub mod display_panel;
 pub mod general_panel;
 pub mod navigation_panel;
 pub mod radio_panel;
+pub mod satellites_notify;
 pub mod satellites_panel;
 pub mod satellites_recorder;
 pub mod scanner_panel;

--- a/crates/sdr-ui/src/sidebar/satellites_notify.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_notify.rs
@@ -32,11 +32,14 @@
 //!
 //! ## GC
 //!
-//! `fired` is pruned every tick: any entry whose `pass.end` is in
-//! the past is dropped. So the set's size is bounded by
-//! "concurrently in-flight or upcoming passes" — typically a
-//! handful at most. Without GC the set would grow unbounded over
-//! a long-running session.
+//! `fired` is pruned every [`tick`](NotifyScheduler::tick): an
+//! entry is dropped once `pass.start + GC_GRACE` is in the past.
+//! `GC_GRACE` is sized to outlast any realistic LEO pass plus a
+//! margin (30 min today) so an in-window notification can't get a
+//! duplicate fire from the GC racing the next tick. The set's
+//! steady-state size is bounded by "concurrently in-flight or
+//! upcoming passes" — typically a handful at most. Without GC the
+//! set would grow unbounded over a long-running session.
 
 use std::collections::HashSet;
 

--- a/crates/sdr-ui/src/sidebar/satellites_notify.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_notify.rs
@@ -1,0 +1,358 @@
+//! Per-satellite "notify me" scheduler — pure state machine.
+//!
+//! Companion to [`satellites_recorder`](super::satellites_recorder)
+//! that fires a desktop notification at T-`lead_min` for any pass
+//! whose satellite is in the watched set. Same separation as the
+//! recorder: this module is pure (no GTK, no I/O), `tick()` returns
+//! a `Vec<Action>` that the wiring layer in
+//! `window.rs::connect_satellites_panel` interprets.
+//!
+//! The shape mirrors the recorder for two reasons:
+//!
+//! 1. **Unit-testable.** Pass synthesis + a `chrono::DateTime`
+//!    advance trick lets every threshold case live in
+//!    `#[cfg(test)] mod tests` without spinning up a GTK harness
+//!    or a notification daemon.
+//! 2. **One firing per pass.** The same dedup discipline the
+//!    recorder uses for AOS / LOS — a `HashSet<NotifyKey>` keyed by
+//!    `(norad_id, pass.start)` — keeps "in window for 5 min" from
+//!    spamming five notifications.
+//!
+//! Per #510.
+//!
+//! ## Notification semantics
+//!
+//! For each watched satellite whose next pass crosses
+//! `(start - lead) <= now < start`, fire **once** per pass.
+//! The wiring layer is responsible for translating each
+//! `Action::Fire` into a desktop notification via
+//! [`crate::notify`]; this module only decides *when* and
+//! *what content* (passing the `Pass` and a copy of the
+//! catalog name through unchanged).
+//!
+//! ## GC
+//!
+//! `fired` is pruned every tick: any entry whose `pass.end` is in
+//! the past is dropped. So the set's size is bounded by
+//! "concurrently in-flight or upcoming passes" — typically a
+//! handful at most. Without GC the set would grow unbounded over
+//! a long-running session.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use sdr_sat::Pass;
+
+/// Default lead-time before AOS at which the notification fires.
+/// Per #510: "T-5 minutes is a reasonable default. Worth making it
+/// a single config knob".
+pub const DEFAULT_NOTIFY_LEAD_MIN: u32 = 5;
+
+/// Lower / upper bounds on the user-configurable lead time (minutes).
+/// Lower bound `1` keeps the notification meaningful (anything less
+/// gives the user no time to react). Upper bound `60` exceeds any
+/// realistic LEO pre-pass prep window.
+pub const NOTIFY_LEAD_MIN_LOWER: u32 = 1;
+pub const NOTIFY_LEAD_MIN_UPPER: u32 = 60;
+
+/// Dedup key for the `fired` set. `(norad_id, pass_start_unix)`
+/// uniquely identifies a pass — two passes of the same satellite
+/// can't share a start time (they're sorted in the SGP4 output).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct NotifyKey {
+    norad_id: u32,
+    pass_start_unix: i64,
+}
+
+/// Action returned by [`NotifyScheduler::tick`]. The wiring layer
+/// translates each action into a `gio::Notification`. Not
+/// `PartialEq` because [`sdr_sat::Pass`] isn't — tests pattern-match
+/// on individual fields instead of comparing whole actions.
+#[derive(Debug, Clone)]
+pub enum Action {
+    /// Fire a "satellite overhead in N minutes" notification.
+    Fire {
+        /// NORAD catalog id — passed through to the notification's
+        /// "Tune" action target so the action handler can look the
+        /// satellite up in `KNOWN_SATELLITES` for downlink / mode /
+        /// bandwidth.
+        norad_id: u32,
+        /// Display name of the satellite (e.g. `"NOAA 19"`).
+        sat_name: String,
+        /// The pass itself — the wiring layer reads `start`,
+        /// `max_elevation_deg`, `start_az_deg`, `end_az_deg` from
+        /// it for the notification body.
+        pass: Pass,
+        /// Lead-time in minutes the user configured. Carried so
+        /// the notification body can read "in 5 min" rather than
+        /// recomputing from `pass.start - now` (and risking a
+        /// "in 4 min" rendering when the tick arrives 30 s late).
+        lead_min: u32,
+    },
+}
+
+/// State machine for per-pass notifications.
+///
+/// Single-threaded — driven from the GTK main loop only.
+#[derive(Debug, Default)]
+pub struct NotifyScheduler {
+    fired: HashSet<NotifyKey>,
+}
+
+impl NotifyScheduler {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Per-tick driver. Returns the actions to fire this tick.
+    ///
+    /// * `now` — current UTC time. Caller passes the same `now` it
+    ///   uses for the rest of the tick so render and notify decisions
+    ///   stay consistent.
+    /// * `lead` — configured lead time. Stored as a `ChronoDuration`
+    ///   rather than `u32 minutes` so unit tests can poke unusual
+    ///   values (e.g. zero-duration to verify the boundary).
+    /// * `lead_min` — same lead time in whole minutes, threaded into
+    ///   `Action::Fire` so the body text doesn't have to re-derive
+    ///   it from `lead.num_minutes()`.
+    /// * `is_watched` — predicate against the user's watched-set.
+    ///   A predicate (rather than a `&HashSet<u32>`) keeps the
+    ///   module independent of how the wiring layer represents the
+    ///   set (`Vec<u32>` from config vs. `HashSet<u32>` for
+    ///   membership) and keeps the test cases trivial.
+    /// * `passes` — the upcoming pass list, in any order. Each
+    ///   pass's `satellite` name is looked up against
+    ///   [`KNOWN_SATELLITES`](sdr_sat::KNOWN_SATELLITES) by the
+    ///   wiring layer to map name → NORAD id; here we receive the
+    ///   already-mapped `(norad_id, pass)` pairs.
+    pub fn tick<'a, I, F>(
+        &mut self,
+        now: DateTime<Utc>,
+        lead: ChronoDuration,
+        lead_min: u32,
+        passes: I,
+        is_watched: F,
+    ) -> Vec<Action>
+    where
+        I: IntoIterator<Item = (u32, &'a Pass)>,
+        F: Fn(u32) -> bool,
+    {
+        // GC first so the dedup check below sees an up-to-date set.
+        self.fired.retain(|key| {
+            // We don't carry pass.end in the key, so we approximate:
+            // a key is stale once its `pass_start_unix` is more than
+            // a generous LEO-pass duration in the past. 30 minutes
+            // covers the longest realistic LEO horizon-to-horizon
+            // pass and avoids a name-lookup on every tick. The
+            // looseness is fine — false positives only delay GC by
+            // at most one full pass duration; they don't gate
+            // anything.
+            now.timestamp() - key.pass_start_unix < GC_GRACE.num_seconds()
+        });
+
+        let mut actions = Vec::new();
+        for (norad_id, pass) in passes {
+            if !is_watched(norad_id) {
+                continue;
+            }
+            let to_start = pass.start - now;
+            // Window: `0 < to_start <= lead`. Excluding zero / negative
+            // means we don't fire for passes already in progress —
+            // the user wanted advance notice, and an in-progress pass
+            // is too late for "in N min" to make sense.
+            if to_start <= ChronoDuration::zero() || to_start > lead {
+                continue;
+            }
+            let key = NotifyKey {
+                norad_id,
+                pass_start_unix: pass.start.timestamp(),
+            };
+            if !self.fired.insert(key) {
+                continue;
+            }
+            actions.push(Action::Fire {
+                norad_id,
+                sat_name: pass.satellite.clone(),
+                pass: pass.clone(),
+                lead_min,
+            });
+        }
+        actions
+    }
+}
+
+/// GC grace window — a fired entry is dropped this long after the
+/// pass started. Sized to outlast any realistic LEO pass plus a
+/// margin so an in-window notification never gets a duplicate fire
+/// from the GC racing the next tick. Pure bookkeeping.
+const GC_GRACE: ChronoDuration = ChronoDuration::minutes(30);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn synthetic_pass(satellite: &str, start: DateTime<Utc>, duration_min: i64) -> Pass {
+        Pass {
+            satellite: satellite.to_string(),
+            start,
+            end: start + ChronoDuration::minutes(duration_min),
+            max_elevation_deg: 56.0,
+            max_el_time: start + ChronoDuration::minutes(duration_min / 2),
+            start_az_deg: 245.0,
+            end_az_deg: 105.0,
+        }
+    }
+
+    fn anchor() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn fires_when_within_lead_window() {
+        let now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        // Pass starts in 4 min — inside the 5 min lead window.
+        let pass = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(4), 12);
+        let mut sched = NotifyScheduler::new();
+        let actions = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| true);
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            Action::Fire {
+                norad_id,
+                sat_name,
+                lead_min,
+                ..
+            } => {
+                assert_eq!(*norad_id, 33591);
+                assert_eq!(sat_name, "NOAA 19");
+                assert_eq!(*lead_min, 5);
+            }
+        }
+    }
+
+    #[test]
+    fn does_not_fire_outside_window() {
+        let now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        // Pass starts in 10 min — well outside the 5 min lead.
+        let pass = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(10), 12);
+        let mut sched = NotifyScheduler::new();
+        let actions = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| true);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn does_not_fire_for_unwatched_satellite() {
+        let now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        let pass = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(4), 12);
+        let mut sched = NotifyScheduler::new();
+        // is_watched returns false → no action.
+        let actions = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| false);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn dedups_across_consecutive_ticks() {
+        let mut now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        let pass = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(4), 12);
+        let mut sched = NotifyScheduler::new();
+
+        // First tick — fires.
+        let a1 = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| true);
+        assert_eq!(a1.len(), 1);
+
+        // Advance one second, same pass — must NOT re-fire.
+        now += ChronoDuration::seconds(1);
+        let a2 = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| true);
+        assert!(a2.is_empty(), "second tick re-fired: {a2:?}");
+
+        // Advance to T+1 min into the pass — must NOT fire again.
+        now = pass.start + ChronoDuration::minutes(1);
+        let a3 = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| true);
+        assert!(a3.is_empty());
+    }
+
+    #[test]
+    fn does_not_fire_for_pass_already_in_progress() {
+        let now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        // Pass started 30 s ago — `to_start` is negative.
+        let pass = synthetic_pass("NOAA 19", now - ChronoDuration::seconds(30), 12);
+        let mut sched = NotifyScheduler::new();
+        let actions = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| true);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn fires_again_for_a_later_pass_of_same_satellite() {
+        let mut now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        let mut sched = NotifyScheduler::new();
+
+        // First pass — starts in 4 min.
+        let pass_a = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(4), 12);
+        let a1 = sched.tick(now, lead, 5, [(33591u32, &pass_a)], |_| true);
+        assert_eq!(a1.len(), 1);
+
+        // 100 minutes later — first pass long over, GC has dropped it,
+        // and a new pass starts in 4 min. Must fire — different
+        // pass, different key, so the dedup set lets it through.
+        now += ChronoDuration::minutes(100);
+        let pass_b = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(4), 12);
+        let a2 = sched.tick(now, lead, 5, [(33591u32, &pass_b)], |_| true);
+        assert_eq!(a2.len(), 1, "second pass did not fire: {a2:?}");
+    }
+
+    #[test]
+    fn boundary_at_exactly_lead_minutes_fires() {
+        let now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        // Exactly `lead` away — `to_start <= lead` includes the
+        // upper boundary on purpose. Without this, a pass at exactly
+        // T-5:00 would skip the only tick where it's in range.
+        let pass = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(5), 12);
+        let mut sched = NotifyScheduler::new();
+        let actions = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| true);
+        assert_eq!(actions.len(), 1);
+    }
+
+    #[test]
+    fn handles_multiple_watched_passes_in_one_tick() {
+        let now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        let pass_a = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(2), 12);
+        let pass_b = synthetic_pass("METEOR-M2 2", now + ChronoDuration::minutes(3), 12);
+        let mut sched = NotifyScheduler::new();
+        let watched: HashSet<u32> = [33591u32, 40069u32].into_iter().collect();
+        let actions = sched.tick(
+            now,
+            lead,
+            5,
+            [(33591u32, &pass_a), (40069u32, &pass_b)],
+            |id| watched.contains(&id),
+        );
+        assert_eq!(actions.len(), 2);
+    }
+
+    #[test]
+    fn gc_drops_long_past_entries() {
+        let mut now = anchor();
+        let lead = ChronoDuration::minutes(5);
+        let mut sched = NotifyScheduler::new();
+
+        let pass = synthetic_pass("NOAA 19", now + ChronoDuration::minutes(4), 12);
+        let _ = sched.tick(now, lead, 5, [(33591u32, &pass)], |_| true);
+        assert_eq!(sched.fired.len(), 1);
+
+        // Advance to >GC_GRACE past `pass.start` (not past `now`):
+        // the GC predicate measures elapsed time since the pass
+        // started, so we need `now - pass.start >= GC_GRACE`.
+        now = pass.start + GC_GRACE + ChronoDuration::minutes(1);
+        let _: Vec<Action> = sched.tick(now, lead, 5, std::iter::empty(), |_| true);
+        assert!(sched.fired.is_empty(), "GC did not drop stale entry");
+    }
+}

--- a/crates/sdr-ui/src/sidebar/satellites_notify.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_notify.rs
@@ -73,18 +73,21 @@ struct NotifyKey {
 /// on individual fields instead of comparing whole actions.
 #[derive(Debug, Clone)]
 pub enum Action {
-    /// Fire a "satellite overhead in N minutes" notification.
+    /// Fire a "satellite overhead in N minutes" notification. The
+    /// satellite display name is carried on `pass.satellite` — no
+    /// separate `sat_name` field, since duplicating it would
+    /// allocate the same string twice per fire (once on the Pass
+    /// clone, once on the field) for no payoff. Per CR round 2 on
+    /// PR #568.
     Fire {
         /// NORAD catalog id — passed through to the notification's
         /// "Tune" action target so the action handler can look the
         /// satellite up in `KNOWN_SATELLITES` for downlink / mode /
         /// bandwidth.
         norad_id: u32,
-        /// Display name of the satellite (e.g. `"NOAA 19"`).
-        sat_name: String,
-        /// The pass itself — the wiring layer reads `start`,
-        /// `max_elevation_deg`, `start_az_deg`, `end_az_deg` from
-        /// it for the notification body.
+        /// The pass itself — the wiring layer reads `satellite`,
+        /// `start`, `max_elevation_deg`, `start_az_deg`,
+        /// `end_az_deg` from it for the notification body.
         pass: Pass,
         /// Lead-time in minutes the user configured. Carried so
         /// the notification body can read "in 5 min" rather than
@@ -176,7 +179,6 @@ impl NotifyScheduler {
             }
             actions.push(Action::Fire {
                 norad_id,
-                sat_name: pass.satellite.clone(),
                 pass: pass.clone(),
                 lead_min,
             });
@@ -224,12 +226,11 @@ mod tests {
         match &actions[0] {
             Action::Fire {
                 norad_id,
-                sat_name,
+                pass,
                 lead_min,
-                ..
             } => {
                 assert_eq!(*norad_id, 33591);
-                assert_eq!(sat_name, "NOAA 19");
+                assert_eq!(pass.satellite, "NOAA 19");
                 assert_eq!(*lead_min, 5);
             }
         }

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -129,6 +129,13 @@ pub const KEY_AUTO_RECORD_AUDIO: &str = "sat_auto_record_audio";
 /// (Satellites panel). Default `true` so first-launch users get
 /// auto-corrected passes out of the box. Per issue #521.
 pub const KEY_DOPPLER_TRACKING_ENABLED: &str = "sat_doppler_tracking_enabled";
+/// Config key for the watched-satellites NORAD-id list (per #510).
+/// Stored as a JSON array of `u32`. Empty / missing → no
+/// notifications fire.
+pub const KEY_WATCHED_SATELLITES: &str = "sat_watched_norad_ids";
+/// Config key for the user-configurable pre-pass notify lead time,
+/// in whole minutes. Per #510.
+pub const KEY_NOTIFY_LEAD_MIN: &str = "sat_notify_lead_min";
 
 // ─── Panel ─────────────────────────────────────────────────────────────
 
@@ -177,6 +184,14 @@ pub struct SatellitesPanel {
     /// in flight. Sibling to the button rather than wrapping it so
     /// the button stays clickable visually after the fetch ends.
     pub refresh_spinner: gtk4::Spinner,
+
+    // Notifications group ---------------------------------------------------
+    /// Pre-pass desktop-alert lead time, in whole minutes
+    /// (`NOTIFY_LEAD_MIN_LOWER..=NOTIFY_LEAD_MIN_UPPER`). Drives
+    /// the `NotifyScheduler` ticker — the user clicks 🔔 next to a
+    /// pass to subscribe; this row controls *how early* the alert
+    /// fires. Per #510.
+    pub notify_lead_row: adw::SpinRow,
 
     // Recording group -------------------------------------------------------
     /// Auto-record toggle — drives #482's "open APT viewer +
@@ -245,6 +260,8 @@ pub struct SatellitesPanelWeak {
     pub refresh_button: glib::WeakRef<gtk4::Button>,
     /// Weak ref to [`SatellitesPanel::refresh_spinner`].
     pub refresh_spinner: glib::WeakRef<gtk4::Spinner>,
+    /// Weak ref to [`SatellitesPanel::notify_lead_row`].
+    pub notify_lead_row: glib::WeakRef<adw::SpinRow>,
     /// Weak ref to [`SatellitesPanel::auto_record_switch`].
     pub auto_record_switch: glib::WeakRef<adw::SwitchRow>,
     /// Weak ref to [`SatellitesPanel::auto_record_audio_switch`].
@@ -274,6 +291,7 @@ impl SatellitesPanel {
             last_refresh_row: self.last_refresh_row.downgrade(),
             refresh_button: self.refresh_button.downgrade(),
             refresh_spinner: self.refresh_spinner.downgrade(),
+            notify_lead_row: self.notify_lead_row.downgrade(),
             auto_record_switch: self.auto_record_switch.downgrade(),
             auto_record_audio_switch: self.auto_record_audio_switch.downgrade(),
             doppler_switch: self.doppler_switch.downgrade(),
@@ -302,6 +320,7 @@ impl SatellitesPanelWeak {
             last_refresh_row: self.last_refresh_row.upgrade()?,
             refresh_button: self.refresh_button.upgrade()?,
             refresh_spinner: self.refresh_spinner.upgrade()?,
+            notify_lead_row: self.notify_lead_row.upgrade()?,
             auto_record_switch: self.auto_record_switch.upgrade()?,
             auto_record_audio_switch: self.auto_record_audio_switch.upgrade()?,
             doppler_switch: self.doppler_switch.upgrade()?,
@@ -417,6 +436,27 @@ pub fn build_satellites_panel() -> SatellitesPanel {
     tle_group.add(&last_refresh_row);
     page.add(&tle_group);
 
+    // ─── Notifications ─────────────────────────────────────────
+    let notify_group = adw::PreferencesGroup::builder()
+        .title("Notifications")
+        .description(
+            "Click 🔔 next to a pass to subscribe; you'll get a desktop \
+             alert this many minutes before the satellite comes overhead.",
+        )
+        .build();
+
+    let notify_lead_row = adw::SpinRow::with_range(
+        f64::from(super::satellites_notify::NOTIFY_LEAD_MIN_LOWER),
+        f64::from(super::satellites_notify::NOTIFY_LEAD_MIN_UPPER),
+        1.0,
+    );
+    notify_lead_row.set_title("Lead time");
+    notify_lead_row.set_subtitle("Minutes before AOS to fire the alert");
+    notify_lead_row.set_digits(0);
+    notify_lead_row.set_value(f64::from(super::satellites_notify::DEFAULT_NOTIFY_LEAD_MIN));
+    notify_group.add(&notify_lead_row);
+    page.add(&notify_group);
+
     // ─── Recording ─────────────────────────────────────────────
     let recording_group = adw::PreferencesGroup::builder()
         .title("Recording")
@@ -491,6 +531,7 @@ pub fn build_satellites_panel() -> SatellitesPanel {
         last_refresh_row,
         refresh_button,
         refresh_spinner,
+        notify_lead_row,
         auto_record_switch,
         auto_record_audio_switch,
         doppler_switch,
@@ -574,6 +615,71 @@ pub fn save_auto_record_audio(config: &Arc<ConfigManager>, value: bool) {
 pub fn save_doppler_tracking_enabled(config: &Arc<ConfigManager>, enabled: bool) {
     config.write(|v| {
         v[KEY_DOPPLER_TRACKING_ENABLED] = serde_json::json!(enabled);
+    });
+}
+
+/// Load the persisted set of watched-satellite NORAD ids. Per #510.
+/// Stored as a JSON array; entries with the wrong type are dropped
+/// silently (cheaper than refusing the whole list, and still safe
+/// because non-watched ids just don't fire notifications).
+#[must_use]
+pub fn load_watched_satellites(config: &Arc<ConfigManager>) -> std::collections::HashSet<u32> {
+    config.read(|v| {
+        v.get(KEY_WATCHED_SATELLITES)
+            .and_then(serde_json::Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(serde_json::Value::as_u64)
+                    .filter_map(|n| u32::try_from(n).ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    })
+}
+
+/// Persist the watched-satellite NORAD-id set. Sorted on write so
+/// the JSON file diffs cleanly across saves (set iteration order is
+/// non-deterministic; sorting makes config commits readable).
+///
+/// Generic over `BuildHasher` so call sites that build the set with
+/// the default hasher don't have to thread a hasher type through —
+/// per the `clippy::implicit_hasher` recommendation. Cheap: every
+/// path is monomorphized inline.
+pub fn save_watched_satellites<S: std::hash::BuildHasher>(
+    config: &Arc<ConfigManager>,
+    watched: &std::collections::HashSet<u32, S>,
+) {
+    let mut sorted: Vec<u32> = watched.iter().copied().collect();
+    sorted.sort_unstable();
+    config.write(|v| {
+        v[KEY_WATCHED_SATELLITES] = serde_json::json!(sorted);
+    });
+}
+
+/// Load the persisted lead-minutes for pre-pass notifications.
+/// Defaults to [`super::satellites_notify::DEFAULT_NOTIFY_LEAD_MIN`]
+/// and clamps to the `[NOTIFY_LEAD_MIN_LOWER, NOTIFY_LEAD_MIN_UPPER]`
+/// range so a hand-edited config can't push us into degenerate
+/// states (e.g. `0` would flicker between fire and miss every
+/// tick). Per #510.
+#[must_use]
+pub fn load_notify_lead_min(config: &Arc<ConfigManager>) -> u32 {
+    use super::satellites_notify::{
+        DEFAULT_NOTIFY_LEAD_MIN, NOTIFY_LEAD_MIN_LOWER, NOTIFY_LEAD_MIN_UPPER,
+    };
+    let raw = config.read(|v| {
+        v.get(KEY_NOTIFY_LEAD_MIN)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(DEFAULT_NOTIFY_LEAD_MIN)
+    });
+    raw.clamp(NOTIFY_LEAD_MIN_LOWER, NOTIFY_LEAD_MIN_UPPER)
+}
+
+/// Persist the pre-pass notify lead time (whole minutes). Per #510.
+pub fn save_notify_lead_min(config: &Arc<ConfigManager>, lead_min: u32) {
+    config.write(|v| {
+        v[KEY_NOTIFY_LEAD_MIN] = serde_json::json!(lead_min);
     });
 }
 
@@ -662,6 +768,16 @@ fn known_satellite_for_pass(pass: &Pass) -> Option<&'static sdr_sat::KnownSatell
 #[must_use]
 pub fn downlink_hz_for_pass(pass: &Pass) -> Option<u64> {
     known_satellite_for_pass(pass).map(|s| s.downlink_hz)
+}
+
+/// Look up the NORAD catalog id for a pass's satellite. Returns
+/// `None` for off-catalog passes — same condition as
+/// [`downlink_hz_for_pass`]. Used by the notify scheduler (#510)
+/// to key the watched-satellite set without leaking the
+/// `KNOWN_SATELLITES` shape into [`super::satellites_notify`].
+#[must_use]
+pub fn norad_id_for_pass(pass: &Pass) -> Option<u32> {
+    known_satellite_for_pass(pass).map(|s| s.norad_id)
 }
 
 /// The full tuning quadruple — frequency, demod mode, channel
@@ -944,6 +1060,68 @@ mod tests {
             "sat_tle_last_refresh": "garbage timestamp",
         })));
         assert_eq!(format_last_refresh(&cfg), "garbage timestamp");
+    }
+
+    #[test]
+    fn watched_satellites_round_trip() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({})));
+        // Empty initial state.
+        assert!(load_watched_satellites(&cfg).is_empty());
+        // Save → load round-trip.
+        let mut watched = std::collections::HashSet::new();
+        watched.insert(33591u32); // NOAA 19
+        watched.insert(40069u32); // METEOR-M2 2
+        save_watched_satellites(&cfg, &watched);
+        let loaded = load_watched_satellites(&cfg);
+        assert_eq!(loaded, watched);
+    }
+
+    #[test]
+    fn watched_satellites_load_skips_invalid_entries() {
+        // Mixed-type array — strings / out-of-u32-range numbers
+        // get silently dropped; the valid u32s survive.
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            "sat_watched_norad_ids": [33591, "junk", 9999999999u64, 40069],
+        })));
+        let loaded = load_watched_satellites(&cfg);
+        let expected: std::collections::HashSet<u32> = [33591u32, 40069u32].into_iter().collect();
+        assert_eq!(loaded, expected);
+    }
+
+    #[test]
+    fn notify_lead_min_default_when_unset() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({})));
+        assert_eq!(
+            load_notify_lead_min(&cfg),
+            super::super::satellites_notify::DEFAULT_NOTIFY_LEAD_MIN
+        );
+    }
+
+    #[test]
+    fn notify_lead_min_clamps_out_of_range() {
+        // 0 is below NOTIFY_LEAD_MIN_LOWER (1) — clamps up.
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            "sat_notify_lead_min": 0,
+        })));
+        assert_eq!(
+            load_notify_lead_min(&cfg),
+            super::super::satellites_notify::NOTIFY_LEAD_MIN_LOWER
+        );
+        // 999 is above NOTIFY_LEAD_MIN_UPPER — clamps down.
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
+            "sat_notify_lead_min": 999,
+        })));
+        assert_eq!(
+            load_notify_lead_min(&cfg),
+            super::super::satellites_notify::NOTIFY_LEAD_MIN_UPPER
+        );
+    }
+
+    #[test]
+    fn notify_lead_min_round_trip() {
+        let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({})));
+        save_notify_lead_min(&cfg, 12);
+        assert_eq!(load_notify_lead_min(&cfg), 12);
     }
 
     fn synthetic_pass(now: DateTime<Utc>, offset_min: i64) -> Pass {

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -440,7 +440,7 @@ pub fn build_satellites_panel() -> SatellitesPanel {
     let notify_group = adw::PreferencesGroup::builder()
         .title("Notifications")
         .description(
-            "Click 🔔 next to a pass to subscribe; you'll get a desktop \
+            "Click the bell next to a pass to subscribe; you'll get a desktop \
              alert this many minutes before the satellite comes overhead.",
         )
         .build();
@@ -676,8 +676,15 @@ pub fn load_notify_lead_min(config: &Arc<ConfigManager>) -> u32 {
     raw.clamp(NOTIFY_LEAD_MIN_LOWER, NOTIFY_LEAD_MIN_UPPER)
 }
 
-/// Persist the pre-pass notify lead time (whole minutes). Per #510.
+/// Persist the pre-pass notify lead time (whole minutes). Clamps
+/// to `[NOTIFY_LEAD_MIN_LOWER, NOTIFY_LEAD_MIN_UPPER]` before
+/// writing — `load_notify_lead_min` clamps on read too, but
+/// clamping at the writer keeps the on-disk contract honest for
+/// any caller (tests, CLI tooling, future scripted edits) that
+/// hands us a raw value. Per #510 / CR round 1 on PR #568.
 pub fn save_notify_lead_min(config: &Arc<ConfigManager>, lead_min: u32) {
+    use super::satellites_notify::{NOTIFY_LEAD_MIN_LOWER, NOTIFY_LEAD_MIN_UPPER};
+    let lead_min = lead_min.clamp(NOTIFY_LEAD_MIN_LOWER, NOTIFY_LEAD_MIN_UPPER);
     config.write(|v| {
         v[KEY_NOTIFY_LEAD_MIN] = serde_json::json!(lead_min);
     });
@@ -1081,7 +1088,7 @@ mod tests {
         // Mixed-type array — strings / out-of-u32-range numbers
         // get silently dropped; the valid u32s survive.
         let cfg = Arc::new(ConfigManager::in_memory(&serde_json::json!({
-            "sat_watched_norad_ids": [33591, "junk", 9999999999u64, 40069],
+            "sat_watched_norad_ids": [33591, "junk", 9_999_999_999_u64, 40069],
         })));
         let loaded = load_watched_satellites(&cfg);
         let expected: std::collections::HashSet<u32> = [33591u32, 40069u32].into_iter().collect();

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -491,12 +491,25 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     // viewer should have closed). Backtrace is `Backtrace::capture`
     // so it costs nothing unless `RUST_BACKTRACE=1` is set. Per
     // PR #558 auto-record-close investigation.
+    //
+    // Also unregister `app.tune-satellite` here. The action was
+    // registered on the GApplication (because notification action
+    // targets resolve against the app's action map), but its
+    // closure captures window-owned widgets via `tune_to_satellite`.
+    // A pre-pass notification that sits in the daemon and gets
+    // clicked AFTER the window closes would fire the closure
+    // against destroyed widgets — silent setter calls + a `Tune`
+    // dispatch into a torn-down DSP channel. Removing the action
+    // on close means that click is treated as "no such action"
+    // rather than "tune via stale state". Per CR round 1 on PR #568.
+    let app_for_close = app.clone();
     window.connect_close_request(move |_| {
         let bt = std::backtrace::Backtrace::capture();
         tracing::info!(
             backtrace = ?bt,
             "main window close-request fired",
         );
+        app_for_close.remove_action(crate::notify::TUNE_SATELLITE_ACTION);
         transcription_engine.borrow_mut().shutdown_nonblocking();
         glib::Propagation::Proceed
     });
@@ -9680,7 +9693,6 @@ fn connect_satellites_panel(
                     // wouldn't drop the bell_btn, which would keep
                     // the closure (and the Vec) pinned forever.
                     let displayed_for_toggle = Rc::downgrade(&displayed_recompute);
-                    let satellite_for_toggle = pass.satellite.clone();
                     bell_btn.connect_toggled(move |b| {
                         let active = b.is_active();
                         {
@@ -9703,11 +9715,19 @@ fn connect_satellites_panel(
                         // simply skip mirroring — the watched-set
                         // write above is the only persistent
                         // effect that matters at that point.
+                        //
+                        // Match siblings by NORAD id, not display
+                        // name: the watched set is keyed by id, and
+                        // any future catalog drift where two entries
+                        // share a label (alternate names, alias
+                        // entries) would otherwise toggle the wrong
+                        // satellite's bells. Per CR round 1 on PR
+                        // #568.
                         let Some(displayed) = displayed_for_toggle.upgrade() else {
                             return;
                         };
                         for entry in displayed.borrow().iter() {
-                            if entry.pass.satellite == satellite_for_toggle
+                            if norad_id_for_pass(&entry.pass) == Some(norad_id)
                                 && let Some(other) = &entry.bell_btn
                                 && other.as_ptr() != b.as_ptr()
                                 && other.is_active() != active

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9697,12 +9697,23 @@ fn connect_satellites_panel(
                         let active = b.is_active();
                         {
                             let mut set = watched_for_toggle.borrow_mut();
-                            if active {
-                                set.insert(norad_id);
+                            // `HashSet::insert` / `HashSet::remove`
+                            // return whether membership actually
+                            // changed. Skip the config write when it
+                            // didn't — sibling-mirror re-enters this
+                            // handler for every other row of the
+                            // same satellite, and without the guard
+                            // every mirror would issue an identical
+                            // save_watched_satellites call. Per CR
+                            // round 3 on PR #568.
+                            let changed = if active {
+                                set.insert(norad_id)
                             } else {
-                                set.remove(&norad_id);
+                                set.remove(&norad_id)
+                            };
+                            if changed {
+                                save_watched_satellites(&config_for_toggle, &set);
                             }
-                            save_watched_satellites(&config_for_toggle, &set);
                         }
                         // Mirror across sibling rows. `set_active`
                         // is a no-op when the state already matches,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -10804,7 +10804,6 @@ fn connect_satellites_panel(
                         norad_id,
                         pass,
                         lead_min,
-                        ..
                     } => {
                         crate::notify::send_pass_alert(&pass, norad_id, lead_min);
                     }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -557,6 +557,7 @@ pub fn build_window(app: &adw::Application, config: &std::sync::Arc<sdr_config::
     };
 
     connect_sidebar_panels(
+        app,
         &panels,
         &state,
         &spectrum_handle,
@@ -3091,6 +3092,7 @@ fn build_breakpoint(
 /// Connect all sidebar panel controls to dispatch `UiToDsp` commands.
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn connect_sidebar_panels(
+    app: &adw::Application,
     panels: &SidebarPanels,
     state: &Rc<AppState>,
     spectrum_handle: &Rc<spectrum::SpectrumHandle>,
@@ -3209,6 +3211,38 @@ fn connect_sidebar_panels(
             status_bar_t.update_demod(header::demod_mode_label(mode), bw_f64);
         })
     };
+    // Register `app.tune-satellite` so the "Tune" button on a #510
+    // pre-pass desktop notification can route back to the same
+    // tune closure the panel's per-row play buttons use. Action
+    // target is the satellite's NORAD id (`u32`); the handler
+    // looks the entry up in `KNOWN_SATELLITES` for downlink /
+    // demod / bandwidth.
+    {
+        let tune_for_action = Rc::clone(&tune_to_satellite);
+        let action = gio::SimpleAction::new(
+            crate::notify::TUNE_SATELLITE_ACTION,
+            Some(glib::VariantTy::UINT32),
+        );
+        action.connect_activate(move |_, param| {
+            let Some(norad_id) = param.and_then(glib::Variant::get::<u32>) else {
+                tracing::warn!("tune-satellite action fired without a u32 target");
+                return;
+            };
+            let Some(known) = sdr_sat::KNOWN_SATELLITES
+                .iter()
+                .find(|s| s.norad_id == norad_id)
+            else {
+                tracing::warn!(
+                    norad_id,
+                    "tune-satellite action target not in KNOWN_SATELLITES",
+                );
+                return;
+            };
+            tune_for_action(known.downlink_hz, known.demod_mode, known.bandwidth_hz);
+        });
+        app.add_action(&action);
+    }
+
     connect_satellites_panel(
         panels,
         config,
@@ -9433,22 +9467,30 @@ fn connect_satellites_panel(
     status_bar: &Rc<StatusBar>,
 ) {
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
+    use sidebar::satellites_notify::{Action as NotifyAction, NotifyScheduler};
     use sidebar::satellites_panel::{
         KEY_STATION_ALT_M, KEY_STATION_LAT_DEG, KEY_STATION_LON_DEG, SatellitesPanelWeak,
         enumerate_upcoming_passes, format_downlink_mhz, format_last_refresh, format_pass_subtitle,
-        format_pass_title, load_auto_record_apt, load_auto_record_audio, load_station_alt_m,
-        load_station_lat_deg, load_station_lon_deg, save_auto_record_apt, save_auto_record_audio,
-        save_f64, save_tle_last_refresh, tune_target_for_pass,
+        format_pass_title, load_auto_record_apt, load_auto_record_audio, load_notify_lead_min,
+        load_station_alt_m, load_station_lat_deg, load_station_lon_deg, load_watched_satellites,
+        norad_id_for_pass, save_auto_record_apt, save_auto_record_audio, save_f64,
+        save_tle_last_refresh, save_watched_satellites, tune_target_for_pass,
     };
     use sidebar::satellites_recorder::{
         Action as RecorderAction, AutoRecorder, SavedTune, ToastKind,
     };
 
     // One pass row + its source `Pass` so the 1 Hz ticker can
-    // refresh the title without re-running pass enumeration.
+    // refresh the title without re-running pass enumeration. The
+    // optional bell `ToggleButton` is held so the watch-toggle
+    // handler can mirror the active state across every row whose
+    // satellite matches — multiple NOAA 19 passes in the visible
+    // list must all reflect the same subscription state. `None`
+    // for off-catalog passes (no NORAD id → no notify).
     struct DisplayedPass {
         row: adw::ActionRow,
         pass: Pass,
+        bell_btn: Option<gtk4::ToggleButton>,
     }
 
     // Borrow the panel for synchronous setup, then capture only
@@ -9468,6 +9510,9 @@ fn connect_satellites_panel(
     panel.lon_row.set_value(load_station_lon_deg(config));
     panel.alt_row.set_value(load_station_alt_m(config));
     panel
+        .notify_lead_row
+        .set_value(f64::from(load_notify_lead_min(config)));
+    panel
         .auto_record_switch
         .set_active(load_auto_record_apt(config));
     panel
@@ -9476,6 +9521,20 @@ fn connect_satellites_panel(
     panel
         .last_refresh_row
         .set_subtitle(&format_last_refresh(config));
+
+    {
+        let config_lead = std::sync::Arc::clone(config);
+        panel.notify_lead_row.connect_value_notify(move |row| {
+            #[allow(
+                clippy::cast_sign_loss,
+                clippy::cast_possible_truncation,
+                reason = "SpinRow is bounded NOTIFY_LEAD_MIN_LOWER..=UPPER \
+                          (positive, < u32::MAX)"
+            )]
+            let value = row.value().round() as u32;
+            sidebar::satellites_panel::save_notify_lead_min(&config_lead, value);
+        });
+    }
 
     // `Option<Arc<TleCache>>`. `None` means the platform refused us
     // a cache directory (rare; sandboxed minimal environments).
@@ -9496,6 +9555,17 @@ fn connect_satellites_panel(
     };
 
     let displayed: Rc<RefCell<Vec<DisplayedPass>>> = Rc::new(RefCell::new(Vec::new()));
+
+    // #510 — per-satellite watched-set + notify scheduler. Loaded
+    // from config so the user's selections survive restarts. The
+    // set is mutated from two sites: (a) the bell toggle on each
+    // pass row (write-through to config); (b) read-only by the
+    // 1 Hz tick that drives the scheduler.
+    let watched: Rc<RefCell<std::collections::HashSet<u32>>> =
+        Rc::new(RefCell::new(load_watched_satellites(config)));
+    let notify_scheduler: Rc<RefCell<NotifyScheduler>> =
+        Rc::new(RefCell::new(NotifyScheduler::new()));
+
     // `recompute` is built unconditionally — when the cache is
     // unavailable it's a no-op so the lat/lon/alt notify handlers
     // can call it without branching. When the cache is available
@@ -9505,6 +9575,8 @@ fn connect_satellites_panel(
         let panel_weak_recompute = panel_weak.clone();
         let displayed_recompute = Rc::clone(&displayed);
         let tune_for_recompute = Rc::clone(tune_to_satellite);
+        let watched_for_recompute = Rc::clone(&watched);
+        let config_for_recompute = std::sync::Arc::clone(config);
         Rc::new(move || {
             let Some(panel) = panel_weak_recompute.upgrade() else {
                 return;
@@ -9576,8 +9648,85 @@ fn connect_satellites_panel(
                     });
                     row.add_suffix(&play_btn);
                 }
+                // 🔔 watch-toggle (#510) — per-satellite, NOT
+                // per-pass. Toggling on row N flips the user's
+                // subscription for THIS satellite. Mirrored across
+                // sibling rows in the toggle handler so two rows
+                // of the same satellite (NOAA 19 typically has 4-6
+                // passes per day) stay in sync. `None` for
+                // off-catalog passes — no NORAD id, no
+                // notification target, no button.
+                let bell_btn = if let Some(norad_id) = norad_id_for_pass(&pass) {
+                    let initial_active = watched_for_recompute.borrow().contains(&norad_id);
+                    let bell_btn = gtk4::ToggleButton::builder()
+                        .icon_name("alarm-symbolic")
+                        .active(initial_active)
+                        .tooltip_text(format!(
+                            "Notify before {} passes (T-pre-pass alert)",
+                            pass.satellite,
+                        ))
+                        .valign(gtk4::Align::Center)
+                        .css_classes(["flat"])
+                        .build();
+                    let a11y_label = format!("Notify before {} passes", pass.satellite);
+                    bell_btn
+                        .update_property(&[gtk4::accessible::Property::Label(a11y_label.as_str())]);
+                    let watched_for_toggle = Rc::clone(&watched_for_recompute);
+                    let config_for_toggle = std::sync::Arc::clone(&config_for_recompute);
+                    // `Weak` (not strong `Rc`) breaks the cycle:
+                    // bell_btn → handler closure → Rc → Vec
+                    // <DisplayedPass> → bell_btn. With a strong ref
+                    // here, removing rows from `passes_group`
+                    // wouldn't drop the bell_btn, which would keep
+                    // the closure (and the Vec) pinned forever.
+                    let displayed_for_toggle = Rc::downgrade(&displayed_recompute);
+                    let satellite_for_toggle = pass.satellite.clone();
+                    bell_btn.connect_toggled(move |b| {
+                        let active = b.is_active();
+                        {
+                            let mut set = watched_for_toggle.borrow_mut();
+                            if active {
+                                set.insert(norad_id);
+                            } else {
+                                set.remove(&norad_id);
+                            }
+                            save_watched_satellites(&config_for_toggle, &set);
+                        }
+                        // Mirror across sibling rows. `set_active`
+                        // is a no-op when the state already matches,
+                        // so the recursion terminates after one
+                        // round-trip per sibling. The pointer
+                        // compare keeps us from re-entering THIS
+                        // button's own handler. If the displayed
+                        // Vec has already been dropped (window
+                        // teardown), the upgrade fails and we
+                        // simply skip mirroring — the watched-set
+                        // write above is the only persistent
+                        // effect that matters at that point.
+                        let Some(displayed) = displayed_for_toggle.upgrade() else {
+                            return;
+                        };
+                        for entry in displayed.borrow().iter() {
+                            if entry.pass.satellite == satellite_for_toggle
+                                && let Some(other) = &entry.bell_btn
+                                && other.as_ptr() != b.as_ptr()
+                                && other.is_active() != active
+                            {
+                                other.set_active(active);
+                            }
+                        }
+                    });
+                    row.add_suffix(&bell_btn);
+                    Some(bell_btn)
+                } else {
+                    None
+                };
                 panel.passes_group.add(&row);
-                new_rows.push(DisplayedPass { row, pass });
+                new_rows.push(DisplayedPass {
+                    row,
+                    pass,
+                    bell_btn,
+                });
             }
             *displayed_recompute.borrow_mut() = new_rows;
         })
@@ -10510,6 +10659,13 @@ fn connect_satellites_panel(
         let state_tick = Rc::clone(state);
         let bandwidth_row_tick = panels.radio.bandwidth_row.clone();
         let spectrum_tick = Rc::clone(spectrum_handle);
+        // #510 — notify scheduler + watched-set + lead time. The
+        // lead time is read fresh from config on every tick so a
+        // user edit (once we expose a setting) takes effect
+        // immediately without restarting the timer.
+        let watched_tick = Rc::clone(&watched);
+        let notify_scheduler_tick = Rc::clone(&notify_scheduler);
+        let config_tick = std::sync::Arc::clone(config);
         // Scanner master switch — read for the per-tick snapshot so
         // SavedTune carries scanner state across AOS → LOS, written
         // by `interpret_action::RestoreTune` to re-arm the scanner
@@ -10602,6 +10758,39 @@ fn connect_satellites_panel(
             for action in actions {
                 interpret_tick(action);
             }
+
+            // #510 — pre-pass desktop alerts. Walk the displayed
+            // pass list, map each to (norad_id, &Pass), feed the
+            // scheduler. Pure function in / pure actions out;
+            // notification I/O happens in the action loop below.
+            let lead_min = load_notify_lead_min(&config_tick);
+            let lead = chrono::Duration::minutes(i64::from(lead_min));
+            let watched_snapshot = watched_tick.borrow().clone();
+            let notify_actions = {
+                let displayed_borrow = displayed_tick.borrow();
+                let pairs: Vec<(u32, &Pass)> = displayed_borrow
+                    .iter()
+                    .filter_map(|e| norad_id_for_pass(&e.pass).map(|id| (id, &e.pass)))
+                    .collect();
+                notify_scheduler_tick
+                    .borrow_mut()
+                    .tick(now, lead, lead_min, pairs, |id| {
+                        watched_snapshot.contains(&id)
+                    })
+            };
+            for action in notify_actions {
+                match action {
+                    NotifyAction::Fire {
+                        norad_id,
+                        pass,
+                        lead_min,
+                        ..
+                    } => {
+                        crate::notify::send_pass_alert(&pass, norad_id, lead_min);
+                    }
+                }
+            }
+
             if needs_recompute {
                 recompute_tick();
             }


### PR DESCRIPTION
## Summary

Closes #510. Adds a per-row 🔔 toggle on each upcoming-pass row in the Satellites panel — toggling subscribes the user to that satellite; the next pass crossing the configured lead-time threshold (default T-5 min) fires a D-Bus desktop notification with a Tune button that snaps the radio to the catalog downlink + demod + bandwidth.

## Notification path

\`gio::Notification\` — on Linux this maps onto \`org.freedesktop.Notifications\`, the same D-Bus interface \`notify-send\` and \`nwg-notifications\` speak. We get urgency hints, action buttons, and per-id replace semantics for free; no \`zbus\` plumbing of our own. Priority is **High** (over **Urgent** — pass alerts are timely but not life-critical, and many daemons keep critical popups on screen until manually dismissed).

## Architecture

Mirrors the auto-record pattern from #482 / #533:

- \`sidebar::satellites_notify\` — pure \`NotifyScheduler\` state machine. 9 unit tests cover the lead-window boundary, dedup across consecutive ticks, GC of stale entries, multi-satellite ticks, in-progress-pass skip, and second-pass-of-same-satellite re-fire.
- \`app.tune-satellite\` GIO action with \`u32\` NORAD-id target. Handler looks the entry up in \`KNOWN_SATELLITES\` and routes through the existing \`tune_to_satellite\` closure — same flow the per-row play button uses.
- Bell \`ToggleButton\` per pass row, mirrored across sibling rows so multiple NOAA 19 passes (4-6/day) reflect the same subscription state. The mirror loop captures the \`displayed\` Vec via \`Rc::downgrade\` to avoid the closure → Vec → button → closure refcount cycle.
- 1 Hz tick reads the watched-set + lead-time fresh from config each tick, drives the scheduler, fires notifications via the new \`notify::send_pass_alert\` helper.

## Persistence

Two new config keys:

- \`sat_watched_norad_ids\` — JSON \`array<u32>\`, sorted on write so config diffs are stable across saves. Invalid entries (wrong type, out-of-u32-range numbers) are silently dropped on load.
- \`sat_notify_lead_min\` — whole minutes, clamped to \`[1, 60]\` on read so a hand-edited config can't push us into degenerate states (e.g. \`0\` would flicker between fire and miss every tick).

## Test plan

- [x] \`cargo build --workspace --features whisper-cpu\`
- [x] \`cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings\`
- [x] \`cargo test --workspace --features whisper-cpu\` (358 tests; all 9 new \`satellites_notify\` + 4 new \`satellites_panel\` round-trip / clamp tests pass)
- [x] \`cargo check --workspace --no-default-features --features sherpa-cpu\` (mutex cross-check)
- [x] \`cargo check --workspace --no-default-features --features sherpa-cuda\` (mutex cross-check)
- [x] \`cargo fmt --all -- --check\`
- [ ] **Manual smoke (in progress on user's R820T):**
  - "Notifications" group renders with Lead-time SpinRow (1-60, default 5).
  - Each pass row shows ▶ + 🔔 suffix; clicking 🔔 latches active and persists across restart.
  - Multiple passes of the same satellite mirror toggle state.
  - For a watched satellite within \`lead_time\` of AOS: D-Bus notification fires once per pass with a Tune button; clicking Tune snaps the radio to the catalog downlink.
  - Toggle 🔔 off → no further notifications for that satellite.

## Follow-ups (filed)

- #566 — APT + LRPT pipeline validation. Surfaced from a "good signal, empty viewer" Meteor pass during smoke testing; planning end-to-end instrumentation post-merge.
- #567 — Doppler tracker keeps running after Stop. Surfaced same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-pass desktop notifications for watched satellites with configurable lead time
  * Notifications include a "Tune" button to quickly tune to the satellite
  * UI: "Notifications" section in Satellites panel, per-pass bell toggle, persisted watched-satellites list and lead-time setting
  * Scheduler emits timely alerts for visible watched passes

* **Bug Fixes**
  * Alerts fire once per pass and replace repeated deliveries instead of stacking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->