### PR TITLE
chore(deps): bump slowrx 0.2 → 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "slowrx"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0509e774d20235c513a919dfff5b372dd0996ffb3edb5a1fb9636c652e9e9431"
+checksum = "c0a27e7dea5ae044a8592881559a27e039ef5d6cf7cfb1446b8c14071a8b3c3e"
 dependencies = [
  "rustfft",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ tempfile = "3"
 # `slowrx::resample::MAX_INPUT_SAMPLE_RATE_HZ` and internally resamples to
 # 11_025 Hz. Both `rustfft` and `thiserror` that slowrx brings are already
 # in the workspace dep tree, so no new transitive deps are added.
-slowrx = "0.2"
+slowrx = "0.2.1"
 
 [workspace.lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
## Summary

- Bumps the workspace `slowrx` dep from `0.2` to `0.2.1`. Upstream just shipped a PD-mode improvement that flows through to the ISS SSTV reception path (`sdr-radio::sstv_decode_tap` → `slowrx::SstvDecoder`).
- No call-site changes — the decoder API surface is unchanged.

## Test plan
- [x] `cargo build --workspace` (clean)
- [x] `cargo check --workspace --locked` (Cargo.lock in sync)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` (no new lints)
- [x] `cargo test -p sdr-radio --lib` (144 / 144 pass)
- [x] `cargo fmt --all -- --check` (no diff)
- [ ] Smoke check next ARISS pass once it's in range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workspace dependencies to latest patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->