### PR TITLE
fix(apt): land bandwidth + audio-chain settings for satellite passes

### DIFF
--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -232,6 +232,21 @@ pub struct SavedTune {
     /// Pre-AOS FM IF NR toggle. Forced OFF at AOS, restored at
     /// LOS. Per #556.
     pub fm_if_nr_enabled: bool,
+    /// Pre-AOS de-emphasis `ComboRow` selection (0 = None, 1 = EU
+    /// 50 µs, 2 = US 75 µs). Forced to 0 (None) at AOS for the
+    /// satellite-image decoders, restored at LOS. The 2400 Hz
+    /// APT subcarrier sits in the rolloff of US 75 µs (cutoff
+    /// ~2122 Hz), so a user listening to FM broadcast pre-pass
+    /// would otherwise have the subcarrier attenuated through
+    /// the entire pass. Per silent-fail investigation following
+    /// the NOAA 15 pass.
+    pub deemphasis_idx: u32,
+    /// Pre-AOS audio notch toggle. Forced OFF at AOS, restored
+    /// at LOS. A user-set notch anywhere in the 1.5-3 kHz
+    /// audio band (typical "remove a hum" use) would null the
+    /// APT subcarrier. Per silent-fail investigation following
+    /// the NOAA 15 pass.
+    pub notch_enabled: bool,
 }
 
 /// Side effects the wiring layer must perform on each transition.
@@ -909,6 +924,8 @@ mod tests {
             squelch_db: -50.0,
             ctcss_mode: CtcssMode::Off,
             fm_if_nr_enabled: false,
+            deemphasis_idx: 0,
+            notch_enabled: false,
         }
     }
 
@@ -1254,6 +1271,12 @@ mod tests {
             squelch_db: SAVED_SQUELCH_DB,
             ctcss_mode: CtcssMode::Tone(SAVED_CTCSS_TONE_HZ),
             fm_if_nr_enabled: true,
+            // pin: pre-AOS deemphasis (US 75 µs index = 2) and
+            // notch must come back at LOS so the user's
+            // FM-broadcast listening setup isn't silently
+            // wiped after the pass.
+            deemphasis_idx: 2,
+            notch_enabled: true,
         };
         // Walk all transitions.
         r.tick(
@@ -1318,6 +1341,14 @@ mod tests {
                     matches!(t.ctcss_mode, CtcssMode::Tone(hz) if (hz - SAVED_CTCSS_TONE_HZ).abs() < f32::EPSILON)
                 );
                 assert!(t.fm_if_nr_enabled);
+                // Pre-AOS deemphasis (US 75 µs = idx 2) and
+                // notch enabled both survive the auto-record
+                // round trip — the user's FM-broadcast
+                // listening setup isn't silently wiped after
+                // the pass. Per silent-fail investigation
+                // following the NOAA 15 pass.
+                assert_eq!(t.deemphasis_idx, 2);
+                assert!(t.notch_enabled);
             }
             other => panic!("expected RestoreTune, got {other:?}"),
         }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -347,12 +347,25 @@ fn tune_to_target(
     state.center_frequency.set(freq_f64);
     state.demod_mode.set(mode);
     state.send_dsp(UiToDsp::Tune(freq_f64));
-    state.send_dsp(UiToDsp::SetBandwidth(bw_hz));
     freq_selector.set_frequency(freq_hz);
     spectrum_handle.set_center_frequency(freq_f64);
+    // **Order is load-bearing.** `set_selected` triggers the
+    // dropdown's `notify::selected` handler which dispatches
+    // `UiToDsp::SetDemodMode(mode)` synchronously. The DSP's
+    // `SetDemodMode` handler resets `state.bandwidth` to the new
+    // mode's `default_bandwidth` (e.g. 12.5 kHz for NFM) — see
+    // `crates/sdr-core/src/controller.rs::SetDemodMode`. So the
+    // explicit `SetBandwidth(bw_hz)` MUST land *after* the mode
+    // switch, otherwise SetDemodMode silently overwrites it and
+    // the satellite auto-record path (e.g. NOAA APT at 38 kHz)
+    // ends up at NFM's 12.5 kHz default — a 12.5 kHz channel
+    // filter throws away most of APT's ~38 kHz signal energy and
+    // the decoder hears static. Per silent-fail investigation
+    // following the NOAA 15 pass.
     if let Some(idx) = demod_selector::demod_mode_to_index(mode) {
         demod_dropdown.set_selected(idx);
     }
+    state.send_dsp(UiToDsp::SetBandwidth(bw_hz));
     // Update the bandwidth row's allowed range for the new mode
     // BEFORE setting the value. The dropdown notify above only
     // queues `SetDemodMode` to the DSP; the range update only
@@ -361,13 +374,12 @@ fn tune_to_target(
     // below would clamp to the previous mode's range AND fire
     // its own notify that dispatches a wrong `SetBandwidth`,
     // overriding the correct `SetBandwidth(bw_hz)` we just sent
-    // at line 202. WFM→NFM retunes are the common failure case.
+    // above. WFM→NFM retunes are the common failure case.
     // Per CR round 2 on PR #574.
     update_bandwidth_row_range_for_mode(radio_panel, state, mode);
     // Suppress the bandwidth row's notify around `set_value` so
     // it doesn't redispatch a redundant `SetBandwidth` —
-    // `tune_to_target` already sent the canonical command at
-    // line 202 above.
+    // `tune_to_target` already sent the canonical command above.
     state.suppress_bandwidth_notify.set(true);
     bandwidth_row.set_value(bw_hz);
     state.suppress_bandwidth_notify.set(false);
@@ -11011,6 +11023,19 @@ fn connect_satellites_panel(
         let squelch_level_row_a = panels.radio.squelch_level_row.clone();
         let ctcss_row_a = panels.radio.ctcss_row.clone();
         let fm_if_nr_row_a = panels.radio.fm_if_nr_row.clone();
+        // AF-chain widgets that also have to be disabled at AOS for
+        // the satellite-image decoders. The 2400 Hz APT subcarrier
+        // sits in the rolloff of US 75 µs / EU 50 µs deemphasis
+        // (cutoff ~2122 Hz / ~3183 Hz respectively); a notch
+        // anywhere in the 1.5-3 kHz audio band would also kill the
+        // subcarrier. Like the gates above, these flip via the
+        // widget's `notify` handler so the DSP gets a normal
+        // `SetDeemphasis(None)` / `SetNotchEnabled(false)` and the
+        // LOS restore-from-config path runs the same way it does for
+        // squelch / CTCSS / FM-IF-NR. Per silent-fail investigation
+        // following the NOAA 15 pass.
+        let deemphasis_row_a = panels.radio.deemphasis_row.clone();
+        let notch_enabled_row_a = panels.radio.notch_enabled_row.clone();
         // Composite-save toggle — read at LOS by the
         // `SaveLrptPass` handler. Strong clone so the closure
         // doesn't need to upgrade a weak ref against panel
@@ -11159,6 +11184,26 @@ fn connect_satellites_panel(
                     }
                     if fm_if_nr_row_a.is_active() {
                         fm_if_nr_row_a.set_active(false);
+                    }
+                    // De-emphasis ComboRow index 0 = "None". Both
+                    // US 75 µs (cutoff ~2122 Hz) and EU 50 µs
+                    // (cutoff ~3183 Hz) attenuate the 2400 Hz APT
+                    // subcarrier that lives in the demodulated
+                    // audio. Force to "None" so the AF chain
+                    // passes the subcarrier through flat. Per
+                    // silent-fail investigation following the
+                    // NOAA 15 pass.
+                    let deemp_off_idx: u32 = 0;
+                    if deemphasis_row_a.selected() != deemp_off_idx {
+                        deemphasis_row_a.set_selected(deemp_off_idx);
+                    }
+                    // Notch: a user-set notch frequency anywhere in
+                    // the 1.5-3 kHz audio band (the typical "remove
+                    // a hum" use case) would null the APT subcarrier.
+                    // Force off; LOS restore reapplies the persisted
+                    // value via the same notify chain.
+                    if notch_enabled_row_a.is_active() {
+                        notch_enabled_row_a.set_active(false);
                     }
                 };
                 match protocol {
@@ -12113,6 +12158,20 @@ fn connect_satellites_panel(
                 if saved.fm_if_nr_enabled != fm_if_nr_row_a.is_active() {
                     fm_if_nr_row_a.set_active(saved.fm_if_nr_enabled);
                 }
+                // Restore the AF-chain widgets the AOS path
+                // forced off — deemphasis (US 75 µs / EU 50 µs
+                // attenuates the 2400 Hz APT subcarrier) and
+                // notch (a user-set notch in the 1.5-3 kHz band
+                // nulls the subcarrier). Same notify-fires-set
+                // pattern as the gate restores above. Per
+                // silent-fail investigation following the NOAA
+                // 15 pass.
+                if saved.deemphasis_idx != deemphasis_row_a.selected() {
+                    deemphasis_row_a.set_selected(saved.deemphasis_idx);
+                }
+                if saved.notch_enabled != notch_enabled_row_a.is_active() {
+                    notch_enabled_row_a.set_active(saved.notch_enabled);
+                }
                 // Re-arm the scanner if it was running pre-AOS.
                 // The AOS-side `tune_a` call goes through
                 // `tune_to_satellite`, which fires
@@ -12188,6 +12247,14 @@ fn connect_satellites_panel(
         let squelch_level_row_tick = panels.radio.squelch_level_row.clone();
         let ctcss_row_tick = panels.radio.ctcss_row.clone();
         let fm_if_nr_row_tick = panels.radio.fm_if_nr_row.clone();
+        // AF-chain widgets that the satellite-image AOS path
+        // also force-disables (deemphasis attenuates the 2400 Hz
+        // APT subcarrier; a notch in the 1.5-3 kHz band nulls
+        // it). Snapshotted here on the same 1-Hz tick as the
+        // gate widgets so the LOS restore path can return them
+        // to their pre-AOS values.
+        let deemphasis_row_tick = panels.radio.deemphasis_row.clone();
+        let notch_enabled_row_tick = panels.radio.notch_enabled_row.clone();
         let _ = glib::timeout_add_local(SATELLITES_COUNTDOWN_TICK, move || {
             let Some(panel) = panel_weak_tick.upgrade() else {
                 return glib::ControlFlow::Break;
@@ -12251,6 +12318,8 @@ fn connect_satellites_panel(
                     ctcss_row_tick.selected(),
                 ),
                 fm_if_nr_enabled: fm_if_nr_row_tick.is_active(),
+                deemphasis_idx: deemphasis_row_tick.selected(),
+                notch_enabled: notch_enabled_row_tick.is_active(),
             };
             // Read the user's selected quality tier on every
             // tick — cheap (just a ComboRow.selected() call), and


### PR DESCRIPTION
## Summary

NOAA APT auto-record was silently failing — signal visible in the waterfall + peaks in the signal-strength graph, but only static audio and no decoded image. Found two compounding bugs in the live-capture pipeline.

### 1. Bandwidth dispatch race vs `SetDemodMode` reset

`tune_to_target` dispatched `SetBandwidth(38_000)` **before** `set_selected` triggered the dropdown's `notify::selected` handler, which dispatches `SetDemodMode(NFM)`. The DSP's `SetDemodMode` handler (`crates/sdr-core/src/controller.rs:1399-1400`) explicitly resets `state.bandwidth = state.radio.demod_config().default_bandwidth` — 12.5 kHz for NFM. So the satellite's 38 kHz channel filter snapped to 12.5 kHz, throwing away most of the APT signal energy.

**Fix:** dispatch `SetBandwidth` **after** `set_selected` so the explicit caller value lands after the mode-default reset. One reordered line in `tune_to_target` plus a load-bearing comment.

This also fixes bookmark recall and scanner-locked spectrum click, which both go through `tune_to_target` and previously had the same race.

### 2. Audio chain not fully reset for APT

`force_audio_chain_off()` disabled squelch / auto-squelch / CTCSS / FM-IF-NR but left **de-emphasis** and **notch** alone. The 2400 Hz APT subcarrier sits in the rolloff of US 75 µs de-emphasis (cutoff ~2122 Hz) and EU 50 µs (~3183 Hz) — a user listening to FM broadcast pre-pass would have the subcarrier attenuated through the entire pass. A user-set notch anywhere in the 1.5-3 kHz audio band would null the subcarrier entirely.

**Fix:**
- Extended `force_audio_chain_off()` to also flip `deemphasis_row` to "None" and `notch_enabled_row` off via the same notify-fires-set pattern the gate widgets already use.
- Added `deemphasis_idx: u32` and `notch_enabled: bool` to `SavedTune` so the LOS restore path returns them to their pre-AOS values (mirrors how squelch / CTCSS / FM-IF-NR survive the round trip).
- Updated the round-trip test in `satellites_recorder.rs::saves_and_restores_user_pre_aos_state` with a non-default deemphasis (US 75 µs = idx 2) + notch enabled in the saved tune, asserting both come back at LOS.

### Why LRPT / SSTV weren't affected

- **LRPT** taps IQ pre-demod, doesn't go through the audio chain at all. The bandwidth-reset bug also doesn't bite LRPT because its `default_bandwidth = 144_000` happens to be the right value for QPSK decoding (lucky coincidence — `controller.rs::SetDemodMode` reset lands on the correct value).
- **SSTV** runs at 12.5 kHz NFM by design — the bandwidth-reset bug aligns with the right setting by accident.

### Out of scope (split into follow-up PR)

Doppler tracker race — the 4 Hz tracker tick can re-dispatch `SetVfoOffset` after AOS zeroed it. APT's AM envelope is forgiving of small carrier offsets so this isn't suspected as a NOAA 15 cause; QPSK lock is more fragile so it's a stronger LRPT suspect. Will land as PR #2 after this one merges.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo check --workspace --locked` (no Cargo.lock drift)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 1982 tests pass, 0 failures
- [x] `cargo fmt --all -- --check` clean
- [x] `make install CARGO_FLAGS=\"--release\"` succeeds
- [x] Smoke: pre-pass setup with WFM/US75/notch-on. AOS arm flips Radio panel to NFM/38 kHz/None/notch-off. LOS restores everything. APT/LRPT/SSTV viewers open. Manual mode switch unchanged.
- [ ] **In flight:** real NOAA pass to confirm the image actually lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User's FM broadcast audio settings (deemphasis and notch filter preferences) are now retained when resuming regular listening after auto-recording satellite passes.

* **Bug Fixes**
  * Fixed command dispatch order to prevent bandwidth settings from being unintentionally overwritten during frequency tuning.

* **Tests**
  * Extended unit tests to verify audio-chain parameter preservation across satellite pass cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->