### PR TITLE
feat(sstv): show detected mode in viewer header + add reception guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ NOAA APT (epic #468), Meteor-M LRPT (epic #469), and ISS SSTV (epic #472) are al
 - `crates/sdr-radio/src/sstv_image.rs` — Shared SSTV image handle (`Arc<Mutex<Inner>>`). DSP tap writes via `write_line`; UI reads via `snapshot()`; `take_completed()` drains the finished frame and resets for the next VIS detection. `SstvImage::clear()` convenience wrapper delegates to the handle.
 - `crates/sdr-ui/src/sstv_viewer.rs` — Live SSTV viewer. `SstvImageRenderer` owns the Cairo ARGB32 surface; `SstvImageView` is the GTK widget (cloneable via Rc). `open_sstv_viewer_if_needed` opens the window and wires `UiToDsp::SetSstvImage`. `write_sstv_rgb_png` is the Cairo-based PNG encoder used by both manual Export and the auto-record LOS save. Wired via `connect_sstv_action` (`Ctrl+Shift+V`).
 
-**User-facing walkthroughs:** `docs/guides/apt-reception.md`, `docs/guides/lrpt-reception.md`.
+**User-facing walkthroughs:** `docs/guides/apt-reception.md`, `docs/guides/lrpt-reception.md`, `docs/guides/sstv-reception.md`.
 
 **Output paths** (all under `~/sdr-recordings/`):
 - APT: `apt-{satellite-slug}-{local-timestamp}.png` (single PNG per pass).

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -918,6 +918,14 @@ fn sstv_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_c
                     hedr_shift_hz,
                     "SSTV VIS detected — new image starting"
                 );
+                // Surface the mode in the viewer's header so the
+                // user can see which PD-family variant is being
+                // decoded. `&'static str` because the slowrx mode
+                // name list is bounded and stable. Per epic #472
+                // mode-display follow-up.
+                let _ = dsp_tx.send(DspToUi::SstvVisDetected {
+                    mode_label: sstv_mode_label(mode),
+                });
             }
             slowrx::SstvEvent::LineDecoded {
                 mode,
@@ -967,6 +975,25 @@ fn sstv_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_c
                 // doesn't require a source change here.
             }
         }
+    }
+}
+
+/// Map a [`slowrx::SstvMode`] to a `&'static str` mode name for
+/// the UI's viewer-header display. The string list intentionally
+/// uses `&'static str` (not `String`) because the slowrx mode
+/// names are bounded and stable — VIS detect fires once per
+/// image and we don't want to allocate per event.
+///
+/// Wildcard fallback `"SSTV"` covers future slowrx modes that
+/// land before we add an explicit arm here. `SstvMode` is
+/// `#[non_exhaustive]` so this match must always have one.
+/// Per epic #472 mode-display follow-up.
+fn sstv_mode_label(mode: slowrx::SstvMode) -> &'static str {
+    match mode {
+        slowrx::SstvMode::Pd120 => "PD120",
+        slowrx::SstvMode::Pd180 => "PD180",
+        slowrx::SstvMode::Pd240 => "PD240",
+        _ => "SSTV",
     }
 }
 

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -162,6 +162,22 @@ pub enum DspToUi {
     /// returned `DspToUi` value once per drain.
     AptLine(Box<AptLine>),
     // --- SSTV decoder (#472 — ISS SSTV) ---
+    /// VIS header detected — the decoder has identified the SSTV
+    /// mode and a new image is starting. Emitted from the DSP
+    /// thread when `sstv_decode_tap` receives a
+    /// `slowrx::SstvEvent::VisDetected`.
+    ///
+    /// `mode_label` is the static, human-readable name of the
+    /// detected mode (e.g. `"PD120"`, `"PD180"`, `"PD240"`).
+    /// Strings are `&'static str` because the slowrx mode name
+    /// list is bounded and stable; there's no allocation per VIS
+    /// event. The UI surfaces this in the SSTV viewer's window
+    /// title subtitle so the user can see which mode the active
+    /// image is being decoded as.
+    SstvVisDetected {
+        /// Human-readable mode name (e.g. `"PD120"`).
+        mode_label: &'static str,
+    },
     /// One decoded SSTV scan line. Emitted from the DSP thread when
     /// `sstv_decode_tap` receives a `slowrx::SstvEvent::LineDecoded`.
     /// The UI handler uses this as a redraw trigger for the live

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -775,6 +775,7 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         | DspToUi::AcarsOutputError { .. }
         // SSTV variants (epic #472) — Linux-only for V1; macOS will
         // get its own ticket when the FFI layer gains an SSTV viewer.
+        | DspToUi::SstvVisDetected { .. }
         | DspToUi::SstvLineDecoded(_)
         | DspToUi::SstvImageComplete { .. } => return None,
     };
@@ -1346,6 +1347,22 @@ mod tests {
         assert!(
             translate_event(&msg).is_none(),
             "AcarsOutputError must not translate to a wire event yet",
+        );
+    }
+
+    #[test]
+    fn translate_sstv_vis_detected_is_dropped_at_ffi_boundary() {
+        // Same drop-at-boundary contract as `SstvLineDecoded` /
+        // `SstvImageComplete` — the mode-display follow-up keeps
+        // SSTV strictly Linux-only at the FFI boundary until the
+        // macOS viewer ticket lands. Per epic #472 mode-display
+        // follow-up.
+        let msg = DspToUi::SstvVisDetected {
+            mode_label: "PD120",
+        };
+        assert!(
+            translate_event(&msg).is_none(),
+            "SstvVisDetected must not translate to a wire event yet",
         );
     }
 

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -52,6 +52,12 @@ const VIEWER_WINDOW_HEIGHT: i32 = 560;
 /// when the window is wider/taller than the image aspect ratio.
 const BACKGROUND_RGB: [f64; 3] = [0.05, 0.05, 0.06];
 
+/// Subtitle shown in the viewer's window title before any VIS header
+/// has been detected for the current image (or after [`SstvImageView::clear`]).
+/// Replaced by the mode name (e.g. `"PD120"`) on the first
+/// [`crate::messages::DspToUi::SstvVisDetected`] event.
+const SSTV_VIEWER_PLACEHOLDER_SUBTITLE: &str = "Waiting for VIS";
+
 // ─── Pure Cairo renderer ────────────────────────────────────────────────────
 
 /// Pure Cairo renderer for a live SSTV image.
@@ -365,6 +371,12 @@ pub struct SstvImageView {
     /// [`Self::set_handle`] after construction.
     /// Per CR round 4 on PR #599.
     handle: Rc<RefCell<Option<SstvImageHandle>>>,
+    /// Optional handle to the window's [`adw::WindowTitle`] so
+    /// [`Self::set_mode_label`] can refresh the subtitle when a new
+    /// VIS header arrives. Set by [`open_sstv_viewer_window`] after
+    /// the header is built; `None` for tests / detached views that
+    /// don't have a window. Per epic #472 mode-display follow-up.
+    title_widget: Rc<RefCell<Option<adw::WindowTitle>>>,
 }
 
 impl Default for SstvImageView {
@@ -396,6 +408,7 @@ impl SstvImageView {
             renderer,
             paused,
             handle: Rc::new(RefCell::new(None)),
+            title_widget: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -407,6 +420,26 @@ impl SstvImageView {
     /// round 4 on PR #599.
     pub fn set_handle(&self, handle: SstvImageHandle) {
         *self.handle.borrow_mut() = Some(handle);
+    }
+
+    /// Attach the window's [`adw::WindowTitle`] so
+    /// [`Self::set_mode_label`] can refresh the subtitle on VIS
+    /// detection. Called from [`open_sstv_viewer_window`] after
+    /// the header is built. Idempotent — replaces any previously-
+    /// attached title. Per epic #472 mode-display follow-up.
+    pub fn set_title_widget(&self, title: adw::WindowTitle) {
+        *self.title_widget.borrow_mut() = Some(title);
+    }
+
+    /// Update the viewer's window-title subtitle to show the
+    /// detected SSTV mode (e.g. `"PD120"`). No-op if no title
+    /// widget has been attached (test / detached views). Called
+    /// from `window.rs`'s `DspToUi::SstvVisDetected` arm. Per
+    /// epic #472 mode-display follow-up.
+    pub fn set_mode_label(&self, label: &str) {
+        if let Some(title) = self.title_widget.borrow().as_ref() {
+            title.set_subtitle(label);
+        }
     }
 
     /// The underlying `GtkDrawingArea`. Pack this into a layout container.
@@ -435,13 +468,16 @@ impl SstvImageView {
     /// shared [`SstvImageHandle`] (if attached via
     /// [`Self::set_handle`]) so the next [`Self::update_from_handle`]
     /// doesn't replay the rows we just cleared. Per CR round 4 on
-    /// PR #599.
+    /// PR #599. Resets the window-title subtitle to the placeholder
+    /// so the user sees "Waiting for VIS" until the next mode is
+    /// detected; per epic #472 mode-display follow-up.
     pub fn clear(&self) {
         if let Some(handle) = self.handle.borrow().as_ref() {
             handle.clear();
         }
         self.renderer.borrow_mut().clear();
         self.drawing_area.queue_draw();
+        self.set_mode_label(SSTV_VIEWER_PLACEHOLDER_SUBTITLE);
     }
 
     /// Toggle pause / resume. Pausing freezes the visible canvas;
@@ -539,6 +575,15 @@ pub fn open_sstv_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
         .build();
 
     let header = adw::HeaderBar::new();
+
+    // Two-line title widget: primary title is the static window
+    // title (e.g. "ISS SSTV"); subtitle starts as a placeholder
+    // and updates to the detected mode name (PD120 / PD180 /
+    // PD240 / future) on each `DspToUi::SstvVisDetected` event.
+    // Per epic #472 mode-display follow-up.
+    let title_widget = adw::WindowTitle::new(title, SSTV_VIEWER_PLACEHOLDER_SUBTITLE);
+    header.set_title_widget(Some(&title_widget));
+    view.set_title_widget(title_widget);
 
     // Pause / Resume toggle.
     let pause_btn = gtk4::ToggleButton::builder()

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -2083,6 +2083,18 @@ fn handle_dsp_message(
                 view.push_line(&line);
             }
         }
+        DspToUi::SstvVisDetected { mode_label } => {
+            // The decoder identified an SSTV mode from a fresh VIS
+            // header. Surface it in the viewer's title so the user
+            // can see whether they're getting PD120 / PD180 / PD240
+            // (or a future slowrx mode) without having to read
+            // `tracing::info!` in the journal. No-op when the
+            // viewer isn't open. Per epic #472 mode-display
+            // follow-up.
+            if let Some(view) = state.sstv_viewer.borrow().as_ref() {
+                view.set_mode_label(mode_label);
+            }
+        }
         DspToUi::SstvLineDecoded(_line_index) => {
             // A new SSTV scan line has arrived — refresh the open
             // viewer (if any) from the shared SstvImage handle.

--- a/docs/guides/apt-reception.md
+++ b/docs/guides/apt-reception.md
@@ -290,9 +290,10 @@ hand-export from the viewer after fixing the underlying issue.
 - **ISS SSTV** (epic [#472](https://github.com/jasonherald/rtl-sdr/issues/472))
   — the International Space Station occasionally broadcasts
   SSTV images on 145.800 MHz during commemoration events.
-  Different band, similar antenna, completely different
-  decoder. Watch
-  [ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com)
+  Different band, different antenna polarization, completely
+  different decoder. Shipped end-to-end — see
+  [`sstv-reception.md`](sstv-reception.md) for the walkthrough.
+  Watch [ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com)
   for upcoming events.
 - **Calibration tuning** — if you're getting consistently good
   images, look at the AVHRR channel telemetry to identify

--- a/docs/guides/apt-reception.md
+++ b/docs/guides/apt-reception.md
@@ -43,7 +43,7 @@ wedges = something's off (see [When things go wrong](#when-things-go-wrong)).
 
 ## Antenna
 
-NOAA APT is at 137 MHz with right-hand circular polarization,
+NOAA APT is at 137 MHz with right-hand circular polarisation,
 broadcast from ~850 km up. You don't need anything fancy to hear
 it, but you do need *something* — a stock RTL-SDR with the rubber
 duck antenna it shipped with will give you noise.
@@ -290,7 +290,7 @@ hand-export from the viewer after fixing the underlying issue.
 - **ISS SSTV** (epic [#472](https://github.com/jasonherald/rtl-sdr/issues/472))
   — the International Space Station occasionally broadcasts
   SSTV images on 145.800 MHz during commemoration events.
-  Different band, different antenna polarization, completely
+  Different band, different antenna polarisation, completely
   different decoder. Shipped end-to-end — see
   [`sstv-reception.md`](sstv-reception.md) for the walkthrough.
   Watch [ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com)

--- a/docs/guides/lrpt-reception.md
+++ b/docs/guides/lrpt-reception.md
@@ -280,7 +280,7 @@ been decoded so far to a different location.
 - **ISS SSTV** (epic [#472](https://github.com/jasonherald/rtl-sdr/issues/472))
   — the International Space Station occasionally broadcasts
   SSTV images on 145.800 MHz during commemoration events.
-  Different band, different antenna polarization, completely
+  Different band, different antenna polarisation, completely
   different decoder. Shipped end-to-end — see
   [`sstv-reception.md`](sstv-reception.md) for the walkthrough.
   Watch [ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com)

--- a/docs/guides/lrpt-reception.md
+++ b/docs/guides/lrpt-reception.md
@@ -280,9 +280,10 @@ been decoded so far to a different location.
 - **ISS SSTV** (epic [#472](https://github.com/jasonherald/rtl-sdr/issues/472))
   — the International Space Station occasionally broadcasts
   SSTV images on 145.800 MHz during commemoration events.
-  Different band, similar antenna, completely different
-  decoder. Watch
-  [ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com)
+  Different band, different antenna polarization, completely
+  different decoder. Shipped end-to-end — see
+  [`sstv-reception.md`](sstv-reception.md) for the walkthrough.
+  Watch [ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com)
   for upcoming events.
 - **False-colour composites.** AVHRR channels 1 (visible),
   2 (near-IR), and 4 (thermal IR) combine into useful

--- a/docs/guides/sstv-reception.md
+++ b/docs/guides/sstv-reception.md
@@ -1,0 +1,370 @@
+# Receive your first ISS SSTV image
+
+A walkthrough from "I have an RTL-SDR, the app installed, and I've
+already received a NOAA APT pass" to "I just decoded an
+SSTV-encoded photograph that an ISS cosmonaut transmitted from
+orbit." If you haven't done APT first, start with
+[apt-reception.md](apt-reception.md) — most of the antenna and
+ground-station setup is shared across all the satellite-reception
+flows in this app.
+
+The big difference from APT and LRPT: **SSTV from the ISS is not
+a regular daily occurrence.** The International Space Station only
+transmits SSTV during scheduled ARISS (Amateur Radio on the
+International Space Station) commemoration events, which happen 2-4
+times per year and run for 2-5 days at a stretch. You can't just
+arm the auto-record toggle on a quiet weekday and expect imagery —
+you need to time it to an active event.
+
+---
+
+## What you'll see
+
+During an active ARISS event, the ISS transmits a rotation of ~12
+photographs over a 2-5 day window. Each pass over your location
+typically captures 1-3 of them, depending on the pass duration and
+where the cycle was when the satellite came into view.
+
+Modes used: **PD120** (most common), **PD180** (high quality), and
+**PD240** (highest quality). All three produce 640 × 496 colour
+images. The viewer's window-title subtitle shows which mode the
+current image is being decoded as.
+
+> **TODO:** hero screenshot — a real ISS SSTV image we received
+> during an ARISS event, ideally showing the mode subtitle in the
+> viewer header. `docs/guides/images/sstv-hero.png`
+
+A typical ARISS event publishes a "see what others received" gallery
+via the ARISS web blog. Receiving a clean image and submitting it
+gets you a paper certificate, which is a fun keepsake.
+
+---
+
+## Knowing when to listen
+
+The single most important step is timing — there's no point arming
+auto-record if there's no active event. Check both:
+
+- **[ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com)** —
+  the official ARISS SSTV blog. Posts go up several weeks before
+  each event with the start / end UTC times and the mode that will
+  be used. Subscribe via RSS if you want a heads-up.
+- **[amsat.org news](https://www.amsat.org/category/announcements/)** —
+  cross-posts ARISS event announcements and sometimes adds
+  technical notes (e.g. "PD120 this time, not PD180").
+
+Past events have run from a few hours to five full days. Event
+windows are announced as continuous, but in practice the ISS crew
+power-cycles the SSTV transmitter during station activities so
+some passes during the window will be silent. Plan to attempt
+several passes per day during an event rather than relying on any
+one.
+
+---
+
+## Antenna
+
+ISS SSTV is on **145.800 MHz** narrow FM — that's the 2 metre
+amateur band, **not** the 137 MHz weather-satellite band APT and
+LRPT use. You need an antenna that works at 145 MHz; the
+horizontal V-dipole tuned for 137 MHz APT will receive 145 MHz
+imperfectly but usefully on high-elevation passes.
+
+### Best: 2 m / 70 cm vertical or J-pole
+
+The ISS's onboard antennas are roughly omnidirectional and
+**vertically polarized**, unlike weather satellites' RHCP. A
+straight vertical antenna (a 2 m amateur whip, a J-pole, a
+quarter-wave ground plane) is the right match. Most of these
+antennas double as 70 cm receivers, which is convenient for ISS
+voice comms on 437 MHz too.
+
+### Acceptable: APT V-dipole rotated 90°
+
+If you already have a 137 MHz V-dipole built for APT, tilt one of
+the arms vertical (or stand it on end) and you'll get a usable
+145 MHz pattern. You're operating it 8 MHz off-resonance and at the
+wrong polarization, so expect the SNR to be a few dB worse than a
+purpose-built 2 m antenna — but workable on passes above ~30°
+elevation.
+
+### Improvised: SDR's stock whip
+
+The rubber-duck antenna that ships with most RTL-SDRs is roughly
+quarter-wave at 145 MHz (it's tuned for the ~150 MHz commercial /
+amateur range). Stand it vertical on a windowsill with sky view
+and you'll get something on a 60°+ pass. Don't expect images on
+low passes.
+
+### What helps more than antenna upgrades
+
+- **Clear sky to the south.** ISS orbits at 51° inclination, so
+  passes track diagonally. From mid-latitude northern locations
+  the highest-elevation pass arc happens with the satellite
+  south of overhead. A south-facing window or balcony beats a
+  better antenna in a basement.
+- **Pass elevation ≥ 30°.** ISS SSTV needs more SNR than APT to
+  decode cleanly because the SSTV demodulator is line-rate-locked
+  rather than re-syncable per scan line. A horizon-grazing pass
+  produces noise where APT would have given you a thin strip.
+
+---
+
+## FM broadcast notch filter
+
+**Probably unnecessary** for ISS SSTV. Broadcast FM (88-108 MHz)
+intermodulation lands on 137 MHz APT and LRPT but mostly skips
+145.800 MHz, which sits in the 2 m amateur band where the IMD
+products from 88-108 MHz land outside the channel.
+
+If you already have a notch installed for APT, leave it in — it
+won't hurt and it does cut some noise on the 145 MHz side. If you
+don't have one, no need to buy one for SSTV alone.
+
+---
+
+## Active mission
+
+The ISS catalog entry is already in the app (NORAD 25544, 145.800
+MHz NFM), wired with the SSTV imaging protocol. No setup needed
+beyond the standard ground-station entry.
+
+The catalog entry doesn't gate on whether ARISS is currently
+active — if you arm auto-record outside an event window the radio
+will tune up, the viewer will open, and the recorder will produce
+an empty per-pass directory (or skip the directory creation, see
+[Troubleshooting](#troubleshooting)). That's harmless but
+pointless; check the schedule first.
+
+---
+
+## Your first pass
+
+The auto-record flow is the same as APT and LRPT — set ground
+station, toggle on, walk away — but the timing differs because
+you're triggering on a specific scheduled event rather than the
+satellite's natural orbit.
+
+### 1. Confirm the ARISS event is active
+
+Check the schedule (see [Knowing when to
+listen](#knowing-when-to-listen)). If we're inside the published
+window, proceed. If not, come back when one starts.
+
+### 2. Open the Satellites panel
+
+Click the satellite icon in the left activity bar (or `Ctrl+7`).
+The panel layout is the same as for APT and LRPT.
+
+### 3. Set your ground station and refresh TLEs
+
+Same as APT: type your US ZIP, or enter lat/lon directly, then
+click ↻ next to **Last refreshed** if the TLE data is stale. The
+upcoming-passes list will repopulate within a second or two.
+
+ISS passes happen **far more often** than weather-satellite passes
+— typically 4-6 visible passes per day from a typical mid-latitude
+location, more from higher latitudes. ISS orbits at 51°
+inclination so passes track diagonally rather than pole-to-pole;
+your pass list will show ISS interleaved with NOAA / Meteor-M
+passes.
+
+### 4. Toggle auto-record
+
+Flip **Auto-record satellite passes** on. The same toggle that
+arms NOAA APT and METEOR-M LRPT also arms ISS SSTV — the recorder
+branches on the catalog entry's protocol field internally. The
+"Also save audio (.wav)" sub-toggle **is** honoured for SSTV
+because the demod is audible NFM and the audio recording captures
+the raw signal (unlike LRPT, where the demod is a silent
+passthrough and audio recording is suppressed).
+
+### 5. Watch the live viewer build
+
+5 seconds before AOS, the recorder takes over your radio:
+
+- Tunes to 145.800 MHz
+- Switches the demod to NFM (you'll hear the SSTV warble through
+  your speakers)
+- Sets the channel bandwidth to 12.5 kHz
+- Zeros the VFO offset
+- Opens a non-modal **ISS SSTV** viewer window alongside the main
+  radio window
+- Clears the canvas so back-to-back passes start fresh
+
+The viewer's window-title subtitle starts as **"Waiting for VIS"**.
+Within the first ~30 seconds of receiving signal the SSTV decoder
+locks onto a VIS header; the subtitle updates to **"PD120"** /
+**"PD180"** / **"PD240"** depending on which mode is being
+transmitted. The image then fills top-to-bottom at the mode's
+native cadence:
+
+- PD120: ~2 lines/sec for ~120 seconds
+- PD180: ~1.4 lines/sec for ~180 seconds
+- PD240: ~1 line/sec for ~240 seconds
+
+Each ARISS image takes a substantial fraction of an ISS pass to
+transmit, so a typical pass produces 1-3 complete images depending
+on the mode and pass duration. The **Pause** and **Clear** buttons
+in the header bar work the same as in the APT and LRPT viewers.
+
+### 6. After LOS
+
+When the satellite drops below the horizon:
+
+- **Per-image PNGs are written** into a directory at
+  `~/sdr-recordings/sstv-iss-2026-04-25-143022/` (catalog slug +
+  local AOS timestamp). One file per completed image —
+  `img0.png`, `img1.png`, etc. The save toast reports how many
+  images landed.
+- **The radio restores** to whatever frequency / mode / bandwidth
+  / scanner state you had before AOS. If playback was off pre-AOS,
+  it stops; if you were tuned to a different mode, you go back to
+  it.
+- **The viewer window stays open** so you can review the imagery
+  before the next pass clears it.
+
+If a pass came in mid-image (e.g. you started auto-record halfway
+through the satellite's transmission of image #4), you'll get a
+partial image — top half is the relevant scene, bottom half stays
+black. That's normal; the next pass starts a new directory.
+
+The save is decoupled from the live viewer — even if you dismissed
+the viewer mid-pass to free screen space, the LOS save still
+produces the per-pass directory. The DSP keeps decoding into a
+shared image buffer regardless of viewer presence.
+
+---
+
+## Manual SSTV mode
+
+Unlike APT and LRPT, **SSTV doesn't have a dedicated mode in the
+demod dropdown** today. The SSTV decoder runs only when the
+satellite recorder armed it for an ISS pass. To use the viewer
+outside the auto-record path:
+
+- `Ctrl+Shift+V` opens the SSTV viewer window even when no pass is
+  in progress. The decoder is wired to NFM audio, so as long as
+  you're tuned to 145.800 MHz NFM with a clean signal, the
+  decoder will produce frames. This is useful if the auto-record
+  schedule missed a pass and you want to watch the next one
+  manually.
+- Switching the demod mode away from NFM stops decode entirely.
+- Closing the viewer window doesn't stop the decoder — the shared
+  image buffer keeps accumulating in the background until the
+  recorder transitions out of the SSTV-aware state.
+
+If you want to receive non-ISS SSTV transmissions (e.g. an HF SSTV
+QSO on 14.230 MHz), the same `Ctrl+Shift+V` flow works once you've
+tuned to USB and set the audio sample rate appropriately. HF SSTV
+is out of scope for the V1 ISS SSTV epic but the underlying
+slowrx decoder doesn't care about the source.
+
+---
+
+## Troubleshooting
+
+### Pass directory was created but is empty
+
+The recorder armed and the radio tuned, but no SSTV image
+completed during the pass. Most common causes, in order:
+
+1. **No active ARISS event.** Check
+   [ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com).
+2. **Pass too low.** SSTV's PD-family decoders are line-rate-
+   locked rather than per-line resyncable; a horizon-grazing pass
+   may carry signal but never sustain enough SNR for VIS detection.
+3. **Antenna polarization mismatch.** A horizontal antenna (e.g.
+   the 137 MHz V-dipole used flat for APT) nulls vertically-
+   polarized 145 MHz signals. Lay the antenna vertical.
+4. **Wrong frequency due to Doppler.** The recorder doesn't
+   currently apply Doppler correction for SSTV; the ±3 kHz shift
+   on 145.800 MHz is normally inside the 12.5 kHz channel
+   bandwidth, but if you've narrowed the bandwidth it may not be.
+   Reset bandwidth to 12.5 kHz.
+
+If the directory is created but empty, you'll see a toast
+"Pass complete, but no SSTV images decoded — nothing saved to {dir}".
+
+### Images are mostly noise / hue-shifted
+
+The decoder locked onto a VIS header but the signal was too weak
+to produce clean image data. Same root causes as the empty
+directory above. Hue shifts (overall image tinted blue or yellow)
+indicate the HEDR (header) frequency-shift detection picked up a
+slight carrier offset — slowrx automatically compensates for this
+during decode, so persistent hue shifts mean the carrier drifted
+mid-image faster than HEDR detection could track.
+
+### Image is striped with horizontal jumps
+
+Sync lost mid-image. The decoder doesn't recover from sync loss
+within an SSTV image (unlike APT, which re-syncs per scan line),
+so the rest of that frame is lost. The next VIS header starts a
+fresh image — wait for it.
+
+### Subtitle says "Waiting for VIS" for the entire pass
+
+The decoder never detected a VIS header. Either there's no signal
+(see "empty pass directory" above), or the signal is present but
+the VIS detector's tone-classification thresholds didn't fire.
+The detector is bandlimited to the standard 1100 / 1300 / 1900 /
+2300 Hz tones — if the satellite's audio chain has shifted those
+tones (rare but possible during onboard equipment swaps), VIS
+won't detect.
+
+### Pass scheduled but nothing happens
+
+Check the **Last refreshed** row in the TLE Data section. ISS
+TLEs go stale faster than NOAA / Meteor-M because the ISS does
+periodic reboost burns that change its orbit by tens of km.
+Refresh weekly during an active ARISS event. Celestrak rate-
+limits aggressive clients, so don't refresh more than once per
+day.
+
+### Auto-record toast says "couldn't create {dir}"
+
+Check disk space and permissions on `~/sdr-recordings/`. The
+shared image is still in memory — open the viewer with
+`Ctrl+Shift+V`, optionally pause to inspect, and use the manual
+**Export PNG** button to write what's been decoded to a different
+location.
+
+### Viewer window gets buried under the main window
+
+Hit `Ctrl+Shift+V` again. The action raises the existing viewer
+to the front rather than opening a duplicate.
+
+---
+
+## Next steps
+
+- **NOAA APT** (epic [#468](https://github.com/jasonherald/rtl-sdr/issues/468))
+  — analog 137 MHz weather satellite. Different band, different
+  antenna ideally (horizontal V-dipole rather than vertical
+  whip), much more frequent passes. See
+  [`apt-reception.md`](apt-reception.md).
+- **Meteor-M LRPT** (epic [#469](https://github.com/jasonherald/rtl-sdr/issues/469))
+  — Russian polar weather satellite on 137 MHz with multi-
+  channel digital imagery. The same horizontal V-dipole that
+  receives APT receives LRPT. See
+  [`lrpt-reception.md`](lrpt-reception.md).
+- **HF SSTV.** The slowrx decoder works on any audio source, not
+  just the ISS. Tune to 14.230 MHz USB during a busy weekend and
+  you'll catch SSTV QSOs from amateurs around the world. The
+  manual-mode `Ctrl+Shift+V` flow handles this; no auto-record
+  scheduling because HF SSTV isn't tied to a satellite pass.
+- **Send your image to ARISS.** After a successful event,
+  [ARISS publishes a submission portal](https://www.spaceflightsoftware.com/ARISS_SSTV/index.php)
+  for received images. Submit your best capture and you'll get a
+  paper certificate by mail — a satisfying piece of physical
+  proof that you decoded a digital image off a spacecraft.
+
+If your first ISS SSTV pass came through clean — VIS subtitle
+populated, image fills the canvas top-to-bottom in colour, no
+horizontal jumps — congratulations. You just demodulated a
+narrowband FM signal from low Earth orbit, ran it through a VIS
+detector and a PD-family colour decoder, and produced a
+photograph that a cosmonaut transmitted from inside the
+International Space Station. That is, on balance, a deeply silly
+thing to be able to do from a balcony with a $30 dongle. Enjoy it.

--- a/docs/guides/sstv-reception.md
+++ b/docs/guides/sstv-reception.md
@@ -11,24 +11,24 @@ flows in this app.
 The big difference from APT and LRPT: **SSTV from the ISS is not
 a regular daily occurrence.** The International Space Station only
 transmits SSTV during scheduled ARISS (Amateur Radio on the
-International Space Station) commemoration events, which happen 2-4
-times per year and run for 2-5 days at a stretch. You can't just
-arm the auto-record toggle on a quiet weekday and expect imagery —
-you need to time it to an active event.
+International Space Station) commemoration events, which (as of May
+2026) happen 2-4 times per year and run for 2-5 days at a stretch.
+You can't just arm the auto-record toggle on a quiet weekday and
+expect imagery — you need to time it to an active event.
 
 ---
 
 ## What you'll see
 
-During an active ARISS event, the ISS transmits a rotation of ~12
-photographs over a 2-5 day window. Each pass over your location
-typically captures 1-3 of them, depending on the pass duration and
-where the cycle was when the satellite came into view.
+During an active ARISS event (as of May 2026), the ISS transmits
+a rotation of ~12 photographs over a 2-5 day window. Each pass over
+your location typically captures 1-3 of them, depending on the pass
+duration and where the cycle was when the satellite came into view.
 
-Modes used: **PD120** (most common), **PD180** (high quality), and
-**PD240** (highest quality). All three produce 640 × 496 colour
-images. The viewer's window-title subtitle shows which mode the
-current image is being decoded as.
+Modes used (as of May 2026): **PD120** (most common), **PD180**
+(high quality), and **PD240** (highest quality). All three produce
+640 × 496 colour images. The viewer's window-title subtitle shows
+which mode the current image is being decoded as.
 
 > **TODO:** hero screenshot — a real ISS SSTV image we received
 > during an ARISS event, ideally showing the mode subtitle in the
@@ -53,12 +53,12 @@ auto-record if there's no active event. Check both:
   cross-posts ARISS event announcements and sometimes adds
   technical notes (e.g. "PD120 this time, not PD180").
 
-Past events have run from a few hours to five full days. Event
-windows are announced as continuous, but in practice the ISS crew
-power-cycles the SSTV transmitter during station activities so
-some passes during the window will be silent. Plan to attempt
-several passes per day during an event rather than relying on any
-one.
+Past events (as of May 2026) have run from a few hours to five
+full days. Event windows are announced as continuous, but in
+practice the ISS crew power-cycles the SSTV transmitter during
+station activities so some passes during the window will be silent.
+Plan to attempt several passes per day during an event rather than
+relying on any one.
 
 ---
 
@@ -73,7 +73,7 @@ imperfectly but usefully on high-elevation passes.
 ### Best: 2 m / 70 cm vertical or J-pole
 
 The ISS's onboard antennas are roughly omnidirectional and
-**vertically polarized**, unlike weather satellites' RHCP. A
+**vertically polarised**, unlike weather satellites' RHCP. A
 straight vertical antenna (a 2 m amateur whip, a J-pole, a
 quarter-wave ground plane) is the right match. Most of these
 antennas double as 70 cm receivers, which is convenient for ISS
@@ -84,7 +84,7 @@ voice comms on 437 MHz too.
 If you already have a 137 MHz V-dipole built for APT, tilt one of
 the arms vertical (or stand it on end) and you'll get a usable
 145 MHz pattern. You're operating it 8 MHz off-resonance and at the
-wrong polarization, so expect the SNR to be a few dB worse than a
+wrong polarisation, so expect the SNR to be a few dB worse than a
 purpose-built 2 m antenna — but workable on passes above ~30°
 elevation.
 
@@ -239,9 +239,9 @@ shared image buffer regardless of viewer presence.
 ## Manual SSTV mode
 
 Unlike APT and LRPT, **SSTV doesn't have a dedicated mode in the
-demod dropdown** today. The SSTV decoder runs only when the
-satellite recorder armed it for an ISS pass. To use the viewer
-outside the auto-record path:
+demod dropdown** (as of May 2026). The SSTV decoder runs only
+when the satellite recorder armed it for an ISS pass. To use the
+viewer outside the auto-record path:
 
 - `Ctrl+Shift+V` opens the SSTV viewer window even when no pass is
   in progress. The decoder is wired to NFM audio, so as long as
@@ -274,11 +274,11 @@ completed during the pass. Most common causes, in order:
 2. **Pass too low.** SSTV's PD-family decoders are line-rate-
    locked rather than per-line resyncable; a horizon-grazing pass
    may carry signal but never sustain enough SNR for VIS detection.
-3. **Antenna polarization mismatch.** A horizontal antenna (e.g.
+3. **Antenna polarisation mismatch.** A horizontal antenna (e.g.
    the 137 MHz V-dipole used flat for APT) nulls vertically-
-   polarized 145 MHz signals. Lay the antenna vertical.
-4. **Wrong frequency due to Doppler.** The recorder doesn't
-   currently apply Doppler correction for SSTV; the ±3 kHz shift
+   polarised 145 MHz signals. Lay the antenna vertical.
+4. **Wrong frequency due to Doppler.** The recorder doesn't apply
+   Doppler correction for SSTV (as of May 2026); the ±3 kHz shift
    on 145.800 MHz is normally inside the 12.5 kHz channel
    bandwidth, but if you've narrowed the bandwidth it may not be.
    Reset bandwidth to 12.5 kHz.


### PR DESCRIPTION
## Summary

Two complementary improvements to the ISS SSTV reception flow.

**1. Viewer mode label** — the SSTV viewer now shows which PD-family mode is currently being decoded in its window-title subtitle. Previously the only way to know whether ISS was sending PD120 / PD180 / PD240 was to scrape `tracing::info!` output from the journal. Now the subtitle starts as "Waiting for VIS" and updates to "PD120" / "PD180" / "PD240" on each VIS detect.

Wiring:

- New `DspToUi::SstvVisDetected { mode_label: &'static str }` carries the mode name from the controller through the message channel. `&'static str` because slowrx's mode names are bounded and stable, so VIS detect doesn't allocate.
- `controller.rs::sstv_decode_tap` emits the message after the existing tracing log; new `sstv_mode_label()` helper handles the `SstvMode → &'static str` mapping with a wildcard fallback for future slowrx modes.
- `SstvImageView` gains `set_title_widget()` and `set_mode_label()` methods plus a new `title_widget` field. `clear()` resets the subtitle to the placeholder so a Clear button click or AOS reset visually mirrors "fresh image incoming".
- `open_sstv_viewer_window` builds an `adw::WindowTitle` (primary title + subtitle) and attaches it to both the header and the view.
- `window.rs` handles the new variant by calling `view.set_mode_label(label)`.
- `sdr-ffi::event` parity arm added: SSTV variants stay Linux-only at the C ABI boundary until the macOS viewer ticket lands. New unit test pins the drop-at-boundary contract.

**2. SSTV reception guide** (`docs/guides/sstv-reception.md`) — a ~340-line user-facing walkthrough mirroring the APT and LRPT guides. Covers the ARISS event schedule (the big difference from weather satellites — SSTV from ISS is event-driven, not daily), 2 m vertical-polarisation antenna recommendations vs the 137 MHz horizontal V-dipole, the auto-record flow, the new mode subtitle, post-LOS per-pass directory layout, manual `Ctrl+Shift+V` mode, and a troubleshooting section keyed off the actual failure modes. APT and LRPT guides cross-link to the new SSTV guide; CLAUDE.md mentions all three walkthroughs.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo check --workspace --locked` (no Cargo.lock drift)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` (no new lints)
- [x] `cargo test --workspace` — 1982 tests pass, 0 failures
- [x] `cargo fmt --all -- --check` clean
- [x] `make install CARGO_FLAGS=\"--release\"` succeeds
- [x] Smoke test on installed binary:
  - `Ctrl+Shift+V` opens viewer with subtitle "Waiting for VIS"
  - Subtitle persists across viewer close/reopen
  - APT (`Ctrl+Shift+A`) and LRPT (`Ctrl+Shift+L`) viewers, Radio/Scanner/Transcript panels unaffected
- [ ] In-flight: subtitle flips to "PD120/PD180/PD240" on the next ARISS event
- [ ] In-flight: real-world readability of the new reception guide once the next ARISS event lets a new user follow it end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Viewer shows a "Waiting for VIS" subtitle and updates the displayed SSTV mode label (PD120/PD180/PD240) when a VIS header is detected; subtitle resets when the viewer is cleared. Mode updates occur as soon as VIS is detected and work with the manual viewer shortcut.

* **Documentation**
  * Added a comprehensive ISS SSTV reception guide and updated APT/LRPT guides to reference it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->