### PR TITLE
docs(sstv): mention PD240 alongside PD120/PD180

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -926,8 +926,9 @@ fn sstv_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_c
             } => {
                 // Write into the shared image handle (if the UI wired one).
                 if let Some(ref handle) = state.sstv_image {
-                    // Derive width/height from the mode spec. PD120/PD180 are
-                    // 640 px wide; other modes vary. `SstvMode` is
+                    // Derive width/height from the mode spec. The PD
+                    // family (PD120 / PD180 / PD240) is all 640 px
+                    // wide; other modes vary. `SstvMode` is
                     // `#[non_exhaustive]` so we use the spec helper
                     // (`slowrx::for_mode` — the free function in
                     // `slowrx::modespec`, re-exported at the crate root).

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -170,9 +170,10 @@ pub enum DspToUi {
     /// only needs the index to know a new row is ready.
     ///
     /// `line_index` is 0-based. Cadence depends on the SSTV mode:
-    /// PD120 produces ~120 lines at ~1 line/sec; PD180 produces
-    /// ~180 lines. ISS ARISS events typically send ~12 images per
-    /// active pass window.
+    /// PD120 produces 248 line pairs (496 rows) over ~120 s;
+    /// PD180 over ~180 s; PD240 over ~240 s (all 640 × 496).
+    /// ISS ARISS events typically send ~12 images per active pass
+    /// window.
     SstvLineDecoded(u32),
     /// One complete SSTV image. Emitted from the DSP thread when
     /// `sstv_decode_tap` receives a `slowrx::SstvEvent::ImageComplete`.
@@ -182,7 +183,8 @@ pub enum DspToUi {
     /// pixel `Vec` doesn't inflate the enum's stack footprint on
     /// the drain path. Per epic #472.
     SstvImageComplete {
-        /// Width in pixels (e.g. 640 for PD120/PD180).
+        /// Width in pixels (640 for the entire PD family —
+        /// PD120 / PD180 / PD240).
         width: u32,
         /// Height in scan lines.
         height: u32,

--- a/crates/sdr-radio/src/sstv_image.rs
+++ b/crates/sdr-radio/src/sstv_image.rs
@@ -117,7 +117,8 @@ impl Inner {
 /// for the next VIS detection without waiting for the save.
 #[derive(Debug, Clone)]
 pub struct CompletedSstvImage {
-    /// Pixel width (e.g. 640 for PD120/PD180).
+    /// Pixel width (640 for the entire PD family —
+    /// PD120 / PD180 / PD240).
     pub width: u32,
     /// Pixel height (total scan lines).
     pub height: u32,
@@ -252,8 +253,9 @@ impl SstvImageHandle {
 
     /// Non-destructive snapshot of the in-flight image for the live
     /// viewer. Clones only the written rows, so a 50-line snapshot
-    /// from a 496-line PD120 image copies ~50 × 640 × 3 ≈ 96 KB —
-    /// cheap compared to the full-image clone.
+    /// from a 496-line PD-family image (PD120 / PD180 / PD240)
+    /// copies ~50 × 640 × 3 ≈ 96 KB — cheap compared to the
+    /// full-image clone.
     #[must_use]
     pub fn snapshot(&self) -> Option<SstvSnapshot> {
         let g = lock_or_recover(&self.inner);
@@ -287,7 +289,8 @@ impl SstvImageHandle {
 mod tests {
     use super::*;
 
-    /// Width + height used by all tests. Matches PD120's spec (640 × 496).
+    /// Width + height used by all tests. Matches the entire PD
+    /// family's spec (PD120 / PD180 / PD240 are all 640 × 496).
     const W: u32 = 640;
     const H: u32 = 496;
 

--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -380,10 +380,11 @@ impl AutoRecorder {
     /// reality (`[Apt, Lrpt, Sstv]` as of epic #472). Per CR
     /// round 2 on PR #541: exposing the variadic builder
     /// publicly would let the wiring layer opt into protocols
-    /// whose LOS flow isn't actually safe yet. When V2 modes
-    /// (Robot / Scottie / Martin / PD240) flow through the
-    /// SSTV wiring via slowrx.rs V2, no constructor change is
-    /// needed — they all dispatch as `ImagingProtocol::Sstv`.
+    /// whose LOS flow isn't actually safe yet. The SSTV path is
+    /// mode-agnostic: PD120, PD180, and PD240 (slowrx 0.2.1)
+    /// already dispatch as `ImagingProtocol::Sstv`, and any
+    /// future slowrx V2 modes (Robot / Scottie / Martin) will
+    /// land the same way without a constructor change.
     #[must_use]
     fn with_supported_protocols(supported: &[sdr_sat::ImagingProtocol]) -> Self {
         Self {

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -5,14 +5,15 @@
 //! shared [`sdr_radio::sstv_image::SstvImageHandle`] as it accumulates
 //! during a satellite pass. ARISS events typically send ~12 images per
 //! 10-minute pass window; each image is announced by a VIS header, decoded
-//! line by line (~1 line/sec for PD120), and completed at
-//! `SstvEvent::ImageComplete`.
+//! line by line (~2 lines/sec for PD120, ~1.4 for PD180, ~1 for PD240),
+//! and completed at `SstvEvent::ImageComplete`.
 //!
 //! Three pieces:
 //!
 //! * [`SstvImageRenderer`] — pure Cairo renderer. Owns an ARGB32
-//!   [`cairo::ImageSurface`] sized for the current image (PD120: 640 × 496).
-//!   No GTK dependency, fully unit-testable.
+//!   [`cairo::ImageSurface`] sized for the current image (the entire PD
+//!   family is 640 × 496 — PD120, PD180, PD240). No GTK dependency,
+//!   fully unit-testable.
 //! * [`SstvImageView`] — GTK widget wrapping a renderer. Driven by the
 //!   `DspToUi::SstvLineDecoded` handler in `window.rs` which triggers a
 //!   `snapshot()` + redraw on each new line. Cloneable (all state is
@@ -41,8 +42,9 @@ use crate::viewer::ViewerError;
 
 // ─── Constants ─────────────────────────────────────────────────────────────
 
-/// Default viewer window size. ISS SSTV in PD120 mode produces 640 × 496
-/// images; headroom is given for the header bar.
+/// Default viewer window size. ISS SSTV in any PD-family mode
+/// (PD120 / PD180 / PD240) produces 640 × 496 images; headroom is
+/// given for the header bar.
 const VIEWER_WINDOW_WIDTH: i32 = 700;
 const VIEWER_WINDOW_HEIGHT: i32 = 560;
 
@@ -109,11 +111,13 @@ impl SstvImageRenderer {
         } else if snap.lines_written < old_lines {
             // Same dimensions but the line counter rolled back — a
             // new SSTV image started with the same mode (e.g.
-            // PD120 → PD120). Without this branch the delta logic
-            // below sees `new_lines < old_lines` → false → no blit,
-            // and stale pixels from the previous image leak through.
-            // Clear the surface and reset the cursor so the new
-            // image paints from row 0. Per CodeRabbit #7 on PR #599.
+            // PD120 → PD120) OR a different PD-family mode (e.g.
+            // PD120 → PD240, all 640 × 496). Without this branch
+            // the delta logic below sees `new_lines < old_lines`
+            // → false → no blit, and stale pixels from the
+            // previous image leak through. Clear the surface and
+            // reset the cursor so the new image paints from row
+            // 0. Per CodeRabbit #7 on PR #599.
             self.clear();
             old_lines = 0;
         }
@@ -739,7 +743,8 @@ mod tests {
     use super::*;
 
     /// Build an `SstvSnapshot` with `lines_written` rows of solid grey
-    /// (so writes are deterministic). PD120 / PD180 width 640.
+    /// (so writes are deterministic). PD-family modes (PD120 / PD180
+    /// / PD240) all use width 640.
     fn snap(width: u32, height: u32, lines_written: u32) -> SstvSnapshot {
         let n = (width as usize) * (height as usize);
         SstvSnapshot {
@@ -803,10 +808,11 @@ mod tests {
 
     #[test]
     fn renderer_same_dimension_rollover_clears_for_new_image() {
-        // PD120 → PD120 (same dims) starts a fresh image — slowrx
-        // resets the line counter on the new VIS detection. The
-        // renderer must detect the rollover and clear stale rows.
-        // Per CR round 1 #7 on PR #599; this test pins that fix.
+        // Same-dimensions rollover (PD120 → PD120, or PD120 → PD180,
+        // or any other PD-family mode swap) starts a fresh image —
+        // slowrx resets the line counter on the new VIS detection.
+        // The renderer must detect the rollover and clear stale
+        // rows. Per CR round 1 #7 on PR #599; this test pins that fix.
         let mut r = SstvImageRenderer::new();
         let _ = r.update_from_snapshot(snap(640, 496, 496)); // full first image
         assert_eq!(r.lines_written, 496);
@@ -819,8 +825,8 @@ mod tests {
 
     #[test]
     fn renderer_dimension_change_rebuilds_surface() {
-        // PD120 (640×496) → some hypothetical 320×240 mode would
-        // resize. Surface gets rebuilt; old contents discarded.
+        // PD-family (640×496) → some hypothetical 320×240 mode
+        // would resize. Surface gets rebuilt; old contents discarded.
         let mut r = SstvImageRenderer::new();
         let _ = r.update_from_snapshot(snap(640, 496, 100));
         let _ = r.update_from_snapshot(snap(320, 240, 50));

--- a/docs/research/05-sstv-slow-scan-tv.md
+++ b/docs/research/05-sstv-slow-scan-tv.md
@@ -30,7 +30,7 @@ For this guide, the focus is **2m (145.800 MHz) ISS SSTV** since that's what you
 The ARISS (Amateur Radio on the International Space Station) program periodically transmits SSTV images from ISS to celebrate anniversaries, educational outreach, or cosmonaut personal projects. Schedule:
 
 - Typical frequency: 145.800 MHz narrow FM
-- Mode: typically **PD120** or **PD180** (Russian cosmonaut choices)
+- Mode: typically **PD120**, **PD180**, or **PD240** (Russian cosmonaut choices)
 - Duration: usually 2–5 days per event
 - Images: 12 different pictures cycled, transmitted ~every 3 minutes
 - Events announced at **ariss.org** and **amsat.org** a few weeks in advance
@@ -91,6 +91,7 @@ Common modes you'll encounter:
 | **PD90** | 320×256 | 90 sec | Color YCrCb | ISS |
 | **PD120** | 640×496 | 2 min | Color YCrCb | ISS (most common recent) |
 | **PD180** | 640×496 | 3 min | Color YCrCb | ISS (high quality option) |
+| **PD240** | 640×496 | 4 min | Color YCrCb | ISS (highest quality PD-family option) |
 | **Martin M1** | 320×256 | 114 sec | Color RGB | Ham HF |
 | **Martin M2** | 320×256 | 58 sec | Color RGB | Ham HF |
 | **Scottie S1** | 320×256 | 110 sec | Color RGB | Ham HF |
@@ -148,6 +149,7 @@ The 7-bit VIS code identifies the mode:
 | 0x63 | PD90 |
 | 0x5F | PD120 |
 | 0x60 | PD180 |
+| 0x61 | PD240 |
 
 (Full VIS table in any SSTV decoder source. The `black.qsl.net/sstv-handbook/` reference has all of them.)
 


### PR DESCRIPTION
## Summary

- slowrx 0.2.1 added PD240 (640 × 496, ~240 s/image, VIS code 0x61) to the PD-family of SSTV decoders.
- The rtl-sdr SSTV decoder dispatch is mode-agnostic (`slowrx::for_mode(mode)` reads the spec table) and the shared 640 × 496 buffer in `sdr-radio::sstv_image` already accommodates PD240 — so the **integration is doc-only**, no behavior change.
- 6 files updated to mention PD240 alongside PD120/PD180 in code comments and the research doc.

## What this gives us

The next ISS ARISS event that transmits in PD240 will Just Work — VIS detect → spec lookup → `decode_pd_line_pair` → image complete → save, all the same code paths that already handle PD120/PD180. The viewer's renderer rebuilds the Cairo surface only on dimension change (which won't trigger since PD240 shares 640 × 496), so the same-dimension rollover path from CR round 1 #7 on PR #599 covers PD120 → PD240 transitions automatically.

## Test plan

- [x] `cargo build --workspace` (clean)
- [x] `cargo check --workspace --locked` (no Cargo.lock drift)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` (no new lints)
- [x] `cargo test -p sdr-core -p sdr-radio -p sdr-ui --no-default-features --features sdr-ui/whisper-cpu --lib` — 642 tests pass (sdr-core 80, sdr-radio 144, sdr-ui 418)
- [x] `cargo fmt --all -- --check` (no diff)
- [ ] Smoke check next ARISS PD240 pass (none in window today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified SSTV PD-family mode specifications (PD120, PD180, PD240) throughout documentation
  * Added PD240 mode details to ISS SSTV guide, including 640×496 resolution and 4-minute transmission characteristics
  * Updated line transmission rates and image dimension documentation for improved mode handling clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->