### PR TITLE
feat: tune_to_target helper (#509) + auto-record quality threshold (#511)

### DIFF
--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -125,6 +125,97 @@ pub const KEY_AUTO_RECORD_APT: &str = "sat_auto_record_apt";
 /// Pairs with [`KEY_AUTO_RECORD_APT`] — only meaningful when
 /// auto-record is on. Default: `false` (opt-in). Per #533.
 pub const KEY_AUTO_RECORD_AUDIO: &str = "sat_auto_record_audio";
+/// Config key for the auto-record quality threshold (selected
+/// `AutoRecordQuality` tier). Per #511.
+pub const KEY_AUTO_RECORD_QUALITY: &str = "sat_auto_record_quality";
+
+/// Pass-quality tiers that gate the auto-record-on-pass feature.
+/// User-selectable via the `AdwComboRow` next to the auto-record
+/// switch — only passes whose peak elevation meets or exceeds the
+/// chosen tier's `min_elev_deg` actually trigger an auto-record.
+///
+/// Tiers map to the existing pass-quality tags from #507 / PR #508
+/// (winner / good / marginal / barely): "winners only" is the
+/// strictest (≥ 40°), "all passes" is the floor (≥
+/// `MIN_PASS_ELEVATION_DEG` = 5°). Default is `WinnersAndGood` —
+/// the band where APT decode actually produces a recognizable
+/// image.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AutoRecordQuality {
+    /// ≥ 40° peak (winner-tier passes only). Strictest.
+    WinnersOnly,
+    /// ≥ 25° peak (winner + good). Default — matches the previous
+    /// hardcoded constant.
+    WinnersAndGood,
+    /// ≥ 15° peak (+ marginal).
+    MarginalOrBetter,
+    /// ≥ [`MIN_PASS_ELEVATION_DEG`] (5°) — every pass above the floor.
+    AllPasses,
+}
+
+impl AutoRecordQuality {
+    /// Order in the `AdwComboRow` (matching declaration order). New
+    /// variants MUST be appended — existing index → variant
+    /// mappings are persisted in the user's config and an insertion
+    /// in the middle would silently shift the user's selection.
+    pub const ALL: [Self; 4] = [
+        Self::WinnersOnly,
+        Self::WinnersAndGood,
+        Self::MarginalOrBetter,
+        Self::AllPasses,
+    ];
+
+    /// Default tier — `WinnersAndGood`. Matches the previously-
+    /// hardcoded `AUTO_RECORD_MIN_ELEV_DEG = 25.0` so existing
+    /// users get the same behavior on upgrade.
+    pub const DEFAULT: Self = Self::WinnersAndGood;
+
+    /// Minimum peak elevation (degrees) for this tier. The
+    /// recorder's `tick_idle` gate compares
+    /// `pass.max_elevation_deg >= self.min_elev_deg()`.
+    #[must_use]
+    pub fn min_elev_deg(self) -> f64 {
+        match self {
+            Self::WinnersOnly => 40.0,
+            Self::WinnersAndGood => 25.0,
+            Self::MarginalOrBetter => 15.0,
+            Self::AllPasses => MIN_PASS_ELEVATION_DEG,
+        }
+    }
+
+    /// Human-readable label for the `AdwComboRow`'s `string_list`.
+    #[must_use]
+    pub fn display_label(self) -> &'static str {
+        match self {
+            Self::WinnersOnly => "Winners only (≥ 40°)",
+            Self::WinnersAndGood => "Winners and good (≥ 25°)",
+            Self::MarginalOrBetter => "Marginal or better (≥ 15°)",
+            Self::AllPasses => "All passes (≥ 5°)",
+        }
+    }
+
+    /// Map a u32 combo index back to the variant. Returns
+    /// [`Self::DEFAULT`] for out-of-range indices so a corrupted
+    /// or future-version config can't crash the panel hydration.
+    #[must_use]
+    pub fn from_index(idx: u32) -> Self {
+        usize::try_from(idx)
+            .ok()
+            .and_then(|i| Self::ALL.get(i).copied())
+            .unwrap_or(Self::DEFAULT)
+    }
+
+    /// Map this variant back to its u32 combo index. Inverse of
+    /// `from_index`.
+    #[must_use]
+    pub fn to_index(self) -> u32 {
+        Self::ALL
+            .iter()
+            .position(|v| *v == self)
+            .and_then(|i| u32::try_from(i).ok())
+            .unwrap_or(0)
+    }
+}
 /// Config key for the persisted Doppler-tracking master switch
 /// (Satellites panel). Default `true` so first-launch users get
 /// auto-corrected passes out of the box. Per issue #521.
@@ -204,6 +295,10 @@ pub struct SatellitesPanel {
     /// demodulated audio lands in `~/sdr-recordings/audio-{slug}-
     /// {timestamp}.wav` paired with the PNG. Per #533.
     pub auto_record_audio_switch: adw::SwitchRow,
+    /// Combo row selecting which pass-quality tier triggers
+    /// auto-record. Sensitive only when `auto_record_switch` is
+    /// on. Per #511.
+    pub auto_record_quality_row: adw::ComboRow,
     /// Master switch for Doppler-correction tracking during
     /// satellite passes. Default ON. When OFF, the
     /// `DopplerTracker` stays dormant regardless of frequency
@@ -266,6 +361,8 @@ pub struct SatellitesPanelWeak {
     pub auto_record_switch: glib::WeakRef<adw::SwitchRow>,
     /// Weak ref to [`SatellitesPanel::auto_record_audio_switch`].
     pub auto_record_audio_switch: glib::WeakRef<adw::SwitchRow>,
+    /// Weak ref to [`SatellitesPanel::auto_record_quality_row`].
+    pub auto_record_quality_row: glib::WeakRef<adw::ComboRow>,
     /// Weak ref to [`SatellitesPanel::doppler_switch`].
     pub doppler_switch: glib::WeakRef<adw::SwitchRow>,
     /// Weak ref to [`SatellitesPanel::passes_group`].
@@ -294,6 +391,7 @@ impl SatellitesPanel {
             notify_lead_row: self.notify_lead_row.downgrade(),
             auto_record_switch: self.auto_record_switch.downgrade(),
             auto_record_audio_switch: self.auto_record_audio_switch.downgrade(),
+            auto_record_quality_row: self.auto_record_quality_row.downgrade(),
             doppler_switch: self.doppler_switch.downgrade(),
             passes_group: self.passes_group.downgrade(),
             passes_status_row: self.passes_status_row.downgrade(),
@@ -323,6 +421,7 @@ impl SatellitesPanelWeak {
             notify_lead_row: self.notify_lead_row.upgrade()?,
             auto_record_switch: self.auto_record_switch.upgrade()?,
             auto_record_audio_switch: self.auto_record_audio_switch.upgrade()?,
+            auto_record_quality_row: self.auto_record_quality_row.upgrade()?,
             doppler_switch: self.doppler_switch.upgrade()?,
             passes_group: self.passes_group.upgrade()?,
             passes_status_row: self.passes_status_row.upgrade()?,
@@ -470,6 +569,40 @@ pub fn build_satellites_panel() -> SatellitesPanel {
         .build();
     recording_group.add(&auto_record_switch);
 
+    // Quality threshold combo row — gates which passes are
+    // worth auto-recording. The `AdwComboRow.string_list` indices
+    // match `AutoRecordQuality::ALL` order; if the order ever
+    // changes the persisted u32 indices in the user's config will
+    // silently drift, so don't reorder. Per #511.
+    let quality_strings = gtk4::StringList::new(
+        &AutoRecordQuality::ALL
+            .iter()
+            .map(|q| q.display_label())
+            .collect::<Vec<_>>(),
+    );
+    let auto_record_quality_row = adw::ComboRow::builder()
+        .title("Quality threshold")
+        .subtitle("Only passes with peak elevation at or above the selected tier auto-record.")
+        .model(&quality_strings)
+        .selected(AutoRecordQuality::DEFAULT.to_index())
+        // Combo is only useful when auto-record is on; sensitivity
+        // tracks the switch state below.
+        .sensitive(false)
+        .build();
+    recording_group.add(&auto_record_quality_row);
+
+    // Sync the combo's sensitivity to the auto-record switch.
+    {
+        let combo_clone = auto_record_quality_row.clone();
+        auto_record_switch.connect_active_notify(move |row| {
+            combo_clone.set_sensitive(row.is_active());
+        });
+        // Initial sync — the switch builder above defaulted to
+        // `false`, so this just keeps the two in lockstep if a
+        // future builder change flips the default.
+        auto_record_quality_row.set_sensitive(auto_record_switch.is_active());
+    }
+
     // Pairs with auto-record. Only takes effect when both this
     // and `auto_record_switch` are on; sampled exclusively at
     // AOS so a mid-pass toggle can't leave a half-stopped writer.
@@ -534,6 +667,7 @@ pub fn build_satellites_panel() -> SatellitesPanel {
         notify_lead_row,
         auto_record_switch,
         auto_record_audio_switch,
+        auto_record_quality_row,
         doppler_switch,
         passes_group,
         passes_status_row,
@@ -575,6 +709,20 @@ pub fn load_auto_record_apt(config: &Arc<ConfigManager>) -> bool {
 #[must_use]
 pub fn load_auto_record_audio(config: &Arc<ConfigManager>) -> bool {
     read_bool_or(config, KEY_AUTO_RECORD_AUDIO, false)
+}
+
+/// Read the persisted auto-record quality threshold. Defaults to
+/// [`AutoRecordQuality::DEFAULT`] (`WinnersAndGood`) — matches the
+/// previously-hardcoded `AUTO_RECORD_MIN_ELEV_DEG`. Per #511.
+#[must_use]
+pub fn load_auto_record_quality(config: &Arc<ConfigManager>) -> AutoRecordQuality {
+    let idx = config.read(|v| {
+        v.get(KEY_AUTO_RECORD_QUALITY)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| u32::try_from(n).ok())
+            .unwrap_or(AutoRecordQuality::DEFAULT.to_index())
+    });
+    AutoRecordQuality::from_index(idx)
 }
 
 /// Load the persisted Doppler-tracking master switch. Defaults
@@ -1403,5 +1551,66 @@ mod tests {
         });
         // Falls back to the default (true), not a panic.
         assert!(load_doppler_tracking_enabled(&config));
+    }
+}
+
+#[cfg(test)]
+mod auto_record_quality_tests {
+    use super::*;
+
+    #[test]
+    fn min_elev_deg_matches_tier_table() {
+        // Pin the four thresholds. If any of these change, the
+        // user-facing labels in `display_label` must change too.
+        assert!((AutoRecordQuality::WinnersOnly.min_elev_deg() - 40.0).abs() < f64::EPSILON);
+        assert!((AutoRecordQuality::WinnersAndGood.min_elev_deg() - 25.0).abs() < f64::EPSILON);
+        assert!((AutoRecordQuality::MarginalOrBetter.min_elev_deg() - 15.0).abs() < f64::EPSILON);
+        assert!(
+            (AutoRecordQuality::AllPasses.min_elev_deg() - MIN_PASS_ELEVATION_DEG).abs()
+                < f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn default_is_winners_and_good() {
+        assert_eq!(
+            AutoRecordQuality::DEFAULT,
+            AutoRecordQuality::WinnersAndGood
+        );
+        // Critical: the default's threshold must equal the previously-
+        // hardcoded constant so existing users get the same behavior on
+        // upgrade. Per #511.
+        assert!((AutoRecordQuality::DEFAULT.min_elev_deg() - 25.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn from_index_round_trips() {
+        for variant in AutoRecordQuality::ALL {
+            assert_eq!(AutoRecordQuality::from_index(variant.to_index()), variant);
+        }
+    }
+
+    #[test]
+    fn from_index_oob_falls_back_to_default() {
+        assert_eq!(
+            AutoRecordQuality::from_index(99),
+            AutoRecordQuality::DEFAULT
+        );
+        assert_eq!(
+            AutoRecordQuality::from_index(u32::MAX),
+            AutoRecordQuality::DEFAULT
+        );
+    }
+
+    #[test]
+    fn all_indices_are_unique_and_sequential() {
+        // Sanity check on the ALL ordering — if a future maintainer
+        // accidentally adds a duplicate, the round-trip test would
+        // miss it but this catches it directly.
+        let indices: Vec<u32> = AutoRecordQuality::ALL
+            .iter()
+            .map(|v| v.to_index())
+            .collect();
+        assert_eq!(indices, vec![0, 1, 2, 3]);
     }
 }

--- a/crates/sdr-ui/src/sidebar/satellites_panel.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_panel.rs
@@ -172,13 +172,18 @@ impl AutoRecordQuality {
 
     /// Minimum peak elevation (degrees) for this tier. The
     /// recorder's `tick_idle` gate compares
-    /// `pass.max_elevation_deg >= self.min_elev_deg()`.
+    /// `pass.max_elevation_deg >= self.min_elev_deg()`. Drives off
+    /// the same `QUALITY_*_DEG` constants the per-pass quality tag
+    /// (`pass_quality_label`) reads, so the user-facing tier name
+    /// in the row subtitle (`winner` / `good` / `marginal`) stays
+    /// numerically aligned with this combo's threshold. Per CR
+    /// round 1 on PR #574.
     #[must_use]
     pub fn min_elev_deg(self) -> f64 {
         match self {
-            Self::WinnersOnly => 40.0,
-            Self::WinnersAndGood => 25.0,
-            Self::MarginalOrBetter => 15.0,
+            Self::WinnersOnly => QUALITY_WINNER_DEG,
+            Self::WinnersAndGood => QUALITY_GOOD_DEG,
+            Self::MarginalOrBetter => QUALITY_MARGINAL_DEG,
             Self::AllPasses => MIN_PASS_ELEVATION_DEG,
         }
     }
@@ -723,6 +728,18 @@ pub fn load_auto_record_quality(config: &Arc<ConfigManager>) -> AutoRecordQualit
             .unwrap_or(AutoRecordQuality::DEFAULT.to_index())
     });
     AutoRecordQuality::from_index(idx)
+}
+
+/// Symmetric writer for [`load_auto_record_quality`]. Persists the
+/// combo's u32 index — `AutoRecordQuality::from_index` snaps any
+/// future-version / out-of-range value back to `DEFAULT` on the
+/// next read. Centralizes the enum→u32 mapping with the read helper
+/// rather than open-coding it at every call site. Per CR round 1 on
+/// PR #574.
+pub fn save_auto_record_quality(config: &Arc<ConfigManager>, quality: AutoRecordQuality) {
+    config.write(|v| {
+        v[KEY_AUTO_RECORD_QUALITY] = serde_json::json!(quality.to_index());
+    });
 }
 
 /// Load the persisted Doppler-tracking master switch. Defaults
@@ -1552,19 +1569,28 @@ mod tests {
         // Falls back to the default (true), not a panic.
         assert!(load_doppler_tracking_enabled(&config));
     }
-}
 
-#[cfg(test)]
-mod auto_record_quality_tests {
-    use super::*;
+    // ─── AutoRecordQuality (#511) ──────────────────────────────────
 
     #[test]
-    fn min_elev_deg_matches_tier_table() {
-        // Pin the four thresholds. If any of these change, the
-        // user-facing labels in `display_label` must change too.
-        assert!((AutoRecordQuality::WinnersOnly.min_elev_deg() - 40.0).abs() < f64::EPSILON);
-        assert!((AutoRecordQuality::WinnersAndGood.min_elev_deg() - 25.0).abs() < f64::EPSILON);
-        assert!((AutoRecordQuality::MarginalOrBetter.min_elev_deg() - 15.0).abs() < f64::EPSILON);
+    fn auto_record_quality_min_elev_deg_matches_canonical_constants() {
+        // Pin the four thresholds against the canonical
+        // `QUALITY_*_DEG` constants the per-pass quality tag also
+        // reads, so the combo's gate and the row subtitle's tier
+        // name (`winner`/`good`/`marginal`/`barely`) can never
+        // numerically drift.
+        assert!(
+            (AutoRecordQuality::WinnersOnly.min_elev_deg() - QUALITY_WINNER_DEG).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (AutoRecordQuality::WinnersAndGood.min_elev_deg() - QUALITY_GOOD_DEG).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (AutoRecordQuality::MarginalOrBetter.min_elev_deg() - QUALITY_MARGINAL_DEG).abs()
+                < f64::EPSILON
+        );
         assert!(
             (AutoRecordQuality::AllPasses.min_elev_deg() - MIN_PASS_ELEVATION_DEG).abs()
                 < f64::EPSILON
@@ -1572,26 +1598,28 @@ mod auto_record_quality_tests {
     }
 
     #[test]
-    fn default_is_winners_and_good() {
+    fn auto_record_quality_default_is_winners_and_good() {
         assert_eq!(
             AutoRecordQuality::DEFAULT,
             AutoRecordQuality::WinnersAndGood
         );
         // Critical: the default's threshold must equal the previously-
-        // hardcoded constant so existing users get the same behavior on
-        // upgrade. Per #511.
-        assert!((AutoRecordQuality::DEFAULT.min_elev_deg() - 25.0).abs() < f64::EPSILON);
+        // hardcoded `AUTO_RECORD_MIN_ELEV_DEG = 25.0` so existing
+        // users get the same behavior on upgrade. Per #511.
+        assert!(
+            (AutoRecordQuality::DEFAULT.min_elev_deg() - QUALITY_GOOD_DEG).abs() < f64::EPSILON
+        );
     }
 
     #[test]
-    fn from_index_round_trips() {
+    fn auto_record_quality_from_index_round_trips() {
         for variant in AutoRecordQuality::ALL {
             assert_eq!(AutoRecordQuality::from_index(variant.to_index()), variant);
         }
     }
 
     #[test]
-    fn from_index_oob_falls_back_to_default() {
+    fn auto_record_quality_from_index_oob_falls_back_to_default() {
         assert_eq!(
             AutoRecordQuality::from_index(99),
             AutoRecordQuality::DEFAULT
@@ -1603,7 +1631,7 @@ mod auto_record_quality_tests {
     }
 
     #[test]
-    fn all_indices_are_unique_and_sequential() {
+    fn auto_record_quality_all_indices_are_unique_and_sequential() {
         // Sanity check on the ALL ordering — if a future maintainer
         // accidentally adds a duplicate, the round-trip test would
         // miss it but this catches it directly.
@@ -1612,5 +1640,40 @@ mod auto_record_quality_tests {
             .map(|v| v.to_index())
             .collect();
         assert_eq!(indices, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn auto_record_quality_display_label_numbers_match_min_elev_deg() {
+        // `display_label` returns `&'static str` to keep the
+        // `gtk4::StringList::new` call cheap and allocation-free,
+        // so we can't drive the labels' text directly off the
+        // `QUALITY_*_DEG` constants. Instead, this test pins that
+        // the integer floor in each label matches the tier's
+        // `min_elev_deg`. If anyone bumps a constant without
+        // updating the label string this fails. Per CR round 1
+        // on PR #574.
+        for tier in AutoRecordQuality::ALL {
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "min_elev_deg returns positive f64 in the 0..50 range — fits i64 cleanly"
+            )]
+            let n = tier.min_elev_deg() as i64;
+            let needle = format!("≥ {n}°");
+            let label = tier.display_label();
+            assert!(
+                label.contains(&needle),
+                "label `{label}` should contain `{needle}` to match min_elev_deg",
+            );
+        }
+    }
+
+    #[test]
+    fn auto_record_quality_save_load_round_trips() {
+        let config = make_config();
+        for quality in AutoRecordQuality::ALL {
+            save_auto_record_quality(&config, quality);
+            assert_eq!(load_auto_record_quality(&config), quality);
+        }
     }
 }

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -32,13 +32,6 @@ use sdr_types::DemodMode;
 
 use crate::sidebar::satellites_panel::tune_target_for_pass;
 
-/// Minimum peak elevation (degrees) for an auto-record-eligible
-/// pass. Below this, APT decode is mostly horizon-grazing noise and
-/// the saved PNG is mostly disk waste. Hardcoded to the
-/// "winners + good" tier (≥ 25°) for V1; will become a user-
-/// selectable combo in #511.
-pub const AUTO_RECORD_MIN_ELEV_DEG: f64 = 25.0;
-
 /// Lead-in before AOS at which the recorder enters `BeforePass` and
 /// fires the auto-tune. Gives the channel filter, demod, and
 /// decoder a few seconds to settle before the satellite crosses
@@ -412,10 +405,18 @@ impl AutoRecorder {
         passes: &[Pass],
         auto_record_on: bool,
         audio_record_on: bool,
+        min_elev_deg: f64,
         now_tune: SavedTune,
     ) -> Vec<Action> {
         match self.state.clone() {
-            State::Idle => self.tick_idle(now, passes, auto_record_on, audio_record_on, now_tune),
+            State::Idle => self.tick_idle(
+                now,
+                passes,
+                auto_record_on,
+                audio_record_on,
+                min_elev_deg,
+                now_tune,
+            ),
             State::BeforePass {
                 pass,
                 tuned_at,
@@ -444,6 +445,7 @@ impl AutoRecorder {
         passes: &[Pass],
         auto_record_on: bool,
         audio_record_on: bool,
+        min_elev_deg: f64,
         now_tune: SavedTune,
     ) -> Vec<Action> {
         if !auto_record_on {
@@ -469,7 +471,10 @@ impl AutoRecorder {
         //    LOS-side `SavePng` + `RestoreTune` actions would
         //    still fire — clobbering any user retunes during
         //    the pass.
-        // 4. Peak elevation meets the quality threshold.
+        // 4. Peak elevation meets the user-selected quality
+        //    threshold (`min_elev_deg` — fed in from the panel's
+        //    `AutoRecordQuality` combo per #511; previously a
+        //    hardcoded 25° constant).
         // 5. AOS is within `AOS_LEAD_SECS` (start tuning a few
         //    seconds early so the pipeline is ready at AOS proper).
         for pass in passes {
@@ -481,7 +486,7 @@ impl AutoRecorder {
             if !self.supported_protocols.contains(&protocol) {
                 continue;
             }
-            if pass.max_elevation_deg < AUTO_RECORD_MIN_ELEV_DEG {
+            if pass.max_elevation_deg < min_elev_deg {
                 continue;
             }
             // Skip already-finished passes. A stale displayed-pass
@@ -871,7 +876,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // Pass starts in 3 s — inside the 5 s lead-in.
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, false, default_tune());
+        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::BeforePass { .. }));
         assert!(matches!(actions[0], Action::StartAutoRecord { .. }));
         // Pre-AOS arming reports "starting" — the pass hasn't
@@ -901,7 +906,7 @@ mod tests {
         // Pass started 30 s ago, ends in 9.5 min — eligible by
         // every other gate (NOAA, 50° peak, end > now).
         let pass = synthetic_noaa19(now, -30, 600, 50.0);
-        let actions = r.tick(now, &[pass], true, false, default_tune());
+        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::BeforePass { .. }));
         match &actions[1] {
             Action::Toast { message, .. } => {
@@ -919,7 +924,7 @@ mod tests {
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], false, false, default_tune());
+        let actions = r.tick(now, &[pass], false, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -930,7 +935,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // 20° peak — "marginal" tier, below the 25° "good" floor.
         let pass = synthetic_noaa19(now, 3, 720, 20.0);
-        let actions = r.tick(now, &[pass], true, false, default_tune());
+        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -952,7 +957,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let mut pass = synthetic_noaa19(now, 3, 720, 50.0);
         pass.satellite = "ISS (ZARYA)".to_string();
-        let actions = r.tick(now, &[pass], true, false, default_tune());
+        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -976,6 +981,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Idle));
@@ -990,6 +996,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
@@ -1006,7 +1013,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // Pass starts in 10 min. Way outside the 5 s lead-in.
         let pass = synthetic_noaa19(now, 600, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, false, default_tune());
+        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -1022,6 +1029,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
@@ -1032,12 +1040,13 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
         // Past settle window: advance to Recording.
         let later = now + ChronoDuration::seconds(SETTLE_SECS);
-        r.tick(later, &[pass], true, false, default_tune());
+        r.tick(later, &[pass], true, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::Recording { .. }));
     }
 
@@ -1051,6 +1060,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -1059,12 +1069,13 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
         // Tick past LOS.
         let los_plus_one = pass.end + ChronoDuration::seconds(1);
-        let actions = r.tick(los_plus_one, &[pass], true, false, default_tune());
+        let actions = r.tick(los_plus_one, &[pass], true, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::Finalizing { .. }));
         // Only `SavePng` — the success / failure toast is the
         // wiring layer's responsibility now (it knows the export
@@ -1112,13 +1123,14 @@ mod tests {
             fm_if_nr_enabled: true,
         };
         // Walk all transitions.
-        r.tick(now, std::slice::from_ref(&pass), true, false, saved);
+        r.tick(now, std::slice::from_ref(&pass), true, false, 25.0, saved);
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
         r.tick(
             after_settle,
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
@@ -1127,10 +1139,11 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Finalizing { .. }));
-        let actions = r.tick(los_plus, &[pass], true, false, default_tune());
+        let actions = r.tick(los_plus, &[pass], true, false, 25.0, default_tune());
         assert!(matches!(r.state(), State::Idle));
         // Restore action carries the original saved tune,
         // including the VFO offset (so a user's drag position
@@ -1179,6 +1192,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
@@ -1189,6 +1203,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Finalizing { .. }));
@@ -1219,6 +1234,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
@@ -1228,6 +1244,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Finalizing { .. }));
@@ -1245,6 +1262,7 @@ mod tests {
             std::slice::from_ref(&pass_a),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -1253,6 +1271,7 @@ mod tests {
             std::slice::from_ref(&pass_a),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
@@ -1260,7 +1279,14 @@ mod tests {
         // The recorder should ignore it — Recording stays put.
         let mut pass_b = synthetic_noaa19(now, 30, 720, 60.0);
         pass_b.satellite = "NOAA 18".to_string();
-        let actions = r.tick(after_settle, &[pass_a, pass_b], true, false, default_tune());
+        let actions = r.tick(
+            after_settle,
+            &[pass_a, pass_b],
+            true,
+            false,
+            25.0,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Recording { .. }));
         // No StartAutoRecord action emitted.
         assert!(
@@ -1336,6 +1362,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         let audio_path = aos_actions
@@ -1356,6 +1383,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
@@ -1364,6 +1392,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         let png_path = los_actions
@@ -1408,6 +1437,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(
@@ -1431,10 +1461,11 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
-        let los_actions = r.tick(los_plus, &[pass], true, true, default_tune());
+        let los_actions = r.tick(los_plus, &[pass], true, true, 25.0, default_tune());
         assert!(los_actions.iter().any(|a| matches!(a, Action::SavePng(_))));
         assert!(
             !los_actions
@@ -1454,7 +1485,14 @@ mod tests {
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let aos_actions = r.tick(now, std::slice::from_ref(&pass), true, true, default_tune());
+        let aos_actions = r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            true,
+            25.0,
+            default_tune(),
+        );
         let audio_path = aos_actions.iter().find_map(|a| match a {
             Action::StartAutoAudioRecord(p) => Some(p.clone()),
             _ => None,
@@ -1477,10 +1515,11 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
-        let los_actions = r.tick(los_plus, &[pass], true, false, default_tune());
+        let los_actions = r.tick(los_plus, &[pass], true, false, 25.0, default_tune());
         assert!(los_actions.iter().any(|a| matches!(a, Action::SavePng(_))));
         assert!(
             los_actions
@@ -1545,7 +1584,7 @@ mod tests {
         let mut r = AutoRecorder::with_supported_protocols(&[]);
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, false, default_tune());
+        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
         // No actions of any kind — no StartAutoRecord, no Toast,
         // no transition.
         assert!(
@@ -1575,6 +1614,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(aos.is_empty());
@@ -1587,6 +1627,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(mid.is_empty());
@@ -1602,6 +1643,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         assert!(
@@ -1629,7 +1671,7 @@ mod tests {
         let mut r = AutoRecorder::with_supported_protocols(&[sdr_sat::ImagingProtocol::Apt]);
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, false, default_tune());
+        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
         let dispatched = actions.iter().find_map(|a| match a {
             Action::StartAutoRecord {
                 satellite,
@@ -1756,6 +1798,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         // CR-bait check: the LRPT arm must dispatch the
@@ -1776,6 +1819,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
@@ -1786,6 +1830,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         assert!(
@@ -1819,7 +1864,8 @@ mod tests {
             now_aos,
             std::slice::from_ref(&pass),
             true,
-            true, // audio_record_on
+            true,
+            25.0, // audio_record_on
             default_tune(),
         );
         assert!(
@@ -1838,6 +1884,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         let after_los = pass.end + ChronoDuration::seconds(1);
@@ -1846,6 +1893,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         assert!(
@@ -1868,6 +1916,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
+            25.0,
             default_tune(),
         );
         assert!(
@@ -1919,6 +1968,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -1927,10 +1977,11 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
-        let los_actions = r.tick(los_plus, &[pass], true, false, default_tune());
+        let los_actions = r.tick(los_plus, &[pass], true, false, 25.0, default_tune());
         assert_save_before_reset(&los_actions, "single-pass LOS");
     }
 
@@ -1953,6 +2004,7 @@ mod tests {
             std::slice::from_ref(&pass1),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let after_settle_1 = now + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -1961,6 +2013,7 @@ mod tests {
             std::slice::from_ref(&pass1),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let los_1 = pass1.end + ChronoDuration::seconds(1);
@@ -1969,6 +2022,7 @@ mod tests {
             std::slice::from_ref(&pass1),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let reset_count_1 = los_1_actions
@@ -1981,7 +2035,7 @@ mod tests {
         // Settle from Finalizing back to Idle (the next tick after
         // LOS does Finalizing → Idle and emits RestoreTune).
         let post_los_1 = los_1 + ChronoDuration::seconds(1);
-        r.tick(post_los_1, &[pass1], true, false, default_tune());
+        r.tick(post_los_1, &[pass1], true, false, 25.0, default_tune());
 
         // Pass 2 — fresh AOS, schedule it after pass 1 completed.
         let pass2_aos = post_los_1 + ChronoDuration::seconds(60);
@@ -1991,6 +2045,7 @@ mod tests {
             std::slice::from_ref(&pass2),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let after_settle_2 = pass2_aos + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -1999,10 +2054,11 @@ mod tests {
             std::slice::from_ref(&pass2),
             true,
             false,
+            25.0,
             default_tune(),
         );
         let los_2 = pass2.end + ChronoDuration::seconds(1);
-        let los_2_actions = r.tick(los_2, &[pass2], true, false, default_tune());
+        let los_2_actions = r.tick(los_2, &[pass2], true, false, 25.0, default_tune());
         let reset_count_2 = los_2_actions
             .iter()
             .filter(|a| matches!(a, Action::ResetImagingDecoders))

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -832,6 +832,13 @@ mod tests {
     use super::*;
     use chrono::{Duration as ChronoDuration, TimeZone};
 
+    /// Default `min_elev_deg` for `tick(...)` in this test module —
+    /// matches `AutoRecordQuality::DEFAULT.min_elev_deg()` (= 25°,
+    /// the "winners and good" tier). Centralized so a future bump to
+    /// the default tier doesn't sprinkle 56 literal updates across
+    /// the file. Per CR round 1 on PR #574.
+    const DEFAULT_MIN_ELEV_DEG: f64 = 25.0;
+
     /// Build a synthetic NOAA 19 pass starting `aos_offset_secs`
     /// from `now`, lasting `duration_secs`, with the given peak
     /// elevation. Mirrors the synthetic-pass fixture pattern used
@@ -876,7 +883,14 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // Pass starts in 3 s — inside the 5 s lead-in.
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            now,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::BeforePass { .. }));
         assert!(matches!(actions[0], Action::StartAutoRecord { .. }));
         // Pre-AOS arming reports "starting" — the pass hasn't
@@ -906,7 +920,14 @@ mod tests {
         // Pass started 30 s ago, ends in 9.5 min — eligible by
         // every other gate (NOAA, 50° peak, end > now).
         let pass = synthetic_noaa19(now, -30, 600, 50.0);
-        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            now,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::BeforePass { .. }));
         match &actions[1] {
             Action::Toast { message, .. } => {
@@ -924,7 +945,14 @@ mod tests {
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], false, false, 25.0, default_tune());
+        let actions = r.tick(
+            now,
+            &[pass],
+            false,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -935,7 +963,14 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // 20° peak — "marginal" tier, below the 25° "good" floor.
         let pass = synthetic_noaa19(now, 3, 720, 20.0);
-        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            now,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -957,7 +992,14 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let mut pass = synthetic_noaa19(now, 3, 720, 50.0);
         pass.satellite = "ISS (ZARYA)".to_string();
-        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            now,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -981,7 +1023,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Idle));
@@ -996,7 +1038,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
@@ -1013,7 +1055,14 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         // Pass starts in 10 min. Way outside the 5 s lead-in.
         let pass = synthetic_noaa19(now, 600, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            now,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Idle));
         assert!(actions.is_empty());
     }
@@ -1029,7 +1078,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
@@ -1040,13 +1089,20 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
         // Past settle window: advance to Recording.
         let later = now + ChronoDuration::seconds(SETTLE_SECS);
-        r.tick(later, &[pass], true, false, 25.0, default_tune());
+        r.tick(
+            later,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Recording { .. }));
     }
 
@@ -1060,7 +1116,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -1069,13 +1125,20 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
         // Tick past LOS.
         let los_plus_one = pass.end + ChronoDuration::seconds(1);
-        let actions = r.tick(los_plus_one, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            los_plus_one,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Finalizing { .. }));
         // Only `SavePng` — the success / failure toast is the
         // wiring layer's responsibility now (it knows the export
@@ -1123,14 +1186,21 @@ mod tests {
             fm_if_nr_enabled: true,
         };
         // Walk all transitions.
-        r.tick(now, std::slice::from_ref(&pass), true, false, 25.0, saved);
+        r.tick(
+            now,
+            std::slice::from_ref(&pass),
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            saved,
+        );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
         r.tick(
             after_settle,
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
@@ -1139,11 +1209,18 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Finalizing { .. }));
-        let actions = r.tick(los_plus, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            los_plus,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(matches!(r.state(), State::Idle));
         // Restore action carries the original saved tune,
         // including the VFO offset (so a user's drag position
@@ -1192,7 +1269,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
@@ -1203,7 +1280,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Finalizing { .. }));
@@ -1234,7 +1311,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::BeforePass { .. }));
@@ -1244,7 +1321,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Finalizing { .. }));
@@ -1262,7 +1339,7 @@ mod tests {
             std::slice::from_ref(&pass_a),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -1271,7 +1348,7 @@ mod tests {
             std::slice::from_ref(&pass_a),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
@@ -1284,7 +1361,7 @@ mod tests {
             &[pass_a, pass_b],
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
@@ -1362,7 +1439,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let audio_path = aos_actions
@@ -1383,7 +1460,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
@@ -1392,7 +1469,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let png_path = los_actions
@@ -1437,7 +1514,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(
@@ -1461,11 +1538,18 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
-        let los_actions = r.tick(los_plus, &[pass], true, true, 25.0, default_tune());
+        let los_actions = r.tick(
+            los_plus,
+            &[pass],
+            true,
+            true,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(los_actions.iter().any(|a| matches!(a, Action::SavePng(_))));
         assert!(
             !los_actions
@@ -1490,7 +1574,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let audio_path = aos_actions.iter().find_map(|a| match a {
@@ -1515,11 +1599,18 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
-        let los_actions = r.tick(los_plus, &[pass], true, false, 25.0, default_tune());
+        let los_actions = r.tick(
+            los_plus,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert!(los_actions.iter().any(|a| matches!(a, Action::SavePng(_))));
         assert!(
             los_actions
@@ -1584,7 +1675,14 @@ mod tests {
         let mut r = AutoRecorder::with_supported_protocols(&[]);
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            now,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         // No actions of any kind — no StartAutoRecord, no Toast,
         // no transition.
         assert!(
@@ -1614,7 +1712,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(aos.is_empty());
@@ -1627,7 +1725,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(mid.is_empty());
@@ -1643,7 +1741,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(
@@ -1671,7 +1769,14 @@ mod tests {
         let mut r = AutoRecorder::with_supported_protocols(&[sdr_sat::ImagingProtocol::Apt]);
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let pass = synthetic_noaa19(now, 3, 720, 50.0);
-        let actions = r.tick(now, &[pass], true, false, 25.0, default_tune());
+        let actions = r.tick(
+            now,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         let dispatched = actions.iter().find_map(|a| match a {
             Action::StartAutoRecord {
                 satellite,
@@ -1798,7 +1903,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         // CR-bait check: the LRPT arm must dispatch the
@@ -1819,7 +1924,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(matches!(r.state(), State::Recording { .. }));
@@ -1830,7 +1935,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(
@@ -1865,7 +1970,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0, // audio_record_on
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(
@@ -1884,7 +1989,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let after_los = pass.end + ChronoDuration::seconds(1);
@@ -1893,7 +1998,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(
@@ -1916,7 +2021,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             true,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         assert!(
@@ -1968,7 +2073,7 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let after_settle = now + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -1977,11 +2082,18 @@ mod tests {
             std::slice::from_ref(&pass),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let los_plus = pass.end + ChronoDuration::seconds(1);
-        let los_actions = r.tick(los_plus, &[pass], true, false, 25.0, default_tune());
+        let los_actions = r.tick(
+            los_plus,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         assert_save_before_reset(&los_actions, "single-pass LOS");
     }
 
@@ -2004,7 +2116,7 @@ mod tests {
             std::slice::from_ref(&pass1),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let after_settle_1 = now + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -2013,7 +2125,7 @@ mod tests {
             std::slice::from_ref(&pass1),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let los_1 = pass1.end + ChronoDuration::seconds(1);
@@ -2022,7 +2134,7 @@ mod tests {
             std::slice::from_ref(&pass1),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let reset_count_1 = los_1_actions
@@ -2035,7 +2147,14 @@ mod tests {
         // Settle from Finalizing back to Idle (the next tick after
         // LOS does Finalizing → Idle and emits RestoreTune).
         let post_los_1 = los_1 + ChronoDuration::seconds(1);
-        r.tick(post_los_1, &[pass1], true, false, 25.0, default_tune());
+        r.tick(
+            post_los_1,
+            &[pass1],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
 
         // Pass 2 — fresh AOS, schedule it after pass 1 completed.
         let pass2_aos = post_los_1 + ChronoDuration::seconds(60);
@@ -2045,7 +2164,7 @@ mod tests {
             std::slice::from_ref(&pass2),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let after_settle_2 = pass2_aos + ChronoDuration::seconds(SETTLE_SECS + 1);
@@ -2054,11 +2173,18 @@ mod tests {
             std::slice::from_ref(&pass2),
             true,
             false,
-            25.0,
+            DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
         let los_2 = pass2.end + ChronoDuration::seconds(1);
-        let los_2_actions = r.tick(los_2, &[pass2], true, false, 25.0, default_tune());
+        let los_2_actions = r.tick(
+            los_2,
+            &[pass2],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
         let reset_count_2 = los_2_actions
             .iter()
             .filter(|a| matches!(a, Action::ResetImagingDecoders))

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9689,13 +9689,13 @@ fn connect_satellites_panel(
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
     use sidebar::satellites_notify::{Action as NotifyAction, NotifyScheduler};
     use sidebar::satellites_panel::{
-        AutoRecordQuality, KEY_AUTO_RECORD_QUALITY, KEY_STATION_ALT_M, KEY_STATION_LAT_DEG,
-        KEY_STATION_LON_DEG, SatellitesPanelWeak, enumerate_upcoming_passes, format_downlink_mhz,
-        format_last_refresh, format_pass_subtitle, format_pass_title, load_auto_record_apt,
-        load_auto_record_audio, load_auto_record_quality, load_notify_lead_min, load_station_alt_m,
-        load_station_lat_deg, load_station_lon_deg, load_watched_satellites, norad_id_for_pass,
-        save_auto_record_apt, save_auto_record_audio, save_f64, save_tle_last_refresh,
-        save_watched_satellites, tune_target_for_pass,
+        AutoRecordQuality, KEY_STATION_ALT_M, KEY_STATION_LAT_DEG, KEY_STATION_LON_DEG,
+        SatellitesPanelWeak, enumerate_upcoming_passes, format_downlink_mhz, format_last_refresh,
+        format_pass_subtitle, format_pass_title, load_auto_record_apt, load_auto_record_audio,
+        load_auto_record_quality, load_notify_lead_min, load_station_alt_m, load_station_lat_deg,
+        load_station_lon_deg, load_watched_satellites, norad_id_for_pass, save_auto_record_apt,
+        save_auto_record_audio, save_f64, save_tle_last_refresh, save_watched_satellites,
+        tune_target_for_pass,
     };
     use sidebar::satellites_recorder::{
         Action as RecorderAction, AutoRecorder, SavedTune, ToastKind,
@@ -10042,17 +10042,31 @@ fn connect_satellites_panel(
             });
     }
 
-    // Persist the quality threshold on change. Per #511.
+    // Persist the quality threshold on change via the symmetric
+    // writer. Validating through `AutoRecordQuality::from_index`
+    // before the write protects the config against transient
+    // out-of-range indices that GTK can emit during model churn —
+    // an unrecognized value would round-trip back to the default
+    // tier on the next read otherwise. Per CR round 1 on PR #574.
     {
         let config_quality = std::sync::Arc::clone(config);
         panel
             .auto_record_quality_row
             .connect_selected_notify(move |row| {
-                let idx = row.selected();
-                config_quality.write(|v| {
-                    v[KEY_AUTO_RECORD_QUALITY] = serde_json::json!(idx);
-                });
-                tracing::info!(idx, "auto_record_quality persisted");
+                let raw = row.selected();
+                let quality = crate::sidebar::satellites_panel::AutoRecordQuality::from_index(raw);
+                if quality.to_index() != raw {
+                    // Transient model-churn value (e.g. mid-rebuild
+                    // selection-cleared). Skip the write so we don't
+                    // overwrite a valid persisted index with garbage.
+                    tracing::debug!(raw, "auto_record_quality: ignoring transient combo index");
+                    return;
+                }
+                crate::sidebar::satellites_panel::save_auto_record_quality(
+                    &config_quality,
+                    quality,
+                );
+                tracing::info!(idx = quality.to_index(), "auto_record_quality persisted");
             });
     }
 

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9689,12 +9689,13 @@ fn connect_satellites_panel(
     use sdr_sat::{GroundStation, KNOWN_SATELLITES, Pass, TleCache};
     use sidebar::satellites_notify::{Action as NotifyAction, NotifyScheduler};
     use sidebar::satellites_panel::{
-        KEY_STATION_ALT_M, KEY_STATION_LAT_DEG, KEY_STATION_LON_DEG, SatellitesPanelWeak,
-        enumerate_upcoming_passes, format_downlink_mhz, format_last_refresh, format_pass_subtitle,
-        format_pass_title, load_auto_record_apt, load_auto_record_audio, load_notify_lead_min,
-        load_station_alt_m, load_station_lat_deg, load_station_lon_deg, load_watched_satellites,
-        norad_id_for_pass, save_auto_record_apt, save_auto_record_audio, save_f64,
-        save_tle_last_refresh, save_watched_satellites, tune_target_for_pass,
+        AutoRecordQuality, KEY_AUTO_RECORD_QUALITY, KEY_STATION_ALT_M, KEY_STATION_LAT_DEG,
+        KEY_STATION_LON_DEG, SatellitesPanelWeak, enumerate_upcoming_passes, format_downlink_mhz,
+        format_last_refresh, format_pass_subtitle, format_pass_title, load_auto_record_apt,
+        load_auto_record_audio, load_auto_record_quality, load_notify_lead_min, load_station_alt_m,
+        load_station_lat_deg, load_station_lon_deg, load_watched_satellites, norad_id_for_pass,
+        save_auto_record_apt, save_auto_record_audio, save_f64, save_tle_last_refresh,
+        save_watched_satellites, tune_target_for_pass,
     };
     use sidebar::satellites_recorder::{
         Action as RecorderAction, AutoRecorder, SavedTune, ToastKind,
@@ -9738,6 +9739,16 @@ fn connect_satellites_panel(
     panel
         .auto_record_audio_switch
         .set_active(load_auto_record_audio(config));
+    let initial_quality = load_auto_record_quality(config);
+    panel
+        .auto_record_quality_row
+        .set_selected(initial_quality.to_index());
+    // Sensitivity tracks the auto-record switch — re-sync after
+    // hydration in case the persisted switch state differs from
+    // the panel's builder default.
+    panel
+        .auto_record_quality_row
+        .set_sensitive(panel.auto_record_switch.is_active());
     panel
         .last_refresh_row
         .set_subtitle(&format_last_refresh(config));
@@ -10028,6 +10039,20 @@ fn connect_satellites_panel(
             .auto_record_audio_switch
             .connect_active_notify(move |sw| {
                 save_auto_record_audio(&config_audio, sw.is_active());
+            });
+    }
+
+    // Persist the quality threshold on change. Per #511.
+    {
+        let config_quality = std::sync::Arc::clone(config);
+        panel
+            .auto_record_quality_row
+            .connect_selected_notify(move |row| {
+                let idx = row.selected();
+                config_quality.write(|v| {
+                    v[KEY_AUTO_RECORD_QUALITY] = serde_json::json!(idx);
+                });
+                tracing::info!(idx, "auto_record_quality persisted");
             });
     }
 
@@ -11191,11 +11216,19 @@ fn connect_satellites_panel(
                 ),
                 fm_if_nr_enabled: fm_if_nr_row_tick.is_active(),
             };
+            // Read the user's selected quality tier on every
+            // tick — cheap (just a ComboRow.selected() call), and
+            // means a mid-pass change applies immediately to the
+            // next eligible pass without a restart. Per #511.
+            let min_elev_deg =
+                AutoRecordQuality::from_index(panel.auto_record_quality_row.selected())
+                    .min_elev_deg();
             let actions = recorder_tick.borrow_mut().tick(
                 now,
                 &passes_snapshot,
                 auto_record_on,
                 audio_record_on,
+                min_elev_deg,
                 now_tune,
             );
             for action in actions {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -205,7 +205,24 @@ fn tune_to_target(
     if let Some(idx) = demod_selector::demod_mode_to_index(mode) {
         demod_dropdown.set_selected(idx);
     }
+    // Update the bandwidth row's allowed range for the new mode
+    // BEFORE setting the value. The dropdown notify above only
+    // queues `SetDemodMode` to the DSP; the range update only
+    // happens when DSP echoes `DemodModeChanged` back, which is
+    // async. Without this synchronous update, `set_value(bw_hz)`
+    // below would clamp to the previous mode's range AND fire
+    // its own notify that dispatches a wrong `SetBandwidth`,
+    // overriding the correct `SetBandwidth(bw_hz)` we just sent
+    // at line 202. WFM→NFM retunes are the common failure case.
+    // Per CR round 2 on PR #574.
+    update_bandwidth_row_range_for_mode(radio_panel, state, mode);
+    // Suppress the bandwidth row's notify around `set_value` so
+    // it doesn't redispatch a redundant `SetBandwidth` —
+    // `tune_to_target` already sent the canonical command at
+    // line 202 above.
+    state.suppress_bandwidth_notify.set(true);
     bandwidth_row.set_value(bw_hz);
+    state.suppress_bandwidth_notify.set(false);
     // Mode-specific control visibility (e.g. squelch / deemph rows
     // shown only in NFM/WFM) — must be poked explicitly because
     // the demod-dropdown notify only covers the dropdown's own
@@ -9743,12 +9760,13 @@ fn connect_satellites_panel(
     panel
         .auto_record_quality_row
         .set_selected(initial_quality.to_index());
-    // Sensitivity tracks the auto-record switch — re-sync after
-    // hydration in case the persisted switch state differs from
-    // the panel's builder default.
-    panel
-        .auto_record_quality_row
-        .set_sensitive(panel.auto_record_switch.is_active());
+    // Sensitivity is wired in `build_satellites_panel` via the
+    // auto-record switch's `connect_active_notify` handler — it
+    // fires on every toggle, including the one triggered above
+    // by `auto_record_switch.set_active(load_auto_record_apt(...))`,
+    // so the persisted switch state propagates to the combo's
+    // sensitivity automatically. No re-sync needed here. Per CR
+    // round 2 on PR #574.
     panel
         .last_refresh_row
         .set_subtitle(&format_last_refresh(config));

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -150,6 +150,74 @@ fn apply_manual_tune(
     radio_panel.update_distance_frequency(freq_hz);
 }
 
+/// Apply the canonical tune-target dispatch — the 13 widget /
+/// state / DSP mirror steps that bookmark recall, the satellite
+/// play button, and auto-record-on-pass all need to perform when
+/// retuning to a new (frequency, demod mode, bandwidth) target.
+///
+/// This is the single source of truth for the mirror sequence. Each
+/// caller layers its own pre/post calls (e.g. bookmark recall calls
+/// `restore_bookmark_profile` after; auto-record AOS layers
+/// `force_audio_chain_off` + `set_playing(true)` before and
+/// `dispatch_vfo_offset(0.0)` after). Per #509.
+///
+/// `reason` is the context string passed to
+/// `ScannerForceDisable::trigger` so the scanner-disabled toast says
+/// *why* (`"satellite tune"`, `"preset/bookmark selection"`, etc.).
+///
+/// Note: `SetDemodMode` is intentionally NOT sent directly here —
+/// the demod dropdown's `notify::selected` handler dispatches it as
+/// a side effect of `set_selected` below. This mirrors the existing
+/// pattern that both call sites historically used.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "consolidating the duplicated 13-step mirror sequence into a single \
+              source of truth requires every captured widget / handle the two \
+              call sites used to capture; threading them through is the point"
+)]
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "freq_hz is bounded by the user-tunable RTL-SDR range (≤6 GHz) and \
+              well below f64's 2^53 mantissa ceiling"
+)]
+fn tune_to_target(
+    state: &Rc<AppState>,
+    freq_selector: &header::frequency_selector::FrequencySelector,
+    demod_dropdown: &gtk4::DropDown,
+    spectrum_handle: &Rc<spectrum::SpectrumHandle>,
+    scanner_force_disable: &ScannerForceDisable,
+    bandwidth_row: &adw::SpinRow,
+    radio_panel: &sidebar::radio_panel::RadioPanel,
+    status_bar: &Rc<StatusBar>,
+    freq_hz: u64,
+    mode: sdr_types::DemodMode,
+    bw_hz: f64,
+    reason: &'static str,
+) {
+    scanner_force_disable.trigger(reason);
+    let freq_f64 = freq_hz as f64;
+    state.center_frequency.set(freq_f64);
+    state.demod_mode.set(mode);
+    state.send_dsp(UiToDsp::Tune(freq_f64));
+    state.send_dsp(UiToDsp::SetBandwidth(bw_hz));
+    freq_selector.set_frequency(freq_hz);
+    spectrum_handle.set_center_frequency(freq_f64);
+    if let Some(idx) = demod_selector::demod_mode_to_index(mode) {
+        demod_dropdown.set_selected(idx);
+    }
+    bandwidth_row.set_value(bw_hz);
+    // Mode-specific control visibility (e.g. squelch / deemph rows
+    // shown only in NFM/WFM) — must be poked explicitly because
+    // the demod-dropdown notify only covers the dropdown's own
+    // state.
+    radio_panel.apply_demod_visibility(mode);
+    // Status bar mirrors. Done last so a panic anywhere upstream
+    // doesn't leave the indicator showing an optimistic value that
+    // the DSP never received.
+    status_bar.update_frequency(freq_f64);
+    status_bar.update_demod(header::demod_mode_label(mode), bw_hz);
+}
+
 /// Build the main application window and return the shared
 /// [`AppState`]. The caller (currently `app.rs::connect_activate`)
 /// decides whether to call `window.present()` based on the
@@ -3354,34 +3422,20 @@ fn connect_sidebar_panels(
         let radio_panel_t = panels.radio.clone();
         let status_bar_t = Rc::clone(status_bar);
         Rc::new(move |freq_hz, mode, bw_hz| {
-            force_disable_t.trigger("satellite tune");
-            #[allow(
-                clippy::cast_precision_loss,
-                reason = "downlink frequencies sit in the 100s of MHz, far \
-                          below f64's 2^53 mantissa ceiling"
-            )]
-            let freq_f64 = freq_hz as f64;
-            let bw_f64 = f64::from(bw_hz);
-            state_t.center_frequency.set(freq_f64);
-            state_t.demod_mode.set(mode);
-            state_t.send_dsp(UiToDsp::Tune(freq_f64));
-            state_t.send_dsp(UiToDsp::SetBandwidth(bw_f64));
-            freq_selector_t.set_frequency(freq_hz);
-            spectrum_t.set_center_frequency(freq_f64);
-            if let Some(idx) = demod_selector::demod_mode_to_index(mode) {
-                demod_dropdown_t.set_selected(idx);
-            }
-            bandwidth_row_t.set_value(bw_f64);
-            // Mode-specific control visibility (e.g. squelch /
-            // deemph rows shown only in NFM/WFM) — must be poked
-            // explicitly because the demod-dropdown notify only
-            // covers the dropdown's own state.
-            radio_panel_t.apply_demod_visibility(mode);
-            // Status bar mirrors. Done last so a panic anywhere
-            // upstream doesn't leave the indicator showing an
-            // optimistic value that the DSP never received.
-            status_bar_t.update_frequency(freq_f64);
-            status_bar_t.update_demod(header::demod_mode_label(mode), bw_f64);
+            tune_to_target(
+                &state_t,
+                &freq_selector_t,
+                &demod_dropdown_t,
+                &spectrum_t,
+                &force_disable_t,
+                &bandwidth_row_t,
+                &radio_panel_t,
+                &status_bar_t,
+                freq_hz,
+                mode,
+                f64::from(bw_hz),
+                "satellite tune",
+            );
         })
     };
     // Register `app.tune-satellite` so the "Tune" button on a #510
@@ -8860,7 +8914,13 @@ fn connect_navigation_panel(
     // Navigation callback: restore full tuning profile from bookmark.
     let state_nav = Rc::clone(state);
     let fs = freq_selector.clone();
-    let dd_weak = demod_dropdown.downgrade();
+    // Strong clone — single-threaded GTK main loop, the closure
+    // outlives the dropdown only at teardown which drops both at
+    // once. Pre-#509 this was a `WeakRef` upgraded inside the
+    // closure; `tune_to_target` takes `&gtk4::DropDown`, and the
+    // strong clone keeps the call shape uniform with the satellite
+    // closure (which has always held a strong clone).
+    let dd = demod_dropdown.clone();
     let sb = Rc::clone(status_bar);
     let spectrum_nav = Rc::clone(spectrum_handle);
     let radio_nav = panels.radio.clone();
@@ -8868,6 +8928,7 @@ fn connect_navigation_panel(
     let source_nav_agc = panels.source.agc_row.clone();
     let force_disable_nav = Rc::clone(scanner_force_disable);
     let volume_button_nav = volume_button.clone();
+    let bandwidth_row_nav = panels.radio.bandwidth_row.clone();
 
     panels.bookmarks.connect_navigate(move |bookmark| {
         // Both bookmark recall AND band-preset selection come in
@@ -8875,37 +8936,31 @@ fn connect_navigation_panel(
         // `connect_preset_to_bookmarks` invokes `on_navigate` with
         // a synthesized Bookmark). Keep the toast reason neutral
         // so a preset click doesn't claim "bookmark recall".
-        force_disable_nav.trigger("preset/bookmark selection");
-
         let freq = bookmark.frequency;
         let mode = sidebar::navigation_panel::parse_demod_mode(&bookmark.demod_mode);
         let bw = bookmark.bandwidth;
 
-        #[allow(clippy::cast_precision_loss)]
-        let freq_f64 = freq as f64;
-        state_nav.center_frequency.set(freq_f64);
-        state_nav.demod_mode.set(mode);
+        // Canonical 13-step mirror sequence — single source of
+        // truth shared with the satellite tune path. Per #509.
+        tune_to_target(
+            &state_nav,
+            &fs,
+            &dd,
+            &spectrum_nav,
+            &force_disable_nav,
+            &bandwidth_row_nav,
+            &radio_nav,
+            &sb,
+            freq,
+            mode,
+            bw,
+            "preset/bookmark selection",
+        );
 
-        // Send Tune and Bandwidth directly. SetDemodMode is sent by the
-        // demod dropdown callback when we update its selection below.
-        state_nav.send_dsp(UiToDsp::Tune(freq_f64));
-        state_nav.send_dsp(UiToDsp::SetBandwidth(bw));
-
-        // Update frequency selector display (does NOT fire callback — no duplicate Tune).
-        fs.set_frequency(freq);
-        spectrum_nav.set_center_frequency(freq_f64);
-
-        // Update demod dropdown — its callback sends SetDemodMode to DSP.
-        if let Some(dd) = dd_weak.upgrade()
-            && let Some(idx) = demod_selector::demod_mode_to_index(mode)
-        {
-            dd.set_selected(idx);
-        }
-
-        // Update bandwidth widget (fires its own DSP callback).
-        radio_nav.bandwidth_row.set_value(bw);
-
-        // Restore optional tuning-profile settings (squelch, gain, etc.).
+        // Restore optional tuning-profile settings (squelch, gain,
+        // etc.). Bookmark-specific layer on top of the canonical
+        // mirror sequence — auto-record / satellite play don't
+        // need this.
         restore_bookmark_profile(
             bookmark,
             &state_nav,
@@ -8914,14 +8969,6 @@ fn connect_navigation_panel(
             &source_nav_agc,
             &volume_button_nav,
         );
-
-        // Update mode-specific control visibility for the restored mode.
-        radio_nav.apply_demod_visibility(mode);
-
-        // Update status bar
-        sb.update_frequency(freq_f64);
-        let label = header::demod_mode_label(mode);
-        sb.update_demod(label, bw);
 
         tracing::info!(
             frequency = freq,


### PR DESCRIPTION
## Summary

Two related satellite-recording improvements landed as one bundled PR.

**#509 — Extract \`tune_to_target\` helper.** Consolidate the 13-step tune-mirror sequence (state cells, DSP commands, widget updates, status-bar mirrors) into a single free function. Bookmark recall, the satellite play button (\`tune_to_satellite\` closure), and the auto-record AOS handler all now route through \`tune_to_target\` — single source of truth means future changes to the mirror sequence can't drift between the two call sites. No behavior change. Closes #509.

**#511 — User-configurable auto-record quality threshold.** Replaces the hardcoded \`AUTO_RECORD_MIN_ELEV_DEG = 25.0\` gate with an \`AdwComboRow\` in the Satellites panel's Recording group offering four tiers:
- Winners only (≥ 40°)
- Winners and good (≥ 25°) — default; matches the previous hardcoded threshold
- Marginal or better (≥ 15°)
- All passes (≥ 5°)

Combo sensitivity tracks the auto-record switch (only useful when auto-record is on). Selection persists to config key \`sat_auto_record_quality\` as a u32 combo index. The recorder's \`tick(...)\` now takes a \`min_elev_deg: f64\` parameter, read at every tick from the panel. Closes #511.

## Why bundled

\`tune_to_target\` (#509) is the consolidation; #511 builds the threshold dropdown right on top of the auto-record state machine those callers feed. Bundling exposes more cross-cutting bugs to CodeRabbit and avoids two PRs touching adjacent code in \`window.rs\` / \`satellites_recorder.rs\`.

## Tests

- 5 new unit tests pinning \`AutoRecordQuality\` mapping (min_elev_deg per tier, default, index round-trip, OOR fallback, ALL ordering)
- 32 existing recorder tests updated for the new \`min_elev_deg\` tick arg
- Full sdr-ui lib: 371 passes (366 prior + 5 new)
- Workspace \`cargo test --workspace\`, \`clippy --all-targets -- -D warnings\`, \`fmt --check\`, \`make lint\` all clean

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test -p sdr-ui --lib --features whisper-cpu\` (371 pass)
- [x] \`make lint\` (cargo deny + audit + clippy + fmt)
- [x] Manual: bookmark recall still tunes correctly via the new helper path
- [x] Manual: satellite play button still works
- [x] Manual: Settings → Satellites → Recording shows the new \`Quality threshold\` combo row, sensitive only when auto-record switch is on, default \`Winners and good\`
- [x] Manual: selection persists across restart (\`~/.config/sdr-rs/config.json\` shows \`sat_auto_record_quality\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted, user-selectable auto-record quality tier for satellites with a UI control that follows the auto-record switch and applies changes live (mid-pass).

* **Refactoring**
  * Consolidated tuning/retune behavior into a single, consistent dispatcher to unify frequency, mode and bandwidth updates and UI synchronization.

* **Tests**
  * Added focused tests covering quality-tier save/load, label alignment, ordering invariants and threshold behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->