### PR TITLE
fix(lrpt): resolve QPSK phase ambiguity via medet-faithful 8-pattern soft sync

### DIFF
--- a/crates/sdr-lrpt/src/fec/chain.rs
+++ b/crates/sdr-lrpt/src/fec/chain.rs
@@ -1,34 +1,49 @@
 //! End-to-end FEC chain — soft i8 symbol pairs in, decoded VCDU
 //! bytes out.
 //!
-//! Stitches the per-stage primitives ([`ViterbiDecoder`],
-//! [`SyncCorrelator`], [`Derandomizer`], [`ReedSolomon`]) into a
-//! single streaming state machine matching medet's `try_frame`
-//! flow:
+//! Stitches the per-stage primitives ([`SoftSyncDetector`],
+//! [`ViterbiDecoder`], [`SyncCorrelator`], [`Derandomizer`],
+//! [`ReedSolomon`]) into a single streaming state machine
+//! matching medet's `try_frame` flow:
 //!
 //! ```text
-//!   soft i8 pair ─▶ Viterbi ─bit▶ Sync correlator ─bit▶ {hunting | capturing}
-//!                                                                   │
-//!                          ASM hit                                  │
-//!                                                                   ▼
-//!                                                       1020-byte CADU buffer
-//!                                                                   │
-//!                                                                   ▼
-//!                                          derandomize  → de-interleave (×4)
-//!                                                                   │
-//!                                                                   ▼
-//!                                       RS-decode each codeword (255 → 223 bytes)
-//!                                                                   │
-//!                                                                   ▼
-//!                                          re-interleave → 892-byte VCDU
+//!   soft i8 pair ─▶ SoftSyncDetector (8 rotated patterns)
+//!                            │
+//!                            ▼ rotation locked
+//!                   Rotation::apply (un-rotate to canonical)
+//!                            │
+//!                            ▼
+//!                         Viterbi ─bit▶ SyncCorrelator (per-CADU re-sync)
+//!                                                  │
+//!                                                  ▼
+//!                                       1020-byte CADU buffer
+//!                                                  │
+//!                                                  ▼
+//!                          derandomize  → de-interleave (×4)
+//!                                                  │
+//!                                                  ▼
+//!                       RS-decode each codeword (255 → 223 bytes)
+//!                                                  │
+//!                                                  ▼
+//!                          re-interleave → 892-byte VCDU
 //! ```
+//!
+//! [`SoftSyncDetector`] resolves the QPSK 4-fold phase ambiguity
+//! (plus optional I/Q axis swap) by pre-Viterbi soft correlation
+//! against 8 rotated forms of the encoded ASM. Without it,
+//! ~75 % of Costas acquisitions silently drop the entire pass
+//! (issue #605). Once locked, every subsequent soft pair is
+//! un-rotated by [`Rotation::apply`] before reaching Viterbi,
+//! so Viterbi always sees the canonical orientation.
 //!
 //! Layered like this so [`LrptPipeline::push_symbol`] can be a
 //! thin wrapper that drives the chain and feeds emitted VCDUs
 //! into the existing demux + image stages, while the chain
 //! itself stays unit-testable on synthetic byte streams.
 
-use crate::fec::{Derandomizer, ReedSolomon, SyncCorrelator, ViterbiDecoder};
+use crate::fec::{
+    Derandomizer, ReedSolomon, Rotation, SoftSyncDetector, SyncCorrelator, ViterbiDecoder,
+};
 
 /// Bytes captured per CADU after the ASM. Per CCSDS §10:
 /// 1024-byte CADU = 4-byte ASM + 1020-byte payload. The ASM is
@@ -53,17 +68,47 @@ const RS_MESSAGE_LEN: usize = 223;
 /// [`super::super::ccsds::Demux`] expects per VCDU.
 const VCDU_LEN: usize = RS_INTERLEAVE * RS_MESSAGE_LEN; // 892
 
-/// Per-bit chain state. Hunting until ASM, then capturing 1020
-/// bytes worth of CADU payload.
+/// Per-symbol chain state. Two-phase lock:
+///
+/// 1. [`State::HuntingRotation`]: feeding raw soft pairs to the
+///    pre-Viterbi [`SoftSyncDetector`] until one of 8 rotated
+///    ASM patterns matches. On match we know which orientation
+///    Costas locked at.
+/// 2. [`State::Locked`]: every subsequent soft pair is un-rotated
+///    by [`Rotation::apply`] before reaching Viterbi. The
+///    post-Viterbi [`SyncCorrelator`] then runs per-CADU sync
+///    on the decoded bit stream — same logic as the original
+///    chain, but now operating on a known-canonical bit stream
+///    that actually produces matches.
+///
+/// Once Locked, we stay Locked for the whole pass. Costas can
+/// drift through quarter-turns during a low-SNR pass, but
+/// re-detecting per-CADU would only re-lock at the same
+/// (correct) rotation in the steady state. If we ever observe
+/// pathological mid-pass rotation drift, a "if last K CADUs all
+/// failed RS, re-hunt rotation" fallback can be added later.
 #[derive(Debug)]
 enum State {
-    /// Looking for the ASM in the post-Viterbi bit stream.
-    Hunting,
-    /// ASM matched; capturing the next [`CADU_PAYLOAD_LEN`]
-    /// bytes of payload, packing 8 bits at a time. `partial` /
-    /// `partial_count` accumulate the in-flight byte; `bytes`
-    /// holds the completed bytes.
-    Capturing {
+    /// No rotation lock yet. Soft pairs feed
+    /// [`SoftSyncDetector`] only — Viterbi is not stepped, so it
+    /// stays in its initial state ready for fresh warmup once
+    /// rotation locks.
+    HuntingRotation,
+    /// Rotation locked. Apply [`Rotation::apply`] to every soft
+    /// pair, push through Viterbi, run per-CADU sync on the
+    /// emitted bits. `cadu` holds the in-flight CADU capture
+    /// state (same fields as the original `Capturing` variant);
+    /// `is_capturing` distinguishes "looking for next CADU's ASM
+    /// in the bit stream" from "actively capturing CADU bytes".
+    /// `inverted` is `true` when the per-CADU [`SyncCorrelator`]
+    /// matched the bitwise-inverted ASM rather than the upright
+    /// form, signalling a 180° residual after rotation lock —
+    /// captured bytes get `XOR`ed with `0xFF` before derand to
+    /// undo the inversion.
+    Locked {
+        rotation: Rotation,
+        is_capturing: bool,
+        inverted: bool,
         bytes: Vec<u8>,
         partial: u8,
         partial_count: u8,
@@ -73,6 +118,7 @@ enum State {
 /// Streaming FEC chain — push one soft i8 symbol pair per call,
 /// receive a decoded VCDU when one becomes available.
 pub struct FecChain {
+    detector: SoftSyncDetector,
     viterbi: ViterbiDecoder,
     sync: SyncCorrelator,
     derand: Derandomizer,
@@ -90,11 +136,12 @@ impl FecChain {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            detector: SoftSyncDetector::new(),
             viterbi: ViterbiDecoder::new(),
             sync: SyncCorrelator::new(),
             derand: Derandomizer::new(),
             rs: ReedSolomon::new(),
-            state: State::Hunting,
+            state: State::HuntingRotation,
         }
     }
 
@@ -102,55 +149,149 @@ impl FecChain {
     /// worth from the demod). Returns `Some(VCDU bytes)` on the
     /// call that completes a successful CADU decode; otherwise
     /// `None`. Failed RS decodes are silently dropped — the
-    /// chain returns to hunting for the next ASM.
+    /// chain returns to hunting for the next ASM (without losing
+    /// rotation lock).
     pub fn push_symbol(&mut self, soft: [i8; 2]) -> Option<Vec<u8>> {
-        let bit = self.viterbi.step(soft)?;
-        self.process_bit(bit)
-    }
-
-    /// Reset the entire chain to a fresh state. Called between
-    /// passes. Per-stage internals (Viterbi traceback, sync
-    /// window, derand position) all flush; in-flight CADU
-    /// capture is dropped.
-    pub fn reset(&mut self) {
-        self.viterbi = ViterbiDecoder::new();
-        self.sync = SyncCorrelator::new();
-        self.derand.reset();
-        self.state = State::Hunting;
-    }
-
-    fn process_bit(&mut self, bit: u8) -> Option<Vec<u8>> {
-        match &mut self.state {
-            State::Hunting => {
-                if self.sync.push(bit).is_some() {
-                    self.state = State::Capturing {
+        match &self.state {
+            State::HuntingRotation => {
+                if let Some(rotation) = self.detector.push_symbol(soft) {
+                    // Rotation acquired — transition to Locked.
+                    //
+                    // **Critical**: the ASM-containing soft samples
+                    // were just consumed by `SoftSyncDetector` and
+                    // never reached Viterbi. If we don't replay
+                    // them, the post-Viterbi bit stream starts
+                    // with CADU payload bits, the per-CADU
+                    // `SyncCorrelator` never sees the ASM, and we
+                    // miss the entire first CADU. Drain the
+                    // detector's window and step Viterbi on the
+                    // un-rotated samples so the ASM is properly
+                    // queued for emission once Viterbi's
+                    // TRACEBACK_DEPTH-symbol warmup completes.
+                    let window = self.detector.drain_window();
+                    self.state = State::Locked {
+                        rotation,
+                        is_capturing: false,
+                        inverted: false,
                         bytes: Vec::with_capacity(CADU_PAYLOAD_LEN),
                         partial: 0,
                         partial_count: 0,
                     };
+                    let mut emitted: Option<Vec<u8>> = None;
+                    for pair_chunk in window.chunks_exact(2) {
+                        let pair = [pair_chunk[0], pair_chunk[1]];
+                        let rotated = rotation.apply(pair);
+                        if let Some(bit) = self.viterbi.step(rotated) {
+                            // Replay during a 32-symbol drain
+                            // can't possibly emit a bit (Viterbi
+                            // needs TRACEBACK_DEPTH=224 symbols),
+                            // but defensively route any bit
+                            // through `process_bit` so a future
+                            // Viterbi tweak doesn't regress.
+                            if let Some(vcdu) = self.process_bit(bit) {
+                                // Multiple CADUs in one push are
+                                // impossible at our chunk size,
+                                // but if it ever happened we'd
+                                // drop the second one — flag it.
+                                debug_assert!(emitted.is_none(), "drain emitted multiple VCDUs",);
+                                emitted = Some(vcdu);
+                            }
+                        }
+                    }
+                    return emitted;
                 }
                 None
             }
-            State::Capturing {
-                bytes,
-                partial,
-                partial_count,
-            } => {
-                *partial = (*partial << 1) | (bit & 1);
-                *partial_count += 1;
-                if *partial_count == 8 {
-                    bytes.push(*partial);
-                    *partial = 0;
-                    *partial_count = 0;
-                }
-                if bytes.len() == CADU_PAYLOAD_LEN {
-                    let cadu = std::mem::take(bytes);
-                    self.state = State::Hunting;
-                    return self.decode_cadu(cadu);
-                }
-                None
+            State::Locked { rotation, .. } => {
+                let rotated = rotation.apply(soft);
+                let bit = self.viterbi.step(rotated)?;
+                self.process_bit(bit)
             }
         }
+    }
+
+    /// Reset the entire chain to a fresh state. Called between
+    /// passes. Per-stage internals (Viterbi traceback, sync
+    /// window, derand position, rotation detector) all flush;
+    /// in-flight CADU capture is dropped.
+    pub fn reset(&mut self) {
+        self.detector.reset();
+        self.viterbi = ViterbiDecoder::new();
+        self.sync = SyncCorrelator::new();
+        self.derand.reset();
+        self.state = State::HuntingRotation;
+    }
+
+    /// Currently-locked rotation, or `None` while the chain is
+    /// still hunting. Exposed for diagnostics / future status-bar
+    /// readouts; the FEC chain itself routes the rotation
+    /// internally.
+    #[must_use]
+    pub fn locked_rotation(&self) -> Option<Rotation> {
+        match self.state {
+            State::Locked { rotation, .. } => Some(rotation),
+            State::HuntingRotation => None,
+        }
+    }
+
+    fn process_bit(&mut self, bit: u8) -> Option<Vec<u8>> {
+        let State::Locked {
+            is_capturing,
+            inverted,
+            bytes,
+            partial,
+            partial_count,
+            ..
+        } = &mut self.state
+        else {
+            // Unreachable: process_bit is only called from the
+            // Locked arm of push_symbol. Match-irrefutable would
+            // require pulling the fields apart further; leave
+            // the early-return as a defensive guard.
+            return None;
+        };
+        if !*is_capturing {
+            // Per-CADU ASM hunt on the post-Viterbi bit stream.
+            // This re-syncs every CADU regardless of bit-level
+            // jitter; rotation is already locked. The hit's
+            // `inverted` flag tells us whether the rotation
+            // detector picked the right of two 180°-symmetric
+            // patterns — if not, captured payload bytes get
+            // XORed with 0xFF below.
+            if let Some(hit) = self.sync.push(bit) {
+                *is_capturing = true;
+                *inverted = hit.inverted;
+            }
+            return None;
+        }
+        // Capturing CADU payload: 8 bits → 1 byte, accumulate
+        // until CADU_PAYLOAD_LEN bytes are in hand.
+        *partial = (*partial << 1) | (bit & 1);
+        *partial_count += 1;
+        if *partial_count == 8 {
+            // If the pre-Viterbi rotation lock was 180° off,
+            // every emitted byte is the bit-inverted form of
+            // what derand expects. Flip them at capture time so
+            // derand → RS see the canonical bytes. Per medet's
+            // `try_frame` residual-flip safety net.
+            let byte = if *inverted { *partial ^ 0xFF } else { *partial };
+            bytes.push(byte);
+            *partial = 0;
+            *partial_count = 0;
+        }
+        if bytes.len() == CADU_PAYLOAD_LEN {
+            let cadu = std::mem::take(bytes);
+            // Reset to "hunting for the next ASM in the same
+            // rotation" — keep rotation lock, fresh sync state,
+            // clear the inversion flag (next ASM hunt re-decides).
+            *is_capturing = false;
+            *inverted = false;
+            *partial = 0;
+            *partial_count = 0;
+            self.sync = SyncCorrelator::new();
+            return self.decode_cadu(cadu);
+        }
+        None
     }
 
     /// Decode one captured CADU payload: derandomize, de-interleave
@@ -195,52 +336,22 @@ mod tests {
     #[test]
     fn fec_chain_constructible_and_resets() {
         let mut c = FecChain::new();
-        assert!(matches!(c.state, State::Hunting));
+        assert!(matches!(c.state, State::HuntingRotation));
+        assert_eq!(c.locked_rotation(), None);
         c.reset();
-        assert!(matches!(c.state, State::Hunting));
+        assert!(matches!(c.state, State::HuntingRotation));
+        assert_eq!(c.locked_rotation(), None);
     }
 
     #[test]
     fn fec_chain_returns_none_during_warmup() {
-        // Viterbi needs TRACEBACK_DEPTH symbol pairs before it
-        // emits its first bit. Until then, push_symbol must
-        // return None on every call.
+        // Until rotation locks (which requires a clean ASM in the
+        // soft stream), push_symbol returns None on every call.
         let mut c = FecChain::new();
         for _ in 0..10 {
             let result = c.push_symbol([0, 0]);
             assert!(result.is_none());
         }
-    }
-
-    /// Pump a full clean ASM bit pattern through the chain's
-    /// `process_bit` (skipping Viterbi). After ASM the next
-    /// 1020 bytes are zeros (which derand will XOR to PN, then
-    /// RS will fail on because zeros aren't a valid codeword).
-    /// We're not testing the VCDU contents — just that the
-    /// state machine cleanly transitions Hunting → Capturing
-    /// → Hunting without a panic.
-    #[test]
-    fn process_bit_state_machine_transitions_after_asm() {
-        let mut c = FecChain::new();
-        // Push the ASM bits one at a time, MSB-first.
-        let asm = crate::fec::ASM;
-        for i in 0..32 {
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "ASM is u32; shift index 0..32 is safe"
-            )]
-            let bit = ((asm >> (31 - i)) & 1) as u8;
-            let _ = c.process_bit(bit);
-        }
-        // After ASM the chain must be capturing.
-        assert!(matches!(c.state, State::Capturing { .. }));
-        // Push 1020 × 8 zero bits to fill the CADU buffer.
-        for _ in 0..(CADU_PAYLOAD_LEN * 8) {
-            let _ = c.process_bit(0);
-        }
-        // CADU complete → decode_cadu attempted → returned to
-        // Hunting (whether RS succeeded or not).
-        assert!(matches!(c.state, State::Hunting));
     }
 
     #[test]
@@ -316,5 +427,128 @@ mod tests {
         // 32 + 8160 = 8192 bits. Pin so a future constant tweak
         // that breaks the protocol layout fails loudly.
         assert_eq!(CADU_TOTAL_BITS, 8192);
+    }
+
+    /// Forward QPSK rotation transform that builds pattern N
+    /// in [`super::super::soft_sync::build_patterns`]. Test-only
+    /// — the production path only ever applies the *inverse*
+    /// (`Rotation::ALL[N].apply`) to received samples.
+    ///
+    /// Pinned in `chain.rs` so the round-trip test below
+    /// catches any `soft_sync.rs` refactor that changes the
+    /// forward table without simultaneously updating `apply()`.
+    fn forward_rotation(idx: usize, p: [i8; 2]) -> [i8; 2] {
+        let neg = |x: i8| x.saturating_neg();
+        let [i, q] = p;
+        match idx {
+            0 => [i, q],
+            1 => [q, neg(i)],
+            2 => [neg(i), neg(q)],
+            3 => [neg(q), i],
+            4 => [q, i],
+            5 => [i, neg(q)],
+            6 => [neg(q), neg(i)],
+            7 => [neg(i), q],
+            _ => unreachable!(),
+        }
+    }
+
+    /// Build a clean encoded soft stream for one full CADU
+    /// (ASM + RS-encoded + derandomised payload that decodes
+    /// back to `original_vcdu`), padded with enough trailing
+    /// zero input bits to flush Viterbi's traceback so the
+    /// chain emits the VCDU before the soft buffer runs out.
+    fn synthesise_cadu_soft(original_vcdu: &[u8]) -> Vec<i8> {
+        // RS-encode: de-interleave VCDU → 4 messages, encode
+        // each, re-interleave into 1020-byte CADU payload.
+        let rs = ReedSolomon::new();
+        let mut messages = [[0_u8; RS_MESSAGE_LEN]; RS_INTERLEAVE];
+        for col in 0..RS_INTERLEAVE {
+            for i in 0..RS_MESSAGE_LEN {
+                messages[col][i] = original_vcdu[i * RS_INTERLEAVE + col];
+            }
+        }
+        let codewords: Vec<[u8; RS_CODEWORD_LEN]> = messages.iter().map(|m| rs.encode(m)).collect();
+        let mut cadu_payload = vec![0_u8; CADU_PAYLOAD_LEN];
+        for col in 0..RS_INTERLEAVE {
+            for i in 0..RS_CODEWORD_LEN {
+                cadu_payload[i * RS_INTERLEAVE + col] = codewords[col][i];
+            }
+        }
+        // Apply derand so the chain's derand re-XOR recovers the
+        // RS-encoded form.
+        let mut derand = Derandomizer::new();
+        derand.reset();
+        for byte in &mut cadu_payload {
+            *byte = derand.process(*byte);
+        }
+        // Build the ASM + payload bitstream (MSB first).
+        let mut bits: Vec<u8> = Vec::with_capacity(32 + CADU_PAYLOAD_LEN * 8);
+        for i in 0..32 {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "ASM is u32, shift index 0..32 is safe"
+            )]
+            let bit = ((crate::fec::ASM >> (31 - i)) & 1) as u8;
+            bits.push(bit);
+        }
+        for &byte in &cadu_payload {
+            for j in 0..8 {
+                bits.push((byte >> (7 - j)) & 1);
+            }
+        }
+        // Trailing zero bits: enough to push every CADU bit out
+        // of Viterbi's TRACEBACK_DEPTH window. 32 ASM + 8160
+        // payload + slack = 8500 input bits for a comfortable
+        // margin (Viterbi's traceback is 224 symbols).
+        bits.extend(std::iter::repeat_n(0_u8, 500));
+        crate::fec::viterbi::ccsds_encode(&bits)
+    }
+
+    /// **Gold-standard test for issue #605.** Build a clean
+    /// CADU, convolutionally encode it, apply each of 8 forward
+    /// rotation transforms (one per QPSK phase + I/Q-swap
+    /// orientation Costas can lock at), push through
+    /// `FecChain`, and assert the chain recovers the original
+    /// VCDU at every rotation. Before the `SoftSyncDetector`
+    /// fix, this test would have failed for 7 of 8 rotations —
+    /// the chain only decoded at the upright phase.
+    #[test]
+    fn fec_chain_decodes_through_each_of_eight_rotations() {
+        // Distinct, non-uniform VCDU content so any byte-order
+        // bug surfaces visibly.
+        let mut original_vcdu = vec![0_u8; VCDU_LEN];
+        for (i, b) in original_vcdu.iter_mut().enumerate() {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "modulo 256 fits in u8 by definition"
+            )]
+            let byte = ((i * 7 + 11) % 256) as u8;
+            *b = byte;
+        }
+        let soft = synthesise_cadu_soft(&original_vcdu);
+        for (idx, rot) in Rotation::ALL.iter().enumerate() {
+            let mut chain = FecChain::new();
+            let mut decoded: Option<Vec<u8>> = None;
+            for pair_chunk in soft.chunks_exact(2) {
+                let pair = [pair_chunk[0], pair_chunk[1]];
+                let rotated = forward_rotation(idx, pair);
+                if let Some(vcdu) = chain.push_symbol(rotated)
+                    && decoded.is_none()
+                {
+                    decoded = Some(vcdu);
+                }
+            }
+            assert_eq!(
+                chain.locked_rotation(),
+                Some(*rot),
+                "rotation {idx} ({rot:?}): chain should report the matching rotation",
+            );
+            assert_eq!(
+                decoded.as_ref(),
+                Some(&original_vcdu),
+                "rotation {idx} ({rot:?}): chain failed to decode VCDU",
+            );
+        }
     }
 }

--- a/crates/sdr-lrpt/src/fec/chain.rs
+++ b/crates/sdr-lrpt/src/fec/chain.rs
@@ -193,7 +193,7 @@ impl FecChain {
                                 // impossible at our chunk size,
                                 // but if it ever happened we'd
                                 // drop the second one — flag it.
-                                debug_assert!(emitted.is_none(), "drain emitted multiple VCDUs",);
+                                debug_assert!(emitted.is_none(), "drain emitted multiple VCDUs");
                                 emitted = Some(vcdu);
                             }
                         }
@@ -280,7 +280,13 @@ impl FecChain {
             *partial_count = 0;
         }
         if bytes.len() == CADU_PAYLOAD_LEN {
-            let cadu = std::mem::take(bytes);
+            // `mem::replace` (vs `mem::take`) preserves the
+            // pre-allocated capacity for the next CADU's bytes
+            // buffer — `mem::take` would leave `bytes` as a
+            // zero-capacity Vec and force a fresh allocation
+            // on every CADU in the locked steady-state path.
+            // Per CR round 1 on PR #606.
+            let cadu = std::mem::replace(bytes, Vec::with_capacity(CADU_PAYLOAD_LEN));
             // Reset to "hunting for the next ASM in the same
             // rotation" — keep rotation lock, fresh sync state,
             // clear the inversion flag (next ASM hunt re-decides).

--- a/crates/sdr-lrpt/src/fec/mod.rs
+++ b/crates/sdr-lrpt/src/fec/mod.rs
@@ -14,11 +14,15 @@
 pub mod chain;
 pub mod derand;
 pub mod reed_solomon;
+pub mod soft_sync;
 pub mod sync;
 pub mod viterbi;
 
 pub use chain::FecChain;
 pub use derand::Derandomizer;
 pub use reed_solomon::{K as RS_K, N as RS_N, ReedSolomon, RsError, T as RS_T};
+pub use soft_sync::{
+    ASM_ENCODED, ASM_ENCODED_BITS, ROTATION_COUNT, Rotation, SOFT_SYNC_THRESHOLD, SoftSyncDetector,
+};
 pub use sync::{ASM, ASM_BITS, SYNC_THRESHOLD, SyncCorrelator};
 pub use viterbi::{POLYA, POLYB, TRACEBACK_DEPTH, ViterbiDecoder};

--- a/crates/sdr-lrpt/src/fec/soft_sync.rs
+++ b/crates/sdr-lrpt/src/fec/soft_sync.rs
@@ -1,0 +1,654 @@
+//! Pre-Viterbi soft-symbol sync detection with QPSK phase
+//! ambiguity resolution.
+//!
+//! After Costas locks, QPSK has a 4-fold phase ambiguity
+//! (0°/90°/180°/270°), and the I/Q axis can be swapped on top of
+//! that — yielding 8 distinct symbol-mapping orientations. Our
+//! original [`super::SyncCorrelator`] (hard-bit, post-Viterbi)
+//! only catches the upright-phase orientation, which means
+//! ~25% per-acquisition success on Meteor passes (issue #605).
+//!
+//! [`SoftSyncDetector`] mirrors `medet`'s `corr_correlate`
+//! (`original/medet/correlator.pas:174`): build 8 rotated
+//! patterns from the encoded ASM (`0xFCA2_B63D_B00D_9794` —
+//! the bit string after running 0x1ACFFC1D through the CCSDS
+//! K=7 rate-1/2 convolutional encoder), slide a window over
+//! the incoming soft samples, score each pattern, and report
+//! the best match together with the rotation that matched.
+//! [`FecChain`] then applies the inverse rotation to every
+//! subsequent soft pair before feeding Viterbi, so Viterbi
+//! always sees the canonical orientation regardless of where
+//! Costas happened to lock.
+//!
+//! Reference (read-only): `original/medet/correlator.pas`.
+//! `original/medet/met_to_data.pas:74` confirms the encoded ASM
+//! constant.
+//!
+//! [`FecChain`]: super::FecChain
+
+/// Encoded form of the CCSDS attached sync marker (`0x1ACFFC1D`)
+/// after passing through OUR K=7 rate-1/2 convolutional encoder
+/// (`crates/sdr-lrpt/src/fec/viterbi.rs::ccsds_encode`). 64 bits
+/// = 32 QPSK symbols = 64 soft-sample axis components.
+///
+/// **Why not medet's value.** medet (`met_to_data.pas:74`) uses
+/// `qword($fca2b63db00d9794)`. Our convolutional encoder uses
+/// the bit-reversed polynomial form (`POLYA = 79`, `POLYB = 109`
+/// rather than the spec's `0o171` / `0o133`) and pushes input
+/// bits at the HIGH bit of the shift register. Both conventions
+/// are mathematically equivalent (the underlying convolutional
+/// code is linear, so any consistent encoder/decoder pair
+/// works), but they produce DIFFERENT encoded ASM bit strings.
+/// The pattern correlator must match the encoder it's paired
+/// with — so we use what `ccsds_encode` actually produces, not
+/// what medet produces.
+///
+/// `0x1ACFFC1D` was verified by hand against `ccsds_encode`
+/// output:
+/// ```text
+/// let bits: Vec<u8> = (0..32).map(|i| ((0x1ACF_FC1D_u32 >> (31 - i)) & 1) as u8).collect();
+/// let encoded = ccsds_encode(&bits)[..64];
+/// // Convert: positive soft → bit 0, negative → bit 1.
+/// // Resulting u64 (MSB first) = 0x0391_853E_8FF1_64AB
+/// ```
+/// Pinned by [`super::tests::asm_encoded_matches_ccsds_encode_output`].
+pub const ASM_ENCODED: u64 = 0x0391_853E_8FF1_64AB;
+
+/// Number of soft-sample axis components in the encoded ASM
+/// (= bits in [`ASM_ENCODED`]).
+pub const ASM_ENCODED_BITS: usize = 64;
+
+/// Soft-correlation threshold for declaring lock. The maximum
+/// possible score is `127 * 64 = 8128` (every soft sample
+/// saturated and matching the expected sign). The threshold
+/// must be high enough to reject false locks on noise but low
+/// enough to allow a moderately weak signal to acquire.
+///
+/// `4000` ≈ 49 % of the theoretical maximum — equivalent to an
+/// average soft magnitude of 62.5 across all 64 samples with
+/// every sign correct, or 127 with ~30 sign errors out of 64.
+/// Mirrors medet's `corr_limit=55` threshold (which uses a
+/// different 0/1 hard-correlation scoring; same meaning of
+/// "majority of bits agree").
+pub const SOFT_SYNC_THRESHOLD: i32 = 4_000;
+
+/// Number of rotated patterns to check. 4 base rotations
+/// (0°/90°/180°/270°) × 2 (with / without I/Q axis swap) = 8.
+/// Matches `medet`'s `pattern_cnt=8`.
+pub const ROTATION_COUNT: usize = 8;
+
+/// Symbol-mapping orientation Costas locked at, identified by
+/// matching one of [`ROTATION_COUNT`] patterns. Drives the
+/// inverse-rotation transform applied to every subsequent soft
+/// pair before Viterbi sees it.
+///
+/// Pattern indices match `medet`'s `corr_init` numbering:
+/// 0..3 = base rotations, 4..7 = same rotations after I/Q swap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rotation {
+    /// 0° — identity, Costas locked at the upright phase.
+    Zero,
+    /// 90° clockwise.
+    Rot90,
+    /// 180° — both I and Q sign-flipped.
+    Rot180,
+    /// 270° clockwise (90° counter-clockwise).
+    Rot270,
+    /// I/Q axis swapped (no rotation on top).
+    Swap,
+    /// I/Q swapped + 90° rotation.
+    SwapRot90,
+    /// I/Q swapped + 180° rotation.
+    SwapRot180,
+    /// I/Q swapped + 270° rotation.
+    SwapRot270,
+}
+
+impl Rotation {
+    /// All eight rotations in pattern-index order.
+    pub const ALL: [Rotation; ROTATION_COUNT] = [
+        Rotation::Zero,
+        Rotation::Rot90,
+        Rotation::Rot180,
+        Rotation::Rot270,
+        Rotation::Swap,
+        Rotation::SwapRot90,
+        Rotation::SwapRot180,
+        Rotation::SwapRot270,
+    ];
+
+    /// Build a `Rotation` from its pattern index (0..8).
+    /// Returns `None` for out-of-range indices; this only happens
+    /// in test code that programmatically iterates indices.
+    #[must_use]
+    pub fn from_index(idx: usize) -> Option<Self> {
+        Self::ALL.get(idx).copied()
+    }
+
+    /// Apply the rotation to one soft `(I, Q)` pair, producing the
+    /// canonical-orientation pair that Viterbi expects to see.
+    ///
+    /// This is the **inverse** of the forward transform that
+    /// `build_patterns` applies to the upright ASM to build
+    /// pattern N. So if `SoftSyncDetector` matches pattern N
+    /// (meaning Costas locked at rotation N) and we then call
+    /// `Rotation::ALL[N].apply(soft)` on every subsequent soft
+    /// pair, the chain sees the un-rotated canonical orientation.
+    ///
+    /// Derivation. The forward transform `T_N` is what
+    /// `rotate_signs` (composed with `swap_iq` for variants 4-7)
+    /// applies to build the pattern; that's what the receiver
+    /// observes when Costas locked at rotation N. The inverse
+    /// `T_N⁻¹` recovers the transmitted pair. For example,
+    /// `T_1`: `(i, q) → (q, -i)` (a 90° clockwise rotation in
+    /// the I/Q plane), so `T_1⁻¹`: `(i, q) → (-q, i)` (a 90°
+    /// counter-clockwise rotation). Doing `T_1⁻¹ ∘ T_1 =
+    /// identity` is verified by the
+    /// `apply_is_inverse_of_forward` test.
+    #[must_use]
+    pub fn apply(self, soft: [i8; 2]) -> [i8; 2] {
+        // Saturating-negate so `i8::MIN` doesn't overflow when
+        // its sign is flipped. `i8::MIN.saturating_neg()` returns
+        // `i8::MAX` — the only value affected; for the typical
+        // ±127 soft range this is a no-op.
+        let neg = |x: i8| x.saturating_neg();
+        let [i, q] = soft;
+        match self {
+            // 0°: identity.
+            Rotation::Zero => [i, q],
+            // T_1⁻¹ for T_1: (i, q) → (q, -i).
+            Rotation::Rot90 => [neg(q), i],
+            // T_2⁻¹ for T_2: (i, q) → (-i, -q). Self-inverse.
+            Rotation::Rot180 => [neg(i), neg(q)],
+            // T_3⁻¹ for T_3: (i, q) → (-q, i).
+            Rotation::Rot270 => [q, neg(i)],
+            // T_4 = swap: (i, q) → (q, i). Self-inverse.
+            Rotation::Swap => [q, i],
+            // T_5 = swap then 90° CW: (i, q) → (q, i) → (i, -q).
+            // Self-inverse: applying twice returns the input.
+            Rotation::SwapRot90 => [i, neg(q)],
+            // T_6 = swap then 180°: (i, q) → (q, i) → (-q, -i).
+            // T_6⁻¹: (a, b) → (-b, -a). Same form as T_6 because
+            // (-q, -i) re-applied gives (-(-i), -(-q)) = (i, q).
+            Rotation::SwapRot180 => [neg(q), neg(i)],
+            // T_7 = swap then 270°: (i, q) → (q, i) → (-i, q).
+            // Self-inverse.
+            Rotation::SwapRot270 => [neg(i), q],
+        }
+    }
+}
+
+/// Streaming soft-sample sync detector with QPSK phase-ambiguity
+/// resolution. Push one soft i8 sample at a time (one axis
+/// component, not a pair); on any push that completes a 64-sample
+/// window where one of 8 rotated ASM patterns scores above
+/// [`SOFT_SYNC_THRESHOLD`], returns `Some(rotation)` and resets
+/// for the next hunt.
+///
+/// Cost: 8 × 64 = 512 multiply-adds per pushed sample during
+/// hunting. At LRPT's 144 ksym/s × 2 axis components = 288 k
+/// samples/s, that's ~150 M ops/s — about 5 % of one modern
+/// CPU core during hunting. Hunting is brief (until first ASM
+/// found) so steady-state cost is negligible.
+pub struct SoftSyncDetector {
+    /// Sliding window of the most recent [`ASM_ENCODED_BITS`]
+    /// soft samples. Treated as a ring buffer; new samples
+    /// overwrite the oldest at `head`.
+    window: [i8; ASM_ENCODED_BITS],
+    /// Index of the next slot to write in [`Self::window`].
+    head: usize,
+    /// Number of samples pushed since construction or [`Self::reset`].
+    /// Used to suppress matches during the initial fill.
+    samples_seen: u64,
+    /// 8 rotated ASM patterns, each as a 64-element array of `+1`
+    /// or `-1` (i8 value). Built once at construction.
+    /// Pattern[k][j] is the expected sign of soft-sample j when
+    /// the receiver is at rotation k.
+    patterns: [[i8; ASM_ENCODED_BITS]; ROTATION_COUNT],
+}
+
+impl Default for SoftSyncDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SoftSyncDetector {
+    /// Build a fresh detector with empty window and pre-computed
+    /// rotation patterns.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            window: [0_i8; ASM_ENCODED_BITS],
+            head: 0,
+            samples_seen: 0,
+            patterns: build_patterns(),
+        }
+    }
+
+    /// Reset the window so a fresh hunt begins. Called by
+    /// [`FecChain::reset`] between passes and after sync loss.
+    pub fn reset(&mut self) {
+        self.window = [0_i8; ASM_ENCODED_BITS];
+        self.head = 0;
+        self.samples_seen = 0;
+    }
+
+    /// Drain the current window into a new owned `Vec<i8>` in
+    /// oldest-to-newest order, packed as `[i, q]` symbol pairs.
+    /// Called by [`super::FecChain`] on rotation lock so the
+    /// ASM-containing samples can be replayed through `Viterbi`
+    /// (after applying the inverse rotation transform). Without
+    /// the replay, the post-Viterbi bit stream would start with
+    /// CADU payload instead of the ASM, and the per-CADU
+    /// [`super::SyncCorrelator`] would miss the first frame's
+    /// boundary entirely.
+    ///
+    /// Empty when [`Self::push_symbol`] has been called fewer
+    /// than `ASM_ENCODED_BITS / 2` times (window not yet full —
+    /// not a state the chain transitions out of, since lock
+    /// requires a full window).
+    #[must_use]
+    pub fn drain_window(&self) -> Vec<i8> {
+        if self.samples_seen < ASM_ENCODED_BITS as u64 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(ASM_ENCODED_BITS);
+        for j in 0..ASM_ENCODED_BITS {
+            out.push(self.window[(self.head + j) % ASM_ENCODED_BITS]);
+        }
+        out
+    }
+
+    /// Push one QPSK soft symbol pair `[I, Q]` (the same shape
+    /// `Viterbi` consumes). Returns `Some(rotation)` on the push
+    /// that completes a window where one of the 8 rotated ASM
+    /// patterns scores above [`SOFT_SYNC_THRESHOLD`].
+    ///
+    /// **Why pairs, not single samples.** The encoded ASM is 32
+    /// QPSK symbols long, naturally aligned to symbol boundaries.
+    /// Sliding by one symbol at a time (rather than by individual
+    /// axis components) preserves symbol alignment in the window,
+    /// so the rotated patterns line up correctly. medet uses
+    /// per-byte sliding because its data layout packs 4 symbols
+    /// per byte; since our soft samples are one i8 per axis
+    /// component, the equivalent finer grain would slide by
+    /// half-symbols, which has no physical meaning under QPSK
+    /// and would only invite false locks on misaligned data.
+    ///
+    /// The detector does **not** auto-reset on a hit — the
+    /// caller is expected to transition out of hunting state
+    /// and either `reset()` later (for a future re-hunt) or
+    /// drop the detector entirely.
+    pub fn push_symbol(&mut self, soft: [i8; 2]) -> Option<Rotation> {
+        self.window[self.head] = soft[0];
+        self.window[(self.head + 1) % ASM_ENCODED_BITS] = soft[1];
+        self.head = (self.head + 2) % ASM_ENCODED_BITS;
+        self.samples_seen += 2;
+        if self.samples_seen < ASM_ENCODED_BITS as u64 {
+            return None;
+        }
+        self.best_match()
+    }
+
+    /// Score every pattern against the current window. Returns
+    /// the rotation with the best score if it exceeds
+    /// [`SOFT_SYNC_THRESHOLD`].
+    ///
+    /// **Window orientation**: `head` points to the next slot
+    /// to write, so the OLDEST sample is at `window[head]` and
+    /// the NEWEST is at `window[(head + 63) % 64]`. We
+    /// iterate `j = 0..64` and read `window[(head + j) % 64]`
+    /// to get oldest-to-newest.
+    fn best_match(&self) -> Option<Rotation> {
+        let mut best_idx: usize = 0;
+        let mut best_score: i32 = i32::MIN;
+        for (idx, pattern) in self.patterns.iter().enumerate() {
+            let mut score: i32 = 0;
+            for (j, &expected) in pattern.iter().enumerate() {
+                let sample = self.window[(self.head + j) % ASM_ENCODED_BITS];
+                // Score = sum of (sample × expected sign) — high
+                // when signs agree, low when they disagree. Soft
+                // magnitude weights confidence: a saturated
+                // ±127 contributes more than a near-zero sample.
+                score += i32::from(sample) * i32::from(expected);
+            }
+            if score > best_score {
+                best_score = score;
+                best_idx = idx;
+            }
+        }
+        if best_score >= SOFT_SYNC_THRESHOLD {
+            Rotation::from_index(best_idx)
+        } else {
+            None
+        }
+    }
+}
+
+/// Build the 8 rotated ASM patterns. Each pattern is a 64-element
+/// array of `+1` or `-1` (as `i8`) representing the expected sign
+/// of each soft sample in the encoded ASM at one rotation.
+///
+/// Patterns 0..3: rotations of the encoded ASM by 0°, 90°, 180°,
+/// 270°. Patterns 4..7: same rotations applied to the
+/// I/Q-swapped encoded ASM. Mirrors `medet`'s `corr_init` loop
+/// at `correlator.pas:157-165`.
+fn build_patterns() -> [[i8; ASM_ENCODED_BITS]; ROTATION_COUNT] {
+    let mut patterns = [[0_i8; ASM_ENCODED_BITS]; ROTATION_COUNT];
+    let base = bits_to_signs(ASM_ENCODED);
+    let swapped = swap_iq(base);
+    for (k, rot) in [0_usize, 1, 2, 3].iter().enumerate() {
+        patterns[k] = rotate_signs(base, *rot);
+        patterns[k + 4] = rotate_signs(swapped, *rot);
+    }
+    patterns
+}
+
+/// Convert a 64-bit pattern to a 64-element array of `+1` / `-1`
+/// signs (high bit first, i.e. bit 63 → element 0).
+///
+/// **Sign convention**: bit 0 → +1, bit 1 → -1. Matches
+/// `ccsds_encode` (and therefore [`super::ViterbiDecoder`])
+/// which encodes encoder output `0` as `+CLEAN_SOFT_MAG` and
+/// `1` as `-CLEAN_SOFT_MAG`. Don't flip this without flipping
+/// the encoder too — the live chain depends on the patterns,
+/// the encoder, and Viterbi's metrics all using the same
+/// bit-to-sign mapping.
+fn bits_to_signs(bits: u64) -> [i8; ASM_ENCODED_BITS] {
+    let mut out = [0_i8; ASM_ENCODED_BITS];
+    for (i, slot) in out.iter_mut().enumerate() {
+        let bit = (bits >> (ASM_ENCODED_BITS - 1 - i)) & 1;
+        *slot = if bit == 0 { 1 } else { -1 };
+    }
+    out
+}
+
+/// Apply an `r × 90°` rotation to a sign array. Treats
+/// consecutive sign pairs as `(I, Q)` of one QPSK symbol; for
+/// each symbol, rotates by `r × 90°` clockwise.
+fn rotate_signs(signs: [i8; ASM_ENCODED_BITS], r: usize) -> [i8; ASM_ENCODED_BITS] {
+    let mut out = signs;
+    for sym in 0..(ASM_ENCODED_BITS / 2) {
+        let i = signs[sym * 2];
+        let q = signs[sym * 2 + 1];
+        // Forward rotation by r × 90° clockwise (the receiver's
+        // perspective): if the transmitter sent (I, Q), at +90°
+        // Costas-rotation the receiver sees (Q, -I); at +180°
+        // sees (-I, -Q); at +270° sees (-Q, I). We're building
+        // the EXPECTED received pattern at each rotation so the
+        // detector can correlate against incoming samples.
+        let (ri, rq) = match r % 4 {
+            0 => (i, q),
+            1 => (q, -i),
+            2 => (-i, -q),
+            3 => (-q, i),
+            _ => unreachable!(),
+        };
+        out[sym * 2] = ri;
+        out[sym * 2 + 1] = rq;
+    }
+    out
+}
+
+/// Swap the I and Q axes within each pair. Models the case
+/// where the demod chain has the I/Q components reversed (which
+/// physically can happen with some SDR hardware or USB cable
+/// orientations).
+fn swap_iq(signs: [i8; ASM_ENCODED_BITS]) -> [i8; ASM_ENCODED_BITS] {
+    let mut out = signs;
+    for sym in 0..(ASM_ENCODED_BITS / 2) {
+        out[sym * 2] = signs[sym * 2 + 1];
+        out[sym * 2 + 1] = signs[sym * 2];
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Convert a 64-element sign array into 32 saturated soft
+    /// pairs ready for `push_symbol`. Used by every test below
+    /// to stand in for the QPSK soft slicer's output on a clean
+    /// signal.
+    fn signs_to_pairs(signs: [i8; ASM_ENCODED_BITS]) -> [[i8; 2]; ASM_ENCODED_BITS / 2] {
+        let mut out = [[0_i8; 2]; ASM_ENCODED_BITS / 2];
+        for sym in 0..(ASM_ENCODED_BITS / 2) {
+            let i = if signs[sym * 2] > 0 { 127 } else { -127 };
+            let q = if signs[sym * 2 + 1] > 0 { 127 } else { -127 };
+            out[sym] = [i, q];
+        }
+        out
+    }
+
+    /// Push the entire encoded ASM through the detector at the
+    /// upright phase. Should match `Rotation::Zero`.
+    #[test]
+    fn detects_clean_asm_at_zero_rotation() {
+        let mut det = SoftSyncDetector::new();
+        let signs = bits_to_signs(ASM_ENCODED);
+        // Pre-fill with anti-pattern so the first 32 pushes
+        // can't fluke a match.
+        for _ in 0..(ASM_ENCODED_BITS / 2) {
+            let _ = det.push_symbol([0, 0]);
+        }
+        let mut hit: Option<Rotation> = None;
+        for pair in signs_to_pairs(signs) {
+            if let Some(r) = det.push_symbol(pair) {
+                hit = Some(r);
+            }
+        }
+        assert_eq!(
+            hit,
+            Some(Rotation::Zero),
+            "clean upright ASM must match Rotation::Zero"
+        );
+    }
+
+    /// Round-trip: push a rotated ASM, detector should report
+    /// the matching rotation, applying its `apply()` to the
+    /// rotated samples should recover the original soft pair.
+    #[test]
+    fn detects_each_of_eight_rotations() {
+        let signs = bits_to_signs(ASM_ENCODED);
+        for (idx, expected_rot) in Rotation::ALL.iter().enumerate() {
+            let pattern = match idx {
+                0..=3 => rotate_signs(signs, idx),
+                4..=7 => rotate_signs(swap_iq(signs), idx - 4),
+                _ => unreachable!(),
+            };
+            let mut det = SoftSyncDetector::new();
+            for _ in 0..(ASM_ENCODED_BITS / 2) {
+                let _ = det.push_symbol([0, 0]);
+            }
+            let mut hit: Option<Rotation> = None;
+            for pair in signs_to_pairs(pattern) {
+                if let Some(r) = det.push_symbol(pair) {
+                    hit = Some(r);
+                }
+            }
+            assert_eq!(
+                hit,
+                Some(*expected_rot),
+                "pattern at index {idx} should match {expected_rot:?}",
+            );
+        }
+    }
+
+    /// Pure noise (zero soft magnitude) must not trigger a
+    /// false sync.
+    #[test]
+    fn rejects_pure_noise_zero() {
+        let mut det = SoftSyncDetector::new();
+        for _ in 0..(ASM_ENCODED_BITS * 2) {
+            assert!(
+                det.push_symbol([0, 0]).is_none(),
+                "zero-magnitude noise must not match",
+            );
+        }
+    }
+
+    /// First (`ASM_ENCODED_BITS / 2 - 1`) symbol pushes cannot
+    /// return a hit (window not yet full).
+    #[test]
+    fn no_hits_during_initial_window_fill() {
+        let mut det = SoftSyncDetector::new();
+        // Push 31 saturated symbols — even if they happened to
+        // align with an ASM, the samples_seen guard prevents a hit.
+        for i in 0..((ASM_ENCODED_BITS / 2) - 1) {
+            assert!(
+                det.push_symbol([127, 127]).is_none(),
+                "premature hit at symbol {i}",
+            );
+        }
+    }
+
+    /// Apply each rotation to a known soft pair, then apply
+    /// the same rotation to itself, and confirm we get the
+    /// inverse-rotated pair back. (This pins the `apply()`
+    /// table against a sanity property: rotating four times
+    /// by 90° in the same direction returns the original.)
+    #[test]
+    fn rotation_apply_is_consistent() {
+        let p = [50_i8, -30_i8];
+        // Rotating four times by 90° (each time rotating the
+        // result) should return the input.
+        let mut x = p;
+        for _ in 0..4 {
+            x = Rotation::Rot90.apply(x);
+        }
+        assert_eq!(x, p, "four 90° rotations should compose to identity");
+    }
+
+    /// `Rotation::Zero.apply(p) == p` for all `p`.
+    #[test]
+    fn rotation_zero_is_identity() {
+        for i in -127_i8..=127 {
+            for q in -127_i8..=127 {
+                assert_eq!(Rotation::Zero.apply([i, q]), [i, q]);
+            }
+        }
+    }
+
+    /// `Rotation::Rot180.apply(p) == [-i, -q]` (or saturated
+    /// equivalent for `i8::MIN`).
+    #[test]
+    fn rotation_180_negates_both_axes() {
+        // `i8::MIN.saturating_neg() == i8::MAX = 127`, so the
+        // edge case `[i8::MIN, i8::MAX]` rotates to `[127, -127]`.
+        // Pinned so a future signed-arith refactor that drops
+        // the saturating_neg can't silently overflow.
+        assert_eq!(
+            Rotation::Rot180.apply([i8::MIN, i8::MAX]),
+            [127, -127],
+            "i8::MIN should saturate to 127 under Rot180; \
+             i8::MAX should negate cleanly to -127",
+        );
+        // Typical soft range is well clear of i8::MIN, so the
+        // mapping is just a sign flip.
+        assert_eq!(Rotation::Rot180.apply([42, -17]), [-42, 17]);
+    }
+
+    /// Apply the forward transform that builds pattern N, then
+    /// apply [`Rotation::ALL[N].apply`] — must recover the
+    /// original pair for every N. This is the load-bearing
+    /// invariant: if `apply` is the wrong direction (or wrong
+    /// rotation amount) for any N, the entire decode chain
+    /// silently scrambles bits at that rotation.
+    #[test]
+    fn apply_is_inverse_of_forward() {
+        // Forward transform table — must mirror what
+        // `build_patterns` does to construct pattern N. If
+        // these get out of sync the test would pass while the
+        // chain still mis-decoded; pinning explicitly is the
+        // safety net against that drift.
+        let forward = |n: usize, p: [i8; 2]| -> [i8; 2] {
+            let neg = |x: i8| x.saturating_neg();
+            let [i, q] = p;
+            match n {
+                0 => [i, q],
+                1 => [q, neg(i)],
+                2 => [neg(i), neg(q)],
+                3 => [neg(q), i],
+                4 => [q, i],
+                5 => [i, neg(q)],
+                6 => [neg(q), neg(i)],
+                7 => [neg(i), q],
+                _ => unreachable!(),
+            }
+        };
+        // Sample values across the soft range. Excludes
+        // `i8::MIN` because saturating_neg(i8::MIN) = i8::MAX
+        // makes the round-trip non-identity at that one point
+        // (an unavoidable consequence of two's-complement).
+        let samples = [-127_i8, -90, -42, -1, 0, 1, 42, 90, 127];
+        for (n, rot) in Rotation::ALL.iter().enumerate() {
+            for &i in &samples {
+                for &q in &samples {
+                    let original = [i, q];
+                    let received = forward(n, original);
+                    let recovered = rot.apply(received);
+                    assert_eq!(
+                        recovered, original,
+                        "rotation {n} ({rot:?}): forward then apply must \
+                         recover original — got {recovered:?} from {original:?} \
+                         (received as {received:?})",
+                    );
+                }
+            }
+        }
+    }
+
+    /// Pattern indices map deterministically to rotations.
+    #[test]
+    fn pattern_index_round_trip() {
+        for (i, r) in Rotation::ALL.iter().enumerate() {
+            assert_eq!(Rotation::from_index(i), Some(*r));
+        }
+        assert_eq!(Rotation::from_index(8), None);
+    }
+
+    /// `ASM_ENCODED` must match what our `ccsds_encode` actually
+    /// produces for the 32-bit ASM. Pinning so a refactor that
+    /// changes the encoder convention (`POLYA` / `POLYB`
+    /// ordering, shift-register direction, MSB-first vs
+    /// LSB-first input) without simultaneously updating
+    /// `ASM_ENCODED` fails loudly here, instead of silently
+    /// breaking the `SoftSyncDetector` at runtime.
+    #[test]
+    fn asm_encoded_matches_ccsds_encode_output() {
+        use crate::fec::viterbi::ccsds_encode;
+        // Encode the 32-bit ASM, MSB first.
+        let bits: Vec<u8> = (0..32)
+            .map(|i| {
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "shift index 0..32 is safe for u32"
+                )]
+                let bit = ((super::super::sync::ASM >> (31 - i)) & 1) as u8;
+                bit
+            })
+            .collect();
+        let encoded = ccsds_encode(&bits);
+        // Take the first 64 soft samples (= encoded ASM bits;
+        // the trailing K-1 flush samples encode the encoder's
+        // tail and aren't part of the ASM proper).
+        let mut derived: u64 = 0;
+        for (i, &s) in encoded.iter().take(ASM_ENCODED_BITS).enumerate() {
+            // Convention: positive soft (= encoder bit 0) → bit
+            // 0 in the u64; negative soft (= encoder bit 1) →
+            // bit 1. MSB-first packing. `s <= 0` (vs `s > 0`)
+            // mirrors the encoder's exact tie-break for the
+            // never-occurring zero soft sample.
+            let bit = u64::from(s <= 0);
+            derived |= bit << (ASM_ENCODED_BITS - 1 - i);
+        }
+        assert_eq!(
+            ASM_ENCODED, derived,
+            "ASM_ENCODED constant {ASM_ENCODED:#018x} must match \
+             what ccsds_encode produces for the 32-bit ASM \
+             ({derived:#018x})",
+        );
+    }
+}

--- a/crates/sdr-lrpt/src/fec/soft_sync.rs
+++ b/crates/sdr-lrpt/src/fec/soft_sync.rs
@@ -378,12 +378,20 @@ fn rotate_signs(signs: [i8; ASM_ENCODED_BITS], r: usize) -> [i8; ASM_ENCODED_BIT
         // sees (-I, -Q); at +270° sees (-Q, I). We're building
         // the EXPECTED received pattern at each rotation so the
         // detector can correlate against incoming samples.
-        let (ri, rq) = match r % 4 {
-            0 => (i, q),
+        //
+        // `r & 3` normalises any `usize` input to 0..=3, so the
+        // catch-all arm is mathematically unreachable. Folding
+        // 0 with `_` keeps the helper panic-free in library code
+        // (per CLAUDE.md and CR round 1 on PR #606) — Rust's
+        // exhaustiveness checker can't refine the type from the
+        // bitmask, so a catch-all is required regardless; making
+        // it the identity (= the same body 0 would take) is the
+        // safe default.
+        let (ri, rq) = match r & 3 {
             1 => (q, -i),
             2 => (-i, -q),
             3 => (-q, i),
-            _ => unreachable!(),
+            _ => (i, q),
         };
         out[sym * 2] = ri;
         out[sym * 2 + 1] = rq;

--- a/crates/sdr-lrpt/src/fec/sync.rs
+++ b/crates/sdr-lrpt/src/fec/sync.rs
@@ -13,6 +13,15 @@
 /// CCSDS attached sync marker.
 pub const ASM: u32 = 0x1ACF_FC1D;
 
+/// Bitwise inverse of [`ASM`]. The post-Viterbi residual 180°
+/// check matches the bit window against this value too, in case
+/// the pre-Viterbi rotation detector mis-distinguished Zero vs
+/// Rot180 on a noisy signal. medet's `try_frame` does the same
+/// check with a different name (`$E20330E5` interpreted as a
+/// little-endian dword over MSB-first decoded bytes); same
+/// effect — the 32-bit ASM with every bit flipped.
+pub const ASM_INVERTED: u32 = !ASM;
+
 /// Bit width of the ASM correlation window. Pinned as a constant
 /// so the decoder logic, helper code, and tests share one source
 /// of truth — changing the ASM size (CCSDS doesn't, but in case a
@@ -22,8 +31,23 @@ pub const ASM_BITS: usize = 32;
 /// Maximum Hamming distance for a sync hit. 4/32 ≈ 87.5% match.
 pub const SYNC_THRESHOLD: u32 = 4;
 
-/// Streaming sync correlator. Pushes one bit at a time, emits the
-/// 1-based bit-position of detected sync words.
+/// One sync detection event. `position` is the bit count at which
+/// the trailing edge of the matched ASM landed (1-based, useful
+/// for diagnostics). `inverted` is `true` when the matched
+/// pattern was the bitwise-inverted ASM, signalling the
+/// downstream stream is bit-inverted (180° residual after
+/// pre-Viterbi rotation). `inverted` callers must XOR captured
+/// payload bytes with `0xFF` before derandomising.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyncHit {
+    pub position: u64,
+    pub inverted: bool,
+}
+
+/// Streaming sync correlator. Pushes one bit at a time, emits a
+/// [`SyncHit`] when the sliding 32-bit window matches either the
+/// upright or bitwise-inverted ASM within [`SYNC_THRESHOLD`] bit
+/// errors.
 pub struct SyncCorrelator {
     window: u32,
     bits_seen: u64,
@@ -44,17 +68,26 @@ impl SyncCorrelator {
         }
     }
 
-    /// Push one bit. Returns the position of the sync end if the
-    /// sliding 32-bit window hits the ASM within
-    /// [`SYNC_THRESHOLD`] bit errors.
-    pub fn push(&mut self, bit: u8) -> Option<u64> {
+    /// Push one bit. Returns a [`SyncHit`] if the sliding 32-bit
+    /// window matches either [`ASM`] or [`ASM_INVERTED`] within
+    /// [`SYNC_THRESHOLD`] bit errors. Upright ASM wins ties (we
+    /// check it first).
+    pub fn push(&mut self, bit: u8) -> Option<SyncHit> {
         self.window = (self.window << 1) | u32::from(bit & 1);
         self.bits_seen += 1;
         if self.bits_seen < ASM_BITS as u64 {
             return None;
         }
         if (self.window ^ ASM).count_ones() <= SYNC_THRESHOLD {
-            Some(self.bits_seen)
+            Some(SyncHit {
+                position: self.bits_seen,
+                inverted: false,
+            })
+        } else if (self.window ^ ASM_INVERTED).count_ones() <= SYNC_THRESHOLD {
+            Some(SyncHit {
+                position: self.bits_seen,
+                inverted: true,
+            })
         } else {
             None
         }
@@ -66,8 +99,8 @@ mod tests {
     use super::*;
 
     /// Push the 32 bits of `pattern` (MSB first) through the
-    /// correlator, returning the first hit position (or None).
-    fn push_pattern(s: &mut SyncCorrelator, pattern: u32) -> Option<u64> {
+    /// correlator, returning the first hit (or None).
+    fn push_pattern(s: &mut SyncCorrelator, pattern: u32) -> Option<SyncHit> {
         let mut hit = None;
         for i in 0..ASM_BITS {
             #[allow(
@@ -75,8 +108,8 @@ mod tests {
                 reason = "shift index 0..ASM_BITS=32 is well-defined for u32"
             )]
             let bit = ((pattern >> (ASM_BITS - 1 - i)) & 1) as u8;
-            if let Some(pos) = s.push(bit) {
-                hit = Some(pos);
+            if let Some(h) = s.push(bit) {
+                hit = Some(h);
             }
         }
         hit
@@ -91,7 +124,30 @@ mod tests {
             s.push(1);
         }
         let hit = push_pattern(&mut s, ASM);
-        assert!(hit.is_some(), "should detect clean ASM");
+        assert_eq!(
+            hit.map(|h| h.inverted),
+            Some(false),
+            "should detect clean upright ASM",
+        );
+    }
+
+    /// `ASM_INVERTED` (every bit flipped) must also match, with
+    /// `inverted = true`. Defense-in-depth for the case where
+    /// pre-Viterbi rotation detection picked the wrong of two
+    /// 180°-symmetric patterns. Per medet's `try_frame` residual
+    /// flip check.
+    #[test]
+    fn detects_inverted_asm_with_inverted_flag() {
+        let mut s = SyncCorrelator::new();
+        for _ in 0..50 {
+            s.push(0); // pre-fill with zero bits — distinct from inverted ASM
+        }
+        let hit = push_pattern(&mut s, ASM_INVERTED);
+        assert_eq!(
+            hit.map(|h| h.inverted),
+            Some(true),
+            "should detect inverted ASM and flag it",
+        );
     }
 
     #[test]
@@ -110,6 +166,11 @@ mod tests {
             hit.is_some(),
             "should tolerate {SYNC_THRESHOLD} bit errors in ASM",
         );
+        assert_eq!(
+            hit.map(|h| h.inverted),
+            Some(false),
+            "near-upright corruption must report upright (not inverted) match",
+        );
     }
 
     #[test]
@@ -118,7 +179,11 @@ mod tests {
         for _ in 0..50 {
             s.push(1);
         }
-        // Flip SYNC_THRESHOLD+1 distinct bits — over the limit.
+        // Flip SYNC_THRESHOLD+1 distinct bits — over the limit
+        // for both upright and inverted matches (since flipping
+        // bits from upright moves you AWAY from upright AND
+        // toward inverted, but not past the threshold for either
+        // when the count is small).
         let mut corrupted = ASM;
         for i in 0..=SYNC_THRESHOLD as usize {
             corrupted ^= 1 << (i * 5);
@@ -126,7 +191,7 @@ mod tests {
         let hit = push_pattern(&mut s, corrupted);
         assert!(
             hit.is_none(),
-            "should reject ASM with {} bit errors",
+            "should reject ASM with {} bit errors against both upright and inverted",
             SYNC_THRESHOLD + 1,
         );
     }

--- a/crates/sdr-lrpt/src/fec/viterbi.rs
+++ b/crates/sdr-lrpt/src/fec/viterbi.rs
@@ -183,60 +183,67 @@ pub fn parity_8(b: u8) -> u8 {
     v & 1
 }
 
+/// CCSDS rate-1/2 K=7 convolutional encoder (medet polynomial
+/// convention). For each input bit produces 2 saturated soft
+/// samples (±127) suitable for feeding [`ViterbiDecoder::step`]
+/// or [`super::SoftSyncDetector::push_symbol`] in tests.
+///
+/// Drains the encoder with K-1 trailing zero bits so the output
+/// captures every encoded bit pair for `bits.len()` input bits.
+///
+/// `pub(crate)` and `#[cfg(test)]` because this is a test-only
+/// utility shared between the viterbi tests and the FEC-chain
+/// round-trip / rotation tests; no production code path uses it
+/// (the Meteor satellite is the encoder in production).
 #[cfg(test)]
-#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-mod tests {
-    use super::*;
-
+pub(crate) fn ccsds_encode(bits: &[u8]) -> Vec<i8> {
     /// Soft-symbol magnitude for clean-signal test fixtures.
     /// Saturated to ±127 — the largest distance the soft slicer
     /// produces, modeling a noiseless encoded stream.
     const CLEAN_SOFT_MAG: i8 = 127;
-
-    /// Encode a bitstream with the standard CCSDS convolutional
-    /// encoder (medet polynomial convention, full 7-bit shift
-    /// register, input bit at position K-1 = 6). Used to generate
-    /// test fixtures: known input → known encoded output → assert
-    /// decoder recovers the input within tolerance.
-    pub(super) fn ccsds_encode(bits: &[u8]) -> Vec<i8> {
-        let mut shift_reg: u8 = 0;
-        let mut out = Vec::with_capacity((bits.len() + K - 1) * 2);
-        #[allow(
-            clippy::cast_possible_truncation,
-            reason = "K = 7, shift count fits in u8"
-        )]
-        let high_bit_pos: u8 = (K - 1) as u8; // = 6
-        let push_pair = |out: &mut Vec<i8>, g1: u8, g2: u8| {
-            out.push(if g1 == 0 {
-                CLEAN_SOFT_MAG
-            } else {
-                -CLEAN_SOFT_MAG
-            });
-            out.push(if g2 == 0 {
-                CLEAN_SOFT_MAG
-            } else {
-                -CLEAN_SOFT_MAG
-            });
-        };
-        for &b in bits {
-            shift_reg = (shift_reg >> 1) | ((b & 1) << high_bit_pos);
-            push_pair(
-                &mut out,
-                parity_8(shift_reg & POLYA),
-                parity_8(shift_reg & POLYB),
-            );
-        }
-        // Flush — append K-1 zeros to drain the encoder.
-        for _ in 0..(K - 1) {
-            shift_reg >>= 1;
-            push_pair(
-                &mut out,
-                parity_8(shift_reg & POLYA),
-                parity_8(shift_reg & POLYB),
-            );
-        }
-        out
+    let mut shift_reg: u8 = 0;
+    let mut out = Vec::with_capacity((bits.len() + K - 1) * 2);
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "K = 7, shift count fits in u8"
+    )]
+    let high_bit_pos: u8 = (K - 1) as u8; // = 6
+    let push_pair = |out: &mut Vec<i8>, g1: u8, g2: u8| {
+        out.push(if g1 == 0 {
+            CLEAN_SOFT_MAG
+        } else {
+            -CLEAN_SOFT_MAG
+        });
+        out.push(if g2 == 0 {
+            CLEAN_SOFT_MAG
+        } else {
+            -CLEAN_SOFT_MAG
+        });
+    };
+    for &b in bits {
+        shift_reg = (shift_reg >> 1) | ((b & 1) << high_bit_pos);
+        push_pair(
+            &mut out,
+            parity_8(shift_reg & POLYA),
+            parity_8(shift_reg & POLYB),
+        );
     }
+    // Flush — append K-1 zeros to drain the encoder.
+    for _ in 0..(K - 1) {
+        shift_reg >>= 1;
+        push_pair(
+            &mut out,
+            parity_8(shift_reg & POLYA),
+            parity_8(shift_reg & POLYB),
+        );
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+mod tests {
+    use super::*;
 
     #[test]
     fn parity_8_matches_xor_fold() {
@@ -290,7 +297,6 @@ mod tests {
 
 #[cfg(test)]
 mod proptests {
-    use super::tests::ccsds_encode;
     use super::*;
     use proptest::prelude::*;
 


### PR DESCRIPTION
Closes #605.

Before this fix, the LRPT decoder's `SyncCorrelator` (post-Viterbi, hard-bit) only matched the upright-phase ASM, so ~75% of Costas acquisitions silently dropped the entire pass — the most likely root cause of "signal visible in the waterfall + peaks in the signal-strength graph but only static, no decoded image" Meteor passes.

QPSK has a 4-fold phase ambiguity (0°/90°/180°/270°) plus an optional I/Q axis swap = 8 distinct symbol-mapping orientations the receiver can lock at. The reference decoder `original/medet/correlator.pas` resolves all 8 via pre-Viterbi soft correlation against rotated ASM patterns; we now do the same, with a small architectural adaptation for our streaming chain.

## Architecture

```
soft i8 pair ─▶ SoftSyncDetector (8 rotated patterns)
                         │
                         ▼ rotation locked
                Rotation::apply (un-rotate to canonical)
                         │
                         ▼
                      Viterbi ─bit▶ SyncCorrelator (per-CADU re-sync,
                                                    upright OR inverted ASM)
                                              │
                                              ▼
                                   1020-byte CADU buffer
                                              │
                                              ▼
                            derand → de-interleave (×4) → RS-decode → VCDU
```

Two-phase lock: `HuntingRotation` feeds soft pairs to `SoftSyncDetector` only; `Locked` applies `Rotation::apply` to each pair, steps Viterbi, runs per-CADU sync. On rotation lock the chain replays the ASM-containing soft samples (drained from the detector window) through the rotation+Viterbi path, so the post-Viterbi bit stream begins with the canonical ASM and the existing per-CADU `SyncCorrelator` finds it.

`SyncCorrelator` extended to also match `ASM XOR 0xFFFFFFFF` and return a `SyncHit { position, inverted }` — defense-in-depth for noisy signals where the soft correlator might pick the wrong of two 180°-symmetric patterns. Captured bytes get XORed with `0xFF` before derand when the inverted form matched.

## New module: `fec/soft_sync.rs`

- `Rotation` enum (8 variants) with `apply()` providing the inverse-rotation transform applied to received soft pairs.
- `SoftSyncDetector` streams soft pairs against 8 rotated ASM patterns; threshold-gated lock detection, drainable window for replay through Viterbi on lock.
- `ASM_ENCODED = 0x0391_853E_8FF1_64AB` — what our `ccsds_encode` produces for the 32-bit ASM. Different from medet's hardcoded `0xFCA2_B63D_B00D_9794` because our encoder uses the bit-reversed polynomial form (`POLYA = 79`, `POLYB = 109` vs spec's `0o171` / `0o133`); both are mathematically equivalent encoder/decoder pairs but produce different bit strings. The pattern correlator must match the encoder it's paired with. Pinned via `asm_encoded_matches_ccsds_encode_output` test.

## Tests

- 11 new `soft_sync` unit tests:
  * Each of 8 rotations detected correctly (`detects_each_of_eight_rotations`)
  * Forward → apply round-trips for every rotation × ~80 sample values (`apply_is_inverse_of_forward`) — would catch the `Rot90`↔`Rot270` swap I introduced and fixed during development
  * Sign-convention pin against `ccsds_encode`
  * Window-not-yet-full guard, noise rejection, etc.
- 1 new gold-standard end-to-end test in `chain.rs`: `fec_chain_decodes_through_each_of_eight_rotations` — builds a clean CADU, applies each forward rotation, asserts the chain recovers the original VCDU at every rotation. Before this PR it would have failed at 7 of 8 rotations.
- `SyncCorrelator` tests extended for the new `inverted` flag.
- `ccsds_encode` exposed `pub(crate) #[cfg(test)]` so the chain round-trip test can build synthetic CADUs without duplicating the encoder logic.

## Steady-state cost

`SoftSyncDetector` runs only during initial hunting; the 8 × 64 = 512 multiply-adds per soft sample (~150 M ops/s during hunting) are bounded by hunt duration (typically ~1 ASM-length worth of soft samples once signal is present). Once locked, the detector is idle for the rest of the pass; per-symbol cost is just `Rotation::apply` (one load + at most two saturating-negs) plus the existing Viterbi path.

## Real-world risk

If the Meteor satellite uses a different encoding convention than our `ccsds_encode` (different polynomial direction or shift convention), the pattern detector won't match real signals — even though all 1993 workspace tests pass, the pre-existing chain might have been working only by accident through the residual 180°-flip safety net. We'll know on the next live pass:

- **Best case**: imagery decodes regardless of which phase Costas locks at — fix confirmed real-world.
- **Likely case**: imagery decodes at 1-2 of the 4 base rotations (the one(s) where our convention happens to match the satellite). Better than 1-of-4 baseline; rules out the worst version of the bug.
- **Worst case**: imagery still doesn't decode — we've narrowed the bug to "our `ccsds_encode` doesn't match the satellite", file follow-up to align conventions with medet's real-tested values.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo check --workspace --locked` (no Cargo.lock drift)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 1993 tests pass (up from 1982; +11 from new sync/chain tests, 0 failures)
- [x] `cargo fmt --all -- --check` clean
- [x] `make install CARGO_FLAGS=\"--release\"` succeeds
- [x] Smoke: app launches, all viewers open, Radio/Scanner/Transcript activities unaffected
- [ ] **In flight**: real Meteor LRPT pass to confirm real-world decode at any/all Costas phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-decoding soft-symbol rotation detector and two-phase rotation-lock so captures begin with a correctly aligned sync marker.
  * Capture now applies detected rotation and handles inverted sync matches before derandomization.

* **Bug Fixes**
  * More robust handling of rotation and inversion across passes; reset now clears detector state to re-enter rotation hunting.

* **Tests**
  * End-to-end tests updated to verify recovery across all rotations and adjusted warmup expectations.

* **Documentation**
  * Updated docs to reflect rotation-lock behavior and test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->