### PR TITLE
feat(sdr-ui): ACARS viewer collapse-dupes + auto-scroll + AOS disengage gate

### DIFF
--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -29,7 +29,37 @@ pub struct ViewerHandles {
     pub status_label: gtk4::Label,
     pub pause_button: gtk4::ToggleButton,
     pub filter_entry: gtk4::SearchEntry,
+    /// Collapse-duplicates toggle (issue #586). When active,
+    /// the message-append site walks the most recent rows for
+    /// a `(aircraft, mode, label, text)` key match within the
+    /// recency window and bumps the existing row's count + last
+    /// seen instead of appending a new one.
+    pub collapse_button: gtk4::ToggleButton,
+    /// `ScrolledWindow` for the auto-scroll-to-top behavior on
+    /// new arrivals. The append site checks whether the user is
+    /// at the top via `vadjustment().value()` and resets the
+    /// adjustment back to its lower bound — if they've manually
+    /// scrolled down to read older rows, auto-follow freezes
+    /// until they scroll back. Bypasses `ColumnView::scroll_to`
+    /// which needs gtk4 `v4_12` (workspace is on `v4_10`).
+    pub scrolled_window: gtk4::ScrolledWindow,
 }
+
+/// Recency window length in seconds (10 minutes). Split into a
+/// named intermediate so the `60 * 10` factor reads as
+/// "ten minutes" without tripping the duration-unit lint that
+/// would otherwise fire on `from_secs(600)`.
+const ACARS_COLLAPSE_WINDOW_SECS: u64 = 60 * 10;
+
+/// Window of "recent" rows the collapse-duplicates path scans
+/// for a key match (issue #586). 10 minutes per the spec; rows
+/// older than this stay as their own entry even if the same
+/// `(aircraft, mode, label, text)` reappears later. Walking
+/// the store from the most recent row backwards typically hits
+/// this cutoff before exhausting many rows in a busy session,
+/// so the linear scan is fine in practice.
+pub const ACARS_COLLAPSE_WINDOW: std::time::Duration =
+    std::time::Duration::from_secs(ACARS_COLLAPSE_WINDOW_SECS);
 
 /// Default window dimensions (per spec `acars_viewer.rs` budget).
 const ACARS_VIEWER_WINDOW_WIDTH: i32 = 1100;
@@ -38,14 +68,37 @@ const ACARS_VIEWER_WINDOW_HEIGHT: i32 = 600;
 // ── glib::Object wrapper around an AcarsMessage ────────────────
 
 mod imp {
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
+    use std::time::SystemTime;
 
     use gtk4::glib;
     use gtk4::glib::subclass::prelude::{ObjectImpl, ObjectSubclass};
 
-    #[derive(Default)]
     pub struct AcarsMessageObject {
         pub inner: RefCell<Option<sdr_acars::AcarsMessage>>,
+        /// Number of times this `(aircraft, mode, label, text)`
+        /// has been seen since the row was inserted. `1` for a
+        /// fresh row; bumped by the duplicate-collapse path
+        /// (issue #586) when the toggle is active.
+        pub count: Cell<u32>,
+        /// Last-seen timestamp. Equal to `inner.timestamp` for a
+        /// fresh row; updated on each duplicate hit so the Time
+        /// column displays the most recent occurrence rather
+        /// than the first. `SystemTime::UNIX_EPOCH` as a
+        /// safe-default sentinel before a real value is set
+        /// (callers populate it via `AcarsMessageObject::new`
+        /// from the wrapped message's own timestamp).
+        pub last_seen: Cell<SystemTime>,
+    }
+
+    impl Default for AcarsMessageObject {
+        fn default() -> Self {
+            Self {
+                inner: RefCell::new(None),
+                count: Cell::new(1),
+                last_seen: Cell::new(SystemTime::UNIX_EPOCH),
+            }
+        }
     }
 
     #[glib::object_subclass]
@@ -68,10 +121,16 @@ glib::wrapper! {
 
 impl AcarsMessageObject {
     /// Wrap an `AcarsMessage` for insertion into a `GListStore`.
+    /// `count` is initialised to 1 and `last_seen` to the
+    /// message's own timestamp; the duplicate-collapse path
+    /// (issue #586) bumps both via [`Self::record_duplicate`]
+    /// when the viewer toggle is active.
     #[must_use]
     pub fn new(msg: sdr_acars::AcarsMessage) -> Self {
         let obj: Self = glib::Object::new();
+        let timestamp = msg.timestamp;
         *obj.imp().inner.borrow_mut() = Some(msg);
+        obj.imp().last_seen.set(timestamp);
         obj
     }
 
@@ -81,6 +140,30 @@ impl AcarsMessageObject {
     #[must_use]
     pub fn message(&self) -> Option<sdr_acars::AcarsMessage> {
         self.imp().inner.borrow().clone()
+    }
+
+    /// Current duplicate count (1 for a fresh row).
+    #[must_use]
+    pub fn count(&self) -> u32 {
+        self.imp().count.get()
+    }
+
+    /// Last-seen timestamp.
+    #[must_use]
+    pub fn last_seen(&self) -> std::time::SystemTime {
+        self.imp().last_seen.get()
+    }
+
+    /// Bump the duplicate count and update `last_seen` to the
+    /// new timestamp. Called by the append site in `window.rs`
+    /// when the collapse toggle is active and an incoming
+    /// message matches an existing row's `(aircraft, mode,
+    /// label, text)` key within the recency window.
+    pub fn record_duplicate(&self, ts: std::time::SystemTime) {
+        self.imp()
+            .count
+            .set(self.imp().count.get().saturating_add(1));
+        self.imp().last_seen.set(ts);
     }
 }
 
@@ -107,7 +190,11 @@ pub fn open_acars_viewer_if_needed(state: &Rc<AppState>) {
 }
 
 /// Column descriptor: (title, render function, expand).
-type ColumnSpec = (&'static str, fn(&sdr_acars::AcarsMessage) -> String, bool);
+/// Render fn takes `&AcarsMessageObject` so the Time column can
+/// read `count` + `last_seen` from the wrapper for the
+/// duplicate-collapse `(×N)` prefix; non-time columns borrow
+/// `obj.imp().inner` themselves.
+type ColumnSpec = (&'static str, fn(&AcarsMessageObject) -> String, bool);
 
 #[allow(clippy::too_many_lines)]
 fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
@@ -146,6 +233,17 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     clear_button.update_property(&[gtk4::accessible::Property::Label(
         "Clear ACARS message list",
     )]);
+    let collapse_button = gtk4::ToggleButton::builder()
+        .icon_name("view-list-bullet-symbolic")
+        .tooltip_text(
+            "Collapse adjacent duplicates within a 10-minute window. \
+             Repeated messages from the same aircraft (e.g. Q0 link tests) \
+             stack into a single row with a (×N) prefix.",
+        )
+        .build();
+    collapse_button.update_property(&[gtk4::accessible::Property::Label(
+        "Collapse duplicate ACARS messages",
+    )]);
     let filter_entry = gtk4::SearchEntry::builder()
         .placeholder_text("Filter aircraft / label / text…")
         .build();
@@ -172,6 +270,7 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
 
     header.pack_start(&pause_button);
     header.pack_start(&clear_button);
+    header.pack_start(&collapse_button);
     header.set_title_widget(Some(&filter_entry));
     header.pack_end(&status_label);
 
@@ -253,16 +352,7 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
             else {
                 return;
             };
-            // Borrow rather than clone the inner message —
-            // factory.connect_bind fires on every visible row
-            // every store change; cloning the full
-            // `AcarsMessage` (with String + ArrayString fields)
-            // here would be wasted work when the render fns
-            // only need a borrow.
-            let inner = obj.imp().inner.borrow();
-            if let Some(msg) = inner.as_ref() {
-                label.set_text(&render(msg));
-            }
+            label.set_text(&render(&obj));
         });
         let column = gtk4::ColumnViewColumn::builder()
             .title(title)
@@ -302,6 +392,8 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         status_label: status_label.clone(),
         pause_button: pause_button.clone(),
         filter_entry: filter_entry.clone(),
+        collapse_button: collapse_button.clone(),
+        scrolled_window: scroll.clone(),
     });
     *state.acars_viewer_handles.borrow_mut() = Some(Rc::clone(&handles));
 
@@ -427,29 +519,56 @@ where
     })
 }
 
-fn render_time(msg: &sdr_acars::AcarsMessage) -> String {
-    let dt: chrono::DateTime<chrono::Local> = msg.timestamp.into();
-    dt.format("%H:%M:%S").to_string()
-}
-fn render_freq(msg: &sdr_acars::AcarsMessage) -> String {
-    format!("{:.3}", msg.freq_hz / 1_000_000.0)
-}
-fn render_aircraft(msg: &sdr_acars::AcarsMessage) -> String {
-    msg.aircraft.to_string()
-}
-fn render_mode(msg: &sdr_acars::AcarsMessage) -> String {
-    char::from(msg.mode).to_string()
-}
-fn render_label(msg: &sdr_acars::AcarsMessage) -> String {
-    let raw = std::str::from_utf8(&msg.label).unwrap_or("??").to_string();
-    match sdr_acars::label::lookup(msg.label) {
-        Some(name) => format!("{raw} ({name})"),
-        None => raw,
+/// Render the Time column. Uses the wrapper's `last_seen` (so
+/// duplicate-collapsed rows show the most recent occurrence,
+/// not the first), and prepends `(×N)` when `count > 1`.
+fn render_time(obj: &AcarsMessageObject) -> String {
+    let dt: chrono::DateTime<chrono::Local> = obj.last_seen().into();
+    let formatted = dt.format("%H:%M:%S").to_string();
+    let count = obj.count();
+    if count > 1 {
+        format!("(×{count}) {formatted}")
+    } else {
+        formatted
     }
 }
-fn render_block(msg: &sdr_acars::AcarsMessage) -> String {
-    char::from(msg.block_id).to_string()
+
+/// Borrow the inner `AcarsMessage` and run `f`, falling back to
+/// an empty string if the slot is unset (model churn / partial
+/// teardown). All non-time columns flow through this helper so
+/// the borrow + None-fallback pattern stays in one place.
+fn render_inner<F: FnOnce(&sdr_acars::AcarsMessage) -> String>(
+    obj: &AcarsMessageObject,
+    f: F,
+) -> String {
+    obj.imp()
+        .inner
+        .borrow()
+        .as_ref()
+        .map_or_else(String::new, f)
 }
-fn render_text(msg: &sdr_acars::AcarsMessage) -> String {
-    msg.text.clone()
+
+fn render_freq(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| format!("{:.3}", m.freq_hz / 1_000_000.0))
+}
+fn render_aircraft(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| m.aircraft.to_string())
+}
+fn render_mode(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| char::from(m.mode).to_string())
+}
+fn render_label(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| {
+        let raw = std::str::from_utf8(&m.label).unwrap_or("??").to_string();
+        match sdr_acars::label::lookup(m.label) {
+            Some(name) => format!("{raw} ({name})"),
+            None => raw,
+        }
+    })
+}
+fn render_block(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| char::from(m.block_id).to_string())
+}
+fn render_text(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| m.text.clone())
 }

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -154,16 +154,19 @@ impl AcarsMessageObject {
         self.imp().last_seen.get()
     }
 
-    /// Bump the duplicate count and update `last_seen` to the
-    /// new timestamp. Called by the append site in `window.rs`
-    /// when the collapse toggle is active and an incoming
-    /// message matches an existing row's `(aircraft, mode,
-    /// label, text)` key within the recency window.
+    /// Bump the duplicate count and advance `last_seen` to the
+    /// later of the current value and `ts`. Called by the
+    /// append site in `window.rs` when the collapse toggle is
+    /// active and an incoming message matches an existing
+    /// row's `(aircraft, mode, label, text)` key within the
+    /// recency window. The `max` keeps the field monotonic
+    /// even if duplicate frames arrive slightly out of order
+    /// (CR round 2 on PR #591) — without it, the displayed
+    /// time and the time-column sort key could regress.
     pub fn record_duplicate(&self, ts: std::time::SystemTime) {
-        self.imp()
-            .count
-            .set(self.imp().count.get().saturating_add(1));
-        self.imp().last_seen.set(ts);
+        let imp = self.imp();
+        imp.count.set(imp.count.get().saturating_add(1));
+        imp.last_seen.set(std::cmp::max(imp.last_seen.get(), ts));
     }
 }
 

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -308,7 +308,22 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     // `Ordering::Equal` when the slot is empty (model churn).
     // Issue #585.
     let sorters: [gtk4::CustomSorter; 7] = [
-        make_message_sorter(|a, b| a.timestamp.cmp(&b.timestamp)),
+        // Time column sorts on the wrapper's `last_seen`, not
+        // the original frame timestamp. After a collapse hit,
+        // `record_duplicate` advances `last_seen` in place
+        // without moving the row in the store; sorting on
+        // `inner.timestamp` would leave the refreshed row
+        // stranded at its original position. Issue #586 / CR
+        // round 1 on PR #591.
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AcarsMessageObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AcarsMessageObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            a_obj.last_seen().cmp(&b_obj.last_seen()).into()
+        }),
         make_message_sorter(|a, b| {
             a.freq_hz
                 .partial_cmp(&b.freq_hz)

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -2,7 +2,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::sync::mpsc;
 
 use sdr_acars::{AcarsMessage, ChannelStats};
@@ -330,32 +330,44 @@ pub struct AppState {
     /// auto-restore doesn't write 0.0 back to config or
     /// re-enter `send_dsp` from the value-changed handler.
     pub suppress_volume_notify: Cell<bool>,
-    /// Stash for a satellite auto-record `StartAutoRecord`
-    /// action that arrived while ACARS was engaged. The arm in
-    /// `connect_satellites_panel`'s `interpret_action` parks
-    /// the action here, dispatches `SetAcarsEnabled(false)`, and
-    /// returns. The `AcarsEnabledChanged(Ok(false))` handler
-    /// then drains it and replays it through the stashed
-    /// `recorder_action_interpreter` (see below). On `Err` the
-    /// stash is dropped and the pass aborted with a toast.
-    /// Issue #589.
-    pub pending_aos_action: RefCell<Option<sdr_ui_recorder_action::RecorderAction>>,
-    /// Late-bound clone of `connect_satellites_panel`'s
+    /// Stash for the **full batch** of `RecorderAction`s a
+    /// recorder tick yielded when ACARS was engaged. The
+    /// recorder tick site detects a `StartAutoRecord` in the
+    /// batch, stashes the entire `Vec` (including any
+    /// `StartAutoAudioRecord`, `ResetImagingDecoders`, etc.
+    /// that fire alongside) here, and dispatches
+    /// `SetAcarsEnabled(false)`. The
+    /// `AcarsEnabledChanged(Ok(false))` handler drains the
+    /// `Vec` and replays each action through the stashed
+    /// `recorder_action_interpreter`. On `Err` the entire
+    /// batch is dropped and the pass aborted with a toast.
+    /// Storing the whole batch — not just the
+    /// `StartAutoRecord` — is what makes the disengage ack a
+    /// real gate (CR round 1 on PR #591). Issue #589.
+    pub pending_aos_actions: RefCell<Option<Vec<sdr_ui_recorder_action::RecorderAction>>>,
+    /// Late-bound `Weak` handle to `connect_satellites_panel`'s
     /// `interpret_action` closure so the
-    /// `AcarsEnabledChanged(Ok(false))` arm can replay a stashed
-    /// `pending_aos_action` without `handle_dsp_message` having
-    /// to plumb the closure through its already-long parameter
-    /// list. Set once during sidebar wiring; cleared on window
-    /// close (the closure captures widgets that drop with the
-    /// window). Issue #589.
-    pub recorder_action_interpreter: RefCell<Option<RecorderActionInterpreter>>,
+    /// `AcarsEnabledChanged(Ok(false))` arm can replay deferred
+    /// AOS actions without `handle_dsp_message` having to plumb
+    /// the closure through its already-long parameter list.
+    ///
+    /// Stored as `Weak` rather than `Rc` to avoid a retain
+    /// cycle: the closure itself captures `Rc<AppState>` (and
+    /// other widget `Rc`s that hold `AppState` transitively), so
+    /// a strong handle here would keep the window tree alive
+    /// past close. The strong owner of the closure is the
+    /// recorder tick's `glib::timeout_add_local`, which drops
+    /// when the timeout returns Break (or the main loop quits).
+    /// Replay sites upgrade to `Rc` per call and skip silently
+    /// when the upgrade fails (closure already dropped). Issue
+    /// #589 / CR round 1 on PR #591.
+    pub recorder_action_interpreter: RefCell<Option<RecorderActionInterpreterWeak>>,
 }
 
-/// Boxed dyn `Fn` over `RecorderAction` — the deferred-AOS gate
-/// stashes a clone of the satellites-panel `interpret_action`
-/// closure and replays it from the
-/// `AcarsEnabledChanged(Ok(false))` handler.
-pub type RecorderActionInterpreter = Rc<dyn Fn(sdr_ui_recorder_action::RecorderAction)>;
+/// `Weak` handle to a `RecorderAction` interpreter closure.
+/// Boxed dyn `Fn`; replay sites call `Weak::upgrade` to get an
+/// `Rc<dyn Fn>` and skip if `None`.
+pub type RecorderActionInterpreterWeak = Weak<dyn Fn(sdr_ui_recorder_action::RecorderAction)>;
 
 /// Re-export wrapper so the `AppState` struct can name the
 /// `RecorderAction` type without pulling the entire
@@ -415,7 +427,7 @@ impl AppState {
             acars_pending: Cell::new(false),
             acars_saved_volume: Cell::new(None),
             suppress_volume_notify: Cell::new(false),
-            pending_aos_action: RefCell::new(None),
+            pending_aos_actions: RefCell::new(None),
             recorder_action_interpreter: RefCell::new(None),
         })
     }
@@ -542,8 +554,8 @@ mod tests {
             "volume notify suppression off at construction"
         );
         assert!(
-            state.pending_aos_action.borrow().is_none(),
-            "no pending AOS action stashed at construction"
+            state.pending_aos_actions.borrow().is_none(),
+            "no pending AOS action batch stashed at construction"
         );
         assert!(
             state.recorder_action_interpreter.borrow().is_none(),

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -330,6 +330,39 @@ pub struct AppState {
     /// auto-restore doesn't write 0.0 back to config or
     /// re-enter `send_dsp` from the value-changed handler.
     pub suppress_volume_notify: Cell<bool>,
+    /// Stash for a satellite auto-record `StartAutoRecord`
+    /// action that arrived while ACARS was engaged. The arm in
+    /// `connect_satellites_panel`'s `interpret_action` parks
+    /// the action here, dispatches `SetAcarsEnabled(false)`, and
+    /// returns. The `AcarsEnabledChanged(Ok(false))` handler
+    /// then drains it and replays it through the stashed
+    /// `recorder_action_interpreter` (see below). On `Err` the
+    /// stash is dropped and the pass aborted with a toast.
+    /// Issue #589.
+    pub pending_aos_action: RefCell<Option<sdr_ui_recorder_action::RecorderAction>>,
+    /// Late-bound clone of `connect_satellites_panel`'s
+    /// `interpret_action` closure so the
+    /// `AcarsEnabledChanged(Ok(false))` arm can replay a stashed
+    /// `pending_aos_action` without `handle_dsp_message` having
+    /// to plumb the closure through its already-long parameter
+    /// list. Set once during sidebar wiring; cleared on window
+    /// close (the closure captures widgets that drop with the
+    /// window). Issue #589.
+    pub recorder_action_interpreter: RefCell<Option<RecorderActionInterpreter>>,
+}
+
+/// Boxed dyn `Fn` over `RecorderAction` — the deferred-AOS gate
+/// stashes a clone of the satellites-panel `interpret_action`
+/// closure and replays it from the
+/// `AcarsEnabledChanged(Ok(false))` handler.
+pub type RecorderActionInterpreter = Rc<dyn Fn(sdr_ui_recorder_action::RecorderAction)>;
+
+/// Re-export wrapper so the `AppState` struct can name the
+/// `RecorderAction` type without pulling the entire
+/// `sidebar::satellites_recorder` module path into every
+/// `AppState` consumer's import graph.
+pub mod sdr_ui_recorder_action {
+    pub use crate::sidebar::satellites_recorder::Action as RecorderAction;
 }
 
 impl AppState {
@@ -382,6 +415,8 @@ impl AppState {
             acars_pending: Cell::new(false),
             acars_saved_volume: Cell::new(None),
             suppress_volume_notify: Cell::new(false),
+            pending_aos_action: RefCell::new(None),
+            recorder_action_interpreter: RefCell::new(None),
         })
     }
 
@@ -505,6 +540,14 @@ mod tests {
         assert!(
             !state.suppress_volume_notify.get(),
             "volume notify suppression off at construction"
+        );
+        assert!(
+            state.pending_aos_action.borrow().is_none(),
+            "no pending AOS action stashed at construction"
+        );
+        assert!(
+            state.recorder_action_interpreter.borrow().is_none(),
+            "no recorder action interpreter wired until satellites panel connects"
         );
         assert!(
             state.acars_viewer_handles.borrow().is_none(),

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2170,22 +2170,30 @@ fn handle_dsp_message(
                             );
                         }
                     }
-                    // Drain a deferred AOS pass (issue #589). When
-                    // a satellite auto-record AOS arrived during
-                    // an engaged session, the StartAutoRecord arm
-                    // stashed the action and dispatched
-                    // SetAcarsEnabled(false) — now that the
-                    // controller has acked the disengage we can
-                    // safely replay the action through the same
-                    // recorder interpreter. Defer to the next
-                    // idle so we're outside the dispatch borrow.
-                    let pending = state.pending_aos_action.borrow_mut().take();
-                    if let Some(action) = pending
-                        && let Some(interp) = state.recorder_action_interpreter.borrow().clone()
+                    // Drain a deferred AOS batch (issue #589). When
+                    // a satellite auto-record tick fired during an
+                    // engaged session, the recorder tick site
+                    // stashed the entire `Vec<RecorderAction>`
+                    // and dispatched SetAcarsEnabled(false) — now
+                    // that the controller has acked the disengage
+                    // we replay every action through the same
+                    // recorder interpreter, in the original order.
+                    // Defer to next idle so we're outside the
+                    // dispatch borrow.
+                    let pending = state.pending_aos_actions.borrow_mut().take();
+                    if let Some(actions) = pending
+                        && let Some(interp_weak) =
+                            state.recorder_action_interpreter.borrow().clone()
+                        && let Some(interp) = interp_weak.upgrade()
                     {
-                        tracing::info!("AOS replay: ACARS disengaged, executing deferred action");
+                        tracing::info!(
+                            "AOS replay: ACARS disengaged, executing {} deferred action(s)",
+                            actions.len()
+                        );
                         glib::idle_add_local_once(move || {
-                            interp(action);
+                            for action in actions {
+                                interp(action);
+                            }
                         });
                     }
                     tracing::info!("ACARS disengaged");
@@ -2212,30 +2220,36 @@ fn handle_dsp_message(
                     // disengage can restore them; a failed engage
                     // simply never set them.
                     //
-                    // Abort any deferred AOS pass (issue #589).
+                    // Abort any deferred AOS batch (issue #589).
                     // The disengage couldn't complete, so the
                     // satellite tune would still be rejected by
-                    // the airband lock. Drop the stashed action
-                    // + clear the round-trip flag so LOS doesn't
+                    // the airband lock. Drop the stashed batch +
+                    // clear the round-trip flag so LOS doesn't
                     // try to re-engage onto an unstable state,
                     // and surface a dedicated toast naming the
-                    // affected satellite.
-                    let aborted = state.pending_aos_action.borrow_mut().take();
-                    if let Some(crate::sidebar::satellites_recorder::Action::StartAutoRecord {
-                        satellite,
-                        ..
-                    }) = aborted
-                    {
+                    // affected satellite (looked up from the
+                    // batch's `StartAutoRecord` entry).
+                    let aborted = state.pending_aos_actions.borrow_mut().take();
+                    if let Some(actions) = aborted {
+                        let satellite = actions.iter().find_map(|a| match a {
+                            crate::sidebar::satellites_recorder::Action::StartAutoRecord {
+                                satellite,
+                                ..
+                            } => Some(satellite.clone()),
+                            _ => None,
+                        });
                         state.acars_was_engaged_pre_pass.set(false);
-                        tracing::warn!(
-                            satellite = %satellite,
-                            error = %err,
-                            "AOS aborted: ACARS disengage failed",
-                        );
-                        if let Some(overlay) = toast_overlay_weak.upgrade() {
-                            overlay.add_toast(adw::Toast::new(&format!(
-                                "Pass {satellite} aborted: ACARS disengage failed"
-                            )));
+                        if let Some(satellite) = satellite {
+                            tracing::warn!(
+                                satellite = %satellite,
+                                error = %err,
+                                "AOS aborted: ACARS disengage failed",
+                            );
+                            if let Some(overlay) = toast_overlay_weak.upgrade() {
+                                overlay.add_toast(adw::Toast::new(&format!(
+                                    "Pass {satellite} aborted: ACARS disengage failed"
+                                )));
+                            }
                         }
                     }
                     // Surface the original engage/disengage
@@ -10845,33 +10859,16 @@ fn connect_satellites_panel(
                 tracing::info!(
                     "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz, protocol {protocol:?}",
                 );
-                // If ACARS is engaged, gate the AOS sequence on
-                // a confirmed disengage. Stash the action +
-                // dispatch `SetAcarsEnabled(false)`, then return
-                // — the `AcarsEnabledChanged(Ok(false))` arm in
-                // `handle_dsp_message` will replay the action
-                // through this same interpreter when the
-                // controller acks. On `Err` the action is
-                // dropped + a toast surfaces (no half-engaged
-                // pass with the wrong source geometry). Issue
-                // #589.
-                if state_a.acars_enabled.get() {
-                    tracing::info!(
-                        "auto-record AOS: gating on ACARS disengage ack for {satellite}"
-                    );
-                    state_a.acars_was_engaged_pre_pass.set(true);
-                    *state_a.pending_aos_action.borrow_mut() =
-                        Some(RecorderAction::StartAutoRecord {
-                            satellite,
-                            norad_id,
-                            freq_hz,
-                            mode,
-                            bandwidth_hz,
-                            protocol,
-                        });
-                    state_a.send_dsp(UiToDsp::SetAcarsEnabled(false));
-                    return;
-                }
+                // ACARS-engaged gating happens at the recorder
+                // tick site (the for-loop calling
+                // `interpret_action`), not here — that's the
+                // only level that has visibility into the
+                // entire `Vec<RecorderAction>` batch and can
+                // defer it as a unit. CR round 1 on PR #591
+                // flagged the gap: stashing only this single
+                // `StartAutoRecord` while iterating the rest
+                // of the batch left `StartAutoAudioRecord` etc.
+                // running while ACARS was still engaged.
                 // Per-protocol viewer dispatch. Adding a new
                 // protocol means adding a match arm here +
                 // flipping `imaging_protocol` on the catalog
@@ -11660,15 +11657,20 @@ fn connect_satellites_panel(
         })
     };
 
-    // Stash a clone of the interpreter on AppState so the
-    // `AcarsEnabledChanged(Ok(false))` arm in
-    // `handle_dsp_message` can replay a deferred AOS action
+    // Stash a `Weak` handle to the interpreter on AppState so
+    // the `AcarsEnabledChanged(Ok(false))` arm in
+    // `handle_dsp_message` can replay deferred AOS actions
     // without needing the closure plumbed through its parameter
-    // list. Issue #589.
-    *state.recorder_action_interpreter.borrow_mut() = Some(Rc::clone(&interpret_action));
+    // list. Stored weakly to avoid an `AppState` ↔ closure
+    // retain cycle (the closure captures `Rc<AppState>`
+    // transitively); the strong owner is the recorder tick
+    // `glib::timeout_add_local`. Issue #589 / CR round 1 on
+    // PR #591.
+    *state.recorder_action_interpreter.borrow_mut() = Some(Rc::downgrade(&interpret_action));
 
     if cache.is_some() {
         let panel_weak_tick = panel_weak.clone();
+        let state_for_recorder = Rc::clone(state);
         let displayed_tick = Rc::clone(&displayed);
         let recompute_tick = Rc::clone(&recompute);
         let recorder_tick = Rc::clone(&recorder);
@@ -11780,8 +11782,39 @@ fn connect_satellites_panel(
                 min_elev_deg,
                 now_tune,
             );
-            for action in actions {
-                interpret_tick(action);
+            // ACARS-disengage gate (issue #589): if any action
+            // in this tick is `StartAutoRecord` AND ACARS is
+            // currently engaged, stash the **whole batch** and
+            // dispatch `SetAcarsEnabled(false)`. The
+            // `AcarsEnabledChanged(Ok(false))` arm in
+            // `handle_dsp_message` will drain the batch and
+            // replay every action through `interpret_tick` once
+            // the controller acks the disengage.
+            //
+            // Stashing the whole batch (not just
+            // `StartAutoRecord`) makes the disengage ack a real
+            // gate: same-tick siblings like
+            // `StartAutoAudioRecord` and `ResetImagingDecoders`
+            // would otherwise execute while the source was
+            // still on airband geometry, capturing audio from
+            // the wrong frequency until the disengage lands.
+            // CR round 1 on PR #591.
+            let needs_acars_gate = state_for_recorder.acars_enabled.get()
+                && actions
+                    .iter()
+                    .any(|a| matches!(a, RecorderAction::StartAutoRecord { .. }));
+            if needs_acars_gate {
+                tracing::info!(
+                    "auto-record AOS: gating {} action(s) on ACARS disengage ack",
+                    actions.len()
+                );
+                state_for_recorder.acars_was_engaged_pre_pass.set(true);
+                *state_for_recorder.pending_aos_actions.borrow_mut() = Some(actions);
+                state_for_recorder.send_dsp(UiToDsp::SetAcarsEnabled(false));
+            } else {
+                for action in actions {
+                    interpret_tick(action);
+                }
             }
 
             // #510 — pre-pass desktop alerts. Walk the displayed
@@ -11979,11 +12012,15 @@ fn try_collapse_into_existing(
         let Some(obj) = item.downcast_ref::<crate::acars_viewer::AcarsMessageObject>() else {
             continue;
         };
-        // Stop scanning once we've passed the recency window —
-        // rows are in insertion order, so any earlier row is
-        // even older.
+        // Skip rows older than the recency window. We can't
+        // early-exit here even though insertion order would
+        // suggest later rows have even older `last_seen`:
+        // `record_duplicate` updates an existing row's
+        // `last_seen` IN PLACE (no store reorder), so the
+        // "monotonic by index" invariant doesn't hold once any
+        // collapse has fired. CR round 1 on PR #591.
         if obj.last_seen() < cutoff {
-            return None;
+            continue;
         }
         let inner = obj.imp().inner.borrow();
         let Some(existing) = inner.as_ref() else {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use gtk4::gio;
 use gtk4::glib;
 use gtk4::prelude::*;
+use gtk4::subclass::prelude::ObjectSubclassIsExt;
 use libadwaita as adw;
 use libadwaita::prelude::*;
 use sdr_core::Engine;
@@ -1987,22 +1988,65 @@ fn handle_dsp_message(
             // don't grow UI memory + filter cost without bound.
             // Splice from the front (oldest first) before append
             // so the new row lands at the bottom.
+            //
+            // Collapse-duplicates (#586): when the viewer's
+            // collapse toggle is active, walk the most recent
+            // rows for a `(aircraft, mode, label, text)` key
+            // match within `ACARS_COLLAPSE_WINDOW`. On hit, bump
+            // the existing wrapper's count + last_seen and emit
+            // an `items_changed` so the row re-binds with the
+            // new `(×N)` prefix instead of appending a duplicate.
+            //
+            // Auto-scroll-to-top: if the viewer is scrolled to
+            // the top, scroll back to position 0 after the
+            // append/mutate so new rows flow into view. If the
+            // user has scrolled down to read older rows, freeze
+            // until they scroll back up.
             if let Some(handles) = state.acars_viewer_handles.borrow().as_ref()
                 && !handles.pause_button.is_active()
             {
-                let cap = crate::acars_config::default_recent_keep();
-                let n = handles.store.n_items();
-                if n >= cap {
-                    let excess = n - cap + 1;
+                let collapse_active = handles.collapse_button.is_active();
+                let mut collapsed_into: Option<u32> = None;
+                if collapse_active {
+                    collapsed_into = try_collapse_into_existing(&handles.store, &msg);
+                }
+
+                if let Some(idx) = collapsed_into {
+                    handles.store.items_changed(idx, 1, 1);
+                } else {
+                    let cap = crate::acars_config::default_recent_keep();
+                    let n = handles.store.n_items();
+                    if n >= cap {
+                        let excess = n - cap + 1;
+                        handles
+                            .store
+                            .splice(0, excess, &[] as &[gtk4::glib::Object]);
+                    }
                     handles
                         .store
-                        .splice(0, excess, &[] as &[gtk4::glib::Object]);
+                        .append(&crate::acars_viewer::AcarsMessageObject::new(
+                            (*msg).clone(),
+                        ));
                 }
-                handles
-                    .store
-                    .append(&crate::acars_viewer::AcarsMessageObject::new(
-                        (*msg).clone(),
-                    ));
+
+                // Auto-scroll-to-top if the user is currently
+                // viewing the top of the list. `vadjustment.value`
+                // is the offset from `lower`; ≈ 0 means the user
+                // is at the top, in which case we hold them
+                // pinned to the top so new rows under the active
+                // sort flow into view (newest with the default
+                // time-desc sort). When the user has scrolled
+                // down to read older rows, we leave the adjustment
+                // alone so reading isn't interrupted — they
+                // resume auto-follow by scrolling back up.
+                //
+                // Direct adjustment manipulation rather than
+                // `ColumnView::scroll_to`: that API is gated
+                // behind gtk4 v4_12 and the workspace pins v4_10.
+                let adj = handles.scrolled_window.vadjustment();
+                if (adj.value() - adj.lower()).abs() < 1.0 {
+                    adj.set_value(adj.lower());
+                }
             }
 
             tracing::trace!(
@@ -2126,6 +2170,24 @@ fn handle_dsp_message(
                             );
                         }
                     }
+                    // Drain a deferred AOS pass (issue #589). When
+                    // a satellite auto-record AOS arrived during
+                    // an engaged session, the StartAutoRecord arm
+                    // stashed the action and dispatched
+                    // SetAcarsEnabled(false) — now that the
+                    // controller has acked the disengage we can
+                    // safely replay the action through the same
+                    // recorder interpreter. Defer to the next
+                    // idle so we're outside the dispatch borrow.
+                    let pending = state.pending_aos_action.borrow_mut().take();
+                    if let Some(action) = pending
+                        && let Some(interp) = state.recorder_action_interpreter.borrow().clone()
+                    {
+                        tracing::info!("AOS replay: ACARS disengaged, executing deferred action");
+                        glib::idle_add_local_once(move || {
+                            interp(action);
+                        });
+                    }
                     tracing::info!("ACARS disengaged");
                 }
                 Err(err) => {
@@ -2149,8 +2211,36 @@ fn handle_dsp_message(
                     // preserved so the eventual successful
                     // disengage can restore them; a failed engage
                     // simply never set them.
-                    // Surface the failure as a toast so the user
-                    // sees the actionable error (e.g. "scanner is
+                    //
+                    // Abort any deferred AOS pass (issue #589).
+                    // The disengage couldn't complete, so the
+                    // satellite tune would still be rejected by
+                    // the airband lock. Drop the stashed action
+                    // + clear the round-trip flag so LOS doesn't
+                    // try to re-engage onto an unstable state,
+                    // and surface a dedicated toast naming the
+                    // affected satellite.
+                    let aborted = state.pending_aos_action.borrow_mut().take();
+                    if let Some(crate::sidebar::satellites_recorder::Action::StartAutoRecord {
+                        satellite,
+                        ..
+                    }) = aborted
+                    {
+                        state.acars_was_engaged_pre_pass.set(false);
+                        tracing::warn!(
+                            satellite = %satellite,
+                            error = %err,
+                            "AOS aborted: ACARS disengage failed",
+                        );
+                        if let Some(overlay) = toast_overlay_weak.upgrade() {
+                            overlay.add_toast(adw::Toast::new(&format!(
+                                "Pass {satellite} aborted: ACARS disengage failed"
+                            )));
+                        }
+                    }
+                    // Surface the original engage/disengage
+                    // failure as a toast too so the user sees
+                    // the actionable error (e.g. "scanner is
                     // running" or "RTL-SDR required").
                     if let Some(overlay) = toast_overlay_weak.upgrade() {
                         overlay.add_toast(adw::Toast::new(&format!("ACARS: {err}")));
@@ -10755,16 +10845,32 @@ fn connect_satellites_panel(
                 tracing::info!(
                     "auto-record AOS: tuning to {satellite} @ {freq_hz} Hz, BW {bandwidth_hz} Hz, protocol {protocol:?}",
                 );
-                // If ACARS is engaged, auto-disengage it so the
-                // satellite tune isn't rejected by the airband
-                // lock (rounds 14-15 on PR #584). Stash the
-                // pre-pass engaged state so the LOS RestoreTune
-                // arm can re-engage. Mirrors how SavedTune
-                // captures other pre-AOS state for round-trip.
+                // If ACARS is engaged, gate the AOS sequence on
+                // a confirmed disengage. Stash the action +
+                // dispatch `SetAcarsEnabled(false)`, then return
+                // — the `AcarsEnabledChanged(Ok(false))` arm in
+                // `handle_dsp_message` will replay the action
+                // through this same interpreter when the
+                // controller acks. On `Err` the action is
+                // dropped + a toast surfaces (no half-engaged
+                // pass with the wrong source geometry). Issue
+                // #589.
                 if state_a.acars_enabled.get() {
-                    tracing::info!("auto-record AOS: auto-disabling ACARS for the pass");
+                    tracing::info!(
+                        "auto-record AOS: gating on ACARS disengage ack for {satellite}"
+                    );
                     state_a.acars_was_engaged_pre_pass.set(true);
+                    *state_a.pending_aos_action.borrow_mut() =
+                        Some(RecorderAction::StartAutoRecord {
+                            satellite,
+                            norad_id,
+                            freq_hz,
+                            mode,
+                            bandwidth_hz,
+                            protocol,
+                        });
                     state_a.send_dsp(UiToDsp::SetAcarsEnabled(false));
+                    return;
                 }
                 // Per-protocol viewer dispatch. Adding a new
                 // protocol means adding a match arm here +
@@ -11554,6 +11660,13 @@ fn connect_satellites_panel(
         })
     };
 
+    // Stash a clone of the interpreter on AppState so the
+    // `AcarsEnabledChanged(Ok(false))` arm in
+    // `handle_dsp_message` can replay a deferred AOS action
+    // without needing the closure plumbed through its parameter
+    // list. Issue #589.
+    *state.recorder_action_interpreter.borrow_mut() = Some(Rc::clone(&interpret_action));
+
     if cache.is_some() {
         let panel_weak_tick = panel_weak.clone();
         let displayed_tick = Rc::clone(&displayed);
@@ -11837,6 +11950,61 @@ fn connect_aviation_panel(panel: &sidebar::aviation_panel::AviationPanel, state:
 /// Format a `SystemTime` as a relative age string ("5s ago",
 /// "2m ago", "1h ago"). Returns "—" if the timestamp is in the
 /// future or unrepresentable.
+/// Walk the most recent rows of the viewer store backwards from
+/// the end and check for a `(aircraft, mode, label, text)` key
+/// match within `ACARS_COLLAPSE_WINDOW`. Returns the matched
+/// row's index after bumping its count + `last_seen` in place,
+/// or `None` if no in-window match — in which case the caller
+/// appends a fresh row. Stops walking as soon as it sees a row
+/// older than the recency window (rows are insertion-ordered
+/// in the underlying store, oldest at index 0). Issue #586.
+fn try_collapse_into_existing(
+    store: &gtk4::gio::ListStore,
+    msg: &sdr_acars::AcarsMessage,
+) -> Option<u32> {
+    use gtk4::prelude::ListModelExt;
+    let n = store.n_items();
+    if n == 0 {
+        return None;
+    }
+    let cutoff = msg
+        .timestamp
+        .checked_sub(crate::acars_viewer::ACARS_COLLAPSE_WINDOW)?;
+    let mut idx = n;
+    while idx > 0 {
+        idx -= 1;
+        let Some(item) = store.item(idx) else {
+            continue;
+        };
+        let Some(obj) = item.downcast_ref::<crate::acars_viewer::AcarsMessageObject>() else {
+            continue;
+        };
+        // Stop scanning once we've passed the recency window —
+        // rows are in insertion order, so any earlier row is
+        // even older.
+        if obj.last_seen() < cutoff {
+            return None;
+        }
+        let inner = obj.imp().inner.borrow();
+        let Some(existing) = inner.as_ref() else {
+            continue;
+        };
+        if existing.aircraft == msg.aircraft
+            && existing.mode == msg.mode
+            && existing.label == msg.label
+            && existing.text == msg.text
+        {
+            // Drop the borrow before mutating via the public
+            // API (which doesn't actually need the borrow held,
+            // but keeping the scope tight is cleaner).
+            drop(inner);
+            obj.record_duplicate(msg.timestamp);
+            return Some(idx);
+        }
+    }
+    None
+}
+
 fn format_relative_age(ts: std::time::SystemTime) -> String {
     let Ok(elapsed) = ts.elapsed() else {
         return "—".to_string();


### PR DESCRIPTION
Bundle 2 of the ACARS follow-ups. Closes #586 + #589, plus an in-PR user request for auto-scroll-to-top on new arrivals.

## Summary

- **#586** — Opt-in duplicate collapse in the viewer. New header-bar toggle (icon `view-list-bullet-symbolic`, default off). When active, an incoming message that matches an existing row's `(aircraft, mode, label, text)` key within a 10-minute window bumps the existing row's count + last_seen instead of appending a new one. Time column shows `(×N) HH:MM:SS` with the most recent timestamp. Filter + sort + clear all compose unchanged.
- **#589** — Satellite AOS retune now gates on a confirmed `AcarsEnabledChanged(Ok(false))` ack rather than firing tune-and-pray. New `pending_aos_action` slot on AppState, `recorder_action_interpreter` late-bind so the disengage handler can replay the deferred action via `glib::idle_add_local_once`. On `Err` the pass aborts cleanly with a dedicated toast naming the affected satellite.
- **Auto-scroll-to-top** (user-flagged during this branch's smoke) — when the viewer is scrolled to the top, append + collapse paths reset the vertical adjustment so new rows flow into view under the active sort. When the user has scrolled down to read older rows, auto-follow freezes until they scroll back. Direct adjustment manipulation rather than `ColumnView::scroll_to` (the latter needs gtk4 v4_12; workspace is on v4_10).

## Test plan

- [x] `cargo build --workspace --features sdr-transcription/whisper-cpu` clean
- [x] `cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] All 1830 lib tests pass
- [x] `acars_defaults_pin_initializer_contract` extended for both new AppState slots (`pending_aos_action`, `recorder_action_interpreter`)
- [x] Live smoke against BCB airband: collapse + auto-scroll + sort + filter all compose; toggle off restores per-frame rows
- [x] AOS gate: scanner-conflict abort path surfaces both `Pass {satellite} aborted` and `ACARS: scanner active` toasts; happy-path AOS waits for ack and runs as before

## Out of scope (still open under #474)

- #577 per-label decoders (heavy, solo PR)
- #579 aircraft-grouped tab (heavy, solo PR)
- #580 multi-block reassembly (medium)
- #581 international channel sets (medium)
- Filter-predicate alloc-free case fold (deferred from PR #590; needs profiling first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggleable ACARS duplicate-collapse: duplicate messages combine into a single row showing (×N) and the most-recent time.
  * Time column now reflects most-recent duplicate timestamp.

* **Improvements**
  * Conditional auto-scroll: view auto-scrolls to top only when the user is already at/near the top.
  * Satellite auto-record actions are deferred until ACARS is disengaged and replayed afterward; clearer error toast when disengage fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->