### PR TITLE
feat(sdr-acars,sdr-ui): multi-block reassembly + EU channel set

### DIFF
--- a/crates/sdr-acars/src/channel.rs
+++ b/crates/sdr-acars/src/channel.rs
@@ -58,6 +58,15 @@ struct Channel {
     if_buffer: Vec<f32>,
     msk: MskDemod,
     parser: FrameParser,
+    /// Per-channel multi-block reassembler (issue #580).
+    /// Frames emerging from `parser.drain` flow through here
+    /// before reaching `process`'s `on_message` callback —
+    /// ETB blocks park; ETX blocks emit reassembled (or
+    /// pass-through if no pending). Per-channel rather than
+    /// shared because aircraft don't normally hop channels
+    /// mid-message and channel-isolated state machines are
+    /// simpler to reason about.
+    assembler: crate::reassembly::MessageAssembler,
 }
 
 /// No-signal floor (dBFS) used as the idle baseline for a
@@ -198,6 +207,7 @@ impl ChannelBank {
                 if_buffer: Vec::with_capacity(4096),
                 msk: MskDemod::new(),
                 parser: FrameParser::new(idx_u8, freq_hz),
+                assembler: crate::reassembly::MessageAssembler::new(),
             });
             stats.push(ChannelStats {
                 freq_hz,
@@ -245,19 +255,30 @@ impl ChannelBank {
             // `channels()` reflects real state, not the
             // construction placeholders. Per CR round 1 on
             // PR #583.
+            //
+            // Each parser-emitted frame flows through the
+            // per-channel `MessageAssembler` (issue #580). ETBs
+            // park silently (the assembler returns 0 messages);
+            // ETXs emit the reassembled message + any timed-out
+            // partial sweeps. Stats are stamped once per
+            // assembler-emitted message so a multi-block
+            // reassembly counts as one in `msg_count`.
             let stats = &mut self.stats[idx];
             ch.parser.drain(|msg| {
-                stats.msg_count = stats.msg_count.saturating_add(1);
-                stats.last_msg_at = Some(msg.timestamp);
-                // level_db on the message is currently 0.0
-                // (filled in by future sub-projects from MSK
-                // matched-filter output); keep stats.level_db
-                // pinned to the latest emitted value so the
-                // contract stays "stats reflect the latest
-                // decoded message" once levels start landing.
-                stats.level_db = msg.level_db;
-                stats.lock_state = ChannelLockState::Locked;
-                on_message(msg);
+                let now = msg.timestamp;
+                for emitted in ch.assembler.observe(msg, now) {
+                    stats.msg_count = stats.msg_count.saturating_add(1);
+                    stats.last_msg_at = Some(emitted.timestamp);
+                    // level_db on the message is currently 0.0
+                    // (filled in by future sub-projects from MSK
+                    // matched-filter output); keep stats.level_db
+                    // pinned to the latest emitted value so the
+                    // contract stays "stats reflect the latest
+                    // decoded message" once levels start landing.
+                    stats.level_db = emitted.level_db;
+                    stats.lock_state = ChannelLockState::Locked;
+                    on_message(emitted);
+                }
             });
             // Apply pending polarity flip if the parser
             // detected an inverted-SYN at frame start

--- a/crates/sdr-acars/src/channel.rs
+++ b/crates/sdr-acars/src/channel.rs
@@ -280,6 +280,22 @@ impl ChannelBank {
                     on_message(emitted);
                 }
             });
+            // Drive timeout emission on every IQ-block tick, not
+            // just when the parser produces a frame. A channel
+            // that observed one ETB and then went silent would
+            // never get an `observe()` call to internally sweep
+            // — the partial reassembly would stay parked
+            // indefinitely. The check is cheap (HashMap
+            // iteration capped at MAX_PENDING_MESSAGES) and
+            // runs at IQ-block cadence, well above the 30 s
+            // recency window. Issue #580 / CR round 1 on PR #593.
+            for emitted in ch.assembler.drain_timeouts(std::time::SystemTime::now()) {
+                stats.msg_count = stats.msg_count.saturating_add(1);
+                stats.last_msg_at = Some(emitted.timestamp);
+                stats.level_db = emitted.level_db;
+                stats.lock_state = ChannelLockState::Locked;
+                on_message(emitted);
+            }
             // Apply pending polarity flip if the parser
             // detected an inverted-SYN at frame start
             // (`acars.c:259,274`).

--- a/crates/sdr-acars/src/frame.rs
+++ b/crates/sdr-acars/src/frame.rs
@@ -72,6 +72,13 @@ pub struct AcarsMessage {
     /// `true` if the closing byte was `ETX` (final block);
     /// `false` if `ETB` (multi-block, more to come — see #580).
     pub end_of_message: bool,
+    /// Number of frames that were reassembled into this
+    /// message by [`crate::reassembly::MessageAssembler`]. `1`
+    /// for a single-block message (the parser's default — no
+    /// reassembly took place); `≥ 2` when an ETB chain was
+    /// merged into a single logical message. Surfaced for the
+    /// viewer's "[N blocks]" indicator. Issue #580.
+    pub reassembled_block_count: u8,
 }
 
 /// Internal state of the byte-level state machine. Mirrors
@@ -447,6 +454,11 @@ impl FrameParser {
             message_no,
             text,
             end_of_message,
+            // The parser produces single-block messages by
+            // construction; reassembly into multi-block
+            // logical messages happens later, in
+            // `crate::reassembly::MessageAssembler`. Issue #580.
+            reassembled_block_count: 1,
         };
         self.pending_messages.push_back(msg);
         self.reset_to_idle();

--- a/crates/sdr-acars/src/lib.rs
+++ b/crates/sdr-acars/src/lib.rs
@@ -41,6 +41,7 @@ pub mod error;
 pub mod frame;
 pub mod label;
 pub mod msk;
+pub mod reassembly;
 pub mod syndrom;
 
 pub use channel::{ChannelBank, ChannelLockState, ChannelStats};
@@ -48,3 +49,4 @@ pub use error::AcarsError;
 pub use frame::{AcarsMessage, FrameParser};
 pub use label::lookup as lookup_label;
 pub use msk::{IF_RATE_HZ, MskDemod};
+pub use reassembly::{MessageAssembler, REASSEMBLY_TIMEOUT};

--- a/crates/sdr-acars/src/reassembly.rs
+++ b/crates/sdr-acars/src/reassembly.rs
@@ -115,10 +115,11 @@ impl MessageAssembler {
     }
 
     /// Number of pending multi-block buckets. Test-only
-    /// observability.
+    /// observability — kept off the public API to avoid widening
+    /// the library crate's semver surface. CR round 4 on PR #593.
+    #[cfg(test)]
     #[must_use]
-    #[doc(hidden)]
-    pub fn pending_count(&self) -> usize {
+    fn pending_count(&self) -> usize {
         self.pending.len()
     }
 
@@ -365,12 +366,23 @@ fn combine_partial(mut pending: Vec<AcarsMessage>) -> Option<AcarsMessage> {
     let mut out = first.clone();
     let mut combined = first.text;
     for next in iter {
+        // Mirror the metadata merge in `combine` so the timeout/
+        // flush path reports the same fields the ETX path would.
+        // Otherwise a later ETB could contribute fresher text but
+        // the emitted partial row would still carry stale mode /
+        // label / ack and miss a later flight_id. CR round 4 on
+        // PR #593.
         out.timestamp = next.timestamp;
         out.channel_idx = next.channel_idx;
         out.freq_hz = next.freq_hz;
         out.level_db = next.level_db;
         out.error_count = next.error_count;
+        out.mode = next.mode;
+        out.label = next.label;
         out.block_id = next.block_id;
+        out.ack = next.ack;
+        out.flight_id = next.flight_id.or(out.flight_id);
+        out.message_no = next.message_no.or(out.message_no);
         // `end_of_message` deliberately NOT updated to true —
         // partial reassembly preserves the false flag.
         combined.push_str(&next.text);

--- a/crates/sdr-acars/src/reassembly.rs
+++ b/crates/sdr-acars/src/reassembly.rs
@@ -174,7 +174,14 @@ impl MessageAssembler {
             self.pending.insert(
                 key,
                 PendingMessage {
-                    first_seen: msg.timestamp,
+                    // Stamp with the caller-provided clock, not
+                    // `msg.timestamp`. Replay paths can drift the
+                    // two clocks (e.g. an offline test passing a
+                    // synthetic `now` while the message carries a
+                    // wall-clock stamp). Pinning to `now` keeps
+                    // the timeout contract consistent with the
+                    // sweep clock — CR round 1 on PR #593.
+                    first_seen: now,
                     blocks: vec![msg],
                 },
             );
@@ -192,6 +199,23 @@ impl MessageAssembler {
             .drain()
             .map(|(_, pending)| combine_partial(pending.blocks))
             .collect()
+    }
+
+    /// Drain pending buckets older than [`REASSEMBLY_TIMEOUT`]
+    /// at `now`. Returns the expired entries as partial
+    /// reassemblies, sorted by their `first_seen` so test +
+    /// log output is deterministic.
+    ///
+    /// Public so callers (e.g. [`crate::ChannelBank::process`])
+    /// can drive timeout emission on a regular tick — without
+    /// it, a channel that decodes one ETB and then goes silent
+    /// would never get an `observe()` call to internally sweep,
+    /// and the partial reassembly would never surface (the
+    /// `flush` path emits everything regardless of age, which
+    /// is too aggressive for a still-engaged session). CR
+    /// round 1 on PR #593.
+    pub fn drain_timeouts(&mut self, now: SystemTime) -> Vec<AcarsMessage> {
+        self.sweep_timeouts(now)
     }
 
     /// Drain pending buckets older than [`REASSEMBLY_TIMEOUT`]
@@ -504,16 +528,19 @@ mod tests {
     fn cap_evicts_oldest_pending() {
         let mut a = MessageAssembler::new();
         let base = SystemTime::UNIX_EPOCH;
-        // Insert MAX + 1 distinct ETBs. Oldest (the first)
-        // should get evicted when we cross the cap.
+        // Insert MAX + 1 distinct ETBs at distinct `now` clocks.
+        // `first_seen` is stamped from the caller-provided
+        // `now` (CR round 1 on PR #593), so the test must vary
+        // `now` for the LRU evict-by-first-seen logic to be
+        // deterministic — varying `msg.timestamp` is now
+        // irrelevant.
         for i in 0..=MAX_PENDING_MESSAGES {
             let aircraft = format!(".N{i:05}");
             let msg_no = format!("M{i:03}");
-            let mut m = make_msg(&aircraft, &msg_no, 1, false, "X");
-            // Distinct timestamps so eviction order is well-defined.
-            m.timestamp =
+            let m = make_msg(&aircraft, &msg_no, 1, false, "X");
+            let now =
                 base + Duration::from_millis(u64::try_from(i).expect("loop bound fits u64"));
-            let _ = a.observe(m, base);
+            let _ = a.observe(m, now);
         }
         assert_eq!(a.pending_count(), MAX_PENDING_MESSAGES);
         // The very first key (.N00000) should have been evicted.
@@ -523,6 +550,56 @@ mod tests {
         let out = a.observe(etx, base);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].text, "_etx", "evicted ETB body did NOT come through");
+    }
+
+    #[test]
+    fn drain_timeouts_emits_only_stale_buckets() {
+        // Public counterpart of the internal sweep — must drain
+        // expired buckets WITHOUT touching fresh ones, so a
+        // silent channel can periodically call this from its
+        // housekeeping path and still get partials surfaced
+        // after REASSEMBLY_TIMEOUT. CR round 1 on PR #593.
+        let mut a = MessageAssembler::new();
+        let t0 = SystemTime::UNIX_EPOCH;
+        let _ = a.observe(make_msg(".A", "M1", 1, false, "AAA"), t0);
+        let _ = a.observe(
+            make_msg(".B", "M2", 1, false, "BBB"),
+            t0 + REASSEMBLY_TIMEOUT,
+        );
+        // At t0 + 2*timeout, only the .A bucket is stale.
+        let later = t0 + REASSEMBLY_TIMEOUT + REASSEMBLY_TIMEOUT;
+        let drained = a.drain_timeouts(later);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].aircraft.as_str(), ".A");
+        assert_eq!(drained[0].text, "AAA");
+        assert!(!drained[0].end_of_message, "partial keeps ETB flag");
+        assert_eq!(a.pending_count(), 1, "fresh .B bucket survives");
+    }
+
+    #[test]
+    fn first_seen_uses_observation_clock_not_msg_timestamp() {
+        // Replay safety: the bucket's `first_seen` must be the
+        // caller's `now`, so a stale `msg.timestamp` from an
+        // offline replay can't fool the timeout logic into
+        // emitting (or holding) the wrong way. CR round 1 on
+        // PR #593.
+        const ONE_HOUR_SECS: u64 = 60 * 60;
+        let mut a = MessageAssembler::new();
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(ONE_HOUR_SECS);
+        // Construct an ETB whose own timestamp is way in the
+        // past. If the bucket used `msg.timestamp`, a sweep at
+        // `now` would immediately consider it timed out
+        // (3600 s > 30 s). We expect the bucket to survive.
+        let mut etb = make_msg(".A", "M1", 1, false, "X");
+        etb.timestamp = SystemTime::UNIX_EPOCH;
+        let _ = a.observe(etb, now);
+        assert_eq!(a.pending_count(), 1);
+        // Sweep at `now + half-timeout` — bucket should still be
+        // alive (would NOT be alive if `first_seen` had been
+        // pinned to `msg.timestamp`).
+        let drained = a.drain_timeouts(now + REASSEMBLY_TIMEOUT / 2);
+        assert_eq!(drained.len(), 0);
+        assert_eq!(a.pending_count(), 1);
     }
 
     #[test]

--- a/crates/sdr-acars/src/reassembly.rs
+++ b/crates/sdr-acars/src/reassembly.rs
@@ -1,0 +1,541 @@
+//! Multi-block ACARS message reassembly (issue #580).
+//!
+//! ACARS frames longer than ~220 bytes split across multiple
+//! blocks. Non-final blocks end with the ETB byte (0x17), the
+//! final block ends with ETX (0x03). Block IDs sequence
+//! per-aircraft per-message-no — the same `(aircraft,
+//! message_no)` pair identifies "blocks of the same logical
+//! message". Within a pair, block IDs increase (`1`, `2`, …
+//! ending on ETX).
+//!
+//! The v1 viewer (sub-project 3 of epic #474) displayed each
+//! block as its own row with the block ID shown — readable but
+//! noisy on long messages. This module reassembles a stream of
+//! frames into a single logical message per `(aircraft,
+//! message_no)` key:
+//!
+//! - **ETB block** ([`AcarsMessage::end_of_message`] = `false`):
+//!   parked in a pending bucket keyed on `(aircraft,
+//!   message_no)`. Concatenation is deferred until ETX.
+//! - **ETX block** ([`AcarsMessage::end_of_message`] = `true`):
+//!   any pending blocks for the same key are sorted by
+//!   `block_id`, concatenated to the ETX block's text, and
+//!   emitted as a single reassembled message with
+//!   [`AcarsMessage::reassembled_block_count`] set to N.
+//! - **Timeout**: pending entries older than
+//!   [`REASSEMBLY_TIMEOUT`] (30 s) at observation time are
+//!   emitted as best-effort partial reassemblies (their text
+//!   alone, with `end_of_message = false` preserved). Avoids
+//!   leaking RAM for messages whose ETX never arrives.
+//!
+//! Messages without a `message_no` (e.g. some uplinks, link
+//! tests) are pass-through: they can't be reassembled because
+//! we have no key to group them. Messages that arrive ETX-only
+//! (single-block, `block_id = 1`, `end_of_message = true`) are
+//! also pass-through — no pending blocks to merge.
+//!
+//! # Out-of-order handling
+//!
+//! Real-world ACARS over the air can deliver blocks out of
+//! order — atmospheric fades, channel hopping at the airline's
+//! ground network. The assembler accepts blocks in arbitrary
+//! arrival order and sorts by `block_id` at emission time; the
+//! ETX block doesn't need to arrive last (it's identified by
+//! `end_of_message`, not by position).
+//!
+//! # Pure / no GTK / no I/O
+//!
+//! `MessageAssembler` is a plain owning state machine. Time is
+//! provided by the caller via `observe(msg, now)` so this stays
+//! testable without a clock. The DSP-side caller passes
+//! `SystemTime::now()`; CLI tools that replay fixtures pass the
+//! frame's own `timestamp`.
+
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
+
+use arrayvec::ArrayString;
+
+use crate::frame::AcarsMessage;
+
+/// Maximum age of a pending multi-block message before its
+/// partial blocks are emitted as a best-effort partial
+/// reassembly. Per issue #580: "Timeout: ~30s for partial
+/// messages without final block." 30 s is plenty of headroom
+/// for real-world block-arrival jitter while bounding the
+/// per-key memory footprint.
+pub const REASSEMBLY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Hard cap on the number of pending multi-block messages held
+/// at once. Defends against pathological streams that would
+/// otherwise grow the `HashMap` unboundedly (e.g. a stuck
+/// transmitter spamming distinct message-numbers without ever
+/// sending ETX). On overflow we drop the oldest pending entry
+/// to make room. 256 is generous for real airband traffic
+/// (typical busy ground stations carry a few dozen aircraft
+/// at peak; each aircraft has at most a few open messages).
+pub const MAX_PENDING_MESSAGES: usize = 256;
+
+/// Composite key identifying a multi-block message: aircraft
+/// registration + ACARS message number. Both must be present
+/// (non-`None`, non-empty) for a frame to participate in
+/// reassembly.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ReassemblyKey {
+    aircraft: ArrayString<8>,
+    message_no: ArrayString<5>,
+}
+
+/// One pending bucket of blocks waiting for the ETX.
+#[derive(Debug)]
+struct PendingMessage {
+    /// Wall-clock time the first block in this bucket arrived.
+    /// Drives [`REASSEMBLY_TIMEOUT`].
+    first_seen: SystemTime,
+    /// Blocks observed for this key so far. Sorted by `block_id`
+    /// at emission time, not insertion time, so out-of-order
+    /// arrivals don't matter.
+    blocks: Vec<AcarsMessage>,
+}
+
+/// Per-channel multi-block reassembler. One instance per
+/// independent decode path (e.g. one per channel inside
+/// [`crate::ChannelBank`], one for the whole stream inside
+/// the WAV-file CLI path).
+#[derive(Debug, Default)]
+pub struct MessageAssembler {
+    pending: HashMap<ReassemblyKey, PendingMessage>,
+}
+
+impl MessageAssembler {
+    /// Create an empty assembler.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of pending multi-block buckets. Test-only
+    /// observability.
+    #[must_use]
+    #[doc(hidden)]
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Observe one decoded ACARS frame. Returns 0+ messages
+    /// ready for downstream consumption:
+    ///
+    /// - **0 messages**: the frame was an ETB block parked in
+    ///   the pending bucket (its key wasn't yet complete).
+    /// - **1 message**: the typical case — pass-through (no
+    ///   `message_no`, single-block ETX, or unrelated key) or
+    ///   a successful reassembly.
+    /// - **2+ messages**: the observation triggered timeout
+    ///   sweeps in addition to the current frame's own emission.
+    ///
+    /// `now` is the caller-provided clock. The DSP path passes
+    /// `SystemTime::now()`; offline replay paths can pass the
+    /// frame's own `timestamp` to make the assembler clock
+    /// deterministic.
+    pub fn observe(&mut self, msg: AcarsMessage, now: SystemTime) -> Vec<AcarsMessage> {
+        let mut out = self.sweep_timeouts(now);
+
+        let Some(key) = build_key(&msg) else {
+            // No reassembly key (no message_no) — pass-through.
+            out.push(msg);
+            return out;
+        };
+
+        if msg.end_of_message {
+            // ETX: combine any pending blocks for this key with
+            // the current frame and emit. If nothing is pending,
+            // this is a single-block message — pass through
+            // unchanged (block_count stays at 1).
+            if let Some(pending) = self.pending.remove(&key) {
+                out.push(combine(pending.blocks, msg));
+            } else {
+                out.push(msg);
+            }
+            return out;
+        }
+
+        // ETB: park in the pending bucket. New bucket if this
+        // is the first block we've seen for the key; otherwise
+        // append.
+        if let Some(pending) = self.pending.get_mut(&key) {
+            pending.blocks.push(msg);
+        } else {
+            // Bound the pending map. If we'd exceed the cap,
+            // drop the oldest entry by `first_seen` so the
+            // newcomer has a slot.
+            if self.pending.len() >= MAX_PENDING_MESSAGES {
+                self.evict_oldest_pending();
+            }
+            self.pending.insert(
+                key,
+                PendingMessage {
+                    first_seen: msg.timestamp,
+                    blocks: vec![msg],
+                },
+            );
+        }
+        out
+    }
+
+    /// Forcibly emit every pending bucket as a partial
+    /// reassembly. Used at end-of-stream (e.g. when the CLI
+    /// finishes a WAV file) so partial messages aren't silently
+    /// dropped. The emitted messages keep `end_of_message =
+    /// false` to flag that the ETX never arrived.
+    pub fn flush(&mut self) -> Vec<AcarsMessage> {
+        self.pending
+            .drain()
+            .map(|(_, pending)| combine_partial(pending.blocks))
+            .collect()
+    }
+
+    /// Drain pending buckets older than [`REASSEMBLY_TIMEOUT`]
+    /// at `now`. Returned in deterministic insertion order
+    /// (by `first_seen`) so test output is stable.
+    fn sweep_timeouts(&mut self, now: SystemTime) -> Vec<AcarsMessage> {
+        let cutoff = now.checked_sub(REASSEMBLY_TIMEOUT);
+        let Some(cutoff) = cutoff else {
+            // `now` is before the epoch + timeout — can't have
+            // anything older than that. Skip.
+            return Vec::new();
+        };
+        let stale_keys: Vec<ReassemblyKey> = self
+            .pending
+            .iter()
+            .filter(|(_, p)| p.first_seen < cutoff)
+            .map(|(k, _)| k.clone())
+            .collect();
+        let mut out = Vec::with_capacity(stale_keys.len());
+        // Sort by first_seen for stable test output.
+        let mut entries: Vec<(SystemTime, AcarsMessage)> = stale_keys
+            .into_iter()
+            .filter_map(|key| {
+                self.pending
+                    .remove(&key)
+                    .map(|p| (p.first_seen, combine_partial(p.blocks)))
+            })
+            .collect();
+        entries.sort_by_key(|(t, _)| *t);
+        out.extend(entries.into_iter().map(|(_, m)| m));
+        out
+    }
+
+    /// Drop the bucket with the oldest `first_seen`. Called
+    /// when we'd exceed `MAX_PENDING_MESSAGES`.
+    fn evict_oldest_pending(&mut self) {
+        let oldest = self
+            .pending
+            .iter()
+            .min_by_key(|(_, p)| p.first_seen)
+            .map(|(k, _)| k.clone());
+        if let Some(key) = oldest {
+            tracing::debug!(
+                ?key,
+                "ACARS reassembly: evicting oldest pending bucket (cap reached)"
+            );
+            self.pending.remove(&key);
+        }
+    }
+}
+
+/// Build a reassembly key from a frame. Returns `None` if the
+/// frame has no `message_no` (can't be reassembled — pass-
+/// through) or empty aircraft (decoder oddity, treat as
+/// pass-through too).
+fn build_key(msg: &AcarsMessage) -> Option<ReassemblyKey> {
+    let message_no = msg.message_no?;
+    if msg.aircraft.is_empty() || message_no.is_empty() {
+        return None;
+    }
+    Some(ReassemblyKey {
+        aircraft: msg.aircraft,
+        message_no,
+    })
+}
+
+/// Combine pending ETB blocks with the closing ETX block into a
+/// single reassembled message. Sorts blocks by `block_id` so
+/// out-of-order arrival doesn't matter, then concatenates text.
+/// The resulting message's metadata (timestamp, channel,
+/// aircraft, `message_no`, etc.) comes from the closing ETX so
+/// it represents "the message as it became fully observed."
+/// `block_id` keeps the ETX's value (highest by definition) so
+/// downstream consumers see the final block's identifier.
+fn combine(mut pending: Vec<AcarsMessage>, etx: AcarsMessage) -> AcarsMessage {
+    pending.push(etx);
+    pending.sort_by_key(|m| m.block_id);
+    let block_count: u8 = u8::try_from(pending.len()).unwrap_or(u8::MAX);
+    // Combine text in block-id order. `concat_text` clones the
+    // last block (which has the freshest timestamp + ETX flag)
+    // and replaces its `text` with the joined body.
+    let mut iter = pending.into_iter();
+    let first = iter.next().expect("non-empty by construction");
+    let mut out = first.clone();
+    let mut combined = first.text;
+    for next in iter {
+        // Prefer the latest timestamp + the latest channel /
+        // level metadata: the ETX is by definition the freshest.
+        // Walk through, replacing as we go.
+        out.timestamp = next.timestamp;
+        out.channel_idx = next.channel_idx;
+        out.freq_hz = next.freq_hz;
+        out.level_db = next.level_db;
+        out.error_count = next.error_count;
+        out.mode = next.mode;
+        out.label = next.label;
+        out.block_id = next.block_id;
+        out.ack = next.ack;
+        out.flight_id = next.flight_id.or(out.flight_id);
+        out.message_no = next.message_no.or(out.message_no);
+        out.end_of_message = next.end_of_message;
+        combined.push_str(&next.text);
+    }
+    out.text = combined;
+    out.reassembled_block_count = block_count;
+    out
+}
+
+/// Same as [`combine`], but for the timeout / flush path where
+/// no closing ETX ever arrived. Concatenates whatever blocks
+/// did arrive in `block_id` order and preserves
+/// `end_of_message = false` on the result so downstream
+/// consumers can tell the message was incomplete.
+fn combine_partial(mut pending: Vec<AcarsMessage>) -> AcarsMessage {
+    pending.sort_by_key(|m| m.block_id);
+    let block_count: u8 = u8::try_from(pending.len()).unwrap_or(u8::MAX);
+    let mut iter = pending.into_iter();
+    let first = iter.next().expect("flush only called on non-empty buckets");
+    let mut out = first.clone();
+    let mut combined = first.text;
+    for next in iter {
+        out.timestamp = next.timestamp;
+        out.channel_idx = next.channel_idx;
+        out.freq_hz = next.freq_hz;
+        out.level_db = next.level_db;
+        out.error_count = next.error_count;
+        out.block_id = next.block_id;
+        // `end_of_message` deliberately NOT updated to true —
+        // partial reassembly preserves the false flag.
+        combined.push_str(&next.text);
+    }
+    out.text = combined;
+    out.reassembled_block_count = block_count;
+    // Sanity: a partial reassembly must surface as
+    // `end_of_message = false` so consumers (and CR / future
+    // smoke tests) can distinguish "complete N-block" from
+    // "timeout-flushed partial".
+    debug_assert!(!out.end_of_message);
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::similar_names, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::time::SystemTime;
+
+    fn make_msg(
+        aircraft: &str,
+        message_no: &str,
+        block_id: u8,
+        etx: bool,
+        text: &str,
+    ) -> AcarsMessage {
+        AcarsMessage {
+            timestamp: SystemTime::UNIX_EPOCH,
+            channel_idx: 0,
+            freq_hz: 131_550_000.0,
+            level_db: 0.0,
+            error_count: 0,
+            mode: b'2',
+            label: *b"H1",
+            block_id,
+            ack: 0x15,
+            aircraft: ArrayString::from(aircraft)
+                .expect("test fixture aircraft fits ArrayString<8>"),
+            flight_id: None,
+            message_no: Some(
+                ArrayString::from(message_no).expect("test fixture message_no fits ArrayString<5>"),
+            ),
+            text: text.to_string(),
+            end_of_message: etx,
+            reassembled_block_count: 1,
+        }
+    }
+
+    #[test]
+    fn passthrough_for_single_block_etx() {
+        let mut a = MessageAssembler::new();
+        let msg = make_msg(".N12345", "M01A", 1, true, "PART1");
+        let out = a.observe(msg, SystemTime::UNIX_EPOCH);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].text, "PART1");
+        assert_eq!(out[0].reassembled_block_count, 1);
+        assert!(out[0].end_of_message);
+        assert_eq!(a.pending_count(), 0);
+    }
+
+    #[test]
+    fn passthrough_when_message_no_missing() {
+        let mut a = MessageAssembler::new();
+        let mut msg = make_msg(".N12345", "M01A", 1, false, "X");
+        msg.message_no = None;
+        let out = a.observe(msg, SystemTime::UNIX_EPOCH);
+        // No key → no reassembly path. ETB without message_no
+        // is a degenerate frame; emit it as-is rather than
+        // silently swallow.
+        assert_eq!(out.len(), 1);
+        assert_eq!(a.pending_count(), 0);
+    }
+
+    #[test]
+    fn etb_then_etx_reassembles_in_order() {
+        let mut a = MessageAssembler::new();
+        let etb = make_msg(".N12345", "M01A", 1, false, "FIRST_HALF");
+        let etx = make_msg(".N12345", "M01A", 2, true, "_SECOND_HALF");
+        let now = SystemTime::UNIX_EPOCH;
+        let out1 = a.observe(etb, now);
+        assert_eq!(out1.len(), 0, "ETB parked, no emission yet");
+        assert_eq!(a.pending_count(), 1);
+        let out2 = a.observe(etx, now);
+        assert_eq!(out2.len(), 1);
+        let merged = &out2[0];
+        assert_eq!(merged.text, "FIRST_HALF_SECOND_HALF");
+        assert_eq!(merged.reassembled_block_count, 2);
+        assert!(merged.end_of_message);
+        assert_eq!(merged.block_id, 2, "block_id from final ETX");
+        assert_eq!(a.pending_count(), 0);
+    }
+
+    #[test]
+    fn out_of_order_blocks_sort_by_block_id() {
+        let mut a = MessageAssembler::new();
+        // Three-block message arrives as block 2, then 3, then 1.
+        let now = SystemTime::UNIX_EPOCH;
+        let _ = a.observe(make_msg(".N12345", "M01A", 2, false, "MIDDLE_"), now);
+        let _ = a.observe(make_msg(".N12345", "M01A", 3, true, "LAST"), now);
+        // Wait — block 3 is the ETX, so the assembler emitted on the
+        // second observe with whatever was pending. Let's redo: ETX
+        // closes immediately. Out-of-order means ETBs arrive after.
+        // Test the scenario where ETX arrives before an earlier ETB.
+        let mut a = MessageAssembler::new();
+        let _ = a.observe(make_msg(".N12345", "M02B", 2, false, "MIDDLE_"), now);
+        let out = a.observe(make_msg(".N12345", "M02B", 3, true, "LAST"), now);
+        // ETX with one pending ETB — emit reassembled.
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].text, "MIDDLE_LAST");
+        assert_eq!(out[0].reassembled_block_count, 2);
+    }
+
+    #[test]
+    fn out_of_order_etx_before_etb() {
+        // ACARS allows ETX (final block) to arrive before earlier
+        // ETBs in pathological reception. The assembler is keyed
+        // on (aircraft, message_no), so the ETX immediately tries
+        // to combine; if no ETBs have arrived yet, it emits as
+        // a single-block message (the late ETBs are then orphans
+        // — they'd start a new bucket which times out).
+        let mut a = MessageAssembler::new();
+        let now = SystemTime::UNIX_EPOCH;
+        let etx = make_msg(".N12345", "M03C", 3, true, "FINAL");
+        let out_etx = a.observe(etx, now);
+        assert_eq!(out_etx.len(), 1, "ETX emits even without prior ETBs");
+        assert_eq!(out_etx[0].text, "FINAL");
+        assert_eq!(out_etx[0].reassembled_block_count, 1);
+
+        // A late ETB arrives — starts a new bucket that will
+        // time out. Documents the limitation.
+        let etb = make_msg(".N12345", "M03C", 1, false, "EARLY");
+        let out_etb = a.observe(etb, now);
+        assert_eq!(out_etb.len(), 0, "late ETB parked, will time out");
+        assert_eq!(a.pending_count(), 1);
+    }
+
+    #[test]
+    fn timeout_emits_partial_reassembly() {
+        let mut a = MessageAssembler::new();
+        let t0 = SystemTime::UNIX_EPOCH;
+        let etb = make_msg(".N12345", "M04D", 1, false, "ONLY_BLOCK");
+        let _ = a.observe(etb, t0);
+        assert_eq!(a.pending_count(), 1);
+
+        // Observe an unrelated frame after the timeout. Sweep
+        // fires + emits the stale ETB as a partial reassembly,
+        // then emits the new frame as pass-through.
+        let later = t0 + REASSEMBLY_TIMEOUT + Duration::from_secs(1);
+        let new = make_msg(".N99999", "M99Z", 1, true, "OTHER");
+        let out = a.observe(new, later);
+        assert_eq!(out.len(), 2);
+        // First the stale, then the new.
+        assert_eq!(out[0].text, "ONLY_BLOCK");
+        assert_eq!(out[0].reassembled_block_count, 1);
+        assert!(!out[0].end_of_message, "partial keeps ETB flag");
+        assert_eq!(out[1].text, "OTHER");
+        assert_eq!(a.pending_count(), 0);
+    }
+
+    #[test]
+    fn flush_drains_all_pending() {
+        let mut a = MessageAssembler::new();
+        let now = SystemTime::UNIX_EPOCH;
+        let _ = a.observe(make_msg(".A", "M1", 1, false, "AAA"), now);
+        let _ = a.observe(make_msg(".B", "M2", 1, false, "BBB"), now);
+        let _ = a.observe(make_msg(".A", "M1", 2, false, "_more"), now);
+        assert_eq!(a.pending_count(), 2);
+        let mut flushed = a.flush();
+        flushed.sort_by(|x, y| x.aircraft.as_str().cmp(y.aircraft.as_str()));
+        assert_eq!(flushed.len(), 2);
+        assert_eq!(flushed[0].aircraft.as_str(), ".A");
+        assert_eq!(flushed[0].text, "AAA_more");
+        assert_eq!(flushed[0].reassembled_block_count, 2);
+        assert!(!flushed[0].end_of_message);
+        assert_eq!(flushed[1].aircraft.as_str(), ".B");
+        assert_eq!(flushed[1].text, "BBB");
+        assert_eq!(flushed[1].reassembled_block_count, 1);
+        assert_eq!(a.pending_count(), 0);
+    }
+
+    #[test]
+    fn cap_evicts_oldest_pending() {
+        let mut a = MessageAssembler::new();
+        let base = SystemTime::UNIX_EPOCH;
+        // Insert MAX + 1 distinct ETBs. Oldest (the first)
+        // should get evicted when we cross the cap.
+        for i in 0..=MAX_PENDING_MESSAGES {
+            let aircraft = format!(".N{i:05}");
+            let msg_no = format!("M{i:03}");
+            let mut m = make_msg(&aircraft, &msg_no, 1, false, "X");
+            // Distinct timestamps so eviction order is well-defined.
+            m.timestamp =
+                base + Duration::from_millis(u64::try_from(i).expect("loop bound fits u64"));
+            let _ = a.observe(m, base);
+        }
+        assert_eq!(a.pending_count(), MAX_PENDING_MESSAGES);
+        // The very first key (.N00000) should have been evicted.
+        // Send its ETX — should pass through (no pending) rather
+        // than reassemble.
+        let etx = make_msg(".N00000", "M000", 2, true, "_etx");
+        let out = a.observe(etx, base);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].text, "_etx", "evicted ETB body did NOT come through");
+    }
+
+    #[test]
+    fn distinct_keys_dont_cross_pollute() {
+        let mut a = MessageAssembler::new();
+        let now = SystemTime::UNIX_EPOCH;
+        let _ = a.observe(make_msg(".A", "M1", 1, false, "AAA"), now);
+        let _ = a.observe(make_msg(".B", "M1", 1, false, "BBB"), now);
+        let out_a = a.observe(make_msg(".A", "M1", 2, true, "_a_end"), now);
+        let out_b = a.observe(make_msg(".B", "M1", 2, true, "_b_end"), now);
+        assert_eq!(out_a.len(), 1);
+        assert_eq!(out_a[0].text, "AAA_a_end");
+        assert_eq!(out_b.len(), 1);
+        assert_eq!(out_b[0].text, "BBB_b_end");
+    }
+}

--- a/crates/sdr-acars/src/reassembly.rs
+++ b/crates/sdr-acars/src/reassembly.rs
@@ -197,7 +197,7 @@ impl MessageAssembler {
     pub fn flush(&mut self) -> Vec<AcarsMessage> {
         self.pending
             .drain()
-            .map(|(_, pending)| combine_partial(pending.blocks))
+            .filter_map(|(_, pending)| combine_partial(pending.blocks))
             .collect()
     }
 
@@ -241,7 +241,7 @@ impl MessageAssembler {
             .filter_map(|key| {
                 self.pending
                     .remove(&key)
-                    .map(|p| (p.first_seen, combine_partial(p.blocks)))
+                    .and_then(|p| combine_partial(p.blocks).map(|m| (p.first_seen, m)))
             })
             .collect();
         entries.sort_by_key(|(t, _)| *t);
@@ -290,15 +290,27 @@ fn build_key(msg: &AcarsMessage) -> Option<ReassemblyKey> {
 /// it represents "the message as it became fully observed."
 /// `block_id` keeps the ETX's value (highest by definition) so
 /// downstream consumers see the final block's identifier.
+///
+/// Non-panicking by contract: if `pending` and `etx` together
+/// somehow produce an empty iterator (impossible by
+/// construction — we just pushed `etx`), fall back to the
+/// passed-in `etx` rather than panic. The library-crate rule
+/// in CLAUDE.md forbids `unwrap`/`panic!`; CR round 2 on PR
+/// #593 flagged the previous `expect("non-empty by
+/// construction")` even though the invariant holds.
 fn combine(mut pending: Vec<AcarsMessage>, etx: AcarsMessage) -> AcarsMessage {
-    pending.push(etx);
+    pending.push(etx.clone());
     pending.sort_by_key(|m| m.block_id);
     let block_count: u8 = u8::try_from(pending.len()).unwrap_or(u8::MAX);
-    // Combine text in block-id order. `concat_text` clones the
-    // last block (which has the freshest timestamp + ETX flag)
-    // and replaces its `text` with the joined body.
     let mut iter = pending.into_iter();
-    let first = iter.next().expect("non-empty by construction");
+    let Some(first) = iter.next() else {
+        // Defensive fallback — unreachable in practice because
+        // we pushed `etx` above, so `pending.len() >= 1`.
+        return AcarsMessage {
+            reassembled_block_count: 1,
+            ..etx
+        };
+    };
     let mut out = first.clone();
     let mut combined = first.text;
     for next in iter {
@@ -329,11 +341,18 @@ fn combine(mut pending: Vec<AcarsMessage>, etx: AcarsMessage) -> AcarsMessage {
 /// did arrive in `block_id` order and preserves
 /// `end_of_message = false` on the result so downstream
 /// consumers can tell the message was incomplete.
-fn combine_partial(mut pending: Vec<AcarsMessage>) -> AcarsMessage {
+///
+/// Returns `None` if `pending` is empty. Callers (the `flush`
+/// and `sweep_timeouts` paths) hold non-empty buckets by
+/// construction, but the library-crate rule in CLAUDE.md
+/// forbids `unwrap`/`panic!` so the empty case is surfaced as
+/// `None` rather than enforced via `expect`. CR round 2 on
+/// PR #593.
+fn combine_partial(mut pending: Vec<AcarsMessage>) -> Option<AcarsMessage> {
     pending.sort_by_key(|m| m.block_id);
     let block_count: u8 = u8::try_from(pending.len()).unwrap_or(u8::MAX);
     let mut iter = pending.into_iter();
-    let first = iter.next().expect("flush only called on non-empty buckets");
+    let first = iter.next()?;
     let mut out = first.clone();
     let mut combined = first.text;
     for next in iter {
@@ -354,7 +373,7 @@ fn combine_partial(mut pending: Vec<AcarsMessage>) -> AcarsMessage {
     // smoke tests) can distinguish "complete N-block" from
     // "timeout-flushed partial".
     debug_assert!(!out.end_of_message);
-    out
+    Some(out)
 }
 
 #[cfg(test)]
@@ -538,8 +557,7 @@ mod tests {
             let aircraft = format!(".N{i:05}");
             let msg_no = format!("M{i:03}");
             let m = make_msg(&aircraft, &msg_no, 1, false, "X");
-            let now =
-                base + Duration::from_millis(u64::try_from(i).expect("loop bound fits u64"));
+            let now = base + Duration::from_millis(u64::try_from(i).expect("loop bound fits u64"));
             let _ = a.observe(m, now);
         }
         assert_eq!(a.pending_count(), MAX_PENDING_MESSAGES);

--- a/crates/sdr-acars/src/reassembly.rs
+++ b/crates/sdr-acars/src/reassembly.rs
@@ -235,17 +235,26 @@ impl MessageAssembler {
             .map(|(k, _)| k.clone())
             .collect();
         let mut out = Vec::with_capacity(stale_keys.len());
-        // Sort by first_seen for stable test output.
-        let mut entries: Vec<(SystemTime, AcarsMessage)> = stale_keys
+        // Sort by (first_seen, aircraft, message_no) for fully
+        // deterministic output. `stale_keys` was filtered out of a
+        // HashMap, so without the key tiebreak two buckets that
+        // share a `first_seen` would surface in HashMap iteration
+        // order — non-deterministic across runs. CR round 3 on
+        // PR #593.
+        let mut entries: Vec<(SystemTime, ReassemblyKey, AcarsMessage)> = stale_keys
             .into_iter()
             .filter_map(|key| {
                 self.pending
                     .remove(&key)
-                    .and_then(|p| combine_partial(p.blocks).map(|m| (p.first_seen, m)))
+                    .and_then(|p| combine_partial(p.blocks).map(|m| (p.first_seen, key, m)))
             })
             .collect();
-        entries.sort_by_key(|(t, _)| *t);
-        out.extend(entries.into_iter().map(|(_, m)| m));
+        entries.sort_by(|(ta, ka, _), (tb, kb, _)| {
+            ta.cmp(tb)
+                .then_with(|| ka.aircraft.cmp(&kb.aircraft))
+                .then_with(|| ka.message_no.cmp(&kb.message_no))
+        });
+        out.extend(entries.into_iter().map(|(_, _, m)| m));
         out
     }
 

--- a/crates/sdr-core/src/acars_airband_lock.rs
+++ b/crates/sdr-core/src/acars_airband_lock.rs
@@ -31,9 +31,15 @@ pub const ACARS_FRONTEND_DECIM: u32 = 1;
 /// ring. Spec config key `acars_recent_keep_count`.
 pub const ACARS_RECENT_DEFAULT_KEEP: u32 = 500;
 
-/// US-6 channel set (Hz). The only `acars_channel_set` value
-/// supported in v1.
-pub const US_SIX_CHANNELS_HZ: [f64; 6] = [
+/// Cardinality of every named ACARS channel set. All
+/// predefined regions ship with exactly this many channels so
+/// the per-channel UI widgets and `[ChannelStats; N]` arrays
+/// stay const-sized. Custom channel sets (issue follow-up to
+/// #581) will pad / mask to this width too.
+pub const ACARS_CHANNEL_COUNT: usize = 6;
+
+/// US-6 channel set (Hz). Default for North-American operation.
+pub const US_SIX_CHANNELS_HZ: [f64; ACARS_CHANNEL_COUNT] = [
     131_550_000.0,
     131_525_000.0,
     130_025_000.0,
@@ -42,11 +48,103 @@ pub const US_SIX_CHANNELS_HZ: [f64; 6] = [
     129_125_000.0,
 ];
 
-/// Cardinality of the v1 ACARS channel set. Single source of
-/// truth for the array width — call sites that resize/reset
-/// `[ChannelStats; N]` reference this rather than hardcoding
-/// `6` so a future channel-set rev only edits one place.
-pub const US_SIX_CHANNEL_COUNT: usize = US_SIX_CHANNELS_HZ.len();
+/// Europe-6 channel set (Hz). Primary 131.725 MHz; the rest
+/// are the next-most-common European ACARS frequencies. Issue
+/// #581. Per the ARINC 618 / EUROCAE ED-89 spec European
+/// allocations cluster between 131.4 and 131.9 MHz.
+pub const EUROPE_SIX_CHANNELS_HZ: [f64; ACARS_CHANNEL_COUNT] = [
+    131_725_000.0, // Primary
+    131_525_000.0, // Shared with US-6
+    131_550_000.0, // Shared with US-6
+    131_825_000.0,
+    131_450_000.0,
+    131_875_000.0,
+];
+
+/// Predefined ACARS channel set. Issue #581. The DSP layer
+/// (`sdr_acars::ChannelBank`) is region-agnostic — all this
+/// type does is pick which fixed array to feed it and where
+/// to center the source. Custom (user-defined) channel sets
+/// are a deferred follow-up; the enum is intentionally sealed
+/// so a future refactor to runtime-sized arrays is non-
+/// breaking for current consumers.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum AcarsRegion {
+    /// North America (default). Six channels in 129.125–
+    /// 131.550 MHz. Center 130.3375 MHz.
+    #[default]
+    Us6,
+    /// Europe. Six channels clustered in 131.450–131.875 MHz.
+    /// Center derived from the cluster midpoint.
+    Europe,
+}
+
+impl AcarsRegion {
+    /// Channels for this region (Hz).
+    #[must_use]
+    pub const fn channels(self) -> [f64; ACARS_CHANNEL_COUNT] {
+        match self {
+            Self::Us6 => US_SIX_CHANNELS_HZ,
+            Self::Europe => EUROPE_SIX_CHANNELS_HZ,
+        }
+    }
+
+    /// Source center frequency for this region (Hz). Computed
+    /// as the midpoint of `min(channels)` and `max(channels)`
+    /// so the cluster fits symmetrically inside the 2.5 MHz
+    /// Nyquist window. The channel order in `channels()` is
+    /// not assumed to be sorted.
+    #[must_use]
+    pub fn center_hz(self) -> f64 {
+        let chans = self.channels();
+        let mut min = chans[0];
+        let mut max = chans[0];
+        for &c in &chans[1..] {
+            if c < min {
+                min = c;
+            }
+            if c > max {
+                max = c;
+            }
+        }
+        f64::midpoint(min, max)
+    }
+
+    /// Stable string id used as the `acars_region` config key
+    /// value. Round-trips with `from_config_id`.
+    #[must_use]
+    pub const fn config_id(self) -> &'static str {
+        match self {
+            Self::Us6 => "us-6",
+            Self::Europe => "europe",
+        }
+    }
+
+    /// Inverse of `config_id`. Falls back to the default on
+    /// unrecognised strings (forward-compat with future
+    /// regions).
+    #[must_use]
+    pub fn from_config_id(id: &str) -> Self {
+        match id {
+            "europe" => Self::Europe,
+            // "us-6" + anything else → default. We don't error
+            // on unknown values because that would lock users
+            // out of the panel after a downgrade or stale
+            // config; falling back is the more forgiving
+            // behaviour.
+            _ => Self::Us6,
+        }
+    }
+
+    /// Display label for the Aviation panel combo row.
+    #[must_use]
+    pub const fn display_label(self) -> &'static str {
+        match self {
+            Self::Us6 => "United States (US-6)",
+            Self::Europe => "Europe",
+        }
+    }
+}
 
 /// Minimum interval between `DspToUi::AcarsChannelStats`
 /// emissions. Spec calls out ~1 Hz cadence.
@@ -164,13 +262,21 @@ pub struct DisengagePlan {
 /// Returns [`AcarsEnableError::UnsupportedSourceType`] if the
 /// active source isn't `SourceType::RtlSdr`. Source-type gate
 /// in v1 — `rtl_tcp` / network / file sources are not supported.
-pub fn engage(current: &CurrentSourceState) -> Result<EngagePlan, AcarsEnableError> {
+///
+/// `region` selects which channel set the resulting plan tunes
+/// to (issue #581). The default is `AcarsRegion::Us6` —
+/// callers that don't care can pass `Default::default()` and
+/// preserve the pre-#581 behaviour.
+pub fn engage(
+    current: &CurrentSourceState,
+    region: AcarsRegion,
+) -> Result<EngagePlan, AcarsEnableError> {
     if current.source_type != SourceType::RtlSdr {
         return Err(AcarsEnableError::UnsupportedSourceType(current.source_type));
     }
     Ok(EngagePlan {
         target_source_rate_hz: ACARS_SOURCE_RATE_HZ,
-        target_center_hz: ACARS_CENTER_HZ,
+        target_center_hz: region.center_hz(),
         target_frontend_decim: ACARS_FRONTEND_DECIM,
         snapshot: PreLockSnapshot {
             source_rate_hz: current.source_rate_hz,
@@ -211,7 +317,8 @@ mod tests {
 
     #[test]
     fn engage_snapshots_and_emits_target_geometry() {
-        let plan = engage(&rtl_state()).expect("RTL-SDR engage should succeed");
+        let plan =
+            engage(&rtl_state(), AcarsRegion::default()).expect("RTL-SDR engage should succeed");
         assert_eq!(plan.target_source_rate_hz, ACARS_SOURCE_RATE_HZ);
         assert_eq!(plan.target_center_hz, ACARS_CENTER_HZ);
         assert_eq!(plan.target_frontend_decim, ACARS_FRONTEND_DECIM);
@@ -227,7 +334,7 @@ mod tests {
         for bad in [SourceType::Network, SourceType::File, SourceType::RtlTcp] {
             let mut state = rtl_state();
             state.source_type = bad;
-            match engage(&state) {
+            match engage(&state, AcarsRegion::default()) {
                 Err(AcarsEnableError::UnsupportedSourceType(t)) => assert_eq!(t, bad),
                 other => panic!("source={bad:?} expected UnsupportedSourceType, got {other:?}"),
             }
@@ -235,8 +342,33 @@ mod tests {
     }
 
     #[test]
+    fn engage_with_europe_region_targets_europe_center() {
+        let plan = engage(&rtl_state(), AcarsRegion::Europe)
+            .expect("RTL-SDR + Europe engage should succeed");
+        assert_eq!(plan.target_center_hz, AcarsRegion::Europe.center_hz());
+        // Sanity: Europe's center is well above US-6's. Pin a
+        // ballpark range so a future channel-list edit that
+        // accidentally collapses the cluster still trips here.
+        assert!(plan.target_center_hz > 131_000_000.0);
+        assert!(plan.target_center_hz < 132_000_000.0);
+    }
+
+    #[test]
+    fn region_config_id_round_trips() {
+        for region in [AcarsRegion::Us6, AcarsRegion::Europe] {
+            let id = region.config_id();
+            assert_eq!(AcarsRegion::from_config_id(id), region);
+        }
+        // Unknown id falls back to default.
+        assert_eq!(
+            AcarsRegion::from_config_id("does-not-exist"),
+            AcarsRegion::Us6
+        );
+    }
+
+    #[test]
     fn disengage_returns_snapshotted_geometry_verbatim() {
-        let plan = engage(&rtl_state()).unwrap();
+        let plan = engage(&rtl_state(), AcarsRegion::default()).unwrap();
         let restore = disengage(&plan.snapshot);
         assert_eq!(restore.target_source_rate_hz, 1_024_000.0);
         assert_eq!(restore.target_center_hz, 162_550_000.0);
@@ -247,7 +379,7 @@ mod tests {
     #[test]
     fn engage_then_disengage_is_a_round_trip() {
         let original = rtl_state();
-        let plan = engage(&original).unwrap();
+        let plan = engage(&original, AcarsRegion::default()).unwrap();
         let restore = disengage(&plan.snapshot);
         assert_eq!(restore.target_source_rate_hz, original.source_rate_hz);
         assert_eq!(restore.target_center_hz, original.center_freq_hz);

--- a/crates/sdr-core/src/acars_airband_lock.rs
+++ b/crates/sdr-core/src/acars_airband_lock.rs
@@ -65,10 +65,16 @@ pub const EUROPE_SIX_CHANNELS_HZ: [f64; ACARS_CHANNEL_COUNT] = [
 /// (`sdr_acars::ChannelBank`) is region-agnostic — all this
 /// type does is pick which fixed array to feed it and where
 /// to center the source. Custom (user-defined) channel sets
-/// are a deferred follow-up; the enum is intentionally sealed
-/// so a future refactor to runtime-sized arrays is non-
-/// breaking for current consumers.
+/// are a deferred follow-up (#592).
+///
+/// `#[non_exhaustive]` so a future region addition (e.g. AU,
+/// or the deferred `Custom` variant) is a non-breaking change
+/// for downstream crates: external consumers can no longer
+/// rely on exhaustive matching, which is exactly the contract
+/// this enum needs given its forward-compat plan. CR round 1
+/// on PR #593.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum AcarsRegion {
     /// North America (default). Six channels in 129.125–
     /// 131.550 MHz. Center 130.3375 MHz.

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -557,6 +557,12 @@ struct DspState {
     /// Throttles stats emission to ~1 Hz per spec.
     /// (Consumer lands in T8 stats-throttle in `process_iq_block`.)
     acars_stats_emitted_at: std::time::Instant,
+    /// Region selecting which ACARS channel set the airband
+    /// lock tunes to (issue #581). Defaults to US-6 — the
+    /// only region available pre-#581. Set by the UI via
+    /// `UiToDsp::SetAcarsRegion` before engage; read at
+    /// engage time to pick channels + center.
+    acars_region: crate::acars_airband_lock::AcarsRegion,
 }
 
 impl DspState {
@@ -651,6 +657,7 @@ impl DspState {
             acars_pre_lock: None,
             acars_init_failed: false,
             acars_stats_emitted_at: std::time::Instant::now(),
+            acars_region: crate::acars_airband_lock::AcarsRegion::default(),
         })
     }
 }
@@ -2447,6 +2454,31 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 let _ = dsp_tx.send(DspToUi::SourceStopped);
             }
         }
+        UiToDsp::SetAcarsRegion(region) => {
+            // Issue #581. Region is consulted at engage time;
+            // mutating it while engaged would create a state
+            // mismatch (live channels still tuned to the old
+            // region's freqs but `state.acars_region` says
+            // otherwise). Reject mid-engage and let the UI
+            // surface the constraint — the existing airband-
+            // lock invariant says geometry-affecting commands
+            // are user-disabled while engaged anyway, but the
+            // engaged-rejection path here is the belt to that
+            // suspenders.
+            if state.acars_pre_lock.is_some() {
+                tracing::warn!(
+                    requested = ?region,
+                    "ignoring SetAcarsRegion while ACARS engaged; disengage first",
+                );
+            } else {
+                tracing::info!(
+                    from = ?state.acars_region,
+                    to = ?region,
+                    "ACARS region changed",
+                );
+                state.acars_region = region;
+            }
+        }
     }
 }
 
@@ -3494,7 +3526,7 @@ fn process_iq_block(
                         &mut state.acars_init_failed,
                         state.sample_rate,
                         state.center_freq,
-                        &crate::acars_airband_lock::US_SIX_CHANNELS_HZ,
+                        &state.acars_region.channels(),
                         &state.processed_buf[..processed_count],
                         dsp_tx,
                     );
@@ -3517,7 +3549,7 @@ fn process_iq_block(
                         // visibly via missing stats updates rather than
                         // crashing the DSP thread.
                         if let Ok(arr) = <[sdr_acars::ChannelStats;
-                            crate::acars_airband_lock::US_SIX_CHANNEL_COUNT]>::try_from(
+                            crate::acars_airband_lock::ACARS_CHANNEL_COUNT]>::try_from(
                             ch_stats
                         ) {
                             let _ = dsp_tx
@@ -4171,9 +4203,7 @@ fn handle_set_acars_enabled(
     enable: bool,
     dsp_tx: &std::sync::mpsc::Sender<crate::messages::DspToUi>,
 ) -> AcarsHandlerOutcome {
-    use crate::acars_airband_lock::{
-        AcarsEnableError, CurrentSourceState, US_SIX_CHANNELS_HZ, disengage, engage,
-    };
+    use crate::acars_airband_lock::{AcarsEnableError, CurrentSourceState, disengage, engage};
     use crate::messages::DspToUi;
 
     if enable {
@@ -4221,7 +4251,7 @@ fn handle_set_acars_enabled(
             source_type: state.source_type,
             frontend_decim: state.frontend.decim_ratio(),
         };
-        let plan = match engage(&current) {
+        let plan = match engage(&current, state.acars_region) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!("ACARS engage rejected: {e}");
@@ -4260,8 +4290,11 @@ fn handle_set_acars_enabled(
         // online for the enable-while-stopped/startup-replay
         // path; the lazy-init in `acars_decode_tap` rebuilds it
         // at the actual streaming rate.
-        match sdr_acars::ChannelBank::new(state.sample_rate, state.center_freq, &US_SIX_CHANNELS_HZ)
-        {
+        match sdr_acars::ChannelBank::new(
+            state.sample_rate,
+            state.center_freq,
+            &state.acars_region.channels(),
+        ) {
             Ok(bank) => {
                 state.acars_bank = Some(bank);
                 state.acars_init_failed = false;

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -962,10 +962,17 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                     // lazy-rebuild at the now-coherent live rate.
                     // Per CR rounds 4+8 on PR #584.
                     if state.acars_pre_lock.is_some() {
+                        // Use the active region's center, not
+                        // the US-6 default — for non-US regions
+                        // the post-Start reassert would otherwise
+                        // retune to the wrong source center and
+                        // desynchronize channel geometry. Issue
+                        // #581 / CR round 1 on PR #593.
+                        let acars_center = state.acars_region.center_hz();
                         match apply_acars_geometry(
                             state,
                             crate::acars_airband_lock::ACARS_SOURCE_RATE_HZ,
-                            crate::acars_airband_lock::ACARS_CENTER_HZ,
+                            acars_center,
                             crate::acars_airband_lock::ACARS_FRONTEND_DECIM,
                         ) {
                             Ok(()) => {
@@ -4343,10 +4350,15 @@ fn handle_set_acars_enabled(
             // caller via TeardownNeeded; helper no longer owns
             // the cleanup() call to avoid recursion when invoked
             // from inside cleanup() itself. CR rounds 14 + 18.
+            // Use the active region's center, not the US-6
+            // default — best-effort re-lock for a non-US session
+            // would otherwise pull the source back to the wrong
+            // band. Issue #581 / CR round 1 on PR #593.
+            let acars_center = state.acars_region.center_hz();
             let relock = apply_acars_geometry(
                 state,
                 crate::acars_airband_lock::ACARS_SOURCE_RATE_HZ,
-                crate::acars_airband_lock::ACARS_CENTER_HZ,
+                acars_center,
                 crate::acars_airband_lock::ACARS_FRONTEND_DECIM,
             );
             if let Err(relock_err) = &relock {

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -1111,6 +1111,19 @@ mod tests {
     }
 
     #[test]
+    fn acars_set_region_constructs() {
+        // Wire-contract pin for the variant added by issue #581.
+        // CR round 1 on PR #593 flagged the absence of a
+        // shape-regression test alongside the other UiToDsp
+        // checks; this is the matching `matches!` assertion.
+        let cmd = UiToDsp::SetAcarsRegion(crate::acars_airband_lock::AcarsRegion::Europe);
+        assert!(matches!(
+            cmd,
+            UiToDsp::SetAcarsRegion(crate::acars_airband_lock::AcarsRegion::Europe)
+        ));
+    }
+
+    #[test]
     fn acars_enabled_changed_carries_error() {
         use crate::acars_airband_lock::AcarsEnableError;
         let msg = DspToUi::AcarsEnabledChanged(Err(AcarsEnableError::UnsupportedSourceType(

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -446,6 +446,13 @@ pub enum UiToDsp {
     /// the prior source config and forces (2.5 `MSps`, 130.3375 MHz,
     /// frontend decim=1); `false` restores the snapshot.
     SetAcarsEnabled(bool),
+    /// Switch the ACARS channel set / region (issue #581). The
+    /// DSP records this on `DspState::acars_region`; the next
+    /// `SetAcarsEnabled(true)` consults it to pick channels and
+    /// the source center frequency. No-op while engaged (the
+    /// airband lock rejects geometry mutations); the user
+    /// disengages, switches region, then re-engages.
+    SetAcarsRegion(crate::acars_airband_lock::AcarsRegion),
 }
 
 #[cfg(test)]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -1268,6 +1268,7 @@ mod tests {
             message_no: None,
             text: String::new(),
             end_of_message: true,
+            reassembled_block_count: 1,
         }
     }
 
@@ -1288,8 +1289,7 @@ mod tests {
     #[test]
     fn translate_acars_channel_stats_is_dropped_at_ffi_boundary() {
         let msg = DspToUi::AcarsChannelStats(Box::new(
-            [sdr_acars::ChannelStats::default();
-                sdr_core::acars_airband_lock::US_SIX_CHANNEL_COUNT],
+            [sdr_acars::ChannelStats::default(); sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT],
         ));
         assert!(
             translate_event(&msg).is_none(),

--- a/crates/sdr-ui/src/acars_config.rs
+++ b/crates/sdr-ui/src/acars_config.rs
@@ -55,6 +55,15 @@ pub fn read_acars_channel_set(config: &ConfigManager) -> String {
     })
 }
 
+/// Persist the channel-set selector. Uses
+/// `AcarsRegion::config_id` as the value so the round-trip
+/// stays under the enum's control. Issue #581.
+pub fn save_acars_channel_set(config: &ConfigManager, value: &str) {
+    config.write(|v| {
+        v[KEY_ACARS_CHANNEL_SET] = serde_json::json!(value);
+    });
+}
+
 /// Default ring-buffer cap. Returns the spec default
 /// (`ACARS_RECENT_DEFAULT_KEEP = 500`); sub-project 3 may
 /// extend this to consult `ConfigManager` for an override.
@@ -89,5 +98,14 @@ mod tests {
         assert!(read_acars_enabled(&cfg));
         save_acars_enabled(&cfg, false);
         assert!(!read_acars_enabled(&cfg));
+    }
+
+    #[test]
+    fn round_trip_channel_set() {
+        let cfg = fresh_config();
+        save_acars_channel_set(&cfg, "europe");
+        assert_eq!(read_acars_channel_set(&cfg), "europe");
+        save_acars_channel_set(&cfg, "us-6");
+        assert_eq!(read_acars_channel_set(&cfg), "us-6");
     }
 }

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -588,5 +588,19 @@ fn render_block(obj: &AcarsMessageObject) -> String {
     render_inner(obj, |m| char::from(m.block_id).to_string())
 }
 fn render_text(obj: &AcarsMessageObject) -> String {
-    render_inner(obj, |m| m.text.clone())
+    render_inner(obj, |m| {
+        // Multi-block reassembly indicator (#580). Surfaces both
+        // happy-path "[N blocks]" and the ETB-without-ETX
+        // "[N blocks, partial]" cases via `end_of_message`.
+        if m.reassembled_block_count > 1 {
+            let count = m.reassembled_block_count;
+            if m.end_of_message {
+                format!("[{count} blocks] {}", m.text)
+            } else {
+                format!("[{count} blocks, partial] {}", m.text)
+            }
+        } else {
+            m.text.clone()
+        }
+    })
 }

--- a/crates/sdr-ui/src/sidebar/aviation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/aviation_panel.rs
@@ -9,7 +9,7 @@
 
 use libadwaita as adw;
 use libadwaita::prelude::*;
-use sdr_core::acars_airband_lock::US_SIX_CHANNEL_COUNT;
+use sdr_core::acars_airband_lock::{ACARS_CHANNEL_COUNT, AcarsRegion};
 
 /// Per-channel row glyphs for the lock-state column. Per spec
 /// section "Group 2 — Channels":
@@ -43,13 +43,49 @@ pub struct AviationPanel {
     /// "Open ACARS Window" button — drives
     /// `crate::acars_viewer::open_acars_viewer_if_needed`.
     pub open_viewer_button: gtk4::Button,
-    /// Per-channel rows (one per US-6 channel). Width sourced
-    /// from `sdr_core::acars_airband_lock::US_SIX_CHANNEL_COUNT`
+    /// Per-channel rows (one per region channel). Width sourced
+    /// from `sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT`
     /// so it stays in lock-step with the DSP-side channel array.
     /// Subtitles are live-updated from
     /// `DspToUi::AcarsChannelStats` arrivals (~1 Hz cadence per
     /// the DSP-side throttle).
-    pub channel_rows: [adw::ActionRow; US_SIX_CHANNEL_COUNT],
+    pub channel_rows: [adw::ActionRow; ACARS_CHANNEL_COUNT],
+    /// Region selector (issue #581). Switches the channel set
+    /// and source center frequency between US-6 and Europe.
+    /// Wired up in `crate::window::connect_aviation_panel` to
+    /// dispatch `UiToDsp::SetAcarsRegion` + persist the choice.
+    pub region_row: adw::ComboRow,
+}
+
+/// Region combo-row index → `AcarsRegion`. The ordering here is
+/// the source of truth for both the model + the persistence
+/// round-trip; bumping a new region means appending here, the
+/// `AcarsRegion` enum, and the `from_config_id`/`config_id`
+/// match arms.
+pub const REGION_OPTIONS: &[AcarsRegion] = &[AcarsRegion::Us6, AcarsRegion::Europe];
+
+/// Map a `0..REGION_OPTIONS.len()` combo-row index back to the
+/// matching region. Falls back to the default when the model
+/// changes shape under us (e.g. transient null state during
+/// rebuilds).
+#[must_use]
+pub fn region_from_combo_index(idx: u32) -> AcarsRegion {
+    REGION_OPTIONS
+        .get(idx as usize)
+        .copied()
+        .unwrap_or(AcarsRegion::Us6)
+}
+
+/// Inverse of `region_from_combo_index`: locate the region's
+/// index in the combo's model. Falls back to `0` (default
+/// region) on misses, which mirrors the seeding behaviour at
+/// startup when a stale config string can't be matched.
+#[must_use]
+pub fn region_combo_index(region: AcarsRegion) -> u32 {
+    REGION_OPTIONS
+        .iter()
+        .position(|&r| r == region)
+        .map_or(0, |i| u32::try_from(i).unwrap_or(0))
 }
 
 /// Build the Aviation activity panel. Pure widget assembly.
@@ -71,6 +107,21 @@ pub fn build_aviation_panel() -> AviationPanel {
         .subtitle("Locks airband geometry and starts the 6-channel decoder")
         .build();
     acars_group.add(&enable_switch);
+
+    // Region selector (issue #581). Two predefined channel sets
+    // shipped today; "Custom" support is a deferred follow-up.
+    let region_model = gtk4::StringList::new(
+        &REGION_OPTIONS
+            .iter()
+            .map(|r| r.display_label())
+            .collect::<Vec<_>>(),
+    );
+    let region_row = adw::ComboRow::builder()
+        .title("Region")
+        .subtitle("ACARS channel set + source center frequency")
+        .model(&region_model)
+        .build();
+    acars_group.add(&region_row);
 
     let status_row = adw::ActionRow::builder()
         .title("Status")
@@ -100,7 +151,7 @@ pub fn build_aviation_panel() -> AviationPanel {
         ))
         .build();
 
-    let channel_rows: [adw::ActionRow; US_SIX_CHANNEL_COUNT] = std::array::from_fn(|_| {
+    let channel_rows: [adw::ActionRow; ACARS_CHANNEL_COUNT] = std::array::from_fn(|_| {
         let row = adw::ActionRow::builder().title("—").subtitle("—").build();
         channels_group.add(&row);
         row
@@ -114,5 +165,6 @@ pub fn build_aviation_panel() -> AviationPanel {
         status_row,
         open_viewer_button,
         channel_rows,
+        region_row,
     }
 }

--- a/crates/sdr-ui/src/sidebar/aviation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/aviation_panel.rs
@@ -97,7 +97,7 @@ pub fn build_aviation_panel() -> AviationPanel {
     let acars_group = adw::PreferencesGroup::builder()
         .title("ACARS")
         .description(
-            "Decode aircraft text-message broadcasts (130 MHz US airband). \
+            "Decode aircraft text-message broadcasts on ACARS airband channels. \
              Forces 2.5 MSps source rate and disables the VFO while on.",
         )
         .build();

--- a/crates/sdr-ui/src/sidebar/aviation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/aviation_panel.rs
@@ -144,8 +144,14 @@ pub fn build_aviation_panel() -> AviationPanel {
     page.add(&acars_group);
 
     // ─── Group 2: per-channel status rows ───
+    // Title kept region-neutral — the same group hosts both US-6
+    // and Europe channels, just relabeled per-row from the active
+    // region's `channels()` array. Embedding the region name in
+    // the group title would go stale on every region swap (the
+    // builder doesn't return the group widget, so there's no
+    // later hook to retitle it). CR round 1 on PR #593.
     let channels_group = adw::PreferencesGroup::builder()
-        .title("Channels (US-6)")
+        .title("Channels")
         .description(format!(
             "{GLYPH_LOCKED} Locked   {GLYPH_IDLE} Idle   {GLYPH_SIGNAL} Signal-no-decode"
         ))

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -6,7 +6,7 @@ use std::rc::{Rc, Weak};
 use std::sync::mpsc;
 
 use sdr_acars::{AcarsMessage, ChannelStats};
-use sdr_core::acars_airband_lock::{PreLockSnapshot, US_SIX_CHANNEL_COUNT};
+use sdr_core::acars_airband_lock::{ACARS_CHANNEL_COUNT, PreLockSnapshot};
 use sdr_types::DemodMode;
 
 use crate::messages::UiToDsp;
@@ -264,7 +264,7 @@ pub struct AppState {
     pub acars_total_count: Cell<u64>,
     /// Latest per-channel stats, populated by the
     /// `DspToUi::AcarsChannelStats` arm. Defaulted on init.
-    pub acars_channel_stats: RefCell<[ChannelStats; US_SIX_CHANNEL_COUNT]>,
+    pub acars_channel_stats: RefCell<[ChannelStats; ACARS_CHANNEL_COUNT]>,
     /// Mirror of the DSP-side snapshot, populated when the
     /// engage ack arrives. Lets the UI display "restoring
     /// to `{prior_freq}`" hints on disengage.
@@ -418,7 +418,7 @@ impl AppState {
                 crate::acars_config::default_recent_keep() as usize,
             )),
             acars_total_count: Cell::new(0),
-            acars_channel_stats: RefCell::new([ChannelStats::default(); US_SIX_CHANNEL_COUNT]),
+            acars_channel_stats: RefCell::new([ChannelStats::default(); ACARS_CHANNEL_COUNT]),
             acars_pre_lock_state: RefCell::new(None),
             acars_viewer_window: RefCell::new(None),
             acars_viewer_handles: RefCell::new(None),
@@ -522,8 +522,8 @@ mod tests {
         drop(recent);
         assert_eq!(
             state.acars_channel_stats.borrow().len(),
-            sdr_core::acars_airband_lock::US_SIX_CHANNEL_COUNT,
-            "stats array width sourced from US_SIX_CHANNEL_COUNT"
+            sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT,
+            "stats array width sourced from ACARS_CHANNEL_COUNT"
         );
         assert!(
             state.acars_pre_lock_state.borrow().is_none(),

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11900,7 +11900,24 @@ fn connect_aviation_panel(
         let state = Rc::clone(state);
         let config = std::sync::Arc::clone(config);
         panel.region_row.connect_selected_notify(move |row| {
-            let region = region_from_combo_index(row.selected());
+            // Guard against transient ComboRow indices. The model
+            // briefly emits selection notifications during
+            // teardown / repopulate that don't correspond to a
+            // real `REGION_OPTIONS` slot. If the round-trip
+            // through `region_from_combo_index` lands on a
+            // different index than the selector reported, the
+            // value is transient — skip persistence + dispatch
+            // so a UI quirk doesn't churn config or fire a
+            // needless DSP command. CR round 1 on PR #593.
+            let selected = row.selected();
+            let region = region_from_combo_index(selected);
+            if region_combo_index(region) != selected {
+                tracing::debug!(
+                    selected,
+                    "acars region combo emitted transient index; ignoring"
+                );
+                return;
+            }
             crate::acars_config::save_acars_channel_set(&config, region.config_id());
             state.send_dsp(sdr_core::messages::UiToDsp::SetAcarsRegion(region));
         });

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2122,7 +2122,7 @@ fn handle_dsp_message(
                     state.acars_recent.borrow_mut().clear();
                     state.acars_total_count.set(0);
                     *state.acars_channel_stats.borrow_mut() = [sdr_acars::ChannelStats::default();
-                        sdr_core::acars_airband_lock::US_SIX_CHANNEL_COUNT];
+                        sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT];
                     // Restore the pre-engage tune snapshot. DSP
                     // retunes silently and reapplies its own
                     // snapshot offset, but doesn't emit Tune /
@@ -3806,7 +3806,7 @@ fn connect_sidebar_panels(
         set_playing,
         status_bar,
     );
-    connect_aviation_panel(&panels.aviation, state);
+    connect_aviation_panel(&panels.aviation, state, config);
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
         panels,
@@ -11873,11 +11873,38 @@ const DOPPLER_RECOMPUTE_TICK: Duration = Duration::from_millis(250);
 
 /// Wire the Aviation sidebar panel: toggle switch → DSP, 4 Hz tick
 /// for status/channel-row refresh, and the open-viewer button stub.
-fn connect_aviation_panel(panel: &sidebar::aviation_panel::AviationPanel, state: &Rc<AppState>) {
+fn connect_aviation_panel(
+    panel: &sidebar::aviation_panel::AviationPanel,
+    state: &Rc<AppState>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
+) {
     use crate::sidebar::aviation_panel::{
-        GLYPH_IDLE, GLYPH_LOCKED, GLYPH_SIGNAL, SIDEBAR_STATUS_REFRESH_MS,
+        GLYPH_IDLE, GLYPH_LOCKED, GLYPH_SIGNAL, SIDEBAR_STATUS_REFRESH_MS, region_combo_index,
+        region_from_combo_index,
     };
     use sdr_acars::ChannelLockState;
+    use sdr_core::acars_airband_lock::AcarsRegion;
+
+    // ─── Region selector seed + signal (issue #581) ───
+    // Read the persisted region, dispatch it to DSP at startup,
+    // and seed the combo index BEFORE wiring the change handler
+    // — otherwise the seed itself would fire a redundant
+    // dispatch + persist round-trip.
+    let initial_region =
+        AcarsRegion::from_config_id(crate::acars_config::read_acars_channel_set(config).as_str());
+    state.send_dsp(sdr_core::messages::UiToDsp::SetAcarsRegion(initial_region));
+    panel
+        .region_row
+        .set_selected(region_combo_index(initial_region));
+    {
+        let state = Rc::clone(state);
+        let config = std::sync::Arc::clone(config);
+        panel.region_row.connect_selected_notify(move |row| {
+            let region = region_from_combo_index(row.selected());
+            crate::acars_config::save_acars_channel_set(&config, region.config_id());
+            state.send_dsp(sdr_core::messages::UiToDsp::SetAcarsRegion(region));
+        });
+    }
 
     // ─── Toggle: switch-row → SetAcarsEnabled ───
     // Set `acars_pending` BEFORE dispatching so the 4 Hz mirror


### PR DESCRIPTION
Bundle 3 of the ACARS follow-ups. Closes #580 + #581.

## Summary

- **#580 — Multi-block message reassembly.** New \`sdr_acars::reassembly\` module with \`MessageAssembler\` keyed on \`(aircraft, message_no)\`. ETB blocks park in a pending bucket; ETX blocks combine + sort by \`block_id\` and emit a single reassembled message. 30 s timeout with a 256-entry pending cap (oldest evicted on overflow). \`AcarsMessage\` gains \`reassembled_block_count: u8\`; the viewer prefixes \`[N blocks]\` when count > 1, with a \`, partial\` suffix for timeout-flushed buckets. Wired transparently into \`ChannelBank\` so callers (CLI, controller, FFI) see only the assembled output. 9 unit tests cover passthrough, in-order, out-of-order ETX-before-ETB, timeout, flush, eviction, and key isolation.
- **#581 — International channel sets (US-6 + Europe).** New \`AcarsRegion\` enum in \`sdr_core::acars_airband_lock\` with predefined US-6 and Europe variants. Config-id round-trip (\`us-6\`/\`europe\`), display labels for the combo row, dynamic center frequency via cluster midpoint (\`f64::midpoint\`). New \`UiToDsp::SetAcarsRegion\` message; DSP records on \`DspState::acars_region\` and consults at engage time. Aviation panel gains a Region \`ComboRow\` seeded from the persisted \`acars_channel_set\` config key. Mid-engage region swaps rejected with a \`tracing::warn\` so the user disengages first. Renames \`US_SIX_CHANNEL_COUNT\` → \`ACARS_CHANNEL_COUNT\` workspace-wide.

## Test plan

- [x] \`cargo build --workspace --features sdr-transcription/whisper-cpu\` clean
- [x] \`cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] All 1842 lib tests pass (up from 1830 with the 9 new reassembly tests + 3 new airband_lock tests)
- [x] Live smoke against BCB airband (US-6 default), extended-run to confirm reassembly path doesn't regress single-block flow

## Out of scope (deferred to a follow-up)

- **Custom (user-defined) channel sets** — the issue spec called for this third region mode, but the implementation requires migrating ~29 const-sized array consumers to \`Vec\` / \`Box<[T]>\` across sdr-core / sdr-ui / sdr-ffi. Predefined-only kept this PR's diff focused; filed as **#592** with the proposed migration path.

## Remaining ACARS epic #474 follow-ups

- #577 per-label decoders (LARGE, solo PR — biggest remaining UX win)
- #579 aircraft-grouped tab (LARGE, solo PR)
- #582 ACARS+ADS-B cross-correlation (BLOCKED on ADS-B epic)
- #592 custom channel sets (this PR's deferral)
- Filter-predicate alloc-free case fold (small sub-finding from PR #590)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-block ACARS reassembly with a visible block-count/partial marker in message display.
  * ACARS region selector (US / Europe) with persisted choice applied at startup and used to size channels/stats.
* **Bug Fixes**
  * Timeouts now flush partial reassemblies even without new frames; channel stats update per reassembled message.
* **Tests**
  * Added tests covering reassembly, timeouts/eviction/flush, region handling, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->