### PR TITLE
fix: gate Doppler timers on is_running so Stop means stop (#567)

### DIFF
--- a/crates/sdr-ui/src/doppler_tracker.rs
+++ b/crates/sdr-ui/src/doppler_tracker.rs
@@ -24,6 +24,34 @@ pub struct Candidate {
     pub elevation_deg: f64,
 }
 
+/// Whether the per-tick Doppler work (SGP4 propagate, candidate
+/// rebuild, offset compute, `SetVfoOffset` dispatch, status-bar
+/// update) should run at all this tick. Encapsulates the
+/// lifecycle gates the wiring layer applies in front of the 1 Hz
+/// trigger and 4 Hz recompute timers.
+///
+/// Returns `false` when:
+///
+/// * `master_enabled` is off — the user-facing Satellites-panel
+///   switch is off, so Doppler is dormant regardless. (The 1 Hz
+///   tick already short-circuits on this; the helper makes the
+///   condition explicit for both ticks + future call sites.)
+/// * `is_running` is off — Stop has been pressed and the DSP
+///   isn't processing samples. Dispatching `SetVfoOffset` to a
+///   stopped DSP queues changes that apply on the next Start,
+///   which presents as "the dial moved on its own while I was
+///   stopped"; suppressing dispatch keeps stop-means-stop. Per
+///   #567.
+///
+/// On resume, the next 4 Hz tick re-computes against the live
+/// satellite geometry (which has continued to move while we were
+/// paused), so picking up mid-pass after a stop produces a fresh
+/// correction rather than a stale one.
+#[must_use]
+pub fn should_tick(master_enabled: bool, is_running: bool) -> bool {
+    master_enabled && is_running
+}
+
 /// Pure trigger evaluation per spec §2: pick the catalog
 /// satellite (if any) the Doppler tracker should be locked to
 /// right now.
@@ -263,6 +291,21 @@ mod tests {
     #[test]
     fn freq_match_tolerance_is_20_khz() {
         assert!((FREQ_MATCH_TOLERANCE_HZ - 20_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn should_tick_requires_both_master_and_running() {
+        // Per #567: Doppler stops dispatching SetVfoOffset when the
+        // user presses Stop. The 4 Hz / 1 Hz tick wiring layer
+        // calls `should_tick` before doing any SGP4 / dispatch work.
+        // Truth table — both gates must be true for the tick to run.
+        assert!(!should_tick(false, false), "off + stopped");
+        assert!(!should_tick(false, true), "master off, running");
+        assert!(
+            !should_tick(true, false),
+            "master on but stopped — the #567 case"
+        );
+        assert!(should_tick(true, true), "both on — normal operation");
     }
 
     #[test]

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -10905,7 +10905,7 @@ fn connect_doppler_tracker(
 ) {
     use crate::doppler_tracker::{
         Candidate, DopplerTracker, FREQ_MATCH_TOLERANCE_HZ, compute_doppler_offset_hz,
-        pick_active_satellite,
+        pick_active_satellite, should_tick,
     };
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Satellite, track};
 
@@ -10983,7 +10983,14 @@ fn connect_doppler_tracker(
                 return glib::ControlFlow::Break;
             };
             let mut t = tracker.borrow_mut();
-            if !t.master_enabled() {
+            // Lifecycle gate: master + running. While stopped,
+            // no candidate rebuild + no `set_active` transition,
+            // so a satellite setting below the horizon mid-stop
+            // doesn't fire a spurious disengage dispatch into a
+            // stopped DSP. On resume, this tick re-evaluates and
+            // engages / disengages naturally against the live
+            // geometry. Per #567.
+            if !should_tick(t.master_enabled(), state.is_running.get()) {
                 return glib::ControlFlow::Continue;
             }
             // Build the ground station from the live panel
@@ -11128,6 +11135,16 @@ fn connect_doppler_tracker(
             let Some(panel) = panel_weak.upgrade() else {
                 return glib::ControlFlow::Break;
             };
+            // Lifecycle gate: master + running. The status-bar
+            // badge clears on the first not-running tick so the
+            // user gets immediate "Doppler is idle" feedback when
+            // they press Stop — `update_doppler(None)` is
+            // idempotent (set_visible(false) on an already-hidden
+            // label is a no-op). Per #567.
+            if !should_tick(tracker.borrow().master_enabled(), state.is_running.get()) {
+                status_bar.update_doppler(None);
+                return glib::ControlFlow::Continue;
+            }
             let active_sat = tracker.borrow().active();
             let Some(sat) = active_sat else {
                 return glib::ControlFlow::Continue;


### PR DESCRIPTION
Closes #567.

## Bug

Both Doppler timers (1 Hz trigger re-evaluation + 4 Hz offset recompute) checked \`master_enabled\` and \`active\` but neither checked \`state.is_running\`. Pressing Stop left the tracker ticking — SGP4 propagating against a dead DSP, dispatching \`SetVfoOffset\` messages that queued up and applied on the next Start, presenting as "the dial moved on its own while I was stopped".

## Fix

New pure helper \`doppler_tracker::should_tick(master, running)\` captures the lifecycle gates. Truth-table unit-tested (4 cases — both off / one-of / both on). Both timer closures now early-return when \`should_tick\` returns false, and the 4 Hz tick additionally clears the Doppler status badge on the first not-running iteration so the user gets immediate "stopped" feedback (within 250 ms, idempotent).

On resume, the next 4 Hz tick recomputes against the live satellite geometry — which has continued to move while we were paused — so picking up mid-pass produces a fresh correction rather than a stale one.

## Math validation against SDR++ original

While in the area I cross-checked the full Doppler signal path against \`original/SDRPlusPlus/core/src/dsp/channel/\` to make sure the sign convention bridge from \`compute_doppler_offset_hz\` to \`SetVfoOffset\` to \`FrequencyXlator\` was end-to-end consistent with the canonical implementation:

| Layer | Convention | Source-of-truth |
|---|---|---|
| Range-rate | Positive = receding (line-of-sight projection in ECI: \`dot(range_vec, rel_vel) / \|range_vec\|\`, station velocity via ω × r) | Textbook |
| Doppler shift | \`Δf = -f₀·ṙ/c\` — non-relativistic, approaching → positive Δf | \`Track::doppler_shift_hz\` |
| VFO offset → DSP | \`RxVfo::set_offset(+Δ)\` internally negates → \`FrequencyXlator::set_offset_hz(-Δ, sr)\` → multiplies by \`e^(-j·2π·Δ·t/sr)\` → shifts spectrum DOWN by Δ → signal at +Δ moves to DC | **Identical** to SDR++ \`dsp::channel::RxVFO::setOffset\` (\`rx_vfo.h:76\`: \`xlator.setOffset(-_offset, _inSamplerate)\`) |

End-to-end: \`SetVfoOffset(doppler_shift_hz)\` is correctly signed at every layer. No anti-corrective dispatch.

The math was already covered by \`compute_doppler_offset_pass_shape_aos_to_los\` and \`compute_doppler_offset_sign_matches_approaching_receding\` against a real captured NOAA 19 TLE; this validation closed the loop on the convention bridge through the DSP.

## Test plan

- [x] \`cargo build --workspace --features whisper-cpu\`
- [x] \`cargo clippy --workspace --all-targets --features whisper-cpu -- -D warnings\`
- [x] \`cargo test --workspace --features whisper-cpu\` — 23/23 doppler_tracker tests including the new \`should_tick_requires_both_master_and_running\` truth table
- [x] \`cargo check --workspace --no-default-features --features sherpa-cpu\` (mutex cross-check)
- [x] \`cargo check --workspace --no-default-features --features sherpa-cuda\` (mutex cross-check)
- [x] \`cargo fmt --all -- --check\`
- [ ] **Manual smoke (in progress on user's R820T):**
  - Doppler engages during a pass; status bar shows \`Doppler: ±X.X kHz\` updating.
  - Press Stop — Doppler badge disappears within ~250 ms.
  - Tracing log clean of \`SetVfoOffset\` traffic during stop interval.
  - Press Play mid-pass — Doppler re-engages with the now-correct shift (not the value from when Stop was pressed).
  - Toggle Doppler master switch off — still no activity (existing behavior preserved).
  - Sanity: with Doppler engaged, the received signal in the spectrum view stays where it is (the demod tap follows it underneath); confirms no regression in the sign-convention bridge.

## Related

- #566 — APT/LRPT pipeline validation. Clean Stop semantics are a prereq for capturing repro IQ recordings against an instrumented decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Doppler correction now only runs when the master switch is enabled and the app is actively running.
  * Fixed spurious engagement/disengagement behavior during stop transitions.
  * Status bar Doppler indicator clears immediately when stopped for clearer idle feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->