### PR TITLE
feat: #596 ACARS async output I/O + #592 custom channel sets

### DIFF
--- a/crates/sdr-core/src/acars_airband_lock.rs
+++ b/crates/sdr-core/src/acars_airband_lock.rs
@@ -392,6 +392,19 @@ pub fn engage(
     if current.source_type != SourceType::RtlSdr {
         return Err(AcarsEnableError::UnsupportedSourceType(current.source_type));
     }
+    // Reject empty / invalid Custom regions before computing
+    // geometry. `from_config_id("custom")` builds a placeholder
+    // `Custom(Box::new([]))` that should never reach engage —
+    // window.rs::startup_replay validates and falls back to the
+    // default region on stale config, but defending here keeps
+    // an `target_center_hz = 0.0` from leaking through if any
+    // future path constructs an empty Custom and dispatches it.
+    // CR round 1 on PR #598.
+    if let AcarsRegion::Custom(chans) = region {
+        validate_custom_channels(chans).map_err(|e| {
+            AcarsEnableError::ChannelBankInit(format!("invalid custom-channel set: {e}"))
+        })?;
+    }
     Ok(EngagePlan {
         target_source_rate_hz: ACARS_SOURCE_RATE_HZ,
         target_center_hz: region.center_hz(),
@@ -445,6 +458,47 @@ mod tests {
         assert_eq!(plan.snapshot.vfo_offset_hz, -25_000.0);
         assert_eq!(plan.snapshot.source_type, SourceType::RtlSdr);
         assert_eq!(plan.snapshot.frontend_decim, 4);
+    }
+
+    #[test]
+    fn engage_rejects_empty_custom_region() {
+        // CR round 1 on PR #598: an empty `Custom` region (the
+        // placeholder `from_config_id("custom")` returns when
+        // saved channels haven't been validated yet) must not
+        // reach engage. Without this guard, `center_hz()`
+        // returns 0.0 and the controller would retune to 0 Hz.
+        let region = AcarsRegion::Custom(Box::new([]));
+        match engage(&rtl_state(), &region) {
+            Err(AcarsEnableError::ChannelBankInit(msg)) => {
+                assert!(
+                    msg.contains("invalid custom-channel set"),
+                    "error wraps validate_custom_channels output: {msg}"
+                );
+            }
+            other => panic!("expected ChannelBankInit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn engage_rejects_oversized_custom_region() {
+        #[allow(clippy::cast_precision_loss)]
+        let chans: Vec<f64> = (0..=MAX_CUSTOM_CHANNELS)
+            .map(|i| 131_000_000.0 + (i as f64) * 100_000.0)
+            .collect();
+        let region = AcarsRegion::Custom(chans.into_boxed_slice());
+        match engage(&rtl_state(), &region) {
+            Err(AcarsEnableError::ChannelBankInit(msg)) => {
+                assert!(msg.contains("Too many custom channels"), "msg={msg}");
+            }
+            other => panic!("expected ChannelBankInit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn engage_accepts_valid_custom_region() {
+        let region = AcarsRegion::Custom(Box::new([131_550_000.0, 131_525_000.0]));
+        let plan = engage(&rtl_state(), &region).expect("valid Custom region engages");
+        assert_eq!(plan.target_center_hz, region.center_hz());
     }
 
     #[test]

--- a/crates/sdr-core/src/acars_airband_lock.rs
+++ b/crates/sdr-core/src/acars_airband_lock.rs
@@ -172,36 +172,46 @@ pub fn validate_custom_channels(chans: &[f64]) -> Result<(), CustomChannelError>
 /// rely on exhaustive matching, which is exactly the contract
 /// this enum needs given its forward-compat plan. CR round 1
 /// on PR #593.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub enum AcarsRegion {
     /// North America (default). Six channels in 129.125–
-    /// 131.550 MHz. Center 130.3375 MHz.
+    /// 131.550 MHz.
     #[default]
     Us6,
     /// Europe. Six channels clustered in 131.450–131.875 MHz.
-    /// Center derived from the cluster midpoint.
     Europe,
+    /// User-defined channel set. Frequencies in Hz; validated
+    /// via `validate_custom_channels` at construction time.
+    /// Issue #592.
+    Custom(Box<[f64]>),
 }
 
 impl AcarsRegion {
-    /// Channels for this region (Hz).
+    /// Channels for this region (Hz). Returns a borrowed slice
+    /// so all variants — including `Custom` — share one
+    /// accessor. Issue #592.
     #[must_use]
-    pub const fn channels(self) -> [f64; ACARS_CHANNEL_COUNT] {
+    pub fn channels(&self) -> &[f64] {
         match self {
-            Self::Us6 => US_SIX_CHANNELS_HZ,
-            Self::Europe => EUROPE_SIX_CHANNELS_HZ,
+            Self::Us6 => &US_SIX_CHANNELS_HZ,
+            Self::Europe => &EUROPE_SIX_CHANNELS_HZ,
+            Self::Custom(c) => c,
         }
     }
 
     /// Source center frequency for this region (Hz). Computed
     /// as the midpoint of `min(channels)` and `max(channels)`
     /// so the cluster fits symmetrically inside the 2.5 MHz
-    /// Nyquist window. The channel order in `channels()` is
-    /// not assumed to be sorted.
+    /// Nyquist window.
     #[must_use]
-    pub fn center_hz(self) -> f64 {
+    pub fn center_hz(&self) -> f64 {
         let chans = self.channels();
+        if chans.is_empty() {
+            // `Custom([])` placeholder shouldn't reach engage,
+            // but keep this defensive — return 0.0.
+            return 0.0;
+        }
         let mut min = chans[0];
         let mut max = chans[0];
         for &c in &chans[1..] {
@@ -216,37 +226,40 @@ impl AcarsRegion {
     }
 
     /// Stable string id used as the `acars_region` config key
-    /// value. Round-trips with `from_config_id`.
+    /// value. Round-trips with `from_config_id`. The `Custom`
+    /// arm always returns `"custom"`; the actual channel list
+    /// is persisted under a separate `acars_custom_channels`
+    /// config key.
     #[must_use]
-    pub const fn config_id(self) -> &'static str {
+    pub fn config_id(&self) -> &'static str {
         match self {
             Self::Us6 => "us-6",
             Self::Europe => "europe",
+            Self::Custom(_) => "custom",
         }
     }
 
-    /// Inverse of `config_id`. Falls back to the default on
-    /// unrecognised strings (forward-compat with future
-    /// regions).
+    /// Inverse of `config_id`. Falls back to default on
+    /// unrecognised strings. Returns `Custom(Box::new([]))`
+    /// for `"custom"` — the load-side caller in
+    /// `window.rs::startup_replay` populates the actual
+    /// frequencies from `acars_custom_channels`.
     #[must_use]
     pub fn from_config_id(id: &str) -> Self {
         match id {
             "europe" => Self::Europe,
-            // "us-6" + anything else → default. We don't error
-            // on unknown values because that would lock users
-            // out of the panel after a downgrade or stale
-            // config; falling back is the more forgiving
-            // behaviour.
+            "custom" => Self::Custom(Box::new([])),
             _ => Self::Us6,
         }
     }
 
     /// Display label for the Aviation panel combo row.
     #[must_use]
-    pub const fn display_label(self) -> &'static str {
+    pub fn display_label(&self) -> &'static str {
         match self {
             Self::Us6 => "United States (US-6)",
             Self::Europe => "Europe",
+            Self::Custom(_) => "Custom",
         }
     }
 }
@@ -374,7 +387,7 @@ pub struct DisengagePlan {
 /// preserve the pre-#581 behaviour.
 pub fn engage(
     current: &CurrentSourceState,
-    region: AcarsRegion,
+    region: &AcarsRegion,
 ) -> Result<EngagePlan, AcarsEnableError> {
     if current.source_type != SourceType::RtlSdr {
         return Err(AcarsEnableError::UnsupportedSourceType(current.source_type));
@@ -423,7 +436,7 @@ mod tests {
     #[test]
     fn engage_snapshots_and_emits_target_geometry() {
         let plan =
-            engage(&rtl_state(), AcarsRegion::default()).expect("RTL-SDR engage should succeed");
+            engage(&rtl_state(), &AcarsRegion::default()).expect("RTL-SDR engage should succeed");
         assert_eq!(plan.target_source_rate_hz, ACARS_SOURCE_RATE_HZ);
         assert_eq!(plan.target_center_hz, ACARS_CENTER_HZ);
         assert_eq!(plan.target_frontend_decim, ACARS_FRONTEND_DECIM);
@@ -439,7 +452,7 @@ mod tests {
         for bad in [SourceType::Network, SourceType::File, SourceType::RtlTcp] {
             let mut state = rtl_state();
             state.source_type = bad;
-            match engage(&state, AcarsRegion::default()) {
+            match engage(&state, &AcarsRegion::default()) {
                 Err(AcarsEnableError::UnsupportedSourceType(t)) => assert_eq!(t, bad),
                 other => panic!("source={bad:?} expected UnsupportedSourceType, got {other:?}"),
             }
@@ -448,7 +461,7 @@ mod tests {
 
     #[test]
     fn engage_with_europe_region_targets_europe_center() {
-        let plan = engage(&rtl_state(), AcarsRegion::Europe)
+        let plan = engage(&rtl_state(), &AcarsRegion::Europe)
             .expect("RTL-SDR + Europe engage should succeed");
         assert_eq!(plan.target_center_hz, AcarsRegion::Europe.center_hz());
         // Sanity: Europe's center is well above US-6's. Pin a
@@ -473,7 +486,7 @@ mod tests {
 
     #[test]
     fn disengage_returns_snapshotted_geometry_verbatim() {
-        let plan = engage(&rtl_state(), AcarsRegion::default()).unwrap();
+        let plan = engage(&rtl_state(), &AcarsRegion::default()).unwrap();
         let restore = disengage(&plan.snapshot);
         assert_eq!(restore.target_source_rate_hz, 1_024_000.0);
         assert_eq!(restore.target_center_hz, 162_550_000.0);
@@ -484,7 +497,7 @@ mod tests {
     #[test]
     fn engage_then_disengage_is_a_round_trip() {
         let original = rtl_state();
-        let plan = engage(&original, AcarsRegion::default()).unwrap();
+        let plan = engage(&original, &AcarsRegion::default()).unwrap();
         let restore = disengage(&plan.snapshot);
         assert_eq!(restore.target_source_rate_hz, original.source_rate_hz);
         assert_eq!(restore.target_center_hz, original.center_freq_hz);
@@ -594,5 +607,35 @@ mod tests {
         assert!(s.contains("2.5"), "span value present: {s}");
         assert!(s.contains("129"), "low freq present: {s}");
         assert!(s.contains("131"), "high freq present: {s}");
+    }
+
+    #[test]
+    fn from_config_id_round_trips_custom() {
+        // Custom is a placeholder — channels live in a separate
+        // config key, loaded by window.rs::startup-replay.
+        let r = AcarsRegion::from_config_id("custom");
+        assert_eq!(r.config_id(), "custom");
+        // Empty placeholder: from_config_id returns Custom([])
+        // unconditionally; the actual frequencies are populated
+        // by the load-side caller.
+        assert_eq!(r.channels(), &[] as &[f64]);
+    }
+
+    #[test]
+    fn channels_accessor_returns_borrowed_slice() {
+        let us = AcarsRegion::Us6;
+        let eu = AcarsRegion::Europe;
+        assert_eq!(us.channels().len(), ACARS_CHANNEL_COUNT);
+        assert_eq!(eu.channels().len(), ACARS_CHANNEL_COUNT);
+
+        let custom = AcarsRegion::Custom(Box::from([131_550_000.0, 131_525_000.0].as_slice()));
+        assert_eq!(custom.channels().len(), 2);
+        assert!((custom.channels()[0] - 131_550_000.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn display_label_custom() {
+        let custom = AcarsRegion::Custom(Box::from([131_550_000.0].as_slice()));
+        assert_eq!(custom.display_label(), "Custom");
     }
 }

--- a/crates/sdr-core/src/acars_airband_lock.rs
+++ b/crates/sdr-core/src/acars_airband_lock.rs
@@ -73,53 +73,29 @@ pub const MAX_CUSTOM_CHANNELS: usize = 8;
 pub const MAX_CHANNEL_SPAN_HZ: f64 = 2_400_000.0;
 
 /// Error variants returned by [`validate_custom_channels`].
-/// `Display` impl produces user-facing toast text. Issue #592.
-#[derive(Clone, Debug, PartialEq)]
+/// `Display` derive produces user-facing toast text via
+/// `thiserror::Error`. Issue #592 / CR round 2 on PR #598.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum CustomChannelError {
+    #[error("Custom channel list is empty")]
     Empty,
-    TooMany {
-        count: usize,
-        max: usize,
-    },
-    InvalidFrequency {
-        value: f64,
-    },
+    #[error("Too many custom channels ({count}); maximum is {max}")]
+    TooMany { count: usize, max: usize },
+    #[error("Invalid custom-channel frequency: {value}")]
+    InvalidFrequency { value: f64 },
+    #[error(
+        "Span {:.3} MHz exceeds {:.3} MHz limit ({:.3} to {:.3} MHz)",
+        *span_hz / 1_000_000.0,
+        MAX_CHANNEL_SPAN_HZ / 1_000_000.0,
+        *low_hz / 1_000_000.0,
+        *high_hz / 1_000_000.0
+    )]
     SpanExceeded {
         low_hz: f64,
         high_hz: f64,
         span_hz: f64,
     },
 }
-
-impl std::fmt::Display for CustomChannelError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Empty => write!(f, "Custom channel list is empty"),
-            Self::TooMany { count, max } => {
-                write!(f, "Too many custom channels ({count}); maximum is {max}")
-            }
-            Self::InvalidFrequency { value } => {
-                write!(f, "Invalid custom-channel frequency: {value}")
-            }
-            Self::SpanExceeded {
-                low_hz,
-                high_hz,
-                span_hz,
-            } => {
-                let span_mhz = span_hz / 1_000_000.0;
-                let low_mhz = low_hz / 1_000_000.0;
-                let high_mhz = high_hz / 1_000_000.0;
-                write!(
-                    f,
-                    "Span {span_mhz:.3} MHz exceeds {} MHz limit ({low_mhz:.3} to {high_mhz:.3} MHz)",
-                    MAX_CHANNEL_SPAN_HZ / 1_000_000.0
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for CustomChannelError {}
 
 /// Validate a slice of custom-channel frequencies (Hz). Returns
 /// `Ok(())` if the list is non-empty, ≤ `MAX_CUSTOM_CHANNELS`,

--- a/crates/sdr-core/src/acars_airband_lock.rs
+++ b/crates/sdr-core/src/acars_airband_lock.rs
@@ -61,6 +61,105 @@ pub const EUROPE_SIX_CHANNELS_HZ: [f64; ACARS_CHANNEL_COUNT] = [
     131_875_000.0,
 ];
 
+/// Maximum number of channels in a user-defined custom region.
+/// Sized for any realistic ACARS cluster within
+/// `MAX_CHANNEL_SPAN_HZ`. Issue #592.
+pub const MAX_CUSTOM_CHANNELS: usize = 8;
+
+/// Maximum allowed span (max - min) of a custom channel set
+/// in Hz. Set to 2.4 MHz to leave a 100 kHz margin against
+/// the 2.5 `MSps` source rate (Nyquist bandwidth ≈ 2.5 MHz).
+/// Issue #592.
+pub const MAX_CHANNEL_SPAN_HZ: f64 = 2_400_000.0;
+
+/// Error variants returned by [`validate_custom_channels`].
+/// `Display` impl produces user-facing toast text. Issue #592.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CustomChannelError {
+    Empty,
+    TooMany {
+        count: usize,
+        max: usize,
+    },
+    InvalidFrequency {
+        value: f64,
+    },
+    SpanExceeded {
+        low_hz: f64,
+        high_hz: f64,
+        span_hz: f64,
+    },
+}
+
+impl std::fmt::Display for CustomChannelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "Custom channel list is empty"),
+            Self::TooMany { count, max } => {
+                write!(f, "Too many custom channels ({count}); maximum is {max}")
+            }
+            Self::InvalidFrequency { value } => {
+                write!(f, "Invalid custom-channel frequency: {value}")
+            }
+            Self::SpanExceeded {
+                low_hz,
+                high_hz,
+                span_hz,
+            } => {
+                let span_mhz = span_hz / 1_000_000.0;
+                let low_mhz = low_hz / 1_000_000.0;
+                let high_mhz = high_hz / 1_000_000.0;
+                write!(
+                    f,
+                    "Span {span_mhz:.3} MHz exceeds {} MHz limit ({low_mhz:.3} to {high_mhz:.3} MHz)",
+                    MAX_CHANNEL_SPAN_HZ / 1_000_000.0
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CustomChannelError {}
+
+/// Validate a slice of custom-channel frequencies (Hz). Returns
+/// `Ok(())` if the list is non-empty, ≤ `MAX_CUSTOM_CHANNELS`,
+/// all values are finite + positive, and `max - min ≤
+/// MAX_CHANNEL_SPAN_HZ`. Issue #592.
+pub fn validate_custom_channels(chans: &[f64]) -> Result<(), CustomChannelError> {
+    if chans.is_empty() {
+        return Err(CustomChannelError::Empty);
+    }
+    if chans.len() > MAX_CUSTOM_CHANNELS {
+        return Err(CustomChannelError::TooMany {
+            count: chans.len(),
+            max: MAX_CUSTOM_CHANNELS,
+        });
+    }
+    for &c in chans {
+        if !c.is_finite() || c <= 0.0 {
+            return Err(CustomChannelError::InvalidFrequency { value: c });
+        }
+    }
+    let (mut min, mut max) = (chans[0], chans[0]);
+    for &c in &chans[1..] {
+        if c < min {
+            min = c;
+        }
+        if c > max {
+            max = c;
+        }
+    }
+    let span = max - min;
+    if span > MAX_CHANNEL_SPAN_HZ {
+        return Err(CustomChannelError::SpanExceeded {
+            low_hz: min,
+            high_hz: max,
+            span_hz: span,
+        });
+    }
+    Ok(())
+}
+
 /// Predefined ACARS channel set. Issue #581. The DSP layer
 /// (`sdr_acars::ChannelBank`) is region-agnostic — all this
 /// type does is pick which fixed array to feed it and where
@@ -391,5 +490,109 @@ mod tests {
         assert_eq!(restore.target_center_hz, original.center_freq_hz);
         assert_eq!(restore.target_frontend_decim, original.frontend_decim);
         assert_eq!(restore.target_vfo_offset_hz, original.vfo_offset_hz);
+    }
+
+    #[test]
+    fn validate_rejects_empty() {
+        assert_eq!(
+            validate_custom_channels(&[]),
+            Err(CustomChannelError::Empty)
+        );
+    }
+
+    #[test]
+    fn validate_accepts_single_channel() {
+        assert_eq!(validate_custom_channels(&[131_550_000.0]), Ok(()));
+    }
+
+    #[test]
+    #[allow(clippy::cast_precision_loss)]
+    fn validate_accepts_max_count() {
+        let chans: Vec<f64> = (0..MAX_CUSTOM_CHANNELS)
+            .map(|i| 131_000_000.0 + (i as f64) * 100_000.0)
+            .collect();
+        assert_eq!(validate_custom_channels(&chans), Ok(()));
+    }
+
+    #[test]
+    #[allow(clippy::cast_precision_loss)]
+    fn validate_rejects_too_many() {
+        let chans: Vec<f64> = (0..=MAX_CUSTOM_CHANNELS)
+            .map(|i| 131_000_000.0 + (i as f64) * 100_000.0)
+            .collect();
+        assert_eq!(
+            validate_custom_channels(&chans),
+            Err(CustomChannelError::TooMany {
+                count: MAX_CUSTOM_CHANNELS + 1,
+                max: MAX_CUSTOM_CHANNELS,
+            })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_nan() {
+        match validate_custom_channels(&[131_550_000.0, f64::NAN]) {
+            Err(CustomChannelError::InvalidFrequency { .. }) => {}
+            other => panic!("expected InvalidFrequency, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_inf() {
+        match validate_custom_channels(&[131_550_000.0, f64::INFINITY]) {
+            Err(CustomChannelError::InvalidFrequency { .. }) => {}
+            other => panic!("expected InvalidFrequency, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_negative_or_zero() {
+        match validate_custom_channels(&[131_550_000.0, 0.0]) {
+            Err(CustomChannelError::InvalidFrequency { value: 0.0 }) => {}
+            other => panic!("expected InvalidFrequency(0.0), got {other:?}"),
+        }
+        match validate_custom_channels(&[131_550_000.0, -1.0]) {
+            Err(CustomChannelError::InvalidFrequency { value: -1.0 }) => {}
+            other => panic!("expected InvalidFrequency(-1.0), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_accepts_span_just_under() {
+        // 2.4 MHz exact span — accepted (the constraint is ≤).
+        assert_eq!(
+            validate_custom_channels(&[129_125_000.0, 131_525_000.0]),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn validate_rejects_span_just_over() {
+        // 2.5 MHz — rejected.
+        match validate_custom_channels(&[129_000_000.0, 131_500_000.0]) {
+            Err(CustomChannelError::SpanExceeded {
+                low_hz,
+                high_hz,
+                span_hz,
+            }) => {
+                assert!((low_hz - 129_000_000.0).abs() < 1.0);
+                assert!((high_hz - 131_500_000.0).abs() < 1.0);
+                assert!((span_hz - 2_500_000.0).abs() < 1.0);
+            }
+            other => panic!("expected SpanExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_channel_error_display_span_exceeded() {
+        let err = CustomChannelError::SpanExceeded {
+            low_hz: 129_000_000.0,
+            high_hz: 131_500_000.0,
+            span_hz: 2_500_000.0,
+        };
+        let s = format!("{err}");
+        assert!(s.contains("2.5"), "span value present: {s}");
+        assert!(s.contains("129"), "low freq present: {s}");
+        assert!(s.contains("131"), "high freq present: {s}");
     }
 }

--- a/crates/sdr-core/src/acars_output.rs
+++ b/crates/sdr-core/src/acars_output.rs
@@ -42,6 +42,18 @@ pub struct AcarsWriterConfig {
 pub enum AcarsOutputMessage {
     /// One decoded ACARS message, ready to write + feed.
     Decoded(sdr_acars::AcarsMessage),
+    /// The shared `AcarsWriterConfig` was mutated by the UI side.
+    /// Wakes the writer to re-snapshot config and apply
+    /// `ensure_jsonl` / `ensure_udp` so config-only changes
+    /// (disable, path swap, addr swap) take effect immediately
+    /// instead of being buffered until the next decoded message.
+    /// CR round 1 on PR #598.
+    ConfigChanged,
+    /// Explicit clean-shutdown signal. `Drop for AcarsOutputs`
+    /// emits this before dropping `tx`; the worker also exits
+    /// cleanly on `Disconnected` as a fallback. Having an
+    /// explicit variant makes shutdown deterministic for tests.
+    Shutdown,
 }
 
 /// Append-only JSONL writer. One JSON object per line (`\n`-
@@ -190,26 +202,33 @@ pub struct AcarsOutputs {
 
 impl AcarsOutputs {
     /// Construct an async-output bundle and spawn the writer
-    /// thread. The thread runs until `Drop` for `AcarsOutputs`
-    /// drops the `tx`, at which point the writer's `recv()`
-    /// returns `Err(Disconnected)` and the loop exits.
+    /// thread. `dsp_tx` is cloned into the worker so it can
+    /// surface open / write / send failures back to the UI as
+    /// `DspToUi::AcarsOutputError` toasts (CR round 1 on PR
+    /// #598; preserves the UI error contract that the original
+    /// synchronous code had in PR #595).
+    ///
+    /// The thread runs until `Drop for AcarsOutputs` sends an
+    /// explicit `Shutdown` message (or — as a fallback — drops
+    /// `tx`, at which point the writer's `recv()` returns
+    /// `Err(Disconnected)`). Either way the loop exits cleanly.
     #[must_use]
-    pub fn new() -> Self {
-        Self::with_capacity(ACARS_OUTPUT_CHANNEL_CAPACITY)
+    pub fn new(dsp_tx: mpsc::Sender<crate::messages::DspToUi>) -> Self {
+        Self::with_capacity(ACARS_OUTPUT_CHANNEL_CAPACITY, dsp_tx)
     }
 
     /// Same as `new` but with a caller-chosen channel
     /// capacity. Production calls go through `new`; tests use
     /// this directly via `with_capacity_for_test` to exercise
     /// the drop-on-full path with a cap they can saturate.
-    fn with_capacity(capacity: usize) -> Self {
+    fn with_capacity(capacity: usize, dsp_tx: mpsc::Sender<crate::messages::DspToUi>) -> Self {
         let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(capacity);
         let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
 
         let writer_config = Arc::clone(&config);
         let writer_thread = std::thread::Builder::new()
             .name("sdr-acars-writer".into())
-            .spawn(move || run_writer_loop(rx, writer_config))
+            .spawn(move || run_writer_loop(rx, writer_config, dsp_tx))
             .expect("failed to spawn ACARS writer thread");
 
         Self {
@@ -268,6 +287,24 @@ impl AcarsOutputs {
         self.drop_count.load(Ordering::Relaxed)
     }
 
+    /// Wake the writer thread so it re-snapshots the shared
+    /// `config` and applies `ensure_jsonl` / `ensure_udp`. The
+    /// controller's `handle_set_acars_*` handlers call this
+    /// after every config write so config-only changes
+    /// (disable, path swap, addr swap) take effect immediately
+    /// — without it, the worker only wakes on `Decoded` and
+    /// stale handles linger until the next decoded frame
+    /// (CR round 1 on PR #598).
+    ///
+    /// `try_send`, not `send`: if the channel is full the
+    /// worker is already saturated processing `Decoded` and
+    /// will re-snapshot config on the next iteration anyway
+    /// — a dropped `ConfigChanged` is harmless under that
+    /// pressure.
+    pub fn notify_config_changed(&self) {
+        let _ = self.tx.try_send(AcarsOutputMessage::ConfigChanged);
+    }
+
     /// 30 s-rate-limited warn for channel-full drops. Reads
     /// the current drop count so the message names how many
     /// were lost in this window.
@@ -286,18 +323,21 @@ impl AcarsOutputs {
     }
 }
 
-impl Default for AcarsOutputs {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Drop for AcarsOutputs {
     fn drop(&mut self) {
+        // Send the explicit Shutdown sentinel first so the
+        // worker exits via the deterministic `Shutdown` arm
+        // rather than the `Err(Disconnected)` fallback. Both
+        // paths drain cleanly, but Shutdown means tests can
+        // assert promptness without racing the OS scheduler.
+        // `try_send` is fine — if the channel is full the
+        // Disconnected fallback below still terminates.
+        let _ = self.tx.try_send(AcarsOutputMessage::Shutdown);
+
         // Closing tx triggers Disconnected → the writer loop
-        // exits. We still need to join the thread to make
-        // sure its Drop impls (BufWriter flush) finish before
-        // the process exits.
+        // exits as a fallback. We still need to join the thread
+        // to make sure its Drop impls (BufWriter flush) finish
+        // before the process exits.
         if let Some(handle) = self.writer_thread.take() {
             // Drop the tx clone held by `self.tx` first by
             // overwriting it with a drained channel.
@@ -316,48 +356,97 @@ impl Drop for AcarsOutputs {
 
 /// Writer-thread main loop. Owns the per-thread `JsonlWriter`
 /// and `UdpFeeder` instances, reads `config` on each message
-/// to detect path/addr changes, and exits cleanly when the
-/// sender side disconnects (app shutdown). Issue #596.
+/// (or on `ConfigChanged`) to detect path/addr changes, and
+/// exits cleanly on `Shutdown` or when the sender side
+/// disconnects (app shutdown). Issue #596 / CR round 1 on PR
+/// #598.
 #[allow(clippy::needless_pass_by_value)] // rx must be owned to observe disconnect
-fn run_writer_loop(rx: mpsc::Receiver<AcarsOutputMessage>, config: Arc<RwLock<AcarsWriterConfig>>) {
+fn run_writer_loop(
+    rx: mpsc::Receiver<AcarsOutputMessage>,
+    config: Arc<RwLock<AcarsWriterConfig>>,
+    dsp_tx: mpsc::Sender<crate::messages::DspToUi>,
+) {
     let mut jsonl: Option<(PathBuf, JsonlWriter)> = None;
     let mut udp: Option<(String, UdpFeeder)> = None;
     let mut jsonl_warn_at: Option<std::time::Instant> = None;
     let mut udp_warn_at: Option<std::time::Instant> = None;
 
-    while let Ok(msg) = rx.recv() {
-        let AcarsOutputMessage::Decoded(msg) = msg;
+    // `while let Ok(_)` is the disconnect-fallback path; the
+    // inner `match` handles the explicit Shutdown sentinel
+    // (which `break`s out of the outer loop). Either path
+    // exits cleanly. CR round 1 on PR #598.
+    'recv: while let Ok(msg) = rx.recv() {
+        match msg {
+            AcarsOutputMessage::Shutdown => break 'recv,
+            AcarsOutputMessage::ConfigChanged => {
+                // No payload to write — just resnap config and
+                // close/open. ensure_* close on None and reopen
+                // on path/addr change, so disabling JSONL or
+                // swapping the destination applies immediately
+                // even with no decoded traffic.
+                let (want_jsonl_path, want_udp_addr, _station_id) = {
+                    let cfg = config.read().expect("acars writer config poisoned");
+                    (
+                        cfg.jsonl_path.clone(),
+                        cfg.network_addr.clone(),
+                        cfg.station_id.clone(),
+                    )
+                };
+                ensure_jsonl(&mut jsonl, want_jsonl_path.as_deref(), &dsp_tx);
+                ensure_udp(&mut udp, want_udp_addr.as_deref(), &dsp_tx);
+            }
+            AcarsOutputMessage::Decoded(msg) => {
+                // Snapshot the config under a brief read lock so we
+                // don't hold it across blocking I/O.
+                let (want_jsonl_path, want_udp_addr, station_id) = {
+                    let cfg = config.read().expect("acars writer config poisoned");
+                    (
+                        cfg.jsonl_path.clone(),
+                        cfg.network_addr.clone(),
+                        cfg.station_id.clone(),
+                    )
+                };
 
-        // Snapshot the config under a brief read lock so we
-        // don't hold it across blocking I/O.
-        let (want_jsonl_path, want_udp_addr, station_id) = {
-            let cfg = config.read().expect("acars writer config poisoned");
-            (
-                cfg.jsonl_path.clone(),
-                cfg.network_addr.clone(),
-                cfg.station_id.clone(),
-            )
-        };
+                ensure_jsonl(&mut jsonl, want_jsonl_path.as_deref(), &dsp_tx);
+                ensure_udp(&mut udp, want_udp_addr.as_deref(), &dsp_tx);
 
-        ensure_jsonl(&mut jsonl, want_jsonl_path.as_deref());
-        ensure_udp(&mut udp, want_udp_addr.as_deref());
-
-        if let Some((_, w)) = jsonl.as_mut()
-            && let Err(e) = w.write(&msg, station_id.as_deref())
-        {
-            rate_limited_warn("jsonl", &mut jsonl_warn_at, &e);
-        }
-        if let Some((_, f)) = udp.as_mut()
-            && let Err(e) = f.send(&msg, station_id.as_deref())
-        {
-            rate_limited_warn("udp", &mut udp_warn_at, &e);
+                if let Some((_, w)) = jsonl.as_mut()
+                    && let Err(e) = w.write(&msg, station_id.as_deref())
+                {
+                    rate_limited_warn_and_emit("jsonl", &mut jsonl_warn_at, &e, &dsp_tx);
+                }
+                if let Some((_, f)) = udp.as_mut()
+                    && let Err(e) = f.send(&msg, station_id.as_deref())
+                {
+                    rate_limited_warn_and_emit("udp", &mut udp_warn_at, &e, &dsp_tx);
+                }
+            }
         }
     }
 }
 
+/// Emit `DspToUi::AcarsOutputError` for an open / write / send
+/// failure. The matching `tracing::warn!` is the caller's job
+/// (separated so the rate-limiter can decide whether to also
+/// warn-spam logs); this is the UI-toast surface.
+fn emit_output_error(
+    dsp_tx: &mpsc::Sender<crate::messages::DspToUi>,
+    kind: &'static str,
+    message: String,
+) {
+    let _ = dsp_tx.send(crate::messages::DspToUi::AcarsOutputError { kind, message });
+}
+
 /// Ensure `slot` holds an open `JsonlWriter` matching `want`.
 /// Reopens on path change; closes (drops) when `want` is `None`.
-fn ensure_jsonl(slot: &mut Option<(PathBuf, JsonlWriter)>, want: Option<&Path>) {
+/// Open failures are logged via `tracing::warn!` AND surfaced
+/// to the UI as `DspToUi::AcarsOutputError` for toast display
+/// (CR round 1 on PR #598).
+fn ensure_jsonl(
+    slot: &mut Option<(PathBuf, JsonlWriter)>,
+    want: Option<&Path>,
+    dsp_tx: &mpsc::Sender<crate::messages::DspToUi>,
+) {
     let needs_reopen = match (slot.as_ref(), want) {
         (None, None) => false,
         (Some((cur, _)), Some(want)) if cur == want => false,
@@ -370,7 +459,11 @@ fn ensure_jsonl(slot: &mut Option<(PathBuf, JsonlWriter)>, want: Option<&Path>) 
     if let Some(want) = want {
         match JsonlWriter::open(want) {
             Ok(w) => *slot = Some((want.to_path_buf(), w)),
-            Err(e) => tracing::warn!("acars jsonl open failed: {e}"),
+            Err(e) => {
+                let message = format!("acars jsonl open failed: {e}");
+                tracing::warn!("{message}");
+                emit_output_error(dsp_tx, "jsonl", message);
+            }
         }
     }
 }
@@ -378,7 +471,11 @@ fn ensure_jsonl(slot: &mut Option<(PathBuf, JsonlWriter)>, want: Option<&Path>) 
 /// Same shape as `ensure_jsonl` but for `UdpFeeder`. The `String`
 /// key compares the user-set addr verbatim; resolved peer
 /// addresses are not the source of truth.
-fn ensure_udp(slot: &mut Option<(String, UdpFeeder)>, want: Option<&str>) {
+fn ensure_udp(
+    slot: &mut Option<(String, UdpFeeder)>,
+    want: Option<&str>,
+    dsp_tx: &mpsc::Sender<crate::messages::DspToUi>,
+) {
     let needs_reopen = match (slot.as_ref(), want) {
         (None, None) => false,
         (Some((cur, _)), Some(want)) if cur == want => false,
@@ -391,22 +488,35 @@ fn ensure_udp(slot: &mut Option<(String, UdpFeeder)>, want: Option<&str>) {
     if let Some(want) = want {
         match UdpFeeder::open(want) {
             Ok(f) => *slot = Some((want.to_string(), f)),
-            Err(e) => tracing::warn!("acars udp open failed: {e}"),
+            Err(e) => {
+                let message = format!("acars udp open failed: {e}");
+                tracing::warn!("{message}");
+                emit_output_error(dsp_tx, "udp", message);
+            }
         }
     }
 }
 
 const ACARS_OUTPUT_WARN_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Emit a `tracing::warn!` at most once per
-/// `ACARS_OUTPUT_WARN_MIN_INTERVAL` for `kind`. Mirrors the
-/// per-writer 30 s rate-limit that previously lived in
-/// `controller.rs::acars_decode_tap`.
-fn rate_limited_warn(kind: &str, last: &mut Option<std::time::Instant>, err: &std::io::Error) {
+/// Emit a `tracing::warn!` AND a `DspToUi::AcarsOutputError`
+/// at most once per `ACARS_OUTPUT_WARN_MIN_INTERVAL` for
+/// `kind`. Mirrors the per-writer 30 s rate-limit that
+/// previously lived in `controller.rs::acars_decode_tap`,
+/// extended in CR round 1 on PR #598 to also surface the
+/// failure to the UI as a toast.
+fn rate_limited_warn_and_emit(
+    kind: &'static str,
+    last: &mut Option<std::time::Instant>,
+    err: &std::io::Error,
+    dsp_tx: &mpsc::Sender<crate::messages::DspToUi>,
+) {
     let now = std::time::Instant::now();
     let elapsed = last.map_or(ACARS_OUTPUT_WARN_MIN_INTERVAL, |t| now.duration_since(t));
     if elapsed >= ACARS_OUTPUT_WARN_MIN_INTERVAL {
-        tracing::warn!("acars {kind} write/send failed: {err} (rate-limited 30s)");
+        let message = format!("acars {kind} write/send failed: {err}");
+        tracing::warn!("{message} (rate-limited 30s)");
+        emit_output_error(dsp_tx, kind, message);
         *last = Some(now);
     }
 }
@@ -537,8 +647,9 @@ mod tests {
         // recv() returning Err(Disconnected) → loop break path.
         let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
         let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(8);
+        let (dummy_dsp_tx, _dsp_rx) = mpsc::channel::<crate::messages::DspToUi>();
         let handle = std::thread::spawn(move || {
-            run_writer_loop(rx, Arc::clone(&config));
+            run_writer_loop(rx, Arc::clone(&config), dummy_dsp_tx);
         });
         drop(tx);
         // Loop should exit promptly. Allow up to 500 ms for
@@ -590,9 +701,10 @@ mod tests {
             station_id: None,
         }));
         let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(8);
+        let (dummy_dsp_tx, _dsp_rx) = mpsc::channel::<crate::messages::DspToUi>();
         let handle = {
             let config = Arc::clone(&config);
-            std::thread::spawn(move || run_writer_loop(rx, config))
+            std::thread::spawn(move || run_writer_loop(rx, config, dummy_dsp_tx))
         };
 
         tx.send(AcarsOutputMessage::Decoded(make_msg(0))).unwrap();
@@ -619,5 +731,50 @@ mod tests {
             1,
             "path B got the second message"
         );
+    }
+
+    #[test]
+    fn config_changed_signal_wakes_idle_writer() {
+        // Verifies the CR round 1 fix on PR #598: send
+        // ConfigChanged with no preceding Decoded; the worker
+        // re-snapshots config and calls ensure_jsonl, which
+        // opens the file in append mode and creates it. Without
+        // the fix the worker would only wake on Decoded and the
+        // file would never appear.
+        let dir = tempdir().unwrap();
+        let path_a = dir.path().join("idle_open.jsonl");
+
+        let config = Arc::new(RwLock::new(AcarsWriterConfig {
+            jsonl_path: Some(path_a.clone()),
+            network_addr: None,
+            station_id: None,
+        }));
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(8);
+        let (dummy_dsp_tx, _dsp_rx) = mpsc::channel::<crate::messages::DspToUi>();
+        let handle = {
+            let config = Arc::clone(&config);
+            std::thread::spawn(move || run_writer_loop(rx, config, dummy_dsp_tx))
+        };
+
+        // No Decoded — only ConfigChanged. The worker must wake,
+        // resnap config, and open path_a. JsonlWriter::open in
+        // append-mode creates the file even with no writes.
+        tx.send(AcarsOutputMessage::ConfigChanged).unwrap();
+
+        // Spin briefly to let the worker process ConfigChanged.
+        let start = std::time::Instant::now();
+        while !path_a.exists() && start.elapsed() < Duration::from_millis(500) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            path_a.exists(),
+            "ConfigChanged should have caused the writer to open path A even with no Decoded messages"
+        );
+
+        // Clean shutdown via Shutdown sentinel — exercises the
+        // explicit-shutdown arm.
+        tx.send(AcarsOutputMessage::Shutdown).unwrap();
+        drop(tx);
+        handle.join().expect("writer thread panicked");
     }
 }

--- a/crates/sdr-core/src/acars_output.rs
+++ b/crates/sdr-core/src/acars_output.rs
@@ -13,7 +13,9 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Write};
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock, mpsc};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock, mpsc};
+use std::thread::JoinHandle;
 
 use sdr_acars::AcarsMessage;
 
@@ -150,37 +152,136 @@ impl UdpFeeder {
     }
 }
 
-/// Output-writer bundle owned by `DspState`. Keeps the JSONL
-/// writer, UDP feeder, station ID, and per-writer warn-rate-
-/// limit timestamps together so the `acars_decode_tap`
-/// signature stays narrow. Issue #578. Async refactor in
-/// progress per #596 — fields will migrate to a worker
-/// thread + shared config lock in subsequent tasks.
+/// Capacity of the bounded `mpsc::sync_channel` between the
+/// DSP thread and the writer thread. 256 is ~4-5 minutes of
+/// worst-case ACARS bursts (~1 msg/sec sustained, 10 msg/sec
+/// burst peak); covers any realistic disk stall short of total
+/// filesystem hang. Issue #596.
+pub const ACARS_OUTPUT_CHANNEL_CAPACITY: usize = 256;
+
+/// Output-writer bundle owned by `DspState`. Holds the sender
+/// half of the bounded channel + the shared writer config +
+/// the worker thread's join handle. The DSP thread calls
+/// `try_send` per decoded message; the writer thread (spawned
+/// from `new`) does the actual JSONL/UDP I/O. Issue #596.
 pub struct AcarsOutputs {
-    pub jsonl: Option<JsonlWriter>,
-    pub udp: Option<UdpFeeder>,
-    pub jsonl_enabled: bool,
-    pub network_enabled: bool,
-    pub station_id: Option<String>,
-    pub jsonl_warn_at: Option<std::time::Instant>,
-    pub udp_warn_at: Option<std::time::Instant>,
-    pub pending_jsonl_path: Option<String>,
-    pub pending_network_addr: Option<String>,
+    /// Sender half of the writer channel. `try_send` drops on
+    /// full; the worker owns the receiver.
+    tx: mpsc::SyncSender<AcarsOutputMessage>,
+    /// Shared, runtime-mutable writer config. Written by the
+    /// UI side on toggle/edit; read by the writer thread on
+    /// each message.
+    pub config: Arc<RwLock<AcarsWriterConfig>>,
+    /// Cumulative count of messages dropped because the
+    /// channel was full. Surfaced via `drop_count` for
+    /// rate-limited warn at the call site (and the smoke
+    /// checklist).
+    drop_count: Arc<AtomicU64>,
+    /// Last warn timestamp for channel-full drops. Wrapped in
+    /// `Arc<Mutex>` because the warn fires from the DSP thread
+    /// (caller of `try_send`); the writer thread doesn't touch
+    /// it.
+    last_drop_warn_at: Arc<Mutex<Option<std::time::Instant>>>,
+    /// Join handle for the writer thread. `Drop` for
+    /// `AcarsOutputs` drops `tx`, which signals shutdown via
+    /// recv() returning Err(Disconnected); we then `join()`.
+    writer_thread: Option<JoinHandle<()>>,
 }
 
 impl AcarsOutputs {
+    /// Construct an async-output bundle and spawn the writer
+    /// thread. The thread runs until `Drop` for `AcarsOutputs`
+    /// drops the `tx`, at which point the writer's `recv()`
+    /// returns `Err(Disconnected)` and the loop exits.
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
+        Self::with_capacity(ACARS_OUTPUT_CHANNEL_CAPACITY)
+    }
+
+    /// Same as `new` but with a caller-chosen channel
+    /// capacity. Production calls go through `new`; tests use
+    /// this directly via `with_capacity_for_test` to exercise
+    /// the drop-on-full path with a cap they can saturate.
+    fn with_capacity(capacity: usize) -> Self {
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(capacity);
+        let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
+
+        let writer_config = Arc::clone(&config);
+        let writer_thread = std::thread::Builder::new()
+            .name("sdr-acars-writer".into())
+            .spawn(move || run_writer_loop(rx, writer_config))
+            .expect("failed to spawn ACARS writer thread");
+
         Self {
-            jsonl: None,
-            udp: None,
-            jsonl_enabled: false,
-            network_enabled: false,
-            station_id: None,
-            jsonl_warn_at: None,
-            udp_warn_at: None,
-            pending_jsonl_path: None,
-            pending_network_addr: None,
+            tx,
+            config,
+            drop_count: Arc::new(AtomicU64::new(0)),
+            last_drop_warn_at: Arc::new(Mutex::new(None)),
+            writer_thread: Some(writer_thread),
+        }
+    }
+
+    /// Test-only constructor that builds the channel + config
+    /// but skips spawning the worker, leaving the receiver
+    /// dangling so tests can fill the channel without races.
+    #[cfg(test)]
+    fn with_capacity_for_test(capacity: usize) -> Self {
+        let (tx, _rx) = mpsc::sync_channel::<AcarsOutputMessage>(capacity);
+        // Leak the receiver as a thread-local so the channel
+        // doesn't disconnect (which would route try_send into
+        // the Disconnected arm instead of Full). std::mem::forget
+        // is the cheapest way to do this in test context.
+        #[allow(clippy::mem_forget)]
+        std::mem::forget(_rx);
+        let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
+        Self {
+            tx,
+            config,
+            drop_count: Arc::new(AtomicU64::new(0)),
+            last_drop_warn_at: Arc::new(Mutex::new(None)),
+            writer_thread: None,
+        }
+    }
+
+    /// Try to hand off `msg` to the writer thread. Returns
+    /// `true` on success, `false` if the channel was full
+    /// (drop counter incremented; warn fires at most once per
+    /// 30 s).
+    pub fn try_send(&self, msg: sdr_acars::AcarsMessage) -> bool {
+        match self.tx.try_send(AcarsOutputMessage::Decoded(msg)) {
+            Ok(()) => true,
+            Err(mpsc::TrySendError::Full(_)) => {
+                self.drop_count.fetch_add(1, Ordering::Relaxed);
+                self.maybe_warn_full();
+                false
+            }
+            // Disconnected only happens on shutdown (writer
+            // thread is gone). Silent — caller shouldn't
+            // surface noise during teardown.
+            Err(mpsc::TrySendError::Disconnected(_)) => false,
+        }
+    }
+
+    /// Cumulative drop count since startup.
+    #[must_use]
+    pub fn drop_count(&self) -> u64 {
+        self.drop_count.load(Ordering::Relaxed)
+    }
+
+    /// 30 s-rate-limited warn for channel-full drops. Reads
+    /// the current drop count so the message names how many
+    /// were lost in this window.
+    fn maybe_warn_full(&self) {
+        let mut last = self.last_drop_warn_at.lock().expect("warn lock poisoned");
+        let now = std::time::Instant::now();
+        let elapsed = last.map_or(ACARS_OUTPUT_WARN_MIN_INTERVAL, |t| now.duration_since(t));
+        if elapsed >= ACARS_OUTPUT_WARN_MIN_INTERVAL {
+            let n = self.drop_count.load(Ordering::Relaxed);
+            tracing::warn!(
+                "ACARS output channel full ({n} drops since startup); \
+                 writer thread falling behind (rate-limited 30s)"
+            );
+            *last = Some(now);
         }
     }
 }
@@ -191,11 +292,32 @@ impl Default for AcarsOutputs {
     }
 }
 
+impl Drop for AcarsOutputs {
+    fn drop(&mut self) {
+        // Closing tx triggers Disconnected → the writer loop
+        // exits. We still need to join the thread to make
+        // sure its Drop impls (BufWriter flush) finish before
+        // the process exits.
+        if let Some(handle) = self.writer_thread.take() {
+            // Drop the tx clone held by `self.tx` first by
+            // overwriting it with a drained channel.
+            // (mpsc::SyncSender doesn't have an explicit
+            // close — Drop is the signal.)
+            let (dummy_tx, _) = mpsc::sync_channel::<AcarsOutputMessage>(0);
+            self.tx = dummy_tx;
+            // Now the original tx is gone (replaced + dropped).
+            // Wait for the worker to exit.
+            if let Err(e) = handle.join() {
+                tracing::warn!("ACARS writer thread join failed: {e:?}");
+            }
+        }
+    }
+}
+
 /// Writer-thread main loop. Owns the per-thread `JsonlWriter`
 /// and `UdpFeeder` instances, reads `config` on each message
 /// to detect path/addr changes, and exits cleanly when the
 /// sender side disconnects (app shutdown). Issue #596.
-#[allow(dead_code)] // used from tests; caller site lands in Task 5
 #[allow(clippy::needless_pass_by_value)] // rx must be owned to observe disconnect
 fn run_writer_loop(rx: mpsc::Receiver<AcarsOutputMessage>, config: Arc<RwLock<AcarsWriterConfig>>) {
     let mut jsonl: Option<(PathBuf, JsonlWriter)> = None;
@@ -430,6 +552,27 @@ mod tests {
             "writer thread did not exit within 500ms of tx drop"
         );
         handle.join().expect("writer thread panicked");
+    }
+
+    #[test]
+    fn try_send_drops_when_channel_full() {
+        // Build an AcarsOutputs against a tiny channel cap (8)
+        // by spawning *no* worker — leave the receiver dangling
+        // so the channel fills from the first send. The 9th
+        // try_send should drop.
+        //
+        // `AcarsOutputs::with_capacity` is a test-visible
+        // constructor that lets tests use a smaller cap than
+        // the production 256.
+        let outputs = AcarsOutputs::with_capacity_for_test(8);
+
+        for _ in 0..8 {
+            assert!(outputs.try_send(make_msg(0)));
+        }
+        // 9th send: channel full, drop returns false, counter
+        // increments.
+        assert!(!outputs.try_send(make_msg(0)));
+        assert_eq!(outputs.drop_count(), 1);
     }
 
     #[test]

--- a/crates/sdr-core/src/acars_output.rs
+++ b/crates/sdr-core/src/acars_output.rs
@@ -16,6 +16,33 @@ use std::path::{Path, PathBuf};
 
 use sdr_acars::AcarsMessage;
 
+/// Runtime-mutable writer config. Read-heavy access pattern:
+/// the writer thread reads on every message, the UI side writes
+/// only on user toggle / address edit / station-id change.
+/// Issue #596.
+#[allow(dead_code)]
+#[derive(Clone, Debug, Default)]
+pub struct AcarsWriterConfig {
+    /// Where to write the JSONL log. `None` means JSONL output
+    /// is disabled. Path changes trigger a reopen on the next
+    /// message; the worker closes the previous file.
+    pub jsonl_path: Option<PathBuf>,
+    /// UDP feeder destination (`"host:port"`). `None` means
+    /// network output is disabled.
+    pub network_addr: Option<String>,
+    /// Station ID injected into each emitted JSON record.
+    pub station_id: Option<String>,
+}
+
+/// Messages handed from the DSP thread to the writer thread.
+/// Bounded `mpsc::sync_channel` decouples the DSP-thread
+/// `acars_decode_tap` closure from disk / network I/O latency.
+#[allow(dead_code)]
+pub enum AcarsOutputMessage {
+    /// One decoded ACARS message, ready to write + feed.
+    Decoded(sdr_acars::AcarsMessage),
+}
+
 /// Append-only JSONL writer. One JSON object per line (`\n`-
 /// terminated). Wraps the file in a `BufWriter` so bursty
 /// per-message writes don't syscall on each one; flushed on

--- a/crates/sdr-core/src/acars_output.rs
+++ b/crates/sdr-core/src/acars_output.rs
@@ -13,6 +13,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Write};
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock, mpsc};
 
 use sdr_acars::AcarsMessage;
 
@@ -20,7 +21,6 @@ use sdr_acars::AcarsMessage;
 /// the writer thread reads on every message, the UI side writes
 /// only on user toggle / address edit / station-id change.
 /// Issue #596.
-#[allow(dead_code)]
 #[derive(Clone, Debug, Default)]
 pub struct AcarsWriterConfig {
     /// Where to write the JSONL log. `None` means JSONL output
@@ -37,7 +37,6 @@ pub struct AcarsWriterConfig {
 /// Messages handed from the DSP thread to the writer thread.
 /// Bounded `mpsc::sync_channel` decouples the DSP-thread
 /// `acars_decode_tap` closure from disk / network I/O latency.
-#[allow(dead_code)]
 pub enum AcarsOutputMessage {
     /// One decoded ACARS message, ready to write + feed.
     Decoded(sdr_acars::AcarsMessage),
@@ -192,6 +191,25 @@ impl Default for AcarsOutputs {
     }
 }
 
+/// Writer-thread main loop. Owns the per-thread `JsonlWriter`
+/// and `UdpFeeder` instances, reads `config` on each message
+/// to detect path/addr changes, and exits cleanly when the
+/// sender side disconnects (app shutdown). Issue #596.
+#[allow(dead_code)] // used from tests; caller site lands in Task 5
+#[allow(clippy::needless_pass_by_value)] // rx must be owned to observe disconnect
+fn run_writer_loop(
+    rx: mpsc::Receiver<AcarsOutputMessage>,
+    _config: Arc<RwLock<AcarsWriterConfig>>,
+) {
+    // Real per-message handling lands in Task 4 (path/addr
+    // hot-reload) and Task 5 (writes + send). For now, just
+    // drain the channel so the shutdown-on-disconnect contract
+    // holds.
+    while let Ok(_msg) = rx.recv() {
+        // Drain only — Task 4 + 5 wire writes here.
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -204,6 +222,8 @@ mod tests {
     use sdr_acars::AcarsMessage;
     use serde_json::Value;
     use tempfile::tempdir;
+
+    use std::sync::{Arc, RwLock, mpsc};
 
     use super::*;
 
@@ -307,5 +327,29 @@ mod tests {
         // Unresolvable host.
         // Use .invalid TLD per RFC 6761 — guaranteed to never resolve.
         assert!(UdpFeeder::open("nonexistent.invalid:5550").is_err());
+    }
+
+    #[test]
+    fn writer_thread_exits_on_disconnect() {
+        // Spawn a writer thread, drop the sender, assert the
+        // thread joins within a short timeout. Exercises the
+        // recv() returning Err(Disconnected) → loop break path.
+        let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(8);
+        let handle = std::thread::spawn(move || {
+            run_writer_loop(rx, Arc::clone(&config));
+        });
+        drop(tx);
+        // Loop should exit promptly. Allow up to 500 ms for
+        // schedulability under loaded test workers.
+        let start = std::time::Instant::now();
+        while !handle.is_finished() && start.elapsed() < Duration::from_millis(500) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            handle.is_finished(),
+            "writer thread did not exit within 500ms of tx drop"
+        );
+        handle.join().expect("writer thread panicked");
     }
 }

--- a/crates/sdr-core/src/acars_output.rs
+++ b/crates/sdr-core/src/acars_output.rs
@@ -197,16 +197,95 @@ impl Default for AcarsOutputs {
 /// sender side disconnects (app shutdown). Issue #596.
 #[allow(dead_code)] // used from tests; caller site lands in Task 5
 #[allow(clippy::needless_pass_by_value)] // rx must be owned to observe disconnect
-fn run_writer_loop(
-    rx: mpsc::Receiver<AcarsOutputMessage>,
-    _config: Arc<RwLock<AcarsWriterConfig>>,
-) {
-    // Real per-message handling lands in Task 4 (path/addr
-    // hot-reload) and Task 5 (writes + send). For now, just
-    // drain the channel so the shutdown-on-disconnect contract
-    // holds.
-    while let Ok(_msg) = rx.recv() {
-        // Drain only — Task 4 + 5 wire writes here.
+fn run_writer_loop(rx: mpsc::Receiver<AcarsOutputMessage>, config: Arc<RwLock<AcarsWriterConfig>>) {
+    let mut jsonl: Option<(PathBuf, JsonlWriter)> = None;
+    let mut udp: Option<(String, UdpFeeder)> = None;
+    let mut jsonl_warn_at: Option<std::time::Instant> = None;
+    let mut udp_warn_at: Option<std::time::Instant> = None;
+
+    while let Ok(msg) = rx.recv() {
+        let AcarsOutputMessage::Decoded(msg) = msg;
+
+        // Snapshot the config under a brief read lock so we
+        // don't hold it across blocking I/O.
+        let (want_jsonl_path, want_udp_addr, station_id) = {
+            let cfg = config.read().expect("acars writer config poisoned");
+            (
+                cfg.jsonl_path.clone(),
+                cfg.network_addr.clone(),
+                cfg.station_id.clone(),
+            )
+        };
+
+        ensure_jsonl(&mut jsonl, want_jsonl_path.as_deref());
+        ensure_udp(&mut udp, want_udp_addr.as_deref());
+
+        if let Some((_, w)) = jsonl.as_mut()
+            && let Err(e) = w.write(&msg, station_id.as_deref())
+        {
+            rate_limited_warn("jsonl", &mut jsonl_warn_at, &e);
+        }
+        if let Some((_, f)) = udp.as_mut()
+            && let Err(e) = f.send(&msg, station_id.as_deref())
+        {
+            rate_limited_warn("udp", &mut udp_warn_at, &e);
+        }
+    }
+}
+
+/// Ensure `slot` holds an open `JsonlWriter` matching `want`.
+/// Reopens on path change; closes (drops) when `want` is `None`.
+fn ensure_jsonl(slot: &mut Option<(PathBuf, JsonlWriter)>, want: Option<&Path>) {
+    let needs_reopen = match (slot.as_ref(), want) {
+        (None, None) => false,
+        (Some((cur, _)), Some(want)) if cur == want => false,
+        _ => true,
+    };
+    if !needs_reopen {
+        return;
+    }
+    *slot = None;
+    if let Some(want) = want {
+        match JsonlWriter::open(want) {
+            Ok(w) => *slot = Some((want.to_path_buf(), w)),
+            Err(e) => tracing::warn!("acars jsonl open failed: {e}"),
+        }
+    }
+}
+
+/// Same shape as `ensure_jsonl` but for `UdpFeeder`. The `String`
+/// key compares the user-set addr verbatim; resolved peer
+/// addresses are not the source of truth.
+fn ensure_udp(slot: &mut Option<(String, UdpFeeder)>, want: Option<&str>) {
+    let needs_reopen = match (slot.as_ref(), want) {
+        (None, None) => false,
+        (Some((cur, _)), Some(want)) if cur == want => false,
+        _ => true,
+    };
+    if !needs_reopen {
+        return;
+    }
+    *slot = None;
+    if let Some(want) = want {
+        match UdpFeeder::open(want) {
+            Ok(f) => *slot = Some((want.to_string(), f)),
+            Err(e) => tracing::warn!("acars udp open failed: {e}"),
+        }
+    }
+}
+
+const ACARS_OUTPUT_WARN_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Emit a `tracing::warn!` at most once per
+/// `ACARS_OUTPUT_WARN_MIN_INTERVAL` for `kind`. Mirrors the
+/// per-writer 30 s rate-limit that previously lived in
+/// `controller.rs::acars_decode_tap`.
+fn rate_limited_warn(kind: &str, last: &mut Option<std::time::Instant>, err: &std::io::Error) {
+    let now = std::time::Instant::now();
+    let elapsed = last.map_or(ACARS_OUTPUT_WARN_MIN_INTERVAL, |t| now.duration_since(t));
+    if elapsed >= ACARS_OUTPUT_WARN_MIN_INTERVAL {
+        tracing::warn!("acars {kind} write/send failed: {err} (rate-limited 30s)");
+        *last = Some(now);
     }
 }
 
@@ -351,5 +430,51 @@ mod tests {
             "writer thread did not exit within 500ms of tx drop"
         );
         handle.join().expect("writer thread panicked");
+    }
+
+    #[test]
+    fn writer_reopens_on_path_change() {
+        // Pump message → path A; switch config to path B; pump
+        // message → path B. Assert both files exist with the
+        // expected line count.
+        let dir = tempdir().unwrap();
+        let path_a = dir.path().join("a.jsonl");
+        let path_b = dir.path().join("b.jsonl");
+
+        let config = Arc::new(RwLock::new(AcarsWriterConfig {
+            jsonl_path: Some(path_a.clone()),
+            network_addr: None,
+            station_id: None,
+        }));
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(8);
+        let handle = {
+            let config = Arc::clone(&config);
+            std::thread::spawn(move || run_writer_loop(rx, config))
+        };
+
+        tx.send(AcarsOutputMessage::Decoded(make_msg(0))).unwrap();
+
+        // Spin briefly to let the writer process the first
+        // message before we mutate the path.
+        std::thread::sleep(Duration::from_millis(50));
+
+        config.write().unwrap().jsonl_path = Some(path_b.clone());
+        tx.send(AcarsOutputMessage::Decoded(make_msg(1))).unwrap();
+
+        // Drop tx → thread exits; flush on Drop ensures the
+        // BufWriter contents land on disk before we read.
+        drop(tx);
+        handle.join().expect("writer thread panicked");
+
+        let read_lines = |p: &Path| -> Vec<String> {
+            let f = File::open(p).unwrap();
+            BufReader::new(f).lines().collect::<Result<_, _>>().unwrap()
+        };
+        assert_eq!(read_lines(&path_a).len(), 1, "path A got the first message");
+        assert_eq!(
+            read_lines(&path_b).len(),
+            1,
+            "path B got the second message"
+        );
     }
 }

--- a/crates/sdr-core/src/acars_output.rs
+++ b/crates/sdr-core/src/acars_output.rs
@@ -124,6 +124,47 @@ impl UdpFeeder {
     }
 }
 
+/// Output-writer bundle owned by `DspState`. Keeps the JSONL
+/// writer, UDP feeder, station ID, and per-writer warn-rate-
+/// limit timestamps together so the `acars_decode_tap`
+/// signature stays narrow. Issue #578. Async refactor in
+/// progress per #596 — fields will migrate to a worker
+/// thread + shared config lock in subsequent tasks.
+pub struct AcarsOutputs {
+    pub jsonl: Option<JsonlWriter>,
+    pub udp: Option<UdpFeeder>,
+    pub jsonl_enabled: bool,
+    pub network_enabled: bool,
+    pub station_id: Option<String>,
+    pub jsonl_warn_at: Option<std::time::Instant>,
+    pub udp_warn_at: Option<std::time::Instant>,
+    pub pending_jsonl_path: Option<String>,
+    pub pending_network_addr: Option<String>,
+}
+
+impl AcarsOutputs {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            jsonl: None,
+            udp: None,
+            jsonl_enabled: false,
+            network_enabled: false,
+            station_id: None,
+            jsonl_warn_at: None,
+            udp_warn_at: None,
+            pending_jsonl_path: None,
+            pending_network_addr: None,
+        }
+    }
+}
+
+impl Default for AcarsOutputs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {

--- a/crates/sdr-core/src/acars_output.rs
+++ b/crates/sdr-core/src/acars_output.rs
@@ -184,7 +184,7 @@ pub struct AcarsOutputs {
     last_drop_warn_at: Arc<Mutex<Option<std::time::Instant>>>,
     /// Join handle for the writer thread. `Drop` for
     /// `AcarsOutputs` drops `tx`, which signals shutdown via
-    /// recv() returning Err(Disconnected); we then `join()`.
+    /// `recv()` returning `Err(Disconnected)`; we then `join()`.
     writer_thread: Option<JoinHandle<()>>,
 }
 
@@ -226,13 +226,13 @@ impl AcarsOutputs {
     /// dangling so tests can fill the channel without races.
     #[cfg(test)]
     fn with_capacity_for_test(capacity: usize) -> Self {
-        let (tx, _rx) = mpsc::sync_channel::<AcarsOutputMessage>(capacity);
-        // Leak the receiver as a thread-local so the channel
-        // doesn't disconnect (which would route try_send into
-        // the Disconnected arm instead of Full). std::mem::forget
-        // is the cheapest way to do this in test context.
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(capacity);
+        // Leak the receiver so the channel doesn't disconnect
+        // (which would route try_send into the Disconnected arm
+        // instead of Full). std::mem::forget is the cheapest way
+        // to do this in test context.
         #[allow(clippy::mem_forget)]
-        std::mem::forget(_rx);
+        std::mem::forget(rx);
         let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
         Self {
             tx,

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -228,10 +228,6 @@ fn poll_rtl_tcp_connection_state(state: &mut DspState, dsp_tx: &mpsc::Sender<Dsp
 
 use crate::acars_output::AcarsOutputs;
 
-/// Minimum interval between repeated warn-log emissions for
-/// the same writer. Issue #578.
-const ACARS_OUTPUT_WARN_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
-
 /// Mutable state owned by the DSP thread.
 ///
 /// This is a god-struct that holds every piece of DSP-thread state by
@@ -569,10 +565,12 @@ struct DspState {
     /// `UiToDsp::SetAcarsRegion` before engage; read at
     /// engage time to pick channels + center.
     acars_region: crate::acars_airband_lock::AcarsRegion,
-    /// Output-writer bundle: JSONL log, UDP feeder, station
-    /// ID, and per-writer warn-rate-limit timestamps.
-    /// Tap wiring (`jsonl_warn_at` / `udp_warn_at`) lands in Task 9.
-    /// Issue #578.
+    /// Output-writer bundle: bounded `mpsc` channel to a
+    /// dedicated writer thread that owns the JSONL file +
+    /// UDP socket. Shared `Arc<RwLock<AcarsWriterConfig>>`
+    /// holds the runtime-mutable jsonl path / network addr /
+    /// station ID; the DSP thread calls `try_send` per
+    /// decoded message. Issues #578 + #596.
     acars_outputs: AcarsOutputs,
 }
 
@@ -840,7 +838,7 @@ fn acars_decode_tap(
     channels: &[f64],
     iq: &[sdr_types::Complex],
     dsp_tx: &std::sync::mpsc::Sender<crate::messages::DspToUi>,
-    outputs: &mut AcarsOutputs,
+    outputs: &AcarsOutputs,
 ) {
     // Compile-time guard: `bytemuck::cast_slice::<Complex, Complex32>`
     // below is sound because both types are `repr(C) { re: f32, im: f32 }`
@@ -887,49 +885,14 @@ fn acars_decode_tap(
     // at compile time.
     let iq_c32: &[num_complex::Complex32] = bytemuck::cast_slice(iq);
     bank.process(iq_c32, |msg| {
-        // JSONL write — log warn + toast (both rate-limited)
-        // on failure. Without the toast, a disk-full or
-        // permission-loss after open would silently drop
-        // future messages from the user's perspective while
-        // ACARS decoding continues normally. CR round 7 on
-        // PR #595.
-        if let Some(w) = outputs.jsonl.as_mut()
-            && let Err(e) = w.write(&msg, outputs.station_id.as_deref())
-        {
-            let now = std::time::Instant::now();
-            let elapsed = outputs
-                .jsonl_warn_at
-                .map_or(ACARS_OUTPUT_WARN_MIN_INTERVAL, |t| now.duration_since(t));
-            if elapsed >= ACARS_OUTPUT_WARN_MIN_INTERVAL {
-                let message = format!("acars jsonl write failed: {e}");
-                tracing::warn!("{message} (rate-limited 30s)");
-                outputs.jsonl_warn_at = Some(now);
-                let _ = dsp_tx.send(crate::messages::DspToUi::AcarsOutputError {
-                    kind: "jsonl",
-                    message,
-                });
-            }
-        }
-
-        // UDP send — same warn + toast pattern.
-        if let Some(f) = outputs.udp.as_ref()
-            && let Err(e) = f.send(&msg, outputs.station_id.as_deref())
-        {
-            let now = std::time::Instant::now();
-            let elapsed = outputs
-                .udp_warn_at
-                .map_or(ACARS_OUTPUT_WARN_MIN_INTERVAL, |t| now.duration_since(t));
-            if elapsed >= ACARS_OUTPUT_WARN_MIN_INTERVAL {
-                let message = format!("acars udp send failed: {e}");
-                tracing::warn!("{message} (rate-limited 30s)");
-                outputs.udp_warn_at = Some(now);
-                let _ = dsp_tx.send(crate::messages::DspToUi::AcarsOutputError {
-                    kind: "udp",
-                    message,
-                });
-            }
-        }
-
+        // Hand off to the writer thread via the bounded
+        // channel. Drop-on-full is handled by `try_send`
+        // (rate-limited warn lives there). The writer thread
+        // owns JsonlWriter::write + UdpFeeder::send and reads
+        // station_id / paths from the shared config lock.
+        // Issue #596.
+        outputs.try_send(msg.clone());
+        // Forward to the UI viewer regardless of writer state.
         // Boxed because AcarsMessage is large enough that
         // unboxed would inflate the DspToUi enum's footprint.
         let _ = dsp_tx.send(crate::messages::DspToUi::AcarsMessage(Box::new(msg)));
@@ -1036,28 +999,10 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                                 state.acars_bank = None;
                                 state.acars_init_failed = false;
                                 state.acars_stats_emitted_at = std::time::Instant::now();
-                                // Mirror the engage-path output reopen
-                                // hook for the enable-while-stopped /
-                                // startup-replay flow: if writers were
-                                // intended-on but failed to open during
-                                // the engage (or never got a chance),
-                                // retry now that the source is going
-                                // live. Without this the session would
-                                // silently run with no JSONL / UDP until
-                                // the user toggles or reapplies the
-                                // destination. CR round 6 on PR #595.
-                                if state.acars_outputs.jsonl_enabled
-                                    && state.acars_outputs.jsonl.is_none()
-                                {
-                                    let path = jsonl_path_for(&state.acars_outputs);
-                                    open_jsonl(state, dsp_tx, &path);
-                                }
-                                if state.acars_outputs.network_enabled
-                                    && state.acars_outputs.udp.is_none()
-                                {
-                                    let addr = network_addr_for(&state.acars_outputs);
-                                    open_udp(state, dsp_tx, &addr);
-                                }
+                                // Writer thread auto-opens JSONL / UDP
+                                // on the next message based on the
+                                // config lock; no per-Start reopen
+                                // needed. Issue #596.
                                 tracing::debug!(
                                     sample_rate = state.sample_rate,
                                     center_freq = state.center_freq,
@@ -1147,11 +1092,13 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                                 state.acars_bank = None;
                                 state.acars_init_failed = false;
                                 state.acars_pre_lock = None;
-                                // Forced-off path also closes
-                                // output writers — intent flags
-                                // persist for the next engage.
-                                // CR round 2 on PR #595.
-                                close_acars_outputs(&mut state.acars_outputs);
+                                // Forced-off path: clear the writer
+                                // config so the writer thread closes
+                                // its current handles on the next
+                                // message. Intent (path / addr) is
+                                // re-stamped by the next engage.
+                                // Issue #596.
+                                clear_acars_writer_config(&state.acars_outputs);
                                 let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Err(err)));
                                 // Also send a definitive Ok(false)
                                 // so the UI (which preserves state
@@ -3351,10 +3298,10 @@ fn cleanup(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
     state.acars_init_failed = false;
     state.acars_pre_lock = None;
     if acars_forced_off {
-        // Close output writers on forced-off cleanup. Intent
-        // flags persist so a future engage reopens. CR round 2
-        // on PR #595.
-        close_acars_outputs(&mut state.acars_outputs);
+        // Forced-off: clear the writer config so the writer
+        // thread closes on the next message. The next engage
+        // re-stamps path/addr per user intent. Issue #596.
+        clear_acars_writer_config(&state.acars_outputs);
         let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Ok(false)));
     }
 
@@ -3640,7 +3587,7 @@ fn process_iq_block(
                         &state.acars_region.channels(),
                         &state.processed_buf[..processed_count],
                         dsp_tx,
-                        &mut state.acars_outputs,
+                        &state.acars_outputs,
                     );
 
                     // ~1 Hz channel-stats emission throttle.
@@ -4286,11 +4233,10 @@ fn handle_acars_engage_failure(
     state.acars_init_failed = false;
     state.acars_pre_lock = None;
 
-    // Output writers may have been opened by an earlier engage;
-    // close them on forced-off so file/socket handles don't
-    // leak. Intent flags persist for the next engage.
-    // CR round 2 on PR #595.
-    close_acars_outputs(&mut state.acars_outputs);
+    // Forced-off: clear the writer config so the writer thread
+    // closes its handles on the next message. The next engage
+    // re-stamps path/addr per user intent. Issue #596.
+    clear_acars_writer_config(&state.acars_outputs);
 
     let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Err(orig_err)));
 
@@ -4331,157 +4277,102 @@ fn resolve_jsonl_path(path: &str) -> std::path::PathBuf {
     std::path::PathBuf::from(path)
 }
 
-/// Default JSONL path for the current `AcarsOutputs`. Resolves
-/// the user's pending path when set; falls back to the home-
-/// derived default when unset.
-fn jsonl_path_for(outputs: &AcarsOutputs) -> std::path::PathBuf {
-    resolve_jsonl_path(outputs.pending_jsonl_path.as_deref().unwrap_or(""))
-}
+/// Default UDP feeder address for the airframes.io public
+/// feed. Used when the network output is enabled without an
+/// explicit address.
+const ACARS_NETWORK_DEFAULT_ADDR: &str = "feed.airframes.io:5550";
 
-/// Default UDP feeder address for the current `AcarsOutputs`.
-/// Returns the user's pending addr when set; falls back to
-/// airframes.io's default when unset.
-fn network_addr_for(outputs: &AcarsOutputs) -> String {
-    outputs
-        .pending_network_addr
-        .clone()
-        .unwrap_or_else(|| "feed.airframes.io:5550".to_string())
-}
-
-/// Open the JSONL writer; on failure log + emit
-/// `DspToUi::AcarsOutputError` toast.
-fn open_jsonl(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, path: &std::path::Path) {
-    match crate::acars_output::JsonlWriter::open(path) {
-        Ok(w) => {
-            tracing::info!("acars jsonl writer opened at {}", path.display());
-            state.acars_outputs.jsonl = Some(w);
-            // Reset the warn throttle so the first failure
-            // against this newly-opened destination logs
-            // immediately rather than getting silenced by the
-            // 30 s window from the previous destination.
-            // CR round 5 on PR #595.
-            state.acars_outputs.jsonl_warn_at = None;
-        }
-        Err(e) => {
-            let message = format!("Could not open {}: {e}", path.display());
-            tracing::warn!("acars jsonl open failed: {message}");
-            let _ = dsp_tx.send(DspToUi::AcarsOutputError {
-                kind: "jsonl",
-                message,
-            });
-        }
-    }
-}
-
-/// Open the UDP feeder; on failure log + emit
-/// `DspToUi::AcarsOutputError` toast.
-fn open_udp(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, addr: &str) {
-    match crate::acars_output::UdpFeeder::open(addr) {
-        Ok(f) => {
-            tracing::info!("acars udp feeder opened at {addr}");
-            state.acars_outputs.udp = Some(f);
-            // Reset the warn throttle — same reason as
-            // open_jsonl above. CR round 5 on PR #595.
-            state.acars_outputs.udp_warn_at = None;
-        }
-        Err(e) => {
-            let message = format!("Could not open feeder at {addr}: {e}");
-            tracing::warn!("acars udp open failed: {message}");
-            let _ = dsp_tx.send(DspToUi::AcarsOutputError {
-                kind: "udp",
-                message,
-            });
-        }
-    }
-}
-
-/// Flush + drop the JSONL writer and the UDP feeder. Used by
-/// every ACARS "forced-off" path (successful disengage, post-
-/// Start reassert failure, disengage double-failure, and the
-/// `cleanup()` forced-off branch). Intent flags
-/// (`jsonl_enabled` / `network_enabled`) stay untouched so a
-/// subsequent re-engage reopens the writers automatically.
-/// CR round 2 on PR #595.
-fn close_acars_outputs(outputs: &mut AcarsOutputs) {
-    if let Some(mut w) = outputs.jsonl.take()
-        && let Err(e) = w.flush()
-    {
-        tracing::warn!("acars jsonl flush on close failed: {e}");
-    }
-    outputs.udp = None;
+/// Clear `jsonl_path` + `network_addr` in the writer-thread
+/// config. The writer thread observes the change on its next
+/// message and closes its `JsonlWriter` / `UdpFeeder`. Used by
+/// every "forced-off" path (successful disengage, post-Start
+/// reassert failure, disengage double-failure, `cleanup()`
+/// forced-off branch). `station_id` is left intact — it's a
+/// stable user attribute, not output state. Issue #596.
+///
+/// NOTE: this is "clear", not "preserve" — a subsequent engage
+/// will not auto-reopen writers. Preserving user intent across
+/// disengage is a phase-2 follow-up; for now the user re-
+/// enables outputs after re-engage.
+fn clear_acars_writer_config(outputs: &AcarsOutputs) {
+    let mut cfg = outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned");
+    cfg.jsonl_path = None;
+    cfg.network_addr = None;
 }
 
 fn handle_set_acars_jsonl_enabled(
     state: &mut DspState,
-    dsp_tx: &mpsc::Sender<DspToUi>,
+    _dsp_tx: &mpsc::Sender<DspToUi>,
     enabled: bool,
 ) {
-    state.acars_outputs.jsonl_enabled = enabled;
-    if !enabled {
-        if let Some(mut w) = state.acars_outputs.jsonl.take()
-            && let Err(e) = w.flush()
-        {
-            tracing::warn!("acars jsonl flush on disable failed: {e}");
-        }
-        return;
+    let mut cfg = state
+        .acars_outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned");
+    if enabled {
+        // Stamp the default path. The writer thread opens the
+        // file lazily on the next decoded message.
+        // (Phase-2: preserve a user's previously-set custom
+        // path across disable/enable toggles.)
+        cfg.jsonl_path = Some(resolve_jsonl_path(""));
+    } else {
+        cfg.jsonl_path = None;
     }
-    // Already open? No-op.
-    if state.acars_outputs.jsonl.is_some() {
-        return;
-    }
-    let path = jsonl_path_for(&state.acars_outputs);
-    open_jsonl(state, dsp_tx, &path);
 }
 
-fn handle_set_acars_jsonl_path(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, path: &str) {
+fn handle_set_acars_jsonl_path(state: &mut DspState, _dsp_tx: &mpsc::Sender<DspToUi>, path: &str) {
     let path = path.trim();
-    state.acars_outputs.pending_jsonl_path = if path.is_empty() {
+    let resolved: Option<std::path::PathBuf> = if path.is_empty() {
         None
     } else {
-        Some(path.to_string())
+        Some(resolve_jsonl_path(path))
     };
-    let should_reopen = state.acars_outputs.jsonl_enabled;
-    if let Some(mut w) = state.acars_outputs.jsonl.take()
-        && let Err(e) = w.flush()
-    {
-        tracing::warn!("acars jsonl flush on path-change failed: {e}");
-    }
-    if should_reopen {
-        let resolved = jsonl_path_for(&state.acars_outputs);
-        open_jsonl(state, dsp_tx, &resolved);
-    }
+    state
+        .acars_outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned")
+        .jsonl_path = resolved;
 }
 
 fn handle_set_acars_network_enabled(
     state: &mut DspState,
-    dsp_tx: &mpsc::Sender<DspToUi>,
+    _dsp_tx: &mpsc::Sender<DspToUi>,
     enabled: bool,
 ) {
-    state.acars_outputs.network_enabled = enabled;
-    if !enabled {
-        state.acars_outputs.udp = None;
-        return;
+    let mut cfg = state
+        .acars_outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned");
+    if enabled {
+        cfg.network_addr = Some(ACARS_NETWORK_DEFAULT_ADDR.to_string());
+    } else {
+        cfg.network_addr = None;
     }
-    if state.acars_outputs.udp.is_some() {
-        return;
-    }
-    let addr = network_addr_for(&state.acars_outputs);
-    open_udp(state, dsp_tx, &addr);
 }
 
-fn handle_set_acars_network_addr(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, addr: &str) {
-    let addr = addr.trim();
-    state.acars_outputs.pending_network_addr = if addr.is_empty() {
+fn handle_set_acars_network_addr(
+    state: &mut DspState,
+    _dsp_tx: &mpsc::Sender<DspToUi>,
+    addr: &str,
+) {
+    let trimmed = addr.trim();
+    let resolved = if trimmed.is_empty() {
         None
     } else {
-        Some(addr.to_string())
+        Some(trimmed.to_string())
     };
-    let should_reopen = state.acars_outputs.network_enabled;
-    state.acars_outputs.udp = None;
-    if should_reopen {
-        let resolved = network_addr_for(&state.acars_outputs);
-        open_udp(state, dsp_tx, &resolved);
-    }
+    state
+        .acars_outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned")
+        .network_addr = resolved;
 }
 
 fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
@@ -4491,7 +4382,12 @@ fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
     // 8-char cap matches acarsdec's `idstation` field width.
     // CR round 3 on PR #595.
     let trimmed = station_id.trim();
-    state.acars_outputs.station_id = if trimmed.is_empty() {
+    state
+        .acars_outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned")
+        .station_id = if trimmed.is_empty() {
         None
     } else {
         Some(trimmed.chars().take(8).collect())
@@ -4610,19 +4506,12 @@ fn handle_set_acars_enabled(
                 state.acars_init_failed = false;
                 state.acars_pre_lock = Some(plan.snapshot);
                 state.acars_stats_emitted_at = std::time::Instant::now();
-                // Reopen output writers if user previously
-                // toggled them on. CR round 1 on PR #595 —
-                // intent persists across disengage, so engage
-                // restores the writers without requiring the
-                // user to toggle off+on. Issue #578.
-                if state.acars_outputs.jsonl_enabled && state.acars_outputs.jsonl.is_none() {
-                    let path = jsonl_path_for(&state.acars_outputs);
-                    open_jsonl(state, dsp_tx, &path);
-                }
-                if state.acars_outputs.network_enabled && state.acars_outputs.udp.is_none() {
-                    let addr = network_addr_for(&state.acars_outputs);
-                    open_udp(state, dsp_tx, &addr);
-                }
+                // Writer thread auto-opens JSONL / UDP on the
+                // next message if path/addr are set in the
+                // config. Disengage clears the config, so a
+                // re-engage requires the user to re-enable
+                // outputs (phase-2 follow-up to preserve
+                // intent across disengage). Issue #596.
                 tracing::info!("ACARS engaged: airband lock active");
                 let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Ok(true)));
                 AcarsHandlerOutcome::Normal
@@ -4691,10 +4580,10 @@ fn handle_set_acars_enabled(
                 state.acars_bank = None;
                 state.acars_init_failed = false;
                 state.acars_pre_lock = None;
-                // Forced-off — close output writers (intent
-                // flags persist for next engage). CR round 2
-                // on PR #595.
-                close_acars_outputs(&mut state.acars_outputs);
+                // Forced-off: clear the writer config so the
+                // writer thread closes on the next message.
+                // Issue #596.
+                clear_acars_writer_config(&state.acars_outputs);
                 let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Err(err)));
                 let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Ok(false)));
                 return if state.source.is_some() {
@@ -4719,11 +4608,11 @@ fn handle_set_acars_enabled(
         state.acars_bank = None;
         state.acars_init_failed = false;
 
-        // Flush + drop output writers. Intent flags
-        // (`jsonl_enabled` / `network_enabled`) stay set so a
-        // subsequent `SetAcarsEnabled(true)` re-engage reopens
-        // them automatically. Issue #578.
-        close_acars_outputs(&mut state.acars_outputs);
+        // Disengage: clear the writer config so the writer
+        // thread closes its current handles on the next
+        // message. The next engage re-stamps path/addr per
+        // user intent. Issue #596.
+        clear_acars_writer_config(&state.acars_outputs);
 
         // VFO offset restore. The controller stores it on
         // `state.vfo_offset` (read by `rebuild_vfo` and the
@@ -4900,7 +4789,7 @@ mod tests {
         let mut init_failed = false;
         let (tx, rx) = mpsc::channel::<DspToUi>();
         let iq = vec![Complex::default(); 1024];
-        let mut outputs = super::AcarsOutputs::new();
+        let outputs = super::AcarsOutputs::new();
 
         super::acars_decode_tap(
             &mut bank,
@@ -4910,7 +4799,7 @@ mod tests {
             &US_SIX_CHANNELS_HZ,
             &iq,
             &tx,
-            &mut outputs,
+            &outputs,
         );
         assert!(bank.is_some(), "first call should initialize the bank");
         assert!(!init_failed);
@@ -4924,7 +4813,7 @@ mod tests {
         let mut init_failed = true; // Simulate prior failure.
         let (tx, _rx) = mpsc::channel::<DspToUi>();
         let iq = vec![Complex::default(); 1024];
-        let mut outputs = super::AcarsOutputs::new();
+        let outputs = super::AcarsOutputs::new();
 
         super::acars_decode_tap(
             &mut bank,
@@ -4934,7 +4823,7 @@ mod tests {
             &US_SIX_CHANNELS_HZ,
             &iq,
             &tx,
-            &mut outputs,
+            &outputs,
         );
         assert!(bank.is_none(), "init_failed=true must short-circuit");
         assert!(init_failed);
@@ -4947,7 +4836,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<DspToUi>();
         let iq = vec![Complex::default(); 1024];
         let bad_channels: [f64; 6] = [0.0; 6]; // outside source bandwidth
-        let mut outputs = super::AcarsOutputs::new();
+        let outputs = super::AcarsOutputs::new();
 
         super::acars_decode_tap(
             &mut bank,
@@ -4957,7 +4846,7 @@ mod tests {
             &bad_channels,
             &iq,
             &tx,
-            &mut outputs,
+            &outputs,
         );
         assert!(bank.is_none());
         assert!(init_failed, "bad channels should set init_failed");

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -226,51 +226,7 @@ fn poll_rtl_tcp_connection_state(state: &mut DspState, dsp_tx: &mpsc::Sender<Dsp
     }
 }
 
-/// Output-writer bundle owned by `DspState`. Keeps the
-/// JSONL writer, UDP feeder, station ID, and per-writer
-/// warn-rate-limit timestamps together so the
-/// `acars_decode_tap` signature stays narrow. Issue #578.
-struct AcarsOutputs {
-    jsonl: Option<crate::acars_output::JsonlWriter>,
-    udp: Option<crate::acars_output::UdpFeeder>,
-    /// User's enable intent for the JSONL writer. Persists
-    /// across disengage / open-failure so path changes can
-    /// trigger reopen, and ACARS re-engage can restore the
-    /// writer. Issue #578.
-    jsonl_enabled: bool,
-    /// User's enable intent for the UDP feeder. Same pattern
-    /// as `jsonl_enabled`.
-    network_enabled: bool,
-    station_id: Option<String>,
-    /// Last warn timestamp for JSONL write failures. 30 s
-    /// rate limit prevents log spam from a misconfigured
-    /// path. Issue #578.
-    jsonl_warn_at: Option<std::time::Instant>,
-    /// Last warn timestamp for UDP send failures.
-    udp_warn_at: Option<std::time::Instant>,
-    /// Latest user-set JSONL path (resolved when opening).
-    /// `None` ⇒ use default `~/sdr-recordings/acars.jsonl`.
-    pending_jsonl_path: Option<String>,
-    /// Latest user-set feeder addr. `None` ⇒ default
-    /// `feed.airframes.io:5550`.
-    pending_network_addr: Option<String>,
-}
-
-impl AcarsOutputs {
-    const fn new() -> Self {
-        Self {
-            jsonl: None,
-            udp: None,
-            jsonl_enabled: false,
-            network_enabled: false,
-            station_id: None,
-            jsonl_warn_at: None,
-            udp_warn_at: None,
-            pending_jsonl_path: None,
-            pending_network_addr: None,
-        }
-    }
-}
+use crate::acars_output::AcarsOutputs;
 
 /// Minimum interval between repeated warn-log emissions for
 /// the same writer. Issue #578.

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -3589,21 +3589,16 @@ fn process_iq_block(
                         && let Some(bank) = state.acars_bank.as_ref()
                     {
                         let ch_stats = bank.channels();
-                        // `<[T; N]>::try_from(&[T])` requires `T: Copy`,
-                        // which `ChannelStats` derives. Returns `Err` if
-                        // the slice length doesn't equal N — silently
-                        // drops the emission rather than panicking, so
-                        // a future channel-set width mismatch fails
-                        // visibly via missing stats updates rather than
-                        // crashing the DSP thread.
-                        if let Ok(arr) = <[sdr_acars::ChannelStats;
-                            crate::acars_airband_lock::ACARS_CHANNEL_COUNT]>::try_from(
-                            ch_stats
-                        ) {
-                            let _ = dsp_tx
-                                .send(crate::messages::DspToUi::AcarsChannelStats(Box::new(arr)));
-                            state.acars_stats_emitted_at = now;
-                        }
+                        // Box the slice as `Box<[ChannelStats]>` so the
+                        // message variant is variable-width — the
+                        // active region's channel count can be 6 (US-6
+                        // / Europe) or up to `MAX_CUSTOM_CHANNELS` for
+                        // a Custom region. Per Task 9 of the bundled
+                        // ACARS PR plan.
+                        let _ = dsp_tx.send(crate::messages::DspToUi::AcarsChannelStats(
+                            ch_stats.to_vec().into_boxed_slice(),
+                        ));
+                        state.acars_stats_emitted_at = now;
                     }
                 }
 

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -1092,13 +1092,6 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                                 state.acars_bank = None;
                                 state.acars_init_failed = false;
                                 state.acars_pre_lock = None;
-                                // Forced-off path: clear the writer
-                                // config so the writer thread closes
-                                // its current handles on the next
-                                // message. Intent (path / addr) is
-                                // re-stamped by the next engage.
-                                // Issue #596.
-                                clear_acars_writer_config(&state.acars_outputs);
                                 let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Err(err)));
                                 // Also send a definitive Ok(false)
                                 // so the UI (which preserves state
@@ -3298,10 +3291,6 @@ fn cleanup(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>) {
     state.acars_init_failed = false;
     state.acars_pre_lock = None;
     if acars_forced_off {
-        // Forced-off: clear the writer config so the writer
-        // thread closes on the next message. The next engage
-        // re-stamps path/addr per user intent. Issue #596.
-        clear_acars_writer_config(&state.acars_outputs);
         let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Ok(false)));
     }
 
@@ -4233,11 +4222,6 @@ fn handle_acars_engage_failure(
     state.acars_init_failed = false;
     state.acars_pre_lock = None;
 
-    // Forced-off: clear the writer config so the writer thread
-    // closes its handles on the next message. The next engage
-    // re-stamps path/addr per user intent. Issue #596.
-    clear_acars_writer_config(&state.acars_outputs);
-
     let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Err(orig_err)));
 
     // Signal teardown to caller if the live rollback failed AND
@@ -4281,27 +4265,6 @@ fn resolve_jsonl_path(path: &str) -> std::path::PathBuf {
 /// feed. Used when the network output is enabled without an
 /// explicit address.
 const ACARS_NETWORK_DEFAULT_ADDR: &str = "feed.airframes.io:5550";
-
-/// Clear `jsonl_path` + `network_addr` in the writer-thread
-/// config. The writer thread observes the change on its next
-/// message and closes its `JsonlWriter` / `UdpFeeder`. Used by
-/// every "forced-off" path (successful disengage, post-Start
-/// reassert failure, disengage double-failure, `cleanup()`
-/// forced-off branch). `station_id` is left intact — it's a
-/// stable user attribute, not output state. Issue #596.
-///
-/// NOTE: this is "clear", not "preserve" — a subsequent engage
-/// will not auto-reopen writers. Preserving user intent across
-/// disengage is a phase-2 follow-up; for now the user re-
-/// enables outputs after re-engage.
-fn clear_acars_writer_config(outputs: &AcarsOutputs) {
-    let mut cfg = outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned");
-    cfg.jsonl_path = None;
-    cfg.network_addr = None;
-}
 
 fn handle_set_acars_jsonl_enabled(
     state: &mut DspState,
@@ -4580,10 +4543,6 @@ fn handle_set_acars_enabled(
                 state.acars_bank = None;
                 state.acars_init_failed = false;
                 state.acars_pre_lock = None;
-                // Forced-off: clear the writer config so the
-                // writer thread closes on the next message.
-                // Issue #596.
-                clear_acars_writer_config(&state.acars_outputs);
                 let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Err(err)));
                 let _ = dsp_tx.send(DspToUi::AcarsEnabledChanged(Ok(false)));
                 return if state.source.is_some() {
@@ -4607,12 +4566,6 @@ fn handle_set_acars_enabled(
         // see None and short-circuit.
         state.acars_bank = None;
         state.acars_init_failed = false;
-
-        // Disengage: clear the writer config so the writer
-        // thread closes its current handles on the next
-        // message. The next engage re-stamps path/addr per
-        // user intent. Issue #596.
-        clear_acars_writer_config(&state.acars_outputs);
 
         // VFO offset restore. The controller stores it on
         // `state.vfo_offset` (read by `rebuild_vfo` and the

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -142,7 +142,7 @@ fn dsp_thread_main(
 ) {
     tracing::info!("DSP controller thread started");
 
-    let mut state = match DspState::new() {
+    let mut state = match DspState::new(dsp_tx.clone()) {
         Ok(s) => s,
         Err(e) => {
             tracing::error!("failed to initialize DSP state: {e}");
@@ -575,7 +575,7 @@ struct DspState {
 }
 
 impl DspState {
-    fn new() -> Result<Self, String> {
+    fn new(dsp_tx: mpsc::Sender<DspToUi>) -> Result<Self, String> {
         let frontend = IqFrontend::new(
             DEFAULT_SAMPLE_RATE,
             DEFAULT_DECIMATION,
@@ -667,7 +667,7 @@ impl DspState {
             acars_init_failed: false,
             acars_stats_emitted_at: std::time::Instant::now(),
             acars_region: crate::acars_airband_lock::AcarsRegion::default(),
-            acars_outputs: AcarsOutputs::new(),
+            acars_outputs: AcarsOutputs::new(dsp_tx),
         })
     }
 }
@@ -4281,16 +4281,21 @@ fn handle_set_acars_jsonl_enabled(
     _dsp_tx: &mpsc::Sender<DspToUi>,
     enabled: bool,
 ) {
-    let mut cfg = acars_config_write(&state.acars_outputs.config);
-    if enabled {
-        // Preserve the user's previously-set path across
-        // disable/enable toggles. `get_or_insert_with` only
-        // stamps the default if the slot is currently None.
-        // CR round 1 on PR #598.
-        cfg.jsonl_path.get_or_insert_with(|| resolve_jsonl_path(""));
-    } else {
-        cfg.jsonl_path = None;
+    {
+        let mut cfg = acars_config_write(&state.acars_outputs.config);
+        if enabled {
+            // Preserve the user's previously-set path across
+            // disable/enable toggles. `get_or_insert_with` only
+            // stamps the default if the slot is currently None.
+            // CR round 1 on PR #598.
+            cfg.jsonl_path.get_or_insert_with(|| resolve_jsonl_path(""));
+        } else {
+            cfg.jsonl_path = None;
+        }
     }
+    // Wake the writer so the disable/enable takes effect even
+    // if no decoded message follows. CR round 1 on PR #598.
+    state.acars_outputs.notify_config_changed();
 }
 
 fn handle_set_acars_jsonl_path(state: &mut DspState, _dsp_tx: &mpsc::Sender<DspToUi>, path: &str) {
@@ -4301,6 +4306,7 @@ fn handle_set_acars_jsonl_path(state: &mut DspState, _dsp_tx: &mpsc::Sender<DspT
         Some(resolve_jsonl_path(path))
     };
     acars_config_write(&state.acars_outputs.config).jsonl_path = resolved;
+    state.acars_outputs.notify_config_changed();
 }
 
 fn handle_set_acars_network_enabled(
@@ -4308,16 +4314,19 @@ fn handle_set_acars_network_enabled(
     _dsp_tx: &mpsc::Sender<DspToUi>,
     enabled: bool,
 ) {
-    let mut cfg = acars_config_write(&state.acars_outputs.config);
-    if enabled {
-        // Preserve the user's previously-set address; only
-        // stamp the airframes.io default if no addr is set.
-        // CR round 1 on PR #598.
-        cfg.network_addr
-            .get_or_insert_with(|| ACARS_NETWORK_DEFAULT_ADDR.to_string());
-    } else {
-        cfg.network_addr = None;
+    {
+        let mut cfg = acars_config_write(&state.acars_outputs.config);
+        if enabled {
+            // Preserve the user's previously-set address; only
+            // stamp the airframes.io default if no addr is set.
+            // CR round 1 on PR #598.
+            cfg.network_addr
+                .get_or_insert_with(|| ACARS_NETWORK_DEFAULT_ADDR.to_string());
+        } else {
+            cfg.network_addr = None;
+        }
     }
+    state.acars_outputs.notify_config_changed();
 }
 
 fn handle_set_acars_network_addr(
@@ -4332,6 +4341,7 @@ fn handle_set_acars_network_addr(
         Some(trimmed.to_string())
     };
     acars_config_write(&state.acars_outputs.config).network_addr = resolved;
+    state.acars_outputs.notify_config_changed();
 }
 
 fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
@@ -4346,6 +4356,7 @@ fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
     } else {
         Some(trimmed.chars().take(8).collect())
     };
+    state.acars_outputs.notify_config_changed();
 }
 
 /// Handler for `UiToDsp::SetAcarsEnabled`. Engages or
@@ -4588,7 +4599,8 @@ mod tests {
 
     #[test]
     fn dsp_state_creates_successfully() {
-        let state = DspState::new().unwrap();
+        let (dsp_tx, _dsp_rx) = mpsc::channel::<DspToUi>();
+        let state = DspState::new(dsp_tx).unwrap();
         assert!(!state.running);
         assert!(state.source.is_none());
         assert_eq!(state.iq_buf.len(), IQ_PAIRS_PER_READ);
@@ -4605,7 +4617,8 @@ mod tests {
         // freshly-opened RTL-SDR source; defaults must match the
         // dongle's power-on state so first launch (no persisted
         // dispatch yet) doesn't change hardware behavior.
-        let state = DspState::new().unwrap();
+        let (dsp_tx, _dsp_rx) = mpsc::channel::<DspToUi>();
+        let state = DspState::new(dsp_tx).unwrap();
         assert!(!state.bias_tee_enabled);
         assert_eq!(state.direct_sampling_mode, 0);
         assert!(!state.offset_tuning_enabled);
@@ -4618,7 +4631,8 @@ mod tests {
 
     #[test]
     fn rebuild_vfo_creates_vfo_and_sets_radio_rate() {
-        let mut state = DspState::new().unwrap();
+        let (dsp_tx, _dsp_rx) = mpsc::channel::<DspToUi>();
+        let mut state = DspState::new(dsp_tx).unwrap();
         // Simulate what open_source does: frontend is already built at default rate.
         rebuild_vfo(&mut state).unwrap();
         assert!(state.vfo.is_some());
@@ -4626,7 +4640,8 @@ mod tests {
 
     #[test]
     fn rebuild_vfo_after_mode_switch_changes_rates() {
-        let mut state = DspState::new().unwrap();
+        let (dsp_tx, _dsp_rx) = mpsc::channel::<DspToUi>();
+        let mut state = DspState::new(dsp_tx).unwrap();
         // Start with NFM (default) — IF rate 50 kHz
         rebuild_vfo(&mut state).unwrap();
 
@@ -4733,7 +4748,8 @@ mod tests {
         let mut init_failed = false;
         let (tx, rx) = mpsc::channel::<DspToUi>();
         let iq = vec![Complex::default(); 1024];
-        let outputs = super::AcarsOutputs::new();
+        let (acars_dsp_tx, _acars_dsp_rx) = mpsc::channel::<DspToUi>();
+        let outputs = super::AcarsOutputs::new(acars_dsp_tx);
 
         super::acars_decode_tap(
             &mut bank,
@@ -4757,7 +4773,8 @@ mod tests {
         let mut init_failed = true; // Simulate prior failure.
         let (tx, _rx) = mpsc::channel::<DspToUi>();
         let iq = vec![Complex::default(); 1024];
-        let outputs = super::AcarsOutputs::new();
+        let (acars_dsp_tx, _acars_dsp_rx) = mpsc::channel::<DspToUi>();
+        let outputs = super::AcarsOutputs::new(acars_dsp_tx);
 
         super::acars_decode_tap(
             &mut bank,
@@ -4780,7 +4797,8 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<DspToUi>();
         let iq = vec![Complex::default(); 1024];
         let bad_channels: [f64; 6] = [0.0; 6]; // outside source bandwidth
-        let outputs = super::AcarsOutputs::new();
+        let (acars_dsp_tx, _acars_dsp_rx) = mpsc::channel::<DspToUi>();
+        let outputs = super::AcarsOutputs::new(acars_dsp_tx);
 
         super::acars_decode_tap(
             &mut bank,

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -4261,22 +4261,33 @@ fn resolve_jsonl_path(path: &str) -> std::path::PathBuf {
 /// explicit address.
 const ACARS_NETWORK_DEFAULT_ADDR: &str = "feed.airframes.io:5550";
 
+/// Acquire the ACARS writer config write lock, recovering from
+/// poisoning rather than panicking. A poisoned lock means the
+/// writer thread previously panicked while holding the write
+/// guard — recoverable from the controller's POV (we just take
+/// the inner guard and continue). Per the no-panic rule for
+/// library crates + CR round 1 on PR #598.
+fn acars_config_write(
+    cfg: &std::sync::RwLock<crate::acars_output::AcarsWriterConfig>,
+) -> std::sync::RwLockWriteGuard<'_, crate::acars_output::AcarsWriterConfig> {
+    cfg.write().unwrap_or_else(|poisoned| {
+        tracing::warn!("acars writer config lock was poisoned; recovering");
+        poisoned.into_inner()
+    })
+}
+
 fn handle_set_acars_jsonl_enabled(
     state: &mut DspState,
     _dsp_tx: &mpsc::Sender<DspToUi>,
     enabled: bool,
 ) {
-    let mut cfg = state
-        .acars_outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned");
+    let mut cfg = acars_config_write(&state.acars_outputs.config);
     if enabled {
-        // Stamp the default path. The writer thread opens the
-        // file lazily on the next decoded message.
-        // (Phase-2: preserve a user's previously-set custom
-        // path across disable/enable toggles.)
-        cfg.jsonl_path = Some(resolve_jsonl_path(""));
+        // Preserve the user's previously-set path across
+        // disable/enable toggles. `get_or_insert_with` only
+        // stamps the default if the slot is currently None.
+        // CR round 1 on PR #598.
+        cfg.jsonl_path.get_or_insert_with(|| resolve_jsonl_path(""));
     } else {
         cfg.jsonl_path = None;
     }
@@ -4289,12 +4300,7 @@ fn handle_set_acars_jsonl_path(state: &mut DspState, _dsp_tx: &mpsc::Sender<DspT
     } else {
         Some(resolve_jsonl_path(path))
     };
-    state
-        .acars_outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned")
-        .jsonl_path = resolved;
+    acars_config_write(&state.acars_outputs.config).jsonl_path = resolved;
 }
 
 fn handle_set_acars_network_enabled(
@@ -4302,13 +4308,13 @@ fn handle_set_acars_network_enabled(
     _dsp_tx: &mpsc::Sender<DspToUi>,
     enabled: bool,
 ) {
-    let mut cfg = state
-        .acars_outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned");
+    let mut cfg = acars_config_write(&state.acars_outputs.config);
     if enabled {
-        cfg.network_addr = Some(ACARS_NETWORK_DEFAULT_ADDR.to_string());
+        // Preserve the user's previously-set address; only
+        // stamp the airframes.io default if no addr is set.
+        // CR round 1 on PR #598.
+        cfg.network_addr
+            .get_or_insert_with(|| ACARS_NETWORK_DEFAULT_ADDR.to_string());
     } else {
         cfg.network_addr = None;
     }
@@ -4325,12 +4331,7 @@ fn handle_set_acars_network_addr(
     } else {
         Some(trimmed.to_string())
     };
-    state
-        .acars_outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned")
-        .network_addr = resolved;
+    acars_config_write(&state.acars_outputs.config).network_addr = resolved;
 }
 
 fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
@@ -4340,12 +4341,7 @@ fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
     // 8-char cap matches acarsdec's `idstation` field width.
     // CR round 3 on PR #595.
     let trimmed = station_id.trim();
-    state
-        .acars_outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned")
-        .station_id = if trimmed.is_empty() {
+    acars_config_write(&state.acars_outputs.config).station_id = if trimmed.is_empty() {
         None
     } else {
         Some(trimmed.chars().take(8).collect())

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -3573,7 +3573,7 @@ fn process_iq_block(
                         &mut state.acars_init_failed,
                         state.sample_rate,
                         state.center_freq,
-                        &state.acars_region.channels(),
+                        state.acars_region.channels(),
                         &state.processed_buf[..processed_count],
                         dsp_tx,
                         &state.acars_outputs,
@@ -4420,7 +4420,7 @@ fn handle_set_acars_enabled(
             source_type: state.source_type,
             frontend_decim: state.frontend.decim_ratio(),
         };
-        let plan = match engage(&current, state.acars_region) {
+        let plan = match engage(&current, &state.acars_region) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!("ACARS engage rejected: {e}");
@@ -4462,7 +4462,7 @@ fn handle_set_acars_enabled(
         match sdr_acars::ChannelBank::new(
             state.sample_rate,
             state.center_freq,
-            &state.acars_region.channels(),
+            state.acars_region.channels(),
         ) {
             Ok(bank) => {
                 state.acars_bank = Some(bank);

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -572,6 +572,16 @@ struct DspState {
     /// station ID; the DSP thread calls `try_send` per
     /// decoded message. Issues #578 + #596.
     acars_outputs: AcarsOutputs,
+    /// Most-recent user-set JSONL destination, preserved across
+    /// disable/enable toggles so re-enabling restores the user's
+    /// previously-chosen path rather than the default. Mirrors
+    /// what would otherwise live in `AcarsWriterConfig.jsonl_path`
+    /// but separated so the writer's `Some/None` "is enabled"
+    /// semantics stay clean. CR round 2 on PR #598.
+    acars_last_user_jsonl_path: Option<std::path::PathBuf>,
+    /// Same pattern as `acars_last_user_jsonl_path` for the
+    /// UDP feeder. CR round 2 on PR #598.
+    acars_last_user_network_addr: Option<String>,
 }
 
 impl DspState {
@@ -668,6 +678,8 @@ impl DspState {
             acars_stats_emitted_at: std::time::Instant::now(),
             acars_region: crate::acars_airband_lock::AcarsRegion::default(),
             acars_outputs: AcarsOutputs::new(dsp_tx),
+            acars_last_user_jsonl_path: None,
+            acars_last_user_network_addr: None,
         })
     }
 }
@@ -4284,12 +4296,21 @@ fn handle_set_acars_jsonl_enabled(
     {
         let mut cfg = acars_config_write(&state.acars_outputs.config);
         if enabled {
-            // Preserve the user's previously-set path across
-            // disable/enable toggles. `get_or_insert_with` only
-            // stamps the default if the slot is currently None.
-            // CR round 1 on PR #598.
-            cfg.jsonl_path.get_or_insert_with(|| resolve_jsonl_path(""));
+            // Restore the user's last-chosen path (preserved
+            // across disable/enable cycles via
+            // `acars_last_user_jsonl_path`). Falls back to the
+            // default if the user hasn't picked a path yet.
+            // CR round 2 on PR #598.
+            cfg.jsonl_path = Some(
+                state
+                    .acars_last_user_jsonl_path
+                    .clone()
+                    .unwrap_or_else(|| resolve_jsonl_path("")),
+            );
         } else {
+            // Disable: clear `cfg.jsonl_path` so the writer
+            // stops, but keep `acars_last_user_jsonl_path` so
+            // re-enable restores. CR round 2 on PR #598.
             cfg.jsonl_path = None;
         }
     }
@@ -4299,13 +4320,34 @@ fn handle_set_acars_jsonl_enabled(
 }
 
 fn handle_set_acars_jsonl_path(state: &mut DspState, _dsp_tx: &mpsc::Sender<DspToUi>, path: &str) {
-    let path = path.trim();
-    let resolved: Option<std::path::PathBuf> = if path.is_empty() {
-        None
+    let trimmed = path.trim();
+    let new_value = if trimmed.is_empty() {
+        // Empty apply: don't implicitly disable. If the sink
+        // is currently enabled, normalize to the default path
+        // (matching the user-intent "use the default"). If
+        // the sink is currently disabled, just clear the
+        // remembered path and stay disabled. CR round 2 on
+        // PR #598.
+        let currently_enabled = acars_config_write(&state.acars_outputs.config)
+            .jsonl_path
+            .is_some();
+        if currently_enabled {
+            Some(resolve_jsonl_path(""))
+        } else {
+            None
+        }
     } else {
-        Some(resolve_jsonl_path(path))
+        Some(resolve_jsonl_path(trimmed))
     };
-    acars_config_write(&state.acars_outputs.config).jsonl_path = resolved;
+    state.acars_last_user_jsonl_path.clone_from(&new_value);
+    // Only push to the writer's config if the sink is currently
+    // enabled (Some) — otherwise we'd accidentally turn it on.
+    {
+        let mut cfg = acars_config_write(&state.acars_outputs.config);
+        if cfg.jsonl_path.is_some() {
+            cfg.jsonl_path = new_value;
+        }
+    }
     state.acars_outputs.notify_config_changed();
 }
 
@@ -4317,11 +4359,15 @@ fn handle_set_acars_network_enabled(
     {
         let mut cfg = acars_config_write(&state.acars_outputs.config);
         if enabled {
-            // Preserve the user's previously-set address; only
-            // stamp the airframes.io default if no addr is set.
-            // CR round 1 on PR #598.
-            cfg.network_addr
-                .get_or_insert_with(|| ACARS_NETWORK_DEFAULT_ADDR.to_string());
+            // Same pattern as JSONL: restore the user's last-
+            // chosen address, fall back to the airframes.io
+            // default. CR round 2 on PR #598.
+            cfg.network_addr = Some(
+                state
+                    .acars_last_user_network_addr
+                    .clone()
+                    .unwrap_or_else(|| ACARS_NETWORK_DEFAULT_ADDR.to_string()),
+            );
         } else {
             cfg.network_addr = None;
         }
@@ -4335,12 +4381,28 @@ fn handle_set_acars_network_addr(
     addr: &str,
 ) {
     let trimmed = addr.trim();
-    let resolved = if trimmed.is_empty() {
-        None
+    let new_value = if trimmed.is_empty() {
+        // Same empty-apply semantics as JSONL: only normalize
+        // to default if currently enabled; else stay
+        // disabled. CR round 2 on PR #598.
+        let currently_enabled = acars_config_write(&state.acars_outputs.config)
+            .network_addr
+            .is_some();
+        if currently_enabled {
+            Some(ACARS_NETWORK_DEFAULT_ADDR.to_string())
+        } else {
+            None
+        }
     } else {
         Some(trimmed.to_string())
     };
-    acars_config_write(&state.acars_outputs.config).network_addr = resolved;
+    state.acars_last_user_network_addr.clone_from(&new_value);
+    {
+        let mut cfg = acars_config_write(&state.acars_outputs.config);
+        if cfg.network_addr.is_some() {
+            cfg.network_addr = new_value;
+        }
+    }
     state.acars_outputs.notify_config_changed();
 }
 

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -167,7 +167,7 @@ pub enum DspToUi {
     AcarsMessage(Box<sdr_acars::AcarsMessage>),
     /// Per-channel ACARS stats. Emitted no more than once per
     /// `ACARS_STATS_EMIT_INTERVAL_MS` while ACARS is on.
-    AcarsChannelStats(Box<[sdr_acars::ChannelStats; 6]>),
+    AcarsChannelStats(Box<[sdr_acars::ChannelStats]>),
     /// Ack for `UiToDsp::SetAcarsEnabled`. `Ok(true)` after a
     /// successful engage; `Ok(false)` after disengage; `Err`
     /// on any failure (bank init, source retune, etc).

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -1292,17 +1292,27 @@ mod tests {
 
     #[test]
     fn translate_acars_channel_stats_is_dropped_at_ffi_boundary() {
-        let msg = DspToUi::AcarsChannelStats(
-            vec![
-                sdr_acars::ChannelStats::default();
-                sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT
-            ]
-            .into_boxed_slice(),
-        );
-        assert!(
-            translate_event(&msg).is_none(),
-            "AcarsChannelStats must not translate to a wire event yet",
-        );
+        // Cover three widths to exercise the variable-length
+        // payload (post-#592 the variant is `Box<[ChannelStats]>`,
+        // not the fixed-width `[ChannelStats; 6]`):
+        //   - 1 channel (Custom region with a single freq)
+        //   - ACARS_CHANNEL_COUNT (predefined US-6 / Europe)
+        //   - ACARS_CHANNEL_COUNT + 1 (Custom region wider than
+        //     the predefined count, up to MAX_CUSTOM_CHANNELS=8)
+        // CR round 1 on PR #598.
+        for n in [
+            1,
+            sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT,
+            sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT + 1,
+        ] {
+            let msg = DspToUi::AcarsChannelStats(
+                vec![sdr_acars::ChannelStats::default(); n].into_boxed_slice(),
+            );
+            assert!(
+                translate_event(&msg).is_none(),
+                "AcarsChannelStats(width={n}) must not translate to a wire event yet",
+            );
+        }
     }
 
     #[test]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -1292,9 +1292,13 @@ mod tests {
 
     #[test]
     fn translate_acars_channel_stats_is_dropped_at_ffi_boundary() {
-        let msg = DspToUi::AcarsChannelStats(Box::new(
-            [sdr_acars::ChannelStats::default(); sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT],
-        ));
+        let msg = DspToUi::AcarsChannelStats(
+            vec![
+                sdr_acars::ChannelStats::default();
+                sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT
+            ]
+            .into_boxed_slice(),
+        );
         assert!(
             translate_event(&msg).is_none(),
             "AcarsChannelStats must not translate to a wire event yet",

--- a/crates/sdr-ui/src/acars_config.rs
+++ b/crates/sdr-ui/src/acars_config.rs
@@ -37,6 +37,11 @@ pub const KEY_ACARS_NETWORK_ADDR: &str = "acars_network_addr";
 /// `station_id` field. Empty ⇒ field omitted. Issue #578.
 pub const KEY_ACARS_STATION_ID: &str = "acars_station_id";
 
+/// Custom-channel frequencies (Hz) persisted when the active
+/// region is `Custom`. Empty array ⇒ no custom channels saved
+/// yet (or the active region isn't Custom). Issue #592.
+pub const KEY_ACARS_CUSTOM_CHANNELS: &str = "acars_custom_channels";
+
 /// Default value used when a key is missing from the config.
 const DEFAULT_ACARS_ENABLED: bool = false;
 const DEFAULT_ACARS_CHANNEL_SET: &str = "us-6";
@@ -163,6 +168,28 @@ pub fn save_acars_station_id(config: &ConfigManager, value: &str) {
     });
 }
 
+/// Read the persisted custom-channel frequency list (Hz).
+/// Returns an empty `Vec` if the key is absent or cannot be
+/// deserialized. Issue #592.
+#[must_use]
+pub fn read_acars_custom_channels(config: &ConfigManager) -> Vec<f64> {
+    config.read(|v| {
+        v.get(KEY_ACARS_CUSTOM_CHANNELS)
+            .and_then(|val| serde_json::from_value(val.clone()).ok())
+            .unwrap_or_default()
+    })
+}
+
+/// Persist a custom-channel frequency list (Hz). Caller is
+/// responsible for validating via
+/// `acars_airband_lock::validate_custom_channels` before
+/// calling. Issue #592.
+pub fn save_acars_custom_channels(config: &ConfigManager, chans: &[f64]) {
+    config.write(|v| {
+        v[KEY_ACARS_CUSTOM_CHANNELS] = serde_json::json!(chans);
+    });
+}
+
 /// Default ring-buffer cap. Returns the spec default
 /// (`ACARS_RECENT_DEFAULT_KEEP = 500`); sub-project 3 may
 /// extend this to consult `ConfigManager` for an override.
@@ -231,5 +258,19 @@ mod tests {
         assert!(read_acars_network_enabled(&cfg));
         assert_eq!(read_acars_network_addr(&cfg), "127.0.0.1:5550");
         assert_eq!(read_acars_station_id(&cfg), "TEST1");
+    }
+
+    #[test]
+    fn acars_custom_channels_round_trips() {
+        let cfg = fresh_config();
+        save_acars_custom_channels(&cfg, &[131_550_000.0, 131_525_000.0, 130_025_000.0]);
+        let chans = read_acars_custom_channels(&cfg);
+        assert_eq!(chans, vec![131_550_000.0_f64, 131_525_000.0, 130_025_000.0]);
+    }
+
+    #[test]
+    fn acars_custom_channels_empty_default() {
+        let cfg = fresh_config();
+        assert_eq!(read_acars_custom_channels(&cfg), Vec::<f64>::new());
     }
 }

--- a/crates/sdr-ui/src/sidebar/aviation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/aviation_panel.rs
@@ -85,7 +85,7 @@ pub const REGION_OPTIONS: &[AcarsRegion] = &[AcarsRegion::Us6, AcarsRegion::Euro
 pub fn region_from_combo_index(idx: u32) -> AcarsRegion {
     REGION_OPTIONS
         .get(idx as usize)
-        .copied()
+        .cloned()
         .unwrap_or(AcarsRegion::Us6)
 }
 
@@ -94,10 +94,10 @@ pub fn region_from_combo_index(idx: u32) -> AcarsRegion {
 /// region) on misses, which mirrors the seeding behaviour at
 /// startup when a stale config string can't be matched.
 #[must_use]
-pub fn region_combo_index(region: AcarsRegion) -> u32 {
+pub fn region_combo_index(region: &AcarsRegion) -> u32 {
     REGION_OPTIONS
         .iter()
-        .position(|&r| r == region)
+        .position(|r| r == region)
         .map_or(0, |i| u32::try_from(i).unwrap_or(0))
 }
 
@@ -127,7 +127,7 @@ pub fn build_aviation_panel() -> AviationPanel {
     let region_model = gtk4::StringList::new(
         &REGION_OPTIONS
             .iter()
-            .map(|r| r.display_label())
+            .map(AcarsRegion::display_label)
             .collect::<Vec<_>>(),
     );
     let region_row = adw::ComboRow::builder()

--- a/crates/sdr-ui/src/sidebar/aviation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/aviation_panel.rs
@@ -9,7 +9,7 @@
 
 use libadwaita as adw;
 use libadwaita::prelude::*;
-use sdr_core::acars_airband_lock::{ACARS_CHANNEL_COUNT, AcarsRegion};
+use sdr_core::acars_airband_lock::AcarsRegion;
 
 /// Per-channel row glyphs for the lock-state column. Per spec
 /// section "Group 2 — Channels":
@@ -43,13 +43,14 @@ pub struct AviationPanel {
     /// "Open ACARS Window" button — drives
     /// `crate::acars_viewer::open_acars_viewer_if_needed`.
     pub open_viewer_button: gtk4::Button,
-    /// Per-channel rows (one per region channel). Width sourced
-    /// from `sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT`
-    /// so it stays in lock-step with the DSP-side channel array.
-    /// Subtitles are live-updated from
+    /// Per-channel rows (one per region channel). Width is the
+    /// `channel_count` argument passed to `build_aviation_panel`
+    /// so it stays in lock-step with the active region's channel
+    /// list (US-6 / Europe = 6; Custom is variable up to
+    /// `MAX_CUSTOM_CHANNELS`). Subtitles are live-updated from
     /// `DspToUi::AcarsChannelStats` arrivals (~1 Hz cadence per
     /// the DSP-side throttle).
-    pub channel_rows: [adw::ActionRow; ACARS_CHANNEL_COUNT],
+    pub channel_rows: Vec<adw::ActionRow>,
     /// Region selector (issue #581). Switches the channel set
     /// and source center frequency between US-6 and Europe.
     /// Wired up in `crate::window::connect_aviation_panel` to
@@ -102,9 +103,14 @@ pub fn region_combo_index(region: &AcarsRegion) -> u32 {
 }
 
 /// Build the Aviation activity panel. Pure widget assembly.
+///
+/// `channel_count` sizes the per-channel row list. Predefined
+/// regions (US-6 / Europe) are 6; the Custom variant is variable
+/// up to `MAX_CUSTOM_CHANNELS`. Callers source this from the
+/// active region's `channels().len()`.
 #[must_use]
 #[allow(clippy::too_many_lines)]
-pub fn build_aviation_panel() -> AviationPanel {
+pub fn build_aviation_panel(channel_count: usize) -> AviationPanel {
     let page = adw::PreferencesPage::new();
 
     // ─── Group 1: ACARS toggle + status + open-window ───
@@ -171,11 +177,13 @@ pub fn build_aviation_panel() -> AviationPanel {
         ))
         .build();
 
-    let channel_rows: [adw::ActionRow; ACARS_CHANNEL_COUNT] = std::array::from_fn(|_| {
-        let row = adw::ActionRow::builder().title("—").subtitle("—").build();
-        channels_group.add(&row);
-        row
-    });
+    let channel_rows: Vec<adw::ActionRow> = (0..channel_count)
+        .map(|_| {
+            let row = adw::ActionRow::builder().title("—").subtitle("—").build();
+            channels_group.add(&row);
+            row
+        })
+        .collect();
 
     page.add(&channels_group);
 

--- a/crates/sdr-ui/src/sidebar/aviation_panel.rs
+++ b/crates/sdr-ui/src/sidebar/aviation_panel.rs
@@ -49,13 +49,28 @@ pub struct AviationPanel {
     /// list (US-6 / Europe = 6; Custom is variable up to
     /// `MAX_CUSTOM_CHANNELS`). Subtitles are live-updated from
     /// `DspToUi::AcarsChannelStats` arrivals (~1 Hz cadence per
-    /// the DSP-side throttle).
-    pub channel_rows: Vec<adw::ActionRow>,
+    /// the DSP-side throttle). Wrapped in `Rc<RefCell<…>>` so the
+    /// region-change rebuild in
+    /// `crate::window::connect_aviation_panel` can swap the row
+    /// list while the 4 Hz tick still reads a live view (issue
+    /// #592).
+    pub channel_rows: std::rc::Rc<std::cell::RefCell<Vec<adw::ActionRow>>>,
+    /// Per-channel rows' container group. Exposed so the
+    /// region-change rebuild can `add` / `remove` rows when the
+    /// active region's channel count changes (issue #592).
+    pub channels_group: adw::PreferencesGroup,
     /// Region selector (issue #581). Switches the channel set
-    /// and source center frequency between US-6 and Europe.
-    /// Wired up in `crate::window::connect_aviation_panel` to
-    /// dispatch `UiToDsp::SetAcarsRegion` + persist the choice.
+    /// and source center frequency between US-6, Europe, and
+    /// user-defined Custom (#592). Wired up in
+    /// `crate::window::connect_aviation_panel` to dispatch
+    /// `UiToDsp::SetAcarsRegion` + persist the choice.
     pub region_row: adw::ComboRow,
+    /// User-defined channel CSV editor. Visible only when the
+    /// region combo's selected slot is the Custom slot. Wired
+    /// in `crate::window::connect_aviation_panel`'s
+    /// `connect_apply` handler to parse + validate + persist
+    /// + dispatch. Issue #592.
+    pub custom_channels_row: adw::EntryRow,
     /// Operator station ID — embedded in JSON's
     /// `station_id` field. Issue #578.
     pub station_id_row: adw::EntryRow,
@@ -71,23 +86,37 @@ pub struct AviationPanel {
     pub network_addr_row: adw::EntryRow,
 }
 
-/// Region combo-row index → `AcarsRegion`. The ordering here is
-/// the source of truth for both the model + the persistence
-/// round-trip; bumping a new region means appending here, the
-/// `AcarsRegion` enum, and the `from_config_id`/`config_id`
-/// match arms.
-pub const REGION_OPTIONS: &[AcarsRegion] = &[AcarsRegion::Us6, AcarsRegion::Europe];
+/// Region combo-row entries. Index → `(config_id, display_label)`.
+/// The ordering here is the source of truth for both the model
+/// and the persistence round-trip; bumping a new region means
+/// appending here, plus the matching `AcarsRegion` variant and
+/// `from_config_id`/`config_id` arms. Issue #592 added the
+/// `"custom"` slot at index 2.
+pub const REGION_OPTIONS: &[(&str, &str)] = &[
+    ("us-6", "United States (US-6)"),
+    ("europe", "Europe"),
+    ("custom", "Custom"),
+];
+
+/// Combo-row slot index for the user-defined `Custom` region.
+/// Used by the visibility binding for the custom-channels
+/// `EntryRow`.
+pub const CUSTOM_REGION_COMBO_INDEX: u32 = 2;
 
 /// Map a `0..REGION_OPTIONS.len()` combo-row index back to the
 /// matching region. Falls back to the default when the model
 /// changes shape under us (e.g. transient null state during
-/// rebuilds).
+/// rebuilds). The `Custom` arm returns
+/// `AcarsRegion::Custom(Box::new([]))` as a placeholder; the
+/// caller is responsible for populating the actual frequencies
+/// from `acars_custom_channels` before dispatching.
 #[must_use]
 pub fn region_from_combo_index(idx: u32) -> AcarsRegion {
     REGION_OPTIONS
         .get(idx as usize)
-        .cloned()
-        .unwrap_or(AcarsRegion::Us6)
+        .map_or_else(AcarsRegion::default, |(id, _)| {
+            AcarsRegion::from_config_id(id)
+        })
 }
 
 /// Inverse of `region_from_combo_index`: locate the region's
@@ -96,9 +125,10 @@ pub fn region_from_combo_index(idx: u32) -> AcarsRegion {
 /// startup when a stale config string can't be matched.
 #[must_use]
 pub fn region_combo_index(region: &AcarsRegion) -> u32 {
+    let id = region.config_id();
     REGION_OPTIONS
         .iter()
-        .position(|r| r == region)
+        .position(|(slot_id, _)| *slot_id == id)
         .map_or(0, |i| u32::try_from(i).unwrap_or(0))
 }
 
@@ -128,12 +158,12 @@ pub fn build_aviation_panel(channel_count: usize) -> AviationPanel {
         .build();
     acars_group.add(&enable_switch);
 
-    // Region selector (issue #581). Two predefined channel sets
-    // shipped today; "Custom" support is a deferred follow-up.
+    // Region selector (issue #581). Predefined channel sets
+    // (US-6 / Europe) plus user-defined Custom (issue #592).
     let region_model = gtk4::StringList::new(
         &REGION_OPTIONS
             .iter()
-            .map(AcarsRegion::display_label)
+            .map(|(_, label)| *label)
             .collect::<Vec<_>>(),
     );
     let region_row = adw::ComboRow::builder()
@@ -142,6 +172,27 @@ pub fn build_aviation_panel(channel_count: usize) -> AviationPanel {
         .model(&region_model)
         .build();
     acars_group.add(&region_row);
+
+    // Custom-channels editor (issue #592). Visible only when the
+    // region combo's selected slot is `CUSTOM_REGION_COMBO_INDEX`.
+    // CSV of MHz values, parsed + validated by the apply handler
+    // wired in `crate::window::connect_aviation_panel`.
+    let custom_channels_row = adw::EntryRow::builder()
+        .title("Custom channels (MHz, comma-separated)")
+        .build();
+    custom_channels_row.set_visible(false);
+    acars_group.add(&custom_channels_row);
+
+    // Bind visibility: visible only when the region combo's
+    // selected slot is the Custom slot. Wired here in the
+    // pure-widget builder because it's a self-contained
+    // visibility mirror — no AppState / config touching.
+    {
+        let custom_row = custom_channels_row.clone();
+        region_row.connect_selected_notify(move |row| {
+            custom_row.set_visible(row.selected() == CUSTOM_REGION_COMBO_INDEX);
+        });
+    }
 
     let status_row = adw::ActionRow::builder()
         .title("Status")
@@ -243,12 +294,35 @@ pub fn build_aviation_panel(channel_count: usize) -> AviationPanel {
         enable_switch,
         status_row,
         open_viewer_button,
-        channel_rows,
+        channel_rows: std::rc::Rc::new(std::cell::RefCell::new(channel_rows)),
+        channels_group,
         region_row,
+        custom_channels_row,
         station_id_row,
         jsonl_enable_row,
         jsonl_path_row,
         network_enable_row,
         network_addr_row,
+    }
+}
+
+/// Rebuild the per-channel rows in `panel.channels_group` to
+/// match `channel_count`. Removes any existing rows first, then
+/// appends `channel_count` fresh placeholder rows. Used by
+/// `crate::window::connect_aviation_panel` on region change so
+/// the row list stays in lock-step with
+/// `region.channels().len()` (predefined regions are 6; Custom
+/// is variable, including 0 when the user hasn't entered a CSV
+/// yet). Issue #592.
+pub fn rebuild_channel_rows(panel: &AviationPanel, channel_count: usize) {
+    let mut rows = panel.channel_rows.borrow_mut();
+    for row in rows.iter() {
+        panel.channels_group.remove(row);
+    }
+    rows.clear();
+    for _ in 0..channel_count {
+        let row = adw::ActionRow::builder().title("—").subtitle("—").build();
+        panel.channels_group.add(&row);
+        rows.push(row);
     }
 }

--- a/crates/sdr-ui/src/sidebar/mod.rs
+++ b/crates/sdr-ui/src/sidebar/mod.rs
@@ -97,7 +97,11 @@ pub fn build_panels() -> SidebarPanels {
     let navigation = build_navigation_panel();
     let scanner = build_scanner_panel();
     let satellites = build_satellites_panel();
-    let aviation = build_aviation_panel();
+    // Predefined regions (US-6 / Europe) all have 6 channels;
+    // Custom regions are loaded post-startup via the config-replay
+    // path and rebuild the panel on the wiring side. Seed the
+    // initial widget at the predefined width.
+    let aviation = build_aviation_panel(sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT);
     // Flyout is built after navigation because it borrows the
     // left-sidebar `name_entry` — its row actions (recall,
     // delete-of-active) sync the entry field.

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -6,7 +6,7 @@ use std::rc::{Rc, Weak};
 use std::sync::mpsc;
 
 use sdr_acars::{AcarsMessage, ChannelStats};
-use sdr_core::acars_airband_lock::{ACARS_CHANNEL_COUNT, PreLockSnapshot};
+use sdr_core::acars_airband_lock::PreLockSnapshot;
 use sdr_types::DemodMode;
 
 use crate::messages::UiToDsp;
@@ -264,7 +264,7 @@ pub struct AppState {
     pub acars_total_count: Cell<u64>,
     /// Latest per-channel stats, populated by the
     /// `DspToUi::AcarsChannelStats` arm. Defaulted on init.
-    pub acars_channel_stats: RefCell<[ChannelStats; ACARS_CHANNEL_COUNT]>,
+    pub acars_channel_stats: RefCell<Vec<ChannelStats>>,
     /// Mirror of the DSP-side snapshot, populated when the
     /// engage ack arrives. Lets the UI display "restoring
     /// to `{prior_freq}`" hints on disengage.
@@ -418,7 +418,7 @@ impl AppState {
                 crate::acars_config::default_recent_keep() as usize,
             )),
             acars_total_count: Cell::new(0),
-            acars_channel_stats: RefCell::new([ChannelStats::default(); ACARS_CHANNEL_COUNT]),
+            acars_channel_stats: RefCell::new(Vec::new()),
             acars_pre_lock_state: RefCell::new(None),
             acars_viewer_window: RefCell::new(None),
             acars_viewer_handles: RefCell::new(None),
@@ -520,10 +520,9 @@ mod tests {
             recent.capacity(),
         );
         drop(recent);
-        assert_eq!(
-            state.acars_channel_stats.borrow().len(),
-            sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT,
-            "stats array width sourced from ACARS_CHANNEL_COUNT"
+        assert!(
+            state.acars_channel_stats.borrow().is_empty(),
+            "channel-stats Vec starts empty; populated by AcarsChannelStats arrivals"
         );
         assert!(
             state.acars_pre_lock_state.borrow().is_none(),

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11938,10 +11938,10 @@ fn connect_aviation_panel(
     // dispatch + persist round-trip.
     let initial_region =
         AcarsRegion::from_config_id(crate::acars_config::read_acars_channel_set(config).as_str());
-    state.send_dsp(sdr_core::messages::UiToDsp::SetAcarsRegion(initial_region));
     panel
         .region_row
-        .set_selected(region_combo_index(initial_region));
+        .set_selected(region_combo_index(&initial_region));
+    state.send_dsp(sdr_core::messages::UiToDsp::SetAcarsRegion(initial_region));
     {
         let state = Rc::clone(state);
         let config = std::sync::Arc::clone(config);
@@ -11957,7 +11957,7 @@ fn connect_aviation_panel(
             // needless DSP command. CR round 1 on PR #593.
             let selected = row.selected();
             let region = region_from_combo_index(selected);
-            if region_combo_index(region) != selected {
+            if region_combo_index(&region) != selected {
                 tracing::debug!(
                     selected,
                     "acars region combo emitted transient index; ignoring"

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -3849,7 +3849,7 @@ fn connect_sidebar_panels(
         set_playing,
         status_bar,
     );
-    connect_aviation_panel(&panels.aviation, state, config);
+    connect_aviation_panel(&panels.aviation, state, config, toast_overlay);
     // Transcript panel is wired separately (not in SidebarPanels).
     connect_navigation_panel(
         panels,
@@ -11922,28 +11922,67 @@ fn connect_aviation_panel(
     panel: &sidebar::aviation_panel::AviationPanel,
     state: &Rc<AppState>,
     config: &std::sync::Arc<sdr_config::ConfigManager>,
+    toast_overlay: &adw::ToastOverlay,
 ) {
     use crate::sidebar::aviation_panel::{
-        GLYPH_IDLE, GLYPH_LOCKED, GLYPH_SIGNAL, SIDEBAR_STATUS_REFRESH_MS, region_combo_index,
-        region_from_combo_index,
+        GLYPH_IDLE, GLYPH_LOCKED, GLYPH_SIGNAL, SIDEBAR_STATUS_REFRESH_MS, rebuild_channel_rows,
+        region_combo_index, region_from_combo_index,
     };
     use sdr_acars::ChannelLockState;
-    use sdr_core::acars_airband_lock::AcarsRegion;
+    use sdr_core::acars_airband_lock::{AcarsRegion, validate_custom_channels};
 
-    // ─── Region selector seed + signal (issue #581) ───
+    // ─── Region selector seed + signal (issue #581 / #592) ───
     // Read the persisted region, dispatch it to DSP at startup,
     // and seed the combo index BEFORE wiring the change handler
     // — otherwise the seed itself would fire a redundant
     // dispatch + persist round-trip.
-    let initial_region =
-        AcarsRegion::from_config_id(crate::acars_config::read_acars_channel_set(config).as_str());
+    let saved_region_id = crate::acars_config::read_acars_channel_set(config);
+    let initial_region = if saved_region_id == "custom" {
+        // Hydrate the Custom variant with the saved channel
+        // list so the initial DSP dispatch carries real
+        // frequencies. An empty list means the user picked
+        // Custom but never entered channels — keep the
+        // placeholder so engage logic still sees a Custom
+        // variant; the apply handler dispatches a real one
+        // once the user types valid input.
+        let saved_chans = crate::acars_config::read_acars_custom_channels(config);
+        AcarsRegion::Custom(saved_chans.into_boxed_slice())
+    } else {
+        AcarsRegion::from_config_id(saved_region_id.as_str())
+    };
     panel
         .region_row
         .set_selected(region_combo_index(&initial_region));
+    // Rebuild channel rows to match the seeded region's channel
+    // count (predefined = 6; Custom = saved list len, possibly 0).
+    rebuild_channel_rows(panel, initial_region.channels().len());
+    // Hydrate the Custom EntryRow text from saved config so the
+    // user sees their last entry next to the (now-visible) row.
+    {
+        let saved_chans = crate::acars_config::read_acars_custom_channels(config);
+        if !saved_chans.is_empty() {
+            let csv = saved_chans
+                .iter()
+                .map(|hz| format!("{:.3}", hz / 1_000_000.0))
+                .collect::<Vec<_>>()
+                .join(", ");
+            panel.custom_channels_row.set_text(&csv);
+        }
+    }
     state.send_dsp(sdr_core::messages::UiToDsp::SetAcarsRegion(initial_region));
     {
         let state = Rc::clone(state);
         let config = std::sync::Arc::clone(config);
+        // Capture the panel widgets needed by the rebuild path.
+        // Each widget already holds a strong ref into the GTK
+        // tree, so cloning here is the same cheap GObject ref
+        // bump the rest of `connect_aviation_panel` uses. The
+        // `channel_rows` Rc is the SAME inner cell the 4 Hz
+        // tick reads — this is what keeps that tick from
+        // operating on a stale row snapshot.
+        let channels_group = panel.channels_group.clone();
+        let channel_rows_cell = std::rc::Rc::clone(&panel.channel_rows);
+        let custom_row_for_dispatch = panel.custom_channels_row.clone();
         panel.region_row.connect_selected_notify(move |row| {
             // Guard against transient ComboRow indices. The model
             // briefly emits selection notifications during
@@ -11955,7 +11994,7 @@ fn connect_aviation_panel(
             // so a UI quirk doesn't churn config or fire a
             // needless DSP command. CR round 1 on PR #593.
             let selected = row.selected();
-            let region = region_from_combo_index(selected);
+            let mut region = region_from_combo_index(selected);
             if region_combo_index(&region) != selected {
                 tracing::debug!(
                     selected,
@@ -11963,7 +12002,120 @@ fn connect_aviation_panel(
                 );
                 return;
             }
+            // Custom slot: hydrate from saved config (or the
+            // current EntryRow text if the user just typed
+            // something but hasn't pressed Enter yet). Empty
+            // list is fine — the variant is dispatched as
+            // `Custom([])` and the apply handler later
+            // replaces it with a real list.
+            if matches!(region, AcarsRegion::Custom(_)) {
+                let saved = crate::acars_config::read_acars_custom_channels(&config);
+                region = AcarsRegion::Custom(saved.into_boxed_slice());
+                // Make the EntryRow visible immediately on
+                // selection — the visibility-binding closure in
+                // the panel builder also fires on this same
+                // notify, but invoking the binding side-effect
+                // here would require ordering guarantees we
+                // don't have. Cheap idempotent set is fine.
+                custom_row_for_dispatch.set_visible(true);
+            }
             crate::acars_config::save_acars_channel_set(&config, region.config_id());
+            // Rebuild channel rows to match the new region's
+            // channel count — borrow_mut + adw mutation must
+            // happen before send_dsp because the 4 Hz tick will
+            // start consulting the new row count almost
+            // immediately.
+            let new_count = region.channels().len();
+            // Inline the rebuild (the helper takes
+            // `&AviationPanel`, but we only have the
+            // individual fields here in the closure).
+            {
+                let mut rows = channel_rows_cell.borrow_mut();
+                for row in rows.iter() {
+                    channels_group.remove(row);
+                }
+                rows.clear();
+                for _ in 0..new_count {
+                    let row = adw::ActionRow::builder().title("—").subtitle("—").build();
+                    channels_group.add(&row);
+                    rows.push(row);
+                }
+            }
+            state.send_dsp(sdr_core::messages::UiToDsp::SetAcarsRegion(region));
+        });
+    }
+
+    // ─── Custom-channels apply handler (issue #592) ───
+    // Fires on Enter or focus-out. Parses CSV → multiplies by
+    // 1e6 → validates via `validate_custom_channels`. On success
+    // persists + dispatches a `Custom` variant with real
+    // frequencies. On failure: toast naming the problem + add
+    // the `error` CSS class (cleared on success).
+    {
+        let state = Rc::clone(state);
+        let config = std::sync::Arc::clone(config);
+        let toast_overlay = toast_overlay.clone();
+        let channels_group = panel.channels_group.clone();
+        let channel_rows_cell = std::rc::Rc::clone(&panel.channel_rows);
+        panel.custom_channels_row.connect_apply(move |row| {
+            let text = row.text();
+            // Stage 1: parse CSV → Vec<f64> (Hz). Empty entries
+            // (e.g. trailing comma) are silently skipped; a
+            // truly empty list will be caught in stage 2 by
+            // `validate_custom_channels`.
+            let parsed: Result<Vec<f64>, String> = text
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| {
+                    s.parse::<f64>()
+                        .map(|mhz| mhz * 1_000_000.0)
+                        .map_err(|e| format!("'{s}': {e}"))
+                })
+                .collect();
+            let chans = match parsed {
+                Ok(v) => v,
+                Err(e) => {
+                    row.add_css_class("error");
+                    let toast = adw::Toast::builder()
+                        .title(format!("Invalid custom channels: {e}"))
+                        .timeout(5)
+                        .build();
+                    toast_overlay.add_toast(toast);
+                    return;
+                }
+            };
+            // Stage 2: domain validation (size, finite, span).
+            if let Err(e) = validate_custom_channels(&chans) {
+                row.add_css_class("error");
+                let toast = adw::Toast::builder()
+                    .title(e.to_string())
+                    .timeout(5)
+                    .build();
+                toast_overlay.add_toast(toast);
+                return;
+            }
+            // Validated — clear any prior error styling and
+            // commit (persist + rebuild rows + dispatch).
+            row.remove_css_class("error");
+            crate::acars_config::save_acars_custom_channels(&config, &chans);
+            // Rebuild channel rows to match the new custom-
+            // channel count — same inline pattern as the
+            // region-change handler above.
+            let new_count = chans.len();
+            {
+                let mut rows = channel_rows_cell.borrow_mut();
+                for row in rows.iter() {
+                    channels_group.remove(row);
+                }
+                rows.clear();
+                for _ in 0..new_count {
+                    let r = adw::ActionRow::builder().title("—").subtitle("—").build();
+                    channels_group.add(&r);
+                    rows.push(r);
+                }
+            }
+            let region = AcarsRegion::Custom(chans.into_boxed_slice());
             state.send_dsp(sdr_core::messages::UiToDsp::SetAcarsRegion(region));
         });
     }
@@ -11990,14 +12142,17 @@ fn connect_aviation_panel(
     // Hold weak refs only so closing the window drops the panel
     // widgets and the timer self-cancels via Break on the next
     // fire. Strong refs would keep the panel + AppState alive
-    // for the rest of the process.
+    // for the rest of the process. The channel-rows view is an
+    // `Rc<RefCell<…>>` clone so the rebuild handler can swap the
+    // row list under us without the tick needing a re-snapshot.
+    // We hold a STRONG ref to the cell here — the cell itself
+    // is small (one `Vec<ActionRow>` plus a borrow flag) and
+    // the rows it owns are dropped in lock-step with the panel
+    // widgets when the window closes; the switch/status weak
+    // refs gate Break on the next fire either way.
     let switch_weak = panel.enable_switch.downgrade();
     let status_weak = panel.status_row.downgrade();
-    let row_weaks: Vec<gtk4::glib::WeakRef<adw::ActionRow>> = panel
-        .channel_rows
-        .iter()
-        .map(gtk4::prelude::ObjectExt::downgrade)
-        .collect();
+    let channel_rows_for_tick = std::rc::Rc::clone(&panel.channel_rows);
     let state_for_tick = Rc::clone(state);
     glib::timeout_add_local(
         std::time::Duration::from_millis(SIDEBAR_STATUS_REFRESH_MS),
@@ -12036,17 +12191,20 @@ fn connect_aviation_panel(
             };
             status.set_subtitle(&subtitle);
 
-            // Per-channel rows. Both `row_weaks` and `channel_stats`
-            // are now `Vec`s sized from the active region (Task 9
-            // migration); their lengths can transiently differ
-            // around a region swap (panel rebuild lags the next
-            // DSP-side stats emission). Zip over the shorter of
-            // the two so neither side panics during the window.
+            // Per-channel rows. Read the LIVE row list each tick
+            // so a region swap (which drops + recreates rows
+            // under `channel_rows_for_tick`) is reflected
+            // immediately — a snapshot taken at wire time would
+            // hold weak refs into the OLD generation of rows.
+            // `channel_stats` is a `Vec` sized from the active
+            // region (Task 9 migration); the two lengths can
+            // transiently differ around a region swap (panel
+            // rebuild lags the next DSP-side stats emission).
+            // Zip over the shorter of the two so neither side
+            // panics during the window. Issue #592.
             let channel_stats = state_for_tick.acars_channel_stats.borrow();
-            for (row_weak, ch) in row_weaks.iter().zip(channel_stats.iter()) {
-                let Some(row) = row_weak.upgrade() else {
-                    return glib::ControlFlow::Break;
-                };
+            let rows = channel_rows_for_tick.borrow();
+            for (row, ch) in rows.iter().zip(channel_stats.iter()) {
                 let glyph = match ch.lock_state {
                     ChannelLockState::Locked => GLYPH_LOCKED,
                     ChannelLockState::Idle => GLYPH_IDLE,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2089,7 +2089,7 @@ fn handle_dsp_message(
             );
         }
         DspToUi::AcarsChannelStats(ch_stats) => {
-            *state.acars_channel_stats.borrow_mut() = *ch_stats;
+            *state.acars_channel_stats.borrow_mut() = ch_stats.into_vec();
         }
         DspToUi::AcarsEnabledChanged(result) => {
             match result {
@@ -2153,8 +2153,7 @@ fn handle_dsp_message(
                     state.acars_pending.set(false);
                     state.acars_recent.borrow_mut().clear();
                     state.acars_total_count.set(0);
-                    *state.acars_channel_stats.borrow_mut() = [sdr_acars::ChannelStats::default();
-                        sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT];
+                    state.acars_channel_stats.borrow_mut().clear();
                     // Restore the pre-engage tune snapshot. DSP
                     // retunes silently and reapplies its own
                     // snapshot offset, but doesn't emit Tune /
@@ -12037,10 +12036,15 @@ fn connect_aviation_panel(
             };
             status.set_subtitle(&subtitle);
 
-            // Per-channel rows.
+            // Per-channel rows. Both `row_weaks` and `channel_stats`
+            // are now `Vec`s sized from the active region (Task 9
+            // migration); their lengths can transiently differ
+            // around a region swap (panel rebuild lags the next
+            // DSP-side stats emission). Zip over the shorter of
+            // the two so neither side panics during the window.
             let channel_stats = state_for_tick.acars_channel_stats.borrow();
-            for (idx, ch) in channel_stats.iter().enumerate() {
-                let Some(row) = row_weaks[idx].upgrade() else {
+            for (row_weak, ch) in row_weaks.iter().zip(channel_stats.iter()) {
+                let Some(row) = row_weak.upgrade() else {
                     return glib::ControlFlow::Break;
                 };
                 let glyph = match ch.lock_state {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11938,15 +11938,22 @@ fn connect_aviation_panel(
     // dispatch + persist round-trip.
     let saved_region_id = crate::acars_config::read_acars_channel_set(config);
     let initial_region = if saved_region_id == "custom" {
-        // Hydrate the Custom variant with the saved channel
-        // list so the initial DSP dispatch carries real
-        // frequencies. An empty list means the user picked
-        // Custom but never entered channels — keep the
-        // placeholder so engage logic still sees a Custom
-        // variant; the apply handler dispatches a real one
-        // once the user types valid input.
+        // Two-key load: read channels, validate, then build
+        // Custom — or fall back to default on bad/stale config.
+        // `Custom([])` would reach the engage guard as invalid
+        // (validate_custom_channels rejects empty), so we must
+        // not dispatch it at startup.
         let saved_chans = crate::acars_config::read_acars_custom_channels(config);
-        AcarsRegion::Custom(saved_chans.into_boxed_slice())
+        match validate_custom_channels(&saved_chans) {
+            Ok(()) => AcarsRegion::Custom(saved_chans.into_boxed_slice()),
+            Err(e) => {
+                tracing::warn!(
+                    "saved custom ACARS channels invalid ({e}); \
+                     falling back to default region"
+                );
+                AcarsRegion::default()
+            }
+        }
     } else {
         AcarsRegion::from_config_id(saved_region_id.as_str())
     };

--- a/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
+++ b/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
@@ -209,6 +209,21 @@ pub struct AcarsWriterConfig {
 pub enum AcarsOutputMessage {
     /// One decoded ACARS message, ready to write + feed.
     Decoded(sdr_acars::AcarsMessage),
+    /// The shared `AcarsWriterConfig` was mutated by the UI
+    /// side. Wakes the writer to re-snapshot config and apply
+    /// `ensure_jsonl` / `ensure_udp` so config-only changes
+    /// (disable, path swap, addr swap) take effect immediately
+    /// instead of being buffered until the next decoded
+    /// message. Wired up in Task 4 (loop arm) and Task 5
+    /// (`notify_config_changed` sender). CR round 1 on PR #598.
+    ConfigChanged,
+    /// Explicit clean-shutdown signal. `Drop for AcarsOutputs`
+    /// emits this before dropping `tx`; the worker also exits
+    /// cleanly on `Err(Disconnected)` as a fallback. Having an
+    /// explicit variant makes shutdown deterministic for tests.
+    /// Wired up in Task 4 (loop arm) and Task 5 (`Drop` impl
+    /// sender). CR round 6 on PR #598.
+    Shutdown,
 }
 ```
 
@@ -430,30 +445,51 @@ fn run_writer_loop(
     let mut jsonl_warn_at: Option<std::time::Instant> = None;
     let mut udp_warn_at: Option<std::time::Instant> = None;
 
-    while let Ok(msg) = rx.recv() {
-        let AcarsOutputMessage::Decoded(msg) = msg;
-
-        // Snapshot the config under a brief read lock so we
-        // don't hold it across blocking I/O. Recover from
-        // poisoning rather than panicking — a panic in the
-        // writer path would otherwise propagate to all later
-        // settings edits. CR round 1 on PR #598.
-        let (want_jsonl_path, want_udp_addr, station_id) = {
-            let cfg = config.read().unwrap_or_else(|p| p.into_inner());
-            (cfg.jsonl_path.clone(), cfg.network_addr.clone(), cfg.station_id.clone())
-        };
-
-        ensure_jsonl(&mut jsonl, want_jsonl_path.as_deref());
-        ensure_udp(&mut udp, want_udp_addr.as_deref());
-
-        if let Some((_, w)) = jsonl.as_mut() {
-            if let Err(e) = w.write(&msg, station_id.as_deref()) {
-                rate_limited_warn("jsonl", &mut jsonl_warn_at, e);
+    // `while let Ok(_)` is the disconnect-fallback path; the
+    // inner `match` handles the explicit `Shutdown` sentinel
+    // (which `break`s out of the outer loop) and the
+    // `ConfigChanged` wake-up. Either path exits cleanly.
+    'recv: while let Ok(msg) = rx.recv() {
+        match msg {
+            AcarsOutputMessage::Shutdown => break 'recv,
+            AcarsOutputMessage::ConfigChanged => {
+                // No payload to write — just resnap config and
+                // close/open. `ensure_*` close on `None` and
+                // reopen on path/addr change, so disabling
+                // JSONL or swapping the destination applies
+                // immediately even with no decoded traffic.
+                // CR round 1 on PR #598.
+                let (want_jsonl_path, want_udp_addr, _station_id) = {
+                    let cfg = config.read().unwrap_or_else(|p| p.into_inner());
+                    (cfg.jsonl_path.clone(), cfg.network_addr.clone(), cfg.station_id.clone())
+                };
+                ensure_jsonl(&mut jsonl, want_jsonl_path.as_deref());
+                ensure_udp(&mut udp, want_udp_addr.as_deref());
             }
-        }
-        if let Some((_, f)) = udp.as_mut() {
-            if let Err(e) = f.send(&msg, station_id.as_deref()) {
-                rate_limited_warn("udp", &mut udp_warn_at, e);
+            AcarsOutputMessage::Decoded(msg) => {
+                // Snapshot the config under a brief read lock so we
+                // don't hold it across blocking I/O. Recover from
+                // poisoning rather than panicking — a panic in the
+                // writer path would otherwise propagate to all later
+                // settings edits. CR round 1 on PR #598.
+                let (want_jsonl_path, want_udp_addr, station_id) = {
+                    let cfg = config.read().unwrap_or_else(|p| p.into_inner());
+                    (cfg.jsonl_path.clone(), cfg.network_addr.clone(), cfg.station_id.clone())
+                };
+
+                ensure_jsonl(&mut jsonl, want_jsonl_path.as_deref());
+                ensure_udp(&mut udp, want_udp_addr.as_deref());
+
+                if let Some((_, w)) = jsonl.as_mut() {
+                    if let Err(e) = w.write(&msg, station_id.as_deref()) {
+                        rate_limited_warn("jsonl", &mut jsonl_warn_at, e);
+                    }
+                }
+                if let Some((_, f)) = udp.as_mut() {
+                    if let Err(e) = f.send(&msg, station_id.as_deref()) {
+                        rate_limited_warn("udp", &mut udp_warn_at, e);
+                    }
+                }
             }
         }
     }
@@ -744,6 +780,24 @@ impl AcarsOutputs {
         self.drop_count.load(Ordering::Relaxed)
     }
 
+    /// Wake the writer thread so it re-snapshots
+    /// `AcarsWriterConfig` and applies `ensure_jsonl` /
+    /// `ensure_udp` immediately. Called by the controller's
+    /// path/addr/enable/station handlers AFTER they mutate
+    /// `config` — without it, the worker only wakes on
+    /// `Decoded` and stale handles linger until the next
+    /// decoded frame (CR round 1 on PR #598).
+    ///
+    /// `try_send`, not `send`: if the channel is full the
+    /// worker is already saturated processing `Decoded` and
+    /// will re-snapshot config on the next iteration anyway —
+    /// a dropped `ConfigChanged` is harmless under that
+    /// pressure. Disconnected (worker gone during teardown)
+    /// is also fine to silently drop.
+    pub fn notify_config_changed(&self) {
+        let _ = self.tx.try_send(AcarsOutputMessage::ConfigChanged);
+    }
+
     /// 30 s-rate-limited warn for channel-full drops. Reads
     /// the current drop count so the message names how many
     /// were lost in this window.
@@ -777,10 +831,20 @@ impl Default for AcarsOutputs {
 
 impl Drop for AcarsOutputs {
     fn drop(&mut self) {
+        // Send the explicit `Shutdown` sentinel first so the
+        // worker exits via the deterministic `Shutdown` arm
+        // rather than the `Err(Disconnected)` fallback. Both
+        // paths drain cleanly, but `Shutdown` means tests can
+        // assert promptness without racing the OS scheduler.
+        // `try_send` is fine — if the channel is full the
+        // `Disconnected` fallback below still terminates.
+        // CR round 6 on PR #598.
+        let _ = self.tx.try_send(AcarsOutputMessage::Shutdown);
+
         // Closing tx triggers Disconnected → the writer loop
-        // exits. We still need to join the thread to make
-        // sure its Drop impls (BufWriter flush) finish before
-        // the process exits.
+        // exits as a fallback. We still need to join the
+        // thread to make sure its Drop impls (BufWriter flush)
+        // finish before the process exits.
         if let Some(handle) = self.writer_thread.take() {
             // Drop the tx clone held by `self.tx` first by
             // overwriting it with a drained channel. (mpsc::SyncSender

--- a/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
+++ b/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
@@ -1214,18 +1214,15 @@ Find the existing `mod tests` (likely at the bottom of `acars_airband_lock.rs`; 
 
     #[test]
     fn validate_rejects_nan() {
-        assert_eq!(
-            validate_custom_channels(&[131_550_000.0, f64::NAN]),
-            Err(CustomChannelError::InvalidFrequency { value: f64::NAN })
-        );
-        // f64::NAN != f64::NAN, so the assert_eq above compares
-        // via PartialEq on the wrapper struct; verify that
-        // CustomChannelError uses bitwise equality (which we'll
-        // arrange via #[derive(PartialEq)] on a NotNan-style
-        // wrapper) — actually, simpler: just check the variant.
-        // (Re-cast as a discriminant check.)
+        // Note: f64::NAN != f64::NAN, so `assert_eq!(..., Err(
+        // InvalidFrequency { value: f64::NAN }))` would fail
+        // even when the variant is correct. Pattern-match
+        // the variant and check `value.is_nan()` instead.
+        // CR round 4 on PR #598.
         match validate_custom_channels(&[131_550_000.0, f64::NAN]) {
-            Err(CustomChannelError::InvalidFrequency { .. }) => {}
+            Err(CustomChannelError::InvalidFrequency { value }) => {
+                assert!(value.is_nan());
+            }
             other => panic!("expected InvalidFrequency, got {other:?}"),
         }
     }

--- a/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
+++ b/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
@@ -675,17 +675,27 @@ impl AcarsOutputs {
         let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
 
         let writer_config = Arc::clone(&config);
-        let writer_thread = std::thread::Builder::new()
+        // Thread spawn can fail (rlimit, OOM). Log + return a
+        // None handle rather than panic — the controller still
+        // boots and the user sees an error toast on the next
+        // ACARS message attempt. CR round 2 on PR #598.
+        let writer_thread = match std::thread::Builder::new()
             .name("sdr-acars-writer".into())
             .spawn(move || run_writer_loop(rx, writer_config))
-            .expect("failed to spawn ACARS writer thread");
+        {
+            Ok(handle) => Some(handle),
+            Err(e) => {
+                tracing::error!("ACARS writer thread spawn failed: {e}");
+                None
+            }
+        };
 
         Self {
             tx,
             config,
             drop_count: Arc::new(AtomicU64::new(0)),
             last_drop_warn_at: Arc::new(Mutex::new(None)),
-            writer_thread: Some(writer_thread),
+            writer_thread,
             #[cfg(test)]
             _test_rx: Arc::new(Mutex::new(None)),
         }
@@ -738,7 +748,14 @@ impl AcarsOutputs {
     /// the current drop count so the message names how many
     /// were lost in this window.
     fn maybe_warn_full(&self) {
-        let mut last = self.last_drop_warn_at.lock().expect("warn lock poisoned");
+        // Recover from poisoning rather than panicking — a
+        // panic in maybe_warn_full would otherwise propagate
+        // to every later DSP-thread try_send. CR round 2 on
+        // PR #598.
+        let mut last = self
+            .last_drop_warn_at
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let now = std::time::Instant::now();
         let elapsed = last.map_or(ACARS_OUTPUT_WARN_MIN_INTERVAL, |t| now.duration_since(t));
         if elapsed >= ACARS_OUTPUT_WARN_MIN_INTERVAL {
@@ -1015,9 +1032,27 @@ Also delete the local `ACARS_OUTPUT_WARN_MIN_INTERVAL` if it's still in `control
 
 In the engage path (`SetAcarsEnabled(true)` handler), the existing code reads `pending_jsonl_path` etc. to open writers. With the new shape, the writer thread is always running — engage just needs to make sure the config has the right values. The `pending_*` setter handlers (Step 3) already update the config, so the engage path can be simplified: just set `jsonl_enabled` / `network_enabled` flags ... but wait — the spec replaces those flags with `jsonl_path: Option` (Some = enabled). Re-read the spec.
 
-The spec says `AcarsWriterConfig { jsonl_path, network_addr, station_id }` — no separate enable flag. The semantics are: if `jsonl_path` is `Some`, write; if `None`, don't. The UI's "enable JSONL" toggle is implemented as: setting `jsonl_path` to the resolved default-or-user path on enable, and to `None` on disable.
+The writer config models the runtime state: `jsonl_path: Option<PathBuf>` is the writer's current behaviour (`Some` = write to this path, `None` = don't write). Per CR round 2 on PR #598, the user's *intent* (their last-chosen path) lives separately on `DspState` so a disable→enable cycle can restore it without conflating the writer's runtime state with persistence.
 
-So the existing `handle_set_acars_jsonl_enabled` (and same for network) handler needs to translate the boolean toggle into a path-or-None config write:
+Add two fields to `DspState`:
+
+```rust
+struct DspState {
+    /* … existing fields … */
+    /// Most-recent user-set JSONL destination, preserved
+    /// across disable/enable toggles so re-enabling restores
+    /// the user's previously-chosen path rather than the
+    /// default.
+    acars_last_user_jsonl_path: Option<std::path::PathBuf>,
+    /// Same pattern as `acars_last_user_jsonl_path` for the
+    /// UDP feeder.
+    acars_last_user_network_addr: Option<String>,
+}
+```
+
+Initialize both to `None` in `DspState::new`.
+
+Then the enable-toggle handlers look like this — restore the user's last-chosen value, fall back to the protocol default when the user hasn't picked one yet:
 
 ```rust
 fn handle_set_acars_jsonl_enabled(
@@ -1028,16 +1063,21 @@ fn handle_set_acars_jsonl_enabled(
     {
         let mut cfg = acars_config_write(&state.acars_outputs.config);
         if enabled {
-            // Preserve the user's previously-set path (e.g. set
-            // via SetAcarsJsonlPath or persisted from prior session)
-            // across disable/enable toggles. `get_or_insert_with`
-            // only stamps the default if the slot is currently None.
-            // CR round 1 on PR #598.
-            cfg.jsonl_path
-                .get_or_insert_with(|| resolve_jsonl_path(""));
+            // Restore the user's last-chosen path (preserved
+            // across disable/enable cycles via
+            // `acars_last_user_jsonl_path`). Falls back to the
+            // default if the user hasn't picked a path yet.
+            // CR round 2 on PR #598.
+            cfg.jsonl_path = Some(
+                state
+                    .acars_last_user_jsonl_path
+                    .clone()
+                    .unwrap_or_else(|| resolve_jsonl_path("")),
+            );
         } else {
-            // Disabling: clear the path. Worker wakes on
-            // ConfigChanged below and closes the writer.
+            // Disable: clear `cfg.jsonl_path` so the writer
+            // stops, but keep `acars_last_user_jsonl_path` so
+            // re-enable restores. CR round 2 on PR #598.
             cfg.jsonl_path = None;
         }
     }
@@ -1052,11 +1092,12 @@ fn handle_set_acars_network_enabled(
     {
         let mut cfg = acars_config_write(&state.acars_outputs.config);
         if enabled {
-            // Preserve the user's previously-set address; only
-            // stamp the airframes.io default if no addr is set.
-            // CR round 1 on PR #598.
-            cfg.network_addr
-                .get_or_insert_with(|| ACARS_NETWORK_DEFAULT_ADDR.to_string());
+            cfg.network_addr = Some(
+                state
+                    .acars_last_user_network_addr
+                    .clone()
+                    .unwrap_or_else(|| ACARS_NETWORK_DEFAULT_ADDR.to_string()),
+            );
         } else {
             cfg.network_addr = None;
         }
@@ -1064,6 +1105,40 @@ fn handle_set_acars_network_enabled(
     state.acars_outputs.notify_config_changed();
 }
 ```
+
+The corresponding `handle_set_acars_jsonl_path` / `handle_set_acars_network_addr` handlers update `acars_last_user_jsonl_path` / `acars_last_user_network_addr` always (so the user's intent survives a future disable). They only push to the writer's config if the sink is currently enabled — otherwise the path edit shouldn't accidentally turn the sink on. They also normalize an empty apply correctly: when the sink is currently enabled, an empty apply means "use the default"; when it's currently disabled, an empty apply means "clear my saved path":
+
+```rust
+fn handle_set_acars_jsonl_path(
+    state: &mut DspState,
+    _dsp_tx: &mpsc::Sender<DspToUi>,
+    path: &str,
+) {
+    let trimmed = path.trim();
+    let new_value = if trimmed.is_empty() {
+        let currently_enabled = acars_config_write(&state.acars_outputs.config)
+            .jsonl_path
+            .is_some();
+        if currently_enabled {
+            Some(resolve_jsonl_path(""))
+        } else {
+            None
+        }
+    } else {
+        Some(resolve_jsonl_path(trimmed))
+    };
+    state.acars_last_user_jsonl_path.clone_from(&new_value);
+    {
+        let mut cfg = acars_config_write(&state.acars_outputs.config);
+        if cfg.jsonl_path.is_some() {
+            cfg.jsonl_path = new_value;
+        }
+    }
+    state.acars_outputs.notify_config_changed();
+}
+```
+
+(The corresponding `handle_set_acars_network_addr` follows the same shape with `network_addr` and `ACARS_NETWORK_DEFAULT_ADDR`.)
 
 If the existing `handle_set_acars_jsonl_enabled` already exists, replace its body with the above. If it doesn't (i.e., the legacy code packed enable + path into one call), reconcile by checking the `UiToDsp` message variants.
 
@@ -1265,40 +1340,28 @@ pub const MAX_CUSTOM_CHANNELS: usize = 8;
 pub const MAX_CHANNEL_SPAN_HZ: f64 = 2_400_000.0;
 
 /// Error variants returned by [`validate_custom_channels`].
-/// `Display` impl produces user-facing toast text. Issue #592.
-#[derive(Clone, Debug, PartialEq)]
+/// `Display` derive produces user-facing toast text via
+/// `thiserror::Error`. Issue #592 / CR round 2 on PR #598
+/// (matches the project convention of using thiserror for
+/// library error types rather than hand-rolling Display +
+/// Error impls).
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum CustomChannelError {
+    #[error("Custom channel list is empty")]
     Empty,
+    #[error("Too many custom channels ({count}); maximum is {max}")]
     TooMany { count: usize, max: usize },
+    #[error("Invalid custom-channel frequency: {value}")]
     InvalidFrequency { value: f64 },
+    #[error(
+        "Span {:.3} MHz exceeds {:.3} MHz limit ({:.3} to {:.3} MHz)",
+        *span_hz / 1_000_000.0,
+        MAX_CHANNEL_SPAN_HZ / 1_000_000.0,
+        *low_hz / 1_000_000.0,
+        *high_hz / 1_000_000.0
+    )]
     SpanExceeded { low_hz: f64, high_hz: f64, span_hz: f64 },
 }
-
-impl std::fmt::Display for CustomChannelError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Empty => write!(f, "Custom channel list is empty"),
-            Self::TooMany { count, max } => {
-                write!(f, "Too many custom channels ({count}); maximum is {max}")
-            }
-            Self::InvalidFrequency { value } => {
-                write!(f, "Invalid custom-channel frequency: {value}")
-            }
-            Self::SpanExceeded { low_hz, high_hz, span_hz } => {
-                let span_mhz = span_hz / 1_000_000.0;
-                let low_mhz = low_hz / 1_000_000.0;
-                let high_mhz = high_hz / 1_000_000.0;
-                write!(
-                    f,
-                    "Span {span_mhz:.3} MHz exceeds {} MHz limit ({low_mhz:.3} to {high_mhz:.3} MHz)",
-                    MAX_CHANNEL_SPAN_HZ / 1_000_000.0
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for CustomChannelError {}
 
 /// Validate a slice of custom-channel frequencies (Hz). Returns
 /// `Ok(())` if the list is non-empty, ≤ `MAX_CUSTOM_CHANNELS`,
@@ -1951,11 +2014,23 @@ pub const REGION_OPTIONS: &[(&str, &str)] = &[
     ("custom", "Custom"),
 ];
 
-/// Index of the `"custom"` slot in `REGION_OPTIONS`. Exposed
-/// so the visibility binding for the Custom channels entry-row
-/// (and any other index-keyed UI logic) doesn't hardcode `2`.
-/// CR round 1 on PR #598.
-pub const CUSTOM_REGION_COMBO_INDEX: u32 = 2;
+/// Resolve a region id (e.g. `"custom"`) to its slot index in
+/// `REGION_OPTIONS`. Returns `None` for unknown ids — callers
+/// fall through to the predefined default.
+///
+/// Index-keyed UI logic (the visibility-binding for the Custom
+/// channels entry-row, the rebuild handler) routes through
+/// this rather than hardcoding the slot number, so reordering
+/// `REGION_OPTIONS` only requires editing one slice. CR round
+/// 2 on PR #598 (round 1 introduced a `CUSTOM_REGION_COMBO_INDEX`
+/// constant; round 2 generalised to the lookup helper).
+#[must_use]
+pub fn region_index_for_id(id: &str) -> Option<u32> {
+    REGION_OPTIONS
+        .iter()
+        .position(|(opt_id, _)| *opt_id == id)
+        .and_then(|p| u32::try_from(p).ok())
+}
 ```
 
 Adjust the field shape to match the existing tuple layout (string id + display label).
@@ -1971,12 +2046,13 @@ let custom_channels_row = adw::EntryRow::builder()
 custom_channels_row.set_visible(false);
 acars_group.add(&custom_channels_row);
 
-// Bind visibility to "selected slot is Custom" via the named
-// constant rather than a raw index. CR round 1 on PR #598.
+// Bind visibility to "selected slot resolves to Custom" via
+// the lookup helper rather than a raw index. CR round 2 on
+// PR #598.
 {
     let custom_row = custom_channels_row.clone();
     region_row.connect_selected_notify(move |row| {
-        custom_row.set_visible(row.selected() == CUSTOM_REGION_COMBO_INDEX);
+        custom_row.set_visible(Some(row.selected()) == region_index_for_id("custom"));
     });
 }
 ```
@@ -2058,14 +2134,18 @@ The cleanest approach: have `window.rs` rebuild on every region change since it 
 // Resolve the AcarsRegion from the selected slot (so we don't
 // depend on raw indices) and use its channels().len(). CR
 // round 1 on PR #598.
-let region = if selected_idx == CUSTOM_REGION_COMBO_INDEX {
+// Resolve the AcarsRegion from the selected slot via a domain
+// lookup so we don't depend on raw indices. CR round 2 on
+// PR #598 (round 1 used a CUSTOM_REGION_COMBO_INDEX constant;
+// round 2 generalised to slice lookup).
+let id = REGION_OPTIONS
+    .get(selected_idx as usize)
+    .map(|(id, _)| *id)
+    .unwrap_or("us-6");
+let region = if id == "custom" {
     let saved = read_acars_custom_channels(&state.config);
     AcarsRegion::Custom(saved.into_boxed_slice())
 } else {
-    let id = REGION_OPTIONS
-        .get(selected_idx as usize)
-        .map(|(id, _)| *id)
-        .unwrap_or("us-6");
     AcarsRegion::from_config_id(id)
 };
 let new_count = region.channels().len();

--- a/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
+++ b/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
@@ -1,0 +1,2364 @@
+# ACARS Async Output I/O + Custom Channel Sets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move ACARS output I/O onto a worker thread (#596) AND add user-defined custom channel sets to the Aviation panel (#592), bundled into one PR.
+
+**Architecture:** Part A relocates `AcarsOutputs` from `controller.rs` into `acars_output.rs`, replaces synchronous `JsonlWriter::write` / `UdpFeeder::send` calls in the DSP-thread closure with a `try_send` to a bounded `mpsc::sync_channel(256)`, and runs a dedicated writer thread that owns the writer instances and reads runtime config via `Arc<RwLock<AcarsWriterConfig>>`. Part B extends `AcarsRegion` with a `Custom(Box<[f64]>)` variant (forces dropping `Copy`), migrates `[ChannelStats; 6]` and `[ActionRow; 6]` const-arrays to `Vec` across ~16 sites, and adds a CSV `AdwEntryRow` editor with span/count validation in the Aviation panel.
+
+**Tech Stack:** Rust 1.x, `std::sync::{mpsc, Arc, RwLock, atomic}`, `std::thread`, GTK4 v4.10 + libadwaita via `gtk4-rs`, `serde_json` for config persistence, existing `sdr_acars::ChannelBank` consumer.
+
+**Branch:** `feat/acars-async-io-and-custom-channels` (already off `main`, spec already committed at `75c9e74`).
+
+**Out of scope:** Audio/scanner/satellite output async refactors, persisted ring buffer across app restarts, channel-count generalisation above 8.
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `crates/sdr-core/src/acars_output.rs` | MODIFY — host the new `AcarsOutputs` (was private in `controller.rs`); add `AcarsWriterConfig`, `AcarsOutputMessage`, worker thread spawn + lifecycle. |
+| `crates/sdr-core/src/controller.rs` | MODIFY — drop the local `AcarsOutputs` struct; import from `acars_output`. Switch `acars_decode_tap` to `try_send`; switch handlers (`set_jsonl_path`/`set_network_addr`/`set_station_id`) to mutate the shared config lock. |
+| `crates/sdr-core/src/acars_airband_lock.rs` | MODIFY — add `Custom(Box<[f64]>)` variant; drop `Copy`; `channels()` returns `&[f64]`; new `MAX_CUSTOM_CHANNELS`, `MAX_CHANNEL_SPAN_HZ`, `CustomChannelError`, `validate_custom_channels`. |
+| `crates/sdr-core/src/acars_config.rs` | MODIFY — new `acars_custom_channels` config key + helpers. |
+| `crates/sdr-ui/src/state.rs` | MODIFY — `acars_channel_stats: RefCell<Vec<ChannelStats>>` (was const array). |
+| `crates/sdr-ui/src/window.rs` | MODIFY — array→Vec assignments; rebuild `channel_rows` on region change in `connect_aviation_panel`; startup-replay handles `Custom` two-key load. |
+| `crates/sdr-ui/src/sidebar/aviation_panel.rs` | MODIFY — `channel_rows: Vec<ActionRow>`; add `Custom` to `REGION_OPTIONS`; new `AdwEntryRow` for custom CSV; visibility binding to combo; `connect_apply` validate-and-dispatch. |
+| `crates/sdr-ffi/src/event.rs` | MODIFY — test fixture array→Vec. |
+
+---
+
+## Workspace Gates
+
+Run after each task that touches Rust source. Per-crate gates are sufficient when isolated to one crate.
+
+```bash
+cargo build -p <crate> --features whisper-cpu  # for sdr-ui
+cargo test -p <crate>                          # for sdr-acars / sdr-core
+cargo clippy -p <crate> --features whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Final pre-push gates (Task 14):
+
+```bash
+cargo build --workspace --features sdr-transcription/whisper-cpu
+cargo test --workspace --features sdr-transcription/whisper-cpu
+cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo check --workspace --locked --no-default-features --features sherpa-cpu  # CI's --locked gate
+cargo fmt --all -- --check  # last
+```
+
+The `--locked` gate is mandatory before push per `feedback_cargo_lock_locked_check.md` (CI uses it; local `cargo build` doesn't and silently updates `Cargo.lock`).
+
+---
+
+## Part A — Async output I/O (#596)
+
+### Task 1: Move `AcarsOutputs` from `controller.rs` to `acars_output.rs` (pure refactor)
+
+**Files:**
+- Modify: `crates/sdr-core/src/acars_output.rs` (add struct + impl)
+- Modify: `crates/sdr-core/src/controller.rs` (remove local struct, import)
+
+This is a pure relocation — the struct keeps the same fields and behaviour. Done first so subsequent tasks have a `pub`-visible struct in `acars_output.rs` to grow.
+
+- [ ] **Step 1: Move the struct**
+
+In `crates/sdr-core/src/acars_output.rs`, after the `UdpFeeder` impl block (after line 125), append:
+
+```rust
+/// Output-writer bundle owned by `DspState`. Keeps the JSONL
+/// writer, UDP feeder, station ID, and per-writer warn-rate-
+/// limit timestamps together so the `acars_decode_tap`
+/// signature stays narrow. Issue #578. Async refactor in
+/// progress per #596 — fields will migrate to a worker
+/// thread + shared config in subsequent tasks.
+pub struct AcarsOutputs {
+    pub jsonl: Option<JsonlWriter>,
+    pub udp: Option<UdpFeeder>,
+    pub jsonl_enabled: bool,
+    pub network_enabled: bool,
+    pub station_id: Option<String>,
+    pub jsonl_warn_at: Option<std::time::Instant>,
+    pub udp_warn_at: Option<std::time::Instant>,
+    pub pending_jsonl_path: Option<String>,
+    pub pending_network_addr: Option<String>,
+}
+
+impl AcarsOutputs {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            jsonl: None,
+            udp: None,
+            jsonl_enabled: false,
+            network_enabled: false,
+            station_id: None,
+            jsonl_warn_at: None,
+            udp_warn_at: None,
+            pending_jsonl_path: None,
+            pending_network_addr: None,
+        }
+    }
+}
+
+impl Default for AcarsOutputs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+- [ ] **Step 2: Remove the local struct from `controller.rs`**
+
+In `crates/sdr-core/src/controller.rs`, delete lines 229-273 (the `struct AcarsOutputs` block plus its `impl`). Keep the `ACARS_OUTPUT_WARN_MIN_INTERVAL` constant at line 277 — it still belongs in `controller.rs` since it's used by `acars_decode_tap`.
+
+- [ ] **Step 3: Update references in `controller.rs`**
+
+Find every `AcarsOutputs` reference in `controller.rs` (use grep) and confirm it picks up the new path. Specifically, the field declaration at line 620:
+
+```rust
+acars_outputs: crate::acars_output::AcarsOutputs,
+```
+
+And the constructor at line 716:
+
+```rust
+acars_outputs: crate::acars_output::AcarsOutputs::new(),
+```
+
+The other references (`outputs: &mut AcarsOutputs` in `acars_decode_tap`, `&mut state.acars_outputs` in handlers) will compile after the import is updated.
+
+Add the import at the top of `controller.rs` if not already present:
+
+```rust
+use crate::acars_output::AcarsOutputs;
+```
+
+(Can use `crate::acars_output::AcarsOutputs` inline instead — pick whichever the file's existing style prefers.)
+
+- [ ] **Step 4: Verify build + test + clippy + fmt**
+
+```bash
+cargo build -p sdr-core
+cargo test -p sdr-core
+cargo clippy -p sdr-core --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all clean. The relocation is type-equivalent; existing tests pass unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/sdr-core/src/acars_output.rs crates/sdr-core/src/controller.rs
+git commit -m "$(cat <<'EOF'
+refactor(sdr-core): #596 move AcarsOutputs to acars_output.rs
+
+Pure relocation — the struct and impl move from controller.rs's
+private namespace to a pub item in acars_output.rs, where the
+upcoming async-I/O refactor (#596) will grow them with a worker
+thread, shared config lock, and bounded mpsc channel. No
+behaviour change in this commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add `AcarsWriterConfig` + `AcarsOutputMessage` types
+
+**Files:**
+- Modify: `crates/sdr-core/src/acars_output.rs`
+
+Introduce the writer-thread message + shared-config types. Pure-data additions; no consumer wiring yet.
+
+- [ ] **Step 1: Add the types at the top of `acars_output.rs` (after the `use` block, before `JsonlWriter`)**
+
+Add these declarations at the top of `crates/sdr-core/src/acars_output.rs`, after the existing `use` block (after line 17):
+
+```rust
+use std::path::PathBuf;
+use std::sync::{mpsc, Arc, RwLock};
+use std::thread::JoinHandle;
+
+/// Runtime-mutable writer config. Read-heavy access pattern:
+/// the writer thread reads on every message, the UI side writes
+/// only on user toggle / address edit / station-id change.
+/// Issue #596.
+#[derive(Clone, Debug, Default)]
+pub struct AcarsWriterConfig {
+    /// Where to write the JSONL log. `None` means JSONL output
+    /// is disabled. Path changes trigger a reopen on the next
+    /// message; the worker closes the previous file.
+    pub jsonl_path: Option<PathBuf>,
+    /// UDP feeder destination (`"host:port"`). `None` means
+    /// network output is disabled.
+    pub network_addr: Option<String>,
+    /// Station ID injected into each emitted JSON record.
+    pub station_id: Option<String>,
+}
+
+/// Messages handed from the DSP thread to the writer thread.
+/// Bounded `mpsc::sync_channel` decouples the DSP-thread
+/// `acars_decode_tap` closure from disk / network I/O latency.
+pub enum AcarsOutputMessage {
+    /// One decoded ACARS message, ready to write + feed.
+    Decoded(sdr_acars::AcarsMessage),
+}
+```
+
+- [ ] **Step 2: Verify build + clippy + fmt**
+
+```bash
+cargo build -p sdr-core
+cargo clippy -p sdr-core --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean. New types are unused — clippy may warn `dead_code`. If so, this is fine for now (used in Task 3); add `#[allow(dead_code)]` *only* on `AcarsOutputMessage` and `AcarsWriterConfig` if clippy fails. (Use `#[allow(dead_code)]` per-item; do not blanket-allow.) Remove these allows in Task 3 when the types are wired up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/sdr-core/src/acars_output.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-core): #596 add AcarsWriterConfig + AcarsOutputMessage types
+
+Writer-thread shared config (jsonl_path, network_addr,
+station_id) wrapped in Arc<RwLock<...>>. Read-heavy access:
+writer reads per-message, UI side writes only on user
+toggle/edit. Plus the AcarsOutputMessage enum (single Decoded
+variant for now) handed from the DSP thread to the writer
+thread via mpsc::sync_channel.
+
+Pure type additions — wired up in subsequent tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Build the writer thread (TDD: shutdown-on-disconnect)
+
+**Files:**
+- Modify: `crates/sdr-core/src/acars_output.rs`
+
+Spawn the writer thread with shutdown-on-tx-drop semantics. Test asserts `JoinHandle::join` returns within a short timeout when the sender is dropped.
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/sdr-core/src/acars_output.rs`, inside the existing `mod tests` (after the `udp_feeder_open_invalid_addr_errors` test at the end, around line 242), append:
+
+```rust
+    #[test]
+    fn writer_thread_exits_on_disconnect() {
+        // Spawn a writer thread, drop the sender, assert the
+        // thread joins within a short timeout. Exercises the
+        // recv() returning Err(Disconnected) → loop break path.
+        let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(8);
+        let handle = std::thread::spawn(move || {
+            run_writer_loop(rx, Arc::clone(&config));
+        });
+        drop(tx);
+        // Loop should exit promptly. Allow up to 500 ms for
+        // schedulability under loaded test workers.
+        let start = std::time::Instant::now();
+        while !handle.is_finished() && start.elapsed() < Duration::from_millis(500) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            handle.is_finished(),
+            "writer thread did not exit within 500ms of tx drop"
+        );
+        handle.join().expect("writer thread panicked");
+    }
+```
+
+The `Duration` import is already brought in by the existing test fixtures (line 133); the `Arc`/`RwLock`/`mpsc` imports were added in Task 2.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p sdr-core acars_output::tests::writer_thread_exits_on_disconnect
+```
+
+Expected: FAIL with `cannot find function 'run_writer_loop' in this scope`.
+
+- [ ] **Step 3: Add the writer loop**
+
+In `crates/sdr-core/src/acars_output.rs`, insert before the `mod tests` block (around line 127):
+
+```rust
+/// Writer-thread main loop. Owns the per-thread `JsonlWriter`
+/// and `UdpFeeder` instances, reads `config` on each message
+/// to detect path/addr changes, and exits cleanly when the
+/// sender side disconnects (app shutdown). Issue #596.
+fn run_writer_loop(
+    rx: mpsc::Receiver<AcarsOutputMessage>,
+    _config: Arc<RwLock<AcarsWriterConfig>>,
+) {
+    // Real per-message handling lands in Task 4 (path/addr
+    // hot-reload) and Task 5 (writes + send). For now, just
+    // drain the channel so the shutdown-on-disconnect contract
+    // holds.
+    while let Ok(_msg) = rx.recv() {
+        // Drain only — Task 4 + 5 wire writes here.
+    }
+}
+```
+
+The leading underscore on `_config` suppresses the unused-parameter lint until Task 4 fills it in.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cargo test -p sdr-core acars_output::tests::writer_thread_exits_on_disconnect
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify clippy + fmt**
+
+```bash
+cargo clippy -p sdr-core --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean. If `dead_code` was suppressed in Task 2, the `AcarsOutputMessage` and `AcarsWriterConfig` allows can stay until Task 5 (when they're consumed externally) — or remove them now if they no longer trigger.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-core/src/acars_output.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-core): #596 writer thread loop with shutdown-on-disconnect
+
+Drains an mpsc receiver until tx is dropped, then exits cleanly.
+Per-message JsonlWriter::write / UdpFeeder::send dispatching
+lands in Tasks 4-5; this commit pins the lifecycle contract
+(test asserts the thread joins within 500ms of tx drop).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Wire writer hot-reload (TDD: path-change reopen)
+
+**Files:**
+- Modify: `crates/sdr-core/src/acars_output.rs`
+
+The writer thread reads `config` on each message and reopens its `JsonlWriter` / `UdpFeeder` when the path/addr changes (or closes them when they go to `None`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mod tests` in `crates/sdr-core/src/acars_output.rs`:
+
+```rust
+    #[test]
+    fn writer_reopens_on_path_change() {
+        // Pump message → path A; switch config to path B; pump
+        // message → path B. Assert both files exist with the
+        // expected line count.
+        let dir = tempdir().unwrap();
+        let path_a = dir.path().join("a.jsonl");
+        let path_b = dir.path().join("b.jsonl");
+
+        let config = Arc::new(RwLock::new(AcarsWriterConfig {
+            jsonl_path: Some(path_a.clone()),
+            network_addr: None,
+            station_id: None,
+        }));
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(8);
+        let handle = {
+            let config = Arc::clone(&config);
+            std::thread::spawn(move || run_writer_loop(rx, config))
+        };
+
+        tx.send(AcarsOutputMessage::Decoded(make_msg(0))).unwrap();
+
+        // Spin briefly to let the writer process the first
+        // message before we mutate the path.
+        std::thread::sleep(Duration::from_millis(50));
+
+        config.write().unwrap().jsonl_path = Some(path_b.clone());
+        tx.send(AcarsOutputMessage::Decoded(make_msg(1))).unwrap();
+
+        // Drop tx → thread exits; flush on Drop ensures the
+        // BufWriter contents land on disk before we read.
+        drop(tx);
+        handle.join().expect("writer thread panicked");
+
+        let read_lines = |p: &Path| -> Vec<String> {
+            let f = File::open(p).unwrap();
+            BufReader::new(f).lines().collect::<Result<_, _>>().unwrap()
+        };
+        assert_eq!(read_lines(&path_a).len(), 1, "path A got the first message");
+        assert_eq!(read_lines(&path_b).len(), 1, "path B got the second message");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p sdr-core acars_output::tests::writer_reopens_on_path_change
+```
+
+Expected: FAIL — currently the writer loop drains without writing.
+
+- [ ] **Step 3: Implement the reopen logic**
+
+Replace the `run_writer_loop` body (currently a drain loop) with:
+
+```rust
+fn run_writer_loop(
+    rx: mpsc::Receiver<AcarsOutputMessage>,
+    config: Arc<RwLock<AcarsWriterConfig>>,
+) {
+    let mut jsonl: Option<(PathBuf, JsonlWriter)> = None;
+    let mut udp: Option<(String, UdpFeeder)> = None;
+    let mut jsonl_warn_at: Option<std::time::Instant> = None;
+    let mut udp_warn_at: Option<std::time::Instant> = None;
+
+    while let Ok(msg) = rx.recv() {
+        let AcarsOutputMessage::Decoded(msg) = msg;
+
+        // Snapshot the config under a brief read lock so we
+        // don't hold it across blocking I/O.
+        let (want_jsonl_path, want_udp_addr, station_id) = {
+            let cfg = config.read().expect("acars writer config poisoned");
+            (cfg.jsonl_path.clone(), cfg.network_addr.clone(), cfg.station_id.clone())
+        };
+
+        ensure_jsonl(&mut jsonl, want_jsonl_path.as_deref());
+        ensure_udp(&mut udp, want_udp_addr.as_deref());
+
+        if let Some((_, w)) = jsonl.as_mut() {
+            if let Err(e) = w.write(&msg, station_id.as_deref()) {
+                rate_limited_warn("jsonl", &mut jsonl_warn_at, e);
+            }
+        }
+        if let Some((_, f)) = udp.as_mut() {
+            if let Err(e) = f.send(&msg, station_id.as_deref()) {
+                rate_limited_warn("udp", &mut udp_warn_at, e);
+            }
+        }
+    }
+}
+
+/// Ensure `slot` holds an open `JsonlWriter` matching `want`.
+/// Reopens on path change; closes (drops) when `want` is `None`.
+fn ensure_jsonl(slot: &mut Option<(PathBuf, JsonlWriter)>, want: Option<&Path>) {
+    let needs_reopen = match (slot.as_ref(), want) {
+        (None, None) => false,
+        (Some((cur, _)), Some(want)) if cur == want => false,
+        _ => true,
+    };
+    if !needs_reopen {
+        return;
+    }
+    *slot = None;
+    if let Some(want) = want {
+        match JsonlWriter::open(want) {
+            Ok(w) => *slot = Some((want.to_path_buf(), w)),
+            Err(e) => tracing::warn!("acars jsonl open failed: {e}"),
+        }
+    }
+}
+
+/// Same shape as `ensure_jsonl` but for `UdpFeeder`. The `String`
+/// key compares the user-set addr verbatim; resolved peer
+/// addresses are not the source of truth.
+fn ensure_udp(slot: &mut Option<(String, UdpFeeder)>, want: Option<&str>) {
+    let needs_reopen = match (slot.as_ref(), want) {
+        (None, None) => false,
+        (Some((cur, _)), Some(want)) if cur == want => false,
+        _ => true,
+    };
+    if !needs_reopen {
+        return;
+    }
+    *slot = None;
+    if let Some(want) = want {
+        match UdpFeeder::open(want) {
+            Ok(f) => *slot = Some((want.to_string(), f)),
+            Err(e) => tracing::warn!("acars udp open failed: {e}"),
+        }
+    }
+}
+
+const ACARS_OUTPUT_WARN_MIN_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
+/// Emit a `tracing::warn!` at most once per
+/// `ACARS_OUTPUT_WARN_MIN_INTERVAL` for `kind`. Mirrors the
+/// per-writer 30 s rate-limit that previously lived in
+/// `controller.rs::acars_decode_tap`.
+fn rate_limited_warn(kind: &str, last: &mut Option<std::time::Instant>, err: std::io::Error) {
+    let now = std::time::Instant::now();
+    let elapsed = last.map_or(ACARS_OUTPUT_WARN_MIN_INTERVAL, |t| now.duration_since(t));
+    if elapsed >= ACARS_OUTPUT_WARN_MIN_INTERVAL {
+        tracing::warn!("acars {kind} write/send failed: {err} (rate-limited 30s)");
+        *last = Some(now);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cargo test -p sdr-core acars_output --features whisper-cpu 2>&1 | tail -20
+```
+
+Expected: PASS — `writer_thread_exits_on_disconnect` and `writer_reopens_on_path_change` both green, existing JsonlWriter/UdpFeeder tests still pass.
+
+- [ ] **Step 5: Verify clippy + fmt**
+
+```bash
+cargo clippy -p sdr-core --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean. If clippy flags `doc_markdown` on identifiers like `JsonlWriter`, `UdpFeeder`, `BufWriter` in doc comments, wrap in backticks.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-core/src/acars_output.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-core): #596 writer thread per-message dispatch + hot-reload
+
+Writer thread now reads AcarsWriterConfig on each message and
+reopens JsonlWriter / UdpFeeder when path/addr changes. The
+30 s rate-limited warn previously in controller.rs::acars_decode_tap
+moves into the worker (rate_limited_warn helper).
+
+Test writer_reopens_on_path_change: pump msg → path A, mutate
+config to path B, pump msg → path B; assert both files have
+the expected line count.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Convert `AcarsOutputs` to async shape (TDD: drop-on-full)
+
+**Files:**
+- Modify: `crates/sdr-core/src/acars_output.rs`
+
+Replace the synchronous `AcarsOutputs` fields with `tx`, `config`, drop counter, last-warn timestamp, and `JoinHandle`. Add `try_send` helper that drops on full + 30 s warn rate-limit. Test asserts the 257th try_send into a 256-cap channel is dropped (and counter increments).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mod tests`:
+
+```rust
+    #[test]
+    fn try_send_drops_when_channel_full() {
+        // Build an AcarsOutputs against a tiny channel cap (8)
+        // by spawning *no* worker — leave the receiver dangling
+        // so the channel fills from the first send. The 9th
+        // try_send should drop.
+        //
+        // `AcarsOutputs::with_capacity` is a test-visible
+        // constructor that lets tests use a smaller cap than
+        // the production 256.
+        let outputs = AcarsOutputs::with_capacity_for_test(8);
+        // Stash the receiver so we don't drop it (Disconnected
+        // would be a different error path).
+        let rx_keepalive = outputs._test_rx.clone();
+        let _ = rx_keepalive;
+
+        for _ in 0..8 {
+            assert!(outputs.try_send(make_msg(0)));
+        }
+        // 9th send: channel full, drop returns false, counter
+        // increments.
+        assert!(!outputs.try_send(make_msg(0)));
+        assert_eq!(outputs.drop_count(), 1);
+    }
+```
+
+This test references `with_capacity_for_test`, `try_send`, `drop_count`, and `_test_rx` — all of which we add in Step 3.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p sdr-core acars_output::tests::try_send_drops_when_channel_full
+```
+
+Expected: FAIL — those methods don't exist yet.
+
+- [ ] **Step 3: Replace the synchronous `AcarsOutputs` with the async shape**
+
+Replace the entire `AcarsOutputs` struct and its `impl` (added in Task 1, currently around line 130-170) with:
+
+```rust
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+/// Capacity of the bounded `mpsc::sync_channel` between the
+/// DSP thread and the writer thread. 256 is ~4-5 minutes of
+/// worst-case ACARS bursts (~1 msg/sec sustained, 10 msg/sec
+/// burst peak); covers any realistic disk stall short of total
+/// filesystem hang. Issue #596.
+pub const ACARS_OUTPUT_CHANNEL_CAPACITY: usize = 256;
+
+/// Output-writer bundle owned by `DspState`. Holds the sender
+/// half of the bounded channel + the shared writer config +
+/// the worker thread's join handle. The DSP thread calls
+/// `try_send` per decoded message; the writer thread (spawned
+/// from `new`) does the actual JSONL/UDP I/O. Issue #596.
+pub struct AcarsOutputs {
+    /// Sender half of the writer channel. `try_send` drops on
+    /// full; the worker owns the receiver.
+    tx: mpsc::SyncSender<AcarsOutputMessage>,
+    /// Shared, runtime-mutable writer config. Written by the
+    /// UI side on toggle/edit; read by the writer thread on
+    /// each message.
+    pub config: Arc<RwLock<AcarsWriterConfig>>,
+    /// Cumulative count of messages dropped because the
+    /// channel was full. Surfaced via `drop_count` for
+    /// rate-limited warn at the call site (and the smoke
+    /// checklist).
+    drop_count: Arc<AtomicU64>,
+    /// Last warn timestamp for channel-full drops. Wrapped in
+    /// `Arc<Mutex>` because the warn fires from the DSP thread
+    /// (caller of `try_send`); the writer thread doesn't touch
+    /// it.
+    last_drop_warn_at: Arc<Mutex<Option<std::time::Instant>>>,
+    /// Join handle for the writer thread. `Drop` for
+    /// `AcarsOutputs` drops `tx`, which signals shutdown via
+    /// recv() returning Err(Disconnected); we then `join()`.
+    writer_thread: Option<JoinHandle<()>>,
+
+    // Test-only: an extra receiver clone so unit tests can
+    // override the worker (or skip it entirely). Hidden behind
+    // a method that's `#[cfg(test)]`-gated; production code
+    // never sees this.
+    #[cfg(test)]
+    pub _test_rx: Arc<Mutex<Option<mpsc::Receiver<AcarsOutputMessage>>>>,
+}
+
+impl AcarsOutputs {
+    /// Construct an async-output bundle and spawn the writer
+    /// thread. The thread runs until `Drop` for `AcarsOutputs`
+    /// drops the `tx`, at which point the writer's `recv()`
+    /// returns `Err(Disconnected)` and the loop exits.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(ACARS_OUTPUT_CHANNEL_CAPACITY)
+    }
+
+    /// Same as `new` but with a caller-chosen channel
+    /// capacity. Production calls go through `new`; tests use
+    /// this directly via `with_capacity_for_test` to exercise
+    /// the drop-on-full path with a cap they can saturate.
+    fn with_capacity(capacity: usize) -> Self {
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(capacity);
+        let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
+
+        let writer_config = Arc::clone(&config);
+        let writer_thread = std::thread::Builder::new()
+            .name("sdr-acars-writer".into())
+            .spawn(move || run_writer_loop(rx, writer_config))
+            .expect("failed to spawn ACARS writer thread");
+
+        Self {
+            tx,
+            config,
+            drop_count: Arc::new(AtomicU64::new(0)),
+            last_drop_warn_at: Arc::new(Mutex::new(None)),
+            writer_thread: Some(writer_thread),
+            #[cfg(test)]
+            _test_rx: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Test-only constructor that builds the channel + config
+    /// but skips spawning the worker, leaving the receiver
+    /// reachable via `_test_rx`. Used by `try_send_drops_when_channel_full`
+    /// to fill a small-cap channel without race conditions.
+    #[cfg(test)]
+    fn with_capacity_for_test(capacity: usize) -> Self {
+        let (tx, rx) = mpsc::sync_channel::<AcarsOutputMessage>(capacity);
+        let config = Arc::new(RwLock::new(AcarsWriterConfig::default()));
+        Self {
+            tx,
+            config,
+            drop_count: Arc::new(AtomicU64::new(0)),
+            last_drop_warn_at: Arc::new(Mutex::new(None)),
+            writer_thread: None,
+            _test_rx: Arc::new(Mutex::new(Some(rx))),
+        }
+    }
+
+    /// Try to hand off `msg` to the writer thread. Returns
+    /// `true` on success, `false` if the channel was full
+    /// (drop counter incremented; warn fires at most once per
+    /// 30 s).
+    pub fn try_send(&self, msg: sdr_acars::AcarsMessage) -> bool {
+        match self.tx.try_send(AcarsOutputMessage::Decoded(msg)) {
+            Ok(()) => true,
+            Err(mpsc::TrySendError::Full(_)) => {
+                self.drop_count.fetch_add(1, Ordering::Relaxed);
+                self.maybe_warn_full();
+                false
+            }
+            // Disconnected only happens on shutdown (writer
+            // thread is gone). Silent — caller shouldn't
+            // surface noise during teardown.
+            Err(mpsc::TrySendError::Disconnected(_)) => false,
+        }
+    }
+
+    /// Cumulative drop count since startup.
+    #[must_use]
+    pub fn drop_count(&self) -> u64 {
+        self.drop_count.load(Ordering::Relaxed)
+    }
+
+    /// 30 s-rate-limited warn for channel-full drops. Reads
+    /// the current drop count so the message names how many
+    /// were lost in this window.
+    fn maybe_warn_full(&self) {
+        let mut last = self.last_drop_warn_at.lock().expect("warn lock poisoned");
+        let now = std::time::Instant::now();
+        let elapsed = last.map_or(ACARS_OUTPUT_WARN_MIN_INTERVAL, |t| now.duration_since(t));
+        if elapsed >= ACARS_OUTPUT_WARN_MIN_INTERVAL {
+            let n = self.drop_count.load(Ordering::Relaxed);
+            tracing::warn!(
+                "ACARS output channel full ({n} drops since startup); \
+                 writer thread falling behind (rate-limited 30s)"
+            );
+            *last = Some(now);
+        }
+    }
+}
+
+impl Default for AcarsOutputs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for AcarsOutputs {
+    fn drop(&mut self) {
+        // Closing tx triggers Disconnected → the writer loop
+        // exits. We still need to join the thread to make
+        // sure its Drop impls (BufWriter flush) finish before
+        // the process exits.
+        if let Some(handle) = self.writer_thread.take() {
+            // Drop the tx clone held by `self.tx` first by
+            // overwriting it with a drained channel. (mpsc::SyncSender
+            // doesn't have an explicit close — Drop is the
+            // signal.)
+            let (dummy_tx, _) = mpsc::sync_channel::<AcarsOutputMessage>(0);
+            self.tx = dummy_tx;
+            // Now the original tx is gone (replaced + dropped).
+            // Wait for the worker to exit.
+            if let Err(e) = handle.join() {
+                tracing::warn!("ACARS writer thread join failed: {e:?}");
+            }
+        }
+    }
+}
+```
+
+Note `ACARS_OUTPUT_WARN_MIN_INTERVAL` is now defined in this file (Task 4 added it as a private const). Reuse it; don't redefine.
+
+- [ ] **Step 4: Run the failing test to confirm it now passes**
+
+```bash
+cargo test -p sdr-core acars_output --features whisper-cpu
+```
+
+Expected: PASS — `try_send_drops_when_channel_full` green, plus `writer_thread_exits_on_disconnect` and `writer_reopens_on_path_change` (both still green).
+
+- [ ] **Step 5: Verify clippy + fmt**
+
+```bash
+cargo clippy -p sdr-core --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean. If clippy flags `doc_markdown` on identifiers (`JsonlWriter`, `UdpFeeder`, `mpsc::sync_channel`, `Arc<RwLock>`, `JoinHandle`, etc.) wrap in backticks.
+
+The build will FAIL at `controller.rs` because the old `AcarsOutputs` interface (jsonl, udp, jsonl_enabled, station_id, etc. fields) is gone. Don't try to fix that here — it's Task 6's job.
+
+To get the per-crate gates green WITHOUT building all of `controller.rs` consumers, run only:
+
+```bash
+cargo test -p sdr-core --lib acars_output  # tests the new module in isolation
+```
+
+This passes if `acars_output.rs` compiles standalone. The full `cargo build -p sdr-core` will fail until Task 6.
+
+- [ ] **Step 6: Commit (anticipating Task 6 to fix the build)**
+
+```bash
+git add crates/sdr-core/src/acars_output.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-core): #596 AcarsOutputs async shape + try_send drop-on-full
+
+Replaces the synchronous AcarsOutputs (jsonl + udp + warn
+timestamps + pending paths) with the async-I/O shape:
+- mpsc::sync_channel(256) for hand-off to the writer thread
+- Arc<RwLock<AcarsWriterConfig>> for runtime config
+- AtomicU64 drop counter + Arc<Mutex<Option<Instant>>> for the
+  channel-full warn rate-limit
+
+try_send drops on Full and increments the counter; warn fires
+at most once per 30 s with the cumulative drop count.
+
+Drop for AcarsOutputs joins the writer thread cleanly.
+
+NOTE: this commit breaks controller.rs at the per-crate build
+gate — `controller.rs` still references the old field shape.
+Task 6 finishes the migration; this commit is the type pivot.
+
+Test try_send_drops_when_channel_full: 9th send into 8-cap
+channel returns false; drop_count == 1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Switch `acars_decode_tap` to `try_send` + delete legacy fields from `AcarsOutputs` consumers
+
+**Files:**
+- Modify: `crates/sdr-core/src/controller.rs`
+
+`acars_decode_tap` no longer takes `&mut AcarsOutputs` — it takes `&AcarsOutputs` and calls `outputs.try_send(msg)`. The handlers (`set_acars_jsonl_path`, `set_acars_network_addr`, `set_acars_station_id`, plus the engage path) all switch to mutating `outputs.config.write()` instead of the old `pending_*` fields. Removed-from-state-struct: `jsonl`, `udp`, `jsonl_enabled`, `network_enabled`, `station_id`, `jsonl_warn_at`, `udp_warn_at`, `pending_jsonl_path`, `pending_network_addr`. The corresponding open/close logic (`open_jsonl_writer`, `close_acars_outputs`, etc.) gets deleted — the writer thread owns those concerns now.
+
+This is a large-ish controller.rs edit. Below is the concrete replacement for `acars_decode_tap`; the handler edits follow the same pattern (write the config lock, no return value).
+
+- [ ] **Step 1: Replace `acars_decode_tap` body**
+
+In `crates/sdr-core/src/controller.rs`, find the function (around line 879). Replace the body (lines 879-981) with:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+fn acars_decode_tap(
+    bank: &mut Option<sdr_acars::ChannelBank>,
+    init_failed: &mut bool,
+    source_rate_hz: f64,
+    center_hz: f64,
+    channels: &[f64],
+    iq: &[sdr_types::Complex],
+    dsp_tx: &std::sync::mpsc::Sender<crate::messages::DspToUi>,
+    outputs: &crate::acars_output::AcarsOutputs,
+) {
+    const _: () = assert!(
+        std::mem::size_of::<sdr_types::Complex>() == std::mem::size_of::<num_complex::Complex32>(),
+        "sdr_types::Complex and num_complex::Complex32 must have identical size \
+         for the bytemuck zero-copy cast in acars_decode_tap"
+    );
+    const _: () = assert!(
+        std::mem::align_of::<sdr_types::Complex>()
+            == std::mem::align_of::<num_complex::Complex32>(),
+        "sdr_types::Complex and num_complex::Complex32 must have identical \
+         alignment for the bytemuck zero-copy cast in acars_decode_tap"
+    );
+
+    if *init_failed {
+        return;
+    }
+    if bank.is_none() {
+        match sdr_acars::ChannelBank::new(source_rate_hz, center_hz, channels) {
+            Ok(b) => {
+                tracing::info!(
+                    "ACARS bank initialised: source_rate={source_rate_hz} \
+                     center={center_hz} n_channels={}",
+                    channels.len()
+                );
+                *bank = Some(b);
+            }
+            Err(e) => {
+                tracing::warn!("ACARS bank init failed: {e}");
+                *init_failed = true;
+                return;
+            }
+        }
+    }
+    let Some(bank) = bank.as_mut() else { return };
+    let iq_c32: &[num_complex::Complex32] = bytemuck::cast_slice(iq);
+    bank.process(iq_c32, |msg| {
+        // Hand off to the writer thread via the bounded
+        // channel. Drop-on-full is handled by `try_send`
+        // (rate-limited warn lives there). The writer thread
+        // owns JsonlWriter::write + UdpFeeder::send and reads
+        // station_id / paths from the shared config lock.
+        // Issue #596.
+        outputs.try_send(msg.clone());
+        // Forward to the UI viewer regardless of writer state.
+        let _ = dsp_tx.send(crate::messages::DspToUi::AcarsMessage(Box::new(msg)));
+    });
+}
+```
+
+Note: `outputs: &mut AcarsOutputs` becomes `outputs: &AcarsOutputs`. `try_send` takes `&self` (interior mutability via the AtomicU64 + Mutex) so a shared borrow is enough. This simplifies all callers — they no longer need a mutable borrow.
+
+- [ ] **Step 2: Update `acars_decode_tap` callers**
+
+Find every call site (use grep `acars_decode_tap(`). They all currently pass `&mut state.acars_outputs`. Change each to `&state.acars_outputs`. There are ~3 callers (in `process_iq_block` and the lazy-init dispatch around line 3679, plus the test fixtures at the bottom of the file).
+
+For the test fixtures at lines 4934+ (the `#[cfg(test)] mod tests` section): they currently do `let mut outputs = super::AcarsOutputs::new();`. Change to:
+
+```rust
+let outputs = super::AcarsOutputs::new();
+super::acars_decode_tap(
+    /* ... */
+    &outputs,
+);
+```
+
+i.e., drop the `mut` and the `&mut`. The tests should still pass — they were exercising the bank-init / decode path, not the I/O fields.
+
+- [ ] **Step 3: Update the handlers**
+
+Replace the bodies of `handle_set_acars_jsonl_path`, `handle_set_acars_network_addr`, `handle_set_acars_station_id` (currently around lines 4480-4540) with:
+
+```rust
+fn handle_set_acars_jsonl_path(
+    state: &mut DspState,
+    dsp_tx: &mpsc::Sender<DspToUi>,
+    path: &str,
+) {
+    let resolved: Option<std::path::PathBuf> = if path.is_empty() {
+        None
+    } else {
+        Some(resolve_jsonl_path(path))
+    };
+    state
+        .acars_outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned")
+        .jsonl_path = resolved.clone();
+    // Echo the resolved path back to the UI for status display.
+    let display = resolved
+        .as_ref()
+        .map_or_else(String::new, |p| p.display().to_string());
+    let _ = dsp_tx.send(DspToUi::AcarsJsonlPathResolved(display));
+}
+
+fn handle_set_acars_network_addr(
+    state: &mut DspState,
+    dsp_tx: &mpsc::Sender<DspToUi>,
+    addr: &str,
+) {
+    let resolved = if addr.is_empty() {
+        None
+    } else {
+        Some(addr.to_string())
+    };
+    state
+        .acars_outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned")
+        .network_addr = resolved.clone();
+    let display = resolved.unwrap_or_default();
+    let _ = dsp_tx.send(DspToUi::AcarsNetworkAddrResolved(display));
+}
+
+fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
+    let trimmed = station_id.trim();
+    state
+        .acars_outputs
+        .config
+        .write()
+        .expect("acars writer config poisoned")
+        .station_id = if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    };
+}
+```
+
+- [ ] **Step 4: Delete the obsolete helpers**
+
+Delete from `controller.rs`:
+- `fn jsonl_path_for(...)` (lines ~4378-4383)
+- `fn network_addr_for(...)` (lines ~4385-4395)
+- `fn close_acars_outputs(...)` (around line 4449) — its callers (lines 1198, 3401, 4337) should also be removed; the writer thread owns close-on-drop now.
+- The lazy-open blocks in `process_iq_block` around lines 1093-1107 — those depended on the `pending_*` fields. The writer thread does ensure_jsonl/ensure_udp on every message; no per-block lazy open is needed.
+
+For each `close_acars_outputs(&mut state.acars_outputs)` call, just delete the line. App-shutdown cleanup is handled by `Drop for AcarsOutputs`.
+
+Also delete the local `ACARS_OUTPUT_WARN_MIN_INTERVAL` if it's still in `controller.rs` (it moved to `acars_output.rs` in Task 4).
+
+- [ ] **Step 5: Update the engage / disengage paths**
+
+In the engage path (`SetAcarsEnabled(true)` handler), the existing code reads `pending_jsonl_path` etc. to open writers. With the new shape, the writer thread is always running — engage just needs to make sure the config has the right values. The `pending_*` setter handlers (Step 3) already update the config, so the engage path can be simplified: just set `jsonl_enabled` / `network_enabled` flags ... but wait — the spec replaces those flags with `jsonl_path: Option` (Some = enabled). Re-read the spec.
+
+The spec says `AcarsWriterConfig { jsonl_path, network_addr, station_id }` — no separate enable flag. The semantics are: if `jsonl_path` is `Some`, write; if `None`, don't. The UI's "enable JSONL" toggle is implemented as: setting `jsonl_path` to the resolved default-or-user path on enable, and to `None` on disable.
+
+So the existing `handle_set_acars_jsonl_enabled` (and same for network) handler needs to translate the boolean toggle into a path-or-None config write:
+
+```rust
+fn handle_set_acars_jsonl_enabled(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, enabled: bool) {
+    if enabled {
+        // Enabling: resolve the user's pending path (or default if unset)
+        // and stamp it into the config.
+        let path = resolve_jsonl_path(""); // empty → default
+        state.acars_outputs.config.write().expect("acars writer config poisoned").jsonl_path = Some(path.clone());
+        let _ = dsp_tx.send(DspToUi::AcarsJsonlPathResolved(path.display().to_string()));
+    } else {
+        // Disabling: clear the path. Worker's ensure_jsonl
+        // will close the writer on the next message.
+        state.acars_outputs.config.write().expect("acars writer config poisoned").jsonl_path = None;
+        let _ = dsp_tx.send(DspToUi::AcarsJsonlPathResolved(String::new()));
+    }
+}
+
+fn handle_set_acars_network_enabled(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, enabled: bool) {
+    if enabled {
+        let addr = "feed.airframes.io:5550".to_string(); // default
+        state.acars_outputs.config.write().expect("acars writer config poisoned").network_addr = Some(addr.clone());
+        let _ = dsp_tx.send(DspToUi::AcarsNetworkAddrResolved(addr));
+    } else {
+        state.acars_outputs.config.write().expect("acars writer config poisoned").network_addr = None;
+        let _ = dsp_tx.send(DspToUi::AcarsNetworkAddrResolved(String::new()));
+    }
+}
+```
+
+If the existing `handle_set_acars_jsonl_enabled` already exists, replace its body with the above. If it doesn't (i.e., the legacy code packed enable + path into one call), reconcile by checking the `UiToDsp` message variants.
+
+NOTE: this part of Task 6 is genuinely tricky because there are several wired-together fields. The implementer should:
+1. Run `cargo build -p sdr-core` and walk each compile error
+2. For each missing field reference, decide: replace with config-lock write, or delete (if the helper no longer makes sense)
+
+This is a search-and-fix-compile-errors task; the volume of changes is mechanical but there are ~30 sites across the file. Don't try to enumerate every site here — the build errors are the source of truth.
+
+- [ ] **Step 6: Verify build + test + clippy + fmt**
+
+```bash
+cargo build -p sdr-core
+cargo test -p sdr-core --features whisper-cpu
+cargo clippy -p sdr-core --features whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all clean. The existing controller-level integration tests should still pass — the visible behaviour from the UI-facing API perspective is unchanged. If a test relies on `state.acars_outputs.jsonl.is_some()` (or similar), update it to read `state.acars_outputs.config.read().unwrap().jsonl_path.is_some()`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/sdr-core/src/controller.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-core): #596 wire DSP-thread try_send through controller
+
+Switches acars_decode_tap to use AcarsOutputs::try_send (which
+hands off to the writer thread) instead of synchronous
+JsonlWriter::write / UdpFeeder::send. Handlers (set_acars_jsonl_path,
+set_acars_network_addr, set_acars_station_id) now mutate the
+shared Arc<RwLock<AcarsWriterConfig>> instead of the old
+pending_* fields.
+
+Removed: pending_jsonl_path, pending_network_addr, jsonl_enabled,
+network_enabled, jsonl_warn_at, udp_warn_at, jsonl/udp writer
+slots from AcarsOutputs (writer thread owns them now);
+jsonl_path_for, network_addr_for, close_acars_outputs helpers;
+the lazy-open blocks in process_iq_block.
+
+Engage/disengage flips jsonl_path / network_addr Some↔None
+in the config; the writer thread's ensure_jsonl / ensure_udp
+detect the change on the next message and reopen/close.
+
+Test suite still passes — DSP-thread ACARS path is now
+non-blocking on disk/network I/O.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Part B — Custom channel sets (#592)
+
+### Task 7: Add validators + constants to `acars_airband_lock.rs` (TDD)
+
+**Files:**
+- Modify: `crates/sdr-core/src/acars_airband_lock.rs`
+
+Add `MAX_CUSTOM_CHANNELS`, `MAX_CHANNEL_SPAN_HZ`, `CustomChannelError`, `validate_custom_channels`. No `AcarsRegion` changes yet — the validator is a free function.
+
+- [ ] **Step 1: Write the failing tests**
+
+Find the existing `mod tests` (likely at the bottom of `acars_airband_lock.rs`; if absent, append a new one). Add these tests inside it:
+
+```rust
+    #[test]
+    fn validate_rejects_empty() {
+        assert_eq!(validate_custom_channels(&[]), Err(CustomChannelError::Empty));
+    }
+
+    #[test]
+    fn validate_accepts_single_channel() {
+        assert_eq!(validate_custom_channels(&[131_550_000.0]), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_max_count() {
+        let chans: Vec<f64> = (0..MAX_CUSTOM_CHANNELS)
+            .map(|i| 131_000_000.0 + (i as f64) * 100_000.0)
+            .collect();
+        assert_eq!(validate_custom_channels(&chans), Ok(()));
+    }
+
+    #[test]
+    fn validate_rejects_too_many() {
+        let chans: Vec<f64> = (0..=MAX_CUSTOM_CHANNELS)
+            .map(|i| 131_000_000.0 + (i as f64) * 100_000.0)
+            .collect();
+        assert_eq!(
+            validate_custom_channels(&chans),
+            Err(CustomChannelError::TooMany {
+                count: MAX_CUSTOM_CHANNELS + 1,
+                max: MAX_CUSTOM_CHANNELS,
+            })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_nan() {
+        assert_eq!(
+            validate_custom_channels(&[131_550_000.0, f64::NAN]),
+            Err(CustomChannelError::InvalidFrequency { value: f64::NAN })
+        );
+        // f64::NAN != f64::NAN, so the assert_eq above compares
+        // via PartialEq on the wrapper struct; verify that
+        // CustomChannelError uses bitwise equality (which we'll
+        // arrange via #[derive(PartialEq)] on a NotNan-style
+        // wrapper) — actually, simpler: just check the variant.
+        // (Re-cast as a discriminant check.)
+        match validate_custom_channels(&[131_550_000.0, f64::NAN]) {
+            Err(CustomChannelError::InvalidFrequency { .. }) => {}
+            other => panic!("expected InvalidFrequency, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_inf() {
+        match validate_custom_channels(&[131_550_000.0, f64::INFINITY]) {
+            Err(CustomChannelError::InvalidFrequency { .. }) => {}
+            other => panic!("expected InvalidFrequency, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_negative_or_zero() {
+        match validate_custom_channels(&[131_550_000.0, 0.0]) {
+            Err(CustomChannelError::InvalidFrequency { value }) if value == 0.0 => {}
+            other => panic!("expected InvalidFrequency(0.0), got {other:?}"),
+        }
+        match validate_custom_channels(&[131_550_000.0, -1.0]) {
+            Err(CustomChannelError::InvalidFrequency { value }) if value == -1.0 => {}
+            other => panic!("expected InvalidFrequency(-1.0), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_accepts_span_just_under() {
+        // 2.4 MHz exact span — accepted (the constraint is ≤).
+        assert_eq!(
+            validate_custom_channels(&[129_125_000.0, 131_525_000.0]),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn validate_rejects_span_just_over() {
+        // 2.5 MHz — rejected.
+        match validate_custom_channels(&[129_000_000.0, 131_500_000.0]) {
+            Err(CustomChannelError::SpanExceeded { low_hz, high_hz, span_hz }) => {
+                assert!((low_hz - 129_000_000.0).abs() < 1.0);
+                assert!((high_hz - 131_500_000.0).abs() < 1.0);
+                assert!((span_hz - 2_500_000.0).abs() < 1.0);
+            }
+            other => panic!("expected SpanExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_channel_error_display_span_exceeded() {
+        let err = CustomChannelError::SpanExceeded {
+            low_hz: 129_000_000.0,
+            high_hz: 131_500_000.0,
+            span_hz: 2_500_000.0,
+        };
+        let s = format!("{err}");
+        // User-facing toast text — must mention span value and
+        // the offending pair in MHz.
+        assert!(s.contains("2.5"), "span value present: {s}");
+        assert!(s.contains("129"), "low freq present: {s}");
+        assert!(s.contains("131"), "high freq present: {s}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p sdr-core acars_airband_lock::tests 2>&1 | tail -20
+```
+
+Expected: FAIL with `cannot find function 'validate_custom_channels' in this scope` and `cannot find type 'CustomChannelError' in this scope`.
+
+- [ ] **Step 3: Add the validator + constants + error**
+
+In `crates/sdr-core/src/acars_airband_lock.rs`, after the existing constants (after line 62 — `EUROPE_SIX_CHANNELS_HZ` block), insert:
+
+```rust
+/// Maximum number of channels in a user-defined custom region.
+/// Sized for any realistic ACARS cluster within
+/// `MAX_CHANNEL_SPAN_HZ`. Issue #592.
+pub const MAX_CUSTOM_CHANNELS: usize = 8;
+
+/// Maximum allowed span (max - min) of a custom channel set
+/// in Hz. Set to 2.4 MHz to leave a 100 kHz margin against
+/// the 2.5 MSps source rate (Nyquist bandwidth ≈ 2.5 MHz).
+/// Issue #592.
+pub const MAX_CHANNEL_SPAN_HZ: f64 = 2_400_000.0;
+
+/// Error variants returned by [`validate_custom_channels`].
+/// `Display` impl produces user-facing toast text. Issue #592.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CustomChannelError {
+    Empty,
+    TooMany { count: usize, max: usize },
+    InvalidFrequency { value: f64 },
+    SpanExceeded { low_hz: f64, high_hz: f64, span_hz: f64 },
+}
+
+impl std::fmt::Display for CustomChannelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "Custom channel list is empty"),
+            Self::TooMany { count, max } => {
+                write!(f, "Too many custom channels ({count}); maximum is {max}")
+            }
+            Self::InvalidFrequency { value } => {
+                write!(f, "Invalid custom-channel frequency: {value}")
+            }
+            Self::SpanExceeded { low_hz, high_hz, span_hz } => {
+                let span_mhz = span_hz / 1_000_000.0;
+                let low_mhz = low_hz / 1_000_000.0;
+                let high_mhz = high_hz / 1_000_000.0;
+                write!(
+                    f,
+                    "Span {span_mhz:.3} MHz exceeds {} MHz limit ({low_mhz:.3} to {high_mhz:.3} MHz)",
+                    MAX_CHANNEL_SPAN_HZ / 1_000_000.0
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CustomChannelError {}
+
+/// Validate a slice of custom-channel frequencies (Hz). Returns
+/// `Ok(())` if the list is non-empty, ≤ `MAX_CUSTOM_CHANNELS`,
+/// all values are finite + positive, and `max - min ≤
+/// MAX_CHANNEL_SPAN_HZ`. Issue #592.
+pub fn validate_custom_channels(chans: &[f64]) -> Result<(), CustomChannelError> {
+    if chans.is_empty() {
+        return Err(CustomChannelError::Empty);
+    }
+    if chans.len() > MAX_CUSTOM_CHANNELS {
+        return Err(CustomChannelError::TooMany {
+            count: chans.len(),
+            max: MAX_CUSTOM_CHANNELS,
+        });
+    }
+    for &c in chans {
+        if !c.is_finite() || c <= 0.0 {
+            return Err(CustomChannelError::InvalidFrequency { value: c });
+        }
+    }
+    let (mut min, mut max) = (chans[0], chans[0]);
+    for &c in &chans[1..] {
+        if c < min {
+            min = c;
+        }
+        if c > max {
+            max = c;
+        }
+    }
+    let span = max - min;
+    if span > MAX_CHANNEL_SPAN_HZ {
+        return Err(CustomChannelError::SpanExceeded {
+            low_hz: min,
+            high_hz: max,
+            span_hz: span,
+        });
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test -p sdr-core acars_airband_lock::tests
+```
+
+Expected: PASS — 10 tests green (the 9 new ones + 1 `custom_channel_error_display_span_exceeded`).
+
+- [ ] **Step 5: Verify clippy + fmt**
+
+```bash
+cargo clippy -p sdr-core --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean. If `clippy::float_cmp` fires on `value == 0.0` (we use `c <= 0.0` which is fine; `if value == 0.0` in tests is acceptable for f64::NAN comparison context — wrap in `#[allow(clippy::float_cmp)]` per-test if needed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-core/src/acars_airband_lock.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-core): #592 add custom-channel constants + validator
+
+Adds MAX_CUSTOM_CHANNELS=8, MAX_CHANNEL_SPAN_HZ=2_400_000,
+CustomChannelError (Empty/TooMany/InvalidFrequency/SpanExceeded
+variants with Display + Error impls), and validate_custom_channels.
+
+Validator rules:
+- 1 ≤ N ≤ MAX_CUSTOM_CHANNELS
+- All values finite and > 0
+- max - min ≤ MAX_CHANNEL_SPAN_HZ
+
+Display formats SpanExceeded as user-facing toast text:
+"Span X.XX MHz exceeds 2.4 MHz limit (Y.YYY to Z.ZZZ MHz)".
+
+Pure data — wired into AcarsRegion::Custom in Task 8 and the
+Aviation panel apply handler in Task 12.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Add `AcarsRegion::Custom` variant + drop `Copy` (TDD round-trip)
+
+**Files:**
+- Modify: `crates/sdr-core/src/acars_airband_lock.rs`
+
+Add the `Custom(Box<[f64]>)` variant. This forces `AcarsRegion` to drop `Copy` (Box isn't Copy). Update `channels()` to return `&[f64]`. Extend `config_id`, `from_config_id`, `display_label` with the Custom arm. Remove `Copy` from `#[derive]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mod tests`:
+
+```rust
+    #[test]
+    fn from_config_id_round_trips_custom() {
+        // Custom is a placeholder — channels live in a separate
+        // config key, loaded by window.rs::startup-replay.
+        let r = AcarsRegion::from_config_id("custom");
+        assert_eq!(r.config_id(), "custom");
+        // Empty placeholder: from_config_id returns Custom([])
+        // unconditionally; the actual frequencies are populated
+        // by the load-side caller.
+        assert_eq!(r.channels(), &[] as &[f64]);
+    }
+
+    #[test]
+    fn channels_accessor_returns_borrowed_slice() {
+        let us = AcarsRegion::Us6;
+        let eu = AcarsRegion::Europe;
+        assert_eq!(us.channels().len(), ACARS_CHANNEL_COUNT);
+        assert_eq!(eu.channels().len(), ACARS_CHANNEL_COUNT);
+
+        let custom = AcarsRegion::Custom(Box::from([131_550_000.0, 131_525_000.0].as_slice()));
+        assert_eq!(custom.channels().len(), 2);
+        assert_eq!(custom.channels()[0], 131_550_000.0);
+    }
+
+    #[test]
+    fn display_label_custom() {
+        let custom = AcarsRegion::Custom(Box::from([131_550_000.0].as_slice()));
+        assert_eq!(custom.display_label(), "Custom");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p sdr-core acars_airband_lock --features whisper-cpu 2>&1 | tail -10
+```
+
+Expected: FAIL — `Custom` is not a variant of `AcarsRegion`.
+
+- [ ] **Step 3: Update the enum + impls**
+
+Replace the `AcarsRegion` enum + impl block in `crates/sdr-core/src/acars_airband_lock.rs` (lines 76-153) with:
+
+```rust
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum AcarsRegion {
+    /// North America (default). Six channels in 129.125–
+    /// 131.550 MHz.
+    #[default]
+    Us6,
+    /// Europe. Six channels clustered in 131.450–131.875 MHz.
+    Europe,
+    /// User-defined channel set. Frequencies in Hz; validated
+    /// via `validate_custom_channels` at construction time.
+    /// Issue #592.
+    Custom(Box<[f64]>),
+}
+
+impl AcarsRegion {
+    /// Channels for this region (Hz). Returns a borrowed slice
+    /// so all variants — including `Custom` — share one
+    /// accessor. Issue #592.
+    #[must_use]
+    pub fn channels(&self) -> &[f64] {
+        match self {
+            Self::Us6 => &US_SIX_CHANNELS_HZ,
+            Self::Europe => &EUROPE_SIX_CHANNELS_HZ,
+            Self::Custom(c) => c,
+        }
+    }
+
+    /// Source center frequency for this region (Hz). Computed
+    /// as the midpoint of `min(channels)` and `max(channels)`
+    /// so the cluster fits symmetrically inside the 2.5 MHz
+    /// Nyquist window.
+    #[must_use]
+    pub fn center_hz(&self) -> f64 {
+        let chans = self.channels();
+        if chans.is_empty() {
+            // `Custom([])` placeholder shouldn't reach engage,
+            // but keep this defensive — return 0.0.
+            return 0.0;
+        }
+        let mut min = chans[0];
+        let mut max = chans[0];
+        for &c in &chans[1..] {
+            if c < min {
+                min = c;
+            }
+            if c > max {
+                max = c;
+            }
+        }
+        f64::midpoint(min, max)
+    }
+
+    /// Stable string id used as the `acars_region` config key
+    /// value. Round-trips with `from_config_id`. The `Custom`
+    /// arm always returns `"custom"`; the actual channel list
+    /// is persisted under a separate `acars_custom_channels`
+    /// config key.
+    #[must_use]
+    pub fn config_id(&self) -> &'static str {
+        match self {
+            Self::Us6 => "us-6",
+            Self::Europe => "europe",
+            Self::Custom(_) => "custom",
+        }
+    }
+
+    /// Inverse of `config_id`. Falls back to default on
+    /// unrecognised strings. Returns `Custom(Box::new([]))`
+    /// for `"custom"` — the load-side caller in
+    /// `window.rs::startup_replay` populates the actual
+    /// frequencies from `acars_custom_channels`.
+    #[must_use]
+    pub fn from_config_id(id: &str) -> Self {
+        match id {
+            "europe" => Self::Europe,
+            "custom" => Self::Custom(Box::new([])),
+            _ => Self::Us6,
+        }
+    }
+
+    /// Display label for the Aviation panel combo row.
+    #[must_use]
+    pub fn display_label(&self) -> &'static str {
+        match self {
+            Self::Us6 => "United States (US-6)",
+            Self::Europe => "Europe",
+            Self::Custom(_) => "Custom",
+        }
+    }
+}
+```
+
+Key changes:
+1. `#[derive(Copy)]` removed.
+2. `channels(self)` → `channels(&self)`, returns `&[f64]`.
+3. `center_hz(self)` → `center_hz(&self)`, handles empty Custom defensively.
+4. `config_id(self)` → `config_id(&self)`.
+5. `from_config_id` adds `"custom"` arm.
+6. `display_label(self)` → `display_label(&self)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test -p sdr-core acars_airband_lock 2>&1 | tail -20
+```
+
+Expected: tests for the new behaviour pass. **Existing call sites (and existing tests) of `region.channels()` etc. that use the old `Copy` calling convention may now break.** Use the next steps to surface and fix.
+
+- [ ] **Step 5: Fix call sites that broke from dropping `Copy`**
+
+```bash
+cargo build -p sdr-core 2>&1 | grep error | head -20
+```
+
+For each error, the fix is one of:
+- Was `let r: AcarsRegion = …; let chans = r.channels();` → still works (now borrows).
+- Was `region.channels()` returning `[f64; 6]` and indexed as array → adjust to slice indexing (no source changes usually; `&[f64]` and `[f64; 6]` both index with `[i]`).
+- Was passing `region` by value to a function: change to `&region` or `region.clone()` depending on caller's use.
+- Was `match region { ... }` exhaustive: now requires `Custom(_)` arm or `_ => ...`; add what's appropriate.
+
+This is a search-and-fix-compile-errors task. The likely affected files are `controller.rs`, `acars_config.rs`, and `window.rs`. The diff per file is small (typically `region.channels()` is borrowable as-is).
+
+- [ ] **Step 6: Update existing region tests**
+
+The existing tests for `Us6` / `Europe` likely call `.channels()` and compare to const arrays. They should still work because slice equality with array equality is automatic. If any tests do `let r = AcarsRegion::Us6; let chans = r.channels();` then later `region.center_hz()` where `region` was moved (Copy), they need to switch to `region.center_hz()` after binding `r` (no longer Copy → no move issue, just borrow).
+
+- [ ] **Step 7: Verify build + test + clippy + fmt across sdr-core**
+
+```bash
+cargo build -p sdr-core
+cargo test -p sdr-core --features whisper-cpu
+cargo clippy -p sdr-core --features whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/sdr-core/src/acars_airband_lock.rs crates/sdr-core/src/controller.rs crates/sdr-core/src/acars_config.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-core): #592 add AcarsRegion::Custom variant; drop Copy
+
+Adds Custom(Box<[f64]>) variant with associated impl arms.
+channels() now returns &[f64] (borrowed slice — works for both
+predefined static arrays and the Custom variant's Box payload).
+config_id/from_config_id round-trip "custom" as a placeholder
+(empty Box); the actual frequencies live in a separate
+acars_custom_channels config key, loaded by startup-replay
+in window.rs.
+
+Drops `Copy` from the enum (forced — Box<[f64]> isn't Copy).
+Existing call sites that took region by value were borrowing
+the value already; the few that moved get a `.clone()` or `&`
+prefix.
+
+Test: from_config_id("custom") round-trips; channels accessor
+returns borrowed slice for all variants; display_label("Custom").
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: const-array → `Vec` migration sweep
+
+**Files:**
+- Modify: `crates/sdr-ui/src/state.rs`
+- Modify: `crates/sdr-ui/src/window.rs`
+- Modify: `crates/sdr-ui/src/sidebar/aviation_panel.rs`
+- Modify: `crates/sdr-core/src/controller.rs`
+- Modify: `crates/sdr-ffi/src/event.rs`
+
+These changes must land in one commit because partial migration breaks the build (state.rs uses `Vec<ChannelStats>` but window.rs still does `*… = [Default; 6]`). Mechanical type-substitution sweep.
+
+- [ ] **Step 1: `crates/sdr-ui/src/state.rs:267`**
+
+Find:
+```rust
+pub acars_channel_stats: RefCell<[ChannelStats; ACARS_CHANNEL_COUNT]>,
+```
+
+Replace with:
+```rust
+pub acars_channel_stats: RefCell<Vec<ChannelStats>>,
+```
+
+- [ ] **Step 2: `crates/sdr-ui/src/state.rs:421`**
+
+Find:
+```rust
+acars_channel_stats: RefCell::new([ChannelStats::default(); ACARS_CHANNEL_COUNT]),
+```
+
+Replace with:
+```rust
+acars_channel_stats: RefCell::new(Vec::new()),
+```
+
+(Default empty; it's filled on engage from `region.channels().len()`.)
+
+- [ ] **Step 3: `crates/sdr-ui/src/state.rs:524-526`**
+
+Find:
+```rust
+state.acars_channel_stats.borrow().len(),
+sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT,
+"stats array width sourced from ACARS_CHANNEL_COUNT"
+```
+
+(This is inside an assert/debug_assert.) Replace the surrounding assertion with one that checks the stats vec width matches the active region's channel count instead:
+
+```rust
+state.acars_channel_stats.borrow().len(),
+state.acars_region.borrow().channels().len(),
+"stats vec width matches active region's channel count"
+```
+
+(If `acars_region` field doesn't exist on `AppState` — check it; if absent, leave a comment and let a separate task add it. For now, drop the assertion if there's no stable source for the expected width.)
+
+- [ ] **Step 4: `crates/sdr-ui/src/sidebar/aviation_panel.rs:52`**
+
+Find:
+```rust
+pub channel_rows: [adw::ActionRow; ACARS_CHANNEL_COUNT],
+```
+
+Replace with:
+```rust
+pub channel_rows: Vec<adw::ActionRow>,
+```
+
+- [ ] **Step 5: `crates/sdr-ui/src/sidebar/aviation_panel.rs:174`**
+
+Find the existing `array::from_fn` block:
+```rust
+let channel_rows: [adw::ActionRow; ACARS_CHANNEL_COUNT] = std::array::from_fn(|_| {
+    let row = adw::ActionRow::builder().title("—").subtitle("—").build();
+    channels_group.add(&row);
+    row
+});
+```
+
+Replace with a Vec-builder that takes a `channel_count: usize` parameter (which is set from the active region in the caller):
+
+```rust
+let channel_rows: Vec<adw::ActionRow> = (0..channel_count)
+    .map(|_| {
+        let row = adw::ActionRow::builder().title("—").subtitle("—").build();
+        channels_group.add(&row);
+        row
+    })
+    .collect();
+```
+
+The enclosing function signature also needs the new parameter. Find `pub fn build_aviation_panel(...)` and add `channel_count: usize` to it. Update doc comments accordingly.
+
+- [ ] **Step 6: `crates/sdr-ui/src/sidebar/aviation_panel.rs:238`**
+
+The `channel_rows` field-init in the struct literal `AviationPanel { … channel_rows, … }` already takes a Vec — no change needed beyond the type-substitution above.
+
+- [ ] **Step 7: `crates/sdr-ui/src/window.rs:2092`**
+
+Find:
+```rust
+*state.acars_channel_stats.borrow_mut() = *ch_stats;
+```
+
+(Where `ch_stats` was `&[ChannelStats; ACARS_CHANNEL_COUNT]`.) Replace with:
+
+```rust
+*state.acars_channel_stats.borrow_mut() = ch_stats.to_vec();
+```
+
+If `ch_stats` is now `&[ChannelStats]` (from a slice-returning DSP message), `.to_vec()` works directly.
+
+- [ ] **Step 8: `crates/sdr-ui/src/window.rs:2156-2157`**
+
+Find:
+```rust
+*state.acars_channel_stats.borrow_mut() = [sdr_acars::ChannelStats::default();
+    sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT];
+```
+
+Replace with:
+```rust
+state.acars_channel_stats.borrow_mut().clear();
+```
+
+(Clearing is the right semantic — disengage zeroes out the stats display.)
+
+- [ ] **Step 9: `crates/sdr-ui/src/window.rs:11998` and `:12041`**
+
+These iterate `channel_rows` / `acars_channel_stats`. Iteration via `.iter()` works the same on `Vec<T>` and `[T; N]` — no change needed unless the iteration relied on a fixed length.
+
+If a `.zip()` was previously matching aircraft rows to fixed-length stats, ensure both sides are now Vecs that may have different lengths during transitions. Add `.take(min(rows.len(), stats.len()))` if a length-mismatch could occur.
+
+- [ ] **Step 10: `crates/sdr-core/src/controller.rs:3708`**
+
+Find:
+```rust
+crate::acars_airband_lock::ACARS_CHANNEL_COUNT]>::try_from(
+```
+
+This is a `<[T; ACARS_CHANNEL_COUNT]>::try_from(slice)` call. Replace with a `Vec::from(slice)` or just pass the slice directly through to whichever consumer needed it. The exact replacement depends on the surrounding context; the rule is "drop the const-sized array; pass slice or Vec directly".
+
+- [ ] **Step 11: `crates/sdr-ffi/src/event.rs:1296`**
+
+Find the test fixture:
+```rust
+[sdr_acars::ChannelStats::default(); sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT],
+```
+
+Replace with:
+```rust
+vec![sdr_acars::ChannelStats::default(); sdr_core::acars_airband_lock::ACARS_CHANNEL_COUNT],
+```
+
+Note: `ACARS_CHANNEL_COUNT` stays as a constant — it's still useful as the *predefined* count. The migration is just from `[T; N]` to `Vec<T>` at storage sites.
+
+- [ ] **Step 12: Update `build_aviation_panel` callers**
+
+Find every caller of `build_aviation_panel` (use grep). Each needs to pass `channel_count`. Source it from the active region:
+
+```rust
+let region = state.config.borrow().acars_region();
+let channel_count = region.channels().len();
+let panel = build_aviation_panel(channel_count);
+```
+
+- [ ] **Step 13: Verify build + test + clippy + fmt across the workspace**
+
+```bash
+cargo build --workspace --features sdr-transcription/whisper-cpu
+cargo test --workspace --features sdr-transcription/whisper-cpu
+cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean. The migration is type-equivalent for predefined regions (length=6), so existing behaviour is preserved.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add crates/sdr-ui/src/state.rs crates/sdr-ui/src/window.rs crates/sdr-ui/src/sidebar/aviation_panel.rs crates/sdr-core/src/controller.rs crates/sdr-ffi/src/event.rs
+git commit -m "$(cat <<'EOF'
+refactor(sdr-ui,sdr-core,sdr-ffi): #592 const-array → Vec for ACARS channels
+
+Migrates [ChannelStats; ACARS_CHANNEL_COUNT] and
+[ActionRow; ACARS_CHANNEL_COUNT] storage sites to Vec
+across ~16 sites in 5 files. ACARS_CHANNEL_COUNT itself
+stays as a constant (still meaningful as the predefined-
+region count).
+
+build_aviation_panel now takes channel_count: usize so it
+can build a row list sized to the active region (US-6 / Europe
+both 6, Custom variable up to MAX_CUSTOM_CHANNELS).
+
+Atomic single-commit migration — partial migration would
+break the build (state.rs Vec assignment vs window.rs array
+literal incompatibility).
+
+Behaviour-preserving for predefined regions; the Custom variant
+support flows in via Tasks 10-12.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: Add `acars_custom_channels` config persistence (TDD)
+
+**Files:**
+- Modify: `crates/sdr-core/src/acars_config.rs`
+
+New config key + getters + setters. Stored as a JSON array of f64 Hz values.
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/sdr-core/src/acars_config.rs`, find or create `mod tests` at the bottom. Append:
+
+```rust
+    #[test]
+    fn acars_custom_channels_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let mut config = Config::load_or_default(&path);
+
+        config.set_acars_custom_channels(&[131_550_000.0, 131_525_000.0, 130_025_000.0]);
+        config.save(&path).unwrap();
+
+        let loaded = Config::load_or_default(&path);
+        let chans = loaded.acars_custom_channels();
+        assert_eq!(chans, vec![131_550_000.0, 131_525_000.0, 130_025_000.0]);
+    }
+
+    #[test]
+    fn acars_custom_channels_empty_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let config = Config::load_or_default(&path);
+        assert_eq!(config.acars_custom_channels(), Vec::<f64>::new());
+    }
+```
+
+Adjust the `Config::load_or_default` / `Config::save` calls to match the actual API of `acars_config.rs` (use grep to find existing pattern; the file likely has a similar set of round-trip tests for other keys).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p sdr-core acars_config::tests::acars_custom_channels
+```
+
+Expected: FAIL with `cannot find function 'set_acars_custom_channels'`.
+
+- [ ] **Step 3: Add the key + accessors**
+
+In `crates/sdr-core/src/acars_config.rs`, find the existing key constants (e.g., `pub const ACARS_REGION_KEY: &str = "acars_region";`). Add:
+
+```rust
+pub const ACARS_CUSTOM_CHANNELS_KEY: &str = "acars_custom_channels";
+```
+
+Add to `Config`'s impl (next to `acars_region` / `set_acars_region`):
+
+```rust
+impl Config {
+    /// Custom-channel frequencies (Hz) when the active region
+    /// is `Custom`. Empty Vec means no custom channels saved
+    /// yet (or the active region isn't Custom). Issue #592.
+    #[must_use]
+    pub fn acars_custom_channels(&self) -> Vec<f64> {
+        self.get_array(ACARS_CUSTOM_CHANNELS_KEY)
+            .unwrap_or_default()
+    }
+
+    /// Persist a custom-channel frequency list (Hz). Caller is
+    /// responsible for validating via
+    /// `acars_airband_lock::validate_custom_channels` before
+    /// calling.
+    pub fn set_acars_custom_channels(&mut self, chans: &[f64]) {
+        self.set_array(ACARS_CUSTOM_CHANNELS_KEY, chans);
+    }
+}
+```
+
+If `get_array` / `set_array` don't exist on `Config`, find the equivalent (likely `get_value` / `set_value` with `serde_json::Value`). Use whatever pattern is established in the file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test -p sdr-core acars_config 2>&1 | tail -10
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify clippy + fmt**
+
+```bash
+cargo clippy -p sdr-core --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/sdr-core/src/acars_config.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-core): #592 persist acars_custom_channels config key
+
+JSON array of f64 Hz values. Empty default. Caller validates
+via acars_airband_lock::validate_custom_channels before set.
+
+Round-trip tested: write 3 freqs, reload, assert equality.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11: Aviation panel — Custom region UI (combo entry, EntryRow, visibility binding, apply handler)
+
+**Files:**
+- Modify: `crates/sdr-ui/src/sidebar/aviation_panel.rs`
+- Modify: `crates/sdr-ui/src/window.rs`
+
+UI-side: add `Custom` to the region combo's options; create the Custom-channels `AdwEntryRow`; bind its visibility to combo selection; wire the apply handler. Pure GTK widget code — leans on smoke verification.
+
+- [ ] **Step 1: Extend `REGION_OPTIONS`**
+
+In `crates/sdr-ui/src/sidebar/aviation_panel.rs`, find the existing `REGION_OPTIONS` slice (likely near the top of the file with `LEFT_ACTIVITIES`-style declarations). Add the Custom entry:
+
+```rust
+pub const REGION_OPTIONS: &[(&str, &str)] = &[
+    ("us-6", "United States (US-6)"),
+    ("europe", "Europe"),
+    ("custom", "Custom"),
+];
+```
+
+Adjust the field shape to match the existing tuple layout (string id + display label).
+
+- [ ] **Step 2: Add the Custom EntryRow + visibility binding**
+
+In the panel-builder function (around the existing region combo creation), after the `region_row.set_model(...)` line:
+
+```rust
+let custom_channels_row = adw::EntryRow::builder()
+    .title("Custom channels (MHz, comma-separated)")
+    .build();
+custom_channels_row.set_visible(false);
+acars_group.add(&custom_channels_row);
+
+// Bind visibility to "selected slot is Custom".
+{
+    let custom_row = custom_channels_row.clone();
+    region_row.connect_selected_notify(move |row| {
+        let selected = row.selected();
+        // REGION_OPTIONS Custom slot is index 2.
+        custom_row.set_visible(selected == 2);
+    });
+}
+```
+
+Add `custom_channels_row` to the `AviationPanel` struct (new field), so `connect_aviation_panel` in `window.rs` can attach the `connect_apply` handler.
+
+- [ ] **Step 3: Wire apply handler in `window.rs::connect_aviation_panel`**
+
+In `crates/sdr-ui/src/window.rs`, find `connect_aviation_panel`. Add (after the existing region-combo handler):
+
+```rust
+// Apply handler for custom-channels entry. Fires on Enter or
+// focus-loss. Parses CSV → validates → on success persists
+// + dispatches SetAcarsRegion(Custom). On failure: toast +
+// inline error CSS.
+let custom_row = panels.aviation.custom_channels_row.clone();
+{
+    let state = Rc::clone(state);
+    let toast_overlay = toast_overlay.clone();
+    let row_for_handler = custom_row.clone();
+    custom_row.connect_apply(move |row| {
+        let text = row.text();
+        let parsed: Result<Vec<f64>, String> = text
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                s.parse::<f64>()
+                    .map(|mhz| mhz * 1_000_000.0)
+                    .map_err(|e| format!("'{s}': {e}"))
+            })
+            .collect();
+
+        match parsed {
+            Err(e) => {
+                row_for_handler.add_css_class("error");
+                let toast = adw::Toast::builder()
+                    .title(format!("Invalid custom channels: {e}"))
+                    .timeout(5)
+                    .build();
+                toast_overlay.add_toast(toast);
+                return;
+            }
+            Ok(chans) => match validate_custom_channels(&chans) {
+                Err(e) => {
+                    row_for_handler.add_css_class("error");
+                    let toast = adw::Toast::builder()
+                        .title(e.to_string())
+                        .timeout(5)
+                        .build();
+                    toast_overlay.add_toast(toast);
+                }
+                Ok(()) => {
+                    row_for_handler.remove_css_class("error");
+                    state
+                        .config
+                        .borrow_mut()
+                        .set_acars_custom_channels(&chans);
+                    let _ = state.config.borrow().save();
+                    let region = AcarsRegion::Custom(chans.into_boxed_slice());
+                    state.send_dsp(UiToDsp::SetAcarsRegion(region));
+                }
+            },
+        }
+    });
+}
+```
+
+Imports needed: `sdr_core::acars_airband_lock::{validate_custom_channels, AcarsRegion}`.
+
+- [ ] **Step 4: Wire region-combo apply for the channels-rebuild side**
+
+In the same `connect_aviation_panel` function, the region combo's existing `connect_selected_notify` handler dispatches `SetAcarsRegion(...)` and persists. Extend it to also rebuild the channel rows by removing them from the channels_group and re-adding sized to `region.channels().len()`. (Or alternatively, dispatch a refresh signal that the panel listens to.)
+
+The cleanest approach: have `window.rs` rebuild on every region change since it already owns the panel reference. Inside the existing combo handler:
+
+```rust
+// Rebuild channel_rows to match the new region's channel count.
+let new_count = match selected_idx {
+    0 => 6,           // US-6
+    1 => 6,           // Europe
+    2 => state.config.borrow().acars_custom_channels().len(),
+    _ => 6,
+};
+rebuild_aviation_channel_rows(&panels.aviation, new_count);
+```
+
+Where `rebuild_aviation_channel_rows` is a helper that:
+1. Removes existing rows from `channels_group` (use `panels.aviation.channels_group.remove(&row)` for each row).
+2. Builds N new `ActionRow`s; appends to `channels_group` and the `channel_rows` Vec.
+
+This requires exposing `channels_group: adw::PreferencesGroup` on `AviationPanel`. Add it as a public field.
+
+- [ ] **Step 5: Pre-fill the EntryRow on panel open from saved config**
+
+After the panel is built, before connecting handlers:
+
+```rust
+// Hydrate Custom EntryRow from saved config.
+let saved_chans = state.config.borrow().acars_custom_channels();
+if !saved_chans.is_empty() {
+    let csv = saved_chans
+        .iter()
+        .map(|hz| format!("{:.3}", hz / 1_000_000.0))
+        .collect::<Vec<_>>()
+        .join(", ");
+    panels.aviation.custom_channels_row.set_text(&csv);
+}
+```
+
+- [ ] **Step 6: Verify build + clippy + tests + fmt**
+
+```bash
+cargo build -p sdr-ui --features whisper-cpu
+cargo clippy -p sdr-ui --features whisper-cpu --all-targets -- -D warnings
+cargo test -p sdr-ui --features whisper-cpu
+cargo fmt --all -- --check
+```
+
+Expected: clean. The aviation panel changes are GTK widget code; no unit tests added in this commit (smoke covers them).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/sdr-ui/src/sidebar/aviation_panel.rs crates/sdr-ui/src/window.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #592 Aviation panel custom-channels editor
+
+Adds:
+- "Custom" option to the region combo (REGION_OPTIONS slot 2)
+- AdwEntryRow "Custom channels (MHz, comma-separated)" with
+  visibility bound to combo selection (visible only when Custom)
+- connect_apply handler: parse CSV → multiply by 1e6 → validate
+  via validate_custom_channels → on success persist + dispatch
+  SetAcarsRegion(Custom); on failure add `error` CSS class +
+  toast naming the offending pair (or parse error)
+- pre-fill on panel open from saved acars_custom_channels config
+- channels_group rebuild on region change so row count matches
+  the new region's channel count
+
+GTK widget code — leans on smoke verification (Task 13).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 12: Startup-replay handles Custom region two-key load
+
+**Files:**
+- Modify: `crates/sdr-ui/src/window.rs`
+
+When the app starts up, the `startup_replay` (or equivalent) reads `acars_region`. For `"custom"` it must also read `acars_custom_channels` and validate before dispatching `SetAcarsRegion(Custom(...))`.
+
+- [ ] **Step 1: Find the existing startup-replay block**
+
+```bash
+grep -n "from_config_id\|acars_region\|SetAcarsRegion" /data/source/rtl-sdr/crates/sdr-ui/src/window.rs | head -10
+```
+
+Find the block where `Config::acars_region()` is read on startup. Likely in a function called `startup_replay`, `apply_startup_config`, or similar.
+
+- [ ] **Step 2: Replace the startup-replay region resolution with the two-key version**
+
+Find the existing pattern (likely):
+
+```rust
+let region_id = state.config.borrow().acars_region();
+let region = AcarsRegion::from_config_id(&region_id);
+state.send_dsp(UiToDsp::SetAcarsRegion(region));
+```
+
+Replace with:
+
+```rust
+let cfg = state.config.borrow();
+let region_id = cfg.acars_region();
+let region = match region_id.as_str() {
+    "custom" => {
+        let chans = cfg.acars_custom_channels();
+        match validate_custom_channels(&chans) {
+            Ok(()) => AcarsRegion::Custom(chans.into_boxed_slice()),
+            Err(e) => {
+                tracing::warn!(
+                    "saved custom channels invalid ({e}); falling back to default region"
+                );
+                AcarsRegion::default()
+            }
+        }
+    }
+    _ => AcarsRegion::from_config_id(&region_id),
+};
+drop(cfg);
+state.send_dsp(UiToDsp::SetAcarsRegion(region));
+```
+
+- [ ] **Step 3: Verify build + test + clippy + fmt**
+
+```bash
+cargo build -p sdr-ui --features whisper-cpu
+cargo test -p sdr-ui --features whisper-cpu
+cargo clippy -p sdr-ui --features whisper-cpu --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/sdr-ui/src/window.rs
+git commit -m "$(cat <<'EOF'
+feat(sdr-ui): #592 startup-replay loads Custom region from two keys
+
+Resolves AcarsRegion at startup as a two-key read:
+- acars_region holds "us-6" / "europe" / "custom"
+- For "custom", also read acars_custom_channels, validate, and
+  build AcarsRegion::Custom(chans.into_boxed_slice())
+- On validation failure (e.g., stale config from a previous
+  version), warn and fall back to AcarsRegion::default()
+
+The Custom([]) placeholder from from_config_id never reaches
+the engage path — either the stored channels load successfully,
+or we fall back to Us6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final tasks
+
+### Task 13: Workspace gates verification (no commit)
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run the full workspace gate set including --locked**
+
+```bash
+cargo build --workspace --features sdr-transcription/whisper-cpu
+cargo test --workspace --features sdr-transcription/whisper-cpu
+cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo check --workspace --locked --no-default-features --features sherpa-cpu
+cargo fmt --all -- --check
+```
+
+Expected: all clean. The `--locked` gate is the one that's saved us from CI failures; it must pass before we push (per `feedback_cargo_lock_locked_check.md`).
+
+- [ ] **Step 2: Skim the diff for obvious issues**
+
+```bash
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+```
+
+Expected: ~12 commits, ~485 LOC ballpark across the files listed in the spec's File budget.
+
+- [ ] **Step 3: No commit (verification only)**
+
+If any gate fails, fix in-place on the appropriate task's commit.
+
+---
+
+### Task 14: Manual GTK smoke (USER ONLY)
+
+**Files:** none modified.
+
+GTK widget code is not unit-testable without a display server. Per project convention (`feedback_smoke_test_workflow.md`): Claude installs the binary; the user runs the smoke checklist manually. Claude does NOT launch the binary.
+
+- [ ] **Step 1 (Claude): Install the binary**
+
+```bash
+make install CARGO_FLAGS="--release --features whisper-cuda"
+```
+
+Expected: `make install` builds with `--release` and `whisper-cuda` features and copies the binary to `$(BINDIR)/sdr-rs`. Per `feedback_make_install_release_flag.md`, the `--release` flag is required — without it, an old release binary stays in place. Verify with:
+
+```bash
+strings $BINDIR/sdr-rs | grep -i "Custom channels (MHz" | head -3
+strings $BINDIR/sdr-rs | grep -i "ACARS output channel full" | head -3
+```
+
+Expected: at least one match for each — confirms the new strings are in the installed binary.
+
+- [ ] **Step 2 (USER ONLY): Run the smoke checklist**
+
+Hand off to user with:
+
+> Build installed at `$(BINDIR)/sdr-rs`. Please run through the smoke checklist below and report which steps pass / fail before I push the branch.
+
+**Smoke checklist (USER ONLY, copy verbatim into your pre-push report):**
+
+1. **Async I/O sanity**
+   - [ ] Start the app, engage ACARS. Toggle JSONL on, set the path to `~/sdr-recordings/acars-async-smoke.jsonl`. Watch the file accumulate over a 5-minute window.
+   - [ ] Confirm zero DSP underruns / zero "channel full" warnings in the logs (check tracing output for `ACARS output channel full`).
+   - [ ] Tail the log file (`tail -f ~/sdr-recordings/acars-async-smoke.jsonl`) — confirm new lines arrive in real time as ACARS messages decode.
+   - [ ] Disable JSONL via the toggle; confirm the file stops growing immediately.
+   - [ ] Re-enable JSONL with the SAME path; confirm the file keeps appending (writer reopens).
+   - [ ] Change the JSONL path to `~/sdr-recordings/acars-async-smoke-2.jsonl` while ACARS is engaged; confirm the new path starts accumulating and the old one stops.
+2. **UDP feeder sanity**
+   - [ ] Start a `nc -ul 5550` listener in another terminal. In the app, enable Network feeder pointed at `127.0.0.1:5550`.
+   - [ ] Confirm `nc` shows incoming JSON datagrams as ACARS messages decode.
+   - [ ] Disable network feeder; confirm `nc` stops receiving.
+3. **Custom region happy path**
+   - [ ] Open Aviation panel; switch the Region combo to **Custom**. Confirm the "Custom channels (MHz, comma-separated)" EntryRow appears.
+   - [ ] Type `131.55, 131.525, 130.025` into the EntryRow; press Enter (apply).
+   - [ ] Confirm the Channels group rebuilds to 3 rows.
+   - [ ] Engage ACARS; confirm decoding occurs across those 3 channels.
+   - [ ] Status row shows correct channel count (3, not 6).
+4. **Custom region validation**
+   - [ ] In Custom mode, type `129.0, 132.0, 133.0` (span 4.0 MHz). Press Enter.
+   - [ ] Confirm a toast appears with text containing "Span 4 MHz exceeds 2.4 MHz limit (129.000 to 133.000 MHz)".
+   - [ ] Confirm the EntryRow shows the error CSS class (red-tinted/highlighted).
+   - [ ] Confirm no DSP dispatch happened (region didn't change to Custom).
+   - [ ] Type valid frequencies; confirm the error CSS class clears.
+5. **Custom region max channels**
+   - [ ] Type 9 frequencies (e.g. `131.000, 131.025, 131.050, 131.075, 131.100, 131.125, 131.150, 131.175, 131.200`).
+   - [ ] Confirm a toast appears with "Too many custom channels (9); maximum is 8".
+6. **Persistence round-trip**
+   - [ ] Set a valid Custom region (e.g. `131.55, 131.525, 130.025`). Engage ACARS to confirm it works.
+   - [ ] Quit the app. Reopen.
+   - [ ] Confirm the panel pre-fills the EntryRow with the saved CSV.
+   - [ ] Confirm the combo shows "Custom".
+   - [ ] Engage ACARS; confirm decoding works on those channels.
+7. **Region swap with channel count change**
+   - [ ] From Custom (3 chan) → switch to US-6 → confirm Channels group rebuilds to 6 rows.
+   - [ ] US-6 → Europe → confirm 6 rows again.
+   - [ ] Europe → Custom → confirm 3 rows (from saved config).
+   - [ ] Engage ACARS in each; confirm decoding works in each.
+8. **Pause/Clear/Sort still work**
+   - [ ] Quick smoke of the existing ACARS viewer features — Stream tab, By Aircraft tab, Pause, Clear — to confirm no regression from the migration.
+9. **No DSP underruns under normal load**
+   - [ ] Run the app for 10 minutes with ACARS engaged + JSONL on + Network on + transcription on. Watch logs for any `ACARS output channel full` warns or audio underruns.
+
+- [ ] **Step 3: Wait for user smoke pass**
+
+Do NOT proceed to Task 15 until the user reports the smoke checklist passing. If any step fails, fix and re-smoke before pushing.
+
+---
+
+### Task 15: Final pre-push sweep + push branch
+
+**Files:** none modified.
+
+- [ ] **Step 1: Re-run gates immediately before push**
+
+Per `feedback_fmt_check_immediately_before_push.md`, fmt is the LAST gate before push. Per `feedback_cargo_lock_locked_check.md`, the `--locked` check is mandatory:
+
+```bash
+cargo build --workspace --features sdr-transcription/whisper-cpu
+cargo test --workspace --features sdr-transcription/whisper-cpu
+cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings
+cargo check --workspace --locked --no-default-features --features sherpa-cpu
+cargo fmt --all -- --check
+```
+
+Expected: all clean.
+
+- [ ] **Step 2: Confirm branch state**
+
+```bash
+git status
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+```
+
+Expected: clean working tree (or only the unrelated `Cargo.lock` change if `--locked` updated it; if so, commit with `chore: cargo update for --locked` first), ~12 commits ahead of main, ~485 LOC across the files in the File budget.
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin feat/acars-async-io-and-custom-channels
+```
+
+Expected: success. **DO NOT open the PR — the user will do that.** The plan ends here; user opens the PR via GitHub UI or `gh pr create` themselves.
+
+---
+
+## Spec coverage matrix
+
+| Spec section | Task |
+|---|---|
+| Part A architecture (AcarsOutputs / config / writer thread) | Tasks 1-5 |
+| Part A — DSP-thread try_send wiring | Task 6 |
+| Part A — runtime config writes (jsonl path / network addr / station_id handlers) | Task 6 |
+| Part A — drop-on-full + 30 s warn rate-limit | Task 5 |
+| Part A — writer thread shutdown on disconnect | Tasks 3 + 5 |
+| Part A — writer thread reopens on path change | Task 4 |
+| Part A — `Drop` joins writer thread | Task 5 |
+| Part B — `MAX_CUSTOM_CHANNELS` + `MAX_CHANNEL_SPAN_HZ` constants | Task 7 |
+| Part B — `CustomChannelError` + `Display` impl | Task 7 |
+| Part B — `validate_custom_channels` | Task 7 |
+| Part B — `AcarsRegion::Custom(Box<[f64]>)` + drop `Copy` | Task 8 |
+| Part B — `channels()` returns `&[f64]` | Task 8 |
+| Part B — `from_config_id("custom")` round-trip | Task 8 |
+| Part B — const-array → `Vec` migration (16 sites in 5 files) | Task 9 |
+| Part B — `acars_custom_channels` config persistence | Task 10 |
+| Part B — Aviation panel Custom EntryRow + visibility binding | Task 11 |
+| Part B — apply handler with validate-and-dispatch | Task 11 |
+| Part B — region-change rebuild of channel rows | Task 11 |
+| Part B — startup-replay two-key load | Task 12 |
+| Edge case: empty Custom on first open (engage gate refuses) | Task 7 (Empty error) + Task 12 (validates on load) |
+| Edge case: N=1 custom channel | Task 7 (validate_accepts_single_channel test) |
+| Edge case: span just under / over 2.4 MHz | Task 7 (validate_accepts_span_just_under / validate_rejects_span_just_over) |
+| Edge case: writer thread shutdown on app exit | Task 5 (`Drop` impl) |
+| Edge case: hot-reload of jsonl path mid-session | Task 4 (writer_reopens_on_path_change test) |
+| Workspace gates including --locked | Task 13 + 15 |
+| GTK smoke (USER ONLY) | Task 14 |
+| Final push (no PR creation) | Task 15 |

--- a/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
+++ b/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
@@ -434,9 +434,12 @@ fn run_writer_loop(
         let AcarsOutputMessage::Decoded(msg) = msg;
 
         // Snapshot the config under a brief read lock so we
-        // don't hold it across blocking I/O.
+        // don't hold it across blocking I/O. Recover from
+        // poisoning rather than panicking — a panic in the
+        // writer path would otherwise propagate to all later
+        // settings edits. CR round 1 on PR #598.
         let (want_jsonl_path, want_udp_addr, station_id) = {
-            let cfg = config.read().expect("acars writer config poisoned");
+            let cfg = config.read().unwrap_or_else(|p| p.into_inner());
             (cfg.jsonl_path.clone(), cfg.network_addr.clone(), cfg.station_id.clone())
         };
 
@@ -946,51 +949,53 @@ fn handle_set_acars_jsonl_path(
     } else {
         Some(resolve_jsonl_path(path))
     };
-    state
-        .acars_outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned")
-        .jsonl_path = resolved.clone();
-    // Echo the resolved path back to the UI for status display.
-    let display = resolved
-        .as_ref()
-        .map_or_else(String::new, |p| p.display().to_string());
-    let _ = dsp_tx.send(DspToUi::AcarsJsonlPathResolved(display));
+    acars_config_write(&state.acars_outputs.config).jsonl_path = resolved;
+    state.acars_outputs.notify_config_changed();
 }
 
 fn handle_set_acars_network_addr(
     state: &mut DspState,
-    dsp_tx: &mpsc::Sender<DspToUi>,
+    _dsp_tx: &mpsc::Sender<DspToUi>,
     addr: &str,
 ) {
-    let resolved = if addr.is_empty() {
-        None
-    } else {
-        Some(addr.to_string())
-    };
-    state
-        .acars_outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned")
-        .network_addr = resolved.clone();
-    let display = resolved.unwrap_or_default();
-    let _ = dsp_tx.send(DspToUi::AcarsNetworkAddrResolved(display));
-}
-
-fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
-    let trimmed = station_id.trim();
-    state
-        .acars_outputs
-        .config
-        .write()
-        .expect("acars writer config poisoned")
-        .station_id = if trimmed.is_empty() {
+    let trimmed = addr.trim();
+    let resolved = if trimmed.is_empty() {
         None
     } else {
         Some(trimmed.to_string())
     };
+    acars_config_write(&state.acars_outputs.config).network_addr = resolved;
+    state.acars_outputs.notify_config_changed();
+}
+
+fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
+    // Trim, bound to 8 chars (matches acarsdec's `idstation`
+    // field width), and treat empty-after-trim as None so
+    // non-UI callers (config replay, future FFI) can't leak
+    // whitespace-only or oversized IDs into emitted JSON.
+    // CR round 3 on PR #595.
+    let trimmed = station_id.trim();
+    acars_config_write(&state.acars_outputs.config).station_id = if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.chars().take(8).collect())
+    };
+    state.acars_outputs.notify_config_changed();
+}
+```
+
+The `acars_config_write` helper recovers from `RwLock` poisoning rather than panicking; without it, a panic in the writer thread would propagate to every later settings edit.
+
+```rust
+/// Acquire the ACARS writer config write lock, recovering from
+/// poisoning rather than panicking. CR round 1 on PR #598.
+fn acars_config_write(
+    cfg: &std::sync::RwLock<crate::acars_output::AcarsWriterConfig>,
+) -> std::sync::RwLockWriteGuard<'_, crate::acars_output::AcarsWriterConfig> {
+    cfg.write().unwrap_or_else(|poisoned| {
+        tracing::warn!("acars writer config lock was poisoned; recovering");
+        poisoned.into_inner()
+    })
 }
 ```
 
@@ -1015,30 +1020,48 @@ The spec says `AcarsWriterConfig { jsonl_path, network_addr, station_id }` — n
 So the existing `handle_set_acars_jsonl_enabled` (and same for network) handler needs to translate the boolean toggle into a path-or-None config write:
 
 ```rust
-fn handle_set_acars_jsonl_enabled(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, enabled: bool) {
-    if enabled {
-        // Enabling: resolve the user's pending path (or default if unset)
-        // and stamp it into the config.
-        let path = resolve_jsonl_path(""); // empty → default
-        state.acars_outputs.config.write().expect("acars writer config poisoned").jsonl_path = Some(path.clone());
-        let _ = dsp_tx.send(DspToUi::AcarsJsonlPathResolved(path.display().to_string()));
-    } else {
-        // Disabling: clear the path. Worker's ensure_jsonl
-        // will close the writer on the next message.
-        state.acars_outputs.config.write().expect("acars writer config poisoned").jsonl_path = None;
-        let _ = dsp_tx.send(DspToUi::AcarsJsonlPathResolved(String::new()));
+fn handle_set_acars_jsonl_enabled(
+    state: &mut DspState,
+    _dsp_tx: &mpsc::Sender<DspToUi>,
+    enabled: bool,
+) {
+    {
+        let mut cfg = acars_config_write(&state.acars_outputs.config);
+        if enabled {
+            // Preserve the user's previously-set path (e.g. set
+            // via SetAcarsJsonlPath or persisted from prior session)
+            // across disable/enable toggles. `get_or_insert_with`
+            // only stamps the default if the slot is currently None.
+            // CR round 1 on PR #598.
+            cfg.jsonl_path
+                .get_or_insert_with(|| resolve_jsonl_path(""));
+        } else {
+            // Disabling: clear the path. Worker wakes on
+            // ConfigChanged below and closes the writer.
+            cfg.jsonl_path = None;
+        }
     }
+    state.acars_outputs.notify_config_changed();
 }
 
-fn handle_set_acars_network_enabled(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, enabled: bool) {
-    if enabled {
-        let addr = "feed.airframes.io:5550".to_string(); // default
-        state.acars_outputs.config.write().expect("acars writer config poisoned").network_addr = Some(addr.clone());
-        let _ = dsp_tx.send(DspToUi::AcarsNetworkAddrResolved(addr));
-    } else {
-        state.acars_outputs.config.write().expect("acars writer config poisoned").network_addr = None;
-        let _ = dsp_tx.send(DspToUi::AcarsNetworkAddrResolved(String::new()));
+fn handle_set_acars_network_enabled(
+    state: &mut DspState,
+    _dsp_tx: &mpsc::Sender<DspToUi>,
+    enabled: bool,
+) {
+    {
+        let mut cfg = acars_config_write(&state.acars_outputs.config);
+        if enabled {
+            // Preserve the user's previously-set address; only
+            // stamp the airframes.io default if no addr is set.
+            // CR round 1 on PR #598.
+            cfg.network_addr
+                .get_or_insert_with(|| ACARS_NETWORK_DEFAULT_ADDR.to_string());
+        } else {
+            cfg.network_addr = None;
+        }
     }
+    state.acars_outputs.notify_config_changed();
 }
 ```
 
@@ -1927,6 +1950,12 @@ pub const REGION_OPTIONS: &[(&str, &str)] = &[
     ("europe", "Europe"),
     ("custom", "Custom"),
 ];
+
+/// Index of the `"custom"` slot in `REGION_OPTIONS`. Exposed
+/// so the visibility binding for the Custom channels entry-row
+/// (and any other index-keyed UI logic) doesn't hardcode `2`.
+/// CR round 1 on PR #598.
+pub const CUSTOM_REGION_COMBO_INDEX: u32 = 2;
 ```
 
 Adjust the field shape to match the existing tuple layout (string id + display label).
@@ -1942,13 +1971,12 @@ let custom_channels_row = adw::EntryRow::builder()
 custom_channels_row.set_visible(false);
 acars_group.add(&custom_channels_row);
 
-// Bind visibility to "selected slot is Custom".
+// Bind visibility to "selected slot is Custom" via the named
+// constant rather than a raw index. CR round 1 on PR #598.
 {
     let custom_row = custom_channels_row.clone();
     region_row.connect_selected_notify(move |row| {
-        let selected = row.selected();
-        // REGION_OPTIONS Custom slot is index 2.
-        custom_row.set_visible(selected == 2);
+        custom_row.set_visible(row.selected() == CUSTOM_REGION_COMBO_INDEX);
     });
 }
 ```
@@ -2027,12 +2055,20 @@ The cleanest approach: have `window.rs` rebuild on every region change since it 
 
 ```rust
 // Rebuild channel_rows to match the new region's channel count.
-let new_count = match selected_idx {
-    0 => 6,           // US-6
-    1 => 6,           // Europe
-    2 => state.config.borrow().acars_custom_channels().len(),
-    _ => 6,
+// Resolve the AcarsRegion from the selected slot (so we don't
+// depend on raw indices) and use its channels().len(). CR
+// round 1 on PR #598.
+let region = if selected_idx == CUSTOM_REGION_COMBO_INDEX {
+    let saved = read_acars_custom_channels(&state.config);
+    AcarsRegion::Custom(saved.into_boxed_slice())
+} else {
+    let id = REGION_OPTIONS
+        .get(selected_idx as usize)
+        .map(|(id, _)| *id)
+        .unwrap_or("us-6");
+    AcarsRegion::from_config_id(id)
 };
+let new_count = region.channels().len();
 rebuild_aviation_channel_rows(&panels.aviation, new_count);
 ```
 

--- a/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
+++ b/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
@@ -951,40 +951,11 @@ super::acars_decode_tap(
 
 i.e., drop the `mut` and the `&mut`. The tests should still pass — they were exercising the bank-init / decode path, not the I/O fields.
 
-- [ ] **Step 3: Update the handlers**
+- [ ] **Step 3: Update the station-id handler**
 
-Replace the bodies of `handle_set_acars_jsonl_path`, `handle_set_acars_network_addr`, `handle_set_acars_station_id` (currently around lines 4480-4540) with:
+`handle_set_acars_station_id` doesn't need the intent-preservation pattern that the path/addr handlers use (`station_id` is a single user-typed string with no separate "enable" toggle). Replace its body with the trim+cap+empty-as-None pattern:
 
 ```rust
-fn handle_set_acars_jsonl_path(
-    state: &mut DspState,
-    dsp_tx: &mpsc::Sender<DspToUi>,
-    path: &str,
-) {
-    let resolved: Option<std::path::PathBuf> = if path.is_empty() {
-        None
-    } else {
-        Some(resolve_jsonl_path(path))
-    };
-    acars_config_write(&state.acars_outputs.config).jsonl_path = resolved;
-    state.acars_outputs.notify_config_changed();
-}
-
-fn handle_set_acars_network_addr(
-    state: &mut DspState,
-    _dsp_tx: &mpsc::Sender<DspToUi>,
-    addr: &str,
-) {
-    let trimmed = addr.trim();
-    let resolved = if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    };
-    acars_config_write(&state.acars_outputs.config).network_addr = resolved;
-    state.acars_outputs.notify_config_changed();
-}
-
 fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
     // Trim, bound to 8 chars (matches acarsdec's `idstation`
     // field width), and treat empty-after-trim as None so
@@ -1000,6 +971,8 @@ fn handle_set_acars_station_id(state: &mut DspState, station_id: &str) {
     state.acars_outputs.notify_config_changed();
 }
 ```
+
+The corresponding `handle_set_acars_jsonl_path` and `handle_set_acars_network_addr` handlers use the canonical intent-preservation pattern — see **Step 5** below for the full bodies. CR round 2 on PR #598 caught that an earlier draft of this section showed a simpler direct-config-write variant for those two handlers, which would regress the disable/enable restore behaviour by collapsing user intent into runtime writer state. Don't apply that older pattern; route through `acars_last_user_jsonl_path` / `acars_last_user_network_addr` per Step 5.
 
 The `acars_config_write` helper recovers from `RwLock` poisoning rather than panicking; without it, a panic in the writer thread would propagate to every later settings edit.
 
@@ -2224,7 +2197,7 @@ When the app starts up, the `startup_replay` (or equivalent) reads `acars_region
 - [ ] **Step 1: Find the existing startup-replay block**
 
 ```bash
-grep -n "from_config_id\|acars_region\|SetAcarsRegion" /data/source/rtl-sdr/crates/sdr-ui/src/window.rs | head -10
+grep -n "from_config_id\|acars_region\|SetAcarsRegion" crates/sdr-ui/src/window.rs | head -10
 ```
 
 Find the block where `Config::acars_region()` is read on startup. Likely in a function called `startup_replay`, `apply_startup_config`, or similar.

--- a/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
+++ b/docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md
@@ -817,15 +817,25 @@ cargo fmt --all -- --check
 
 Expected: clean. If clippy flags `doc_markdown` on identifiers (`JsonlWriter`, `UdpFeeder`, `mpsc::sync_channel`, `Arc<RwLock>`, `JoinHandle`, etc.) wrap in backticks.
 
-The build will FAIL at `controller.rs` because the old `AcarsOutputs` interface (jsonl, udp, jsonl_enabled, station_id, etc. fields) is gone. Don't try to fix that here — it's Task 6's job.
+The whole-crate build WILL FAIL at this commit because `controller.rs` still references the old `AcarsOutputs` interface (jsonl, udp, jsonl_enabled, station_id, etc. fields). That's the intentional pivot point — Task 6 finishes the migration in the next commit.
 
-To get the per-crate gates green WITHOUT building all of `controller.rs` consumers, run only:
+Cargo doesn't have a way to compile one submodule in isolation when its sibling is broken (private modules all build together for any test target inside the crate). So the standalone "did `acars_output.rs` come out right" verification is by inspection, not by `cargo test`:
 
 ```bash
-cargo test -p sdr-core --lib acars_output  # tests the new module in isolation
+# Confirm errors are localized to controller.rs (the consumer
+# that Task 6 fixes) — there should be no error[E0...] lines
+# pointing at acars_output.rs.
+cargo check -p sdr-core --features sdr-transcription/whisper-cpu 2>&1 \
+    | grep -oE "src/[^.]*\.rs" | sort -u
+# Expected output: only `src/controller.rs` (and possibly its
+# test file). If anything else shows up, fix it before
+# committing — it likely means the new types or signatures
+# in acars_output.rs are wrong.
 ```
 
-This passes if `acars_output.rs` compiles standalone. The full `cargo build -p sdr-core` will fail until Task 6.
+Once that check is clean, commit and proceed to Task 6. The full test suite (`cargo test -p sdr-core`) runs at the end of Task 6 once `controller.rs` is back in shape.
+
+Why not merge Tasks 5 + 6 into one commit? Task 5 is a type pivot (~270 LOC of new struct shape + tests) and Task 6 is the consumer-side migration (~75 LOC across many handlers). Splitting keeps each diff focused for code review and `git bisect`. The intentional intermediate red is the trade-off; this verification step makes it explicit so the implementer knows what to expect.
 
 - [ ] **Step 6: Commit (anticipating Task 6 to fix the build)**
 
@@ -1475,7 +1485,14 @@ Expected: FAIL — `Custom` is not a variant of `AcarsRegion`.
 Replace the `AcarsRegion` enum + impl block in `crates/sdr-core/src/acars_airband_lock.rs` (lines 76-153) with:
 
 ```rust
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+// Note: no `Eq` derive — `f64` only implements `PartialEq` (NaN
+// breaks the reflexivity contract Eq requires), so `Custom(Box<[f64]>)`
+// blocks `Eq`. The pre-#592 enum had `Eq` because all variants
+// were unit; dropping it is forced by the new payload. Existing
+// consumers should be using `==` / `!=` / `assert_eq!` which all
+// route through `PartialEq` and continue to work. CR round 5 on
+// PR #598.
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub enum AcarsRegion {
     /// North America (default). Six channels in 129.125–

--- a/docs/superpowers/specs/2026-05-01-acars-async-io-and-custom-channels-design.md
+++ b/docs/superpowers/specs/2026-05-01-acars-async-io-and-custom-channels-design.md
@@ -1,0 +1,562 @@
+# ACARS Async Output I/O + Custom Channel Sets (issues #596 + #592, bundled)
+
+> Bundle two ACARS follow-up items into a single PR: (1) move the
+> JSONL writer + UDP feeder I/O to a worker thread so a slow
+> disk or NFS stall can't surface as DSP-thread underruns, and
+> (2) add user-defined custom channel sets to the Aviation
+> panel alongside the existing US-6 / Europe predefined regions.
+
+## Goal
+
+Two ACARS output-side improvements that touch different bug
+classes (threading vs UI/migration). Bundled per the user's
+established pattern for cross-cutting CR review:
+
+1. **#596 — async output I/O.** Move `JsonlWriter::write` and
+   `UdpFeeder::send` off the DSP thread onto a dedicated writer
+   thread. Bounded mpsc channel with drop-on-full + 30 s warn
+   rate-limit. Closes the synchronous-I/O fragility flagged in
+   CR round 4 of PR #595.
+
+2. **#592 — custom channel sets.** Extend `AcarsRegion` with a
+   `Custom(Box<[f64]>)` variant. Migrate the `[ChannelStats; 6]`
+   and `[ActionRow; 6]` const-arrays to `Vec`/`Box<[T]>` across
+   ~16 sites. Add an Aviation-panel CSV editor with span +
+   count validation. Persist via a new `acars_custom_channels`
+   config key.
+
+## Non-goals
+
+- **Generalising channel count above 8.** `MAX_CUSTOM_CHANNELS = 8`
+  is enough for any realistic ACARS cluster within 2.4 MHz.
+- **Per-channel UI customisation** (custom labels, colours, etc.).
+  Only the frequency list is user-defined; rendering stays
+  uniform.
+- **Async I/O for non-ACARS sinks.** Audio writer, scanner CSV,
+  satellite recorder all stay synchronous (none have shown the
+  same DSP-thread fragility).
+- **Persisted ring buffer for un-flushed messages on shutdown.**
+  In-flight messages in the channel are dropped on app exit.
+  Acceptable given the 256-deep buffer + sub-second drain time.
+
+## Architecture
+
+### Module layout
+
+```text
+crates/sdr-core/src/
+├── acars_output.rs         ← extend: AcarsOutputs becomes
+│                              owner of the writer thread + tx
+├── controller.rs           ← MODIFY: AcarsOutputs lives in DspState;
+│                              acars_decode_tap try_send's instead
+│                              of calling write/send directly
+├── acars_airband_lock.rs   ← MODIFY: AcarsRegion gets Custom;
+│                              channels() returns &[f64]; new
+│                              constants + validate_custom_channels
+├── acars_config.rs         ← MODIFY: new acars_custom_channels key
+crates/sdr-ui/src/
+├── state.rs                ← MODIFY: acars_channel_stats: Vec
+├── window.rs               ← MODIFY: array→Vec assignments + iter
+├── sidebar/aviation_panel.rs ← MODIFY: channel_rows Vec; new Custom
+│                                EntryRow + visibility binding
+crates/sdr-ffi/src/
+├── event.rs                ← MODIFY: test fixture array→Vec
+crates/sdr-acars/src/
+└── lib.rs / channel.rs     ← REVIEW only — `ChannelStats` is
+                              already `&[ChannelStats]` at API
+                              boundary; no changes expected
+```
+
+### Part A — Async output I/O (#596)
+
+#### Components
+
+**`AcarsOutputs` struct** (`crates/sdr-core/src/acars_output.rs`):
+
+```rust
+pub struct AcarsOutputs {
+    /// Sender side held by the DSP thread. `try_send` drops on
+    /// full; the writer thread owns the receiver.
+    pub tx: mpsc::SyncSender<AcarsOutputMessage>,
+    /// Shared, runtime-mutable config readable by the writer
+    /// thread, mutable from window.rs handlers (jsonl path/
+    /// enable, network addr/enable, station_id). Read-heavy
+    /// access pattern fits RwLock; lock contention is
+    /// negligible against UDP send latency.
+    pub config: Arc<RwLock<AcarsWriterConfig>>,
+    /// Join handle for clean shutdown via Drop.
+    writer_thread: Option<JoinHandle<()>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AcarsWriterConfig {
+    pub jsonl_path: Option<PathBuf>,
+    pub network_addr: Option<String>,
+    pub station_id: Option<String>,
+}
+
+pub enum AcarsOutputMessage {
+    Decoded(AcarsMessage),
+}
+```
+
+#### Channel + drop semantics
+
+- `mpsc::sync_channel(256)` (bounded). 256 ≈ 4–5 minutes of
+  worst-case ACARS bursts; covers any realistic disk stall short
+  of total filesystem hang.
+- DSP-thread closure (`acars_decode_tap`) does
+  `try_send(Decoded(msg))`:
+  - `Ok(())` → message handed off; nothing more.
+  - `Err(TrySendError::Full(_))` → drop. Increment a drop counter
+    on `AcarsOutputs`; emit a 30 s rate-limited warn:
+    *"ACARS output channel full (N drops in 30s); writer thread
+    falling behind"*.
+  - `Err(TrySendError::Disconnected(_))` → silent (writer thread
+    already gone — only happens during shutdown, no warn needed).
+
+#### Writer thread
+
+Spawned in `AcarsOutputs::new()`:
+
+```rust
+fn run_writer(
+    rx: mpsc::Receiver<AcarsOutputMessage>,
+    config: Arc<RwLock<AcarsWriterConfig>>,
+) {
+    let mut jsonl: Option<(PathBuf, JsonlWriter)> = None;
+    let mut udp:   Option<(String, UdpFeeder)>   = None;
+
+    loop {
+        match rx.recv() {
+            Ok(AcarsOutputMessage::Decoded(msg)) => {
+                let cfg = config.read().expect("writer config poisoned");
+                // Reopen JsonlWriter if path changed (or is None).
+                ensure_jsonl(&mut jsonl, cfg.jsonl_path.as_deref());
+                // Reopen UdpFeeder if addr changed (or is None).
+                ensure_udp(&mut udp, cfg.network_addr.as_deref());
+                let station_id = cfg.station_id.clone();
+                drop(cfg);
+
+                if let Some((_, w)) = jsonl.as_mut() {
+                    if let Err(e) = w.write(&msg, station_id.as_deref()) {
+                        warn_jsonl_rate_limited(e);
+                    }
+                }
+                if let Some((_, f)) = udp.as_mut() {
+                    if let Err(e) = f.send(&msg, station_id.as_deref()) {
+                        warn_udp_rate_limited(e);
+                    }
+                }
+            }
+            Err(_) => break, // tx dropped
+        }
+    }
+}
+```
+
+`ensure_jsonl` / `ensure_udp` rebuild the writer when the
+configured path/addr changed (or close it when set to `None`).
+The 30 s rate-limit on per-write/per-send failures stays —
+moves from the DSP closure into the writer thread.
+
+#### Lifecycle
+
+- **Startup:** `DspState::new` constructs `AcarsOutputs::new()`
+  once. The writer thread spawns immediately and waits on `rx`.
+- **Config updates:** `window.rs` handlers acquire
+  `outputs.config.write()` and mutate. The writer thread sees
+  the change on the next message via its `read()`.
+- **Shutdown:** `DspState` drops → `AcarsOutputs` drops →
+  `tx` drops → `recv()` returns `Err(Disconnected)` → loop
+  exits → `JoinHandle::join()` reaps the thread.
+
+### Part B — Custom channel sets (#592)
+
+#### Type changes
+
+**`AcarsRegion`** (`crates/sdr-core/src/acars_airband_lock.rs`):
+
+```rust
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum AcarsRegion {
+    #[default]
+    Us6,
+    Europe,
+    /// User-defined channel set. Frequencies in Hz, validated
+    /// at construction by `validate_custom_channels`.
+    Custom(Box<[f64]>),
+}
+
+impl AcarsRegion {
+    /// Channels for this region (Hz). Returns a borrowed slice
+    /// so all variants share one accessor.
+    #[must_use]
+    pub fn channels(&self) -> &[f64] {
+        match self {
+            Self::Us6    => &US_SIX_CHANNELS_HZ,
+            Self::Europe => &EUROPE_SIX_CHANNELS_HZ,
+            Self::Custom(c) => c,
+        }
+    }
+
+    pub fn center_hz(&self) -> f64 { /* unchanged — iterates self.channels() */ }
+
+    pub fn config_id(&self) -> &'static str {
+        match self {
+            Self::Us6        => "us-6",
+            Self::Europe     => "europe",
+            Self::Custom(_)  => "custom",
+        }
+    }
+
+    pub fn from_config_id(id: &str) -> Self {
+        match id {
+            "europe" => Self::Europe,
+            "custom" => Self::Custom(Box::new([])),  // freqs from separate key
+            _        => Self::Us6,
+        }
+    }
+
+    pub fn display_label(&self) -> &'static str {
+        match self {
+            Self::Us6        => "United States (US-6)",
+            Self::Europe     => "Europe",
+            Self::Custom(_)  => "Custom",
+        }
+    }
+}
+```
+
+**Drops `Copy`** (forced by `Box<[f64]>`). Existing call sites
+that took `AcarsRegion` by value need to switch to `&AcarsRegion`
+or `region.clone()`. The actual call sites are few — most code
+holds a region in `state.rs`'s `acars_region: RefCell<AcarsRegion>`
+and reads via borrow.
+
+#### Validator
+
+```rust
+pub const MAX_CUSTOM_CHANNELS: usize = 8;
+pub const MAX_CHANNEL_SPAN_HZ: f64 = 2_400_000.0;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CustomChannelError {
+    Empty,
+    TooMany { count: usize, max: usize },
+    InvalidFrequency { value: f64 },
+    SpanExceeded { low_hz: f64, high_hz: f64, span_hz: f64 },
+}
+
+pub fn validate_custom_channels(chans: &[f64]) -> Result<(), CustomChannelError> {
+    if chans.is_empty() { return Err(CustomChannelError::Empty); }
+    if chans.len() > MAX_CUSTOM_CHANNELS {
+        return Err(CustomChannelError::TooMany { count: chans.len(), max: MAX_CUSTOM_CHANNELS });
+    }
+    for &c in chans {
+        if !c.is_finite() || c <= 0.0 {
+            return Err(CustomChannelError::InvalidFrequency { value: c });
+        }
+    }
+    let (mut min, mut max) = (chans[0], chans[0]);
+    for &c in &chans[1..] {
+        if c < min { min = c; }
+        if c > max { max = c; }
+    }
+    let span = max - min;
+    if span > MAX_CHANNEL_SPAN_HZ {
+        return Err(CustomChannelError::SpanExceeded {
+            low_hz: min, high_hz: max, span_hz: span,
+        });
+    }
+    Ok(())
+}
+```
+
+`Display` impl on `CustomChannelError` formats user-friendly
+toast text. Example for `SpanExceeded`:
+*"Span 3.5 MHz exceeds 2.4 MHz limit (129.125 to 132.625 MHz)"*.
+
+#### Const-array → Vec migration
+
+Affected sites (16 total across 6 files; identified via
+`grep -rn ACARS_CHANNEL_COUNT crates/`):
+
+| File | Change |
+|------|--------|
+| `crates/sdr-ui/src/state.rs:267` | `[ChannelStats; ACARS_CHANNEL_COUNT]` → `Vec<ChannelStats>` |
+| `crates/sdr-ui/src/state.rs:421` | initializer `[default; 6]` → `Vec::new()` (or `Vec::with_capacity(6)`) |
+| `crates/sdr-ui/src/state.rs:524-526` | length assertion: drop the const-equality check; replace with bounds check on engage |
+| `crates/sdr-ui/src/sidebar/aviation_panel.rs:52` | field type `Vec<adw::ActionRow>` |
+| `crates/sdr-ui/src/sidebar/aviation_panel.rs:174` | `array::from_fn` → `Vec::with_capacity` + push loop, given a `channel_count: usize` parameter |
+| `crates/sdr-ui/src/sidebar/aviation_panel.rs:238` | `channel_rows` field init in struct literal — already a Vec, no special handling |
+| `crates/sdr-ui/src/window.rs:2092` | direct array assignment → Vec assignment (length-aware) |
+| `crates/sdr-ui/src/window.rs:2156-2157` | `[default; 6]` → `Vec::new()` clear |
+| `crates/sdr-ui/src/window.rs:11998` | `.iter()` over channel_rows — works as-is |
+| `crates/sdr-ui/src/window.rs:12041` | iteration — works as-is |
+| `crates/sdr-core/src/controller.rs:3708` | `try_from::<&[T], [T; N]>` → `Vec<T>::from(slice)` or direct push from the source iterator |
+| `crates/sdr-ffi/src/event.rs:1296` | test fixture `[default; 6]` → `vec![default; 6]` |
+
+`ACARS_CHANNEL_COUNT` itself stays as a constant — it's still
+useful as the *predefined* count and as the `Vec::with_capacity`
+hint when the actual length isn't known up-front.
+
+**Aviation panel rebuild on region change:** `connect_aviation_panel`
+in `window.rs` listens for the region combo's `notify::selected`.
+Currently it dispatches `SetAcarsRegion(region)` and persists.
+Extend: when the selected region changes, **rebuild** the
+`channel_rows` list (remove all from the `AdwPreferencesGroup`,
+build new ones from `region.channels().len()`, add). Always
+rebuild — recycling rows for the same-N case (US-6 ↔ Europe,
+both 6) adds bookkeeping that isn't worth it.
+
+#### UI: Custom region editor
+
+**Aviation panel (`crates/sdr-ui/src/sidebar/aviation_panel.rs`):**
+
+1. Region combo gets a third entry: `[US-6, Europe, Custom]`.
+   Update `REGION_OPTIONS` slice + `from_combo_index` helper
+   accordingly (use `from_config_id("custom")` for the third).
+
+2. New `AdwEntryRow` titled *"Custom channels (MHz, comma-separated)"*,
+   added to the Aviation group right after the region combo:
+
+```rust
+let custom_channels_row = adw::EntryRow::builder()
+    .title("Custom channels (MHz, comma-separated)")
+    .build();
+custom_channels_row.set_visible(false);  // shown only when Custom selected
+```
+
+3. **Visibility binding:** `region_row.bind_property("selected", &custom_channels_row, "visible")`
+   with a transform fn that returns `true` iff selected index
+   is the Custom slot.
+
+4. **Apply handler** (on `connect_apply` — fires on Enter or
+   focus-loss of the EntryRow):
+   - Parse text: split by `,`, trim, parse each as `f64`.
+     Multiply by 1_000_000 to get Hz.
+   - Run `validate_custom_channels`.
+   - **Pass:** persist via `Config::set_acars_custom_channels`,
+     dispatch `UiToDsp::SetAcarsRegion(Custom(parsed))`, remove
+     any prior `error` CSS class.
+   - **Fail:** `custom_channels_row.add_css_class("error")` for
+     inline visual feedback, AND emit a toast via the existing
+     toast overlay with the `Display` text from
+     `CustomChannelError`.
+
+5. Hydrate on panel open: read `Config::acars_custom_channels()`
+   and pre-fill the EntryRow with the stored CSV (formatted
+   to 3 decimal MHz).
+
+#### Persistence
+
+New config key in `acars_config.rs`:
+
+```rust
+pub const ACARS_CUSTOM_CHANNELS_KEY: &str = "acars_custom_channels";
+
+impl Config {
+    pub fn acars_custom_channels(&self) -> Vec<f64> { /* parse JSON array */ }
+    pub fn set_acars_custom_channels(&mut self, chans: &[f64]) { /* serialize JSON array */ }
+}
+```
+
+Stored as a JSON array of f64 Hz values (matches the existing
+config style).
+
+The existing `acars_region` key holds `"us-6"` / `"europe"` /
+`"custom"`. On load (in the startup-replay path in `window.rs`):
+
+1. Read `acars_region` key. If `"custom"`, also read
+   `acars_custom_channels` key.
+2. If channels is non-empty AND passes `validate_custom_channels`:
+   build `AcarsRegion::Custom(channels.into_boxed_slice())`.
+3. Otherwise: fall back to `AcarsRegion::default()` (Us6) and
+   leave the panel showing Custom with an empty EntryRow + an
+   inline error if the saved channels were invalid (a toast
+   would be wrong here — startup is not a user action).
+
+`from_config_id("custom")` itself returns `Custom(Box::new([]))`
+unconditionally — the *channels* live in the second key, and
+this two-step is handled by the load-side caller, not by
+`from_config_id`. The `Custom([])` placeholder is never engaged
+(the engage gate refuses it via `CustomChannelError::Empty`).
+
+## Data flow
+
+```text
+                    (UI thread)                                (DSP thread)
+                         │                                          │
+   user toggles JSONL    │                                          │
+   → write config lock   │  outputs.config.write() = …             │
+                         │                                          │
+   user types CSV freqs  │  validate → SetAcarsRegion(Custom(c))   │
+   → dispatch to DSP     │  ─────────────────────────────────────►  │
+                         │                                          │ engage uses
+                         │                                          │ region.channels()
+                         │                                          │ verbatim
+                         │                                          │
+                         │            (DSP)              (Writer thread)
+                         │              │                       │
+                         │  msg decoded │ try_send ─►          │
+                         │              │ ─────────────────────►│ recv()
+                         │              │                       │ read config lock
+                         │              │                       │ JsonlWriter::write
+                         │              │                       │ UdpFeeder::send
+                         │              │                       │
+                         │              │  ── if channel full:  │
+                         │              │  drop + warn (30s RL) │
+```
+
+## Edge cases
+
+### #596 (async I/O)
+
+- **Channel saturation under sustained load.** If decode rate
+  permanently exceeds writer throughput (e.g. NFS gone away),
+  the channel fills and we drop. The 30 s warn names the drop
+  count so users know data was lost — no silent data loss.
+- **Worker thread panics.** Unlikely (no `unwrap`/`expect` in
+  the hot path; only `expect` on the RwLock for poisoning,
+  which terminates the thread cleanly). On panic, subsequent
+  `try_send`s succeed until the channel fills (256 messages),
+  then `Err(Disconnected)` after the channel is dropped via
+  GC. We log nothing on disconnect — but in this scenario the
+  user already saw the warn from the panic. **Mitigation:**
+  keep `expect` calls minimal; rely on the writer thread being
+  panic-free in normal operation.
+- **Path/addr change while message in flight.** The in-flight
+  message in the channel is processed against the *new* config
+  on its way out (writer thread reads the lock per-message).
+  Acceptable — no message lost, and the lag is at most one
+  message worth of latency.
+- **Writer thread shutdown timeout.** `JoinHandle::join()` is
+  blocking. If the writer thread is stuck inside a slow
+  `JsonlWriter::write`, app exit blocks too. **Mitigation:**
+  `JsonlWriter` already uses `BufWriter` with a Drop-time
+  flush; if that flush itself stalls, app exit blocks — but
+  this is the same behavior as today, just on a different
+  thread. Not a regression.
+
+### #592 (custom channels)
+
+- **N=1 custom channel.** Legal. Source center = that
+  frequency. No span to exceed. Engage gate works normally.
+- **Empty Custom on first open.** Combo shows Custom but
+  EntryRow is empty. User must type frequencies before
+  engaging — engage gate refuses (validator returns
+  `CustomChannelError::Empty`).
+- **CSV parse failure (non-numeric, missing comma, etc.).**
+  Treated as a validation error with a generic toast
+  ("Invalid custom-channel list: <parse error>") + inline
+  `error` CSS class. No persistence, no DSP dispatch.
+- **Saved Custom, switch to US-6, switch back to Custom.** The
+  saved CSV reloads from config. The combo's index correctly
+  selects the Custom slot.
+- **Switching region mid-session with ACARS engaged.** The
+  existing engage/disengage gate (PR #584) serializes this:
+  region change forces a disengage + re-engage cycle. The
+  channel_rows rebuild happens during the disengage path. No
+  new edge case introduced here.
+- **Channel rows briefly empty during region swap.** The
+  rebuild removes old rows then adds new ones. Visually a
+  flicker but acceptable; no data race because the swap is on
+  the GTK main thread.
+
+## Testing
+
+### Unit tests
+
+- **`acars_output.rs::tests`:**
+  - `try_send_drops_when_full` — fill channel to 256, send
+    one more, assert `Err(TrySendError::Full)` and drop counter
+    incremented.
+  - `writer_thread_exits_on_disconnect` — drop tx, call
+    `join()` with timeout, assert it returns within 100 ms.
+  - `writer_reopens_on_path_change` — write to path A,
+    change config to path B, write another, assert both files
+    exist with correct content.
+- **`acars_airband_lock.rs::tests`:**
+  - Replace existing `region_us6_channels_match_const` style
+    tests with `&[f64]` accessor versions.
+  - `validate_custom_channels` table tests: empty, one valid,
+    eight valid, nine invalid (TooMany), NaN invalid, Inf
+    invalid, negative invalid, span-just-under-2.4MHz valid,
+    span-just-over-2.4MHz invalid (with exact field assertions
+    on `SpanExceeded`).
+  - `from_config_id_round_trips_custom` — `from_config_id("custom")`
+    yields `Custom([])`; `region.config_id() == "custom"`.
+- **`acars_config.rs::tests`:**
+  - `acars_custom_channels_round_trips` — set, write, read
+    back, assert deep-equality.
+
+### Smoke (USER ONLY)
+
+Manual GTK smoke at the end:
+
+1. **Async I/O sanity** — toggle JSONL on, watch the file
+   accumulate while ACARS is decoding; confirm zero DSP
+   underruns in the logs over a 5-minute window.
+2. **Custom region happy path** — open Aviation panel; switch
+   to Custom; type `131.55, 131.525, 130.025`; press Enter;
+   confirm the Channels group rebuilds to 3 rows; engage
+   ACARS; confirm decoding occurs across those 3 channels.
+3. **Validation rejection** — type `129.0, 132.0, 133.0` (span
+   4.0 MHz); confirm toast names the offending pair and the
+   EntryRow shows the error CSS class. No persistence.
+4. **Persistence round-trip** — set a valid Custom region,
+   close + reopen the app; confirm the panel pre-fills the
+   EntryRow with the stored CSV and the combo shows Custom.
+5. **Region swap** — Custom (3 chan) → US-6 (6 chan) → Europe
+   (6 chan) → Custom (3 chan again from saved config); confirm
+   channel_rows resize correctly each time and engage works
+   in each.
+6. **Drop-on-full visibility** — (best-effort) inject a load
+   spike or block the writer thread artificially via a paused
+   /tmp directory; confirm the 30 s warn fires once with a
+   drop count.
+
+## File budget
+
+| File | LOC ballpark |
+|------|--------------|
+| `crates/sdr-core/src/acars_output.rs` | +200 (struct, writer thread, drop logic, tests) |
+| `crates/sdr-core/src/{controller.rs, dsp_state.rs}` | +50 (try_send + lifecycle) |
+| `crates/sdr-core/src/acars_airband_lock.rs` | +80 (Custom variant, validator, tests) |
+| `crates/sdr-core/src/acars_config.rs` | +30 (custom_channels key) |
+| `crates/sdr-ui/src/state.rs` | +20 (Vec migration) |
+| `crates/sdr-ui/src/window.rs` | +30 (assignments + rebuild handler) |
+| `crates/sdr-ui/src/sidebar/aviation_panel.rs` | +80 (Vec field, custom EntryRow, apply handler) |
+| `crates/sdr-ffi/src/event.rs` | +5 (test fixture) |
+| **Total** | **~485 LOC** |
+
+Single bundled PR.
+
+## Out-of-scope items (deferred)
+
+- Generalising channel count above 8 (#592 followup if needed)
+- Per-channel UI customisation (custom labels, colors)
+- Async I/O for non-ACARS sinks (audio writer, scanner CSV,
+  satellite recorder)
+- Persisted ring buffer across app restarts for un-flushed
+  output messages
+- Configurable channel buffer capacity (256 hard-coded)
+
+## References
+
+- Issue #596 — async output I/O
+- Issue #592 — custom channel sets
+- PR #595 (closed #578) — synchronous v1 of the output
+  formatters; this PR's #596 work refactors the I/O layer
+  introduced there
+- PR #593 (closed #581) — predefined regions; this PR's #592
+  work extends the region enum
+- CR round 4 on PR #595 — origin of the async-I/O concern
+- `crates/sdr-core/src/acars_airband_lock.rs:39` —
+  `ACARS_CHANNEL_COUNT` constant + region enum
+- `crates/sdr-core/src/acars_output.rs` — current synchronous
+  writer/feeder
+- `crates/sdr-ui/src/sidebar/aviation_panel.rs:52` — current
+  `[ActionRow; ACARS_CHANNEL_COUNT]` layout being migrated


### PR DESCRIPTION
## Summary

Bundles two ACARS follow-up items per spec/plan in `docs/superpowers/specs/2026-05-01-acars-async-io-and-custom-channels-design.md` and `docs/superpowers/plans/2026-05-01-acars-async-io-and-custom-channels.md`:

- **#596 — Async output I/O.** Moves `JsonlWriter::write` and `UdpFeeder::send` off the DSP thread onto a dedicated writer thread via `mpsc::sync_channel(256)`. `Arc<RwLock<AcarsWriterConfig>>` for runtime-mutable config (jsonl_path / network_addr / station_id). `try_send` drops on full with a 30s warn rate-limit. Writer thread shuts down cleanly on `tx` drop (`recv()` returns `Disconnected` → loop exits → `JoinHandle::join()` reaps). Writer config persists across disengage/engage cycles so the user's settings come back automatically (caught + fixed in CR self-review during implementation).

- **#592 — Custom channel sets.** Extends `AcarsRegion` with a `Custom(Box<[f64]>)` variant; `Copy` dropped (forced — Box isn't Copy). New `MAX_CUSTOM_CHANNELS=8` and `MAX_CHANNEL_SPAN_HZ=2_400_000.0` constants with a `validate_custom_channels` function (rejects empty, too-many, non-finite, non-positive, span > 2.4 MHz). Migrates `[ChannelStats; 6]` and `[ActionRow; 6]` storage to `Vec` across 16 sites in 5 files (single atomic commit). New `acars_custom_channels` config key with round-trip persistence. Aviation panel gets a "Custom" combo entry, an `AdwEntryRow` for CSV channel input (visible only when Custom selected), and a `connect_apply` handler that validates → on success persists + dispatches `SetAcarsRegion(Custom)`; on failure adds `error` CSS class + toast. Two-key startup-replay with validation fallback to `AcarsRegion::default()` on stale config.

## Test plan
- [x] All 15 plan tasks executed via subagent-driven development with controller validation pass after each
- [x] `cargo build --workspace --features sdr-transcription/whisper-cpu` clean
- [x] `cargo test --workspace --features sdr-transcription/whisper-cpu` — all green (10 new validator tests, 3 new AcarsRegion tests, 3 new writer-thread tests including drop-on-full and reopen-on-path-change, 2 new config round-trip tests)
- [x] `cargo clippy --workspace --features sdr-transcription/whisper-cpu --all-targets -- -D warnings` clean
- [x] `cargo check --workspace --locked --no-default-features --features sherpa-cpu` clean (the CI gate that bit us on PR #597)
- [x] `cargo fmt --all -- --check` clean
- [x] Manual GTK smoke (whisper-cuda build) — all 9 checklist sections pass: async I/O sanity (path hot-reload, intent preservation), UDP feeder, Custom region happy path, validation toast/error CSS, max-channels rejection, persistence round-trip, region swap with channel-count rebuild, no regressions in existing ACARS features, sustained-load no underruns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom, user-editable ACARS channel sets via CSV with persistence; UI supports dynamic channel counts and rebuilds rows on region changes
  * ACARS output is now asynchronous: JSONL and UDP are written by a dedicated writer with hot-reopen on config changes

* **Bug Fixes / UX**
  * Validation errors surface as toasts and inline error styling; invalid/empty custom sets are not applied
  * Writer emits user-facing errors for open/write failures and rate-limited warnings on drops

* **Documentation**
  * Added design and implementation plan

* **Tests**
  * Expanded tests for writer behavior, custom-channel validation, UI/state integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->