### PR TITLE
feat(sstv): wire slowrx 0.1.0 for ISS SSTV reception (#472 V1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Four config keys per side live in `activity_bar.rs`: `ui_sidebar_{left,right}_{s
 
 ### Satellite reception
 
-NOAA APT (epic #468) and Meteor-M LRPT (epic #469) are both shipped end-to-end. ISS SSTV (#472) is the remaining weather-sat epic and will reuse the same scaffolding.
+NOAA APT (epic #468), Meteor-M LRPT (epic #469), and ISS SSTV (epic #472) are all shipped end-to-end.
 
 **Key files:**
 
@@ -145,14 +145,17 @@ NOAA APT (epic #468) and Meteor-M LRPT (epic #469) are both shipped end-to-end. 
 - `crates/sdr-radio/src/lrpt_decoder.rs` — LRPT counterpart of `apt_decode_tap`: bridges the post-VFO IQ buffer to `LrptDemod` (QPSK) → `LrptPipeline` (Viterbi → ASM sync → derand → RS → demux → JPEG) → `LrptImage` shared assembler. Per-APID line watermark prevents double-push.
 - `crates/sdr-radio/src/demod/lrpt.rs` — `LrptDemodulator`: silent-passthrough demod that pins `RadioModule`'s IF rate to 144 ksps (`sdr_dsp::lrpt::SAMPLE_RATE_HZ`) so the controller's `lrpt_decode_tap` reads `radio_input` at the rate the QPSK demod expects.
 - `crates/sdr-ui/src/lrpt_viewer.rs` — Multi-channel live LRPT viewer with per-APID Cairo surfaces, dynamic channel dropdown, Pause/Resume + Export PNG header buttons. Polls the shared `LrptImage` at 4 Hz; PNG export uses `gio::spawn_blocking` so encoding doesn't freeze the GTK main loop.
+- `crates/sdr-radio/src/sstv_image.rs` — Shared SSTV image handle (`Arc<Mutex<Inner>>`). DSP tap writes via `write_line`; UI reads via `snapshot()`; `take_completed()` drains the finished frame and resets for the next VIS detection. `SstvImage::clear()` convenience wrapper delegates to the handle.
+- `crates/sdr-ui/src/sstv_viewer.rs` — Live SSTV viewer. `SstvImageRenderer` owns the Cairo ARGB32 surface; `SstvImageView` is the GTK widget (cloneable via Rc). `open_sstv_viewer_if_needed` opens the window and wires `UiToDsp::SetSstvImage`. `write_sstv_rgb_png` is the Cairo-based PNG encoder used by both manual Export and the auto-record LOS save. Wired via `connect_sstv_action` (`Ctrl+Shift+V`).
 
 **User-facing walkthroughs:** `docs/guides/apt-reception.md`, `docs/guides/lrpt-reception.md`.
 
 **Output paths** (all under `~/sdr-recordings/`):
 - APT: `apt-{satellite-slug}-{local-timestamp}.png` (single PNG per pass).
 - LRPT: `lrpt-{satellite-slug}-{local-timestamp}/apid{N}.png` (per-pass directory holding one PNG per AVHRR APID — LRPT is multispectral). Audio recording is suppressed for LRPT regardless of the user toggle: the demod is silent and ~170 MB of stereo silence per pass would be wasteful.
+- SSTV: `sstv-{satellite-slug}-{local-timestamp}/img{N}.png` (per-pass directory, one PNG per completed image frame — ARISS events typically send ~12 per pass). Audio recording is NOT suppressed for SSTV: ISS SSTV is audible NFM and the audio recording captures the raw signal.
 
-`png_path_for` and `lrpt_dir_for` in `satellites_recorder.rs` are the single sources of truth for those paths; the recorder's `PassOutput` enum dispatches APT to `Action::SavePng` and LRPT to `Action::SaveLrptPass`.
+`png_path_for`, `lrpt_dir_for`, and `sstv_dir_for` in `satellites_recorder.rs` are the single sources of truth for those paths; the recorder's `PassOutput` enum dispatches APT to `Action::SavePng`, LRPT to `Action::SaveLrptPass`, and SSTV to `Action::SaveSstvPass`.
 
 ## C++ Reference
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -343,9 +343,9 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block2"
@@ -458,9 +458,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -665,9 +665,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16dd574a72a021b90c7656c474ea31d11a2f0366a8eff574186e761e0b9e3586"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
  "bitflags",
  "libc",
@@ -734,13 +734,13 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dbus"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
  "libc",
  "libdbus-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -815,12 +815,9 @@ dependencies = [
 
 [[package]]
 name = "earshot"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d393a8f23619412e0502df1b94cd148e34855a50a4143d365cc6336cc338b4f4"
-dependencies = [
- "libm",
-]
+checksum = "7984231f8b4c72eb3b88c70040dc1e4ff6803fa9169e93c0ac465942d74fa36a"
 
 [[package]]
 name = "either"
@@ -1152,16 +1149,29 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "gio"
-version = "0.22.5"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401b600a9795c46ff45890146968b712c96ce4e9393798804133e137bd81d89c"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "gio"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3848bcba3a35cc0a71df8ba8ecfd799d6bfb862342a53a4a915fb62213aa4e6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1200,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.22.5"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b7df55594e0e787d1560e23f7e12d7360d0b22e7b7c228ec2488b9e59b1b6b"
+checksum = "c207e04e51605dcf7b2924c41591b3a10e1438eaac5bcf448fb91f325381104a"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -1221,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda575994e3689b1bc12f89c3df621ead46ff292623b76b4710a3a5b79be54bb"
+checksum = "506d23499707c7142898429757e8d9a3871d965239a2cb66dfa05052be6d6f19"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1233,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.22.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642"
+checksum = "5f7fbac234ed5bc2a28359b7bde8e1b9cdf1441cc2d7f068e4824672d7db9445"
 dependencies = [
  "libc",
  "system-deps",
@@ -1270,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.22.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eda93f09d3778f38255b231b17ef67195013a592c91624a4daf8bead875565"
+checksum = "22a861859b887a79cf461359c192c97a57d8fb0229dd291232e57aa11f6fa72c"
 dependencies = [
  "glib-sys",
  "libc",
@@ -1369,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d47a7ca9ec6f50b5ace32eaaf11fe152c9bbc4f780a35e42c9b7fc5b046f9c"
+checksum = "7181b837f04cbe93f79441475f7a00560a92cba7a72e38cc1a68b6f8b78eaae2"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -1402,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a25bd07084651c77bb6e7bce7d4cea8d9f98d210acee473e400a9106bc0ce50"
+checksum = "20ba8e695e2640455561274e65e45f0a151619e450746007667f4b23ceae4e1b"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -1548,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -1559,7 +1569,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1692,6 +1702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1743,6 +1759,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1832,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1897,6 +1915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libadwaita"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -2069,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "mdns-sd"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451927183d65d600e52b4e877a1251e051576f84fa01e5b4a50b450dfaaa537c"
+checksum = "c2bb8ce26633738d98ffcef71ec58bff967c6675be50229823c2835f6316e67e"
 dependencies = [
  "fastrand",
  "flume",
@@ -2137,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -2377,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "pango"
-version = "0.22.4"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4804fb6018c6604eac198f0f897320d3696c9af7983cde056f07cef93cac9202"
+checksum = "251bdc6e6487b811be0e406a21e301e07e45c0aa8fa39e00c0c8e12a91752438"
 dependencies = [
  "gio",
  "glib",
@@ -2723,6 +2747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,7 +2945,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2992,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -3007,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3142,6 +3172,7 @@ dependencies = [
  "sdr-transcription",
  "sdr-types",
  "serde_json",
+ "slowrx",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -3224,6 +3255,7 @@ dependencies = [
  "sdr-types",
  "serde",
  "serde_json",
+ "slowrx",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3646,6 +3678,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "slowrx"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8821576f1ad5b83f264c2f5c3e3d55af596ee83ed682e93eaa16b1a39b390953"
+dependencies = [
+ "rustfft",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,7 +3857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3916,9 +3958,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4153,6 +4195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,18 +4317,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4291,9 +4348,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4301,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4311,9 +4368,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4324,11 +4381,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -4345,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4369,23 +4460,23 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "wgpu"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -4413,9 +4504,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -4446,36 +4537,36 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -4522,13 +4613,14 @@ dependencies = [
  "wgpu-types",
  "windows",
  "windows-core",
+ "windows-result",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -4536,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -4714,15 +4806,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -4879,9 +4962,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -4891,6 +4974,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "slowrx"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8821576f1ad5b83f264c2f5c3e3d55af596ee83ed682e93eaa16b1a39b390953"
+checksum = "0509e774d20235c513a919dfff5b372dd0996ffb3edb5a1fb9636c652e9e9431"
 dependencies = [
  "rustfft",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ tempfile = "3"
 # `slowrx::resample::MAX_INPUT_SAMPLE_RATE_HZ` and internally resamples to
 # 11_025 Hz. Both `rustfft` and `thiserror` that slowrx brings are already
 # in the workspace dep tree, so no new transitive deps are added.
-slowrx = "0.1"
+slowrx = "0.2"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,6 +304,13 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 # without touching ~/.config/autostart/ on the dev box.
 tempfile = "3"
 
+# SSTV decode (ISS SSTV reception, epic #472). Wraps the slowrx FM-demod +
+# VIS detect + PLL + line decode chain; accepts any audio sample rate up to
+# `slowrx::resample::MAX_INPUT_SAMPLE_RATE_HZ` and internally resamples to
+# 11_025 Hz. Both `rustfft` and `thiserror` that slowrx brings are already
+# in the workspace dep tree, so no new transitive deps are added.
+slowrx = "0.1"
+
 [workspace.lints.rust]
 unsafe_code = "deny"
 

--- a/crates/sdr-core/Cargo.toml
+++ b/crates/sdr-core/Cargo.toml
@@ -58,6 +58,7 @@ dirs-next.workspace = true
 # and the crate's `lib.rs` cfg dispatch resolves to the stub backend.
 sdr-sink-audio.workspace = true
 sdr-transcription.workspace = true
+slowrx.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sdr-sink-audio = { workspace = true, features = ["pipewire"] }

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -23,6 +23,7 @@ use sdr_dsp::channel::RxVfo;
 use sdr_pipeline::iq_frontend::{FftWindow, IqFrontend};
 use sdr_pipeline::source_manager::Source;
 use sdr_radio::lrpt_decoder::LrptDecoder;
+use slowrx::SstvDecoder;
 
 use crate::sink_slot::{
     AudioSinkSlot, AudioSinkType, DEFAULT_NETWORK_SINK_HOST, DEFAULT_NETWORK_SINK_PORT,
@@ -535,6 +536,31 @@ struct DspState {
     /// log at the IQ block rate (~100 Hz) until source-stop.
     /// Per `CodeRabbit` round 12 on PR #543.
     lrpt_init_failed: bool,
+    /// ISS SSTV decoder. Lazy-init on first `sstv_decode_tap` call
+    /// at the `RadioModule`'s current audio sample rate (typically
+    /// 48 kHz). The decoder internally resamples to `11_025` Hz, so
+    /// any rate within `slowrx`'s accepted range is fine.
+    /// `None` means "not yet built" — built once, kept across demod
+    /// toggles so re-entering NFM during a pass picks up where it
+    /// left off. Per epic #472.
+    sstv_decoder: Option<slowrx::SstvDecoder>,
+    /// Pre-allocated mono downmix buffer for the SSTV decoder input.
+    /// Reused across DSP blocks, resized in place each call so we
+    /// don't alloc inside the hot loop. Mirrors `apt_mono_buf`.
+    sstv_mono_buf: Vec<f32>,
+    /// Most recent audio sample rate that `SstvDecoder::new` rejected,
+    /// or `None` if every prior init succeeded / hasn't been tried.
+    /// Guards against the audio-block hot loop retrying on a rate the
+    /// decoder will never accept. Cleared in `cleanup` alongside the
+    /// decoder reset so a fresh source restart gets one fresh attempt.
+    /// Mirrors `apt_init_failed_at_rate`. Per epic #472.
+    sstv_init_failed_at_rate: Option<u32>,
+    /// Shared SSTV image handle. `None` until the UI side wires it
+    /// via `UiToDsp::SetSstvImage`; when `None` the tap runs but
+    /// lines are discarded (manual NFM use without a viewer is
+    /// silent-but-harmless). Set at AOS by the auto-record wiring;
+    /// cleared at LOS by `UiToDsp::ClearSstvImage`. Per epic #472.
+    sstv_image: Option<sdr_radio::sstv_image::SstvImageHandle>,
     /// Live ACARS bank. May be temporarily `None` while ACARS
     /// is still engaged — specifically, the `Start` path
     /// invalidates this so `acars_decode_tap`'s lazy-init can
@@ -672,6 +698,10 @@ impl DspState {
             lrpt_decoder: None,
             lrpt_image: None,
             lrpt_init_failed: false,
+            sstv_decoder: None,
+            sstv_mono_buf: Vec::new(),
+            sstv_init_failed_at_rate: None,
+            sstv_image: None,
             acars_bank: None,
             acars_pre_lock: None,
             acars_init_failed: false,
@@ -815,6 +845,121 @@ fn lrpt_decode_tap(
         return;
     };
     decoder.process(radio_input);
+}
+
+/// ISS SSTV decode tap. Mirrors [`apt_decode_tap`]'s shape: lazy-init
+/// the [`SstvDecoder`] at the `RadioModule`'s current audio sample
+/// rate, downmix the post-`radio.process` stereo audio block to mono,
+/// feed the decoder, and dispatch events through the DSP→UI channel.
+///
+/// Only runs in NFM mode — the SSTV 1200–2300 Hz subcarrier rides on
+/// wide-FM-style audio which the NFM demod captures cleanly.
+///
+/// Events dispatched:
+/// - `SstvEvent::LineDecoded` → calls `image_handle.write_line` if
+///   the handle is wired; also sends `DspToUi::SstvLineDecoded` for
+///   the viewer's redraw trigger.
+/// - `SstvEvent::ImageComplete` → calls `image_handle.take_completed`
+///   and sends `DspToUi::SstvImageComplete` so the wiring layer can
+///   queue the completed image for LOS save.
+/// - `SstvEvent::VisDetected` → logged via `tracing::info!` only.
+///
+/// Per epic #472.
+fn sstv_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_count: usize) {
+    // Lazy-init. Audio rate comes from `RadioModule::audio_sample_rate`
+    // (typically 48 kHz, well within slowrx's accepted range).
+    if state.sstv_decoder.is_none() {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let rate_hz = state.radio.audio_sample_rate() as u32;
+        // Guard against retry-spamming the warn log on a rate the
+        // decoder will reject. Mirrors `apt_init_failed_at_rate`.
+        if state.sstv_init_failed_at_rate == Some(rate_hz) {
+            return;
+        }
+        match SstvDecoder::new(rate_hz) {
+            Ok(decoder) => {
+                tracing::info!("SSTV decoder initialised at {rate_hz} Hz");
+                state.sstv_decoder = Some(decoder);
+                state.sstv_init_failed_at_rate = None;
+            }
+            Err(e) => {
+                tracing::warn!("SSTV decoder init failed at {rate_hz} Hz: {e}");
+                state.sstv_init_failed_at_rate = Some(rate_hz);
+                return;
+            }
+        }
+    }
+    let Some(decoder) = state.sstv_decoder.as_mut() else {
+        return;
+    };
+
+    // Mono downmix. SSTV is mono — averaging L+R is equivalent to
+    // either channel for FM-demodulated audio. Mirrors `apt_mono_buf`.
+    state.sstv_mono_buf.clear();
+    state.sstv_mono_buf.extend(
+        state.audio_buf[..audio_count]
+            .iter()
+            .map(|s| (s.l + s.r) * 0.5),
+    );
+
+    // `SstvDecoder::process` returns a `Vec<SstvEvent>` — iterate and
+    // dispatch. `SstvEvent` is `#[non_exhaustive]`, so a wildcard arm
+    // handles future mode additions without a compile break.
+    for event in decoder.process(&state.sstv_mono_buf) {
+        match event {
+            slowrx::SstvEvent::VisDetected {
+                mode,
+                sample_offset,
+                hedr_shift_hz,
+            } => {
+                tracing::info!(
+                    ?mode,
+                    sample_offset,
+                    hedr_shift_hz,
+                    "SSTV VIS detected — new image starting"
+                );
+            }
+            slowrx::SstvEvent::LineDecoded {
+                mode,
+                line_index,
+                ref pixels,
+            } => {
+                // Write into the shared image handle (if the UI wired one).
+                if let Some(ref handle) = state.sstv_image {
+                    // Derive width/height from the mode spec. PD120/PD180 are
+                    // 640 px wide; other modes vary. `SstvMode` is
+                    // `#[non_exhaustive]` so we use the spec helper
+                    // (`slowrx::for_mode` — the free function in
+                    // `slowrx::modespec`, re-exported at the crate root).
+                    let spec = slowrx::for_mode(mode);
+                    handle.write_line(line_index, spec.line_pixels, spec.image_lines, pixels);
+                }
+                let _ = dsp_tx.send(DspToUi::SstvLineDecoded(line_index));
+            }
+            slowrx::SstvEvent::ImageComplete { image, .. } => {
+                // `take_completed` atomically swaps out the in-flight
+                // pixel buffer and resets for the next VIS detection.
+                // Move the completed image (via the shared handle's
+                // take path) into the DspToUi message for the wiring
+                // layer to save at LOS. If no handle is wired, fall
+                // back to the slowrx-owned `image` directly.
+                let completed = state
+                    .sstv_image
+                    .as_ref()
+                    .and_then(sdr_radio::sstv_image::SstvImageHandle::take_completed);
+                let _ = dsp_tx.send(DspToUi::SstvImageComplete {
+                    width: image.width,
+                    height: image.height,
+                    pixels: completed.map_or_else(|| image.pixels.clone(), |c| c.pixels),
+                });
+            }
+            _ => {
+                // `SstvEvent` is `#[non_exhaustive]` — silently
+                // ignore future variants so a slowrx 0.2 update
+                // doesn't require a source change here.
+            }
+        }
+    }
 }
 
 /// ACARS decode tap. Mirrors `lrpt_decode_tap`'s shape: takes
@@ -2228,6 +2373,23 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             // round 1 on PR #543.
         }
 
+        UiToDsp::SetSstvImage(handle) => {
+            tracing::info!("SSTV image handle attached — decoder tap will push lines");
+            state.sstv_image = Some(handle);
+            // Decoder state intentionally NOT dropped here —
+            // same contract as `SetLrptImage`. The handle is
+            // a long-lived singleton; re-attaching is a no-op
+            // for the decoder. Lifecycle stays owned by the
+            // source-stop cleanup path. Per epic #472.
+        }
+
+        UiToDsp::ClearSstvImage => {
+            tracing::info!("SSTV image handle cleared — line writes silently discarded");
+            state.sstv_image = None;
+            // Decoder stays alive — mirrors `ClearLrptImage`.
+            // Per epic #472.
+        }
+
         UiToDsp::ResetImagingDecoders => {
             // Between-pass reset for the auto-record flow when
             // the source stays open across pass boundaries
@@ -3393,6 +3555,17 @@ fn reset_imaging_decoders(state: &mut DspState) {
         state.lrpt_decoder = None;
     }
     state.lrpt_init_failed = false;
+
+    // SSTV decoder reset: drop and re-init on next tap call so
+    // the next pass starts from a clean VIS-detection state.
+    // Mirrors the LRPT `drop + None` approach — slowrx doesn't
+    // expose a `reset()` method so we reconstruct lazily. The
+    // `sstv_mono_buf` is left allocated (reused), and the
+    // `sstv_init_failed_at_rate` memo is cleared so the next
+    // source-start gets a fresh init attempt. Per epic #472.
+    state.sstv_decoder = None;
+    state.sstv_mono_buf.clear();
+    state.sstv_init_failed_at_rate = None;
 }
 
 /// Rebuild the IQ frontend with the current sample rate, preserving user settings.
@@ -3690,6 +3863,14 @@ fn process_iq_block(
                             && state.radio.current_mode() == sdr_types::DemodMode::Nfm
                         {
                             apt_decode_tap(state, dsp_tx, audio_count);
+                            // ISS SSTV decode tap (#472). Also NFM-gated —
+                            // the SSTV 1200–2300 Hz subcarrier rides the
+                            // same wide-FM audio path as NOAA APT. Both
+                            // decoders run in parallel when in NFM mode;
+                            // only one will see a valid VIS header for
+                            // the active signal, so the other runs cheaply
+                            // as a no-op pass through the correlator.
+                            sstv_decode_tap(state, dsp_tx, audio_count);
                         }
 
                         // Emit CTCSS sustained-gate edges for the UI

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -947,10 +947,17 @@ fn sstv_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_c
                     .sstv_image
                     .as_ref()
                     .and_then(sdr_radio::sstv_image::SstvImageHandle::take_completed);
+                let width = image.width;
+                let height = image.height;
+                // `map_or` consumes `image.pixels` directly in the
+                // `None` arm, avoiding the `.clone()` the
+                // `map_or_else` call had. The `Some` arm returns
+                // the handle's buffer — both arms are owned moves.
+                let pixels = completed.map_or(image.pixels, |c| c.pixels);
                 let _ = dsp_tx.send(DspToUi::SstvImageComplete {
-                    width: image.width,
-                    height: image.height,
-                    pixels: completed.map_or_else(|| image.pixels.clone(), |c| c.pixels),
+                    width,
+                    height,
+                    pixels,
                 });
             }
             _ => {
@@ -3563,6 +3570,15 @@ fn reset_imaging_decoders(state: &mut DspState) {
     // `sstv_mono_buf` is left allocated (reused), and the
     // `sstv_init_failed_at_rate` memo is cleared so the next
     // source-start gets a fresh init attempt. Per epic #472.
+    //
+    // Clear the shared image handle so stale pixels from a
+    // mid-image LOS don't bleed into the next pass's live
+    // viewer. The handle survives here (the DSP tap re-uses it
+    // across passes if the user keeps the source running);
+    // only the in-flight buffer is wiped.
+    if let Some(handle) = state.sstv_image.as_ref() {
+        handle.clear();
+    }
     state.sstv_decoder = None;
     state.sstv_mono_buf.clear();
     state.sstv_init_failed_at_rate = None;

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -161,6 +161,34 @@ pub enum DspToUi {
     /// `mpsc::Receiver::try_recv()` hot path that copies the
     /// returned `DspToUi` value once per drain.
     AptLine(Box<AptLine>),
+    // --- SSTV decoder (#472 — ISS SSTV) ---
+    /// One decoded SSTV scan line. Emitted from the DSP thread when
+    /// `sstv_decode_tap` receives a `slowrx::SstvEvent::LineDecoded`.
+    /// The UI handler uses this as a redraw trigger for the live
+    /// viewer — the actual pixels are written into the shared
+    /// `SstvImageHandle` before this message is sent, so the viewer
+    /// only needs the index to know a new row is ready.
+    ///
+    /// `line_index` is 0-based. Cadence depends on the SSTV mode:
+    /// PD120 produces ~120 lines at ~1 line/sec; PD180 produces
+    /// ~180 lines. ISS ARISS events typically send ~12 images per
+    /// active pass window.
+    SstvLineDecoded(u32),
+    /// One complete SSTV image. Emitted from the DSP thread when
+    /// `sstv_decode_tap` receives a `slowrx::SstvEvent::ImageComplete`.
+    /// The UI wiring layer accumulates these for LOS save —
+    /// `interpret_action::SaveSstvPass` drains them into per-image
+    /// PNG files named `img0.png`, `img1.png`, etc. Boxed so the
+    /// pixel `Vec` doesn't inflate the enum's stack footprint on
+    /// the drain path. Per epic #472.
+    SstvImageComplete {
+        /// Width in pixels (e.g. 640 for PD120/PD180).
+        width: u32,
+        /// Height in scan lines.
+        height: u32,
+        /// Row-major RGB triples, length = `width * height`.
+        pixels: Vec<[u8; 3]>,
+    },
     /// One decoded ACARS frame. Boxed because `AcarsMessage`
     /// holds an inline `String` body and `arrayvec` fields,
     /// so the enum's stack footprint stays small.
@@ -388,6 +416,21 @@ pub enum UiToDsp {
     /// next source-stop, mirroring the APT decoder's
     /// "decoder kept across mode toggles" behavior.
     ClearLrptImage,
+    /// Hand the DSP thread a clone of the shared
+    /// `sdr_radio::sstv_image::SstvImageHandle` the live SSTV
+    /// viewer reads from. Sent by the wiring layer at AOS for
+    /// SSTV auto-record passes (or whenever the user opens the
+    /// SSTV viewer manually). The DSP thread stores the handle
+    /// and writes decoded scan lines into it whenever the SSTV
+    /// decoder tap runs (`current_mode` == `DemodMode::Nfm`).
+    /// Per epic #472.
+    SetSstvImage(sdr_radio::sstv_image::SstvImageHandle),
+    /// Drop the shared SSTV image handle. Sent at LOS / when
+    /// the live viewer closes — the DSP decoder continues
+    /// running (lines are silently discarded) until the next
+    /// source-stop. Mirrors the LRPT `ClearLrptImage` pattern.
+    /// Per epic #472.
+    ClearSstvImage,
     /// Start sending audio to the transcription engine.
     EnableTranscription(std::sync::mpsc::SyncSender<sdr_transcription::TranscriptionInput>),
     /// Stop sending audio to the transcription engine.

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -1222,4 +1222,50 @@ mod tests {
         let _: UiToDsp = UiToDsp::SetAcarsNetworkAddr("127.0.0.1:5550".to_string());
         let _: UiToDsp = UiToDsp::SetAcarsStationId("STN1".to_string());
     }
+
+    #[test]
+    fn sstv_dsp_to_ui_variants_construct() {
+        // Shape regression for the two SSTV events added in
+        // epic #472. Catches silent payload changes — if the
+        // line_index field is renamed or the struct gains a
+        // field, the pattern match here fails at compile or
+        // runtime before it can silently break the UI handler.
+        // Per CodeRabbit round 1 on PR #599.
+        let line_decoded = DspToUi::SstvLineDecoded(42);
+        assert!(matches!(
+            line_decoded,
+            DspToUi::SstvLineDecoded(idx) if idx == 42
+        ));
+
+        let image_complete = DspToUi::SstvImageComplete {
+            width: 640,
+            height: 496,
+            pixels: vec![[255_u8, 0, 0]; 640 * 496],
+        };
+        assert!(matches!(
+            image_complete,
+            DspToUi::SstvImageComplete {
+                width: 640,
+                height: 496,
+                ref pixels,
+            } if pixels.len() == 640 * 496
+        ));
+    }
+
+    #[test]
+    fn sstv_ui_to_dsp_variants_construct() {
+        // Shape regression for the two SSTV control commands
+        // added in epic #472. A future rename of `SetSstvImage`
+        // / `ClearSstvImage` or a change to the
+        // `SstvImageHandle` payload type trips this regression
+        // net rather than silently breaking the controller's
+        // `sstv_decode_tap` plumbing.
+        // Per CodeRabbit round 1 on PR #599.
+        let img = sdr_radio::sstv_image::SstvImage::new();
+        let set_sstv = UiToDsp::SetSstvImage(img.handle());
+        assert!(matches!(set_sstv, UiToDsp::SetSstvImage(_)));
+
+        let clear_sstv = UiToDsp::ClearSstvImage;
+        assert!(matches!(clear_sstv, UiToDsp::ClearSstvImage));
+    }
 }

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -1350,6 +1350,38 @@ mod tests {
     }
 
     #[test]
+    fn translate_sstv_line_decoded_is_dropped_at_ffi_boundary() {
+        // SSTV variants (epic #472) are Linux-only for V1; the
+        // macOS FFI layer will get its own ticket when the FFI
+        // layer gains an SSTV viewer. Pin the drop-at-boundary
+        // contract so a future change that accidentally surfaces
+        // SSTV through the C ABI trips this assert first.
+        // Per CodeRabbit round 1 on PR #599.
+        let msg = DspToUi::SstvLineDecoded(0);
+        assert!(
+            translate_event(&msg).is_none(),
+            "SstvLineDecoded must not translate to a wire event yet",
+        );
+    }
+
+    #[test]
+    fn translate_sstv_image_complete_is_dropped_at_ffi_boundary() {
+        // Same drop-at-boundary contract as `SstvLineDecoded`
+        // above — the pixel Vec should never flow through the
+        // C ABI until the macOS viewer ticket ships. Per
+        // CodeRabbit round 1 on PR #599.
+        let msg = DspToUi::SstvImageComplete {
+            width: 1,
+            height: 1,
+            pixels: vec![[0_u8, 0, 0]],
+        };
+        assert!(
+            translate_event(&msg).is_none(),
+            "SstvImageComplete must not translate to a wire event yet",
+        );
+    }
+
+    #[test]
     fn rtl_tcp_state_discriminants_match_header() {
         assert_eq!(SDR_RTL_TCP_STATE_DISCONNECTED, 0);
         assert_eq!(SDR_RTL_TCP_STATE_CONNECTING, 1);

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -772,7 +772,11 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         | DspToUi::AcarsEnabledChanged(_)
         // Output-error toast (issue #578) — Linux-only writer path;
         // macOS ticket will handle when FFI layer gets ACARS output.
-        | DspToUi::AcarsOutputError { .. } => return None,
+        | DspToUi::AcarsOutputError { .. }
+        // SSTV variants (epic #472) — Linux-only for V1; macOS will
+        // get its own ticket when the FFI layer gains an SSTV viewer.
+        | DspToUi::SstvLineDecoded(_)
+        | DspToUi::SstvImageComplete { .. } => return None,
     };
 
     Some((event, owned_cstring, owned_vec))

--- a/crates/sdr-radio/Cargo.toml
+++ b/crates/sdr-radio/Cargo.toml
@@ -14,6 +14,7 @@ sdr-pipeline.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+slowrx.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/sdr-radio/src/lib.rs
+++ b/crates/sdr-radio/src/lib.rs
@@ -11,6 +11,7 @@ pub mod demod;
 pub mod if_chain;
 pub mod lrpt_decoder;
 pub mod lrpt_image;
+pub mod sstv_image;
 
 use sdr_dsp::filter::{DEEMPHASIS_TAU_EU, DEEMPHASIS_TAU_US};
 use sdr_dsp::multirate::RationalResampler;

--- a/crates/sdr-radio/src/sstv_image.rs
+++ b/crates/sdr-radio/src/sstv_image.rs
@@ -83,16 +83,28 @@ impl Inner {
     }
 
     /// Copy one scan line's pixels into the buffer.
+    ///
+    /// Duplicate or out-of-order writes are idempotent on the
+    /// pixel data and do not advance the counter past
+    /// `line_index + 1`, preventing `lines_written` from
+    /// drifting above `height` even when slowrx re-emits a
+    /// row (rare edge case observed on noisy signals).
     fn write_line(&mut self, line_index: u32, pixels: &[[u8; 3]]) {
         if self.width == 0 {
             return; // `init_if_needed` wasn't called first; skip defensively.
+        }
+        if line_index >= self.height {
+            return; // out-of-bounds row — silently drop.
         }
         let w = self.width as usize;
         let row_start = (line_index as usize) * w;
         let row_end = row_start + w;
         if row_end <= self.pixels.len() && pixels.len() >= w {
             self.pixels[row_start..row_end].copy_from_slice(&pixels[..w]);
-            self.lines_written += 1;
+            // Track the highest written row+1, not a count of
+            // writes — makes duplicate and out-of-order writes
+            // idempotent and prevents overflow past `height`.
+            self.lines_written = self.lines_written.max(line_index.saturating_add(1));
         }
     }
 }
@@ -248,7 +260,11 @@ impl SstvImageHandle {
         if g.is_empty() {
             return None;
         }
-        let lines = g.lines_written as usize;
+        // Clamp defensively: `lines_written` should never exceed
+        // `height` after the `write_line` fix, but belt-and-
+        // suspenders keeps `snapshot` panic-safe even if the
+        // accounting somehow drifted.
+        let lines = g.lines_written.min(g.height) as usize;
         let w = g.width as usize;
         Some(SstvSnapshot {
             width: g.width,
@@ -408,5 +424,57 @@ mod tests {
         );
         // First pixel should be [255, 0, 0].
         assert_eq!(&flat[0..3], &[255_u8, 0, 0]);
+    }
+
+    /// Duplicate `write_line` calls for the same row must not
+    /// advance `lines_written` — idempotent pixel write.
+    /// Regression for the CR #5 finding (PR #599): the old
+    /// `+= 1` counter drifted above `height` on re-sends.
+    #[test]
+    fn duplicate_write_does_not_advance_counter() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        h.write_line(0, W, H, &red_row());
+        h.write_line(0, W, H, &red_row()); // duplicate
+        h.write_line(0, W, H, &red_row()); // duplicate again
+        let snap = h.snapshot().unwrap();
+        assert_eq!(
+            snap.lines_written, 1,
+            "duplicate writes must not advance lines_written past 1"
+        );
+    }
+
+    /// Out-of-order writes must not inflate `lines_written`
+    /// beyond the highest row index seen.
+    #[test]
+    fn out_of_order_writes_track_highest_row() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        h.write_line(5, W, H, &red_row()); // write row 5 first
+        h.write_line(2, W, H, &blank_row()); // then row 2
+        let snap = h.snapshot().unwrap();
+        // lines_written should be 6 (highest row index 5 + 1),
+        // not 2 (a naive count of calls).
+        assert_eq!(
+            snap.lines_written, 6,
+            "out-of-order write: lines_written must be max(row_index)+1"
+        );
+    }
+
+    /// An out-of-bounds row index (>= height) must be silently
+    /// dropped; neither the pixel buffer nor `lines_written`
+    /// should be affected.
+    #[test]
+    fn out_of_bounds_row_is_silently_dropped() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        h.write_line(0, W, H, &red_row()); // valid
+        h.write_line(H, W, H, &red_row()); // OOB: index == height
+        h.write_line(H + 99, W, H, &red_row()); // OOB: way past
+        let snap = h.snapshot().unwrap();
+        assert_eq!(
+            snap.lines_written, 1,
+            "OOB row must not advance lines_written"
+        );
     }
 }

--- a/crates/sdr-radio/src/sstv_image.rs
+++ b/crates/sdr-radio/src/sstv_image.rs
@@ -1,0 +1,412 @@
+//! Shared SSTV image handle: bridges `sstv_decode_tap` (writer)
+//! and `sstv_viewer` (reader). Mirrors [`crate::lrpt_image::LrptImage`]'s
+//! `Arc<Mutex<Inner>>` shape but holds a single growing image at a time.
+//!
+//! slowrx emits one image per VIS detection; ARISS events typically
+//! send ~12 images per pass, so the consumer copies + clears between
+//! detections via [`SstvImageHandle::take_completed`].
+//!
+//! ```text
+//!     SstvDecoder ──[per-line events]──▶  SstvImageHandle (writer)
+//!                                               ▲
+//!                                               │ (Arc<Mutex<Inner>>)
+//!                                               │
+//!                                         SstvImageHandle
+//!                                         │            │
+//!                                         ▼            ▼
+//!                                   live viewer    LOS PNG export
+//! ```
+//!
+//! One [`SstvImage`] corresponds to **one satellite pass**. A fresh pass =
+//! constructing a fresh handle (or calling the existing one's clear path
+//! via [`SstvImageHandle::take_completed`]); the inner buffer automatically
+//! resets after each [`SstvEvent::ImageComplete`].
+
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+use tracing::warn;
+
+/// Per-line SSTV mode information carried alongside pixel data.
+/// Stored with the in-flight image so the viewer and save path can
+/// read it without going back to the decoder.
+#[derive(Debug, Clone, Copy)]
+pub struct SstvModeInfo {
+    /// Pixel width of the image this mode produces.
+    pub width: u32,
+    /// Total number of scan lines the mode produces.
+    pub height: u32,
+}
+
+/// Inner mutable state for the shared SSTV image buffer.
+struct Inner {
+    /// Pixel width of the current image (set on first `write_line`).
+    width: u32,
+    /// Total number of expected scan lines (set on first `write_line`).
+    height: u32,
+    /// Row-major RGB pixels, length = `width * height` when complete.
+    /// Partially-filled during a live pass.
+    pixels: Vec<[u8; 3]>,
+    /// Number of lines written so far.
+    lines_written: u32,
+}
+
+impl Inner {
+    fn new() -> Self {
+        Self {
+            width: 0,
+            height: 0,
+            pixels: Vec::new(),
+            lines_written: 0,
+        }
+    }
+
+    /// True if no lines have been written yet.
+    fn is_empty(&self) -> bool {
+        self.lines_written == 0
+    }
+
+    /// Reset to empty state, ready for a new image.
+    fn clear(&mut self) {
+        self.width = 0;
+        self.height = 0;
+        self.pixels.clear();
+        self.lines_written = 0;
+    }
+
+    /// Initialise buffer dimensions on the first line of a new image.
+    fn init_if_needed(&mut self, width: u32, height: u32) {
+        if self.width == 0 || self.height == 0 {
+            self.width = width;
+            self.height = height;
+            self.pixels = vec![[0, 0, 0]; (width * height) as usize];
+        }
+    }
+
+    /// Copy one scan line's pixels into the buffer.
+    fn write_line(&mut self, line_index: u32, pixels: &[[u8; 3]]) {
+        if self.width == 0 {
+            return; // `init_if_needed` wasn't called first; skip defensively.
+        }
+        let w = self.width as usize;
+        let row_start = (line_index as usize) * w;
+        let row_end = row_start + w;
+        if row_end <= self.pixels.len() && pixels.len() >= w {
+            self.pixels[row_start..row_end].copy_from_slice(&pixels[..w]);
+            self.lines_written += 1;
+        }
+    }
+}
+
+/// A completed SSTV image ready to be saved to disk.
+///
+/// Returned by [`SstvImageHandle::take_completed`] at an
+/// [`SstvEvent::ImageComplete`] event. Owns the pixel data
+/// out-right so the in-flight buffer can immediately reset
+/// for the next VIS detection without waiting for the save.
+#[derive(Debug, Clone)]
+pub struct CompletedSstvImage {
+    /// Pixel width (e.g. 640 for PD120/PD180).
+    pub width: u32,
+    /// Pixel height (total scan lines).
+    pub height: u32,
+    /// Row-major RGB triples, length = `width * height`.
+    pub pixels: Vec<[u8; 3]>,
+}
+
+impl CompletedSstvImage {
+    /// Flatten the pixels into a contiguous RGB byte slice suitable
+    /// for PNG encoding. Each pixel is 3 bytes (R, G, B) in row-major
+    /// order; the returned `Vec<u8>` has length `width * height * 3`.
+    ///
+    /// This method is the single serialisation entry point — callers
+    /// in `sdr-ui` (which have Cairo available) convert this flat
+    /// buffer into an ARGB32 surface and call `write_to_png`, mirroring
+    /// the LRPT viewer's `write_rgb_png` helper.
+    #[must_use]
+    pub fn to_flat_rgb(&self) -> Vec<u8> {
+        self.pixels
+            .iter()
+            .flat_map(|&[r, g, b]| [r, g, b])
+            .collect()
+    }
+}
+
+/// A non-destructive snapshot of the in-flight SSTV image for the
+/// live viewer. Contains only the rows written so far.
+#[derive(Debug, Clone)]
+pub struct SstvSnapshot {
+    pub width: u32,
+    pub height: u32,
+    /// Rows 0 … `lines_written - 1`, each `width` RGB triples.
+    pub pixels: Vec<[u8; 3]>,
+    /// Number of complete scan lines in `pixels`.
+    pub lines_written: u32,
+}
+
+/// Recover from a poisoned mutex, emitting a single warning.
+fn lock_or_recover(inner: &Mutex<Inner>) -> MutexGuard<'_, Inner> {
+    inner.lock().unwrap_or_else(|e: PoisonError<_>| {
+        warn!("SstvImage mutex poisoned, recovering — a decoder thread panicked");
+        e.into_inner()
+    })
+}
+
+/// Cloneable handle to the shared SSTV image buffer.
+///
+/// All clones read and write the same underlying buffer. Clone the
+/// handle to share it between the DSP tap and the UI viewer.
+#[derive(Clone)]
+pub struct SstvImageHandle {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl std::fmt::Debug for SstvImageHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SstvImageHandle").finish_non_exhaustive()
+    }
+}
+
+/// `SstvImage` is the top-level constructor. Call [`SstvImage::handle`]
+/// to get a cloneable [`SstvImageHandle`] for sharing across threads.
+pub struct SstvImage {
+    handle: SstvImageHandle,
+}
+
+impl Default for SstvImage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SstvImage {
+    /// Create a fresh, empty image (ready for a new pass).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            handle: SstvImageHandle {
+                inner: Arc::new(Mutex::new(Inner::new())),
+            },
+        }
+    }
+
+    /// Return a cloneable handle for sharing between the DSP tap
+    /// and the UI viewer. Every clone reads/writes the same buffer.
+    #[must_use]
+    pub fn handle(&self) -> SstvImageHandle {
+        self.handle.clone()
+    }
+
+    /// Clear the buffer without returning the pixels. Convenience
+    /// wrapper around [`SstvImageHandle::clear`]; equivalent to
+    /// `self.handle().clear()` but avoids cloning the Arc handle.
+    pub fn clear(&self) {
+        self.handle.clear();
+    }
+}
+
+impl SstvImageHandle {
+    /// Write one decoded scan line into the buffer.
+    ///
+    /// Initialises the image dimensions on the first call for a new
+    /// image (i.e. after construction or after `take_completed` reset
+    /// the buffer). `width` and `height` are the mode's full-image
+    /// dimensions; `line_index` is the 0-based row being written;
+    /// `pixels` is the decoded row from `SstvEvent::LineDecoded`.
+    pub fn write_line(&self, line_index: u32, width: u32, height: u32, pixels: &[[u8; 3]]) {
+        let mut g = lock_or_recover(&self.inner);
+        g.init_if_needed(width, height);
+        g.write_line(line_index, pixels);
+    }
+
+    /// Atomically swap out the completed in-flight image and reset the
+    /// buffer for the next VIS detection.
+    ///
+    /// Returns `None` when the buffer is empty (no lines written since
+    /// last reset), so callers can skip saving empty images gracefully.
+    #[must_use]
+    pub fn take_completed(&self) -> Option<CompletedSstvImage> {
+        let mut g = lock_or_recover(&self.inner);
+        if g.is_empty() {
+            return None;
+        }
+        let completed = CompletedSstvImage {
+            width: g.width,
+            height: g.height,
+            pixels: std::mem::take(&mut g.pixels),
+        };
+        g.clear();
+        Some(completed)
+    }
+
+    /// Non-destructive snapshot of the in-flight image for the live
+    /// viewer. Clones only the written rows, so a 50-line snapshot
+    /// from a 496-line PD120 image copies ~50 × 640 × 3 ≈ 96 KB —
+    /// cheap compared to the full-image clone.
+    #[must_use]
+    pub fn snapshot(&self) -> Option<SstvSnapshot> {
+        let g = lock_or_recover(&self.inner);
+        if g.is_empty() {
+            return None;
+        }
+        let lines = g.lines_written as usize;
+        let w = g.width as usize;
+        Some(SstvSnapshot {
+            width: g.width,
+            height: g.height,
+            pixels: g.pixels[..lines * w].to_vec(),
+            lines_written: g.lines_written,
+        })
+    }
+
+    /// Clear the buffer without returning the pixels. Use between
+    /// passes when the previous image doesn't need to be saved.
+    pub fn clear(&self) {
+        let mut g = lock_or_recover(&self.inner);
+        g.clear();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// Width + height used by all tests. Matches PD120's spec (640 × 496).
+    const W: u32 = 640;
+    const H: u32 = 496;
+
+    fn blank_row() -> Vec<[u8; 3]> {
+        vec![[0, 0, 0]; W as usize]
+    }
+
+    fn red_row() -> Vec<[u8; 3]> {
+        vec![[255, 0, 0]; W as usize]
+    }
+
+    #[test]
+    fn snapshot_returns_none_before_any_write() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        assert!(h.snapshot().is_none());
+    }
+
+    #[test]
+    fn take_completed_returns_none_before_any_write() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        assert!(h.take_completed().is_none());
+    }
+
+    #[test]
+    fn write_line_then_snapshot_round_trip() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        h.write_line(0, W, H, &red_row());
+        let snap = h.snapshot().unwrap();
+        assert_eq!(snap.width, W);
+        assert_eq!(snap.height, H);
+        assert_eq!(snap.lines_written, 1);
+        assert_eq!(snap.pixels.len(), W as usize);
+        assert_eq!(snap.pixels[0], [255, 0, 0]);
+    }
+
+    #[test]
+    fn take_completed_drains_and_resets() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        h.write_line(0, W, H, &red_row());
+        h.write_line(1, W, H, &blank_row());
+
+        let completed = h.take_completed().unwrap();
+        assert_eq!(completed.width, W);
+        assert_eq!(completed.height, H);
+        assert_eq!(completed.pixels.len(), (W * H) as usize);
+        // First row is red.
+        assert_eq!(completed.pixels[0], [255, 0, 0]);
+        // Second row is black.
+        assert_eq!(completed.pixels[W as usize], [0, 0, 0]);
+
+        // Buffer should be reset.
+        assert!(h.snapshot().is_none());
+        assert!(h.take_completed().is_none());
+    }
+
+    #[test]
+    fn clones_share_same_buffer() {
+        let img = SstvImage::new();
+        let a = img.handle();
+        let b = a.clone();
+        a.write_line(0, W, H, &red_row());
+        let snap = b.snapshot().unwrap();
+        assert_eq!(snap.pixels[0], [255, 0, 0]);
+    }
+
+    #[test]
+    fn clear_resets_without_returning_pixels() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        h.write_line(0, W, H, &red_row());
+        h.clear();
+        assert!(h.snapshot().is_none());
+    }
+
+    #[test]
+    fn multiple_images_can_be_cycled() {
+        // Simulate two successive VIS detections (two images in a pass).
+        let img = SstvImage::new();
+        let h = img.handle();
+
+        // Image 1: one red row.
+        h.write_line(0, W, H, &red_row());
+        let first = h.take_completed().unwrap();
+        assert_eq!(first.pixels[0], [255, 0, 0]);
+
+        // Image 2: one blank row.
+        h.write_line(0, W, H, &blank_row());
+        let second = h.take_completed().unwrap();
+        assert_eq!(second.pixels[0], [0, 0, 0]);
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn recovers_from_poisoned_mutex() {
+        use std::thread;
+        let img = SstvImage::new();
+        let h = img.handle();
+        h.write_line(0, W, H, &red_row());
+
+        let inner_clone = Arc::clone(&h.inner);
+        let _ = thread::spawn(move || {
+            let _guard = inner_clone.lock().expect("first lock");
+            panic!("intentional panic to poison the mutex");
+        })
+        .join();
+
+        assert!(h.inner.is_poisoned(), "mutex must be poisoned for test");
+        // Snapshot and write both go through `lock_or_recover` and must work.
+        let snap = h.snapshot().unwrap();
+        assert_eq!(snap.lines_written, 1);
+        h.write_line(1, W, H, &blank_row());
+        let snap2 = h.snapshot().unwrap();
+        assert_eq!(snap2.lines_written, 2);
+    }
+
+    #[test]
+    fn to_flat_rgb_has_expected_length() {
+        let img = SstvImage::new();
+        let h = img.handle();
+        for i in 0_u32..4 {
+            h.write_line(i, W, H, &red_row());
+        }
+        let completed = h.take_completed().unwrap();
+        let flat = completed.to_flat_rgb();
+        // Full-image flat RGB is width * height * 3 bytes.
+        assert_eq!(
+            flat.len(),
+            (W * H) as usize * 3,
+            "flat RGB must be width * height * 3 bytes"
+        );
+        // First pixel should be [255, 0, 0].
+        assert_eq!(&flat[0..3], &[255_u8, 0, 0]);
+    }
+}

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -55,9 +55,9 @@ pub const IMAGING_BAND_MAX_HZ: u64 = 148_000_000;
 
 /// Imaging protocol the receiver should use for a given catalog
 /// satellite. Drives the auto-record dispatch in
-/// `sidebar::satellites_recorder` so APT vs LRPT vs SSTV (future)
-/// each get their own decoder + viewer without the recorder
-/// itself caring about protocol details.
+/// `sidebar::satellites_recorder` so APT vs LRPT vs SSTV each get
+/// their own decoder + viewer without the recorder itself caring
+/// about protocol details.
 ///
 /// `None` on a [`KnownSatellite::imaging_protocol`] means "in the
 /// catalog for pass-prediction display purposes, but auto-record
@@ -71,9 +71,13 @@ pub enum ImagingProtocol {
     Apt,
     /// Meteor-M Low-Rate Picture Transmission (QPSK + CCSDS framing
     /// on 137 MHz). Decoded by `sdr_dsp::lrpt::LrptDemod` +
-    /// `sdr_lrpt::LrptPipeline`. Wiring lands in Task 7 (epic #469).
+    /// `sdr_lrpt::LrptPipeline`. Shipped in epic #469.
     Lrpt,
-    // Sstv variant added in epic #472 for ISS SSTV reception.
+    /// Slow-Scan Television (FM audio with PLL pixel decode on
+    /// 145.800 MHz). Used during ARISS SSTV events from the ISS.
+    /// Decoded by the `slowrx` crate via `sdr_radio::sstv_image`.
+    /// Shipped in epic #472.
+    Sstv,
 }
 
 /// A satellite the user-facing scheduler ships with by default. The list
@@ -118,9 +122,8 @@ pub struct KnownSatellite {
     /// (so the user sees upcoming passes and can manually tune)
     /// but the auto-record path doesn't have a decoder + viewer
     /// for it yet. NOAA APT shipped in epic #468; Meteor LRPT
-    /// flips from `None` to `Some(Lrpt)` in Task 7 of epic #469
-    /// alongside the live LRPT viewer; ISS SSTV gets `Some(Sstv)`
-    /// in epic #472.
+    /// shipped in Task 7 of epic #469; ISS SSTV shipped in epic
+    /// #472 with `Some(Sstv)`.
     pub imaging_protocol: Option<ImagingProtocol>,
 }
 
@@ -188,17 +191,21 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     // failed shortly after, no usable TLE on Celestrak (404 from the
     // GP API). Per #506.
     // ISS SSTV — epic #472. 145.800 MHz is the primary downlink for
-    // SSTV transmission events and the ARISS voice repeater; both
-    // ride wide-FM and use the same tune-and-listen flow.
-    // `imaging_protocol: None` until epic #472 ships the SSTV
-    // decoder + viewer.
+    // SSTV transmission events during ARISS events; ISS rides wide-FM
+    // so the standard NFM demod path captures it cleanly.
+    // `imaging_protocol: Some(Sstv)` enrolls ISS in the auto-record
+    // flow: at AOS the recorder opens the SSTV viewer and signals the
+    // DSP to attach the `SstvDecoder`; at LOS the per-pass directory
+    // is written via `Action::SaveSstvPass`. Audio recording is NOT
+    // suppressed for SSTV — the user-toggle applies as usual (SSTV is
+    // audible unlike LRPT's silent QPSK). Shipped in epic #472.
     KnownSatellite {
         name: "ISS (ZARYA)",
         norad_id: 25_544,
         downlink_hz: 145_800_000,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
-        imaging_protocol: None,
+        imaging_protocol: Some(ImagingProtocol::Sstv),
     },
 ];
 
@@ -303,14 +310,17 @@ mod tests {
                 s.name,
             );
         }
-        // ISS → None. Becomes Some(Sstv) in epic #472.
+        // ISS → Some(Sstv). Shipped in epic #472. The `slowrx`-backed
+        // SSTV decoder + viewer + per-pass directory save are all wired
+        // end-to-end, so the catalog entry flips from None to Some(Sstv).
         let iss = KNOWN_SATELLITES
             .iter()
             .find(|s| s.name.contains("ISS"))
             .expect("ISS in catalog");
         assert_eq!(
-            iss.imaging_protocol, None,
-            "ISS should be None until epic #472"
+            iss.imaging_protocol,
+            Some(ImagingProtocol::Sstv),
+            "ISS should be Some(Sstv) after epic #472"
         );
     }
 }

--- a/crates/sdr-ui/src/lib.rs
+++ b/crates/sdr-ui/src/lib.rs
@@ -27,6 +27,7 @@ pub mod radioreference;
 pub mod shortcuts;
 pub mod sidebar;
 pub mod spectrum;
+pub mod sstv_viewer;
 pub mod state;
 pub mod status_bar;
 pub mod ui_helpers;

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -377,12 +377,13 @@ impl AutoRecorder {
     ///
     /// **Crate-private** so external callers can only use
     /// [`Self::new`], which encodes today's "fully wired"
-    /// reality (`[Apt]`). Per CR round 2 on PR #541: exposing
-    /// the variadic builder publicly would let the wiring
-    /// layer opt into protocols whose LOS flow isn't actually
-    /// safe yet. When Task 7 of epic #469 finishes the LRPT
-    /// wiring, flip `new()` to default to `[Apt, Lrpt]` rather
-    /// than re-exporting this builder.
+    /// reality (`[Apt, Lrpt, Sstv]` as of epic #472). Per CR
+    /// round 2 on PR #541: exposing the variadic builder
+    /// publicly would let the wiring layer opt into protocols
+    /// whose LOS flow isn't actually safe yet. When V2 modes
+    /// (Robot / Scottie / Martin / PD240) flow through the
+    /// SSTV wiring via slowrx.rs V2, no constructor change is
+    /// needed — they all dispatch as `ImagingProtocol::Sstv`.
     #[must_use]
     fn with_supported_protocols(supported: &[sdr_sat::ImagingProtocol]) -> Self {
         Self {

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -51,7 +51,10 @@ const SETTLE_SECS: i64 = 3;
 /// APT writes a single PNG; LRPT writes one PNG per AVHRR
 /// channel (APID) into a directory, since LRPT is multispectral
 /// and a single file can't represent all the data the user
-/// actually wants to keep. Per epic #469 task 7.4.
+/// actually wants to keep. SSTV writes a directory of per-image
+/// PNGs — ISS ARISS events send ~12 images per pass and each
+/// image is distinct content, so a directory matches LRPT's
+/// multi-artifact model. Per epic #469 task 7.4 + epic #472.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PassOutput {
     /// Single PNG file (NOAA APT). Wiring layer dispatches via
@@ -62,6 +65,11 @@ pub enum PassOutput {
     /// the directory is created lazily by the wiring layer's
     /// per-channel save loop.
     LrptDir(PathBuf),
+    /// Directory holding one PNG per decoded SSTV image (ISS SSTV).
+    /// Wiring layer dispatches via [`Action::SaveSstvPass`].
+    /// Named `img0.png`, `img1.png`, etc. in arrival order.
+    /// Per epic #472.
+    SstvDir(PathBuf),
 }
 
 impl PassOutput {
@@ -72,6 +80,7 @@ impl PassOutput {
         match self {
             Self::AptPng(_) => sdr_sat::ImagingProtocol::Apt,
             Self::LrptDir(_) => sdr_sat::ImagingProtocol::Lrpt,
+            Self::SstvDir(_) => sdr_sat::ImagingProtocol::Sstv,
         }
     }
 }
@@ -269,6 +278,14 @@ pub enum Action {
     /// strategy is statically separated — no path-meaning
     /// overload.
     SaveLrptPass(PathBuf),
+    /// Save all decoded SSTV images from this pass into `dir`.
+    /// Fired on `Recording → Finalizing` for SSTV passes.
+    /// Wiring layer creates the directory and writes one PNG
+    /// per completed image accumulated in `AppState::sstv_completed_images`:
+    /// `img0.png`, `img1.png`, etc. in arrival order. Distinct
+    /// from `SaveLrptPass` so the wiring layer's dispatch is
+    /// statically typed — per epic #472.
+    SaveSstvPass(PathBuf),
     /// Stop the in-flight WAV writer opened by
     /// [`Action::StartAutoAudioRecord`]. Fired alongside
     /// [`Action::SavePng`] on LOS, but only when audio recording
@@ -338,14 +355,14 @@ impl Default for AutoRecorder {
 impl AutoRecorder {
     /// Build a recorder that arms on every imaging protocol the
     /// wiring layer has fully wired in `interpret_action`
-    /// (decoder tap, viewer open, LOS save). As of epic #469
-    /// task 7 that's `[Apt, Lrpt]`; ISS SSTV adds `Sstv` once
-    /// epic #472 ships.
+    /// (decoder tap, viewer open, LOS save). As of epic #472
+    /// that's `[Apt, Lrpt, Sstv]`.
     #[must_use]
     pub fn new() -> Self {
         Self::with_supported_protocols(&[
             sdr_sat::ImagingProtocol::Apt,
             sdr_sat::ImagingProtocol::Lrpt,
+            sdr_sat::ImagingProtocol::Sstv,
         ])
     }
 
@@ -529,6 +546,7 @@ impl AutoRecorder {
             let output = match protocol {
                 sdr_sat::ImagingProtocol::Apt => PassOutput::AptPng(png_path_for(pass, now)),
                 sdr_sat::ImagingProtocol::Lrpt => PassOutput::LrptDir(lrpt_dir_for(pass, now)),
+                sdr_sat::ImagingProtocol::Sstv => PassOutput::SstvDir(sstv_dir_for(pass, now)),
             };
             // Audio recording is suppressed for LRPT regardless
             // of the user toggle: the LRPT demod is a silent
@@ -538,8 +556,9 @@ impl AutoRecorder {
             // ~115 MB per pass for no value. (`144 kHz` is the
             // demod's IF rate, not the WAV writer's; an earlier
             // draft conflated the two.) The toggle still
-            // applies to APT — voice/audio capture is genuinely
-            // useful there.
+            // applies to APT and SSTV — both produce audible
+            // audio (SSTV is audible FSK modulation) that some
+            // users may want to record.
             let want_audio = audio_record_on && protocol != sdr_sat::ImagingProtocol::Lrpt;
             let audio_path = want_audio.then(|| audio_path_for(pass, now));
             let mut actions = Vec::with_capacity(3);
@@ -712,6 +731,19 @@ fn lrpt_dir_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
     pass_recording_dir(pass, now, "lrpt")
 }
 
+/// Build the export directory for an ISS SSTV pass:
+/// `~/sdr-recordings/sstv-ISS--ZARYA--2026-04-25-143015`.
+///
+/// The wiring layer creates the directory lazily and writes one
+/// PNG per completed SSTV image inside it (`img0.png`,
+/// `img1.png`, …). ARISS events typically emit ~12 images per
+/// pass — a directory mirrors the LRPT model for multi-artifact
+/// passes. Per epic #472.
+#[must_use]
+fn sstv_dir_for(pass: &Pass, now: DateTime<Utc>) -> PathBuf {
+    pass_recording_dir(pass, now, "sstv")
+}
+
 /// Build the audio-recording path for a satellite + timestamp:
 /// `~/sdr-recordings/audio-NOAA-19-2026-04-25-143015.wav`.
 /// Pairs with [`png_path_for`] — same sat slug + timestamp so a
@@ -731,6 +763,7 @@ fn save_action_for(output: &PassOutput) -> Action {
     match output {
         PassOutput::AptPng(p) => Action::SavePng(p.clone()),
         PassOutput::LrptDir(p) => Action::SaveLrptPass(p.clone()),
+        PassOutput::SstvDir(p) => Action::SaveSstvPass(p.clone()),
     }
 }
 
@@ -976,18 +1009,37 @@ mod tests {
     }
 
     #[test]
-    fn idle_does_not_arm_for_unflagged_satellite() {
-        // ISS is in the catalog but `imaging_protocol: None`
-        // (SSTV decoder + viewer ship in epic #472). The
-        // recorder must skip it — tuning would succeed but no
-        // decoder would produce imagery, and the LOS-side save
-        // would emit an action with no backing data.
-        //
-        // Pre-task-7 of epic #469 this test used Meteor as the
-        // unflagged-protocol fixture; once Meteor flipped to
-        // `Some(Lrpt)` we needed a different unflagged catalog
-        // entry. ISS is the canonical "in the catalog for
-        // pass display, no auto-record yet" case.
+    fn idle_does_not_arm_for_unknown_satellite() {
+        // A satellite that isn't in the catalog at all produces no
+        // tune target, so the recorder must skip it.  We use a
+        // fictional name so this test doesn't accidentally break
+        // when a real catalog entry gets its protocol filled in
+        // (as happened when Meteor → Lrpt, then ISS → Sstv shipped
+        // in epic #472). Pre-epic-#472 this test used "ISS (ZARYA)"
+        // as the fixture because ISS had `imaging_protocol: None`;
+        // now that ISS ships with `Some(Sstv)` the fixture is a
+        // name that will never appear in the catalog.
+        let mut r = AutoRecorder::new();
+        let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
+        let mut pass = synthetic_noaa19(now, 3, 720, 50.0);
+        pass.satellite = "UNKNOWN-SAT-99".to_string();
+        let actions = r.tick(
+            now,
+            &[pass],
+            true,
+            false,
+            DEFAULT_MIN_ELEV_DEG,
+            default_tune(),
+        );
+        assert!(matches!(r.state(), State::Idle));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn idle_arms_for_iss_sstv_pass() {
+        // ISS has `imaging_protocol: Some(Sstv)` since epic #472.
+        // The recorder must arm for it when auto-record is on and
+        // the pass is within AOS_LEAD_SECS.
         let mut r = AutoRecorder::new();
         let now = Utc.with_ymd_and_hms(2024, 6, 15, 18, 0, 0).unwrap();
         let mut pass = synthetic_noaa19(now, 3, 720, 50.0);
@@ -1000,8 +1052,15 @@ mod tests {
             DEFAULT_MIN_ELEV_DEG,
             default_tune(),
         );
-        assert!(matches!(r.state(), State::Idle));
-        assert!(actions.is_empty());
+        // The recorder should have transitioned out of Idle.
+        assert!(!matches!(r.state(), State::Idle));
+        // At minimum a StartAutoRecord must be in the action batch.
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, Action::StartAutoRecord { .. })),
+            "expected StartAutoRecord for ISS SSTV pass"
+        );
     }
 
     #[test]

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -1910,10 +1910,13 @@ mod tests {
         // 1:1 — pin it so a future variant addition without
         // updating `protocol()` fails this test loudly instead
         // of silently dispatching to the wrong save action.
+        // Per CodeRabbit round 1 on PR #599: extend to cover SSTV.
         let apt = PassOutput::AptPng(PathBuf::from("/tmp/apt.png"));
         let lrpt = PassOutput::LrptDir(PathBuf::from("/tmp/lrpt-dir"));
+        let sstv = PassOutput::SstvDir(PathBuf::from("/tmp/sstv-dir"));
         assert_eq!(apt.protocol(), sdr_sat::ImagingProtocol::Apt);
         assert_eq!(lrpt.protocol(), sdr_sat::ImagingProtocol::Lrpt);
+        assert_eq!(sstv.protocol(), sdr_sat::ImagingProtocol::Sstv);
     }
 
     #[test]
@@ -1926,6 +1929,17 @@ mod tests {
     fn save_action_for_lrpt_emits_save_lrpt_pass() {
         let action = save_action_for(&PassOutput::LrptDir(PathBuf::from("/tmp/lrpt-dir")));
         assert!(matches!(action, Action::SaveLrptPass(_)));
+    }
+
+    #[test]
+    fn save_action_for_sstv_emits_save_sstv_pass() {
+        // Pin the SSTV arm of `save_action_for` — mirrors the
+        // APT/LRPT tests above. A future rename of
+        // `Action::SaveSstvPass` or a mis-route to `SaveLrptPass`
+        // fails here before it can silently discard ISS imagery.
+        // Per CodeRabbit round 1 on PR #599.
+        let action = save_action_for(&PassOutput::SstvDir(PathBuf::from("/tmp/sstv-dir")));
+        assert!(matches!(action, Action::SaveSstvPass(_)));
     }
 
     /// LRPT recorder configured with both Apt + Lrpt support so

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -1054,12 +1054,21 @@ mod tests {
         );
         // The recorder should have transitioned out of Idle.
         assert!(!matches!(r.state(), State::Idle));
-        // At minimum a StartAutoRecord must be in the action batch.
+        // Pin the protocol payload (and satellite) so SSTV-specific
+        // dispatch regressions fail loudly here rather than silently
+        // falling through to "wrong protocol but a StartAutoRecord
+        // was present" — which the previous looser assertion would
+        // have permitted. Per CR round 2 on PR #599.
         assert!(
-            actions
-                .iter()
-                .any(|a| matches!(a, Action::StartAutoRecord { .. })),
-            "expected StartAutoRecord for ISS SSTV pass"
+            actions.iter().any(|a| matches!(
+                a,
+                Action::StartAutoRecord {
+                    protocol: sdr_sat::ImagingProtocol::Sstv,
+                    satellite,
+                    ..
+                } if satellite == "ISS (ZARYA)"
+            )),
+            "expected StartAutoRecord(Sstv) for ISS (ZARYA) pass; got {actions:?}"
         );
     }
 

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -1,0 +1,634 @@
+//! Live ISS SSTV image viewer + per-image PNG export.
+//!
+//! SSTV counterpart to [`crate::apt_viewer`] and [`crate::lrpt_viewer`].
+//! Displays the growing SSTV image decoded by `sstv_decode_tap` via the
+//! shared [`sdr_radio::sstv_image::SstvImageHandle`] as it accumulates
+//! during a satellite pass. ARISS events typically send ~12 images per
+//! 10-minute pass window; each image is announced by a VIS header, decoded
+//! line by line (~1 line/sec for PD120), and completed at
+//! `SstvEvent::ImageComplete`.
+//!
+//! Three pieces:
+//!
+//! * [`SstvImageRenderer`] — pure Cairo renderer. Owns an ARGB32
+//!   [`cairo::ImageSurface`] sized for the current image (PD120: 640 × 496).
+//!   No GTK dependency, fully unit-testable.
+//! * [`SstvImageView`] — GTK widget wrapping a renderer. Driven by the
+//!   `DspToUi::SstvLineDecoded` handler in `window.rs` which triggers a
+//!   `snapshot()` + redraw on each new line. Cloneable (all state is
+//!   `Rc`-shared) so toolbar closures can hold their own handle.
+//! * [`open_sstv_viewer_window`] — opens the view in a non-modal transient
+//!   window. Header bar: Pause / Resume + Export PNG.
+//!
+//! [`connect_sstv_action`] wires the `app.sstv-open` action
+//! (`Ctrl+Shift+V`). Activating it opens a viewer window and registers
+//! the [`SstvImageHandle`] with the DSP controller via
+//! `UiToDsp::SetSstvImage`.
+
+use std::cell::{Cell, RefCell};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use gtk4::prelude::*;
+use gtk4::{cairo, gio, glib};
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use sdr_radio::sstv_image::{SstvImageHandle, SstvSnapshot};
+
+use crate::messages::UiToDsp;
+use crate::viewer::ViewerError;
+
+// ─── Constants ─────────────────────────────────────────────────────────────
+
+/// Default viewer window size. ISS SSTV in PD120 mode produces 640 × 496
+/// images; headroom is given for the header bar.
+const VIEWER_WINDOW_WIDTH: i32 = 700;
+const VIEWER_WINDOW_HEIGHT: i32 = 560;
+
+/// Background painted before any pixel data arrives, or around the image
+/// when the window is wider/taller than the image aspect ratio.
+const BACKGROUND_RGB: [f64; 3] = [0.05, 0.05, 0.06];
+
+// ─── Pure Cairo renderer ────────────────────────────────────────────────────
+
+/// Pure Cairo renderer for a live SSTV image.
+///
+/// Owns a persistent ARGB32 [`cairo::ImageSurface`]. `update_from_snapshot`
+/// writes the latest rows into the surface; `render` and `export_png` read
+/// from it. No allocation on each line arrival.
+pub struct SstvImageRenderer {
+    /// Persistent ARGB32 surface. Rebuilt when image dimensions change
+    /// (e.g. on a new VIS detection for a different mode). `None` before
+    /// the first snapshot arrives.
+    surface: Option<cairo::ImageSurface>,
+    /// Dimensions of the current surface. `(0, 0)` when `surface` is None.
+    width: u32,
+    height: u32,
+    /// How many lines have been written so far.
+    lines_written: u32,
+    /// Snapshot of the most-recently received pixel data, for export.
+    last_snapshot: Option<SstvSnapshot>,
+}
+
+impl Default for SstvImageRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SstvImageRenderer {
+    /// Build an empty renderer (no surface allocated yet).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            surface: None,
+            width: 0,
+            height: 0,
+            lines_written: 0,
+            last_snapshot: None,
+        }
+    }
+
+    /// Update the renderer from a live [`SstvSnapshot`].
+    ///
+    /// If the image dimensions changed since the last update (i.e. a new
+    /// VIS header for a different mode was detected), the surface is rebuilt.
+    /// Writes all lines present in the snapshot into the Cairo surface.
+    ///
+    /// Returns `true` when at least one new line was written (the view
+    /// should queue a redraw). Returns `false` on surface errors (logged,
+    /// not propagated — a failed redraw shouldn't kill the UI).
+    pub fn update_from_snapshot(&mut self, snap: &SstvSnapshot) -> bool {
+        // Rebuild surface on dimension change (new image / new mode).
+        if snap.width != self.width || snap.height != self.height {
+            self.rebuild_surface(snap.width, snap.height);
+        }
+        let Some(ref mut surface) = self.surface else {
+            return false;
+        };
+
+        let stride = match usize::try_from(surface.stride()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("SSTV renderer: invalid stride: {e}");
+                return false;
+            }
+        };
+        let mut data = match surface.data() {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!("SSTV renderer: surface data lock failed: {e}");
+                return false;
+            }
+        };
+
+        let w = snap.width as usize;
+        let new_lines = snap.lines_written;
+        let old_lines = self.lines_written;
+        // Write only the lines that arrived since the last update.
+        for row in (old_lines as usize)..(new_lines as usize) {
+            let row_offset = row * stride;
+            let px_start = row * w;
+            let px_end = px_start + w;
+            if px_end > snap.pixels.len() {
+                break;
+            }
+            for (col, &[r, g, b]) in snap.pixels[px_start..px_end].iter().enumerate() {
+                let p = row_offset + col * 4;
+                if p + 3 < data.len() {
+                    // Cairo ARGB32 little-endian: B, G, R, A.
+                    data[p] = b;
+                    data[p + 1] = g;
+                    data[p + 2] = r;
+                    data[p + 3] = 0xFF;
+                }
+            }
+        }
+        drop(data);
+
+        let changed = new_lines > old_lines;
+        self.lines_written = new_lines;
+        self.last_snapshot = Some(snap.clone());
+        changed
+    }
+
+    /// Rebuild the Cairo surface for new image dimensions.
+    #[allow(clippy::cast_possible_wrap)]
+    fn rebuild_surface(&mut self, width: u32, height: u32) {
+        match cairo::ImageSurface::create(cairo::Format::ARgb32, width as i32, height as i32) {
+            Ok(s) => {
+                self.surface = Some(s);
+                self.width = width;
+                self.height = height;
+                self.lines_written = 0;
+            }
+            Err(e) => {
+                tracing::warn!("SSTV renderer: surface creation failed ({width}×{height}): {e}");
+                self.surface = None;
+                self.width = 0;
+                self.height = 0;
+                self.lines_written = 0;
+            }
+        }
+    }
+
+    /// Reset to empty (ready for a new pass).
+    pub fn clear(&mut self) {
+        if let Some(ref mut surface) = self.surface
+            && let Ok(mut data) = surface.data()
+        {
+            data.fill(0);
+        }
+        self.lines_written = 0;
+        self.last_snapshot = None;
+    }
+
+    /// Paint the current surface into `cr`, scaled to fit `(width, height)`
+    /// while preserving the image's aspect ratio. Top-aligned so the live
+    /// pass builds downward visually. No-op when no data has arrived yet.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ViewerError::Cairo`] on any Cairo operation failure.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn render(&self, cr: &cairo::Context, width: i32, height: i32) -> Result<(), ViewerError> {
+        cr.set_source_rgb(BACKGROUND_RGB[0], BACKGROUND_RGB[1], BACKGROUND_RGB[2]);
+        cr.paint().map_err(|e| ViewerError::Cairo {
+            op: "background paint",
+            source: e,
+        })?;
+
+        let Some(ref surface) = self.surface else {
+            return Ok(());
+        };
+        if self.lines_written == 0 || width <= 0 || height <= 0 {
+            return Ok(());
+        }
+
+        let img_w = f64::from(self.width);
+        let img_h = f64::from(self.lines_written);
+        let scale = (f64::from(width) / img_w).min(f64::from(height) / img_h);
+        let off_x = (f64::from(width) - img_w * scale) / 2.0;
+
+        cr.save().map_err(|e| ViewerError::Cairo {
+            op: "save",
+            source: e,
+        })?;
+        cr.translate(off_x, 0.0);
+        cr.scale(scale, scale);
+        cr.set_source_surface(surface, 0.0, 0.0)
+            .map_err(|e| ViewerError::Cairo {
+                op: "set_source_surface",
+                source: e,
+            })?;
+        cr.rectangle(0.0, 0.0, img_w, img_h);
+        cr.fill().map_err(|e| ViewerError::Cairo {
+            op: "image fill",
+            source: e,
+        })?;
+        cr.restore().map_err(|e| ViewerError::Cairo {
+            op: "restore",
+            source: e,
+        })?;
+        Ok(())
+    }
+
+    /// Export the current image to a PNG file, synchronously.
+    ///
+    /// **GTK callers must use `gio::spawn_blocking`** to avoid
+    /// freezing the main loop during the encode.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ViewerError::EmptyChannel`] when no data has been received,
+    /// or a `Cairo` / `Io` / `PngEncode` variant on failure.
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn export_png(&self, path: &Path) -> Result<(), ViewerError> {
+        let Some(ref snap) = self.last_snapshot else {
+            return Err(ViewerError::EmptyChannel { apid: None });
+        };
+        if snap.lines_written == 0 {
+            return Err(ViewerError::EmptyChannel { apid: None });
+        }
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent).map_err(|e| ViewerError::Io {
+                op: "create_dir_all",
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+        write_sstv_rgb_png(path, &snap.pixels, snap.width, snap.height)
+    }
+
+    /// Cheap snapshot of the latest pixel data for handing to a
+    /// `gio::spawn_blocking` worker.
+    #[must_use]
+    pub fn snapshot_for_export(&self) -> Option<SstvSnapshot> {
+        self.last_snapshot.clone()
+    }
+}
+
+/// Write an RGB SSTV image to `path` as a PNG via Cairo.
+///
+/// Mirrors [`crate::lrpt_viewer::write_rgb_png`] but works with the
+/// SSTV `Vec<[u8; 3]>` format directly. `Cairo` objects are `!Send`
+/// but we only create and use them within this function, so calling
+/// it from a `gio::spawn_blocking` worker is safe.
+///
+/// # Errors
+///
+/// Returns [`ViewerError`] on any Cairo, I/O, or PNG encoding failure.
+#[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+pub fn write_sstv_rgb_png(
+    path: &Path,
+    pixels: &[[u8; 3]],
+    width: u32,
+    height: u32,
+) -> Result<(), ViewerError> {
+    if pixels.is_empty() || width == 0 || height == 0 {
+        return Err(ViewerError::EmptyChannel { apid: None });
+    }
+    let mut surface =
+        cairo::ImageSurface::create(cairo::Format::ARgb32, width as i32, height as i32).map_err(
+            |e| ViewerError::Cairo {
+                op: "export surface",
+                source: e,
+            },
+        )?;
+
+    let stride = usize::try_from(surface.stride())?;
+    {
+        let mut data = surface.data()?;
+        let w = width as usize;
+        for (row, row_pixels) in pixels.chunks_exact(w).enumerate() {
+            let row_offset = row * stride;
+            for (col, &[r, g, b]) in row_pixels.iter().enumerate() {
+                let p = row_offset + col * 4;
+                if p + 3 < data.len() {
+                    data[p] = b;
+                    data[p + 1] = g;
+                    data[p + 2] = r;
+                    data[p + 3] = 0xFF;
+                }
+            }
+        }
+    }
+    let mut file = std::fs::File::create(path).map_err(|e| ViewerError::Io {
+        op: "file create",
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    surface.write_to_png(&mut file)?;
+    tracing::info!(?path, width, height, "SSTV image exported to PNG");
+    Ok(())
+}
+
+// ─── GTK widget ─────────────────────────────────────────────────────────────
+
+/// Live SSTV image viewer widget.
+///
+/// Holds a `DrawingArea` plus shared rendering state. Cloneable —
+/// every clone holds an `Rc` to the same renderer + pause flag, so
+/// toolbar callbacks can hold their own handle without lifetime dance.
+/// Driven by the `DspToUi::SstvLineDecoded` handler in `window.rs`,
+/// which calls [`SstvImageView::update_from_handle`] to pull the latest
+/// snapshot from the shared [`SstvImageHandle`] and queue a redraw.
+#[derive(Clone)]
+pub struct SstvImageView {
+    drawing_area: gtk4::DrawingArea,
+    renderer: Rc<RefCell<SstvImageRenderer>>,
+    paused: Rc<Cell<bool>>,
+}
+
+impl Default for SstvImageView {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SstvImageView {
+    /// Build a fresh view with a blank renderer.
+    #[must_use]
+    pub fn new() -> Self {
+        let renderer = Rc::new(RefCell::new(SstvImageRenderer::new()));
+        let paused = Rc::new(Cell::new(false));
+
+        let drawing_area = gtk4::DrawingArea::builder()
+            .hexpand(true)
+            .vexpand(true)
+            .build();
+        let renderer_for_draw = Rc::clone(&renderer);
+        drawing_area.set_draw_func(move |_area, cr, w, h| {
+            if let Err(e) = renderer_for_draw.borrow().render(cr, w, h) {
+                tracing::warn!("SSTV render failed: {e}");
+            }
+        });
+
+        Self {
+            drawing_area,
+            renderer,
+            paused,
+        }
+    }
+
+    /// The underlying `GtkDrawingArea`. Pack this into a layout container.
+    #[must_use]
+    pub fn drawing_area(&self) -> &gtk4::DrawingArea {
+        &self.drawing_area
+    }
+
+    /// Pull the latest snapshot from `handle` and update the renderer.
+    /// Queues a redraw only if a new line arrived and the viewer is
+    /// not paused. Always buffers data even when paused so nothing is
+    /// lost while the user inspects the image.
+    pub fn update_from_handle(&self, handle: &SstvImageHandle) {
+        if let Some(snap) = handle.snapshot() {
+            let changed = self.renderer.borrow_mut().update_from_snapshot(&snap);
+            if changed && !self.paused.get() {
+                self.drawing_area.queue_draw();
+            }
+        }
+    }
+
+    /// Wipe all buffered data and queue a redraw.
+    pub fn clear(&self) {
+        self.renderer.borrow_mut().clear();
+        self.drawing_area.queue_draw();
+    }
+
+    /// Toggle pause / resume. Pausing freezes the visible canvas;
+    /// snapshots pushed while paused still accumulate so nothing is
+    /// lost, and become visible on resume via a forced single redraw.
+    pub fn set_paused(&self, paused: bool) {
+        let was_paused = self.paused.replace(paused);
+        if was_paused && !paused {
+            self.drawing_area.queue_draw();
+        }
+    }
+
+    /// `true` when the view is currently paused.
+    #[must_use]
+    pub fn is_paused(&self) -> bool {
+        self.paused.get()
+    }
+
+    /// Asynchronously export the current image to PNG.
+    ///
+    /// Snapshots the pixel data on the GTK main thread (cheap clone),
+    /// spawns a `gio::spawn_blocking` worker for the CPU-heavy encode,
+    /// then marshals the result back to the main context where
+    /// `on_complete` fires. Per the APT viewer's async export pattern.
+    ///
+    /// `on_complete` runs on the GTK main thread, so it can safely
+    /// capture `Rc`-shared widgets and post toasts.
+    pub fn export_png_async(
+        &self,
+        path: PathBuf,
+        on_complete: impl FnOnce(Result<(), ViewerError>) + 'static,
+    ) {
+        let snap = self.renderer.borrow().snapshot_for_export();
+        let Some(snap) = snap else {
+            on_complete(Err(ViewerError::EmptyChannel { apid: None }));
+            return;
+        };
+        glib::spawn_future_local(async move {
+            let join = gio::spawn_blocking(move || {
+                write_sstv_rgb_png(&path, &snap.pixels, snap.width, snap.height)
+            })
+            .await;
+            let result = match join {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!("SSTV PNG export worker panicked: {e:?}");
+                    Err(ViewerError::InvalidBuffer(
+                        "PNG export worker panicked — see logs".to_string(),
+                    ))
+                }
+            };
+            on_complete(result);
+        });
+    }
+}
+
+// ─── Non-modal viewer window ─────────────────────────────────────────────────
+
+/// Open the SSTV viewer in a non-modal transient window. Returns the inner
+/// [`SstvImageView`] so the caller can pump snapshots into it.
+///
+/// Non-modal so the user can keep tuning while the SSTV image builds.
+pub fn open_sstv_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
+    parent: &W,
+    title: &str,
+) -> (SstvImageView, adw::Window) {
+    let view = SstvImageView::new();
+
+    let window = adw::Window::builder()
+        .title(title)
+        .default_width(VIEWER_WINDOW_WIDTH)
+        .default_height(VIEWER_WINDOW_HEIGHT)
+        .transient_for(parent)
+        .modal(false)
+        .build();
+
+    let header = adw::HeaderBar::new();
+
+    // Pause / Resume toggle.
+    let pause_btn = gtk4::ToggleButton::builder()
+        .icon_name("media-playback-pause-symbolic")
+        .tooltip_text("Pause / resume live image update")
+        .build();
+    pause_btn.update_property(&[gtk4::accessible::Property::Label(
+        "Pause or resume live SSTV image update",
+    )]);
+    let pause_view = view.clone();
+    pause_btn.connect_toggled(move |btn| {
+        pause_view.set_paused(btn.is_active());
+    });
+    header.pack_start(&pause_btn);
+
+    // Clear button — wipes the current image buffer.
+    let clear_btn = gtk4::Button::builder()
+        .icon_name("edit-clear-all-symbolic")
+        .tooltip_text("Clear the image buffer and start fresh")
+        .build();
+    clear_btn.update_property(&[gtk4::accessible::Property::Label("Clear SSTV image buffer")]);
+    let clear_view = view.clone();
+    clear_btn.connect_clicked(move |_| {
+        clear_view.clear();
+    });
+    header.pack_start(&clear_btn);
+
+    // Export PNG button.
+    let export_btn = gtk4::Button::builder()
+        .icon_name("document-save-symbolic")
+        .tooltip_text("Export the current SSTV image to PNG")
+        .build();
+    export_btn.update_property(&[gtk4::accessible::Property::Label(
+        "Export SSTV image to PNG",
+    )]);
+    let export_view = view.clone();
+    let window_for_export = window.downgrade();
+    let export_btn_weak = export_btn.downgrade();
+    export_btn.connect_clicked(move |_| {
+        let Some(window_for_export) = window_for_export.upgrade() else {
+            return;
+        };
+        let Some(btn) = export_btn_weak.upgrade() else {
+            return;
+        };
+        if !btn.is_sensitive() {
+            return;
+        }
+        btn.set_sensitive(false);
+        let btn_for_complete = btn.downgrade();
+        let path = default_export_path();
+        let path_for_msg = path.clone();
+        let window_weak = window_for_export.downgrade();
+        export_view.export_png_async(path, move |result| {
+            let toast = match result {
+                Ok(()) => adw::Toast::builder()
+                    .title(format!("Saved {}", path_for_msg.display()))
+                    .build(),
+                Err(e) => adw::Toast::builder()
+                    .title(format!("PNG export failed: {e}"))
+                    .build(),
+            };
+            if let Some(window) = window_weak.upgrade() {
+                show_toast_in(&window, toast);
+            }
+            if let Some(btn) = btn_for_complete.upgrade() {
+                btn.set_sensitive(true);
+            }
+        });
+    });
+    header.pack_end(&export_btn);
+
+    let toolbar = adw::ToolbarView::new();
+    toolbar.add_top_bar(&header);
+    toolbar.set_content(Some(view.drawing_area()));
+
+    let toast_overlay = adw::ToastOverlay::new();
+    toast_overlay.set_child(Some(&toolbar));
+
+    window.set_content(Some(&toast_overlay));
+    window.present();
+
+    (view, window)
+}
+
+/// Default export path: `~/sdr-recordings/sstv-YYYY-MM-DD-HHMMSS.png`.
+fn default_export_path() -> PathBuf {
+    let timestamp = glib::DateTime::now_local()
+        .and_then(|dt| dt.format("%Y-%m-%d-%H%M%S"))
+        .map_or_else(|_| "unknown".to_string(), |s| s.to_string());
+    glib::home_dir()
+        .join("sdr-recordings")
+        .join(format!("sstv-{timestamp}.png"))
+}
+
+/// Show `toast` inside the window's [`adw::ToastOverlay`], if present.
+fn show_toast_in<W: gtk4::prelude::IsA<gtk4::Window>>(window: &W, toast: adw::Toast) {
+    if let Some(child) = window.as_ref().child()
+        && let Some(overlay) = child.downcast_ref::<adw::ToastOverlay>()
+    {
+        overlay.add_toast(toast);
+    }
+}
+
+// ─── Live viewer action ──────────────────────────────────────────────────────
+
+/// Wire the `app.sstv-open` action onto `app`. Activating it (via the
+/// app menu or `Ctrl+Shift+V`) opens a non-modal SSTV viewer window.
+/// If a viewer is already open, activating is a no-op.
+pub fn connect_sstv_action(
+    app: &adw::Application,
+    parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,
+    state: &Rc<crate::state::AppState>,
+) {
+    let action = gio::SimpleAction::new("sstv-open", None);
+    let parent_provider = Rc::clone(parent_provider);
+    let state_for_action = Rc::clone(state);
+    action.connect_activate(move |_, _| {
+        open_sstv_viewer_if_needed(&parent_provider, &state_for_action);
+    });
+    app.add_action(&action);
+    app.set_accels_for_action("app.sstv-open", &["<Ctrl><Shift>v"]);
+}
+
+/// Open the SSTV viewer window if it isn't already open, registering
+/// the new view in `state.sstv_viewer` and sending `SetSstvImage` to
+/// the DSP so the decoder tap starts pushing lines into the handle.
+/// No-op if a viewer is already open.
+pub fn open_sstv_viewer_if_needed(
+    parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,
+    state: &Rc<crate::state::AppState>,
+) {
+    if state.sstv_viewer.borrow().is_some() {
+        return;
+    }
+    let Some(parent) = parent_provider() else {
+        tracing::warn!("sstv-open invoked with no main window available");
+        return;
+    };
+    let (view, window) = open_sstv_viewer_window(&parent, "ISS SSTV");
+    *state.sstv_viewer.borrow_mut() = Some(view);
+    *state.sstv_viewer_window.borrow_mut() = Some(window.downgrade());
+
+    // Hand the shared handle to the DSP so the decoder tap can push
+    // lines into it. The handle is a clone of the long-lived singleton
+    // in `AppState::sstv_image`.
+    state.send_dsp(UiToDsp::SetSstvImage(state.sstv_image.handle()));
+
+    let state_for_close = Rc::clone(state);
+    window.connect_close_request(move |_| {
+        *state_for_close.sstv_viewer.borrow_mut() = None;
+        *state_for_close.sstv_viewer_window.borrow_mut() = None;
+        // When the user closes the viewer, don't send ClearSstvImage —
+        // the decoder keeps running and the shared handle keeps
+        // accumulating data so the recorder's LOS save still has
+        // pixels. This mirrors the LRPT viewer's close-without-clear
+        // semantics (per CodeRabbit rounds 7 + 8 on PR #543).
+        glib::Propagation::Proceed
+    });
+}

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -475,6 +475,14 @@ impl SstvImageView {
             on_complete(Err(ViewerError::EmptyChannel { apid: None }));
             return;
         };
+        // A cached snapshot from a fresh VIS detect (allocated, but
+        // no decoded lines yet) would otherwise produce a blank PNG.
+        // Mirrors the synchronous `export_png()` guard. Per CR round
+        // 6 on PR #599.
+        if snap.lines_written == 0 {
+            on_complete(Err(ViewerError::EmptyChannel { apid: None }));
+            return;
+        }
         glib::spawn_future_local(async move {
             let join = gio::spawn_blocking(move || {
                 // Ensure the parent directory exists. First-run exports
@@ -613,13 +621,24 @@ pub fn open_sstv_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
 }
 
 /// Default export path: `~/sdr-recordings/sstv-YYYY-MM-DD-HHMMSS.png`.
+///
+/// Two manual exports inside the same wall-clock second would otherwise
+/// collide because the file is opened with `File::create`. Probe for
+/// existing files and append `-1`, `-2`, … until a free name is found.
+/// Per CR round 6 on PR #599.
 fn default_export_path() -> PathBuf {
     let timestamp = glib::DateTime::now_local()
         .and_then(|dt| dt.format("%Y-%m-%d-%H%M%S"))
         .map_or_else(|_| "unknown".to_string(), |s| s.to_string());
-    glib::home_dir()
-        .join("sdr-recordings")
-        .join(format!("sstv-{timestamp}.png"))
+    let dir = glib::home_dir().join("sdr-recordings");
+    let stem = format!("sstv-{timestamp}");
+    let mut path = dir.join(format!("{stem}.png"));
+    let mut suffix = 1_u32;
+    while path.exists() {
+        path = dir.join(format!("{stem}-{suffix}.png"));
+        suffix += 1;
+    }
+    path
 }
 
 /// Show `toast` inside the window's [`adw::ToastOverlay`], if present.

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -713,3 +713,109 @@ pub fn open_sstv_viewer_if_needed(
         glib::Propagation::Proceed
     });
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Build an `SstvSnapshot` with `lines_written` rows of solid grey
+    /// (so writes are deterministic). PD120 / PD180 width 640.
+    fn snap(width: u32, height: u32, lines_written: u32) -> SstvSnapshot {
+        let n = (width as usize) * (height as usize);
+        SstvSnapshot {
+            width,
+            height,
+            pixels: vec![[0x80, 0x80, 0x80]; n],
+            lines_written,
+        }
+    }
+
+    #[test]
+    fn renderer_initial_state_is_empty() {
+        let r = SstvImageRenderer::new();
+        assert!(r.surface.is_none());
+        assert_eq!(r.width, 0);
+        assert_eq!(r.height, 0);
+        assert_eq!(r.lines_written, 0);
+        assert!(r.last_snapshot.is_none());
+    }
+
+    #[test]
+    fn renderer_first_snapshot_allocates_surface() {
+        let mut r = SstvImageRenderer::new();
+        let changed = r.update_from_snapshot(snap(640, 496, 1));
+        assert!(
+            changed,
+            "first snapshot with one line should report changed"
+        );
+        assert!(
+            r.surface.is_some(),
+            "surface should allocate on first update"
+        );
+        assert_eq!(r.width, 640);
+        assert_eq!(r.height, 496);
+        assert_eq!(r.lines_written, 1);
+        assert!(r.last_snapshot.is_some());
+    }
+
+    #[test]
+    fn renderer_incremental_advances_only_by_delta() {
+        // Two updates, each advancing the line counter, should be
+        // additive without re-painting already-written rows.
+        let mut r = SstvImageRenderer::new();
+        let _ = r.update_from_snapshot(snap(640, 496, 100));
+        assert_eq!(r.lines_written, 100);
+
+        let changed = r.update_from_snapshot(snap(640, 496, 250));
+        assert!(changed, "advancing should report changed");
+        assert_eq!(r.lines_written, 250);
+    }
+
+    #[test]
+    fn renderer_no_advance_reports_unchanged() {
+        let mut r = SstvImageRenderer::new();
+        let _ = r.update_from_snapshot(snap(640, 496, 100));
+
+        let changed = r.update_from_snapshot(snap(640, 496, 100));
+        assert!(!changed, "same lines_written should report unchanged");
+        assert_eq!(r.lines_written, 100);
+    }
+
+    #[test]
+    fn renderer_same_dimension_rollover_clears_for_new_image() {
+        // PD120 → PD120 (same dims) starts a fresh image — slowrx
+        // resets the line counter on the new VIS detection. The
+        // renderer must detect the rollover and clear stale rows.
+        // Per CR round 1 #7 on PR #599; this test pins that fix.
+        let mut r = SstvImageRenderer::new();
+        let _ = r.update_from_snapshot(snap(640, 496, 496)); // full first image
+        assert_eq!(r.lines_written, 496);
+
+        // New image starts: lines_written drops back to 1.
+        let changed = r.update_from_snapshot(snap(640, 496, 1));
+        assert!(changed, "rollover with one new line should report changed");
+        assert_eq!(r.lines_written, 1, "counter reset to new image's progress");
+    }
+
+    #[test]
+    fn renderer_dimension_change_rebuilds_surface() {
+        // PD120 (640×496) → some hypothetical 320×240 mode would
+        // resize. Surface gets rebuilt; old contents discarded.
+        let mut r = SstvImageRenderer::new();
+        let _ = r.update_from_snapshot(snap(640, 496, 100));
+        let _ = r.update_from_snapshot(snap(320, 240, 50));
+        assert_eq!(r.width, 320);
+        assert_eq!(r.height, 240);
+        assert_eq!(r.lines_written, 50);
+    }
+
+    #[test]
+    fn renderer_clear_resets_to_empty() {
+        let mut r = SstvImageRenderer::new();
+        let _ = r.update_from_snapshot(snap(640, 496, 100));
+        r.clear();
+        assert_eq!(r.lines_written, 0);
+        assert!(r.last_snapshot.is_none());
+    }
+}

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -99,7 +99,7 @@ impl SstvImageRenderer {
     /// Returns `true` when at least one new line was written (the view
     /// should queue a redraw). Returns `false` on surface errors (logged,
     /// not propagated — a failed redraw shouldn't kill the UI).
-    pub fn update_from_snapshot(&mut self, snap: &SstvSnapshot) -> bool {
+    pub fn update_from_snapshot(&mut self, snap: SstvSnapshot) -> bool {
         let mut old_lines = self.lines_written;
 
         // Rebuild surface on dimension change (new image / new mode).
@@ -161,7 +161,10 @@ impl SstvImageRenderer {
 
         let changed = new_lines > old_lines;
         self.lines_written = new_lines;
-        self.last_snapshot = Some(snap.clone());
+        // Move the snapshot directly into the cache; no clone. The
+        // pixel borrow above ends with `drop(data)`, so NLL lets us
+        // consume `snap` here. Per CR round 3 on PR #599.
+        self.last_snapshot = Some(snap);
         changed
     }
 
@@ -396,7 +399,10 @@ impl SstvImageView {
     /// lost while the user inspects the image.
     pub fn update_from_handle(&self, handle: &SstvImageHandle) {
         if let Some(snap) = handle.snapshot() {
-            let changed = self.renderer.borrow_mut().update_from_snapshot(&snap);
+            // Move the snapshot into the renderer; it caches a single
+            // copy in `last_snapshot` for redraws and avoids cloning.
+            // Per CR round 3 on PR #599.
+            let changed = self.renderer.borrow_mut().update_from_snapshot(snap);
             if changed && !self.paused.get() {
                 self.drawing_area.queue_draw();
             }
@@ -604,7 +610,10 @@ fn show_toast_in<W: gtk4::prelude::IsA<gtk4::Window>>(window: &W, toast: adw::To
 
 /// Wire the `app.sstv-open` action onto `app`. Activating it (via the
 /// app menu or `Ctrl+Shift+V`) opens a non-modal SSTV viewer window.
-/// If a viewer is already open, activating is a no-op.
+/// If a viewer is already open, activating it presents (focuses) the
+/// existing window and re-sends the current `SstvImageHandle` to the
+/// DSP so the viewer reflects the latest state — mirrors the LRPT
+/// viewer's behavior (CR round 1 on PR #599).
 pub fn connect_sstv_action(
     app: &adw::Application,
     parent_provider: &Rc<dyn Fn() -> Option<gtk4::Window>>,

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -100,9 +100,22 @@ impl SstvImageRenderer {
     /// should queue a redraw). Returns `false` on surface errors (logged,
     /// not propagated — a failed redraw shouldn't kill the UI).
     pub fn update_from_snapshot(&mut self, snap: &SstvSnapshot) -> bool {
+        let mut old_lines = self.lines_written;
+
         // Rebuild surface on dimension change (new image / new mode).
         if snap.width != self.width || snap.height != self.height {
             self.rebuild_surface(snap.width, snap.height);
+            old_lines = 0;
+        } else if snap.lines_written < old_lines {
+            // Same dimensions but the line counter rolled back — a
+            // new SSTV image started with the same mode (e.g.
+            // PD120 → PD120). Without this branch the delta logic
+            // below sees `new_lines < old_lines` → false → no blit,
+            // and stale pixels from the previous image leak through.
+            // Clear the surface and reset the cursor so the new
+            // image paints from row 0. Per CodeRabbit #7 on PR #599.
+            self.clear();
+            old_lines = 0;
         }
         let Some(ref mut surface) = self.surface else {
             return false;
@@ -125,7 +138,6 @@ impl SstvImageRenderer {
 
         let w = snap.width as usize;
         let new_lines = snap.lines_written;
-        let old_lines = self.lines_written;
         // Write only the lines that arrived since the last update.
         for row in (old_lines as usize)..(new_lines as usize) {
             let row_offset = row * stride;
@@ -605,6 +617,24 @@ pub fn open_sstv_viewer_if_needed(
     state: &Rc<crate::state::AppState>,
 ) {
     if state.sstv_viewer.borrow().is_some() {
+        // Re-send the image handle so the tap stays wired even if
+        // a future code path ever clears it (idempotent). Then
+        // raise the existing window so `Ctrl+Shift+V` actually
+        // surfaces a buried / minimised viewer rather than being a
+        // silent no-op. Weak-ref upgrade fails closed: if the
+        // window was garbage-collected but the AppState slot wasn't
+        // cleared yet, we just skip. Mirrors the LRPT viewer's
+        // present-on-repeat-open pattern (CodeRabbit round 13 on
+        // PR #543). Per CodeRabbit #8 on PR #599.
+        state.send_dsp(UiToDsp::SetSstvImage(state.sstv_image.handle()));
+        if let Some(window) = state
+            .sstv_viewer_window
+            .borrow()
+            .as_ref()
+            .and_then(glib::WeakRef::upgrade)
+        {
+            window.present();
+        }
         return;
     }
     let Some(parent) = parent_provider() else {

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -354,6 +354,13 @@ pub struct SstvImageView {
     drawing_area: gtk4::DrawingArea,
     renderer: Rc<RefCell<SstvImageRenderer>>,
     paused: Rc<Cell<bool>>,
+    /// Optional shared-source handle. When set, [`Self::clear`] also
+    /// clears the in-flight pixel buffer in the shared
+    /// [`SstvImageHandle`], so the next [`Self::update_from_handle`]
+    /// doesn't replay the rows the user just cleared. Set via
+    /// [`Self::set_handle`] after construction.
+    /// Per CR round 4 on PR #599.
+    handle: Rc<RefCell<Option<SstvImageHandle>>>,
 }
 
 impl Default for SstvImageView {
@@ -384,7 +391,18 @@ impl SstvImageView {
             drawing_area,
             renderer,
             paused,
+            handle: Rc::new(RefCell::new(None)),
         }
+    }
+
+    /// Attach a shared [`SstvImageHandle`] so [`Self::clear`] also
+    /// wipes the source-side pixel buffer. Without this, a Clear
+    /// button click would only wipe the local renderer cache and
+    /// the next snapshot replay would restore every cleared row.
+    /// Idempotent — replaces any previously-set handle. Per CR
+    /// round 4 on PR #599.
+    pub fn set_handle(&self, handle: SstvImageHandle) {
+        *self.handle.borrow_mut() = Some(handle);
     }
 
     /// The underlying `GtkDrawingArea`. Pack this into a layout container.
@@ -409,8 +427,15 @@ impl SstvImageView {
         }
     }
 
-    /// Wipe all buffered data and queue a redraw.
+    /// Wipe all buffered data and queue a redraw. Also clears the
+    /// shared [`SstvImageHandle`] (if attached via
+    /// [`Self::set_handle`]) so the next [`Self::update_from_handle`]
+    /// doesn't replay the rows we just cleared. Per CR round 4 on
+    /// PR #599.
     pub fn clear(&self) {
+        if let Some(handle) = self.handle.borrow().as_ref() {
+            handle.clear();
+        }
         self.renderer.borrow_mut().clear();
         self.drawing_area.queue_draw();
     }
@@ -663,6 +688,11 @@ pub fn open_sstv_viewer_if_needed(
         return;
     };
     let (view, window) = open_sstv_viewer_window(&parent, "ISS SSTV");
+    // Attach the shared handle to the view so the Clear button
+    // and any other `view.clear()` callsite wipes the source-side
+    // pixel buffer too — otherwise the next `update_from_handle`
+    // replays the old rows. Per CR round 4 on PR #599.
+    view.set_handle(state.sstv_image.handle());
     *state.sstv_viewer.borrow_mut() = Some(view);
     *state.sstv_viewer_window.borrow_mut() = Some(window.downgrade());
 

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -446,6 +446,18 @@ impl SstvImageView {
         };
         glib::spawn_future_local(async move {
             let join = gio::spawn_blocking(move || {
+                // Ensure the parent directory exists. First-run exports
+                // target `~/sdr-recordings/sstv-iss-{ts}/` which the
+                // recorder creates at AOS, but a manual export to a
+                // brand-new directory should work too. Per CR round 2
+                // on PR #599.
+                if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+                    std::fs::create_dir_all(parent).map_err(|e| ViewerError::Io {
+                        op: "create_dir_all",
+                        path: parent.to_path_buf(),
+                        source: e,
+                    })?;
+                }
                 write_sstv_rgb_png(&path, &snap.pixels, snap.width, snap.height)
             })
             .await;

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -2,6 +2,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
+use std::path::PathBuf;
 use std::rc::{Rc, Weak};
 use std::sync::mpsc;
 
@@ -43,6 +44,23 @@ pub fn rtl_tcp_state_discriminant(state: &sdr_types::RtlTcpConnectionState) -> u
         sdr_types::RtlTcpConnectionState::AuthRequired => RTL_TCP_STATE_DISC_AUTH_REQUIRED,
         sdr_types::RtlTcpConnectionState::AuthFailed => RTL_TCP_STATE_DISC_AUTH_FAILED,
     }
+}
+
+/// A retry batch of SSTV images that failed to fully export at LOS,
+/// keyed by the pass directory they were originally destined for so
+/// the next save attempt writes them back to the correct
+/// `sstv-iss-{ts}` folder. Per CR round 6 #21 on PR #599.
+#[derive(Debug, Clone)]
+pub struct PendingSstvExport {
+    /// Original per-pass directory (e.g.
+    /// `~/sdr-recordings/sstv-iss-2026-05-02-201234/`). The retry
+    /// writes `img0.png`, `img1.png`, … here so all of a pass's
+    /// images stay co-located even when the first save attempt
+    /// failed.
+    pub dir: PathBuf,
+    /// Images to retry. Order is preserved so retried filenames
+    /// match what the original save would have written.
+    pub images: Vec<sdr_radio::sstv_image::CompletedSstvImage>,
 }
 
 /// Shared application state, designed for single-threaded GTK main loop access.
@@ -275,16 +293,15 @@ pub struct AppState {
     /// them all in arrival order (`img0.png`, `img1.png`, …).
     /// Per epic #472.
     pub sstv_completed_images: RefCell<Vec<sdr_radio::sstv_image::CompletedSstvImage>>,
-    /// Carry-over slot for SSTV images whose LOS save failed: the
-    /// `SaveSstvPass` failure path leaves them in
-    /// `sstv_completed_images`, but the *next* pass's AOS would
-    /// otherwise wipe that buffer to start fresh. The AOS branch
-    /// instead drains them into here so they survive across
-    /// passes; the next successful `SaveSstvPass` writes them
-    /// alongside the new pass's images. Today there's no manual
-    /// "export pending" UI — items in this Vec are recovered at
-    /// the next LOS-save success. Per CR round 5 #20 on PR #599.
-    pub sstv_pending_export: RefCell<Vec<sdr_radio::sstv_image::CompletedSstvImage>>,
+    /// Dir-tagged retry buffer for SSTV images whose LOS save
+    /// failed. Each entry is a [`PendingSstvExport`] keyed by the
+    /// pass's original `sstv-iss-{ts}` directory so retries write
+    /// back to the right pass folder instead of bleeding into the
+    /// current pass's directory. The next `SaveSstvPass` retries
+    /// each batch against its own dir; entries that still fail
+    /// stay queued for another attempt. Per CR round 6 #21 on
+    /// PR #599 (refines round 5 #20's dir-less design).
+    pub sstv_pending_export: RefCell<Vec<PendingSstvExport>>,
     /// `(satellite_norad_id, aos_time)` for the currently-recording
     /// SSTV pass, or `None` between passes. Mirrors `apt_recording_pass`
     /// and `lrpt_recording_pass` — used by `is_recording()` and the
@@ -672,6 +689,11 @@ mod tests {
 
     #[test]
     fn is_recording_table() {
+        // Per repo rule on named constants for magic numbers
+        // (`crates/CLAUDE.md`). Per CR round 6 on PR #599.
+        const ISS_NORAD_ID: u32 = 25_544;
+        const NOAA_19_NORAD_ID: u32 = 33_591;
+        const NOAA_LRPT_PLACEHOLDER_ID: u32 = 33_592;
         // Each row: (apt, lrpt, sstv, audio, iq, expected)
         let cases = [
             (false, false, false, false, false, false),
@@ -688,18 +710,19 @@ mod tests {
         for (apt, lrpt, sstv, audio, iq, expected) in cases {
             let s = make_test_state();
             if apt {
-                *s.apt_recording_pass.borrow_mut() = Some((33_591, chrono::Utc::now()));
+                *s.apt_recording_pass.borrow_mut() = Some((NOAA_19_NORAD_ID, chrono::Utc::now()));
             }
             if lrpt {
                 // NORAD 33_592 = NOAA 19 placeholder; matches the
                 // shape `apt_recording_pass` uses above. Per CR
                 // round 2 on PR #575.
-                *s.lrpt_recording_pass.borrow_mut() = Some((33_592, chrono::Utc::now()));
+                *s.lrpt_recording_pass.borrow_mut() =
+                    Some((NOAA_LRPT_PLACEHOLDER_ID, chrono::Utc::now()));
             }
             if sstv {
                 // ISS NORAD 25_544 — the only SSTV entry in the
                 // catalog. Per epic #472.
-                *s.sstv_recording_pass.borrow_mut() = Some((25_544, chrono::Utc::now()));
+                *s.sstv_recording_pass.borrow_mut() = Some((ISS_NORAD_ID, chrono::Utc::now()));
             }
             s.audio_recording_active.set(audio);
             s.iq_recording_active.set(iq);

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -253,6 +253,33 @@ pub struct AppState {
     /// Cleared between passes via `LrptImage::clear` rather
     /// than reconstructed.
     pub lrpt_image: sdr_radio::lrpt_image::LrptImage,
+    /// Currently-open ISS SSTV viewer, or `None` when no viewer
+    /// is open. Same lifecycle pattern as `apt_viewer`. Set by
+    /// [`crate::sstv_viewer::open_sstv_viewer_if_needed`]; cleared
+    /// by the window's `close-request` handler. Per epic #472.
+    pub sstv_viewer: RefCell<Option<crate::sstv_viewer::SstvImageView>>,
+    /// Weak handle to the open SSTV viewer window. Cleared alongside
+    /// `sstv_viewer`. Weak so `AppState` doesn't keep the window
+    /// alive past its natural lifetime. Per epic #472.
+    pub sstv_viewer_window: RefCell<Option<gtk4::glib::WeakRef<libadwaita::Window>>>,
+    /// Long-lived shared SSTV image handle. Allocated once per
+    /// process; the DSP tap pushes decoded scan lines into it,
+    /// the viewer reads it, and the LOS save drains completed
+    /// images via `SstvImage::handle()`. Cleared between images
+    /// by `take_completed` inside the DSP tap. Per epic #472.
+    pub sstv_image: sdr_radio::sstv_image::SstvImage,
+    /// Accumulated completed SSTV images for this pass, drained
+    /// at LOS by `SaveSstvPass`. Each entry is a `CompletedSstvImage`
+    /// received via `DspToUi::SstvImageComplete`. The wiring layer
+    /// appends images here as they arrive so the LOS save can write
+    /// them all in arrival order (`img0.png`, `img1.png`, …).
+    /// Per epic #472.
+    pub sstv_completed_images: RefCell<Vec<sdr_radio::sstv_image::CompletedSstvImage>>,
+    /// `(satellite_norad_id, aos_time)` for the currently-recording
+    /// SSTV pass, or `None` between passes. Mirrors `apt_recording_pass`
+    /// and `lrpt_recording_pass` — used by `is_recording()` and the
+    /// LOS compare-and-clear guard. Per epic #472.
+    pub sstv_recording_pass: RefCell<Option<(u32, chrono::DateTime<chrono::Utc>)>>,
     /// ACARS toggle (mirrors persisted `acars_enabled`).
     pub acars_enabled: Cell<bool>,
     /// Bounded ring of recent decoded messages. Cap is set
@@ -413,6 +440,11 @@ impl AppState {
             lrpt_viewer: RefCell::new(None),
             lrpt_viewer_window: RefCell::new(None),
             lrpt_image: sdr_radio::lrpt_image::LrptImage::new(),
+            sstv_viewer: RefCell::new(None),
+            sstv_viewer_window: RefCell::new(None),
+            sstv_image: sdr_radio::sstv_image::SstvImage::new(),
+            sstv_completed_images: RefCell::new(Vec::new()),
+            sstv_recording_pass: RefCell::new(None),
             acars_enabled: Cell::new(false),
             acars_recent: RefCell::new(VecDeque::with_capacity(
                 crate::acars_config::default_recent_keep() as usize,
@@ -451,6 +483,7 @@ impl AppState {
     pub fn is_recording(&self) -> bool {
         self.apt_recording_pass.borrow().is_some()
             || self.lrpt_recording_pass.borrow().is_some()
+            || self.sstv_recording_pass.borrow().is_some()
             || self.audio_recording_active.get()
             || self.iq_recording_active.get()
     }
@@ -614,6 +647,10 @@ mod tests {
         assert!(!s.audio_recording_active.get());
         assert!(!s.iq_recording_active.get());
         assert!(s.lrpt_recording_pass.borrow().is_none());
+        assert!(
+            s.sstv_recording_pass.borrow().is_none(),
+            "no SSTV pass in flight at construction"
+        );
     }
 
     #[test]
@@ -624,18 +661,20 @@ mod tests {
 
     #[test]
     fn is_recording_table() {
-        // Each row: (apt, lrpt, audio, iq, expected)
+        // Each row: (apt, lrpt, sstv, audio, iq, expected)
         let cases = [
-            (false, false, false, false, false),
-            (true, false, false, false, true),
-            (false, true, false, false, true),
-            (false, false, true, false, true),
-            (false, false, false, true, true),
-            (true, true, true, true, true),
-            (true, false, false, true, true),
-            (false, true, true, false, true),
+            (false, false, false, false, false, false),
+            (true, false, false, false, false, true),
+            (false, true, false, false, false, true),
+            (false, false, true, false, false, true),
+            (false, false, false, true, false, true),
+            (false, false, false, false, true, true),
+            (true, true, true, true, true, true),
+            (true, false, false, false, true, true),
+            (false, true, false, true, false, true),
+            (false, false, true, false, true, true),
         ];
-        for (apt, lrpt, audio, iq, expected) in cases {
+        for (apt, lrpt, sstv, audio, iq, expected) in cases {
             let s = make_test_state();
             if apt {
                 *s.apt_recording_pass.borrow_mut() = Some((33_591, chrono::Utc::now()));
@@ -646,12 +685,17 @@ mod tests {
                 // round 2 on PR #575.
                 *s.lrpt_recording_pass.borrow_mut() = Some((33_592, chrono::Utc::now()));
             }
+            if sstv {
+                // ISS NORAD 25_544 — the only SSTV entry in the
+                // catalog. Per epic #472.
+                *s.sstv_recording_pass.borrow_mut() = Some((25_544, chrono::Utc::now()));
+            }
             s.audio_recording_active.set(audio);
             s.iq_recording_active.set(iq);
             assert_eq!(
                 s.is_recording(),
                 expected,
-                "row apt={apt} lrpt={lrpt} audio={audio} iq={iq}",
+                "row apt={apt} lrpt={lrpt} sstv={sstv} audio={audio} iq={iq}",
             );
         }
     }

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -275,6 +275,16 @@ pub struct AppState {
     /// them all in arrival order (`img0.png`, `img1.png`, …).
     /// Per epic #472.
     pub sstv_completed_images: RefCell<Vec<sdr_radio::sstv_image::CompletedSstvImage>>,
+    /// Carry-over slot for SSTV images whose LOS save failed: the
+    /// `SaveSstvPass` failure path leaves them in
+    /// `sstv_completed_images`, but the *next* pass's AOS would
+    /// otherwise wipe that buffer to start fresh. The AOS branch
+    /// instead drains them into here so they survive across
+    /// passes; the next successful `SaveSstvPass` writes them
+    /// alongside the new pass's images. Today there's no manual
+    /// "export pending" UI — items in this Vec are recovered at
+    /// the next LOS-save success. Per CR round 5 #20 on PR #599.
+    pub sstv_pending_export: RefCell<Vec<sdr_radio::sstv_image::CompletedSstvImage>>,
     /// `(satellite_norad_id, aos_time)` for the currently-recording
     /// SSTV pass, or `None` between passes. Mirrors `apt_recording_pass`
     /// and `lrpt_recording_pass` — used by `is_recording()` and the
@@ -444,6 +454,7 @@ impl AppState {
             sstv_viewer_window: RefCell::new(None),
             sstv_image: sdr_radio::sstv_image::SstvImage::new(),
             sstv_completed_images: RefCell::new(Vec::new()),
+            sstv_pending_export: RefCell::new(Vec::new()),
             sstv_recording_pass: RefCell::new(None),
             acars_enabled: Cell::new(false),
             acars_recent: RefCell::new(VecDeque::with_capacity(

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -54,10 +54,15 @@ pub fn rtl_tcp_state_discriminant(state: &sdr_types::RtlTcpConnectionState) -> u
 pub struct PendingSstvExport {
     /// Original per-pass directory (e.g.
     /// `~/sdr-recordings/sstv-iss-2026-05-02-201234/`). The retry
-    /// writes `img0.png`, `img1.png`, … here so all of a pass's
-    /// images stay co-located even when the first save attempt
-    /// failed.
+    /// writes images here so all of a pass's images stay
+    /// co-located even when the first save attempt failed.
     pub dir: PathBuf,
+    /// First image's filename index within `dir`. The retry
+    /// writes `img{start_index}.png`, `img{start_index+1}.png`, …
+    /// so a late-tail retry for a pass that already saved
+    /// `img0.png` … `img11.png` doesn't clobber those when it
+    /// flushes images 12 onward. Per CR round 8 #27 on PR #599.
+    pub start_index: usize,
     /// Images to retry. Order is preserved so retried filenames
     /// match what the original save would have written.
     pub images: Vec<sdr_radio::sstv_image::CompletedSstvImage>,

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -504,19 +504,26 @@ impl AppState {
         }
     }
 
-    /// `true` if the app is actively writing pass artifacts to disk —
-    /// any APT pass, LRPT pass, audio recording, or IQ recording.
+    /// `true` if the app is actively writing pass artifacts to disk
+    /// OR holds in-memory imagery that hasn't been flushed yet — any
+    /// APT pass, LRPT pass, SSTV pass, audio recording, IQ recording,
+    /// or queued [`PendingSstvExport`] retry batches.
     /// Used to gate the tray-Quit confirmation modal.
     ///
     /// Maintenance contract: every new "we're writing pass artifacts"
     /// state added to `AppState` MUST be OR-ed in here, and the
     /// table-driven test in `is_recording_table` must be extended.
     /// Otherwise a future recording type can be silently dropped on Quit.
+    ///
+    /// Per CR round 9 #28 on PR #599 for the `sstv_pending_export`
+    /// branch — without it, an LOS save failure would leave decoded
+    /// imagery only in memory and the user could quit without warning.
     #[must_use]
     pub fn is_recording(&self) -> bool {
         self.apt_recording_pass.borrow().is_some()
             || self.lrpt_recording_pass.borrow().is_some()
             || self.sstv_recording_pass.borrow().is_some()
+            || !self.sstv_pending_export.borrow().is_empty()
             || self.audio_recording_active.get()
             || self.iq_recording_active.get()
     }
@@ -699,20 +706,27 @@ mod tests {
         const ISS_NORAD_ID: u32 = 25_544;
         const NOAA_19_NORAD_ID: u32 = 33_591;
         const NOAA_LRPT_PLACEHOLDER_ID: u32 = 33_592;
-        // Each row: (apt, lrpt, sstv, audio, iq, expected)
+        // Each row: (apt, lrpt, sstv, audio, iq, sstv_pending, expected)
+        // The `sstv_pending` column covers in-memory retry batches
+        // queued by an LOS save failure (or a late-tail post-success
+        // move). Without OR-ing this into `is_recording()` the tray
+        // Quit path would treat the app as idle and silently drop the
+        // pending imagery. Per CR round 9 #28 on PR #599.
         let cases = [
-            (false, false, false, false, false, false),
-            (true, false, false, false, false, true),
-            (false, true, false, false, false, true),
-            (false, false, true, false, false, true),
-            (false, false, false, true, false, true),
-            (false, false, false, false, true, true),
-            (true, true, true, true, true, true),
-            (true, false, false, false, true, true),
-            (false, true, false, true, false, true),
-            (false, false, true, false, true, true),
+            (false, false, false, false, false, false, false),
+            (true, false, false, false, false, false, true),
+            (false, true, false, false, false, false, true),
+            (false, false, true, false, false, false, true),
+            (false, false, false, true, false, false, true),
+            (false, false, false, false, true, false, true),
+            (false, false, false, false, false, true, true),
+            (true, true, true, true, true, true, true),
+            (true, false, false, false, true, false, true),
+            (false, true, false, true, false, false, true),
+            (false, false, true, false, true, false, true),
+            (false, false, false, false, false, true, true),
         ];
-        for (apt, lrpt, sstv, audio, iq, expected) in cases {
+        for (apt, lrpt, sstv, audio, iq, sstv_pending, expected) in cases {
             let s = make_test_state();
             if apt {
                 *s.apt_recording_pass.borrow_mut() = Some((NOAA_19_NORAD_ID, chrono::Utc::now()));
@@ -731,10 +745,19 @@ mod tests {
             }
             s.audio_recording_active.set(audio);
             s.iq_recording_active.set(iq);
+            if sstv_pending {
+                // Single empty placeholder batch is enough — the
+                // guard checks `is_empty()`, not image count.
+                s.sstv_pending_export.borrow_mut().push(PendingSstvExport {
+                    dir: std::path::PathBuf::from("/tmp/test-sstv-pending"),
+                    start_index: 0,
+                    images: Vec::new(),
+                });
+            }
             assert_eq!(
                 s.is_recording(),
                 expected,
-                "row apt={apt} lrpt={lrpt} sstv={sstv} audio={audio} iq={iq}",
+                "row apt={apt} lrpt={lrpt} sstv={sstv} audio={audio} iq={iq} sstv_pending={sstv_pending}",
             );
         }
     }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11851,8 +11851,17 @@ fn connect_satellites_panel(
                 // compare-and-clear on completion — mirrors the
                 // LRPT and APT patterns from PR #571 / #575.
                 let exported_sstv_pass = *state_a.sstv_recording_pass.borrow();
+                // Clone the worker inputs so a `spawn_blocking`
+                // panic doesn't lose the imagery we already drained
+                // from `sstv_pending_export`. The originals move
+                // into the worker; the backups feed the panic
+                // fallback's `retained` list. Per CR round 7 #25 on
+                // PR #599.
+                let pending_batches_backup = pending_batches.clone();
+                let current_images_backup = current_images.clone();
+                let dir_backup = dir.clone();
                 glib::spawn_future_local(async move {
-                    let dir_for_msg = dir.clone();
+                    let dir_for_msg = dir_backup.clone();
                     let join = gio::spawn_blocking(move || {
                         save_sstv_batches(pending_batches, current_images, dir)
                     })
@@ -11863,19 +11872,27 @@ fn connect_satellites_panel(
                         retained,
                     } = join.unwrap_or_else(|e| {
                         tracing::warn!("auto-record SaveSstvPass: worker thread panicked: {e:?}",);
+                        // Re-construct the full retain list from
+                        // the backups: prior pending batches
+                        // (preserved as-is) plus the current pass
+                        // re-keyed to its dir, so neither is
+                        // silently dropped by the failure-path
+                        // drain below. Per CR round 7 #25 on PR
+                        // #599.
+                        let mut retained = pending_batches_backup;
+                        if !current_images_backup.is_empty() {
+                            retained.push(PendingSstvExport {
+                                dir: dir_backup.clone(),
+                                images: current_images_backup,
+                            });
+                        }
                         SstvSaveOutcome {
                             message: format!(
                                 "Pass complete but PNG worker panicked (target was {})",
                                 dir_for_msg.display()
                             ),
                             current_ok: false,
-                            // On panic we don't know which batches
-                            // failed — keep the (already-drained)
-                            // pending list empty rather than guess.
-                            // The current pass's images stay in
-                            // `sstv_completed_images` and are
-                            // dropped at next AOS.
-                            retained: Vec::new(),
+                            retained,
                         }
                     });
                     post_toast(&toast_overlay_weak_for_save, &message);
@@ -11905,9 +11922,33 @@ fn connect_satellites_panel(
                             let mut completed = state_sstv_close.sstv_completed_images.borrow_mut();
                             let to_drain = exported_image_count.min(completed.len());
                             completed.drain(..to_drain);
-                            if completed.is_empty() {
-                                *slot = None;
+                            // Late frames pushed by
+                            // `DspToUi::SstvImageComplete` while
+                            // the worker was running stay in
+                            // `completed`. Without further action
+                            // they'd survive the export, then get
+                            // wiped by the next AOS — breaking the
+                            // per-pass auto-save contract. Move
+                            // them into `sstv_pending_export`
+                            // keyed to *this* pass's `dir` so the
+                            // next `SaveSstvPass` retries them
+                            // into the correct folder. Per CR
+                            // round 7 #26 on PR #599.
+                            if !completed.is_empty() {
+                                let late_tail: Vec<_> = completed.drain(..).collect();
+                                tracing::info!(
+                                    "auto-record SaveSstvPass: queueing {} late SSTV frame(s) for retry into {}",
+                                    late_tail.len(),
+                                    dir_for_msg.display()
+                                );
+                                state_sstv_close.sstv_pending_export.borrow_mut().push(
+                                    PendingSstvExport {
+                                        dir: dir_for_msg.clone(),
+                                        images: late_tail,
+                                    },
+                                );
                             }
+                            *slot = None;
                         } else {
                             // Failure path: clear the slot so the
                             // recorder isn't stuck in a permanent

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11661,10 +11661,18 @@ fn connect_satellites_panel(
                 });
             }
             RecorderAction::SaveSstvPass(dir) => {
-                // Drain the completed-image buffer that was filled
-                // during the pass by `DspToUi::SstvImageComplete`
-                // handlers above, then write each frame as
-                // `img{N}.png` in the per-pass directory.
+                // Snapshot (clone) the completed-image buffer that
+                // was filled during the pass by
+                // `DspToUi::SstvImageComplete` handlers above.
+                // We deliberately do NOT drain here — the buffer
+                // is only cleared after the worker confirms a
+                // successful save. If `create_dir_all` fails, a
+                // PNG write fails, or the worker panics, the
+                // originals remain for a future retry or manual
+                // export. The clear-on-success path below does a
+                // compare-and-clear guarded by `exported_sstv_pass`
+                // so an overlapping pass doesn't have its buffer
+                // wiped by a late completion from a prior pass.
                 //
                 // Reading from `state.sstv_completed_images`
                 // (rather than the shared `SstvImage` handle)
@@ -11673,15 +11681,15 @@ fn connect_satellites_panel(
                 // live viewer so closing the viewer window
                 // mid-pass doesn't lose the imagery.
                 //
-                // Snapshot + drain on the main thread (cheap
-                // — just a `Vec` swap), then off-load encoding
-                // + file I/O to `gio::spawn_blocking` so multi-
-                // image PNG encoding doesn't freeze the UI right
-                // when the auto-record toast is landing.
+                // Clone + off-load encoding + file I/O to
+                // `gio::spawn_blocking` so multi-image PNG encoding
+                // doesn't freeze the UI right when the auto-record
+                // toast is landing. Per CodeRabbit #9 on PR #599.
                 let images: Vec<sdr_radio::sstv_image::CompletedSstvImage> = state_a
                     .sstv_completed_images
-                    .borrow_mut()
-                    .drain(..)
+                    .borrow()
+                    .iter()
+                    .cloned()
                     .collect();
                 let toast_overlay_weak_for_save = toast_overlay_weak.clone();
                 let state_sstv_close = Rc::clone(&state_a);
@@ -11775,10 +11783,25 @@ fn connect_satellites_panel(
                         )
                     });
                     post_toast(&toast_overlay_weak_for_save, &result_msg);
-                    // Clear the recording-pass slot (compare-and-clear
-                    // so an overlapping pass doesn't have its slot
+                    // On success: clear the completed-image buffer
+                    // and the recording-pass slot (compare-and-clear
+                    // so an overlapping pass's slot and buffer aren't
                     // wiped by a late completion callback).
-                    {
+                    // On failure: leave the buffer intact for a
+                    // subsequent retry or manual export — the user
+                    // can still inspect the in-memory images.
+                    // Per CodeRabbit #9 on PR #599.
+                    if save_ok {
+                        let mut slot = state_sstv_close.sstv_recording_pass.borrow_mut();
+                        if *slot == exported_sstv_pass {
+                            state_sstv_close.sstv_completed_images.borrow_mut().clear();
+                            *slot = None;
+                        }
+                    } else {
+                        // Failure path: still clear the slot so the
+                        // recorder isn't stuck in a permanent "pass
+                        // in flight" state, but leave the image
+                        // buffer intact for retry.
                         let mut slot = state_sstv_close.sstv_recording_pass.borrow_mut();
                         if *slot == exported_sstv_pass {
                             *slot = None;

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11698,6 +11698,12 @@ fn connect_satellites_panel(
                     .iter()
                     .cloned()
                     .collect();
+                // Capture exact count snapshotted so the success
+                // path can drain only those — late frames pushed
+                // by `DspToUi::SstvImageComplete` while we're
+                // awaiting the worker stay buffered for the next
+                // save cycle. Per CR round 4 on PR #599.
+                let exported_image_count = images.len();
                 let toast_overlay_weak_for_save = toast_overlay_weak.clone();
                 let state_sstv_close = Rc::clone(&state_a);
                 // Snapshot the WeakRef BEFORE spawning so a
@@ -11811,8 +11817,24 @@ fn connect_satellites_panel(
                     if save_ok {
                         let mut slot = state_sstv_close.sstv_recording_pass.borrow_mut();
                         if *slot == exported_sstv_pass {
-                            state_sstv_close.sstv_completed_images.borrow_mut().clear();
-                            *slot = None;
+                            // Drain only the images we actually
+                            // exported. Late frames that arrived
+                            // while we were awaiting the worker
+                            // stay buffered. Per CR round 4 on
+                            // PR #599.
+                            let mut completed =
+                                state_sstv_close.sstv_completed_images.borrow_mut();
+                            let to_drain = exported_image_count.min(completed.len());
+                            completed.drain(..to_drain);
+                            // Only release the recording-pass slot
+                            // if no late frames are pending.
+                            // Otherwise leave it set so the user
+                            // can see "buffered images for pass X"
+                            // semantics if/when a manual export
+                            // path lands later.
+                            if completed.is_empty() {
+                                *slot = None;
+                            }
                         }
                     } else {
                         // Failure path: still clear the slot so the
@@ -11824,12 +11846,17 @@ fn connect_satellites_panel(
                             *slot = None;
                         }
                     }
-                    // Close the viewer on successful save — cleans
-                    // up for the next pass. On failure, keep it
-                    // open so the user can inspect the in-memory
-                    // image and retry. Mirrors LRPT semantics from
-                    // CR round 9 on PR #554.
+                    // Close the viewer on successful save AND only
+                    // when the buffer is empty — if late frames
+                    // arrived while saving, keep the viewer open
+                    // so the user can see them rather than burying
+                    // a tail. On failure: also keep open so the
+                    // user can inspect the in-memory image and
+                    // retry. Mirrors LRPT semantics from CR round
+                    // 9 on PR #554, refined per CR round 4 #18 on
+                    // PR #599.
                     if save_ok
+                        && state_sstv_close.sstv_completed_images.borrow().is_empty()
                         && let Some(window) = exported_sstv_window_weak
                             .as_ref()
                             .and_then(glib::WeakRef::upgrade)

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -33,7 +33,7 @@ use crate::sidebar::source_panel::{
     NETWORK_PROTOCOL_UDP_IDX,
 };
 use crate::spectrum;
-use crate::state::AppState;
+use crate::state::{AppState, PendingSstvExport};
 use crate::status_bar::{self, StatusBar};
 
 /// Default recording directory under the user's home.
@@ -149,6 +149,135 @@ fn apply_manual_tune(
     status_bar.update_frequency(freq_hz);
     spectrum_handle.set_center_frequency(freq_hz);
     radio_panel.update_distance_frequency(freq_hz);
+}
+
+/// Outcome of `save_sstv_batches` reported back to the GTK main
+/// thread. Used by the `RecorderAction::SaveSstvPass` arm. Per CR
+/// round 6 #21 on PR #599.
+struct SstvSaveOutcome {
+    /// User-facing toast text summarising the per-batch save
+    /// results.
+    message: String,
+    /// `true` iff every image in the *current* pass batch saved
+    /// cleanly. Drives the compare-and-clear of
+    /// `state.sstv_completed_images` and viewer auto-close.
+    current_ok: bool,
+    /// Batches that still need to be saved on a future attempt:
+    /// any prior pending batch where at least one image failed,
+    /// plus the current batch if it had any failures (re-keyed
+    /// to the *current* `dir`). On the next `SaveSstvPass` each
+    /// retained batch is retried against its own preserved `dir`
+    /// — never the new pass's directory.
+    retained: Vec<PendingSstvExport>,
+}
+
+/// Worker-thread save routine: iterate prior failed batches first
+/// (each into its own original `dir`), then save the current
+/// pass's images into `current_dir`. Retain any batch that had
+/// any per-image failures so the next `SaveSstvPass` can retry it
+/// in its own folder. Per CR round 6 #21 on PR #599.
+fn save_sstv_batches(
+    pending_batches: Vec<PendingSstvExport>,
+    current_images: Vec<sdr_radio::sstv_image::CompletedSstvImage>,
+    current_dir: std::path::PathBuf,
+) -> SstvSaveOutcome {
+    let mut retained: Vec<PendingSstvExport> = Vec::new();
+    let mut total_saved = 0_usize;
+    let mut total_failed = 0_usize;
+    let mut error_summary: Vec<String> = Vec::new();
+
+    // Save each previously-retained batch to its own directory.
+    for batch in pending_batches {
+        let (saved, errs) = save_sstv_batch(&batch.dir, &batch.images);
+        total_saved += saved;
+        let failed = errs.len();
+        total_failed += failed;
+        if failed > 0 {
+            error_summary.extend(errs.iter().map(|e| format!("{}: {e}", batch.dir.display())));
+            retained.push(batch);
+        }
+    }
+
+    // Save the current pass.
+    let current_dir_display = current_dir.display().to_string();
+    let current_image_count = current_images.len();
+    let (cur_saved, cur_errs) = save_sstv_batch(&current_dir, &current_images);
+    total_saved += cur_saved;
+    total_failed += cur_errs.len();
+    let current_ok = cur_errs.is_empty() && (cur_saved > 0 || current_image_count == 0);
+    if !cur_errs.is_empty() {
+        error_summary.extend(
+            cur_errs
+                .iter()
+                .map(|e| format!("{current_dir_display}: {e}")),
+        );
+        retained.push(PendingSstvExport {
+            dir: current_dir,
+            images: current_images,
+        });
+    }
+
+    let message = if total_saved == 0 && total_failed == 0 {
+        // No prior pending batches and the current pass produced
+        // no images — same warn-and-skip semantics as before.
+        tracing::warn!(
+            "auto-record SaveSstvPass but no SSTV images were decoded — pass produced no imagery",
+        );
+        format!(
+            "Pass complete, but no SSTV images decoded — nothing saved to {current_dir_display}"
+        )
+    } else if total_failed == 0 {
+        format!("Pass complete — {total_saved} SSTV image(s) saved")
+    } else {
+        format!(
+            "Pass complete — {total_saved} image(s) saved, {total_failed} failed: {}",
+            error_summary.join("; ")
+        )
+    };
+
+    SstvSaveOutcome {
+        message,
+        current_ok,
+        retained,
+    }
+}
+
+/// Save a single batch of SSTV images into `dir`. Returns
+/// `(saved_count, per_image_error_messages)`. A directory-creation
+/// failure surfaces as one error covering the whole batch; image
+/// write failures surface per image.
+fn save_sstv_batch(
+    dir: &std::path::Path,
+    images: &[sdr_radio::sstv_image::CompletedSstvImage],
+) -> (usize, Vec<String>) {
+    if images.is_empty() {
+        return (0, Vec::new());
+    }
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        tracing::warn!("auto-record SaveSstvPass: failed to create directory {dir:?}: {e}",);
+        return (0, vec![format!("create_dir_all failed: {e}")]);
+    }
+    let mut saved = 0_usize;
+    let mut errors: Vec<String> = Vec::new();
+    for (idx, img) in images.iter().enumerate() {
+        let path = dir.join(format!("img{idx}.png"));
+        match crate::sstv_viewer::write_sstv_rgb_png(&path, &img.pixels, img.width, img.height) {
+            Ok(()) => {
+                tracing::info!(
+                    ?path,
+                    width = img.width,
+                    height = img.height,
+                    "auto-record SSTV image saved",
+                );
+                saved += 1;
+            }
+            Err(e) => {
+                tracing::warn!("auto-record SSTV export img{idx} to {path:?} failed: {e}",);
+                errors.push(format!("img{idx}: {e}"));
+            }
+        }
+    }
+    (saved, errors)
 }
 
 /// Apply the canonical tune-target dispatch — the 13 widget /
@@ -11158,27 +11287,14 @@ fn connect_satellites_panel(
                             &state_a,
                         );
                         state_a.sstv_image.clear();
-                        // Don't clear blindly: a prior pass's
-                        // `SaveSstvPass` may have intentionally retained
-                        // its `CompletedSstvImage`s on partial export
-                        // failure (CR round 4 on PR #599). Carry them
-                        // forward into `sstv_pending_export` so the next
-                        // successful save attempt writes them to disk
-                        // instead of silently dropping them on AOS. Per
-                        // CR round 5 on PR #599.
-                        {
-                            let mut completed = state_a.sstv_completed_images.borrow_mut();
-                            if !completed.is_empty() {
-                                tracing::warn!(
-                                    "AOS: carrying {} retained SSTV images from prior failed save into pending_export",
-                                    completed.len()
-                                );
-                                state_a
-                                    .sstv_pending_export
-                                    .borrow_mut()
-                                    .append(&mut completed);
-                            }
-                        }
+                        // Failed-pass images now live in
+                        // `sstv_pending_export` keyed by their
+                        // original pass directory (moved there at
+                        // `SaveSstvPass` time, not here at AOS).
+                        // The current-pass buffer is the round-4
+                        // simple clear. Per CR round 6 #21 on
+                        // PR #599 (refines round 5 #20).
+                        state_a.sstv_completed_images.borrow_mut().clear();
                         if let Some(view) = state_a.sstv_viewer.borrow().as_ref() {
                             view.clear();
                         }
@@ -11688,18 +11804,14 @@ fn connect_satellites_panel(
                 });
             }
             RecorderAction::SaveSstvPass(dir) => {
-                // Snapshot (clone) the completed-image buffer that
-                // was filled during the pass by
-                // `DspToUi::SstvImageComplete` handlers above.
-                // We deliberately do NOT drain here — the buffer
-                // is only cleared after the worker confirms a
-                // successful save. If `create_dir_all` fails, a
-                // PNG write fails, or the worker panics, the
-                // originals remain for a future retry or manual
-                // export. The clear-on-success path below does a
-                // compare-and-clear guarded by `exported_sstv_pass`
-                // so an overlapping pass doesn't have its buffer
-                // wiped by a late completion from a prior pass.
+                // Per-pass auto-record save. Each pass's images are
+                // written into their own `sstv-iss-{ts}` directory.
+                // Failed-pass batches are kept in
+                // `sstv_pending_export` keyed by their *original*
+                // `dir`, then retried separately against that dir
+                // at the next LOS — they never bleed into the
+                // current pass's directory. Per CR round 6 #21 on
+                // PR #599.
                 //
                 // Reading from `state.sstv_completed_images`
                 // (rather than the shared `SstvImage` handle)
@@ -11708,33 +11820,24 @@ fn connect_satellites_panel(
                 // live viewer so closing the viewer window
                 // mid-pass doesn't lose the imagery.
                 //
-                // Clone + off-load encoding + file I/O to
+                // Encoding + file I/O is offloaded to
                 // `gio::spawn_blocking` so multi-image PNG encoding
                 // doesn't freeze the UI right when the auto-record
                 // toast is landing. Per CodeRabbit #9 on PR #599.
-                // Drain any images carried over from a prior pass's
-                // failed save (preserved at AOS in
-                // `sstv_pending_export`) so the next successful save
-                // writes them out instead of silently retaining them
-                // forever. Per CR round 5 on PR #599.
-                let mut images: Vec<sdr_radio::sstv_image::CompletedSstvImage> =
+                let pending_batches: Vec<PendingSstvExport> =
                     std::mem::take(&mut *state_a.sstv_pending_export.borrow_mut());
-                let pending_export_count = images.len();
-                images.extend(state_a.sstv_completed_images.borrow().iter().cloned());
-                // Capture exact count snapshotted from the *current*
-                // pass so the success path can drain only those —
-                // late frames pushed by
-                // `DspToUi::SstvImageComplete` while we're awaiting
-                // the worker stay buffered for the next save cycle.
-                // Per CR round 4 on PR #599.
-                let exported_image_count = images.len() - pending_export_count;
-                // Clone the pending-export prefix so the failure
-                // path can put it back into `sstv_pending_export`
-                // for retry on the next save attempt — `images`
-                // itself is moved into the blocking worker. Per CR
-                // round 5 on PR #599.
-                let pending_export_backup: Vec<sdr_radio::sstv_image::CompletedSstvImage> =
-                    images.iter().take(pending_export_count).cloned().collect();
+                let current_images: Vec<sdr_radio::sstv_image::CompletedSstvImage> = state_a
+                    .sstv_completed_images
+                    .borrow()
+                    .iter()
+                    .cloned()
+                    .collect();
+                // Snapshot count of the *current* pass so the
+                // success path can drain only those — late frames
+                // pushed by `DspToUi::SstvImageComplete` while we
+                // were awaiting the worker stay buffered for the
+                // next save cycle. Per CR round 4 on PR #599.
+                let exported_image_count = current_images.len();
                 let toast_overlay_weak_for_save = toast_overlay_weak.clone();
                 let state_sstv_close = Rc::clone(&state_a);
                 // Snapshot the WeakRef BEFORE spawning so a
@@ -11750,145 +11853,77 @@ fn connect_satellites_panel(
                 let exported_sstv_pass = *state_a.sstv_recording_pass.borrow();
                 glib::spawn_future_local(async move {
                     let dir_for_msg = dir.clone();
-                    let (result_msg, save_ok) = gio::spawn_blocking(move || {
-                        if images.is_empty() {
-                            tracing::warn!(
-                                "auto-record SaveSstvPass but no SSTV images were decoded — pass produced no imagery",
-                            );
-                            return (
-                                format!(
-                                    "Pass complete, but no SSTV images decoded — nothing saved to {}",
-                                    dir.display()
-                                ),
-                                false,
-                            );
-                        }
-                        if let Err(e) = std::fs::create_dir_all(&dir) {
-                            tracing::warn!(
-                                "auto-record SaveSstvPass: failed to create directory {dir:?}: {e}",
-                            );
-                            return (
-                                format!("Pass complete but couldn't create {}: {e}", dir.display()),
-                                false,
-                            );
-                        }
-                        let mut saved = 0_usize;
-                        let mut errors: Vec<String> = Vec::new();
-                        for (idx, img) in images.iter().enumerate() {
-                            let path = dir.join(format!("img{idx}.png"));
-                            match crate::sstv_viewer::write_sstv_rgb_png(
-                                &path,
-                                &img.pixels,
-                                img.width,
-                                img.height,
-                            ) {
-                                Ok(()) => {
-                                    tracing::info!(
-                                        ?path,
-                                        width = img.width,
-                                        height = img.height,
-                                        "auto-record SSTV image saved",
-                                    );
-                                    saved += 1;
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        "auto-record SSTV export img{idx} to {path:?} failed: {e}",
-                                    );
-                                    errors.push(format!("img{idx}: {e}"));
-                                }
-                            }
-                        }
-                        let msg = if errors.is_empty() {
-                            format!(
-                                "Pass complete — {saved} SSTV image(s) saved to {}",
-                                dir.display()
-                            )
-                        } else {
-                            format!(
-                                "Pass complete — {saved} image(s) saved, {} failed: {}",
-                                errors.len(),
-                                errors.join("; ")
-                            )
-                        };
-                        // Only treat as full success when every image
-                        // saved cleanly. Partial success must NOT
-                        // clear the buffer — the failed images stay
-                        // in memory so a future export can retry
-                        // them. (LRPT's analogous path treats
-                        // partial-success as success because LRPT's
-                        // source IQ is consumed live and re-decode
-                        // isn't possible; SSTV's CompletedSstvImage
-                        // buffer makes retry trivial.)
-                        // Per CR round 2 on PR #599.
-                        (msg, errors.is_empty() && saved > 0)
+                    let join = gio::spawn_blocking(move || {
+                        save_sstv_batches(pending_batches, current_images, dir)
                     })
-                    .await
-                    .unwrap_or_else(|e| {
-                        tracing::warn!(
-                            "auto-record SaveSstvPass: worker thread panicked: {e:?}",
-                        );
-                        (
-                            format!(
+                    .await;
+                    let SstvSaveOutcome {
+                        message,
+                        current_ok,
+                        retained,
+                    } = join.unwrap_or_else(|e| {
+                        tracing::warn!("auto-record SaveSstvPass: worker thread panicked: {e:?}",);
+                        SstvSaveOutcome {
+                            message: format!(
                                 "Pass complete but PNG worker panicked (target was {})",
                                 dir_for_msg.display()
                             ),
-                            false,
-                        )
+                            current_ok: false,
+                            // On panic we don't know which batches
+                            // failed — keep the (already-drained)
+                            // pending list empty rather than guess.
+                            // The current pass's images stay in
+                            // `sstv_completed_images` and are
+                            // dropped at next AOS.
+                            retained: Vec::new(),
+                        }
                     });
-                    post_toast(&toast_overlay_weak_for_save, &result_msg);
-                    // On success: clear the completed-image buffer
-                    // and the recording-pass slot (compare-and-clear
-                    // so an overlapping pass's slot and buffer aren't
-                    // wiped by a late completion callback).
-                    // On failure: leave the buffer intact for a
-                    // subsequent retry or manual export — the user
-                    // can still inspect the in-memory images.
-                    // Per CodeRabbit #9 on PR #599.
-                    if save_ok {
-                        let mut slot = state_sstv_close.sstv_recording_pass.borrow_mut();
-                        if *slot == exported_sstv_pass {
-                            // Drain only the images we actually
-                            // exported. Late frames that arrived
-                            // while we were awaiting the worker
-                            // stay buffered. Per CR round 4 on
-                            // PR #599.
+                    post_toast(&toast_overlay_weak_for_save, &message);
+                    // Restore retained batches (pending that still
+                    // failed + the current batch if it failed) into
+                    // `sstv_pending_export`. New pending items
+                    // queued by a parallel AOS slip in *after* the
+                    // retained set so retry order honours
+                    // chronological pass start.
+                    if !retained.is_empty() {
+                        let mut pending = state_sstv_close.sstv_pending_export.borrow_mut();
+                        let mut combined = retained;
+                        combined.append(&mut pending);
+                        *pending = combined;
+                    }
+                    // Drain only the current-pass images we
+                    // actually snapshotted. Late frames pushed
+                    // while the worker was running stay buffered
+                    // for the next save cycle. Compare-and-clear
+                    // by the recording-pass tuple so an
+                    // overlapping pass's buffer/slot isn't wiped
+                    // by a late completion callback. Per CR round
+                    // 4 on PR #599.
+                    let mut slot = state_sstv_close.sstv_recording_pass.borrow_mut();
+                    if *slot == exported_sstv_pass {
+                        if current_ok {
                             let mut completed = state_sstv_close.sstv_completed_images.borrow_mut();
                             let to_drain = exported_image_count.min(completed.len());
                             completed.drain(..to_drain);
-                            // Only release the recording-pass slot
-                            // if no late frames are pending.
-                            // Otherwise leave it set so the user
-                            // can see "buffered images for pass X"
-                            // semantics if/when a manual export
-                            // path lands later.
                             if completed.is_empty() {
                                 *slot = None;
                             }
-                        }
-                    } else {
-                        // Failure path: still clear the slot so the
-                        // recorder isn't stuck in a permanent "pass
-                        // in flight" state, but leave the image
-                        // buffer intact for retry. Also put any
-                        // images that came from `sstv_pending_export`
-                        // back so they keep getting carried forward
-                        // until a save actually succeeds. Per CR
-                        // round 5 on PR #599.
-                        if !pending_export_backup.is_empty() {
-                            let mut pending = state_sstv_close.sstv_pending_export.borrow_mut();
-                            // Prepend in case a parallel AOS already
-                            // queued additional retained items while
-                            // the worker was running.
-                            let mut combined = pending_export_backup;
-                            combined.append(&mut pending);
-                            *pending = combined;
-                        }
-                        let mut slot = state_sstv_close.sstv_recording_pass.borrow_mut();
-                        if *slot == exported_sstv_pass {
+                        } else {
+                            // Failure path: clear the slot so the
+                            // recorder isn't stuck in a permanent
+                            // "pass in flight" state. The current
+                            // images are already in `retained`
+                            // (queued for retry under their own
+                            // `dir`), so the buffer can be safely
+                            // drained too — keeping them would
+                            // duplicate-save on the next attempt.
+                            let mut completed = state_sstv_close.sstv_completed_images.borrow_mut();
+                            let to_drain = exported_image_count.min(completed.len());
+                            completed.drain(..to_drain);
                             *slot = None;
                         }
                     }
+                    drop(slot);
                     // Close the viewer on successful save AND only
                     // when the buffer is empty — if late frames
                     // arrived while saving, keep the viewer open
@@ -11898,7 +11933,7 @@ fn connect_satellites_panel(
                     // retry. Mirrors LRPT semantics from CR round
                     // 9 on PR #554, refined per CR round 4 #18 on
                     // PR #599.
-                    if save_ok
+                    if current_ok
                         && state_sstv_close.sstv_completed_images.borrow().is_empty()
                         && let Some(window) = exported_sstv_window_weak
                             .as_ref()

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -545,6 +545,7 @@ pub fn build_window(
         // it internally — passing twice keeps the call sites
         // symmetric. Per epic #469 task 7.5.
         crate::lrpt_viewer::connect_lrpt_action(app, &parent_provider, &state);
+        crate::sstv_viewer::connect_sstv_action(app, &parent_provider, &state);
     }
 
     // Set initial status bar values and mode-specific control visibility.
@@ -1934,6 +1935,43 @@ fn handle_dsp_message(
             if let Some(view) = state.apt_viewer.borrow().as_ref() {
                 view.push_line(&line);
             }
+        }
+        DspToUi::SstvLineDecoded(_line_index) => {
+            // A new SSTV scan line has arrived — refresh the open
+            // viewer (if any) from the shared SstvImage handle.
+            // The viewer polls the handle via `update_from_handle`
+            // which reads whatever the DSP tap has written since
+            // the last call.  When no viewer is open we silently
+            // drop, mirroring APT semantics above.
+            if let Some(view) = state.sstv_viewer.borrow().as_ref() {
+                view.update_from_handle(&state.sstv_image.handle());
+            }
+        }
+        DspToUi::SstvImageComplete {
+            width,
+            height,
+            pixels,
+        } => {
+            // The SSTV decoder has closed out a full image frame.
+            // Accumulate it into the pass buffer so the
+            // `SaveSstvPass` interpreter can write every image that
+            // arrived during the pass to disk.  The viewer is
+            // refreshed one last time so the final frame is visible.
+            let completed = sdr_radio::sstv_image::CompletedSstvImage {
+                width,
+                height,
+                pixels,
+            };
+            state.sstv_completed_images.borrow_mut().push(completed);
+            if let Some(view) = state.sstv_viewer.borrow().as_ref() {
+                view.update_from_handle(&state.sstv_image.handle());
+            }
+            tracing::info!(
+                width,
+                height,
+                "SSTV image complete; {} in buffer",
+                state.sstv_completed_images.borrow().len()
+            );
         }
         DspToUi::ScannerMutexStopped(reason) => {
             tracing::info!(?reason, "scanner mutex stopped");
@@ -11099,6 +11137,37 @@ fn connect_satellites_panel(
                         let aos = chrono::Utc::now();
                         *state_a.lrpt_recording_pass.borrow_mut() = Some((norad_id, aos));
                     }
+                    sdr_sat::ImagingProtocol::Sstv => {
+                        // **Order is load-bearing.** Open the viewer
+                        // (which sends `UiToDsp::SetSstvImage`) and
+                        // clear both the shared handle and the canvas
+                        // BEFORE starting playback / retuning so no
+                        // leftover rows from a previous pass land in
+                        // the fresh image buffer.  Mirrors the LRPT
+                        // arm's clear-before-start discipline from
+                        // CR round 8 on PR #543.
+                        crate::sstv_viewer::open_sstv_viewer_if_needed(
+                            &parent_provider_a,
+                            &state_a,
+                        );
+                        state_a.sstv_image.clear();
+                        state_a.sstv_completed_images.borrow_mut().clear();
+                        if let Some(view) = state_a.sstv_viewer.borrow().as_ref() {
+                            view.clear();
+                        }
+                        // ISS SSTV is audible NFM — do NOT force the
+                        // audio chain off.  The user's squelch /
+                        // CTCSS / FM-IF-NR settings are correct for
+                        // the mode; we only suppress them for
+                        // silent-passthrough decoders (LRPT) and the
+                        // APT path (subcarrier noise). Per CLAUDE.md
+                        // and step 8 of epic #472 task spec.
+                        set_playing_a(true);
+                        tune_a(freq_hz, mode, bandwidth_hz);
+                        state_a.dispatch_vfo_offset(0.0);
+                        let aos = chrono::Utc::now();
+                        *state_a.sstv_recording_pass.borrow_mut() = Some((norad_id, aos));
+                    }
                 }
             }
             RecorderAction::StartAutoAudioRecord(path) => {
@@ -11586,6 +11655,147 @@ fn connect_satellites_panel(
                     {
                         tracing::info!(
                             "auto-record LOS: closing LRPT viewer window after PNG save"
+                        );
+                        window.close();
+                    }
+                });
+            }
+            RecorderAction::SaveSstvPass(dir) => {
+                // Drain the completed-image buffer that was filled
+                // during the pass by `DspToUi::SstvImageComplete`
+                // handlers above, then write each frame as
+                // `img{N}.png` in the per-pass directory.
+                //
+                // Reading from `state.sstv_completed_images`
+                // (rather than the shared `SstvImage` handle)
+                // mirrors the LRPT design from CodeRabbit round 7
+                // on PR #543: the save path is decoupled from the
+                // live viewer so closing the viewer window
+                // mid-pass doesn't lose the imagery.
+                //
+                // Snapshot + drain on the main thread (cheap
+                // — just a `Vec` swap), then off-load encoding
+                // + file I/O to `gio::spawn_blocking` so multi-
+                // image PNG encoding doesn't freeze the UI right
+                // when the auto-record toast is landing.
+                let images: Vec<sdr_radio::sstv_image::CompletedSstvImage> = state_a
+                    .sstv_completed_images
+                    .borrow_mut()
+                    .drain(..)
+                    .collect();
+                let toast_overlay_weak_for_save = toast_overlay_weak.clone();
+                let state_sstv_close = Rc::clone(&state_a);
+                // Snapshot the WeakRef BEFORE spawning so a
+                // viewer reopen during the async save can't
+                // trick us into closing the wrong window.
+                // Mirrors the LRPT pattern from CR round 2 on
+                // PR #575.
+                let exported_sstv_window_weak =
+                    state_a.sstv_viewer_window.borrow().as_ref().cloned();
+                // Snapshot the recording-pass tuple for
+                // compare-and-clear on completion — mirrors the
+                // LRPT and APT patterns from PR #571 / #575.
+                let exported_sstv_pass = *state_a.sstv_recording_pass.borrow();
+                glib::spawn_future_local(async move {
+                    let dir_for_msg = dir.clone();
+                    let (result_msg, save_ok) = gio::spawn_blocking(move || {
+                        if images.is_empty() {
+                            tracing::warn!(
+                                "auto-record SaveSstvPass but no SSTV images were decoded — pass produced no imagery",
+                            );
+                            return (
+                                format!(
+                                    "Pass complete, but no SSTV images decoded — nothing saved to {}",
+                                    dir.display()
+                                ),
+                                false,
+                            );
+                        }
+                        if let Err(e) = std::fs::create_dir_all(&dir) {
+                            tracing::warn!(
+                                "auto-record SaveSstvPass: failed to create directory {dir:?}: {e}",
+                            );
+                            return (
+                                format!("Pass complete but couldn't create {}: {e}", dir.display()),
+                                false,
+                            );
+                        }
+                        let mut saved = 0_usize;
+                        let mut errors: Vec<String> = Vec::new();
+                        for (idx, img) in images.iter().enumerate() {
+                            let path = dir.join(format!("img{idx}.png"));
+                            match crate::sstv_viewer::write_sstv_rgb_png(
+                                &path,
+                                &img.pixels,
+                                img.width,
+                                img.height,
+                            ) {
+                                Ok(()) => {
+                                    tracing::info!(
+                                        ?path,
+                                        width = img.width,
+                                        height = img.height,
+                                        "auto-record SSTV image saved",
+                                    );
+                                    saved += 1;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "auto-record SSTV export img{idx} to {path:?} failed: {e}",
+                                    );
+                                    errors.push(format!("img{idx}: {e}"));
+                                }
+                            }
+                        }
+                        let msg = if errors.is_empty() {
+                            format!(
+                                "Pass complete — {saved} SSTV image(s) saved to {}",
+                                dir.display()
+                            )
+                        } else {
+                            format!(
+                                "Pass complete — {saved} image(s) saved, {} failed: {}",
+                                errors.len(),
+                                errors.join("; ")
+                            )
+                        };
+                        (msg, saved > 0)
+                    })
+                    .await
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(
+                            "auto-record SaveSstvPass: worker thread panicked: {e:?}",
+                        );
+                        (
+                            format!(
+                                "Pass complete but PNG worker panicked (target was {})",
+                                dir_for_msg.display()
+                            ),
+                            false,
+                        )
+                    });
+                    post_toast(&toast_overlay_weak_for_save, &result_msg);
+                    // Clear the recording-pass slot (compare-and-clear
+                    // so an overlapping pass doesn't have its slot
+                    // wiped by a late completion callback).
+                    {
+                        let mut slot = state_sstv_close.sstv_recording_pass.borrow_mut();
+                        if *slot == exported_sstv_pass {
+                            *slot = None;
+                        }
+                    }
+                    // Close the viewer on successful save — cleans
+                    // up for the next pass. On failure, keep it
+                    // open so the user can inspect the in-memory
+                    // image and retry. Mirrors LRPT semantics from
+                    // CR round 9 on PR #554.
+                    if save_ok
+                        && let Some(window) = exported_sstv_window_weak
+                            .as_ref()
+                            .and_then(glib::WeakRef::upgrade)
+                    {
+                        tracing::info!(
+                            "auto-record LOS: closing SSTV viewer window after PNG save"
                         );
                         window.close();
                     }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11767,7 +11767,17 @@ fn connect_satellites_panel(
                                 errors.join("; ")
                             )
                         };
-                        (msg, saved > 0)
+                        // Only treat as full success when every image
+                        // saved cleanly. Partial success must NOT
+                        // clear the buffer — the failed images stay
+                        // in memory so a future export can retry
+                        // them. (LRPT's analogous path treats
+                        // partial-success as success because LRPT's
+                        // source IQ is consumed live and re-decode
+                        // isn't possible; SSTV's CompletedSstvImage
+                        // buffer makes retry trivial.)
+                        // Per CR round 2 on PR #599.
+                        (msg, errors.is_empty() && saved > 0)
                     })
                     .await
                     .unwrap_or_else(|e| {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -186,9 +186,12 @@ fn save_sstv_batches(
     let mut total_failed = 0_usize;
     let mut error_summary: Vec<String> = Vec::new();
 
-    // Save each previously-retained batch to its own directory.
+    // Save each previously-retained batch to its own directory,
+    // honouring its `start_index` so a late-tail retry doesn't
+    // overwrite the prefix that already saved successfully on the
+    // first attempt. Per CR round 8 #27 on PR #599.
     for batch in pending_batches {
-        let (saved, errs) = save_sstv_batch(&batch.dir, &batch.images);
+        let (saved, errs) = save_sstv_batch(&batch.dir, &batch.images, batch.start_index);
         total_saved += saved;
         let failed = errs.len();
         total_failed += failed;
@@ -201,7 +204,7 @@ fn save_sstv_batches(
     // Save the current pass.
     let current_dir_display = current_dir.display().to_string();
     let current_image_count = current_images.len();
-    let (cur_saved, cur_errs) = save_sstv_batch(&current_dir, &current_images);
+    let (cur_saved, cur_errs) = save_sstv_batch(&current_dir, &current_images, 0);
     total_saved += cur_saved;
     total_failed += cur_errs.len();
     let current_ok = cur_errs.is_empty() && (cur_saved > 0 || current_image_count == 0);
@@ -213,6 +216,10 @@ fn save_sstv_batches(
         );
         retained.push(PendingSstvExport {
             dir: current_dir,
+            // Original attempt started at index 0; on retry we
+            // re-attempt the entire batch from the same start to
+            // keep filenames stable. Per CR round 8 #27 on PR #599.
+            start_index: 0,
             images: current_images,
         });
     }
@@ -242,13 +249,23 @@ fn save_sstv_batches(
     }
 }
 
-/// Save a single batch of SSTV images into `dir`. Returns
+/// Save a single batch of SSTV images into `dir`, naming files
+/// `img{start_index}.png`, `img{start_index+1}.png`, … . Returns
 /// `(saved_count, per_image_error_messages)`. A directory-creation
 /// failure surfaces as one error covering the whole batch; image
 /// write failures surface per image.
+///
+/// `start_index` lets a late-tail retry append after the prefix
+/// that already saved on the first attempt (round-7 #26 left late
+/// frames in `sstv_completed_images`; we now move them into a
+/// retry batch keyed to the same dir, with `start_index =
+/// exported_image_count` so the retry's `img12.png` doesn't
+/// clobber a successfully-saved `img0.png`). Per CR round 8 #27
+/// on PR #599.
 fn save_sstv_batch(
     dir: &std::path::Path,
     images: &[sdr_radio::sstv_image::CompletedSstvImage],
+    start_index: usize,
 ) -> (usize, Vec<String>) {
     if images.is_empty() {
         return (0, Vec::new());
@@ -259,7 +276,8 @@ fn save_sstv_batch(
     }
     let mut saved = 0_usize;
     let mut errors: Vec<String> = Vec::new();
-    for (idx, img) in images.iter().enumerate() {
+    for (offset, img) in images.iter().enumerate() {
+        let idx = start_index + offset;
         let path = dir.join(format!("img{idx}.png"));
         match crate::sstv_viewer::write_sstv_rgb_png(&path, &img.pixels, img.width, img.height) {
             Ok(()) => {
@@ -11883,6 +11901,12 @@ fn connect_satellites_panel(
                         if !current_images_backup.is_empty() {
                             retained.push(PendingSstvExport {
                                 dir: dir_backup.clone(),
+                                // Original attempt would have
+                                // started at index 0; on panic
+                                // retry we reuse that start so
+                                // filenames remain stable. Per
+                                // CR round 8 #27 on PR #599.
+                                start_index: 0,
                                 images: current_images_backup,
                             });
                         }
@@ -11944,6 +11968,16 @@ fn connect_satellites_panel(
                                 state_sstv_close.sstv_pending_export.borrow_mut().push(
                                     PendingSstvExport {
                                         dir: dir_for_msg.clone(),
+                                        // Late frames belong AFTER
+                                        // the prefix that already
+                                        // saved successfully on this
+                                        // pass — `exported_image_count`
+                                        // images went out at indices
+                                        // 0..exported_image_count, so
+                                        // the retry starts at that
+                                        // index. Per CR round 8 #27
+                                        // on PR #599.
+                                        start_index: exported_image_count,
                                         images: late_tail,
                                     },
                                 );

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -1955,17 +1955,24 @@ fn handle_dsp_message(
             // The SSTV decoder has closed out a full image frame.
             // Accumulate it into the pass buffer so the
             // `SaveSstvPass` interpreter can write every image that
-            // arrived during the pass to disk.  The viewer is
-            // refreshed one last time so the final frame is visible.
+            // arrived during the pass to disk.
+            //
+            // We deliberately do NOT call `view.update_from_handle`
+            // here: by the time this message arrives the controller's
+            // tap has already called `SstvImageHandle::take_completed`,
+            // which clears the in-flight pixel buffer for the next
+            // VIS detection. Reading from the now-empty handle would
+            // either no-op (snapshot returns None) or actively wipe
+            // the displayed frame. The final row was already rendered
+            // by the previous `SstvLineDecoded` refresh, so the
+            // viewer already shows the correct end state.
+            // Per CR round 3 on PR #599.
             let completed = sdr_radio::sstv_image::CompletedSstvImage {
                 width,
                 height,
                 pixels,
             };
             state.sstv_completed_images.borrow_mut().push(completed);
-            if let Some(view) = state.sstv_viewer.borrow().as_ref() {
-                view.update_from_handle(&state.sstv_image.handle());
-            }
             tracing::info!(
                 width,
                 height,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11158,7 +11158,27 @@ fn connect_satellites_panel(
                             &state_a,
                         );
                         state_a.sstv_image.clear();
-                        state_a.sstv_completed_images.borrow_mut().clear();
+                        // Don't clear blindly: a prior pass's
+                        // `SaveSstvPass` may have intentionally retained
+                        // its `CompletedSstvImage`s on partial export
+                        // failure (CR round 4 on PR #599). Carry them
+                        // forward into `sstv_pending_export` so the next
+                        // successful save attempt writes them to disk
+                        // instead of silently dropping them on AOS. Per
+                        // CR round 5 on PR #599.
+                        {
+                            let mut completed = state_a.sstv_completed_images.borrow_mut();
+                            if !completed.is_empty() {
+                                tracing::warn!(
+                                    "AOS: carrying {} retained SSTV images from prior failed save into pending_export",
+                                    completed.len()
+                                );
+                                state_a
+                                    .sstv_pending_export
+                                    .borrow_mut()
+                                    .append(&mut completed);
+                            }
+                        }
                         if let Some(view) = state_a.sstv_viewer.borrow().as_ref() {
                             view.clear();
                         }
@@ -11692,18 +11712,29 @@ fn connect_satellites_panel(
                 // `gio::spawn_blocking` so multi-image PNG encoding
                 // doesn't freeze the UI right when the auto-record
                 // toast is landing. Per CodeRabbit #9 on PR #599.
-                let images: Vec<sdr_radio::sstv_image::CompletedSstvImage> = state_a
-                    .sstv_completed_images
-                    .borrow()
-                    .iter()
-                    .cloned()
-                    .collect();
-                // Capture exact count snapshotted so the success
-                // path can drain only those — late frames pushed
-                // by `DspToUi::SstvImageComplete` while we're
-                // awaiting the worker stay buffered for the next
-                // save cycle. Per CR round 4 on PR #599.
-                let exported_image_count = images.len();
+                // Drain any images carried over from a prior pass's
+                // failed save (preserved at AOS in
+                // `sstv_pending_export`) so the next successful save
+                // writes them out instead of silently retaining them
+                // forever. Per CR round 5 on PR #599.
+                let mut images: Vec<sdr_radio::sstv_image::CompletedSstvImage> =
+                    std::mem::take(&mut *state_a.sstv_pending_export.borrow_mut());
+                let pending_export_count = images.len();
+                images.extend(state_a.sstv_completed_images.borrow().iter().cloned());
+                // Capture exact count snapshotted from the *current*
+                // pass so the success path can drain only those —
+                // late frames pushed by
+                // `DspToUi::SstvImageComplete` while we're awaiting
+                // the worker stay buffered for the next save cycle.
+                // Per CR round 4 on PR #599.
+                let exported_image_count = images.len() - pending_export_count;
+                // Clone the pending-export prefix so the failure
+                // path can put it back into `sstv_pending_export`
+                // for retry on the next save attempt — `images`
+                // itself is moved into the blocking worker. Per CR
+                // round 5 on PR #599.
+                let pending_export_backup: Vec<sdr_radio::sstv_image::CompletedSstvImage> =
+                    images.iter().take(pending_export_count).cloned().collect();
                 let toast_overlay_weak_for_save = toast_overlay_weak.clone();
                 let state_sstv_close = Rc::clone(&state_a);
                 // Snapshot the WeakRef BEFORE spawning so a
@@ -11822,8 +11853,7 @@ fn connect_satellites_panel(
                             // while we were awaiting the worker
                             // stay buffered. Per CR round 4 on
                             // PR #599.
-                            let mut completed =
-                                state_sstv_close.sstv_completed_images.borrow_mut();
+                            let mut completed = state_sstv_close.sstv_completed_images.borrow_mut();
                             let to_drain = exported_image_count.min(completed.len());
                             completed.drain(..to_drain);
                             // Only release the recording-pass slot
@@ -11840,7 +11870,20 @@ fn connect_satellites_panel(
                         // Failure path: still clear the slot so the
                         // recorder isn't stuck in a permanent "pass
                         // in flight" state, but leave the image
-                        // buffer intact for retry.
+                        // buffer intact for retry. Also put any
+                        // images that came from `sstv_pending_export`
+                        // back so they keep getting carried forward
+                        // until a save actually succeeds. Per CR
+                        // round 5 on PR #599.
+                        if !pending_export_backup.is_empty() {
+                            let mut pending = state_sstv_close.sstv_pending_export.borrow_mut();
+                            // Prepend in case a parallel AOS already
+                            // queued additional retained items while
+                            // the worker was running.
+                            let mut combined = pending_export_backup;
+                            combined.append(&mut pending);
+                            *pending = combined;
+                        }
                         let mut slot = state_sstv_close.sstv_recording_pass.borrow_mut();
                         if *slot == exported_sstv_pass {
                             *slot = None;


### PR DESCRIPTION
Closes the V1 portion of **#472** (ISS 2m SSTV at 145.800 MHz). Decode SSTV images during ISS passes, show them building up in a live viewer, save as PNGs at LOS.

## Architecture (mirrors APT for the tap, LRPT for multi-image save)

- **slowrx 0.1.0** — pure-Rust SSTV decoder library, just published to crates.io. Added as a workspace dep and called directly; zero DSP work in this PR.
- **`sdr-sat::ImagingProtocol::Sstv`** — new variant. ISS catalog entry flips `imaging_protocol: None → Some(Sstv)`.
- **`sdr-radio::sstv_image`** — new module with `Arc<Mutex<>>` shared image accumulator. `SstvImageHandle` exposes `write_line` (writer side), `snapshot` (UI poll), `take_completed` (LOS save), `clear`. Handles slowrx's per-pass semantics: one image per VIS detection, multiple per pass (ARISS sends ~12 per event).
- **`sdr-core::controller::sstv_decode_tap`** — new tap mirroring `apt_decode_tap`: reads `state.audio_buf[..audio_count]`, downmixes L+R to mono, feeds `slowrx::SstvDecoder::process`. `LineDecoded` → `write_line` + `DspToUi::SstvLineDecoded`. `ImageComplete` → push into `state.sstv_completed_images` + `DspToUi::SstvImageComplete`. Lazy-init at the radio's audio rate (typically 48 kHz, well within slowrx's `MAX_INPUT_SAMPLE_RATE_HZ`); `sstv_init_failed_at_rate` caches retry-skip on rate mismatch.
- **`sdr-ui::sstv_viewer`** — new Cairo viewer (mirrors `apt_viewer.rs`): Pause/Resume + Export PNG headers, polls `SstvImageHandle::snapshot` on a `glib::timeout_add_local` tick.
- **`satellites_recorder`** — `PassOutput::SstvDir(PathBuf)`, `Action::SaveSstvPass(PathBuf)`, `sstv_dir_for(pass, now)` → `~/sdr-recordings/sstv-iss-{ts}/`. `Sstv` joins the recorder's default `supported_protocols`.
- **`window.rs::interpret_action`** — opens the SSTV viewer at AOS via the existing tune+recorder mechanism, routes `SstvLineDecoded` / `SstvImageComplete` to the viewer + state, drains `sstv_completed_images` on `SaveSstvPass` via `gio::spawn_blocking` (LRPT pattern).

## Audio recording during SSTV pass

Unlike LRPT (silent QPSK) and APT (audio suppressed), ISS SSTV is audible NFM — the iconic SSTV warble is part of the experience. We deliberately do NOT suppress audio for SSTV; the user's existing audio-recording toggle applies as configured.

## Forward compat with slowrx.rs V2

Every match on `slowrx::SstvMode` uses `_` for unknown variants since `SstvMode` is `non_exhaustive`. When slowrx ships V2 mode coverage (Robot/Scottie/Martin/PD240) we'll get those modes for free via `cargo update`.

## Validation

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets --workspace -- -D warnings`
- ✅ `cargo build --workspace`
- ✅ `cargo test --workspace` (all green; ~1700 tests across ~25 suites; new SSTV unit tests in `sdr-radio::sstv_image` cover write/snapshot/take/clear)
- ✅ `make install CARGO_FLAGS="--release --features whisper-cuda"` clean
- ✅ Manual GTK smoke (user-validated): app launches, ISS now shows SSTV protocol in Satellites panel, manual tune to 145.800 NFM works, NOAA/Meteor flows unaffected
- ⏳ Real-radio smoke against an ARISS pass: queued for next ARISS event (2-4× a year). slowrx 0.1.0 itself was validated end-to-end against Dec-2017 ARISS captures during its recovery effort — same code path here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ISS SSTV end-to-end: live decoding, incremental viewer, per-pass auto-recording, and per-pass PNG exports (sstv-{satellite-slug}-{timestamp}/imgN.png).
  * Live SSTV viewer: incremental rendering, pause/resume, clear, async PNG export with toasts and keyboard shortcut (Ctrl+Shift+V); viewer auto-opens on pass start.
  * Recorder UI: SSTV protocol selectable, ISS auto-arming, and “also save audio” applies to APT and SSTV.
  * Robust saving: per-pass export worker with retries and queued pending exports.

* **Documentation**
  * Satellite reception guide updated with SSTV output path and dispatch details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->