### PR TITLE
feat(sdr-ui): #579 ACARS aircraft tab + label names + Ack column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,6 +3419,7 @@ dependencies = [
 name = "sdr-ui"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "bytemuck",
  "cairo-rs",
  "chrono",

--- a/crates/sdr-acars/src/label.rs
+++ b/crates/sdr-acars/src/label.rs
@@ -2,24 +2,106 @@
 //! label code identifying its category (Q0 = link test, H1 =
 //! crew message, B1 = weather, etc.).
 //!
-//! v1 ships an EMPTY table — `acarsdec` itself doesn't include a
-//! code→name dictionary, so there's nothing to verbatim-port for
-//! the e2e diff against the reference. Population is queued for
-//! the UI sub-project (where names actually get displayed) and
-//! tracked in issue #577 (which also covers per-label
-//! structured-field parsing). Sources to draw from when the
-//! table lands: ARINC 618 spec, sigidwiki ACARS labels page,
-//! community wikis.
-//!
-//! The public API ([`lookup`]) is kept stable now so downstream
-//! tasks (Task 8 re-exports, Task 9 CLI, sub-project 3 UI) can
-//! call it without code churn when names are added later.
+//! The public API ([`lookup`]) returns `Some(name)` for ~80 known
+//! labels or `None` for unknown codes. Sources: sigidwiki ACARS
+//! labels page, airframes.io public docs, `acarsdeco2` / `vdlm2dec`
+//! name tables. ARINC 618 is paywalled; this is a best-effort
+//! curated list rather than a verbatim port.
 
 /// Look up the human-readable name for a 2-byte label code.
-/// Currently always returns `None` — see module-level docs.
+/// Returns `Some(name)` for known ACARS labels (~80 entries
+/// covering OOOI events, position reports, weather, ATC, and
+/// ACMS) or `None` for unknown codes. Names are sourced from
+/// the sigidwiki ACARS labels page, airframes.io public docs,
+/// and the open-source `acarsdeco2` / `vdlm2dec` projects'
+/// name tables. ARINC 618 itself is paywalled; `acarsdec`
+/// doesn't ship a name table either, so this is a curated
+/// best-effort list rather than a verbatim port.
 #[must_use]
-pub fn lookup(_code: [u8; 2]) -> Option<&'static str> {
-    None
+#[allow(clippy::too_many_lines)]
+pub fn lookup(code: [u8; 2]) -> Option<&'static str> {
+    Some(match &code {
+        // OOOI events (numeric pairs)
+        b"10" | b"17" => "Arrival info",
+        b"11" | b"QA" => "Out (gate)",
+        b"12" | b"QB" => "Off (wheels)",
+        b"13" | b"QC" => "On (wheels)",
+        b"14" | b"QD" => "In (gate)",
+        b"15" | b"80" => "Departure",
+        b"16" | b"25" | b"32" | b"35" | b"40" | b"44" | b"45" | b"4M" | b"4N" | b"5U" | b"81"
+        | b"A6" | b"A8" | b"QH" | b"QM" | b"QP" | b"QQ" | b"QR" => "Position",
+        b"1F" | b"82" => "Free text",
+        b"1G" => "Gate request",
+        b"1H" => "Gate assignment",
+        b"1L" | b"2C" | b"30" | b"57" | b"M1" | b"QG" => "Position report",
+        b"1S" | b"26" | b"5Z" | b"8S" => "Schedule",
+        // Departure clearance + datalink (2x)
+        b"20" => "Departure clearance",
+        b"21" => "Departure clearance reply",
+        b"22" | b"83" => "Pre-departure clearance",
+        b"23" => "Datalink expedite",
+        b"27" => "Schedule (revision)",
+        b"2N" => "Takeoff time",
+        b"2Z" => "Destination update",
+        // 3x — fuel + maintenance
+        b"33" => "Fuel report",
+        b"39" => "Maintenance ground report",
+        // 5x — OOOI summary
+        b"51" => "Ground service request",
+        b"52" | b"8A" => "Engine maintenance",
+        b"5Y" => "OOOI report",
+        // 7x — voice + tests
+        b"70" => "Voice contact request",
+        b"7A" | b"7B" | b"7C" => "Test message",
+        // 8x — dispatch + clearance
+        b"8D" => "Dispatch reply",
+        b"8E" => "ETA report",
+        // A-family
+        b"A0" => "Test",
+        b"A7" => "Pre-departure clearance request",
+        b"A9" => "Pre-departure clearance reply",
+        b"AA" | b"Q5" => "Engine data",
+        // B-family — weather
+        b"B1" | b"BA" => "Weather request",
+        b"B2" => "Weather information",
+        b"B3" => "Weather (text)",
+        b"B4" => "Weather (route)",
+        b"B5" => "Weather (terminal)",
+        b"B6" => "Weather (en-route)",
+        b"B7" => "Weather (clearance)",
+        b"B8" => "Weather (SIGMET)",
+        b"B9" => "Weather (other)",
+        // C-family — ATC
+        b"C0" => "Uplink command",
+        b"C1" => "ATC",
+        b"C2" => "ATC clearance request",
+        b"C3" => "ATC reply",
+        // H-family — free text
+        b"H1" => "Crew message",
+        b"H2" => "Free text uplink",
+        b"H3" => "Free text downlink",
+        // Q-family — control + position + OOOI
+        b"Q0" => "Link test",
+        b"Q1" => "ATIS",
+        b"Q2" => "ACARS network test",
+        b"Q3" => "Voice circuit test",
+        b"Q4" => "Navaids",
+        b"Q6" => "Engine display data",
+        b"Q7" => "Component maintenance",
+        b"QE" => "OOOI summary",
+        b"QF" => "OOOI (extended)",
+        b"QK" => "Voice request",
+        b"QL" => "ATIS (alt)",
+        b"QN" | b"QS" => "Diversion",
+        b"QT" => "ACARS request",
+        // RB — alias dispatched the same as 26 in label_parsers
+        b"RB" => "Schedule (alias for 26)",
+        // Underscore prefix — generic up/down link
+        b"_d" => "General downlink",
+        b"_e" => "General uplink",
+        // Unknown
+        _ => return None,
+    })
 }
 
 #[cfg(test)]
@@ -28,12 +110,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn lookup_returns_none_in_v1() {
-        // Pin the v1 stub. Once #577 populates the table this
-        // test gets replaced with positive `assert_eq!` checks
-        // for known labels (H1, Q0, _d, B1, etc.).
-        assert_eq!(lookup(*b"H1"), None);
-        assert_eq!(lookup(*b"Q0"), None);
+    fn lookup_known_labels() {
+        // Spot-check 5 canonical labels across the major code
+        // families (alphanumeric pair, numeric, underscore prefix,
+        // alias). Adding all 80 here would just be a copy of the
+        // table in `lookup` itself.
+        assert_eq!(lookup(*b"H1"), Some("Crew message"));
+        assert_eq!(lookup(*b"Q0"), Some("Link test"));
+        assert_eq!(lookup(*b"M1"), Some("Position report"));
+        assert_eq!(lookup(*b"_d"), Some("General downlink"));
+        assert_eq!(lookup(*b"RB"), Some("Schedule (alias for 26)"));
+    }
+
+    #[test]
+    fn lookup_numeric_labels() {
+        // OOOI events (10-15) are particularly important — the
+        // viewer's UI uses them to highlight gate/wheels events.
+        assert_eq!(lookup(*b"10"), Some("Arrival info"));
+        assert_eq!(lookup(*b"11"), Some("Out (gate)"));
+        assert_eq!(lookup(*b"12"), Some("Off (wheels)"));
+        assert_eq!(lookup(*b"13"), Some("On (wheels)"));
+        assert_eq!(lookup(*b"14"), Some("In (gate)"));
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        // Bogus codes outside the known table should still
+        // resolve to `None` so the viewer falls back to the bare
+        // 2-char code in the column display.
         assert_eq!(lookup([0xFF, 0xFF]), None);
+        assert_eq!(lookup(*b"ZZ"), None);
     }
 }

--- a/crates/sdr-ui/Cargo.toml
+++ b/crates/sdr-ui/Cargo.toml
@@ -74,6 +74,7 @@ sdr-rtltcp-discovery.workspace = true
 sdr-server-rtltcp = { path = "../sdr-server-rtltcp", default-features = false }
 sdr-acars.workspace = true
 sdr-tray.workspace = true
+arrayvec.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -623,33 +623,50 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         });
     }
 
-    // ── Filter: live substring match on aircraft + label + text ──
+    // ── Filter: live substring match across both tabs ────────────
+    // Stream tab: aircraft + label + text. Aircraft tab: tail only
+    // (label/text don't exist on aircraft rows).
     {
         let filter = handles.filter.clone();
+        let aircraft_filter = handles.aircraft_filter.clone();
         let entry = handles.filter_entry.clone();
         entry.connect_search_changed(move |entry| {
             let needle_str: String = entry.text().as_str().to_lowercase();
+
+            // Stream filter — existing logic unchanged.
+            let stream_needle = needle_str.clone();
             filter.set_filter_func(move |obj| {
                 let Some(obj) = obj.downcast_ref::<AcarsMessageObject>() else {
                     return false;
                 };
-                // Borrow the inner message — the filter predicate
-                // fires for every row on every keystroke + every
-                // append, so cloning the full message here would
-                // be a measurable hot-path cost on long-running
-                // sessions.
                 let inner = obj.imp().inner.borrow();
                 let Some(msg) = inner.as_ref() else {
                     return false;
                 };
-                if needle_str.is_empty() {
+                if stream_needle.is_empty() {
                     return true;
                 }
-                let needle = &needle_str;
+                let needle = &stream_needle;
                 msg.aircraft.to_lowercase().contains(needle)
                     || std::str::from_utf8(&msg.label)
                         .is_ok_and(|s| s.to_lowercase().contains(needle))
                     || msg.text.to_lowercase().contains(needle)
+            });
+
+            // Aircraft filter — tail substring only.
+            let aircraft_needle = needle_str;
+            aircraft_filter.set_filter_func(move |obj| {
+                let Some(obj) = obj.downcast_ref::<AircraftEntryObject>() else {
+                    return false;
+                };
+                let inner = obj.imp().inner.borrow();
+                let Some(entry) = inner.as_ref() else {
+                    return false;
+                };
+                if aircraft_needle.is_empty() {
+                    return true;
+                }
+                entry.tail.to_lowercase().contains(&aircraft_needle)
             });
         });
     }

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -43,6 +43,30 @@ pub struct ViewerHandles {
     /// until they scroll back. Bypasses `ColumnView::scroll_to`
     /// which needs gtk4 `v4_12` (workspace is on `v4_10`).
     pub scrolled_window: gtk4::ScrolledWindow,
+    /// "By Aircraft" tab parallel store, one row per unique
+    /// tail seen since session start. Issue #579.
+    pub aircraft_store: gtk4::gio::ListStore,
+    /// Filter applied to `aircraft_store`. Same `filter_entry`
+    /// drives both this and the stream `filter`; this one
+    /// matches tail substring only (no label/text — those don't
+    /// exist on aircraft rows).
+    pub aircraft_filter: gtk4::CustomFilter,
+    /// `FilterListModel` wrapping `aircraft_store` for the
+    /// aircraft column view.
+    pub aircraft_filter_model: gtk4::FilterListModel,
+    /// O(1) tail → `AircraftEntryObject` lookup so the message-
+    /// append site in `window.rs` can find-or-insert without
+    /// scanning the store. Holds clones of the same glib
+    /// objects that live in `aircraft_store`; updates flow
+    /// through to the column view via the shared refcount.
+    pub aircraft_index: std::cell::RefCell<
+        std::collections::HashMap<arrayvec::ArrayString<8>, AircraftEntryObject>,
+    >,
+    /// `GtkStack` switching between the "stream" page (existing
+    /// chronological view) and "aircraft" page (per-tail
+    /// summary). Cloned into the click-to-filter handler on the
+    /// aircraft column view to switch back to the stream tab.
+    pub stack: gtk4::Stack,
 }
 
 /// Recency window length in seconds (10 minutes). Split into a
@@ -489,6 +513,16 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     content.append(&scroll);
     window.set_content(Some(&content));
 
+    // Placeholder aircraft store + filter + stack for the
+    // "By Aircraft" tab. Wired to a real column view + click
+    // handlers in subsequent tasks; this stub keeps the
+    // struct buildable so the field additions land cleanly.
+    let aircraft_store = gtk4::gio::ListStore::new::<AircraftEntryObject>();
+    let aircraft_filter = gtk4::CustomFilter::new(|_obj| true);
+    let aircraft_filter_model =
+        gtk4::FilterListModel::new(Some(aircraft_store.clone()), Some(aircraft_filter.clone()));
+    let stack = gtk4::Stack::new();
+
     // Hoist handles so all signal handlers below can clone from it.
     let handles = Rc::new(ViewerHandles {
         store,
@@ -499,6 +533,11 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         filter_entry: filter_entry.clone(),
         collapse_button: collapse_button.clone(),
         scrolled_window: scroll.clone(),
+        aircraft_store,
+        aircraft_filter,
+        aircraft_filter_model,
+        aircraft_index: std::cell::RefCell::new(std::collections::HashMap::new()),
+        stack,
     });
     *state.acars_viewer_handles.borrow_mut() = Some(Rc::clone(&handles));
 

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -631,10 +631,11 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
             state.acars_recent.borrow_mut().clear();
             // Don't reset acars_total_count — that's the
             // running total since toggle-on, distinct from the
-            // visible count. Status label refresh in the
-            // items_changed handler recomputes "filtered / total"
-            // from the now-empty filter_model + total_count.
-            handles.status_label.set_label("0 / 0 messages");
+            // visible count. Status label refresh fires from
+            // items_changed on both filter models above and
+            // recomputes "filtered / total <messages|aircraft>"
+            // from whichever tab is currently visible (CR round 1
+            // on PR #597).
         });
     }
 
@@ -691,20 +692,46 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     // stack.visible_child_name(). Re-evaluated on:
     //   - either filter model's items-changed signal
     //   - stack visible-child-notify
+    //
+    // CR round 1 on PR #597: capture WeakRefs (not strong clones)
+    // for each GTK object. The signal handlers below own the
+    // Rc<refresh>; if the refresh captured strong refs, the
+    // chain `filter_model → handler → Rc → filter_model` would
+    // hold the model alive past viewer close. WeakRef + upgrade-
+    // or-return matches the ScannerForceDisable pattern in
+    // window.rs.
     {
-        let stack = handles.stack.clone();
-        let status = handles.status_label.clone();
-        let store = handles.store.clone();
-        let aircraft_store = handles.aircraft_store.clone();
-        let filter_model = handles.filter_model.clone();
-        let aircraft_filter_model = handles.aircraft_filter_model.clone();
+        let stack_weak = handles.stack.downgrade();
+        let status_weak = handles.status_label.downgrade();
+        let store_weak = handles.store.downgrade();
+        let aircraft_store_weak = handles.aircraft_store.downgrade();
+        let filter_model_weak = handles.filter_model.downgrade();
+        let aircraft_filter_model_weak = handles.aircraft_filter_model.downgrade();
         let refresh = std::rc::Rc::new(move || {
+            let Some(stack) = stack_weak.upgrade() else {
+                return;
+            };
+            let Some(status) = status_weak.upgrade() else {
+                return;
+            };
             let on_aircraft = stack.visible_child_name().as_deref() == Some("aircraft");
             if on_aircraft {
+                let Some(aircraft_store) = aircraft_store_weak.upgrade() else {
+                    return;
+                };
+                let Some(aircraft_filter_model) = aircraft_filter_model_weak.upgrade() else {
+                    return;
+                };
                 let filtered = aircraft_filter_model.n_items();
                 let total = aircraft_store.n_items();
                 status.set_label(&format!("{filtered} / {total} aircraft"));
             } else {
+                let Some(store) = store_weak.upgrade() else {
+                    return;
+                };
+                let Some(filter_model) = filter_model_weak.upgrade() else {
+                    return;
+                };
                 let filtered = filter_model.n_items();
                 let total = store.n_items();
                 status.set_label(&format!("{filtered} / {total} messages"));
@@ -1029,7 +1056,11 @@ fn render_ack(obj: &AcarsMessageObject) -> String {
     render_inner(obj, |m| match m.ack {
         b'\x15' => "NAK".to_string(),
         b'!' => "!".to_string(),
-        c if c.is_ascii_graphic() => char::from(c).to_string(),
+        // CR round 1 on PR #597: 0x20..=0x7E (printable
+        // ASCII inclusive of space) rather than is_ascii_graphic
+        // which excludes space. ACARS ACK can be a literal space
+        // and we want to render it as ' ', not "0x20".
+        c if (0x20..=0x7E).contains(&c) => char::from(c).to_string(),
         c => format!("0x{c:02X}"),
     })
 }

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -613,6 +613,8 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         let handles = Rc::clone(&handles);
         clear_button.connect_clicked(move |_| {
             handles.store.remove_all();
+            handles.aircraft_store.remove_all();
+            handles.aircraft_index.borrow_mut().clear();
             state.acars_recent.borrow_mut().clear();
             // Don't reset acars_total_count — that's the
             // running total since toggle-on, distinct from the

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -591,15 +591,24 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     });
     *state.acars_viewer_handles.borrow_mut() = Some(Rc::clone(&handles));
 
-    // Click-to-filter (issue #579): double-click / Enter / Space on
-    // an aircraft row sets the filter entry to the tail and switches
-    // to the Stream tab. `GtkColumnView::connect_activate` fires on
-    // double-click / Enter / Space; single click stays as selection.
+    // Click-to-filter (issue #579): single-click on an aircraft row
+    // sets the filter entry to the tail and switches to the Stream
+    // tab. `single_click_activate(true)` on the ColumnView means a
+    // single click both selects AND emits `activate`. Using
+    // `view.model().item(position)` rather than
+    // `handles.aircraft_filter_model.item(position)` so the lookup
+    // matches the visible row regardless of current sort order
+    // (`position` is the column view / sort-model index, not the
+    // pre-sort FilterListModel index).
     {
         let handles = Rc::clone(&handles);
-        aircraft_column_view.connect_activate(move |_view, position| {
-            let Some(obj) = handles
-                .aircraft_filter_model
+        aircraft_column_view.connect_activate(move |view, position| {
+            // `position` is the column view's row index, which maps
+            // to the selection/sort model's order. Use `view.model()`
+            // so the lookup matches the visible row regardless of
+            // current sort + filter.
+            let Some(model) = view.model() else { return };
+            let Some(obj) = model
                 .item(position)
                 .and_then(|o| o.downcast::<AircraftEntryObject>().ok())
             else {
@@ -866,15 +875,16 @@ fn build_aircraft_column_view(
     let sort_model =
         gtk4::SortListModel::new(Some(filter_model.clone()), Option::<gtk4::Sorter>::None);
     // SingleSelection (vs NoSelection on the Stream tab) so the
-    // column view's `activate` signal fires on double-click / Enter.
-    // Click-to-filter wiring depends on `connect_activate`, which
-    // NoSelection does not propagate.
+    // column view's `activate` signal fires. Click-to-filter wiring
+    // depends on `connect_activate`; `single_click_activate(true)`
+    // on the ColumnView makes a single click both select and emit
+    // `activate`, matching the "click an aircraft to drill in" UX.
     let selection = gtk4::SingleSelection::new(Some(sort_model.clone()));
-    selection.set_can_unselect(true);
     let column_view = gtk4::ColumnView::builder()
         .model(&selection)
         .show_column_separators(true)
         .show_row_separators(true)
+        .single_click_activate(true)
         .build();
     sort_model.set_sorter(column_view.sorter().as_ref());
 

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -170,6 +170,93 @@ impl AcarsMessageObject {
     }
 }
 
+// ── glib::Object wrapper around an AircraftEntry (issue #579) ──
+
+mod imp_aircraft {
+    use std::cell::RefCell;
+
+    use gtk4::glib;
+    use gtk4::glib::subclass::prelude::{ObjectImpl, ObjectSubclass};
+
+    pub struct AircraftEntryObject {
+        pub inner: RefCell<Option<super::AircraftEntry>>,
+    }
+
+    impl Default for AircraftEntryObject {
+        fn default() -> Self {
+            Self {
+                inner: RefCell::new(None),
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for AircraftEntryObject {
+        const NAME: &'static str = "AircraftEntryObject";
+        type Type = super::AircraftEntryObject;
+    }
+
+    impl ObjectImpl for AircraftEntryObject {}
+}
+
+glib::wrapper! {
+    /// Glib subclass wrapping an `AircraftEntry`. Used as the
+    /// row model for the "By Aircraft" tab in the ACARS viewer.
+    /// The aircraft column view's factories + sorters borrow
+    /// the inner `AircraftEntry` via `obj.imp().inner.borrow()`.
+    pub struct AircraftEntryObject(ObjectSubclass<imp_aircraft::AircraftEntryObject>);
+}
+
+/// Per-aircraft summary backing one row of the "By Aircraft"
+/// tab. Mutated in place via [`AircraftEntryObject::record_message`]
+/// — `last_seen` advances monotonically (`max(prev, msg.timestamp)`)
+/// to mirror the same out-of-order discipline as
+/// `AcarsMessageObject::record_duplicate` (CR round 2 on PR #591).
+#[derive(Clone, Debug)]
+pub struct AircraftEntry {
+    pub tail: arrayvec::ArrayString<8>,
+    pub last_seen: std::time::SystemTime,
+    pub msg_count: u32,
+    pub last_label: [u8; 2],
+}
+
+impl AircraftEntryObject {
+    /// Wrap an `AircraftEntry` for insertion into the aircraft
+    /// `gio::ListStore`. Caller should typically seed `msg_count`
+    /// to 0 and immediately invoke [`Self::record_message`] for
+    /// the message that triggered the insert; that gives the new
+    /// row a `msg_count` of 1 with `last_seen` and `last_label`
+    /// taken from the message.
+    #[must_use]
+    pub fn new(entry: AircraftEntry) -> Self {
+        let obj: Self = glib::Object::new();
+        *obj.imp().inner.borrow_mut() = Some(entry);
+        obj
+    }
+
+    /// Borrow-clone of the wrapped entry. Returns `None` only if
+    /// a caller called `take()` (we don't); column-view factories
+    /// can `expect` in their bind closures.
+    #[must_use]
+    pub fn entry(&self) -> Option<AircraftEntry> {
+        self.imp().inner.borrow().clone()
+    }
+
+    /// Record a new message for this aircraft: bumps `msg_count`,
+    /// advances `last_seen` monotonically to
+    /// `max(last_seen, msg.timestamp)`, and overwrites
+    /// `last_label`. Same out-of-order discipline as
+    /// `AcarsMessageObject::record_duplicate`.
+    pub fn record_message(&self, msg: &sdr_acars::AcarsMessage) {
+        let imp = self.imp();
+        let mut slot = imp.inner.borrow_mut();
+        let Some(entry) = slot.as_mut() else { return };
+        entry.msg_count = entry.msg_count.saturating_add(1);
+        entry.last_seen = std::cmp::max(entry.last_seen, msg.timestamp);
+        entry.last_label = msg.label;
+    }
+}
+
 // ── Public API: open / present-if-already-open ─────────────────
 
 /// Open the ACARS viewer window if not already open. If a
@@ -603,4 +690,102 @@ fn render_text(obj: &AcarsMessageObject) -> String {
             m.text.clone()
         }
     })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use super::*;
+    use arrayvec::ArrayString;
+    use sdr_acars::AcarsMessage;
+
+    fn fixture_message(tail: &str, label: [u8; 2], ts: SystemTime) -> AcarsMessage {
+        let mut aircraft = ArrayString::<8>::new();
+        aircraft.push_str(tail);
+        AcarsMessage {
+            timestamp: ts,
+            channel_idx: 0,
+            freq_hz: 131_550_000.0,
+            level_db: 0.0,
+            error_count: 0,
+            mode: b'2',
+            label,
+            block_id: b'5',
+            ack: b'!',
+            aircraft,
+            flight_id: None,
+            message_no: None,
+            text: String::new(),
+            end_of_message: true,
+            reassembled_block_count: 1,
+            parsed: None,
+        }
+    }
+
+    #[test]
+    fn aircraft_entry_object_record_message_bumps_count() {
+        // GTK glib::Object subclasses can be constructed without
+        // a running GTK Application — `glib::Object::new` works
+        // as long as the type was registered (which happens via
+        // the `#[glib::object_subclass]` macro at module load).
+        gtk4::glib::MainContext::default();
+        let ts = SystemTime::now();
+        let entry = AircraftEntry {
+            tail: {
+                let mut s = ArrayString::<8>::new();
+                s.push_str(".N12345");
+                s
+            },
+            last_seen: ts,
+            msg_count: 0,
+            last_label: *b"H1",
+        };
+        let obj = AircraftEntryObject::new(entry);
+        assert_eq!(obj.entry().unwrap().msg_count, 0);
+
+        let msg = fixture_message(".N12345", *b"M1", ts + Duration::from_secs(1));
+        obj.record_message(&msg);
+        assert_eq!(obj.entry().unwrap().msg_count, 1);
+
+        obj.record_message(&msg);
+        assert_eq!(obj.entry().unwrap().msg_count, 2);
+    }
+
+    #[test]
+    fn aircraft_entry_object_last_seen_monotonic() {
+        gtk4::glib::MainContext::default();
+        let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let entry = AircraftEntry {
+            tail: ArrayString::new(),
+            last_seen: t0,
+            msg_count: 0,
+            last_label: *b"  ",
+        };
+        let obj = AircraftEntryObject::new(entry);
+
+        // Out-of-order timestamps must not regress last_seen.
+        let later = fixture_message("X", *b"H1", t0 + Duration::from_mins(1));
+        let earlier = fixture_message("X", *b"H1", t0 + Duration::from_secs(30));
+        obj.record_message(&later);
+        obj.record_message(&earlier);
+        assert_eq!(obj.entry().unwrap().last_seen, t0 + Duration::from_mins(1));
+    }
+
+    #[test]
+    fn aircraft_entry_object_record_message_updates_label() {
+        gtk4::glib::MainContext::default();
+        let ts = SystemTime::now();
+        let entry = AircraftEntry {
+            tail: ArrayString::new(),
+            last_seen: ts,
+            msg_count: 0,
+            last_label: *b"H1",
+        };
+        let obj = AircraftEntryObject::new(entry);
+        let msg = fixture_message("X", *b"M1", ts);
+        obj.record_message(&msg);
+        assert_eq!(obj.entry().unwrap().last_label, *b"M1");
+    }
 }

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -246,11 +246,10 @@ pub struct AircraftEntry {
 
 impl AircraftEntryObject {
     /// Wrap an `AircraftEntry` for insertion into the aircraft
-    /// `gio::ListStore`. Caller should typically seed `msg_count`
-    /// to 0 and immediately invoke [`Self::record_message`] for
-    /// the message that triggered the insert; that gives the new
-    /// row a `msg_count` of 1 with `last_seen` and `last_label`
-    /// taken from the message.
+    /// `gio::ListStore`. Callers should set `msg_count` to 1 in
+    /// the seed entry (already counting the inserting message)
+    /// so the column view's first bind reads the correct value.
+    /// Subsequent messages are recorded via [`Self::record_message`].
     #[must_use]
     pub fn new(entry: AircraftEntry) -> Self {
         let obj: Self = glib::Object::new();
@@ -384,23 +383,28 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         for msg in recent.iter() {
             store.append(&AcarsMessageObject::new(msg.clone()));
 
-            // Mirror into aircraft_index + aircraft_store. New
-            // tail → seed an entry with msg_count=0 and let
-            // record_message bring it to 1; existing tail →
-            // record_message bumps in place.
+            // Mirror into aircraft_index + aircraft_store.
+            // New tail → initialize with msg_count=1 (already
+            // counting this message) so the column view's first
+            // bind reads the correct value, not zero. Existing
+            // tail → record_message bumps in place. No
+            // items_changed needed in the hydration loop; the
+            // column view binds once after all hydration is done,
+            // reading the final state.
             let mut idx = aircraft_index_initial.borrow_mut();
-            let obj = idx.entry(msg.aircraft).or_insert_with(|| {
+            if let Some(obj) = idx.get(&msg.aircraft) {
+                obj.record_message(msg);
+            } else {
                 let entry = AircraftEntry {
                     tail: msg.aircraft,
                     last_seen: msg.timestamp,
-                    msg_count: 0,
+                    msg_count: 1,
                     last_label: msg.label,
                 };
                 let obj = AircraftEntryObject::new(entry);
                 aircraft_store.append(&obj);
-                obj
-            });
-            obj.record_message(msg);
+                idx.insert(msg.aircraft, obj);
+            }
         }
     }
     let initial_count = store.n_items();
@@ -861,7 +865,12 @@ fn build_aircraft_column_view(
     // view's sorter once it exists.
     let sort_model =
         gtk4::SortListModel::new(Some(filter_model.clone()), Option::<gtk4::Sorter>::None);
-    let selection = gtk4::NoSelection::new(Some(sort_model.clone()));
+    // SingleSelection (vs NoSelection on the Stream tab) so the
+    // column view's `activate` signal fires on double-click / Enter.
+    // Click-to-filter wiring depends on `connect_activate`, which
+    // NoSelection does not propagate.
+    let selection = gtk4::SingleSelection::new(Some(sort_model.clone()));
+    selection.set_can_unselect(true);
     let column_view = gtk4::ColumnView::builder()
         .model(&selection)
         .show_column_separators(true)

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -671,25 +671,50 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         });
     }
 
-    // ── Status label: <filtered> / <total> ───────────────────────
-    // Re-evaluated on every store change. `items-changed` fires on
-    // append AND on filter re-evaluation, so this catches both.
-    //
-    // Read the filter-model count off the signal's `model`
-    // argument rather than capturing a strong clone — the latter
-    // creates a self-reference (model owns the handler, handler
-    // owns the model) that would keep the viewer model + store
-    // alive past window close.
+    // ── Status label: <filtered> / <total> on the visible tab ────
+    // Switches wording between "messages" and "aircraft" based on
+    // stack.visible_child_name(). Re-evaluated on:
+    //   - either filter model's items-changed signal
+    //   - stack visible-child-notify
     {
+        let stack = handles.stack.clone();
         let status = handles.status_label.clone();
         let store = handles.store.clone();
-        handles
-            .filter_model
-            .connect_items_changed(move |model, _, _, _| {
-                let filtered = model.n_items();
+        let aircraft_store = handles.aircraft_store.clone();
+        let filter_model = handles.filter_model.clone();
+        let aircraft_filter_model = handles.aircraft_filter_model.clone();
+        let refresh = std::rc::Rc::new(move || {
+            let on_aircraft = stack.visible_child_name().as_deref() == Some("aircraft");
+            if on_aircraft {
+                let filtered = aircraft_filter_model.n_items();
+                let total = aircraft_store.n_items();
+                status.set_label(&format!("{filtered} / {total} aircraft"));
+            } else {
+                let filtered = filter_model.n_items();
                 let total = store.n_items();
                 status.set_label(&format!("{filtered} / {total} messages"));
-            });
+            }
+        });
+
+        // Wire the same refresh closure to all three signal
+        // sources. Each clone is its own move-into-closure so
+        // lifetimes work out.
+        {
+            let r = std::rc::Rc::clone(&refresh);
+            handles
+                .filter_model
+                .connect_items_changed(move |_, _, _, _| r());
+        }
+        {
+            let r = std::rc::Rc::clone(&refresh);
+            handles
+                .aircraft_filter_model
+                .connect_items_changed(move |_, _, _, _| r());
+        }
+        {
+            let r = std::rc::Rc::clone(&refresh);
+            handles.stack.connect_visible_child_notify(move |_| r());
+        }
     }
 
     // Wire close-request to clear the `AppState` weak-ref slot AND

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -510,20 +510,38 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         .hexpand(true)
         .build();
 
-    let content = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-    content.append(&header);
-    content.append(&scroll);
-    window.set_content(Some(&content));
-
-    // Placeholder aircraft store + filter + stack for the
-    // "By Aircraft" tab. Wired to a real column view + click
-    // handlers in subsequent tasks; this stub keeps the
-    // struct buildable so the field additions land cleanly.
+    // Aircraft store + filter + filter model — needed before
+    // `build_aircraft_column_view` is called below.
     let aircraft_store = gtk4::gio::ListStore::new::<AircraftEntryObject>();
     let aircraft_filter = gtk4::CustomFilter::new(|_obj| true);
     let aircraft_filter_model =
         gtk4::FilterListModel::new(Some(aircraft_store.clone()), Some(aircraft_filter.clone()));
+
+    // Build the aircraft column view. Helper returns its own
+    // `ScrolledWindow` so each tab retains its own `GtkAdjustment`
+    // and scroll position independently.
+    let (aircraft_scroll, aircraft_column_view) =
+        build_aircraft_column_view(&aircraft_filter_model);
+
+    // Stack with two pages — Stream (existing) and By Aircraft
+    // (issue #579). Switcher in the header bar between the
+    // existing buttons and the filter entry.
     let stack = gtk4::Stack::new();
+    stack.set_transition_type(gtk4::StackTransitionType::Crossfade);
+    stack.add_titled(&scroll, Some("stream"), "Stream");
+    stack.add_titled(&aircraft_scroll, Some("aircraft"), "By Aircraft");
+
+    let stack_switcher = gtk4::StackSwitcher::builder().stack(&stack).build();
+    // Pack switcher between the action buttons (already
+    // `pack_start`'d) and the filter entry (set as title widget).
+    // `pack_start` preserves declaration order so the switcher
+    // sits to the right of the collapse button.
+    header.pack_start(&stack_switcher);
+
+    let content = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+    content.append(&header);
+    content.append(&stack);
+    window.set_content(Some(&content));
 
     // Hoist handles so all signal handlers below can clone from it.
     let handles = Rc::new(ViewerHandles {
@@ -542,6 +560,26 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         stack,
     });
     *state.acars_viewer_handles.borrow_mut() = Some(Rc::clone(&handles));
+
+    // Click-to-filter (issue #579): double-click / Enter / Space on
+    // an aircraft row sets the filter entry to the tail and switches
+    // to the Stream tab. `GtkColumnView::connect_activate` fires on
+    // double-click / Enter / Space; single click stays as selection.
+    {
+        let handles = Rc::clone(&handles);
+        aircraft_column_view.connect_activate(move |_view, position| {
+            let Some(obj) = handles
+                .aircraft_filter_model
+                .item(position)
+                .and_then(|o| o.downcast::<AircraftEntryObject>().ok())
+            else {
+                return;
+            };
+            let Some(entry) = obj.entry() else { return };
+            handles.filter_entry.set_text(&entry.tail);
+            handles.stack.set_visible_child_name("stream");
+        });
+    }
 
     // ── Clear button ──────────────────────────────────────────────
     {
@@ -663,6 +701,189 @@ where
             _ => gtk4::Ordering::Equal,
         }
     })
+}
+
+/// Aircraft-tab column descriptor. Same shape as [`ColumnSpec`]
+/// but the render closure operates on [`AircraftEntryObject`].
+type AircraftColumnSpec = (&'static str, fn(&AircraftEntryObject) -> String, bool);
+
+/// Build the aircraft-tab column view + scrolled window. Returns
+/// the `ScrolledWindow` so the caller can pack it into the stack.
+/// The column view emits `connect_activate` for click-to-filter;
+/// the caller wires that handler so the activate closure can hold
+/// `Rc`s of the relevant viewer state.
+#[allow(clippy::too_many_lines)]
+fn build_aircraft_column_view(
+    filter_model: &gtk4::FilterListModel,
+) -> (gtk4::ScrolledWindow, gtk4::ColumnView) {
+    let columns: [AircraftColumnSpec; 4] = [
+        ("Aircraft", render_aircraft_tail, false),
+        ("Last Seen", render_aircraft_last_seen, false),
+        ("Count", render_aircraft_count, false),
+        ("Last Label", render_aircraft_last_label, true),
+    ];
+
+    let sorters: [gtk4::CustomSorter; 4] = [
+        // Aircraft tail — case-insensitive alphabetical
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let a_inner = a_obj.imp().inner.borrow();
+            let b_inner = b_obj.imp().inner.borrow();
+            match (a_inner.as_ref(), b_inner.as_ref()) {
+                (Some(a), Some(b)) => cmp_case_insensitive(&a.tail, &b.tail).into(),
+                _ => gtk4::Ordering::Equal,
+            }
+        }),
+        // Last Seen — newest first wins descending sort
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let a_inner = a_obj.imp().inner.borrow();
+            let b_inner = b_obj.imp().inner.borrow();
+            match (a_inner.as_ref(), b_inner.as_ref()) {
+                (Some(a), Some(b)) => a.last_seen.cmp(&b.last_seen).into(),
+                _ => gtk4::Ordering::Equal,
+            }
+        }),
+        // Count — numeric
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let a_inner = a_obj.imp().inner.borrow();
+            let b_inner = b_obj.imp().inner.borrow();
+            match (a_inner.as_ref(), b_inner.as_ref()) {
+                (Some(a), Some(b)) => a.msg_count.cmp(&b.msg_count).into(),
+                _ => gtk4::Ordering::Equal,
+            }
+        }),
+        // Last Label — byte ordering on the 2-char code
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let a_inner = a_obj.imp().inner.borrow();
+            let b_inner = b_obj.imp().inner.borrow();
+            match (a_inner.as_ref(), b_inner.as_ref()) {
+                (Some(a), Some(b)) => a.last_label.cmp(&b.last_label).into(),
+                _ => gtk4::Ordering::Equal,
+            }
+        }),
+    ];
+
+    // `SortListModel` in the chain so column-header clicks reorder
+    // visible rows. Sorter starts as `None`; bound to the column
+    // view's sorter once it exists.
+    let sort_model =
+        gtk4::SortListModel::new(Some(filter_model.clone()), Option::<gtk4::Sorter>::None);
+    let selection = gtk4::NoSelection::new(Some(sort_model.clone()));
+    let column_view = gtk4::ColumnView::builder()
+        .model(&selection)
+        .show_column_separators(true)
+        .show_row_separators(true)
+        .build();
+    sort_model.set_sorter(column_view.sorter().as_ref());
+
+    let mut last_seen_column: Option<gtk4::ColumnViewColumn> = None;
+
+    for (idx, (title, render, expand)) in columns.into_iter().enumerate() {
+        let factory = gtk4::SignalListItemFactory::new();
+        factory.connect_setup(move |_factory, item| {
+            let Some(item) = item.downcast_ref::<gtk4::ListItem>() else {
+                return;
+            };
+            let label = gtk4::Label::builder()
+                .xalign(0.0)
+                .ellipsize(gtk4::pango::EllipsizeMode::End)
+                .build();
+            item.set_child(Some(&label));
+        });
+        factory.connect_bind(move |_factory, item| {
+            let Some(item) = item.downcast_ref::<gtk4::ListItem>() else {
+                return;
+            };
+            let Some(label) = item.child().and_then(|w| w.downcast::<gtk4::Label>().ok()) else {
+                return;
+            };
+            let Some(obj) = item
+                .item()
+                .and_then(|o| o.downcast::<AircraftEntryObject>().ok())
+            else {
+                return;
+            };
+            label.set_text(&render(&obj));
+        });
+        let column = gtk4::ColumnViewColumn::builder()
+            .title(title)
+            .factory(&factory)
+            .resizable(true)
+            .expand(expand)
+            .build();
+        column.set_sorter(Some(&sorters[idx]));
+        if idx == 1 {
+            last_seen_column = Some(column.clone());
+        }
+        column_view.append_column(&column);
+    }
+    // Default sort: Last Seen descending — newest active aircraft
+    // at top, stale entries drift down.
+    if let Some(col) = last_seen_column {
+        column_view.sort_by_column(Some(&col), gtk4::SortType::Descending);
+    }
+
+    let scrolled = gtk4::ScrolledWindow::builder()
+        .child(&column_view)
+        .vexpand(true)
+        .hexpand(true)
+        .build();
+
+    (scrolled, column_view)
+}
+
+fn render_aircraft_tail(obj: &AircraftEntryObject) -> String {
+    obj.entry().map(|e| e.tail.to_string()).unwrap_or_default()
+}
+
+fn render_aircraft_last_seen(obj: &AircraftEntryObject) -> String {
+    let Some(entry) = obj.entry() else {
+        return String::new();
+    };
+    let dt: chrono::DateTime<chrono::Local> = entry.last_seen.into();
+    dt.format("%H:%M:%S").to_string()
+}
+
+fn render_aircraft_count(obj: &AircraftEntryObject) -> String {
+    obj.entry()
+        .map(|e| e.msg_count.to_string())
+        .unwrap_or_default()
+}
+
+fn render_aircraft_last_label(obj: &AircraftEntryObject) -> String {
+    let Some(entry) = obj.entry() else {
+        return String::new();
+    };
+    let raw = std::str::from_utf8(&entry.last_label)
+        .unwrap_or("??")
+        .to_string();
+    match sdr_acars::label::lookup(entry.last_label) {
+        Some(name) => format!("{raw} ({name})"),
+        None => raw,
+    }
 }
 
 /// Render the Time column. Uses the wrapper's `last_seen` (so

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -404,15 +404,16 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         .build();
     sort_model.set_sorter(column_view.sorter().as_ref());
 
-    // Seven columns per spec section "Content":
-    //   Time | Freq | Aircraft | Mode | Label | Block | Text
-    let columns: [ColumnSpec; 7] = [
+    // Eight columns per spec section "Content" (issue #579 adds Ack):
+    //   Time | Freq | Aircraft | Mode | Label | Block | Ack | Text
+    let columns: [ColumnSpec; 8] = [
         ("Time", render_time, false),
         ("Freq", render_freq, false),
         ("Aircraft", render_aircraft, false),
         ("Mode", render_mode, false),
         ("Label", render_label, false),
         ("Block", render_block, false),
+        ("Ack", render_ack, false),
         ("Text", render_text, true),
     ];
 
@@ -421,7 +422,7 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     // clone on the comparator hot path) and falling back to
     // `Ordering::Equal` when the slot is empty (model churn).
     // Issue #585.
-    let sorters: [gtk4::CustomSorter; 7] = [
+    let sorters: [gtk4::CustomSorter; 8] = [
         // Time column sorts on the wrapper's `last_seen`, not
         // the original frame timestamp. After a collapse hit,
         // `record_duplicate` advances `last_seen` in place
@@ -447,6 +448,7 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         make_message_sorter(|a, b| a.mode.cmp(&b.mode)),
         make_message_sorter(|a, b| a.label.cmp(&b.label)),
         make_message_sorter(|a, b| a.block_id.cmp(&b.block_id)),
+        make_message_sorter(|a, b| a.ack.cmp(&b.ack)),
         make_message_sorter(|a, b| cmp_case_insensitive(&a.text, &b.text)),
     ];
 
@@ -712,6 +714,14 @@ fn render_label(obj: &AcarsMessageObject) -> String {
 }
 fn render_block(obj: &AcarsMessageObject) -> String {
     render_inner(obj, |m| char::from(m.block_id).to_string())
+}
+fn render_ack(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| match m.ack {
+        b'\x15' => "NAK".to_string(),
+        b'!' => "!".to_string(),
+        c if c.is_ascii_graphic() => char::from(c).to_string(),
+        c => format!("0x{c:02X}"),
+    })
 }
 fn render_text(obj: &AcarsMessageObject) -> String {
     render_inner(obj, |m| {

--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -371,10 +371,36 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
     // already bounded by `default_recent_keep`, which is the
     // same cap the append site enforces on `store` (CR round 1
     // on PR #587), so this can't push the store past its cap.
+    //
+    // A parallel pass seeds the aircraft_store + aircraft_index
+    // in the same walk so the By Aircraft tab also shows the
+    // retained backlog on reopen (issue #579).
+    let aircraft_store = gtk4::gio::ListStore::new::<AircraftEntryObject>();
+    let aircraft_index_initial: std::cell::RefCell<
+        std::collections::HashMap<arrayvec::ArrayString<8>, AircraftEntryObject>,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
     {
         let recent = state.acars_recent.borrow();
-        for msg in recent.iter().cloned() {
-            store.append(&AcarsMessageObject::new(msg));
+        for msg in recent.iter() {
+            store.append(&AcarsMessageObject::new(msg.clone()));
+
+            // Mirror into aircraft_index + aircraft_store. New
+            // tail → seed an entry with msg_count=0 and let
+            // record_message bring it to 1; existing tail →
+            // record_message bumps in place.
+            let mut idx = aircraft_index_initial.borrow_mut();
+            let obj = idx.entry(msg.aircraft).or_insert_with(|| {
+                let entry = AircraftEntry {
+                    tail: msg.aircraft,
+                    last_seen: msg.timestamp,
+                    msg_count: 0,
+                    last_label: msg.label,
+                };
+                let obj = AircraftEntryObject::new(entry);
+                aircraft_store.append(&obj);
+                obj
+            });
+            obj.record_message(msg);
         }
     }
     let initial_count = store.n_items();
@@ -510,9 +536,9 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         .hexpand(true)
         .build();
 
-    // Aircraft store + filter + filter model — needed before
+    // Aircraft filter + filter model — needed before
     // `build_aircraft_column_view` is called below.
-    let aircraft_store = gtk4::gio::ListStore::new::<AircraftEntryObject>();
+    // `aircraft_store` was declared in the hydration block above.
     let aircraft_filter = gtk4::CustomFilter::new(|_obj| true);
     let aircraft_filter_model =
         gtk4::FilterListModel::new(Some(aircraft_store.clone()), Some(aircraft_filter.clone()));
@@ -556,7 +582,7 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         aircraft_store,
         aircraft_filter,
         aircraft_filter_model,
-        aircraft_index: std::cell::RefCell::new(std::collections::HashMap::new()),
+        aircraft_index: aircraft_index_initial,
         stack,
     });
     *state.acars_viewer_handles.borrow_mut() = Some(Rc::clone(&handles));

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2005,6 +2005,15 @@ fn handle_dsp_message(
             if let Some(handles) = state.acars_viewer_handles.borrow().as_ref()
                 && !handles.pause_button.is_active()
             {
+                // Capture scroll state BEFORE the append. With the
+                // GtkStack wrap (issue #579), GTK shifts the visible
+                // area to preserve content when a new row lands at
+                // position 0 under the descending-time sort. Checking
+                // adj.value() AFTER the append would see the shifted
+                // value and skip the snap-to-top.
+                let adj = handles.scrolled_window.vadjustment();
+                let was_at_top = (adj.value() - adj.lower()).abs() < 1.0;
+
                 let collapse_active = handles.collapse_button.is_active();
                 let mut collapsed_into: Option<u32> = None;
                 if collapse_active {
@@ -2029,58 +2038,45 @@ fn handle_dsp_message(
                         ));
                 }
 
-                // Auto-scroll-to-top if the user is currently
-                // viewing the top of the list. `vadjustment.value`
-                // is the offset from `lower`; ≈ 0 means the user
-                // is at the top, in which case we hold them
-                // pinned to the top so new rows under the active
-                // sort flow into view (newest with the default
-                // time-desc sort). When the user has scrolled
-                // down to read older rows, we leave the adjustment
-                // alone so reading isn't interrupted — they
-                // resume auto-follow by scrolling back up.
-                //
-                // Direct adjustment manipulation rather than
-                // `ColumnView::scroll_to`: that API is gated
-                // behind gtk4 v4_12 and the workspace pins v4_10.
-                let adj = handles.scrolled_window.vadjustment();
-                if (adj.value() - adj.lower()).abs() < 1.0 {
+                // Auto-scroll-to-top: snap back if the user was at
+                // the top before the append. Direct adjustment
+                // manipulation rather than `ColumnView::scroll_to`:
+                // that API is gated behind gtk4 `v4_12` and the
+                // workspace pins `v4_10`.
+                if was_at_top {
                     adj.set_value(adj.lower());
                 }
 
                 // Aircraft-index update (issue #579). Find or
-                // insert the AircraftEntryObject for this tail,
-                // then call record_message to bump count +
-                // monotonic last_seen + last_label. On an
-                // existing-entry hit, manually nudge the
-                // filter/sort models via items_changed since
-                // GListStore doesn't fire that signal on field
-                // mutation of an already-stored object.
+                // insert the AircraftEntryObject for this tail.
+                // New tails initialize with msg_count=1 (already
+                // counting this message) so the column view's bind
+                // reads the correct value on first paint. Existing
+                // tails bump in place via record_message, then we
+                // nudge the filter/sort models via items_changed
+                // since GListStore doesn't fire that signal on
+                // field mutation of an already-stored object.
                 {
                     let mut idx = handles.aircraft_index.borrow_mut();
-                    let inserted = !idx.contains_key(&msg.aircraft);
-                    let obj = idx.entry(msg.aircraft).or_insert_with(|| {
+                    if let Some(obj) = idx.get(&msg.aircraft) {
+                        obj.record_message(&msg);
+                        // O(n) over ~50 aircraft is fine; Clear
+                        // invalidates positions otherwise so we
+                        // re-find each time rather than tracking
+                        // a position field on the object.
+                        if let Some(pos) = handles.aircraft_store.find(obj) {
+                            handles.aircraft_store.items_changed(pos, 1, 1);
+                        }
+                    } else {
                         let entry = crate::acars_viewer::AircraftEntry {
                             tail: msg.aircraft,
                             last_seen: msg.timestamp,
-                            msg_count: 0,
+                            msg_count: 1,
                             last_label: msg.label,
                         };
                         let obj = crate::acars_viewer::AircraftEntryObject::new(entry);
                         handles.aircraft_store.append(&obj);
-                        obj
-                    });
-                    obj.record_message(&msg);
-                    if !inserted {
-                        // O(n) over ~50 aircraft is fine; Clear
-                        // invalidates positions otherwise so we
-                        // re-find each time rather than tracking
-                        // a position field on the object. Spec
-                        // edge-case "Aircraft store doesn't
-                        // auto-redraw on field change".
-                        if let Some(pos) = handles.aircraft_store.find(obj) {
-                            handles.aircraft_store.items_changed(pos, 1, 1);
-                        }
+                        idx.insert(msg.aircraft, obj);
                     }
                 }
             }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2047,6 +2047,42 @@ fn handle_dsp_message(
                 if (adj.value() - adj.lower()).abs() < 1.0 {
                     adj.set_value(adj.lower());
                 }
+
+                // Aircraft-index update (issue #579). Find or
+                // insert the AircraftEntryObject for this tail,
+                // then call record_message to bump count +
+                // monotonic last_seen + last_label. On an
+                // existing-entry hit, manually nudge the
+                // filter/sort models via items_changed since
+                // GListStore doesn't fire that signal on field
+                // mutation of an already-stored object.
+                {
+                    let mut idx = handles.aircraft_index.borrow_mut();
+                    let inserted = !idx.contains_key(&msg.aircraft);
+                    let obj = idx.entry(msg.aircraft).or_insert_with(|| {
+                        let entry = crate::acars_viewer::AircraftEntry {
+                            tail: msg.aircraft,
+                            last_seen: msg.timestamp,
+                            msg_count: 0,
+                            last_label: msg.label,
+                        };
+                        let obj = crate::acars_viewer::AircraftEntryObject::new(entry);
+                        handles.aircraft_store.append(&obj);
+                        obj
+                    });
+                    obj.record_message(&msg);
+                    if !inserted {
+                        // O(n) over ~50 aircraft is fine; Clear
+                        // invalidates positions otherwise so we
+                        // re-find each time rather than tracking
+                        // a position field on the object. Spec
+                        // edge-case "Aircraft store doesn't
+                        // auto-redraw on field change".
+                        if let Some(pos) = handles.aircraft_store.find(obj) {
+                            handles.aircraft_store.items_changed(pos, 1, 1);
+                        }
+                    }
+                }
             }
 
             tracing::trace!(

--- a/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
+++ b/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
@@ -667,7 +667,7 @@ The ACK byte is currently invisible in the viewer — `0x15` (NAK) renders as a 
 | Time | Freq | Aircraft | Mode | Label | Block | Ack | Text |
 ```
 
-`render_ack`: `0x15` → `"NAK"`, `b'!'` → `"!"`, printable ASCII → that char as a string, others → `0xNN` hex.
+`render_ack`: `0x15` → `"NAK"`, `b'!'` → `"!"`, printable ASCII (`0x20..=0x7E`, including space) → that char as a string, others → `0xNN` hex.
 
 - [ ] **Step 1: Add the `render_ack` function**
 
@@ -1042,10 +1042,10 @@ The final `let handles = Rc::new(ViewerHandles { … })` block should now refere
 Add right after the `*state.acars_viewer_handles.borrow_mut() = Some(Rc::clone(&handles));` line:
 
 ```rust
-    // Click-to-filter (issue #579): double-click an aircraft row
+    // Click-to-filter (issue #579): single-click an aircraft row
     // → set filter entry to the tail and switch to Stream tab.
-    // GtkColumnView::connect_activate fires on double-click /
-    // Enter / Space. Single click stays as just selection.
+    // `single_click_activate(true)` on the ColumnView makes a
+    // single click both select AND emit `activate`.
     {
         let handles = Rc::clone(&handles);
         aircraft_column_view.connect_activate(move |_view, position| {
@@ -1095,7 +1095,7 @@ descending; all 4 columns are resizable + sortable. Each tab
 wraps its own ScrolledWindow so per-tab scroll position is
 preserved automatically by GTK.
 
-Click-to-filter: double-click / Enter on an aircraft row sets
+Click-to-filter: single-click / Enter on an aircraft row sets
 the filter entry to the tail and switches to the Stream tab.
 
 Aircraft store/filter/index population happens in subsequent
@@ -1639,7 +1639,7 @@ Hand off to user with:
    - [ ] Open the app, engage ACARS, open the ACARS viewer.
    - [ ] Stream tab shows messages with the existing column layout PLUS a new `Ack` column between Block and Text.
    - [ ] Label column shows `H1 (Crew message)` for known labels and just `H1` (or whatever code) for unknowns.
-   - [ ] ACK column shows `NAK` for `0x15`, the printable char for graphic ASCII, `0xNN` for other bytes.
+   - [ ] ACK column shows `NAK` for `0x15`, the printable char for bytes `0x20..=0x7E` (including space), `0xNN` for other bytes.
 2. **By Aircraft tab populates**
    - [ ] Switch to By Aircraft tab via the GtkStackSwitcher in the header.
    - [ ] Status label changes wording from "messages" to "aircraft".
@@ -1648,7 +1648,7 @@ Hand off to user with:
    - [ ] Stay on aircraft tab. Confirm Count and Last Seen fields bump when new messages arrive from already-seen aircraft.
    - [ ] New aircraft → new row appears (with Count=1).
 4. **Click-to-filter**
-   - [ ] Double-click an aircraft row.
+   - [ ] Single-click an aircraft row.
    - [ ] Filter entry gets the tail. Stack switches to Stream tab. Stream tab shows only that aircraft's messages.
 5. **Filter applies to both tabs**
    - [ ] Type a substring in the filter (e.g. `UA` or `.N`).

--- a/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
+++ b/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
@@ -678,7 +678,10 @@ fn render_ack(obj: &AcarsMessageObject) -> String {
     render_inner(obj, |m| match m.ack {
         b'\x15' => "NAK".to_string(),
         b'!' => "!".to_string(),
-        c if c.is_ascii_graphic() => char::from(c).to_string(),
+        // Printable ASCII range 0x20..=0x7E (inclusive of
+        // space, exclusive of DEL). `is_ascii_graphic`
+        // excludes space, which is a legitimate ACK byte.
+        c if (0x20..=0x7E).contains(&c) => char::from(c).to_string(),
         c => format!("0x{c:02X}"),
     })
 }
@@ -1441,12 +1444,13 @@ Replace the existing Clear-button block (lines 418-432) with:
             handles.aircraft_store.remove_all();
             handles.aircraft_index.borrow_mut().clear();
             state.acars_recent.borrow_mut().clear();
-            // Don't reset acars_total_count — that's the
-            // running total since toggle-on, distinct from the
-            // visible count. Status label refresh in the
-            // items_changed handler recomputes "filtered / total"
-            // from the now-empty filter_model + total_count.
-            handles.status_label.set_label("0 / 0 messages");
+            // Status label is recomputed by the existing
+            // items_changed / visible-child refresh wiring —
+            // both `store.remove_all()` and `aircraft_store
+            // .remove_all()` fire items_changed, which the
+            // tab-aware refresh closure handles. Don't hard-
+            // code wording here; that would leave the aircraft
+            // tab saying "0 / 0 messages" until the next event.
         });
     }
 ```

--- a/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
+++ b/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
@@ -94,7 +94,7 @@ mod tests {
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `cargo test -p sdr-acars label::tests --features sdr-transcription/whisper-cpu`
-Expected: FAIL with `assertion `left == right` failed` for the positive lookups (the stub returns `None` for everything).
+Expected: FAIL with ``assertion `left == right` failed`` for the positive lookups (the stub returns `None` for everything).
 
 - [ ] **Step 3: Replace `lookup` body with the populated table**
 

--- a/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
+++ b/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
@@ -1670,7 +1670,7 @@ Hand off to user with:
    - [ ] Resume. Both tabs resume from current state.
 7. **Clear works on both tabs**
    - [ ] Click Clear. Both tabs empty.
-   - [ ] Status label resets to `0 / 0`.
+   - [ ] Status label resets to `0 / 0 messages` on Stream or `0 / 0 aircraft` on By Aircraft (tab-aware).
 8. **Sort each aircraft column**
    - [ ] Click each header. Confirm: Aircraft column sorts case-insensitively alphabetical, Last Seen descending newest-first / ascending oldest-first, Count descending highest-first / ascending lowest-first, Last Label byte-ordered.
 9. **Reopen retains aircraft state**

--- a/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
+++ b/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
@@ -869,11 +869,18 @@ fn build_aircraft_column_view(
     // view's sorter once it exists.
     let sort_model =
         gtk4::SortListModel::new(Some(filter_model.clone()), Option::<gtk4::Sorter>::None);
-    let selection = gtk4::NoSelection::new(Some(sort_model.clone()));
+    // SingleSelection (vs NoSelection on the Stream tab) so the
+    // column view's `activate` signal fires. Click-to-filter
+    // wiring depends on `connect_activate`; `single_click_activate
+    // (true)` on the ColumnView makes a single click both select
+    // and emit `activate`, matching the "click an aircraft to drill
+    // in" UX. NoSelection suppresses the activate signal entirely.
+    let selection = gtk4::SingleSelection::new(Some(sort_model.clone()));
     let column_view = gtk4::ColumnView::builder()
         .model(&selection)
         .show_column_separators(true)
         .show_row_separators(true)
+        .single_click_activate(true)
         .build();
     sort_model.set_sorter(column_view.sorter().as_ref());
 

--- a/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
+++ b/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
@@ -1,0 +1,1731 @@
+# ACARS Aircraft-Grouped Viewer Tab + Label Names + ACK Column Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "By Aircraft" tab to the ACARS viewer, populate the label-name lookup table so labels render as `H1 (Crew message)`, and add an ACK column to the Stream tab so `0x15` reads as `NAK` — three readability improvements bundled into a single PR.
+
+**Architecture:** A `GtkStack` with `GtkStackSwitcher` replaces the single content area in the ACARS viewer. The new "aircraft" page wraps a second `GtkColumnView` over a parallel `gio::ListStore` of `AircraftEntryObject`s, kept in sync with the message store via a `HashMap<tail, AircraftEntryObject>` index updated at the message-append site in `window.rs`. Click-to-filter (vs tree-list expand) keeps state simple. Label-name lookup gets populated; ACK column slots between Block and Text on the Stream tab.
+
+**Tech Stack:** Rust 1.x, GTK4 v4.10 + libadwaita via `gtk4-rs`, `glib::Object` subclassing, `gio::ListStore` + `FilterListModel` + `SortListModel`, `CustomFilter` + `CustomSorter`. Pure-Rust unit tests via `cargo test`; GTK widget code verified via manual smoke (per project workflow).
+
+**Branch:** `feat/acars-aircraft-tab` (already off `main`, spec already committed at `de39218`).
+
+**Out of scope:** ADS-B cross-correlation (#582), tree-list expand/collapse, custom user-tagged aircraft. See spec § "Out-of-scope items".
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `crates/sdr-acars/src/label.rs` | MODIFY — populate `lookup` from empty stub to ~80-entry static match table; expand tests. |
+| `crates/sdr-ui/src/acars_viewer.rs` | MODIFY — add `AircraftEntryObject` glib subclass + `mod imp_aircraft`; build `GtkStack` with Stream + By Aircraft pages; add aircraft column view, sorters, click-to-filter, ACK column on Stream tab; extend `ViewerHandles`; update Clear handler. |
+| `crates/sdr-ui/src/window.rs` | MODIFY — extend `DspToUi::AcarsMessage` handler arm to update `aircraft_index` (find-or-insert + `record_message` + `items_changed`) when viewer is open and not paused. |
+
+No new files. The new `AircraftEntryObject` lives in a private `mod imp_aircraft` inside `acars_viewer.rs` mirroring the existing `mod imp` for `AcarsMessageObject`.
+
+---
+
+## Workspace Gates
+
+Run after each task that touches Rust source. Per-crate gates are sufficient when a task is isolated to one crate.
+
+```bash
+cargo build --workspace --features sdr-transcription/whisper-cpu
+cargo test --workspace --features sdr-transcription/whisper-cpu
+cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+---
+
+## Task 1: Populate `label.rs` lookup table
+
+**Files:**
+- Modify: `crates/sdr-acars/src/label.rs`
+
+The stub at lines 21-23 always returns `None`. Replace with a static match arm covering ~80 known ACARS labels sourced from sigidwiki, airframes.io public docs, and acarsdeco2 / vdlm2dec public name tables. Names are 1-3 words, terse, no trailing punctuation. Aliases (RB → 26) get a parenthetical hint.
+
+- [ ] **Step 1: Write the failing positive-lookup tests**
+
+Replace the existing `mod tests` body in `crates/sdr-acars/src/label.rs` (currently lines 25-39) with:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_known_labels() {
+        // Spot-check 5 canonical labels across the major code
+        // families (alphanumeric pair, numeric, underscore prefix,
+        // alias). Adding all 80 here would just be a copy of the
+        // table in `lookup` itself.
+        assert_eq!(lookup(*b"H1"), Some("Crew message"));
+        assert_eq!(lookup(*b"Q0"), Some("Link test"));
+        assert_eq!(lookup(*b"M1"), Some("Position report"));
+        assert_eq!(lookup(*b"_d"), Some("General downlink"));
+        assert_eq!(lookup(*b"RB"), Some("Schedule (alias for 26)"));
+    }
+
+    #[test]
+    fn lookup_numeric_labels() {
+        // OOOI events (10-15) are particularly important — the
+        // viewer's UI uses them to highlight gate/wheels events.
+        assert_eq!(lookup(*b"10"), Some("Arrival info"));
+        assert_eq!(lookup(*b"11"), Some("Out (gate)"));
+        assert_eq!(lookup(*b"12"), Some("Off (wheels)"));
+        assert_eq!(lookup(*b"13"), Some("On (wheels)"));
+        assert_eq!(lookup(*b"14"), Some("In (gate)"));
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        // Bogus codes outside the known table should still
+        // resolve to `None` so the viewer falls back to the bare
+        // 2-char code in the column display.
+        assert_eq!(lookup([0xFF, 0xFF]), None);
+        assert_eq!(lookup(*b"ZZ"), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p sdr-acars label::tests --features sdr-transcription/whisper-cpu`
+Expected: FAIL with `assertion `left == right` failed` for the positive lookups (the stub returns `None` for everything).
+
+- [ ] **Step 3: Replace `lookup` body with the populated table**
+
+Replace `pub fn lookup(_code: [u8; 2]) -> Option<&'static str>` (currently at lines 20-23) with:
+
+```rust
+/// Look up the human-readable name for a 2-byte label code.
+/// Returns `Some(name)` for known ACARS labels (~80 entries
+/// covering OOOI events, position reports, weather, ATC, and
+/// ACMS) or `None` for unknown codes. Names are sourced from
+/// the sigidwiki ACARS labels page, airframes.io public docs,
+/// and the open-source `acarsdeco2` / `vdlm2dec` projects'
+/// name tables. ARINC 618 itself is paywalled; `acarsdec`
+/// doesn't ship a name table either, so this is a curated
+/// best-effort list rather than a verbatim port.
+#[must_use]
+pub fn lookup(code: [u8; 2]) -> Option<&'static str> {
+    Some(match &code {
+        // OOOI events (numeric pairs)
+        b"10" => "Arrival info",
+        b"11" => "Out (gate)",
+        b"12" => "Off (wheels)",
+        b"13" => "On (wheels)",
+        b"14" => "In (gate)",
+        b"15" => "Departure",
+        b"16" => "Position",
+        b"17" => "Arrival info",
+        b"1F" => "Free text",
+        b"1G" => "Gate request",
+        b"1H" => "Gate assignment",
+        b"1L" => "Position report",
+        b"1S" => "Schedule",
+        // Departure clearance + datalink (2x)
+        b"20" => "Departure clearance",
+        b"21" => "Departure clearance reply",
+        b"22" => "Pre-departure clearance",
+        b"23" => "Datalink expedite",
+        b"25" => "Position",
+        b"26" => "Schedule",
+        b"27" => "Schedule (revision)",
+        b"2C" => "Position report",
+        b"2N" => "Takeoff time",
+        b"2Z" => "Destination update",
+        // 3x — fuel + maintenance
+        b"30" => "Position report",
+        b"32" => "Position",
+        b"33" => "Fuel report",
+        b"35" => "Position",
+        b"39" => "Maintenance ground report",
+        // 4x — position
+        b"40" => "Position",
+        b"44" => "Position",
+        b"45" => "Position",
+        b"4M" => "Position",
+        b"4N" => "Position",
+        // 5x — OOOI summary
+        b"51" => "Ground service request",
+        b"52" => "Engine maintenance",
+        b"57" => "Position report",
+        b"5U" => "Position",
+        b"5Y" => "OOOI report",
+        b"5Z" => "Schedule",
+        // 7x — voice + tests
+        b"70" => "Voice contact request",
+        b"7A" => "Test message",
+        b"7B" => "Test message",
+        b"7C" => "Test message",
+        // 8x — dispatch + clearance
+        b"80" => "Departure",
+        b"81" => "Position",
+        b"82" => "Free text",
+        b"83" => "Pre-departure clearance",
+        b"8A" => "Engine maintenance",
+        b"8D" => "Dispatch reply",
+        b"8E" => "ETA report",
+        b"8S" => "Schedule",
+        // A-family
+        b"A0" => "Test",
+        b"A6" => "Position",
+        b"A7" => "Pre-departure clearance request",
+        b"A8" => "Position",
+        b"A9" => "Pre-departure clearance reply",
+        b"AA" => "Engine data",
+        // B-family — weather
+        b"B1" => "Weather request",
+        b"B2" => "Weather information",
+        b"B3" => "Weather (text)",
+        b"B4" => "Weather (route)",
+        b"B5" => "Weather (terminal)",
+        b"B6" => "Weather (en-route)",
+        b"B7" => "Weather (clearance)",
+        b"B8" => "Weather (SIGMET)",
+        b"B9" => "Weather (other)",
+        b"BA" => "Weather request",
+        // C-family — ATC
+        b"C0" => "Uplink command",
+        b"C1" => "ATC",
+        b"C2" => "ATC clearance request",
+        b"C3" => "ATC reply",
+        // H-family — free text
+        b"H1" => "Crew message",
+        b"H2" => "Free text uplink",
+        b"H3" => "Free text downlink",
+        // M-family
+        b"M1" => "Position report",
+        // Q-family — control + position + OOOI
+        b"Q0" => "Link test",
+        b"Q1" => "ATIS",
+        b"Q2" => "ACARS network test",
+        b"Q3" => "Voice circuit test",
+        b"Q4" => "Navaids",
+        b"Q5" => "Engine data",
+        b"Q6" => "Engine display data",
+        b"Q7" => "Component maintenance",
+        b"QA" => "Out (gate)",
+        b"QB" => "Off (wheels)",
+        b"QC" => "On (wheels)",
+        b"QD" => "In (gate)",
+        b"QE" => "OOOI summary",
+        b"QF" => "OOOI (extended)",
+        b"QG" => "Position report",
+        b"QH" => "Position",
+        b"QK" => "Voice request",
+        b"QL" => "ATIS (alt)",
+        b"QM" => "Position",
+        b"QN" => "Diversion",
+        b"QP" => "Position",
+        b"QQ" => "Position",
+        b"QR" => "Position",
+        b"QS" => "Diversion",
+        b"QT" => "ACARS request",
+        // RB — alias dispatched the same as 26 in label_parsers
+        b"RB" => "Schedule (alias for 26)",
+        // Underscore prefix — generic up/down link
+        b"_d" => "General downlink",
+        b"_e" => "General uplink",
+        // Unknown
+        _ => return None,
+    })
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p sdr-acars label::tests --features sdr-transcription/whisper-cpu`
+Expected: PASS — `running 3 tests ... test result: ok. 3 passed; 0 failed`.
+
+- [ ] **Step 5: Run clippy + fmt for the crate**
+
+```bash
+cargo clippy -p sdr-acars --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean (no warnings, no diff).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-acars/src/label.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-acars): #579 populate label-name lookup table
+
+Replace the empty v1 stub with a curated ~80-entry static match
+covering OOOI events, position reports, weather, ATC, ACMS, and
+free-text labels. Sources: sigidwiki ACARS labels page,
+airframes.io public docs, acarsdeco2 / vdlm2dec name tables.
+ARINC 618 itself is paywalled; this is a best-effort table
+rather than a verbatim port.
+
+The viewer's `render_label` already calls `label::lookup` and
+formats results as `H1 (Crew message)`, so this populates the
+display end-to-end with no viewer change needed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Define `AircraftEntry` + `AircraftEntryObject` glib subclass
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs`
+
+Add the glib subclass scaffold next to `AcarsMessageObject` (existing `mod imp` at lines 70-111). New module is `mod imp_aircraft`. The wrapper type itself goes after the existing `glib::wrapper!` block and exposes `new(entry: AircraftEntry)`, `entry()` getter, and `record_message(&self, msg: &AcarsMessage)`. Pure data — no GTK widget code yet.
+
+Tests live inline in `crates/sdr-ui/src/acars_viewer.rs::tests` (new module added at file bottom). The existing test convention in this crate uses GTK init via `gtk4::init()` for tests that touch widgets, but `glib::Object` subclasses can be constructed directly without an `Application`.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `crates/sdr-ui/src/acars_viewer.rs` (at the end of the file, after `render_text`):
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use super::*;
+    use arrayvec::ArrayString;
+    use sdr_acars::AcarsMessage;
+
+    fn fixture_message(tail: &str, label: [u8; 2], ts: SystemTime) -> AcarsMessage {
+        let mut aircraft = ArrayString::<8>::new();
+        aircraft.push_str(tail);
+        AcarsMessage {
+            timestamp: ts,
+            freq_hz: 131_550_000.0,
+            channel: 0,
+            mode: b'2',
+            aircraft,
+            label,
+            block_id: b'5',
+            ack: b'!',
+            text: String::new(),
+            msn: ArrayString::new(),
+            flight_id: ArrayString::new(),
+            reassembled_block_count: 1,
+            end_of_message: true,
+            parsed: None,
+        }
+    }
+
+    #[test]
+    fn aircraft_entry_object_record_message_bumps_count() {
+        // GTK glib::Object subclasses can be constructed without
+        // a running GTK Application — `glib::Object::new` works
+        // as long as the type was registered (which happens via
+        // the `#[glib::object_subclass]` macro at module load).
+        gtk4::glib::MainContext::default();
+        let ts = SystemTime::now();
+        let entry = AircraftEntry {
+            tail: {
+                let mut s = ArrayString::<8>::new();
+                s.push_str(".N12345");
+                s
+            },
+            last_seen: ts,
+            msg_count: 0,
+            last_label: *b"H1",
+        };
+        let obj = AircraftEntryObject::new(entry);
+        assert_eq!(obj.entry().unwrap().msg_count, 0);
+
+        let msg = fixture_message(".N12345", *b"M1", ts + Duration::from_secs(1));
+        obj.record_message(&msg);
+        assert_eq!(obj.entry().unwrap().msg_count, 1);
+
+        obj.record_message(&msg);
+        assert_eq!(obj.entry().unwrap().msg_count, 2);
+    }
+
+    #[test]
+    fn aircraft_entry_object_last_seen_monotonic() {
+        gtk4::glib::MainContext::default();
+        let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let entry = AircraftEntry {
+            tail: ArrayString::new(),
+            last_seen: t0,
+            msg_count: 0,
+            last_label: *b"  ",
+        };
+        let obj = AircraftEntryObject::new(entry);
+
+        // Out-of-order timestamps must not regress last_seen.
+        let later = fixture_message("X", *b"H1", t0 + Duration::from_secs(60));
+        let earlier = fixture_message("X", *b"H1", t0 + Duration::from_secs(30));
+        obj.record_message(&later);
+        obj.record_message(&earlier);
+        assert_eq!(obj.entry().unwrap().last_seen, t0 + Duration::from_secs(60));
+    }
+
+    #[test]
+    fn aircraft_entry_object_record_message_updates_label() {
+        gtk4::glib::MainContext::default();
+        let ts = SystemTime::now();
+        let entry = AircraftEntry {
+            tail: ArrayString::new(),
+            last_seen: ts,
+            msg_count: 0,
+            last_label: *b"H1",
+        };
+        let obj = AircraftEntryObject::new(entry);
+        let msg = fixture_message("X", *b"M1", ts);
+        obj.record_message(&msg);
+        assert_eq!(obj.entry().unwrap().last_label, *b"M1");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p sdr-ui acars_viewer::tests --features sdr-transcription/whisper-cpu --no-run`
+Expected: FAIL with `cannot find type 'AircraftEntryObject' in this scope` and similar for `AircraftEntry`.
+
+- [ ] **Step 3: Add `mod imp_aircraft`, the wrapper type, and the impl block**
+
+Add after the existing `mod imp` block (after line 111 in `crates/sdr-ui/src/acars_viewer.rs`):
+
+```rust
+// ── glib::Object wrapper around an AircraftEntry (issue #579) ──
+
+mod imp_aircraft {
+    use std::cell::RefCell;
+
+    use gtk4::glib;
+    use gtk4::glib::subclass::prelude::{ObjectImpl, ObjectSubclass};
+
+    pub struct AircraftEntryObject {
+        pub inner: RefCell<Option<super::AircraftEntry>>,
+    }
+
+    impl Default for AircraftEntryObject {
+        fn default() -> Self {
+            Self {
+                inner: RefCell::new(None),
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for AircraftEntryObject {
+        const NAME: &'static str = "AircraftEntryObject";
+        type Type = super::AircraftEntryObject;
+    }
+
+    impl ObjectImpl for AircraftEntryObject {}
+}
+
+glib::wrapper! {
+    /// Glib subclass wrapping an `AircraftEntry`. Used as the
+    /// row model for the "By Aircraft" tab in the ACARS viewer.
+    /// The aircraft column view's factories + sorters borrow
+    /// the inner `AircraftEntry` via `obj.imp().inner.borrow()`.
+    pub struct AircraftEntryObject(ObjectSubclass<imp_aircraft::AircraftEntryObject>);
+}
+
+/// Per-aircraft summary backing one row of the "By Aircraft"
+/// tab. Mutated in place via [`AircraftEntryObject::record_message`]
+/// — `last_seen` advances monotonically (`max(prev, msg.timestamp)`)
+/// to mirror the same out-of-order discipline as
+/// `AcarsMessageObject::record_duplicate` (CR round 2 on PR #591).
+#[derive(Clone, Debug)]
+pub struct AircraftEntry {
+    pub tail: arrayvec::ArrayString<8>,
+    pub last_seen: std::time::SystemTime,
+    pub msg_count: u32,
+    pub last_label: [u8; 2],
+}
+
+impl AircraftEntryObject {
+    /// Wrap an `AircraftEntry` for insertion into the aircraft
+    /// `gio::ListStore`. Caller should typically seed `msg_count`
+    /// to 0 and immediately invoke [`Self::record_message`] for
+    /// the message that triggered the insert; that gives the new
+    /// row a `msg_count` of 1 with `last_seen` and `last_label`
+    /// taken from the message.
+    #[must_use]
+    pub fn new(entry: AircraftEntry) -> Self {
+        let obj: Self = glib::Object::new();
+        *obj.imp().inner.borrow_mut() = Some(entry);
+        obj
+    }
+
+    /// Borrow-clone of the wrapped entry. Returns `None` only if
+    /// a caller called `take()` (we don't); column-view factories
+    /// can `expect` in their bind closures.
+    #[must_use]
+    pub fn entry(&self) -> Option<AircraftEntry> {
+        self.imp().inner.borrow().clone()
+    }
+
+    /// Record a new message for this aircraft: bumps `msg_count`,
+    /// advances `last_seen` monotonically to
+    /// `max(last_seen, msg.timestamp)`, and overwrites
+    /// `last_label`. Same out-of-order discipline as
+    /// `AcarsMessageObject::record_duplicate`.
+    pub fn record_message(&self, msg: &sdr_acars::AcarsMessage) {
+        let imp = self.imp();
+        let mut slot = imp.inner.borrow_mut();
+        let Some(entry) = slot.as_mut() else { return };
+        entry.msg_count = entry.msg_count.saturating_add(1);
+        entry.last_seen = std::cmp::max(entry.last_seen, msg.timestamp);
+        entry.last_label = msg.label;
+    }
+}
+```
+
+You also need to import `glib::subclass::prelude::ObjectSubclassIsExt` if not already in scope (it's already imported at the top via line 13 — verify).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p sdr-ui acars_viewer::tests --features sdr-transcription/whisper-cpu`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 5: Run clippy + fmt**
+
+```bash
+cargo clippy -p sdr-ui --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-ui/src/acars_viewer.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 add AircraftEntryObject glib subclass
+
+Backs the upcoming "By Aircraft" tab in the ACARS viewer with a
+glib::Object subclass wrapping an AircraftEntry summary (tail,
+last_seen, msg_count, last_label). Mirrors the AcarsMessageObject
+pattern in the same file: a private mod imp_aircraft holds the
+RefCell<Option<…>> slot, the wrapper type exposes new/entry/
+record_message, and last_seen updates monotonically the same way
+record_duplicate does on the message wrapper.
+
+Pure data — column view + store wiring lands in subsequent tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Extend `ViewerHandles` with aircraft store + index + stack
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs:25-46`
+
+Add the new fields to `ViewerHandles` so the message-append site in `window.rs` can reach them via `state.acars_viewer_handles`.
+
+- [ ] **Step 1: Extend the struct**
+
+Replace the existing `pub struct ViewerHandles { … }` (lines 25-46 in `acars_viewer.rs`) with:
+
+```rust
+pub struct ViewerHandles {
+    pub store: gtk4::gio::ListStore,
+    pub filter: gtk4::CustomFilter,
+    pub filter_model: gtk4::FilterListModel,
+    pub status_label: gtk4::Label,
+    pub pause_button: gtk4::ToggleButton,
+    pub filter_entry: gtk4::SearchEntry,
+    /// Collapse-duplicates toggle (issue #586). When active,
+    /// the message-append site walks the most recent rows for
+    /// a `(aircraft, mode, label, text)` key match within the
+    /// recency window and bumps the existing row's count + last
+    /// seen instead of appending a new one.
+    pub collapse_button: gtk4::ToggleButton,
+    /// `ScrolledWindow` for the auto-scroll-to-top behavior on
+    /// new arrivals. The append site checks whether the user is
+    /// at the top via `vadjustment().value()` and resets the
+    /// adjustment back to its lower bound — if they've manually
+    /// scrolled down to read older rows, auto-follow freezes
+    /// until they scroll back. Bypasses `ColumnView::scroll_to`
+    /// which needs gtk4 `v4_12` (workspace is on `v4_10`).
+    pub scrolled_window: gtk4::ScrolledWindow,
+    /// "By Aircraft" tab parallel store, one row per unique
+    /// tail seen since session start. Issue #579.
+    pub aircraft_store: gtk4::gio::ListStore,
+    /// Filter applied to `aircraft_store`. Same `filter_entry`
+    /// drives both this and the stream `filter`; this one
+    /// matches tail substring only (no label/text — those don't
+    /// exist on aircraft rows).
+    pub aircraft_filter: gtk4::CustomFilter,
+    /// FilterListModel wrapping `aircraft_store` for the
+    /// aircraft column view.
+    pub aircraft_filter_model: gtk4::FilterListModel,
+    /// O(1) tail → AircraftEntryObject lookup so the message-
+    /// append site in `window.rs` can find-or-insert without
+    /// scanning the store. Holds clones of the same glib
+    /// objects that live in `aircraft_store`; updates flow
+    /// through to the column view via the shared refcount.
+    pub aircraft_index: std::cell::RefCell<
+        std::collections::HashMap<arrayvec::ArrayString<8>, AircraftEntryObject>,
+    >,
+    /// `GtkStack` switching between the "stream" page (existing
+    /// chronological view) and "aircraft" page (per-tail
+    /// summary). Cloned into the click-to-filter handler on the
+    /// aircraft column view to switch back to the stream tab.
+    pub stack: gtk4::Stack,
+}
+```
+
+- [ ] **Step 2: Verify the struct still compiles (no consumers updated yet)**
+
+Run: `cargo check -p sdr-ui --features sdr-transcription/whisper-cpu`
+Expected: FAIL with `missing fields aircraft_store, aircraft_filter, …` at the existing `ViewerHandles { store, … }` initializer at line 406.
+
+- [ ] **Step 3: Stub the new fields at the construction site**
+
+In `crates/sdr-ui/src/acars_viewer.rs`, find the `let handles = Rc::new(ViewerHandles { … })` block (currently around line 406). Modify it to:
+
+```rust
+    // Placeholder aircraft store + filter + stack for the
+    // "By Aircraft" tab. Wired to a real column view + click
+    // handlers in subsequent tasks; this stub keeps the
+    // struct buildable so the field additions land cleanly.
+    let aircraft_store = gtk4::gio::ListStore::new::<AircraftEntryObject>();
+    let aircraft_filter = gtk4::CustomFilter::new(|_obj| true);
+    let aircraft_filter_model =
+        gtk4::FilterListModel::new(Some(aircraft_store.clone()), Some(aircraft_filter.clone()));
+    let stack = gtk4::Stack::new();
+
+    // Hoist handles so all signal handlers below can clone from it.
+    let handles = Rc::new(ViewerHandles {
+        store,
+        filter,
+        filter_model,
+        status_label: status_label.clone(),
+        pause_button: pause_button.clone(),
+        filter_entry: filter_entry.clone(),
+        collapse_button: collapse_button.clone(),
+        scrolled_window: scroll.clone(),
+        aircraft_store,
+        aircraft_filter,
+        aircraft_filter_model,
+        aircraft_index: std::cell::RefCell::new(std::collections::HashMap::new()),
+        stack,
+    });
+```
+
+- [ ] **Step 4: Verify it builds**
+
+Run: `cargo check -p sdr-ui --features sdr-transcription/whisper-cpu`
+Expected: PASS (warnings about `aircraft_store` etc. being unused are OK at this checkpoint — they'll be wired up in later tasks; suppress with `#[allow(dead_code)]` only if clippy fails).
+
+Run: `cargo clippy -p sdr-ui --features sdr-transcription/whisper-cpu --all-targets -- -D warnings`
+Expected: PASS. Clippy may flag unused fields on the stub — if so, those fields are about to be used in later tasks, but for this commit we want clippy clean. Add `#[allow(dead_code)]` to the new fields if needed. Do NOT add any other allow attributes.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p sdr-ui --features sdr-transcription/whisper-cpu`
+Expected: PASS — 3 tests from Task 2 still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-ui/src/acars_viewer.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 extend ViewerHandles with aircraft store + index + stack
+
+Adds the fields the message-append site in window.rs will use to
+find-or-insert an AircraftEntryObject and bump the matching row's
+count/timestamp. Stubs the construction site with empty store +
+no-op filter so subsequent tasks can wire the column view
+incrementally without breaking compilation between commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add ACK column to Stream tab
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs` — `columns` array + `sorters` array + new `render_ack` function
+
+The ACK byte is currently invisible in the viewer — `0x15` (NAK) renders as a control char glyph or empty cell on most fonts. New 8th column slots between Block and Text:
+
+```text
+| Time | Freq | Aircraft | Mode | Label | Block | Ack | Text |
+```
+
+`render_ack`: `0x15` → `"NAK"`, `b'!'` → `"!"`, printable ASCII → that char as a string, others → `0xNN` hex.
+
+- [ ] **Step 1: Add the `render_ack` function**
+
+Insert after `render_block` (currently at line 587-589 in `acars_viewer.rs`):
+
+```rust
+fn render_ack(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| match m.ack {
+        b'\x15' => "NAK".to_string(),
+        b'!' => "!".to_string(),
+        c if c.is_ascii_graphic() => char::from(c).to_string(),
+        c => format!("0x{c:02X}"),
+    })
+}
+```
+
+- [ ] **Step 2: Extend the columns + sorters arrays**
+
+In `build_acars_viewer_window` (currently around lines 296-340), update the `ColumnSpec` count from 7 to 8 and add the Ack column between Block and Text:
+
+```rust
+    // Eight columns per spec section "Content" (issue #579 adds Ack):
+    //   Time | Freq | Aircraft | Mode | Label | Block | Ack | Text
+    let columns: [ColumnSpec; 8] = [
+        ("Time", render_time, false),
+        ("Freq", render_freq, false),
+        ("Aircraft", render_aircraft, false),
+        ("Mode", render_mode, false),
+        ("Label", render_label, false),
+        ("Block", render_block, false),
+        ("Ack", render_ack, false),
+        ("Text", render_text, true),
+    ];
+
+    // Per-column sorters. (See header comment on the previous
+    // sorters block — same `make_message_sorter` helper.)
+    let sorters: [gtk4::CustomSorter; 8] = [
+        // Time column sorts on the wrapper's `last_seen`, not
+        // the original frame timestamp. After a collapse hit,
+        // `record_duplicate` advances `last_seen` in place
+        // without moving the row in the store; sorting on
+        // `inner.timestamp` would leave the refreshed row
+        // stranded at its original position. Issue #586 / CR
+        // round 1 on PR #591.
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AcarsMessageObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AcarsMessageObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            a_obj.last_seen().cmp(&b_obj.last_seen()).into()
+        }),
+        make_message_sorter(|a, b| {
+            a.freq_hz
+                .partial_cmp(&b.freq_hz)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }),
+        make_message_sorter(|a, b| cmp_case_insensitive(&a.aircraft, &b.aircraft)),
+        make_message_sorter(|a, b| a.mode.cmp(&b.mode)),
+        make_message_sorter(|a, b| a.label.cmp(&b.label)),
+        make_message_sorter(|a, b| a.block_id.cmp(&b.block_id)),
+        make_message_sorter(|a, b| a.ack.cmp(&b.ack)),
+        make_message_sorter(|a, b| cmp_case_insensitive(&a.text, &b.text)),
+    ];
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `cargo build -p sdr-ui --features sdr-transcription/whisper-cpu`
+Expected: PASS.
+
+Run: `cargo clippy -p sdr-ui --features sdr-transcription/whisper-cpu --all-targets -- -D warnings`
+Expected: clean.
+
+Run: `cargo test -p sdr-ui --features sdr-transcription/whisper-cpu`
+Expected: PASS (existing 3 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/acars_viewer.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 add Ack column to ACARS Stream tab
+
+Slots between Block and Text. Renders 0x15 as "NAK" (the most
+common case — ACARS negative-ack), '!' as itself, other printable
+ASCII as the char, and everything else as a 0xNN hex escape.
+Sortable on the raw byte. Closes the gap where the ACK byte was
+rendering as a control-char glyph or empty cell on the default
+column font.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Build the aircraft column view
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs`
+
+Build a second `GtkColumnView` over `aircraft_filter_model` with 4 columns: Aircraft, Last Seen, Count, Last Label. Default sort: Last Seen descending. The column view goes inside its own `ScrolledWindow` (so each tab keeps its own scroll position). Stack switcher and stack itself wired in Task 6.
+
+- [ ] **Step 1: Add a helper for building the aircraft column view**
+
+Add to `crates/sdr-ui/src/acars_viewer.rs` (place right after `make_message_sorter`, around line 538):
+
+```rust
+/// Aircraft-tab column descriptor. Same shape as `ColumnSpec`
+/// but the render closure operates on `AircraftEntryObject`.
+type AircraftColumnSpec = (&'static str, fn(&AircraftEntryObject) -> String, bool);
+
+/// Build the aircraft-tab column view + scrolled window. Returns
+/// the `ScrolledWindow` so the caller can pack it into the stack.
+/// The column view emits `connect_activate` for click-to-filter;
+/// the caller wires that handler so the activate closure can hold
+/// `Rc`s of the relevant viewer state.
+fn build_aircraft_column_view(
+    filter_model: &gtk4::FilterListModel,
+) -> (gtk4::ScrolledWindow, gtk4::ColumnView) {
+    let columns: [AircraftColumnSpec; 4] = [
+        ("Aircraft", render_aircraft_tail, false),
+        ("Last Seen", render_aircraft_last_seen, false),
+        ("Count", render_aircraft_count, false),
+        ("Last Label", render_aircraft_last_label, true),
+    ];
+
+    let sorters: [gtk4::CustomSorter; 4] = [
+        // Aircraft tail — case-insensitive alphabetical
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let a_inner = a_obj.imp().inner.borrow();
+            let b_inner = b_obj.imp().inner.borrow();
+            match (a_inner.as_ref(), b_inner.as_ref()) {
+                (Some(a), Some(b)) => cmp_case_insensitive(&a.tail, &b.tail).into(),
+                _ => gtk4::Ordering::Equal,
+            }
+        }),
+        // Last Seen — newest first wins descending sort
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let a_inner = a_obj.imp().inner.borrow();
+            let b_inner = b_obj.imp().inner.borrow();
+            match (a_inner.as_ref(), b_inner.as_ref()) {
+                (Some(a), Some(b)) => a.last_seen.cmp(&b.last_seen).into(),
+                _ => gtk4::Ordering::Equal,
+            }
+        }),
+        // Count — numeric
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let a_inner = a_obj.imp().inner.borrow();
+            let b_inner = b_obj.imp().inner.borrow();
+            match (a_inner.as_ref(), b_inner.as_ref()) {
+                (Some(a), Some(b)) => a.msg_count.cmp(&b.msg_count).into(),
+                _ => gtk4::Ordering::Equal,
+            }
+        }),
+        // Last Label — byte ordering on the 2-char code
+        gtk4::CustomSorter::new(|a, b| {
+            let Some(a_obj) = a.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let Some(b_obj) = b.downcast_ref::<AircraftEntryObject>() else {
+                return gtk4::Ordering::Equal;
+            };
+            let a_inner = a_obj.imp().inner.borrow();
+            let b_inner = b_obj.imp().inner.borrow();
+            match (a_inner.as_ref(), b_inner.as_ref()) {
+                (Some(a), Some(b)) => a.last_label.cmp(&b.last_label).into(),
+                _ => gtk4::Ordering::Equal,
+            }
+        }),
+    ];
+
+    // SortListModel in the chain so column-header clicks reorder
+    // visible rows. Sorter starts as None; bound to the column
+    // view's sorter once it exists.
+    let sort_model =
+        gtk4::SortListModel::new(Some(filter_model.clone()), Option::<gtk4::Sorter>::None);
+    let selection = gtk4::NoSelection::new(Some(sort_model.clone()));
+    let column_view = gtk4::ColumnView::builder()
+        .model(&selection)
+        .show_column_separators(true)
+        .show_row_separators(true)
+        .build();
+    sort_model.set_sorter(column_view.sorter().as_ref());
+
+    let mut last_seen_column: Option<gtk4::ColumnViewColumn> = None;
+
+    for (idx, (title, render, expand)) in columns.into_iter().enumerate() {
+        let factory = gtk4::SignalListItemFactory::new();
+        factory.connect_setup(move |_factory, item| {
+            let Some(item) = item.downcast_ref::<gtk4::ListItem>() else {
+                return;
+            };
+            let label = gtk4::Label::builder()
+                .xalign(0.0)
+                .ellipsize(gtk4::pango::EllipsizeMode::End)
+                .build();
+            item.set_child(Some(&label));
+        });
+        factory.connect_bind(move |_factory, item| {
+            let Some(item) = item.downcast_ref::<gtk4::ListItem>() else {
+                return;
+            };
+            let Some(label) = item.child().and_then(|w| w.downcast::<gtk4::Label>().ok()) else {
+                return;
+            };
+            let Some(obj) = item
+                .item()
+                .and_then(|o| o.downcast::<AircraftEntryObject>().ok())
+            else {
+                return;
+            };
+            label.set_text(&render(&obj));
+        });
+        let column = gtk4::ColumnViewColumn::builder()
+            .title(title)
+            .factory(&factory)
+            .resizable(true)
+            .expand(expand)
+            .build();
+        column.set_sorter(Some(&sorters[idx]));
+        if idx == 1 {
+            last_seen_column = Some(column.clone());
+        }
+        column_view.append_column(&column);
+    }
+    // Default sort: Last Seen descending — newest active aircraft
+    // at top, stale entries drift down.
+    if let Some(col) = last_seen_column {
+        column_view.sort_by_column(Some(&col), gtk4::SortType::Descending);
+    }
+
+    let scrolled = gtk4::ScrolledWindow::builder()
+        .child(&column_view)
+        .vexpand(true)
+        .hexpand(true)
+        .build();
+
+    (scrolled, column_view)
+}
+
+fn render_aircraft_tail(obj: &AircraftEntryObject) -> String {
+    obj.entry().map(|e| e.tail.to_string()).unwrap_or_default()
+}
+
+fn render_aircraft_last_seen(obj: &AircraftEntryObject) -> String {
+    let Some(entry) = obj.entry() else { return String::new() };
+    let dt: chrono::DateTime<chrono::Local> = entry.last_seen.into();
+    dt.format("%H:%M:%S").to_string()
+}
+
+fn render_aircraft_count(obj: &AircraftEntryObject) -> String {
+    obj.entry().map(|e| e.msg_count.to_string()).unwrap_or_default()
+}
+
+fn render_aircraft_last_label(obj: &AircraftEntryObject) -> String {
+    let Some(entry) = obj.entry() else { return String::new() };
+    let raw = std::str::from_utf8(&entry.last_label)
+        .unwrap_or("??")
+        .to_string();
+    match sdr_acars::label::lookup(entry.last_label) {
+        Some(name) => format!("{raw} ({name})"),
+        None => raw,
+    }
+}
+```
+
+- [ ] **Step 2: Verify it builds (helper not yet called)**
+
+Run: `cargo build -p sdr-ui --features sdr-transcription/whisper-cpu`
+Expected: PASS, but with a `dead_code` warning on `build_aircraft_column_view` if it isn't called yet. This is intentional — Task 6 wires it up. If clippy fails on this, add a temporary `#[allow(dead_code)]` to the helper that you'll remove in Task 6. **Do not commit until Task 6 is done** so the column view actually shows up in the UI in this commit pair.
+
+- [ ] **Step 3: Skip commit — bundle with Task 6**
+
+Continue to Task 6 without committing. The column view helper is meaningless without the stack wiring.
+
+---
+
+## Task 6: Build the GtkStack with Stream + By Aircraft pages
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs`
+
+Replace the single-`ScrolledWindow` content area with a `GtkStack` containing both pages and a `GtkStackSwitcher` in the header bar. The stack reuses the `stack` field of `ViewerHandles` (currently a placeholder built in Task 3).
+
+- [ ] **Step 1: Wire the stack into the window content area**
+
+In `build_acars_viewer_window`, find the existing block (currently around lines 394-403):
+
+```rust
+    let scroll = gtk4::ScrolledWindow::builder()
+        .child(&column_view)
+        .vexpand(true)
+        .hexpand(true)
+        .build();
+
+    let content = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+    content.append(&header);
+    content.append(&scroll);
+    window.set_content(Some(&content));
+```
+
+Replace with:
+
+```rust
+    let scroll = gtk4::ScrolledWindow::builder()
+        .child(&column_view)
+        .vexpand(true)
+        .hexpand(true)
+        .build();
+
+    // Build the aircraft column view. Helper returns its own
+    // ScrolledWindow so each tab retains its own GtkAdjustment
+    // and scroll position independently.
+    let (aircraft_scroll, aircraft_column_view) =
+        build_aircraft_column_view(&aircraft_filter_model);
+
+    // Stack with two pages — Stream (existing) and By Aircraft
+    // (issue #579). Switcher in the header bar between the
+    // existing buttons and the filter entry.
+    let stack = gtk4::Stack::new();
+    stack.set_transition_type(gtk4::StackTransitionType::Crossfade);
+    stack.add_titled(&scroll, Some("stream"), "Stream");
+    stack.add_titled(&aircraft_scroll, Some("aircraft"), "By Aircraft");
+
+    let stack_switcher = gtk4::StackSwitcher::builder()
+        .stack(&stack)
+        .build();
+    // Pack switcher between the action buttons (already
+    // pack_start'd) and the filter entry (set as title widget).
+    // pack_start preserves declaration order so the switcher
+    // sits to the right of the collapse button.
+    header.pack_start(&stack_switcher);
+
+    let content = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+    content.append(&header);
+    content.append(&stack);
+    window.set_content(Some(&content));
+```
+
+- [ ] **Step 2: Update the `ViewerHandles { … }` initializer to use the real stack**
+
+The block from Task 3 currently constructs an empty placeholder `let stack = gtk4::Stack::new();`. Remove that placeholder line and the placeholder `aircraft_store` / `aircraft_filter` / `aircraft_filter_model` declarations — they need to be hoisted to BEFORE `build_aircraft_column_view` is called so the helper can reference `aircraft_filter_model`.
+
+Concretely: move the four `let aircraft_store = …; let aircraft_filter = …; let aircraft_filter_model = …;` declarations from the (Task 3) placeholder block to right before `build_aircraft_column_view(&aircraft_filter_model)`. Drop the placeholder `let stack = gtk4::Stack::new();` (the real stack from Step 1 above is what gets stored).
+
+The final `let handles = Rc::new(ViewerHandles { … })` block should now reference the real `stack` variable.
+
+- [ ] **Step 3: Wire click-to-filter on the aircraft column view**
+
+Add right after the `*state.acars_viewer_handles.borrow_mut() = Some(Rc::clone(&handles));` line:
+
+```rust
+    // Click-to-filter (issue #579): double-click an aircraft row
+    // → set filter entry to the tail and switch to Stream tab.
+    // GtkColumnView::connect_activate fires on double-click /
+    // Enter / Space. Single click stays as just selection.
+    {
+        let handles = Rc::clone(&handles);
+        aircraft_column_view.connect_activate(move |_view, position| {
+            let Some(obj) = handles
+                .aircraft_filter_model
+                .item(position)
+                .and_then(|o| o.downcast::<AircraftEntryObject>().ok())
+            else {
+                return;
+            };
+            let Some(entry) = obj.entry() else { return };
+            handles.filter_entry.set_text(&entry.tail);
+            handles.stack.set_visible_child_name("stream");
+        });
+    }
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `cargo build -p sdr-ui --features sdr-transcription/whisper-cpu`
+Expected: PASS.
+
+Run: `cargo clippy -p sdr-ui --features sdr-transcription/whisper-cpu --all-targets -- -D warnings`
+Expected: clean. If you added `#[allow(dead_code)]` to `build_aircraft_column_view` in Task 5, remove it now — the function is called.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p sdr-ui --features sdr-transcription/whisper-cpu`
+Expected: PASS — 3 existing tests still pass.
+
+- [ ] **Step 6: Commit Task 5 + Task 6 together**
+
+```bash
+git add crates/sdr-ui/src/acars_viewer.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 add "By Aircraft" tab to ACARS viewer
+
+Replaces the single ScrolledWindow content area with a GtkStack
+holding two pages:
+  - "stream" — existing chronological message column view
+  - "aircraft" — new per-tail summary (Aircraft, Last Seen,
+    Count, Last Label)
+
+GtkStackSwitcher in the header bar between the action buttons
+and the filter entry. Default aircraft-tab sort is Last Seen
+descending; all 4 columns are resizable + sortable. Each tab
+wraps its own ScrolledWindow so per-tab scroll position is
+preserved automatically by GTK.
+
+Click-to-filter: double-click / Enter on an aircraft row sets
+the filter entry to the tail and switches to the Stream tab.
+
+Aircraft store/filter/index population happens in subsequent
+tasks (hydration on viewer open, message-append site update,
+filter handler split).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Hydrate `aircraft_index` from `acars_recent` on viewer open
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs`
+
+The viewer currently hydrates the message store from `state.acars_recent` on open (lines 263-268). Add a parallel pass that walks the same ring and populates `aircraft_store` + `aircraft_index`.
+
+- [ ] **Step 1: Replace the hydration block**
+
+Find the existing block (around lines 263-268):
+
+```rust
+    {
+        let recent = state.acars_recent.borrow();
+        for msg in recent.iter().cloned() {
+            store.append(&AcarsMessageObject::new(msg));
+        }
+    }
+```
+
+Replace with:
+
+```rust
+    let aircraft_store = gtk4::gio::ListStore::new::<AircraftEntryObject>();
+    let aircraft_index_initial: std::collections::HashMap<
+        arrayvec::ArrayString<8>,
+        AircraftEntryObject,
+    > = std::collections::HashMap::new();
+    let aircraft_index_initial =
+        std::cell::RefCell::new(aircraft_index_initial);
+    {
+        let recent = state.acars_recent.borrow();
+        for msg in recent.iter() {
+            store.append(&AcarsMessageObject::new(msg.clone()));
+
+            // Mirror into aircraft_index + aircraft_store. New
+            // tail → seed an entry with msg_count=0 and let
+            // record_message bring it to 1; existing tail →
+            // record_message bumps in place.
+            let mut idx = aircraft_index_initial.borrow_mut();
+            let obj = idx.entry(msg.aircraft).or_insert_with(|| {
+                let entry = AircraftEntry {
+                    tail: msg.aircraft,
+                    last_seen: msg.timestamp,
+                    msg_count: 0,
+                    last_label: msg.label,
+                };
+                let obj = AircraftEntryObject::new(entry);
+                aircraft_store.append(&obj);
+                obj
+            });
+            obj.record_message(msg);
+        }
+    }
+```
+
+- [ ] **Step 2: Update the placeholder declaration block to use the hydrated values**
+
+The placeholder block from Tasks 3 + 6 currently constructs `aircraft_store` + `aircraft_filter` + `aircraft_filter_model`. Replace its `let aircraft_store = gtk4::gio::ListStore::new::<AircraftEntryObject>();` with code that consumes the hydrated values. Concretely, remove that line — we already declared and populated `aircraft_store` in the hydration block above. Move the `aircraft_filter` + `aircraft_filter_model` declarations to remain after hydration.
+
+The final layout in `build_acars_viewer_window` should be:
+
+```rust
+    // (existing message store + aircraft hydration block from Step 1)
+    let initial_count = store.n_items();
+    // (existing status_label + header pack_* lines)
+    // (existing filter / filter_model / sort_model / column_view block)
+
+    // Build aircraft filter + model AFTER aircraft_store is
+    // populated — FilterListModel ::new takes a model reference
+    // so this is order-flexible, but keeping the declaration
+    // close to the consumer (build_aircraft_column_view) makes
+    // the data flow obvious.
+    let aircraft_filter = gtk4::CustomFilter::new(|_obj| true);
+    let aircraft_filter_model =
+        gtk4::FilterListModel::new(Some(aircraft_store.clone()), Some(aircraft_filter.clone()));
+
+    let (aircraft_scroll, aircraft_column_view) =
+        build_aircraft_column_view(&aircraft_filter_model);
+
+    // (existing stack construction)
+
+    // (existing handles construction — using the now-real
+    // aircraft_store, aircraft_filter, aircraft_filter_model,
+    // and aircraft_index_initial.into_inner())
+```
+
+In the `let handles = Rc::new(ViewerHandles { … })` block, set:
+
+```rust
+        aircraft_index: aircraft_index_initial,
+```
+
+(The `aircraft_index_initial` `RefCell` becomes the `ViewerHandles::aircraft_index` field directly — no `into_inner()` needed because the field type is `RefCell<HashMap<…, …>>`.)
+
+- [ ] **Step 3: Verify build + tests + clippy**
+
+```bash
+cargo build -p sdr-ui --features sdr-transcription/whisper-cpu
+cargo clippy -p sdr-ui --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo test -p sdr-ui --features sdr-transcription/whisper-cpu
+cargo fmt --all -- --check
+```
+
+Expected: all clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/acars_viewer.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 hydrate aircraft index from acars_recent on open
+
+Mirrors the existing message-store hydration: walks the bounded
+ACARS ring and seeds the per-tail aircraft_index + aircraft_store
+so reopening the viewer mid-session shows the retained backlog
+on the By Aircraft tab instead of an empty table. Same loop as
+the messages — single pass, hash-map find-or-insert, record_message
+to bump count + monotonic last_seen.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Update filter handler to drive both Stream + Aircraft filters
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs`
+
+The existing `connect_search_changed` handler (lines 437-462) updates only the message `filter`. Extend it to also update `aircraft_filter` — same `needle`, but matches tail substring only.
+
+- [ ] **Step 1: Replace the filter handler block**
+
+Find the `// ── Filter: live substring match on aircraft + label + text ──` block (currently lines 434-463). Replace with:
+
+```rust
+    // ── Filter: live substring match across both tabs ────────────
+    // Stream tab: aircraft + label + text. Aircraft tab: tail only
+    // (label/text don't exist on aircraft rows).
+    {
+        let filter = handles.filter.clone();
+        let aircraft_filter = handles.aircraft_filter.clone();
+        let entry = handles.filter_entry.clone();
+        entry.connect_search_changed(move |entry| {
+            let needle_str: String = entry.text().as_str().to_lowercase();
+
+            // Stream filter — existing logic unchanged.
+            let stream_needle = needle_str.clone();
+            filter.set_filter_func(move |obj| {
+                let Some(obj) = obj.downcast_ref::<AcarsMessageObject>() else {
+                    return false;
+                };
+                let inner = obj.imp().inner.borrow();
+                let Some(msg) = inner.as_ref() else {
+                    return false;
+                };
+                if stream_needle.is_empty() {
+                    return true;
+                }
+                let needle = &stream_needle;
+                msg.aircraft.to_lowercase().contains(needle)
+                    || std::str::from_utf8(&msg.label)
+                        .is_ok_and(|s| s.to_lowercase().contains(needle))
+                    || msg.text.to_lowercase().contains(needle)
+            });
+
+            // Aircraft filter — tail substring only.
+            let aircraft_needle = needle_str;
+            aircraft_filter.set_filter_func(move |obj| {
+                let Some(obj) = obj.downcast_ref::<AircraftEntryObject>() else {
+                    return false;
+                };
+                let inner = obj.imp().inner.borrow();
+                let Some(entry) = inner.as_ref() else {
+                    return false;
+                };
+                if aircraft_needle.is_empty() {
+                    return true;
+                }
+                entry.tail.to_lowercase().contains(&aircraft_needle)
+            });
+        });
+    }
+```
+
+- [ ] **Step 2: Verify build + clippy + tests**
+
+```bash
+cargo build -p sdr-ui --features sdr-transcription/whisper-cpu
+cargo clippy -p sdr-ui --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo test -p sdr-ui --features sdr-transcription/whisper-cpu
+cargo fmt --all -- --check
+```
+
+Expected: all clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-ui/src/acars_viewer.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 share filter entry across Stream + Aircraft tabs
+
+Extends the existing connect_search_changed handler to update both
+filter and aircraft_filter from the same needle. Stream filter
+matches aircraft + label + text (existing semantics); aircraft
+filter matches tail substring only (label/text don't exist on
+aircraft rows).
+
+Empty filter shows everything on both tabs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Switch status-label wording based on visible tab
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs`
+
+Status label currently shows `"{filtered} / {total} messages"`. On the aircraft tab, it should show `"{filtered} / {total} aircraft"`. Wire the existing `connect_items_changed` to also re-evaluate when the stack swaps tabs.
+
+- [ ] **Step 1: Add a helper that refreshes status from whichever tab is visible**
+
+Find the existing status-label block (currently lines 465-484). Replace it with:
+
+```rust
+    // ── Status label: <filtered> / <total> on the visible tab ────
+    // Switches wording between "messages" and "aircraft" based on
+    // stack.visible_child_name(). Re-evaluated on:
+    //   - either filter model's items-changed signal
+    //   - stack visible-child-notify
+    {
+        let stack = handles.stack.clone();
+        let status = handles.status_label.clone();
+        let store = handles.store.clone();
+        let aircraft_store = handles.aircraft_store.clone();
+        let filter_model = handles.filter_model.clone();
+        let aircraft_filter_model = handles.aircraft_filter_model.clone();
+        let refresh = move || {
+            let on_aircraft = stack.visible_child_name().as_deref() == Some("aircraft");
+            if on_aircraft {
+                let filtered = aircraft_filter_model.n_items();
+                let total = aircraft_store.n_items();
+                status.set_label(&format!("{filtered} / {total} aircraft"));
+            } else {
+                let filtered = filter_model.n_items();
+                let total = store.n_items();
+                status.set_label(&format!("{filtered} / {total} messages"));
+            }
+        };
+
+        // Wire the same refresh closure to all three signal
+        // sources. Each clone is its own move-into-closure so
+        // lifetimes work out.
+        {
+            let refresh = refresh.clone();
+            handles
+                .filter_model
+                .connect_items_changed(move |_, _, _, _| refresh());
+        }
+        {
+            let refresh = refresh.clone();
+            handles
+                .aircraft_filter_model
+                .connect_items_changed(move |_, _, _, _| refresh());
+        }
+        {
+            let refresh = refresh.clone();
+            handles.stack.connect_visible_child_notify(move |_| refresh());
+        }
+    }
+```
+
+- [ ] **Step 2: Verify build + clippy + tests**
+
+```bash
+cargo build -p sdr-ui --features sdr-transcription/whisper-cpu
+cargo clippy -p sdr-ui --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo test -p sdr-ui --features sdr-transcription/whisper-cpu
+cargo fmt --all -- --check
+```
+
+Expected: all clean. Note: the closure captures both `store` and `filter_model` — make sure these are clones (not moves) so the existing append site can still see them. The code above uses `.clone()` on each before the move.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-ui/src/acars_viewer.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 switch status-label wording per ACARS viewer tab
+
+Shows "filtered / total messages" on Stream, "filtered / total
+aircraft" on By Aircraft. Wires a single refresh closure to
+items_changed on both filter models and visible-child-notify on
+the stack so the wording updates immediately on tab swap and on
+message/aircraft arrival.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Extend Clear button to clear aircraft store + index
+
+**Files:**
+- Modify: `crates/sdr-ui/src/acars_viewer.rs`
+
+The existing Clear handler (lines 419-432) wipes `store` + `acars_recent` and updates the status label. Extend to also wipe `aircraft_store` + `aircraft_index`.
+
+- [ ] **Step 1: Update the Clear button block**
+
+Replace the existing Clear-button block (lines 418-432) with:
+
+```rust
+    // ── Clear button ──────────────────────────────────────────────
+    {
+        let state = Rc::clone(state);
+        let handles = Rc::clone(&handles);
+        clear_button.connect_clicked(move |_| {
+            handles.store.remove_all();
+            handles.aircraft_store.remove_all();
+            handles.aircraft_index.borrow_mut().clear();
+            state.acars_recent.borrow_mut().clear();
+            // Don't reset acars_total_count — that's the
+            // running total since toggle-on, distinct from the
+            // visible count. Status label refresh in the
+            // items_changed handler recomputes "filtered / total"
+            // from the now-empty filter_model + total_count.
+            handles.status_label.set_label("0 / 0 messages");
+        });
+    }
+```
+
+- [ ] **Step 2: Verify build + clippy + tests**
+
+```bash
+cargo build -p sdr-ui --features sdr-transcription/whisper-cpu
+cargo clippy -p sdr-ui --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo test -p sdr-ui --features sdr-transcription/whisper-cpu
+cargo fmt --all -- --check
+```
+
+Expected: all clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-ui/src/acars_viewer.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 clear aircraft store + index on Clear button
+
+Extends the existing Clear handler to also wipe aircraft_store
+and aircraft_index. Without this, clicking Clear would empty
+the message list but leave stale aircraft rows visible on the
+By Aircraft tab — including aircraft last seen before the click
+that have since been "forgotten" from the message ring.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Wire the message-append site in `window.rs` to update the aircraft index
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs:2005-2050`
+
+The existing `DspToUi::AcarsMessage` arm pushes into `state.acars_recent` and (if open + not paused) into `viewer.store`. Add a parallel block that updates `viewer.aircraft_index` + `viewer.aircraft_store`.
+
+- [ ] **Step 1: Locate the existing append block**
+
+Read `crates/sdr-ui/src/window.rs` around lines 2005-2050 to confirm the append block layout. It's the `if let Some(handles) = state.acars_viewer_handles.borrow().as_ref() && !handles.pause_button.is_active() { … }` block.
+
+- [ ] **Step 2: Add aircraft-index update inside the gate**
+
+Inside the same `if let Some(handles) = … && !handles.pause_button.is_active() { … }` block, AFTER the existing `// Auto-scroll-to-top` block (after the `adj.set_value(adj.lower());` line, around line 2049), insert:
+
+```rust
+                // Aircraft-index update (issue #579). Find or
+                // insert the AircraftEntryObject for this tail,
+                // then call record_message to bump count +
+                // monotonic last_seen + last_label. On an
+                // existing-entry hit, manually nudge the
+                // filter/sort models via items_changed since
+                // GListStore doesn't fire that signal on field
+                // mutation of an already-stored object.
+                {
+                    let mut idx = handles.aircraft_index.borrow_mut();
+                    let inserted = !idx.contains_key(&msg.aircraft);
+                    let obj = idx.entry(msg.aircraft).or_insert_with(|| {
+                        let entry = crate::acars_viewer::AircraftEntry {
+                            tail: msg.aircraft,
+                            last_seen: msg.timestamp,
+                            msg_count: 0,
+                            last_label: msg.label,
+                        };
+                        let obj = crate::acars_viewer::AircraftEntryObject::new(entry);
+                        handles.aircraft_store.append(&obj);
+                        obj
+                    });
+                    obj.record_message(&msg);
+                    if !inserted {
+                        // O(n) over ~50 aircraft is fine; Clear
+                        // invalidates positions otherwise so we
+                        // re-find each time rather than tracking
+                        // a position field on the object. Spec
+                        // edge-case "Aircraft store doesn't
+                        // auto-redraw on field change".
+                        if let Some(pos) = handles.aircraft_store.find(obj) {
+                            handles.aircraft_store.items_changed(pos, 1, 1);
+                        }
+                    }
+                }
+```
+
+Note: `gio::ListStore::find` returns `Option<u32>`. The bound name `obj` is the inserted-or-existing `AircraftEntryObject` reference inside `idx`.
+
+- [ ] **Step 3: Verify build + clippy + tests**
+
+```bash
+cargo build --workspace --features sdr-transcription/whisper-cpu
+cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo test --workspace --features sdr-transcription/whisper-cpu
+cargo fmt --all -- --check
+```
+
+Expected: all clean. If clippy flags `redundant_closure` or similar, prefer the explicit form shown above.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #579 update aircraft index on each ACARS message
+
+Extends the DspToUi::AcarsMessage handler arm: when the viewer is
+open and not paused, find-or-insert into aircraft_index and call
+record_message to bump count + monotonic last_seen + last_label.
+On an existing-entry hit, look up the position via gio::ListStore
+::find and emit items_changed(pos, 1, 1) so the filter/sort models
+re-evaluate (GListStore doesn't fire items-changed on field
+mutation by itself).
+
+Pause and Clear semantics inherit from the surrounding gate +
+the existing Clear handler — both now cover aircraft state too.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Workspace gates verification
+
+**Files:** none modified — gate run only.
+
+- [ ] **Step 1: Run the full workspace gate set**
+
+```bash
+cargo build --workspace --features sdr-transcription/whisper-cpu
+cargo test --workspace --features sdr-transcription/whisper-cpu
+cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all clean. Total runtime ~3-5 minutes on a developer workstation.
+
+- [ ] **Step 2: Skim the diff for obvious issues**
+
+```bash
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+git diff main...HEAD -- crates/sdr-acars/src/label.rs | head -200
+```
+
+Expected: ~10 commits, ~3 files changed, ~430 LOC. Spot-check that:
+- `label.rs` lookup table covers ~80 entries
+- `acars_viewer.rs` has the new `AircraftEntryObject` + `imp_aircraft` module + `build_aircraft_column_view` + the stack wiring
+- `window.rs` has the aircraft-index update block inside the existing pause-gated branch
+
+- [ ] **Step 3: No commit (verification only)**
+
+If any gate fails, fix in-place on the appropriate task's commit (use `git rebase -i` only if you understand the history rewrite; otherwise add a follow-up commit on the same task's commit message theme).
+
+---
+
+## Task 13: Manual GTK smoke (USER ONLY)
+
+**Files:** none modified.
+
+GTK widget code (stack, columns, factories, click handlers) is not unit-testable without a display server. Per project convention (`feedback_smoke_test_workflow.md`): Claude installs the binary; the user runs the smoke checklist manually. Claude does NOT launch the binary.
+
+- [ ] **Step 1 (Claude): Install the binary**
+
+```bash
+make install CARGO_FLAGS="--release --features whisper-cuda"
+```
+
+Expected: `make install` builds with `--release` and `whisper-cuda` features and copies the binary to `$(BINDIR)/sdr-rs`. Per `feedback_make_install_release_flag.md`, the `--release` flag is required — without it, an old release binary stays in place. Verify with:
+
+```bash
+strings $BINDIR/sdr-rs | grep -i "by aircraft" | head -3
+```
+
+Expected: at least one match for the new tab title (`"By Aircraft"` from the `add_titled` call). If no match, the install copied a stale binary — re-run `make install` with the flag.
+
+- [ ] **Step 2 (USER ONLY): Run the smoke checklist**
+
+Hand off to user with:
+
+> Build installed at `$(BINDIR)/sdr-rs`. Please run through the smoke checklist below and report which steps pass / fail before I push the branch.
+
+**Smoke checklist (USER ONLY, copy verbatim into your pre-push report):**
+
+1. **Stream tab unchanged**
+   - [ ] Open the app, engage ACARS, open the ACARS viewer.
+   - [ ] Stream tab shows messages with the existing column layout PLUS a new `Ack` column between Block and Text.
+   - [ ] Label column shows `H1 (Crew message)` for known labels and just `H1` (or whatever code) for unknowns.
+   - [ ] ACK column shows `NAK` for `0x15`, the printable char for graphic ASCII, `0xNN` for other bytes.
+2. **By Aircraft tab populates**
+   - [ ] Switch to By Aircraft tab via the GtkStackSwitcher in the header.
+   - [ ] Status label changes wording from "messages" to "aircraft".
+   - [ ] One row per unique tail, sorted Last Seen descending by default.
+3. **By Aircraft live updates**
+   - [ ] Stay on aircraft tab. Confirm Count and Last Seen fields bump when new messages arrive from already-seen aircraft.
+   - [ ] New aircraft → new row appears (with Count=1).
+4. **Click-to-filter**
+   - [ ] Double-click an aircraft row.
+   - [ ] Filter entry gets the tail. Stack switches to Stream tab. Stream tab shows only that aircraft's messages.
+5. **Filter applies to both tabs**
+   - [ ] Type a substring in the filter (e.g. `UA` or `.N`).
+   - [ ] Stream tab shows messages from any aircraft whose tail / label / text contains the substring.
+   - [ ] Switch to By Aircraft tab. Aircraft list shows only tails containing the substring (no label/text match — intentional).
+6. **Pause works on both tabs**
+   - [ ] Pause. Confirm both tabs freeze: no new entries on Stream, no count bumps on existing aircraft, no new aircraft rows.
+   - [ ] Resume. Both tabs resume from current state.
+7. **Clear works on both tabs**
+   - [ ] Click Clear. Both tabs empty.
+   - [ ] Status label resets to `0 / 0`.
+8. **Sort each aircraft column**
+   - [ ] Click each header. Confirm: Aircraft column sorts case-insensitively alphabetical, Last Seen descending newest-first / ascending oldest-first, Count descending highest-first / ascending lowest-first, Last Label byte-ordered.
+9. **Reopen retains aircraft state**
+   - [ ] Close the viewer mid-session. Reopen.
+   - [ ] Both tabs hydrate from the in-memory ACARS ring.
+
+- [ ] **Step 3: Wait for user smoke pass**
+
+Do NOT proceed to Task 14 until the user reports the smoke checklist passing. If any step fails, file as a follow-up issue on the appropriate task's commit and fix before proceeding.
+
+---
+
+## Task 14: Final pre-push sweep + push branch
+
+**Files:** none modified.
+
+- [ ] **Step 1: Re-run gates immediately before push**
+
+Per `feedback_fmt_check_immediately_before_push.md`, fmt is the LAST gate before push:
+
+```bash
+cargo build --workspace --features sdr-transcription/whisper-cpu
+cargo test --workspace --features sdr-transcription/whisper-cpu
+cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all clean. If `cargo fmt --check` fails, run `cargo fmt --all`, re-stage, re-commit (or amend the last commit if it's a fmt-only fix), then re-run the check.
+
+- [ ] **Step 2: Confirm branch state**
+
+```bash
+git status
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+```
+
+Expected: clean working tree, ~10 commits ahead of main, 3 files changed (`label.rs`, `acars_viewer.rs`, `window.rs`), ~430 LOC.
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin feat/acars-aircraft-tab
+```
+
+Expected: success. **DO NOT open the PR — the user will do that.** The plan ends here; user opens the PR via GitHub UI or `gh pr create` themselves.
+
+---
+
+## Spec coverage matrix
+
+| Spec section | Task |
+|------|------|
+| Component 1 — Stack switcher | Task 6 |
+| Component 2 — `AircraftEntryObject` | Task 2 |
+| Component 3 — Aircraft store + index in `ViewerHandles` | Task 3 |
+| Component 4 — Lifecycle integration (open / append / clear / pause) | Tasks 7, 10, 11 |
+| Component 5 — Click-to-filter | Task 6 |
+| Component 6 — Filter semantics | Task 8 |
+| Component 7 — Status label switching | Task 9 |
+| Component 8 — Aircraft-tab columns | Task 5 |
+| Component 9 — Label-name lookup table | Task 1 |
+| Component 10 — ACK column on Stream tab | Task 4 |
+| Edge case: store doesn't auto-redraw | Task 11 (items_changed nudge) |
+| Edge case: aircraft index drift on Clear | Task 10 |
+| Edge case: pause-while-aircraft-active | Task 11 (gated by pause_button.is_active) |
+| Edge case: click-on-filtered-out / click-on-stream-tab | Task 6 (no-op fall-through) |
+| Testing — unit tests | Tasks 1, 2 |
+| Testing — smoke (USER ONLY) | Task 13 |

--- a/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
+++ b/docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md
@@ -1058,9 +1058,16 @@ Add right after the `*state.acars_viewer_handles.borrow_mut() = Some(Rc::clone(&
     // single click both select AND emit `activate`.
     {
         let handles = Rc::clone(&handles);
-        aircraft_column_view.connect_activate(move |_view, position| {
-            let Some(obj) = handles
-                .aircraft_filter_model
+        aircraft_column_view.connect_activate(move |view, position| {
+            // `position` is the column view's row index, which
+            // maps to the immediate model (SingleSelection) wrapping
+            // sort + filter. Look up via `view.model()` so the
+            // resolved row matches the visible ordering regardless
+            // of current sort + filter; resolving through
+            // `aircraft_filter_model` directly would diverge once
+            // a non-default sort is active.
+            let Some(model) = view.model() else { return };
+            let Some(obj) = model
                 .item(position)
                 .and_then(|o| o.downcast::<AircraftEntryObject>().ok())
             else {

--- a/docs/superpowers/specs/2026-04-30-acars-aircraft-tab-design.md
+++ b/docs/superpowers/specs/2026-04-30-acars-aircraft-tab-design.md
@@ -1,0 +1,532 @@
+# ACARS Aircraft-Grouped Viewer Tab + Label Names (issue #579, v1)
+
+> Add a "By Aircraft" tab to the ACARS viewer alongside the
+> existing "Stream" tab — one row per tail number with last-seen,
+> message count, and last label. Bundle in the long-stub label-
+> name lookup table so labels render as `H1 (Crew message)`
+> instead of cryptic 2-char codes. Plus a separate ACK column
+> on the Stream tab so `0x15` shows as `NAK` etc.
+
+## Goal
+
+Make the ACARS viewer dramatically more useful for a long-
+running session by:
+
+1. Letting the user see *which aircraft are active* at a glance
+   (currently buried in the firehose Stream view).
+2. Decoding the label codes so a user without an ACARS
+   protocol cheat sheet can read the firehose.
+3. Surfacing the ACK byte so downlink protocol state is visible.
+
+All three are user-visible readability improvements that
+together turn the viewer from "raw protocol dump" to "scannable
+ops dashboard."
+
+## Non-goals
+
+- **Tree-list expand/collapse** — rejected in favor of click-to-
+  filter (single click on aircraft row → filter set + switch to
+  Stream tab). Simpler state model, same user goal.
+- **ADS-B cross-correlation** — owned by issue #582, blocked on
+  ADS-B not yet shipping.
+- **Per-aircraft routing or aggregator views** (the way
+  `airframes.io` does it). Out of scope for v1.
+- **Custom user-tagged aircraft** — saved tail filters, watch-
+  lists, etc. Future-issue territory if requested.
+
+## Architecture
+
+### Module layout
+
+```text
+crates/sdr-acars/src/
+├── label.rs                         ← MODIFY: populate ~80-entry lookup table
+crates/sdr-ui/src/
+├── acars_viewer.rs                  ← MODIFY: stack, aircraft tab, ACK column
+├── window.rs                        ← MODIFY: aircraft-index update on append
+```
+
+No new files. The new `AircraftEntryObject` glib subclass lives
+in a private `mod imp_aircraft` inside `acars_viewer.rs` to mirror
+how `AcarsMessageObject` is already structured.
+
+### Component 1 — Stack switcher (acars_viewer.rs)
+
+Replace the single `ScrolledWindow` in the viewer's content area
+with a `GtkStack` holding two pages:
+
+- `"stream"` — existing `GtkColumnView` of messages
+- `"aircraft"` — new `GtkColumnView` of aircraft entries
+
+A `GtkStackSwitcher` goes in the header bar between the
+existing buttons and the filter entry:
+
+```text
+[⏸][🗑][≡]    [Stream | By Aircraft]    [filter…]    [3 / 12 messages]
+```
+
+Each page wraps its own `ScrolledWindow`, so each tab's
+`GtkAdjustment` retains its scroll position independently — no
+manual saving/restoring needed.
+
+### Component 2 — `AircraftEntryObject` glib subclass
+
+```rust
+mod imp_aircraft {
+    pub struct AircraftEntryObject {
+        pub inner: RefCell<Option<AircraftEntry>>,
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AircraftEntry {
+    pub tail: ArrayString<8>,
+    pub last_seen: SystemTime,
+    pub msg_count: u32,
+    pub last_label: [u8; 2],
+}
+
+impl AircraftEntryObject {
+    pub fn new(entry: AircraftEntry) -> Self;
+    pub fn entry(&self) -> Option<AircraftEntry>;
+    pub fn record_message(&self, msg: &AcarsMessage);
+}
+```
+
+`record_message` mutates in place: bumps `msg_count`, advances
+`last_seen` to `max(last_seen, msg.timestamp)`, sets
+`last_label` to the message's label. Same monotonic-update
+discipline as `AcarsMessageObject::record_duplicate` (CR round 2
+on PR #591).
+
+### Component 3 — Aircraft store + index in `ViewerHandles`
+
+```rust
+pub struct ViewerHandles {
+    /* existing fields */
+    pub aircraft_store: gtk4::gio::ListStore,
+    pub aircraft_filter: gtk4::CustomFilter,
+    pub aircraft_filter_model: gtk4::FilterListModel,
+    pub aircraft_index: RefCell<HashMap<ArrayString<8>, AircraftEntryObject>>,
+    pub stack: gtk4::Stack,
+}
+```
+
+`aircraft_store` holds the `AircraftEntryObject`s.
+`aircraft_filter_model` wraps it for the column view.
+`aircraft_index` is the `HashMap<tail, AircraftEntryObject>`
+that gives the message-append site O(1) lookup-or-insert; the
+hashmap holds clones of the same objects that live in the
+store, so updates flow through to the column view via the
+shared glib refcount.
+
+### Component 4 — Lifecycle integration
+
+#### Viewer open (acars_viewer.rs::build_acars_viewer_window)
+
+Same hydration loop as the existing message store, with a
+second pass that populates the aircraft index from the same
+ring:
+
+```rust
+let aircraft_index: RefCell<HashMap<ArrayString<8>, AircraftEntryObject>> =
+    RefCell::new(HashMap::new());
+{
+    let recent = state.acars_recent.borrow();
+    for msg in recent.iter() {
+        let mut idx = aircraft_index.borrow_mut();
+        let obj = idx.entry(msg.aircraft).or_insert_with(|| {
+            let entry = AircraftEntry {
+                tail: msg.aircraft,
+                last_seen: msg.timestamp,
+                msg_count: 0,
+                last_label: msg.label,
+            };
+            let obj = AircraftEntryObject::new(entry);
+            aircraft_store.append(&obj);
+            obj
+        });
+        obj.record_message(msg);
+    }
+}
+```
+
+#### Message append (window.rs::handle_dsp_message — `DspToUi::AcarsMessage` arm)
+
+The existing append path:
+
+1. Pushes the message into `state.acars_recent` (ring trim)
+2. Pushes into `viewer.store` if open + not paused
+
+Extends with:
+
+3. If viewer open + not paused:
+   - Find or insert in `viewer.aircraft_index`
+   - Call `obj.record_message(msg)` to bump count/timestamp/label
+   - The store auto-redraws because `record_message` mutates
+     the object that's already in the store (glib's notify is
+     not strictly required for `GListStore` items but the
+     filter/sort models pick up changes via items_changed
+     when the count changes — see Edge Cases below)
+
+#### Clear (existing handler)
+
+The existing `clear_button.connect_clicked` clears `store` +
+`acars_recent`. Extend to also clear `aircraft_store` and
+`aircraft_index`.
+
+#### Pause
+
+Existing pause-toggle gates the message-append site via
+`viewer.pause_button.is_active()`. Extend the same gate to skip
+the aircraft-index update.
+
+#### Viewer close
+
+`window.connect_close_request` already clears the AppState weak
+ref slot and the per-viewer handles. The `aircraft_index` and
+`aircraft_store` drop with the handles via Rc refcount — no
+explicit cleanup needed.
+
+### Component 5 — Click-to-filter
+
+```rust
+column_view_aircraft.connect_activate(move |_view, position| {
+    let Some(obj) = aircraft_filter_model
+        .item(position)
+        .and_then(|o| o.downcast::<AircraftEntryObject>().ok())
+    else { return; };
+    let Some(entry) = obj.entry() else { return };
+    filter_entry.set_text(&entry.tail);
+    stack.set_visible_child_name("stream");
+});
+```
+
+`connect_activate` fires on:
+- Double-click row
+- Enter key
+- `<Space>` if the focused row is selected
+
+Single-click does NOT activate (that's `connect_row_activated`
+or equivalent on a `GtkListView`; `GtkColumnView` activation is
+double-click for legibility).
+
+### Component 6 — Filter semantics
+
+Single `filter_entry` shared across both tabs. Two
+`CustomFilter`s, both updated by the same
+`connect_search_changed` handler:
+
+```rust
+filter_entry.connect_search_changed(move |entry| {
+    let needle = entry.text().as_str().to_lowercase();
+    // Stream filter: existing aircraft + label + text substring
+    stream_filter.set_filter_func(/* existing logic */);
+    // Aircraft filter: tail substring only
+    let needle_clone = needle.clone();
+    aircraft_filter.set_filter_func(move |obj| {
+        let Some(obj) = obj.downcast_ref::<AircraftEntryObject>() else {
+            return false;
+        };
+        let inner = obj.imp().inner.borrow();
+        let Some(entry) = inner.as_ref() else { return false };
+        if needle_clone.is_empty() {
+            return true;
+        }
+        entry.tail.to_lowercase().contains(&needle_clone)
+    });
+});
+```
+
+### Component 7 — Status label switching
+
+Status label currently shows `"{filtered} / {total} messages"`.
+On the aircraft tab, show `"{filtered} / {total} aircraft"`.
+Switch the wording based on `stack.visible_child_name()`:
+
+```rust
+stack.connect_visible_child_notify(move |stack| {
+    let label = stack.visible_child_name().as_deref();
+    refresh_status_label(label);
+});
+```
+
+The two `connect_items_changed` handlers (one per filter model)
+each refresh from their own counts, scoped to whichever tab is
+visible.
+
+### Component 8 — Aircraft-tab columns
+
+```text
+| Aircraft | Last Seen | Count | Last Label              |
+|----------|-----------|-------|-------------------------|
+| .N12345  | 14:32:11  |     8 | M1 (Position report)    |
+| .C-FYKW  | 14:31:45  |     3 | H1 (Crew message)       |
+```
+
+4 columns. All resizable. All sortable via `CustomSorter`s on
+`AircraftEntryObject`'s inner fields. Default sort: Last Seen
+descending (newest active aircraft at top).
+
+Column-render fns mirror the existing `render_*` pattern from
+the Stream tab — read inner via the `imp` borrow, format,
+return `String`.
+
+### Component 9 — Label-name lookup table
+
+Populate `crates/sdr-acars/src/label.rs::lookup`. Currently
+returns `None` for all inputs; replace with a static match
+covering ~80 known ACARS labels.
+
+#### Source-list outline (curated during implementation)
+
+| Code | Name |
+|------|------|
+| `H1` | Crew message |
+| `Q0` | Link test |
+| `M1` | Position report |
+| `B1` | Weather request |
+| `B2` | Weather acknowledge |
+| `_D` | General downlink |
+| `_E` | General uplink |
+| `10` | Arrival |
+| `11` | Out (gate) |
+| `12` | Off (wheels) |
+| `13` | On (wheels) |
+| `14` | In (gate) |
+| `15` | Departure |
+| `17` | Arrival info |
+| `1G` | Gate request |
+| `20` | Departure clearance |
+| `21` | Departure clearance reply |
+| `26` | Schedule |
+| `2N` | Takeoff time |
+| `2Z` | Destination update |
+| `33` | Fuel report |
+| `39` | Maintenance ground report |
+| `44` | Position |
+| `45` | Position |
+| `5Y` | OOOI report |
+| `7B` | Test message |
+| `80` | Departure |
+| `83` | Pre-departure clearance |
+| `8D` | Dispatch reply |
+| `8E` | ETA report |
+| `8S` | Schedule |
+| `Q1` – `QT` | OOOI events (out / off / on / in / etc.) |
+| `RB` | Schedule (alias for 26) |
+
+(The full ~80-entry table will be populated from ARINC 618 +
+sigidwiki + community wikis during implementation. Per
+[feedback memory] the project favors port-fidelity, but ARINC
+618 is a paid spec — acarsdec doesn't ship a name table either,
+so we curate from public sources.)
+
+#### Output format
+
+`Option<&'static str>` per the existing signature. Names are
+1-3 words, terse, no trailing punctuation. Aliases (e.g. RB →
+"Schedule (alias for 26)") get a parenthetical for clarity.
+
+#### Tests
+
+Per-label `#[test]`s for ~5 canonical labels (don't test all 80;
+that's just a copy of the table). Plus an `unknown_returns_none`
+test that hits two known-bogus codes.
+
+### Component 10 — ACK column on the Stream tab
+
+New 8th column between Block and Text:
+
+```text
+| Time | Freq | Aircraft | Mode | Label | Block | Ack | Text |
+```
+
+`render_ack(obj)` body:
+
+```rust
+fn render_ack(obj: &AcarsMessageObject) -> String {
+    render_inner(obj, |m| match m.ack {
+        b'\x15' => "NAK".to_string(),
+        b'!'    => "!".to_string(),
+        c if c.is_ascii_graphic() => char::from(c).to_string(),
+        c       => format!("0x{c:02X}"),
+    })
+}
+```
+
+`NAK` (0x15, the ACARS negative-ack) is the most common case
+and previously rendered as a nonprintable control char glyph
+or empty cell. Now legible.
+
+Sortable on `m.ack` byte. Resizable, narrow default width.
+
+## Data flow
+
+```text
+DspToUi::AcarsMessage
+        │
+        ▼
+window.rs::handle_dsp_message
+        │
+        ├── push to state.acars_recent (always)
+        ├── push to viewer.store (if open + not paused)
+        └── update viewer.aircraft_index (if open + not paused)   ← NEW
+                │
+                ▼
+        AircraftEntryObject::record_message
+                │
+                ▼
+        store mutates → filter/sort models invalidate → column view redraws
+```
+
+## Edge cases
+
+### Aircraft store doesn't auto-redraw on field change
+
+`GListStore::items_changed` only fires on insert/remove, not on
+field mutation of an existing item. The aircraft column view's
+sort by Last Seen would freeze on an existing entry's bumped
+timestamp.
+
+**Mitigation:** when `record_message` updates an existing
+entry, look up the entry's current position via
+`aircraft_store.find(&obj)` (gtk4-rs `gio::ListStore::find`,
+O(n) over ~50 aircraft is fine), then call
+`aircraft_store.items_changed(idx, 1, 1)` to nudge the
+filter/sort models. The `find`-based lookup keeps
+`aircraft_index` simple (no position field on the object, no
+`(obj, idx)` tuple) and stays correct even if items get
+removed via Clear and re-inserted on the next message. The
+filter/sort models pick up the items_changed signal and
+re-evaluate.
+
+Alternative considered: re-sort manually on every update.
+Rejected — GTK's CustomSorter will re-sort if we call
+`items_changed`, no manual sort needed.
+
+Alternative considered: track `(obj, Cell<u32>)` in the index
+to skip the `find`. Rejected — Clear invalidates positions and
+the bookkeeping risk outweighs the O(n) win at this scale.
+
+### Aircraft index drift on Clear
+
+When user clicks Clear, both `store` and `acars_recent` are
+emptied. The aircraft entries remain stale unless we also
+clear `aircraft_index` and `aircraft_store`. Handled in the
+existing `clear_button` handler — adds 2 lines.
+
+### Pause-while-aircraft-active
+
+Pause currently skips `viewer.store` appends but lets
+`acars_recent` keep filling. Aircraft index/store should follow
+the same pattern: pause skips the index update, the ring keeps
+growing. Resume picks up new aircraft + new messages from there
+forward. Deliberately does not retroactively backfill the gap
+(matches existing message-append behavior; same user-intuition
+trade-off).
+
+### Click-activation on a filtered-out row
+
+If the user has typed a filter and an aircraft row is hidden,
+they can't click it. Non-issue.
+
+### Click-activation when stack is already on Stream tab
+
+If `stack.visible_child_name() == "stream"`, the
+`set_visible_child_name("stream")` call is a no-op. Non-issue.
+
+## Testing
+
+### Unit tests
+
+- `label.rs::tests`:
+  - `lookup_known_labels` — 5 spot-checks for canonical labels
+  - `lookup_unknown_returns_none` — 2 known-bogus codes
+- `acars_viewer.rs::tests`:
+  - `aircraft_entry_object_record_message_bumps_count` — round-trip
+  - `aircraft_entry_object_last_seen_monotonic_under_record_message` — out-of-order timestamps don't regress
+  - `aircraft_entry_record_message_updates_label`
+
+The aircraft-index lifecycle (insert/update/clear) and the
+column view rendering can't be unit-tested without a GTK
+display — covered by smoke.
+
+### Smoke (USER ONLY)
+
+Manual GTK smoke checklist (provided to user after `make install`):
+
+1. **Stream tab unchanged**
+   - Open viewer with ACARS engaged. Stream tab shows messages.
+   - Label column now shows `H1 (Crew message)` for known labels,
+     bare code for unknowns.
+   - New ACK column shows `NAK` for `0x15`, printable char or
+     `0xNN` for others.
+2. **By Aircraft tab populates**
+   - Switch to By Aircraft tab via stack switcher.
+   - One row per unique tail seen since session start.
+   - Sorted Last Seen descending by default.
+3. **By Aircraft live updates**
+   - Stay on aircraft tab. Confirm Count and Last Seen fields
+     bump on new messages from already-seen aircraft.
+   - New aircraft → new row appears.
+4. **Click-to-filter**
+   - Double-click an aircraft row.
+   - Filter entry gets the tail. Stack switches to Stream tab.
+     Stream tab shows only that aircraft's messages.
+5. **Filter applies to both tabs**
+   - Type "UA" in filter. Stream tab shows messages from all
+     aircraft with "UA" in the tail (or label/text).
+   - Switch to By Aircraft tab. Aircraft list shows only tails
+     containing "UA" (no label/text match on this tab —
+     intentional).
+6. **Pause works on both tabs**
+   - Pause. Confirm both tabs freeze (no new entries / no
+     count bumps on existing aircraft).
+   - Resume. Both tabs resume from current state.
+7. **Clear works on both tabs**
+   - Clear. Both tabs empty.
+8. **Sort each aircraft column**
+   - Click each header — alphabetical by tail, descending by
+     Last Seen, descending by Count, alphabetical by Last
+     Label.
+9. **Reopen retains aircraft state**
+   - Close and reopen viewer mid-session. Both tabs hydrate
+     from `acars_recent` (the existing message-side hydration
+     already does this; aircraft side mirrors it).
+
+## File budget
+
+| File | LOC |
+|------|-----|
+| `crates/sdr-acars/src/label.rs` | +120 (table + tests) |
+| `crates/sdr-ui/src/acars_viewer.rs` | +280 (stack + aircraft tab + ACK column + glib subclass) |
+| `crates/sdr-ui/src/window.rs` | +30 (aircraft-index update at append site) |
+| **Total** | **~430 LOC** |
+
+Single bundled PR.
+
+## Out-of-scope items (deferred)
+
+- ADS-B integration (#582 — blocked on ADS-B)
+- Custom user-tagged aircraft / watchlists
+- Per-aircraft routing or aggregator-style views
+- Tree-list expand/collapse (rejected in design phase)
+- ACK rendering improvements beyond the basic NAK / printable
+  / hex split (e.g. mapping printable acks to a sequence-number
+  display)
+
+## References
+
+- Existing viewer: `crates/sdr-ui/src/acars_viewer.rs`
+- Existing label-stub:
+  `crates/sdr-acars/src/label.rs::lookup`
+- ACARS protocol references:
+  `docs/research/07-acars-aviation-datalink.md`
+- Issue #579 acceptance
+- Sibling specs:
+  - Sub-project 1 (DSP/parser) — PR #583
+  - Sub-project 2 (controller) — PR #584
+  - Sub-project 3 (viewer scaffold) — PR #587
+  - #577 (label parsers) — PR #594
+  - #578 (output formatters) — PR #595


### PR DESCRIPTION
## Summary

Bundles three ACARS viewer readability improvements per spec/plan in `docs/superpowers/specs/2026-04-30-acars-aircraft-tab-design.md` and `docs/superpowers/plans/2026-04-30-acars-aircraft-tab.md`:

- **"By Aircraft" tab** (#579) — `GtkStack` switcher alongside the existing Stream tab. One row per tail with Aircraft / Last Seen / Count / Last Label. All 4 columns sortable; default sort is Last Seen descending. Single-click on a row sets the filter to the tail and switches to the Stream tab. Hydrates from the `acars_recent` ring on open; updates live as messages arrive; pause/clear semantics inherit from the existing handlers.
- **Label-name lookup** (`crates/sdr-acars/src/label.rs`) — populated the long-stub `lookup` table with ~100 curated entries (sigidwiki / airframes.io / acarsdeco2 / vdlm2dec). Labels now render as `H1 (Crew message)` instead of bare 2-char codes. The viewer's `render_label` already calls `label::lookup`, so this populates display end-to-end with no viewer change needed.
- **Ack column** on the Stream tab — slots between Block and Text. Renders `0x15` as `NAK` (the most common case), `'!'` as itself, other printable ASCII as the char, and everything else as `0xNN` hex. Sortable on the raw byte.

Mid-flight smoke fixes also folded in: aircraft count showing 0 (synchronous bind on append before `record_message` ran), click-to-filter activation (`SingleSelection` + `single_click_activate(true)` + correct model lookup), and a Stream-tab auto-scroll regression caused by the new `GtkStack` wrapping the scrolled window.

## Test plan
- [x] All 14 plan tasks executed via subagent-driven development with controller validation pass after each
- [x] `cargo build --workspace --features sdr-transcription/whisper-cpu` clean
- [x] `cargo test --workspace --features sdr-transcription/whisper-cpu` — all green (3 new label.rs tests + 3 new AircraftEntryObject tests)
- [x] `cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual GTK smoke (whisper-cuda build) — all 9 checklist items pass after two fix rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "By Aircraft" tab with per-tail summaries (last-seen, count, last label), tab switcher, seeded aircraft list, and click-to-filter back to Stream.
  * Stream adds an ACK column with human-readable rendering and sorting.

* **Improvements**
  * ACARS label lookup now resolves ~80 known labels to human-friendly names.
  * Status text reflects active tab counts; Clear wipes both views and indexes.

* **Tests / Docs**
  * Updated unit tests and added planning/design documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->