### PR TITLE
feat(sdr-ui): ACARS viewer sort + auto-mute on engage

### DIFF
--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -177,12 +177,19 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
 
     let filter = gtk4::CustomFilter::new(|_obj| true);
     let filter_model = gtk4::FilterListModel::new(Some(store.clone()), Some(filter.clone()));
-    let selection = gtk4::NoSelection::new(Some(filter_model.clone()));
+    // SortListModel in the chain so column-header clicks reorder
+    // the visible rows. Issue #585. Sorter starts as `None`; it's
+    // bound to `column_view.sorter()` after the column-view exists
+    // so the user's header-click state drives sort order.
+    let sort_model =
+        gtk4::SortListModel::new(Some(filter_model.clone()), Option::<gtk4::Sorter>::None);
+    let selection = gtk4::NoSelection::new(Some(sort_model.clone()));
     let column_view = gtk4::ColumnView::builder()
         .model(&selection)
         .show_column_separators(true)
         .show_row_separators(true)
         .build();
+    sort_model.set_sorter(column_view.sorter().as_ref());
 
     // Seven columns per spec section "Content":
     //   Time | Freq | Aircraft | Mode | Label | Block | Text
@@ -196,7 +203,28 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         ("Text", render_text, true),
     ];
 
-    for (title, render, expand) in columns {
+    // Per-column sorters. Each is a `CustomSorter` reading the
+    // inner `AcarsMessage` via `obj.imp().inner.borrow()` (no
+    // clone on the comparator hot path) and falling back to
+    // `Ordering::Equal` when the slot is empty (model churn).
+    // Issue #585.
+    let sorters: [gtk4::CustomSorter; 7] = [
+        make_message_sorter(|a, b| a.timestamp.cmp(&b.timestamp)),
+        make_message_sorter(|a, b| {
+            a.freq_hz
+                .partial_cmp(&b.freq_hz)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }),
+        make_message_sorter(|a, b| a.aircraft.to_lowercase().cmp(&b.aircraft.to_lowercase())),
+        make_message_sorter(|a, b| a.mode.cmp(&b.mode)),
+        make_message_sorter(|a, b| a.label.cmp(&b.label)),
+        make_message_sorter(|a, b| a.block_id.cmp(&b.block_id)),
+        make_message_sorter(|a, b| a.text.to_lowercase().cmp(&b.text.to_lowercase())),
+    ];
+
+    let mut time_column: Option<gtk4::ColumnViewColumn> = None;
+
+    for (idx, (title, render, expand)) in columns.into_iter().enumerate() {
         let factory = gtk4::SignalListItemFactory::new();
         factory.connect_setup(move |_factory, item| {
             // Fail closed on unexpected item type rather than
@@ -242,7 +270,17 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
             .resizable(true)
             .expand(expand)
             .build();
+        column.set_sorter(Some(&sorters[idx]));
+        if idx == 0 {
+            time_column = Some(column.clone());
+        }
         column_view.append_column(&column);
+    }
+    // Default sort: Time descending so newest stays at top
+    // (matches the append-at-bottom behaviour pre-#585; just
+    // expressed as a sort instead of insertion order).
+    if let Some(col) = time_column {
+        column_view.sort_by_column(Some(&col), gtk4::SortType::Descending);
     }
 
     let scroll = gtk4::ScrolledWindow::builder()
@@ -348,6 +386,31 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     }
 
     window
+}
+
+/// Build a `CustomSorter` over `AcarsMessageObject` rows. The
+/// inner `AcarsMessage` is borrowed (no clone on the comparator
+/// hot path) and `Ordering::Equal` is returned on any unexpected
+/// row state (model churn / wrong wrapper type / empty slot).
+/// Issue #585.
+fn make_message_sorter<F>(cmp: F) -> gtk4::CustomSorter
+where
+    F: Fn(&sdr_acars::AcarsMessage, &sdr_acars::AcarsMessage) -> std::cmp::Ordering + 'static,
+{
+    gtk4::CustomSorter::new(move |a, b| {
+        let Some(a_obj) = a.downcast_ref::<AcarsMessageObject>() else {
+            return gtk4::Ordering::Equal;
+        };
+        let Some(b_obj) = b.downcast_ref::<AcarsMessageObject>() else {
+            return gtk4::Ordering::Equal;
+        };
+        let a_inner = a_obj.imp().inner.borrow();
+        let b_inner = b_obj.imp().inner.borrow();
+        match (a_inner.as_ref(), b_inner.as_ref()) {
+            (Some(a_msg), Some(b_msg)) => cmp(a_msg, b_msg).into(),
+            _ => gtk4::Ordering::Equal,
+        }
+    })
 }
 
 fn render_time(msg: &sdr_acars::AcarsMessage) -> String {

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -215,11 +215,11 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
                 .partial_cmp(&b.freq_hz)
                 .unwrap_or(std::cmp::Ordering::Equal)
         }),
-        make_message_sorter(|a, b| a.aircraft.to_lowercase().cmp(&b.aircraft.to_lowercase())),
+        make_message_sorter(|a, b| cmp_case_insensitive(&a.aircraft, &b.aircraft)),
         make_message_sorter(|a, b| a.mode.cmp(&b.mode)),
         make_message_sorter(|a, b| a.label.cmp(&b.label)),
         make_message_sorter(|a, b| a.block_id.cmp(&b.block_id)),
-        make_message_sorter(|a, b| a.text.to_lowercase().cmp(&b.text.to_lowercase())),
+        make_message_sorter(|a, b| cmp_case_insensitive(&a.text, &b.text)),
     ];
 
     let mut time_column: Option<gtk4::ColumnViewColumn> = None;
@@ -386,6 +386,20 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     }
 
     window
+}
+
+/// Allocation-free, Unicode-aware case-insensitive comparison.
+/// Used by the Aircraft + Text column sorters where comparator
+/// fires once per row pair per sort. The naive
+/// `a.to_lowercase().cmp(&b.to_lowercase())` allocates two
+/// `String`s per call; this version threads `char::to_lowercase`
+/// through the iterator pair and stops at the first non-equal
+/// codepoint without ever materialising a folded string.
+/// CR round 1 on PR #590.
+fn cmp_case_insensitive(a: &str, b: &str) -> std::cmp::Ordering {
+    a.chars()
+        .flat_map(char::to_lowercase)
+        .cmp(b.chars().flat_map(char::to_lowercase))
 }
 
 /// Build a `CustomSorter` over `AcarsMessageObject` rows. The

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -314,6 +314,22 @@ pub struct AppState {
     /// `AcarsEnabledChanged` arm (`Ok(true)` / `Ok(false)` /
     /// `Err`).
     pub acars_pending: Cell<bool>,
+    /// Pre-engage audio volume captured by the
+    /// `AcarsEnabledChanged(Ok(true))` arm so the disengage path
+    /// can restore it. While ACARS is engaged the speaker output
+    /// is meaningless (the demod is parked on whatever single
+    /// VFO position the user had pre-engage; the 6 ACARS channels
+    /// are decoded silently in parallel), so we auto-mute on
+    /// engage (issue #588) and restore on disengage. Per-session
+    /// override: if the user manually re-raises volume mid-session,
+    /// the disengage arm respects that and skips restore.
+    pub acars_saved_volume: Cell<Option<f32>>,
+    /// Mirror of `suppress_bandwidth_notify` for the volume
+    /// `ScaleButton`. Set around programmatic `set_value` calls
+    /// from the `AcarsEnabledChanged` arm so the auto-mute /
+    /// auto-restore doesn't write 0.0 back to config or
+    /// re-enter `send_dsp` from the value-changed handler.
+    pub suppress_volume_notify: Cell<bool>,
 }
 
 impl AppState {
@@ -364,6 +380,8 @@ impl AppState {
             acars_saved_tune: Cell::new(None),
             acars_was_engaged_pre_pass: Cell::new(false),
             acars_pending: Cell::new(false),
+            acars_saved_volume: Cell::new(None),
+            suppress_volume_notify: Cell::new(false),
         })
     }
 
@@ -479,6 +497,14 @@ mod tests {
         assert!(
             !state.acars_pending.get(),
             "no SetAcarsEnabled command in flight at construction"
+        );
+        assert!(
+            state.acars_saved_volume.get().is_none(),
+            "no saved pre-engage volume until first engage"
+        );
+        assert!(
+            !state.suppress_volume_notify.get(),
+            "volume notify suppression off at construction"
         );
         assert!(
             state.acars_viewer_handles.borrow().is_none(),

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1112,6 +1112,7 @@ pub fn build_window(
     let demod_dropdown_for_dsp = demod_dropdown.clone();
     let sample_rate_row_for_dsp = panels.source.sample_rate_row.clone();
     let decimation_row_for_dsp = panels.source.decimation_row.clone();
+    let volume_button_for_dsp = volume_button.clone();
     // Just the three widgets the rtl_tcp status renderer touches —
     // cloning the whole SourcePanel would be a lot of refcount
     // traffic for one signal handler. Weak refs, upgraded per
@@ -1200,6 +1201,7 @@ pub fn build_window(
                         &demod_dropdown_for_dsp,
                         &sample_rate_row_for_dsp,
                         &decimation_row_for_dsp,
+                        &volume_button_for_dsp,
                         &rtl_tcp_status_row_weak,
                         &rtl_tcp_disconnect_button_weak,
                         &rtl_tcp_retry_button_weak,
@@ -1428,6 +1430,7 @@ fn handle_dsp_message(
     demod_dropdown: &gtk4::DropDown,
     sample_rate_row: &adw::ComboRow,
     decimation_row: &adw::ComboRow,
+    volume_button: &gtk4::ScaleButton,
     rtl_tcp_status_row_weak: &glib::WeakRef<adw::ActionRow>,
     rtl_tcp_disconnect_button_weak: &glib::WeakRef<gtk4::Button>,
     rtl_tcp_retry_button_weak: &glib::WeakRef<gtk4::Button>,
@@ -2048,6 +2051,25 @@ fn handle_dsp_message(
                     sample_rate_row.set_sensitive(false);
                     decimation_row.set_sensitive(false);
                     status_bar.update_frequency(center_hz);
+                    // Auto-mute the speaker (issue #588). With ACARS
+                    // engaged the demod is parked on the user's
+                    // single pre-engage VFO position, which is
+                    // unrelated to the 6 ACARS channels being
+                    // decoded silently in parallel — so whatever
+                    // comes out of the speaker is at best an
+                    // unrelated airband channel and at worst static.
+                    // Capture pre-engage volume + flip to 0; the
+                    // suppress flag prevents the value-changed
+                    // handler from persisting 0.0 to config or
+                    // double-dispatching SetVolume. We send
+                    // SetVolume(0.0) explicitly here.
+                    #[allow(clippy::cast_possible_truncation)]
+                    let pre_engage_volume = volume_button.value() as f32;
+                    state.acars_saved_volume.set(Some(pre_engage_volume));
+                    state.suppress_volume_notify.set(true);
+                    volume_button.set_value(0.0);
+                    state.suppress_volume_notify.set(false);
+                    state.send_dsp(UiToDsp::SetVolume(0.0));
                     tracing::info!("ACARS engaged");
                 }
                 Ok(false) => {
@@ -2080,6 +2102,30 @@ fn handle_dsp_message(
                     demod_dropdown.set_sensitive(true);
                     sample_rate_row.set_sensitive(true);
                     decimation_row.set_sensitive(true);
+                    // Auto-restore volume (issue #588) — but only
+                    // if the user didn't manually move it during
+                    // the session. We muted to 0.0 on engage; if
+                    // current value is still ≈ 0, no override
+                    // happened, restore the saved value. If the
+                    // user moved it (current > tolerance), respect
+                    // their explicit choice and skip restore.
+                    // Tolerance 0.01 (1%) is well above ScaleButton
+                    // popover step granularity. Don't suppress on
+                    // restore: the value-changed handler's
+                    // dispatch + persist of the restored value is
+                    // exactly what we want.
+                    if let Some(saved) = state.acars_saved_volume.take() {
+                        const VOLUME_OVERRIDE_TOLERANCE: f64 = 0.01;
+                        let current = volume_button.value();
+                        if current.abs() < VOLUME_OVERRIDE_TOLERANCE {
+                            volume_button.set_value(f64::from(saved));
+                        } else {
+                            tracing::debug!(
+                                current,
+                                "ACARS disengage: keeping user-overridden volume"
+                            );
+                        }
+                    }
                     tracing::info!("ACARS disengaged");
                 }
                 Err(err) => {
@@ -2095,6 +2141,14 @@ fn handle_dsp_message(
                     // `state.acars_enabled` value, undoing the
                     // user's failed toggle.
                     state.acars_pending.set(false);
+                    // `acars_saved_volume` (and `acars_saved_tune`)
+                    // are intentionally NOT cleared here. Err
+                    // doesn't disambiguate engage-vs-disengage
+                    // failure: a failed disengage on an already-
+                    // engaged session needs the saved snapshots
+                    // preserved so the eventual successful
+                    // disengage can restore them; a failed engage
+                    // simply never set them.
                     // Surface the failure as a toast so the user
                     // sees the actionable error (e.g. "scanner is
                     // running" or "RTL-SDR required").
@@ -9409,6 +9463,16 @@ fn connect_volume_persistence(
     let config_vol = std::sync::Arc::clone(config);
     let volume_row_weak = panels.audio.volume_row.downgrade();
     volume_button.connect_value_changed(move |_btn, value| {
+        // Suppress fires when the ACARS engage path programmatically
+        // sets the value to 0 (or restores it on disengage); without
+        // this guard the auto-mute would persist 0.0 to config and
+        // double-dispatch SetVolume. The engage / disengage arms in
+        // `handle_dsp_message` take responsibility for the explicit
+        // SetVolume dispatch. Mirrors `suppress_bandwidth_notify` /
+        // `suppress_demod_notify`.
+        if state_vol.suppress_volume_notify.get() {
+            return;
+        }
         #[allow(clippy::cast_possible_truncation)]
         state_vol.send_dsp(UiToDsp::SetVolume(value as f32));
         config_vol.write(|v| {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -9463,6 +9463,23 @@ fn connect_volume_persistence(
     let config_vol = std::sync::Arc::clone(config);
     let volume_row_weak = panels.audio.volume_row.downgrade();
     volume_button.connect_value_changed(move |_btn, value| {
+        // Audio-panel slider mirror runs unconditionally so the
+        // header `ScaleButton` stays the single source of truth
+        // for the audio panel's percent slider — including
+        // during the ACARS programmatic mute/restore where
+        // dispatch + persist are suppressed below. Without
+        // mirroring here, the panel slider would still show the
+        // pre-mute percent while the header sits at 0.0, and a
+        // user touching the panel slider could fight ACARS by
+        // dispatching the stale value. CR round 1 on PR #590.
+        if let Some(row) = volume_row_weak.upgrade() {
+            let target_pct = value * sidebar::audio_panel::VOLUME_PERCENT_MAX;
+            if (row.value() - target_pct).abs()
+                > VOLUME_SYNC_EPSILON * sidebar::audio_panel::VOLUME_PERCENT_MAX
+            {
+                row.set_value(target_pct);
+            }
+        }
         // Suppress fires when the ACARS engage path programmatically
         // sets the value to 0 (or restores it on disengage); without
         // this guard the auto-mute would persist 0.0 to config and
@@ -9478,14 +9495,6 @@ fn connect_volume_persistence(
         config_vol.write(|v| {
             v[sidebar::audio_panel::KEY_AUDIO_VOLUME] = serde_json::json!(value);
         });
-        if let Some(row) = volume_row_weak.upgrade() {
-            let target_pct = value * sidebar::audio_panel::VOLUME_PERCENT_MAX;
-            if (row.value() - target_pct).abs()
-                > VOLUME_SYNC_EPSILON * sidebar::audio_panel::VOLUME_PERCENT_MAX
-            {
-                row.set_value(target_pct);
-            }
-        }
     });
 
     // Audio panel row is mirror-only. Drives the button, which


### PR DESCRIPTION
First bundled follow-up to ACARS epic #474. Closes #585 + #588.

## Summary

- **#585** — Sortable column headers in the ACARS viewer. SortListModel in the pipeline, per-column `CustomSorter`s built via a small helper that borrows the inner message (no clone on the comparator hot path). Default sort is Time descending so newest stays at top.
- **#588** — Auto-mute the speaker when ACARS engages and restore on disengage. New `acars_saved_volume` + `suppress_volume_notify` AppState slots. Override-respect: if the user manually moves the volume during a session, the disengage path leaves it alone.

## Test plan

- [x] `cargo build --workspace --features sdr-transcription/whisper-cpu` clean
- [x] `cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] All 1830 lib tests pass
- [x] `acars_defaults_pin_initializer_contract` extended for both new AppState slots
- [x] Live smoke against BCB airband: sort + filter compose, time-desc default holds, all 7 columns sort correctly, sort persists across new arrivals
- [x] Live smoke for mute: engage mutes; disengage restores; manual override during session sticks past disengage; engage-Err leaves volume untouched; restart-while-engaged mutes on auto-engage at startup

## Out of scope (still open under #474)

- #577 per-label decoders (heavy)
- #579 aircraft-grouped tab (heavy)
- #580 multi-block reassembly (medium)
- #581 international channel sets (medium)
- #586 collapse duplicate messages (small — next bundle candidate)
- #589 gate satellite AOS retune on disengage ack (medium refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable column headers in the ACARS viewer to sort rows by any column, preserving newest-on-top initial order.
  * Per-session ACARS volume state: UI saves and restores the prior slider level when ACARS mutes/unmutes.

* **Bug Fixes**
  * ACARS engage/disengage now mutes via the volume control and restores prior volume unless user changed it.
  * Suppresses duplicate/persistent zero-volume updates during programmatic mute/restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->