### PR TITLE
docs: ship onboarding guides (getting-started + sdr-concepts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ NOAA APT (epic #468), Meteor-M LRPT (epic #469), and ISS SSTV (epic #472) are al
 - `crates/sdr-radio/src/sstv_image.rs` — Shared SSTV image handle (`Arc<Mutex<Inner>>`). DSP tap writes via `write_line`; UI reads via `snapshot()`; `take_completed()` drains the finished frame and resets for the next VIS detection. `SstvImage::clear()` convenience wrapper delegates to the handle.
 - `crates/sdr-ui/src/sstv_viewer.rs` — Live SSTV viewer. `SstvImageRenderer` owns the Cairo ARGB32 surface; `SstvImageView` is the GTK widget (cloneable via Rc). `open_sstv_viewer_if_needed` opens the window and wires `UiToDsp::SetSstvImage`. `write_sstv_rgb_png` is the Cairo-based PNG encoder used by both manual Export and the auto-record LOS save. Wired via `connect_sstv_action` (`Ctrl+Shift+V`).
 
-**User-facing walkthroughs:** `docs/guides/apt-reception.md`, `docs/guides/lrpt-reception.md`, `docs/guides/sstv-reception.md`.
+**User-facing walkthroughs:** `docs/guides/apt-reception.md`, `docs/guides/lrpt-reception.md`, `docs/guides/sstv-reception.md`. The two onboarding entry points are `docs/guides/getting-started.md` (first-FM-station tour) and `docs/guides/sdr-concepts.md` (IQ / sample rate / decimation / FFT / bandwidth, against this app's UI).
 
 **Output paths** (all under `~/sdr-recordings/`):
 - APT: `apt-{satellite-slug}-{local-timestamp}.png` (single PNG per pass).

--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ sdr-rs
 3. Choose demodulation mode (WFM, NFM, AM, USB, LSB, etc.)
 4. Press **Play**
 
+### New to SDR?
+
+- [`docs/guides/getting-started.md`](docs/guides/getting-started.md) — first-time-user walkthrough: tour of the activity bar, your first FM-broadcast signal in under five minutes, concrete next things to try.
+- [`docs/guides/sdr-concepts.md`](docs/guides/sdr-concepts.md) — IQ, sample rate, decimation, FFT, why bandwidth matters — explained against this app's UI. Reading this lets you reason about *why* something isn't working, not just what to try.
+- [`docs/guides/apt-reception.md`](docs/guides/apt-reception.md) / [`lrpt-reception.md`](docs/guides/lrpt-reception.md) / [`sstv-reception.md`](docs/guides/sstv-reception.md) — receive your first weather satellite image / Meteor LRPT pass / ISS SSTV photograph end-to-end.
+
 ### Keyboard Shortcuts
 
 | Key | Action |

--- a/docs/guides/apt-reception.md
+++ b/docs/guides/apt-reception.md
@@ -2,7 +2,10 @@
 
 A walkthrough from "I have an RTL-SDR and the app installed" to "I just
 received a satellite image off my own antenna." Aimed at a first-timer
-who hasn't decoded weather satellites before.
+who hasn't decoded weather satellites before. If you're brand new to
+the app, [`getting-started.md`](getting-started.md) tours the activity
+bar and gets a first signal up in under five minutes — worth doing
+once before tackling a satellite pass.
 
 The whole thing takes about as long as the pass itself — 10–15
 minutes of attended time once you've got an antenna up.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -63,7 +63,7 @@ get a first signal working.
 
 When the app launches you'll see four regions:
 
-```
+```text
 +=========================================================+
 |  ▶ [ 100.000.000 Hz ]  WFM ▾   ━━━━ vol             ☰  |   ← header bar
 +--+---------------------------+--+--+----------------+--+

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,285 @@
+# Getting started with SDR-RS
+
+A first-time-user walkthrough. Aimed at someone who picked up an
+RTL-SDR dongle, installed this app, and isn't sure what they're
+looking at when they launch it.
+
+You can be listening to your first FM-broadcast station in under
+five minutes. Real signal-finding takes longer, but that's because
+of the radio spectrum, not the software — once you know which
+sidebar panel does what, the workflow is short.
+
+---
+
+## What you bought, and what it does
+
+An **RTL-SDR** is a $30 USB device that started life as a European
+TV tuner. Someone discovered the chip exposes raw radio samples
+over USB, and it became the cheapest software-defined radio
+receiver on the planet. It's not a transmitter; it can only listen.
+It covers roughly 24-1700 MHz with one common gap, which is enough
+to pick up:
+
+- FM broadcast (88-108 MHz)
+- Air-band aviation voice (118-137 MHz)
+- Weather satellites (137 MHz)
+- Amateur radio (multiple bands; 144 / 440 MHz are easiest)
+- Pagers and trunked-radio systems (~150-470 MHz)
+- The International Space Station's ham downlink (145.800 MHz)
+- Plus the noise floor between all of those, which is its own
+  kind of fun.
+
+A **software-defined radio** moves the radio's "dial" and
+"demodulator" out of dedicated hardware and into software. The
+RTL-SDR sends raw I/Q samples (the digital representation of
+whatever's on the antenna) to your computer, and SDR-RS does
+everything past that — channel filter, FM/AM/SSB demodulation,
+audio output, recording, decoding. That's why one $30 dongle can
+listen to a dozen different protocols: the protocol logic is just
+code.
+
+If you care about the underlying concepts (sample rate, IQ,
+decimation, why bandwidth matters), see
+[`sdr-concepts.md`](sdr-concepts.md). You don't need any of it to
+get a first signal working.
+
+---
+
+## What you'll need
+
+- The RTL-SDR dongle, plugged in.
+- An antenna. The little rubber-duck antenna that ships with the
+  dongle works for FM broadcast and not much else. For weather
+  satellites you'll want a horizontal V-dipole; for air-band a
+  ¼-wave whip; for ham bands a tuned dipole. Antenna choice is the
+  single biggest quality lever in this whole hobby.
+- SDR-RS launched. (`make install` from the repo root, or pull a
+  pre-built binary if one exists for your distro.)
+- About 5 minutes if you're aiming at FM broadcast as a first win.
+
+---
+
+## The two-minute orientation
+
+When the app launches you'll see four regions:
+
+```
++=========================================================+
+|  ▶ [ 100.000.000 Hz ]  WFM ▾   ━━━━ vol             ☰  |   ← header bar
++--+---------------------------+--+--+----------------+--+
+|  |                           |  |  |                |  |
+|🎚 |    spectrum + waterfall   |  |  |  transcript    |  |
+|🛰 |    (the wiggly graph and  |  |  |  (when active) |  |
+|🎵 |     scrolling thing)      |  |  |                |  |
+|… |                           |  |  |                |  |
+|  |                           |  |  |                |  |
++--+---------------------------+--+--+----------------+--+
+|  status bar: SNR ▮▯▯▯  •  Sample 2.4 Msps  •  WFM 200kHz |
++----------------------------------------------------------+
+```
+
+- **Header bar** (top): play/stop, the digit-by-digit frequency
+  display, the demodulation-mode dropdown, volume, and an app-menu
+  hamburger. The most-used controls live here so you never have to
+  scroll for them.
+- **Left sidebar (icons)**: the **activity bar**. Clicking each
+  icon switches the panel beside it between General / Radio /
+  Audio / Display / Scanner / Share / Satellites. Think of it like
+  VS Code's left rail. Each activity has different controls.
+  **`F9` toggles the sidebar open/closed.**
+- **Centre**: the spectrum plot (top half) and waterfall (bottom
+  half). The spectrum shows what's being received *right now*; the
+  waterfall shows the last few seconds, scrolling downward. Strong
+  signals are bright; noise is dark.
+- **Right sidebar (icons)**: transcript and bookmarks panels. Same
+  pattern as the left, just on the other side.
+- **Status bar** (bottom): live signal-to-noise readout, sample
+  rate, current demod mode + bandwidth.
+
+The left activity icons in order: General, Radio, Audio, Display,
+Scanner, Share over network, Satellites. `Ctrl+1` through
+`Ctrl+7` jumps to each.
+
+---
+
+## First signal: FM broadcast
+
+The easiest possible win. FM broadcast is loud, ubiquitous, and
+your stock antenna already kind of works at 100 MHz.
+
+1. **Plug the dongle in.** SDR-RS should auto-detect it (Source
+   should say "RTL-SDR" in the General panel — `Ctrl+1`).
+2. **Type a station's frequency** into the header-bar frequency
+   display. Click the digit you want to change and scroll, or just
+   click and type. NPR / BBC / your favourite station — whatever
+   you'd find on a car radio. Try **101.5 MHz** if nothing comes
+   to mind.
+3. **Pick the right demod**: WFM (Wide FM). It's probably already
+   selected; if not, header-bar dropdown → WFM.
+4. **Hit play** (▶ button, header bar) or press **Space**.
+5. Adjust volume.
+
+If you hear music, congratulations — you've used a software-defined
+radio. If you hear static, the most likely culprits are antenna
+(move it near a window, point it up) or you've tuned to a frequency
+nothing's broadcasting on.
+
+---
+
+## What each panel does
+
+The **activity bar** on the left switches between conceptual layers
+of the radio:
+
+- **General** (`Ctrl+1`) — choose a *source*. RTL-SDR (your
+  dongle), TCP/UDP network IQ (someone else's dongle on the
+  network), or WAV file playback (a recorded session). For first
+  use, leave it on RTL-SDR.
+- **Radio** (`Ctrl+2`) — *demodulation* and audio post-processing.
+  Bandwidth, squelch, CTCSS, deemphasis, notch, noise blanker.
+  This is where you'd dial in a narrow voice channel or knock down
+  a hum.
+- **Audio** (`Ctrl+3`) — output device selection (PipeWire on
+  Linux, CoreAudio on macOS) and audio recording.
+- **Display** (`Ctrl+4`) — spectrum/waterfall appearance: FFT
+  size, framerate, dB range, colormap.
+- **Scanner** (`Ctrl+5`) — sequential scan across bookmarked
+  channels. Once you have a few favourite frequencies saved as
+  bookmarks, the scanner cycles through them looking for activity.
+- **Share over network** (`Ctrl+6`) — turn your machine into a
+  network radio source for other clients (GQRX, SDR++, another
+  copy of this app on your phone).
+- **Satellites** (`Ctrl+7`) — pass prediction for NOAA APT,
+  Meteor-M LRPT, and ISS SSTV. Auto-record on overhead pass.
+
+**Right sidebar**:
+
+- **Transcript** — when transcription is enabled, decoded speech
+  shows up here. Useful for ham conversations, air traffic, etc.
+- **Bookmarks** — your saved frequencies. Each bookmark stores
+  not just the frequency but the demod mode, bandwidth, squelch,
+  and audio settings, so recalling a bookmark restores the full
+  listening setup.
+
+---
+
+## Concrete next things to try
+
+Pick whichever sounds fun. They escalate roughly in difficulty.
+
+### Easy, indoor-antenna-OK
+
+- **Air-band voice** — tune to your nearest airport's tower
+  frequency (lookup: `liveatc.net` or your country's aviation
+  authority). Demod = AM. Bandwidth ~10-12 kHz. You'll hear clipped
+  voice in classic ATC cadence: "Cessna 1234 cleared for takeoff
+  runway 27 left." Air-band is one of the more reliably-active
+  bands.
+- **Public weather radio** (NOAA NWR in the US, similar elsewhere)
+  — tune one of the seven NOAA frequencies (162.400-162.550 MHz).
+  Demod = NFM. Bandwidth 12.5 kHz. Synthesised voice reading the
+  forecast 24/7. Cheerfully boring, but a guaranteed signal to
+  confirm your setup is working.
+- **2-metre amateur repeaters** (144-148 MHz in the US). Quiet
+  most of the time but bursty. Listen during commute hours for
+  the best chance of activity. Demod = NFM. Use the **squelch**
+  control in the Radio panel so you only hear audio when someone
+  transmits.
+
+### Medium, outdoor antenna helps
+
+- **Trunked or pager systems** — POCSAG / FLEX paging on
+  150-160 MHz, P25 trunked on 851 MHz. SDR-RS doesn't decode
+  these yet (it's tracker work), but you can hear the digital
+  warble.
+- **NOAA APT weather satellites** — see
+  [`apt-reception.md`](apt-reception.md). Image of cloud cover
+  from a polar-orbiting satellite, end-to-end including the
+  antenna and the satellite-pass-prediction setup.
+
+### Harder, real antenna and patience
+
+- **Meteor-M LRPT** — Russian polar weather sat, multi-channel
+  digital imagery. Same antenna as APT, harder demodulator. See
+  [`lrpt-reception.md`](lrpt-reception.md).
+- **ISS SSTV** — the International Space Station occasionally
+  beams photographs from orbit on 145.800 MHz during ARISS
+  events. See [`sstv-reception.md`](sstv-reception.md).
+
+---
+
+## Things every newcomer wonders
+
+### "Why is everything so noisy?"
+
+The radio spectrum is mostly noise. Real signals are narrower than
+they look in the spectrum view, and most of the time there's
+nothing on most of them. The waterfall is doing its job by showing
+you the noise floor honestly. Look for vertical bars (continuous
+signals) or short bright dashes (bursts).
+
+### "Why does my signal sound terrible?"
+
+Most often: bandwidth wrong (in the Radio panel — air-band ATC
+needs ~10 kHz, FM broadcast needs 200 kHz, an FM repeater needs
+12.5 kHz), or demod wrong (FM broadcast on AM = silence,
+NFM on WFM = quiet).
+
+The Radio panel's **bandwidth** slider is the single most
+common knob a beginner gets wrong.
+
+### "Why doesn't my dongle pick up X?"
+
+If X is below ~24 MHz: most RTL-SDRs can't go below that without
+a special "direct sampling" mod or a separate upconverter.
+Shortwave is unfortunately not in scope for stock hardware.
+
+If X is above ~1.7 GHz: same story, hardware limit. Anything
+satellite-related higher than that (Inmarsat / Iridium at
+1.5-1.6 GHz is right at the edge and *technically* possible but
+needs a sensitive antenna).
+
+### "Why are the signals drifting / shifting frequency?"
+
+RTL-SDRs have a small frequency error — typically tens of ppm —
+because they use cheap crystals. For an unmodified dongle that's
+within tolerance for casual listening; for satellite work you
+sometimes need to apply a "PPM correction" in the General panel.
+Most satellite passes work fine without it.
+
+### "Can I record what I'm hearing?"
+
+Yes. Audio panel → start a recording. Files land in
+`~/sdr-recordings/`.
+
+### "Can I share my dongle with another machine?"
+
+Yes — Share over network panel (`Ctrl+6`). Turn it on, the other
+machine can connect via TCP using SDR-RS, GQRX, or any
+`rtl_tcp`-compatible client. Useful if you have one good antenna
+on the roof but want to listen from your laptop.
+
+---
+
+## Where to go next
+
+- [`sdr-concepts.md`](sdr-concepts.md) — the underlying ideas
+  (IQ, sample rate, decimation, FFT, why bandwidth matters)
+  explained against this app's own UI. Reading this lets you
+  reason about *why* something isn't working, not just what to
+  try.
+- [`apt-reception.md`](apt-reception.md) — your first NOAA
+  weather satellite image. The most achievable "wow" moment in
+  the hobby.
+- [`lrpt-reception.md`](lrpt-reception.md) — Meteor-M LRPT
+  multi-channel imagery, once APT works.
+- [`sstv-reception.md`](sstv-reception.md) — receive a
+  photograph from the International Space Station during an
+  ARISS event.
+
+The radio hobby is deep and old. SDR-RS is one tool in it; the
+broader community has decades of accumulated knowledge on
+antennas, propagation, and protocols. Search terms like "amateur
+radio band plan", "rtl-sdr cheat sheet", and your country's
+regulator's website will keep you busy for as long as you want
+them to.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -13,12 +13,12 @@ sidebar panel does what, the workflow is short.
 
 ## What you bought, and what it does
 
-An **RTL-SDR** is a $30 USB device that started life as a European
-TV tuner. Someone discovered the chip exposes raw radio samples
-over USB, and it became the cheapest software-defined radio
-receiver on the planet. It's not a transmitter; it can only listen.
-It covers roughly 24-1700 MHz with one common gap, which is enough
-to pick up:
+An **RTL-SDR** is a ~$30 USB device (as of May 2026) that started
+life as a European TV tuner. Someone discovered the chip exposes
+raw radio samples over USB, and it became the cheapest
+software-defined radio receiver on the planet. It's not a
+transmitter; it can only listen. It covers roughly 24-1700 MHz
+with one common gap, which is enough to pick up:
 
 - FM broadcast (88-108 MHz)
 - Air-band aviation voice (118-137 MHz)
@@ -29,12 +29,20 @@ to pick up:
 - Plus the noise floor between all of those, which is its own
   kind of fun.
 
+> **Legal note:** Monitoring rules vary by country and (in the US)
+> by state. Broadcast and amateur radio are universally legal to
+> listen to; intercepting, recording, retransmitting, or acting on
+> the content of two-way private communications often is not. If
+> you're not sure, check your local regulator (FCC in the US,
+> Ofcom in the UK, etc.) before tuning to anything that isn't
+> obviously a public broadcast.
+
 A **software-defined radio** moves the radio's "dial" and
 "demodulator" out of dedicated hardware and into software. The
 RTL-SDR sends raw I/Q samples (the digital representation of
 whatever's on the antenna) to your computer, and SDR-RS does
 everything past that — channel filter, FM/AM/SSB demodulation,
-audio output, recording, decoding. That's why one $30 dongle can
+audio output, recording, decoding. That's why one cheap dongle can
 listen to a dozen different protocols: the protocol logic is just
 code.
 

--- a/docs/guides/sdr-concepts.md
+++ b/docs/guides/sdr-concepts.md
@@ -24,7 +24,7 @@ something else — bits, scan-lines, packets). The audio output
 plays it. That's the whole signal path. Every panel in this app
 configures one of those stages.
 
-```
+```text
 antenna → tuner → IQ samples → channel filter → demodulator → audio
           [RTL-SDR]            [Radio panel]    [demod dropdown]
 ```
@@ -188,6 +188,17 @@ SDR-RS implements 8 demods:
 - **RAW**: just outputs the IQ as audio. Doesn't sound like
   anything; useful for piping to an external decoder.
 
+There's also a satellite-specialised path that doesn't appear in
+the regular demod dropdown:
+
+- **LRPT** (Low-Rate Picture Transmission): the QPSK digital
+  channel from Meteor-M weather satellites. Not a general-purpose
+  demod — it's a silent passthrough wired by the Satellites
+  panel's auto-record flow when a Meteor pass starts (or via
+  `Ctrl+Shift+L` for manual operation). The 144 kHz channel
+  bandwidth shown later in the table refers to this path; you
+  don't pick "LRPT" from the dropdown the way you pick WFM.
+
 ### How to know which to use
 
 If you're on FM broadcast: WFM. Voice on aviation: AM. Voice on
@@ -319,7 +330,7 @@ Files land under `~/sdr-recordings/` with timestamped names.
 The left sidebar's icon order isn't aesthetic — it's the
 conceptual order of the signal chain:
 
-```
+```text
 General      → choose the source (RTL-SDR / network / file)
 Radio        → choose the demod and audio post-processing
 Audio        → choose the output device

--- a/docs/guides/sdr-concepts.md
+++ b/docs/guides/sdr-concepts.md
@@ -1,0 +1,355 @@
+# SDR concepts, against this app's UI
+
+A guide to the underlying ideas of software-defined radio,
+explained as you'd see them in SDR-RS. Not a textbook — a
+working set of mental models that lets you reason about what
+each control actually does.
+
+If you just want to receive your first signal, see
+[`getting-started.md`](getting-started.md). This document is
+for when you've done that and want to understand why it
+worked.
+
+---
+
+## The chain, in one paragraph
+
+The antenna picks up a wide swath of radio spectrum. The
+RTL-SDR's tuner translates a chunk of that swath down to
+near-zero-frequency baseband and digitises it into a stream of
+**IQ samples** at a chosen **sample rate**. The Radio panel's
+**channel filter** narrows that stream to one specific channel.
+The **demodulator** turns the channel's IQ into audio (or
+something else — bits, scan-lines, packets). The audio output
+plays it. That's the whole signal path. Every panel in this app
+configures one of those stages.
+
+```
+antenna → tuner → IQ samples → channel filter → demodulator → audio
+          [RTL-SDR]            [Radio panel]    [demod dropdown]
+```
+
+---
+
+## IQ samples
+
+The fundamental data type of SDR. Every sample the RTL-SDR sends
+your computer is a *complex number*: a real part (called **I** for
+"in-phase") and an imaginary part (**Q** for "quadrature").
+
+### Why complex?
+
+A real-only sample at one moment in time can't tell you which
+direction a signal is rotating in the spectrum — it's just an
+amplitude. A complex sample (I + jQ) encodes both amplitude *and*
+phase. With phase you can distinguish a signal at +5 kHz offset
+from one at −5 kHz offset; with only amplitude you couldn't.
+
+### What you see in the UI
+
+The **spectrum plot** at the top of the centre area is the FFT
+(Fourier transform) of recent IQ samples. It shows you which
+frequencies are present in the captured spectrum window: vertical
+height = how strong each frequency is. The **waterfall** below
+the spectrum is the same data over time, scrolling downward, with
+brightness mapped to strength. Strong narrow signals look like
+bright vertical bars. Wideband signals look like fat columns.
+Noise is the diffuse glow.
+
+### Sample size
+
+The RTL-SDR sends 8-bit IQ pairs (one byte each for I and Q).
+Cheap hardware, ~48 dB dynamic range. Higher-end SDRs (AirSpy,
+SDRplay) send 12 or 16 bits per axis, which gets you 70-90 dB —
+they hear weaker signals next to stronger ones. SDR-RS handles
+the RTL-SDR's 8-bit stream natively; the spectrum view's dB
+scale reflects what 8 bits can show.
+
+---
+
+## Sample rate
+
+The number of IQ samples per second the dongle delivers to your
+computer. The RTL-SDR can sample at rates from 250 ksps up to
+~3.2 Msps. SDR-RS defaults around 2.0 Msps.
+
+### What this controls
+
+**The width of the spectrum view.** Sample rate = bandwidth you
+can see at once. At 2.0 Msps the spectrum plot covers ±1 MHz
+around the centre frequency (the Nyquist limit — half the sample
+rate). At 250 ksps it covers ±125 kHz: same vertical resolution
+of the FFT bins but a much narrower window.
+
+### When to change it
+
+Most users never need to. The defaults are tuned to give a useful
+spectrum view (~2 MHz wide) and enough headroom for any single
+demodulator. Push it higher if you need a wider view (e.g.
+hunting through a band), or lower if your USB connection is
+flaky and dropping samples (which shows up as gaps in the
+waterfall).
+
+The **General panel** (`Ctrl+1`) is where you'd change the
+sample rate.
+
+---
+
+## Decimation
+
+The SDR captures at 2 Msps. The demodulator probably wants the
+data at a much lower rate — FM broadcast is happy at 250 ksps,
+voice is fine at 48 kHz, APT subcarrier work at 11 ksps. Going
+straight from 2 Msps to 11 ksps in one step would waste CPU on
+filter taps that are mostly throwing samples away. **Decimation**
+is the staged downsampling that bridges them: filter the wider
+stream to remove energy outside the new band, then keep one
+sample per N (the decimation factor).
+
+### What you see in the UI
+
+The General panel's **decimation** slider controls how
+aggressively the source rate is decimated before reaching the
+demodulator. Higher decimation = narrower IF (intermediate
+frequency) view = lower CPU cost but less spectrum visible to
+the demodulator. SDR-RS auto-picks a sensible decimation when
+you change demod modes; you mostly leave it alone.
+
+### When it matters
+
+If you crank the spectrum-window-width FFT setting in the Display
+panel and notice the waterfall becomes coarse-pixelated, you're
+seeing the limit of the post-decimation IF stream rather than the
+2 Msps source. The fix is usually to *lower* decimation (more IF
+samples = more data for FFT) at the cost of CPU.
+
+---
+
+## Bandwidth (channel filter)
+
+After decimation, the chain knows which frequency it's tuned to,
+but the demodulator only wants ONE channel — not the whole
+band. The **channel filter** is a narrow band-pass around the
+tuned frequency that removes everything outside it before demod.
+
+### Why this matters
+
+It's almost always the most-important knob a beginner gets
+wrong. **Different protocols use different bandwidths**:
+
+| Use case | Typical channel BW | Demod |
+|----------|-------------------|-------|
+| FM broadcast | 200 kHz | WFM |
+| FM repeater (voice) | 12.5 kHz | NFM |
+| Aviation voice (AM) | ~10 kHz | AM |
+| Single sideband (ham HF) | ~2.7 kHz | USB / LSB |
+| CW (Morse) | ~500 Hz | CW |
+| NOAA APT (weather sat) | 38 kHz | NFM |
+| Meteor LRPT (digital weather sat) | 144 kHz | LRPT |
+
+If you tune to FM broadcast at 200 kHz wide and listen on NFM
+with 12.5 kHz channel filter, you'll hear distorted fragments —
+the filter throws away most of the signal energy. If you tune to
+ham voice at 12.5 kHz wide and listen on WFM with 200 kHz
+filter, you'll hear faint voice plus a lot of adjacent-channel
+hiss.
+
+### Where you set it in the UI
+
+**Radio panel** (`Ctrl+2`) → bandwidth row. The slider's allowed
+range adjusts to the current demod mode (NFM caps at 25 kHz, WFM
+goes up to 200 kHz, etc).
+
+---
+
+## Demodulation
+
+The actual extraction of information from a modulated carrier.
+SDR-RS implements 8 demods:
+
+- **WFM** (Wide FM): broadcast FM. 200 kHz channels, plus
+  optional deemphasis (US 75 µs / EU 50 µs to match the
+  broadcaster's pre-emphasis).
+- **NFM** (Narrow FM): voice FM, 12.5 kHz typical. Used by ham
+  radio repeaters, public-service trunked systems (the audio
+  layer at least), pagers, weather radio.
+- **AM** (Amplitude Modulation): aviation voice, AM broadcast,
+  some shortwave. Picks up a carrier's amplitude variations.
+- **USB / LSB** (Upper / Lower Sideband): single-sideband voice,
+  used on amateur HF bands. Only one half of the AM spectrum
+  is transmitted, doubling spectrum efficiency. **Voice on SSB
+  sounds like Donald Duck if you're tuned even 100 Hz off** —
+  use the frequency-fine knob.
+- **DSB** (Double-sideband): both sidebands without a carrier.
+  Niche.
+- **CW** (Continuous Wave): Morse code. Receiver injects a
+  beat-frequency oscillator (BFO) so the on/off keying becomes
+  audible tones. Bandwidth ~500 Hz.
+- **RAW**: just outputs the IQ as audio. Doesn't sound like
+  anything; useful for piping to an external decoder.
+
+### How to know which to use
+
+If you're on FM broadcast: WFM. Voice on aviation: AM. Voice on
+amateur HF: USB above 10 MHz, LSB below 10 MHz (the convention).
+Voice on amateur 2 m/70 cm: NFM. NOAA weather satellites: NFM
+(the APT decoder takes the audio). When in doubt: try one, listen,
+try another.
+
+---
+
+## Squelch
+
+A volume gate that closes the audio output when the signal isn't
+strong enough to be intelligible. Without squelch, listening to
+an idle voice repeater is just continuous hiss — squelch makes the
+hiss vanish until someone keys up.
+
+### Variants
+
+The Radio panel offers four:
+
+- **Power squelch**: gates on raw signal-strength threshold (in
+  dBFS). Set the threshold a few dB above your local noise floor.
+  The classic, works for any modulation.
+- **Auto-squelch**: tracks the noise floor automatically and
+  gates above it. Set-and-forget for casual listening.
+- **CTCSS** (Continuous Tone-Coded Squelch System): the audio gate
+  opens only when a specific sub-audible tone (67 Hz - 254 Hz) is
+  detected on the carrier. Used by many amateur repeaters to
+  reject signals from other repeaters on the same frequency. If
+  you know the repeater's CTCSS tone (Repeaterbook lists them),
+  set it here and the squelch only opens for that repeater.
+- **Voice-squelch**: detects the syllabic envelope of human
+  speech and gates the audio when speech is present, irrespective
+  of carrier level. Useful in noisy bands where power squelch
+  would either let through hiss or cut off weak voice.
+
+You can have only one type of squelch active at a time (the
+panel enforces this). All of them only affect what you hear from
+the speaker; the spectrum / waterfall / decoders see the
+ungated signal.
+
+---
+
+## Auto-gain control (AGC) and the tuner
+
+The RTL-SDR has a single tuner-gain control (in the General
+panel). It's important because:
+
+- **Too little gain**: weak signals get lost in the dongle's
+  thermal noise floor. Image: dim waterfall, no carriers visible.
+- **Too much gain**: strong signals overload the tuner's
+  amplifier. Image: ghost images of the strong signal appearing
+  at multiples of its frequency, "spurs" at every 1 MHz from a
+  big FM station, loud broadband noise that tracks gain.
+
+The dongle has both an "auto" gain mode and a manual gain stepped
+in dB increments. **Auto often picks too low a gain in low-signal
+environments** — manual at ~30 dB gain is a sane starting point
+for general listening.
+
+---
+
+## SNR and the noise floor
+
+The status bar shows a **signal-to-noise ratio** estimate (SNR)
+in dB. This is the difference between current signal level and
+the local noise floor.
+
+- A very strong commercial FM station at close range: 50+ dB SNR.
+- A clean repeater conversation: 20-30 dB SNR.
+- Marginal voice still intelligible: 5-10 dB SNR.
+- Below 0 dB SNR: the noise is stronger than the signal; you'd
+  need to know what you're looking for to extract anything.
+
+Most digital protocols have a hard threshold: above N dB they
+decode flawlessly, below N dB they don't decode at all. NOAA APT
+needs ~10 dB; LRPT needs ~5 dB more than that; SSTV is forgiving.
+
+---
+
+## Spectrum view: FFT
+
+The spectrum plot is computed by **Fast Fourier Transform** on
+windows of recent IQ samples. The Display panel exposes a few
+knobs:
+
+- **FFT size**: how many IQ samples per FFT window. Bigger =
+  finer frequency resolution (more bins) but slower update and
+  more CPU. 4096 / 8192 are typical.
+- **Window function**: how samples are weighted at the FFT
+  edges. Hamming / Blackman / Hann are different trade-offs
+  between resolution and side-lobe rejection. Hann is fine
+  for everything.
+- **Frame rate**: how often the spectrum + waterfall redraw.
+  60 Hz is buttery-smooth; 30 Hz saves some CPU. The decoders
+  don't care — this only affects what your eyes see.
+
+### What the FFT plot CAN'T tell you
+
+It can't tell you the modulation type or the demod that'll
+recover audio. A peak in the spectrum means "there's energy at
+this frequency"; figuring out *what kind* of energy (FM voice?
+AM aviation? data burst? jammer?) is what you do by tuning to
+it and listening / decoding.
+
+---
+
+## Recording
+
+Three things you can record from SDR-RS:
+
+- **Audio (.wav)**: the demodulated audio output. Audio panel
+  → "Start recording".
+- **IQ (.wav)**: the raw IQ stream from the source.
+  Reproducible offline replay later. Big files: at 2 Msps with
+  8-bit IQ, that's 4 MB/sec on disk.
+- **Pass artifacts**: NOAA APT (single PNG), Meteor LRPT
+  (per-pass directory, one PNG per AVHRR channel), ISS SSTV
+  (per-pass directory, one PNG per completed image). All
+  triggered by the Satellites panel auto-record toggle.
+
+Files land under `~/sdr-recordings/` with timestamped names.
+
+---
+
+## Why the activity-bar layout matches the SDR pipeline
+
+The left sidebar's icon order isn't aesthetic — it's the
+conceptual order of the signal chain:
+
+```
+General      → choose the source (RTL-SDR / network / file)
+Radio        → choose the demod and audio post-processing
+Audio        → choose the output device
+Display      → configure the spectrum view
+Scanner      → automate channel-by-channel listening
+Share        → expose your dongle to other clients
+Satellites   → schedule auto-record on overhead pass
+```
+
+Each panel maps to one stage. If you're trying to figure out
+where a control lives, ask "which conceptual stage is this?"
+— the answer points at the right panel.
+
+---
+
+## Further reading
+
+- [`getting-started.md`](getting-started.md) — first-signal
+  walkthrough.
+- [`apt-reception.md`](apt-reception.md) — NOAA APT weather
+  satellite end-to-end.
+- [`lrpt-reception.md`](lrpt-reception.md) — Meteor-M LRPT
+  digital weather satellite.
+- [`sstv-reception.md`](sstv-reception.md) — ISS SSTV.
+- The [SDR++ wiki](https://github.com/AlexandreRouma/SDRPlusPlus/wiki),
+  since SDR-RS is a port of SDR++; many concepts and best
+  practices carry over verbatim.
+- [rtl-sdr.com](https://www.rtl-sdr.com/) — the community blog
+  for RTL-SDR users; reception reports, antenna builds, decoder
+  tooling.
+- Your country's amateur-radio regulator publishes a band plan
+  showing which frequencies are used for what (US: ARRL band
+  plan, UK: Ofcom, etc).


### PR DESCRIPTION
Closes #576 (the standalone-docs portion).

The in-app pieces (first-launch tour, \"Try this\" presets, inline help / glossary tooltips) are split out as #608, #609, #610 so each follow-up PR has a clean scope.

## What landed

**`docs/guides/getting-started.md`** — first-time-user walkthrough. Aimed at someone who picked up an RTL-SDR and isn't sure what they're looking at when they launch the app. Two-minute orientation of the activity bar, \"first signal: FM broadcast\" walkthrough that gets a station playing in under five minutes, panel-by-panel explanation, then a graduated list of concrete next things to try (air-band, NOAA weather radio, ham repeaters, APT, LRPT, SSTV).

**`docs/guides/sdr-concepts.md`** — the underlying ideas (IQ samples, sample rate, decimation, channel filter / bandwidth, demodulation, squelch, AGC, SNR, FFT, recording) explained *against this app's own UI*. Reading this lets a user reason about *why* something isn't working, not just what to try. Also calls out why the activity bar's order matches the SDR pipeline — the structural metaphor that motivated the layout becomes a teaching tool.

## Cross-links

- `README.md` \"Usage\" section gains a \"New to SDR?\" sub-section with links to both new guides and all three reception walkthroughs.
- `docs/guides/apt-reception.md` opening paragraph points new users at `getting-started.md` first.
- `CLAUDE.md`'s walkthroughs index lists the two new docs as the onboarding entry points.
- `lrpt-reception.md` and `sstv-reception.md` already cross-link to `apt-reception.md` (which now points at `getting-started`), so the reading order chains naturally.

## Out of scope (decomposed)

- **#608**: in-app first-launch tour (`AdwAlertDialog` walkthrough of the activity bar).
- **#609**: \"Try this\" preset launchers (FM broadcast, NOAA weather radio, air-band scan).
- **#610**: inline `?` help buttons + glossary tooltips per panel (SNR, IF, AF, MCU, APID, AOS/LOS, etc).

Each in-app piece is a non-trivial UI change; landing them as focused follow-ups keeps each PR's CR cycle clean. The standalone docs are the load-bearing piece — they're what a user reads in a browser tab next to the app, so they unblock the discoverability problem #576 calls out even before the in-app pieces ship.

## Test plan
- [x] `cargo build --workspace` clean (sanity — no code changes)
- [x] `cargo fmt --all -- --check` clean
- [ ] Read both guides end-to-end with fresh eyes (you, ideally — the docs are written for users who don't already know how the app works, and you're the closest available reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive getting-started guide: hardware/software checklist, UI orientation, FM walkthrough, troubleshooting, and next listening targets.
  * Added an SDR concepts guide: signal chain, sampling/FFT, demodulation modes, squelch, gain/AGC, and recording options.
  * Updated README with a “New to SDR?” section linking onboarding resources and expanded walkthrough references in reception docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->