### PR TITLE
fix(sat): disable Doppler tracker during imaging-pass auto-record

### DIFF
--- a/crates/sdr-ui/src/sidebar/satellites_recorder.rs
+++ b/crates/sdr-ui/src/sidebar/satellites_recorder.rs
@@ -247,6 +247,20 @@ pub struct SavedTune {
     /// APT subcarrier. Per silent-fail investigation following
     /// the NOAA 15 pass.
     pub notch_enabled: bool,
+    /// Pre-AOS Doppler-tracker master switch. Forced OFF at
+    /// AOS for the duration of an imaging-protocol pass,
+    /// restored at LOS. The Doppler shift on a NOAA / Meteor /
+    /// ISS pass is ±3.5 kHz worst case at 137 MHz / 145 MHz —
+    /// well inside the channel filters of all three imaging
+    /// protocols (APT 38 kHz, LRPT 144 kHz, SSTV 12.5 kHz).
+    /// During a pass the tracker's 4 Hz tick re-dispatches
+    /// `SetVfoOffset(predicted_doppler)` which can disrupt
+    /// QPSK Costas lock (LRPT) and the APT line-rate clock.
+    /// Disabling for the pass duration loses no functional
+    /// value (channel filters absorb the shift) and removes
+    /// a known disruption source. Per silent-fail investigation
+    /// following the NOAA 15 pass.
+    pub doppler_enabled: bool,
 }
 
 /// Side effects the wiring layer must perform on each transition.
@@ -926,6 +940,7 @@ mod tests {
             fm_if_nr_enabled: false,
             deemphasis_idx: 0,
             notch_enabled: false,
+            doppler_enabled: false,
         }
     }
 
@@ -1277,6 +1292,10 @@ mod tests {
             // wiped after the pass.
             deemphasis_idx: 2,
             notch_enabled: true,
+            // pin: pre-AOS Doppler-tracker switch must come
+            // back at LOS so the user's preference survives
+            // the imaging-protocol pass-time disable.
+            doppler_enabled: true,
         };
         // Walk all transitions.
         r.tick(
@@ -1349,6 +1368,11 @@ mod tests {
                 // following the NOAA 15 pass.
                 assert_eq!(t.deemphasis_idx, 2);
                 assert!(t.notch_enabled);
+                // Pre-AOS Doppler tracker enabled likewise
+                // survives the round trip — the user's
+                // preference comes back at LOS even though
+                // AOS forced it off for the pass duration.
+                assert!(t.doppler_enabled);
             }
             other => panic!("expected RestoreTune, got {other:?}"),
         }

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11036,6 +11036,17 @@ fn connect_satellites_panel(
         // following the NOAA 15 pass.
         let deemphasis_row_a = panels.radio.deemphasis_row.clone();
         let notch_enabled_row_a = panels.radio.notch_enabled_row.clone();
+        // Doppler tracker master switch — also disabled at AOS for
+        // the duration of an imaging-protocol pass. The 4 Hz tick
+        // re-dispatches `SetVfoOffset(predicted_doppler)` which
+        // can disrupt QPSK Costas lock (LRPT) and APT's line-rate
+        // clock. The ±3.5 kHz worst-case Doppler shift at 137 MHz
+        // / 145 MHz is well inside all three imaging-protocol
+        // channel filters (APT 38 kHz, LRPT 144 kHz, SSTV
+        // 12.5 kHz), so disabling for the pass loses no functional
+        // value. Per silent-fail investigation following the
+        // NOAA 15 pass.
+        let doppler_switch_a = panels.satellites.doppler_switch.clone();
         // Composite-save toggle — read at LOS by the
         // `SaveLrptPass` handler. Strong clone so the closure
         // doesn't need to upgrade a weak ref against panel
@@ -11204,6 +11215,17 @@ fn connect_satellites_panel(
                     // value via the same notify chain.
                     if notch_enabled_row_a.is_active() {
                         notch_enabled_row_a.set_active(false);
+                    }
+                    // Doppler tracker: 4 Hz `SetVfoOffset` ticks can
+                    // disrupt QPSK Costas lock and the APT line-rate
+                    // clock. The ±3.5 kHz worst-case shift fits
+                    // inside every imaging-protocol channel filter,
+                    // so disabling for the pass loses no functional
+                    // value and removes a known disruption source.
+                    // Per silent-fail investigation following the
+                    // NOAA 15 pass.
+                    if doppler_switch_a.is_active() {
+                        doppler_switch_a.set_active(false);
                     }
                 };
                 match protocol {
@@ -12172,6 +12194,15 @@ fn connect_satellites_panel(
                 if saved.notch_enabled != notch_enabled_row_a.is_active() {
                     notch_enabled_row_a.set_active(saved.notch_enabled);
                 }
+                // Doppler tracker — restore the user's pre-AOS
+                // master-switch preference. The AOS-side
+                // `force_audio_chain_off` flipped it off for the
+                // pass; this brings it back so the next pass (if
+                // they have Doppler on as their default) gets
+                // automatic correction again.
+                if saved.doppler_enabled != doppler_switch_a.is_active() {
+                    doppler_switch_a.set_active(saved.doppler_enabled);
+                }
                 // Re-arm the scanner if it was running pre-AOS.
                 // The AOS-side `tune_a` call goes through
                 // `tune_to_satellite`, which fires
@@ -12255,6 +12286,11 @@ fn connect_satellites_panel(
         // to their pre-AOS values.
         let deemphasis_row_tick = panels.radio.deemphasis_row.clone();
         let notch_enabled_row_tick = panels.radio.notch_enabled_row.clone();
+        // Doppler tracker master switch — also force-disabled at
+        // AOS for the duration of an imaging-protocol pass.
+        // Snapshotted here so the LOS restore path can return
+        // the user's pre-AOS preference.
+        let doppler_switch_tick = panels.satellites.doppler_switch.clone();
         let _ = glib::timeout_add_local(SATELLITES_COUNTDOWN_TICK, move || {
             let Some(panel) = panel_weak_tick.upgrade() else {
                 return glib::ControlFlow::Break;
@@ -12320,6 +12356,7 @@ fn connect_satellites_panel(
                 fm_if_nr_enabled: fm_if_nr_row_tick.is_active(),
                 deemphasis_idx: deemphasis_row_tick.selected(),
                 notch_enabled: notch_enabled_row_tick.is_active(),
+                doppler_enabled: doppler_switch_tick.is_active(),
             };
             // Read the user's selected quality tier on every
             // tick — cheap (just a ComboRow.selected() call), and


### PR DESCRIPTION
## Summary

Follow-up to PR #603 (APT bandwidth + audio chain) per the silent-fail investigation. The Doppler tracker's 4 Hz tick re-dispatches `SetVfoOffset(predicted_doppler)` every 250 ms during a pass when the delta exceeds `DOPPLER_DISPATCH_THRESHOLD_HZ` (5 Hz). Each dispatch walks the same DSP path a manual VFO drag does — re-tunes the front-end and resets some downstream state. For the satellite-image decoders this is a known disruption source:

- **LRPT QPSK** Costas loop has to re-acquire on each step. A continuous ~100 Hz/sec drift at TCA (which the loop tracks fine) becomes a stair-step of 5+ Hz instantaneous jumps every 250 ms (which the loop fights).
- **APT** line-rate clock recovery sees periodic phase discontinuities at exactly the moments the AM envelope detector is integrating scan-line samples.
- **SSTV** PD-family decoders use a per-line PLL that doesn't benefit from external frequency steps.

The ±3.5 kHz worst-case Doppler shift at 137 MHz / 145 MHz is well inside every imaging-protocol channel filter (APT 38 kHz, LRPT 144 kHz, SSTV 12.5 kHz). Disabling the tracker for the duration of a pass therefore loses no functional value — the channel filter absorbs the shift either way — and removes the disruption source.

## Implementation

Mirrors the audio-chain force-off / restore pattern from PR #603:

- `force_audio_chain_off()` extended to also flip `panels.satellites.doppler_switch` to off via the same notify-fires-set chain (the tracker's `set_master_enabled` on-disable transition handles flushing the live offset back to the user_reference baseline).
- `SavedTune` gains `doppler_enabled: bool` for the LOS restore.
- The 1-Hz tick that snapshots `SavedTune` reads the doppler_switch state pre-AOS.
- The LOS `RecorderAction::RestoreTune` handler restores the switch alongside squelch / CTCSS / FM-IF-NR / deemphasis / notch.

Round-trip test in `satellites_recorder.rs::saves_and_restores_user_pre_aos_state` extended with `doppler_enabled: true` in the saved-tune fixture and a matching assertion that it survives AOS → LOS.

User can still flip Doppler on mid-pass manually if they want to override the auto-disable. The pre-AOS preference is what gets restored at LOS.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo check --workspace --locked` (no Cargo.lock drift)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 1982 tests pass, 0 failures
- [x] `cargo fmt --all -- --check` clean
- [x] `make install CARGO_FLAGS=\"--release\"` succeeds
- [x] Smoke: pre-AOS Doppler ON. AOS arm flips switch off. LOS restores. Manual mid-pass toggle still works.
- [ ] **In flight:** real NOAA + Meteor passes to confirm decode behaviour with Doppler suppressed during the pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doppler tracker setting is now preserved when recording satellites across the full acquisition-to-loss cycle.

* **Bug Fixes**
  * Automatically disable Doppler tracker during satellite imaging to prevent signal disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->